### PR TITLE
[data utils] pin_memory returns list or tuple accurately

### DIFF
--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -61,8 +61,10 @@ def pin_memory(data, device=None):
             return {k: pin_memory(sample, device) for k, sample in data.items()}
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
         return type(data)(*(pin_memory(sample, device) for sample in data))
+    elif isinstance(data, list):
+        return [pin_memory(sample, device) for sample in data]
     elif isinstance(data, tuple):
-        return [pin_memory(sample, device) for sample in data]  # Backwards compatibility.
+        return (pin_memory(sample, device) for sample in data)  # Backwards compatibility.
     elif isinstance(data, collections.abc.Sequence):
         try:
             return type(data)([pin_memory(sample, device) for sample in data])  # type: ignore[call-arg]


### PR DESCRIPTION
Fixes #48419

#### Background

My data (node schema for a graph) comes in the format `NodeSchema(node_id='node_id', float_tensor_features=['embedding_features'], int_tensor_features=(), int_categorical_tensor_features=(), single_text_features=(), labels=(), set_name=None, node_type='node_type', sample_weight=None, other_columns=())`. 

When we pin it to memory, as part of our dataloader,  we find an issue: all our schema properties are changes from tuples to lists.
This is problematic as we sometimes have to do certain operations that will no longer work. e.g:

```
>>> ['b'] + ('a',)   # without fix
TypeError: can only concatenate list (not "tuple") to list
>>> tuple(['b']) + ('a',) # fixed
('b', 'a')
```
#### Issue

The type returned by the method is not the same as the type that goes in - tuples become lists.

#### Fix

Simply add another condition that catches the tuple and does the same thing but returning a tuple instead of a list.

