### PR TITLE
Add `IListRefTag::Materialized` to `IListRefIterator` destructor.

### DIFF
--- a/aten/src/ATen/core/IListRef.h
+++ b/aten/src/ATen/core/IListRef.h
@@ -388,6 +388,9 @@ class IListRefIterator : public std::iterator<std::bidirectional_iterator_tag, T
       case IListRefTag::Unboxed:
         payload_.unboxed_iterator = iterator.payload_.unboxed_iterator;
         break;
+      case IListRefTag::Materialized:
+        payload_.materialized_iterator = iterator.payload_.materialized_iterator;
+        break;
       default:
         TORCH_INTERNAL_ASSERT(false, "invalid IListRef tag.");
     }
@@ -403,6 +406,9 @@ class IListRefIterator : public std::iterator<std::bidirectional_iterator_tag, T
         break;
       case IListRefTag::Unboxed:
         payload_.unboxed_iterator.~unboxed_iterator_type();
+        break;
+      case IListRefTag::Materialized:
+        payload_.materialized_iterator.~materialized_iterator_type();
         break;
       default:
         TORCH_INTERNAL_ASSERT(false, "invalid IListRef tag.");

--- a/aten/src/ATen/core/IListRef.h
+++ b/aten/src/ATen/core/IListRef.h
@@ -399,7 +399,7 @@ class IListRefIterator : public std::iterator<std::bidirectional_iterator_tag, T
 
 #if defined(_MSC_VER) && _ITERATOR_DEBUG_LEVEL == 2
   // See [Note: MSVC Iterator Debug]
-  ~IListRefIterator() {
+  ~IListRefIterator() noexcept(false) {
     switch (tag_) {
       case IListRefTag::Boxed:
         payload_.boxed_iterator.~boxed_iterator_type();


### PR DESCRIPTION
Fixes #85404
