### PR TITLE
Enable cache action for lint workflow

### DIFF
--- a/.github/requirements-gha-cache.txt
+++ b/.github/requirements-gha-cache.txt
@@ -6,6 +6,7 @@
 #   functorch/docs/requirements.txt
 #   .circleci/docker/requirements-ci.txt
 jinja2==3.0.1
+lintrunner=0.9.2
 pynvml==11.4.1
 rich==10.9.0
 rockset==0.8.10

--- a/.github/requirements-gha-cache.txt
+++ b/.github/requirements-gha-cache.txt
@@ -1,0 +1,12 @@
+# This file is to cache other dependencies not specified elsewhere in:
+#   requirement.txt
+#   requirements-flake8.txt
+#   docs/requirements.txt
+#   docs/cpp/requirements.txt
+#   functorch/docs/requirements.txt
+#   .circleci/docker/requirements-ci.txt
+jinja2==3.0.1
+pynvml==11.4.1
+rich==10.9.0
+rockset==0.8.10
+torch==1.*

--- a/.github/requirements-gha-cache.txt
+++ b/.github/requirements-gha-cache.txt
@@ -9,4 +9,3 @@ jinja2==3.0.1
 pynvml==11.4.1
 rich==10.9.0
 rockset==0.8.10
-torch==1.*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -308,6 +308,8 @@ jobs:
           python-version: 3.5
           architecture: x64
           cache: pip
+          cache-dependency-path: |
+            **/.github/requirements-gha-cache.txt
       - name: Setup Python 3.8
         if: matrix.test_type != 'older_python_version'
         uses: actions/setup-python@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,7 +82,8 @@ jobs:
           python-version: 3.x
           architecture: x64
           cache: pip
-          cache-dependency-path: '**/requirements.txt'
+          cache-dependency-path: |
+            **/requirements.txt
       - name: Install requirements
         id: requirements
         run: pip install -r requirements.txt --user
@@ -171,9 +172,9 @@ jobs:
           python-version: 3.x
           architecture: x64
           cache: pip
-          cache-dependency-path:
-            - '**/requirements.txt'
-            - '**/.github/requirements-gha-cache.txt'
+          cache-dependency-path: |
+            **/requirements.txt
+            **/.github/requirements-gha-cache.txt
       - name: Install requirements
         id: requirements
         run: |
@@ -262,11 +263,11 @@ jobs:
           python-version: 3.8
           architecture: x64
           cache: pip
-          cache-dependency-path:
-            - '**/requirements.txt'
-            - '**/requirements-flake8.txt'
-            - '**/.circleci/docker/requirements-ci.txt'
-            - '**/.github/requirements-gha-cache.txt'
+          cache-dependency-path: |
+            **/requirements.txt
+            **/requirements-flake8.txt
+            **/.circleci/docker/requirements-ci.txt
+            **/.github/requirements-gha-cache.txt
       - name: Install dependencies
         # mypy and boto3 versions copied from
         # .circleci/docker/common/install_conda.sh
@@ -314,7 +315,8 @@ jobs:
           python-version: 3.8
           architecture: x64
           cache: pip
-          cache-dependency-path: '**/.github/requirements-gha-cache.txt'
+          cache-dependency-path: |
+            **/.github/requirements-gha-cache.txt
       - name: Install torch
         if: matrix.test_type == 'with_torch'
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,17 +14,18 @@ jobs:
   lintrunner:
     runs-on: linux.20_04.16x
     steps:
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+        with:
+          submodules: false
+          fetch-depth: 1
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
           architecture: x64
           cache: pip
-
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-        with:
-          submodules: false
 
       - name: Install lintrunner
         run: pip install lintrunner==0.9.*
@@ -65,12 +66,6 @@ jobs:
     name: quick-checks
     runs-on: linux.20_04.4x
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-          architecture: x64
-          cache: pip
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
@@ -81,6 +76,12 @@ jobs:
         run: |
           # Remove any artifacts from the previous checkouts
           git clean -fxd
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+          architecture: x64
+          cache: pip
       - name: Install requirements
         id: requirements
         run: pip install -r requirements.txt --user
