### PR TITLE
[functorch] Simplify BatchedTensorImpl

### DIFF
--- a/functorch/functorch/csrc/BatchedTensorImpl.cpp
+++ b/functorch/functorch/csrc/BatchedTensorImpl.cpp
@@ -13,37 +13,6 @@
 namespace at {
 namespace functorch {
 
-BatchedTensorImpl::BatchedTensorImpl(Tensor value, int64_t bdim, int64_t level)
-  : TensorImpl(
-      c10::DispatchKeySet(DispatchKey::FuncTorchBatched),
-      value.dtype(),
-      value.device()
-    )
-  , value_(std::move(value))
-  , level_(level)
-  , bdim_(bdim)
-{
-  // TODO: I don't think this ctor gets used.
-  TORCH_INTERNAL_ASSERT(false);
-  TORCH_INTERNAL_ASSERT(value_.defined());
-  set_storage_access_should_throw();
-  set_sizes_strides_policy(SizesStridesPolicy::CustomStrides);
-  checkInvariants();
-
-  const auto public_dims = value_.dim() - 1;
-  const auto value_sizes = value_.sizes();
-  const auto value_strides = value_.strides();
-  sizes_and_strides_.resize(public_dims);
-  for (const auto dim : c10::irange(0, public_dims)) {
-    auto actual_dim = actualDim(dim, /*wrap_dim=*/false);
-    sizes_and_strides_.size_at_unchecked(dim) = value_sizes.at(actual_dim);
-    sizes_and_strides_.stride_at_unchecked(dim) = value_strides.at(actual_dim);
-  }
-  storage_offset_= value_.storage_offset();
-  refresh_numel();
-  refresh_contiguous();
-}
-
 BatchedTensorImpl::BatchedTensorImpl(DispatchKeySet key_set, Tensor value, int64_t bdim, int64_t level)
   : TensorImpl(
       key_set.add(DispatchKey::FuncTorchBatched),
@@ -81,36 +50,11 @@ int64_t BatchedTensorImpl::actualDim(int64_t dim, bool wrap_dim) const {
     const auto ndim = sizes_and_strides_.size();
     dim = maybe_wrap_dim(dim, ndim);
   }
-  auto is_bdim = createBatchDimBitset(bdim_);
-
-  // TODO(vfdev): As BatchedTensorImpl is refactored and has only one dim.
-  // Below code may be simplified.
-
-  // Example: assume dim = 3, and is_bdim = 10010011000...
-  // The 1's are batch dims and 0's are normal dims of the underlying value_ Tensor.
-  // actualDim gives us the index of `dim` in the `value_` Tensor, which is equivalent
-  // to asking "where does the 3rd (0-indexed) zero occur in the bitset?".
-  // The answer to that is index 5.
-  //
-  // TODO(rzou): the PDEP instruction does exactly this
-  // (https://stackoverflow.com/questions/7669057/find-nth-set-bit-in-an-int)
-  // but it might require newer (>= ~2015) CPUs. We should clean this up
-  // if/when we have dropped support for older CPUs.
-  int64_t non_bdim_count = 0;
-  for (int64_t actual_dim = 0; actual_dim < kVmapMaxTensorDims; actual_dim++) {
-    if (is_bdim[actual_dim]) {
-      continue;
-    }
-    if (non_bdim_count == dim) {
-      return actual_dim;
-    }
-    non_bdim_count++;
+  if (bdim_ <= dim) {
+    return dim + 1;
+  } else {
+    return dim;
   }
-  // If we hit this assert, then that means
-  // `non_bdim_count` + #num_bdims > kVmapMaxTensorDims. We restrict the number
-  // of dims a BatchedTensorImpl can have to kVmapMaxTensorDims so this should
-  // never be hit.
-  TORCH_INTERNAL_ASSERT(false);
 }
 
 void BatchedTensorImpl::checkInvariants() const {

--- a/functorch/functorch/csrc/BatchedTensorImpl.h
+++ b/functorch/functorch/csrc/BatchedTensorImpl.h
@@ -43,7 +43,6 @@ constexpr int64_t kBatchDimsStackSize = 5;
 // bt.sizes() returns (5, 7); bt.sum(0) performs a reduction over the (public)
 // dim 0, which is equivalent to dim 3 in the underlying ones(2, 3, 5, 7) tensor.
 struct BatchedTensorImpl : public c10::TensorImpl {
-  explicit BatchedTensorImpl(Tensor value, int64_t dim, int64_t level);
   explicit BatchedTensorImpl(at::DispatchKeySet key_set, Tensor value, int64_t dim, int64_t level);
 
   // Returns batch dimension of this tensor
@@ -142,6 +141,10 @@ FUNCTORCH_API Tensor makeBatched(const Tensor& tensor, int64_t dim, int64_t leve
 // Adds a batch dim to `tensor`, returning a BatchedTensor
 FUNCTORCH_API Tensor addBatchDim(const Tensor& tensor, int64_t dim, int64_t level);
 
+// Certain dispatch keys must be propagated to the BatchedTensor (or, in general,
+// any wrapper Tensor subclasses). This is because there are methods on Tensor
+// that skip dispatch and check for the presence of a dispatch key (e.g. is_cpu()).
+// TODO: should probably contain more (or all?) backend keys
 constexpr DispatchKeySet kKeysToPropagateToWrapper({
   DispatchKey::Negative,
   DispatchKey::Conjugate,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #84702
* __->__ #84701
* #84700
* #84699
* #84698

Three changes:
- deleted an unused constructor
- simplified an implementation from the old days when a
BatchedTensorImpl could have multiple bdims
- added a comment about getKeysToPropagateToWrapper