### PR TITLE
Slowly introduce ops to be tested by test_numpy_ref on MPS backend

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -18,9 +18,10 @@ import itertools
 from collections import defaultdict
 from torch._six import inf
 from torch.nn import Parameter
+from torch.testing._internal import opinfo
 from torch.testing._internal.common_utils import \
-    (gradcheck, gradgradcheck, run_tests, TestCase, download_file,
-     TEST_WITH_UBSAN, dtype_abbrs)
+    (gradcheck, gradgradcheck, run_tests, TestCase, download_file, IS_CI,
+     TEST_WITH_UBSAN, dtype_abbrs, skipIfSlowGradcheckEnv, TEST_WITH_ASAN, suppress_warnings)
 from torch.testing import make_tensor
 from torch.testing._comparison import TensorLikePair
 from torch.testing._internal.common_dtype import get_all_dtypes, integral_types
@@ -28,12 +29,30 @@ import torch.backends.mps
 from torch.distributions import Uniform, Exponential
 from functools import partial
 
-from torch.testing._internal.common_methods_invocations import op_db
-from torch.testing._internal.common_device_type import ops, instantiate_device_type_tests
+from torch.testing._internal.common_methods_invocations import (
+    op_db,
+    UnaryUfuncInfo,
+    ReductionOpInfo,
+    SpectralFuncInfo,
+    BinaryUfuncInfo,
+)
+from torch.testing._internal.common_device_type import ops, instantiate_device_type_tests, onlyMPS
 from torch.testing._internal.common_nn import NNTestCase
 import numpy as np
 import torch
 import torch.utils._pytree as pytree
+
+
+# Copied from `test_ops.py` for the purposes of duplicating `test_numpy_ref`
+_ref_test_ops = tuple(
+    filter(
+        lambda op: not isinstance(
+            op, (UnaryUfuncInfo, ReductionOpInfo, SpectralFuncInfo, BinaryUfuncInfo)
+        )
+        and op.ref is not None,
+        op_db,
+    )
+)
 
 # Same logic as test_cuda.py
 if not torch.backends.mps.is_available():
@@ -7811,10 +7830,56 @@ class TestConsistency(TestCase):
             # So each test append to the dict and write it.
             with open("new_mps_allowlist_grad.txt", "w") as f:
                 pprint.pprint(self.NEW_ALLOW_LIST_GRAD, stream=f)
+
+
+# Copied from `TestCommon` in `test_ops.py`, just enough to duplicate the `test_numpy_ref` for MPS
+@skipIfSlowGradcheckEnv
+class TestCommon(TestCase):
+    exact_dtype = True
+
+    # Verifies, on teardown, that no OpInfo is still using dynamic dtypes in CI
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+        if IS_CI:
+            err_msg = (
+                "The operator(s) below is(are) using dynamic_dtypes in the OpInfo entries."
+                "This is OK for testing, but be sure to set the dtypes manually before landing your PR!"
+            )
+            # Assure no opinfo entry has dynamic_dtypes
+            filtered_ops = list(filter(opinfo.utils.is_dynamic_dtype_set, op_db))
+            for op in filtered_ops:
+                fmt_str = opinfo.utils.str_format_dynamic_dtype(op)
+                err_msg += "\n" + fmt_str
+
+            assert len(filtered_ops) == 0, err_msg
+
+    # This is the MPS equivalent of `test_numpy_ref` from `test_ops.py`. It lives over here while
+    # MPS still requires some fairly heavy special casing in the test framework.
+    # When MPS becomes more consistent, this can probably be merged with that test using
+    # `@dtypesIfMPS(torch.float32)`, but for now, the assertions themselves need to be loosened
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
+    @onlyMPS
+    @suppress_warnings
+    # MPS only supports float32
+    @ops(_ref_test_ops, allowed_dtypes=(torch.float32,))
+    def test_numpy_ref_mps(self, device, dtype, op):
+        # Unlike above, this test compares in `float32` since at the time of this test's creation MPS does
+        # not support float64 Tensors.
+        # A few ops are currently broken on their reference inputs, but not their sample inputs. These should
+        # get patched up and this workaround removed.
+        broken_on_ref_inputs = op.name in ['cat', 'clamp', 'where']
+        inputs = op.reference_inputs(device, dtype) if not broken_on_ref_inputs else op.sample_inputs(device, dtype)
+        for sample_input in inputs:
+            self.compare_with_reference(op, op.ref, sample_input)
+
 # TODO: Actually instantiate that test for the "mps" device to better reflect what it is doing.
 # This requires mps to be properly registered in the device generic test framework which is not the
