### PR TITLE
[AOT Autograd] Redirect named_parameters to original mod

### DIFF
--- a/functorch/functorch/_src/aot_autograd.py
+++ b/functorch/functorch/_src/aot_autograd.py
@@ -892,6 +892,7 @@ def aot_module_simplified(mod: nn.Module, *top_args, **top_kwargs) -> nn.Module:
             )
 
     forward.zero_grad = mod.zero_grad
+    forward.named_parameters = mod.named_parameters
     return forward
 
 


### PR DESCRIPTION
Helps in comparing accuracy.

@diff-train-skip-merge