### PR TITLE
[Prim] Implement group_norm_backward

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -878,17 +878,17 @@ def native_group_norm_backward(
     if output_mask[0]:
         s = 1.0 / (HxW * cpg)
         if gamma is not None:
-            ds_val = torch.mul(ds, gamma.reshape(1, C)).reshape(N, group, cpg).sum(2)
-            db_val = (db * gamma.reshape(1, C)).reshape(N, group, cpg).sum(2)
+            ds_val = torch.mul(ds, gamma.unsqueeze(0)).reshape(N, group, cpg).sum(2)
+            db_val = torch.mul(db, gamma.unsqueeze(0)).reshape(N, group, cpg).sum(2)
             c1 = torch.mul(
-                rstd.reshape(N, group, 1),
+                rstd.unsqueeze(-1),
                 gamma.reshape(1, group, cpg),
             )
         else:
             ds_val = ds.reshape(N, group, cpg).sum(2)
             db_val = db.reshape(N, group, cpg).sum(2)
             c1 = torch.mul(
-                rstd.reshape(N, group, 1),
+                rstd.unsqueeze(-1),
                 torch.ones((1, group, cpg), device=rstd.device),
             )
         c2 = (db_val * mean - ds_val) * rstd * rstd * rstd * s

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -861,7 +861,9 @@ def native_group_norm_backward(
     group: int,
     output_mask: List[bool],
 ) -> Tuple[Optional[Tensor], Optional[Tensor], Optional[Tensor]]:
-    utils.check_same_device(grad_output, input, mean, rstd, allow_cpu_scalar_tensors=False)
+    utils.check_same_device(
+        grad_output, input, mean, rstd, allow_cpu_scalar_tensors=False
+    )
     utils.check_same_shape(input, grad_output, allow_cpu_scalar_tensors=False)
     utils.check_same_shape(mean, rstd, allow_cpu_scalar_tensors=False)
     assert input.numel() == N * C * HxW
@@ -905,7 +907,10 @@ def native_group_norm_backward(
         )
         d_input = d_input.reshape(input.shape).to(input.dtype)
     if output_mask[1]:
-        d_gamma = ((ds.view(N, group, cpg) - db.view(N, group, cpg) * mean.unsqueeze(-1)) * rstd.unsqueeze(-1)).reshape(C)
+        d_gamma = (
+            (ds.view(N, group, cpg) - db.view(N, group, cpg) * mean.unsqueeze(-1))
+            * rstd.unsqueeze(-1)
+        ).reshape(C)
     if output_mask[2]:
         d_bias = db.sum(dim=[0])
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -904,9 +904,9 @@ def native_group_norm_backward(
         )
         d_input = d_input.reshape(input.shape).to(input.dtype)
     if output_mask[1]:
-        raise RuntimeError("Not implemented")
+        d_gamma = ((ds.view(N, group, cpg) - db.view(N, group, cpg) * mean.view(N, group, 1)) * rstd.view(N, group, 1)).reshape(C)
     if output_mask[2]:
-        raise RuntimeError("Not implemented")
+        d_bias = db.sum(dim=[0])
 
     return (d_input, d_gamma, d_bias)
 


### PR DESCRIPTION
Test plan: CI, i.e. `python3 test_decomp.py -v -k test_comprehensive_nn_functional_group_norm` plus:
```
#!/usr/bin/env python3.8
import torch

func = torch.ops.aten.native_group_norm_backward.default
decomp =  torch._decomp.decomposition_table[func]
for args in (
        (torch.rand(1, 6, 3), torch.rand(1, 6, 3), torch.rand(1, 2), torch.rand(1, 2), torch.rand(6), 1, 6, 3, 2, [True, True, True]),
        (torch.rand(64, 768, 7, 7), torch.rand(64, 768, 7, 7), torch.rand(64, 1), torch.rand(64, 1), torch.rand(768), 64, 768, 49, 1, [True, True, True])):
    nrc=func(*args)
    drc=decomp(*args)
    for i in range(len(nrc)):
       print(i, torch.max(nrc[i]-drc[i]))
    print(all(torch.allclose(x, y) for (x, y) in zip(nrc, drc)))
```

@diff-train-skip-merge