### PR TITLE
Pin numpy version during MPS tests

### DIFF
--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           # shellcheck disable=SC1090
           set -ex
-          ${CONDA_INSTALL} numpy expecttest pyyaml
+          ${CONDA_INSTALL} expecttest numpy=1.22.3 pyyaml=6.0
           # As wheels are cross-compiled they are reported as x86_64 ones
           ORIG_WHLNAME=$(ls -1 dist/*.whl); ARM_WHLNAME=${ORIG_WHLNAME/x86_64/arm64}; mv ${ORIG_WHLNAME} ${ARM_WHLNAME}
           ${CONDA_RUN} python3 -mpip install dist/*.whl


### PR DESCRIPTION
numpy-1.23.1 for some reason can not be loaded on M1

Fixes https://github.com/pytorch/pytorch/issues/86688
