### PR TITLE
Introduce a match filter for SubgraphRewriter

### DIFF
--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -772,3 +772,71 @@ class TestSubgraphRewriter(JitTestCase):
                 repalcement_node_found += 1
 
         self.assertEqual(repalcement_node_found, 2)
+
+    def test_replace_pattern_with_filter(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, scale, zero_point):
+                # Match, second input to add is a scalar
+                x = x.dequantize()
+                x = torch.add(x, 2)
+                x = x.relu()
+                x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+
+                y = x + 1
+                # NOT a match, second input to add is NOT a scalar
+                x = x.dequantize()
+                x = torch.add(x, y)
+                x = x.relu()
+                x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+
+                return x
+
+        def BinaryOpScalarReLUPattern(x, num, scale, zero_point):
+            x = x.dequantize()
+            x = torch.add(x, num)
+            x = x.relu()
+            x = torch.quantize_per_tensor(x, scale, zero_point, torch.quint8)
+            return x
+
+        def BinaryOpScalarReLUReplacement(x, num, scale, zero_point):
+            x = torch.mul(x, num)
+            return x
+
+        def second_input_is_scalar(match, original_graph, pattern_graph):
+            """ check the node that's matched to the second input of the pattern graph
+            is a scalar number
+            """
+            input_idx = 0
+            for node in pattern_graph.nodes:
+                if node.op == "placeholder":
+                    if input_idx == 1:
+                        num_node = node
+                    input_idx += 1
+            if not isinstance(match.nodes_map[num_node], (int, float)):
+                return False
+            return True
+
+        def num_repalcement_node_found(traced):
+            return sum(1 for node in traced.graph.nodes if node.target == torch.mul)
+
+        # match without filter, should find 2 match
+        traced = symbolic_trace(M())
+        matches = subgraph_rewriter.replace_pattern(
+            traced,
+            BinaryOpScalarReLUPattern,
+            BinaryOpScalarReLUReplacement)
+        self.assertEqual(len(matches), 2)
+        self.assertEqual(num_repalcement_node_found(traced), 2)
+
+        # match with filter, should find 1 match
+        traced = symbolic_trace(M())
+        matches = subgraph_rewriter.replace_pattern_with_filter(
+            traced,
+            BinaryOpScalarReLUPattern,
+            BinaryOpScalarReLUReplacement,
+            second_input_is_scalar)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(num_repalcement_node_found(traced), 1)

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -63,6 +63,7 @@ def _replace_submodules(gm: GraphModule, replacement: torch.nn.Module) -> None:
 
     gm.graph.lint()
 
+
 @compatibility(is_backward_compatible=True)
 def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -> List[Match]:
     """
@@ -181,6 +182,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
     """
     return _replace_pattern(gm, pattern, replacement)
 
+
 # Experimental API, not backward compatible
 @compatibility(is_backward_compatible=False)
 def replace_pattern_with_filter(
@@ -201,8 +203,12 @@ def replace_pattern_with_filter(
     return _replace_pattern(gm, pattern, replacement, match_filter)
 
 
-def _replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable,
-                     match_filter: Optional[Callable[["InternalMatch", Graph, Graph], bool]] = None) -> List[Match]:  # type: ignore[name-defined]
+def _replace_pattern(
+    gm: GraphModule,
+    pattern: Callable,
+    replacement: Callable,
+    match_filter: Optional[Callable[["InternalMatch", Graph, Graph], bool]] = None  # type: ignore[name-defined]
+) -> List[Match]:
 
     from torch.fx.passes.utils.matcher_utils import SubgraphMatcher, InternalMatch
 

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -8,7 +8,7 @@ import copy
 from typing import Callable, Dict, List, NamedTuple, Optional, Set
 import torch
 
-__all__ = ['Match', 'replace_pattern']
+__all__ = ['Match', 'replace_pattern', 'replace_pattern_with_filter']
 
 @compatibility(is_backward_compatible=True)
 class Match(NamedTuple):
@@ -75,6 +75,7 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
         ``gm``: The GraphModule that wraps the Graph to operate on
         ``pattern``: The subgraph to match in ``gm`` for replacement
         ``replacement``: The subgraph to replace ``pattern`` with
+        ``match_filter``: A function that takes in (`InternalMatch`, original_graph, pattern_graph)
 
     Returns:
         List[Match]: A list of ``Match`` objects representing the places
@@ -178,6 +179,31 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
             add_2 = add_1 + max_2
             return add_2
     """
+    return _replace_pattern(gm, pattern, replacement)
+
+# Experimental API, not backward compatible
+@compatibility(is_backward_compatible=False)
+def replace_pattern_with_filter(
+    gm: GraphModule,
+    pattern: Callable,
+    replacement: Callable,
+    match_filter: Callable[["InternalMatch", Graph, Graph], bool],  # type: ignore[name-defined]
+) -> List[Match]:
+    """
+    See replace_pattern for documentation. This function is an overload with an additional match_filter argument.
+
+    Args:
+        ``match_filter``: A function that takes in (match: InternalMatch, original_graph: Graph, pattern_graph: Graph)
+            and returns a boolean indicating whether the match satisfies the condition. See matcher_utils.py for
+            definition of InternalMatch.
+    """
+
+    return _replace_pattern(gm, pattern, replacement, match_filter)
+
+
+def _replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable,
+                     match_filter: Optional[Callable[["InternalMatch", Graph, Graph], bool]] = None) -> List[Match]:  # type: ignore[name-defined]
+
     from torch.fx.passes.utils.matcher_utils import SubgraphMatcher, InternalMatch
 
     # Get the graphs for `gm`, `pattern`, `replacement`
@@ -188,6 +214,10 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
     matcher = SubgraphMatcher(pattern_graph, match_output=False, match_placeholder=False,
                               remove_overlapping_matches=True)
     _matches: List[InternalMatch] = matcher.match(original_graph)
+
+    # Filter out matches that don't match the filter
+    if match_filter:
+        _matches = [m for m in _matches if match_filter(m, original_graph, pattern_graph)]
 
     replacement_placeholders = [n for n in replacement_graph.nodes if n.op == "placeholder"]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86430
* #86421

This PR introduces an interface for user defined function that filters the matches in SubgraphRewriter. The function will have the following signature. 

callable(match: InternalMatch, original_graph: Graph, pattern_graph: Graph) -> bool 

This filter is applied after SubgraphMatcher returns the matches, and before replacement takes place. 