### PR TITLE
Reduce memory usage requirement of `test_warp_softmax_64bit_indexing` in `test_nn.py`

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15551,11 +15551,11 @@ class TestNNDeviceType(NNTestCase):
             rtol = torch.testing._comparison._DTYPE_PRECISIONS[dtype][0]
             atol = torch.testing._comparison._DTYPE_PRECISIONS[dtype][1]
             atol = 0.001 if dtype is torch.half else atol
-            assert torch.allclose(y.cpu(), yy, rtol=rtol, atol=atol)
+            self.assertTrue(torch.allclose(y.cpu(), yy, rtol=rtol, atol=atol))
             # x is half
-            assert torch.allclose(x.grad.cpu(), xx.grad,
-                                  rtol=torch.testing._comparison._DTYPE_PRECISIONS[torch.half][0],
-                                  atol=0.001)
+            self.assertTrue(torch.allclose(x.grad.cpu(), xx.grad,
+                                           rtol=torch.testing._comparison._DTYPE_PRECISIONS[torch.half][0],
+                                           atol=0.001))
 
         run_test(1100000000, 2)  # Illegal memory access https://github.com/pytorch/pytorch/issues/52715
         run_test(2200000000, 1)  # invalid configuration argument https://github.com/pytorch/pytorch/issues/52716

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15548,9 +15548,7 @@ class TestNNDeviceType(NNTestCase):
             yy = F.log_softmax(xx.float(), dim=-1).to(dtype)
             yy.backward(yy)
             # workaround to reduce memory usage vs. self.assertEqual, see #84944
-            rtol = torch.testing._comparison._DTYPE_PRECISIONS[dtype][0]
-            atol = torch.testing._comparison._DTYPE_PRECISIONS[dtype][1]
-            atol = 0.001 if dtype is torch.half else atol
+            rtol, atol = torch.testing._comparison.get_tolerances(dtype, atol=1e-3 if dtype is torch.half else None)
             self.assertTrue(torch.allclose(y.cpu(), yy, rtol=rtol, atol=atol))
             # x is half
             self.assertTrue(torch.allclose(x.grad.cpu(), xx.grad,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15551,9 +15551,8 @@ class TestNNDeviceType(NNTestCase):
             rtol, atol = torch.testing._comparison.get_tolerances(dtype, atol=1e-3 if dtype is torch.half else None)
             self.assertTrue(torch.allclose(y.cpu(), yy, rtol=rtol, atol=atol))
             # x is half
-            self.assertTrue(torch.allclose(x.grad.cpu(), xx.grad,
-                                           rtol=torch.testing._comparison._DTYPE_PRECISIONS[torch.half][0],
-                                           atol=0.001))
+            rtol, atol = torch.testing._comparison.get_tolerances(torch.half, atol=1e-3)
+            self.assertTrue(torch.allclose(x.grad.cpu(), xx.grad, rtol=rtol, atol=atol))
 
         run_test(1100000000, 2)  # Illegal memory access https://github.com/pytorch/pytorch/issues/52715
         run_test(2200000000, 1)  # invalid configuration argument https://github.com/pytorch/pytorch/issues/52716


### PR DESCRIPTION
For reference: #84944 

CC @xwang233 @ngimel @ptrblck 