### PR TITLE
Add `weights_only` option to `torch.load`

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -148,17 +148,17 @@ class SerializationMixin(object):
 
         test(io.BytesIO())
 
-    def test_serialization(self):
+    def _test_serialization(self, weights_only):
         # Test serialization with a real file
         b = self._test_serialization_data()
         with tempfile.NamedTemporaryFile() as f:
             torch.save(b, f)
             f.seek(0)
-            c = torch.load(f)
+            c = torch.load(f, weights_only=weights_only)
             self._test_serialization_assert(b, c)
         with TemporaryFileName() as fname:
             torch.save(b, fname)
-            c = torch.load(fname)
+            c = torch.load(fname, weights_only=weights_only)
             self._test_serialization_assert(b, c)
         # test non-ascii encoding of bytes arrays/strings
         # The following bytes are produced by serializing
@@ -180,11 +180,17 @@ class SerializationMixin(object):
         buf = io.BytesIO(serialized)
         utf8_bytes = b'\xc5\xbc\xc4\x85\xc4\x85\xc3\xb3\xc5\xbc\xc4\x85\xc5\xbc'
         utf8_str = utf8_bytes.decode('utf-8')
-        loaded_utf8 = torch.load(buf, encoding='utf-8')
+        loaded_utf8 = torch.load(buf, weights_only=weights_only, encoding='utf-8')
         self.assertEqual(loaded_utf8, [utf8_str, torch.zeros(1, dtype=torch.float), 2])
         buf.seek(0)
-        loaded_bytes = torch.load(buf, encoding='bytes')
+        loaded_bytes = torch.load(buf, weights_only=weights_only, encoding='bytes')
         self.assertEqual(loaded_bytes, [utf8_bytes, torch.zeros(1, dtype=torch.float), 2])
+
+    def test_serialization(self):
+        self._test_serialization(False)
+
+    def test_serialization_safe(self):
+        self._test_serialization(True)
 
     def test_serialization_filelike(self):
         # Test serialization (load and save) with a filelike object
@@ -680,24 +686,30 @@ class serialization_method(object):
     def __exit__(self, *args, **kwargs):
         torch.save = self.torch_save
 
+@unittest.skipIf(IS_WINDOWS, "NamedTemporaryFile on windows")
 class TestBothSerialization(TestCase):
-    @unittest.skipIf(IS_WINDOWS, "NamedTemporaryFile on windows")
-    def test_serialization_new_format_old_format_compat(self, device):
+    def _test_serialization_new_format_old_format_compat(self, device, weights_only):
         x = [torch.ones(200, 200, device=device) for i in range(30)]
 
         def test(f_new, f_old):
             torch.save(x, f_new, _use_new_zipfile_serialization=True)
             f_new.seek(0)
-            x_new_load = torch.load(f_new)
+            x_new_load = torch.load(f_new, weights_only=weights_only)
             self.assertEqual(x, x_new_load)
 
             torch.save(x, f_old, _use_new_zipfile_serialization=False)
             f_old.seek(0)
-            x_old_load = torch.load(f_old)
+            x_old_load = torch.load(f_old, weights_only=weights_only)
             self.assertEqual(x_old_load, x_new_load)
 
         with tempfile.NamedTemporaryFile() as f_new, tempfile.NamedTemporaryFile() as f_old:
             test(f_new, f_old)
+
+    def test_serialization_new_format_old_format_compat(self, device):
+        self._test_serialization_new_format_old_format_compat(device, False)
+
+    def test_serialization_new_format_old_format_compat_safe(self, device):
+        self._test_serialization_new_format_old_format_compat(device, True)
 
 
 class TestOldSerialization(TestCase, SerializationMixin):
@@ -727,8 +739,7 @@ class TestOldSerialization(TestCase, SerializationMixin):
                 loaded = torch.load(checkpoint)
                 self.assertTrue(isinstance(loaded, module.Net))
                 if can_retrieve_source:
