### PR TITLE
add alias to generate tensor with random uniform distribution

### DIFF
--- a/torch/random.py
+++ b/torch/random.py
@@ -4,6 +4,18 @@ import warnings
 
 from torch._C import default_generator
 import torch
+from torch.types import _int, _float
+
+
+def uniform(low: _float, high: _float, *size: _int) -> torch.Tensor:
+    """
+    Returns a tensor filled with numbers sampled from a uniform random distribution
+    Args:
+        low (float): Lower bound of the distribution.
+        high (float): Upper bound of the distribution.
+        *size (int): Sequence of integers that defines the shape of the Tensor. Can be a variable number or a list.
+    """
+    return torch.empty(size).uniform_(low, high)
 
 
 def set_rng_state(new_state: torch.Tensor) -> None:


### PR DESCRIPTION
Fixes issue #67321 

Added alias `torch.random.uniform(low, high, size) for initiating a uniformly distributed tensor.

cc @pbelevich
