### PR TITLE
Add torch_lazy_all_numbers_special_scalars flag

### DIFF
--- a/torch/csrc/lazy/core/config.cpp
+++ b/torch/csrc/lazy/core/config.cpp
@@ -13,6 +13,11 @@ C10_DEFINE_bool(
     "Handle special scalars 0 and 1 diffrently");
 
 C10_DEFINE_bool(
+    torch_lazy_all_numbers_special_scalars,
+    false,
+    "Handle all numbers as special scalars");
+
+C10_DEFINE_bool(
     torch_lazy_reuse_ir,
     false,
     "Reuse IR nodes from previous tracing when possible");

--- a/torch/csrc/lazy/core/config.h
+++ b/torch/csrc/lazy/core/config.h
@@ -4,6 +4,7 @@
 
 C10_DECLARE_bool(torch_lazy_ir_debug);
 C10_DECLARE_bool(torch_lazy_handle_special_scalars);
+C10_DECLARE_bool(torch_lazy_all_numbers_special_scalars);
 C10_DECLARE_bool(torch_lazy_param_aliasing);
 C10_DECLARE_bool(torch_lazy_reuse_ir);
 C10_DECLARE_bool(torch_lazy_use_thread_pool);

--- a/torch/csrc/lazy/core/tensor_util.cpp
+++ b/torch/csrc/lazy/core/tensor_util.cpp
@@ -60,6 +60,9 @@ std::vector<BackendDataPtr> CreateTensorsData(
 bool IsSpecialScalar(const at::Scalar& value) {
   if (FLAGS_torch_lazy_handle_special_scalars &&
       (value.isIntegral(false) || value.isFloatingPoint())) {
+    if (FLAGS_torch_lazy_all_numbers_special_scalars) {
+      return true;
+    }
     double scalar_value = value.toDouble();
     return scalar_value == 0.0 || std::fabs(scalar_value) == 1.0;
   }


### PR DESCRIPTION
This is to allow even non zero and one scalars to appear as constants in the graph. The assumption being that none of them will change.

The flag is set to `false` by default to preserve the original behaviour.

CC: @wconstab @JackCaoG @ke1337 @vaibhavc-cerebras @glebk-cerebras