### PR TITLE
[vulkan][ez] fix always printing out a warning when retrieving the global context

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -145,9 +145,11 @@ Context* context() {
     return nullptr;
   }());
 
-  TORCH_WARN(
-      "Pytorch Vulkan Context: The global context could not be retrieved "
-      "because it failed to initialize.");
+  if (!context) {
+    TORCH_WARN(
+        "Pytorch Vulkan Context: The global context could not be retrieved "
+        "because it failed to initialize.");
+  }
 
   return context.get();
 }


### PR DESCRIPTION
Summary: D40151818 (https://github.com/pytorch/pytorch/commit/82ed5ca3401e965067fd03a6bac57978f884f715) replaces the `TORCH_CHECK` with a `TORCH_WARN` but since it does not check if the context is valid the message gets printed every time. This diff fixes that.

Test Plan:
Referring to [Pytorch Vulkan Testing Procedures](https://fb.quip.com/fZALAc9zhlcU)

On Mac:
1. `vulkan_api_test` on Mac
2. model comparison binary on Mac

On Android:
1. `vulkan_api_test` on Android
2. benchmark binary on Android

Reviewed By: salilsdesai

Differential Revision: D40266820