@@ -157,18 +158,18 @@ jobs:
     name: workflow-checks
     runs-on: linux.20_04.4x
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-          architecture: x64
-          cache: pip
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
           fetch-depth: 1
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+          architecture: x64
+          cache: pip
       - name: Install requirements
         id: requirements
         run: |
@@ -205,16 +206,16 @@ jobs:
     env:
       NPM_CONFIG_PREFIX: ~/.npm-global
     steps:
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          cache: npm
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
           fetch-depth: 1
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
       - name: Install markdown-toc
         run: npm install -g markdown-toc
       - name: Regenerate ToCs and check that they didn't change
@@ -246,18 +247,18 @@ jobs:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     runs-on: linux.20_04.4x
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-          architecture: x64
-          cache: pip
       # [see note: pytorch repo ref]
       # deep clone (fetch-depth 0) required, to allow us to use git log
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+          cache: pip
       - name: Install dependencies
         # mypy and boto3 versions copied from
         # .circleci/docker/common/install_conda.sh
@@ -284,6 +285,13 @@ jobs:
       matrix:
         test_type: [with_torch, without_torch, older_python_version]
     steps:
+      # [see note: pytorch repo ref]
+      # deep clone (fetch-depth 0) required, to allow us to use git log
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+        with:
+          submodules: false
+          fetch-depth: 1
       - name: Setup Python 3.5
         if: matrix.test_type == 'older_python_version'
         uses: actions/setup-python@v2
@@ -298,13 +306,6 @@ jobs:
           python-version: 3.8
           architecture: x64
           cache: pip
-      # [see note: pytorch repo ref]
-      # deep clone (fetch-depth 0) required, to allow us to use git log
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-        with:
-          submodules: false
-          fetch-depth: 1
       - name: Install torch
         if: matrix.test_type == 'with_torch'
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
-          cache: pip
 
+      # Lintrunner is not cached because it might change frequently
       - name: Install lintrunner
         run: pip install lintrunner==0.9.*
 
@@ -82,6 +82,7 @@ jobs:
           python-version: 3.x
           architecture: x64
           cache: pip
+          cache-dependency-path: '**/requirements.txt'
       - name: Install requirements
         id: requirements
         run: pip install -r requirements.txt --user
@@ -170,6 +171,9 @@ jobs:
           python-version: 3.x
           architecture: x64
           cache: pip
+          cache-dependency-path:
+            - '**/requirements.txt'
+            - '**/.github/requirements-gha-cache.txt'
       - name: Install requirements
         id: requirements
         run: |
@@ -258,13 +262,18 @@ jobs:
           python-version: 3.8
           architecture: x64
           cache: pip
+          cache-dependency-path:
+            - '**/requirements.txt'
+            - '**/requirements-flake8.txt'
+            - '**/.circleci/docker/requirements-ci.txt'
+            - '**/.github/requirements-gha-cache.txt'
       - name: Install dependencies
         # mypy and boto3 versions copied from
         # .circleci/docker/common/install_conda.sh
         run: |
           set -eux
           pip install -r requirements.txt
-          pip install boto3==1.16.34
+          pip install boto3==1.19.12
           pip install typing-extensions==3.10 --user
           pip install -r requirements-flake8.txt --user
           pip install rockset==0.8.10 --user
@@ -305,6 +314,7 @@ jobs:
           python-version: 3.8
           architecture: x64
           cache: pip
+          cache-dependency-path: '**/.github/requirements-gha-cache.txt'
       - name: Install torch
         if: matrix.test_type == 'with_torch'
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
+          cache: pip
 
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
@@ -69,6 +70,7 @@ jobs:
         with:
           python-version: 3.x
           architecture: x64
+          cache: pip
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
@@ -81,7 +83,7 @@ jobs:
           git clean -fxd
       - name: Install requirements
         id: requirements
-        run: pip3 install -r requirements.txt --user
+        run: pip install -r requirements.txt --user
       - name: Ensure no non-breaking spaces
         if: always()
         run: |
@@ -160,6 +162,7 @@ jobs:
         with:
           python-version: 3.x
           architecture: x64
+          cache: pip
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
@@ -169,10 +172,10 @@ jobs:
       - name: Install requirements
         id: requirements
         run: |
