### PR TITLE
Add ref for cumsum

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1072,7 +1072,6 @@ symbolic_tensor_failures = {
     xfail('cummax', ''),  # aten.cummax.default - couldn't find symbolic meta function/decomposition
     xfail('cummin', ''),  # aten.cummin.default - couldn't find symbolic meta function/decomposition
     xfail('cumprod', ''),  # aten.cumprod.default - couldn't find symbolic meta function/decomposition
-    xfail('cumsum', ''),  # aten.cumsum.default - couldn't find symbolic meta function/decomposition
     xfail('cumulative_trapezoid', ''),  # aten.slice.Tensor - couldn't find symbolic meta function/decomposition
     xfail('deg2rad', ''),  # aten.deg2rad.default - couldn't find symbolic meta function/decomposition
     xfail('diagonal_scatter', ''),  # aten.diagonal_scatter.default - couldn't find symbolic meta function/decomposition

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1988,7 +1988,7 @@ def sum(
     dim: Union[Optional[int], Optional[List[int]]] = None,
     keepdim: bool = False,
     *,
-    dtype=None,
+    dtype: Optional[torch.dtype] = None,
     out: Optional[Tensor] = None,
 ) -> TensorLikeType:
     if dtype is None:
@@ -3571,6 +3571,30 @@ def unfold_copy(a: TensorLikeType, dimension: int, size: int, step: int):
         a.shape, a.stride(), dimension, size, step
     )
     return a.as_strided(new_size, new_stride)
+
+
+@register_decomposition(torch.ops.aten.cumsum)
+def cumsum(
+    a: TensorLikeType,
+    dim: int,
+    *,
+    keepdim: bool = False,
+    dtype: Optional[torch.dtype] = None,
+    out: Optional[Tensor] = None,
+) -> TensorLikeType:
+    # We implement all the kwargs of a reduction. ATen just handles dtype
+    # nb. This decomposition may not be as efficient as a backend-specific implementation
+    ndim = a.ndim
+    dim = utils.canonicalize_dim(ndim, dim)
+    if ndim == 0:
+        return sum(a.unsqueeze(0), dim=0, keepdim=keepdim, dtype=dtype, out=out)
+    a = a.unsqueeze(dim + 1)
+    rg = torch.arange(a.shape[dim], device=a.device)
+    mask = rg.unsqueeze(1) <= rg
+    for _ in range(ndim - dim - 1):
+        mask = mask.unsqueeze(-1)
+    masked_a = utils.mask_tensor(mask, a)
+    return sum(masked_a, dim=dim, keepdim=keepdim, dtype=dtype, out=out)
 
 
 @register_decomposition(torch.ops.aten.unsqueeze, disable_meta=True)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17798,6 +17798,12 @@ python_ref_db = [
         supports_out=True,
     ),
     PythonRefInfo(
+        "_refs.cumsum",
+        torch_opinfo_name="cumsum",
+        supports_out=True,
+        supports_nvfuser=False,  # arange not supported
+    ),
+    PythonRefInfo(
         "_refs.sum_to_size",
         torch_opinfo_name="sum_to_size",
         validate_view_consistency=False,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86229

As noted in the comment, this decomposition may not be as efficient as
specific implementations of it in different backends. Added here to then
benchmark it. Note that this is needed by TorchInductor https://github.com/pytorch/pytorch/issues/93631