### PR TITLE
Fix placeholder's target name.

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -774,6 +774,8 @@ class Graph:
 
         candidate = name if name is not None else self._target_to_str(target)
         name = self._graph_namespace.create_name(candidate, None)
+        if op == "placeholder":
+            target = name
         n = Node(self, name, op, target, args, kwargs, type_expr)
 
         self._graph_namespace.associate_name_with_obj(name, n)


### PR DESCRIPTION
When a placeholder's target name conflicts with another node
output, the placeholder should use a new name as its
target. Alternative solution is sorting `nodes` before running a graph
so that all placeholders are executed as early as possible.
See #84311's for details.

Fixes #84311


cc @ezyang @SherlockNoMad @soumith @EikanWang @jgong5 @wenzhe-nrv