### PR TITLE
re-enable ATen packedtensoraccessor_test

### DIFF
--- a/aten/src/ATen/core/TensorAccessor.h
+++ b/aten/src/ATen/core/TensorAccessor.h
@@ -160,7 +160,7 @@ protected:
   index_t strides_[N];
   C10_HOST void bounds_check_(index_t i) const {
     TORCH_CHECK_INDEX(
-        0 <= i && i < N,
+        0 <= i && i < index_t{N},
         "Index ",
         i,
         " is not within bounds of a tensor of dimension ",

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -29,8 +29,7 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/native_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/operator_name_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/operators_test.cpp
-  # Fix this.
-  # ${CMAKE_CURRENT_SOURCE_DIR}/packedtensoraccessor_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/packedtensoraccessor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/pow_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/quantized_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduce_ops_test.cpp


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84397
* #84395
* #84345

Summary:

Test Plan: Rely on CI.

Reviewers:

Subscribers:

Tasks:

Tags: