### PR TITLE
Prefer signal from land checks over PR signals

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -18,9 +18,12 @@ from trymerge import (find_matching_merge_rule,
                       gh_get_team_members,
                       read_merge_rules,
                       validate_revert,
+                      filter_pending_checks,
+                      filter_failed_checks,
                       GitHubPR,
                       MergeRule,
                       MandatoryChecksMissingError,
+                      WorkflowCheckState,
                       main as trymerge_main)
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from typing import Any, List, Optional
@@ -336,6 +339,37 @@ class TestGitHubPR(TestCase):
         pr = GitHubPR("pytorch", "pytorch", 79694)
         repo = DummyGitRepo()
         self.assertIsNotNone(validate_revert(repo, pr, comment_id=1189459845))
+
+    def test_checks_filter(self) -> None:
+        # setup checks
+        check1 = WorkflowCheckState(name="check1", status="SUCCESS", url="url1")
+        check2 = WorkflowCheckState(name="check2", status="FAILURE", url="url2")
+        check3 = WorkflowCheckState(name="check3", status="STARTUP_FAILURE", url="url3")
+        check4 = WorkflowCheckState(name="check4", status=None, url="url4")
+        check5 = WorkflowCheckState(name="check5", status="SUCCESS", url="url5")
+        check6 = WorkflowCheckState(name="check6", status="FAILURE", url="url6")
+        check7 = WorkflowCheckState(name="check7", status="STARTUP_FAILURE", url="url7")
+        check8 = WorkflowCheckState(name="check8", status=None, url="url8")
+
+        checks = {
+            "check1" : check1,
+            "check2" : check2,
+            "check3" : check3,
+            "check4" : check4,
+            "check5" : check5,
+            "check6" : check6,
+            "check7" : check7,
+            "check8" : check8,
+        }
+
+        # get pending
+        pending_checks = filter_pending_checks(checks)
+
+        # get failing
+        failing_checks = filter_failed_checks(checks)
+
+        self.assertListEqual(failing_checks, [check2, check3, check6, check7])
+        self.assertListEqual(pending_checks, [check4, check8])
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -348,7 +348,7 @@ class TestGitHubPR(TestCase):
             WorkflowCheckState(name="check3", status=None, url="url3"),
         ]
 
-        checks_dict = { check.name : check for check in checks }
+        checks_dict = {check.name : check for check in checks}
 
         pending_checks = filter_pending_checks(checks_dict)
         failing_checks = filter_failed_checks(checks_dict)

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -341,35 +341,20 @@ class TestGitHubPR(TestCase):
         self.assertIsNotNone(validate_revert(repo, pr, comment_id=1189459845))
 
     def test_checks_filter(self) -> None:
-        # setup checks
-        check1 = WorkflowCheckState(name="check1", status="SUCCESS", url="url1")
-        check2 = WorkflowCheckState(name="check2", status="FAILURE", url="url2")
-        check3 = WorkflowCheckState(name="check3", status="STARTUP_FAILURE", url="url3")
-        check4 = WorkflowCheckState(name="check4", status=None, url="url4")
-        check5 = WorkflowCheckState(name="check5", status="SUCCESS", url="url5")
-        check6 = WorkflowCheckState(name="check6", status="FAILURE", url="url6")
-        check7 = WorkflowCheckState(name="check7", status="STARTUP_FAILURE", url="url7")
-        check8 = WorkflowCheckState(name="check8", status=None, url="url8")
+        checks = [
+            WorkflowCheckState(name="check0", status="SUCCESS", url="url0"),
+            WorkflowCheckState(name="check1", status="FAILURE", url="url1"),
+            WorkflowCheckState(name="check2", status="STARTUP_FAILURE", url="url2"),
+            WorkflowCheckState(name="check3", status=None, url="url3"),
+        ]
 
-        checks = {
-            "check1" : check1,
-            "check2" : check2,
-            "check3" : check3,
-            "check4" : check4,
-            "check5" : check5,
-            "check6" : check6,
-            "check7" : check7,
-            "check8" : check8,
-        }
+        checks_dict = { check.name : check for check in checks }
 
