### PR TITLE
Tensor cuda array interface: avoid constructing storage for element size

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1022,7 +1022,7 @@ class Tensor(torch._C._TensorBase):
             torch.int64: "<i8",
         }[self.dtype]
 
-        itemsize = self.storage().element_size()
+        itemsize = self.element_size()
 
         shape = tuple(self.shape)
         if self.is_contiguous():


### PR DESCRIPTION
Fixes #84267 