### PR TITLE
[functorch] fix whirlwind tour ipynb

### DIFF
--- a/functorch/notebooks/whirlwind_tour.ipynb
+++ b/functorch/notebooks/whirlwind_tour.ipynb
@@ -45,6 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import torch\n",
     "from functorch import grad\n",
     "x = torch.randn([])\n",
     "cos_x = grad(lambda x: torch.sin(x))(x)\n",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #85981
* #85980
* __->__ #85974

It was missing an "import torch"