### PR TITLE
Removing multigpu 10.2 . Using 11.6 cuda for multigpu tests instead

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -85,13 +85,21 @@ jobs:
       build-environment: linux-bionic-cuda10.2-py3.9-gcc7
       docker-image-name: pytorch-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7
 
-  linux-bionic-cuda10_2-py3_9-gcc7-test:
-    name: linux-bionic-cuda10.2-py3.9-gcc7
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-bionic-cuda10_2-py3_9-gcc7-build
+  linux-bionic-cuda11_6-py3_9-gcc7-build:
+    name: linux-bionic-cuda11.6-py3.9-gcc7
+    uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-bionic-cuda10.2-py3.9-gcc7
-      docker-image: ${{ needs.linux-bionic-cuda10_2-py3_9-gcc7-build.outputs.docker-image }}
+      build-environment: linux-bionic-cuda11.6-py3.9-gcc7
+      docker-image-name: pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7
+      build-with-debug: false
+
+  linux-bionic-cuda11_6-py3_9-gcc7-test:
+    name: linux-bionic-cuda11.6-py3.9-gcc7
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-bionic-cuda11_6-py3_9-gcc7-build
+    with:
+      build-environment: linux-bionic-cuda11.6-py3.9-gcc7
+      docker-image: ${{ needs.linux-bionic-cuda11_6-py3_9-gcc7-build.outputs.docker-image }}
       test-matrix: |
         { include: [
           { config: "multigpu", shard: 1, num_shards: 1, runner: "linux.16xlarge.nvidia.gpu" },


### PR DESCRIPTION
Removing multigpu 10.2 . Using 11.6 cuda for multigpu tests instead
