### PR TITLE
Make strong_type safe to use on Windows, include in TensorImpl.h

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -21,6 +21,7 @@
 #include <c10/util/irange.h>
 #include <c10/util/python_stub.h>
 #include <c10/util/safe_numerics.h>
+#include <c10/util/strong_type.h>
 
 #include <algorithm>
 #include <atomic>

--- a/c10/util/strong_type.h
+++ b/c10/util/strong_type.h
@@ -33,19 +33,11 @@
 #endif
 
 #ifndef STRONG_HAS_STD_FORMAT
-#if __has_include(<format>)
-#define STRONG_HAS_STD_FORMAT 1
-#else
 #define STRONG_HAS_STD_FORMAT 0
-#endif
 #endif
 
 #ifndef STRONG_HAS_FMT_FORMAT
-#if __has_include(<fmt/format.h>)
-#define STRONG_HAS_FMT_FORMAT 1
-#else
 #define STRONG_HAS_FMT_FORMAT 0
-#endif
 #endif
 
 #if STRONG_HAS_STD_FORMAT


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #85936
* #85928
* __->__ #85925
* #85919

Previously, strong_type included format.h which appears to pull in
min/max macros on Windows.  This breaks everything.  So I disabled
it and now include it from TensorImpl.h to ensure everything works.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D39944617](https://our.internmc.facebook.com/intern/diff/D39944617)