### PR TITLE
Make sure that we can load old optimizer checkpoint

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -99,6 +99,7 @@ class Adam(Optimizer):
             group.setdefault('maximize', False)
             group.setdefault('foreach', None)
             group.setdefault('capturable', False)
+            group.setdefault('differentiable', False)
         state_values = list(self.state.values())
         step_is_tensor = (len(state_values) != 0) and torch.is_tensor(state_values[0]['step'])
         if not step_is_tensor:

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -114,6 +114,7 @@ class SGD(Optimizer):
             group.setdefault('nesterov', False)
             group.setdefault('maximize', False)
             group.setdefault('foreach', None)
+            group.setdefault('differentiable', False)
 
     @_use_grad_for_differentiable
     def step(self, closure=None):


### PR DESCRIPTION
We want to make sure that we can load checkpoints that were saved with older version of the code (which doesn't contain the differentiable attribute).