### PR TITLE
fix cudagraphify for inplace parameter change

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4018,6 +4018,42 @@ if HAS_CUDA:
             )
             self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))
 
+        @patch.object(config.triton, "cudagraphs", True)
+        def test_inplace_updates_cudagraphs(self):
+            class Repro(torch.nn.Module):
+                def __init__(self):
+                    super(Repro, self).__init__()
+                    self.weight1 = torch.nn.Parameter(
+                        torch.randn(10, 20, requires_grad=True)
+                    )
+
+                def forward(self, x):
+                    x = torch.matmul(x, self.weight1)
+                    return x
+
+            from copy import deepcopy
+
+            model = Repro().cuda()
+            model_ref = deepcopy(model)
+            model_opt = torch._dynamo.optimize("inductor")(model)
+
+            input = torch.randn(10, 10, device="cuda", requires_grad=True)
+
+            for i in range(2):
+                output_ref = model_ref(input)
+                output_res = model_opt(input)
+                output_ref.sum().backward()
+                output_res.sum().backward()
+                for (p_ref, p_res) in zip(
+                    model_ref.parameters(), model_opt.parameters()
+                ):
+                    self.assertEqual(p_ref.grad, p_res.grad)
+                with torch.no_grad():
+                    for param in model_ref.parameters():
+                        param.add_(1.0)
+                    for param in model_opt.parameters():
+                        param.add_(1.0)
+
         def test_accuracy_issue1(self):
             class Repro(torch.nn.Module):
                 def __init__(self):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -231,7 +231,7 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
     inputs = [x.to("cuda") if is_unspec_input(x) else x for x in inputs]
 
     static_inputs = [
-        static_input(x) if idx not in static_input_idxs else x
+        static_input(x) if idx not in static_input_idxs else x.detach()
         for idx, x in enumerate(inputs)
     ]
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchdynamo/issues/1687
cc @albanD, @chillee, I don't know what I'm doing. 
According to previous discussions, calling `detach()` on inputs can cause bugs if inputs are later inplace-resized (cc @ezyang) https://github.com/pytorch/pytorch/pull/85301/files#diff-8678402e01603e588fcf175a61de9ed578d885b1cc082e028021856190223fb7L433, but should we weed out these patterns before they are sent to cudagraphify?