### PR TITLE
[FSDP] Fix `pin_memory()` for CPU offloading

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1851,7 +1851,7 @@ class FullyShardedDataParallel(nn.Module):
         # transfer.
         if self.cpu_offload.offload_params:
             assert p._local_shard.device == torch.device("cpu")  # type: ignore[attr-defined]
-            p._local_shard.pin_memory()  # type: ignore[attr-defined]
+            p._local_shard = p._local_shard.pin_memory()  # type: ignore[attr-defined]
             # When offloading parameters, also move the grad shard to CPU during
             # backward pass. In this case, it's important to pre-allocate the
             # CPU grad shard in pinned memory so that we can do a non-blocking


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #85052 [Easy][FSDP] Change `assert` -> `p_assert`
* #85051 [Easy][FSDP] Remove outdated comment
* **#85048 [FSDP] Fix `pin_memory()` for CPU offloading**
* #83917 [FSDP] Add rate limiter
* #84366 [FSDP][Easy] Save unpadded/padded unsharded sizes as attributes
* #83665 [FSDP] Generalize prefetching; lower unshard/reshard to handle
* #84761 [FSDP][Easy] Minor cleanup
* #84601 [FSDP] Subtest prefetching for `test_fsdp_grad_acc.py`
* #84600 [FSDP] Remove `forward_prefetch`

