### PR TITLE
Change `torch.cuda.is_available` to use the new `device_count` function

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -85,7 +85,7 @@ def is_available() -> bool:
         return False
     # This function never throws and returns 0 if driver is missing or can't
     # be initialized
-    return torch._C._cuda_getDeviceCount() > 0
+    return device_count() > 0
 
 def is_bf16_supported():
     r"""Returns a bool indicating if the current CUDA/ROCm device supports dtype bfloat16"""


### PR DESCRIPTION
Follow up to #84879

In #84879 the implementation of `torch.cuda.device_count()` was changed to avoid a call to `torch._C._cuda_getDeviceCount()` when the device count can be queried through NVML. 

This PR updates the implementation of `torch.cuda.is_available()` according to this as well. 
Please let me know if and where I should add any new tests. 

cc @malfet 
