### PR TITLE
Temporary fix to skip NVIDIA driver installation from RHEL repo

### DIFF
--- a/.github/scripts/install_nvidia_utils_linux.sh
+++ b/.github/scripts/install_nvidia_utils_linux.sh
@@ -30,7 +30,12 @@ install_nvidia_driver_amzn2() {
             INSTALLED_DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader)
 
             if [ "$INSTALLED_DRIVER_VERSION" != "$DRIVER_VERSION" ]; then
-                echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has been installed, but we expect to have $DRIVER_VERSION instead. Continuing with NVIDIA driver installation"
+                # TODO
+                # Remove this after torchrec and FBGEMM have both been updated to use
+                # PyTorch NVIDIA installation script instead of using the latest driver
+                # from RHEL repo
+                HAS_NVIDIA_DRIVER=1
+                echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has been installed, but we expect to have $DRIVER_VERSION instead. Skipping NVIDIA driver installation for now until torchrec and FBGEMM are updated to use PyTorch NVIDIA installation script instead of RHEL repo"
             else
                 HAS_NVIDIA_DRIVER=1
                 echo "NVIDIA driver ($INSTALLED_DRIVER_VERSION) has already been installed. Skipping NVIDIA driver installation"


### PR DESCRIPTION
This is a temporary fix until torchrec and FBGEMM are updated to use PyTorch NVIDIA installation script instead of using the latest driver from RHEL repo.  It might take a day or so to finish updating the 2 repos, so I want to have this in place to avoid any issue with NVIDIA driver till then.  The driver from RHEL repo `515.65.01` is even newer than what we are using in PyTorch CI `515.57`.  So everything should just work with both of them