### PR TITLE
[Profiler] record gradient from nnModule

### DIFF
--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -75,6 +75,7 @@ using TensorID = strong::type<size_t, struct TensorID_, strong::regular>;
 
 struct TORCH_API RawTensorMetadata {
   RawTensorMetadata() = default;
+  RawTensorMetadata(const RawTensorMetadata&) = default;
   explicit RawTensorMetadata(const at::Tensor& t);
   TensorImplAddress impl_;
   StorageImplData data_;
@@ -236,12 +237,18 @@ using PyMethod = strong_t</*PyMethodDef*/ void*, struct PyMethod_>;
 using PyOptimizerSelf = strong_t<PyObject*, struct PyOptSelf_>;
 using PyOptimizerCls = strong_t<PyObject*, struct PyOptimizer_>;
 
+struct ParameterInfo {
+  std::string param_name_;
+  TensorMetadata param_;
+  c10::optional<TensorMetadata> grad_;
+};
+
 struct NNModuleInfo {
   PyModuleSelf self_;
   PyModuleCls cls_;
   at::StringView cls_name_;
 
-  std::vector<std::pair<std::string, TensorMetadata>> params_;
+  std::vector<ParameterInfo> params_;
   // Indicates that `self_` is the kth instance of `cls_` observed.
   size_t id_{std::numeric_limits<size_t>::max()};
 };

--- a/torch/csrc/profiler/python/init.cpp
+++ b/torch/csrc/profiler/python/init.cpp
@@ -139,10 +139,14 @@ void initPythonBindings(PyObject* module) {
             return py::reinterpret_borrow<py::object>(layout_obj);
           })
       .def_property_readonly("device", &TensorMetadata::device)
-      .def_property_readonly("dtype", [](const TensorMetadata& metadata) {
-        return py::reinterpret_borrow<py::object>(
-            torch::autograd::utils::wrap(torch::getTHPDtype(metadata.dtype_)));
-      });
+      .def_property_readonly(
+          "dtype",
+          [](const TensorMetadata& metadata) {
+            return py::reinterpret_borrow<py::object>(
+                torch::autograd::utils::wrap(
+                    torch::getTHPDtype(metadata.dtype_)));
+          })
+      .def_readonly("dim", &TensorMetadata::dim_);
 
   using torch_op_t = ExtraFields<EventType::TorchOp>;
   py::class_<torch_op_t>(m, "_ExtraFields_TorchOp")
@@ -180,7 +184,11 @@ void initPythonBindings(PyObject* module) {
           [](const NNModuleInfo& s) {
             py::list list;
             for (auto& p : s.params_) {
-              list.append(std::make_pair(p.first, p.second));
+              list.append(std::tuple<
+                          std::string,
+                          TensorMetadata,
+                          c10::optional<TensorMetadata>>(
+                  p.param_name_, p.param_, p.grad_));
             }
             return list;
           })


### PR DESCRIPTION
Summary:
- catch .grad tensor info
- update data type and `check_and_store`, etc
- update unit test case

Test Plan: buck run mode/opt //caffe2/test:profiler

Reviewed By: chaekit

Differential Revision: D39711295

