### PR TITLE
Add int32_t range check in packed_accessor32 in PyTorch TensorBase

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -569,6 +569,10 @@ class TORCH_API TensorBase {
 
   template<typename T, size_t N, template <typename U> class PtrTraits = DefaultPtrTraits>
   PackedTensorAccessor32<T,N,PtrTraits> packed_accessor32() const& {
+    TORCH_CHECK(
+        impl_->numel() <=
+            static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
+        "numel needs to be smaller than int32_t max; otherwise, please use packed_accessor64");
     return generic_packed_accessor<T,N,PtrTraits,int32_t>();
   }
   template<typename T, size_t N, template <typename U> class PtrTraits = DefaultPtrTraits>


### PR DESCRIPTION
Summary:
As ajtulloch suggested, we can make tensor.packed_accessor32<...>() raise an exception if tensor.numel() > std::numeric_limits<uint32_t>::max().

Trade-off: run-time check overhead (one-time) when doing `packed_accessor32` accessor.

Differential Revision: D39996275

