### PR TITLE
Fix use-dict-literal lint

### DIFF
--- a/benchmarks/distributed/ddp/benchmark.py
+++ b/benchmarks/distributed/ddp/benchmark.py
@@ -87,7 +87,7 @@ def run_benchmark(benchmark, ranks, opts):
     measurements = []
     if dist.get_rank() in set(ranks):
         if not opts:
-            opts = dict()
+            opts = {}
         measurements = benchmark_process_group(group, benchmark, **opts)
     dist.destroy_process_group(group)
     dist.barrier()

--- a/functorch/examples/maml_omniglot/support/omniglot_loaders.py
+++ b/functorch/examples/maml_omniglot/support/omniglot_loaders.py
@@ -161,7 +161,7 @@ class OmniglotNShot:
                      lambda x: x / 255.]),
             )
 
-            temp = dict()  # {label:img1, img2..., 20 imgs, label2: img1, img2,... in total, 1623 label}
+            temp = {}  # {label:img1, img2..., 20 imgs, label2: img1, img2,... in total, 1623 label}
             for (img, label) in self.x:
                 if label in temp.keys():
                     temp[label].append(img)

--- a/test/distributed/_shard/checkpoint/test_checkpoint.py
+++ b/test/distributed/_shard/checkpoint/test_checkpoint.py
@@ -112,7 +112,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
         )
 
         st = sharded_tensor.zeros(spec, 4, 4, dtype=torch.float64)
-        mapping = dict()
+        mapping = {}
 
         (_, md, storage_md) = _prepare_sharded_tensor_write("fqn", st, "tensor", mapping)
 
@@ -173,7 +173,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
 
 class TestStorageKeys(TestCase):
     def test_create_key_handles_collision(self):
-        keys = dict()
+        keys = {}
         key0 = _create_storage_key(keys, "foo")
         key1 = _create_storage_key(keys, "foo")
         self.assertNotEqual(key0, key1)

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -290,7 +290,7 @@ class PrefixTCPStoreTest(TestCase, StoreTestBase):
 class MyPythonStore(dist.Store):
     def __init__(self):
         super(MyPythonStore, self).__init__()
-        self.store = dict()
+        self.store = {}
 
     def set(self, key, value):
         if not isinstance(key, string_classes):

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -322,7 +322,7 @@ if __name__ == "__main__":
         default="schemas.txt",
     )
     args = parser.parse_args()
-    existing_schema_dict = dict()
+    existing_schema_dict = {}
     slist = []
     with open(args.existing_schemas, "r") as f:
         while True:

--- a/test/mobile/test_lite_script_type.py
+++ b/test/mobile/test_lite_script_type.py
@@ -45,7 +45,7 @@ class TestLiteScriptModule(TestCase):
 
             def forward(self, a: torch.Tensor):
                 self.foo = Foo(a)
-                re: Dict[str, Foo] = dict()
+                re: Dict[str, Foo] = {}
                 re["test"] = Foo(a)
                 return self.foo, re["test"]
 

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -185,7 +185,7 @@ class TestQuantizedOps(TestCase):
                     # some functions require inplace=True to test in-place.
                     # copy.copy is needed because these are modified in place
                     extra_kwargs = \
-                        copy.copy(op_group.get('extra_kwargs', dict()))
+                        copy.copy(op_group.get('extra_kwargs', {}))
                     output_is_observed = \
                         copy.copy(op_group.get('output_is_observed', False))
 

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -945,7 +945,7 @@ class TestQuantizeFx(QuantizationTestCase):
         for (is_dynamic, ModuleClass, module_constructor_inputs,
              inputs, quantized_node, weight_prepack_node) in tests:
             quant_type = QuantType.DYNAMIC if is_dynamic else QuantType.STATIC
