### PR TITLE
[AO] Cubic sparsity level scheduler

### DIFF
--- a/test/ao/sparsity/test_scheduler.py
+++ b/test/ao/sparsity/test_scheduler.py
@@ -3,7 +3,7 @@
 
 from torch import nn
 from torch.ao.sparsity import WeightNormSparsifier
-from torch.ao.sparsity import BaseScheduler, LambdaSL
+from torch.ao.sparsity import BaseScheduler, LambdaSL, CubicSL
 
 from torch.testing._internal.common_utils import TestCase
 
@@ -82,3 +82,98 @@ class TestScheduler(TestCase):
         assert sparsifier.groups[0]['sparsity_level'] == 0.0  # Epoch 0
         scheduler.step()
         assert sparsifier.groups[0]['sparsity_level'] == 5.0  # Epoch 1
+
+
+class TestCubicScheduler(TestCase):
+    def setUp(self):
+        self.model_sparse_config = [
+            {'tensor_fqn': '0.weight', 'sparsity_level': 0.8},
+            {'tensor_fqn': '2.weight', 'sparsity_level': 0.4},
+        ]
+        self.sorted_sparse_levels = [conf['sparsity_level'] for conf in self.model_sparse_config]
+        self.initial_sparsity = 0.1
+        self.initial_step = 3
+
+    def _make_model(self, **kwargs):
+        model = nn.Sequential(
+            nn.Linear(13, 17),
+            nn.Dropout(0.5),
+            nn.Linear(17, 3),
+        )
+        return model
+
+    def _make_scheduler(self, model, **kwargs):
+        sparsifier = WeightNormSparsifier()
+        sparsifier.prepare(model, config=self.model_sparse_config)
+
+        scheduler_args = {
+            'init_sl': self.initial_sparsity,
+            'init_t': self.initial_step,
+        }
+        scheduler_args.update(kwargs)
+
+        scheduler = CubicSL(sparsifier, **scheduler_args)
+        return sparsifier, scheduler
+
+    @staticmethod
+    def _get_sparsity_levels(sparsifier, precision=32):
+        r"""Gets the current levels of sparsity in a sparsifier."""
+        return [round(group['sparsity_level'], precision) for group in sparsifier.groups]
+
+    def test_constructor(self):
+        model = self._make_model()
+        sparsifier, scheduler = self._make_scheduler(model=model, initially_zero=True)
+        self.assertIs(
+            scheduler.sparsifier, sparsifier,
+            msg="Sparsifier is not properly attached")
+        self.assertEqual(
+            scheduler._step_count, 1,
+            msg="Scheduler is initialized with incorrect step count")
+        self.assertEqual(
+            scheduler.base_sl, self.sorted_sparse_levels,
+            msg="Scheduler did not store the target sparsity levels correctly")
+
+        # Value before t_0 is 0
+        self.assertEqual(
+            self._get_sparsity_levels(sparsifier), scheduler._make_sure_a_list(0.0),
+            msg="Sparsifier is not reset correctly after attaching to the Scheduler")
+
+        # Value before t_0 is s_0
+        model = self._make_model()
+        sparsifier, scheduler = self._make_scheduler(model=model, initially_zero=False)
+        self.assertEqual(
+            self._get_sparsity_levels(sparsifier),
+            scheduler._make_sure_a_list(self.initial_sparsity),
+            msg="Sparsifier is not reset correctly after attaching to the Scheduler")
+
+    def test_step(self):
+        # For n=5, dt=2, there will be totally 10 steps between s_0 and s_f, starting from t_0
+        model = self._make_model()
+        sparsifier, scheduler = self._make_scheduler(
+            model=model, initially_zero=True, init_t=3, delta_t=2, total_t=5)
+
+        scheduler.step()
+        scheduler.step()
+        self.assertEqual(scheduler._step_count, 3, msg="Scheduler step_count is expected to increment")
+        # Value before t_0 is supposed to be 0
+        self.assertEqual(
+            self._get_sparsity_levels(sparsifier), scheduler._make_sure_a_list(0.0),
+            msg="Scheduler step updating the sparsity level before t_0")
+
+        scheduler.step()  # Step = 3  =>  sparsity = initial_sparsity
+        self.assertEqual(
+            self._get_sparsity_levels(sparsifier), scheduler._make_sure_a_list(self.initial_sparsity),
+            msg="Sparsifier is not reset to initial sparsity at the first step")
+
+        scheduler.step()  # Step = 4  =>  sparsity ~ [0.3, 0.2]
+        self.assertEqual(
+            self._get_sparsity_levels(sparsifier, 1), [0.3, 0.2],
+            msg="Sparsity level is not set correctly after the first step")
+
+        current_step = scheduler._step_count - scheduler.init_t[0] - 1
+        more_steps_needed = scheduler.delta_t[0] * scheduler.total_t[0] - current_step
+        for _ in range(more_steps_needed):  # More steps needed to final sparsity level
+            scheduler.step()
+        self.assertEqual(
+            self._get_sparsity_levels(sparsifier), self.sorted_sparse_levels,
+            msg="Sparsity level is not reaching the target level afer delta_t * n steps ")

