### PR TITLE
[CuDNN v8 API][Quantization]fix alignment function in quantized cuDNN V8 path

### DIFF
--- a/aten/src/ATen/native/quantized/cudnn/utils.h
+++ b/aten/src/ATen/native/quantized/cudnn/utils.h
@@ -203,11 +203,15 @@ at::Tensor getRequantMultiplierTensor(double requant_multiplier, uint8_t num_dim
   return requantize_multiplier_tensor;
 }
 
-uint8_t getAlignment(const at::Tensor &t) {
+uint8_t getAlignment(const Tensor &t) {
   // alignment are in bytes
   uint8_t alignment = 1;
   uintptr_t address = reinterpret_cast<uintptr_t>(t.data_ptr());
-  while (address % alignment == 0 && alignment < 16) alignment *= 2;
+  for (; alignment < 16; alignment *= 2) {
+    if (address % (alignment * 2)) {
+      return alignment;
+    }
+  }
   return alignment;
 }
 

--- a/aten/src/ATen/native/quantized/cudnn/utils.h
+++ b/aten/src/ATen/native/quantized/cudnn/utils.h
@@ -203,7 +203,7 @@ at::Tensor getRequantMultiplierTensor(double requant_multiplier, uint8_t num_dim
   return requantize_multiplier_tensor;
 }
 
-uint8_t getAlignment(const at:Tensor &t) {
+uint8_t getAlignment(const at::Tensor &t) {
   // alignment are in bytes
   uint8_t alignment = 1;
   uintptr_t address = reinterpret_cast<uintptr_t>(t.data_ptr());

--- a/aten/src/ATen/native/quantized/cudnn/utils.h
+++ b/aten/src/ATen/native/quantized/cudnn/utils.h
@@ -203,7 +203,7 @@ at::Tensor getRequantMultiplierTensor(double requant_multiplier, uint8_t num_dim
   return requantize_multiplier_tensor;
 }
 
-uint8_t getAlignment(const Tensor &t) {
+uint8_t getAlignment(const at:Tensor &t) {
   // alignment are in bytes
   uint8_t alignment = 1;
   uintptr_t address = reinterpret_cast<uintptr_t>(t.data_ptr());


### PR DESCRIPTION
This bug was in the native cuDNN V8 API integration and was fixed a while ago, but the change was never ported here.

Previously the returned alignment could be twice the actual alignment of the data if the alignment was smaller than 16.