### PR TITLE
TestModule: Don't assume sample inputs version counter is zero

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -282,9 +282,10 @@ class TestModule(TestCase):
             # === Check that the inplace operation gives the same result ===
             input_arg_copy = deepcopy(input_args)
             input_arg_clone = tuple(i.clone() for i in input_arg_copy)
+            input_clone_version = input_arg_clone[0]._version
             with freeze_rng_state():
                 output_ip = m_inplace(*input_arg_clone, **input_kwargs)
-            self.assertNotEqual(input_arg_clone[0]._version, input_version)
+            self.assertGreater(input_arg_clone[0]._version, input_clone_version)
             self.assertEqual(output_op, output_ip)
 
             # === Check that the gradients are the same ===


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #85473
* __->__ #85734

The intention of this assert is to check the input tensor's version
counter has increased, indicating it was mutated by `m_inplace`.
However, the cloning step to create `input_arg_clone` restarts the
version counter to zero, so this test may fail if the sample input
was ever mutated during its creation.