### PR TITLE
[BE] Skip binary smoke tests in PR

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -90,7 +90,6 @@ LINUX_BINARY_BUILD_WORFKLOWS = [
         build_configs=generate_binary_build_matrix.generate_wheels_matrix(OperatingSystem.LINUX),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -99,7 +98,6 @@ LINUX_BINARY_BUILD_WORFKLOWS = [
         build_configs=generate_binary_build_matrix.generate_conda_matrix(OperatingSystem.LINUX),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_CONDA},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -111,7 +109,6 @@ LINUX_BINARY_BUILD_WORFKLOWS = [
         ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -123,7 +120,6 @@ LINUX_BINARY_BUILD_WORFKLOWS = [
         ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
-            isolated_workflow=True,
         ),
     ),
 ]
@@ -169,7 +165,6 @@ WINDOWS_BINARY_BUILD_WORKFLOWS = [
         build_configs=generate_binary_build_matrix.generate_wheels_matrix(OperatingSystem.WINDOWS),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -178,7 +173,6 @@ WINDOWS_BINARY_BUILD_WORKFLOWS = [
         build_configs=generate_binary_build_matrix.generate_conda_matrix(OperatingSystem.WINDOWS),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_CONDA},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -190,7 +184,6 @@ WINDOWS_BINARY_BUILD_WORKFLOWS = [
         ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -202,7 +195,6 @@ WINDOWS_BINARY_BUILD_WORKFLOWS = [
         ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
-            isolated_workflow=True,
         ),
     ),
 ]
@@ -238,7 +230,6 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
         build_configs=generate_binary_build_matrix.generate_wheels_matrix(OperatingSystem.MACOS),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -247,7 +238,6 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
         build_configs=generate_binary_build_matrix.generate_conda_matrix(OperatingSystem.MACOS),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_CONDA},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -259,7 +249,6 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
         ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -271,7 +260,6 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
         ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -281,7 +269,6 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
         cross_compile_arm64=True,
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
-            isolated_workflow=True,
         ),
     ),
     BinaryBuildWorkflow(
@@ -291,7 +278,6 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
         build_configs=generate_binary_build_matrix.generate_conda_matrix(OperatingSystem.MACOS_ARM64),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_CONDA},
-            isolated_workflow=True,
         ),
     ),
 ]

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -29,7 +29,7 @@ class CIFlowConfig:
     run_on_canary: bool = False
     labels: Set[str] = field(default_factory=set)
     # Certain jobs might not want to be part of the ciflow/[all,trunk] workflow
-    isolated_workflow: bool = False
+    isolated_workflow: bool = True
 
     def __post_init__(self) -> None:
         if not self.isolated_workflow:

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-master.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-master.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - 'ciflow/trunk/*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-master.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-master.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - 'ciflow/trunk/*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-linux-binary-manywheel-master.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-master.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - 'ciflow/trunk/*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - 'ciflow/trunk/*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/generated-windows-binary-libtorch-release-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-master.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - 'ciflow/trunk/*'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
My thought behind this:

* We now have land check `ciflow/trunk` for every PR and the smoke test `
linux-binary-manywheel` is the job with the longest duration at the moment (2.6h at p90 on https://hud.pytorch.org/metrics). This is a long pole TTS
* Looking at the Rockset data, I count only [28 cases](https://paste.sh/yYj8d-P-#eAQfPOR9jIS2unEbVk8PV8UK) in which the `linux-binary-manywheel` failed while `trunk` succeeded.  These binary build failures were flaky or cancelled or were old (CUDA 10.2). It means that trunk signals can safely cover binary smoke test signals, making the latter redundant in PR
  * Windows binary smoke tests [windows-binary-libtorch-release](https://paste.sh/s0KnWuSg#IHWqKNyVXbaIfZSUZsjcg8EZ) and [windows-binary-libtorch-debug](https://paste.sh/DQixwftN#pmMP87ObFoRFrBZB-_ZElso-) have even less failures.  All were flaky 
* We are already running exactly the same step in trunk. AFAIK, it's very rare to have a PR reverted solely because of breaking binary builds.  Normally, other signals come first like breaking tests or land race

So, it makes sense to skip this relatively slow step and run it only in trunk. Also here is the Rockset query for reference. It query all the occurrences (ciflow/trunk) where `linux-binary-manywheel` failed while `trunk` succeeded, thus `linux-binary-manywheel` could block merge.

```
WITH
binary_builds AS (
    SELECT
        workflow_run.head_branch,
        workflow_run.conclusion,
        workflow_run.head_sha,
        workflow_run.html_url
    FROM
        commons.workflow_run
    WHERE
        workflow_run.head_branch LIKE 'ciflow/trunk/%'
        AND workflow_run.name = 'linux-binary-manywheel'
        AND workflow_run.conclusion != 'null'
        AND workflow_run.conclusion != 'cancelled'
      GROUP BY
          workflow_run.conclusion,
          workflow_run.head_branch,
          workflow_run.head_sha,
          workflow_run.html_url
),
trunk_builds AS (
    SELECT
        workflow_run.head_branch,
        workflow_run.conclusion,
        workflow_run.head_sha,
        workflow_run.html_url
    FROM
        commons.workflow_run
    WHERE
        workflow_run.head_branch LIKE 'ciflow/trunk/%'
        AND workflow_run.name = 'trunk'
        AND workflow_run.conclusion != 'null'
        AND workflow_run.conclusion != 'cancelled'
    GROUP BY
        workflow_run.conclusion,
        workflow_run.head_branch,
        workflow_run.head_sha,
        workflow_run.html_url
)
SELECT
    binary_builds.head_branch,
    binary_builds.head_sha,
    binary_builds.conclusion AS binary_builds_conclusion,
    trunk_builds.conclusion AS trunk_builds_conclusion,
    binary_builds.html_url AS binary_builds_html_url,
    trunk_builds.html_url AS trunk_builds_html_url
FROM
    binary_builds
    LEFT JOIN trunk_builds ON binary_builds.head_sha = trunk_builds.head_sha AND binary_builds.head_branch = trunk_builds.head_branch
WHERE
    binary_builds.conclusion != 'success'
    AND trunk_builds.conclusion = 'success'
ORDER BY
    binary_builds.head_branch DESC
```
