### PR TITLE
Simplify reshape and fix _refs.unflatten

### DIFF
--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -669,7 +669,7 @@ def infer_size(shape: ShapeType, numel: int) -> Tuple[int, ...]:
     for i, d in enumerate(shape):
         if d == -1:
             check(dim is None, lambda: "only one dimension can be inferred")
-            dim = d
+            dim = i
         elif d >= 0:
             newsize *= d
         else:

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -659,6 +659,32 @@ def extract_shape_from_varargs(
     return shape  # type: ignore[return-value]
 
 
+def infer_size(shape: ShapeType, numel: int) -> Tuple[int, ...]:
+    """
+    Infers the size of a dim with size -1, if it exists.
+    Also checks that new shape is compatible with the number of elements.
+    """
+    dim = None
+    newsize = 1
+    for i, d in enumerate(shape):
+        if d == -1:
+            check(dim is None, lambda: "only one dimension can be inferred")
+            dim = d
+        elif d >= 0:
+            newsize *= d
+        else:
+            check(False, lambda: f"invalid shape dimension {d}")
+    check(numel == newsize or (dim is not None and newsize > 0 and numel % newsize == 0),
+          lambda: f"shape '{list(shape)}' is invalid for input of size {numel}")
+    if dim is not None:
+        check(newsize != 0,
+              lambda: f"cannot reshape tensor fo 0 elements into shape {shape} because the "
+                      f"unspecified dimension size -1 can be any value and is ambiguous")
+        shape = list(shape)
+        shape[dim] = numel // newsize
+    return tuple(shape)
+
+
 _integer_dtypes = (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
 _low_precision_dtypes = (torch.float16, torch.bfloat16, torch.complex32)
 _float_dtypes = (torch.float16, torch.bfloat16, torch.float32, torch.float64)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #83827

Unflatten was incorrectly calling into `reshape` rather than `view`.
When looking at the checks performed in `reshape`, I saw that the
in PrimTorch is quite divergent from that in PyTorch, to the point that
it took me some time to be able to prove that they were equivalent.

I refactored that part into a separate function, and I implemented the
logic that we have in ATen, together with the same errors.