### PR TITLE
Adding XLA folks to reviewer/approvers

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -317,6 +317,25 @@
       ]
    },
    {
+      "name": "Lazy Tensor",
+      "patterns": [
+         "torch/csrc/lazy/**",
+         "test/cpp/lazy/**",
+         "test/lazy/**",
+         "codegen/api/lazy.py",
+         "codegen/dest/lazy_ir.py",
+         "codegen/dest/lazy_ts_lowering.py",
+         "codegen/gen_lazy_tensor.py",
+         "aten/src/ATen/native/ts_native_functions.yaml"
+      ],
+      "approved_by": [ "alanwaketan", "JackCaoG"],
+      "mandatory_checks_name": [
+         "Facebook CLA Check",
+         "Lint",
+         "pull"
+       ]
+   },
+   {
       "name": "superuser",
       "patterns": ["*"],
       "approved_by": ["pytorch/metamates"],


### PR DESCRIPTION
XLA folks will be doing a lot of smaller changes to the Lazy component that they can review themselves w/o either @wconstab or myself. They need approval permissions for the Lazy component.