### PR TITLE
ns for fx: fix comparison for quant model to reference model

### DIFF
--- a/torch/ao/ns/fx/graph_matcher.py
+++ b/torch/ao/ns/fx/graph_matcher.py
@@ -216,9 +216,7 @@ def _get_subgraph_relationship_type(
         else:
             return SubgraphTypeRelationship.NOT_RELATED
     elif node_a.op == 'call_module':
-        assert (subgraph_a.base_op_node == subgraph_a.start_node and
-                subgraph_b.base_op_node == subgraph_b.start_node), \
-            "Matching call_module patterns where base_op_node != start_node is not supported yet"
+
         # for call_module, we need to look up the modules to do the type check
         assert isinstance(node_a.target, str)
         mod_a = getattr_from_fqn(gm_a, node_a.target)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#84791 ns for fx: fix comparison for quant model to reference model**

Summary:

While debugging PTQ accuracy issues with a model quantized for `fbgemm` where
the output of reference model does not match closely the output of quantized
model, I noticed that Numeric Suite for FX currently does not match patterns
in quantized models properly. For example if we have

```
x0 -> dq -> op -> q -> ...
```

Before this PR, NS would insert a logger after the op inside the reference pattern:

```
x0 -> dq -> op -> log0 -> q -> ...
```

This is not useful because to match quantized ops, we want to insert a logger
after the q.  This PR changes the matching to do

```
x0 -> dq -> op -> q -> log0 -> ...
```

instead.

Note: this only makes sense for op-based backends.  How this applies to TensorRT
is out of scope for this PR - the entire architecture of NS may have to be changed
to support that.

Test plan:

```
python test/test_quantization.py -k test_simple_mod_reference
python test/test_quantization.py -k test_simple_fun_reference
```

cc @ezyang @SherlockNoMad @soumith @EikanWang @jgong5 @wenzhe-nrv