### PR TITLE
[Easy][FSDP] Update `StateDictType` doc

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -280,7 +280,7 @@ class StateDictType(Enum):
     currently processing (returning or loading).
     The default value is FULL_STATE_DICT to comply the PyTorch convention.
     ..note::
-        FSDP currently supports two types of ``state_dict``:
+        FSDP currently supports three types of ``state_dict``:
             1. ``state_dict/load_state_dict`: this pair of APIs return and load
                the non-sharded, unflattened parameters. The semantics is the
                same as using DDP.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #84201 [FSDP] Short-term fix to remove `optim_input`
* **#84200 [Easy][FSDP] Update `StateDictType` doc**
* #84199 [Easy][FSDP] ufmt `_optim_utils.py`
* #84198 [Easy][FSDP] Fix sharded optim state dict doc formatting

