### PR TITLE
Introduce TORCH_DISABLE_GPU_ASSERTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,7 @@ if(NOT USE_XNNPACK AND CMAKE_VERSION VERSION_LESS ${XNNPACK_MIN_CMAKE_VER})
 endif()
 option(USE_ZMQ "Use ZMQ" OFF)
 option(USE_ZSTD "Use ZSTD" OFF)
+option(TORCH_ENABLE_GPU_ASSERTS "Enabled GPU asserts by default" ON)
 # Ensure that an ITT build is the default for x86 CPUs
 cmake_dependent_option(
   USE_ITT "Use Intel(R) VTune Profiler ITT functionality" ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,7 @@ if(NOT USE_XNNPACK AND CMAKE_VERSION VERSION_LESS ${XNNPACK_MIN_CMAKE_VER})
 endif()
 option(USE_ZMQ "Use ZMQ" OFF)
 option(USE_ZSTD "Use ZSTD" OFF)
-option(TORCH_ENABLE_GPU_ASSERTS "Enabled GPU asserts by default" ON)
+option(TORCH_DISABLE_GPU_ASSERTS "Disable GPU asserts by default" OFF)
 # Ensure that an ITT build is the default for x86 CPUs
 cmake_dependent_option(
   USE_ITT "Use Intel(R) VTune Profiler ITT functionality" ON

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -328,7 +328,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 // code that would otherwise be suppressed when building Release.
 #if defined(__ANDROID__) || defined(__APPLE__) ||  \
     (defined(USE_ROCM) && ROCM_VERSION < 40100) || \
-    (defined(USE_ROCM) && defined(ROCM_DISABLE_GPU_ASSERTS))
+    (!defined(PYTORCH_ENABLE_KERNEL_ASSERTS))
 // Those platforms do not support assert()
 #define CUDA_KERNEL_ASSERT(cond)
 #define SYCL_KERNEL_ASSERT(cond)
@@ -368,7 +368,7 @@ extern SYCL_EXTERNAL void __assert_fail(
     unsigned int line,
     const char* func);
 #else // __SYCL_DEVICE_ONLY__
-#if (defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__)))
+#if (defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__)) && defined(PYTORCH_ENABLE_KERNEL_ASSERTS))
 // CUDA supports __assert_fail function which are common for both device
 // and host side code.
 __host__ __device__
@@ -386,7 +386,7 @@ __host__ __device__
         const char* function) throw() __attribute__((__noreturn__));
 
 #if (defined(__HIP_ARCH__) || defined(__HIP__)) && \
-    !defined(ROCM_DISABLE_GPU_ASSERTS)
+    && defined(PYTORCH_ENABLE_KERNEL_ASSERTS)
 // ROCm supports __assert_fail only as a device side function.
 __device__ __attribute__((noinline)) __attribute__((weak)) void __assert_fail(
     const char* assertion,

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -369,7 +369,7 @@ extern SYCL_EXTERNAL void __assert_fail(
 #else // __SYCL_DEVICE_ONLY__
 #if (                                                                       \
     defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__)) && \
-    defined(TORCH_ENABLE_GPU_ASSERTS))
+    !defined(TORCH_DISABLE_GPU_ASSERTS))
 // CUDA supports __assert_fail function which are common for both device
 // and host side code.
 __host__ __device__
@@ -387,7 +387,7 @@ __host__ __device__
         const char* function) throw() __attribute__((__noreturn__));
 
 #if (defined(__HIP_ARCH__) || defined(__HIP__)) && \
-    defined(TORCH_ENABLE_GPU_ASSERTS)
+    !defined(TORCH_DISABLE_GPU_ASSERTS)
 // ROCm supports __assert_fail only as a device side function.
 __device__ __attribute__((noinline)) __attribute__((weak)) void __assert_fail(
     const char* assertion,

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -328,7 +328,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 // code that would otherwise be suppressed when building Release.
 #if defined(__ANDROID__) || defined(__APPLE__) ||  \
     (defined(USE_ROCM) && ROCM_VERSION < 40100) || \
-    (!defined(PYTORCH_ENABLE_KERNEL_ASSERTS))
+    (!defined(TORCH_ENABLE_GPU_ASSERTS))
 // Those platforms do not support assert()
 #define CUDA_KERNEL_ASSERT(cond)
 #define SYCL_KERNEL_ASSERT(cond)
@@ -368,7 +368,8 @@ extern SYCL_EXTERNAL void __assert_fail(
     unsigned int line,
     const char* func);
 #else // __SYCL_DEVICE_ONLY__
-#if (defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__)) && defined(PYTORCH_ENABLE_KERNEL_ASSERTS))
+#if (defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__)) && \
+    defined(TORCH_ENABLE_GPU_ASSERTS))
 // CUDA supports __assert_fail function which are common for both device
 // and host side code.
 __host__ __device__
@@ -386,7 +387,7 @@ __host__ __device__
         const char* function) throw() __attribute__((__noreturn__));
 
 #if (defined(__HIP_ARCH__) || defined(__HIP__)) && \
-    && defined(PYTORCH_ENABLE_KERNEL_ASSERTS)
+    defined(TORCH_ENABLE_GPU_ASSERTS)
 // ROCm supports __assert_fail only as a device side function.
 __device__ __attribute__((noinline)) __attribute__((weak)) void __assert_fail(
     const char* assertion,

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -327,8 +327,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 // even when NDEBUG is defined. This is useful for important assertions in CUDA
 // code that would otherwise be suppressed when building Release.
 #if defined(__ANDROID__) || defined(__APPLE__) ||  \
-    (defined(USE_ROCM) && ROCM_VERSION < 40100) || \
-    (defined(USE_ROCM) && !defined(TORCH_ENABLE_GPU_ASSERTS))
+    (defined(USE_ROCM) && ROCM_VERSION < 40100)
 // Those platforms do not support assert()
 #define CUDA_KERNEL_ASSERT(cond)
 #define SYCL_KERNEL_ASSERT(cond)

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -368,7 +368,8 @@ extern SYCL_EXTERNAL void __assert_fail(
     unsigned int line,
     const char* func);
 #else // __SYCL_DEVICE_ONLY__
-#if (defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__)) && \
+#if (                                                                       \
+    defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__)) && \
     defined(TORCH_ENABLE_GPU_ASSERTS))
 // CUDA supports __assert_fail function which are common for both device
 // and host side code.

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -326,7 +326,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 // CUDA_KERNEL_ASSERT checks the assertion
 // even when NDEBUG is defined. This is useful for important assertions in CUDA
 // code that would otherwise be suppressed when building Release.
-#if defined(__ANDROID__) || defined(__APPLE__) ||  \
+#if defined(__ANDROID__) || defined(__APPLE__) || \
     (defined(USE_ROCM) && ROCM_VERSION < 40100)
 // Those platforms do not support assert()
 #define CUDA_KERNEL_ASSERT(cond)

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -328,7 +328,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 // code that would otherwise be suppressed when building Release.
 #if defined(__ANDROID__) || defined(__APPLE__) ||  \
     (defined(USE_ROCM) && ROCM_VERSION < 40100) || \
-    (!defined(TORCH_ENABLE_GPU_ASSERTS))
+    (defined(USE_ROCM) && !defined(TORCH_ENABLE_GPU_ASSERTS))
 // Those platforms do not support assert()
 #define CUDA_KERNEL_ASSERT(cond)
 #define SYCL_KERNEL_ASSERT(cond)

