### PR TITLE
[ONNX] Fix reduce node shape inference

### DIFF
--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -268,6 +268,20 @@ class TestONNXShapeInference(common_utils.TestCase):
         )
         self.run_test(g, resize.node(), expect_tensor("Float", shape=(4, 32, 128, 128)))
 
+    def test_reduce_prod_with_axes(self):
+        g = self.create_empty_graph()
+        input = g.addInput()
+        input.setType(input.type().with_dtype(torch.long).with_sizes([2]))
+        reduce_prod = g.op("ReduceProd", input, axes_i=[0])
+        self.run_test(g, reduce_prod.node(), expect_tensor("Long", shape=(1,)))
+
+    def test_reduce_prod_without_axes(self):
+        g = self.create_empty_graph()
+        input = g.addInput()
+        input.setType(input.type().with_dtype(torch.long).with_sizes([2]))
+        reduce_prod = g.op("ReduceProd", input)
+        self.run_test(g, reduce_prod.node(), expect_tensor("Long", shape=(1,)))
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -886,7 +886,7 @@ void ProcessReduceNode(Node* n) {
     if (!n->hasAttributeS("axes")) {
       std::iota(axes_vector.begin(), axes_vector.end(), 0);
     } else {
-      std::vector<int64_t> axes_vector = n->is(attr::axes);
+      axes_vector = n->is(attr::axes);
     }
     for (auto idx : c10::irange(axes_vector.size())) {
       if (axes_vector[idx] < 0) {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -882,17 +882,18 @@ void ProcessReduceNode(Node* n) {
     auto input_shape_value_0 = input_shape_0.value().sizes();
     size_t rank_0 = input_shape_value_0.value().size();
     std::vector<::c10::ShapeSymbol> final_shape;
+    std::vector<int64_t> axes_vector(rank_0);
     if (!n->hasAttributeS("axes")) {
-      UpdateShape(n->output(0), c10::SymbolicShape(final_shape));
-      return;
+      std::iota(axes_vector.begin(), axes_vector.end(), 0);
+    } else {
+      std::vector<int64_t> axes_vector = n->is(attr::axes);
     }
-    final_shape.reserve(rank_0);
-    std::vector<int64_t> axes_vector = n->is(attr::axes);
     for (auto idx : c10::irange(axes_vector.size())) {
       if (axes_vector[idx] < 0) {
         axes_vector[idx] += rank_0;
       }
     }
+    final_shape.reserve(rank_0);
     // ONNX keepdims defaults to 1 when not set.
     int64_t keepdims = 1;
     if (n->hasAttributeS("keepdims")) {


### PR DESCRIPTION
Fix logic in `ProcessReduceNode`. Previously a scalar was assigned for output shape of reduce nodes
when `axes` attribute was not provided, regardless of the value of `keepdims_i` attribute. Hence it is 
incorrectly assuming all output axes should be folded. 
Since input rank is known, this fix populates axes to be `[0, 1, ..., input_rank - 1]` if axes is not
provided.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #85765

