### PR TITLE
[Profiler] Record Optimizer param_groups and states

### DIFF
--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -157,6 +157,25 @@ void initPythonBindings(PyObject* module) {
       .def_readonly("total_allocated", &allocation_t::total_allocated_)
       .def_readonly("total_reserved", &allocation_t::total_reserved_);
 
+  py::class_<OptInfo>(m, "_OptInfo")
+      .def_property_readonly(
+          "param_addrs",
+          [](const OptInfo& s) {
+            py::list params_addrs;
+            for (auto& addr : s.params_addr_) {
+              params_addrs.append(reinterpret_cast<intptr_t>(addr));
+            }
+            return params_addrs;
+          })
+      .def_property_readonly("opt_state", [](const OptInfo& s) {
+        py::list states;
+        for (auto& a : s.opt_state_) {
+          states.append(
+              std::make_pair(a.first, reinterpret_cast<intptr_t>(a.second)));
+        }
+        return states;
+      });
+
   py::class_<NNModuleInfo>(m, "_NNModuleInfo")
       .def_property_readonly(
           "params",
@@ -172,6 +191,7 @@ void initPythonBindings(PyObject* module) {
           "cls_name", [](const NNModuleInfo& s) { return s.cls_name_.str(); });
 
   py::class_<ExtraFields<EventType::PyCall>>(m, "_ExtraFields_PyCall")
+      .def_readonly("opt", &ExtraFields<EventType::PyCall>::opt_)
       .def_readonly("module", &ExtraFields<EventType::PyCall>::module_)
       .def_readonly("callsite", &ExtraFields<EventType::PyCall>::callsite_)
       .def_readonly("caller", &ExtraFields<EventType::PyCall>::caller_)

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -114,6 +114,13 @@ class Optimizer(object):
                       "instance, capturable=True can impair performance, and you should set capturable=False.")
                 self._warned_capturable_if_run_uncaptured = True
 
+    def _hook_code(self):
+        """
+        no-op hook function for memory profiling.
+        This hook is called in profile_hook_step() to track Optimizer's state and param_groups
+        """
+        pass
+
     def _hook_for_profile(self):
         self._zero_grad_profile_name = "Optimizer.zero_grad#{}.zero_grad".format(self.__class__.__name__)
 
@@ -124,7 +131,9 @@ class Optimizer(object):
                 obj, *_ = args
                 profile_name = "Optimizer.step#{}.step".format(obj.__class__.__name__)
                 with torch.autograd.profiler.record_function(profile_name):
-                    return func(*args, **kwargs)
+                    out = func(*args, **kwargs)
+                    obj._hook_code()
+                    return out
             return wrapper
 
         hooked = getattr(self.__class__.step, "hooked", None)


### PR DESCRIPTION
Summary:
Record Optimizer's parameter groups and states for detaild memory profiling:
- add a no-op function inside hook on optimizer.py
- new CallType and Config specialization
- recoding with new ExtraField
- unit test case

Test Plan:
buck run mode/opt //caffe2/test:profiler -- -r test_opt

buck run mode/opt //caffe2/test:profiler

Differential Revision: D38728175

