### PR TITLE
Lazily load decompositions for jvp

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -896,29 +896,6 @@ def compiled_with_cxx11_abi():
 from torch._ops import ops
 from torch._classes import classes
 
-# Import from torch._decomp import decompositions_for_jvp to register
-# decompositions for jvp to the jit registry
-# (decompositions_for_jvp depends on torch.ops, so we place it after)
-#
-# FIXME: We specify that __debug__ must be True because
-# if python is run with -OO or -O flags (i.e., __debug__ is False), we encounter the
-# following error:
-#
-# Return value was annotated as having type Tuple[NoneType, NoneType] but is actually of
-# type Tuple[Tensor, Tensor]:
-#   File ".../torch/_decomp/__init__.py", line 1585
-#     else:
-#         buffer = z
-#     return min - torch.log1p(z), buffer
-#     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
-# Currently broken for 3.11, see https://github.com/pytorch/pytorch/issues/85506
-if (os.environ.get("PYTORCH_JIT", "1" if sys.version_info < (3, 11) else "0") == "1" and
-        __debug__ and
-        not torch._C._is_deploy_enabled() and
-        os.environ.get('PYTORCH_DISABLE_LIBRARY', "0") == "0"):
-    from torch._decomp import decompositions_for_jvp
-    del decompositions_for_jvp
-
 # quantization depends on torch.fx
 # Import quantization
 from torch import quantization as quantization

--- a/torch/autograd/forward_ad.py
+++ b/torch/autograd/forward_ad.py
@@ -1,4 +1,6 @@
 import torch
+import os
+import sys
 from .grad_mode import _DecoratorContextManager
 from collections import namedtuple
 
@@ -66,6 +68,29 @@ def make_dual(tensor, tangent, *, level=None):
     for detailed steps on how to use this API.
 
     """
+    # See NOTE: [forward-mode AD decompositions mechanism]
+    #
+    # Import from torch._decomp import decompositions_for_jvp to register
+    # decompositions for jvp to the jit registry
+    #
+    # FIXME: We specify that __debug__ must be True because
+    # if python is run with -OO or -O flags (i.e., __debug__ is False), we encounter the
+    # following error:
+    #
+    # Return value was annotated as having type Tuple[NoneType, NoneType] but is actually of
+    # type Tuple[Tensor, Tensor]:
+    #   File ".../torch/_decomp/__init__.py", line 1585
+    #     else:
+    #         buffer = z
+    #     return min - torch.log1p(z), buffer
+    #     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
+    # Currently broken for 3.11, see https://github.com/pytorch/pytorch/issues/85506
+    if (os.environ.get("PYTORCH_JIT", "1" if sys.version_info < (3, 11) else "0") == "1" and
+            __debug__ and
+            not torch._C._is_deploy_enabled() and
+            os.environ.get('PYTORCH_DISABLE_LIBRARY', "0") == "0"):
+        from torch._decomp import decompositions_for_jvp  # noqa: F401
+
     if level is None:
         level = _current_level
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #85849
* #79056
* #85711
* __->__ #85989
* #85634

Reduces time it takes to run `python -c "import torch"` by ~10%

See https://github.com/pytorch/pytorch/issues/85513