### PR TITLE
Revert "Deletes CCACHE_DISABLE and SCCACHE_DISABLE from nccl.cmake (#84007)"

### DIFF
--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -38,6 +38,11 @@ if(NOT __NCCL_INCLUDED)
       BUILD_IN_SOURCE 1
       CONFIGURE_COMMAND ""
       BUILD_COMMAND
+        env
+        # TODO: remove these flags when
+        # https://github.com/pytorch/pytorch/issues/13362 is fixed
+        "CCACHE_DISABLE=1"
+        "SCCACHE_DISABLE=1"
         ${MAKE_COMMAND}
         "CXX=${CMAKE_CXX_COMPILER}"
         "CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #84209

This reverts commit 37d3db7579386e928f70815afa7b5a21ffb2fefd.

After 37d3db75 landed, we observed errors like the following when building on the AWS cluster with cuda11.6:

```
...
FAILED: nccl_external-prefix/src/nccl_external-stamp/nccl_external-build nccl/lib/libnccl_static.a /scratch/dberard/nccl-bisect/pytorch/build/nccl_external-prefix/src/nccl_external-stamp/nccl_external-build /scratch/dberard/nccl-bisect/pytorch/build/nccl/lib/libnccl_static.a
cd /scratch/dberard/nccl-bisect/pytorch/third_party/nccl/nccl && make -j24 -l24 CXX=/data/shared/bin/c++ CUDA_HOME=/usr/local/cuda-11.6 NVCC=/data/shared/bin/cuda/nvcc "NVCC_GENCODE=-gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_80,code=sm_80" BUILDDIR=/scratch/dberard/nccl-bisect/pytorch/build/nccl VERBOSE=0 && /usr/local/lib/python3.6/dist-packages/cmake/data/bin/cmake -E touch /scratch/dberard/nccl-bisect/pytorch/build/nccl_external-prefix/src/nccl_external-stamp/nccl_external-build
make -C src build BUILDDIR=/scratch/dberard/nccl-bisect/pytorch/build/nccl
make[1]: Entering directory '/scratch/dberard/nccl-bisect/pytorch/third_party/nccl/nccl/src'
make[2]: Entering directory '/scratch/dberard/nccl-bisect/pytorch/third_party/nccl/nccl/src/collectives/device'
/usr/local/cuda-11.6/bin/crt/link.stub:111:118: error: redefinition of ‘const unsigned char def_module_id_str_5b13a6ab_11_sendrecv_cu_2dca4361_39257 []’
 static const unsigned char __DEFSTRNAME(id) [] __attribute__((aligned(1))) __attribute__((section ("__nv_module_id"))) = "def " __TO_STRING(id); \
                                                                                                                      ^
/tmp/tmpxft_00010ccb_00000000-3_devlink.reg.c:4:1: note: in expansion of macro ‘DEFINE_REGISTER_FUNC’
 DEFINE_REGISTER_FUNC(_5b13a6ab_11_sendrecv_cu_2dca4361_39257)
 ^~~~~~~~~~~~~~~~~~~~
/usr/local/cuda-11.6/bin/crt/link.stub:79:30: note: ‘const unsigned char def_module_id_str_5b13a6ab_11_sendrecv_cu_2dca4361_39257 [44]’ previously defined here
 #define __DEFSTRNAME_CORE(X) def_module_id_str##X
                              ^
/usr/local/cuda-11.6/bin/crt/link.stub:80:25: note: in expansion of macro ‘__DEFSTRNAME_CORE’
 #define __DEFSTRNAME(X) __DEFSTRNAME_CORE(X)
                         ^~~~~~~~~~~~~~~~~
/usr/local/cuda-11.6/bin/crt/link.stub:111:28: note: in expansion of macro ‘__DEFSTRNAME’
 static const unsigned char __DEFSTRNAME(id) [] __attribute__((aligned(1))) __attribute__((section ("__nv_module_id"))) = "def " __TO_STRING(id); \
                            ^~~~~~~~~~~~
/tmp/tmpxft_00010ccb_00000000-3_devlink.reg.c:3:1: note: in expansion of macro ‘DEFINE_REGISTER_FUNC’
 DEFINE_REGISTER_FUNC(_5b13a6ab_11_sendrecv_cu_2dca4361_39257)
 ^~~~~~~~~~~~~~~~~~~~
...
```

After reverting the issue goes away