### PR TITLE
Fix `expectedFailureMeta` to avoid skipping tests

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1161,7 +1161,7 @@ def expectedFailureCUDA(fn):
     return expectedFailure('cuda')(fn)
 
 def expectedFailureMeta(fn):
-    return skipIfTorchDynamo(expectedFailure('meta')(fn))
+    return skipIfTorchDynamo()(expectedFailure('meta')(fn))
 
 def expectedFailureXLA(fn):
     return expectedFailure('xla')(fn)


### PR DESCRIPTION
Fixes #84874
