### PR TITLE
[aarch64] Use the correct binary when cross building //caffe2/torch/csrc/deploy:remove_dt_needed

### DIFF
--- a/torch/csrc/deploy/interpreter/defs.bzl
+++ b/torch/csrc/deploy/interpreter/defs.bzl
@@ -70,7 +70,7 @@ def embedded_interpreter(name, suffix, legacy = False, exported_deps = [], expor
         # and loading the cuda part additively.  Hence to achieve requirement (1) we bundle
         # two complete interpreter libs, one with and one without cuda.
 
-        cp_cmd = "$(location //caffe2/torch/csrc/deploy:remove_dt_needed)" if suffix == "all" else "cp"
+        cp_cmd = "$(exe //caffe2/torch/csrc/deploy:remove_dt_needed)" if suffix == "all" else "cp"
 
         build_name = "build_" + name
         if not legacy:


### PR DESCRIPTION
Test Plan: CI

Differential Revision: D39807135

