### PR TITLE
Enable maxpool_2d in NNC

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -98,6 +98,7 @@ bool isSupported(Node* node) {
       "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
       "aten::softmax.int(Tensor self, int dim , ScalarType? dtype=None) -> Tensor",
       "aten::log_softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor",
+      "aten::max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor",
   };
   static const OperatorSet supported_misc_set{
       "aten::cat(Tensor[] tensors, int dim=0) -> Tensor",

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -245,6 +245,7 @@ std::unordered_map<std::string, std::string> ExtCallMemoryReuse::
       {"nnc_aten_quantized_mul_scalar", "nnc_aten_quantized_mul_scalar_out"},
       {"nnc_aten_max_red", "nnc_aten_max_red_out"},
       {"nnc_aten_conv1d", "nnc_aten_conv1d_out"},
+      {"nnc_aten_max_pool2d", "nnc_aten_max_pool2d_out"},
   };
 }
 

--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -1888,6 +1888,10 @@ int nnc_lowerings_lazy_registration() {
       {"aten::adaptive_avg_pool2d(Tensor self, int[2] output_size) -> (Tensor)"},
       computeAdaptiveAvgPool2d);
 
+  RegisterNNCLoweringsFunction aten_max_pool2d(
+      {"aten::max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor)"},
+      computeMaxPool2d);
+
   RegisterNNCLoweringsFunction aten_add(
       {"aten::add.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> (Tensor)",
        "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> (Tensor)"},

--- a/torch/csrc/jit/tensorexpr/operators/reduction.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/reduction.cpp
@@ -230,7 +230,7 @@ Tensor computeMaxPool2d(
   BufHandle ResultBuf = Buf::make(
       "max_pool2d",
       outputShape,
-      Dtype(*outputType),
+      dtype,
       c10::nullopt, // initializer
       ExprVectorToExprHandleVector(strides),
       qx_qscale,

--- a/torch/csrc/jit/tensorexpr/operators/reduction.h
+++ b/torch/csrc/jit/tensorexpr/operators/reduction.h
@@ -24,6 +24,12 @@ TORCH_API Tensor computeAdaptiveAvgPool2d(
     const std::vector<ExprHandle>& outputStrides,
     const c10::optional<ScalarType>& outputType,
     at::Device device);
+TORCH_API Tensor computeMaxPool2d(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const std::vector<ExprHandle>& outputStrides,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device);
 Tensor computeMax(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,


### PR DESCRIPTION
This PR implemented maxpool2d for NNC with external call.
 
- maxpool2d NNC lowering function implementation and lowering path enabling:
```
torch/csrc/jit/tensorexpr/operators/reduction.cpp
torch/csrc/jit/tensorexpr/operators/reduction.h
torch/csrc/jit/tensorexpr/lowerings.cpp
```

- maxpool2d NNC external call implementations for both default and out version
```
torch/csrc/jit/tensorexpr/external_functions.cpp
torch/csrc/jit/tensorexpr/codegen.cpp
```

- add into TE fuser reduce group
```
torch/csrc/jit/passes/tensorexpr_fuser.cpp
```

- Add related test case for quantization and non-quantization scenarios:
```
test/cpp/tensorexpr/test_quantization.cpp
```


cc @EikanWang @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10