### PR TITLE
[BE] Move conda cmake installation to Docker

### DIFF
--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -139,6 +139,7 @@ case "$image" in
     DB=yes
     VISION=yes
     KATEX=yes
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7)
     CUDA_VERSION=11.6.2
@@ -151,6 +152,7 @@ case "$image" in
     KATEX=yes
     UCX_COMMIT=${_UCX_COMMIT}
     UCC_COMMIT=${_UCC_COMMIT}
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-bionic-cuda11.7-cudnn8-py3-gcc7)
     CUDA_VERSION=11.7.0
@@ -163,6 +165,7 @@ case "$image" in
     KATEX=yes
     UCX_COMMIT=${_UCX_COMMIT}
     UCC_COMMIT=${_UCC_COMMIT}
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-xenial-py3-clang5-asan)
     ANACONDA_PYTHON_VERSION=3.7
@@ -184,6 +187,7 @@ case "$image" in
     PROTOBUF=yes
     DB=yes
     VISION=yes
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-xenial-py3-clang7-onnx)
     ANACONDA_PYTHON_VERSION=3.7
@@ -198,6 +202,7 @@ case "$image" in
     PROTOBUF=yes
     DB=yes
     VISION=yes
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-xenial-py3-clang5-android-ndk-r19c)
     ANACONDA_PYTHON_VERSION=3.7
@@ -224,6 +229,7 @@ case "$image" in
     VISION=yes
     VULKAN_SDK_VERSION=1.2.162.1
     SWIFTSHADER=yes
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-bionic-py3.8-gcc9)
     ANACONDA_PYTHON_VERSION=3.8
@@ -231,6 +237,7 @@ case "$image" in
     PROTOBUF=yes
     DB=yes
     VISION=yes
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-bionic-cuda10.2-cudnn7-py3.7-clang9)
     CUDA_VERSION=10.2
@@ -240,6 +247,7 @@ case "$image" in
     PROTOBUF=yes
     DB=yes
     VISION=yes
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7)
     CUDA_VERSION=10.2
@@ -249,6 +257,7 @@ case "$image" in
     PROTOBUF=yes
     DB=yes
     VISION=yes
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-focal-rocm5.1-py3.7)
     ANACONDA_PYTHON_VERSION=3.7
@@ -257,6 +266,7 @@ case "$image" in
     DB=yes
     VISION=yes
     ROCM_VERSION=5.1.1
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-focal-rocm5.2-py3.7)
     ANACONDA_PYTHON_VERSION=3.7
@@ -265,6 +275,7 @@ case "$image" in
     DB=yes
     VISION=yes
     ROCM_VERSION=5.2
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-focal-py3.7-gcc7)
     ANACONDA_PYTHON_VERSION=3.7
@@ -274,6 +285,7 @@ case "$image" in
     DB=yes
     VISION=yes
     KATEX=yes
+    CONDA_CMAKE=yes
     ;;
   pytorch-linux-jammy-cuda11.6-cudnn8-py3.8-clang12)
     ANACONDA_PYTHON_VERSION=3.8
@@ -383,6 +395,7 @@ docker build \
        --build-arg "IMAGE_NAME=${IMAGE_NAME}" \
        --build-arg "UCX_COMMIT=${UCX_COMMIT}" \
        --build-arg "UCC_COMMIT=${UCC_COMMIT}" \
+       --build-arg "CONDA_CMAKE=${CONDA_CMAKE}" \
        -f $(dirname ${DOCKERFILE})/Dockerfile \
        -t "$tmp_tag" \
        "$@" \

--- a/.circleci/docker/centos-rocm/Dockerfile
+++ b/.circleci/docker/centos-rocm/Dockerfile
@@ -40,6 +40,7 @@ RUN bash ./install_user.sh && rm install_user.sh
 # Install conda and other packages (e.g., numpy, pytest)
 ENV PATH /opt/conda/bin:$PATH
 ARG ANACONDA_PYTHON_VERSION
+ARG CONDA_CMAKE
 COPY requirements-ci.txt /opt/conda/requirements-ci.txt
 COPY ./common/install_conda.sh install_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh

