### PR TITLE
Remove `optim_mt` from `test/test_optim.py`

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -8,12 +8,10 @@ import itertools
 from copy import deepcopy
 
 import torch
-from torch._six import inf
 import torch.optim as optim
-import torch.optim._multi_tensor as optim_mt
 import torch.nn.functional as F
+from torch.nn import Parameter
 from torch.optim import SGD
-from torch.autograd import Variable
 from torch import sparse
 from torch.optim.lr_scheduler import LambdaLR, MultiplicativeLR, SequentialLR, StepLR, \
     MultiStepLR, ConstantLR, LinearLR, ExponentialLR, CosineAnnealingLR, ReduceLROnPlateau, \
@@ -46,18 +44,19 @@ class TestOptim(TestCase):
             scheduler_constructors = []
         params_t = torch.tensor([1.5, 1.5])
 
-        params = Variable(params_t, requires_grad=True)
+        params = Parameter(params_t)
         optimizer = constructor([params])
         schedulers = []
         for scheduler_constructor in scheduler_constructors:
             schedulers.append(scheduler_constructor(optimizer))
 
         if not sparse_only:
-            params_c = Variable(params_t.clone(), requires_grad=True)
+            params_c = Parameter(params_t.clone())
             optimizer_c = constructor([params_c])
 
         solution = torch.tensor([1, 1])
-        initial_dist = params.data.dist(solution)
+        with torch.no_grad():
+            initial_dist = params.dist(solution)
 
         def eval(params, sparse_grad, w):
             # Depending on w, provide only the x or y gradient
@@ -94,28 +93,40 @@ class TestOptim(TestCase):
                     scheduler.step()
             if not sparse_only:
                 optimizer_c.step(functools.partial(eval, params_c, False, w))
-                self.assertEqual(params.data, params_c.data)
+                self.assertEqual(params, params_c)
 
         if not maximize:
             self.assertLessEqual(params.data.dist(solution), initial_dist)
         else:
-            self.assertGreaterEqual(rosenbrock(params.data), rosenbrock(params_t))
+            self.assertGreaterEqual(rosenbrock(params), rosenbrock(params_t))
 
-    def _test_basic_cases_template(self, weight, bias, input, constructor,
-                                   scheduler_constructors, constructor_accepts_maximize=True):
+    def _test_basic_cases_template(self, weight_tensor, bias_tensor, input_tensor, constructor,
+                                   scheduler_constructors, constructor_accepts_maximize=True, constructor_accepts_foreach=False):
         maximize_options = set([False, constructor_accepts_maximize])
-        if not constructor_accepts_maximize:
-            def three_arg_constructor(weight, bias, maximize):
-                self.assertFalse(maximize)
-                return constructor(weight, bias)
-        else:
-            three_arg_constructor = constructor
+        foreach_options = set([False, constructor_accepts_foreach])
 
-        for maximize in maximize_options:
-            weight = Variable(weight, requires_grad=True)
-            bias = Variable(bias, requires_grad=True)
-            input = Variable(input)
-            optimizer = three_arg_constructor(weight, bias, maximize)
+        four_arg_constructor = constructor
+        if constructor_accepts_maximize and constructor_accepts_foreach:
+            pass
+        elif constructor_accepts_maximize:
+            def four_arg_constructor(weight, bias, maximize, foreach):
+                self.assertFalse(foreach)
+                return constructor(weight, bias, maximize)
+        elif constructor_accepts_foreach:
+            def four_arg_constructor(weight, bias, maximize, foreach):
+                self.assertFalse(maximize)
+                return constructor(weight, bias, foreach)
+        else:
+            def four_arg_constructor(weight, bias, maximize, foreach):
+                self.assertFalse(maximize or foreach)
+                return constructor(weight, bias)
+
+        for maximize, foreach in itertools.product(maximize_options, foreach_options):
+            with torch.no_grad():
+                weight = Parameter(weight_tensor.clone().detach())
+                bias = Parameter(bias_tensor.clone().detach())
+                input = input_tensor.clone().detach().requires_grad_()
+            optimizer = four_arg_constructor(weight, bias, maximize, foreach)
             schedulers = []
             for scheduler_constructor in scheduler_constructors:
                 schedulers.append(scheduler_constructor(optimizer))
@@ -133,7 +144,7 @@ class TestOptim(TestCase):
                 return loss
 
             initial_value = fn().item()
-            for _i in range(200):
+            for _ in range(200):
                 for scheduler in schedulers:
                     if isinstance(scheduler, ReduceLROnPlateau):
                         val_loss = fn()
@@ -147,9 +158,10 @@ class TestOptim(TestCase):
                 self.assertLess(fn().item(), initial_value)
 
     def _test_state_dict(self, weight, bias, input, constructor):
