### PR TITLE
Remove guards from Python stack tracing OD flow

### DIFF
--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -18,24 +18,14 @@ class LibKinetoClient : public libkineto::ClientInterface {
     reportInputShapes_ = setupOpInputsCollection;
   }
 
-#ifdef USE_KINETO_MIN_CHANGE
   void start(bool withStack) override {
-    ProfilerConfig cfg {
-      ProfilerState::KINETO_ONDEMAND,
-          /*report_input_shapes=*/reportInputShapes_,
-          /*profile_memory=*/false,
-          /*with_stack=*/withStack,
-#else
-  void start() override {
     ProfilerConfig cfg{
         ProfilerState::KINETO_ONDEMAND,
         /*report_input_shapes=*/reportInputShapes_,
         /*profile_memory=*/false,
-        /*with_stack=*/false,
-#endif
-          /*with_flops=*/false,
-          /*with_modules=*/false
-    };
+        /*with_stack=*/withStack,
+        /*with_flops=*/false,
+        /*with_modules=*/false};
     std::set<ActivityType> activities{ActivityType::CPU};
     std::unordered_set<at::RecordScope> scopes;
     scopes.insert(at::RecordScope::FUNCTION);


### PR DESCRIPTION
Summary:
Diff for removing #ifdef guard from Python stack tracing option on on-demand flow.
1. Point a new Kineto submodule to compile in CIs with kineto.submodule.txt
2. The new Kineto submodule has 'withStack' inside #ifdef USE_KINETO_MIN_CHANGE
3. This diff removed #ifdef from codes
4. but we still need another diff to deprecate 'USE_KINETO_MIN_CHANGE' from TARGETS and .bzl files.

Test Plan:
launch a python test case with the following command for on-demand flow:
echo -e "PYTHON_STACK_TRACE=true" > /tmp/scott_kineto.conf && dyno gputrace --gputrace_duration 300ms --gpuconf /tmp/scott_kineto.conf

Differential Revision: D38963630

