### PR TITLE
Move slow-grad checks to CUDA-11.6

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -13,20 +13,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  linux-xenial-cuda10_2-py3-gcc7-slow-gradcheck-build:
-    name: linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck
+  linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build:
+    name: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck
-      docker-image-name: pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7
+      build-environment: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
+      docker-image-name: pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7
 
-  linux-xenial-cuda10_2-py3-gcc7-slow-gradcheck-test:
-    name: linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck
+  linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-test:
+    name: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-xenial-cuda10_2-py3-gcc7-slow-gradcheck-build
+    needs: linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build
     with:
-      build-environment: linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck
-      docker-image: ${{ needs.linux-xenial-cuda10_2-py3-gcc7-slow-gradcheck-build.outputs.docker-image }}
+      build-environment: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
+      docker-image: ${{ needs.linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build.outputs.docker-image }}
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 2, runner: "linux.4xlarge.nvidia.gpu" },
@@ -77,13 +77,6 @@ jobs:
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
-
-  linux-bionic-cuda10_2-py3_9-gcc7-build:
-    name: linux-bionic-cuda10.2-py3.9-gcc7
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: linux-bionic-cuda10.2-py3.9-gcc7
-      docker-image-name: pytorch-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7
 
   linux-bionic-cuda11_6-py3_9-gcc7-build:
     name: linux-bionic-cuda11.6-py3.9-gcc7

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1277,7 +1277,7 @@ op_db: List[OpInfo] = [
                 dtypes=(torch.complex128,),
             ),
             DecorateInfo(
-                unittest.skip("Skipped!"),
+                unittest.skip("Skipped, see https://github.com//issues/84192"),
                 "TestGradients",
                 "test_fn_gradgrad",
                 device_type="cuda",

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1277,7 +1277,7 @@ op_db: List[OpInfo] = [
                 dtypes=(torch.complex128,),
             ),
             DecorateInfo(
-                toleranceOverride({torch.float64: tol(atol=1e-4, rtol=1e-4)}),
+                unittest.skip("Skipped!"),
                 "TestGradients",
                 "test_fn_gradgrad",
                 device_type="cuda",

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1280,7 +1280,7 @@ op_db: List[OpInfo] = [
                 toleranceOverride({torch.float64: tol(atol=1e-4, rtol=1e-4)}),
                 "TestGradients",
                 "test_fn_gradgrad",
-                device="cuda",
+                device_type="cuda",
             ),
         ),
     ),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1279,6 +1279,7 @@ op_db: List[OpInfo] = [
             DecorateInfo(
                 "TestGradients",
                 "test_fn_gradgrad",
+                device="cuda",
                 toleranceOverride({torch.float64: tol(atol=1e-4, rtol=1e-4)})
             ),
         ),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1277,10 +1277,10 @@ op_db: List[OpInfo] = [
                 dtypes=(torch.complex128,),
             ),
             DecorateInfo(
+                toleranceOverride({torch.float64: tol(atol=1e-4, rtol=1e-4)}),
                 "TestGradients",
                 "test_fn_gradgrad",
                 device="cuda",
-                toleranceOverride({torch.float64: tol(atol=1e-4, rtol=1e-4)}),
             ),
         ),
     ),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1283,7 +1283,7 @@ op_db: List[OpInfo] = [
                 device_type="cuda",
             ),
             DecorateInfo(
-                unittest.skip("Skipped!"),
+                unittest.skip("Skipped, see https://github.com//issues/84192"),
                 "TestGradients",
                 "test_fn_fwgrad_bwgrad",
                 device_type="cuda",

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1282,6 +1282,12 @@ op_db: List[OpInfo] = [
                 "test_fn_gradgrad",
                 device_type="cuda",
             ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestGradients",
+                "test_fn_fwgrad_bwgrad",
+                device_type="cuda",
+            ),
         ),
     ),
     OpInfo(

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1280,7 +1280,7 @@ op_db: List[OpInfo] = [
                 "TestGradients",
                 "test_fn_gradgrad",
                 device="cuda",
-                toleranceOverride({torch.float64: tol(atol=1e-4, rtol=1e-4)})
+                toleranceOverride({torch.float64: tol(atol=1e-4, rtol=1e-4)}),
             ),
         ),
     ),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1276,6 +1276,11 @@ op_db: List[OpInfo] = [
                 "test_fn_fwgrad_bwgrad",
                 dtypes=(torch.complex128,),
             ),
+            DecorateInfo(
+                "TestGradients",
+                "test_fn_gradgrad",
+                toleranceOverride({torch.float64: tol(atol=1e-4, rtol=1e-4)})
+            ),
         ),
     ),
     OpInfo(


### PR DESCRIPTION
Mitigates #84192 by skipping two tests

Please note: We tried to increase the tolerance for test_fn_gradgrad_linalg_det_singular_cuda_float64 but this did not help.
Ref:
Increase `test_fn_gradgrad_linalg_det_singular_cuda_float64` error tolerance to  1e-4 as suggested in https://github.com/pytorch/pytorch/issues/84192#issuecomment-1230644574

