### PR TITLE
[BE] Get rid of deprecation warnings in workflows (take 3)

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -73,4 +73,4 @@ runs:
         # Copy install binaries back
         mkdir -p "${GITHUB_WORKSPACE}/build_android_install_${MATRIX_ARCH}"
         docker cp "${container_name}:/var/lib/jenkins/workspace/build_android/install" "${GITHUB_WORKSPACE}/build_android_install_${MATRIX_ARCH}"
-        echo "::set-output name=container_id::${container_name}"
+        echo "container_id=${container_name}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -47,12 +47,12 @@ runs:
         if [ -n "${IS_XLA}" ]; then
           echo "XLA workflow uses pre-built test image at ${XLA_IMAGE_TAG}"
           DOCKER_TAG=$(git rev-parse HEAD:.circleci/docker)
-          echo "::set-output name=docker-tag::${DOCKER_TAG}"
-          echo "::set-output name=docker-image::${DOCKER_IMAGE_BASE}:${XLA_IMAGE_TAG}"
+          echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "docker-image=${DOCKER_IMAGE_BASE}:${XLA_IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
         else
           DOCKER_TAG=$(git rev-parse HEAD:.circleci/docker)
-          echo "::set-output name=docker-tag::${DOCKER_TAG}"
-          echo "::set-output name=docker-image::${DOCKER_IMAGE_BASE}:${DOCKER_TAG}"
+          echo "docker-tag=${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "docker-image=${DOCKER_IMAGE_BASE}:${DOCKER_TAG}" >> "${GITHUB_OUTPUT}"
         fi
 
     - name: Check if image should be built
@@ -93,10 +93,10 @@ runs:
             # In order to avoid a stampeding herd of jobs trying to push all at once we set it to
             # skip the push. If this is negatively affecting TTS across the board the suggestion
             # should be to run the docker-builds.yml workflow to generate the correct docker builds
-            echo ::set-output name=skip_push::true
+            echo "skip_push=true" >> "${GITHUB_OUTPUT}"
           fi
         fi
-        echo ::set-output name=rebuild::yes
+        echo "rebuild=yes" >> "${GITHUB_OUTPUT}"
 
     - name: Build and push docker image
       if: inputs.always-rebuild || steps.check.outputs.rebuild

--- a/.github/actions/download-build-artifacts/action.yml
+++ b/.github/actions/download-build-artifacts/action.yml
@@ -21,7 +21,7 @@ runs:
 
     - name: Download PyTorch Build Artifacts from GHA
       if: inputs.use-gha
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.name }}
 

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -25,7 +25,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: nick-fields/retry@71062288b76e2b6214ebde0e673ce0de1755740a
+    - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
       name: Setup dependencies
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/get-workflow-job-id/action.yml
+++ b/.github/actions/get-workflow-job-id/action.yml
@@ -15,7 +15,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: nick-fields/retry@7d4a37704547a311dbb66ebdf5b23ec19374a767
+    - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
       id: get-job-id
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/get-workflow-job-id/action.yml
+++ b/.github/actions/get-workflow-job-id/action.yml
@@ -28,4 +28,4 @@ runs:
           set -eux
           python3 -m pip install requests==2.26.0
           GHA_WORKFLOW_JOB_ID=$(python3 .github/scripts/get_workflow_job_id.py "${GITHUB_RUN_ID}" "${RUNNER_NAME}")
-          echo "::set-output name=job-id::${GHA_WORKFLOW_JOB_ID}"
+          echo "job-id=${GHA_WORKFLOW_JOB_ID}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -111,7 +111,7 @@ runs:
 
     # GHA upload
     - name: Store Test Downloaded JSONs on Github
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: inputs.use-gha
       with:
         # Add the run attempt, see [Artifact run attempt]
