### PR TITLE
Add vmap support for slogdet; fix regression from functorch 0.2.1 (#8…

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
+++ b/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
@@ -204,6 +204,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   OP_DECOMPOSE(square);
   OP_DECOMPOSE(numpy_T);
   OP_DECOMPOSE(reshape_as);
+  OP_DECOMPOSE(slogdet);
   OP_DECOMPOSE(t);
   OP_DECOMPOSE2(result_type, Tensor);
   OP_DECOMPOSE2(result_type, Scalar);

--- a/functorch/test/test_vmap.py
+++ b/functorch/test/test_vmap.py
@@ -3538,6 +3538,15 @@ class TestVmapOperatorsOpInfo(TestCase):
             self.opinfo_vmap_test(device, torch.float, op, check_has_batch_rule=False,
                                   postprocess_fn=compute_A)
 
+    def test_slogdet(self, device):
+        # There's no OpInfo for this
+        def test():
+            B = 2
+            x = torch.randn(2, 5, 5, device=device)
+            self.vmap_outplace_test(torch.slogdet, (x,), {}, (0,))
+
+        check_vmap_fallback(self, test, torch.slogdet)
+
     def test_fill__Tensor(self, device):
         # There's no OpInfo for fill_.Tensor, so here's an extra test for it.
         def test():


### PR DESCRIPTION
…6815)

This PR adds vmap support for slogdet -- slogdet just decomposes into linalg.slogdet.

This fixes a regression from functorch 0.2.1 (slogdet had a batching rule then, and doesn't anymore). We didn't catch the regression because it seems like slogdet doesn't have an OpInfo (I'm not sure if it had one before).

Test Plan:
- new one-off test.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/86815
Approved by: https://github.com/samdow
