### PR TITLE
[NNC] enable bf16 for mkldnn prepack conv2d

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -940,6 +940,12 @@ class TensorExprFuser {
           return false;
         }
 
+        if (*st == c10::ScalarType::BFloat16 && *device == c10::kCPU) {
+#ifndef TORCH_ENABLE_LLVM
+          return false;
+#endif
+        }
+
         // These operators only support floats, because integer divisors need to
         // raise ZeroDivisionError.
         if (node->isMemberOf(float_only_operator_set) && !isFloatingType(*st)) {

--- a/torch/csrc/jit/tensorexpr/half_support.h
+++ b/torch/csrc/jit/tensorexpr/half_support.h
@@ -101,15 +101,22 @@ class HalfRewriter : public IRMutator {
     // just don't allow half casts we didn't insert.
     if (isHalf(v)) {
       if (inserted_half_casts_.count(v) < 1) {
-        return child;
+        v->set_src_value(child);
+        v->set_dtype(v->dtype().cloneWithScalarType(c10::kFloat));
+        return v;
       }
     }
 
     // Remove Half(Float()) and friends.
     CastPtr cast_child = to<Cast>(child);
     if (cast_child) {
+      auto cast_to_double = v->dtype().scalar_type() == ScalarType::Double;
+      auto from_half = isHalf(cast_child->src_value());
+      // Cannot simplify the double(float(half)) to double(half) as NNC does
+      // not support cast BF16 to double directly.
+      auto not_cast_half_to_doulbe = !(cast_to_double && from_half);
       if (v->dtype().is_floating_point() &&
-          cast_child->dtype().is_floating_point()) {
+          cast_child->dtype().is_floating_point() && not_cast_half_to_doulbe) {
         return alloc<Cast>(v->dtype(), cast_child->src_value());
       }
     }

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -291,6 +291,7 @@ bool mkldnnPrepackedConvIsSupportedJit(const torch::jit::Node* node) {
 #if AT_MKLDNN_ENABLED()
   auto const& input = getTensorInfoJit(node->input(0));
   auto const& weight = getTensorInfoJit(node->input(1));
+  auto const& output = getTensorInfoJit(node->output(0));
   auto const& stride = toIValue(node->input(3));
   auto const& pad = toIValue(node->input(4));
   auto const& dilation = toIValue(node->input(5));
@@ -299,7 +300,7 @@ bool mkldnnPrepackedConvIsSupportedJit(const torch::jit::Node* node) {
 
   // Everything should be statically known (bias could be NoneType =
   // prim::Constant()).
-  if (!input || !weight || !stride || !pad || !dilation || !groups) {
+  if (!input || !weight || !output || !stride || !pad || !dilation || !groups) {
     GRAPH_DEBUG("some params aren't static");
     return false;
   }
@@ -323,6 +324,7 @@ bool mkldnnPrepackedConvIsSupportedJit(const torch::jit::Node* node) {
   return mkldnnPrepackedConvIsSupported(
       *input,
       *weight,
+      *output,
       _pair_int(*stride),
       _pair_int(*pad),
       _pair_int(*dilation),

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -1002,9 +1002,7 @@ void LLVMCodeGenImpl::visit(HalfImmPtr v) {
 }
 
 void LLVMCodeGenImpl::visit(BFloat16ImmPtr v) {
-  TORCH_INTERNAL_ASSERT(
-      false,
-      buildErrorMessage("Fuser's LLVM codegen does not support bfloat16"));
+  value_ = llvm::ConstantInt::get(ShortTy_, v->value().x);
 }
 
 void LLVMCodeGenImpl::visit(BoolImmPtr v) {

--- a/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
@@ -311,14 +311,23 @@ bool conv2dIsSupported(
 bool mkldnnPrepackedConvIsSupported(
     const TensorInfo& input,
     const TensorInfo& weight,
+    const TensorInfo& output,
     const std::vector<int64_t>& stride,
     const std::vector<int64_t>& pad,
     const std::vector<int64_t>& dilation,
     int64_t groups) {
 #if AT_MKLDNN_ENABLED()
-  if (input.dtype != c10::ScalarType::Float ||
-      weight.dtype != c10::ScalarType::Float) {
-    GRAPH_DEBUG("mkldnnPrepackedConvIsSupported: only float32 allowed");
+  bool is_fp32 = input.dtype == c10::ScalarType::Float &&
+      weight.dtype == c10::ScalarType::Float &&
+      output.dtype == c10::ScalarType::Float;
+
+  bool is_bf16 = input.dtype == c10::ScalarType::BFloat16 &&
+      weight.dtype == c10::ScalarType::BFloat16 &&
+      output.dtype == c10::ScalarType::BFloat16;
+
+  if (!is_fp32 && !is_bf16) {
+    GRAPH_DEBUG(
+        "mkldnnPrepackedConvIsSupported: only float32 of bfloat16 allowed");
     return false;
   }
   if (input.dims.size() != 4 || weight.dims.size() != 4) {

--- a/torch/csrc/jit/tensorexpr/operators/conv2d.h
+++ b/torch/csrc/jit/tensorexpr/operators/conv2d.h
@@ -66,6 +66,7 @@ bool conv2dIsSupported(
 bool mkldnnPrepackedConvIsSupported(
     const TensorInfo& input,
     const TensorInfo& weight,
+    const TensorInfo& output,
     const std::vector<int64_t>& stride,
     const std::vector<int64_t>& pad,
     const std::vector<int64_t>& dilation,


### PR DESCRIPTION
## Pitch
Enable bf16 support for mkldnn prepack conv2d in NNC.

## Performance
The BF16 conv performance has been evaluated in https://github.com/pytorch/pytorch/pull/82705.

## Additional context
This PR depends on BF16 support in NNC: https://github.com/pytorch/pytorch/pull/84041.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel