### PR TITLE
[ci] retry workflow if on master

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -58,6 +58,14 @@ jobs:
           python3 -m tools.stats.upload_test_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --head-branch "${HEAD_BRANCH}"
           python3 -m tools.stats.upload_sccache_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
 
+      - name: Rerun if failed on master
+        if: github.event.workflow_run.run_attempt == 1 && github.event.workflow_run.head_branch == 'master'
+        env:
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run rerun "${WORKFLOW_RUN_ID}" --failed
+
   check-api-rate:
     if: ${{ always() }}
     runs-on: [self-hosted, linux.2xlarge]


### PR DESCRIPTION
To help reduce redness from flakiness, rerun workflows that are red on master

Only rerun once to prevent non flaky failures from being continuously rerun

Pros:
* master is more green
* tracking flakiness can be more organized (through rockset)

Cons:
* will cause red jobs to show up as in progress on master while they are being re run -> redness might take a while to show up (can change hud to show completed workflow over in progress one, but this could also be confusing)
* doesn't represent devs' experience