### PR TITLE
Make launch check exit code depend on results

### DIFF
--- a/torch/testing/_internal/check_kernel_launches.py
+++ b/torch/testing/_internal/check_kernel_launches.py
@@ -160,4 +160,4 @@ def check_cuda_kernel_launches():
 
 if __name__ == "__main__":
     unsafe_launches = check_cuda_kernel_launches()
-    sys.exit(0)
+    sys.exit(0 if unsafe_launches == 0 else 1)


### PR DESCRIPTION
It is possible for code to land that doesn't check kernel launches for success (#85885) fixes such an issue.

I think setting the return code of the linter is the correct way of handling this.