### PR TITLE
Added return code to the method compute_q8gemm_prepacked_sparse_dq

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/operator-run.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/operator-run.c
@@ -176,7 +176,7 @@ static void compute_q8gemm_prepack_a_sparse(
       context->a_packed + mr_packed_block_start);
 }
 
-static void compute_q8gemm_prepacked_sparse_dq(
+static enum pytorch_qnnp_status compute_q8gemm_prepacked_sparse_dq(
     const struct q8gemm_prepackA_sparse_dq_context context[RESTRICT_STATIC 1],
     size_t group_index, /* ignored */
     size_t pixel_index, /* ignored */
@@ -244,8 +244,9 @@ static void compute_q8gemm_prepacked_sparse_dq(
       pytorch_qnnp_log_error(
           "Invalid indices dtype specified for "
           "operator-run compute_q8gemm_prepacked_sparse_dq");
-      assert(false);
+      return pytorch_qnnp_status_invalid_parameter;
   }
+  return pytorch_qnnp_status_success;
 }
 
 struct q8sum_rows_context {


### PR DESCRIPTION
Summary:
Changed the return type of the method to return pytorch_qnnp_status.
In case of failure, replaced the assert(false) with return pytorch_qnnp_status_invalid_parameter.
and returns pytorch_qnnp_status_success in all other 'happy' scenarios.

Test Plan:
buck2 test //caffe2/test:ao -- TestQlinearPackedParams

https://pxl.cl/2h9ks

Reviewed By: kimishpatel

Differential Revision: D40473999

