### PR TITLE
Migrate last workflows from 18.04 to 22.04

### DIFF
--- a/.github/workflows/update_pytorch_labels.yml
+++ b/.github/workflows/update_pytorch_labels.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   update-labels-in-S3:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: ${{ github.repository == 'pytorch/pytorch' }}
     steps:
       - name: Checkout PyTorch

--- a/.github/workflows/update_s3_htmls.yml
+++ b/.github/workflows/update_s3_htmls.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update-html:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: ${{ github.repository == 'pytorch/pytorch' }}
     strategy:
       matrix:


### PR DESCRIPTION
18.04 is getting deprecated in december--let's migrate them off now.

This PR does NOT touch functorch nor third_party workflows.