### PR TITLE
[FSDP] Print exec order only in debug mode

### DIFF
--- a/test/distributed/fsdp/test_fsdp_exec_order.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order.py
@@ -88,6 +88,11 @@ class Model(torch.nn.Module):
 
 
 class TestFSDPExecOrder(FSDPTest):
+    
+    def setUp(self):
+        super().setUp()
+        dist.set_debug_level(dist.DebugLevel.INFO)
+
     @property
     def device(self):
         return torch.device("cuda")

--- a/test/distributed/fsdp/test_fsdp_exec_order.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order.py
@@ -88,7 +88,6 @@ class Model(torch.nn.Module):
 
 
 class TestFSDPExecOrder(FSDPTest):
-    
     def setUp(self):
         super().setUp()
 

--- a/test/distributed/fsdp/test_fsdp_exec_order.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order.py
@@ -91,7 +91,6 @@ class TestFSDPExecOrder(FSDPTest):
     
     def setUp(self):
         super().setUp()
-        dist.set_debug_level(dist.DebugLevel.INFO)
 
     @property
     def device(self):
@@ -110,6 +109,7 @@ class TestFSDPExecOrder(FSDPTest):
         in the first iteration."""
         # Rank 0 runs the forward pass in one order and all other ranks run in
         # different order
+        dist.set_debug_level(dist.DebugLevel.INFO)
         fsdp_model = Model.wrap(sharding_strategy, self.device)
         if self.rank != 0:
             fsdp_model.flip_path()
@@ -132,6 +132,7 @@ class TestFSDPExecOrder(FSDPTest):
     ):
         """Tests that FSDP warns the user if the all-gather order changes after
         the first iteration."""
+        dist.set_debug_level(dist.DebugLevel.INFO)
         # On the first iteration, all ranks run the same order, and on the next
         # iteration, all but rank 0 run in a different order
         fsdp_model = Model.wrap(sharding_strategy, self.device)
@@ -167,6 +168,7 @@ class TestFSDPExecOrder(FSDPTest):
         [ShardingStrategy.FULL_SHARD, ShardingStrategy.SHARD_GRAD_OP],
     )
     def test_train_eval(self, sharding_strategy: ShardingStrategy):
+        dist.set_debug_level(dist.DebugLevel.INFO)
         fsdp_model = Model.wrap(sharding_strategy, self.device)
         NUM_ITERS = 3
         NUM_EPOCHS = 2

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3383,7 +3383,7 @@ class FullyShardedDataParallel(nn.Module):
             allowed_debug_levels = [dist.DebugLevel.INFO, dist.DebugLevel.DETAIL]
             if (
                 eod.warn_status == _ExecOrderWarnStatus.WARNED
-                or dist.get_debug_level() not in allowed_debug_levels
+                or self._debug_level not in allowed_debug_levels
             ):
                 return
             # However, we may issue multiple warnings on the first deviating


### PR DESCRIPTION
Since exec order warning can result in very long module name print out, gating this only to be printing in debug mode. Oftentimes such as in multiModal training, there is not a lot we can do about this warning since some modules go unused in certain iterations.