### PR TITLE
Add hooks for register_buffer/module/parameter

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -591,6 +591,46 @@ class TestNN(NNTestCase):
         expected_grad = -sig_x * (1 - sig_x) * 2 * mask
         self.assertEqual(input.grad, expected_grad)
 
+    def test_hook_buffer_registration(self):
+        def buffer_registration_hook(module, name, buffer):
+            buffer.registered = True
+        handle = torch.nn.modules.module.register_module_buffer_registration_hook(
+            buffer_registration_hook
+        )
+        try:
+            l, n, s = self._create_basic_net()
+            for b in s.buffers():
+                self.assertTrue(getattr(b, "registered", False))
+        finally:
+            handle.remove()
+
+    def test_hook_submodule_registration(self):
+        def module_registration_hook(module, name, submodule):
+            module.registered = True
+            submodule.registered = True
+        handle = torch.nn.modules.module.register_module_module_registration_hook(
+            module_registration_hook
+        )
+        try:
+            l, n, s = self._create_basic_net()
+            for m in s.modules():
+                self.assertTrue(getattr(m, "registered", False))
+        finally:
+            handle.remove()
+
+    def test_hook_parameter_registration(self):
+        def parameter_registration_hook(module, name, parameter):
+            parameter.registered = True
+        handle = torch.nn.modules.module.register_module_parameter_registration_hook(
+            parameter_registration_hook
+        )
+        try:
+            l, n, s = self._create_basic_net()
+            for p in s.parameters():
+                self.assertTrue(getattr(p, "registered", False))
+        finally:
+            handle.remove()
+
     def test_to(self):
         m = nn.Linear(3, 5)
         self.assertIs(m, m.to('cpu'))

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -459,7 +459,7 @@ class Module:
                             .format(torch.typename(tensor), name))
         else:
             for hook in _global_buffer_registration_hooks.values():
-                tensor = hook(name, tensor) or tensor
+                tensor = hook(self, name, tensor) or tensor
             self._buffers[name] = tensor
             if persistent:
                 self._non_persistent_buffers_set.discard(name)
@@ -507,7 +507,7 @@ class Module:
                 "the forward() method.".format(name))
         else:
             for hook in _global_parameter_registration_hooks.values():
-                param = hook(name, param) or param
+                param = hook(self, name, param) or param
             self._parameters[name] = param
 
     def add_module(self, name: str, module: Optional['Module']) -> None:
@@ -533,7 +533,7 @@ class Module:
         elif name == '':
             raise KeyError("module name can't be empty string \"\"")
         for hook in _global_module_registration_hooks.values():
-            module = hook(name, module) or module
+            module = hook(self, name, module) or module
         self._modules[name] = module
 
     def register_module(self, name: str, module: Optional['Module']) -> None:
@@ -1379,7 +1379,7 @@ class Module:
                         "cannot assign module before Module.__init__() call")
                 remove_from(self.__dict__, self._parameters, self._buffers, self._non_persistent_buffers_set)
                 for hook in _global_module_registration_hooks.values():
-                    value = hook(name, value) or value
+                    value = hook(self, name, value) or value
                 modules[name] = value
             elif modules is not None and name in modules:
                 if value is not None:
@@ -1387,7 +1387,7 @@ class Module:
                                     "(torch.nn.Module or None expected)"
                                     .format(torch.typename(value), name))
                 for hook in _global_module_registration_hooks.values():
-                    value = hook(name, value) or value
+                    value = hook(self, name, value) or value
                 modules[name] = value
             else:
                 buffers = self.__dict__.get('_buffers')
@@ -1397,7 +1397,7 @@ class Module:
                                         "(torch.Tensor or None expected)"
                                         .format(torch.typename(value), name))
                     for hook in _global_buffer_registration_hooks.values():
-                        value = hook(name, value) or value
+                        value = hook(self, name, value) or value
                     buffers[name] = value
                 else:
                     super().__setattr__(name, value)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -13,7 +13,8 @@ from typing import Union, Tuple, Any, Callable, Iterator, Set, Optional, overloa
 from ...utils.hooks import RemovableHandle
 
 __all__ = ['register_module_forward_pre_hook', 'register_module_forward_hook', 'register_module_backward_hook',
-           'register_module_full_backward_hook', 'Module']
+           'register_module_full_backward_hook', 'register_module_buffer_registration_hook',
+           'register_module_module_registration_hook', 'register_module_parameter_registration_hook', 'Module']
 
 _grad_t = Union[Tuple[Tensor, ...], Tensor]
 # See https://mypy.readthedocs.io/en/latest/generics.html#generic-methods-and-generic-self for the use
