### PR TITLE
[QNNPack] Update GoogleTest SHA256 Hash

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/cmake/DownloadGoogleTest.cmake
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/cmake/DownloadGoogleTest.cmake
@@ -11,7 +11,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   URL https://github.com/google/googletest/archive/release-1.10.0.zip
-  URL_HASH SHA256=f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf
+  URL_HASH SHA256=94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91
   SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/googletest"
   BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/googletest"
   CONFIGURE_COMMAND ""

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/deps/clog/cmake/DownloadGoogleTest.cmake
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/deps/clog/cmake/DownloadGoogleTest.cmake
@@ -11,7 +11,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   URL https://github.com/google/googletest/archive/release-1.10.0.zip
-  URL_HASH SHA256=f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf
+  URL_HASH SHA256=94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91
   SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/googletest"
   BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/googletest"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Summary: Fixes hash mismatch error when building qnnpack

Test Plan:
```
export ANDROID_NDK=/opt/android_ndk/r20
export ANDROID_NDK_HOME=${ANDROID_NDK}
export ANDROID_SDK=/opt/android_sdk
export ANDROID_HOME=${ANDROID_SDK}

cd ~/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack

./scripts/build-android-arm64.sh
```

# Before

```
[1/9] Creating directories for 'googletest'
[2/9] Performing download step (download, verify and extract) for 'googletest'
FAILED: googletest-prefix/src/googletest-stamp/googletest-download /data/users/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/googletest-stamp/googletest-download
cd /home/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/deps && /data/users/salilsdesai/miniconda3/envs/pytorch/bin/cmake -P /data/users/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/googletest-stamp/download-googletest.cmake && /data/users/salilsdesai/miniconda3/envs/pytorch/bin/cmake -P /data/users/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/googletest-stamp/verify-googletest.cmake && /data/users/salilsdesai/miniconda3/envs/pytorch/bin/cmake -P /data/users/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/googletest-stamp/extract-googletest.cmake && /data/users/salilsdesai/miniconda3/envs/pytorch/bin/cmake -E touch /data/users/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/googletest-stamp/googletest-download
-- Downloading...
   dst='/data/users/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/release-1.10.0.zip'
   timeout='none'
   inactivity timeout='none'
-- Using src='https://github.com/google/googletest/archive/release-1.10.0.zip'
-- [download 1% complete]
...
-- [download 100% complete]
-- verifying file...
       file='/data/users/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/release-1.10.0.zip'
-- SHA256 hash of
    /data/users/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/release-1.10.0.zip
  does not match expected value
    expected: 'f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf'
      actual: '94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91'
-- Hash mismatch, removing...
````

# After (No Error)

```
[1/9] Creating directories for 'googletest'
[2/9] Performing download step (download, verify and extract) for 'googletest'
-- Downloading...
   dst='/data/users/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/release-1.10.0.zip'
   timeout='none'
   inactivity timeout='none'
-- Using src='https://github.com/google/googletest/archive/release-1.10.0.zip'
-- [download 1% complete]
...
-- [download 100% complete]
-- verifying file...
       file='/data/users/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/release-1.10.0.zip'
-- Downloading... done
-- extracting...
     src='/home/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/build/android/arm64-v8a/deps/googletest-download/googletest-prefix/src/release-1.10.0.zip'
     dst='/home/salilsdesai/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/deps/googletest'
-- extracting... [tar xfz]
-- extracting... [analysis]
-- extracting... [rename]
-- extracting... [clean up]
-- extracting... done
[3/9] No update step for 'googletest'
[4/9] No patch step for 'googletest'
[5/9] No configure step for 'googletest'
[6/9] No build step for 'googletest'
[7/9] No install step for 'googletest'
[8/9] No test step for 'googletest'
[9/9] Completed 'googletest'
```

Reviewed By: digantdesai

Differential Revision: D39273970

