### PR TITLE
To support XPU profiler with Kineto

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -267,6 +267,11 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
 
   m.def("_supported_activities", []() {
     std::set<ActivityType> activities{ActivityType::CPU};
+#if defined(USE_KINETO)
+    if (at::hasXPU()) {
+       activities.insert(ActivityType::XPU);
+    }
+#endif
 #if defined(USE_KINETO) && !defined(LIBKINETO_NOCUPTI)
     if (at::getNumGPUs() > 0 && !at::hasHIP()) {
       activities.insert(ActivityType::CUDA);

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -520,7 +520,7 @@ void prepareProfiler(
           config.state == ProfilerState::KINETO_GPU_FALLBACK,
       "Supported only in Kineto profiler");
   torch::profiler::impl::kineto::prepareTrace(
-      /*cpuOnly=*/!at::hasCUDA(), activities, config.experimental_config);
+      /*cpuOnly=*/!(at::hasCUDA() || at::hasXPU()), activities, config.experimental_config);
 }
 
 void enableProfilerWithEventPostProcess(

--- a/torch/csrc/profiler/api.h
+++ b/torch/csrc/profiler/api.h
@@ -14,6 +14,7 @@ namespace impl {
 // ----------------------------------------------------------------------------
 enum class C10_API_ENUM ActivityType {
   CPU = 0,
+  XPU,  // XPU kernels, runtime
   CUDA, // CUDA kernels, runtime
   NUM_KINETO_ACTIVITIES, // must be the last one
 };

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -44,6 +44,7 @@ void initPythonBindings(PyObject* module) {
 
   py::enum_<ActivityType>(m, "ProfilerActivity")
       .value("CPU", ActivityType::CPU)
+      .value("XPU", ActivityType::XPU)
       .value("CUDA", ActivityType::CUDA);
 
   py::class_<ExperimentalConfig>(m, "_ExperimentalConfig")


### PR DESCRIPTION
As Kineto's changes start to support extend profilers to register, we made some following changes to PyTorch's profiler shim layel. This patch only affects c source codes related to kineto profiler which will add the support of XPU profiler with some APIs into kineto_shim and initializations.

Signed-off-by: Xunsong, Huang <xunsong.huang@intel.com>

Fixes #ISSUE_NUMBER
