### PR TITLE
Remove unused build option INTERN_BUILD_ATEN_OPS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,9 +605,6 @@ if(ANDROID OR IOS OR DEFINED ENV{BUILD_PYTORCH_MOBILE_WITH_HOST_TOOLCHAIN})
   endif()
 endif()
 
-# INTERN_BUILD_ATEN_OPS is used to control whether to build ATen/TH operators.
-set(INTERN_BUILD_ATEN_OPS ON)
-
 if(NOT DEFINED USE_BLAS)
   set(USE_BLAS ON)
 endif()

--- a/aten/CMakeLists.txt
+++ b/aten/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(NOT INTERN_BUILD_ATEN_OPS)
-  return()
-endif()
-
 # Find modules
 if(NOT INTERN_BUILD_MOBILE)
   list(APPEND CMAKE_MODULE_PATH /usr/lib/x86_64-linux-gnu/)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -56,56 +56,54 @@ endif()
 # ---[ Declare source file lists
 
 # ---[ ATen build
-if(INTERN_BUILD_ATEN_OPS)
-  set(__caffe2_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
-  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-  add_subdirectory(../aten aten)
-  set(CMAKE_POSITION_INDEPENDENT_CODE ${__caffe2_CMAKE_POSITION_INDEPENDENT_CODE})
+set(__caffe2_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+add_subdirectory(../aten aten)
+set(CMAKE_POSITION_INDEPENDENT_CODE ${__caffe2_CMAKE_POSITION_INDEPENDENT_CODE})
 
-  # Generate the headers wrapped by our operator
-  file(GLOB_RECURSE torchgen_python "${PROJECT_SOURCE_DIR}/torchgen/*.py")
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/contrib/aten/aten_op.h
-  COMMAND
-  "${PYTHON_EXECUTABLE}" ${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/gen_op.py
-    --aten_root=${CMAKE_CURRENT_SOURCE_DIR}/../aten
-    --template_dir=${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten
-    --yaml_dir=${CMAKE_CURRENT_BINARY_DIR}/../aten/src/ATen
-    --install_dir=${CMAKE_CURRENT_BINARY_DIR}/contrib/aten
-  DEPENDS
-  ${torchgen_python}
-  ${CMAKE_BINARY_DIR}/aten/src/ATen/Declarations.yaml
-  ${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/gen_op.py
-  ${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/aten_op_template.h)
+# Generate the headers wrapped by our operator
+file(GLOB_RECURSE torchgen_python "${PROJECT_SOURCE_DIR}/torchgen/*.py")
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/contrib/aten/aten_op.h
+COMMAND
+"${PYTHON_EXECUTABLE}" ${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/gen_op.py
+  --aten_root=${CMAKE_CURRENT_SOURCE_DIR}/../aten
+  --template_dir=${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten
+  --yaml_dir=${CMAKE_CURRENT_BINARY_DIR}/../aten/src/ATen
+  --install_dir=${CMAKE_CURRENT_BINARY_DIR}/contrib/aten
+DEPENDS
+${torchgen_python}
+${CMAKE_BINARY_DIR}/aten/src/ATen/Declarations.yaml
+${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/gen_op.py
+${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/aten_op_template.h)
 
-  add_custom_target(__aten_op_header_gen
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/contrib/aten/aten_op.h)
-  add_library(aten_op_header_gen INTERFACE)
-  add_dependencies(aten_op_header_gen __aten_op_header_gen)
+add_custom_target(__aten_op_header_gen
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/contrib/aten/aten_op.h)
+add_library(aten_op_header_gen INTERFACE)
+add_dependencies(aten_op_header_gen __aten_op_header_gen)
 
-  # Add source, includes, and libs to lists
-  list(APPEND Caffe2_CPU_SRCS ${ATen_CPU_SRCS})
-  list(APPEND Caffe2_GPU_SRCS ${ATen_CUDA_CPP_SRCS})
-  list(APPEND Caffe2_GPU_SRCS_W_SORT_BY_KEY ${ATen_CUDA_SRCS_W_SORT_BY_KEY})
-  list(APPEND Caffe2_GPU_CU_SRCS ${ATen_CUDA_CU_SRCS})
-  list(APPEND Caffe2_GPU_CU_SRCS_W_SORT_BY_KEY ${ATen_CUDA_CU_SRCS_W_SORT_BY_KEY})
-  list(APPEND Caffe2_HIP_SRCS ${ATen_HIP_SRCS})
-  list(APPEND Caffe2_MPS_SRCS ${ATen_MPS_SRCS})
-  list(APPEND Caffe2_HIP_SRCS ${ATen_HIP_SRCS_W_SORT_BY_KEY})
-  list(APPEND Caffe2_CPU_TEST_SRCS ${ATen_CPU_TEST_SRCS})
-  list(APPEND Caffe2_MPS_TEST_SRCS ${ATen_MPS_TEST_SRCS})
-  list(APPEND Caffe2_GPU_TEST_SRCS ${ATen_CUDA_TEST_SRCS})
-  list(APPEND Caffe2_HIP_TEST_SRCS ${ATen_HIP_TEST_SRCS})
-  list(APPEND Caffe2_CPU_TEST_SRCS ${ATen_CORE_TEST_SRCS})
-  list(APPEND Caffe2_VULKAN_TEST_SRCS ${ATen_VULKAN_TEST_SRCS})
-  list(APPEND Caffe2_CPU_INCLUDE ${ATen_CPU_INCLUDE})
-  list(APPEND Caffe2_GPU_INCLUDE ${ATen_CUDA_INCLUDE})
-  list(APPEND Caffe2_HIP_INCLUDE ${ATen_HIP_INCLUDE})
-  list(APPEND Caffe2_VULKAN_INCLUDE ${ATen_VULKAN_INCLUDE})
-  list(APPEND Caffe2_DEPENDENCY_LIBS ${ATen_CPU_DEPENDENCY_LIBS})
-  list(APPEND Caffe2_CUDA_DEPENDENCY_LIBS ${ATen_CUDA_DEPENDENCY_LIBS})
-  list(APPEND Caffe2_HIP_DEPENDENCY_LIBS ${ATen_HIP_DEPENDENCY_LIBS})
-  list(APPEND Caffe2_DEPENDENCY_INCLUDE ${ATen_THIRD_PARTY_INCLUDE})
-endif()
+# Add source, includes, and libs to lists
+list(APPEND Caffe2_CPU_SRCS ${ATen_CPU_SRCS})
+list(APPEND Caffe2_GPU_SRCS ${ATen_CUDA_CPP_SRCS})
+list(APPEND Caffe2_GPU_SRCS_W_SORT_BY_KEY ${ATen_CUDA_SRCS_W_SORT_BY_KEY})
+list(APPEND Caffe2_GPU_CU_SRCS ${ATen_CUDA_CU_SRCS})
+list(APPEND Caffe2_GPU_CU_SRCS_W_SORT_BY_KEY ${ATen_CUDA_CU_SRCS_W_SORT_BY_KEY})
+list(APPEND Caffe2_HIP_SRCS ${ATen_HIP_SRCS})
+list(APPEND Caffe2_MPS_SRCS ${ATen_MPS_SRCS})
+list(APPEND Caffe2_HIP_SRCS ${ATen_HIP_SRCS_W_SORT_BY_KEY})
+list(APPEND Caffe2_CPU_TEST_SRCS ${ATen_CPU_TEST_SRCS})
+list(APPEND Caffe2_MPS_TEST_SRCS ${ATen_MPS_TEST_SRCS})
+list(APPEND Caffe2_GPU_TEST_SRCS ${ATen_CUDA_TEST_SRCS})
+list(APPEND Caffe2_HIP_TEST_SRCS ${ATen_HIP_TEST_SRCS})
+list(APPEND Caffe2_CPU_TEST_SRCS ${ATen_CORE_TEST_SRCS})
+list(APPEND Caffe2_VULKAN_TEST_SRCS ${ATen_VULKAN_TEST_SRCS})
+list(APPEND Caffe2_CPU_INCLUDE ${ATen_CPU_INCLUDE})
+list(APPEND Caffe2_GPU_INCLUDE ${ATen_CUDA_INCLUDE})
+list(APPEND Caffe2_HIP_INCLUDE ${ATen_HIP_INCLUDE})
+list(APPEND Caffe2_VULKAN_INCLUDE ${ATen_VULKAN_INCLUDE})
+list(APPEND Caffe2_DEPENDENCY_LIBS ${ATen_CPU_DEPENDENCY_LIBS})
+list(APPEND Caffe2_CUDA_DEPENDENCY_LIBS ${ATen_CUDA_DEPENDENCY_LIBS})
+list(APPEND Caffe2_HIP_DEPENDENCY_LIBS ${ATen_HIP_DEPENDENCY_LIBS})
+list(APPEND Caffe2_DEPENDENCY_INCLUDE ${ATen_THIRD_PARTY_INCLUDE})
 
 # ---[ Caffe2 build
 # Note: the folders that are being commented out have not been properly

--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -44,310 +44,303 @@ configure_file(
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../caffe2
         DESTINATION include
         FILES_MATCHING PATTERN "*.h")
-if(NOT INTERN_BUILD_ATEN_OPS)
-  install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/core
-          DESTINATION include/ATen
-          FILES_MATCHING PATTERN "*.h")
-endif()
 install(FILES ${CMAKE_BINARY_DIR}/caffe2/core/macros.h
         DESTINATION include/caffe2/core)
 
 # ---[ ATen specific
-if(INTERN_BUILD_ATEN_OPS)
-  if(MSVC)
-    set(OPT_FLAG "/fp:strict ")
-  else(MSVC)
-    set(OPT_FLAG "-O3 ")
-    if("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
-      set(OPT_FLAG " ")
-    endif()
-  endif(MSVC)
-
-  if(NOT MSVC AND NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/MapAllocator.cpp PROPERTIES COMPILE_FLAGS "-fno-openmp")
+if(MSVC)
+  set(OPT_FLAG "/fp:strict ")
+else(MSVC)
+  set(OPT_FLAG "-O3 ")
+  if("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
+    set(OPT_FLAG " ")
   endif()
+endif(MSVC)
 
-  file(GLOB_RECURSE all_python "${CMAKE_CURRENT_LIST_DIR}/../torchgen/*.py")
+if(NOT MSVC AND NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+  set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/MapAllocator.cpp PROPERTIES COMPILE_FLAGS "-fno-openmp")
+endif()
 
-  set(GEN_ROCM_FLAG)
-  if(USE_ROCM)
-    set(GEN_ROCM_FLAG --rocm)
+file(GLOB_RECURSE all_python "${CMAKE_CURRENT_LIST_DIR}/../torchgen/*.py")
+
+set(GEN_ROCM_FLAG)
+if(USE_ROCM)
+  set(GEN_ROCM_FLAG --rocm)
+endif()
+
+set(GEN_MPS_FLAG)
+if(USE_MPS)
+  set(GEN_MPS_FLAG --mps)
+endif()
+
+set(CUSTOM_BUILD_FLAGS)
+if(INTERN_BUILD_MOBILE)
+  if(USE_VULKAN)
+    list(APPEND CUSTOM_BUILD_FLAGS --backend_whitelist CPU QuantizedCPU Vulkan)
+  else()
+    list(APPEND CUSTOM_BUILD_FLAGS --backend_whitelist CPU QuantizedCPU)
   endif()
+endif()
 
-  set(GEN_MPS_FLAG)
-  if(USE_MPS)
-    set(GEN_MPS_FLAG --mps)
-  endif()
-
-  set(CUSTOM_BUILD_FLAGS)
-  if(INTERN_BUILD_MOBILE)
-    if(USE_VULKAN)
-      list(APPEND CUSTOM_BUILD_FLAGS --backend_whitelist CPU QuantizedCPU Vulkan)
-    else()
-      list(APPEND CUSTOM_BUILD_FLAGS --backend_whitelist CPU QuantizedCPU)
-    endif()
-  endif()
-
-  if(SELECTED_OP_LIST)
-    if(TRACING_BASED)
-      message(STATUS "Running tracing-based selective build given operator list: ${SELECTED_OP_LIST}")
-      list(APPEND CUSTOM_BUILD_FLAGS
-        --op_selection_yaml_path ${SELECTED_OP_LIST})
-    elseif(NOT STATIC_DISPATCH_BACKEND)
-      message(WARNING
-        "You have to run tracing-based selective build with dynamic dispatch.\n"
-        "Switching to STATIC_DISPATCH_BACKEND=CPU."
-      )
-      set(STATIC_DISPATCH_BACKEND CPU)
-    endif()
-  endif()
-
-  if(STATIC_DISPATCH_BACKEND)
-    message(STATUS "Custom build with static dispatch backends: ${STATIC_DISPATCH_BACKEND}")
-    list(LENGTH STATIC_DISPATCH_BACKEND len)
+if(SELECTED_OP_LIST)
+  if(TRACING_BASED)
+    message(STATUS "Running tracing-based selective build given operator list: ${SELECTED_OP_LIST}")
     list(APPEND CUSTOM_BUILD_FLAGS
-      --static_dispatch_backend ${STATIC_DISPATCH_BACKEND})
-  endif()
-
-  # Codegen unboxing
-  if(USE_LIGHTWEIGHT_DISPATCH)
-    file(GLOB_RECURSE all_unboxing_script "${CMAKE_CURRENT_LIST_DIR}/../tools/jit/*.py")
-    list(APPEND CUSTOM_BUILD_FLAGS --skip_dispatcher_op_registration)
-    set(GEN_UNBOXING_COMMAND
-        "${PYTHON_EXECUTABLE}" -m tools.jit.gen_unboxing
-        --source-path ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen
-        --install_dir ${CMAKE_BINARY_DIR}/aten/src/ATen
-        )
-    if(SELECTED_OP_LIST)
-      list(APPEND GEN_UNBOXING_COMMAND
-              --TEST_ONLY_op_registration_allowlist_yaml_path "${SELECTED_OP_LIST}")
-    endif()
-    set("GEN_UNBOXING_COMMAND_sources"
-        ${GEN_UNBOXING_COMMAND}
-        --output-dependencies ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_unboxing_sources.cmake
-        )
-    message(STATUS "Generating sources for lightweight dispatch")
-    execute_process(
-        COMMAND ${GEN_UNBOXING_COMMAND_sources} --dry-run
-        RESULT_VARIABLE RETURN_VALUE
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
+      --op_selection_yaml_path ${SELECTED_OP_LIST})
+  elseif(NOT STATIC_DISPATCH_BACKEND)
+    message(WARNING
+      "You have to run tracing-based selective build with dynamic dispatch.\n"
+      "Switching to STATIC_DISPATCH_BACKEND=CPU."
     )
-    if(NOT RETURN_VALUE EQUAL 0)
-      message(FATAL_ERROR "Failed to get generated_unboxing_sources list")
-    endif()
-
-    include("${CMAKE_BINARY_DIR}/aten/src/ATen/generated_unboxing_sources.cmake")
-    add_custom_command(
-        COMMENT "Generating ATen unboxing sources"
-        OUTPUT
-        ${generated_unboxing_sources}
-        ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_unboxing_sources.cmake
-        COMMAND ${GEN_UNBOXING_COMMAND_sources}
-        DEPENDS ${all_unboxing_script} ${sources_templates}
-        ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/native_functions.yaml
-        ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/tags.yaml
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
-    )
-  else() # Otherwise do not generate or include sources into build.
-    set(generated_unboxing_sources "")
+    set(STATIC_DISPATCH_BACKEND CPU)
   endif()
+endif()
 
-  set(GEN_PER_OPERATOR_FLAG)
-  if(USE_PER_OPERATOR_HEADERS)
-    list(APPEND GEN_PER_OPERATOR_FLAG "--per-operator-headers")
-  endif()
+if(STATIC_DISPATCH_BACKEND)
+  message(STATUS "Custom build with static dispatch backends: ${STATIC_DISPATCH_BACKEND}")
+  list(LENGTH STATIC_DISPATCH_BACKEND len)
+  list(APPEND CUSTOM_BUILD_FLAGS
+    --static_dispatch_backend ${STATIC_DISPATCH_BACKEND})
+endif()
 
-  set(GEN_COMMAND
-      "${PYTHON_EXECUTABLE}" -m torchgen.gen
+# Codegen unboxing
+if(USE_LIGHTWEIGHT_DISPATCH)
+  file(GLOB_RECURSE all_unboxing_script "${CMAKE_CURRENT_LIST_DIR}/../tools/jit/*.py")
+  list(APPEND CUSTOM_BUILD_FLAGS --skip_dispatcher_op_registration)
+  set(GEN_UNBOXING_COMMAND
+      "${PYTHON_EXECUTABLE}" -m tools.jit.gen_unboxing
       --source-path ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen
       --install_dir ${CMAKE_BINARY_DIR}/aten/src/ATen
-      ${GEN_PER_OPERATOR_FLAG}
-      ${GEN_ROCM_FLAG}
-      ${GEN_MPS_FLAG}
-      ${CUSTOM_BUILD_FLAGS}
-  )
-
-  file(GLOB_RECURSE headers_templates "${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/templates/*\.h")
-  file(GLOB_RECURSE sources_templates "${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/templates/*\.cpp")
-  set(declarations_yaml_templates "")
-
-  foreach(gen_type "headers" "sources" "declarations_yaml")
-    # The codegen outputs may change dynamically as PyTorch is
-    # developed, but add_custom_command only supports dynamic inputs.
-    #
-    # We work around this by generating a .cmake file which is
-    # included below to set the list of output files. If that file
-    # ever changes then cmake will be re-run automatically because it
-    # was included and so we get fully dynamic outputs.
-
-    set("GEN_COMMAND_${gen_type}"
-        ${GEN_COMMAND}
-        --generate ${gen_type}
-        --output-dependencies ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_${gen_type}.cmake
-    )
-
-    # Dry run to bootstrap the output variables
-    execute_process(
-        COMMAND ${GEN_COMMAND_${gen_type}} --dry-run
-        RESULT_VARIABLE RETURN_VALUE
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
-    )
-
-    if(NOT RETURN_VALUE EQUAL 0)
-      message(FATAL_ERROR "Failed to get generated_${gen_type} list")
-    endif()
-
-    include("${CMAKE_BINARY_DIR}/aten/src/ATen/generated_${gen_type}.cmake")
-    include("${CMAKE_BINARY_DIR}/aten/src/ATen/core_generated_${gen_type}.cmake")
-    include("${CMAKE_BINARY_DIR}/aten/src/ATen/cpu_vec_generated_${gen_type}.cmake")
-    include("${CMAKE_BINARY_DIR}/aten/src/ATen/cuda_generated_${gen_type}.cmake")
-    include("${CMAKE_BINARY_DIR}/aten/src/ATen/ops_generated_${gen_type}.cmake")
-
-    message(STATUS "${gen_type} outputs: ${gen_outputs}")
-
-    add_custom_command(
-      COMMENT "Generating ATen ${gen_type}"
-      OUTPUT
-        ${generated_${gen_type}}
-        ${cuda_generated_${gen_type}}
-        ${core_generated_${gen_type}}
-        ${cpu_vec_generated_${gen_type}}
-        ${ops_generated_${gen_type}}
-        ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_${gen_type}.cmake
-        ${CMAKE_BINARY_DIR}/aten/src/ATen/ops_generated_${gen_type}.cmake
-        ${CMAKE_BINARY_DIR}/aten/src/ATen/core_generated_${gen_type}.cmake
-        ${CMAKE_BINARY_DIR}/aten/src/ATen/cpu_vec_generated_${gen_type}.cmake
-        ${CMAKE_BINARY_DIR}/aten/src/ATen/cuda_generated_${gen_type}.cmake
-      COMMAND ${GEN_COMMAND_${gen_type}}
-      DEPENDS ${all_python} ${${gen_type}_templates}
-        ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/native_functions.yaml
-        ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/tags.yaml
+      )
+  if(SELECTED_OP_LIST)
+    list(APPEND GEN_UNBOXING_COMMAND
+            --TEST_ONLY_op_registration_allowlist_yaml_path "${SELECTED_OP_LIST}")
+  endif()
+  set("GEN_UNBOXING_COMMAND_sources"
+      ${GEN_UNBOXING_COMMAND}
+      --output-dependencies ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_unboxing_sources.cmake
+      )
+  message(STATUS "Generating sources for lightweight dispatch")
+  execute_process(
+      COMMAND ${GEN_UNBOXING_COMMAND_sources} --dry-run
+      RESULT_VARIABLE RETURN_VALUE
       WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
-    )
-  endforeach()
-
-  # Generated headers used from a CUDA (.cu) file are
-  # not tracked correctly in CMake. We make the libATen.so depend explicitly
-  # on building the generated ATen files to workaround.
-  add_custom_target(ATEN_CPU_FILES_GEN_TARGET DEPENDS
-      ${generated_headers} ${core_generated_headers} ${cpu_vec_generated_headers} ${ops_generated_headers}
-      ${generated_sources} ${core_generated_sources} ${cpu_vec_generated_sources} ${ops_generated_sources}
-      ${generated_declarations_yaml} ${generated_unboxing_sources})
-  add_custom_target(ATEN_CUDA_FILES_GEN_TARGET DEPENDS
-      ${cuda_generated_headers} ${cuda_generated_sources})
-  add_library(ATEN_CPU_FILES_GEN_LIB INTERFACE)
-  add_library(ATEN_CUDA_FILES_GEN_LIB INTERFACE)
-  add_dependencies(ATEN_CPU_FILES_GEN_LIB ATEN_CPU_FILES_GEN_TARGET)
-  add_dependencies(ATEN_CUDA_FILES_GEN_LIB ATEN_CUDA_FILES_GEN_TARGET)
-
-  if(USE_PER_OPERATOR_HEADERS)
-    target_compile_definitions(ATEN_CPU_FILES_GEN_LIB INTERFACE AT_PER_OPERATOR_HEADERS)
-    target_compile_definitions(ATEN_CUDA_FILES_GEN_LIB INTERFACE AT_PER_OPERATOR_HEADERS)
+  )
+  if(NOT RETURN_VALUE EQUAL 0)
+    message(FATAL_ERROR "Failed to get generated_unboxing_sources list")
   endif()
 
-  # Handle source files that need to be compiled multiple times for
-  # different vectorization options
-  file(GLOB cpu_kernel_cpp_in "${PROJECT_SOURCE_DIR}/aten/src/ATen/native/cpu/*.cpp" "${PROJECT_SOURCE_DIR}/aten/src/ATen/native/quantized/cpu/kernels/*.cpp")
-
-  list(APPEND CPU_CAPABILITY_NAMES "DEFAULT")
-  list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}")
-
-  if(CXX_AVX512_FOUND)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_AVX512_CPU_DEFINITION")
-    list(APPEND CPU_CAPABILITY_NAMES "AVX512")
-    if(MSVC)
-      list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}/arch:AVX512")
-    else(MSVC)
-      list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG} -mavx512f -mavx512bw -mavx512vl -mavx512dq -mfma")
-    endif(MSVC)
-  endif(CXX_AVX512_FOUND)
-
-  if(CXX_AVX2_FOUND)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_AVX2_CPU_DEFINITION")
-
-    # Some versions of GCC pessimistically split unaligned load and store
-    # instructions when using the default tuning. This is a bad choice on
-    # new Intel and AMD processors so we disable it when compiling with AVX2.
-    # See https://stackoverflow.com/questions/52626726/why-doesnt-gcc-resolve-mm256-loadu-pd-as-single-vmovupd#tab-top
-    check_cxx_compiler_flag("-mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store" COMPILER_SUPPORTS_NO_AVX256_SPLIT)
-    if(COMPILER_SUPPORTS_NO_AVX256_SPLIT)
-      set(CPU_NO_AVX256_SPLIT_FLAGS "-mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store")
-    endif(COMPILER_SUPPORTS_NO_AVX256_SPLIT)
-
-    list(APPEND CPU_CAPABILITY_NAMES "AVX2")
-    if(DEFINED ENV{ATEN_AVX512_256})
-      if($ENV{ATEN_AVX512_256} MATCHES "TRUE")
-        if(CXX_AVX512_FOUND)
-          message("-- ATen AVX2 kernels will use 32 ymm registers")
-          if(MSVC)
-            list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}/arch:AVX512")
-          else(MSVC)
-            list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG} -march=native ${CPU_NO_AVX256_SPLIT_FLAGS}")
-          endif(MSVC)
-        endif(CXX_AVX512_FOUND)
-      endif()
-    else()
-      if(MSVC)
-        list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}/arch:AVX2")
-      else(MSVC)
-        list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG} -mavx2 -mfma ${CPU_NO_AVX256_SPLIT_FLAGS}")
-      endif(MSVC)
-    endif()
-  endif(CXX_AVX2_FOUND)
-
-  if(CXX_VSX_FOUND)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_VSX_CPU_DEFINITION")
-    LIST(APPEND CPU_CAPABILITY_NAMES "VSX")
-    LIST(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}  ${CXX_VSX_FLAGS}")
-  endif(CXX_VSX_FOUND)
-
-  if(CXX_ZVECTOR_FOUND)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_ZVECTOR_CPU_DEFINITION")
-    LIST(APPEND CPU_CAPABILITY_NAMES "ZVECTOR")
-    LIST(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}  ${CXX_ZVECTOR_FLAGS}")
-  endif(CXX_ZVECTOR_FOUND)
-
-  list(LENGTH CPU_CAPABILITY_NAMES NUM_CPU_CAPABILITY_NAMES)
-  math(EXPR NUM_CPU_CAPABILITY_NAMES "${NUM_CPU_CAPABILITY_NAMES}-1")
-
-  # The sources list might get reordered later based on the capabilites.
-  # See NOTE [ Linking AVX and non-AVX files ]
-  foreach(i RANGE ${NUM_CPU_CAPABILITY_NAMES})
-    function(process_vec NAME)
-      list(GET CPU_CAPABILITY_NAMES ${i} CPU_CAPABILITY)
-      set(NEW_IMPL ${CMAKE_BINARY_DIR}/aten/src/ATen/${NAME}.${CPU_CAPABILITY}.cpp)
-      configure_file("${PROJECT_SOURCE_DIR}/cmake/IncludeSource.cpp.in" ${NEW_IMPL})
-      set(cpu_kernel_cpp ${NEW_IMPL} ${cpu_kernel_cpp} PARENT_SCOPE) # Create list of copies
-      list(GET CPU_CAPABILITY_FLAGS ${i} FLAGS)
-      if(MSVC)
-        set(EXTRA_FLAGS "/DCPU_CAPABILITY=${CPU_CAPABILITY} /DCPU_CAPABILITY_${CPU_CAPABILITY}")
-      else(MSVC)
-        set(EXTRA_FLAGS "-DCPU_CAPABILITY=${CPU_CAPABILITY} -DCPU_CAPABILITY_${CPU_CAPABILITY}")
-      endif(MSVC)
-      # Disable certain warnings for GCC-9.X
-      if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0.0))
-        if(("${NAME}" STREQUAL "native/cpu/GridSamplerKernel.cpp") AND ("${CPU_CAPABILITY}" STREQUAL "DEFAULT"))
-          # See https://github.com/pytorch/pytorch/issues/38855
-          set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wno-uninitialized")
-        endif()
-        if("${NAME}" STREQUAL "native/quantized/cpu/kernels/QuantizedOpKernels.cpp")
-          # See https://github.com/pytorch/pytorch/issues/38854
-          set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wno-deprecated-copy")
-        endif()
-      endif()
-      set_source_files_properties(${NEW_IMPL} PROPERTIES COMPILE_FLAGS "${FLAGS} ${EXTRA_FLAGS}")
-    endfunction()
-    foreach(IMPL ${cpu_kernel_cpp_in})
-      file(RELATIVE_PATH NAME "${PROJECT_SOURCE_DIR}/aten/src/ATen/" "${IMPL}")
-      process_vec("${NAME}")
-    endforeach()
-    foreach(IMPL ${cpu_vec_generated_sources})
-      file(RELATIVE_PATH NAME "${CMAKE_BINARY_DIR}/aten/src/ATen/" "${IMPL}")
-      process_vec("${NAME}")
-    endforeach()
-  endforeach()
-  list(APPEND ATen_CPU_SRCS ${cpu_kernel_cpp})
+  include("${CMAKE_BINARY_DIR}/aten/src/ATen/generated_unboxing_sources.cmake")
+  add_custom_command(
+      COMMENT "Generating ATen unboxing sources"
+      OUTPUT
+      ${generated_unboxing_sources}
+      ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_unboxing_sources.cmake
+      COMMAND ${GEN_UNBOXING_COMMAND_sources}
+      DEPENDS ${all_unboxing_script} ${sources_templates}
+      ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/native_functions.yaml
+      ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/tags.yaml
+      WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
+  )
+else() # Otherwise do not generate or include sources into build.
+  set(generated_unboxing_sources "")
 endif()
