### PR TITLE
optimize the performance of binary_kernel_reduce for welford using Ro…

### DIFF
--- a/aten/src/ATen/native/cpu/moments_utils.h
+++ b/aten/src/ATen/native/cpu/moments_utils.h
@@ -8,6 +8,7 @@
 
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec/vec.h>
+#include <ATen/cpu/vec/functional.h>
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/SmallVector.h>
 #include <c10/util/irange.h>

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1798,6 +1798,28 @@ class TestReductions(TestCase):
                 with self.assertRaisesRegex(RuntimeError, error_msg):
                     op(x, dim=dim)
 
+    @onlyCPU
+    def test_var_bfloat16(self, device):
+        def helper(size, device, format=torch.contiguous_format):
+            input_bf = torch.randn(size, dtype=torch.bfloat16, device=device).contiguous(memory_format=format)
+            input_f = input_bf.float()
+            out_f = input_f.var()
+            out_bf = input_bf.var()
+            self.assertEqual(out_f, out_bf.float(), atol=0.01, rtol=0.01)
+            out_f = input_f.var(1)
+            out_bf = input_bf.var(1)
+            self.assertEqual(out_f, out_bf.float(), atol=0.01, rtol=0.01)
+            out_f = input_f.var(2)
+            out_bf = input_bf.var(2)
+            self.assertEqual(out_f, out_bf.float(), atol=0.01, rtol=0.01)
+        helper((2, 10, 10), device)
+        helper((4, 10, 40), device)
+        helper((4, 20, 40), device)
+        helper((4, 300, 300), device)
+        helper((4, 20, 40, 5), device, torch.channels_last)
+        helper((4, 20, 40, 5, 5), device, torch.channels_last_3d)
+        helper((4, 100, 300, 300), device, torch.channels_last)
+
     # TODO: update this test to comapre against NumPy
     @onlyCUDA
     def test_var(self, device):


### PR DESCRIPTION
### Description
Optimize the performance of binary_kernel_reduce for welford using RowwiseMoments for bfloat16 on CPU.
This PR depends on the optimization of RowwiseMoments https://github.com/pytorch/pytorch/pull/84404 and https://github.com/pytorch/pytorch/pull/84405

### Testing
single socket (28cores):
```
before: torch.Size([10, 128, 10, 124]) bf16: 0.000414 s
        torch.Size([10, 128, 30, 124]) bf16: 0.00163 s
            
after: torch.Size([10, 128, 10, 124]) bf16: 2.246e-05 s
       torch.Size([10, 128, 30, 124]) bf16: 6.811e-05 s
```
single core:
```
before: torch.Size([10, 128, 10, 124]) bf16: 0.00980 s
        torch.Size([10, 128, 30, 124]) bf16: 0.0398 s
            
after: torch.Size([10, 128, 10, 124]) bf16: 0.000310 s
       torch.Size([10, 128, 30, 124]) bf16: 0.00127 s
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10