### PR TITLE
[torchdynamo] Use ProcessPoolExecutor for triton compiles

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -51,7 +51,7 @@ unroll_reductions_threshold = 8
 
 comment_origin = False
 
-compile_threads = 1
+compile_threads = min(32, os.cpu_count())
 
 # How to import torchinductor, either torchinductor or torch.inductor
 inductor_import = __name__.replace(".config", "")

--- a/torch/_inductor/triton_ops/autotune.py
+++ b/torch/_inductor/triton_ops/autotune.py
@@ -3,7 +3,6 @@ import copy
 import hashlib
 import json
 import logging
-import multiprocessing
 import os.path
 import re
 import threading
@@ -12,7 +11,6 @@ from typing import List
 import torch
 
 from .. import config
-from ..codecache import AsyncCompile
 from ..ir import ReductionHint
 from ..triton_ops.mm_perf_model import estimate_matmul_time
 from ..utils import conditional_product, has_triton
@@ -53,36 +51,34 @@ class CachingAutotuner(KernelInterface):
         self.launchers = []
         self.lock = threading.Lock()
 
-    def precompile(self):
+    def precompile(self, warm_cache_only_with_cc=None):
         with self.lock:
             if self.launchers:
                 return
-            self.launchers = AsyncCompile.map(self._precompile_config, self.configs)
+            self.launchers = [
+                self._precompile_config(c, warm_cache_only_with_cc)
+                for c in self.configs
+            ]
             self.configs = None
 
-    def _precompile_config(self, cfg: Config):
+    def _precompile_config(self, cfg: Config, warm_cache_only_with_cc: int):
         """Ahead of time compile a given autotuner config."""
-        torch.cuda.set_device(torch.cuda.current_device())
         compile_meta = copy.deepcopy(self.meta)
         for k, v in cfg.kwargs.items():
             compile_meta["constants"][self.fn.arg_names.index(k)] = v
         compile_meta["num_warps"] = cfg.num_warps
         compile_meta["num_stages"] = cfg.num_stages
 
-        if config.compile_threads > 1:
-            major, minor = torch.cuda.get_device_capability(compile_meta["device"])
-            compile_meta["cc"] = major * 10 + minor
-            try:
-                p = multiprocessing.Process(
-                    target=triton.compile,
-                    args=(self.fn,),
-                    kwargs={**compile_meta, "warm_cache_only": True},
-                )
-                p.start()
-                p.join()
-            except Exception:
-                log.exception("Error in async Triton compile")
-                # continue on to hopefully get a better error message below
+        if warm_cache_only_with_cc:
+            triton.compile(
+                self.fn,
+                warm_cache_only=True,
+                cc=warm_cache_only_with_cc,
+                **compile_meta,
+            )
+            return
+
+        torch.cuda.set_device(torch.cuda.current_device())
 
         binary = triton.compile(
             self.fn,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #87032

This patch significantly improves the parallel compilation performance for cThis patch significantly improves the parallel compilation performance for compiling triton kernels
by using ProcessPoolExecutor to create persistent pool of compilation
workers.

Previously os.fork overhead and GIL contention limited the achieved
parallelism. This patch replaces
the worker threads with a pool of processes to do the raw compilation,
and does serial work on the main thread
for everything else. This other work couldn't be parallelized anyway
since it is mostly in python.

In cold start situations, the time to get the worker threads started can
be significant portion of the time.
This patch starts the workers earlier so they are ready to perform
compilation (see code comments) when dynamo
gets to that point.

Just tested this on one example benchmark (tf_efficientnet_b0), but the
results are significant, almost eliminating the difference between a
warm and cold compilation.

```
39.613s - warm
41.290s - cold, this patch

2m53.197s - cold, single threaded:
1m7.092s - cold, old setup n = 8 (its best config)
```
 (cold compilation is done after running `rm -rf
/tmp/torchinductor_$USER`).ompiling triton kernels
by using ProcessPoolExecutor to create persistent pool of compilation workers.

Previously os.fork overhead and GIL contention limited the achieved parallelism. This patch replaces
the worker threads with a pool of processes to do the raw compilation, and does serial work on the main thread
for everything else. This other work couldn't be parallelized anyway since it is mostly in python.

In cold start situations, the time to get the worker threads started can be significant portion of the time.
This patch starts the workers earlier so they are ready to perform compilation (see code comments) when dynamo
gets to that point.

Just tested this on one example benchmark (tf_efficientnet_b0), but the results are significant, almost eliminating the difference between a warm and cold compilation.

```
39.613s - warm
41.290s - cold, this patch

2m53.197s - cold, single threaded:
1m7.092s - cold, old setup n = 8 (its best config)
```
 (cold compilation is done after running `rm -rf /tmp/torchinductor_$USER`).