### PR TITLE
[Quant] Support lowering of channel shuffle in FX

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -5295,6 +5295,43 @@ class TestQuantizeFx(QuantizationTestCase):
             backend_config=backend_config
         )
 
+    def test_channel_shuffle_lowering(self):
+        # Three versions of channel shuffle
+        class M1(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.op = torch.nn.ChannelShuffle(2)
+
+            def forward(self, x):
+                return self.op(x + x) + x
+
+        class M2(torch.nn.Module):
+            def forward(self, x):
+                return torch.channel_shuffle(x + x, 2) + x
+
+        class M3(torch.nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.channel_shuffle(x + x, 2) + x
+
+        x = torch.randn(4, 4, 4, 4)
+        for m in (M1().eval(), M2().eval(), M3().eval()):
+            m = prepare_fx(m, {"": default_qconfig}, example_inputs=(x,))
+            m_copy = copy.deepcopy(m)
+            m = convert_fx(m)
+            m_ref = convert_to_reference_fx(m_copy)
+            print(m)
+            print(m_ref)
+            node_occurrence = {
+                ns.call_function(torch.quantize_per_tensor): 1,
+                ns.call_method("dequantize"): 1
+            }
+            node_occurrence_ref = {
+                ns.call_function(torch.quantize_per_tensor): 4,
+                ns.call_method("dequantize"): 4
+            }
+            self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
+            self.checkGraphModuleNodes(m_ref, expected_node_occurrence=node_occurrence_ref)
+
 @skipIfNoFBGEMM
 class TestQuantizeFxOps(QuantizationTestCase):
     def setUp(self):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -5316,9 +5316,9 @@ class TestQuantizeFx(QuantizationTestCase):
         x = torch.randn(4, 4, 4, 4)
         # torch.channel_shuffle is equivalent to torch.nn.functional.channel_shuffle
         model_node_pairs = [
-          (M1().eval(), ns.call_module(torch.nn.ChannelShuffle)),
-          (M2().eval(), ns.call_function(torch.channel_shuffle)),
-          (M3().eval(), ns.call_function(torch.channel_shuffle))
+            (M1().eval(), ns.call_module(torch.nn.ChannelShuffle)),
+            (M2().eval(), ns.call_function(torch.channel_shuffle)),
+            (M3().eval(), ns.call_function(torch.channel_shuffle))
         ]
         for m, node in model_node_pairs:
             m = prepare_fx(m, {"": default_qconfig}, example_inputs=(x,))

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -5319,8 +5319,6 @@ class TestQuantizeFx(QuantizationTestCase):
             m_copy = copy.deepcopy(m)
             m = convert_fx(m)
             m_ref = convert_to_reference_fx(m_copy)
-            print(m)
-            print(m_ref)
             node_occurrence = {
                 ns.call_function(torch.quantize_per_tensor): 1,
                 ns.call_method("dequantize"): 1

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -111,6 +111,8 @@ def is_copy_node(node, modules):
         torch.flatten,
         torch.mean,
         operator.floordiv,
+        # F.channel_shuffle and torch.channel_shuffle are essentially the same thing
+        # so we only need to put one of them here
         torch.channel_shuffle,
     ]
     method_list = [

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -111,6 +111,7 @@ def is_copy_node(node, modules):
         torch.flatten,
         torch.mean,
         operator.floordiv,
+        torch.channel_shuffle,
     ]
     method_list = [
         "clamp",
@@ -131,6 +132,7 @@ def is_copy_node(node, modules):
         torch.nn.MaxPool3d,
         torch.nn.ReLU,
         torch.nn.ReLU6,
+        torch.nn.ChannelShuffle,
     ]
     return _is_node_in_list(node, modules, func_list, method_list, module_type_list)
 


### PR DESCRIPTION
## Description
Support lowering of channel shuffle in FX by adding its module and functional op to `is_copy_node` list in `torch/ao/quantization/fx/_lower_to_native_backend.py`

## Validation
UTs added to test
- correctness of quantized `ChannelShuffle` module.
- FX lowering of `ChannelShuffle` module and functional `channel_shuffle`.

cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @leslie-fang-intel @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @ezyang @SherlockNoMad @soumith @EikanWang @wenzhe-nrv