### PR TITLE
[Kineto][Profiler] Guard event metadata python thread via verbose flag

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -134,11 +134,15 @@ struct AddTensorboardFields : public MetadataBase {
 };
 
 struct AddGenericMetadata : public MetadataBase {
-  AddGenericMetadata(std::shared_ptr<Result>& result) : MetadataBase(result) {
+  AddGenericMetadata(std::shared_ptr<Result>& result, const bool verbose)
+      : MetadataBase(result) {
     result->visit(*this);
-    result->visit_if_base<PyExtraFieldsBase>([&, this](const auto& i) -> void {
-      this->addMetadata("Python thread", std::to_string(i.python_tid_));
-    });
+    if (verbose) {
+      result->visit_if_base<PyExtraFieldsBase>(
+          [&, this](const auto& i) -> void {
+            this->addMetadata("Python thread", std::to_string(i.python_tid_));
+          });
+    }
   }
 
   void operator()(ExtraFields<EventType::TorchOp>& op_event) {
@@ -311,7 +315,7 @@ struct KinetoThreadLocalState : public ProfilerStateBase {
 
         kineto_events_.emplace_back(e, config_.experimental_config.verbose);
         AddTensorboardFields add_tb(e, kineto_events_.back());
-        AddGenericMetadata add_generic(e);
+        AddGenericMetadata add_generic(e, config_.experimental_config.verbose);
 
         // It is not safe to use the activity after post processing.
         e->kineto_activity_ = nullptr;


### PR DESCRIPTION
Summary: For Python Tracing enabled trace files, this field "python thread": 0 is repeated for every python_function event. This bloats the trace json size for large number of events or deep call stacks. Instead make this metadata guarded by the verbose flag.

Test Plan: CI

Reviewed By: robieta, slgong-fb

Differential Revision: D40325815

Pulled By: aaronenyeshi

