### PR TITLE
Update `ncclResult`

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -41,6 +41,10 @@ ncclResult_t to_nccl_result(torch::cuda::nccl::ncclResult var) {
       return ncclResult_t::ncclInvalidArgument;
     case torch::cuda::nccl::ncclResult::InvalidUsage:
       return ncclResult_t::ncclInvalidUsage;
+    case torch::cuda::nccl::ncclResult::RemoteError:
+      return ncclResult_t::ncclRemoteError;
+    case torch::cuda::nccl::ncclResult::InProgress:
+      return ncclResult_t::ncclInProgress;
     case torch::cuda::nccl::ncclResult::NumResults:
       return ncclResult_t::ncclNumResults;
     default:
@@ -62,6 +66,10 @@ torch::cuda::nccl::ncclResult from_nccl_result(ncclResult_t var) {
       return torch::cuda::nccl::ncclResult::InvalidArgument;
     case ncclInvalidUsage:
       return torch::cuda::nccl::ncclResult::InvalidUsage;
+    case ncclRemoteError:
+      return torch::cuda::nccl::ncclResult::RemoteError;
+    case ncclInProgress:
+      return torch::cuda::nccl::ncclResult::InProgress;
     case ncclNumResults:
       return torch::cuda::nccl::ncclResult::NumResults;
     default:

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -47,7 +47,9 @@ enum class ncclResult {
   InternalError = 3,
   InvalidArgument = 4,
   InvalidUsage = 5,
-  NumResults = 6
+  RemoteError = 6,  // added in 2.13.4
+  InProgress = 7,  // added in 2.14.3
+  NumResults = 8
 };
 
 /* Reduction operation selector */

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -43,6 +43,14 @@ std::string getNcclErrorDetailStr(ncclResult_t error, c10::optional<std::string>
     case ncclInvalidUsage:
       interpret = "ncclInvalidUsage: This usually reflects invalid usage of NCCL library.";
       break;
+    case ncclRemoteError:
+      interpret = "ncclRemoteError: A network error or a remote process exiting prematurely.";
+      break;
+    // NOTE(crcrpar): This should not been accessed until `ncclCommInitRankConfig` is integrated.
+    //   See: https://docs.nvidia.com/deeplearning/nccl/archives/nccl_2143/user-guide/docs/usage/communicators.html#creating-a-communication-with-options
+    case ncclInProgress:
+      interpret = "ncclInProgress: A NCCL operation on the communicator is being enqueued and is being processed in the background.";
+      break;
     default:
       interpret = "Unknown NCCL error!";
   }


### PR DESCRIPTION
Adding

- ncclResult_t::ncclRemoteError <- [2.13.4](https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-13-4.html#rel_2-13-4)
- ncclResult_t::ncclInProgress  <- [2.14.3](https://docs.nvidia.com/deeplearning/nccl/archives/nccl_2143/user-guide/docs/api/types.html#ncclresult-t)

to `torch::cuda::nccl::ncclResult` to be on the same page as the current submodule nccl: (ref: https://github.com/NVIDIA/nccl/blob/f89fd4777d2ef9229c039ff750ae21da01626f52/src/nccl.h.in#L34-L43).