### PR TITLE
Dispatch for xpu in adaptive_avg_pooling

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -106,7 +106,7 @@ namespace {
       return at::mkldnn_adaptive_avg_pool2d(input, output_size);
     }
 
-    if (!input.is_quantized() && output_size[0] == 1 && output_size[1] == 1) {
+    if (!input.is_quantized() && output_size[0] == 1 && output_size[1] == 1 && !input.is_xpu()) {
       // in this case, adaptive pooling is just computing mean over hw
       // dimensions, which can be done more efficiently
       #if defined(C10_MOBILE) && defined(USE_XNNPACK)

--- a/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
@@ -306,7 +306,7 @@ Tensor adaptive_avg_pool3d(Tensor const& input, IntArrayRef output_size) {
         "adaptive_avg_pool2d: elements of output_size must be greater than or equal to 0 ",
         "but received {", output_size[0], ", ", output_size[1], ",", output_size[2], "}");
 
-  if (output_size[0] == 1 && output_size[1] == 1 && output_size[2] == 1) {
+  if (output_size[0] == 1 && output_size[1] == 1 && output_size[2] == 1 && !input.is_xpu()) {
     // in this case, adaptive pooling is just computing mean over hw
     // dimensions, which can be done more efficiently
     Tensor out = input.mean({-1, -2, -3}, /* keepdim = */ true);


### PR DESCRIPTION
Motivation:

- See native_functions.yaml, operators adaptive_avg_pool2d/adaptive_avg_pool3d are not recommended to register for backends.

- When adaptive_avg_pool2d/adaptive_avg_pool3d have a input of xpu tensor, they can't step into xpu implementation.

Solution:

- Dispatch to _adaptive_avg_pool2d/_adaptive_avg_pool3d for xpu backend in adaptive_avg_pool2d/adaptive_avg_pool3d implementation.