### PR TITLE
[dont-land][dynamo][fsdp] reset flat params during dynamo bytecode tracing

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -86,13 +86,12 @@ def cleanup_module(nn_module):
 
     # very bad hack to mutate the original module back to have register_parameters
 
-    if hasattr(nn_module, "is_flat_param"):
-        for attr_name in dir(nn_module):
-            attr = getattr(nn_module, attr_name)
-            if isinstance(attr, torch.Tensor):
-                copy_tensor = copy.deepcopy(attr.clone().detach())
-                delattr(nn_module, attr_name)
-                nn_module.register_buffer(attr_name, copy_tensor)
+    for attr_name in dir(nn_module):
+        attr = getattr(nn_module, attr_name)
+        if isinstance(attr, torch.Tensor):
+            copy_tensor = copy.deepcopy(attr.clone().detach())
+            delattr(nn_module, attr_name)
+            setattr(nn_module, attr_name, torch.nn.Parameter(copy_tensor))
     return nn_module
 
 

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1148,7 +1148,6 @@ class FlatParamHandle:
                 module.register_parameter(param_name, nn.Parameter(view))
             else:
                 setattr(module, param_name, view)
-                setattr(module, "is_flat_param", True)
         for i, (
             param_name,
             module,

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1148,6 +1148,7 @@ class FlatParamHandle:
                 module.register_parameter(param_name, nn.Parameter(view))
             else:
                 setattr(module, param_name, view)
+                setattr(module, "is_flat_param", True)
         for i, (
             param_name,
             module,


### PR DESCRIPTION
cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire @jansel @lezcano @fdrocha @wconstab this should unblock for the flat params error

as title, this is hack and not suitable for landing.