### PR TITLE
[triton] allow cuda properties to be queried from workers

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -51,8 +51,7 @@ unroll_reductions_threshold = 8
 
 comment_origin = False
 
-# compile_threads = min(32, os.cpu_count())
-compile_threads = 1  # temporarily disabled to work around fork issue
+compile_threads = min(32, os.cpu_count())
 
 # How to import torchinductor, either torchinductor or torch.inductor
 inductor_import = __name__.replace(".config", "")

--- a/torch/_inductor/cuda_properties.py
+++ b/torch/_inductor/cuda_properties.py
@@ -1,0 +1,46 @@
+import functools
+
+import torch
+
+
+# API to query cuda properties that will work in a triton compile process
+# that cannot use the GPU APIs (due to processing fork() and initialization
+# time issues). Properties are recorded in the main process before
+# we fork the workers.
+
+
+@functools.lru_cache(None)
+def _properties():
+    r = {
+        i: torch.cuda.get_device_properties(i) for i in range(torch.cuda.device_count())
+    }
+    return r
+
+
+_compile_worker_current_device = None
+
+
+def set_compiler_worker_current_device(device):
+    global _compile_worker_current_device
+    _compile_worker_current_device = device
+
+
+def current_device():
+    if _compile_worker_current_device is not None:
+        return _compile_worker_current_device
+    return torch.cuda.current_device()
+
+
+def _device(device):
+    if device is not None:
+        return device
+    return current_device()
+
+
+def get_device_properties(device=None):
+    return _properties()[_device(device)]
+
+
+def get_device_capability(device=None):
+    p = get_device_properties(device)
+    return p.major, p.minor

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -21,6 +21,7 @@ from torch._prims_common import is_boolean_dtype, is_float_dtype
 
 from . import config, dependencies
 from .codegen.common import index_prevent_reordering
+from .cuda_properties import get_device_properties
 from .dependencies import extract_read_writes, var_builder
 from .utils import cache_on_self, sympy_dot, sympy_product, sympy_subs
 from .virtualized import ops, V
@@ -450,7 +451,7 @@ class Reduction(Loops):
         reduction_type,
         reduction_numel,
     ):
-        num_sm = torch.cuda.get_device_properties(device).multi_processor_count
+        num_sm = get_device_properties(device).multi_processor_count
         min_elements_per_thread = 32
         max_elements_per_thread = 512
         threads_per_sm = 2048

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -18,6 +18,7 @@ from torch._prims_common import (
 )
 
 from . import config, ir, overrides
+from .cuda_properties import current_device
 from .decomposition import decompositions, get_decompositions
 from .ir import (
     ExpandView,
@@ -118,7 +119,7 @@ def decode_device(device):
     if isinstance(device, str):
         device = torch.device(device)
     if device.type == "cuda" and device.index is None:
-        return torch.device("cuda", index=torch.cuda.current_device())
+        return torch.device("cuda", index=current_device())
     return device
 
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -16,6 +16,7 @@ import torch
 from torch.fx.immutable_collections import immutable_dict, immutable_list
 
 from . import config
+from .cuda_properties import get_device_capability
 
 VarRanges = Dict[sympy.Expr, sympy.Expr]
 
@@ -35,7 +36,7 @@ def has_triton():
     try:
         import triton
 
-        return triton is not None and torch.cuda.get_device_capability() >= (7, 0)
+        return triton is not None and get_device_capability() >= (7, 0)
     except ImportError:
         return False
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/pull/87048 by saving the needed properties before fork. 

Actually attempting to get CUDA to load in the workers is probably not desired: cuda initialization takes O(seconds). Having multiple processes using the same device will slow things down. 

This just moves the needed properties from the main trainer process to the workers.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #87101

