### PR TITLE
Make negative integer test always done for Int to SymInt

### DIFF
--- a/c10/core/SymIntArrayRef.h
+++ b/c10/core/SymIntArrayRef.h
@@ -81,9 +81,9 @@ class SymIntArrayRef final {
 
   static SymIntArrayRef fromIntArrayRef(IntArrayRef array_ref) {
     for (size_t i = 0; i < array_ref.size(); ++i) {
-      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      TORCH_CHECK(
           SymInt::check_range(array_ref[i]),
-          "IntArrayRef contains int that cannot be representative as a SymInt",
+          "IntArrayRef contains an int that cannot be represented as a SymInt: ",
           array_ref[i]);
     }
     return SymIntArrayRef(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83815

Otherwise, it would be easy to trigger arbitrary memory access
by passing a sufficiently negative integer to the API.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>