### PR TITLE
[DataLoader] Replacing `traverse` function with `traverse_datapipes`

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -44,7 +44,7 @@ from torch.utils.data import (
     runtime_validation,
     runtime_validation_disabled,
 )
-from torch.utils.data.graph import traverse, traverse_dps
+from torch.utils.data.graph import traverse_dps
 from torch.utils.data.datapipes.utils.common import StreamWrapper
 from torch.utils.data.datapipes.utils.decoder import (
     basichandlers as decoder_basichandlers,
@@ -2534,27 +2534,13 @@ class TestCircularSerialization(TestCase):
         src_1 = m1_1.datapipe
 
         res1 = traverse_dps(dp1)
-        res2 = traverse(dp1, only_datapipe=False)
-
         exp_res_1 = {id(dp1): (dp1, {
             id(src_1): (src_1, {}),
             id(child_1): (child_1, {id(dm_1): (dm_1, {
                 id(m2_1): (m2_1, {id(m1_1): (m1_1, {id(src_1): (src_1, {})})})
             })})
         })}
-        exp_res_2 = {id(dp1): (dp1, {
-            id(src_1): (src_1, {}),
-            id(child_1): (child_1, {id(dm_1): (dm_1, {
-                id(m2_1): (m2_1, {
-                    id(m1_1): (m1_1, {id(src_1): (src_1, {})}),
-                    id(src_1): (src_1, {})
-                })
-            })})
-        })}
-
         self.assertEqual(res1, exp_res_1)
-        self.assertEqual(res2, exp_res_2)
-
         dp2 = TestCircularSerialization.CustomIterDataPipe(fn=_fake_fn, source_dp=dp1)
         self.assertTrue(list(dp2) == list(pickle.loads(pickle.dumps(dp2))))
 
@@ -2563,9 +2549,8 @@ class TestCircularSerialization(TestCase):
         m2_2 = dm_2.main_datapipe
         m1_2 = m2_2.datapipe
 
-        res3 = traverse_dps(dp2)
-        res4 = traverse(dp2, only_datapipe=False)
-        exp_res_3 = {id(dp2): (dp2, {
+        res2 = traverse_dps(dp2)
+        exp_res_2 = {id(dp2): (dp2, {
             id(dp1): (dp1, {
                 id(src_1): (src_1, {}),
                 id(child_1): (child_1, {id(dm_1): (dm_1, {
@@ -2583,44 +2568,7 @@ class TestCircularSerialization(TestCase):
                 })})
             })})
         })}
-        exp_res_4 = {id(dp2): (dp2, {
-            id(dp1): (dp1, {
-                id(src_1): (src_1, {}),
-                id(child_1): (child_1, {id(dm_1): (dm_1, {
-                    id(m2_1): (m2_1, {
-                        id(m1_1): (m1_1, {id(src_1): (src_1, {})}),
-                        id(src_1): (src_1, {})
-                    })
-                })})
-            }),
-            id(child_2): (child_2, {id(dm_2): (dm_2, {
-                id(m2_2): (m2_2, {
-                    id(m1_2): (m1_2, {
-                        id(dp1): (dp1, {
-                            id(src_1): (src_1, {}),
-                            id(child_1): (child_1, {id(dm_1): (dm_1, {
-                                id(m2_1): (m2_1, {
-                                    id(m1_1): (m1_1, {id(src_1): (src_1, {})}),
-                                    id(src_1): (src_1, {})
-                                })
-                            })})
-                        })
-                    }),
-                    id(dp1): (dp1, {
-                        id(src_1): (src_1, {}),
-                        id(child_1): (child_1, {id(dm_1): (dm_1, {
-                            id(m2_1): (m2_1, {
-                                id(m1_1): (m1_1, {id(src_1): (src_1, {})}),
-                                id(src_1): (src_1, {})
-                            })
-                        })})
-                    })
-                })
-            })})
-        })}
-
-        self.assertEqual(res3, exp_res_3)
-        self.assertEqual(res4, exp_res_4)
+        self.assertEqual(res2, exp_res_2)
 
     class LambdaIterDataPipe(CustomIterDataPipe):
 
@@ -2644,7 +2592,6 @@ class TestCircularSerialization(TestCase):
         src_1 = m1_1.datapipe
 
         res1 = traverse_dps(dp1)
-        res2 = traverse(dp1, only_datapipe=False)
 
         exp_res_1 = {id(dp1): (dp1, {
             id(src_1): (src_1, {}),
@@ -2652,18 +2599,8 @@ class TestCircularSerialization(TestCase):
                 id(m2_1): (m2_1, {id(m1_1): (m1_1, {id(src_1): (src_1, {})})})
             })})
         })}
