### PR TITLE
[data] add autocompletion to datapipes

### DIFF
--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -190,6 +190,10 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
         # Instead of showing <torch. ... .MapperIterDataPipe object at 0x.....>, return the class name
         return str(self.__class__.__qualname__)
 
+    def __dir__(self):
+        # for auto-completion in a REPL (e.g. Jupyter notebook)
+        return super().__dir__() + list(self.functions.keys())
+
     def reset(self) -> None:
         r"""
         Reset the `IterDataPipe` to the initial state. By default, no-op. For subclasses of `IterDataPipe`,
@@ -312,6 +316,11 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
             return self.str_hook(self)
         # Instead of showing <torch. ... .MapperMapDataPipe object at 0x.....>, return the class name
         return str(self.__class__.__qualname__)
+
+    def __dir__(self):
+        # for auto-completion in a REPL (e.g. Jupyter notebook)
+        return super().__dir__() + list(self.functions.keys())
+
 
 
 class _DataPipeSerializationWrapper:

--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -192,7 +192,7 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
 
     def __dir__(self):
         # for auto-completion in a REPL (e.g. Jupyter notebook)
-        return super().__dir__() + list(self.functions.keys())
+        return list(super().__dir__()) + list(self.functions.keys())
 
     def reset(self) -> None:
         r"""
@@ -319,7 +319,7 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
 
     def __dir__(self):
         # for auto-completion in a REPL (e.g. Jupyter notebook)
-        return super().__dir__() + list(self.functions.keys())
+        return list(super().__dir__()) + list(self.functions.keys())
 
 
 


### PR DESCRIPTION
In REPLs (e.g. jupyter notebook) autocomplete now works:

<img width="750" alt="image" src="https://user-images.githubusercontent.com/53842584/195776448-f33180da-d1cd-4e47-b9a0-4fd9eb2f78b7.png">

even with custom data pipes:

<img width="804" alt="image" src="https://user-images.githubusercontent.com/53842584/195776957-5c51895e-f469-4b13-81ba-c9b507022555.png">

Unfortunately I wasn't able to figure out how to get autocomplete to work for non-REPLs (e.g. VSCode) - may need to generate fake pyi stubs, which 1) won't work for custom datapipes and 2) is a larger project to tackle :)