### PR TITLE
[PyTorch] Return const ref from SizesAndStrides::{size,stride}_at_unchecked

### DIFF
--- a/c10/core/impl/SizesAndStrides.h
+++ b/c10/core/impl/SizesAndStrides.h
@@ -236,7 +236,7 @@ class C10_API SizesAndStrides {
     return sizes_data()[idx];
   }
 
-  SymInt size_at_unchecked(size_t idx) const noexcept {
+  const SymInt& size_at_unchecked(size_t idx) const noexcept {
     return sizes_data()[idx];
   }
 
@@ -255,7 +255,7 @@ class C10_API SizesAndStrides {
     return strides_data()[idx];
   }
 
-  SymInt stride_at_unchecked(size_t idx) const noexcept {
+  const SymInt& stride_at_unchecked(size_t idx) const noexcept {
     return strides_data()[idx];
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84379

SymInt is not free to copy, so these accessors should return const ref rather than a value and let the caller decide whether to copy. (It won't; usually it calls to_int_unchecked right away.)

Differential Revision: [D39191312](https://our.internmc.facebook.com/intern/diff/D39191312/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D39191312/)!