### PR TITLE
Upcast to fp32 in test_addmm_block ref_half_bfloat16

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -1576,7 +1576,7 @@ class TestSparseCSR(TestCase):
                 return res
 
         def ref_half_bfloat16(c, a, b, alpha=None, beta=None, out=None):
-            res = alpha * (a.to_dense() @ b.to_dense()) + beta * c
+            res = alpha * (a.to_dense().to(torch.float32) @ b.to_dense().to(torch.float32)).to(a.dtype) + beta * c
             if out is not None:
                 out.copy_(res)
                 return out


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/86681