### PR TITLE
length of a collection is always greater or equal to zero so the logi…

### DIFF
--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -46,7 +46,10 @@ class SamplerIterDataPipe(IterDataPipe[T_co]):
 
     def __len__(self) -> int:
         # Dataset has been tested as `Sized`
-        if isinstance(self.sampler, Sized) and len(self.sampler) >= 0:
+        # OpenRefactory Warning: Collection length comparison should be meaningful.
+        # The length of a collection is always greater than or equal to zero.
+        # So testing that a length is greater than or equal to zero is always true.
+        if isinstance(self.sampler, Sized) and len(self.sampler) > 0:
             return len(self.sampler)
         raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))
 


### PR DESCRIPTION
We have detected this issue in the `master` branch of `pytorch` project on the version with commit has `14093b`. This issue is an instance of an inappropriate logic.

**Fixes for inappropriate logic:**
In file: `torch/utils/data/datapipes/iter/combinatorics.py`, the comparison of Collection length creates a logical short circuit. Out intelligent code repair system **iCR** suggested that the Collection length comparison should be done without creating a logical short circuit.

This issue was detected by our **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. You will get more info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)