### PR TITLE
caffe2: set `supports_python_dlopen = True` on libtorch

### DIFF
--- a/tools/target_definitions.bzl
+++ b/tools/target_definitions.bzl
@@ -204,6 +204,7 @@ def add_torch_libs():
             ("llvm-fb", None, "LLVMipo"),
         ] + ([("openmpi", None, "openmpi")] if use_mpi else []),
         compiler_flags = compiler_flags_cpu,
+        supports_python_dlopen = True,
         **common_flags
     )
 


### PR DESCRIPTION
Summary:
Like it says in the title. This library ends up depended on by Python and
exposed as a root anyway. I pulled this out of D39104634 since it needs a
Github PR to land, so I'll land it afterwards.

Note: this is a better way to do what D37946374 (https://github.com/pytorch/pytorch/commit/0933c037e7e5d306d3ba537dcbe3192ccd060f34) does. That diff excluded all of
libtorch's deps from Omnibus linking (hence the timeouts). This diff, in
contrast, only excluded libtorch itself (which most of the time it already is
implicitly by virtue of being depended on by a Python dep, but not necessarily
always).

Context on this attribute: D39104635

Reviewed By: ndmitchell

Differential Revision: D39168231

