### PR TITLE
Add new approvers for ideep

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -244,6 +244,8 @@
   approved_by:
   - XiaobingSuper
   - yanbing-j
+  - sanchitintel
+  - chunyuan-w
   mandatory_checks_name:
   - Facebook CLA Check
   - Lint


### PR DESCRIPTION
Please approve adding [`sanchitintel`](https://github.com/sanchitintel) & [`chunyuan-w`](https://github.com/chunyuan-w) from Intel in the approvers list for `ideep` in the merge rules. Thanks!

cc @Jgong5 @ashokei @malfet 

