### PR TITLE
[easy] fix nested view call taking in more than one -1

### DIFF
--- a/aten/src/ATen/native/transformers/transformer.cpp
+++ b/aten/src/ATen/native/transformers/transformer.cpp
@@ -118,7 +118,7 @@ Tensor transformer_encoder_layer_forward(
      x = at::linear(x, qkv_weight, qkv_bias);
      x = x.view({x.size(0), -1, 3, num_heads, embed_dim / num_heads});
      x = flash_attention_helper(x, x, x, 0.0, false);
-     x = x.view({-1, -1, embed_dim});
+     x = x.view({{x.size(0) * 3, -1, embed_dim});
      x = at::linear(x, proj_weight, proj_bias);
   } else {
 #endif

--- a/aten/src/ATen/native/transformers/transformer.cpp
+++ b/aten/src/ATen/native/transformers/transformer.cpp
@@ -119,7 +119,7 @@ Tensor transformer_encoder_layer_forward(
      auto x_size_0 = x.size(0);
      x = x.view({x_size_0, -1, 3, num_heads, embed_dim / num_heads});
      x = flash_attention_helper(x, x, x, 0.0, false);
-     x = x.view({{x_size_0 * 3, -1, embed_dim});
+     x = x.view({{x_size_0, -1, embed_dim});
      x = at::linear(x, proj_weight, proj_bias);
   } else {
 #endif

--- a/aten/src/ATen/native/transformers/transformer.cpp
+++ b/aten/src/ATen/native/transformers/transformer.cpp
@@ -116,9 +116,10 @@ Tensor transformer_encoder_layer_forward(
        embed_dim / num_heads == 128)) {
      TORCH_WARN_ONCE("transformer_encoder_layer_forward is using flash attention.");
      x = at::linear(x, qkv_weight, qkv_bias);
-     x = x.view({x.size(0), -1, 3, num_heads, embed_dim / num_heads});
+     auto x_size_0 = x.size(0);
+     x = x.view({x_size_0, -1, 3, num_heads, embed_dim / num_heads});
      x = flash_attention_helper(x, x, x, 0.0, false);
-     x = x.view({{x.size(0) * 3, -1, embed_dim});
+     x = x.view({{x_size_0 * 3, -1, embed_dim});
      x = at::linear(x, proj_weight, proj_bias);
   } else {
 #endif


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/85691 (allowing only one -1 in nested view/reshape) broke this. Was not caught by CI but internal tests are broken

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #86134

