### PR TITLE
[CI] Add triton wheels build workflow

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -34,7 +34,7 @@ def build_triton(commit_hash: str) -> Path:
         triton_pythondir = triton_basedir / "python"
         check_call(["git", "clone", "https://github.com/openai/triton"], cwd=tmpdir)
         check_call(["git", "checkout", commit_hash], cwd=triton_basedir)
-        patch_setup_py(triton_pythondir / "setup.py", name="pytorch-triton", version=f"2.0.0+{commit_hash[:10]}")
+        patch_setup_py(triton_pythondir / "setup.py", name="torchtriton", version=f"2.0.0+{commit_hash[:10]}")
         check_call([sys.executable, "setup.py", "bdist_wheel"], cwd=triton_pythondir)
         whl_path = list((triton_pythondir / "dist").glob("*.whl"))[0]
         shutil.copy(whl_path, Path.cwd())

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -17,6 +17,7 @@ def check_and_replace(inp: str, src: str, dst: str) -> str:
         raise RuntimeError(f"Can't find ${src} in the input")
     return inp.replace(src, dst)
 
+
 def patch_setup_py(path: Path, *, version: str = "2.0.0", name: str = "triton") -> None:
     with open(path) as f:
         orig = f.read()
@@ -43,8 +44,7 @@ def build_triton(commit_hash: str) -> Path:
 
 def main() -> None:
     pin = read_triton_pin()
-    path = build_triton(pin)
-    print(path)
+    build_triton(pin)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -11,13 +11,19 @@ def read_triton_pin() -> str:
         return f.read().strip()
 
 
+def check_and_replace(inp: str, src: str, dst: str) -> str:
+    """ Checks that `src` can be found in `input` and replaces it with `dst` """
+    if src not in inp:
+        raise RuntimeError(f"Can't find ${src} in the input")
+    return inp.replace(src, dst)
+
 def patch_setup_py(path: Path, *, version: str = "2.0.0", name: str = "triton") -> None:
     with open(path) as f:
         orig = f.read()
     # Replace name
-    orig = orig.replace("name=\"triton\",", f"name=\"{name}\",")
+    orig = check_and_replace(orig, "name=\"triton\",", f"name=\"{name}\",")
     # Replace version
-    orig = orig.replace("version=\"2.0.0\",", f"version=\"{version}\",")
+    orig = check_and_replace(orig, "version=\"2.0.0\",", f"version=\"{version}\",")
     with open(path, "w") as f:
         f.write(orig)
 
@@ -43,4 +49,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from subprocess import check_call
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import sys
+import shutil
+SCRIPT_DIR = Path(__file__).parent
+
+def read_triton_pin() -> str:
+    with open(SCRIPT_DIR.parent / "ci_commit_pins" / "triton.txt") as f:
+        return f.read().strip()
+
+
+def patch_setup_py(path: Path, *, version: str = "2.0.0", name: str = "triton") -> None:
+    with open(path) as f:
+        orig = f.read()
+    # Replace name
+    orig = orig.replace("name=\"triton\",", f"name=\"{name}\",")
+    # Replace version
+    orig = orig.replace("version=\"2.0.0\",", f"version=\"{version}\",")
+    with open(path, "w") as f:
+        f.write(orig)
+
+
+def build_triton(commit_hash: str) -> Path:
+    with TemporaryDirectory() as tmpdir:
+        triton_basedir = Path(tmpdir) / "triton"
+        triton_pythondir = triton_basedir / "python"
+        check_call(["git", "clone", "https://github.com/openai/triton"], cwd=tmpdir)
+        check_call(["git", "checkout", commit_hash], cwd=triton_basedir)
+        patch_setup_py(triton_pythondir / "setup.py", name="pytorch-triton", version=f"2.0.0+{commit_hash[:10]}")
+        check_call([sys.executable, "setup.py", "bdist_wheel"], cwd=triton_pythondir)
+        whl_path = list((triton_pythondir / "dist").glob("*.whl"))[0]
+        shutil.copy(whl_path, Path.cwd())
+        return Path.cwd() / whl_path.name
+
+
+def main() -> None:
+    pin = read_triton_pin()
+    path = build_triton(pin)
+    print(path)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -1,7 +1,18 @@
 name: Build Triton wheels
 
 on:
