### PR TITLE
Fix bugs in how LTC decides whether or not to symint op or not

### DIFF
--- a/torchgen/api/lazy.py
+++ b/torchgen/api/lazy.py
@@ -338,7 +338,11 @@ class LazyIrSchema:
     opkind: Optional[str] = None
 
     def __init__(
-        self, func: FunctionSchema, properties: Optional[LazyIrProperties] = None, *, symint: bool
+        self,
+        func: FunctionSchema,
+        properties: Optional[LazyIrProperties] = None,
+        *,
+        symint: bool,
     ):
         if properties:
             self.properties = properties
@@ -349,7 +353,9 @@ class LazyIrSchema:
         for arg_field in ["pre_self_positional", "self_arg", "post_self_positional"]:
             if arg_field == "self_arg" and func.arguments.self_arg is not None:
                 arg = getattr(func.arguments, "self_arg").argument
-                positional_args.append(LazyArgument(arg, self.properties, symint=symint))
+                positional_args.append(
+                    LazyArgument(arg, self.properties, symint=symint)
+                )
             elif getattr(func.arguments, arg_field) is not None:
                 positional_args.extend(
                     LazyArgument(arg, self.properties, symint=symint)
@@ -375,7 +381,8 @@ class LazyIrSchema:
                         ), "We expect there is only one generator arg"
                         self.generator_arg = NamedCType(arg.name, arg.type)
                 keyword_args.extend(
-                    LazyArgument(arg, self.properties, symint=symint) for arg in curr_args
+                    LazyArgument(arg, self.properties, symint=symint)
+                    for arg in curr_args
                 )
         self.keyword_args = tuple(keyword_args)
         self.name = func.name

--- a/torchgen/api/lazy.py
+++ b/torchgen/api/lazy.py
@@ -203,12 +203,16 @@ class LazyArgument:
     # TODO: this is lies, it is false for symint list
     is_symint_or_list: bool
 
+    # Whether or not we are treating this as symint or not
+    symint: bool
+
     # true if this argument is or contains a lazy IR value
     is_lazy_value: bool
 
-    def __init__(self, arg: Argument, properties: "LazyIrProperties"):
+    def __init__(self, arg: Argument, properties: "LazyIrProperties", *, symint: bool):
         self.name = arg.name
         self.orig_type = arg.type
+        self.symint = symint
         self.is_optional = isinstance(arg.type, OptionalType)
         self.is_generator = isGeneratorType(arg.type)
         if self.is_generator:
@@ -222,7 +226,7 @@ class LazyArgument:
         else:
             self.lazy_type_ = process_ir_type(arg.type, properties)
         self.is_wrapped_scalar = isWrappedScalarType(arg.type)
