### PR TITLE
[ONNX] Update floor_divide behavior to match eager

### DIFF
--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -29,7 +29,6 @@ from torch.onnx._internal import _beartype, jit_utils, registration
 
 __all__ = [
     "dequantize",
-    "div",
     "embedding_bag",
     "fake_quantize_per_tensor_affine",
     "flip",


### PR DESCRIPTION
- Support `aten::trunc`
- Change floor_divide to round down to match eager
- Remove `floor_divide` in opset 10

## TODO

Unit tests

Fixes #78442, fixes #86084
