### PR TITLE
[Mobile Tracer] Allow tracing multiple input models at once

### DIFF
--- a/torch/csrc/jit/mobile/model_tracer/TracerRunner.cpp
+++ b/torch/csrc/jit/mobile/model_tracer/TracerRunner.cpp
@@ -267,6 +267,10 @@ void run_model(
 }
 
 TracerResult trace_run(const std::string& input_module_path) {
+  return trace_run(std::vector<std::string>({input_module_path}));
+}
+
+TracerResult trace_run(const std::vector<std::string>& input_module_paths) {
   at::globalContext().setQEngine(at::QEngine::QNNPACK);
   c10::ObservedOperators::getUnobservedOperatorList().clear();
 
@@ -283,19 +287,24 @@ TracerResult trace_run(const std::string& input_module_path) {
 
   using torch::jit::MobileModuleLoadOptions;
 
-  // run with QNNPACK
-  run_model(input_module_path, root_ops, enabled_backends, called_kernel_tags);
-  // Not every model can be successfully run with fbgemm,
-  // but for those that can this can help broaden the tracers scope around hyper
-  // optimized QNNPack paths
-  try {
-    at::globalContext().setQEngine(at::QEngine::FBGEMM);
+  for (auto& input_module_path : input_module_paths) {
+    // run with QNNPACK
+    at::globalContext().setQEngine(at::QEngine::QNNPACK);
+
     run_model(
         input_module_path, root_ops, enabled_backends, called_kernel_tags);
-  } catch (std::exception& ex) {
-    std::cerr
-        << "ModelTracer encountered an error while attempting to run the model in FBGEMM mode"
-        << ex.what() << "\n Skipping FBGEMM execution" << std::endl;
+    // Not every model can be successfully run with fbgemm,
+    // but for those that can this can help broaden the tracers scope around
+    // hyper optimized QNNPack paths
+    try {
+      at::globalContext().setQEngine(at::QEngine::FBGEMM);
+      run_model(
+          input_module_path, root_ops, enabled_backends, called_kernel_tags);
+    } catch (std::exception& ex) {
+      std::cerr
+          << "ModelTracer encountered an error while attempting to run the model in FBGEMM mode"
+          << ex.what() << "\n Skipping FBGEMM execution" << std::endl;
+    }
   }
 
   op_tracer.getCalledOperators().withLock(

--- a/torch/csrc/jit/mobile/model_tracer/TracerRunner.cpp
+++ b/torch/csrc/jit/mobile/model_tracer/TracerRunner.cpp
@@ -267,7 +267,7 @@ void run_model(
 }
 
 TracerResult trace_run(const std::string& input_module_path) {
-  return trace_run(std::vector<std::string>({input_module_path}));
+  return trace_run(std::vector<std::string>(1, input_module_path));
 }
 
 TracerResult trace_run(const std::vector<std::string>& input_module_paths) {

--- a/torch/csrc/jit/mobile/model_tracer/TracerRunner.h
+++ b/torch/csrc/jit/mobile/model_tracer/TracerRunner.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <set>
+#include <string>
+#include <vector>
+
 #include <ATen/core/ivalue.h>
 #include <torch/csrc/jit/mobile/model_tracer/BuildFeatureTracer.h>
 #include <torch/csrc/jit/mobile/model_tracer/CustomClassTracer.h>
@@ -25,6 +29,8 @@ struct TracerResult {
 };
 
 TracerResult trace_run(const std::string& input_module_path);
+TracerResult trace_run(const std::vector<std::string>& input_module_paths);
+
 } // namespace mobile
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/mobile/model_tracer/TracerRunner.h
+++ b/torch/csrc/jit/mobile/model_tracer/TracerRunner.h
@@ -28,7 +28,6 @@ struct TracerResult {
   std::set<std::string> enabled_backends;
 };
 
-
 /**
  * Trace a single model and return the TracerResult.
  */

--- a/torch/csrc/jit/mobile/model_tracer/TracerRunner.h
+++ b/torch/csrc/jit/mobile/model_tracer/TracerRunner.h
@@ -28,7 +28,15 @@ struct TracerResult {
   std::set<std::string> enabled_backends;
 };
 
+
+/**
+ * Trace a single model and return the TracerResult.
+ */
 TracerResult trace_run(const std::string& input_module_path);
+
+/**
+ * Trace multiple models and return the TracerResult.
+ */
 TracerResult trace_run(const std::vector<std::string>& input_module_paths);
 
 } // namespace mobile

--- a/torch/csrc/jit/mobile/model_tracer/tracer.cpp
+++ b/torch/csrc/jit/mobile/model_tracer/tracer.cpp
@@ -1,11 +1,12 @@
 #include <iostream>
+#include <sstream>
 #include <string>
 
 /**
- * The tracer.cpp generates a binary that accepts a TorchScript model or a
- * Torch Mobile Model (with bytecode.pkl) which has at least 1 bundled
- * input. This binary then feeds the bundled input(s) into the model
- * and executes using the lite interpreter.
+ * The tracer.cpp generates a binary that accepts multiple Torch Mobile Model(s)
+ * (with bytecode.pkl), each of which has at least 1 bundled
+ * input. This binary then feeds the bundled input(s) into each corresponding
+ * model and executes it using the lite interpreter.
  *
  * Both root operators as well as called operators are recorded and saved
  * into a YAML file (whose path is provided on the command line).
@@ -33,7 +34,7 @@ typedef std::map<std::string, std::set<std::string>> kt_type;
 C10_DEFINE_string(
     model_input_path,
     "",
-    "The path of the input model file (.ptl).");
+    "A comma separated list of path(s) to the input model file(s) (.ptl).");
 
 C10_DEFINE_string(
     build_yaml_path,
@@ -113,9 +114,9 @@ void printCustomClassesYAML(
 }
 
 /**
- * Converts a pytorch model (full/lite) to lite interpreter model for
- * mobile, and additionally writes out a list of root and called
- * operators.
+ * Runs multiple PyTorch lite interpreter models, and additionally writes
+ * out a list of root and called operators, kernel dtypes, and loaded/used
+ * TorchBind custom classes.
  */
 int main(int argc, char* argv[]) {
   if (!c10::ParseCommandLineFlags(&argc, &argv)) {
@@ -126,21 +127,27 @@ int main(int argc, char* argv[]) {
   REQUIRE_STRING_ARG(model_input_path);
   REQUIRE_STRING_ARG(build_yaml_path);
 
-  const std::string input_module_path = FLAGS_model_input_path;
-
+  std::istringstream sin(FLAGS_model_input_path);
   std::ofstream yaml_out(FLAGS_build_yaml_path);
 
-  std::cout << "Processing: " << input_module_path << std::endl;
   std::cout << "Output: " << FLAGS_build_yaml_path << std::endl;
   torch::jit::mobile::TracerResult tracer_result;
+  std::vector<std::string> model_input_paths;
+
+  for (std::string model_input_path;
+       std::getline(sin, model_input_path, ',');) {
+    std::cout << "Processing: " << model_input_path << std::endl;
+    model_input_paths.push_back(model_input_path);
+  }
+
   try {
-    tracer_result = torch::jit::mobile::trace_run(FLAGS_model_input_path);
+    tracer_result = torch::jit::mobile::trace_run(model_input_paths);
   } catch (std::exception& ex) {
     std::cerr
         << "ModelTracer has not been able to load the module for the following reasons:\n"
         << ex.what()
-        << "\nPlease consider posting to the PyTorch with the error message."
-        << std::endl;
+        << "\nPlease consider opening an issue at https://github.com/pytorch/pytorch/issues "
+        << "with the detailed error message." << std::endl;
 
     throw ex;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84849
* __->__ #84833
* #84814

Summary: For practical usage, folks may want to custom build PyTorch for support with multiple models. The current tracer allows tracing just one model. There are multiple way to address this limitation:

1. Provide a tool to merge multiple YAML files produced by each of these runs. Each run corresponds to a YAML file for a single model.
2. Allow the tracer to run multiple models at once.

This PR implements the solution [2] above.

Test Plan: Build the tracer using: `USE_NUMPY=0 USE_DISTRIBUTED=0 USE_CUDA=0 TRACING_BASED=1 python setup.py develop`

Run with 1 input file: `./build/bin/model_tracer --model_input_path /tmp/path_to_model.ptl --build_yaml_path /tmp/selected_ops.yaml`

Run with multiple input files: `./build/bin/model_tracer --model_input_path /tmp/path_to_model.ptl,/tmp/path_to_model.ptl --build_yaml_path /tmp/selected_ops.yaml`

Both runs completed successfully.
