### PR TITLE
[No CI] Decomp for _embedding_bag

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -158,6 +158,8 @@ def op_assert_ref(test_case, op, test_dtype, i, orig, decomp, ref, args, kwargs)
         (torch.float16, torch.ops.aten.native_batch_norm.default): 1e-5,
         (torch.bfloat16, torch.ops.aten.linalg_vector_norm.default): 1e-6,
         (torch.float16, torch.ops.aten.linalg_vector_norm.default): 1e-6,
+
+        (torch.float16, torch.ops.aten._embedding_bag.default): 5e-3,
     }
     if ref.is_floating_point():
         orig_diff = (orig - ref).abs().max()
@@ -460,7 +462,12 @@ class TestDecomp(TestCase):
         aten_name = op.decomp_aten_name or op.aten_name
 
         func = op.get_op()
+
         for sample_input in samples:
+            # TODO: padding_idx is not yet support for aten._embedding_bag decomp, clean up
+            if aten_name == 'nn.functional.embedding_bag' and 'padding_idx' in sample_input.kwargs:
+                continue
+
             if requires_grad:
                 if None in sample_input.args:
                     continue

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -585,7 +585,7 @@ def meta_cdist_forward(x1, x2, p, compute_mode):
     return x1.new_empty(output_shape)
 
 
-@torch.library.impl(meta_lib, "_embedding_bag")
+# @torch.library.impl(meta_lib, "_embedding_bag")
 def meta_embedding_bag(
     weight,
     indices,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6525,12 +6525,12 @@ def sample_inputs_embedding_bag(op_info, device, dtype, requires_grad, **kwargs)
                               kwargs={'padding_idx': 2, 'mode': mode,
                                       'per_sample_weights': per_sample_weights},)
 
-            idx = make_long_input((6, ), low=0, high=S)
-            weights = make_input((S, S))
-            offsets_ = torch.tensor([0, 3, 6], device=device, dtype=torch.long)
-            per_sample_weights = make_per_sample_weight(generate_per_sample_weight, idx)
-            yield SampleInput(weights, args=(idx,),
-                              kwargs={'mode': mode, 'offsets': offsets_, 'include_last_offset': True},)
+            # idx = make_long_input((6, ), low=0, high=S)
+            # weights = make_input((S, S))
+            # offsets_ = torch.tensor([0, 3, 6], device=device, dtype=torch.long)
+            # per_sample_weights = make_per_sample_weight(generate_per_sample_weight, idx)
+            # yield SampleInput(weights, args=(idx,),
+            #                   kwargs={'mode': mode, 'offsets': offsets_, 'include_last_offset': True},)
 
             if not requires_grad:
                 # Following inputs return different gradient from the numerical gradient.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84235

This PR is not for land. I am publishing this diff just to show the problems I ran into... 
And it's a **bad** idea to try decomposing aten._embedding_bag. 

Here are the problems I ran into:
- CPU kernel and CUDA kernel have different behavior for the the op!!! In order to match the eager kernel behavior, I have code like this "if offsets.device.type != "cpu":", and this is crazy... 
- I would expect the fourth output, "max_indices" to be None, unless mode == MODE_MAX. (but it's not) And we should have a way to ask cross_ref test to skip comparing the values for 4th output in some test cases. 
- If padding_idx is specified, the operator becomes data dependent. I couldn't find a good way to write the decomposition without introduce graph break. 
- Slice with invalid index has different behavior in CPU and CUDA. tensor[0:0] would return empty tensor in CPU, but error out in CUDA.  
- We need to check the size of bag, to determine whether to we should perform reduction op, or create a zero tensor. This introduce guards on shape.  
