### PR TITLE
Update action lint with missing new runners from scale-config

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,9 +5,12 @@ self-hosted-runner:
     - linux.large
     - linux.2xlarge
     - linux.4xlarge
+    - linux.12xlarge
+    - linux.24xlarge
     - linux.4xlarge.nvidia.gpu
     - linux.8xlarge.nvidia.gpu
     - linux.16xlarge.nvidia.gpu
+    - linux.g5.4xlarge.nvidia.gpu
     - windows.4xlarge
     - windows.8xlarge.nvidia.gpu
     - bm-runner


### PR DESCRIPTION
Using runner label like `linux.12xlarge` results in linter failure from actionlint, i.e. https://github.com/pytorch/pytorch/actions/runs/3253740221/jobs/5341281952

```
Error (ACTIONLINT) [runner-label]
    label "linux.12xlarge" is unknown. available labels are "windows-
    latest", "windows-2022", "windows-2019", "windows-2016", "ubuntu-
    latest", "ubuntu-22.04", "ubuntu-20.04", "ubuntu-[18](https://github.com/pytorch/pytorch/actions/runs/3253740221/jobs/5341281952#step:7:19).04", "macos-latest",
    "macos-12", "macos-12.0", "macos-11", "macos-11.0", "macos-10.15",
    "self-hosted", "x64", "arm", "arm64", "linux", "macos", "windows",
    "linux.[20](https://github.com/pytorch/pytorch/actions/runs/3253740221/jobs/5341281952#step:7:21)_04.4x", "linux.20_04.16x", "linux.large", "linux.2xlarge",
    "linux.4xlarge", "linux.4xlarge.nvidia.gpu", "linux.8xlarge.nvidia.gpu",
    "linux.16xlarge.nvidia.gpu", "windows.4xlarge",
    "windows.8xlarge.nvidia.gpu", "bm-runner", "linux.rocm.gpu", "macos-m1-
    12", "macos-12-xl", "macos-12", "macos12.3-m1". if it is a custom label
    for self-hosted runner, set list of labels in actionlint.yaml config file

         47  |            # an OOM issue when running the job, so this upgrades the runner from 4xlarge
         48  |            # to the next available tier of 12xlarge. So much memory just to generate cpp
         49  |            # doc
    >>>  50  |            runner: linux.12xlarge
         51  |            # Nightly cpp docs take about 150m to finish, and the number is stable
         52  |            timeout-minutes: 180
         53  |          - docs_type: python
```

`linux.12xlarge` is a valid runner label from https://github.com/pytorch/test-infra/blob/main/.github/scale-config.yml. This also adds `linux.24xlarge` and `linux.g5.4xlarge.nvidia.gpu`, which are also not added yet
