### PR TITLE
Add prims.clone

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1812,7 +1812,6 @@ fake_backward_xfails = fake_tensor_stride_failing_ops | {
     "linalg.svd",
     "linalg.svdvals",
     "pca_lowrank",
-    "roll",
     "svd_lowrank",
     "sgn",
     "cholesky",

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1812,6 +1812,7 @@ fake_backward_xfails = fake_tensor_stride_failing_ops | {
     "linalg.svd",
     "linalg.svdvals",
     "pca_lowrank",
+    "roll",
     "svd_lowrank",
     "sgn",
     "cholesky",

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -600,7 +600,26 @@ conj_physical = _make_prim(
 def _clone_meta(
     input: TensorLikeType, *, memory_format: torch.memory_format = torch.preserve_format
 ) -> TensorLikeType:
-    return TensorMeta(input)
+    if memory_format != torch.preserve_format:
+        return torch.empty(
+            input.shape,
+            dtype=input.dtype,
+            layout=input.layout,
+            device=input.device,
+            requires_grad=input.requires_grad,
+            memory_format=memory_format,
+        )
+
+    # memory_format == torch.preserve_format
+    strides = utils.compute_elementwise_output_strides(input)
+    return torch.empty_strided(
+        input.shape,
+        strides,
+        dtype=input.dtype,
+        layout=input.layout,
+        device=input.device,
+        requires_grad=input.requires_grad,
+    )
 
 
 clone = _make_prim(

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -159,6 +159,7 @@ __all__ = [
     #
     # Data conversion and movement prims
     #
+    "clone",
     "convert_element_type",
     "device_put",
     "item",
@@ -185,10 +186,6 @@ __all__ = [
     "empty_strided",
     "scalar_tensor",
     "arange",
-    #
-    # Data conversion and movement Prims
-    #
-    "clone",
     #
     # Linear algebra (linalg) Prims
     #

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -186,6 +186,10 @@ __all__ = [
     "scalar_tensor",
     "arange",
     #
+    # Data conversion and movement Prims
+    #
+    "clone",
+    #
     # Linear algebra (linalg) Prims
     #
     "svd",
@@ -592,6 +596,21 @@ conj_physical = _make_prim(
     meta=_conj_physical_meta,
     impl_aten=torch._conj_physical,
     doc="Returns the physical conjugation of a complex tensor",
+    return_type=RETURN_TYPE.NEW,
+)
+
+
+def _clone_meta(
+    input: TensorLikeType, *, memory_format: torch.memory_format = torch.preserve_format
+) -> TensorLikeType:
+    return TensorMeta(input)
+
+
+clone = _make_prim(
+    schema="clone(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor",
+    meta=_clone_meta,
+    impl_aten=torch.clone,
+    doc="Returns the copy of a tensor",
     return_type=RETURN_TYPE.NEW,
 )
 

--- a/torch/_prims/nvfuser_prims.py
+++ b/torch/_prims/nvfuser_prims.py
@@ -42,6 +42,7 @@ nvprim_names = [
     "atanh",
     "cos",
     "cosh",
+    "clone",
     "bitwise_not",
     "ceil",
     "erf",
@@ -322,9 +323,14 @@ def _amin_nvfuser(
     return fd.ops.min(a, dims, keep_dims)
 
 
+def _clone_nvfuser(fd: Any, input: TensorLikeType, *, memory_format=None):
+    return fd.ops.set(input)
+
+
 _nvfuser_impls["native_batch_norm"] = _native_batch_norm_nvfuser
 _nvfuser_impls["broadcast_in_dim"] = _broadcast_in_dim_nvfuser
 _nvfuser_impls["convert_element_type"] = _convert_element_type_nvfuser
+_nvfuser_impls["clone"] = _clone_nvfuser
 _nvfuser_impls["transpose"] = _transpose_nvfuser
 _nvfuser_impls["squeeze"] = _squeeze_nvfuser
 _nvfuser_impls["view_of"] = _view_of_nvfuser

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1671,10 +1671,7 @@ def where(
 def clone(
     a: TensorLikeType, *, memory_format: torch.memory_format = torch.preserve_format
 ) -> TensorLikeType:
-    result = torch.empty_like(
-        a, requires_grad=a.requires_grad, memory_format=memory_format
-    )
-    copy_to(result, a)
+    result = prims.clone(a, memory_format=memory_format)
     return result
 
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17561,7 +17561,6 @@ python_ref_db = [
     PythonRefInfo(
         "_refs.clone",
         torch_opinfo_name="clone",
-        supports_nvfuser=False,
     ),
     #
     # View & Shape OpInfos


### PR DESCRIPTION
This simple PR adds `clone` as a primitive.
Current implementation of `clone` is not supported with nvFuser executor because of `empty_like` + `copy_to`.