### PR TITLE
[Inductor] TorchInductor tracing fx_graph.py should import overrides

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -212,6 +212,8 @@ def dump_compiler_graph_state(gm, args, compiler_name):
 
 
 def save_graph_repro(fd, gm, args, compiler_name):
+    if "inductor" in compiler_name:
+        fd.write(f"import {config.inductor_import}.overrides\n")
     fd.write(generate_compiler_repro_string(gm, args))
     fd.write(COMPILER_REPRO_OPTIONS[compiler_name][0])
     if "_accuracy" in compiler_name:


### PR DESCRIPTION
Running the generated script would be failed if there are ops like ```philox_rand_like``` and ```philox_rand_like```. 



cc @jansel @lezcano @fdrocha