### PR TITLE
Forward fix for FB internal breakage (manual export of internal diff D39421802)

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -769,7 +769,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // want to use them
   bool is_contiguous_default(at::MemoryFormat memory_format) const {
     // TODO: handle symbolic shapes correctly
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(compute_contiguous() == is_contiguous_);
     if (memory_format == at::MemoryFormat::ChannelsLast) {
       return is_channels_last_contiguous_;
     } else if (memory_format == at::MemoryFormat::ChannelsLast3d) {


### PR DESCRIPTION
D39421802 is a forward-fix for D39419569 (corresponds to #84806).

The forward-fix is mostly internal-facing, but has a single line that has to be exported to GH first. Manual export was required, because automatic export failed due to diff dependecies.

@diff-train-skip-merge