### PR TITLE
move caffe2_*_includes to caffe2/defs_hip.bzl

### DIFF
--- a/caffe2/defs_hip.bzl
+++ b/caffe2/defs_hip.bzl
@@ -1,10 +1,5 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(
-    "//caffe2:defs_hip.bzl",
-    "caffe2_includes",
-    "caffe2_video_image_includes",
-    "get_hip_file_path",
-)
+load("//caffe2:defs_hip.bzl", "get_hip_file_path")
 
 gpu_file_extensions = [".cu", ".c", ".cc", ".cpp"]
 gpu_header_extensions = [".cuh", ".h", ".hpp"]
@@ -34,6 +29,26 @@ def is_caffe2_gpu_file(filepath):
         return True
 
     return False
+
+caffe2_includes = [
+    "operators/**/*",
+    "operators/*",
+    "sgd/*",
+    "transforms/*",
+    # distributed folder is managed by its own TARGETS file
+    # "distributed/*",
+    "queue/*",
+    # "binaries/*",
+    "**/*_test*",
+    "core/*",
+    "db/*",
+    "utils/**/*",
+]
+
+caffe2_video_image_includes = [
+    "image/*",
+    "video/*",
+]
 
 def get_caffe2_hip_srcs(
         include_patterns = caffe2_includes,

--- a/defs_hip.bzl
+++ b/defs_hip.bzl
@@ -1,26 +1,6 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@fbcode//tools/build/buck:rocm_flags.bzl", "get_rocm_arch_args")
 
-caffe2_includes = [
-    "operators/**/*",
-    "operators/*",
-    "sgd/*",
-    "transforms/*",
-    # distributed folder is managed by its own TARGETS file
-    # "distributed/*",
-    "queue/*",
-    # "binaries/*",
-    "**/*_test*",
-    "core/*",
-    "db/*",
-    "utils/**/*",
-]
-
-caffe2_video_image_includes = [
-    "image/*",
-    "video/*",
-]
-
 hip_external_deps = [
     ("rocm", None, "amdhip64-lazy"),
     ("rocm", None, "MIOpen-lazy"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84481
* #84480
* #84479
* #84478
* #84477
* __->__ #84476
* #84475
* #84474
* #84464
* #84463
* #84462
* #84461

These are only used in that file.

Differential Revision: [D39206788](https://our.internmc.facebook.com/intern/diff/D39206788/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D39206788/)!