### PR TITLE
Release the GIL when munmap'ing tensors - fixes #77139

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -613,7 +613,6 @@ static int THPVariable_clear(THPVariable* self) {
     pybind11::gil_scoped_release no_gil;
     self->cdata = MaybeOwned<Variable>();
   }
-  self->cdata = MaybeOwned<Variable>();
   return 0;
 }
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -609,6 +609,7 @@ static int THPVariable_clear(THPVariable* self) {
     }
   }
   TORCH_INTERNAL_ASSERT(!isResurrectable((THPVariable*)self));
+  pybind11::gil_scoped_release no_gil;
   self->cdata = MaybeOwned<Variable>();
   return 0;
 }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -609,7 +609,10 @@ static int THPVariable_clear(THPVariable* self) {
     }
   }
   TORCH_INTERNAL_ASSERT(!isResurrectable((THPVariable*)self));
-  pybind11::gil_scoped_release no_gil;
+  {
+    pybind11::gil_scoped_release no_gil;
+    self->cdata = MaybeOwned<Variable>();
+  }
   self->cdata = MaybeOwned<Variable>();
   return 0;
 }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -610,6 +610,8 @@ static int THPVariable_clear(THPVariable* self) {
   }
   TORCH_INTERNAL_ASSERT(!isResurrectable((THPVariable*)self));
   {
+    // MapAllocator can take significant time to release large tensors;
+    // release the GIL here to avoid impacting main thread perf.
     pybind11::gil_scoped_release no_gil;
     self->cdata = MaybeOwned<Variable>();
   }


### PR DESCRIPTION
Fixes #77139, where deallocating large tensors with munmap takes a significant amount of time while holding the GIL. This causes the pin_memory thread to interfere with the main thread = performance sadness.

Thanks @igozali @zhengwy888 @colesbury as well.