### PR TITLE
Add a reset() method to nvFuser FusionCache to enable proper resetting during tests.

### DIFF
--- a/torch/csrc/jit/codegen/cuda/python_frontend/fusion_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/fusion_cache.cpp
@@ -19,6 +19,7 @@ FusionCache* FusionCache::get(size_t max_fusions) {
   if (singleton_ == nullptr) {
     singleton_ = new FusionCache(max_fusions);
   }
+  singleton_->max_fusions_ = max_fusions;
   return singleton_;
 }
 
@@ -45,6 +46,15 @@ void FusionCache::print(std::ostream& os) {
     os << "Cache Lookups: " << fusion_cache_start_->visits;
     os << " Cache Hits: " << total_cache_hits;
     os << " Hit Rate: " << hit_rate << "%\n";
+  }
+}
+
+void FusionCache::reset() {
+  std::lock_guard<std::mutex> guard(fusion_cache_lock);
+  if (singleton_ != nullptr) {
+    auto max_fusions = singleton_->max_fusions_;
+    delete singleton_;
+    singleton_ = new FusionCache(max_fusions);
   }
 }
 

--- a/torch/csrc/jit/codegen/cuda/python_frontend/fusion_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/fusion_cache.cpp
@@ -19,7 +19,8 @@ FusionCache* FusionCache::get(size_t max_fusions) {
   if (singleton_ == nullptr) {
     singleton_ = new FusionCache(max_fusions);
   }
-  TORCH_CHECK(max_fusions >= singleton_->fusions_.size(),
+  TORCH_CHECK(
+      max_fusions >= singleton_->fusions_.size(),
       "The max fusions is set less than the number of fusions in the cache.");
   singleton_->max_fusions_ = max_fusions;
   return singleton_;

--- a/torch/csrc/jit/codegen/cuda/python_frontend/fusion_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/fusion_cache.cpp
@@ -19,6 +19,8 @@ FusionCache* FusionCache::get(size_t max_fusions) {
   if (singleton_ == nullptr) {
     singleton_ = new FusionCache(max_fusions);
   }
+  TORCH_CHECK(max_fusions >= singleton_->fusions_.size(),
+      "The max fusions is set less than the number of fusions in the cache.");
   singleton_->max_fusions_ = max_fusions;
   return singleton_;
 }

--- a/torch/csrc/jit/codegen/cuda/python_frontend/fusion_cache.h
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/fusion_cache.h
@@ -67,6 +67,8 @@ class TORCH_CUDA_CU_API FusionCache {
   size_t numFusions() const;
   //! print cache stats
   void print(std::ostream& os);
+  //! Reset Cache to an empty state
+  static void reset();
 
   //! The rest of the public methods are only used in C++
 

--- a/torch/csrc/jit/codegen/cuda/python_frontend/test/test_nvfuser_fusion_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/test/test_nvfuser_fusion_cache.cpp
@@ -29,7 +29,7 @@ TEST_F(NVFuserTest, PyFusionCache_CUDA) {
   // You should never get a nullptr
   ASSERT_FALSE(fc == nullptr);
   ASSERT_TRUE(fc->numFusions() == 0);
-  
+
   // Check that cache methods all assert when presented with a null record.
   {
     std::unique_ptr<RecordFunctor> null_record(nullptr);

--- a/torch/csrc/jit/codegen/cuda/python_frontend/test/test_nvfuser_fusion_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/test/test_nvfuser_fusion_cache.cpp
@@ -16,12 +16,20 @@ using namespace torch::jit::fuser::cuda;
 
 // RUN CMD: bin/test_jit --gtest_filter="NVFuserTest*PyFusionCache*"
 TEST_F(NVFuserTest, PyFusionCache_CUDA) {
+  // Reset cache before testing.
+  try {
+    FusionCache::reset();
+    SUCCEED();
+  } catch (const std::exception& e) {
+    FAIL() << "Did not properly reset cache!" << e.what();
+  }
+
   // Create a fusion manager with a maximum of 1 Fusion
   FusionCache* fc = FusionCache::get(1);
-
   // You should never get a nullptr
   ASSERT_FALSE(fc == nullptr);
-
+  ASSERT_TRUE(fc->numFusions() == 0);
+  
   // Check that cache methods all assert when presented with a null record.
   {
     std::unique_ptr<RecordFunctor> null_record(nullptr);


### PR DESCRIPTION
Fixes issue Jie found in his PR:

https://github.com/pytorch/pytorch/pull/84626#issuecomment-1250745334