### PR TITLE
[ONNX] Update behavior for `register_custom_op_symbolic`

### DIFF
--- a/test/onnx/internal/test_registraion.py
+++ b/test/onnx/internal/test_registraion.py
@@ -36,7 +36,8 @@ class TestGlobalHelpers(common_utils.TestCase):
             ([], 16, None),
             ([], 9, None),
             ([], 8, None),
-            ([8], 16, None),  # Ops lower than 9 are not supported by versions >= 9
+            # Ops registered at opset 1 found as a fallback when target >= 9
+            ([1], 16, 1),
         ],
     )
     def test_dispatch_opset_version_returns_correct_version(

--- a/test/onnx/test_pytorch_onnx_no_runtime.py
+++ b/test/onnx/test_pytorch_onnx_no_runtime.py
@@ -625,7 +625,9 @@ class TestONNXExport(common_utils.TestCase):
         def symbolic_custom_invalid_add(g, input, other, alpha=None):
             return g.op("Add", input, other, invalid_attr_i=1)
 
-        torch.onnx.register_custom_op_symbolic("::add", symbolic_custom_invalid_add, 1)
+        torch.onnx.register_custom_op_symbolic(
+            "::add", symbolic_custom_invalid_add, opset_version=9
+        )
 
         x = torch.randn(2, 3, 4)
         y = torch.randn(2, 3, 4)
@@ -635,9 +637,9 @@ class TestONNXExport(common_utils.TestCase):
 
         try:
             with self.assertRaises(torch.onnx.errors.CheckerError):
-                torch.onnx.export(test_model, (x, y), f)
+                torch.onnx.export(test_model, (x, y), f, opset_version=9)
         finally:
-            torch.onnx.unregister_custom_op_symbolic("::add", 1)
+            torch.onnx.unregister_custom_op_symbolic("::add", 9)
 
         self.assertTrue(f.getvalue(), "ONNX graph was not exported.")
         loaded_model = onnx.load_from_string(f.getvalue())

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -17,11 +17,7 @@ from pytorch_test_common import (
     skipIfUnsupportedMaxOpsetVersion,
     skipIfUnsupportedMinOpsetVersion,
 )
-from torch.onnx import (
-    OperatorExportTypes,
-    TrainingMode,
-    utils,
-)
+from torch.onnx import OperatorExportTypes, TrainingMode, utils
 from torch.onnx._globals import GLOBALS
 from torch.onnx.symbolic_helper import _unpack_list, parse_args
 from torch.testing._internal import common_utils

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -19,9 +19,7 @@ from pytorch_test_common import (
 )
 from torch.onnx import (
     OperatorExportTypes,
-    register_custom_op_symbolic,
     TrainingMode,
-    unregister_custom_op_symbolic,
     utils,
 )
 from torch.onnx._globals import GLOBALS
@@ -1160,12 +1158,12 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         self.assertEqual(next(iter).kind(), "custom_namespace::custom_op")
 
     def test_custom_opsets_gelu(self):
-        self.addCleanup(unregister_custom_op_symbolic, "::gelu", 1)
+        self.addCleanup(torch.onnx.unregister_custom_op_symbolic, "::gelu", 9)
 
         def gelu(g, self, approximate):
             return g.op("com.microsoft::Gelu", self).setType(self.type())
 
-        register_custom_op_symbolic("::gelu", gelu, 1)
+        torch.onnx.register_custom_op_symbolic("::gelu", gelu, 9)
         model = torch.nn.GELU(approximate="none")
         x = torch.randn(3, 3)
         f = io.BytesIO()
@@ -1184,12 +1182,12 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         self.assertEqual(graph.opset_import[1].version, 1)
 
     def test_register_aten_custom_op_symbolic(self):
-        self.addCleanup(unregister_custom_op_symbolic, "aten::gelu", 1)
+        self.addCleanup(torch.onnx.unregister_custom_op_symbolic, "aten::gelu", 9)
 
         def gelu(g, self, approximate):
             return g.op("com.microsoft::Gelu", self).setType(self.type())
 
-        register_custom_op_symbolic("aten::gelu", gelu, 1)
+        torch.onnx.register_custom_op_symbolic("aten::gelu", gelu, 9)
         model = torch.nn.GELU(approximate="none")
         x = torch.randn(3, 3)
         f = io.BytesIO()
@@ -1201,6 +1199,8 @@ class TestUtilityFuns_opset9(_BaseTestCase):
 
     @skipIfNoLapack
     def test_custom_opsets_inverse(self):
+        self.addCleanup(torch.onnx.unregister_custom_op_symbolic, "::linalg_inv", 9)
+
         class CustomInverse(torch.nn.Module):
             def forward(self, x):
                 return torch.inverse(x) + x
@@ -1208,7 +1208,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         def linalg_inv(g, self):
             return g.op("com.microsoft::Inverse", self).setType(self.type())
 
-        register_custom_op_symbolic("::linalg_inv", linalg_inv, 1)
+        torch.onnx.register_custom_op_symbolic("::linalg_inv", linalg_inv, 9)
         model = CustomInverse()
         x = torch.randn(2, 3, 3)
         f = io.BytesIO()
@@ -1760,7 +1760,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             tensors = _unpack_list(tensor_list)
             return g.op("Concat", *tensors, axis_i=dim)
 
-        register_custom_op_symbolic("::cat", cat, _onnx_opset_version)
+        torch.onnx.register_custom_op_symbolic("::cat", cat, _onnx_opset_version)
 
         class CatModel(torch.nn.Module):
             def forward(self, x):
@@ -1781,7 +1781,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
                 "report this bug."
             ),
         )
