### PR TITLE
add itt unit test and docstrings

### DIFF
--- a/docs/source/bottleneck.rst
+++ b/docs/source/bottleneck.rst
@@ -47,9 +47,9 @@ where [args] are any number of arguments to `script.py`, or run
     evaluating. If the profiler outputs don't help, you could try looking at
     the result of :func:`torch.autograd.profiler.emit_nvtx()` with ``nvprof``.
     However, please take into account that the NVTX overhead is very high and
-    often gives a heavily skewed timeline. Similarly, Intel VTune Profiler helps
-    to analyze performance on Intel platforms further with
-    :func:`torch.autograd.profiler.emit_nvtx()`.
+    often gives a heavily skewed timeline. Similarly, ``Intel® VTune™ Profiler``
+    helps to analyze performance on Intel platforms further with
+    :func:`torch.autograd.profiler.emit_itt()`.
 
 .. warning::
     If you are profiling CUDA code, the first profiler that ``bottleneck`` runs

--- a/docs/source/profiler.rst
+++ b/docs/source/profiler.rst
@@ -26,3 +26,12 @@ API Reference
 .. autofunction:: torch.profiler.schedule
 
 .. autofunction:: torch.profiler.tensorboard_trace_handler
+
+Intel Instrumentation and Tracing Technology APIs
+-------------------------------------------------
+
+.. autofunction:: torch.profiler.itt.mark
+
+.. autofunction:: torch.profiler.itt.range_push
+
+.. autofunction:: torch.profiler.itt.range_pop

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -127,6 +127,16 @@ class TestProfilerCUDA(TestCase):
             q = s.sum()
             q.backward()
 
+        # Only testing that emit_itt runs when
+        # record_shapes option is enabled.
+        with torch.autograd.profiler.emit_itt(record_shapes=True) as prof:
+            x = torch.randn(10, 10, requires_grad=True)
+            y = torch.randn(10, 10, requires_grad=True)
+            z = x + y
+            s = custom_layer(z)
+            q = s.sum()
+            q.backward()
+
 class TestRecordFunction(TestCase):
     def _record_function_with_param(self):
         u = torch.randn(3, 4, 5, requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -25,7 +25,7 @@ import torch
 from torch import nn
 from torch._six import inf, nan
 from torch.autograd.function import once_differentiable
-from torch.autograd.profiler import (profile, record_function, emit_nvtx)
+from torch.autograd.profiler import (profile, record_function, emit_nvtx, emit_itt)
 from torch.autograd.profiler_util import (_format_time, EventList, FunctionEvent, FunctionEventAvg)
 from torch.utils.checkpoint import checkpoint
 from torch.testing import make_tensor
@@ -7987,6 +7987,16 @@ class TestAutogradDeviceType(TestCase):
         out, _ = l(s)
         out.sum().backward()
         self.assertFalse(s.grad is None or s.grad.abs().sum().item() == 0)
+
+    @onlyCPU
+    def test_profiler_emit_itt(self, device):
+        # This test is not intended to ensure correctness of itt ranges.
+        # That would require something a great deal more complex (you'd have to create a
+        # profile in a subprocess, open it, and parse the sql somehow).
+        # This test is merely intended to catch if emit_itt breaks on construction.
+        a = torch.tensor([1, 2, 3], dtype=torch.float32, device=device)
+        with emit_itt():
+            a.add(1.0)
 
     @skipIfMps  # the test doesn't work as randn is not supported with type long
     @deviceCountAtLeast(1)

--- a/test/test_itt.py
+++ b/test/test_itt.py
@@ -1,0 +1,24 @@
+# Owner(s): ["module: intel"]
+
+import torch
+from torch.testing._internal.common_utils import TestCase, run_tests, load_tests
+
+# load_tests from common_utils is used to automatically filter tests for
+# sharding on sandcastle. This line silences flake warnings
+load_tests = load_tests
+
+class TestItt(TestCase):
+    def setUp(self):
+        super(TestItt, self).setUp()
+
+    def tearDown(self):
+        super(TestItt, self).tearDown()
+
+    def test_itt(self):
+        # Just making sure we can see the symbols
+        torch.profiler.itt.range_push("foo")
+        torch.profiler.itt.mark("bar")
+        torch.profiler.itt.range_pop()
+
+if __name__ == '__main__':
+    run_tests()

--- a/torch/profiler/itt.py
+++ b/torch/profiler/itt.py
@@ -20,6 +20,9 @@ __all__ = ['range_push', 'range_pop', 'mark', 'range']
 
 def range_push(msg):
     """
+    Pushes a range onto a stack of nested range span.  Returns zero-based
+    depth of the range that is started.
+
     Arguments:
         msg (str): ASCII message to associate with range
     """
@@ -28,6 +31,8 @@ def range_push(msg):
 
 def range_pop():
     """
+    Pops a range off of a stack of nested range spans. Returns the
+    zero-based depth of the range that is ended.
     """
     return _itt.rangePop()
 
@@ -35,6 +40,7 @@ def range_pop():
 def mark(msg):
     """
     Describe an instantaneous event that occurred at some point.
+
     Arguments:
         msg (str): ASCII message to associate with the event.
     """


### PR DESCRIPTION
Add unit tests and docstrings corresponding to PR https://github.com/pytorch/pytorch/pull/63289
UT:
1. `test_profiler_emit_itt` in `test/test_autograd.py`. This test is merely intended to catch if emit_itt breaks on construction.
2. Test `torch.profiler.itt` functions in `test/test_itt.py`
3. Only testing that emit_itt runs when `record_shapes` option is enabled in `test/test_profiler.py`.

Docstring:
1. add ITT related info into `docs/source/bottleneck.rst`
4. add `torch.profiler.itt` functions to `docs/source/profiler.rst`
5. add docstring to `torch.profiler.itt` functions in `torch/profiler/itt.py`