### PR TITLE
[C++ API] Added missing antialiasing path in interpolation C++ api

### DIFF
--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -2252,6 +2252,20 @@ TEST_F(FunctionalTest, Interpolate) {
     auto output = F::interpolate(tensor, options);
     ASSERT_TRUE(output.allclose(expected));
   }
+  {
+    auto tensor = torch::rand({2, 3, 32, 32});
+    std::vector<int64_t> osize = {8, 10};
+    auto expected = at::native::_upsample_bicubic2d_aa(
+        tensor, osize, false, torch::nullopt);
+
+    auto options = F::InterpolateFuncOptions()
+                       .size(osize)
+                       .mode(torch::kBicubic)
+                       .align_corners(false)
+                       .antialias(true);
+    auto output = F::interpolate(tensor, options);
+    ASSERT_TRUE(output.allclose(expected));
+  }
 }
 
 TEST_F(FunctionalTest, Pad1) {


### PR DESCRIPTION
Description:

Following https://github.com/pytorch/pytorch/pull/69318#issuecomment-1238433540 adding missing bicubic path for anti-alias flag to C++ frontend.

- https://github.com/pytorch/pytorch/pull/70930

- added tests in pytorch/test/cpp/api/functional.cpp

