### PR TITLE
Preserve/strip OptionalSymIntArrayRef when finding real schema

### DIFF
--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -52,6 +52,7 @@ inline Return callUnboxedKernelFunction(void* unboxed_kernel_func, OperatorKerne
 
 // This template requires you to explicitly specify the argument you want to
 // forward; it doesn't work if you try to deduce it
+// NB: keep this in sync with cloneWithRealTypes in function_schema.cpp
 
 template <typename T>
 inline typename remove_symint<T>::type unpackSymInt(T x) { return x; }

--- a/aten/src/ATen/core/function_schema.cpp
+++ b/aten/src/ATen/core/function_schema.cpp
@@ -27,7 +27,8 @@ FunctionSchema FunctionSchema::cloneWithRealTypes(bool with_symint) const {
     if (
       *a.real_type() == *getTypePtr<c10::SymInt>() ||
       *a.real_type() == *getTypePtr<c10::optional<c10::SymInt>>() ||
-      *a.real_type() == *getTypePtr<c10::SymIntArrayRef>()
+      *a.real_type() == *getTypePtr<c10::SymIntArrayRef>() ||
+      *a.real_type() == *getTypePtr<at::OptionalSymIntArrayRef>()
     ) {
       // Keep the fake type
       return a.cloneWithType(a.type());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #86145
* #86139
* #86078
* #86094
* __->__ #86114

Missed this one because I forgot you also have to update it.  Thankfully
the new Metal CI caught it.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>