### PR TITLE
[FSDP] `summon_full_params()` in default stream; clean up streams

### DIFF
--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -304,6 +304,7 @@ class FlatParamHandle:
         self._use_orig_params = use_orig_params
         self._training_state = HandleTrainingState.IDLE
         self._debug_level = dist.get_debug_level()
+        self._computation_stream = torch.cuda.current_stream()
         self._init_flat_param(params, module, use_orig_params)
         self._use_unsharded_views(as_params=False)
 
@@ -1070,7 +1071,7 @@ class FlatParamHandle:
         self._check_on_compute_device(unsharded_flat_param)
         # Do not free the memory until all ops in the current stream finish
         unsharded_flat_param.record_stream(
-            cast(torch._C.Stream, torch.cuda.current_stream())
+            cast(torch._C.Stream, self._computation_stream)
         )
         _free_storage(unsharded_flat_param)
 

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -2023,12 +2023,12 @@ class FullyShardedDataParallel(nn.Module):
         """
         if not self._is_root:
             return
-        default_stream = self._streams["computation"]
-        self._streams["unshard"].wait_stream(default_stream)
-        # Having the pre-all-gather stream wait for the default stream even if
-        # we do not leverage the pre-all-gather stream is tolerable since this
-        # only runs once per iteration
-        self._streams["pre_unshard"].wait_stream(default_stream)
+        computation_stream = self._streams["computation"]
+        self._streams["unshard"].wait_stream(computation_stream)
+        # Having the pre-all-gather stream wait for the computation stream even
+        # if we do not leverage the pre-all-gather stream is tolerable since
+        # this only runs once per iteration
+        self._streams["pre_unshard"].wait_stream(computation_stream)
 
     def _prefetch_handles(
         self,
@@ -3442,7 +3442,7 @@ class FullyShardedDataParallel(nn.Module):
             if not self._sync_gradients:
                 return
 
-            # Wait for all ops in the default stream (e.g. gradient
+            # Wait for all ops in the computation stream (e.g. gradient
             # computation) to finish before reduce-scattering the gradient
             self._streams["post_backward"].wait_stream(self._streams["computation"])
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#86811 [FSDP] `summon_full_params()` in default stream; clean up streams**

This has `summon_full_params()` use the computation stream. It also cleans up the stream variables to be more clear.

This time around, I decided to rename the "all_gather" stream to the "unshard" stream to emphasize that it includes both the actual all-gather op but also the corresponding memory allocations (and also now the unflattening as well). (A similar reasoning applies for the "pre-all-gather" stream becoming the "pre-unshard" stream.)