### PR TITLE
Add support for .to() for NestedTensor backends

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2215,6 +2215,7 @@
     QuantizedCPU, QuantizedCUDA: empty_like_quantized
     SparseCPU, SparseCUDA, SparseMeta: empty_like_sparse_coo
     SparseCsrCPU, SparseCsrCUDA: empty_like_sparse_csr
+    NestedTensorCPU, NestedTensorCUDA: empty_like_nested
   autogen: empty_like.out
 
 - func: empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
@@ -6739,6 +6740,7 @@
   device_guard: False
   dispatch:
     CompositeExplicitAutograd: _to_copy
+    NestedTensorCPU, NestedTensorCUDA: _to_copy_nested
   autogen: _to_copy.out
   tags: canonical
 

--- a/aten/src/ATen/native/nested/NestedTensorFactories.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorFactories.cpp
@@ -1,0 +1,114 @@
+#include <ATen/ATen.h>
+#include <ATen/native/nested/NestedTensorFactories.h>
+#include <ATen/native/nested/NestedTensorUtils.h>
+
+namespace at {
+namespace native {
+
+TensorOptions verify_empty_parameters(
+    const at::Tensor& self,
+    c10::optional<ScalarType> dtype,
+    c10::optional<Layout> layout,
+    c10::optional<Device> device,
+    c10::optional<bool> pin_memory,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  TensorOptions options_ =
+      TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(
+          pin_memory);
+
+  TORCH_CHECK(
+      !(options_.has_memory_format() && optional_memory_format.has_value()),
+      "Cannot set memory_format both in TensorOptions and explicit argument; please delete "
+      "the redundant setter.");
+  TensorOptions options = self.options().merge_in(options_).merge_memory_format(
+      optional_memory_format);
+
+  auto memory_format =
+      options_.memory_format_opt().value_or(MemoryFormat::Preserve);
+  TORCH_CHECK(
+      memory_format == MemoryFormat::Preserve,
+      "empty_like_nested only supports memory format Preserve, but got ",
+      memory_format,
+      " instead.");
+
+  TORCH_CHECK(
+      self.is_contiguous(),
+      "empty_like only supports contiguous memory format for Nested Tensors");
+
+  TORCH_CHECK(
+      !(options.layout() != kStrided && optional_memory_format.has_value()),
+      "memory format option is only supported by strided tensors");
+  return options;
+}
+
+Tensor empty_like_nested(
+    const Tensor& self,
+    c10::optional<ScalarType> dtype,
+    c10::optional<Layout> layout,
+    c10::optional<Device> device,
+    c10::optional<bool> pin_memory,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  auto options = verify_empty_parameters(
+      self, dtype, layout, device, pin_memory, optional_memory_format);
+  auto self_nt = get_nested_tensor_impl(self);
+  Tensor new_buffer = at::empty_like(self_nt->get_buffer(), options);
+  auto nested_size = self_nt->get_nested_size_tensor().clone();
+  auto nested_strides = self_nt->get_nested_stride_tensor().clone();
+  auto offsets = std::vector<int64_t>(self_nt->get_storage_offsets());
+  auto tensor = detail::make_tensor_base<NestedTensorImpl>(
+      new_buffer, nested_size, nested_strides, std::move(offsets));
+  return tensor;
+}
+
+// Take a Device that may not have device_index set (i.e., having it as -1
+// representing the current device) and return the corresponding Device
+// according to the actual device at the time of this function call.  No-op
+// if the device_index is set.
+static inline Device ensure_has_index(Device device) {
+  if (device.is_cpu() || device.has_index()) {
+    return device;
+  }
+  const c10::impl::DeviceGuardImplInterface* impl =
+      c10::impl::getDeviceGuardImpl(device.type());
+  return impl->getDevice();
+}
+
+Tensor _to_copy_nested(
+    const Tensor& self,
+    c10::optional<ScalarType> dtype,
+    c10::optional<Layout> layout,
+    c10::optional<Device> device,
+    c10::optional<bool> pin_memory,
+    bool non_blocking,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  TORCH_CHECK(
+      !layout.has_value() || self.layout() == layout.value(),
+      "to(options) doesn't support converting to a different layout, "
+      "but got self.layout being ",
+      self.layout(),
+      " and options.layout set as ",
+      layout.value());
+  auto options =
+      TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(
+          pin_memory);
+
+  if (options.has_device()) {
+    options = options.device(ensure_has_index(options.device()));
+  }
+  // memory_format is handled separately due to MemoryFormat::Preserve logic
+  options = self.options().merge_in(options).memory_format(c10::nullopt);
+  auto memory_format = optional_memory_format.value_or(MemoryFormat::Preserve);
+
+  bool pin_out =
+      (non_blocking && self.is_cuda() && options.device().is_cpu() &&
+       (options.layout() == c10::kStrided));
+
+  Tensor r;
+  r = at::empty_like(self, dtype, layout, device, pin_out, memory_format);
+  get_nested_tensor_impl(r)->get_buffer().copy_(
+      get_nested_tensor_impl(self)->get_buffer());
+  return r;
+}
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/nested/NestedTensorFactories.h
+++ b/aten/src/ATen/native/nested/NestedTensorFactories.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace at {
+namespace native {
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -15,7 +15,6 @@
 
 #include <tuple>
 
-
 namespace at {
 namespace native {
 

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/ATen_fwd.h>
 #include <c10/macros/Macros.h>
+
 namespace at {
 namespace native {
 

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -1399,6 +1399,7 @@ aten_native_source_non_codegen_list = [
     "aten/src/ATen/native/mkl/SparseBlasImpl.cpp",
     "aten/src/ATen/native/mkl/SparseCsrLinearAlgebra.cpp",
     "aten/src/ATen/native/mkl/SpectralOps.cpp",
+    "aten/src/ATen/native/nested/NestedTensorFactories.cpp",
     "aten/src/ATen/native/nested/NestedTensorMath.cpp",
     "aten/src/ATen/native/nested/NestedTensorAliases.cpp",
     "aten/src/ATen/native/nested/NestedTensorTransformerFunctions.cpp",

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -63,6 +63,18 @@ def noncontiguous_to_padded_tensor(input, shape=None):
         view.copy_(tensor)
     return result
 
+# Helper function to generate a random nested tensor
+def random_nt(device, dtype, num_tensors, max_dims, min_dims=None):
+    if min_dims is None:
+        min_dims = tuple([0] * len(max_dims))
+    ts1 = []
+    for _ in range(num_tensors):
+        tensor_dims = tuple([torch.randint(low=min_dim, high=max_dim, size=(1,)).item()
+                            for (min_dim, max_dim) in zip(min_dims, max_dims)])
+        t1 = torch.randn(tensor_dims, device=device, dtype=dtype)
+        ts1.append(t1)
+    return torch.nested.nested_tensor(ts1, device=device, dtype=dtype)
+
 class TestNestedTensor(TestCase):
 
     @torch.inference_mode()
@@ -301,19 +313,60 @@ class TestNestedTensor(TestCase):
         nested_namespace_result = torch.nested.to_padded_tensor(nt, 4)
         self.assertEqual(result, nested_namespace_result)
 
-class TestNestedTensorDeviceType(TestCase):
+    def test_to(self):
+        ntensors = 4
+        nt = random_nt(torch.device('cpu'), torch.float32, ntensors, (4, 4))
 
-    # Helper function to generate a random nested tensor
-    def random_nt(self, device, dtype, num_tensors, max_dims, min_dims=None):
-        if min_dims is None:
-            min_dims = tuple([0] * len(max_dims))
-        ts1 = []
-        for _ in range(num_tensors):
-            tensor_dims = tuple([torch.randint(low=min_dim, high=max_dim, size=(1,)).item()
-                                for (min_dim, max_dim) in zip(min_dims, max_dims)])
-            t1 = torch.randn(tensor_dims, device=device, dtype=dtype)
-            ts1.append(t1)
-        return torch.nested.nested_tensor(ts1, device=device, dtype=dtype)
+        def test_copy_behavior(t, non_blocking=False):
+            self.assertIs(t, t.to(t, non_blocking=non_blocking))
+            self.assertIs(t, t.to(t.dtype, non_blocking=non_blocking))
+            self.assertIs(t, t.to(torch.empty_like(t), non_blocking=non_blocking))
+            self.assertIsNot(t, t.to(t, non_blocking=non_blocking, copy=True))
+            self.assertIsNot(t, t.to(t.dtype, non_blocking=non_blocking, copy=True))
+            self.assertIsNot(t, t.to(torch.empty_like(t), non_blocking=non_blocking, copy=True))
+
+            devices = [t.device]
+            if t.device.type == 'cuda':
+                if t.device.index == -1:
+                    devices.append('cuda:{}'.format(torch.cuda.current_device()))
+                elif t.device.index == torch.cuda.current_device():
+                    devices.append('cuda')
+            for device in devices:
+                self.assertIs(t, t.to(device, non_blocking=non_blocking))
+                self.assertIs(t, t.to(device, t.dtype, non_blocking=non_blocking))
+                self.assertIsNot(t, t.to(device, non_blocking=non_blocking, copy=True))
+                self.assertIsNot(t, t.to(device, t.dtype, non_blocking=non_blocking, copy=True))
+
+        test_copy_behavior(nt)
+        self.assertEqual(nt.device, nt.to('cpu').device)
+        self.assertEqual(nt.device, nt.to('cpu', dtype=torch.float32).device)
+        self.assertIs(torch.float32, nt.to('cpu', dtype=torch.float32).dtype)
+        self.assertEqual(nt.device, nt.to(torch.float32).device)
+        self.assertIs(torch.float32, nt.to(dtype=torch.float32).dtype)
+
+        def test_data_ptr(getter):
+            self.assertEqual(getter(nt), getter(nt.to('cpu')))
+            self.assertEqual(getter(nt), getter(nt.to(dtype=nt.dtype, device=nt.device, copy=False)))
+            self.assertEqual(getter(nt), getter(nt.to('cpu', copy=False)))
+            self.assertNotEqual(getter(nt), getter(nt.to('cpu', copy=True)))
+
+        test_data_ptr(lambda nt: nt.data_ptr())
+
+        if torch.cuda.is_available():
+            for non_blocking in [True, False]:
+                for cuda in ['cuda', 'cuda:0' if torch.cuda.device_count() == 1 else 'cuda:1']:
+                    nt2 = random_nt(cuda, torch.float32, ntensors, (4, 4))
+                    test_copy_behavior(nt2, non_blocking)
+                    self.assertEqual(nt2.device, nt2.to(cuda, non_blocking=non_blocking).device)
+                    self.assertEqual(nt.device, nt2.to('cpu', non_blocking=non_blocking).device)
+                    self.assertEqual(nt2.device, nt.to(cuda, non_blocking=non_blocking).device)
+                    self.assertIs(torch.int32, nt2.to('cpu', dtype=torch.int32, non_blocking=non_blocking).dtype)
+                    self.assertEqual(nt.device, nt2.to('cpu', dtype=torch.int32, non_blocking=non_blocking).device)
+                    self.assertIs(torch.int32, nt2.to(dtype=torch.int32).dtype)
+                    self.assertEqual(nt2.device, nt2.to(dtype=torch.int32).device)
+
+
+class TestNestedTensorDeviceType(TestCase):
 
     # Helper function to generate a pair of random nested tensors
     # the 2 nested tensors have same shapes
@@ -789,7 +842,7 @@ class TestNestedTensorDeviceType(TestCase):
         params = ((2, (1, 1)), ((4), (4, 4)), (10, (3, 5, 7)))
 
         def test_sum(device, dtype, ntensors, max_sizes, dim, keepdim=True):
-            nt = self.random_nt(device, dtype, ntensors, max_sizes)
+            nt = random_nt(device, dtype, ntensors, max_sizes)
             nt2 = nt.clone()
             ub2 = nt2.unbind()
             nt.requires_grad_(True)
@@ -845,7 +898,7 @@ class TestNestedTensorDeviceType(TestCase):
     @dtypes(torch.float, torch.float16)
     @skipMeta
     def test_clone(self, device, dtype):
-        nt1 = self.random_nt(device, dtype, 4, (4, 4), (1, 1))
+        nt1 = random_nt(device, dtype, 4, (4, 4), (1, 1))
         nt2 = nt1.clone()
         # Verify the values match
         self.assertEqual(nt1, nt2)
@@ -870,7 +923,7 @@ class TestNestedTensorDeviceType(TestCase):
         self.assertEqual(nt0, y)
         # normal nested tensor
         ntensors = 4
-        nt = self.random_nt(device, dtype, ntensors, (4, 4))
+        nt = random_nt(device, dtype, ntensors, (4, 4))
         # edge case: invalid dropout
         self.assertRaises(ValueError, lambda: torch.nn.Dropout(-0.1))
         self.assertRaises(ValueError, lambda: torch.nn.Dropout(1.1))
@@ -914,7 +967,7 @@ class TestNestedTensorDeviceType(TestCase):
     @dtypes(torch.float, torch.double)
     def test_dropout_noncontiguous(self, device, dtype):
         ntensors = 4
-        nt0 = self.random_nt(device, dtype, ntensors, (4, 4))
+        nt0 = random_nt(device, dtype, ntensors, (4, 4))
         nt1 = nt0.transpose(-1, -2)
         p = 0.3
         with freeze_rng_state():
@@ -929,7 +982,7 @@ class TestNestedTensorDeviceType(TestCase):
     def test_softmax(self, device, dtype):
         # normal nested tensor
         ntensors = 4
-        nt = self.random_nt(device, dtype, ntensors, (4, 4))
+        nt = random_nt(device, dtype, ntensors, (4, 4))
         # error case: softmax across nested dimension
         self.assertRaisesRegex(
             RuntimeError,
@@ -1286,7 +1339,7 @@ class TestNestedTensorDeviceType(TestCase):
 
     @dtypes(torch.float, torch.float16, torch.double)
     def test_transpose(self, device, dtype):
-        nt = self.random_nt(device, dtype, 4, (4, 4))
+        nt = random_nt(device, dtype, 4, (4, 4))
         # error case: transpose nested dimension
         self.assertRaisesRegex(
             RuntimeError,
@@ -1352,7 +1405,7 @@ class TestNestedTensorDeviceType(TestCase):
 
     @dtypes(torch.float, torch.float16, torch.double)
     def test_transpose_inference_mode_interaction(self, device, dtype):
-        nt = self.random_nt(device, dtype, 4, (4, 4))
+        nt = random_nt(device, dtype, 4, (4, 4))
         # Construct in default mode and transpose while in inference mode
         with torch.inference_mode():
             ntT = nt.transpose(-1, -2)
@@ -1363,7 +1416,7 @@ class TestNestedTensorDeviceType(TestCase):
 
         # Construct and transpose while in inference mode
         with torch.inference_mode():
-            nt = self.random_nt(device, dtype, 4, (4, 4))
+            nt = random_nt(device, dtype, 4, (4, 4))
             ntT = nt.transpose(-1, -2)
             ptT_from_ntT = noncontiguous_to_padded_tensor(ntT)
             pt = torch.nested.to_padded_tensor(nt, 0.0)
@@ -1372,7 +1425,7 @@ class TestNestedTensorDeviceType(TestCase):
 
     @dtypes(torch.float, torch.float16, torch.double)
     def test_view(self, device, dtype):
-        nt = self.random_nt(device, dtype, 4, (4, 4))
+        nt = random_nt(device, dtype, 4, (4, 4))
         # error case: empty shape
         self.assertRaisesRegex(
             RuntimeError,
@@ -1446,7 +1499,7 @@ class TestNestedTensorDeviceType(TestCase):
 
     @dtypes(torch.float, torch.float16, torch.double)
     def test_reshape(self, device, dtype):
-        nt = self.random_nt(device, dtype, 4, (4, 4))
+        nt = random_nt(device, dtype, 4, (4, 4))
         # error case: empty shape
         self.assertRaisesRegex(
             RuntimeError,
@@ -1557,6 +1610,46 @@ class TestNestedTensorDeviceType(TestCase):
         with self.assertRaisesRegex(RuntimeError, "not supported when is_causal=True"):
             torch.ops.aten._scaled_dot_product_attention(
                 query, key, value, dropout_p=dropout_p, need_attn_weights=need_attn_weights, is_causal=True)
+
+    @dtypes(torch.float, torch.float16, torch.double)
+    def test_empty_like(self, device, dtype):
+        ntensors = 4
+        nt = random_nt(device, dtype, ntensors, (4, 4))
+
+        # Create empty on same device as original nested tensor
+        nt_empty = torch.empty_like(nt)
+        assert nt.is_same_size(nt_empty)
+        self.assertEqual(nt.dtype, nt_empty.dtype)
+        self.assertEqual(nt.device, nt_empty.device)
+        self.assertEqual(nt.layout, nt_empty.layout)
+
+        if torch.cuda.is_available():
+            if device == "cpu":
+                nt_cuda = torch.empty_like(nt, device='cuda')
+                self.assertEqual(torch.device("cuda").type, nt_cuda.device.type)
+            else:
+                nt_cpu = torch.empty_like(nt, device='cpu')
+                self.assertEqual(torch.device("cpu").type, nt_cpu.device.type)
+
+        # Check changing dtype of empty_like nested tensor output
+        dtype_set = {torch.float, torch.float16, torch.double}
+        for other_dtype in dtype_set - {dtype}:
+            nt_empty_other_dtype = torch.empty_like(nt, dtype=other_dtype)
+            self.assertEqual(nt.dtype, dtype)
+            self.assertEqual(nt_empty_other_dtype.dtype, other_dtype)
+            self.assertEqual(nt.device, nt_empty.device)
+            self.assertEqual(nt.layout, nt_empty.layout)
+
+        # Create tensor for autograd
+        nt_empty_req_grad = torch.empty_like(nt, requires_grad=True)
+        self.assertEqual(nt_empty_req_grad.requires_grad, True)
+
+        # Test noncontiguous tensor fails to copy
+        nt_cont, nt_noncont = random_nt_noncontiguous_pair((2, 3, 6, 7))
+        nt_empty = torch.empty_like(nt_cont)
+        assert nt_cont.is_same_size(nt_empty)
+        with self.assertRaisesRegex(RuntimeError, "empty_like only supports contiguous memory format for Nested Tensors"):
+            nt_empty = torch.empty_like(nt_noncont)
 
 
 class TestNestedTensorAutograd(TestCase):


### PR DESCRIPTION
Summary: This commit adds support for moving NestedTensors from CPU to GPU and back. The implementation includes requires implementing empty_like(), which is based on PR#83140.

Test Plan: Added a new unit test based on the unit test for the main .to() implementation. All unit tests must pass, as well as every sandcastle job.

Differential Revision: D40437585

