### PR TITLE
Fix empty input issue of convolution for channels last memory format

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -12,8 +12,13 @@
 #include <c10/util/accumulate.h>
 #include <c10/util/irange.h>
 #include <c10/macros/Macros.h>
-#include <ATen/ops/permute.h>
 #include <limits>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/permute.h>
+#endif
 
 #if AT_NNPACK_ENABLED()
 #include <nnpack.h>

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1508,7 +1508,8 @@ at::Tensor _convolution(
       break;
     case ConvBackend::Empty:
     {
-      auto weight_view = at::_unsafe_view(weight, -1);
+      auto weight_view = weight.is_contiguous() ? at::_unsafe_view(weight, -1) :
+        at::_unsafe_view(weight.clone(at::MemoryFormat::Contiguous), -1);
       output = (input.size(1) == 0) ? (input.view(-1) * weight_view) : (input * weight_view[0]);
       if (bias.defined()) {
         output.add_(bias[0]);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -741,6 +741,7 @@ class TestNN(NNTestCase):
                 self.assertRaises(RuntimeError, lambda: output2.backward(torch.ones(1, 5, 10, 10)))
 
     def test_conv2d_channels_last_empty_input(self):
+        # channels_last2d
         input = torch.randn((0, 4, 20, 20))
         conv = torch.nn.Conv2d(4, 4, 3, 1)
         out = conv(input)
@@ -748,6 +749,19 @@ class TestNN(NNTestCase):
         out_cl = conv_cl(input)
         self.assertEqual(out, out_cl)
         input_cl = input.to(memory_format=torch.channels_last)
+        out_cl2 = conv(input_cl)
+        self.assertEqual(out_cl, out_cl2)
+        out_cl3 = conv_cl(input_cl)
+        self.assertEqual(out_cl, out_cl3)
+
+        # channels_last3d
+        input = torch.randn((0, 4, 20, 20, 20))
+        conv = torch.nn.Conv3d(4, 4, 3, 1)
+        out = conv(input)
+        conv_cl = torch.nn.Conv3d(4, 4, 3, 1).to(memory_format=torch.channels_last_3d)
+        out_cl = conv_cl(input)
+        self.assertEqual(out, out_cl)
+        input_cl = input.to(memory_format=torch.channels_last_3d)
         out_cl2 = conv(input_cl)
         self.assertEqual(out_cl, out_cl2)
         out_cl3 = conv_cl(input_cl)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -740,6 +740,19 @@ class TestNN(NNTestCase):
                 self.assertFalse(output2.requires_grad)
                 self.assertRaises(RuntimeError, lambda: output2.backward(torch.ones(1, 5, 10, 10)))
 
+    def test_conv2d_channels_last_empty_input(self):
+        input = torch.randn((0, 4, 20, 20))
+        conv = torch.nn.Conv2d(4, 4, 3, 1)
+        out = conv(input)
+        conv_cl = torch.nn.Conv2d(4, 4, 3, 1).to(memory_format=torch.channels_last)
+        out_cl = conv_cl(input)
+        self.assertEqual(out, out_cl)
+        input_cl = input.to(memory_format=torch.channels_last)
+        out_cl2 = conv(input_cl)
+        self.assertEqual(out_cl, out_cl2)
+        out_cl3 = conv_cl(input_cl)
+        self.assertEqual(out_cl, out_cl3)
+
     def test_parameters_and_named_parameters(self):
         def names(named_parameters):
             return [k for k, _ in named_parameters]

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -740,34 +740,6 @@ class TestNN(NNTestCase):
                 self.assertFalse(output2.requires_grad)
                 self.assertRaises(RuntimeError, lambda: output2.backward(torch.ones(1, 5, 10, 10)))
 
-    def test_conv_empty_input(self):
-        def help(input, conv, memory_format=None):
-            ref_out = conv(input)
-            conv_cl = conv.to(memory_format=memory_format)
-            out_cl = conv_cl(input)
-            self.assertEqual(ref_out, out_cl)
-            input_cl = input.to(memory_format=memory_format)
-            out_cl2 = conv(input_cl)
-            self.assertEqual(out_cl, out_cl2)
-            out_cl3 = conv_cl(input_cl)
-            self.assertEqual(out_cl, out_cl3)
-
-        # channels_last case
-        input2d = torch.randn((0, 4, 20, 20))
-        conv2d = torch.nn.Conv2d(4, 4, 3, 1)
-        help(input2d, conv2d, torch.channels_last)
-        # channels_last_3d case
-        input3d = torch.randn((0, 4, 20, 20, 20))
-        conv3d = torch.nn.Conv3d(4, 4, 3, 1)
-        help(input3d, conv3d, torch.channels_last_3d)
-        # non-contiguous case
-        weight = torch.rand(4, 8, 3, 3)[:, ::2, :, :]
-        bias = torch.rand(4)
-        out = F.conv2d(input2d, weight, bias, (1, 1), 0, (1, 1), 1)
-        weight = weight.contiguous()
-        out_ref = F.conv2d(input2d, weight, bias, (1, 1), 0, (1, 1), 1)
-        self.assertEqual(out_ref, out)
-
     def test_parameters_and_named_parameters(self):
         def names(named_parameters):
             return [k for k, _ in named_parameters]
@@ -11761,6 +11733,36 @@ class TestNNDeviceType(NNTestCase):
         bn = nn.BatchNorm2d(1).to(device, dtype)
         data = torch.rand(880801, 1, 1, 1, device=device, dtype=dtype)
         out = bn(data).sum().backward()
+
+    @dtypesIfCUDA(torch.float, torch.double, torch.half, torch.complex128)
+    @dtypes(torch.float, torch.double, torch.bfloat16, torch.complex128)
+    def test_conv_empty_input(self, device, dtype):
+        def help(input, conv, memory_format):
+            ref_out = conv(input)
+            conv_cl = conv.to(memory_format=memory_format)
+            out_cl = conv_cl(input)
+            self.assertEqual(ref_out, out_cl)
+            input_cl = input.to(memory_format=memory_format)
+            out_cl2 = conv(input_cl)
+            self.assertEqual(out_cl, out_cl2)
+            out_cl3 = conv_cl(input_cl)
+            self.assertEqual(out_cl, out_cl3)
+
+        # channels_last case
+        input2d = torch.randn((0, 4, 20, 20)).to(device=device, dtype=dtype)
+        conv2d = torch.nn.Conv2d(4, 4, 3, 1).to(device=device, dtype=dtype)
+        help(input2d, conv2d, torch.channels_last)
+        # channels_last_3d case
+        input3d = torch.randn((0, 4, 20, 20, 20)).to(device=device, dtype=dtype)
+        conv3d = torch.nn.Conv3d(4, 4, 3, 1).to(device=device, dtype=dtype)
+        help(input3d, conv3d, torch.channels_last_3d)
+        # non-contiguous case
+        weight = torch.rand(4, 8, 3, 3)[:, ::2, :, :].to(device=device, dtype=dtype)
+        bias = torch.rand(4).to(device=device, dtype=dtype)
+        out = F.conv2d(input2d, weight, bias, (1, 1), 0, (1, 1), 1)
+        weight = weight.contiguous()
+        out_ref = F.conv2d(input2d, weight, bias, (1, 1), 0, (1, 1), 1)
+        self.assertEqual(out_ref, out)
 
     def test_InstanceNorm1d_general(self, device):
         b = random.randint(3, 5)


### PR DESCRIPTION
Fixes empty input convolution issue : when input is empty e.g. shape of (0, 3, 3, 4) and weight is channels last format, at::_unsafe_view will raise "view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead."


cc @VitalyFedyunin @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10