### PR TITLE
Skip chalf.mean in  test_reductions_large_half_tensors

### DIFF
--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -3392,12 +3392,10 @@ as the input tensor excluding its innermost dimension'):
         expected = torch.tensor(0, device=device, dtype=dtype)
         self.assertEqual(torch.sum(t), expected)
 
-        is_rocm_or_win_and_chalf = (TEST_WITH_ROCM or IS_WINDOWS) and dtype is torch.chalf
-        # On Rocm/Windows:
-        # RuntimeError: "mean_cuda" not implemented for 'ComplexHalf'
+        # mean_cuda is not implemented for ComplexHalf
         err_msg = "not implemented for 'ComplexHalf'"
         ctx = self.assertRaisesRegex(
-            RuntimeError, err_msg) if is_rocm_or_win_and_chalf else contextlib.nullcontext()
+            RuntimeError, err_msg) if dtype is torch.chalf else contextlib.nullcontext()
         with ctx:
             self.assertEqual(torch.mean(t), expected)
 

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -18,7 +18,7 @@ from torch.testing._internal.common_dtype import (
     integral_types_and, floating_and_complex_types_and, all_types_and, all_types,
 )
 from torch.testing._internal.common_utils import (
-    TEST_WITH_ROCM, TestCase, run_tests, skipIfNoSciPy, slowTest, torch_to_numpy_dtype_dict,
+    TestCase, run_tests, skipIfNoSciPy, slowTest, torch_to_numpy_dtype_dict,
     IS_WINDOWS)
 from torch.testing._internal.common_device_type import (
     OpDTypes, expectedFailureMeta, instantiate_device_type_tests, onlyCPU, dtypes, dtypesIfCUDA, dtypesIfCPU,


### PR DESCRIPTION
As `mean_reduce` is not implemented for complex half

Fixes https://github.com/pytorch/pytorch/issues/86743 and unblock A10G testing