@@ -121,7 +121,7 @@ runs:
         path: test/**/*.json
 
     - name: Store Test Reports on Github
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: inputs.use-gha
       with:
         # Add the run attempt, see [Artifact run attempt]

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -105,6 +105,14 @@ def filter(test_matrix: Dict[str, List[Any]], labels: Set[str]) -> Dict[str, Lis
         return filtered_test_matrix
 
 
+def set_output(name: str, val: Any) -> None:
+    if os.getenv("GITHUB_OUTPUT"):
+        with open(str(os.getenv("GITHUB_OUTPUT")), "a") as env:
+            print(f"{name}={val}", file=env)
+    else:
+        print(f"::set-output name={name}::{val}")
+
+
 def main() -> None:
     args = parse_args()
     # Load the original test matrix set by the workflow. Its format, however,
@@ -115,7 +123,7 @@ def main() -> None:
     if test_matrix is None:
         warnings.warn(f"Invalid test matrix input '{args.test_matrix}', exiting")
         # We handle invalid test matrix gracefully by marking it as empty
-        print("::set-output name=is-test-matrix-empty::True")
+        set_output("is-test-matrix-empty", True)
         sys.exit(0)
 
     pr_number = args.pr_number
@@ -151,12 +159,12 @@ def main() -> None:
         filtered_test_matrix = test_matrix
 
     # Set the filtered test matrix as the output
-    print(f"::set-output name=test-matrix::{json.dumps(filtered_test_matrix)}")
+    set_output("test-matrix", json.dumps(filtered_test_matrix))
 
     filtered_test_matrix_len = len(filtered_test_matrix.get("include", []))
     # and also put a flag if the test matrix is empty, so subsequent jobs can
     # quickly check it without the need to parse the JSON string
-    print(f"::set-output name=is-test-matrix-empty::{filtered_test_matrix_len == 0}")
+    set_output("is-test-matrix-empty", filtered_test_matrix_len == 0)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/parse_ref.py
+++ b/.github/scripts/parse_ref.py
@@ -4,18 +4,26 @@ import os
 import re
 
 
+def set_output(name: str, val: str) -> None:
+    if os.getenv("GITHUB_OUTPUT"):
+        with open(str(os.getenv("GITHUB_OUTPUT")), "a") as env:
+            print(f"{name}={val}", file=env)
+    else:
+        print(f"::set-output name={name}::{val}")
+
+
 def main() -> None:
-    ref = os.environ['GITHUB_REF']
+    ref = os.environ["GITHUB_REF"]
     m = re.match(r'^refs/(\w+)/(.*)$', ref)
     if m:
         category, stripped = m.groups()
-        if category == 'heads':
-            print(f'::set-output name=branch::{stripped}')
-        elif category == 'pull':
-            print(f'::set-output name=branch::pull/{stripped.split("/")[0]}')
-        elif category == 'tags':
-            print(f'::set-output name=tag::{stripped}')
+        if category == "heads":
+            set_output("branch", stripped)
+        elif category == "pull":
+            set_output("branch", "pull/" + stripped.split("/")[0])
+        elif category == "tags":
+            set_output("tag", stripped)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -27,6 +27,8 @@ class TestConfigFilter(TestCase):
 
     def setUp(self) -> None:
         os.environ["GITHUB_TOKEN"] = "GITHUB_TOKEN"
+        if os.getenv("GITHUB_OUTPUT"):
+            del os.environ["GITHUB_OUTPUT"]
 
     @mock.patch("filter_test_configs.requests.get", side_effect=mocked_gh_get_labels)
     def test_get_labels(self, mocked_gh: Any) -> None:

--- a/.github/workflows/_binary-test-linux.yml
+++ b/.github/workflows/_binary-test-linux.yml
@@ -171,7 +171,7 @@ jobs:
           path: "${{ runner.temp }}/artifacts/"
 
       - name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
-        uses: nick-fields/retry@7d4a37704547a311dbb66ebdf5b23ec19374a767
+        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         if: ${{ inputs.GPU_ARCH_TYPE == 'cuda' }}
         with:
           timeout_minutes: 10

--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -101,7 +101,7 @@ jobs:
           no-sudo: true
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.build_name }}
           path: "${{ runner.temp }}/artifacts/"

--- a/.github/workflows/_buck-build-test.yml
+++ b/.github/workflows/_buck-build-test.yml
@@ -28,7 +28,7 @@ jobs:
           activate-environment: build
 
       - name: Install dependencies
-        uses: nick-fields/retry@7d4a37704547a311dbb66ebdf5b23ec19374a767
+        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -46,7 +46,7 @@ jobs:
               typing_extensions
 
       - name: Install Buck
-        uses: nick-fields/retry@7d4a37704547a311dbb66ebdf5b23ec19374a767
+        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -56,7 +56,7 @@ jobs:
             sudo apt install ./buck.2021.01.12.01_all.deb
 
       - name: Download third party libraries and generate wrappers
-        uses: nick-fields/retry@7d4a37704547a311dbb66ebdf5b23ec19374a767
+        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         with:
           timeout_minutes: 10
           max_attempts: 5

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -74,7 +74,7 @@ jobs:
           docker-image: ${{ inputs.docker-image }}
 
       - name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
