### PR TITLE
Move decompositions and helpers for jvp from functorch into core

### DIFF
--- a/functorch/functorch/_src/aot_autograd.py
+++ b/functorch/functorch/_src/aot_autograd.py
@@ -11,10 +11,10 @@ import torch.nn as nn
 import torch.utils._pytree as pytree
 import torch.utils.dlpack
 from torch import Tensor
+from torch._decomp import register_decomposition
 from torch._subclasses import FakeTensorMode
 from torch.fx import immutable_collections, Interpreter
 from torch.nn.utils import stateless
-from torch._decomp import register_decomposition
 
 from functorch import make_fx
 from functorch._C import CompileCache

--- a/functorch/functorch/_src/aot_autograd.py
+++ b/functorch/functorch/_src/aot_autograd.py
@@ -14,12 +14,12 @@ from torch import Tensor
 from torch._subclasses import FakeTensorMode
 from torch.fx import immutable_collections, Interpreter
 from torch.nn.utils import stateless
+from torch._decomp import register_decomposition
 
 from functorch import make_fx
 from functorch._C import CompileCache
 from functorch.experimental import functionalize
 from . import config
-from .decompositions import register_decomposition
 from .named_members_polyfill import _named_buffers, _named_parameters
 from .partitioners import default_partition
 

--- a/functorch/functorch/_src/compilers.py
+++ b/functorch/functorch/_src/compilers.py
@@ -10,10 +10,10 @@ from typing import Callable, Optional, Tuple, Union
 import torch
 import torch.fx as fx
 import torch.nn as nn
+from torch._decomp import get_decompositions
 
 from .aot_autograd import aot_function, aot_module, make_boxed_compiler
 from .compile_utils import strip_overloads
