### PR TITLE
Add a way to skip lowering to nvprims

### DIFF
--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -166,6 +166,9 @@ class TestPrims(TestCase):
             "while there exists nvfuser implementations for them.")
 
     def test_skip_ops_nvfuser_prims_mode(self, device):
+        # This test verifies that the NvfuserPrimsMode skips the specified
+        # functions. Skipping a function means that it's not converted into
+        # nvprims counterparts.
         from torch._prims.context import NvfuserPrimsMode
 
         a = torch.randn(5, 5, device=device)
@@ -187,6 +190,10 @@ class TestPrims(TestCase):
         self.assertFalse(include_any_nvprims_sin)
 
     def test_skip_ops_nvfuser_capability_mode(self, device):
+        # This test verifies that the NvfuserCapabilityMode skips the specified
+        # functions. Skipping a function means that specific
+        # reference/decomposition is not traced and there's no attempt to lower
+        # it to nvprims.
         from torch._prims.context import TorchRefsNvfuserCapabilityMode
 
         a = torch.randn(5, 5, device=device)

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -171,7 +171,7 @@ class TestPrims(TestCase):
         # nvprims counterparts.
         from torch._prims.context import NvfuserPrimsMode
 
-        a = torch.randn(5, 5, device=device)
+        a = make_tensor(5, 5, device=device, dtype=torch.float32)
 
         def func(a):
             return torch.ops.prims.sin.default(a)
@@ -196,7 +196,7 @@ class TestPrims(TestCase):
         # it to nvprims.
         from torch._prims.context import TorchRefsNvfuserCapabilityMode
 
-        a = torch.randn(5, 5, device=device)
+        a = make_tensor(5, 5, device=device, dtype=torch.float32)
 
         def func(a):
             return torch.sin(a)

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -790,10 +790,11 @@ class TestDecomp(TestCase):
 
         from torch._prims.context import TorchRefsNvfuserCapabilityMode, _is_func_unsupported_nvfuser
         from torch.fx.experimental.proxy_tensor import make_fx
-        op = torch._decomp.decomposition_table.get(torch.ops.aten.leaky_relu_backward.default)
+        op = torch.ops.aten.leaky_relu_backward.default
+        op_decomp = torch._decomp.decomposition_table.get(op)
 
         def fn0(*arg):
-            return _is_func_unsupported_nvfuser(TorchRefsNvfuserCapabilityMode(), op, arg, {})
+            return _is_func_unsupported_nvfuser(TorchRefsNvfuserCapabilityMode(), op, op_decomp, arg, {})
 
         def fn1(x):
             x = x * 2

--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -129,6 +129,8 @@ class NvfuserPrimsMode(torch.overrides.TorchFunctionMode):
         if kwargs is None:
             kwargs = {}
 
+        # If the function is in the skip list, then we don't want to
+        # remap it to the nvprims.
         if torch.overrides.resolve_name(orig_func) in self.skip_ops:
             return orig_func(*args, **kwargs)
 

--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -106,6 +106,14 @@ class NvfuserPrimsMode(torch.overrides.TorchFunctionMode):
 
     By default, this context manager will fall back on the torch.ops.prims* if the
     nvprim does not exist.
+    It's possible to skip certain prims by passing their names to the skip_ops
+    argument. skip_ops is expected to be a sequence of strings, e.g.,
+    ["prims.add.default"] In order to check the expected name of a prim, one can
+    use the `torch.overrides.resolve_name`.
+
+    >>> # xdoctest: +SKIP("undefined vars")
+    >>> with NvfuserPrimsMode(skips_ops=("prims.add.default")):
+    ...     torch.ops.prims.add.default(x, y)  # does not call torch.ops.nvprims.add.default(x, y)
     """
 
     def __init__(self, *, skip_ops=()):

--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -219,6 +219,24 @@ def _is_node_supported_nvfuser(node):
 def _is_func_unsupported_nvfuser(
     torch_function_mode, orig_func, func, args, kwargs, *, skip_ops=()
 ):
+    """
+    This function traces the `func` under `torch_function_mode` and checks if
+    any of the traced nodes are not supported by nvFuser. If so, we should
+    fallback to the original function.
+
+    `skip_ops` argument is expected to be a list of strings of function names
+    that would match with `torch.overrides.resolve_name`.
+
+    Args:
+        torch_function_mode: The torch_function_mode context manager. orig_func:
+        The original function, its name will be used to check if
+                   it should be skipped.
+        func: The function to be traced. args: The args to be passed to the
+        function. kwargs: The kwargs to be passed to the function.
+    Keyword args:
+        skip_ops: A list of ops to skip when checking if the function is
+        supported.
+    """
     # One supported case is easy to check: if the resolved name of the original
     # function in the skip list, skip it.
     if torch.overrides.resolve_name(orig_func) in skip_ops:

--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -108,6 +108,9 @@ class NvfuserPrimsMode(torch.overrides.TorchFunctionMode):
     nvprim does not exist.
     """
 
+    def __init__(self, *, skip_ops=()):
+        self.skip_ops = skip_ops
+
     def __torch_function__(
         self,
         orig_func: Callable,
@@ -117,6 +120,10 @@ class NvfuserPrimsMode(torch.overrides.TorchFunctionMode):
     ):
         if kwargs is None:
             kwargs = {}
+
+        if torch.overrides.resolve_name(orig_func) in self.skip_ops:
+            return orig_func(*args, **kwargs)
+
         if isinstance(orig_func, torch._ops.OpOverload) or isinstance(
             orig_func, torch._ops.OpOverloadPacket
         ):

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1696,7 +1696,7 @@ def resolve_name(f):
         Name of the function; if eval'ed it should give back the input
         function.
     """
-    if isinstance(f, torch._ops.OpOverload):
+    if isinstance(f, torch._ops.OpOverload) or isinstance(f, torch._ops.OpOverloadPacket):
         return str(f)
     return _get_overridable_functions()[1].get(f)
 


### PR DESCRIPTION
This PR adds `skip_ops` argument to `TorchRefsNvfuserCapabilityMode` and `NvfuserPrimsMode` which is an iterable of function names to be skipped in the translation to nvprims process.