-        exp_res_2 = {id(dp1): (dp1, {
-            id(src_1): (src_1, {}),
-            id(child_1): (child_1, {id(dm_1): (dm_1, {
-                id(m2_1): (m2_1, {
-                    id(m1_1): (m1_1, {id(src_1): (src_1, {})}),
-                    id(src_1): (src_1, {})
-                })
-            })})
-        })}
 
         self.assertEqual(res1, exp_res_1)
-        self.assertEqual(res2, exp_res_2)
 
         dp2 = TestCircularSerialization.LambdaIterDataPipe(fn=_fake_fn, source_dp=dp1)
         self.assertTrue(list(dp2) == list(dill.loads(dill.dumps(dp2))))
@@ -2673,9 +2610,8 @@ class TestCircularSerialization(TestCase):
         m2_2 = dm_2.main_datapipe
         m1_2 = m2_2.datapipe
 
-        res3 = traverse_dps(dp2)
-        res4 = traverse(dp2, only_datapipe=False)
-        exp_res_3 = {id(dp2): (dp2, {
+        res2 = traverse_dps(dp2)
+        exp_res_2 = {id(dp2): (dp2, {
             id(dp1): (dp1, {
                 id(src_1): (src_1, {}),
                 id(child_1): (child_1, {id(dm_1): (dm_1, {
@@ -2693,45 +2629,7 @@ class TestCircularSerialization(TestCase):
                 })})
             })})
         })}
-        exp_res_4 = {id(dp2): (dp2, {
-            id(dp1): (dp1, {
-                id(src_1): (src_1, {}),
-                id(child_1): (child_1, {id(dm_1): (dm_1, {
-                    id(m2_1): (m2_1, {
-                        id(m1_1): (m1_1, {id(src_1): (src_1, {})}),
-                        id(src_1): (src_1, {})
-                    })
-                })})
-            }),
-            id(child_2): (child_2, {id(dm_2): (dm_2, {
-                id(m2_2): (m2_2, {
-                    id(m1_2): (m1_2, {
-                        id(dp1): (dp1, {
-                            id(src_1): (src_1, {}),
-                            id(child_1): (child_1, {id(dm_1): (dm_1, {
-                                id(m2_1): (m2_1, {
-                                    id(m1_1): (m1_1, {id(src_1): (src_1, {})}),
-                                    id(src_1): (src_1, {})
-                                })
-                            })})
-                        })
-                    }),
-                    id(dp1): (dp1, {
-                        id(src_1): (src_1, {}),
-                        id(child_1): (child_1, {id(dm_1): (dm_1, {
-                            id(m2_1): (m2_1, {
-                                id(m1_1): (m1_1, {id(src_1): (src_1, {})}),
-                                id(src_1): (src_1, {})
-                            })
-                        })})
-                    })
-                })
-            })})
-        })}
-
-        self.assertEqual(res3, exp_res_3)
-        self.assertEqual(res4, exp_res_4)
-
+        self.assertEqual(res2, exp_res_2)
 
 class TestSharding(TestCase):
 

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -44,7 +44,7 @@ from torch.utils.data import (
     runtime_validation,
     runtime_validation_disabled,
 )
-from torch.utils.data.graph import traverse, traverse_datapipes
+from torch.utils.data.graph import traverse, traverse_dps
 from torch.utils.data.datapipes.utils.common import StreamWrapper
 from torch.utils.data.datapipes.utils.decoder import (
     basichandlers as decoder_basichandlers,
@@ -985,10 +985,10 @@ class TestFunctionalIterDataPipe(TestCase):
 
         # Pickle Test:
         dp1, dp2, dp3 = input_dp.fork(num_instances=3)
-        traverse_datapipes(dp1)  # This should not raise any error
+        traverse_dps(dp1)  # This should not raise any error
         for _ in zip(dp1, dp2, dp3):
             pass
-        traverse_datapipes(dp2)  # This should not raise any error either
+        traverse_dps(dp2)  # This should not raise any error either
 
     def test_mux_iterdatapipe(self):
 
@@ -1155,10 +1155,10 @@ class TestFunctionalIterDataPipe(TestCase):
 
         # Pickle Test:
         dp1, dp2 = input_dp.demux(num_instances=2, classifier_fn=odd_or_even)
-        traverse_datapipes(dp1)  # This should not raise any error
+        traverse_dps(dp1)  # This should not raise any error
         for _ in zip(dp1, dp2):
             pass
-        traverse_datapipes(dp2)  # This should not raise any error either
+        traverse_dps(dp2)  # This should not raise any error either
 
     def test_map_iterdatapipe(self):
         target_length = 10
@@ -2374,7 +2374,7 @@ class TestGraph(TestCase):
         shuffled_dp = numbers_dp.shuffle()
         sharded_dp = shuffled_dp.sharding_filter()
         mapped_dp = sharded_dp.map(lambda x: x * 10)
-        graph = traverse_datapipes(mapped_dp)
+        graph = traverse_dps(mapped_dp)
         expected: Dict[Any, Any] = {
             id(mapped_dp): (mapped_dp, {
                 id(sharded_dp): (sharded_dp, {
@@ -2397,7 +2397,7 @@ class TestGraph(TestCase):
         dp0_upd = dp0.map(lambda x: x * 10)
         dp1_upd = dp1.filter(lambda x: x % 3 == 1)
         combined_dp = dp0_upd.mux(dp1_upd, dp2)
-        graph = traverse_datapipes(combined_dp)
+        graph = traverse_dps(combined_dp)
         expected = {
             id(combined_dp): (combined_dp, {
                 id(dp0_upd): (dp0_upd, {
@@ -2431,21 +2431,21 @@ class TestGraph(TestCase):
     def test_traverse_mapdatapipe(self):
         source_dp = dp.map.SequenceWrapper(range(10))
         map_dp = source_dp.map(partial(_fake_add, 1))
-        graph = traverse_datapipes(map_dp)
+        graph = traverse_dps(map_dp)
         expected: Dict[Any, Any] = {id(map_dp): (map_dp, {id(source_dp): (source_dp, {})})}
         self.assertEqual(expected, graph)
 
     def test_traverse_mixdatapipe(self):
         source_map_dp = dp.map.SequenceWrapper(range(10))
         iter_dp = dp.iter.IterableWrapper(source_map_dp)
-        graph = traverse_datapipes(iter_dp)
+        graph = traverse_dps(iter_dp)
         expected: Dict[Any, Any] = {id(iter_dp): (iter_dp, {id(source_map_dp): (source_map_dp, {})})}
         self.assertEqual(expected, graph)
 
     def test_traverse_circular_datapipe(self):
         source_iter_dp = dp.iter.IterableWrapper(list(range(10)))
         circular_dp = TestGraph.CustomIterDataPipe(source_iter_dp)
-        graph = traverse_datapipes(circular_dp)
+        graph = traverse_dps(circular_dp)
         # See issue: https://github.com/pytorch/data/issues/535
         expected: Dict[Any, Any] = {
             id(circular_dp): (circular_dp, {
@@ -2464,7 +2464,7 @@ class TestGraph(TestCase):
     def test_traverse_unhashable_datapipe(self):
         source_iter_dp = dp.iter.IterableWrapper(list(range(10)))
         unhashable_dp = TestGraph.CustomIterDataPipe(source_iter_dp)
-        graph = traverse_datapipes(unhashable_dp)
+        graph = traverse_dps(unhashable_dp)
         with self.assertRaises(NotImplementedError):
             hash(unhashable_dp)
         expected: Dict[Any, Any] = {
@@ -2533,7 +2533,7 @@ class TestCircularSerialization(TestCase):
         m1_1 = m2_1.datapipe
         src_1 = m1_1.datapipe
 
-        res1 = traverse_datapipes(dp1)
+        res1 = traverse_dps(dp1)
         res2 = traverse(dp1, only_datapipe=False)
 
         exp_res_1 = {id(dp1): (dp1, {
@@ -2563,7 +2563,7 @@ class TestCircularSerialization(TestCase):
         m2_2 = dm_2.main_datapipe
         m1_2 = m2_2.datapipe
 
-        res3 = traverse_datapipes(dp2)
+        res3 = traverse_dps(dp2)
         res4 = traverse(dp2, only_datapipe=False)
         exp_res_3 = {id(dp2): (dp2, {
             id(dp1): (dp1, {
@@ -2643,7 +2643,7 @@ class TestCircularSerialization(TestCase):
         m1_1 = m2_1.datapipe
         src_1 = m1_1.datapipe
 
-        res1 = traverse_datapipes(dp1)
+        res1 = traverse_dps(dp1)
         res2 = traverse(dp1, only_datapipe=False)
 
         exp_res_1 = {id(dp1): (dp1, {
@@ -2673,7 +2673,7 @@ class TestCircularSerialization(TestCase):
         m2_2 = dm_2.main_datapipe
         m1_2 = m2_2.datapipe
 
-        res3 = traverse_datapipes(dp2)
+        res3 = traverse_dps(dp2)
         res4 = traverse(dp2, only_datapipe=False)
         exp_res_3 = {id(dp2): (dp2, {
             id(dp1): (dp1, {

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -9,7 +9,7 @@ from torch.utils.data import IterDataPipe, MapDataPipe
 from torch.utils.data._utils.serialization import DILL_AVAILABLE
 
 
-__all__ = ["traverse"]
+__all__ = ["traverse", "traverse_datapipes"]
 
 DataPipe = Union[IterDataPipe, MapDataPipe]
 DataPipeGraph = Dict[int, Tuple[DataPipe, "DataPipeGraph"]]  # type: ignore[misc]
@@ -81,12 +81,32 @@ def _list_connected_datapipes(scan_obj: DataPipe, only_datapipe: bool, cache: Se
     return captured_connections
 
 
+def traverse_datapipes(datapipe: DataPipe) -> DataPipeGraph:
+    r"""
+    Traverse the DataPipes and their attributes to extract the DataPipe graph.
+    This would only look into the attribute from each DataPipe that is either a
+    DataPipe and a Python collection object such as ``list``, ``tuple``,
+    ``set`` and ``dict``.
+    Args:
+        datapipe: the end DataPipe of the graph
+    Returns:
+        A graph represented as a nested dictionary, where keys are ids of DataPipe instances
+        and values are tuples of DataPipe instance and the sub-graph
+    """
+    cache: Set[int] = set()
+    return _traverse_helper(datapipe, only_datapipe=True, cache=cache)
+
+
 def traverse(datapipe: DataPipe, only_datapipe: Optional[bool] = None) -> DataPipeGraph:
     r"""
-    Traverse the DataPipes and their attributes to extract the DataPipe graph. When
+    [Deprecated] Traverse the DataPipes and their attributes to extract the DataPipe graph. When
     ``only_dataPipe`` is specified as ``True``, it would only look into the attribute
     from each DataPipe that is either a DataPipe and a Python collection object such as
     ``list``, ``tuple``, ``set`` and ``dict``.
+
+    Note:
+        This function is deprecated. Please use `traverse_datapipes` instead.
+
     Args:
         datapipe: the end DataPipe of the graph
         only_datapipe: If ``False`` (default), all attributes of each DataPipe are traversed.
@@ -95,12 +115,12 @@ def traverse(datapipe: DataPipe, only_datapipe: Optional[bool] = None) -> DataPi
         A graph represented as a nested dictionary, where keys are ids of DataPipe instances
         and values are tuples of DataPipe instance and the sub-graph
     """
-    if only_datapipe is not None:
-        msg = "`only_datapipe` is deprecated from `traverse` function and will be removed after 1.13."
-        if not only_datapipe:
-            msg += "And, default value will be changed to `only_datapipe=True`"
-        warnings.warn(msg, FutureWarning)
-    else:
+    msg = "`traverse` function and will be removed after 1.13. " \
+          "Please use `traverse_datapipes` instead."
+    if not only_datapipe:
+        msg += " And, the behavior will be changed to the equivalent of `only_datapipe=True`."
+    warnings.warn(msg, FutureWarning)
+    if only_datapipe is None:
         only_datapipe = False
     cache: Set[int] = set()
     return _traverse_helper(datapipe, only_datapipe, cache)

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -9,7 +9,7 @@ from torch.utils.data import IterDataPipe, MapDataPipe
 from torch.utils.data._utils.serialization import DILL_AVAILABLE
 
 
-__all__ = ["traverse", "traverse_datapipes"]
+__all__ = ["traverse", "traverse_dps"]
 
 DataPipe = Union[IterDataPipe, MapDataPipe]
 DataPipeGraph = Dict[int, Tuple[DataPipe, "DataPipeGraph"]]  # type: ignore[misc]
@@ -81,12 +81,13 @@ def _list_connected_datapipes(scan_obj: DataPipe, only_datapipe: bool, cache: Se
     return captured_connections
 
 
-def traverse_datapipes(datapipe: DataPipe) -> DataPipeGraph:
+def traverse_dps(datapipe: DataPipe) -> DataPipeGraph:
     r"""
     Traverse the DataPipes and their attributes to extract the DataPipe graph.
-    This would only look into the attribute from each DataPipe that is either a
+    This only looks into the attribute from each DataPipe that is either a
     DataPipe and a Python collection object such as ``list``, ``tuple``,
     ``set`` and ``dict``.
+
     Args:
         datapipe: the end DataPipe of the graph
     Returns:
@@ -105,7 +106,7 @@ def traverse(datapipe: DataPipe, only_datapipe: Optional[bool] = None) -> DataPi
     ``list``, ``tuple``, ``set`` and ``dict``.
 
     Note:
-        This function is deprecated. Please use `traverse_datapipes` instead.
+        This function is deprecated. Please use `traverse_dps` instead.
 
     Args:
         datapipe: the end DataPipe of the graph
@@ -116,7 +117,7 @@ def traverse(datapipe: DataPipe, only_datapipe: Optional[bool] = None) -> DataPi
         and values are tuples of DataPipe instance and the sub-graph
     """
     msg = "`traverse` function and will be removed after 1.13. " \
-          "Please use `traverse_datapipes` instead."
+          "Please use `traverse_dps` instead."
     if not only_datapipe:
         msg += " And, the behavior will be changed to the equivalent of `only_datapipe=True`."
     warnings.warn(msg, FutureWarning)

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Set
 
 import torch
 
-from torch.utils.data.graph import DataPipe, DataPipeGraph, traverse
+from torch.utils.data.graph import DataPipe, DataPipeGraph, traverse_datapipes
 
 __all__ = [
     "apply_random_seed",
@@ -32,7 +32,7 @@ def _get_all_graph_pipes_helper(graph: DataPipeGraph, id_cache: Set[int]) -> Lis
 
 
 def apply_sharding(datapipe: DataPipe, num_of_instances: int, instance_id: int) -> DataPipe:
-    graph = traverse(datapipe, only_datapipe=True)
+    graph = traverse_datapipes(datapipe)
     all_pipes = get_all_graph_pipes(graph)
     already_applied_to = None
     for pipe in all_pipes:
@@ -67,7 +67,7 @@ def apply_shuffle_settings(datapipe: DataPipe, shuffle: Optional[bool] = None) -
     if shuffle is None:
         return datapipe
 
-    graph = traverse(datapipe, only_datapipe=True)
+    graph = traverse_datapipes(datapipe)
     all_pipes = get_all_graph_pipes(graph)
     shufflers = [pipe for pipe in all_pipes if _is_shuffle_datapipe(pipe)]
     if not shufflers and shuffle:
@@ -107,7 +107,7 @@ def apply_random_seed(datapipe: DataPipe, rng: torch.Generator) -> DataPipe:
         datapipe: DataPipe that needs to set randomness
         rng: Random number generator to generate random seeds
     """
-    graph = traverse(datapipe, only_datapipe=True)
+    graph = traverse_datapipes(datapipe)
     all_pipes = get_all_graph_pipes(graph)
     # Using a set to track id of DataPipe to prevent setting randomness per DataPipe more than once.
     # And, `id` is used in case of unhashable DataPipe

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Set
 
 import torch
 
-from torch.utils.data.graph import DataPipe, DataPipeGraph, traverse_datapipes
+from torch.utils.data.graph import DataPipe, DataPipeGraph, traverse_dps
 
 __all__ = [
     "apply_random_seed",
@@ -32,7 +32,7 @@ def _get_all_graph_pipes_helper(graph: DataPipeGraph, id_cache: Set[int]) -> Lis
 
 
 def apply_sharding(datapipe: DataPipe, num_of_instances: int, instance_id: int) -> DataPipe:
-    graph = traverse_datapipes(datapipe)
+    graph = traverse_dps(datapipe)
     all_pipes = get_all_graph_pipes(graph)
     already_applied_to = None
     for pipe in all_pipes:
@@ -67,7 +67,7 @@ def apply_shuffle_settings(datapipe: DataPipe, shuffle: Optional[bool] = None) -
     if shuffle is None:
         return datapipe
 
-    graph = traverse_datapipes(datapipe)
+    graph = traverse_dps(datapipe)
     all_pipes = get_all_graph_pipes(graph)
     shufflers = [pipe for pipe in all_pipes if _is_shuffle_datapipe(pipe)]
     if not shufflers and shuffle:
@@ -107,7 +107,7 @@ def apply_random_seed(datapipe: DataPipe, rng: torch.Generator) -> DataPipe:
         datapipe: DataPipe that needs to set randomness
         rng: Random number generator to generate random seeds
     """
-    graph = traverse_datapipes(datapipe)
+    graph = traverse_dps(datapipe)
     all_pipes = get_all_graph_pipes(graph)
     # Using a set to track id of DataPipe to prevent setting randomness per DataPipe more than once.
     # And, `id` is used in case of unhashable DataPipe


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #85668
* __->__ #85667

This PR deprecates `traverse` function and replaces it with `traverse_datapipes` instead.

While use `DataLoader`, I realized that it is raising `FutureWarning` even though I am not explicitly using `traverse`. What is happening is that `DataLoader` invokes `traverse(dp, only_datapipe=True)`, and the usage of the keyword causes the `only_datapipe` warning to be raised.

```
/home/ubuntu/miniconda3/lib/python3.8/site-packages/torch/utils/data/graph.py:102: FutureWarning: `only_datapipe` is deprecated from `traverse` function and will be removed after 1.13.
  warnings.warn(msg, FutureWarning)
```

A few things we'd like to do:
1. Deprecate the key word arg `only_datapipe`
2. Change the default behavior from `only_datapipe=False` to `only_datapipe=True` in the future
3. Do not raise a warning when users are using the function correctly

This creates a paradox it is impossible for the users to change their code to match the future default behavior (i.e. call `traverse(dp)` without `only_datapipe`):
  - they cannot do so because the default behavior of `traverse` hasn't changed yet, so they must use `only_datapipe=True`
  - if they use `only_datapipe=True`, eventually the kwarg will go away and cause a runtime error; they also get a `FutureWarning` in the present

IIUC, there doesn't seem to be a way to accomplish those 3 goals without replacing the function with a new one that has a different name; hence, this PR. Let me know if there is a better alternative.

If this looks right, I will send a follow up PR in `TorchData`.

Differential Revision: [D39832183](https://our.internmc.facebook.com/intern/diff/D39832183)