### PR TITLE
[vulkan] Use aliases when retrieving from packed/unpacked lists in OpContexts

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -78,6 +78,20 @@ uint32_t get_dim(const vTensor& v_in) {
   return get_dim<N>(v_in.sizes());
 }
 
+inline c10::optional<Tensor> get_optional_tensor(
+    const c10::impl::GenericList& gen_list,
+    const uint32_t idx) {
+  return gen_list.get(idx).isTensor() ? gen_list.get(idx).toTensor()
+                                      : c10::optional<Tensor>();
+}
+
+inline c10::optional<Scalar> get_optional_scalar(
+    const c10::impl::GenericList& gen_list,
+    const uint32_t idx) {
+  return gen_list.get(idx).isScalar() ? gen_list.get(idx).toScalar()
+                                      : c10::optional<Scalar>();
+}
+
 api::utils::uvec3 adaptive_work_group_size(
     const api::utils::uvec3& global_work_group);
 

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -993,21 +993,17 @@ Conv2dPackedContext::Conv2dPackedContext(
 
 Conv2dPackedContext Conv2dPackedContext::pack(c10::impl::GenericList unpacked) {
   return Conv2dPackedContext(
-      unpacked.get(0).toTensor(), // weight
-      unpacked.get(1).isTensor() ? unpacked.get(1).toTensor()
-                                 : c10::optional<Tensor>(), // bias
-      unpacked.get(2).toIntVector(), // stride
-      unpacked.get(3).toIntVector(), // padding
-      unpacked.get(4).toIntVector(), // dilation
-      unpacked.get(5).toBool(), // transposed
-      unpacked.get(6).toBool(), // quantized
-      unpacked.get(7).toIntVector(), // output_padding
-      unpacked.get(8).toInt(), // groups
-      unpacked.get(9).isScalar() ? unpacked.get(8).toScalar()
-                                 : c10::optional<Scalar>(), // output_min
-      unpacked.get(10).isScalar() ? unpacked.get(9).toScalar()
-                                  : c10::optional<Scalar>() // output_max
-  );
+      unpacked.get(Unpacked::Weight).toTensor(),
+      get_optional_tensor(unpacked, Unpacked::Bias),
+      unpacked.get(Unpacked::Stride).toIntVector(),
+      unpacked.get(Unpacked::Padding).toIntVector(),
+      unpacked.get(Unpacked::Dilation).toIntVector(),
+      unpacked.get(Unpacked::isTransposed).toBool(),
+      unpacked.get(Unpacked::isQuantized).toBool(),
+      unpacked.get(Unpacked::OutputPadding).toIntVector(),
+      unpacked.get(Unpacked::Groups).toInt(),
+      get_optional_scalar(unpacked, Unpacked::OutputMin),
+      get_optional_scalar(unpacked, Unpacked::OutputMax));
 }
 
 c10::intrusive_ptr<Conv2dPackedContext> create_conv2d_context(
@@ -1088,22 +1084,38 @@ Tensor run_conv2d_context(
   const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
   const vTensor& v_input = convert(input);
 
-  const vTensor& packed_v_weight = convert(conv_context->get_val(0).toTensor());
-  const vTensor& packed_v_bias = convert(conv_context->get_val(1).toTensor());
-  const auto packed_filter = conv_context->get_val(2).toIntVector();
-  const auto packed_stride = conv_context->get_val(3).toIntVector();
-  const auto packed_padding = conv_context->get_val(4).toIntVector();
-  const auto packed_output_padding = conv_context->get_val(5).toIntVector();
-  const auto packed_dilation = conv_context->get_val(6).toIntVector();
-  const auto transposed = conv_context->get_val(7).toBool();
-  const auto quantized = conv_context->get_val(8).toBool();
-  /* const auto groups = conv_context->get_val(9).toInt(); */
-  const float packed_output_min =
-      safe_downcast<float>(conv_context->get_val(10).toDouble());
-  const float packed_output_max =
-      safe_downcast<float>(conv_context->get_val(11).toDouble());
-  const Conv2dMethod method_ = (Conv2dMethod)conv_context->get_val(12).toInt();
-  const auto unpacked_filter = conv_context->get_val(13).toIntVector();
+  const vTensor& packed_v_weight = convert(
+      conv_context->get_val(Conv2dPackedContext::Packed::Weight).toTensor());
+  const vTensor& packed_v_bias = convert(
+      conv_context->get_val(Conv2dPackedContext::Packed::Bias).toTensor());
+  const auto packed_filter =
+      conv_context->get_val(Conv2dPackedContext::Packed::FilterSizes)
+          .toIntVector();
+  const auto packed_stride =
+      conv_context->get_val(Conv2dPackedContext::Packed::Stride).toIntVector();
+  const auto packed_padding =
+      conv_context->get_val(Conv2dPackedContext::Packed::Padding).toIntVector();
+  const auto packed_output_padding =
+      conv_context->get_val(Conv2dPackedContext::Packed::OutputPadding)
+          .toIntVector();
+  const auto packed_dilation =
+      conv_context->get_val(Conv2dPackedContext::Packed::Dilation)
+          .toIntVector();
+  const auto transposed =
+      conv_context->get_val(Conv2dPackedContext::Packed::isTransposed).toBool();
+  const auto quantized =
+      conv_context->get_val(Conv2dPackedContext::Packed::isQuantized).toBool();
+  const float packed_output_min = safe_downcast<float>(
+      conv_context->get_val(Conv2dPackedContext::Packed::OutputMin).toDouble());
+  const float packed_output_max = safe_downcast<float>(
+      conv_context->get_val(Conv2dPackedContext::Packed::OutputMax).toDouble());
+  const Conv2dMethod method_ =
+      (Conv2dMethod)conv_context
+          ->get_val(Conv2dPackedContext::Packed::ConvMethod)
+          .toInt();
+  const auto unpacked_filter =
+      conv_context->get_val(Conv2dPackedContext::Packed::WeightSizes)
+          .toIntVector();
 
   TORCH_CHECK(
       usable(input, quantized),
@@ -1204,6 +1216,7 @@ Tensor run_tconv2d_context(
   return run_conv2d_context(input_arg, conv_context);
 }
 
+// TODO: this can probably be consolidated with the other run method
 Tensor run_qconv2d_context(
     const Tensor& input_arg,
     double scale,
@@ -1214,22 +1227,36 @@ Tensor run_qconv2d_context(
   const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
   const vTensor& v_input = convert(input);
 
-  const vTensor& packed_v_weight = convert(conv_context->get_val(0).toTensor());
-  const vTensor& packed_v_bias = convert(conv_context->get_val(1).toTensor());
-  const auto packed_filter = conv_context->get_val(2).toIntVector();
-  const auto packed_stride = conv_context->get_val(3).toIntVector();
-  const auto packed_padding = conv_context->get_val(4).toIntVector();
-  const auto packed_output_padding = conv_context->get_val(5).toIntVector();
-  const auto packed_dilation = conv_context->get_val(6).toIntVector();
-  /* const auto transposed = conv_context->get_val(7).toBool(); */
-  const auto quantized = conv_context->get_val(8).toBool();
-  /* const auto groups = conv_context->get_val(9).toInt(); */
-  const float packed_output_min =
-      safe_downcast<float>(conv_context->get_val(10).toDouble());
-  const float packed_output_max =
-      safe_downcast<float>(conv_context->get_val(11).toDouble());
-  const Conv2dMethod method_ = (Conv2dMethod)conv_context->get_val(12).toInt();
-  const auto unpacked_filter = conv_context->get_val(13).toIntVector();
+  const vTensor& packed_v_weight = convert(
+      conv_context->get_val(Conv2dPackedContext::Packed::Weight).toTensor());
+  const vTensor& packed_v_bias = convert(
+      conv_context->get_val(Conv2dPackedContext::Packed::Bias).toTensor());
+  const auto packed_filter =
+      conv_context->get_val(Conv2dPackedContext::Packed::FilterSizes)
+          .toIntVector();
+  const auto packed_stride =
+      conv_context->get_val(Conv2dPackedContext::Packed::Stride).toIntVector();
+  const auto packed_padding =
+      conv_context->get_val(Conv2dPackedContext::Packed::Padding).toIntVector();
+  const auto packed_output_padding =
+      conv_context->get_val(Conv2dPackedContext::Packed::OutputPadding)
+          .toIntVector();
+  const auto packed_dilation =
+      conv_context->get_val(Conv2dPackedContext::Packed::Dilation)
+          .toIntVector();
+  const auto quantized =
+      conv_context->get_val(Conv2dPackedContext::Packed::isQuantized).toBool();
+  const float packed_output_min = safe_downcast<float>(
+      conv_context->get_val(Conv2dPackedContext::Packed::OutputMin).toDouble());
+  const float packed_output_max = safe_downcast<float>(
+      conv_context->get_val(Conv2dPackedContext::Packed::OutputMax).toDouble());
+  const Conv2dMethod method_ =
+      (Conv2dMethod)conv_context
+          ->get_val(Conv2dPackedContext::Packed::ConvMethod)
+          .toInt();
+  const auto unpacked_filter =
+      conv_context->get_val(Conv2dPackedContext::Packed::WeightSizes)
+          .toIntVector();
 
   TORCH_CHECK(
       usable(input, quantized),
@@ -1373,18 +1400,14 @@ Conv2dOpContext::State Conv2dOpContext::unpack() const {
   const c10::impl::GenericList unpacked_ = conv_context_.unpack();
 
   return Conv2dOpContext::State(
-      unpacked_.get(0).toTensor(), // weight
-      unpacked_.get(1).isTensor() ? unpacked_.get(1).toTensor()
-                                  : c10::optional<Tensor>(), // bias
-      unpacked_.get(2).toIntVector(), // stride
-      unpacked_.get(3).toIntVector(), // padding
-      unpacked_.get(4).toIntVector(), // dilation
-      unpacked_.get(7).toInt(), // groups
-      unpacked_.get(8).isScalar() ? unpacked_.get(8).toScalar()
-                                  : c10::optional<Scalar>(), // output_min
-      unpacked_.get(9).isScalar() ? unpacked_.get(9).toScalar()
-                                  : c10::optional<Scalar>() // output_max
-  );
+      unpacked_.get(Conv2dPackedContext::Unpacked::Weight).toTensor(),
+      get_optional_tensor(unpacked_, Conv2dPackedContext::Unpacked::Bias),
+      unpacked_.get(Conv2dPackedContext::Unpacked::Stride).toIntVector(),
+      unpacked_.get(Conv2dPackedContext::Unpacked::Padding).toIntVector(),
+      unpacked_.get(Conv2dPackedContext::Unpacked::Dilation).toIntVector(),
+      unpacked_.get(Conv2dPackedContext::Unpacked::Groups).toInt(),
+      get_optional_scalar(unpacked_, Conv2dPackedContext::Unpacked::OutputMin),
+      get_optional_scalar(unpacked_, Conv2dPackedContext::Unpacked::OutputMax));
 }
 
 c10::intrusive_ptr<Conv2dOpContext> conv2d_clamp_prepack(

--- a/aten/src/ATen/native/vulkan/ops/Convolution.h
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.h
@@ -39,6 +39,43 @@ class Conv2dPackedContext final : virtual public VulkanPackedContext,
       const c10::optional<Scalar>& output_min = c10::nullopt,
       const c10::optional<Scalar>& output_max = c10::nullopt);
 
+  /*
+   * Assigns a name to each index in the unpacked list.
+   */
+  struct Unpacked final {
+    static constexpr uint32_t Weight = 0u;
+    static constexpr uint32_t Bias = 1u;
+    static constexpr uint32_t Stride = 2u;
+    static constexpr uint32_t Padding = 3u;
+    static constexpr uint32_t Dilation = 4u;
+    static constexpr uint32_t isTransposed = 5u;
+    static constexpr uint32_t isQuantized = 6u;
+    static constexpr uint32_t OutputPadding = 7u;
+    static constexpr uint32_t Groups = 8u;
+    static constexpr uint32_t OutputMin = 9u;
+    static constexpr uint32_t OutputMax = 10u;
+  };
+
+  /*
+   * Assigns a name to each index in the packed list.
+   */
+  struct Packed final {
+    static constexpr uint32_t Weight = 0u;
+    static constexpr uint32_t Bias = 1u;
+    static constexpr uint32_t FilterSizes = 2u;
+    static constexpr uint32_t Stride = 3u;
+    static constexpr uint32_t Padding = 4u;
+    static constexpr uint32_t OutputPadding = 5u;
+    static constexpr uint32_t Dilation = 6u;
+    static constexpr uint32_t isTransposed = 7u;
+    static constexpr uint32_t isQuantized = 8u;
+    static constexpr uint32_t Groups = 9u;
+    static constexpr uint32_t OutputMin = 10u;
+    static constexpr uint32_t OutputMax = 11u;
+    static constexpr uint32_t ConvMethod = 12u;
+    static constexpr uint32_t WeightSizes = 13u;
+  };
+
   static Conv2dPackedContext pack(c10::impl::GenericList);
 
   const c10::impl::GenericList unpack() const override {

--- a/aten/src/ATen/native/vulkan/ops/Gru.h
+++ b/aten/src/ATen/native/vulkan/ops/Gru.h
@@ -23,6 +23,32 @@ class GruPackedContext final : virtual public VulkanPackedContext,
       bool bidirectional,
       bool batch_first);
 
+  /*
+   * Assigns a name to each index in the unpacked list.
+   */
+  struct Unpacked final {
+    static constexpr uint32_t Params = 0u;
+    static constexpr uint32_t hasBiases = 1u;
+    static constexpr uint32_t NumLayers = 2u;
+    static constexpr uint32_t Dropout = 3u;
+    static constexpr uint32_t Train = 4u;
+    static constexpr uint32_t Bidirectional = 5u;
+    static constexpr uint32_t BatchFirst = 6u;
+  };
+
+  /*
+   * Assigns a name to each index in the packed list.
+   */
+  struct Packed final {
+    static constexpr uint32_t LinearContexts = 0u;
+    static constexpr uint32_t hasBiases = 1u;
+    static constexpr uint32_t NumLayers = 2u;
+    static constexpr uint32_t Dropout = 3u;
+    static constexpr uint32_t Train = 4u;
+    static constexpr uint32_t Bidirectional = 5u;
+    static constexpr uint32_t BatchFirst = 6u;
+  };
+
   static GruPackedContext pack(c10::impl::GenericList);
 
   const c10::impl::GenericList unpack() const override;

--- a/aten/src/ATen/native/vulkan/ops/Lstm.h
+++ b/aten/src/ATen/native/vulkan/ops/Lstm.h
@@ -23,6 +23,32 @@ class LstmPackedContext final : virtual public VulkanPackedContext,
       bool bidirectional,
       bool batch_first);
 
+  /*
+   * Assigns a name to each index in the unpacked list.
+   */
+  struct Unpacked final {
+    static constexpr uint32_t Params = 0u;
+    static constexpr uint32_t hasBiases = 1u;
+    static constexpr uint32_t NumLayers = 2u;
+    static constexpr uint32_t Dropout = 3u;
+    static constexpr uint32_t Train = 4u;
+    static constexpr uint32_t Bidirectional = 5u;
+    static constexpr uint32_t BatchFirst = 6u;
+  };
+
+  /*
+   * Assigns a name to each index in the packed list.
+   */
+  struct Packed final {
+    static constexpr uint32_t LinearContexts = 0u;
+    static constexpr uint32_t hasBiases = 1u;
+    static constexpr uint32_t NumLayers = 2u;
+    static constexpr uint32_t Dropout = 3u;
+    static constexpr uint32_t Train = 4u;
+    static constexpr uint32_t Bidirectional = 5u;
+    static constexpr uint32_t BatchFirst = 6u;
+  };
+
   static LstmPackedContext pack(c10::impl::GenericList);
 
   const c10::impl::GenericList unpack() const override;

--- a/aten/src/ATen/native/vulkan/ops/Mm.h
+++ b/aten/src/ATen/native/vulkan/ops/Mm.h
@@ -19,6 +19,24 @@ class LinearPackedContext final : virtual public VulkanPackedContext,
  public:
   LinearPackedContext(const Tensor& weight, const c10::optional<Tensor>& bias);
 
+  /*
+   * Assigns a name to each index in the unpacked list.
+   */
+  struct Unpacked final {
+    static constexpr uint32_t Weight = 0u;
+    static constexpr uint32_t Bias = 1u;
+  };
+
+  /*
+   * Assigns a name to each index in the packed list.
+   */
+  struct Packed final {
+    static constexpr uint32_t Weight = 0u;
+    static constexpr uint32_t Bias = 1u;
+    static constexpr uint32_t WeightSizes = 2u;
+    static constexpr uint32_t BiasDefined = 3u;
+  };
+
   static LinearPackedContext pack(c10::impl::GenericList);
 
   const c10::impl::GenericList unpack() const override {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83526

Instead of retrieving elements of pack/unpacked lists using raw indices, this diff introduces aliases which improve code readability and guard against future errors.

Differential Revision: [D38748293](https://our.internmc.facebook.com/intern/diff/D38748293/)