-# case right now.
+# case right now. We can probably use `allow_mps` introduced in https://github.com/pytorch/pytorch/pull/87342
+# to achieve this.
 instantiate_device_type_tests(TestConsistency, globals(), only_for="cpu")
+instantiate_device_type_tests(TestCommon, globals(), allow_mps=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7865,8 +7865,8 @@ class TestCommon(TestCase):
     # MPS only supports float32
     @ops(_ref_test_ops, allowed_dtypes=(torch.float32,))
     def test_numpy_ref_mps(self, device, dtype, op):
-        # Unlike above, this test compares in `float32` since at the time of this test's creation MPS does
-        # not support float64 Tensors.
+        # Unlike `test_numpy_ref`, this test compares in `float32` since at the time of this test's creation MPS
+        # does not support float64 Tensors.
         # A few ops are currently broken on their reference inputs, but not their sample inputs. These should
         # get patched up and this workaround removed.
         broken_on_ref_inputs = op.name in ['cat', 'clamp', 'where']

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -192,7 +192,10 @@ class TestCommon(TestCase):
             # Sets the default dtype to NumPy's default dtype of double
             cur_default = torch.get_default_dtype()
             torch.set_default_dtype(torch.double)
-            for sample_input in op.reference_inputs(device, dtype):
+            # TODO: This currently uses `sample_inputs` instead of `reference_inputs` because almost all of
+            # `reference_inputs` fails on MPS since many of them test handling of tensors of different fp types
+            # which MPS does not yet handle.
+            for sample_input in op.sample_inputs(device, dtype):
                 self.compare_with_reference(
                     op, op.ref, sample_input, exact_dtype=(dtype is not torch.long)
                 )

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -207,7 +207,7 @@ class TestCommon(TestCase):
             torch.set_default_dtype(torch.double)
             # A few ops are currently broken on their reference inputs, but not their sample inputs. These should
             # get patched up and this workaround removed.
-            broken_on_ref_inputs = op.name in ['cat', 'clamp', 'clone', 'where']
+            broken_on_ref_inputs = op.name in ['cat', 'clamp', 'where']
             inputs = op.reference_inputs(device, dtype) if not broken_on_ref_inputs else op.sample_inputs(device, dtype)
             for sample_input in inputs:
                 self.compare_with_reference(

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -98,11 +98,24 @@ _ref_test_ops = tuple(
         op_db,
     )
 )
+_ops_failing_on_mps = [
+    'addbmm',
+    'linalg.cross',
+    'linalg.tensorinv',
+    'linalg.tensorsolve',
+    'linalg.vander',
+    'linalg.vecdot',
+    'native_layer_norm',
+    'nn.functional.conv_transpose2d',
+    'nn.functional.gelu',
+    'nn.functional.layer_norm',
+    'nn.functional.pdist',
+    'searchsorted'
+]
 # This list specifies the ops that should be tested by `test_numpy_ref_mps`. Currently a large chunk of
 # `op_db`'s tests fail, but as MPS is brought in line with numpy, this list should expand.
-_ops_passing_on_mps = ['where']
 _ref_test_ops_passing_on_mps = tuple(
-    filter(lambda op: op.name in _ops_passing_on_mps, _ref_test_ops)
+    filter(lambda op: op.name not in _ops_failing_on_mps, _ref_test_ops)
 )
 _ops_and_refs = op_db + python_ref_db
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -182,20 +182,14 @@ class TestCommon(TestCase):
     # MPS only supports float32
     @ops(_ref_test_ops, allowed_dtypes=(torch.float32,))
     def test_numpy_ref_mps(self, device, dtype, op):
-        try:
-            # Sets the default dtype to NumPy's default dtype of double
-            cur_default = torch.get_default_dtype()
-            torch.set_default_dtype(torch.double)
-            # A few ops are currently broken on their reference inputs, but not their sample inputs. These should
-            # get patched up and this workaround removed.
-            broken_on_ref_inputs = op.name in ['cat', 'clamp', 'where']
-            inputs = op.reference_inputs(device, dtype) if not broken_on_ref_inputs else op.sample_inputs(device, dtype)
-            for sample_input in inputs:
-                self.compare_with_reference(
-                    op, op.ref, sample_input, exact_dtype=(dtype is not torch.long)
-                )
-        finally:
-            torch.set_default_dtype(cur_default)
+        # Unlike above, this test compares in `float32` since at the time of this test's creation MPS does
+        # not support float64 Tensors.
+        # A few ops are currently broken on their reference inputs, but not their sample inputs. These should
+        # get patched up and this workaround removed.
+        broken_on_ref_inputs = op.name in ['cat', 'clamp', 'where']
+        inputs = op.reference_inputs(device, dtype) if not broken_on_ref_inputs else op.sample_inputs(device, dtype)
+        for sample_input in inputs:
+            self.compare_with_reference(op, op.ref, sample_input)
 
     # Tests that the cpu and gpu results are consistent
     @onlyCUDA

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -98,22 +98,6 @@ _ref_test_ops = tuple(
         op_db,
     )
 )