--- a/caffe2/core/macros.h.in
+++ b/caffe2/core/macros.h.in
@@ -44,6 +44,7 @@ static_assert(
 #cmakedefine CAFFE2_USE_NVTX
 #cmakedefine CAFFE2_USE_ITT
 #cmakedefine CAFFE2_USE_TRT
+#cmakedefine TORCH_ENABLE_GPU_ASSERTS
 
 #ifndef EIGEN_MPL2_ONLY
 #cmakedefine EIGEN_MPL2_ONLY
@@ -85,4 +86,5 @@ static_assert(
   {"USE_NVTX", "${CAFFE2_USE_NVTX}"}, \
   {"USE_ITT", "${CAFFE2_USE_ITT}"}, \
   {"USE_TRT", "${CAFFE2_USE_TRT}"}, \
+  {"TORCH_ENABLE_GPU_ASSERTS", "${TORCH_ENABLE_GPU_ASSERTS}"}, \
 }

--- a/caffe2/core/macros.h.in
+++ b/caffe2/core/macros.h.in
@@ -44,7 +44,7 @@ static_assert(
 #cmakedefine CAFFE2_USE_NVTX
 #cmakedefine CAFFE2_USE_ITT
 #cmakedefine CAFFE2_USE_TRT
-#cmakedefine TORCH_ENABLE_GPU_ASSERTS
+#cmakedefine TORCH_DISABLE_GPU_ASSERTS
 
 #ifndef EIGEN_MPL2_ONLY
 #cmakedefine EIGEN_MPL2_ONLY
@@ -86,5 +86,5 @@ static_assert(
   {"USE_NVTX", "${CAFFE2_USE_NVTX}"}, \
   {"USE_ITT", "${CAFFE2_USE_ITT}"}, \
   {"USE_TRT", "${CAFFE2_USE_TRT}"}, \
-  {"TORCH_ENABLE_GPU_ASSERTS", "${TORCH_ENABLE_GPU_ASSERTS}"}, \
+  {"TORCH_DISABLE_GPU_ASSERTS", "${TORCH_DISABLE_GPU_ASSERTS}"}, \
 }

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1249,14 +1249,13 @@ if(ANDROID)
 endif()
 
 # ---[ Kernel asserts
-set(TORCH_ENABLE_GPU_ASSERTS OFF CACHE BOOL "Default kernel asserts are disabled on ROCm only")
 # Kernel asserts are enabled by default for CUDA and disabled for ROCm.
-# For ROCm, it can be enabled by setting TORCH_ENABLE_GPU_ASSERTS
-if(USE_CUDA OR (USE_ROCM AND TORCH_ENABLE_GPU_ASSERTS))
+# For ROCm, it can be enabled by setting FORCE_ENABLE_GPU_ASSERTS
+if(USE_CUDA OR FORCE_ENABLE_GPU_ASSERTS)
   message(STATUS "Enabling kernel asserts")
-  add_definitions(-DTORCH_ENABLE_GPU_ASSERTS)
 else()
   message(STATUS "Disabling kernel asserts")
+  caffe2_update_option(TORCH_ENABLE_GPU_ASSERTS OFF)
 endif()
 
 # ---[ LLVM

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1250,17 +1250,12 @@ endif()
 
 # ---[ Kernel asserts
 # Kernel asserts are enabled by default for CUDA and disabled for ROCm.
-# For ROCm, it can be enabled by setting FORCE_ENABLE_GPU_ASSERTS
-if(USE_ROCM)
+# For ROCm, it can be enabled by setting ROCM_FORCE_ENABLE_GPU_ASSERTS
+if(USE_ROCM AND ROCM_FORCE_ENABLE_GPU_ASSERTS)
+  message(STATUS "Forcefully enabling kernel asserts on ROCM")
+elseif(USE_ROCM AND NOT ROCM_FORCE_ENABLE_GPU_ASSERTS)
   message(STATUS "Disabling kernel asserts for ROCm")
   caffe2_update_option(TORCH_DISABLE_GPU_ASSERTS ON)
-else()
-  message(STATUS "Enabling kernel asserts")
-endif()
-
-if(FORCE_ENABLE_GPU_ASSERTS)
-  caffe2_update_option(TORCH_DISABLE_GPU_ASSERTS OFF)
-  message(STATUS "Forcefully enabling kernel asserts")
 endif()
 
 # ---[ LLVM

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1251,11 +1251,16 @@ endif()
 # ---[ Kernel asserts
 # Kernel asserts are enabled by default for CUDA and disabled for ROCm.
 # For ROCm, it can be enabled by setting FORCE_ENABLE_GPU_ASSERTS
-if(USE_CUDA OR FORCE_ENABLE_GPU_ASSERTS)
-  message(STATUS "Enabling kernel asserts")
+if(USE_ROCM)
+  message(STATUS "Disabling kernel asserts for ROCm")
+  caffe2_update_option(TORCH_DISABLE_GPU_ASSERTS ON)
 else()
-  message(STATUS "Disabling kernel asserts")
-  caffe2_update_option(TORCH_ENABLE_GPU_ASSERTS OFF)
+  message(STATUS "Enabling kernel asserts")
+endif()
+
+if(FORCE_ENABLE_GPU_ASSERTS)
+  caffe2_update_option(TORCH_DISABLE_GPU_ASSERTS OFF)
+  message(STATUS "Forcefully enabling kernel asserts")
 endif()
 
 # ---[ LLVM

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1249,12 +1249,12 @@ if(ANDROID)
 endif()
 
 # ---[ Kernel asserts
-set(PYTORCH_ENABLE_KERNEL_ASSERTS OFF CACHE BOOL "Default kernel asserts are disabled on ROCm only")
+set(TORCH_ENABLE_GPU_ASSERTS OFF CACHE BOOL "Default kernel asserts are disabled on ROCm only")
 # Kernel asserts are enabled by default for CUDA and disabled for ROCm.
-# For ROCm, it can be enabled by setting PYTORCH_ENABLE_KERNEL_ASSERTS
-if(USE_CUDA OR (USE_ROCM AND PYTORCH_ENABLE_KERNEL_ASSERTS))
+# For ROCm, it can be enabled by setting TORCH_ENABLE_GPU_ASSERTS
+if(USE_CUDA OR (USE_ROCM AND TORCH_ENABLE_GPU_ASSERTS))
   message(STATUS "Enabling kernel asserts")
-  add_definitions(PYTORCH_ENABLE_KERNEL_ASSERTS)
+  add_definitions(-DTORCH_ENABLE_GPU_ASSERTS)
 else()
   message(STATUS "Disabling kernel asserts")
 endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1248,6 +1248,17 @@ if(ANDROID)
   list(APPEND Caffe2_DEPENDENCY_LIBS log)
 endif()
 
+# ---[ Kernel asserts
+set(PYTORCH_ENABLE_KERNEL_ASSERTS OFF CACHE BOOL "Default kernel asserts are disabled on ROCm only")
+# Kernel asserts are enabled by default for CUDA and disabled for ROCm.
+# For ROCm, it can be enabled by setting PYTORCH_ENABLE_KERNEL_ASSERTS
+if(USE_CUDA OR (USE_ROCM AND PYTORCH_ENABLE_KERNEL_ASSERTS))
+  message(STATUS "Enabling kernel asserts")
+  add_definitions(PYTORCH_ENABLE_KERNEL_ASSERTS)
+else()
+  message(STATUS "Disabling kernel asserts")
+endif()
+
 # ---[ LLVM
 if(USE_LLVM)
   message(STATUS "Looking for LLVM in ${USE_LLVM}")

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -199,5 +199,5 @@ function(caffe2_print_configuration_summary)
   # coreml
   message(STATUS "  USE_COREML_DELEGATE     : ${USE_COREML_DELEGATE}")
   message(STATUS "  BUILD_LAZY_TS_BACKEND   : ${BUILD_LAZY_TS_BACKEND}")
-  message(STATUS "  TORCH_ENABLE_GPU_ASSERTS : ${TORCH_ENABLE_GPU_ASSERTS}")
+  message(STATUS "  TORCH_DISABLE_GPU_ASSERTS : ${TORCH_DISABLE_GPU_ASSERTS}")
 endfunction()

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -199,4 +199,5 @@ function(caffe2_print_configuration_summary)
   # coreml
   message(STATUS "  USE_COREML_DELEGATE     : ${USE_COREML_DELEGATE}")
   message(STATUS "  BUILD_LAZY_TS_BACKEND   : ${BUILD_LAZY_TS_BACKEND}")
+  message(STATUS "  TORCH_ENABLE_GPU_ASSERTS : ${TORCH_ENABLE_GPU_ASSERTS}")
 endfunction()

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -143,9 +143,6 @@ message("Building PyTorch for GPU arch: ${PYTORCH_ROCM_ARCH}")
 # Add HIP to the CMAKE Module Path
 set(CMAKE_MODULE_PATH ${HIP_PATH}/cmake ${CMAKE_MODULE_PATH})
 
-#Disable kernel assert due to performance regression
-set(ROCM_ENABLE_KERNEL_ASSERTS FALSE CACHE BOOL "Kernel asserts are disabled by default for ROCm")
-
 macro(find_package_and_print_version PACKAGE_NAME)
   find_package("${PACKAGE_NAME}" ${ARGN})
   message("${PACKAGE_NAME} VERSION: ${${PACKAGE_NAME}_VERSION}")
@@ -285,19 +282,6 @@ if(HIP_FOUND)
   find_package_and_print_version(rocprim REQUIRED)
   find_package_and_print_version(hipcub REQUIRED)
   find_package_and_print_version(rocthrust REQUIRED)
-
-  if(ROCM_VERSION_DEV VERSION_GREATER_EQUAL "4.1.0")
-    if(ROCM_ENABLE_KERNEL_ASSERTS)
-      message("ROCm version >= 4.1; enabling asserts")
-    else()
-      add_definitions(-DROCM_DISABLE_GPU_ASSERTS)
-      message("ROCm version >= 4.1; kernel asserts are disabled")
-    endif()
-  else()
-    # Disable Asserts In Code (Can't use asserts on HIP stack.)
-    add_definitions(-DNDEBUG)
-    message("ROCm version < 4.1; disablng asserts")
-  endif()
 
   if(HIP_COMPILER STREQUAL clang)
     set(hip_library_name amdhip64)

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -154,4 +154,4 @@ by recompiling the PyTorch from source.
 
 Please add below line as an argument to cmake command parameters::
 
-    -DFORCE_ENABLE_GPU_ASSERTS:BOOL=ON
+    -DROCM_FORCE_ENABLE_GPU_ASSERTS:BOOL=ON

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -144,3 +144,14 @@ Refer to CUDA Semantics doc
 ---------------------------
 
 For any sections not listed here, please refer to the CUDA semantics doc: :ref:`cuda-semantics`
+
+
+Enabling kernel asserts
+-----------------------
+
+Kernel asserts are supported on ROCm, but they are disabled due to performance overhead. It can be enabled
+by recompiling the PyTorch from source.
+
+Please add below line as an argument to cmake command parameters::
+
+    -DTORCH_ENABLE_GPU_ASSERTS:BOOL=TRUE

--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -154,4 +154,4 @@ by recompiling the PyTorch from source.
 
 Please add below line as an argument to cmake command parameters::
 
-    -DTORCH_ENABLE_GPU_ASSERTS:BOOL=TRUE
+    -DFORCE_ENABLE_GPU_ASSERTS:BOOL=ON


### PR DESCRIPTION
- Asserts for CUDA are enabled by default
- Disabled for ROCm by default by setting `TORCH_DISABLE_GPU_ASSERTS` to `ON`
- Can be enabled for ROCm by setting above variable to`OFF` during build or can be forcefully enabled by setting `ROCM_FORCE_ENABLE_GPU_ASSERTS:BOOL=ON`

This is follow up changes as per comment in PR #81790, comment [link](https://github.com/pytorch/pytorch/pull/81790#issuecomment-1215929021)
