### PR TITLE
Enable `src_mask` in fast path of `TransformerEncoderLayer `

### DIFF
--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -191,8 +191,22 @@ void host_softmax(
               output_data_base + outer_idx * outer_stride + inner_idx;
           bool* mask_data = nullptr;
           if (MaskedSoftMax) {
-            mask_data = mask_data_base + outer_idx * outer_stride + inner_idx;
-          }
+            // Process mask differently depending on the type:
+            // For a generic mask of mask_type == 2, mask shape is the same as the input shape,
+            // so indexing is the same.
+            int64_t mask_outer_idx = outer_idx;
+            if (mask_type_ == 0) {
+                // Optimized case: attention mask of shape LxL
+                // outer_idx goes over BxHxL, mask_outer_idx goes over L.
+                mask_outer_idx = outer_idx % (input.size(2));
+            } else if (mask_type_ == 1) {
+                // Optimized case: padding mask of shape BxL
+                // outer_idx goes over BxHxL, mask_outer_idx goes over B.
+                mask_outer_idx = outer_idx / (input.size(1) * input.size(2));
+            };
+
+            mask_data = mask_data_base + mask_outer_idx * outer_stride + inner_idx;
+          };
 
           // Calc max in softmax dim
           bool is_meaningful_max = false;
@@ -574,15 +588,50 @@ Tensor log_softmax(const Tensor& self, Dimname dim, optional<ScalarType> dtype) 
 }
 
 Tensor masked_softmax_cpu(const Tensor& input_, const Tensor& mask_, const c10::optional<int64_t> dim_, const c10::optional<int64_t> mask_type_) {
-  TORCH_CHECK(
-      input_.sizes() == mask_.sizes(), "Mask shape should match input shape");
+
+  auto mask = mask_.contiguous();
+  auto mask_type = mask_type_; // Mask type might get transformed below
+
   TORCH_CHECK(
       mask_.scalar_type() == ScalarType::Bool,
       "Mask should be a boolean tensor");
 
+  if ((mask.dim() != 2) || (input_.dim() != 4)) {
+    // Mask types 0 and 1 are only allowed for 2D masks and 4D inputs
+    mask_type = 2;
+  };
+
+  if (mask_type == 2) {
+      TORCH_CHECK(input_.sizes() == mask_.sizes(),
+                  "For mask_type == 2 mask shape should match input shape")
+  } else if (mask_type == 1) {
+      // Padding mask of shape (B, L)
+      TORCH_CHECK((input_.sizes()[0] == mask.sizes()[0]) && (input_.sizes()[2] == mask.sizes()[1]),
+                  "For mask_type == 1 mask shape should be (B, L)");
+
+      if (dim_ != input_.dim() - 1) {
+            // We only process padding mask in the optimized way if softmax is applied along the last dimesion,
+            // otherwise we need to expand the mask into a generic 4D one
+            mask = mask_.view({input_.sizes()[0], 1, 1, input_.sizes()[2]});
+            mask = at::expand_inplace(input_, mask)->contiguous();
+            mask_type = 2;
+      }
+
+  } else if (mask_type == 0) {
+          // Attention mask of shape (L, L)
+      TORCH_CHECK((mask.dim() == 2) && (input_.sizes()[2] == mask.sizes()[0]) && (input_.sizes()[2] == mask.sizes()[1]),
+                  "For mask_type == 0 mask shape should be (L, L)");
+      if (dim_ != input_.dim() - 1) {
+            // We only process attention mask in a optimized way if softmax is applied along the last dimesion,
+            // otherwise we need to expand the mask into a generic 4D one
+            mask = mask_.view({1, 1, input_.sizes()[2], input_.sizes()[2]});
+            mask = at::expand_inplace(input_, mask)->contiguous();
+            mask_type = 2;
+      }
+  };
+
   Tensor output = at::empty_like(input_, input_.options());
   auto input = input_.contiguous();
-  auto mask = mask_.contiguous();
   int64_t dim = dim_.has_value() ? dim_.value() : input.dim() - 1;
   dim = maybe_wrap_dim(dim, input_.dim());
 
@@ -596,7 +645,7 @@ Tensor masked_softmax_cpu(const Tensor& input_, const Tensor& mask_, const c10::
             scalar_t,
             false /* LogSoftMax */,
             true /* MaskedSoftMax */>(
-            output, input, dim, mask.data_ptr<bool>(), mask_type_);
+            output, input, dim, mask.data_ptr<bool>(), mask_type);
       });
   return output;
 }

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -203,7 +203,7 @@ void host_softmax(
                 // Optimized case: padding mask of shape BxL
                 // outer_idx goes over BxHxL, mask_outer_idx goes over B.
                 mask_outer_idx = outer_idx / (input.size(1) * input.size(2));
-            };
+            }
 
             mask_data = mask_data_base + mask_outer_idx * outer_stride + inner_idx;
           };

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -626,7 +626,7 @@ Tensor masked_softmax_cpu(const Tensor& input_, const Tensor& mask_, const c10::
             mask = mask.expand(input_.sizes()).contiguous();
             mask_type = 2;
       }
