### PR TITLE
Fix some bugs in SymFloat IValue and toPyObject handling

### DIFF
--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -627,8 +627,9 @@ py::object toPyObject(IValue ivalue) {
     TORCH_CHECK(false, "RRef is only supported with the distributed package");
 #endif
   } else if (ivalue.isSymInt()) {
-    auto si = ivalue.toSymInt();
-    return py::cast(si);
+    return py::cast(ivalue.toSymInt());
+  } else if (ivalue.isSymFloat()) {
+    return py::cast(ivalue.toSymFloat());
   } else {
     AT_ERROR(
         "Missing cases in 'toPyObject'! Can't convert ",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #86078
* #86088
* #86087
* #86080
* #86075
* __->__ #86072

- Test for symbolic cases first before non-symbolic, as symbolic
  ints/floats advertise as being ints/floats
- Add missing case for toPyObject

Signed-off-by: Edward Z. Yang <ezyang@fb.com>