### PR TITLE
Allow viable/strict promotion even if periodic or docker-release-builds jobs are failing

### DIFF
--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -84,8 +84,6 @@ def isGreen(commit: str, results: Dict[str, Any]) -> Tuple[bool, str]:
                     return (False, workflowName + " checks were not successful")
                 else:
                     regex[required_check] = True
-        if workflowName in ["periodic", "docker-release-builds"] and conclusion not in ["success", "skipped"]:
-            return (False, workflowName + " checks were not successful")
 
     missing_workflows = [x for x in regex.keys() if not regex[x]]
     if len(missing_workflows) > 0:

--- a/.github/scripts/test_fetch_latest_green_commit.py
+++ b/.github/scripts/test_fetch_latest_green_commit.py
@@ -81,13 +81,12 @@ class TestPrintCommits(TestCase):
 
     @mock.patch('fetch_latest_green_commit.get_commit_results', return_value=TestChecks().make_test_checks())
     def test_skippable_failed(self, mock_get_commit_results: Any) -> None:
-        "Test with skippable job (ex: docker-release-builds) failing"
+        "Test with failing skippable jobs (ex: docker-release-builds) should pass"
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "periodic", "skipped")
         workflow_checks = set_workflow_job_status(workflow_checks, "docker-release-builds", "failed")
         result = isGreen("sha", workflow_checks)
-        self.assertFalse(result[0])
-        self.assertEqual(result[1], "docker-release-builds checks were not successful")
+        self.assertTrue(result[0])
 
     @mock.patch('fetch_latest_green_commit.get_commit_results', return_value={})
     def test_no_workflows(self, mock_get_commit_results: Any) -> None:


### PR DESCRIPTION
Allow `viable/strict` promotion even if `periodic` or `docker-release-builds` jobs are failing

**Why?** Those jobs only run occasionally and for all we know the current viable/strict commit may already include the errors that the above cron based workflows may have later detected.  Blocking the viable/strict upgrade because of these scheduled jobs doesn't really offer any value, it just leads to people getting older PRs when they try to fork off of viable/strict without guaranteeing an improvement in test quality

Though frankly, the current situation is worse than that.

Assume the branch history looks like A -> B 

A is the current `viable/strict` commit
B is a commit that failed some `periodic` test, so `viable/strict` wasn't upgraded to B

Now lets say there's a commit C that gets merged. C neither contains a fix for the failing periodic build, nor does a scheduled periodic workflow run against C. The branch becomes A -> B -> C

In the above scenario, today we will promote `viable/strict` to C since there was no failing workflow there!!! Even though it didn't actually fix what was broken with B!

In short, avoiding the upgrade to B really doesn't make any sense today and we shouldn't do it.