### PR TITLE
[ao] Fixing tests for block pruning shapes

### DIFF
--- a/test/ao/sparsity/test_sparsifier.py
+++ b/test/ao/sparsity/test_sparsifier.py
@@ -18,14 +18,16 @@ class Model(nn.Module):
     def __init__(self):
         super().__init__()
         self.seq = nn.Sequential(
-            nn.Linear(16, 16)
+            nn.Linear(37, 39)
         )
-        self.linear = nn.Linear(16, 16)
-        self.head = nn.Linear(16, 4)
+        self.linear = nn.Linear(39, 33)
+        self.head = nn.Linear(33, 13)
 
     def forward(self, x):
         x = self.seq(x)
+        x = torch.relu(x)
         x = self.linear(x)
+        x = torch.relu(x)
         x = self.head(x)
         return x
 

--- a/torch/ao/pruning/sparsifier/weight_norm_sparsifier.py
+++ b/torch/ao/pruning/sparsifier/weight_norm_sparsifier.py
@@ -99,7 +99,7 @@ class WeightNormSparsifier(BaseSparsifier):
         dw = (block_w - w % block_w) % block_w
 
         if mask is None:
-            mask = torch.ones(h+dh, w+dw, device=data.device)
+            mask = torch.ones(h + dh, w + dw, device=data.device)
 
         if sparsity_level >= 1.0:
             mask.data = torch.zeros_like(mask)
@@ -148,7 +148,7 @@ class WeightNormSparsifier(BaseSparsifier):
         values_per_block = reduce((lambda x, y: x * y), sparse_block_shape)
 
         if mask is None:
-            mask = torch.ones((h+dh, w+dw), device=data.device)
+            mask = torch.ones((h + dh, w + dw), device=data.device)
 
         if values_per_block == zeros_per_block:
             # Everything should be sparsified

--- a/torch/ao/pruning/sparsifier/weight_norm_sparsifier.py
+++ b/torch/ao/pruning/sparsifier/weight_norm_sparsifier.py
@@ -99,7 +99,7 @@ class WeightNormSparsifier(BaseSparsifier):
         dw = (block_w - w % block_w) % block_w
 
         if mask is None:
-            mask = torch.ones(h, w, device=data.device)
+            mask = torch.ones(h+dh, w+dw, device=data.device)
 
         if sparsity_level >= 1.0:
             mask.data = torch.zeros_like(mask)
@@ -141,13 +141,14 @@ class WeightNormSparsifier(BaseSparsifier):
 
         In this context the `zeros_per_block` describes the number of zeroed-out elements within a patch.
         """
-        if mask is None:
-            mask = torch.ones(data.shape, device=data.device)
         h, w = data.shape[-2:]
         block_h, block_w = sparse_block_shape
         dh = (block_h - h % block_h) % block_h
         dw = (block_w - w % block_w) % block_w
         values_per_block = reduce((lambda x, y: x * y), sparse_block_shape)
+
+        if mask is None:
+            mask = torch.ones((h+dh, w+dw), device=data.device)
 
         if values_per_block == zeros_per_block:
             # Everything should be sparsified
@@ -168,7 +169,7 @@ class WeightNormSparsifier(BaseSparsifier):
             dim=1, indices=sorted_idx, output_shape=padded_data.shape, block_shape=sparse_block_shape, mask=mask_reshape
         )
 
-        mask.data = mask_reshape.squeeze().reshape(mask.shape)[:h, :w].contiguous()
+        mask.data = mask_reshape.squeeze().reshape(mask.shape).contiguous()
         return mask
 
     def update_mask(self, module, tensor_name, sparsity_level, sparse_block_shape,


### PR DESCRIPTION
The current unittests were only checking the tensors whose shapes were already multiples of the block size. That caused some hidden bugs to creep in. Specifically, for the shapes that would require padding for the mask/data, the sparsifier would try to apply shape-mismatching tensors onto each other. This caused segfaults as well as silent failures.

This makes minor adjustments to the code to make sure the masks and data shapes are aligned, as well as fixing the tests to catch this.

Test Plan:

```python
python test/test_ao_sparsity.py
```
