### PR TITLE
Make test_api compile on DEBUG mode with some compiler versions

### DIFF
--- a/test/cpp/api/static.cpp
+++ b/test/cpp/api/static.cpp
@@ -47,6 +47,8 @@ TEST(TestStatic, EnableIfModule) {
   ASSERT_FALSE(torch::detail::check_not_lvalue_references<std::string&>());
 }
 
+namespace {
+
 struct A : torch::nn::Module {
   int forward() {
     return 5;
@@ -72,6 +74,8 @@ struct D : torch::nn::Module {
 };
 
 struct E : torch::nn::Module {};
+
+} // anonymous namespace
 
 // Put in a function because macros don't handle the comma between arguments to
 // is_same well ...


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #86078
* #86094
* __->__ #86092
* #86091
* #86088
* #86087
* #86080
* #86075
* #86072

The symbol seems to conflict under some compiler versions, giving
an error like "relocation refers to global symbol which is defined in a
discarded section".  Simple enough to put it in an anonymous namespace,
so why not.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>