### PR TITLE
nnc: add more fusion of elementwise OPs with conv 

### DIFF
--- a/aten/src/ATen/native/mkldnn/ConvPrepack.cpp
+++ b/aten/src/ATen/native/mkldnn/ConvPrepack.cpp
@@ -25,10 +25,12 @@ c10::intrusive_ptr<mkldnn::ConvOpContext> createConvPrePackOpContext(
     std::vector<int64_t> dilation,
     int64_t groups,
     std::vector<int64_t> input_size,
-    std::string attr) {
-  auto it = fusion_attr_map.find(attr);
-  TORCH_CHECK(it != fusion_attr_map.end(), "Fusion behavior undefined.");
-  ideep::attr_t op_attr = it->second;
+    std::string attr,
+    std::vector<c10::optional<at::Scalar>> scalars,
+    c10::optional<std::string> algorithm) {
+  auto it = fusion_attr_map().find(attr);
+  TORCH_CHECK(it != fusion_attr_map().end(), "Fusion behavior undefined.");
+  ideep::attr_t op_attr = it->second(scalars, algorithm);
 
   return mkldnn::MkldnnConvOpContext::create_context(
       std::move(weight),

--- a/aten/src/ATen/native/mkldnn/ConvPrepack.h
+++ b/aten/src/ATen/native/mkldnn/ConvPrepack.h
@@ -20,7 +20,9 @@ c10::intrusive_ptr<mkldnn::ConvOpContext> createConvPrePackOpContext(
     std::vector<int64_t> dilation,
     int64_t groups,
     std::vector<int64_t> input_size,
-    std::string attr);
+    std::string attr,
+    std::vector<c10::optional<at::Scalar>> scalars,
+    c10::optional<std::string> algorithm);
 
 Tensor conv_run(
     const Tensor& input,

--- a/aten/src/ATen/native/mkldnn/OpContext.cpp
+++ b/aten/src/ATen/native/mkldnn/OpContext.cpp
@@ -7,6 +7,76 @@ namespace at {
 namespace native {
 namespace mkldnn {
 
+#define ATTR_FUNC(NAME)                              \
+  [](std::vector<c10::optional<at::Scalar>> scalars, \
+     c10::optional<std::string> algorithm) {         \
+    return ideep::attr_t::fuse_##NAME();             \
+  }
+
+static constexpr float kMin = -std::numeric_limits<float>::infinity();
+static constexpr float kMax = std::numeric_limits<float>::infinity();
+
+AttrFunction attr_func_none = [](std::vector<c10::optional<at::Scalar>> scalars,
+                                 c10::optional<std::string> algorithm) {
+  const static ideep::attr_t empty_attr = ideep::attr_t();
+  return empty_attr;
+};
+
+AttrFunction attr_func_leaky_relu =
+    [](std::vector<c10::optional<at::Scalar>> scalars,
+       c10::optional<std::string> algorithm) {
+      auto alpha_value = scalars[0].value().to<float>();
+      return ideep::attr_t::fuse_relu(1.0, alpha_value);
+    };
+
+AttrFunction attr_func_hardtanh =
+    [](std::vector<c10::optional<at::Scalar>> scalars,
+       c10::optional<std::string> algorithm) {
+      auto lower_bound_value = scalars[0].value().to<float>();
+      auto upper_bound_value = scalars[1].value().to<float>();
+      return ideep::attr_t::fuse_clamp(lower_bound_value, upper_bound_value);
+    };
+
+AttrFunction attr_func_gelu = [](std::vector<c10::optional<at::Scalar>> scalars,
+                                 c10::optional<std::string> algorithm) {
+  dnnl::algorithm gelu_type;
+  if (algorithm.value() == "none") {
+    gelu_type = dnnl::algorithm::eltwise_gelu_erf;
+  } else if (algorithm.value() == "tanh") {
+    gelu_type = dnnl::algorithm::eltwise_gelu_tanh;
+  } else {
+    TORCH_CHECK(
+        false, "ipex::linear_gelu_run only support tanh approximate now");
+  }
+
+  return ideep::attr_t::fuse_gelu(1.0, 0.f, 0.f, gelu_type);
+};
+
+AttrFunction attr_func_clamp =
+    [](std::vector<c10::optional<at::Scalar>> scalars,
+       c10::optional<std::string> algorithm) {
+      float lower_bound_value =
+          scalars[0] ? scalars[0].value().to<float>() : kMin;
+      float upper_bound_value =
+          scalars[1] ? scalars[1].value().to<float>() : kMax;
+
+      return ideep::attr_t::fuse_clamp(lower_bound_value, upper_bound_value);
+    };
+
+const std::map<std::string, AttrFunction>& fusion_attr_map() {
+  static const std::map<std::string, AttrFunction> fusion_attr_map{
+      {"none", attr_func_none},
+      {"relu", ATTR_FUNC(relu)},
+      {"sigmoid", ATTR_FUNC(sigmoid)},
+      {"tanh", ATTR_FUNC(tanh)},
+      {"leaky_relu", attr_func_leaky_relu},
+      {"hardtanh", attr_func_hardtanh},
+      {"gelu", attr_func_gelu},
+      {"clamp", attr_func_clamp},
+  };
+  return fusion_attr_map;
+};
+
 c10::intrusive_ptr<ConvOpContext> MkldnnConvOpContext::create_context(
     at::Tensor&& weight,
     c10::optional<at::Tensor>&& bias,

--- a/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
+++ b/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
@@ -32,13 +32,15 @@ TORCH_LIBRARY(mkldnn, m) {
                 // NOLINTNEXTLINE(performance-move-const-arg,cppcoreguidelines-avoid-magic-numbers)
                 std::move(std::get<6>(state)),
                 // NOLINTNEXTLINE(performance-move-const-arg,cppcoreguidelines-avoid-magic-numbers)
-                std::move(std::get<7>(state)));
+                std::move(std::get<7>(state)),
+                std::move(std::get<8>(state)),
+                std::move(std::get<9>(state)));
           });
 }
 
 TORCH_LIBRARY(mkldnn_prepacked, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "mkldnn_prepacked::conv2d_prepack(Tensor W, Tensor? B, int[2] stride, int[2] padding, int[2] dilation, int groups, int[4] input_size, str attr) -> __torch__.torch.classes.mkldnn.ConvOpContext"));
+      "mkldnn_prepacked::conv2d_prepack(Tensor W, Tensor? B, int[2] stride, int[2] padding, int[2] dilation, int groups, int[4] input_size, str attr, Scalar?[] scalars, str? algorithm) -> __torch__.torch.classes.mkldnn.ConvOpContext"));
 
   m.def(TORCH_SELECTIVE_SCHEMA(
       "mkldnn_prepacked::conv2d_run(Tensor X, __torch__.torch.classes.mkldnn.ConvOpContext W_prepack) -> Tensor Y"));

