### PR TITLE
Strip GCC5 stuff from PyTorch

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -451,15 +451,6 @@ Tensor& orgqr_kernel_impl(Tensor& result, const Tensor& tau) {
   return result;
 }
 
-// we use `enum class LapackLstsqDriverType` as keys in an unordered_map.
-// Clang5 and Gcc5 do not support std::hash for enum classes, hence
-// we provide our own hash function.
-struct LapackLstsqDriverTypeHash {
-  std::size_t operator()(const LapackLstsqDriverType& driver_type) const {
-    return static_cast<std::size_t>(driver_type);
-  }
-};
-
 /*
   Solves a least squares problem. That is minimizing ||B - A X||.
 
@@ -490,7 +481,7 @@ void apply_lstsq(const Tensor& A, Tensor& B, Tensor& rank, Tensor& singular_valu
 
   auto lapack_func = lapackLstsq<driver_t::Gelsd, scalar_t, value_t>;
   static auto driver_type_to_func
-    = std::unordered_map<driver_t, decltype(lapack_func), LapackLstsqDriverTypeHash>({
+    = std::unordered_map<driver_t, decltype(lapack_func)>({
     {driver_t::Gels, lapackLstsq<driver_t::Gels, scalar_t, value_t>},
     {driver_t::Gelsy, lapackLstsq<driver_t::Gelsy, scalar_t, value_t>},
     {driver_t::Gelsd, lapackLstsq<driver_t::Gelsd, scalar_t, value_t>},

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -119,7 +119,7 @@ Tensor qcat_nhwc_kernel(
       c10::nullopt);
 
   // N, H, and W are explicitly captured here because there's a bug in GCC5
-  // which causes an internal compiler error if they're not
+  // and clang5 which causes an internal compiler error if they're not
   AT_DISPATCH_QINT_TYPES(output.scalar_type(), "qcat_nhwc", [&, N, H, W]() {
     using Vec = Vectorized<scalar_t>;
     at::parallel_for(0, N * H * W, 0, [&](int64_t begin, int64_t end) {

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -439,15 +439,6 @@ __device__ __attribute__((noinline)) __attribute__((weak)) void __assert_fail(
 #define C10_IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
 #endif
 
-#if !defined(__clang__) && !defined(_MSC_VER) && defined(__GNUC__) && \
-    __GNUC__ < 6
-#define CONSTEXPR_EXCEPT_GCC5
-#define IS_NOT_GCC5_CONSTEXPR 0
-#else
-#define CONSTEXPR_EXCEPT_GCC5 constexpr
-#define IS_NOT_GCC5_CONSTEXPR 1
-#endif
-
 #if defined(__CUDA_ARCH__)
 #if defined(_MSC_VER) && defined(__CUDACC__)
 #define CONSTEXPR_EXCEPT_WIN_CUDA const

--- a/c10/test/util/string_view_test.cpp
+++ b/c10/test/util/string_view_test.cpp
@@ -218,19 +218,17 @@ static_assert(!string_view("hello").empty(), "");
 } // namespace test_empty
 
 namespace test_remove_prefix {
-CONSTEXPR_EXCEPT_GCC5 string_view remove_prefix(string_view input, size_t len) {
+constexpr string_view remove_prefix(string_view input, size_t len) {
   input.remove_prefix(len);
   return input;
 }
 
 TEST(StringViewTest, whenRemovingValidPrefix_thenWorks) {
-#if IS_NOT_GCC5_CONSTEXPR
   static_assert(
       remove_prefix(string_view("hello"), 0) == string_view("hello"), "");
   static_assert(
       remove_prefix(string_view("hello"), 1) == string_view("ello"), "");
   static_assert(remove_prefix(string_view("hello"), 5) == string_view(""), "");
-#endif
 
   EXPECT_EQ(remove_prefix(string_view("hello"), 0), string_view("hello"));
   EXPECT_EQ(remove_prefix(string_view("hello"), 1), string_view("ello"));
@@ -245,19 +243,17 @@ TEST(StringViewTest, whenRemovingTooLargePrefix_thenThrows) {
 } // namespace test_remove_prefix
 
 namespace test_remove_suffix {
-CONSTEXPR_EXCEPT_GCC5 string_view remove_suffix(string_view input, size_t len) {
+constexpr string_view remove_suffix(string_view input, size_t len) {
   input.remove_suffix(len);
   return input;
 }
 
 TEST(StringViewTest, whenRemovingValidSuffix_thenWorks) {
-#if IS_NOT_GCC5_CONSTEXPR
   static_assert(
       remove_suffix(string_view("hello"), 0) == string_view("hello"), "");
   static_assert(
       remove_suffix(string_view("hello"), 1) == string_view("hell"), "");
   static_assert(remove_suffix(string_view("hello"), 5) == string_view(""), "");
-#endif
 
   EXPECT_EQ(remove_suffix(string_view("hello"), 0), string_view("hello"));
   EXPECT_EQ(remove_suffix(string_view("hello"), 1), string_view("hell"));
@@ -272,17 +268,15 @@ TEST(StringViewTest, whenRemovingTooLargeSuffix_thenThrows) {
 } // namespace test_remove_suffix
 
 namespace test_swap_function {
-CONSTEXPR_EXCEPT_GCC5 std::pair<string_view, string_view> get() {
+constexpr std::pair<string_view, string_view> get() {
   string_view first = "first";
   string_view second = "second";
   swap(first, second);
   return std::make_pair(first, second);
 }
 TEST(StringViewTest, testSwapFunction) {
-#if IS_NOT_GCC5_CONSTEXPR
   static_assert(string_view("second") == get().first, "");
   static_assert(string_view("first") == get().second, "");
-#endif
 
   EXPECT_EQ(string_view("second"), get().first);
   EXPECT_EQ(string_view("first"), get().second);
@@ -290,17 +284,15 @@ TEST(StringViewTest, testSwapFunction) {
 } // namespace test_swap_function
 
 namespace test_swap_method {
-CONSTEXPR_EXCEPT_GCC5 std::pair<string_view, string_view> get() {
+constexpr std::pair<string_view, string_view> get() {
   string_view first = "first";
   string_view second = "second";
   first.swap(second);
   return std::make_pair(first, second);
 }
 TEST(StringViewTest, testSwapMethod) {
-#if IS_NOT_GCC5_CONSTEXPR
   static_assert(string_view("second") == get().first, "");
   static_assert(string_view("first") == get().second, "");
-#endif
 
   EXPECT_EQ(string_view("second"), get().first);
   EXPECT_EQ(string_view("first"), get().second);

--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -179,7 +179,7 @@ class basic_string_view final {
     return size() == 0;
   }
 
-  CONSTEXPR_EXCEPT_GCC5 void remove_prefix(size_type n) {
+  constexpr void remove_prefix(size_type n) {
     if (n > size()) {
       throw std::out_of_range(
           "basic_string_view::remove_prefix: out of range. PrefixLength: " +
@@ -189,7 +189,7 @@ class basic_string_view final {
     size_ -= n;
   }
 
-  CONSTEXPR_EXCEPT_GCC5 void remove_suffix(size_type n) {
+  constexpr void remove_suffix(size_type n) {
     if (n > size()) {
       throw std::out_of_range(
           "basic_string_view::remove_suffix: out of range. SuffixLength: " +
@@ -198,7 +198,7 @@ class basic_string_view final {
     size_ -= n;
   }
 
-  CONSTEXPR_EXCEPT_GCC5 void swap(basic_string_view& sv) noexcept {
+  constexpr void swap(basic_string_view& sv) noexcept {
     auto tmp = *this;
     *this = sv;
     sv = tmp;
@@ -694,7 +694,7 @@ inline std::basic_ostream<CharT>& operator<<(
 }
 
 template <class CharT>
-CONSTEXPR_EXCEPT_GCC5 inline void swap(
+constexpr inline void swap(
     basic_string_view<CharT>& lhs,
     basic_string_view<CharT>& rhs) {
   lhs.swap(rhs);


### PR DESCRIPTION
[This file](https://github.com/pytorch/pytorch/pull/63208/files) indicates that we don't support anything less than GCC 7.5. Given that, let's remove this GCC 5 stuff.