### PR TITLE
Add user facing documentation for CSAN

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,6 +96,10 @@ coverage_ignore_functions = [
     "check_error",
     "cudart",
     "is_bf16_supported",
+    # torch.cuda._sanitizer
+    "format_log_message",
+    "zip_arguments",
+    "zip_by_key",
     # torch.distributed.autograd
     "is_available",
     # torch.distributed.elastic.events
@@ -266,6 +270,15 @@ coverage_ignore_classes = [
     "ShortStorage",
     "ShortTensor",
     "cudaStatus",
+    # torch.cuda._sanitizer
+    "Access",
+    "AccessType",
+    "CUDASanitizer",
+    "CUDASanitizerDispatchMode",
+    "CUDASanitizerErrors",
+    "EventHandler",
+    "SynchronizationError",
+    "UnsynchronizedAccessError",
     # torch.distributed.elastic.multiprocessing.errors
     "ChildFailedError",
     "ProcessFailure",

--- a/docs/source/cuda._sanitizer.rst
+++ b/docs/source/cuda._sanitizer.rst
@@ -1,0 +1,95 @@
+.. currentmodule:: torch.cuda._sanitizer
+
+torch.cuda._sanitizer
+=====================
+
+Overview
+--------
+
+.. automodule:: torch.cuda._sanitizer
+
+
+Usage
+------
+
+Here is an example of a simple synchronization error in PyTorch:
+
+::
+
+    import torch
+
+    a = torch.rand(4, 2, device="cuda")
+
+    with torch.cuda.stream(torch.cuda.Stream()):
+        torch.mul(a, 5, out=a)
+
+The ``a`` tensor is initialized on the default stream and, without any synchronization
+methods, modified on a new stream. When this script is run on the commandline with:
+::
+
+    TORCH_CUDA_SANITIZER=1 python example_error.py
+
+the following output is printed by CSAN:
+
+::
+
+    ============================
+    CSAN detected a possible data race on tensor with data pointer 139719969079296
+    Access by stream 94646435460352 during kernel:
+    aten::mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+    writing to argument: self, out, output
+    With stack trace:
+        File "pytorch/torch/cuda/_sanitizer.py", line 364, in _handle_kernel_launch
+            stack_trace = traceback.StackSummary.extract(
+        ...
+        File "example_error.py", line 6, in <module>
+            torch.mul(a, 5, out=a)
+
+    Previous access by stream 0 during kernel:
+    aten::rand(int[] size, *, int? dtype=None, Device? device=None) -> Tensor
+    writing to argument: output
+    With stack trace:
+        File "pytorch/torch/cuda/_sanitizer.py", line 364, in _handle_kernel_launch
+            stack_trace = traceback.StackSummary.extract(
+        ...
+        File "example_error.py", line 3, in <module>
+            a = torch.rand(10000, device="cuda")
+
+    Tensor was allocated with stack trace:
+        File "pytorch/torch/cuda/_sanitizer.py", line 420, in _handle_memory_allocation
+            traceback.StackSummary.extract(
+        ...
+        File "example_error.py", line 3, in <module>
+            a = torch.rand(10000, device="cuda")
+
+This gives extensive insight into the origin of the error:
+
+- A tensor was incorrectly accessed from streams with ids: 0 (default stream) and 94646435460352 (new stream)
+- The tensor was allocated by invoking ``a = torch.rand(10000, device="cuda")``
+- The faulty accesses were caused by operators
+    - ``a = torch.rand(10000, device="cuda")`` on stream 0
+    - ``torch.mul(a, 5, out=a)`` on stream 94646435460352
+- The error message also displays the schemas of the invoked operators, along with a note
+  showing which arguments of the operators correspond to the affected tensor.
+
+  - In the example, it can be seen that tensor ``a`` corresponds to arguments ``self``, ``out``
+    and the ``output`` value of the invoked operator ``torch.mul``.
+
+.. seealso::
+    The list of supported torch operators and their schemas can be viewed
+    :doc:`here <torch>`.
+
+The bug can be fixed by forcing the new stream to wait for the default stream:
+
+::
+
+    with torch.cuda.stream(torch.cuda.Stream()):
+        torch.cuda.current_stream().wait_stream(torch.cuda.default_stream())
+        torch.mul(a, 5, out=a)
+
+When the script is run again, there are no errors reported.
+
+API Reference
+-------------
+
+.. autofunction:: enable_cuda_sanitizer

--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -135,8 +135,8 @@ Jiterator (beta)
     jiterator._create_jit_fn
     jiterator._create_multi_output_jit_fn
 
-Sanitizer (prototype)
----------------------
+Stream Sanitizer (prototype)
+----------------------------
 
 CUDA Sanitizer is a prototype tool for detecting synchronization errors between streams in PyTorch.
 See the :doc:`documentation <cuda._sanitizer>` for information on how to use it.

--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -134,3 +134,14 @@ Jiterator (beta)
 
     jiterator._create_jit_fn
     jiterator._create_multi_output_jit_fn
+
+Sanitizer (prototype)
+---------------------
+
+CUDA Sanitizer is a prototype tool for detecting synchronization errors between streams in PyTorch.
+See the :doc:`documentation <cuda._sanitizer>` for information on how to use it.
+
+.. toctree::
+    :hidden:
+
+    cuda._sanitizer

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -351,6 +351,9 @@ class EventHandler:
         stack_trace = traceback.StackSummary.extract(
             traceback.walk_stack(None), lookup_lines=False
         )
+        # The stack trace generated in this way is in the inverse order, so it must be
+        # reversed.
+        stack_trace.reverse()
 
         for data_ptr in read_only:
             self.tensors_accessed.ensure_tensor_exists(data_ptr)
@@ -402,11 +405,15 @@ class EventHandler:
 
     def _handle_memory_allocation(self, data_ptr: DataPtr) -> None:
         self.tensors_accessed.ensure_tensor_does_not_exist(data_ptr)
+        stack_trace = traceback.StackSummary.extract(
+            traceback.walk_stack(None), lookup_lines=False
+        )
+        # The stack trace generated in this way is in the inverse order, so it must be
+        # reversed.
+        stack_trace.reverse()
         self.tensors_accessed.create_tensor(
             data_ptr,
-            traceback.StackSummary.extract(
-                traceback.walk_stack(None), lookup_lines=False
-            ),
+            stack_trace,
         )
 
     def _handle_memory_deallocation(self, data_ptr: DataPtr) -> None:

--- a/torch/cuda/_sanitizer.py
+++ b/torch/cuda/_sanitizer.py
@@ -5,8 +5,8 @@ to determine if they are synchronized or not. When enabled in a python program a
 possible data race is detected, a detailed warning will be printed and the program
 will exit.
 
-It can be enabled either by importing this module and using
-:func:`enable_cuda_sanitizer()` or by exporting ``TORCH_CUDA_SANITIZER``
+It can be enabled either by importing this module and calling
+:func:`enable_cuda_sanitizer()` or by exporting the ``TORCH_CUDA_SANITIZER``
 environment variable.
 """
 


### PR DESCRIPTION
This adds a user facing tutorial for the CSAN tool. The documentation preview should be available [here](https://docs-preview.pytorch.org/84689/index.html) once the GitHub job completes on this PR.