### PR TITLE
Adds refs.randn_like

### DIFF
--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -577,6 +577,7 @@ def canonicalize_device(device: DeviceLikeType) -> torch.device:
 # Asserts if any of the following are true:
 #   - a non-scalar or non-Tensor is given
 #   - the shape of any tensors is distinct
+# TODO: rename the kwarg allow_cpu_scalar_tensors to be clearer
 def check_same_shape(*args, allow_cpu_scalar_tensors: bool):
     """
     Checks that all Tensors in args have the same shape.


### PR DESCRIPTION
This PR adds `refs.randn_like` with a new pattern for `_like` tensor factories:

- The `foo_like` operation calls `empty_like` to create the proper metadata
- It calls  the `foo` operation (`randn` in this case)
- It finishes by "filling" the `empty_like` metadata with the values created from the `foo` operation

This pattern requires updating `refs.fill(a, value)` to accept a tensor for value, and not just a number.

This PR also adds a new SampleInput for `randn`, as suggested by @ngimel in https://github.com/pytorch/pytorch/pull/85128.