### PR TITLE
Avoid throwing an exception when ScriptList doesn't match.

### DIFF
--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -209,10 +209,8 @@ IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_t> N) {
     case TypeKind::ListType: {
       // If the object is a ScriptList, retrieve the c10::List
       // instance inside it.
-      try {
-        auto script_list = py::cast<ScriptList>(obj);
-        return script_list.list_;
-      } catch (...) {
+      if (py::isinstance<ScriptList>(obj)) {
+        return py::cast<ScriptList>(obj).list_;
       }
 
       // If not (i.e. it is a regular Python list), make a new


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #84921
* #84919

This prevents 'catch throw' gdb breakpoint pollution and
should also improve performance.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>