### PR TITLE
Optimize the performance of binary_kernel_reduce for welford

### DIFF
--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -169,7 +169,14 @@ struct inner_reduce {
 template <typename T, typename acc_t>
 struct inner_reduce<T, acc_t, true> {
   static inline void call(T * data, int64_t size, acc_t & acc) {
-    std::tie(acc.mean, acc.m2) = utils::RowwiseMoments(data, size);
+    double new_mean = 0, new_m2 = 0;
+    std::tie(new_mean, new_m2) = RowwiseMoments(data, size);
+    new_m2 = new_m2 * size;
+    double delta = new_mean - acc.mean;
+    double new_count = acc.nf + size;
+    double nb_over_n = double(size) / new_count;
+    acc.mean = acc.mean + delta * nb_over_n;
+    acc.m2 = acc.m2 + new_m2 + delta * delta * acc.nf * nb_over_n;
     acc.n += size;
     acc.nf += size;
   }

--- a/aten/src/ATen/native/cpu/group_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/group_norm_kernel.cpp
@@ -52,13 +52,15 @@ void GroupNormKernelImplInternal(
   const bool beta_null = beta_data == nullptr;
   const int64_t inner_size = D * HxW;
 
+  using T_ACC = vec::vec_scalar_t<T>;
+
   at::parallel_for(0, N * G, 1, [&](int64_t start, int64_t end) {
     for (const auto i : c10::irange(start, end)) {
       const T* X_ptr = X_data + i * inner_size;
-      T mean_val;
-      T rstd_val;
-      std::tie(mean_val, rstd_val) = utils::RowwiseMoments(X_ptr, inner_size);
-      rstd_val = T(1) / std::sqrt(std::max(rstd_val, T(0)) + eps);
+      T_ACC mean_val;
+      T_ACC rstd_val;
+      std::tie(mean_val, rstd_val) = RowwiseMoments(X_ptr, inner_size);
+      rstd_val = T_ACC(1) / std::sqrt(std::max(rstd_val, T_ACC(0)) + eps);
       if (gamma_null && beta_null) {
         T* Y_ptr = Y_data + i * inner_size;
         for (const auto j : c10::irange(inner_size)) {
@@ -68,8 +70,8 @@ void GroupNormKernelImplInternal(
         const int64_t g = i % G;
         for (const auto j : c10::irange(D)) {
           const int64_t c = g * D + j;
-          const T scale = rstd_val * (gamma_null ? T(1) : gamma_data[c]);
-          const T bias = -scale * mean_val + (beta_null ? T(0) : beta_data[c]);
+          const T_ACC scale = rstd_val * (gamma_null ? T(1) : gamma_data[c]);
+          const T_ACC bias = -scale * mean_val + (beta_null ? T(0) : beta_data[c]);
           X_ptr = X_data + (i * D + j) * HxW;
           T* Y_ptr = Y_data + (i * D + j) * HxW;
           for (const auto k : c10::irange(HxW)) {

--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -53,9 +53,9 @@ void LayerNormKernelImplInternal(
     for (const auto i : c10::irange(start, end)) {
       const T* X_ptr = X_data + i * N;
       T* Y_ptr = Y_data + i * N;
-      T mean_val;
-      T rstd_val;
-      std::tie(mean_val, rstd_val) = utils::RowwiseMoments(X_ptr, N);
+      T_ACC mean_val;
+      T_ACC rstd_val;
+      std::tie(mean_val, rstd_val) = RowwiseMoments(X_ptr, N);
       rstd_val = T(1) / std::sqrt(rstd_val + eps);
       const T_ACC scale = rstd_val;
       const T_ACC bias = -rstd_val * mean_val;

--- a/aten/src/ATen/native/cpu/moments_utils.h
+++ b/aten/src/ATen/native/cpu/moments_utils.h
@@ -8,13 +8,16 @@
 
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec/vec.h>
+#include <ATen/cpu/vec/functional.h>
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/SmallVector.h>
 #include <c10/util/irange.h>
 
 namespace at {
 namespace native {
-namespace utils {
+inline namespace CPU_CAPABILITY {
+
+template<typename T> using acc_t = vec::vec_scalar_t<T>;
 
 constexpr int64_t kChunkSize = 16;
 
@@ -52,20 +55,71 @@ C10_ALWAYS_INLINE void AddMomentsVec(
   m0 = n;
 }
 
+template <typename T>
+inline void UpdateMomentsVec(
+    int64_t m0,
+    const T* X_ptr,
+    const std::array<vec::Vectorized<acc_t<T>>, kChunkSize>& c_vecs,
+    int64_t& m0_stk0,
+    vec::Vectorized<acc_t<T>>& m1_stk0,
+    vec::Vectorized<acc_t<T>>& m2_stk0) {
+  using Vec = vec::Vectorized<acc_t<T>>;
+  Vec m1_vec(0);
+  Vec m2_vec(0);
+  for (const auto j : c10::irange(m0)) {
+    const Vec x_vec = Vec::loadu(X_ptr + j * Vec::size());
+    const Vec delta_vec = x_vec - m1_vec;
+    m1_vec += delta_vec * c_vecs[j];
+    m2_vec += delta_vec * (x_vec - m1_vec);
+  }
+  AddMomentsVec(m0, m1_vec, m2_vec, m0_stk0, m1_stk0, m2_stk0);
+}
+
+// each bfloat16 vector will be converted to two float vectors,
+// and accumulated successively on m1_stk0/m2_stk0.
+template <>
+inline void UpdateMomentsVec<BFloat16>(
+    int64_t m0,
+    const BFloat16* X_ptr,
+    const std::array<vec::Vectorized<float>, kChunkSize>& c_vecs,
+    int64_t& m0_stk0,
+    vec::Vectorized<float>& m1_stk0,
+    vec::Vectorized<float>& m2_stk0) {
+  using bVec = vec::Vectorized<BFloat16>;
+  using fVec = vec::Vectorized<float>;
+  fVec m1_fvec0(0), m1_fvec1(0);
+  fVec m2_fvec0(0), m2_fvec1(0);
+  for (const auto j : c10::irange(m0)) {
+    const bVec x_bvec = bVec::loadu(X_ptr + j * bVec::size());
+    fVec x_fvec0, x_fvec1;
+    std::tie(x_fvec0, x_fvec1) = convert_bfloat16_float(x_bvec);
+    const fVec delta_fvec0 = x_fvec0 - m1_fvec0;
+    const fVec delta_fvec1 = x_fvec1 - m1_fvec1;
+    m1_fvec0 += delta_fvec0 * c_vecs[j];
+    m1_fvec1 += delta_fvec1 * c_vecs[j];
+    m2_fvec0 += delta_fvec0 * (x_fvec0 - m1_fvec0);
+    m2_fvec1 += delta_fvec1 * (x_fvec1 - m1_fvec1);
+  }
+  AddMomentsVec(m0, m1_fvec0, m2_fvec0, m0_stk0, m1_stk0, m2_stk0);
+  AddMomentsVec(m0, m1_fvec1, m2_fvec1, m0_stk0, m1_stk0, m2_stk0);
+}
+
 // Compute rowwise moments by Welford algorithm and cascade sum to improve
 // numerical stability.
 // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
 // https://en.wikipedia.org/wiki/Pairwise_summation
 template <typename T, int64_t kMaxDepth>
-std::pair<T, T> RowwiseMomentsImpl(const T* X, int64_t N, int64_t ddof = 0) {
-  using Vec = vec::Vectorized<T>;
+std::pair<acc_t<T>, acc_t<T>> RowwiseMomentsImpl(const T* X, int64_t N, int64_t ddof = 0) {
+  using T_ACC = acc_t<T>;
 
-  constexpr int64_t kVecSize = Vec::size();
+  constexpr int64_t kVecSize = vec::Vectorized<T>::size();
+  constexpr int64_t kAccVecSize = vec::Vectorized<T_ACC>::size();
   const int64_t n = N / kVecSize;
   const int64_t m = divup(n, kChunkSize);
-  const int64_t depth = CeilLog2(m);
+  const int64_t depth = utils::CeilLog2(m);
 
-  const Vec kZeroVec(T(0));
+  using Vec = vec::Vectorized<T_ACC>;
+  const Vec kZeroVec(T_ACC(0));
   c10::SmallVector<int64_t, kMaxDepth> m0_stk(depth, 0);
   c10::SmallVector<Vec, kMaxDepth> m1_stk(depth, kZeroVec);
   c10::SmallVector<Vec, kMaxDepth> m2_stk(depth, kZeroVec);
@@ -76,19 +130,12 @@ std::pair<T, T> RowwiseMomentsImpl(const T* X, int64_t N, int64_t ddof = 0) {
     static std::array<Vec, kChunkSize> c_vecs = ([]() {
       std::array<Vec, kChunkSize> result;
       for (const auto i : c10::irange(kChunkSize)) {
-        result[i] = Vec(T(1) / static_cast<T>(i + 1));
+        result[i] = Vec(T_ACC(1) / static_cast<T_ACC>(i + 1));
       }
       return result;
     })();
-    Vec m1_vec(0);
-    Vec m2_vec(0);
-    for (const auto j : c10::irange(m0)) {
-      const Vec x_vec = Vec::loadu(X_ptr + j * kVecSize);
-      const Vec delta_vec = x_vec - m1_vec;
-      m1_vec += delta_vec * c_vecs[j];
-      m2_vec += delta_vec * (x_vec - m1_vec);
-    }
-    AddMomentsVec(m0, m1_vec, m2_vec, m0_stk[0], m1_stk[0], m2_stk[0]);
+    UpdateMomentsVec(m0, X_ptr, c_vecs, m0_stk[0], m1_stk[0], m2_stk[0]);
+
     int64_t mask = i + 1;
     for (int64_t j = 1; j < depth && (mask & 1) == 0; ++j) {
       AddMomentsVec(
@@ -109,34 +156,37 @@ std::pair<T, T> RowwiseMomentsImpl(const T* X, int64_t N, int64_t ddof = 0) {
         m0_stk[i], m1_stk[i], m2_stk[i], m0_stk[0], m1_stk[0], m2_stk[0]);
   }
 
-  std::array<T, kVecSize> m1_arr{};
-  std::array<T, kVecSize> m2_arr{};
+  std::array<T_ACC, kAccVecSize> m1_arr{};
+  std::array<T_ACC, kAccVecSize> m2_arr{};
   m1_stk[0].store(m1_arr.data());
   m2_stk[0].store(m2_arr.data());
 
   int64_t m0 = 0;
-  T m1 = 0;
-  T m2 = 0;
+  T_ACC m1 = 0;
+  T_ACC m2 = 0;
   for (int64_t i = n * kVecSize; i < N; ++i) {
-    const T delta = X[i] - m1;
+    T_ACC x = static_cast<T_ACC>(X[i]);
+    const T_ACC delta = x - m1;
     ++m0;
-    m1 += delta / static_cast<T>(m0);
-    m2 += delta * (X[i] - m1);
+    m1 += delta / static_cast<T_ACC>(m0);
+    m2 += delta * (x - m1);
   }
-  for (const auto i : c10::irange(kVecSize)) {
-    AddMoments(n, m1_arr[i], m2_arr[i], m0, m1, m2);
+  // for BFloat16, each vector in m1_arr/m2_arr holds 2*n accumulated result
+  int64_t m0_add = n * kVecSize / kAccVecSize;
+  for (const auto i : c10::irange(kAccVecSize)) {
+    AddMoments(m0_add, m1_arr[i], m2_arr[i], m0, m1, m2);
   }
 
-  return std::make_pair(m1, m2 / static_cast<T>(N - ddof));
+  return std::make_pair(m1, m2 / static_cast<T_ACC>(N - ddof));
 }
 
 template <typename T>
-std::pair<T, T> RowwiseMoments(const T* X, int64_t N, int64_t ddof = 0) {
+std::pair<acc_t<T>, acc_t<T>> RowwiseMoments(const T* X, int64_t N, int64_t ddof = 0) {
   using Vec = vec::Vectorized<T>;
   constexpr int64_t kVecSize = Vec::size();
   const int64_t n = N / kVecSize;
   const int64_t m = divup(n, kChunkSize);
-  const int64_t depth = CeilLog2(m);
+  const int64_t depth = utils::CeilLog2(m);
   if (depth <= 4) {
     return RowwiseMomentsImpl<T, 4>(X, N, ddof);
   } else if (depth <= 8) {
@@ -150,6 +200,6 @@ std::pair<T, T> RowwiseMoments(const T* X, int64_t N, int64_t ddof = 0) {
   }
 }
 
-} // namespace utils
+} // namespace
 } // namespace native
 } // namespace at

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1795,6 +1795,20 @@ class TestReductions(TestCase):
                 with self.assertRaisesRegex(RuntimeError, e_msg):
                     op(x, dim=dim)
 
+    @onlyCPU
+    def test_var_bfloat16(self, device):
+        input_bf = torch.randn(2, 10, 10, dtype=torch.bfloat16, device=device)
+        input_f = input_bf.float()
+        out_f = input_f.var()
+        out_bf = input_bf.var()
+        self.assertEqual(out_f, out_bf.float(), atol=0.01, rtol=0.01)
+        out_f = input_f.var(1)
+        out_bf = input_bf.var(1)
+        self.assertEqual(out_f, out_bf.float(), atol=0.01, rtol=0.01)
+        out_f = input_f.var(1)
+        out_bf = input_bf.var(1)
+        self.assertEqual(out_f, out_bf.float(), atol=0.01, rtol=0.01)
+
     # TODO: update this test to comapre against NumPy
     @onlyCUDA
     def test_var(self, device):


### PR DESCRIPTION
Optimize the performance of binary_kernel_reduce for welford using RowwiseMoments.
This PR depends on the optimization of RowwiseMoments https://github.com/pytorch/pytorch/pull/84405 and https://github.com/pytorch/pytorch/pull/84405