### PR TITLE
Use self-hosted runner for viable/strict update

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   do_update_viablestrict:
-    runs-on: ubuntu-20.04
+    runs-on: linux.2xlarge
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Queuing for GH self hosted runners has been too much to be acceptable and this job gets canceled too frequently:

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/31798555/187349721-f6bfe44c-aef2-45e2-b73e-8b54602ccf55.png">

Let's use our own runner here instead for this important job.