-# This list specifies the ops that should be skipped by `test_numpy_ref_mps`. Currently a large chunk of
-# `op_db`'s tests fail, but as MPS is brought in line with numpy, this list should disappear.
-_ops_failing_on_mps = [
-    'addbmm',
-    'linalg.cross',
-    'linalg.tensorinv',
-    'linalg.tensorsolve',
-    'linalg.vander',
-    'linalg.vecdot',
-    'native_layer_norm',
-    'nn.functional.conv_transpose2d',
-    'nn.functional.gelu',
-    'nn.functional.layer_norm',
-    'nn.functional.pdist',
-    'searchsorted'
-]
 _ops_and_refs = op_db + python_ref_db
 
 # Create a list of operators that are a subset of _ref_test_ops but don't have a
@@ -198,9 +182,6 @@ class TestCommon(TestCase):
     # MPS only supports float32
     @ops(_ref_test_ops, allowed_dtypes=(torch.float32,))
     def test_numpy_ref_mps(self, device, dtype, op):
-        if op.name in _ops_failing_on_mps:
-            raise unittest.SkipTest("Unsupported or fails on MPS")
-
         try:
             # Sets the default dtype to NumPy's default dtype of double
             cur_default = torch.get_default_dtype()

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -10,6 +10,7 @@ from typing import List, Any, ClassVar, Optional, Sequence, Tuple, Union, Dict, 
 import unittest
 import os
 import torch
+import torch.backends.mps
 from torch.testing._internal.common_utils import TestCase, TEST_WITH_ROCM, TEST_MKL, \
     skipCUDANonDefaultStreamIf, TEST_WITH_ASAN, TEST_WITH_UBSAN, TEST_WITH_TSAN, \
     IS_SANDCASTLE, IS_FBCODE, IS_REMOTE_GPU, IS_WINDOWS, \
@@ -198,6 +199,8 @@ except ImportError:
 #         Skips the test if the device is not a CPU device
 #     - @onlyCUDA
 #         Skips the test if the device is not a CUDA device
+#     - @onlyMPS
+#         Skips the test if the device is not a MPS device
 #     - @skipCPUIfNoLapack
 #         Skips the test if the device is a CPU device and LAPACK is not installed
 #     - @skipCPUIfNoMkl
@@ -590,7 +593,7 @@ PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY = 'PYTORCH_TESTING_DEVICE_EXCEPT_FOR'
 # The tests in these test cases are derived from the generic tests in
 # generic_test_class.
 # See note "Generic Device Type Testing."
-def instantiate_device_type_tests(generic_test_class, scope, except_for=None, only_for=None, include_lazy=False):
+def instantiate_device_type_tests(generic_test_class, scope, except_for=None, only_for=None, include_lazy=False, allow_mps=False):
     # Removes the generic test class from its enclosing scope so its tests
     # are not discoverable.
     del scope[generic_test_class.__name__]
@@ -609,9 +612,13 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
     generic_members = set(generic_test_class.__dict__.keys()) - set(empty_class.__dict__.keys())
     generic_tests = [x for x in generic_members if x.startswith('test')]
 
+    # MPS backend support is disabled in `get_device_type_test_bases` while support is being ramped
+    # up, so allow callers to specifically opt tests into being tested on MPS, similar to `include_lazy`
+    test_bases = device_type_test_bases.copy()
+    if allow_mps and torch.backends.mps.is_available() and MPSTestBase not in test_bases:
+        test_bases.append(MPSTestBase)
     # Filter out the device types based on user inputs
-    desired_device_type_test_bases = filter_desired_device_types(device_type_test_bases,
-                                                                 except_for, only_for)
+    desired_device_type_test_bases = filter_desired_device_types(test_bases, except_for, only_for)
     if include_lazy:
         # Note [Lazy Tensor tests in device agnostic testing]
         # Right now, test_view_ops.py runs with LazyTensor.
@@ -1141,6 +1148,10 @@ def onlyCPU(fn):
 
 def onlyCUDA(fn):
     return onlyOn('cuda')(fn)
+
+
+def onlyMPS(fn):
+    return onlyOn('mps')(fn)
 
 
 def disablecuDNN(fn):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8703,6 +8703,7 @@ op_db: List[OpInfo] = [
                # TypeError: _copy_dispatcher() got an unexpected keyword argument 'memory_format'
                # (NumPy reference needs to be extended with memory_format)
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_numpy_ref'),
+               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_numpy_ref_mps'),
            ),),
     OpInfo('contiguous',
            op=lambda x, *args, **kwargs: x.contiguous(*args, **kwargs),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8208,8 +8208,9 @@ op_db: List[OpInfo] = [
                    toleranceOverride({torch.float32: tol(atol=1.3e-05, rtol=1.3e-05),
                                       torch.complex64: tol(atol=1e-05, rtol=1.2e-03)}),
                    'TestCommon', 'test_numpy_refs'),
+               # MPS has slightly worse precision. Is this acceptable?
                DecorateInfo(
-                   toleranceOverride({torch.float32: tol(atol=1.3e-05, rtol=1.3e-05),
+                   toleranceOverride({torch.float32: tol(atol=1.3e-04, rtol=1.3e-04),
                                       torch.complex64: tol(atol=1e-05, rtol=1.2e-03)}),
                    'TestCommon', 'test_numpy_refs_mps'),
                DecorateInfo(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6268,7 +6268,9 @@ def sample_inputs_where(op_info, device, dtype, requires_grad, **kwargs):
              ((M, 1, M), (M, M), (M, M, 1), True),
              ((), (), (), False),
              ((M, 1, M), (), (M, M, 1), True),
-             ((), (M, M), (), True),)
+             ((), (M, M), (), True),
+             (((), (2), (1, 1), True)),
+             )
 
     for shape, mask_shape, other_shape, broadcasts_input in cases:
         yield SampleInput(make_arg(shape),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6269,7 +6269,7 @@ def sample_inputs_where(op_info, device, dtype, requires_grad, **kwargs):
              ((), (), (), False),
              ((M, 1, M), (), (M, M, 1), True),
              ((), (M, M), (), True),
-             (((), (2), (1, 1), True)),
+             ((), (2), (1, 1), True),
              )
 
     for shape, mask_shape, other_shape, broadcasts_input in cases:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6257,7 +6257,7 @@ def sample_inputs_where(op_info, device, dtype, requires_grad, **kwargs):
 
         if mask_t.sum() == 0:
             def random_index(shape):
-                return tuple(map(lambda max_idx: random.randint(0, max_idx), shape))
+                return tuple(map(lambda max_idx: random.randrange(0, max_idx), shape))
 
             mask_t[random_index(mask_t.shape)] = True
             return mask_t

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8212,7 +8212,7 @@ op_db: List[OpInfo] = [
                DecorateInfo(
                    toleranceOverride({torch.float32: tol(atol=1.3e-04, rtol=1.3e-04),
                                       torch.complex64: tol(atol=1e-05, rtol=1.2e-03)}),
-                   'TestCommon', 'test_numpy_refs_mps'),
+                   'TestCommon', 'test_numpy_ref_mps'),
                DecorateInfo(
                    toleranceOverride({torch.float32: tol(atol=1e-5, rtol=1e-5)}),
                    'TestConsistency',

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1094,7 +1094,11 @@ op_db: List[OpInfo] = [
         supports_fwgrad_bwgrad=True,
         supports_forward_ad=True,
         skips=(
-            DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+            DecorateInfo(
+                unittest.skip("Unsupported on MPS for now"),
+                "TestCommon",
+                "test_numpy_ref_mps",
+            ),
         ),
     ),
     OpInfo(
@@ -1214,7 +1218,11 @@ op_db: List[OpInfo] = [
                 "test_schema_correctness",
                 dtypes=(torch.complex64, torch.complex128),
             ),
-            DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+            DecorateInfo(
+                unittest.skip("Unsupported on MPS for now"),
+                "TestCommon",
+                "test_numpy_ref_mps",
+            ),
         ),
     ),
     OpInfo(
@@ -1652,7 +1660,11 @@ op_db: List[OpInfo] = [
         supports_out=False,
         sample_inputs_func=sample_inputs_linalg_vander,
         skips=(
-               DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+            DecorateInfo(
+                unittest.skip("Unsupported on MPS for now"),
+                "TestCommon",
+                "test_numpy_ref_mps",
+            ),
         ),
     ),
     ReductionOpInfo(
@@ -2131,7 +2143,11 @@ op_db: List[OpInfo] = [
         check_batched_forward_grad=False,
         decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoCusolver],
         skips=(
-            DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+            DecorateInfo(
+                unittest.skip("Unsupported on MPS for now"),
+                "TestCommon",
+                "test_numpy_ref_mps",
+            ),
         ),
     ),
     OpInfo(
@@ -2152,7 +2168,11 @@ op_db: List[OpInfo] = [
             ),
         ],
         skips=(
-            DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+            DecorateInfo(
+                unittest.skip("Unsupported on MPS for now"),
+                "TestCommon",
+                "test_numpy_ref_mps",
+            ),
         ),
     ),
 ]

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1093,6 +1093,9 @@ op_db: List[OpInfo] = [
         supports_out=True,
         supports_fwgrad_bwgrad=True,
         supports_forward_ad=True,
+        skips=(
+            DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+        ),
     ),
     OpInfo(
         "linalg.det",
@@ -1211,6 +1214,7 @@ op_db: List[OpInfo] = [
                 "test_schema_correctness",
                 dtypes=(torch.complex64, torch.complex128),
             ),
+            DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
         ),
     ),
     OpInfo(
@@ -1647,6 +1651,9 @@ op_db: List[OpInfo] = [
         supports_fwgrad_bwgrad=True,
         supports_out=False,
         sample_inputs_func=sample_inputs_linalg_vander,
+        skips=(
+               DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+        ),
     ),
     ReductionOpInfo(
         "linalg.vector_norm",
@@ -2123,6 +2130,9 @@ op_db: List[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         decorators=[skipCPUIfNoLapack, skipCUDAIfNoMagmaAndNoCusolver],
+        skips=(
+            DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+        ),
     ),
     OpInfo(
         "linalg.tensorsolve",
@@ -2141,6 +2151,9 @@ op_db: List[OpInfo] = [
                 device_type="cuda",
             ),
         ],
+        skips=(
+            DecorateInfo(unittest.skip("Unsupported on MPS for now"), 'TestCommon', 'test_numpy_ref_mps'),
+        ),
     ),
 ]
 

