### PR TITLE
Store type(module) in the module stack

### DIFF
--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -153,7 +153,7 @@ class NNModuleVariable(VariableTracker):
         @contextmanager
         def record_nn_module_stack():
             try:
-                tx.nn_module_stack[self.module_key] = mod.__class__.__name__
+                tx.nn_module_stack[self.module_key] = type(mod)
                 yield
             finally:
                 del tx.nn_module_stack[self.module_key]

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -450,7 +450,10 @@ class CodeGen(object):
                             line = lines[idx].strip()
                             if line.startswith('File '):
                                 break
-                            context_lines.append(line)
+
+                            # Skip printing module stack
+                            if not line.startswith("Module stack"):
+                                context_lines.append(line)
                             idx += 1
 
                         summary_lines = []


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #87149

- As requested by quantization team, it prefer storing type(module) in the module stack. 
- Consequently, as module stack gets verbose, we skip printing module stack in the gm.print_readable()

