### PR TITLE
[quant] Move the order of x86 engine to avoid changing the default qe…

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -324,9 +324,9 @@ const std::vector<at::QEngine>& Context::supportedQEngines() {
 
 #ifdef USE_FBGEMM
     if (fbgemm::fbgemmSupportedCPU()) {
-      engines.push_back(at::kFBGEMM);
       // The X86 qengine is available if and only if FBGEMM is available
       engines.push_back(at::kX86);
+      engines.push_back(at::kFBGEMM);
     }
 #endif
 

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -223,13 +223,13 @@ default_reuse_input_qconfig = QConfig(activation=default_reuse_input_observer,
 Default qconfig for operators that reuse the observers from input Tensor, e.g. reshape
 """
 
-def get_default_qconfig(backend='x86', version=0):
+def get_default_qconfig(backend='fbgemm', version=0):
     """
     Returns the default PTQ qconfig for the specified backend.
 
     Args:
       * `backend`: a string representing the target backend. Currently supports
-        `x86` (default), `fbgemm`, `qnnpack` and `onednn`.
+        `x86`, `fbgemm` (default), `qnnpack` and `onednn`.
 
     Return:
         qconfig
@@ -298,13 +298,13 @@ default_embedding_qat_qconfig = QConfig(activation=NoopObserver.with_args(dtype=
 default_embedding_qat_qconfig_4bit = QConfig(activation=NoopObserver.with_args(dtype=torch.float32),
                                              weight=default_embedding_fake_quant_4bit)
 
-def get_default_qat_qconfig(backend='x86', version=1):
+def get_default_qat_qconfig(backend='fbgemm', version=1):
     """
     Returns the default QAT qconfig for the specified backend.
 
     Args:
       * `backend`: a string representing the target backend. Currently supports
-        `x86`(default), `fbgemm`, `qnnpack` and `onednn`.
+        `x86`, `fbgemm` (default), `qnnpack` and `onednn`.
       * `version`: version, for backwards compatibility. Can be `None` or `1`.
 
     Return:
@@ -392,13 +392,13 @@ default_per_channel_symmetric_qnnpack_qat_qconfig = QConfig(
                                                        eps=2 ** -12),
     weight=fused_per_channel_wt_fake_quant_range_neg_127_to_127)
 
-def get_default_qconfig_dict(backend='x86', version=0):
+def get_default_qconfig_dict(backend='fbgemm', version=0):
     warnings.warn(
         "torch.ao.quantization.get_default_qconfig_dict is deprecated and will be removed in "
         "a future version. Please use torch.ao.quantization.get_default_qconfig_mapping instead.")
     return torch.ao.quantization.get_default_qconfig_mapping(backend, version).to_dict()
 
-def get_default_qat_qconfig_dict(backend='x86', version=1):
+def get_default_qat_qconfig_dict(backend='fbgemm', version=1):
     warnings.warn(
         "torch.ao.quantization.get_default_qat_qconfig_dict is deprecated and will be removed in "
         "a future version. Please use torch.ao.quantization.get_default_qat_qconfig_mapping instead.")

--- a/torch/ao/quantization/qconfig_mapping.py
+++ b/torch/ao/quantization/qconfig_mapping.py
@@ -120,25 +120,25 @@ def _get_default_qconfig_mapping(is_qat: bool, backend: str, version: int) -> QC
 
     return qconfig_mapping
 
-def get_default_qconfig_mapping(backend="x86", version=0) -> QConfigMapping:
+def get_default_qconfig_mapping(backend="fbgemm", version=0) -> QConfigMapping:
     """
     Return the default QConfigMapping for post training quantization.
 
     Args:
       * ``backend`` : the quantization backend for the default qconfig mapping, should be
-         one of ["x86" (default), "fbgemm", "qnnpack", "onednn"]
+         one of ["x86", "fbgemm" (default), "qnnpack", "onednn"]
       * ``version`` : the version for the default qconfig mapping
     """
     # TODO: add assert for backend choices
     return _get_default_qconfig_mapping(False, backend, version)
 
-def get_default_qat_qconfig_mapping(backend="x86", version=1) -> QConfigMapping:
+def get_default_qat_qconfig_mapping(backend="fbgemm", version=1) -> QConfigMapping:
     """
     Return the default QConfigMapping for quantization aware training.
 
     Args:
       * ``backend`` : the quantization backend for the default qconfig mapping, should be
-         one of ["x86" (default), "fbgemm", "qnnpack", "onednn"]
+         one of ["x86", "fbgemm" (default), "qnnpack", "onednn"]
       * ``version`` : the version for the default qconfig mapping
     """
     return _get_default_qconfig_mapping(True, backend, version)


### PR DESCRIPTION
…ngine (#86631)

since the default qengine is the last element of the engine in supported_engines list, adding x86 qengine in the end of the list changes the default quantized engine as well. this PR will be a short term fix to revert the changes. We have an issue here to track the proper fix: https://github.com/pytorch/pytorch/issues/86404

Motivation:
a meta internal team found that the inference failed in onednn prepacking with error: "could not create a primitive descriptor for a reorder primitive." in a COPPER_LAKE machine, we are working with intel to repro and fix the problem. in the mean time, we'll revert the changes of default option back to fbgemm
Pull Request resolved: https://github.com/pytorch/pytorch/pull/86631
Approved by: https://github.com/vkuzo

Fixes #ISSUE_NUMBER
