### PR TITLE
[WIP] Fix path issue in torchgen.gen_backend_stubs

### DIFF
--- a/torchgen/gen_backend_stubs.py
+++ b/torchgen/gen_backend_stubs.py
@@ -533,9 +533,9 @@ def run(
     source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[str] = None
 ) -> None:
 
-    # Assumes that this file lives at PYTORCH_ROOT/torchgen/gen_backend_stubs.py
+    # Assumes that this file lives at torchgen/gen_backend_stubs.py
     pytorch_root = pathlib.Path(__file__).parent.parent.absolute()
-    template_dir = os.path.join(pytorch_root, "aten/src/ATen/templates")
+    template_dir = os.path.join(pytorch_root, "packaged/ATen/templates")
 
     def make_file_manager(install_dir: str) -> FileManager:
         return FileManager(
@@ -545,9 +545,9 @@ def run(
     fm = make_file_manager(output_dir)
 
     native_yaml_path = os.path.join(
-        pytorch_root, "aten/src/ATen/native/native_functions.yaml"
+        pytorch_root, "packaged/ATen/native/native_functions.yaml"
     )
-    tags_yaml_path = os.path.join(pytorch_root, "aten/src/ATen/native/tags.yaml")
+    tags_yaml_path = os.path.join(pytorch_root, "packaged/ATen/native/tags.yaml")
     parsed_yaml = parse_native_yaml(native_yaml_path, tags_yaml_path)
     native_functions, backend_indices = (
         parsed_yaml.native_functions,


### PR DESCRIPTION
### Issue Description
The path in `gen_backend_stubs` was the PyTorch source tree instead of the torchgen package which fails out of PyTorch source tree.
All the required file are mirrored to the `packaged` director of the torchgen. 
Fix the path to the correct location for extension to generate the code with `gen_backend_stubs`

