### PR TITLE
resubmit: [mta] APEX style Fused Adam (#81705)

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachFunctors.cuh
@@ -48,6 +48,25 @@ __device__ bool init_args(
 }
 
 template<int depth, typename T>
+__device__ bool init_args(
+    T** args,
+    FusedOptimizerTensorListMetadata<depth>& tl,
+    int chunk_idx,
+    int chunk_size,
+    int tensor_loc) {
+        bool all_aligned = true;
+        for (int i = 0; i < depth; i++) {
+            args[i] =  (T*)tl.addresses[i][tensor_loc];
+            args[i] += chunk_idx * chunk_size;
+
+            if (!is_aligned(args[i])) {
+                all_aligned = false;
+            }
+        }
+        return all_aligned;
+}
+
+template<int depth, typename T>
 __device__ void load_args(T r_args[][kILP], T** args, int i_start, int chunk_size, int n) {
 #pragma unroll
     for(int ii = 0; ii < kILP; ii++) {

--- a/aten/src/ATen/native/cuda/FusedAdamKernel.cu
+++ b/aten/src/ATen/native/cuda/FusedAdamKernel.cu
@@ -1,0 +1,37 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/TypeDefault.h>
+#include <ATen/native/cuda/fused_adam_amsgrad_impl.cuh>
+#include <ATen/native/cuda/fused_adam_impl.cuh>
+
+
+namespace at { namespace native {
+
+// note(crcrpar): To observe the CI rules, i.e. 20 minutes per file to compile, defensively split instantiations into _impl files.
+// this is only for CUDA 11.3 for which it took about 20 minutes and 28 minutes in my workstation and CI, respectively.
+// As a data point, it took about 20 seconds for CUDA 11.7 installed in my environment.
+// See https://github.com/pytorch/pytorch/pull/81705 for details.
+void _fused_adam_kernel_cuda_(
+    at::TensorList params,
+    at::TensorList grads,
+    at::TensorList exp_avgs,
+    at::TensorList exp_avg_sqs,
+    at::TensorList max_exp_avg_sqs,
+    at::TensorList state_steps,
+    const double lr,
+    const double beta1,
+    const double beta2,
+    const double weight_decay,
+    const double eps,
+    const bool amsgrad,
+    const bool maximize,
+    const c10::optional<at::Tensor>& grad_scale,
+    const c10::optional<at::Tensor>& found_inf
+) {
+  if (amsgrad) {
+    _fused_adam_cuda_impl_(params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, state_steps, lr, beta1, beta2, weight_decay, eps, amsgrad, maximize, grad_scale, found_inf);
+  } else {
+    _fused_adam_cuda_impl_(params, grads, exp_avgs, exp_avg_sqs, state_steps, lr, beta1, beta2, weight_decay, eps, amsgrad, maximize, grad_scale, found_inf);
+  }
+}
+
+}} // namespace at::native

--- a/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
@@ -1,0 +1,52 @@
+#include <ATen/native/cuda/fused_adam_amsgrad_impl.cuh>
+
+#include <ATen/Dispatch.h>
+#include <ATen/native/ForeachUtils.h>
+#include <ATen/native/cuda/fused_adam_utils.cuh>
+#include <ATen/native/cuda/MultiTensorApply.cuh>
+#include <vector>
+
+namespace at { namespace native {
+
+void _fused_adam_cuda_impl_(
+    at::TensorList params,
+    at::TensorList grads,
+    at::TensorList exp_avgs,
+    at::TensorList exp_avg_sqs,
+    at::TensorList max_exp_avg_sqs,
+    at::TensorList state_steps,
+    const double lr,
+    const double beta1,
+    const double beta2,
+    const double weight_decay,
+    const double eps,
+    const bool amsgrad,
+    const bool maximize,
+    const c10::optional<at::Tensor>& grad_scale,
+    const c10::optional<at::Tensor>& found_inf
+) {
+  std::vector<std::vector<at::Tensor>> tensor_lists{
+    params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec(), max_exp_avg_sqs.vec() };
+
+  float* grad_scale_ptr = grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
+  float* found_inf_ptr = found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, params[0].scalar_type(),
+      "fused_adam_kernel_cuda", [&]() {
+        multi_tensor_apply_for_fused_optimizer<5>(
+            tensor_lists,
+            state_steps,
+            FusedAdamMathFunctor<scalar_t, 5>(),
+            lr,
+            beta1,
+            beta2,
+            weight_decay,
+            eps,
+            maximize,
+            /* amsgrad */true,
+            grad_scale_ptr,
+            found_inf_ptr);
+        });
+}
+
+} } // namespace at::native

--- a/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cuh
@@ -1,0 +1,24 @@
+#pragma once
+#include <ATen/core/Tensor.h>
+
+namespace at { namespace native {
+
+void _fused_adam_cuda_impl_(
+    at::TensorList params,
+    at::TensorList grads,
+    at::TensorList exp_avgs,
+    at::TensorList exp_avg_sqs,
+    at::TensorList max_exp_avg_sqs,
+    at::TensorList state_steps,
+    const double lr,
+    const double beta1,
+    const double beta2,
+    const double weight_decay,
+    const double eps,
+    const bool amsgrad,
+    const bool maximize,
+    const c10::optional<at::Tensor>& grad_scale,
+    const c10::optional<at::Tensor>& found_inf
+);
+
+} } // namespace at::native

--- a/aten/src/ATen/native/cuda/fused_adam_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_impl.cu
@@ -1,0 +1,51 @@
+#include <ATen/native/cuda/fused_adam_impl.cuh>
+
+#include <ATen/Dispatch.h>
+#include <ATen/native/ForeachUtils.h>
+#include <ATen/native/cuda/fused_adam_utils.cuh>
+#include <ATen/native/cuda/MultiTensorApply.cuh>
+#include <vector>
+
+namespace at { namespace native {
+
+void _fused_adam_cuda_impl_(
+    at::TensorList params,
+    at::TensorList grads,
+    at::TensorList exp_avgs,
+    at::TensorList exp_avg_sqs,
+    at::TensorList state_steps,
+    const double lr,
+    const double beta1,
+    const double beta2,
+    const double weight_decay,
+    const double eps,
+    const bool amsgrad,
+    const bool maximize,
+    const c10::optional<at::Tensor>& grad_scale,
+    const c10::optional<at::Tensor>& found_inf
+) {
+  std::vector<std::vector<at::Tensor>> tensor_lists{
+    params.vec(), grads.vec(), exp_avgs.vec(), exp_avg_sqs.vec() };
+
+  float* grad_scale_ptr = grad_scale.has_value() ? grad_scale->data_ptr<float>() : nullptr;
+  float* found_inf_ptr = found_inf.has_value() ? found_inf->data_ptr<float>() : nullptr;
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, params[0].scalar_type(),
+      "fused_adam_kernel_cuda", [&]() {
+        multi_tensor_apply_for_fused_optimizer<4>(
+            tensor_lists,
+            state_steps,
+            FusedAdamMathFunctor<scalar_t, 4>(),
+            lr,
+            beta1,
+            beta2,
+            weight_decay,
+            eps,
+            maximize,
+            /* amsgrad */false,
+            grad_scale_ptr,
+            found_inf_ptr);
+        });
+}
+
+} } // namespace at::native

--- a/aten/src/ATen/native/cuda/fused_adam_impl.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_impl.cuh
@@ -1,0 +1,23 @@
+#pragma once
+#include <ATen/core/Tensor.h>
+
+namespace at { namespace native {
+
+void _fused_adam_cuda_impl_(
+    at::TensorList params,
+    at::TensorList grads,
+    at::TensorList exp_avgs,
+    at::TensorList exp_avg_sqs,
+    at::TensorList state_steps,
+    const double lr,
+    const double beta1,
+    const double beta2,
+    const double weight_decay,
+    const double eps,
+    const bool amsgrad,
+    const bool maximize,
+    const c10::optional<at::Tensor>& grad_scale,
+    const c10::optional<at::Tensor>& found_inf
+);
+
+} } // namespace at::native

--- a/aten/src/ATen/native/cuda/fused_adam_utils.cuh
+++ b/aten/src/ATen/native/cuda/fused_adam_utils.cuh
@@ -1,0 +1,165 @@
+#pragma once
+#include <ATen/core/Tensor.h>
+#include <ATen/native/cuda/MultiTensorApply.cuh>
+#include <ATen/native/cuda/ForeachFunctors.cuh>
+
+
+namespace at { namespace native {
+
+namespace {
+
+constexpr uint8_t kParamIdx = 0;
+constexpr uint8_t kGradIdx = 1;
+constexpr uint8_t kExpAvgIdx = 2;
+constexpr uint8_t kExpAvgSqIdx = 3;
+constexpr uint8_t kMaxExpAvgSqIdx = 4;
+
+template <typename scalar_type, typename opmath_t, int depth=4>
+C10_DEVICE __forceinline__ void adam_math(
+    scalar_type r_args[depth][kILP],
+    const float* step_count,
+    const double lr,
+    const double beta1,
+    const double beta2,
+    const double weight_decay,
+    const double eps,
+    const bool maximize,
+    const bool amsgrad,
+    const float* grad_scale_ptr,
+    const float* found_inf_ptr
+) {
+#pragma unroll
+    for (int ii = 0; ii < kILP; ii++) {
+        // Load values.
+        opmath_t param = static_cast<opmath_t>(r_args[kParamIdx][ii]);
+        opmath_t grad = static_cast<opmath_t>(r_args[kGradIdx][ii]);
+        if (grad_scale_ptr) {
+            grad /= (static_cast<double>(*grad_scale_ptr));
+        }
+        const opmath_t grad_to_store = grad;
+        if (maximize) {
+            grad = -grad;
+        }
+        opmath_t exp_avg = static_cast<opmath_t>(r_args[kExpAvgIdx][ii]);
+        opmath_t exp_avg_sq = static_cast<opmath_t>(r_args[kExpAvgSqIdx][ii]);
+        opmath_t max_exp_avg_sq;
+        if (amsgrad) {
+            max_exp_avg_sq = static_cast<opmath_t>(r_args[kMaxExpAvgSqIdx][ii]);
+        }
+
+        // Update param, grad, 1st and 2nd order momentum.
+        if (weight_decay != 0) {
+            grad += param * weight_decay;
+        }
+        // todo(crcrpar): use lerp
+        // ref: https://developer.nvidia.com/blog/lerp-faster-cuda/
+        exp_avg = beta1 * exp_avg + (1 - beta1) * grad;
+        exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * grad * grad;
+
+        if (amsgrad) {
+            max_exp_avg_sq = std::max(max_exp_avg_sq, exp_avg_sq);
+        }
+
+        const opmath_t bias_correction1 = 1 - std::pow(beta1, *step_count);
+        const opmath_t bias_correction2 = 1 - std::pow(beta2, *step_count);
+
+        const opmath_t step_size = lr / bias_correction1;
+
+        const opmath_t bias_correction2_sqrt = std::sqrt(bias_correction2);
+
+        opmath_t denom;
+        if (amsgrad) {
+            denom = (std::sqrt(max_exp_avg_sq) / bias_correction2_sqrt) + eps;
+        } else {
+            denom = (std::sqrt(exp_avg_sq) / bias_correction2_sqrt) + eps;
+        }
+
+        param -= step_size * exp_avg / denom;
+
+        // Store results.
+        r_args[kParamIdx][ii] = param;
+        if (grad_scale_ptr) {
+          r_args[kGradIdx][ii] = grad_to_store;
+        }
+        r_args[kExpAvgIdx][ii] = exp_avg;
+        r_args[kExpAvgSqIdx][ii] = exp_avg_sq;
+        if (amsgrad) {
+            r_args[kMaxExpAvgSqIdx][ii] = max_exp_avg_sq;
+        }
+    }
+}
+
+// [note: Conditional Gradient Store when `optimizer.step` is called by GradScaler]
+// When a user is training their model(s) with an FP16 AMP recipe,
+// parameter updates are done via `grad_scaler.step(optimizer)` instead of `optimizer.step()`.
+// For most optimizers, GradScaler unscales gradients on behalf of those optimizers.
+// Also, before `.step`, it makes sure that all the gradients involved are finite, which incurs a device sync.
+// On the other hand, fused optimizers set their member variable of `_step_supports_amp_scaling` to `True`
+// in order to remove the device sync above. This means that fused optimizers have to have
+// their CUDA kernels (a) unscale gradients and (b) skip parameter updates accordingly.
+// To be functionally on par with `torch.optim` optimizers and `_multi_tensor` ones,
+// the kernel below writes out gradients only when `grad_scale_ptr != nullptr.
+template <typename scalar_type, int depth=4>
+struct FusedAdamMathFunctor {
+    static_assert(depth == 4 || depth == 5, "depth of 4 for Adam, depth of 5 for Adam with AMSGrad.");
+    using opmath_t = at::opmath_type<scalar_type>;
+    C10_DEVICE __forceinline__ void operator()(
+            int chunk_size,
+            FusedOptimizerTensorListMetadata<depth>& tl,
+            const double lr,
+            const double beta1,
+            const double beta2,
+            const double weight_decay,
+            const double eps,
+            const bool maximize,
+            const bool amsgrad,
+            const float* grad_scale_ptr,
+            const float* found_inf_ptr
+  ) {
+        int tensor_loc = tl.block_to_tensor[blockIdx.x];
+        int chunk_idx = tl.block_to_chunk[blockIdx.x];
+        int n = tl.numel_for_tensor[tensor_loc];
+
+        if (found_inf_ptr && *found_inf_ptr == 1) {
+            return;
+        }
+        float *step_count = reinterpret_cast<float*>(tl.state_steps_addresses[tensor_loc]);
+
+        scalar_type* args[depth];
+        const bool all_aligned{init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc)};
+        n -= chunk_idx * chunk_size;
+        scalar_type r_args[depth][kILP];
+
+        if ((n % kILP == 0) && (chunk_size % kILP == 0) && all_aligned) {
+            for (int i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
+#pragma unroll
+                for (int i = 0; i < depth; i++) {
+                    load_store(r_args[i], args[i], 0, i_start);
+                }
+                adam_math<scalar_type, opmath_t, depth>(
+                    r_args, step_count, lr, beta1, beta2, weight_decay, eps, maximize, amsgrad, grad_scale_ptr, found_inf_ptr);
+#pragma unroll
+                for (int i = 0; i < depth; i++) {
+                  if (i != kGradIdx || grad_scale_ptr) {
+                    load_store(args[i], r_args[i], i_start, 0);
+                  }
+                }
+            }
+        } else {
+            for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
+              load_args<depth>(r_args, args, i_start, chunk_size, n);
+              adam_math<scalar_type, opmath_t, depth>(
+                  r_args, step_count, lr, beta1, beta2, weight_decay, eps, maximize, amsgrad, grad_scale_ptr, found_inf_ptr);
+#pragma unroll
+              for (int i = 0; i < depth; i++) {
+                  if (i != kGradIdx || grad_scale_ptr) {
+                    store_args(args[i], r_args[i], i_start, chunk_size, n);
+                  }
+              }
+            }
+        }
+    }
+};
+} // namespace
+
+}} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13812,3 +13812,11 @@
   dispatch:
     CPU: foobar
   autogen: _foobar.out