-        self.is_symint_or_list = (
+        self.is_symint_or_list = symint and (
             isSymIntType(arg.type)
             or (isinstance(arg.type, OptionalType) and isSymIntType(arg.type.elem))
             # TODO: lists of symints are not currently treated as value types
@@ -319,6 +323,12 @@ class LazyIrSchema:
     # build a LazyArgument since lazy IR doesn't support it
     generator_arg: Optional[NamedCType] = None
 
+    # original function schema
+    func: FunctionSchema
+
+    # Whether or not we are code-genning for SymInt or not
+    symint: bool
+
     properties: LazyIrProperties = LazyIrProperties(
         # default properties
         "ShapePrecompute",
@@ -328,19 +338,21 @@ class LazyIrSchema:
     opkind: Optional[str] = None
 
     def __init__(
-        self, func: FunctionSchema, properties: Optional[LazyIrProperties] = None
+        self, func: FunctionSchema, properties: Optional[LazyIrProperties] = None, *, symint: bool
     ):
         if properties:
             self.properties = properties
 
+        self.func = func
+        self.symint = symint
         positional_args: List[LazyArgument] = []
         for arg_field in ["pre_self_positional", "self_arg", "post_self_positional"]:
             if arg_field == "self_arg" and func.arguments.self_arg is not None:
                 arg = getattr(func.arguments, "self_arg").argument
-                positional_args.append(LazyArgument(arg, self.properties))
+                positional_args.append(LazyArgument(arg, self.properties, symint=symint))
             elif getattr(func.arguments, arg_field) is not None:
                 positional_args.extend(
-                    LazyArgument(arg, self.properties)
+                    LazyArgument(arg, self.properties, symint=symint)
                     for arg in getattr(func.arguments, arg_field)
                 )
         self.positional_args = tuple(positional_args)
@@ -363,7 +375,7 @@ class LazyIrSchema:
                         ), "We expect there is only one generator arg"
                         self.generator_arg = NamedCType(arg.name, arg.type)
                 keyword_args.extend(
-                    LazyArgument(arg, self.properties) for arg in curr_args
+                    LazyArgument(arg, self.properties, symint=symint) for arg in curr_args
                 )
         self.keyword_args = tuple(keyword_args)
         self.name = func.name

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -22,6 +22,7 @@ from torchgen.api.types import (
     OptionalCType,
     VectorCType,
 )
+from torchgen.api.translate import translate
 from torchgen.context import method_with_native_function
 from torchgen.dest.lazy_ts_lowering import ts_lowering_body
 from torchgen.model import (
@@ -77,7 +78,10 @@ def node_ctor_arg_rvalue_string(arg: LazyArgument) -> str:
         if isinstance(arg.orig_type, ListType) and arg.orig_type.elem == BaseType(
             BaseTy.SymInt
         ):
-            return f"GetSymIntArrayRefValue({arg.name})"
+            if arg.symint:
+                return f"GetSymIntArrayRefValue({arg.name})"
+            else:
+                return f"std::vector<int64_t>({arg.name}.begin(), {arg.name}.end())"
         elif isinstance(arg.lazy_type, VectorCType) and isinstance(
             arg.lazy_type.elem, BaseCType
         ):
@@ -102,12 +106,14 @@ def node_ctor_inputs(schema: LazyIrSchema) -> str:
     return ", ".join(node_ctor_values)
 
 
-def gen_fallback_code(schema: LazyIrSchema, overload_name: str) -> str:
+def gen_fallback_code(schema: LazyIrSchema, sig, overload_name: str) -> str:
     """
     Generate code that falls back to eager conditioned on a predicate
     """
+    dispatcher_sig = DispatcherSignature.from_schema(schema.func)
+    exprs = translate(sig.arguments(), dispatcher_sig.arguments())
     fallback_args = ",\n                ".join(
-        [str(arg.name) for arg in schema.filtered_args(generator=True)]
+        [a.expr for a in exprs]
     )
     if len(overload_name):
         aten_op_str = f"ATEN_OP2({schema.aten_name}, {overload_name})"
@@ -167,7 +173,8 @@ class GenLazyIR(ABC):
     @method_with_native_function
     def __call__(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> List[str]:
         func = f.functional.func if isinstance(f, NativeFunctionsGroup) else f.func
-        schema = LazyIrSchema(func)
+        metadata = self.backend_index.get_kernel(f.functional if isinstance(f, NativeFunctionsGroup) else f)
+        schema = LazyIrSchema(func, symint=metadata and metadata.supports_symint())
         return self.gen(schema)
 
     # there is no lowering functionality generated unless this IR base class is subclassed and
@@ -444,9 +451,9 @@ class GenLazyNativeFuncDefinition:
                 )
         return ("\n        ").join(lazy_tensor_decls)
 
-    def force_eager_fallback(self, func: NativeFunction, schema: LazyIrSchema) -> str:
+    def force_eager_fallback(self, func: NativeFunction, schema: LazyIrSchema, metadata, sig) -> str:
         if self.gen_forced_fallback_code:
-            return gen_fallback_code(schema, overload_name=func.func.name.overload_name)
+            return gen_fallback_code(schema, sig, overload_name=func.func.name.overload_name)
         return ""
 
     def metrics(self, func: NativeFunction, schema: LazyIrSchema) -> str:
@@ -525,7 +532,7 @@ std::vector<torch::lazy::Shape> shapes{torch::lazy::Shape(out_meta.scalar_type()
         auto out_meta = at::{dispatch_ns}::{aten_name}({', '.join(meta_call_args)});
         {meta_out}"""
         else:
-            shape_sig = ComputeShapeSignature(metadata.kernel, func)
+            shape_sig = ComputeShapeSignature(metadata.kernel, func, symint=metadata.supports_symint())
             shape_str = f"""
             auto shapes = {shape_sig.shape_call};"""
 
@@ -598,11 +605,11 @@ std::vector<torch::lazy::Shape> shapes{torch::lazy::Shape(out_meta.scalar_type()
         sig = kernel_signature(func, self.backend_index)
         metadata = self.backend_index.get_kernel(func)
         assert metadata is not None
-        schema = LazyIrSchema(func.func)
+        schema = LazyIrSchema(func.func, symint=metadata.supports_symint())
         return [
             f"""\
     {sig.decl(name=f"{self.class_method_name}::{metadata.kernel}")} {{
-        {self.force_eager_fallback(func, schema)}
+        {self.force_eager_fallback(func, schema, metadata, sig)}
         {self.metrics(func, schema)}
         {self.get_device(func, schema)}
         {self.lazy_tensor_decls(func, schema)}
@@ -618,10 +625,10 @@ class ComputeShapeSignature:
     Here we use the base name as the suffix of the signature to avoid generating for in-place variants.
     """
 
-    def __init__(self, kernel_name: str, f: NativeFunction):
-        self.__schema = LazyIrSchema(f.func)
+    def __init__(self, kernel_name: str, f: NativeFunction, *, symint: bool):
+        self.__schema = LazyIrSchema(f.func, symint=symint)
         self.__dispatch_args = ", ".join(
-            [a.decl() for a in dispatcher.arguments(f.func)]
+            [a.decl() for a in dispatcher.arguments(f.func, symint=symint)]
         )
         self.__call_args = ", ".join(
             [f"{arg.name}" for arg in self.__schema.filtered_args(generator=True)]
@@ -660,7 +667,7 @@ class GenLazyShapeInferenceDefinition:
         if is_structured or is_view_copy_op:
             return []
         else:
-            shape_sig = ComputeShapeSignature(metadata.kernel, f)
+            shape_sig = ComputeShapeSignature(metadata.kernel, f, symint=metadata.supports_symint())
             return ["\n".join([f"{shape_sig.shape_decl};"])]
 
 
@@ -675,7 +682,8 @@ def generate_non_native_lazy_ir_nodes(
         for p in op.get("properties", []):
             setattr(properties, p, True)
 
-        schema = LazyIrSchema(FunctionSchema.parse(op["func"]), properties)
+        # non-native is assumed to want symint bindings if you wrote symint
+        schema = LazyIrSchema(FunctionSchema.parse(op["func"]), properties, symint=True)
         schema.opkind = op.get("opkind")
         nodes.append(gen_lazy_ir.gen(schema)[0])
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84832

This fixes two problems:

- First, shape signature didn't respect the symint property (so it
  would always mark the operator as symint).  This was relatively
  easy to fix.

- Second, the call to fallback goes directly through at::_ops, so
  it must always be SymInt-aware, even if SymInt is disabled externally.
  This was a bit more difficult, because the current LTC codegen
  is poorly factored.  First, I needed to make it so individual
  arguments knew if they were going to be SymInt in LTC or not; second,
  I need to plumb enough information about the enclosing bindings so
  that I could use translate to do the expressions (previously, it was
  just assumed the signatures matched.)

The LTC codegen would do well to have a complete rewrite, but this will
have to do for now, I suppose.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>