--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -75,8 +75,6 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   }
 
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
-  # DO NOT install cmake here as it would install a version newer than 3.13, but
-  # we want to pin to version 3.13.
   CONDA_COMMON_DEPS="astunparse pyyaml mkl=2022.0.1 mkl-include=2022.0.1 setuptools cffi future six"
   if [ "$ANACONDA_PYTHON_VERSION" = "3.10" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
@@ -90,6 +88,14 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   else
     # Install `typing_extensions` for 3.7
     conda_install numpy=1.18.5 ${CONDA_COMMON_DEPS} typing_extensions
+  fi
+
+  # Use conda cmake in some cases. Conda cmake will be newer than our supported
+  # min version (3.5 for xenial and 3.10 for bionic), so we only do it in those
+  # following builds that we know should use conda. Specifically, Ubuntu bionic
+  # and focal cannot find conda mkl with stock cmake, so we need a cmake from conda
+  if [ -n "${CONDA_CMAKE}" ]; then
+    conda_install cmake
   fi
 
   # Magma package names are concatenation of CUDA major and minor ignoring revision

--- a/.circleci/docker/ubuntu-cuda/Dockerfile
+++ b/.circleci/docker/ubuntu-cuda/Dockerfile
@@ -26,6 +26,7 @@ RUN bash ./install_docs_reqs.sh && rm install_docs_reqs.sh
 # Install conda and other packages (e.g., numpy, pytest)
 ENV PATH /opt/conda/bin:$PATH
 ARG ANACONDA_PYTHON_VERSION
+ARG CONDA_CMAKE
 COPY requirements-ci.txt /opt/conda/requirements-ci.txt
 COPY ./common/install_conda.sh install_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh

--- a/.circleci/docker/ubuntu-rocm/Dockerfile
+++ b/.circleci/docker/ubuntu-rocm/Dockerfile
@@ -28,6 +28,7 @@ RUN bash ./install_user.sh && rm install_user.sh
 # Install conda and other packages (e.g., numpy, pytest)
 ENV PATH /opt/conda/bin:$PATH
 ARG ANACONDA_PYTHON_VERSION
+ARG CONDA_CMAKE
 COPY requirements-ci.txt /opt/conda/requirements-ci.txt
 COPY ./common/install_conda.sh install_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh

--- a/.circleci/docker/ubuntu/Dockerfile
+++ b/.circleci/docker/ubuntu/Dockerfile
@@ -37,6 +37,7 @@ RUN bash ./install_docs_reqs.sh && rm install_docs_reqs.sh
 # Install conda and other packages (e.g., numpy, pytest)
 ENV PATH /opt/conda/bin:$PATH
 ARG ANACONDA_PYTHON_VERSION
+ARG CONDA_CMAKE
 COPY requirements-ci.txt /opt/conda/requirements-ci.txt
 COPY ./common/install_conda.sh install_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -23,28 +23,6 @@ fi
 # shellcheck disable=SC2034
 BUILD_TEST_LIBTORCH=0
 
-# Use conda cmake in some CI build. Conda cmake will be newer than our supported
-# min version (3.5 for xenial and 3.10 for bionic),
-# so we only do it in four builds that we know should use conda.
-# Linux bionic cannot find conda mkl with cmake 3.10, so we need a cmake from conda.
-# Alternatively we could point cmake to the right place
-# export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
-if [[ "${TEST_CONFIG:-}" == *xla* ]] || \
-   [[ "$BUILD_ENVIRONMENT" == *centos* ]] || \
-   [[ "$BUILD_ENVIRONMENT" == *linux-bionic* ]] || \
-   [[ "$BUILD_ENVIRONMENT" == *linux-focal* ]]; then
-  if ! which conda; then
-    echo "Expected ${BUILD_ENVIRONMENT} to use conda, but 'which conda' returns empty"
-    exit 1
-  else
-    conda install -q -y cmake
-  fi
-  if [[ "$BUILD_ENVIRONMENT" == *centos* ]]; then
-    # cmake3 package will conflict with conda cmake
-    sudo yum -y remove cmake3 || true
-  fi
-fi
-
 retry () {
   "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@")
 }


### PR DESCRIPTION
This is parts of the effort to consolidate pip and conda installation in the CI to improve our CI reliability.  This moves conda cmake installation to Docker in those use cases that require it:

* Ubuntu bionic and focal

On the other hand:
* XLA doesn't seem to need conda cmake anymore (Build and test successfully)
* Centos is not in used anywhere in the CI