### PR TITLE
Update debug flag for vulkan

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Allocator.h
+++ b/aten/src/ATen/native/vulkan/api/Allocator.h
@@ -22,7 +22,7 @@
 
 #define VMA_STATS_STRING_ENABLED 0
 
-#ifdef DEBUG
+#ifdef VULKAN_DEBUG
 #define VMA_DEBUG_ALIGNMENT 4096
 #define VMA_DEBUG_ALWAYS_DEDICATED_MEMORY 0
 #define VMA_DEBUG_DETECT_CORRUPTION 1
@@ -39,7 +39,7 @@
     printf("\n"); \
 } while(false)
 */
-#endif /* DEBUG */
+#endif /* VULKAN_DEBUG */
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/aten/src/ATen/native/vulkan/api/Runtime.cpp
+++ b/aten/src/ATen/native/vulkan/api/Runtime.cpp
@@ -236,11 +236,11 @@ std::unique_ptr<Runtime> init_global_vulkan_runtime() {
 #endif /* USE_VULKAN_VOLK, USE_VULKAN_WRAPPER */
 
   const bool enableValidationMessages =
-#if defined(DEBUG)
+#if defined(VULKAN_DEBUG)
       true;
 #else
       false;
-#endif /* DEBUG */
+#endif /* VULKAN_DEBUG */
   const bool initDefaultDevice = true;
   const uint32_t numRequestedQueues = 1; // TODO: raise this value
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #85715
* #85714
* #85713

DEBUG is too generic name and when building some other target it seems to
conflict with it, so defining VULKAN_DEBUG

Differential Revision: [D39449772](https://our.internmc.facebook.com/intern/diff/D39449772/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D39449772/)!