### PR TITLE
[ONNX] Default runtime type checking to raising errors

### DIFF
--- a/torch/onnx/_globals.py
+++ b/torch/onnx/_globals.py
@@ -33,9 +33,9 @@ class _InternalGlobals:
         self.onnx_shape_inference: bool = True
 
         # Internal feature flags
-        if os.getenv("TORCH_ONNX_EXPERIMENTAL_RUNTIME_TYPE_CHECK") == "ERRORS":
+        if os.getenv("TORCH_ONNX_EXPERIMENTAL_RUNTIME_TYPE_CHECK") == "WARNINGS":
             self.runtime_type_check_state = (
-                _exporter_states.RuntimeTypeCheckState.ERRORS
+                _exporter_states.RuntimeTypeCheckState.WARNINGS
             )
         elif os.getenv("TORCH_ONNX_EXPERIMENTAL_RUNTIME_TYPE_CHECK") == "DISABLED":
             self.runtime_type_check_state = (
@@ -43,7 +43,7 @@ class _InternalGlobals:
             )
         else:
             self.runtime_type_check_state = (
-                _exporter_states.RuntimeTypeCheckState.WARNINGS
+                _exporter_states.RuntimeTypeCheckState.ERRORS
             )
 
     @property

--- a/torch/onnx/_internal/_beartype.py
+++ b/torch/onnx/_internal/_beartype.py
@@ -50,7 +50,7 @@ def _create_beartype_decorator(
     assert isinstance(_beartype_lib, ModuleType)
 
     if runtime_check_state == _exporter_states.RuntimeTypeCheckState.ERRORS:
-        # Enable runtime type checking which errors on any type hint violation.
+        # Enable runtime type checking with errors on any type hint violation.
         return _beartype_lib.beartype
 
     # Warnings only

--- a/torch/onnx/_internal/_beartype.py
+++ b/torch/onnx/_internal/_beartype.py
@@ -50,7 +50,7 @@ def _create_beartype_decorator(
     assert isinstance(_beartype_lib, ModuleType)
 
     if runtime_check_state == _exporter_states.RuntimeTypeCheckState.ERRORS:
-        # Enable runtime type checking with errors on any type hint violation.
+        # Enable runtime type checking which errors on any type hint violation.
         return _beartype_lib.beartype
 
     # Warnings only

--- a/torch/onnx/_internal/_beartype.py
+++ b/torch/onnx/_internal/_beartype.py
@@ -45,12 +45,6 @@ def _create_beartype_decorator(
         return _no_op_decorator
     if _beartype_lib is None:
         # If the beartype library is not installed, return a no-op decorator
-        if runtime_check_state == _exporter_states.RuntimeTypeCheckState.ERRORS:
-            warnings.warn(
-                "TORCH_ONNX_EXPERIMENTAL_RUNTIME_TYPE_CHECK is set to 'ERRORS', "
-                "but the beartype library is not installed. "
-                "Install beartype with `pip install beartype` to enable runtime type checking."
-            )
         return _no_op_decorator
 
     assert isinstance(_beartype_lib, ModuleType)


### PR DESCRIPTION
Default runtime type checking to raise by changing the default value to  `GLOBALS.runtime_type_check_state` into ERRORS