### PR TITLE
[Pytorch][benchmark vulkan] Fix vulkan profiling

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -21,7 +21,7 @@ Context::Context(size_t adapter_i, const ContextConfig& config)
       fences_(device_),
 // Diagnostics
 #ifdef USE_VULKAN_GPU_DIAGNOSTICS
-      querypool_(device_, config_.queryPoolConfig),
+      querypool_(config_.queryPoolConfig, adapter_p_),
 #endif /* USE_VULKAN_GPU_DIAGNOSTICS */
       // Command buffer submission
       cmd_mutex_{},

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -57,6 +57,8 @@ class Context final {
   DescriptorPool descriptor_pool_;
   FencePool fences_;
   // Diagnostics
+  // TODO: remove USE_VULKAN_GPU_DIAGNOSTICS
+  bool enable_op_profiling_{false};
 #ifdef USE_VULKAN_GPU_DIAGNOSTICS
   QueryPool querypool_;
 #endif /* USE_VULKAN_GPU_DIAGNOSTICS */
@@ -75,6 +77,14 @@ class Context final {
 
   inline Adapter* adapter_ptr() {
     return adapter_p_;
+  }
+
+  inline void enable_op_profiling() {
+    enable_op_profiling_ = true;
+  }
+
+  inline bool op_profiling_enabled() {
+    return enable_op_profiling_;
   }
 
   inline VkDevice device() {
@@ -337,9 +347,12 @@ inline void Context::submit_copy(
   set_cmd();
 
 #ifdef USE_VULKAN_GPU_DIAGNOSTICS
-  std::string label = "cmd_copy";
-  uint32_t log_idx = querypool_.shader_profile_begin(
+  uint32_t log_idx = UINT32_MAX;
+  if (enable_op_profiling_) {
+    std::string label = "cmd_copy";
+    log_idx = querypool_.shader_profile_begin(
       cmd_, label, create_extent3d({0, 0, 0}), create_extent3d({0, 0, 0}));
+  }
 #endif /* USE_VULKAN_GPU_DIAGNOSTICS */
 
   cmd_.insert_barrier(pipeline_barrier);
@@ -347,7 +360,9 @@ inline void Context::submit_copy(
   record_copy(cmd_, source, destination, copy_range, src_offset, dst_offset);
 
 #ifdef USE_VULKAN_GPU_DIAGNOSTICS
-  querypool_.shader_profile_end(cmd_, log_idx);
+  if (enable_op_profiling_) {
+    querypool_.shader_profile_end(cmd_, log_idx);
+  }
 #endif /* USE_VULKAN_GPU_DIAGNOSTICS */
 
   submit_count_++;
@@ -382,11 +397,14 @@ inline void Context::submit_compute_job(
   set_cmd();
 
 #ifdef USE_VULKAN_GPU_DIAGNOSTICS
-  uint32_t log_idx = querypool_.shader_profile_begin(
-      cmd_,
-      shader_descriptor.kernel_name,
-      create_extent3d(global_work_group),
-      create_extent3d(local_work_group_size));
+  uint32_t log_idx = UINT32_MAX;
+  if (enable_op_profiling_) {
+    log_idx = querypool_.shader_profile_begin(
+        cmd_,
+        shader_descriptor.kernel_name,
+        create_extent3d(global_work_group),
+        create_extent3d(local_work_group_size));
+  }
 #endif /* USE_VULKAN_GPU_DIAGNOSTICS */
 
   // Factor out template parameter independent code to minimize code bloat.
@@ -403,7 +421,9 @@ inline void Context::submit_compute_job(
       cmd_, descriptor_set, pipeline_barrier, global_work_group);
 
 #ifdef USE_VULKAN_GPU_DIAGNOSTICS
-  querypool_.shader_profile_end(cmd_, log_idx);
+  if (enable_op_profiling_) {
+    querypool_.shader_profile_end(cmd_, log_idx);
+  }
 #endif /* USE_VULKAN_GPU_DIAGNOSTICS */
 
   submit_count_++;

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -351,7 +351,7 @@ inline void Context::submit_copy(
   if (enable_op_profiling_) {
     std::string label = "cmd_copy";
     log_idx = querypool_.shader_profile_begin(
-      cmd_, label, create_extent3d({0, 0, 0}), create_extent3d({0, 0, 0}));
+        cmd_, label, create_extent3d({0, 0, 0}), create_extent3d({0, 0, 0}));
   }
 #endif /* USE_VULKAN_GPU_DIAGNOSTICS */
 

--- a/aten/src/ATen/native/vulkan/api/QueryPool.cpp
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.cpp
@@ -2,6 +2,7 @@
 #include <ATen/native/vulkan/api/Utils.h>
 #include <ATen/native/vulkan/ops/Tensor.h>
 
+#include <cmath>
 #include <iostream>
 
 namespace at {
@@ -9,9 +10,16 @@ namespace native {
 namespace vulkan {
 namespace api {
 
-QueryPool::QueryPool(const VkDevice device, const QueryPoolConfig& config)
+namespace {
+  // On Mali gpus timestamp_period seems to return 0.
+  // For some reason when 52.08 is used op runtimes seem to make more sense
+  // TODO: Figure out what is special about 52.08
+  constexpr int64_t default_ns_per_tick = 52; // lround(52.08f);
+}
+
+QueryPool::QueryPool(const QueryPoolConfig& config, const Adapter* adapter_p)
     : mutex_{},
-      device_(device),
+      device_(adapter_p->device_handle()),
       config_(config),
       querypool_(VK_NULL_HANDLE),
       shader_log_{},
@@ -28,6 +36,10 @@ QueryPool::QueryPool(const VkDevice device, const QueryPoolConfig& config)
   VK_CHECK(vkCreateQueryPool(device_, &info, nullptr, &querypool_));
 
   shader_log_.reserve(config_.initialReserveSize);
+
+  TORCH_CHECK(adapter_p, "Valid GPU device must be created for QueryPool");
+  ns_per_tick_ = std::lround(adapter_p->timestamp_period());
+  ns_per_tick_ = (ns_per_tick_ == 0) ? default_ns_per_tick : ns_per_tick_;
 }
 
 QueryPool::~QueryPool() {
@@ -45,7 +57,7 @@ void QueryPool::reset(const CommandBuffer& cmd) {
   shader_log_.clear();
 }
 
-uint32_t QueryPool::write_timestamp(const CommandBuffer& cmd) {
+size_t QueryPool::write_timestamp(const CommandBuffer& cmd) {
   TORCH_CHECK(
       in_use_ < config_.maxQueryCount,
       "Vulkan QueryPool: Exceeded the maximum number of queries "
@@ -93,7 +105,7 @@ void QueryPool::shader_profile_end(
     const uint32_t log_idx) {
   std::lock_guard<std::mutex> lock(mutex_);
 
-  uint32_t query_idx = write_timestamp(cmd);
+  size_t query_idx = write_timestamp(cmd);
 
   shader_log_[log_idx].end_query_idx = query_idx;
 }
@@ -117,9 +129,8 @@ void QueryPool::extract_results() {
       flags)); // flags
 
   for (ShaderDuration& entry : shader_log_) {
-    entry.start_time_ns = query_data.at(entry.start_query_idx);
-    entry.end_time_ns = query_data.at(entry.end_query_idx);
-
+    entry.start_time_ns = query_data.at(entry.start_query_idx) * ns_per_tick_;
+    entry.end_time_ns = query_data.at(entry.end_query_idx) * ns_per_tick_;
     entry.execution_duration_ns = entry.end_time_ns - entry.start_time_ns;
   }
 }

--- a/aten/src/ATen/native/vulkan/api/QueryPool.cpp
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.cpp
@@ -11,11 +11,11 @@ namespace vulkan {
 namespace api {
 
 namespace {
-  // On Mali gpus timestamp_period seems to return 0.
-  // For some reason when 52.08 is used op runtimes seem to make more sense
-  // TODO: Figure out what is special about 52.08
-  constexpr int64_t default_ns_per_tick = 52; // lround(52.08f);
-}
+// On Mali gpus timestamp_period seems to return 0.
+// For some reason when 52.08 is used op runtimes seem to make more sense
+// TODO: Figure out what is special about 52.08
+constexpr int64_t default_ns_per_tick = 52; // lround(52.08f);
+} // namespace
 
 QueryPool::QueryPool(const QueryPoolConfig& config, const Adapter* adapter_p)
     : mutex_{},

--- a/aten/src/ATen/native/vulkan/api/QueryPool.h
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.h
@@ -37,7 +37,7 @@ struct ShaderDuration final {
 
 class QueryPool final {
  public:
-  explicit QueryPool(const VkDevice, const QueryPoolConfig&);
+  explicit QueryPool(const QueryPoolConfig&, const Adapter* adapter_p);
 
   QueryPool(const QueryPool&) = delete;
   QueryPool& operator=(const QueryPool&) = delete;
@@ -59,7 +59,7 @@ class QueryPool final {
   size_t in_use_;
 
  private:
-  uint32_t write_timestamp(const CommandBuffer&);
+  size_t write_timestamp(const CommandBuffer&);
 
   std::string generate_string_report();
 
@@ -80,6 +80,7 @@ class QueryPool final {
   void extract_results();
   void print_results();
   uint64_t get_total_op_ns(std::string op_name);
+  uint64_t ns_per_tick_;
   void shader_log_for_each(std::function<void(const ShaderDuration&)> fn);
 };
 

--- a/aten/src/ATen/test/vulkan_perf_test.cpp
+++ b/aten/src/ATen/test/vulkan_perf_test.cpp
@@ -63,6 +63,7 @@ static void add_op_benchmark(benchmark::State& state) {
   const auto in_vulkan2 = in_cpu2.vulkan();
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -112,6 +113,7 @@ static void add_op_q_benchmark(benchmark::State& state) {
       in_vulkan2, scale, zero_point, c10::ScalarType::QUInt8);
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -193,6 +195,7 @@ static void conv2d_op_benchmark(benchmark::State& state) {
       {weights.output_channels}, at::device(at::kCPU).dtype(at::kFloat));
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -295,6 +298,7 @@ static void conv2d_op_q_benchmark(benchmark::State& state) {
       in_vulkan1, scale, zero_point, c10::ScalarType::QUInt8);
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -385,6 +389,7 @@ static void conv2dpw_op_benchmark(benchmark::State& state) {
       {weights.output_channels}, at::device(at::kCPU).dtype(at::kFloat));
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -486,6 +491,7 @@ static void conv2dpw_op_q_benchmark(benchmark::State& state) {
       in_vulkan1, scale, zero_point, c10::ScalarType::QUInt8);
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -575,6 +581,7 @@ static void conv2ddw_op_benchmark(benchmark::State& state) {
       {weights.output_channels}, at::device(at::kCPU).dtype(at::kFloat));
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -675,6 +682,7 @@ static void conv2ddw_op_q_benchmark(benchmark::State& state) {
       in_vulkan1, scale, zero_point, c10::ScalarType::QUInt8);
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -730,6 +738,7 @@ static void sub_op_benchmark(benchmark::State& state) {
   const auto in_vulkan2 = in_cpu2.vulkan();
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -779,6 +788,7 @@ static void sub_op_q_benchmark(benchmark::State& state) {
       in_vulkan2, scale, zero_point, c10::ScalarType::QUInt8);
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -824,6 +834,7 @@ static void mul_op_benchmark(benchmark::State& state) {
   const auto in_vulkan2 = in_cpu2.vulkan();
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -873,6 +884,7 @@ static void mul_op_q_benchmark(benchmark::State& state) {
       in_vulkan2, scale, zero_point, c10::ScalarType::QUInt8);
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -918,6 +930,7 @@ static void div_op_benchmark(benchmark::State& state) {
   const auto in_vulkan2 = in_cpu2.vulkan();
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 
@@ -967,6 +980,7 @@ static void div_op_q_benchmark(benchmark::State& state) {
       in_vulkan2, scale, zero_point, c10::ScalarType::QUInt8);
 
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+  at::native::vulkan::api::context()->enable_op_profiling();
   at::native::vulkan::api::context()->reset_querypool();
 #endif
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #85715
* #85714
* __->__ #85713

This diff:
- adds interface to enable/disable profiling
- Fixes profiling bug where ticks measured by timestamp queries are not
  accounting for timestampPeriod.

Differential Revision: [D39449769](https://our.internmc.facebook.com/intern/diff/D39449769/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D39449769/)!