### PR TITLE
Working min-cut partitioner saving sym_size for simple tst

### DIFF
--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -4,6 +4,7 @@ import warnings
 from contextlib import contextmanager, nullcontext
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Tuple
+from torch.fx.experimental.proxy_tensor import is_sym_node
 
 import torch
 import torch.fx.traceback as fx_traceback
@@ -387,6 +388,12 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Tensor], aot_config: AOTConfi
     with torch.no_grad():
         with track_graph_compiling("joint"):
             fw_module, bw_module = aot_config.partition_fn(fx_g, joint_inputs)
+            fw_outs = [n for n in fw_module.graph.nodes if n.op == "output"][0].args[0]
+            # we only need to bookkeep the symints that are saved for bw, not any symints
+            # the user forward might have returned in its own output
+            fw_outs = fw_outs[_num_outs:]
+            symint_outs = [n for n in fw_outs if is_sym_node(n)]
+            _num_symints = len(symint_outs)
 
         if config.debug_graphs:
             print("====== Forward graph ======")
@@ -401,6 +408,7 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Tensor], aot_config: AOTConfi
         compiled_fw = compiled_fw_func
         compiled_bw = None
         num_outs = _num_outs
+        num_symints = _num_symints
 
         @staticmethod
         @disable_torchdynamo
@@ -409,14 +417,21 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Tensor], aot_config: AOTConfi
                 CompiledFunction.compiled_fw, deduped_flat_tensor_args
             )
             num_outs = CompiledFunction.num_outs
-            ctx.save_for_backward(*fw_outs[num_outs:])
+            num_symints = CompiledFunction.num_symints
+            if num_symints > 0:
+                ctx.save_for_backward(*fw_outs[num_outs:-num_symints])
+                ctx.symints = fw_outs[-num_symints:]
+            else:
+                ctx.save_for_backward(*fw_outs[num_outs:])
+                ctx.symints = []
+
             return tuple(fw_outs[0:num_outs])
 
         @staticmethod
         @disable_torchdynamo
         def backward(ctx, *flat_args):