-from .decompositions import get_decompositions
 from .partitioners import (
     default_partition,
     draw_graph,

--- a/functorch/functorch/_src/eager_transforms.py
+++ b/functorch/functorch/_src/eager_transforms.py
@@ -6,7 +6,6 @@
 
 from typing import Callable, Union, Tuple, List, Any
 import torch
-import inspect
 from functools import partial, wraps
 import contextlib
 from torch.utils._pytree import tree_flatten, tree_unflatten, tree_map

--- a/functorch/functorch/_src/eager_transforms.py
+++ b/functorch/functorch/_src/eager_transforms.py
@@ -14,8 +14,8 @@ from .pytree_hacks import tree_map_, treespec_pprint
 import torch.autograd.forward_ad as fwAD
 
 from .vmap import vmap
-from .decompositions import decomposition_table, decomposition_table_for_jvp
-
+from torch._decomp import decomposition_table
+import torch._decomp.decompositions_for_jvp
 
 from functorch._C import (
     _wrap_for_grad,
@@ -1439,37 +1439,6 @@ def functionalize(func: Callable, *, remove: str = 'mutations') -> Callable:
             _func_decrement_nesting()
     return wrapped
 
-
-def _register_jit_decomposition(decomp, use_python=False):
-    if decomp in decomposition_table_for_jvp:
-        decomposition_table_used = decomposition_table_for_jvp
-    elif decomp in decomposition_table:
-        decomposition_table_used = decomposition_table
-    else:
-        raise RuntimeError(f"could not find decomposition for {decomp}")
-    decomp_fn = decomposition_table_used[decomp]
-    if use_python:
-        decomp_fn = torch.jit.ignore(decomp_fn)
-        sig = inspect.signature(decomp_fn)
-
-        # Create a string wrapping the function from the signature
-        # example output:
-        # def wrapped_decomp(x: torch.Tensor, y: int, z: int):
-        #   return decomp_fn(x, y, z)
-        # Thanks copilot!
-        def get_function_def(sig):
-            param_def = [f"{param_str}" for param_str in sig.parameters.values()]
-            param_use = [f"{param_str}" for param_str in sig.parameters.keys()]
-
-            return f"def wrapped_decomp({', '.join(param_def)}):\n  return decomp_fn({', '.join(param_use)})\n"
-
-        f_str = get_function_def(sig)
-        graph = torch.jit.CompilationUnit(f_str).wrapped_decomp.graph
-    else:
-        graph = torch.jit.script(decomp_fn).graph
-    torch.jit._register_decomposition(decomp, graph)
-
-
 # use an alternate way to register an operator into the decomposition table
 # _register_jit_decomposition doesn't work for some operators, e.g. addr,
 #  because the Tensor types generated cannot be unioned by torchscript
@@ -1484,14 +1453,5 @@ def _register_python_decomposition_vmap(decomp):
         raise RuntimeError(f"could not find decomposition for {decomp}")
 
 
-_register_jit_decomposition(torch.ops.aten.trace.default, use_python=True)
-_register_jit_decomposition(torch.ops.aten.nll_loss_backward.default)
-_register_jit_decomposition(torch.ops.aten.nll_loss2d_backward.default)
-_register_jit_decomposition(torch.ops.aten._log_softmax_backward_data.default)
-_register_jit_decomposition(torch.ops.aten._softmax_backward_data.default)
-_register_jit_decomposition(torch.ops.aten.log_sigmoid_forward.default)
-_register_jit_decomposition(torch.ops.aten.native_layer_norm_backward.default)
-_register_jit_decomposition(torch.ops.aten.native_batch_norm_backward.default)
-_register_jit_decomposition(torch.ops.aten.cudnn_batch_norm_backward.default)
 _register_python_decomposition_vmap(torch.ops.aten.mse_loss_backward.default)
 _register_python_decomposition_vmap(torch.ops.aten.addr.default)

--- a/functorch/functorch/compile/__init__.py
+++ b/functorch/functorch/compile/__init__.py
@@ -1,5 +1,4 @@
 from .._src.python_key import pythonkey_decompose
-from .._src.decompositions import register_decomposition, decomposition_table, get_decompositions
 from .._src.fx_minifier import minifier
 from .._src.aot_autograd import (
     aot_function,

--- a/functorch/test/test_pythonkey.py
+++ b/functorch/test/test_pythonkey.py
@@ -24,10 +24,10 @@ from functorch._src.aot_autograd import aot_module_simplified
 from functorch.compile import (
     nnc_jit, compiled_function, compiled_module,
     min_cut_rematerialization_partition, aot_function, aot_module,
-    decomposition_table, nop,
-    num_of_recompilations, default_partition, default_decompositions,
+    nop, num_of_recompilations, default_partition, default_decompositions,
     memory_efficient_fusion, clear_compile_cache, get_aot_compilation_context
 )
+from torch._decomp import decomposition_table
 
 from torch.testing._internal.common_device_type import ops
 from functorch_additional_op_db import additional_op_db

--- a/torch/_decomp/decompositions_for_jvp.py
+++ b/torch/_decomp/decompositions_for_jvp.py
@@ -197,7 +197,7 @@ def prod(x: List[int]):
 
 @register_decomposition_for_jvp(
     aten.native_batch_norm_backward
-)  # @register_decomposition_for_jvp after in core
+)
 def native_batch_norm_backward(
     grad_out: Tensor,
     input: Tensor,

--- a/torch/_decomp/decompositions_for_jvp.py
+++ b/torch/_decomp/decompositions_for_jvp.py
@@ -195,9 +195,7 @@ def prod(x: List[int]):
     return r
 
 
-@register_decomposition_for_jvp(
-    aten.native_batch_norm_backward
-)
+@register_decomposition_for_jvp(aten.native_batch_norm_backward)
 def native_batch_norm_backward(
     grad_out: Tensor,
     input: Tensor,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84151
* __->__ #84358

This refactor shouldn't change any behavior. At this point functorch still relies on the mechanism in DynamicLayerFront; we just moved some parts of it into core.