### PR TITLE
Memory snapshots from C++

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -659,6 +659,7 @@ def libtorch_sources(gencode_pattern = ":generate-code[{}]"):
 libtorch_cuda_core_sources = [
     "torch/csrc/CudaIPCTypes.cpp",
     "torch/csrc/cuda/comm.cpp",
+    "torch/csrc/cuda/memory_snapshot.cpp",
     "torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp",
     "torch/csrc/profiler/cuda.cpp",
     "torch/csrc/autograd/functions/comm.cpp",

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -1,0 +1,121 @@
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <torch/csrc/cuda/memory_snapshot.h>
+#include <torch/csrc/jit/serialization/pickler.h>
+namespace torch {
+namespace cuda {
+
+using torch::jit::Pickler;
+using c10::IValue;
+using c10::Dict;
+
+using c10::cuda::CUDACachingAllocator::BlockInfo;
+using c10::cuda::CUDACachingAllocator::History;
+using c10::cuda::CUDACachingAllocator::SegmentInfo;
+
+namespace {
+  std::unique_ptr<c10::cuda::CUDACachingAllocator::Context> blank_context() {
+    // in the future the C++-only version of context gathering could include C++ or torchscript frames.
+    return std::make_unique<c10::cuda::CUDACachingAllocator::Context>();
+  }
+  std::vector<char> write_pickle(const IValue& v) {
+    std::vector<char> result;
+    {
+      auto writer = [&](const char* data, size_t size) {
+        result.insert(result.end(), data, data + size);
+      };
+      Pickler pickler(writer, nullptr, nullptr, nullptr, nullptr, false);
+      pickler.protocol();
+      pickler.pushIValue(v);
+      pickler.stop();
+    }
+    return result;
+  }
+  Dict<IValue, IValue> new_dict() {
+    return Dict<IValue,IValue>(c10::AnyType::get(), c10::AnyType::get());
+  }
+  c10::List<IValue> new_list() {
+    return List<IValue>(c10::AnyType::get());
+  }
+}
+  void _record_memory_history(bool enabled) {
+    c10::cuda::CUDACachingAllocator::setContextRecorder(enabled ? blank_context : nullptr);
+  }
+
+  std::vector<char> _memory_snapshot_pickled() {
+    IValue device_s = "device";
+    IValue address_s = "address";
+    IValue total_size_s = "total_size";
+    IValue allocated_size_s = "allocated_size";
+    IValue active_size_s = "active_size";
+    IValue stream_s = "stream";
+    IValue segment_type_s = "segment_type";
+    IValue large_s = "large";
+    IValue small_s = "small";
+    IValue size_s = "size";
+    IValue state_s = "state";
+    IValue active_allocated_s = "active_allocated";
+    IValue active_pending_free_s = "active_pending_free";
+    IValue inactive_s = "inactive";
+    IValue addr_s = "addr";
+    IValue real_size_s = "real_size";
+    IValue filename_s = "filename";
+    IValue name_s = "name";
+    IValue line_s = "line";
+    IValue frames_s = "frames";
+    IValue history_s = "history";
+    IValue blocks_s = "blocks";
+
+    auto empty_frames = new_list();
+
+    const auto segmentInfoToDict = [&](const SegmentInfo& segmentInfo) {
+      auto segmentDict = new_dict();
+      segmentDict.insert(device_s, segmentInfo.device);
+      segmentDict.insert(address_s, segmentInfo.address);
+      segmentDict.insert(total_size_s, segmentInfo.total_size);
+      segmentDict.insert(allocated_size_s, segmentInfo.allocated_size);
+      segmentDict.insert(active_size_s, segmentInfo.active_size);
+      segmentDict.insert(stream_s, int64_t(segmentInfo.stream));
+      segmentDict.insert(segment_type_s, (segmentInfo.is_large ? large_s : small_s));
+
+      auto blocks = new_list();
+      for (const auto& blockInfo : segmentInfo.blocks) {
+        auto blockDict = new_dict();
+        blockDict.insert(size_s, blockInfo.size);
+        blockDict.insert(state_s,
+            (blockInfo.allocated
+                ? active_allocated_s
+                : (blockInfo.active ? active_pending_free_s : inactive_s)));
+        if (blockInfo.history) {
+          auto history = new_list();
+          History* h = blockInfo.history;
+          while (h) {
+            auto history_entry = new_dict();
+            history_entry.insert(addr_s, (int64_t)h->addr);
+            history_entry.insert(real_size_s, (int64_t) h->real_size);
+            if (h->context) {
+              history_entry.insert(frames_s, empty_frames);
+            }
+            h = h->next.get();
+            history.push_back(std::move(history_entry));
+          }
+          blockDict.insert(history_s, std::move(history));
+        }
+        blocks.push_back(blockDict);
+      }
+      segmentDict.insert(blocks_s, blocks);
+
+      return segmentDict;
+    };
+
+    const std::vector<SegmentInfo>& snapshot =
+        c10::cuda::CUDACachingAllocator::snapshot();
+
+    auto result = new_list();
+    for (const auto& segmentInfo : snapshot) {
+      result.push_back(segmentInfoToDict(segmentInfo));
+    }
+
+    return write_pickle(result);
+ }
+}
+} // namespace torch

--- a/torch/csrc/cuda/memory_snapshot.h
+++ b/torch/csrc/cuda/memory_snapshot.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <torch/csrc/Export.h>
+#include <vector>
+
+namespace torch {
+namespace cuda {
+
+// C++-only versions of these, for python use
+// those defined in cuda/Module.cpp which also record python state.
+TORCH_CUDA_CU_API void _record_memory_history(bool enabled);
+TORCH_CUDA_CU_API std::vector<char> _memory_snapshot_pickled();
+
+} // namespace cuda
+} // namespace torch

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -567,7 +567,9 @@ void Pickler::pushTensorReference(const IValue& ivalue) {
 // ivalue to the stack as a string so we can preserve type tags across
 // serialization
 void Pickler::startTypeTag() {
-  pushGlobal("torch.jit._pickle", "restore_type_tag");
+  if (tag_aggregates_) {
+    pushGlobal("torch.jit._pickle", "restore_type_tag");
+  }
 }
 namespace {
 c10::optional<std::string> type_printer(const c10::Type& type) {
@@ -580,6 +582,9 @@ c10::optional<std::string> type_printer(const c10::Type& type) {
 
 // See startTypeTag
 void Pickler::endTypeTag(const IValue& ivalue) {
+  if (!tag_aggregates_) {
+    return;
+  }
   TORCH_INTERNAL_ASSERT(ivalue.isGenericDict() || ivalue.isList());
 
   // Push the dict type

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -130,12 +130,14 @@ class TORCH_API Pickler {
       std::vector<at::Tensor>* tensor_table,
       std::function<c10::QualifiedName(const c10::ClassTypePtr&)> type_renamer,
       std::vector<c10::ClassTypePtr>* memoized_class_types,
-      std::function<std::string(const at::Tensor&)> get_tensor_id = nullptr)
+      std::function<std::string(const at::Tensor&)> get_tensor_id = nullptr,
+      bool tag_aggregates = true)
       : writer_(std::move(writer)),
         tensor_table_(tensor_table),
         type_renamer_(std::move(type_renamer)),
         memoized_class_types_(memoized_class_types),
-        get_tensor_id_(std::move(get_tensor_id)) {}
+        get_tensor_id_(std::move(get_tensor_id)),
+        tag_aggregates_(tag_aggregates) {}
   // NOLINTNEXTLINE(bugprone-exception-escape)
   ~Pickler();
 
@@ -274,6 +276,7 @@ class TORCH_API Pickler {
   std::unordered_map<std::string, uint32_t> memoized_globals_map_;
   std::unordered_map<std::string, uint32_t> memoized_strings_map_;
   std::unordered_map<std::string, uint32_t> memoized_devices_map_;
+  bool tag_aggregates_;
 };
 
 // returns a (tensor, record_size) for a tensor, converting it to a CPU tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86189

Sometimes the driving process want to save memory snapshots but isn't Python.
Add a simple API to turn it on without python stack traces. It still
saves to the same format for the vizualization and summary scripts, using
the C++ Pickler.