### PR TITLE
SymInt support for multiply_integers

### DIFF
--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -6,6 +6,7 @@
 #include <c10/util/intrusive_ptr.h>
 
 #include <memory>
+#include <numeric>
 
 namespace c10 {
 
@@ -184,6 +185,20 @@ class C10_API SymInt {
 };
 
 #undef SKIP_IS_SYMBOLIC_ON_MOBILE
+
+/// Sum of a list of SymInt; accumulates into the c10::SymInt expression
+template <
+    typename C,
+    typename std::enable_if<
+        std::is_same<typename C::value_type, c10::SymInt>::value,
+        int>::type = 0>
+inline c10::SymInt multiply_integers(const C& container) {
+  return std::accumulate(
+      container.begin(),
+      container.end(),
+      c10::SymInt(1),
+      [](c10::SymInt a, c10::SymInt b) { return a * b; });
+}
 
 C10_API std::ostream& operator<<(std::ostream& os, SymInt s);
 } // namespace c10

--- a/c10/util/accumulate.h
+++ b/c10/util/accumulate.h
@@ -11,20 +11,6 @@
 
 namespace c10 {
 
-/// Sum of a list of SymInt; accumulates into the c10::SymInt expression
-template <
-    typename C,
-    typename std::enable_if<
-        std::is_same<typename C::value_type, c10::SymInt>::value,
-        int>::type = 0>
-inline c10::SymInt multiply_integers(const C& container) {
-  return std::accumulate(
-      container.begin(),
-      container.end(),
-      c10::SymInt(1),
-      [](c10::SymInt a, c10::SymInt b) { return a * b; });
-}
-
 /// Sum of a list of integers; accumulates into the int64_t datatype
 template <
     typename C,

--- a/c10/util/accumulate.h
+++ b/c10/util/accumulate.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <c10/core/SymInt.h>
 #include <c10/util/ArrayRef.h>
 
 #include <iterator>

--- a/c10/util/accumulate.h
+++ b/c10/util/accumulate.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <c10/core/SymInt.h>
 #include <c10/util/ArrayRef.h>
 
 #include <iterator>
@@ -9,6 +10,20 @@
 #include <type_traits>
 
 namespace c10 {
+
+/// Sum of a list of SymInt; accumulates into the c10::SymInt expression
+template <
+    typename C,
+    typename std::enable_if<
+        std::is_same<typename C::value_type, c10::SymInt>::value,
+        int>::type = 0>
+inline c10::SymInt multiply_integers(const C& container) {
+  return std::accumulate(
+      container.begin(),
+      container.end(),
+      c10::SymInt(1),
+      [](c10::SymInt a, c10::SymInt b) { return a * b; });
+}
 
 /// Sum of a list of integers; accumulates into the int64_t datatype
 template <


### PR DESCRIPTION
These helpers are used in symintifying `reshape`. Ported from [symbolic-shapes](https://github.com/pytorch/pytorch/tree/symbolic-shapes) branch 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #84905
* __->__ #84904
* #84903

