### PR TITLE
[c10d] Start deprecating *_multigpu APIs

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -468,6 +468,9 @@ Please refer to the `profiler documentation <https://pytorch.org/docs/master/pro
 Multi-GPU collective functions
 ------------------------------
 
+.. warning::
+    The multi-GPU functions will be deprecated. If you must use them, please revisit our documentation later.
+
 If you have more than one GPU on each node, when using the NCCL and Gloo backend,
 :func:`~torch.distributed.broadcast_multigpu`
 :func:`~torch.distributed.all_reduce_multigpu`

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1330,7 +1330,8 @@ def broadcast_multigpu(tensor_list, src, group=None, async_op=False, src_tensor=
     """
     warnings.warn(
         "torch.distributed.broadcast_multigpu will be deprecated. If you must "
-        "use it, please revisit our documentation later."
+        "use it, please revisit our documentation later at "
+        "https://pytorch.org/docs/master/distributed.html#multi-gpu-collective-functions"
     )
 
     if _rank_not_in_group(group):
@@ -1432,7 +1433,8 @@ def all_reduce_multigpu(tensor_list, op=ReduceOp.SUM, group=None, async_op=False
     """
     warnings.warn(
         "torch.distributed.all_reduce_multigpu will be deprecated. If you must "
-        "use it, please revisit our documentation later."
+        "use it, please revisit our documentation later at "
+        "https://pytorch.org/docs/master/distributed.html#multi-gpu-collective-functions"
     )
 
     if _rank_not_in_group(group):
@@ -1621,7 +1623,8 @@ def reduce_multigpu(
     """
     warnings.warn(
         "torch.distributed.reduce_multigpu will be deprecated. If you must "
-        "use it, please revisit our documentation later."
+        "use it, please revisit our documentation later at "
+        "https://pytorch.org/docs/master/distributed.html#multi-gpu-collective-functions"
     )
 
     if _rank_not_in_group(group):
@@ -1739,7 +1742,8 @@ def all_gather_multigpu(
     """
     warnings.warn(
         "torch.distributed.all_gather_multigpu will be deprecated. If you must "
-        "use it, please revisit our documentation later."
+        "use it, please revisit our documentation later at "
+        "https://pytorch.org/docs/master/distributed.html#multi-gpu-collective-functions"
     )
 
     if _rank_not_in_group(group):
@@ -2640,7 +2644,8 @@ def reduce_scatter_multigpu(
     """
     warnings.warn(
         "torch.distributed.reduce_scatter_multigpu will be deprecated. If you must "
-        "use it, please revisit our documentation later."
+        "use it, please revisit our documentation later at "
+        "https://pytorch.org/docs/master/distributed.html#multi-gpu-collective-functions"
     )
 
     if _rank_not_in_group(group):

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1328,6 +1328,11 @@ def broadcast_multigpu(tensor_list, src, group=None, async_op=False, src_tensor=
         None, if not async_op or if not part of the group
 
     """
+    warnings.warn(
+        "torch.distributed.broadcast_multigpu will be deprecated. If you must "
+        "use it, please revisit our documentation later."
+    )
+
     if _rank_not_in_group(group):
         _warn_not_in_group("broadcast_multigpu")
         return
@@ -1425,6 +1430,11 @@ def all_reduce_multigpu(tensor_list, op=ReduceOp.SUM, group=None, async_op=False
         None, if not async_op or if not part of the group
 
     """
+    warnings.warn(
+        "torch.distributed.all_reduce_multigpu will be deprecated. If you must "
+        "use it, please revisit our documentation later."
+    )
+
     if _rank_not_in_group(group):
         return
 
@@ -1609,6 +1619,11 @@ def reduce_multigpu(
         None, otherwise
 
     """
+    warnings.warn(
+        "torch.distributed.reduce_multigpu will be deprecated. If you must "
+        "use it, please revisit our documentation later."
+    )
+
     if _rank_not_in_group(group):
         _warn_not_in_group("reduce_multigpu")
         return
@@ -1722,6 +1737,11 @@ def all_gather_multigpu(
         None, if not async_op or if not part of the group
 
     """
+    warnings.warn(
+        "torch.distributed.all_gather_multigpu will be deprecated. If you must "
+        "use it, please revisit our documentation later."
+    )
+
     if _rank_not_in_group(group):
         _warn_not_in_group("all_gather_multigpu")
         return
@@ -2618,6 +2638,11 @@ def reduce_scatter_multigpu(
         None, if not async_op or if not part of the group.
 
     """
+    warnings.warn(
+        "torch.distributed.reduce_scatter_multigpu will be deprecated. If you must "
+        "use it, please revisit our documentation later."
+    )
+
     if _rank_not_in_group(group):
         _warn_not_in_group("reduce_scatter_multigpu")
         return


### PR DESCRIPTION
### Deprecation reasons:
- For most users training is on one GPU per process so these APIs are rarely used 
- They added one more API dimension
- They can be expressed in a composed manner
- They are not abstracted – specific to GPU
- They caused backend APIs and implementations to have nested `std::vector<std::vector<Tensor>>`, which is hard to read or maintain
