### PR TITLE
[FSDP] Replace `current_stream()` with explicit streams in FSDP

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3439,9 +3439,10 @@ class FullyShardedDataParallel(nn.Module):
             if not self._sync_gradients:
                 return
 
-            # Wait for all ops in the current stream (e.g. gradient
-            # computation) to finish before reduce-scattering the gradient
-            self._streams["post_backward"].wait_stream(self._streams["computation"])
+            # Wait for all ops in the current stream to finish before
+            # reduce-scattering the gradient
+            # TODO (awgu): This current stream is actually the unshard stream!
+            self._streams["post_backward"].wait_stream(torch.cuda.current_stream())
 
             with torch.cuda.stream(self._streams["post_backward"]):
                 orig_grad_data = param.grad.data


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #86874 [FSDP] Clarify `torch.cuda.current_stream()` usage in post-backward
* #86836 [FSDP] `summon_full_params()` in computation stream
* **#86834 [FSDP] Replace `current_stream()` with explicit streams in FSDP**
* #86833 [FSDP] Rename streams

The post-backward hook `self._streams["post_backward"].wait_stream(torch.cuda.current_stream())` is handled in a separate PR. I left a TODO for now.

This PR is almost certainly safe, but there is a very small chance this breaks something. The only concerning `torch.cuda.current_stream()` usage is left untouched.