### PR TITLE
[PolishTypo] inherentely->inherently, intentially->intentionally

### DIFF
--- a/aten/src/ATen/native/tags.yaml
+++ b/aten/src/ATen/native/tags.yaml
@@ -25,7 +25,7 @@
 - tag: nondeterministic_seeded
   desc: |
           This tag indicates if an operator is nondeterminstically seeded (ie is random)
-          such that the operator intentially produces different results when run twice on the same inputs.
+          such that the operator intentionally produces different results when run twice on the same inputs.
 - tag: nondeterministic_bitwise
   desc: |
           This tag indicates if an operator doesn't guarentee bitwise equivalence

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -1126,7 +1126,7 @@ class UfuncInnerLoop:
 # (the 'dispatch' entry in native_functions.yaml).
 # However, there can be other examples of different backends having different information.
 # External backends can choose to opt their kernels to be structured independently from in-tree backends,
-# which means that this information isn't inherentely tied to a NativeFunction- it's different per backend.
+# which means that this information isn't inherently tied to a NativeFunction- it's different per backend.
 @dataclass(frozen=True)
 class BackendIndex:
     dispatch_key: DispatchKey


### PR DESCRIPTION
Polish comment typo, `inherentely->inherently`, `intentially->intentionally`