### PR TITLE
Sets CUDA_MODULE_LOADING to LAZY when not set by the user

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -53,6 +53,20 @@ void set_magma_init_fn(void (*fn)()) {
   magma_init_fn = fn;
 }
 
+// Sets the CUDA_MODULE_LOADING environment variable
+// if it's not set by the user.
+void maybe_set_cuda_module_loading(const std::string &def_value) {
+  auto value = std::getenv("CUDA_MODULE_LOADING");
+  if (!value) {
+#ifdef _WIN32
+    auto env_var = "CUDA_MODULE_LOADING=" + def_value;
+    _putenv(env_var.c_str());
+#else
+    setenv("CUDA_MODULE_LOADING", def_value.c_str(), 1);
+#endif
+  }
+}
+
 // NB: deleter is dynamic, because we need it to live in a separate
 // compilation unit (alt is to have another method in hooks, but
 // let's not if we don't need to!)
@@ -62,6 +76,7 @@ void CUDAHooks::initCUDA() const {
   // have a chance to enable vitals.
   at::vitals::VitalsAPI.setVital("CUDA", "used", "true", /* force = */ true);
 
+  maybe_set_cuda_module_loading("LAZY");
   const auto num_devices = c10::cuda::device_count_ensure_non_zero();
   c10::cuda::CUDACachingAllocator::init(num_devices);
   at::cuda::detail::init_p2p_access_cache(num_devices);

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -224,6 +224,8 @@ def _lazy_init():
                 "libcudart functions unavailable. It looks like you have a broken build?")
         # This function throws if there's a driver initialization error, no GPUs
         # are found or any other error occurs
+        if 'CUDA_MODULE_LOADING' not in os.environ:
+            os.environ['CUDA_MODULE_LOADING'] = 'LAZY'
         torch._C._cuda_init()
         # Some of the queued calls may reentrantly call _lazy_init();
         # we need to just return without initializing in that case.

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -310,8 +310,12 @@ def get_cachingallocator_config():
 
 
 def get_cuda_module_loading_config():
-    config = os.environ.get('CUDA_MODULE_LOADING', '')
-    return config
+    if TORCH_AVAILABLE and torch.cuda.is_available():
+        torch.cuda.init()
+        config = os.environ.get('CUDA_MODULE_LOADING', '')
+        return config
+    else:
+        return "N/A"
 
 
 def is_xnnpack_available():

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -32,6 +32,7 @@ SystemEnv = namedtuple('SystemEnv', [
     'python_platform',
     'is_cuda_available',
     'cuda_runtime_version',
+    'cuda_module_loading',
     'nvidia_driver_version',
     'nvidia_gpu_models',
     'cudnn_version',
@@ -307,6 +308,12 @@ def get_cachingallocator_config():
     ca_config = os.environ.get('PYTORCH_CUDA_ALLOC_CONF', '')
     return ca_config
 
+
+def get_cuda_module_loading_config():
+    config = os.environ.get('CUDA_MODULE_LOADING', '')
+    return config
+
+
 def is_xnnpack_available():
     if TORCH_AVAILABLE:
         import torch.backends.xnnpack
@@ -345,6 +352,7 @@ def get_env_info():
         is_cuda_available=cuda_available_str,
         cuda_compiled_version=cuda_version_str,
         cuda_runtime_version=get_running_cuda_version(run_lambda),
+        cuda_module_loading=get_cuda_module_loading_config(),
         nvidia_gpu_models=get_gpu_info(run_lambda),
         nvidia_driver_version=get_nvidia_driver_version(run_lambda),
         cudnn_version=get_cudnn_version(run_lambda),

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -391,6 +391,7 @@ Python version: {python_version}
 Python platform: {python_platform}
 Is CUDA available: {is_cuda_available}
 CUDA runtime version: {cuda_runtime_version}
+CUDA_MODULE_LOADING set to: {cuda_module_loading}
 GPU models and configuration: {nvidia_gpu_models}
 Nvidia driver version: {nvidia_driver_version}
 cuDNN version: {cudnn_version}


### PR DESCRIPTION
This PR sets CUDA_MODULE_LOADING if it's not set by the user. By default, it sets it to "LAZY".

It was tested using the following commands:
```
python -c "import torch; tensor=torch.randn(20, 16, 50, 100).cuda(); free, total = torch.cuda.cudart().cudaMemGetInfo(0); print(total-free)"
```
which shows a memory usage of: 287,047,680 bytes

vs

```
CUDA_MODULE_LOADING="DEFAULT" python -c "import torch; tensor=torch.randn(20, 16, 50, 100).cuda(); free, total = torch.cuda.cudart().cudaMemGetInfo(0); print(total-free)"
```
which shows 666,632,192 bytes. 

C++ implementation is needed for the libtorch users (otherwise it could have been a pure python functionality).

cc: @ptrblck @ngimel @malfet 