+
+# Fused Optimizer CUDA kernels.
+- func: _fused_adam_(Tensor(a!)[] self, Tensor(b!)[] grads, Tensor(c!)[] exp_avgs, Tensor(d!)[] exp_avg_sqs, Tensor(e!)[] max_exp_avg_sqs, Tensor[] state_steps, *, float lr, float beta1, float beta2, float weight_decay, float eps, bool amsgrad, bool maximize, Tensor? grad_scale=None, Tensor? found_inf=None) -> ()
+  # Unlike "foreach" functions, lists of tensors should be guaranteed to be on the same device (for now).
+  variants: function
+  dispatch:
+    CUDA: _fused_adam_kernel_cuda_
+  autogen: _fused_adam, _fused_adam.out

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4,6 +4,7 @@ from itertools import repeat, chain, product
 from typing import NamedTuple
 import collections
 import contextlib
+from copy import deepcopy
 import ctypes
 import gc
 import io
@@ -2225,20 +2226,24 @@ torch.cuda.synchronize()
             self.assertEqual(s1.get_growth_interval(), 2)
             self.assertEqual(s1._init_growth_tracker, 0)
 
-    def _create_scaling_models_optimizers(self, device="cuda"):
+    def _create_scaling_models_optimizers(self, device="cuda", optimizer_ctor=torch.optim.SGD, optimizer_kwargs=None):
         # Create a module+optimizer that will use scaling, and a control module+optimizer
         # that will not use scaling, against which the scaling-enabled module+optimizer can be compared.
         mod_control = torch.nn.Sequential(torch.nn.Linear(8, 8), torch.nn.Linear(8, 8)).to(device=device)
         mod_scaling = torch.nn.Sequential(torch.nn.Linear(8, 8), torch.nn.Linear(8, 8)).to(device=device)
