### PR TITLE
[ONNX] Renable assert diagnostic test (#85999)

### DIFF
--- a/test/onnx/internal/test_diagnostics.py
+++ b/test/onnx/internal/test_diagnostics.py
@@ -112,7 +112,6 @@ class TestOnnxDiagnostics(common_utils.TestCase):
         engine.clear()
         super().setUp()
 
-    @unittest.skip("TODO: Pass locally but fail in CI.")
     def test_assert_diagnostic_raises_when_diagnostic_not_found(self):
         with self.assertRaises(AssertionError):
             with assert_diagnostic(

--- a/torch/onnx/_internal/diagnostics/_diagnostic.py
+++ b/torch/onnx/_internal/diagnostics/_diagnostic.py
@@ -100,6 +100,10 @@ class ExportDiagnosticEngine(infra.DiagnosticEngine):
     def background_context(self) -> infra.DiagnosticContext:
         return self._background_context
 
+    def clear(self):
+        super().clear()
+        self._background_context._diagnostics.clear()
+
     def sarif_log(self):
         log = super().sarif_log()
         log.runs.append(self._background_context.sarif())

--- a/torch/onnx/_internal/diagnostics/infra/_infra.py
+++ b/torch/onnx/_internal/diagnostics/infra/_infra.py
@@ -305,7 +305,6 @@ class DiagnosticContext:
     options: Optional[DiagnosticOptions] = None
     _diagnostics: List[Diagnostic] = dataclasses.field(init=False, default_factory=list)
     _invocation: Invocation = dataclasses.field(init=False)
-    _is_active: bool = dataclasses.field(init=False, default=True)
 
     def __enter__(self):
         return self
@@ -339,12 +338,8 @@ class DiagnosticContext:
             The created diagnostic.
 
         Raises:
-            RuntimeError: If the context is not active.
             ValueError: If the rule is not supported by the tool.
         """
-        if not self._is_active:
-            raise RuntimeError("The diagnostics context is not active.")
-
         diagnostic = self.tool.create_diagnostic(rule, level, message_args, **kwargs)
         self._diagnostics.append(diagnostic)
         return diagnostic


### PR DESCRIPTION
Fix to properly clear 'background_context' of export diagnostic 'engine' in `clear`.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/85999
Approved by: https://github.com/abock

Fixes #ISSUE_NUMBER
