### PR TITLE
[perf][1/5] Replace IValue::toString()->string() with IValue::toStringRef()

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
@@ -303,7 +303,7 @@ facebook::jni::local_ref<JIValue> JIValue::newJIValueFromStringDict(
       facebook::jni::alias_ref<JIValue::javaobject>>::create();
   for (auto& pair : dict) {
     jmap->put(
-        facebook::jni::make_jstring(pair.key().toString()->string()),
+        facebook::jni::make_jstring(pair.key().toStringRef()),
         JIValue::newJIValueFromAtIValue(pair.value()));
   }
   return jMethodDictStringKey(JIValue::javaClassStatic(), jmap);

--- a/aten/src/ATen/core/boxing/impl/kernel_function_legacy_test.cpp
+++ b/aten/src/ATen/core/boxing/impl/kernel_function_legacy_test.cpp
@@ -508,8 +508,8 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithStringLi
   auto output = std::move(outputs[0]).toList();
 
   EXPECT_EQ(2, output.size());
-  EXPECT_EQ("value1", output.get(0).toString()->string());
-  EXPECT_EQ("value2", output.get(1).toString()->string());
+  EXPECT_EQ("value1", output.get(0).toStringRef());
+  EXPECT_EQ("value2", output.get(1).toStringRef());
 }
 
 int captured_dict_size = 0;
@@ -550,7 +550,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithDictInpu
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  EXPECT_EQ("value2", outputs[0].toString()->string());
+  EXPECT_EQ("value2", outputs[0].toStringRef());
 }
 
 Dict<string, string> kernelWithDictOutput(Dict<string, string> input) {
@@ -612,7 +612,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithUnordere
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  EXPECT_EQ("value2", outputs[0].toString()->string());
+  EXPECT_EQ("value2", outputs[0].toStringRef());
 }
 
 std::unordered_map<string, string> kernelWithUnorderedMapOutput(std::unordered_map<string, string> input) {
@@ -897,7 +897,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithOptional
   EXPECT_EQ(3, outputs.size());
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(outputs[0].toTensor()));
   EXPECT_TRUE(outputs[1].isNone());
-  EXPECT_EQ("text", outputs[2].toString()->string());
+  EXPECT_EQ("text", outputs[2].toStringRef());
 
   outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(3, outputs.size());

--- a/aten/src/ATen/core/boxing/impl/kernel_function_test.cpp
+++ b/aten/src/ATen/core/boxing/impl/kernel_function_test.cpp
@@ -484,7 +484,7 @@ TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernelWithDictInput_with
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  EXPECT_EQ("value2", outputs[0].toString()->string());
+  EXPECT_EQ("value2", outputs[0].toStringRef());
 }
 
 Dict<string, string> kernelWithDictOutput(Dict<string, string> input) {
@@ -639,7 +639,7 @@ TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernelWithOptionalInputs
   EXPECT_EQ(3, outputs.size());
   EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(outputs[0].toTensor()));
   EXPECT_TRUE(outputs[1].isNone());
-  EXPECT_EQ("text", outputs[2].toString()->string());
+  EXPECT_EQ("text", outputs[2].toStringRef());
 
   outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(3, outputs.size());

--- a/aten/src/ATen/core/boxing/impl/kernel_lambda_legacy_test.cpp
+++ b/aten/src/ATen/core/boxing/impl/kernel_lambda_legacy_test.cpp
@@ -456,8 +456,8 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithStringList
   auto output = std::move(outputs[0]).toList();
 
   EXPECT_EQ(2, output.size());
-  EXPECT_EQ("value1", output.get(0).toString()->string());
-  EXPECT_EQ("value2", output.get(1).toString()->string());
+  EXPECT_EQ("value1", output.get(0).toStringRef());
+  EXPECT_EQ("value2", output.get(1).toStringRef());
 }
 
 TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithDictInput_withoutOutput_whenRegistered_thenCanBeCalled) {
@@ -494,7 +494,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithDictInput_
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  EXPECT_EQ("value2", outputs[0].toString()->string());
+  EXPECT_EQ("value2", outputs[0].toStringRef());
 }
 
 TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
