### PR TITLE
Enable manual test config label selection on GHA macos

### DIFF
--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -33,6 +33,18 @@ on:
         default: "3.8"
         description: |
           The python version to be used. Will be 3.8 by default
+      test-matrix:
+        required: false
+        type: string
+        description: |
+          An option JSON description of what test configs to run later on. This
+          is moved here from the Linux test workflow so that we can apply filter
+          logic using test-config labels earlier and skip unnecessary builds
+
+    outputs:
+      test-matrix:
+        value: ${{ inputs.test-matrix }}
+        description: An optional JSON description of what test configs to run later on.
 
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID:
@@ -90,7 +102,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Apply the filter logic to the build step too if the test-config label is already there
+      - name: Select all requested test configurations (if the test matrix is available)
+        id: filter
+        uses: ./.github/actions/filter-test-configs
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          test-matrix: ${{ inputs.test-matrix }}
+
       - name: Build
+        if: steps.filter.outputs.is-test-matrix-empty == 'False' || inputs.test-matrix == ''
+        id: build
         env:
           OUR_GITHUB_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
         run: |
@@ -98,13 +120,13 @@ jobs:
           ${CONDA_RUN} .jenkins/pytorch/macos-build.sh
 
       - name: Archive artifacts into zip
-        if: inputs.build-generates-artifacts
+        if: inputs.build-generates-artifacts && steps.build.outcome != 'skipped'
         run: |
           zip -1 -r artifacts.zip dist/ build/.ninja_log build/compile_commands.json .pytorch-test-times.json
 
       - name: Store PyTorch Build Artifacts on GHA
         uses: actions/upload-artifact@v2
-        if: inputs.build-generates-artifacts
+        if: inputs.build-generates-artifacts && steps.build.outcome != 'skipped'
         with:
           name: ${{ env.BUILD_ENVIRONMENT }}
           retention-days: 14
@@ -114,7 +136,7 @@ jobs:
       - name: Upload sccache stats to GHA
         uses: actions/upload-artifact@v2
         # Only if sccache is installed, see above
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && steps.build.outcome != 'skipped' }}
         with:
           name: sccache-stats-${{ inputs.build-environment }}-runattempt${{ github.run_attempt }}-${{ steps.get-job-id.outputs.job-id }}
           retention-days: 14

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -45,6 +45,9 @@ on:
       test-matrix:
         value: ${{ inputs.test-matrix }}
         description: An optional JSON description of what test configs to run later on.
+      build-outcome:
+        value: ${{ jobs.build.outputs.build-outcome }}
+        description: The outcome of the build step. This is used to influence test filtering logic later on.
 
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID:
@@ -64,6 +67,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
       BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
+    outputs:
+      build-outcome: ${{ steps.build.outcome }}
     steps:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -6,7 +6,7 @@ on:
       build-environment:
         required: true
         type: string
-        description: Top-level label for whats being built/tested.
+        description: Top-level label for what's being built/tested.
       sync-tag:
         required: false
         type: string

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -32,21 +32,17 @@ jobs:
           git clean -fxd
 
       - name: Download build artifacts
-        id: download-build-artifacts
         uses: ./.github/actions/download-build-artifacts
         with:
           name: ${{ inputs.build-environment }}
           use-gha: true
-        continue-on-error: true
 
       - name: Setup miniconda
-        if: steps.download-build-artifacts.outcome == 'success'
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
           python-version: 3.9
 
       - name: Install PyTorch
-        if: steps.download-build-artifacts.outcome == 'success'
         env:
           ENV_NAME: conda-test-env-${{ github.run_id }}
           PY_VERS: 3.9
