### PR TITLE
Enable capturing of comm collective parameters (#98)

### DIFF
--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -561,12 +561,30 @@ void record_function_with_scope_and_debug_handle(
         guard, fn, inputs, ##__VA_ARGS__);                 \
   }
 
+#define RECORD_FUNCTION_WITH_SCOPE_INPUTS_OUTPUTS( \
+    scope, fn, inputs, outputs, ...)               \
+  at::RecordFunction guard(scope);                 \
+  if (guard.isActive()) {                          \
+    if (guard.needsInputs()) {                     \
+      guard.before(fn, inputs, ##__VA_ARGS__);     \
+    } else {                                       \
+      guard.before(fn, ##__VA_ARGS__);             \
+    }                                              \
+    if (guard.needsOutputs()) {                    \
+      guard.setOutputs(outputs);                   \
+    }                                              \
+  }
+
 #define RECORD_FUNCTION(fn, inputs, ...) \
   RECORD_FUNCTION_WITH_SCOPE(            \
       at::RecordScope::FUNCTION, fn, inputs, ##__VA_ARGS__)
 
 #define RECORD_TORCHSCRIPT_FUNCTION(mn, inputs) \
   RECORD_FUNCTION_WITH_SCOPE(at::RecordScope::TORCHSCRIPT_FUNCTION, mn, inputs)
+
+#define RECORD_FUNCTION_WITH_INPUTS_OUTPUTS(fn, inputs, outputs, ...) \
+  RECORD_FUNCTION_WITH_SCOPE_INPUTS_OUTPUTS(                          \
+      at::RecordScope::FUNCTION, fn, inputs, outputs, ##__VA_ARGS__)
 
 // Custom user scopes in C++; similar to Python's 'with record_function("..."):'
 #define RECORD_USER_SCOPE(fn) \

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.hpp
@@ -65,17 +65,55 @@ class TORCH_API ParamCommsDebugInfo
   std::vector<int64_t> outputSplitSizes_;
 };
 
-
-#define RECORD_PARAM_COMMS(rank, colName, inSize, outSize, dType, inSplitSizes, outSplitSizes) \
-  auto paramCommsInfo = std::make_shared<torch::ParamCommsDebugInfo>( \
-    rank, \
-    colName, \
-    inSize, \
-    outSize, \
-    dType, \
-    inSplitSizes, \
-    outSplitSizes); \
+#define RECORD_PARAM_COMMS(                                                    \
+    seq,                                                                       \
+    pg_ptr,                                                                    \
+    rank,                                                                      \
+    colName,                                                                   \
+    inSize,                                                                    \
+    outSize,                                                                   \
+    dType,                                                                     \
+    inSplitSizes,                                                              \
+    outSplitSizes)                                                             \
+  auto paramCommsInfo = std::make_shared<torch::ParamCommsDebugInfo>(          \
+      rank, colName, inSize, outSize, dType, inSplitSizes, outSplitSizes);     \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
-  RECORD_FUNCTION(torch::kParamCommsCallName, std::vector<c10::IValue>());
+  std::initializer_list<const c10::IValue> paramList = {                       \
+      c10::IValue(seq),                                                        \
+      c10::IValue(pg_ptr),                                                   \
+      rank,                                                                    \
+      colName,                                                                 \
+      inSplitSizes,                                                            \
+      outSplitSizes};                                                          \
+  c10::ArrayRef<const c10::IValue> paramInputs(paramList);                     \
+  RECORD_FUNCTION(torch::kParamCommsCallName, paramInputs);
 
+#define RECORD_PARAM_COMMS_DATA(                                               \
+    seq,                                                                       \
+    pg_ptr,                                                                    \
+    InputTensors,                                                               \
+    OutputTensors,                                                              \
+    rank,                                                                      \
+    colName,                                                                   \
+    inSize,                                                                    \
+    outSize,                                                                   \
+    dType,                                                                     \
+    inSplitSizes,                                                              \
+    outSplitSizes)                                                             \
+  auto paramCommsInfo = std::make_shared<torch::ParamCommsDebugInfo>(          \
+      rank, colName, inSize, outSize, dType, inSplitSizes, outSplitSizes);     \
+  c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
+  std::initializer_list<const c10::IValue> paramList = {                       \
+      c10::IValue(InputTensors),                                                \
+      c10::IValue(seq),                                                        \
+      c10::IValue(pg_ptr),                                                     \
+      rank,                                                                    \
+      colName,                                                                 \
+      inSplitSizes,                                                            \
+      outSplitSizes};                                                          \
+  c10::ArrayRef<const c10::IValue> paramInputs(paramList);                     \
+  RECORD_FUNCTION_WITH_INPUTS_OUTPUTS(                                         \
+      torch::kParamCommsCallName,                                              \
+      paramInputs,                                                             \
+      std::vector<c10::IValue>(1, c10::IValue(OutputTensors)));
 } // namespace torch

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -552,6 +552,8 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeInternal(
 // Same as calling synchronize().
 bool ProcessGroupNCCL::WorkNCCL::wait(std::chrono::milliseconds timeout) {
   RECORD_PARAM_COMMS(
+      static_cast<int>(this->seq_), // seq
+      0, // process group ptr
       rank_, // rank
       "wait", // colName
       0, // inSize
@@ -674,6 +676,17 @@ ProcessGroupNCCL::ProcessGroupNCCL(
             << "\nTIMEOUT(ms): " << options_->timeout.count()
             << "\nUSE_HIGH_PRIORITY_STREAM: "
             << options_->is_high_priority_stream;
+
+  RECORD_PARAM_COMMS(
+      0, // seq
+      reinterpret_cast<std::intptr_t>(this), // process group ptr
+      rank, // rank
+      "init", // colName
+      0, // inSize
+      0, // outSize
+      at::kByte, // dType
+      std::vector<int64_t>(), // inSplitSizes
+      std::vector<int64_t>()); // outSplitSizes
 
 #ifdef USE_NCCL_WITH_UCC
   static c10::once_flag initialize_ucc_lib_flag;
@@ -1844,7 +1857,12 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce(
 
   // @lint-ignore CLANGTIDY
   auto tensor = tensors.back();
-  RECORD_PARAM_COMMS(
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      reinterpret_cast<std::intptr_t>(this), // process group ptr
+      tensors, // inputTensors
+      tensors, // outputTensors
       rank_, // rank
       "allreduce", // colName
       tensor.numel(), // inSize
@@ -1862,7 +1880,12 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allreduce_coalesced(
   auto total_numel = check_gpu_tensors_same_device(tensors);
 
   // @lint-ignore CLANGTIDY
-  RECORD_PARAM_COMMS(
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      reinterpret_cast<std::intptr_t>(this), // process group ptr
+      tensors, // inputTensors
+      tensors, // outputTensors
       rank_, // rank
       "allreduce_coalesced", // colName
       total_numel, // inSize
@@ -1882,7 +1905,13 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::broadcast(
 
   // @lint-ignore CLANGTIDY
   auto tensor = tensors.back();
-  RECORD_PARAM_COMMS(
+
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      reinterpret_cast<std::intptr_t>(this), // process group ptr
+      tensors, // inputTensors
+      tensors, // outputTensors
       rank_, // rank
       "broadcast", // colName
       tensor.numel(), // inSize
@@ -1934,7 +1963,13 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_broadcast_oop(
         false,
         "Tensor input and output of _broadcast_oop must have the same number of elements ");
   }
-  RECORD_PARAM_COMMS(
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() +
+          1), // seq + 1 to match collective increment.
+      reinterpret_cast<std::intptr_t>(this), // process group ptr
+      inputTensors, // inputTensors
+      outputTensors, // outputTensors
       rank_, // rank
       "_broadcast_oop", // colName
       tensor.numel(), // inSize
@@ -1970,7 +2005,12 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce(
   check_gpu_tensors_different_devices(tensors);
   // @lint-ignore CLANGTIDY
   auto tensor = tensors.back();
-  RECORD_PARAM_COMMS(
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      reinterpret_cast<std::intptr_t>(this),
+      tensors, // inputTensors
+      tensors, // outputTensors
       rank_, // rank
       "reduce", // colName
       tensor.numel(), // inSize
@@ -2027,7 +2067,12 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_oop(
         false,
         "Tensor input and output of _reduce_oop must have the same number of elements ");
   }
-  RECORD_PARAM_COMMS(
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      reinterpret_cast<std::intptr_t>(this), // process group ptr
+      inputTensors, // inputTensors
+      outputTensors, // outputTensors
       rank_, // rank
       "_reduce_oop", // colName
       tensor.numel(), // inSize
@@ -2077,7 +2122,13 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::allgather(
 
     // @lint-ignore CLANGTIDY
     auto tensor = inputTensors.back();
-    RECORD_PARAM_COMMS(
+    RECORD_PARAM_COMMS_DATA(
+        static_cast<int>(
+            this->getSequenceNumberForGroup() +
+            1), // seq + 1 to match collective
+        reinterpret_cast<std::intptr_t>(this), // process group ptr
+        inputTensors, // inputTensors
+        outputTensors, // outputTensors
         rank_, // rank
         "all_gather", // colName
         tensor.numel(), // inSize
@@ -2167,20 +2218,26 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::reduce_scatter(
   if (same_size) {
     // @lint-ignore CLANGTIDY
     auto tensor = outputTensors.back();
-    RECORD_PARAM_COMMS(
-        rank_, // rank
-        "reduce_scatter", // colName
-        tensor.numel() * // inSize
-            this->getSize(), // outSize
-        tensor.numel(), // dType
-        tensor.scalar_type(),
-        std::vector<int64_t>(), // inSplitSizes
-        std::vector<int64_t>()); // outSplitSizes
 
     int dev_in_group{0};
     auto inputFlattened =
         flatten_for_scatter_gather(inputTensors, outputTensors, size_);
     check_gpu_tensors_different_devices(inputFlattened);
+
+    RECORD_PARAM_COMMS_DATA(
+        static_cast<int>(
+            this->getSequenceNumberForGroup() +
+            1), // seq + 1 to match collective
+        reinterpret_cast<std::intptr_t>(this), // process group ptr
+        inputTensors, // inputTensors
+        outputTensors, // outputTensors
+        rank_, // rank
+        "reduce_scatter", // colName
+        tensor.numel() * this->getSize(), // inSize
+        tensor.numel(), // outSize
+        tensor.scalar_type(), // dType
+        std::vector<int64_t>(), // inSplitSizes
+        std::vector<int64_t>()); // outSplitSizes
 
     return collective(
         inputFlattened,
@@ -2265,7 +2322,13 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_scatter_base(
 
   // @lint-ignore CLANGTIDY
   const auto& tensor = outputTensor;
-  RECORD_PARAM_COMMS(
+
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      reinterpret_cast<std::intptr_t>(this), // process group ptr
+      inputTensor, // inputTensor
+      outputTensor, // outputTensor
       rank_, // rank
       "_reduce_scatter_base", // colName
       tensor.numel() * // inSize
@@ -2308,6 +2371,9 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::_reduce_scatter_base(
 
 c10::intrusive_ptr<Work> ProcessGroupNCCL::barrier(const BarrierOptions& opts) {
   RECORD_PARAM_COMMS(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      reinterpret_cast<std::intptr_t>(this), // process group ptr
       rank_, // rank
       "barrier", // colName
       0, // inSize
@@ -2381,7 +2447,13 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::alltoall_base(
     std::vector<at::Tensor> inputTensors = {inputTensor};
     std::vector<at::Tensor> outputTensors = {outputTensor};
 
-    RECORD_PARAM_COMMS(
+    RECORD_PARAM_COMMS_DATA(
+        static_cast<int>(
+            this->getSequenceNumberForGroup() +
+            1), // seq + 1 to match collective
+        reinterpret_cast<std::intptr_t>(this), // process group ptr
+        inputTensor, // inputTensor
+        outputTensor, // outputTensor
         rank_, // rank
         "all_to_all", // colName
         inputTensor.numel(), // inSize
@@ -2412,7 +2484,13 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::alltoall_base(
     std::vector<at::Tensor> inputTensors = {inputTensor};
     std::vector<at::Tensor> outputTensors = {outputTensor};
 
-    RECORD_PARAM_COMMS(
+    RECORD_PARAM_COMMS_DATA(
+        static_cast<int>(
+            this->getSequenceNumberForGroup() +
+            1), // seq + 1 to match collective
+        reinterpret_cast<std::intptr_t>(this), // process group ptr
+        inputTensor, // inputTensor
+        outputTensor, // outputTensor
         rank_, // rank
         "all_to_allv", // colName
         inputTensor.numel(), // inSize
@@ -2592,14 +2670,6 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::gather(
 
   // @lint-ignore CLANGTIDY
   auto tensor = inputTensors.back();
-  RECORD_PARAM_COMMS(
-      rank_, // rank
-      "gather", // colName
-      tensor.numel(), // inSize
-      tensor.numel() * this->getSize(), // outSize
-      tensor.scalar_type(), // dType
-      std::vector<int64_t>(), // inSplitSizes
-      std::vector<int64_t>()); // outSplitSize
 
   std::vector<at::Tensor> outputs;
 
@@ -2631,6 +2701,20 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::gather(
     // `collective` template function requires it to invoke its function
     outputs.emplace_back();
   }
+
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      reinterpret_cast<std::intptr_t>(this), // process group ptr
+      inputTensors, // inputTensors
+      outputTensors, // outputTensors
+      rank_, // rank
+      "gather", // colName
+      tensor.numel(), // inSize
+      tensor.numel() * this->getSize(), // outSize
+      tensor.scalar_type(), // dType
+      std::vector<int64_t>(), // inSplitSizes
+      std::vector<int64_t>()); // outSplitSize
 
   return collective(
       inputTensors,
@@ -2667,14 +2751,6 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::scatter(
 
   // @lint-ignore CLANGTIDY
   auto tensor = outputTensors.back();
-  RECORD_PARAM_COMMS(
-      rank_, // rank
-      "scatter", // colName
-      tensor.numel(), // inSize
-      tensor.numel() * this->getSize(), // outSize
-      tensor.scalar_type(), // dType
-      std::vector<int64_t>(), // inSplitSizes
-      std::vector<int64_t>()); // outSplitSize
 
   std::vector<at::Tensor> inputs;
 
@@ -2707,6 +2783,20 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::scatter(
     // `collective` template function requires it to invoke its function
     inputs.emplace_back();
   }
+
+  RECORD_PARAM_COMMS_DATA(
+      static_cast<int>(
+          this->getSequenceNumberForGroup() + 1), // seq + 1 to match collective
+      reinterpret_cast<std::intptr_t>(this), // process group ptr
+      inputTensors, // inputTensors
+      outputTensors, // outputTensors
+      rank_, // rank
+      "scatter", // colName
+      tensor.numel(), // inSize
+      tensor.numel() * this->getSize(), // outSize
+      tensor.scalar_type(), // dType
+      std::vector<int64_t>(), // inSplitSizes
+      std::vector<int64_t>()); // outSplitSize
 
   return collective(
       outputTensors,

--- a/torch/csrc/distributed/c10d/UCCTracing.cpp
+++ b/torch/csrc/distributed/c10d/UCCTracing.cpp
@@ -112,7 +112,7 @@ void CommTraceLogger::recordComms(
       ",\n\t\t\"req\": ",
       workReq,
       ",\n\t\t\"seqnum\": ",
-      seqnum++,
+      seqnum,
       ",\n\t\t\"world_size\": ",
       world_size);
 
@@ -149,6 +149,8 @@ void CommTraceLogger::recordComms(
 
   // record the trace to kineto trace if applicable
   RECORD_PARAM_COMMS(
+      static_cast<int64_t>(seqnum), // seq
+      0, // process group ptr
       rank,
       commName.c_str(),
       inSize,
@@ -156,6 +158,8 @@ void CommTraceLogger::recordComms(
       dtype,
       curInSplitSizes_,
       curOutSplitSizes_);
+
+  ++seqnum;
 
   // reset optional field
   curRoot_ = -1;

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -32,7 +32,7 @@ from torch._C._distributed_c10d import (
     Work
 )
 from torch._six import string_classes
-
+from torch.autograd.profiler import record_function
 from .constants import default_pg_timeout
 from .rendezvous import register_rendezvous_handler, rendezvous  # noqa: F401
 
@@ -3321,15 +3321,17 @@ def new_group(ranks=None, timeout=default_pg_timeout, backend=None, pg_options=N
         group_rank = global_rank
 
     backend = Backend(backend)
-    pg = _new_process_group_helper(
-        group_world_size,
-        group_rank,
-        ranks,
-        backend,
-        default_store,
-        pg_options=pg_options,
-        timeout=timeout,
-    )
+
+    with record_function(f"## process_group:init with ranks: {ranks}"):
+        pg = _new_process_group_helper(
+            group_world_size,
+            group_rank,
+            ranks,
+            backend,
+            default_store,
+            pg_options=pg_options,
+            timeout=timeout,
+        )
 
     # Create the global rank to group rank mapping
     _pg_group_ranks[pg] = {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/torch_ucc/pull/98

Add tensor input, output, and other metadata for PyTorch comms.

Test Plan: P517138779

Reviewed By: Pavani-Panakanti

Differential Revision: D38357077

