### PR TITLE
[FSDP] Clarify `torch.cuda.current_stream()` usage in post-backward

### DIFF
--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1069,6 +1069,8 @@ class FlatParamHandle:
         self._check_storage_allocated(unsharded_flat_param)
         self._check_on_compute_device(unsharded_flat_param)
         # Do not free the memory until all ops in the current stream finish
+        # NOTE: The current stream may be the computation stream *or* the
+        # unshard stream, depending on the calling context.
         unsharded_flat_param.record_stream(
             cast(torch._C.Stream, torch.cuda.current_stream())
         )

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3444,7 +3444,8 @@ class FullyShardedDataParallel(nn.Module):
 
             # Wait for all ops in the current stream to finish before
             # reduce-scattering the gradient
-            # TODO (awgu): This current stream is actually the unshard stream!
+            # NOTE: The current stream may be the computation stream *or* the
+            # unshard stream, depending on the calling context.
             self._streams["post_backward"].wait_stream(torch.cuda.current_stream())
 
             with torch.cuda.stream(self._streams["post_backward"]):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#86874 [FSDP] Clarify `torch.cuda.current_stream()` usage in post-backward**
* #86836 [FSDP] `summon_full_params()` in computation stream
* #86834 [FSDP] Replace `current_stream()` with explicit streams in FSDP
* #86833 [FSDP] Rename streams

As a simple experiment, add something like `if self.rank == 0: print(f"current stream: {torch.cuda.current_stream()})` in `FullyShardedDataParallel._post_backward_hook()` before `self._streams["post_backward"].wait_stream(torch.cuda.current_stream())` and in `FlatParamHandle._free_unsharded_flat_param()` before `record_stream()` and run `test_fsdp_core.py`. The default stream has value `0x0`, while a created stream has value like `0x55c9ba1e6500`. You should see that the current stream can be either the default computation stream or the unshard stream (even within the same model).