-        for c, s in zip(mod_control.parameters(), mod_scaling.parameters()):
-            s.data.copy_(c.data)
+        with torch.no_grad():
+            for c, s in zip(mod_control.parameters(), mod_scaling.parameters()):
+                s.copy_(c)
 
-        opt_control = torch.optim.SGD(mod_control.parameters(), lr=1.0)
-        opt_scaling = torch.optim.SGD(mod_scaling.parameters(), lr=1.0)
+        kwargs = {"lr": 1.0}
+        if optimizer_kwargs is not None:
+            kwargs.update(optimizer_kwargs)
+        opt_control = optimizer_ctor(mod_control.parameters(), **kwargs)
+        opt_scaling = optimizer_ctor(mod_scaling.parameters(), **kwargs)
 
         return mod_control, mod_scaling, opt_control, opt_scaling
 
-    def _create_scaling_case(self, device="cuda", dtype=torch.float):
+    def _create_scaling_case(self, device="cuda", dtype=torch.float, optimizer_ctor=torch.optim.SGD, optimizer_kwargs=None):
         data = [(torch.randn((8, 8), dtype=dtype, device=device), torch.randn((8, 8), dtype=dtype, device=device)),
                 (torch.randn((8, 8), dtype=dtype, device=device), torch.randn((8, 8), dtype=dtype, device=device)),
                 (torch.randn((8, 8), dtype=dtype, device=device), torch.randn((8, 8), dtype=dtype, device=device)),
@@ -2248,13 +2253,17 @@ torch.cuda.synchronize()
 
         skip_iter = 2
 
-        return self._create_scaling_models_optimizers(device=device) + (data, loss_fn, skip_iter)
+        return self._create_scaling_models_optimizers(
+            device=device, optimizer_ctor=optimizer_ctor, optimizer_kwargs=optimizer_kwargs,
+        ) + (data, loss_fn, skip_iter)
 
     # _run_scaling_case generalizes some single-optimizer test logic to avoid too much copy-pasting below.
-    def _run_scaling_case(self, run, unskipped, skipped, atol=1e-7):
+    def _run_scaling_case(self, run, unskipped, skipped, atol=1e-7, optimizer_ctor=torch.optim.SGD, optimizer_kwargs=None):
         # Ensure scaling can be disabled without changing user control flow.
         for enabled in True, False:
-            mod_control, mod_scaling, opt_control, opt_scaling, data, loss_fn, skip_iter = self._create_scaling_case()
+            (
+                mod_control, mod_scaling, opt_control, opt_scaling, data, loss_fn, skip_iter,
+            ) = self._create_scaling_case(optimizer_ctor=optimizer_ctor, optimizer_kwargs=optimizer_kwargs)
 
             # For functionality, test with a modest initial scale, and an unrealistically-large growth factor
             # so any potential errors with the growth factor handling will be magnified.
@@ -2276,10 +2285,16 @@ torch.cuda.synchronize()
                 self.assertTrue(scaler.get_scale() == 1.0)
 
             for c, s in zip(mod_control.parameters(), mod_scaling.parameters()):
+                self.assertEqual(c.grad, s.grad, atol=atol, rtol=1e-05)
+
+                c_state, s_state = opt_control.state[c], opt_scaling.state[s]
+                for k in c_state:
+                    self.assertEqual(c_state[k], s_state[k], atol=atol, rtol=1e-05, msg=k)
+
                 self.assertEqual(c, s, atol=atol, rtol=1e-05)
 
     # Compares no scaling + no autocasting against scaling + autocasting.
-    def test_grad_scaling_autocast(self):
+    def _grad_scaling_autocast_test(self, *, atol=1e-3, optimizer_ctor=torch.optim.SGD, optimizer_kwargs=None):
         try_pickle = False
 
         def run(data, model, optimizer, scaler, loss_fn, skip_iter, try_scaling_api):
@@ -2291,7 +2306,8 @@ torch.cuda.synchronize()
                 if try_scaling_api:
                     scaler.scale(loss).backward()
                     if i == skip_iter and scaler.is_enabled():
-                        model[1].weight.grad.data.fill_(float('inf'))
+                        with torch.no_grad():
+                            model[1].weight.grad.fill_(float('inf'))
                     scaler.step(optimizer)
                     scaler.update()
                     if try_pickle:
@@ -2302,11 +2318,81 @@ torch.cuda.synchronize()
                         optimizer.step()
             return scaler
 
-        # sets atol=1e-3 because we're comparing pure fp32 arithmetic vs a mixture of fp16 and fp32
-        self._run_scaling_case(run, unskipped=3, skipped=1, atol=1e-3)
-        # this will be picked up by try_pickle within run():
-        try_pickle = True
-        self._run_scaling_case(run, unskipped=3, skipped=1, atol=1e-3)
+        # NOTE(mkozuki): With current way of testing, `torch.optim.Adam` is failing in spite of `foreach` and `fused`.
+        #   Giving some flexibility to this test might help.
+        context = contextlib.nullcontext
+        if optimizer_ctor in (torch.optim.Adam,):
+            from functools import partial
+            context = partial(self.assertRaises, AssertionError)
+        with context():
+            # sets atol=1e-3 because we're comparing pure fp32 arithmetic vs a mixture of fp16 and fp32
+            self._run_scaling_case(
+                run, unskipped=3, skipped=1, atol=atol, optimizer_ctor=optimizer_ctor, optimizer_kwargs=optimizer_kwargs,
+            )
+            # this will be picked up by try_pickle within run():
+            try_pickle = True
+            self._run_scaling_case(
+                run, unskipped=3, skipped=1, atol=atol, optimizer_ctor=optimizer_ctor, optimizer_kwargs=optimizer_kwargs,
+            )
+
+    def test_grad_scaling_autocast(self):
+        for optimizer_ctor in (torch.optim.SGD, torch.optim.Adam):
+            self._grad_scaling_autocast_test(optimizer_ctor=optimizer_ctor)
+
+    def test_grad_scaling_autocast_foreach(self):
+        for optimizer_ctor in (torch.optim.SGD, torch.optim.Adam):
+            self._grad_scaling_autocast_test(optimizer_ctor=optimizer_ctor, optimizer_kwargs={"foreach": True})
+
+    def test_grad_scaling_autocast_fused(self):
+        self._grad_scaling_autocast_test(optimizer_ctor=torch.optim.Adam, optimizer_kwargs={"fused": True})
+
+    def test_grad_scaling_autocast_fused_optimizers(self):
+        for optimizer_ctor, optimizer_kwargs in (
+            (torch.optim.Adam, {"fused": True, "amsgrad": False}),
+            (torch.optim.Adam, {"fused": True, "amsgrad": True}),
+        ):
+            self._grad_scaling_autocast_fused_optimizers(
+                optimizer_ctor=optimizer_ctor, optimizer_kwargs=optimizer_kwargs)
+
+    def _grad_scaling_autocast_fused_optimizers(self, optimizer_ctor, optimizer_kwargs):
+        (
+            mod_control, mod_scaling, opt_control, opt_scaling, data, loss_fn, _,
+        ) = self._create_scaling_case(optimizer_ctor=optimizer_ctor, optimizer_kwargs=optimizer_kwargs)
+        kwargs = deepcopy(optimizer_kwargs)
+        kwargs["fused"] = False
+        opt_control = optimizer_ctor(mod_control.parameters(), lr=1.0, **kwargs)
+
+        scaler = torch.cuda.amp.GradScaler(init_scale=128.0)
+
+        for input, target in data:
+            opt_control.zero_grad()
+            with torch.autocast('cuda'):
+                output_control = mod_control(input)
+                loss_control = loss_fn(output_control, target)
+            scaler.scale(loss_control).backward()
+            scaler.step(opt_control)
+            scaler.update()
+
+            opt_scaling.zero_grad()
+            with torch.autocast('cuda'):
+                output_scaling = mod_scaling(input)
+                loss_scaling = loss_fn(output_scaling, target)
+            scaler.scale(loss_scaling).backward()
+            scaler.step(opt_scaling)
+            scaler.update()
+
+            self.assertEqual(loss_control, loss_scaling)
+            for param_control, param_scaling in zip(mod_control.parameters(), mod_scaling.parameters()):
+                self.assertEqual(param_control.grad, param_scaling.grad)
+                self.assertEqual(param_control, param_scaling)
+
+                state_control, state_scaling = opt_control.state[param_control], opt_scaling.state[param_scaling]
+
+                for k in state_control:
+                    actual = state_scaling[k]
+                    if k == "step":
+                        actual = actual.squeeze()
+                    self.assertEqual(state_control[k], actual, msg=k)
 
     def test_grad_scaling_clipping(self):
         def run(data, model, optimizer, scaler, loss_fn, skip_iter, try_scaling_api):
@@ -3844,15 +3930,79 @@ torch.cuda.synchronize()
         model_control.eval()
         self.assertEqual(model_graphed(real_inputs[0]), model_control(real_inputs[0]))
 
+    def _test_graphed_optimizer(self, steps_warmup, steps_train, optimizer_ctor, kwargs):
+        for actually_do_graphs in (True, False):
+            params = [torch.randn((i + 5, i + 5), device="cuda") for i in range(2)]
+            params_control = [p.clone().requires_grad_() for p in params]
+            params_graphed = [p.clone().requires_grad_() for p in params]
+
+            grads = [[torch.randn_like(p) for p in params] for _ in range(steps_warmup + steps_train)]
+
+            # Control (capturable=False)
+
+            opt = optimizer_ctor(params_control, capturable=False, **kwargs)
+
+            for i in range(steps_warmup + steps_train):
+                for j, p in enumerate(params_control):
+                    p.grad = grads[i][j]
+                opt.step()
+
+            # capturable=True
+
+            opt = optimizer_ctor(params_graphed, capturable=True, **kwargs)
+
+            for i in range(steps_warmup):
+                for j, p in enumerate(params_graphed):
+                    p.grad = grads[i][j]
+                opt.step()
+
+            if actually_do_graphs:
+                g = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(g):
+                    opt.step()
+
+            for i in range(steps_train):
+                if actually_do_graphs:
+                    for j, p in enumerate(params_graphed):
+                        p.grad.copy_(grads[i + steps_warmup][j])
+                    g.replay()
+                else:
+                    # Passing capturable=True to the constructor and running without graphs should still be
+                    # numerically correct, even if it's not ideal for performance.
+                    for j, p in enumerate(params_graphed):
+                        p.grad = grads[i + steps_warmup][j]
+                    opt.step()
+
+            for p_control, p_graphed in zip(params_control, params_graphed):
+                self.assertEqual(p_control, p_graphed)
+
     @unittest.skipIf((not TEST_CUDA) or
                      TEST_WITH_ROCM or
                      int(torch.version.cuda.split(".")[0]) < 11, "CUDA >= 11.0 required for graphs")
     def test_graph_adam_adamw(self):
-        OptClasses = (torch.optim.Adam, torch.optim.AdamW)
-        cases = []
         # Needs generalization if we want to extend this test to non-Adam-like optimizers.
-        for Class, foreach, amsgrad in product(OptClasses, (False, True), (False, True)):
-            cases.append((Class, {"lr": 0.1, "betas": (0.8, 0.7), "foreach": foreach, "amsgrad": amsgrad}))
+        cases = [
+            (optimizer_ctor, {"lr": 0.1, "betas": (0.8, 0.7), "foreach": foreach, "amsgrad": amsgrad})
+            for optimizer_ctor, foreach, amsgrad in product(
+                (torch.optim.Adam, torch.optim.AdamW), (False, True), (False, True),)
+        ] + [
+            (torch.optim.Adam, {"lr": 0.1, "betas": (0.8, 0.7), "fused": True, "amsgrad": amsgrad})
+            for amsgrad in (False, True)
+        ]
+
+        for optimizer_ctor, kwargs in cases:
+            with self.subTest(optimizer_ctor=optimizer_ctor, kwargs=kwargs):
+                self._test_graphed_optimizer(3, 2, optimizer_ctor, kwargs)
+
+    @unittest.skipIf(
+        (not TEST_CUDA) or TEST_WITH_ROCM or int(torch.version.cuda.split(".")[0]) < 11,
+        "CUDA >= 11.0 required for graphs",
+    )
+    def test_graph_scaling_fusedadam(self):
+        cases = [
+            (torch.optim.Adam, {"lr": 0.1, "betas": (0.8, 0.7), "fused": True, "amsgrad": amsgrad})
+            for amsgrad in (False, True)
+        ]
 
         steps_warmup = 3
         steps_train = 2
@@ -3863,7 +4013,21 @@ torch.cuda.synchronize()
                 params_control = [p.clone().requires_grad_() for p in params]
                 params_graphed = [p.clone().requires_grad_() for p in params]
 
+                # `GradScaler` in-place updates gradients thus it's necessary to duplicate gradients.
                 grads = [[torch.randn_like(p) for p in params] for _ in range(steps_warmup + steps_train)]
+                with torch.no_grad():
+                    grads_control = [[g.clone() for g in gs] for gs in grads]
+                    grads_graphed = [[g.clone() for g in gs] for gs in grads]
+
+                # Gradient Scaler
+                scaler_for_control = torch.cuda.amp.GradScaler(init_scale=128.0)
+                with torch.no_grad():
+                    scaler_for_control._lazy_init_scale_growth_tracker(torch.device("cuda"))
+
+                scaler_for_graphed = torch.cuda.amp.GradScaler()
+                scaler_for_graphed.load_state_dict(scaler_for_control.state_dict())
+                with torch.no_grad():
+                    scaler_for_graphed._lazy_init_scale_growth_tracker(torch.device("cuda"))
 
                 # Control (capturable=False)
 
@@ -3871,8 +4035,9 @@ torch.cuda.synchronize()
 
                 for i in range(steps_warmup + steps_train):
                     for j, p in enumerate(params_control):
-                        p.grad = grads[i][j]
-                    opt.step()
+                        p.grad = grads_control[i][j]
+                    scaler_for_control.step(opt)
+                    scaler_for_control.update()
 
                 # capturable=True
 
@@ -3880,25 +4045,28 @@ torch.cuda.synchronize()
 
                 for i in range(steps_warmup):
                     for j, p in enumerate(params_graphed):
-                        p.grad = grads[i][j]
-                    opt.step()
+                        p.grad = grads_graphed[i][j]
+                    scaler_for_graphed.step(opt)
+                    scaler_for_graphed.update()
 
                 if actually_do_graphs:
                     g = torch.cuda.CUDAGraph()
                     with torch.cuda.graph(g):
-                        opt.step()
+                        scaler_for_graphed.step(opt)
+                        scaler_for_graphed.update()
 
                 for i in range(steps_train):
                     if actually_do_graphs:
                         for j, p in enumerate(params_graphed):
-                            p.grad.copy_(grads[i + steps_warmup][j])
+                            p.grad.copy_(grads_graphed[i + steps_warmup][j])
                         g.replay()
                     else:
                         # Passing capturable=True to the constructor and running without graphs should still be
                         # numerically correct, even if it's not ideal for performance.
                         for j, p in enumerate(params_graphed):
-                            p.grad = grads[i + steps_warmup][j]
-                        opt.step()
+                            p.grad = grads_graphed[i + steps_warmup][j]
+                        scaler_for_graphed.step(opt)
+                        scaler_for_graphed.update()
 
                 for p_control, p_graphed in zip(params_control, params_graphed):
                     self.assertEqual(p_control, p_graphed)

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -461,47 +461,17 @@ class TestOptim(TestCase):
                 lambda param: optimizer([param], lr=0.001, momentum=1, dampening=0.5, weight_decay=1)
             )
 
