### PR TITLE
Increment `version_range_max`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -963,7 +963,7 @@ def main():
     with open(os.path.join(cwd, "README.md"), encoding="utf-8") as f:
         long_description = f.read()
 
-    version_range_max = max(sys.version_info[1], 9) + 1
+    version_range_max = max(sys.version_info[1], 10) + 1
     torch_package_data = [
         'py.typed',
         'bin/*',


### PR DESCRIPTION
Python 3.10 should be added as a listing in `Programming Language` on https://pypi.org/project/torch/:  

<img width="238" alt="Screenshot 2022-09-11 at 2 48 01" src="https://user-images.githubusercontent.com/7121753/189495599-72bd6a28-4248-4e4e-8194-b5b1f9e984e2.png">