### PR TITLE
Bug fix for torch._C._will_engine_execute_node

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -435,7 +435,7 @@ class TestAutograd(TestCase):
 
         # .backward(inputs=) is OK
         out = c.sum()
-        torch.autograd.backward(out, inputs=(a,), retain_graph=True)
+        torch.autograd.backward(out, inputs=(a, b2), retain_graph=True)
         self.assertEqual(counter[0], 2)
 
         # .backward() is OK


### PR DESCRIPTION
This change was originally landed as part of #86260, but has been factored out for the purposes of cherry-picking into 1.13 release.

bug fix: `torch._C._will_engine_execute_node` in the release branch produces incorrect returns that the tensor will be executed by backward when the tensor is directly passed as input to .grad, but this tensor is not part of the backward graph 