### PR TITLE
[Quant] Remove warnings from creating tensors using torch.tensor

### DIFF
--- a/torch/ao/nn/quantized/_reference/modules/rnn.py
+++ b/torch/ao/nn/quantized/_reference/modules/rnn.py
@@ -57,6 +57,12 @@ class RNNCellBase(nn.RNNCellBase):
         assert weight_qparams_dict is not None
         for key, weight_qparams in weight_qparams_dict.items():
             # TODO: refactor the duplicated code to utils.py
+            weight_qscheme = weight_qparams["qscheme"]
+            weight_dtype = weight_qparams["dtype"]
+            setattr(self, key + "_qscheme", weight_qscheme)
+            setattr(self, key + "_dtype", weight_dtype)
+            assert weight_qscheme in [None, torch.per_tensor_affine, torch.per_channel_affine], \
+                Exception(f"qscheme: {weight_qscheme} is not support in {self._get_name()}")
             if weight_qscheme is not None:
                 scale = weight_qparams["scale"]
                 scale_tensor = scale.clone().detach() \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84278
* #84277

Summary:
I think @vasiliy made a PR for this already [here](https://github.com/pytorch/pytorch/pull/80883), but some of his changes didn't seem to make it through the migration.
I just copied over the ones that didn't into this pull.

Test Plan:
```
python test/test_quantization.py TestQuantizeFxOps
```

Reviewers:

Subscribers:

Tasks: Fixes https://github.com/pytorch/pytorch/issues/73566

Tags: quant