### PR TITLE
Override Quantized Backend to use Fbgemm in Qlinear Packed Params Test

### DIFF
--- a/test/ao/sparsity/test_qlinear_packed_params.py
+++ b/test/ao/sparsity/test_qlinear_packed_params.py
@@ -4,6 +4,10 @@
 import tempfile
 import torch
 from torch.ao.nn.sparse.quantized.dynamic.linear import Linear
+from torch.testing._internal.common_quantization import (
+    skipIfNoFBGEMM,
+    skipIfNoQNNPACK,
+)
 from torch.testing._internal.common_quantized import (
     qengine_is_qnnpack,
     override_quantized_engine,
@@ -12,7 +16,7 @@ from torch.testing._internal.common_quantized import (
 from torch.testing._internal.common_utils import TestCase
 
 class TestQlinearPackedParams(TestCase):
-    def test_qlinear_packed_params(self, allow_non_zero_zero_points=False):
+    def qlinear_packed_params_test(self, allow_non_zero_zero_points=False):
         # copied from https://pytorch.org/docs/stable/sparse.html#csr-tensor-operations,
         # so row/col block indices match that example, but with blocks and
         # scaled rows
@@ -154,8 +158,16 @@ class TestQlinearPackedParams(TestCase):
                     self.assertEqual(y1, y2)
 
 
+    @skipIfNoFBGEMM
+    def test_qlinear_packed_params_fbgemm(self):
+        torch.manual_seed(0)
+        with override_quantized_engine('fbgemm'):
+            self.qlinear_packed_params_test(allow_non_zero_zero_points=False)
+
+
+    @skipIfNoQNNPACK
     def test_qlinear_packed_params_qnnpack(self):
         torch.manual_seed(0)
         with override_quantized_engine('qnnpack'):
             with override_cpu_allocator_for_qnnpack(qengine_is_qnnpack()):
-                self.test_qlinear_packed_params(allow_non_zero_zero_points=True)
+                self.qlinear_packed_params_test(allow_non_zero_zero_points=True)


### PR DESCRIPTION
Summary: After D39934051, we must explicitly ```override_quantized_engine('fbgemm')``` for this test to work

Test Plan:
```
buck test //caffe2/test:ao -- TestQlinearPackedParams
```

Before:
```
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/5629499663624574
    ✓ ListingSuccess: caffe2/test:ao : 72 tests discovered (32.830)
    ✓ Pass: caffe2/test:ao - test_qlinear_packed_params_qnnpack (ao.sparsity.test_qlinear_packed_params.TestQlinearPackedParams) (25.085)
    ✗ Fail: caffe2/test:ao - test_qlinear_packed_params (ao.sparsity.test_qlinear_packed_params.TestQlinearPackedParams) (26.706)
Test output:
> RuntimeError: Didn't find engine for operation ao::sparse::qlinear_prepack X86
```

After:
```
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/7599824485968786
    ✓ ListingSuccess: caffe2/test:ao : 72 tests discovered (31.082)
    ✓ Pass: caffe2/test:ao - test_qlinear_packed_params_fbgemm (ao.sparsity.test_qlinear_packed_params.TestQlinearPackedParams) (100.409)
    ✓ Pass: caffe2/test:ao - test_qlinear_packed_params_qnnpack (ao.sparsity.test_qlinear_packed_params.TestQlinearPackedParams) (100.544)
Summary
  Pass: 2
  ListingSuccess: 1
```

Differential Revision: D40078176

