### PR TITLE
Fixed ListType::isSubtypeOfExt to have correct comparison for nested TensorType

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -838,6 +838,12 @@ bool ListType::isSubtypeOfExt(const Type& rhs_, std::ostream* why_not) const {
   if (rhs_.kind() == AnyListType::Kind) {
     return true;
   }
+
+  auto rhs = rhs_.cast<ListType>();
+  if (rhs && rhs->getElementType()->cast<TensorType>()) {
+    return getElementType()->isSubtypeOfExt(*rhs->getElementType(), why_not);
+  }
+
   return false;
 }
 

--- a/test/cpp/jit/test_jit_type.cpp
+++ b/test/cpp/jit/test_jit_type.cpp
@@ -60,5 +60,20 @@ TEST(JitTypeTest, UnifyTypes) {
   TORCH_INTERNAL_ASSERT(!dict_out);
 }
 
+TEST(JitTypeTest, ListTypeOfTensorsIsSubtypeOf) {
+  auto list_type = ListType::create(TensorType::get());
+  auto tensor_type = c10::TensorType::create(
+      at::kFloat,
+      at::kCPU,
+      c10::SymbolicShape(std::vector<c10::optional<int64_t>>({1, 49})),
+      std::vector<c10::Stride>(
+          {c10::Stride{2, true, 1},
+           c10::Stride{1, true, 1},
+           c10::Stride{0, true, c10::nullopt}}),
+      false);
+  auto list_type_modified = ListType::create(tensor_type);
+  TORCH_INTERNAL_ASSERT(list_type_modified->isSubtypeOf(list_type));
+}
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
### Description
Fixed `ListType::isSubtypeOfExt` method to have correct comparison for nested TensorType.

### Details
Originally `ListType::isSubtypeOfExt` method relies on `Type::isSubtypeOfExt(rhs_, why_not)` which invokes the equality of `ListType` objects which leads to nested element types comparison. So there is a case when it doesn't work correctly:
```cpp
// Empty TensorType
auto tt = TensorType::get();

// Modified TensorType
auto tt_modified = c10::TensorType::create(
      at::kFloat,
      at::kCPU,
      c10::SymbolicShape(std::vector<c10::optional<int64_t>>({1, 49})),
      std::vector<c10::Stride>(
          {c10::Stride{2, true, 1},
           c10::Stride{1, true, 1},
           c10::Stride{0, true, c10::nullopt}}),
      false);

tt_modified->isSubtypeOf(*tt); // Returns true

// But if we put these tensor types inside ListType
auto lt = ListType::create(tt);
auto lt_modified = ListType::create(tt_modified);
lt_modified->isSubtypeOf(*lt); // Returns false because it invokes *tt == *tt_modified
```
Changes in PR help to align the behaviour of `TensorType::isSubtypeOfExt` and `ListType::isSubtypeOfExt`.

@antoniojkim @ke1337