### PR TITLE
Hotfix for S298125

### DIFF
--- a/aten/src/ATen/native/metal/ops/MetalConcat.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConcat.mm
@@ -16,13 +16,11 @@ namespace at {
 namespace native {
 namespace metal {
 
-Tensor cat_batch(const TensorList tensors, MetalTensorImplStorage& mt) {
-  at::Tensor tensor = tensors[0];
+Tensor cat_batch(const Tensor& tensor, ITensorListRef tensors, MetalTensorImplStorage& mt) {
   MetalCommandBuffer* commandBuffer = getCommandBuffer(tensor);
   MPSImage* Y = mt.texture()->image();
   ushort cat_dim4_pointer = 0;
-  for (int i = 0; i < tensors.size(); ++i) {
-    const auto& t = tensors[i];
+  for (const auto& t : tensors) {
     MPSImage* X = imageFromTensor(t);
     MetalCommandBuffer* Xcb = getCommandBuffer(t);
     TORCH_CHECK(
@@ -55,8 +53,7 @@ Tensor cat_batch(const TensorList tensors, MetalTensorImplStorage& mt) {
   return output;
 }
 
-Tensor cat_feature(const TensorList tensors, MetalTensorImplStorage& mt) {
-  at::Tensor tensor = tensors[0];
+Tensor cat_feature(const Tensor& tensor, ITensorListRef tensors, MetalTensorImplStorage& mt) {
   MetalCommandBuffer* commandBuffer = getCommandBuffer(tensor);
   MPSImage* Y = mt.texture()->image();
   ushort channel_offset = 0;
@@ -68,9 +65,9 @@ Tensor cat_feature(const TensorList tensors, MetalTensorImplStorage& mt) {
   tt.texture()->allocateTemporaryStorage(temp_size, commandBuffer);
   MPSImage* T = tt.texture()->image();
 
-  for (int i = 0; i < tensors.size(); ++i) {
-    MPSImage* X = imageFromTensor(tensors[i]);
-    MetalCommandBuffer* Xcb = getCommandBuffer(tensors[i]);
+  for (const auto& t : tensors) {
+    MPSImage* X = imageFromTensor(t);
+    MetalCommandBuffer* Xcb = getCommandBuffer(t);
     TORCH_CHECK(
         [commandBuffer isEqual:Xcb],
         @"inputs have different Metal command buffers");
@@ -165,15 +162,15 @@ Tensor cat_feature(const TensorList tensors, MetalTensorImplStorage& mt) {
   return output;
 }
 
-Tensor cat(const TensorList tensors, int64_t dim) {
+Tensor cat(ITensorListRef tensors, int64_t dim) {
   TORCH_CHECK(
       dim == 0 || dim == 1,
       "Metal cat is implemented only for batch dimension");
   int64_t cat_dim_size = 0;
-  at::Tensor tensor = tensors[0];
+  TORCH_CHECK(!tensors.empty(), "cat expected a non-empty list of Tensor");
+  at::Tensor tensor = *tensors.begin();
   MetalCommandBuffer* commandBuffer = getCommandBuffer(tensor);
-  for (int i = 0; i < tensors.size(); ++i) {
-    const auto& t = tensors[i];
+  for (const auto& t : tensors) {
     TORCH_CHECK(t.dim() == 4, "Metal cat expects 4 dimensional inputs");
     TORCH_CHECK(t.is_metal(), "Metal cat expects metal tensors");
 
@@ -197,9 +194,9 @@ Tensor cat(const TensorList tensors, int64_t dim) {
   mt.texture()->allocateTemporaryStorage(result_size, commandBuffer);
 
   if (dim == 1) {
-    return cat_feature(tensors, mt);
+    return cat_feature(tensor, tensors, mt);
   }
-  return cat_batch(tensors, mt);
+  return cat_batch(tensor, tensors, mt);
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {


### PR DESCRIPTION
Summary:
Crash error is:

```
Mismatch in kernel C++ signatures

operator: aten::cat

no debug info

kernel 1: FN2at6TensorEN3c108ArrayRefIS0_EExE

dispatch key: Metal

registered at buck-out/gen/a1f97bbb/fbobjc/Libraries/FBPyTorchCore/torch_core_ig_ops_metal/aten/src/ATen/native/metal/ops/MetalConcat.mm:205

kernel 2: FN2at6TensorERKN3c108IListRefIS0_EExE

dispatch key: CPU

registered at buck-out/gen/a1f97bbb/fbobjc/Libraries/FBPyTorchCore/torch_core_ig_ops_aten/RegisterCPU.cpp:29749

Exception raised from registerKernel at xplat/caffe2/aten/src/ATen/core/dispatch/OperatorEntry.cpp:130 (most recent call first):
```

We fix it by changing the Metal kernel to take an IListRef instead of an ArrayRef.

Test Plan: Build igios per https://www.internalfb.com/intern/wiki/IOS_On_Demand/iOS_On_Demand_Use_Guide/ and show it doesn't crash

Differential Revision: D39888394

