### PR TITLE
[FSDP] Add `low_prec` prefix to param and reduce dtype varnames

### DIFF
--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -116,8 +116,8 @@ class HandleTrainingState(Enum):
 class HandleConfig:
     sharding_strategy: HandleShardingStrategy
     offload_params: bool
-    param_dtype: Optional[torch.dtype]
-    reduce_dtype: Optional[torch.dtype]
+    low_prec_param_dtype: Optional[torch.dtype]
+    low_prec_reduce_dtype: Optional[torch.dtype]
     keep_low_precision_grads: Optional[bool] = False
 
 
@@ -773,8 +773,8 @@ class FlatParamHandle:
             # that  `_full_param_padded` is in the low precision
             unsharded_flat_param = flat_param._full_prec_full_param_padded  # type: ignore[attr-defined]
             p_assert(
-                unsharded_flat_param.dtype != self._config.param_dtype,
-                f"Expects full precision but got {self._config.param_dtype}",
+                unsharded_flat_param.dtype != self._config.low_prec_param_dtype,
+                f"Expects full precision but got {self._config.low_prec_param_dtype}",
             )
         else:
             unsharded_flat_param = flat_param._full_param_padded  # type: ignore[attr-defined]
@@ -953,7 +953,7 @@ class FlatParamHandle:
                 assert flat_param.grad is not None  # mypy
                 # This cast is meaningful when `param_dtype` is a low precision
                 # dtype.
-                flat_param.grad.data = flat_param.grad.to(self._config.param_dtype)
+                flat_param.grad.data = flat_param.grad.to(self._config.low_prec_param_dtype)
 
         flat_param = self.flat_param
         # TODO (awgu): We should replace these conditional checks to encode
@@ -1637,7 +1637,7 @@ class FlatParamHandle:
 
     @property
     def _uses_param_mixed_precision(self) -> bool:
-        return self._config.param_dtype is not None
+        return self._config.low_prec_param_dtype is not None
 
     @property
     def _force_full_precision(self) -> bool:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#86512 [FSDP] Add `_low_prec` prefix to param and reduce dtype varnames**
* #86495 [FSDP] Add `keep_low_precision_grads` support when CPU offloading
* #85738 [FSDP] Add initial `summon_full_params(with_grads=True)`
* #84911 [FSDP] Add `use_orig_params`

This PR renames `param_dtype` and `reduce_dtype` in `HandleConfig` to `low_prec_param_dtype` and `low_prec_reduce_dtype` to emphasize that they are meant to be of the low precision (if not `None`).

(In my mind, mixed precision refers to the paradigm of using both full and low precision together during training. "Reduced" and "low precision" mean the same thing, but I prefer the term "low precision" in the code since it is shorter. A particular dtype can be a low precision dtype or a full precision dtype.)