### PR TITLE
Updated tryConvertToType to use more precise types

### DIFF
--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -134,7 +134,14 @@ Value* tryConvertToType(
       } else if (concrete_int) {
         value = graph.insert(aten::IntImplicit, {value}, {}, loc);
       } else if (concrete_number) {
-        value = graph.insert(aten::ScalarImplicit, {value}, {}, loc);
+        auto scalar_type = value->type()->cast<TensorType>()->scalarType();
+        if (scalar_type && isIntegralType(*scalar_type, false)) {
+          value = graph.insert(aten::IntImplicit, {value}, {}, loc);
+        } else if (scalar_type && isFloatingType(*scalar_type)) {
+          value = graph.insert(aten::FloatImplicit, {value}, {}, loc);
+        } else {
+          value = graph.insert(aten::ScalarImplicit, {value}, {}, loc);
+        }
       }
     } else if (value_equals_number) {
       if (concrete_float) {


### PR DESCRIPTION
### Description
Update `tryConvertToType` to use more precise types during conversion to `NumberType`.

### Details
This problem with `NumberType` was found in torch-mlir during PyTorch LTC to JIT graph conversion when we lower Scalar operation to Constant with tensor output type. In cases when Constant has a consumer which expects scalar literal type, it triggers (tensor to scalar) type alignment in PyTorch. The alignment works well, and from JIT perspective `ScalarImplicit` with `NumberType` is a valid operation. But from backends perspective we still have to convert `NumberType` Pythonism to something more precise (like `IntImplicit` or `FloatImplicit`) which takes compilation time. So the best option is to change `tryConvertToType` to produce more precise output type during conversion from tensor to number type.

@antoniojkim @ke1337 