-    def test_multi_tensor_optimizers(self):
+    def _test_derived_optimizers(self, optimizer_pairs_with_flags, flag):
         if not torch.cuda.is_available():
             return
-
-        optimizer_pairs_with_flags = [
-            ((optim.Adam, optim._multi_tensor.Adam), dict(weight_decay=1., amsgrad=True)),
-            ((optim.Adam, optim._multi_tensor.Adam), dict(weight_decay=1., amsgrad=False)),
-            ((optim.Adam, optim._multi_tensor.Adam), dict(weight_decay=0., amsgrad=True)),
-            ((optim.Adam, optim._multi_tensor.Adam), dict(weight_decay=0., amsgrad=False)),
-            ((optim.AdamW, optim._multi_tensor.AdamW), dict(weight_decay=1., amsgrad=True)),
-            ((optim.AdamW, optim._multi_tensor.AdamW), dict(weight_decay=1., amsgrad=False)),
-            ((optim.AdamW, optim._multi_tensor.AdamW), dict(weight_decay=0., amsgrad=True)),
-            ((optim.AdamW, optim._multi_tensor.AdamW), dict(weight_decay=0., amsgrad=False)),
-            ((optim.NAdam, optim._multi_tensor.NAdam), dict(weight_decay=0., momentum_decay=6e-3)),
-            ((optim.NAdam, optim._multi_tensor.NAdam), dict(weight_decay=1., momentum_decay=6e-3)),
-            ((optim.NAdam, optim._multi_tensor.NAdam), dict(weight_decay=0., momentum_decay=4e-3)),
-            ((optim.NAdam, optim._multi_tensor.NAdam), dict(weight_decay=0.01, momentum_decay=4e-3)),
-            ((optim.SGD, optim._multi_tensor.SGD), dict(lr=0.2, momentum=1, dampening=0, weight_decay=1, nesterov=True)),
-            ((optim.SGD, optim._multi_tensor.SGD), dict(lr=0.2, momentum=1, dampening=0.5, weight_decay=1, nesterov=False)),
-            ((optim.RAdam, optim._multi_tensor.RAdam), dict(weight_decay=0)),
-            ((optim.RAdam, optim._multi_tensor.RAdam), dict(weight_decay=1)),
-            ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=1, centered=True)),
-            ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=0, centered=True)),
-            ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=1, centered=False)),
-            ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=0, momentum=1, centered=False)),
-            ((optim.Rprop, optim._multi_tensor.Rprop), dict(lr=1e-2, etas=(0.5, 1.2), step_sizes=(1e-6, 50))),
-            ((optim.ASGD, optim._multi_tensor.ASGD), dict(weight_decay=0)),
-            ((optim.ASGD, optim._multi_tensor.ASGD), dict(weight_decay=1)),
-            ((optim.Adamax, optim._multi_tensor.Adamax), dict(weight_decay=0)),
-            ((optim.Adamax, optim._multi_tensor.Adamax), dict(weight_decay=1)),
-            ((optim.Adadelta, optim._multi_tensor.Adadelta), dict(weight_decay=0)),
-            ((optim.Adadelta, optim._multi_tensor.Adadelta), dict(weight_decay=1)),
-            ((optim.Adagrad, optim._multi_tensor.Adagrad), dict(weight_decay=0)),
-            ((optim.Adagrad, optim._multi_tensor.Adagrad), dict(weight_decay=1)),
-        ]
+        assert flag in ("foreach", "fused")
 
         kIterations = 4
         device = 'cuda'
