### PR TITLE
Be more conservative about propagating constants.

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -443,6 +443,17 @@ def forward(self, x_1):
         g = make_fx(f, tracing_mode=self.tracing_mode)()
         self.assertEqual(g(), f())
 
+    def test_constant_blowup(self):
+        def f():
+            val = torch.tensor([2])
+            blowup = val.repeat(1000)
+            return blowup.sum().item()
+
+        self.assertRaisesRegex(
+            RuntimeError, "data-dependent",
+            lambda: make_fx(f, tracing_mode=self.tracing_mode)()
+        )
+
     def test_decomposition_interpreter(self):
         def fn(x):
             return torch.nn.functional.silu(x)

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -29,6 +29,8 @@ prim = torch.ops.prim
 
 CURRENT_DECOMPOSITION_TABLE: Dict[torch._ops.OpOverload, Callable] = {}
 
+CONSTANT_NUMEL_LIMIT = 1
+
 
 def fake_signature(fn, nargs):
     """FX gets confused by varargs, de-confuse it"""
@@ -233,7 +235,11 @@ def proxy_call(proxy_mode, func_overload, args, kwargs=None):
 
     constant = None
     # NB: do NOT include factories as constants
-    if all_constant and any_constant:
+    if (
+        all_constant
+        and any_constant
+        and pytree.tree_all_only(torch.Tensor, lambda t: t.numel() <= CONSTANT_NUMEL_LIMIT, out)
+    ):
         with maybe_disable_fake_tensor_mode():
             const_args, const_kwargs = pytree.tree_map_only(
                 _ProxyTensor, lambda t: t.constant, (f_args, f_kwargs)
@@ -403,7 +409,7 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
             # constant, so we keep a copy of the original argument along so
             # we can query it if we're asked to item() it at some later point
             is_lift = func_overload is torch.ops.aten.lift_fresh_copy.default
-            if is_lift:
+            if is_lift and out.numel() <= CONSTANT_NUMEL_LIMIT:
                 with maybe_disable_fake_tensor_mode():
                     constant = args[0].clone()
             else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #83669
* #83668
* #83667
* #83650
* __->__ #83648
* #83646

If a constant would turn into something large, don't keep
it as a constant, just drop it.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>