### PR TITLE
[PyTorch][Profiler] Increase max number of elements to record in execution graph

### DIFF
--- a/torch/csrc/profiler/execution_graph_observer.cpp
+++ b/torch/csrc/profiler/execution_graph_observer.cpp
@@ -44,10 +44,12 @@ inline std::string vectorToString(const std::vector<T>& v) {
   return fmt::format("[{}]", fmt::join(v, ","));
 }
 
+constexpr size_t maxNumElements = 4096;
+
 inline std::string getValueType(
     const c10::IValue& val,
     const bool baseType = true,
-    const size_t maxArrayLen = 100) {
+    const size_t maxArrayLen = maxNumElements) {
   std::string type = val.tagKind();
 
   if (val.isTensor()) {
@@ -79,7 +81,7 @@ inline std::string getValueType(
 
 inline std::string getValueShape(
     const c10::IValue& val,
-    const size_t maxArrayLen = 100) {
+    const size_t maxArrayLen = maxNumElements) {
   if (val.isTensor()) {
     auto& tensor = val.toTensor();
     if (tensor.defined()) {
@@ -122,8 +124,14 @@ inline std::string getScalarValue(const c10::IValue& val) {
   } else if (val.isBool()) {
     return val.toBool() ? "true" : "false";
   } else if (val.isString()) {
-    constexpr int maxStringLen = 500;
-    return fmt::format("\"{}\"", val.toStringRef().substr(0, maxStringLen));
+    const std::string& str_val = val.toStringRef();
+    if (str_val.size() > maxNumElements) {
+      LOG(WARNING) << "string size=" << str_val.size()
+                   << " exceeded maxNumElements=" << maxNumElements;
+      return fmt::format("\"{}\"", str_val.substr(0, maxNumElements));
+    }
+
+    return fmt::format("\"{}\"", str_val);
   } else if (val.isDevice()) {
     return fmt::format("\"{}\"", val.toDevice().str());
   }
@@ -314,7 +322,7 @@ bool initExecutionGraphStart(ExecutionGraphObserver& ob) {
 
   ob.out << fmt::format(
       R"JSON({{
-  "schema": "1.0.0", "pid": {}, "time": "{}", "start_ts": {},
+  "schema": "1.0.1", "pid": {}, "time": "{}", "start_ts": {},
   "nodes": [)JSON",
       ob.pid,
       ob.record_time,
@@ -368,7 +376,7 @@ inline ExecutionGraphObserver::ID getObjectID(
 inline std::string convertIValue(
     ExecutionGraphObserver& ob,
     const c10::IValue& val,
-    const size_t maxArrayLen = 100) {
+    const size_t maxArrayLen = maxNumElements) {
   if (val.isTensor()) {
     const auto t = val.toTensor().unsafeGetTensorImpl();
     ExecutionGraphObserver::ID tensor_id = getObjectID(ob, t);


### PR DESCRIPTION
Summary: Noticed some jobs are exceeding the max num of elements in an array. 100 was too conservative (observed 128 sizes in CMF model), but we also don't want have unbounded container size. Setting to a large number 4096 that probably will catch extreme cases.

Test Plan:
```
buck build mode/opt-split-dwarf //hpc/models/ads:ads_10x_launcher --show-output

buck-out/gen/hpc/models/ads/ads_10x_launcher.par +checkpoint=model_store +launcher=mast +data_loader=dist +mode=mast launcher.data_project=ads_model_platform launcher.fbl_entitlement=ads_global_qps checkpoint.model_type=ctr_mobile_feed_model data_loader.table_ds=["2022-08-15"] data_loader.num_batches=5000 profiling_trace=true
```

Differential Revision: D39137530

