### PR TITLE
[Pytorch][vulkan] Generate shader with parameters

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Common.h
+++ b/aten/src/ATen/native/vulkan/api/Common.h
@@ -20,6 +20,13 @@
     CONCAT_LITERALS(vulkan., name), name##_spv, name##_spv_len, \
         name##_spv_layout                                       \
   }
+#define VK_SHADER(name)                                         \
+  ::at::native::vulkan::api::ShaderInfo {                       \
+    CONCAT_LITERALS(vulkan., name), name##_spv, name##_spv_len, \
+        name##_spv_layout, name##_spv_tile_size,                \
+        name##_spv_weight_storage_type,                         \
+        name##_spv_weight_storage_layout,                       \
+  }
 #endif /* USE_VULKAN_SHADERC_RUNTIME */
 
 /*

--- a/aten/src/ATen/native/vulkan/api/Shader.cpp
+++ b/aten/src/ATen/native/vulkan/api/Shader.cpp
@@ -50,6 +50,23 @@ ShaderSource::ShaderSource(
       kernel_name{std::move(name)},
       kernel_layout{layout} {}
 
+ShaderInfo::ShaderInfo(
+    std::string name,
+    const uint32_t* const spirv_bin,
+    const uint32_t size,
+    const std::vector<VkDescriptorType>& layout,
+    const std::vector<uint32_t>& tile_size,
+    const StorageType weight_storage_type,
+    const std::string weight_storage_layout)
+    : shader_src(name, spirv_bin, size, layout),
+      tile_size(tile_size),
+      weight_storage_type(weight_storage_type),
+      weight_storage_layout(weight_storage_layout) {
+        for (uint64_t i = 0; i < tile_size.size(); ++i) {
+          shader_src.out_tile_size.data[i] = tile_size[i];
+        }
+    }
+
 bool operator==(const ShaderSource& _1, const ShaderSource& _2) {
   if (_1.type != _2.type) {
     return false;

--- a/aten/src/ATen/native/vulkan/api/Shader.h
+++ b/aten/src/ATen/native/vulkan/api/Shader.h
@@ -3,6 +3,7 @@
 #ifdef USE_VULKAN_API
 
 #include <ATen/native/vulkan/api/Common.h>
+#include <ATen/native/vulkan/api/Types.h>
 #include <ATen/native/vulkan/api/Utils.h>
 #include <c10/util/hash.h>
 
@@ -70,6 +71,24 @@ struct ShaderSource final {
 };
 
 bool operator==(const ShaderSource& _1, const ShaderSource& _2);
+
+struct ShaderInfo final {
+  ShaderSource shader_src;
+  c10::SmallVector<uint32_t, 4> tile_size;
+  StorageType weight_storage_type{StorageType::Unknown};
+  std::string weight_storage_layout;
+
+  explicit ShaderInfo() = default;
+  explicit ShaderInfo(std::string, const char*);
+  explicit ShaderInfo(
+      std::string,
+      const uint32_t*,
+      const uint32_t,
+      const std::vector<VkDescriptorType>&,
+      const std::vector<uint32_t>& tile_size,
+      const StorageType weight_storage_type,
+      const std::string weight_storage_layout);
+};
 
 class ShaderModule final {
  public:

--- a/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
@@ -2,6 +2,10 @@
 #define PRECISION $precision
 #define FORMAT $format
 
+// TILE_SIZE = (1, 1, 1)
+// WEIGHT_STORAGE = IMAGE
+// WEIGHT_STORAGE_LAYOUT = OC4,H,IC4,W,4ic,4oc
+
 layout(std430) buffer;
 
 /*

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_dw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_dw.glsl
@@ -2,6 +2,11 @@
 #define PRECISION $precision
 #define FORMAT $format
 
+// TILE_SIZE = (1, 1, 1)
+// WEIGHT_STORAGE = IMAGE
+// WEIGHT_STORAGE_LAYOUT = OC4,H,IC,W,4oc
+// Note that for DW kernel IC = 1 so the weight layout is really OC4, H, W, 4oc
+
 layout(std430) buffer;
 
 /*

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_pw_2x2.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_pw_2x2.glsl
@@ -2,6 +2,10 @@
 #define PRECISION $precision
 #define FORMAT $format
 
+// TILE_SIZE = (2, 2, 1)
+// WEIGHT_STORAGE = IMAGE
+// WEIGHT_STORAGE_LAYOUT = OC4,IC4,4ic,4oc
+
 layout(std430) buffer;
 
 /*

--- a/aten/src/ATen/native/vulkan/glsl/conv_transpose2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv_transpose2d.glsl
@@ -2,6 +2,10 @@
 #define PRECISION $precision
 #define FORMAT $format
 
+// TILE_SIZE = (1, 1, 1)
+// WEIGHT_STORAGE = IMAGE
+// WEIGHT_STORAGE_LAYOUT = OC4,H,W,IC,4oc
+
 layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */

--- a/aten/src/ATen/native/vulkan/glsl/quantized_conv2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_conv2d.glsl
@@ -2,6 +2,10 @@
 #define PRECISION $precision
 #define FORMAT $format
 
+// TILE_SIZE = (1, 1, 1)
+// WEIGHT_STORAGE = IMAGE
+// WEIGHT_STORAGE_LAYOUT = OC4,H,IC4,W,4ic,4oc
+
 layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */

--- a/aten/src/ATen/native/vulkan/glsl/quantized_conv2d_dw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_conv2d_dw.glsl
@@ -2,6 +2,11 @@
 #define PRECISION $precision
 #define FORMAT $format
 
+// TILE_SIZE = (1, 1, 1)
+// WEIGHT_STORAGE = IMAGE
+// WEIGHT_STORAGE_LAYOUT = OC4,H,IC,W,4oc
+// Note that for DW kernel IC = 1 so the weight layout is really OC4, H, W, 4oc
+
 layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */

--- a/aten/src/ATen/native/vulkan/glsl/quantized_conv2d_pw_2x2.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_conv2d_pw_2x2.glsl
@@ -2,6 +2,10 @@
 #define PRECISION $precision
 #define FORMAT $format
 
+// TILE_SIZE = (2, 2, 1)
+// WEIGHT_STORAGE = IMAGE
+// WEIGHT_STORAGE_LAYOUT = OC4,IC4,4ic,4oc
+
 /*
  * Output Image
  */

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -277,7 +277,7 @@ static api::ShaderSource get_shader(
     const Conv2dMethod method,
     const bool transposed,
     const bool quantized) {
-  api::ShaderSource shader;
+  api::ShaderInfo shader;
 
   if (quantized) {
     if (transposed) {
@@ -286,39 +286,36 @@ static api::ShaderSource get_shader(
 
     switch (method) {
       case Conv2dSlidingWindow:
-        shader = VK_KERNEL(quantized_conv2d);
-        return shader;
+        shader = VK_SHADER(quantized_conv2d);
+        break;
       case Conv2dDepthwise:
-        shader = VK_KERNEL(quantized_conv2d_dw);
-        return shader;
+        shader = VK_SHADER(quantized_conv2d_dw);
+        break;
       case Conv2dPointwise:
-        shader = VK_KERNEL(quantized_conv2d_pw_2x2);
-        // Set explicitly for now. In the future, this will be set automatically
-        // by shader codegen.
-        shader.out_tile_size = {2u, 2u, 1u};
-        return shader;
+        shader = VK_SHADER(quantized_conv2d_pw_2x2);
+        break;
+      // todo fail for quantized transposed conv
     }
+    return shader.shader_src;
   }
 
   if (transposed) {
-    shader = VK_KERNEL(conv_transpose2d);
-    return shader;
+    shader = VK_SHADER(conv_transpose2d);
+    return shader.shader_src;
   }
 
   switch (method) {
     case Conv2dSlidingWindow:
-      shader = VK_KERNEL(conv2d);
-      return shader;
+      shader = VK_SHADER(conv2d);
+      break;
     case Conv2dDepthwise:
-      shader = VK_KERNEL(conv2d_dw);
-      return shader;
+      shader = VK_SHADER(conv2d_dw);
+      break;
     case Conv2dPointwise:
-      shader = VK_KERNEL(conv2d_pw_2x2);
-      // Set explicitly for now. In the future, this will be set automatically
-      // by shader codegen.
-      shader.out_tile_size = {2u, 2u, 1u};
-      return shader;
+      shader = VK_SHADER(conv2d_pw_2x2);
+      break;
   }
+  return shader.shader_src;
 }
 
 //


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #86740
* #86739
* __->__ #86738
* #86737

Parametsr such as tile size and weight type and format is embedded within the
shader code. This is used to generate ShaderInfo.

For now we will maintain both ShaderSrc and ShaderInfo so as to transition from
VK_KERNEL to VK_SHADER incremental. Otherwise we will have to switch multiple
of them at the same time.

Differential Revision: [D40280338](https://our.internmc.facebook.com/intern/diff/D40280338/)