### PR TITLE
[Static Runtime] Block linalg_svdvals codegen & run codegen script

### DIFF
--- a/benchmarks/static_runtime/test_generated_ops.cc
+++ b/benchmarks/static_runtime/test_generated_ops.cc
@@ -7704,38 +7704,6 @@ TEST(StaticRuntime, autogen_outer) {
       /*check_resize=*/true);
 }
 
-TEST(StaticRuntime, autogen_linalg_svdvals) {
-  const std::string script = R"IR(
-    graph(%A: Tensor, %driver: str?):
-        %bias: None = prim::Constant()
-        %ret = aten::linalg_svdvals(%A, %driver)
-        %cloned = aten::clone(%ret, %bias)
-        return (%cloned)
-  )IR";
-
-  auto A0 = at::rand({6, 6, 6});
-  auto driver0 = "floor";
-  std::vector<IValue> args{A0, driver0};
-  testStaticRuntime(
-      script,
-      args,
-      {},
-      /*use_allclose=*/false,
-      /*use_equalnan=*/false,
-      /*check_resize=*/true);
-
-  auto A1 = at::rand({22, 22, 22});
-  auto driver1 = "floor";
-  std::vector<IValue> args2{A1, driver1};
-  testStaticRuntime(
-      script,
-      args,
-      args2,
-      /*use_allclose=*/false,
-      /*use_equalnan=*/false,
-      /*check_resize=*/true);
-}
-
 TEST(StaticRuntime, autogen_linalg_cond) {
   const std::string script = R"IR(
     graph(%self: Tensor, %p: int?):

--- a/torch/csrc/jit/runtime/static/generated_ops.cpp
+++ b/torch/csrc/jit/runtime/static/generated_ops.cpp
@@ -4864,28 +4864,6 @@ REGISTER_OPERATOR_FUNCTOR(aten::outer, aten_outer, [](Node* n) -> SROperator {
 });
 
 REGISTER_OPERATOR_FUNCTOR(
-    aten::linalg_svdvals,
-    aten_linalg_svdvals,
-    [](Node* n) -> SROperator {
-      if (n->matches(torch::schema(
-              "aten::linalg_svdvals(Tensor A, *, str? driver=None) -> Tensor"))) {
-        return [](ProcessedNode* p_node) {
-          const auto& A = p_node->Input(0).toTensor();
-          const auto driver = p_node->Input(1).toOptional<c10::string_view>();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::native::linalg_svdvals(A, driver);
-            return;
-          }
-          auto& out = p_node->Output(0).toTensor();
-          fastResizeToZero(out);
-          at::native::linalg_svdvals_out(A, driver, out);
-        };
-      }
-      LogAndDumpSchema(n);
-      return nullptr;
-    });
-
-REGISTER_OPERATOR_FUNCTOR(
     aten::linalg_cond,
     aten_linalg_cond,
     [](Node* n) -> SROperator {

--- a/torchgen/static_runtime/generator.py
+++ b/torchgen/static_runtime/generator.py
@@ -42,6 +42,7 @@ BLOCKED_OPS = frozenset(
         # non cpu ops
         "sparse_sampled_addmm",
         "hspmm",
+        "linalg_svdvals",
         # sparse ops
         "sspaddmm",
         "coalesce",
@@ -220,6 +221,7 @@ BLOCKED_OPS = frozenset(
         "special_shifted_chebyshev_polynomial_w",
         "special_spherical_bessel_j0",
         "_foobar",
+        "_nested_tensor_strides",
     )
 )
 


### PR DESCRIPTION
Summary:
The test is causing issues:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
    graph(%A: Tensor, %driver: str?):
        %bias: None = prim::Constant()
        %ret = aten::linalg_svdvals(%A, %driver)
               ~~~~ <--- HERE
        %cloned = aten::clone(%ret, %bias)
        return (%cloned)
RuntimeError: torch.linalg.svd: keyword argument `driver=` is only supported on CUDA inputs with cuSOLVER backend.
```

Just block the op and re-run the codegen script to remove everything and update the generated ops.

Test Plan: Existing tests

Differential Revision: D39973860

