### PR TITLE
[ONNX] Enable test_custom_opsets_inverse

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -2,7 +2,6 @@
 
 import copy
 import io
-import unittest
 
 import onnx
 

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1154,16 +1154,15 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         self.assertEqual(graph.opset_import[1].domain, "com.microsoft")
 
     @skipIfNoLapack
-    @unittest.skip("It started failing after #80074")
     def test_custom_opsets_inverse(self):
         class CustomInverse(torch.nn.Module):
             def forward(self, x):
                 return torch.inverse(x) + x
 
-        def inverse(g, self):
+        def linalg_inv(g, self):
             return g.op("com.microsoft::Inverse", self).setType(self.type())
 
-        register_custom_op_symbolic("::inverse", inverse, 1)
+        register_custom_op_symbolic("::linalg_inv", linalg_inv, 1)
         model = CustomInverse()
         x = torch.randn(2, 3, 3)
         f = io.BytesIO()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #85013

in [#87004](https://github.com/pytorch/pytorch/pull/80074), `aten::inverse` becomes alias of `aten::linalg.inv`.