### PR TITLE
Enables `where` to have cpu scalar args

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -14,7 +14,6 @@
 #include <ATen/native/TypeProperties.h>
 #include <c10/core/QScheme.h>
 #include <ATen/TensorSubclassLikeUtils.h>
-
 namespace at {
 namespace meta {
 
@@ -399,8 +398,19 @@ static void isin_sorting(
   }
 }
 
+template<typename... Args>
+Device out_device(Args&... inps){
+  for (const auto& i : {inps...}){
+    if (i.device() != at::kCPU) {
+      return i.device();
+    }
+  }
+  return at::kCPU;
+}
+
+
 Tensor& where_self_out(const Tensor& condition, const Tensor& self, const Tensor& other, Tensor& out) {
-  Tensor self_, other_;
+  Tensor self_, other_, condition_;
   if (self.dtype() != other.dtype()) {
     auto result_type = at::native::result_type(self, other);
     self_ = self.to(result_type);
@@ -409,16 +419,30 @@ Tensor& where_self_out(const Tensor& condition, const Tensor& self, const Tensor
     self_ = self;
     other_ = other;
   }
+  auto device = out_device(condition, self_, other_);
+  condition_ = condition;
+  if (device != at::kCPU) { // allow CPU scalars on non-cpu device
+    if (condition.device() != device && condition.ndimension() == 0) {
+      condition_ = condition.to(device);
+    }
+    if (self_.device() != device && self_.ndimension() == 0) {
+        self_ = self_.to(device);
+    }
+    if (other_.device() != device && other_.ndimension() == 0) {
+        other_ = other_.to(device);
+    }
+  }
   if (condition.scalar_type() == ScalarType::Byte) {
   TORCH_WARN_ONCE("where received a uint8 condition tensor. This behavior is deprecated and will be removed in a future version of PyTorch. Use a boolean condition instead.");
   } else {
   TORCH_CHECK(condition.scalar_type() == ScalarType::Bool, "where expected condition to be a boolean tensor, but got a tensor with dtype ", condition.scalar_type());
   }
-  Tensor cond_bool = condition.scalar_type() == ScalarType::Byte ? condition.to(ScalarType::Bool) : condition;
+  condition_ = condition_.scalar_type() == ScalarType::Byte ? condition_.to(ScalarType::Bool) : condition_;
+  // if there's still a device mismatch, let tensoriterator error out with it
   auto iter = at::TensorIteratorConfig()
     .check_all_same_dtype(false)
     .add_output(out)
-    .add_input(cond_bool)
+    .add_input(condition_)
     .add_input(self_)
     .add_input(other_)
     .build();
@@ -426,9 +450,11 @@ Tensor& where_self_out(const Tensor& condition, const Tensor& self, const Tensor
   return out;
 }
 
+
 Tensor where(const Tensor& condition, const Tensor& self, const Tensor& other) {
+  auto device = out_device(condition, self, other);
   auto result_type = at::native::result_type(self, other);
-  Tensor ret = at::empty({0}, self.options().dtype(result_type));
+  Tensor ret = at::empty({0}, self.options().dtype(result_type).device(device));
   at::native::where_self_out(condition, self, other, ret);
   return ret;
 }

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -14,6 +14,7 @@
 #include <ATen/native/TypeProperties.h>
 #include <c10/core/QScheme.h>
 #include <ATen/TensorSubclassLikeUtils.h>
+
 namespace at {
 namespace meta {
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5118,6 +5118,14 @@ else:
 
                 check_equal(condition, x, y)
                 check_equal(condition, y, x)
+                if self.device_type == "cuda":
+                    check_equal(condition, torch.tensor(x), y)
+                    check_equal(condition, y, torch.tensor(x))
+                    if not isinstance(y, torch.Tensor):
+                        check_equal(condition, torch.tensor(y), torch.tensor(x))
+                    if isinstance(y, torch.Tensor) and y.ndim > 0:
+                        check_equal(torch.tensor(True), x, y)
+                        check_equal(torch.tensor(True), y, x)
 
 
     def test_hook_remove(self, device):


### PR DESCRIPTION
This is for decompositions only, no attempt made to have good performance for this case. 
