### PR TITLE
fix: strides were incorrect in parts of `test_out`

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -674,6 +674,16 @@ class TestCommon(TestCase):
                 # assumes (see above) that out is an iterable of tensors
                 return tuple(map(fn, out))
 
+            # A wrapper around map that works with single tensors and always
+            #   instantiates the map. Used below to create an empty tensor or list
+            #   and iterable tensor outputs.
+            def _apply_empty_like(out):
+                if isinstance(out, torch.Tensor):
+                    return torch.empty_like(out)
+
+                # assumes (see above) that out is an iterable of tensors
+                return tuple(map(torch.empty_like, out))
+
             # Extracts strides from a tensor or iterable of tensors into a tuple
             def _extract_strides(out):
                 if isinstance(out, torch.Tensor):
@@ -696,7 +706,7 @@ class TestCommon(TestCase):
                 return tuple(map(lambda t: t.data_ptr(), out))
 
             def _compare_out(transform, *, compare_strides_and_data_ptrs=True):
-                out = _apply_out_transform(transform, expected)
+                out = _apply_empty_like(expected)
                 original_strides = _extract_strides(out)
                 original_ptrs = _extract_data_ptrs(out)
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8618,9 +8618,7 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_linalg_cholesky_inverse,
            gradcheck_wrapper=gradcheck_wrapper_triangular_input_real_positive_diagonal,
            decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
-           skips=(
-               # Strides are not the same! Original strides were ((4, 2, 1),) and strides are now ((4, 1, 2),)
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),)),
+           skips=()),
     OpInfo('cholesky_solve',
            op=torch.cholesky_solve,
            dtypes=floating_and_complex_types(),
@@ -9439,8 +9437,6 @@ op_db: List[OpInfo] = [
            skips=(
                # FIXME: geqrf can't forward with complex inputs that require grad
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes'),
-               # Strides are not the same!
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),
            )),
     BinaryUfuncInfo('gt',
                     ref=np.greater,
@@ -9827,8 +9823,6 @@ op_db: List[OpInfo] = [
                             'TestCommon', 'test_noncontiguous_samples',
                             device_type='cpu'), ],
            skips=(
-               # Strides are not the same!
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),
                # https://github.com/pytorch/pytorch/issues/67470
                DecorateInfo(unittest.skip("67470!"),
                             'TestCommon', 'test_noncontiguous_samples',
@@ -10435,10 +10429,7 @@ op_db: List[OpInfo] = [
            gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
            error_inputs_func=error_inputs_avg_pool3d,
            sample_inputs_func=sample_inputs_avgpool3d,
-           skips=(
-               # AssertionError: Tensor-likes are not close!
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='cpu'),
-           )),
+           skips=()),
     OpInfo(
         "nn.functional.binary_cross_entropy_with_logits",
         aten_name="binary_cross_entropy_with_logits",
@@ -11026,9 +11017,7 @@ op_db: List[OpInfo] = [
            dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
            error_inputs_func=error_inputs_avg_pool2d,
            sample_inputs_func=sample_inputs_avgpool2d,
-           skips=(
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='cuda'),
-           )),
+           skips=()),
     OpInfo('nn.functional.fractional_max_pool2d',
            supports_autograd=True,
            supports_out=False,
@@ -11249,8 +11238,6 @@ op_db: List[OpInfo] = [
            check_batched_forward_grad=False,
            supports_expanded_weight=True,
            decorators=(
-               # Strides are not the same!
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),
                DecorateInfo(toleranceOverride({torch.float16: tol(atol=1e-02, rtol=1e-02)}),
                             'TestCudaFuserOpInfo', 'test_nvfuser_correctness'),
            )),
@@ -12048,8 +12035,6 @@ op_db: List[OpInfo] = [
            skips=(
                # ormqr does not support forward when complex inputs require grad
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes'),
-               # Strides are not the same!
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),
            )),
     OpInfo('permute',
            ref=np.transpose,
@@ -12724,8 +12709,6 @@ op_db: List[OpInfo] = [
            gradcheck_wrapper=lambda *args, **kwargs: gradcheck_wrapper_triangular_input(*args, idx=1, **kwargs),
            decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
            skips=(
-               # AssertionError: Scalars are not equal!
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),
                # Gradcheck fails
                DecorateInfo(unittest.expectedFailure, 'TestGradients', 'test_fn_fwgrad_bwgrad',
                             dtypes=floating_and_complex_types()),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1396,10 +1396,6 @@ op_db: List[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         skips=(
-            # AssertionError: Scalars are not equal!
-            DecorateInfo(
-                unittest.expectedFailure, "TestCommon", "test_out", device_type="cpu"
-            ),
             DecorateInfo(
                 unittest.skip("Skipped!"),
                 "TestCommon",


### PR DESCRIPTION
This PR adds a small fix to `test_ops.py:TestCommon.test_out` and then removes any unittest.expectedFailure from the opinfos related to this issue.

The replaced code `_apply_out_transform(transform, expected)` was applying the op to `expected` which was created by applying the op to `sample.input`, so the op was being applied twice. The fix is to create a tensor that is empty like `expected`.

Note: further down in the function `_apply_out_transform` is again used on `expected` which i think is a code smell but using `_apply_empty_like ` in that case caused other errors 🤷 .


cc @amjames 
