### PR TITLE
Set python build-docs timeout to 30 minutes and cpp build-docs timeout to 180 minutes

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -39,6 +39,9 @@ jobs:
     # Don't run on forked repos.
     if: github.repository_owner == 'pytorch'
     runs-on: [self-hosted, linux.4xlarge]
+    # https://hud.pytorch.org/tts shows that it takes less than 30m to finish
+    # these jobs unless there are issues
+    timeout-minutes: 30
     strategy:
       matrix:
         docs_type: [cpp, python]

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -39,12 +39,15 @@ jobs:
     # Don't run on forked repos.
     if: github.repository_owner == 'pytorch'
     runs-on: [self-hosted, linux.4xlarge]
-    # https://hud.pytorch.org/tts shows that it takes less than 30m to finish
-    # these jobs unless there are issues
-    timeout-minutes: 30
     strategy:
       matrix:
-        docs_type: [cpp, python]
+        include:
+          - docs_type: cpp
+            # Nightly cpp docs take about 150m to finish, and the number is stable
+            timeout-minutes: 180
+          - docs_type: python
+            # It takes less than 30m to finish python docs unless there are issues
+            timeout-minutes: 30
     steps:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
@@ -79,6 +82,8 @@ jobs:
           echo "password ${GITHUB_PYTORCHBOT_TOKEN}" >> "${RUNNER_TEMP}/.netrc"
 
       - name: Build ${{ matrix.docs_type }} docs
+        timeout-minutes: ${{ matrix.timeout-minutes }}
+        id: build-docs
         env:
           WITH_PUSH: ${{ github.event_name == 'schedule' || startsWith(github.event.ref, 'refs/tags/v') }}
           DOCKER_IMAGE: ${{ inputs.docker-image }}
@@ -121,7 +126,7 @@ jobs:
 
       - name: Upload Python Docs Preview
         uses: seemethere/upload-artifact-s3@v5
-        if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'python' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome != 'success' }}
         with:
           retention-days: 14
           s3-bucket: doc-previews
@@ -131,7 +136,7 @@ jobs:
 
       - name: Upload C++ Docs Preview
         uses: seemethere/upload-artifact-s3@v5
-        if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'cpp' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome != 'success' }}
         with:
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload Python Docs Preview
         uses: seemethere/upload-artifact-s3@v5
-        if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome != 'success' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}
         with:
           retention-days: 14
           s3-bucket: doc-previews
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload C++ Docs Preview
         uses: seemethere/upload-artifact-s3@v5
-        if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome != 'success' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
         with:
           retention-days: 14
           if-no-files-found: error


### PR DESCRIPTION
Anything more means there's something wrong and we should just return. AFAIK the timeout doesn't include queuing time, only the job duration https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

![Screen Shot 2022-08-23 at 18 31 57](https://user-images.githubusercontent.com/475357/186298046-5637384f-887c-4c6a-a946-c101b6c66741.png)

This will help avoid having python build docs timeout after 6 hours.

