### PR TITLE
[MPS] Fix non-contig to contig tensor copy

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -186,7 +186,9 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_, bool n
     // For View tensors, the storage offset can be bigger than what's being reported by nbytes
     src_total_size = at::detail::computeStorageNbytesContiguous(src.sizes(), src.element_size(), src.storage_offset());
   } else {
-    src = src_;
+    // Views are not the only source of non-contiguous tensors
+    // For example, tensor constructed from ndarray can be non-contagious
+    src = src_.contiguous();
     if (src.dtype() != dst_.dtype()) {
       // In case of dtype change, perform conversion on source device
       src = src.to(dst_.dtype());

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -172,7 +172,6 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
 static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_, bool non_blocking)
 {
   MPSStream* stream = getCurrentMPSStream();
-  Tensor dst;
   Tensor src;
 
   id<MTLDevice> device = MPSDevice::getInstance()->device();
@@ -180,15 +179,16 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_, bool n
   id<MTLBuffer> destBuffer = getMTLBufferStorage(dst_);
   uint64_t src_total_size = 0;
 
-  if (src_.is_view()) {
+  // This is weird, but sometimes this function can be called
+  //  with contiguous destination and non-contiguous source
+  if (src_.is_view() || dst_.is_contiguous() != src_.is_contiguous()) {
     src = src_.to(dst_.dtype()).expand_as(dst_).contiguous();
     // Get the actual size of a View (takes into account the storage offset)
     // For View tensors, the storage offset can be bigger than what's being reported by nbytes
     src_total_size = at::detail::computeStorageNbytesContiguous(src.sizes(), src.element_size(), src.storage_offset());
   } else {
-    // Views are not the only source of non-contiguous tensors
-    // For example, tensor constructed from ndarray can be non-contiguous
-    src = src_.contiguous();
+    TORCH_INTERNAL_ASSERT(src_.strides() == dst_.strides());
+    src = src_;
     if (src.dtype() != dst_.dtype()) {
       // In case of dtype change, perform conversion on source device
       src = src.to(dst_.dtype());

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -187,7 +187,7 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_, bool n
     src_total_size = at::detail::computeStorageNbytesContiguous(src.sizes(), src.element_size(), src.storage_offset());
   } else {
     // Views are not the only source of non-contiguous tensors
-    // For example, tensor constructed from ndarray can be non-contagious
+    // For example, tensor constructed from ndarray can be non-contiguous
     src = src_.contiguous();
     if (src.dtype() != dst_.dtype()) {
       // In case of dtype change, perform conversion on source device

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1642,6 +1642,13 @@ class TestMPS(TestCase):
             mps_result = rotate_subset(mps_data)
             self.assertEqual(cpu_result, mps_result.to("cpu"))
 
+    # See https://github.com/pytorch/pytorch/issues/85967
+    def test_from_numpy_non_contiguous(self):
+        a = np.arange(9).reshape(3,3)[:,:2]
+        t_cpu = torch.tensor(a, device="cpu")
+        t_mps = torch.tensor(a, device="mps")
+        self.assertEqual(t_cpu, t_mps.to("cpu"))
+
 
 class TestLogical(TestCase):
     def _wrap_tensor(self, x, device="cpu", dtype=None, requires_grad=False):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1644,7 +1644,7 @@ class TestMPS(TestCase):
 
     # See https://github.com/pytorch/pytorch/issues/85967
     def test_from_numpy_non_contiguous(self):
-        a = np.arange(9).reshape(3,3)[:,:2]
+        a = np.arange(9).reshape(3, 3)[:, :2]
         t_cpu = torch.tensor(a, device="cpu")
         t_mps = torch.tensor(a, device="mps")
         self.assertEqual(t_cpu, t_mps.to("cpu"))


### PR DESCRIPTION
This handles a rare case when MPS tensor is constructed from non-contiguous CPU tensor.
Fixes https://github.com/pytorch/pytorch/issues/85967
