### PR TITLE
New calling convention for Python dispatcher

### DIFF
--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -267,6 +267,7 @@ c10::DispatchKey parseDispatchKey(const std::string& k) {
       {"ZeroTensor", c10::DispatchKey::ZeroTensor},
       {"FuncTorchDynamicLayerBackMode",
        c10::DispatchKey::FuncTorchDynamicLayerBackMode},
+      {"Functionalize", c10::DispatchKey::Functionalize},
       {"ADInplaceOrView", c10::DispatchKey::ADInplaceOrView},
       {"AutogradOther", c10::DispatchKey::AutogradOther},
       {"AutogradFunctionality", c10::DispatchKey::AutogradFunctionality},

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -963,4 +963,4 @@ if 'TORCH_CUDA_SANITIZER' in os.environ:
 
     csan.enable_cuda_sanitizer()
 
-from ._dispatch import python
+torch._C._set_python_dispatcher(True)

--- a/torch/_dispatch/python.py
+++ b/torch/_dispatch/python.py
@@ -1,61 +1,7 @@
-import torch
+import torch._C
 from contextlib import contextmanager
 
 __all__ = ['enable_python_dispatcher', 'no_python_dispatcher']
-
-DispatchKey = torch._C.DispatchKey  # type: ignore[attr-defined]
-
-def has_key(op, k):
-    return (
-        torch._C._dispatch_has_kernel_for_dispatch_key(op.name(), k)
-        or k in op.py_kernels
-    )
-
-is_included_in_alias = torch._C._dispatch_is_included_in_alias
-
-# Equivalent to computeDispatchTableEntryWithDebug
-# TODO: memoize this or something
-def resolve_key(op: torch._ops.PyOperatorABC, k: DispatchKey):  # type: ignore[valid-type]
-    # 1. (Direct) operator registration
-    if has_key(op, k):
-        return k
-    # 2.1 Use CompositeExplicitAutogradNonFunctional kernel if available
-    cand = DispatchKey.CompositeExplicitAutogradNonFunctional
-    if (k == DispatchKey.Undefined or is_included_in_alias(k, cand)) and has_key(op, cand):
-        return cand
-    # 2.2 Use CompositeExplicitAutograd kernel if available
-    cand = DispatchKey.CompositeExplicitAutograd
-    if (k == DispatchKey.Undefined or is_included_in_alias(k, cand)) and has_key(op, cand):
-        return cand
-    has_backend_kernel = (
-        torch._C._dispatch_has_kernel_for_any_dispatch_key(op.name(), torch._C._dispatch_get_backend_keyset_from_autograd(k))
-        or has_key(op, DispatchKey.CompositeExplicitAutograd)
-    )
-    # 2.3. Use CompositeImplicitAutograd kernel if available
-    cand = DispatchKey.CompositeImplicitAutogradNestedTensor
-    if (
-        (k != DispatchKey.Undefined and is_included_in_alias(k, cand))  # type: ignore[attr-defined]
-            and has_key(op, cand) and not has_backend_kernel):
-        return cand
-    cand = DispatchKey.CompositeImplicitAutograd
-    if (k == DispatchKey.Undefined or is_included_in_alias(k, cand)) and has_key(op, cand):
-        if (
-            k == DispatchKey.AutogradOther
-            and torch._C._dispatch_has_kernel_for_any_dispatch_key(op.name(), torch._C._dispatch_autogradother_backends)  # type: ignore[attr-defined] # noqa: B950
-        ):
-            raise RuntimeError("ambiguous autogradother kernel")
-        elif not has_backend_kernel:
-            return cand
-    # 2.4. For autograd backend keys, use kernel from DispatchKey::Autograd if available
-    cand = DispatchKey.Autograd
-    if is_included_in_alias(k, cand) and has_key(op, cand):
-        return cand
-    # Backend fallback
-    if torch._C._dispatch_has_backend_fallback(k):
-        # The dispatch key itself will implicitly route to backend fallback.
-        # This is probably not great for the pure Python implementation.
-        return k
-    raise RuntimeError("could not find kernel")
 
 @contextmanager
 def no_python_dispatcher():
@@ -72,17 +18,3 @@ def enable_python_dispatcher():
         yield
     finally:
         del g
-
-# The Python dispatcher
-def python_dispatcher(op, ks, args, kwargs):
-    """
-    with no_python_dispatcher():
-        print(op, ks, args, kwargs)
-    """
-    k = resolve_key(op, ks.highestPriorityTypeId())
-    source = f'torch.ops.{op}.dispatch(k, *args, **kwargs)'
-    filename = f'{op}[{torch._C._dispatch_key_name(k)}]'
-    compiled = compile(source, filename, 'eval')  # TODO: maybe cache?
-    return eval(compiled, {'torch': torch, 'k': k, 'args': args, 'kwargs': kwargs})
-
-torch._C._set_python_dispatcher(python_dispatcher)

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -2275,59 +2275,38 @@ void ConcretePyInterpreterVTable::python_dispatcher(
     const c10::OperatorHandle& op,
     c10::DispatchKeySet ks,
     torch::jit::Stack* stack) const {
+
+  py::gil_scoped_acquire g;
+  py::handle torch_api_function_overload = getTorchApiFunction(op);
+
+  c10::DispatchKey k = ks.highestPriorityTypeId();
+  auto handler = torch_api_function_overload.attr(toString(k));
+  if (handler.ptr() == nullptr) {
+    throw python_error();
+  }
+  if (py::isinstance<c10::DispatchKey>(handler)) {
+    // NB: not redispatch, as that will permanently remove the python
+    // dispatcher for subsequent redispatches
+    op.callBoxedForDispatchKey(py::cast<c10::DispatchKey>(handler), *stack);
+    return;
+  }
+
   const auto& schema = op.schema();
   const auto num_arguments = schema.arguments().size();
   auto arguments = torch::jit::pop(*stack, num_arguments);
-
-  // Parse the name into namespace and name (no overload_name)
-  // TODO: put this into the library
-  const auto& qualified_name = op.operator_name().name;
-  const auto& overload_name = schema.overload_name();
-  auto pos = qualified_name.find("::");
-  TORCH_INTERNAL_ASSERT(pos != std::string::npos, qualified_name);
-  // Make me some null terminated strings
-  std::string ns_str = qualified_name.substr(0, pos);
-  const char* ns = ns_str.c_str();
-  const char* func_name = qualified_name.c_str() + pos + strlen("::");
-
-  // The plan: convert all the arguments back into PyObjects,
-  // extracting out the tensor handles, then call
-  // handle_torch_function_no_python_arg_parser
-  // NB: at the point arguments are pushed to the stack, ALL defaults
-  // are already present
-
-  py::gil_scoped_acquire g;
-
-  std::vector<py::handle> overloaded_args;
-  py::handle torch_api_function =
-      py::module::import("torch").attr("ops").attr(ns).attr(func_name);
-  py::handle torch_api_function_overload;
-  if (overload_name == "") {
-    torch_api_function_overload = torch_api_function.attr("default");
-  } else {
-    torch_api_function_overload =
-        torch_api_function.attr(overload_name.c_str());
-  }
-  std::string module_name_str = "torch.ops." + ns_str;
 
   auto args_kwargs = parseIValuesToPyArgsKwargs(op, arguments);
   auto args = std::move(args_kwargs.first);
   auto kwargs = std::move(args_kwargs.second);
 
-  auto python_dispatcher =
-      c10::impl::PythonDispatcherTLS::get_state().ptr(getPyInterpreter());
-  TORCH_INTERNAL_ASSERT(python_dispatcher);
-
-  py::object obj = py::reinterpret_steal<py::object>(PyObject_CallFunction(
-      python_dispatcher,
-      "OOOO",
-      torch_api_function_overload,
-      py::cast(ks).ptr(),
+  py::object obj = py::reinterpret_steal<py::object>(PyObject_Call(
+      handler.ptr(),
       args.ptr(),
       kwargs.ptr()));
 
-  if (obj == nullptr)
+  if (obj == nullptr) {
     throw python_error();
+  }
 
   pushPyOutToStack(op, stack, std::move(obj), "Python dispatcher");
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #85131

Instead of calling into the Python dispatcher for EVERY dispatcher
call, we now have a two step process.  First, we
getattr(op: OpOverload, dispatch_key) to "load" the handler for the
function.  This can either be a conventional function (in which
case we will call it, in the same way the old Python dispatcher
worked), or it can be a DispatchKey, in which case we will directly
call that DispatchKey in C++, bypassing marshalling between Python
and C++ entirely.  OpOverload.__getattr__ is carefully written so
that it will cache the

A further optimization would be to define __slots__ on OpOverload,
and ensuring that the DispatchKey strings are interned.

The resulting Python dispatcher is less flexible: after the first
lookup, the handler is cached and we won't recompute it.  Furthermore,
by default, dispatches will not go into Python, and so you won't
get stack frames for the Python dispatcher by default.  But we get
a huge performance improvement: on the following microbenchmark
we go from 2.5s to 1.9s.

```
import time
import torch
from functorch import make_fx

def f(x):
    for i in range(1000):
        x = x * x
    return x

begin = time.time()
res = make_fx(f, tracing_mode="symbolic")(torch.randn(10, 20))
print(time.time()-begin)
```

Signed-off-by: Edward Z. Yang <ezyang@fb.com>