### PR TITLE
[ShardedTensor] Add `is_meta`

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
@@ -45,6 +45,11 @@ def tensor_device(types, args=(), kwargs=None, pg=None):
     return self_st.local_shards()[0].tensor.device
 
 
+@_sharded_op_impl(torch.Tensor.is_meta.__get__)
+def st_is_meta(types, args=(), kwargs=None, pg=None):
+    return args[0].local_tensor().is_meta
+
+
 def sharded_type_as_check(*args, **kwargs):
     """
     Perform extra checks for the sharded_type_as op such as the input needs to

--- a/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
@@ -45,7 +45,7 @@ def tensor_device(types, args=(), kwargs=None, pg=None):
     return self_st.local_shards()[0].tensor.device
 
 
-@_sharded_op_impl(torch.Tensor.is_meta.__get__)
+@_sharded_op_impl(torch.Tensor.is_meta.__get__)  # type: ignore[attr-defined]
 def st_is_meta(types, args=(), kwargs=None, pg=None):
     return args[0].local_tensor().is_meta
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #84911 [FSDP] Add `use_orig_params`
* #85039 [FSDP] Add `TensorFlattener` for TP support
* #85483 [ShardedTensor] Add `is_floating_point`
* **#85482 [ShardedTensor] Add `is_meta`**
* #85481 [FSDP] Make `_ran_pre_backward_hook` check more robust
* #85479 [Easy][FSDP] Simplify `assert` to `p_assert`

This adds `is_meta` support to `ShardedTensor`. This is needed for `ShardedTensor` + FSDP.