+  push:
+    branches:
+      main
+    paths:
+      - .github/workflows/build-triton-wheel.yml
+      - .github/scripts/build_triton_wheel.py
+      - .github/ci_commit_pins/triton.txt
   pull_request:
+    paths:
+      - .github/workflows/build-triton-wheel.yml
+      - .github/scripts/build_triton_wheel.py
+      - .github/ci_commit_pins/triton.txt
 
 jobs:
   build-wheel:

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -14,6 +14,10 @@ on:
       - .github/scripts/build_triton_wheel.py
       - .github/ci_commit_pins/triton.txt
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   build-wheel:
     runs-on: [self-hosted, linux.2xlarge]

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_vers: [ "3.8", "3.9", "3.10" ]
+        py_vers: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
     timeout-minutes: 40
     env:
       DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.6
@@ -48,6 +48,9 @@ jobs:
 
           # Determine python executable for given version
           case $PY_VERS in
+          3.7)
+            PYTHON_EXECUTABLE=/opt/python/cp37-cp37m/bin/python
+            ;;
           3.8)
             PYTHON_EXECUTABLE=/opt/python/cp38-cp38/bin/python
             ;;
@@ -55,11 +58,14 @@ jobs:
             PYTHON_EXECUTABLE=/opt/python/cp39-cp39/bin/python
             ;;
           3.10)
-            PYTHON_EXECUTABLE=/opt/python/cp39-cp39/bin/python
+            PYTHON_EXECUTABLE=/opt/python/cp310-cp310/bin/python
+            ;;
+          3.11)
+            PYTHON_EXECUTABLE=/opt/python/cp311-cp311/bin/python
             ;;
           *)
             echo "Unsupported python version ${PY_VERS}"
-            exit -1
+            exit 1
             ;;
           esac
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+        with:
+          submodules: false
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
@@ -34,12 +36,13 @@ jobs:
       - name: Build Triton wheel
         run: |
           set -x
-          mkdir -p artifacts/
+          mkdir -p "${RUNNER_TEMP}/artifacts/"
           container_name=$(docker run \
             --tty \
             --detach \
             -v "${GITHUB_WORKSPACE}:/pytorch" \
-            -w /pytorch/artifacts/ \
+            -v "${RUNNER_TEMP}/artifacts:/artifacts" \
+            -w /artifacts/ \
             "${DOCKER_IMAGE}"      \
           )
 
@@ -51,14 +54,18 @@ jobs:
           3.9)
             PYTHON_EXECUTABLE=/opt/python/cp39-cp39/bin/python
             ;;
+          3.10)
+            PYTHON_EXECUTABLE=/opt/python/cp39-cp39/bin/python
+            ;;
           *)
             echo "Unsupported python version ${PY_VERS}"
+            exit -1
             ;;
           esac
 
           docker exec -t "${container_name}" yum install -y zlib-devel
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}" /pytorch/.github/scripts/build_triton_wheel.py
-          docker exec -t "${container_name}" chown -R 1000.1000 /pytorch/artifacts
+          docker exec -t "${container_name}" chown -R 1000.1000 /artifacts
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_vers: [ "3.8", "3.9" ]
+        py_vers: [ "3.8", "3.9", "3.10" ]
     timeout-minutes: 40
     env:
       DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.6
@@ -42,6 +42,8 @@ jobs:
             -w /pytorch/artifacts/ \
             "${DOCKER_IMAGE}"      \
           )
+
+          # Determine python executable for given version
           case $PY_VERS in
           3.8)
             PYTHON_EXECUTABLE=/opt/python/cp38-cp38/bin/python
@@ -53,7 +55,8 @@ jobs:
             echo "Unsupported python version ${PY_VERS}"
             ;;
           esac