-        # get pending
-        pending_checks = filter_pending_checks(checks)
+        pending_checks = filter_pending_checks(checks_dict)
+        failing_checks = filter_failed_checks(checks_dict)
 
-        # get failing
-        failing_checks = filter_failed_checks(checks)
-
-        self.assertListEqual(failing_checks, [check2, check3, check6, check7])
-        self.assertListEqual(pending_checks, [check4, check8])
+        self.assertListEqual(failing_checks, [checks[1], checks[2]])
+        self.assertListEqual(pending_checks, [checks[3]])
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1113,7 +1113,7 @@ def get_combined_checks_from_pr_and_land_validation(
     land_validation_checks = get_land_checkrun_conclusions(pr.org, pr.project, land_check_commit) if land_check_commit else {}
 
     # Merge the two checks together. Land validation check results (if any) overwrite pr check results
-    merged_checks = dict(pr_checks, **land_validation_checks)  # explanation: https://stackoverflow.com/a/9819617
+    merged_checks = {**pr_checks, **land_validation_checks}  # explanation: https://stackoverflow.com/a/26853961/21539
     return merged_checks
 
 def filter_checks_with_lambda(

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1059,15 +1059,15 @@ def checks_to_str(checks: List[Tuple[str, Optional[str]]]) -> str:
     return ", ".join(f"[{c[0]}]({c[1]})" if c[1] is not None else c[0] for c in checks)
 
 # Combine checks from both the PR and land validation to get a holistic view of all checks. This helps us cover the corner case where
-# certain workflows may have been requested on the PR but are not part of land validation (e.g. nightly builds) or are implicitly run on PRs 
-# but not on land validation branches (like CLA Checks).  
+# certain workflows may have been requested on the PR but are not part of land validation (e.g. nightly builds) or are implicitly run on PRs
+# but not on land validation branches (like CLA Checks).
 # At the same time, we prioritize the signal workflows which do run on land validation. E.g. if a workflow fails on the PR but passes on land validation
 # then we'd use the successful result from the land validation.
 def get_combined_checks_from_pr_and_land_validation(pr: GitHubPR, land_check_commit: str) -> Dict[str, Tuple[str, str]]:
   pr_checks = pr.get_checkrun_conclusions()
   land_validation_checks = get_land_checkrun_conclusions(pr.org, pr.project, land_check_commit) if land_check_commit else {}
 
-  # Merge the two checks together. Land validation check results (if any) overwrite pr check results 
+  # Merge the two checks together. Land validation check results (if any) overwrite pr check results
   merged_checks = dict(pr_checks, **land_validation_checks) # explanation: https://stackoverflow.com/a/9819617
 
   return merged_checks

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -521,9 +521,9 @@ def add_workflow_conclusions(
                         continue
                     if checkrun_node["conclusion"] == 'FAILURE':
                         has_failing_check = True
-                    workflow_name = f'{get_check_run_name_prefix(workflow_run)}{checkrun_node["name"]}'
-                    conclusions[workflow_name] = WorkflowCheckState(
-                        name=workflow_name,
+                    checkrun_name = f'{get_check_run_name_prefix(workflow_run)}{checkrun_node["name"]}'
+                    conclusions[checkrun_name] = WorkflowCheckState(
+                        name=checkrun_name,
                         status=checkrun_node["conclusion"],
                         url=checkrun_node["detailsUrl"]
                     )

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1096,15 +1096,15 @@ def get_combined_checks_from_pr_and_land_validation(
     """
     Combines checks from both the PR and land validation to get a holistic view
     of all checks.
-    
-    This helps us cover the corner case where certain workflows may have been 
+
+    This helps us cover the corner case where certain workflows may have been
     requested on the PR but are not part of land validation (e.g. nightly
-    builds) or are implicitly run on PRs but not on land validation branches 
+    builds) or are implicitly run on PRs but not on land validation branches
     (like CLA Checks).
-    
-    At the same time, we prioritize the signal workflows which do run on land 
+
+    At the same time, we prioritize the signal workflows which do run on land
     validation. 
-    
+
     E.g. if a workflow fails on the PR but passes on land validation then we'd
     use the successful result from the land validation.
     """

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1114,7 +1114,6 @@ def get_combined_checks_from_pr_and_land_validation(
 
     # Merge the two checks together. Land validation check results (if any) overwrite pr check results
     merged_checks = dict(pr_checks, **land_validation_checks)  # explanation: https://stackoverflow.com/a/9819617
-
     return merged_checks
 
 def filter_checks_with_lambda(
@@ -1123,14 +1122,10 @@ def filter_checks_with_lambda(
 ) -> List[WorkflowCheckState]:
     return [check for check in checks.values() if status_filter(check.status)]
 
-def filter_pending_checks(
-    checks: Dict[str, WorkflowCheckState]
-) -> List[WorkflowCheckState]:
+def filter_pending_checks(checks: Dict[str, WorkflowCheckState]) -> List[WorkflowCheckState]:
     return filter_checks_with_lambda(checks, lambda x: x is None)
 
-def filter_failed_checks(
-    checks: Dict[str, WorkflowCheckState]
-) -> List[WorkflowCheckState]:
+def filter_failed_checks(checks: Dict[str, WorkflowCheckState]) -> List[WorkflowCheckState]:
     return filter_checks_with_lambda(checks, lambda x: x in ["FAILURE", "STARTUP_FAILURE"])
 
 def validate_revert(repo: GitRepo, pr: GitHubPR, *,
@@ -1285,8 +1280,8 @@ def merge(pr_num: int, repo: GitRepo,
         if initial_commit_sha != pr.last_commit()['oid']:
             raise RuntimeError("New commits were pushed while merging. Please rerun the merge command.")
         try:
+            find_matching_merge_rule(pr, repo)
             checks = get_combined_checks_from_pr_and_land_validation(pr, land_check_commit)
-
             pending = filter_pending_checks(checks)
             failing = filter_failed_checks(checks)
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1103,7 +1103,7 @@ def get_combined_checks_from_pr_and_land_validation(
     (like CLA Checks).
 
     At the same time, we prioritize the signal workflows which do run on land
-    validation. 
+    validation.
 
     E.g. if a workflow fails on the PR but passes on land validation then we'd
     use the successful result from the land validation.
@@ -1285,8 +1285,6 @@ def merge(pr_num: int, repo: GitRepo,
         if initial_commit_sha != pr.last_commit()['oid']:
             raise RuntimeError("New commits were pushed while merging. Please rerun the merge command.")
         try:
-            find_matching_merge_rule(pr, repo, land_check_commit=land_check_commit)
-
             checks = get_combined_checks_from_pr_and_land_validation(pr, land_check_commit)
 
             pending = filter_pending_checks(checks)


### PR DESCRIPTION
# The problem

When a dev forks their branch from a red master build, their branch can fail CI checks for reasons unrelated to their changes, but the same checks would however pass in the land validation commit (which is rebased off of viable/strict)

Today, in the above scenario the `merge -l` command fails because mergebot sees the failing checks in the PR, which is not helpful when that same check passes in land validation.

# The solution
This PR changes the behavior so that:
1. If both the PR and land validation ran a workflow, only look at the results from land validation
2. If only the PR ran a specific workflow (e.g. for CLA Check or a nightly run) then continue to look the result from the PR (which matches existing behavior)

### Bonus fixes
It also includes a few extra BE fixes:
- Replaces the tuple we used to pass workflow check results around with a named tuple so that it's easier to tell what data is being used
- Reduces the number of API calls to github by ~50% during merges.  Before, we were pulling results from github every time and then filtering it down to the relevant category of checks (e.g. failed/pending/startup_failed). Now, our filters share the check results