### PR TITLE
Add pybind11 caster for MemoryFormat and use it consistently

### DIFF
--- a/tools/autograd/templates/python_nn_functions.cpp
+++ b/tools/autograd/templates/python_nn_functions.cpp
@@ -67,7 +67,7 @@ static PyObject * THPVariable__parse_to(PyObject* module, PyObject* args, PyObje
   }
   PyTuple_SET_ITEM(tuple.get(), 2, torch::autograd::utils::wrap(non_blocking));
   if (opt_memory_format.has_value()) {
-    PyTuple_SET_ITEM(tuple.get(), 3, torch::utils::getTHPMemoryFormat(opt_memory_format.value()).release().ptr());
+    PyTuple_SET_ITEM(tuple.get(), 3, torch::utils::getTHPMemoryFormat(opt_memory_format.value()));
   } else {
     Py_INCREF(Py_None);
     PyTuple_SET_ITEM(tuple.get(), 3, Py_None);

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -132,8 +132,7 @@ std::pair<py::object, py::dict> parseIValuesToPyArgsKwargs(
       return py::reinterpret_borrow<py::object>(
           reinterpret_cast<PyObject*>(obj));
     } else if (match(c10::MemoryFormatType::Kind)) {
-      return torch::utils::getTHPMemoryFormat(
-          static_cast<c10::MemoryFormat>(arguments[idx].toInt()));
+      return py::cast(static_cast<c10::MemoryFormat>(arguments[idx].toInt()));
     } else {
       return torch::jit::toPyObject(arguments[idx]);
     }

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -12,6 +12,8 @@
 #include <torch/csrc/Device.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/Generator.h>
+#include <torch/csrc/MemoryFormat.h>
+#include <torch/csrc/utils/tensor_memoryformats.h>
 
 #include <stdexcept>
 #include <utility>
@@ -105,6 +107,28 @@ struct TORCH_PYTHON_API type_caster<at::IntArrayRef> {
 
  private:
   std::vector<int64_t> v_value;
+};
+
+template <>
+struct TORCH_PYTHON_API type_caster<at::MemoryFormat> {
+ public:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+  PYBIND11_TYPE_CASTER(at::MemoryFormat, _("at::MemoryFormat"));
+
+  bool load(handle src, bool) {
+    PyObject* obj = src.ptr();
+    if (THPMemoryFormat_Check(obj)) {
+      value = reinterpret_cast<THPMemoryFormat*>(obj)->memory_format;
+      return true;
+    }
+    return false;
+  }
+  static handle cast(
+      at::MemoryFormat src,
+      return_value_policy /* policy */,
+      handle /* parent */) {
+    return handle(torch::utils::getTHPMemoryFormat(src));
+  }
 };
 
 template <>

--- a/torch/csrc/utils/tensor_memoryformats.cpp
+++ b/torch/csrc/utils/tensor_memoryformats.cpp
@@ -17,9 +17,11 @@ std::array<PyObject*, static_cast<int>(at::MemoryFormat::NumOptions)>
     memory_format_registry = {};
 } // anonymous namespace
 
-py::object getTHPMemoryFormat(at::MemoryFormat memory_format) {
+PyObject* getTHPMemoryFormat(at::MemoryFormat memory_format) {
   return py::reinterpret_borrow<py::object>(
-      memory_format_registry[static_cast<size_t>(memory_format)]);
+             memory_format_registry[static_cast<size_t>(memory_format)])
+      .release()
+      .ptr();
 }
 
 void initializeMemoryFormats() {

--- a/torch/csrc/utils/tensor_memoryformats.h
+++ b/torch/csrc/utils/tensor_memoryformats.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <c10/core/MemoryFormat.h>
-#include <torch/csrc/utils/pybind.h>
+#include <torch/csrc/utils/python_stub.h>
 
 namespace torch {
 namespace utils {
 
 void initializeMemoryFormats();
-py::object getTHPMemoryFormat(c10::MemoryFormat);
+PyObject* getTHPMemoryFormat(c10::MemoryFormat);
 
 } // namespace utils
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #85936
* __->__ #85928
* #85925
* #85919

To avoid an import cycle, I had to change the raw MemoryFormat
to PyObject function to return a raw PyObject* pointer.  It is
only used in one place.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D39944619](https://our.internmc.facebook.com/intern/diff/D39944619)