### PR TITLE
make _shape_as_tensor composite compliant

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -251,6 +251,10 @@
 - func: _reshape_from_tensor(Tensor self, Tensor shape) -> Tensor
 
 - func: _shape_as_tensor(Tensor self) -> Tensor
+  dispatch:
+    # _shape_as_tensor doesn't decompose into a valid trace
+    # (it just decomposes into empty()), so we make it a primitive
+    CompositeExplicitAutograd: _shape_as_tensor
 
 - func: dropout(Tensor input, float p, bool train) -> Tensor
   tags: nondeterministic_seeded

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -159,6 +159,8 @@ DONT_REQUIRE_DERIVATIVE = {
     "logical_or",
     # This function returns nested_tensor shape as a tensor that is non-differentiable
     "_nested_tensor_size",
+    # This is essentially as factory function like the *_like ops
+    "_shape_as_tensor"
 }
 
 # The C -> R functions at the time of adding this are still being audited and tested

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -160,7 +160,7 @@ DONT_REQUIRE_DERIVATIVE = {
     # This function returns nested_tensor shape as a tensor that is non-differentiable
     "_nested_tensor_size",
     # This is essentially as factory function like the *_like ops
-    "_shape_as_tensor"
+    "_shape_as_tensor",
 }
 
 # The C -> R functions at the time of adding this are still being audited and tested


### PR DESCRIPTION
`_shape_as_tensor` wasn't composite compliant, because it would call `at::tensor()` (which would muck directly with the data pointer).

I fixed it by making it a primitive w.r.t. tracing (by making it CompositeExplicitAutograd). It also seems like a factory-function, so I gave it the same treatment as `*_like` ops with autograd. I confirmed that this preserves autograd behavior:
```
>>> a = torch.ones(2, 3, 4, requires_grad=True)
>>> b = torch.ops.aten._shape_as_tensor(a)
>>> b.requires_grad
False
```

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #84868

