### PR TITLE
remove unnecessary __syncthreads() in conv_depthwise2d_grad_weight_kernel

### DIFF
--- a/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
@@ -236,7 +236,6 @@ __global__ void conv_depthwise2d_grad_weight_kernel(
       }
     }
   }
-  __syncthreads();
 
   // At this point each thread in the block has a local gradient, which we need to
   // accumulate prior to writing the global value


### PR DESCRIPTION
Threads within a thread block would be synchronize inside the function BlockReduceSum when intra-warp reduce finishes.  It's unnessary to synchronize threads before invoking function BlockReduceSum.
