### PR TITLE
Address CR comments for "Delete ProxyTensor wrapper subclass"

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1237,6 +1237,9 @@ def cudnn_batch_norm_backward(
 def transpose_int(self: Tensor, dim0: int, dim1: int) -> Tensor:
     dim0, dim1 = utils.canonicalize_dims(self.dim(), (dim0, dim1))  # type: ignore[misc]
 
+    # NB: these no-op views force this operator to return a
+    # fresh TensorImpl, which is important for autograd to
+    # work correctly (assert will fail if you don't do it)
     if self.dim() <= 1:
         return self.view(self.shape)
 

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -15,6 +15,7 @@ from torch.fx.passes.shape_prop import _extract_tensor_metadata
 from contextlib import contextmanager, nullcontext
 import inspect
 from dataclasses import dataclass
+import weakref
 
 from torch.utils._python_dispatch import TorchDispatchMode, enable_torch_dispatch_mode
 from torch._subclasses import FakeTensor
@@ -44,10 +45,40 @@ def decompose(decomposition_table):
     finally:
         CURRENT_DECOMPOSITION_TABLE = old_decomposition_table
 
+# ensure we cannot collide with other properties
+proxy_slot = object()
+no_default = object()
+
+def set_proxy_slot(obj, tracer, proxy):
+    d = obj.__dict__.setdefault(proxy_slot, weakref.WeakKeyDictionary())
+    assert isinstance(d, weakref.WeakKeyDictionary)
+    d[tracer] = proxy
+
+def has_proxy_slot(obj, tracer):
+    return get_proxy_slot(obj, tracer, False, lambda _: True)
+
+# the default argument is what to return if the slot is not set.
+# the transform argument is handy if you need to extract a subfield from
+# the successfully looked up result (but NOT the default.)
+def get_proxy_slot(obj, tracer, default=no_default, transform=lambda x: x):
+    d = obj.__dict__.get(proxy_slot)
+    if not d:
+        if default is no_default:
+            raise KeyError(f"{obj} is not tracked with proxy for {tracer}")
+        return default
+    assert isinstance(d, weakref.WeakKeyDictionary)
+    if tracer not in d:
+        if default is no_default:
+            raise KeyError(f"{obj} is not tracked with proxy for {tracer}")
+        else:
+            return default
+    return transform(d[tracer])
+
+
 def track_tensor(tensor, proxy, *, constant, tracer):
     # The basic idea is that we need to associate each tensor/SymInt
     # with a Proxy.  How do we setup this association?  We just store
-    # the proxy on the __dict__ of the object, keyed on the tracer
+    # the proxy on the proxy slot of the object, keyed on the tracer
     # (so that if we have multiple tracers at the same time, they
     # don't clobber each other.)
     for i, s in enumerate(tensor.shape):
@@ -57,9 +88,9 @@ def track_tensor(tensor, proxy, *, constant, tracer):
             # TODO: improve naming
             # TODO: lazily insert this into the graph only on first
             # use?  Maybe complicated and DCE is a better idea
-            inner_s.__dict__[tracer] = proxy.size(i)
+            set_proxy_slot(inner_s, tracer, proxy.size(i))
         # TODO: also do stride/numel
-    tensor.__dict__[tracer] = _ProxyTensor(proxy, constant)
+    set_proxy_slot(tensor, tracer, _ProxyTensor(proxy, constant))
 
 def track_tensor_tree(inner_res, proxy_res, *, constant, tracer):
     def wrap_with_proxy(e, proxy, constant):
@@ -107,8 +138,13 @@ def fetch_symint_proxy(tracer):
         if n.constant is not None:
             return n.constant
         else:
-            return n.__dict__[tracer]
+            # NB: we REQUIRE all symints to be tracked
+            return get_proxy_slot(n, tracer)
     return inner
+
+
+def fetch_tensor_proxy(tracer):
+    return lambda t: get_proxy_slot(t, tracer, t)
 
 
 def proxy_call(proxy_mode, func_overload, args, kwargs=None):
@@ -131,13 +167,7 @@ def proxy_call(proxy_mode, func_overload, args, kwargs=None):
 
     tracer = proxy_mode.tracer
 
-    def fetch(t):
-        if isinstance(t, torch.Tensor) and tracer in t.__dict__:
-            return t.__dict__[tracer]
-        else:
-            return t
-
-    f_args, f_kwargs = pytree.tree_map(fetch, (args, kwargs))
+    f_args, f_kwargs = pytree.tree_map_only(torch.Tensor, fetch_tensor_proxy(tracer), (args, kwargs))
 
     # If there are SymInts, we also should not consider this constant.
     # However, fake tensor handling of SymInts is sufficiently broken that
@@ -271,7 +301,7 @@ def wrap_key(f, tensors, tracer):
         out = f(*tensors)
         return pytree.tree_map_only(
             torch.Tensor,
-            lambda t: t.__dict__[tracer].proxy if tracer in t.__dict__ else t,
+            lambda t: get_proxy_slot(t, tracer, t, lambda x: x.proxy),
             out
         )
 
@@ -311,9 +341,10 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
         if func in [prim.device]:
             return func_overload(*args, **kwargs)
 
-        if any(
-            isinstance(arg, torch.Tensor) and self.tracer in arg.__dict__
-            for arg in pytree.tree_flatten(args)[0]
+        if pytree.tree_any_only(
+            torch.Tensor,
+            lambda t: has_proxy_slot(t, self.tracer),
+            (args, kwargs)
         ):
             out = proxy_call(self, func_overload, args, kwargs)
         # When we trace through a torch.tensor invocation, you never actually
@@ -380,14 +411,13 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
             track_tensor_tree(out, proxy_out, constant=constant, tracer=self.tracer)
 
         def assert_proxy_tensor(e):
-            if isinstance(e, torch.Tensor):
-                assert self.tracer in e.__dict__, \
-                    f"Internal Error: make_fx is incorrectly baking a tensor constant into the graph: {str(e)}"
+            assert has_proxy_slot(e, self.tracer), \
+                f"Internal Error: make_fx is incorrectly baking a tensor constant into the graph: {str(e)}"
 
         # When we trace factory functions, we expect that tensor outputs are *always* tracked.
         # (Except for torch.tensor() constants handled through lift(), which is handled
         # specially further up).
-        pytree.tree_map(assert_proxy_tensor, out)
+        pytree.tree_map_only(torch.Tensor, assert_proxy_tensor, out)
         return out
 
 
@@ -417,7 +447,7 @@ class ProxySymDispatchMode(SymDispatchMode):
             return func(*args, **kwargs)
         p_args, p_kwargs = pytree.tree_map_only(
             PySymInt,
-            lambda s: s.__dict__[self.tracer] if s.constant is None else s.constant,
+            lambda s: get_proxy_slot(s, self.tracer) if s.constant is None else s.constant,
             (args, kwargs)
         )
         # func doesn't have a __torch_function__ that Proxy can interpose, so
@@ -427,7 +457,7 @@ class ProxySymDispatchMode(SymDispatchMode):
         p_out = fx.Proxy(n_out, self.tracer)
         out = func(*args, **kwargs)
         assert isinstance(out, PySymInt), f"{func}(*{args}, **{kwargs}) = {out}"
-        out.__dict__[self.tracer] = p_out
+        set_proxy_slot(out, self.tracer, p_out)
         return out
 
 
@@ -462,7 +492,7 @@ class DecompositionInterpreter(torch.fx.Interpreter):
         out = super().output(target, args, kwargs)
 
         def unwrap(e):
-            return e.__dict__[self.tracer].proxy.node if self.tracer in e.__dict__ else e
+            return get_proxy_slot(e, self.tracer, e, lambda x: x.proxy.node)
         self.new_graph.output(pytree.tree_map(unwrap, out))
         return out
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -24,6 +24,22 @@ SYM_FUNCTION_MODE = None
 # Didn't bother with ancestors for now, unlikely to have multiple modes for
 # symints right now
 
+
+# SymDispatchMode gets invoked whenever an operation is processed on
+# a PySymInt.  When this occurs, you get called at __sym_dispatch__
+# with the operation in question.  This is symmetric to TorchDispatchMode
+# but with some caveats:
+#
+#   - In TorchDispatchMode, you get the same arguments as what a user
+#     invoked your API with; e.g., if you call torch.ops.aten.foo(a, b),
+#     you get (a, b) as args to your call.  In SymDispatchMode, if
+#     you call a + b (where a and b are SymInts), you will get
+#     (a.get_pyobj(), b.get_pyobj()) as your args (these are PySymInts)
+#
+#   - SymInt/PySymInt don't have FX proxy support (unlike, e.g., Tensor).
+#     So you have to manually call Tracer/create_node to write into
+#     the graph.  See ProxySymDispatchMode for an example
+#
 class SymDispatchMode:
     def __sym_dispatch__(self, func, types, args, kwargs):
         raise NotImplementedError()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #83669
* #83668
* #83667
* #83650
* #83648
* __->__ #83646

CR is on https://github.com/pytorch/pytorch/pull/83330

- Factor proxy slot getters/setters into helper functions
- Use a weak map for storing proxies, so they go away when
  tracing is done
- More documentation on SymDispatchMode

Signed-off-by: Edward Z. Yang <ezyang@fb.com>