### PR TITLE
Add alias info to torch._C

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -629,6 +629,13 @@ class Graph:
     ...
 
 
+# Defined in torch/aten/src/ATen/core/alias_info.h
+class AliasInfo:
+    is_write: _bool
+    before_set: List[str]
+    after_set: List[str]
+
+
 # Defined in torch/aten/src/ATen/core/function_schema.h
 class Argument:
     name: str
@@ -637,6 +644,7 @@ class Argument:
     def has_default_value(self) -> _bool: ...
     kwarg_only : _bool
     is_out: _bool
+    alias_info: Optional[AliasInfo]
     ...
 class FunctionSchema:
     arguments: List[Argument]

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -632,8 +632,8 @@ class Graph:
 # Defined in torch/aten/src/ATen/core/alias_info.h
 class AliasInfo:
     is_write: _bool
-    before_set: List[str]
-    after_set: List[str]
+    before_set: Set[str]
+    after_set: Set[str]
 
 
 # Defined in torch/aten/src/ATen/core/function_schema.h


### PR DESCRIPTION
This adds the `AliasInfo` class to torch._C, as defined in https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/python/init.cpp#L1943. This will fix MYPY errors for missing `Argument` attributes.