-          docker exec -t "${container_name}" yum install zlib-devel
+
+          docker exec -t "${container_name}" yum install -y zlib-devel
           docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}" /pytorch/.github/scripts/build_triton_wheel.py
           docker exec -t "${container_name}" chown -R 1000.1000 /pytorch/artifacts
 

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -1,0 +1,69 @@
+name: Build Triton wheels
+
+on:
+  pull_request:
+
+jobs:
+  build-wheel:
+    runs-on: [self-hosted, linux.2xlarge]
+    strategy:
+      fail-fast: false
+      matrix:
+        py_vers: [ "3.8", "3.9" ]
+    timeout-minutes: 40
+    env:
+      DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.6
+      PY_VERS: ${{ matrix.py_vers }}
+    steps:
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+
+      - name: Setup Linux
+        uses: ./.github/actions/setup-linux
+
+      - name: Setup SSH (Click me for login details)
+        uses: pytorch/test-infra/.github/actions/setup-ssh@main
+        with:
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Docker image
+        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        with:
+          docker-image: ${{ env.DOCKER_IMAGE }}
+
+      - name: Build Triton wheel
+        run: |
+          set -x
+          mkdir -p artifacts/
+          container_name=$(docker run \
+            --tty \
+            --detach \
+            -v "${GITHUB_WORKSPACE}:/pytorch" \
+            -w /pytorch/artifacts/ \
+            "${DOCKER_IMAGE}"      \
+          )
+          case $PY_VERS in
+          3.8)
+            PYTHON_EXECUTABLE=/opt/python/cp38-cp38/bin/python
+            ;;
+          3.9)
+            PYTHON_EXECUTABLE=/opt/python/cp39-cp39/bin/python
+            ;;
+          *)
+            echo "Unsupported python version ${PY_VERS}"
+            ;;
+          esac
+          docker exec -t "${container_name}" yum install zlib-devel
+          docker exec -t "${container_name}" "${PYTHON_EXECUTABLE}" /pytorch/.github/scripts/build_triton_wheel.py
+          docker exec -t "${container_name}" chown -R 1000.1000 /pytorch/artifacts
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "pytorch-triton-${{ matrix.py_vers }}"
+          if-no-files-found: error
+          path:
+            ${{ runner.temp }}/artifacts/*
+
+      - name: Teardown Linux
+        uses: pytorch/test-infra/.github/actions/teardown-linux@main
+        if: always()

--- a/setup.py
+++ b/setup.py
@@ -975,6 +975,12 @@ def main():
     extras_require = {
         'opt-einsum': ['opt-einsum>=3.3']
     }
+    if platform.system() == 'linux':
+        triton_pin_file = os.path.join(cwd, ".github", "ci_commit_pins", "triton.txt")
+        if os.path.exists(triton_pin_file):
+            with open(triton_pin_file) as f:
+                triton_pin = f.read().strip()
+                extras_require['dynamo'] = ['pytorch-triton=2.0.0+'+triton_pin[:10]]
 
     # Parse the command line and check the arguments before we proceed with
     # building deps and setup. We need to set values so `--help` works.

--- a/setup.py
+++ b/setup.py
@@ -975,12 +975,14 @@ def main():
     extras_require = {
         'opt-einsum': ['opt-einsum>=3.3']
     }
-    if platform.system() == 'linux':
+    import pdb
+    pdb.set_trace()
+    if platform.system() == 'Linux':
         triton_pin_file = os.path.join(cwd, ".github", "ci_commit_pins", "triton.txt")
         if os.path.exists(triton_pin_file):
             with open(triton_pin_file) as f:
                 triton_pin = f.read().strip()
-                extras_require['dynamo'] = ['pytorch-triton=2.0.0+'+triton_pin[:10]]
+                extras_require['dynamo'] = ['torchtriton==2.0.0+' + triton_pin[:10], 'jinja2']
 
     # Parse the command line and check the arguments before we proceed with
     # building deps and setup. We need to set values so `--help` works.

--- a/setup.py
+++ b/setup.py
@@ -975,8 +975,6 @@ def main():
     extras_require = {
         'opt-einsum': ['opt-einsum>=3.3']
     }
-    import pdb
-    pdb.set_trace()
     if platform.system() == 'Linux':
         triton_pin_file = os.path.join(cwd, ".github", "ci_commit_pins", "triton.txt")
         if os.path.exists(triton_pin_file):


### PR DESCRIPTION
Also, add `torchtriton` and `jinja2` as extra `dynamo` dependency to PyTorch wheels,

Version packages as first 10 characters of pinned repo hash and make `torch[dynamo]` wheel depend on the exact version it was build against.

TODO: Automate uploading to nightly wheels storage