--- a/test/test_mkldnn_fusion.py
+++ b/test/test_mkldnn_fusion.py
@@ -47,6 +47,71 @@ class TestMkldnnFusion(JitTestCase):
         torch._C._jit_set_te_must_use_llvm_cpu(old_te_must_use_llvm_cpu)
         return graph
 
+    def _eltwise_list(self):
+        eltwise_list = [
+            [torch.relu, 'aten::relu'],
+            [torch.sigmoid, 'aten::sigmoid'],
+            [torch.tanh, 'aten::tanh'],
+            [nn.LeakyReLU(0.1, inplace=False), 'aten::leaky_relu'],
+            [nn.Hardtanh(inplace=False), 'aten::hardtanh'],
+            [nn.GELU(approximate="none"), 'aten::gelu'],
+            [nn.GELU(approximate="tanh"), 'aten::gelu'],
+        ]
+        return eltwise_list
+
+    def _clamp_modules(self):
+        class MNoOpt(nn.Module):
+            def __init__(self, m, in_channels, out_channels, bias, **kwargs):
+                super(MNoOpt, self).__init__()
+                self.conv = m(in_channels, out_channels, bias=bias, **kwargs)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = torch.clamp(x, min=-0.5, max=0.9)
+                return x
+
+        class MInf(nn.Module):
+            def __init__(self, m, in_channels, out_channels, bias, **kwargs):
+                super(MInf, self).__init__()
+                self.conv = m(in_channels, out_channels, bias=bias, **kwargs)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = torch.clamp(x, min=0, max=float('inf'))
+                return x
+
+        class MNegInf(nn.Module):
+            def __init__(self, m, in_channels, out_channels, bias, **kwargs):
+                super(MNegInf, self).__init__()
+                self.conv = m(in_channels, out_channels, bias=bias, **kwargs)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = torch.clamp(x, min=float('-inf'), max=0)
+                return x
+
+        class MOptMin(nn.Module):
+            def __init__(self, m, in_channels, out_channels, bias, **kwargs):
+                super(MOptMin, self).__init__()
+                self.conv = m(in_channels, out_channels, bias=bias, **kwargs)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = torch.clamp(x, max=2)
+                return x
+
+        class MOptMax(nn.Module):
+            def __init__(self, m, in_channels, out_channels, bias, **kwargs):
+                super(MOptMax, self).__init__()
+                self.conv = m(in_channels, out_channels, bias=bias, **kwargs)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = torch.clamp(x, min=0)
+                return x
+
+        return [MNoOpt, MInf, MNegInf, MOptMin, MOptMax]
+
     def test_single_conv(self):
         class M(nn.Module):
             def __init__(self, in_channels, out_channels, bias, **kwargs):
