### PR TITLE
[MPS] Fix mps to cpu casting from a smaller dtype to a bigger dtype

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -36,7 +36,7 @@ void* pageAlignedBlockPtr(
 // Copy sourceBuffer into destBuffer, casting sourceBuffer to src.scalar_type().
 // The shapes and dtypes are taken from dst and src, but their storage pointers are not used.
 void copy_cast_mps(at::Tensor& dst, const at::Tensor& src,
-                   id<MTLBuffer> destBuffer, id<MTLBuffer> sourceBuffer) {
+                   id<MTLBuffer> destBuffer, id<MTLBuffer> sourceBuffer, bool non_blocking = true) {
   using namespace mps;
 
   struct CachedGraph : public MPSCachedGraph
@@ -84,6 +84,8 @@ void copy_cast_mps(at::Tensor& dst, const at::Tensor& src,
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{cachedGraph->inputTensor_: srcData};
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{cachedGraph->outputTensor_: dstData};
     runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    if (!non_blocking)
+      stream->synchronize(SyncType::COMMIT_AND_WAIT);
   }
 }
 
@@ -113,38 +115,52 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
     src = src_;
   }
   id<MTLBuffer> sourceBuffer = getMTLBufferStorage(src);
-  size_t src_total_size = src_.is_view() ? at::detail::computeStorageNbytesContiguous(src.sizes(), src.element_size(), src.storage_offset()) :
-                                           src.nbytes();
-  size_t size_to_copy = src.nbytes();
-
-  // In case of dtype change, first convert src inplace
-  if (src_.dtype() != dst_.dtype()) {
-    copy_cast_mps(dst, src, sourceBuffer, sourceBuffer);
-    // Use the element size of dst to calculate the total size after casting
-    size_to_copy = (size_to_copy / src.element_size()) * dst.element_size();
-  }
-
-  // If there's anything wrong with source, we shouldn't return dst_ silently and must error out.
-  TORCH_INTERNAL_ASSERT(sourceBuffer && size_to_copy > 0);
-  TORCH_INTERNAL_ASSERT(src_total_size >= storage_byte_offset);
-  TORCH_INTERNAL_ASSERT(dst.nbytes() >= (dst.storage_offset() * dst.element_size()));
+  size_t dst_tensor_nbytes = dst.nbytes();
 
   @autoreleasepool {
     MTLResourceOptions options = MTLResourceOptionCPUCacheModeDefault | MTLResourceStorageModeShared;
     NSUInteger alignedLength = 0;
 
     void* host_dst = dst.storage().data();
-    void* alignedPtr = pageAlignedBlockPtr(host_dst, (NSUInteger)src_total_size, &alignedLength);
+    void* alignedPtr = pageAlignedBlockPtr(host_dst, (NSUInteger)dst_tensor_nbytes, &alignedLength);
+    NSUInteger destOffset = (uintptr_t(host_dst) - uintptr_t(alignedPtr));
+    // 4 bytes alignment required on macos for blits.
+    TORCH_INTERNAL_ASSERT(destOffset % 4 == 0, "Unaligned blit request");
+
     id<MTLBuffer> destBuffer = [device newBufferWithBytesNoCopy:alignedPtr
                                                          length:alignedLength
                                                         options:options
                                                     deallocator:nil];
-     NSUInteger destOffset = uintptr_t(host_dst) - uintptr_t(alignedPtr);
-    // 4 bytes alignment required on macos for blits.
-    TORCH_INTERNAL_ASSERT(destOffset % 4 == 0, "Unaligned blit request");
+    id<MTLBuffer> tmpBuffer = sourceBuffer;
+    Tensor tmp;
+    bool needsBlit = true;
+    if (src_.dtype() != dst.dtype()) {
+      if (destOffset == 0 && storage_byte_offset == 0) {
+        // Return the casted tensor directly if there's no destination offset
+        needsBlit = false;
+        tmpBuffer = destBuffer;
+      } else if (src.element_size() < dst.element_size()) {
+          tmp = at::native::empty_mps(dst.sizes(), dst.scalar_type(), c10::nullopt, kMPS);
+          tmpBuffer = getMTLBufferStorage(tmp);
+      }
+    }
 
-    stream->copy_and_sync(sourceBuffer, destBuffer, size_to_copy, storage_byte_offset, destOffset, non_blocking);
-    [destBuffer release];
+    size_t size_to_copy = src.nbytes();
+    // In case of dtype change, first convert src inplace
+    if (src_.dtype() != dst.dtype()) {
+      copy_cast_mps(dst, src, tmpBuffer, sourceBuffer, non_blocking);
+    }
+
+    if (needsBlit) {
+      size_to_copy = (size_to_copy / src.element_size()) * dst.element_size();
+
+      // If there's anything wrong with source, we shouldn't return dst_ silently and must error out.
+      TORCH_INTERNAL_ASSERT(sourceBuffer && dst_tensor_nbytes > 0);
+      TORCH_INTERNAL_ASSERT(dst_tensor_nbytes >= (dst.storage_offset() * dst.element_size()));
+
+      stream->copy_and_sync(tmpBuffer, destBuffer, size_to_copy, storage_byte_offset, destOffset, non_blocking);
+      [destBuffer release];
+    }
   }
   if (!dst.is_same(dst_)) {
     dst_.copy_(dst, non_blocking);
@@ -235,17 +251,29 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
   } else {
     src = src_;
   }
