### PR TITLE
Add PyInterpreterTLS

### DIFF
--- a/aten/src/ATen/ThreadLocalState.cpp
+++ b/aten/src/ATen/ThreadLocalState.cpp
@@ -15,6 +15,7 @@ ThreadLocalState::ThreadLocalState()
       functorch_tls_(functorch::getCopyOfFuncTorchTLS()),
       autograd_tls_(c10::AutogradState::get_tls_state()),
       python_dispatcher_state_(c10::impl::PythonDispatcherTLS::get_state()),
+      py_interpreter_state_(c10::impl::PyInterpreterTLS::get_state()),
       python_torch_function_state_(at::impl::PythonTorchFunctionTLS::get_state()) {
   rf_tls_ = at::get_record_function_tls_();
 
@@ -43,6 +44,8 @@ void ThreadLocalState::setThreadLocalState(
   at::SavedTensorDefaultHooks::set_stack(state.saved_tensors_default_hooks_);
 
   c10::impl::PythonDispatcherTLS::set_state(state.python_dispatcher_state_);
+
+  c10::impl::PyInterpreterTLS::set_state(state.py_interpreter_state_);
 
   c10::ThreadLocalDebugInfo::_forceCurrentDebugInfo(state.debug_info_);
 

--- a/aten/src/ATen/ThreadLocalState.h
+++ b/aten/src/ATen/ThreadLocalState.h
@@ -11,6 +11,7 @@
 #include <ATen/PythonTorchFunctionTLS.h>
 #include <ATen/record_function.h>
 #include <c10/core/impl/PythonDispatcherTLS.h>
+#include <c10/core/impl/PyInterpreterTLS.h>
 #include <c10/core/impl/TorchDispatchModeTLS.h>
 
 namespace at {
@@ -59,7 +60,10 @@ class TORCH_API ThreadLocalState {
   std::shared_ptr<SafePyObject> torch_dispatch_mode_state_;
 
   // TLS for enable_python_dispatcher
-  c10::impl::PyInterpreter* python_dispatcher_state_;
+  bool python_dispatcher_state_;
+
+  // TLS for PyInterpreter
+  const c10::impl::PyInterpreter* py_interpreter_state_;
 
   // TLS for __torch_function__ (mode and disable_torch_function)
   at::impl::PythonTorchFunctionTLS python_torch_function_state_;

--- a/aten/src/ATen/core/PythonFallbackKernel.cpp
+++ b/aten/src/ATen/core/PythonFallbackKernel.cpp
@@ -1,5 +1,6 @@
 #include <c10/core/impl/TorchDispatchModeTLS.h>
 #include <c10/core/impl/PythonDispatcherTLS.h>
+#include <c10/core/impl/PyInterpreterTLS.h>
 #include <ATen/core/PythonFallbackKernel.h>
 #include <c10/core/SafePyObject.h>
 
@@ -89,8 +90,8 @@ void pythonFallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
 }
 
 void pythonDispatcherFallback(const c10::OperatorHandle& op, c10::DispatchKeySet dispatch_keys, torch::jit::Stack* stack) {
-  auto* state = c10::impl::PythonDispatcherTLS::get_state();
-  TORCH_INTERNAL_ASSERT(state, "Hit PythonDispatcher dispatch key but PythonDispatcherTLS was not set");
+  auto* state = c10::impl::PyInterpreterTLS::get_state();
+  TORCH_INTERNAL_ASSERT(state, "Hit PythonDispatcher dispatch key but PyInterpreterTLS was not set");
   (*state)->python_dispatcher(op, dispatch_keys.remove(c10::DispatchKey::PythonDispatcher), stack);
 }
 

--- a/c10/core/impl/PyInterpreterTLS.cpp
+++ b/c10/core/impl/PyInterpreterTLS.cpp
@@ -1,0 +1,21 @@
+#include <c10/core/impl/PyInterpreterTLS.h>
+
+namespace c10 {
+namespace impl {
+
+thread_local const PyInterpreter* pyInterpreterState;
+
+void PyInterpreterTLS::set_state(const PyInterpreter* state) {
+  pyInterpreterState = state;
+}
+
+const PyInterpreter* PyInterpreterTLS::get_state() {
+  return pyInterpreterState;
+}
+
+void PyInterpreterTLS::reset_state() {
+  pyInterpreterState = nullptr;
+}
+
+} // namespace impl
+} // namespace c10

--- a/c10/core/impl/PyInterpreterTLS.cpp
+++ b/c10/core/impl/PyInterpreterTLS.cpp
@@ -3,14 +3,23 @@
 namespace c10 {
 namespace impl {
 
-thread_local const PyInterpreter* pyInterpreterState;
+// This is only ever populated by a non-torchdeploy Python interpreter
+const PyInterpreter* globalPyInterpreterState = nullptr;
+
+// This is only ever populated by torchdeploy Python interpreters
+thread_local const PyInterpreter* pyInterpreterState = nullptr;
+
+void PyInterpreterTLS::set_global_state(const PyInterpreter* state) {
+  globalPyInterpreterState = state;
+}
 
 void PyInterpreterTLS::set_state(const PyInterpreter* state) {
   pyInterpreterState = state;
 }
 
 const PyInterpreter* PyInterpreterTLS::get_state() {
-  return pyInterpreterState;
+  if (pyInterpreterState) return pyInterpreterState;
+  return globalPyInterpreterState;
 }
 
 void PyInterpreterTLS::reset_state() {

--- a/c10/core/impl/PyInterpreterTLS.h
+++ b/c10/core/impl/PyInterpreterTLS.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <c10/core/impl/PyInterpreter.h>
+#include <c10/macros/Macros.h>
+
+namespace c10 {
+namespace impl {
+
+// This TLS is set by torchdeploy ONLY and specifies what the
+// current Python interpreter for a thread is.
+//
+// TODO: maybe we should also set this TLS for non-torchdeploy
+// Python interpreters too; but in that case, it's better as
+// a global variable
+struct C10_API PyInterpreterTLS {
+  static void set_state(const PyInterpreter* state);
+  static const PyInterpreter* get_state();
+  static void reset_state();
+};
+
+} // namespace impl
+} // namespace c10

--- a/c10/core/impl/PyInterpreterTLS.h
+++ b/c10/core/impl/PyInterpreterTLS.h
@@ -8,11 +8,10 @@ namespace impl {
 
 // This TLS is set by torchdeploy ONLY and specifies what the
 // current Python interpreter for a thread is.
-//
-// TODO: maybe we should also set this TLS for non-torchdeploy
-// Python interpreters too; but in that case, it's better as
-// a global variable
 struct C10_API PyInterpreterTLS {
+  // For use by a non-torchdeploy python interpreter
+  static void set_global_state(const PyInterpreter* state);
+  // For use by a torchdeploy python interpreter
   static void set_state(const PyInterpreter* state);
   static const PyInterpreter* get_state();
   static void reset_state();

--- a/c10/core/impl/PythonDispatcherTLS.cpp
+++ b/c10/core/impl/PythonDispatcherTLS.cpp
@@ -6,24 +6,20 @@
 namespace c10 {
 namespace impl {
 
-thread_local PyInterpreter* pythonDispatcherState;
-
-void PythonDispatcherTLS::set_state(PyInterpreter* state) {
+void PythonDispatcherTLS::set_state(bool state) {
   if (state) {
     c10::impl::tls_set_dispatch_key_included(
         DispatchKey::PythonDispatcher, true);
   } else {
     PythonDispatcherTLS::reset_state();
   }
-  pythonDispatcherState = state;
 }
 
-PyInterpreter* PythonDispatcherTLS::get_state() {
-  return pythonDispatcherState;
+bool PythonDispatcherTLS::get_state() {
+  return c10::impl::tls_is_dispatch_key_included(DispatchKey::PythonDispatcher);
 }
 
 void PythonDispatcherTLS::reset_state() {
-  pythonDispatcherState = nullptr;
   c10::impl::tls_set_dispatch_key_included(
       DispatchKey::PythonDispatcher, false);
 }

--- a/c10/core/impl/PythonDispatcherTLS.h
+++ b/c10/core/impl/PythonDispatcherTLS.h
@@ -8,8 +8,8 @@ namespace c10 {
 namespace impl {
 
 struct C10_API PythonDispatcherTLS {
-  static void set_state(PyInterpreter* state);
-  static PyInterpreter* get_state();
+  static void set_state(bool state);
+  static bool get_state();
   static void reset_state();
 };
 
@@ -20,7 +20,7 @@ struct C10_API DisablePythonDispatcher {
   ~DisablePythonDispatcher() {
     PythonDispatcherTLS::set_state(old_);
   }
-  PyInterpreter* old_;
+  bool old_;
 };
 
 } // namespace impl

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -55,12 +55,12 @@ struct EnableTorchFunction {
 
 struct EnablePythonDispatcher {
   EnablePythonDispatcher() : old_(c10::impl::PythonDispatcherTLS::get_state()) {
-    c10::impl::PythonDispatcherTLS::set_state(getPyInterpreter());
+    c10::impl::PythonDispatcherTLS::set_state(true);
   }
   ~EnablePythonDispatcher() {
     c10::impl::PythonDispatcherTLS::set_state(old_);
   }
-  c10::impl::PyInterpreter* old_;
+  bool old_;
 };
 
 } // namespace

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -333,7 +333,13 @@ class PyInterpreterHolder {
  public:
   PyInterpreterHolder()
       : impl_(new c10::impl::PyInterpreter(
-            ConcretePyInterpreterVTable::instance())) {}
+            ConcretePyInterpreterVTable::instance())) {
+#ifndef USE_DEPLOY
+    // If this is not a torchdeploy interpreter, register this as the global
+    // PyInterpreter
+    c10::impl::PyInterpreterTLS::set_global_state(impl_);
+#endif
+  }
   // NB: intentionally leaks the PyInterpreter, as there may still be
   // references to it that are live, living in objects that aren't being
   // destructed while Python is being cleaned up.

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -4,8 +4,8 @@
 #include <torch/csrc/python_headers.h>
 #include <memory>
 
-#include <c10/core/impl/PyInterpreterTLS.h>
 #include <ATen/core/function_schema.h>
+#include <c10/core/impl/PyInterpreterTLS.h>
 #include <pybind11/pybind11.h>
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/Export.h>

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -4,6 +4,7 @@
 #include <torch/csrc/python_headers.h>
 #include <memory>
 
+#include <c10/core/impl/PyInterpreterTLS.h>
 #include <ATen/core/function_schema.h>
 #include <pybind11/pybind11.h>
 #include <torch/csrc/Exceptions.h>
@@ -69,6 +70,17 @@ inline const at::Tensor& THPVariable_Unpack(PyObject* obj) {
 }
 
 TORCH_PYTHON_API c10::impl::PyInterpreter* getPyInterpreter();
+
+// TODO: Maybe only allow if you aren't already in an interpreter
+struct SetPyInterpreterTLS {
+  SetPyInterpreterTLS() : old_(c10::impl::PyInterpreterTLS::get_state()) {
+    c10::impl::PyInterpreterTLS::set_state(getPyInterpreter());
+  }
+  ~SetPyInterpreterTLS() {
+    c10::impl::PyInterpreterTLS::set_state(old_);
+  }
+  const c10::impl::PyInterpreter* old_;
+};
 
 std::pair<py::object, py::dict> parseIValuesToPyArgsKwargs(
     const c10::OperatorHandle& op,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86095
* #86089

This is set by torchdeploy to indicate the current Interpreter that
you are interacting with.  This will allow Python op registrations
to contextually select the correct interpreter to attempt to handle
an operator.

There is some perf concern as we have to set the TLS on every
InterpreterSession entry point.  Hopefully you are not going over these
in a tight loop.

There is some encapsulation concern.  I sprayed this over every
method in InterpreterSession, but I am not sure if this gets every
possible way to end up "in" libtorch in a context where you could
trigger an operator that was overridden by a Python interpreter,
and it makes sense to ask the Python interpreter to figure it out
(clearly, non-interpreter associated operations should never get
the Python treatment).

Signed-off-by: Edward Z. Yang <ezyang@fb.com>