### PR TITLE
Add a hypothesis fuzz test for consistency with numpy / across backends.

### DIFF
--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -7,7 +7,6 @@ import hypothesis
 import hypothesis.extra.numpy
 import hypothesis.strategies
 from numpy.testing import assert_array_equal
-from numpy.typing import DTypeLike
 
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import TestCase, run_tests
@@ -17,13 +16,13 @@ import torch.backends.mps
 
 
 @hypothesis.strategies.composite
-def ufunc_inputs(draw, ufunc, input_dtype: DTypeLike = np.int32):
+def ufunc_inputs(draw, ufunc, input_dtype: type = np.int32):
     shapes, result_shape = draw(mutually_broadcastable_shapes(signature=ufunc.signature))
     return [draw(hypothesis.extra.numpy.arrays(input_dtype, shape=shape)) for shape in shapes]
 
 
 @hypothesis.strategies.composite
-def where_inputs(draw, xy_dtype: DTypeLike = int):
+def where_inputs(draw, xy_dtype: type = int):
     # TODO: Could we do this with a ufunc sig? `where` doesn't seem to have one
     # @given(mutually_broadcastable_shapes(signature=np.where.signature))
     shapes, result_shape = draw(mutually_broadcastable_shapes(num_shapes=3))

--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -42,6 +42,7 @@ class TestConsistentWithNumpy(TestCase):
         torch_cpu_out = torch.matmul(*torch_inputs)
         # Make sure we get consistent results between numpy and CPU pytorch
         # `assert_array_almost_equal_nulp` handles nans badly, so just check the non-nan values
+        # In particular, `assert_array_almost_equal_nulp(math.nan, math.nan)` raises
         assert_array_almost_equal_nulp(np.nan_to_num(np_out), np.nan_to_num(torch_cpu_out.numpy()))
 
         torch_dev_inputs = [arr.to(device) for arr in torch_inputs]

--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -7,7 +7,6 @@ import hypothesis
 import hypothesis.extra.numpy
 import hypothesis.strategies
 from numpy.testing import assert_array_equal
-from hypothesis import reproduce_failure
 
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import TestCase, run_tests

--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -1,4 +1,3 @@
-from math import hypot
 import unittest
 from hypothesis import given
 from hypothesis.extra.numpy import mutually_broadcastable_shapes
@@ -14,7 +13,10 @@ import torch.cuda
 import torch.backends.mps
 
 
-AVAILABLE_BACKENDS = [backend_str for backend_str, backend in {"cuda": torch.cuda, "mps": torch.backends.mps}.items() if backend.is_available()]
+AVAILABLE_BACKENDS = [
+    backend_str for backend_str, backend in {"cuda": torch.cuda, "mps": torch.backends.mps}.items()
+    if backend.is_available()
+]
 
 
 @hypothesis.strategies.composite

--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -6,7 +6,7 @@ import numpy as np
 import hypothesis
 import hypothesis.extra.numpy
 import hypothesis.strategies
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal_nulp
 
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import TestCase, run_tests
@@ -41,12 +41,12 @@ class TestConsistentWithNumpy(TestCase):
         np_out = np.matmul(*inputs)
         torch_cpu_out = torch.matmul(*torch_inputs)
         # Make sure we get consistent results between numpy and CPU pytorch
-        assert_array_almost_equal(np_out, torch_cpu_out.numpy())
+        assert_array_almost_equal_nulp(np_out, torch_cpu_out.numpy())
 
         torch_dev_inputs = [arr.to(device) for arr in torch_inputs]
         torch_dev_out = torch.matmul(*torch_dev_inputs)
         # Now make sure every backend also produces identical results to numpy (and thus CPU pytorch)
-        assert_array_almost_equal(np_out, torch_dev_out.cpu().numpy())
+        assert_array_almost_equal_nulp(np_out, torch_dev_out.cpu().numpy())
 
     @given(where_inputs())
     def test_where_consistent(self, device, where_inputs):

