### PR TITLE
Fix wrong lintrunner version

### DIFF
--- a/.github/requirements-gha-cache.txt
+++ b/.github/requirements-gha-cache.txt
@@ -8,7 +8,7 @@
 cffi==1.15.0
 dataclasses==0.6
 jinja2==3.0.1
-lintrunner=0.9.2
+lintrunner==0.9.2
 ninja==1.10.0.post1
 pynvml==11.4.1
 requests==2.26


### PR DESCRIPTION
The syntax is invalid for pip.  I missed this a while back:

```
Run pip install -r .github/requirements-gha-cache.txt
ERROR: Invalid requirement: 'lintrunner=0.9.2' (from line 11 of .github/requirements-gha-cache.txt)
Hint: = is not a valid operator. Did you mean == ?
```
