### PR TITLE
Missed one CHECK_NOTNULL in #82032's find-replace

### DIFF
--- a/caffe2/contrib/nccl/cuda_nccl_gpu.cc
+++ b/caffe2/contrib/nccl/cuda_nccl_gpu.cc
@@ -177,7 +177,7 @@ void runNCCL(const NCCLExecution& ex, InitF&& init_f, F&& f) {
   // Now, wait on all the events in the original stream.
   CUDAGuard dg(ex.stream_gpu_id);
   for (auto& event : events) {
-    CUDA_ENFORCE(cudaStreamWaitEvent(CHECK_NOTNULL(ex.stream), event, 0));
+    CUDA_ENFORCE(cudaStreamWaitEvent(TORCH_CHECK_NOTNULL(ex.stream), event, 0));
   }
 }
 


### PR DESCRIPTION
Building master fails with the following:

```
pytorch/caffe2/contrib/nccl/cuda_nccl_gpu.cc:180:51: error: 'CHECK_NOTNULL' was not declared in this scope; did you mean 'TORCH_CHECK_NOTNULL'?
  180 |     CUDA_ENFORCE(cudaStreamWaitEvent(CHECK_NOTNULL(ex.stream), event, 0));
```

Seems like #82032 just missed one find-replace. cc @wconstab

Not sure why this wouldn't have been caught elsewhere.