### PR TITLE
[vulkan] Do not populate unpacked args of PackedContexts when deserializing

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -926,7 +926,8 @@ Conv2dPackedContext::Conv2dPackedContext(
     const IntArrayRef output_padding_arg,
     const int64_t groups,
     const c10::optional<Scalar>& output_min,
-    const c10::optional<Scalar>& output_max)
+    const c10::optional<Scalar>& output_max,
+    const bool fill_unpacked)
     : unpacked_{c10::AnyType::get()} {
   const auto stride = expand_param_if_needed(stride_arg, "stride", 2);
   const auto padding = expand_param_if_needed(padding_arg, "padding", 2);
@@ -955,7 +956,7 @@ Conv2dPackedContext::Conv2dPackedContext(
   const auto method = determine_method(
       weight.sizes(), stride, padding, dilation, groups, transposed, quantized);
 
-  packed_.reserve(14);
+  packed_.reserve(Packed::NumArgs);
   packed_.emplace_back(
       convert(pack_weights(weight, transposed, quantized, method)));
   packed_.emplace_back(
@@ -977,20 +978,28 @@ Conv2dPackedContext::Conv2dPackedContext(
   packed_.emplace_back(method);
   packed_.emplace_back(weight.sizes().vec());
 
-  unpacked_.reserve(11);
-  unpacked_.emplace_back(weight);
-  unpacked_.emplace_back(bias);
-  unpacked_.emplace_back(stride_arg.vec());
-  unpacked_.emplace_back(padding_arg.vec());
-  unpacked_.emplace_back(dilation_arg.vec());
-  unpacked_.emplace_back(transposed);
-  unpacked_.emplace_back(quantized);
-  unpacked_.emplace_back(output_padding_arg.vec());
-  unpacked_.emplace_back(groups);
-  unpacked_.emplace_back(output_min);
-  unpacked_.emplace_back(output_max);
+  if (fill_unpacked) {
+    unpacked_.reserve(Unpacked::NumArgs);
+    unpacked_.emplace_back(weight);
+    unpacked_.emplace_back(bias);
+    unpacked_.emplace_back(stride_arg.vec());
+    unpacked_.emplace_back(padding_arg.vec());
+    unpacked_.emplace_back(dilation_arg.vec());
+    unpacked_.emplace_back(transposed);
+    unpacked_.emplace_back(quantized);
+    unpacked_.emplace_back(output_padding_arg.vec());
+    unpacked_.emplace_back(groups);
+    unpacked_.emplace_back(output_min);
+    unpacked_.emplace_back(output_max);
+  }
 }
 
+/*
+ * This function is used as the __setstate__ method of the PackContext class,
+ * which is used to deserialize the class. Note that fill_unpacked is set to
+ * false, since the unpacked list is not required to run inference - the
+ * original tensors are therefore released in order to save memory.
+ */
 Conv2dPackedContext Conv2dPackedContext::pack(c10::impl::GenericList unpacked) {
   return Conv2dPackedContext(
       unpacked.get(Unpacked::Weight).toTensor(),
@@ -1003,7 +1012,8 @@ Conv2dPackedContext Conv2dPackedContext::pack(c10::impl::GenericList unpacked) {
       unpacked.get(Unpacked::OutputPadding).toIntVector(),
       unpacked.get(Unpacked::Groups).toInt(),
       get_optional_scalar(unpacked, Unpacked::OutputMin),
-      get_optional_scalar(unpacked, Unpacked::OutputMax));
+      get_optional_scalar(unpacked, Unpacked::OutputMax),
+      /* fill_unpacked= */ false);
 }
 
 c10::intrusive_ptr<Conv2dPackedContext> create_conv2d_context(

--- a/aten/src/ATen/native/vulkan/ops/Convolution.h
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.h
@@ -26,7 +26,7 @@ class Conv2dPackedContext final : virtual public VulkanPackedContext,
   c10::impl::GenericList unpacked_;
 
  public:
-  explicit Conv2dPackedContext(
+  Conv2dPackedContext(
       const Tensor& weight,
       const c10::optional<Tensor>& bias,
       const IntArrayRef stride_arg,
@@ -37,8 +37,7 @@ class Conv2dPackedContext final : virtual public VulkanPackedContext,
       const IntArrayRef output_padding_arg,
       const int64_t groups,
       const c10::optional<Scalar>& output_min = c10::nullopt,
-      const c10::optional<Scalar>& output_max = c10::nullopt,
-      const bool fill_unpacked = true);
+      const c10::optional<Scalar>& output_max = c10::nullopt);
 
   /*
    * Assigns a name to each index in the unpacked list.
@@ -84,13 +83,7 @@ class Conv2dPackedContext final : virtual public VulkanPackedContext,
   static Conv2dPackedContext pack(c10::impl::GenericList);
 
   const c10::impl::GenericList unpack() const override {
-    TORCH_CHECK(
-        unpacked_.size() == Unpacked::NumArgs,
-        "unpacked_ must have ",
-        Unpacked::NumArgs,
-        " arguments, found ",
-        unpacked_.size(),
-        "!");
+    TORCH_CHECK(unpacked_.size() > 0u, "unpacked_ does not have any elements!");
 
     return unpacked_;
   }

--- a/aten/src/ATen/native/vulkan/ops/Convolution.h
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.h
@@ -26,7 +26,7 @@ class Conv2dPackedContext final : virtual public VulkanPackedContext,
   c10::impl::GenericList unpacked_;
 
  public:
-  Conv2dPackedContext(
+  explicit Conv2dPackedContext(
       const Tensor& weight,
       const c10::optional<Tensor>& bias,
       const IntArrayRef stride_arg,
@@ -37,7 +37,8 @@ class Conv2dPackedContext final : virtual public VulkanPackedContext,
       const IntArrayRef output_padding_arg,
       const int64_t groups,
       const c10::optional<Scalar>& output_min = c10::nullopt,
-      const c10::optional<Scalar>& output_max = c10::nullopt);
+      const c10::optional<Scalar>& output_max = c10::nullopt,
+      const bool fill_unpacked = true);
 
   /*
    * Assigns a name to each index in the unpacked list.
@@ -54,6 +55,8 @@ class Conv2dPackedContext final : virtual public VulkanPackedContext,
     static constexpr uint32_t Groups = 8u;
     static constexpr uint32_t OutputMin = 9u;
     static constexpr uint32_t OutputMax = 10u;
+
+    static constexpr uint32_t NumArgs = 11u;
   };
 
   /*
@@ -74,11 +77,21 @@ class Conv2dPackedContext final : virtual public VulkanPackedContext,
     static constexpr uint32_t OutputMax = 11u;
     static constexpr uint32_t ConvMethod = 12u;
     static constexpr uint32_t WeightSizes = 13u;
+
+    static constexpr uint32_t NumArgs = 14u;
   };
 
   static Conv2dPackedContext pack(c10::impl::GenericList);
 
   const c10::impl::GenericList unpack() const override {
+    TORCH_CHECK(
+        unpacked_.size() == Unpacked::NumArgs,
+        "unpacked_ must have ",
+        Unpacked::NumArgs,
+        " arguments, found ",
+        unpacked_.size(),
+        "!");
+
     return unpacked_;
   }
 };

--- a/aten/src/ATen/native/vulkan/ops/Gru.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Gru.cpp
@@ -115,8 +115,7 @@ TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
 
 std::vector<c10::intrusive_ptr<LinearPackedContext>> pack_linear_op_contexts(
     const std::vector<Tensor>& params_cpu,
-    int64_t num_layers,
-    const bool fill_unpacked) {
+    int64_t num_layers) {
   TORCH_CHECK(
       static_cast<int64_t>(params_cpu.size()) == 4 * num_layers,
       "Vulkan gru expects 'params_cpu' size to be 4 * 'num_layers'.");
@@ -148,31 +147,24 @@ std::vector<c10::intrusive_ptr<LinearPackedContext>> pack_linear_op_contexts(
     const auto& b_hz = b_h_rzn[1];
     const auto& b_hn = b_h_rzn[2];
 
-    linear_op_contexts.emplace_back(
-        create_packed_linear(w_ir.t(), b_ir, fill_unpacked));
-    linear_op_contexts.emplace_back(
-        create_packed_linear(w_hr.t(), b_hr, fill_unpacked));
-    linear_op_contexts.emplace_back(
-        create_packed_linear(w_iz.t(), b_iz, fill_unpacked));
-    linear_op_contexts.emplace_back(
-        create_packed_linear(w_hz.t(), b_hz, fill_unpacked));
-    linear_op_contexts.emplace_back(
-        create_packed_linear(w_in.t(), b_in, fill_unpacked));
-    linear_op_contexts.emplace_back(
-        create_packed_linear(w_hn.t(), b_hn, fill_unpacked));
+    linear_op_contexts.emplace_back(create_linear_context(w_ir.t(), b_ir));
+    linear_op_contexts.emplace_back(create_linear_context(w_hr.t(), b_hr));
+    linear_op_contexts.emplace_back(create_linear_context(w_iz.t(), b_iz));
+    linear_op_contexts.emplace_back(create_linear_context(w_hz.t(), b_hz));
+    linear_op_contexts.emplace_back(create_linear_context(w_in.t(), b_in));
+    linear_op_contexts.emplace_back(create_linear_context(w_hn.t(), b_hn));
   }
   return linear_op_contexts;
 }
 
 GruPackedContext::GruPackedContext(
     const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
-    const bool has_biases,
-    const int64_t num_layers,
-    const double dropout,
-    const bool train,
-    const bool bidirectional,
-    const bool batch_first,
-    const bool fill_unpacked) {
+    bool has_biases,
+    int64_t num_layers,
+    double dropout,
+    bool train,
+    bool bidirectional,
+    bool batch_first) {
   TORCH_INTERNAL_ASSERT(
       has_biases, "Vulkan gru expects 'has_biases' to be true.");
   TORCH_INTERNAL_ASSERT(!train, "Vulkan gru expects 'train' to be false.");
@@ -184,9 +176,8 @@ GruPackedContext::GruPackedContext(
       dropout < std::numeric_limits<double>::epsilon() * 1000,
       "Vulkan gru expects 'dropout' to be 0.0.");
 
-  packed_.reserve(7);
-  packed_.emplace_back(
-      pack_linear_op_contexts(params_cpu, num_layers, fill_unpacked));
+  packed_.reserve(Packed::NumArgs);
+  packed_.emplace_back(pack_linear_op_contexts(params_cpu, num_layers));
   packed_.emplace_back(has_biases);
   packed_.emplace_back(num_layers);
   packed_.emplace_back(dropout);
@@ -208,7 +199,7 @@ GruPackedContext GruPackedContext::pack(c10::impl::GenericList unpacked) {
 
 const c10::impl::GenericList GruPackedContext::unpack() const {
   c10::impl::GenericList unpacked_gru_context{c10::AnyType::get()};
-  unpacked_gru_context.reserve(7);
+  unpacked_gru_context.reserve(Unpacked::NumArgs);
 
   const c10::List<c10::IValue> packed_linear_contexts =
       get_val(Packed::LinearContexts).toList();
@@ -224,13 +215,8 @@ const c10::impl::GenericList GruPackedContext::unpack() const {
         packed_linear_context.toCustomClass<LinearPackedContext>()->unpack();
 
     TORCH_CHECK(
-        unpacked_linear_context.size() ==
-            LinearPackedContext::Unpacked::NumArgs,
-        "unpacked_linear_context must have ",
-        Unpacked::NumArgs,
-        " arguments, found ",
-        unpacked_linear_context.size(),
-        "!");
+        unpacked_linear_context.size() > 0u,
+        "unpacked_linear_context does not have any elements!");
 
     params_cpu.emplace_back(
         unpacked_linear_context.get(LinearPackedContext::Unpacked::Weight)

--- a/aten/src/ATen/native/vulkan/ops/Gru.h
+++ b/aten/src/ATen/native/vulkan/ops/Gru.h
@@ -16,12 +16,13 @@ class GruPackedContext final : virtual public VulkanPackedContext,
  public:
   GruPackedContext(
       const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
-      bool has_biases,
-      int64_t num_layers,
-      double dropout,
-      bool train,
-      bool bidirectional,
-      bool batch_first);
+      const bool has_biases,
+      const int64_t num_layers,
+      const double dropout,
+      const bool train,
+      const bool bidirectional,
+      const bool batch_first,
+      const bool fill_unpacked = true);
 
   /*
    * Assigns a name to each index in the unpacked list.
@@ -34,6 +35,8 @@ class GruPackedContext final : virtual public VulkanPackedContext,
     static constexpr uint32_t Train = 4u;
     static constexpr uint32_t Bidirectional = 5u;
     static constexpr uint32_t BatchFirst = 6u;
+
+    static constexpr uint32_t NumArgs = 7u;
   };
 
   /*
@@ -47,6 +50,8 @@ class GruPackedContext final : virtual public VulkanPackedContext,
     static constexpr uint32_t Train = 4u;
     static constexpr uint32_t Bidirectional = 5u;
     static constexpr uint32_t BatchFirst = 6u;
+
+    static constexpr uint32_t NumArgs = 7u;
   };
 
   static GruPackedContext pack(c10::impl::GenericList);

--- a/aten/src/ATen/native/vulkan/ops/Gru.h
+++ b/aten/src/ATen/native/vulkan/ops/Gru.h
@@ -16,13 +16,12 @@ class GruPackedContext final : virtual public VulkanPackedContext,
  public:
   GruPackedContext(
       const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
-      const bool has_biases,
-      const int64_t num_layers,
-      const double dropout,
-      const bool train,
-      const bool bidirectional,
-      const bool batch_first,
-      const bool fill_unpacked = true);
+      bool has_biases,
+      int64_t num_layers,
+      double dropout,
+      bool train,
+      bool bidirectional,
+      bool batch_first);
 
   /*
    * Assigns a name to each index in the unpacked list.

--- a/aten/src/ATen/native/vulkan/ops/Lstm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Lstm.cpp
@@ -152,7 +152,8 @@ TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
 std::vector<c10::intrusive_ptr<LinearPackedContext>>
 pack_lstm_linear_op_contexts(
     const std::vector<Tensor>& params_cpu,
-    int64_t num_layers) {
+    const int64_t num_layers,
+    const bool fill_unpacked) {
   TORCH_CHECK(
       static_cast<int64_t>(params_cpu.size()) == 4 * num_layers,
       "Vulkan LSTM expects 'params_cpu' size to be 4 * 'num_layers'.");
@@ -188,26 +189,35 @@ pack_lstm_linear_op_contexts(
     const auto& b_hg = b_h_ifgo[2];
     const auto& b_ho = b_h_ifgo[3];
 
-    linear_op_contexts.emplace_back(create_linear_context(w_ii.t(), b_ii));
-    linear_op_contexts.emplace_back(create_linear_context(w_hi.t(), b_hi));
-    linear_op_contexts.emplace_back(create_linear_context(w_if.t(), b_if));
-    linear_op_contexts.emplace_back(create_linear_context(w_hf.t(), b_hf));
-    linear_op_contexts.emplace_back(create_linear_context(w_ig.t(), b_ig));
-    linear_op_contexts.emplace_back(create_linear_context(w_hg.t(), b_hg));
-    linear_op_contexts.emplace_back(create_linear_context(w_io.t(), b_io));
-    linear_op_contexts.emplace_back(create_linear_context(w_ho.t(), b_ho));
+    linear_op_contexts.emplace_back(
+        create_packed_linear(w_ii.t(), b_ii, fill_unpacked));
+    linear_op_contexts.emplace_back(
+        create_packed_linear(w_hi.t(), b_hi, fill_unpacked));
+    linear_op_contexts.emplace_back(
+        create_packed_linear(w_if.t(), b_if, fill_unpacked));
+    linear_op_contexts.emplace_back(
+        create_packed_linear(w_hf.t(), b_hf, fill_unpacked));
+    linear_op_contexts.emplace_back(
+        create_packed_linear(w_ig.t(), b_ig, fill_unpacked));
+    linear_op_contexts.emplace_back(
+        create_packed_linear(w_hg.t(), b_hg, fill_unpacked));
+    linear_op_contexts.emplace_back(
+        create_packed_linear(w_io.t(), b_io, fill_unpacked));
+    linear_op_contexts.emplace_back(
+        create_packed_linear(w_ho.t(), b_ho, fill_unpacked));
   }
   return linear_op_contexts;
 }
 
 LstmPackedContext::LstmPackedContext(
     const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
-    bool has_biases,
-    int64_t num_layers,
-    double dropout,
-    bool train,
-    bool bidirectional,
-    bool batch_first) {
+    const bool has_biases,
+    const int64_t num_layers,
+    const double dropout,
+    const bool train,
+    const bool bidirectional,
+    const bool batch_first,
+    const bool fill_unpacked) {
   TORCH_INTERNAL_ASSERT(
       has_biases, "Vulkan LSTM expects 'has_biases' to be true.");
   TORCH_INTERNAL_ASSERT(!train, "Vulkan LSTM expects 'train' to be false.");
@@ -219,8 +229,9 @@ LstmPackedContext::LstmPackedContext(
       dropout < std::numeric_limits<double>::epsilon() * 1000,
       "Vulkan LSTM expects 'dropout' to be 0.0.");
 
-  packed_.reserve(7);
-  packed_.emplace_back(pack_lstm_linear_op_contexts(params_cpu, num_layers));
+  packed_.reserve(Packed::NumArgs);
+  packed_.emplace_back(
+      pack_lstm_linear_op_contexts(params_cpu, num_layers, fill_unpacked));
   packed_.emplace_back(has_biases);
   packed_.emplace_back(num_layers);
   packed_.emplace_back(dropout);
@@ -242,7 +253,7 @@ LstmPackedContext LstmPackedContext::pack(c10::impl::GenericList unpacked) {
 
 const c10::impl::GenericList LstmPackedContext::unpack() const {
   c10::impl::GenericList unpacked_lstm_context{c10::AnyType::get()};
-  unpacked_lstm_context.reserve(7);
+  unpacked_lstm_context.reserve(Unpacked::NumArgs);
 
   const c10::List<c10::IValue> packed_linear_contexts =
       get_val(Packed::LinearContexts).toList();
@@ -256,6 +267,16 @@ const c10::impl::GenericList LstmPackedContext::unpack() const {
   for (c10::IValue packed_linear_context : packed_linear_contexts) {
     const c10::impl::GenericList unpacked_linear_context =
         packed_linear_context.toCustomClass<LinearPackedContext>()->unpack();
+
+    TORCH_CHECK(
+        unpacked_linear_context.size() ==
+            LinearPackedContext::Unpacked::NumArgs,
+        "unpacked_linear_context must have ",
+        Unpacked::NumArgs,
+        " arguments, found ",
+        unpacked_linear_context.size(),
+        "!");
+
     params_cpu.emplace_back(
         unpacked_linear_context.get(LinearPackedContext::Unpacked::Weight)
             .toTensor()

--- a/aten/src/ATen/native/vulkan/ops/Lstm.h
+++ b/aten/src/ATen/native/vulkan/ops/Lstm.h
@@ -16,12 +16,13 @@ class LstmPackedContext final : virtual public VulkanPackedContext,
  public:
   LstmPackedContext(
       const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
-      bool has_biases,
-      int64_t num_layers,
-      double dropout,
-      bool train,
-      bool bidirectional,
-      bool batch_first);
+      const bool has_biases,
+      const int64_t num_layers,
+      const double dropout,
+      const bool train,
+      const bool bidirectional,
+      const bool batch_first,
+      const bool fill_unpacked = true);
 
   /*
    * Assigns a name to each index in the unpacked list.
@@ -34,6 +35,8 @@ class LstmPackedContext final : virtual public VulkanPackedContext,
     static constexpr uint32_t Train = 4u;
     static constexpr uint32_t Bidirectional = 5u;
     static constexpr uint32_t BatchFirst = 6u;
+
+    static constexpr uint32_t NumArgs = 7u;
   };
 
   /*
@@ -47,6 +50,8 @@ class LstmPackedContext final : virtual public VulkanPackedContext,
     static constexpr uint32_t Train = 4u;
     static constexpr uint32_t Bidirectional = 5u;
     static constexpr uint32_t BatchFirst = 6u;
+
+    static constexpr uint32_t NumArgs = 7u;
   };
 
   static LstmPackedContext pack(c10::impl::GenericList);

--- a/aten/src/ATen/native/vulkan/ops/Lstm.h
+++ b/aten/src/ATen/native/vulkan/ops/Lstm.h
@@ -16,13 +16,12 @@ class LstmPackedContext final : virtual public VulkanPackedContext,
  public:
   LstmPackedContext(
       const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
-      const bool has_biases,
-      const int64_t num_layers,
-      const double dropout,
-      const bool train,
-      const bool bidirectional,
-      const bool batch_first,
-      const bool fill_unpacked = true);
+      bool has_biases,
+      int64_t num_layers,
+      double dropout,
+      bool train,
+      bool bidirectional,
+      bool batch_first);
 
   /*
    * Assigns a name to each index in the unpacked list.

--- a/aten/src/ATen/native/vulkan/ops/Mm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mm.cpp
@@ -371,8 +371,7 @@ TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
 
 LinearPackedContext::LinearPackedContext(
     const Tensor& weight,
-    const c10::optional<Tensor>& bias,
-    const bool fill_unpacked)
+    const c10::optional<Tensor>& bias)
     : unpacked_{c10::AnyType::get()} {
   TORCH_CHECK(
       available(weight, bias),
@@ -386,31 +385,17 @@ LinearPackedContext::LinearPackedContext(
   packed_.emplace_back(weight.sizes());
   packed_.emplace_back(bias && bias->defined());
 
-  if (fill_unpacked) {
+  if (!at::globalContext().releaseWeightsWhenPrepacking()) {
     unpacked_.reserve(Unpacked::NumArgs);
     unpacked_.emplace_back(weight);
     unpacked_.emplace_back(bias);
   }
 }
 
-/*
- * This function is used as the __setstate__ method of the PackContext class,
- * which is used to deserialize the class. See comments in
- * Conv2dPackedContext::pack() for why fill_unpacked is set to false.
- */
 LinearPackedContext LinearPackedContext::pack(c10::impl::GenericList unpacked) {
   return LinearPackedContext(
       unpacked.get(Unpacked::Weight).toTensor(),
-      get_optional_tensor(unpacked, Unpacked::Bias),
-      /* fill_unpacked= */ false);
-}
-
-c10::intrusive_ptr<LinearPackedContext> create_packed_linear(
-    Tensor weight,
-    c10::optional<Tensor> bias,
-    const bool fill_unpacked) {
-  return c10::make_intrusive<LinearPackedContext>(
-      LinearPackedContext(weight, bias, fill_unpacked));
+      get_optional_tensor(unpacked, Unpacked::Bias));
 }
 
 c10::intrusive_ptr<LinearPackedContext> create_linear_context(

--- a/aten/src/ATen/native/vulkan/ops/Mm.h
+++ b/aten/src/ATen/native/vulkan/ops/Mm.h
@@ -17,10 +17,7 @@ class LinearPackedContext final : virtual public VulkanPackedContext,
   c10::impl::GenericList unpacked_;
 
  public:
-  LinearPackedContext(
-      const Tensor& weight,
-      const c10::optional<Tensor>& bias,
-      const bool fill_unpacked = true);
+  LinearPackedContext(const Tensor& weight, const c10::optional<Tensor>& bias);
 
   /*
    * Assigns a name to each index in the unpacked list.
@@ -47,26 +44,11 @@ class LinearPackedContext final : virtual public VulkanPackedContext,
   static LinearPackedContext pack(c10::impl::GenericList);
 
   const c10::impl::GenericList unpack() const override {
-    TORCH_CHECK(
-        unpacked_.size() == Unpacked::NumArgs,
-        "unpacked_ must have ",
-        Unpacked::NumArgs,
-        " arguments, found ",
-        unpacked_.size(),
-        "!");
+    TORCH_CHECK(unpacked_.size() > 0u, "unpacked_ does not have any elements!");
 
     return unpacked_;
   }
 };
-
-/*
- * This function is defined for use in other PackedContexts that store linear op
- * contexts as part of its packed args.
- */
-c10::intrusive_ptr<LinearPackedContext> create_packed_linear(
-    Tensor weight,
-    c10::optional<Tensor> bias,
-    const bool fill_unpacked);
 
 c10::intrusive_ptr<LinearPackedContext> create_linear_context(
     Tensor&& weight,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83587

Vulkan ops that use `PackedContext` objects currently maintain two lists storing the parameters of the op:

1. `unpacked_` which stores the original arguments passed in to the op
2. `packed_` which stores pre-processed arguments which are used for inference.

The `unpacked_` list is only needed for serialization - during inference, where it is not expected that the model will be saved, then there is no point keeping the `unpacked_` list in memory.

This diff introduces a flag `fill_unpacked`, by default set to `true`, that is passed into the `*PackedContext()` constructors. `unpacked_` is populated only if `fill_unpacked = true`.

The `create_*_context()` functions will call the constructor with `fill_unpacked = true`, which ensures that `unpacked_` is populated for serialization.

However, when loading a model, the `*PackedContext` objects are deserialized by calling `*PackedContext::pack()`, which will call the constructor with `fill_unpacked = false` - the original tensors will therefore be discarded after packing, saving a significant amount of CPU memory during model inference.

Differential Revision: [D38761645](https://our.internmc.facebook.com/intern/diff/D38761645/)