### PR TITLE
[CI] Move bazel from 11.3 to 11.6

### DIFF
--- a/.circleci/docker/ubuntu-cuda/Dockerfile
+++ b/.circleci/docker/ubuntu-cuda/Dockerfile
@@ -122,5 +122,9 @@ COPY ./common/install_cudnn.sh install_cudnn.sh
 RUN if [ "${CUDNN_VERSION}" -eq 8 ]; then bash install_cudnn.sh; fi
 RUN rm install_cudnn.sh
 
+# Delete /usr/local/cuda-11.X/cuda-11.X symlinks
+RUN if [ -h /usr/local/cuda-11.6/cuda-11.6 ]; then rm /usr/local/cuda-11.6/cuda-11.6; fi
+RUN if [ -h /usr/local/cuda-11.7/cuda-11.7 ]; then rm /usr/local/cuda-11.7/cuda-11.7; fi
+
 USER jenkins
 CMD ["bash"]

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -253,12 +253,12 @@ jobs:
       cuda-version: "11.6"
       sync-tag: win-cuda-build
 
-  linux-xenial-cuda11_3-py3_7-gcc7-bazel-test:
-    name: linux-xenial-cuda11.3-py3.7-gcc7-bazel-test
+  linux-bionic-cuda11_6-py3_10-gcc7-bazel-test:
+    name: linux-bionic-cuda11.6-py3.10-gcc7-bazel-test
     uses: ./.github/workflows/_bazel-build-test.yml
     with:
-      build-environment: linux-xenial-cuda11.3-py3.7-gcc7-bazel-test
-      docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
+      build-environment: linux-bionicl-cuda11.6-py3.10-gcc7-bazel-test
+      docker-image-name: pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7
 
   linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single:
     name: linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,6 +28,10 @@ COMMON_COPTS = [
 ] + if_cuda([
     "-DUSE_CUDA",
     "-DUSE_CUDNN",
+    # TODO: This should be passed only when building for CUDA-11.5 or newer
+    # use cub in a safe manner, see:
+    # https://github.com/pytorch/pytorch/pull/55292
+    "-DCUB_WRAPPED_NAMESPACE=at_cuda_detail",
 ])
 
 aten_generation_srcs = ["aten/src/ATen/native/native_functions.yaml"] + ["aten/src/ATen/native/tags.yaml"] + glob(["aten/src/ATen/templates/**"])


### PR DESCRIPTION
In process of doing so have to:
- Delete `/usr/local/cuda-11.6/cuda-11.6` symlink to self, otherwise Bazel builds fail with
```
ERROR: circular symlinks detected
[start of symlink cycle]
/usr/local/cuda-11.6/cuda-11.6
[end of symlink cycle]
```
- Add `-DCUB_WRAPPED_NAMESPACE=at_cuda_detail"` to `COMMON_COPTS` if building with CUDA, to mimic the behaviour in
https://github.com/pytorch/pytorch/blob/4b8ae047881314580826113f8a224f3fd935b203/cmake/Dependencies.cmake#L1664-L1668