+  id<MTLBuffer> destBuffer = getMTLBufferStorage(dst_);
+  id<MTLBuffer> sourceBuffer = getMTLBufferStorage(src);
+
   // Scatter to `dst` if the memory is not contiguous
   // If the memory is not contiguous, it means that the tensor has strides and we would not be
   // able to do the copy using a single blit
   if (!dst_.is_contiguous()) {
-    return scatterViewTensor(src, dst_);
+    Tensor tmp;
+    if (src.dtype() != dst_.dtype()) {
+      id<MTLBuffer> tmpBuffer = sourceBuffer;
+      if (src.element_size() < dst_.element_size()) {
+        tmp = at::native::empty_mps(dst_.sizes(), dst_.scalar_type(), c10::nullopt, kMPS);
+        tmpBuffer = getMTLBufferStorage(tmp);
+      }
+
+      copy_cast_mps(dst_, src, tmpBuffer, sourceBuffer);
+    }
+
+    return scatterViewTensor((src.dtype() != dst_.dtype() && tmp.has_storage()) ? tmp : src, dst_);
   }
   src._set_conj(src_.is_conj());
   src._set_neg(src_.is_neg());
 
-  id<MTLBuffer> destBuffer = getMTLBufferStorage(dst_);
-  id<MTLBuffer> sourceBuffer = getMTLBufferStorage(src);
   const size_t src_size = src.nbytes();
   if (src.dtype() == dst_.dtype()) {
     MPSStream* stream = getCurrentMPSStream();

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -823,7 +823,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(
   const int normalized_ndim = normalized_shape.size();
   // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
   const int axis = input_ndim - normalized_ndim;
-  at::Tensor input_reshaped = input.view({1, M, -1});
+  at::Tensor input_reshaped = input.reshape({1, M, -1});
   // Unlike Batch Normalization, which applies scalar scale and bias for each
   // entire channel/plane with the affine option, Layer Normalization applies
   // per-element scale and bias. E.g. For input {N, C, H, W}, weight for

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3846,7 +3846,7 @@ class TestNLLLoss(TestCase):
 
     def test_cast_mps_to_cpu(self):
         def helper(src_dtype, dst_dtype):
-            input = torch.rand((1,3,128,128), dtype=src_dtype)
+            input = torch.rand((1, 3, 128, 128), dtype=src_dtype)
             input_cast_mps = input.to('mps')
             input_cast_cpu = input_cast_mps.to('cpu', dtype=dst_dtype)
 
@@ -3857,7 +3857,7 @@ class TestNLLLoss(TestCase):
 
     def test_cast_mps_to_mps(self):
         def helper(src_dtype, dst_dtype):
-            input_cpu = torch.rand((1,3,128,128), dtype=src_dtype)
+            input_cpu = torch.rand((1, 3, 128, 128), dtype=src_dtype)
             input_mps = input_cpu.to('mps')
             output_mps = input_mps.to(dtype=dst_dtype)
             output_cpu = input_cpu.to(dtype=dst_dtype)
@@ -5096,7 +5096,7 @@ class TestGatherScatter(TestCase):
 
     def test_cast_gather_scatter(self):
         for _ in range(0, 50):
-            input = np.random.randint(0, 255, size=(5, 5, 4), dtype = np.uint8)
+            input = np.random.randint(0, 255, size=(5, 5, 4), dtype=np.uint8)
             with torch.no_grad():
                 s = torch.tensor(input, dtype=torch.uint8, device="mps").unsqueeze(0)
                 s_cpu = torch.tensor(input, dtype=torch.uint8, device="cpu").unsqueeze(0)
@@ -5104,7 +5104,7 @@ class TestGatherScatter(TestCase):
                 s_cpu = s_cpu.long()
                 self.assertEqual(s.cpu(), s_cpu)
 
-                s= s.float()
+                s = s.float()
                 s_cpu = s_cpu.float()
                 self.assertEqual(s.cpu(), s_cpu)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3844,6 +3844,29 @@ class TestNLLLoss(TestCase):
         for shape in [[], (2, 3), (2, 8, 4, 5)]:
             helper(shape)
 
+    def test_cast_mps_to_cpu(self):
+        def helper(src_dtype, dst_dtype):
+            input = torch.rand((1,3,128,128), dtype=src_dtype)
+            input_cast_mps = input.to('mps')
+            input_cast_cpu = input_cast_mps.to('cpu', dtype=dst_dtype)
+
+            # needs to match the initial Tensor
+            self.assertEqual(input_cast_cpu, input.to(dtype=dst_dtype))
+        helper(torch.half, torch.float)
+        helper(torch.float, torch.half)
+
+    def test_cast_mps_to_mps(self):
+        def helper(src_dtype, dst_dtype):
+            input_cpu = torch.rand((1,3,128,128), dtype=src_dtype)
+            input_mps = input_cpu.to('mps')
+            output_mps = input_mps.to(dtype=dst_dtype)
+            output_cpu = input_cpu.to(dtype=dst_dtype)
+            self.assertEqual(output_mps.cpu(), output_cpu)
+        helper(torch.half, torch.float)
+        helper(torch.float, torch.half)
+        helper(torch.half, torch.long)
+        helper(torch.float, torch.int)
+
     # Test adaptive avg pool2d - when the input size is a multiple of output size
     # Not testing for channels last right now
     def test_adaptive_avg_pool2d_simple(self):
@@ -5070,6 +5093,24 @@ class TestGatherScatter(TestCase):
         x_cpu[::2] = 1.0
 
         self.assertEqual(x_cpu, x_mps)
+
+    def test_cast_gather_scatter(self):
+        for _ in range(0, 50):
+            input = np.random.randint(0, 255, size=(5, 5, 4), dtype = np.uint8)
+            with torch.no_grad():
+                s = torch.tensor(input, dtype=torch.uint8, device="mps").unsqueeze(0)
+                s_cpu = torch.tensor(input, dtype=torch.uint8, device="cpu").unsqueeze(0)
+                s = s.long()
+                s_cpu = s_cpu.long()
+                self.assertEqual(s.cpu(), s_cpu)
+
+                s= s.float()
+                s_cpu = s_cpu.float()
+                self.assertEqual(s.cpu(), s_cpu)
+
+                s /= 255
+                s_cpu /= 255
+                self.assertEqual(s.cpu(), s_cpu)
 
     def test_slicing_replace_column(self):
         # https://github.com/pytorch/pytorch/issues/78074


### PR DESCRIPTION
Fixes #82566 , #80800 

- mps->cpu casts from a smaller dtype to a bigger dtype mps->mps cast from smaller/bigger dtype to another dtype in case of scatter 
- For mps->cpu copies where we don't have a source/destination offset, we can save the cast result directly in the destTensor, so we can skip the additional overhead of the blit. 
- In case we can return the data without doing the blit, we need to check if it's blocking call, case in which we'd need a synchronize(SyncType::COMMIT_AND_WAIT); call (previously this was done by the blit).

