### PR TITLE
🦊 [AI Accelerators] Consolidate native_layer_norm for nested tensor

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2887,6 +2887,7 @@
     CUDA: layer_norm_cuda
     MPS: layer_norm_mps
     CompositeExplicitAutograd: math_native_layer_norm
+    NestedTensorCPU, NestedTensorCUDA: nested_layer_norm
   autogen: native_layer_norm.out
 
 - func: native_layer_norm_backward(Tensor grad_out, Tensor input, SymInt[] normalized_shape, Tensor mean, Tensor rstd, Tensor? weight, Tensor? bias, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
@@ -13134,12 +13135,6 @@
   dispatch:
     NestedTensorCPU: NestedTensor_softmax_dropout
     NestedTensorCUDA: NestedTensor_softmax_dropout_cuda
-
-- func: _nested_tensor_layer_norm(Tensor self, Tensor? weight, Tensor? bias, float eps) -> Tensor
-  variants: method
-  dispatch:
-    NestedTensorCPU, NestedTensorCUDA: NestedTensor_layer_norm
-  autogen: _nested_tensor_layer_norm.out
 
 # Apparently, putting "forward" in the name will cause Python bindings to be skipped, so "fwd" it is.
 - func: _transformer_encoder_layer_fwd(Tensor src, int embed_dim, int num_heads, Tensor qkv_weight, Tensor qkv_bias, Tensor proj_weight, Tensor proj_bias, bool use_gelu, bool norm_first, float eps, Tensor norm_weight_1, Tensor norm_bias_1, Tensor norm_weight_2, Tensor norm_bias_2, Tensor ffn_weight_1, Tensor ffn_bias_1, Tensor ffn_weight_2, Tensor ffn_bias_2, Tensor? mask=None, int? mask_type=None) -> Tensor

--- a/aten/src/ATen/native/transformers/transformer.cpp
+++ b/aten/src/ATen/native/transformers/transformer.cpp
@@ -49,14 +49,6 @@ Tensor ffn(
   return res;
 }
 
-void add_in_place(Tensor& input, const Tensor& arg, bool use_nested_tensor) {
-  if (use_nested_tensor) {
-    NestedTensor_add_NestedTensor_in_place(input, arg);
-  } else {
-    input.add_(arg);
-  }
-}
-
 Tensor norm(
     const Tensor& input,
     const int64_t embed_dim,
@@ -64,11 +56,7 @@ Tensor norm(
     const Tensor& weight,
     const Tensor& bias,
     const bool use_nested_tensor) {
-  if (use_nested_tensor) {
-    return NestedTensor_layer_norm(input, weight, bias, eps);
-  } else {
-    return at::layer_norm(input, {embed_dim}, weight, bias, eps, true);
-  }
+  return at::layer_norm(input, {embed_dim}, weight, bias, eps, true);
 }
 
 } // namespace
@@ -140,7 +128,7 @@ Tensor transformer_encoder_layer_forward(
 #if BETTER_TRANSFORMER_USE_FLASH_ATTENTION
   }
 #endif
-  add_in_place(x, src, use_nested_tensor);
+  x.add_(src);
   if (!norm_first) {
     x = norm(x, embed_dim, layer_norm_eps, layer_norm_weight_1, layer_norm_bias_1, use_nested_tensor);
   }
@@ -158,7 +146,7 @@ Tensor transformer_encoder_layer_forward(
       ffn_bias_2,
       use_gelu,
       /* add_norm* */ false);
-  add_in_place(x, pre_ffn_res, use_nested_tensor);
+  x.add_(pre_ffn_res);
   if (!norm_first) {
     x = norm(x, embed_dim, layer_norm_eps, layer_norm_weight_2, layer_norm_bias_2, use_nested_tensor);
   }
@@ -197,7 +185,6 @@ std::tuple<Tensor, Tensor, Tensor>  transformer_decoder_only_layer_forward(
     }
   }
   TORCH_CHECK(!norm_first, "norm_first is not supported yet");
-  const bool use_nested_tensor = src.is_nested();
   auto mha_out = native_decoder_only_multi_head_attention(
       src,
       src,
@@ -215,20 +202,14 @@ std::tuple<Tensor, Tensor, Tensor>  transformer_decoder_only_layer_forward(
   auto x = std::get<0>(mha_out);
   auto incr_key_out = std::get<2>(mha_out);
   auto incr_value_out = std::get<3>(mha_out);
-  if (use_nested_tensor) {
-    NestedTensor_add_NestedTensor_in_place(x, src);
-    x = NestedTensor_layer_norm(
-        x, layer_norm_weight_1, layer_norm_bias_1, layer_norm_eps);
-  } else {
-    x.add_(src);
-    x = at::layer_norm(
-        x,
-        {embed_dim},
-        layer_norm_weight_1,
-        layer_norm_bias_1,
-        layer_norm_eps,
-        true);
-  }
+  x.add_(src);
+  x = at::layer_norm(
+      x,
+      {embed_dim},
+      layer_norm_weight_1,
+      layer_norm_bias_1,
+      layer_norm_eps,
+      true);
 
   auto pre_ffn_res = x;
   x = ffn(
@@ -239,20 +220,14 @@ std::tuple<Tensor, Tensor, Tensor>  transformer_decoder_only_layer_forward(
       ffn_bias_2,
       use_gelu,
       /* add_norm* */ false);
-  if (use_nested_tensor) {
-    NestedTensor_add_NestedTensor_in_place(x, pre_ffn_res);
-    x = NestedTensor_layer_norm(
-        x, layer_norm_weight_2, layer_norm_bias_2, layer_norm_eps);
-  } else {
-    x.add_(pre_ffn_res);
-    x = at::layer_norm(
-        x,
-        {embed_dim},
-        layer_norm_weight_2,
-        layer_norm_bias_2,
-        layer_norm_eps,
-        true);
-  }
+  x.add_(pre_ffn_res);
+  x = at::layer_norm(
+      x,
+      {embed_dim},
+      layer_norm_weight_2,
+      layer_norm_bias_2,
+      layer_norm_eps,
+      true);
   return std::make_tuple(std::move(x), std::move(incr_key_out), std::move(incr_value_out));
 }
 

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -289,6 +289,7 @@ ALLOW_LIST = [
     ("aten::to_padded_tensor", datetime.date(2022, 10, 1)),
     ("aten::nested_to_padded_tensor", datetime.date(2022, 10, 1)),
     ("aten::nested_tensor", datetime.date(2022, 10, 15)),
+    ("aten::_nested_tensor_layer_norm", datetime.date(2022, 10, 15)),
 
 ]
 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -283,7 +283,6 @@ def get_ignored_functions() -> Set[Callable]:
         Tensor._neg_view,
         Tensor._is_zerotensor,
         Tensor._addmm_activation,
-        Tensor._nested_tensor_layer_norm,
         Tensor.to_padded_tensor,
     }
 


### PR DESCRIPTION
Summary: In order to make the layer normalization implementation for nested tensors public, it needs to be generalized to accept a normalized_shape argument instead of assuming it to be the last dimension of the nested_tensor. This commit does that, as well as adding extra unit tests to ensure the implementation is correct.

Test Plan:
All unit tests designed to test different ways of using the function work:

`buck test //caffe2/test:nested -- test_layer_norm`

Differential Revision: D40105207