-        weight = Variable(weight, requires_grad=True)
-        bias = Variable(bias, requires_grad=True)
-        input = Variable(input)
+        weight = Parameter(weight)
+        bias = Parameter(bias)
+        with torch.no_grad():
+            input = input.clone().detach().requires_grad_()
 
         def fn_base(optimizer, weight, bias):
             optimizer.zero_grad()
@@ -165,8 +177,9 @@ class TestOptim(TestCase):
         for _i in range(20):
             optimizer.step(fn)
         # Clone the weights and construct new optimizer for them
-        weight_c = Variable(weight.data.clone(), requires_grad=True)
-        bias_c = Variable(bias.data.clone(), requires_grad=True)
+        with torch.no_grad():
+            weight_c = Parameter(weight.clone().detach())
+            bias_c = Parameter(bias.clone().detach())
         optimizer_c = constructor(weight_c, bias_c)
         fn_c = functools.partial(fn_base, optimizer_c, weight_c, bias_c)
         # Load state dict
@@ -174,7 +187,7 @@ class TestOptim(TestCase):
         state_dict_c = deepcopy(optimizer.state_dict())
         optimizer_c.load_state_dict(state_dict_c)
         # Run both optimizations in parallel
-        for _i in range(20):
+        for _ in range(20):
             optimizer.step(fn)
             optimizer_c.step(fn_c)
             self.assertEqual(weight, weight_c)
@@ -218,9 +231,10 @@ class TestOptim(TestCase):
         if not torch.cuda.is_available():
             return
 
-        input_cuda = Variable(input.data.float().cuda())
-        weight_cuda = Variable(weight.data.float().cuda(), requires_grad=True)
-        bias_cuda = Variable(bias.data.float().cuda(), requires_grad=True)
+        with torch.no_grad():
+            input_cuda = input.clone().detach().to(dtype=torch.float32, device="cuda")
+            weight_cuda = Parameter(weight.clone().detach().to(dtype=torch.float32, device="cuda"))
+            bias_cuda = Parameter(bias.clone().detach().to(dtype=torch.float32, device="cuda"))
         optimizer_cuda = constructor(weight_cuda, bias_cuda)
         fn_cuda = functools.partial(fn_base, optimizer_cuda, weight_cuda, bias_cuda)
 
@@ -249,21 +263,28 @@ class TestOptim(TestCase):
         self.assertEqual(getPublicAttr(optimizer), getPublicAttr(deepcopy(optimizer)))
 
     def _test_basic_cases(self, constructor, scheduler_constructors=None,
-                          ignore_multidevice=False, constructor_accepts_maximize=False):
+                          ignore_multidevice=False, constructor_accepts_maximize=False, constructor_accepts_foreach=False):
         if scheduler_constructors is None:
             scheduler_constructors = []
 
-        def make_two_arg_constructor(constructor, maximize: bool = False):
+        def make_two_arg_constructor(constructor, maximize: bool = False, foreach: bool = False):
+            if constructor_accepts_maximize and constructor_accepts_foreach:
+                return lambda weight, bias: constructor(weight, bias, maximize, foreach)
             if constructor_accepts_maximize:
                 return lambda weight, bias: constructor(weight, bias, maximize)
+            if constructor_accepts_foreach:
+                return lambda weight, bias: constructor(weight, bias, foreach)
             return constructor
 
-        for maximize in (True, False):
+        for maximize, foreach in itertools.product(
+            set([False, constructor_accepts_maximize]),
+            set([False, constructor_accepts_foreach]),
+        ):
             self._test_state_dict(
                 torch.randn(10, 5),
                 torch.randn(10),
                 torch.randn(5),
-                make_two_arg_constructor(constructor, maximize),
+                make_two_arg_constructor(constructor, maximize, foreach),
             )
         self._test_basic_cases_template(
             torch.randn(10, 5),
@@ -272,6 +293,7 @@ class TestOptim(TestCase):
             constructor,
             scheduler_constructors,
             constructor_accepts_maximize,
+            constructor_accepts_foreach,
         )
         # non-contiguous parameters
         self._test_basic_cases_template(
@@ -281,6 +303,7 @@ class TestOptim(TestCase):
             constructor,
             scheduler_constructors,
             constructor_accepts_maximize,
+            constructor_accepts_foreach,
         )
         # CUDA
         if not torch.cuda.is_available():
@@ -292,6 +315,7 @@ class TestOptim(TestCase):
             constructor,
             scheduler_constructors,
             constructor_accepts_maximize,
+            constructor_accepts_foreach,
         )
         # Multi-GPU
         if not torch.cuda.device_count() > 1 or ignore_multidevice:
@@ -303,6 +327,7 @@ class TestOptim(TestCase):
             constructor,
             scheduler_constructors,
             constructor_accepts_maximize,
