### PR TITLE
[BE] Get rid of `std::result_of` in `c10`

### DIFF
--- a/c10/util/FunctionRef.h
+++ b/c10/util/FunctionRef.h
@@ -55,7 +55,7 @@ class function_ref<Ret(Params...)> {
           typename std::remove_reference<Callable>::type,
           function_ref>::value>::type* = nullptr,
       typename std::enable_if<std::is_convertible<
-          typename std::result_of<Callable && (Params && ...)>::type,
+          typename c10::invoke_result_t<Callable, Params...>,
           Ret>::value>::type* = nullptr)
       : callback(callback_fn<typename std::remove_reference<Callable>::type>),
         callable(reinterpret_cast<intptr_t>(&callable)) {}


### PR DESCRIPTION
As it is a deprecated and to be removed in C++20

Fixes https://github.com/pytorch/pytorch/issues/85962
