### PR TITLE
[FSDP] Make `_ran_pre_backward_hook` check more robust

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3072,7 +3072,7 @@ class FullyShardedDataParallel(nn.Module):
             _handles_key = tuple(_handles)  # avoid shadowing `handles_key`
             # Only run the pre-backward hook once per group of handles involved
             # in the same module forward computation
-            if _handles_key and self._ran_pre_backward_hook[_handles_key]:
+            if _handles_key and self._ran_pre_backward_hook.get(_handles_key, False):
                 return
 
             with torch.autograd.profiler.record_function(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #84911 [FSDP] Add `use_orig_params`
* #85039 [FSDP] Add `TensorFlattener` for TP support
* #85483 [ShardedTensor] Add `is_floating_point`
* #85482 [ShardedTensor] Add `is_meta`
* **#85481 [FSDP] Make `_ran_pre_backward_hook` check more robust**
* #85479 [Easy][FSDP] Simplify `assert` to `p_assert`

