### PR TITLE
Make functorch compilable with Py-3.11

### DIFF
--- a/functorch/csrc/dim/dim.cpp
+++ b/functorch/csrc/dim/dim.cpp
@@ -1440,15 +1440,20 @@ py::object getname(PyCodeObject* code, _Py_CODEUNIT c) {
         case STORE_GLOBAL:
           names = code->co_names;
           break;
-#if PY_VERSION_HEX < 0x030b0000
-        // TODO: Re-enable this for Python-3.11
         case STORE_FAST:
+#if PY_VERSION_HEX < 0x030b0000
           names = code->co_varnames;
+#else
+          names = PyCode_GetVarnames(code);
+#endif
           break;
         case STORE_DEREF:
+#if PY_VERSION_HEX < 0x030b0000
           names = code->co_cellvars;
-          break;
+#else
+          names = PyCode_GetCellvars(code);
 #endif
+          break;
         default:
             return py::object();
     }

--- a/torch/csrc/utils/python_compat.h
+++ b/torch/csrc/utils/python_compat.h
@@ -82,6 +82,11 @@ static inline PyFrameObject* PyFrame_GetBack(PyFrameObject* frame) {
   Py_XINCREF(frame->f_back);
   return frame->f_back;
 }
+
+static inline PyFrameObject* PyThreadState_GetFrame(PyThreadState* state) {
+  Py_XINCREF(state->frame);
+  return state->frame;
+}
 #endif
 
 #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)


### PR DESCRIPTION
By using compatibility wrappers from [python_compat.h](https://github.com/pytorch/pytorch/blob/master/torch/csrc/utils/python_compat.h) and skipping part of `getname` switch

Fixes https://github.com/pytorch/pytorch/issues/85006

Please note that `import torch` right now fails by default on 3.11 with some jit issue, so I think this shouldn't be a really issue for a bit