### PR TITLE
[BE] Delete `Check for new workflow" check

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -60,13 +60,6 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
-      - name: Check for new workflows
-        run: |
-          if [ ! -f "./.github/actions/setup-linux/action.yml" ]; then
-            echo "::error::Your PR is based on a version of master that is too old for our CI to work. Please rebase your PR on latest master and resubmit."
-            exit 1
-          fi
-
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
 


### PR DESCRIPTION
This check was introduced back in Mar, and all PRs for the last 60+ days should pass this check.
