### PR TITLE
Intercept aten._reshape_alias for nvFuser

### DIFF
--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -405,6 +405,12 @@ class TorchRefsNvfuserCapabilityMode(TorchRefsMode):
                 warn("view has ignored kwargs!")
             return torch.ops.nvprims.view(a, shape)
 
+        if orig_func == torch.ops.aten._reshape_alias.default:
+            a, shape, stride = args
+            if len(kwargs) > 0:
+                warn("view has ignored kwargs!")
+            return torch.ops.nvprims.view(a, shape)
+
         if self._is_native_batch_norm(orig_func):
             return torch.ops.nvprims.native_batch_norm(*args, **kwargs)
 


### PR DESCRIPTION
This would help forming larger fusion groups. If this won't end up executed by nvFuser then eager mode implementation would call into `.reshape`: https://github.com/pytorch/pytorch/blob/37e9e89afbc3554258545a026fab4cd9e1a4b85d/torch/_prims/nvfuser_prims.py#L552-L553

cc @kevinstephano @jjsjann123