### PR TITLE
WIP: [primtorch] Adding multigammaln ref

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -646,6 +646,14 @@ def logsumexp(
     return result
 
 
+@register_decomposition(torch.ops.aten.special_multigammaln)
+@out_wrapper()
+def multigammaln(a: TensorLikeType, dim: int) -> TensorLikeType:
+    c = 0.25 * dim * (dim - 1) * prims.log(torch.pi)
+    b = prims.arange(0, dim) / 2
+    return sum(prims.lgamma(a - b), -1) + c
+
+
 @register_decomposition(torch.ops.aten.nan_to_num)
 @out_wrapper()
 def nan_to_num(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16296,6 +16296,11 @@ op_db: List[OpInfo] = [
                    ),
                    # lgamma have multiple singularities at x <= 0
                    reference_numerics_filter=NumericsFilter(condition=lambda x: x < 0.1, safe_val=1)),
+    OpInfo('multigammaln',
+           dtypes=floating_and_complex_types(),
+           supports_out=False,
+           supports_forward_ad=True,
+           supports_fwgrad_bwgrad=True),
     OpInfo(
         'logdet',
         dtypes=floating_and_complex_types(),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18630,6 +18630,11 @@ python_ref_db = [
         "_refs.lgamma",
         torch_opinfo_name="lgamma",
     ),
+    PythonRefInfo(
+        "_refs.multigammaln",
+        torch_opinfo_name="multigammln",
+        supports_nvfuser=False,
+    ),
     ElementwiseUnaryPythonRefInfo(
         "_refs.log",
         torch_opinfo_name="log",


### PR DESCRIPTION
This adds the `multigammaln` op as a ref. This is congruence with what jax does.
