### PR TITLE
Give better error message when merge fails to find any rules

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -165,7 +165,7 @@ class TestGitHubPR(TestCase):
         "Tests that PR fails to read the merge rules"
         pr = GitHubPR("pytorch", "pytorch", 77700)
         repo = DummyGitRepo()
-        self.assertRaises(RuntimeError, lambda: find_matching_merge_rule(pr, repo))
+        self.assertRaisesRegex(RuntimeError, "testing", lambda: find_matching_merge_rule(pr, repo))
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
     @mock.patch('trymerge.read_merge_rules', side_effect=mocked_read_merge_rules)

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -132,7 +132,7 @@ def mocked_read_merge_rules(repo: Any, org: str, project: str) -> List[MergeRule
 
 
 def mocked_read_merge_rules_raise(repo: Any, org: str, project: str) -> List[MergeRule]:
-    raise FileNotFoundError("testing")
+    raise RuntimeError("testing")
 
 
 class DummyGitRepo(GitRepo):

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1017,8 +1017,8 @@ def find_matching_merge_rule(pr: GitHubPR,
 
     rules = read_merge_rules(repo, pr.org, pr.project)
     if not rules:
-        reject_reason = ("No matching merge rules found in merge_rules.yaml. " +
-                         "Please verify the file content to ensure there are a valid merge rule defined.")
+        reject_reason = ("No matching merge rule found in merge_rules.yaml. " +
+                         "Please verify the file content to ensure there are valid merge rules defined.")
         raise RuntimeError(reject_reason)
 
     #  Used to determine best rejection reason

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1013,7 +1013,7 @@ def find_matching_merge_rule(pr: GitHubPR,
         project=pr.project,
         labels=["module: ci"],
     )
-    reject_reason = (f"No rule found to match PR. Please [report]{issue_link} this issue to DevX team")
+    reject_reason = f"No rule found to match PR. Please [report]{issue_link} this issue to DevX team"
 
     rules = read_merge_rules(repo, pr.org, pr.project)
     if not rules:

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1018,7 +1018,7 @@ def find_matching_merge_rule(pr: GitHubPR,
 
     rules = read_merge_rules(repo, pr.org, pr.project)
     if not rules:
-        reject_reason = f"Rejecting the merge as no rule is defined for the repository in {MERGE_RULE_PATH}"
+        reject_reason = f"Rejecting the merge as no rules are defined for the repository in {MERGE_RULE_PATH}"
         raise RuntimeError(reject_reason)
 
     #  Used to determine best rejection reason

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -965,7 +965,7 @@ class MergeRule:
     mandatory_checks_name: Optional[List[str]]
 
 
-def get_new_issue_link(
+def gen_new_issue_link(
     org: str,
     project: str,
     labels: List[str],


### PR DESCRIPTION
Fixes #84147 and https://github.com/pytorch/test-infra/issues/421.

* If merge rule file is missing or fails to load for whatever reasons:

```
No rules find to match PR, please [report]{issue_link} this issue to DevX team.
```

* If the list of rules is empty:

```
Merges are not allowed into repository without a rules.
```

