### PR TITLE
remove vkuzo from CODEOWNERS for AO

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,22 +23,20 @@
 
 # Architecture Optimization (quantization, sparsity, etc.)
 /aten/src/ATen/native/ao_sparse @z-a-f @salilsdesai @kimishpatel @digantdesai @jianyuh
-/aten/src/ATen/native/quantized @vkuzo @jerryzh168 @z-a-f @salilsdesai @kimishpatel @digantdesai @jianyuh
-/aten/src/ATen/native/quantized/cpu @vkuzo @jerryzh168 @z-a-f @salilsdesai @kimishpatel @digantdesai @jianyuh
-/aten/src/ATen/native/quantized/cuda @vkuzo @jerryzh168 @dzdang
-/aten/src/ATen/native/quantized/cudnn @vkuzo @jerryzh168 @dzdang
+/aten/src/ATen/native/quantized @jerryzh168 @z-a-f @salilsdesai @kimishpatel @digantdesai @jianyuh
+/aten/src/ATen/native/quantized/cpu @jerryzh168 @z-a-f @salilsdesai @kimishpatel @digantdesai @jianyuh
+/aten/src/ATen/native/quantized/cuda @jerryzh168 @dzdang
+/aten/src/ATen/native/quantized/cudnn @jerryzh168 @dzdang
 /test/test_quantization.py @jerryzh168
 /test/ao/ @jerryzh168 @z-a-f @hdcharles
 /test/quantization/ @jerryzh168 @z-a-f
-/torch/quantization/ @jerryzh168 @vkuzo
-ao/ @vkuzo
-ao/ns/ @vkuzo
+/torch/quantization/ @jerryzh168
 ao/sparisty/ @z-a-f @hdcharles
 ao/quantization/ @jerryzh168
-nn/intrinsic/ @jerryzh168 @vkuzo
-nn/quantized/ @jerryzh168 @vkuzo
+nn/intrinsic/ @jerryzh168
+nn/quantized/ @jerryzh168
 nn/quantizable/ @jerryzh168 @z-a-f
-nn/qat/ @jerryzh168 @vkuzo
+nn/qat/ @jerryzh168
 
 # Tensorpipe RPC Agent.
 /torch/csrc/distributed/rpc/tensorpipe_agent.cpp @jiayisuse @osalpekar @lw @beauby


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#86038 remove vkuzo from CODEOWNERS for AO**

Summary:

I was added to various places in https://github.com/pytorch/pytorch/pull/79505, this is
too noisy to be useful so taking myself off.  Always happy to help when folks tag me
manually.

Test plan: CI