### PR TITLE
[quant] Subpackage import

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -876,10 +876,11 @@ from torch import profiler as profiler
 # Quantized, sparse, AO, etc. should be last to get imported, as nothing
 # is expected to depend on them.
 import torch.nn.intrinsic
+from torch import ao as ao
+# nn.quant* depends on ao -- so should be after those.
 import torch.nn.quantizable
 import torch.nn.quantized
-# AO depends on nn, as well as quantized stuff -- so should be after those.
-from torch import ao as ao
+import torch.nn.qat
 
 _C._init_names(list(torch._storage_classes))
 

--- a/torch/ao/__init__.py
+++ b/torch/ao/__init__.py
@@ -1,0 +1,16 @@
+# torch.ao is a pacakge with a lot of interdependencies.
+# We will use lazy import to avoid cyclic dependencies here.
+
+
+__all__ = [
+    "nn",
+    "ns",
+    "quantization",
+    "sparsity",
+]
+
+def __getattr__(name):
+    if name in __all__:
+        import importlib
+        return importlib.import_module("." + name, __name__)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torch/ao/nn/__init__.py
+++ b/torch/ao/nn/__init__.py
@@ -6,6 +6,7 @@
 import importlib
 
 __all__ = [
+    "qat",
     "quantizable",
     "quantized",
     "sparse",

--- a/torch/ao/nn/qat/dynamic/modules/linear.py
+++ b/torch/ao/nn/qat/dynamic/modules/linear.py
@@ -1,5 +1,4 @@
 import torch
-from torch.ao.quantization import activation_is_memoryless
 
 
 class Linear(torch.ao.nn.qat.Linear):
@@ -18,7 +17,7 @@ class Linear(torch.ao.nn.qat.Linear):
     def __init__(self, in_features, out_features, bias=True,
                  qconfig=None, device=None, dtype=None) -> None:
         super().__init__(in_features, out_features, bias, qconfig, device, dtype)
-        if not activation_is_memoryless(qconfig):
+        if not torch.ao.quantization.activation_is_memoryless(qconfig):
             raise ValueError(
                 "Dynamic QAT requires a memoryless observer." +
                 "This means a MovingAverage observer with averaging constant equal to 1"

--- a/torch/nn/qat/__init__.py
+++ b/torch/nn/qat/__init__.py
@@ -4,4 +4,15 @@ r"""QAT Dynamic Modules
 This package is in the process of being deprecated.
 Please, use `torch.ao.nn.qat.dynamic` instead.
 """
+from . import dynamic  # noqa: F403
+from . import modules  # noqa: F403
 from .modules import *  # noqa: F403
+
+__all__ = [
+    "Linear",
+    "Conv1d",
+    "Conv2d",
+    "Conv3d",
+    "Embedding",
+    "EmbeddingBag",
+]

--- a/torch/nn/quantized/__init__.py
+++ b/torch/nn/quantized/__init__.py
@@ -1,2 +1,40 @@
+from . import dynamic  # noqa: F403
 from . import functional  # noqa: F403
+from . import modules  # noqa: F403
 from .modules import *  # noqa: F403
+
+__all__ = [
+    'BatchNorm2d',
+    'BatchNorm3d',
+    'Conv1d',
+    'Conv2d',
+    'Conv3d',
+    'ConvTranspose1d',
+    'ConvTranspose2d',
+    'ConvTranspose3d',
+    'DeQuantize',
+    'Dropout',
+    'ELU',
+    'Embedding',
+    'EmbeddingBag',
+    'GroupNorm',
+    'Hardswish',
+    'InstanceNorm1d',
+    'InstanceNorm2d',
+    'InstanceNorm3d',
+    'LayerNorm',
+    'LeakyReLU',
+    'Linear',
+    'LSTM',
+    'MaxPool2d',
+    'MultiheadAttention',
+    'PReLU',
+    'Quantize',
+    'ReLU6',
+    'Sigmoid',
+    'Softmax',
+    # Wrapper modules
+    'FloatFunctional',
+    'FXFloatFunctional',
+    'QFunctional',
+]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84377

Some of the subpackages were not included in the 'torch.nn.quantized'.
That would cause some specific cases fail.
For example, `from torch.nn.quantized import dynamic` would work,
but `import torch; torch.nn.quantized.dynamic` would fail.