### PR TITLE
[DataLoader] Move loop content into a function to ensure we don't preserve anything

### DIFF
--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -21,31 +21,32 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
 
     torch.cuda.set_device(device_id)
 
+    def do_one_step():
+        try:
+            r = in_queue.get(timeout=MP_STATUS_CHECK_INTERVAL)
+        except queue.Empty:
+            return
+        idx, data = r
+        if not done_event.is_set() and not isinstance(data, ExceptionWrapper):
+            try:
+                data = pin_memory(data, device)
+            except Exception:
+                data = ExceptionWrapper(
+                    where="in pin memory thread for device {}".format(device_id))
+            r = (idx, data)
+        while not done_event.is_set():
+            try:
+                out_queue.put(r, timeout=MP_STATUS_CHECK_INTERVAL)
+                break
+            except queue.Full:
+                continue
+
     # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on the
     # logic of this function.
     while not done_event.is_set():
         # Make sure that we don't preserve any object from one iteration
         # to the next
-        def one_step():
-            try:
-                r = in_queue.get(timeout=MP_STATUS_CHECK_INTERVAL)
-            except queue.Empty:
-                return
-            idx, data = r
-            if not done_event.is_set() and not isinstance(data, ExceptionWrapper):
-                try:
-                    data = pin_memory(data, device)
-                except Exception:
-                    data = ExceptionWrapper(
-                        where="in pin memory thread for device {}".format(device_id))
-                r = (idx, data)
-            while not done_event.is_set():
-                try:
-                    out_queue.put(r, timeout=MP_STATUS_CHECK_INTERVAL)
-                    break
-                except queue.Full:
-                    continue
-        one_step()
+        do_one_step()
 
 def pin_memory(data, device=None):
     if isinstance(data, torch.Tensor):

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -30,7 +30,7 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event, device):
             try:
                 r = in_queue.get(timeout=MP_STATUS_CHECK_INTERVAL)
             except queue.Empty:
-                continue
+                return
             idx, data = r
             if not done_event.is_set() and not isinstance(data, ExceptionWrapper):
                 try:


### PR DESCRIPTION
Can lead to CPU memory saving as we don't hold onto the pin memory buffer as long as we used to.