### PR TITLE
[ONNX] Reland: Update training state logic to support ScriptedModule

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1162,10 +1162,7 @@ class TestUtilityFuns(_BaseTestCase):
         #       so we expect 3 constants with different scopes. The 3 constants are for the 3 layers.
         #       If CSE in exporter is improved later, this test needs to be updated.
         #       It should expect 1 constant, with same scope as root.
-        scope_prefix = (
-            f"test_utility_funs.TestUtilityFuns_opset{self.opset_version}."
-            "test_scope_of_constants_when_combined_by_cse_pass.<locals>"
-        )
+        scope_prefix = "test_utility_funs.TestUtilityFuns.test_scope_of_constants_when_combined_by_cse_pass.<locals>"
         expected_root_scope_name = f"{scope_prefix}.N::"
         expected_layer_scope_name = f"{scope_prefix}.M::layers"
         expected_constant_scope_name = [
@@ -1215,10 +1212,7 @@ class TestUtilityFuns(_BaseTestCase):
         graph, _, _ = self._model_to_graph(
             N(), (torch.randn(2, 3)), input_names=[], dynamic_axes={}
         )
-        scope_prefix = (
-            f"test_utility_funs.TestUtilityFuns_opset{self.opset_version}."
-            "test_scope_of_nodes_when_combined_by_cse_pass.<locals>"
-        )
+        scope_prefix = "test_utility_funs.TestUtilityFuns.test_scope_of_nodes_when_combined_by_cse_pass.<locals>"
         expected_root_scope_name = f"{scope_prefix}.N::"
         expected_layer_scope_name = f"{scope_prefix}.M::layers"
         expected_add_scope_names = [

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1162,7 +1162,10 @@ class TestUtilityFuns(_BaseTestCase):
         #       so we expect 3 constants with different scopes. The 3 constants are for the 3 layers.
         #       If CSE in exporter is improved later, this test needs to be updated.
         #       It should expect 1 constant, with same scope as root.
-        scope_prefix = f"test_utility_funs.TestUtilityFuns_opset{self.opset_version}.test_scope_of_constants_when_combined_by_cse_pass.<locals>"
+        scope_prefix = (
+            f"test_utility_funs.TestUtilityFuns_opset{self.opset_version}."
+            "test_scope_of_constants_when_combined_by_cse_pass.<locals>"
+        )
         expected_root_scope_name = f"{scope_prefix}.N::"
         expected_layer_scope_name = f"{scope_prefix}.M::layers"
         expected_constant_scope_name = [
@@ -1212,7 +1215,10 @@ class TestUtilityFuns(_BaseTestCase):
         graph, _, _ = self._model_to_graph(
             N(), (torch.randn(2, 3)), input_names=[], dynamic_axes={}
         )
-        scope_prefix = f"test_utility_funs.TestUtilityFuns_opset{self.opset_version}.test_scope_of_nodes_when_combined_by_cse_pass.<locals>"
+        scope_prefix = (
+            f"test_utility_funs.TestUtilityFuns_opset{self.opset_version}."
+            "test_scope_of_nodes_when_combined_by_cse_pass.<locals>"
+        )
         expected_root_scope_name = f"{scope_prefix}.N::"
         expected_layer_scope_name = f"{scope_prefix}.M::layers"
         expected_add_scope_names = [

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -4,6 +4,7 @@ import copy
 import functools
 import io
 from typing import Callable
+import warnings
 
 import onnx
 import parameterized
@@ -157,8 +158,6 @@ class TestUtilityFuns(_BaseTestCase):
             self.assertFalse(torch.onnx.is_in_onnx_export())
 
     def test_validate_dynamic_axes_invalid_input_output_name(self):
-        import warnings
-
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             utils._validate_dynamic_axes(

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -3,8 +3,8 @@
 import copy
 import functools
 import io
-from typing import Callable
 import warnings
+from typing import Callable
 
 import onnx
 import parameterized
@@ -19,8 +19,7 @@ from pytorch_test_common import (
     skipIfUnsupportedMaxOpsetVersion,
     skipIfUnsupportedMinOpsetVersion,
 )
-from torch.onnx import OperatorExportTypes, TrainingMode, utils
-from torch.onnx import _constants
+from torch.onnx import _constants, OperatorExportTypes, TrainingMode, utils
 from torch.onnx._globals import GLOBALS
 from torch.onnx.symbolic_helper import _unpack_list, parse_args
 from torch.testing._internal import common_utils

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1162,7 +1162,7 @@ class TestUtilityFuns(_BaseTestCase):
         #       so we expect 3 constants with different scopes. The 3 constants are for the 3 layers.
         #       If CSE in exporter is improved later, this test needs to be updated.
         #       It should expect 1 constant, with same scope as root.
-        scope_prefix = "test_utility_funs.TestUtilityFuns_opset9.test_scope_of_constants_when_combined_by_cse_pass.<locals>"
+        scope_prefix = f"test_utility_funs.TestUtilityFuns_opset{self.opset_version}.test_scope_of_constants_when_combined_by_cse_pass.<locals>"
         expected_root_scope_name = f"{scope_prefix}.N::"
         expected_layer_scope_name = f"{scope_prefix}.M::layers"
         expected_constant_scope_name = [
@@ -1212,7 +1212,7 @@ class TestUtilityFuns(_BaseTestCase):
         graph, _, _ = self._model_to_graph(
             N(), (torch.randn(2, 3)), input_names=[], dynamic_axes={}
         )
-        scope_prefix = "test_utility_funs.TestUtilityFuns_opset9.test_scope_of_nodes_when_combined_by_cse_pass.<locals>"
+        scope_prefix = f"test_utility_funs.TestUtilityFuns_opset{self.opset_version}.test_scope_of_nodes_when_combined_by_cse_pass.<locals>"
         expected_root_scope_name = f"{scope_prefix}.N::"
         expected_layer_scope_name = f"{scope_prefix}.M::layers"
         expected_add_scope_names = [

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -90,7 +90,7 @@ def select_model_mode_for_export(model, mode: _C_onnx.TrainingMode):
         )
     originally_training: bool = False
 
-    if not isinstance(model, torch.jit.ScriptFunction):
+    if hasattr(model, "training"):
         originally_training = model.training
 
         # ONNX opset 12 has better support for training amenable models, with updated
@@ -119,10 +119,7 @@ def select_model_mode_for_export(model, mode: _C_onnx.TrainingMode):
     try:
         yield
     finally:
-        if not (
-            isinstance(model, torch.jit.ScriptFunction)
-            or mode == _C_onnx.TrainingMode.PRESERVE
-        ):
+        if hasattr(model, "training") and not mode == _C_onnx.TrainingMode.PRESERVE:
             model.train(originally_training)
 
 


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/issues/86325, it was reported that ScriptedModule do not have a training attribute and will fail export because we don't expect them as input.

Also

- Parameterized the test_util_funs test

Thanks @borisfom for the suggestion!

Fixes #86325
