### PR TITLE
no ios arm builds on circleci

### DIFF
--- a/.circleci/cimodel/data/simple/ios_definitions.py
+++ b/.circleci/cimodel/data/simple/ios_definitions.py
@@ -61,18 +61,7 @@ class IOSJob:
 WORKFLOW_DATA = [
     IOSJob(XCODE_VERSION, ArchVariant("x86_64"), is_org_member_context=False, extra_props={
         "lite_interpreter": miniutils.quote(str(int(True)))}),
-    IOSJob(XCODE_VERSION, ArchVariant("arm64"), extra_props={
-        "lite_interpreter": miniutils.quote(str(int(True)))}),
-    IOSJob(XCODE_VERSION, ArchVariant("arm64", "metal"), extra_props={
-        "use_metal": miniutils.quote(str(int(True))),
-        "lite_interpreter": miniutils.quote(str(int(True)))}),
-    IOSJob(XCODE_VERSION, ArchVariant("arm64", "custom-ops"), extra_props={
-        "op_list": "mobilenetv2.yaml",
-        "lite_interpreter": miniutils.quote(str(int(True)))}),
     IOSJob(XCODE_VERSION, ArchVariant("x86_64", "coreml"), is_org_member_context=False, extra_props={
-        "use_coreml": miniutils.quote(str(int(True))),
-        "lite_interpreter": miniutils.quote(str(int(True)))}),
-    IOSJob(XCODE_VERSION, ArchVariant("arm64", "coreml"), extra_props={
         "use_coreml": miniutils.quote(str(int(True))),
         "lite_interpreter": miniutils.quote(str(int(True)))}),
 ]

--- a/.circleci/cimodel/data/simple/ios_definitions.py
+++ b/.circleci/cimodel/data/simple/ios_definitions.py
@@ -61,9 +61,20 @@ class IOSJob:
 WORKFLOW_DATA = [
     IOSJob(XCODE_VERSION, ArchVariant("x86_64"), is_org_member_context=False, extra_props={
         "lite_interpreter": miniutils.quote(str(int(True)))}),
+    # IOSJob(XCODE_VERSION, ArchVariant("arm64"), extra_props={
+    #     "lite_interpreter": miniutils.quote(str(int(True)))}),
+    # IOSJob(XCODE_VERSION, ArchVariant("arm64", "metal"), extra_props={
+    #     "use_metal": miniutils.quote(str(int(True))),
+    #     "lite_interpreter": miniutils.quote(str(int(True)))}),
+    # IOSJob(XCODE_VERSION, ArchVariant("arm64", "custom-ops"), extra_props={
+    #     "op_list": "mobilenetv2.yaml",
+    #     "lite_interpreter": miniutils.quote(str(int(True)))}),
     IOSJob(XCODE_VERSION, ArchVariant("x86_64", "coreml"), is_org_member_context=False, extra_props={
         "use_coreml": miniutils.quote(str(int(True))),
         "lite_interpreter": miniutils.quote(str(int(True)))}),
+    # IOSJob(XCODE_VERSION, ArchVariant("arm64", "coreml"), extra_props={
+    #     "use_coreml": miniutils.quote(str(int(True))),
+    #     "lite_interpreter": miniutils.quote(str(int(True)))}),
 ]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1532,47 +1532,6 @@ workflows:
           lite_interpreter: "1"
           name: ios-12-5-1-x86-64
       - pytorch_ios_build:
-          build_environment: ios-12-5-1-arm64
-          context: org-member
-          filters:
-            branches:
-              ignore:
-                - master
-                - nightly
-                - postnightly
-          ios_arch: arm64
-          ios_platform: OS
-          lite_interpreter: "1"
-          name: ios-12-5-1-arm64
-      - pytorch_ios_build:
-          build_environment: ios-12-5-1-arm64-metal
-          context: org-member
-          filters:
-            branches:
-              ignore:
-                - master
-                - nightly
-                - postnightly
-          ios_arch: arm64
-          ios_platform: OS
-          lite_interpreter: "1"
-          name: ios-12-5-1-arm64-metal
-          use_metal: "1"
-      - pytorch_ios_build:
-          build_environment: ios-12-5-1-arm64-custom-ops
-          context: org-member
-          filters:
-            branches:
-              ignore:
-                - master
-                - nightly
-                - postnightly
-          ios_arch: arm64
-          ios_platform: OS
-          lite_interpreter: "1"
-          name: ios-12-5-1-arm64-custom-ops
-          op_list: mobilenetv2.yaml
-      - pytorch_ios_build:
           build_environment: ios-12-5-1-x86-64-coreml
           filters:
             branches:
@@ -1584,19 +1543,5 @@ workflows:
           ios_platform: SIMULATOR
           lite_interpreter: "1"
           name: ios-12-5-1-x86-64-coreml
-          use_coreml: "1"
-      - pytorch_ios_build:
-          build_environment: ios-12-5-1-arm64-coreml
-          context: org-member
-          filters:
-            branches:
-              ignore:
-                - master
-                - nightly
-                - postnightly
-          ios_arch: arm64
-          ios_platform: OS
-          lite_interpreter: "1"
-          name: ios-12-5-1-arm64-coreml
           use_coreml: "1"
     when: << pipeline.parameters.run_build >>


### PR DESCRIPTION
Get rid of ios arm builds on circleci b/c most people dont have these permissions and they make the job show up as failing/red.

Next step is to see if we can do only builds since they might not require credentials