### PR TITLE
[kineto] guard global observer init against Edge profiler

### DIFF
--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -2,8 +2,8 @@
 #include <libkineto.h>
 #include <torch/csrc/autograd/profiler_kineto.h>
 
-// Ondemand tracing is not supported on Apple platform
-#ifdef __APPLE__
+// Ondemand tracing is not supported on Apple or edge platform
+#if defined(__APPLE__) || defined(EDGE_PROFILER_USE_KINETO)
 #define ENABLE_GLOBAL_OBSERVER (0)
 #else
 #define ENABLE_GLOBAL_OBSERVER (1)


### PR DESCRIPTION
Summary:
looks like Sandcastle CI didn't cover any of concrete mobile CI(cc: kimishpatel i'd assume we have ton of mobile tests in Github?). This is failing on Oculus with the similar failure as Mac(not sure if this is an ARM thing). either way on demand tracing should not be enabled on these platforms so disable them completely

in the future, we should have runtime check on this for even safer guarding

Test Plan:
Set up Hollywood via P536072492

## Before
crash on mutex. likely SIOF
```
FORTIFY: pthread_mutex_lock called on a destroyed mutex (0x5d7e298b08)
*** Aborted at 1665017107 (Unix time, try 'date -d 1665017107') ***
*** Signal 6 (SIGABRT) (0xeca) received by PID 3786 (pthread TID 0x785bd1eed0) (linux TID 3786) (maybe from PID 3786, UID 0) (code: -1), stack trace: ***
(error retrieving stack trace)
```

## After
Redacted in the top but the test passes without the crash
P536101962

Differential Revision: D40129840

