### PR TITLE
Disable decomposition registration on Python-3.11

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -912,11 +912,10 @@ from torch._classes import classes
 #     return min - torch.log1p(z), buffer
 #     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
 # Currently broken for 3.11, see https://github.com/pytorch/pytorch/issues/85506
-if (os.environ.get("PYTORCH_JIT", "1") == "1" and
+if (os.environ.get("PYTORCH_JIT", "1" if sys.version_info < (3, 11) else "0") == "1" and
         __debug__ and
         not torch._C._is_deploy_enabled() and
-        os.environ.get('PYTORCH_DISABLE_LIBRARY', "0") == "0" and
-        sys.version_info < (3, 11)):
+        os.environ.get('PYTORCH_DISABLE_LIBRARY', "0") == "0"):
     from torch._decomp import decompositions_for_jvp
     del decompositions_for_jvp
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -911,10 +911,12 @@ from torch._classes import classes
 #         buffer = z
 #     return min - torch.log1p(z), buffer
 #     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
+# Currently broken for 3.11, see https://github.com/pytorch/pytorch/issues/85506
 if (os.environ.get("PYTORCH_JIT", "1") == "1" and
         __debug__ and
         not torch._C._is_deploy_enabled() and
-        os.environ.get('PYTORCH_DISABLE_LIBRARY', "0") == "0"):
+        os.environ.get('PYTORCH_DISABLE_LIBRARY', "0") == "0" and
+        sys.version_info < (3, 11)):
     from torch._decomp import decompositions_for_jvp
     del decompositions_for_jvp
 


### PR DESCRIPTION
As it is currently broken (probably need few tweaks to AST tree parsing)

See https://github.com/pytorch/pytorch/issues/85506
