### PR TITLE
Remove assertEqualIgnoreType from test_pooling

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1086,24 +1086,24 @@ torch.cuda.synchronize()
         self.assertRaises(RuntimeError, lambda: F.adaptive_max_pool3d(t, []))
 
     def _test_maxpool_indices(self, num_dim, adaptive=False, device="cpu", dtype=torch.float):
-        def expected_indices(dim):
+        def expected_indices(dim, dtype):
             if dim == 1:
-                return torch.tensor([1, 3], dtype=torch.long).repeat(2, 2, 1)
+                return torch.tensor([1, 3], dtype=dtype).repeat(2, 2, 1)
             if dim == 2:
-                return torch.tensor([[5, 7], [13, 15]], dtype=torch.long).repeat(2, 2, 1, 1)
+                return torch.tensor([[5, 7], [13, 15]], dtype=dtype).repeat(2, 2, 1, 1)
 
-        def expected_grad(dim):
+        def expected_grad(dim, dtype):
             if dim == 1:
-                return torch.tensor([0, 1, 0, 1], dtype=torch.float).repeat(2, 2, 1)
-            grad = expected_grad(dim - 1)
+                return torch.tensor([0, 1, 0, 1], dtype=dtype).repeat(2, 2, 1)
+            grad = expected_grad(dim - 1, dtype=dtype)
             zero = torch.zeros(grad.size())
             return torch.stack((zero, grad, zero, grad), 2)
 
-        def expected_output(dim):
+        def expected_output(dim, dtype):
             if dim == 1:
-                return torch.arange(2, 17, 2, dtype=torch.float).view(2, 2, 2)
+                return torch.arange(2, 17, 2, dtype=dtype).view(2, 2, 2)
             if dim == 2:
-                col = torch.arange(6, 63, 8, dtype=torch.float)
+                col = torch.arange(6, 63, 8, dtype=dtype)
                 return torch.stack([col, col + 2], 1).view(2, 2, 2, 2)
 
         if adaptive:
@@ -1119,8 +1119,8 @@ torch.cuda.synchronize()
         # Check forward
         output, indices = module(input_var)
         if num_dim != 3:
-            expected_indices = expected_indices(num_dim)
-            expected_output = expected_output(num_dim)
+            expected_indices = expected_indices(num_dim, dtype=indices.data.dtype)
+            expected_output = expected_output(num_dim, dtype=output.data.dtype)
             self.assertEqual(indices.dim(), input.dim())
             self.assertEqual(indices.data.squeeze(), expected_indices)
             self.assertEqual(output.data.squeeze(), expected_output)
@@ -1130,7 +1130,7 @@ torch.cuda.synchronize()
         # Make sure backward works
         grad_output = torch.ones(output.size(), device=device, dtype=dtype)
         output.backward(grad_output, retain_graph=True)
-        expected_grad = expected_grad(num_dim)
+        expected_grad = expected_grad(num_dim, dtype=input_var.grad.data.dtype)
         self.assertEqual(input_var.grad.data, expected_grad.view_as(input))
 
         # Make sure backward after changing indices will result in an error

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1096,7 +1096,7 @@ torch.cuda.synchronize()
             if dim == 1:
                 return torch.tensor([0, 1, 0, 1], dtype=dtype).repeat(2, 2, 1)
             grad = expected_grad(dim - 1, dtype=dtype)
-            zero = torch.zeros(grad.size())
+            zero = torch.zeros(grad.size(), dtype=dtype)
             return torch.stack((zero, grad, zero, grad), 2)
 
         def expected_output(dim, dtype):


### PR DESCRIPTION
Fix TODOs related to https://github.com/pytorch/pytorch/issues/38095 in test_pooling.py.

This PR correctly casts the expected outputs to satisfy the asserts. If you'd prefer feeding `exact_dtype=False` as an argument instead I can update accordingly. 