### PR TITLE
Don't only apply DDP optimizer on forward frames

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -224,7 +224,7 @@ def catch_errors_wrapper(callback):
                 return None
             if config.optimize_ddp:
                 ddp_module = DistributedDataParallel._get_active_ddp_module()
-                if ddp_module and frame.f_code.co_name == "forward":
+                if ddp_module:
                     with compile_lock:
                         ddp_optimizer = DDPOptimizer(
                             bucket_bytes_cap=ddp_module.bucket_bytes_cap,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #87097

Previously a check would only apply DDP optimizer on frames named "forward".

But on hf_T5_large, a graph break causes some frames like:

```
<graph break in _shift_right>
<graph break in forward>
```

So instead, apply DDP optimizer on all frames.