### PR TITLE
[ROCm] guard ROCm-only files in NVFUSER_RUNTIME_FILES

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -16,13 +16,10 @@
 
 #include <nvfuser_resources/PhiloxCudaStateRaw.h>
 #include <nvfuser_resources/array.h>
-#include <nvfuser_resources/array_rocm.h>
 #include <nvfuser_resources/bf16_support.h>
-#include <nvfuser_resources/bf16_support_rocm.h>
 #include <nvfuser_resources/block_reduction.h>
 #include <nvfuser_resources/block_sync_atomic.h>
 #include <nvfuser_resources/block_sync_default.h>
-#include <nvfuser_resources/block_sync_default_rocm.h>
 #include <nvfuser_resources/broadcast.h>
 #include <nvfuser_resources/fp16_support.h>
 #include <nvfuser_resources/fused_reduction.h>
@@ -39,8 +36,14 @@
 #include <nvfuser_resources/tuple.h>
 #include <nvfuser_resources/type_traits.h>
 #include <nvfuser_resources/warp.h>
-#include <nvfuser_resources/warp_rocm.h>
 #include <nvfuser_resources/welford.h>
+
+#ifdef USE_ROCM
+#include <nvfuser_resources/array_rocm.h>
+#include <nvfuser_resources/bf16_support_rocm.h>
+#include <nvfuser_resources/block_sync_default_rocm.h>
+#include <nvfuser_resources/warp_rocm.h>
+#endif
 
 #ifndef USE_ROCM
 #include <cuda_occupancy.h>

--- a/torch/csrc/jit/codegen/cuda/nvfuser.cmake
+++ b/torch/csrc/jit/codegen/cuda/nvfuser.cmake
@@ -9,16 +9,13 @@ endif()
 # The list of NVFUSER runtime files
 list(APPEND NVFUSER_RUNTIME_FILES
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/array.cu
-  ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/array_rocm.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/block_reduction.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/block_sync_atomic.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/block_sync_default.cu
-  ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/block_sync_default_rocm.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/broadcast.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/fp16_support.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/fused_reduction.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/bf16_support.cu
-  ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/bf16_support_rocm.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/grid_broadcast.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/grid_reduction.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/grid_sync.cu
@@ -30,13 +27,21 @@ list(APPEND NVFUSER_RUNTIME_FILES
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/type_traits.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/welford.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/warp.cu
-  ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/warp_rocm.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/tensorcore.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/memory.cu
   ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/swizzle.cu
   ${TORCH_ROOT}/aten/src/ATen/cuda/detail/PhiloxCudaStateRaw.cuh
   ${TORCH_ROOT}/aten/src/ATen/cuda/detail/UnpackRaw.cuh
 )
+
+if(USE_ROCM)
+list(APPEND NVFUSER_RUNTIME_FILES
+  ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/array_rocm.cu
+  ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/bf16_support_rocm.cu
+  ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/block_sync_default_rocm.cu
+  ${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/runtime/warp_rocm.cu
+)
+endif()
 
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/include/nvfuser_resources")
 


### PR DESCRIPTION
Addresses comment in #82498 as a follow-up PR.  

https://github.com/pytorch/pytorch/pull/82498#discussion_r958745967