### PR TITLE
[coreml][bug] coreml gpu flag not set

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
@@ -75,7 +75,7 @@ static NSString* gModelCacheDirectory = @"";
   if (@available(iOS 12.0, macOS 10.14, *)) {
     MLModelConfiguration* config = [[MLModelConfiguration alloc] init];
     MLComputeUnits computeUnits = MLComputeUnitsCPUOnly;
-    if (backend == "cpuandgpu") {
+    if (backend == "cpuAndGPU") {
       computeUnits = MLComputeUnitsCPUAndGPU;
     } else if (backend == "all") {
       computeUnits = MLComputeUnitsAll;


### PR DESCRIPTION
Summary:
Delegated CoreML models with cpuAndGPU flag set does not properly run models on CPU

- Fix will allow us to target models on CPU

Test Plan: brymkowski can you test this on your performance benchmarks?

Reviewed By: salilsdesai

Differential Revision: D39361382

