### PR TITLE
Fix failing test_model_dump due to empty file

### DIFF
--- a/test/test_model_dump.py
+++ b/test/test_model_dump.py
@@ -131,6 +131,8 @@ class TestModelDump(TestCase):
 
         with tempfile.NamedTemporaryFile() as tf:
             torch.jit.save(torch.jit.script(SimpleModel()), tf)
+            # Actually write contents to disk so we can read it below
+            tf.flush()
 
             stdout = io.StringIO()
             torch.utils.model_dump.main(


### PR DESCRIPTION
The `torch.jit.save` call on a file object may not actually write the data to disk due to buffering. The call to `model_dump.main` on that file will when fail with an error like

> zipfile.BadZipFile: File is not a zip file

Inspecting the file confirms that it is either empty (usually) or incomplete (possible).

Fix this by flushing the file after saving the model.

Fixes #84745