### PR TITLE
[BE][PT-D] Fix race on checkpoint file

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -5093,6 +5093,7 @@ class DistributedTest:
 
             self.assertEqual(averager2.step, 0)
 
+            dist.barrier()
             if self.rank == 0:
                 os.remove(chkpt_file)
 
@@ -9011,6 +9012,7 @@ class DistributedTest:
             for orig_param, dummy_param in zip(ddp_model.parameters(), dummy_ddp_model.parameters()):
                 self.assertEqual(orig_param.grad, dummy_param.grad)
 
+            dist.barrier()
             if rank == 0:
                 os.remove(chkpt_file)
 


### PR DESCRIPTION
Without calling `dist.barrier()` before removing the checkpoint file, rank 0 may run ahead and delete the checkpoint file before nonzero ranks are able to load from the checkpoint.

This PR adds a `dist.barrier()` to ensure all ranks can load the checkpoint before rank 0 deletes it.

For example, including the added `dist.barrier()`:
https://github.com/pytorch/pytorch/blob/037e8eefcf0b669430211b83d19aedf2185ed6fc/torch/testing/_internal/distributed/distributed_test.py#L5068-L5098