### PR TITLE
ci: Remove dead code related to android uploads

### DIFF
--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -19,23 +19,6 @@ on:
           If this is set, our linter will use this to make sure that every other
           job with the same `sync-tag` is identical.
 
-    secrets:
-      SONATYPE_NEXUS_USERNAME:
-        description: nexus user
-        required: true
-      SONATYPE_NEXUS_PASSWORD:
-        description: nexus pass
-        required: true
-      ANDROID_SIGN_KEY:
-        description: android key
-        required: true
-      ANDROID_SIGN_PASS:
-        description: android pass
-        required: true
-      SCRIBE_GRAPHQL_ACCESS_TOKEN:
-        description: token for writing to scribe/scuba
-        required: true
-
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
@@ -159,25 +142,6 @@ jobs:
 
           mkdir -p "${GITHUB_WORKSPACE}/build_android_artifacts"
           docker cp "${ID_X86_32}:/var/lib/jenkins/workspace/android/artifacts.tgz" "${GITHUB_WORKSPACE}/build_android_artifacts/"
-
-      - name: Publish android snapshot
-        if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/nightly' }}
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          ANDROID_SIGN_KEY: ${{ secrets.ANDROID_SIGN_KEY }}
-          ANDROID_SIGN_PASS: ${{ secrets.ANDROID_SIGN_PASS }}
-          ID_X86_32: ${{ steps.build-x86_32.outputs.container_id }}
-        run: |
-          set -eux
-          (echo "./.circleci/scripts/publish_android_snapshot.sh" | docker exec \
-            -e BUILD_ENVIRONMENT="pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-publish-snapshot" \
-            -e SONATYPE_NEXUS_USERNAME \
-            -e SONATYPE_NEXUS_PASSWORD \
-            -e ANDROID_SIGN_KEY \
-            -e ANDROID_SIGN_PASS \
-            -e http_proxy="http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128" -e https_proxy="http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128" -e no_proxy="localhost,127.0.0.1,github.com,amazonaws.com,s3.amazonaws.com,169.254.169.254,169.254.170.2,/var/run/docker.sock" \
-            -u jenkins -i "${ID_X86_32}" bash) 2>&1
 
       - name: Store PyTorch Android Build Artifacts on S3
         uses: seemethere/upload-artifact-s3@v5

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -96,12 +96,6 @@ jobs:
     with:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
-    secrets:
-      SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-      SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-      ANDROID_SIGN_KEY: ${{ secrets.ANDROID_SIGN_KEY }}
-      ANDROID_SIGN_PASS: ${{ secrets.ANDROID_SIGN_PASS }}
-      SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
 
   linux-bionic-py3_7-clang9-slow-build:
     name: linux-bionic-py3.7-clang9-slow


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83930

These uploads actually never got triggeredhappened in nightlies so
removing it altogether. Someone can re-add in the future if they feel
these are important but I can't find an instance of this running since
we migrated so I have a hard time believing anyone will miss it.

https://hud.pytorch.org/hud/pytorch/pytorch/nightly/1?per_page=50&name_filter=android

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>