### PR TITLE
[Pytorch][Vulkan] Update spv generation script to embed shader parameters

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Types.h
+++ b/aten/src/ATen/native/vulkan/api/Types.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+enum class StorageType {
+  Buffer,
+  Image,
+  Unknown
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/tools/gen_vulkan_spv.py
+++ b/tools/gen_vulkan_spv.py
@@ -8,10 +8,20 @@ import re
 import sys
 import subprocess
 from torchgen.code_template import CodeTemplate
+from dataclasses import dataclass
+from typing import List
 
 H_NAME = "spv.h"
 CPP_NAME = "spv.cpp"
 DEFAULT_ENV = {"precision": "highp", "format": "rgba32f"}
+
+
+@dataclass
+class ShaderInfo:
+    tile_size: List[int]
+    layouts: List[str]
+    weight_storage_type: str = ""
+    weight_storage_layout : str = ""
 
 def getName(filePath):
     return os.path.basename(filePath).replace("/", "_").replace(".", "_")
@@ -20,6 +30,33 @@ def isDescriptorLine(lineStr):
     descriptorLineId = r"^layout\(set"
     return re.search(descriptorLineId, lineStr)
 
+def isTileSizeLine(lineStr):
+    tile_size_id = r"^\/\/ TILE_SIZE = \("
+    return re.search(tile_size_id, lineStr)
+
+def findTileSizes(lineStr):
+    tile_size_id = r"^\/\/ TILE_SIZE = \(([0-9]+), ([0-9]+), ([0-9]+)\)"
+    matches = re.search(tile_size_id, lineStr)
+    return [int(matches.group(1)), int(matches.group(2)), int(matches.group(3))]
+
+def isWeightStorageTypeLine(lineStr):
+    weight_storage_id = r"^\/\/ WEIGHT_STORAGE = "
+    return re.search(weight_storage_id, lineStr)
+
+def getWeightStorageType(lineStr):
+    weight_storage_id = r"^\/\/ WEIGHT_STORAGE = ([a-zA-Z]+)"
+    matches = re.search(weight_storage_id, lineStr)
+    return matches.group(1)
+
+def isWeightStorageLayoutLine(lineStr):
+    weight_storage_id = r"^\/\/ WEIGHT_STORAGE_LAYOUT = "
+    return re.search(weight_storage_id, lineStr)
+
+def getWeightStorageLayout(lineStr):
+    weight_storage_id = r"^\/\/ WEIGHT_STORAGE_LAYOUT = ([a-zA-Z0-9,]+)"
+    matches = re.search(weight_storage_id, lineStr)
+    return matches.group(1)
+
 typeIdMapping = {
     r"image[123]D\b": "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
     r"sampler[123]D\b": "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
@@ -27,21 +64,30 @@ typeIdMapping = {
     r"\buniform\b.*\bBlock\b": "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER",
 }
 
+storageTypeToEnum = {
+    "IMAGE" : "api::StorageType::Image",
+    "BUFFER" : "api::StorageType::Buffer",
+}
+
 def determineDescriptorType(lineStr):
     for identifier, typeNum in typeIdMapping.items():
         if re.search(identifier, lineStr):
             return typeNum
 
-    raise Exception("Could not identify descriptor type of line: {}".format(lineStr))
-
-def getLayout(srcFilePath):
-    layout = []
+def getShaderInfo(srcFilePath):
+    shader_info = ShaderInfo([], [], "", "")
     with open(srcFilePath, 'r') as srcFile:
         for line in srcFile:
             if isDescriptorLine(line):
-                layout.append(determineDescriptorType(line))
+                shader_info.layouts.append(determineDescriptorType(line))
+            if isTileSizeLine(line):
+                shader_info.tile_size = findTileSizes(line)
+            if isWeightStorageTypeLine(line):
+                shader_info.weight_storage_type = getWeightStorageType(line)
+            if isWeightStorageLayoutLine(line):
+                shader_info.weight_storage_layout = getWeightStorageLayout(line)
 
-    return layout
+    return shader_info
 
 def genCppH(hFilePath, cppFilePath, srcDirPath, glslcPath, tmpDirPath, env):
     print("hFilePath:{} cppFilePath:{} srcDirPath:{} glslcPath:{} tmpDirPath:{}".format(
@@ -85,6 +131,8 @@ def genCppH(hFilePath, cppFilePath, srcDirPath, glslcPath, tmpDirPath, env):
     h = "#pragma once\n"
     h += "#include <stdint.h>\n"
     h += "#include <vector>\n"
+    h += "#include <string>\n"
+    h += "#include <ATen/native/vulkan/api/Types.h>\n"
     h += "#include <ATen/native/vulkan/api/vk_api.h>"
 
     nsbegin = "\nnamespace at {\nnamespace native {\nnamespace vulkan {\n"
@@ -101,7 +149,7 @@ def genCppH(hFilePath, cppFilePath, srcDirPath, glslcPath, tmpDirPath, env):
         h += "extern const uint32_t {}[];\n".format(name)
         h += "extern const uint32_t {};\n".format(name_len)
 
-        layout = getLayout(srcPath)
+        shader_info = getShaderInfo(srcPath)
         name_layout = name + "_layout"
         h += "extern const std::vector<VkDescriptorType> {};\n".format(name_layout)
 
@@ -117,9 +165,32 @@ def genCppH(hFilePath, cppFilePath, srcDirPath, glslcPath, tmpDirPath, env):
 
         # Add layout
         cpp += "const std::vector<VkDescriptorType> {} = {{\n".format(name_layout)
-        for descriptor in layout:
+        for descriptor in shader_info.layouts:
             cpp += "  {},\n".format(descriptor)
         cpp += "};\n"
+
+        # Add tile size
+        if (len(shader_info.tile_size) > 0):
+            name_tile_size = name + "_tile_size"
+            h += "extern const std::vector<uint32_t> {};\n".format(name_tile_size)
+            cpp += "const std::vector<uint32_t> {} = {{\n".format(name_tile_size)
+            for s in shader_info.tile_size:
+                cpp += "  {},\n".format(s)
+            cpp += "};\n"
+
+        # Add weight type
+        if (shader_info.weight_storage_type != ""):
+            name_weight_storage_type = name + "_weight_storage_type"
+            h += "extern const api::StorageType {};\n".format(name_weight_storage_type)
+            cpp += "const api::StorageType {} = \n".format(name_weight_storage_type)
+            cpp += "  {};\n".format(storageTypeToEnum[shader_info.weight_storage_type])
+
+        # Add weight type
+        if (shader_info.weight_storage_layout != ""):
+            name_weight_storage_layout = name + "_weight_storage_layout"
+            h += "extern const std::string {};\n".format(name_weight_storage_layout)
+            cpp += "const std::string {} = ".format(name_weight_storage_layout)
+            cpp += "  \"{}\";\n".format(shader_info.weight_storage_layout)
 
     cpp += nsend
     h += nsend


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This diffs adds shader parameters such as tile size, weight storage type and
format to the generated spv.cpp file.
This is used in ShaderInfo struct that ops such as convolution will use to
determine, the workgroup size  and how to pack weights.

Differential Revision: [D40280337](https://our.internmc.facebook.com/intern/diff/D40280337/)