### PR TITLE
[FSDP] Replace `current_stream()` in `flat_param.py`

### DIFF
--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -304,6 +304,11 @@ class FlatParamHandle:
         self._use_orig_params = use_orig_params
         self._training_state = HandleTrainingState.IDLE
         self._debug_level = dist.get_debug_level()
+        self._computation_stream = (
+            torch.cuda.current_stream()
+            if torch.cuda.is_available()
+            else None
+        )
         self._init_flat_param(params, module, use_orig_params)
         self._use_unsharded_views(as_params=False)
 
@@ -1069,8 +1074,9 @@ class FlatParamHandle:
         self._check_storage_allocated(unsharded_flat_param)
         self._check_on_compute_device(unsharded_flat_param)
         # Do not free the memory until all ops in the current stream finish
+        assert self._computation_stream is not None  # mypy
         unsharded_flat_param.record_stream(
-            cast(torch._C.Stream, torch.cuda.current_stream())
+            cast(torch._C.Stream, self._computation_stream)
         )
         _free_storage(unsharded_flat_param)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #86873 [FSDP] Make post-backward `wait_stream()` explicit
* #86836 [FSDP] `summon_full_params()` in computation stream
* **#86835 [FSDP] Replace `current_stream()` in `flat_param.py`**
* #86834 [FSDP] Replace `current_stream()` with explicit streams in FSDP
* #86833 [FSDP] Rename streams

