### PR TITLE
[Quant] Remove warnings from using torch.tensor(value)

### DIFF
--- a/torch/ao/nn/quantized/_reference/modules/rnn.py
+++ b/torch/ao/nn/quantized/_reference/modules/rnn.py
@@ -57,23 +57,23 @@ class RNNCellBase(nn.RNNCellBase):
         assert weight_qparams_dict is not None
         for key, weight_qparams in weight_qparams_dict.items():
             # TODO: refactor the duplicated code to utils.py
-            weight_qscheme = weight_qparams["qscheme"]
-            weight_dtype = weight_qparams["dtype"]
-            setattr(self, key + "_qscheme", weight_qscheme)
-            setattr(self, key + "_dtype", weight_dtype)
-            assert weight_qscheme in [None, torch.per_tensor_affine, torch.per_channel_affine], \
-                Exception(f"qscheme: {weight_qscheme} is not support in {self._get_name()}")
             if weight_qscheme is not None:
-                self.register_buffer(
-                    key + "_scale",
-                    torch.tensor(weight_qparams["scale"], dtype=torch.float, device=device))
-                self.register_buffer(
-                    key + "_zero_point",
-                    torch.tensor(weight_qparams["zero_point"], dtype=torch.int, device=device))
+                scale = weight_qparams["scale"]
+                scale_tensor = scale.clone().detach() \
+                    if isinstance(scale, torch.Tensor) else \
+                    torch.tensor(scale, dtype=torch.float, device=device)
+                self.register_buffer(key + "_scale", scale_tensor)
+                zp = weight_qparams["zero_point"]
+                zp_tensor = zp.clone().detach() \
+                    if isinstance(zp, torch.Tensor) else \
+                    torch.tensor(zp, dtype=torch.int, device=device)
+                self.register_buffer(key + "_zero_point", zp_tensor)
                 if weight_qscheme == torch.per_channel_affine:
-                    self.register_buffer(
-                        key + "_axis",
-                        torch.tensor(weight_qparams["axis"], dtype=torch.int, device=device))
+                    axis = weight_qparams["axis"]
+                    axis_tensor = axis.clone().detach() \
+                        if isinstance(axis, torch.Tensor) else \
+                        torch.tensor(axis, dtype=torch.int, device=device)
+                    self.register_buffer(key + "_axis", axis_tensor)
                 else:
                     # added for TorchScriptability, not used
                     self.register_buffer(

--- a/torch/ao/nn/quantized/_reference/modules/rnn.py
+++ b/torch/ao/nn/quantized/_reference/modules/rnn.py
@@ -57,6 +57,12 @@ class RNNCellBase(nn.RNNCellBase):
         assert weight_qparams_dict is not None
         for key, weight_qparams in weight_qparams_dict.items():
             # TODO: refactor the duplicated code to utils.py
+            weight_qscheme = weight_qparams["qscheme"]
+            weight_dtype = weight_qparams["dtype"]
+            setattr(self, key + "_qscheme", weight_qscheme)
+            setattr(self, key + "_dtype", weight_dtype)
+            assert weight_qscheme in [None, torch.per_tensor_affine, torch.per_channel_affine], \
+                Exception(f"qscheme: {weight_qscheme} is not support in {self._get_name()}")
             if weight_qscheme is not None:
                 scale = weight_qparams["scale"]
                 scale_tensor = scale.clone().detach() \

--- a/torch/ao/nn/quantized/_reference/modules/utils.py
+++ b/torch/ao/nn/quantized/_reference/modules/utils.py
@@ -20,16 +20,22 @@ class ReferenceQuantizedModule(torch.nn.Module):
             zero_point_dtype = weight_qparams["zero_point"].dtype if \
                 isinstance(weight_qparams["zero_point"], torch.Tensor) else \
                 torch.int
-            self.register_buffer(
-                "weight_scale",
-                torch.tensor(weight_qparams["scale"], dtype=torch.float, device=device))
-            self.register_buffer(
-                "weight_zero_point",
-                torch.tensor(weight_qparams["zero_point"], dtype=zero_point_dtype, device=device))
+            w_scale = weight_qparams["scale"]
+            w_scale_tensor = w_scale.clone().detach() \
+                if isinstance(w_scale, torch.Tensor) \
+                else torch.tensor(w_scale, dtype=torch.float, device=device)
+            self.register_buffer("weight_scale", w_scale_tensor)
+            w_zp = weight_qparams["zero_point"]
+            w_zp_tensor = w_zp.clone().detach() \
+                if isinstance(w_zp, torch.Tensor) \
+                else torch.tensor(w_zp, dtype=zero_point_dtype, device=device)
+            self.register_buffer("weight_zero_point", w_zp_tensor)
             if self.weight_qscheme in [torch.per_channel_affine, torch.per_channel_affine_float_qparams]:
-                self.register_buffer(
-                    "weight_axis",
-                    torch.tensor(weight_qparams["axis"], dtype=torch.int, device=device))
+                w_axis = weight_qparams["axis"]
+                w_axis_tensor = w_axis.clone().detach() \
+                    if isinstance(w_axis, torch.Tensor) \
+                    else torch.tensor(w_axis, dtype=torch.int, device=device)
+                self.register_buffer("weight_axis", w_axis_tensor)
             else:
                 # added for TorchScriptability, not used
                 self.register_buffer(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84277

Summary:

I think zafar made an earlier pull for these changes [here](https://github.com/pytorch/pytorch/commit/ce0786add26c1e117b16b58e8ae12dbe776133e1), but they didn't seem to make it through the migration.

Test Plan:
```
python test/test_quantization.py
```

Reviewers:

Subscribers:

Tasks: https://github.com/pytorch/pytorch/issues/73566

Tags: quant

Differential Revision: [D39145070](https://our.internmc.facebook.com/intern/diff/D39145070)