### PR TITLE
Remove improper asserts.

### DIFF
--- a/aten/src/ATen/templates/RegisterFunctionalization.cpp
+++ b/aten/src/ATen/templates/RegisterFunctionalization.cpp
@@ -38,8 +38,6 @@ constexpr auto exclude_keys_for_meta_dispatch =
 
 
 inline Tensor to_meta(const Tensor& t) {
-    TORCH_INTERNAL_ASSERT(t.sym_sizes().size() == t.strides().size());
-    TORCH_INTERNAL_ASSERT(t.sym_sizes().size() == t.sym_strides().size());
     return at::native::empty_strided_meta_symint(t.sym_sizes(), t.sym_strides(),
 /*dtype=*/c10::make_optional(t.scalar_type()), /*layout=*/c10::make_optional(t.layout()),
 /*device=*/c10::make_optional(c10::Device(kMeta)), /*pin_memory=*/c10::nullopt);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #85207
* __->__ #85206
* #85205
* #85204

strides() will raise an error if it is called on a tensor with symbolic
shapes, so we cannot actually assert using it.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>