### PR TITLE
Fix flake8 complain 'Could not statically determine the binary parameter'

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -5,6 +5,7 @@ import os
 import unittest
 import contextlib
 import math
+import shlex
 import torch
 import torch.nn.functional as F
 from torch.testing import FileCheck
@@ -920,7 +921,7 @@ class TestTEFuser(JitTestCase):
                 return ingate * forgetgate * cellgate * outgate
             ''')
             for permutation in permutations(choices, len(choices)):
-                code = template.format(*permutation)
+                code = shlex.quote(template.format(*permutation))
                 scope = {}
                 exec(code, globals(), scope)
                 cu = torch.jit.CompilationUnit(code)
@@ -2614,7 +2615,7 @@ class TestNNCOpInfo(TestNNCOpInfoParent):
 def f({', '.join(param_names)}):
     return op.op({', '.join(fx_args)})"""
             g = {'torch': torch, 'inf' : math.inf, 'op': op}
-            exec(code, g)
+            exec(shlex.quote(code), g)
             f = g['f']
             f.__module__ = 'test'
             out = f(*param_values)


### PR DESCRIPTION
Fix flake8:

test/test_jit_fuser_te.py:925:17: P204 Could not statically determine the binary parameter. Please make sure your command is properly escaped. If you're using `eval`, please don't (ever!). If you're shelling out to a process, please pass in an array of arguments. If you do need shell support, make sure you're escaping all the arguments (e.g. with `shlex.quote`).
