### PR TITLE
Allow custom backend to execute getitem when they want

### DIFF
--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -42,15 +42,7 @@ class CapabilityBasedPartitioner:
         self.allows_single_node_partition = allows_single_node_partition
 
     def __is_node_supported(self, node: Node) -> bool:
-        return (
-            self.operator_support.is_node_supported(dict(self.graph_module.named_modules()), node)
-            and
-            # reject 'getitem' node since they are special cased in partitioning.
-            (
-                node.op != "call_function" or
-                _get_qualified_name(node.target) != "_operator.getitem"    # type: ignore[arg-type]
-            )
-        )
+        return self.operator_support.is_node_supported(dict(self.graph_module.named_modules()), node)
 
     def propose_partitions(self) -> List[Partition]:
         # assumptions: nodes in candidate list is sorted in topological order


### PR DESCRIPTION
If a backend wants to execute getitem, `CapabilityBasedPartitioner` should let that backend to execute getitem if that backend wants. The function getitem is just a normal Python function. If `CapabilityBasedPartitioner` rejects to partition getitem, it will cause 2x slow down when running ONNXRuntime via TorchDynamo.

Figure 1. Profiling result when rejecting getitem. There are much more sub-graphs (each gray bin below "F" bin is a sub-graph) and there is a launching cost for each of them.
![image](https://user-images.githubusercontent.com/3524474/195960391-0b69514a-6a86-4400-80c7-33e1b000764f.png)

Figure 2. Profiling result when partitioning getitem (each gray bin below "F" bin is a sub-graph). Most BERT-base is partitioned into a single sub-graph.
![image](https://user-images.githubusercontent.com/3524474/195960508-524e0524-9aa4-4141-843d-95ba1b0fac7f.png)
