### PR TITLE
remove unused pytorch_includes

### DIFF
--- a/defs_hip.bzl
+++ b/defs_hip.bzl
@@ -21,19 +21,6 @@ caffe2_video_image_includes = [
     "video/*",
 ]
 
-pytorch_includes = [
-    "aten/src/ATen/cuda/*",
-    "aten/src/ATen/native/cuda/*",
-    "aten/src/ATen/native/cuda/linalg/*",
-    "aten/src/ATen/native/cudnn/*",
-    "aten/src/ATen/native/nested/cuda/*",
-    "aten/src/ATen/native/sparse/cuda/*",
-    "aten/src/ATen/native/transformers/cuda/*",
-    "aten/src/THC/*",
-    "aten/src/ATen/test/*",
-    "torch/*",
-]
-
 gpu_file_extensions = [".cu", ".c", ".cc", ".cpp"]
 gpu_header_extensions = [".cuh", ".h", ".hpp"]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84481
* #84480
* #84479
* #84478
* #84477
* #84476
* #84475
* __->__ #84474
* #84464
* #84463
* #84462
* #84461

Differential Revision: [D39206790](https://our.internmc.facebook.com/intern/diff/D39206790/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D39206790/)!