### PR TITLE
Make param 'option' const& to prevent unnecessary copy at call-site

### DIFF
--- a/caffe2/proto/caffe2_pb.h
+++ b/caffe2/proto/caffe2_pb.h
@@ -108,7 +108,7 @@ inline TORCH_API caffe2::DeviceOption DeviceToOption(const at::Device& device) {
   return option;
 }
 
-inline TORCH_API at::Device OptionToDevice(const caffe2::DeviceOption option) {
+inline TORCH_API at::Device OptionToDevice(const caffe2::DeviceOption& option) {
   auto type = option.device_type();
   c10::DeviceIndex id = -1;
   switch (type) {


### PR DESCRIPTION
Reviewed By: ajtulloch

Differential Revision: D39208916

