### PR TITLE
Allow functionalize_aten_op to work with non-SymInt signature.

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -276,8 +276,10 @@ struct _functionalize_aten_op final {};
 
 template <class Op, bool symint, class ReturnType, class... ParameterTypes>
 struct _functionalize_aten_op<Op, symint, ReturnType(ParameterTypes...)> final {
-  static ReturnType call(typename c10::maybe_keep_symint<symint, ParameterTypes>::type... args) {
-    using FuncType = ReturnType(typename c10::maybe_keep_symint<symint, ParameterTypes>::type...);
+  static ReturnType call(
+      typename c10::maybe_keep_symint<symint, ParameterTypes>::type... args) {
+    using FuncType = ReturnType(
+        typename c10::maybe_keep_symint<symint, ParameterTypes>::type...);
     auto op = c10::Dispatcher::singleton()
                   .findSchemaOrThrow(
                       (const char*)Op::name, (const char*)Op::overload_name)
@@ -294,10 +296,12 @@ struct _functionalize_aten_op<Op, symint, ReturnType(ParameterTypes...)> final {
 };
 
 template <class Op>
-using functionalize_aten_op = _functionalize_aten_op<Op, false, typename Op::schema>;
+using functionalize_aten_op =
+    _functionalize_aten_op<Op, false, typename Op::schema>;
 
 template <class Op>
-using functionalize_aten_op_symint = _functionalize_aten_op<Op, true, typename Op::schema>;
+using functionalize_aten_op_symint =
+    _functionalize_aten_op<Op, true, typename Op::schema>;
 
 } // namespace functionalization
 } // namespace at

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -271,18 +271,19 @@ TORCH_API void functionalize_op_helper(
     const c10::OperatorHandle& op,
     torch::jit::Stack* stack);
 
-template <class Op, class ReturnType, class... ParameterTypes>
+template <class Op, bool symint, class ReturnType, class... ParameterTypes>
 struct _functionalize_aten_op final {};
 
-template <class Op, class ReturnType, class... ParameterTypes>
-struct _functionalize_aten_op<Op, ReturnType(ParameterTypes...)> final {
-  static ReturnType call(ParameterTypes... args) {
+template <class Op, bool symint, class ReturnType, class... ParameterTypes>
+struct _functionalize_aten_op<Op, symint, ReturnType(ParameterTypes...)> final {
+  static ReturnType call(typename c10::maybe_keep_symint<symint, ParameterTypes>::type... args) {
+    using FuncType = ReturnType(typename c10::maybe_keep_symint<symint, ParameterTypes>::type...);
     auto op = c10::Dispatcher::singleton()
                   .findSchemaOrThrow(
                       (const char*)Op::name, (const char*)Op::overload_name)
-                  .typed<ReturnType(ParameterTypes...)>();
+                  .typed<FuncType>();
 
-    return c10::impl::BoxedKernelWrapper<ReturnType(ParameterTypes...)>::call(
+    return c10::impl::BoxedKernelWrapper<FuncType>::call(
         c10::BoxedKernel::makeFromFunction<functionalize_op_helper>(),
         op,
         // BoxedKernelWrapper knows to ignore this keyset argument,
@@ -293,7 +294,10 @@ struct _functionalize_aten_op<Op, ReturnType(ParameterTypes...)> final {
 };
 
 template <class Op>
-using functionalize_aten_op = _functionalize_aten_op<Op, typename Op::schema>;
+using functionalize_aten_op = _functionalize_aten_op<Op, false, typename Op::schema>;
+
+template <class Op>
+using functionalize_aten_op_symint = _functionalize_aten_op<Op, true, typename Op::schema>;
 
 } // namespace functionalization
 } // namespace at

--- a/aten/src/ATen/core/boxing/KernelFunction.h
+++ b/aten/src/ATen/core/boxing/KernelFunction.h
@@ -42,6 +42,16 @@ struct remove_symint<c10::optional<c10::SymInt>> {
   using type = c10::optional<int64_t>;
 };
 
+
+template <bool symint, typename T>
+struct maybe_keep_symint final {};
+
+template <typename T>
+struct maybe_keep_symint<true, T> { using type = T; };
+
+template <typename T>
+struct maybe_keep_symint<false, T> { using type = typename remove_symint<T>::type; };
+
 template <typename T>
 using fn_has_symint = typename guts::typelist::true_for_any_type<
   has_symint,

--- a/aten/src/ATen/native/CPUFallback.h
+++ b/aten/src/ATen/native/CPUFallback.h
@@ -13,15 +13,6 @@ namespace at { namespace native {
 // External backends can add their own custom logging on top if it to customize their own CPU fallbacks.
 TORCH_API void cpu_fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack);
 
-template <bool symint, typename T>
-struct maybe_keep_symint final {};
-
-template <typename T>
-struct maybe_keep_symint<true, T> { using type = T; };
-
-template <typename T>
-struct maybe_keep_symint<false, T> { using type = typename remove_symint<T>::type; };
-
 // This is a helper function that backends can use to directly call their boxed CPU fallback
 // TODO: update and add a usage example after https://github.com/pytorch/pytorch/pull/58092 lands.
 template<c10::KernelFunction::BoxedKernelFunction* fallback_fn, class Op, bool symint, class ReturnType, class... ParameterTypes>
@@ -29,13 +20,13 @@ struct _call_fallback_fn final {};
 
 template<c10::KernelFunction::BoxedKernelFunction* fallback_fn, class Op, bool symint, class ReturnType, class... ParameterTypes>
 struct _call_fallback_fn<fallback_fn, Op, symint, ReturnType(ParameterTypes...)> final {
-    static ReturnType call(typename maybe_keep_symint<symint, ParameterTypes>::type... args) {
+    static ReturnType call(typename c10::maybe_keep_symint<symint, ParameterTypes>::type... args) {
         auto op = c10::Dispatcher::singleton()
             // TODO: figure out how to make compiler happy without dynamic casts
             .findSchemaOrThrow((const char*) Op::name, (const char*) Op::overload_name)
             //.findSchemaOrThrow("a", "b")
-            .typed<ReturnType (typename maybe_keep_symint<symint, ParameterTypes>::type...)>();
-        return c10::impl::BoxedKernelWrapper<ReturnType (typename maybe_keep_symint<symint, ParameterTypes>::type...)>::call(
+            .typed<ReturnType (typename c10::maybe_keep_symint<symint, ParameterTypes>::type...)>();
+        return c10::impl::BoxedKernelWrapper<ReturnType (typename c10::maybe_keep_symint<symint, ParameterTypes>::type...)>::call(
             c10::BoxedKernel::makeFromFunction<fallback_fn>(),
             op,
             c10::DispatchKeySet(), // we know that the cpu_fallback doesn't use the dispatch keyset.

--- a/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
@@ -442,7 +442,7 @@ at::Tensor LazyNativeFunctions::new_empty_strided_symint(
     c10::optional<at::Device> device,
     c10::optional<bool> pin_memory) {
   return at::functionalization::
-      functionalize_aten_op<ATEN_OP(new_empty_strided)>::call(
+      functionalize_aten_op_symint<ATEN_OP(new_empty_strided)>::call(
           self, size, stride, dtype, layout, device, pin_memory);
 }
 

--- a/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_native_functions.cpp
@@ -451,7 +451,7 @@ at::Tensor LazyNativeFunctions::narrow_copy_symint(
     int64_t dim,
     c10::SymInt start,
     c10::SymInt length) {
-  return at::functionalization::functionalize_aten_op<ATEN_OP(
+  return at::functionalization::functionalize_aten_op_symint<ATEN_OP(
       narrow_copy)>::call(self, dim, start, length);
 }
 at::Tensor LazyNativeFunctions::pixel_shuffle(
@@ -539,7 +539,7 @@ at::Tensor LazyNativeFunctions::slice_backward_symint(
     c10::SymInt start,
     c10::SymInt end,
     c10::SymInt step) {
-  return at::functionalization::functionalize_aten_op<ATEN_OP(
+  return at::functionalization::functionalize_aten_op_symint<ATEN_OP(
       slice_backward)>::call(grad_output, input_sizes, dim, start, end, step);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #86078
* #86088
* #86087
* __->__ #86080
* #86075
* #86072

This is done similarly to how we did CPU fallback template.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>