### PR TITLE
[QNNPACK] Export cpuinfo-targets in clog CMakeLists

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/deps/clog/CMakeLists.txt
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/deps/clog/CMakeLists.txt
@@ -63,7 +63,7 @@ set_target_properties(clog PROPERTIES
   C_EXTENSIONS NO)
 CLOG_TARGET_RUNTIME_LIBRARY(clog)
 set_target_properties(clog PROPERTIES PUBLIC_HEADER include/clog.h)
-target_include_directories(clog BEFORE PUBLIC include)
+target_include_directories(clog PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 if(CLOG_LOG_TO_STDIO)
   target_compile_definitions(clog PRIVATE CLOG_LOG_TO_STDIO=1)
 else()
@@ -73,7 +73,10 @@ if(ANDROID AND NOT CLOG_LOG_TO_STDIO)
   target_link_libraries(clog PRIVATE log)
 endif()
 
+add_library(cpuinfo::clog ALIAS clog)
+
 install(TARGETS clog
+  EXPORT cpuinfo-targets
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")


### PR DESCRIPTION
Summary:
Fixes the following error when building qnnpack:
```
CMake Error: install(EXPORT "cpuinfo-targets" ...) includes target "cpuinfo" which requires target "clog" that is not in any export set.
```

This diff mirrors the changes to the CMakeLists of
https://github.com/pytorch/cpuinfo/pull/69

Test Plan:
# Build Qnnpack
```
export ANDROID_NDK=/opt/android_ndk/r20
export ANDROID_NDK_HOME=${ANDROID_NDK}
export ANDROID_SDK=/opt/android_sdk
export ANDROID_HOME=${ANDROID_SDK}

cd ~/fbsource/fbcode/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack

./scripts/build-android-arm64.sh
```
Succeeds

Differential Revision: D39438768

