### PR TITLE
Avoid unnecessary copy of pointeeSet in MemoryDAG::setWildcards

### DIFF
--- a/torch/csrc/jit/passes/utils/memory_dag.cpp
+++ b/torch/csrc/jit/passes/utils/memory_dag.cpp
@@ -186,7 +186,7 @@ void MemoryDAG::setWildcards(
     auto wildcardElement = getWildcardElement(v);
     TORCH_INTERNAL_ASSERT(wildcardElement);
 
-    const MemoryLocations pointeeSet = getMemoryLocations(elementMap.at(v));
+    const MemoryLocations& pointeeSet = getMemoryLocations(elementMap.at(v));
     for (const auto& pointee : pointeeSet) {
       auto from = this->fromIndex(pointee);
       // avoid cycles where the wildcard points to itself


### PR DESCRIPTION
Test Plan:
CI

By making use of latest [copy constructor tags](https://fb.workplace.com/groups/638005567605797/permalink/731932211546465/), [this strobelight query](https://fburl.com/scuba/strobelight_services/5nizhawx) shows that this is used in several services such as `mast_hpc_job/customer_application` or `mui/mui_service_bi`

Differential Revision: D38830797

