### PR TITLE
[TensorImpl] Make set_storage_keep_dtype virtual

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2176,7 +2176,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return data_type_ != caffe2::TypeMeta();
   }
 
-  void set_storage_keep_dtype(at::Storage storage) {
+  TENSORIMPL_MAYBE_VIRTUAL void set_storage_keep_dtype(at::Storage storage) {
     TORCH_CHECK(
         allow_tensor_metadata_change(),
         "set_storage ",


### PR DESCRIPTION
Summary:

For lazy tensor impl, set_storage_keep_dtype needs to be virtual to take care of dummy storage created for frontend tensors. For lazy tensor impl, simple move of storage doesn't work because it may not have been evaluated and for other book keeping that TensorImpl need to do, this function should be virtual.

