### PR TITLE
[bootcamp][Pytorch]Unit tests for NestedTensor_softmax

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -588,6 +588,37 @@ class TestNestedTensorDeviceType(TestCase):
             lambda: vector.mul(nt1)
         )
 
+    @dtypes(torch.float)
+    @dtypesIfCUDA(torch.float, torch.half)
+    @parametrize("batch_size", [2, 8, 16, 32])
+    @parametrize("max_seq_len", [5, 10, 100])
+    def test_nested_tensor_softmax(self, device, dtype, batch_size, max_seq_len):
+        softmax = torch.nn.Softmax(dim=3)
+        # padding distribution (sequence length of each data point)
+        padding = torch.randint(low=1, high=max_seq_len, size=(batch_size,))
+        nt_list = []
+        padded_list = []
+        query_list = []
+        head = torch.randint(low=1, high=5, size=(1,)) * 2
+        # preparing random input for softmax and nested_tensor_softmax
+        for i in range(batch_size):
+            query_list.append(torch.zeros((padding[i], padding[i]), dtype=dtype, device=device))
+            nt_list.append(torch.randn((head, padding[i], padding[i]), dtype=dtype, device=device))
+            padded_tensor = torch.zeros((head, max_seq_len, max_seq_len), dtype=dtype, device=device)
+            padded_tensor[:, :padding[i], :padding[i]] = nt_list[-1]
+            padded_list.append(padded_tensor)
+        nt = torch.nested_tensor(nt_list)
+        # stack tensors in padded_list to create a new dimension matching nested tensor
+        padded = torch.stack(padded_list).to(device)
+        query = torch.nested_tensor(query_list)
+        gt_out = softmax(nt)
+        softmax_out = torch._nested_tensor_softmax_with_shape(padded, query)
+        # fill in ground truth values in a tensor for comparison
+        gt = torch.zeros_like(padded, dtype=dtype, device=device)
+        for i in range(batch_size):
+            gt[i, :, :padding[i], :padding[i]] = gt_out[i, :, :, :]
+        torch.testing.assert_close(softmax_out, gt, rtol=1e-7, atol=1e-5)
+
     @dtypes(torch.float, torch.float16)
     @skipMeta
     @torch.inference_mode()


### PR DESCRIPTION
Summary:
Unit tests for pytorch _nested_tensor_softmax_ operator.

The unit tests run cpu/gpu implementations of _nested_tensor_softmax_ depending on devices available.

Test Plan:
arc lint
    buck test mode/dev-nosan //caffe2/test:nested -- test_nested_tensor_softmax

# CPU impl test:
{F761843855}

# GPU impl test:

For test purposes I changed device to cuda temporarily as the device list in the test doesn't include cuda somehow. Below are the test results (the test name still says cpu since the input parameter for device is still cpu but is changed to cuda inside the function).

{F761843395}

The GPU implementation didn't pass the test cases. This is probably because NestedTensor_softmax_dropout_cuda applied a mask on top, which might achieve different softmax values. The implementation is also temporary, which requires more investigation.

Notice that the attn_mask is ported to the device of query in order for gpu implementation to run.

Differential Revision: D38791384

