### PR TITLE
Add bfloat16 support for lerp on CPU

### DIFF
--- a/aten/src/ATen/native/cpu/LerpKernel.cpp
+++ b/aten/src/ATen/native/cpu/LerpKernel.cpp
@@ -9,7 +9,36 @@ namespace native {
 namespace {
 
 void lerp_scalar_kernel(at::TensorIteratorBase& iter, const Scalar& weight) {
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(iter.common_dtype(), "lerp_kernel_scalar", [&] {
+  if (iter.common_dtype() == kBFloat16) {
+    using bVec = Vectorized<BFloat16>;
+    using fVec = Vectorized<float>;
+    float weight_val = weight.to<float>();
+    auto weight_vec = fVec(weight_val);
+    auto threshold_vec = fVec(0.5);
+    auto one_vec = fVec(1);
+    at::native::cpu_kernel_vec(
+      iter,
+      [weight_val](BFloat16 self_val, BFloat16 end_val) -> BFloat16 {
+        return (weight_val < 0.5)
+              ? float(self_val) + weight_val * (float(end_val) - float(self_val))
+              : float(end_val) - (float(end_val) - float(self_val)) * (float(1) - weight_val);
+      },
+      [=](bVec self_vec, bVec end_vec) -> bVec {
+          fVec self_vec0, self_vec1, end_vec0, end_vec1;
+          std::tie(self_vec0, self_vec1) = convert_bfloat16_float(self_vec);
+          std::tie(end_vec0, end_vec1) = convert_bfloat16_float(end_vec);
+          auto result0 = fVec::blendv(
+            end_vec0 - (end_vec0 - self_vec0) * (one_vec - weight_vec),
+            self_vec0 + weight_vec * (end_vec0 - self_vec0),
+            weight_vec < threshold_vec);
+          auto result1 = fVec::blendv(
+            end_vec1 - (end_vec1 - self_vec1) * (one_vec - weight_vec),
+            self_vec1 + weight_vec * (end_vec1 - self_vec1),
+            weight_vec < threshold_vec);
+          return convert_float_bfloat16(result0, result1);
+      });
+  } else {
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(iter.common_dtype(), "lerp_kernel_scalar", [&] {
     using value_t = typename c10::scalar_value_type<scalar_t>::type;
     scalar_t weight_val = weight.to<scalar_t>();
     at::native::cpu_kernel(
@@ -19,11 +48,40 @@ void lerp_scalar_kernel(at::TensorIteratorBase& iter, const Scalar& weight) {
               ? self_val + weight_val * (end_val - self_val)
               : end_val - (end_val - self_val) * (scalar_t(1) - weight_val);
         });
-  });
+    });
+  }
 }
 
 void lerp_tensor_kernel(at::TensorIteratorBase& iter) {
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(iter.common_dtype(), "lerp_kernel_tensor", [&] {
+  if (iter.common_dtype() == kBFloat16) {
+    using bVec = Vectorized<BFloat16>;
+    using fVec = Vectorized<float>;
+    auto one_vec = fVec(1);
+    auto threshold_vec = fVec(0.5);
+    at::native::cpu_kernel_vec(
+      iter,
+      [=](BFloat16 self_val, BFloat16 end_val, BFloat16 weight_val) -> BFloat16 {
+        return (weight_val < 0.5)
+              ? float(self_val) + weight_val * (float(end_val) - float(self_val))
+              : float(end_val) - (float(end_val) - float(self_val)) * (float(1) - weight_val);
+      },
+      [=](bVec self_vec, bVec end_vec, bVec weight_vec) -> bVec {
+          fVec self_vec0, self_vec1, end_vec0, end_vec1, weight_vec0, weight_vec1;
+          std::tie(self_vec0, self_vec1) = convert_bfloat16_float(self_vec);
+          std::tie(end_vec0, end_vec1) = convert_bfloat16_float(end_vec);
+          std::tie(weight_vec0, weight_vec1) = convert_bfloat16_float(weight_vec);
+          auto result0 = fVec::blendv(
+            end_vec0 - (end_vec0 - self_vec0) * (one_vec - weight_vec0),
+            self_vec0 + weight_vec0 * (end_vec0 - self_vec0),
+            weight_vec0 < threshold_vec);
+          auto result1 = fVec::blendv(
+            end_vec1 - (end_vec1 - self_vec1) * (one_vec - weight_vec1),
+            self_vec1 + weight_vec1 * (end_vec1 - self_vec1),
+            weight_vec1 < threshold_vec);
+          return convert_float_bfloat16(result0, result1);
+      });
+  } else {
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(iter.common_dtype(), "lerp_kernel_tensor", [&] {
     using value_t = typename c10::scalar_value_type<scalar_t>::type;
     at::native::cpu_kernel(
         iter,
@@ -33,6 +91,7 @@ void lerp_tensor_kernel(at::TensorIteratorBase& iter) {
               : end_val - (end_val - self_val) * (scalar_t(1) - weight_val);
         });
   });
+  }
 }
 
 } // anonymous namespace

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3372,6 +3372,23 @@ class TestBinaryUfuncs(TestCase):
             expected = torch.lerp(xref, yref, wref).to(dtype)
             self.assertEqual(actual, expected, atol=0.0, rtol=0.0)
 
+    @onlyCPU
+    @dtypes(torch.bfloat16)
+    def test_lerp_lowp_cpu(self, device, dtype):
+        xvals = (0.0, -30000.0)
+        yvals = (0.1, -20000.0)
+        for shape in [(4,), (20,), (3, 10, 10)]:
+            xs = [torch.full(shape, xval, device=device, dtype=dtype) for xval in xvals]
+            ys = [torch.full(shape, yval, device=device, dtype=dtype) for yval in yvals]
+            weights = [70000, torch.full(shape, 8, device=device, dtype=dtype)]
+            for x, y, w in zip(xs, ys, weights):
+                xref = x.float()
+                yref = y.float()
+                wref = w.float() if isinstance(w, torch.Tensor) else w
+                actual = torch.lerp(x, y, w)
+                expected = torch.lerp(xref, yref, wref).to(dtype)
+                self.assertEqual(actual, expected, atol=0.0, rtol=0.0)
+
     def _test_logaddexp(self, device, dtype, base2):
         if base2:
             ref_func = np.logaddexp2

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13273,7 +13273,7 @@ op_db: List[OpInfo] = [
                                     dtypes=[torch.bfloat16]),
                    ),),
     OpInfo('lerp',
-           dtypes=floating_and_complex_types(),
+           dtypes=floating_and_complex_types_and(torch.bfloat16),
            dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
            dtypesIfROCM=floating_and_complex_types_and(torch.half, torch.bfloat16),
            sample_inputs_func=sample_inputs_lerp,


### PR DESCRIPTION
### Description
Add bfloat16 support for lerp on CPU

### Testing
single core:
<html>
<body>
<!--StartFragment-->

op | shape |fp32 forward/ms|bf16 forward/s|fb32 backward/s| bf16 backward/s
-- | -- | -- | -- | -- | --
lerp (tensor) | [10, 128, 10, 124] | 0.005489 | 0.000613 | 0.006658 | 0.003385
  | [10, 128, 20, 124] | 0.011057 | 0.001204 | 0.016032 | 0.007869
  | [10, 128, 30, 124] | 0.016691 | 0.001954 | 0.025549 | 0.012823
  |   |   |   |   |  
lerp (scalar) | [10, 128, 10, 124] | 0.001096 | 0.000507 | 0.002024 | 0.001479
  | [10, 128, 20, 124] | 0.00247 | 0.000997 | 0.005468 | 0.002907
  | [10, 128, 30, 124] | 0.004178 | 0.001513 | 0.009775 | 0.004859

<!--EndFragment-->
</body>
</html>

single socket (28cores):
<html>
<body>
<!--StartFragment-->

op | shape | fp32 forward/s| bf16 forward/s| fb32backward/s| bf16 backward/s
-- | -- | -- | -- | -- | --
lerp (tensor) | [10, 128, 10, 124] | 0.000236 | 3.93E-05 | 0.000494 | 0.000235
  | [10, 128, 20, 124] | 0.000525 | 7.39E-05 | 0.002485 | 0.000638
  | [10, 128, 30, 124] | 0.000801 | 0.000121 | 0.004235 | 0.001529
  |   |   |   |   |  
lerp (scalar) | [10, 128, 10, 124] | 5.90E-05 | 3.32E-05 | 0.000129 | 0.000116
  | [10, 128, 20, 124] | 0.000155 | 5.87E-05 | 0.000368 | 0.000206
  | [10, 128, 30, 124] | 0.000324 | 9.04E-05 | 0.001322 | 0.000313

<!--EndFragment-->
</body>
</html>