### PR TITLE
Upload the benchmark result to S3 and post the URL

### DIFF
--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -32,6 +32,15 @@ threshold: 100
 direction: decrease
 timeout: 720
 tests:"""
+S3_BUCKET = "ossci-metrics"
+S3_PREFIX = "torchbench-pr-test"
+
+class S3Client:
+    def __init__(self, bucket):
+        pass
+
+    def upload_file(self, file_path, s3key):
+        assert file_path.is_file(), f"Specified file path {file_path} does not exist or not file."
 
 def gen_abtest_config(control: str, treatment: str, models: List[str]) -> str:
     d = {}
@@ -143,7 +152,8 @@ def process_upload_s3(result_dir):
     result_dir = Path(result_dir)
     assert result_dir.exists(), f"Specified result directory doesn't exist."
     # upload all files to S3 bucket oss-ci-metrics
-    pass
+    files = [x for x in result_dir.iterdir() if x.is_file()]
+    # upload file to S3 bucket
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run TorchBench tests based on PR')

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -13,7 +13,7 @@ Testing environment:
 # 1. Does not reuse the build artifact in other CI workflows
 # 2. CI jobs are serialized because there is only one worker
 import os
-import boto3
+import boto3  # type: ignore[import]
 import git  # type: ignore[import]
 import pathlib
 import argparse
@@ -38,13 +38,13 @@ S3_PREFIX = "torchbench-pr-test"
 S3_URL_BASE = "https://ossci-metrics.s3.amazonaws.com/"
 
 class S3Client:
-    def __init__(self, bucket=S3_BUCKET, prefix=S3_PREFIX):
+    def __init__(self, bucket: str=S3_BUCKET, prefix: str=S3_PREFIX):
         self.s3 = boto3.client('s3')
         self.resource = boto3.resource('s3')
         self.bucket = bucket
         self.prefix = prefix
 
-    def upload_file(self, file_path, filekey_prefix):
+    def upload_file(self, file_path: Path, filekey_prefix: str):
         assert file_path.is_file(), f"Specified file path {file_path} does not exist or not file."
         file_name = file_path.name
         s3_key = f"{self.prefix}/{filekey_prefix}/{file_name}"
@@ -161,14 +161,14 @@ def run_userbenchmarks(pytorch_path: str, torchbench_path: str, base_sha: str, h
     print(f"Running torchbench userbenchmark command: {command}")
     subprocess.check_call(command, cwd=torchbench_path, env=env)
 
-def process_upload_s3(result_dir):
+def process_upload_s3(result_dir: str):
     # validate result directory
     result_dir = Path(result_dir)
-    assert result_dir.exists(), f"Specified result directory doesn't exist."
+    assert result_dir.exists(), f"Specified result directory {result_dir} doesn't exist."
     # upload all files to S3 bucket oss-ci-metrics
     files = [x for x in result_dir.iterdir() if x.is_file()]
     # upload file to S3 bucket
-    s3_client = S3Client()
+    s3_client: S3Client = S3Client()
     filekey_prefix = result_dir.name
     for f in files:
         s3_client.upload_file(f, filekey_prefix)

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -38,13 +38,13 @@ S3_PREFIX = "torchbench-pr-test"
 S3_URL_BASE = "https://ossci-metrics.s3.amazonaws.com/"
 
 class S3Client:
-    def __init__(self, bucket: str=S3_BUCKET, prefix: str=S3_PREFIX):
+    def __init__(self, bucket: str = S3_BUCKET, prefix: str = S3_PREFIX):
         self.s3 = boto3.client('s3')
         self.resource = boto3.resource('s3')
         self.bucket = bucket
         self.prefix = prefix
 
-    def upload_file(self, file_path: Path, filekey_prefix: str):
+    def upload_file(self, file_path: Path, filekey_prefix: str) -> None:
         assert file_path.is_file(), f"Specified file path {file_path} does not exist or not file."
         file_name = file_path.name
         s3_key = f"{self.prefix}/{filekey_prefix}/{file_name}"
@@ -161,15 +161,15 @@ def run_userbenchmarks(pytorch_path: str, torchbench_path: str, base_sha: str, h
     print(f"Running torchbench userbenchmark command: {command}")
     subprocess.check_call(command, cwd=torchbench_path, env=env)
 
-def process_upload_s3(result_dir: str):
+def process_upload_s3(result_dir: str) -> None:
     # validate result directory
-    result_dir = Path(result_dir)
-    assert result_dir.exists(), f"Specified result directory {result_dir} doesn't exist."
+    result_dir_path = Path(result_dir)
+    assert result_dir_path.exists(), f"Specified result directory {result_dir} doesn't exist."
     # upload all files to S3 bucket oss-ci-metrics
-    files = [x for x in result_dir.iterdir() if x.is_file()]
+    files = [x for x in result_dir_path.iterdir() if x.is_file()]
     # upload file to S3 bucket
     s3_client: S3Client = S3Client()
-    filekey_prefix = result_dir.name
+    filekey_prefix = result_dir_path.name
     for f in files:
         s3_client.upload_file(f, filekey_prefix)
 

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -49,7 +49,7 @@ class S3Client:
         file_name = file_path.name
         s3_key = f"{self.prefix}/{filekey_prefix}/{file_name}"
         print(f"Uploading file {file_name} to S3 with key: {s3_key}")
-        self.s3.upload_file(str(file_path), self.bucket, s3_key, ExtraArgs={'ACL':'public-read'})
+        self.s3.upload_file(str(file_path), self.bucket, s3_key, ExtraArgs={'ACL': 'public-read'})
         # output the result URL
         print(f"Uploaded the result file {file_name} to {S3_URL_BASE}/{self.bucket}/{s3_key}")
 

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -51,7 +51,7 @@ class S3Client:
         print(f"Uploading file {file_name} to S3 with key: {s3_key}")
         self.s3.upload_file(str(file_path), self.bucket, s3_key)
         # output the result URL
-        print(f"Uploaded the result file {file_name} to {S3_URL_BASE}/{s3_key}")
+        print(f"Uploaded the result file {file_name} to {S3_URL_BASE}{s3_key}")
 
 def gen_abtest_config(control: str, treatment: str, models: List[str]) -> str:
     d = {}

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -35,7 +35,7 @@ timeout: 720
 tests:"""
 S3_BUCKET = "ossci-metrics"
 S3_PREFIX = "torchbench-pr-test"