--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -1,0 +1,75 @@
+from array import array
+from math import hypot
+from typing_extensions import Self
+import unittest
+from hypothesis import given
+from hypothesis.extra.numpy import mutually_broadcastable_shapes
+import numpy as np
+import hypothesis
+import hypothesis.extra.numpy
+import hypothesis.strategies
+from numpy.testing import assert_array_equal
+from numpy.typing import DTypeLike
+
+import torch
+import torch.cuda
+import torch.backends.mps
+
+
+AVAILABLE_BACKENDS = [backend_str for backend_str, backend in {"cuda": torch.cuda, "mps": torch.backends.mps}.items() if backend.is_available()]
+
+
+@hypothesis.strategies.composite
+def ufunc_inputs(draw, ufunc, input_dtype: DTypeLike = np.int32):
+    shapes, result_shape = draw(mutually_broadcastable_shapes(signature=ufunc.signature))
+    return [draw(hypothesis.extra.numpy.arrays(input_dtype, shape=shape)) for shape in shapes]
+
+
+@hypothesis.strategies.composite
+def where_inputs(draw, xy_dtype = int):
+    # TODO: Could we do this with a ufunc sig? `where` doesn't seem to have one
+    # @given(mutually_broadcastable_shapes(signature=np.where.signature))
+    shapes, result_shape = draw(mutually_broadcastable_shapes(num_shapes=3))
+    cond = draw(hypothesis.extra.numpy.arrays(bool, shape=shapes[0]))
+    x = draw(hypothesis.extra.numpy.arrays(xy_dtype, shape=shapes[1]))
+    y = draw(hypothesis.extra.numpy.arrays(xy_dtype, shape=shapes[2]))
+    return cond,x,y
+
+
+class TestConsistentWithNumpy(unittest.TestCase):
+
+    # TODO: This is very close to being able to be genericized over arbitrary ufuncs
+    @given(ufunc_inputs(np.matmul, input_dtype=np.float32))
+    def test_matmul_consistent(self, inputs):
+        torch_inputs = [torch.from_numpy(arr) for arr in inputs]
+        np_out = np.matmul(*inputs)
+        torch_cpu_out = torch.matmul(*torch_inputs)
+        # Make sure we get consistent results between numpy and CPU pytorch
+        assert_array_equal(np_out, torch_cpu_out.numpy())
+
+        for dev_str in AVAILABLE_BACKENDS:
+            dev = torch.device(dev_str)
+            torch_dev_inputs = [arr.to(dev) for arr in torch_inputs]
+            torch_dev_out = torch.matmul(*torch_dev_inputs)
+            # Now make sure every backend also produces identical results to numpy (and thus CPU pytorch)
+            assert_array_equal(np_out, torch_dev_out.cpu().numpy())
+
+    @given(where_inputs())
+    def test_where_consistent(self, where_inputs):
+        cond, x, y = where_inputs
+        t_cond, t_x, t_y = torch.from_numpy(cond), torch.from_numpy(x), torch.from_numpy(y)
+
+        np_out = np.where(cond, x, y)
+        torch_cpu_out = torch.where(t_cond, t_x, t_y)
+        # Make sure we get consistent results between numpy and CPU pytorch
+        assert_array_equal(np_out, torch_cpu_out.numpy())
+
+        for dev_str in AVAILABLE_BACKENDS:
+            dev = torch.device(dev_str)
+            torch_dev_out = torch.where(t_cond.to(dev), t_x.to(dev), t_y.to(dev))
+            # Now make sure every backend also produces identical results to numpy (and thus CPU pytorch)
+            assert_array_equal(np_out, torch_dev_out.cpu().numpy())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -41,12 +41,13 @@ class TestConsistentWithNumpy(TestCase):
         np_out = np.matmul(*inputs)
         torch_cpu_out = torch.matmul(*torch_inputs)
         # Make sure we get consistent results between numpy and CPU pytorch
-        assert_array_almost_equal_nulp(np_out, torch_cpu_out.numpy())
+        # `assert_array_almost_equal_nulp` handles nans badly, so just check the non-nan values
+        assert_array_almost_equal_nulp(np.nan_to_num(np_out), np.nan_to_num(torch_cpu_out.numpy()))
 
         torch_dev_inputs = [arr.to(device) for arr in torch_inputs]
         torch_dev_out = torch.matmul(*torch_dev_inputs)
         # Now make sure every backend also produces identical results to numpy (and thus CPU pytorch)
-        assert_array_almost_equal_nulp(np_out, torch_dev_out.cpu().numpy())
+        assert_array_almost_equal_nulp(np.nan_to_num(np_out), np.nan_to_num(torch_dev_out.cpu().numpy()))
 
     @given(where_inputs())
     def test_where_consistent(self, device, where_inputs):

--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -1,3 +1,5 @@
+# Owner(s): ["module: tests"]
+
 import unittest
 from hypothesis import given
 from hypothesis.extra.numpy import mutually_broadcastable_shapes

