### PR TITLE
[do not merge] Testing for dispatch error

### DIFF
--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -40,7 +40,7 @@ std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> allreduce_(
 }
 
 std::tuple<std::vector<std::vector<at::Tensor>>, c10::intrusive_ptr<Work>>
-allgather_(
+allgather_cpu_(
     const std::vector<std::vector<at::Tensor>>& output_tensors,
     const std::vector<at::Tensor>& input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
@@ -177,8 +177,7 @@ TORCH_LIBRARY(c10d, m) {
       "allreduce_",
       dispatch(c10::DispatchKey::CompositeExplicitAutograd, allreduce_));
   m.def(
-      "allgather_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, allgather_));
+      "allgather_(Tensor[][] output_tensors, Tensor[] input_tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int timeout) -> (Tensor[][], __torch__.torch.classes.c10d.Work)");
   m.def(
       "reduce_scatter_",
       dispatch(c10::DispatchKey::CompositeExplicitAutograd, reduce_scatter_));
@@ -410,6 +409,13 @@ c10::intrusive_ptr<Work> recv(
                            int64_t)>();
   return op.call(tensors, process_group, srcRank, tag);
 }
+
+namespace {
+TORCH_LIBRARY_IMPL(c10d, CPU, m) {
+  m.impl("allgather_", allgather_cpu_);
+}
+
+} // namespace
 
 } // namespace ops
 } // namespace c10d


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #85119 [do not merge] Testing for dispatch error (update)
* **#85115 [do not merge] Testing for dispatch error**

1. `ghstack checkout https://github.com/pytorch/pytorch/pull/85115`
2. `python setup.py develop`
3.  run the following script
```python
import torch
import os
import torch.distributed as dist

os.environ["MASTER_ADDR"] = "localhost"
os.environ["MASTER_PORT"] = "29500"
os.environ["RANK"] = "0"
os.environ["WORLD_SIZE"] = "1"
os.environ["TORCH_SHOW_CPP_STACKTRACES"] = "1"

if __name__ == "__main__":
    dist.init_process_group("gloo")
    t = torch.zeros(2)
    t_list = [torch.zeros(2) for _ in range(1)]
    print(f"{t_list=}")
    dist.all_gather(t_list, t)

```

Errors with

```
Traceback (most recent call last):
  File "produce_dispatch_error_example.py", line 16, in <module>
    dist.all_gather(t_list, t)
  File "/fsx/users/howardhuang/work/pytorch/torch/distributed/distributed_c10d.py", line 2188, in all_gather
    work = default_pg.allgather([tensor_list], [tensor])
NotImplementedError: There were no tensor arguments to this function (e.g., you passed an empty list of Tensors), but no fallback function is registered for schema c10d::allgather_.  This usually means that this function requires a non-empty list of Tensors, or that you (the operator writer) forgot to register a fallback function.  Available functions are [CPU, BackendSelect, Python, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradXLA, AutogradMPS, AutogradXPU, AutogradHPU, AutogradLazy, Tracer, AutocastCPU, AutocastCUDA, Batched, VmapMode, PythonTLSSnapshot, PythonDispatcher].

CPU: registered at ../torch/csrc/distributed/c10d/Ops.cpp:414 [kernel]
...
```

I believe the error is happening when the op gets called here: https://github.com/pytorch/pytorch/pull/85115/files#diff-a0bb1747a4de5846bd43d0ec684e4650298648a083243bcdaf590e2b1e747873R264-R265, but I am not sure how to debug further.

Interestingly, if I change the definition in allgather of `input_tensors` from `const std::vector<at::Tensor>& input_tensors` -> `at::TensorList` as shown in https://github.com/pytorch/pytorch/pull/85119, then this script does not error out.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @kwen2501 @awgu