### PR TITLE
Made max_pool2d_with_indices_backward_cuda contiguify `indices`

### DIFF
--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -423,14 +423,14 @@ IntArrayRef stride,
 IntArrayRef padding,
 IntArrayRef dilation,
 bool ceil_mode,
-const Tensor& indices,
+const Tensor& indices_,
 const Tensor& gradInput) {
   NoNamesGuard guard;
 
   TensorArg gradInput_arg{ gradInput, "gradInput", 1 };
   TensorArg gradOutput_arg{ gradOutput_, "gradOutput_", 2 };
   TensorArg input_arg{ input_, "input_", 3 };
-  TensorArg indices_arg{ indices, "indices", 4 };
+  TensorArg indices_arg{ indices_, "indices", 4 };
 
   checkAllSameGPU(__func__,
                   {gradInput_arg, gradOutput_arg, input_arg, indices_arg});
@@ -473,6 +473,8 @@ const Tensor& gradInput) {
   const int64_t out_stride_c = gradOutput.stride(-3);
   const int64_t out_stride_h = gradOutput.stride(-2);
   const int64_t out_stride_w = gradOutput.stride(-1);
+
+  const Tensor indices = indices_.contiguous(memory_format);
 
   gradInput.zero_();
 

--- a/functorch/test/test_ops.py
+++ b/functorch/test/test_ops.py
@@ -1264,7 +1264,6 @@ class TestOperators(TestCase):
         xfail('nn.functional.logsigmoid'),  # Forward AD not implemented and no decomposition
         # NYI: Tensor.clone(memory_format) inside vmap is only supported with
         # memory_format torch.preserve_format or torch.contiguous_format (got ChannelsLast)
-        xfail('nn.functional.max_pool2d', device_type='cuda'),  # AssertionError: Tensor-likes are not close!
         xfail('nn.functional.max_unpool2d'),
         xfail('nn.functional.max_unpool2d', 'grad'),
         xfail('nn.functional.multi_margin_loss'),  # Forward AD not implemented and no decomposition


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #85493

Currently, max_pool2d_with_indices_backward(grad_output, self, ..., indices)
(on cuda) assumes that indices has the same suggested memory format as
self.

This is indeed always true in regular PyTorch: the max_pool2d_with_indices
forward pass returns indices with the same suggeted memory format as
self.

However, we'd like to make an argument that always contiguifying indices
is good for consistency, has negligible added cost, and is more robust
(for Tensor Subclass authors):

- the max_pool2d_with_indices_backward implementation for CPU always
contiguifies `indices`. Ditto for the max_pool3d_with_indices_backward
implementation.
- Calling .contiguous() has almost no cost (compared to before) because
there is a fast-path that checks the cached memory_format on the
TensorImpl.
- functorch has trouble writing a batching rule for
`max_pool2d_with_indices_backward`. Having it accept `indices` with
arbitrary strides helps make it so that vmap doesn't need to special
case the batching rule for the strides of `indices`.

Test Plan:
- Not sure if it's worth writing a separate test case
- this PR fixes one of functorch's test cases.