### PR TITLE
[TorchDynamo]: fused bias for cpu convolution path

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1075,7 +1075,9 @@ def convolution(
     groups: int,
 ):
     is_cpu = all(
-        input.get_device().type == "cpu" for input in (x, weight, bias) if input is not None
+        input.get_device().type == "cpu"
+        for input in (x, weight, bias)
+        if input is not None
     )
     result = TensorBox.create(
         ir.Convolution.create(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1083,7 +1083,7 @@ def convolution(
         ir.Convolution.create(
             x,
             weight,
-            bias if inputs_is_cpu else None,  # For cpu path, bias can always be fused
+            bias if is_cpu else None,  # For cpu path, bias can always be fused
             stride,
             padding,
             dilation,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1075,7 +1075,7 @@ def convolution(
     groups: int,
 ):
     is_cpu = all(
-        input.get_device().type == "cpu" for input in (x, w, bias) if input is not None
+        input.get_device().type == "cpu" for input in (x, weight, bias) if input is not None
     )
     result = TensorBox.create(
         ir.Convolution.create(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #87050

For aten.convolution CPU path, the bias always can be fused, so this PR adds a device check: if inputs' device is CPU, we will fuse it for a good performance.


cc @jansel @lezcano @fdrocha