### PR TITLE
Fix broadcasting to implicit leading dimensions in `torch.where` on MPS

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4672,6 +4672,7 @@ class TestNLLLoss(TestCase):
         helper((1, 1, 1), (1, 1, 4), (2, 3, 1))
         helper([], (1, 1, 4), (2, 3, 1))
         helper([], (2, 3, 4), [])
+        helper((2, 3), (5, 2, 3), (2, 3))
 
     # Test normal
     def test_normal(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4672,7 +4672,10 @@ class TestNLLLoss(TestCase):
         helper((1, 1, 1), (1, 1, 4), (2, 3, 1))
         helper([], (1, 1, 4), (2, 3, 1))
         helper([], (2, 3, 4), [])
+        helper((5, 2, 3), (2, 3), (2, 3))
         helper((2, 3), (5, 2, 3), (2, 3))
+        helper((2, 3), (2, 3), (5, 2, 3))
+        helper((2, 3), (5, 2, 3), (6, 5, 2, 3))
 
     # Test normal
     def test_normal(self):


### PR DESCRIPTION
Fixes #86239
