### PR TITLE
Replacement is irrelevant for 1-sample multinomial

### DIFF
--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -581,14 +581,14 @@ Tensor& multinomial_out(const Tensor& self,
     return result;
   }
 
-  // Fast-path for no replacement.
+  // Fast-path for no replacement or if only one sample is drawn.
   // Reference:
   // https://github.com/pytorch/pytorch/issues/11931#issuecomment-625882503
   // Half is not supported on CPU.
   TORCH_CHECK(
       !(self.device().is_cpu() && self.scalar_type() == ScalarType::Half),
       "multinomial is not implemented for half on CPU");
-  if (!with_replacement) {
+  if (!with_replacement || n_sample == 1) {
     // Sanity checks on `self`.
     auto is_valid = ((self.max() < INFINITY) & (self.min() >= 0)).item();
     TORCH_CHECK(

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -517,14 +517,10 @@ Tensor& multinomial_out_mps(const Tensor& self,
     return result;
   }
 
-  // Fast-path for no replacement.
+  // Fast-path for no replacement (or if only one sample draw).
   // Reference:
   // https://github.com/pytorch/pytorch/issues/11931#issuecomment-625882503
-  // Half is not supported on CPU.
-  TORCH_CHECK(
-      !(self.device().is_cpu() && self.scalar_type() == ScalarType::Half),
-      "multinomial is not implemented for half on CPU");
-  if (!with_replacement) {
+  if (!with_replacement || n_sample == 1) {
     // Sanity checks on `self`.
     auto is_valid = ((self.max() < INFINITY) & (self.min() >= 0)).item();
     TORCH_CHECK(


### PR DESCRIPTION
So use fast path, both on CPU and on MPS

Also, remove some spurious copy-n-paste checks from MPS codepath

CUDA already has this optimization, see
https://github.com/pytorch/pytorch/blob/dc9c507d24d0c833cb09105177326f1f6bbe99c4/aten/src/ATen/native/cuda/MultinomialKernel.cu#L355-L356
