### PR TITLE
Increase timeout for ProcessGroupGlooTest

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -215,7 +215,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
 
     def opts(self, threads=2):
         opts = c10d.ProcessGroupGloo._Options()
-        opts._timeout = 5.0
+        opts._timeout = 50.0
         opts._devices = [create_device(interface=LOOPBACK)]
         opts._threads = threads
         return opts


### PR DESCRIPTION
We see spurious failures due to timeouts in`test_allreduce_coalesced_basics` but only when running the whole test suite with
`python run_test.py --verbose -i distributed/test_c10d_gloo`. Increasing the timeout to 50s should provide enough leeway to avoid this. Note that the default for the `_timeout` is 30 minutes.

Originally reported in EasyBuild at https://github.com/easybuilders/easybuild-easyconfigs/pull/15137#issuecomment-1073809305 and patch proposed by @casparvl