### PR TITLE
Skip MPS test from generic M1 testsuite

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -98,6 +98,8 @@ TESTS = discover_tests(
         'test_jit_string',
         'test_kernel_launch_checks',
         'test_metal',
+        # Right now we have a separate CI job for running MPS
+        'test_mps',
         'test_nnapi',
         'test_segment_reductions',
         'test_static_runtime',


### PR DESCRIPTION
As there is separate Run MPS shard right now

See if this reduces the number of crashes

