### PR TITLE
Adds normal prim, randn reference, and randn OpInfo

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -247,7 +247,7 @@ class TestCommon(TestCase):
                     if getattr(op, 'validate_view_consistency', True) and not skip_view_consistency:
                         self.assertEqual(a._is_view(), b._is_view())
 
-            # Computes the dtype the more precise computatino would occur in
+            # Computes the dtype the more precise computation would occur in
             precise_dtype = torch.bool
             if prims.utils.is_integer_dtype(dtype):
                 # Note: bool and integer dtypes do not have more
@@ -443,6 +443,16 @@ class TestCommon(TestCase):
                 sample_input.args,
                 sample_input.kwargs,
             )
+
+            # This test requires that the input be a tensor or sequence of 1+ tensors
+            if not isinstance(t_inp, torch.Tensor):
+                if isinstance(t_inp, Sequence):
+                    if not len(t_inp) > 0 or not isinstance(t_inp[0], torch.Tensor):
+                        continue
+                else:
+                    continue
+
+
             noncontig_sample = sample_input.noncontiguous()
             n_inp, n_args, n_kwargs = (
                 noncontig_sample.input,

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -247,7 +247,7 @@ class TestCommon(TestCase):
                     if getattr(op, 'validate_view_consistency', True) and not skip_view_consistency:
                         self.assertEqual(a._is_view(), b._is_view())
 
-            # Computes the dtype the more precise computation would occur in
+            # Computes the dtype the more precise computatino would occur in
             precise_dtype = torch.bool
             if prims.utils.is_integer_dtype(dtype):
                 # Note: bool and integer dtypes do not have more
@@ -443,16 +443,6 @@ class TestCommon(TestCase):
                 sample_input.args,
                 sample_input.kwargs,
             )