-  };
+  }
 
   Tensor output = at::empty_like(input_, input_.options());
   auto input = input_.contiguous();

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -194,7 +194,7 @@ void host_softmax(
             // Process mask differently depending on the type:
             // For a generic mask of mask_type == 2, mask shape is the same as the input shape,
             // so indexing is the same.
-            int64_t mask_outer_idx = outer_idx;
+            auto mask_outer_idx = outer_idx;
             if (mask_type_ == 0) {
                 // Optimized case: attention mask of shape LxL
                 // outer_idx goes over BxHxL, mask_outer_idx goes over L.

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -162,9 +162,6 @@ void host_softmax(
     int64_t mask_type = mask_type_.value();
     // If mask_type == 2, then mask_.sizes() must equal input_.sizes()
     TORCH_CHECK((mask_type == 0) || (mask_type == 1) || (mask_type == 2), "Mask Type should be 0 (src_mask) or 1 (src_key_padding_mask), or 2 (default_mask)");
-
-    // TODO: Add support for TxT src_mask
-    TORCH_CHECK(mask_type != 0, "src_mask not currently supported on CPU");
   }
 
   int64_t outer_size = 1;

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -599,7 +599,7 @@ Tensor masked_softmax_cpu(const Tensor& input_, const Tensor& mask_, const c10::
   if ((mask.dim() != 2) || (input_.dim() != 4)) {
     // Mask types 0 and 1 are only allowed for 2D masks and 4D inputs
     mask_type = 2;
-  };
+  }
 
   if (mask_type == 2) {
       TORCH_CHECK(input_.sizes() == mask.sizes(),

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -612,7 +612,7 @@ Tensor masked_softmax_cpu(const Tensor& input_, const Tensor& mask_, const c10::
             // We only process padding mask in the optimized way if softmax is applied along the last dimesion,
             // otherwise we need to expand the mask into a generic 4D one
             mask = mask_.view({input_.sizes()[0], 1, 1, input_.sizes()[2]});
-            mask = at::expand_inplace(input_, mask)->contiguous();
+            mask = mask.expand(input_.sizes()).contiguous();
             mask_type = 2;
       }
   } else if (mask_type == 0) {
@@ -623,7 +623,7 @@ Tensor masked_softmax_cpu(const Tensor& input_, const Tensor& mask_, const c10::
             // We only process attention mask in a optimized way if softmax is applied along the last dimesion,
             // otherwise we need to expand the mask into a generic 4D one
             mask = mask.view({1, 1, input_.sizes()[2], input_.sizes()[2]});
-            mask = at::expand_inplace(input_, mask)->contiguous();
+            mask = mask.expand(input_.sizes()).contiguous();
             mask_type = 2;
       }
   };

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -128,53 +128,6 @@ Tensor masked_softmax(
         "negatively affect performance. Prefer to use a boolean mask directly.");
     attn_mask = attn_mask->to(at::kBool);
   }
-
-  if (attn_scores.is_cpu() && attn_mask) {
-
-    const auto batch_size = attn_scores.sizes()[0];
-    const auto num_heads = attn_scores.sizes()[1];
-    const auto seq_len = attn_scores.sizes()[3];
-
-    TORCH_CHECK((mask_type == 0) || (mask_type == 1) || (mask_type == 2),
-    "Mask Type should be 0 (src_mask) or 1 (src_key_padding_mask), or 2 (default_mask)");
-    if (mask_type == 0) {
-
-      TORCH_CHECK((attn_mask->dim() == 2) || (attn_mask->dim() == 3),
-      "Mask of type 0 (src_mask) should have either 2 dimensions (seq_len, src_len) or 3 dimensions (batch_size * num_heads, seq_len, seq_len)");
-      if (attn_mask->dim() == 2) {
-          TORCH_CHECK(attn_mask->sizes()[0] == seq_len);
-          TORCH_CHECK(attn_mask->sizes()[1] == seq_len);
-          attn_mask = attn_mask->view({1, 1, seq_len, seq_len});
-
-        } else {
-          TORCH_CHECK(attn_mask->sizes()[0] == batch_size * num_heads);
-          TORCH_CHECK(attn_mask->sizes()[1] == seq_len);
-          TORCH_CHECK(attn_mask->sizes()[2] == seq_len);
-          attn_mask = attn_mask->view({batch_size, num_heads, seq_len, seq_len});
-
-        };
-
-    } else if (mask_type == 1) {
-
-      TORCH_CHECK((attn_mask->dim() == 1) || (attn_mask->dim() == 2),
-      "Mask of type 1 (src_key_padding_mask) should have either 1 dimension (seq_len) or 2 dimensions (batch_size, seq_len)");
-      if (attn_mask->dim() == 1) {
-          TORCH_CHECK(attn_mask->sizes()[0] == seq_len);
-          attn_mask = attn_mask->view({1, 1, 1, seq_len});
-        } else if (attn_mask->dim() == 2) {
-          TORCH_CHECK(attn_mask->sizes()[0] == batch_size);
-          TORCH_CHECK(attn_mask->sizes()[1] == seq_len);
-          attn_mask = attn_mask->view({batch_size, 1, 1, seq_len});
-        } else {
-           TORCH_CHECK(false, "Wrong attn_mask dims");
-        }
-
-    };
-
-    attn_mask = at::expand_inplace(attn_scores, *attn_mask)->contiguous();
-
-  }
-
   if (attn_mask) {
     return _masked_softmax(attn_scores, *attn_mask, attn_scores.dim() - 1, mask_type);
   } else {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14951,6 +14951,7 @@ class TestNNDeviceType(NNTestCase):
                     if (self.device_type == "cuda"):
                         input = input.cuda()
                         mask = mask.cuda()
+                        mask_orig = mask_orig.cuda()
                     native_res = torch._masked_softmax(input, mask_orig, dim, mask_type)
                     mask = ~mask
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14928,6 +14928,52 @@ class TestNNDeviceType(NNTestCase):
         s = exp.sum(dim=3, keepdim=True).expand(exp.size())
         return exp / s
 
+    def test_masked_softmax_mask_types_0_1(self, device):
+        # Test that mask type 0 (LxL attention mask) and mask type 1 (BxL padding mask)
+        # are processed correctly on the fast path and the results match explicit slow
+        # calculation.
+        sizes = [(1, 1, 32), (3, 16, 310), (12, 4, 1024), (4, 2, 1200)]
+
+        for (B, num_heads, L) in sizes:
+
+            # mask_type == 0 => attention mask of shape LxL
+            src_mask_orig = torch.randint(0, 2, (L, L)).bool()
+            src_mask = src_mask_orig.reshape(1, 1, L, L).expand(B, num_heads, L, L).bool()
+
+            # mask_type == 1 => padding mask of shape BxL
+            src_key_padding_mask_orig = torch.randint(0, 2, (B, L)).bool()
+            src_key_padding_mask = src_key_padding_mask_orig.reshape(B, 1, 1, L).expand(B, num_heads, L, L).bool()
+
+            masks = [(src_mask_orig, src_mask, 0), (src_key_padding_mask_orig, src_key_padding_mask, 1)]
+            for dim in [0, 3]:
+                for mask_orig, mask, mask_type in masks:
+                    input = torch.randn((B, num_heads, L, L))
+                    if (self.device_type == "cuda"):
+                        input = input.cuda()
+                        mask = mask.cuda()
+                    native_res = torch._masked_softmax(input, mask_orig, dim, mask_type)
+                    mask = ~mask
+
+                    def slow_masked_softmax(input, mask):
+                        exp = torch.exp(input)
+                        exp = exp * mask
+                        s = exp.sum(dim=dim, keepdim=True).expand(exp.size())
+                        return exp / s
+
+                    pt_res = slow_masked_softmax(input, mask)
+                    pt_res = torch.nan_to_num(pt_res)
+
+                    mask_not = mask.logical_not()
+                    # In result, should only fill the entirely masked out rows since those are non-deterministic (*may* be 0)
+                    # Converts rows with all True's to False
+                    mask_out = mask_not.all(dim, keepdim=True).expand(mask_not.shape)
+                    self.assertEqual(
+                        pt_res.masked_fill(mask_out, 0),
+                        native_res.masked_fill(mask_out, 0),
+                        exact_dtype=True
+                    )
+
+
     def test_masked_softmax(self, device):
         sizes = [(1, 1, 32), (3, 16, 310), (12, 4, 1024), (4, 2, 1200)]
         for (B, num_heads, L) in sizes:
@@ -17894,23 +17940,14 @@ class TestNNDeviceType(NNTestCase):
 
         # Batched inputs
         src = torch.rand(32, 10, 512)
-        # Attention mask of shape (batch_size * nhead, src_len, src_len)
-        src_mask = torch.zeros(32 * 8, 10, 10).to(torch.bool)
-        with torch.no_grad():
-            model(src, src_mask=src_mask)
-        # Padding mask of shape (batch_size, src_len)
-        src_key_padding_mask = torch.zeros(32, 10).to(torch.bool)
-        with torch.no_grad():
-            model(src, src_key_padding_mask=src_key_padding_mask)
 
-        # Unbatched inputs
-        src = torch.rand(10, 512)
         # Attention mask of shape (src_len, src_len)
         src_mask = torch.zeros(10, 10).to(torch.bool)
         with torch.no_grad():
             model(src, src_mask=src_mask)
-        # Padding mask of shape (src_len)
-        src_key_padding_mask = torch.zeros(10).to(torch.bool)
+
+        # Padding mask of shape (batch_size, src_len)
+        src_key_padding_mask = torch.zeros(32, 10).to(torch.bool)
         with torch.no_grad():
             model(src, src_key_padding_mask=src_key_padding_mask)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -17890,28 +17890,30 @@ class TestNNDeviceType(NNTestCase):
         Test transformer fast path on CPU with different valid mask types and shapes
         """
         model = torch.nn.TransformerEncoderLayer(d_model=512, nhead=8, batch_first=True, device=device, dtype=dtype)
-        src = torch.rand(32, 10, 512)
         model.eval()
 
-        # Attention mask of shape (seq_len, src_len)
-        src_mask = torch.zeros(10, 10).to(torch.bool)
-        with torch.no_grad():
-            model(src, src_mask=src_mask)
-
+        # Batched inputs
+        src = torch.rand(32, 10, 512)
         # Attention mask of shape (batch_size * nhead, src_len, src_len)
         src_mask = torch.zeros(32 * 8, 10, 10).to(torch.bool)
         with torch.no_grad():
             model(src, src_mask=src_mask)
+        # Padding mask of shape (batch_size, src_len)
+        src_key_padding_mask = torch.zeros(32, 10).to(torch.bool)
+        with torch.no_grad():
+            model(src, src_key_padding_mask=src_key_padding_mask)
 
+        # Unbatched inputs
+        src = torch.rand(10, 512)
+        # Attention mask of shape (src_len, src_len)
+        src_mask = torch.zeros(10, 10).to(torch.bool)
+        with torch.no_grad():
+            model(src, src_mask=src_mask)
         # Padding mask of shape (src_len)
         src_key_padding_mask = torch.zeros(10).to(torch.bool)
         with torch.no_grad():
             model(src, src_key_padding_mask=src_key_padding_mask)
 
-        # Padding mask of shape (batch_size, src_len)
-        src_key_padding_mask = torch.zeros(32, 10).to(torch.bool)
-        with torch.no_grad():
-            model(src, src_key_padding_mask=src_key_padding_mask)
 
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.half, torch.float)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -213,7 +213,7 @@ class TestTransformers(NNTestCase):
         ]
         input_mask_pairs = [
             (
-                torch.tensor(pair[0], device=device, dtype=torch.float32),  # float input
+                torch.tensor(pair[0], device=device, dtype=torch.get_default_dtype()),  # float input
                 torch.tensor(pair[1], device=device, dtype=torch.bool)  # bool mask
             ) for pair in input_mask_pairs
         ]
@@ -266,7 +266,7 @@ class TestTransformers(NNTestCase):
             model = model.train()
         else:
             model = model.eval()
-        x = torch.arange(0, 16).reshape(2, 2, 4).to(torch.float).to(device)
+        x = torch.arange(0, 16).reshape(2, 2, 4).to(torch.get_default_dtype()).to(device)
         src_mask = torch.Tensor([[0, 1], [0, 0]]).to(torch.bool).to(device)
 
         if with_no_grad:

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1093,12 +1093,10 @@ class MultiheadAttention(Module):
             why_not_fast_path = "add_zero_attn was enabled"
         elif not self._qkv_same_embed_dim:
             why_not_fast_path = "_qkv_same_embed_dim was not True"
-        elif attn_mask is not None:
-            why_not_fast_path = "attn_mask was not None"
-        elif query.is_nested and key_padding_mask is not None:
-            why_not_fast_path = "key_padding_mask is not supported with NestedTensor input"
-        elif self.num_heads % 2 == 1:
-            why_not_fast_path = "num_heads is odd"
+        elif query.is_nested and (key_padding_mask is not None or attn_mask is not None):
+            why_not_fast_path = "key_padding_mask and attn_mask are not supported with NestedTensor input"
+        elif not query.is_nested and key_padding_mask is not None and attn_mask is not None:
+            why_not_fast_path = "key_padding_mask and attn_mask were both supplied"
         elif torch.is_autocast_enabled():
             why_not_fast_path = "autocast is enabled"
 

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -466,15 +466,14 @@ class TransformerEncoderLayer(Module):
             why_not_sparsity_fast_path = "activation_relu_or_gelu was not True"
         elif not (self.norm1.eps == self.norm2.eps):
             why_not_sparsity_fast_path = "norm1.eps is not equal to norm2.eps"
-        elif src_mask is not None:
-            why_not_sparsity_fast_path = "src_mask is not supported for fastpath"
-        elif src.is_nested and src_key_padding_mask is not None:
-            why_not_sparsity_fast_path = "src_key_padding_mask is not supported with NestedTensor input for fastpath"
+        elif src.is_nested and (src_key_padding_mask is not None or src_mask is not None):
+            why_not_sparsity_fast_path = "src_key_padding_mask and src_mask are not supported with NestedTensor input"
+        elif (not src.is_nested) and (src_key_padding_mask is not None and src_mask is not None):
+            why_not_sparsity_fast_path = "src_key_padding_mask and src_mask were both supplied"
         elif self.self_attn.num_heads % 2 == 1:
             why_not_sparsity_fast_path = "num_head is odd"
         elif torch.is_autocast_enabled():
             why_not_sparsity_fast_path = "autocast is enabled"
-
         if not why_not_sparsity_fast_path:
             tensor_args = (
                 src,


### PR DESCRIPTION
## Issues
Fixes https://github.com/pytorch/pytorch/issues/81129#issuecomment-1179435674

## Description

Passing a 2D attention mask `src_mask` into the fast path of `TransformerEncoderLayer` in CPU was causing an error and so was disabled in https://github.com/pytorch/pytorch/pull/81277. This PR unrolls this fix, enabling `src_mask` on the fast path:

- Either attention mask `src_mask` of shape `(L, L)` or padding mask `src_key_padding_mask` of shape `(B, L)` are now allowed on the CPU fast path. If softmax is applied along the last dimension (as in multi-head attention), these masks are processed without expanding them to 4D. Instead, when iterating through the input, `Softmax.cpp::host_softmax` converts the index to match the mask dimensions, depending on the type.
- If softmax is applied along the dimension other than the last, `Softmax.cpp::masked_softmax_cpu` expands masks to 4D, converting them to `mask_type=2`. Theoretically one could also add special optimized cases for `dim=0, 1, 2` and process them without mask expansion, but I don't know how often is that used

## Tests:
- `test_transformerencoderlayer_fast_path` is extended to cover both attention mask and padding mask
- `test_masked_softmax_mask_types_0_1` is added to ensure results from CPU softmax with attention and padding masks match the explicit slow calculation
- `test_masked_softmax_devices_parity` is added to ensure results from masked softmax on CPU and CUDA match

## Note
I had to replace `float` with `torch.get_default_dtype()` in a couple of tests for the following reason:
- `test_nn.py` [sets the default type to `torch.double`](https://github.com/pytorch/pytorch/blob/master/test/test_nn.py#L24-L26)
- If I execute `test_nn.py` and `test_transformers.py` in one `pytest` run, this default still holds for transformer tests
- Some tests in `test_transformers.py` which were previously following the slow path now switched to fast path, and hard-coded `float` started clashing with default `double`

Let me know if there is a better way around it - or maybe I'm not supposed to run tests with `pytest` like this



