### PR TITLE
[Quant][fx] Remove WEIGHT_INDEX_DICT and BIAS_INDEX_DICT (Part 2)

### DIFF
--- a/torch/ao/ns/fx/mappings.py
+++ b/torch/ao/ns/fx/mappings.py
@@ -195,6 +195,10 @@ def get_base_name_to_sets_of_related_ops() -> Dict[str, Set[NSNodeTargetType]]:
         set([
             F.hardswish,
         ]),
+        # F.group_norm
+        set([
+            F.group_norm,
+        ]),
         # F.instance_norm
         set([
             F.instance_norm,

--- a/torch/ao/quantization/backend_config/_common_operator_config_utils.py
+++ b/torch/ao/quantization/backend_config/_common_operator_config_utils.py
@@ -355,16 +355,35 @@ def _get_default_op_configs(dtype_configs: List[DTypeConfig]) -> List[BackendPat
         torch.nn.PReLU,
         torch.nn.functional.elu,
         torch.nn.functional.hardswish,
-        torch.nn.functional.instance_norm,
         torch.nn.functional.leaky_relu,
         torch.nn.functional.dropout,
-        torch.nn.functional.layer_norm
     ]
     for op in default_ops:
         configs.append(
             BackendPatternConfig(op)
                 .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)  # noqa: E131
                 .set_dtype_configs(dtype_configs))
+
+    configs.append(
+        BackendPatternConfig(torch.nn.functional.layer_norm)
+        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 2, "bias": 3})
+    )
+
+    configs.append(
+        BackendPatternConfig(torch.nn.functional.group_norm)
+        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 2, "bias": 3})
+    )
+
+    configs.append(
+        BackendPatternConfig(torch.nn.functional.instance_norm)
+        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 3, "bias": 4})
+    )
     return configs
 
 def _get_fixed_qparams_op_configs(dtype_configs: List[DTypeConfig]) -> List[BackendPatternConfig]:

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -74,6 +74,8 @@ from .utils import (
     assert_and_get_unique_device,
     get_non_observable_arg_indexes_and_types,
     get_new_attr_name_with_prefix,
+    node_arg_is_weight,
+    node_arg_is_bias,
     NON_QUANTIZABLE_WEIGHT_OPS,
 )
 
@@ -135,8 +137,6 @@ __all__ = [
     "maybe_insert_output_observer_for_node",
     "maybe_make_input_output_share_observers",
     "maybe_propagate_dtype_for_node",
-    "node_arg_is_bias",
-    "node_arg_is_weight",
     "prepare",
     "propagate_dtypes_for_known_nodes",
     "qat_swap_modules",
@@ -153,22 +153,6 @@ DO_NOT_OBS_DTYPE_LIST = [int, float, torch.bool, None]
 def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Module]) -> bool:
     return isinstance(node, torch.fx.Node) and node.op == "call_module" and \
         is_activation_post_process(modules[str(node.target)])
