### PR TITLE
.github: Improve sanity check for generated files

### DIFF
--- a/.github/scripts/pr-sanity-check.sh
+++ b/.github/scripts/pr-sanity-check.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+GIT_TOP_DIR=$(git rev-parse --show-toplevel)
+
+TMPFILE=$(mktemp)
+trap "rm -rf ${TMPFILE}" EXIT
+
+# By default just run against the latest commit
+BASE=${BASE:-HEAD~1}
+HEAD=${HEAD:-HEAD}
+
+ancestor=$(git merge-base "${BASE}" "${HEAD}")
+echo "INFO: Checking aginst the following stats"
+(
+    set -x
+    git diff --stat "$ancestor" "${HEAD}" | sed '$d' > "${TMPFILE}"
+)
+
+while read -r git_attribute; do
+    if echo "${git_attribute}" | grep "linguist-generated=true" >/dev/null 2>/dev/null; then
+        pattern=$(echo ${git_attribute} | cut -d' ' -f1)
+        escaped_pattern=$(printf '%s\n' "$pattern" | sed -e 's/[\/&]/\\&/g')
+        # Delete known generated files
+        sed -i '/'"${escaped_pattern}"'/d' "${TMPFILE}"
+    fi
+done < "${GIT_TOP_DIR}/.gitattributes"
+
+echo "INFO: Showing non-generated files:"
+(
+    set -x
+    cat "${TMPFILE}"
+)
+
+# Get only files that have changed
+changed_files=$(cut -d' ' -f2 "${TMPFILE}" | xargs)
+
+details=$(git diff --shortstat "$ancestor" "${HEAD}" -- ${changed_files})
+add=$(echo "$details" | grep -o '[0-9]* insertion' | grep -o '[0-9]*' || true)
+remove=$(echo "$details" | grep -o '[0-9]* deletion' | grep -o '[0-9]*' || true)
+pr_size=0
+if [ "$add" ]; then
+  pr_size=$(("$pr_size" + "$add"))
+fi
+if [ "$remove" ]; then
+  pr_size=$(("$pr_size" + "$remove"))
+fi
+echo "INFO: PR SIZE is ${pr_size}"
+
+if ((pr_size > 2000)); then
+    echo
+    echo 'Your PR is '"$pr_size"' LOC which is more than the 2000 maximum'
+    echo 'allowed within PyTorch infra. PLease make sure to split up'
+    echo 'your PR into smaller pieces that can be reviewed.'
+    echo 'If you think that this rule should not apply to your PR,'
+    echo 'please contact @albanD or @seemethere.'
+    echo
+    exit 1
+fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -134,33 +134,7 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          set -x
-
-          ancestor=$(git merge-base "${BASE}" "${HEAD}")
-          details=$(git diff --shortstat "$ancestor" "${HEAD}")
-          add=$(echo "$details" | grep -o '[0-9]* insertion' | grep -o '[0-9]*' || true)
-          remove=$(echo "$details" | grep -o '[0-9]* deletion' | grep -o '[0-9]*' || true)
-
-          pr_size=0
-          if [ "$add" ]; then
-              pr_size=$(("$pr_size" + "$add"))
-          fi
-          if [ "$remove" ]; then
-              pr_size=$(("$pr_size" + "$remove"))
-          fi
-
-          if ((pr_size > 2000)); then
-            echo
-            echo 'Your PR is '"$pr_size"' LOC which is more than the 2000 maximum'
-            echo 'allowed within PyTorch infra. PLease make sure to split up'
-            echo 'your PR into smaller pieces that can be reviewed.'
-            echo 'If you think that this rule should not apply to your PR,'
-            echo 'please contact @albanD or @seemethere.'
-            echo
-            false
-          fi
-
-
+          bash .github/scripts/pr-sanity-check.sh
 
   workflow-checks:
     name: workflow-checks


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #86143

Makes it so that generated files from .gitattributes do not affect the
pr-sanity-check

Tested using: (https://github.com/pytorch/pytorch/pull/86143)
```
❯ BASE=d401732baadf2df666f242cd32db5df3b09dbec6 HEAD=eaf9aa24acf6a1fc68243935f4b33188a59bfdd2 bash .github/scripts/pr-sanity-check.sh
INFO: Checking aginst the following stats
+ git diff --stat 6d06be89fe2b9ca30c3d97475dd192fc7e3f7357 eaf9aa24acf6a1fc68243935f4b33188a59bfdd2
+ sed '$d'
INFO: Showing non-generated files:
+ cat /tmp/tmp.mQeK24emtZ
 .github/scripts/test_trymerge.py |     2 +-
 .github/scripts/trymerge.py      |    14 +
INFO: PR SIZE is 16
```

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>