### PR TITLE
[functorch] refactor: get_exhaustive_batched_inputs

### DIFF
--- a/functorch/test/common_utils.py
+++ b/functorch/test/common_utils.py
@@ -197,7 +197,8 @@ def generate_vmap_inputs(arg_values, kwarg_values, is_batch_norm_and_training=Fa
     # batch it since running_mean/var will be seen as unbatched tensors
     if num_tensors == 1 and is_batch_norm_and_training:
         return
-    bdim_choices = get_bdim_choices(num_tensors)
+    bdim_choices = get_bdim_choices_batch_norm(
+        num_tensors, **arg_values) if is_batch_norm_and_training else get_bdim_choices(num_tensors)
 
     @memoize
     def get_batched_arg(arg, bdim):

--- a/functorch/test/common_utils.py
+++ b/functorch/test/common_utils.py
@@ -173,10 +173,17 @@ def construct_in_dims(bdim_choice_for_tensors, is_tensors):
         result.append(next(bdim))
     return tuple(result)
 
-def get_exhaustive_batched_inputs(arg_values, kwarg_values, batch_size=2):
+
+def get_exhaustive_batched_inputs(arg_values, kwarg_values, batch_size=2,
+                                  is_batch_norm_and_training=False):
     flat_args, arg_spec = pytree.tree_flatten(tuple(arg_values))
     is_tensors = [isinstance(a, torch.Tensor) for a in flat_args]
-    bdim_choices = get_bdim_choices(sum(is_tensors))
+    num_tensors = sum(is_tensors)
+    # For Batch Norm, if there's only an input, we can't
+    # batch it since running_mean/var will be seen as unbatched tensors
+    if num_tensors == 1 and is_batch_norm_and_training:
+        return
+    bdim_choices = get_bdim_choices(num_tensors)
 
     @memoize
     def get_batched_arg(arg, bdim):
@@ -210,36 +217,9 @@ def is_batch_norm_training(op_name, kwarg_values):
         return is_training[0]
 
 
-def get_exhaustive_batched_inputs_batch_norm_is_training(arg_values, kwarg_values, batch_size=2):
-    flat_args, arg_spec = pytree.tree_flatten(tuple(arg_values))
-    is_tensors = [isinstance(a, torch.Tensor) for a in flat_args]
-    num_tensors = sum(is_tensors)
-    if num_tensors == 1:  # if there's only an input, can't batch it since running_mean/var will be seen as unbatched tensors
-        return
-    bdim_choices = get_bdim_choices_batch_norm(num_tensors, *arg_values)
-
-    @memoize
-    def get_batched_arg(arg, bdim):
-        assert isinstance(arg, torch.Tensor)
-        assert bdim is not None
-        result, _ = add_batch_dim(arg, bdim, batch_size)
-        return result
-
-    for bdim_choice in bdim_choices:
-        flat_in_dims = construct_in_dims(bdim_choice, is_tensors)
-
-        flat_batched_args = tuple(arg if in_dim is None else get_batched_arg(arg, in_dim)
-                                  for arg, in_dim in zip(flat_args, flat_in_dims))
-        batched_args = pytree.tree_unflatten(flat_batched_args, arg_spec)
-        in_dims = pytree.tree_unflatten(flat_in_dims, arg_spec)
-        yield batched_args, in_dims, kwarg_values
-
-
 def generate_vmap_inputs(args, kwargs, is_batch_norm_and_training=False, batch_size=2):
-    if is_batch_norm_and_training:
-        return get_exhaustive_batched_inputs_batch_norm_is_training(
-            args, kwargs, batch_size)
-    return get_exhaustive_batched_inputs(args, kwargs, batch_size)
+    return get_exhaustive_batched_inputs(args, kwargs, batch_size,
+                                         is_batch_norm_and_training=is_batch_norm_and_training)
 
 
 def clone_if_tensor(x):

--- a/functorch/test/common_utils.py
+++ b/functorch/test/common_utils.py
@@ -198,7 +198,7 @@ def generate_vmap_inputs(arg_values, kwarg_values, is_batch_norm_and_training=Fa
     if num_tensors == 1 and is_batch_norm_and_training:
         return
     bdim_choices = get_bdim_choices_batch_norm(
-        num_tensors, **arg_values) if is_batch_norm_and_training else get_bdim_choices(num_tensors)
+        num_tensors, *arg_values) if is_batch_norm_and_training else get_bdim_choices(num_tensors)
 
     @memoize
     def get_batched_arg(arg, bdim):

--- a/functorch/test/test_ops.py
+++ b/functorch/test/test_ops.py
@@ -21,7 +21,7 @@ from functorch_additional_op_db import additional_op_db
 from torch.testing._internal.common_methods_invocations import op_db
 from common_utils import (
     get_fallback_and_vmap_exhaustive,
-    get_exhaustive_batched_inputs,
+    generate_vmap_inputs,
     decorate,
     xfail,
     skip,
@@ -1083,8 +1083,8 @@ class TestOperators(TestCase):
             kwargs = sample.kwargs
 
             is_batch_norm_and_training = is_batch_norm and is_batch_norm_training(op.name, kwargs)
-            generator = get_exhaustive_batched_inputs(args, kwargs,
-                                                      is_batch_norm_and_training=is_batch_norm_and_training)
+            generator = generate_vmap_inputs(args, kwargs,
+                                             is_batch_norm_and_training=is_batch_norm_and_training)
 
             for batched_args, in_dims, kwargs in generator:
                 vmapped_op = vmap(op, in_dims)

--- a/functorch/test/test_ops.py
+++ b/functorch/test/test_ops.py
@@ -22,7 +22,6 @@ from torch.testing._internal.common_methods_invocations import op_db
 from common_utils import (
     get_fallback_and_vmap_exhaustive,
     get_exhaustive_batched_inputs,
-    get_exhaustive_batched_inputs_batch_norm_is_training,
     decorate,
     xfail,
     skip,
@@ -1082,10 +1081,10 @@ class TestOperators(TestCase):
         for sample in samples:
             args = [sample.input] + list(sample.args)
             kwargs = sample.kwargs
-            if is_batch_norm and is_batch_norm_training(op.name, kwargs):
-                generator = get_exhaustive_batched_inputs_batch_norm_is_training(args, kwargs)
-            else:
-                generator = get_exhaustive_batched_inputs(args, kwargs)
+
+            is_batch_norm_and_training = is_batch_norm and is_batch_norm_training(op.name, kwargs)
+            generator = get_exhaustive_batched_inputs(args, kwargs,
+                                                      is_batch_norm_and_training=is_batch_norm_and_training)
 
             for batched_args, in_dims, kwargs in generator:
                 vmapped_op = vmap(op, in_dims)


### PR DESCRIPTION
`get_exhaustive_batched_inputs_batch_norm_is_training` and `get_exhaustive_batched_inputs` are same except for a couple of lines.

We move the above functionality into `generate_vmap_inputs` (which is now only function to create batched inputs)