### PR TITLE
Designate divice to generate_square_subsequent_mask

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -150,11 +150,11 @@ class Transformer(Module):
         return output
 
     @staticmethod
-    def generate_square_subsequent_mask(sz: int) -> Tensor:
+    def generate_square_subsequent_mask(sz: int, device='cpu') -> Tensor:
         r"""Generate a square mask for the sequence. The masked positions are filled with float('-inf').
             Unmasked positions are filled with float(0.0).
         """
-        return torch.triu(torch.full((sz, sz), float('-inf')), diagonal=1)
+        return torch.triu(torch.full((sz, sz), float('-inf'), device=device), diagonal=1)
 
     def _reset_parameters(self):
         r"""Initiate parameters in the transformer model."""


### PR DESCRIPTION
When the model is on GPU, generating the mask on defalut device(cpu) is quite time consuming.
