### PR TITLE
[xnnpack][lite-int][graph-build] graph passes and op checking

### DIFF
--- a/test/jit/xnnpack/test_xnnpack_delegate.py
+++ b/test/jit/xnnpack/test_xnnpack_delegate.py
@@ -67,3 +67,37 @@ class TestXNNPackBackend(unittest.TestCase):
             }
         )
         lowered(torch.zeros(1))
+
+    def test_xnnpack_unsupported(self):
+        class AddSpliceModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                z = x + y[:, :, 1, :]
+                return z
+
+        sample_inputs = (torch.rand(1, 512, 512, 3), torch.rand(1, 512, 512, 3))
+        sample_output = torch.zeros(1, 512, 512, 3)
+
+        error_msg = (
+            "the module contains the following unsupported ops:\n"
+            "aten::select\n"
+            "aten::slice\n"
+        )
+
+        add_module = torch.jit.script(AddSpliceModule())
+        with self.assertRaisesRegex(
+            RuntimeError,
+            error_msg,
+        ):
+            _ = torch._C._jit_to_backend(
+                "xnnpack",
+                add_module,
+                {
+                    "forward": {
+                        "inputs" : [sample_inputs[0], sample_inputs[1]],
+                        "outputs": [sample_output]
+                    }
+                }
+            )

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_preprocess.cpp
@@ -6,6 +6,7 @@
 #include <xnnpack.h>
 
 #include <ATen/core/List.h>
+#include <torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h>
 
 namespace torch {
 namespace jit {
@@ -82,6 +83,10 @@ c10::IValue preprocess(
     graph->inputs()[0]->setType(TensorType::create(inp.toTensor()));
     example_inputs.emplace_back(inp.toTensor());
   }
+
+  // inp above has been confirmed to be either Tensor or TensorList
+  XNNGraph graph_builder;
+  graph_builder.buildXNNGraph(graph, example_inputs);
 
   compiled.insert("Answer", at::empty({1}, c10::ScalarType::Float));
 

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
@@ -1,0 +1,69 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <caffe2/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h>
+#include <torch/csrc/jit/runtime/graph_iterator.h>
+#include <xnnpack.h>
+
+// graph passes
+#include <torch/csrc/jit/passes/constant_propagation.h>
+#include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/passes/frozen_graph_optimizations.h>
+#include <torch/csrc/jit/passes/lower_tuples.h>
+#include <torch/csrc/jit/passes/remove_mutation.h>
+#include <torch/csrc/jit/runtime/jit_trace.h>
+#include <torch/csrc/jit/tensorexpr/graph_opt.h>
+
+
+namespace torch {
+namespace jit {
+namespace xnnpack {
+namespace delegate {
+
+std::shared_ptr<torch::jit::Graph> XNNGraph::optimizeAndTraceGraph(
+    std::shared_ptr<torch::jit::Graph> graph,
+    std::vector<c10::IValue>& example_inputs) {
+
+  graph = tensorexpr::removeUnusedSelfArgument(graph);
+  OptimizeFrozenGraph(graph, true);
+  RemoveListMutation(graph);
+  RemoveTensorMutation(graph);
+  LowerAllTuples(graph);
+  ConstantPropagation(graph);
+  graph = TraceGraph(graph, example_inputs);
+
+  return graph;
+}
+
+void XNNGraph::buildXNNGraph(
+    std::shared_ptr<torch::jit::Graph>& graph,
+    std::vector<c10::IValue> example_inputs) {
+  graph = optimizeAndTraceGraph(graph, example_inputs);
+  checkOpsToDelegate(graph);
+}
+
+void XNNGraph::checkOpsToDelegate(std::shared_ptr<torch::jit::Graph>& graph) {
+  std::unordered_set<string> unsupported_ops;
+  DepthFirstGraphNodeIterator it(graph);
+  Node* node = nullptr;
+  while ((node = it.next()) != nullptr) {
+    switch (node->kind()) {
+      case prim::Constant:
+      case aten::add: {
+        break;
+      }
+      default: {
+        unsupported_ops.insert(node->kind().toDisplayString());
+      }
+    }
+  }
+  std::stringstream error;
+  for(auto itr = unsupported_ops.begin(); itr != unsupported_ops.end(); itr++){
+    error << *itr << std::endl;;
+  }
+  TORCH_CHECK(unsupported_ops.empty(), "the module contains the following unsupported ops:\n" + error.str());
+}
+
+} // namespace delegate
+} // namespace xnnpack
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h
@@ -1,0 +1,54 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#include <ATen/Functions.h>
+#include <ATen/Utils.h>
+#include <torch/torch.h>
+#include <xnnpack.h>
+#include <unordered_set>
+#include <vector>
+
+namespace torch {
+namespace jit {
+namespace xnnpack {
+namespace delegate {
+
+class XNNGraph {
+ private:
+  // xnn_subgraph
+  xnn_subgraph_t _subgraph_ptr;
+
+  // Graph passes for optimizing and tracing torchscript graph
+  // Essentially massaging the graph into a digestiable format for
+  // xnnpack graph lowering.
+  std::shared_ptr<torch::jit::Graph> optimizeAndTraceGraph(
+    std::shared_ptr<torch::jit::Graph> graph,
+    std::vector<c10::IValue>& example_inputs);
+
+  // Makes a pass through the graph and throws if any ops are unsupported
+  void checkOpsToDelegate(std::shared_ptr<torch::jit::Graph>& graph);
+
+ public:
+  XNNGraph() : _subgraph_ptr(nullptr) {
+    xnn_status status = xnn_initialize(/*allocator =*/nullptr);
+    TORCH_CHECK(xnn_status_success == status, "Failed to initialize xnnpack");
+  }
+
+  ~XNNGraph() {
+    xnn_deinitialize();
+    if(_subgraph_ptr != nullptr){
+      xnn_delete_subgraph(_subgraph_ptr);
+    }
+  }
+
+  void buildXNNGraph(
+      std::shared_ptr<torch::jit::Graph>& graph,
+      std::vector<c10::IValue> example_inputs);
+
+  void runGraphOnInputs(
+      std::vector<at::Tensor> tensor_inputs,
+      std::vector<at::Tensor> tensor_outputs);
+};
+
+} // namespace delegate
+} // namespace xnnpack
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Beginning of building the xnnpack graph from the torchscript IR. We first massage the torchscript graph using a few graph passes that perform things such as unused self argument removal and constant propagation.
This also performs tracing for us so that the model does not have to be prepped by tracing before being lowered by us.

The other check we perform is through the torchscript IR to identify any nodes that are not lowerable/supported, and throwing an error to spit out the specific nodes that are not lowerable.

Differential Revision: [D39838338](https://our.internmc.facebook.com/intern/diff/D39838338/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D39838338/)!

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel