### PR TITLE
Set shuffle to DataPipes with set_shuffle API

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -3166,7 +3166,7 @@ class TestIterDataPipeGraphFastForward(TestCase):
         if rng is None:
             rng = torch.Generator()
         rng = rng.manual_seed(0)
-        torch.utils.data.graph_settings.apply_shuffle_seed(datapipe, rng)
+        torch.utils.data.graph_settings.apply_random_seed(datapipe, rng)
 
         # Test Case: fast forward works with list
         rng.manual_seed(0)
@@ -3199,7 +3199,7 @@ class TestIterDataPipeGraphFastForward(TestCase):
         rng = torch.Generator()
         graph3 = graph2.shuffle()
         rng.manual_seed(0)
-        torch.utils.data.graph_settings.apply_shuffle_seed(graph3, rng)
+        torch.utils.data.graph_settings.apply_random_seed(graph3, rng)
         res3 = list(graph3)
         self._fast_forward_graph_test_helper(graph3, _simple_graph_snapshot_restoration,
                                              expected_res=res3)
@@ -3219,7 +3219,7 @@ class TestIterDataPipeGraphFastForward(TestCase):
         cdp1, cdp2 = graph5.fork(2)
         graph6 = cdp1.zip(cdp2)
         rng = rng.manual_seed(100)
-        torch.utils.data.graph_settings.apply_shuffle_seed(graph6, rng)
+        torch.utils.data.graph_settings.apply_random_seed(graph6, rng)
         res6 = [(x, x) for x in res5]
         self._fast_forward_graph_test_helper(graph6, _simple_graph_snapshot_restoration,
                                              expected_res=res6)
@@ -3250,7 +3250,7 @@ class TestIterDataPipeGraphFastForward(TestCase):
         if rng is None:
             rng = torch.Generator()
         rng.manual_seed(0)
-        torch.utils.data.graph_settings.apply_shuffle_seed(datapipe, rng)
+        torch.utils.data.graph_settings.apply_random_seed(datapipe, rng)
         it = iter(datapipe)
         for _ in range(n_iter):
             next(it)
@@ -3277,7 +3277,7 @@ class TestIterDataPipeGraphFastForward(TestCase):
         rng = torch.Generator()
         graph3 = graph2.shuffle()
         rng.manual_seed(0)
-        torch.utils.data.graph_settings.apply_shuffle_seed(graph3, rng)
+        torch.utils.data.graph_settings.apply_random_seed(graph3, rng)
         res3 = list(graph3)
         self._snapshot_test_helper(graph3, expected_res=res3)
 
@@ -3307,13 +3307,13 @@ class TestIterDataPipeGraphFastForward(TestCase):
 
         rng = torch.Generator()
         rng.manual_seed(0)
-        torch.utils.data.graph_settings.apply_shuffle_seed(graph, rng)
+        torch.utils.data.graph_settings.apply_random_seed(graph, rng)
 
         # Get expected result
         expected_res = list(graph)
 
         rng.manual_seed(0)
-        torch.utils.data.graph_settings.apply_shuffle_seed(graph, rng)
+        torch.utils.data.graph_settings.apply_random_seed(graph, rng)
         it = iter(graph)
         n_iter = 3
         for _ in range(n_iter):

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -223,13 +223,13 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
             np.random.seed(np_seed)
 
         from torch.utils.data import IterDataPipe
-        from torch.utils.data.graph_settings import apply_shuffle_seed
+        from torch.utils.data.graph_settings import apply_random_seed
 
         shared_rng = torch.Generator()
         if isinstance(dataset, IterDataPipe):
             assert shared_seed is not None
             shared_rng.manual_seed(shared_seed)
