### PR TITLE
Added roundup_bypass_threshold_mb knobs to the PyTorch Caching Allocator

### DIFF
--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -379,6 +379,10 @@ Available options:
   the size 1200 lies between 1024 and 2048 and if we do 4 divisions between
   them, the values are 1024, 1280, 1536, and 1792. So, allocation size of 1200
   will be rounded to 1280 as the nearest ceiling of power-2 division.
+* ``roundup_bypass_threshold_mb`` bypass rounding the requested allocation size,
+  for allocation requests larger than the threshold value (in MB). This can help
+  reduce the memory footprint when making large allocations that are expected to
+  be persistent or have a large lifetime.
 * ``garbage_collection_threshold`` helps actively reclaiming unused GPU memory to
   avoid triggering expensive sync-and-reclaim-all operation (release_cached_blocks),
   which can be unfavorable to latency-critical GPU applications (e.g., servers).


### PR DESCRIPTION
Summary:
Added an additional roundup knob( ``roundup_bypass_threshold_mb``) to bypass rounding the requested allocation size, for allocation requests larger than the threshold value (in MB). This can help reduce the memory footprint when making large allocations that are expected to be persistent or have a large lifetime.

Differential Revision: D39868104

