### PR TITLE
improve performance of workspace lookup/insertion

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -99,11 +99,11 @@ cublasHandle_t getCurrentCUDABlasHandle() {
   // cublasSetWorkspace not available on CUDA 10.2
   cudaStream_t _stream = stream;
   auto key = std::make_tuple(static_cast<void *>(handle), static_cast<void *>(_stream));
-  if (cublas_handle_stream_to_workspace().find(key) == cublas_handle_stream_to_workspace().end()) {
-      auto workspace_ptr = getNewWorkspace();
-      cublas_handle_stream_to_workspace()[key] = std::move(workspace_ptr);
+  auto workspace_it = cublas_handle_stream_to_workspace().find(key);
+  if (workspace_it == cublas_handle_stream_to_workspace().end()) {
+    workspace_it = cublas_handle_stream_to_workspace().insert(workspace_it, {key, getNewWorkspace()});
   }
-  TORCH_CUDABLAS_CHECK(cublasSetWorkspace(handle, cublas_handle_stream_to_workspace()[key].get(), getChosenWorkspaceSize()));
+  TORCH_CUDABLAS_CHECK(cublasSetWorkspace(handle, workspace_it->second.get(), getChosenWorkspaceSize()));
 #endif
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
   // On CUDA >= 11, and architecture >= Ampere, cuBLAS can use TF32 to speedup


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #85400
* #85399

Summary:
Avoid multiple traversals of the map with correct std::map usage.

Test Plan: Rely on CI.

Reviewers:

Subscribers:

Tasks:

Tags: