### PR TITLE
Removed now unnecessary extra compile arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -794,10 +794,6 @@ def configure_extension_build():
             # http://legacy.python.org/dev/peps/pep-3123/
             # We also depend on it in our code (even Python 3).
             '-fno-strict-aliasing',
-            # Clang has an unfixed bug leading to spurious missing
-            # braces warnings, see
-            # https://bugs.llvm.org/show_bug.cgi?id=21629
-            '-Wno-missing-braces',
         ]
 
     library_dirs.append(lib_path)


### PR DESCRIPTION
The `-Wno-missing-braces` argument was added in https://github.com/pytorch/pytorch/commit/67612cba09605b3a8abbc7c528def64d2cdba21c. However, since then, the issue with Clang appears to have been resolved (https://bugs.llvm.org/show_bug.cgi?id=21629.), making this extra complier argument unnecessary.

Note: the fix is only implemented in Clang version 6.0.0 and greater.