-S3_URL_BASE = "https://ossci-metrics.s3.amazonaws.com/"
+S3_URL_BASE = f"https://{S3_BUCKET}.s3.amazonaws.com/"
 
 class S3Client:
     def __init__(self, bucket: str = S3_BUCKET, prefix: str = S3_PREFIX):
@@ -51,7 +51,7 @@ class S3Client:
         print(f"Uploading file {file_name} to S3 with key: {s3_key}")
         self.s3.upload_file(str(file_path), self.bucket, s3_key)
         # output the result URL
-        print(f"Uploaded the result file {file_name} to {S3_URL_BASE}/{self.bucket}/{s3_key}")
+        print(f"Uploaded the result file {file_name} to {S3_URL_BASE}/{s3_key}")
 
 def gen_abtest_config(control: str, treatment: str, models: List[str]) -> str:
     d = {}

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -49,10 +49,7 @@ class S3Client:
         file_name = file_path.name
         s3_key = f"{self.prefix}/{filekey_prefix}/{file_name}"
         print(f"Uploading file {file_name} to S3 with key: {s3_key}")
-        response = self.s3.upload_file(str(file_path), self.bucket, s3_key)
-        # make the object public
-        object_acl = self.resource.ObjectAcl(self.bucket, s3_key)
-        object_acl.put(ACL='public-read')
+        self.s3.upload_file(str(file_path), self.bucket, s3_key, ExtraArgs={'ACL':'public-read'})
         # output the result URL
         print(f"Uploaded the result file {file_name} to {S3_URL_BASE}/{self.bucket}/{s3_key}")
 

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -35,6 +35,7 @@ timeout: 720
 tests:"""
 S3_BUCKET = "ossci-metrics"
 S3_PREFIX = "torchbench-pr-test"
+S3_URL_BASE = "https://ossci-metrics.s3.amazonaws.com/"
 
 class S3Client:
     def __init__(self, bucket=S3_BUCKET, prefix=S3_PREFIX):
@@ -52,6 +53,8 @@ class S3Client:
         # make the object public
         object_acl = self.resource.ObjectAcl(self.bucket, s3_key)
         object_acl.put(ACL='public-read')
+        # output the result URL
+        print(f"Uploaded the result file {file_name} to {S3_URL_BASE}/{self.bucket}/{s3_key}")
 
 def gen_abtest_config(control: str, treatment: str, models: List[str]) -> str:
     d = {}

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -49,7 +49,7 @@ class S3Client:
         file_name = file_path.name
         s3_key = f"{self.prefix}/{filekey_prefix}/{file_name}"
         print(f"Uploading file {file_name} to S3 with key: {s3_key}")
-        self.s3.upload_file(str(file_path), self.bucket, s3_key, ExtraArgs={'ACL': 'public-read'})
+        self.s3.upload_file(str(file_path), self.bucket, s3_key)
         # output the result URL
         print(f"Uploaded the result file {file_name} to {S3_URL_BASE}/{self.bucket}/{s3_key}")
 

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -10,6 +10,8 @@ env:
   PR_BODY: ${{ github.event.pull_request.body }}
   PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
   PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
 jobs:
   run-torchbench:
@@ -39,7 +41,7 @@ jobs:
           # pin cmake version to 3.22 since 3.23 breaks pytorch build
           # see details at: https://github.com/pytorch/pytorch/issues/74985
           conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
-                           setuptools cmake=3.22 cffi typing_extensions \
+                           setuptools cmake=3.22 cffi typing_extensions boto3 \
                            future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
       - name: Setup TorchBench branch
         run: |

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -78,6 +78,13 @@ jobs:
                   --pr-num "$PR_NUM" \
                   --pr-base-sha "$PR_MERGE_BASE" \
                   --pr-head-sha "$PR_HEAD_SHA"
+      - name: Upload result to S3
+        run: |
+          . "${HOME}"/anaconda3/etc/profile.d/conda.sh
+          conda activate pr-ci
+          python3 pytorch/.github/scripts/run_torchbench.py \
+                  s3-upload \
+                  --result-dir "~/.torchbench/bisection/pr${{ github.event.number }}"
       - name: Remove conda environment and cleanup
         run: |
           conda env remove --name pr-ci

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -85,8 +85,8 @@ jobs:
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
           conda activate pr-ci
           python3 pytorch/.github/scripts/run_torchbench.py \
-                  s3-upload \
-                  --result-dir "~/.torchbench/bisection/pr${{ github.event.number }}"
+                  upload-s3 \
+                  --result-dir "${HOME}/.torchbench/bisection/pr${{ github.event.number }}"
       - name: Remove conda environment and cleanup
         run: |
           conda env remove --name pr-ci


### PR DESCRIPTION
Upload the benchmark result to S3 and make it accessible to the public.

The URL is available at the end of the "Upload to S3" step of the workflow. For example, this PR uploads 3 files:
```
Uploaded the result file control.json to https://ossci-metrics.s3.amazonaws.com/torchbench-pr-test/pr84726/control.json
Uploading file treatment.json to S3 with key: torchbench-pr-test/pr84726/treatment.json
Uploaded the result file treatment.json to https://ossci-metrics.s3.amazonaws.com/torchbench-pr-test/pr84726/treatment.json
Uploading file result.csv to S3 with key: torchbench-pr-test/pr84726/result.csv
Uploaded the result file result.csv to https://ossci-metrics.s3.amazonaws.com/torchbench-pr-test/pr84726/result.csv
```

RUN_TORCHBENCH: nvfuser