### PR TITLE
Add Lazy backend type string

### DIFF
--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -43,6 +43,8 @@ static const char* backend_to_string(const at::Backend& backend) {
       return "torch.mps";
     case at::Backend::PrivateUse1:
       return "torch.privateuseone";
+    case at::Backend::Lazy:
+      return "torch.lazy";
     default:
       AT_ERROR("Unimplemented backend ", backend);
   }


### PR DESCRIPTION
As the title suggest, the `Lazy` case was missing the in the `backend_to_string` switch case causing
```
RuntimeError: Unimplemented backend Lazy
```
when called with a lazy backend.

CC: @wconstab @Krovatkin @desertfire 