### PR TITLE
Tweak several test serialization to store models state_dict

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -844,11 +844,11 @@ class TestSerialization(TestCase, SerializationMixin):
         big_model = torch.nn.Conv2d(20000, 320000, kernel_size=3, device='meta')
 
         with BytesIOContext() as f:
-            torch.save(big_model, f)
+            torch.save(big_model.state_dict(), f)
             f.seek(0)
             state = torch.load(f)
 
-        self.assertEqual(state.weight.size(), big_model.weight.size())
+        self.assertEqual(state['weight'].size(), big_model.weight.size())
 
 
     def run(self, *args, **kwargs):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -828,7 +828,7 @@ class TestSerialization(TestCase, SerializationMixin):
         big_model = torch.nn.Conv2d(20000, 3200, kernel_size=3)
 
         with BytesIOContext() as f:
-            torch.save(big_model, f)
+            torch.save(big_model.state_dict(), f)
             f.seek(0)
             state = torch.load(f)
 
@@ -837,7 +837,7 @@ class TestSerialization(TestCase, SerializationMixin):
 
         with TemporaryFileName() as fname:
             path = pathlib.Path(fname)
-            torch.save(model, path)
+            torch.save(model.state_dict(), path)
             torch.load(path)
 
     def test_meta_serialization(self):


### PR DESCRIPTION
Namely, change:
- `test_meta_serialization`
- `test_serialization_2gb_file`
- `test_pathlike_serialization`