### PR TITLE
Enable mul_hi in PhiloxRNGEngine on XPU GPU backend

### DIFF
--- a/aten/src/ATen/core/PhiloxRNGEngine.h
+++ b/aten/src/ATen/core/PhiloxRNGEngine.h
@@ -12,6 +12,10 @@
 #include <cuda.h>
 #endif
 
+#ifdef SYCL_LANGUAGE_VERSION
+#include <sycl.hpp>
+#endif
+
 #include <ATen/core/Array.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
@@ -173,6 +177,9 @@ private:
                                     uint32_t *result_high) {
     #ifdef __CUDA_ARCH__
       *result_high = __umulhi(a, b);
+      return a*b;
+    #elif __SYCL_DEVICE_ONLY__
+      *result_high = sycl::mul_hi(a, b);
       return a*b;
     #else
       const uint64_t product = static_cast<uint64_t>(a) * b;


### PR DESCRIPTION
For the multiplying operation of two uint32_t data a and b, the result is in uint64_t datatype.
In this PR, we enable the fast path with sycl::mul_hi instruction to extract the high 32-bit value of the multiplying result of two uint32_t data on Intel XPU GPU backend.

