### PR TITLE
Don't make parameters have symbolic shapes

### DIFF
--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -142,20 +142,24 @@ class MetaConverter:
         arg_cnt = self.arg_cnt
         self.arg_cnt += 1
 
+        # Don't make parameters have symbolic shapes; they are assumed to stay
+        # constant size across training runs
+        make_symbolic = shape_env is not None and not isinstance(t, torch.nn.Parameter)
+
         def sym(name, x):
-            if shape_env is None:
-                return x
-            else:
+            if make_symbolic:
                 return shape_env.create_symint(f"t{arg_cnt}.{name}()", x)
+            else:
+                return x
 
         def sym_list(name, xs):
-            if shape_env is None:
-                return xs
-            else:
+            if make_symbolic:
                 return [
                     shape_env.create_symint(f"t{arg_cnt}.{name}({i})", x)
                     for i, x in enumerate(xs)
                 ]
+            else:
+                return xs
 
         def sym_size(t):
             return sym_list("size", t.size())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #85809

Parameters won't change size across iterations of the
training loop, so this is a cost-free optimization that
avoids us having to do symbolic math over parameters.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>