### PR TITLE
Limit world size in test_fsdp_pure_fp16

### DIFF
--- a/test/distributed/fsdp/test_fsdp_pure_fp16.py
+++ b/test/distributed/fsdp/test_fsdp_pure_fp16.py
@@ -32,6 +32,11 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 class TestPureFP16(FSDPTest):
 
+    @property
+    def world_size(self):
+        # Test fails due to inaccuracies when using more than 5 GPUs
+        return min(5, super().world_size)
+
     @skip_if_lt_x_gpu(2)
     @parametrize(
         "cpu_offload",


### PR DESCRIPTION
When using more than 5 GPUs for this test the difference between the reference output tensor and the FSDP output tensor becomes to large likely due to the usual floating point inaccuracies especially as FP16 is used.
So set the world size (i.e. the number of GPUs) to a maximum of 5.

Fixes #78975
