### PR TITLE
release the current symintnode in the move c-tor

### DIFF
--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -1,7 +1,6 @@
 #include <c10/core/SymInt.h>
 #include <c10/core/SymIntNodeImpl.h>
 #include <array>
-
 namespace c10 {
 
 std::array<SymIntNode, 2> normalize_symints(SymInt a_, SymInt b_) {

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -63,6 +63,7 @@ class C10_API SymInt {
     return *this;
   }
   SymInt& operator=(SymInt&& s) {
+    release_(); // release the current SymIntNode if any
     data_ = s.data_;
     if (s.is_symbolic())
       s.data_ = 0;
@@ -78,10 +79,14 @@ class C10_API SymInt {
         reinterpret_cast<void*>(static_cast<uintptr_t>(extended_bits)));
   }
 
-  ~SymInt() {
+  void release_() {
     if (is_symbolic()) {
       SymIntNode::reclaim(toSymIntNodeImplUnowned()); // steal
     }
+  }
+
+  ~SymInt() {
+    release_();
   }
 
   int64_t expect_int() const {

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -4,7 +4,6 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 #include <c10/util/intrusive_ptr.h>
-
 #include <memory>
 
 namespace c10 {
@@ -116,6 +115,10 @@ class C10_API SymInt {
 
   int64_t as_int_unchecked() const {
     return data_;
+  }
+
+  void unsafeReset() {
+    data_ = 0;
   }
 
   // Return whether the integer is representable as a SymInt.

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -117,10 +117,6 @@ class C10_API SymInt {
     return data_;
   }
 
-  void unsafeReset() {
-    data_ = 0;
-  }
-
   // Return whether the integer is representable as a SymInt.
   static bool check_range(int64_t i) {
     return i > MIN_INT;
@@ -148,7 +144,7 @@ class C10_API SymInt {
   // Since 0b10... is reserved for symbolic indices, any integers lower than
   // this value would collide with our representation.
   static constexpr int64_t MIN_INT = -1LL & static_cast<int64_t>(~(1ULL << 62));
-  int64_t data_;
+  int64_t data_ = 0;
 };
 
 C10_API std::ostream& operator<<(std::ostream& os, SymInt s);

--- a/c10/core/impl/SizesAndStrides.cpp
+++ b/c10/core/impl/SizesAndStrides.cpp
@@ -37,8 +37,8 @@ void SizesAndStrides::resizeSlowPath(
             inlineStorage_[C10_SIZES_AND_STRIDES_MAX_INLINE_SIZE + i]);
       }
       for (size_t i = 0; i < elemsToZero; i++) {
-        tempStorage[oldSize + i].unsafeReset();
-        tempStorage[newSize + oldSize + i].unsafeReset();
+        tempStorage[oldSize + i] = 0;
+        tempStorage[newSize + oldSize + i] = 0;
       }
       outOfLineStorage_ = tempStorage;
     } else {
@@ -68,8 +68,8 @@ void SizesAndStrides::resizeSlowPath(
         // Zero the end of the sizes portion.
         const auto elemsToZero = newSize - oldSize;
         for (size_t i = 0; i < elemsToZero; i++) {
-          outOfLineStorage_[oldSize + i].unsafeReset();
-          outOfLineStorage_[newSize + oldSize + i].unsafeReset();
+          outOfLineStorage_[oldSize + i] = 0;
+          outOfLineStorage_[newSize + oldSize + i] = 0;
         }
       }
     }

--- a/c10/core/impl/SizesAndStrides.cpp
+++ b/c10/core/impl/SizesAndStrides.cpp
@@ -37,8 +37,8 @@ void SizesAndStrides::resizeSlowPath(
             inlineStorage_[C10_SIZES_AND_STRIDES_MAX_INLINE_SIZE + i]);
       }
       for (size_t i = 0; i < elemsToZero; i++) {
-        tempStorage[oldSize + i] = 0;
-        tempStorage[newSize + oldSize + i] = 0;
+        tempStorage[oldSize + i].unsafeReset();
+        tempStorage[newSize + oldSize + i].unsafeReset();
       }
       outOfLineStorage_ = tempStorage;
     } else {
@@ -68,8 +68,8 @@ void SizesAndStrides::resizeSlowPath(
         // Zero the end of the sizes portion.
         const auto elemsToZero = newSize - oldSize;
         for (size_t i = 0; i < elemsToZero; i++) {
-          outOfLineStorage_[oldSize + i] = 0;
-          outOfLineStorage_[newSize + oldSize + i] = 0;
+          outOfLineStorage_[oldSize + i].unsafeReset();
+          outOfLineStorage_[newSize + oldSize + i].unsafeReset();
         }
       }
     }

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1414,6 +1414,20 @@ TEST(TestSymInt, AddSymbolicInt) {
   ASSERT_TRUE((a + b).expect_int() == 8);
 }
 
+TEST(TestSymInt, TestIntrusive) {
+  auto a = c10::make_intrusive<c10::SymIntNodeImpl>();
+  auto b = c10::make_intrusive<c10::SymIntNodeImpl>();
+  ASSERT_EQ(a.use_count(), 1);
+  ASSERT_EQ(b.use_count(), 1);
+  auto as = a->toSymInt();
+  auto bs = b->toSymInt();
+  ASSERT_EQ(a.use_count(), 2);
+  ASSERT_EQ(b.use_count(), 2);
+  as = bs;
+  ASSERT_EQ(a.use_count(), 1);
+  ASSERT_EQ(b.use_count(), 3);
+}
+
 TEST(FallbackGraphsTest, Basic) {
   auto x = at::randn({1}, at::kCPU);
   auto y = at::randn({1}, at::kCPU);


### PR DESCRIPTION
release the current symintnode in the move c-tor

This should fix the following memory leak:
```
  auto a = c10::make_intrusive<c10::SymIntNodeImpl>();
  auto b = c10::make_intrusive<c10::SymIntNodeImpl>();
  std::cout << "ac = " << a.use_count() << " bc = " << b.use_count() << std::endl;
  auto as = a->toSymInt();
  auto bs = b->toSymInt();
  std::cout << "ac = " << a.use_count() << " bc = " << b.use_count() << std::endl;
  std::cout << "about to reassign SymInts\n";
  as = bs;
  std::cout << "after reassignment\n";
  std::cout << "ac = " << a.use_count() << " bc = " << b.use_count() << std::endl;
```


```
[ RUN      ] TestIntrusive.Basic
Creating SymIntNodeImpl 0x42ac330
Creating SymIntNodeImpl 0x428cd80
ac = 1 bc = 1
ac = 2 bc = 2
about to reassign SymInts
after reassignment
ac = 2 bc = 3
Destroying SymIntNodeImpl 0x428cd80
```


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel