### PR TITLE
[FSDP] Optimizer states may be on CPU, copy them to GPU before gathering

### DIFF
--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -180,6 +180,8 @@ def _communicate_optim_state(
             if not flat_param._is_sharded:  # type: ignore[attr-defined]
                 tensor_state[state_name] = value.cpu()
                 continue
+            if not value.is_cuda:
+                value = value.to(fsdp_module.compute_device)
             if tensor_buffer is None:
                 # Assume that positive-dimension tensor optimizer state
                 # has the same shape as the sharded flattened parameter


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84708
* #84654

**Background**:
Optimizer states may not always on GPUs. Some examples include, 1.) CPU offload is enable, 2.) after lightning trainer fit() is called.

**What Does This PR Do?**
If states are not on GPUs, move them to GPUs before gathering the global states.

Differential Revision: [D39332300](https://our.internmc.facebook.com/intern/diff/D39332300/)