### PR TITLE
[Future] Introduce Future::wait_for variant of wait that takes timeout argument.

### DIFF
--- a/test/test_futures.py
+++ b/test/test_futures.py
@@ -103,6 +103,23 @@ class TestFuture(TestCase):
 
         self.assertEqual(f.wait(), torch.ones(2, 2))
 
+    def test_wait_for(self) -> None:
+        f = Future[torch.Tensor]()
+        self.assertEqual(f.wait_for(0), False)
+        self.assertEqual(f.wait_for(10), False)
+
+        f.set_result(torch.ones(2, 2))
+        self.assertEqual(f.wait_for(0), True)
+        self.assertEqual(f.wait_for(10), True)
+        self.assertEqual(f.wait_for(), True)
+
+        ferr = Future[ValueError]()
+        ferr.set_exception(ValueError("error"))
+        self.assertEqual(ferr.wait_for(0), True)
+        self.assertEqual(ferr.wait_for(10), True)
+        self.assertEqual(ferr.wait_for(), True)
+
+
     def test_wait_multi_thread(self) -> None:
 
         def slow_set_future(fut, value):

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1874,6 +1874,11 @@ void initJITBindings(PyObject* module) {
           &PythonFutureWrapper::wait,
           py::call_guard<py::gil_scoped_release>())
       .def(
+          "wait_for",
+          &PythonFutureWrapper::wait_for,
+          py::call_guard<py::gil_scoped_release>(),
+          py::arg("timeout") = int64_t(-1))
+      .def(
           "then",
           &PythonFutureWrapper::then,
           py::call_guard<py::gil_scoped_release>())
@@ -1993,9 +1998,20 @@ void initJITBindings(PyObject* module) {
     }
   });
 
-  m.def("wait", [](const std::shared_ptr<PythonFutureWrapper>& fut) {
-    return fut->wait();
-  });
+  m.def(
+      "wait",
+      [](const std::shared_ptr<PythonFutureWrapper>& fut) {
+        return fut->wait();
+      },
+      py::arg("future"));
+
+  m.def(
+      "wait_for",
+      [](const std::shared_ptr<PythonFutureWrapper>& fut, int64_t timeout) {
+        return fut->wait_for(timeout);
+      },
+      py::arg("future"),
+      py::arg("timeout") = int64_t(-1));
 
   m.def(
       "_collect_all",

--- a/torch/futures/__init__.py
+++ b/torch/futures/__init__.py
@@ -73,6 +73,22 @@ class Future(torch._C.Future, Generic[T], metaclass=_PyFutureMeta):
         """
         return super().wait()
 
+    def wait_for(self, timeout=-1) -> bool:
+        r"""
+        Block until this ``Future`` resolves or the timeout expires.
+
+        Args:
+            timeout (int): timeout of this operation in milliseconds. Default
+            value of -1, meaning wait undefinitely.
+
+        This methods performs the same synchronization as ``wait``in the case
+        of success.
+
+        Returns:
+            True if waited successfully, false otherwise.
+        """
+        return super().wait_for(timeout)
+
     def value(self) -> T:
         r"""
         Obtain the value of an already-completed future.


### PR DESCRIPTION
Future::wait doesn't support timeouts, which is a reliability problem when writing
robust distributed code.

This change introduce it on IValue::Future and expose it on the bindings as wait_for.

This is preferable to changing the semantics of wait by introducing an optional argument
as timeouts would be expressed as exceptions instead of the return value which has poor
usability given it's a common case that needs to be handled.

This is part of the work to improve Future enough such that it can replace ProcessGroup::Work.


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel