### PR TITLE
[Easy][FSDP] Remove outdated comment

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1065,8 +1065,7 @@ class FullyShardedDataParallel(nn.Module):
         # Used for guarding against mistargeted backward prefetches
         self._needs_pre_backward_unshard: Dict[_HandlesKey, bool] = {}
         # The data structures use tuples of handles to generalize over the case
-        # where a module's forward involves multiple handles. The two forward
-        # order structures are populated and finalized in the first iteration.
+        # where a module's forward involves multiple handles.
 
         # `_state_dict_type` controls the `state_dict()` behavior, which is
         # implemented using post-save and pre-load hooks


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #85052 [Easy][FSDP] Change `assert` -> `p_assert`
* **#85051 [Easy][FSDP] Remove outdated comment**
* #85048 [FSDP] Fix `pin_memory()` for CPU offloading
* #83917 [FSDP] Add rate limiter
* #84366 [FSDP][Easy] Save unpadded/padded unsharded sizes as attributes
* #83665 [FSDP] Generalize prefetching; lower unshard/reshard to handle
* #84761 [FSDP][Easy] Minor cleanup
* #84601 [FSDP] Subtest prefetching for `test_fsdp_grad_acc.py`
* #84600 [FSDP] Remove `forward_prefetch`

