### PR TITLE
Add remaining device types in the pybinded DeviceType enum

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -196,12 +196,15 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .value("FPGA", c10::DeviceType::FPGA)
       .value("ORT", c10::DeviceType::ORT)
       .value("XLA", c10::DeviceType::XLA)
-      .value("Lazy", c10::DeviceType::Lazy)
-      .value("MPS", c10::DeviceType::MPS)
-      .value("HPU", c10::DeviceType::HPU)
-      .value("Meta", c10::DeviceType::Meta)
       .value("Vulkan", c10::DeviceType::Vulkan)
-      .value("Metal", c10::DeviceType::Metal);
+      .value("Metal", c10::DeviceType::Metal)
+      .value("XPU", c10::DeviceType::XPU)
+      .value("MPS", c10::DeviceType::MPS)
+      .value("Meta", c10::DeviceType::Meta)
+      .value("HPU", c10::DeviceType::HPU)
+      .value("VE", c10::DeviceType::VE)
+      .value("Lazy", c10::DeviceType::Lazy)
+      .value("IPU", c10::DeviceType::IPU);
 
   py::class_<KinetoEvent>(m, "_KinetoEvent")
       // name of the event


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#83676 Add remaining device types in the pybinded DeviceType enum**

Small change to update pybinded definition to match https://github.com/pytorch/pytorch/blob/master/c10/core/DeviceType.h#L32-L58