### PR TITLE
[nnapi] remove unused field 'order_' in nnapi.h

### DIFF
--- a/caffe2/mobile/contrib/nnapi/nnapi.h
+++ b/caffe2/mobile/contrib/nnapi/nnapi.h
@@ -21,8 +21,7 @@ class NNApi {
       const NetDef& run_net,
       Workspace* ws = nullptr,
       const PreferenceCode pref = ANEURALNETWORKS_PREFER_SUSTAINED_SPEED)
-      : order_(StorageOrder::NHWC),
-        preference_(pref),
+      : preference_(pref),
         run_net_(run_net),
         ws_(ws) {
     if (!loadNNApiLibrary()) {
@@ -43,7 +42,6 @@ class NNApi {
   ANeuralNetworksCompilation* compilation_{nullptr};
   ANeuralNetworksExecution* run_{nullptr};
   ANeuralNetworksEvent* run_end_{nullptr};
-  StorageOrder order_;
   PreferenceCode preference_;
   NetDef run_net_;
   Workspace ws_;


### PR DESCRIPTION
Summary: This fixes the build

Test Plan: `buck build //xplat/caffe2:nnapi_benchmarkAndroid`

Reviewed By: salilsdesai

Differential Revision: D38924916

