### PR TITLE
Remove unnecessary tensor copy in baddbmm_out_cuda_impl

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -363,7 +363,11 @@ const Tensor& baddbmm_out_cuda_impl(const Tensor& result, const Tensor& self, co
     transpose_result = true;
     result_ = resolve_conj_if_indicated(result, true);
   } else {
+    if (!result.is_contiguous()){
     result_ = c10::MaybeOwned<Tensor>::owned(result.transpose(1, 2).clone(at::MemoryFormat::Contiguous).transpose(1, 2));
+    } else {
+      result_ = c10::MaybeOwned<Tensor>::borrowed(result);
+    }
   }
 
   int leading_dim = transpose_result ? 1 : 2;


### PR DESCRIPTION
Summary: We only need to clone `result` if it's not contiguous.

Test Plan:
```
CUBLASLT_LOG_LEVEL=5 buck run mode/opt //caffe2/test:linalg

...

Ran 739 tests in 370.657s

OK (skipped=53)
```

Differential Revision: D39063652

