### PR TITLE
Add some common tools to docker base

### DIFF
--- a/.circleci/docker/common/install_base.sh
+++ b/.circleci/docker/common/install_base.sh
@@ -68,7 +68,9 @@ install_ubuntu() {
     sudo \
     vim \
     jq \
-    libtool
+    libtool \
+    unzip \
+    gdb
 
   # Should resolve issues related to various apt package repository cert issues
   # see: https://github.com/pytorch/pytorch/issues/65931
@@ -126,7 +128,9 @@ install_centos() {
     opencv-devel \
     sudo \
     wget \
-    vim
+    vim \
+    unzip \
+    gdb
 
   # Cleanup
   yum clean all


### PR DESCRIPTION
I always need to install these 2 tools whenever I use Docker manually to debug build and test issues:

* unzip is to extracted the zipped artifacts from PyTorch CI
* gdb is to do you know what :)

IMO, it makes sense to have them as part of the container image
