### PR TITLE
remove unused gpu_*_extensions from defs_hip.bzl

### DIFF
--- a/defs_hip.bzl
+++ b/defs_hip.bzl
@@ -21,9 +21,6 @@ caffe2_video_image_includes = [
     "video/*",
 ]
 
-gpu_file_extensions = [".cu", ".c", ".cc", ".cpp"]
-gpu_header_extensions = [".cuh", ".h", ".hpp"]
-
 hip_external_deps = [
     ("rocm", None, "amdhip64-lazy"),
     ("rocm", None, "MIOpen-lazy"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84481
* #84480
* #84479
* #84478
* #84477
* #84476
* __->__ #84475
* #84474
* #84464
* #84463
* #84462
* #84461

Differential Revision: [D39206791](https://our.internmc.facebook.com/intern/diff/D39206791/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D39206791/)!