### PR TITLE
Try to fix shutdown test in edge cases

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4600,8 +4600,12 @@ class MyFunction(Function):
     def backward(ctx, grad):
         return grad
 
+# Run on cuda if it is available to ensure that the worker thread
+# is properly initialized by the time we exit.
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 for shape in [(1,), ()]:
-    v = torch.ones(shape, requires_grad=True)
+    v = torch.ones(shape, requires_grad=True, device=device)
     MyFunction.apply(v).backward()
 """
         s = TestCase.runWithPytorchAPIUsageStderr(code)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/85259
See the issue for debugging details.
tl;dr: when a worker thread is actually used, make sure it is initialized before exiting.
Yes, it is very unlikely it will take >10s to initialize but it is what seems to happen.
