### PR TITLE
[Easy][FSDP] Simplify `assert` to `p_assert`

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3431,9 +3431,8 @@ class FullyShardedDataParallel(nn.Module):
                 p = handle.flat_param
                 if p.requires_grad:
                     if hasattr(p, "_post_backward_hook_state"):
-                        assert len(p._post_backward_hook_state) == 2 and len(  # type: ignore[attr-defined]
-                            p._post_backward_hook_state  # type: ignore[attr-defined]
-                        ), (  # type: ignore[attr-defined]
+                        p_assert(
+                            len(p._post_backward_hook_state) == 2,  # type: ignore[attr-defined]
                             "p._post_backward_hook_state fields are not valid."
                         )
                         p._post_backward_hook_state[1].remove()  # type: ignore[attr-defined]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #84911 [FSDP] Add `use_orig_params`
* #85039 [FSDP] Add `TensorFlattener` for TP support
* #85483 [ShardedTensor] Add `is_floating_point`
* #85482 [ShardedTensor] Add `is_meta`
* #85481 [FSDP] Make `_ran_pre_backward_hook` check more robust
* **#85479 [Easy][FSDP] Simplify `assert` to `p_assert`**

