### PR TITLE
MultiThreaded FileSystemWriter for distributed checkpointing.

### DIFF
--- a/torch/distributed/_shard/checkpoint/filesystem.py
+++ b/torch/distributed/_shard/checkpoint/filesystem.py
@@ -296,7 +296,7 @@ class FileSystemWriter(StorageWriter):
             single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
             sync_files : force files to be synced to permanent storage. Default to True.
             thread_count: Number of IO threads to use to write. Default to 1.
-            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving then. Default 10Mb. 
+            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving then. Default 10Mb.
 
         N. B. If sync_files is disabled, there's no guarantee that the checkpoint will be consistent in the case of a failure.
         """

--- a/torch/distributed/_shard/checkpoint/filesystem.py
+++ b/torch/distributed/_shard/checkpoint/filesystem.py
@@ -1,3 +1,8 @@
+from abc import ABC, abstractmethod
+import queue
+import threading
+import collections
+
 from dataclasses import dataclass
 import os
 import dataclasses
@@ -61,6 +66,143 @@ def _result_from_write_item(item: WriteItem, size_in_bytes, storage_data) -> Wri
         size_in_bytes=size_in_bytes,
         storage_data=storage_data)
 
+class _TensorLoader(ABC):
+    @abstractmethod
+    def add(self, size, obj):
+        pass
+
+    def start_loading(self):
+        pass
+
+    @abstractmethod
+    def values(self):
+        pass
+
+class _SerialCpuLoader(_TensorLoader):
+    def __init__(self, resolve_fun):
+        self.resolve_fun = resolve_fun
+        self.items = []
+
+    def add(self, size, obj):
+        self.items.append((size, obj))
+
+    def start_loading(self):
+        pass
+
+    def values(self):
+        for _, obj in self.items:
+            tensor = self.resolve_fun(obj).detach()
+            tensor = tensor.cpu()
+            if tensor.storage().size() != tensor.numel():
+                tensor = tensor.clone()
+            yield (tensor, obj,)
+
+class _OverlappingCpuLoader(_TensorLoader):
+    def __init__(self, resolve_fun, stream=None, inflight_threshhold=1_000_000):
+        self.resolve_fun = resolve_fun
+        self.items = []
+        self.inflight_threshhold = inflight_threshhold
+        self.in_flight_data = 0
+        self.current_items: collections.deque = collections.deque()
+        self.idx = 0
+        self.started = False
+        self.stream = stream or torch.cuda.current_stream()
+        if self.stream != torch.cuda.current_stream():
+            self.stream.wait_stream(torch.cuda.current_stream())
+
+    @property
+    def _done(self):
+        return self.idx >= len(self.items)
+
+    def _drain(self):
+        drained = []
+        if self.in_flight_data >= self.inflight_threshhold:
+            self.stream.synchronize()
+        while self.in_flight_data >= self.inflight_threshhold:
+            val = self.current_items.popleft()
+            self.in_flight_data -= val[0].numel() * val[0].element_size()
+            drained.append(val)
+        return drained
+
+    def _refill(self):
+        with torch.cuda.stream(self.stream):
+            while not self._done and self.in_flight_data < self.inflight_threshhold:
+                _, obj = self.items[self.idx]
+                self.idx += 1
+                tensor = self.resolve_fun(obj).detach()
+                if tensor.is_cuda:
+                    tensor = tensor.to(device="cpu", non_blocking=True)
+                elif tensor.device == torch.device("cpu"):
+                    if tensor.storage().size() != tensor.numel():
+                        # this forces the tensor to be both contiguous and with minimal storage
+                        tensor = tensor.clone()
+
+                self.current_items.append((tensor, obj,))
+                self.in_flight_data += tensor.numel() * tensor.element_size()
+
+    def _finish(self):
+        assert self._done
+        if len(self.current_items) > 0:
+            self.stream.synchronize()
+        return self.current_items
+
+    def add(self, size, obj):
+        if self.started:
+            raise RuntimeError("cannot add items after loading started")
+        self.items.append((size, obj))
+
+    def start_loading(self):
+        if self.started:
+            return
+        self.started = True
+        self.items.sort(key=lambda x: x[0])
+        self._refill()
+
+    def values(self):
+        self.start_loading()
+        while not self._done:
+            drained = self._drain()
+            self._refill()
+            for obj in drained:
+                yield obj
+
+        for val in self._finish():
+            yield val
+
+
+def _item_size(item: WriteItem) -> int:
+    size = 1
+    assert item.tensor_data is not None
+    # can't use math.prod as PT needs to support older python
+    for s in item.tensor_data.size:
+        size *= s
+
+    dtype = item.tensor_data.properties.dtype
+    return size * torch._utils._element_size(dtype)
+
+def _split_by_size_and_type(bins, items: List[WriteItem]) -> List[List[WriteItem]]:
+    if bins == 1:
+        return [items]
+
+    bytes_w = [wi for wi in items if wi.type == WriteItemType.BYTE_IO]
+    tensor_w = [wi for wi in items if wi.type != WriteItemType.BYTE_IO]
+
+    buckets: List[List[WriteItem]] = [[] for _ in range(bins)]
+    bucket_sizes = [0 for _ in range(bins)]
+
+    tensor_w.sort(key=_item_size, reverse=True)
+
+    for i, wi in enumerate(bytes_w):
+        buckets[i % bins].append(wi)
+
+    for wi in tensor_w:
+        # TODO replace with headq
+        idx = min(enumerate(bucket_sizes), key=lambda x: x[1])[0]
+        buckets[idx].append(wi)
+        bucket_sizes[idx] += _item_size(wi)
+
+    return buckets
+
 def _write_item(stream, data, write_item, storage_key):
     offset = stream.tell()
 
@@ -80,30 +222,50 @@ def _write_item(stream, data, write_item, storage_key):
     )
 
 def _write_files_from_queue(
-    file_queue: List,
+    file_queue: queue.Queue,
+    result_queue: queue.Queue,
     planner: SavePlanner,
+    inflight_threshhold: int,
     use_fsync: bool,
 ):
-    write_results = []
+    try:
+        while True:
+            file_name, storage_key, write_items = file_queue.get_nowait()
+            loader: _TensorLoader
 
-    for file_path, file_name, write_items in file_queue:
-        tensor_w = [wi for wi in write_items if wi.type != WriteItemType.BYTE_IO]
-        bytes_w = [wi for wi in write_items if wi.type == WriteItemType.BYTE_IO]
+            if torch.cuda.is_available() and inflight_threshhold > 0:
+                loader = _OverlappingCpuLoader(
+                    lambda x: planner.resolve_data(x),
+                    inflight_threshhold=inflight_threshhold,
+                )
+            else:
+                loader = _SerialCpuLoader(
+                    lambda x: planner.resolve_data(x),
+                )
 
-        with open(file_path, "wb") as stream:
-            for write_item in bytes_w:
-                data = planner.resolve_data(write_item)
-                write_results.append(_write_item(stream, data, write_item, file_name))
-
+            tensor_w = [wi for wi in write_items if wi.type != WriteItemType.BYTE_IO]
             for write_item in tensor_w:
-                tensor = _trim(cast(torch.Tensor, planner.resolve_data(write_item)))
-                assert not tensor.is_cuda
-                write_results.append(_write_item(stream, tensor, write_item, file_name))
+                loader.add(_item_size(write_item), write_item)
+            loader.start_loading()
 
-            if use_fsync:
-                os.fsync(stream.fileno())
+            bytes_w = [wi for wi in write_items if wi.type == WriteItemType.BYTE_IO]
+            write_results = []
 
-    return write_results
+            with open(file_name, "wb") as stream:
+                for write_item in bytes_w:
+                    data = planner.resolve_data(write_item)
+                    write_results.append(_write_item(stream, data, write_item, storage_key))
+
+                for tensor, write_item in loader.values():
+                    assert not tensor.is_cuda
+                    write_results.append(_write_item(stream, tensor, write_item, storage_key))
+
+                if use_fsync:
+                    os.fsync(stream.fileno())
+            result_queue.put(write_results)
+    except queue.Empty:
+        pass
+
 
 class FileSystemWriter(StorageWriter):
     """
