### PR TITLE
Turn on functionalization by default in functorch

### DIFF
--- a/functorch/functorch/_src/config.py
+++ b/functorch/functorch/_src/config.py
@@ -9,7 +9,7 @@ Global flags for aot autograd
 """
 import os
 
-use_functionalize = False
+use_functionalize = True
 
 # TODO: flip this to true by default
 # Waiting on

--- a/functorch/test/test_pythonkey.py
+++ b/functorch/test/test_pythonkey.py
@@ -391,7 +391,6 @@ class TestEagerFusionOpInfo(AOTTestCase):
         xfail('cholesky'),
         xfail('cumulative_trapezoid'),
         xfail('diag_embed'),
-        xfail('linalg.householder_product'),
         xfail('logit'),
         xfail('trapezoid'),
         xfail('trapz'),

--- a/functorch/test/test_pythonkey.py
+++ b/functorch/test/test_pythonkey.py
@@ -643,6 +643,7 @@ class TestAOTModuleSimplified(AOTTestCase):
         assert torch.allclose(inputs[0].grad, cloned_inputs[0].grad)
         assert torch.allclose(inputs[1].grad, cloned_inputs[1].grad)
 
+    @unittest.skip("Breaks with functionalization on by default")
     def test_aot_module_simplified_preserves_stack_trace(self):
         class MockModule(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84435

I talked to @SherlockNoMad abt this PR and we agreed prior to brian coming back it was worth disabling this test for getting functionalization on (and that is already the state of torchdynamo)
