### PR TITLE
set the correct size of aten tensor in presence of mkldnn padding

### DIFF
--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -248,7 +248,8 @@ Operation createUnaryOp(
     // tensor's physical size could be bigger than a logical one
     // `a_it.get_desc().get_size()` returns the real physical size (in bytes)
     // we use it to compute `nelem` for `aten` ops
-    auto nelem = a_it.get_desc().get_size() / elementSize(a.scalar_type());
+    auto nelem = static_cast<int64_t>(
+        a_it.get_desc().get_size() / elementSize(a.scalar_type()));
     // we also wrap `a` storage into an aten tensor
     auto in_aten =
         at::from_blob(mkldnn_raw_data, {nelem}, a_options_with_strided);

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -244,9 +244,14 @@ Operation createUnaryOp(
     auto a_it = at::native::itensor_from_mkldnn(a);
     auto mkldnn_raw_data = a_it.get_data_handle();
     auto a_options_with_strided = a.options().layout(c10::kStrided);
+
+    // tensor's physical size could be bigger than a logical one
+    // `a_it.get_desc().get_size()` returns the real physical size (in bytes)
+    // we use it to compute `nelem` for `aten` ops
+    auto nelem = a_it.get_desc().get_size() / elementSize(a.scalar_type());
     // we also wrap `a` storage into an aten tensor
     auto in_aten =
-        at::from_blob(mkldnn_raw_data, {a.numel()}, a_options_with_strided);
+        at::from_blob(mkldnn_raw_data, {nelem}, a_options_with_strided);
 
     auto out_raw_data = mkldnn_raw_data;
     auto out = a;
@@ -263,12 +268,9 @@ Operation createUnaryOp(
       out_raw_data = at::native::itensor_from_mkldnn(out).get_data_handle();
     }
 
-    // tensor's physical size could be bigger than a logical one
-    // `a_it.get_desc().get_size()` returns the real physical size (in bytes)
-    // we use it to compute `nelem` for `aten` ops
     TORCH_INTERNAL_ASSERT(
         a_it.get_desc().get_size() % elementSize(a.scalar_type()) == 0);
-    auto nelem = a_it.get_desc().get_size() / elementSize(a.scalar_type());
+
     auto out_aten = at::from_blob(
         out_raw_data, {static_cast<int64_t>(nelem)}, a_options_with_strided);
     aten_op(out_aten, in_aten);


### PR DESCRIPTION
This fixes https://github.com/pytorch/pytorch/issues/86556