### PR TITLE
[1.13] Remove torch.vmap

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -609,7 +609,6 @@ Utilities
     get_float32_matmul_precision
     set_warn_always
     is_warn_always_enabled
-    vmap
     _assert
 
 Operator Tags

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -3,7 +3,8 @@
 from torch.testing._internal.common_utils import TestCase, run_tests
 import torch
 import torch.nn.functional as F
-from torch import Tensor, vmap
+from torch import Tensor
+from torch._vmap_internals import vmap
 import functools
 import itertools
 import warnings

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -917,8 +917,6 @@ del register_after_fork
 # torch.jit.script as a decorator, for instance):
 from ._lobpcg import lobpcg as lobpcg
 
-from ._vmap_internals import vmap as vmap
-
 # These were previously defined in native_functions.yaml and appeared on the
 # `torch` namespace, but we moved them to c10 dispatch to facilitate custom
 # class usage. We add these lines here to preserve backward compatibility.


### PR DESCRIPTION
torch.vmap is a prototype feature (functorch.vmap is in beta). We're still working on deduplicating the two.

This PR removes torch.vmap from the 1.13 release. Hopefully by the next release we will have everything deduplicated so we don't need to do this anymore.
