### PR TITLE
[FSDP] Change `backward_prefetch` default to `BACKWARD_PRE`

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -889,9 +889,10 @@ class FullyShardedDataParallel(nn.Module):
 
         backward_prefetch (Optional[BackwardPrefetch]):
             This is an experimental feature that is subject to change in the
-            the near future. It allows users to enable two different backward_prefetch
+            the near future. It allows users to enable two different backward prefetch
             algorithms to help backward communication and computation overlapping.
             Pros and cons of each algorithm is explained in the class ``BackwardPrefetch``.
+            (Default: ``BackwardPrefetch.BACKWARD_PRE``)
         mixed_precision (Optional[MixedPrecision]): A ``MixedPrecision`` instance
             describing the mixed precision training config to be used. ``MixedPrecision``
             supports configuring parameter, buffer, and gradient communication dtype. Note
@@ -986,7 +987,7 @@ class FullyShardedDataParallel(nn.Module):
         sharding_strategy: Optional[ShardingStrategy] = None,
         cpu_offload: Optional[CPUOffload] = None,
         auto_wrap_policy: Optional[Callable] = None,
-        backward_prefetch: Optional[BackwardPrefetch] = None,
+        backward_prefetch: Optional[BackwardPrefetch] = BackwardPrefetch.BACKWARD_PRE,
         mixed_precision: Optional[MixedPrecision] = None,
         ignored_modules: Optional[Iterable[torch.nn.Module]] = None,
         param_init_fn: Optional[Callable[[nn.Module], None]] = None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#86513 [FSDP] Change `backward_prefetch` default to `BACKWARD_PRE`**
* #86512 [FSDP] Add `_low_prec` prefix to param and reduce dtype varnames
* #86495 [FSDP] Add `keep_low_precision_grads` support when CPU offloading
* #85738 [FSDP] Add initial `summon_full_params(with_grads=True)`
* #84911 [FSDP] Add `use_orig_params`