-          pip3 install -r requirements.txt --user
+          pip install -r requirements.txt --user
       - name: Install Jinja2
         run: |
-          pip3 install Jinja2==3.0.1 --user
+          pip install Jinja2==3.0.1 --user
       - name: Regenerate workflows
         id: generate_workflows
         run: .github/scripts/generate_ci_workflows.py
@@ -204,6 +207,8 @@ jobs:
     steps:
       - name: Setup Node
         uses: actions/setup-node@v2
+        with:
+          cache: npm
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
@@ -246,6 +251,7 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
+          cache: pip
       # [see note: pytorch repo ref]
       # deep clone (fetch-depth 0) required, to allow us to use git log
       - name: Checkout PyTorch
@@ -257,13 +263,13 @@ jobs:
         # .circleci/docker/common/install_conda.sh
         run: |
           set -eux
-          python3 -mpip install -r requirements.txt
-          python3 -mpip install boto3==1.16.34
-          pip3 install typing-extensions==3.10 --user
-          pip3 install -r requirements-flake8.txt --user
-          python3 -mpip install rockset==0.8.10 --user
-          python3 -mpip install -r requirements.txt --user
-          python3 -mpip install mypy==0.960 --user
+          pip install -r requirements.txt
+          pip install boto3==1.16.34
+          pip install typing-extensions==3.10 --user
+          pip install -r requirements-flake8.txt --user
+          pip install rockset==0.8.10 --user
+          pip install -r requirements.txt --user
+          pip install mypy==0.960 --user
           make setup_lint
       - name: Test tools
         run: |
@@ -284,12 +290,14 @@ jobs:
         with:
           python-version: 3.5
           architecture: x64
+          cache: pip
       - name: Setup Python 3.8
         if: matrix.test_type != 'older_python_version'
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
           architecture: x64
+          cache: pip
       # [see note: pytorch repo ref]
       # deep clone (fetch-depth 0) required, to allow us to use git log
       - name: Checkout PyTorch

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -216,6 +216,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           cache: npm
+          # This is not a node project so there is no package-lock.json. I will just use
+          # the same python requirements here
+          cache-dependency-path: requirements.txt
       - name: Install markdown-toc
         run: npm install -g markdown-toc
       - name: Regenerate ToCs and check that they didn't change

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -212,13 +212,9 @@ jobs:
         with:
           submodules: false
           fetch-depth: 1
+      # This is not a node project so there is no package-lock.json to cache
       - name: Setup Node
         uses: actions/setup-node@v2
-        with:
-          cache: npm
-          # This is not a node project so there is no package-lock.json. I will just use
-          # the same python requirements here
-          cache-dependency-path: requirements.txt
       - name: Install markdown-toc
         run: npm install -g markdown-toc
       - name: Regenerate ToCs and check that they didn't change

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
+          cache: pip
           cache-dependency-path: |
             **/.github/requirements-gha-cache.txt
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,10 +25,11 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
+          cache-dependency-path: |
+            **/.github/requirements-gha-cache.txt
 
-      # Lintrunner is not cached because it might change frequently
       - name: Install lintrunner
-        run: pip install lintrunner==0.9.*
+        run: pip install lintrunner==0.9.2
 
       - name: Initialize lint dependencies
         run: lintrunner init


### PR DESCRIPTION
Cache all python dependencies using [GHA cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows).  I'm doing this for lint workflow first and will slowly roll it out to other workflows.

### Testing

Before caching, pip cache is not found. Dependencies installation continues as usual:

![Screen Shot 2022-08-24 at 16 36 15](https://user-images.githubusercontent.com/475357/186543554-9d7f5978-2c2d-4362-9535-c3b17e922da1.png)

After caching https://github.com/pytorch/pytorch/runs/8006214772?check_suite_focus=true. The long hash at the end of the cache key is the hash of requirements files

![Screen Shot 2022-08-24 at 16 51 51](https://user-images.githubusercontent.com/475357/186543825-055ea025-3d42-42fc-877d-baec358de0ed.png)

Note that the cache is in the runners themselves. This should be a transparent process.


