### PR TITLE
Add merge rules for PrimTorch+nvFuser

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -39,6 +39,25 @@
   - Lint
   - pull
 
+- name: PrimTorch+NVFuser
+  patterns:
+  - test/test_ops.py
+  - test/test_prims.py
+  - torch/_prims/**
+  - torch/_prims_common/**
+  - torch/_refs/**
+  - torch/testing/_internal/common_methods_invocations.py
+  approved_by:
+  - IvanYashchuk
+  - jjsjann123
+  - kevinstephano
+  - mruberry
+  - ngimel
+  mandatory_checks_name:
+  - Facebook CLA Check
+  - Lint
+  - pull
+
 - name: OSS CI
   patterns:
   - .github/**


### PR DESCRIPTION
Would it be okay to have these merge rules for PrimTorch with nvFuser execution work?