### PR TITLE
use deepcopy for the node.meta(dict) in fx graph node_copy

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1134,7 +1134,7 @@ class Graph:
         assert isinstance(args, tuple)
         assert isinstance(kwargs, dict)
         result_node = self.create_node(node.op, node.target, args, kwargs, node.name, node.type)
-        result_node.meta = copy.copy(node.meta)
+        result_node.meta = copy.deepcopy(node.meta)
         return result_node
 
     @compatibility(is_backward_compatible=True)


### PR DESCRIPTION
In FX Graph's copy, the object in new copied graph nodes' meta are reference to the original graph nodes' meta. So when we make changes to the object in new copied graph nodes' meta, the object in original copied graph nodes' meta will also been changed. Take below case for example:
```
import torch
import torch.nn as nn
from torch.fx import symbolic_trace
import copy

class MyModule(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.linear = torch.nn.Linear(4, 5)

    def forward(self, x):
        x2 = x + x
        return self.linear(x2)

class test_property():
    def __init__(self):
        self.test = True

    def is_test(self):
        return self.test

    def set_test(self, val):
        self.test = val

original_model = symbolic_trace(MyModule())
original_graph = original_model.graph
for node in original_graph.nodes:
    node.meta["test"] = test_property()

print("node.meta[\"test\"] before change the new graph")
for node in original_graph.nodes:
    print(node.meta["test"].is_test())

# new_graph = torch.fx.Graph()
# new_graph.graph_copy(original_graph, val_map={})
new_graph = copy.deepcopy(original_graph)
for node in new_graph.nodes:
    if "test" in node.meta.keys():
        node.meta["test"].set_test(False)

print("node.meta[\"test\"] after change the new graph")
for node in original_graph.nodes:
    if "test" in node.meta.keys():
        print(node.meta["test"].is_test())
```
The output is:
```
node.meta["test"] before change the new graph
True
True
True
True
node.meta["test"] after change the new graph
False
False
False
True
```

However, we think when we do the copy of the original graph into a new graph. The changes made in new graph should not affect original graph.
