### PR TITLE
[SDPA] Use scaled_dot_product_attention within attention.cpp

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13279,7 +13279,8 @@
 - func: _native_multi_head_attention(Tensor query, Tensor key, Tensor value, int embed_dim, int num_head, Tensor qkv_weight, Tensor qkv_bias, Tensor proj_weight, Tensor proj_bias, Tensor? mask=None, bool need_weights=True, bool average_attn_weights=True, int? mask_type=None) -> (Tensor, Tensor)
   variants: function
   dispatch:
-    CPU, CUDA, NestedTensorCPU, NestedTensorCUDA: native_multi_head_attention
+    CPU, NestedTensorCPU: native_multi_head_attention_cpu
+    CUDA, NestedTensorCUDA: native_multi_head_attention_cuda
   autogen: _native_multi_head_attention.out
 
 - func: _scaled_dot_product_attention(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> (Tensor, Tensor)

--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
@@ -322,14 +322,11 @@ bool is_safe_to_get_storage_as_tensor(const NestedTensorImpl* tensor) {
   const int64_t* tensor_size_ptr = tensor_sizes.data_ptr<int64_t>();
   const int64_t* tensor_stride_ptr = tensor_strides.data_ptr<int64_t>();
 
-  int64_t offset_constant = (tensor_offsets[1] - tensor_offsets[0]) /
-      tensor_size_ptr[0] * tensor_stride_ptr[0];
-
+  int64_t offset_constant = (tensor_offsets[1] - tensor_offsets[0]) / (tensor_size_ptr[0] * tensor_stride_ptr[0]);
   for (int64_t i = 2; i < n_tensors; i++) {
-    int64_t current_offset_constant =
-        (tensor_offsets[i] - tensor_offsets[i - 1]) /
-        tensor_size_ptr[(i - 1) * tensor_stride_0] *
-        tensor_stride_ptr[(i - 1) * tensor_stride_0];
+    // TODO: When 0 seq_len nested tensors are allowed we need to guard against this
+    int64_t previous_numel = tensor_size_ptr[(i - 1) * tensor_stride_0] * tensor_stride_ptr[(i - 1) * tensor_stride_0];
+    int64_t current_offset_constant = (tensor_offsets[i] - tensor_offsets[i - 1]) / previous_numel;
     if (current_offset_constant != offset_constant) {
       return false;
     }
@@ -431,7 +428,6 @@ std::tuple<Tensor, Tensor> mem_efficient_helper_nested_unpacked(
       {Nnz_kv, num_heads, head_dim},
       {nnz_v_stride, head_v_stride, head_dim_stride},
       value_impl->get_storage_offsets()[0]);
-
   std::tuple<Tensor, Tensor> attention_and_weights =
       at::_efficient_attention_forward(
           query_buffer_reshaped.unsqueeze(0),

--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
@@ -322,10 +322,14 @@ bool is_safe_to_get_storage_as_tensor(const NestedTensorImpl* tensor) {
   const int64_t* tensor_size_ptr = tensor_sizes.data_ptr<int64_t>();
   const int64_t* tensor_stride_ptr = tensor_strides.data_ptr<int64_t>();
 
-  int64_t offset_constant = (tensor_offsets[1] - tensor_offsets[0]) / (tensor_size_ptr[0] * tensor_stride_ptr[0]);
+  int64_t numel_0 = (tensor_size_ptr[0] * tensor_stride_ptr[0]);
+  TORCH_INTERNAL_ASSERT(numel_0 > 0, "numels must be positive!");
+
+  int64_t offset_constant = (tensor_offsets[1] - tensor_offsets[0]) / numel_0;
   for (int64_t i = 2; i < n_tensors; i++) {
     // TODO: When 0 seq_len nested tensors are allowed we need to guard against this
     int64_t previous_numel = tensor_size_ptr[(i - 1) * tensor_stride_0] * tensor_stride_ptr[(i - 1) * tensor_stride_0];
+    TORCH_INTERNAL_ASSERT(previous_numel > 0, "numels must be positive!");
     int64_t current_offset_constant = (tensor_offsets[i] - tensor_offsets[i - 1]) / previous_numel;
     if (current_offset_constant != offset_constant) {
       return false;

--- a/aten/src/ATen/native/transformers/attention.h
+++ b/aten/src/ATen/native/transformers/attention.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <ATen/ATen.h>
+#include <c10/macros/Export.h>
+
+namespace at {
+namespace native {
+
+TORCH_API Tensor bmm_nt(const Tensor& a, const Tensor& b);
+TORCH_API Tensor masked_softmax(
+    Tensor& attn_scores,
+    c10::optional<Tensor> attn_mask,
+    const Tensor& query,
+    c10::optional<int64_t> mask_type = NULL);
+
+TORCH_API Tensor transform0213_gemm_nt_bias(
+    const Tensor& a,
+    const Tensor& b,
+    const Tensor& c,
+    const Tensor& query);
+
+TORCH_API Tensor bmm_nn(Tensor& out, const Tensor& a, const Tensor& b);
+
+TORCH_API void debug_assert_shape(int line, const Tensor& t, c10::IntArrayRef shape);
+
+TORCH_API Tensor qkv_projection(
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value,
+    const int64_t embed_dim,
+    const Tensor& qkv_weight);
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -560,13 +560,13 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
     // We have not done linear projection yet but the input for SDP
     // Is expected to be 4 dimensional. We "cheaply" create view tensors
     // That will then be used for checking hot path conditions with select_sd_backend
-    auto q = query.view({query.size(0), -1, num_head, dim_per_head});
-    auto k = key.view({key.size(0), -1, num_head, dim_per_head});
-    auto v = value.view({value.size(0), -1, num_head, dim_per_head});
+    auto q = query.view({query.size(0), -1, num_head, dim_per_head}).transpose(1, 2);
+    auto k = key.view({key.size(0), -1, num_head, dim_per_head}).transpose(1, 2);
+    auto v = value.view({value.size(0), -1, num_head, dim_per_head}).transpose(1, 2);
 
     sdp::sdp_params kernel_params{q, k, v, mask.has_value(), 0.0, need_weights, false};
     auto backend = select_sdp_backend(kernel_params);
-    if (backend != sdp::SDPBackend::math && backend != sdp::SDPBackend::error) {
+    if (backend == sdp::SDPBackend::flash_attention || backend == sdp::SDPBackend::efficient_attention) {
       auto x = at::linear(query, qkv_weight, qkv_bias);
       auto chunks = x.chunk(3, -1);
       auto x_size_0 = x.size(0);
@@ -835,7 +835,6 @@ std::tuple<at::Tensor, at::Tensor> _efficient_attention_forward(
 // TODO In theory it is possible to compile with _CUDA_ARCH < 5.0 and run on a
 // machine that is >= 5.0. In practice, this is not a problem but since
 // this would avoid runtime architecture checks, we should look into it
-
   TORCH_CHECK(query.dim() == 4);
   TORCH_CHECK(key.dim() == 4);
   TORCH_CHECK(value.dim() == 4);

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -17,6 +17,7 @@
 
 #include <c10/cuda/CUDAMathCompat.h>
 
+#include <ATen/native/transformers/attention.h>
 #include <ATen/native/nested/NestedTensorUtils.h>
 #include <ATen/native/nested/NestedTensorTransformerFunctions.h>
 #include <ATen/native/nested/NestedTensorUtils.h>
@@ -479,6 +480,204 @@ __host__ std::tuple<Tensor, Tensor, Tensor> transform_bias_rescale_qkv_cuda(
   return std::make_tuple(q_k_v_s[0], q_k_v_s[1], q_k_v_s[2]);
 }
 
+std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value,
+    const int64_t embed_dim,
+    const int64_t num_head,
+    const Tensor& qkv_weight,
+    const Tensor& qkv_bias,
+    const Tensor& proj_weight,
+    const Tensor& proj_bias,
+    const c10::optional<Tensor>& mask,
+    bool need_weights,
+    bool average_attn_weights,
+    const c10::optional<int64_t> mask_type) {
+  // query shape: [B, T, D]
+  // qkv_weight shape: [3 * D, D]
+
+  TORCH_CHECK(
+      !mask || !query.is_nested(),
+      "NestedTensor with mask is not supported yet");
+  const auto D = embed_dim;
+  TORCH_CHECK(
+      query.dim() == 3,
+      "expected 3-D `query`, got ",
+      query.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      query.is_nested() || query.sizes()[2] == embed_dim,
+      "passed-in embed_dim ",
+      embed_dim,
+      " didn't match last dim of query ",
+      query.sizes()[2]);
+  TORCH_CHECK(
+      key.dim() == 3,
+      "expected 3-D `key`, got ",
+      key.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      value.dim() == 3,
+      "expected 3-D `value`, got ",
+      value.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      query.is_nested() || key.is_nested() || value.is_nested() ||
+          (query.sizes() == key.sizes() && key.sizes() == value.sizes()),
+      "expected `query`/`key`/`value` shapes to match");
+  TORCH_CHECK(
+      qkv_weight.dim() == 2,
+      "expected 2-D `qkv_weight`, got ",
+      qkv_weight.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      D * 3 == qkv_weight.sizes()[0],
+      "expected `qkv_weight` first dim to be 3x embed_dim");
+  TORCH_CHECK(
+      D == qkv_weight.sizes()[1],
+      "expected `qkv_weight` second dim to be embed_Dim");
+  TORCH_CHECK(
+      qkv_bias.dim() == 1,
+      "expected 2-D `qkv_bias`, got ",
+      qkv_bias.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      qkv_bias.sizes()[0] == 3 * D,
+      "expected `qkv_bias` first dim and first dim of query to be equal");
+  TORCH_CHECK(D % num_head == 0, "`embed_dim` must divide evenly by `num_heads`");
+
+#ifndef NDEBUG
+  const auto B = query.is_nested()
+      ? get_nested_tensor_impl(query)->get_nested_size_tensor().size(0)
+      : query.sizes()[0];
+  auto T = query.is_nested() ? 0 : query.sizes()[1];
+
+#endif
+  const auto dim_per_head = D / num_head;
+  if ((query.is_same(key) && key.is_same(value)) && dim_per_head % 8 == 0 ) {
+
+    // We have not done linear projection yet but the input for SDP
+    // Is expected to be 4 dimensional. We "cheaply" create view tensors
+    // That will then be used for checking hot path conditions with select_sd_backend
+    auto q = query.view({query.size(0), -1, num_head, dim_per_head});
+    auto k = key.view({key.size(0), -1, num_head, dim_per_head});
+    auto v = value.view({value.size(0), -1, num_head, dim_per_head});
+
+    sdp::sdp_params kernel_params{q, k, v, mask.has_value(), 0.0, need_weights, false};
+    auto backend = select_sdp_backend(kernel_params);
+    if (backend != sdp::SDPBackend::math && backend != sdp::SDPBackend::error) {
+      auto x = at::linear(query, qkv_weight, qkv_bias);
+      auto chunks = x.chunk(3, -1);
+      auto x_size_0 = x.size(0);
+
+      chunks[0] = (chunks[0].view({x_size_0, -1, num_head, dim_per_head}))
+                      .transpose(1, 2);
+      chunks[1] = (chunks[1].view({x_size_0, -1, num_head, dim_per_head}))
+                      .transpose(1, 2);
+      chunks[2] = (chunks[2].view({x_size_0, -1, num_head, dim_per_head}))
+                      .transpose(1, 2);
+
+      auto y = at::_scaled_dot_product_attention(
+          chunks[0], chunks[1], chunks[2], mask, 0.0, need_weights, false);
+      auto past_sdp =
+          std::get<0>(y).transpose(1, 2).reshape({x_size_0, -1, embed_dim});
+      return std::make_tuple(
+          at::linear(past_sdp, proj_weight, proj_bias), Tensor());
+    }
+    // Returned math or error lets not use it
+  }
+
+  // shape: [B, T, 3 x D]
+  auto qkv = qkv_projection(query, key, value, embed_dim, qkv_weight);
+
+  if (!qkv.is_nested() && qkv.numel() == 0) {
+    if (query.is_nested()) {
+      return std::make_tuple(Tensor(), Tensor());
+    }
+    return std::make_tuple(at::empty_like(query), Tensor());
+  }
+
+#ifndef NDEBUG
+  if (!query.is_nested() || !qkv.is_nested()) {
+    if (query.is_nested()) {
+      T = qkv.size(1);
+    }
+    debug_assert_shape(__LINE__, qkv, {B, T, 3 * D});
+  }
+#endif
+
+#ifdef DEBUG_PRINT_EACH_STEP
+  if (!qkv.is_nested()) {
+    std::cerr << "qkv: " << qkv << std::endl;
+  }
+#endif
+  // shape: 3 x [B, num_head, T, dim_per_head]
+  auto q_k_v = _transform_bias_rescale_qkv(qkv, qkv_bias, num_head);
+  qkv = Tensor(); // Not used any more, allow free
+  auto& q = std::get<0>(q_k_v);
+  const auto& k = std::get<1>(q_k_v);
+  const auto& v = std::get<2>(q_k_v);
+#ifndef NDEBUG
+  debug_assert_shape(__LINE__, q, {B, num_head, T, dim_per_head});
+  debug_assert_shape(__LINE__, k, {B, num_head, T, dim_per_head});
+  debug_assert_shape(__LINE__, v, {B, num_head, T, dim_per_head});
+#endif
+#ifdef DEBUG_PRINT_EACH_STEP
+  std::cerr << "q: " << q << std::endl;
+  std::cerr << "k: " << k << std::endl;
+  std::cerr << "v: " << v << std::endl;
+#endif
+
+  // shape: [B, num_head, T, T]
+  auto qkt = bmm_nt(q, k);
+  // q & k are dead but cannot be freed because they were packed with v
+#ifndef NDEBUG
+  debug_assert_shape(__LINE__, qkt, {B, num_head, T, T});
+#endif
+#ifdef DEBUG_PRINT_EACH_STEP
+  std::cerr << "qkt: " << qkt << std::endl;
+#endif
+
+  // shape: [B, num_head, T, T]
+  // TODO: long-term, have a kernel that works with
+  // NestedTensor directly if there is no mask passed
+  qkt = masked_softmax(qkt, mask, query, mask_type);
+#ifdef DEBUG_PRINT_EACH_STEP
+  std::cerr << "qkt after softmax: " << qkt << std::endl;
+#endif
+
+  // shape: [B, num_head, T, dim_per_head]
+  // reuse storage for q; we're done with it
+  auto attn_ctx = bmm_nn(q, qkt, v);
+  // qkv is not dead; we just reused storage for q!
+  if (!need_weights) {
+    qkt = Tensor();
+  }
+#ifndef NDEBUG
+  debug_assert_shape(__LINE__, attn_ctx, {B, num_head, T, dim_per_head});
+#endif
+#ifdef DEBUG_PRINT_EACH_STEP
+  std::cerr << "attn_ctx: " << attn_ctx << std::endl;
+#endif
+
+  // shape: [B, T, D]
+  // Fuse transform_0213 inside
+  auto proj = transform0213_gemm_nt_bias(
+      attn_ctx, proj_weight, proj_bias, query);
+#ifndef NDEBUG
+  debug_assert_shape(__LINE__, proj, {B, T, D});
+#endif
+  if (need_weights && average_attn_weights) {
+    // weights are not needed for full transformer, so don't worry too
+    // much about performance -- we implement this just to make use
+    // cases that don't disable need_weights still get some speedup.
+    qkt = qkt.sum(1);
+    qkt /= num_head;
+  }
+  return std::make_tuple(std::move(proj), std::move(qkt));
+}
+
 std::tuple<Tensor, Tensor> flash_attention_helper_dense_unpacked(
     const Tensor& query,
     const Tensor& key,
@@ -768,7 +967,7 @@ std::tuple<at::Tensor, at::Tensor> _efficient_attention_forward(
           kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes));
     }
     Kernel::check_supported(p);
-    kernel_fn<<<p.getBlocksGrid(), p.getThreadsGrid(), smem_bytes>>>(p);
+    kernel_fn<<<p.getBlocksGrid(), p.getThreadsGrid(), smem_bytes, stream>>>(p);
   };
   // Dispatch to the right kernel
   DISPATCH_KERNEL(query, key, value, ([&]() {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -9,6 +9,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/util/env.h>
 #include <c10/util/irange.h>
+#include <ATen/NestedTensorImpl.h>
 
 #include <functional>
 #include <unordered_set>
@@ -61,6 +62,26 @@ inline bool check_for_attn_weights(sdp_params params, bool debug) {
   }
   return true;
 }
+inline bool check_for_seq_len_1_nested_tensor(sdp_params params, bool debug) {
+  if (!params.query.is_nested()) {
+    return true;
+  }
+  const at::Tensor& sizes = at::native::get_nested_tensor_impl(params.query)->get_nested_size_tensor();
+  auto* sizes_ptr = sizes.data_ptr<int64_t>();
+  const int64_t n_tensors = params.query.size(0);
+  const int64_t size_tensor_stride = sizes.stride(0);
+
+  // This is being called inside sdp with shape [batch, heads, {seq_len}, dim]
+  for (const auto i : c10::irange(n_tensors)) {
+    if (sizes_ptr[(i * size_tensor_stride) + 1] <= 1) {
+      TORCH_CHECK(
+          !debug, "Flash Attention does not support sequence_length < 1");
+      return false;
+    }
+  }
+
+  return true;
+}
 
 inline bool check_for_attn_mask(sdp_params params, bool debug) {
   if (params.has_attn_mask) {
@@ -73,7 +94,7 @@ inline bool check_for_attn_mask(sdp_params params, bool debug) {
 inline bool check_tensor_shapes(sdp_params params, bool debug) {
   auto query_dim = params.query.dim();
   if (!(query_dim == params.key.dim() && query_dim == params.value.dim() &&
-        query_dim == 4)) {
+        (query_dim == 4 ))) {
     TORCH_CHECK(
         !debug,
         "Flash attention requires query, key and value to be 4 dimensional, but got Query dim: ",
@@ -206,7 +227,8 @@ inline bool use_mem_efficient_attention(sdp_params params, bool debug) {
       check_runtime_disabled_mem_efficient,
       check_for_attn_weights,
       check_tensor_shapes,
-      check_for_attn_mask};
+      check_for_attn_mask,
+      check_for_seq_len_1_nested_tensor};
   for (auto& constraint : constraints) {
     if (!constraint(params, debug)) {
       return false;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -200,7 +200,8 @@ inline bool use_flash_attention(sdp_params params, bool debug) {
       check_for_attn_weights,
       check_for_attn_mask,
       check_head_dim_size,
-      check_gpu_sm75_or_greater};
+      check_gpu_sm75_or_greater,
+      check_for_seq_len_1_nested_tensor};
   for (auto& constraint : constraints) {
     if (!constraint(params, debug)) {
       return false;

--- a/aten/src/ATen/native/transformers/transformer.cpp
+++ b/aten/src/ATen/native/transformers/transformer.cpp
@@ -95,7 +95,6 @@ Tensor transformer_encoder_layer_forward(
   if (norm_first) {
     x = norm(x, embed_dim, layer_norm_eps, layer_norm_weight_1, layer_norm_bias_1, use_nested_tensor);
   }
-
 #if BETTER_TRANSFORMER_USE_FLASH_ATTENTION
   if (x.is_nested() && x.is_cuda() && x.dtype() == at::kHalf && !mask.has_value() &&
       (embed_dim / num_heads == 16 ||
@@ -111,7 +110,7 @@ Tensor transformer_encoder_layer_forward(
      x = at::linear(x, proj_weight, proj_bias);
   } else {
 #endif
-     x = std::get<0>(native_multi_head_attention(
+     x = std::get<0>(at::_native_multi_head_attention(
          x,
          x,
          x,
@@ -128,6 +127,21 @@ Tensor transformer_encoder_layer_forward(
 #if BETTER_TRANSFORMER_USE_FLASH_ATTENTION
   }
 #endif
+  x = std::get<0>(at::_native_multi_head_attention(
+      x,
+      x,
+      x,
+      embed_dim,
+      num_heads,
+      qkv_weight,
+      qkv_bias,
+      proj_weight,
+      proj_bias,
+      mask,
+      false /* need_weights */,
+      true /* average_attn_weights */,
+      mask_type));
+
   x.add_(src);
   if (!norm_first) {
     x = norm(x, embed_dim, layer_norm_eps, layer_norm_weight_1, layer_norm_bias_1, use_nested_tensor);

--- a/aten/src/ATen/native/transformers/transformer.cpp
+++ b/aten/src/ATen/native/transformers/transformer.cpp
@@ -95,38 +95,21 @@ Tensor transformer_encoder_layer_forward(
   if (norm_first) {
     x = norm(x, embed_dim, layer_norm_eps, layer_norm_weight_1, layer_norm_bias_1, use_nested_tensor);
   }
-#if BETTER_TRANSFORMER_USE_FLASH_ATTENTION
-  if (x.is_nested() && x.is_cuda() && x.dtype() == at::kHalf && !mask.has_value() &&
-      (embed_dim / num_heads == 16 ||
-       embed_dim / num_heads == 32 ||
-       embed_dim / num_heads == 64 ||
-       embed_dim / num_heads == 128)) {
-     TORCH_WARN_ONCE("transformer_encoder_layer_forward is using flash attention.");
-     x = at::linear(x, qkv_weight, qkv_bias);
-     auto x_size_0 = x.size(0);
-     x = x.view({x_size_0, -1, 3, num_heads, embed_dim / num_heads});
-     x = flash_attention_helper(x, x, x, 0.0, false, false);
-     x = x.view({x_size_0, -1, embed_dim});
-     x = at::linear(x, proj_weight, proj_bias);
-  } else {
-#endif
-     x = std::get<0>(at::_native_multi_head_attention(
-         x,
-         x,
-         x,
-         embed_dim,
-         num_heads,
-         qkv_weight,
-         qkv_bias,
-         proj_weight,
-         proj_bias,
-         mask,
-         false /* need_weights */,
-         true /* average_attn_weights */,
-         mask_type));
-#if BETTER_TRANSFORMER_USE_FLASH_ATTENTION
-  }
-#endif
+  x = std::get<0>(at::_native_multi_head_attention(
+      x,
+      x,
+      x,
+      embed_dim,
+      num_heads,
+      qkv_weight,
+      qkv_bias,
+      proj_weight,
+      proj_bias,
+      mask,
+      false /* need_weights */,
+      true /* average_attn_weights */,
+      mask_type));
+
   x.add_(src);
   if (!norm_first) {
     x = norm(x, embed_dim, layer_norm_eps, layer_norm_weight_1, layer_norm_bias_1, use_nested_tensor);

--- a/aten/src/ATen/native/transformers/transformer.cpp
+++ b/aten/src/ATen/native/transformers/transformer.cpp
@@ -127,25 +127,11 @@ Tensor transformer_encoder_layer_forward(
 #if BETTER_TRANSFORMER_USE_FLASH_ATTENTION
   }
 #endif
-  x = std::get<0>(at::_native_multi_head_attention(
-      x,
-      x,
-      x,
-      embed_dim,
-      num_heads,
-      qkv_weight,
-      qkv_bias,
-      proj_weight,
-      proj_bias,
-      mask,
-      false /* need_weights */,
-      true /* average_attn_weights */,
-      mask_type));
-
   x.add_(src);
   if (!norm_first) {
     x = norm(x, embed_dim, layer_norm_eps, layer_norm_weight_1, layer_norm_bias_1, use_nested_tensor);
   }
+
 
   auto pre_ffn_res = x;
 

--- a/benchmarks/transformer/better_transformer_vs_mha_functional.py
+++ b/benchmarks/transformer/better_transformer_vs_mha_functional.py
@@ -1,0 +1,195 @@
+"""
+Tests the performance of torch.nn.MultiheadAttention's fast path (BetterTransformer)
+vs the slow path (torch.nn.functional.multi_head_attention)
+
+To run this script install these dependencies:
+
+pip install tqdm
+pip install prettytable
+"""
+
+import torch
+import random
+import numpy as np
+from pprint import pprint
+import itertools
+import json
+import argparse
+from pathlib import Path
+from typing import Optional
+
+from prettytable import PrettyTable
+from collections import defaultdict, OrderedDict
+from tqdm import tqdm
+
+
+import warnings
+
+warnings.filterwarnings("ignore")
+
+error_dict = defaultdict(int)
+
+
+def benchmark_torch_function(iters, f, *args, **kwargs):
+    f(*args, **kwargs)
+    f(*args, **kwargs)
+    torch.cuda.synchronize()
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    start_event.record()
+    for _ in range(iters):
+        f(*args, **kwargs)
+    end_event.record()
+    torch.cuda.synchronize()
+    # elapsed_time has a resolution of 0.5 microseconds:
+    # but returns milliseconds, so we need to multiply it to increase resolution
+    return start_event.elapsed_time(end_event) * 1000 / iters, *f(*args, **kwargs)
+
+
+def run(a: int, b: int, iters: int, batch_size: int, sequence_length: int,
+        embed_dim: int, num_heads: int, device: str, dtype: str, block_size: int, seed):
+    random.seed(seed)
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+    from scipy.stats import beta
+    lengths = beta.rvs(a, b, size=batch_size) * (sequence_length + block_size - 1) // block_size
+    lengths = list(map(int, list(lengths)))
+    lengths = [l * block_size for l in lengths]
+    lengths = [max(l, block_size) for l in lengths]
+
+    # Used to enforce no padding
+    # lengths = [sequence_length] * batch_size
+
+    # Ensure one row in the batch of ele has the max_sequence_length
+    lengths[random.randint(0, batch_size - 1)] = sequence_length
+
+    q = [torch.randn(l, embed_dim, device=device, dtype=dtype)
+         for l in lengths]
+    q = torch.nested.nested_tensor(q, device=device, dtype=dtype)
+    k, v = q, q
+
+    qkv = torch.nn.Linear(embed_dim, 3 * embed_dim, device=device, dtype=dtype)
+    proj = torch.nn.Linear(embed_dim, embed_dim, device=device, dtype=dtype)
+
+    native_mha = torch.nn.MultiheadAttention(
+        embed_dim, num_heads, batch_first=True, device=device, dtype=dtype
+    ).eval()
+    native_mha.in_proj_weight = qkv.weight
+    native_mha.in_proj_bias = qkv.bias
+    native_mha.out_proj.weight = proj.weight
+    native_mha.out_proj.bias = proj.bias
+
+    # Create query mask
+    q_mask = torch.nested.to_padded_tensor(
+        torch.nested.nested_tensor([
+            torch.tensor([True] * length, dtype=torch.bool)
+            for length in lengths
+        ]), 0)
+    q_mask = q_mask.cuda()
+
+    if q_mask.size(1) == 0:
+        return None
+
+    # Benchmark the native MHA in core
+    with torch.backends.cuda.sdp_kernel(enable_math=False, enable_flash=True):
+        with torch.inference_mode():
+            time_native_mha_fast, y_native_mha_fast, _ = benchmark_torch_function(
+                iters, native_mha, q, k, v, need_weights=False)
+    q = q.to_padded_tensor(0)
+    k = q
+    v = q
+    # Internal Flash Attention
+    time_native_mha_slow, y_native_mha_slow, _ = benchmark_torch_function(
+        iters, native_mha, q, k, v, key_padding_mask=~q_mask, need_weights=False)
+
+    # Convert to padded for comparison
+    if y_native_mha_fast.is_nested:
+        y_native_mha_fast = torch.nested.to_padded_tensor(y_native_mha_fast, 0)
+    y_native_mha_fast = y_native_mha_fast * q_mask.unsqueeze(-1)
+
+    if y_native_mha_slow.is_nested:
+        y_native_mha_slow = torch.nested.to_padded_tensor(y_native_mha_slow, 0)
+    y_native_mha_slow = y_native_mha_slow * q_mask.unsqueeze(-1)
+
+    # Correctness check
+    entry_name = f"batch:{batch_size}_seq_len:{sequence_length}_n_heads:{num_heads}_embed_dim:{embed_dim}"
+    try:
+        torch.testing.assert_close(y_native_mha_fast, y_native_mha_slow, atol=1e-3, rtol=1e-3)
+    except AssertionError as e:
+        error_dict[entry_name] += 1
+        pprint(error_dict)
+
+    # Calculate amount of padding
+    padding = 1 - q_mask.float().mean().item()
+
+    # Calculate the speedup for flash attention
+    speedup_fast_internal = time_native_mha_slow / time_native_mha_fast
+
+    result_entry = OrderedDict()
+    result_entry['dtype'] = dtype
+    result_entry["batch_size"] = batch_size
+    result_entry["sequence_length"] = sequence_length
+    result_entry["n_heads"] = num_heads
+    result_entry["embed_dim"] = embed_dim
+    result_entry["time_native_mha_slow(μs)"] = f"{time_native_mha_slow:.3f}"
+    result_entry["time_native_mha_fast (μs)"] = f"{time_native_mha_fast:.3f}"
+    result_entry["speedup flash_mha v native_mha"] = f"{speedup_fast_internal:.3f}"
+    result_entry["padding"] = f"{padding:.3f}"
+    return result_entry
+
+
+def main(save_path: Optional[Path], error_path: Optional[Path]):
+    table = PrettyTable()
+    entries = defaultdict(list)
+
+    print("CUDA device: ", torch.cuda.get_device_name(0))
+    iters = 100
+    header = None
+    batch_sizes = [16, 32, 64, 128, 256]
+    sequence_lengths = [64, 128, 256, 512]
+    embed_dims = [512, 1024]
+    num_heads_list = [8, 16]
+    betas = range(1, 64, 4)
+
+    for (batch_size, sequence_length, embed_dim, num_heads, block_size, b) in tqdm(
+            list(itertools.product(batch_sizes, sequence_lengths, embed_dims, num_heads_list, [2], betas))):
+        seed = 26214  # Magic number that works well for higher b values
+        entry = run(1, b * 0.05, iters, batch_size, sequence_length,
+                    embed_dim, num_heads, "cuda", torch.float16, block_size, seed)
+        if entry is None:
+            continue
+        if header is None:
+            table.field_names = list(entry.keys())
+            header = list(entry.keys())
+        row = []
+        for k, v in entry.items():
+            row.append(v)
+            entries[k].append(v)
+        table.add_row(row)
+
+    # Print the full table to console
+    print(table)
+    pprint(error_dict)
+
+    csv_string = table.get_csv_string()
+    if save_path is not None:
+        with open(save_path, 'w') as csvfile:
+            csvfile.write(csv_string)
+
+    print(f"Total errors: {sum(error_dict.values())}")
+    if error_path is not None:
+        with open(error_path, 'w') as file:
+            file.write(json.dumps(error_dict))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--save_path", type=str, help="Path to save the results")
+    parser.add_argument("--error_save_path", type=str, help="Path to save the errors")
+
+    args = parser.parse_args()
+    save_path = Path(args.save_path) if args.save_path else None
+    error_path = Path(args.error_save_path) if args.error_save_path else None
+
+    main(save_path, error_path)

--- a/test/test_native_mha.py
+++ b/test/test_native_mha.py
@@ -9,7 +9,7 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     skipMeta,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
 
 class TestMHADeviceType(TestCase):
     @torch.no_grad()
@@ -256,31 +256,56 @@ class TestMHADeviceType(TestCase):
         else:
             self.assertEqual(weight_pt, weight_npt)
 
+    # @dtypesIfCUDA(torch.float, torch.half)
+    # @dtypes(torch.float)
+    # @skipMeta
+    # @torch.no_grad()
+    # def test_native_multihead_self_attention(self, device, dtype):
+    #     for (use_padding, pad_all) in ((False, False), (True, False), (True, True)):
+    #         for use_nt in (False, True):
+    #             # Figuring out exactly which elements of the weights are garbage in this
+    #             # case eludes me, and it's not particularly enlightening to test anyway
+    #             # because padding doesn't especially affect the intermediate weights.
+    #             for need_weights in (False, not pad_all):
+    #                 for average_attn_weights in (False, True):
+    #                     with self.subTest(use_padding=use_padding, pad_all=pad_all,
+    #                                       use_nt=use_nt, need_weights=need_weights,
+    #                                       average_attn_weights=average_attn_weights):
+    #                         self._test_multihead_attention_impl(
+    #                             device,
+    #                             dtype,
+    #                             "self",
+    #                             use_nt=use_nt,
+    #                             use_padding=use_padding,
+    #                             pad_all=pad_all,
+    #                             need_weights=need_weights,
+    #                             average_attn_weights=average_attn_weights,
+    #                         )
+
     @dtypesIfCUDA(torch.float, torch.half)
     @dtypes(torch.float)
     @skipMeta
+    @parametrize("use_nt", [False, True])
+    @parametrize("use_padding, pad_all", [(False, False), (True, False), (True, True)])
+    @parametrize("need_weights", [False])
+    @parametrize("average_attn_weights", [False, True])
     @torch.no_grad()
-    def test_native_multihead_self_attention(self, device, dtype):
-        for (use_padding, pad_all) in ((False, False), (True, False), (True, True)):
-            for use_nt in (False, True):
-                # Figuring out exactly which elements of the weights are garbage in this
-                # case eludes me, and it's not particularly enlightening to test anyway
-                # because padding doesn't especially affect the intermediate weights.
-                for need_weights in (False, not pad_all):
-                    for average_attn_weights in (False, True):
-                        with self.subTest(use_padding=use_padding, pad_all=pad_all,
-                                          use_nt=use_nt, need_weights=need_weights,
-                                          average_attn_weights=average_attn_weights):
-                            self._test_multihead_attention_impl(
-                                device,
-                                dtype,
-                                "self",
-                                use_nt=use_nt,
-                                use_padding=use_padding,
-                                pad_all=pad_all,
-                                need_weights=need_weights,
-                                average_attn_weights=average_attn_weights,
-                            )
+    def test_native_multihead_self_attention(self, device, dtype, use_nt, need_weights, average_attn_weights, use_padding=False, pad_all=False
+                                             ):
+        for need_weights in (False, not pad_all):
+            with self.subTest(use_padding=use_padding, pad_all=pad_all,
+                              use_nt=use_nt, need_weights=need_weights,
+                              average_attn_weights=average_attn_weights):
+                self._test_multihead_attention_impl(
+                    device,
+                    dtype,
+                    "self",
+                    use_nt=use_nt,
+                    use_padding=use_padding,
+                    pad_all=pad_all,
+                    need_weights=need_weights,
+                    average_attn_weights=average_attn_weights,
+                )
 
     @dtypesIfCUDA(torch.float, torch.half)
     @dtypes(torch.float)


### PR DESCRIPTION
# Summary
Use the private _scaled_dot_product_attention to support _native_multiheaded_attention. _SDP provides access to fused kernels when certain conditions are meant enabling a speed up for MHA.

cc @cpuhrsch @jbschlosser @bhosmer @mikaylagawarecki