### PR TITLE
Let retried jobs advance viable/strict

### DIFF
--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -110,7 +110,7 @@ def main() -> None:
     )
     qlambda = rs.QueryLambda.retrieve(
         'commit_jobs_batch_query',
-        version='15aba20837ae9d75',
+        version='8003fdfd18b64696',
         workspace='commons')
 
     commits = get_latest_commits()


### PR DESCRIPTION
Today, even if we retry a failed workflow it succeeds on the retry, viable/strict doesn't advance forward.

Success on retry is proof that the error wasn't with the current commit and that we should in fact promote viable/strict. This PR points to an updated rockset query which will only look at the success status of the most recent job in each workflow

Here's the query edited:

Original query:
https://console.rockset.com/lambdas/details/commons.commit_jobs_batch_query/versions/15aba20837ae9d75?tab=sql

Updated query: https://console.rockset.com/lambdas/details/commons.commit_jobs_batch_query/versions/8003fdfd18b64696?tab=sql

Testing:
Tested the old and new query against commits known to have succeeded on retry