### PR TITLE
Eliminate a copy of the DeviceOption struct.

### DIFF
--- a/caffe2/core/blob_serialization.cc
+++ b/caffe2/core/blob_serialization.cc
@@ -821,8 +821,7 @@ static at::TensorOptions TensorOptionsFromProto(
 
 std::unique_ptr<BaseContext> ContextFromProto(
     const TensorProto& tensor_proto) {
-  auto device = OptionToDevice(tensor_proto.device_detail());
-  return CreateContext(device);
+  return CreateContext(OptionToDevice(tensor_proto.device_detail()));
 }
 
 // === Local helper functions ===


### PR DESCRIPTION
Summary: Eliminate a copy of the DeviceOption struct. This code pattern was detected by an automatic performance tool.

Test Plan: Rely on unit tests.

Differential Revision: D39243510

