### PR TITLE
[1.13] Fix functorch version docs

### DIFF
--- a/functorch/docs/source/conf.py
+++ b/functorch/docs/source/conf.py
@@ -90,7 +90,7 @@ master_doc = 'index'
 project = 'functorch'
 copyright = 'PyTorch Contributors'
 author = 'PyTorch Contributors'
-functorch_version = str(functorch.__version__)
+functorch_version = '1.13'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
The functorch docs build seems to use a build of PyTorch that is not the RC binary to produce the documentation. This results in the version looking like '1.13.0a??????'.

This PR just hard-codes the functorch version in the docs to be 1.13 in the release branch.

Test Plan:
- check docs preview
