### PR TITLE
[Nested Tensor] fix from_padded bug

### DIFF
--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
@@ -60,45 +60,46 @@ Tensor nested_from_padded_cuda(
     auto input_size_ptr = output_size_ptr + target_size_sizes.numel();
     auto offsets_ptr = input_size_ptr + padded_sizes_tensor.numel();
 
+    Tensor padded_contiguous = padded.contiguous();
     if (padded.dtype() == kFloat) {
       if (do_transform_0213) {
         remove_padding_transform0213_kernelLauncher(
-            padded.data_ptr<float>(),
+            padded_contiguous.data_ptr<float>(),
             output.data_ptr<float>(),
             offsets_ptr,
             input_size_ptr,
             output_size_ptr,
-            padded.dim() - 2,
-            padded.sizes()[0]);
+            padded_contiguous.dim() - 2,
+            padded_contiguous.sizes()[0]);
       } else {
         remove_padding_kernelLauncher(
-            padded.data_ptr<float>(),
+            padded_contiguous.data_ptr<float>(),
             output.data_ptr<float>(),
             offsets_ptr,
             input_size_ptr,
             output_size_ptr,
-            padded.dim() - 1,
-            padded.sizes()[0]);
+            padded_contiguous.dim() - 1,
+            padded_contiguous.sizes()[0]);
       }
     } else if (padded.dtype() == kHalf) {
       if (do_transform_0213) {
         remove_padding_transform0213_kernelLauncher(
-            padded.data_ptr<c10::Half>(),
+            padded_contiguous.data_ptr<c10::Half>(),
             output.data_ptr<c10::Half>(),
             offsets_ptr,
             input_size_ptr,
             output_size_ptr,
-            padded.dim() - 2,
-            padded.sizes()[0]);
+            padded_contiguous.dim() - 2,
+            padded_contiguous.sizes()[0]);
       } else {
         remove_padding_kernelLauncher(
-            padded.data_ptr<c10::Half>(),
+            padded_contiguous.data_ptr<c10::Half>(),
             output.data_ptr<c10::Half>(),
             offsets_ptr,
             input_size_ptr,
             output_size_ptr,
-            padded.dim() - 1,
-            padded.sizes()[0]);
+            padded_contiguous.dim() - 1,
+            padded_contiguous.sizes()[0]);
       }
     } else {
       AT_ERROR("Only support fp32/fp16 for padded input");

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -298,7 +298,6 @@ class TestNestedTensorDeviceType(TestCase):
                 torch.nested_tensor(ts2, device=device, dtype=dtype))
 
     @dtypes(*floating_types_and_half())
-    @dtypesIfCUDA(torch.float64)
     def test_detach(self, device, dtype):
         a = torch.randn(2, 4, device=device, dtype=dtype, requires_grad=False)
         b = torch.randn(5, 4, device=device, dtype=dtype, requires_grad=False)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2702,7 +2702,7 @@
   cpu_nested_shape_example: non_differentiable
 
 - name: to_padded_tensor(Tensor self, float padding, int[]? output_size=None) -> Tensor
-  self: at::_nested_from_padded(grad.contiguous(), self._nested_tensor_size())
+  self: at::_nested_from_padded(grad, self._nested_tensor_size())
   padding: non_differentiable
 
 # fft

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2702,7 +2702,7 @@
   cpu_nested_shape_example: non_differentiable
 
 - name: to_padded_tensor(Tensor self, float padding, int[]? output_size=None) -> Tensor
-  self: at::_nested_from_padded(grad, self._nested_tensor_size())
+  self: at::_nested_from_padded(grad.contiguous(), self._nested_tensor_size())
   padding: non_differentiable
 
 # fft


### PR DESCRIPTION
Fixes #84082

Explained in the issue that the problem was arising from grad being not contiguous and the fast kernel not handiling this case gracefully.  The other thing I can do is add a contiguous call to https://github.com/pytorch/pytorch/blob/d144594512e10ab2a9625347816c2dee1fb55667/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp#L45

