### PR TITLE
Add total GPU memory utilization

### DIFF
--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -76,9 +76,7 @@ if __name__ == "__main__":
             if handle is not None:
                 stats["per_process_gpu_info"] = get_per_process_gpu_info(handle)
                 # https://docs.nvidia.com/deploy/nvml-api/structnvmlUtilization__t.html
-                gpu_utilization = pynvml.nvmlDeviceGetUtilizationRates(
-                    handle
-                )
+                gpu_utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
                 stats["total_gpu_utilization"] = gpu_utilization.gpu
                 stats["total_gpu_mem_utilization"] = gpu_utilization.memory
         except Exception as e:

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -75,9 +75,12 @@ if __name__ == "__main__":
             }
             if handle is not None:
                 stats["per_process_gpu_info"] = get_per_process_gpu_info(handle)
-                stats["total_gpu_utilizaiton"] = pynvml.nvmlDeviceGetUtilizationRates(
+                # https://docs.nvidia.com/deploy/nvml-api/structnvmlUtilization__t.html
+                gpu_utilization = pynvml.nvmlDeviceGetUtilizationRates(
                     handle
-                ).gpu
+                )
+                stats["total_gpu_utilization"] = gpu_utilization.gpu
+                stats["total_gpu_mem_utilization"] = gpu_utilization.memory
         except Exception as e:
             stats = {
                 "time": datetime.datetime.utcnow().isoformat("T") + "Z",


### PR DESCRIPTION
Although we already have per process GPU memory usage, I'm curious to see what is the number for `gpu_utilization.memory` per https://docs.nvidia.com/deploy/nvml-api/structnvmlUtilization__t.html.  Also fixing a tiny typo issue that has been bugging me for a while `total_gpu_utilizaiton`
