### PR TITLE
[CI] Build MacOS M1 binaries without distributed support

### DIFF
--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -41,7 +41,7 @@ cross_compile_arm64() {
 }
 
 compile_x86_64() {
-  USE_DISTRIBUTED=1 WERROR=1 python setup.py bdist_wheel
+  USE_DISTRIBUTED=0 WERROR=1 python setup.py bdist_wheel
 }
 
 build_lite_interpreter() {

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -35,11 +35,11 @@ fi
 
 cross_compile_arm64() {
   # Cross compilation for arm64
-  USE_DISTRIBUTED=1 CMAKE_OSX_ARCHITECTURES=arm64 MACOSX_DEPLOYMENT_TARGET=11.0 USE_MKLDNN=OFF USE_QNNPACK=OFF WERROR=1 BUILD_TEST=OFF USE_PYTORCH_METAL=1 python setup.py bdist_wheel
+  CMAKE_OSX_ARCHITECTURES=arm64 MACOSX_DEPLOYMENT_TARGET=11.0 USE_MKLDNN=OFF USE_QNNPACK=OFF WERROR=1 BUILD_TEST=OFF USE_PYTORCH_METAL=1 python setup.py bdist_wheel
 }
 
 compile_x86_64() {
-  USE_DISTRIBUTED=1 WERROR=1 python setup.py bdist_wheel
+  WERROR=1 python setup.py bdist_wheel
 }
 
 build_lite_interpreter() {

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -35,7 +35,8 @@ fi
 
 cross_compile_arm64() {
   # Cross compilation for arm64
-  # Explicitly set USE_DISTRIBUTED=0 to align with the default build config on mac. See https://github.com/pytorch/pytorch/issues/86448
+  # Explicitly set USE_DISTRIBUTED=0 to align with the default build config on mac. This also serves as the sole CI config that tests
+  # that building with USE_DISTRIBUTED=0 works at all. See https://github.com/pytorch/pytorch/issues/86448
   USE_DISTRIBUTED=0 CMAKE_OSX_ARCHITECTURES=arm64 MACOSX_DEPLOYMENT_TARGET=11.0 USE_MKLDNN=OFF USE_QNNPACK=OFF WERROR=1 BUILD_TEST=OFF USE_PYTORCH_METAL=1 python setup.py bdist_wheel
 }
 

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -35,11 +35,12 @@ fi
 
 cross_compile_arm64() {
   # Cross compilation for arm64
-  CMAKE_OSX_ARCHITECTURES=arm64 MACOSX_DEPLOYMENT_TARGET=11.0 USE_MKLDNN=OFF USE_QNNPACK=OFF WERROR=1 BUILD_TEST=OFF USE_PYTORCH_METAL=1 python setup.py bdist_wheel
+  # Explicitly set USE_DISTRIBUTED=0 to align with the default build config on mac. See https://github.com/pytorch/pytorch/issues/86448
+  USE_DISTRIBUTED=0 CMAKE_OSX_ARCHITECTURES=arm64 MACOSX_DEPLOYMENT_TARGET=11.0 USE_MKLDNN=OFF USE_QNNPACK=OFF WERROR=1 BUILD_TEST=OFF USE_PYTORCH_METAL=1 python setup.py bdist_wheel
 }
 
 compile_x86_64() {
-  WERROR=1 python setup.py bdist_wheel
+  USE_DISTRIBUTED=1 WERROR=1 python setup.py bdist_wheel
 }
 
 build_lite_interpreter() {

--- a/test/test_functional_optim.py
+++ b/test/test_functional_optim.py
@@ -1,14 +1,15 @@
 # Owner(s): ["oncall: distributed"]
 
 from typing import List, Optional, Tuple
+import unittest
 
 import torch
+import torch.distributed
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 from torch.optim import SGD, Adam, AdamW
 from torch.testing._internal.common_utils import TestCase, run_tests
-from torch.distributed.optim.utils import functional_optim_map, register_functional_optim
 
 class MyModule(torch.nn.Module):
     def __init__(self):
@@ -64,6 +65,10 @@ class MyDummyFnOptimizer(object):
         with torch.no_grad():
             raise RuntimeError("MyDummyFnOptimizer does not support step() as of now")
 
+if torch.distributed.is_available():
+    from torch.distributed.optim.utils import functional_optim_map, register_functional_optim
+
+@unittest.skipIf(not torch.distributed.is_available(), "These are testing distributed functions")
 class TestFunctionalOptimParity(TestCase):
     def _validate_parameters(self, params_1, params_2):
         for p1, p2 in zip(params_1, params_2):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1786,7 +1786,9 @@ class TestImports(TestCase):
             # Distributed does not work on Windows or by default on Mac
             ignored_modules.append("torch.distributed.")
             ignored_modules.append("torch.testing._internal.dist_utils")
+            # And these both end up with transitive dependencies on distributed
             ignored_modules.append("torch.nn.parallel._replicated_tensor_ddp_interop")
+            ignored_modules.append("torch.testing._internal.common_fsdp")
 
         torch_dir = os.path.dirname(torch.__file__)
         for base, folders, files in os.walk(torch_dir):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -18,7 +18,7 @@ import torch
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import \
-    (IS_FBCODE, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, skipIfRocm, slowTest,
+    (IS_FBCODE, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, skipIfRocm, slowTest,
      parametrize, subtest, instantiate_parametrized_tests, dtype_name, TEST_WITH_ROCM)
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
@@ -1782,10 +1782,11 @@ class TestImports(TestCase):
         # See https://github.com/pytorch/pytorch/issues/77801
         if not sys.version_info >= (3, 9):
             ignored_modules.append("torch.utils.benchmark")
-        if IS_WINDOWS:
-            # Distributed does not work on Windows
+        if IS_WINDOWS or IS_MACOS:
+            # Distributed does not work on Windows or by default on Mac
             ignored_modules.append("torch.distributed.")
             ignored_modules.append("torch.testing._internal.dist_utils")
+            ignored_modules.append("torch.nn.parallel._replicated_tensor_ddp_interop")
 
         torch_dir = os.path.dirname(torch.__file__)
         for base, folders, files in os.walk(torch_dir):


### PR DESCRIPTION
Partial fix for #86448 which causes the broken code to be exercised in CI. If this demonstrates the break, I'm not sure whether there should be a fix forward of https://github.com/pytorch/pytorch/pull/85781 or a revert