### PR TITLE
Reland: [Profiler] Unify global and thread local profiler lookup. (#83894)

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -15,6 +15,7 @@
 #include <torch/csrc/profiler/itt_observer.h>
 #include <torch/csrc/profiler/kineto_shim.h>
 #include <torch/csrc/profiler/nvtx_observer.h>
+#include <torch/csrc/profiler/orchestration/observer.h>
 #include <torch/csrc/profiler/util.h>
 
 #include <ATen/Context.h>
@@ -60,7 +61,7 @@ using torch::profiler::impl::ActiveProfilerType;
 using torch::profiler::impl::dtypesToStr;
 using torch::profiler::impl::EventType;
 using torch::profiler::impl::ExtraFields;
-using torch::profiler::impl::ProfilerThreadLocalStateBase;
+using torch::profiler::impl::ProfilerStateBase;
 using torch::profiler::impl::PyExtraFieldsBase;
 using torch::profiler::impl::Result;
 using torch::profiler::impl::shapesToStr;
@@ -200,20 +201,21 @@ static inline uint64_t getForwardThreadKey(uint64_t tid, uint64_t seqNr) {
   return (((tid) << 48) | ((seqNr) & (((uint64_t)1 << 48) - 1)));
 }
 
-struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
+struct KinetoThreadLocalState : public ProfilerStateBase {
   explicit KinetoThreadLocalState(
       const ProfilerConfig& config,
       std::set<torch::profiler::impl::ActivityType> activities)
-      : ProfilerThreadLocalStateBase(config),
+      : ProfilerStateBase(config),
         start_time_(getTimeUs()),
         record_queue_(config, activities) {}
   ~KinetoThreadLocalState() override = default;
 
-  static KinetoThreadLocalState* getTLS() {
-    auto tls = ProfilerThreadLocalStateBase::getTLS();
+  static KinetoThreadLocalState* get(bool global) {
+    auto* state = ProfilerStateBase::get(/*global=*/global);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-        tls == nullptr || tls->profilerType() == ActiveProfilerType::KINETO);
-    return static_cast<KinetoThreadLocalState*>(tls);
+        state == nullptr ||
+        state->profilerType() == ActiveProfilerType::KINETO);
+    return static_cast<KinetoThreadLocalState*>(state);
   }
 
   ActiveProfilerType profilerType() override {
@@ -402,20 +404,10 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
   post_process_t event_post_process_cb_;
 };
 
-using KinetoTLSGlobalStateManager =
-    torch::profiler::impl::GlobalStateManager<KinetoThreadLocalState>;
-
-template <bool use_global>
-static KinetoThreadLocalState* getStatePtr() {
-  return c10::guts::if_constexpr<use_global>(
-      [] { return KinetoTLSGlobalStateManager::get(); },
-      [] { return KinetoThreadLocalState::getTLS(); });
-}
-
 template <bool use_global_state_ptr = false>
 std::unique_ptr<at::ObserverContext> onFunctionEnter(
     const at::RecordFunction& fn) {
-  auto state_ptr = getStatePtr<use_global_state_ptr>();
+  auto state_ptr = KinetoThreadLocalState::get(use_global_state_ptr);
   if (!state_ptr) {
     return nullptr;
   }
@@ -427,7 +419,7 @@ template <bool use_global_state_ptr = false>
 void onFunctionExit(
     const at::RecordFunction& fn,
     at::ObserverContext* ctx_ptr) {
-  auto state_ptr = getStatePtr<use_global_state_ptr>();
+  auto state_ptr = KinetoThreadLocalState::get(use_global_state_ptr);
   if (!state_ptr) {
     return;
   }
@@ -459,7 +451,8 @@ void onFunctionExit(
 
 template <bool use_global_callback = false>
 void pushProfilingCallbacks(const std::unordered_set<at::RecordScope>& scopes) {
-  auto registration_state_ptr = getStatePtr<use_global_callback>();
+  auto registration_state_ptr =
+      KinetoThreadLocalState::get(use_global_callback);
   TORCH_INTERNAL_ASSERT(registration_state_ptr, "Expected profiler state set");
   auto recordFunctionCallback =
       at::RecordFunctionCallback(
@@ -484,10 +477,10 @@ void reportBackendEventToActiveKinetoProfiler(
     const std::string& event_name,
     const std::string& backend_name) {
   TORCH_INTERNAL_ASSERT(
-      KinetoTLSGlobalStateManager::get() == nullptr,
+      KinetoThreadLocalState::get(/*global=*/true) == nullptr,
       "On-demand profiling does not support post processing callback");
 
-  auto state_ptr = KinetoThreadLocalState::getTLS();
+  auto state_ptr = KinetoThreadLocalState::get(/*global=*/false);
   if (!state_ptr) {
     return;
   }
@@ -535,11 +528,11 @@ void enableProfilerWithEventPostProcess(
       config.state != ProfilerState::ITT,
       "ITT does not support post processing callback.");
   TORCH_INTERNAL_ASSERT(
-      KinetoTLSGlobalStateManager::get() == nullptr,
+      KinetoThreadLocalState::get(/*global=*/true) == nullptr,
       "On-demand profiling does not support post processing callback");
 
   enableProfiler(config, activities, scopes);
-  auto state_ptr = KinetoThreadLocalState::getTLS();
+  auto state_ptr = KinetoThreadLocalState::get(config.global());
   state_ptr->setEventPostProcessingCallback(std::move(cb));
 }
 
@@ -547,7 +540,12 @@ void enableProfiler(
     const torch::profiler::impl::ProfilerConfig& config,
     const std::set<torch::profiler::impl::ActivityType>& activities,
     const std::unordered_set<at::RecordScope>& scopes) {
-  TORCH_CHECK(!profilerEnabled(), "Profiler is already enabled on this thread");
+  const auto has_cpu = activities.count(ActivityType::CPU);
+  TORCH_CHECK(
+      KinetoThreadLocalState::get(/*global=*/config.global()) == nullptr,
+      "Profiler is already enabled",
+      (config.global() ? "." : " on this thread."));
+
   if (config.state == ProfilerState::NVTX) {
     torch::profiler::impl::pushNVTXCallbacks(config, scopes);
     return;
@@ -559,34 +557,26 @@ void enableProfiler(
   TORCH_CHECK(
       config.state == ProfilerState::KINETO ||
       config.state == ProfilerState::KINETO_GPU_FALLBACK || config.global());
-  TORCH_CHECK(
-      !activities.empty(), "No activities specified for Kineto profiler");
+  TORCH_CHECK(!activities.empty(), "No activities specified.");
+  TORCH_INTERNAL_ASSERT(
+      has_cpu || !config.global(),
+      "Ondemand profiling must enable CPU tracing");
 
-  if (config.global()) {
-    KinetoTLSGlobalStateManager::init(config, activities);
+  KinetoThreadLocalState::push(
+      std::make_shared<KinetoThreadLocalState>(config, activities));
 
-    TORCH_INTERNAL_ASSERT(
-        activities.count(ActivityType::CPU),
-        "Ondemand profiling must enable CPU tracing");
-    pushProfilingCallbacks<true>(scopes);
-  } else {
-    auto state = std::make_shared<KinetoThreadLocalState>(config, activities);
-    c10::ThreadLocalDebugInfo::_push(c10::DebugInfoKind::PROFILER_STATE, state);
+  if (has_cpu) {
+    config.global() ? pushProfilingCallbacks</*global=*/true>(scopes)
+                    : pushProfilingCallbacks</*global=*/false>(scopes);
+  }
 
-    if (activities.count(ActivityType::CPU)) {
-      pushProfilingCallbacks<false>(scopes);
-    }
+  if (!config.global()) {
     torch::profiler::impl::kineto::startTrace();
   }
 }
 
 std::unique_ptr<ProfilerResult> disableProfiler() {
-  auto state_ptr = std::static_pointer_cast<
-      torch::profiler::impl::ProfilerThreadLocalStateBase>(
-      KinetoTLSGlobalStateManager::get() == nullptr
-          ? c10::ThreadLocalDebugInfo::_pop(c10::DebugInfoKind::PROFILER_STATE)
-          : KinetoTLSGlobalStateManager::pop());
-
+  auto state_ptr = ProfilerStateBase::pop();
   const auto& config = state_ptr->config();
   TORCH_CHECK(
       state_ptr &&
@@ -600,7 +590,7 @@ std::unique_ptr<ProfilerResult> disableProfiler() {
   state_ptr->removeCallback();
 
   // Traces are converged via libkineto automatically for ondemand flow
-  if (state_ptr->config().state == ProfilerState::KINETO_ONDEMAND) {
+  if (state_ptr->config().global()) {
     (void)std::static_pointer_cast<KinetoThreadLocalState>(state_ptr)
         ->finalizeTrace();
     return std::make_unique<ProfilerResult>();

--- a/torch/csrc/autograd/profiler_legacy.cpp
+++ b/torch/csrc/autograd/profiler_legacy.cpp
@@ -120,18 +120,17 @@ namespace profiler {
 
 namespace {
 using torch::profiler::impl::ActiveProfilerType;
-using torch::profiler::impl::ProfilerThreadLocalStateBase;
+using torch::profiler::impl::ProfilerStateBase;
 
-struct ProfilerLegacyThreadLocalState : public ProfilerThreadLocalStateBase {
+struct ProfilerLegacyThreadLocalState : public ProfilerStateBase {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit ProfilerLegacyThreadLocalState(
       const torch::profiler::impl::ProfilerConfig& config)
-      : ProfilerThreadLocalStateBase(config),
-        remoteProfiledEvents_{c10::nullopt} {}
+      : ProfilerStateBase(config), remoteProfiledEvents_{c10::nullopt} {}
   ~ProfilerLegacyThreadLocalState() override = default;
 
   static ProfilerLegacyThreadLocalState* getTLS() {
-    auto tls = ProfilerThreadLocalStateBase::getTLS();
+    auto tls = ProfilerStateBase::get(/*global=*/false);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         tls == nullptr || tls->profilerType() == ActiveProfilerType::LEGACY);
     return static_cast<ProfilerLegacyThreadLocalState*>(tls);

--- a/torch/csrc/profiler/execution_graph_observer.cpp
+++ b/torch/csrc/profiler/execution_graph_observer.cpp
@@ -623,7 +623,7 @@ void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
 bool addExecutionGraphObserver(const std::string& output_file_path) {
   // Check if the observer is already initialized.
   if (ObserverManager::get() == nullptr) {
-    ObserverManager::init();
+    ObserverManager::push(std::make_shared<ExecutionGraphObserver>());
     auto& ob = *ObserverManager::get();
     ob.pid = processId();
     // Set output
@@ -660,7 +660,9 @@ void removeExecutionGraphObserver() {
       removeCallback(ob->cb_handle);
       ob->cb_handle = INVALID_CALLBACK_HANDLE;
       // Release the current EG observer object and reset.
-      ObserverManager::pop();
+      TORCH_INTERNAL_ASSERT(
+          ObserverManager::pop() != nullptr,
+          "Global state ptr cannot be null before resetting");
       VLOG(1) << "Removed PyTorch execution graph observer";
     } else {
       LOG(WARNING) << "Execution graph observer was not registered.";

--- a/torch/csrc/profiler/itt_observer.cpp
+++ b/torch/csrc/profiler/itt_observer.cpp
@@ -6,9 +6,9 @@ namespace torch {
 namespace profiler {
 namespace impl {
 
-struct ITTThreadLocalState : ProfilerThreadLocalStateBase {
+struct ITTThreadLocalState : ProfilerStateBase {
   explicit ITTThreadLocalState(const ProfilerConfig& config)
-      : ProfilerThreadLocalStateBase(config) {
+      : ProfilerStateBase(config) {
     // Only `report_input_shapes` makes sense in this context.
     TORCH_CHECK(!config.profile_memory);
     TORCH_CHECK(!config.with_stack);
@@ -25,7 +25,7 @@ struct ITTThreadLocalState : ProfilerThreadLocalStateBase {
       override {}
 
   static ITTThreadLocalState* getTLS() {
-    auto tls = ProfilerThreadLocalStateBase::getTLS();
+    auto tls = ProfilerStateBase::get(/*global=*/false);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         tls == nullptr || tls->profilerType() == ActiveProfilerType::ITT);
     return static_cast<ITTThreadLocalState*>(tls);

--- a/torch/csrc/profiler/nvtx_observer.cpp
+++ b/torch/csrc/profiler/nvtx_observer.cpp
@@ -6,9 +6,9 @@ namespace torch {
 namespace profiler {
 namespace impl {
 
-struct NVTXThreadLocalState : ProfilerThreadLocalStateBase {
+struct NVTXThreadLocalState : ProfilerStateBase {
   explicit NVTXThreadLocalState(const ProfilerConfig& config)
-      : ProfilerThreadLocalStateBase(config) {
+      : ProfilerStateBase(config) {
     // Only `report_input_shapes` makes sense in this context.
     TORCH_CHECK(!config.profile_memory);
     TORCH_CHECK(!config.with_stack);
@@ -25,7 +25,7 @@ struct NVTXThreadLocalState : ProfilerThreadLocalStateBase {
       override {}
 
   static NVTXThreadLocalState* getTLS() {
-    auto tls = ProfilerThreadLocalStateBase::getTLS();
+    auto tls = ProfilerStateBase::get(/*global=*/false);
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         tls == nullptr || tls->profilerType() == ActiveProfilerType::NVTX);
     return static_cast<NVTXThreadLocalState*>(tls);

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -6,6 +6,11 @@ namespace torch {
 namespace profiler {
 namespace impl {
 
+using GlobalManager = GlobalStateManager<ProfilerStateBase>;
+
+// ----------------------------------------------------------------------------
+// -- Profiler Config ---------------------------------------------------------
+// ----------------------------------------------------------------------------
 ExperimentalConfig::ExperimentalConfig(
     std::vector<std::string> profiler_metrics,
     bool profiler_measure_per_kernel)
@@ -15,6 +20,22 @@ ExperimentalConfig::ExperimentalConfig(
 /*explicit*/ ExperimentalConfig::operator bool() const {
   return !profiler_metrics.empty();
 }
+
+ProfilerConfig::ProfilerConfig(
+    ProfilerState state,
+    bool report_input_shapes,
+    bool profile_memory,
+    bool with_stack,
+    bool with_flops,
+    bool with_modules,
+    ExperimentalConfig experimental_config)
+    : state{state},
+      experimental_config{experimental_config},
+      report_input_shapes{report_input_shapes},
+      profile_memory{profile_memory},
+      with_stack{with_stack},
+      with_flops{with_flops},
+      with_modules{with_modules} {}
 
 bool ProfilerConfig::disabled() const {
   return state == torch::profiler::impl::ProfilerState::Disabled;
@@ -60,11 +81,13 @@ ProfilerConfig ProfilerConfig::fromIValue(
       ivalues.get(ProfilerIValueIdx::PROFILE_MEMORY).toBool());
 }
 
-/*explicit*/ ProfilerThreadLocalStateBase::ProfilerThreadLocalStateBase(
-    const ProfilerConfig& config)
+// ----------------------------------------------------------------------------
+// -- Profiler base class -----------------------------------------------------
+// ----------------------------------------------------------------------------
+/*explicit*/ ProfilerStateBase::ProfilerStateBase(const ProfilerConfig& config)
     : c10::MemoryReportingInfoBase(), config_(config) {}
 
-ProfilerThreadLocalStateBase::~ProfilerThreadLocalStateBase() {
+ProfilerStateBase::~ProfilerStateBase() {
   if (handle_) {
     auto handle = handle_;
     removeCallback();
@@ -72,8 +95,46 @@ ProfilerThreadLocalStateBase::~ProfilerThreadLocalStateBase() {
   }
 }
 
-void ProfilerThreadLocalStateBase::setCallbackHandle(
-    at::CallbackHandle handle) {
+/*static*/ ProfilerStateBase* ProfilerStateBase::get(bool global) {
+  auto* out = global
+      ? GlobalManager::get()
+      : static_cast<ProfilerStateBase*>(
+            c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PROFILER_STATE));
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!out || out->config().global() == global);
+  return out;
+}
+
+/*static*/ void ProfilerStateBase::push(
+    std::shared_ptr<ProfilerStateBase>&& state) {
+  TORCH_INTERNAL_ASSERT(state != nullptr);
+  if (state->config().global()) {
+    GlobalManager::push(std::move(state));
+  } else {
+    c10::ThreadLocalDebugInfo::_push(c10::DebugInfoKind::PROFILER_STATE, state);
+  }
+}
+
+namespace {
+std::shared_ptr<ProfilerStateBase> popTLS() {
+  // If there is no active thread local profiler then we simply return null.
+  // However if there is an active profiler but it is not the top
+  // `DebugInfoBase`then `c10::ThreadLocalDebugInfo::_pop` will throw.
+  // TODO(robieta): make `noexcept` version.
+  return c10::ThreadLocalDebugInfo::get(c10::DebugInfoKind::PROFILER_STATE)
+      ? std::static_pointer_cast<ProfilerStateBase>(
+            c10::ThreadLocalDebugInfo::_pop(c10::DebugInfoKind::PROFILER_STATE))
+      : nullptr;
+}
+} // namespace
+
+/*static*/ std::shared_ptr<ProfilerStateBase> ProfilerStateBase::pop(
+    bool global) {
+  auto out = global ? GlobalManager::pop() : popTLS();
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!out || out->config().global() == global);
+  return out;
+}
+
+void ProfilerStateBase::setCallbackHandle(at::CallbackHandle handle) {
   if (handle_) {
     at::removeCallback(handle_);
     SOFT_ASSERT(
@@ -85,7 +146,7 @@ void ProfilerThreadLocalStateBase::setCallbackHandle(
   handle_ = handle;
 }
 
-void ProfilerThreadLocalStateBase::removeCallback() {
+void ProfilerStateBase::removeCallback() {
   if (handle_) {
     at::removeCallback(handle_);
     handle_ = 0;
@@ -93,18 +154,18 @@ void ProfilerThreadLocalStateBase::removeCallback() {
 }
 
 bool profilerEnabled() {
-  auto state_ptr = ProfilerThreadLocalStateBase::getTLS();
+  auto* state_ptr = ProfilerStateBase::get(/*global=*/false);
   return state_ptr && !state_ptr->config().disabled();
 }
 
 TORCH_API ActiveProfilerType profilerType() {
-  auto state_ptr = ProfilerThreadLocalStateBase::getTLS();
+  auto* state_ptr = ProfilerStateBase::get(/*global=*/false);
   return state_ptr == nullptr ? ActiveProfilerType::NONE
                               : state_ptr->profilerType();
 }
 
 torch::profiler::impl::ProfilerConfig getProfilerConfig() {
-  auto state_ptr = ProfilerThreadLocalStateBase::getTLS();
+  auto* state_ptr = ProfilerStateBase::get(/*global=*/false);
   TORCH_CHECK(
       state_ptr,
       "Tried to access profiler config, but profiler is not enabled!");

--- a/torch/csrc/profiler/util.h
+++ b/torch/csrc/profiler/util.h
@@ -181,12 +181,11 @@ class TORCH_API GlobalStateManager {
     return singleton_;
   }
 
-  template <typename... Args>
-  static void init(Args... args) {
+  static void push(std::shared_ptr<T>&& state) {
     if (singleton().state_) {
       LOG(WARNING) << "GlobalStatePtr already exists!";
     } else {
-      singleton().state_ = std::make_shared<T>(std::forward<Args>(args)...);
+      singleton().state_ = std::move(state);
     }
   }
 
@@ -195,9 +194,6 @@ class TORCH_API GlobalStateManager {
   }
 
   static std::shared_ptr<T> pop() {
-    TORCH_INTERNAL_ASSERT(
-        singleton().state_ != nullptr,
-        "Global state ptr cannot be null before resetting");
     auto out = singleton().state_;
     singleton().state_.reset();
     return out;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84276
* #84275
* #84274
* #84273
* #83965
* #83964
* #83895
* __->__ #84668
* #84667

This PR renames `ProfilerThreadLocalStateBase` to simply `ProfilerStateBase`, and adds `push`, `pop`, and `get` methods. `global` can be specified, or can be omitted for priority selection.

In order to support this unification it was necessary to make a (mostly) non-throwing version of pop. The asserts around observer removal are intended to act as guard rails against multiple profilers trampling over each other. However on-demand wants to do exactly that because it wants to be able to preempt.

A hack would be to get the current observer and then only pop if an observer is found, but that would be prone to race conditions. By removing the asserts, we can preserve the old behavior by adding `ASSERT(pop())` on the caller side while allowing more complex handling for the kineto client interface. (Later PR.)

Differential Revision: [D39326253](https://our.internmc.facebook.com/intern/diff/D39326253/)