### PR TITLE
Remove codesigning from github actions ios build workflow

### DIFF
--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -23,20 +23,6 @@ on:
           If this is set, our linter will use this to make sure that every other
           job with the same `sync-tag` is identical.
 
-    secrets:
-      IOS_CERT_KEY_2022:
-        required: true
-        description: ios cert
-      IOS_CERT_SECRET:
-        required: true
-        description: ios cert
-      IOS_DEV_TEAM_ID:
-        required: true
-        description: ios cert
-      IOS_SIGN_KEY_2022:
-        required: true
-        description: ios cert
-
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
   BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
@@ -45,16 +31,9 @@ env:
 
 jobs:
   build:
-    # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
-    #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
     if: github.repository_owner == 'pytorch'
     runs-on: macos-12
     timeout-minutes: 240
-    env:
-      IOS_CERT_KEY_2022: ${{ secrets.IOS_CERT_KEY_2022 }}
-      IOS_CERT_SECRET: ${{ secrets.IOS_CERT_SECRET }}
-      IOS_DEV_TEAM_ID: ${{ secrets.IOS_DEV_TEAM_ID }}
-      IOS_SIGN_KEY_2022: ${{ secrets.IOS_SIGN_KEY_2022 }}
     steps:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
@@ -108,29 +87,15 @@ jobs:
             setuptools \
             typing_extensions
 
-      - name: Run Fastlane
+      - name: Setup Fastlane
         run: |
           set -x
           cd ios/TestApp
           # install fastlane
           sudo gem install bundler && bundle install
           bundle update fastlane
-          # install certificates
-          echo "${IOS_CERT_KEY_2022}" >> cert.txt
-          base64 --decode cert.txt -o Certificates.p12
-          rm cert.txt
-          bundle exec fastlane install_root_cert
-          bundle exec fastlane install_dev_cert
-          # install the provisioning profile
-          PROFILE=PyTorch_CI_2022.mobileprovision
-          PROVISIONING_PROFILES=~/Library/MobileDevice/Provisioning\ Profiles
-          mkdir -pv "${PROVISIONING_PROFILES}"
-          cd "${PROVISIONING_PROFILES}"
-          echo "${IOS_SIGN_KEY_2022}" >> cert.txt
-          base64 --decode cert.txt -o ${PROFILE}
-          rm cert.txt
 
-      - name: Build
+      - name: Build PyTorch Mobile Runtime
         run: |
           # shellcheck disable=SC1091
           source "${RUNNER_TEMP}/anaconda/bin/activate"
@@ -139,20 +104,16 @@ jobs:
           export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname "$(which conda)")/../"}
           scripts/build_ios.sh
 
-      - name: Run Build Test
+      - name: Build TestApp
+        if: inputs.ios-platform == 'SIMULATOR'
         timeout-minutes: 5
         run: |
-          PROFILE=PyTorch_CI_2022
           # run the ruby build script
           if ! [ -x "$(command -v xcodebuild)" ]; then
             echo 'Error: xcodebuild is not installed.'
             exit 1
           fi
-          if [ "${IOS_PLATFORM}" != "SIMULATOR" ]; then
-            ruby scripts/xcode_build.rb -i build_ios/install -x ios/TestApp/TestApp.xcodeproj -p "${IOS_PLATFORM}" -c "${PROFILE}" -t "${IOS_DEV_TEAM_ID}"
-          else
-            ruby scripts/xcode_build.rb -i build_ios/install -x ios/TestApp/TestApp.xcodeproj -p "${IOS_PLATFORM}"
-          fi
+          ruby scripts/xcode_build.rb -i build_ios/install -x ios/TestApp/TestApp.xcodeproj -p "${IOS_PLATFORM}"
 
       - name: Run Simulator Tests
         if: inputs.ios-platform == 'SIMULATOR'
@@ -191,6 +152,7 @@ jobs:
           else
             bundle exec fastlane scan --only_testing TestAppTests/TestAppTests/testFullJIT
           fi
+
       - name: Dump Simulator Tests On a Failure
         if: |
           failure() && inputs.ios-platform == 'SIMULATOR'

--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -31,7 +31,6 @@ env:
 
 jobs:
   build:
-    if: github.repository_owner == 'pytorch'
     runs-on: macos-12
     timeout-minutes: 240
     steps:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -127,11 +127,6 @@ jobs:
       build-environment: ios-12-5-1-x86-64
       ios-platform: SIMULATOR
       ios-arch: x86_64
-    secrets:
-      IOS_CERT_KEY_2022: ${{ secrets.IOS_CERT_KEY_2022 }}
-      IOS_CERT_SECRET: ${{ secrets.IOS_CERT_SECRET}}
-      IOS_DEV_TEAM_ID: ${{ secrets.IOS_DEV_TEAM_ID}}
-      IOS_SIGN_KEY_2022: ${{ secrets.IOS_SIGN_KEY_2022 }}
 
   macos-12-py3-x86-64-build:
     name: macos-12-py3-x86-64


### PR DESCRIPTION
Codesigning isn't necessary for simulator builds, and we're not running any device tests. More importantly, our dev certificate is expiring at the end of the month, and we don't have a replacement. As a result, we need to remove our job dependencies on it. This commit removes our references to it from our github CI, but a follow up PR will be needed to remove it from CircleCI workflows. 
