### PR TITLE
[Nested Tensor] Fixes buffer size bug with clone

### DIFF
--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -658,7 +658,7 @@ Tensor clone_nested(
   else if (memory_format == c10::MemoryFormat::Contiguous) {
     const Tensor& self_buffer = self_ptr->get_buffer(),
         sizemat = self_ptr->get_nested_size_tensor();
-    Tensor output_buffer = at::empty_like(self_buffer);
+    Tensor output_buffer = at::empty(self.numel(), self_buffer.options());
     Tensor output = wrap_buffer(output_buffer, sizemat);
     std::vector<Tensor> self_unbind = self.unbind(),
         output_unbind = output.unbind();


### PR DESCRIPTION
# Summary
When we call chunk on a consistent dim of a NT for chunk_size > 1 the resulting tensors are views of the original NT
whose numels is now less than the size of the buffer. Clone was previously creating a new NT with a buffer that was the same size as the original.


cc @cpuhrsch @jbschlosser @bhosmer @mikaylagawarecki