### PR TITLE
Retry installing lintrunner if download fails

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,11 @@ jobs:
             **/.github/requirements-gha-cache.txt
 
       - name: Install lintrunner
-        run: pip install lintrunner==0.9.2
+        uses: nick-fields/retry@7d4a37704547a311dbb66ebdf5b23ec19374a767
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: pip install lintrunner==0.9.2
 
       - name: Initialize lint dependencies
         run: lintrunner init


### PR DESCRIPTION
Occasionally lintrunner fails to download due to network issues (it caused one build [to fail](https://github.com/pytorch/pytorch/actions/runs/3054209039/jobs/4925814096) this week)

Let's make sure we retry the download before giving up