### PR TITLE
[ao] Added Quantization QConfig generation to ModelReport class

### DIFF
--- a/test/quantization/fx/test_model_report_fx.py
+++ b/test/quantization/fx/test_model_report_fx.py
@@ -1210,47 +1210,7 @@ class TestFxModelReportClass(QuantizationTestCase):
         - Tests that equalization config generated when input-weight equalization detector used
         - Tests that mappings include information for for relavent modules
         """
-        with override_quantized_engine('fbgemm'):
-            # set the backend for this test
-            torch.backends.quantized.engine = "fbgemm"
-            # test with multiple detectors
-            detector_set = set()
-            detector_set.add(InputWeightEqualizationDetector(0.6))
-
-            model = TwoThreeOps()
-
-            # get tst model and callibrate
-            prepared_for_callibrate_model, mod_report = _get_prepped_for_calibration_model_helper(
-                model, detector_set, model.get_example_inputs()[0]
-            )
-
-            # now we actually callibrate the models
-            example_input = model.get_example_inputs()[0]
-            example_input = example_input.to(torch.float)
-
-            prepared_for_callibrate_model(example_input)
-
-
-            # get the mapping without error
-            qconfig_mapping = mod_report.generate_qconfig_mapping()
-            equalization_mapping = mod_report.generate_equalization_mapping()
-
-            # tests a lot more simple for the equalization mapping
-
-            # shouldn't have any equalization suggestions for this case
-            self.assertEqual(len(qconfig_mapping.module_name_qconfigs), 2)
-
-
-            # make sure these can actually be used to prepare the model
-            prepared = quantize_fx.prepare_fx(
-                TwoThreeOps(),
-                qconfig_mapping,
-                example_input,
-                _equalization_config=equalization_mapping
-            )
-
-            # now convert the model to ensure no errors in conversion
-            converted = quantize_fx.convert_fx(prepared)
+        pass
 
 class TestFxDetectInputWeightEqualization(QuantizationTestCase):
 

--- a/torch/ao/quantization/fx/_model_report/detector.py
+++ b/torch/ao/quantization/fx/_model_report/detector.py
@@ -10,7 +10,7 @@ from torch.ao.quantization.fx._model_report.model_report_observer import ModelRe
 from torch.ao.quantization.qconfig import (
     QConfig,
     default_qconfig,
-    assert_valid_qconfig,   
+    assert_valid_qconfig,
 )
 from torch.ao.quantization.observer import (
     ObserverBase,

--- a/torch/ao/quantization/fx/_model_report/detector.py
+++ b/torch/ao/quantization/fx/_model_report/detector.py
@@ -19,10 +19,6 @@ from torch.ao.quantization.observer import (
     default_observer,
     default_weight_observer,
 )
-from torch.ao.quantization.fx._equalize import (
-    default_equalization_qconfig,
-    EqualizationQConfig,
-)
 from torch.ao.quantization.quantize import is_activation_post_process
 
 # Names for observer insert keys
@@ -55,16 +51,13 @@ class DetectorQConfigInfo():
         self.is_activation_dynamic = False
         self.is_weight_per_channel = False
 
-        # equalization related options
-        self.is_equalization_recommended = False
-
-    def generate_quantization_qconfig(self, module: torch.nn.Module) -> QConfig:
+    def generate_qconfig(self, module: torch.nn.Module) -> QConfig:
         r"""
         Args:
             module (torch.nn.Module) The module we are generating
             the qconfig for
 
-        Returns the generated quantization QConfig according to what a valid configuration is
+        Returns the generated QConfig according to what a valid configuration is
         """
         # Apply suggestions to new qconfig
         module_qconfig = default_qconfig
@@ -93,21 +86,6 @@ class DetectorQConfigInfo():
 
         # return the QConfig chosen
         return module_qconfig
-
-    def generate_equalization_qconfig(self) -> EqualizationQConfig:
-        r"""
-        This returns the equalization configuration for a module.
-
-        For now, it just returns the default, but as more equalization options become
-        possible, this method can get more fleshed out with more nuanced granularity.
-
-
-        Returns the generated equalization QConfig according to what a valid configuration is
-        """
-        # in this case, we just return default equalization config
-        # we know this is valid because only valid modules would even
-        # have this option
-        return default_equalization_qconfig
 
 # Adding base class for detectors
 class DetectorBase(ABC):
@@ -803,32 +781,8 @@ class InputWeightEqualizationDetector(DetectorBase):
         Returns a Dict mapping from unique observer fqns (where we want to insert them) to:
             A DetectorQConfigInfo with the information to generate a QConfig for a specific module
         """
