### PR TITLE
Actually chown artifacts

### DIFF
--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -202,7 +202,10 @@ jobs:
           docker exec -t "${container_name}" bash -c "source ${BINARY_ENV_FILE} && bash /builder/${{ inputs.PACKAGE_TYPE }}/build.sh"
       - name: Chown artifacts
         if: always()
-        uses: ./pytorch/.github/actions/chown-workspace
+        shell: bash
+        run: |
+          # Ensure the working directory gets chowned back to the current user
+          docker run --rm -v "${RUNNER_TEMP}/artifacts:/v" -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Rollback part of https://github.com/pytorch/pytorch/commit/045ebc771d5070696f839e586285ace9c06f1339 to actually chown artifacts folder rather than workspace

Fixes https://github.com/pytorch/pytorch/issues/84644