### PR TITLE
OpInfo: Add outputs_uninitialized property

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -582,7 +582,7 @@ class TestCommon(TestCase):
                 final_strides = _extract_strides(out)
                 final_ptrs = _extract_data_ptrs(out)
 
-                self.assertEqual(expected, out)
+                self.assertOutputsMatch(expected, out, op=op)
 
                 if compare_strides_and_data_ptrs:
                     stride_msg = "Strides are not the same! Original strides were {0} and strides are now {1}".format(
@@ -699,7 +699,7 @@ class TestCommon(TestCase):
                 op_out(out=out)
                 final_strides = _extract_strides(out)
                 final_ptrs = _extract_data_ptrs(out)
-                self.assertEqual(expected, out)
+                self.assertOutputsMatch(expected, out, op=op)
 
                 if compare_strides_and_data_ptrs:
                     stride_msg = "Strides are not the same! Original strides were {0} and strides are now {1}".format(
@@ -1030,6 +1030,9 @@ class TestCommon(TestCase):
     @ops(op_db, allowed_dtypes=(torch.bool,))
     @unittest.skipIf(TEST_WITH_UBSAN, "Test uses undefined behavior")
     def test_non_standard_bool_values(self, device, dtype, op):
+        if op.outputs_uninitialized:
+            self.skipTest('Cannot compare uninitialized data')
+
         # Test boolean values other than 0x00 and 0x01 (gh-54789)
         def convert_boolean_tensors(x):
             if not isinstance(x, torch.Tensor) or x.dtype != torch.bool:

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -697,7 +697,6 @@ class TensorLikePair(TensorMetaPair):
         expected: Any,
         *,
         id: Tuple[Any, ...] = (),
-        allow_subclasses: bool = True,
         rtol: Optional[float] = None,
         atol: Optional[float] = None,
         equal_nan: bool = False,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13498,6 +13498,7 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_like_fns,
            reference_inputs_func=reference_inputs_like_fns,
            supports_autograd=False,
+           outputs_uninitialized=True,
            skips=(
                # Empty tensor data is garbage so it's hard to make comparisons with it.
                DecorateInfo(unittest.skip("Skipped!"),
@@ -13519,7 +13520,6 @@ op_db: List[OpInfo] = [
                # Empty tensor data is garbage so it's hard to make comparisons with it.
                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_complex_half_reference_testing'),
                # Empty tensor data is garbage so it's hard to make comparisons with it.
-               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_non_standard_bool_values'),
                DecorateInfo(unittest.skip("Expected: empty_like is not comparable"), 'TestCompositeCompliance',
                             'test_operator'),
            )),
@@ -13608,6 +13608,7 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16, torch.chalf),
            supports_out=False,
            sample_inputs_func=sample_inputs_new_fns,
+           outputs_uninitialized=True,
            skips=(
                DecorateInfo(unittest.expectedFailure, "TestNormalizeOperators", "test_normalize_operator_exhaustive"),
                # Empty tensor data is garbage so it's hard to make comparisons with it.
@@ -13627,7 +13628,6 @@ op_db: List[OpInfo] = [
                # Empty tensor data is garbage so it's hard to make comparisons with it.
                DecorateInfo(unittest.skip("Skipped!"), 'TestCudaFuserOpInfo'),
                # Empty tensor data is garbage so it's hard to make comparisons with it.
-               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_non_standard_bool_values'),
                DecorateInfo(unittest.skip("Expected: new_empty is not comparable"), 'TestCompositeCompliance',
                             'test_operator'),
                DecorateInfo(unittest.skip("Expected: new_empty is not comparable"),
@@ -13640,6 +13640,7 @@ op_db: List[OpInfo] = [
            supports_out=False,
            sample_inputs_func=partial(sample_inputs_new_fns, is_strided=True),
            supports_autograd=False,
+           outputs_uninitialized=True,
            skips=(
                # FX failed to normalize op
                DecorateInfo(unittest.expectedFailure, "TestNormalizeOperators", "test_normalize_operator_exhaustive"),
@@ -13657,8 +13658,6 @@ op_db: List[OpInfo] = [
                             'TestMathBits', 'test_neg_view'),
                DecorateInfo(unittest.skip("Expected: new_empty_strided is not comparable"),
                             'TestMathBits', 'test_neg_conj_view'),
-               DecorateInfo(unittest.skip("Expected: new_empty_strided is not comparable"),
-                            'TestCommon', 'test_non_standard_bool_values'),
                DecorateInfo(unittest.skip("Expected: new_empty_strided is not comparable"),
                             'TestCommon', 'test_complex_half_reference_testing'),
                DecorateInfo(unittest.skip("Expected: new_empty_strided is not comparable"),
@@ -13686,6 +13685,7 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16, torch.chalf),
            sample_inputs_func=sample_inputs_empty,
            supports_autograd=False,
+           outputs_uninitialized=True,
            skips=(
                DecorateInfo(unittest.expectedFailure, "TestNormalizeOperators", "test_normalize_operator_exhaustive"),
                # Empty tensor data is garbage so it's hard to make comparisons with it.
@@ -13705,14 +13705,10 @@ op_db: List[OpInfo] = [
                # Empty tensor data is garbage so it's hard to make comparisons with it.
                DecorateInfo(unittest.skip("Skipped!"), 'TestCudaFuserOpInfo'),
                # Empty tensor data is garbage so it's hard to make comparisons with it.
-               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_non_standard_bool_values'),
                DecorateInfo(unittest.skip("Expected: empty is not comparable"), 'TestCompositeCompliance',
                             'test_operator'),
                # requires_grad doesn't exist in the jit schema
                DecorateInfo(unittest.expectedFailure, 'TestOperatorSignatures', 'test_get_torch_func_signature_exhaustive'),
-               DecorateInfo(unittest.skip("Expected: empty is not comparable"),
-                            'TestCommon',
-                            'test_out'),
                DecorateInfo(unittest.skip("Expected: empty is not comparable"),
                             'TestCommon',
                             'test_out_warning'),
@@ -17024,9 +17020,6 @@ python_ref_db = [
                          'test_python_ref_torch_fallback'),
             DecorateInfo(unittest.skip("Expected: empty is not comparable"),
                          'TestCommon',
-                         'test_out'),
-            DecorateInfo(unittest.skip("Expected: empty is not comparable"),
-                         'TestCommon',
                          'test_out_warning'),
             DecorateInfo(unittest.skip("Expected: empty is not comparable"),
                          'TestMathBits',
@@ -17052,9 +17045,6 @@ python_ref_db = [
             DecorateInfo(unittest.skip("Expected: empty is not comparable"),
                          'TestCommon',
                          'test_python_ref_torch_fallback'),
-            DecorateInfo(unittest.skip("Expected: empty is not comparable"),
-                         'TestCommon',
-                         'test_out'),
             DecorateInfo(unittest.skip("Expected: empty is not comparable"),
                          'TestCommon',
                          'test_out_warning'),
@@ -17093,9 +17083,6 @@ python_ref_db = [
             DecorateInfo(unittest.skip("Expected: empty is not comparable"),
                          'TestCommon',
                          'test_python_ref_torch_fallback'),
-            DecorateInfo(unittest.skip("Expected: empty is not comparable"),
-                         'TestCommon',
-                         'test_out'),
             DecorateInfo(unittest.skip("Expected: empty is not comparable"),
                          'TestCommon',
                          'test_out_warning'),

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -802,6 +802,9 @@ class OpInfo(object):
 
     is_factory_function: bool = False
 
+    # True if the tensor outputs have uninitialized memory, e.g. torch.empty
+    outputs_uninitialized: bool = False
+
     def __post_init__(self):
         self._original_opinfo_args = asdict(self).copy()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84087

Currently all empty-like functions manually skip lots of OpInfo tests
because their tensor ouputs are uninitialized and so can't be compared
with `assertEqual`. Instead, this adds an `assertOutputsMatch` method
which will check the `outputs_uninitialized` property and if it's set
it will only compare tensor meta-data as if the tensor was a
meta-device tensor.

To support the metadata-only comparison, I've split the
`TensorLikePair` class into `TensorMetaPair` for comparing attributes
and `TensorLikePair` which is derived from `TensorMetaPair` and adds
the value-comparisons.