### PR TITLE
[doc] Add pin_memory and layout to new_{zeros, ones, full}

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -121,7 +121,7 @@ Example::
 add_docstr_all(
     "new_empty",
     """
-new_empty(size, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, /
+new_empty(size, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, \
 pin_memory=False) -> Tensor
 """
     + r"""

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -28,6 +28,8 @@ new_common_args = parse_kwargs(
         returned tensor. Default: ``False``.
     pin_memory (bool, optional): If set, returned tensor would be allocated in
         the pinned memory. Works only for CPU tensors. Default: ``False``.
+    layout (:class:`torch.layout`, optional): the desired layout of returned Tensor.
+        Default: ``torch.strided``.
 """
 )
 
@@ -76,8 +78,11 @@ Example::
 
 add_docstr_all(
     "new_full",
-    r"""
-new_full(size, fill_value, dtype=None, device=None, requires_grad=False) -> Tensor
+    """
+new_full(size, fill_value, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, \
+pin_memory=False) -> Tensor
+"""
+    + r"""
 
 Returns a Tensor of size :attr:`size` filled with :attr:`fill_value`.
 By default, the returned Tensor has the same :class:`torch.dtype` and
@@ -85,9 +90,13 @@ By default, the returned Tensor has the same :class:`torch.dtype` and
 
 Args:
     fill_value (scalar): the number to fill the output tensor with.
+    
+Keyword args:
     {dtype}
     {device}
     {requires_grad}
+    {layout}
+    {pin_memory}
 
 Example::
 
@@ -156,8 +165,11 @@ Example::
 
 add_docstr_all(
     "new_ones",
-    r"""
-new_ones(size, dtype=None, device=None, requires_grad=False) -> Tensor
+    """
+new_ones(size, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, \
+pin_memory=False) -> Tensor
+"""
+    + r"""
 
 Returns a Tensor of size :attr:`size` filled with ``1``.
 By default, the returned Tensor has the same :class:`torch.dtype` and
@@ -166,9 +178,13 @@ By default, the returned Tensor has the same :class:`torch.dtype` and
 Args:
     size (int...): a list, tuple, or :class:`torch.Size` of integers defining the
         shape of the output tensor.
+
+Keyword args:
     {dtype}
     {device}
     {requires_grad}
+    {layout}
+    {pin_memory}
 
 Example::
 
@@ -184,8 +200,11 @@ Example::
 
 add_docstr_all(
     "new_zeros",
-    r"""
-new_zeros(size, dtype=None, device=None, requires_grad=False) -> Tensor
+    """
+new_zeros(size, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, \
+pin_memory=False) -> Tensor
+"""
+    + r"""
 
 Returns a Tensor of size :attr:`size` filled with ``0``.
 By default, the returned Tensor has the same :class:`torch.dtype` and
@@ -194,9 +213,13 @@ By default, the returned Tensor has the same :class:`torch.dtype` and
 Args:
     size (int...): a list, tuple, or :class:`torch.Size` of integers defining the
         shape of the output tensor.
+
+Keyword args:
     {dtype}
     {device}
     {requires_grad}
+    {layout}
+    {pin_memory}
 
 Example::
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -35,8 +35,11 @@ new_common_args = parse_kwargs(
 
 add_docstr_all(
     "new_tensor",
-    r"""
-new_tensor(data, dtype=None, device=None, requires_grad=False) -> Tensor
+    """
+new_tensor(data, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, \
+pin_memory=False) -> Tensor
+"""
+    + r"""
 
 Returns a new Tensor with :attr:`data` as the tensor data.
 By default, the returned Tensor has the same :class:`torch.dtype` and
@@ -59,9 +62,13 @@ By default, the returned Tensor has the same :class:`torch.dtype` and
 
 Args:
     data (array_like): The returned Tensor copies :attr:`data`.
+
+Keyword args:
     {dtype}
     {device}
     {requires_grad}
+    {layout}
+    {pin_memory}
 
 Example::
 
@@ -113,17 +120,26 @@ Example::
 
 add_docstr_all(
     "new_empty",
-    r"""
-new_empty(size, dtype=None, device=None, requires_grad=False) -> Tensor
+    """
+new_empty(size, *, dtype=None, device=None, requires_grad=False, layout=torch.strided, /
+pin_memory=False) -> Tensor
+"""
+    + r"""
 
 Returns a Tensor of size :attr:`size` filled with uninitialized data.
 By default, the returned Tensor has the same :class:`torch.dtype` and
 :class:`torch.device` as this tensor.
 
 Args:
+    size (int...): a list, tuple, or :class:`torch.Size` of integers defining the
+        shape of the output tensor.
+
+Keyword args:
     {dtype}
     {device}
     {requires_grad}
+    {layout}
+    {pin_memory}
 
 Example::
 
@@ -139,17 +155,26 @@ Example::
 
 add_docstr_all(
     "new_empty_strided",
-    r"""
-new_empty_strided(size, stride, dtype=None, device=None, requires_grad=False) -> Tensor
+    """
+new_empty_strided(size, stride, dtype=None, device=None, requires_grad=False, layout=torch.strided, \
+pin_memory=False) -> Tensor
+"""
+    + r"""
 
 Returns a Tensor of size :attr:`size` and strides :attr:`stride` filled with
 uninitialized data. By default, the returned Tensor has the same
 :class:`torch.dtype` and :class:`torch.device` as this tensor.
 
 Args:
+    size (int...): a list, tuple, or :class:`torch.Size` of integers defining the
+        shape of the output tensor.
+
+Keyword args:
     {dtype}
     {device}
     {requires_grad}
+    {layout}
+    {pin_memory}
 
 Example::
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -90,7 +90,7 @@ By default, the returned Tensor has the same :class:`torch.dtype` and
 
 Args:
     fill_value (scalar): the number to fill the output tensor with.
-    
+
 Keyword args:
     {dtype}
     {device}


### PR DESCRIPTION
Fixes #84986

Besides adding `pin_memory` and `layout`, I have also updated the signature to reflect keyword only arguments.