@@ -100,7 +165,7 @@ class TestMkldnnFusion(JitTestCase):
             [torch.contiguous_format, False],
             [torch.channels_last, True],
         ]:
-            for eltwise_fn in [torch.relu]:
+            for eltwise_fn, op_name in self._eltwise_list():
                 for bias in [True, False]:
                     for oC in [1, 10]:
                         m = M(eltwise_fn, 3, oC, bias, kernel_size=(3, 3)).to(memory_format=memory_format)
@@ -108,11 +173,30 @@ class TestMkldnnFusion(JitTestCase):
 
                         graph = self._check_model(m, x)
                         if enabled:
-                            self.assertFused(graph, ['aten::conv2d', 'aten::' + eltwise_fn.__name__])
+                            self.assertFused(graph, ['aten::conv2d', 'aten::' + op_name])
                             self.assertGraphContainsExactly(graph, FUSION_GROUP, 1)
                         else:
                             self.assertGraphContains(graph, kind='aten::conv2d')
 
+    def test_conv_clamp(self):
+        modules = self._clamp_modules()
+        op_name = 'aten::clamp'
+
+        for memory_format, enabled in [
+            [torch.contiguous_format, False],
+            [torch.channels_last, True],
+        ]:
+            for M in modules:
+                for bias in [True, False]:
+                    m = M(nn.Conv2d, 3, 10, bias, kernel_size=(3, 3)).to(memory_format=memory_format)
+                    x = torch.randn(1, 3, 224, 224).to(memory_format=memory_format)
+
+                    graph = self._check_model(m, x)
+                    if enabled:
+                        self.assertFused(graph, ['aten::conv2d', op_name])
+                        self.assertGraphContainsExactly(graph, FUSION_GROUP, 1)
+                    else:
+                        self.assertGraphContains(graph, kind='aten::conv2d')
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_mkldnn_fusion.py
+++ b/test/test_mkldnn_fusion.py
@@ -173,7 +173,7 @@ class TestMkldnnFusion(JitTestCase):
 
                         graph = self._check_model(m, x)
                         if enabled:
-                            self.assertFused(graph, ['aten::conv2d', 'aten::' + op_name])
+                            self.assertFused(graph, ['aten::conv2d', op_name])
                             self.assertGraphContainsExactly(graph, FUSION_GROUP, 1)
                         else:
                             self.assertGraphContains(graph, kind='aten::conv2d')

