### PR TITLE
[Static Runtime] Fold linear prepack ops

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1337,6 +1337,10 @@ struct WeakOrStrongCompilationUnit {
     return strong_ptr_ != c10::nullopt;
   }
 
+  bool holdingEmptyStrongRef() const {
+    return holdingStrongRef() && *strong_ptr_ == nullptr;
+  }
+
   c10::optional<std::shared_ptr<torch::jit::CompilationUnit>> strong_ptr_;
   c10::optional<std::weak_ptr<torch::jit::CompilationUnit>> weak_ptr_;
 };
@@ -1360,8 +1364,13 @@ struct TORCH_API WeakOrStrongTypePtr {
 
   WeakOrStrongCompilationUnit cu_;
   TypePtr type_;
+
   bool holds_strong_ref() const {
     return cu_.holdingStrongRef();
+  }
+
+  bool holds_empty_strong_ref() const {
+    return cu_.holdingEmptyStrongRef();
   }
 };
 

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1455,6 +1455,10 @@ struct C10_EXPORT ivalue::Object final : c10::intrusive_ptr_target {
     return !type_.holds_strong_ref();
   }
 
+  bool is_empty_strong_compilation_ref() const {
+    return type_.holds_empty_strong_ref();
+  }
+
  private:
   void resizeObject(size_t slot);
   WeakOrStrongTypePtr type_;

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -3666,3 +3666,38 @@ TEST(StaticRuntime, ClampNaNToNum) {
   testStaticRuntime(src1, {a.to(at::kDouble)}, {}, /*use_allclose=*/true, /*use_equalnan=*/true);
   testStaticRuntime(src1, {a.to(at::kDouble)}, {b.to(at::kDouble)}, /*use_allclose=*/true, /*use_equalnan=*/true);
 }
+
+TEST(StaticRuntime, PrepackWeights) {
+  const std::string src = R"IR(
+    graph(%input: Tensor, %weight: Tensor, %bias: Tensor?, %scale: Tensor, %zero_point: Tensor):
+        %none: NoneType = prim::Constant()
+        %result: Tensor = fb::quantized_linear_unpacked_weight_v2(%input, %weight, %bias, %scale, %zero_point)
+        %dequantized: Tensor = aten::dequantize(%result)
+        return (%dequantized)
+  )IR";
+
+  auto graph = getGraphFromIR(src);
+  PrepackWeights(graph);
+  ASSERT_TRUE(graphHasOp(graph, "quantized::linear"));
+  ASSERT_TRUE(graphHasOp(graph, "quantized::linear_prepack"));
+  ASSERT_FALSE(graphHasOp(graph, "fb::quantized_linear_unpacked_weight_v2"));
+
+  auto scale = at::tensor({2}, at::kFloat);
+  auto zero_point = at::tensor({3}, at::kLong);
+
+  auto weight =
+      at::quantize_per_tensor(torch::randn({3, 2}), 2, 3, torch::kQInt8);
+  auto input =
+      at::quantize_per_tensor(torch::randn({3, 2}), 2, 3, torch::kQUInt8);
+  auto args1 = std::vector<IValue>{input, weight, c10::nullopt, scale, zero_point};
+
+  auto weight_2 =
+      at::quantize_per_tensor(torch::randn({8, 3}), 2, 3, torch::kQInt8);
+  auto input_2 =
+      at::quantize_per_tensor(torch::randn({9, 3}), 2, 3, torch::kQUInt8);
+  auto bias_2 = torch::randn({3}, torch::kFloat);
+  auto args2 = std::vector<IValue>{input, weight, bias_2, scale, zero_point};
+
+  testStaticRuntime(src, args1);
+  testStaticRuntime(src, args2);
+}

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -126,7 +126,9 @@ c10::optional<Value*> tryInsertConstant(
   } else if (val.isObject()) {
     const auto& ref = val.toObjectRef();
     // see: [Constant Object Weak CompilationUnit Reference]
-    if (!ref.type()->is_module() && ref.is_weak_compilation_ref()) {
+    if (!ref.type()->is_module() &&
+        (ref.is_weak_compilation_ref() ||
+         ref.is_empty_strong_compilation_ref())) {
       n->ival_(attr::value, val);
       n->output()->setType(val.type());
     } else {

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -161,6 +161,7 @@ void OptimizeGraph(
   UseVariadicStack(graph);
   EliminateTrivialEquallySplit(graph);
   EliminateExtraPermuteOps(graph);
+  PrepackWeights(graph);
 
   if (opts.enable_out_variant) {
     UseVariadicOp(

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -85,5 +85,7 @@ TORCH_API void FuseClampNaNToNum(std::shared_ptr<Graph>& graph);
 TORCH_API void UseInPlaceGetRealInputsFromOptionalInputsV2(
     std::shared_ptr<Graph>& graph);
 
+TORCH_API void PrepackWeights(std::shared_ptr<Graph>& graph);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Split `quantized_linear_unpacked_weight_v2` into `linear_prepack` and `quantized_linear` so that the prepacking operation may be eliminated by constant folding.

Test Plan:
Fixes a huge regression in an internal model:

```
Before
        89.6141 ms.    99.0923%. fb::quantized_linear_unpacked_weight_v2 (12 nodes)
After
       0.806852 ms.    53.5365%. quantized::linear (12 nodes, out variant)
(prepacking eliminated)
```

Differential Revision: D39622530

