### PR TITLE
[torch] Implement fast version of min/max

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_double.h
@@ -320,6 +320,22 @@ inline Vectorized<double> Vectorized<double>::frac() const {
   return *this - this->trunc();
 }
 
+// Implements the vectorized version of std::max() operation,
+// which DOESNOT propagates NaN for second argument
+template <>
+Vectorized<double> inline max(const Vectorized<double>& a, const Vectorized<double>& b) {
+  // std::max(NaN, nonNan) -> NaN
+  return _mm256_max_pd(b, a);
+}
+
+// Implements the vectorized version of std::min() operation,
+// which DOESNOT propagates NaN for second argument
+template <>
+Vectorized<double> inline min(const Vectorized<double>& a, const Vectorized<double>& b) {
+  // std::max(NaN, nonNan) -> NaN
+  return _mm256_min_pd(b, a);
+}
+
 // Implements the IEEE 754 201X `maximum` operation, which propagates NaN if
 // either input is a NaN.
 template <>

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -326,6 +326,22 @@ inline Vectorized<float> Vectorized<float>::frac() const {
   return *this - this->trunc();
 }
 
+// Implements the vectorized version of std::max() operation,
+// which DOESNOT propagates NaN for second argument
+template <>
+Vectorized<float> inline max(const Vectorized<float>& a, const Vectorized<float>& b) {
+  // std::max(NaN, nonNan) -> NaN
+  return _mm256_max_ps(b, a);
+}
+
+// Implements the vectorized version of std::min() operation,
+// which DOESNOT propagates NaN for second argument
+template <>
+Vectorized<float> inline min(const Vectorized<float>& a, const Vectorized<float>& b) {
+  // std::min(NaN, nonNan) -> NaN
+  return _mm256_min_ps(b, a);
+}
+
 // Implements the IEEE 754 201X `maximum` operation, which propagates NaN if
 // either input is a NaN.
 template <>

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
@@ -711,6 +711,11 @@ Vectorized<float> inline maximum(const Vectorized<float>& a, const Vectorized<fl
   return Vectorized<float>(r0, r1);
 }
 
+template <>
+Vectorized<float> inline max(const Vectorized<float>& a, const Vectorized<float>& b) {
+  return maximum(a, b);
+}
+
 // Implements the IEEE 754 201X `minimum` operation, which propagates NaN if
 // either input is a NaN.
 template <>
@@ -718,6 +723,11 @@ Vectorized<float> inline minimum(const Vectorized<float>& a, const Vectorized<fl
   float32x4_t r0 = vminq_f32(a.get_low(), b.get_low());
   float32x4_t r1 = vminq_f32(a.get_high(), b.get_high());
   return Vectorized<float>(r0, r1);
+}
+
+template <>
+Vectorized<float> inline min(const Vectorized<float>& a, const Vectorized<float>& b) {
+  return minimum(a, b);
 }
 
 template <>

--- a/aten/src/ATen/cpu/vec/vec512/vec512_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_double.h
@@ -352,6 +352,22 @@ inline Vectorized<double> Vectorized<double>::frac() const {
   return *this - this->trunc();
 }
 
+// Implements the vectorized version of std::max() operation,
+// which DOESNOT propagates NaN for second argument
+template <>
+Vectorized<double> inline max(const Vectorized<double>& a, const Vectorized<double>& b) {
+  // std::max(NaN, nonNan) -> NaN
+  return _mm512_max_pd(b, a);
+}
+
+// Implements the vectorized version of std::min() operation,
+// which DOESNOT propagates NaN for second argument
+template <>
+Vectorized<double> inline min(const Vectorized<double>& a, const Vectorized<double>& b) {
+  // std::max(NaN, nonNan) -> NaN
+  return _mm512_min_pd(b, a);
+}
+
 // Implements the IEEE 754 201X `maximum` operation, which propagates NaN if
 // either input is a NaN.
 template <>

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float.h
@@ -367,6 +367,22 @@ inline Vectorized<float> Vectorized<float>::frac() const {
   return *this - this->trunc();
 }
 
+// Implements the vectorized version of std::max() operation,
+// which DOESNOT propagates NaN for second argument
+template <>
+Vectorized<float> inline max(const Vectorized<float>& a, const Vectorized<float>& b) {
+  // std::max(NaN, nonNan) -> NaN
+  return _mm512_max_ps(b, a);
+}
+
+// Implements the vectorized version of std::min() operation,
+// which DOESNOT propagates NaN for second argument
+template <>
+Vectorized<float> inline min(const Vectorized<float>& a, const Vectorized<float>& b) {
+  // std::min(NaN, nonNan) -> NaN
+  return _mm512_min_ps(b, a);
+}
+
 // Implements the IEEE 754 201X `maximum` operation, which propagates NaN if
 // either input is a NaN.
 template <>


### PR DESCRIPTION
Summary: Add non IEEE conformant implementations of max/min operations that follow std::max()/std::min()

Test Plan: CI

Differential Revision: D40215266

