### PR TITLE
[ONNX] Add `caffe2/python/onnx/**` to merge rule

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -16,6 +16,7 @@
   - torch/csrc/onnx/**
   - torch/onnx/**
   - third_party/onnx
+  - caffe2/python/onnx/**
   approved_by:
   - BowenBao
   - abock


### PR DESCRIPTION
This PR extends merge rule such that any related fixes needed for caffe2 onnx tests can be merged in the same PR. Test skips need to be added to `caffe2/python/onnx/tests/onnx_backend_test.py` for new ONNX operators when ONNX submodule is updated.

Unblocks #83201
