### PR TITLE
[functorch][docs] Downgrade the warning about forward-mode AD coverage

### DIFF
--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -760,11 +760,11 @@ def jvp(func: Callable, primals: Any, tangents: Any, *, strict: bool = False, ha
         evaluated at ``primals`` and the Jacobian-vector product.
         If ``has_aux is True``, then instead returns a ``(output, jvp_out, aux)`` tuple.
 
-    .. warning::
-        PyTorch's forward-mode AD coverage on operators is not very good at the
-        moment. You may see this API error out with "forward-mode AD not
-        implemented for operator X". If so, please file us a bug report and we
-        will prioritize it.
+    .. note::
+        PyTorch's forward-mode AD coverage on operators is not as good as
+        PyTorch's reverse-mode AD coverage. You may see this API error out
+        with "forward-mode AD not implemented for operator X". If so, please
+        file a bug report and we will prioritize it.
 
     jvp is useful when you wish to compute gradients of a function R^1 -> R^N
 
@@ -901,11 +901,11 @@ def jacfwd(func: Callable, argnums: argnums_t = 0, has_aux: bool = False, *, ran
         instead returns a ``(jacobian, aux)`` tuple where ``jacobian``
         is the Jacobian and ``aux`` is auxiliary objects returned by :attr:`func`.
 
-    .. warning::
-        PyTorch's forward-mode AD coverage on operators is not very good at the
-        moment. You may see this API error out with "forward-mode AD not
-        implemented for operator X". If so, please file us a bug report and we
-        will prioritize it.
+    .. note::
+        PyTorch's forward-mode AD coverage on operators is not as good as
+        PyTorch's reverse-mode AD coverage. You may see this API error out
+        with "forward-mode AD not implemented for operator X". If so, please
+        file a bug report and we will prioritize it.
 
     A basic usage with a pointwise, unary operation will give a diagonal array
     as the Jacobian
@@ -1050,11 +1050,11 @@ def hessian(func, argnums=0):
         returns the Hessian of :attr:`func` with respect to the arg(s) at
         :attr:`argnums`.
 
-    .. warning::
-        PyTorch's forward-mode AD coverage on operators is not very good at the
-        moment. You may see this API error out with "forward-mode AD not
-        implemented for operator X". If so, please file us a bug report and we
-        will prioritize it.
+    .. note::
+        PyTorch's forward-mode AD coverage on operators is not as good as
+        PyTorch's reverse-mode AD coverage. You may see this API error out
+        with "forward-mode AD not implemented for operator X". If so, please
+        file a bug report and we will prioritize it.
 
     A basic usage with a R^N -> R^1 function gives a N x N Hessian:
 

--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -761,10 +761,8 @@ def jvp(func: Callable, primals: Any, tangents: Any, *, strict: bool = False, ha
         If ``has_aux is True``, then instead returns a ``(output, jvp_out, aux)`` tuple.
 
     .. note::
-        PyTorch's forward-mode AD coverage on operators is not as good as
-        PyTorch's reverse-mode AD coverage. You may see this API error out
-        with "forward-mode AD not implemented for operator X". If so, please
-        file a bug report and we will prioritize it.
+        You may see this API error out with "forward-mode AD not implemented
+        for operator X". If so, please file a bug report and we will prioritize it.
 
     jvp is useful when you wish to compute gradients of a function R^1 -> R^N
 
@@ -902,10 +900,9 @@ def jacfwd(func: Callable, argnums: argnums_t = 0, has_aux: bool = False, *, ran
         is the Jacobian and ``aux`` is auxiliary objects returned by :attr:`func`.
 
     .. note::
-        PyTorch's forward-mode AD coverage on operators is not as good as
-        PyTorch's reverse-mode AD coverage. You may see this API error out
-        with "forward-mode AD not implemented for operator X". If so, please
-        file a bug report and we will prioritize it.
+        You may see this API error out with "forward-mode AD not implemented
+        for operator X". If so, please file a bug report and we will prioritize it.
+        An alternative is to use :func:`jacrev`, which has better operator coverage.
 
     A basic usage with a pointwise, unary operation will give a diagonal array
     as the Jacobian
@@ -1051,10 +1048,10 @@ def hessian(func, argnums=0):
         :attr:`argnums`.
 
     .. note::
-        PyTorch's forward-mode AD coverage on operators is not as good as
-        PyTorch's reverse-mode AD coverage. You may see this API error out
-        with "forward-mode AD not implemented for operator X". If so, please
-        file a bug report and we will prioritize it.
+        You may see this API error out with "forward-mode AD not implemented
+        for operator X". If so, please file a bug report and we will prioritize it.
+        An alternative is to use ``jacrev(jacrev(func))``, which has better
+        operator coverage.
 
     A basic usage with a R^N -> R^1 function gives a N x N Hessian:
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #87383

Previously we claimed that "forward-mode AD coverage is not that good".
We've since improved it so I clarified the statement in our docs and
downgraded the warning to a note.

Test Plan:
- view docs