### PR TITLE
[Inductor] Convert 0d CPU tensor to scalar during triton codegen

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4055,8 +4055,10 @@ if HAS_CUDA:
                     return [permute, add]
 
             inps = [
-                rand_strided((12, 3, 512, 64), (64, 196608, 768, 1), torch.float32, 'cuda'),
-                rand_strided((), (), torch.int64, 'cpu'),
+                rand_strided(
+                    (12, 3, 512, 64), (64, 196608, 768, 1), torch.float32, "cuda"
+                ),
+                rand_strided((), (), torch.int64, "cpu"),
             ]
             mod = make_fx(Repro().to(device="cuda"))(*inps)
             compiled = compile_fx_inner(mod, inps)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3802,7 +3802,6 @@ class CommonTemplate:
         self.common(forward, args)
 
     @requires_cuda()
-    @patch.object(config.triton, "cudagraphs", False)
     def test_unspec_inputs(self):
         def fn(x, y):
             return x + y, x * y, x / y
@@ -3818,7 +3817,6 @@ class CommonTemplate:
         self.assertTrue(same(opt(*inputs), fn(*inputs)))
 
     @requires_cuda()
-    @patch.object(config.triton, "cudagraphs", False)
     def test_unspec_inputs_fp16(self):
         def fn(x, y):
             return x + y, x * y, x / y

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3817,22 +3817,6 @@ class CommonTemplate:
         inputs = (inputs[1], inputs[0])
         self.assertTrue(same(opt(*inputs), fn(*inputs)))
 
-    @requires_cuda()
-    @patch.object(config.triton, "cudagraphs", True)
-    def test_unspec_inputs_cudagraphs(self):
-        def fn(x, y):
-            return x + y, x * y, x / y
-
-        opt = torch._dynamo.optimize("inductor")(fn)
-
-        inputs = (
-            rand_strided((2, 3), (3, 1), device="cuda"),
-            rand_strided((), (), device="cpu"),
-        )
-        self.assertTrue(same(opt(*inputs), fn(*inputs)))
-        inputs = (inputs[1], inputs[0])
-        self.assertTrue(same(opt(*inputs), fn(*inputs)))
-
     @patch.object(config.triton, "mm", "aten")
     def test_list_clearing(self):
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3817,6 +3817,22 @@ class CommonTemplate:
         inputs = (inputs[1], inputs[0])
         self.assertTrue(same(opt(*inputs), fn(*inputs)))
 
+    @requires_cuda()
+    @patch.object(config.triton, "cudagraphs", False)
+    def test_unspec_inputs_fp16(self):
+        def fn(x, y):
+            return x + y, x * y, x / y
+
+        opt = torch._dynamo.optimize("inductor")(fn)
+
+        inputs = (
+            rand_strided((2, 3), (3, 1), dtype=torch.float16, device="cuda"),
+            rand_strided((), (), dtype=torch.float16, device="cpu"),
+        )
+        self.assertTrue(same(opt(*inputs), fn(*inputs)))
+        inputs = (inputs[1], inputs[0])
+        self.assertTrue(same(opt(*inputs), fn(*inputs)))
+
     @patch.object(config.triton, "mm", "aten")
     def test_list_clearing(self):
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -43,6 +43,7 @@ def signature_of(arg):
     if isinstance(arg, TensorArg):
         tye = JITFunction._type_of(arg.dtype)
         if V.graph.is_unspec_arg(arg.buffer):
+            # had unwrapped 0d tensor as scalar
             new_tye = tye.lstrip("*")
             if new_tye in ["fp16", "bf16"]:
                 return "fp32"

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -79,10 +79,6 @@ def complex_memory_overlap(t):
     return False
 
 
-def is_unspec_input(t):
-    return t.device.type == "cpu" and t.dim() == 0
-
-
 @functools.lru_cache(None)
 def _step_logger():
     return dynamo_logging.get_step_logger(log)
@@ -187,11 +183,7 @@ def align_inputs(model, inputs, static_input_idxs=()):
         for i in check_inputs:
             if new_inputs[i].data_ptr() % ALIGNMENT:
                 new_inputs[i] = clone_preserve_strides(new_inputs[i])
-        new_inputs_to_cuda = [
-            x.to("cuda") if is_unspec_input(x) else x for x in new_inputs
-        ]
-        new_inputs.clear()
-        return model(new_inputs_to_cuda)
+        return model(new_inputs)
 
     return run
 
@@ -247,9 +239,6 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
         return torch.as_strided(buffer, x.size(), x.stride())
 
     assert isinstance(inputs, (list, tuple))
-    # dynamo wraps unspec variable as 0 dim tensor on CPU, need to move to GPU explicitly
-    inputs = [x.to("cuda") if is_unspec_input(x) else x for x in inputs]
-
     static_inputs = [
         static_input(x) if idx not in static_input_idxs else x.detach()
         for idx, x in enumerate(inputs)


### PR DESCRIPTION
This is a follow up to address [this](https://github.com/pytorch/torchdynamo/pull/1284#pullrequestreview-1130319129). We revised to use the codegen approach to handle 0d CPU tensor, which will not support cudagraph any more.


cc @jansel @lezcano @fdrocha @mlazos @soumith @voznesenskym