### PR TITLE
[caffe2] Remove last clang-for-cuda sources

### DIFF
--- a/defs_gpu.bzl
+++ b/defs_gpu.bzl
@@ -71,9 +71,7 @@ ATEN_NATIVE_CUDA_H_PATTERN = [
 ]
 
 # T66678203: Clang CUDA rollout
-ATEN_CUDA_CLANG_CU_PATTERN = [
-    "aten/src/ATen/native/cuda/DistributionBernoulli.cu",
-]
+ATEN_CUDA_CLANG_CU_PATTERN = []
 
 ### Cuda Files
 def get_aten_cuda_headers():


### PR DESCRIPTION
Summary: We're no longer pursuing clang-for-cuda, so remove the last use-case.

Test Plan: CI

Reviewed By: pallab-zz

Differential Revision: D38996710

