### PR TITLE
[docs] Person of interest update: sparse, torchrec and smaller tweaks

### DIFF
--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -54,13 +54,14 @@ Autograd (torch.autograd)
 -  Jeffrey Wan (`soulitzer <https://github.com/soulitzer>`__)
 -  (emeritus) Adam Paszke (`apaszke <https://github.com/apaszke>`__)
 
-JIT / TorchScript / FX
-~~~~~~~~~~~~~~~~~~~~~~
+Compilers (JIT / TorchScript / FX / TorchDynamo)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Elias Ellison (`eellison <https://github.com/eellison>`__)
 -  Michael Suo (`suo <https://github.com/suo>`__)
 -  Yanan Cao (`gmagogsfm <https://github.com/gmagogsfm>`__)
 -  James Reed (`jamesr66a <https://github.com/jamesr66a>`__)
+-  Jason Ansel (`jansel <https://github.com/jansel>`__)
 -  (emeritus) Zach Devito (`zdevito <https://github.com/zdevito>`__)
 
 
@@ -83,9 +84,10 @@ Distributed
 -  Junjie Wang (`fduwjj <https://github.com/fduwjj>`__)
 -  Howard Huang (`H-Huang <https://github.com/H-Huang>`__)
 -  Tristan Rice (`d4l3k <https://github.com/d4l3k>`__)
--  Kiuk Chung (`kiukchung <https://github.com/kiukchung>`__)
 -  Alisson Azzolini (`aazzolini <https://github.com/aazzolini>`__)
 -  Ke Wen (`kwen2501 <https://github.com/kwen2501>`__)
+-  James Reed (`jamesr66a <https://github.com/jamesr66a>`__)
+-  (emeritus) Kiuk Chung (`kiukchung <https://github.com/kiukchung>`__)
 -  (emeritus) Pieter Noordhuis (`pietern <https://github.com/pietern>`__)
 -  (emeritus) Mingzhe Li (`mingzhe09088 <https://github.com/mingzhe09088>`__)
 -  (emeritus) Omkar Salpekar (`osalpekar <https://github.com/osalpekar>`__)
@@ -105,6 +107,14 @@ Linear Algebra (torch.linalg)
 -  Ivan Yashchuk (`IvanYashchuk <https://github.com/IvanYashchuk>`__)
 -  (emeritus) Vishwak Srinivasan (`vishwakftw <https://github.com/vishwakftw>`__)
 
+Sparse (torch.sparse)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Pearu Peterson (`pearu <https://github.com/pearu>`__)
+-  Nikita Vedeneev (`nikitaved <https://github.com/nikitaved>`__)
+-  Ivan Yashchuk (`IvanYashchuk <https://github.com/IvanYashchuk>`__)
+-  Christian Puhrsch (`cpuhrsch <https://github.com/cpuhrsch>`__)
+
 Fast Fourier Transform (torch.fft)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -115,6 +125,7 @@ CPU Performance / SIMD
 ~~~~~~~~~~~~~~~~~~~~~~
 
 -  Vitaly Fedyunin (`VitalyFedyunin <https://github.com/VitalyFedyunin>`__)
+-  Mingfei Ma (`mingfeima <https://github.com/mingfeima>`__)
 -  (emeritus) Xiaoqiang Zheng (`zheng-xq <https://github.com/zheng-xq>`__)
 -  (emeritus) Sam Gross (`colesbury <https://github.com/colesbury>`__)
 -  (emeritus) Christian Puhrsch (`cpuhrsch <https://github.com/cpuhrsch>`__)
@@ -126,6 +137,8 @@ NVIDIA / CUDA
 -  Natalia Gimelshein (`ngimel <https://github.com/ngimel>`__)
 -  Edward Yang (`ezyang <https://github.com/ezyang>`__)
 -  Piotr Bialecki (`ptrblck <https://github.com/ptrblck>`__)
+-  Christian Sarofeen (`csarofeen <https://github.com/csarofeen>`__)
+-  Andrew Tulloch (`ajtulloch <https://github.com/ajtulloch>`__)
 -  (emeritus) Xiaoqiang Zheng (`zheng-xq <https://github.com/zheng-xq>`__)
 
 NVFuser
@@ -141,6 +154,7 @@ Intel / MKLDNN
 
 -  Vitaly Fedyunin (`VitalyFedyunin <https://github.com/VitalyFedyunin>`__)
 -  Jianhui Li (`Jianhui-Li <https://github.com/Jianhui-Li>`__)
+-  Mingfei Ma (`mingfeima <https://github.com/mingfeima>`__)
 -  (emeritus) Junjie Bai (`bddppq <https://github.com/bddppq>`__)
 -  (emeritus) Yinghai Lu (`yinghai <https://github.com/yinghai>`__)
 
@@ -288,13 +302,19 @@ TorchAudio
 -  Moto Hira (`mthrok <https://github.com/mthrok>`__)
 -  (emeritus) Vincent QB (`vincentqb <https://github.com/vincentqb>`__)
 
+TorchRec
+~~~~~~~~
+
+-  Dmytro Ivchenko (`divchenko <https://github.com/divchenko>`__)
+-  Colin Taylor (`colin2328 <https://github.com/colin2328>`__)
+
 TorchX
 ~~~~~~
 
 -  Tristan Rice (`d4l3k <https://github.com/d4l3k>`__)
 -  Kiuk Chung (`kiukchung <https://github.com/kiukchung>`__)
 
-TorchData
-~~~~~~~~~
+TorchData / TorchArrow
+~~~~~~~~~~~~~~~~~~~~~~
 -  Vitaly Fedyunin (`VitalyFedyunin <https://github.com/VitalyFedyunin>`__)
 -  Wenlei Xie (`wenleix <https://github.com/wenleix>`__)


### PR DESCRIPTION
Fixes #83363

This is not a full update yet, but fixes some obvious things: missing modules (torchrec, sparse) and brings a few people from merge_rules.json who are working on the respective modules. There are still discrepancies - e.g. Intel CPU work is split in many categories in merge_rules, but it's better to improve things incrementally.
