### PR TITLE
Log Watchdog events to scuba

### DIFF
--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -12,11 +12,11 @@ import select
 import signal
 import threading
 import time
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from torch.distributed.elastic.timer.api import TimerClient, TimerRequest
 
-__all__ = ['FileTimerClient', 'FileTimerRequest', 'FileTimerServer']
+__all__ = ["FileTimerClient", "FileTimerRequest", "FileTimerServer"]
 
 class FileTimerRequest(TimerRequest):
     """
@@ -145,9 +145,17 @@ class FileTimerServer:
 
         daemon: bool, running the watchdog thread in daemon mode or not.
                       A daemon thread will not block a process to stop.
+        log_event: Callable[[Dict[str, str]], None], an optional callback for
+                logging the events in JSON format.
     """
 
-    def __init__(self, file_path: str, max_interval: float = 10, daemon: bool = True) -> None:
+    def __init__(
+        self,
+        file_path: str,
+        max_interval: float = 10,
+        daemon: bool = True,
+        log_event: Callable[[str, Optional[FileTimerRequest]], None] = None
+    ) -> None:
         self._file_path = file_path
         self._max_interval = max_interval
         self._daemon = daemon
@@ -161,6 +169,7 @@ class FileTimerServer:
         self._request_count = 0
         # For test only. Process all requests and stop the server.
         self._run_once = False
+        self._log_event = log_event if log_event is not None else lambda name, request: None
 
 
     def start(self) -> None:
@@ -172,6 +181,7 @@ class FileTimerServer:
         self._watchdog_thread = threading.Thread(target=self._watchdog_loop, daemon=self._daemon)
         logging.info("Starting watchdog thread...")
         self._watchdog_thread.start()
+        self._log_event("watchdog started", None)
 
     def stop(self) -> None:
         logging.info(f"Stopping {type(self).__name__}")
@@ -184,6 +194,7 @@ class FileTimerServer:
             logging.info("No watchdog thread running, doing nothing")
         if os.path.exists(self._file_path):
             os.remove(self._file_path)
+        self._log_event("watchdog stopped", None)
 
     def run_once(self) -> None:
         self._run_once = True
@@ -219,20 +230,23 @@ class FileTimerServer:
         reaped_worker_pids = set()
         for worker_pid, expired_timers in self.get_expired_timers(now).items():
             logging.info(f"Reaping worker_pid=[{worker_pid}]." f" Expired timers: {self._get_scopes(expired_timers)}")
+            reaped_worker_pids.add(worker_pid)
             # In case we have multiple expired timers, we find the first timer
             # with a valid signal (>0) in the expiration time order.
             expired_timers.sort(key=lambda timer: timer.expiration_time)
             signal = 0
+            expired_timer = None
             for timer in expired_timers:
                 if timer.signal > 0:
                     signal = timer.signal
+                    expired_timer = timer
                     break
             if signal <= 0:
                 logging.info(f"No signal specified with worker=[{worker_pid}]. Do not reap it.")
                 continue
             if self._reap_worker(worker_pid, signal):
                 logging.info(f"Successfully reaped worker=[{worker_pid}] with signal={signal}")
-                reaped_worker_pids.add(worker_pid)
+                self._log_event("kill worker process", expired_timer)
             else:
                 logging.error(f"Error reaping worker=[{worker_pid}]. Will retry on next watchdog.")
         self.clear_timers(reaped_worker_pids)
@@ -284,12 +298,15 @@ class FileTimerServer:
             if expiration_time < 0:
                 if key in self._timers:
                     del self._timers[key]
+                    self._log_event("clear timer", request)
             else:
                 self._timers[key] = request
+                self._log_event("set timer", request)
 
     def clear_timers(self, worker_pids: Set[int]) -> None:
         for (pid, scope_id) in list(self._timers.keys()):
             if pid in worker_pids:
+                self._log_event("clear timer", self._timers[(pid, scope_id)])
                 del self._timers[(pid, scope_id)]
 
     def get_expired_timers(self, deadline: float) -> Dict[int, List[FileTimerRequest]]:


### PR DESCRIPTION
Summary: This diff logs some events of FileTimerServer to a scuba table. The events include "server started", "server stopped", "set timer", "clear timer" and "kill worker process".

Test Plan:
### Unit Test
```
buck test mode/dev-nosan //caffe2/test/distributed/elastic/agent/server/test:local_agent_test
```
```
Test Session: https://www.internalfb.com/intern/testinfra/testrun/1407375146936031
RE: reSessionID-2224cf79-6a28-4762-ab7c-9875adb244dc 3.4 KiB▲,  0.0 B▼
Jobs completed: 57. Time elapsed: 3084.4s.
Tests finished: Pass 55. Fail 0. Fatal 0. Skip 0. 0 builds failed
```

Differential Revision: D39665560

