### PR TITLE
Add at::symint:: namespace for ease of templated functions

### DIFF
--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -4,6 +4,7 @@
 #include <ATen/Functions.h>
 #else
 #include <ATen/ops/view_copy.h>
+#include <ATen/ops/view.h>
 #endif
 
 #include <ATen/Tensor.h>
@@ -437,15 +438,16 @@ inline std::vector<Tensor> expand_outplace(TensorList to_expand) {
   return result;
 }
 
-static inline Tensor sum_to(
+template <typename T>
+inline Tensor _sum_to(
     Tensor tensor,
-    const c10::SymIntArrayRef shape,
+    const c10::ArrayRef<T> shape,
     bool always_return_non_view = false) {
   if (shape.size() == 0) {
     return tensor.sum();
   }
 
-  auto sizes = tensor.sym_sizes();
+  auto sizes = at::symint::sizes<T>(tensor);
   c10::SmallVector<int64_t, 8> reduce_dims;
   const int64_t leading_dims = sizes.size() - shape.size();
   for (const auto i : c10::irange(leading_dims)) {
@@ -465,22 +467,27 @@ static inline Tensor sum_to(
     // This is only actually used by the functionalization pass.
     // We want to be able to guarantee that this function doesn't return a view
     // of the input.
-    return leading_dims > 0 ? at::view_copy_symint(tensor, shape)
+    return leading_dims > 0 ? at::symint::view_copy<T>(tensor, shape)
                             : tensor.clone();
   } else {
-    return leading_dims > 0 ? tensor.view_symint(shape) : tensor;
+    return leading_dims > 0 ? at::symint::view<T>(tensor, shape) : tensor;
   }
+}
+
+inline Tensor sum_to(
+    Tensor tensor,
+    const c10::SymIntArrayRef shape,
+    bool always_return_non_view = false) {
+  return _sum_to(tensor, shape, always_return_non_view);
 }
 
 // Sums `tensor` repeatedly to produce a tensor of shape `shape`.
 // Precondition: is_expandable_to(shape, tensor.sizes()) must be true
-static inline Tensor sum_to(
+inline Tensor sum_to(
     Tensor tensor,
     const IntArrayRef shape,
     bool always_return_non_view = false) {
-  auto sym_size = c10::SymIntArrayRef(
-      reinterpret_cast<const c10::SymInt*>(shape.data()), shape.size());
-  return sum_to(tensor, sym_size, always_return_non_view);
+  return _sum_to(tensor, shape, always_return_non_view);
 }
 
 static inline bool is_expandable_to(

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -3,8 +3,8 @@
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #else
-#include <ATen/ops/view_copy.h>
 #include <ATen/ops/view.h>
+#include <ATen/ops/view_copy.h>
 #endif
 
 #include <ATen/Tensor.h>

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -942,4 +942,24 @@ inline c10::MaybeOwned<TensorBase> TensorBase::expect_contiguous(MemoryFormat me
     return c10::MaybeOwned<TensorBase>::owned(__dispatch_contiguous(memory_format));
   }
 }
+
+namespace symint {
+
+template <typename T>
+using enable_if_symint = std::enable_if_t<std::is_same<T, c10::SymInt>::value>;
+template <typename T>
+using enable_if_int = std::enable_if_t<std::is_same<T, int64_t>::value>;
+
+template <typename T, typename = enable_if_symint<T>>
+c10::SymIntArrayRef sizes(const TensorBase& t) { return t.sym_sizes(); }
+template <typename T, typename = enable_if_int<T>>
+IntArrayRef sizes(const TensorBase& t) { return t.sizes(); }
+
+template <typename T, typename = enable_if_symint<T>>
+c10::SymIntArrayRef strides(const TensorBase& t) { return t.sym_strides(); }
+template <typename T, typename = enable_if_int<T>>
+IntArrayRef strides(const TensorBase& t) { return t.strides(); }
+
+} // namespace symint
+
 } // namespace at

--- a/torchgen/api/types.py
+++ b/torchgen/api/types.py
@@ -450,11 +450,11 @@ class CppSignature:
             cpp_no_default_args=self.cpp_no_default_args,
         )
 
-    def name(self) -> str:
+    def name(self, *, suppress_symint_suffix: bool = False) -> str:
         n = cpp.name(
             self.func,
             faithful_name_for_out_overloads=self.faithful,
-            symint_overload=self.symint,
+            symint_overload=False if suppress_symint_suffix else self.symint,
         )
         if self.fallback_binding:
             n = f"__dispatch_{n}"
@@ -467,6 +467,7 @@ class CppSignature:
         name: Optional[str] = None,
         prefix: str = "",
         is_redispatching_fn: bool = False,
+        suppress_symint_suffix: bool = False,
     ) -> str:
         returns_type = cpp.returns_type(
             self.func.returns, symint=self.symint
@@ -476,7 +477,7 @@ class CppSignature:
             cpp_args = ["c10::DispatchKeySet dispatchKeySet"] + cpp_args
         cpp_args_str = ", ".join(cpp_args)
         if name is None:
-            name = prefix + self.name()
+            name = prefix + self.name(suppress_symint_suffix=suppress_symint_suffix)
         return f"{returns_type} {name}({cpp_args_str})"
 
     # Render the C++ definition for this signature, not including

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -636,12 +636,10 @@ static C10_NOINLINE c10::TypedOperatorHandle<{name}::schema> create_{name}_typed
 class ComputeFunction:
     @method_with_native_function
     def __call__(self, f: NativeFunction) -> Optional[str]:
-        if Variant.function not in f.variants:
-            return None
-
         sig_group = CppSignatureGroup.from_native_function(
             f, method=False, fallback_binding=f.manual_cpp_binding
         )
+        has_symint = f.func.has_symint()
 
         result = ""
         for sig in sig_group.signatures():
@@ -650,10 +648,31 @@ class ComputeFunction:
             exprs = translate(sig.arguments(), target_sig.arguments())
             exprs_str = ", ".join([e.expr for e in exprs])
 
-            result += f"""
+            if sig.symint:
+                intlike_t = "c10::SymInt"
+            else:
+                intlike_t = "int64_t"
+
+            if Variant.function in f.variants:
+                result += f"""
 // aten::{f.func}
 inline {sig.decl()} {{
     return at::_ops::{f.func.name.unambiguous_name()}::call({exprs_str});
+}}"""
+
+            # The template function can be used from template situations
+            # where you want to switch between the symint or not version
+            # depending on a template argument
+            #
+            # NB: we ALWAYS generate this even for methods.  But we put it in
+            # this header so it can take advantage of per-op headers
+            if has_symint:
+                result += f"""
+namespace symint {{
+  template <typename T, typename = std::enable_if_t<std::is_same<T, {intlike_t}>::value>>
+  {sig.decl(suppress_symint_suffix=True)} {{
+    return at::_ops::{f.func.name.unambiguous_name()}::call({exprs_str});
+  }}
 }}
 """
         return result


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86329
* #86235

Our prevailing strategy for symbolic shapes in C++ is to only
write the SymInt version of the code, and pay a slight performance
tax from not knowing if it is symbolic or not.  However, there are
some fastpath functions where this tax is unacceptable, and we want
to specialize for the int case.  Sometimes, it is easy to template
the function; but when the function involves Tensors, it is not,
because the functions you may want to call are not templated,
e.g., t.view vs t.view_symint

This PR adds an at::symint:: namespace which contains templated
functions for all functions in PyTorch which you can use in this
way.  To show this works, I refactored sum_to to stop incorrectly
reinterpret casting and instead use a template.  Instead of
t.sizes(), we call at::symint::sizes<T>(t), and so forth.

The template functions are SFINAE'd using a template argument that
is not otherwise used. As such, deduction is impossible. Typically, deduction
is hard anyway, because many of the constructors are ambiguous (this
is why we split foo and foo_symint in the first place). So you must pass
a template argument to these functions.

These functions are codegened into Functions.h so they are subject
to per-operator headers.  This matters most for methods, which likely
didn't include the per-operator header, so you will have to add an
include in that case.  We never generate method variants for these.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>