### PR TITLE
Upload to different path for pypi cudnn

### DIFF
--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -118,8 +118,6 @@ jobs:
             echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
           fi
       - name: Upload binaries
-        # Please note this is temporary disabling of uploading pypi cudnn wheel to our wheels repo
-        if: ${{ !contains(inputs.build_name, 'with-pypi-cudnn') }}
         env:
           PKG_DIR: "${{ runner.temp }}/artifacts"
           UPLOAD_SUBFOLDER: "${{ env.DESIRED_CUDA }}"
@@ -127,5 +125,9 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws-pytorch-uploader-secret-access-key }}
           ANACONDA_API_TOKEN: ${{ secrets.conda-pytorchbot-token }}
+          BUILD_NAME: ${{ inputs.build_name }}
         run: |
+            if [[ ${BUILD_NAME} == *with-pypi-cudnn* ]]; then
+              export UPLOAD_SUBFOLDER="${UPLOAD_SUBFOLDER}_pypi_cudnn"
+            fi
             bash .circleci/scripts/binary_upload.sh


### PR DESCRIPTION
We want to upload pypi cudnn builds to a different download folder something like cu117_pypi_cudnn
