### PR TITLE
[fx][pass infra] Adding error catching

### DIFF
--- a/test/fx/test_pass_infra.py
+++ b/test/fx/test_pass_infra.py
@@ -156,3 +156,18 @@ class TestPassManager(TestCase):
             _topological_sort_passes(passes, constraints)
         expected_error_msg = f"Circular dependency detected within the following passes: {passes}"
         self.assertEqual(e.exception.args[0], expected_error_msg)
+
+    def test_pass_manager_error(self):
+        """
+        Tests error catching + debug
+        """
+        def pass_fail(graph_module):
+            raise RuntimeError("bad")
+
+        m = AddModule()
+        traced_m = torch.fx.symbolic_trace(m)
+        pm = PassManager(passes=[replace_add_with_mul_pass, replace_mul_with_div_pass, pass_fail])
+
+        # Comment out this line to see the actual error message
+        with self.assertRaises(RuntimeError):
+            pm(traced_m)

--- a/torch/fx/passes/infra/pass_manager.py
+++ b/torch/fx/passes/infra/pass_manager.py
@@ -188,6 +188,7 @@ class PassManager:
         steps=None,
         run_checks_after_each_pass: bool = False,
         suppress_check_failures: bool = False,
+        debug: bool = False,
     ):
         if passes:
             self.passes = passes
@@ -198,6 +199,7 @@ class PassManager:
 
         self.run_checks_after_each_pass = run_checks_after_each_pass
         self.suppress_check_failures = suppress_check_failures
+        self.debug = debug
 
     def add_pass(self, _pass: Callable):
         """
@@ -275,8 +277,16 @@ class PassManager:
             modified = False
 
             # Run the set of passes on the graph module
-            for fn in self.passes:
-                res = fn(module)
+            for i, fn in enumerate(self.passes):
+                if self.debug: 
+                    print(f"Running pass \'{fn.__name__}\'")
+                
+                try:
+                    res = fn(module)
+                except Exception as e:
+                    prev_pass_names = [p.__name__ for p in self.passes[:i]]
+                    msg = f"An error occured when running the \'{fn.__name__}\' pass after the following passes: {prev_pass_names}"
+                    raise RuntimeError(msg) from e
 
                 module = res.graph_module
                 modified = modified or res.modified


### PR DESCRIPTION
Example:

```
======================================================================
ERROR: test_pass_manager_error (fx.test_pass_infra.TestPassManager)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/angelayi/Projects/pytorch/torch/fx/passes/infra/pass_manager.py", line 285, in __call__
    res = fn(module)
  File "/Users/angelayi/Projects/pytorch/test/fx/test_pass_infra.py", line 164, in pass_fail
    raise RuntimeError("bad")
RuntimeError: bad

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/angelayi/Projects/pytorch/test/fx/test_pass_infra.py", line 170, in test_pass_manager_error
    pm(traced_m)
  File "/Users/angelayi/Projects/pytorch/torch/fx/passes/infra/pass_manager.py", line 289, in __call__
    raise RuntimeError(msg) from e
RuntimeError: An error occured when running the 'pass_fail' pass after the following passes: ['replace_add_with_mul_pass', 'replace_mul_with_div_pass']
```

Fixes #ISSUE_NUMBER
