### PR TITLE
Revert "Manually shard slow-gradcheck CI job to prevent timeout #83354"

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -164,32 +164,7 @@ test_python_shard() {
     exit 1
   fi
 
-  if [[ "$BUILD_ENVIRONMENT" == *slow-gradcheck* ]]; then
-    # Manually shard to prevent slow-gradcheck CI from timing out
-    # See https://github.com/pytorch/pytorch/issues/83335#issuecomment-1213517290
-    if [[ "$NUM_TEST_SHARDS" != "2" ]]; then
-      echo "Expected NUM_TEST_SHARDS to equal 2 for slow-gradcheck"
-      exit 1
-    fi
-    if [[ "$1" == "1" ]]; then
-      SLOW_GRADCHECK_INC_EXC="--include test_ops_gradients"
-    else
-      SLOW_GRADCHECK_INC_EXC="--exclude test_ops_gradients"
-    fi
-    # shellcheck disable=SC2086
-    time python test/run_test.py \
-      --exclude-jit-executor \
-      --exclude-distributed-tests \
-      $SLOW_GRADCHECK_INC_EXC \
-      --verbose
-  else
-    time python test/run_test.py \
-      --exclude-jit-executor \
-      --exclude-distributed-tests \
-      --shard "$1" "$NUM_TEST_SHARDS" \
-      --verbose
-  fi
-
+  time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --shard "$1" "$NUM_TEST_SHARDS" --verbose
 
   assert_git_not_dirty
 }


### PR DESCRIPTION
Now that https://github.com/pytorch/test-infra/pull/529 exists, we can undo the custom sharding from #83354 for slow grad check

test plan: look at logs to see if it sharded + look at time to see that its evenly distributed