-            node_occurrence = dict()
+            node_occurrence = {}
             if weight_prepack_node:
                 node_occurrence[weight_prepack_node] = 0
             self.checkGraphModeFxOp(
@@ -970,7 +970,7 @@ class TestQuantizeFx(QuantizationTestCase):
         for (is_dynamic, ModuleClass, module_constructor_inputs,
              inputs, quantized_node, weight_prepack_node) in tests:
             quant_type = QuantType.DYNAMIC if is_dynamic else QuantType.STATIC
-            node_occurrence = dict()
+            node_occurrence = {}
             if weight_prepack_node:
                 node_occurrence[weight_prepack_node] = 0
             result_dict = self.checkGraphModeFxOp(
@@ -1205,7 +1205,7 @@ class TestQuantizeFx(QuantizationTestCase):
             for (ModuleClass, module_constructor_inputs,
                  inputs, quantized_node, weight_prepack_node) in tests:
                 for is_reference in [True, False]:
-                    node_occurrence = dict()
+                    node_occurrence = {}
                     if weight_prepack_node:
                         node_occurrence[weight_prepack_node] = 0
                     m = ModuleClass(*module_constructor_inputs).eval()

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2336,7 +2336,7 @@ class TestAutograd(TestCase):
         # which means that a lot of accessors on them may segfault. Test that we
         # properly error in this case.
         t = torch.ones(1, requires_grad=True)
-        t._backward_hooks = dict()
+        t._backward_hooks = {}
         with self.assertRaisesRegex(RuntimeError, "Attribute '_register_hook_dict' is invalid"):
             f._register_hook_dict(t)
         with self.assertRaisesRegex(RuntimeError, "Attribute 'register_hook' is invalid"):

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1539,7 +1539,7 @@ class FFTDocTestFinder:
         doctests = []
 
         modname = name if name is not None else obj.__name__
-        globs = dict() if globs is None else globs
+        globs = {} if globs is None else globs
 
         for fname in obj.__all__:
             func = getattr(obj, fname)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -809,7 +809,7 @@ def gen_variable_type_func(
     fn: NativeFunctionWithDifferentiabilityInfo,
 ) -> Dict[str, List[str]]:
     f = fn.func
-    result = dict()
+    result = {}
     with native_function_manager(f):
         name = cpp.name(f.func)
         formals = gen_formals(f)

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -64,12 +64,12 @@ def add_view_copy_derivatives(
         g.view.func.name: g for g in view_groups
     }
 
-    view_infos = dict()
+    view_infos = {}
 
     for _, info_dispatch_dict in infos.items():
         # maybe_view_group only needs to be calculated once per info_dispatch_dict
         maybe_view_group = None
-        view_copy_differentiability_infos = dict()
+        view_copy_differentiability_infos = {}
         for dispatch_key, info in info_dispatch_dict.items():
             maybe_view_group = view_name_to_group.get(info.func.func.name, None)
             if maybe_view_group is not None and maybe_view_group.view_copy is not None:
@@ -123,7 +123,7 @@ def load_derivatives(
         functions_by_signature: Dict[
             FunctionSchema, List[NativeFunction]
         ] = defaultdict(list)
-        functions_by_schema: Dict[str, NativeFunction] = dict()
+        functions_by_schema: Dict[str, NativeFunction] = {}
         for function in native_functions_without_view_copies:
             functions_by_signature[function.func.signature()].append(function)
             assert str(function.func) not in functions_by_schema
@@ -136,7 +136,7 @@ def load_derivatives(
         # infos is a dict that maps FunctionSchema -> a dict of per dispatch key DifferentiabilityInfos
         # this is useful because in tools/autograd/gen_autograd.py:match_differentiability_info
         # we ultimately need to categorize the DifferentiabilityInfos by FunctionSchema
-        infos: Dict[FunctionSchema, Dict[str, DifferentiabilityInfo]] = dict()
+        infos: Dict[FunctionSchema, Dict[str, DifferentiabilityInfo]] = {}
         used_dispatch_keys: Set[str] = set()
         for defn_dict in definitions:
             # Ensure that the old derivatives.yaml schema with no dispatch key can be loaded.
@@ -666,7 +666,7 @@ def create_differentiability_info(
             "Please use a different name in native_functions.yaml."
         )
 
-    diffinfo_dict = dict()
+    diffinfo_dict = {}
     for key, defn in defn_dict["dispatch"].items():
         if key != "Default" and key not in _VALID_AUTOGRAD_KEYS:
             raise RuntimeError(

--- a/tools/code_coverage/package/tool/summarize_jsons.py
+++ b/tools/code_coverage/package/tool/summarize_jsons.py
@@ -26,7 +26,7 @@ from .print_report import (
 )
 
 
-# coverage_records: Dict[str, LineInfo] = dict()
+# coverage_records: Dict[str, LineInfo] = {}
 covered_lines: Dict[str, Set[int]] = {}
 uncovered_lines: Dict[str, Set[int]] = {}
 tests_type: TestStatusType = {"success": set(), "partial": set(), "fail": set()}

--- a/tools/setup_helpers/cmake_utils.py
+++ b/tools/setup_helpers/cmake_utils.py
@@ -51,7 +51,7 @@ def get_cmake_cache_variables_from_file(
       dict: A ``dict`` containing the value of cached CMake variables.
     """
 
-    results = dict()
+    results = {}
     for i, line in enumerate(cmake_cache_file, 1):
         line = line.strip()
         if not line or line.startswith(("#", "//")):

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -108,7 +108,7 @@ def get_disabled_tests(
     dirpath: str, filename: str = DISABLED_TESTS_FILE
 ) -> Optional[Dict[str, Any]]:
     def process_disabled_test(the_response: Dict[str, Any]) -> Dict[str, Any]:
-        disabled_test_from_issues = dict()
+        disabled_test_from_issues = {}
         for item in the_response["items"]:
             title = item["title"]
             key = "DISABLED "

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -670,7 +670,7 @@ class TestCase:
 class TestSuite:
     def __init__(self, name: str) -> None:
         self.name = name
-        self.test_cases: Dict[str, TestCase] = dict()
+        self.test_cases: Dict[str, TestCase] = {}
         self.failed_count = 0
         self.skipped_count = 0
         self.errored_count = 0
@@ -725,7 +725,7 @@ class TestFile:
     def __init__(self, name: str) -> None:
         self.name = name
         self.total_time = 0.0
-        self.test_suites: Dict[str, TestSuite] = dict()
+        self.test_suites: Dict[str, TestSuite] = {}
 
     def append(self, test_case: TestCase) -> None:
         suite_name = test_case.class_name
@@ -765,7 +765,7 @@ def get_recursive_files(folder: str, extension: str) -> Iterable[str]:
 
 
 def parse_reports(folder: str) -> Dict[str, TestFile]:
-    tests_by_file = dict()
+    tests_by_file = {}
     for report in get_recursive_files(folder, ".xml"):
         report_path = Path(report)
         # basename of the directory of test-report is the test filename

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -9,7 +9,7 @@ from tools.stats.import_test_stats import get_disabled_tests, get_slow_tests
 def calculate_shards(
     num_shards: int, tests: List[str], job_times: Dict[str, float]
 ) -> List[Tuple[float, List[str]]]:
-    filtered_job_times: Dict[str, float] = dict()
+    filtered_job_times: Dict[str, float] = {}
     unknown_jobs: List[str] = []
     for test in tests:
         if test in job_times:

--- a/torch/_C/_distributed_rpc.pyi
+++ b/torch/_C/_distributed_rpc.pyi
@@ -78,7 +78,7 @@ class _TensorPipeRpcBackendOptionsBase(RpcBackendOptions):
         _channels: Optional[List],
         rpc_timeout: float = _DEFAULT_RPC_TIMEOUT_SEC,
         init_method: str = _DEFAULT_INIT_METHOD,
-        device_maps: Dict[str, Dict[torch.device, torch.device]] = dict(),
+        device_maps: Dict[str, Dict[torch.device, torch.device]] = {},
         devices: List[torch.device] = list()): ...
     def _set_device_map(self, to: str, device_map: Dict[torch.device, torch.device]): ...
 

--- a/torch/_lazy/extract_compiled_graph.py
+++ b/torch/_lazy/extract_compiled_graph.py
@@ -72,7 +72,7 @@ class ReturnValueHandler:
         self.index: List[List[int]] = []
         self.total_count = len(lazy_out_list)
 
-        tensor_id_to_idx: Dict[int, int] = dict()
+        tensor_id_to_idx: Dict[int, int] = {}
         for dup_idx, lazy_tensor in enumerate(lazy_out_list):
             uniq_idx = tensor_id_to_idx.get(id(lazy_tensor), None)
             if uniq_idx is not None:

--- a/torch/_masked/__init__.py
+++ b/torch/_masked/__init__.py
@@ -278,7 +278,7 @@ defined as ``prod(x[:i])``.""",
         cumprod="cumulative_prod",
     )
 
-    operation_names = dict()
+    operation_names = {}
     operation_names.update(reduction_names)
     operation_names.update(normalization_names)
 

--- a/torch/ao/quantization/backend_config/utils.py
+++ b/torch/ao/quantization/backend_config/utils.py
@@ -7,7 +7,7 @@ from .backend_config import BackendConfig, DTypeConfig
 from ..quantization_types import Pattern
 
 def get_pattern_to_dtype_configs(backend_config: BackendConfig) -> Dict[Pattern, List[DTypeConfig]]:
-    pattern_to_dtype_configs: Dict[Pattern, List[DTypeConfig]] = dict()
+    pattern_to_dtype_configs: Dict[Pattern, List[DTypeConfig]] = {}
     for pattern, config in backend_config.configs.items():
         pattern_to_dtype_configs[pattern] = config.dtype_configs
     return pattern_to_dtype_configs
@@ -27,28 +27,28 @@ def get_fused_module_classes(backend_config: BackendConfig) -> Tuple[type, ...]:
     return tuple(set(fused_module_classes))
 
 def get_pattern_to_input_type_to_index(backend_config: BackendConfig) -> Dict[Pattern, Dict[str, int]]:
-    pattern_to_input_type_to_index: Dict[Pattern, Dict[str, int]] = dict()
+    pattern_to_input_type_to_index: Dict[Pattern, Dict[str, int]] = {}
     for pattern, config in backend_config.configs.items():
         pattern_to_input_type_to_index[pattern] = config._input_type_to_index
     return pattern_to_input_type_to_index
 
 def get_root_module_to_quantized_reference_module(
         backend_config: BackendConfig) -> Dict[Type[torch.nn.Module], Type[torch.nn.Module]]:
-    mapping: Dict[Type[torch.nn.Module], Type[torch.nn.Module]] = dict()
+    mapping: Dict[Type[torch.nn.Module], Type[torch.nn.Module]] = {}
     for config in backend_config.configs.values():
         if config.root_module is not None and config.reference_quantized_module is not None:
             mapping[config.root_module] = config.reference_quantized_module
     return mapping
 
 def get_fuser_method_mapping(backend_config: BackendConfig) -> Dict[Pattern, Union[nn.Sequential, Callable]]:
-    fuser_method_mapping : Dict[Pattern, Union[nn.Sequential, Callable]] = dict()
+    fuser_method_mapping : Dict[Pattern, Union[nn.Sequential, Callable]] = {}
     for pattern, config in backend_config.configs.items():
         if config.fuser_method is not None:
             fuser_method_mapping[pattern] = config.fuser_method
     return fuser_method_mapping
 
 def get_module_to_qat_module(backend_config: BackendConfig) -> Dict[Pattern, Type[torch.nn.Module]]:
-    module_to_qat_module: Dict[Pattern, Type[torch.nn.Module]] = dict()
+    module_to_qat_module: Dict[Pattern, Type[torch.nn.Module]] = {}
     for pattern, config in backend_config.configs.items():
         if config.qat_module is not None:
             module_to_qat_module[pattern] = config.qat_module
@@ -64,7 +64,7 @@ def get_fusion_pattern_to_root_node_getter(backend_config: BackendConfig) -> Dic
     This can work for all patterns whose root node is the "last node" in the pattern,
     e.g. (torch.add, MatchAllNode, (torch.ReLU, torch.Conv2d))
     """
-    root_node_getter_mapping: Dict[Pattern, Callable] = dict()
+    root_node_getter_mapping: Dict[Pattern, Callable] = {}
     for pattern, config in backend_config.configs.items():
         if config._root_node_getter is not None:
             root_node_getter_mapping[pattern] = config._root_node_getter
@@ -84,7 +84,7 @@ def get_fusion_pattern_to_extra_inputs_getter(backend_config: BackendConfig) -> 
         add, extra_input, conv_pattern = pattern
         return [extra_input]
     """
-    extra_inputs_getter_mapping: Dict[Pattern, Callable] = dict()
+    extra_inputs_getter_mapping: Dict[Pattern, Callable] = {}
     for pattern, config in backend_config.configs.items():
         if config._extra_inputs_getter is not None:
             extra_inputs_getter_mapping[pattern] = config._extra_inputs_getter

--- a/torch/ao/quantization/fuser_method_mappings.py
+++ b/torch/ao/quantization/fuser_method_mappings.py
@@ -177,7 +177,7 @@ def get_fuser_method(op_list, additional_fuser_method_mapping=None):
     return None if fuser method does not exist
     '''
     if additional_fuser_method_mapping is None:
-        additional_fuser_method_mapping = dict()
+        additional_fuser_method_mapping = {}
     all_mappings = get_combined_dict(DEFAULT_OP_LIST_TO_FUSER_METHOD,
                                      additional_fuser_method_mapping)
     fuser_method = all_mappings.get(op_list, None)

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -331,9 +331,9 @@ def fold_weight(
     graph module with the traced nodes and run the graph module to pack the
     weight. then replace the original chain of ops with the packed weight.
     """
-    packed_weights = dict()
+    packed_weights = {}
     # map from folded node name to the prepacked weight name
-    folded_nodes = dict()
+    folded_nodes = {}
     # get packed weights
     for node in quantized.graph.nodes:
         if node.op == 'call_function' and node.target in WEIGHT_PREPACK_OPS:

--- a/torch/ao/quantization/fx/backend_config_utils.py
+++ b/torch/ao/quantization/fx/backend_config_utils.py
@@ -86,7 +86,7 @@ def get_pattern_to_quantize_handlers(backend_config: BackendConfig) -> Dict[Patt
     we can refactor this after we convert the path for fbgemm/qnnpack fully to the
     new path, this is not exposed to backend developers
     """
-    pattern_to_quantize_handlers = dict()
+    pattern_to_quantize_handlers = {}
     for pattern, config in backend_config.configs.items():
         observation_type = config.observation_type
         dtype_configs = config.dtype_configs
@@ -110,7 +110,7 @@ def get_pattern_to_quantize_handlers(backend_config: BackendConfig) -> Dict[Patt
 # TODO: move this to torch/ao/quantization/backend_config/utils.py
 def get_fusion_pattern_to_fuse_handler_cls(
         backend_config: BackendConfig) -> Dict[Pattern, Callable]:
-    fusion_pattern_to_fuse_handlers: Dict[Pattern, Callable] = dict()
+    fusion_pattern_to_fuse_handlers: Dict[Pattern, Callable] = {}
     for pattern, config in backend_config.configs.items():
         if config.fuser_method is not None:
             # TODO: is this logic right?

--- a/torch/ao/quantization/fx/pattern_utils.py
+++ b/torch/ao/quantization/fx/pattern_utils.py
@@ -25,8 +25,8 @@ DEFAULT_QUANTIZATION_PATTERNS = OrderedDict()
 # Mapping from pattern to activation_post_process(observer/fake_quant) constructor for output activation
 # e.g. pattern: torch.sigmoid,
 #      output_activation_post_process: default_fixed_qparams_range_0to1_fake_quant
-DEFAULT_OUTPUT_FAKE_QUANTIZE_MAP = dict()
-DEFAULT_OUTPUT_OBSERVER_MAP = dict()
+DEFAULT_OUTPUT_FAKE_QUANTIZE_MAP = {}
+DEFAULT_OUTPUT_OBSERVER_MAP = {}
 
 # Register pattern for both static quantization and qat
 def register_quant_pattern(pattern, fixed_qparams_observer=None):

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -1137,7 +1137,7 @@ def insert_observers_for_model(
     #
     # TODO: rename this to node_name_to_target_dtype_info
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]] = defaultdict(dict)
-    cache_for_no_tensor_check: Dict[Node, bool] = dict()
+    cache_for_no_tensor_check: Dict[Node, bool] = {}
 
     inputs_seen_counter = 0
     outputs_seen_counter = 0

--- a/torch/ao/quantization/fx/qconfig_mapping_utils.py
+++ b/torch/ao/quantization/fx/qconfig_mapping_utils.py
@@ -107,7 +107,7 @@ def generate_qconfig_map(
         qconfig_mapping: QConfigMapping,
         node_name_to_scope: Dict[str, Tuple[str, type]]) -> Dict[str, QConfigAny]:
     global_qconfig = qconfig_mapping.global_qconfig
-    qconfig_map = dict()
+    qconfig_map = {}
 
     # example:
     #

--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -47,7 +47,7 @@ class QuantizeHandler(ABC):
         # determine how many of the first two args are Tensors (versus scalars)
         # this distinguishes things like "x + y" from "x + 2" or "2 + x"
         if isinstance(self.root_node, Node):
-            cache_for_no_tensor_check: Dict[Node, bool] = dict()
+            cache_for_no_tensor_check: Dict[Node, bool] = {}
             for arg_idx in range(len(self.root_node.args)):
                 arg = self.root_node.args[arg_idx]
                 if isinstance(arg, Node) and (

--- a/torch/ao/sparsity/sparsifier/base_sparsifier.py
+++ b/torch/ao/sparsity/sparsifier/base_sparsifier.py
@@ -51,7 +51,7 @@ class BaseSparsifier(abc.ABC):
     """
     def __init__(self, defaults: Optional[Dict[str, Any]] = None):
         super().__init__()
-        self.defaults: Dict[str, Any] = defaults or dict()
+        self.defaults: Dict[str, Any] = defaults or {}
 
         self.state: Dict[str, Dict] = defaultdict(dict)
         self.groups: List[Dict[str, Any]] = []
@@ -275,7 +275,7 @@ class BaseSparsifier(abc.ABC):
             tensor_name = config['tensor_name']
             parametrize.remove_parametrizations(module, tensor_name,
                                                 leave_parametrized=True)
-            sparse_params = dict()
+            sparse_params = {}
             if params_to_keep is not None:
                 global_params = {k: config[k] for k in params_to_keep}
                 sparse_params.update(global_params)

--- a/torch/ao/sparsity/sparsifier/utils.py
+++ b/torch/ao/sparsity/sparsifier/utils.py
@@ -77,4 +77,4 @@ class FakeSparsity(nn.Module):
         # We don't want to let the parametrizations to save the mask.
         # That way we make sure that the linear module doesn't store the masks
         # alongside their parametrizations.
-        return dict()
+        return {}

--- a/torch/distributed/_shard/checkpoint/default_planner.py
+++ b/torch/distributed/_shard/checkpoint/default_planner.py
@@ -165,7 +165,7 @@ def create_default_global_save_plan(all_plans: List[SavePlan]) -> Tuple[List[Sav
 
     The only global planning change is to update index hints in all ``MetadataIndex`` objects.
     """
-    md: Dict[str, STORAGE_TYPES] = dict()
+    md: Dict[str, STORAGE_TYPES] = {}
     new_plans = []
     for plan in all_plans:
         new_items = []

--- a/torch/distributed/_shard/checkpoint/resharding.py
+++ b/torch/distributed/_shard/checkpoint/resharding.py
@@ -167,7 +167,7 @@ def _prepare_sharded_tensor_write(
     NB `storage_key` is used to compose the key names of the local shards.
     """
     write_requests = []
-    shard_to_storage_key: Dict[str, str] = dict()
+    shard_to_storage_key: Dict[str, str] = {}
     storage_md = {}
 
     for shard_md in sharded_tensor.metadata().shards_metadata:

--- a/torch/distributed/_shard/checkpoint/state_dict_saver.py
+++ b/torch/distributed/_shard/checkpoint/state_dict_saver.py
@@ -61,7 +61,7 @@ def _prepare(
     metadata = Metadata(state_dict_metadata={})
     tensor_write_requests: List[TensorWriteRequest] = []
     bytes_write_requests: List[BytesWriteRequest] = []
-    storage_key_to_fqn: Dict[str, str] = dict()
+    storage_key_to_fqn: Dict[str, str] = {}
 
     storage_md = {}
 

--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -455,7 +455,7 @@ class ShardedTensor(ShardedTensorBase):
         world_size = dist.get_world_size(self._process_group)
         rank_sizes = [0 for _ in range(world_size)]
         max_rank_size = 0
-        shard_placement: Dict[ShardMetadata, Tuple[int, int]] = dict()
+        shard_placement: Dict[ShardMetadata, Tuple[int, int]] = {}
         # collect sizes
         for shard_md in self.metadata().shards_metadata:
             shard_rank = cast(_remote_device, shard_md.placement).rank()

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -999,7 +999,7 @@ class FullyShardedDataParallel(nn.Module):
             TracingConfig
         ):
             # Initialize a dict that maps each module to its parent FSDP wrap
-            module_to_fsdp: Dict[nn.Module, FullyShardedDataParallel] = dict()
+            module_to_fsdp: Dict[nn.Module, FullyShardedDataParallel] = {}
             for wrap in self.fsdp_modules(self):
                 module_to_fsdp[wrap.module] = wrap
             # Set self._fsdp_params_exec_order based on execution_info.module_forward_order.

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -239,7 +239,7 @@ def _all_gather(obj, worker_names=None, timeout=UNSET_RPC_TIMEOUT):
     # Leader's signal is the first to be unblocked, after receiving all
     # followers' data objects.
     if is_leader:
-        worker_name_to_response_future_dict = dict()
+        worker_name_to_response_future_dict = {}
         for follower_name in worker_names - {leader_name}:
             fut = rpc_async(
                 follower_name,

--- a/torch/fx/experimental/unification/dispatch.py
+++ b/torch/fx/experimental/unification/dispatch.py
@@ -1,6 +1,6 @@
 from functools import partial
 from .multipledispatch import dispatch  # type: ignore[import]
 
-namespace = dict()  # type: ignore[var-annotated]
+namespace = {}  # type: ignore[var-annotated]
 
 dispatch = partial(dispatch, namespace=namespace)

--- a/torch/fx/experimental/unification/match.py
+++ b/torch/fx/experimental/unification/match.py
@@ -7,7 +7,7 @@ from .unification_tools import groupby, first  # type: ignore[import]
 class Dispatcher(object):
     def __init__(self, name):
         self.name = name
-        self.funcs = dict()
+        self.funcs = {}
         self.ordering = []
 
     def add(self, signature, func):
@@ -60,7 +60,7 @@ class VarDispatcher(Dispatcher):
 
 
 
-global_namespace = dict()  # type: ignore[var-annotated]
+global_namespace = {}  # type: ignore[var-annotated]
 
 
 def match(*signature, **kwargs):

--- a/torch/fx/experimental/unification/multipledispatch/core.py
+++ b/torch/fx/experimental/unification/multipledispatch/core.py
@@ -3,7 +3,7 @@ import sys
 
 from .dispatcher import Dispatcher, MethodDispatcher
 
-global_namespace = dict()  # type: ignore[var-annotated]
+global_namespace = {}  # type: ignore[var-annotated]
 
 
 def dispatch(*types, **kwargs):
@@ -25,7 +25,7 @@ def dispatch(*types, **kwargs):
     >>> f(3.0)
     2.0
     >>> # Specify an isolated namespace with the namespace keyword argument
-    >>> my_namespace = dict()
+    >>> my_namespace = {}
     >>> @dispatch(int, namespace=my_namespace)
     ... def foo(x):
     ...     return x + 1

--- a/torch/fx/experimental/unification/multipledispatch/dispatcher.py
+++ b/torch/fx/experimental/unification/multipledispatch/dispatcher.py
@@ -333,7 +333,7 @@ class Dispatcher(object):
         self.name = d['name']
         self.funcs = d['funcs']
         self._ordering = ordering(self.funcs)
-        self._cache = dict()
+        self._cache = {}
 
     @property
     def __doc__(self):

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -116,7 +116,7 @@ def reduce_package_graph_module(
 def reduce_deploy_graph_module(
     importer: PackageImporter, body: Dict[Any, Any], import_block: str
 ) -> torch.nn.Module:
-    ns = dict()
+    ns = {}
     ns["__builtins__"] = importer.patched_builtins
     fn_src = body.get('_code')
     assert fn_src is not None

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -192,7 +192,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
     replacement_placeholders = [n for n in replacement_graph.nodes if n.op == "placeholder"]
 
     # As we progressively replace nodes, we'll need to keep track of how the match results should change
-    match_changed_node: Dict[Node, Node] = dict()
+    match_changed_node: Dict[Node, Node] = {}
 
     for match in _matches:
 

--- a/torch/nn/quantized/_reference/modules/rnn.py
+++ b/torch/nn/quantized/_reference/modules/rnn.py
@@ -288,7 +288,7 @@ class RNNBase(nn.RNNBase):
                 'scale': 1.0,
                 'zero_point': 0
             }
-            weight_qparams_dict = dict()
+            weight_qparams_dict = {}
             for wn in self._flat_weights_names:
                 if wn.startswith("weight"):
                     weight_qparams_dict[wn] = weight_qparams

--- a/torch/onnx/_onnx_supported_ops.py
+++ b/torch/onnx/_onnx_supported_ops.py
@@ -76,7 +76,7 @@ def _symbolic_argument_count(func):
 
 
 def _all_symbolics_schemas():
-    symbolics_schemas: Dict[str, _TorchSchema] = dict()
+    symbolics_schemas: Dict[str, _TorchSchema] = {}
 
     for domain, version in symbolic_registry._registry:
         for opname, sym_func in symbolic_registry._registry[(domain, version)].items():

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1484,9 +1484,9 @@ def sample_inputs_full_like(self, device, dtype, requires_grad, **kwargs):
 
 def sample_inputs_multinomial(self, device, dtype, requires_grad, **kwargs):
     cases = [
-        ([3], 3, dict()),
-        ([10], 3, dict()),
-        ([3, 10], 3, dict()),
+        ([3], 3, {}),
+        ([10], 3, {}),
+        ([3, 10], 3, {}),
         ([3], 3, dict(replacement=False)),
         ([3], 3, dict(replacement=True)),
         ([3, 4], 4, dict(replacement=True)),
@@ -3766,7 +3766,7 @@ def sample_inputs_avgpool1d(op_info, device, dtype, requires_grad, **kwargs):
 
     # Order: input_shape, kernel_size, kwargs
     cases: List[Tuple[Tuple[int, ...], Union[int, Tuple[int, ...]], Dict]] = [
-        ((2, 3, 9), (3,), dict()),
+        ((2, 3, 9), (3,), {}),
         ((1, 3, 9), 3, dict(stride=1, padding=1, ceil_mode=True, count_include_pad=False)),
         ((1, 3, 9), (6,), dict(stride=(3,), padding=(2,), ceil_mode=True, count_include_pad=True)),
         ((2, 3, 9), (3,), dict(stride=(1,), padding=(1,), ceil_mode=False, count_include_pad=True)),
@@ -3785,7 +3785,7 @@ def sample_inputs_avgpool3d(op_info, device, dtype, requires_grad, **kwargs):
 
     # Order: input_shape, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override
     cases: List[Tuple[Tuple[int, ...], Union[int, Tuple[int, ...]], Dict]] = [
-        ((2, 3, 3, 4, 4), (2, 2, 2), dict()),
+        ((2, 3, 3, 4, 4), (2, 2, 2), {}),
         ((1, 2, 4, 4, 4), 2, dict(stride=1, padding=1, ceil_mode=True,
                                   count_include_pad=False, divisor_override=2)),
         ((1, 2, 5, 5, 5), (2, 3, 4), dict(stride=(1, 2, 2), padding=(0, 1, 2), ceil_mode=True,
@@ -5072,7 +5072,7 @@ def reference_inputs_diagonal_diag_embed(op_info, device, dtype, requires_grad, 
     shapes2d = ((L, M),)
     shapes3d = ((L, M, S),)
 
-    kwargs1d = dict()
+    kwargs1d = {}
 
     kwargs2d = (
         # dim1 > dim2 is allowed
@@ -5107,7 +5107,7 @@ def error_inputs_diagonal_diag_embed(op_info, device, **kwargs):
     shapes2d = ((M, L),)
     shapes3d = ((M, S, L),)
 
-    kwargs1d = dict()
+    kwargs1d = {}
 
     kwargs2d = (
         # dim1 == dim2 is not allowed
@@ -5193,10 +5193,10 @@ def sample_inputs_cross_entropy(op_info, device, dtype, requires_grad, **kwargs)
     reductions = ("mean", "sum", "none")
 
     input_shape_and_kwargs: List[Tuple[Tuple[int, ...], Dict[str, Any]]] = [
-        (shape, dict()),
-        ((*shape, 1), dict()),
-        ((*shape, 1, 2), dict()),
-        ((*shape, 1, 2, 3), dict()),
+        (shape, {}),
+        ((*shape, 1), {}),
+        ((*shape, 1, 2), {}),
+        ((*shape, 1, 2, 3), {}),
         *[(shape, dict(reduction=reduction)) for reduction in reductions],
         *[
             (

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -588,7 +588,7 @@ class QuantizationTestCase(TestCase):
             expected_node, expected_node_occurrence, expected_node_list:
                see docs for checkGraphModeFxOp
         """
-        nodes_in_graph = dict()
+        nodes_in_graph = {}
         node_list = []
         modules = dict(graph_module.named_modules(remove_duplicate=False))
         for node in graph_module.graph.nodes:

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -3019,7 +3019,7 @@ class RpcTest(RpcAgentTestFixture, RpcTestCommon):
         self.assertEqual(a.owner(), a.owner())
         self.assertEqual(a.owner(), b.owner())
         self.assertEqual(a.owner(), rpc.get_worker_info())
-        x = dict()
+        x = {}
         x[a.owner()] = a
         x[other_a.owner()] = other_a
         self.assertEqual(x[a.owner()], a)

--- a/torch/testing/_internal/distributed/rpc_utils.py
+++ b/torch/testing/_internal/distributed/rpc_utils.py
@@ -178,7 +178,7 @@ def generate_tests(
             continue
 
         name = f"{prefix}{test_class.__name__}"
-        class_ = type(name, (test_class, mixin, SpawnHelper), dict())
+        class_ = type(name, (test_class, mixin, SpawnHelper), {})
         class_.__module__ = module_name
         ret[name] = class_
     return ret

--- a/torch/utils/bottleneck/__main__.py
+++ b/torch/utils/bottleneck/__main__.py
@@ -36,7 +36,7 @@ def run_env_analysis():
     print('Running environment analysis...')
     info = get_env_info()
 
-    result: Dict[str, str] = dict()
+    result: Dict[str, str] = {}
 
     debug_str = ''
     if info.is_debug_build:

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -258,7 +258,7 @@ def parse(graph, trace, args=None, omit_useless_nodes=True):
         if node.type().kind() != CLASSTYPE_KIND:
             nodes_py.append(NodePyIO(node, "input"))
 
-    attr_to_scope: Dict[Any, str] = dict()
+    attr_to_scope: Dict[Any, str] = {}
     for node in graph.nodes():
         if node.kind() == GETATTR_KIND:
             attr_name = node.s("name")
@@ -297,7 +297,7 @@ def parse(graph, trace, args=None, omit_useless_nodes=True):
             module_name = getattr(module, "original_name", "Module")
         return module_name
 
-    alias_to_name = dict()
+    alias_to_name = {}
     base_name = parse_traced_name(trace)
     for name, module in trace.named_modules(prefix="__module"):
         mod_name = parse_traced_name(module)

--- a/torchgen/api/autograd.py
+++ b/torchgen/api/autograd.py
@@ -383,7 +383,7 @@ Attempted to convert a derivative formula for a mutable operator
             )
             continue
 
-        fw_derivative_dict: Dict[str, Sequence[ForwardDerivative]] = dict()
+        fw_derivative_dict: Dict[str, Sequence[ForwardDerivative]] = {}
         for key, info in info_dict.items():
             if not info.forward_derivatives:
                 fw_derivative_dict[key] = []

--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -1327,7 +1327,7 @@ def dispatch_lambda_exprs(
     arg_parser_outputs = arg_parser_output_exprs(ps, f)
     lambda_args = dispatch_lambda_args(ps, f)
     inits: List[str] = []
-    lambda_args_exprs: Dict[str, str] = dict()
+    lambda_args_exprs: Dict[str, str] = {}
 
     has_toptions = has_tensor_options(f)
 


### PR DESCRIPTION
Fix use-dict-literal pylint suggestions by changing `dict()` to `{}`. This PR should do the change for every Python file except test/jit/test_list_dict.py, where I think the intent is to test the constructor.