### PR TITLE
Compile C10 with `Wshadow`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -927,9 +927,6 @@ if(NOT MSVC)
   append_cxx_flag_if_supported("-fno-trapping-math" CMAKE_CXX_FLAGS)
   append_cxx_flag_if_supported("-Werror=format" CMAKE_CXX_FLAGS)
   append_cxx_flag_if_supported("-Werror=cast-function-type" CMAKE_CXX_FLAGS)
-  check_cxx_compiler_flag("-Werror=sign-compare" HAS_WERROR_SIGN_COMPARE)
-  # This doesn't work globally so we use the test on specific
-  # target_compile_options
 endif()
 
 if(USE_ASAN)

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -52,8 +52,9 @@ target_compile_options(c10 PRIVATE "-DC10_BUILD_MAIN_LIB")
 if(${COMPILER_SUPPORTS_HIDDEN_VISIBILITY})
   target_compile_options(c10 PRIVATE "-fvisibility=hidden")
 endif()
-if(HAS_WERROR_SIGN_COMPARE AND WERROR)
-  target_compile_options(c10 PRIVATE "-Werror=sign-compare")
+if(WERROR)
+  target_compile_options_if_supported(c10 PRIVATE "-Werror=sign-compare")
+  target_compile_options_if_supported(c10 PRIVATE "-Werror=shadow")
 endif()
 
 # ---[ Dependency of c10


### PR DESCRIPTION
This should prevent further regressions like https://github.com/pytorch/pytorch/pull/86646
Update `fmt` to `7.1.0` to fix variable shadowing in that library
