### PR TITLE
[ONNX] Fix triu/tril export with diagonal input

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -6855,6 +6855,13 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         x = torch.randn(2, 3, 4)
         self.run_test(trilModelwithNegDiagonal(), (x))
 
+        class trilModelWithDiagonalInput(torch.nn.Module):
+            def forward(self, x, diagnonal: int):
+                return torch.tril(x, diagonal=diagnonal)
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(trilModelWithDiagonalInput(), (x, 5))
+
     @skipIfUnsupportedMinOpsetVersion(14)
     def test_triu(self):
         class triuModel(torch.nn.Module):
@@ -6871,12 +6878,19 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         x = torch.randn(2, 3, 4)
         self.run_test(triuModelwithDiagonal(), (x))
 
-        class trilModelwithNegDiagonal(torch.nn.Module):
+        class triuModelwithNegDiagonal(torch.nn.Module):
             def forward(self, x):
-                return torch.tril(x, diagonal=-1)
+                return torch.triu(x, diagonal=-1)
 
         x = torch.randn(2, 3, 4)
-        self.run_test(trilModelwithNegDiagonal(), (x))
+        self.run_test(triuModelwithNegDiagonal(), (x))
+
+        class triuModelWithDiagonalInput(torch.nn.Module):
+            def forward(self, x, diagnonal: int):
+                return torch.triu(x, diagonal=diagnonal)
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(triuModelWithDiagonalInput(), (x, 5))
 
     def test_mish(self):
         class MishModel(torch.nn.Module):

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -33,19 +33,15 @@ def hardswish(g: jit_utils.GraphContext, self):
 
 
 @_onnx_symbolic("aten::tril")
-@symbolic_helper.parse_args("v", "i")
 @_beartype.beartype
 def tril(g: jit_utils.GraphContext, self, diagonal, out=None):
-    k = g.op("Constant", value_t=torch.tensor(diagonal, dtype=torch.int64))
-    return g.op("Trilu", self, k, upper_i=0)
+    return g.op("Trilu", self, diagonal, upper_i=0)
 
 
 @_onnx_symbolic("aten::triu")
-@symbolic_helper.parse_args("v", "i")
 @_beartype.beartype
 def triu(g: jit_utils.GraphContext, self, diagonal, out=None):
-    k = g.op("Constant", value_t=torch.tensor(diagonal, dtype=torch.int64))
-    return g.op("Trilu", self, k, upper_i=1)
+    return g.op("Trilu", self, diagonal, upper_i=1)
 
 
 @_onnx_symbolic("aten::reshape")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86843

Investigation with @thiagocrepaldi discovered this bug with triu/tril export when
`diagonal` is passed in as input. Previously assumption was made that `diagonal`
is always provided a constant value.
