### PR TITLE
Use irange in half_float_ops.cc

### DIFF
--- a/caffe2/operators/half_float_ops.cc
+++ b/caffe2/operators/half_float_ops.cc
@@ -1,5 +1,6 @@
 #include "caffe2/operators/half_float_ops.h"
 #include <c10/util/Half.h>
+#include <c10/util/irange.h>
 #include "caffe2/utils/cpuid.h"
 #ifdef USE_FBGEMM
 #include "fbgemm/FbgemmConvert.h"
@@ -130,17 +131,14 @@ bool Float16UniformFillOp<CPUContext>::RunOnDevice() {
 
   // Get a batch row by row and convert
   auto leading_dim_sz = output->size(0);
-  // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-  int rowsz = output->numel() / output->size(0);
+  const auto rowsz = output->numel() / output->size(0);
 
   vector<float> intermediate_data_;
   intermediate_data_.resize(rowsz);
-  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-  for (uint64_t i = 0; i < leading_dim_sz; i++) {
+  for (const auto i : c10::irange(leading_dim_sz)) {
     math::RandUniform<float, CPUContext>(
         rowsz, min_, max_, intermediate_data_.data(), &context_);
-    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (uint64_t j = 0; j < rowsz; j++) {
+    for (const auto j : c10::irange(rowsz)) {
       out[i * rowsz + j] = intermediate_data_[j];
     }
   }


### PR DESCRIPTION
Summary:
Fixes:
```
caffe2/operators/half_float_ops.cc: In member function 'bool caffe2::Float16UniformFillOp<Context>::RunOnDevice() [with Context = caffe2::CPUContext]':
caffe2/operators/half_float_ops.cc:139:26: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (uint64_t i = 0; i < leading_dim_sz; i++) {
                        ~~^~~~~~~~~~~~~~~~
caffe2/operators/half_float_ops.cc:143:28: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (uint64_t j = 0; j < rowsz; j++) {
                          ~~^~~~~~~
```

Test Plan: Sandcastle

Differential Revision: D39389026