--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -20,6 +20,7 @@ from ao.sparsity.test_pruner import TestBasePruner  # noqa: F401
 
 # Scheduler
 from ao.sparsity.test_scheduler import TestScheduler  # noqa: F401
+from ao.sparsity.test_scheduler import TestCubicScheduler  # noqa: F401
 
 # Composability
 if not IS_ARM64:

--- a/torch/ao/sparsity/__init__.py
+++ b/torch/ao/sparsity/__init__.py
@@ -10,6 +10,7 @@ from .sparsifier.nearly_diagonal_sparsifier import NearlyDiagonalSparsifier
 # Scheduler
 from .scheduler.base_scheduler import BaseScheduler
 from .scheduler.lambda_scheduler import LambdaSL
+from .scheduler.cubic_scheduler import CubicSL
 
 # Parametrizations
 from .sparsifier.utils import FakeSparsity

--- a/torch/ao/sparsity/scheduler/base_scheduler.py
+++ b/torch/ao/sparsity/scheduler/base_scheduler.py
@@ -150,3 +150,15 @@ class BaseScheduler(object):
 
         self._last_sl = [group['sparsity_level'] for group in self.sparsifier.groups]
         self.sparsifier.enable_mask_update = True
+
+    def _make_sure_a_list(self, var):
+        r"""Utility that extends it to the same length as the .groups, ensuring it is a list"""
+        n = len(self.sparsifier.groups)
+        if not isinstance(var, (list, tuple)):
+            return [var] * n
+        else:
+            if len(var) != n:
+                raise ValueError("Expected variable of length {n}, but got {got}".format(
+                    n=n, got=len(var)
+                ))
+            return list(var)  # We want the result to be in a list, not tuple

