### PR TITLE
Decomposition - batch_norm, save_mean and save_variance always float32

### DIFF
--- a/functorch/test/test_pythonkey.py
+++ b/functorch/test/test_pythonkey.py
@@ -348,6 +348,59 @@ class TestAOTAutograd(AOTTestCase):
         out.sum().backward()
         self.assertEqual(count, [(['forward'], 4), (['inference'], 4), (['backward'], 8)])
 
+    def test_batch_norm_amp(self):
+        device = "cuda"
+        class MockModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.self_self_conv1 = torch.nn.Conv2d(
+                    3, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False
+                )
+                self.register_buffer("self_self_bn1_running_mean", torch.ones([64]))
+                self.register_buffer("self_self_bn1_running_var", torch.ones([64]))
+                self.self_self_bn1_weight = torch.nn.Parameter(torch.ones([64]))
+                self.self_self_bn1_bias = torch.nn.Parameter(torch.ones([64]))
+
+            def forward(self, x: torch.Tensor):
+                self_self_conv1 = self.self_self_conv1(x)
+                self_self_bn1_weight = self.self_self_bn1_weight
+                self_self_bn1_bias = self.self_self_bn1_bias
+                self_self_bn1_running_mean = self.self_self_bn1_running_mean
+                self_self_bn1_running_var = self.self_self_bn1_running_var
+                batch_norm = torch.nn.functional.batch_norm(
+                    self_self_conv1,
+                    self_self_bn1_running_mean,
+                    self_self_bn1_running_var,
+                    weight=self_self_bn1_weight,
+                    bias=self_self_bn1_bias,
+                    training=False,
+                    momentum=0.1,
+                    eps=1e-05,
+                )
+                return (batch_norm,)
+
+        inp = torch.ones([16, 3, 224, 224], dtype=torch.float32, device=device)
+
+        mod = MockModule().to(device=device)
+
+        # Test that autocast works
+        def fn(x):
+            with torch.cuda.amp.autocast():
+                out = mod(x)
+                loss = out[0].sum()
+                loss.backward()
+                return out
+
+        # Get golden output
+        ref = fn(inp)
+
+        # make_fx and new output
+        cudnn_batch_norm_decomp = torch._decomp.get_decompositions({torch.ops.aten.cudnn_batch_norm})
+        aot_fn = make_fx(fn, decomposition_table=cudnn_batch_norm_decomp)(inp)
+        res = aot_fn(inp)
+
+        # Check accuracy
+        self.assertTrue(torch.allclose(ref[0], res[0]))
 
 
 class TestEagerFusionOpInfo(AOTTestCase):

--- a/functorch/test/test_pythonkey.py
+++ b/functorch/test/test_pythonkey.py
@@ -351,58 +351,30 @@ class TestAOTAutograd(AOTTestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
     def test_batch_norm_amp(self):
         device = "cuda"
+        input_dtype = torch.float16
+        param_dtype = torch.float32
+        weight, bias = [torch.ones(64, device=device, dtype=param_dtype, requires_grad=True) for _ in range(2)]
+        running_mean, running_var = [torch.ones(64, device=device, dtype=param_dtype) for _ in range(2)]
 
-        class MockModule(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.self_self_conv1 = torch.nn.Conv2d(
-                    3, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False
-                )
-                self.register_buffer("self_self_bn1_running_mean", torch.ones([64]))
-                self.register_buffer("self_self_bn1_running_var", torch.ones([64]))
-                self.self_self_bn1_weight = torch.nn.Parameter(torch.ones([64]))
-                self.self_self_bn1_bias = torch.nn.Parameter(torch.ones([64]))
+        def bn(x):
+            return torch.ops.aten.cudnn_batch_norm(
+                x,
+                weight,
+                bias,
+                running_mean,
+                running_var,
+                False,
+                0.1,
+                1e-05,
+            )
+        inp = torch.ones(torch.Size([16, 64, 112, 112]), dtype=input_dtype, device=device)
 
-            def forward(self, x: torch.Tensor):
-                self_self_conv1 = self.self_self_conv1(x)
-                self_self_bn1_weight = self.self_self_bn1_weight
-                self_self_bn1_bias = self.self_self_bn1_bias
-                self_self_bn1_running_mean = self.self_self_bn1_running_mean
-                self_self_bn1_running_var = self.self_self_bn1_running_var
-                batch_norm = torch.nn.functional.batch_norm(
-                    self_self_conv1,
-                    self_self_bn1_running_mean,
-                    self_self_bn1_running_var,
-                    weight=self_self_bn1_weight,
-                    bias=self_self_bn1_bias,
-                    training=False,
-                    momentum=0.1,
-                    eps=1e-05,
-                )
-                return (batch_norm,)
-
-        inp = torch.ones([16, 3, 224, 224], dtype=torch.float32, device=device)
-
-        mod = MockModule().to(device=device)
-
-        # Test that autocast works
-        def fn(x):
-            with torch.cuda.amp.autocast():
-                out = mod(x)
-                loss = out[0].sum()
-                loss.backward()
-                return out
-
-        # Get golden output
-        ref = fn(inp)
-
-        # make_fx and new output
+        ref = bn(inp)
         cudnn_batch_norm_decomp = torch._decomp.get_decompositions({torch.ops.aten.cudnn_batch_norm})
-        aot_fn = make_fx(fn, decomposition_table=cudnn_batch_norm_decomp)(inp)
+        aot_fn = make_fx(bn, decomposition_table=cudnn_batch_norm_decomp)(inp)
         res = aot_fn(inp)
-
-        # Check accuracy
-        self.assertTrue(torch.allclose(ref[0], res[0]))
+        for a, b in zip(ref, res):
+            assert torch.allclose(a, b)
 
 
 class TestEagerFusionOpInfo(AOTTestCase):

--- a/functorch/test/test_pythonkey.py
+++ b/functorch/test/test_pythonkey.py
@@ -348,8 +348,10 @@ class TestAOTAutograd(AOTTestCase):
         out.sum().backward()
         self.assertEqual(count, [(['forward'], 4), (['inference'], 4), (['backward'], 8)])
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
     def test_batch_norm_amp(self):
         device = "cuda"
+
         class MockModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1099,8 +1099,8 @@ def cudnn_batch_norm(
         return (a, b, c, input.new_zeros((0,), dtype=torch.uint8))
     return (
         a,
-        input.new_zeros((0,)),
-        input.new_zeros((0,)),
+        input.new_zeros((0,), dtype=torch.float32),
+        input.new_zeros((0,), dtype=torch.float32),
         input.new_zeros((0,), dtype=torch.uint8),
     )
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1099,8 +1099,8 @@ def cudnn_batch_norm(
         return (a, b, c, input.new_zeros((0,), dtype=torch.uint8))
     return (
         a,
-        input.new_zeros((0,), dtype=torch.float32),
-        input.new_zeros((0,), dtype=torch.float32),
+        weight.new_zeros((0,)),
+        weight.new_zeros((0,)),
         input.new_zeros((0,), dtype=torch.uint8),
     )
 


### PR DESCRIPTION
AMP error shown here - https://github.com/pytorch/torchdynamo/issues/835

Test missing