### PR TITLE
Add support to traverse all python collection objects

### DIFF
--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -153,9 +153,10 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
         If this doesn't cover your custom DataPipe's use case, consider writing custom methods for
         `__getstate__` and `__setstate__`, or use `pickle.dumps` for serialization.
         """
+        state = self.__dict__
         if IterDataPipe.getstate_hook is not None:
-            return IterDataPipe.getstate_hook(self)
-        return self.__dict__
+            return IterDataPipe.getstate_hook(state)
+        return state
 
     def __reduce_ex__(self, *args, **kwargs):
         if IterDataPipe.reduce_ex_hook is not None:
@@ -275,9 +276,10 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
         If this doesn't cover your custom DataPipe's use case, consider writing custom methods for
         `__getstate__` and `__setstate__`, or use `pickle.dumps` for serialization.
         """
+        state = self.__dict__
         if MapDataPipe.getstate_hook is not None:
-            return MapDataPipe.getstate_hook(self)
-        return self.__dict__
+            return MapDataPipe.getstate_hook(state)
+        return state
 
     def __reduce_ex__(self, *args, **kwargs):
         if MapDataPipe.reduce_ex_hook is not None:

--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -149,8 +149,6 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
             self._seed = None
 
     def __getstate__(self):
-        if IterDataPipe.getstate_hook is not None:
-            return IterDataPipe.getstate_hook(self)
         state = (
             self.datapipe,
             self.buffer_size,
@@ -161,6 +159,8 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
             self._valid_iterator_id,
             self._number_of_samples_yielded,
         )
+        if IterDataPipe.getstate_hook is not None:
+            return IterDataPipe.getstate_hook(state)
         return state
 
     def __setstate__(self, state):

--- a/torch/utils/data/datapipes/iter/combining.py
+++ b/torch/utils/data/datapipes/iter/combining.py
@@ -168,9 +168,6 @@ class _ForkerIterDataPipe(IterDataPipe):
         self.end_ptr = None
 
     def __getstate__(self):
-        if IterDataPipe.getstate_hook is not None:
-            return IterDataPipe.getstate_hook(self)
-
         state = (
             self.main_datapipe,
             self.num_instances,
@@ -178,6 +175,8 @@ class _ForkerIterDataPipe(IterDataPipe):
             self._valid_iterator_id,
             self._number_of_samples_yielded,
         )
+        if IterDataPipe.getstate_hook is not None:
+            return IterDataPipe.getstate_hook(state)
         return state
 
     def __setstate__(self, state):
@@ -401,9 +400,6 @@ class _DemultiplexerIterDataPipe(IterDataPipe):
         self.main_datapipe_exhausted = False
 
     def __getstate__(self):
-        if IterDataPipe.getstate_hook is not None:
-            return IterDataPipe.getstate_hook(self)
-
         state = (
             self.main_datapipe,
             self.num_instances,
@@ -413,6 +409,8 @@ class _DemultiplexerIterDataPipe(IterDataPipe):
             self._valid_iterator_id,
             self._number_of_samples_yielded,
         )
+        if IterDataPipe.getstate_hook is not None:
+            return IterDataPipe.getstate_hook(state)
         return state
 
     def __setstate__(self, state):
@@ -486,15 +484,14 @@ class MultiplexerIterDataPipe(IterDataPipe):
         self.buffer = []
 
     def __getstate__(self):
-        if IterDataPipe.getstate_hook is not None:
-            return IterDataPipe.getstate_hook(self)
-
         state = (
             self.datapipes,
             self.length,
             self._valid_iterator_id,
             self._number_of_samples_yielded,
         )
+        if IterDataPipe.getstate_hook is not None:
+            return IterDataPipe.getstate_hook(state)
         return state
 
     def __setstate__(self, state):

--- a/torch/utils/data/datapipes/iter/grouping.py
+++ b/torch/utils/data/datapipes/iter/grouping.py
@@ -283,8 +283,6 @@ class GrouperIterDataPipe(IterDataPipe[DataChunk]):
         self.buffer_elements = defaultdict(list)
 
     def __getstate__(self):
-        if IterDataPipe.getstate_hook is not None:
-            return IterDataPipe.getstate_hook(self)
         state = (
             self.datapipe,
             self.group_key_fn,
@@ -296,6 +294,8 @@ class GrouperIterDataPipe(IterDataPipe[DataChunk]):
             self._valid_iterator_id,
             self._number_of_samples_yielded,
         )
+        if IterDataPipe.getstate_hook is not None:
+            return IterDataPipe.getstate_hook(state)
         return state
 
     def __setstate__(self, state):

--- a/torch/utils/data/datapipes/map/combinatorics.py
+++ b/torch/utils/data/datapipes/map/combinatorics.py
@@ -93,8 +93,6 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         return len(self.datapipe)
 
     def __getstate__(self):
