### PR TITLE
ci: Replace setup-miniconda with test-infra version

### DIFF
--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -42,11 +42,6 @@ on:
         required: true
         description: Secret for S3 bucket for macOS sccache.
 
-# For setup-miniconda, see https://github.com/conda-incubator/setup-miniconda/issues/179
-defaults:
-  run:
-    shell: bash -e -l {0}
-
 jobs:
   build:
     # Don't run on forked repos.
@@ -71,12 +66,9 @@ jobs:
           fi
 
       - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          auto-update-conda: true
           python-version: ${{ inputs.python_version }}
-          activate-environment: build
-          miniconda-version: 4.7.12
 
       - name: Install macOS homebrew dependencies
         run: |
@@ -103,7 +95,7 @@ jobs:
           OUR_GITHUB_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
         run: |
           echo "CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname "$(which conda)")/../"}" >> "${GITHUB_ENV}"
-          .jenkins/pytorch/macos-build.sh
+          ${CONDA_RUN} .jenkins/pytorch/macos-build.sh
 
       - name: Archive artifacts into zip
         if: inputs.build-generates-artifacts

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -15,7 +15,6 @@ on:
           If this is set, our linter will use this to make sure that every other
           job with the same `sync-tag` is identical.
 
-
 jobs:
   run_mps_test:
     name: "Run MPS tests"
@@ -41,7 +40,7 @@ jobs:
       - name: Setup miniconda
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install PyTorch
         env:

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -38,8 +38,7 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
-      - name: Setup miniconda (x86, py3.8)
-        if: ${{ runner.arch == 'X64' }}
+      - name: Setup miniconda
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
           python-version: 3.8

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -38,6 +38,12 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
+      - name: Setup miniconda (x86, py3.8)
+        if: ${{ runner.arch == 'X64' }}
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        with:
+          python-version: 3.8
+
       - name: Install PyTorch
         env:
           ENV_NAME: conda-test-env-${{ github.run_id }}
@@ -45,12 +51,11 @@ jobs:
         shell: arch -arch arm64 bash {0}
         run: |
           # shellcheck disable=SC1090
-          . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
-          conda create -yp "${ENV_NAME}" "python=${PY_VERS}" numpy expecttest pyyaml
+          ${CONDA_INSTALL} numpy expecttest pyyaml
           # As wheels are cross-compiled they are reported as x86_64 ones
           ORIG_WHLNAME=$(ls -1 dist/*.whl); ARM_WHLNAME=${ORIG_WHLNAME/x86_64/arm64}; mv ${ORIG_WHLNAME} ${ARM_WHLNAME}
-          conda run -p "${ENV_NAME}" python3 -mpip install dist/*.whl
+          ${CONDA_RUN} python3 -mpip install dist/*.whl
 
       - name: Run MPS tests
         env:
@@ -58,11 +63,9 @@ jobs:
         shell: arch -arch arm64 bash {0}
         run: |
           # shellcheck disable=SC1090
-          . ~/miniconda3/etc/profile.d/conda.sh
           set -ex
           # TODO(https://github.com/pytorch/pytorch/issues/79293)
           # This step currently fails if we actually run as if we're in CI.
           unset CI
 
-          conda run --cwd test -p "${ENV_NAME}" python3 test_mps.py -v
-          conda env remove -p "${ENV_NAME}"
+          ${CONDA_RUN} --cwd test python3 test_mps.py -v

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -60,13 +60,6 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
-      - name: Start monitoring script
-        id: monitor-script
-        run: |
-          python3 -m pip install psutil==5.9.1
-          python3 -m pip install pynvml==11.4.1
-          python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
-          echo "::set-output name=monitor-script-pid::${!}"
 
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts
@@ -74,24 +67,25 @@ jobs:
           name: ${{ inputs.build-environment }}
           use-gha: true
 
-      - name: Setup miniconda for x86
-        if: inputs.build-environment == 'macos-12-py3-x86-64'
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Setup miniconda (x86, py3.8)
+        if: ${{ runner.arch == 'X64' }}
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          auto-update-conda: true
           python-version: 3.8
-          activate-environment: build
-          miniconda-version: 4.7.12
 
-      - name: Setup miniconda for arm64
-        if: inputs.build-environment == 'macos-12-py3-arm64'
+      - name: Setup miniconda (arm64, py3.9)
+        if: ${{ runner.arch == 'ARM64' }}
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        with:
+          python-version: 3.9
+
+      - name: Start monitoring script
+        id: monitor-script
         run: |
-          # Conda is already installed and setup for bash here
-          # Cleanup lingering conda environment and create
-          # a new one for this run
-          conda env remove -n build
-          conda create -n build python=3.9.12
-          conda list
+          ${CONDA_RUN} python3 -m pip install psutil==5.9.1
+          ${CONDA_RUN} python3 -m pip install pynvml==11.4.1
+          ${CONDA_RUN} python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
+          echo "::set-output name=monitor-script-pid::${!}"
 
       - name: Install macOS homebrew dependencies
         run: |
@@ -126,18 +120,8 @@ jobs:
           export PR_BODY="${PR_BODY//[\'\"]}"
           arch
 
-          # This is a no-op for x86
-          conda activate build
-
-          python3 -mpip install dist/*.whl
-          .jenkins/pytorch/macos-test.sh
-
-      - name: Cleanup miniconda for arm64
-        if: inputs.build-environment == 'macos-12-py3-arm64'
-        run: |
-          # Cleanup conda env
-          conda deactivate
-          conda env remove -n build
+          ${CONDA_RUN} python3 -mpip install dist/*.whl
+          ${CONDA_RUN} .jenkins/pytorch/macos-test.sh
 
       - name: Get workflow job id
         id: get-job-id
@@ -182,6 +166,6 @@ jobs:
           GHA_WORKFLOW_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
         run: |
           set -x
-          python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.19.12
-          python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
+          ${CONDA_RUN} python3 -m pip install -r requirements.txt
+          ${CONDA_RUN} python3 -m pip install boto3==1.19.12
+          ${CONDA_RUN} python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #84236

Replaces our use of the conda-incubator version of setup-miniconda with
one that's more tailored to our specific needs.

Should address issues highlighted in https://github.com/pytorch/pytorch/issues/84196

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>