### PR TITLE
[Profiler] Optimizer param_groups (part 3 of Record Optimizer)

### DIFF
--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -269,6 +269,31 @@ class Callsite {
   Config<CallType::PyCall>::key_t caller_;
 };
 
+void check_and_store(
+    const pybind11::handle& name,
+    const pybind11::handle& param,
+    std::vector<std::pair<std::basic_string<char>, void*>>& storeroom) {
+  auto t = param.ptr();
+  if (py::isinstance<py::str>(name) && THPVariable_CheckExact(t)) {
+    auto storage = THPVariable_Unpack(t).storage().unsafeGetStorageImpl();
+    if (storage) {
+      storeroom.emplace_back(name.cast<std::string>(), storage->data());
+    }
+  }
+}
+
+void check_and_store(
+    const pybind11::handle& param,
+    std::vector<void*>& storeroom) {
+  auto t = param.ptr();
+  if (THPVariable_CheckExact(t)) {
+    auto storage = THPVariable_Unpack(t).storage().unsafeGetStorageImpl();
+    if (storage) {
+      storeroom.emplace_back(storage->data());
+    }
+  }
+}
+
 // ============================================================================
 // == Type specific store and load implementations. ===========================
 // ============================================================================
@@ -358,13 +383,7 @@ void ValueCache::store<CallType::PyModuleCall>(
     py::dict params = py::handle((PyObject*)key).attr("_parameters");
     std::vector<std::pair<std::string, void*>> params_;
     for (auto& it : params) {
-      auto t = it.second.ptr();
-      if (py::isinstance<py::str>(it.first) && THPVariable_CheckExact(t)) {
-        auto storage = THPVariable_Unpack(t).storage().unsafeGetStorageImpl();
-        if (storage) {
-          params_.emplace_back(it.first.cast<std::string>(), storage->data());
-        }
-      }
+      check_and_store(it.first, it.second, params_);
     }
     cache.modules_and_params_[key] = make_pair(cls, params_);
   }
@@ -396,6 +415,13 @@ void ValueCache::store<CallType::PyOptimizerCall>(
     py::list param_groups_handle =
         py::handle((PyObject*)key).attr("param_groups");
     std::vector<void*> params_;
+    // param_groups is a list of dict
+    for (auto& param_group : param_groups_handle) {
+      for (auto& param :
+           py::cast<py::dict>(param_group).attr("get")("params")) {
+        check_and_store(param, params_);
+      }
+    }
     std::vector<std::pair<std::string, void*>> states_;
 
     cache.optimizer_data_[key] = {cls, params_, states_};

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -175,8 +175,17 @@ void initPythonBindings(PyObject* module) {
           "cls_name", [](const NNModuleInfo& s) { return s.cls_name_.str(); });
 
   py::class_<OptimizerInfo>(m, "_OptInfo")
-      .def_property_readonly("self", [](const OptimizerInfo& a) {
-        return reinterpret_cast<intptr_t>(a.self_.value_of());
+      .def_property_readonly(
+          "self",
+          [](const OptimizerInfo& a) {
+            return reinterpret_cast<intptr_t>(a.self_.value_of());
+          })
+      .def_property_readonly("param_addrs", [](const OptimizerInfo& s) {
+        py::list params_addrs;
+        for (auto& addr : s.params_addr_) {
+          params_addrs.append(reinterpret_cast<intptr_t>(addr));
+        }
+        return params_addrs;
       });
 
   py::class_<ExtraFields<EventType::PyCall>>(m, "_ExtraFields_PyCall")


### PR DESCRIPTION
Summary:
- use TensorMetadata struct
- check_and_store util as overloading
- param_groups
- clean up unit test cases

Test Plan: buck run mode/opt //caffe2/test:profiler

Reviewed By: chaekit

Differential Revision: D39406072

