### PR TITLE
LU solve/unpack fix to prevent bad memory usage on CPU

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2015,7 +2015,7 @@ TORCH_IMPL_FUNC(lu_unpack_out)(const Tensor& LU,
       .add_owned_input(pivots.contiguous())
       .build();
 
-    unpack_pivots_stub(pivots.device().type(), iter, std::min(m, n));
+    unpack_pivots_stub(pivots.device().type(), iter, std::min(m, n), std::max(m, n));
 
     // Transform the permutation into a permutation matrix
     P.zero_();

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2015,7 +2015,7 @@ TORCH_IMPL_FUNC(lu_unpack_out)(const Tensor& LU,
       .add_owned_input(pivots.contiguous())
       .build();
 
-    unpack_pivots_stub(pivots.device().type(), iter, std::min(m, n), std::max(m, n));
+    unpack_pivots_stub(pivots.device().type(), iter, std::min(m, n), m);
 
     // Transform the permutation into a permutation matrix
     P.zero_();

--- a/aten/src/ATen/native/BatchLinearAlgebra.h
+++ b/aten/src/ATen/native/BatchLinearAlgebra.h
@@ -280,7 +280,8 @@ DECLARE_DISPATCH(lu_factor_fn, lu_factor_stub);
 
 using unpack_pivots_fn = void(*)(
   TensorIterator& iter,
-  const int64_t dim_size);
+  const int64_t dim_size,
+  const int64_t max_pivot);
 DECLARE_DISPATCH(unpack_pivots_fn, unpack_pivots_stub);
 
 using lu_solve_fn = void (*)(

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -1086,7 +1086,7 @@ void svd_kernel(const Tensor& A,
   });
 }
 
