### PR TITLE
Reenable TestCppExtensionJIT on M1

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -15,7 +15,7 @@ import torch
 import torch.backends.cudnn
 import torch.utils.cpp_extension
 from torch.utils.cpp_extension import CUDA_HOME, ROCM_HOME
-from torch.testing._internal.common_utils import gradcheck, skipIfSlowGradcheckEnv, IS_ARM64
+from torch.testing._internal.common_utils import gradcheck, skipIfSlowGradcheckEnv
 
 
 TEST_CUDA = torch.cuda.is_available() and CUDA_HOME is not None
@@ -39,7 +39,6 @@ def remove_build_path():
 
 # There's only one test that runs gracheck, run slow mode manually
 @skipIfSlowGradcheckEnv
-@unittest.skipIf(IS_ARM64, "Does not work on arm")
 class TestCppExtensionJIT(common.TestCase):
     """Tests just-in-time cpp extensions.
     Don't confuse this with the PyTorch JIT (aka TorchScript).


### PR DESCRIPTION
Works fine locally, let's see if it'll pass CI
