### PR TITLE
[BE] Generate names of known device from array

### DIFF
--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -47,9 +47,17 @@ DeviceType parse_type(const std::string& device_string) {
   if (device != types.end()) {
     return device->second;
   }
+  std::vector<const char*> device_names;
+  for (const auto& it : types) {
+    if (it.first) {
+      device_names.push_back(it.first);
+    }
+  }
   TORCH_CHECK(
       false,
-      "Expected one of cpu, cuda, ipu, xpu, mkldnn, opengl, opencl, ideep, hip, ve, ort, mps, xla, lazy, vulkan, meta, hpu, privateuseone device type at start of device string: ",
+      "Expected one of ",
+      c10::Join(", ", device_names),
+      " device type at start of device string: ",
       device_string);
 }
 enum DeviceStringParsingState { START, INDEX_START, INDEX_REST, ERROR };


### PR DESCRIPTION
Rather than hardcoding list of device names, generate it from list of known types.
Performance is not important at the error codepath, as it will not be evaluated during normal codepath.
