### PR TITLE
Disallow saved tensor hooks in functorch transforms

### DIFF
--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -12,7 +12,7 @@ from torch.utils._pytree import tree_flatten, tree_unflatten, tree_map
 from .pytree_hacks import tree_map_, treespec_pprint
 import torch.autograd.forward_ad as fwAD
 
-from .vmap import vmap
+from .vmap import vmap, doesnt_support_saved_tensors_hooks
 from torch._decomp import decomposition_table
 
 from torch._C._functorch import (
@@ -262,6 +262,7 @@ def vjp(func: Callable, *primals, has_aux: bool = False):
     return _vjp_with_argnums(func, *primals, has_aux=has_aux)
 
 
+@doesnt_support_saved_tensors_hooks
 def _vjp_with_argnums(func: Callable, *primals, argnums: Optional[argnums_t] = None, has_aux: bool = False):
     # This is the same function as vjp but also accepts an argnums argument
     # All args are the same as vjp except for the added argument
@@ -789,6 +790,7 @@ def jvp(func: Callable, primals: Any, tangents: Any, *, strict: bool = False, ha
     return _jvp_with_argnums(func, primals, tangents, argnums=None, strict=strict, has_aux=has_aux)
 
 
+@doesnt_support_saved_tensors_hooks
 def _jvp_with_argnums(func: Callable, primals: Any, tangents: Any, argnums: Optional[argnums_t], *,
                       strict: bool = False, has_aux: bool):
     # This is the same function as jvp but also accepts an argnums argument
@@ -1096,6 +1098,7 @@ def grad_and_value(func: Callable, argnums: argnums_t = 0, has_aux: bool = False
 
     See :func:`grad` for examples
     """
+    @doesnt_support_saved_tensors_hooks
     @wraps(func)
     def wrapper(*args, **kwargs):
         level = _grad_increment_nesting()
@@ -1441,6 +1444,7 @@ def functionalize(func: Callable, *, remove: str = 'mutations') -> Callable:
             " replaced with their non-aliasing counterparts, {view}_copy.\n"
         )
 
+    @doesnt_support_saved_tensors_hooks
     @wraps(func)
     def wrapped(*args, **kwargs):
         try:

--- a/functorch/_src/vmap.py
+++ b/functorch/_src/vmap.py
@@ -23,6 +23,19 @@ in_dims_t = Union[int, Tuple]
 out_dims_t = Union[int, Tuple[int, ...]]
 
 
+def doesnt_support_saved_tensors_hooks(f):
+    message = (
+        "functorch transforms don't yet support saved tensor hooks. "
+        "Please open an issue with your use case."
+    )
+
+    @functools.wraps(f)
+    def fn(*args, **kwargs):
+        with torch.autograd.graph._disable_saved_tensors_hooks(message):
+            return f(*args, **kwargs)
+    return fn
+
+
 # Checks that all args-to-be-batched have the same batch dim size
 def _validate_and_get_batch_size(
         flat_in_dims: List[Optional[int]],
@@ -468,6 +481,7 @@ def _check_randomness_arg(randomness):
         raise RuntimeError(f"Only allowed values for randomness are 'error', 'different', or 'same'. Got {randomness}")
 
 
+@doesnt_support_saved_tensors_hooks
 def _flat_vmap(func, batch_size, flat_in_dims, flat_args, args_spec, out_dims, randomness, **kwargs):
     vmap_level = _vmap_increment_nesting(batch_size, randomness)
     try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #85972
* #85971

Technically they may only be a problem with the grad transform. Though
the branch cut is soon, this is the more conservative change, it also
lets us disable checkpointing for functorch (which definitely doesn't
work with all transforms) and not a lot of people use saved tensor hooks
with functorch (I discovered this while testing).

Test Plan:
- new tests

Differential Revision: [D39970934](https://our.internmc.facebook.com/intern/diff/D39970934)