### PR TITLE
Patch torch refs mode tracing

### DIFF
--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -69,8 +69,9 @@ def torch_to_refs_map():
 nvfuser_decompositions: Sequence[
     Union[torch._ops.OpOverload, torch._ops.OpOverloadPacket]
 ] = {  # type: ignore[assignment]
-    # nll_loss_forward decomposition gives data-dependent control flow during tracing
-    torch.ops.aten.nll_loss_forward,
+    # see issue: github.com/pytorch/pytorch/issues/84734
+    torch.ops.aten.nll_loss_forward.default,
+    torch.ops.aten.nll_loss_forward.output,
 }
 
 
@@ -112,7 +113,6 @@ class NvfuserPrimsMode(torch.overrides.TorchFunctionMode):
             if namespace == "prims":
                 nvfunc = getattr(torch.ops.nvprims, name, None)
                 if nvfunc is not None:
-                    print("running nvprim: ", name)
                     return nvfunc(*args, **kwargs)
         return orig_func(*args, **kwargs)
 

--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -123,6 +123,7 @@ class NvfuserPrimsMode(torch.overrides.TorchFunctionMode):
             if namespace == "prims":
                 nvfunc = getattr(torch.ops.nvprims, name, None)
                 if nvfunc is not None:
+                    print("running nvprim: ", name)
                     return nvfunc(*args, **kwargs)
         return orig_func(*args, **kwargs)
 

--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -165,7 +165,7 @@ class TorchRefsMode(torch.overrides.TorchFunctionMode):
         # implementations.
         # There're other ways to implement this functionality,
         # see https://github.com/pytorch/pytorch/pull/82657#discussion_r939776417
-        if func is None and isinstance(orig_func, torch._ops.OpOverload) and not func in nvfuser_decompositions:
+        if func is None and isinstance(orig_func, torch._ops.OpOverload) and not orig_func in nvfuser_decompositions:
             func = torch._decomp.decomposition_table.get(orig_func, None)
 
         if func is not None:


### PR DESCRIPTION
A WAR for #84734 via excluding decomposition of `nll_loss_forward` which causes tracing failure under `TorchRefsMode`.