### PR TITLE
Reopen inductor ut test_dense_mask_index_cpu and test_expanded_reduction_cpu

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -774,7 +774,9 @@ class CommonTemplate:
         # Mismatched elements: 1 / 256 (0.4%)
         # Greatest absolute difference: 2.002716064453125e-05 at index (36,) (up to 1e-05 allowed)
         # Greatest relative difference: 4.907013266928203e-06 at index (36,) (up to 1.3e-06 allowed)
-        self.common(fn, (torch.randn(2, 197, 256), torch.randn(2, 1, 256)), atol=5e-5, rtol=1e-5)
+        self.common(
+            fn, (torch.randn(2, 197, 256), torch.randn(2, 1, 256)), atol=5e-5, rtol=1e-5
+        )
 
     def test_min_max_reduction(self):
         def fn(a, b):


### PR DESCRIPTION
Solve issue https://github.com/pytorch/pytorch/issues/93542.
Reopen 
```
test_dense_mask_index_cpu (__main__.CpuTests)
test_expanded_reduction_cpu (__main__.CpuTests)
```

The failures for these two UTs is caused by different reduce order for "sum".

For example, below code will get difference result for difference order of sum:
```python
import torch
size = 100000
a  = torch.randn(size)
b = torch.randn(3)
for i in range(10):
    c = torch.zeros((1, ))
    order = torch.randperm(size)
    for j in range(size):
        c += (a[order[j]] * b[2])
    print(c.item())
```
output:
```
1.209582805633545
1.2103385925292969
1.2097705602645874
1.2099699974060059
1.2103685140609741
1.2103989124298096
1.210781216621399
1.210976243019104
1.2101386785507202
1.2098314762115479
```


The generated CPP code cannot guarantee a fixed reduce order for "sum" with
```
 #pragma omp for reduction(+:var)
```
or guarantee exactly same reduce order for aten::sum (which is the reference to compare in UT).

We can increase the tolerance here.




cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @jansel @lezcano @fdrocha