### PR TITLE
sym_offset

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -248,6 +248,10 @@ c10::SymInt NestedTensorImpl::sym_numel_custom() const {
   return NestedTensorImpl::numel_custom();
 }
 
+c10::SymInt NestedTensorImpl::sym_storage_offset_custom() const {
+  return NestedTensorImpl::storage_offset();
+}
+
 bool NestedTensorImpl::is_contiguous_custom(MemoryFormat) const {
   return nested_tensor_impl_is_contiguous(this);
 }

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -100,6 +100,8 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   // with real implementations
   int64_t numel_custom() const override;
   c10::SymInt sym_numel_custom() const override;
+  c10::SymInt sym_storage_offset_custom() const override;
+
   bool is_contiguous_custom(MemoryFormat) const override;
   int64_t size_custom(int64_t d) const override {
     return this->size(d);

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -302,6 +302,10 @@ class TORCH_API TensorBase {
     return impl_->sym_numel();
   }
 
+  c10::SymInt sym_storage_offset() const {
+    return impl_->sym_storage_offset();
+  }
+
   // Length of one array element in bytes.  This is the traditional
   // Numpy naming.
   size_t itemsize() const {

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -212,13 +212,16 @@ void TensorImpl::HandleResize() {
   if (reserved_) {
     // If tensor is reserved then don't claim its memeory unless nbytes()
     // is smaller than new size
-    reset_tensor =
-        storage_.nbytes() < (storage_offset_ + numel_) * data_type_.itemsize();
-  } else {
     reset_tensor = storage_.nbytes() <
-            (storage_offset_ + numel_) * data_type_.itemsize() ||
+        (storage_offset_.as_int_unchecked() + numel_) * data_type_.itemsize();
+  } else {
+    reset_tensor =
+        storage_.nbytes() < (storage_offset_.as_int_unchecked() + numel_) *
+                data_type_.itemsize() ||
         !FLAGS_caffe2_keep_on_shrink ||
-        storage_.nbytes() - (storage_offset_ + numel_) * data_type_.itemsize() >
+        storage_.nbytes() -
+                (storage_offset_.as_int_unchecked() + numel_) *
+                    data_type_.itemsize() >
             static_cast<size_t>(FLAGS_caffe2_max_keep_on_shrink_memory);
   }
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1285,7 +1285,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         "Caffe2 uses a lazy allocation, so you will need to call "
         "mutable_data() or raw_mutable_data() to actually allocate memory.");
     // Caller does the type check.
-    return storage_.unsafe_data<T>() + storage_offset_;
+    return storage_.unsafe_data<T>() + storage_offset_.as_int_unchecked();
   }
 
   /**
@@ -1314,7 +1314,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     }
     return static_cast<void*>(
         static_cast<char*>(storage_.data()) +
-        data_type_.itemsize() * storage_offset_);
+        data_type_.itemsize() * storage_offset_.as_int_unchecked());
   }
 
   /**
@@ -1323,7 +1323,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    */
   template <typename T>
   inline T* unsafe_data() const {
-    return storage_.unsafe_data<T>() + storage_offset_;
+    return storage_.unsafe_data<T>() + storage_offset_.as_int_unchecked();
   }
 
   /**
@@ -1353,7 +1353,27 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * WARNING: This is NOT computed in bytes.
    */
   TENSORIMPL_MAYBE_VIRTUAL int64_t storage_offset() const {
+    return storage_offset_.expect_int();
+  }
+
+  c10::SymInt sym_storage_offset() const {
+    if (C10_UNLIKELY(
+            sizes_strides_policy_ >=
+            static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+      return sym_storage_offset_custom();
+    }
+    return sym_storage_offset_default();
+  }
+
+  inline c10::SymInt sym_storage_offset_default() const {
     return storage_offset_;
+  }
+
+  virtual c10::SymInt sym_storage_offset_custom() const {
+    if (C10_UNLIKELY(is_python_dispatch())) {
+      return load_pyobj_interpreter()->sym_storage_offset(this);
+    }
+    return sym_storage_offset_default();
   }
 
  protected:
@@ -1433,7 +1453,15 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         allow_tensor_metadata_change(),
         "set_storage_offset ",
         err_msg_tensor_metadata_change_not_allowed);
-    storage_offset_ = storage_offset;
+    storage_offset_ = c10::SymInt(storage_offset);
+  }
+
+  void set_storage_offset(c10::SymInt storage_offset) {
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "set_storage_offset ",
+        err_msg_tensor_metadata_change_not_allowed);
+    storage_offset_ = std::move(storage_offset);
   }
 
   /**
@@ -1963,7 +1991,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     if (data_type_ == meta && storage_initialized()) {
       return static_cast<void*>(
           static_cast<char*>(storage_.data()) +
-          storage_offset_ * meta.itemsize());
+          storage_offset_.as_int_unchecked() * meta.itemsize());
     } else {
       bool had_special_dtor = data_type_.placementDelete() != nullptr;
       storage_offset_ = 0;
@@ -1977,7 +2005,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
           (meta.placementNew() == nullptr && !had_special_dtor &&
            (storage_.nbytes() >= (numel_ * data_type_.itemsize())))) {
         TORCH_INTERNAL_ASSERT(
-            storage_offset_ == 0); // because we just reallocated
+            storage_offset_.as_int_unchecked() ==
+            0); // because we just reallocated
         return storage_.data();
       }
       const Allocator* allocator = storage_.allocator();
@@ -2005,7 +2034,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       }
       storage_.set_nbytes(numel_ * data_type_.itemsize());
       TORCH_INTERNAL_ASSERT(
-          storage_offset_ == 0); // because we just reallocated
+          storage_offset_.as_int_unchecked() ==
+          0); // because we just reallocated
       device_opt_ = storage_.device();
       return storage_.data();
     }
@@ -2020,7 +2050,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   template <typename T>
   inline T* mutable_data() {
     if (storage_initialized() && data_type_.Match<T>()) {
-      return static_cast<T*>(storage_.data()) + storage_offset_;
+      return static_cast<T*>(storage_.data()) +
+          storage_offset_.as_int_unchecked();
     }
     // Check it here statically - otherwise TypeMeta would throw the runtime
     // error in attempt to invoke TypeMeta::ctor()
@@ -2497,7 +2528,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
   c10::impl::SizesAndStrides sizes_and_strides_;
 
-  int64_t storage_offset_ = 0;
+  c10::SymInt storage_offset_ = 0;
   // If sizes and strides are empty, the numel is 1!!  However, most of the
   // time, we will immediately set sizes to {0} and reset numel to 0.
   // (Can't do that in the default initializers, because there's no way to

--- a/c10/core/impl/PyInterpreter.cpp
+++ b/c10/core/impl/PyInterpreter.cpp
@@ -99,6 +99,14 @@ static c10::SymInt noop_sym_numel_fn(const PyInterpreter*, const TensorImpl*) {
       "attempted to call `sym_numel` on Tensor with nontrivial PyObject after corresponding interpreter died");
 }
 
+static c10::SymInt noop_sym_storage_offset_fn(
+    const PyInterpreter*,
+    const TensorImpl*) {
+  TORCH_INTERNAL_ASSERT(
+      0,
+      "attempted to call `sym_storage_offset` on Tensor with nontrivial PyObject after corresponding interpreter died");
+}
+
 static c10::SymIntArrayRef noop_sym_strides_fn(
     const PyInterpreter*,
     const TensorImpl*) {
@@ -120,6 +128,7 @@ void PyInterpreter::disarm() noexcept {
   sym_sizes_fn_ = &noop_sym_sizes_fn;
   layout_fn_ = &noop_layout_fn;
   sym_numel_fn_ = &noop_sym_numel_fn;
+  sym_storage_offset_fn_ = &noop_sym_storage_offset_fn;
   trace_gpu_functions.disarm();
   sym_strides_fn_ = &noop_sym_strides_fn;
 }

--- a/c10/core/impl/PyInterpreter.h
+++ b/c10/core/impl/PyInterpreter.h
@@ -177,6 +177,7 @@ struct C10_API PyInterpreter {
       c10::SymIntArrayRef(const PyInterpreter*, const TensorImpl*);
   using layout_sig = c10::Layout(const PyInterpreter*, const TensorImpl*);
   using sym_numel_sig = c10::SymInt(const PyInterpreter*, const TensorImpl*);
+  using sym_storage_offset_sig = sym_numel_sig;
   using sym_strides_sig =
       c10::SymIntArrayRef(const PyInterpreter*, const TensorImpl*);
 
@@ -193,6 +194,7 @@ struct C10_API PyInterpreter {
       sym_sizes_sig* sym_sizes,
       layout_sig* layout,
       sym_numel_sig* sym_numel,
+      sym_storage_offset_sig* sym_storage_offset,
       sym_strides_sig* sym_strides,
       GPUTraceFunctionWrapper trace_gpu_functions)
       : name_fn_(name_fn),
@@ -207,6 +209,7 @@ struct C10_API PyInterpreter {
         sym_sizes_fn_(sym_sizes),
         layout_fn_(layout),
         sym_numel_fn_(sym_numel),
+        sym_storage_offset_fn_(sym_storage_offset),
         trace_gpu_functions(trace_gpu_functions),
         sym_strides_fn_(sym_strides) {}
 
@@ -222,6 +225,7 @@ struct C10_API PyInterpreter {
   sym_sizes_sig* sym_sizes_fn_;
   layout_sig* layout_fn_;
   sym_numel_sig* sym_numel_fn_;
+  sym_storage_offset_sig* sym_storage_offset_fn_;
   GPUTraceFunctionWrapper trace_gpu_functions;
   sym_strides_sig* sym_strides_fn_;
 
@@ -289,6 +293,11 @@ struct C10_API PyInterpreter {
   __ubsan_ignore_function__ c10::SymInt sym_numel(
       const TensorImpl* self) const {
     return (*sym_numel_fn_)(this, self);
+  }
+
+  __ubsan_ignore_function__ c10::SymInt sym_storage_offset(
+      const TensorImpl* self) const {
+    return (*sym_storage_offset_fn_)(this, self);
   }
 
   __ubsan_ignore_function__ void trace_gpu_event_creation(

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -79,13 +79,12 @@ def create_contiguous(shape):
 
 class FakeSymbolicTensor(torch.Tensor):
     @staticmethod
-    def __new__(cls, sym_shape, sym_strides, dtype, layout, requires_grad, device):
-        offset = 0
+    def __new__(cls, sym_shape, sym_strides, dtype, layout, requires_grad, device, storage_offset=0):
         # TODO: this is wrong in general
         sym_stride = create_contiguous(sym_shape)
         r = torch.Tensor._make_wrapper_subclass(
             cls, sym_shape,
-            sym_stride, offset,
+            sym_stride, storage_offset,
             dtype=dtype, layout=layout, requires_grad=requires_grad,
             device=device,
         )
@@ -120,6 +119,9 @@ class FakeSymbolicTensor(torch.Tensor):
             self = args[0]
             return len(self.sym_shape)
 
+        if func_overload == torch.ops.aten.sym_storage_offset.default:
+            return None
+
         if func_overload == torch.ops.aten.new_empty.default:
             self = args[0]
             shape = args[1]
@@ -128,10 +130,10 @@ class FakeSymbolicTensor(torch.Tensor):
         raise RuntimeError(f"operator {func_overload} not supported")
 
 
-def create_symbolic_tensor(name, arg, shape_env):
+def create_symbolic_tensor(name, arg, shape_env, storage_offset=0):
     sym_shapes = tuple([shape_env.create_symint(f"{name}_{idx}", val) for idx, val in enumerate(arg.size())])
     sym_strides = tuple([shape_env.create_symint(f"{name}_{idx}_stride", val) for idx, val in enumerate(arg.stride())])
-    return FakeSymbolicTensor(sym_shapes, sym_strides, arg.dtype, arg.layout, arg.requires_grad, arg.device)
+    return FakeSymbolicTensor(sym_shapes, sym_strides, arg.dtype, arg.layout, arg.requires_grad, arg.device, storage_offset)
 
 
 CPP_SYMINT_CLASS = type(torch._C.SymIntNode.new_symint(1))
@@ -170,6 +172,7 @@ class TestPySymInt(TestCase):
     def test_roundtrip(self):
         shape_env = ShapeEnv()
         x = create_symbolic_tensor("x", torch.randn(5, 4, 3), shape_env)
+
         self.assertTrue(not isinstance(x.shape[0], PySymInt))
         self.assertTrue(isinstance(x.shape[0], CPP_SYMINT_CLASS))
 
@@ -186,6 +189,16 @@ class TestPySymInt(TestCase):
         self.assertTrue(x.size(1) == 4)
         self.assertTrue(x.size(2) == 3)
         self.assertTrue(isinstance(x.size(2), CPP_SYMINT_CLASS))
+
+        offset = shape_env.create_symint("offset", 2)
+        y = create_symbolic_tensor("x", torch.randn(5, 4, 3), shape_env, offset)
+        self.assertTrue(isinstance(y.storage_offset(), CPP_SYMINT_CLASS))
+        self.assertTrue(y.storage_offset() == 2)
+
+        offset = 2
+        z = create_symbolic_tensor("z", torch.randn(5, 4, 3), shape_env, offset)
+        self.assertTrue(isinstance(z.storage_offset(), int))
+        self.assertTrue(z.storage_offset() == 2)
 
     @skipIfNoSympy
     def test_binary(self):

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -213,7 +213,7 @@ static PyObject * THPVariable_storage_offset(PyObject* self_, PyObject* args)
     return handle_torch_function(self_, "storage_offset");
   }
   auto& self = THPVariable_Unpack(self_);
-  return wrap(self.storage_offset());
+  return py::cast(self.sym_storage_offset()).release().ptr();
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -806,9 +806,6 @@ static PyObject* THPVariable_make_wrapper_subclass(
     tensor_impl->set_sym_sizes_and_strides(sym_sizes, sym_strides);
     tensor_impl->set_storage_offset(r.toSymIntOptional(3).value_or(c10::SymInt{0}));
 
-    // N.B. we ignore the storage argument as it's eiher stored on a python
-    // tensor or gets overriden for XLA
-
     const auto sizes_strides_policy = r.stringViewOptional(10);
     if (sizes_strides_policy.has_value()) {
       TORCH_CHECK(

--- a/torch/csrc/jit/mobile/promoted_prim_ops.cpp
+++ b/torch/csrc/jit/mobile/promoted_prim_ops.cpp
@@ -73,6 +73,11 @@ void sym_numel(Stack& stack) {
   push(stack, t.sym_numel());
 }
 
+void sym_storage_offset(Stack& stack) {
+  auto t = std::move(pop(stack)).toTensor();
+  push(stack, t.sym_storage_offset());
+}
+
 void sym_stride(Stack& stack) {
   auto t = std::move(pop(stack)).toTensor();
   pack(stack, t.sym_strides().vec());

--- a/torch/csrc/jit/mobile/promoted_prim_ops.h
+++ b/torch/csrc/jit/mobile/promoted_prim_ops.h
@@ -25,6 +25,8 @@ void sym_size_int(Stack& stack);
 
 void sym_numel(Stack& stack);
 
+void sym_storage_offset(Stack& stack);
+
 void sym_stride(Stack& stack);
 
 void device(Stack& stack);

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -432,6 +432,11 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs{
         sym_numel,
         aliasAnalysisFromSchema()),
     OperatorGeneratorArgs(
+        TORCH_SELECTIVE_SCHEMA(
+            "aten::sym_storage_offset(Tensor self) -> SymInt"),
+        sym_storage_offset,
+        aliasAnalysisFromSchema()),
+    OperatorGeneratorArgs(
         TORCH_SELECTIVE_SCHEMA("aten::sym_stride(Tensor self) -> SymInt[]"),
         sym_stride,
         aliasAnalysisFromSchema()),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84394
* #84393
* #84392

Store storage_offset_ on TensorImpl directly as SymInt

Unlike numel, which is a derived quantity, storage offset is canonical,
so it is simplest if we store it correctly.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

final fixes

remove dead code

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel