### PR TITLE
C++20 compatible changes

### DIFF
--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -39,6 +39,7 @@
 #include <type_traits>
 #include <utility>
 
+#include <c10/utils/C++17.h>
 #include <c10/util/Metaprogramming.h>
 
 C10_CLANG_DIAGNOSTIC_PUSH()
@@ -1238,7 +1239,7 @@ constexpr optional<X&> make_optional(std::reference_wrapper<X> v) {
 namespace std {
 template <typename T>
 struct hash<c10::optional<T>> {
-  typedef typename hash<T>::result_type result_type;
+  typedef c10::invoke_result_t<std::hash<T>, T> result_type;
   typedef c10::optional<T> argument_type;
 
   constexpr result_type operator()(argument_type const& arg) const {

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -39,7 +39,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <c10/utils/C++17.h>
+#include <c10/util/C++17.h>
 #include <c10/util/Metaprogramming.h>
 
 C10_CLANG_DIAGNOSTIC_PUSH()


### PR DESCRIPTION
`std::hash<T>::result_type` is deprecated since C++17 and removed in c++20, so use `c10::invoke_result_t` to define it

Fixes https://github.com/pytorch/pytorch/issues/85603
