### PR TITLE
fix 0d cpu tensor handling when it's the first arg

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3800,25 +3800,33 @@ class CommonTemplate:
     @patch.object(config.triton, "cudagraphs", False)
     def test_unspec_inputs(self):
         def fn(x, y):
-            return x + y
+            return x + y, x * y, x / y
+
+        opt = torch._dynamo.optimize("inductor")(fn)
 
         inputs = (
             rand_strided((2, 3), (3, 1), device="cuda"),
             rand_strided((), (), device="cpu"),
         )
-        self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))
+        self.assertTrue(same(opt(*inputs), fn(*inputs)))
+        inputs = (inputs[1], inputs[0])
+        self.assertTrue(same(opt(*inputs), fn(*inputs)))
 
     @requires_cuda()
     @patch.object(config.triton, "cudagraphs", True)
     def test_unspec_inputs_cudagraphs(self):
         def fn(x, y):
-            return x + y
+            return x + y, x * y, x / y
+
+        opt = torch._dynamo.optimize("inductor")(fn)
 
         inputs = (
             rand_strided((2, 3), (3, 1), device="cuda"),
             rand_strided((), (), device="cpu"),
         )
-        self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))
+        self.assertTrue(same(opt(*inputs), fn(*inputs)))
+        inputs = (inputs[1], inputs[0])
+        self.assertTrue(same(opt(*inputs), fn(*inputs)))
 
     @patch.object(config.triton, "mm", "aten")
     def test_list_clearing(self):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -310,8 +310,19 @@ def make_pointwise(
             else:
                 return fn(*[load(index) for load in loaders])
 
+        if not override_device:
+            device = None
+            for i in inputs:
+                if i.get_device().type == "cuda":
+                    device = i.get_device()
+                    break
+            if not device:
+                device = inputs[0].get_device()
+
+        device = override_device or device
+
         return Pointwise.create(
-            device=override_device or inputs[0].get_device(),
+            device=device,
             dtype=dtype,
             inner_fn=inner_fn,
             ranges=ranges,


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchdynamo/issues/1681
When at least one of the pw args is on cuda, set device to cuda. We assume that cases of true device mismatch have been already weeded out during tracing, and what we have is 0d cpu tensor + cuda tensor interop.
Also fix 0d tensor test that previously wasn't compiling with dynamo. 


cc @jansel @lezcano @fdrocha