@@ -552,7 +552,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithUnorderedM
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  EXPECT_EQ("value2", outputs[0].toString()->string());
+  EXPECT_EQ("value2", outputs[0].toStringRef());
 }
 
 TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithUnorderedMapOutput_whenRegistered_thenCanBeCalled) {
@@ -832,7 +832,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithOptionalIn
   EXPECT_EQ(3, outputs.size());
   EXPECT_EQ(DispatchKey::CUDA, extractDispatchKey(outputs[0].toTensor()));
   EXPECT_TRUE(outputs[1].isNone());
-  EXPECT_EQ("text", outputs[2].toString()->string());
+  EXPECT_EQ("text", outputs[2].toStringRef());
 
   outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(3, outputs.size());

--- a/aten/src/ATen/core/boxing/impl/kernel_lambda_test.cpp
+++ b/aten/src/ATen/core/boxing/impl/kernel_lambda_test.cpp
@@ -410,7 +410,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithDictInput_withOu
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  EXPECT_EQ("value2", outputs[0].toString()->string());
+  EXPECT_EQ("value2", outputs[0].toStringRef());
 }
 
 TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithDictOutput_whenRegistered_thenCanBeCalled) {
@@ -554,7 +554,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithOptionalInputs_w
   EXPECT_EQ(3, outputs.size());
   EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(outputs[0].toTensor()));
   EXPECT_TRUE(outputs[1].isNone());
-  EXPECT_EQ("text", outputs[2].toString()->string());
+  EXPECT_EQ("text", outputs[2].toStringRef());
 
   outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(3, outputs.size());

