### PR TITLE
Setup torch/csrc/functorch/*; move CompileCache.{h, cpp} there

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -894,6 +894,7 @@ libtorch_python_core_sources = [
     "torch/csrc/autograd/python_torch_functions_manual.cpp",
     "torch/csrc/autograd/python_variable.cpp",
     "torch/csrc/autograd/python_variable_indexing.cpp",
+    "torch/csrc/functorch/CompileCache.cpp",
     "torch/csrc/jit/backends/backend_init.cpp",
     "torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp",
     "torch/csrc/jit/python/init.cpp",

--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -14,7 +14,7 @@
 #include <functorch/csrc/LegacyVmapTransforms.h>
 #include <functorch/csrc/BatchedFallback.h>
 #include <functorch/csrc/BatchRulesHelper.h>
-#include <functorch/csrc/CompileCache.h>
+#include <torch/csrc/functorch/CompileCache.h>
 #include <c10/core/AutogradState.h>
 #include <functorch/csrc/dim/dim.h>
 
@@ -407,7 +407,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("set_fwd_grad_enabled", &at::functorch::set_fwd_grad_enabled);
   m.def("get_fwd_grad_enabled", &at::functorch::get_fwd_grad_enabled);
 
-  at::functorch::initCompileCacheBindings(m.ptr());
+  torch::functorch::initCompileCacheBindings(m.ptr());
 
   // initialize first-class dims and install it as a submodule on _C
   auto dim = Dim_init();

--- a/torch/csrc/functorch/CompileCache.cpp
+++ b/torch/csrc/functorch/CompileCache.cpp
@@ -15,6 +15,7 @@
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/jit/tensorexpr/codegen.h>
 #include <torch/csrc/utils/pybind.h>
+#include <torch/csrc/utils/python_numbers.h>
 
 using namespace torch::jit::tensorexpr;
 
@@ -185,7 +186,7 @@ public:
     for (int i = numTensorArgs; i < PyTuple_Size(args); i++) {
       PyObject *arg = PyTuple_GET_ITEM(args, i);
       assert(PyLong_Check(arg));
-      cacheKey.push_back(PyLong_AsLong(arg));
+      cacheKey.push_back(THPUtils_unpackLong(arg));
     }
     return cacheKey;
   }

--- a/torch/csrc/functorch/CompileCache.cpp
+++ b/torch/csrc/functorch/CompileCache.cpp
@@ -10,8 +10,8 @@
 /// allowing different types of hashing functions, and is agnostic of the
 /// compiler.
 ///
-#include <torch/csrc/functorch/CompileCache.h>
 #include <torch/csrc/autograd/custom_function.h>
+#include <torch/csrc/functorch/CompileCache.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/jit/tensorexpr/codegen.h>
 #include <torch/csrc/utils/pybind.h>
@@ -35,13 +35,13 @@ struct LocalState {
 };
 
 /// Helper to pack tensor (dtype, requires grad) into an 8-bit key.
-static uint8_t packFlags(const LocalState &state, const at::Tensor &v) {
-  static_assert(static_cast<int>(at::ScalarType::NumOptions) < 128,
-                "overflow possible");
+static uint8_t packFlags(const LocalState& state, const at::Tensor& v) {
+  static_assert(
+      static_cast<int>(at::ScalarType::NumOptions) < 128, "overflow possible");
   at::ScalarType dtype = v.dtype().toScalarType();
   bool requires_grad = state.gradModeEnabled && v.requires_grad();
   return static_cast<uint8_t>(requires_grad) |
-         (static_cast<uint8_t>(dtype) << 1);
+      (static_cast<uint8_t>(dtype) << 1);
 }
 
 using hash_key_t = std::vector<int64_t>;
@@ -97,11 +97,13 @@ std::vector<int> genDimFlags(c10::IntArrayRef sizes, c10::IntArrayRef strides) {
       flag |= STRIDE_ZERO;
     } else if (strides[dim] == 1) {
       flag |= STRIDE_ONE;
-    } else if (dim + 1 < (int64_t)sizes.size() &&
-               strides[dim] == strides[dim + 1] * sizes[dim + 1]) {
+    } else if (
+        dim + 1 < (int64_t)sizes.size() &&
+        strides[dim] == strides[dim + 1] * sizes[dim + 1]) {
       flag |= STRIDE_CONTIGUOUS;
-    } else if (dim > 0 && strides[dim] == strides[dim - 1] * sizes[dim - 1] &&
-               (dimflags[dim - 1] & STRIDE_CONTIGUOUS) == 0) {
+    } else if (
+        dim > 0 && strides[dim] == strides[dim - 1] * sizes[dim - 1] &&
+        (dimflags[dim - 1] & STRIDE_CONTIGUOUS) == 0) {
       flag |= STRIDE_TRANSPOSED_CONTIGUOUS;
     } else {
       flag |= STRIDE_AS_ARG;
@@ -111,10 +113,12 @@ std::vector<int> genDimFlags(c10::IntArrayRef sizes, c10::IntArrayRef strides) {
   return dimflags;
 }
 
-hash_key_t dynamic_hasher(const LocalState &state, const at::Tensor &v) {
-  hash_key_t hash = {DYNAMIC_HASH, static_cast<int>(packFlags(state, v)),
-                     static_cast<int>(state.apply(v.key_set()).raw_repr()),
-                     static_cast<int>(v.ndimension())};
+hash_key_t dynamic_hasher(const LocalState& state, const at::Tensor& v) {
+  hash_key_t hash = {
+      DYNAMIC_HASH,
+      static_cast<int>(packFlags(state, v)),
+      static_cast<int>(state.apply(v.key_set()).raw_repr()),
+      static_cast<int>(v.ndimension())};
   auto dimFlags = genDimFlags(v.sizes(), v.strides());
   hash.insert(hash.end(), dimFlags.begin(), dimFlags.end());
   return hash;
@@ -122,10 +126,12 @@ hash_key_t dynamic_hasher(const LocalState &state, const at::Tensor &v) {
 
 /// Per-tensor cache specialization key targetting static shapes. Recordsdtype,
 /// dispatch options, aliasing, and full shapes and strides.
-hash_key_t static_hasher(const LocalState &state, const at::Tensor &v) {
-  hash_key_t hash = {STATIC_HASH, static_cast<int>(packFlags(state, v)),
-                     static_cast<int>(state.apply(v.key_set()).raw_repr()),
-                     static_cast<int>(v.ndimension())};
+hash_key_t static_hasher(const LocalState& state, const at::Tensor& v) {
+  hash_key_t hash = {
+      STATIC_HASH,
+      static_cast<int>(packFlags(state, v)),
+      static_cast<int>(state.apply(v.key_set()).raw_repr()),
+      static_cast<int>(v.ndimension())};
   hash.insert(hash.end(), v.sizes().begin(), v.sizes().end());
   hash.insert(hash.end(), v.strides().begin(), v.strides().end());
   return hash;
@@ -134,7 +140,7 @@ hash_key_t static_hasher(const LocalState &state, const at::Tensor &v) {
 /// ArgCompileCache is a templated class allowing plugging of different types of
 /// Hasher/Specialization Keys.
 struct CompileCache {
-public:
+ public:
   CompileCache() = default;
   ~CompileCache() = default;
 
@@ -142,10 +148,10 @@ public:
 
   /// Cache type mapping specialization keys to compiled kernels.
   class vector_hasher {
-  public:
-    std::size_t operator()(hash_key_t const &vec) const {
+   public:
+    std::size_t operator()(hash_key_t const& vec) const {
       std::size_t seed = vec.size();
-      for (auto &i : vec) {
+      for (auto& i : vec) {
         seed ^= i + 0x9e3779b9 + (seed << 6) + (seed >> 2);
       }
       return seed;
@@ -155,11 +161,14 @@ public:
 
   /// Compute the set of specialization keys based on the inputs to
   /// the kernel.
-  hash_key_t computeCacheKey(PyObject *args,
-                             const std::vector<at::Tensor> &tensorArgs,
-                             int numTensorArgs, const std::string &hasherType,
-                             int64_t id, int64_t fw_compiler_id,
-                             int64_t bw_compiler_id) {
+  hash_key_t computeCacheKey(
+      PyObject* args,
+      const std::vector<at::Tensor>& tensorArgs,
+      int numTensorArgs,
+      const std::string& hasherType,
+      int64_t id,
+      int64_t fw_compiler_id,
+      int64_t bw_compiler_id) {
     LocalState state;
     hash_key_t cacheKey;
     for (int i = 0; i < numTensorArgs; ++i) {
@@ -184,18 +193,18 @@ public:
 
     // Cache the non-tensor args. Currently, all the non-tensor args are cached.
     for (int i = numTensorArgs; i < PyTuple_Size(args); i++) {
-      PyObject *arg = PyTuple_GET_ITEM(args, i);
+      PyObject* arg = PyTuple_GET_ITEM(args, i);
       assert(PyLong_Check(arg));
       cacheKey.push_back(THPUtils_unpackLong(arg));
     }
     return cacheKey;
   }
 
-  std::vector<at::Tensor> parsePythonArgs(int numTensorArgs, PyObject *args) {
+  std::vector<at::Tensor> parsePythonArgs(int numTensorArgs, PyObject* args) {
     // Convert to Tensor Args
     std::vector<at::Tensor> tensorArgs(numTensorArgs);
     for (int i = 0; i < numTensorArgs; ++i) {
-      PyObject *arg = PyTuple_GET_ITEM(args, i);
+      PyObject* arg = PyTuple_GET_ITEM(args, i);
       if (arg == Py_None) {
         // If an input tensor is None, add it as an undefined tensor.
         tensorArgs[i] = at::Tensor();
@@ -203,12 +212,12 @@ public:
         // Fail if its a non-tensor arg. It should be marked static.
         std::string dtype = Py_TYPE(arg)->tp_name;
         std::string index = std::to_string(i);
-        throw std::runtime_error("Found an argument of type " + dtype +
-                                 " at index " + index +
-                                 ". Non-tensor arguments must be marked static."
-                                 " Please set the static_argnums correctly to "
-                                 "mark the argument at index " +
-                                 index + " static.");
+        throw std::runtime_error(
+            "Found an argument of type " + dtype + " at index " + index +
+            ". Non-tensor arguments must be marked static."
+            " Please set the static_argnums correctly to "
+            "mark the argument at index " +
+            index + " static.");
       } else {
         tensorArgs[i] = THPVariable_Unpack(arg);
       }
@@ -217,13 +226,22 @@ public:
   }
 
   /// Check if the function has already been compiled.
-  py::object at(int64_t id, int64_t fw_compiler_id, int64_t bw_compiler_id,
-                int numTensorArgs, const std::string &hasherType,
-                PyObject *args) {
+  py::object at(
+      int64_t id,
+      int64_t fw_compiler_id,
+      int64_t bw_compiler_id,
+      int numTensorArgs,
+      const std::string& hasherType,
+      PyObject* args) {
     std::vector<at::Tensor> tensorArgs = parsePythonArgs(numTensorArgs, args);
-    hash_key_t cacheKey =
-        computeCacheKey(args, tensorArgs, numTensorArgs, hasherType, id,
-                        fw_compiler_id, bw_compiler_id);
+    hash_key_t cacheKey = computeCacheKey(
+        args,
+        tensorArgs,
+        numTensorArgs,
+        hasherType,
+        id,
+        fw_compiler_id,
+        bw_compiler_id);
 
     auto item = cache_.find(cacheKey); // protected by GIL
 
@@ -234,56 +252,94 @@ public:
   }
 
   /// Insert a new compiled functions for new tensor properties.
-  void insert(int64_t id, int64_t fw_compiler_id, int64_t bw_compiler_id,
-              int numTensorArgs, const std::string &hasherType,
-              const py::object &compileFn, PyObject *args) {
+  void insert(
+      int64_t id,
+      int64_t fw_compiler_id,
+      int64_t bw_compiler_id,
+      int numTensorArgs,
+      const std::string& hasherType,
+      const py::object& compileFn,
+      PyObject* args) {
     std::vector<at::Tensor> tensorArgs = parsePythonArgs(numTensorArgs, args);
     LocalState state;
-    hash_key_t cacheKey =
-        computeCacheKey(args, tensorArgs, numTensorArgs, hasherType, id,
-                        fw_compiler_id, bw_compiler_id);
+    hash_key_t cacheKey = computeCacheKey(
+        args,
+        tensorArgs,
+        numTensorArgs,
+        hasherType,
+        id,
+        fw_compiler_id,
+        bw_compiler_id);
     cache_.emplace(cacheKey, compileFn);
   }
 
-  int64_t size() const { return cache_.size(); }
+  int64_t size() const {
+    return cache_.size();
+  }
 
   /// Clear the cache.
-  void clear() { cache_.clear(); }
+  void clear() {
+    cache_.clear();
+  }
 
-private:
+ private:
   /// Compilation cache holding key and the compiled function.
   Cache cache_;
 };
 
-static CompileCache *createCompileCache() { return new CompileCache(); }
+static CompileCache* createCompileCache() {
+  return new CompileCache();
+}
 
 } // namespace
 
 namespace torch {
 namespace functorch {
 
-void initCompileCacheBindings(PyObject *module) {
+void initCompileCacheBindings(PyObject* module) {
   py::handle te(module);
   py::class_<CompileCache>(te, "CompileCache")
       .def(py::init(&createCompileCache))
-      .def("at",
-           [](CompileCache &self, int64_t id, int64_t fw_compiler_id,
-              int64_t bw_compiler_id, int numTensorArgs,
-              const std::string &hasherType, py::args args) {
-             return self.at(id, fw_compiler_id, bw_compiler_id, numTensorArgs,
-                            hasherType, args.ptr());
-           })
-      .def("insert",
-           [](CompileCache &self, int64_t id, int64_t fw_compiler_id,
-              int64_t bw_compiler_id, int numTensorArgs,
-              const std::string &hasherType, const py::object &compileFn,
-              py::args args, py::kwargs kwargs) {
-             self.insert(id, fw_compiler_id, bw_compiler_id, numTensorArgs,
-                         hasherType, compileFn, args.ptr());
-           })
-      .def("clear", [](CompileCache &self) { self.clear(); })
-      .def("size", [](CompileCache &self) { return self.size(); });
+      .def(
+          "at",
+          [](CompileCache& self,
+             int64_t id,
+             int64_t fw_compiler_id,
+             int64_t bw_compiler_id,
+             int numTensorArgs,
+             const std::string& hasherType,
+             py::args args) {
+            return self.at(
+                id,
+                fw_compiler_id,
+                bw_compiler_id,
+                numTensorArgs,
+                hasherType,
+                args.ptr());
+          })
+      .def(
+          "insert",
+          [](CompileCache& self,
+             int64_t id,
+             int64_t fw_compiler_id,
+             int64_t bw_compiler_id,
+             int numTensorArgs,
+             const std::string& hasherType,
+             const py::object& compileFn,
+             py::args args,
+             py::kwargs kwargs) {
+            self.insert(
+                id,
+                fw_compiler_id,
+                bw_compiler_id,
+                numTensorArgs,
+                hasherType,
+                compileFn,
+                args.ptr());
+          })
+      .def("clear", [](CompileCache& self) { self.clear(); })
+      .def("size", [](CompileCache& self) { return self.size(); });
 }
 
 } // namespace functorch
-} // namespace at
+} // namespace torch

--- a/torch/csrc/functorch/CompileCache.cpp
+++ b/torch/csrc/functorch/CompileCache.cpp
@@ -10,7 +10,7 @@
 /// allowing different types of hashing functions, and is agnostic of the
 /// compiler.
 ///
-#include <functorch/csrc/CompileCache.h>
+#include <torch/csrc/functorch/CompileCache.h>
 #include <torch/csrc/autograd/custom_function.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/jit/tensorexpr/codegen.h>
@@ -258,7 +258,7 @@ static CompileCache *createCompileCache() { return new CompileCache(); }
 
 } // namespace
 
-namespace at {
+namespace torch {
 namespace functorch {
 
 void initCompileCacheBindings(PyObject *module) {

--- a/torch/csrc/functorch/CompileCache.h
+++ b/torch/csrc/functorch/CompileCache.h
@@ -10,10 +10,12 @@
 namespace torch {
 namespace functorch {
 
-// CompileCache is the compilation cache used for AOTAutograd.
+// CompileCache is the compilation cache used by the AOTAutograd frontend.
+// We're planning on deleting this in favor of torchdynamo's caching mechanism
+// (CompilerCache predates torchdynamo).
 
 /// Initialize python bindings for kernel compilation cache.
-void initCompileCacheBindings(PyObject *module);
+TORCH_API void initCompileCacheBindings(PyObject* module);
 
 } // namespace functorch
-} // namespace at
+} // namespace torch

--- a/torch/csrc/functorch/CompileCache.h
+++ b/torch/csrc/functorch/CompileCache.h
@@ -7,7 +7,7 @@
 
 #include <torch/csrc/utils/pybind.h>
 
-namespace at {
+namespace torch {
 namespace functorch {
 
 // CompileCache is the compilation cache used for AOTAutograd.


### PR DESCRIPTION
The plan for functorch C++ is:
- all C++-only code goes into aten/functorch.
- any C++ code with a python dependency goes into torch/csrc/functorch. This will include the functorch Python bindings as well as all of torchdim.

Alternative:
- we could split it so that code goes into torch/csrc/functorch/nopython and torch/csrc/functorch/python instead of putting anything into ATen. This just feels like a matter of cosmetics.

This PR also does two more things:
- fix a windows lint error regarding PyLong_asLong
- clang-format the code (because the linter got triggered)

Test Plan:
- run tests
- check internal build

Fixes #ISSUE_NUMBER
