### PR TITLE
build/test MaybeOwned_test in OSS and fix it

### DIFF
--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -5,6 +5,7 @@ if(MSVC)
 endif(MSVC)
 
 list(APPEND ATen_CPU_TEST_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/MaybeOwned_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/scalar_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/apply_utils_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/basic.cpp

--- a/aten/src/ATen/test/MaybeOwned_test.cpp
+++ b/aten/src/ATen/test/MaybeOwned_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Tensor.h>
 #include <ATen/core/ivalue.h>
@@ -54,9 +55,6 @@ template <typename T>
 T getSampleValue2();
 
 template <typename T>
-bool equal(const T&, const T&);
-
-template <typename T>
 void assertBorrow(const c10::MaybeOwned<T>&, const T&);
 
 template <typename T>
@@ -73,8 +71,7 @@ c10::intrusive_ptr<MyString> getSampleValue2() {
   return c10::make_intrusive<MyString>("goodbye");
 }
 
-template<>
-bool equal(const c10::intrusive_ptr<MyString>& lhs, const c10::intrusive_ptr<MyString>& rhs) {
+bool are_equal(const c10::intrusive_ptr<MyString>& lhs, const c10::intrusive_ptr<MyString>& rhs) {
   if (!lhs || !rhs) {
     return !lhs && !rhs;
   }
@@ -113,8 +110,7 @@ Tensor getSampleValue2() {
   return at::native::ones({2, 2}).to(at::kCPU);
 }
 
-template<>
-bool equal(const Tensor& lhs, const Tensor& rhs) {
+bool are_equal(const Tensor& lhs, const Tensor& rhs) {
   if (!lhs.defined() || !rhs.defined()) {
     return !lhs.defined() && !rhs.defined();
   }
@@ -150,8 +146,7 @@ IValue getSampleValue2() {
   return IValue("hello");
 }
 
-template<>
-bool equal(const IValue& lhs, const IValue& rhs) {
+bool are_equal(const IValue& lhs, const IValue& rhs) {
   if (lhs.isTensor() != rhs.isTensor()) {
     return false;
   }
@@ -241,14 +236,14 @@ TYPED_TEST(MaybeOwnedTest, MoveDereferencing) {
   // Need a different value.
   this->owned = c10::MaybeOwned<TypeParam>::owned(c10::in_place, getSampleValue2<TypeParam>());
 
-  EXPECT_TRUE(equal(*std::move(this->borrowed), getSampleValue<TypeParam>()));
-  EXPECT_TRUE(equal(*std::move(this->owned), getSampleValue2<TypeParam>()));
+  EXPECT_TRUE(are_equal(*std::move(this->borrowed), getSampleValue<TypeParam>()));
+  EXPECT_TRUE(are_equal(*std::move(this->owned), getSampleValue2<TypeParam>()));
 
   // Borrowed is unaffected.
   assertBorrow(this->borrowed, this->borrowFrom);
 
   // Owned is a null c10::intrusive_ptr / empty Tensor.
-  EXPECT_TRUE(equal(*this->owned, TypeParam()));
+  EXPECT_TRUE(are_equal(*this->owned, TypeParam()));
 }
 
 TYPED_TEST(MaybeOwnedTest, MoveConstructor) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84345
* #84344
* __->__ #84342

Summary:
This was not listed in the compilation for the ATen tests and was only
getting built in Meta internal repositories.

This ended up with the following problems:
 * at::zeros was not available
 * equal() for tensors was being selected from ATen/ops/equal.h and crashing

Test Plan: Verified locally.

Reviewers:

Subscribers:

Tasks:

Tags: