### PR TITLE
Set maximum 1536 threads per SM on sm_87 and sm_89

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -255,13 +255,13 @@ using namespace c10::hip;
 // constants from
 // (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications)
 // The maximum number of threads per multiprocessor is 1024 for Turing
-// architecture (7.5), 1536 for Geforce Ampere (8.6), and 2048 for all other
-// architectures. You'll get warnings if you exceed these constants. Hence, the
-// following macros adjust the input values from the user to resolve potential
-// warnings.
+// architecture (7.5), 1536 for Geforce/Jetson Ampere (8.6, 8.7) and Ada
+// Lovelace (8.9), and 2048 for all other architectures. You'll get warnings
+// if you exceed these constants. Hence, the following macros adjust the input
+// values from the user to resolve potential warnings.
 #if __CUDA_ARCH__ == 750
 constexpr uint32_t CUDA_MAX_THREADS_PER_SM = 1024;
-#elif __CUDA_ARCH__ == 860
+#elif __CUDA_ARCH__ == 860 || __CUDA_ARCH__ == 870 || __CUDA_ARCH__ == 890
 constexpr uint32_t CUDA_MAX_THREADS_PER_SM = 1536;
 #else
 constexpr uint32_t CUDA_MAX_THREADS_PER_SM = 2048;


### PR DESCRIPTION
When compiling pytorch with CUDA 11.8 and sm_89 support, I received numerous ptxas warnings, such as

```
ptxas warning : Value of threads per SM for entry _ZN2at6native38_GLOBAL__N__7d852361_6_RNN_cu_08bf8c056kernel17lstm_cell_forwardIffiLi2EEEvNS_4cuda6detail10TensorInfoIT_T1_EES9_S9_S9_S9_S9_S9_S9_S8_S8_ is out of range. .minnctapersm will be ignored
```

Per the [CUDA docs](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications), capability 8.7 should also have a maximum of 1536 threads per SM. Capability 8.9 is conspicuously missing from this list, but running deviceQuery from the CUDA samples shows it to also be 1536.

```
Device 0: "NVIDIA GeForce RTX 4090"
  CUDA Driver Version / Runtime Version          11.8 / 11.8
  CUDA Capability Major/Minor version number:    8.9
  Total amount of global memory:                 24256 MBytes (25433735168 bytes)
MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM
MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM
  (128) Multiprocessors, (128) CUDA Cores/MP:    16384 CUDA Cores
  GPU Max Clock rate:                            2535 MHz (2.54 GHz)
  Memory Clock rate:                             10501 Mhz
  Memory Bus Width:                              384-bit
  L2 Cache Size:                                 75497472 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        102400 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     Yes
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Disabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes

```