### PR TITLE
[dynamo] fix logging

### DIFF
--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -10,8 +10,8 @@ logging.addLevelName(CODE, "CODE")
 # Return all loggers that torchdynamo/torchinductor is responsible for
 def get_loggers():
     return [
-        logging.getLogger("torchdynamo"),
-        logging.getLogger("torchinductor"),
+        logging.getLogger("torch._dynamo"),
+        logging.getLogger("torch._inductor"),
     ]
 
 
@@ -37,12 +37,12 @@ LOGGING_CONFIG = {
         },
     },
     "loggers": {
-        "torchdynamo": {
+        "torch._dynamo": {
             "level": "DEBUG",
             "handlers": ["torchdynamo_console"],
             "propagate": False,
         },
-        "torchinductor": {
+        "torch._inductor": {
             "level": "DEBUG",
             "handlers": ["torchdynamo_console"],
             "propagate": False,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #87239

Currently, setting `torch._dynamo.config.log_level` doesn't do anything,
as the module name has changed during the move.