### PR TITLE
rebase and merge - add sleep

### DIFF
--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -44,6 +44,8 @@ jobs:
           if [ -n "${REBASE}" ]; then
             python3 .github/scripts/tryrebase.py "${PR_NUM}" --branch "${REBASE}"
             git checkout master
+            # give github some time to get the push and start workflows
+            sleep 60
           fi
           if [ -n "${FORCE}" ]; then
             if [ -n "${COMMENT_ID}" ]; then

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -44,7 +44,9 @@ jobs:
           if [ -n "${REBASE}" ]; then
             python3 .github/scripts/tryrebase.py "${PR_NUM}" --branch "${REBASE}"
             git checkout master
-            # give github some time to get the push and start workflows
+            git fetch -p
+            # give github some time between the push and start workflows so that Github's messages
+            # on the PR appear in chronological order (timing issues can otherwise
             sleep 60
           fi
           if [ -n "${FORCE}" ]; then

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -46,7 +46,7 @@ jobs:
             git checkout master
             git fetch -p
             # give github some time between the push and start workflows so that Github's messages
-            # on the PR appear in chronological order (timing issues can otherwise
+            # on the PR appear in chronological order (timing issues can shuffle them around)
             sleep 60
           fi
           if [ -n "${FORCE}" ]; then


### PR DESCRIPTION
not a fan of this solution, so if anyone has better ideas please tell me

add a sleep between the tryrebase.py and trymerge.py scripts so that github has time to get the push and start workflows, and so that we dont get weird event orders like https://github.com/pytorch/pytorch/pull/85267 where the push from the rebase looks like its after the merge