### PR TITLE
disable c10::SymIntNode tests on mobile

### DIFF
--- a/c10/test/core/SymInt_test.cpp
+++ b/c10/test/core/SymInt_test.cpp
@@ -4,7 +4,7 @@
 #include <c10/core/SymIntNodeImpl.h>
 
 using namespace c10;
-
+#ifndef C10_MOBILE
 void check(int64_t value) {
   EXPECT_TRUE(SymInt::check_range(value));
   const auto i = SymInt(value);
@@ -29,3 +29,4 @@ TEST(SymIntTest, AddNode) {
 TEST(SymIntTest, CheckRange) {
   EXPECT_FALSE(SymInt::check_range(INT64_MIN));
 }
+#endif

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1446,6 +1446,7 @@ TEST(TestSymInt, AddSymbolicInt) {
   ASSERT_TRUE((a + b).expect_int() == 8);
 }
 
+#ifndef C10_MOBILE
 TEST(TestSymInt, TestIntrusive) {
   auto a = c10::make_intrusive<c10::SymIntNodeImpl>();
   auto b = c10::make_intrusive<c10::SymIntNodeImpl>();
@@ -1520,6 +1521,7 @@ TEST(TestSymInt, TestSymIntToSymIntNodeDispatch) {
     }
   }
 }
+#endif
 
 TEST(FallbackGraphsTest, Basic) {
   auto x = at::randn({1}, at::kCPU);

--- a/test/cpp/lazy/test_lazy_ops.cpp
+++ b/test/cpp/lazy/test_lazy_ops.cpp
@@ -84,6 +84,7 @@ static inline at::DeviceType DefaultDevice() {
 
 } // namespace
 
+#ifndef C10_MOBILE
 TEST(LazyDynamicOpsTest, NarrowCopy) {
   auto x = torch::rand({5, 10, 10}).to(kLazy);
   const size_t Y_DIM = 3;
@@ -110,6 +111,7 @@ TEST(LazyDynamicOpsTest, NarrowCopyViaSymSizes) {
   AllClose(z.cpu(), zc);
   FLAGS_ltc_enable_symbolic_shapes = false;
 }
+#endif
 
 TEST_F(LazyOpsTest, TestScalarTensor) {
   torch::Tensor scalar_tensor = torch::scalar_tensor(


### PR DESCRIPTION
This fixes c++ tests' breaks where we were passing pointers and expected `is_symbolic` to return `true`
