### PR TITLE
Fix caffe2 test

### DIFF
--- a/caffe2/distributed/file_store_handler_op_test.py
+++ b/caffe2/distributed/file_store_handler_op_test.py
@@ -5,14 +5,14 @@
 
 import errno
 import os
-import tempfile
 import shutil
+import tempfile
 
 from caffe2.distributed.python import StoreHandlerTimeoutError
 from caffe2.distributed.store_ops_test_util import StoreOpsTests
-from caffe2.python import core, workspace, dyndep
+from caffe2.python import core, dyndep, workspace
 from caffe2.python.test_util import TestCase
-
+import common.thread_safe_fork  # noqa: F401
 dyndep.InitOpsLibrary("@/caffe2/caffe2/distributed:file_store_handler_ops")
 dyndep.InitOpsLibrary("@/caffe2/caffe2/distributed:store_ops")
 


### PR DESCRIPTION
Summary:
thsi test is failing blaming my diff: https://www.internalfb.com/intern/test/562949956474510/
followed  https://fb.workplace.com/groups/koski.users/permalink/5811736972171470/ suggestion

Test Plan:
```
[aidana@devvm2509.cln0 ~/fbsource/fbcode (0ae71702c)]$ buck1 test mode/opt-split-dwarf //caffe2/caffe2/distributed:file_store_handler_ops_test -- --exact 'caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp)' --run-disabled --jobs 18 --stress-runs 10 --record-results

Invalidating internal cached state: Buck configuration options changed between invocations. This may cause slower builds.
  Changed value //cache.cache_cas_host='buildinfra-buckcache-dc-l7-prod.inter...' (was 'buildinfra-buckcache-prod.internal.tf...')
Parsing buck files: finished in 31.9 sec
Creating action graph: finished in 26.8 sec
Building: finished in 44.7 sec (100%) 15449/15449 jobs, 0/15449 updated
  Total time: 01:43.4 min
More details at https://www.internalfb.com/intern/buck/build/8df3039d-8d68-47e8-90d9-9c4c85382ef2
BUILD SUCCEEDED
Tpx test run coordinator for Meta. See https://fburl.com/tpx for details.
Running with tpx session id: f17e661d-f6db-4743-82b5-b6201076b11d
Trace available for this run at /tmp/tpx-20220927-065213.416126-f17e661d-f6db-4743-82b5-b6201076b11d/trace.log
RemoteExecution session id: reSessionID-f17e661d-f6db-4743-82b5-b6201076b11d-tpx
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/5348024685406637
    ✓ ListingSuccess: caffe2/caffe2/distributed:file_store_handler_ops_test : 2 tests discovered (2.238)
    ✓ Pass: caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp) (2.538)
    ✓ Pass: caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp) (2.734)
    ✓ Pass: caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp) (2.808)
    ✓ Pass: caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp) (2.808)
    ✓ Pass: caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp) (2.808)
    ✓ Pass: caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp) (2.809)
    ✓ Pass: caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp) (2.809)
    ✓ Pass: caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp) (2.810)
    ✓ Pass: caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp) (2.831)
    ✓ Pass: caffe2/caffe2/distributed:file_store_handler_ops_test - test_set_get (caffe2.caffe2.distributed.file_store_handler_op_test.TestFileStoreHandlerOp) (2.810)
Summary
  Pass: 10
  ListingSuccess: 1
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/5348024685406637
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
```

Reviewed By: motanvfb

Differential Revision: D39822669



cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu