### PR TITLE
[1.13] Release-only improvements to functorch docs

### DIFF
--- a/functorch/docs/source/conf.py
+++ b/functorch/docs/source/conf.py
@@ -98,10 +98,10 @@ functorch_version = str(functorch.__version__)
 #
 # The short X.Y version.
 # TODO: change to [:2] at v1.0
-version = 'nightly (' + functorch_version + ')'
+version = functorch_version
 # The full version, including alpha/beta/rc tags.
 # TODO: verify this works as expected
-release = 'nightly'
+release = functorch_version
 
 # Customized html_title here.
 # Default is " ".join(project, release, "documentation") if not set

--- a/functorch/notebooks/aot_autograd_optimizations.ipynb
+++ b/functorch/notebooks/aot_autograd_optimizations.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# AOT Autograd - How to use and optimize?\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/aot_autograd_optimizations.ipynb\">\n",
+    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/release/1.13/functorch/notebooks/aot_autograd_optimizations.ipynb\">\n",
     "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>\n",
     "\n",

--- a/functorch/notebooks/ensembling.ipynb
+++ b/functorch/notebooks/ensembling.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "This example illustrates how to vectorize model ensembling using vmap.\n",
         "\n",
-        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/ensembling.ipynb\">\n",
+        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/release/1.13/functorch/notebooks/ensembling.ipynb\">\n",
         "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>\n",
         "\n",

--- a/functorch/notebooks/jacobians_hessians.ipynb
+++ b/functorch/notebooks/jacobians_hessians.ipynb
@@ -5,7 +5,7 @@
       "source": [
         "# Jacobians, Hessians, hvp, vhp, and more: composing functorch transforms\n",
         "\n",
-        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/jacobians_hessians.ipynb\">\n",
+        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/release/1.13/functorch/notebooks/jacobians_hessians.ipynb\">\n",
         "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>\n",
         "\n",

--- a/functorch/notebooks/neural_tangent_kernels.ipynb
+++ b/functorch/notebooks/neural_tangent_kernels.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Neural Tangent Kernels\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/neural_tangent_kernels.ipynb\">\n",
+    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/release/1.13/functorch/notebooks/neural_tangent_kernels.ipynb\">\n",
     "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>\n",
     "\n",

--- a/functorch/notebooks/per_sample_grads.ipynb
+++ b/functorch/notebooks/per_sample_grads.ipynb
@@ -9,7 +9,7 @@
       "source": [
         "# Per-sample-gradients\n",
         "\n",
-        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/per_sample_grads.ipynb\">\n",
+        "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/release/1.13/functorch/notebooks/per_sample_grads.ipynb\">\n",
         "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>\n",
         "\n",

--- a/functorch/notebooks/whirlwind_tour.ipynb
+++ b/functorch/notebooks/whirlwind_tour.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Whirlwind Tour\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/master/functorch/notebooks/whirlwind_tour.ipynb\">\n",
+    "<a href=\"https://colab.research.google.com/github/pytorch/pytorch/blob/release/1.13/functorch/notebooks/whirlwind_tour.ipynb\">\n",
     "  <img style=\"width: auto\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>\n",
     "\n",


### PR DESCRIPTION
This PR:
- corrects the functorch version string (previously it said "nightly", it should instead say the version, which is 1.13).
- Adds permalinks to colabs. The colab notebooks previously linked to the ones on the master branch, instead, they should link to the ones on the release/1.13 branch.

Test Plan:
- build and tested docs locally

Fixes #ISSUE_NUMBER
