### PR TITLE
Disable autocast in aot autograd

### DIFF
--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -514,8 +514,8 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Tensor], aot_config: AOTConfi
                         CompiledFunction.compiled_bw, all_args, steal_args=True
                     )
             else:
-                fw_outs = call_func_with_args(
-                    CompiledFunction.compiled_fw, deduped_flat_tensor_args
+                out = call_func_with_args(
+                    CompiledFunction.compiled_bw, all_args, steal_args=True
                 )
             return tuple(out)
 

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -315,7 +315,7 @@ class NonIdempotentAMP(torch.fx.Interpreter):
     """
     When we invoke a Composite Implicit autograd operator that has an autocast rule, such as Einsum,
     autocast is disabled during its invocation. When we trace out the operators in an implicit op,
-    re-applying on autocast rules on those operators might yield divergence from what was executed at runtime.
+    re-applying autocast rules on those operators might yield divergence from what was executed at runtime.
     This pass checks for divergence. If divergence is found, we will disable autocast.
     We would like to avoid disabling autocast if possible because accessing TLS is slow.
     """
@@ -416,7 +416,6 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Tensor], aot_config: AOTConfi
         _num_outs = 1
 
     joint_inputs = (deduped_flat_args, out)
-
 
     if config.use_functionalize:
         # Trace once without decompositions, into a graph of ATen ops.

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -285,7 +285,7 @@ def aot_dispatch_base(flat_fn, flat_args: List[Tensor], aot_config: AOTConfig):
     context = disable_autocast_manager if disable_amp else nullcontext
 
     with context(), track_graph_compiling("inference"):
-            compiled_fw = aot_config.fw_compiler(fw_module, flat_args)
+        compiled_fw = aot_config.fw_compiler(fw_module, flat_args)
 
     @wraps(compiled_fw)
     def new_fn(args):

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -288,19 +288,14 @@ def aot_dispatch_base(flat_fn, flat_args: List[Tensor], aot_config: AOTConfig):
         with track_graph_compiling("inference"):
             compiled_fw = aot_config.fw_compiler(fw_module, flat_args)
 
-    if not disable_amp:
-
-        @wraps(compiled_fw)
-        def new_fn(args):
-            fw_outs = call_func_with_args(compiled_fw, args)
-            return fw_outs
-    else:
-
-        @wraps(compiled_fw)
-        def new_fn(args):
+    @wraps(compiled_fw)
+    def new_fn(args):
+        if disable_amp:
             with disable_autocast_manager():
                 fw_outs = call_func_with_args(compiled_fw, args)
-            return fw_outs
+        else:
+            fw_outs = call_func_with_args(compiled_fw, args)
+        return fw_outs
 
     return new_fn
 

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -300,16 +300,6 @@ def aot_dispatch_base(flat_fn, flat_args: List[Tensor], aot_config: AOTConfig):
     return new_fn
 
 
-# @contextmanager
-# def disable_autocast_cache():
-#     old_value = torch.is_autocast_cache_enabled()
-#     torch.set_autocast_cache_enabled(False)
-#     try:
-#         yield
-#     finally:
-#         torch.set_autocast_cache_enabled(old_value)
-
-
 @contextmanager
 def disable_autocast_manager():
     guard = torch._C._DisableAutocast()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86515
* #85921

Fix for https://github.com/pytorch/torchdynamo/issues/1368

From comment:
> When we invoke a Composite Implicit autograd operator that has an autocast rule, such as Einsum,
autocast is disabled during its invocation. When we trace out the operators in an implicit op,
re-applying on autocast rules on those operators might yield divergence from what was executed at runtime.
This pass checks for divergence. If divergence is found, we will disable autocast.
We would like to avoid disabling autocast if possible because accessing TLS is slow.

Concretely, the problem found was when invoked `sum` in `einsum`:

As seen by the following divergence:
```
>>> with torch.cuda.amp.autocast(enabled=True):
...     print(torch.ops.aten.sum.dim_IntList(torch.rand([2, 2, 2], device="cuda", dtype=torch.half), [1, 2]).dtype)
... 
torch.float32
>>> print(torch.ops.aten.sum.dim_IntList(torch.rand([2, 2, 2], device="cuda", dtype=torch.half), [1, 2]).dtype)
torch.float16
```


Edit: we've decided to accept the overhead of universally disabling autocast instead