### PR TITLE
Conditionally build the TestApp benchmark based on lite interpreter

### DIFF
--- a/ios/TestApp/TestApp/Benchmark.h
+++ b/ios/TestApp/TestApp/Benchmark.h
@@ -1,3 +1,5 @@
+#ifdef BUILD_LITE_INTERPRETER
+
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -10,3 +12,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/ios/TestApp/TestApp/Benchmark.mm
+++ b/ios/TestApp/TestApp/Benchmark.mm
@@ -1,3 +1,5 @@
+#ifdef BUILD_LITE_INTERPRETER
+
 #import "Benchmark.h"
 #include <string>
 #include <vector>
@@ -103,3 +105,4 @@ static int iter = 10;
 }
 
 @end
+#endif

--- a/ios/TestApp/TestApp/ViewController.mm
+++ b/ios/TestApp/TestApp/ViewController.mm
@@ -1,6 +1,9 @@
 #import "ViewController.h"
 
+
+#ifdef BUILD_LITE_INTERPRETER
 #import "Benchmark.h"
+#endif
 
 @interface ViewController ()
 @property(nonatomic, strong) UITextView* textView;
@@ -11,6 +14,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
+#ifdef BUILD_LITE_INTERPRETER
   self.textView = [[UITextView alloc] initWithFrame:self.view.bounds];
   self.textView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   [self.view addSubview:self.textView];
@@ -30,8 +34,10 @@
 
   [Benchmark setup:config];
   [self runBenchmark];
+#endif
 }
 
+#ifdef BUILD_LITE_INTERPRETER
 - (void)runBenchmark {
   self.textView.text = @"Start benchmarking...\n";
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
@@ -41,5 +47,6 @@
     });
   });
 }
+#endif
 
 @end

--- a/ios/TestApp/benchmark/setup.rb
+++ b/ios/TestApp/benchmark/setup.rb
@@ -36,6 +36,11 @@ targets.each do |target|
         config.build_settings['LIBRARY_SEARCH_PATHS']   = libraries_search_path
         config.build_settings['OTHER_LDFLAGS']          = other_linker_flags
         config.build_settings['ENABLE_BITCODE']         = 'No'
+        if (options[:lite])
+            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = ['$(inherited)', "BUILD_LITE_INTERPRETER"]
+        else
+            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = ['$(inherited)']
+        end
         dev_team_id = options[:team_id]
         if dev_team_id
             config.build_settings['DEVELOPMENT_TEAM']   = dev_team_id


### PR DESCRIPTION
The TestApp benchmark was recently re-added, however it seems it only builds when pytorch is built with the lite interpreter. This diff adds a macro to compile out the benchmark when pytorch is built as full jit. This should fix our full jit simulator nightly builds.