### PR TITLE
Reference implementation for torch.Tensor.sum_to_size

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1660,6 +1660,7 @@ class TestRefsOpsInfo(TestCase):
         '_refs.linalg.svd',
         '_refs.linalg.svdvals',
         '_refs.unflatten',
+        '_refs.sum_to_size',
         # ref implementation missing kwargs
         '_refs.full',  # missing "layout"
         '_refs.full_like',  # missing "layout"

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -374,7 +374,7 @@ class TestCommon(TestCase):
             skip_zero_dim = True
 
         # skip zero-dim tensors for some composites of reduction operations
-        normalization_ops = ["_refs.softmax", "_refs.logsumexp", "_refs.log_softmax"]
+        normalization_ops = ["_refs.softmax", "_refs.logsumexp", "_refs.log_softmax", "_refs.sum_to_size"]
         if executor == "nvfuser" and op.name in normalization_ops:
             skip_zero_dim = True
 

--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -51,6 +51,7 @@ def torch_to_refs_map():
         torch.Tensor.fill_: torch._refs.fill_,
         torch.Tensor.zero_: torch._refs.zero_,
         torch.Tensor.to: torch._refs.to,
+        torch.Tensor.sum_to_size: torch._refs.sum_to_size,
         # TODO: Should these methods be mapped some other way?
         torch.Tensor.copy_: torch._prims.copy_to,
         torch.Tensor.resize: torch._prims.resize,

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -1509,6 +1509,20 @@ def prod(xs: Sequence[NumberType]) -> NumberType:
     return reduce(operator.mul, xs, 1)
 
 
