### PR TITLE
Implement embedding with NNC IR

### DIFF
--- a/test/cpp/tensorexpr/test_ops.cpp
+++ b/test/cpp/tensorexpr/test_ops.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <torch/csrc/jit/ir/irparser.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
 #include <torch/csrc/jit/tensorexpr/expr.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
@@ -75,4 +76,44 @@ TEST(Ops, ChannelsLastSum) {
 
     ASSERT_TRUE(at::allclose(bt, ref));
   }
+}
+
+TEST(Ops, Embedding) {
+  const auto graph_string = R"IR(
+    graph(%embedding_weight : Float(10000, 300, strides=[300, 1], device=cpu),
+          %indices : Long(2, 4, strides=[4, 1], device=cpu)):
+      %padding_idx : int = prim::Constant[value=-1]()
+      %1 : int = prim::Constant[value=1]()
+      %2 : bool = prim::Constant[value=0]()
+      %3 : Float(2, 4, 300, strides=[1200, 300, 1], requires_grad=0, device=cpu) = aten::embedding(%embedding_weight, %indices, %padding_idx, %2, %2)
+      %4 : Float(2, 4, 300, strides=[1200, 300, 1], requires_grad=0, device=cpu) = aten::add(%3, %3, %1)
+      %5 : Float(2, 4, 300, strides=[1200, 300, 1], requires_grad=0, device=cpu) = aten::mul(%4, %4)
+      return (%5))IR";
+
+  auto graph = std::make_shared<torch::jit::Graph>();
+  parseIR(graph_string, &*graph);
+
+  auto indices =
+      at::randint(10, {2, 4}, at::TensorOptions(c10::kCPU).dtype(at::kLong));
+  auto embedding_weight =
+      at::rand({10000, 300}, at::TensorOptions(c10::kCPU).dtype(at::kFloat));
+  auto y_1 = at::embedding(embedding_weight, indices);
+  auto y_2 = at::add(y_1, y_1, 1);
+  auto y_expected = at::mul(y_2, y_2);
+
+  TensorExprKernel k(graph);
+  std::vector<at::Tensor> inputs = {embedding_weight, indices};
+
+  std::vector<c10::IValue> stack = at::fmap<c10::IValue>(inputs);
+  k.run(stack);
+  auto y = stack[0].toTensor();
+
+  bool check = at::allclose(y_expected, y);
+  if (!check) {
+    std::cout << "indices:\n" << indices << std::endl;
+    std::cout << "embedding_weight:\n" << embedding_weight << std::endl;
+    std::cout << "y_expected:\n" << y_expected << std::endl;
+    std::cout << "y:\n" << y << std::endl;
+  }
+  TORCH_CHECK_EQ(check, 1);
 }

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -101,6 +101,7 @@ bool isSupported(Node* node) {
   static const OperatorSet supported_misc_set{
       "aten::cat(Tensor[] tensors, int dim=0) -> Tensor",
       "aten::unsqueeze(Tensor(a) self, int dim) -> Tensor(a)",
+      "aten::embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor",
   };
   // clang-format on
 

--- a/torch/csrc/jit/tensorexpr/operators/misc.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/misc.cpp
@@ -360,6 +360,7 @@ StmtPtr computeIndirectIndexing(
         innerStmtFunc) {
   auto outputRank = outputShape.size();
   auto indicesRank = indices.node()->dims().size();
+  auto idxingTargetRank = idxingTarget.node()->dims().size();
   auto dtypeIndirectIdxing =
       idxingTarget.node()->dims().at(dimOfIndirectIdxing)->dtype();
 
@@ -383,7 +384,7 @@ StmtPtr computeIndirectIndexing(
 
   // Generate target load with indirect-indexing: idxingTarget[..., x, ...]
   std::vector<ExprPtr> idxingTargetIndices;
-  for (size_t i = 0, idxLoopIndices = indicesRank; i < indicesRank; ++i) {
+  for (size_t i = 0, idxLoopIndices = indicesRank; i < idxingTargetRank; ++i) {
     idxingTargetIndices.push_back(
         (i == dimOfIndirectIdxing) ? indirectIdxVar
                                    : loopIndices[idxLoopIndices++]);

--- a/torch/csrc/jit/tensorexpr/operators/misc.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/misc.cpp
@@ -351,6 +351,80 @@ Tensor computeChunk(
       });
 }
 
+StmtPtr computeIndirectIndexing(
+    const BufHandle& idxingTarget,
+    const BufHandle& indices,
+    size_t dimOfIndirectIdxing,
+    const std::vector<ExprHandle>& outputShape,
+    const std::function<StmtPtr(const ExprPtr&, const std::vector<ExprPtr>&)>&
+        innerStmtFunc) {
+  auto outputRank = outputShape.size();
+  auto indicesRank = indices.node()->dims().size();
+  auto dtypeIndirectIdxing =
+      idxingTarget.node()->dims().at(dimOfIndirectIdxing)->dtype();
+
+  // Generate loop-nest indices
+  std::vector<VarPtr> loopVars(outputRank);
+  std::vector<ExprPtr> loopIndices(outputRank);
+  for (size_t i = 0; i < outputRank; ++i) {
+    loopVars[i] = alloc<Var>("i_" + c10::to_string(i), outputShape[i].dtype());
+    loopIndices[i] = loopVars[i];
+  }
+
+  // Generate indirect-indexing load expr: indices[...]
+  std::vector<ExprPtr> indirectIdxLoadIndices(indicesRank);
+  for (size_t i = 0; i < indicesRank; ++i) {
+    indirectIdxLoadIndices[i] = loopIndices[i];
+  }
+  auto loadIndirectIdx = alloc<Load>(indices.node(), indirectIdxLoadIndices);
+
+  // Generate indirect-indexing var: x
+  auto indirectIdxVar = alloc<Var>("ind_idx", dtypeIndirectIdxing);
+
+  // Generate target load with indirect-indexing: idxingTarget[..., x, ...]
+  std::vector<ExprPtr> idxingTargetIndices;
+  for (size_t i = 0, idxLoopIndices = indicesRank; i < indicesRank; ++i) {
+    idxingTargetIndices.push_back(
+        (i == dimOfIndirectIdxing) ? indirectIdxVar
+                                   : loopIndices[idxLoopIndices++]);
+  }
+  auto loadIdxingTarget = alloc<Load>(idxingTarget.node(), idxingTargetIndices);
+
+  // Generate stmt for the inner-most loop body
+  StmtPtr innerStmt = innerStmtFunc(loadIdxingTarget, loopIndices);
+
+  // Generate stmt for the idxingTarget scoped loops
+  for (size_t i = outputRank; i > indicesRank; --i) {
+    innerStmt = alloc<For>(
+        loopVars[i - 1],
+        immLike(outputShape[i - 1], 0),
+        outputShape[i - 1].node(),
+        innerStmt);
+  }
+
+  // Generate stmt for the indirect-indexing: x = indices[...]
+  StmtPtr loadIndirectIdxStmt = Let::make(
+      VarHandle(indirectIdxVar),
+      promoteToDtype(
+          ExprHandle(loadIndirectIdx), dtypeIndirectIdxing.scalar_type()));
+
+  // Merge the stmts of the idxing target scoped loops and the indirect-indexing
+  auto block = alloc<tensorexpr::Block>(
+      std::vector<StmtPtr>({loadIndirectIdxStmt, innerStmt}));
+
+  // Generate stmt for the indice scoped loops
+  StmtPtr outerStmt = IRSimplifier::simplify(block);
+  for (size_t i = indicesRank; i > 0; --i) {
+    outerStmt = alloc<For>(
+        loopVars[i - 1],
+        immLike(outputShape[i - 1], 0),
+        outputShape[i - 1].node(),
+        outerStmt);
+  }
+
+  return outerStmt;
+}
+
 Tensor computeTranspose(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,
@@ -653,6 +727,38 @@ Tensor computeCat(
 }
 
 Tensor computeEmbedding(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const std::vector<ExprHandle>& outputStrides,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device) {
+  const BufHandle& idxingTarget = c10::get<BufHandle>(inputs[0]);
+  const BufHandle& indices = c10::get<BufHandle>(inputs[1]);
+  Dtype outputDtype = outputType.has_value() ? Dtype(*outputType) : kFloat;
+  BufHandle outputBuf("embedding", outputShape, outputStrides, outputDtype);
+
+  // Set the indirect-indexing param
+  size_t dimOfIndirectIdxing = 0;
+
+  StmtPtr st = computeIndirectIndexing(
+      idxingTarget,
+      indices,
+      dimOfIndirectIdxing,
+      outputShape,
+      [&](const ExprPtr& loadIdxingTarget,
+          const std::vector<ExprPtr>& loopIndices) {
+        return alloc<Store>(
+            outputBuf.node(),
+            loopIndices,
+            promoteToDtype(
+                ExprHandle(loadIdxingTarget), outputDtype.scalar_type())
+                .node());
+      });
+
+  return Tensor(outputBuf.node(), st);
+}
+
+Tensor computeEmbeddingExternalCall(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,
     const std::vector<ExprHandle>& outputStrides,

--- a/torch/csrc/jit/tensorexpr/operators/misc.h
+++ b/torch/csrc/jit/tensorexpr/operators/misc.h
@@ -42,6 +42,37 @@ ExprHandle scalarOrConstant(const ArgValue& v);
 ExprHandle broadcast(BufHandle b, const std::vector<ExprHandle>& axes);
 ExprHandle constant(const ArgValue& v);
 
+// Infrastructure to provide indirect-indexing related lowering. It helps
+// generating the overall loop-nest for the Op and indirect-indexing related
+// logic, while leaving Op-specific logic to be defined by Op with injected
+// function.
+//
+// E.x.: take a 2D indices and a 3D idxingTarget (to be indirect-indexing), and
+// the 2nd dim of idxingTarget is the dim to be indirect-indexing. The param
+// dimOfIndirectIdxing should be set to 1 (the 2nd dim). Below stmt will be
+// generated as result -
+// for i : size_i
+//   for j : size_j
+//     x = indices[i, j]
+//     for m : size_m
+//       for n : size_n
+//         innerStmt by innerStmtFunc(idxingTarget[m, x, n], [i, j, m, n])
+StmtPtr computeIndirectIndexing(
+    // Target tensor for indirect-indexing
+    const BufHandle& idxingTarget,
+    // Indices for indirect-indexing
+    const BufHandle& indices,
+    // Indirect-indexing dim of target
+    size_t dimOfIndirectIdxing,
+    // Original lowering outputShape
+    const std::vector<ExprHandle>& outputShape,
+    // OP-specific customization for inner-most loop body generation
+    const std::function<StmtPtr(
+        // Loaded IdxingTarget
+        const ExprPtr&,
+        // Loop-nest Indices
+        const std::vector<ExprPtr>&)>& innerStmtFunc);
+
 ExprHandle clamp(
     const ExprHandle& cmin,
     const ExprHandle& cmax,
@@ -87,6 +118,13 @@ Tensor computeCat(
     const c10::optional<ScalarType>& outputType,
     at::Device device);
 Tensor computeEmbedding(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const std::vector<ExprHandle>& outputStrides,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device);
+
+Tensor computeEmbeddingExternalCall(
     const std::vector<ArgValue>& inputs,
     const std::vector<ExprHandle>& outputShape,
     const std::vector<ExprHandle>& outputStrides,


### PR DESCRIPTION
This PR re-implemented aten::embedding with native NNC IR, which should provide better performance and fusion potential. The existing embedding has been renamed with externalcall suffix.

A new generic infrastructure function is implemented for indirect-indexing related Ops. It helps generating the overall loop-nest for the Op and indirect-indexing related logic, while leaving Op-specific logic to be defined by Op with injected function. E.x.: take a 2D indices and a 3D target (to be indirect indexing), and the 2nd dim is the dim to be indirect-indexing. This new infrastructure function will generate below lowering statement, while each Op can specify its specific logic with a lambda function as the inner-most loop body.
```
for i : size_i
   for j : size_j
     x = indices[i, j]
     for m : size_m
       for n : size_n
         innerStmt by Op with innerStmtFunc(idxingTarget[m, x, n], [i, j, m, n]) 
```

aten::embedding is implemented based on above new function very easily.

This PR has been tested and verified with unit case as below:
```
import time
import torch
import torch.nn as nn

warm_up_num = 10
run_num = 200000

class EmbeddingModel(nn.Module):
  def __init__(self):
    super(EmbeddingModel,self).__init__()
    self.embedding = nn.Embedding(10000, 300)
  def forward(self,x):
    x = self.embedding(x)
    x = x + x
    x = x * x
    return x

if __name__ =='__main__':
  torch.manual_seed(0)
  model = EmbeddingModel()
  model.eval()
  print(model)

  jit_model = torch.jit.script(model)
  jit_model = torch.jit.freeze(jit_model)
  print("[INFO]: Before fusion")
  print(jit_model.graph)

  input_tensor = torch.LongTensor([[1,2,4,5],[4,3,2,9]])

  print("Warming up ...")
  with torch.no_grad():
    for i in range(warm_up_num):
      warmup_ts = time.time()
      out = jit_model(input_tensor)
      warmup_duration = (time.time() - warmup_ts)*1000000
      print(f"  round {i} : {warmup_duration} us")

  print("")
  print("Official run and benchmarking...")
  with torch.no_grad():
    start_ts = time.time()
    for i in range(run_num):
      out = jit_model(input_tensor)
    end_ts = time.time()
  print(f"Latency: {(end_ts-start_ts)/run_num*1000000} us")
```

With this PR, embedding will be pulled into NNC fusion group as below:
```
%x.26 : Float(2, 4, 300, strides=[1200, 300, 1], requires_grad=0, device=cpu) = aten::embedding(%self.embedding.weight, %x.1, %padding_idx.41, %2, %2)
%x.22 : Float(2, 4, 300, strides=[1200, 300, 1], requires_grad=0, device=cpu) = aten::add(%x.26, %x.26, %1)
%x.18 : Float(2, 4, 300, strides=[1200, 300, 1], requires_grad=0, device=cpu) = aten::mul(%x.22, %x.22)
```
And related NNC IR (original) are generated as below:
```
after fuse{
  for (int64_t i = 0ll; i < 2ll; i++) {
    for (int64_t j = 0ll; j < 4ll; j++) {
      int64_t ind_idx = tx_1[i, j];
      for (int64_t k_2 = 0ll; k_2 < 300ll; k_2++) {
        aten_mul[i, j, k_2] = ((const_self_embedding_weight[ind_idx, k_2]) + (const_self_embedding_weight[ind_idx, k_2])) * ((const_self_embedding_weight[ind_idx, k_2]) + (const_self_embedding_weight[ind_idx, k_2]));
      }
    }
  }
}
```

The performance of this PR (embedding+add+mul all fused in NNC) vs. before this PR (add+mul fused in NNC, embedding as aten call) under JIT mode is as below table (run above unit test with numactl to set CPU Cores on a CPX 4x8380H server), which shows about 80% ~ more than 200% performance benefit.
<html>
<body>
<!--StartFragment--><div ccp_infra_version='3' ccp_infra_timestamp='1661742578237' ccp_infra_user_hash='526604988' ccp_infra_copy_id='c1817984-ca7b-456b-b62a-28ac3a7321f1' data-ccp-timestamp='1661742578237'><html><head><meta name=ProgId content=Excel.Sheet><meta name=Generator content="Microsoft Excel 15"></head><body link="#0563C1" vlink="#954F72">

Execution CPU | Vector DIM | Word Num | Indices | Pytorch (us) | Pytorch + NNC Embedding (us) | Perf Improvement
-- | -- | -- | -- | -- | -- | --
1 | 16 | 16 | [16] | 9.72 | 4.72 | 105.93%
1 | 16 | 16 | [128] | 10.47 | 5.69 | 84.01%
1 | 16 | 16 | [256, 256] | 570.15 | 199.63 | 185.60%
1 | 16 | 10000 | [16] | 10.02 | 4.76 | 110.50%
1 | 16 | 10000 | [128] | 10.41 | 5.79 | 79.79%
1 | 16 | 10000 | [256, 256] | 762.89 | 268.16 | 184.49%
1 | 128 | 100 | [16] | 10.36 | 5.08 | 103.94%
1 | 128 | 100 | [128] | 13.57 | 5.82 | 133.16%
1 | 128 | 100 | [256, 256] | 27898.13 | 13461.12 | 107.25%
1 | 128 | 10000 | [16] | 10.38 | 5.13 | 102.34%
1 | 128 | 10000 | [128] | 13.51 | 6.15 | 119.67%
1 | 128 | 10000 | [256, 256] | 29312.62 | 14779.03 | 98.34%
1 | 512 | 10000 | [16] | 11.41 | 5.29 | 115.69%
1 | 512 | 10000 | [128] | 44.72 | 10.04 | 345.42%
1 | 512 | 10000 | [256, 256] | 122491.56 | 62629.17 | 95.58%
4 | 128 | 10000 | [16] | 10.45 | 4.96 | 110.69%
4 | 128 | 10000 | [128] | 13.78 | 5.99 | 130.05%
4 | 128 | 10000 | [256, 256] | 9771.33 | 4973.41 | 96.47%
4 | 512 | 10000 | [16] | 11.58 | 5.54 | 109.03%
4 | 512 | 10000 | [128] | 27.39 | 8.96 | 205.69%
4 | 512 | 10000 | [256, 256] | 40666.72 | 20633.8 | 97.09%

</body></html></div><!--EndFragment-->
</body>
</html>

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel