### PR TITLE
(Further) limit world size in test_fsdp_pure_fp16

### DIFF
--- a/test/distributed/fsdp/test_fsdp_pure_fp16.py
+++ b/test/distributed/fsdp/test_fsdp_pure_fp16.py
@@ -33,8 +33,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 class TestPureFP16(FSDPTest):
     @property
     def world_size(self):
-        # Test fails due to inaccuracies when using more than 5 GPUs
-        return min(5, super().world_size)
+        # Test fails due to inaccuracies when using more than 4 GPUs
+        return min(4, super().world_size)
 
     @skip_if_lt_x_gpu(2)
     @parametrize(


### PR DESCRIPTION
Test still fails when run on 5 A100 GPUs, although it works with 5 V100s. Using 4 GPUs seems to be fine.

Followup to #85957


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu