### PR TITLE
Increase docker build timeout

### DIFF
--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: nick-fields/retry@7d4a37704547a311dbb66ebdf5b23ec19374a767
         name: Build and upload nightly docker
         with:
-          timeout_minutes: 10
+          timeout_minutes: 30
           max_attempts: 3
           command: |
             set -ex


### PR DESCRIPTION
Docker builds used to take around 15 mins to run (more than the 10 min timeout) and have recently started taking even longer due to conda's slow dependency resolver.

We were in this bad state where we _depended_ on the retry to complete the build. That is, the first attempt would try to build docker, timeout, then the second attempt would continue to build on top of the cache the first build had setup, etc.

Increasing the timeout so that docker builds actually have enough time to complete the build within a single attempt
