### PR TITLE
Stop modifying the global logger on `import functorch`

### DIFF
--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -12,8 +12,6 @@ import logging
 __all__ = ['SubgraphMatcher', 'InternalMatch']
 
 format_str = "%(levelname)s > %(message)s"
-LOGLEVEL = os.environ.get('LOGLEVEL', 'WARNING').upper()
-logging.basicConfig(level=LOGLEVEL, format=format_str)
 logger = logging.getLogger(__name__)
 
 @compatibility(is_backward_compatible=False)

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -6,7 +6,6 @@ from torch.fx.node import Node
 from torch.fx._compatibility import compatibility
 import torch.utils._pytree as pytree
 from typing import Dict, List, Set, Any
-import os
 import logging
 
 __all__ = ['SubgraphMatcher', 'InternalMatch']

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -10,7 +10,6 @@ import logging
 
 __all__ = ['SubgraphMatcher', 'InternalMatch']
 
-format_str = "%(levelname)s > %(message)s"
 logger = logging.getLogger(__name__)
 
 @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #86150
* __->__ #86147
* #86125

Fixes https://github.com/pytorch/pytorch/issues/85952

`logging.basicConfig` modifies the global logger which affects other
programs. importing a package should generally be side-effect free so
this PR gets rid of that call.

Test Plan:
- tested locally