-            contiguous_args = [t.contiguous() for t in flat_args]
-            all_args = list(ctx.saved_tensors) + list(contiguous_args)
+            contiguous_args = [t.contiguous() if torch.is_tensor(t) else t for t in flat_args]
+            all_args = list(ctx.symints) + list(ctx.saved_tensors) + list(contiguous_args)
             if CompiledFunction.compiled_bw is None:
                 with track_graph_compiling("backward", True):
                     CompiledFunction.compiled_bw = aot_config.bw_compiler(
@@ -538,7 +553,7 @@ class PytreeThunk:
             return x
         return pytree.tree_unflatten(x, self.spec)
 
-KNOWN_TYPES = [torch.Tensor, int, str, float, bool]
+KNOWN_TYPES = [torch.Tensor, int, str, float, bool, torch.SymIntNode, torch.SymFloatNode]
 
 
 def aot_function(

--- a/functorch/_src/partitioners.py
+++ b/functorch/_src/partitioners.py
@@ -1,3 +1,4 @@
+from torch.fx.experimental.proxy_tensor import is_sym_node
 import torch
 import torch.fx as fx
 import operator
@@ -148,17 +149,21 @@ def default_partition(
     forward_only_graph = _extract_graph_with_inputs_outputs(joint_module.graph, primal_inputs, fwd_outputs)
     forward_node_names = {node.name for node in forward_only_graph.nodes if node.op != 'output'}
     saved_values = []
+
     for node in joint_module.graph.nodes:
         if node.name not in forward_node_names:
             continue
         # Since we can't save tuple of tensor values, we need to flatten out what we're saving
-        # if 'tensor_meta' not in node.meta and node.op == 'call_function':
-        #     users = node.users
-        #     assert all(user.target == operator.getitem for user in users)
-        #     for user in users:
-        #         saved_values.append(user)
-        # else:
-        if 'tensor_meta' in node.meta:
+        if (
+            'tensor_meta' not in node.meta
+            and node.op == 'call_function'
+            and not is_sym_node(node)
+        ):
+            users = node.users
+            assert all(user.target == operator.getitem for user in users)
+            for user in users:
+                saved_values.append(user)
+        else:
             saved_values.append(node)
     saved_values = list(set(saved_values))
 
@@ -188,7 +193,14 @@ def _size_of(metadata):
         torch.bool: 1,
     }
 
-    numel = _prod(metadata.shape)
+    def to_size_hint(s):
+        if isinstance(s, torch.SymIntNode):
+            py_s = s.get_pyobj()
+            return py_s.shape_env.size_hint(py_s.expr)
+        assert isinstance(s, int)
+        return s
+
+    numel = _prod(map(to_size_hint, metadata.shape))
     dtype = metadata.dtype
 
     if dtype not in sizes:
@@ -368,7 +380,10 @@ def min_cut_rematerialization_partition(
         if ban_recomputation(node) and node in required_fw_nodes:
             nx_graph.add_edge("source", node.name + "_in", capacity=math.inf)
 
-        if 'tensor_meta' not in node.meta:
+        if is_sym_node(node):
+            weight = 1
+        # TODO(whc) try changing this to isTensor(node.meta['val'])?
+        elif 'tensor_meta' not in node.meta:
             weight = math.inf
         else:
             weight = get_node_weight(node)

--- a/functorch/test/test_aotdispatch.py
+++ b/functorch/test/test_aotdispatch.py
@@ -38,6 +38,7 @@ from common_utils import (
     skipOps,
 )
 from torch._subclasses.fake_tensor import DynamicOutputShapeException
+from torch.fx.experimental.proxy_tensor import is_sym_node
 
 USE_TORCHVISION = False
 try:
@@ -429,7 +430,6 @@ class TestAOTAutograd(AOTTestCase):
         for a, b in zip(ref, res):
             assert torch.allclose(a, b)
 
-    @unittest.expectedFailure  # RuntimeError: Cannot call sizes() on tensor with symbolic sizes/strides
     @patch("functorch.compile.config.use_dynamic_shapes", True)
     @patch("functorch.compile.config.use_fake_tensor", True)
     def test_output_op_depending_on_symint(self):
@@ -552,6 +552,100 @@ class TestPartitioning(AOTTestCase):
                                              partitioner=default_partition)
         self.assertEqual(get_num_ins_outs(fw_graph), (3, 4))
         self.assertEqual(get_num_ins_outs(bw_graph), (4, 3))
+
+    @patch("functorch.compile.config.use_dynamic_shapes", True)
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_save_shape(self):
+
+        def f(x):
+            s = x.sum(dim=1)
+            return s
+
+        inp = [torch.ones([10, 10], requires_grad=True)]
+        fw_graph, bw_graph = get_fw_bw_graph(f, inp)
+        _, fw_output = get_ins_outs(fw_graph)
+        self.assertEqual(get_num_ins_outs(fw_graph), (1, 3))
+        self.assertEqual(get_num_ins_outs(bw_graph), (3, 1))
+        self.assertEqual(str(fw_output[0]), "sum_1")
+        # make sure we don't do the suboptimal thing of saving the bigger primals input to sum,
+        # rather than saving the sizes of the primals input for use in backward expand
+        self.assertEqual(str(fw_output[1]), "sym_size")
+        self.assertEqual(str(fw_output[2]), "sym_size_1")
+
+        inp = [
+            torch.randn(10, requires_grad=True),
+            torch.randn((3, 10), requires_grad=True),
+            torch.randn((2, 10), requires_grad=True),
+        ]
+
+        def f(a, b, c):
+            # ensure we still do the right thing (save individual size vars) when sizes
+            # exist as tuples first.  (TODO: they don't actually exist as tuples in the trace, even here.)
+            sb = torch.ops.aten.sym_size(b)
+            sc = c.size()
+            x = sb[0] + sc[0]
+            a_sz = (x, a.size(0))
+            return torch.cat([a.expand(a_sz), b, c])
+        fw_graph, bw_graph = get_fw_bw_graph(f, inp)
+        self.assertEqual(get_num_ins_outs(fw_graph), (3, 5))
+        self.assertEqual(get_num_ins_outs(bw_graph), (5, 3))
+        _, outs = get_ins_outs(fw_graph)
+        self.assertTrue(all([is_sym_node(n) for n in outs[1:]]))
+
+    @patch("functorch.compile.config.use_dynamic_shapes", True)
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_min_cut_partitioner_output_tensor_shape_tensor(self):
+
+        inp = [
+            torch.randn(10, requires_grad=True),
+            torch.randn((3, 10), requires_grad=True),
+            torch.randn((2, 10), requires_grad=True),
+        ]
+
+        def f(a, b, c):
+            # Try to force symints intermixed with outputs in the function's returns
+            sb = b.size()
+            sc = c.size()
+            x = sb[0] + sc[0]
+            a_sz = (x, a.size(0))
+            cat = torch.cat([a.expand(a_sz), b, c])
+            return cat, sb, c
+
+        fw_graph_cell = [None]
+        bw_graph_cell = [None]
+        compiled_outs = aot_function(
+            f,
+            fw_compiler=partial(extract_graph, graph_cell=fw_graph_cell),
+            bw_compiler=partial(extract_graph, graph_cell=bw_graph_cell),
+            partition_fn=min_cut_rematerialization_partition,
+            decompositions=default_decompositions)(*inp)
+        fw_graph = fw_graph_cell[0]
+        (compiled_outs[0].sum() + compiled_outs[2].sum()).backward()
+        bw_graph = bw_graph_cell[0]
+
+        # TODO(whc) 8 outputs from forward
+        # 2 are user-output tensors
+        # 2 more are individual symints from single user-output 'sizes'
+        # 4 are save-for-backward sizes values
+        #   one of these saved symint sizes duplicates a returned user output
+        # what behavior do we want here?
+        self.assertEqual(get_num_ins_outs(fw_graph), (3, 8))
+        self.assertEqual(get_num_ins_outs(bw_graph), (8, 3))
+        _, fw_graph_out_nodes = get_ins_outs(fw_graph)
+        # self.assertTrue(is_tensor_node(outs[0])) # helper doesn't exist
+        self.assertTrue(is_sym_node(fw_graph_out_nodes[1]))
+        self.assertTrue(is_sym_node(fw_graph_out_nodes[2]))
+        # self.assertTrue(is_tensor_node(outs[3]))
+        self.assertTrue(all([is_sym_node(n) for n in fw_graph_out_nodes[4:]]))
+
+        real_outs = f(*inp)
+        self.assertEqual(compiled_outs, real_outs)
+        self.assertTrue(isinstance(real_outs[1], torch.Size))
+
+        # TODO(whc) we should learn to return torch.Sizes
+        self.assertFalse(isinstance(compiled_outs[1], torch.Size))
 
     @unittest.skipIf(not USE_NETWORKX, "networkx not available")
     def test_min_cut_partitioner(self):

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -55,6 +55,15 @@ def decompose(decomposition_table):
 proxy_slot = object()
 no_default = object()
 
+def is_sym_node(node):
+    # TODO(whc) what cases does node.meta not have a val?
+    # will all symints have a node.meta['val']? what about all tensors?
+    return (
+        hasattr(node, 'meta')
+        and "val" in node.meta
+        and (isinstance(node.meta['val'], PySymInt) or isinstance(node.meta['val'], PySymFloat))
+    )
+
 def set_proxy_slot(obj, tracer, proxy):
     d = obj.__dict__.setdefault(proxy_slot, weakref.WeakKeyDictionary())
     assert isinstance(d, weakref.WeakKeyDictionary)


### PR DESCRIPTION
so far the test case i wrote works,

but i know of several bugs that I want to find new test cases for
 - i'm assuming the symints will be the last saved items but i am not actually sorting them that way
 - i'm not sure if i would handle a case where something called .sym_sizes() instead of sym_size() in backward