### PR TITLE
Pin sphinxcontrib.katex to 0.8.6

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,9 @@
 sphinx==5.0.0
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
-sphinxcontrib.katex
+# TODO: sphinxcontrib.katex 0.9.0 adds a local KaTeX server to speed up pre-rendering
+# but it doesn't seem to work and hangs around idly. The initial thought is probably
+# something related to Docker setup. We can investigate this later
+sphinxcontrib.katex=0.8.6
 matplotlib
 tensorboard
 # required to build torch.distributed.elastic.rendezvous.etcd* docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ sphinx==5.0.0
 # TODO: sphinxcontrib.katex 0.9.0 adds a local KaTeX server to speed up pre-rendering
 # but it doesn't seem to work and hangs around idly. The initial thought is probably
 # something related to Docker setup. We can investigate this later
-sphinxcontrib.katex=0.8.6
+sphinxcontrib.katex==0.8.6
 matplotlib
 tensorboard
 # required to build torch.distributed.elastic.rendezvous.etcd* docs


### PR DESCRIPTION
sphinxcontrib.katex 0.9.0 adds a local KaTeX server to speed up pre-rendering but it doesn't seem to work and hangs around idly. The initial thought is probably something related to Docker setup. We can investigate this later.

Here is the release change log from the [sphinxcontrib-katex](https://github.com/hagenw/sphinxcontrib-katex/commit/e27a051532dee33fbe329636b042426bf3ad6e26)