### PR TITLE
Import forgotten pack_weight_bias in rnn.py

### DIFF
--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -11,6 +11,7 @@ while adding an import statement here.
 __all__ = ['pack_weight_bias', 'PackedParameter', 'RNNBase', 'LSTM', 'GRU', 'RNNCellBase', 'RNNCell', 'LSTMCell',
            'GRUCell']
 
+from torch.ao.nn.quantized.dynamic.modules.rnn import pack_weight_bias
 from torch.ao.nn.quantized.dynamic.modules.rnn import PackedParameter
 from torch.ao.nn.quantized.dynamic.modules.rnn import RNNBase
 from torch.ao.nn.quantized.dynamic.modules.rnn import LSTM


### PR DESCRIPTION
`pack_weight_bias` is exported in `__all__`, but the actual import was lot during migration in https://github.com/pytorch/pytorch/pull/78714.