@@ -95,7 +96,7 @@ _global_forward_hooks: Dict[int, Callable] = OrderedDict()
 _EXTRA_STATE_KEY_SUFFIX = '_extra_state'
 
 
-def register_buffer_registration_hook(hook: Callable[..., None]) -> RemovableHandle:
+def register_module_buffer_registration_hook(hook: Callable[..., None]) -> RemovableHandle:
     r"""Registers a buffer registration hook common to all modules.
 
     .. warning ::
@@ -105,7 +106,7 @@ def register_buffer_registration_hook(hook: Callable[..., None]) -> RemovableHan
     The hook will be called every time :func:`register_buffer` is invoked.
     It should have the following signature::
 
-        hook(name, module) -> None or modified input
+        hook(module, name, buffer) -> None or new buffer
 
     The hook can modify the input or return a single modified value in the hook.
 
@@ -119,7 +120,7 @@ def register_buffer_registration_hook(hook: Callable[..., None]) -> RemovableHan
     return handle
 
 
-def register_module_registration_hook(hook: Callable[..., None]) -> RemovableHandle:
+def register_module_module_registration_hook(hook: Callable[..., None]) -> RemovableHandle:
     r"""Registers a module registration hook common to all modules.
 
     .. warning ::
@@ -129,7 +130,7 @@ def register_module_registration_hook(hook: Callable[..., None]) -> RemovableHan
     The hook will be called every time :func:`register_module` is invoked.
     It should have the following signature::
 
-        hook(name, module) -> None or modified input
+        hook(module, name, submodule) -> None or new submodule
 
     The hook can modify the input or return a single modified value in the hook.
 
@@ -143,7 +144,7 @@ def register_module_registration_hook(hook: Callable[..., None]) -> RemovableHan
     return handle
 
 
-def register_parameter_registration_hook(hook: Callable[..., None]) -> RemovableHandle:
+def register_module_parameter_registration_hook(hook: Callable[..., None]) -> RemovableHandle:
     r"""Registers a parameter registration hook common to all modules.
 
     .. warning ::
@@ -153,7 +154,7 @@ def register_parameter_registration_hook(hook: Callable[..., None]) -> Removable
     The hook will be called every time :func:`register_parameter` is invoked.
     It should have the following signature::
 
-        hook(name, param) -> None or modified input
+        hook(module, name, param) -> None or new parameter
 
     The hook can modify the input or return a single modified value in the hook.
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -42,6 +42,11 @@ def _addindent(s_, numSpaces):
     s = first + '\n' + s
     return s
 
+r"""This tracks hooks common to all modules that are executed immediately before
+.registering the buffer/module/parameter"""
+_global_buffer_registration_hooks: Dict[int, Callable] = OrderedDict()
+_global_module_registration_hooks: Dict[int, Callable] = OrderedDict()
+_global_parameter_registration_hooks: Dict[int, Callable] = OrderedDict()
 
 class _WrappedHook:
     def __init__(self, hook: Callable, module: Optional["Module"] = None):
@@ -88,6 +93,78 @@ _global_forward_pre_hooks: Dict[int, Callable] = OrderedDict()
 _global_forward_hooks: Dict[int, Callable] = OrderedDict()
 
 _EXTRA_STATE_KEY_SUFFIX = '_extra_state'
+
+
+def register_buffer_registration_hook(hook: Callable[..., None]) -> RemovableHandle:
+    r"""Registers a buffer registration hook common to all modules.
+
+    .. warning ::
+
+        This adds global state to the `nn.Module` module
+
+    The hook will be called every time :func:`register_buffer` is invoked.
+    It should have the following signature::
+
+        hook(name, module) -> None or modified input
+
+    The hook can modify the input or return a single modified value in the hook.
+
+    Returns:
+        :class:`torch.utils.hooks.RemovableHandle`:
+            a handle that can be used to remove the added hook by calling
+            ``handle.remove()``
+    """
+    handle = hooks.RemovableHandle(_global_buffer_registration_hooks)
+    _global_buffer_registration_hooks[handle.id] = hook
+    return handle
+
+
+def register_module_registration_hook(hook: Callable[..., None]) -> RemovableHandle:
+    r"""Registers a module registration hook common to all modules.
+
+    .. warning ::
+
+        This adds global state to the `nn.Module` module
+
+    The hook will be called every time :func:`register_module` is invoked.
+    It should have the following signature::
+
+        hook(name, module) -> None or modified input
+
+    The hook can modify the input or return a single modified value in the hook.
+
+    Returns:
+        :class:`torch.utils.hooks.RemovableHandle`:
+            a handle that can be used to remove the added hook by calling
+            ``handle.remove()``
+    """
+    handle = hooks.RemovableHandle(_global_module_registration_hooks)
+    _global_module_registration_hooks[handle.id] = hook
+    return handle
+
+
+def register_parameter_registration_hook(hook: Callable[..., None]) -> RemovableHandle:
+    r"""Registers a parameter registration hook common to all modules.
+
+    .. warning ::
+
+        This adds global state to the `nn.Module` module
+
+    The hook will be called every time :func:`register_parameter` is invoked.
+    It should have the following signature::
+
+        hook(name, param) -> None or modified input
+
+    The hook can modify the input or return a single modified value in the hook.
+
+    Returns:
+        :class:`torch.utils.hooks.RemovableHandle`:
+            a handle that can be used to remove the added hook by calling
+            ``handle.remove()``
+    """
+    handle = hooks.RemovableHandle(_global_parameter_registration_hooks)
+    _global_parameter_registration_hooks[handle.id] = hook
+    return handle
 
 
 def register_module_forward_pre_hook(hook: Callable[..., None]) -> RemovableHandle:
@@ -380,6 +457,8 @@ class Module:
                             "(torch Tensor or None required)"
                             .format(torch.typename(tensor), name))
         else:
+            for hook in _global_buffer_registration_hooks.values():
+                tensor = hook(name, tensor) or tensor
             self._buffers[name] = tensor
             if persistent:
                 self._non_persistent_buffers_set.discard(name)
@@ -426,6 +505,8 @@ class Module:
                 "as a function of another Tensor, compute the value in "
                 "the forward() method.".format(name))
         else:
+            for hook in _global_parameter_registration_hooks.values():
+                param = hook(name, param) or param
             self._parameters[name] = param
 
     def add_module(self, name: str, module: Optional['Module']) -> None:
@@ -450,6 +531,8 @@ class Module:
             raise KeyError("module name can't contain \".\", got: {}".format(name))
         elif name == '':
             raise KeyError("module name can't be empty string \"\"")
+        for hook in _global_module_registration_hooks.values():
+            module = hook(name, module) or module
         self._modules[name] = module
 
     def register_module(self, name: str, module: Optional['Module']) -> None:
@@ -1294,12 +1377,16 @@ class Module:
                     raise AttributeError(
                         "cannot assign module before Module.__init__() call")
                 remove_from(self.__dict__, self._parameters, self._buffers, self._non_persistent_buffers_set)
+                for hook in _global_module_registration_hooks.values():
+                    value = hook(name, value) or value
                 modules[name] = value
             elif modules is not None and name in modules:
                 if value is not None:
                     raise TypeError("cannot assign '{}' as child module '{}' "
                                     "(torch.nn.Module or None expected)"
                                     .format(torch.typename(value), name))
+                for hook in _global_module_registration_hooks.values():
+                    value = hook(name, value) or value
                 modules[name] = value
             else:
                 buffers = self.__dict__.get('_buffers')
@@ -1308,6 +1395,8 @@ class Module:
                         raise TypeError("cannot assign '{}' as buffer '{}' "
                                         "(torch.Tensor or None expected)"
                                         .format(torch.typename(value), name))
+                    for hook in _global_buffer_registration_hooks.values():
+                        value = hook(name, value) or value
                     buffers[name] = value
                 else:
                     super().__setattr__(name, value)


### PR DESCRIPTION
As described in the issue, this PR adds hooks to be run when `register_parameter`, `register_buffer` and `register_module` are called.

Fixes #85837

cc @albanD @mruberry @jbschlosser @walterddr @kshitij12345 @saketh-are