### PR TITLE
[JIT] update error message when a type cannot be inferred

### DIFF
--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -507,14 +507,10 @@ inline InferredType tryToInferContainerType(py::handle input) {
     }
     return InferredType(ListType::create(element_type));
   } else {
-    // TODO: this message is not correct anymore, since this InferredType is
-    // used from a bunch of circumstances unrelated to tracing. We can re-use
-    // this instead of the attribute_failure stuff in concreteType
     return InferredType(c10::str(
-        "Only tensors and (possibly nested) tuples of tensors, lists, or dicts",
-        "are supported ",
-        "as inputs or outputs of traced functions",
-        ", but instead got value of type ",
+        "TorchScript tried to infer the type of an object, but it doesn't ",
+        "support automatic type inference of this type of object. The ",
+        "reported type of this object is ",
         py::str(input.get_type().attr("__name__")),
         "."));
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #85785

This error can be observed in non-tracing scenarios; the new error
message is probably less confusing, although ideally it would be great
if we could dump additional information about what's actually getting
scripted at the time when this failure occurs.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel