### PR TITLE
Remove assertEqualIgnoreTypes from test_unary_ufuncs

### DIFF
--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -704,9 +704,7 @@ class TestUnaryUfuncs(TestCase):
                 # Tests complex out (resized out)
                 complex_out = torch.empty(0, device=device, dtype=dtype)
                 torch_fn(t, out=complex_out)
-                self.assertEqual(
-                    torch.from_numpy(np_complex_out), complex_out.cpu()
-                )
+                self.assertEqual(torch.from_numpy(np_complex_out), complex_out.cpu())
 
                 # Tests long out behavior (expected failure)
                 long_out = torch.empty(0, device=device, dtype=torch.long)

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -686,12 +686,9 @@ class TestUnaryUfuncs(TestCase):
                     torch.float32 if dtype is torch.complex64 else torch.float64
                 )
                 np_float_out = np_fn(a).astype(torch_to_numpy_dtype_dict[float_dtype])
-                float_out = torch.empty_like(t).float()
+                float_out = torch.empty_like(t, dtype=float_dtype)
                 torch_fn(t, out=float_out)
-                # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
-                self.assertEqualIgnoreType(
-                    torch.from_numpy(np_float_out), float_out.cpu()
-                )
+                self.assertEqual(torch.from_numpy(np_float_out), float_out.cpu())
 
                 # Tests float out (resized out)
                 float_out = torch.empty(1, device=device, dtype=float_dtype)
@@ -699,19 +696,15 @@ class TestUnaryUfuncs(TestCase):
                 self.assertEqual(torch.from_numpy(np_float_out), float_out.cpu())
 
                 # Tests complex out
-                np_complex_out = np_fn(a)
+                np_complex_out = np_fn(a).astype(torch_to_numpy_dtype_dict[dtype])
                 complex_out = torch.empty_like(t)
                 torch_fn(t, out=complex_out)
-                # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
-                self.assertEqualIgnoreType(
-                    torch.from_numpy(np_complex_out), complex_out.cpu()
-                )
+                self.assertEqual(torch.from_numpy(np_complex_out), complex_out.cpu())
 
                 # Tests complex out (resized out)
                 complex_out = torch.empty(0, device=device, dtype=dtype)
                 torch_fn(t, out=complex_out)
-                # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
-                self.assertEqualIgnoreType(
+                self.assertEqual(
                     torch.from_numpy(np_complex_out), complex_out.cpu()
                 )
 


### PR DESCRIPTION
Fix TODOs related to #38095 in test_unary_ufuncs.py
