### PR TITLE
[xnnpack][lite-int][graph-build] torchscript -> xnnpack graph

### DIFF
--- a/test/jit/xnnpack/test_xnnpack_delegate.py
+++ b/test/jit/xnnpack/test_xnnpack_delegate.py
@@ -68,6 +68,67 @@ class TestXNNPackBackend(unittest.TestCase):
         )
         lowered(torch.zeros(1))
 
+    def test_xnnpack_backend_add(self):
+        class AddModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                z = x + y
+                z = z + x
+                z = z + x
+                return z
+
+        add_module = AddModule()
+        sample_inputs = (torch.rand(1, 512, 512, 3), torch.rand(1, 512, 512, 3))
+        sample_output = torch.zeros(1, 512, 512, 3)
+
+        add_module = torch.jit.script(add_module)
+        expected_output = add_module(sample_inputs[0], sample_inputs[1])
+
+        lowered_add_module = torch._C._jit_to_backend(
+            "xnnpack",
+            add_module,
+            {
+                "forward": {
+                    "inputs" : [sample_inputs[0], sample_inputs[1]],
+                    "outputs": [sample_output]
+                }
+            }
+        )
+
+        actual_output = lowered_add_module.forward(sample_inputs[0], sample_inputs[1])
+        self.assertTrue(torch.allclose(actual_output, expected_output, atol=1e-03, rtol=1e-03))
+
+    def test_xnnpack_broadcasting(self):
+        class AddModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                return x + y
+
+        add_module = AddModule()
+        sample_inputs = (torch.rand(5, 1, 4, 1), torch.rand(3, 1, 1))
+        sample_output = torch.zeros(5, 3, 4, 1)
+
+        add_module = torch.jit.script(add_module)
+        expected_output = add_module(sample_inputs[0], sample_inputs[1])
+
+        lowered_add_module = torch._C._jit_to_backend(
+            "xnnpack",
+            add_module,
+            {
+                "forward": {
+                    "inputs" : [sample_inputs[0], sample_inputs[1]],
+                    "outputs": [sample_output]
+                }
+            }
+        )
+
+        actual_output = lowered_add_module.forward(sample_inputs[0], sample_inputs[1])
+        self.assertTrue(torch.allclose(actual_output, expected_output, atol=1e-03, rtol=1e-03))
+
     def test_xnnpack_unsupported(self):
         class AddSpliceModule(torch.nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
@@ -41,10 +41,9 @@ class XNNPackBackend : public PyTorchBackendInterface {
   c10::impl::GenericList execute(
       c10::IValue handle,
       c10::impl::GenericList inputs) override {
-    c10::List<at::Tensor> output_list;
     auto answer = handle.toGenericDict().at("Answer");
-    output_list.emplace_back(answer.toTensor());
-    return c10::impl::toList(output_list);
+
+    return answer.toList();
   }
 };
 

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_preprocess.cpp
@@ -87,8 +87,25 @@ c10::IValue preprocess(
   // inp above has been confirmed to be either Tensor or TensorList
   XNNGraph graph_builder;
   graph_builder.buildXNNGraph(graph, example_inputs);
+  // at this point graph is complete, for the sake of testing preprocess at this
+  // point we will do runtime setup and run with some default values
 
-  compiled.insert("Answer", at::empty({1}, c10::ScalarType::Float));
+  // grabbing the inputs from compile spec for testing
+
+  std::vector<at::Tensor> inputs;
+  auto input_list = inp.toList();
+
+  for (int i = 0; i < input_list.size(); i++) {
+    inputs.push_back(input_list.get(i).toTensor());
+  }
+  std::vector<at::Tensor> outputs;
+  outputs.push_back(out.toList().get(0).toTensor());
+
+  graph_builder.runGraphOnInputs(inputs, outputs);
+
+  c10::List<at::Tensor> output_list(outputs);
+
+  compiled.insert("Answer", output_list);
 
   return compiled;
 }

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
@@ -37,6 +37,68 @@ void XNNGraph::buildXNNGraph(
     std::vector<c10::IValue> example_inputs) {
   graph = optimizeAndTraceGraph(graph, example_inputs);
   checkOpsToDelegate(graph);
+  gatherTensorValues(graph);
+
+  // count unique input/outputs (some inputs can be outputs)
+  std::unordered_set<torch::jit::Value*> externals;
+  for (auto inp : _inputs) {
+    externals.insert(inp);
+  }
+  for (auto out : _outputs) {
+    externals.insert(out);
+  }
+
+  // create subgraph
+  xnn_status status = xnn_create_subgraph(
+      /*external_value_ids=*/externals.size(),
+      /*flags=*/0,
+      &_subgraph_ptr);
+  TORCH_CHECK(xnn_status_success == status, "Failed to create xnn subgraph");
+
+  defineAllTensorValues();
+  defineAllNodes(graph);
+  // at this point graph is complete, for the sake of testing preprocess at
+  // this point we will do runtime setup and run with some default values
+}
+
+void XNNGraph::runGraphOnInputs(
+    std::vector<at::Tensor> tensor_inputs,
+    std::vector<at::Tensor> tensor_outputs) {
+  TORCH_CHECK(
+      _subgraph_ptr != nullptr,
+      "run buildXNNGraph before running graph on inputs");
+  xnn_runtime_t runtime = nullptr;
+  xnn_status status =
+      xnn_create_runtime_v2(_subgraph_ptr, nullptr, /*flags=*/0, &runtime);
+  TORCH_CHECK(
+      xnn_status_success == status,
+      "failed to create runtime for running inputs");
+
+  // smart pointer for runtime
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> auto_runtime(
+      runtime, xnn_delete_runtime);
+
+  std::vector<xnn_external_value> external_values;
+  TORCH_CHECK(
+      tensor_inputs.size() == _inputs.size(),
+      "supplied inputs does not match expected inputs");
+  for (int i = 0; i < tensor_inputs.size(); i++) {
+    external_values.push_back(
+        {_val_to_ids[_inputs[i]], tensor_inputs[i].data_ptr<float>()});
+  }
+
+  TORCH_CHECK(
+      tensor_outputs.size() == _outputs.size(),
+      "supplied outputs does not match expected outputs");
+  for (int i = 0; i < tensor_outputs.size(); i++) {
+    external_values.push_back(
+        {_val_to_ids[_outputs[i]], tensor_outputs[i].data_ptr<float>()});
+  }
+  status = xnn_setup_runtime(
+      auto_runtime.get(), external_values.size(), external_values.data());
+  TORCH_CHECK(xnn_status_success == status, "runtime not properly setup");
+
+  TORCH_CHECK(xnn_status_success == xnn_invoke_runtime(auto_runtime.get()));
 }
 
 void XNNGraph::checkOpsToDelegate(std::shared_ptr<torch::jit::Graph>& graph) {
@@ -64,6 +126,143 @@ void XNNGraph::checkOpsToDelegate(std::shared_ptr<torch::jit::Graph>& graph) {
       unsupported_ops.empty(),
       "the module contains the following unsupported ops:\n" + error.str());
 }
+
+void XNNGraph::defineAllNodes(std::shared_ptr<torch::jit::Graph>& graph) {
+  DepthFirstGraphNodeIterator it(graph);
+  Node* node = nullptr;
+  while ((node = it.next()) != nullptr) {
+    switch (node->kind()) {
+      case prim::Constant: {
+        break;
+      }
+      case aten::add: {
+        // todo: handle alpha for aten::add
+        uint32_t input1_id = _val_to_ids[node->inputs()[0]];
+        uint32_t input2_id = _val_to_ids[node->inputs()[1]];
+        TORCH_CHECK(
+            node->inputs()[2]->type()->cast<IntType>() == 1,
+            "non-1 alpha values not supported");
+        uint32_t output_id = _val_to_ids[node->outputs()[0]];
+
+        xnn_status status = xnn_define_add2(
+            _subgraph_ptr,
+            output_min,
+            output_max,
+            input1_id,
+            input2_id,
+            output_id,
+            /*flags=*/0);
+        TORCH_CHECK(status == xnn_status_success, "failed to create add node");
+        break;
+      }
+      default: {
+        throw std::exception();
+        TORCH_CHECK(
+            false,
+            "The node of ",
+            node->kind().toQualString(),
+            " is not supported yet");
+        break;
+      }
+    }
+  }
+}
+
+void XNNGraph::defineAllTensorValues() {
+  uint32_t external_id =
+      std::numeric_limits<decltype(XNN_INVALID_VALUE_ID)>::min();
+  for (auto val : _intermediate_tensors) {
+    if (_val_to_ids.find(val) == _val_to_ids.end()) {
+      uint32_t id = XNN_INVALID_VALUE_ID;
+
+      // cast value to tensortype
+      auto tensor_ptr = val->type()->cast<TensorType>();
+      auto num_dims = tensor_ptr->dim().value();
+
+      // create size_t* for tensor shape, casting must be done from long ->
+      // size_t
+      std::vector<long> sizes = tensor_ptr->sizes().concrete_sizes().value();
+      std::vector<size_t> tensor_shape;
+      tensor_shape.reserve(sizes.size());
+      for (auto dim : sizes) {
+        TORCH_CHECK(dim >= 0, "Input Dims should be unsigned");
+        tensor_shape.push_back(static_cast<size_t>(dim));
+      }
+
+      // ext_id value
+      uint32_t ext_id = XNN_INVALID_VALUE_ID;
+
+      // update flag for if tensor is either graph input/output
+      uint32_t flags = 0;
+
+      if (isGraphInput(val) || isGraphOutput(val)) {
+        if (isGraphInput(val)) {
+          flags |= XNN_VALUE_FLAG_EXTERNAL_INPUT;
+        }
+        if (isGraphOutput(val)) {
+          flags |= XNN_VALUE_FLAG_EXTERNAL_OUTPUT;
+        }
+        ext_id = external_id++;
+      }
+      xnn_status status = xnn_define_tensor_value(
+          /*subgraph=*/_subgraph_ptr,
+          /*datatype=*/xnn_datatype_fp32,
+          /*num_dims=*/num_dims,
+          /*dims=*/tensor_shape.data(),
+          /*data=*/nullptr, // currently no constant data
+          /*external_id=*/ext_id,
+          /*flags=*/flags,
+          /*id_out=*/&id);
+      TORCH_CHECK(
+          status == xnn_status_success,
+          "failed to define xnn_tensor_id for: " + val->debugName());
+      _val_to_ids.insert({val, id});
+    }
+  }
+}
+
+void XNNGraph::gatherTensorValues(std::shared_ptr<torch::jit::Graph>& graph) {
+  for (auto input : graph->inputs()) {
+    if (input->isCompleteTensor()) {
+      _intermediate_tensors.insert(input);
+      _inputs.push_back(input);
+    }
+  }
+
+  DepthFirstGraphNodeIterator it(graph);
+  Node* n = nullptr;
+  while ((n = it.next()) != nullptr) {
+    gatherNodeInputs(*n);
+  }
+
+  for (auto output : graph->outputs()) {
+    if (output->isCompleteTensor()) {
+      _intermediate_tensors.insert(output);
+      _outputs.push_back(output);
+    }
+  }
+}
+
+void XNNGraph::gatherNodeInputs(torch::jit::Node& node) {
+  switch (node.kind()) {
+    case aten::add: {
+      // this case will support all ops with only two inputs i.e. sub, add,
+      for (auto value : node.inputs()) {
+        if (value->isCompleteTensor()) {
+          _intermediate_tensors.insert(value);
+        }
+      }
+    }
+  }
+}
+
+bool XNNGraph::isGraphInput(torch::jit::Value* val) {
+  return std::count(_inputs.begin(), _inputs.end(), val) > 0;
+};
+
+bool XNNGraph::isGraphOutput(torch::jit::Value* val) {
+  return std::count(_outputs.begin(), _outputs.end(), val) > 0;
+};
 
 } // namespace delegate
 } // namespace xnnpack

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h
@@ -13,8 +13,19 @@ namespace delegate {
 
 class XNNGraph {
  private:
+  const float output_min = -std::numeric_limits<float>::infinity();
+  const float output_max = std::numeric_limits<float>::infinity();
+
   // xnn_subgraph
   xnn_subgraph_t _subgraph_ptr;
+  // Set of all the tensor values throughout the jit graph
+  std::unordered_set<torch::jit::Value*> _intermediate_tensors;
+  // Set of all the tensor values mapped to the xnnpack ids
+  std::unordered_map<torch::jit::Value*, uint32_t> _val_to_ids;
+  // Vector containing the torch valued inputs/outputs,
+  // must be ordered to preserve the order of input/outputs
+  std::vector<torch::jit::Value*> _inputs;
+  std::vector<torch::jit::Value*> _outputs;
 
   // Graph passes for optimizing and tracing torchscript graph
   // Essentially massaging the graph into a digestiable format for
@@ -23,8 +34,30 @@ class XNNGraph {
       std::shared_ptr<torch::jit::Graph> graph,
       std::vector<c10::IValue>& example_inputs);
 
+  // Gather all the intermediate tensor values within a graph. This
+  // skips through all prim constants. The purpose of this is for defining
+  // the tensor values beforehand for the xnnpack subgraph.
+  void gatherTensorValues(std::shared_ptr<torch::jit::Graph>& graph);
+
+  // Gathers the tensor values in a give node
+  void gatherNodeInputs(torch::jit::Node& node);
+
+  // Helper function to determine if a jit value is a graph input
+  bool isGraphInput(torch::jit::Value* val);
+
+  // Helper function to determine if a jit value is a graph output
+  bool isGraphOutput(torch::jit::Value* val);
+
+  // Defines all xnnpack nodes for the nodes in the graph
+  void defineAllNodes(std::shared_ptr<torch::jit::Graph>& graph);
+
+  // Defines all xnn tensor values used throughout the graph
+  void defineAllTensorValues();
+
   // Makes a pass through the graph and throws if any ops are unsupported
   void checkOpsToDelegate(std::shared_ptr<torch::jit::Graph>& graph);
+
+
 
  public:
   XNNGraph() : _subgraph_ptr(nullptr) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #86986
* #86981
* #86980

This point we perform conversion for Torchscript IR to XNNPack graph. Currently we only support converting Add Nodes and fp32 tensor values.

As a caveat, we are not building this at runtime. So for testing we just run the xnn graph once ahead of time and with sample inputs and forward it to execute. This is only for testing, and will be changed in a later diff. This will allow us to check that graph creation is sound.

Differential Revision: [D39838851](https://our.internmc.facebook.com/intern/diff/D39838851/)