### PR TITLE
[ci] put more logs in a folded group

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -698,11 +698,18 @@ def run_doctests(test_module, test_directory, options):
 
 
 def print_log_file(test: str, file_path: str, failed: bool) -> None:
+    num_lines = sum(1 for _ in open(file_path, 'rb'))
+    n = 300
     with open(file_path, "r") as f:
         print_to_stderr("")
         if failed:
-            print_to_stderr(f"PRINTING LOG FILE of {test} ({file_path})")
-            print_to_stderr(f.read())
+            print_to_stderr(f"Expand the folded group to see the beginning of the log file of {test}")
+            print_to_stderr(f"##[group]PRINTING BEGINNING OF LOG FILE of {test} ({file_path})")
+            for _ in range(num_lines - n):
+                print_to_stderr(next(f))
+            print_to_stderr("##[endgroup]")
+            for _ in range(n):
+                print_to_stderr(next(f))
             print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})")
         else:
             print_to_stderr(f"Expand the folded group to see the log file of {test}")

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -703,11 +703,12 @@ def print_log_file(test: str, file_path: str, failed: bool) -> None:
     with open(file_path, "r") as f:
         print_to_stderr("")
         if failed:
-            print_to_stderr(f"Expand the folded group to see the beginning of the log file of {test}")
-            print_to_stderr(f"##[group]PRINTING BEGINNING OF LOG FILE of {test} ({file_path})")
-            for _ in range(num_lines - n):
-                print_to_stderr(next(f).rstrip())
-            print_to_stderr("##[endgroup]")
+            if n > num_lines:
+                print_to_stderr(f"Expand the folded group to see the beginning of the log file of {test}")
+                print_to_stderr(f"##[group]PRINTING BEGINNING OF LOG FILE of {test} ({file_path})")
+                for _ in range(num_lines - n):
+                    print_to_stderr(next(f).rstrip())
+                print_to_stderr("##[endgroup]")
             for _ in range(min(n, num_lines)):
                 print_to_stderr(next(f).rstrip())
             print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})")

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -708,7 +708,7 @@ def print_log_file(test: str, file_path: str, failed: bool) -> None:
             for _ in range(num_lines - n):
                 print_to_stderr(next(f).rstrip())
             print_to_stderr("##[endgroup]")
-            for _ in range(n):
+            for _ in range(min(n, num_lines)):
                 print_to_stderr(next(f).rstrip())
             print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})")
         else:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -699,7 +699,7 @@ def run_doctests(test_module, test_directory, options):
 
 def print_log_file(test: str, file_path: str, failed: bool) -> None:
     num_lines = sum(1 for _ in open(file_path, 'rb'))
-    n = 300
+    n = 100
     with open(file_path, "r") as f:
         print_to_stderr("")
         if failed:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -706,10 +706,10 @@ def print_log_file(test: str, file_path: str, failed: bool) -> None:
             print_to_stderr(f"Expand the folded group to see the beginning of the log file of {test}")
             print_to_stderr(f"##[group]PRINTING BEGINNING OF LOG FILE of {test} ({file_path})")
             for _ in range(num_lines - n):
-                print_to_stderr(next(f))
+                print_to_stderr(next(f).rstrip())
             print_to_stderr("##[endgroup]")
             for _ in range(n):
-                print_to_stderr(next(f))
+                print_to_stderr(next(f).rstrip())
             print_to_stderr(f"FINISHED PRINTING LOG FILE of {test} ({file_path})")
         else:
             print_to_stderr(f"Expand the folded group to see the log file of {test}")

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -210,7 +210,6 @@ class TestCommon(TestCase):
     @onlyNativeDeviceTypes
     @ops(python_ref_db)
     def test_python_ref_meta(self, device, dtype, op):
-        assert 1 + 3 == 2
         with FakeTensorMode() as mode:
             pass
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -210,6 +210,7 @@ class TestCommon(TestCase):
     @onlyNativeDeviceTypes
     @ops(python_ref_db)
     def test_python_ref_meta(self, device, dtype, op):
+        assert 1 + 3 == 2
         with FakeTensorMode() as mode:
             pass
 


### PR DESCRIPTION
fixes: request to not print the entire log file, but the last couple of lines since they are probably the most relevant

all but last 300 lines of failing tests get put into a folded group
example https://github.com/pytorch/pytorch/actions/runs/3177200444/jobs/5177703202