-        for optimizers, params in optimizer_pairs_with_flags:
+        for optimizer_ctor, params in optimizer_pairs_with_flags:
             res, state = [], []
-            for opt in optimizers:
+            for flag_value in (False, True):
+                params[flag] = flag_value
                 input = torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], dtype=torch.float64, device=device).reshape(3, 2)
 
                 torch.manual_seed(1)
@@ -510,7 +480,7 @@ class TestOptim(TestCase):
                                             torch.nn.Linear(3, 1),
                                             torch.nn.Sigmoid())
                 model.to(dtype=torch.float64, device=device)
-                optimizer = opt(model.parameters(), **params)
+                optimizer = optimizer_ctor(model.parameters(), **params)
 
                 for _ in range(kIterations):
                     optimizer.zero_grad()
@@ -537,7 +507,55 @@ class TestOptim(TestCase):
                 mt_p_state = mt_state[mt_p]
 
                 for k in st_p_state:
-                    self.assertEqual(st_p_state[k], mt_p_state[k], atol=5e-5, rtol=0)
+                    actual = mt_p_state[k]
+                    # If `torch.optim.Adam` is `__init__`ed with either `fused=True` or `capturable=True`,
+                    # `step` Tensor is 1D while usually it's 0D.
+                    if k == "step" and isinstance(actual, torch.Tensor) and actual.ndim == 1:
+                        actual = actual[0]
+                    self.assertEqual(st_p_state[k], actual, atol=5e-5, rtol=0)
+
+    def test_multi_tensor_optimizers(self):
+        optimizer_pairs_with_flags = [
+            (optim.Adam, dict(weight_decay=1., amsgrad=True)),
+            (optim.Adam, dict(weight_decay=1., amsgrad=False)),
+            (optim.Adam, dict(weight_decay=0., amsgrad=True)),
+            (optim.Adam, dict(weight_decay=0., amsgrad=False)),
+            (optim.AdamW, dict(weight_decay=1., amsgrad=True)),
+            (optim.AdamW, dict(weight_decay=1., amsgrad=False)),
+            (optim.AdamW, dict(weight_decay=0., amsgrad=True)),
+            (optim.AdamW, dict(weight_decay=0., amsgrad=False)),
+            (optim.NAdam, dict(weight_decay=0., momentum_decay=6e-3)),
+            (optim.NAdam, dict(weight_decay=1., momentum_decay=6e-3)),
+            (optim.NAdam, dict(weight_decay=0., momentum_decay=4e-3)),
+            (optim.NAdam, dict(weight_decay=0.01, momentum_decay=4e-3)),
+            (optim.SGD, dict(lr=0.2, momentum=1, dampening=0, weight_decay=1, nesterov=True)),
+            (optim.SGD, dict(lr=0.2, momentum=1, dampening=0.5, weight_decay=1, nesterov=False)),
+            (optim.RAdam, dict(weight_decay=0)),
+            (optim.RAdam, dict(weight_decay=1)),
+            (optim.RMSprop, dict(weight_decay=1, momentum=1, centered=True)),
+            (optim.RMSprop, dict(weight_decay=1, momentum=0, centered=True)),
+            (optim.RMSprop, dict(weight_decay=1, momentum=1, centered=False)),
+            (optim.RMSprop, dict(weight_decay=0, momentum=1, centered=False)),
+            (optim.Rprop, dict(lr=1e-2, etas=(0.5, 1.2), step_sizes=(1e-6, 50))),
+            (optim.ASGD, dict(weight_decay=0)),
+            (optim.ASGD, dict(weight_decay=1)),
+            (optim.Adamax, dict(weight_decay=0)),
+            (optim.Adamax, dict(weight_decay=1)),
+            (optim.Adadelta, dict(weight_decay=0)),
+            (optim.Adadelta, dict(weight_decay=1)),
+            (optim.Adagrad, dict(weight_decay=0)),
+            (optim.Adagrad, dict(weight_decay=1)),
+        ]
+        self._test_derived_optimizers(optimizer_pairs_with_flags, "foreach")
+
+    def test_fused_optimizers(self):
+        optimizer_pairs_with_flags = [
+            (optim.Adam, dict(weight_decay=1., amsgrad=False)),
+            (optim.Adam, dict(weight_decay=1., amsgrad=True)),
+            (optim.Adam, dict(weight_decay=0., amsgrad=False)),
+            (optim.Adam, dict(weight_decay=0., amsgrad=True)),
+        ]
+        self._test_derived_optimizers(optimizer_pairs_with_flags, "fused")
 
     def test_adam(self):
         for optimizer in [optim.Adam, optim_mt.Adam]:
