### PR TITLE
Re-introduce the functorch docs build (#85838)

### DIFF
--- a/.circleci/scripts/functorch_doc_push_script.sh
+++ b/.circleci/scripts/functorch_doc_push_script.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# =================== The following code **should** be executed inside Docker container ===================
+
+# Install dependencies
+sudo apt-get -y update
+sudo apt-get -y install expect-dev
+
+# This is where the local pytorch install in the docker image is located
+pt_checkout="/var/lib/jenkins/workspace"
+source "$pt_checkout/.jenkins/pytorch/common_utils.sh"
+echo "functorch_doc_push_script.sh: Invoked with $*"
+
+set -ex
+
+version=${DOCS_VERSION:-nightly}
+echo "version: $version"
+
+# Build functorch docs
+pushd $pt_checkout/functorch/docs
+pip -q install -r requirements.txt
+make html
+popd
+
+git clone https://github.com/pytorch/functorch -b gh-pages --depth 1 functorch_ghpages
+pushd functorch_ghpages
+
+if [ $version == "master" ]; then
+  version=nightly
+fi
+
+git rm -rf "$version" || true
+mv "$pt_checkout/functorch/docs/build/html" "$version"
+
+git add "$version" || true
+git status
+git config user.email "soumith+bot@pytorch.org"
+git config user.name "pytorchbot"
+# If there aren't changes, don't make a commit; push is no-op
+git commit -m "Generate Python docs from pytorch/pytorch@${GITHUB_SHA}" || true
+git status
+
+if [[ "${WITH_PUSH:-}" == true ]]; then
+  git push -u origin gh-pages
+fi
+
+popd
+# =================== The above code **should** be executed inside Docker container ===================

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -48,6 +48,9 @@ jobs:
           - docs_type: python
             # It takes less than 30m to finish python docs unless there are issues
             timeout-minutes: 30
+          - docs_type: functorch
+            # It takes less than 15m to finish functorch docs unless there are issues
+            timeout-minutes: 15
     steps:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
@@ -143,3 +146,13 @@ jobs:
           s3-bucket: doc-previews
           path: cppdocs/
           s3-prefix: pytorch/${{ github.event.pull_request.number }}/cppdocs
+
+      - name: Upload functorch Docs Preview
+        uses: seemethere/upload-artifact-s3@v5
+        if: ${{ github.event_name == 'pull_request' && matrix.docs_type == 'functorch' && steps.build-docs.outcome == 'success' }}
+        with:
+          retention-days: 14
+          s3-bucket: doc-previews
+          if-no-files-found: error
+          path: functorch_ghpages/nightly/
+          s3-prefix: pytorch/${{ github.event.pull_request.number }}/functorchdocs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #86125

We deleted it when merging functorch into pytorch. This PR makes a new
functorch docs build.

The docs are relatively simple:
- cd into `functorch/docs` and run `make html` to build the docs.
- docs should get pushed to the pytorch/functorch repo's gh-pages
branch.

The long term plan is:
- one day, the functorch APIs will just be torch.* APIs, at which point
we can fold all of the functorch docs into the regular PyTorch docs
- When that happens, the functorch examples and tutorials (that are on
the functorch docs site) can be moved to the pytorch examples and
pytorch tutorials.

Test Plan:
- check docs preview
- watch this PR after it goes in

Differential Revision: [D40026222](https://our.internmc.facebook.com/intern/diff/D40026222)