### PR TITLE
[TVM] Add Normalize to C2 Frontend

### DIFF
--- a/caffe2/opt/tvm_transformer.cc
+++ b/caffe2/opt/tvm_transformer.cc
@@ -203,6 +203,7 @@ const std::unordered_set<std::string>& TvmTransformer::getSupportedOps() {
       "Logit",
       "MatMul",
       "Mul",
+      "Normalize",
       "Relu",
       "Reshape",
       "ReplaceNaN",


### PR DESCRIPTION
Summary: As title states, add TVM support for Normalize when compiling

Test Plan:
__Command__
```
buck2 test mode/opt-split-dwarf //caffe2/caffe2/fb/tvm:test_tvm_transform
```
__Result__
```
Buck UI:      https://www.internalfb.com/buck2/b157c764-3ce0-4372-9b2d-74db50d0f931
Test Session: https://www.internalfb.com/intern/testinfra/testrun/8725724395520327
RE: reSessionID-8e229f26-b969-4d2f-b570-e14f9beed568  Up: 63 MiB  Down: 10 GiB
Jobs completed: 174220. Time elapsed: 170.6s. Cache hits: 95%. Commands: 75677 (cached: 71791, rem
Tests finished: Pass 31. Fail 0. Fatal 0. Skip 4. 0 builds failed
```

Differential Revision: D40281703

