### PR TITLE
[CI] Fix builder ref for release, linux only

### DIFF
--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -156,6 +156,7 @@ jobs:
       - name: Checkout pytorch/builder to builder dir
         uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
         with:
+          ref: release/1.13
           submodules: recursive
           repository: pytorch/builder
           path: builder


### PR DESCRIPTION
Release only change, this fixes builder checkout step for linux builds. To checkout from release branch rather then main.
Ref: https://github.com/pytorch/pytorch/actions/runs/3207520081/jobs/5242480748


```
Determining the default branch
  Retrieving the default branch name
  Default branch 'main'
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/main:refs/remotes/origin/main
  remote: Enumerating objects: 283, done.    
```

In this PR:
```
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release/1.13*:refs/remotes/origin/release/1.13* +refs/tags/release/1.13*:refs/tags/release/1.13*
```

This is follow up PR of: https://github.com/pytorch/pytorch/pull/86484