### PR TITLE
[deploy][inference] Load extra_files of package in cpp (needed for saved requests and warmup)

### DIFF
--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -268,6 +268,25 @@ struct TORCH_API Package {
     TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
+  // Load extra files from package.
+  // Example usage:
+  //  in python:
+  //    with PackageExporter(output) as pe:
+  //        pe.save_binary("extra_files", "greeting", b'\xff\xfeh\x00e\x00l\x00l\x00o\x00')
+  //  in cpp:
+  //    std::string decodedBinary = package->loadExtraFile("greeting", true).toStringRef();
+  //    std::cout << decodedBinary; --> outputs "hello"
+  c10::IValue loadExtraFile(const std::string& key, const bool isBinary = false) {
+    TORCH_DEPLOY_TRY
+    auto I = acquireSession();
+    if(isBinary) {
+      return I.self.attr("load_binary")({"extra_files", key}).toIValue();
+    } else {
+      return I.self.attr("load_text")({"extra_files", key}).toIValue();
+    }
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
+  }
+
   InterpreterSession acquireSession() {
     TORCH_DEPLOY_TRY
     auto I = manager_->acquireOne();


### PR DESCRIPTION
Summary:
- Adds a method to the package struct to enable reading of data saved in "extra_files" of the package
- D38378610 **[torchrec] Allow storing binary data in extra_files** - added how to save and read the extra files in python
- For warmup, I need a way to save the requests, which can only be read as binary in python and the extra_files provides a convenient way to do so

Test Plan: Tested that I can save a recordio file in python as binary, and read it as a string in cpp

Differential Revision: D38914842

