### PR TITLE
[vulkan] Add option for printing GPU timestamp info in speed_benchmark_torch

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Adapter.cpp
+++ b/aten/src/ATen/native/vulkan/api/Adapter.cpp
@@ -265,6 +265,7 @@ Adapter::Adapter(
     const uint32_t num_queues)
     : queue_usage_mutex_{},
       physical_device_(physical_device),
+      gpu_name_(physical_device_.properties.deviceName),
       queues_{},
       queue_usage_{},
       queue_mutexes_{},
@@ -386,6 +387,7 @@ std::string Adapter::stringize() const {
   PRINT_LIMIT_PROP_VEC3(maxComputeWorkGroupCount);
   PRINT_LIMIT_PROP(maxComputeWorkGroupInvocations);
   PRINT_LIMIT_PROP_VEC3(maxComputeWorkGroupSize);
+  PRINT_LIMIT_PROP(timestampPeriod);
   ss << "    }" << std::endl;
   ss << "  }" << std::endl;
   ;

--- a/aten/src/ATen/native/vulkan/api/Adapter.h
+++ b/aten/src/ATen/native/vulkan/api/Adapter.h
@@ -103,6 +103,7 @@ class Adapter final {
   std::mutex queue_usage_mutex_;
   // Physical Device Info
   PhysicalDevice physical_device_;
+  std::string gpu_name_;
   // Queue Management
   std::vector<Queue> queues_;
   std::vector<uint32_t> queue_usage_;
@@ -124,6 +125,10 @@ class Adapter final {
 
   inline VkPhysicalDevice physical_handle() const {
     return physical_device_.handle;
+  }
+
+  inline std::string gpu_name() const {
+    return gpu_name_;
   }
 
   inline VkDevice device_handle() const {

--- a/aten/src/ATen/native/vulkan/api/QueryPool.h
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.h
@@ -51,6 +51,7 @@ class QueryPool final {
   std::mutex mutex_;
 
   VkDevice device_;
+  std::string gpu_name_;
   QueryPoolConfig config_;
 
   VkQueryPool querypool_;
@@ -60,6 +61,11 @@ class QueryPool final {
 
  private:
   size_t write_timestamp(const CommandBuffer&);
+
+  std::string create_shader_event_name(
+      const ShaderDuration& entry,
+      const bool include_gpuname,
+      const bool include_idx);
 
   std::string generate_string_report();
 
@@ -79,6 +85,10 @@ class QueryPool final {
 
   void extract_results();
   void print_results();
+  std::string gen_string_for_aibench(
+      const bool include_gpuname = false,
+      const bool include_idx = true);
+
   uint64_t get_total_op_ns(std::string op_name);
   uint64_t ns_per_tick_;
   void shader_log_for_each(std::function<void(const ShaderDuration&)> fn);

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -233,6 +233,7 @@ class VulkanAPITest : public ::testing::Test {
       GTEST_SKIP() << "Vulkan is not available";
     }
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
+    at::native::vulkan::api::context()->enable_op_profiling();
     at::native::vulkan::api::context()->reset_querypool();
 #endif
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #86972
* #86971
* __->__ #86969

Adds some functionality in `QueryPool` to print out collected GPU timestamps in a format that can be displayed by AIBench, and add the ability to print this out in `speed_benchmark_torch`.

Differential Revision: [D40266073](https://our.internmc.facebook.com/intern/diff/D40266073/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D40266073/)!