### PR TITLE
Add an option to include actual license terms to the output

### DIFF
--- a/third_party/build_bundled.py
+++ b/third_party/build_bundled.py
@@ -181,9 +181,14 @@ if __name__ == '__main__':
         ),
         help="location to output new bundled licenses file",
     )
-
+    parser.add_argument(
+        "--include-files",
+        action="store_true",
+        default=False,
+        help="include actual license terms to the output",
+    )
     args = parser.parse_args()
     fname = args.out_file
     print(f"+ Writing bundled licenses to {args.out_file}")
     with open(fname, 'w') as fid:
-        create_bundled(third_party, fid)
+        create_bundled(third_party, fid, args.include_files)


### PR DESCRIPTION
When building products using PyTorch, it is often required to display license terms for all dependencies.
The feature itself has been implemented in #81500 but it seems there are no options to enable it.
This PR implements the option.

cc/ @mattip @rgommers 