### PR TITLE
[FSDP] Add `keep_low_precision_grads` support when CPU offloading

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -613,9 +613,11 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
         loss.backward()
 
     @skip_if_lt_x_gpu(2)
-    @parametrize("offload_params", [False, True])
-    def test_grads_reduced_precision(self, offload_params: bool):
-        self._test_grads_reduced_precision(offload_params)
+    def test_grads_reduced_precision(self):
+        self.run_subtests(
+            {"offload_params": [False, True]},
+            self._test_grads_reduced_precision,
+        )
 
     @skip_if_lt_x_gpu(2)
     @parametrize("convert_sync_bn", [True, False])
@@ -683,9 +685,11 @@ class TestFSDPMixedPrecisionUnsharded(TestFSDPMixedPrecision):
         return 1
 
     @skip_if_lt_x_gpu(1)
-    @parametrize("offload_params", [False, True])
-    def test_grads_reduced_precision(self, offload_params: bool):
-        return self._test_grads_reduced_precision(offload_params)
+    def test_grads_reduced_precision(self):
+        self.run_subtests(
+            {"offload_params": [False, True]},
+            self._test_grads_reduced_precision,
+        )
 
     @skip_if_lt_x_gpu(1)
     def test_mixed_precision_no_reshard_after_forward(self):
@@ -716,7 +720,6 @@ class TestFSDPMixedPrecisionUnsharded(TestFSDPMixedPrecision):
         )
 
 instantiate_parametrized_tests(TestFSDPMixedPrecisionSharded)
-instantiate_parametrized_tests(TestFSDPMixedPrecisionUnsharded)
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -949,9 +949,10 @@ class FlatParamHandle:
         gradient to the ``.grad`` attribute.
         """
         def cast_grad_to_param_dtype_if_needed(flat_param):
-            # This is meaningful when `param_dtype` is a low precision dtype.
             if self._config.keep_low_precision_grads:
                 assert flat_param.grad is not None  # mypy
+                # This cast is meaningful when `param_dtype` is a low precision
+                # dtype.
                 flat_param.grad.data = flat_param.grad.to(self._config.param_dtype)
 
         flat_param = self.flat_param

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -913,22 +913,26 @@ class FlatParamHandle:
                 # a GPU tensor (the new sharded gradient).
                 if not grad_offloaded:
                     flat_param._saved_grad_shard = flat_param.grad.data  # type: ignore[attr-defined]
-                    # If we're using mixed precision with keeping grads
-                    # casted, gradient here might still be of the reduced
-                    # dtype if we didn't clear / set the gradients to None
-                    # after previous backward. In that case, make sure
-                    # p._saved_grad_shard is cast to the full precision type
-                    # so that we can accumulate in full precision in
-                    # _post_backward_hook and assign back in full precision
-                    # in _wait_for_post_backward.
-                    if (
-                        self._config.keep_low_precision_grads
-                        and flat_param._saved_grad_shard.dtype  # type: ignore[attr-defined]
-                        != flat_param._local_shard.dtype  # type: ignore[attr-defined]
-                    ):
-                        flat_param._saved_grad_shard = flat_param._saved_grad_shard.to(  # type: ignore[attr-defined]
-                            flat_param._local_shard.dtype  # type: ignore[attr-defined]
-                        )
+                    sharded_grad = flat_param._saved_grad_shard  # type: ignore[attr-defined]
+                else:
+                    p_assert(
+                        hasattr(flat_param, "_cpu_grad"),
+                        "`_cpu_grad` should be defined if the gradient is on CPU"
+                    )
+                    sharded_grad = flat_param._cpu_grad  # type: ignore[attr-defined]
+                # If user specified to keep the gradient in low precision, then
+                # the gradient may still be of the low precision dtype if the
+                # user did not set the gradient to `None` after the previous
+                # backward, in which case FSDP should cast back to the full
+                # precision dtype so that FSDP can accumulate in that dtype in
+                # the post-backward hook and assign to `.grad` in that dtype in
+                # the post-backward callback.
+                local_shard_dtype = flat_param._local_shard.dtype  # type: ignore[attr-defined]
+                if (
+                    self._config.keep_low_precision_grads
+                    and sharded_grad.dtype != local_shard_dtype
+                ):
+                    sharded_grad.data = sharded_grad.to(local_shard_dtype)
             else:
                 padded_unsharded_size = flat_param._padded_unsharded_size  # type: ignore[attr-defined]
                 p_assert(
@@ -944,6 +948,12 @@ class FlatParamHandle:
         Prepares the gradient for optimizer computation by moving the sharded
         gradient to the ``.grad`` attribute.
         """
+        def cast_grad_to_param_dtype_if_needed(flat_param):
+            # This is meaningful when `param_dtype` is a low precision dtype.
+            if self._config.keep_low_precision_grads:
+                assert flat_param.grad is not None  # mypy
+                flat_param.grad.data = flat_param.grad.to(self._config.param_dtype)
+
         flat_param = self.flat_param
         # TODO (awgu): We should replace these conditional checks to encode
         # the logical intention more directly.
@@ -952,6 +962,7 @@ class FlatParamHandle:
             self._check_sharded(flat_param)
             self._check_on_cpu(flat_param)
             flat_param.grad = flat_param._cpu_grad  # type: ignore[attr-defined]
+            cast_grad_to_param_dtype_if_needed(flat_param)
         elif hasattr(flat_param, "_saved_grad_shard"):
             self._check_sharded(flat_param)
             self._check_on_compute_device(flat_param)
@@ -960,9 +971,7 @@ class FlatParamHandle:
             # no need to forward `_saved_grad_shard` to `grad`
             if flat_param._post_backward_called:  # type: ignore[attr-defined]
                 flat_param.grad = flat_param._saved_grad_shard  # type: ignore[attr-defined]
-                if self._config.keep_low_precision_grads:
-                    assert flat_param.grad is not None  # mypy
-                    flat_param.grad.data = flat_param.grad.to(self._config.param_dtype)
+                cast_grad_to_param_dtype_if_needed(flat_param)
         else:
             p_assert(
                 not self.uses_sharded_strategy


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #86513 [FSDP] Change `backward_prefetch` default to `BACKWARD_PRE`
* #86512 [FSDP] Add `_low_prec` prefix to param and reduce dtype varnames
* **#86495 [FSDP] Add `keep_low_precision_grads` support when CPU offloading**
* #85738 [FSDP] Add initial `summon_full_params(with_grads=True)`
* #84911 [FSDP] Add `use_orig_params`

When CPU offloading, FSDP uses `_cpu_grad`, not `_saved_grad_shard`. This adds support for `keep_low_precision_grads` for that case.