### PR TITLE
[JIT] Allow freezing modules that contain mutable interfaces

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1588,7 +1588,7 @@ class TestFreezing(JitTestCase):
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 self.idx += 1
-                if self.idx%2 == 1:
+                if self.idx % 2 == 1:
                     self.impl = self.option1
                 else:
                     self.impl = self.option2

--- a/test/jit/test_module_interface.py
+++ b/test/jit/test_module_interface.py
@@ -514,8 +514,7 @@ class TestModuleInterface(JitTestCase):
         m = torch.jit.script(TestModule())
         m.proxy_mod = m.sub
         m.eval()
-        with self.assertRaisesRegex(RuntimeError, "failed to freeze interface attribute 'proxy_mod'"):
-            mf = torch._C._freeze_module(m._c, freezeInterfaces=True)
+        mf = torch._C._freeze_module(m._c, freezeInterfaces=True)
 
     def test_freeze_module_with_inplace_mutation_in_interface(self):
         class SubModule(torch.nn.Module):
@@ -561,8 +560,7 @@ class TestModuleInterface(JitTestCase):
         m.proxy_mod = m.sub
         m.sub.b = m.proxy_mod.b
         m.eval()
-        with self.assertRaisesRegex(RuntimeError, "failed to freeze interface attribute 'proxy_mod'"):
-            mf = torch._C._freeze_module(m._c, freezeInterfaces=True)
+        mf = torch._C._freeze_module(m._c, freezeInterfaces=True)
 
     def test_freeze_module_with_mutated_interface(self):
         class SubModule(torch.nn.Module):
@@ -606,7 +604,7 @@ class TestModuleInterface(JitTestCase):
 
         m = torch.jit.script(TestModule())
         m.eval()
-        with self.assertRaisesRegex(RuntimeError, "failed to freeze interface attribute 'proxy_mod'"):
+        with self.assertRaisesRegex(RuntimeError, "Freezing does not support SetAttr on an interface type."):
             mf = torch._C._freeze_module(m._c, freezeInterfaces=True)
 
     def test_freeze_module_with_interface_and_fork(self):

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -490,7 +490,6 @@ class AttributePropagator {
     return inlined;
   }
 
-
   //   [Note: Inlining interfaces strategy]
   // There's two structures that are relevant to freezing:
   // - the graph describing the computation in a method

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -127,21 +127,26 @@ class AttributePropagator {
     };
 
     std::unordered_map<std::string, std::unordered_set<std::string>>
-        interfacesToRetype;
+        interfacesToReassignType;
 
     for (auto function : preservedMethods_) {
       GRAPH_DEBUG("Analyzing function: " + function->name());
       auto graph = toGraphFunction(*function).graph();
       optimizeSubGraphs(graph, applyInline);
       if (freezeInterfaces_) {
-        inlineInterfaceCalls(graph, interfacesToRetype);
+        inlineInterfaceCalls(graph, interfacesToReassignType);
       }
+    }
+
+    reassignInterfaceTypes(interfacesToReassignType);
+
+    for (auto function : preservedMethods_) {
+      GRAPH_DEBUG("Recording mutable attrs for function: " + function->name());
+      auto graph = toGraphFunction(*function).graph();
       // Record Attributes that are explicitly set in the module.
       // They cannot be folded.
       recordMutableAttrs(graph);
     }
-
-    reassignInterfaceTypes(interfacesToRetype);
 
     for (auto function : preservedMethods_) {
       GRAPH_DEBUG("Propagating function: " + function->name());


### PR DESCRIPTION
This PR allows freezing modules like the one below:
```python
# Ex. 1
        @torch.jit.interface
        class ModuleInterface(torch.nn.Module):
            def forward(self, inp: torch.Tensor) -> torch.Tensor:
                pass

        class ImplementsInterface(torch.nn.Module):
            def __init__(self):
                super(ImplementsInterface, self).__init__()
                self.sum = torch.zeros((2, 2))

            def forward(self, inp: torch.Tensor) -> torch.Tensor:
                self.sum += inp.relu()  # this makes the interface-implementing module mutable
                                        # and previously this would prevent freezing
                return self.sum

        class WrapperModule(torch.nn.Module):
            impl: ModuleInterface

            def __init__(self):
                super().__init__()
                self.impl = ImplementsInterface()

            def forward(self, x: torch.Tensor) -> torch.Tensor:
                return self.impl.forward(x)
```

Previously during freezing, we handle interfaces as shown below:
1. we inline interfaces in any preserved method graphs
2. during `cleanupFrozenModule`, we try to simplify the module data structure (<- this part is unrelated to freezing so far). During this step, if we found that a interface type was mutable, we'd error out; because of the possibility of a module that _swaps out the value of an interface-typed attribute at runtime_.

Below is an example of a module that swaps out the value of an interface-typed attribute at runtime:
```python
# Ex. 2
class MyBadModule(torch.nn.Module):
    impl: MyInterface
    option1: IfaceImpl1
    option2: IfaceImpl2
    ....
    def forward(self, x):
        if x > 0:
            self.impl = self.option1
        else:
            self.impl = self.option2
        ....
```

^ this type of situation cannot be supported by freezing (or at least would be difficult to do correctly) because it greatly complicates the details of handling types and simplifying the module data structure.

But we can still support the first example without _too_ much work:
1. inline the interface code as before
2. check to see if we have any setattrs on interface types; if so, error out
3. otherwise, replace the type of the interface types with the concrete type implementation
4. continue simplifying the module data structure as if we never had any interfaces.