@@ -987,6 +1005,49 @@ class TestOptim(TestCase):
             # make sure step can still run even if
             # all params have no grad
             opt.step()
+
+    # make sure that `state_steps` is correctly either updated or not updated when `found_inf`.
+    def test_functional_fused_adam_with_foundinf(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is required.")
+
+        from torch.optim import adam
+
+        num_tensors = 5
+        for amsgrad in (False, True):
+            params, grads, exp_avgs, exp_avg_sqs = [[torch.ones((1,), device="cuda") for _ in range(num_tensors)] for _ in range(4)]
+            max_exp_avg_sqs = [torch.ones((1,), device="cuda") for _ in range(num_tensors)] if amsgrad else []
+            state_steps = [torch.ones((1,), dtype=torch.float32, device="cuda") for _ in range(num_tensors)]
+            grad_scale = torch.cuda.amp.grad_scaler._MultiDeviceReplicator(
+                torch.ones((1,), dtype=torch.float32, device="cuda"))
+            found_inf = torch.cuda.amp.grad_scaler._MultiDeviceReplicator(
+                torch.ones((1,), dtype=torch.float32, device="cuda"))
+
+            adam.adam(
+                params,
+                grads,
+                exp_avgs,
+                exp_avg_sqs,
+                max_exp_avg_sqs,
+                state_steps,
+                foreach=False,
+                capturable=False,
+                fused=True,
+                amsgrad=amsgrad,
+                beta1=0.9,
+                beta2=0.99,
+                lr=1e-2,
+                weight_decay=.0,
+                eps=1e-8,
+                maximize=False,
+                grad_scale=grad_scale,
+                found_inf=found_inf,
+            )
+
+            self.assertEqual(
+                state_steps,
+                [torch.ones((1,), dtype=torch.float32, device="cuda") for _ in range(num_tensors)],
+            )
 
 
 class SchedulerTestNet(torch.nn.Module):
@@ -2779,6 +2840,7 @@ class TestSWAUtils(TestCase):
 
         # check that momentum is preserved
         self.assertEqual(dnn.bn.momentum, 0.3)
+
 
 instantiate_parametrized_tests(TestLRScheduler)
 

--- a/torch/distributed/optim/functional_adam.py
+++ b/torch/distributed/optim/functional_adam.py
@@ -27,6 +27,7 @@ class _FunctionalAdam(object):
         amsgrad: bool = False,
         maximize: bool = False,
         foreach: bool = False,
+        fused: bool = False,
         _allow_empty_param_list: bool = False,
     ):
         if not 0.0 <= lr:
@@ -50,6 +51,7 @@ class _FunctionalAdam(object):
         self.amsgrad = amsgrad
         self.maximize = maximize
         self.foreach = foreach
+        self.fused = fused
         self.state = torch.jit.annotate(Dict[torch.Tensor, Dict[str, torch.Tensor]], {})
 
         if len(params) == 0 and not _allow_empty_param_list:
@@ -105,7 +107,10 @@ class _FunctionalAdam(object):
                    lr=self.defaults['lr'],
                    weight_decay=self.defaults['weight_decay'],
                    eps=self.defaults['eps'],