+            constructor_accepts_foreach,
         )
 
     def _test_complex_optimizer(self, optimizer_constructor):
@@ -352,113 +377,114 @@ class TestOptim(TestCase):
         return [dict(params=bias, **kwargs)]
 
     def test_sgd(self):
-        for optimizer in [optim.SGD, optim_mt.SGD]:
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict_single(weight, bias, lr=1e-2),
-                    lr=1e-3, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict_single(weight, bias, lr=1e-2), maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                [lambda opt: StepLR(opt, gamma=0.9, step_size=10)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                [lambda opt: LinearLR(opt, start_factor=0.4, end_factor=0.8, total_iters=4)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                [lambda opt: StepLR(opt, gamma=0.9, step_size=10),
-                 lambda opt: LinearLR(opt, start_factor=0.4, end_factor=0.6, total_iters=4)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                [lambda opt: StepLR(opt, gamma=0.9, step_size=10),
-                 lambda opt: ReduceLROnPlateau(opt)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                [lambda opt: StepLR(opt, gamma=0.99, step_size=10),
-                 lambda opt: ExponentialLR(opt, gamma=0.99),
-                 lambda opt: ReduceLROnPlateau(opt)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, momentum=0.5, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, momentum=0.5, weight_decay=1, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize:
-                optimizer([weight, bias], nesterov=True, lr=1e-3, momentum=0.5, weight_decay=1, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                [lambda opt: PolynomialLR(opt, power=0.9, total_iters=4)],
-                constructor_accepts_maximize=True
-            )
-            with self.assertRaisesRegex(ValueError, "Invalid momentum value: -0.5"):
-                optimizer(None, lr=1e-2, momentum=-0.5)
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-3, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD(
+                self._build_params_dict_single(weight, bias, lr=1e-2),
+                lr=1e-3, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD(
+                self._build_params_dict_single(weight, bias, lr=1e-2), maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: StepLR(opt, gamma=0.9, step_size=10)],
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: LinearLR(opt, start_factor=0.4, end_factor=0.8, total_iters=4)],
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: StepLR(opt, gamma=0.9, step_size=10),
+                lambda opt: LinearLR(opt, start_factor=0.4, end_factor=0.6, total_iters=4)],
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: StepLR(opt, gamma=0.9, step_size=10),
+                lambda opt: ReduceLROnPlateau(opt)],
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: StepLR(opt, gamma=0.99, step_size=10),
+                lambda opt: ExponentialLR(opt, gamma=0.99),
+                lambda opt: ReduceLROnPlateau(opt)],
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach:
+            optim.SGD([weight, bias], lr=1e-3, momentum=0.5, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach:
+            optim.SGD([weight, bias], lr=1e-3, momentum=0.5, weight_decay=1, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach:
+            optim.SGD([weight, bias], nesterov=True, lr=1e-3, momentum=0.5, weight_decay=1, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.SGD([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: PolynomialLR(opt, power=0.9, total_iters=4)],
+            constructor_accepts_maximize=True, constructor_accepts_foreach=True,
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid momentum value: -0.5"):
+            optim.SGD(None, lr=1e-2, momentum=-0.5)
 
     def test_sgd_sparse(self):
-        for optimizer in [optim.SGD, optim_mt.SGD]:
+        for foreach in (False, True):
             self._test_rosenbrock_sparse(
-                lambda params: optimizer(params, lr=4.8e-3)
+                lambda params: optim.SGD(params, lr=4.8e-3, foreach=foreach)
             )
             self._test_rosenbrock_sparse(
-                lambda params: optimizer(params, lr=0.0048),
+                lambda params: optim.SGD(params, lr=0.0048, foreach=foreach),
                 [lambda opt: StepLR(opt, gamma=0.99999, step_size=300)]
             )
 
     def test_sgd_complex(self):
-        for optimizer in [optim.SGD, optim_mt.SGD]:
+        for foreach in (False, True):
             self._test_complex_optimizer(
-                lambda param: optimizer([param], lr=0.001)
+                lambda param: optim.SGD([param], lr=0.001, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optimizer([param], lr=0.001, momentum=1)
+                lambda param: optim.SGD([param], lr=0.001, momentum=1, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optimizer([param], lr=0.001, momentum=1, weight_decay=1)
+                lambda param: optim.SGD([param], lr=0.001, momentum=1, weight_decay=1, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optimizer([param], lr=0.001, nesterov=True, momentum=1, weight_decay=1)
+                lambda param: optim.SGD([param], lr=0.001, nesterov=True, momentum=1, weight_decay=1, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optimizer([param], lr=0.001, momentum=1, dampening=0.5, weight_decay=1)
+                lambda param: optim.SGD([param], lr=0.001, momentum=1, dampening=0.5, weight_decay=1, foreach=foreach)
             )
 
     def _test_derived_optimizers(self, optimizer_pairs_with_flags, flag):
@@ -468,10 +494,9 @@ class TestOptim(TestCase):
 
         kIterations = 4
         device = 'cuda'
-        for optimizer_ctor, params in optimizer_pairs_with_flags:
+        for optimizer_constructor, params in optimizer_pairs_with_flags:
             res, state = [], []
-            for flag_value in (False, True):
-                params[flag] = flag_value
+            for foreach in (False, True):
                 input = torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], dtype=torch.float64, device=device).reshape(3, 2)
 
                 torch.manual_seed(1)
@@ -480,7 +505,9 @@ class TestOptim(TestCase):
                                             torch.nn.Linear(3, 1),
                                             torch.nn.Sigmoid())
                 model.to(dtype=torch.float64, device=device)
-                optimizer = optimizer_ctor(model.parameters(), **params)
+                params_with_foreach = deepcopy(params)
+                params_with_foreach["foreach"] = foreach
+                optimizer = optimizer_constructor(model.parameters(), **params_with_foreach)
 
                 for _ in range(kIterations):
                     optimizer.zero_grad()
@@ -558,109 +585,131 @@ class TestOptim(TestCase):
         self._test_derived_optimizers(optimizer_pairs_with_flags, "fused")
 
     def test_adam(self):
-        for optimizer in [optim.Adam, optim_mt.Adam]:
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, amsgrad=True, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, weight_decay=0.1, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3, amsgrad=True, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3, maximize=maximize),
-                [lambda opt: ExponentialLR(opt, gamma=0.9)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3, maximize=maximize),
-                [lambda opt: LinearLR(opt, start_factor=0.4, total_iters=4)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3, maximize=maximize),
-                [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, amsgrad=True, maximize=maximize),
-                [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4),
-                 lambda opt: ExponentialLR(opt, gamma=0.9)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, amsgrad=True, maximize=maximize),
-                [lambda opt: ExponentialLR(opt, gamma=0.9),
-                 lambda opt: ReduceLROnPlateau(opt)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3, amsgrad=True, maximize=maximize),
-                [lambda opt: StepLR(opt, gamma=0.9, step_size=10),
-                 lambda opt: ReduceLROnPlateau(opt)],
-                constructor_accepts_maximize=True
-            )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                [weight, bias], lr=1e-3, amsgrad=True, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                [weight, bias], lr=1e-3, weight_decay=0.1, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-3, amsgrad=True, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: ExponentialLR(opt, gamma=0.9)],
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: LinearLR(opt, start_factor=0.4, total_iters=4)],
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4)],
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                [weight, bias], lr=1e-3, amsgrad=True, maximize=maximize, foreach=foreach),
+            [lambda opt: ConstantLR(opt, factor=0.4, total_iters=4),
+                lambda opt: ExponentialLR(opt, gamma=0.9)],
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                [weight, bias], lr=1e-3, amsgrad=True, maximize=maximize, foreach=foreach),
+            [lambda opt: ExponentialLR(opt, gamma=0.9),
+                lambda opt: ReduceLROnPlateau(opt)],
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-3, amsgrad=True, maximize=maximize, foreach=foreach),
+            [lambda opt: StepLR(opt, gamma=0.9, step_size=10),
+                lambda opt: ReduceLROnPlateau(opt)],
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
 
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3, maximize=maximize),
-                [lambda opt: PolynomialLR(opt, total_iters=4, power=0.9)],
-                constructor_accepts_maximize=True
-            )
-            self._test_complex_2d(optimizer)
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adam(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-3, maximize=maximize, foreach=foreach),
+            [lambda opt: PolynomialLR(opt, total_iters=4, power=0.9)],
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_complex_2d(optim.Adam)
+        self._test_complex_2d(functools.partial(optim.Adam, foreach=True))
 
