### PR TITLE
[ONNX] Ignore print(Tensor) during tracing

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -37,7 +37,8 @@ from pytorch_test_common import (
 )
 from torch import Tensor
 from torch.nn.utils import rnn as rnn_utils
-from torch.onnx import _constants, verification
+from torch.onnx import _constants, errors, verification
+from torch.onnx._globals import GLOBALS
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import skipIfNoLapack
 
@@ -12489,6 +12490,38 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 )
 
         self.run_test(LerpModel(), torch.rand(5, 4, 3))
+
+    @common_utils.parametrize("use_complex_dtypes", [True, False])
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_print_tensor_within_torch_nn_module(self, use_complex_dtypes: bool):
+        class PrintTensorOnMyModel(torch.nn.Module):
+            def forward(self, x):
+                x_firsts = x[:, 0]
+                print(f"x_firsts: {x_firsts}")
+                return x_firsts
+
+        m = PrintTensorOnMyModel().eval()
+        if use_complex_dtypes:
+            dtype = torch.cfloat
+        else:
+            dtype = torch.float
+        x = torch.randn(10, 5, dtype=dtype)
+
+        if use_complex_dtypes:
+            if GLOBALS.onnx_shape_inference:
+                exception_type = RuntimeError
+            else:
+                exception_type = errors.OnnxExporterError
+            with self.assertRaises(exception_type):
+                self.run_test(
+                    m,
+                    x,
+                )
+        else:
+            self.run_test(
+                m,
+                x,
+            )
 
     # Cannot export with older opsets because of "ConstantFill" op
     # ConstantFill was a temp op removed at opset 8. This is no longer supported by onnxruntime

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -12495,8 +12495,12 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
     def test_print_tensor_within_torch_nn_module(self, input_dtype: torch.dtype):
         class PrintTensorOnMyModel(torch.nn.Module):
             def forward(self, x):
+                # 'print' has side effect calling 'resolve_conj' and 'resolve_neg'.
                 x_firsts = x[:, 0]
                 print(f"x_firsts: {x_firsts}")
+                # 'tolist' has side effect calling 'resolve_conj' and 'resolve_neg'.
+                # Annotation added to pass torch script.
+                _: List[float] = x.tolist()
                 return x_firsts
 
         m = PrintTensorOnMyModel().eval()

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -12503,7 +12503,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 _: List[float] = x.tolist()
                 return x_firsts
 
-        m = PrintTensorOnMyModel().eval()
+        m = PrintTensorOnMyModel()
         x = torch.randn(10, 5, dtype=input_dtype)
         if input_dtype == torch.cfloat:
             with self.assertRaises(RuntimeError):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -504,6 +504,16 @@ def _is_tuple_construct(x: _C.Value) -> bool:
 
 
 @_beartype.beartype
+def is_complex_value(x: _C.Value) -> bool:
+    assert _is_value(x)
+    return _type_utils.JitScalarType.from_name(x.type().scalarType()) in {
+        _type_utils.JitScalarType.COMPLEX32,
+        _type_utils.JitScalarType.COMPLEX64,
+        _type_utils.JitScalarType.COMPLEX128,
+    }
+
+
+@_beartype.beartype
 def is_caffe2_aten_fallback() -> bool:
     return (
         GLOBALS.operator_export_type == _C_onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -31,6 +31,7 @@ __all__ = [
     "check_training_mode",
     "dequantize_helper",
     "is_caffe2_aten_fallback",
+    "is_complex_value",
     "parse_args",
     "pytorch_name_to_type",
     "quantize_helper",

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -269,6 +269,7 @@ __all__ = [
     "unsafe_split",
     "unsqueeze",
     "unsupported_complex_operators",
+    "noop_complex_operators",
     "unused",
     "var_mean",
     "var",
@@ -6663,10 +6664,20 @@ def onnx_placeholder(g: jit_utils.GraphContext, *inputs, **attrs):
     return torch._C._jit_onnx_convert_pattern_from_subblock(block, node, env)
 
 
-@_onnx_symbolic("aten::_conj")
-@_onnx_symbolic("aten::conj_physical")
 @_onnx_symbolic("aten::resolve_conj")
 @_onnx_symbolic("aten::resolve_neg")
+@_beartype.beartype
+def noop_complex_operators(g: jit_utils.GraphContext, input: _C.Value):
+    # ONNX does not have operators to *directly* manipulate real/imaginary components
+    # However, a few torch APIs (e.g. .tolist()) use complex operations when input is real,
+    # which results in failures due to missing operators for complex numbers
+
+    # `aten::resolve_conj` and `aten::resolve_neg` can safely be implemented as no-op
+    return input
+
+
+@_onnx_symbolic("aten::_conj")
+@_onnx_symbolic("aten::conj_physical")
 @_beartype.beartype
 def unsupported_complex_operators(g: jit_utils.GraphContext, input: _C.Value):
     # ONNX does not have operators to *directly* manipulate real/imaginary components
@@ -6675,9 +6686,11 @@ def unsupported_complex_operators(g: jit_utils.GraphContext, input: _C.Value):
 
     # While `aten::_conj` and `aten::conj_phisical` raise exception when input is complex
     if symbolic_helper.is_complex_value(input):
+        # FIXME(justinchuby): report correct name for symbolic being executed
         return symbolic_helper._onnx_unsupported(
-            "aten::_conj, aten::conj_physical, aten::resolve_conj, aten::resolve_neg",
+            "aten::_conj, aten::conj_physical",
             input,
         )
-    # `aten::resolve_conj` and `aten:: resolve_neg` can safely be implemented as no-op
-    return input
+
+    # they can safely be implemented as no-op for real numbers only
+    return noop_complex_operators(g, input)


### PR DESCRIPTION
Fixes #73619
Fixes https://github.com/microsoft/onnxruntime/issues/11812

This PR adds new symbolics: `aten::_conj`, `aten::conj_physical`, `aten::resolve_conj`, and `aten::resolve_neg`
While the last two are always NO-OP by definition (do not change nodes), the first raises an exception as they are not supported by ONNX yet