### PR TITLE
Chore: Add 'mps' to the docs of tensor_attributes

### DIFF
--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -157,7 +157,7 @@ Via a string:
 
     >>> torch.device('cpu')
     device(type='cpu')
-    
+
     >>> torch.device('mps')
     device(type='mps')
 
@@ -170,7 +170,7 @@ Via a string and device ordinal:
 
     >>> torch.device('cuda', 0)
     device(type='cuda', index=0)
-   
+
     >>> torch.device('mps', 0)
     device(type='mps', index=0)
 

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -139,7 +139,7 @@ torch.device
 A :class:`torch.device` is an object representing the device on which a :class:`torch.Tensor` is
 or will be allocated.
 
-The :class:`torch.device` contains a device type (``'cpu'`` or ``'cuda'``) and optional device
+The :class:`torch.device` contains a device type (``'cpu'``, ``'cuda'`` or ``'mps'``) and optional device
 ordinal for the device type. If the device ordinal is not present, this object will always represent
 the current device for the device type, even after :func:`torch.cuda.set_device()` is called; e.g.,
 a :class:`torch.Tensor` constructed with device ``'cuda'`` is equivalent to ``'cuda:X'`` where X is
@@ -157,6 +157,9 @@ Via a string:
 
     >>> torch.device('cpu')
     device(type='cpu')
+    
+    >>> torch.device('mps')
+    device(type='mps')
 
     >>> torch.device('cuda')  # current cuda device
     device(type='cuda')
@@ -167,6 +170,9 @@ Via a string and device ordinal:
 
     >>> torch.device('cuda', 0)
     device(type='cuda', index=0)
+   
+    >>> torch.device('mps', 0)
+    device(type='mps', index=0)
 
     >>> torch.device('cpu', 0)
     device(type='cpu', index=0)


### PR DESCRIPTION
Since PyTorch supports 'mps' (Apple metal) devices it should be reflected in the documentation.