### PR TITLE
Make mergebot failure messages more readable

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1341,16 +1341,17 @@ def main() -> None:
         run_url = os.getenv("GH_RUN_URL")
         if run_url is not None:
             # Hide this behind a collapsed bullet since it's not helpful to most devs
-            internal_debugging = \
-              "<details><summary>Details for Dev Infra team</summary>" + \
-              f"\nRaised by <a href=\"{run_url}\">workflow job</a>\n" + \
-              "</details>"
+            internal_debugging = (
+                "<details><summary>Details for Dev Infra team</summary>" +
+                f"\nRaised by <a href=\"{run_url}\">workflow job</a>\n" +
+                "</details>"
+            )
 
         msg = (
-          f"## {title}\n" + \
-          f"{exception}\n\n" + \
-          f"{troubleshooting}\n\n" + \
-          f"{internal_debugging}\n"
+            f"## {title}\n" +
+            f"{exception}\n\n" +
+            f"{troubleshooting}\n\n" +
+            f"{internal_debugging}\n"
         )
 
         gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1347,11 +1347,13 @@ def main() -> None:
                 "</details>"
             )
 
-        msg = (
-            f"## {title}\n" +
-            f"{exception}\n\n" +
-            f"{troubleshooting}\n\n" +
-            f"{internal_debugging}\n"
+        msg = "\n".join(
+            f"## {title}",
+            f"{exception}",
+            f"",
+            f"{troubleshooting}",
+            f""
+            f"{internal_debugging}"
         )
 
         gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1341,20 +1341,20 @@ def main() -> None:
         run_url = os.getenv("GH_RUN_URL")
         if run_url is not None:
             # Hide this behind a collapsed bullet since it's not helpful to most devs
-            internal_debugging = (
-                "<details><summary>Details for Dev Infra team</summary>" +
-                f"\nRaised by <a href=\"{run_url}\">workflow job</a>\n" +
+            internal_debugging = "\n".join((
+                "<details><summary>Details for Dev Infra team</summary>",
+                f"Raised by <a href=\"{run_url}\">workflow job</a>",
                 "</details>"
-            )
+            ))
 
-        msg = "\n".join(
+        msg = "\n".join((
             f"## {title}",
             f"{exception}",
-            f"",
+            "",
             f"{troubleshooting}",
-            f""
+            "",
             f"{internal_debugging}"
-        )
+        ))
 
         gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
         import traceback

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1330,13 +1330,29 @@ def main() -> None:
     org, project = repo.gh_owner_and_name()
     pr = GitHubPR(org, project, args.pr_num)
 
-    def handle_exception(e: Exception, msg: str = "Merge failed") -> None:
-        msg += f"\nReason: {e}"
+    def handle_exception(e: Exception, title: str = "Merge failed") -> None:
+        exception = f"**Reason**: {e}"
+
+        troubleshooting = ""
+        if args.land_checks:
+            troubleshooting += get_land_check_troubleshooting_message()
+
+        internal_debugging = ""
         run_url = os.getenv("GH_RUN_URL")
         if run_url is not None:
-            msg += f"\nRaised by [workflow job]({run_url})"
-        if args.land_checks:
-            msg += get_land_check_troubleshooting_message()
+            # Hide this behind a collapsed bullet since it's not helpful to most devs
+            internal_debugging = \
+              "<details><summary>Details for Dev Infra team</summary>" + \
+              f"\nRaised by <a href=\"{run_url}\">workflow job</a>\n" + \
+              "</details>"
+
+        msg = (
+          f"## {title}\n" + \
+          f"{exception}\n\n" + \
+          f"{troubleshooting}\n\n" + \
+          f"{internal_debugging}\n"
+        )
+
         gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
         import traceback
         traceback.print_exc()

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -141,6 +141,6 @@ def get_land_check_troubleshooting_message() -> str:
         " If you believe this is an error, you can use the old behavior with `@pytorchbot merge -g`"
         + " (optionally with the `ciflow/trunk` to get land checks)"
         + ' or use `@pytorchbot merge -f "some reason here"`.'
-        + f" For more information, see the [bot wiki]({BOT_COMMANDS_WIKI}). \n"
+        + f" For more information, see the [bot wiki]({BOT_COMMANDS_WIKI}). \n\n"
         + CONTACT_US
     )


### PR DESCRIPTION
Reformat how mergebot outputs merge and revert errors to make the failure more obvious and hide text that doesn't actually help most users debug their PRs. (The workflow job helps the DevX team to debug mergebot errors)

### Old message:
<img width="933" alt="image" src="https://user-images.githubusercontent.com/4468967/187276407-fb35880c-5ada-4f1f-a01e-86b5071ab0fd.png">

### New message contents:
<img width="833" alt="image" src="https://user-images.githubusercontent.com/4468967/187276280-e7397edb-1887-41a2-b206-4d005b59f683.png">

### New message contents detailed expanded:
<img width="843" alt="image" src="https://user-images.githubusercontent.com/4468967/187276342-b50e6b28-f19e-4547-bf29-1a7878a3a97c.png">
