### PR TITLE
fx quant: fix bug in custom module test

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -2584,6 +2584,7 @@ class TestQuantizeFx(QuantizationTestCase):
             @classmethod
             def from_observed(cls, observed_module):
                 assert hasattr(observed_module, 'qconfig')
+                observed_module.linear.qconfig = observed_module.qconfig
                 quantized = cls(nnqd.Linear.from_float(observed_module.linear))
                 return quantized
 
@@ -2658,7 +2659,7 @@ class TestQuantizeFx(QuantizationTestCase):
             example_inputs = (torch.randn(3, 3),)
             # check prepared model
             m = prepare_fx(
-                original_m,
+                copy.deepcopy(original_m),
                 qconfig_dict,
                 example_inputs=example_inputs,
                 prepare_custom_config=prepare_custom_config_dict)
@@ -2685,7 +2686,8 @@ class TestQuantizeFx(QuantizationTestCase):
             res = m(*example_inputs)
 
             # quantize the reference model
-            ref_m = prepare_fx(original_ref_m, qconfig_dict, example_inputs=example_inputs)
+            ref_m = prepare_fx(
+                copy.deepcopy(original_ref_m), qconfig_dict, example_inputs=example_inputs)
             ref_m(*example_inputs)
             ref_m = convert_fx(ref_m)
             ref_res = ref_m(*example_inputs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #85345 quantization: align observer dtype with reference model spec
* **#85344 fx quant: fix bug in custom module test**

Summary:

`TestQuantizeFx.test_custom_module_class` was subtly broken because the
various parts of the test case were modifying the original model. This
seems incorrect because `prepare_fx` and `convert_fx` are inplace.
To fix this, we can `copy.deepcopy` the model before applying the
test cases to it.

This test case was triggered by an unrelated refactor, splitting the
fix in a separate diff to keep the refator clean.

Test plan:

```
python test/test_quantization.py TestQuantizeFx.test_custom_module_class
```