### PR TITLE
Patching getitem in partitioner

### DIFF
--- a/test/test_fx_passes.py
+++ b/test/test_fx_passes.py
@@ -175,10 +175,17 @@ class TestPartitionFunctions:
         c2 = x0 + c0
         return b1, c2
 
+    @staticmethod
+    def forward13(a, b, c):
+        a0, a1, a2, a3 = a.split(1, 0)
+        b1 = a0 + b
+        c1 = a1 + c
+        return b1 + c1
+
 # A mock OperatorSupport class, where only operator.add is supported
 class MockOperatorSupport(OperatorSupport):
     def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
-        return node.op == "call_function" and node.target in {operator.add}
+        return node.op == "call_function" and node.target in {operator.add, operator.getitem}
 
 
 @instantiate_parametrized_tests
@@ -205,6 +212,9 @@ class TestFXGraphPasses(JitTestCase):
 
         # 4 not necessarily the only partition, just to verify that there's no cyclic dependency after partition
         (TestPartitionFunctions.forward12, [["add_2"], ["add_3", "add_4", "add_1"], ["add"]]),
+
+        # 5 getitem special case
+        (TestPartitionFunctions.forward13, [["add_2", "add_1", "add"]]),
     ])
     def test_partitioner(self, fn, expected_partition):
         traced = symbolic_trace(fn)

--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -42,11 +42,10 @@ class CapabilityBasedPartitioner:
         self.allows_single_node_partition = allows_single_node_partition
 
     def __is_node_supported(self, node: Node) -> bool:
-        # reject 'getitem' node since they are special cased in partitioning.
-        return
-        (
+        return (
             self.operator_support.is_node_supported(dict(self.graph_module.named_modules()), node)
             and
+            # reject 'getitem' node since they are special cased in partitioning.
             (
                 node.op != "call_function" or
                 _get_qualified_name(node.target) != "_operator.getitem"    # type: ignore[arg-type]
@@ -140,8 +139,6 @@ class CapabilityBasedPartitioner:
                 if user_node in assignment:
                     merge_candidates[assignment[user_node]] = None
 
-            # Filter out all the partitions that has dependency on other users
-            # TODO: find a better way to do this, rather than pair-wise comparision
             merge_candidates_list = list(merge_candidates.keys())
             if len(merge_candidates_list) > 1:
                 self_id = merge_candidates_list[0]

--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -42,8 +42,16 @@ class CapabilityBasedPartitioner:
         self.allows_single_node_partition = allows_single_node_partition
 
     def __is_node_supported(self, node: Node) -> bool:
-        # TODO: reject 'getitem' node since they are special cased in partitioning.
-        return self.operator_support.is_node_supported(dict(self.graph_module.named_modules()), node)
+        # reject 'getitem' node since they are special cased in partitioning.
+        return
+        (
+            self.operator_support.is_node_supported(dict(self.graph_module.named_modules()), node)
+            and
+            (
+                node.op != "call_function" or
+                _get_qualified_name(node.target) != "_operator.getitem"    # type: ignore[arg-type]
+            )
+        )
 
     def propose_partitions(self) -> List[Partition]:
         # assumptions: nodes in candidate list is sorted in topological order


### PR DESCRIPTION
1. rejecting getitem operator in backends fusion query getitem is merged in a special post partition pass, backends that takes getitem shouldn't affect the logic
2. added test for failing cases

Fixes #86698 
