### PR TITLE
fix is_namedtuple import to _is_namedtuple, silence deprecated warning 

### DIFF
--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -1,7 +1,9 @@
 import torch
 import torch.distributed as dist
 from torch.nn.parallel._functions import _get_stream
-from torch.nn.parallel.scatter_gather import _is_namedtuple
+from torch.nn.parallel.scatter_gather import (  # type: ignore[attr-defined]
+    _is_namedtuple,
+)
 from typing import Dict, Any, List
 
 __all__ = []  # type: ignore[var-annotated]

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -1,9 +1,7 @@
 import torch
 import torch.distributed as dist
 from torch.nn.parallel._functions import _get_stream
-from torch.nn.parallel.scatter_gather import (  # type: ignore[attr-defined]
-    _is_namedtuple
-)
+from torch.nn.parallel.scatter_gather import _is_namedtuple
 from typing import Dict, Any, List
 
 __all__ = []  # type: ignore[var-annotated]


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/84156

is_namedtuple was remapped to _is_namedtuple back in July per this related PR:
https://github.com/pytorch/pytorch/pull/81476

There is no more code referencing the older _is_namedtuple (per github search and running with it removed). 
However the import, which was apparently a short term cover fix, still remaps is_namedtuple to _is_namedtuple, and thus generates this warning (which can flood your console in multi-node as it's 1 per GPU).

This PR corrects the import to singularly import _is_namedtuple and thus remove the deprecated warning.
<img width="1276" alt="is_namedtuple_deprecated" src="https://user-images.githubusercontent.com/46302957/187004884-e70526f4-ee79-486f-bf72-545340368552.png">
