### PR TITLE
Make addmm meta kernel consistent with mm

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -48,6 +48,8 @@ namespace detail {
 namespace meta {
 
 #define ADDMM_META() \
+  TORCH_CHECK(self.scalar_type() == mat2.scalar_type(), "self and mat2 must have the same dtype"); \
+  TORCH_CHECK(mat1.scalar_type() == mat2.scalar_type(), "mat1 and mat2 must have the same dtype"); \
   TORCH_CHECK(mat1.dim() == 2, "mat1 must be a matrix, got ", mat1.dim(), "-D tensor"); \
   TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix, got ", mat2.dim(), "-D tensor"); \
   TORCH_CHECK( \

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -48,20 +48,20 @@ namespace detail {
 namespace meta {
 
 #define ADDMM_META() \
-  TORCH_CHECK(self.dim() == 2, "self must be a matrix, got ", self.dim(), "-D tensor"); \
+  TORCH_CHECK(mat1.dim() == 2, "mat1 must be a matrix, got ", mat1.dim(), "-D tensor"); \
   TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix, got ", mat2.dim(), "-D tensor"); \
   TORCH_CHECK( \
-      self.sizes()[1] == mat2.sizes()[0], "mat1 and mat2 shapes cannot be multiplied (", \
-      self.sizes()[0], "x", self.sizes()[1], " and ", mat2.sizes()[0], "x", mat2.sizes()[1], ")"); \
+      mat1.sizes()[1] == mat2.sizes()[0], "mat1 and mat2 shapes cannot be multiplied (", \
+      mat1.sizes()[0], "x", mat1.sizes()[1], " and ", mat2.sizes()[0], "x", mat2.sizes()[1], ")"); \
  \
-  auto names = at::namedinference::propagate_names_for_addmm(self, mat2, mat1); \
-  set_output_raw_strided(0, {self.sizes()[0], mat2.sizes()[1]}, {}, self.options(), names);
+  auto names = at::namedinference::propagate_names_for_addmm(mat1, mat2, self); \
+  set_output_raw_strided(0, {mat1.sizes()[0], mat2.sizes()[1]}, {}, mat1.options(), names);
 
-TORCH_META_FUNC(addmm)(const Tensor& mat1, const Tensor& self, const Tensor& mat2, const Scalar& beta, const Scalar& alpha) {
+TORCH_META_FUNC(addmm)(const Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha) {
   ADDMM_META();
 }
 
-TORCH_META_FUNC(_addmm_activation)(const Tensor& mat1, const Tensor& self, const Tensor& mat2, const Scalar& beta, const Scalar& alpha, bool use_gelu) {
+TORCH_META_FUNC(_addmm_activation)(const Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha, bool use_gelu) {
   ADDMM_META();
 }
 

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -48,20 +48,20 @@ namespace detail {
 namespace meta {
 
 #define ADDMM_META() \
-  TORCH_CHECK(mat1.dim() == 2, "mat1 must be a matrix, got ", mat1.dim(), "-D tensor"); \
+  TORCH_CHECK(self.dim() == 2, "self must be a matrix, got ", self.dim(), "-D tensor"); \
   TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix, got ", mat2.dim(), "-D tensor"); \
   TORCH_CHECK( \
-      mat1.sizes()[1] == mat2.sizes()[0], "mat1 and mat2 shapes cannot be multiplied (", \
-      mat1.sizes()[0], "x", mat1.sizes()[1], " and ", mat2.sizes()[0], "x", mat2.sizes()[1], ")"); \
+      self.sizes()[1] == mat2.sizes()[0], "mat1 and mat2 shapes cannot be multiplied (", \
+      self.sizes()[0], "x", self.sizes()[1], " and ", mat2.sizes()[0], "x", mat2.sizes()[1], ")"); \
  \
-  auto names = at::namedinference::propagate_names_for_addmm(mat1, mat2, self); \
-  set_output_raw_strided(0, {mat1.sizes()[0], mat2.sizes()[1]}, {}, self.options(), names);
+  auto names = at::namedinference::propagate_names_for_addmm(self, mat2, mat1); \
+  set_output_raw_strided(0, {self.sizes()[0], mat2.sizes()[1]}, {}, self.options(), names);
 
-TORCH_META_FUNC(addmm)(const Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha) {
+TORCH_META_FUNC(addmm)(const Tensor& mat1, const Tensor& self, const Tensor& mat2, const Scalar& beta, const Scalar& alpha) {
   ADDMM_META();
 }
 
-TORCH_META_FUNC(_addmm_activation)(const Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha, bool use_gelu) {
+TORCH_META_FUNC(_addmm_activation)(const Tensor& mat1, const Tensor& self, const Tensor& mat2, const Scalar& beta, const Scalar& alpha, bool use_gelu) {
   ADDMM_META();
 }
 

--- a/test/lazy/test_meta_kernel.py
+++ b/test/lazy/test_meta_kernel.py
@@ -17,21 +17,18 @@ class TestMetaKernel(TestCase):
 
         fc_nobias = torch.nn.Linear(2, 2, bias=False, dtype=float32).to("lazy")
 
-        try:
+        with self.assertRaises(Exception):
             out_nobias = fc_nobias(input)
-            self.assertTrue(False)  # Should never reach here as the above line should throw exception
-        except Exception as e:
-            self.assertTrue(True)
 
     def test_addmm(self):
         """Tests that the addmm meta kernel returns the correct output type"""
         input = torch.ones(2, 2, dtype=torch.float16).to("lazy")
-        self.assertTrue(input.dtype == torch.float16)
+        self.assertEqual(input.dtype, torch.float16)
 
         fc_nobias = torch.nn.Linear(2, 2, bias=False, dtype=float16).to("lazy")
         out_nobias = fc_nobias(input)
-        self.assertTrue(out_nobias.dtype == torch.float16)
+        self.assertEqual(out_nobias.dtype, torch.float16)
 
         fc_bias = torch.nn.Linear(2, 2, bias=True, dtype=float16).to("lazy")
         out_bias = fc_bias(input)
-        self.assertTrue(out_bias.dtype == torch.float16)
+        self.assertEqual(out_bias.dtype, torch.float16)

--- a/test/lazy/test_meta_kernel.py
+++ b/test/lazy/test_meta_kernel.py
@@ -1,0 +1,24 @@
+# Owner(s): ["oncall: jit"]
+
+import torch
+
+from torch.testing._internal.common_utils import TestCase
+import torch._lazy
+import torch._lazy.ts_backend
+
+torch._lazy.ts_backend.init()
+
+class TestMetaKernel(TestCase):
+
+    def test_mixed_precision_addmm(self):
+        """Tests that the addmm meta kernel returns the correct output type"""
+        input = torch.ones(2, 2, dtype=torch.float16).to("lazy")
+        self.assertTrue(input.dtype == torch.float16)
+
+        fc_nobias = torch.nn.Linear(2, 2, bias=False, dtype=float32).to("lazy")
+        out_nobias = fc_nobias(input)
+        self.assertTrue(out_nobias.dtype == torch.float16)
+
+        fc_bias = torch.nn.Linear(2, 2, bias=True, dtype=float32).to("lazy")
+        out_bias = fc_bias(input)
+        self.assertTrue(out_bias.dtype == torch.float16)

--- a/test/lazy/test_meta_kernel.py
+++ b/test/lazy/test_meta_kernel.py
@@ -10,15 +10,28 @@ torch._lazy.ts_backend.init()
 
 class TestMetaKernel(TestCase):
 
-    def test_mixed_precision_addmm(self):
+    def test_addmm_invalid_dtype(self):
         """Tests that the addmm meta kernel returns the correct output type"""
         input = torch.ones(2, 2, dtype=torch.float16).to("lazy")
         self.assertTrue(input.dtype == torch.float16)
 
         fc_nobias = torch.nn.Linear(2, 2, bias=False, dtype=float32).to("lazy")
+
+        try:
+            out_nobias = fc_nobias(input)
+            self.assertTrue(False)  # Should never reach here as the above line should throw exception
+        except Exception as e:
+            self.assertTrue(True)
+
+    def test_addmm(self):
+        """Tests that the addmm meta kernel returns the correct output type"""
+        input = torch.ones(2, 2, dtype=torch.float16).to("lazy")
+        self.assertTrue(input.dtype == torch.float16)
+
+        fc_nobias = torch.nn.Linear(2, 2, bias=False, dtype=float16).to("lazy")
         out_nobias = fc_nobias(input)
         self.assertTrue(out_nobias.dtype == torch.float16)
 
-        fc_bias = torch.nn.Linear(2, 2, bias=True, dtype=float32).to("lazy")
+        fc_bias = torch.nn.Linear(2, 2, bias=True, dtype=float16).to("lazy")
         out_bias = fc_bias(input)
         self.assertTrue(out_bias.dtype == torch.float16)


### PR DESCRIPTION
Change the names of the parameters in the `addmm` meta kernel to be more consistent with `mm`. Functionally, the only difference in behaviour should be that `addmm` meta kernel gets its options from the `input` tensor instead of from the `bias` parameter.

Fixes #84930

CC: @ezyang @ngimel @wconstab @ke1337 @glebk-cerebras
