### PR TITLE
Fix `tensor.stride()` type hint

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -597,7 +597,7 @@ def gen_pyi(
                 "def size(self, dim: _int) -> _int: ...",
             ],
             "stride": [
-                "def stride(self) -> Tuple[_int]: ...",
+                "def stride(self) -> Tuple[_int, ...]: ...",
                 "def stride(self, _int) -> _int: ...",
             ],
             "new_ones": [

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -1273,7 +1273,7 @@ def _collapse_view_helper(
         strides = (1,)
     else:
         shape = a.shape  # type: ignore[assignment]
-        strides = a.stride()
+        strides = a.stride()  # type: ignore[assignment]
 
     utils.validate_idx(len(shape), start)
     utils.validate_exclusive_idx(len(shape), end)

--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -17,7 +17,7 @@ class TensorMetadata(NamedTuple):
     shape : torch.Size
     dtype : torch.dtype
     requires_grad : bool
-    stride : Tuple[int]
+    stride : Tuple[int, ...]
     memory_format : Optional[torch.memory_format]
 
     # Quantization metadata


### PR DESCRIPTION
`tensor.stride()` now hints at tuple of variable length instead of tuple with constant length of 1

Fixes #84176
