### PR TITLE
[functorch] Add more details to the functorch install page (#86823)

### DIFF
--- a/functorch/docs/source/install.rst
+++ b/functorch/docs/source/install.rst
@@ -1,9 +1,18 @@
 Install functorch
 =================
 
-As of PyTorch 1.13, functorch is now included in the PyTorch binary. That is,
-installing PyTorch will let you ``import functorch``. Please see the
-`PyTorch homepage <https://pytorch.org>`_ for installation instructions.
+As of PyTorch 1.13, functorch is now included in the PyTorch binary and no
+longer requires the installation of a separate functorch package. That is,
+after installing PyTorch (`instructions <https://pytorch.org>`_),
+you'll be able to ``import functorch`` in your program.
+
+If you're upgrading from an older version of functorch (functorch 0.1.x or 0.2.x),
+then you may need to uninstall functorch first via ``pip uninstall functorch``.
+
+We've maintained backwards compatibility for ``pip install functorch``: this
+command works for PyTorch 1.13 and will continue to work for the foreseeable future
+until we do a proper deprecation. This is helpful if you're maintaining a library
+that supports multiple versions of PyTorch and/or functorch.
 
 Colab
 -----


### PR DESCRIPTION
Added some details about:
- `pip uninstall functorch` being helpful if there are problems
- `pip install functorch` still working for BC reasons.

Test Plan:
- wait for docs preview
Pull Request resolved: https://github.com/pytorch/pytorch/pull/86823
Approved by: https://github.com/samdow

Fixes #ISSUE_NUMBER
