### PR TITLE
Escape curly brackets in FxGraphDrawer _typename

### DIFF
--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -140,12 +140,16 @@ if HAS_PYDOT:
 
         def _typename(self, target: Any) -> str:
             if isinstance(target, torch.nn.Module):
-                return torch.typename(target)
+                ret = torch.typename(target)
+            elif isinstance(target, str):
+                ret = target
+            else:
+                ret = _get_qualified_name(target)
 
-            if isinstance(target, str):
-                return target
-
-            return _get_qualified_name(target)
+            # Escape "{" and "}" to prevent dot files like:
+            # https://gist.github.com/SungMinCho/1a017aab662c75d805c5954d62c5aabc
+            # which triggers `Error: bad label format (...)` from dot
+            return ret.replace("{", r"\{").replace("}", r"\}")
 
         def _get_node_label(
             self,


### PR DESCRIPTION
Summary:
Encountered `Error: bad label format` from dot (i.e. graphviz) when benchmarking models that have dict-like structure.

The root cause was that curly brackets were not properly escaped, like this example P522499127 (unescaped curly brackets in target= string)

This diff insert the fix in FxGraphDrawer, since many of these graph generation codes rely on that class.

(Modified summary before exporting to GitHub PR)

Test Plan:
```
CUDA_VISIBLE_DEVICES=7 buck run mode/opt -c python.package_style=inplace //hpc/new/models/feed/benchmark:feed_lower_benchmark -- --model-name={INSERT IFR QE MODEL NAME HERE} --batch-iter 100 --batch-size 768 --num-gpu 1 --lower-presets {INSERT ITS PRESET}
```

Will not encounter dot errors after this diff.

(Modified test plan before exporting to GitHub PR)

Reviewed By: yinghai

Differential Revision: D38758827

