### PR TITLE
better error message fix

### DIFF
--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -149,7 +149,7 @@ class TracerBase:
                 def no_node(arg):
                     if isinstance(arg, Node):
                         raise RuntimeError("Keys for dictionaries used as an argument cannot contain a "
-                                           "Node. Got key: {k}")
+                                           f"Node. Got key: {k}")
                 map_aggregate(k, no_node)
 
                 r[k] = self.create_arg(v)


### PR DESCRIPTION
Summary:
A user had a problem with fx-scripting and the error message can be improved.

Error was shown as:

RuntimeError: Keys for dictionaries used as an argument cannot contain a Node. Got key: {k}

which is obvious not quite helpful.

Test Plan:
Test in a notebook:
{F778667593}

Reviewed By: xunnanxu, SherlockNoMad

Differential Revision: D40157518

