### PR TITLE
[AIBench] Pass Vulkan Profiling Data to Kineto Profiler in lite_predictor_benchmark

### DIFF
--- a/aten/src/ATen/native/vulkan/api/QueryPool.cpp
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.cpp
@@ -187,6 +187,12 @@ uint64_t QueryPool::get_total_op_ns(std::string op_name) {
   return sum;
 }
 
+void QueryPool::shader_log_for_each(
+    std::function<void(const ShaderDuration&)> fn) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::for_each(shader_log_.begin(), shader_log_.end(), fn);
+}
+
 } // namespace api
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/native/vulkan/api/QueryPool.h
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.h
@@ -80,6 +80,7 @@ class QueryPool final {
   void extract_results();
   void print_results();
   uint64_t get_total_op_ns(std::string op_name);
+  void shader_log_for_each(std::function<void(const ShaderDuration&)> fn);
 };
 
 } // namespace api


### PR DESCRIPTION
Summary: This lets us more easily analyze operator-level performance of models run with Vulkan

Test Plan: Generated chrometrace with vulkan events recorded

Reviewed By: kimishpatel

Differential Revision: D38280587

