### PR TITLE
Include CoreML error description in exception thrown when inference fails

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
@@ -143,7 +143,12 @@ class CoreMLBackend: public torch::jit::PyTorchBackendInterface {
     PTMCoreMLExecutor *executor = model_wrapper->executor;
     [executor setInputs:inputs];
 
-    id<MLFeatureProvider> outputsProvider = [executor forward];
+    NSError *error;
+    id<MLFeatureProvider> outputsProvider = [executor forward:&error];
+    if (!outputsProvider) {
+      TORCH_CHECK(false, [[error description] UTF8String]);
+    }
+
     return pack_outputs(model_wrapper->outputs, outputsProvider);
   }
 

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.h
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setInputs:(c10::impl::GenericList)inputs;
 
-- (id<MLFeatureProvider>)forward;
+- (id<MLFeatureProvider>)forward:(NSError**)error;
 
 @end
 

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
@@ -35,15 +35,8 @@
   }
 }
 
-- (id<MLFeatureProvider>)forward {
-  NSError *error;
-  MLPredictionOptions *options = [[MLPredictionOptions alloc] init];
-  id<MLFeatureProvider> outputs = [self.model predictionFromFeatures:_inputProvider options:options error:&error];
-  if (error) {
-    NSLog(@"Prediction failed with error %@", error);
-    return nil;
-  }
-  return outputs;
+- (id<MLFeatureProvider>)forward:(NSError **)error {
+  return [self.model predictionFromFeatures:_inputProvider error:error];
 }
 
 @end


### PR DESCRIPTION
Summary:
Catch the error and throw an exception with PTMCoreMLBackend when inference fails. This way the error description will be available in the logged crash, as opposed to crashing with a less descriptive exception.

I'll be drafting follow up diffs to actually catch exceptions in the segmentation shim next. Ideally we would fail inference gracefully and not crash at all, but at least after this diff we'll have the full diagnostic info

Test Plan: Force an error, and confirm its description appears in the exception thrown via the console

Differential Revision: D39407865

