### PR TITLE
[MPS] Cache multinomial_with_replacement graph

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -204,6 +204,11 @@ struct MPSGraphCache
     return result;
   }
 
+  template<typename T>
+  inline T* CreateCachedGraphAs(const std::string& key, CreateCachedGraphBlock createCacheBlock, void* view_ptr = nullptr) {
+    return static_cast<T *>(CreateCachedGraph(key, createCacheBlock, view_ptr));
+  }
+
   MPSCachedGraph* LookUp(const std::string& key) const {
 
     __block MPSCachedGraph* result = nullptr;


### PR DESCRIPTION
Reuse existing RandomCachedGraph to keep RNG state as part of the graph
Add `CreateCachedGraphAs` convenience wrapper
Addresses https://github.com/pytorch/pytorch/pull/86342#pullrequestreview-1132197848