### PR TITLE
Adding expm1 to MPS

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -253,6 +253,7 @@ TORCH_IMPL_FUNC(expm1_out_mps) (const Tensor& self, const Tensor& output) {
   mps::unary_op(self, output, "expm1_out_mps",
                 ^ MPSGraphTensor* (MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
                   MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0
+                                                       shape:@[@1]
                                                        dataType:inputTensor.dataType];
                   MPSGraphTensor* ePowTensor = [mpsGraph exponentWithTensor:inputTensor
                                                                          name:nil];

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -156,7 +156,6 @@ Tensor& func_out(const Tensor& self, Tensor& output) {                          
 
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(exp_out_mps, exponent)
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(exp2_out_mps, exponentBase2)
-//CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(expm1_out_mps, exponentBase2)
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(reciprocal_out_mps, reciprocal)
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(sqrt_out_mps, squareRoot)
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(rsqrt_out_mps, reverseSquareRoot)
@@ -255,9 +254,9 @@ TORCH_IMPL_FUNC(expm1_out_mps) (const Tensor& self, const Tensor& output) {
                 ^ MPSGraphTensor* (MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
                   MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0
                                                        dataType:inputTensor.dataType];
-                  MPSGraphTensor* ePowYTensor = [mpsGraph exponentWithTensor:yTensor
+                  MPSGraphTensor* ePowTensor = [mpsGraph exponentWithTensor:inputTensor
                                                                          name:nil];
-                  return [mpsGraph subtractionWithPrimaryTensor:exponentTensor
+                  return [mpsGraph subtractionWithPrimaryTensor:ePowTensor
                                                secondaryTensor:oneTensor
                                                    name: nil];
                 });

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -156,6 +156,7 @@ Tensor& func_out(const Tensor& self, Tensor& output) {                          
 
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(exp_out_mps, exponent)
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(exp2_out_mps, exponentBase2)
+//CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(expm1_out_mps, exponentBase2)
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(reciprocal_out_mps, reciprocal)
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(sqrt_out_mps, squareRoot)
 CREATE_MPS_STRUCTURED_UNARY_TORCH_IMPL_FUNC(rsqrt_out_mps, reverseSquareRoot)
@@ -245,6 +246,19 @@ TORCH_IMPL_FUNC(frac_out_mps) (const Tensor& self, const Tensor& output) {
                                                                     name:nil];
                   return [mpsGraph subtractionWithPrimaryTensor:inputTensor
                                                secondaryTensor:truncTensor
+                                                   name: nil];
+                });
+}
+
+TORCH_IMPL_FUNC(expm1_out_mps) (const Tensor& self, const Tensor& output) {
+  mps::unary_op(self, output, "expm1_out_mps",
+                ^ MPSGraphTensor* (MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
+                  MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0
+                                                       dataType:inputTensor.dataType];
+                  MPSGraphTensor* ePowYTensor = [mpsGraph exponentWithTensor:yTensor
+                                                                         name:nil];
+                  return [mpsGraph subtractionWithPrimaryTensor:exponentTensor
+                                               secondaryTensor:oneTensor
                                                    name: nil];
                 });
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2329,6 +2329,7 @@
   structured_inherits: TensorIteratorBase
   dispatch:
     CPU, CUDA: expm1_out
+    MPS: expm1_out_mps
     SparseCPU, SparseCUDA: expm1_sparse_out
     SparseCsrCPU, SparseCsrCUDA: expm1_sparse_csr_out
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4922,6 +4922,7 @@ class TestNLLLoss(TestCase):
 
         helper((2, 8, 4, 5), torch.exp)
         helper((2, 8, 3, 5), torch.exp2)
+        helper((2, 8, 3, 5), torch.expm1)
         helper((2, 8, 3, 5), torch.log)
         helper((2, 8, 3, 5), torch.cos)
 


### PR DESCRIPTION
Fixes #86744 

- Implementing the new `expm1_out_mps` function in `aten/src/ATen/native/mps/operations/UnaryOps.mm`
- Adding it to `aten/src/ATen/native/native_functions.yaml`
- Adding it to existing `test.test_mps.TestNLLLoss.test_unary_ops`