-        if IterDataPipe.getstate_hook is not None:
-            return IterDataPipe.getstate_hook(self)
         state = (
             self.datapipe,
             self.indices,
@@ -105,6 +103,8 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
             self._valid_iterator_id,
             self._number_of_samples_yielded,
         )
+        if IterDataPipe.getstate_hook is not None:
+            return IterDataPipe.getstate_hook(state)
         return state
 
     def __setstate__(self, state):

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -1,17 +1,18 @@
 import io
 import pickle
+import warnings
+
+from collections.abc import Collection
+from typing import Dict, List, Optional, Set, Tuple, Type, Union
 
 from torch.utils.data import IterDataPipe, MapDataPipe
 from torch.utils.data._utils.serialization import DILL_AVAILABLE
 
-from typing import Dict, List, Set, Tuple, Type, Union
 
 __all__ = ["traverse"]
 
 DataPipe = Union[IterDataPipe, MapDataPipe]
 DataPipeGraph = Dict[int, Tuple[DataPipe, "DataPipeGraph"]]  # type: ignore[misc]
-
-reduce_ex_hook = None
 
 
 def _stub_unpickler():
@@ -28,16 +29,22 @@ def _list_connected_datapipes(scan_obj: DataPipe, only_datapipe: bool, cache: Se
     else:
         d = None
 
-    def stub_pickler(obj):
-        return _stub_unpickler, ()
-
     captured_connections = []
 
-    def getstate_hook(obj):
-        state = {}
-        for k, v in obj.__dict__.items():
-            if isinstance(v, (IterDataPipe, MapDataPipe, tuple)):
-                state[k] = v
+    def getstate_hook(ori_state):
+        state = None
+        if isinstance(ori_state, dict):
+            state = {}  # type: ignore[assignment]
+            for k, v in ori_state.items():
+                if isinstance(v, (IterDataPipe, MapDataPipe, Collection)):
+                    state[k] = v  # type: ignore[attr-defined]
+        elif isinstance(ori_state, (tuple, list)):
+            state = []  # type: ignore[assignment]
+            for v in ori_state:
+                if isinstance(v, (IterDataPipe, MapDataPipe, Collection)):
+                    state.append(v)  # type: ignore[attr-defined]
+        elif isinstance(ori_state, (IterDataPipe, MapDataPipe, Collection)):
+            state = ori_state  # type: ignore[assignment]
         return state
 
     def reduce_hook(obj):
@@ -45,6 +52,7 @@ def _list_connected_datapipes(scan_obj: DataPipe, only_datapipe: bool, cache: Se
             raise NotImplementedError
         else:
             captured_connections.append(obj)
+            # Adding id to remove duplicate DataPipe serialized at the same level
             cache.add(id(obj))
             return _stub_unpickler, ()
 
@@ -73,7 +81,27 @@ def _list_connected_datapipes(scan_obj: DataPipe, only_datapipe: bool, cache: Se
     return captured_connections
 
 
-def traverse(datapipe: DataPipe, only_datapipe: bool = False) -> DataPipeGraph:
+def traverse(datapipe: DataPipe, only_datapipe: Optional[bool] = None) -> DataPipeGraph:
+    r"""
+    Traverse the DataPipes and their attributes to extract the DataPipe graph. When
+    ``only_dataPipe`` is specified as ``True``, it would only look into the attribute
+    from each DataPipe that is either a DataPipe and a Python collection object such as
+    ``list``, ``tuple``, ``set`` and ``dict``.
+    Args:
+        datapipe: the end DataPipe of the graph
+        only_datapipe: If ``False`` (default), all attributes of each DataPipe are traversed.
+          This argument is deprecating and will be removed after the next release.
+    Returns:
+        A graph represented as a nested dictionary, where keys are ids of DataPipe instances
+        and values are tuples of DataPipe instance and the sub-graph
+    """
+    if only_datapipe is not None:
+        msg = "`only_datapipe` is deprecated from `traverse` function and will be removed after 1.13."
+        if not only_datapipe:
+            msg += "And, default value will be changed to `only_datapipe=True`"
+        warnings.warn(msg, FutureWarning)
+    else:
+        only_datapipe = False
     cache: Set[int] = set()
     return _traverse_helper(datapipe, only_datapipe, cache)
 
@@ -87,6 +115,7 @@ def _traverse_helper(datapipe: DataPipe, only_datapipe: bool, cache: Set[int]) -
     if dp_id in cache:
         return {}
     cache.add(dp_id)
+    # Using cache.copy() here is to prevent the same DataPipe pollutes the cache on different paths
     items = _list_connected_datapipes(datapipe, only_datapipe, cache.copy())
     d: DataPipeGraph = {dp_id: (datapipe, {})}
     for item in items:


### PR DESCRIPTION
Fixes https://github.com/pytorch/data/issues/752


This PR makes `traverse` function supporting more collections data structures from Python. The `getstate_hook` will be invoked after custom `__getstate__` function. This would guarantee that `traverse` function will be working as long as the `DataPipe` is working properly with multiprocessing.