### PR TITLE
Fix type annotation in `_ConvNd` for in_channels

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -54,7 +54,7 @@ class _ConvNd(Module):
     def _conv_forward(self, input: Tensor, weight: Tensor, bias: Optional[Tensor]) -> Tensor:
         ...
 
-    _in_channels: int
+    in_channels: int
     _reversed_padding_repeated_twice: List[int]
     out_channels: int
     kernel_size: Tuple[int, ...]


### PR DESCRIPTION
`_ConvNd` has an attribute `in_channels` that was mistakenly annotated as `_in_channels`.

This fixes https://github.com/pytorch/pytorch/issues/84223