### PR TITLE
fx quant: fix issue with FX quant for x.view(x.size(...), ...)

### DIFF
--- a/torch/ao/quantization/backend_config/_common_operator_config_utils.py
+++ b/torch/ao/quantization/backend_config/_common_operator_config_utils.py
@@ -326,6 +326,20 @@ def _get_conv_configs(dtype_configs):
 
     return conv_configs
 
+def _get_tensor_info_op_configs(dtype_configs):
+    """
+    These ops work on tensors of different dtypes but return non-tensors
+    containing information about the input tensor.
+    """
+
+    def _get_config(op):
+        return BackendPatternConfig(op) \
+            .set_observation_type(ObservationType.OUTPUT_NOT_OBSERVED) \
+            .set_dtype_configs(dtype_configs)
+
+    return [_get_config(op) for op in ("shape", "size")]
+
+
 def _get_share_qparams_op_configs(dtype_configs):
     """ Get the operator config for the operators that works for both float and quantized input
     if input is quantized, the output Tensor shares the same quantization parameter
@@ -389,8 +403,6 @@ def _get_share_qparams_op_configs(dtype_configs):
         "resize_",
         "relu",
         "relu_",
-        "shape",
-        "size",
         "squeeze",
         "squeeze_",
         "transpose",
@@ -405,4 +417,5 @@ __all__ = [
     "_get_linear_configs",
     "_get_conv_configs",
     "_get_share_qparams_op_configs",
+    "_get_tensor_info_op_configs",
 ]

--- a/torch/ao/quantization/backend_config/native.py
+++ b/torch/ao/quantization/backend_config/native.py
@@ -9,6 +9,7 @@ from ._common_operator_config_utils import (
     _get_linear_configs,
     _get_conv_configs,
     _get_share_qparams_op_configs,
+    _get_tensor_info_op_configs,
 )
 from .backend_config import BackendConfig, BackendPatternConfig, DTypeConfig
 from .observation_type import ObservationType
@@ -256,6 +257,9 @@ def get_native_backend_config() -> BackendConfig:
     share_qparams_op_dtype_configs = [
         default_op_quint8_dtype_config,
     ]
+    tensor_info_op_dtype_configs = [
+        default_op_quint8_dtype_config,
+    ]
     fixed_qparams_op_dtype_configs = [
         weighted_op_int8_dtype_config,
     ]
@@ -268,6 +272,7 @@ def get_native_backend_config() -> BackendConfig:
         .set_backend_pattern_config(_CAT_CONFIG) \
         .set_backend_pattern_configs(_get_bn_configs()) \
         .set_backend_pattern_configs(_get_share_qparams_op_configs(share_qparams_op_dtype_configs)) \
+        .set_backend_pattern_configs(_get_tensor_info_op_configs(tensor_info_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_rnn_op_configs()) \
         .set_backend_pattern_configs(_get_embedding_op_configs())
 

--- a/torch/ao/quantization/backend_config/observation_type.py
+++ b/torch/ao/quantization/backend_config/observation_type.py
@@ -11,3 +11,6 @@ class ObservationType(Enum):
     # on qconfig.activation
     # example: torch.cat, maxpool
     OUTPUT_SHARE_OBSERVER_WITH_INPUT = 1
+    # this means the output is never observed
+    # example: x.shape, x.size
+    OUTPUT_NOT_OBSERVED = 2

--- a/torch/ao/quantization/backend_config/tensorrt.py
+++ b/torch/ao/quantization/backend_config/tensorrt.py
@@ -6,6 +6,7 @@ from ._common_operator_config_utils import (
     _get_linear_configs,
     _get_conv_configs,
     _get_share_qparams_op_configs,
+    _get_tensor_info_op_configs,
 )
 
 def get_tensorrt_backend_config() -> BackendConfig:
@@ -50,6 +51,9 @@ def get_tensorrt_backend_config() -> BackendConfig:
     share_qparams_op_dtype_configs = [
         non_weighted_op_qint8_dtype_config,
     ]
+    tensor_info_op_dtype_configs = [
+        non_weighted_op_qint8_dtype_config,
+    ]
     # there might be things not supported in fx2trt, but it will error out
     # during fx2trt conversion and can support them after that
     return BackendConfig("tensorrt") \
@@ -58,7 +62,8 @@ def get_tensorrt_backend_config() -> BackendConfig:
         .set_backend_pattern_config(cat_config) \
         .set_backend_pattern_configs(_get_linear_configs(linear_dtype_configs)) \
         .set_backend_pattern_configs(_get_binary_op_configs(binary_op_dtype_configs)) \
-        .set_backend_pattern_configs(_get_share_qparams_op_configs(share_qparams_op_dtype_configs))
+        .set_backend_pattern_configs(_get_share_qparams_op_configs(share_qparams_op_dtype_configs)) \
+        .set_backend_pattern_configs(_get_tensor_info_op_configs(tensor_info_op_dtype_configs))
 
 def get_tensorrt_backend_config_dict():
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#83784 fx quant: fix issue with FX quant for x.view(x.size(...), ...)**

Summary:

https://github.com/pytorch/pytorch/issues/83658 reported that ops
followed by a certain pattern of `view` and `size` ops were not quantized
correctly by FX graph mode quantization.

Before this PR, the "size" op was in the "op shares qparams with input"
category, and the code assumed that the input of this op has the same dtype
as its output. This led to incorrectly propagating the `int` dtype
as the output of whichever op was preceding the `view` op, which in turn
made that op blocklisted from quantization.

The fix is to create a new category of ops which work on different dtypes
of tensors but are not observed.  This PR does so for `size`, and also for
`shape` since it works the same way.

Test plan:

```
python test/test_quantization.py -k test_linear_view_size
```

cc @ezyang @SherlockNoMad @soumith @EikanWang @jgong5 @wenzhe-nrv