--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -43,12 +43,12 @@ class TestConsistentWithNumpy(TestCase):
         # Make sure we get consistent results between numpy and CPU pytorch
         # `assert_array_almost_equal_nulp` handles nans badly, so just check the non-nan values
         # In particular, `assert_array_almost_equal_nulp(math.nan, math.nan)` raises
-        assert_array_almost_equal_nulp(np.nan_to_num(np_out), np.nan_to_num(torch_cpu_out.numpy()))
+        assert_array_almost_equal_nulp(np.nan_to_num(np_out), np.nan_to_num(torch_cpu_out.numpy()), nulp=10)
 
         torch_dev_inputs = [arr.to(device) for arr in torch_inputs]
         torch_dev_out = torch.matmul(*torch_dev_inputs)
         # Now make sure every backend also produces identical results to numpy (and thus CPU pytorch)
-        assert_array_almost_equal_nulp(np.nan_to_num(np_out), np.nan_to_num(torch_dev_out.cpu().numpy()))
+        assert_array_almost_equal_nulp(np.nan_to_num(np_out), np.nan_to_num(torch_dev_out.cpu().numpy()), nulp=10)
 
     @given(where_inputs())
     def test_where_consistent(self, device, where_inputs):

--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -6,7 +6,7 @@ import numpy as np
 import hypothesis
 import hypothesis.extra.numpy
 import hypothesis.strategies
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import TestCase, run_tests
@@ -41,12 +41,12 @@ class TestConsistentWithNumpy(TestCase):
         np_out = np.matmul(*inputs)
         torch_cpu_out = torch.matmul(*torch_inputs)
         # Make sure we get consistent results between numpy and CPU pytorch
-        assert_array_equal(np_out, torch_cpu_out.numpy())
+        assert_array_almost_equal(np_out, torch_cpu_out.numpy())
 
         torch_dev_inputs = [arr.to(device) for arr in torch_inputs]
         torch_dev_out = torch.matmul(*torch_dev_inputs)
         # Now make sure every backend also produces identical results to numpy (and thus CPU pytorch)
-        assert_array_equal(np_out, torch_dev_out.cpu().numpy())
+        assert_array_almost_equal(np_out, torch_dev_out.cpu().numpy())
 
     @given(where_inputs())
     def test_where_consistent(self, device, where_inputs):

--- a/test/test_consistent_fuzz.py
+++ b/test/test_consistent_fuzz.py
@@ -1,6 +1,4 @@
-from array import array
 from math import hypot
-from typing_extensions import Self
 import unittest
 from hypothesis import given
 from hypothesis.extra.numpy import mutually_broadcastable_shapes
@@ -26,14 +24,14 @@ def ufunc_inputs(draw, ufunc, input_dtype: DTypeLike = np.int32):
 
 
 @hypothesis.strategies.composite
-def where_inputs(draw, xy_dtype = int):
+def where_inputs(draw, xy_dtype: DTypeLike = int):
     # TODO: Could we do this with a ufunc sig? `where` doesn't seem to have one
     # @given(mutually_broadcastable_shapes(signature=np.where.signature))
     shapes, result_shape = draw(mutually_broadcastable_shapes(num_shapes=3))
     cond = draw(hypothesis.extra.numpy.arrays(bool, shape=shapes[0]))
     x = draw(hypothesis.extra.numpy.arrays(xy_dtype, shape=shapes[1]))
     y = draw(hypothesis.extra.numpy.arrays(xy_dtype, shape=shapes[2]))
-    return cond,x,y
+    return cond, x, y
 
 
 class TestConsistentWithNumpy(unittest.TestCase):


### PR DESCRIPTION
Adds a second test that would have caught https://github.com/pytorch/pytorch/issues/86239

The `where` test now passes where it used to fail with
```
    | (shapes (1, 2), (2, 1) mismatch)
    |  x: array([[0, 0]])
    |  y: array([[0],
    |        [0]])
    | Falsifying example: test_where_consistent(
    |     where_inputs=(array([False, False]), array([[0]]), array(0)),
    |     self=<test_consistent_fuzz.TestConsistentWithNumpy testMethod=test_where_consistent>,
    | )
```

before the fix in #86240

The `matmul` test is currently failing locally on MPS, but I'm uncertain whether it is exercising behavior that torch cares to make consistent or not (e.g. numpy produces `inf` while pytorch produces `nan`)