### PR TITLE
switching the exact check to isinstance check

### DIFF
--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -79,7 +79,6 @@
 namespace torch {
 inline bool is_symint_node(py::handle obj) {
   auto static tp_symn = py::type::of<c10::SymIntNodeImpl>();
-  // TODO: switch this to `isinstance`
   if (py::isinstance(obj, tp_symn)) {
     TORCH_CHECK(
         !jit::tracer::isTracing(), "JIT tracing of SymInts isn't supported!");

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -80,7 +80,7 @@ namespace torch {
 inline bool is_symint_node(py::handle obj) {
   auto static tp_symn = py::type::of<c10::SymIntNodeImpl>();
   // TODO: switch this to `isinstance`
-  if (obj.get_type().equal(tp_symn)) {
+  if (py::isinstance(obj, tp_symn)) {
     TORCH_CHECK(
         !jit::tracer::isTracing(), "JIT tracing of SymInts isn't supported!");
     return true;


### PR DESCRIPTION
Simplifying a type check if an object is a SymIntNode in `is_symint_node`