--- a/torch/ao/sparsity/scheduler/cubic_scheduler.py
+++ b/torch/ao/sparsity/scheduler/cubic_scheduler.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+import warnings
+
+from .base_scheduler import BaseScheduler
+
+__all__ = ["CubicSL"]
+
+def _clamp(x, lo, hi):
+    return max(lo, min(hi, x))
+
+
+class CubicSL(BaseScheduler):
+    r"""Sets the sparsity level of each parameter group to the final sl
+    plus a given exponential function.
+
+    .. math::
+
+        s_i = s_f + (s_0 - s_f) \cdot \left( 1 - \frac{t - t_0}{n\Delta t} \right)^3
+
+    where :math:`s_i` is the sparsity at epoch :math:`t`, :math;`s_f` is the final
+    sparsity level, :math:`f(i)` is the function to be applied to the current epoch
+    :math:`t`, initial epoch :math:`t_0`, and final epoch :math:`t_f`.
+    :math:`\Delta t` is used to control how often the update of the sparsity level
+    happens. By default,
+
+    Args:
+        sparsifier (BaseSparsifier): Wrapped sparsifier.
+        init_sl (int, list): Initial level of sparsity
+        init_t (int, list): Initial step, when pruning starts
+        delta_t (int, list): Pruning frequency
+        total_t (int, list): Total number of pruning steps
+        initially_zero (bool, list): If True, sets the level of sparsity to 0
+            before init_t (:math:`t_0`). Otherwise, the sparsity level before
+            init_t (:math:`t_0`) is set to init_sl(:math:`s_0`)
+        last_epoch (int): The index of last epoch. Default: -1.
+        verbose (bool): If ``True``, prints a message to stdout for
+            each update. Default: ``False``.
+    """
+    def __init__(self,
+                 sparsifier,
+                 init_sl=0.0,
+                 init_t=0,
+                 delta_t=10,
+                 total_t=100,
+                 initially_zero=False,
+                 last_epoch=-1,
+                 verbose=False
+                 ):
+        self.sparsifier = sparsifier
+
+        self.init_sl = self._make_sure_a_list(init_sl)
+        self.init_t = self._make_sure_a_list(init_t)
+        self.delta_t = self._make_sure_a_list(delta_t)
+        self.total_t = self._make_sure_a_list(total_t)
+
+        self.initially_zero = self._make_sure_a_list(initially_zero)
+
+        super().__init__(sparsifier, last_epoch, verbose)
+
+    @staticmethod
+    def sparsity_compute_fn(s_0, s_f, t, t_0, dt, n, initially_zero=False):
+        r""""Computes the current level of sparsity.
+
+        Based on https://arxiv.org/pdf/1710.01878.pdf
+
+        Args:
+            s_0: Initial level of sparsity, :math:`s_i`
+            s_f: Target level of sparsity, :math:`s_f`
+            t: Current step, :math:`t`
+            t_0: Initial step, :math:`t_0`
+            dt: Pruning frequency, :math:`\Delta T`
+            n: Pruning steps, :math:`n`
+            initially_zero: Sets the level of sparsity to 0 before t_0.
+                If False, sets to s_0
+
+        Returns:
+            The sparsity level :math:`s_t` at the current step :math:`t`
+        """
+        if initially_zero and t < t_0:
+            return 0
+        s_t = s_f + (s_0 - s_f) * (1.0 - (t - t_0) / (dt * n)) ** 3
+        s_t = _clamp(s_t, s_0, s_f)
+        return s_t
+
+    def get_sl(self):
+        if not self._get_sl_called_within_step:
+            warnings.warn(
+                "To get the last sparsity level computed by the scheduler, "
+                "please use `get_last_sl()`.")
+        return [
+            self.sparsity_compute_fn(
+                s_0=initial_sparsity,
+                s_f=final_sparsity,
+                t=self.last_epoch,
+                t_0=initial_epoch,
+                dt=delta_epoch,
+                n=interval_epochs,
+                initially_zero=initially_zero
+            ) for initial_sparsity, final_sparsity, initial_epoch, delta_epoch, interval_epochs, initially_zero in
+            zip(
+                self.init_sl,
+                self.base_sl,
+                self.init_t,
+                self.delta_t,
+                self.total_t,
+                self.initially_zero
+            )
+        ]


### PR DESCRIPTION
The scheduler updates the levels of sparsity based on https://arxiv.org/abs/1710.01878.

 ## Implementation

The update rule is defined as:

$$
\begin{aligned}
s_t &= s_f + (s_i - s_f)\left( 1 - \frac{t - t_0}{n\Delta t} \right)^3  \\
\mbox{for} ~ t &\in \left\\{ t_0, t_0+\Delta t, \dots, t_0 + n\Delta t \right\\} \end{aligned}
$$

There is a minor difference compared to the original paper. By providing `initially_zero` argument, one can set the level of sparsity before step $t_0$: If `False`, the sparsity level before $t_0$ is set to $s_i$, otherwise 0.

 ## Tests

```
python test/test_ao_sparsity.py -- TestCubicScheduler
```