-        uses: nick-fields/retry@7d4a37704547a311dbb66ebdf5b23ec19374a767
+        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         if: contains(inputs.build-environment, 'cuda') && !contains(matrix.config, 'nogpu')
         with:
           timeout_minutes: 10

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -91,7 +91,7 @@ jobs:
           python3 -m pip install psutil==5.9.1
           python3 -m pip install pynvml==11.4.1
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
-          echo "::set-output name=monitor-script-pid::${!}"
+          echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -107,7 +107,7 @@ jobs:
           ${CONDA_RUN} python3 -m pip install psutil==5.9.1
           ${CONDA_RUN} python3 -m pip install pynvml==11.4.1
           ${CONDA_RUN} python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
-          echo "::set-output name=monitor-script-pid::${!}"
+          echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
       - name: Install macOS homebrew dependencies
         run: |

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -69,7 +69,7 @@ jobs:
           python3 -m pip install psutil==5.9.1
           python3 -m pip install pynvml==11.4.1
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
-          echo "::set-output name=monitor-script-pid::${!}"
+          echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts

--- a/.github/workflows/_update-commit-hash.yml
+++ b/.github/workflows/_update-commit-hash.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
           submodules: false

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -86,7 +86,7 @@ jobs:
           python3 -m pip install psutil==5.9.1
           python3 -m pip install pynvml==11.4.1
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
-          echo "::set-output name=monitor-script-pid::${!}"
+          echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
       - name: Download PyTorch Build Artifacts
         uses: seemethere/download-artifact-s3@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
             **/.github/requirements-gha-cache.txt
 
       - name: Install lintrunner
-        uses: nick-fields/retry@7d4a37704547a311dbb66ebdf5b23ec19374a767
+        uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         with:
           timeout_minutes: 5
           max_attempts: 3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           architecture: x64
@@ -83,7 +83,7 @@ jobs:
           # Remove any artifacts from the previous checkouts
           git clean -fxd
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
           architecture: x64
@@ -147,7 +147,7 @@ jobs:
           submodules: false
           fetch-depth: 1
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
           architecture: x64
@@ -199,7 +199,7 @@ jobs:
           fetch-depth: 1
       # This is not a node project so there is no package-lock.json to cache
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
       - name: Install markdown-toc
         run: npm install -g markdown-toc
       - name: Regenerate ToCs and check that they didn't change
@@ -238,7 +238,7 @@ jobs:
         with:
           submodules: false
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           architecture: x64
@@ -283,7 +283,7 @@ jobs:
           fetch-depth: 1
       - name: Setup Python 3.5
         if: matrix.test_type == 'older_python_version'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.5
           architecture: x64
@@ -292,7 +292,7 @@ jobs:
             **/.github/requirements-gha-cache.txt
       - name: Setup Python 3.8
         if: matrix.test_type != 'older_python_version'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           architecture: x64

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           cache: pip
           cache-dependency-path: |

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
+          python-version: 3.10
           cache: pip
           cache-dependency-path: |
             **/.github/requirements-gha-cache.txt

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
           cache: pip
           cache-dependency-path: |
             **/.github/requirements-gha-cache.txt

--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -25,7 +25,7 @@ jobs:
         uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      - uses: nick-fields/retry@7d4a37704547a311dbb66ebdf5b23ec19374a767
+      - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         name: Build and upload nightly docker
         with:
           timeout_minutes: 30

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout repo
         id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.MERGEBOT_TOKEN }}

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.MERGEBOT_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
           architecture: x64

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -40,7 +40,7 @@ jobs:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
         run: |
           output=$(python3 .github/scripts/fetch_latest_green_commit.py)
-          echo "::set-output name=latest_viable_sha::$output"
+          echo "latest_viable_sha=$output" >> "${GITHUB_OUTPUT}"
         id: get-latest-commit
 
       - name: Push SHA to viable/strict branch


### PR DESCRIPTION
- Per [deprecation announcement](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) replace `echo "::set-output name="` with echo to `${GITHUB_OUTPUT}` as shown in following [example](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs#example-defining-outputs-for-a-job)
- Update `actions/setup-python` from `v2` to `v4` to get rid of deprecated node version warning
- Update `actions/checkout-python` from `v2` to `v3` (and `silent-checkout` branch as well)
- Update `retry` action to https://github.com/nick-fields/retry/commit/3e91a01664abd3c5cd539100d10d33b9c5b68482