### PR TITLE
Make nested TreeSpec printing nicer (#46538)

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -202,12 +202,12 @@ class TestPytree(TestCase):
         # Check that it looks sane
         pytree = (0, [0, 0, 0])
         _, spec = tree_flatten(pytree)
-        self.assertEqual(repr(spec), ("{'children_specs': ['*',\n"
-                                      "                    {'children_specs': ['*', '*', '*'],\n"
-                                      "                     'context': None,\n"
-                                      "                     'type': <class 'list'>}],\n"
-                                      " 'context': None,\n"
-                                      " 'type': <class 'tuple'>}"))
+        print()
+        print(repr(spec))
+        self.assertEqual(repr(spec), ("TreeSpec(tuple, None, [*,\n"
+                                      "                       TreeSpec(list, None, [*,\n"
+                                      "                                             *,\n"
+                                      "                                             *])])"))
 
     def test_broadcast_to_and_flatten(self):
         cases = [

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -202,8 +202,6 @@ class TestPytree(TestCase):
         # Check that it looks sane
         pytree = (0, [0, 0, 0])
         _, spec = tree_flatten(pytree)
-        print()
-        print(repr(spec))
         self.assertEqual(repr(spec), ("TreeSpec(tuple, None, [*,\n"
                                       "                       TreeSpec(list, None, [*,\n"
                                       "                                             *,\n"

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -202,8 +202,14 @@ class TestPytree(TestCase):
         # Check that it looks sane
         pytree = (0, [0, 0, 0])
         _, spec = tree_flatten(pytree)
-        self.assertEqual(
-            repr(spec), 'TreeSpec(tuple, None, [*, TreeSpec(list, None, [*, *, *])])')
+        self.assertEqual(repr(spec), 
+                ("{'type': <class 'tuple'>,\n"
+                 " 'context': None,\n"
+                 " 'children_specs': ['*',\n"
+                 "                    {'type': <class 'list'>,\n"
+                 "                     'context': None,\n"
+                 "                     'children_specs': ['*', '*', '*']}]}"))
+
 
     def test_broadcast_to_and_flatten(self):
         cases = [

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -200,12 +200,12 @@ class TestPytree(TestCase):
 
     def test_treespec_repr(self):
         # Check that it looks sane
-        pytree = (0, [0, 0, 0])
+        pytree = (0, [0, 0, [0]])
         _, spec = tree_flatten(pytree)
         self.assertEqual(repr(spec), ("TreeSpec(tuple, None, [*,\n"
                                       "                       TreeSpec(list, None, [*,\n"
                                       "                                             *,\n"
-                                      "                                             *])])"))
+                                      "                                             TreeSpec(list, None, [*])])])"))
 
     def test_broadcast_to_and_flatten(self):
         cases = [

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -202,14 +202,12 @@ class TestPytree(TestCase):
         # Check that it looks sane
         pytree = (0, [0, 0, 0])
         _, spec = tree_flatten(pytree)
-        self.assertEqual(repr(spec), 
-                ("{'type': <class 'tuple'>,\n"
-                 " 'context': None,\n"
-                 " 'children_specs': ['*',\n"
-                 "                    {'type': <class 'list'>,\n"
-                 "                     'context': None,\n"
-                 "                     'children_specs': ['*', '*', '*']}]}"))
-
+        self.assertEqual(repr(spec), ("{'children_specs': ['*',\n"
+                                      "                    {'children_specs': ['*', '*', '*'],\n"
+                                      "                     'context': None,\n"
+                                      "                     'type': <class 'list'>}],\n"
+                                      " 'context': None,\n"
+                                      " 'type': <class 'tuple'>}"))
 
     def test_broadcast_to_and_flatten(self):
         cases = [

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -124,7 +124,8 @@ class TreeSpec:
         children_specs_str: str = ''
         if len(self.children_specs):
             indent += len(repr_prefix)
-            children_specs_str += self.children_specs[0].__repr__(indent) + ','
+            children_specs_str += self.children_specs[0].__repr__(indent)
+            children_specs_str += ',' if len(self.children_specs) > 1 else ''
             children_specs_str += ','.join(['\n' + ' ' * indent + child.__repr__(indent) for child in self.children_specs[1:]])
         repr_suffix: str = f'{children_specs_str}])'
         return repr_prefix + repr_suffix

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -119,11 +119,13 @@ class TreeSpec:
 
     def __post_init__(self) -> None:
         self.num_leaves: int = sum([spec.num_leaves for spec in self.children_specs])
-         
+
     def __repr__(self) -> str:
         # Represent leaf node with '*', root node with dictionary
-        dict_factory = lambda tuples: '*' if tuples[0][1] is None else dict(tuples)
-        return pprint.pformat(asdict(self, dict_factory=dict_factory), sort_dicts=False)
+        def dict_factory(tuples: List[Any]) -> Any:
+            d: Dict[Any, Any] = dict(tuples)
+            return '*' if d['type'] is None else d
+        return pprint.pformat(asdict(self, dict_factory=dict_factory))
 
 class LeafSpec(TreeSpec):
     def __init__(self) -> None:


### PR DESCRIPTION
1. Made TreeSpec into a dataclass.
2. In `__repr__`, recursively transformed TreeSpec into dictionaries and then pretty-printed it.

Fixes #46538. Hi, @ezyang. this PR is for the TreeSpec `__repr__` refactor we discussed.
