### PR TITLE
Don't convert INT64_MAX start index into zero

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2079,10 +2079,6 @@ Tensor slice(
   // TODO: support negative strides
   TORCH_CHECK(step > 0, "slice step must be positive");
 
-  // INT64_MAX stands for default value.
-  if (start_val == INT64_MAX) {
-    start_val = 0;
-  }
   if (start_val < 0) {
     start_val += sizes[dim];
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84509

I... don't understand why we did it this way in the first place?
Source: https://github.com/pytorch/pytorch/pull/48719/files#r962087365

Signed-off-by: Edward Z. Yang <ezyang@fb.com>