### PR TITLE
sort ATen tests in CMake

### DIFF
--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -5,82 +5,82 @@ if(MSVC)
 endif(MSVC)
 
 list(APPEND ATen_CPU_TEST_SRCS
-  ${CMAKE_CURRENT_SOURCE_DIR}/MaybeOwned_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/scalar_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/apply_utils_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/basic.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/atest.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/Dimname_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Dict_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Dimname_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/MaybeOwned_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NamedTensor_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/half_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/apply_utils_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/atest.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/basic.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/broadcast_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/wrapdim_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/dlconvertor_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/native_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/scalar_tensor_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/test_parallel.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/undefined_tensor_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/verify_api_visibility.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/thread_init_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/weakref_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/quantized_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/extension_backend_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/operators_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/lazy_tensor_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/tensor_iterator_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/math_kernel_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/memory_overlapping_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/mobile_memory_cleanup.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu_generator_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu_profiling_allocator_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cpu_rng_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_key_set_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/dlconvertor_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/extension_backend_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/half_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ivalue_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/lazy_tensor_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/math_kernel_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/memory_format_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/memory_overlapping_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/mobile_memory_cleanup.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/native_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/operators_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pow_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/variant_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/quantized_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduce_ops_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reportMemoryUsage_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/memory_format_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/cpu_rng_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/ivalue_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/vmap_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/scalar_tensor_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/scalar_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/stride_properties_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/tensor_iterator_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_parallel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/thread_init_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/type_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_key_set_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/stride_properties_test.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/undefined_tensor_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/variant_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/verify_api_visibility.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/vmap_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/weakref_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wrapdim_test.cpp)
 
 list(APPEND ATen_CUDA_TEST_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_apply_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_atomic_ops_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_caching_host_allocator_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_complex_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_complex_math_test.cu
-  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_integer_divider_test.cu
-  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_apply_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_stream_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_complex_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_cub_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_device_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_half_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_distributions_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_dlconvertor_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_generator_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_half_test.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_integer_divider_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_optional_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_packedtensoraccessor_test.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_reportMemoryUsage_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_vectorized_test.cu
-  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_dlconvertor_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_generator_test.cu
-  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_cub_test.cu)
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_stream_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cuda_vectorized_test.cu)
 if(CAFFE2_USE_CUDNN)
   list(APPEND ATen_CUDA_TEST_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cuda_cudnn_test.cpp)
 endif()
 
 list(APPEND ATen_HIP_TEST_SRCS
-  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_complex_test.hip
-  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_complex_math_test.hip
-  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_integer_divider_test.hip
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_apply_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_half_test.hip
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_complex_math_test.hip
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_complex_test.hip
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_distributions_test.hip
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_dlconvertor_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_generator_test.hip
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_half_test.hip
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_integer_divider_test.hip
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_optional_test.hip
   ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_packedtensoraccessor_test.hip
-  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_vectorized_test.hip
-  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_dlconvertor_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_generator_test.hip)
+  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_vectorized_test.hip)
 # TODO: fix and enable these
 #  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_tensor_interop_test.cpp
 #  ${CMAKE_CURRENT_SOURCE_DIR}/hip/hip_stream_test.cpp
@@ -89,10 +89,10 @@ list(APPEND ATen_VULKAN_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/vulkan_api_test.cpp)
 
 list(APPEND ATen_MOBILE_TEST_SRCS
-  ${CMAKE_CURRENT_SOURCE_DIR}/vec_test_all_types.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/cpu_profiling_allocator_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu_caching_allocator_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/quantized_test.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/cpu_profiling_allocator_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/quantized_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/vec_test_all_types.cpp)
 
 list(APPEND ATen_VEC_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/vec_test_all_types.cpp


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84345
* __->__ #84344
* #84342

Summary:
This will make it easier to compare and spot missing files.

Test Plan: Rely on CI.

Reviewers:

Subscribers:

Tasks:

Tags: