### PR TITLE
Don't cache model specs within PTMCoreMLCompiler

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
@@ -167,7 +167,7 @@ static auto cls = torch::jit::backend<CoreMLBackend>("coreml");
 
 struct PTMCoreMLContext : public ContextInterface {
   void setModelCacheDirectory(std::string dir) override {
-    [PTMCoreMLCompiler setModelCacheDirectory:dir];
+    [PTMCoreMLCompiler setCacheDirectory:dir];
   }
 };
 

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.h
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.h
@@ -6,9 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PTMCoreMLCompiler : NSObject
 
-+ (void)setModelCacheDirectory:(const std::string&)dir;
++ (void)setCacheDirectory:(const std::string&)dir;
 
-+ (NSString*)modelCacheDirectory;
++ (NSString*)cacheDirectory;
 
 + (BOOL)compileModel:(const std::string&)modelSpecs
              modelID:(const std::string&)modelID;

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
@@ -6,69 +6,58 @@
 
 @implementation PTMCoreMLCompiler
 
-static NSString* gModelCacheDirectory = @"";
+static NSString *gCacheDirectory = @"";
+static NSString *gCompiledModelExtension = @"mlmodelc";
+static NSString *gVersionExtension = @"version";
 
-+ (void)setModelCacheDirectory:(const std::string&)dir {
-  gModelCacheDirectory = [NSString stringWithCString:dir.c_str()];
++ (void)setCacheDirectory:(const std::string&)dir {
+  gCacheDirectory = [NSString stringWithCString:dir.c_str()];
 }
 
-+ (nonnull NSString *)modelCacheDirectory {
-  BOOL isSet = gModelCacheDirectory.length != 0;
-  BOOL isWriteable = isSet && [[NSFileManager defaultManager] isWritableFileAtPath:gModelCacheDirectory];
++ (nonnull NSString *)cacheDirectory {
+  BOOL isSet = gCacheDirectory.length != 0;
+  BOOL isWriteable = isSet && [[NSFileManager defaultManager] isWritableFileAtPath:gCacheDirectory];
   if (!isSet || !isWriteable) {
     // set the default directory to tmp
-    gModelCacheDirectory = NSTemporaryDirectory();
+    gCacheDirectory = NSTemporaryDirectory();
   }
-  return gModelCacheDirectory;
+  return gCacheDirectory;
 }
 
 + (BOOL)compileModel:(const std::string&)modelSpecs modelID:(const std::string&)modelID {
-  NSString* modelName = [NSString stringWithCString:modelID.c_str() encoding:NSUTF8StringEncoding];
-  NSURL* modelPath = [PTMCoreMLCompiler _cacheFilePath:modelName];
-  NSURL* compiledModelPath = [modelPath URLByAppendingPathExtension:@"mlmodelc"];
-
-  BOOL modelIsCached = [[NSFileManager defaultManager] fileExistsAtPath:modelPath.path];
-  BOOL compiledModelIsCached = [[NSFileManager defaultManager] fileExistsAtPath:compiledModelPath.path];
+  NSString *modelName = [NSString stringWithCString:modelID.c_str() encoding:NSUTF8StringEncoding];
+  NSString *modelPath = [NSTemporaryDirectory() stringByAppendingPathComponent:modelName];
+  NSURL *compiledURL = [PTMCoreMLCompiler _cacheURLForModel:modelName extension:gCompiledModelExtension];
+  BOOL compiledModelIsCached = [[NSFileManager defaultManager] fileExistsAtPath:compiledURL.path];
 
 #if TARGET_OS_IPHONE
-  NSError *error = nil;
-  NSURL *compilationOSPath = [modelPath URLByAppendingPathExtension:@"version"];
-  NSString *compilationOS = [NSString stringWithContentsOfFile:compilationOSPath.path encoding:NSUTF8StringEncoding error:&error];
+  NSURL *versionURL = [PTMCoreMLCompiler _cacheURLForModel:modelName extension:gVersionExtension];
+  NSString *compilationOS = [NSString stringWithContentsOfFile:versionURL.path encoding:NSUTF8StringEncoding error:nil];
   NSString *currentOS = [UIDevice currentDevice].systemVersion;
   BOOL wasCachedOnThisOS = [currentOS isEqualToString:compilationOS];
 #else
   BOOL wasCachedOnThisOS = NO;
 #endif
 
-  if (modelIsCached != compiledModelIsCached || !wasCachedOnThisOS) {
-    modelIsCached = NO;
-    compiledModelIsCached = NO;
-    [PTMCoreMLCompiler _cleanupCachedModel:modelID];
-  }
-
-  if (!modelIsCached) {
-    // Note that the serialized protobuf binary contains bytes not text.
-    // https://developers.google.com/protocol-buffers/docs/pythontutorial#parsing-and-serialization
-    NSData* data = [NSData dataWithBytes:modelSpecs.c_str() length:modelSpecs.length()];
-    if (![data writeToFile:modelPath.path atomically:YES]) {
-      // If the model cannot be persisted on disk then compilation cannot proceed.
-      NSLog(@"Failed to save specs for MLModel!");
-      [PTMCoreMLCompiler _cleanupCachedModel:modelID];
-      return NO;
-    }
-  }
-
-  if (compiledModelIsCached) {
+  if (compiledModelIsCached && wasCachedOnThisOS) {
     return YES;
   }
 
-  return [PTMCoreMLCompiler _compileModel:modelID atPath:modelPath andCache:compiledModelPath];
+  if (!wasCachedOnThisOS) {
+    [PTMCoreMLCompiler _cleanupCachedModel:modelName];
+  }
+
+  BOOL writeSuccess = [PTMCoreMLCompiler _writeModelSpecs:modelSpecs toPath:modelPath];
+  if (!writeSuccess) {
+    return NO;
+  }
+
+  return [PTMCoreMLCompiler _compileModel:modelName atPath:modelPath];
 }
 
 + (nullable MLModel*)loadModel:(const std::string&)modelID backend:(const std::string&)backend allowLowPrecision:(BOOL)allowLowPrecision {
-  NSString* modelName = [NSString stringWithCString:modelID.c_str() encoding:NSUTF8StringEncoding];
-  NSURL* modelPath = [PTMCoreMLCompiler _cacheFilePath:modelName];
-  NSURL* compiledModelPath = [modelPath URLByAppendingPathExtension:@"mlmodelc"];
+  NSString *modelName = [NSString stringWithCString:modelID.c_str() encoding:NSUTF8StringEncoding];
+  NSURL *modelURL = [PTMCoreMLCompiler _cacheURLForModel:modelName extension:gCompiledModelExtension];
 
   NSError *error;
   MLModel *model;
@@ -82,60 +71,68 @@ static NSString* gModelCacheDirectory = @"";
     }
     config.computeUnits = computeUnits;
     config.allowLowPrecisionAccumulationOnGPU = allowLowPrecision;
-    model = [MLModel modelWithContentsOfURL:compiledModelPath configuration:config error:&error];
+    model = [MLModel modelWithContentsOfURL:modelURL configuration:config error:&error];
   } else {
-    model = [MLModel modelWithContentsOfURL:compiledModelPath error:&error];
+    model = [MLModel modelWithContentsOfURL:modelURL error:&error];
   }
 
   if (error) {
-    NSLog(@"Failed to initialize MLModel!");
-    [PTMCoreMLCompiler _cleanupCachedModel:modelID];
+    [PTMCoreMLCompiler _cleanupCachedModel:modelName];
     return nil;
   }
 
   return model;
 }
 
-+ (BOOL)_compileModel:(const std::string&)modelID atPath:(NSURL *)modelPath andCache:(NSURL *)cachePath {
++ (BOOL)_writeModelSpecs:(const std::string&)modelSpecs toPath:(NSString *)modelPath {
+  // Note that the serialized protobuf binary contains bytes not text.
+  // https://developers.google.com/protocol-buffers/docs/pythontutorial#parsing-and-serialization
+  NSData* data = [NSData dataWithBytes:modelSpecs.c_str() length:modelSpecs.length()];
+  return [data writeToFile:modelPath atomically:YES];
+}
+
++ (BOOL)_compileModel:(NSString *)modelName atPath:(NSString *)modelPath {
   NSError *error;
-  NSURL *temporaryURL = [MLModel compileModelAtURL:modelPath error:&error];
-  if (!error) {
-#if TARGET_OS_IPHONE
-    NSURL *compilationOSPath = [modelPath URLByAppendingPathExtension:@"version"];
-    NSString *currentOSVer = [UIDevice currentDevice].systemVersion;
-    [currentOSVer writeToFile:compilationOSPath.path atomically:YES];
-#endif
-    [PTMCoreMLCompiler _moveFileToCache:temporaryURL cacheURL:cachePath error:&error];
-  }
+  NSURL *modelURL = [NSURL fileURLWithPath:modelPath];
+  NSURL *temporaryURL = [MLModel compileModelAtURL:modelURL error:&error];
+
+  // After the compiled model has been created, the original specs can be cleared to save cache space.
+  [[NSFileManager defaultManager] removeItemAtPath:modelPath error:nil];
+
   if (error) {
-    NSLog(@"Failed to compile MLModel!");
-    [PTMCoreMLCompiler _cleanupCachedModel:modelID];
+    return NO; // Model could not be compiled
   }
-  return !error;
-}
 
-+ (void)_cleanupCachedModel:(const std::string&)modelID {
-  NSString* modelName = [NSString stringWithCString:modelID.c_str() encoding:NSUTF8StringEncoding];
-  NSURL* modelPath = [PTMCoreMLCompiler _cacheFilePath:modelName];
-  NSURL* compiledModelPath = [modelPath URLByAppendingPathExtension:@"mlmodelc"];
-  NSURL* compilationOSPath = [modelPath URLByAppendingPathExtension:@"version"];
-  NSError* error = nil;
-  [[NSFileManager defaultManager] removeItemAtPath:modelPath.path error:&error];
-  [[NSFileManager defaultManager] removeItemAtPath:compiledModelPath.path error:&error];
-  [[NSFileManager defaultManager] removeItemAtPath:compilationOSPath.path error:&error];
-}
-
-+ (void)_moveFileToCache:(NSURL *)fileURL cacheURL:(NSURL *)cacheURL error:(NSError **)error {
-  if ([fileURL isEqual:cacheURL]) {
-    return;
+  NSURL *compiledURL = [PTMCoreMLCompiler _cacheURLForModel:modelName extension:gCompiledModelExtension];
+  if (![compiledURL isEqual:temporaryURL]) {
+    [[NSFileManager defaultManager] removeItemAtURL:compiledURL error:nil];
+    [[NSFileManager defaultManager] moveItemAtURL:temporaryURL toURL:compiledURL error:&error];
   }
-  [[NSFileManager defaultManager] removeItemAtURL:cacheURL error:nil];
-  [[NSFileManager defaultManager] moveItemAtURL:fileURL toURL:cacheURL error:error];
+
+  if (error) {
+    return NO; // Model could not be saved in cache
+  }
+
+#if TARGET_OS_IPHONE
+  NSURL *versionURL = [PTMCoreMLCompiler _cacheURLForModel:modelName extension:gVersionExtension];
+  NSString *currentOSVer = [UIDevice currentDevice].systemVersion;
+  [currentOSVer writeToFile:versionURL.path atomically:YES];
+#endif
+
+  return YES;
 }
 
-+ (NSURL *)_cacheFilePath:(NSString *)fileName {
-  NSString *filePath = [[PTMCoreMLCompiler modelCacheDirectory] stringByAppendingPathComponent:fileName];
-  return [NSURL fileURLWithPath:filePath];
++ (void)_cleanupCachedModel:(NSString *)modelName {
+  NSURL *modelURL = [PTMCoreMLCompiler _cacheURLForModel:modelName extension:gCompiledModelExtension];
+  NSURL *versionURL = [PTMCoreMLCompiler _cacheURLForModel:modelName extension:gVersionExtension];
+  [[NSFileManager defaultManager] removeItemAtPath:modelURL.path error:nil];
+  [[NSFileManager defaultManager] removeItemAtPath:versionURL.path error:nil];
+}
+
++ (NSURL *)_cacheURLForModel:(NSString *)modelID extension:(NSString *)pathExtension {
+  NSString *filename = [modelID stringByAppendingPathExtension:pathExtension];
+  NSString *filePath = [[PTMCoreMLCompiler cacheDirectory] stringByAppendingPathComponent:filename];
+  return [NSURL fileURLWithPath:filePath isDirectory:NO];
 }
 
 @end


### PR DESCRIPTION
Summary: It turns out disk cache space is more limited than I realized - Instagram starts evicting cached items at 10mb. We don't actually need to cache the model specs, once the model is compiled all we need is the compiled model. With this diff, after model compilation succeeds we cleanup the model specs from disk.

Test Plan: Delete instagram from device to ensure an empty cache, build, launch camera, open a MCS or Segmentation effect, confirm it loads and works correctly. Restart the app and launch again, to confirm it can load the compiled model from cache as well.

Differential Revision: D39562009

