### PR TITLE
functionalization: support inplace views on inputs

### DIFF
--- a/functorch/functorch/csrc/init.cpp
+++ b/functorch/functorch/csrc/init.cpp
@@ -63,10 +63,12 @@ void _propagate_functional_input_mutation(const Tensor& unwrapped, const Tensor&
       // Functions might resize zero-sized inputs, which we need to reflect ehre.
       unwrapped.resize_(wrapped_inner.sizes());
     }
-      TORCH_INTERNAL_ASSERT(unwrapped.sizes() == wrapped_inner.sizes(),
-          "An inplace-mutation op (like transpose_() was called on an input to the functionalization pass."
-          " Propagating those mutations to the input is currently not supported.");
-      unwrapped.copy_(wrapped_inner);
+    // If the input tensor's metadata was mutated, then use as_strided_()
+    // to propagate the metadata change.
+    if (unwrapped.sizes() != wrapped_inner.sizes()) {
+      unwrapped.as_strided_(wrapped_inner.sizes(), wrapped_inner.strides());
+    }
+    unwrapped.copy_(wrapped_inner);
   }
 }
 


### PR DESCRIPTION
A version of this PR was sitting at https://github.com/pytorch/pytorch/pull/82601 but that PR some other cleanup that relies on being able to use functorch in pytorch/pytorch CI tests, which isn't ready yet. I pulled the change out here to unblock functionalization for some models run with inductor (see https://github.com/pytorch/torchdynamo/issues/964#issuecomment-1225971788).

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83993
* #83992

