### PR TITLE
Fix import of instruction count benchmark

### DIFF
--- a/benchmarks/instruction_counts/core/utils.py
+++ b/benchmarks/instruction_counts/core/utils.py
@@ -4,7 +4,7 @@ import re
 import textwrap
 from typing import List, Optional, Tuple
 
-from torch.utils.benchmark import _make_temp_dir
+from torch.utils.benchmark.utils.common import _make_temp_dir
 
 from core.api import GroupedBenchmark, TimerArgs
 from core.types import Definition, FlatIntermediateDefinition, Label

--- a/torch/utils/benchmark/utils/cpp_jit.py
+++ b/torch/utils/benchmark/utils/cpp_jit.py
@@ -69,6 +69,10 @@ if hasattr(torch.__config__, "_cxx_flags"):
         CXX_FLAGS = torch.__config__._cxx_flags().strip().split()
         if CXX_FLAGS is not None and "-g" not in CXX_FLAGS:
             CXX_FLAGS.append("-g")
+        # remove "-W" flags to allow build benchmarks
+        # with a relaxed constraint of compiler versions
+        if CXX_FLAGS is not None:
+            CXX_FLAGS = list(filter(lambda x: not x.startswith("-W"), CXX_FLAGS))
 
     except RuntimeError:
         # We are in FBCode.


### PR DESCRIPTION
This PR fixes the instruction count benchmark

1. Fix the updated import path
2. Allows building the benchmark with less compiler options (remove all "-W" options)

Test plan:
```
BENCHMARK_USE_DEV_SHM=1 python main.py --mode ci
```

Manually tested and worked on the CI machine.
