### PR TITLE
Rework printing tensor aliases in CSAN error message

### DIFF
--- a/docs/source/cuda._sanitizer.rst
+++ b/docs/source/cuda._sanitizer.rst
@@ -44,7 +44,7 @@ the following output is printed by CSAN:
     CSAN detected a possible data race on tensor with data pointer 139719969079296
     Access by stream 94646435460352 during kernel:
     aten::mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
-    writing to argument: self, out, output
+    writing to argument: self, out, and to the output
     With stack trace:
       File "example_error.py", line 6, in <module>
         torch.mul(a, 5, out=a)
@@ -54,7 +54,7 @@ the following output is printed by CSAN:
 
     Previous access by stream 0 during kernel:
     aten::rand(int[] size, *, int? dtype=None, Device? device=None) -> Tensor
-    writing to argument: output
+    writing to the output
     With stack trace:
       File "example_error.py", line 3, in <module>
         a = torch.rand(10000, device="cuda")

--- a/docs/source/cuda._sanitizer.rst
+++ b/docs/source/cuda._sanitizer.rst
@@ -44,7 +44,7 @@ the following output is printed by CSAN:
     CSAN detected a possible data race on tensor with data pointer 139719969079296
     Access by stream 94646435460352 during kernel:
     aten::mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
-    writing to argument: self, out, and to the output
+    writing to argument(s) self, out, and to the output
     With stack trace:
       File "example_error.py", line 6, in <module>
         torch.mul(a, 5, out=a)

--- a/test/test_cuda_sanitizer.py
+++ b/test/test_cuda_sanitizer.py
@@ -481,14 +481,14 @@ class TestMessages(TestCase):
                 CSAN detected a possible data race on tensor with data pointer 1
                 Access by stream 1001 during kernel:
                 schema
-                writing to arguments: b, and to the output
+                writing to argument(s) b, and to the output
                 With stack trace:
                   File "file", line 0, in name
                     trace a
 
                 Previous access by stream 1000 during kernel:
                 schema
-                reading from arguments: a
+                reading from argument(s) a
                 With stack trace:
                   File "file", line 0, in name
                     trace b

--- a/test/test_cuda_sanitizer.py
+++ b/test/test_cuda_sanitizer.py
@@ -117,13 +117,14 @@ class TestArgumentHandler(TestCase):
         argument_handler.parse_outputs(out)
 
         self.assertEqual(
-            argument_handler.tensor_names,
+            argument_handler.tensor_aliases,
             {
                 M.data_ptr(): ["self"],
                 vec.data_ptr(): ["vec1", "vec2"],
-                out.data_ptr(): ["output"],
+                out.data_ptr(): [],
             },
         )
+        self.assertEqual({out.data_ptr()}, argument_handler.outputs)
 
 
 def tensor_id(i: int) -> DataPtr:
@@ -156,6 +157,7 @@ class TestEventHandler(TestCase):
             stream,
             read_only,
             read_write,
+            {},
             "",
             {k: [""] for k in read_only + read_write},
         )
@@ -446,7 +448,8 @@ class TestMessages(TestCase):
             seq_num=1,
             stream=stream_id(1),
             operator="schema",
-            names=["b"],
+            aliases=["b"],
+            is_output=True,
             stack_trace=traceback.StackSummary.from_list(
                 [("file", 0, "name", "trace a")]
             ),
@@ -456,7 +459,8 @@ class TestMessages(TestCase):
             seq_num=2,
             stream=stream_id(0),
             operator="schema",
-            names=["a"],
+            aliases=["a"],
+            is_output=False,
             stack_trace=traceback.StackSummary.from_list(
                 [("file", 0, "name", "trace b")]
             ),
@@ -477,14 +481,14 @@ class TestMessages(TestCase):
                 CSAN detected a possible data race on tensor with data pointer 1
                 Access by stream 1001 during kernel:
                 schema
-                writing to argument: b
+                writing to arguments: b, and to the output
                 With stack trace:
                   File "file", line 0, in name
                     trace a
 
                 Previous access by stream 1000 during kernel:
                 schema
-                reading from argument: a
+                reading from arguments: a
                 With stack trace:
                   File "file", line 0, in name
                     trace b


### PR DESCRIPTION
Small rework of how the error message is formatted, introduces a distinction between the arguments and the output of kernels. Verified manually on multiple examples that the message is printed as expected.