### PR TITLE
Add error checking to flaky test bot platform parser

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1673,6 +1673,16 @@ def check_if_enable(test: unittest.TestCase):
                         "rocm": TEST_WITH_ROCM,
                         "asan": TEST_WITH_ASAN
                     }
+
+                    invalid_platforms = list(filter(lambda p: p not in platform_to_conditional, platforms))
+                    if len(invalid_platforms) > 0:
+                        invalid_plats_str = ", ".join(invalid_platforms)
+                        valid_plats = ", ".join(platform_to_conditional.keys())
+                        raise RuntimeError(f"Test {disabled_test} is disabled for some unrecognized " + \
+                            f"platforms: [{invalid_plats_str}]. Please edit issue {issue_url} to fix the platforms " + \
+                            f"assigned to this flaky test, changing \"Platforms: ...\" to a comma separated " + \
+                            f"subset of the following (or leave it blank to match all platforms): {valid_plats}")
+
                     if platforms == [] or any([platform_to_conditional[platform] for platform in platforms]):
                         skip_msg = f"Test is disabled because an issue exists disabling it: {issue_url}" \
                             f" for {'all' if platforms == [] else ''}platform(s) {', '.join(platforms)}. " \

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1678,11 +1678,11 @@ def check_if_enable(test: unittest.TestCase):
                     if len(invalid_platforms) > 0:
                         invalid_plats_str = ", ".join(invalid_platforms)
                         valid_plats = ", ".join(platform_to_conditional.keys())
-                        
-                        print(f"Test {disabled_test} is disabled for some unrecognized " + \
-                            f"platforms: [{invalid_plats_str}]. Please edit issue {issue_url} to fix the platforms " + \
-                            f"assigned to this flaky test, changing \"Platforms: ...\" to a comma separated " + \
-                            f"subset of the following (or leave it blank to match all platforms): {valid_plats}")
+
+                        print(f"Test {disabled_test} is disabled for some unrecognized ",
+                              f"platforms: [{invalid_plats_str}]. Please edit issue {issue_url} to fix the platforms ",
+                              "assigned to this flaky test, changing \"Platforms: ...\" to a comma separated ",
+                              f"subset of the following (or leave it blank to match all platforms): {valid_plats}")
 
                         # Sanitize the platforms list so that we continue to disable the test for any valid platforms given
                         platforms = list(filter(lambda p: p in platform_to_conditional, platforms))

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1678,10 +1678,14 @@ def check_if_enable(test: unittest.TestCase):
                     if len(invalid_platforms) > 0:
                         invalid_plats_str = ", ".join(invalid_platforms)
                         valid_plats = ", ".join(platform_to_conditional.keys())
-                        raise RuntimeError(f"Test {disabled_test} is disabled for some unrecognized " + \
+                        
+                        print(f"Test {disabled_test} is disabled for some unrecognized " + \
                             f"platforms: [{invalid_plats_str}]. Please edit issue {issue_url} to fix the platforms " + \
                             f"assigned to this flaky test, changing \"Platforms: ...\" to a comma separated " + \
                             f"subset of the following (or leave it blank to match all platforms): {valid_plats}")
+
+                        # Sanitize the platforms list so that we continue to disable the test for any valid platforms given
+                        platforms = list(filter(lambda p: p in platform_to_conditional, platforms))
 
                     if platforms == [] or any([platform_to_conditional[platform] for platform in platforms]):
                         skip_msg = f"Test is disabled because an issue exists disabling it: {issue_url}" \


### PR DESCRIPTION
If an invalid platform is specified when disabling a test with flaky test bot, the CI crashes, skipping all tests that come after it.

This turns it into a console message instead.  Not erroring out here since it'll affect random PRs.  Actual error message should go into the bot that parses the original issue so that it can respond on that issue directly