### PR TITLE
move functionalize out of experimental namespace

### DIFF
--- a/functorch/__init__.py
+++ b/functorch/__init__.py
@@ -15,7 +15,7 @@ from . import _C
 # functorch transforms
 from ._src.vmap import vmap
 from ._src.eager_transforms import (
-    grad, grad_and_value, vjp, jacrev, jvp, jacfwd, hessian,
+    grad, grad_and_value, vjp, jacrev, jvp, jacfwd, hessian, functionalize
 )
 from ._src.python_key import make_fx
 

--- a/functorch/docs/source/experimental.rst
+++ b/functorch/docs/source/experimental.rst
@@ -8,5 +8,3 @@ Experimental Function Transforms
 .. autosummary::
     :toctree: generated
     :nosignatures:
-
-    functionalize

--- a/functorch/docs/source/functorch.rst
+++ b/functorch/docs/source/functorch.rst
@@ -17,6 +17,7 @@ Function Transforms
     jacrev
     jacfwd
     hessian
+    functionalize
 
 Utilities for working with torch.nn.Modules
 -------------------------------------------

--- a/functorch/experimental/__init__.py
+++ b/functorch/experimental/__init__.py
@@ -1,4 +1,5 @@
 from .batch_norm_replacement import replace_all_batch_norm_modules_
 # PyTorch forward-mode is not mature yet
-from .._src.eager_transforms import jvp, jacfwd, hessian, functionalize
+from .._src.eager_transforms import jvp, jacfwd, hessian
 from .._src.vmap import chunk_vmap
+from functorch import functionalize


### PR DESCRIPTION
Did a very quick sanity check - it looks like functorch docs don't get the nice preview link that pytofch-bot gives for normal pytorch docs, so I built locally and scanned `html/generated/functorch.functionalize.html`

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #85747
* __->__ #85742