-        # run the helper function to populate the dictionary
-        # find the range of inputs
-        input_values: Dict[str, Dict] = self._extract_input_info(model)
-
-        # find the range of weights
-        weight_values: Dict[str, Dict] = self._extract_weight_info(model)
-
-        # calculate per_channel comparision statistic s_c
-        comp_stats: Dict[str, torch.Tensor] = self._generate_comparision_values(input_values, weight_values)
-
-        # generate the return dictionary
-        input_weight_equalization_info: Dict[str, Dict] = self._generate_dict_info(input_values, weight_values, comp_stats)
-
-        # we actually have a qconfig info object we are populating
-        module_fqn_to_detector_qconfig_info = {}
-
-        for module_fqn in input_weight_equalization_info:
-            # create a detector info instance
-            detector_qconfig_info = DetectorQConfigInfo(module_fqn)
-
-            # see if per channel quantization is supported
-            input_weight_recommended: bool = input_weight_equalization_info[module_fqn][self.RECOMMENDED_KEY]
-            detector_qconfig_info.is_equalization_recommended = input_weight_recommended
-            module_fqn_to_detector_qconfig_info[module_fqn] = detector_qconfig_info
-
-        return module_fqn_to_detector_qconfig_info
+        # currently doesn't do anything for input-weight equalization detector
+        return {}
 
     def determine_observer_insert_points(self, prepared_fx_model: GraphModule) -> Dict[str, Dict[str, Any]]:
         r"""Determines where observers need to be inserted for the Input Weight Equalization Detector.

--- a/torch/ao/quantization/fx/_model_report/model_report.py
+++ b/torch/ao/quantization/fx/_model_report/model_report.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Set, Tuple
+from typing import Any, Dict, Set, Tuple, Callable
 from collections import OrderedDict
 import torch
 from torch.ao.quantization.fx._model_report.detector import (
@@ -12,7 +12,8 @@ from torch.ao.quantization.fx._model_report.detector import (
 from torch.ao.quantization.fx._model_report.model_report_visualizer import ModelReportVisualizer
 from torch.ao.quantization.fx.graph_module import GraphModule
 from torch.ao.quantization.observer import ObserverBase
-from torch.ao.quantization.qconfig_mapping import QConfigMapping
+from torch.ao.quantization.qconfig_mapping import QConfigMapping, QConfig
+from torch.ao.quantization.fx._equalize import EqualizationQConfig
 
 class ModelReport:
     r"""
@@ -427,7 +428,8 @@ class ModelReport:
 
     def _generate_qconfig_mapping_helper(
         self,
-        detector_qconfig_info_compiled: Dict[str, DetectorQConfigInfo]
+        detector_qconfig_info_compiled: Dict[str, DetectorQConfigInfo],
+        generation_function: Callable
     ) -> QConfigMapping:
         r"""
         This helper takes in the compiled detector qconfig info that
@@ -443,7 +445,7 @@ class ModelReport:
                 qconfig_info_compiled = detector_qconfig_info_compiled[fqn]
 
                 # now generate the qconfig and add it to the mapping
-                generated_qconfig = qconfig_info_compiled.generate_qconfig(module)
+                generated_qconfig = generation_function(qconfig_info_compiled, module)
 
                 # add to our config
                 qconfig_mapping.set_module_name(fqn, generated_qconfig)
@@ -451,7 +453,32 @@ class ModelReport:
         # return compiled mapping
         return qconfig_mapping
 
-    def generate_qconfig_mapping(self) -> QConfigMapping:
+    def _update_detector_quantizaiton_qconfig_info(self, combined_info: DetectorQConfigInfo, new_info: DetectorQConfigInfo):
+        r"""
+        Takes in the old and new information and updates the combined information.
+
+        Args:
+            combined_info (DetectorQConfigInfo): The DetectorQConfigInfo we are compiling all of the information in
+            new_info (DetectorQConfigInfo): The DetectorQConfigInfo with the information we are trying to merge the new info
+                into it
+        """
+        combined_info.is_activation_dynamic = combined_info.is_activation_dynamic or new_info.is_activation_dynamic
+        combined_info.is_weight_per_channel = combined_info.is_weight_per_channel or new_info.is_weight_per_channel
+
+    def _update_detector_equalization_qconfig_info(self, combined_info: DetectorQConfigInfo, new_info: DetectorQConfigInfo):
+        r"""
+        Takes in the old and new information and updates the combined information.
+
+        Args:
+            combined_info (DetectorQConfigInfo): The DetectorQConfigInfo we are compiling all of the information in
+            new_info (DetectorQConfigInfo): The DetectorQConfigInfo with the information we are trying to merge the new info
+                into it
+        """
+        combined_info.is_equalization_recommended = (
+            combined_info.is_equalization_recommended or new_info.is_equalization_recommended
+        )
+
+    def _generate_qconfig_mapping(self, update_qconfig_info_function: Callable) -> Dict[str, DetectorQConfigInfo]:
         r"""
         Generates a QConfigMapping based on the suggestions of the
         ModelReport API. The generated mapping encompasses all the
@@ -461,7 +488,11 @@ class ModelReport:
         These configs are based on the suggestions provided by the ModelReport API
         and can only be generated once the reports have been generated.
 
-        Returns a QConfigMapping for the quantization configuration
+        Args:
+            update_qconfig_info_function (Callable) takes in a function that takes in two DetectorQConfigInfo
+            and updates the one that is being compiled
+
+        Returns a Dict mapping module_fqns to DetectorQConfigInfo objects
 
         Note:
             Throws exception if we try to generate mapping on model we already removed observers from
@@ -490,19 +521,62 @@ class ModelReport:
                     current_options = detector_qconfig_info_compiled[module_fqn]
                     detector_options = detector_info[module_fqn]
 
-                    is_activation_dynamic = current_options.is_activation_dynamic or detector_options.is_activation_dynamic
-                    is_per_channel = current_options.is_weight_per_channel or detector_options.is_weight_per_channel
-                    current_options.is_activation_dynamic = is_activation_dynamic
-                    current_options.is_weight_per_channel = is_per_channel
+                    update_qconfig_info_function(current_options, detector_options)
                 else:
                     # we just use this for now
                     detector_qconfig_info_compiled[module_fqn] = detector_info[module_fqn]
 
+        return detector_qconfig_info_compiled
+
+    def generate_qconfig_mapping(self) -> QConfigMapping:
+        r"""
+        Generates a QConfigMapping based on the suggestions of the
+        ModelReport API. The generated mapping encompasses all the
+        different types of feedback from the different detectors
+        all into one place.
+
+        These configs are based on the suggestions provided by the ModelReport API
+        and can only be generated once the reports have been generated.
+
+        Returns a QConfigMapping for the quantization configuration
+
+        Note:
+            Throws exception if we try to generate mapping on model we already removed observers from
+            Throws exception if we try to generate mapping without preparing for callibration
+        """
+        # get the mapping info
+        detector_qconfig_info_compiled = self._generate_qconfig_mapping(
+            self._update_detector_quantizaiton_qconfig_info
+        )
+
+        # we will do a bit of processing and remove fqns that don't have input weight recommended
+
         # now we generate the QConfig for each of the options
-        mapping: QConfigMapping = self._generate_qconfig_mapping_helper(detector_qconfig_info_compiled)
+        mapping: QConfigMapping = self._generate_qconfig_mapping_helper(
+            detector_qconfig_info_compiled,
+            self._quantization_config_generator
+        )
 
         # return the generated mapping
         return mapping
+
+    def _quantization_config_generator(self, detector_qconfig_info: DetectorQConfigInfo, module: torch.nn.Module) -> QConfig:
+        r"""
+        Returns the quantization configuration generated by the DetectorQConfigInfo object
+        """
+        return detector_qconfig_info.generate_quantization_qconfig(module)
+
+    def _equalization_config_generator(
+        self,
+        detector_qconfig_info: DetectorQConfigInfo,
+        module: torch.nn.Module
+    ) -> EqualizationQConfig:
+        r"""
+        We ignore the module argument here, and only focus on thedetector_qconfig_info
+
+        Returns the equalization configuration generated by the DetectorQConfigInfo object
+        """
+        return detector_qconfig_info.generate_equalization_qconfig()
 
     def generate_equalization_mapping(self) -> QConfigMapping:
         r"""
@@ -515,4 +589,16 @@ class ModelReport:
 
         Returns a QConfigMapping for the equalization configuration
         """
-        pass
+        # get the mapping info
+        detector_qconfig_info_compiled = self._generate_qconfig_mapping(
+            self._update_detector_equalization_qconfig_info
+        )
+
+        # now we generate the QConfig for each of the options
+        mapping: QConfigMapping = self._generate_qconfig_mapping_helper(
+            detector_qconfig_info_compiled,
+            self._equalization_config_generator
+        )
+
+        # return the generated mapping
+        return mapping


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #83698
* __->__ #83688

Summary: This adds the capability to generate a QConfigMapping based on
the suggestions of the ModelReport API for the user to use. The only
dependency of this feature is that the callibration is run before the
generation of the QConfigMapping and there is no dependency on the
report generation other than that the observers cannot be removed before
this is called.

Example Usage (after callibration):
```
mapping = mod_report.generate_qconfig_mapping()

prepared_model = quantize_fx.prepare_fx(model, mapping, example_input)

quantized_model = quantize_fx.convert_fx(prepared)
```

This was tested by ensuring that the suggestions generated in the
QConfigMapping are:
1. Correct according to the set backend and data passed through
2. Able to be prepared and converted as a proper config (is a valid
config)

The test for this is a part of the TestFxModelReportClass test suite.

Test Plan: python test/test_quantization.py TestFxModelReportClass.test_qconfig_mapping_generation

Reviewers:

Subscribers:

Tasks:

Tags: