### PR TITLE
Change torch.autograd.graph.disable_saved_tensors_hooks to be public API

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -273,3 +273,5 @@ Also see :ref:`saved-tensors-hooks-doc`.
 .. autoclass:: torch.autograd.graph.saved_tensors_hooks
 
 .. autoclass:: torch.autograd.graph.save_on_cpu
+
+.. autoclass:: torch.autograd.graph.disable_saved_tensors_hooks

--- a/functorch/_src/vmap.py
+++ b/functorch/_src/vmap.py
@@ -31,7 +31,7 @@ def doesnt_support_saved_tensors_hooks(f):
 
     @functools.wraps(f)
     def fn(*args, **kwargs):
-        with torch.autograd.graph._disable_saved_tensors_hooks(message):
+        with torch.autograd.graph.disable_saved_tensors_hooks(message):
             return f(*args, **kwargs)
     return fn
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6719,7 +6719,7 @@ for shape in [(1,), ()]:
         self.assertEqual(2 * 3 * 3 * b, b.grad)
 
     def test_disabling_saved_tensor_hooks(self):
-        with torch.autograd.graph._disable_saved_tensors_hooks("error message"):
+        with torch.autograd.graph.disable_saved_tensors_hooks("error message"):
             with self.assertRaisesRegex(RuntimeError, "error message"):
                 with torch.autograd.graph.saved_tensors_hooks(lambda x: x, lambda x: x):
                     pass
@@ -6728,15 +6728,15 @@ for shape in [(1,), ()]:
 
         with torch.autograd.graph.saved_tensors_hooks(lambda x: x, lambda x: x):
             with self.assertRaisesRegex(RuntimeError, "error message"):
-                with torch.autograd.graph._disable_saved_tensors_hooks("error message"):
+                with torch.autograd.graph.disable_saved_tensors_hooks("error message"):
                     pass
 
         self.assertTrue(torch._C._autograd._saved_tensors_hooks_is_enabled())
 
     def test_disabling_saved_tensor_hooks_nested(self):
-        with torch.autograd.graph._disable_saved_tensors_hooks("outer"):
-            with self.assertRaisesRegex(RuntimeError, "inner"):
-                with torch.autograd.graph._disable_saved_tensors_hooks("inner"):
+        with torch.autograd.graph.disable_saved_tensors_hooks("outer"):
+            with torch.autograd.graph.disable_saved_tensors_hooks("inner"):
+                with self.assertRaisesRegex(RuntimeError, "inner"):
                     with torch.autograd.graph.saved_tensors_hooks(lambda x: x, lambda x: x):
                         pass
 

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -136,7 +136,26 @@ class save_on_cpu(saved_tensors_hooks):
 
 
 @contextlib.contextmanager
-def _disable_saved_tensors_hooks(error_message):
+def disable_saved_tensors_hooks(error_message):
+    """Context-manager that disables the saved tensors default hooks feature.
+
+    Useful for if you are creating a feature that does not work with saved
+    tensors default hooks.
+
+    Args:
+        error_message (str): When saved tensors default hooks are used when they
+                             have been are disabled, a RuntimeError with this
+                             error message gets raised.
+
+    Example::
+
+        >>> message = "saved tensors default hooks are disabled"
+        >>> with torch.autograd.graph.disable_saved_tensors_hooks(message):
+        ...     # Raises RuntimeError: saved tensors default hooks are disabled
+        ...     with torch.autograd.graph.save_on_cpu():
+        ...         pass
+
+    """
     try:
         maybe_prev_message = torch._C._autograd._saved_tensors_hooks_get_disabled_error_message()
         torch._C._autograd._saved_tensors_hooks_disable(error_message)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #85994
* #85972
* #85971

Also addresses some comments from the review in
https://github.com/pytorch/pytorch/pull/85971