### PR TITLE
[ROCm] Temporarily disabling ROCm CI job

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -250,6 +250,7 @@ jobs:
       sync-tag: rocm-build
 
   linux-focal-rocm5_2-py3_7-test:
+    if: false # Disable temporarily due to bad hosts
     name: linux-focal-rocm5.2-py3.7
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_2-py3_7-build


### PR DESCRIPTION
It looks like bad host(s):

* https://github.com/pytorch/pytorch/actions/runs/2869858550
* https://github.com/pytorch/pytorch/runs/7865037015

This is to unblock trunk