-                   foreach=self.foreach)
+                   foreach=self.foreach,
+                   fused=self.fused,
+                   grad_scale=None,
+                   found_inf=None)
 
     def step(self, gradients: List[Optional[Tensor]]):
         params = self.param_group['params']
@@ -164,4 +169,7 @@ class _FunctionalAdam(object):
                    lr=self.defaults['lr'],
                    weight_decay=self.defaults['weight_decay'],
                    eps=self.defaults['eps'],
-                   foreach=self.foreach)
+                   foreach=self.foreach,
+                   fused=self.fused,
+                   grad_scale=None,
+                   found_inf=None)

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -1,10 +1,51 @@
+from collections import defaultdict
 import math
+from typing import cast, List, Optional, Dict, Tuple
+
 import torch
 from torch import Tensor
 from .optimizer import Optimizer, _use_grad_for_differentiable
-from typing import List, Optional
 
 __all__ = ['Adam', 'adam']
+
+
+# TODO(crcrpar): Move this to soemwhere (e.g. torch/optim/_utils?) else when adding another fused optimizer.
+# NOTE(crcrpar): Almost the same as `_MultiDeviceReplicator` defined in
+# torch/cuda/amp/grad_scaler.py except for the key being str only for torch script.
+class _MultiDeviceReplicator:
+    main_tensor: Tensor
+    _per_device_tensors: Dict[str, Tensor]
+
+    def __init__(self, main_tensor: Tensor) -> None:
+        self.main_tensor = main_tensor
+        self._per_device_tensors = {str(main_tensor.device): main_tensor}
+
+    def get(self, device: str):
+        if device in self._per_device_tensors:
+            return self._per_device_tensors[device]
+        tensor = self.main_tensor.to(device=device, non_blocking=True, copy=True)
+        self._per_device_tensors[device] = tensor
+        return tensor
+
+
+# todo(crcrpar): Move this to another place when adding another fused optimizer.
+def _get_fp16AMP_params(
+    *,
+    optimizer: Optimizer,
+    grad_scaler: Optional[torch.cuda.amp.GradScaler] = None,
+    device: torch.device,
+) -> Optional[_MultiDeviceReplicator]:
+    if grad_scaler is None:
+        return None
+    found_inf_dict = grad_scaler._check_inf_per_device(optimizer)
+    # Combines found_inf tensors from all devices. As in GradScaler.update(),
+    # tensors are combined on the scale's device, which is an arbitrary but
+    # reasonable choice that avoids new context creation.
+    found_infs = [f.to(device, non_blocking=True) for f in found_inf_dict.values()]
+    assert len(found_infs) > 0, "No inf checks were recorded in _check_inf_per_device."
+    with torch.no_grad():
+        found_inf_combined = cast(torch.Tensor, sum(found_infs))
+    return _MultiDeviceReplicator(found_inf_combined)
 
 class Adam(Optimizer):
     r"""Implements Adam algorithm.
@@ -65,6 +106,9 @@ class Adam(Optimizer):
         capturable (bool, optional): whether this instance is safe to capture in a CUDA graph.
             Passing True can impair ungraphed performance, so if you don't intend to
             graph capture this instance, leave it False (default: False)
+        fused (bool, optional): whether fused implementation of optimizer is used.
+            Currently, `torch.float64`, `torch.float32`, `torch.float16`, and `torch.bfloat16`
+            are supported. (default: False)
 
     .. _Adam\: A Method for Stochastic Optimization:
         https://arxiv.org/abs/1412.6980
@@ -75,7 +119,7 @@ class Adam(Optimizer):
     def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
                  weight_decay=0, amsgrad=False, *, foreach: Optional[bool] = None,
                  maximize: bool = False, capturable: bool = False,
-                 differentiable: bool = False):
+                 differentiable: bool = False, fused: bool = False):
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
         if not 0.0 <= eps:
@@ -89,8 +133,22 @@ class Adam(Optimizer):
         defaults = dict(lr=lr, betas=betas, eps=eps,
                         weight_decay=weight_decay, amsgrad=amsgrad,
                         maximize=maximize, foreach=foreach, capturable=capturable,
-                        differentiable=differentiable)
+                        differentiable=differentiable, fused=fused)
         super(Adam, self).__init__(params, defaults)
+
+        if fused:
+            if differentiable:
+                raise RuntimeError("`fused` cannot be `differentiable`")
+            self._step_supports_amp_scaling = True
+            # TODO(crcrpar): [low prec params & their higher prec copy]
+            # Suppor AMP with FP16/BF16 model params which would need
+            # higher prec copy of params to do update math in higher prec to
+            # alleviate the loss of information.
+            if not all(
+                p.is_cuda and torch.is_floating_point(p)
+                for pg in self.param_groups for p in pg['params']
+            ):
+                raise RuntimeError("FusedAdam requires all the params to be CUDA, floating point")
 
     def __setstate__(self, state):
         super().__setstate__(state)
@@ -100,6 +158,7 @@ class Adam(Optimizer):
             group.setdefault('foreach', None)
             group.setdefault('capturable', False)
             group.setdefault('differentiable', False)
+            group.setdefault('fused', False)
         state_values = list(self.state.values())
         step_is_tensor = (len(state_values) != 0) and torch.is_tensor(state_values[0]['step'])
         if not step_is_tensor:
@@ -107,12 +166,14 @@ class Adam(Optimizer):
                 s['step'] = torch.tensor(float(s['step']))
 
     @_use_grad_for_differentiable
-    def step(self, closure=None):
+    def step(self, closure=None, *, grad_scaler=None):
         """Performs a single optimization step.
 
         Args:
             closure (Callable, optional): A closure that reevaluates the model
                 and returns the loss.