--- a/torch/testing/_internal/opinfo/definitions/signal.py
+++ b/torch/testing/_internal/opinfo/definitions/signal.py
@@ -292,7 +292,11 @@ op_db: List[OpInfo] = [
         reference_inputs_func=reference_inputs_window,
         error_inputs_func=error_inputs_window,
         skips=(
-            DecorateInfo(unittest.skip("Buggy on MPS for now (mistakenly promotes to float64)"), 'TestCommon', 'test_numpy_ref_mps'),
+            DecorateInfo(
+                unittest.skip("Buggy on MPS for now (mistakenly promotes to float64)"),
+                "TestCommon",
+                "test_numpy_ref_mps",
+            ),
         ),
     ),
     make_signal_windows_opinfo(
@@ -304,7 +308,11 @@ op_db: List[OpInfo] = [
         reference_inputs_func=partial(reference_inputs_exponential_window, tau=2.78),
         error_inputs_func=error_inputs_exponential_window,
         skips=(
-            DecorateInfo(unittest.skip("Buggy on MPS for now (mistakenly promotes to float64)"), 'TestCommon', 'test_numpy_ref_mps'),
+            DecorateInfo(
+                unittest.skip("Buggy on MPS for now (mistakenly promotes to float64)"),
+                "TestCommon",
+                "test_numpy_ref_mps",
+            ),
         ),
     ),
     make_signal_windows_opinfo(
@@ -316,7 +324,11 @@ op_db: List[OpInfo] = [
         reference_inputs_func=partial(reference_inputs_gaussian_window, std=1.92),
         error_inputs_func=error_inputs_gaussian_window,
         skips=(
-            DecorateInfo(unittest.skip("Buggy on MPS for now (mistakenly promotes to float64)"), 'TestCommon', 'test_numpy_ref_mps'),
+            DecorateInfo(
+                unittest.skip("Buggy on MPS for now (mistakenly promotes to float64)"),
+                "TestCommon",
+                "test_numpy_ref_mps",
+            ),
         ),
     ),
 ]

--- a/torch/testing/_internal/opinfo/definitions/signal.py
+++ b/torch/testing/_internal/opinfo/definitions/signal.py
@@ -291,6 +291,9 @@ op_db: List[OpInfo] = [
         sample_inputs_func=sample_inputs_window,
         reference_inputs_func=reference_inputs_window,
         error_inputs_func=error_inputs_window,
+        skips=(
+            DecorateInfo(unittest.skip("Buggy on MPS for now (mistakenly promotes to float64)"), 'TestCommon', 'test_numpy_ref_mps'),
+        ),
     ),
     make_signal_windows_opinfo(
         name="signal.windows.exponential",
@@ -300,6 +303,9 @@ op_db: List[OpInfo] = [
         sample_inputs_func=partial(sample_inputs_window, tau=2.78),
         reference_inputs_func=partial(reference_inputs_exponential_window, tau=2.78),
         error_inputs_func=error_inputs_exponential_window,
+        skips=(
+            DecorateInfo(unittest.skip("Buggy on MPS for now (mistakenly promotes to float64)"), 'TestCommon', 'test_numpy_ref_mps'),
+        ),
     ),
     make_signal_windows_opinfo(
         name="signal.windows.gaussian",
@@ -309,5 +315,8 @@ op_db: List[OpInfo] = [
         sample_inputs_func=partial(sample_inputs_window, std=1.92),
         reference_inputs_func=partial(reference_inputs_gaussian_window, std=1.92),
         error_inputs_func=error_inputs_gaussian_window,
+        skips=(
+            DecorateInfo(unittest.skip("Buggy on MPS for now (mistakenly promotes to float64)"), 'TestCommon', 'test_numpy_ref_mps'),
+        ),
     ),
 ]


### PR DESCRIPTION
Enable a test that would have caught https://github.com/pytorch/pytorch/issues/86239

Prior to the fix for that bug, this test fails with

```
_____________________________ TestCommonMPS.test_numpy_ref_mps_where_mps_float32 _____________________________
Traceback (most recent call last):
  File "/Users/alex/git/pytorch/test/test_ops.py", line 197, in test_numpy_ref_mps
    self.compare_with_reference(
  File "/Users/alex/git/pytorch/torch/testing/_internal/common_utils.py", line 2366, in compare_with_reference
    actual = torch_fn(t_inp, *t_args, **t_kwargs)
  File "/Users/alex/git/pytorch/torch/testing/_internal/opinfo/core.py", line 1068, in __call__
    return self.op(*args, **kwargs)
  File "/Users/alex/git/pytorch/torch/testing/_internal/common_methods_invocations.py", line 15167, in <lambda>
    op=lambda self, condition, other: torch.where(condition, self, other),
RuntimeError: 0'th index 3 of x tensor does not match the other tensors
```