### PR TITLE
PixelShuffle check that output is not null before applying kernel (#85155)

### DIFF
--- a/aten/src/ATen/native/PixelShuffle.cpp
+++ b/aten/src/ATen/native/PixelShuffle.cpp
@@ -68,7 +68,7 @@ Tensor pixel_unshuffle_cpu(const Tensor& self, int64_t downscale_factor) {
   check_pixel_unshuffle_shapes(self, downscale_factor);
 
   if (self.numel() == 0) {
-    return self;
+    return self.clone();
   }
 
   // Format: (B1, ..., Bn), C, H, W

--- a/aten/src/ATen/native/PixelShuffle.cpp
+++ b/aten/src/ATen/native/PixelShuffle.cpp
@@ -53,6 +53,11 @@ Tensor pixel_shuffle_cpu(const Tensor& self, int64_t upscale_factor) {
   auto output = at::empty({0}, self.options());
   auto memory_format = self.suggest_memory_format();
   output.resize_(output_sizes, memory_format);
+
+  if (output.numel() == 0) {
+    return output;
+  }
+
   auto input = self.contiguous(memory_format);
 
   pixel_shuffle_kernel(kCPU, output, input, upscale_factor);
@@ -61,6 +66,10 @@ Tensor pixel_shuffle_cpu(const Tensor& self, int64_t upscale_factor) {
 
 Tensor pixel_unshuffle_cpu(const Tensor& self, int64_t downscale_factor) {
   check_pixel_unshuffle_shapes(self, downscale_factor);
+
+  if (self.numel() == 0) {
+    return self;
+  }
 
   // Format: (B1, ..., Bn), C, H, W
   std::vector<int64_t> output_sizes(self.sizes().begin(), self.sizes().end() - 3);
@@ -72,6 +81,11 @@ Tensor pixel_unshuffle_cpu(const Tensor& self, int64_t downscale_factor) {
   auto output = at::empty({0}, self.options());
   auto memory_format = self.suggest_memory_format();
   output.resize_(output_sizes, memory_format);
+
+  if (output.numel() == 0) {
+    return output;
+  }
+
   auto input = self.contiguous(memory_format);
 
   pixel_unshuffle_kernel(kCPU, output, input, downscale_factor);

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7432,6 +7432,16 @@ def sample_inputs_pixel_shuffle(op_info, device, dtype, requires_grad, **kwargs)
             kwargs=dict(upscale_factor=upscale_factor),
         )
         for upscale_factor in (1, 3)
+    ] + [
+        SampleInput(
+            make_tensor(shape, device=device, dtype=dtype, requires_grad=requires_grad),
+            kwargs=dict(upscale_factor=1),
+        )
+        for shape in [
+            (1, 0, 1, 1),
+            (1, 1, 0, 1),
+            (1, 1, 1, 0),
+        ]
     ]
 
 def sample_inputs_pixel_unshuffle(op_info, device, dtype, requires_grad, **kwargs):
@@ -7441,6 +7451,16 @@ def sample_inputs_pixel_unshuffle(op_info, device, dtype, requires_grad, **kwarg
             kwargs=dict(downscale_factor=downscale_factor),
         )
         for downscale_factor in (1, 3)
+    ] + [
+        SampleInput(
+            make_tensor(shape, device=device, dtype=dtype, requires_grad=requires_grad),
+            kwargs=dict(downscale_factor=1),
+        )
+        for shape in [
+            (1, 0, 1, 1),
+            (1, 1, 0, 1),
+            (1, 1, 1, 0),
+        ]
     ]
 
 def sample_inputs_binary_cross_entropy(op_info, device, dtype, requires_grad, logits=False, **kwargs):


### PR DESCRIPTION
* Checks that output tensor is not null before applying kernel in `pixel_shuffle` op
* Checks that output tensor is not null before applying kernel in `pixel_unshuffle` op
* Add test case testing `pixel_shuffle` with shapes producing empty output
* Add test case testing `pixel_unshuffle` with shapes producing empty output

Fixes #85155

FYI @lezcano 