### PR TITLE
[allocator tracing] missing GIL acquire

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -537,6 +537,7 @@ struct Frame {
 struct StackContext : public c10::cuda::CUDACachingAllocator::Context {
   std::vector<Frame> frames;
   ~StackContext() {
+    py::gil_scoped_acquire acquire;
     for (auto& f : frames) {
       Py_XDECREF((PyObject*)f.code);
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #86241
* #86190
* __->__ #86254

Bug where the context destructor needs to hold the GIL to free the context.