### PR TITLE
Change Lezcano to lezcano

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -120,7 +120,7 @@
   - test/test_linalg.py
   approved_by:
   - mruberry
-  - Lezcano
+  - lezcano
   - IvanYashchuk
   mandatory_checks_name:
   - Facebook CLA Check

--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -103,7 +103,7 @@ Linear Algebra (torch.linalg)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Mike Ruberry (`mruberry <https://github.com/mruberry>`__)
--  Mario Lezcano (`Lezcano <https://github.com/Lezcano>`__)
+-  Mario Lezcano (`lezcano <https://github.com/lezcano>`__)
 -  Ivan Yashchuk (`IvanYashchuk <https://github.com/IvanYashchuk>`__)
 -  (emeritus) Vishwak Srinivasan (`vishwakftw <https://github.com/vishwakftw>`__)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #85396

I changed my handle to lezcano (no caps) as rhere's always issues with
capital letters when automatising stuff.

The last issue was https://github.com/pytorch/test-infra/pull/751