### PR TITLE
[PyTorch] Fix default arg for MKL thread count

### DIFF
--- a/caffe2/core/init_omp.cc
+++ b/caffe2/core/init_omp.cc
@@ -50,9 +50,8 @@ REGISTER_CAFFE2_INIT_FUNCTION(Caffe2SetOpenMPThreads,
 
 #ifdef CAFFE2_USE_MKL
 bool Caffe2SetMKLThreads(int*, char***) {
-  if (!getenv("MKL_NUM_THREADS")) {
-    VLOG(1) << "MKL_NUM_THREADS not passed, defaulting to 1 thread";
-    mkl_set_num_threads(1);
+  if (!getenv("MKL_NUM_THREADS") && FLAGS_caffe2_mkl_num_threads == 0) {
+    VLOG(1) << "MKL_NUM_THREADS not passed, using MKL defaults.";
   }
 
   // If caffe2_omp_num_threads is set, we use that for MKL as well.


### PR DESCRIPTION
Summary:
The `caffe2_mkl_num_threads` arg controls how many threads the [MKL library](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-mkl-for-dpcpp/top.html) will use when doing matrix multiplication and other linear algebra. It's described like this:
> The number of mkl threads. 0 to use default value.

However, the code that parses it is buggy. Setting it to 0 does *not* make it use the default value (which would be the number of CPU cores). Instead, it gets set to 1, which disables threading.

This diff fixes the logic so that MKL will be threaded by default; threading can still be disabled if desired by setting the arg to 1 explicitly.

This causes **a ≈ 7x speedup** for matrix multiplication inside of PyTorch on apps that use the default args.

Differential Revision: D38911802

