### PR TITLE
[torchgen] Add documentation for `autogen` keyword

### DIFF
--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -476,6 +476,21 @@ as `Tensor &`, which 1) allowed changing which `TensorImpl` the `Tensor` itself 
 was not necessary to allow the underlying data to change. (This was like using `T * const` when we
 wanted `const T*`.)
 
+### `autogen`
+
+```
+- func: my_op_(Tensor(a!) self) -> Tensor(a!)
+...
+  autogen: my_op, my_op.out
+```
+
+For an in-place variant of a native function (op name ends with an `_`), we offer the option to 
+generate a functional variant and an out= variant. If a functional variant is given, we will be 
+able to generate an out= variant. We don't support `autogen` for view ops, ops that bypass the 
+dispatcher and composite ops. We also generate kernels for generated ops, which merely copy and 
+return the result from the base ops. These generated kernels can be found in 
+`<gen-out>/aten/src/ATen/CompositeViewCopyKernels.cpp`.
+
 
 ## Writing an implementation in C++
 

--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -484,11 +484,11 @@ wanted `const T*`.)
   autogen: my_op, my_op.out
 ```
 
-For an in-place variant of a native function (op name ends with an `_`), we offer the option to 
-generate a functional variant and an out= variant. If a functional variant is given, we will be 
-able to generate an out= variant. We don't support `autogen` for view ops, ops that bypass the 
-dispatcher and composite ops. We also generate kernels for generated ops, which merely copy and 
-return the result from the base ops. These generated kernels can be found in 
+For an in-place variant of a native function (op name ends with an `_`), we offer the option to
+generate a functional variant and an out= variant. If a functional variant is given, we will be
+able to generate an out= variant. We don't support `autogen` for view ops, ops that bypass the
+dispatcher and composite ops. We also generate kernels for generated ops, which merely copy and
+return the result from the base ops. These generated kernels can be found in
 `<gen-out>/aten/src/ATen/CompositeViewCopyKernels.cpp`.
 
 

--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -484,12 +484,19 @@ wanted `const T*`.)
   autogen: my_op, my_op.out
 ```
 
-For an in-place variant of a native function (op name ends with an `_`), we offer the option to
-generate a functional variant and an out= variant. If a functional variant is given, we will be
-able to generate an out= variant. We don't support `autogen` for view ops, ops that bypass the
-dispatcher and composite ops. We also generate kernels for generated ops, which merely copy and
-return the result from the base ops. These generated kernels can be found in
-`<gen-out>/aten/src/ATen/CompositeViewCopyKernels.cpp`.
+`autogen` keyword is being used to specify which native function the codegen system should generate
+implementations for.
+* For an in-place variant of a native function (op name ends with an `_`), we will generate a functional
+variant and an out= variant.
+* If a functional variant is given, we generate an out= variant.
+* We don't support `autogen` for view ops, ops that bypass the dispatcher as well as composite ops.
+
+We also generate kernels for generated ops, which merely copy and return the result from the base ops.
+These generated kernels can be found in `<gen-out>/aten/src/ATen/CompositeViewCopyKernels.cpp`.
+
+Also notice that for new operators being added to `native_functions.yaml`, if they satisfy the requirements
+mentioned above, they should include `autogen` keyword, since functionalization depends on it. We will
+enforce this in codegen.
 
 
 ## Writing an implementation in C++


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #83610

This is a follow up for #81437. This PR explains what operator can use `autogen` and what will be generated. Also talked about generated kernels and where to find them.