@@ -60,7 +56,6 @@ jobs:
           ${CONDA_RUN} python3 -mpip install dist/*.whl
 
       - name: Run MPS tests
-        if: steps.download-build-artifacts.outcome == 'success'
         env:
           ENV_NAME: conda-test-env-${{ github.run_id }}
         shell: arch -arch arm64 bash {0}

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -6,7 +6,7 @@ on:
       build-environment:
         required: true
         type: string
-        description: Top-level label for what's being built/tested.
+        description: Top-level label for whats being built/tested.
       sync-tag:
         required: false
         type: string
@@ -32,17 +32,21 @@ jobs:
           git clean -fxd
 
       - name: Download build artifacts
+        id: download-build-artifacts
         uses: ./.github/actions/download-build-artifacts
         with:
           name: ${{ inputs.build-environment }}
           use-gha: true
+        continue-on-error: true
 
       - name: Setup miniconda
+        if: steps.download-build-artifacts.outcome == 'success'
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
           python-version: 3.9
 
       - name: Install PyTorch
+        if: steps.download-build-artifacts.outcome == 'success'
         env:
           ENV_NAME: conda-test-env-${{ github.run_id }}
           PY_VERS: 3.9
@@ -56,6 +60,7 @@ jobs:
           ${CONDA_RUN} python3 -mpip install dist/*.whl
 
       - name: Run MPS tests
+        if: steps.download-build-artifacts.outcome == 'success'
         env:
           ENV_NAME: conda-test-env-${{ github.run_id }}
         shell: arch -arch arm64 bash {0}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -33,16 +33,38 @@ on:
         description: secret acess key for test stats upload
 
 jobs:
+  # This needs to be run right before the test starts so that it can gather the
+  # latest labels from the PR
+  filter:
+    runs-on: [self-hosted, linux.large]
+    outputs:
+      test-matrix: ${{ steps.filter.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ steps.filter.outputs.is-test-matrix-empty }}
+    steps:
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+        with:
+          fetch-depth: 1
+          submodules: false
+
+      - name: Select all requested test configurations
+        id: filter
+        uses: ./.github/actions/filter-test-configs
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          test-matrix: ${{ inputs.test-matrix }}
+
   test:
-    # Don't run on forked repos.
-    if: github.repository_owner == 'pytorch'
+    needs: filter
+    # Don't run on forked repos or empty test matrix
+    if: github.repository_owner == 'pytorch' && needs.filter.outputs.is-test-matrix-empty == 'False'
     # For setup-miniconda, see https://github.com/conda-incubator/setup-miniconda/issues/179
     # Also ensure that we always run with the right architecture
     defaults:
       run:
         shell: arch -arch ${{ inputs.arch }} bash -e -l {0}
     strategy:
-      matrix: ${{ fromJSON(inputs.test-matrix) }}
+      matrix: ${{ fromJSON(needs.filter.outputs.test-matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 240

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -199,7 +199,7 @@ jobs:
     name: macos-12-py3-arm64-mps
     uses: ./.github/workflows/_mac-test-mps.yml
     needs: macos-12-py3-arm64-build
-    if: macos-12-py3-arm64-build.outputs.build-outcome == 'success'
+    if: needs.macos-12-py3-arm64-build.outputs.build-outcome == 'success'
     with:
       sync-tag: macos-12-py3-arm64-mps-test
       build-environment: macos-12-py3-arm64

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -141,6 +141,12 @@ jobs:
       xcode-version: "13.3.1"
       runner-type: macos-12-xl
       build-generates-artifacts: true
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 2, runner: "macos-12" },
+          { config: "default", shard: 2, num_shards: 2, runner: "macos-12" },
+          { config: "functorch", shard: 1, num_shards: 1, runner: "macos-12" },
+        ]}
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
@@ -151,12 +157,7 @@ jobs:
     needs: macos-12-py3-x86-64-build
     with:
       build-environment: macos-12-py3-x86-64
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "macos-12" },
-          { config: "default", shard: 2, num_shards: 2, runner: "macos-12" },
-          { config: "functorch", shard: 1, num_shards: 1, runner: "macos-12" },
-        ]}
+      test-matrix: ${{ needs.macos-12-py3-x86-64-build.outputs.test-matrix }}
       arch: x86_64
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
@@ -185,6 +186,11 @@ jobs:
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
       python_version: 3.9.12
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 2, runner: "macos-m1-12" },
+          { config: "default", shard: 2, num_shards: 2, runner: "macos-m1-12" },
+        ]}
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
@@ -203,11 +209,7 @@ jobs:
     needs: macos-12-py3-arm64-build
     with:
       build-environment: macos-12-py3-arm64
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "macos-m1-12" },
-          { config: "default", shard: 2, num_shards: 2, runner: "macos-m1-12" },
-        ]}
+      test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
       arch: arm64
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -199,6 +199,7 @@ jobs:
     name: macos-12-py3-arm64-mps
     uses: ./.github/workflows/_mac-test-mps.yml
     needs: macos-12-py3-arm64-build
+    if: macos-12-py3-arm64-build.outputs.build-outcome == 'success'
     with:
       sync-tag: macos-12-py3-arm64-mps-test
       build-environment: macos-12-py3-arm64


### PR DESCRIPTION
Following up with https://github.com/pytorch/pytorch/pull/83690 and https://github.com/pytorch/pytorch/pull/84669, functorch team has started using the new label in some of their [PRs](https://github.com/pytorch/pytorch/labels/test-config%2Ffunctorch).  This is to enable manual test config using label on GHA macos.

This also works with `ciflow/mps` as follows:

* If only `test-config/functorch` is present, no arm64 build is performed and mps test is skipped
* If only `ciflow/mps` is present, mps test is run in addition to all other tests
* If both `test-config/functorch` and `ciflow/mps` is present, both functorch and mps tests are run
* If none of the label is present, pull workflow is run as usual

### Issues
#82367
