### PR TITLE
Modified roundup_power2_divisions to specify the number of divisions for each power of two interval

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -104,6 +104,7 @@ constexpr size_t kLargeBuffer =
 constexpr size_t kMinLargeAlloc =
     10485760; // allocations between 1 and 10 MiB may use kLargeBuffer
 constexpr size_t kRoundLarge = 2097152; // round up large allocations to 2 MiB
+constexpr size_t kRoundUpPowerOfTwoIntervals = 16;
 
 namespace {
 
@@ -406,11 +407,24 @@ class CachingAllocatorConfig {
   // More description below in function roundup_power2_next_division
   // As ane example, if we want 4 divisions between 2's power, this can be done
   // using env variable: PYTORCH_CUDA_ALLOC_CONF=roundup_power2_divisions:4
-  static size_t roundup_power2_divisions() {
-    return instance().m_roundup_power2_divisions;
-  }
-  static size_t roundup_bypass_threshold() {
-    return instance().m_roundup_bypass_threshold;
+  static size_t roundup_power2_divisions(size_t size) {
+    size_t log_size = (63 - llvm::countLeadingZeros(size));
+
+    // Our intervals start at 1MB and end at 64GB
+    const size_t interval_start =
+        63 - llvm::countLeadingZeros(static_cast<size_t>(1048576));
+    const size_t interval_end =
+        63 - llvm::countLeadingZeros(static_cast<size_t>(68719476736));
+    TORCH_CHECK(
+        (interval_end - interval_start == Native::kRoundUpPowerOfTwoIntervals),
+        "kRoundUpPowerOfTwoIntervals mismatch");
+
+    int index = static_cast<int>(log_size) - static_cast<int>(interval_start);
+
+    index = std::max(0, index);
+    index = std::min(
+        index, static_cast<int>(Native::kRoundUpPowerOfTwoIntervals) - 1);
+    return instance().m_roundup_power2_divisions[index];
   }
 
   static CachingAllocatorConfig& instance() {
@@ -423,128 +437,269 @@ class CachingAllocatorConfig {
     return *s_instance;
   }
 
-  void parseArgs(const char* env) {
-    // If empty, set the default values
-    m_max_split_size = std::numeric_limits<size_t>::max();
-    m_roundup_power2_divisions = 0;
-    m_roundup_bypass_threshold = std::numeric_limits<size_t>::max();
-    m_garbage_collection_threshold = 0;
-
-    if (env == nullptr) {
-      return;
-    }
-
-    const std::string config(env);
-
-    std::regex exp("[\\s,]+");
-    std::sregex_token_iterator it(config.begin(), config.end(), exp, -1);
-    std::sregex_token_iterator end;
-    std::vector<std::string> options(it, end);
-
-    bool used_cudaMallocAsync = false;
-    bool used_native_specific_option = false;
-
-    for (auto option : options) {
-      std::regex exp2("[:]+");
-      std::sregex_token_iterator it2(option.begin(), option.end(), exp2, -1);
-      std::sregex_token_iterator end2;
-      std::vector<std::string> kv(it2, end2);
-      if (kv.size() >= 2) {
-        /* Maximum split size in MB.  Limited to large size blocks */
-        if (kv[0] == "max_split_size_mb") {
-          size_t val2 = stoi(kv[1]);
-          TORCH_CHECK(
-              val2 > Native::kLargeBuffer / (1024 * 1024),
-              "CachingAllocator option max_split_size_mb too small, must be > ",
-              Native::kLargeBuffer / (1024 * 1024),
-              "");
-          val2 = std::max(val2, Native::kLargeBuffer / (1024 * 1024));
-          val2 = std::min(
-              val2, (std::numeric_limits<size_t>::max() / (1024 * 1024)));
-          m_max_split_size = val2 * 1024 * 1024;
-          used_native_specific_option = true;
-        } else if (kv[0] == "roundup_power2_divisions") {
-          size_t val2 = stoi(kv[1]);
-          TORCH_CHECK(
-              llvm::isPowerOf2_64(val2),
-              "For roundups, the divisons has to be power of 2 ",
-              "");
-          m_roundup_power2_divisions = val2;
-          used_native_specific_option = true;
-        } else if (kv[0] == "roundup_bypass_threshold_mb") {
-          size_t val2 = stoi(kv[1]);
-          m_roundup_bypass_threshold = val2 * 1024 * 1024;
-          used_native_specific_option = true;
-        } else if (kv[0] == "backend") {
-          TORCH_CHECK(
-              ((kv[1] == "native") || (kv[1] == "cudaMallocAsync")),
-              "Unknown allocator backend, "
-              "options are native and cudaMallocAsync");
-          used_cudaMallocAsync = (kv[1] == "cudaMallocAsync");
-          if (used_cudaMallocAsync) {
-#if CUDA_VERSION >= 11040
-            int version;
-            C10_CUDA_CHECK(cudaDriverGetVersion(&version));
-            TORCH_CHECK(
-                version >= 11040,
-                "backend:cudaMallocAsync requires CUDA runtime "
-                "11.4 or newer, but cudaDriverGetVersion returned ",
-                version);
-#else
-            TORCH_CHECK(
-                false,
-                "backend:cudaMallocAsync requires PyTorch to be built with "
-                "CUDA 11.4 or newer, but CUDA_VERSION is ",
-                CUDA_VERSION);
-#endif
-          }
-          TORCH_INTERNAL_ASSERT(
-              kv[1] == get()->name(),
-              "Allocator backend parsed at runtime != "
-              "allocator backend parsed at load time");
-        } else if (kv[0] == "garbage_collection_threshold") {
-          /*
-           * Perform garbage collection of GPU memory blocks to avoid
-           * triggering expensive sync-and-reclaim-all operation. Upon setting
-           * the threshold (e.g., 0.8), the allocator will start reclaiming
-           * blocks if GPU memory capacity usage exceeds the threshold (i.e.,
-           * 80% of total memory).
-           * Values 0.0 and 1.0 are not allowed as they are less meaningful.
-           */
-          double val2 = stod(kv[1]);
-          TORCH_CHECK(
-              val2 > 0,
-              "garbage_collect_threshold too small, set it 0.0~1.0",
-              "");
-          TORCH_CHECK(
-              val2 < 1.0,
-              "garbage_collect_threshold too big, set it 0.0~1.0",
-              "");
-          m_garbage_collection_threshold = val2;
-          used_native_specific_option = true;
-        } else {
-          TORCH_CHECK(false, "Unrecognized CachingAllocator option: ", kv[0]);
-        }
-      }
-
-      if (used_cudaMallocAsync && used_native_specific_option) {
-        TORCH_WARN(
-            "backend:cudaMallocAsync ignores max_split_size_mb, roundup_bypass_threshold_mb,"
-            "roundup_power2_divisions, and garbage_collect_threshold.");
-      }
-    }
-  }
+  void parseArgs(const char* env);
 
  private:
   CachingAllocatorConfig()
       : m_max_split_size(std::numeric_limits<size_t>::max()),
-        m_roundup_power2_divisions(0),
-        m_garbage_collection_threshold(0) {}
+        m_garbage_collection_threshold(0) {
+    m_roundup_power2_divisions.assign(Native::kRoundUpPowerOfTwoIntervals, 0);
+  }
+
+  void lexArgs(const char* env, std::vector<std::string>& config);
+  void consumeToken(
+      const std::vector<std::string>& config,
+      size_t i,
+      const char c);
+  size_t parseMaxSplitSize(const std::vector<std::string>& config, size_t i);
+  size_t parseGarbageCollectionThreshold(
+      const std::vector<std::string>& config,
+      size_t i);
+  size_t parseRoundUpPower2Divisions(
+      const std::vector<std::string>& config,
+      size_t i);
+  size_t parseAllocatorConfig(
+      const std::vector<std::string>& config,
+      size_t i,
+      bool& used_cudaMallocAsync);
+
   std::atomic<size_t> m_max_split_size;
-  std::atomic<size_t> m_roundup_power2_divisions;
-  std::atomic<size_t> m_roundup_bypass_threshold;
+  std::vector<size_t> m_roundup_power2_divisions;
   std::atomic<double> m_garbage_collection_threshold;
 };
+
+void CachingAllocatorConfig::lexArgs(
+    const char* env,
+    std::vector<std::string>& config) {
+  std::vector<char> buf;
+
+  size_t env_length = strlen(env);
+  for (size_t i = 0; i < env_length; i++) {
+    if (env[i] == ',' || env[i] == ':' || env[i] == '[' || env[i] == ']') {
+      if (buf.size() != 0) {
+        config.emplace_back(std::string(buf.begin(), buf.end()));
+        buf.clear();
+      }
+      config.emplace_back(std::string(1, env[i]));
+    } else if (env[i] != ' ') {
+      buf.emplace_back(static_cast<char>(env[i]));
+    }
+  }
+  if (!buf.empty()) {
+    config.emplace_back(std::string(buf.begin(), buf.end()));
+  }
+}
+
+void CachingAllocatorConfig::consumeToken(
+    const std::vector<std::string>& config,
+    size_t i,
+    const char c) {
+  TORCH_CHECK(
+      i < config.size() && config[i].compare(std::string(1, c)) == 0,
+      "Error parsing CachingAllocator settings, expected ",
+      c,
+      "");
+}
+
+size_t CachingAllocatorConfig::parseMaxSplitSize(
+    const std::vector<std::string>& config,
+    size_t i) {
+  consumeToken(config, ++i, ':');
+  if (++i < config.size()) {
+    size_t val1 = stoi(config[i]);
+    TORCH_CHECK(
+        val1 > Native::kLargeBuffer / (1024 * 1024),
+        "CachingAllocator option max_split_size_mb too small, must be > ",
+        Native::kLargeBuffer / (1024 * 1024),
+        "");
+    val1 = std::max(val1, Native::kLargeBuffer / (1024 * 1024));
+    val1 = std::min(val1, (std::numeric_limits<size_t>::max() / (1024 * 1024)));
+    m_max_split_size = val1 * 1024 * 1024;
+  } else {
+    TORCH_CHECK(false, "Error, expecting max_split_size_mb value", "");
+  }
+  return i;
+}
+
+size_t CachingAllocatorConfig::parseGarbageCollectionThreshold(
+    const std::vector<std::string>& config,
+    size_t i) {
+  consumeToken(config, ++i, ':');
+  if (++i < config.size()) {
+    double val1 = stod(config[i]);
+    TORCH_CHECK(
+        val1 > 0, "garbage_collect_threshold too small, set it 0.0~1.0", "");
+    TORCH_CHECK(
+        val1 < 1.0, "garbage_collect_threshold too big, set it 0.0~1.0", "");
+    m_garbage_collection_threshold = val1;
+  } else {
+    TORCH_CHECK(
+        false, "Error, expecting garbage_collection_threshold value", "");
+  }
+  return i;
+}
+
+size_t CachingAllocatorConfig::parseRoundUpPower2Divisions(
+    const std::vector<std::string>& config,
+    size_t i) {
+  consumeToken(config, ++i, ':');
+  bool first_value = true;
+
+  if (++i < config.size()) {
+    if (config[i].compare("[") == 0) {
+      size_t last_index = 0;
+      while (++i < config.size() && config[i].compare("]") != 0) {
+        std::string val1 = config[i];
+        size_t val2 = 0;
+
+        consumeToken(config, ++i, ':');
+        if (++i < config.size()) {
+          val2 = stoi(config[i]);
+        } else {
+          TORCH_CHECK(
+              false, "Error parsing roundup_power2_divisions value", "");
+        }
+        TORCH_CHECK(
+            llvm::isPowerOf2_64(val2),
+            "For roundups, the divisons has to be power of 2 ",
+            "");
+
+        if (val1.compare(">") == 0) {
+          std::fill(
+              std::next(
+                  m_roundup_power2_divisions.begin(),
+                  static_cast<std::vector<unsigned long>::difference_type>(
+                      last_index)),
+              m_roundup_power2_divisions.end(),
+              val2);
+        } else {
+          size_t val1_long = stoul(val1);
+          TORCH_CHECK(
+              llvm::isPowerOf2_64(val1_long),
+              "For roundups, the intervals have to be power of 2 ",
+              "");
+
+          size_t index = 63 - llvm::countLeadingZeros(val1_long);
+          index = std::max((size_t)0, index);
+          index = std::min(index, m_roundup_power2_divisions.size() - 1);
+
+          if (first_value) {
+            std::fill(
+                m_roundup_power2_divisions.begin(),
+                std::next(
+                    m_roundup_power2_divisions.begin(),
+                    static_cast<std::vector<unsigned long>::difference_type>(
+                        index)),
+                val2);
+            first_value = false;
+          }
+          if (index < m_roundup_power2_divisions.size()) {
+            m_roundup_power2_divisions[index] = val2;
+          }
+          last_index = index;
+        }
+
+        if (config[i + 1].compare("]") != 0) {
+          consumeToken(config, ++i, ',');
+        }
+      }
+    } else { // Keep this for backwards compatibility
+      size_t val1 = stoi(config[i]);
+      TORCH_CHECK(
+          llvm::isPowerOf2_64(val1),
+          "For roundups, the divisons has to be power of 2 ",
+          "");
+      std::fill(
+          m_roundup_power2_divisions.begin(),
+          m_roundup_power2_divisions.end(),
+          val1);
+    }
+  } else {
+    TORCH_CHECK(false, "Error, expecting roundup_power2_divisions value", "");
+  }
+  return i;
+}
+
+size_t CachingAllocatorConfig::parseAllocatorConfig(
+    const std::vector<std::string>& config,
+    size_t i,
+    bool& used_cudaMallocAsync) {
+  consumeToken(config, ++i, ':');
+  if (++i < config.size()) {
+    TORCH_CHECK(
+        ((config[i] == "native") || (config[i] == "cudaMallocAsync")),
+        "Unknown allocator backend, "
+        "options are native and cudaMallocAsync");
+    used_cudaMallocAsync = (config[i] == "cudaMallocAsync");
+    if (used_cudaMallocAsync) {
+#if CUDA_VERSION >= 11040
+      int version;
+      C10_CUDA_CHECK(cudaDriverGetVersion(&version));
+      TORCH_CHECK(
+          version >= 11040,
+          "backend:cudaMallocAsync requires CUDA runtime "
+          "11.4 or newer, but cudaDriverGetVersion returned ",
+          version);
+#else
+      TORCH_CHECK(
+          false,
+          "backend:cudaMallocAsync requires PyTorch to be built with "
+          "CUDA 11.4 or newer, but CUDA_VERSION is ",
+          CUDA_VERSION);
+#endif
+    }
+    TORCH_INTERNAL_ASSERT(
+        config[i] == get()->name(),
+        "Allocator backend parsed at runtime != "
+        "allocator backend parsed at load time");
+  } else {
+    TORCH_CHECK(false, "Error parsing backend value", "");
+  }
+  return i;
+}
+
+void CachingAllocatorConfig::parseArgs(const char* env) {
+  // If empty, set the default values
+  m_max_split_size = std::numeric_limits<size_t>::max();
+  m_roundup_power2_divisions.assign(Native::kRoundUpPowerOfTwoIntervals, 0);
+  m_garbage_collection_threshold = 0;
+  bool used_cudaMallocAsync = false;
+  bool used_native_specific_option = false;
+
+  if (env == nullptr) {
+    return;
+  }
+
+  std::vector<std::string> config;
+  lexArgs(env, config);
+
+  for (size_t i = 0; i < config.size(); i++) {
+    if (config[i].compare("max_split_size_mb") == 0) {
+      i = parseMaxSplitSize(config, i);
+      used_native_specific_option = true;
+    } else if (config[i].compare("garbage_collection_threshold") == 0) {
+      i = parseGarbageCollectionThreshold(config, i);
+      used_native_specific_option = true;
+    } else if (config[i].compare("roundup_power2_divisions") == 0) {
+      i = parseRoundUpPower2Divisions(config, i);
+      used_native_specific_option = true;
+    } else if (config[i].compare("backend") == 0) {
+      i = parseAllocatorConfig(config, i, used_cudaMallocAsync);
+    } else {
+      TORCH_CHECK(false, "Unrecognized CachingAllocator option: ", config[i]);
+    }
+
+    if (i + 1 < config.size()) {
+      consumeToken(config, ++i, ',');
+    }
+  }
+
+  if (used_cudaMallocAsync && used_native_specific_option) {
+    TORCH_WARN(
+        "backend:cudaMallocAsync ignores max_split_size_mb, roundup_bypass_threshold_mb,"
+        "roundup_power2_divisions, and garbage_collect_threshold.");
+  }
+}
 
 namespace Native {
 
@@ -1137,10 +1292,8 @@ class DeviceCachingAllocator {
   static size_t round_size(size_t size) {
     if (size < kMinBlockSize) {
       return kMinBlockSize;
-    } else if (size > CachingAllocatorConfig::roundup_bypass_threshold()) {
-      return kMinBlockSize * ((size + kMinBlockSize - 1) / kMinBlockSize);
     } else {
-      auto divisions = CachingAllocatorConfig::roundup_power2_divisions();
+      auto divisions = CachingAllocatorConfig::roundup_power2_divisions(size);
       if (divisions > 0 && size > (kMinBlockSize * divisions)) {
         return roundup_power2_next_division(size, divisions);
       } else {

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -394,6 +394,12 @@ Available options:
   the size 1200 lies between 1024 and 2048 and if we do 4 divisions between
   them, the values are 1024, 1280, 1536, and 1792. So, allocation size of 1200
   will be rounded to 1280 as the nearest ceiling of power-2 division.
+  Specify a single value to apply for all allocation sizes or specify an
+  array of key value pairs to set power-2 division individually for each
+  power of two interval. For example to set 1 division for all allocations
+  under 256MB, 2 division for allocations between 256MB and 512MB, 4 divisions
+  for allocations between 512MB and 1GB and 8 divisions for any larger allocations,
+  set the knob value to: [256:1,512:2,1024:4,>:8].
   ``roundup_power2_divisions`` is only meaningful with ``backend:native``.
   With ``backend:cudaMallocAsync``, ``roundup_power2_divisions`` is ignored.
 * ``roundup_bypass_threshold_mb`` bypass rounding the requested allocation size,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4767,10 +4767,14 @@ class TestCudaComm(TestCase):
         nelems = 21 * 1024 * 1024
         nbytes = 4 * nelems  # floats are 4 bytes
 
+        nelems_big = 100 * 1024 * 1024
+        nbytes_big = 4 * nelems_big  # floats are 4 bytes
+
         start_mem = torch.cuda.memory_stats()[key]
         torch.cuda.memory._set_allocator_settings("")
         x = torch.rand(nelems, device='cuda')
 
+        # test roundup_power2_divisions single value syntax
         reg_mem = torch.cuda.memory_stats()[key]
         torch.cuda.memory._set_allocator_settings("roundup_power2_divisions:4")
         y = torch.rand(nelems, device='cuda')
@@ -4792,6 +4796,26 @@ class TestCudaComm(TestCase):
         reg_mem = torch.cuda.memory_stats()[key]
         self.assertTrue(reg_mem - start_mem == nbytes)
 
+        # roundup_power2_divisions knob array syntax
+        torch.cuda.memory.empty_cache()
+        torch.cuda.memory._set_allocator_settings(
+            "garbage_collection_threshold:0.5,roundup_power2_divisions:[64:8,128:2,256:2,512:2,1024:1,>:1]")
+        start_mem = torch.cuda.memory_stats()[key]
+        w = torch.rand(nelems, device='cuda')
+
+        pow2_div8_mem = torch.cuda.memory_stats()[key]
+        if not TEST_CUDAMALLOCASYNC:
+            # not supported with the cudaMallocAsync backend
+            self.assertTrue(pow2_div8_mem - start_mem == power2_div(nbytes, 8))
+
+        torch.cuda.memory.empty_cache()
+        start_mem = torch.cuda.memory_stats()[key]
+        v = torch.rand(nelems_big, device='cuda')
+
+        pow2_div2_mem = torch.cuda.memory_stats()[key]
+        if not TEST_CUDAMALLOCASYNC:
+            # not supported with the cudaMallocAsync backend
+            self.assertTrue(pow2_div2_mem - start_mem == power2_div(nbytes_big, 2))
 
         with self.assertRaises(RuntimeError):
             torch.cuda.memory._set_allocator_settings("foo:1,bar:2")


### PR DESCRIPTION
Summary:
Improved roundup_power2_divisions knob so it allows better control of rouding in the PyTorch CUDA Caching Allocator.

This new version allows setting the number of divisions per power of two interval starting from 1MB and ending at 64GB and above. An example use case is when rouding is desirable for small allocations but there are also very large allocations which are persistent, thus would not benefit from rounding and take up extra space.

Test Plan: Tested locally

Differential Revision: D40103909