-void unpack_pivots_cpu_kernel(TensorIterator& iter, const int64_t dim_size) {
+void unpack_pivots_cpu_kernel(TensorIterator& iter, const int64_t dim_size, const int64_t max_pivot) {
   if (iter.numel() == 0) {
     return;
   }
@@ -1103,7 +1103,7 @@ void unpack_pivots_cpu_kernel(TensorIterator& iter, const int64_t dim_size) {
 
       for (const auto i : c10::irange(dim_size)) {
         auto new_idx = pivots_data[i] - 1;
-        TORCH_CHECK(new_idx >= 0 && new_idx < dim_size,
+        TORCH_CHECK(new_idx >= 0 && new_idx < max_pivot,
                     "pivots passed to lu_unpack must be between 1 and LU.size(-1)."
                     "Did you properly pass the result of lu_factor?");
         std::swap(

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -993,12 +993,12 @@ void apply_lu_solve(const Tensor& LU, const Tensor& pivots, const Tensor& B, Tra
 // This is a type dispatching helper function for 'apply_lu_solve'
 void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor& B, TransposeType trans) {
   // Lapack will write into unrelated memory if pivots are not in the right range so we do
-  // some simple sanity checks here.
+  // some simple sanity checks here for the CPU version
   TORCH_CHECK(pivots.gt(0).all().item<bool>(),
-              "Pivots given to lu_solve must all be greater than 1. "
+              "Pivots given to lu_solve must all be greater or equal to 1. "
               "Did you properly pass the result of lu_factor?");
-  TORCH_CHECK(pivots.le(LU.size(-1)).all().item<bool>(),
-              "Pivots given to lu_solve must all be smaller or equal to LU.size(-1). "
+  TORCH_CHECK(pivots.le(LU.size(-2)).all().item<bool>(),
+              "Pivots given to lu_solve must all be smaller or equal to LU.size(-2). "
               "Did you properly pass the result of lu_factor?");
 
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(LU.scalar_type(), "linalg.lu_solve_cpu", [&]{
@@ -1104,7 +1104,7 @@ void unpack_pivots_cpu_kernel(TensorIterator& iter, const int64_t dim_size, cons
       for (const auto i : c10::irange(dim_size)) {
         auto new_idx = pivots_data[i] - 1;
         TORCH_CHECK(new_idx >= 0 && new_idx < max_pivot,
-                    "pivots passed to lu_unpack must be between 1 and LU.size(-1)."
+                    "pivots passed to lu_unpack must be between 1 and LU.size(-2) inclusive."
                     "Did you properly pass the result of lu_factor?");
         std::swap(
           perm_data[i],

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -7,6 +7,7 @@
 
 #include <c10/util/irange.h>
 
+
 namespace at { namespace native {
 
 namespace {
@@ -1101,9 +1102,13 @@ void unpack_pivots_cpu_kernel(TensorIterator& iter, const int64_t dim_size) {
       const auto pivots_data = reinterpret_cast<const int32_t*>(pivots_ptr);
 
       for (const auto i : c10::irange(dim_size)) {
+        auto new_idx = pivots_data[i] - 1;
+        TORCH_CHECK(new_idx >= 0 && new_idx < dim_size,
+                    "pivots passed to lu_unpack must be between 1 and LU.size(-1)."
+                    "Did you properly pass the result of lu_factor?");
         std::swap(
           perm_data[i],
-          perm_data[pivots_data[i] - 1]
+          perm_data[new_idx]
         );
       }
 

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -101,14 +101,14 @@ static void _launch_kernel(int total_n_elems, func_t f) {
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
-void unpack_pivots_cuda_kernel(TensorIterator& iter, const int64_t dim_size) {
+void unpack_pivots_cuda_kernel(TensorIterator& iter, const int64_t dim_size, const int64_t max_pivot) {
   if (iter.numel() == 0) {
     return;
   }
 
   if (!iter.can_use_32bit_indexing()) {
     for (auto& sub_iter : iter.with_32bit_indexing()) {
-      unpack_pivots_cuda_kernel(sub_iter, dim_size);
+      unpack_pivots_cuda_kernel(sub_iter, dim_size, max_pivot);
     }
     return;
   }

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -2473,7 +2473,7 @@ static void lu_solve_kernel(const Tensor& LU, const Tensor& pivots, const Tensor
       .add_output(perm)
       .add_input(*pivots_)
       .build();
-    unpack_pivots_stub(pivots_->device().type(), iter, n);
+    unpack_pivots_stub(pivots_->device().type(), iter, n, n);
 
     if (trans == TransposeType::NoTranspose) {
       // Get the inverse permutation

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4953,21 +4953,26 @@ class TestLinalg(TestCase):
 
     @onlyCPU
     @dtypes(*floating_and_complex_types())
-    def test_linalg_lu_solve_cpu_errors(self, device, dtype):
-        sample = torch.rand(3, 2, 2, device=device, dtype=dtype)
-        B = torch.rand(3, 2, 2, device=device, dtype=dtype)
+    def test_linalg_lu_cpu_errors(self, device, dtype):
+        sample = torch.randn(3, 2, 2, device=device, dtype=dtype)
+        B = torch.randn(3, 2, 2, device=device, dtype=dtype)
         LU, pivots = torch.linalg.lu_factor(sample)
 
         # This should run without issues
         torch.linalg.lu_solve(LU, pivots, B, adjoint=True)
+        torch.lu_unpack(LU, pivots)
 
-        with self.assertRaisesRegex(RuntimeError, "greater than 1"):
-            pivots[0] = 0
+        pivots[0] = 0
+        with self.assertRaisesRegex(RuntimeError, r"greater than 1"):
             torch.linalg.lu_solve(LU, pivots, B, adjoint=True)
+        with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-1\)."):
+            torch.lu_unpack(LU, pivots)
 
-        with self.assertRaisesRegex(RuntimeError, "smaller or equal to LU.size\(-1\)"):
-            pivots[0] = 3
+        pivots[0] = 3
+        with self.assertRaisesRegex(RuntimeError, r"smaller or equal to LU.size\(-1\)"):
             torch.linalg.lu_solve(LU, pivots, B, adjoint=True)
+        with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-1\)."):
+            torch.lu_unpack(LU, pivots)
 
 
     @skipCPUIfNoLapack

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4954,7 +4954,7 @@ class TestLinalg(TestCase):
     @onlyCPU
     @dtypes(*floating_and_complex_types())
     def test_linalg_lu_cpu_errors(self, device, dtype):
-        ### Square tests
+        # Square tests
         sample = torch.randn(3, 2, 2, device=device, dtype=dtype)
         B = torch.randn(3, 2, 2, device=device, dtype=dtype)
         LU, pivots = torch.linalg.lu_factor(sample)
@@ -4975,7 +4975,7 @@ class TestLinalg(TestCase):
         with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-2\)."):
             torch.lu_unpack(LU, pivots)
 
-        ### Rectangular tests
+        # Rectangular tests
         sample = torch.randn(3, 4, 2, device=device, dtype=dtype)
         B = torch.randn(3, 4, 2, device=device, dtype=dtype)
         LU, pivots = torch.linalg.lu_factor(sample)
@@ -4992,7 +4992,7 @@ class TestLinalg(TestCase):
             torch.lu_unpack(LU, pivots)
 
 
-        ### Rectangular tests
+        # Rectangular tests
         sample = torch.randn(2, 3, 5, device=device, dtype=dtype)
         B = torch.randn(2, 3, 5, device=device, dtype=dtype)
         LU, pivots = torch.linalg.lu_factor(sample)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4954,6 +4954,7 @@ class TestLinalg(TestCase):
     @onlyCPU
     @dtypes(*floating_and_complex_types())
     def test_linalg_lu_cpu_errors(self, device, dtype):
+        ### Square tests
         sample = torch.randn(3, 2, 2, device=device, dtype=dtype)
         B = torch.randn(3, 2, 2, device=device, dtype=dtype)
         LU, pivots = torch.linalg.lu_factor(sample)
@@ -4971,6 +4972,39 @@ class TestLinalg(TestCase):
         pivots[0] = 3
         with self.assertRaisesRegex(RuntimeError, r"smaller or equal to LU.size\(-2\)"):
             torch.linalg.lu_solve(LU, pivots, B, adjoint=True)
+        with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-2\)."):
+            torch.lu_unpack(LU, pivots)
+
+        ### Rectangular tests
+        sample = torch.randn(3, 4, 2, device=device, dtype=dtype)
+        B = torch.randn(3, 4, 2, device=device, dtype=dtype)
+        LU, pivots = torch.linalg.lu_factor(sample)
+
+        # This should run without issues
+        torch.lu_unpack(LU, pivots)
+
+        pivots[0] = 0
+        with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-2\)."):
+            torch.lu_unpack(LU, pivots)
+
+        pivots[0] = 5
+        with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-2\)."):
+            torch.lu_unpack(LU, pivots)
+
+
+        ### Rectangular tests
+        sample = torch.randn(2, 3, 5, device=device, dtype=dtype)
+        B = torch.randn(2, 3, 5, device=device, dtype=dtype)
+        LU, pivots = torch.linalg.lu_factor(sample)
+
+        # This should run without issues
+        torch.lu_unpack(LU, pivots)
+
+        pivots[0] = 0
+        with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-2\)."):
+            torch.lu_unpack(LU, pivots)
+
+        pivots[0] = 4
         with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-2\)."):
             torch.lu_unpack(LU, pivots)
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4963,15 +4963,15 @@ class TestLinalg(TestCase):
         torch.lu_unpack(LU, pivots)
 
         pivots[0] = 0
-        with self.assertRaisesRegex(RuntimeError, r"greater than 1"):
+        with self.assertRaisesRegex(RuntimeError, r"greater or equal to 1"):
             torch.linalg.lu_solve(LU, pivots, B, adjoint=True)
-        with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-1\)."):
+        with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-2\)."):
             torch.lu_unpack(LU, pivots)
 
         pivots[0] = 3
-        with self.assertRaisesRegex(RuntimeError, r"smaller or equal to LU.size\(-1\)"):
+        with self.assertRaisesRegex(RuntimeError, r"smaller or equal to LU.size\(-2\)"):
             torch.linalg.lu_solve(LU, pivots, B, adjoint=True)
-        with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-1\)."):
+        with self.assertRaisesRegex(RuntimeError, r"between 1 and LU.size\(-2\)."):
             torch.lu_unpack(LU, pivots)
 
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4951,6 +4951,25 @@ class TestLinalg(TestCase):
                         self.assertEqual(B_left, X @ A_adj)
 
 
+    @onlyCPU
+    @dtypes(*floating_and_complex_types())
+    def test_linalg_lu_solve_cpu_errors(self, device, dtype):
+        sample = torch.rand(3, 2, 2, device=device, dtype=dtype)
+        B = torch.rand(3, 2, 2, device=device, dtype=dtype)
+        LU, pivots = torch.linalg.lu_factor(sample)
+
+        # This should run without issues
+        torch.linalg.lu_solve(LU, pivots, B, adjoint=True)
+
+        with self.assertRaisesRegex(RuntimeError, "greater than 1"):
+            pivots[0] = 0
+            torch.linalg.lu_solve(LU, pivots, B, adjoint=True)
+
+        with self.assertRaisesRegex(RuntimeError, "smaller or equal to LU.size\(-1\)"):
+            pivots[0] = 3
+            torch.linalg.lu_solve(LU, pivots, B, adjoint=True)
+
+
     @skipCPUIfNoLapack
     @skipCUDAIfNoMagma
     @dtypes(torch.double)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/77898
Fixes https://github.com/pytorch/pytorch/issues/85026

There is a minor perf impact but:
- For lu_solve, the actual compute is going to be more expensive than this O(n) check (ones pass over the other matrices is O(n^2) in any case)
- For lu_unpack, the check inside the kernel should be almost free.