### PR TITLE
Enrich error context for package exporter

### DIFF
--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -533,14 +533,15 @@ class PackageExporter:
             # Couldn't find a source!  Add it to our dependency graph as broken
             # and continue.
             filename = getattr(module_obj, "__file__", None)
-            error_context = None
+            error_context = f"module_name: {module_name} "
+            if filename is not None:
+                error_context += f"filename: {filename}"
             if filename is None:
                 packaging_error = PackagingErrorReason.NO_DUNDER_FILE
             elif filename.endswith(tuple(importlib.machinery.EXTENSION_SUFFIXES)):
                 packaging_error = PackagingErrorReason.IS_EXTENSION_MODULE
             else:
                 packaging_error = PackagingErrorReason.SOURCE_FILE_NOT_FOUND
-                error_context = f"filename: {filename}"
             self.dependency_graph.add_node(
                 module_name,
                 action=_ModuleProviderAction.INTERN,


### PR DESCRIPTION
Summary:
The exception now include module name failing the check:

  PytorchModelPackagerException:
  * Module is a C extension module. torch.package supports Python modules only.
    _swigfaiss_gpu
      Context: module_name: _swigfaiss_gpu filename: /mnt/xarfuse/uid-233664/c36dd00e-seed-nspid4026531836_cgpid57478-ns-4026531840/_swigfaiss_gpu.so
    _swigfaiss
      Context: module_name: _swigfaiss filename: /mnt/xarfuse/uid-233664/c36dd00e-seed-nspid4026531836_cgpid57478-ns-4026531840/_swigfaiss.so

Test Plan: N2531121

Differential Revision: D39743995

