### PR TITLE
Re-enabled 2 Metaprogramming tests on Windows

### DIFF
--- a/c10/test/util/Metaprogramming_test.cpp
+++ b/c10/test/util/Metaprogramming_test.cpp
@@ -260,9 +260,7 @@ TEST(MetaprogrammingTest, FilterMap_movableOnly_byValue) {
 }
 
 // See https://github.com/pytorch/pytorch/issues/35546
-TEST(
-    MetaprogrammingTest,
-    DISABLED_ON_WINDOWS(FilterMap_onlyCopiesIfNecessary)) {
+TEST(MetaprogrammingTest, FilterMap_onlyCopiesIfNecessary) {
   struct map_copy_counting_by_copy {
     CopyCounting operator()(CopyCounting v) const {
       return v;
@@ -289,9 +287,7 @@ TEST(
   EXPECT_EQ(2, result[2].move_count);
 }
 
-TEST(
-    MetaprogrammingTest,
-    DISABLED_ON_WINDOWS(FilterMap_onlyMovesIfNecessary_1)) {
+TEST(MetaprogrammingTest, FilterMap_onlyMovesIfNecessary_1) {
   struct map_copy_counting_by_move {
     CopyCounting operator()(CopyCounting&& v) const {
       return std::move(v);


### PR DESCRIPTION
With C++17 these tests are not failing

Fixes #25161

Depends on https://github.com/pytorch/pytorch/pull/85969
