### PR TITLE
[ShardedTensor] Add `is_floating_point`

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
@@ -20,6 +20,7 @@ _register_default_op(torch.Tensor.dim, _sharded_op_impl)
 _register_default_op(torch.Tensor.ndim.__get__, _sharded_op_impl)  # type: ignore[attr-defined]
 _register_default_op(torch.Tensor.is_contiguous, _sharded_op_impl)
 _register_default_op(torch.Tensor.contiguous, _sharded_op_impl)
+_register_default_op(torch.Tensor.is_floating_point, _sharded_op_impl)
 
 # __reduce_ex__ to dispatch to get_state/set_state
 _register_default_op(torch.Tensor.__reduce_ex__, _sharded_op_impl)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #84911 [FSDP] Add `use_orig_params`
* #85039 [FSDP] Add `TensorFlattener` for TP support
* **#85483 [ShardedTensor] Add `is_floating_point`**
* #85482 [ShardedTensor] Add `is_meta`
* #85481 [FSDP] Make `_ran_pre_backward_hook` check more robust
* #85479 [Easy][FSDP] Simplify `assert` to `p_assert`

This adds `is_floating_point()` support to `ShardedTensor`. This is needed for `ShardedTensor` + FSDP.