-                    self.assertEqual(len(w), 1)
-                    self.assertTrue(w[0].category, 'WarningMessage')
+                    self.assertEqual(len(w), 0)
 
             # Replace the module with different source
             fname = get_file_path_2(os.path.dirname(os.path.dirname(torch.__file__)), 'torch', 'testing',
@@ -739,9 +750,8 @@ class TestOldSerialization(TestCase, SerializationMixin):
                 loaded = torch.load(checkpoint)
                 self.assertTrue(isinstance(loaded, module.Net))
                 if can_retrieve_source:
-                    self.assertEqual(len(w), 2)
-                    self.assertTrue(w[0].category, 'WarningMessage')
-                    self.assertTrue(w[1].category, 'SourceChangeWarning')
+                    self.assertEqual(len(w), 1)
+                    self.assertTrue(w[0].category, 'SourceChangeWarning')
 
     def test_serialization_container(self):
         self._test_serialization_container('file', tempfile.NamedTemporaryFile)
@@ -773,7 +783,8 @@ class TestOldSerialization(TestCase, SerializationMixin):
         self.assertEqual(i, i_loaded)
         self.assertEqual(j, j_loaded)
 
-    def test_serialization_offset_filelike(self):
+    @parametrize('weights_only', (True, False))
+    def test_serialization_offset_filelike(self, weights_only):
         a = torch.randn(5, 5)
         b = torch.randn(1024, 1024, 512, dtype=torch.float32)
         i, j = 41, 43
@@ -785,9 +796,9 @@ class TestOldSerialization(TestCase, SerializationMixin):
             self.assertTrue(f.tell() > 2 * 1024 * 1024 * 1024)
             f.seek(0)
             i_loaded = pickle.load(f)
-            a_loaded = torch.load(f)
+            a_loaded = torch.load(f, weights_only=weights_only)
             j_loaded = pickle.load(f)
-            b_loaded = torch.load(f)
+            b_loaded = torch.load(f, weights_only=weights_only)
         self.assertTrue(torch.equal(a, a_loaded))
         self.assertTrue(torch.equal(b, b_loaded))
         self.assertEqual(i, i_loaded)
@@ -799,7 +810,8 @@ class TestOldSerialization(TestCase, SerializationMixin):
 
 
 class TestSerialization(TestCase, SerializationMixin):
-    def test_serialization_zipfile(self):
+    @parametrize('weights_only', (True, False))
+    def test_serialization_zipfile(self, weights_only):
         data = self._test_serialization_data()
 
         def test(name_or_buffer):
@@ -808,7 +820,7 @@ class TestSerialization(TestCase, SerializationMixin):
             if hasattr(name_or_buffer, 'seek'):
                 name_or_buffer.seek(0)
 
-            result = torch.load(name_or_buffer)
+            result = torch.load(name_or_buffer, weights_only=weights_only)
             self.assertEqual(result, data)
 
         with tempfile.NamedTemporaryFile() as f:
@@ -834,21 +846,23 @@ class TestSerialization(TestCase, SerializationMixin):
             f.seek(0)
             state = torch.load(f)
 
-    def test_pathlike_serialization(self):
+    @parametrize('weights_only', (True, False))
+    def test_pathlike_serialization(self, weights_only):
         model = torch.nn.Conv2d(20, 3200, kernel_size=3)
 
         with TemporaryFileName() as fname:
             path = pathlib.Path(fname)
             torch.save(model.state_dict(), path)
-            torch.load(path)
+            torch.load(path, weights_only=weights_only)
 
-    def test_meta_serialization(self):
+    @parametrize('weights_only', (True, False))
+    def test_meta_serialization(self, weights_only):
         big_model = torch.nn.Conv2d(20000, 320000, kernel_size=3, device='meta')
 
         with BytesIOContext() as f:
             torch.save(big_model.state_dict(), f)
             f.seek(0)
-            state = torch.load(f)
+            state = torch.load(f, weights_only=weights_only)
 
         self.assertEqual(state['weight'].size(), big_model.weight.size())
 
@@ -985,6 +999,8 @@ class TestSubclassSerialization(TestCase):
 
 instantiate_device_type_tests(TestBothSerialization, globals())
 instantiate_parametrized_tests(TestSubclassSerialization)
+instantiate_parametrized_tests(TestOldSerialization)
+instantiate_parametrized_tests(TestSerialization)
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -239,9 +239,17 @@ class Unpickler:
                 pid = self.stack.pop()
                 # Only allow persistent load of storage
                 if type(pid) is not tuple and not type(pid) is not int:
-                    raise RuntimeError(f"persistent_load id must be tuple or int, but got {type(pid)}")
-                if type(pid) is tuple and len(pid) > 0 and pid[0] != "storage":
-                    raise RuntimeError(f"Only persistent_load of storage is allowed, but got {pid[0]}")
+                    raise RuntimeError(
+                        f"persistent_load id must be tuple or int, but got {type(pid)}"
+                    )
+                if (
+                    type(pid) is tuple
+                    and len(pid) > 0
+                    and torch.serialization._maybe_decode_ascii(pid[0]) != "storage"
+                ):
+                    raise RuntimeError(
+                        f"Only persistent_load of storage is allowed, but got {pid[0]}"
+                    )
                 self.append(self.persistent_load(pid))
             elif key[0] in [BINGET[0], LONG_BINGET[0]]:
                 idx = (read(1) if key[0] == BINGET[0] else unpack("<I", read(4)))[0]

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -6,31 +6,58 @@
 # buf = io.BytesIO(data)
 # weights = torch.load(buf, pickle_module=WeightsUnpickler)
 
-from sys import maxsize
-from struct import unpack
 from collections import OrderedDict
+from pickle import (
+    APPENDS,
+    BINGET,
+    BININT,
+    BININT1,
+    BININT2,
+    BINPERSID,
+    BINPUT,
+    BINUNICODE,
+    BUILD,
+    bytes_types,
+    decode_long,
+    EMPTY_DICT,
+    EMPTY_LIST,
+    EMPTY_SET,
+    EMPTY_TUPLE,
+    GLOBAL,
+    LONG1,
+    LONG_BINGET,
+    LONG_BINPUT,
+    MARK,
+    NEWFALSE,
+    NEWOBJ,
+    NEWTRUE,
+    NONE,
+    PROTO,
+    REDUCE,
+    SETITEM,
+    SETITEMS,
+    STOP,
+    TUPLE,
+    TUPLE1,
+    TUPLE2,
+    TUPLE3,
+    UnpicklingError,
+)
+from struct import unpack
+from sys import maxsize
+from typing import Any, Dict, List
 
 import torch
-from pickle import (UnpicklingError, bytes_types, decode_long,
-                    STOP, PROTO,
-                    MARK,
-                    # Risky ops: class resolution, state modification, function invokation
-                    GLOBAL, BUILD, REDUCE, NEWOBJ, APPENDS,
-                    # Construct tirivial objects
-                    NONE, NEWTRUE, NEWFALSE, EMPTY_DICT, EMPTY_LIST, EMPTY_TUPLE, EMPTY_SET,
-                    LONG1, LONG_BINGET,
-                    BININT, BININT1, BININT2, BINPERSID, BINUNICODE,
-                    BINGET, BINPUT, LONG_BINPUT, SETITEM, SETITEMS, TUPLE, TUPLE1, TUPLE2, TUPLE3)
 
 
 # Unpickling machinery
 
-class Unpickler:
 
+class Unpickler:
     def __init__(self, file, *, encoding: str = "UNUSED"):
         self.readline = file.readline
         self.read = file.read
-        self.memo = {}
+        self.memo: Dict[int, Any] = {}
 
     def load(self):
         """Read a pickled object representation from the open file.
@@ -38,7 +65,7 @@ class Unpickler:
         Return the reconstituted object hierarchy specified in the file.
         """
         self.metastack = []
-        self.stack = []
+        self.stack: List[Any] = []
         self.append = self.stack.append
         read = self.read
         readline = self.readline
@@ -47,16 +74,8 @@ class Unpickler:
             if not key:
                 raise EOFError
             assert isinstance(key, bytes_types)
-            if key[0] == STOP[0]:
-                rc = self.stack.pop()
-                return rc
-            elif key[0] == PROTO[0]:
-                # Read and ignore proto version
-                read(1)[0]
-                pass
-            elif key[0] == NONE[0]:
-                self.append(None)
-            elif key[0] == GLOBAL[0]:
+            # Risky operators
+            if key[0] == GLOBAL[0]:
                 module = readline()[:-1].decode("utf-8")
                 name = readline()[:-1].decode("utf-8")
                 full_path = f"{module}.{name}"
@@ -77,12 +96,16 @@ class Unpickler:
             elif key[0] == NEWOBJ[0]:
                 args = self.stack.pop()
                 cls = self.stack.pop()
-                if cls != torch.nn.Parameter:
+                if cls is not torch.nn.Parameter:
                     raise RuntimeError("Trying to instantiate unsupported class")
                 self.append(cls.__new__(cls, *args))
             elif key[0] == REDUCE[0]:
                 args = self.stack.pop()
                 func = self.stack[-1]
+                if func not in ALLOWED_GLOBALS.values():
+                    raise RuntimeError(
+                        "Trying to call reduce for unrecognized function"
+                    )
                 self.stack[-1] = func(*args)
             elif key[0] == BUILD[0]:
                 state = self.stack.pop()
@@ -93,51 +116,13 @@ class Unpickler:
                     inst.__dict__.update(state)
                 else:
                     raise RuntimeError("Can only build parameter and dict objects")
+            # Stack manipulation
             elif key[0] == APPENDS[0]:
                 items = self.pop_mark()
                 list_obj = self.stack[-1]
                 if type(list_obj) is not list or not hasattr(list_obj, "extend"):
                     raise RuntimeError("Can only extend lists")
                 list_obj.extend(items)
-            elif key[0] == NEWFALSE[0]:
-                self.append(False)
-            elif key[0] == NEWTRUE[0]:
-                self.append(True)
-            elif key[0] == EMPTY_TUPLE[0]:
-                self.append(())
-            elif key[0] == EMPTY_LIST[0]:
-                self.append([])
-            elif key[0] == EMPTY_DICT[0]:
-                self.append({})
-            elif key[0] == EMPTY_SET[0]:
-                self.append(set())
-            elif key[0] == BININT[0]:
-                self.append(unpack('<i', read(4))[0])
-            elif key[0] == BININT1[0]:
-                self.append(self.read(1)[0])
-            elif key[0] == BININT2[0]:
-                self.append(unpack('<H', read(2))[0])
-            elif key[0] == BINUNICODE[0]:
-                strlen = unpack('<I', read(4))[0]
-                if strlen > maxsize:
-                    raise RuntimeError("String is too long")
-                strval = str(read(strlen), 'utf-8', 'surrogatepass')
-                self.append(strval)
-            elif key[0] == BINPERSID[0]:
-                pid = self.stack.pop()
-                self.append(self.persistent_load(pid))
-            elif key[0] in [BINGET[0], LONG_BINGET[0]]:
-                idx = (read(1) if key[0] == BINGET[0] else unpack('<I', read(4)))[0]
-                self.append(self.memo[idx])
-            elif key[0] in [BINPUT[0], LONG_BINPUT[0]]:
-                i = (read(1) if key[0] == BINPUT[0] else unpack('<I', read(4)))[0]
-                if i < 0:
-                    raise ValueError("negative argument")
-                self.memo[i] = self.stack[-1]
-            elif key[0] == LONG1[0]:
-                n = read(1)[0]
-                data = read(n)
-                self.append(decode_long(data))
             elif key[0] == SETITEM[0]:
                 (v, k) = (self.stack.pop(), self.stack.pop())
                 self.stack[-1][k] = v
@@ -158,6 +143,55 @@ class Unpickler:
                 self.stack[-2:] = [(self.stack[-2], self.stack[-1])]
             elif key[0] == TUPLE3[0]:
                 self.stack[-3:] = [(self.stack[-3], self.stack[-2], self.stack[-1])]
+            # Basic types construction
+            elif key[0] == NONE[0]:
+                self.append(None)
+            elif key[0] == NEWFALSE[0]:
+                self.append(False)
+            elif key[0] == NEWTRUE[0]:
+                self.append(True)
+            elif key[0] == EMPTY_TUPLE[0]:
+                self.append(())
+            elif key[0] == EMPTY_LIST[0]:
+                self.append([])
+            elif key[0] == EMPTY_DICT[0]:
+                self.append({})
+            elif key[0] == EMPTY_SET[0]:
+                self.append(set())
+            elif key[0] == BININT[0]:
+                self.append(unpack("<i", read(4))[0])
+            elif key[0] == BININT1[0]:
+                self.append(self.read(1)[0])
+            elif key[0] == BININT2[0]:
+                self.append(unpack("<H", read(2))[0])
+            elif key[0] == BINUNICODE[0]:
+                strlen = unpack("<I", read(4))[0]
+                if strlen > maxsize:
+                    raise RuntimeError("String is too long")
+                strval = str(read(strlen), "utf-8", "surrogatepass")
+                self.append(strval)
+            elif key[0] == BINPERSID[0]:
+                pid = self.stack.pop()
+                self.append(self.persistent_load(pid))
+            elif key[0] in [BINGET[0], LONG_BINGET[0]]:
+                idx = (read(1) if key[0] == BINGET[0] else unpack("<I", read(4)))[0]
+                self.append(self.memo[idx])
+            elif key[0] in [BINPUT[0], LONG_BINPUT[0]]:
+                i = (read(1) if key[0] == BINPUT[0] else unpack("<I", read(4)))[0]
+                if i < 0:
+                    raise ValueError("negative argument")
+                self.memo[i] = self.stack[-1]
+            elif key[0] == LONG1[0]:
+                n = read(1)[0]
+                data = read(n)
+                self.append(decode_long(data))
+            # First and last deserializer ops
+            elif key[0] == PROTO[0]:
+                # Read and ignore proto version
+                read(1)[0]
+            elif key[0] == STOP[0]:
+                rc = self.stack.pop()
+                return rc
             else:
                 raise RuntimeError(f"Unsupported operatnd {key[0]}")
 
@@ -170,6 +204,7 @@ class Unpickler:
 
     def persistent_load(self, pid):
         raise UnpicklingError("unsupported persistent id encountered")
+
 
 def load(file, *, encoding: str = "UNUSED"):
     return Unpickler(file).load()

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -142,7 +142,7 @@ class Unpickler:
                 cls = self.stack.pop()
                 if cls is not torch.nn.Parameter:
                     raise RuntimeError(f"Trying to instantiate unsupported class {cls}")
-                self.append(cls.__new__(cls, *args))
+                self.append(torch.nn.Parameter(*args))
             elif key[0] == REDUCE[0]:
                 args = self.stack.pop()
                 func = self.stack[-1]

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -1,0 +1,175 @@
+# Very restricted unpickler
+# Based of https://github.com/python/cpython/blob/main/Lib/pickle.py
+# Expected to be useful for loading PyTorch model weights
+# For example:
+# data = urllib.request.urlopen('https://download.pytorch.org/models/resnet50-0676ba61.pth').read()
+# buf = io.BytesIO(data)
+# weights = torch.load(buf, pickle_module=WeightsUnpickler)
+
+from sys import maxsize
+from struct import unpack
+from collections import OrderedDict
+
+import torch
+from pickle import (UnpicklingError, bytes_types, decode_long,
+                    STOP, PROTO,
+                    MARK,
+                    # Risky ops: class resolution, state modification, function invokation
+                    GLOBAL, BUILD, REDUCE, NEWOBJ, APPENDS,
+                    # Construct tirivial objects
+                    NONE, NEWTRUE, NEWFALSE, EMPTY_DICT, EMPTY_LIST, EMPTY_TUPLE, EMPTY_SET,
+                    LONG1, LONG_BINGET,
+                    BININT, BININT1, BININT2, BINPERSID, BINUNICODE,
+                    BINGET, BINPUT, LONG_BINPUT, SETITEM, SETITEMS, TUPLE, TUPLE1, TUPLE2, TUPLE3)
+
+
+# Unpickling machinery
+
+class Unpickler:
+
+    def __init__(self, file, *, encoding: str = "UNUSED"):
+        self.readline = file.readline
+        self.read = file.read
+        self.memo = {}
+
+    def load(self):
+        """Read a pickled object representation from the open file.
+
+        Return the reconstituted object hierarchy specified in the file.
+        """
+        self.metastack = []
+        self.stack = []
+        self.append = self.stack.append
+        read = self.read
+        readline = self.readline
+        while True:
+            key = read(1)
+            if not key:
+                raise EOFError
+            assert isinstance(key, bytes_types)
+            if key[0] == STOP[0]:
+                rc = self.stack.pop()
+                return rc
+            elif key[0] == PROTO[0]:
+                # Read and ignore proto version
+                read(1)[0]
+                pass
+            elif key[0] == NONE[0]:
+                self.append(None)
+            elif key[0] == GLOBAL[0]:
+                module = readline()[:-1].decode("utf-8")
+                name = readline()[:-1].decode("utf-8")
+                full_path = f"{module}.{name}"
+                ALLOWED_GLOBALS = {
+                    "collections.OrderedDict": OrderedDict,
+                    "torch.FloatTensor": torch.FloatTensor,
+                    "torch.FloatStorage": torch.FloatStorage,
+                    "torch.LongTensor": torch.LongTensor,
+                    "torch.LongStorage": torch.FloatStorage,
+                    "torch.nn.parameter.Parameter": torch.nn.Parameter,
+                    "torch._utils._rebuild_parameter": torch._utils._rebuild_parameter,
+                    "torch._utils._rebuild_tensor_v2": torch._utils._rebuild_tensor_v2,
+                }
+                if full_path in ALLOWED_GLOBALS:
+                    self.append(ALLOWED_GLOBALS[full_path])
+                else:
+                    raise RuntimeError(f"Unsupported class {full_path}")
+            elif key[0] == NEWOBJ[0]:
+                args = self.stack.pop()
+                cls = self.stack.pop()
+                if cls != torch.nn.Parameter:
+                    raise RuntimeError("Trying to instantiate unsupported class")
+                self.append(cls.__new__(cls, *args))
+            elif key[0] == REDUCE[0]:
+                args = self.stack.pop()
+                func = self.stack[-1]
+                self.stack[-1] = func(*args)
+            elif key[0] == BUILD[0]:
+                state = self.stack.pop()
+                inst = self.stack[-1]
+                if type(inst) is torch.nn.Parameter:
+                    inst.__setstate__(state)
+                elif type(inst) is OrderedDict:
+                    inst.__dict__.update(state)
+                else:
+                    raise RuntimeError("Can only build parameter and dict objects")
+            elif key[0] == APPENDS[0]:
+                items = self.pop_mark()
+                list_obj = self.stack[-1]
+                if type(list_obj) is not list or not hasattr(list_obj, "extend"):
+                    raise RuntimeError("Can only extend lists")
+                list_obj.extend(items)
+            elif key[0] == NEWFALSE[0]:
+                self.append(False)
+            elif key[0] == NEWTRUE[0]:
+                self.append(True)
+            elif key[0] == EMPTY_TUPLE[0]:
+                self.append(())
+            elif key[0] == EMPTY_LIST[0]:
+                self.append([])
+            elif key[0] == EMPTY_DICT[0]:
+                self.append({})
+            elif key[0] == EMPTY_SET[0]:
+                self.append(set())
+            elif key[0] == BININT[0]:
+                self.append(unpack('<i', read(4))[0])
+            elif key[0] == BININT1[0]:
+                self.append(self.read(1)[0])
+            elif key[0] == BININT2[0]:
+                self.append(unpack('<H', read(2))[0])
+            elif key[0] == BINUNICODE[0]:
+                strlen = unpack('<I', read(4))[0]
+                if strlen > maxsize:
+                    raise RuntimeError("String is too long")
+                strval = str(read(strlen), 'utf-8', 'surrogatepass')
+                self.append(strval)
+            elif key[0] == BINPERSID[0]:
+                pid = self.stack.pop()
+                self.append(self.persistent_load(pid))
+            elif key[0] in [BINGET[0], LONG_BINGET[0]]:
+                idx = (read(1) if key[0] == BINGET[0] else unpack('<I', read(4)))[0]
+                self.append(self.memo[idx])
+            elif key[0] in [BINPUT[0], LONG_BINPUT[0]]:
+                i = (read(1) if key[0] == BINPUT[0] else unpack('<I', read(4)))[0]
+                if i < 0:
+                    raise ValueError("negative argument")
+                self.memo[i] = self.stack[-1]
+            elif key[0] == LONG1[0]:
+                n = read(1)[0]
+                data = read(n)
+                self.append(decode_long(data))
+            elif key[0] == SETITEM[0]:
+                (v, k) = (self.stack.pop(), self.stack.pop())
+                self.stack[-1][k] = v
+            elif key[0] == SETITEMS[0]:
+                items = self.pop_mark()
+                for i in range(0, len(items), 2):
+                    self.stack[-1][items[i]] = items[i + 1]
+            elif key[0] == MARK[0]:
+                self.metastack.append(self.stack)
+                self.stack = []
+                self.append = self.stack.append
+            elif key[0] == TUPLE[0]:
+                items = self.pop_mark()
+                self.append(tuple(items))
+            elif key[0] == TUPLE1[0]:
+                self.stack[-1] = (self.stack[-1],)
+            elif key[0] == TUPLE2[0]:
+                self.stack[-2:] = [(self.stack[-2], self.stack[-1])]
+            elif key[0] == TUPLE3[0]:
+                self.stack[-3:] = [(self.stack[-3], self.stack[-2], self.stack[-1])]
+            else:
+                raise RuntimeError(f"Unsupported operatnd {key[0]}")
+
+    # Return a list of items pushed in the stack after last MARK instruction.
+    def pop_mark(self):
+        items = self.stack
+        self.stack = self.metastack.pop()
+        self.append = self.stack.append
+        return items
+
+    def persistent_load(self, pid):
+        raise UnpicklingError("unsupported persistent id encountered")
+
+def load(file, *, encoding: str = "UNUSED"):
+    return Unpickler(file).load()

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -237,6 +237,11 @@ class Unpickler:
                 self.append(strdata)
             elif key[0] == BINPERSID[0]:
                 pid = self.stack.pop()
+                # Only allow persistent load of storage
+                if type(pid) is not tuple and not type(pid) is not int:
+                    raise RuntimeError(f"persistent_load id must be tuple or int, but got {type(pid)}")
+                if type(pid) is tuple and len(pid) > 0 and pid[0] != "storage":
+                    raise RuntimeError(f"Only persistent_load of storage is allowed, but got {pid[0]}")
                 self.append(self.persistent_load(pid))
             elif key[0] in [BINGET[0], LONG_BINGET[0]]:
                 idx = (read(1) if key[0] == BINGET[0] else unpack("<I", read(4)))[0]

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -750,8 +750,8 @@ def load(
     """
     UNSAFE_MESSAGE = (
         "Weights only load failed. Re-running `torch.load` with `weights_only` set to `False`"
-        " will likely succeede but it can result in arbitrary code execution."
-        "Do it only if you get the file from a trusted source."
+        " will likely succeed, but it can result in arbitrary code execution."
+        "Do it only if you get the file from a trusted source. WeightsUnpickler error: "
     )
     # Add ability to force safe only weight loads via environment variable
     if os.getenv("TORCH_FORCE_WEIGHTS_ONLY_LOAD", "0").lower() in ['1', 'y', 'yes', 'true']:
@@ -784,14 +784,14 @@ def load(
                 if weights_only:
                     try:
                         return _load(opened_zipfile, map_location, _weights_only_unpickler, **pickle_load_args)
-                    except RuntimeError:
-                        raise pickle.UnpicklingError(UNSAFE_MESSAGE)
+                    except RuntimeError as e:
+                        raise pickle.UnpicklingError(UNSAFE_MESSAGE + str(e)) from None
                 return _load(opened_zipfile, map_location, pickle_module, **pickle_load_args)
         if weights_only:
             try:
                 return _legacy_load(opened_file, map_location, _weights_only_unpickler, **pickle_load_args)
-            except RuntimeError:
-                raise pickle.UnpicklingError(UNSAFE_MESSAGE)
+            except RuntimeError as e:
+                raise pickle.UnpicklingError(UNSAFE_MESSAGE + str(e)) from None
         return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
 
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -785,6 +785,7 @@ def load(
                         return _load(opened_zipfile, map_location, pickle, **pickle_load_args)
                 return _load(opened_zipfile, map_location, pickle_module, **pickle_load_args)
         if pickle_module is None:
+            orig_position = opened_file.tell()
             try:
                 return _legacy_load(opened_file, map_location, _weights_only_unpickler, **pickle_load_args)
             except RuntimeError:
@@ -792,7 +793,7 @@ def load(
                 if weight_load_only:
                     raise
                 warnings.warn(UNSAFE_MESSAGE)
-                opened_file.seek(0)
+                opened_file.seek(orig_position)
                 return _legacy_load(opened_file, map_location, pickle, **pickle_load_args)
         return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -654,7 +654,7 @@ def load(
     f: FILE_LIKE,
     map_location: MAP_LOCATION = None,
     pickle_module: Any = None,
-    weight_load_only: bool = False,
+    weights_only: bool = False,
     **pickle_load_args: Any
 ) -> Any:
     # Reference: https://github.com/pytorch/pytorch/issues/54354
@@ -702,8 +702,8 @@ def load(
             locations
         pickle_module: module used for unpickling metadata and objects (has to
             match the :attr:`pickle_module` used to serialize file)
-        weights_load_only: Indicates whether unpickler should be restricted to
-            loading only tensor, primitive types and dictionaries
+        weights_only: Indicates whether unpickler should be restricted to
+            loading only tensors, primitive types and dictionaries
         pickle_load_args: (Python 3 only) optional keyword arguments passed over to
             :func:`pickle_module.load` and :func:`pickle_module.Unpickler`, e.g.,
             :attr:`errors=...`.
@@ -749,9 +749,9 @@ def load(
     UNSAFE_MESSAGE = (
         "*WARNING* Safe load failed, defaulting to standard Python pickle module, "
         " which can result in arbitrary code execution. To avoid this please ivoke load"
-        " method with weight_load_only argument set to True"
+        " method with weights_only argument set to True"
     )
-    if weight_load_only:
+    if weights_only:
         if pickle_module is not None:
             raise RuntimeError("Can not safely load weights when expiclit picke_module is specified")
         picke_module = _weights_only_unpickler
@@ -778,7 +778,7 @@ def load(
                         return _load(opened_zipfile, map_location, _weights_only_unpickler, **pickle_load_args)
                     except RuntimeError:
                         # Rethrow the exception if only safe unpickler is allowed
-                        if weight_load_only:
+                        if weights_only:
                             raise
                         warnings.warn(UNSAFE_MESSAGE)
                         opened_file.seek(orig_position)
@@ -790,7 +790,7 @@ def load(
                 return _legacy_load(opened_file, map_location, _weights_only_unpickler, **pickle_load_args)
             except RuntimeError:
                 # Rethrow the exception if only safe unpickler is allowed
-                if weight_load_only:
+                if weights_only:
                     raise
                 warnings.warn(UNSAFE_MESSAGE)
                 opened_file.seek(orig_position)


### PR DESCRIPTION
This addresses the security issue in default Python's `unpickler` that allows arbitrary code execution while unpickling.
Restrict classes allowed to be unpicked to in `None`, `int`, `bool`, `str`, `float`, `list`, `tuple`, `dict`/`OrderedDict` as well as `torch.Size`, `torch.nn.Param` as well as  `torch.Tensor` and `torch.Storage` variants.

Defaults `weights_only` is set to `False`,  but allows global override to safe only load via `TORCH_FORCE_WEIGHTS_ONLY_LOAD` environment variable.

To some extent, addresses https://github.com/pytorch/pytorch/issues/52596