### PR TITLE
[ONNX] Fix scalar_type_analysis metadata for copied constant

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1098,7 +1098,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             self.assertIn(node.scopeName(), expected_torch_script_scope_names)
 
     def test_scope_of_constants_when_combined_by_cse_pass(self):
-        LAYER_NUM = 3
+        layer_num = 3
 
         class M(torch.nn.Module):
             def __init__(self, constant):
@@ -1111,7 +1111,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
                 return x + self.constant
 
         class N(torch.nn.Module):
-            def __init__(self, layers: int = LAYER_NUM):
+            def __init__(self, layers: int = layer_num):
                 super().__init__()
                 self.layers = torch.nn.ModuleList(
                     [M(constant=torch.tensor(1.0)) for i in range(layers)]
@@ -1130,22 +1130,22 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         #       so we expect 3 constants with different scopes. The 3 constants are for the 3 layers.
         #       If CSE in exporter is improved later, this test needs to be updated.
         #       It should expect 1 constant, with same scope as root.
-        SCOPE_PREFIX = "test_utility_funs.TestUtilityFuns_opset9.test_scope_of_constants_when_combined_by_cse_pass.<locals>"
-        EXPECTED_ROOT_SCOPE_NAME = f"{SCOPE_PREFIX}.N::"
-        EXPECTED_LAYER_SCOPE_NAME = f"{SCOPE_PREFIX}.M::layers"
-        EXPECTED_CONSTANT_SCOPE_NAME = [
-            f"{EXPECTED_ROOT_SCOPE_NAME}/{EXPECTED_LAYER_SCOPE_NAME}.{i}"
-            for i in range(LAYER_NUM)
+        scope_prefix = "test_utility_funs.TestUtilityFuns_opset9.test_scope_of_constants_when_combined_by_cse_pass.<locals>"
+        expected_root_scope_name = f"{scope_prefix}.N::"
+        expected_layer_scope_name = f"{scope_prefix}.M::layers"
+        expected_constant_scope_name = [
+            f"{expected_root_scope_name}/{expected_layer_scope_name}.{i}"
+            for i in range(layer_num)
         ]
 
         constant_scope_names = []
         for node in graph.nodes():
             if node.kind() == "onnx::Constant":
                 constant_scope_names.append(node.scopeName())
-        self.assertEqual(constant_scope_names, EXPECTED_CONSTANT_SCOPE_NAME)
+        self.assertEqual(constant_scope_names, expected_constant_scope_name)
 
     def test_scope_of_nodes_when_combined_by_cse_pass(self):
-        LAYER_NUM = 3
+        layer_num = 3
 
         class M(torch.nn.Module):
             def __init__(self, constant, bias):
@@ -1161,7 +1161,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
                 return (x + self.constant) * self.bias
 
         class N(torch.nn.Module):
-            def __init__(self, layers: int = LAYER_NUM):
+            def __init__(self, layers: int = layer_num):
                 super().__init__()
 
                 self.layers = torch.nn.ModuleList(
@@ -1180,15 +1180,15 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         graph, _, _ = self._model_to_graph(
             N(), (torch.randn(2, 3)), input_names=[], dynamic_axes={}
         )
-        SCOPE_PREFIX = "test_utility_funs.TestUtilityFuns_opset9.test_scope_of_nodes_when_combined_by_cse_pass.<locals>"
-        EXPECTED_ROOT_SCOPE_NAME = f"{SCOPE_PREFIX}.N::"
-        EXPECTED_LAYER_SCOPE_NAME = f"{SCOPE_PREFIX}.M::layers"
-        EXPECTED_ADD_SCOPE_NAMES = [
-            f"{EXPECTED_ROOT_SCOPE_NAME}/{EXPECTED_LAYER_SCOPE_NAME}.0"
+        scope_prefix = "test_utility_funs.TestUtilityFuns_opset9.test_scope_of_nodes_when_combined_by_cse_pass.<locals>"
+        expected_root_scope_name = f"{scope_prefix}.N::"
+        expected_layer_scope_name = f"{scope_prefix}.M::layers"
+        expected_add_scope_names = [
+            f"{expected_root_scope_name}/{expected_layer_scope_name}.0"
         ]
-        EXPECTED_MUL_SCOPE_NAMES = [
-            f"{EXPECTED_ROOT_SCOPE_NAME}/{EXPECTED_LAYER_SCOPE_NAME}.{i}"
-            for i in range(LAYER_NUM)
+        expected_mul_scope_names = [
+            f"{expected_root_scope_name}/{expected_layer_scope_name}.{i}"
+            for i in range(layer_num)
         ]
 
         add_scope_names = []
@@ -1198,8 +1198,8 @@ class TestUtilityFuns_opset9(_BaseTestCase):
                 add_scope_names.append(node.scopeName())
             elif node.kind() == "onnx::Mul":
                 mul_scope_names.append(node.scopeName())
-        self.assertEqual(add_scope_names, EXPECTED_ADD_SCOPE_NAMES)
-        self.assertEqual(mul_scope_names, EXPECTED_MUL_SCOPE_NAMES)
+        self.assertEqual(add_scope_names, expected_add_scope_names)
+        self.assertEqual(mul_scope_names, expected_mul_scope_names)
 
     def test_aten_fallthrough(self):
         # Test aten export of op with no symbolic

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -423,6 +423,7 @@ struct TORCH_API Node {
     return scope_->namesFromRoot();
   }
 
+  // Copies the source range, scope and callstack from another node.
   Node* copyMetadata(Node* from) {
     this->setSourceRange(from->sourceRange());
     this->setScope(from->scope());

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -288,7 +288,6 @@ static void UpdateScalarTypeForInputs(
         at::Tensor val = input->node()->t(attr::value);
         at::Tensor new_val = val.to(scalar_type);
         Node* const_node = n->owningGraph()->create(onnx::Constant);
-        const_node->copyMetadata(n);
         const_node->t_(attr::value, new_val);
         const_node->insertBefore(n);
         const_node->output()->setType(TensorType::create(new_val));
@@ -297,7 +296,6 @@ static void UpdateScalarTypeForInputs(
       } else {
         Node* cast_node = n->owningGraph()->create(onnx::Cast);
         cast_node->addInput(input);
-        cast_node->copyMetadata(n);
         cast_node->i_(attr::to, onnx_type);
         cast_node->insertBefore(n);
         cast_node->output()->setType(CreateProfiledTensorTypeWithScalarType(

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -292,7 +292,7 @@ static void UpdateScalarTypeForInputs(
         const_node->t_(attr::value, new_val);
         const_node->insertBefore(n);
         const_node->output()->setType(TensorType::create(new_val));
-        const_node->copyMetadata(input->node());
+        const_node->copyMetadata(n);
         n->replaceInputWith(input, const_node->output());
       } else {
         Node* cast_node = n->owningGraph()->create(onnx::Cast);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #86648
* __->__ #86716

Fix the source of metadata for copied constant. Since the constant is being implicitly casted,
it makes more sense to assign code location and etc with the user node.
This issue was discovered in https://github.com/pytorch/pytorch/issues/86627. This PR also adds unit test coverage for scope
information of nodes when they are altered by CSE and related passes.
