### PR TITLE
Fix DEBUG=1 BUILD_CAFFE2=1 build due to missing CHECK_NOTNULL

### DIFF
--- a/caffe2/contrib/nccl/cuda_nccl_gpu.cc
+++ b/caffe2/contrib/nccl/cuda_nccl_gpu.cc
@@ -177,7 +177,7 @@ void runNCCL(const NCCLExecution& ex, InitF&& init_f, F&& f) {
   // Now, wait on all the events in the original stream.
   CUDAGuard dg(ex.stream_gpu_id);
   for (auto& event : events) {
-    CUDA_ENFORCE(cudaStreamWaitEvent(CHECK_NOTNULL(ex.stream), event, 0));
+    CUDA_ENFORCE(cudaStreamWaitEvent(TORCH_CHECK_NOTNULL(ex.stream), event, 0));
   }
 }
 


### PR DESCRIPTION
This PR replaces CHECK_NOTNULL by TORCH_CHECK_NOTNULL to fix debug
builds for pytorch with libcaffe2

Fixes #ISSUE_NUMBER
