### PR TITLE
[JIT SSA] Allow updating shape functions without recompilation

### DIFF
--- a/torchgen/shape_functions/gen_jit_shape_functions.py
+++ b/torchgen/shape_functions/gen_jit_shape_functions.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+import importlib.util
 import os
+import sys
 from itertools import chain
 from pathlib import Path
 
@@ -7,8 +9,6 @@ from pathlib import Path
 # Manually importing the shape function module based on current directory
 # instead of torch imports to avoid needing to recompile Pytorch before
 # running the script
-import importlib.util
-import sys
 
 file_path = Path.cwd() / "torch" / "jit" / "_shape_functions.py"
 module_name = "torch.jit._shape_functions"
@@ -19,8 +19,11 @@ if not file_path.exists():
     raise Exception(err_msg)
 
 spec = importlib.util.spec_from_file_location(module_name, file_path)
+assert spec is not None
 module = importlib.util.module_from_spec(spec)
 sys.modules[module_name] = module
+assert spec.loader is not None
+assert module is not None
 spec.loader.exec_module(module)
 
 bounded_compute_graph_mapping = module.bounded_compute_graph_mapping

--- a/torchgen/shape_functions/gen_jit_shape_functions.py
+++ b/torchgen/shape_functions/gen_jit_shape_functions.py
@@ -3,10 +3,29 @@ import os
 from itertools import chain
 from pathlib import Path
 
-from torch.jit._shape_functions import (
-    bounded_compute_graph_mapping,
-    shape_compute_graph_mapping,
-)
+
+# Manually importing the shape function module based on current directory
+# instead of torch imports to avoid needing to recompile Pytorch before
+# running the script
+import importlib.util
+import sys
+
+file_path = Path.cwd() / "torch" / "jit" / "_shape_functions.py"
+module_name = "torch.jit._shape_functions"
+
+err_msg = """Could not find shape functions file, please make sure
+you are in the root directory of the Pytorch git repo"""
+if not file_path.exists():
+    raise Exception(err_msg)
+
+spec = importlib.util.spec_from_file_location(module_name, file_path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[module_name] = module
+spec.loader.exec_module(module)
+
+bounded_compute_graph_mapping = module.bounded_compute_graph_mapping
+shape_compute_graph_mapping = module.shape_compute_graph_mapping
+
 
 SHAPE_HEADER = r"""
 /**


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #78769
* __->__ #83629

In order to avoid extra round trips, and avoid confusion in places such as
this to manually pull in the latest copy of the shape_functions.py file

This also fixes the cases where people pull in the wrong version of the file. This can happen in cases such as when developers run `python setup.py install` instead of `python setup.py develop` to generate their current copy of Pytorch.