### PR TITLE
Misspelling Correction PR common_methods_invocations.py

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3104,7 +3104,7 @@ def error_inputs_max_pool1d(op_info, device, **kwargs):
                                      kwargs={'kernel_size': 1, 'stride': 1, 'padding': 0, 'dilation': 0}),
                          error_regex=error_msg)
 
-        # error inputs for invalied output size
+        # error inputs for invalid output size
         # NOTE: CPU vs (CPU with requires_grad and CUDA) error messages are different.
         error_msg = 'Invalid computed output size: -2' if torch.device(device).type == 'cpu' and not requires_grad \
             else \


### PR DESCRIPTION
Noticed a misspelling while looking at Issue #85712. This fix just fixes the mispelling on line #3107.