-
-def node_arg_is_weight(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
-    if isinstance(node, Node) and node.op == "call_function" and node.target in backend_config.configs:
-        weight_index = backend_config.configs[node.target]._input_type_to_index.get("weight")
-        if weight_index is not None and weight_index < len(node.args) and node.args[weight_index] is arg:
-            return True
-        return node.kwargs.get("weight") is arg
-    return False
-
-def node_arg_is_bias(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
-    if isinstance(node, Node) and node.op == "call_function" and node.target in backend_config.configs:
-        bias_index = backend_config.configs[node.target]._input_type_to_index.get("bias")
-        if bias_index is not None and bias_index < len(node.args) and node.args[bias_index] is arg:
-            return True
-        return node.kwargs.get("bias") is arg
-    return False
 
 def is_input_arg_dtype_supported_by_backend(
     arg: Argument,

--- a/torch/ao/quantization/fx/utils.py
+++ b/torch/ao/quantization/fx/utils.py
@@ -3,8 +3,10 @@ import re
 import torch
 import torch.nn as nn
 from torch.ao.quantization import QuantType
+from torch.ao.quantization.backend_config import BackendConfig
 from torch.ao.quantization.utils import is_per_tensor, is_per_channel
 from torch.ao.quantization.quantize import is_activation_post_process
+
 
 from torch.fx import GraphModule, map_arg
 
@@ -24,7 +26,6 @@ __all__ = [
     "all_node_args_except_first",
     "all_node_args_have_no_tensors",
     "assert_and_get_unique_device",
-    "BIAS_INDEX_DICT",
     "collect_producer_nodes",
     "create_getattr_from_value",
     "create_node_from_old_node_preserve_meta",
@@ -38,43 +39,40 @@ __all__ = [
     "get_qconv_op",
     "get_qconv_prepack_op",
     "get_quantize_node_info",
+    "get_skipped_module_name_and_classes",
     "graph_module_from_producer_nodes",
     "graph_pretty_str",
     "is_get_tensor_info_node",
     "maybe_get_next_module",
     "NodeInfo",
     "node_return_type_is_int",
+    "node_arg_is_bias",
+    "node_arg_is_weight",
     "NON_OBSERVABLE_ARG_DICT",
     "NON_QUANTIZABLE_WEIGHT_OPS",
     "quantize_node",
     "return_arg_list",
-    "WEIGHT_INDEX_DICT",
-    "get_skipped_module_name_and_classes",
 ]
-
-
-# A dictionary for querying the weight index for a given op
-WEIGHT_INDEX_DICT = {
-    torch.nn.functional.conv1d : [1],
-    torch.nn.functional.conv2d : [1],
-    torch.nn.functional.conv3d : [1],
-    torch.nn.functional.linear : [1],
-    torch.nn.functional.layer_norm : [2],
-    torch.nn.functional.group_norm : [2],
-    torch.nn.functional.instance_norm : [3],
-}
 
 NON_QUANTIZABLE_WEIGHT_OPS = {torch.nn.functional.layer_norm, torch.nn.functional.group_norm, torch.nn.functional.instance_norm}
 
-BIAS_INDEX_DICT = {
-    torch.nn.functional.conv1d : [2],
-    torch.nn.functional.conv2d : [2],
-    torch.nn.functional.conv3d : [2],
-    torch.nn.functional.linear : [2],
-    torch.nn.functional.layer_norm : [3],
-    torch.nn.functional.group_norm : [3],
-    torch.nn.functional.instance_norm : [4],
-}
+def node_arg_is_weight(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
+    """Returns if node arg is weight"""
+    if isinstance(node, Node) and node.op == "call_function" and node.target in backend_config.configs:
+        weight_index = backend_config.configs[node.target]._input_type_to_index.get("weight")
+        if weight_index is not None and weight_index < len(node.args) and node.args[weight_index] is arg:
+            return True
+        return node.kwargs.get("weight") is arg
+    return False
+
+def node_arg_is_bias(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
+    """Returns if node arg is bias"""
+    if isinstance(node, Node) and node.op == "call_function" and node.target in backend_config.configs:
+        bias_index = backend_config.configs[node.target]._input_type_to_index.get("bias")
+        if bias_index is not None and bias_index < len(node.args) and node.args[bias_index] is arg:
+            return True
+        return node.kwargs.get("bias") is arg
+    return False
 
 def graph_pretty_str(g, shorten=True) -> str:
     """Returns a printable representation of the ops in the graph of g.


### PR DESCRIPTION
Summary:
- Finishes the second part of https://github.com/pytorch/pytorch/pull/83263
- Removes WEIGHT_INDEX_DICT and BIAS_INDEX_DICT from utils.py
- Moves two funcitons, `node_arg_is_weight` and `node_arg_is_bias` into utils.py from prepare.py
convert.py and _equalize.py now use node_arg_is_weight instead of the dictionaries
- Adds in quantization support for `F.groupnorm`.

Add in missing BackendPatternConfigs for layernorm, instancenorm, and groupnorm

Test Plan:
```
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps
```

Reviewers:

Subscribers:

Tasks:

Tags:

ghstack-source-id: 2b157e0dc4f1553be1f4813b4693db952e6fc558
Pull Request resolved: https://github.com/pytorch/pytorch/pull/83848

Fixes #83093