### PR TITLE
[WIP] [RFC] Naive nested tensor support in proxy tensor [Needs tests]

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1881,7 +1881,6 @@ static PyObject* THPVariable_NewWithVar(
       " but the raw Tensor object is already associated to a python object ",
       "of type ",
       mb_obj.value()->ob_type->tp_name);
-  
 
   // Make sure that the reinterpret into a THPVariable* will be valid
   TORCH_CHECK(

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1881,6 +1881,7 @@ static PyObject* THPVariable_NewWithVar(
       " but the raw Tensor object is already associated to a python object ",
       "of type ",
       mb_obj.value()->ob_type->tp_name);
+  
 
   // Make sure that the reinterpret into a THPVariable* will be valid
   TORCH_CHECK(


### PR DESCRIPTION
```
a, b = torch.tensor([0.5, 0.5]), torch.tensor([0.33, 0.33])

def foo(x, y):
    nt = torch.nested_tensor([x, y])
    return nt * nt
z = make_fx(foo)(a, b)
```
Before:
```
RuntimeError: Internal error: NestedTensorImpl doesn't support sizes. Please file an issue on https://github.com/pytorch/nestedtensor
```
After:

```
def forward(self, x_1, y_1):
    nested_tensor = torch.ops.aten.nested_tensor.default([x_1, y_1]);  x_1 = y_1 = None
    getitem = nested_tensor[0]
    getitem_1 = nested_tensor[1];  nested_tensor = None
    _tensor_constant0 = self._tensor_constant0
    _tensor_constant0_1 = self._tensor_constant0
    mul = torch.ops.aten.mul.Tensor(_tensor_constant0, _tensor_constant0_1);  _tensor_constant0 = _tensor_constant0_1 = None
    getitem_2 = mul[0]
    getitem_3 = mul[1];  mul = None
    _tensor_constant1 = self._tensor_constant1
    return _tensor_constant1
```

cc @ezyang @SherlockNoMad @soumith @EikanWang @jgong5 @wenzhe-nrv