### PR TITLE
Add exception for build_variables.bzl in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,7 @@ build_host_protoc
 build_android
 build_ios
 /build_*
+!/build_variables.bzl
 .build_debug/*
 .build_release/*
 .build_profile/*


### PR DESCRIPTION
Fixes #80431
The regular expression of .gitignore accidentally matches build_variables.bzl, which in turn causes .dockerignore to match it.
An exception needs to be set for build_variables.bzl.