### PR TITLE
[frontend] Print real type for Argument

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -550,7 +550,10 @@ inline std::ostream& operator<<(std::ostream& out, const Argument& arg) {
   // in schema, we have Tensor?(a!) input, and t(a!)?.
   // however, t?(a!) doesn't work with schema parser.
   // so we always use Type(alias)? format
-  auto type = arg.type();
+  // real_type versus fake_type: in order to be compatible with FunctionSchema
+  // parser, printing an argument with either MemoryFormat or Layout type should
+  // give us the original schema string, hence printing out real_type.
+  auto type = arg.real_type();
   bool is_opt = type->kind() == OptionalType::Kind;
   auto unopt_type = is_opt ? type->castRaw<OptionalType>()->getElementType() : type;
 

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -2114,7 +2114,7 @@ struct MemoryFormatType;
 using MemoryFormatTypePtr = SingletonTypePtr<MemoryFormatType>;
 struct TORCH_API MemoryFormatType : public EnumerationType<TypeKind::MemoryFormatType> {
 std::string str() const override {
-return "MemoryFormatType";
+return "MemoryFormat";
 }
 static const TypeKind Kind = TypeKind::MemoryFormatType;
 // global singleton
@@ -2128,7 +2128,7 @@ struct LayoutType;
 using LayoutTypePtr = SingletonTypePtr<LayoutType>;
 struct TORCH_API LayoutType : public EnumerationType<TypeKind::LayoutType> {
 std::string str() const override {
-return "LayoutType";
+return "Layout";
 }
 static const TypeKind Kind = TypeKind::LayoutType;
 // global singleton

--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -192,5 +192,19 @@ class TestFunctionSchema(TestCase):
         self.assertTrue(schema.arguments[-1].alias_info.is_write)
         self.assertEqual(str(schema), schema_str)
 
+    def test_tensor_option_arguments_properly_parsed(self):
+        schema_str = '_to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, ' \
+                     'bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor'
+        schema = parse_schema(schema_str)
+        # fake type of MemoryFormat? is int?
+        self.assertEqual(schema.arguments[-1].type.str(), "int?")
+        # fake type of Layout? is int?
+        self.assertEqual(schema.arguments[2].type.str(), "int?")
+        # fake type of Device? is Device?
+        self.assertEqual(schema.arguments[2].type.str(), "Device?")
+        # print real types in FunctionSchema
+        self.assertEqual(str(schema), schema_str)
+
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -201,7 +201,7 @@ class TestFunctionSchema(TestCase):
         # fake type of Layout? is int?
         self.assertEqual(schema.arguments[2].type.str(), "int?")
         # fake type of Device? is Device?
-        self.assertEqual(schema.arguments[2].type.str(), "Device?")
+        self.assertEqual(schema.arguments[3].type.str(), "Device?")
         # print real types in FunctionSchema
         self.assertEqual(str(schema), schema_str)
 


### PR DESCRIPTION
Retry of [#84985](https://github.com/pytorch/pytorch/pull/84985). For some reason `ghstack land` doesn't work on that PR


In JIT world, if we parse an argument in schema and print its type, we always get `fake_type`. For example, `MemoryFormat? memory_format` becomes `int? memory_format`. This doesn't align with the original schema string and creates discrepency between `torchgen.FunctionSchema` and `torch._C.FunctionSchema`. Here I'm letting `torch._C.Argument` print its `real_type` and hence be aligned with the original schema string.

Rely on newly added unit test.

Differential Revision: [D39550665](https://our.internmc.facebook.com/intern/diff/D39550665)