### PR TITLE
[DDP] Add `PackedSequence` support when `device_ids` is specified

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2355,7 +2355,6 @@ class DistributedDataParallelTest(
         for p1, p2 in zip(lstm.parameters(), lstm_ddp.parameters()):
             self.assertEqual(p1.grad, p2.grad)
 
-
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
     def test_channels_last_contig(self):

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2303,18 +2303,26 @@ class DistributedDataParallelTest(
     def test_ddp_packed_sequence(self):
         """
         Tests that DDP with ``device_ids`` specified can run a forward and
-        backward pass with ``PackedSequence`` s without erroring. Because LSTMs
-        are non-deterministic, we cannot reliably compare against a local run.
+        backward pass with ``PackedSequence`` s with parity compared to a local
+        version of the model.
         """
         store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = dist.init_process_group(
+            "nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
         seqs = ["sequence_sequence", "seq", "sequence"]
         vocab = ["<pad>"] + sorted(set([ch for seq in seqs for ch in seq]))
         vectorized_seqs = [[vocab.index(tok) for tok in seq] for seq in seqs]
-        embed = nn.Embedding(len(vocab), 4)
-        lstm = nn.LSTM(input_size=4, hidden_size=5, batch_first=True)
+        # Set the seed to make the embedding and LSTM deterministic (even
+        # across ranks since DDP broadcasts parameters from rank 0)
+        torch.manual_seed(0)
+        embed = nn.Embedding(len(vocab), 4)  # keep on CPU
+        lstm = nn.LSTM(input_size=4, hidden_size=2, batch_first=True).to(self.rank)
         lstm_ddp = DistributedDataParallel(
-            lstm.to(self.rank),
+            copy.deepcopy(lstm),
             device_ids=[self.rank],
             process_group=process_group,
         )
@@ -2332,8 +2340,20 @@ class DistributedDataParallelTest(
         packed_input = torch.nn.utils.rnn.pack_padded_sequence(
             embedded_seq_tensor, seq_lengths, batch_first=True,
         )
-        packed_output, (ht, ct) = lstm_ddp(packed_input)
+        packed_input_ddp = torch.nn.utils.rnn.pack_padded_sequence(
+            embedded_seq_tensor.detach().clone(), seq_lengths, batch_first=True,
+        )
+        # Move the input to GPU explicitly for the local model
+        packed_output, (ht, ct) = lstm(packed_input.to(self.rank))
+        # Let DDP move the input to GPU internally
+        packed_output_ddp, (ht_ddp, ct_ddp) = lstm_ddp(packed_input_ddp)
+        self.assertEqual(packed_output.data, packed_output_ddp.data)
+        self.assertEqual(ht, ht_ddp)
+        self.assertEqual(ct, ct_ddp)
         packed_output.data.sum().backward()
+        packed_output_ddp.data.sum().backward()
+        for p1, p2 in zip(lstm.parameters(), lstm_ddp.parameters()):
+            self.assertEqual(p1.grad, p2.grad)
 
 
     @requires_nccl()

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -55,7 +55,6 @@ def _recursive_to(inputs, target_gpu, use_side_stream_for_tensor_copies):
     def to_map(obj):
         if isinstance(obj, torch.Tensor) or isinstance(obj, PackedSequence):
             device = obj.data.device if isinstance(obj, PackedSequence) else obj.device
-            print(f"type(obj): {type(obj)}")
             if device == torch.device("cuda", target_gpu):
                 return (obj,)
             if not use_side_stream_for_tensor_copies:

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -1,10 +1,12 @@
+from typing import Any, Dict, List, Tuple
+
 import torch
 import torch.distributed as dist
 from torch.nn.parallel._functions import _get_stream
 from torch.nn.parallel.scatter_gather import (  # type: ignore[attr-defined]
-    _is_namedtuple
+    _is_namedtuple,
 )
-from typing import Any, Dict, List, Tuple
+from torch.nn.utils.rnn import PackedSequence
 
 __all__ = []  # type: ignore[var-annotated]
 
@@ -51,8 +53,10 @@ def _recursive_to(inputs, target_gpu, use_side_stream_for_tensor_copies):
     """
 
     def to_map(obj):
-        if isinstance(obj, torch.Tensor):
-            if obj.device == torch.device("cuda", target_gpu):
+        if isinstance(obj, torch.Tensor) or isinstance(obj, PackedSequence):
+            device = obj.data.device if isinstance(obj, PackedSequence) else obj.device
+            print(f"type(obj): {type(obj)}")
+            if device == torch.device("cuda", target_gpu):
                 return (obj,)
             if not use_side_stream_for_tensor_copies:
                 return (obj.to(target_gpu),)
@@ -69,7 +73,10 @@ def _recursive_to(inputs, target_gpu, use_side_stream_for_tensor_copies):
                     current_stream.wait_stream(stream)
                     # Ensure tensor memory is not reused until work on
                     # main stream is complete
-                    output.record_stream(current_stream)  # type: ignore[arg-type]
+                    if isinstance(obj, PackedSequence):
+                        output.data.record_stream(current_stream)  # type: ignore[arg-type]
+                    else:
+                        output.record_stream(current_stream)  # type: ignore[arg-type]
                 return (output,)
         if _is_namedtuple(obj):
             return [type(obj)(*args) for args in zip(*map(to_map, obj))]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#86614 [DDP] Add `PackedSequence` support when `device_ids` is specified**
* #86528 [FSDP] Remove `utils.py` (moved to `_utils.py`)
* #85738 [FSDP] Add initial `summon_full_params(with_grads=True)`
* #84911 [FSDP] Add `use_orig_params`

Before this PR, if a user runs DDP with `device_ids` specified and with a `PackedSequence` input, then the execution will error with something like:
```
raise ValueError(
  ValueError: batch_sizes should always be on CPU. Instances of PackedSequence should never be created manually. They should be instantiated by
 functions like pack_sequence and pack_padded_sequences in nn.utils.rnn. https://pytorch.org/docs/stable/nn.html...
```
This is because the DDP forward calls `_to_kwargs()`, which calls `_recursive_to()`, which moves the inputs to GPU. However, `_is_namedtuple(packed_sequence)` returns `True`, leading to the branch `return [type(obj)(*args) for args in zip(*map(to_map, obj))]`, which tries to construct a `PackedSequence` directly via `type(obj)(*args)`, leading to the error.

Repro for `_is_namedtuple(packed_sequence)` returning `True`:
```
import random

import torch
import torch.nn.utils.rnn as rnn_utils
from torch.nn.parallel.scatter_gather import _is_namedtuple

def _ordered_sequence(tensor_type):
    seqs = [tensor_type(random.randint(1, 256))
            for _ in range(32)]
    seqs = [s.random_(-128, 128) for s in seqs]
    ordered = sorted(seqs, key=len, reverse=True)
    return ordered

def _padded_sequence(tensor_type):
    ordered = _ordered_sequence(tensor_type)
    lengths = [len(i) for i in ordered]
    padded_tensor = rnn_utils.pad_sequence(ordered)
    return padded_tensor, lengths

padded, lengths = _padded_sequence(torch.Tensor)
packed = rnn_utils.pack_padded_sequence(
    padded, lengths, enforce_sorted=False)
print(type(packed), packed.data.device)
print(_is_namedtuple(packed))
```

Test Plan:
```
python test/distributed/test_c10d_nccl.py -k test_ddp_packed_sequence
```
Without the fix, the added unit test fails with the expected error.
