### PR TITLE
Handle python frame is empty in GetPythonFrames

### DIFF
--- a/torch/csrc/lazy/python/python_util.cpp
+++ b/torch/csrc/lazy/python/python_util.cpp
@@ -33,7 +33,9 @@ std::vector<SourceLocation> GetPythonFrames() {
   if (Py_IsInitialized()) {
     pybind11::gil_scoped_acquire gil;
     PyFrameObject* frame = PyEval_GetFrame();
-    Py_INCREF(frame);
+    if (frame != nullptr) {
+      Py_INCREF(frame);
+    }
     while (frame != nullptr) {
       SourceLocation loc;
       auto code = THPCodeObjectPtr(PyFrame_GetCode(frame));


### PR DESCRIPTION
Fixes https://github.com/pytorch/xla/issues/3900 and https://github.com/pytorch/xla/issues/3795 for pytorch/xla when `XLA_IR_DEBUG=1`
