### PR TITLE
[DataLoader2] Change graph traverse default option to only_datapipe=True

### DIFF
--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -89,7 +89,8 @@ def traverse(datapipe: DataPipe, only_datapipe: Optional[bool] = None) -> DataPi
     ``list``, ``tuple``, ``set`` and ``dict``.
     Args:
         datapipe: the end DataPipe of the graph
-        only_datapipe: If ``False`` (default), all attributes of each DataPipe are traversed.
+        only_datapipe: If ``False``, all attributes of each DataPipe are traversed.
+          If ``True`` (by default), only DataPipe will be traversed.
           This argument is deprecating and will be removed after the next release.
     Returns:
         A graph represented as a nested dictionary, where keys are ids of DataPipe instances
@@ -98,10 +99,10 @@ def traverse(datapipe: DataPipe, only_datapipe: Optional[bool] = None) -> DataPi
     if only_datapipe is not None:
         msg = "`only_datapipe` is deprecated from `traverse` function and will be removed after 1.13."
         if not only_datapipe:
-            msg += "And, default value will be changed to `only_datapipe=True`"
+            msg += "And, it will behave like `only_datapipe=True`."
         warnings.warn(msg, FutureWarning)
     else:
-        only_datapipe = False
+        only_datapipe = True
     cache: Set[int] = set()
     return _traverse_helper(datapipe, only_datapipe, cache)
 

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -32,7 +32,7 @@ def _get_all_graph_pipes_helper(graph: DataPipeGraph, id_cache: Set[int]) -> Lis
 
 
 def apply_sharding(datapipe: DataPipe, num_of_instances: int, instance_id: int) -> DataPipe:
-    graph = traverse(datapipe, only_datapipe=True)
+    graph = traverse(datapipe)
     all_pipes = get_all_graph_pipes(graph)
     already_applied_to = None
     for pipe in all_pipes:
@@ -67,7 +67,7 @@ def apply_shuffle_settings(datapipe: DataPipe, shuffle: Optional[bool] = None) -
     if shuffle is None:
         return datapipe
 
-    graph = traverse(datapipe, only_datapipe=True)
+    graph = traverse(datapipe)
     all_pipes = get_all_graph_pipes(graph)
     shufflers = [pipe for pipe in all_pipes if _is_shuffle_datapipe(pipe)]
     if not shufflers and shuffle:
@@ -107,7 +107,7 @@ def apply_random_seed(datapipe: DataPipe, rng: torch.Generator) -> DataPipe:
         datapipe: DataPipe that needs to set randomness
         rng: Random number generator to generate random seeds
     """
-    graph = traverse(datapipe, only_datapipe=True)
+    graph = traverse(datapipe)
     all_pipes = get_all_graph_pipes(graph)
     # Using a set to track id of DataPipe to prevent setting randomness per DataPipe more than once.
     # And, `id` is used in case of unhashable DataPipe


### PR DESCRIPTION
Changes the default behavior of `torch.utils.data.traverse` function from `only_datapipe=False` to `only_datapipe=True`.

I am introducing this BC-breaking change for the following reasons:
- Ultimately we want to remove `only_datapipe` and use it as `only_datapipe=True`. Keeping a default value as `False` makes the deprecation cycle even longer.
- This function is tied to `DataLoader2` graph. Since `DataLoader2` is in prototype phase, any BC-breaking change is allowed. And, we do add a deprecation warning for removing the `only_datapipe` option.
- I did a quick search on Github, 99% percent of usages are `forks` from torchdata or pytorch.

## BC-breaking Note:
This PR changes the default option of `torch.utils.data.traverse` function to `only_datapipe=True`. When it traverses the DataPipe, it would skip all non-collection objects. This would reduce the traversing complexity and reduce the chance that traverse non-picklable objects.