### PR TITLE
Optimize __dlpack_device__ performance

### DIFF
--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -45,7 +45,7 @@ The DLPack capsule shares the tensor's memory.
 
 # TODO: add a typing.Protocol to be able to tell Mypy that only objects with
 # __dlpack__ and __dlpack_device__ methods are accepted.
-def from_dlpack(ext_tensor: Any) -> torch.Tensor:
+def from_dlpack(ext_tensor: Any) -> 'torch.Tensor':
     """from_dlpack(ext_tensor) -> Tensor
 
     Converts a tensor from an external library into a ``torch.Tensor``.


### PR DESCRIPTION
This can be critical when processing a large number of tensors

```bash
python -m timeit --setup 'import torch; t = torch.empty(1000, device="cuda")' 't.__dlpack_device__()'
```

based on 1.12.1:
before:
100000 loops, best of 5: 2.32 usec per loop
after:
500000 loops, best of 5: 844 nsec per loop
