### PR TITLE
ANTIALIAS updated to Resampling.LANCZOS in torch/utils/tensorboard/summary.py

### DIFF
--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -489,9 +489,12 @@ def make_image(tensor, rescale=1, rois=None, labels=None):
     image = Image.fromarray(tensor)
     if rois is not None:
         image = draw_boxes(image, rois, labels=labels)
-    image = image.resize((scaled_width, scaled_height), Image.ANTIALIAS)
+    try:
+        ANTIALIAS = Image.Resampling.LANCZOS
+    except AttributeError:
+        ANTIALIAS = Image.ANTIALIAS
+    image = image.resize((scaled_width, scaled_height), ANTIALIAS)
     import io
-
     output = io.BytesIO()
     image.save(output, format="PNG")
     image_string = output.getvalue()


### PR DESCRIPTION
**Line 492: ANTIALIAS updated to Resampling.LANCZOS**

Removes the following Depreciation Warning:

`DeprecationWarning: ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). `
`Use Resampling.LANCZOS instead.`

---

```
   try:
        ANTIALIAS = Image.Resampling.LANCZOS
    except AttributeError:
        ANTIALIAS = Image.ANTIALIAS
    image = image.resize((scaled_width, scaled_height), ANTIALIAS)
```


Now Resampling.LANCZOS will be used unless it gives an AttributeError exception in which case it will revert back to using Image.ANTIALIAS.