### PR TITLE
Fix black binary again for debug python

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -738,6 +738,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
+    '--no-black-binary',
     'black==22.3.0',
     'ufmt==1.3.3',
     'usort==1.0.2',

--- a/tools/linter/adapters/pip_init.py
+++ b/tools/linter/adapters/pip_init.py
@@ -37,8 +37,8 @@ if __name__ == "__main__":
         "--dry-run", help="do not install anything, just print what would be done."
     )
     parser.add_argument(
-        "--no-binary",
-        help="do not use pre-compiled binaries from pip.",
+        "--no-black-binary",
+        help="do not use pre-compiled binaries from pip for black.",
         action="store_true",
     )
 
@@ -72,7 +72,7 @@ if __name__ == "__main__":
                 "Package {package_name} did not have a version specified. "
                 "Please specify a version to produce a consistent linting experience."
             )
-        if args.no_binary:
+        if args.no_black_binary and "black" in package_name:
             pip_args.append(f"--no-binary={package_name}")
 
     dry_run = args.dry_run == "1"


### PR DESCRIPTION
The `--no-binary` flag was not ported when moving from black only to ufmt.
This adds it back.

This is to work around the fact that black binary hard crashes when running with debug python and it needs to be compiled from source.