### PR TITLE
Add support for map_location for backends

### DIFF
--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -222,7 +222,21 @@ def _rebuild_sparse_csr_tensor(layout, data):
     raise NotImplementedError("rebuilding sparse tensor for layout %s" % (layout))
 
 
+class _Mapper:
+    map_location = None
+
+    @staticmethod
+    def get_location(device):
+        if _Mapper.map_location is not None:
+            if isinstance(_Mapper.map_location, dict):
+                return _Mapper.map_location.get(device, device)
+            else:
+                return _Mapper.map_location
+        return device
+
+
 def _rebuild_device_tensor_from_numpy(data, dtype, device, requires_grad):
+    device = _Mapper.get_location(device)
     tensor = torch.from_numpy(data).to(dtype=dtype, device=device)
     tensor.requires_grad = requires_grad
     return tensor

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1097,6 +1097,7 @@ def _load(zip_file, map_location, pickle_module, pickle_file='data.pkl', **pickl
 
     unpickler = UnpicklerWrapper(data_file, **pickle_load_args)
     unpickler.persistent_load = persistent_load
+    torch._utils._Mapper.map_location = map_location
     result = unpickler.load()
 
     torch._utils._validate_loaded_sparse_tensors()


### PR DESCRIPTION
In torch.load, map_location variable is not handled properly in case of other backend device like HPU.

A new class _Mapper is created in _utils.py which stores the information of the map_location variable which is set by serialization.py. This class is used to get the correct device to be used for the tensors based on the set map_location variable.

Signed-off-by: Sanju C Sudhakaran <scsudhakaran@habana.ai>
Signed-off-by: Jeeja <jeejakp@habana.ai>

Fixes #ISSUE_NUMBER
