### PR TITLE
Fix the error with constant_pad_nd for 4D+ padding

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -296,6 +296,11 @@ Tensor replication_pad3d_backward_mps(const Tensor& grad_output, const Tensor& i
 // backward pass is exlicitly handled in autograd by negating the "pad" argument
 Tensor constant_pad_nd_mps(const Tensor& self, IntArrayRef pad, const Scalar& value)
 {
+  if (pad.size() > 6) {
+    TORCH_WARN_ONCE("MPS: The constant padding of more than 3 dimensions is not currently supported natively. ",
+                    "It uses View Ops default implementation to run. This may have performance implications.");
+    return at::native::constant_pad_nd(self, pad, value);
+  }
   Tensor output = at::empty({0}, self.options());
   return mps::pad_out_template(output, self, pad, c10::nullopt, MPSGraphPaddingModeConstant, value.toDouble(), __func__);
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3468,6 +3468,13 @@ class TestNLLLoss(TestCase):
 
         self.assertEqual(y_cpu, y_mps.cpu())
 
+    def test_constant_pad_4d_warning(self):
+        inputCPU = torch.rand((1, 2, 2, 2, 1, 1))
+        inputMPS = inputCPU.detach().clone().to('mps')
+        outputCPU = F.pad(inputCPU, [0, 0, 0, 0, 0, 0, 1, 0])
+        outputMPS = F.pad(inputMPS, [0, 0, 0, 0, 0, 0, 1, 0])
+        self.assertEqual(outputCPU, outputMPS)
+
     def test_pad(self):
         def helper(shape, padding, op, value=0):
             inputCPU = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=True)


### PR DESCRIPTION
- We warn the user and fall back to default implementation for 4D+ constant padding

Fixes #84535
