### PR TITLE
[Inductor] Truncate function expr str if it's too long at RecordLoadStore

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3437,6 +3437,31 @@ class CommonTemplate:
             ],
         )
 
+    # From https://github.com/pytorch/torchdynamo/issues/1352
+    def test_max_pool2d_with_indices_backward4(self):
+        def fn(a, b, c):
+            return aten.max_pool2d_with_indices_backward(
+                a, b, [5, 5], [1, 1], [2, 2], [1, 1], False, c
+            )
+
+        x = torch.randn([2, 64, 3, 4])
+        result, indices = aten.max_pool2d_with_indices(
+            x,
+            [5, 5],
+            [1, 1],
+            2,
+            1,
+            False,
+        )
+        self.common(
+            fn,
+            [
+                torch.randn_like(result),
+                x,
+                indices,
+            ],
+        )
+
     def test_avg_pool2d_backward(self):
         def fn(a, b):
             return aten.avg_pool2d_backward(

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -149,6 +149,9 @@ class RecordLoadStore(V.MockHandler):  # type: ignore[name-defined]
         self._var_ranges: VarRanges = var_ranges
         self._normalize: bool = normalize
 
+    # Truncate the expr str by a threshold to prevent it's too long
+    # and cause process hanging. The result is not used.
+    # https://github.com/pytorch/torchdynamo/issues/1352
     @staticmethod
     def truncate_expr(expr):
         if len(expr) > config.realize_bytes_threshold:

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -16,8 +16,6 @@ log = logging.getLogger(__name__)
 
 Dep = Union["MemoryDep", "StarDep"]
 
-MAX_EXPR_LENGTH = 1000
-
 
 class MemoryDep(typing.NamedTuple):
     name: str

--- a/torch/_inductor/virtualized.py
+++ b/torch/_inductor/virtualized.py
@@ -60,13 +60,17 @@ class MockHandler:
         def inner(*args, **kwargs):
             fargs = [_arg_str(a) for a in args]
             fargs.extend(f"{k}={v}" for k, v in kwargs.items())
-            return f"{name}({', '.join(fargs)})"
+            return self.truncate_expr(f"{name}({', '.join(fargs)})")
 
         return inner
 
     @staticmethod
-    def masked(mask, body, other):
-        return f"masked({mask}, {body()}, {other})"
+    def truncate_expr(expr):
+        return expr
+
+    @classmethod
+    def masked(cls, mask, body, other):
+        return cls.truncate_expr(f"masked({mask}, {body()}, {other})")
 
     @staticmethod
     def indirect_indexing(index_var):


### PR DESCRIPTION
See context at https://github.com/pytorch/torchdynamo/issues/1352#issuecomment-1283131872
Fixes https://github.com/pytorch/torchdynamo/issues/1352


cc @jansel @lezcano @fdrocha @mlazos @soumith @voznesenskym @penguinwu @anijain2305