### PR TITLE
fix and enable ATen ExclusivelyOwned_test

### DIFF
--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -7,8 +7,6 @@ endif(MSVC)
 list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/Dict_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Dimname_test.cpp
-  # Fix this.
-  # ${CMAKE_CURRENT_SOURCE_DIR}/ExclusivelyOwned_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/MaybeOwned_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NamedTensor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/apply_utils_test.cpp
@@ -111,6 +109,7 @@ list(APPEND ATen_VEC_TEST_SRCS
 # Caffe2 specific tests
 if(BUILD_CAFFE2)
   list(APPEND ATen_CPU_TEST_SRCS
+    ${CMAKE_CURRENT_SOURCE_DIR}/ExclusivelyOwned_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor_interop_test.cpp)
   list(APPEND ATen_CUDA_TEST_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cuda_tensor_interop_test.cpp)

--- a/aten/src/ATen/test/ExclusivelyOwned_test.cpp
+++ b/aten/src/ATen/test/ExclusivelyOwned_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Tensor.h>
 #include <caffe2/core/tensor.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84397
* __->__ #84395
* #84345

Summary:
This depends on caffe2 so it must move to that section.

Test Plan: Rely on CI.

Reviewers:

Subscribers:

Tasks:

Tags: