### PR TITLE
Move torchdynamo TestCase it its own file

### DIFF
--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -237,6 +237,8 @@ class TorchBenchmarkRunner(BenchmarkRunner):
         if batch_size is None and is_training and model_name in USE_SMALL_BATCH_SIZE:
             batch_size = USE_SMALL_BATCH_SIZE[model_name]
 
+        # workaround "RuntimeError: not allowed to set torch.backends.cudnn flags"
+        torch.backends.__allow_nonbracketed_mutation_flag = True
         if is_training:
             benchmark = benchmark_cls(
                 test="train", device=device, jit=False, batch_size=batch_size

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -4,6 +4,7 @@ import functools
 import torch
 
 import torch._dynamo
+import torch._dynamo.test_case
 from torch._dynamo.optimizations.training import is_aot_autograd_safe_to_run
 from torch._dynamo.testing import rand_strided
 
@@ -13,7 +14,7 @@ def compiler_safe_fn(gm, example_inputs, is_safe):
     return gm.forward
 
 
-class AotAutogradFallbackTests(torch._dynamo.testing.TestCase):
+class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
     def test_LSTM(self):
         # https://github.com/pytorch/torchdynamo/issues/1147
         class Repro(torch.nn.Module):
@@ -133,6 +134,6 @@ class AotAutogradFallbackTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_aot_cudagraphs.py
+++ b/test/dynamo/test_aot_cudagraphs.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import torch
 
 import torch._dynamo
+import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import same
 
@@ -52,7 +53,7 @@ N_ITERS = 5
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "these tests require cuda")
-class TestAotCudagraphs(torch._dynamo.testing.TestCase):
+class TestAotCudagraphs(torch._dynamo.test_case.TestCase):
     @patch_all()
     def test_basic(self):
         def model(x, y):
@@ -201,6 +202,6 @@ class TestAotCudagraphs(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_distributed.py
+++ b/test/dynamo/test_distributed.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 import torch._dynamo
+import torch._dynamo.test_case
 import torch.distributed as dist
 from torch import nn
 from torch._dynamo import config
@@ -43,7 +44,7 @@ def skip_if_no_active_ddp():
 
 
 @pytest.mark.skip("Module hangs in PyTorch CI")
-class TestDistributed(torch._dynamo.testing.TestCase):
+class TestDistributed(torch._dynamo.test_case.TestCase):
     """
     Test harness initializes dist process group
     """

--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -25,6 +25,6 @@ DynamicShapesNNModuleTests = make_dynamic_cls(test_modules.NNModuleTests)
 DynamicShapesUnspecTests = make_dynamic_cls(test_unspec.UnspecTests)
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -3,12 +3,13 @@ from unittest.mock import patch
 
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch.utils._pytree as pytree
 from torch.fx.experimental.proxy_tensor import make_fx
 
 
-class ExportTests(torch._dynamo.testing.TestCase):
+class ExportTests(torch._dynamo.test_case.TestCase):
     # TODO(voz): Refactor to a shared test function.
     # The tests in this file are a little redundant,
     # They all take a func, run it with eager, then export it, then compare
@@ -1423,6 +1424,6 @@ class ExportTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch import sub
 from torch._dynamo.testing import requires_static_shapes
@@ -53,7 +54,7 @@ def inline_unused(x):
     return x + 5.6
 
 
-class FunctionTests(torch._dynamo.testing.TestCase):
+class FunctionTests(torch._dynamo.test_case.TestCase):
     @make_test
     def test_inline_jit_annotations(x):
         x = inline_script_if_tracing(x)
@@ -670,6 +671,6 @@ class FunctionTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_global.py
+++ b/test/dynamo/test_global.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import same
 
@@ -43,7 +44,7 @@ def reset_name():
     _name = 0
 
 
-class TestGlobals(torch._dynamo.testing.TestCase):
+class TestGlobals(torch._dynamo.test_case.TestCase):
     def test_store_global_1(self):
         def fn(x):
             global g_counter
@@ -227,6 +228,6 @@ class TestGlobals(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_minifier.py
+++ b/test/dynamo/test_minifier.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import torch
 
 import torch._dynamo
+import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.optimizations.backends import create_backend
 
@@ -23,7 +24,7 @@ class MockModule(torch.nn.Module):
         return x
 
 
-class MinfierTests(torch._dynamo.testing.TestCase):
+class MinfierTests(torch._dynamo.test_case.TestCase):
     def test_after_dynamo(self):
         @create_backend
         def bad_dynamo_backend(subgraph):
@@ -92,6 +93,6 @@ class MinfierTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import numpy as np
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch.onnx.operators
 from torch._dynamo import bytecode_transformation
@@ -34,7 +35,7 @@ def my_custom_function(x):
     return x + 1
 
 
-class MiscTests(torch._dynamo.testing.TestCase):
+class MiscTests(torch._dynamo.test_case.TestCase):
     def test_boolarg(self):
         def boolarg(aa, bb, flag):
             if flag:
@@ -2719,6 +2720,6 @@ class TestTracer(JitTestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_model_output.py
+++ b/test/dynamo/test_model_output.py
@@ -4,6 +4,7 @@ import unittest.mock
 
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import same
 
@@ -22,7 +23,7 @@ def maybe_skip(fn):
     return fn
 
 
-class TestHFPretrained(torch._dynamo.testing.TestCase):
+class TestHFPretrained(torch._dynamo.test_case.TestCase):
     @maybe_skip
     def test_pretrained(self):
         def fn(a, tmp):
@@ -38,7 +39,7 @@ class TestHFPretrained(torch._dynamo.testing.TestCase):
         self.assertTrue(same(ref, res))
 
 
-class TestModelOutput(torch._dynamo.testing.TestCase):
+class TestModelOutput(torch._dynamo.test_case.TestCase):
     @maybe_skip
     def test_mo_create(self):
         def fn(a, b):
@@ -160,6 +161,6 @@ class TestModelOutput(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.eval_frame import unsupported
 from torch._dynamo.mutation_guard import GenerationTracker
@@ -604,7 +605,7 @@ def make_test(fn, expected_ops=None):
     return test_fn
 
 
-class NNModuleTests(torch._dynamo.testing.TestCase):
+class NNModuleTests(torch._dynamo.test_case.TestCase):
     test_seq = make_test(Seq())
     test_basicmodule1 = make_test(BasicModule())
     test_basicmodule2 = make_test(BasicModule())
@@ -884,6 +885,6 @@ class NNModuleTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_no_fake_tensors.py
+++ b/test/dynamo/test_no_fake_tensors.py
@@ -24,6 +24,6 @@ NoFakeTensorsNNModuleTests = make_no_fake_cls(test_modules.NNModuleTests)
 NoFakeTensorsUnspecTests = make_no_fake_cls(test_unspec.UnspecTests)
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_nops.py
+++ b/test/dynamo/test_nops.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo import eval_frame
 
@@ -35,7 +36,7 @@ with_debug_nops = eval_frame._optimize_catch_errors(
 )
 
 
-class NopTests(torch._dynamo.testing.TestCase):
+class NopTests(torch._dynamo.test_case.TestCase):
     @with_debug_nops
     def test1(self):
         self.assertEqual(fn1(1, 2), -7)
@@ -66,6 +67,6 @@ class NopTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_optimizations.py
+++ b/test/dynamo/test_optimizations.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import torch
 
 import torch._dynamo
+import torch._dynamo.test_case
 from torch._dynamo.optimizations import backends
 from torch._dynamo.optimizations.analysis import has_mutation
 from torch._dynamo.optimizations.log_args import conv_args_analysis
@@ -64,7 +65,7 @@ class Conv_Bn_Relu(torch.nn.Module):
         return self.relu(self.bn(self.conv(x)))
 
 
-class TestOptimizations(torch._dynamo.testing.TestCase):
+class TestOptimizations(torch._dynamo.test_case.TestCase):
     def test_inplacifier(self):
         gm = torch.fx.symbolic_trace(Seq())
         normalize(gm)
@@ -183,7 +184,7 @@ class TestOptimizations(torch._dynamo.testing.TestCase):
         self.assertEqual(r2.dtype, torch.bfloat16)
 
 
-class NormalizeIRTests(torch._dynamo.testing.TestCase):
+class NormalizeIRTests(torch._dynamo.test_case.TestCase):
     @unittest.skipIf(not has_functorch(), "requires functorch")
     def test_inplace_normalize(self):
         def fn(a, b):
@@ -202,6 +203,6 @@ class NormalizeIRTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_optimizers.py
+++ b/test/dynamo/test_optimizers.py
@@ -6,6 +6,7 @@ import unittest
 import torch
 
 import torch._dynamo
+import torch._dynamo.test_case
 import torch._dynamo.testing
 
 input = torch.ones([10, 10])
@@ -37,7 +38,7 @@ def make_test(optim_cls, exp_frame_cnt=1, closure=None, **kwargs):
     return test_fn
 
 
-class OptimizerTests(torch._dynamo.testing.TestCase):
+class OptimizerTests(torch._dynamo.test_case.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -97,6 +98,6 @@ for opt in optimizers:
     setattr(OptimizerTests, "test_" + opt.__name__.lower(), make_test(opt))
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_python_autograd.py
+++ b/test/dynamo/test_python_autograd.py
@@ -4,7 +4,8 @@ from typing import Callable, Dict, List, NamedTuple, Optional
 import torch
 
 import torch._dynamo
-from torch._dynamo.testing import CompileCounter, same, TestCase
+from torch._dynamo.test_case import run_tests, TestCase
+from torch._dynamo.testing import CompileCounter, same
 
 """
 This is an example of a pure-python version of autograd implemented by
@@ -283,6 +284,4 @@ class TestPythonAutograd(TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
-
     run_tests()

--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -6,10 +6,11 @@ import torch
 
 import torch._dynamo
 import torch._dynamo.config
+import torch._dynamo.test_case
 import torch._dynamo.testing
 
 
-class RecompileUxTests(torch._dynamo.testing.TestCase):
+class RecompileUxTests(torch._dynamo.test_case.TestCase):
     # TODO(whc) dynamo actualy recompiles one more time than the cache limit
     cache_limit = 1
 

--- a/test/dynamo/test_replay_record.py
+++ b/test/dynamo/test_replay_record.py
@@ -6,6 +6,7 @@ import unittest
 
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 
 try:
@@ -16,7 +17,7 @@ except ImportError:
 requires_dill = unittest.skipIf(dill is None, "requires dill")
 
 
-class ReplayRecordTests(torch._dynamo.testing.TestCase):
+class ReplayRecordTests(torch._dynamo.test_case.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -181,6 +182,6 @@ class ReplayRecordTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import numpy as np
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch._dynamo.utils
 from torch import nn
@@ -749,7 +750,7 @@ class TestModule(torch.nn.Module):
         return self.inner_fn(tensor.shape, (1, 2, 3))
 
 
-class ReproTests(torch._dynamo.testing.TestCase):
+class ReproTests(torch._dynamo.test_case.TestCase):
     def test_do_paste_mask(self):
         torch._dynamo.utils.counters.clear()
         opt__do_paste_mask = torch._dynamo.optimize(
@@ -1712,6 +1713,6 @@ class ReproTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_skip_non_tensor.py
+++ b/test/dynamo/test_skip_non_tensor.py
@@ -4,10 +4,11 @@ from unittest.mock import patch
 import torch
 
 import torch._dynamo
+import torch._dynamo.test_case
 from torch._dynamo.testing import CompileCounter
 
 
-class SkipNonTensorTests(torch._dynamo.testing.TestCase):
+class SkipNonTensorTests(torch._dynamo.test_case.TestCase):
     def test_add_tensor1(self):
         def fn(a, b):
             return a + b
@@ -107,6 +108,6 @@ class SkipNonTensorTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_subgraphs.py
+++ b/test/dynamo/test_subgraphs.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo import config
 from torch._dynamo.testing import unsupported
@@ -17,7 +18,7 @@ def indirectly_unsupported(a, b):
     return unsupported(a, c)
 
 
-class SubGraphTests(torch._dynamo.testing.TestCase):
+class SubGraphTests(torch._dynamo.test_case.TestCase):
     def _common(self, fn, frame_count, op_count):
         torch._dynamo.reset()
         v1 = torch.ones(10)
@@ -528,6 +529,6 @@ class SubGraphTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import numpy as np
 import torch
 
+import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import same
 
@@ -51,7 +52,7 @@ UnspecNNModuleTests = make_unspec_cls(test_modules.NNModuleTests)
 
 
 @patch.object(torch._dynamo.config, "specialize_int_float", False)
-class UnspecTests(torch._dynamo.testing.TestCase):
+class UnspecTests(torch._dynamo.test_case.TestCase):
     def test_numpy_correctness(self):
         def fn(x, y, z):
             xy = [x + y, y, False]
@@ -221,6 +222,6 @@ class UnspecTests(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/dynamo/test_verify_correctness.py
+++ b/test/dynamo/test_verify_correctness.py
@@ -8,6 +8,7 @@ import torch
 
 import torch._dynamo
 import torch._dynamo.config as config
+import torch._dynamo.test_case
 from torch._dynamo.optimizations import backends
 from torch._dynamo.testing import same
 
@@ -77,7 +78,7 @@ def transform(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     return gm
 
 
-class TestVerifyCorrectness(torch._dynamo.testing.TestCase):
+class TestVerifyCorrectness(torch._dynamo.test_case.TestCase):
     @patch.object(config, "verify_correctness", True)
     def test_example_inputs(self):
         def fn(a, bc, d):
@@ -169,6 +170,6 @@ class TestVerifyCorrectness(torch._dynamo.testing.TestCase):
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests()

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4023,6 +4023,6 @@ if HAS_CUDA:
 
 
 if __name__ == "__main__":
-    from torch._dynamo.testing import run_tests
+    from torch._dynamo.test_case import run_tests
 
     run_tests(needs="filelock")

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -5,17 +5,18 @@ from unittest.mock import patch
 
 import torch
 import torch.testing
+from torch.testing._internal.common_utils import (
+    IS_WINDOWS,
+    TEST_WITH_CROSSREF,
+    TEST_WITH_TORCHDYNAMO,
+    TestCase as TorchTestCase,
+)
 
 from . import config, reset, utils
 
-from torch.testing._internal.common_utils import TestCase as TorchTestCase
-from torch.testing._internal.common_utils import IS_WINDOWS
-from torch.testing._internal.common_utils import TEST_WITH_CROSSREF
-from torch.testing._internal.common_utils import TEST_WITH_TORCHDYNAMO
-from torch.testing._internal.common_utils import run_tests
-
 
 def run_tests(needs=()):
+    from torch.testing._internal.common_utils import run_tests
 
     if (
         TEST_WITH_TORCHDYNAMO

--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -1,0 +1,68 @@
+import contextlib
+import importlib
+import sys
+from unittest.mock import patch
+
+import torch
+import torch.testing
+
+from . import config, reset, utils
+
+from torch.testing._internal.common_utils import TestCase as TorchTestCase
+from torch.testing._internal.common_utils import IS_WINDOWS
+from torch.testing._internal.common_utils import TEST_WITH_CROSSREF
+from torch.testing._internal.common_utils import TEST_WITH_TORCHDYNAMO
+from torch.testing._internal.common_utils import run_tests
+
+
+def run_tests(needs=()):
+
+    if (
+        TEST_WITH_TORCHDYNAMO
+        or IS_WINDOWS
+        or TEST_WITH_CROSSREF
+        or sys.version_info >= (3, 11)
+    ):
+        return  # skip testing
+
+    if isinstance(needs, str):
+        needs = (needs,)
+    for need in needs:
+        if need == "cuda" and not torch.cuda.is_available():
+            return
+        else:
+            try:
+                importlib.import_module(need)
+            except ImportError:
+                return
+    run_tests()
+
+
+class TestCase(TorchTestCase):
+    @classmethod
+    def tearDownClass(cls):
+        cls._exit_stack.close()
+        super().tearDownClass()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._exit_stack = contextlib.ExitStack()
+        cls._exit_stack.enter_context(
+            patch.object(config, "raise_on_backend_error", True)
+        )
+        cls._exit_stack.enter_context(
+            patch.object(config, "raise_on_ctx_manager_usage", True)
+        )
+
+    def setUp(self):
+        super().setUp()
+        reset()
+        utils.counters.clear()
+
+    def tearDown(self):
+        for k, v in utils.counters.items():
+            print(k, v.most_common())
+        reset()
+        utils.counters.clear()
+        super().tearDown()

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -1,19 +1,16 @@
 import contextlib
 import dis
 import functools
-import importlib
 import logging
 import os.path
-import sys
 import types
 import unittest
 from unittest.mock import patch
 
 import torch
-import torch.testing._internal.common_utils
 from torch import fx
 
-from . import config, eval_frame, optimize_assert, reset, utils
+from . import config, eval_frame, optimize_assert, reset
 from .bytecode_transformation import (
     create_instruction,
     debug_checks,
@@ -27,35 +24,6 @@ unsupported = eval_frame.unsupported
 three = 3
 
 log = logging.getLogger(__name__)
-
-
-def run_tests(needs=()):
-    from torch.testing._internal.common_utils import (
-        IS_WINDOWS,
-        run_tests,
-        TEST_WITH_CROSSREF,
-        TEST_WITH_TORCHDYNAMO,
-    )
-
-    if (
-        TEST_WITH_TORCHDYNAMO
-        or IS_WINDOWS
-        or TEST_WITH_CROSSREF
-        or sys.version_info >= (3, 11)
-    ):
-        return  # skip testing
-
-    if isinstance(needs, str):
-        needs = (needs,)
-    for need in needs:
-        if need == "cuda" and not torch.cuda.is_available():
-            return
-        else:
-            try:
-                importlib.import_module(need)
-            except ImportError:
-                return
-    run_tests()
 
 
 def clone_me(x):
@@ -225,36 +193,6 @@ def standard_test(self, fn, nargs, expected_ops=None, expected_ops_dynamic=None)
     self.assertEqual(actual.frame_count, 1)
     if expected_ops is not None:
         self.assertEqual(actual.op_count, expected_ops)
-
-
-class TestCase(torch.testing._internal.common_utils.TestCase):
-    @classmethod
-    def tearDownClass(cls):
-        cls._exit_stack.close()
-        super().tearDownClass()
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls._exit_stack = contextlib.ExitStack()
-        cls._exit_stack.enter_context(
-            patch.object(config, "raise_on_backend_error", True)
-        )
-        cls._exit_stack.enter_context(
-            patch.object(config, "raise_on_ctx_manager_usage", True)
-        )
-
-    def setUp(self):
-        super().setUp()
-        reset()
-        utils.counters.clear()
-
-    def tearDown(self):
-        for k, v in utils.counters.items():
-            print(k, v.most_common())
-        reset()
-        utils.counters.clear()
-        super().tearDown()
 
 
 def dummy_fx_compile(gm: fx.GraphModule, example_inputs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86957
* #86951
* #86950


This is to work around some issues in torchdynamo CI.  Importing `common_utils` has global side effects that break torchbench, so trying to isolate those imports to their own file.