### PR TITLE
`cuda._is_in_bad_fork`->`_C._cuda_isInBadFork`

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -328,7 +328,7 @@ class TensorVariable(VariableTracker):
                 )
         elif (
             proxy.node.target == torch._C._DisableFuncTorch
-            or proxy.node.target == torch._C._cuda_isInBadFork
+            or proxy.node.target == torch.cuda._is_in_bad_fork
         ):
             from . import UserDefinedObjectVariable
 


### PR DESCRIPTION
Former is always available, while later is only available if PyTorch compiled with CUDA And if it does, then
```
$ python -c "import torch;print(torch._C._cuda_isInBadFork == torch.cuda._is_in_bad_fork)"
True
```

Fixes https://github.com/pytorch/torchdynamo/issues/1709 ( at least the symptom)



cc @jansel @lezcano @fdrocha