-            dataset = apply_shuffle_seed(dataset, shared_rng)
+            dataset = apply_random_seed(dataset, shared_rng)
 
         global _worker_info
         _worker_info = WorkerInfo(id=worker_id, num_workers=num_workers,
@@ -277,7 +277,7 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
                 if isinstance(dataset, IterDataPipe):
                     assert r.seed is not None
                     shared_rng.manual_seed(r.seed)
-                    dataset = apply_shuffle_seed(dataset, shared_rng)
+                    dataset = apply_random_seed(dataset, shared_rng)
 
                 # Recreate the fetcher for worker-reuse policy
                 fetcher = _DatasetKind.create_fetcher(

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -624,7 +624,7 @@ class _BaseDataLoaderIter(object):
         if isinstance(self._dataset, IterDataPipe):
             shared_rng = torch.Generator()
             shared_rng.manual_seed(self._shared_seed)
-            self._dataset = torch.utils.data.graph_settings.apply_shuffle_seed(self._dataset, shared_rng)
+            self._dataset = torch.utils.data.graph_settings.apply_random_seed(self._dataset, shared_rng)
         self._dataset_kind = loader._dataset_kind
         self._IterableDataset_len_called = loader._IterableDataset_len_called
         self._auto_collation = loader._auto_collation
@@ -665,7 +665,7 @@ class _BaseDataLoaderIter(object):
         if isinstance(self._dataset, IterDataPipe):
             shared_rng = torch.Generator()
             shared_rng.manual_seed(self._shared_seed)
-            self._dataset = torch.utils.data.graph_settings.apply_shuffle_seed(self._dataset, shared_rng)
+            self._dataset = torch.utils.data.graph_settings.apply_random_seed(self._dataset, shared_rng)
 
     def _next_index(self):
         return next(self._sampler_iter)  # may raise StopIteration

--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -142,10 +142,11 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
 
     def reset(self) -> None:
         self._buffer = []
-        if self._enabled and self._seed is None:
-            self._seed = int(torch.empty((), dtype=torch.int64).random_().item())
-        self._rng.seed(self._seed)
-        self._seed = None
+        if self._enabled:
+            if self._seed is None:
+                self._seed = int(torch.empty((), dtype=torch.int64).random_().item())
+            self._rng.seed(self._seed)
+            self._seed = None
 
     def __getstate__(self):
         if IterDataPipe.getstate_hook is not None:

--- a/torch/utils/data/datapipes/utils/snapshot.py
+++ b/torch/utils/data/datapipes/utils/snapshot.py
@@ -1,6 +1,6 @@
 from torch.utils.data.datapipes._hook_iterator import _SnapshotState
 from torch.utils.data.datapipes.datapipe import IterDataPipe
-from torch.utils.data.graph_settings import apply_shuffle_seed
+from torch.utils.data.graph_settings import apply_random_seed
 
 
 # TODO: Caveats
@@ -39,7 +39,7 @@ def _simple_graph_snapshot_restoration(datapipe: IterDataPipe, n_iterations: int
     # simple fast-forwarding. Therefore, we need to call `reset` twice, because if `SnapshotState` is `Restored`,
     # the first reset will not actually reset.
     datapipe.reset()  # This ensures `SnapshotState` is `Iterating` by this point, even if it was `Restored`.
-    apply_shuffle_seed(datapipe, rng)
+    apply_random_seed(datapipe, rng)
 
     remainder = n_iterations
     it = iter(datapipe)  # This always reset the DataPipe if it hasn't already.

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -1,13 +1,14 @@
+import inspect
 import warnings
 
 from typing import Any, List, Optional, Set
 
 import torch
-import torch.utils.data.datapipes as dp
 
 from torch.utils.data.graph import DataPipe, DataPipeGraph, traverse
 
 __all__ = [
+    "apply_random_seed",
     "apply_sharding",
     "apply_shuffle_seed",
     "apply_shuffle_settings",
@@ -17,6 +18,7 @@ __all__ = [
 
 def get_all_graph_pipes(graph: DataPipeGraph) -> List[DataPipe]:
     return _get_all_graph_pipes_helper(graph, set())
+
 
 def _get_all_graph_pipes_helper(graph: DataPipeGraph, id_cache: Set[int]) -> List[DataPipe]:
     results: List[DataPipe] = []
@@ -45,13 +47,29 @@ def apply_sharding(datapipe: DataPipe, num_of_instances: int, instance_id: int) 
     return datapipe
 
 
-def apply_shuffle_settings(datapipe: DataPipe, shuffle: Optional[bool]) -> DataPipe:
+def _is_shuffle_datapipe(datapipe: DataPipe) -> bool:
+    if not hasattr(datapipe, "set_shuffle") or not hasattr(datapipe, "set_seed"):
+        return False
+    if not inspect.ismethod(datapipe.set_shuffle) or not inspect.ismethod(datapipe.set_seed):
+        return False
+    return True
+
+
+def apply_shuffle_settings(datapipe: DataPipe, shuffle: Optional[bool] = None) -> DataPipe:
+    r"""
+    Traverse the graph of ``DataPipes`` to find and set shuffle attribute
+    to each `DataPipe` that has an API of ``set_shuffle``.
+
+    Args:
+        datapipe: DataPipe that needs to set shuffle attribute
+        shuffle: (default: ``None`` and no-op to the graph)
+    """
     if shuffle is None:
         return datapipe
 
     graph = traverse(datapipe, only_datapipe=True)
     all_pipes = get_all_graph_pipes(graph)
-    shufflers = [pipe for pipe in all_pipes if isinstance(pipe, (dp.iter.Shuffler, dp.map.Shuffler))]
+    shufflers = [pipe for pipe in all_pipes if _is_shuffle_datapipe(pipe)]
     if not shufflers and shuffle:
         warnings.warn(
             "`shuffle=True` was set, but the datapipe does not contain a `Shuffler`. Adding one at the end. "
@@ -67,12 +85,43 @@ def apply_shuffle_settings(datapipe: DataPipe, shuffle: Optional[bool]) -> DataP
 
 
 def apply_shuffle_seed(datapipe: DataPipe, rng: Any) -> DataPipe:
+    warnings.warn(
+        "`apply_shuffle_seed` is deprecated since 1.12 and will be removed in the future releases."
+        "\nPlease use `apply_random_seed` instead."
+    )
+    return apply_random_seed(datapipe, rng)
+
+
+def _is_random_datapipe(datapipe: DataPipe) -> bool:
+    if hasattr(datapipe, "set_seed") and inspect.ismethod(datapipe.set_seed):
+        return True
+    return False
+
+
+def apply_random_seed(datapipe: DataPipe, rng: Any) -> DataPipe:
+    r"""
+    Traverse the graph of ``DataPipes`` to find ``Shuffler`` and set random seed
+    based on the provided RNG.
+
+    Args:
+        datapipe: DataPipe that needs to set randomness
+        rng: the random number generator to generate random seeds
+    """
     graph = traverse(datapipe, only_datapipe=True)
     all_pipes = get_all_graph_pipes(graph)
-    shufflers = {pipe for pipe in all_pipes if isinstance(pipe, (dp.iter.Shuffler, dp.map.Shuffler))}
+    # Using a set to track id of DataPipe to prevent setting randomness per DataPipe more than once.
+    # And, `id` is used in case of unhashable DataPipe
+    cache = set()
+    random_datapipes = []
+    for pipe in all_pipes:
+        if id(pipe) in cache:
+            continue
+        if _is_random_datapipe(pipe):
+            random_datapipes.append(pipe)
+            cache.add(id(pipe))
 
-    for shuffler in shufflers:
-        shuffle_seed = int(torch.empty((), dtype=torch.int64).random_(generator=rng).item())
-        shuffler.set_seed(shuffle_seed)
+    for pipe in random_datapipes:
+        random_seed = int(torch.empty((), dtype=torch.int64).random_(generator=rng).item())
+        pipe.set_seed(random_seed)
 
     return datapipe

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -58,11 +58,11 @@ def _is_shuffle_datapipe(datapipe: DataPipe) -> bool:
 def apply_shuffle_settings(datapipe: DataPipe, shuffle: Optional[bool] = None) -> DataPipe:
     r"""
     Traverse the graph of ``DataPipes`` to find and set shuffle attribute
-    to each `DataPipe` that has an API of ``set_shuffle``.
+    to each `DataPipe` that has APIs of ``set_shuffle`` and ``set_seed``.
 
     Args:
         datapipe: DataPipe that needs to set shuffle attribute
-        shuffle: (default: ``None`` and no-op to the graph)
+        shuffle: Shuffle option (default: ``None`` and no-op to the graph)
     """
     if shuffle is None:
         return datapipe
@@ -98,14 +98,14 @@ def _is_random_datapipe(datapipe: DataPipe) -> bool:
     return False
 
 
-def apply_random_seed(datapipe: DataPipe, rng: Any) -> DataPipe:
+def apply_random_seed(datapipe: DataPipe, rng: torch.Generator) -> DataPipe:
     r"""
-    Traverse the graph of ``DataPipes`` to find ``Shuffler`` and set random seed
-    based on the provided RNG.
+    Traverse the graph of ``DataPipes`` to find random ``DataPipe`` with an API of
+    ``set_seed`` then set the random seed based on the provided RNG.
 
     Args:
         datapipe: DataPipe that needs to set randomness
-        rng: the random number generator to generate random seeds
+        rng: Random number generator to generate random seeds
     """
     graph = traverse(datapipe, only_datapipe=True)
     all_pipes = get_all_graph_pipes(graph)


### PR DESCRIPTION
This PR requires PR is landed: https://github.com/pytorch/pytorch/pull/83202

## changes
- For `apply_shuffle_setting` and `apply_shuffle_seed`, it makes sure it will apply shuffle setting to each of DataPipe that contains a method called `set_shuffle` or `set_seed`.
- Change the API from `apply_shuffle_seed` to `apply_random_seed`.
- Fix a bug that `apply_shuffle_seed` only accepts DataPipe that is hashable. After the PR, this function uses `id` to prevent seeding the same DataPipe multiple times per epoch.
- Fix another bug from `shuffler` that `reset` with `_enable=False` would also reset `_seed`.