### PR TITLE
assert lambda >= 0 in poisson distribution cuda kernel

### DIFF
--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -47,6 +47,7 @@ void poisson_cuda_kernel(
     at::PhiloxCudaState philox_args) {
   auto functor = [philox_args] __device__(
           scalar_t & ret_val, const scalar_t& lambda) {
+        CUDA_KERNEL_ASSERT(lambda >= 0 && "invalid Poisson rate, expected rate to be non-negative");
         auto seeds = at::cuda::philox::unpack(philox_args);
         curandStatePhilox4_32_10_t state;
         curand_init(std::get<0>(seeds),

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8514,6 +8514,8 @@ element in :attr:`input` i.e.,
 .. math::
     \text{{out}}_i \sim \text{{Poisson}}(\text{{input}}_i)
 
+:attr:`input` must be non-negative.
+
 Args:
     input (Tensor): the input tensor containing the rates of the Poisson distribution
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #85906

fix https://github.com/pytorch/pytorch/issues/85731
