### PR TITLE
Add version selector back to functorch docs (#86602)

### DIFF
--- a/functorch/docs/source/_templates/layout.html
+++ b/functorch/docs/source/_templates/layout.html
@@ -1,0 +1,9 @@
+{% extends "!layout.html" %}
+<link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html" />
+
+{% block sidebartitle %}
+    <div class="version">
+      <a href='https://pytorch.org/functorch/versions.html'>{{ version }} &#x25BC</a>
+    </div>
+    {% include "searchbox.html" %}
+{% endblock %}


### PR DESCRIPTION
I accidentally deleted it in
https://github.com/pytorch/pytorch/pull/85856/ . This brings the version selector back.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/86602
Approved by: https://github.com/samdow

Fixes #ISSUE_NUMBER
