### PR TITLE
[Functorch] Make minpybind less likely to crash

### DIFF
--- a/functorch/functorch/csrc/dim/minpybind.h
+++ b/functorch/functorch/csrc/dim/minpybind.h
@@ -617,7 +617,8 @@ struct vector_args {
             }
             *format_it++ = '\0';
             _PyArg_Parser* _parser = new _PyArg_Parser{format_str, &names_buf[0], fname_cstr, 0};
-            _PyArg_ParseStackAndKeywords((PyObject*const*)args, nargs, kwnames.ptr(), _parser);
+            PyObject *dummy = NULL;
+            _PyArg_ParseStackAndKeywords((PyObject*const*)args, nargs, kwnames.ptr(), _parser, &dummy, &dummy, &dummy, &dummy, &dummy);
 #else
             _PyArg_Parser* _parser = new _PyArg_Parser{NULL, &names_buf[0], fname_cstr, 0};
             std::unique_ptr<PyObject*[]> buf(new PyObject*[names.size()]);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #83464
* #83777
* __->__ #84788

Error handling in `vector_args::parse` is fundamentally broken, as it
calls to
[`_PyArg_ParseStackAndKeywords`](https://github.com/python/cpython/blob/000593c0f97ac9b75b56064a957b84a3aaa60674/Include/modsupport.h#L106)
 variadic function, which are
akin to `sscanf` without any arguments, which results, in case of partial
parse in a random segfault/stack corruption. Remedy it by passing a few
references to dummy pyobject

Differential Revision: [D39032967](https://our.internmc.facebook.com/intern/diff/D39032967)

@diff-train-skip-merge Manually copied this commit to fbsync to fix shipit