### PR TITLE
[PyTorch] Improving efficiency of `torch.square` by calling `mul` instead of `pow`

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -611,9 +611,9 @@ Tensor& arctanh_out(const Tensor& self, Tensor& result) { return at::atanh_out(r
 Tensor arctanh(const Tensor& self) { return self.atanh(); }
 Tensor& arctanh_(Tensor& self) { return self.atanh_(); }
 
-Tensor& square_out(const Tensor& self, Tensor& result) { return at::pow_out(result, self, 2); }
-Tensor square(const Tensor& self) { return at::pow(self, 2); }
-Tensor& square_(Tensor& self) { return self.pow_(2); }
+Tensor& square_out(const Tensor& self, Tensor& result) { return at::mul_out(result, self, self); }
+Tensor square(const Tensor& self) { return at::mul(self, self); }
+Tensor& square_(Tensor& self) { return self.mul_(self); }
 
 Tensor& logit_out(const Tensor& self,
     c10::optional<double> eps,


### PR DESCRIPTION
Summary:
`x.square()` is significantly (~2x) slower than `x * x`. According to the profiling included below, this is due to relying on `pow`, despite there being a [special case for the power of two](https://github.com/pytorch/pytorch/blob/ce1b727e774c75f8e31b28ff5915851385c70dcf/aten/src/ATen/native/cpu/PowKernel.cpp#L52). This PR changes square to call `mul` instead of `pow` to close the performance gap.

For detailed benchmark results, see the following.
```
************************************************************************************
size =  ()
x.square()
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
                 Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
         aten::square        20.93%     448.000us       100.00%       2.140ms       2.090us          1024
            aten::pow        71.59%       1.532ms        79.07%       1.692ms       1.652us          1024
    aten::result_type         3.74%      80.000us         3.74%      80.000us       0.078us          1024
             aten::to         3.74%      80.000us         3.74%      80.000us       0.078us          1024
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 2.140ms

x * x
-------------  ------------  ------------  ------------  ------------  ------------  ------------
         Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
-------------  ------------  ------------  ------------  ------------  ------------  ------------
    aten::mul       100.00%     354.000us       100.00%     354.000us       0.437us           810
-------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 354.000us

************************************************************************************
size =  1
x.square()
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
                 Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
         aten::square        20.10%     160.000us       100.00%     796.000us       0.777us          1024
            aten::pow        71.11%     566.000us        79.90%     636.000us       0.621us          1024
    aten::result_type         4.15%      33.000us         4.15%      33.000us       0.032us          1024
             aten::to         4.65%      37.000us         4.65%      37.000us       0.036us          1024
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 796.000us

x * x
-------------  ------------  ------------  ------------  ------------  ------------  ------------
         Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
-------------  ------------  ------------  ------------  ------------  ------------  ------------
    aten::mul       100.00%     388.000us       100.00%     388.000us       0.468us           829
-------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 388.000us

************************************************************************************
size =  10
x.square()
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
                 Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
         aten::square        21.53%     174.000us       100.00%     808.000us       0.789us          1024
            aten::pow        71.29%     576.000us        78.47%     634.000us       0.619us          1024
    aten::result_type         4.21%      34.000us         4.21%      34.000us       0.033us          1024
             aten::to         2.97%      24.000us         2.97%      24.000us       0.023us          1024
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 808.000us

x * x
-------------  ------------  ------------  ------------  ------------  ------------  ------------
         Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
-------------  ------------  ------------  ------------  ------------  ------------  ------------
    aten::mul       100.00%     385.000us       100.00%     385.000us       0.461us           835
-------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 385.000us

************************************************************************************
size =  1000
x.square()
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
                 Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
         aten::square        19.60%     157.000us       100.00%     801.000us       0.782us          1024
            aten::pow        72.28%     579.000us        80.40%     644.000us       0.629us          1024
    aten::result_type         4.24%      34.000us         4.24%      34.000us       0.033us          1024
             aten::to         3.87%      31.000us         3.87%      31.000us       0.030us          1024
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 801.000us

x * x
-------------  ------------  ------------  ------------  ------------  ------------  ------------
         Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
-------------  ------------  ------------  ------------  ------------  ------------  ------------
    aten::mul       100.00%     415.000us       100.00%     415.000us       0.499us           832
-------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 415.000us

************************************************************************************
size =  1000000
x.square()
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
                 Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
         aten::square         0.39%     543.000us       100.00%     139.923ms     136.644us          1024
            aten::pow        99.51%     139.235ms        99.61%     139.380ms     136.113us          1024
    aten::result_type         0.06%      88.000us         0.06%      88.000us       0.086us          1024
             aten::to         0.04%      57.000us         0.04%      57.000us       0.056us          1024
---------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 139.923ms

x * x
-------------  ------------  ------------  ------------  ------------  ------------  ------------
         Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
-------------  ------------  ------------  ------------  ------------  ------------  ------------
    aten::mul       100.00%     132.887ms       100.00%     132.887ms     129.772us          1024
-------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 132.887ms
```

Test Plan:
buck build //caffe2:ATen-cpu
buck2 test //caffe2/test:torch

Differential Revision: D39225491

