### PR TITLE
Read via FileAdapter when loading files in torch if not flatbuffer - Part 2

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -597,7 +597,7 @@ mobile::Module _load_for_mobile(
   }
 
   std::unique_ptr<FileAdapter> rai = std::make_unique<FileAdapter>(filename);
-  return _load_for_mobile(
+  return _load_for_mobile_impl(
       std::move(rai), device, extra_files, module_load_options);
 }
 
@@ -606,6 +606,7 @@ TORCH_API mobile::Module _load_for_mobile(
     c10::optional<c10::Device> device,
     ExtraFilesMap& extra_files,
     uint64_t module_load_options) {
+  // TODO optimize file read for non-flatbuffer models
   std::shared_ptr<char> data;
   size_t size = 0;
   std::tie(data, size) = get_rai_content(rai.get());


### PR DESCRIPTION
Summary: D38998858 (https://github.com/pytorch/pytorch/commit/3fae89d4a468a02be501357eb123ce2bf7086d2f) used the wrong version of `_load_for_mobile` that kept the "load everything in memory then parse" technique.  This fixes it to call the `_load_for_mobile_impl` version which for non-flatbuffer models will stream parse.  See D38998858 (https://github.com/pytorch/pytorch/commit/3fae89d4a468a02be501357eb123ce2bf7086d2f) for the expected memory optimization gains.

Test Plan: CI Signals.

Reviewed By: qihqi

Differential Revision: D39138280

