### PR TITLE
Skip fsdp forward in dynamo

### DIFF
--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -130,6 +130,7 @@ def _allowed_function_ids():
             "torch._inductor.",
             "torch._C.inductor.",
             "torch.fx.",
+            "torch.distributed.fsdp."
         )
         allowed_modules_dot = tuple([x + "." for x in allowed_modules])
         module = inspect.getmodule(obj)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -94,6 +94,7 @@ from .wrap import (
     _recursive_wrap,
     _wrap_batchnorm_individually,
 )
+import torchdynamo
 
 _TORCHDISTX_AVAIL = True
 try:


### PR DESCRIPTION
WIP

this might be worth landing, but we are still experimenting with fsdp so it's possible we do this a different way

(oh and i need to import torchdynamo the new way.. but my scripts still use the old way..)

cc @jansel @lezcano @fdrocha