+            grad_scaler (:class:`torch.cuda.amp.GradScaler`, optional): A GradScaler which is
+                supplied from ``grad_scaler.step(optimizer)``.
         """
         self._cuda_graph_capture_health_check()
 
@@ -130,6 +191,14 @@ class Adam(Optimizer):
             state_steps = []
             beta1, beta2 = group['betas']
 
+            grad_scale = None
+            found_inf = None
+            if group['fused'] and grad_scaler is not None:
+                grad_scale = grad_scaler._get_scale_async()
+                device = grad_scale.device
+                grad_scale = _MultiDeviceReplicator(grad_scale)
+                found_inf = _get_fp16AMP_params(optimizer=self, grad_scaler=grad_scaler, device=device)
+
             for p in group['params']:
                 if p.grad is not None:
                     params_with_grad.append(p)
@@ -140,8 +209,11 @@ class Adam(Optimizer):
                     state = self.state[p]
                     # Lazy state initialization
                     if len(state) == 0:
-                        state['step'] = torch.zeros((1,), dtype=torch.float, device=p.device) \
-                            if self.defaults['capturable'] else torch.tensor(0.)
+                        state['step'] = (
+                            torch.zeros((1,), dtype=torch.float, device=p.device)
+                            if self.defaults['capturable'] or self.defaults['fused']
+                            else torch.tensor(0.)
+                        )
                         # Exponential moving average of gradient values
                         state['exp_avg'] = torch.zeros_like(p, memory_format=torch.preserve_format)
                         # Exponential moving average of squared gradient values
@@ -174,7 +246,10 @@ class Adam(Optimizer):
                  maximize=group['maximize'],
                  foreach=group['foreach'],
                  capturable=group['capturable'],
-                 differentiable=group['differentiable'])
+                 differentiable=group['differentiable'],
+                 fused=group['fused'],
+                 grad_scale=grad_scale,
+                 found_inf=found_inf)
 
         return loss
 
@@ -187,9 +262,12 @@ def adam(params: List[Tensor],
          state_steps: List[Tensor],
          # kwonly args with defaults are not supported by functions compiled with torchscript issue #70627
          # setting this as kwarg for now as functional API is compiled by torch/distributed/optim
-         foreach: bool = None,
+         foreach: Optional[bool] = None,
          capturable: bool = False,
          differentiable: bool = False,
+         fused: bool = False,
+         grad_scale: Optional[_MultiDeviceReplicator] = None,
+         found_inf: Optional[_MultiDeviceReplicator] = None,
          *,
          amsgrad: bool,
          beta1: float,
@@ -214,6 +292,8 @@ def adam(params: List[Tensor],
 
     if foreach and not torch.jit.is_scripting():
         func = _multi_tensor_adam
+    elif fused and not torch.jit.is_scripting():
+        func = _fused_adam
     else:
         func = _single_tensor_adam
 
@@ -231,7 +311,9 @@ def adam(params: List[Tensor],
          eps=eps,
          maximize=maximize,
          capturable=capturable,
-         differentiable=differentiable)
+         differentiable=differentiable,
+         grad_scale=grad_scale,
+         found_inf=found_inf)
 
 
 def _single_tensor_adam(params: List[Tensor],
@@ -240,6 +322,8 @@ def _single_tensor_adam(params: List[Tensor],
                         exp_avg_sqs: List[Tensor],
                         max_exp_avg_sqs: List[Tensor],
                         state_steps: List[Tensor],
+                        grad_scale: Optional[_MultiDeviceReplicator],
+                        found_inf: Optional[_MultiDeviceReplicator],
                         *,
                         amsgrad: bool,
                         beta1: float,
@@ -250,6 +334,8 @@ def _single_tensor_adam(params: List[Tensor],
                         maximize: bool,
                         capturable: bool,
                         differentiable: bool):
+
+    assert grad_scale is None and found_inf is None
 
     for i, param in enumerate(params):
 
@@ -332,6 +418,8 @@ def _multi_tensor_adam(params: List[Tensor],
                        exp_avg_sqs: List[Tensor],
                        max_exp_avg_sqs: List[Tensor],
                        state_steps: List[Tensor],
+                       grad_scale: Optional[_MultiDeviceReplicator],
+                       found_inf: Optional[_MultiDeviceReplicator],
                        *,
                        amsgrad: bool,
                        beta1: float,
@@ -348,6 +436,8 @@ def _multi_tensor_adam(params: List[Tensor],
     if capturable:
         assert all(p.is_cuda and step.is_cuda for p, step in zip(params, state_steps)), \
             "If capturable=True, params and state_steps must be CUDA tensors."
+
+    assert grad_scale is None and found_inf is None
 
     if maximize:
         grads = torch._foreach_neg(tuple(grads))  # type: ignore[assignment]
@@ -431,3 +521,86 @@ def _multi_tensor_adam(params: List[Tensor],
             denom = torch._foreach_add(exp_avg_sq_sqrt, eps)
 
         torch._foreach_addcdiv_(params_, exp_avgs, denom, step_size)
+
+
+# TODO(crcrpar): Move this to another place when adding another fused optimizer.
+# TODO(crcrpar): Make this generic when there's more fused optimizers.
+# TODO(crcrpar): Think of rewriting this in C++.
+@torch.no_grad()
+def _group_params_by_device_and_dtype(
+    params: List[Tensor],
+    grads: List[Tensor],
+    exp_avgs: List[Tensor],
+    exp_avg_sqs: List[Tensor],
+    max_exp_avg_sqs: List[Tensor],
+    state_steps: List[Tensor],
+) -> Dict[Tuple[str, torch.dtype], List[List[Tensor]]]:
+    per_device_and_dtype_tensors = defaultdict(lambda: [[] for _ in range(6)])
+    for i, (p, step) in enumerate(zip(params, state_steps)):
+        key = (str(p.device), p.dtype)
+        per_device_and_dtype_tensors[key][0].append(p)
+        per_device_and_dtype_tensors[key][1].append(grads[i])
+        per_device_and_dtype_tensors[key][2].append(exp_avgs[i])
+        per_device_and_dtype_tensors[key][3].append(exp_avg_sqs[i])
+        if max_exp_avg_sqs:
+            per_device_and_dtype_tensors[key][4].append(max_exp_avg_sqs[i])
+        per_device_and_dtype_tensors[key][5].append(step)
+    return per_device_and_dtype_tensors
+
+
+def _fused_adam(
+    params: List[Tensor],
+    grads: List[Tensor],
+    exp_avgs: List[Tensor],
+    exp_avg_sqs: List[Tensor],
+    max_exp_avg_sqs: List[Tensor],
+    state_steps: List[Tensor],
+    grad_scale: Optional[_MultiDeviceReplicator],
+    found_inf: Optional[_MultiDeviceReplicator],
+    *,
+    amsgrad: bool,
+    beta1: float,
+    beta2: float,
+    lr: float,
+    weight_decay: float,
+    eps: float,
+    maximize: bool,
+    capturable: bool,  # Needed for consistency.
+    differentiable: bool,
+) -> None:
+    grouped_tensors = _group_params_by_device_and_dtype(params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, state_steps)
+    for (device, dtype) in grouped_tensors:
+        (
+            device_params,
+            device_grads,
+            device_exp_avgs,
+            device_exp_avg_sqs,
+            device_max_exp_avg_sqs,
+            device_state_steps,
+        ) = grouped_tensors[(device, dtype)]
+        if grad_scale is not None and found_inf is not None:
+            device_grad_scale = grad_scale.get(device)
+            device_found_inf = found_inf.get(device)
+        else:
+            device_grad_scale = None
+            device_found_inf = None
+        torch._foreach_add_(device_state_steps, 1)
+        torch._fused_adam_(
+            device_params,
+            device_grads,
+            device_exp_avgs,
+            device_exp_avg_sqs,
+            device_max_exp_avg_sqs,
+            device_state_steps,
+            amsgrad=amsgrad,
+            lr=lr,
+            beta1=beta1,
+            beta2=beta2,
+            weight_decay=weight_decay,
+            eps=eps,
+            maximize=maximize,
+            grad_scale=device_grad_scale,
+            found_inf=device_found_inf,
+        )
+        if device_found_inf is not None:
+            torch._foreach_sub_(device_state_steps, [device_found_inf] * len(device_state_steps))


### PR DESCRIPTION
This PR implements an APEX style FusedAdam in PyTorch. This is different from the APEX one in that this is compatible with `torch.cuda.amp.GradScaler` by setting `_step_supports_amp_scaling` to `True` and unscales gradients inside its CUDA kernel.

related: https://github.com/pytorch/pytorch/issues/68041, https://github.com/pytorch/pytorch/issues/71274, https://github.com/pytorch/pytorch/issues/80167 possibly related to https://github.com/pytorch/pytorch/issues/80595#issuecomment-1178519436

Pull Request resolved: https://github.com/pytorch/pytorch/pull/81705
Approved by: https://github.com/ngimel


cc @ptrblck @ngimel