### PR TITLE
Grammatically updated the tech docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,11 +18,8 @@ Features described in this documentation are classified by release status:
   breaking changes can happen and notice will be given one release ahead
   of time).
 
-  *Beta:*  These features are tagged as Beta because the API may change based on
-  user feedback, because the performance needs to improve, or because
-  coverage across operators is not yet complete. For Beta features, we are
-  committing to seeing the feature through to the Stable classification.
-  We are not, however, committing to backwards compatibility.
+  *Beta:*  These features are tagged as Beta because the API may change for several reasons, such as user feedback, the performance needs improvement, or coverage across operators is not yet complete. For Beta features, we are committed to seeing them through to the Stable designation. 
+   are not, however, committing to backward compatibility.
 
   *Prototype:*  These features are typically not available as part of
   binary distributions like PyPI or Conda, except sometimes behind run-time


### PR DESCRIPTION
Small grammatical update to the torch tech docs.


![Pytorch](https://user-images.githubusercontent.com/109078860/189973873-780989a7-42f1-4482-9a8f-f9a606752aac.png)
