### PR TITLE
[FSDP] Make post-backward `wait_stream()` explicit

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3442,10 +3442,9 @@ class FullyShardedDataParallel(nn.Module):
             if not self._sync_gradients:
                 return
 
-            # Wait for all ops in the current stream to finish before
-            # reduce-scattering the gradient
-            # TODO (awgu): This current stream is actually the unshard stream!
-            self._streams["post_backward"].wait_stream(torch.cuda.current_stream())
+            # Wait for all ops in the unshard stream to finish before reducing
+            # the gradient (via either reduce-scatter or all-reduce)
+            self._streams["post_backward"].wait_stream(self._streams["unshard"])
 
             with torch.cuda.stream(self._streams["post_backward"]):
                 orig_grad_data = param.grad.data


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#86873 [FSDP] Make post-backward `wait_stream()` explicit**
* #86836 [FSDP] `summon_full_params()` in computation stream
* #86835 [FSDP] Replace `current_stream()` in `flat_param.py`
* #86834 [FSDP] Replace `current_stream()` with explicit streams in FSDP
* #86833 [FSDP] Rename streams

I need to consult some PyTorch experts for two points:
1. I am not sure why the post-backward hook sees the unshard stream as `torch.cuda.current_stream()`. In particular, it seems that for a tensor `t` allocated in stream `s`, registering a hook on `t`'s `AccumulateGrad` object will have `torch.cuda.current_stream()` return `s` inside the hook.
2. I am not sure why we only need to have the post-backward stream wait for the unshard stream and not the computation stream. It seems that somehow the post-backward stream and the computation stream are synchronized automatically -- maybe this is because the gradient computation must be finished in order for this hook to run at all. In that case though, everything in the unshard stream must have finished. This suggests somehow that `wait_stream()` is not transitive.
