### PR TITLE
ci: Just use regular checkout

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - Dockerfile
       - docker.Makefile
+      - .github/workflows/docker-release.yml
   push:
     branches:
       - nightly

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -47,7 +47,10 @@ jobs:
       # [see note: pytorch repo ref]
       # deep clone (fetch-depth 0) required for git merge-base
       - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
       - name: Setup SSH (Click me for login details)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86824

checkout-pytorch seems to have issues and is purpose made for our PR
testing and appears to conflict with what we're trying to do for binary
builds.

For builds like
https://github.com/pytorch/pytorch/actions/runs/3207520052/jobs/5242479607
there is a confusion over where the reference is pulled and I believe it is
root caused by the checkout logic in checkout-pytorch.

So with that in mind I suggest we just use the upstream checkout action
for this job

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>