### PR TITLE
[Quant] Improve performance of ONEDNN backend

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -5,6 +5,141 @@
 #include <ATen/Tensor.h>
 #include <ATen/native/quantized/PackedParams.h>
 #include <ideep.hpp>
+#include <memory>
+#include <mutex>
+
+using PrimitiveCacheKey = std::tuple<
+    double, // input_scale
+    int64_t, // input_zero_point
+    std::vector<int64_t>, // input_shape
+    double, // output_scale
+    int64_t, // output_zero_point
+    int64_t>; // OMP_number_of_threads
+
+enum CacheKeyIndex {
+  InputScale,
+  InputZeroPoint,
+  InputShape,
+  OutputScale,
+  OutputZeroPoint,
+  NumOfThreads,
+};
+
+// Base class of primitive cache
+struct PrimitiveCache {
+  PrimitiveCacheKey key;
+
+  bool hit(const PrimitiveCacheKey& key) {
+    return this->key == key;
+  }
+};
+
+using LinearParams = ideep::matmul_forward_params;
+using Conv = dnnl::convolution_forward;
+using ConvDesc = dnnl::convolution_forward::primitive_desc;
+using ConvParams = ideep::convolution_forward_params;
+using Deconv = dnnl::deconvolution_forward;
+using DeconvDesc = dnnl::deconvolution_forward::primitive_desc;
+using DeconvParams = ideep::deconv_forward_params;
+
+struct LinearPrimitiveCache : PrimitiveCache {
+  LinearPrimitiveCache() {}
+
+  LinearPrimitiveCache(
+      const PrimitiveCacheKey& key,
+      const LinearParams& param) {
+    this->key = key;
+    this->param = param;
+  }
+
+  LinearPrimitiveCache(
+      const PrimitiveCacheKey& key,
+      const LinearParams& param,
+      const ideep::tensor& bias) {
+    this->key = key;
+    this->param = param;
+    if (!bias.is_empty()) {
+      expected_bias =
+          bias.reorder_if_differ_in(param.pd.bias_desc(), param.bias_attr);
+    }
+  }
+
+  LinearParams param;
+  ideep::tensor expected_bias;
+
+  // For dynamic qlinear, scale and zero point
+  // are set at execution time. So we only need to compare
+  // the rest part of key.
+  bool hit_dynamic(const PrimitiveCacheKey& new_key) {
+    auto cached_input_shape = std::get<InputShape>(this->key);
+    auto new_input_shape = std::get<InputShape>(new_key);
+    return (
+        cached_input_shape == new_input_shape &&
+        std::get<NumOfThreads>(this->key) == std::get<NumOfThreads>(new_key));
+  }
+
+  LinearParams& get_param() {
+    return param;
+  }
+
+  ideep::tensor& get_expected_bias() {
+    return expected_bias;
+  }
+};
+
+struct ConvPrimitiveCache : PrimitiveCache {
+  ConvPrimitiveCache() {}
+
+  ConvPrimitiveCache(
+      const PrimitiveCacheKey& key,
+      const ConvParams& params,
+      const ideep::tensor& bias) {
+    this->key = key;
+    this->params = params;
+    if (!bias.is_empty()) {
+      this->expected_bias =
+          bias.reorder_if_differ_in(params.pd.bias_desc(), params.bias_attr);
+    }
+  }
+
+  ideep::tensor expected_bias;
+  ConvParams params;
+
+  ConvParams& get_params() {
+    return params;
+  }
+
+  ideep::tensor& get_bias() {
+    return expected_bias;
+  }
+};
+
+struct DeconvPrimitiveCache : PrimitiveCache {
+  DeconvPrimitiveCache() {}
+
+  DeconvPrimitiveCache(
+      const PrimitiveCacheKey& key,
+      const DeconvParams& params,
+      const ideep::tensor& bias) {
+    this->key = key;
+    this->params = params;
+    if (!bias.is_empty()) {
+      this->expected_bias =
+          bias.reorder_if_differ_in(params.pd.bias_desc(), params.bias_attr);
+    }
+  }
+
+  DeconvParams params;
+  ideep::tensor expected_bias;
+
+  DeconvParams& get_params() {
+    return params;
+  }
+
+  ideep::tensor& get_bias() {
+    return expected_bias;
+  }
+};
 
 struct PackedLinearWeightsOnednn : public LinearPackedParamsBase {
   PackedLinearWeightsOnednn(
@@ -15,7 +150,9 @@ struct PackedLinearWeightsOnednn : public LinearPackedParamsBase {
       : weight_(std::move(weight)),
         bias_(std::move(bias)),
         orig_weight_(std::move(orig_weight)),
-        orig_bias_(std::move(orig_bias)) {}
+        orig_bias_(std::move(orig_bias)) {
+    cache_initialized_flag = std::make_unique<std::once_flag>();
+  }
   std::unique_ptr<ideep::tensor> weight_;
   c10::optional<ideep::tensor> bias_;
   at::Tensor orig_weight_;
@@ -44,6 +181,9 @@ struct PackedLinearWeightsOnednn : public LinearPackedParamsBase {
       c10::optional<at::Tensor> bias);
 
  private:
+  LinearPrimitiveCache prim_cache;
+  std::unique_ptr<std::once_flag> cache_initialized_flag;
+
   template <bool ReluFused>
   at::Tensor apply_impl(
       at::Tensor input,
@@ -52,6 +192,10 @@ struct PackedLinearWeightsOnednn : public LinearPackedParamsBase {
 
   template <bool ReluFused>
   at::Tensor apply_dynamic_impl(at::Tensor input, bool reduce_range=false);
+
+  LinearPrimitiveCache& get_cache() {
+    return prim_cache;
+  }
 };
 
 template <int kSpatialDim = 2>
@@ -67,16 +211,18 @@ struct PackedConvWeightsOnednn : public ConvPackedParamsBase<kSpatialDim> {
       torch::List<int64_t> dilation,
       int64_t groups,
       uint8_t transpose)
-    : weight_(std::move(weight)),
-    bias_(std::move(bias)),
-    orig_weight_(std::move(orig_weight)),
-    orig_bias_(std::move(orig_bias)),
-    stride_(std::move(stride)),
-    padding_(std::move(padding)),
-    output_padding_(std::move(output_padding)),
-    dilation_(std::move(dilation)),
-    groups_(groups),
-    transpose_(transpose) {}
+      : weight_(std::move(weight)),
+        bias_(std::move(bias)),
+        orig_weight_(std::move(orig_weight)),
+        orig_bias_(std::move(orig_bias)),
+        stride_(std::move(stride)),
+        padding_(std::move(padding)),
+        output_padding_(std::move(output_padding)),
+        dilation_(std::move(dilation)),
+        groups_(groups),
+        transpose_(transpose) {
+    cache_initialized_flag = std::make_unique<std::once_flag>();
+  }
 
   std::unique_ptr<ideep::tensor> weight_;
   c10::optional<ideep::tensor> bias_;
@@ -140,11 +286,25 @@ struct PackedConvWeightsOnednn : public ConvPackedParamsBase<kSpatialDim> {
   }
 
  private:
+  ConvPrimitiveCache conv_prim_cache;
+  DeconvPrimitiveCache deconv_prim_cache;
+  std::unique_ptr<std::once_flag> cache_initialized_flag;
+
   template <bool ReluFused>
   at::Tensor apply_impl(
       const at::Tensor& input,
       double output_scale,
       int64_t output_zero_point);
+
+  ConvPrimitiveCache& get_conv_cache() {
+    assert(!transpose());
+    return conv_prim_cache;
+  }
+
+  DeconvPrimitiveCache& get_deconv_cache() {
+    assert(transpose());
+    return deconv_prim_cache;
+  }
 };
 
 #endif // #if AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -1227,49 +1227,89 @@ at::Tensor PackedConvWeightsOnednn<kSpatialDim>::apply_impl(
   const ideep::dims& dilates = dilation().vec();
   const ideep::dims& padding_l = padding().vec();
   const ideep::dims& padding_r = padding().vec();
-  const ideep::scale_t& src_scales = ideep::scale_t(1, 1.0/act.q_scale()); // Scales of ONEDNN and PyTorch are reciprocal
+  double input_scale = act.q_scale();
+  int64_t input_zp = act.q_zero_point();
+  // Scales of ONEDNN and PyTorch are reciprocal
+  const ideep::scale_t& src_scales = ideep::scale_t(1, 1.0/input_scale);
   const ideep::scale_t& weights_scales = weights.get_scale();
-  const ideep::scale_t& dst_scales = ideep::scale_t(weights_scales.size(), 1.0/output_scale); // Scales of ONEDNN and PyTorch are reciprocal
-  const ideep::zero_point_t src_zero_points = ideep::zero_point_t(1, act.q_zero_point());
+  int64_t scale_size = weights_scales.size();
+  double inv_output_scale = 1.0/output_scale;
+  const ideep::zero_point_t src_zero_points = ideep::zero_point_t(1, input_zp);
   const ideep::zero_point_t dst_zero_points = ideep::zero_point_t(1, output_zero_point);
   ideep::attr_t op_attr = kReluFused ? ideep::attr_t::fuse_relu() : ideep::attr_t();
-  op_attr.set_zero_points(DNNL_ARG_SRC, ideep::utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL}); // runtime src zero point
-  if (with_bias) {
-    // Bias might be modified outside (e.g. by quantization bias correction).
-    // If so, update the prepacked bias as well.
-    if (bias_.value().get_data_handle() != orig_bias_.value().data_ptr()) {
-      bias_.value().init(bias_.value().get_desc(), orig_bias_.value().data_ptr());
-    }
-    const auto& b = bias_.value();
-    if (transpose()) {
-      ideep::convolution_transpose_forward::compute_v2(
+  // Since src zero point is unknown, set runtime value here
+  op_attr.set_zero_points(DNNL_ARG_SRC, ideep::utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+
+  // Bias might be modified outside (e.g. by quantization bias correction).
+  // If so, update the prepacked bias as well.
+  if (with_bias && bias_.value().get_data_handle() != orig_bias_.value().data_ptr()) {
+    bias_.value().init(bias_.value().get_desc(), orig_bias_.value().data_ptr());
+  }
+  const auto& b = with_bias ? bias_.value() : ideep::tensor();
+  int num_threads = at::get_num_threads();
+  if (transpose()) {
+    // Primitive cache is initialized when called for the first time
+    // and won't be updated afterwards.
+    PrimitiveCacheKey cache_key = std::make_tuple(
+        input_scale, input_zp, src_dims, output_scale, output_zero_point, num_threads);
+    std::call_once(*cache_initialized_flag, [&](){
+        DeconvParams params;
+        ideep::convolution_transpose_forward::prepare(
+            params, src, weights, b, dst_dims, dst,
+            strides, padding_l, padding_r, dilates, groups(),
+            src_scales, weights_scales, ideep::scale_t(scale_size, inv_output_scale),
+            src_zero_points, dst_zero_points, op_attr,
+            dnnl::algorithm::deconvolution_direct,
+            dnnl::prop_kind::forward_inference,
+            ideep::u8s8, ideep::engine::cpu_engine());
+        get_deconv_cache() = DeconvPrimitiveCache(cache_key, params, b);
+        weights = weights.reorder_if_differ_in(params.pd.weights_desc());
+    });
+    if (get_deconv_cache().hit(cache_key)) {
+      DeconvParams& params = get_deconv_cache().get_params();
+      auto& expected_bias = get_deconv_cache().get_bias();
+      ideep::convolution_transpose_forward::compute<false, false>(
+          params, src, weights, expected_bias, dst);
+    } else {
+      ideep::convolution_transpose_forward::compute(
           src, weights, b, dst_dims, dst,
           strides, padding_l, padding_r, dilates,
-          groups(), src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-          op_attr, dnnl::algorithm::deconvolution_direct, dnnl::prop_kind::forward_inference,
-          ideep::u8s8, ideep::engine::cpu_engine());
-    } else {
-      ideep::convolution_forward::compute_v2(
-          src, weights, b, dst_dims, dst,
-          strides, dilates, padding_l, padding_r, groups(),
-          src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-          op_attr, dnnl::algorithm::convolution_direct, dnnl::prop_kind::forward_inference,
+          groups(), src_scales, weights_scales,
+          ideep::scale_t(scale_size, inv_output_scale),
+          src_zero_points, dst_zero_points, op_attr,
+          dnnl::algorithm::deconvolution_direct,
+          dnnl::prop_kind::forward_inference,
           ideep::u8s8, ideep::engine::cpu_engine());
     }
-  } else {
-    if (transpose()) {
-      ideep::convolution_transpose_forward::compute_v2(
-          src, weights, dst_dims, dst,
-          strides, padding_l, padding_r, dilates,
-          groups(), src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-          op_attr, dnnl::algorithm::deconvolution_direct, dnnl::prop_kind::forward_inference,
-          ideep::u8s8, ideep::engine::cpu_engine());
+  } else {  // not transposed
+    PrimitiveCacheKey cache_key = std::make_tuple(
+        input_scale, input_zp, src_dims, output_scale, output_zero_point, num_threads);
+    std::call_once(*cache_initialized_flag, [&](){
+        ConvParams params;
+        ideep::convolution_forward::prepare(
+            params, src, weights, b, dst_dims, dst,
+            strides, dilates, padding_l, padding_r, groups(),
+            src_scales, weights_scales, ideep::scale_t(scale_size, inv_output_scale),
+            src_zero_points, dst_zero_points,
+            op_attr, dnnl::algorithm::convolution_direct,
+            dnnl::prop_kind::forward_inference,
+            ideep::u8s8, ideep::engine::cpu_engine());
+        get_conv_cache() = ConvPrimitiveCache(cache_key, params, b);
+        weights = weights.reorder_if_differ_in(params.pd.weights_desc());
+    });
+    // If hit, use cached data. If miss, fall back to normal path.
+    if (get_conv_cache().hit(cache_key)) {
+      auto& params = get_conv_cache().get_params();
+      auto& expected_bias = get_conv_cache().get_bias();
+      ideep::convolution_forward::compute<false, false>(params, src, weights, expected_bias, dst);
     } else {
-      ideep::convolution_forward::compute_v2(
-          src, weights, dst_dims, dst,
+      ideep::convolution_forward::compute(
+          src, weights, b, dst_dims, dst,
           strides, dilates, padding_l, padding_r, groups(),
-          src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-          op_attr, dnnl::algorithm::convolution_direct, dnnl::prop_kind::forward_inference,
+          src_scales, weights_scales, ideep::scale_t(scale_size, inv_output_scale),
+          src_zero_points, dst_zero_points, op_attr,
+          dnnl::algorithm::convolution_direct,
+          dnnl::prop_kind::forward_inference,
           ideep::u8s8, ideep::engine::cpu_engine());
     }
   }

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -629,10 +629,13 @@ at::Tensor PackedLinearWeightsOnednn::apply_impl(
   ideep::attr_t op_attr = ReluFused ? ideep::attr_t::fuse_relu() : ideep::attr_t();
   ideep::tensor x(input_desc, input_contig->data_ptr<c10::quint8>());
   auto dst_dims = {M, N};
-  const ideep::scale_t& src_scales = ideep::scale_t(1, 1.0/input.q_scale());
+  double input_scale = input.q_scale();
+  int64_t input_zero_point = input.q_zero_point();
+  const ideep::scale_t& src_scales = ideep::scale_t(1, 1.0/input_scale);
   const ideep::scale_t& weights_scales = w.get_scale();
-  const ideep::scale_t& dst_scales = ideep::scale_t(1, 1.0/output_scale); // Scales of ONEDNN and PyTorch are reciprocal
-  const ideep::zero_point_t& src_zero_point = ideep::zero_point_t(1, input.q_zero_point());
+  // Scales of ONEDNN and PyTorch are reciprocal
+  const ideep::scale_t& dst_scales = ideep::scale_t(1, 1.0/output_scale);
+  const ideep::zero_point_t& src_zero_point = ideep::zero_point_t(1, input_zero_point);
   const ideep::zero_point_t& dst_zero_point = ideep::zero_point_t(1, output_zero_point);
   // Compute: Use ideep::matmul_forward to support asymmetric quantization
   // Allocate output Tensor
@@ -646,18 +649,35 @@ at::Tensor PackedLinearWeightsOnednn::apply_impl(
   }
   ideep::tensor y({dst_dims, ideep::tensor::data_type::u8, {output.strides().cbegin(), output.strides().cend()}},
                   output.data_ptr());
-  if (bias_.has_value()) {
+  bool with_bias = bias_.has_value();
+  if (with_bias) {
     // Bias might be modified outside (e.g. by quantization bias correction).
     // If so, update the prepacked bias as well.
     if (bias_.value().get_data_handle() != orig_bias_.value().data_ptr()) {
       bias_.value().init(bias_.value().get_desc(), orig_bias_.value().data_ptr());
     }
-    const auto& b = bias_.value();
-    ideep::matmul_forward::compute_v2(x, w, b, y, 1.0f, 1.0f, src_scales, weights_scales, dst_scales,
-                                      src_zero_point, dst_zero_point, op_attr);
+  }
+  const auto& b = with_bias ? bias_.value() : ideep::tensor();
+  // Primitive cache is initialized when called for the first time
+  // and won't be updated afterwards.
+  int num_threads = at::get_num_threads();
+  PrimitiveCacheKey cache_key = std::make_tuple(
+      input_scale, input_zero_point, input_dims, output_scale, output_zero_point, num_threads);
+  std::call_once(*cache_initialized_flag, [&](){
+      LinearParams params;
+      ideep::matmul_forward::prepare</*is_dynamic=*/false>(
+          params, x, w, b, y, src_scales, weights_scales,
+          dst_scales, src_zero_point, dst_zero_point, 1.0f, 1.0f, op_attr);
+      get_cache() = LinearPrimitiveCache(cache_key, params, b);
+      w = w.reorder_if_differ_in(params.pd.weights_desc());
+  });
+  if (get_cache().hit(cache_key)) {
+    LinearParams& params = get_cache().get_param();
+    ideep::tensor& expected_bias = get_cache().get_expected_bias();
+    ideep::matmul_forward::compute<false, false>(params, x, w, expected_bias, y);
   } else {
-    ideep::matmul_forward::compute_v2(x, w, y, 1.0f, 1.0f, src_scales, weights_scales, dst_scales,
-                                      src_zero_point, dst_zero_point, op_attr);
+    ideep::matmul_forward::compute(x, w, b, y, src_scales, weights_scales, dst_scales,
+                                   src_zero_point, dst_zero_point, 1.0f, 1.0f, op_attr);
   }
   auto out_sizes = input.sizes().vec();
   out_sizes.back() = N;

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -503,10 +503,21 @@ at::Tensor PackedLinearWeightsOnednn::apply_dynamic_impl(
   x.init(input_desc, input_contig.data_ptr());
   // Find quantization parameters
   float x_max = 0, x_min = 0;
-  if (input.numel() > 0) {
-    x_min = input_contig.min().item<float>();
-    x_max = input_contig.max().item<float>();
+#ifdef USE_FBGEMM
+  // Use FBGEMM's FindMinMax if available since it's faster
+  fbgemm::FindMinMax(
+      /*m=*/input_contig.data_ptr<float>(),
+      /*min=*/&x_min,
+      /*max=*/&x_max,
+      /*len=*/input.numel());
+#else
+  if (input_contig.numel() > 0) {
+    Tensor t_min, t_max;
+    std::tie(t_min, t_max) = at::aminmax(input_contig);
+    x_max = t_max.item<float>();
+    x_min = t_min.item<float>();
   }
+#endif
   const int precision = 8;
   auto q_params = quant_utils::ChooseQuantizationParams(
       /*min=*/x_min,
@@ -531,20 +542,36 @@ at::Tensor PackedLinearWeightsOnednn::apply_dynamic_impl(
   ideep::tensor y({dst_dims, ideep::tensor::data_type::f32,
                    {output.strides().cbegin(), output.strides().cend()}},
                   output.data_ptr());
-  if (bias_.has_value()) {
+  bool with_bias = bias_.has_value();
+  if (with_bias) {
     // Bias might be modified outside (e.g. by quantization bias correction).
     // If so, update the prepacked bias as well.
     if (bias_.value().get_data_handle() != orig_bias_.value().data_ptr()) {
       bias_.value().init(bias_.value().get_desc(), orig_bias_.value().data_ptr());
     }
-    const ideep::tensor b = bias_.value();
-    ideep::matmul_forward::compute_v2(x, w, b, y, 1.0f, 1.0f,
-                                      src_scales, weights_scales, ideep::scale_t(),
-                                      src_zero_point, ideep::zero_point_t(), op_attr);
+  }
+  const auto& b = with_bias ? bias_.value() : ideep::tensor();
+  // Primitive cache is initialized when called for the first time
+  // and won't be updated afterwards.
+  int num_threads = at::get_num_threads();
+  PrimitiveCacheKey cache_key = std::make_tuple(
+      q_params.scale, q_params.zero_point, input_dims, 1.0, 0, num_threads);
+  std::call_once(*cache_initialized_flag, [&](){
+      LinearParams params;
+      ideep::matmul_forward::prepare</*is_dynamic=*/true>(
+          params, x, w, b, y, src_scales, weights_scales, ideep::IDEEP_EMPTY_SCALE,
+          src_zero_point, ideep::IDEEP_EMPTY_ZP, 1.0f, 1.0f, op_attr);
+      get_cache() = LinearPrimitiveCache(cache_key, params);
+      w = w.reorder_if_differ_in(params.pd.weights_desc());
+  });
+  if (get_cache().hit_dynamic(cache_key)) {
+    LinearParams& params = get_cache().get_param();
+    ideep::matmul_forward::compute</*reorder_weight=*/false>(
+        params, x, w, b, y, src_scales, src_zero_point);
   } else {
-    ideep::matmul_forward::compute_v2(x, w, y, 1.0f, 1.0f,
-                                      src_scales, weights_scales, ideep::scale_t(),
-                                      src_zero_point, ideep::zero_point_t(), op_attr);
+    ideep::matmul_forward::compute(x, w, b, y, src_scales, weights_scales,
+                                   ideep::IDEEP_EMPTY_SCALE, src_zero_point,
+                                   ideep::IDEEP_EMPTY_ZP, 1.0f, 1.0f, op_attr);
   }
   auto out_sizes = input.sizes().vec();
   out_sizes.back() = w.get_dim(1);


### PR DESCRIPTION
## Description
This PR improves performance of ONEDNN quantization backend by adding fast paths. For qconv, qconv_transpose and qlinear.
It uses a cache to store reusable data on the first run thus reducing runtime overhead afterwards.

Note: Other quantization backends not affected.

## Validation
**Correctness**:
Covered by UT

**Performance**:
(Time to run each op, in microseconds)
Convolution, 1 core per instance, multiple instances on whole socket
shape | onednn (old) | onednn (new) | Improvement
-- | -- | -- | --
mb1_ic128oc128_id2od2kd3sd1dd0pd1 _ih8oh8kh3sh1dh0ph1_iw10ow10kw3sw1dw0pw1 | 767.038 | 415.238 | 45.86%
mb1_ic256oc128_id4od4kd1sd1dd0pd0 _ih16oh16kh1sh1dh0ph0_iw20ow20kw1sw1dw0pw0 | 194.979 | 167.353 | 14.17%
mb1_ic32oc16_ih112oh112kh1sh1dh0ph0 _iw112ow112kw1sw1dw0pw0 | 104.024 | 78.206 | 24.82%
mb1_ic3oc16_ih224oh112kh3sh2dh0ph1 _iw224ow112kw3sw2dw0pw1 | 104.178 | 81.559 | 21.71%
mb30_ic256oc256_ih14oh14kh3sh1dh0ph1 _iw14ow14kw3sw1dw0pw1 | 12249.438 | 12079.125 | 1.39%
mb56_ic3oc28_ih24oh22kh3sh1dh0ph0 _iw24ow22kw3sw1dw0pw0 | 438.046 | 405.21 | 7.50%
mb100_ic128oc128_ih16oh16kh3sh1dh0ph1 _iw16ow16kw3sw1dw0pw1 | 13893.188 | 13797.609 | 0.69%
g2mb1_ic128oc256_ih28oh28kh3sh1dh0ph1 _iw28ow28kw3sw1dw0pw1 | 499.014 | 475.333 | 4.75%
g32mb1_ic1024oc1024_ih14oh14kh3sh1dh0ph1 _iw14ow14kw3sw1dw0pw1 | 294.877 | 270.568 | 8.24%
g64mb1_ic1024oc2048_ih14oh7kh3sh2dh0ph1 _iw14ow7kw3sw2dw0pw1 | 122.664 | 95.503 | 22.14%
g256mb1_ic256oc256_ih10oh5kh3sh2dh0ph1 _iw10ow5kw3sw2dw0pw1 | 31.343 | 13.522 | 56.86%
g512mb1_ic512oc512_ih19oh10kh3sh2dh0ph1 _iw19ow10kw3sw2dw0pw1 | 54.116 | 34.651 | 35.97%
g1024mb1_ic1024oc1024_ih10oh10kh3sh1dh0ph1 _iw10ow10kw3sw1dw0pw1 | 74.989 | 55.566 | 25.90%

Convolution, 4 cores per instance, multiple instances on whole socket
shape | onednn (old) | onednn (new) | Improvement
-- | -- | -- | --
mb1_ic128oc128_id2od2kd3sd1dd0pd1 _ih8oh8kh3sh1dh0ph1_iw10ow10kw3sw1dw0pw1 | 249.978 | 160.429 | 35.82%
mb1_ic256oc128_id4od4kd1sd1dd0pd0 _ih16oh16kh1sh1dh0ph0_iw20ow20kw1sw1dw0pw0 | 102.726 | 89.555 | 12.82%
mb1_ic32oc16_ih112oh112kh1sh1dh0ph0 _iw112ow112kw1sw1dw0pw0 | 72.993 | 57.622 | 21.06%
mb1_ic3oc16_ih224oh112kh3sh2dh0ph1 _iw224ow112kw3sw2dw0pw1 | 76.607 | 61.847 | 19.27%
mb30_ic256oc256_ih14oh14kh3sh1dh0ph1 _iw14ow14kw3sw1dw0pw1 | 3109.625 | 3006.062 | 3.33%
mb56_ic3oc28_ih24oh22kh3sh1dh0ph0 _iw24ow22kw3sw1dw0pw0 | 191.194 | 175.997 | 7.95%
mb100_ic128oc128_ih16oh16kh3sh1dh0ph1 _iw16ow16kw3sw1dw0pw1 | 3435.625 | 3391.438 | 1.29%
g2mb1_ic128oc256_ih28oh28kh3sh1dh0ph1 _iw28ow28kw3sw1dw0pw1 | 205.209 | 191.931 | 6.47%
g32mb1_ic1024oc1024_ih14oh14kh3sh1dh0ph1 _iw14ow14kw3sw1dw0pw1 | 157.004 | 142.82 | 9.03%
g64mb1_ic1024oc2048_ih14oh7kh3sh2dh0ph1 _iw14ow7kw3sw2dw0pw1 | 83.262 | 71.689 | 13.90%
g256mb1_ic256oc256_ih10oh5kh3sh2dh0ph1 _iw10ow5kw3sw2dw0pw1 | 31.848 | 13.378 | 57.99%
g512mb1_ic512oc512_ih19oh10kh3sh2dh0ph1 _iw19ow10kw3sw2dw0pw1 | 50.216 | 32.663 | 34.95%
g1024mb1_ic1024oc1024_ih10oh10kh3sh1dh0ph1 _iw10ow10kw3sw1dw0pw1 | 67.359 | 49.779 | 26.10%

Transposed Convolution, 1 core per instance, multiple instances on whole socket
shape | onednn (old) | onednn (new) | Improvement
-- | -- | -- | --
mb1_ic512oc256_ih4oh8kh4sh2dh0ph1_iw4ow8kw4sw2dw0pw1 | 537.12 | 505.142 | 5.95%
mb1_ic256oc128_ih8oh16kh4sh2dh0ph1_iw8ow16kw4sw2dw0pw1 | 296.95 | 275.724 | 7.15%
mb1_ic128oc64_ih16oh32kh4sh2dh0ph1_iw16ow32kw4sw2dw0pw1 | 266.933 | 251.175 | 5.90%
mb1_ic64oc3_ih32oh64kh4sh2dh0ph1_iw32ow64kw4sw2dw0pw1 | 141.77 | 126.41 | 10.83%
mb1_ic100oc512_ih1oh4kh4sh1dh0ph0_iw1ow4kw4sw1dw0pw0 | 89.511 | 66.719 | 25.46%

Transposed Convolution, 4 cores per instance, multiple instances on whole socket
shape | onednn (old) | onednn (new) | Improvement
-- | -- | -- | --
mb1_ic512oc256_ih4oh8kh4sh2dh0ph1 _iw4ow8kw4sw2dw0pw1 | 181.594 | 163.77 | 9.82%
mb1_ic256oc128_ih8oh16kh4sh2dh0ph1 _iw8ow16kw4sw2dw0pw1 | 163 | 145.104 | 10.98%
mb1_ic128oc64_ih16oh32kh4sh2dh0ph1 _iw16ow32kw4sw2dw0pw1 | 163.158 | 150.71 | 7.63%
mb1_ic64oc3_ih32oh64kh4sh2dh0ph1 _iw32ow64kw4sw2dw0pw1 | 109.955 | 98.603 | 10.32%
mb1_ic100oc512_ih1oh4kh4sh1dh0ph0 _iw1ow4kw4sw1dw0pw0 | 69.502 | 54.523 | 21.55%

Linear, 1 core per instance, multiple instances on whole socket
shape | onednn (old) | onednn (new) | Improvement
-- | -- | -- | --
mb1ic16oc8 | 54.415 | 35.816 | 34.18%
mb1ic32oc16 | 26.764 | 16.041 | 40.07%
mb1ic64oc32 | 26.735 | 16.007 | 40.13%
mb1ic100oc1 | 26.712 | 16.06 | 39.88%
mb1ic512oc1000 | 65.261 | 51.947 | 20.40%
mb1ic1024oc1000 | 112.603 | 98.175 | 12.81%
mb1ic2048oc1000 | 207.294 | 192.014 | 7.37%
mb1ic4096oc4096 | 3761.094 | 3745.609 | 0.41%
mb1ic9216oc4096 | 8918.672 | 8912.547 | 0.07%
mb20ic2048oc91 | 52.487 | 44.623 | 14.98%
mb30ic512oc37 | 29.257 | 19.642 | 32.86%
mb100ic128oc256 | 39.32 | 29.81 | 24.19%
mb100ic256oc512 | 74.499 | 64.322 | 13.66%
mb100ic512oc1024 | 220.029 | 204.745 | 6.95%
mb100ic1024oc784 | 352.311 | 336.309 | 4.54%

Linear, 4 cores per instance, multiple instances on whole socket
shape | onednn (old) | onednn (new) | Improvement
-- | -- | -- | --
mb1ic16oc8 | 58.252 | 40.433 | 30.59%
mb1ic32oc16 | 23.901 | 15.549 | 34.94%
mb1ic64oc32 | 24.594 | 16.214 | 34.07%
mb1ic100oc1 | 24.011 | 15.4 | 35.86%
mb1ic512oc1000 | 49.781 | 41.988 | 15.65%
mb1ic1024oc1000 | 70.304 | 61.88 | 11.98%
mb1ic2048oc1000 | 92.259 | 85.715 | 7.09%
mb1ic4096oc4096 | 794.937 | 781.137 | 1.74%
mb1ic9216oc4096 | 2081.375 | 2067.75 | 0.65%
mb20ic2048oc91 | 66.929 | 58.338 | 12.84%
mb30ic512oc37 | 35.332 | 26.337 | 25.46%
mb100ic128oc256 | 42.21 | 38.908 | 7.82%
mb100ic256oc512 | 66.49 | 63.967 | 3.79%
mb100ic512oc1024 | 130.828 | 122.673 | 6.23%
mb100ic1024oc784 | 160.987 | 154.765 | 3.86%

Environment:

- PyTorch version: 1.13.0a0+gitcdd625b
- Is debug build: False
- CUDA used to build PyTorch: None
- ROCM used to build PyTorch: N/A

- OS: Ubuntu 20.04.3 LTS (x86_64)
- GCC version: (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
- Clang version: Could not collect
- CMake version: version 3.22.5
- Libc version: glibc-2.31

- Python version: 3.9.12 (main, Jun  1 2022, 11:38:51)  [GCC 7.5.0] (64-bit runtime)
- Python platform: Linux-5.11.0-27-generic-x86_64-with-glibc2.31
- Is CUDA available: False
- CUDA runtime version: No CUDA
- GPU models and configuration: No CUDA
- Nvidia driver version: No CUDA
- cuDNN version: No CUDA
- HIP runtime version: N/A
- MIOpen runtime version: N/A
- Is XNNPACK available: True

Versions of relevant libraries:
- [pip3] intel-extension-for-pytorch==1.13.0+cpu
- [pip3] numpy==1.23.3
- [pip3] pytorch-widedeep==0.3.7
- [pip3] torch==1.13.0a0+git48b423b
- [pip3] torchvision==0.14.0a0+ebb68f3
- [conda] blas                      1.0                         mkl
- [conda] intel-extension-for-pytorch 1.13.0+cpu               pypi_0    pypi
- [conda] mkl                       2021.4.0           h06a4308_640
- [conda] mkl-include               2022.1.0                 pypi_0    pypi
- [conda] mkl-service               2.4.0            py39h7f8727e_0
- [conda] mkl-static                2022.1.0                 pypi_0    pypi
- [conda] mkl_fft                   1.3.1            py39hd3c417c_0
- [conda] mkl_random                1.2.2            py39h51133e4_0
- [conda] numpy                     1.23.3                   pypi_0    pypi
- [conda] numpy-base                1.22.3           py39hf524024_0
- [conda] torch                     1.13.0a0+git48b423b          pypi_0    pypi
- [conda] torchvision               0.14.0a0+ebb68f3          pypi_0    pypi
