### PR TITLE
[ONNX] Fix get wrong summary of the docstring in `torch.onnx._deprecation.deprecated`

### DIFF
--- a/torch/onnx/_deprecation.py
+++ b/torch/onnx/_deprecation.py
@@ -42,7 +42,7 @@ def deprecated(since: str, removed_in: str, instructions: str):
         )
 
         # Split docstring at first occurrence of newline
-        summary_and_body = docstring.split("\n", 1)
+        summary_and_body = docstring.split("\n\n", 1)
 
         if len(summary_and_body) > 1:
             summary, body = summary_and_body


### PR DESCRIPTION
The summary of the deprecated function could be multi-line. Therefore the code below:
https://github.com/pytorch/pytorch/blob/9ac2a06acf75538a35751f785d5f509d6127d6cd/torch/onnx/_deprecation.py#L45
should be adjusted to

```python
summary_and_body = docstring.split("\n\n", 1)
```
Otherwise, the multi-line summary will be separated wrongly.