### PR TITLE
Test distributed backends in parallel

### DIFF
--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -43,8 +43,7 @@ def resolve_library_path(path: str) -> str:
 
 
 TEST_MASTER_ADDR = "127.0.0.1"
-# A random free port from 1024 to 65535 will be selected
-TEST_MASTER_PORT = 0
+TEST_MASTER_PORT = 29500
 # USE_GLOBAL_DEPS controls whether __init__.py tries to load
 # libtorch_global_deps, see Note [Global dependencies]
 USE_GLOBAL_DEPS = True

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -43,7 +43,8 @@ def resolve_library_path(path: str) -> str:
 
 
 TEST_MASTER_ADDR = "127.0.0.1"
-TEST_MASTER_PORT = 29500
+# A random free port from 1024 to 65535 will be selected
+TEST_MASTER_PORT = 0
 # USE_GLOBAL_DEPS controls whether __init__.py tries to load
 # libtorch_global_deps, see Note [Global dependencies]
 USE_GLOBAL_DEPS = True

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -503,7 +503,7 @@ class TestDistBackend(MultiProcessTestCase):
     @classmethod
     def setUpClass(cls):
         os.environ["MASTER_ADDR"] = str(MASTER_ADDR)
-        os.environ["MASTER_PORT"] = str(MASTER_PORT)
+        # Not setting MASTER_PORT and get a random free port
         super().setUpClass()
 
     def setUp(self):

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1924,9 +1924,8 @@ class DistributedTest:
             device_id = rank_to_GPU[rank][0]
             torch.cuda.set_device(device_id)
 
-            # Note that the master port is set to 0, which means that a random
-            # free port from 1024 to 65535 will be selected
-            os.environ["MASTER_PORT"] = str(MASTER_PORT)
+            new_port = str(MASTER_PORT + 1)
+            os.environ["MASTER_PORT"] = new_port
             gen_iterator = dist.rendezvous("env://", rank, dist.get_world_size())
             store, rank, size = next(gen_iterator)
             store = dist.PrefixStore(new_port, store)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1924,8 +1924,9 @@ class DistributedTest:
             device_id = rank_to_GPU[rank][0]
             torch.cuda.set_device(device_id)
 
-            new_port = str(MASTER_PORT + 1)
-            os.environ["MASTER_PORT"] = new_port
+            # Note that the master port is set to 0, which means that a random
+            # free port from 1024 to 65535 will be selected
+            os.environ["MASTER_PORT"] = str(MASTER_PORT)
             gen_iterator = dist.rendezvous("env://", rank, dist.get_world_size())
             store, rank, size = next(gen_iterator)
             store = dist.PrefixStore(new_port, store)


### PR DESCRIPTION
This allows multiple backends (nccl, gloo) to be tested in parallel and speed up the process. The improvement is mainly in the 1st distributed CUDA shard where the long pole `distributed/test_distributed_spawn` test is executed:

* [linux-bionic-cuda11.6-py3.10-gcc7 / test (distributed, 1, 2, linux.8xlarge.nvidia.gpu)](https://github.com/pytorch/pytorch/runs/8007596825?check_suite_focus=true#logs) takes 1h24m. This is better than the current average expectation of 2h12m

On the other hand, there is no improvement for the following two jobs:

* [linux-focal-py3.7-gcc7 / test (distributed, 1, 1, linux.2xlarge)](https://github.com/pytorch/pytorch/runs/8007417353?check_suite_focus=true#logs) takes 1h47m
* [linux-bionic-cuda11.6-py3.10-gcc7 / test (distributed, 2, 2, linux.8xlarge.nvidia.gpu)](https://github.com/pytorch/pytorch/runs/8007596870?check_suite_focus=true#logs) takes 1h40m

This is still a gain though because it allows us to add more shards for distributed test if needed.

Issue https://github.com/pytorch/pytorch/issues/83694