-
-            # This test requires that the input be a tensor or sequence of 1+ tensors
-            if not isinstance(t_inp, torch.Tensor):
-                if isinstance(t_inp, Sequence):
-                    if not len(t_inp) > 0 or not isinstance(t_inp[0], torch.Tensor):
-                        continue
-                else:
-                    continue
-
-
             noncontig_sample = sample_input.noncontiguous()
             n_inp, n_args, n_kwargs = (
                 noncontig_sample.input,

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -189,6 +189,7 @@ __all__ = [
     #
     # Randomness Prims
     #
+    "normal",
     "uniform",
     #
     # FFT prims
@@ -2528,6 +2529,64 @@ svd = _make_prim(
 # Randomness Prims
 #
 
+# TODO: add generator support
+# NOTE: there is currently no way of acquiring the "default" torch generator
+def _normal_meta(
+    shape: ShapeType,
+    *,
+    mean: Union[float, complex],
+    std: float,
+    dtype: torch.dtype,
+    device: torch.device,
+    requires_grad: bool,
+) -> TensorLikeType:
+    utils.check(
+        std >= 0.0,
+        lambda: f"expected non-negative standard deviation, but got std={std}",
+    )
+
+    utils.check(
+        utils.is_float_dtype(dtype) or utils.is_complex_dtype(dtype),
+        lambda: f"expected a floating-point or complex dtype, but got dtype={dtype}",
+    )
+
+    strides = utils.make_contiguous_strides_for(shape)
+    return TensorMeta(shape=shape, strides=strides, dtype=dtype, device=device)
+
+
+def _normal_aten(
+    shape: ShapeType,
+    *,
+    mean: Union[float, complex],
+    std: float,
+    dtype: torch.dtype,
+    device: torch.device,
+    requires_grad: bool,
+) -> Tensor:
+    a = torch.empty(shape, dtype=dtype, device=device, requires_grad=requires_grad)
+    with torch.no_grad():
+        # NOTE: normal_ is incorrectly annotated to expect mean to be a float
+        a.normal_(mean, std)  # type: ignore[arg-type]
+    return a
+
+
+_normal_doc = """
+    Constructs a tensor filled with values drawn from a normal distribution with the specified mean
+    and standard deviation.
+
+    Only supports floating-point types.
+"""
+
+normal = _make_prim(
+    schema=(
+        "normal(SymInt[] shape, *, Scalar mean, Scalar std, ScalarType dtype, Device device,  bool requires_grad) -> Tensor"
+    ),
+    return_type=RETURN_TYPE.NEW,
+    meta=_normal_meta,
+    impl_aten=_normal_aten,
+    doc=_normal_doc,
+)
+
 
 def _uniform_meta(
     shape: ShapeType,
@@ -2568,6 +2627,10 @@ uniform = _make_prim(
     impl_aten=_uniform_aten,
     doc=_uniform_doc,
 )
+
+#
+# FFT prims
+#
 
 
 def _fft_r2c_meta(

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -126,8 +126,10 @@ def compare_tensor_meta(a: TensorLikeType, b: TensorLikeType, check_strides=Fals
     if check_strides:
         same_strides, idx = check_significant_strides(a, b)
         if not same_strides:
-            msg = "Stride mismatch! Strides are {0} and {1} (mismatched at {2})!".format(
-                a.stride(), b.stride(), idx
+            msg = (
+                "Stride mismatch! Strides are {0} and {1} (mismatched at {2})!".format(
+                    a.stride(), b.stride(), idx
+                )
             )
             raise RuntimeError(msg)
 
@@ -678,12 +680,16 @@ def infer_size(shape: ShapeType, numel: int) -> Tuple[int, ...]:
             newsize *= d
         else:
             check(False, lambda: f"invalid shape dimension {d}")
-    check(numel == newsize or (dim is not None and newsize > 0 and numel % newsize == 0),
-          lambda: f"shape '{list(shape)}' is invalid for input of size {numel}")
+    check(
+        numel == newsize or (dim is not None and newsize > 0 and numel % newsize == 0),
+        lambda: f"shape '{list(shape)}' is invalid for input of size {numel}",
+    )
     if dim is not None:
-        check(newsize != 0,
-              lambda: f"cannot reshape tensor fo 0 elements into shape {shape} because the "
-                      f"unspecified dimension size -1 can be any value and is ambiguous")
+        check(
+            newsize != 0,
+            lambda: f"cannot reshape tensor fo 0 elements into shape {shape} because the "
+            f"unspecified dimension size -1 can be any value and is ambiguous",
+        )
         shape = list(shape)
         shape[dim] = numel // newsize
     return tuple(shape)
@@ -1081,6 +1087,7 @@ def number_type(x: Union[NumberType, torch.SymIntNode, torch.SymFloatNode]) -> T
         return float
     else:
         return type(x)
+
 
 # TODO: document type promotion kinds
 def elementwise_dtypes(
@@ -1513,3 +1520,15 @@ def mask_tensor(mask: TensorLikeType, t: TensorLikeType):
         return mask.logical_and(t)
     else:
         return torch.where(mask, t, 0)
+
+
+def dtype_or_default(dtype: Optional[torch.dtype]) -> torch.dtype:
+    return dtype if dtype is not None else torch.get_default_dtype()
+
+
+def device_or_default(device: Optional[torch.device]) -> torch.device:
+    return device if device is not None else torch.device("cpu")
+
+
+def layout_or_default(layout: Optional[torch.layout]) -> torch.layout:
+    return layout if layout is not None else torch.strided

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -245,20 +245,21 @@ __all__ = [
     #
     # Tensor Creation
     #
+    "arange",
     "empty",
     "empty_like",
     "empty_strided",
     "eye",
     "full",
     "full_like",
+    "linspace",
+    "logspace",
     "ones",
     "ones_like",
+    "randn",
     "scalar_tensor",
     "zeros",
     "zeros_like",
-    "arange",
-    "linspace",
-    "logspace",
     #
     # Randomness References
     #
@@ -3922,6 +3923,35 @@ ones = partial(full, fill_value=True)
 
 ones_like = partial(full_like, fill_value=True)
 
+# TODO: add pin_memory support
+@register_decomposition(torch.ops.aten.randn)
+@out_wrapper()
+def randn(
+    *shape,
+    dtype: Optional[torch.dtype] = None,
+    device: Optional[torch.device] = None,
+    layout: Optional[torch.layout] = None,
+    requires_grad: bool = False,
+    pin_memory: Optional[bool] = None,
+) -> TensorLikeType:
+
+    check(pin_memory is None, lambda: "pin_memory parameter is not supported!")
+
+    shape_ = utils.extract_shape_from_varargs(shape)
+
+    dtype = utils.dtype_or_default(dtype)
+    device = utils.device_or_default(device)
+    layout = utils.layout_or_default(layout)
+
+    return prims.normal(
+        shape_,
+        mean=0.0,
+        std=1.0,
+        dtype=dtype,
+        device=device,
+        requires_grad=requires_grad,
+    )
+
 
 # TODO: missing kwargs (e.g. layout)
 def scalar_tensor(
@@ -3938,6 +3968,10 @@ def scalar_tensor(
 zeros = partial(full, fill_value=False)
 
 zeros_like = partial(full_like, fill_value=False)
+
+#
+# Randomness References
+#
 
 
 @register_decomposition(torch.ops.aten.uniform)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -750,6 +750,17 @@ def sample_inputs_arange(op, device, dtype, requires_grad, **kwargs):
     yield SampleInput(2)
     yield SampleInput(1, args=(3, 1))
 
+def sample_inputs_randn(op, device, dtype, requires_grad, **kwargs):
+    make_arg = partial(make_tensor, dtype=dtype, device=device, requires_grad=False)
+
+    shapes = (
+        (M,),
+        (S, S)
+    )
+
+    for shape in shapes:
+        yield SampleInput(input=shape, kwargs=dict(dtype=dtype, device=device, requires_grad=requires_grad))
+
 
 def sample_inputs_uniform(op, device, dtype, requires_grad, **kwargs):
 
@@ -13682,8 +13693,35 @@ op_db: List[OpInfo] = [
            supports_autograd=False,
            skips=(
            )),
+    OpInfo('randn',
+           dtypes=floating_and_complex_types_and(torch.half, torch.bfloat16, torch.complex32),
+           op=lambda *args, **kwargs: wrapper_set_seed(torch.randn, *args, **kwargs),
+           supports_out=True,
+           sample_inputs_func=sample_inputs_randn,
+           supports_autograd=False,
+           skips=(
+               # Reference doesn't support the pin_memory parameter
+               DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_comprehensive'),
+               # randn generates different values based on the strides of out tensor
+               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='cpu'),
+               # randn fails to warn when resizing its out tensor
+               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning'),
+               # FX failed to normalize op - add the op to the op_skip list.
+               DecorateInfo(unittest.expectedFailure, 'TestNormalizeOperators', 'test_normalize_operator_exhaustive'),
+               # Tests that assume input tensor has a meaningful effect on output tensor
+               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager'),
+               DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_view'),
+               DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_conj_view'),
+               DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_conj_view'),
+               # AssertionError: JIT Test does not execute any logic
+               DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),
+               # aten.uniform_.default - couldn't find symbolic meta function/decomposition
+               DecorateInfo(unittest.expectedFailure, 'TestProxyTensorOpInfo', 'test_make_fx_symbolic_exhaustive'),
+               # aten.uniform was not decomposed
+               DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_quick'),
+           )),
     OpInfo('randn_like',
-           dtypes=floating_types_and(torch.half, torch.bfloat16, torch.complex32, torch.complex64, torch.complex128),
+           dtypes=floating_and_complex_types_and(torch.half, torch.bfloat16, torch.complex32),
            op=lambda inp, *args, **kwargs:
                wrapper_set_seed(torch.randn_like, inp, *args, **kwargs),
            supports_out=False,
@@ -17260,6 +17298,22 @@ python_ref_db = [
                          'test_neg_view'),
             # FIXME: should not compare results of empty_like
             DecorateInfo(unittest.skip("Can't check result for empty_like"), 'TestCommon', 'test_python_ref_executor'),
+        ),
+    ),
+    PythonRefInfo(
+        "_refs.randn",
+        torch_opinfo_name="randn",
+        op=lambda *args, **kwargs: wrapper_set_seed(refs.randn, *args, **kwargs),
+        supports_nvfuser=False,
+        skips=(
+            # see https://github.com/pytorch/pytorch/issues/85121
+            DecorateInfo(unittest.skip("make_traced() doesn't set seed properly!"),
+                         'TestCommon',
+                         'test_python_ref_executor'),
+            # These tests expect the input to be a tensor or a sequence of tensors
+            DecorateInfo(unittest.skip, 'TestMathBits', 'test_neg_view'),
+            DecorateInfo(unittest.skip, 'TestMathBits', 'test_conj_view'),
+            DecorateInfo(unittest.skip, 'TestMathBits', 'test_neg_conj_view'),
         ),
     ),
     PythonRefInfo(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13705,9 +13705,9 @@ op_db: List[OpInfo] = [
            supports_autograd=False,
            skips=(
                # Tests that assume input is a tensor or sequence of tensors
-               DecorateInfo(unittest.skip, "TestCommon", "test_noncontiguous_samples"),
-               DecorateInfo(unittest.skip, "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
-               DecorateInfo(unittest.skip, "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestCommon", "test_noncontiguous_samples"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
                # Reference doesn't support the pin_memory parameter
                DecorateInfo(unittest.expectedFailure, 'TestDecomp', 'test_comprehensive'),
                # CPU randn generates different values based on the strides of out tensor
@@ -14225,7 +14225,7 @@ op_db: List[OpInfo] = [
                # linalg_vector_norm.default than original on output 0.
                # Original max diff: 2.560596747969157e-07,
                # Decomp max diff: 1.8187482915266173e-06
-               DecorateInfo(unittest.skip, 'TestDecomp', 'test_comprehensive',
+               DecorateInfo(unittest.skip("Inconsistent accuracy"), 'TestDecomp', 'test_comprehensive',
                             device_type='cpu', dtypes=(torch.float16,)),
            )),
     ShapeFuncInfo('repeat',
@@ -17324,10 +17324,10 @@ python_ref_db = [
                          'TestCommon',
                          'test_python_ref_executor'),
             # These tests expect the input to be a tensor or a sequence of tensors
-            DecorateInfo(unittest.skip, "TestCommon", "test_noncontiguous_samples"),
-            DecorateInfo(unittest.skip, 'TestMathBits', 'test_neg_view'),
-            DecorateInfo(unittest.skip, 'TestMathBits', 'test_conj_view'),
-            DecorateInfo(unittest.skip, 'TestMathBits', 'test_neg_conj_view'),
+            DecorateInfo(unittest.skip("Test expects tensor input"), "TestCommon", "test_noncontiguous_samples"),
+            DecorateInfo(unittest.skip("Test expects tensor input"), 'TestMathBits', 'test_neg_view'),
+            DecorateInfo(unittest.skip("Test expects tensor input"), 'TestMathBits', 'test_conj_view'),
+            DecorateInfo(unittest.skip("Test expects tensor input"), 'TestMathBits', 'test_neg_conj_view'),
         ),
     ),
     PythonRefInfo(


### PR DESCRIPTION
This PR extends prims support for random operations by adding `prims.normal` and `refs.randn`. Note that in the future we may not want to model draws from distributions as their own prims. 

`prims.normal` accepts a shape and the mean and standard deviation of a normal distribution as numbers. This is distinct from `torch.normal` which takes two tensors so every generated datapoint can be drawn from a normal distribution with its own mean and standard deviation. To address this @ngimel and I expect to add `prims.normal_with_tensors`. The current `prims.normal` could be implemented using `prims.normal_with_tensors`, but we expect the case of two numbers is much more common, and that executors will likely want to specialize for it, anyway.

In a follow-up PR I plan to add `refs.randn_like`, `prims.normal_with_tensors` (as mentioned above), and `refs.normal`. 

While writing this PR I noticed the following issues:

- https://github.com/pytorch/pytorch/issues/85123
- https://github.com/pytorch/pytorch/issues/85121

The latter of which is prohibiting some testing.

In future PRs I plan to add a prim for changing layout, add support for pinned memory, and improve support for testing tensor creation operators, likely with a TensorCreationOpInfo class. 