### PR TITLE
upgrade flake8-bugbear

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -32,7 +32,7 @@ init_command = [
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
     'flake8==3.8.2',
-    'flake8-bugbear==20.1.4',
+    'flake8-bugbear==22.9.23',
     'flake8-comprehensions==3.3.0',
     'flake8-executable==2.0.4',
     'flake8-pyi==20.5.0',


### PR DESCRIPTION
This newer version includes the check `B026` that disallows the confusing parameter unpacking after a keyword parameter, i.e.

```py
def foo(bar, baz):
    print(f"bar={bar}, baz={baz}")

foo(baz="baz", *["bar"])
```

```
bar=bar, baz=baz
```

We found some cases of this in `torchvision`: https://github.com/pytorch/vision/pull/6593#discussion_r973568747

As you can see, there are no changes other than the upgrade in this PR. This means we already don't have an such case in the code base. With this PR, we can be also be sure we will never have.