### PR TITLE
[BE] Remove remaining cuda-11.3 builds

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -135,13 +135,6 @@ jobs:
       docker-image: ${{ needs.linux-bionic-py3_7-clang9-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-py3_7-clang9-build.outputs.test-matrix }}
 
-  linux-bionic-cuda11_3-py3_7-clang9-build:
-    name: linux-bionic-cuda11.3-py3.7-clang9
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: linux-bionic-cuda11.3-py3.7-clang9
-      docker-image-name: pytorch-linux-bionic-cuda11.3-cudnn8-py3-clang9
-
   linux-vulkan-bionic-py3_7-clang9-build:
     name: linux-vulkan-bionic-py3.7-clang9
     uses: ./.github/workflows/_linux-build.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -86,12 +86,12 @@ jobs:
       build-generates-artifacts: false
 
   # no-ops builds test USE_PER_OPERATOR_HEADERS=0 where ATen/ops is not generated
-  linux-xenial-cuda11_3-py3_7-gcc7-no-ops-build:
-    name: linux-xenial-cuda11.3-py3.7-gcc7-no-ops
+  linux-bionic-cuda11_7-py3_10-gcc7-no-ops-build:
+    name: linux-bionic-cuda11.7-py3.10-gcc7-no-ops
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-xenial-cuda11.3-py3.7-gcc7-no-ops
-      docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
+      build-environment: linux-bionic-cuda11.7-py3.10-gcc7-no-ops
+      docker-image-name: pytorch-linux-bionic-cuda11.7-cudnn8-py3-gcc7
 
   pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build:
     name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build


### PR DESCRIPTION
`linux-bionic-cuda11_3-py3_7-clang9-build` is redundant is is covered by `linux-jammy-cuda11.6-cudnn8-py3.8-clang12`

And migrate no-per-operator header build (which mimics internal behavior) from  `linux-xenial-cuda11.3` to `linux-bionic-cuda11.7`
