### PR TITLE
Setup torch/csrc/functorch/*; move CompileCache.{h, cpp} there

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -894,6 +894,7 @@ libtorch_python_core_sources = [
     "torch/csrc/autograd/python_torch_functions_manual.cpp",
     "torch/csrc/autograd/python_variable.cpp",
     "torch/csrc/autograd/python_variable_indexing.cpp",
+    "torch/csrc/functorch/CompileCache.cpp",
     "torch/csrc/jit/backends/backend_init.cpp",
     "torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp",
     "torch/csrc/jit/python/init.cpp",

--- a/torch/csrc/functorch/CompileCache.cpp
+++ b/torch/csrc/functorch/CompileCache.cpp
@@ -10,7 +10,7 @@
 /// allowing different types of hashing functions, and is agnostic of the
 /// compiler.
 ///
-#include <functorch/csrc/CompileCache.h>
+#include <torch/csrc/functorch/CompileCache.h>
 #include <torch/csrc/autograd/custom_function.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/jit/tensorexpr/codegen.h>
@@ -258,7 +258,7 @@ static CompileCache *createCompileCache() { return new CompileCache(); }
 
 } // namespace
 
-namespace at {
+namespace torch {
 namespace functorch {
 
 void initCompileCacheBindings(PyObject *module) {

--- a/torch/csrc/functorch/CompileCache.h
+++ b/torch/csrc/functorch/CompileCache.h
@@ -7,7 +7,7 @@
 
 #include <torch/csrc/utils/pybind.h>
 
-namespace at {
+namespace torch {
 namespace functorch {
 
 // CompileCache is the compilation cache used for AOTAutograd.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #85288
* #85287
* __->__ #85286

The plan for functorch C++ is:
- all C++-only code goes into aten/functorch.
- any C++ code with a python dependency goes into torch/csrc/functorch.
This will include the functorch Python bindings as well as all of
torchdim.

Alternative:
- we could split it so that code goes into torch/csrc/functorch/nopython
and torch/csrc/functorch/python instead of putting anything into ATen.
This just feels like a matter of cosmetics.

Test Plan:
- run tests
- check internal build