### PR TITLE
Update _torch_docs / ldexp 

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5744,7 +5744,7 @@ add_docstr(
     r"""
 ldexp(input, other, *, out=None) -> Tensor
 
-Multiplies :attr:`input` by 2**:attr:`other`.
+Multiplies :attr:`input` by 2 ** :attr:`other`.
 
 .. math::
     \text{{out}}_i = \text{{input}}_i * 2^\text{{other}}_i


### PR DESCRIPTION
Fixes a typo on ldexp docstring.

https://pytorch.org/docs/master/generated/torch.ldexp.html?highlight=ldexp#torch.ldexp

<img width="976" alt="image" src="https://user-images.githubusercontent.com/2459423/195191117-15b4e1f3-dfd5-466c-b5aa-72851f0c2393.png">

https://livesphinx.herokuapp.com/