### PR TITLE
Fix compile error for vs2022 #79358

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -132,8 +132,9 @@ public:
   // versions GCC/Clang have buggy determinations on whether or not an
   // identifier is odr-used or not, and in any case it's hard to tell if
   // a variable is odr-used or not.  So best to just cut the problem at the root.
+  static constexpr size_type size_T = sizeof(T);  // Workaround to compile with VS2022.
   static constexpr size_type size() {
-    return VECTOR_WIDTH / sizeof(T);
+    return VECTOR_WIDTH / size_T;
   }
   Vectorized() : values{static_cast<T>(0)} {}
   Vectorized(T val) {


### PR DESCRIPTION
Fixes #79358 

- #79358
- https://github.com/xmake-io/xmake-repo/pull/1503#issuecomment-1263104439
