### PR TITLE
Let users use with semantics to restore modes

### DIFF
--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1852,7 +1852,7 @@ class TorchFunctionMode(metaclass=TorchFunctionModeMeta):
     def __enter__(self):
         old = _get_torch_function_mode()
         if hasattr(self, "inner"):
-            raise RuntimeError(f"{self} has already been used as a mode. Please use a fresh version or use restore")
+            return _restore_mode(self, mode_info=_TorchFunctionModeInfo())
         else:
             self.inner = old
             if old is None:

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -151,7 +151,7 @@ class TorchDispatchMode(metaclass=TorchDispatchModeMeta):
     def __enter__(self):
         old = _get_torch_dispatch_mode()
         if hasattr(self, "inner"):
-            raise RuntimeError(f"{self} has already been used as a mode. Please use a fresh version or use restore")
+            return _restore_mode(self, mode_info=TorchDispatchModeInfo())
         else:
             self.inner = old
             if old is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83541

From ask [here](https://github.com/pytorch/pytorch/pull/83496#discussion_r946907064), does not remove ProxyTensorMode's trace_factory_function flag that was also discussed in that comment (waiting until after ProxyTensor is removed based on comment)