### PR TITLE
Add ShouldSyncTensor interface

### DIFF
--- a/torch/csrc/lazy/backend/backend_interface.cpp
+++ b/torch/csrc/lazy/backend/backend_interface.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/lazy/backend/backend_interface.h>
+#include <torch/csrc/lazy/core/internal_ops/ltc_ops.h>
 
 namespace torch {
 namespace lazy {
@@ -15,6 +16,11 @@ const BackendImplInterface* getBackend() {
   auto* interface = backend_impl_registry.load();
   TORCH_CHECK(interface, "Lazy tensor backend not registered.");
   return interface;
+}
+
+// default implementation
+bool BackendImplInterface::ShouldSyncTensor(const LazyTensorPtr tensor) const {
+  return tensor->GetIrValue()->op() != ltc_not_supported;
 }
 
 BackendRegistrar::BackendRegistrar(

--- a/torch/csrc/lazy/backend/backend_interface.h
+++ b/torch/csrc/lazy/backend/backend_interface.h
@@ -5,6 +5,7 @@
 #include <torch/csrc/lazy/backend/backend_device.h>
 #include <torch/csrc/lazy/backend/lowering_context.h>
 #include <torch/csrc/lazy/core/shape.h>
+#include <torch/csrc/lazy/core/tensor.h>
 #include <atomic>
 
 namespace torch {
@@ -39,6 +40,8 @@ class TORCH_API BackendImplInterface {
    * */
 
   virtual const IrBuilder* GetIrBuilder() const = 0;
+
+  virtual bool ShouldSyncTensor(const LazyTensorPtr tensor) const = 0;
 
   /**
    * Data Transfer

--- a/torch/csrc/lazy/backend/backend_interface.h
+++ b/torch/csrc/lazy/backend/backend_interface.h
@@ -41,7 +41,7 @@ class TORCH_API BackendImplInterface {
 
   virtual const IrBuilder* GetIrBuilder() const = 0;
 
-  virtual bool ShouldSyncTensor(const LazyTensorPtr tensor) const = 0;
+  virtual bool ShouldSyncTensor(const LazyTensorPtr tensor) const;
 
   /**
    * Data Transfer

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -2,8 +2,8 @@
 
 #include <c10/core/SymIntNodeImpl.h>
 #include <c10/util/intrusive_ptr.h>
+#include <torch/csrc/lazy/backend/backend_data.h>
 #include <torch/csrc/lazy/backend/backend_device.h>
-#include <torch/csrc/lazy/backend/backend_interface.h>
 #include <torch/csrc/lazy/core/ir.h>
 #include <torch/csrc/lazy/core/lazy_view.h>
 #include <torch/csrc/lazy/core/util.h>

--- a/torch/csrc/lazy/ts_backend/ts_backend_impl.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_backend_impl.cpp
@@ -2,7 +2,6 @@
 
 #include <ATen/Functions.h>
 #include <torch/csrc/lazy/backend/backend_device.h>
-#include <torch/csrc/lazy/core/internal_ops/ltc_ops.h>
 #include <torch/csrc/lazy/generated/LazyNativeFunctions.h>
 #include <torch/csrc/lazy/ts_backend/config.h>
 #include <torch/csrc/lazy/ts_backend/ir_builder.h>
@@ -52,10 +51,6 @@ class TSBackendImpl : public torch::lazy::BackendImplInterface {
   const IrBuilder* GetIrBuilder() const override {
     static const IrBuilder* builder = new TorchScriptIrBuilder();
     return builder;
-  }
-
-  bool ShouldSyncTensor(const LazyTensorPtr tensor) const override {
-    return tensor->GetIrValue()->op() != ltc_not_supported;
   }
 
   std::string CreateMetricReport() const override {

--- a/torch/csrc/lazy/ts_backend/ts_backend_impl.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_backend_impl.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/Functions.h>
 #include <torch/csrc/lazy/backend/backend_device.h>
+#include <torch/csrc/lazy/core/internal_ops/ltc_ops.h>
 #include <torch/csrc/lazy/generated/LazyNativeFunctions.h>
 #include <torch/csrc/lazy/ts_backend/config.h>
 #include <torch/csrc/lazy/ts_backend/ir_builder.h>
@@ -51,6 +52,10 @@ class TSBackendImpl : public torch::lazy::BackendImplInterface {
   const IrBuilder* GetIrBuilder() const override {
     static const IrBuilder* builder = new TorchScriptIrBuilder();
     return builder;
+  }
+
+  bool ShouldSyncTensor(const LazyTensorPtr tensor) const override {
+    return tensor->GetIrValue()->op() != ltc_not_supported;
   }
 
   std::string CreateMetricReport() const override {


### PR DESCRIPTION
Adding an `ShouldSyncTensor` interface to allow for the case of output pruning should a vendor not support retrieving the value of a certain output.

CC: @wconstab @JackCaoG @Krovatkin 