### PR TITLE
[ONNX] Fix scalar_type_analysis metadata for copied constant (#86716)

### DIFF
--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -423,6 +423,7 @@ struct TORCH_API Node {
     return scope_->namesFromRoot();
   }
 
+  // Copies the source range, scope and callstack from another node.
   Node* copyMetadata(Node* from) {
     this->setSourceRange(from->sourceRange());
     this->setScope(from->scope());

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -288,16 +288,14 @@ static void UpdateScalarTypeForInputs(
         at::Tensor val = input->node()->t(attr::value);
         at::Tensor new_val = val.to(scalar_type);
         Node* const_node = n->owningGraph()->create(onnx::Constant);
-        const_node->copyMetadata(n);
         const_node->t_(attr::value, new_val);
         const_node->insertBefore(n);
         const_node->output()->setType(TensorType::create(new_val));
-        const_node->copyMetadata(input->node());
+        const_node->copyMetadata(n);
         n->replaceInputWith(input, const_node->output());
       } else {
         Node* cast_node = n->owningGraph()->create(onnx::Cast);
         cast_node->addInput(input);
-        cast_node->copyMetadata(n);
         cast_node->i_(attr::to, onnx_type);
         cast_node->insertBefore(n);
         cast_node->output()->setType(CreateProfiledTensorTypeWithScalarType(


### PR DESCRIPTION
Fix the source of metadata for copied constant. Since the constant is being implicitly casted, it makes more sense to assign code location and etc with the user node. This issue was discovered in https://github.com/pytorch/pytorch/issues/86627. This PR also adds unit test coverage for scope information of nodes when they are altered by CSE and related passes.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/86716
Approved by: https://github.com/thiagocrepaldi, https://github.com/malfet

Fixes #ISSUE_NUMBER
