### PR TITLE
[xnnpack][lite-int] preprocess

### DIFF
--- a/test/jit/xnnpack/test_xnnpack_delegate.py
+++ b/test/jit/xnnpack/test_xnnpack_delegate.py
@@ -1,0 +1,69 @@
+# Owner(s): ["oncall: jit"]
+
+import unittest
+
+import torch
+import torch._C
+
+torch.ops.load_library("//caffe2:xnnpack_backend")
+
+class TestXNNPackBackend(unittest.TestCase):
+    def test_xnnpack_lowering(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return x + x
+
+        scripted_module = torch.jit.script(Module())
+
+        faulty_compile_spec = {
+            "backward": {
+                "inputs" : [torch.zeros(1)],
+                "outputs": [torch.zeros(1)],
+            }
+        }
+        error_msg = (
+            "method_compile_spec does not contain the \"forward\" key."
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            error_msg,
+        ):
+            _ = torch._C._jit_to_backend(
+                "xnnpack",
+                scripted_module,
+                faulty_compile_spec,
+            )
+
+        mismatch_compile_spec = {
+            "forward" : {
+                "inputs" : [torch.zeros(1), torch.zeros(1)],
+                "outputs" : [torch.zeros(1)]
+            }
+        }
+        error_msg = ("method_compile_spec inputs do not match expected number of forward inputs")
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            error_msg,
+        ):
+            _ = torch._C._jit_to_backend(
+                "xnnpack",
+                scripted_module,
+                mismatch_compile_spec
+            )
+
+        lowered = torch._C._jit_to_backend(
+            "xnnpack",
+            scripted_module,
+            {
+                "forward": {
+                    "inputs" : [torch.zeros(1)],
+                    "outputs": [torch.zeros(1)],
+                }
+            }
+        )
+        lowered(torch.zeros(1))

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
@@ -1,0 +1,59 @@
+#include <ATen/Utils.h>
+#include <c10/core/TensorImpl.h>
+#include <torch/csrc/jit/backends/backend.h>
+#include <torch/csrc/jit/backends/backend_exception.h>
+
+#include <xnnpack.h>
+
+namespace torch {
+namespace jit {
+namespace xnnpack {
+namespace delegate {
+
+class XNNPackBackend : public PyTorchBackendInterface {
+ public:
+  // Constructor.
+  // NOLINTNEXTLINE(modernize-use-equals-default)
+  explicit XNNPackBackend() {}
+  // NOLINTNEXTLINE(modernize-use-override)
+  virtual ~XNNPackBackend() = default;
+
+  bool is_available() override {
+    return xnn_status_success == xnn_initialize(/*allocator=*/nullptr);
+  }
+
+  c10::impl::GenericDict compile(
+      c10::IValue processed,
+      c10::impl::GenericDict method_compile_spec) override {
+    auto dict = processed.toGenericDict();
+    c10::Dict<c10::IValue, c10::IValue> handles(
+        c10::StringType::get(), c10::AnyType::get());
+    handles.insert("forward", dict);
+
+    return handles;
+  }
+
+  // Currently this is not implemented, and everything is computed a head of
+  // time the current implementation just takes the computed results from ahead
+  // of time and grabs them. The inputs are fed in through the compile spec for
+  // the sake of testing. In reality, the inputs will be fed in at this stage
+  // and ran here.
+  c10::impl::GenericList execute(
+      c10::IValue handle,
+      c10::impl::GenericList inputs) override {
+    c10::List<at::Tensor> output_list;
+    auto answer = handle.toGenericDict().at("Answer");
+    output_list.emplace_back(answer.toTensor());
+    return c10::impl::toList(output_list);
+  }
+};
+
+namespace {
+constexpr auto backend_name = "xnnpack";
+static auto cls = torch::jit::backend<XNNPackBackend>(backend_name);
+} // namespace
+
+} // namespace delegate
+} // namespace xnnpack
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_preprocess.cpp
@@ -1,0 +1,96 @@
+#include <torch/csrc/jit/backends/backend.h>
+#include <torch/csrc/jit/backends/backend_preprocess.h>
+
+#include <torch/csrc/jit/tensorexpr/graph_opt.h>
+#include <torch/torch.h>
+#include <xnnpack.h>
+
+#include <ATen/core/List.h>
+
+namespace torch {
+namespace jit {
+namespace xnnpack {
+namespace delegate {
+
+// Expected method_compile_spec should look something like this:
+// {
+//     "forward" : {"inputs" : at::Tensor}
+// }
+// or
+// {
+//     "forward" : {"inputs" : c10::List<at::Tensor>}
+// }
+// in which the value for "inputs" is the input shape to the module.
+// The module fed to the xnnpack backend must first be traced in order
+// to propagate input shapes through the module. This is important
+// for building the xnnpack_subgraph_t object.
+c10::IValue preprocess(
+    const Module& mod,
+    const c10::Dict<c10::IValue, c10::IValue>& method_compile_spec,
+    const BackendDebugHandleGenerator& generate_debug_handles) {
+  auto output_min = -std::numeric_limits<float>::infinity();
+  auto output_max = std::numeric_limits<float>::infinity();
+
+  c10::Dict<IValue, IValue> compiled(StringType::get(), TensorType::get());
+
+  c10::IValue inp;
+  c10::IValue out;
+
+  TORCH_CHECK(
+      method_compile_spec.contains("forward"),
+      "method_compile_spec does not contain the \"forward\" key.");
+  auto innerDict = method_compile_spec.at("forward");
+
+  TORCH_CHECK(
+      innerDict.isGenericDict() &&
+          innerDict.toGenericDict().contains("inputs") &&
+          innerDict.toGenericDict().contains("outputs"),
+      "method_compile_spec does not contain a dictionary with an \"inputs\" key, under \"forward\" key.");
+
+  inp = innerDict.toGenericDict().at("inputs");
+  out = innerDict.toGenericDict().at("outputs");
+
+  TORCH_CHECK(
+      inp.isTensor() || inp.isTensorList(),
+      "method_compile_spec does not contain either a Tensor or TensorList, under it's \"inputs\" key.");
+  TORCH_CHECK(
+      out.isTensor() || out.isTensorList(),
+      "method_compile_spec does not contain either a Tensor or TensorList, under it's \"outputs\" key.");
+
+  // Graph preprocessing
+  const auto& forward_method = mod.get_method("forward");
+
+  auto graph = toGraphFunction(forward_method.function()).graph()->copy();
+  graph = tensorexpr::removeUnusedSelfArgument(graph);
+  std::vector<c10::IValue> example_inputs;
+  if (inp.isTensorList()) {
+    c10::List<at::Tensor> inp_list = inp.toTensorList();
+    TORCH_CHECK(
+        graph->inputs().size() == inp_list.size(),
+        "method_compile_spec inputs do not match expected number of forward inputs");
+
+    example_inputs.reserve(inp_list.size());
+    for (const auto i : c10::irange(inp_list.size())) {
+      graph->inputs()[i]->setType(TensorType::create(inp_list[i]));
+      example_inputs.emplace_back(inp_list[i]);
+    }
+  } else {
+    TORCH_CHECK(
+        graph->inputs().size() == 1,
+        "method_compile_spec inputs do not match expected number of forward inputs");
+
+    graph->inputs()[0]->setType(TensorType::create(inp.toTensor()));
+    example_inputs.emplace_back(inp.toTensor());
+  }
+
+  compiled.insert("Answer", at::empty({1}, c10::ScalarType::Float));
+
+  return compiled;
+}
+constexpr auto backend_name = "xnnpack";
+static auto pre_reg = backend_preprocess_register(backend_name, preprocess);
+
+} // namespace delegate
+} // namespace xnnpack
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86980

Split up original preprocess diff:

This diff introduces the skeleton structure of the delegate APIs. first introducing the method compile spec error handling. For now it just outputs an empty tensor object upon execute. But just proves that delegate apis is working and a new xnnpack delegate backend has been added.

Differential Revision: [D38562918](https://our.internmc.facebook.com/intern/diff/D38562918/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D38562918/)!