### PR TITLE
[aarch64] Fix _mm_pause() on aarch64

### DIFF
--- a/aten/src/ATen/native/cpu/AtomicAddFloat.h
+++ b/aten/src/ATen/native/cpu/AtomicAddFloat.h
@@ -3,17 +3,11 @@
 
 #if (defined(__x86_64__) || defined(__i386__) || defined(__aarch64__))
 #include <ATen/native/cpu/Intrinsics.h>
-#endif
-
-#include <atomic>
-
-#ifdef __aarch64__
-static __inline void _mm_pause() {
-  __asm__ __volatile__("yield;" : : : "memory");
-}
 #else
 #define _mm_pause()
 #endif
+
+#include <atomic>
 
 static inline void cpu_atomic_add_float(float* dst, float fvalue)
 {
@@ -30,7 +24,11 @@ static inline void cpu_atomic_add_float(float* dst, float fvalue)
 
   unsigned* old_intV = (unsigned*)(&old_value.intV);
   while (!std::atomic_compare_exchange_strong(dst_intV, old_intV, new_value.intV)) {
+#ifdef __aarch64__
+    __asm__ __volatile__("yield;" : : : "memory");
+#else
     _mm_pause();
+#endif
     old_value.floatV = *dst;
     new_value.floatV = old_value.floatV + fvalue;
   }


### PR DESCRIPTION
Summary:
It's possible if you're using simde that _mm_pause is already
defined, so intsead use the asm for yield

Test Plan: CI

Differential Revision: D39225258

