### PR TITLE
Reduce warning suppression by just disabling pytest warnings plugin

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,8 @@ addopts =
     --tb=native
     # capture only Python print and C++ py::print, but not C output (low-level Python errors)
     --capture=sys
-    --disable-warnings
+    # don't suppress warnings, but don't shove them all to the end either
+    -p no:warnings
 testpaths =
     test
 junit_logging_reruns = all


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86255

Fixes https://github.com/pytorch/pytorch/issues/85626

Signed-off-by: Edward Z. Yang <ezyang@fb.com>