### PR TITLE
modify the signature of method `__getitem__` from `ModuleList`

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -100,7 +100,7 @@ class Sequential(Module):
         return next(islice(iterator, idx, None))
 
     @_copy_to_script_wrapper
-    def __getitem__(self, idx) -> Union['Sequential', T]:
+    def __getitem__(self, idx: Union[slice, int]) -> Union['Sequential', T]:
         if isinstance(idx, slice):
             return self.__class__(OrderedDict(list(self._modules.items())[idx]))
         else:
@@ -275,7 +275,7 @@ class ModuleList(Module):
         return str(idx)
 
     @_copy_to_script_wrapper
-    def __getitem__(self, idx: int) -> Union[Module, 'ModuleList']:
+    def __getitem__(self, idx: Union[int, slice]) -> Union[Module, 'ModuleList']:
         if isinstance(idx, slice):
             return self.__class__(list(self._modules.values())[idx])
         else:


### PR DESCRIPTION
The type of the parameter idx can be either slice or int. The same for the `Sequential` class

Fixes #83797