-        unregister_custom_op_symbolic("::cat", _onnx_opset_version)
+        torch.onnx.unregister_custom_op_symbolic("::cat", _onnx_opset_version)
 
 
 class TestUtilityFuns_opset10(TestUtilityFuns_opset9):

--- a/torch/onnx/_internal/registration.py
+++ b/torch/onnx/_internal/registration.py
@@ -33,26 +33,27 @@ def _dispatch_opset_version(
     """
     if not registered_opsets:
         return None
-    registered_versions = sorted(registered_opsets)
+
+    reversed_registered_versions = sorted(registered_opsets, reverse=True)
     # Linear search for the opset version, which is fine since the number of opset
     # versions is small.
 
-    # Always round toward opset 9 (ONNX_BASE_OPSET).
-    # Count down until opset 9 is reached.
-    for version in reversed(registered_versions):
-        if _constants.ONNX_BASE_OPSET <= version <= target:
-            return version
+    if target >= _constants.ONNX_BASE_OPSET:
+        # Always look down toward opset 1 when the target is >= ONNX_BASE_OPSET (opset 9).
+        # When a custom op is register at opset 1, we want to be able to discover it as a
+        # fallback for all opsets >= ONNX_BASE_OPSET.
+        for version in reversed_registered_versions:
+            if version <= target:
+                return version
+        return None
 
-    for version in registered_versions:
+    # target < opset 9. This is the legacy behavior to support opset 7 and opset 8.
+    # for caffe2 support. We search up toward opset 9.
+    for version in reversed(reversed_registered_versions):
         # Count back up until _constants.ONNX_BASE_OPSET
         if target <= version <= _constants.ONNX_BASE_OPSET:
             return version
 
-    assert (
-        not registered_versions
-        or _constants.ONNX_BASE_OPSET <= target < registered_versions[0]
-        or registered_versions[-1] < _constants.ONNX_BASE_OPSET <= target
-    )
     return None
 
 

--- a/torch/onnx/_internal/registration.py
+++ b/torch/onnx/_internal/registration.py
@@ -34,7 +34,7 @@ def _dispatch_opset_version(
     if not registered_opsets:
         return None
 
-    reversed_registered_versions = sorted(registered_opsets, reverse=True)
+    descending_registered_versions = sorted(registered_opsets, reverse=True)
     # Linear search for the opset version, which is fine since the number of opset
     # versions is small.
 
@@ -42,14 +42,14 @@ def _dispatch_opset_version(
         # Always look down toward opset 1 when the target is >= ONNX_BASE_OPSET (opset 9).
         # When a custom op is register at opset 1, we want to be able to discover it as a
         # fallback for all opsets >= ONNX_BASE_OPSET.
-        for version in reversed_registered_versions:
+        for version in descending_registered_versions:
             if version <= target:
                 return version
         return None
 
     # target < opset 9. This is the legacy behavior to support opset 7 and opset 8.
     # for caffe2 support. We search up toward opset 9.
-    for version in reversed(reversed_registered_versions):
+    for version in reversed(descending_registered_versions):
         # Count back up until _constants.ONNX_BASE_OPSET
         if target <= version <= _constants.ONNX_BASE_OPSET:
             return version

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1932,13 +1932,9 @@ def register_custom_op_symbolic(
 
     _verify_custom_op_name(symbolic_name)
 
-    versions = range(
-        max(_constants.ONNX_MIN_OPSET, opset_version), _constants.ONNX_MAX_OPSET + 1
-    )
-
     registration.custom_onnx_symbolic(
         symbolic_name,
-        versions,
+        opset_version,
         decorate=[
             _symbolic_context_handler,
         ],
@@ -1961,9 +1957,7 @@ def unregister_custom_op_symbolic(symbolic_name: str, opset_version: int):
 
     _verify_custom_op_name(symbolic_name)
 
-    for version in range(_constants.ONNX_MIN_OPSET, _constants.ONNX_MAX_OPSET + 1):
-        if version >= opset_version:
-            registration.registry.unregister(symbolic_name, version)
+    registration.registry.unregister(symbolic_name, opset_version)
 
 
 @_beartype.beartype


### PR DESCRIPTION
Update `register_custom_op_symbolic`'s behavior to _only register the symbolic function at a single version_. This is more aligned with the semantics of the API signature.

As a result of this change, opset 7 and opset 8 implementations are now seen as fallback when the opset_version >= 9. Previously any ops internally registered to opset < 9 are not discoverable by an export version target >= 9. Updated the test to reflect this change.

The implication of this change is that users will need to register a symbolic function to the exact version when they want to override an existing symbolic. They are not impacted if (1) an implementation does not existing for the op, or (2) they are already registering to the exact version for export.