### PR TITLE
Warn on use of global constructors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -800,6 +800,7 @@ if(NOT MSVC)
   string(APPEND CMAKE_CXX_FLAGS " -Wall")
   string(APPEND CMAKE_CXX_FLAGS " -Wextra")
   append_cxx_flag_if_supported("-Werror=return-type" CMAKE_CXX_FLAGS)
+  append_cxx_flag_if_supported("-Wglobal-constructors" CMAKE_CXX_FLAGS)
   if(NOT USE_CUDNN)
     # Temporary fix to ignore non virtual dtor error if cudnn is used. A
     # separate PR to cudnn_frontend is needed to address this later on


### PR DESCRIPTION
To prevent further reverts similar to https://github.com/pytorch/pytorch/pull/82040#issuecomment-1229503604