+def is_expandable_to(shape: ShapeType, desired: ShapeType) -> bool:
+    """Checks if a shape can be expanded to another shape.
+    This is equivalent to checking if the two shapes are broadcastable.
+    """
+    # This is a Python implementation of
+    # aten/src/ATen/ExpandUtils.h:is_expandable_to
+    if len(shape) > len(desired):
+        return False
+    for i in range(len(shape)):
+        if shape[i] != desired[i] and shape[i] != 1:
+            return False
+    return True
+
+
 def mask_tensor(mask: TensorLikeType, t: TensorLikeType):
     """
     Similar to torch.where(mask, t, 0) but if t is boolean,

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -1518,7 +1518,7 @@ def is_expandable_to(shape: ShapeType, desired: ShapeType) -> bool:
     if len(shape) > len(desired):
         return False
     for i in range(len(shape)):
-        if shape[i] != desired[i] and shape[i] != 1:
+        if shape[-i - 1] != desired[-i - 1] and shape[-i - 1] != 1:
             return False
     return True
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -189,6 +189,7 @@ __all__ = [
     "std_mean",
     "var_mean",
     "sum",
+    "sum_to_size",
     "prod",
     "var",
     #
@@ -1877,6 +1878,39 @@ def sum(
         out=out,
         output_dtype_kind=REDUCTION_OUTPUT_TYPE_KIND.SAME,
     )
+
+
+def _is_expandable_to(shape, desired):
+    # Python implementation of
+    # aten/src/ATen/ExpandUtils.h:is_expandable_to
+    if len(shape) > len(desired):
+        return False
+    for i in range(len(shape)):
+        if shape[i] != desired[i] and shape[i] != 1:
+            return False
+    return True
+
+
+def sum_to_size(
+    a: Tensor,
+    *shape: ShapeType,
+) -> Tensor:
+    shape = utils.extract_shape_from_varargs(shape, validate=False)
+    utils.check(
+        _is_expandable_to(shape, a.shape),
+        lambda: f'sum_to_size: size "{shape}" is not expandable to size "{a.shape}"',
+    )
+    # In ATen scalar tensors are sent through sum and the result is returned as
+    # type promoted
+    if shape == a.shape and len(shape) > 0:
+        return prims.view_of(a)
+    leading_dims = a.ndim - len(shape)
+    reduce_dims = tuple(range(leading_dims)) + tuple(
+        i
+        for i in range(leading_dims, len(shape))
+        if shape[i - leading_dims] == 1 and a.shape[i] != 1
+    )
+    return torch.sum(a, dim=reduce_dims, keepdim=True, dtype=None)
 
 
 @register_decomposition(torch.ops.aten.prod)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1882,7 +1882,7 @@ def sum(
 
 def sum_to_size(
     a: Tensor,
-    *shape: ShapeType,
+    *shape,
 ) -> Tensor:
     shape = utils.extract_shape_from_varargs(shape, validate=False)
     utils.check(

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1891,7 +1891,7 @@ def sum_to_size(
     )
     # In ATen scalar tensors are sent through sum and the result is returned as
     # type promoted
-    if shape == a.shape and len(shape) > 0:
+    if utils.is_same_shape(shape, a.shape) and len(shape) > 0:
         return prims.view_of(a)
     leading_dims = a.ndim - len(shape)
     reduce_dims = tuple(range(leading_dims)) + tuple(

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1880,24 +1880,13 @@ def sum(
     )
 
 
-def _is_expandable_to(shape, desired):
-    # Python implementation of
-    # aten/src/ATen/ExpandUtils.h:is_expandable_to
-    if len(shape) > len(desired):
-        return False
-    for i in range(len(shape)):
-        if shape[i] != desired[i] and shape[i] != 1:
-            return False
-    return True
-
-
 def sum_to_size(
     a: Tensor,
     *shape: ShapeType,
 ) -> Tensor:
     shape = utils.extract_shape_from_varargs(shape, validate=False)
     utils.check(
-        _is_expandable_to(shape, a.shape),
+        utils.is_expandable_to(shape, a.shape),
         lambda: f'sum_to_size: size "{shape}" is not expandable to size "{a.shape}"',
     )
     # In ATen scalar tensors are sent through sum and the result is returned as

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17415,6 +17415,11 @@ python_ref_db = [
         torch_opinfo_name="sum",
         supports_out=True,
     ),
+    PythonRefInfo(
+        "_refs.sum_to_size",
+        torch_opinfo_name="sum_to_size",
+        validate_view_consistency=False,
+    ),
     ReductionPythonRefInfo(
         "_refs.prod",
         torch_opinfo_name="prod",

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6131,20 +6131,20 @@ def sample_inputs_sum_to_size(op_info, device, dtype, requires_grad, **kwargs):
     # list of tuples (shape, shape) defining the shapes of the input and output tensors
     sample_shapes = [
         ((), ()),
-        ((S), (1)),
+        ((S,), (1,)),
         ((S, S), (1, 1)),
         ((S, S), (1, S)),
         ((S, S), (S, S)),
         ((S, S, S), (S, 1, S)),
     ]
 
-    samples = []
-
     for input_shape, output_shape in sample_shapes:
         input_t = make_arg(input_shape)
-        samples.append(SampleInput(input_t, args=(output_shape,)))
-
-    return samples
+        yield SampleInput(input_t, args=(output_shape,))
+        if output_shape == ():
+            continue
+        yield SampleInput(input_t, args=(list(output_shape),))
+        yield SampleInput(input_t, args=(*output_shape,))
 
 
 def error_inputs_sum_to_size(op_info, device, **kwargs):
@@ -8846,7 +8846,13 @@ op_db: List[OpInfo] = [
            skips=(
                # lambda impl
                DecorateInfo(unittest.expectedFailure, "TestNormalizeOperators", "test_normalize_operator_exhaustive"),
-               DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float,)),),),
+               DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float,)),
+               # AssertionError: Tensor-likes are not close!
+               # Mismatched elements: 5 / 5 (100.0%)
+               # https://github.com/pytorch/pytorch/issues/85409
+               DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_view'),
+               DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_conj_view'),
+            )),
     OpInfo('symeig',
            dtypes=floating_and_complex_types(),
            check_batched_grad=False,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6146,6 +6146,14 @@ def sample_inputs_sum_to_size(op_info, device, dtype, requires_grad, **kwargs):
 
     return samples
 
+
+def error_inputs_sum_to_size(op_info, device, **kwargs):
+    shape = (M, S, M)
+    err_msg = f"is not expandable to size"
+    si = SampleInput(make_tensor(shape, device=device, dtype=torch.float32), args=(M, M))
+    yield ErrorInput(si, error_regex=err_msg)
+
+
 def sample_inputs_resize_ops(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, dtype=dtype, device=device)
     cases = (((S, S, S), (S * S, S)),
@@ -8826,6 +8834,7 @@ op_db: List[OpInfo] = [
            op=lambda x, *args, **kwargs: x.sum_to_size(*args, **kwargs),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_sum_to_size,
+           error_inputs_func=error_inputs_sum_to_size,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            supports_out=False,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8852,7 +8852,7 @@ op_db: List[OpInfo] = [
                # https://github.com/pytorch/pytorch/issues/85409
                DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_view'),
                DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_conj_view'),
-            )),
+           )),
     OpInfo('symeig',
            dtypes=floating_and_complex_types(),
            check_batched_grad=False,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6153,6 +6153,11 @@ def error_inputs_sum_to_size(op_info, device, **kwargs):
     si = SampleInput(make_tensor(shape, device=device, dtype=torch.float32), args=(M, M))
     yield ErrorInput(si, error_regex=err_msg)
 
+    shape = (M + 1, S, S, M)
+    err_msg = f"is not expandable to size"
+    si = SampleInput(make_tensor(shape, device=device, dtype=torch.float32), args=(M + 1, 1))
+    yield ErrorInput(si, error_regex=err_msg)
+
 
 def sample_inputs_resize_ops(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, dtype=dtype, device=device)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6149,12 +6149,12 @@ def sample_inputs_sum_to_size(op_info, device, dtype, requires_grad, **kwargs):
 
 def error_inputs_sum_to_size(op_info, device, **kwargs):
     shape = (M, S, M)
-    err_msg = f"is not expandable to size"
+    err_msg = "is not expandable to size"
     si = SampleInput(make_tensor(shape, device=device, dtype=torch.float32), args=(M, M))
     yield ErrorInput(si, error_regex=err_msg)
 
     shape = (M + 1, S, S, M)
-    err_msg = f"is not expandable to size"
+    err_msg = "is not expandable to size"
     si = SampleInput(make_tensor(shape, device=device, dtype=torch.float32), args=(M + 1, 1))
     yield ErrorInput(si, error_regex=err_msg)
 


### PR DESCRIPTION
New ref: `torch._refs.sum_to_size`.

View consistency validation is disabled because the ref returns a view instead of returning the input.