### PR TITLE
Nvfuser python api patch take 2

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -195,13 +195,15 @@ class TestCommon(TestCase):
                         self.assertTrue(isinstance(b, FakeTensor))
                         prims.utils.compare_tensor_meta(a, b)
 
-    def _ref_test_helper(self, ctx, device, dtype, op, skip_zero_numel=False, skip_zero_dim=False):
+    def _ref_test_helper(self, ctx, device, dtype, op, skip_zero_numel=False, skip_zero_dim=False, skip_bfloat=False):
         # NOTE: this test works by comparing the reference
         ex = None
         for sample in op.reference_inputs(device, dtype, requires_grad=False):
             if isinstance(sample.input, torch.Tensor) and sample.input.numel() == 0 and skip_zero_numel:
                 continue
             if isinstance(sample.input, torch.Tensor) and sample.input.ndim == 0 and skip_zero_dim:
+                continue
+            if skip_bfloat and not torch.cuda.is_bf16_supported() and ((isinstance(sample.input, torch.Tensor) and sample.input.dtype == torch.bfloat16) or any(isinstance(arg, torch.Tensor) and arg.dtype==torch.bfloat16 for arg in sample.args)):
                 continue
             with ctx():
                 ref_result = op(sample.input, *sample.args, **sample.kwargs)
@@ -354,6 +356,7 @@ class TestCommon(TestCase):
             op,
             skip_zero_numel=("nvfuser" in executor),  # nvfuser doesn't support zero-sized tensors
             skip_zero_dim=skip_zero_dim,
+            skip_bfloat=("nvfuser" in executor),  # nvfuser doesn't support bfloat tensors for pre-11 cuda TK
         )
 
     @skipMeta

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -208,7 +208,7 @@ class TestCommon(TestCase):
                 (torch.version.cuda is not None)
                 and ([int(x) for x in torch.version.cuda.split(".")] < [11, 0]))
 
-            if skip_bfloat and is_lower_than_cuda11_0() and ((isinstance(sample.input, torch.Tensor) and sample.input.dtype == torch.bfloat16) or any(isinstance(arg, torch.Tensor) and arg.dtype==torch.bfloat16 for arg in sample.args)):
+            if skip_bfloat and is_lower_than_cuda11_0 and ((isinstance(sample.input, torch.Tensor) and sample.input.dtype == torch.bfloat16) or any(isinstance(arg, torch.Tensor) and arg.dtype==torch.bfloat16 for arg in sample.args)):
                 continue
             with ctx():
                 ref_result = op(sample.input, *sample.args, **sample.kwargs)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -203,7 +203,12 @@ class TestCommon(TestCase):
                 continue
             if isinstance(sample.input, torch.Tensor) and sample.input.ndim == 0 and skip_zero_dim:
                 continue
-            if skip_bfloat and not torch.cuda.is_bf16_supported() and ((isinstance(sample.input, torch.Tensor) and sample.input.dtype == torch.bfloat16) or any(isinstance(arg, torch.Tensor) and arg.dtype==torch.bfloat16 for arg in sample.args)):
+
+            is_lower_than_cuda11_0 = (
+                (torch.version.cuda is not None)
+                and ([int(x) for x in torch.version.cuda.split(".")] < [11, 0]))
+
+            if skip_bfloat and is_lower_than_cuda11_0() and ((isinstance(sample.input, torch.Tensor) and sample.input.dtype == torch.bfloat16) or any(isinstance(arg, torch.Tensor) and arg.dtype==torch.bfloat16 for arg in sample.args)):
                 continue
             with ctx():
                 ref_result = op(sample.input, *sample.args, **sample.kwargs)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -208,7 +208,20 @@ class TestCommon(TestCase):
                 (torch.version.cuda is not None)
                 and ([int(x) for x in torch.version.cuda.split(".")] < [11, 0]))
 
-            if skip_bfloat and is_lower_than_cuda11_0 and ((isinstance(sample.input, torch.Tensor) and sample.input.dtype == torch.bfloat16) or any(isinstance(arg, torch.Tensor) and arg.dtype==torch.bfloat16 for arg in sample.args)):
+            if (
+                skip_bfloat
+                and is_lower_than_cuda11_0
+                and (
+                    (
+                        isinstance(sample.input, torch.Tensor)
+                        and sample.input.dtype == torch.bfloat16
+                    )
+                    or any(
+                        isinstance(arg, torch.Tensor) and arg.dtype == torch.bfloat16
+                        for arg in sample.args
+                    )
+                )
+            ):
                 continue
             with ctx():
                 ref_result = op(sample.input, *sample.args, **sample.kwargs)

--- a/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
@@ -180,11 +180,12 @@ void initNvFuserPythonBindings(PyObject* module) {
       .def(
           "define_constant",
           [](nvfuser::FusionDefinition& self,
-             c10::complex<double> val) -> nvfuser::Scalar* {
+             std::complex<double> val) -> nvfuser::Scalar* {
             nvfuser::Scalar* out = self.defineScalar();
             self.defineRecord(new nvfuser::ConstantRecord<
                               torch::jit::fuser::cuda::ComplexDouble,
-                              c10::complex<double>>({out->index}, val));
+                              c10::complex<double>>(
+                {out->index}, static_cast<c10::complex<double>>(val)));
             return out;
           },
           py::return_value_policy::reference)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19270,7 +19270,6 @@ python_ref_db = [
     PythonRefInfo(
         "_refs.addcdiv",
         torch_opinfo_name="addcdiv",
-        supports_nvfuser=False,
     ),
     ElementwiseBinaryPythonRefInfo(
         "_refs.clamp_min",


### PR DESCRIPTION
landing #83645 again.

Previously we are breaking on codegen bf16 kernel for cuda TK 10.2. Added a short-cut to disable bf tests on pre cuda 11 build.