--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor_test.cpp
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor_test.cpp
@@ -491,7 +491,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithDictInput_withO
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  EXPECT_EQ("value2", outputs[0].toString()->string());
+  EXPECT_EQ("value2", outputs[0].toStringRef());
 }
 
 struct KernelWithDictOutput final : OperatorKernel {
@@ -546,7 +546,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithTupleInput_with
   std::tuple<string, int64_t, float> tup{"foobar", 123, 420.1337};
   auto outputs = callOp(*op, tup);
   EXPECT_EQ(1, outputs.size());
-  EXPECT_EQ("foobar", outputs[0].toString()->string());
+  EXPECT_EQ("foobar", outputs[0].toStringRef());
 }
 
 TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithCache_thenCacheIsKeptCorrectly) {
@@ -774,7 +774,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithOptionalInputs_
   EXPECT_EQ(3, outputs.size());
   EXPECT_EQ(DispatchKey::CPU, extractDispatchKey(outputs[0].toTensor()));
   EXPECT_TRUE(outputs[1].isNone());
-  EXPECT_EQ("text", outputs[2].toString()->string());
+  EXPECT_EQ("text", outputs[2].toStringRef());
 
   outputs = callOp(*op, dummyTensor(DispatchKey::CPU), c10::IValue(), 4, c10::IValue());
   EXPECT_EQ(3, outputs.size());

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -418,7 +418,7 @@ TEST(OperatorRegistrationTest, whenRegisteringMismatchingKernelsInSameOpCall_the
 }
 
 void backend_fallback_kernel(const c10::OperatorHandle& op, c10::Stack* stack) {
-  (*stack)[1] = (*stack)[1].toString()->string() + op.schema().name();
+  (*stack)[1] = (*stack)[1].toStringRef() + op.schema().name();
 }
 
 TEST(OperatorRegistrationTest, whenRegisteringBackendFallbackKernel_thenCanBeCalled) {
@@ -428,7 +428,7 @@ TEST(OperatorRegistrationTest, whenRegisteringBackendFallbackKernel_thenCanBeCal
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
   auto stack = callOp(*op, dummyTensor(c10::DispatchKey::CPU), "hello ");
-  EXPECT_EQ("hello _test::dummy", stack[1].toString()->string());
+  EXPECT_EQ("hello _test::dummy", stack[1].toStringRef());
 }
 
 TEST(OperatorRegistrationTest, whenRegisteringBackendFallbackKernelForWrongBackend_thenCannotBeCalled) {
@@ -472,7 +472,7 @@ TEST(OperatorRegistrationTest, whenRegisteringBackendFallbackKernelAndRegularKer
   called = false;
   auto stack = callOp(*op, dummyTensor(c10::DispatchKey::CPU), "hello ");
   EXPECT_FALSE(called);
-  EXPECT_EQ("hello _test::dummy", stack[1].toString()->string());
+  EXPECT_EQ("hello _test::dummy", stack[1].toStringRef());
 }
 
 TEST(OperatorRegistrationTest, whenRegisteringBackendFallbackKernelAndRegularKernelForSameBackend_thenCallsRegularKernel) {
@@ -875,7 +875,7 @@ TEST(OperatorRegistrationTest, testAvailableArgTypes) {
     "(bool a) -> bool");
   testArgTypes<std::string>::test(
     "string1", [] (const std::string& v) {EXPECT_EQ("string1", v);},
-    "string2", [] (const IValue& v) {EXPECT_EQ("string2", v.toString()->string());},
+    "string2", [] (const IValue& v) {EXPECT_EQ("string2", v.toStringRef());},
     "(str a) -> str");
   testArgTypes<Tensor>::test(
     dummyTensor(c10::DispatchKey::CPU), [] (const Tensor& v) {EXPECT_EQ(c10::DispatchKey::CPU, extractDispatchKey(v));},
@@ -902,7 +902,7 @@ TEST(OperatorRegistrationTest, testAvailableArgTypes) {
     "(bool? a) -> bool?");
   testArgTypes<c10::optional<std::string>>::test(
     c10::optional<std::string>("string1"), [] (const c10::optional<std::string>& v) {EXPECT_EQ("string1", v.value());},
-    c10::optional<std::string>("string2"), [] (const IValue& v) {EXPECT_EQ("string2", v.toString()->string());},
+    c10::optional<std::string>("string2"), [] (const IValue& v) {EXPECT_EQ("string2", v.toStringRef());},
     "(str? a) -> str?");
   testArgTypes<c10::optional<Tensor>>::test(
     c10::optional<Tensor>(dummyTensor(c10::DispatchKey::CPU)), [] (const c10::optional<Tensor>& v) {EXPECT_EQ(c10::DispatchKey::CPU, extractDispatchKey(v.value()));},
@@ -1939,7 +1939,7 @@ TEST(NewOperatorRegistrationTest, fallback) {
   auto op = Dispatcher::singleton().findSchema({"_test::dummy", ""});
   ASSERT_TRUE(op.has_value());
   auto stack = callOp(*op, dummyTensor(c10::DispatchKey::CPU), "hello ");
-  EXPECT_EQ("hello _test::dummy", stack[1].toString()->string());
+  EXPECT_EQ("hello _test::dummy", stack[1].toStringRef());
 }
 
 TEST(NewOperatorRegistrationTest, BackendSelectRedispatchesToCPU) {

--- a/test/cpp/jit/test_module_api.cpp
+++ b/test/cpp/jit/test_module_api.cpp
@@ -254,10 +254,10 @@ TEST(ModuleAPITest, DeepCopyString) {
   m.setattr(attr1, str);
   auto copied = m.deepcopy();
   auto original_str = str;
-  ASSERT_EQ(copied.attr(attr1).toString()->string(), original_str);
+  ASSERT_EQ(copied.attr(attr1).toStringRef(), original_str);
   // check string mutation is not reflected in the copied module
   str += "str";
-  ASSERT_EQ(copied.attr(attr1).toString()->string(), original_str);
+  ASSERT_EQ(copied.attr(attr1).toStringRef(), original_str);
 }
 
 TEST(ModuleAPITest, DeepCopyEnum) {

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -490,7 +490,7 @@ TEST(TorchpyTest, TestPyYAML) {
   EXPECT_EQ(1, load.attr("__getitem__")({"a"}).toIValue().toInt());
 
   auto dump = I.global("yaml", "dump")({load});
-  EXPECT_EQ(kDocument, dump.toIValue().toString()->string());
+  EXPECT_EQ(kDocument, dump.toIValue().toStringRef());
 }
 #endif
 

--- a/torch/csrc/deploy/test_deploy_gpu.cpp
+++ b/torch/csrc/deploy/test_deploy_gpu.cpp
@@ -115,6 +115,6 @@ TEST(TorchpyTest, TestPyYAML) {
   EXPECT_EQ(1, load.attr("__getitem__")({"a"}).toIValue().toInt());
 
   auto dump = I.global("yaml", "dump")({load});
-  EXPECT_EQ(kDocument, dump.toIValue().toString()->string());
+  EXPECT_EQ(kDocument, dump.toIValue().toStringRef());
 }
 #endif

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -102,7 +102,7 @@ c10::optional<Value*> tryInsertConstant(
       return c10::nullopt;
     }
   } else if (val.isString()) {
-    n->s_(attr::value, val.toString()->string());
+    n->s_(attr::value, val.toStringRef());
     n->output()->setType(StringType::get());
   } else if (val.isDevice()) {
     std::stringstream ss;

--- a/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
@@ -309,7 +309,7 @@ std::unordered_set<std::string> _get_mobile_model_contained_types(
     std::vector<std::string> type_name_list;
     for (const auto& type_definition : type_table) {
       std::unordered_set<std::string> type_tokens;
-      std::string type_name = type_definition.toString()->string();
+      std::string type_name = type_definition.toStringRef();
       type_name_list.emplace_back(type_name);
     }
     at::TypeParser parser(type_name_list);

--- a/torch/csrc/jit/mobile/import_data.cpp
+++ b/torch/csrc/jit/mobile/import_data.cpp
@@ -174,7 +174,7 @@ std::map<std::string, at::Tensor> load_parameters_from_zip(
   auto result = unpickler.deserialize(device).toGenericDict();
   std::map<std::string, at::Tensor> map;
   for (const auto& e : result) {
-    auto key = e.key().toString()->string();
+    auto key = e.key().toStringRef();
     auto value = e.value().toTensor().tensor_data();
     map[key] = value;
   }

--- a/torch/csrc/jit/mobile/parse_bytecode.cpp
+++ b/torch/csrc/jit/mobile/parse_bytecode.cpp
@@ -181,7 +181,7 @@ void parseTypes(
   std::vector<std::string> types_string_list;
   types_string_list.resize(types_list.size());
   for (size_t i = 0; i < types_list.size(); i++) {
-    types_string_list[i] = types_list[i].toString()->string();
+    types_string_list[i] = types_list[i].toStringRef();
   }
 
   std::vector<c10::TypePtr> types_ptr_list = c10::parseType(types_string_list);

--- a/torch/csrc/jit/mobile/parse_operators.cpp
+++ b/torch/csrc/jit/mobile/parse_operators.cpp
@@ -21,9 +21,7 @@ void parseOperators(
       num_args = op_item[2].toInt();
     }
     function->append_operator(
-        op_item[0].toString()->string(),
-        op_item[1].toString()->string(),
-        num_args);
+        op_item[0].toStringRef(), op_item[1].toStringRef(), num_args);
   }
   function->initialize_operators(
       (module_load_options & MobileModuleLoadOptions::OPERATOR_CHECK));

--- a/torch/csrc/jit/passes/onnx/function_extraction.cpp
+++ b/torch/csrc/jit/passes/onnx/function_extraction.cpp
@@ -1169,7 +1169,7 @@ void ONNXTrackScopeAttributes(
     } else if (v.isBool()) {
       attr_node->i_(k, v.toBool());
     } else if (v.isString()) {
-      attr_node->s_(k, v.toString()->string());
+      attr_node->s_(k, v.toStringRef());
     } else if (v.isIntList()) {
       attr_node->is_(k, v.toIntList().vec());
     } else if (v.isBoolList()) {

--- a/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
+++ b/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
@@ -184,8 +184,8 @@ c10::optional<ModuleInstanceInfo> InlinedCallStackDeserializer::
   }
   const auto& tup_elems = iv.toTupleRef().elements();
   TORCH_CHECK(tup_elems.size() == 2);
-  std::string type_name = tup_elems[0].toString()->string();
-  std::string instance_name = tup_elems[1].toString()->string();
+  std::string type_name = tup_elems[0].toStringRef();
+  std::string instance_name = tup_elems[1].toStringRef();
   // type_name might be empty string ""
   // In that case type_ptr should be just nullptr
   auto type_ptr = cu->get_class(type_name);

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -711,7 +711,7 @@ flatbuffers::Offset<mobile::serialization::IValue> FlatbufferSerializer::
   } else if (ivalue.isString()) {
     ivalue_type = IValueUnion::String;
     offset = mobile::serialization::CreateString(
-                 fbb, fbb.CreateSharedString(ivalue.toString()->string()))
+                 fbb, fbb.CreateSharedString(ivalue.toStringRef()))
                  .Union();
   } else if (ivalue.isGenericDict()) {
     ivalue_type = IValueUnion::Dict;

--- a/torch/csrc/jit/serialization/source_range_serialization.cpp
+++ b/torch/csrc/jit/serialization/source_range_serialization.cpp
@@ -85,7 +85,7 @@ std::shared_ptr<Source> SourceRangeDeserializer::deserialize_source(
 
     source = std::make_shared<Source>(str_cord, filename, starting_line_no_);
   } else {
-    std::string text_ = tup_elems[0].toString()->string();
+    std::string text_ = tup_elems[0].toStringRef();
     c10::optional<std::string> filename_ =
         tup_elems[1].toOptional<std::string>();
     int64_t starting_line_no_ = tup_elems[2].toInt();


### PR DESCRIPTION
Summary: `IValue::toString()` creates a `new c10::intrusive_ptr` (like `std::shared_ptr`) and `->string()` immediately accesses it, creating an atomic reference increment/decrement. We can skip both of these operations by calling `IValue::toStringRef()`.

Test Plan: CI

Reviewed By: jaybean-dev

Differential Revision: D39605242

