### PR TITLE
Optimize transpose copy on CPU using fbgemm transpose

### DIFF
--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -166,6 +166,12 @@ static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) 
       }
       return self;
     }
+
+    if (fbgemm::fbgemmSupportedCPU() && fbgemm_copy_transpose_valid(self, src) &&
+      src.dtype() == self.dtype() && (src.dtype() == at::kFloat || src.dtype() == at::kBFloat16)) {
+      fbgemm_copy_transpose_same_type(self, src);
+      return self;
+    }
   #endif
 
   if (self.is_same(src)) {

--- a/aten/src/ATen/native/cpu/utils.h
+++ b/aten/src/ATen/native/cpu/utils.h
@@ -93,6 +93,13 @@ inline void transpose<float>(int64_t M, int64_t N, const float* src, int64_t ld_
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU does not support FBGEMM.");
   fbgemm::transpose_simd<float>(M, N, src, ld_src, dst, ld_dst);
 }
+
+template <>
+inline void transpose<BFloat16>(int64_t M, int64_t N, const BFloat16* src, int64_t ld_src, BFloat16* dst, int64_t ld_dst) {
+  TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU does not support FBGEMM.");
+  fbgemm::transpose_simd<uint16_t>(M, N, reinterpret_cast<const uint16_t*>(src), ld_src, reinterpret_cast<uint16_t*>(dst), ld_dst);
+}
+
 #endif
 
 } // namespace utils

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2796,6 +2796,29 @@ else:
             self.assertEqual(x, y)
 
     @onlyCPU
+    def test_transpose_copy(self, device):
+        for shape in [(20, 7), (249, 137), (1029, 917), (1, 7, 19, 17), (3, 77, 1091)]:
+            inputf = torch.randn(shape, dtype=torch.float, device=device)
+            inputbf = inputf.to(torch.bfloat16)
+            inputf_t = inputf.transpose(-1, -2)
+            inputbf_t = inputbf.transpose(-1, -2)
+            inputf_tc = inputf_t.contiguous()
+            inputbf_tc = inputbf_t.contiguous()
+            self.assertEqual(inputf_t, inputf_tc)
+            self.assertEqual(inputbf_t, inputbf_tc)
+            self.assertEqual(inputf.transpose(-1, -2), inputf_tc)
+            self.assertEqual(inputbf.transpose(-1, -2), inputbf_tc)
+            if len(shape) == 4:
+                inputf_p = inputf.permute(1, 0, 3, 2)
+                inputbf_p = inputbf.permute(1, 0, 3, 2)
+                inputf_pc = inputf_p.contiguous()
+                inputbf_pc = inputbf_p.contiguous()
+                self.assertEqual(inputf_p, inputf_pc)
+                self.assertEqual(inputbf_p, inputbf_pc)
+                self.assertEqual(inputf.permute(1, 0, 3, 2), inputf_pc)
+                self.assertEqual(inputbf.permute(1, 0, 3, 2), inputbf_pc)
+
+    @onlyCPU
     def test_bfloat16_float_copy(self, device):
         for shape in [(20, 7), (249, 137), (1029, 917), (1, 7, 19, 17), (3, 77, 1091)]:
             input = torch.randn(shape, dtype=torch.float, device=device)


### PR DESCRIPTION
### Description
Optimize transpose copy on CPU using fbgemm transpose

### Testing
single socket (28cores):
```
before: torch.Size([10, 128, 10, 124]) -> torch.Size([10, 128, 124, 10]) fp32: 4.819e-05 s; bf16: 4.846e-05 s
        torch.Size([10, 128, 30, 124]) -> torch.Size([10, 128, 124, 30]) fp32: 0.000171 s; bf16: 0.000129 s
            
after: torch.Size([10, 128, 10, 124]) -> torch.Size([10, 128, 124, 10])  fp32: 2.439e-05 s; bf16: 2.152e-05 s
        torch.Size([10, 128, 30, 124]) -> torch.Size([10, 128, 124, 30]) fp32: 0.000132 s; bf16: 3.916e-05 s
```
single core:
```
before: torch.Size([10, 128, 10, 124]) -> torch.Size([10, 128, 124, 10]) fp32: 0.00109 s;  bf16: 0.00103 s
        torch.Size([10, 128, 30, 124]) -> torch.Size([10, 128, 124, 30]) fp32: 0.00339 s; bf16: 0.00295 s
            
after: torch.Size([10, 128, 10, 124]) -> torch.Size([10, 128, 124, 10]) fp32: 0.000566  s; bf16: 0.000382 s
        torch.Size([10, 128, 30, 124]) -> torch.Size([10, 128, 124, 30]) fp32: 0.00282 s; bf16: 0.000999 s
```