-            with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
-                optimizer(None, lr=1e-2, betas=(1.0, 0.0))
+        with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
+            optim.Adam(None, lr=1e-2, betas=(1.0, 0.0))
 
-            with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
-                optimizer(None, lr=1e-2, weight_decay=-1)
+        with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
+            optim.Adam(None, lr=1e-2, weight_decay=-1)
 
     def test_adamw(self):
-        for optimizer in [optim.AdamW, optim_mt.AdamW]:
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, weight_decay=1, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, weight_decay=1, amsgrad=True, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_complex_2d(optimizer)
-            with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
-                optimizer(None, lr=1e-2, weight_decay=-1)
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.AdamW([weight, bias], lr=1e-3, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.AdamW(
+                self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.AdamW(
+                [weight, bias], lr=1e-3, weight_decay=1, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.AdamW(
+                [weight, bias], lr=1e-3, weight_decay=1, amsgrad=True, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_complex_2d(optim.AdamW)
+        self._test_complex_2d(functools.partial(optim.AdamW, foreach=True))
+        with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
+            optim.AdamW(None, lr=1e-2, weight_decay=-1)
 
     def test_sparse_adam(self):
         self._test_rosenbrock_sparse(
@@ -685,29 +734,33 @@ class TestOptim(TestCase):
     def test_adadelta(self):
         # Handles https://github.com/pytorch/pytorch/issues/69698
         self.rel_tol = 4e-3
-        for optimizer in [optim.Adadelta, optim_mt.Adadelta]:
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, rho=0.95), maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, rho=0.95), maximize=maximize),
-                [lambda opt: StepLR(opt, gamma=0.9, step_size=10),
-                 lambda opt: ReduceLROnPlateau(opt)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], weight_decay=1, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            with self.assertRaisesRegex(ValueError, "Invalid rho value: 1.1"):
-                optimizer(None, lr=1e-2, rho=1.1)
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adadelta([weight, bias], maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adadelta(
+                self._build_params_dict(weight, bias, rho=0.95), maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adadelta(
+                self._build_params_dict(weight, bias, rho=0.95), maximize=maximize, foreach=foreach),
+            [lambda opt: StepLR(opt, gamma=0.9, step_size=10),
+                lambda opt: ReduceLROnPlateau(opt)],
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adadelta(
+                [weight, bias], weight_decay=1, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid rho value: 1.1"):
+            optim.Adadelta(None, lr=1e-2, rho=1.1)
 
     def test_adadelta_complex(self):
         # Handles https://github.com/pytorch/pytorch/issues/69698
@@ -724,232 +777,257 @@ class TestOptim(TestCase):
             )
 
     def test_nadam(self):
-        for optimizer in [optim.NAdam, optim_mt.NAdam]:
-            self._test_basic_cases(
-                lambda weight, bias: optimizer([weight, bias], lr=1e-3)
-            )
-            self._test_basic_cases(
-                lambda weight, bias: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3)
-            )
-            self._test_basic_cases(
-                lambda weight, bias: optimizer([weight, bias], lr=1e-3, weight_decay=0.1, momentum_decay=6e-3)
-            )
-            self._test_basic_cases(
-                lambda weight, bias: optimizer([weight, bias], lr=1e-3, weight_decay=0.1, momentum_decay=6e-3),
-                [lambda opt: ExponentialLR(opt, gamma=0.9)]
-            )
-            with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
-                optimizer(None, lr=1e-2, betas=(1.0, 0.0))
-            with self.assertRaisesRegex(ValueError, "Invalid momentum_decay value: -0.2"):
-                optimizer(None, lr=1e-2, momentum_decay=-0.2)
+        self._test_basic_cases(
+            lambda weight, bias, foreach: optim.NAdam([weight, bias], lr=1e-3, foreach=foreach),
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, foreach: optim.NAdam(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-3, foreach=foreach),
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, foreach: optim.NAdam(
+                [weight, bias], lr=1e-3, weight_decay=0.1, momentum_decay=6e-3, foreach=foreach),
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, foreach: optim.NAdam(
+                [weight, bias], lr=1e-3, weight_decay=0.1, momentum_decay=6e-3, foreach=foreach),
+            [lambda opt: ExponentialLR(opt, gamma=0.9)],
+            constructor_accepts_foreach=True,
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
+            optim.NAdam(None, lr=1e-2, betas=(1.0, 0.0))
+        with self.assertRaisesRegex(ValueError, "Invalid momentum_decay value: -0.2"):
+            optim.NAdam(None, lr=1e-2, momentum_decay=-0.2)
 
     def test_adagrad(self):
-        for optimizer in [optim.Adagrad, optim_mt.Adagrad]:
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-1, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    [weight, bias], lr=1e-1, initial_accumulator_value=0.1, maximize=maximize,
-                ),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-1,
-                    maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-1,
-                    maximize=maximize),
-                [lambda opt: ReduceLROnPlateau(opt)],
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-1,
-                    maximize=maximize),
-                [lambda opt: ReduceLROnPlateau(opt),
-                 lambda opt: ExponentialLR(opt, gamma=0.99)],
-                constructor_accepts_maximize=True
-            )
-            with self.assertRaisesRegex(ValueError, "Invalid lr_decay value: -0.5"):
-                optimizer(None, lr=1e-2, lr_decay=-0.5)
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adagrad([weight, bias], lr=1e-1, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adagrad(
+                [weight, bias], lr=1e-1, initial_accumulator_value=0.1, maximize=maximize, foreach=foreach,
+            ),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adagrad(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-1,
+                maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adagrad(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-1,
+                maximize=maximize, foreach=foreach),
+            [lambda opt: ReduceLROnPlateau(opt)],
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adagrad(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-1,
+                maximize=maximize, foreach=foreach),
+            [lambda opt: ReduceLROnPlateau(opt),
+                lambda opt: ExponentialLR(opt, gamma=0.99)],
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid lr_decay value: -0.5"):
+            optim.Adagrad(None, lr=1e-2, lr_decay=-0.5)
 
     def test_adagrad_sparse(self):
-        for optimizer in [optim.Adagrad, optim_mt.Adagrad]:
+        for foreach in (False, True):
             self._test_rosenbrock_sparse(
-                lambda params: optimizer(params, lr=1e-1)
+                lambda params: optim.Adagrad(params, lr=1e-1, foreach=foreach)
             )
             self._test_rosenbrock_sparse(
-                lambda params: optimizer(params, lr=0.1),
+                lambda params: optim.Adagrad(params, lr=0.1, foreach=foreach),
                 [lambda opt: StepLR(opt, gamma=1 - 1e-5, step_size=500),
                  lambda opt: ReduceLROnPlateau(opt, threshold=1e-4)]
             )
 
     def test_adagrad_complex(self):
-        for optimizer in [optim.Adagrad, optim_mt.Adagrad]:
+        for foreach in (False, True):
             self._test_complex_optimizer(
-                lambda param: optimizer([param], lr=1e-1)
+                lambda param: optim.Adagrad([param], lr=1e-1, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optimizer(
-                    [param], lr=1e-1, initial_accumulator_value=0.1
+                lambda param: optim.Adagrad(
+                    [param], lr=1e-1, initial_accumulator_value=0.1, foreach=foreach,
                 )
             )
 
     def test_adamax(self):
-        for optimizer in [optim.Adamax, optim_mt.Adamax]:
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    [weight, bias], lr=1e-1, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-1, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    [weight, bias], lr=1e-1, weight_decay=1, maximize=maximize),
-                constructor_accepts_maximize=True
-            )
-            self._test_complex_2d(optimizer)
-            with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 1: 1.0"):
-                optimizer(None, lr=1e-2, betas=(0.0, 1.0))
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adamax(
+                [weight, bias], lr=1e-1, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adamax(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-1, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, maximize, foreach: optim.Adamax(
+                [weight, bias], lr=1e-1, weight_decay=1, maximize=maximize, foreach=foreach),
+            constructor_accepts_maximize=True,
+            constructor_accepts_foreach=True,
+        )
+        self._test_complex_2d(optim.Adamax)
+        self._test_complex_2d(functools.partial(optim.Adamax, foreach=True))
+        with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 1: 1.0"):
+            optim.Adamax(None, lr=1e-2, betas=(0.0, 1.0))
 
     def test_radam(self):
-        for optimizer in [optim.RAdam, optim_mt.RAdam]:
-            self._test_basic_cases(
-                lambda weight, bias: optimizer([weight, bias], lr=1e-3)
-            )
-            self._test_basic_cases(
-                lambda weight, bias: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3)
-            )
-            self._test_basic_cases(
-                lambda weight, bias: optimizer([weight, bias], lr=1e-3, weight_decay=0.1)
-            )
-            self._test_basic_cases(
-                lambda weight, bias: optimizer([weight, bias], lr=1e-3),
-                [lambda opt: ExponentialLR(opt, gamma=0.9),
-                    lambda opt: ReduceLROnPlateau(opt)]
-            )
-            with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
-                optimizer(None, lr=1e-2, betas=(1.0, 0.0))
+        self._test_basic_cases(
+            lambda weight, bias, foreach: optim.RAdam([weight, bias], lr=1e-3, foreach=foreach),
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, foreach: optim.RAdam(
+                self._build_params_dict(weight, bias, lr=1e-2), lr=1e-3, foreach=foreach),
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, foreach: optim.RAdam([weight, bias], lr=1e-3, weight_decay=0.1, foreach=foreach),
+            constructor_accepts_foreach=True,
+        )
+        self._test_basic_cases(
+            lambda weight, bias, foreach: optim.RAdam([weight, bias], lr=1e-3, foreach=foreach),
+            [lambda opt: ExponentialLR(opt, gamma=0.9), lambda opt: ReduceLROnPlateau(opt)],
+            constructor_accepts_foreach=True,
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
+            optim.RAdam(None, lr=1e-2, betas=(1.0, 0.0))
 
-            with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
-                optimizer(None, lr=1e-2, weight_decay=-1)
+        with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
+            optim.RAdam(None, lr=1e-2, weight_decay=-1)
 
     def test_rmsprop(self):
-        for optimizer in [optim.RMSprop, optim_mt.RMSprop]:
+        for foreach in (False, True):
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-2, maximize=maximize),
-                constructor_accepts_maximize=True
+                lambda weight, bias, maximize, foreach: optim.RMSprop(
+                    [weight, bias], lr=1e-2, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
+                lambda weight, bias, maximize, foreach: optim.RMSprop(
                     self._build_params_dict(weight, bias, lr=1e-3),
-                    lr=1e-2, maximize=maximize),
-                constructor_accepts_maximize=True
+                    lr=1e-2, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
+                lambda weight, bias, maximize, foreach: optim.RMSprop(
                     self._build_params_dict(weight, bias, lr=1e-3),
-                    lr=1e-2, centered=True, maximize=maximize),
-                constructor_accepts_maximize=True
+                    lr=1e-2, centered=True, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
+                lambda weight, bias, maximize, foreach: optim.RMSprop(
                     self._build_params_dict(weight, bias, lr=1e-3),
-                    lr=1e-2, centered=True, momentum=0.1, maximize=maximize),
-                constructor_accepts_maximize=True
+                    lr=1e-2, centered=True, momentum=0.1, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
+                lambda weight, bias, maximize, foreach: optim.RMSprop(
                     self._build_params_dict(weight, bias, lr=1e-3),
-                    lr=1e-2, momentum=0.1, maximize=maximize),
-                constructor_accepts_maximize=True
+                    lr=1e-2, momentum=0.1, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
+                lambda weight, bias, maximize, foreach: optim.RMSprop(
                     self._build_params_dict(weight, bias, lr=1e-3),
-                    lr=1e-2, momentum=0.1, weight_decay=1, maximize=maximize),
-                constructor_accepts_maximize=True
+                    lr=1e-2, momentum=0.1, weight_decay=1, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
-            self._test_complex_2d(optimizer)
-            self._test_complex_2d(lambda param: optimizer(param, centered=True))
-            self._test_complex_2d(lambda param: optimizer(param, momentum=0.1))
-            self._test_complex_2d(lambda param: optimizer(param, maximize=True))
-            self._test_complex_optimizer(lambda param: optimizer([param]))
-            self._test_complex_optimizer(lambda param: optimizer([param], centered=True))
-            self._test_complex_optimizer(lambda param: optimizer([param], momentum=0.1))
-            self._test_complex_optimizer(lambda param: optimizer([param], maximize=True))
+            self._test_complex_2d(lambda param: optim.RMSprop(param, foreach=foreach))
+            self._test_complex_2d(lambda param: optim.RMSprop(param, centered=True, foreach=foreach))
+            self._test_complex_2d(lambda param: optim.RMSprop(param, momentum=0.1, foreach=foreach))
+            self._test_complex_2d(lambda param: optim.RMSprop(param, maximize=True, foreach=foreach))
+            self._test_complex_optimizer(lambda param: optim.RMSprop([param], foreach=foreach))
+            self._test_complex_optimizer(lambda param: optim.RMSprop([param], centered=True, foreach=foreach))
+            self._test_complex_optimizer(lambda param: optim.RMSprop([param], momentum=0.1, foreach=foreach))
+            self._test_complex_optimizer(lambda param: optim.RMSprop([param], maximize=True, foreach=foreach))
             with self.assertRaisesRegex(ValueError, "Invalid momentum value: -1.0"):
-                optimizer(None, lr=1e-2, momentum=-1.0)
+                optim.RMSprop(None, lr=1e-2, momentum=-1.0, foreach=foreach)
 
     def test_asgd(self):
-        for optimizer in [optim.ASGD, optim_mt.ASGD]:
+        for foreach in (False, True):
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=1e-3, t0=100, maximize=maximize),
-                constructor_accepts_maximize=True
+                lambda weight, bias, maximize, foreach: optim.ASGD(
+                    [weight, bias], lr=1e-3, t0=100, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
+                lambda weight, bias, maximize, foreach: optim.ASGD(
                     self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3, t0=100, maximize=maximize),
-                constructor_accepts_maximize=True
+                    lr=1e-3, t0=100, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
+                lambda weight, bias, maximize, foreach: optim.ASGD(
                     self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=1e-3, weight_decay=1, maximize=maximize),
-                constructor_accepts_maximize=True
+                    lr=1e-3, weight_decay=1, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
             # Ref: https://github.com/pytorch/pytorch/issues/84560
             # self._test_complex_2d(optimizer)
-            self._test_complex_optimizer(lambda params: optimizer([params]))
-            self._test_complex_optimizer(lambda params: optimizer([params], maximize=True))
-            self._test_complex_optimizer(lambda params: optimizer([params], maximize=True, weight_decay=0.9))
-            self._test_complex_optimizer(lambda params: optimizer([params], maximize=False, weight_decay=0.9))
-            self._test_complex_optimizer(lambda params: optimizer([params], weight_decay=0.9))
-
+            self._test_complex_optimizer(lambda params: optim.ASGD([params], foreach=foreach))
+            self._test_complex_optimizer(lambda params: optim.ASGD([params], maximize=True, foreach=foreach))
+            self._test_complex_optimizer(lambda params: optim.ASGD([params], maximize=True, weight_decay=0.9, foreach=foreach))
+            self._test_complex_optimizer(lambda params: optim.ASGD([params], maximize=False, weight_decay=0.9, foreach=foreach))
+            self._test_complex_optimizer(lambda params: optim.ASGD([params], weight_decay=0.9, foreach=foreach))
             with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -0.5"):
-                optimizer(None, lr=1e-2, weight_decay=-0.5)
+                optim.ASGD(None, lr=1e-2, weight_decay=-0.5, foreach=foreach)
 
     @skipIfRocm
     def test_rprop(self):
-        for optimizer in [optim.Rprop, optim_mt.Rprop]:
+        for foreach in (False, True):
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer([weight, bias], lr=2e-4, maximize=maximize),
-                constructor_accepts_maximize=True
+                lambda weight, bias, maximize, foreach: optim.Rprop(
+                    [weight, bias], lr=2e-4, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
             self._test_basic_cases(
-                lambda weight, bias, maximize: optimizer(
-                    self._build_params_dict(weight, bias, lr=1e-2),
-                    lr=2e-4, maximize=maximize),
-                constructor_accepts_maximize=True
+                lambda weight, bias, maximize, foreach: optim.Rprop(
+                    self._build_params_dict(weight, bias, lr=1e-2), lr=2e-4, maximize=maximize, foreach=foreach),
+                constructor_accepts_maximize=True,
+                constructor_accepts_foreach=True,
             )
-            self._test_complex_2d(optimizer)
+            self._test_complex_2d(lambda param: optim.Rprop(param, foreach=foreach))
             self._test_complex_optimizer(
-                lambda param: optimizer([param], lr=0.001)
+                lambda param: optim.Rprop([param], lr=0.001, foreach=foreach)
             )
             self._test_complex_optimizer(
-                lambda param: optimizer([param], lr=0.001, maximize=True)
+                lambda param: optim.Rprop([param], lr=0.001, maximize=True, foreach=foreach)
             )
             with self.assertRaisesRegex(ValueError, "Invalid eta values: 1.0, 0.5"):
-                optimizer(None, lr=1e-2, etas=(1.0, 0.5))
+                optim.Rprop(None, lr=1e-2, etas=(1.0, 0.5), foreach=foreach)
 
     def test_lbfgs(self):
         self._test_basic_cases(
@@ -964,8 +1042,8 @@ class TestOptim(TestCase):
     @unittest.skipIf(TEST_WITH_UBSAN, "division-by-zero error with UBSAN")
     def test_lbfgs_return_type(self):
         params = [torch.randn(10, 5), torch.randn(10)]
-        opt1 = optim.LBFGS(params, 0.01, tolerance_grad=inf)
-        opt2 = optim.LBFGS(params, 0.01, tolerance_grad=-inf)
+        opt1 = optim.LBFGS(params, 0.01, tolerance_grad=math.inf)
+        opt2 = optim.LBFGS(params, 0.01, tolerance_grad=-math.inf)
 
         def closure():
             return torch.tensor([10])
@@ -976,10 +1054,10 @@ class TestOptim(TestCase):
 
     def test_invalid_param_type(self):
         with self.assertRaises(TypeError):
-            optim.SGD(Variable(torch.randn(5, 5)), lr=3)
+            optim.SGD(Parameter(torch.randn(5, 5)), lr=3)
 
     def test_duplicate_params_in_param_group(self):
-        param = Variable(torch.randn(5, 5))
+        param = Parameter(torch.randn(5, 5))
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             optim.SGD([param, param], lr=0.1)
@@ -1115,7 +1193,7 @@ class TestLRScheduler(TestCase):
 
     def test_no_cyclic_references(self):
         import gc
-        param = Variable(torch.empty(10), requires_grad=True)
+        param = Parameter(torch.empty(10))
         optim = SGD([param], lr=0.5)
         scheduler = LambdaLR(optim, lambda epoch: 1.0)
         del scheduler


### PR DESCRIPTION
As per title, this updates `test_optim.py` so that `foreach` optimizers are constructed using the `foreach` keyword argument of `torch.optim` optimizers.

Also, this makes some cosmetic changes to remove `torch.autograd.Variable`, `.data` calls, and `torch._six`.


Related: https://github.com/pytorch/pytorch/pull/81705#discussion_r939440776
