### PR TITLE
[fx] Make wrapped_fn also work for non-mutating passes.

### DIFF
--- a/torch/fx/passes/infra/pass_manager.py
+++ b/torch/fx/passes/infra/pass_manager.py
@@ -28,8 +28,7 @@ def inplace_wrapper(fn: Callable) -> Callable:
 
     @wraps(fn)
     def wrapped_fn(gm):
-        fn(gm)
-        return PassResult(gm, True)
+        return fn(gm) or PassResult(gm, True)
 
     if wrapped_fn.__name__ == 'wrapped_fn':
         wrapped_fn.__name__ = str(fn)


### PR DESCRIPTION
Summary: Before the change, wrapped_fn should only take mutating passes, but we don't actually have any way to detect whether a pass is mutating before running it. To make this an abstraction without involving any precondition depending on PassManager run, we could just relax the precondition to take any kind of passes, and conditionally return the original pass based on the pass result.

Test Plan: eyes

Reviewed By: qihqi, angelayi

Differential Revision: D39086343

