### PR TITLE
[ONNX] Add `third_party/onnx` to merge rule

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -15,6 +15,7 @@
   - torch/csrc/jit/serialization/onnx.*
   - torch/csrc/onnx/**
   - torch/onnx/**
+  - third_party/onnx
   approved_by:
   - BowenBao
   - abock


### PR DESCRIPTION
We expect to bump onnx submodule version regularly to develop support for new onnx operators/functions. Adding this to merge rule reduces the burden for core maintainers for approval.
