### PR TITLE
[FSDP] Dequeue one instead of flush

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1532,9 +1532,8 @@ class FullyShardedDataParallel(nn.Module):
         if not handles:
             return
         if self.limit_all_gathers:
-            events = self._free_event_queue.flush_if_needed()
+            events = self._free_event_queue._dequeue()
             if events:
-                # As a minor optimization, only synchronize the latest event
                 events[-1].synchronize()
         any_ran_pre_unshard = False
         with torch.cuda.stream(self._streams["pre_all_gather"]):

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -710,8 +710,8 @@ class _ExecOrderData:
 class _FreeEventQueue:
     """
     This tracks all pending frees corresponding to inflight all-gathers. The
-    queueing pattern is iterative enqueues followed by a flush, and the current
-    heuristic for the flush is based on the number of inflight all-gathers.
+    queueing pattern is iterative enqueues with a single dequeue per iteration
+    once the limit ``_max_num_inflight_all_gathers`` is reached.
     """
 
     def __init__(self) -> None:
@@ -722,21 +722,8 @@ class _FreeEventQueue:
         """Enqueues a free event."""
         self._queue.append(free_event)
 
-    def flush_if_needed(self) -> List[torch.cuda.Event]:
-        """
-        If the queue should be flushed (based on an internal criteria), then
-        this returns a non-empty :class:`list` of free events. Otherwise, this
-        returns an empty :class:`list`.
-        """
-        events: List[torch.cuda.Event] = []
-        if len(self._queue) >= self._max_num_inflight_all_gathers:
-            while self._queue:
-                event = self._dequeue()
-                assert event is not None
-                events.append(event)
-        return events
-
     def dequeue_if_needed(self) -> Optional[torch.cuda.Event]:
+        """Dequeues a single event if the limit is reached."""
         if len(self._queue) >= self._max_num_inflight_all_gathers:
             return self._dequeue()
         return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#86165 [FSDP] Dequeue one instead of flush**
* #85039 [FSDP] Add `FSDPExtensions` for TP support

For the rate limiter, I initially implemented the approach of only dequeueing a single event, but there was concern about blocking the CPU _every_ iteration. The landed approach instead blocks every `_max_num_inflight_all_gathers` iterations and flushes the entire queue.

However, upon further analysis, the approach of dequeueing a single event should be more performant with the same memory usage -- as the name suggests, both have `_max_num_inflight_all_gathers` concurrently inflight all-gathers. The cost of blocking the CPU thread is not important compared to the duration the CPU thread is actually blocked. This PR's approach reduces the latter quantity.

**Fast Communication; Slow Computation**
![Screen Shot 2022-10-06 at 9 59 37 AM](https://user-images.githubusercontent.com/31054793/194332827-a31422d6-8413-477f-a0e0-55ec27a955e5.png)

**Slow Communication; Fast Computation**
<img width="718" alt="Screen Shot 2022-10-04 at 4 34 15 PM" src="https://user-images.githubusercontent.com/31054793/193921508-f2a4fd22-2b03-4a8e-b6ca-634c584c70e2.png">

**T5-11B**
2 nodes / 16 40 GB A100s with EFA and batch size 6:
- [Old] 5.81 s / batch; 24 and 20 CUDA malloc retries on local rank 0s; 35.234 GB peak active; 38.806 GB peak reserved
- [New] 5.10 s / batch; 25 and 29 CUDA malloc retries on local rank 0s; 35.234 GB peak active; 38.868 GB peak reserved

4 nodes / 32 40 GB A100s with EFA and batch size 7:
- [Old] 5.21 s / batch; 0, 0, 0, 0 CUDA malloc retries on local rank 0s; 33.695 GB peak active; 38.494 GB peak reserved
- [New] 4.93 s / batch; 1, 0, 0, 0 CUDA malloc retries on local rank 0s; 33.678 GB peak active; 38.792 GB peak reserved

The new version changes the fragmentation in the allocator. It is possible that by blocking the CPU thread more in the old approach, the initial blocks used to serve the all-gather stream allocations are different compared to the new approach. Even though the number of CUDA malloc retries increases slightly, the net result is a speedup with the new approach.