### PR TITLE
[functorch] Fix dangling impls

### DIFF
--- a/functorch/csrc/BatchRulesDecompositions.cpp
+++ b/functorch/csrc/BatchRulesDecompositions.cpp
@@ -181,6 +181,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   OP_DECOMPOSE(pairwise_distance);
   OP_DECOMPOSE(pinverse);
   OP_DECOMPOSE(poisson_nll_loss);
+  OP_DECOMPOSE(positive);
   OP_DECOMPOSE(qr);
   OP_DECOMPOSE(ravel);
   OP_DECOMPOSE2(repeat_interleave, self_int);

--- a/functorch/csrc/BatchRulesDynamic.cpp
+++ b/functorch/csrc/BatchRulesDynamic.cpp
@@ -64,7 +64,10 @@ void unsupportedAllclose(const c10::OperatorHandle& op, torch::jit::Stack* stack
 TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
     UNSUPPORTED_DYNAMIC(nonzero);
     UNSUPPORTED_DYNAMIC(where);
-    UNSUPPORTED_DYNAMIC(unique);
+    UNSUPPORTED_DYNAMIC(unique_dim);
+    UNSUPPORTED_DYNAMIC(unique_consecutive);
+    UNSUPPORTED_DYNAMIC(unique_dim_consecutive);
+    UNSUPPORTED_DYNAMIC(_unique2);
     m.impl("_local_scalar_dense", torch::CppFunction::makeFromBoxedFunction<&unsupportedLocalScalarDense>());
     m.impl("item", torch::CppFunction::makeFromBoxedFunction<&unsupportedItem>());
     m.impl("is_nonzero", torch::CppFunction::makeFromBoxedFunction<&unsupportedIsNonzero>());

--- a/functorch/csrc/BatchRulesUnaryOps.cpp
+++ b/functorch/csrc/BatchRulesUnaryOps.cpp
@@ -139,7 +139,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   UNARY_POINTWISE_ALL(mvlgamma);
   UNARY_POINTWISE_ALL(nan_to_num);
   UNARY_POINTWISE_ALL(neg);
-  UNARY_POINTWISE_ALL(positive);
   UNARY_POINTWISE_ALL(rad2deg);
   UNARY_POINTWISE_ALL(reciprocal);
   UNARY_POINTWISE_ALL(round);

--- a/functorch/test/test_vmap.py
+++ b/functorch/test/test_vmap.py
@@ -3196,6 +3196,8 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('nn.functional.dropout'),  # works, can't check against for loop because of randomness inconsistency
         xfail('masked_select'),  # dynamic op
         xfail('nonzero'),  # dynamic op
+        xfail('unique', ''),  # dynamic op
+        xfail('unique_consecutive', ''),  # dynamic op
         xfail('allclose'),  # returns a boolean
         xfail('uniform'),  # randomness is tested separately
         xfail('rand_like'),  # randomness is tested separately

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -759,6 +759,10 @@ CompositeImplicitAutograd[alias] (inactive): fn1 :: (Tensor _0) -> Tensor _0 [ b
 '''
         )
 
+    # Definition: a dangling impl happens when someone does an impl() on a
+    # function but not a def() for it. This is usually a bug, e.g. someone
+    # misspelled an operator name, or someone registered an impl for an op that
+    # no longer exists
     @skipIfTorchDynamo("Installing functorch reveals a dangling impl - aten::postive_")
     def test_find_dangling_impls(self):
         dangling_impls = C._dispatch_find_dangling_impls()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #85299
* #85152
* #85151

Our dangling impls were:
- positive_ (the in-place op just never existed)
- unique (something happened to this op, maybe it was renamed)

Test Plan:
- `import functorch; torch._C._dispatch_find_dangling_impls`
- It's difficult to write a test for this because the number of dangling
impls depends on if `test_dispatch` has been run already or not
(test_dispatch adds a dangling impl)
- Can't remove the torchdynamo skip for this yet either