### PR TITLE
Improve readability in ranged assertions

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -1281,7 +1281,7 @@ bool TensorIteratorBase::can_use_32bit_indexing() const {
 }
 
 std::unique_ptr<TensorIterator> TensorIteratorBase::split(int dim) {
-  TORCH_INTERNAL_ASSERT(dim >= 0 && dim < ndim() && shape()[dim] >= 2);
+  TORCH_INTERNAL_ASSERT(0 <= dim && dim < ndim() && shape()[dim] >= 2);
   std::unique_ptr<TensorIterator> copy(new TensorIterator(*this));
 
   bool overlaps = is_dim_reduced(dim);

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -336,11 +336,11 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   }
 
   const TensorBase& input_base(int arg = 0) const {
-    AT_ASSERT(arg >= 0 && arg < ntensors() - num_outputs_);
+    AT_ASSERT(0 <= arg && arg < ntensors() - num_outputs_);
     return tensor_base(num_outputs_ + arg);
   }
   const Tensor& input(int arg = 0) const {
-    AT_ASSERT(arg >= 0 && arg < ntensors() - num_outputs_);
+    AT_ASSERT(0 <= arg && arg < ntensors() - num_outputs_);
     return tensor(num_outputs_ + arg);
   }
 

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -235,7 +235,7 @@ const KernelFunction& OperatorEntry::kernelForDispatchKey(DispatchKey k) const {
 bool OperatorEntry::hasComputedKernelForDispatchKey(DispatchKey k) const {
   TORCH_CHECK(!isAliasDispatchKey(k), "Alias keys do not have runtime kernel registrations.");
   const auto dispatch_ix = getDispatchTableIndexForDispatchKey(k);
-  TORCH_INTERNAL_ASSERT(dispatch_ix >= 0 && dispatch_ix < c10::num_runtime_entries, toString(k), dispatch_ix);
+  TORCH_INTERNAL_ASSERT(0 <= dispatch_ix && dispatch_ix < c10::num_runtime_entries, toString(k), dispatch_ix);
   return dispatchTable_[dispatch_ix].isValid();
 }
 

--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -47,7 +47,7 @@ cudaDeviceProp* getCurrentDeviceProperties() {
 cudaDeviceProp* getDeviceProperties(int64_t device) {
   c10::call_once(init_flag, initCUDAContextVectors);
   if (device == -1) device = c10::cuda::current_device();
-  AT_ASSERT(device >= 0 && device < num_gpus);
+  AT_ASSERT(0 <= device && device < num_gpus);
   c10::call_once(device_flags[device], initDeviceProperty, device);
   return &device_properties[device];
 }
@@ -55,8 +55,8 @@ cudaDeviceProp* getDeviceProperties(int64_t device) {
 bool canDeviceAccessPeer(int64_t device, int64_t peer_device) {
   c10::call_once(init_flag, initCUDAContextVectors);
   if (device == -1) device = c10::cuda::current_device();
-  AT_ASSERT(device >= 0 && device < num_gpus);
-  AT_ASSERT(peer_device >= 0 && peer_device < num_gpus);
+  AT_ASSERT(0 <= device && device < num_gpus);
+  AT_ASSERT(0 <= peer_device && peer_device < num_gpus);
   int can_access = 0;
   AT_CUDA_CHECK(cudaDeviceCanAccessPeer(&can_access, device, peer_device));
   return can_access != 0;

--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -191,8 +191,8 @@ static void fractional_max_pool2d_out_single_batch_frame(
 
           for (h2 = inputHStart; h2 < inputHStart + poolSizeH; ++h2) {
             for (w2 = inputWStart; w2 < inputWStart + poolSizeW; ++w2) {
-              AT_ASSERT(h2 >= 0 && h2 < inputH);
-              AT_ASSERT(w2 >= 0 && w2 < inputW);
+              AT_ASSERT(0 <= h2 && h2 < inputH);
+              AT_ASSERT(0 <= w2 && w2 < inputW);
 
               int planeIndex = h2 * inputW + w2;
               scalar_t val = inputForPlane[planeIndex];
@@ -263,7 +263,7 @@ static void fractional_max_pool2d_backward_out_single_batch_frame(
         for (w = 0; w < outputW; ++w) {
           int outputIndex = h * outputW + w;
           int64_t index = indicesForPlane[outputIndex];
-          AT_ASSERT(index >= 0 && index < inputW * inputH);
+          AT_ASSERT(0 <= index && index < inputW * inputH);
 
           gradInputForPlane[index] += gradOutputForPlane[outputIndex];
         }

--- a/aten/src/ATen/native/FractionalMaxPool3d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool3d.cpp
@@ -171,9 +171,9 @@ static void fractional_max_pool3d_out_single_batch_frame(
             for (t2 = inputTStart; t2 < inputTStart + poolSizeT; ++t2) {
               for (h2 = inputHStart; h2 < inputHStart + poolSizeH; ++h2) {
                 for (w2 = inputWStart; w2 < inputWStart + poolSizeW; ++w2) {
-                  AT_ASSERT(t2 >= 0 && t2 < inputT);
-                  AT_ASSERT(h2 >= 0 && h2 < inputH);
-                  AT_ASSERT(w2 >= 0 && w2 < inputW);
+                  AT_ASSERT(0 <= t2 && t2 < inputT);
+                  AT_ASSERT(0 <= h2 && h2 < inputH);
+                  AT_ASSERT(0 <= w2 && w2 < inputW);
 
                   int64_t planeIndex = t2 * inputH * inputW + h2 * inputW + w2;
                   scalar_t val = inputForPlane[planeIndex];
@@ -295,7 +295,7 @@ static void fractional_max_pool3d_backward_out_single_batch_frame(
           for (w = 0; w < outputW; ++w) {
             int64_t outputIndex = t * outputH * outputW + h * outputW + w;
             int64_t index = indicesForPlane[outputIndex];
-            AT_ASSERT(index >= 0 && index < inputT * inputH * inputW);
+            AT_ASSERT(0 <= index && index < inputT * inputH * inputW);
             gradInputForPlane[index] += gradOutputForPlane[outputIndex];
           }
         }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1630,7 +1630,7 @@ Tensor reshape_as(const Tensor& self, const Tensor& other) {
 static Tensor select_sparse(const Tensor& self, int64_t dim, int64_t index) {
   int64_t sparse_dim = self.sparse_dim();
   int64_t dense_dim = self.dense_dim();
-  TORCH_INTERNAL_ASSERT(dim >= 0 && dim < sparse_dim + dense_dim);
+  TORCH_INTERNAL_ASSERT(0 <= dim && dim < sparse_dim + dense_dim);
 
   auto indices = self._indices();
   auto values = self._values();

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -145,7 +145,7 @@ __global__ void elementwise_kernel(int N, func_t f) {
 
 template<int nt, int vt, typename func_t>
 static void launch_legacy_kernel(int64_t N, const func_t& f) {
-  TORCH_INTERNAL_ASSERT(N >= 0 && N <= std::numeric_limits<int32_t>::max());
+  TORCH_INTERNAL_ASSERT(0 <= N && N <= std::numeric_limits<int32_t>::max());
   if (N == 0) {
     return;
   }

--- a/aten/src/ATen/native/cuda/CuFFTPlanCache.h
+++ b/aten/src/ATen/native/cuda/CuFFTPlanCache.h
@@ -406,7 +406,7 @@ private:
 #endif
 static_assert(0 <= CUFFT_MAX_PLAN_NUM && CUFFT_MAX_PLAN_NUM <= std::numeric_limits<int64_t>::max(),
               "CUFFT_MAX_PLAN_NUM not in size_t range");
-static_assert(CUFFT_DEFAULT_CACHE_SIZE >= 0 && CUFFT_DEFAULT_CACHE_SIZE <= CUFFT_MAX_PLAN_NUM,
+static_assert(0 <= CUFFT_DEFAULT_CACHE_SIZE && CUFFT_DEFAULT_CACHE_SIZE <= CUFFT_MAX_PLAN_NUM,
               "CUFFT_DEFAULT_CACHE_SIZE not in [0, CUFFT_MAX_PLAN_NUM] range");
 
 // This cache assumes that the mapping from key to value never changes.

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -39,7 +39,7 @@ __global__ void index_elementwise_kernel(int N, func_t f) {
 
 template<int nt, int vt, typename func_t>
 static void launch_kernel(int64_t N, const func_t& f) {
-  TORCH_INTERNAL_ASSERT(N >= 0 && N <= std::numeric_limits<int32_t>::max());
+  TORCH_INTERNAL_ASSERT(0 <= N && N <= std::numeric_limits<int32_t>::max());
   if (N == 0) {
     return;
   }
@@ -171,7 +171,7 @@ void index_copy_kernel_impl(
     auto* __restrict__ self_data = reinterpret_cast<scalar_t*>(self_ptr + offsets[0]);
     auto idx = *reinterpret_cast<int64_t*>(idx_ptr + offsets[1]);
     auto* __restrict__ source_data = reinterpret_cast<scalar_t*>(source_ptr + offsets[2]);
-    CUDA_KERNEL_ASSERT(idx >= 0 && idx < self_dim_size && "index_copy_(): index out of bounds");
+    CUDA_KERNEL_ASSERT(0 <= idx && idx < self_dim_size && "index_copy_(): index out of bounds");
 
     self_data[idx * self_dim_stride] = *source_data;
   };

--- a/aten/src/ATen/native/cuda/MaxUnpooling.cu
+++ b/aten/src/ATen/native/cuda/MaxUnpooling.cu
@@ -45,7 +45,7 @@ __global__ void max_unpooling2d_forward_kernel(
     int n = linearIndex / inputWidth / inputHeight / numChannels;
     output += (n * numChannels + c) * outputHeight * outputWidth;
     int maxind = indices[linearIndex];
-    CUDA_KERNEL_ASSERT(maxind >= 0 && maxind < outputImageSize);
+    CUDA_KERNEL_ASSERT(0 <= maxind && maxind < outputImageSize);
     output[maxind] = input[linearIndex];
   }
 }
@@ -67,7 +67,7 @@ __global__ void max_unpooling3d_forward_kernel(
   if (iRow < input.size(2) && iColumn < input.size(3)) {
     T val = input[slice][iFrame][iRow][iColumn];
     int64_t index = indices[slice][iFrame][iRow][iColumn];
-    CUDA_KERNEL_ASSERT(index >= 0 && index < outputImageSize);
+    CUDA_KERNEL_ASSERT(0 <= index && index < outputImageSize);
     output[slice * oT * oH * oW + index] = val;
   }
 }

--- a/aten/src/ATen/native/cuda/NLLLoss2d.cu
+++ b/aten/src/ATen/native/cuda/NLLLoss2d.cu
@@ -101,7 +101,7 @@ __global__ void nll_loss2d_forward_kernel(
        i += step) {
     int64_t t = target[toffset + i];
     if (t != ignore_index) {
-      CUDA_KERNEL_ASSERT(t >= 0 && t < n_classes);
+      CUDA_KERNEL_ASSERT(0 <= t && t < n_classes);
       cur_weight = weight != nullptr ? weight[t] : static_cast<scalar_t>(1);
       const auto input_index = ioffset + i + map_nelem * t;
       CUDA_KERNEL_ASSERT(input_index >= 0);
@@ -190,7 +190,7 @@ __global__ void nll_loss2d_backward_kernel(
        i += step) {
     const int64_t t = target_thread[i];
     if (t != ignore_index) {
-      CUDA_KERNEL_ASSERT(t >= 0 && t < n_classes);
+      CUDA_KERNEL_ASSERT(0 <= t && t < n_classes);
       const auto grad_input_index = i + map_nelem * t;
       CUDA_KERNEL_ASSERT(grad_input_index >= 0);
       grad_input_thread[i + map_nelem * t] = weights != nullptr ? weights[t] * grad

--- a/aten/src/ATen/native/cuda/ROCmLoops.cuh
+++ b/aten/src/ATen/native/cuda/ROCmLoops.cuh
@@ -119,7 +119,7 @@ __global__ void elementwise_kernel(int N, func_t f) {
 
 template<int nt, int vt, typename func_t>
 static void launch_kernel(int64_t N, const func_t& f) {
-  TORCH_INTERNAL_ASSERT(N >= 0 && N <= std::numeric_limits<int32_t>::max());
+  TORCH_INTERNAL_ASSERT(0 <= N && N <= std::numeric_limits<int32_t>::max());
   if (N == 0) {
     return;
   }
@@ -282,7 +282,7 @@ __global__ void elementwise_kernel(int N, func_t f, array_t data) {
 // TODO (@zasdfgbnm): this function assume trivial 1d and no dynamic casting
 template<typename func_t, typename array_t, std::enable_if_t<detail::has_same_arg_types<func_t>::value, int> = 0>
 static void launch_kernel(int64_t N, const func_t& f, array_t data) {
-  TORCH_INTERNAL_ASSERT(N >= 0 && N <= std::numeric_limits<int32_t>::max());
+  TORCH_INTERNAL_ASSERT(0 <= N && N <= std::numeric_limits<int32_t>::max());
   if (N == 0) {
     return;
   }

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -100,7 +100,7 @@ __global__ void _scatter_gather_elementwise_kernel(int N, func_t f) {
 
 template <int nt, int vt, typename func_t>
 static void _launch_scatter_gather_kernel(int64_t N, const func_t& f) {
-  TORCH_INTERNAL_ASSERT(N >= 0 && N <= std::numeric_limits<int32_t>::max());
+  TORCH_INTERNAL_ASSERT(0 <= N && N <= std::numeric_limits<int32_t>::max());
   if (N == 0) {
     return;
   }
@@ -141,7 +141,7 @@ struct _cuda_scatter_gather_internal_kernel {
       auto offsets = offset_calc.get(i);
 
       int64_t idx_dim = *(int64_t*)(index_ptr + offsets[2]);
-      CUDA_KERNEL_ASSERT(idx_dim >= 0 && idx_dim < index_size
+      CUDA_KERNEL_ASSERT(0 <= idx_dim && idx_dim < index_size
         && "index out of bounds");
 
       f(
@@ -362,7 +362,7 @@ struct _cuda_scatter_fill_internal_kernel {
       auto offsets = offset_calc.get(i);
 
       int64_t idx_dim = *(int64_t*)(index_ptr + offsets[1]);
-      CUDA_KERNEL_ASSERT(idx_dim >= 0 && idx_dim < index_size
+      CUDA_KERNEL_ASSERT(0 <= idx_dim && idx_dim < index_size
         && "index out of bounds"
       );
 

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -765,7 +765,7 @@ Tensor select_sparse_csr(const Tensor& self, int64_t dim, int64_t index) {
     index += size;
   }
 
-  TORCH_INTERNAL_ASSERT(dim >= 0 && dim < self.dim());
+  TORCH_INTERNAL_ASSERT(0 <= dim && dim < self.dim());
 
   auto new_sizes = DimVector(self.sizes());
   new_sizes.erase(new_sizes.begin() + dim);

--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -198,7 +198,7 @@ static void initCUDAStreamsOnce() {
 
 // Helper to verify the GPU index is valid
 static inline void check_gpu(DeviceIndex device_index) {
-  TORCH_INTERNAL_ASSERT(device_index >= 0 && device_index < num_gpus);
+  TORCH_INTERNAL_ASSERT(0 <= device_index && device_index < num_gpus);
 }
 
 // Helper to determine the index of the stream to return

--- a/caffe2/operators/cross_entropy_op.cu
+++ b/caffe2/operators/cross_entropy_op.cu
@@ -13,7 +13,7 @@ __global__ void LabelCrossEntropyKernel(
     const int N, const int D, const float* Xdata, const int* labeldata,
     const float log_threshold, float* Ydata) {
   CUDA_1D_KERNEL_LOOP(i, N) {
-    CUDA_KERNEL_ASSERT(labeldata[i] >= 0 && labeldata[i] < D);
+    CUDA_KERNEL_ASSERT(0 <= labeldata[i] && labeldata[i] < D);
     Ydata[i] = -logf(fmaxf(Xdata[i * D + labeldata[i]], log_threshold));
   }
 }

--- a/caffe2/operators/softmax_ops.cu
+++ b/caffe2/operators/softmax_ops.cu
@@ -19,7 +19,7 @@ __global__ void LabelCrossEntropyKernel(
     const float* weights,
     float* Ydata) {
   CUDA_1D_KERNEL_LOOP(i, N) {
-    CUDA_KERNEL_ASSERT(labeldata[i] >= 0 && labeldata[i] < D);
+    CUDA_KERNEL_ASSERT(0 <= labeldata[i] && labeldata[i] < D);
     float weight = weights ? weights[i] : 1.0;
     Ydata[i] = -logPdata[i * D + labeldata[i]] * weight;
   }
@@ -158,7 +158,7 @@ __global__ void SpatialCrossEntropyLossKernel(
     const int label = static_cast<int>(label_data[index]);
 
     if (label != DONTCARE) {
-      CUDA_KERNEL_ASSERT(label >= 0 && label < D);
+      CUDA_KERNEL_ASSERT(0 <= label && label < D);
       float weight = (weights == NULL ? 1.0 : weights[index]);
       loss_data[index] =
           -logf(

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -445,7 +445,7 @@ class TORCH_CUDA_CU_API WelfordTriplet {
 
   //! Convert a given index to a name
   static ValName indexToValName(int index) {
-    TORCH_INTERNAL_ASSERT(index >= 0 && index < 3, "Invalid index: ", index);
+    TORCH_INTERNAL_ASSERT(0 <= index && index < 3, "Invalid index: ", index);
     return static_cast<ValName>(index);
   }
 

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -431,7 +431,7 @@ Val* TensorIndex::index(int i) const {
       nDims() > 0, "Tried to get an index of a 0-dim TensorIndex");
   if (i < 0)
     i += nDims();
-  TORCH_INTERNAL_ASSERT(i >= 0 && i < int(nDims()));
+  TORCH_INTERNAL_ASSERT(0 <= i && i < int(nDims()));
   return indices_[i];
 }
 

--- a/torch/csrc/jit/codegen/cuda/lower_shift.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_shift.cpp
@@ -96,12 +96,12 @@ int AxisHaloInfo::width() const {
 }
 
 int AxisHaloInfo::width(int pos) const {
-  TORCH_INTERNAL_ASSERT(pos >= 0 && pos < 2);
+  TORCH_INTERNAL_ASSERT(0 <= pos && pos < 2);
   return widths_[pos];
 }
 
 void AxisHaloInfo::setWidth(int pos, int width) {
-  TORCH_INTERNAL_ASSERT(pos >= 0 && pos < 2);
+  TORCH_INTERNAL_ASSERT(0 <= pos && pos < 2);
   widths_[pos] = width;
 }
 

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -142,7 +142,7 @@ TensorView* softmax(TensorView* x, int dim) {
   const int kNumberOfDims =
       TensorDomain::noReductions(x->getMaybeRFactorDomain()).size();
   const int kReductionAxis = (dim < 0) ? dim + kNumberOfDims : dim;
-  TORCH_INTERNAL_ASSERT(kReductionAxis >= 0 && kReductionAxis < kNumberOfDims);
+  TORCH_INTERNAL_ASSERT(0 <= kReductionAxis && kReductionAxis < kNumberOfDims);
 
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   broadcast_mask[kReductionAxis] = true;
@@ -165,7 +165,7 @@ TensorView* softmax_backward(TensorView* dy, TensorView* y, int dim) {
   const int kNumberOfDims =
       TensorDomain::noReductions(y->getMaybeRFactorDomain()).size();
   const int kReductionAxis = (dim < 0) ? dim + kNumberOfDims : dim;
-  TORCH_INTERNAL_ASSERT(kReductionAxis >= 0 && kReductionAxis < kNumberOfDims);
+  TORCH_INTERNAL_ASSERT(0 <= kReductionAxis && kReductionAxis < kNumberOfDims);
 
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   broadcast_mask[kReductionAxis] = true;
@@ -185,7 +185,7 @@ TensorView* log_softmax(TensorView* x, int dim) {
   const int kNumberOfDims =
       TensorDomain::noReductions(x->getMaybeRFactorDomain()).size();
   const int kReductionAxis = (dim < 0) ? dim + kNumberOfDims : dim;
-  TORCH_INTERNAL_ASSERT(kReductionAxis >= 0 && kReductionAxis < kNumberOfDims);
+  TORCH_INTERNAL_ASSERT(0 <= kReductionAxis && kReductionAxis < kNumberOfDims);
 
   std::vector<bool> broadcast_mask(kNumberOfDims, false);
   broadcast_mask[kReductionAxis] = true;
@@ -208,7 +208,7 @@ TensorView* log_softmax_backward(TensorView* dy, TensorView* y, int dim) {
   const int kNumberOfDims =
       TensorDomain::noReductions(y->getMaybeRFactorDomain()).size();
   const int kReductionAxis = (dim < 0) ? dim + kNumberOfDims : dim;
-  TORCH_INTERNAL_ASSERT(kReductionAxis >= 0 && kReductionAxis < kNumberOfDims);
+  TORCH_INTERNAL_ASSERT(0 <= kReductionAxis && kReductionAxis < kNumberOfDims);
 
   auto bcast_sum_grad = sum(dy, {kReductionAxis}, true /* keepdim */);
   auto softmax = exp(y);


### PR DESCRIPTION
Changes
```
assert(x >= 0 && x < 20)
```
to
```
assert(0 <= x && x < 20)
```
in order to better demonstrate that `x` must be in the range `[0, 20)`.

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport