### PR TITLE
[inductor] new way to compile f64 libdevice calls

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -120,10 +120,6 @@ inductor_skips = defaultdict(dict)
 
 inductor_skips["cpu"] = {
     "linalg.ldl_solve": {b8, f16, f32, f64, i32, i64},  # segfault
-    "linalg.lu_solve": {b8, f16, f32, f64, i32, i64},  # segfault
-    "reciprocal": {b8, i32, i64},  # segfault
-    "lu_solve": {b8, f16, f32, f64, i32, i64},  # segfault
-    "lu_unpack": {b8, f16, f32, f64, i32, i64},  # segfault
     "__rdiv__": {b8, f16, f32, f64, i32, i64},  # flaky
 }
 
@@ -135,29 +131,12 @@ inductor_skips["cuda"] = {
     "sparse.sampled_addmm": {f32, f64},
     "broadcast_tensors": {f16, f32, f64},
     "dsplit": {f16, f32, f64},
-    # Call parameter type does not match function signature!
-    "masked.logsumexp": {f64},
-    "erf": {f64},
-    "logsumexp": {f64},
-    "lu_unpack": {f32, f64},  # RuntimeError: CUDA error
-    "nn.functional.binary_cross_entropy_with_logits": {f64},
-    "nn.functional.gelu": {f64},
-    "nn.functional.glu": {f64},
-    "nn.functional.poisson_nll_loss": {f64},
-    "nn.functional.tanhshrink": {f16, f64},
-    "nn.functional.conv_transpose3d": {f16, f64},
-    "nn.functional._scaled_dot_product_attention": {f64},
-    "nn.functional.triplet_margin_loss": {f16},
-    "special.ndtr": {f64},
     # Jiterator kernel is not expected to work with inductor
     "jiterator_2inputs_2outputs": {b8, f16, f32, f64, i32, i64},
     "jiterator_4inputs_with_extra_args": {b8, f16, f32, f64, i32, i64},
     "jiterator_binary": {b8, f16, f32, f64, i32, i64},
     "jiterator_binary_return_by_ref": {b8, f16, f32, f64, i32, i64},
     "jiterator_unary": {b8, f16, f32, f64, i32, i64},
-    # Triton bug leads to segfault
-    "nn.functional.softplus": {f64},
-    "nn.functional.mish": {f64},
     # Disabled on migration to core
     "linalg.pinv.singular": {f32, f64},
     "linalg.householder_product": {f32},
@@ -220,6 +199,9 @@ inductor_expected_failures_single_sample["cpu"] = {
     "linalg.lstsq.grad_oriented": {f32, f64},
     "linalg.matrix_rank": {f32, f64},
     "linalg.matrix_rank.hermitian": {f32, f64},
+    "linalg.lu_solve": {f32, f64},
+    "lu_solve": {f32, f64},
+    "lu_unpack": {f32, f64},
     "logdet": {f32, f64},
     "masked.norm": {f16},
     "masked_fill": {f16},
@@ -296,7 +278,6 @@ inductor_expected_failures_single_sample["cuda"] = {
     "corrcoef": {f16, f32, f64, i32, i64},
     "cov": {f16, f32, f64, i32, i64},
     "equal": {b8, f16, f32, f64, i32, i64},
-    "erf": {b8},
     "fft.fft": {f16, f32, f64},
     "fft.fft2": {b8, f16, f32, f64, i32, i64},
     "fft.fftn": {b8, f16, f32, f64, i32, i64},
@@ -330,6 +311,7 @@ inductor_expected_failures_single_sample["cuda"] = {
     "linalg.matrix_rank": {f32, f64},
     "linalg.matrix_rank.hermitian": {f32, f64},
     "linalg.pinv.hermitian": {f32, f64},
+    "lu_unpack": {f32, f64},
     "masked.argmax": {f16, f32, f64, i32},
     "masked.argmin": {f16, f32, f64, i32},
     "masked_scatter": {f16, f32, f64},
@@ -338,7 +320,6 @@ inductor_expected_failures_single_sample["cuda"] = {
     "min.reduction_with_dim": {b8, i32, i64},
     "multinomial": {f16, f32, f64},
     "nn.functional.adaptive_avg_pool2d": {f16},
-    "nn.functional._scaled_dot_product_attention": {f64},
     "nn.functional.ctc_loss": {f32, f64},
     "nn.functional.grid_sample": {f16},
     "nn.functional.gaussian_nll_loss": {f16, f32, f64},
@@ -370,6 +351,11 @@ inductor_expected_failures_single_sample["cuda"] = {
     "unique": {b8, f16, f32, f64, i32, i64},
     "unique_consecutive": {b8, f16, f32, f64, i32, i64},
     "view_as_complex": {f16, f32, f64},
+    # AssertionError: Tensor-likes are not close!
+    "erf": {b8, f64},
+    "nn.functional.gelu": {f64},
+    "nn.functional.conv_transpose3d": {f16},
+    "nn.functional.triplet_margin_loss": {f16},
 }
 
 inductor_gradient_expected_failures_single_sample = defaultdict(dict)
@@ -393,7 +379,6 @@ inductor_gradient_expected_failures_single_sample["cuda"] = {
     "nn.functional.normalize": {f16},
     "nn.functional.softsign": {f16},
     "nn.functional.local_response_norm": {f16},
-    "norm.inf": {f64},
     "outer": {f16},
     "quantile": {f32, f64},
     "scatter_reduce.amax": {f16, f32, f64},

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -80,15 +80,6 @@ class OpOverrides:
         return repr(value)
 
     @staticmethod
-    def sigmoid(x):
-        x = ops.exp(f"-{x}")
-        return f"1 / (1 + {x})"
-
-    @staticmethod
-    def silu(x):
-        return f"{x} * {ops.sigmoid(x)}"
-
-    @staticmethod
     def reciprocal(x):
         return ops.div("1", x)
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -307,6 +307,11 @@ class CppOverrides(OpOverrides):
     def randn(seed: sympy.Expr, offset: sympy.Expr, dtype):
         return f"static_cast<{DTYPE_TO_CPP[dtype]}>(randn_cpu({seed}, {offset}));"
 
+    @staticmethod
+    def sigmoid(x):
+        x = ops.exp(f"-{x}")
+        return f"1 / (1 + {x})"
+
 
 class CppKernel(Kernel):
     overrides = CppOverrides

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -114,15 +114,27 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def abs(x):
-        return f"tl.libdevice.abs({x}) if ({x}).dtype is tl.float64 else tl.abs({x})"
+        return f"tl.abs({x})"
+
+    @staticmethod
+    def libdevice_abs(x):
+        return f"tl.libdevice.abs({x})"
 
     @staticmethod
     def exp(x):
-        return f"tl.libdevice.exp({x}) if ({x}).dtype is tl.float64 else tl.exp({x})"
+        return f"tl.exp({x})"
+
+    @staticmethod
+    def libdevice_exp(x):
+        return f"tl.libdevice.exp({x})"
 
     @staticmethod
     def sqrt(x):
-        return f"tl.libdevice.sqrt({x}) if ({x}).dtype is tl.float64 else tl.sqrt({x})"
+        return f"tl.sqrt({x})"
+
+    @staticmethod
+    def libdevice_sqrt(x):
+        return f"tl.libdevice.sqrt({x})"
 
     @staticmethod
     def relu(x):
@@ -154,11 +166,19 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def cos(x):
-        return f"tl.libdevice.cos({x}) if ({x}).dtype is tl.float64 else tl.cos({x})"
+        return f"tl.cos({x})"
+
+    @staticmethod
+    def libdevice_cos(x):
+        return f"tl.libdevice.cos({x})"
 
     @staticmethod
     def sin(x):
-        return f"tl.libdevice.sin({x}) if ({x}).dtype is tl.float64 else tl.sin({x})"
+        return f"tl.sin({x})"
+
+    @staticmethod
+    def libdevice_sin(x):
+        return f"tl.libdevice.sin({x})"
 
     @staticmethod
     def index_expr(expr, dtype):
@@ -197,6 +217,14 @@ class TritonOverrides(OpOverrides):
         return f"tl.libdevice.rsqrt({x})"
 
     @staticmethod
+    def sigmoid(x):
+        return f"tl.sigmoid({x})"
+
+    @staticmethod
+    def libdevice_sigmoid(x):
+        return f"1/(1 + tl.libdevice.exp(-({x})))"
+
+    @staticmethod
     def signbit(x):
         # XX: This is wrong for the value -0.0 in floating point
         return f"tl.libdevice.signbitf({x}) if ({x}).dtype is tl.float32 else {x} < 0"
@@ -211,7 +239,11 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def log(x):
-        return f"tl.libdevice.log({x}) if ({x}).dtype is tl.float64 else tl.log({x})"
+        return f"tl.log({x})"
+
+    @staticmethod
+    def libdevice_log(x):
+        return f"tl.libdevice.log({x})"
 
     @staticmethod
     def isinf(x):

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -98,6 +98,7 @@ decompositions = get_decompositions(
         aten.upsample_nearest2d_backward,
         aten.softplus,
         aten.softplus_backward,
+        aten.silu,
     ]
 )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #87189

Porting over [torchdynamo/#1633](https://github.com/pytorch/torchdynamo/pull/1633)

`torch/_inductor/codegen/triton.py` now defines `libdevice_<function>` variants
of some functions. You can request dispatch to those for
float64 dtypes when using `register_pointwise` by setting
`use_libdevice_for_f64=True`.

Other minor changes:
    - In triton, sigmoid now codegens tl.sigmoid
    - silu now comes from decomp, not lowering
    - Some test skips no longer necessary, removed or made xfails

Switching to `tl.sigmoid` has exactly same performance.
Moving `silu` to decomp does not change anything, same triton code is generated.