+
+set(GEN_PER_OPERATOR_FLAG)
+if(USE_PER_OPERATOR_HEADERS)
+  list(APPEND GEN_PER_OPERATOR_FLAG "--per-operator-headers")
+endif()
+
+set(GEN_COMMAND
+    "${PYTHON_EXECUTABLE}" -m torchgen.gen
+    --source-path ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen
+    --install_dir ${CMAKE_BINARY_DIR}/aten/src/ATen
+    ${GEN_PER_OPERATOR_FLAG}
+    ${GEN_ROCM_FLAG}
+    ${GEN_MPS_FLAG}
+    ${CUSTOM_BUILD_FLAGS}
+)
+
+file(GLOB_RECURSE headers_templates "${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/templates/*\.h")
+file(GLOB_RECURSE sources_templates "${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/templates/*\.cpp")
+set(declarations_yaml_templates "")
+
+foreach(gen_type "headers" "sources" "declarations_yaml")
+  # The codegen outputs may change dynamically as PyTorch is
+  # developed, but add_custom_command only supports dynamic inputs.
+  #
+  # We work around this by generating a .cmake file which is
+  # included below to set the list of output files. If that file
+  # ever changes then cmake will be re-run automatically because it
+  # was included and so we get fully dynamic outputs.
+
+  set("GEN_COMMAND_${gen_type}"
+      ${GEN_COMMAND}
+      --generate ${gen_type}
+      --output-dependencies ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_${gen_type}.cmake
+  )
+
+  # Dry run to bootstrap the output variables
+  execute_process(
+      COMMAND ${GEN_COMMAND_${gen_type}} --dry-run
+      RESULT_VARIABLE RETURN_VALUE
+      WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
+  )
+
+  if(NOT RETURN_VALUE EQUAL 0)
+    message(FATAL_ERROR "Failed to get generated_${gen_type} list")
+  endif()
+
+  include("${CMAKE_BINARY_DIR}/aten/src/ATen/generated_${gen_type}.cmake")
+  include("${CMAKE_BINARY_DIR}/aten/src/ATen/core_generated_${gen_type}.cmake")
+  include("${CMAKE_BINARY_DIR}/aten/src/ATen/cpu_vec_generated_${gen_type}.cmake")
+  include("${CMAKE_BINARY_DIR}/aten/src/ATen/cuda_generated_${gen_type}.cmake")
+  include("${CMAKE_BINARY_DIR}/aten/src/ATen/ops_generated_${gen_type}.cmake")
+
+  message(STATUS "${gen_type} outputs: ${gen_outputs}")
+
+  add_custom_command(
+    COMMENT "Generating ATen ${gen_type}"
+    OUTPUT
+      ${generated_${gen_type}}
+      ${cuda_generated_${gen_type}}
+      ${core_generated_${gen_type}}
+      ${cpu_vec_generated_${gen_type}}
+      ${ops_generated_${gen_type}}
+      ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_${gen_type}.cmake
+      ${CMAKE_BINARY_DIR}/aten/src/ATen/ops_generated_${gen_type}.cmake
+      ${CMAKE_BINARY_DIR}/aten/src/ATen/core_generated_${gen_type}.cmake
+      ${CMAKE_BINARY_DIR}/aten/src/ATen/cpu_vec_generated_${gen_type}.cmake
+      ${CMAKE_BINARY_DIR}/aten/src/ATen/cuda_generated_${gen_type}.cmake
+    COMMAND ${GEN_COMMAND_${gen_type}}
+    DEPENDS ${all_python} ${${gen_type}_templates}
+      ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/native_functions.yaml
+      ${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/tags.yaml
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
+  )
+endforeach()
+
+# Generated headers used from a CUDA (.cu) file are
+# not tracked correctly in CMake. We make the libATen.so depend explicitly
+# on building the generated ATen files to workaround.
+add_custom_target(ATEN_CPU_FILES_GEN_TARGET DEPENDS
+    ${generated_headers} ${core_generated_headers} ${cpu_vec_generated_headers} ${ops_generated_headers}
+    ${generated_sources} ${core_generated_sources} ${cpu_vec_generated_sources} ${ops_generated_sources}
+    ${generated_declarations_yaml} ${generated_unboxing_sources})
+add_custom_target(ATEN_CUDA_FILES_GEN_TARGET DEPENDS
+    ${cuda_generated_headers} ${cuda_generated_sources})
+add_library(ATEN_CPU_FILES_GEN_LIB INTERFACE)
+add_library(ATEN_CUDA_FILES_GEN_LIB INTERFACE)
+add_dependencies(ATEN_CPU_FILES_GEN_LIB ATEN_CPU_FILES_GEN_TARGET)
+add_dependencies(ATEN_CUDA_FILES_GEN_LIB ATEN_CUDA_FILES_GEN_TARGET)
+
+if(USE_PER_OPERATOR_HEADERS)
+  target_compile_definitions(ATEN_CPU_FILES_GEN_LIB INTERFACE AT_PER_OPERATOR_HEADERS)
+  target_compile_definitions(ATEN_CUDA_FILES_GEN_LIB INTERFACE AT_PER_OPERATOR_HEADERS)
+endif()
+
+# Handle source files that need to be compiled multiple times for
+# different vectorization options
+file(GLOB cpu_kernel_cpp_in "${PROJECT_SOURCE_DIR}/aten/src/ATen/native/cpu/*.cpp" "${PROJECT_SOURCE_DIR}/aten/src/ATen/native/quantized/cpu/kernels/*.cpp")
+
+list(APPEND CPU_CAPABILITY_NAMES "DEFAULT")
+list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}")
+
+if(CXX_AVX512_FOUND)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_AVX512_CPU_DEFINITION")
+  list(APPEND CPU_CAPABILITY_NAMES "AVX512")
+  if(MSVC)
+    list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}/arch:AVX512")
+  else(MSVC)
+    list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG} -mavx512f -mavx512bw -mavx512vl -mavx512dq -mfma")
+  endif(MSVC)
+endif(CXX_AVX512_FOUND)
+
+if(CXX_AVX2_FOUND)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_AVX2_CPU_DEFINITION")
+
+  # Some versions of GCC pessimistically split unaligned load and store
+  # instructions when using the default tuning. This is a bad choice on
+  # new Intel and AMD processors so we disable it when compiling with AVX2.
+  # See https://stackoverflow.com/questions/52626726/why-doesnt-gcc-resolve-mm256-loadu-pd-as-single-vmovupd#tab-top
+  check_cxx_compiler_flag("-mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store" COMPILER_SUPPORTS_NO_AVX256_SPLIT)
+  if(COMPILER_SUPPORTS_NO_AVX256_SPLIT)
+    set(CPU_NO_AVX256_SPLIT_FLAGS "-mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store")
+  endif(COMPILER_SUPPORTS_NO_AVX256_SPLIT)
+
+  list(APPEND CPU_CAPABILITY_NAMES "AVX2")
+  if(DEFINED ENV{ATEN_AVX512_256})
+    if($ENV{ATEN_AVX512_256} MATCHES "TRUE")
+      if(CXX_AVX512_FOUND)
+        message("-- ATen AVX2 kernels will use 32 ymm registers")
+        if(MSVC)
+          list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}/arch:AVX512")
+        else(MSVC)
+          list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG} -march=native ${CPU_NO_AVX256_SPLIT_FLAGS}")
+        endif(MSVC)
+      endif(CXX_AVX512_FOUND)
+    endif()
+  else()
+    if(MSVC)
+      list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}/arch:AVX2")
+    else(MSVC)
+      list(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG} -mavx2 -mfma ${CPU_NO_AVX256_SPLIT_FLAGS}")
+    endif(MSVC)
+  endif()
+endif(CXX_AVX2_FOUND)
+
+if(CXX_VSX_FOUND)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_VSX_CPU_DEFINITION")
+  LIST(APPEND CPU_CAPABILITY_NAMES "VSX")
+  LIST(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}  ${CXX_VSX_FLAGS}")
+endif(CXX_VSX_FOUND)
+
+if(CXX_ZVECTOR_FOUND)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_ZVECTOR_CPU_DEFINITION")
+  LIST(APPEND CPU_CAPABILITY_NAMES "ZVECTOR")
+  LIST(APPEND CPU_CAPABILITY_FLAGS "${OPT_FLAG}  ${CXX_ZVECTOR_FLAGS}")
+endif(CXX_ZVECTOR_FOUND)
+
+list(LENGTH CPU_CAPABILITY_NAMES NUM_CPU_CAPABILITY_NAMES)
+math(EXPR NUM_CPU_CAPABILITY_NAMES "${NUM_CPU_CAPABILITY_NAMES}-1")
+
+# The sources list might get reordered later based on the capabilites.
+# See NOTE [ Linking AVX and non-AVX files ]
+foreach(i RANGE ${NUM_CPU_CAPABILITY_NAMES})
+  function(process_vec NAME)
+    list(GET CPU_CAPABILITY_NAMES ${i} CPU_CAPABILITY)
+    set(NEW_IMPL ${CMAKE_BINARY_DIR}/aten/src/ATen/${NAME}.${CPU_CAPABILITY}.cpp)
+    configure_file("${PROJECT_SOURCE_DIR}/cmake/IncludeSource.cpp.in" ${NEW_IMPL})
+    set(cpu_kernel_cpp ${NEW_IMPL} ${cpu_kernel_cpp} PARENT_SCOPE) # Create list of copies
+    list(GET CPU_CAPABILITY_FLAGS ${i} FLAGS)
+    if(MSVC)
+      set(EXTRA_FLAGS "/DCPU_CAPABILITY=${CPU_CAPABILITY} /DCPU_CAPABILITY_${CPU_CAPABILITY}")
+    else(MSVC)
+      set(EXTRA_FLAGS "-DCPU_CAPABILITY=${CPU_CAPABILITY} -DCPU_CAPABILITY_${CPU_CAPABILITY}")
+    endif(MSVC)
+    # Disable certain warnings for GCC-9.X
+    if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0.0))
+      if(("${NAME}" STREQUAL "native/cpu/GridSamplerKernel.cpp") AND ("${CPU_CAPABILITY}" STREQUAL "DEFAULT"))
+        # See https://github.com/pytorch/pytorch/issues/38855
+        set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wno-uninitialized")
+      endif()
+      if("${NAME}" STREQUAL "native/quantized/cpu/kernels/QuantizedOpKernels.cpp")
+        # See https://github.com/pytorch/pytorch/issues/38854
+        set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wno-deprecated-copy")
+      endif()
+    endif()
+    set_source_files_properties(${NEW_IMPL} PROPERTIES COMPILE_FLAGS "${FLAGS} ${EXTRA_FLAGS}")
+  endfunction()
+  foreach(IMPL ${cpu_kernel_cpp_in})
+    file(RELATIVE_PATH NAME "${PROJECT_SOURCE_DIR}/aten/src/ATen/" "${IMPL}")
+    process_vec("${NAME}")
+  endforeach()
+  foreach(IMPL ${cpu_vec_generated_sources})
+    file(RELATIVE_PATH NAME "${CMAKE_BINARY_DIR}/aten/src/ATen/" "${IMPL}")
+    process_vec("${NAME}")
+  endforeach()
+endforeach()
+list(APPEND ATen_CPU_SRCS ${cpu_kernel_cpp})
 
 function(append_filelist name outputvar)
   set(_rootdir "${${CMAKE_PROJECT_NAME}_SOURCE_DIR}/")


### PR DESCRIPTION
This option was set to false in the caffe2 mobile runtime, however that build no longer exists and this option is set to true in all remaining builds. It should be safe to remove this option and associated conditionals and simplify out buildfiles a bit.