### PR TITLE
Adopt ncclRemoteError

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -60,8 +60,8 @@ std::string ncclGetErrorWithVersion(ncclResult_t error) {
 // Provides additional detail into NCCL error codes based on when these are
 // thrown in the NCCL codebase.
 std::string getNcclErrorDetailStr(
-  ncclResult_t error,
-  c10::optional<std::string> processGroupFailureReason /* = c10::nullopt */
+    ncclResult_t error,
+    c10::optional<std::string> processGroupFailureReason /* = c10::nullopt */
 ) {
   // Prioritize failure reason provided by PG NCCL first, as it can abort
   // communicators when it encounters collective timeouts, etc.
@@ -78,9 +78,11 @@ std::string getNcclErrorDetailStr(
       interpret = "ncclUnhandledCudaError: Call to CUDA function failed.";
       break;
     case ncclSystemError:
-      interpret = "ncclSystemError: System call (e.g. socket, malloc) or external library call failed or device error. ";
+      interpret =
+          "ncclSystemError: System call (e.g. socket, malloc) or external library call failed or device error. ";
 #ifndef NCCL_REMOTE_ERROR
-      // Before ncclRemoteError was created, unexpected remote disconnect was categorized as ncclSystemError
+      // Before ncclRemoteError was created, unexpected remote disconnect was
+      // categorized as ncclSystemError
       interpret += "It can be also caused by unexpected exit of a remote peer.";
 #endif
       break;
@@ -91,11 +93,13 @@ std::string getNcclErrorDetailStr(
       interpret = "ncclInvalidArgument: Invalid value for an argument.";
       break;
     case ncclInvalidUsage:
-      interpret = "ncclInvalidUsage: This usually reflects invalid usage of NCCL library.";
+      interpret =
+          "ncclInvalidUsage: This usually reflects invalid usage of NCCL library.";
       break;
 #ifdef NCCL_REMOTE_ERROR
     case ncclRemoteError:
-      interpret = "ncclRemoteError: A call failed possibly due to a network error or a remote process exiting prematurely.";
+      interpret =
+          "ncclRemoteError: A call failed possibly due to a network error or a remote process exiting prematurely.";
       break;
 #endif
     default:

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -66,7 +66,7 @@ std::string getNcclErrorDetailStr(
   // Prioritize failure reason provided by PG NCCL first, as it can abort
   // communicators when it encounters collective timeouts, etc.
   if (processGroupFailureReason != c10::nullopt) {
-    return (*processGroupFailureReason).c_str();
+    return *processGroupFailureReason;
   }
   std::string interpret;
   std::string err;

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -16,8 +16,10 @@
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && defined(NCCL_MINOR) && \
     (NCCL_MINOR >= 13)
 #define ENABLE_NCCL_GET_LAST_ERROR
+#define NCCL_REMOTE_ERROR
 #elif defined(NCCL_MAJOR) && (NCCL_MAJOR >= 3)
 #define ENABLE_NCCL_GET_LAST_ERROR
+#define NCCL_REMOTE_ERROR
 #endif
 
 // Error checking is enabled only for NCCL versions 2.4+ since ncclCommAbort()
@@ -43,44 +45,6 @@
 #elif defined(NCCL_MAJOR) && (NCCL_MAJOR >= 3)
 #define ENABLE_NCCL_PREMUL_SUM_SUPPORT
 #endif
-
-namespace {
-// Provides additional detail into NCCL error codes based on when these are
-// thrown in the NCCL codebase.
-std::string getNcclErrorDetailStr(ncclResult_t error, c10::optional<std::string> processGroupFailureReason = c10::nullopt) {
-  // Prioritize failure reason provided by PG NCCL first, as it can abort
-  // communicators when it encounters collective timeouts, etc.
-  if (processGroupFailureReason != c10::nullopt) {
-    return (*processGroupFailureReason).c_str();
-  }
-  std::string interpret;
-  std::string err;
-#ifdef ENABLE_NCCL_GET_LAST_ERROR
-  err = "\nLast error:\n" + std::string(ncclGetLastError(NULL));
-#endif
-  switch (error) {
-    case ncclUnhandledCudaError:
-      interpret = "ncclUnhandledCudaError: Call to CUDA function failed.";
-      break;
-    case ncclSystemError:
-      interpret = "ncclSystemError: System call (e.g. socket, malloc) or external library call failed or device error. "
-        "It can be also caused by unexpected exit of a remote peer.";
-      break;
-    case ncclInternalError:
-      interpret = "ncclInternalError: Internal check failed.";
-      break;
-    case ncclInvalidArgument:
-      interpret = "ncclInvalidArgument: Invalid value for an argument.";
-      break;
-    case ncclInvalidUsage:
-      interpret = "ncclInvalidUsage: This usually reflects invalid usage of NCCL library.";
-      break;
-    default:
-      interpret = "Unknown NCCL error!";
-  }
-  return interpret + err;
-}
-} // namespace
 
 // Macro to throw on a non-successful NCCL return value.
 #define C10D_NCCL_CHECK(cmd, failureReason)                                                  \
@@ -114,6 +78,50 @@ namespace c10d {
 
 std::string getNcclVersion();
 std::string ncclGetErrorWithVersion(ncclResult_t error);
+
+// Provides additional detail into NCCL error codes based on when these are
+// thrown in the NCCL codebase.
+std::string getNcclErrorDetailStr(ncclResult_t error, c10::optional<std::string> processGroupFailureReason = c10::nullopt) {
+  // Prioritize failure reason provided by PG NCCL first, as it can abort
+  // communicators when it encounters collective timeouts, etc.
+  if (processGroupFailureReason != c10::nullopt) {
+    return (*processGroupFailureReason).c_str();
+  }
+  std::string interpret;
+  std::string err;
+#ifdef ENABLE_NCCL_GET_LAST_ERROR
+  err = "\nLast error:\n" + std::string(ncclGetLastError(NULL));
+#endif
+  switch (error) {
+    case ncclUnhandledCudaError:
+      interpret = "ncclUnhandledCudaError: Call to CUDA function failed.";
+      break;
+    case ncclSystemError:
+      interpret = "ncclSystemError: System call (e.g. socket, malloc) or external library call failed or device error. ";
+#ifndef NCCL_REMOTE_ERROR
+      // Before ncclRemoteError was created, unexpected remote disconnect was categorized as ncclSystemError
+      interpret += "It can be also caused by unexpected exit of a remote peer.";
+#endif
+      break;
+    case ncclInternalError:
+      interpret = "ncclInternalError: Internal check failed.";
+      break;
+    case ncclInvalidArgument:
+      interpret = "ncclInvalidArgument: Invalid value for an argument.";
+      break;
+    case ncclInvalidUsage:
+      interpret = "ncclInvalidUsage: This usually reflects invalid usage of NCCL library.";
+      break;
+#ifdef NCCL_REMOTE_ERROR
+    case ncclRemoteError:
+      interpret = "ncclRemoteError: A call failed possibly due to a network error or a remote process exiting prematurely.";
+      break;
+#endif
+    default:
+      interpret = "Unknown NCCL error!";
+  }
+  return interpret + err;
+}
 
 // RAII wrapper for NCCL communicator
 class NCCLComm {

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -13,6 +13,7 @@
 #include <c10/util/Optional.h>
 
 // ncclGetLastError() is enabled only for NCCL versions 2.13+
+// ncclRemoteError only exists in NCCL versions 2.13+
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && defined(NCCL_MINOR) && \
     (NCCL_MINOR >= 13)
 #define ENABLE_NCCL_GET_LAST_ERROR

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -82,47 +82,9 @@ std::string ncclGetErrorWithVersion(ncclResult_t error);
 
 // Provides additional detail into NCCL error codes based on when these are
 // thrown in the NCCL codebase.
-std::string getNcclErrorDetailStr(ncclResult_t error, c10::optional<std::string> processGroupFailureReason = c10::nullopt) {
-  // Prioritize failure reason provided by PG NCCL first, as it can abort
-  // communicators when it encounters collective timeouts, etc.
-  if (processGroupFailureReason != c10::nullopt) {
-    return (*processGroupFailureReason).c_str();
-  }
-  std::string interpret;
-  std::string err;
-#ifdef ENABLE_NCCL_GET_LAST_ERROR
-  err = "\nLast error:\n" + std::string(ncclGetLastError(NULL));
-#endif
-  switch (error) {
-    case ncclUnhandledCudaError:
-      interpret = "ncclUnhandledCudaError: Call to CUDA function failed.";
-      break;
-    case ncclSystemError:
-      interpret = "ncclSystemError: System call (e.g. socket, malloc) or external library call failed or device error. ";
-#ifndef NCCL_REMOTE_ERROR
-      // Before ncclRemoteError was created, unexpected remote disconnect was categorized as ncclSystemError
-      interpret += "It can be also caused by unexpected exit of a remote peer.";
-#endif
-      break;
-    case ncclInternalError:
-      interpret = "ncclInternalError: Internal check failed.";
-      break;
-    case ncclInvalidArgument:
-      interpret = "ncclInvalidArgument: Invalid value for an argument.";
-      break;
-    case ncclInvalidUsage:
-      interpret = "ncclInvalidUsage: This usually reflects invalid usage of NCCL library.";
-      break;
-#ifdef NCCL_REMOTE_ERROR
-    case ncclRemoteError:
-      interpret = "ncclRemoteError: A call failed possibly due to a network error or a remote process exiting prematurely.";
-      break;
-#endif
-    default:
-      interpret = "Unknown NCCL error!";
-  }
-  return interpret + err;
-}
+std::string getNcclErrorDetailStr(
+  ncclResult_t error,
+  c10::optional<std::string> processGroupFailureReason = c10::nullopt);
 
 // RAII wrapper for NCCL communicator
 class NCCLComm {


### PR DESCRIPTION
`ncclRemoteError` was added in NCCL 2.13 to indicate a network error or a remote process exiting prematurely.
