### PR TITLE
[torch::deploy] Ignore return value of function declared with 'warn_unused_result'

### DIFF
--- a/torch/csrc/deploy/environment.h
+++ b/torch/csrc/deploy/environment.h
@@ -57,7 +57,7 @@ class Environment {
   }
   virtual ~Environment() {
     auto rmCmd = fmt::format("rm -rf {}", extraPythonLibrariesDir_);
-    system(rmCmd.c_str());
+    (void)system(rmCmd.c_str());
   }
   virtual void configureInterpreter(Interpreter* interp) = 0;
   virtual const std::vector<std::string>& getExtraPythonPaths() {


### PR DESCRIPTION
Summary:
Addresses the following build failure that we get on some of our internal build environments:
caffe2/torch/csrc/deploy/environment.h:60:5: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result] system(rmCmd.c_str());

Test Plan: buck build //caffe2/torch/...

Differential Revision: D39364411

