### PR TITLE
Uses compatible release specifier for the cuda pypi requirements

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -225,8 +225,8 @@ def generate_wheels_matrix(os: str,
                         "package_type": package_type,
                         "pytorch_extra_install_requirements":
                         "nvidia-cuda-runtime-cu11;"
-                        "nvidia-cudnn-cu11==8.5.0.96;"
-                        "nvidia-cublas-cu11==11.10.3.66",
+                        "nvidia-cudnn-cu11~=8.5.0.96;"
+                        "nvidia-cublas-cu11~=11.10.3.66",
                         "build_name":
                         f"{package_type}-py{python_version}-{gpu_arch_type}{gpu_arch_version}-with-pypi-cudnn"
                         .replace(

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -229,7 +229,7 @@ jobs:
       DESIRED_PYTHON: "3.7"
       build_name: manywheel-py3_7-cuda11_7-with-pypi-cudnn
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: nvidia-cuda-runtime-cu11;nvidia-cudnn-cu11==8.5.0.96;nvidia-cublas-cu11==11.10.3.66
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: nvidia-cuda-runtime-cu11;nvidia-cudnn-cu11~=8.5.0.96;nvidia-cublas-cu11~=11.10.3.66
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -807,7 +807,7 @@ jobs:
       DESIRED_PYTHON: "3.8"
       build_name: manywheel-py3_8-cuda11_7-with-pypi-cudnn
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: nvidia-cuda-runtime-cu11;nvidia-cudnn-cu11==8.5.0.96;nvidia-cublas-cu11==11.10.3.66
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: nvidia-cuda-runtime-cu11;nvidia-cudnn-cu11~=8.5.0.96;nvidia-cublas-cu11~=11.10.3.66
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -1385,7 +1385,7 @@ jobs:
       DESIRED_PYTHON: "3.9"
       build_name: manywheel-py3_9-cuda11_7-with-pypi-cudnn
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: nvidia-cuda-runtime-cu11;nvidia-cudnn-cu11==8.5.0.96;nvidia-cublas-cu11==11.10.3.66
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: nvidia-cuda-runtime-cu11;nvidia-cudnn-cu11~=8.5.0.96;nvidia-cublas-cu11~=11.10.3.66
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -1963,7 +1963,7 @@ jobs:
       DESIRED_PYTHON: "3.10"
       build_name: manywheel-py3_10-cuda11_7-with-pypi-cudnn
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: nvidia-cuda-runtime-cu11;nvidia-cudnn-cu11==8.5.0.96;nvidia-cublas-cu11==11.10.3.66
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: nvidia-cuda-runtime-cu11;nvidia-cudnn-cu11~=8.5.0.96;nvidia-cublas-cu11~=11.10.3.66
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -2541,7 +2541,7 @@ jobs:
       DESIRED_PYTHON: "3.11"
       build_name: manywheel-py3_11-cuda11_7-with-pypi-cudnn
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: nvidia-cuda-runtime-cu11;nvidia-cudnn-cu11==8.5.0.96;nvidia-cublas-cu11==11.10.3.66
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: nvidia-cuda-runtime-cu11;nvidia-cudnn-cu11~=8.5.0.96;nvidia-cublas-cu11~=11.10.3.66
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
https://stackoverflow.com/questions/39590187/in-requirements-txt-what-does-tilde-equals-mean has a good discussion on the benefits of `~=`.

A use case for this is, let's say there is a regression in cudnn that we haven't discovered yet in `8.5.0.96`. And the cudnn team fixes it and pushes it to pypi as `8.5.0.97`. A pytorch wheel that specifies `8.5.0.96` with ~= can now pull the updated cudnn whereas a wheel with `==` cannot.

cc: @atalman @ptrblck @malfet 