@@ -123,6 +285,8 @@ class FileSystemWriter(StorageWriter):
         path: Union[str, os.PathLike],
         single_file_per_rank: bool = False,
         sync_files: bool = True,
+        thread_count: int = 1,
+        per_thread_copy_ahead: int = 10_000_000,
     ) -> None:
         """
         Initialize the writer pointing to `path`
@@ -130,7 +294,9 @@ class FileSystemWriter(StorageWriter):
         Args:
             path: diretory where the checkpoint will be writen to.
             single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
-            sync_files: force files to be synced to permanent storage. Default to True.
+            sync_files : force files to be synced to permanent storage. Default to True.
+            thread_count: Number of IO threads to use to write. Default to 1.
+            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving then. Default 10Mb. 
 
         N. B. If sync_files is disabled, there's no guarantee that the checkpoint will be consistent in the case of a failure.
         """
@@ -138,6 +304,8 @@ class FileSystemWriter(StorageWriter):
         self.path = Path(path)
         self.single_file_per_rank = single_file_per_rank
         self.sync_files = sync_files
+        self.thread_count = thread_count
+        self.per_thread_copy_ahead = per_thread_copy_ahead
 
     def init(self, is_coordinator: bool) -> None:
         pass
@@ -168,24 +336,49 @@ class FileSystemWriter(StorageWriter):
             file_count += 1
             return file_name
 
-        file_queue = []
+        file_queue: queue.Queue = queue.Queue()
         if self.single_file_per_rank:
-            file_name = gen_file()
-            file_queue.append((self.path / file_name, file_name, plan.items))
+            for bucket in _split_by_size_and_type(self.thread_count, plan.items):
+                file_name = gen_file()
+                file_queue.put((self.path / file_name, file_name, bucket))
         else:
             for item in plan.items:
                 file_name = gen_file()
-                file_queue.append((self.path / file_name, file_name, [item]))
+                file_queue.put((self.path / file_name, file_name, [item]))
 
-        results = _write_files_from_queue(
+        result_queue: queue.Queue = queue.Queue()
+
+        threads = []
+        for _ in range(1, self.thread_count):
+            t = threading.Thread(
+                target=_write_files_from_queue,
+                args=(file_queue, result_queue, planner, self.per_thread_copy_ahead, self.sync_files,)
+            )
+            t.start()
+            threads.append(t)
+
+        _write_files_from_queue(
             file_queue=file_queue,
+            result_queue=result_queue,
             planner=planner,
+            inflight_threshhold=self.per_thread_copy_ahead,
             use_fsync=self.sync_files,
         )
 
-        fut: Future[List[WriteResult]] = Future()
-        fut.set_result(results)
-        return fut
+        for t in threads:
+            t.join()
+
+        res = []
+        try:
+            while True:
+                res += result_queue.get_nowait()
+        except queue.Empty:
+            pass
+
+            fut: Future[List[WriteResult]] = Future()
+            fut.set_result(res)
+            return fut
+
 
     def finish(self, metadata: Metadata, results: List[List[WriteResult]]) -> None:
         storage_md = dict()


### PR DESCRIPTION
This adds two knobs to FileSystemWriter: thread_count and per_thread_copy_ahead.

Those two lead to up to 50% performance improvement on 32 GPUs workloads on AWS.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu