### PR TITLE
Freeze the rest of python docs requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,9 +4,9 @@ sphinx==5.0.0
 # but it doesn't seem to work and hangs around idly. The initial thought is probably
 # something related to Docker setup. We can investigate this later
 sphinxcontrib.katex==0.8.6
-matplotlib
-tensorboard
+matplotlib==3.5.3
+tensorboard==2.10.0
 # required to build torch.distributed.elastic.rendezvous.etcd* docs
-python-etcd>=0.4.5
-sphinx_copybutton
-sphinx-panels
+python-etcd==0.4.5
+sphinx-copybutton==0.5.0
+sphinx-panels==0.4.1


### PR DESCRIPTION
This is to avoid similar issue like #83774 `pip freeze -r requirements.txt`
