### PR TITLE
Enable NCCL_DESYNC_DEBUG when TORCH_DISTRIBUTED_DEBUG=DETAIL

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -584,7 +584,8 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       "ProcessGroupNCCL is only supported with GPUs, no GPUs found!");
   blockingWait_ = parseEnvVarFlag(NCCL_BLOCKING_WAIT);
   asyncErrorHandling_ = parseEnvVarFlag(NCCL_ASYNC_ERROR_HANDLING);
-  desyncDebug_ = parseEnvVarFlag(NCCL_DESYNC_DEBUG);
+  desyncDebug_ = parseEnvVarFlag(NCCL_DESYNC_DEBUG) ||
+      dist_debug_level_ >= DebugLevel::Detail;
 
   if (blockingWait_) {
     if (asyncErrorHandling_ || desyncDebug_) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -584,8 +584,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       "ProcessGroupNCCL is only supported with GPUs, no GPUs found!");
   blockingWait_ = parseEnvVarFlag(NCCL_BLOCKING_WAIT);
   asyncErrorHandling_ = parseEnvVarFlag(NCCL_ASYNC_ERROR_HANDLING);
-  desyncDebug_ = parseEnvVarFlag(NCCL_DESYNC_DEBUG) ||
-      dist_debug_level_ >= DebugLevel::Detail;
+  desyncDebug_ = parseEnvVarFlag(NCCL_DESYNC_DEBUG) || (dist_debug_level_ >= DebugLevel::Detail);
 
   if (blockingWait_) {
     if (asyncErrorHandling_ || desyncDebug_) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -584,7 +584,8 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       "ProcessGroupNCCL is only supported with GPUs, no GPUs found!");
   blockingWait_ = parseEnvVarFlag(NCCL_BLOCKING_WAIT);
   asyncErrorHandling_ = parseEnvVarFlag(NCCL_ASYNC_ERROR_HANDLING);
-  desyncDebug_ = parseEnvVarFlag(NCCL_DESYNC_DEBUG) || (dist_debug_level_ >= DebugLevel::Detail);
+  desyncDebug_ = parseEnvVarFlag(NCCL_DESYNC_DEBUG) ||
+      (dist_debug_level_ >= DebugLevel::Detail);
 
   if (blockingWait_) {
     if (asyncErrorHandling_ || desyncDebug_) {

--- a/torch/csrc/distributed/c10d/debug.h
+++ b/torch/csrc/distributed/c10d/debug.h
@@ -10,7 +10,7 @@
 
 namespace c10d {
 
-enum class DebugLevel { Off = 0, Info = 1, Detail = 2};
+enum class DebugLevel { Off = 0, Info = 1, Detail = 2 };
 
 TORCH_API void setDebugLevel(DebugLevel level);
 

--- a/torch/csrc/distributed/c10d/debug.h
+++ b/torch/csrc/distributed/c10d/debug.h
@@ -10,7 +10,7 @@
 
 namespace c10d {
 
-enum class DebugLevel { Off, Info, Detail };
+enum class DebugLevel { Off = 0, Info = 1, Detail = 2};
 
 TORCH_API void setDebugLevel(DebugLevel level);
 


### PR DESCRIPTION
Automatically enable `NCCL_DESYNC_DEBUG` when `TORCH_DISTRIBUTED_DEBUG` is set to `DETAIL`.
Saving user from setting two env variables.
