### PR TITLE
[Pytorch] add an option to disable TORCH_WARN and TORCH_WARN_ONCE log

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -98,6 +98,9 @@ def get_strip_error_messages():
         return True  # always strip in OSS CI to expose potential issues
     return read_bool("pt", "strip_error_messages", not _is_build_mode_dev())
 
+def get_disable_warn():
+    return read_bool("pt", "disable_warn", False)
+
 def get_enable_eager_symbolication():
     return read_bool("pt", "enable_eager_symbolication", default = False, required = False)
 
@@ -200,6 +203,8 @@ _COMMON_PREPROCESSOR_FLAGS = [
     ["-DC10_MOBILE_TRIM_DISPATCH_KEYS"] if get_enable_mobile_dispatch_keys_trimming() else []
 ) + (
     ["-DSTRIP_ERROR_MESSAGES"] if get_strip_error_messages() else []
+) + (
+    ["-DDISABLE_WARN"] if get_disable_warn() else []
 )
 
 def get_aten_preprocessor_flags():
@@ -1727,9 +1732,7 @@ def define_buck_targets(
         name = "mobile_bytecode",
         header_namespace = "",
         exported_headers = {
-            ("torch/csrc/jit/serialization/mobile_bytecode_generated.h" if IS_OSS
-            else "torch/csrc/jit/serialization/mobile_bytecode_generated_fbsource.h")
-            : ":mobile_bytecode_header[mobile_bytecode_generated_fbsource.h]",
+            ("torch/csrc/jit/serialization/mobile_bytecode_generated.h" if IS_OSS else "torch/csrc/jit/serialization/mobile_bytecode_generated_fbsource.h"): ":mobile_bytecode_header[mobile_bytecode_generated_fbsource.h]",
         },
         # Avoid leaking implementation details by only exposing this header to
         # the internals of the loader/serializer layer.

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -562,17 +562,21 @@ namespace detail {
 // Report a warning to the user.  Accepts an arbitrary number of extra
 // arguments which are concatenated into the warning message using operator<<
 //
-#define TORCH_WARN_WITH(warning_t, ...)                      \
+#ifdef DISABLE_WARN
+#define _TORCH_WARN_WITH(...) ((void)0);
+#else
+#define _TORCH_WARN_WITH(warning_t, ...)                     \
   ::c10::warn(::c10::Warning(                                \
       warning_t(),                                           \
       {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
       WARNING_MESSAGE_STRING(__VA_ARGS__),                   \
       false));
+#endif
 
-#define TORCH_WARN(...) TORCH_WARN_WITH(::c10::UserWarning, __VA_ARGS__);
+#define TORCH_WARN(...) _TORCH_WARN_WITH(::c10::UserWarning, __VA_ARGS__);
 
 #define TORCH_WARN_DEPRECATION(...) \
-  TORCH_WARN_WITH(::c10::DeprecationWarning, __VA_ARGS__);
+  _TORCH_WARN_WITH(::c10::DeprecationWarning, __VA_ARGS__);
 
 // Report a warning to the user only once.  Accepts an arbitrary number of extra
 // arguments which are concatenated into the warning message using operator<<
@@ -584,12 +588,16 @@ namespace detail {
         return true;                                                      \
       }()
 
+#ifdef DISABLE_WARN
+#define TORCH_WARN_ONCE(...) ((void)0);
+#else
 #define TORCH_WARN_ONCE(...)                   \
   if (::c10::WarningUtils::get_warnAlways()) { \
     TORCH_WARN(__VA_ARGS__);                   \
   } else {                                     \
     _TORCH_WARN_ONCE(__VA_ARGS__);             \
   }
+#endif
 
 // Report an error with a specific argument
 // NOTE: using the argument name in TORCH_CHECK's message is preferred


### PR DESCRIPTION
Summary: Add an option to disable TORCH_WARN, some op could trigger spammy TOCH_WARN log which is not desired under certain scenario.

Test Plan:
Tested with
-pt.disable_warn = 1 and -pt.disable_warn = 0

verified TORCH_WARN and TORCH_WARN_ONCE are properly handled

tested with
-pt.strip_error_messages = 1, -pt.disable_warn = 0

verified strip error message is respected when warn is printed

Differential Revision: D40321550