--- a/torch/csrc/jit/passes/mkldnn_rewrite.cpp
+++ b/torch/csrc/jit/passes/mkldnn_rewrite.cpp
@@ -13,6 +13,67 @@ namespace jit {
 
 #if AT_MKLDNN_ENABLED()
 
+namespace mkldnn {
+
+const std::vector<std::string> zero_scalar_operand =
+    std::vector<std::string>({});
+const std::vector<std::string> one_scalar_operand =
+    std::vector<std::string>({"%alpha"});
+const std::vector<std::string> two_scalar_operands =
+    std::vector<std::string>({"%alpha", "%beta"});
+const std::string algorithm_indicator = std::string("%algorithm");
+
+std::string construct_operand_list(
+    std::vector<std::string> scalar_input,
+    std::string algorithm_indicator) {
+  std::string constructed_operand_list = "";
+
+  std::string joined_scalar_operands = c10::Join(", ", scalar_input);
+  std::string scalar_operands = "%scalars : Scalar?[] = prim::ListConstruct(" +
+      joined_scalar_operands + ")\n";
+
+  constructed_operand_list += scalar_operands;
+
+  if (algorithm_indicator.empty()) {
+    std::string algorithm_placeholder = "%algorithm : str? = prim::Constant()";
+    constructed_operand_list += algorithm_placeholder;
+  }
+
+  return constructed_operand_list;
+}
+
+bool aten_gelu_approximate_is_supported(
+    const Match& match,
+    const std::unordered_map<std::string, Value*>& vmap) {
+  const auto& match_vmap = match.values_map;
+  auto approximate_value =
+      graph_rewrite_helper::getIValue("algorithm", match_vmap, vmap).value();
+  return approximate_value == "none" || approximate_value == "tanh";
+}
+
+const std::map<std::string, PostOp>& fusion_rewrite_map() {
+  static const std::map<std::string, PostOp> fusion_rewrite_map{
+      {"none", {zero_scalar_operand}},
+
+      // For element-wise OP that only has the activation as input:
+      {"relu", {zero_scalar_operand}},
+      {"sigmoid", {zero_scalar_operand}},
+      {"tanh", {zero_scalar_operand}},
+
+      // For element-wise OP that has other scalar inputs:
+      {"leaky_relu", {one_scalar_operand}},
+      {"hardtanh", {two_scalar_operands}},
+      {"clamp", {two_scalar_operands}},
+      {"gelu",
+       {zero_scalar_operand,
+        algorithm_indicator,
+        {aten_gelu_approximate_is_supported}}},
+  };
+  return fusion_rewrite_map;
+}
+
+} // namespace mkldnn
+
 c10::VaryingShape<int64_t> getSizesOf(Node* n, size_t idx) {
   auto tt = n->input(idx)->type()->cast<TensorType>();
   return tt->sizes();
@@ -59,6 +120,14 @@ void insertPrePackedConvOpForNode(Node* n) {
   prepack_node->addInput(input_size);
   auto attr = graph->insertConstant(IValue("none"));
   prepack_node->addInput(attr);
+  std::vector<c10::optional<at::Scalar>> empty_scalars;
+  auto scalars = graph->insertConstant(IValue(empty_scalars));
+  prepack_node->addInput(scalars);
+
+  c10::optional<std::string> empty_algorithm;
+  auto algorithm = graph->insertConstant(IValue(empty_algorithm));
+  prepack_node->addInput(algorithm);
+
   prepack_node->output()->setType(
       getCustomClass("__torch__.torch.classes.mkldnn.ConvOpContext"));
   graph->insertNode(prepack_node);
@@ -125,46 +194,95 @@ void insertMkldnnPrePackedOps(script::Module& module) {
   }
 }
 
-void FuseReluWithPackedOps(std::shared_ptr<Graph>& graph) {
+template <typename T>
+void RewriteEltwiseGraph(
+    std::shared_ptr<Graph>& graph,
+    const std::map<std::string, T>& fusion_rewrite_map,
+    std::string prepack_op_name,
+    std::string run_op_name,
+    std::string op_context_name,
+    std::string graph_input,
+    std::string prepack_input) {
   auto conv_op_rstring = at::jit::CodeTemplate(R"(
-    graph(%input, %weight, %bias, %stride:int[], %padding:int[],
-          %dilation:int[], %groups:int, %input_size:int[], %dummy_attr:str):
-        %packed_weight_bias = mkldnn_prepacked::conv2d_prepack(
-            %weight, %bias, %stride, %padding, %dilation, %groups,
-            %input_size, %dummy_attr)
-        %conv2d_res = mkldnn_prepacked::conv2d_run(%input, %packed_weight_bias)
-        %res = aten::${op}(%conv2d_res)
+    graph(${graph_input}
+          %input_size:int[], %attr_placeholder:str, %scalars_placeholder: Scalar?[], %algorithm_placeholder: str?${op_input_str}):
+        %packed_weight_bias = ${prepack_op_name}(
+            ${prepack_input}
+            %input_size, %attr_placeholder, %scalars_placeholder, %algorithm_placeholder)
+        %conv2d_res = ${run_op_name}(%input, %packed_weight_bias)
+        %res = aten::${op}(%conv2d_res${op_input_str})
         return (%res))");
 
   auto conv_op_fused_rstring = at::jit::CodeTemplate(R"(
-    graph(%input, %weight, %bias, %stride:int[], %padding:int[],
-          %dilation:int[], %groups:int, %input_size:int[], %dummy_attr:str):
+    graph(${graph_input}
+          %input_size:int[], %attr_placeholder:str, %scalars_placeholder: Scalar?[], %algorithm_placeholder: str?${op_input_str}):
         %attr: str = prim::Constant[value="${op_attr}"]()
-        %packed_weight_bias : __torch__.torch.classes.mkldnn.ConvOpContext = mkldnn_prepacked::conv2d_prepack(
-            %weight, %bias, %stride, %padding, %dilation, %groups,
-            %input_size, %attr)
-        %res = mkldnn_prepacked::conv2d_run(%input, %packed_weight_bias)
+        ${construct_operand_list}
+        %packed_weight_bias : __torch__.torch.classes.${op_context_name} =  ${prepack_op_name}(
+            ${prepack_input}
+            %input_size, %attr, %scalars, %algorithm)
+        %res = ${run_op_name}(%input, %packed_weight_bias)
         return (%res))");
 
-  for (auto const& it : mkldnn::fusion_rewrite_map) {
+  for (auto const& it : fusion_rewrite_map) {
     std::string op = it.first;
     if (op == std::string("none")) {
       continue;
     }
+    std::vector<std::string> op_input = it.second.scalar_input;
+    std::string algorithm_input = it.second.algorithm_input;
+
+    if (!algorithm_input.empty()) {
+      op_input.push_back(algorithm_input);
+    }
+    std::string op_input_str = c10::Join(", ", op_input);
+
+    if (!op_input.empty()) {
+      op_input_str = ", " + op_input_str;
+    }
 
     at::jit::TemplateEnv env;
     env.s("op", op);
+    env.s("op_input_str", op_input_str);
+    env.s("prepack_op_name", prepack_op_name);
+    env.s("run_op_name", run_op_name);
+    env.s("graph_input", graph_input);
+    env.s("prepack_input", prepack_input);
 
     at::jit::TemplateEnv env_fused;
     env_fused.s("op_attr", op);
+    env_fused.s("op_input_str", op_input_str);
+    env_fused.s(
+        "construct_operand_list",
+        mkldnn::construct_operand_list(
+            it.second.scalar_input, it.second.algorithm_input));
+    env_fused.s("prepack_op_name", prepack_op_name);
+    env_fused.s("run_op_name", run_op_name);
+    env_fused.s("op_context_name", op_context_name);
+    env_fused.s("graph_input", graph_input);
+    env_fused.s("prepack_input", prepack_input);
 
     SubgraphRewriter rewriter;
     rewriter.RegisterRewritePattern(
         conv_op_rstring.format(env), conv_op_fused_rstring.format(env_fused));
 
-    auto filters = it.second;
+    auto filters = it.second.filters;
     rewriter.runOnGraph(graph, filters);
   }
+}
+
+void FuseEltwiseWithPackedOps(std::shared_ptr<Graph>& graph) {
+  RewriteEltwiseGraph<mkldnn::PostOp>(
+      graph,
+      mkldnn::fusion_rewrite_map(),
+      std::string("mkldnn_prepacked::conv2d_prepack"),
+      std::string("mkldnn_prepacked::conv2d_run"),
+      std::string("mkldnn.ConvOpContext"),
+      std::string(
+          "%input, %weight, %bias, %stride:int[], %padding:int[], %dilation:int[], %groups:int,"),
+      std::string("%weight, %bias, %stride, %padding, %dilation, %groups,"));
+
+  // TODO: add linear
 }
 
 void PrePackingOpsFolder(Block* b) {
@@ -214,10 +332,13 @@ void FuseConvWithEltwise(std::shared_ptr<Graph>& graph) {
       *graph);
   insertMkldnnPrePackedOps(graph);
   GRAPH_DEBUG(
-      "After insertMkldnnPrePackedOps, before FuseReluWithPackedOps\n", *graph);
-  FuseReluWithPackedOps(graph);
+      "After insertMkldnnPrePackedOps, before FuseEltwiseWithPackedOps\n",
+      *graph);
+  FuseEltwiseWithPackedOps(graph);
   GRAPH_DEBUG(
-      "After FuseReluWithPackedOps, before FoldPrePackingOps\n", *graph);
+      "After FuseEltwiseWithPackedOps, before ConstantPropagation\n", *graph);
+  ConstantPropagation(graph);
+  GRAPH_DEBUG("After ConstantPropagation, before FoldPrePackingOps\n", *graph);
   FoldPrePackingOps(graph);
   GRAPH_DEBUG("After FoldPrePackingOps. End of FuseConvWithEltwise\n", *graph);
 }

--- a/torch/csrc/jit/passes/mkldnn_rewrite.h
+++ b/torch/csrc/jit/passes/mkldnn_rewrite.h
@@ -18,10 +18,10 @@ namespace jit {
 
 namespace mkldnn {
 
-const static std::map<std::string, std::vector<torch::jit::MatchFilter>>
-    fusion_rewrite_map = {
-        {"none", {}},
-        {"relu", {}},
+struct PostOp {
+  std::vector<std::string> scalar_input;
+  std::string algorithm_input = "";
+  std::vector<torch::jit::MatchFilter> filters = {};
 };
 
 } // namespace mkldnn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84466
* #84255
* #84401
* #84400
* __->__ #84254

add conv eltwise fusion for sigmoid and tanh

refactor the code to support more eltwise OPs

add conv eltwise fusion for leaky_relu, hardtanh, gelu and clamp

add UT for for leaky_relu, hardtanh, gelu and clamp

refactor UT to define eltwise OP list only once

remove unused variable

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel