### PR TITLE
Cast grad_input to half when input_dtype is half in _softmax_backward_data aten decomposition

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -624,17 +624,17 @@ def diagonal_backward(
 
 
 def _cast_grad_to_input_dtype(
-    grad_output: Tensor, grad_input: Tensor, input_dtype: int
+    grad_output: Tensor, grad_input: Tensor, input_dtype: torch.dtype
 ):
     if grad_output.dtype != input_dtype:
-        grad_input = grad_input.to(utils.get_dtype(input_dtype))
+        grad_input = grad_input.to(input_dtype)
     return grad_input
 
 
 @register_decomposition(aten._softmax_backward_data)
 @compute_only_pw_cast_for_opmath
 def _softmax_backward_data(
-    grad_output: Tensor, output: Tensor, dim: int, input_dtype: int
+    grad_output: Tensor, output: Tensor, dim: int, input_dtype: torch.dtype
 ):
     new_grad_output = grad_output * output
     grad_input = new_grad_output - output * torch.sum(
@@ -646,7 +646,7 @@ def _softmax_backward_data(
 @register_decomposition(aten._log_softmax_backward_data)
 @compute_only_pw_cast_for_opmath
 def _log_softmax_backward_data(
-    grad_output: Tensor, output: Tensor, dim: int, input_dtype: int
+    grad_output: Tensor, output: Tensor, dim: int, input_dtype: torch.dtype
 ):
     grad_input = grad_output - torch.exp(output) * torch.sum(
         grad_output, dim=dim, keepdim=True

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -31,7 +31,11 @@ class Reduction(Enum):
 # This wraps a decomposition and performs various type promotion logic within it, depending on the strategy provided
 # We're currently re-using ELEMENTWISE_TYPE_PROMOTION_KIND, although some of the usages are on non-elementwise ops
 # Will need to validate the non-elementwise uses
-def type_casts(f: Callable, type_promotion: utils.ELEMENTWISE_TYPE_PROMOTION_KIND):
+def type_casts(
+    f: Callable,
+    type_promotion: utils.ELEMENTWISE_TYPE_PROMOTION_KIND,
+    compute_dtype_only: bool = False,
+):
     @functools.wraps(f)
     def inner(*args, **kwargs):
         flat_args = [
@@ -55,11 +59,19 @@ def type_casts(f: Callable, type_promotion: utils.ELEMENTWISE_TYPE_PROMOTION_KIN
                 return x
 
         r = f(*tree_map(increase_prec, args), **tree_map(increase_prec, kwargs))
-        return tree_map(decrease_prec, r)
+        if compute_dtype_only:
+            return r
+        else:
+            return tree_map(decrease_prec, r)
 
     return inner
 
 
+compute_only_pw_cast_for_opmath = functools.partial(
+    type_casts,
+    type_promotion=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    compute_dtype_only=True,
+)
 pw_cast_for_opmath = functools.partial(
     type_casts, type_promotion=utils.ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
 )
@@ -611,15 +623,16 @@ def diagonal_backward(
     return torch.diagonal_scatter(grad_input, grad_output, offset, dim1, dim2)
 
 
-def _cast_grad_to_half(grad_output: Tensor, grad_input: Tensor, input_dtype: int):
-    dtype_mismatch = grad_output.dtype != input_dtype
-    half_to_float = (grad_output.dtype == torch.float) and (input_dtype == torch.half)
-    if dtype_mismatch and half_to_float:
-        grad_input = grad_input.to(torch.half)
+def _cast_grad_to_input_dtype(
+    grad_output: Tensor, grad_input: Tensor, input_dtype: int
+):
+    if grad_output.dtype != input_dtype:
+        grad_input = grad_input.to(utils.get_dtype(input_dtype))
     return grad_input
 
 
 @register_decomposition(aten._softmax_backward_data)
+@compute_only_pw_cast_for_opmath
 def _softmax_backward_data(
     grad_output: Tensor, output: Tensor, dim: int, input_dtype: int
 ):
@@ -627,17 +640,18 @@ def _softmax_backward_data(
     grad_input = new_grad_output - output * torch.sum(
         new_grad_output, dim=dim, keepdim=True
     )
-    return _cast_grad_to_half(grad_output, grad_input, input_dtype)
+    return _cast_grad_to_input_dtype(grad_output, grad_input, input_dtype)
 
 
 @register_decomposition(aten._log_softmax_backward_data)
+@compute_only_pw_cast_for_opmath
 def _log_softmax_backward_data(
     grad_output: Tensor, output: Tensor, dim: int, input_dtype: int
 ):
     grad_input = grad_output - torch.exp(output) * torch.sum(
         grad_output, dim=dim, keepdim=True
     )
-    return _cast_grad_to_half(grad_output, grad_input, input_dtype)
+    return _cast_grad_to_input_dtype(grad_output, grad_input, input_dtype)
 
 
 @register_decomposition(aten.im2col)


### PR DESCRIPTION
Fixes #85504

`_softmax_backward_data` and `_log_softmax_backward_data` cast `grad_input` to half when the `input_dtype` is half.
When running with amp without the cast, consumer ops can trigger `RuntimeError: expected scalar type Float but found Half`.

https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/SoftMax.cpp#L70-L83
https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/SoftMax.cpp#L102-L113
