### PR TITLE
Fix warning in kineto_shim.h

### DIFF
--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -116,7 +116,7 @@ TraceWrapper::operator bool() const {
 
 ActivityTraceWrapper::ActivityTraceWrapper(
     std::unique_ptr<interface_trace_t>&& trace)
-    : trace_(std::move(trace)), saved_{false} {}
+    : trace_(std::move(trace)) {}
 
 ActivityTraceWrapper::operator bool() const {
 #ifdef USE_KINETO

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -108,7 +108,9 @@ struct ActivityTraceWrapper {
 
  private:
   std::unique_ptr<interface_trace_t> trace_;
+#ifdef USE_KINETO
   bool saved_ = false; // Kineto's save is destructive
+#endif
 };
 
 using ActivitySet = std::set<torch::autograd::profiler::ActivityType>;


### PR DESCRIPTION
Fixes:
```
In file included from /dev/shm/rbarnes/tempfs/pytorch/torch/csrc/profiler/kineto_shim.cpp:1:
/dev/shm/rbarnes/tempfs/pytorch/torch/csrc/profiler/kineto_shim.h:111:8: warning: private field 'saved_' is not used [-Wunused-private-field]
  bool saved_ = false; // Kineto's save is destructive
       ^
```