### PR TITLE
Adding a unit test that would gate PRs and prevent reverts, e.g. #83327

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7509,7 +7509,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         # Compare
         self.assertEqual(res_cpu, res_cuda)
 
-    def test_permute_matmual(self):
+    def test_permute_matmul(self):
         a = torch.ones([2, 5, 24, 24])
         b = torch.ones([3, 2, 5, 24, 24])
         c = a.permute(0, 1, 3, 2).matmul(b)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7509,6 +7509,12 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
         # Compare
         self.assertEqual(res_cpu, res_cuda)
 
+    def test_permute_matmual(self):
+        a = torch.ones([2, 5, 24, 24])
+        b = torch.ones([3, 2, 5, 24, 24])
+        c = a.permute(0, 1, 3, 2).matmul(b)
+        self.assertEqual([c.min(), c.max(), c.sum()], [24, 24, 414720])
+
 instantiate_device_type_tests(TestLinalg, globals())
 
 if __name__ == '__main__':


### PR DESCRIPTION
PR #83327 slipped through CI, adding this unit test as part of efforts to minimize future reverts 