### PR TITLE
Fix for binary upload step, use bash shell rather then default sh

### DIFF
--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -112,6 +112,7 @@ jobs:
           echo "DRY_RUN=disabled" >> "$GITHUB_ENV"
       - name: Set UPLOAD_CHANNEL (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/') }}
+        shell: bash -e -l {0}
         run: |
           # reference ends with an RC suffix
           if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then


### PR DESCRIPTION
This fixes the issue during upload:

```
Run # reference ends with an RC suffix
  # reference ends with an RC suffix
  if [[ ${GITHUB_REF_NAME} = *-rc[0-9]* ]]; then
    echo "UPLOAD_CHANNEL=test" >> "$GITHUB_ENV"
  fi
  shell: sh -e {0}
/__w/_temp/f045f5d8-ddb.sh: 2: [[: not found
```

Test failure:
https://github.com/pytorch/pytorch/actions/runs/3199561387/jobs/5225448559

Test success:
https://github.com/pytorch/pytorch/actions/runs/3199573560/jobs/5225480345

Error started when we switched to: continuumio/miniconda3:4.12.0
