### PR TITLE
[Profiler] Add quoted metadata API to remove empty trace cpu_op metadata

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -85,7 +85,7 @@ struct MetadataBase {
   }
 
   void addMetadata(const std::string& key, const std::string& value) {
-    if (kineto_activity_ && !value.empty()) {
+    if (kineto_activity_ && !value.empty() && value != "\"\"") {
       torch::profiler::impl::kineto::addMetadata(kineto_activity_, key, value);
     }
   }


### PR DESCRIPTION
Summary: The profiler utility function, stacksToStr, is quoting all metadata values, and therefore even empty metadata fields are being pushed into the trace files. Remove this and add an argument to use quoted metadata api provided by libkineto::GenericTraceActivity.

Test Plan:
Before, a trace file will dump extra empty fields for Module Hierarchy and Call Stack:
```
  {
    "ph": "X", "cat": "cpu_op", "name": "autograd::engine::evaluate_function: AddBackward0", "pid": 798015, "tid": 798264,
    "ts": 1661451887593736, "dur": 21,
    "args": {
      "Trace name": "PyTorch Profiler", "Trace iteration": 0,
      "External id": 513,
      "Profiler Event Index": 0, "Module Hierarchy": "", "Call stack": "", "Fwd thread id": 3, "Sequence number": 1, "ID": 139880536829952, "Parent ID": null
    }
  }
```
After, these fields will not be in the trace file anymore:
```
  {
    "ph": "X", "cat": "cpu_op", "name": "autograd::engine::evaluate_function: AddBackward0", "pid": 1482813, "tid": 1483069,
    "ts": 1661468912444365, "dur": 43,
    "args": {
      "Trace name": "PyTorch Profiler", "Trace iteration": 0,
      "External id": 513,
      "Profiler Event Index": 0, "Fwd thread id": 3, "Sequence number": 1, "ID": 139852271321088, "Parent ID": null
    }
  }
```
Also, with input tracking on, it looks correct compared to previous kineto observer:
```
  {
    "ph": "X", "cat": "cpu_op", "name": "aten::add_", "pid": 1572428, "tid": 1572776,
    "ts": 1661469920242309, "dur": 19,
    "args": {
      "Trace name": "PyTorch Profiler", "Trace iteration": 0,
      "External id": 531,
      "Profiler Event Index": 18, "Input Dims": [[256, 256], [256, 256], []], "Input type": ["float", "float", "Scalar"], "ID": 140023871647232, "Parent ID": 140023871646720
    }
  }
```

Differential Revision: D39041244

Pulled By: aaronenyeshi

