### PR TITLE
fix segmentation fault in QTensor.choose_qparams_optimized

### DIFF
--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -330,6 +330,8 @@ std::tuple<Tensor, Tensor> choose_qparams_optimized(
     const double ratio,
     int64_t bit_width) {
 
+  TORCH_CHECK(numel <= input_tensor.numel(), "numel ", numel,
+      " greater than input_tensor.numel() ", input_tensor.numel());
   const float* input_row = input_tensor.data_ptr<float>();
   float xmin = *std::min_element(input_row, input_row + numel);
   float xmax = *std::max_element(input_row, input_row + numel);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#85552 fix segmentation fault in QTensor.choose_qparams_optimized**

Summary:

Fixes segmentation fault in `QTensor.choose_qparams_optimized`, this
guards against the user passing in a value of `numel` which does not
make sense.

Fixes https://github.com/pytorch/pytorch/issues/85212

Test plan:

Probably not worth it to add a test for this, so testing manually.

```
import torch

input = torch.full((64,), 1, dtype=torch.float32, requires_grad=False)
numel = 1250999896764
n_bins = 0
ratio = 0
bit_width = 0
torch.choose_qparams_optimized(input, numel, n_bins, ratio, bit_width)
// RuntimeError is thrown
```