### PR TITLE
Apply decomp before autograd

### DIFF
--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 import torch.utils._pytree as pytree
 import torch.utils.dlpack
 from torch import Tensor
+from torch._decomp import get_decompositions
 from torch._subclasses import FakeTensorMode
 from torch.fx import immutable_collections, Interpreter
 from torch.nn.utils import stateless
@@ -285,8 +286,24 @@ def aot_dispatch_base(flat_fn, flat_args: List[Tensor], aot_config: AOTConfig):
     return new_fn
 
 
+pre_autograd_decompositions = get_decompositions(
+    {
+        aten.upsample_bilinear2d.vec,
+    }
+)
+
+
 def aot_dispatch_autograd(flat_fn, flat_args: List[Tensor], aot_config: AOTConfig):
-    joint_forward_backward = create_joint_forward_backward(flat_fn)
+
+    if config.enable_pre_autograd_decomps:
+        # Trace with decompositions before autograd so that
+        # we can generate backward function from forward decomposition
+        decomposed_forward = make_fx(flat_fn, pre_autograd_decompositions)(
+            *flat_args
+        )
+        joint_forward_backward = create_joint_forward_backward(decomposed_forward)
+    else:
+        joint_forward_backward = create_joint_forward_backward(flat_fn)
 
     out = flat_fn(*flat_args)
     out = pytree.tree_map(

--- a/functorch/_src/config.py
+++ b/functorch/_src/config.py
@@ -11,6 +11,8 @@ import os
 
 use_functionalize = True
 
+enable_pre_autograd_decomps = True
+
 use_fake_tensor = True
 
 debug_partitioner = os.environ.get('AOT_PARTITIONER_DEBUG', False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #85181

This is a duplicate of https://github.com/pytorch/pytorch/pull/84380 

For the following function
```
def fn(x):
    return torch.nn.functional.interpolate(x, scale_factor=2., mode = 'bilinear')  + 1
```

AOTAutograd would produce following backward graph, as there is no decomp for aten.upsample_bilinear2d_backward.vec. 
```        
====== Backward graph ======
class GraphModule(torch.nn.Module):
    def forward(self, tangents_1):
        
        # No stacktrace found for following nodes 
        upsample_bilinear2d_backward_vec = torch.ops.aten.upsample_bilinear2d_backward.vec(tangents_1, None, [2, 3, 4, 5], False, [2.0, 2.0]);  tangents_1 = None
        return [upsample_bilinear2d_backward_vec]
```

After this change, AOTAutograd would produce the backward graph from the decomposed forward graph. 

```
====== Forward graph ======
class GraphModule(torch.nn.Module):
    def forward(self, primals_1):
        
        # No stacktrace found for following nodes 
        arange = torch.ops.aten.arange.default(8, dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
        arange_1 = torch.ops.aten.arange.default(10, dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
        add_tensor = torch.ops.aten.add.Tensor(arange, 0.5);  arange = None
        mul_tensor = torch.ops.aten.mul.Tensor(add_tensor, 0.5);  add_tensor = None
        sub_tensor = torch.ops.aten.sub.Tensor(mul_tensor, 0.5);  mul_tensor = None
        clamp_default = torch.ops.aten.clamp.default(sub_tensor, 0.0);  sub_tensor = None
        add_tensor_1 = torch.ops.aten.add.Tensor(arange_1, 0.5);  arange_1 = None
        mul_tensor_1 = torch.ops.aten.mul.Tensor(add_tensor_1, 0.5);  add_tensor_1 = None
        sub_tensor_1 = torch.ops.aten.sub.Tensor(mul_tensor_1, 0.5);  mul_tensor_1 = None
        clamp_default_1 = torch.ops.aten.clamp.default(sub_tensor_1, 0.0);  sub_tensor_1 = None
        floor_default = torch.ops.aten.floor.default(clamp_default)
        _to_copy_default = torch.ops.aten._to_copy.default(floor_default, dtype = torch.int64);  floor_default = None
        ceil_default = torch.ops.aten.ceil.default(clamp_default)
        clamp_default_2 = torch.ops.aten.clamp.default(ceil_default, None, 3);  ceil_default = None
        _to_copy_default_1 = torch.ops.aten._to_copy.default(clamp_default_2, dtype = torch.int64);  clamp_default_2 = None
        floor_default_1 = torch.ops.aten.floor.default(clamp_default_1)
        _to_copy_default_2 = torch.ops.aten._to_copy.default(floor_default_1, dtype = torch.int64);  floor_default_1 = None
        ceil_default_1 = torch.ops.aten.ceil.default(clamp_default_1)
        clamp_default_3 = torch.ops.aten.clamp.default(ceil_default_1, None, 4);  ceil_default_1 = None
        _to_copy_default_3 = torch.ops.aten._to_copy.default(clamp_default_3, dtype = torch.int64);  clamp_default_3 = None
        unsqueeze_default = torch.ops.aten.unsqueeze.default(clamp_default, 1);  clamp_default = None
        unsqueeze_default_1 = torch.ops.aten.unsqueeze.default(_to_copy_default, 1);  _to_copy_default = None
        unsqueeze_default_2 = torch.ops.aten.unsqueeze.default(_to_copy_default_1, 1);  _to_copy_default_1 = None
        slice_tensor = torch.ops.aten.slice.Tensor(primals_1, 0, 0, 9223372036854775807)
        slice_tensor_1 = torch.ops.aten.slice.Tensor(slice_tensor, 1, 0, 9223372036854775807);  slice_tensor = None
        index_tensor = torch.ops.aten.index.Tensor(slice_tensor_1, [None, None, unsqueeze_default_1, _to_copy_default_2]);  slice_tensor_1 = None
        slice_tensor_2 = torch.ops.aten.slice.Tensor(primals_1, 0, 0, 9223372036854775807)
        slice_tensor_3 = torch.ops.aten.slice.Tensor(slice_tensor_2, 1, 0, 9223372036854775807);  slice_tensor_2 = None
        index_tensor_1 = torch.ops.aten.index.Tensor(slice_tensor_3, [None, None, unsqueeze_default_2, _to_copy_default_2]);  slice_tensor_3 = None
        slice_tensor_4 = torch.ops.aten.slice.Tensor(primals_1, 0, 0, 9223372036854775807)
        slice_tensor_5 = torch.ops.aten.slice.Tensor(slice_tensor_4, 1, 0, 9223372036854775807);  slice_tensor_4 = None
        index_tensor_2 = torch.ops.aten.index.Tensor(slice_tensor_5, [None, None, unsqueeze_default_1, _to_copy_default_3]);  slice_tensor_5 = None
        slice_tensor_6 = torch.ops.aten.slice.Tensor(primals_1, 0, 0, 9223372036854775807);  primals_1 = None
        slice_tensor_7 = torch.ops.aten.slice.Tensor(slice_tensor_6, 1, 0, 9223372036854775807);  slice_tensor_6 = None
        index_tensor_3 = torch.ops.aten.index.Tensor(slice_tensor_7, [None, None, unsqueeze_default_2, _to_copy_default_3]);  slice_tensor_7 = None
        sub_tensor_2 = torch.ops.aten.sub.Tensor(unsqueeze_default, unsqueeze_default_1);  unsqueeze_default = None
        rsub_scalar = torch.ops.aten.rsub.Scalar(sub_tensor_2, 1.0)
        sub_tensor_3 = torch.ops.aten.sub.Tensor(clamp_default_1, _to_copy_default_2);  clamp_default_1 = None
        rsub_scalar_1 = torch.ops.aten.rsub.Scalar(sub_tensor_3, 1.0)
        mul_tensor_2 = torch.ops.aten.mul.Tensor(index_tensor, rsub_scalar);  index_tensor = None
        mul_tensor_3 = torch.ops.aten.mul.Tensor(index_tensor_1, sub_tensor_2);  index_tensor_1 = None
        add_tensor_2 = torch.ops.aten.add.Tensor(mul_tensor_2, mul_tensor_3);  mul_tensor_2 = mul_tensor_3 = None
        mul_tensor_4 = torch.ops.aten.mul.Tensor(index_tensor_2, rsub_scalar);  index_tensor_2 = None
        mul_tensor_5 = torch.ops.aten.mul.Tensor(index_tensor_3, sub_tensor_2);  index_tensor_3 = None
        add_tensor_3 = torch.ops.aten.add.Tensor(mul_tensor_4, mul_tensor_5);  mul_tensor_4 = mul_tensor_5 = None
        mul_tensor_6 = torch.ops.aten.mul.Tensor(add_tensor_2, rsub_scalar_1);  add_tensor_2 = None
        mul_tensor_7 = torch.ops.aten.mul.Tensor(add_tensor_3, sub_tensor_3);  add_tensor_3 = None
        add_tensor_4 = torch.ops.aten.add.Tensor(mul_tensor_6, mul_tensor_7);  mul_tensor_6 = mul_tensor_7 = None
        add_tensor_5 = torch.ops.aten.add.Tensor(add_tensor_4, 1);  add_tensor_4 = None
        return [add_tensor_5, _to_copy_default_2, unsqueeze_default_1, unsqueeze_default_2, sub_tensor_3, _to_copy_default_3, rsub_scalar_1, sub_tensor_2, rsub_scalar]
        
====== Backward graph ======
class GraphModule(torch.nn.Module):
    def forward(self, _to_copy_default_2, unsqueeze_default_1, unsqueeze_default_2, sub_tensor_3, _to_copy_default_3, rsub_scalar_1, sub_tensor_2, rsub_scalar, tangents_1):
        
        # No stacktrace found for following nodes 
        mul_tensor_8 = torch.ops.aten.mul.Tensor(tangents_1, sub_tensor_3);  sub_tensor_3 = None
        mul_tensor_9 = torch.ops.aten.mul.Tensor(tangents_1, rsub_scalar_1);  tangents_1 = rsub_scalar_1 = None
        mul_tensor_10 = torch.ops.aten.mul.Tensor(mul_tensor_8, sub_tensor_2)
        mul_tensor_11 = torch.ops.aten.mul.Tensor(mul_tensor_8, rsub_scalar);  mul_tensor_8 = None
        mul_tensor_12 = torch.ops.aten.mul.Tensor(mul_tensor_9, sub_tensor_2);  sub_tensor_2 = None
        mul_tensor_13 = torch.ops.aten.mul.Tensor(mul_tensor_9, rsub_scalar);  mul_tensor_9 = rsub_scalar = None
        new_zeros_default = torch.ops.aten.new_zeros.default(mul_tensor_10, [2, 3, 4, 5], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'))
        index_put_default = torch.ops.aten.index_put.default(new_zeros_default, [None, None, unsqueeze_default_2, _to_copy_default_3], mul_tensor_10, True);  new_zeros_default = mul_tensor_10 = None
        slice_backward_default = torch.ops.aten.slice_backward.default(index_put_default, [2, 3, 4, 5], 1, 0, 9223372036854775807, 1);  index_put_default = None
        slice_backward_default_1 = torch.ops.aten.slice_backward.default(slice_backward_default, [2, 3, 4, 5], 0, 0, 9223372036854775807, 1);  slice_backward_default = None
        new_zeros_default_1 = torch.ops.aten.new_zeros.default(mul_tensor_11, [2, 3, 4, 5], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'))
        index_put_default_1 = torch.ops.aten.index_put.default(new_zeros_default_1, [None, None, unsqueeze_default_1, _to_copy_default_3], mul_tensor_11, True);  new_zeros_default_1 = _to_copy_default_3 = mul_tensor_11 = None
        slice_backward_default_2 = torch.ops.aten.slice_backward.default(index_put_default_1, [2, 3, 4, 5], 1, 0, 9223372036854775807, 1);  index_put_default_1 = None
        slice_backward_default_3 = torch.ops.aten.slice_backward.default(slice_backward_default_2, [2, 3, 4, 5], 0, 0, 9223372036854775807, 1);  slice_backward_default_2 = None
        add_tensor_6 = torch.ops.aten.add.Tensor(slice_backward_default_1, slice_backward_default_3);  slice_backward_default_1 = slice_backward_default_3 = None
        new_zeros_default_2 = torch.ops.aten.new_zeros.default(mul_tensor_12, [2, 3, 4, 5], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'))
        index_put_default_2 = torch.ops.aten.index_put.default(new_zeros_default_2, [None, None, unsqueeze_default_2, _to_copy_default_2], mul_tensor_12, True);  new_zeros_default_2 = unsqueeze_default_2 = mul_tensor_12 = None
        slice_backward_default_4 = torch.ops.aten.slice_backward.default(index_put_default_2, [2, 3, 4, 5], 1, 0, 9223372036854775807, 1);  index_put_default_2 = None
        slice_backward_default_5 = torch.ops.aten.slice_backward.default(slice_backward_default_4, [2, 3, 4, 5], 0, 0, 9223372036854775807, 1);  slice_backward_default_4 = None
        add_tensor_7 = torch.ops.aten.add.Tensor(add_tensor_6, slice_backward_default_5);  add_tensor_6 = slice_backward_default_5 = None
        new_zeros_default_3 = torch.ops.aten.new_zeros.default(mul_tensor_13, [2, 3, 4, 5], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'))
        index_put_default_3 = torch.ops.aten.index_put.default(new_zeros_default_3, [None, None, unsqueeze_default_1, _to_copy_default_2], mul_tensor_13, True);  new_zeros_default_3 = unsqueeze_default_1 = _to_copy_default_2 = mul_tensor_13 = None
        slice_backward_default_6 = torch.ops.aten.slice_backward.default(index_put_default_3, [2, 3, 4, 5], 1, 0, 9223372036854775807, 1);  index_put_default_3 = None
        slice_backward_default_7 = torch.ops.aten.slice_backward.default(slice_backward_default_6, [2, 3, 4, 5], 0, 0, 9223372036854775807, 1);  slice_backward_default_6 = None
        add_tensor_8 = torch.ops.aten.add.Tensor(add_tensor_7, slice_backward_default_7);  add_tensor_7 = slice_backward_default_7 = None
        return [add_tensor_8]
```
