### PR TITLE
[ONNX] Fix FindCommonAncestor in function_extraction

### DIFF
--- a/torch/csrc/jit/passes/onnx/function_extraction.cpp
+++ b/torch/csrc/jit/passes/onnx/function_extraction.cpp
@@ -309,6 +309,7 @@ c10::optional<ScopePtr> FunctionExtractor::FindCommonAncestor(
   if (diff != 0) {
     auto deeper_scope = diff > 0 ? a : b;
     auto other_scope = diff > 0 ? b : a;
+    diff = std::abs(diff);
     while (diff > 0) {
       deeper_scope = deeper_scope->parent();
       diff--;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86650

One line fix to get absolute value of `diff` before looping over.
