### PR TITLE
ONNX: fix default function value in _optimize_graph

### DIFF
--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -553,6 +553,7 @@ def _optimize_graph(
 ):
     if params_dict is None:
         params_dict = {}
+
     # Inline everything
     _C._jit_pass_inline(graph)
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -546,11 +546,14 @@ def _optimize_graph(
     operator_export_type: _C_onnx.OperatorExportTypes,
     _disable_torch_constant_prop: bool = False,
     fixed_batch_size: bool = False,
-    params_dict={},
+    params_dict=None,
     dynamic_axes=None,
     input_names=None,
     module=None,
 ):
+    if params_dict is None:
+        params_dict = {}
+        
     # Inline everything
     _C._jit_pass_inline(graph)
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -546,7 +546,7 @@ def _optimize_graph(
     operator_export_type: _C_onnx.OperatorExportTypes,
     _disable_torch_constant_prop: bool = False,
     fixed_batch_size: bool = False,
-    params_dict=None,
+    params_dict={},
     dynamic_axes=None,
     input_names=None,
     module=None,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -553,7 +553,6 @@ def _optimize_graph(
 ):
     if params_dict is None:
         params_dict = {}
-        
     # Inline everything
     _C._jit_pass_inline(graph)
 


### PR DESCRIPTION
The default value for params_dict in _optimize_graph, which is None, throw the following error:

>     _C._jit_pass_onnx_unpack_quantized_weights(
> TypeError: _jit_pass_onnx_unpack_quantized_weights(): incompatible function arguments. The following argument types are supported:
>     1. (arg0: torch::jit::Graph, arg1: Dict[str, IValue], arg2: bool) -> Dict[str, IValue]

Replacing it by an empty dict fixes the issue (and makes more sense).
