### PR TITLE
Deletes CCACHE_DISABLE and SCCACHE_DISABLE from nccl.cmake

### DIFF
--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -22,10 +22,6 @@ if(NOT __NCCL_INCLUDED)
       CONFIGURE_COMMAND ""
       BUILD_COMMAND
         env
-        # TODO: remove these flags when
-        # https://github.com/pytorch/pytorch/issues/13362 is fixed
-        "CCACHE_DISABLE=1"
-        "SCCACHE_DISABLE=1"
         make
         "CXX=${CMAKE_CXX_COMPILER}"
         "CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}"


### PR DESCRIPTION
Looking through the code and online, it does not look like these variables actually change anything. Regardless, this change was instituted to fix https://github.com/pytorch/pytorch/issues/13362, but we are again running into similar issues even with the workaround: see https://github.com/pytorch/pytorch/issues/83790.

Thus, since
1. this change isn't preventing flakiness
2. these variables do not seem used anywhere in pytorch/pytorch nor mozilla/sccache
we should remove this confusion.