### PR TITLE
Add A Permutted Strides Input To Unary Opinfos

### DIFF
--- a/torch/testing/_creation.py
+++ b/torch/testing/_creation.py
@@ -22,7 +22,7 @@ def make_tensor(
     requires_grad: bool = False,
     noncontiguous: bool = False,
     exclude_zero: bool = False,
-    stride_ordering: Optional[List[int]] = None,
+    stride_permutation: Optional[List[int]] = None,
 ) -> torch.Tensor:
     r"""Creates a tensor with the given :attr:`shape`, :attr:`device`, and :attr:`dtype`, and filled with
     values uniformly drawn from ``[low, high)``.
@@ -65,8 +65,8 @@ def make_tensor(
             :attr:`dtype`'s :func:`~torch.finfo` object), and for complex types it is replaced with a complex number
             whose real and imaginary parts are both the smallest positive normal number representable by the complex
             type. Default ``False``.
-        memory_permutation (Optional[bool]): If not None, the returned tensor will be dense with permutted strides.
-            Channels-last would be passed in as [0, 2, 3, 1] (NHWC)
+        stride_permutation (Optional[bool]): Sets a stride permutation on the returned tensor. For example, a
+            channels-last permutation would be passed in as [0, 2, 3, 1]
 
     Raises:
         ValueError: if ``requires_grad=True`` is passed for integral `dtype`
@@ -146,14 +146,14 @@ def make_tensor(
     else:
         raise TypeError(f"The requested dtype '{dtype}' is not supported by torch.testing.make_tensor()."
                         " To request support, file an issue at: https://github.com/pytorch/pytorch/issues")
-    if stride_ordering:
+    if stride_permutation:
         strides = [None for _ in range(len(shape))]
-        assert len(shape) == len(stride_ordering)
+        assert len(shape) == len(stride_permutation)
         prod = 1
         ndim = len(shape)
         for i in range(ndim):
-            strides[stride_ordering[ndim - 1 - i]] = prod
-            prod *= shape[stride_ordering[ndim - 1 - i]]
+            strides[stride_permutation[ndim - 1 - i]] = prod
+            prod *= shape[stride_permutation[ndim - 1 - i]]
         result = torch.as_strided(result, shape, strides)
 
     if noncontiguous and result.numel() > 1:

--- a/torch/testing/_creation.py
+++ b/torch/testing/_creation.py
@@ -148,13 +148,14 @@ def make_tensor(
                         " To request support, file an issue at: https://github.com/pytorch/pytorch/issues")
     if stride_permutation is not None:
         strides = [None for _ in range(len(shape))]
-        assert len(shape) == len(stride_permutation)
-        prod = 1
         ndim = len(shape)
+        if ndim != len(stride_permutation):
+            raise ValueError(f"Length of shape must equal length of stride permutation, {ndim} != {len(stride_permutation)}")
+        prod = 1
         for i in range(ndim):
-            strides[stride_permutation[ndim - 1 - i]] = prod
+            strides[stride_permutation[ndim - 1 - i]] = prod  # type: ignore[call-overload]
             prod *= shape[stride_permutation[ndim - 1 - i]]
-        result = torch.as_strided(result, shape, strides)
+        result = torch.as_strided(result, shape, strides)  # type: ignore[arg-type]
 
     if noncontiguous and result.numel() > 1:
         result = torch.repeat_interleave(result, 2, dim=-1)

--- a/torch/testing/_creation.py
+++ b/torch/testing/_creation.py
@@ -65,7 +65,7 @@ def make_tensor(
             :attr:`dtype`'s :func:`~torch.finfo` object), and for complex types it is replaced with a complex number
             whose real and imaginary parts are both the smallest positive normal number representable by the complex
             type. Default ``False``.
-        stride_permutation (Optional[bool]): Sets a stride permutation on the returned tensor. For example, a
+        stride_permutation (Optional[List[int]]): Sets a stride permutation on the returned tensor. For example, a
             channels-last permutation would be passed in as [0, 2, 3, 1]
 
     Raises:

--- a/torch/testing/_creation.py
+++ b/torch/testing/_creation.py
@@ -146,7 +146,7 @@ def make_tensor(
     else:
         raise TypeError(f"The requested dtype '{dtype}' is not supported by torch.testing.make_tensor()."
                         " To request support, file an issue at: https://github.com/pytorch/pytorch/issues")
-    if stride_permutation:
+    if stride_permutation is not None:
         strides = [None for _ in range(len(shape))]
         assert len(shape) == len(stride_permutation)
         prod = 1

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -2517,7 +2517,7 @@ def sample_inputs_foreach(
         return [
             make_tensor((N, N), dtype=dtype, device=device, noncontiguous=noncontiguous)
             for _ in range(N)
-        ] + make_tensor((N, N), dtype=dtype, device=device, stride_permutation = [1, 0])
+        ]
     else:
         return [
             make_tensor(

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -2038,10 +2038,11 @@ def sample_inputs_elementwise_unary(
             low=low,
             high=high,
             requires_grad=requires_grad,
-            stride_permutation=[0, 2, 3, 1]
+            stride_permutation=[0, 2, 3, 1],
         ),
         kwargs=op_kwargs,
     )
+
 
 # Replace values satisfying condition with a safe value. This is used to block
 # out values the could cause singularity like tan(pi/2)
@@ -2135,7 +2136,10 @@ def generate_elementwise_unary_tensors(op, *, device, dtype, requires_grad, **kw
         yield SampleInput(a, kwargs=op.sample_kwargs(device, dtype, a)[0])
 
     make_arg_channels_last = partial(make_arg, stride_permutation=[0, 2, 3, 1])
-    yield SampleInput(make_arg((2, 3, 4, 5)), kwargs=op.sample_kwargs(device, dtype, a)[0])
+    yield SampleInput(
+        make_arg((2, 3, 4, 5)), kwargs=op.sample_kwargs(device, dtype, a)[0]
+    )
+
 
 def generate_elementwise_unary_small_value_tensors(
     op, *, device, dtype, requires_grad=False

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -2038,7 +2038,7 @@ def sample_inputs_elementwise_unary(
             low=low,
             high=high,
             requires_grad=requires_grad,
-            stride_ordering=[0, 2, 3, 1]
+            stride_permutation=[0, 2, 3, 1]
         ),
         kwargs=op_kwargs,
     )
@@ -2134,7 +2134,7 @@ def generate_elementwise_unary_tensors(op, *, device, dtype, requires_grad, **kw
         a = make_arg(shape)
         yield SampleInput(a, kwargs=op.sample_kwargs(device, dtype, a)[0])
 
-    make_arg_channels_last = partial(make_arg, stride_ordering=[0, 2, 3, 1])
+    make_arg_channels_last = partial(make_arg, stride_permutation=[0, 2, 3, 1])
     yield SampleInput(make_arg((2, 3, 4, 5)), kwargs=op.sample_kwargs(device, dtype, a)[0])
 
 def generate_elementwise_unary_small_value_tensors(
@@ -2517,7 +2517,7 @@ def sample_inputs_foreach(
         return [
             make_tensor((N, N), dtype=dtype, device=device, noncontiguous=noncontiguous)
             for _ in range(N)
-        ] + make_tensor((N, N), dtype=dtype, device=device, stride_ordering = [1, 0])
+        ] + make_tensor((N, N), dtype=dtype, device=device, stride_permutation = [1, 0])
     else:
         return [
             make_tensor(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #85976

Adds a mechanism to create tensors with a permutted stride in `make_tensor`, and then adds a channels last tensor input to a couple of sample generation mechanisms `sample_inputs_elementwise_unary` and `generate_elementwise_unary_tensors`. 

I think in a subsequent test we should add a OpInfo test that asserts for every operator we're testing we are generating a permutted stride input. 
