### PR TITLE
[quant] Check if cuda quantizing while on qnnpack engine

### DIFF
--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -126,6 +126,10 @@ inline Tensor new_qtensor(
 
 #ifdef USE_PYTORCH_QNNPACK
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK) {
+    TORCH_CHECK(!device.is_cuda(), "It looks like you are trying to quantize a CUDA tensor ",
+                "while QNNPACK backend is enabled. Although not expected to happen in ",
+                "practice, you might have done it for testing purposes. ",
+                "Please, either change the quantization engine or move the tensor to a CPU.");
     allocator = c10::GetDefaultMobileCPUAllocator();
   }
 #endif


### PR DESCRIPTION
Although not possible in practice, while running the tests it is possible to try to quantize a CUDA tensor while quantization engine is set to QNNPACK. This would override the memory allocator from CUDA to MobileCPU, which would cause the new quantized tensors to be allocated on a CPU (instead of CUDA).

Please, note that this is not a realistic scenario, as the qnnpack quantization engine is only "emulated" during the tests. When running on a real mobile CPU we don't expect a CUDA to be present.
