### PR TITLE
[ONNX] Export 'aten::resolve_neg' and 'aten::resolve_conj' as Noop in ONNX

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7182,6 +7182,19 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             dynamic_axes={"embedding_matrix": [0, 1], "x": [0, 1], "w": [0, 1]},
         )
 
+    def test_export_succeed_with_resolve_conj_resolve_neg_side_effect(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                # 'print' has side effect calling 'resolve_conj' and 'resolve_neg'.
+                print(x)
+                # 'tolist' has side effect calling 'resolve_conj' and 'resolve_neg'.
+                # Annotation added to pass torch script.
+                _: List[float] = x.tolist()
+                return x
+
+        x = torch.randn(3, requires_grad=True)
+        self.run_test(Model(), x)
+
     @skipIfUnsupportedMinOpsetVersion(8)
     def test_meshgrid(self):
         class Meshgrid(torch.nn.Module):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -6303,14 +6303,18 @@ def is_pinned(g: jit_utils.GraphContext, self, device=None):
 
 
 @_onnx_symbolic("aten::resolve_conj")
-def resolve_conj(g: jit_utils.GraphContext, self: _C.Value):
-    # Noop in ONNX.
+def resolve_conj(g: jit_utils.GraphContext, self: _C.Value) -> _C.Value:
+    # Noop in ONNX. This op is materializing conjugation w.r.t conjugate bit. 
+    # It is only adjusting the internal representation in torch but not its "value".
+    # Hence from ONNX perspective this op does nothing.
     return self
 
 
 @_onnx_symbolic("aten::resolve_neg")
-def resolve_neg(g: jit_utils.GraphContext, self: _C.Value):
-    # Noop in ONNX.
+def resolve_neg(g: jit_utils.GraphContext, self: _C.Value) -> _C.Value:
+    # Noop in ONNX. This op is materializing negation w.r.t negative bit. 
+    # It is only adjusting the internal representation in torch but not its "value".
+    # Hence from ONNX perspective this op does nothing.
     return self
 
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -6304,7 +6304,7 @@ def is_pinned(g: jit_utils.GraphContext, self, device=None):
 
 @_onnx_symbolic("aten::resolve_conj")
 def resolve_conj(g: jit_utils.GraphContext, self: _C.Value) -> _C.Value:
-    # Noop in ONNX. This op is materializing conjugation w.r.t conjugate bit. 
+    # Noop in ONNX. This op is materializing conjugation w.r.t conjugate bit.
     # It is only adjusting the internal representation in torch but not its "value".
     # Hence from ONNX perspective this op does nothing.
     return self
@@ -6312,7 +6312,7 @@ def resolve_conj(g: jit_utils.GraphContext, self: _C.Value) -> _C.Value:
 
 @_onnx_symbolic("aten::resolve_neg")
 def resolve_neg(g: jit_utils.GraphContext, self: _C.Value) -> _C.Value:
-    # Noop in ONNX. This op is materializing negation w.r.t negative bit. 
+    # Noop in ONNX. This op is materializing negation w.r.t negative bit.
     # It is only adjusting the internal representation in torch but not its "value".
     # Hence from ONNX perspective this op does nothing.
     return self

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -6302,6 +6302,18 @@ def is_pinned(g: jit_utils.GraphContext, self, device=None):
     return None
 
 
+@_onnx_symbolic("aten::resolve_conj")
+def resolve_conj(g: jit_utils.GraphContext, self: _C.Value):
+    # Noop in ONNX.
+    return self
+
+
+@_onnx_symbolic("aten::resolve_neg")
+def resolve_neg(g: jit_utils.GraphContext, self: _C.Value):
+    # Noop in ONNX.
+    return self
+
+
 @_onnx_symbolic("prim::ConstantSplit")
 @_beartype.beartype
 def prim_constant_split(g: jit_utils.GraphContext, self, split_size, dim):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86180

Fixes #73619