### PR TITLE
hash update - bug fix for branches

### DIFF
--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -136,7 +136,7 @@ def main() -> None:
     )
     with open(f".github/ci_commit_pins/{args.repo_name}.txt", "r+") as f:
         old_hash = f.read().strip()
-        subprocess.run(f"git checkout {old_hash}", cwd=args.repo_name)
+        subprocess.run(f"git checkout {old_hash}".split(), cwd=args.repo_name)
         f.seek(0)
         f.truncate()
         f.write(f"{hash}\n")

--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -136,6 +136,7 @@ def main() -> None:
     )
     with open(f".github/ci_commit_pins/{args.repo_name}.txt", "r+") as f:
         old_hash = f.read().strip()
+        subprocess.run(f"git checkout {old_hash}", cwd=args.repo_name)
         f.seek(0)
         f.truncate()
         f.write(f"{hash}\n")

--- a/.github/workflows/update-commit-hashes.yml
+++ b/.github/workflows/update-commit-hashes.yml
@@ -7,6 +7,7 @@ on:
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     - cron: 37 7 * * *
   workflow_dispatch:
+  pull_request:
 
 jobs:
   update-xla-commit-hash:

--- a/.github/workflows/update-commit-hashes.yml
+++ b/.github/workflows/update-commit-hashes.yml
@@ -7,7 +7,6 @@ on:
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     - cron: 37 7 * * *
   workflow_dispatch:
-  pull_request:
 
 jobs:
   update-xla-commit-hash:


### PR DESCRIPTION
hash updates for xla were failing because the current pinned hash is a branch, so the git command for getting the date couldn't find the branch due to not having a local version of the branch.  Fixed by checking out the branch to make sure it exists locally.

example of failure: https://github.com/pytorch/pytorch/runs/7913835742?check_suite_focus=true

Test plan:
made it pull request trigger and ran, to get this:
https://github.com/pytorch/pytorch/runs/7959221184?check_suite_focus=true