### PR TITLE
[Profiler] add config option to remove 'Call stack' field from trace file

### DIFF
--- a/torch/_C/_profiler.pyi
+++ b/torch/_C/_profiler.pyi
@@ -35,6 +35,7 @@ class _ExperimentalConfig:
         self,
         profiler_metrics: List[str] = ...,
         profiler_measure_per_kernel: bool = ...,
+        verbose: bool = ...,
     ) -> None: ...
     ...
 

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -20,7 +20,9 @@ namespace profiler {
 using experimental_event_t = std::shared_ptr<torch::profiler::impl::Result>;
 
 struct TORCH_API KinetoEvent {
-  explicit KinetoEvent(std::shared_ptr<const torch::profiler::impl::Result>);
+  KinetoEvent(
+      std::shared_ptr<const torch::profiler::impl::Result>,
+      const bool verbose);
 
   uint64_t startThreadId() const;
   uint64_t endThreadId() const;

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -13,9 +13,11 @@ using GlobalManager = GlobalStateManager<ProfilerStateBase>;
 // ----------------------------------------------------------------------------
 ExperimentalConfig::ExperimentalConfig(
     std::vector<std::string> profiler_metrics,
-    bool profiler_measure_per_kernel)
+    bool profiler_measure_per_kernel,
+    bool verbose)
     : profiler_metrics{profiler_metrics},
-      profiler_measure_per_kernel{profiler_measure_per_kernel} {}
+      profiler_measure_per_kernel{profiler_measure_per_kernel},
+      verbose{verbose} {}
 
 /*explicit*/ ExperimentalConfig::operator bool() const {
   return !profiler_metrics.empty();

--- a/torch/csrc/profiler/orchestration/observer.h
+++ b/torch/csrc/profiler/orchestration/observer.h
@@ -39,12 +39,14 @@ enum class C10_API_ENUM ActiveProfilerType {
 struct TORCH_API ExperimentalConfig {
   ExperimentalConfig(
       std::vector<std::string> profiler_metrics = {},
-      bool profiler_measure_per_kernel = false);
+      bool profiler_measure_per_kernel = false,
+      bool verbose = true);
   ~ExperimentalConfig() = default;
   explicit operator bool() const;
 
   std::vector<std::string> profiler_metrics;
   bool profiler_measure_per_kernel;
+  bool verbose;
 };
 
 struct TORCH_API ProfilerConfig {

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -50,7 +50,8 @@ void initPythonBindings(PyObject* module) {
       .def(
           py::init<
               std::vector<std::string> /* profiler_metrics */,
-              bool /* profiler_measure_per_kernel */
+              bool /* profiler_measure_per_kernel */,
+              bool /* verbose */
               >(),
           "An experimental config for Kineto features. Please note that"
           "backward compatibility is not guaranteed.\n"
@@ -58,9 +59,11 @@ void initPythonBindings(PyObject* module) {
           "       to measure GPU performance events.\n"
           "       If this list contains values Kineto runs in CUPTI profiler mode\n"
           "    profiler_measure_per_kernel (bool) : whether to profile metrics per kernel\n"
-          "       or for the entire measurement duration.",
+          "       or for the entire measurement duration.\n"
+          "    verbose (bool) : whether the trace file has `Call stack` field or not.",
           py::arg("profiler_metrics") = std::vector<std::string>(),
-          py::arg("profiler_measure_per_kernel") = false)
+          py::arg("profiler_measure_per_kernel") = false,
+          py::arg("verbose") = true)
       .def(py::pickle(
           [](const ExperimentalConfig& p) { // __getstate__
             py::list py_metrics;
@@ -69,11 +72,12 @@ void initPythonBindings(PyObject* module) {
               py_metrics.append(mbytes);
             }
             /* Return a tuple that fully encodes the state of the config */
-            return py::make_tuple(py_metrics, p.profiler_measure_per_kernel);
+            return py::make_tuple(
+                py_metrics, p.profiler_measure_per_kernel, p.verbose);
           },
           [](py::tuple t) { // __setstate__
-            if (t.size() != 2) {
-              throw std::runtime_error("Expected 2 values in state");
+            if (t.size() != 3) {
+              throw std::runtime_error("Expected 3 values in state");
             }
 
             py::list py_metrics = t[0].cast<py::list>();
@@ -83,7 +87,8 @@ void initPythonBindings(PyObject* module) {
               metrics.push_back(py::str(py_metric));
             }
 
-            return ExperimentalConfig(std::move(metrics), t[1].cast<bool>());
+            return ExperimentalConfig(
+                std::move(metrics), t[1].cast<bool>(), t[2].cast<bool>());
           }));
 
   py::class_<ProfilerConfig>(m, "ProfilerConfig")


### PR DESCRIPTION
Summary: `Call stack` field increases trace file size exponentially for Python stack tracing (need to be deprecated carefully). Added a config option to avoid this increase.

Test Plan:
`experimental_config=_ExperimentalConfig(no_callstack_trace=True),` will remove the field.
+ CI tests

Differential Revision: D39489828

