### PR TITLE
Upgrade default cuda version of torchbench

### DIFF
--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -134,6 +134,7 @@ def run_userbenchmarks(pytorch_path: str, torchbench_path: str, base_sha: str, h
                "--head", head_sha,
                "--userbenchmark", userbenchmark,
                "--output-dir", output_dir]
+    print(f"Running torchbench userbenchmark command: {command}")
     subprocess.check_call(command, cwd=torchbench_path, env=env)
 
 if __name__ == "__main__":

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -121,6 +121,7 @@ def run_torchbench(pytorch_path: str, torchbench_path: str, output_dir: str) -> 
                "--pytorch-src", pytorch_path, "--torchbench-src", torchbench_path,
                "--config", os.path.join(output_dir, TORCHBENCH_CONFIG_NAME),
                "--output", os.path.join(output_dir, "result.txt")]
+    print(f"Running torchbench command: {command}")
     subprocess.check_call(command, cwd=torchbench_path, env=env)
 
 def run_userbenchmarks(pytorch_path: str, torchbench_path: str, base_sha: str, head_sha: str,

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -4,8 +4,6 @@ on:
 
 env:
   PYTHON_VERSION: "3.8"
-  CUDA_VERSION: "11.6"
-  MAGMA_VERSION: "magma-cuda116"
   # must be consistent with https://github.com/pytorch/benchmark/blob/main/requirements.txt#L19
   NUMPY_VERSION: "1.21.2"
   PR_NUM: ${{ github.event.number }}
@@ -43,8 +41,6 @@ jobs:
           conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
                            setuptools cmake=3.22 cffi typing_extensions \
                            future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
-          # install magma
-          conda install -y -c pytorch "${MAGMA_VERSION}"
       - name: Setup TorchBench branch
         run: |
           # shellcheck disable=SC1091

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -4,8 +4,8 @@ on:
 
 env:
   PYTHON_VERSION: "3.8"
-  CUDA_VERSION: "11.3"
-  MAGMA_VERSION: "magma-cuda113"
+  CUDA_VERSION: "11.6"
+  MAGMA_VERSION: "magma-cuda116"
   # must be consistent with https://github.com/pytorch/benchmark/blob/main/requirements.txt#L19
   NUMPY_VERSION: "1.21.2"
   PR_NUM: ${{ github.event.number }}


### PR DESCRIPTION
Upgrade CUDA version of torchbench as we are moving away from CUDA 11.3
This PR needs to land together with https://github.com/pytorch/benchmark/pull/1141

RUN_TORCHBENCH: nvfuser
TORCHBENCH_BRANCH: xz9/setup-cuda-compile
