### PR TITLE
guard include of x64 intrinsics headers

### DIFF
--- a/caffe2/quantization/server/dnnlowp.h
+++ b/caffe2/quantization/server/dnnlowp.h
@@ -6,7 +6,9 @@
 #include <cstdint>
 #include <limits>
 
+#ifdef __x86_64__
 #include <immintrin.h>
+#endif
 
 #include <fbgemm/QuantUtils.h>
 

--- a/caffe2/quantization/server/fully_connected_fake_lowp_op.h
+++ b/caffe2/quantization/server/fully_connected_fake_lowp_op.h
@@ -16,7 +16,9 @@
 
 #pragma once
 
+#ifdef __x86_64__
 #include <immintrin.h>
+#endif
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/conversions.h"


### PR DESCRIPTION
Summary: make inclusion of immintrin.h only for x64

Test Plan: CI

Differential Revision: D38886597

