### PR TITLE
Allow PrivateUse1 backends to not have Storage (#86557)

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -1491,10 +1491,19 @@ void TensorIteratorBase::build(TensorIteratorConfig& config) {
 
   if (is_meta_) return;
 
+  auto has_storage = true;
+  for (auto& op : operands_) {
+    has_storage &= op.tensor_base().has_storage();
+  }
+  auto privateuse1_without_storage =
+     common_device_.type() == DeviceType::PrivateUse1 &&
+     !has_storage;
+
   // XLA and lazy tensors don't have storage, so they don't have an underlying data pointer.
   // Nothing beyond this point is important for meta functions, so it's fine to exit early here.
   // Extend the condition to ORT tesnors as ORT tensors also don't have storage.
-  if (common_device_.type() == DeviceType::XLA  ||
+  if (privateuse1_without_storage  ||
+      common_device_.type() == DeviceType::XLA  ||
       common_device_.type() == DeviceType::IPU  ||
       common_device_.type() == DeviceType::Lazy ||
       common_device_.type() == DeviceType::ORT  ||

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -115,6 +115,7 @@ class Tensor(torch._C._TensorBase):
             if (
                 self.is_sparse
                 or self.device.type in ["lazy", "xla", "mps", "ort", "meta", "hpu"]
+                or (self.storage is None and self.device.type == "privateuseone")
                 or (type(self) is not Tensor and self.data_ptr() == 0)
             ):
                 new_tensor = self.clone()
@@ -270,7 +271,9 @@ class Tensor(torch._C._TensorBase):
         # 2. Python list is not a good fit due to performance reason.
         #    `tolist()` converts every single element in the tensor into python objects
         #    and serialize them one by one.
-        if self.device.type in ["xla", "ort", "hpu"]:
+        if self.device.type in ["xla", "ort", "hpu"] or (
+            self.storage is None and self.device.type == "privateuseone"
+        ):
             # Convert BFloat16 tesors to Float32 before conversion to numpy, as numpy doesn't
             # support BFloat16. The rebuild tensor from numpy takes in the original self.dtype,
             # this would reconstruct the BFloat16 tensor from numpy.

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -111,11 +111,13 @@ class Tensor(torch._C._TensorBase):
             # doesn't work because of
             # https://github.com/pytorch/pytorch/issues/47442
             # Update the test in test_serialization if you remove 'meta' from here
-
             if (
                 self.is_sparse
                 or self.device.type in ["lazy", "xla", "mps", "ort", "meta", "hpu"]
-                or (self.storage is None and self.device.type == "privateuseone")
+                or (
+                    not torch._C._has_storage(self)
+                    and self.device.type == "privateuseone"
+                )
                 or (type(self) is not Tensor and self.data_ptr() == 0)
             ):
                 new_tensor = self.clone()
@@ -272,7 +274,7 @@ class Tensor(torch._C._TensorBase):
         #    `tolist()` converts every single element in the tensor into python objects
         #    and serialize them one by one.
         if self.device.type in ["xla", "ort", "hpu"] or (
-            self.storage is None and self.device.type == "privateuseone"
+            not torch._C._has_storage(self) and self.device.type == "privateuseone"
         ):
             # Convert BFloat16 tesors to Float32 before conversion to numpy, as numpy doesn't
             # support BFloat16. The rebuild tensor from numpy takes in the original self.dtype,


### PR DESCRIPTION
This is cherry-pick of https://github.com/pytorch/pytorch/pull/86557 to enable the DirectML out-of-tree plugin in 1.13.

Link to landed master PR (if applicable): https://github.com/pytorch/pytorch/pull/86557, https://github.com/pytorch/pytorch/pull/86845
Criteria Category: Critical fixes for enabling the DirectML out-of-tree backend plugin in 1.13.