### PR TITLE
[FSDP] Ensure that all ranks use the same order to iterate through optimizer states

### DIFF
--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -28,6 +28,12 @@ from torch.distributed.fsdp._shard_utils import (
 from torch.distributed.fsdp.flat_param import FlatParameter, FlatParamHandle
 
 
+def sorted_items(dictionary: Dict[str, Any]) -> Iterator[Tuple[str, Any]]:
+    keys = sorted(dictionary.keys())
+    for k in keys:
+        yield k, dictionary[k]
+
+
 class _ConsolidatedOptimState:
     """
     This holds the consolidated optimizer state on the target rank. Positive-
@@ -165,7 +171,7 @@ def _communicate_optim_state(
     group = fsdp_module.process_group
 
     tensor_buffer = None  # initialize lazily in case it is not needed
-    for state_name, value in flat_param_state.items():
+    for state_name, value in sorted_items(flat_param_state):
         # Positive-dimension tensor state: communicate across ranks
         if torch.is_tensor(value) and value.dim() > 0:
             # If the parameter is not sharded (e.g. world size of 1), then
@@ -228,7 +234,7 @@ def _unflatten_communicated_optim_state(
     for _ in range(num_unflat_params):
         unflat_state_param = {}
         # Add positive-dimension tensor state: unflatten with views
-        for state_name, flat_tensor in tensor_state.items():
+        for state_name, flat_tensor in sorted_items(tensor_state):
             views_generated = state_name in flat_param_views
             if not views_generated:
                 views = FlatParamHandle._get_unflat_views(flat_param, flat_tensor)
@@ -247,10 +253,10 @@ def _unflatten_communicated_optim_state(
             unflat_state_param[state_name] = optim_state
 
         # Add zero-dimension tensor state: take the target rank's value
-        for state_name, zero_dim_tensor in zero_dim_tensor_state.items():
+        for state_name, zero_dim_tensor in sorted_items(zero_dim_tensor_state):
             unflat_state_param[state_name] = zero_dim_tensor
         # Add non-tensor state: take the target rank's value
-        for state_name, non_tensor in non_tensor_state.items():
+        for state_name, non_tensor in sorted_items(non_tensor_state):
             unflat_state_param[state_name] = non_tensor
         unflat_param_state.append(unflat_state_param)
     return unflat_param_state
@@ -643,9 +649,9 @@ def _process_pos_dim_tensor_state(
     """
     flat_osd = flat_optim_state_dict  # alias
     no_tensor_osd: Dict[str, Any] = {"state": {}}
-    for key, param_state in flat_osd["state"].items():
+    for key, param_state in sorted_items(flat_osd["state"]):
         no_tensor_osd["state"][key] = {}
-        for state_name, value in param_state.items():
+        for state_name, value in sorted_items(param_state):
             is_pos_dim_tensor_state = torch.is_tensor(value) and value.dim() > 0
             if not is_pos_dim_tensor_state:
                 no_tensor_osd["state"][key][state_name] = value
@@ -722,8 +728,8 @@ def _broadcast_pos_dim_tensor_states(
     ), "Expects rank 0 to pass in the flattened optimizer state dict"
     no_tensor_osd = processed_optim_state_dict  # alias
     flat_osd = flat_optim_state_dict  # alias
-    for key, param_state in no_tensor_osd["state"].items():
-        for state_name, value in param_state.items():
+    for key, param_state in sorted_items(no_tensor_osd["state"]):
+        for state_name, value in sorted_items(param_state):
             is_pos_dim_tensor_state = isinstance(value, _PosDimTensorInfo)
             if not is_pos_dim_tensor_state:
                 continue
@@ -891,7 +897,7 @@ def _rekey_sharded_optim_state_dict(
 
     sharded_osd_state = sharded_osd["state"]
     rekeyed_osd_state = {}
-    for key, param_state in sharded_osd_state.items():
+    for key, param_state in sorted_items(sharded_osd_state):
         flat_param_id = unflat_param_names_to_flat_param_id[key.unflat_param_names]
         rekeyed_osd_state[flat_param_id] = param_state
 
@@ -1039,7 +1045,7 @@ def _get_unflat_to_flat_param_ids(
     """
     # Construct as a dict and then convert to list
     unflat_to_flat_param_ids = {}
-    for flat_param_id, unflat_param_ids in flat_to_unflat_param_ids.items():
+    for flat_param_id, unflat_param_ids in sorted_items(flat_to_unflat_param_ids):
         for unflat_param_id in unflat_param_ids:
             assert unflat_param_id not in unflat_to_flat_param_ids, (
                 "`flat_to_unflat_param_ids` has the unflattened parameter "
@@ -1206,7 +1212,7 @@ def _optim_state_dict(
             assert len(r0_optim_state_key.unflat_param_names) == 1
             unflat_param_name = r0_optim_state_key.unflat_param_names[0]
             fsdp_osd_state[unflat_param_name] = copy.copy(osd_state[flat_param_id])
-            for state_name, value in fsdp_osd_state[unflat_param_name].items():
+            for state_name, value in sorted_items(fsdp_osd_state[unflat_param_name]):
                 if torch.is_tensor(value):
                     fsdp_osd_state[unflat_param_name][state_name] = value.cpu()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84651

**Background:**
Optimizer states are of the type `Dict[int, Dict[str, torch.Tensor]]` and the order of `dict.items()`  is the creation order of keys. Without checkpoint (state_dict/load_state_dict), the creation order of keys depends on the implementation of the optimizer (e.g., Adam seems to creates `exp_avg` then `exp_avg_sq`). However, when loading states from a checkpoint, since the optimizer state are lazily initialized, the order depends on the user code (reading state_dict from IO). See the following example:

```
optimizer_state_dict = USER_CODE_TO_READ_STATE_FROM_IO()
optimizer.load_state_dict(optimizer_state_dict)
```
The key order of `optimizer_state_dict` depends on `USER_CODE_TO_READ_STATE_FROM_IO` and there is no guarantee that the order is the same across ranks.

**What Can Go Wrong?**
After the first checkpoint load, the key order of optimizer may not be the same on different ranks. When users try to save another checkpoint, user will call `_unflatten_optim_state()` to save the optimizer states. Inside `_unflatten_optim_state()`, `dict.itmes()` will be called to iterate all the local optimizer state and `all_gather()` will be used to gather the local states. Since the order may be different across ranks, the gathered states are not correct.

We have seen some models get NaN loss after the second checkpoint load because of this issue.

**What This PR Does?**
This PR implements a `sorted_items()` to return sorted (key, value) pairs. We can do this because the key is either an integer or a string.

Differential Revision: [D39315184](https://our.internmc.facebook.com/intern/diff/D39315184/)