### PR TITLE
[FSDP] Fix `use_orig_params=True` + AC

### DIFF
--- a/torch/distributed/fsdp/_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/_sharded_data_parallel.py
@@ -1,0 +1,119 @@
+import collections
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.fsdp.flat_param import FlatParamHandle, HandleTrainingState
+from torch.utils.hooks import RemovableHandle
+from torch.distributed.fsdp.fully_sharded_data_parallel import TrainingState_
+
+
+class ShardedDataParallelState:
+    ...
+
+
+def sharded_data_parallel(
+    *modules: Tuple[nn.Module, ...],
+    process_group: Optional[dist.ProcessGroup] = None,
+
+):
+    """"""
+    # Initialize state
+    state = ShardedDataParallelState()
+    state.process_group = process_group
+    state.rank = process_group.rank()
+    state.world_size = process_group.size()
+
+    assert torch.cuda.is_available()
+    state.device = torch.cuda.current_device()
+    state.streams: Dict[str, torch.cuda.Stream] = {}
+    state.training_state = TrainingState_.IDLE
+
+    state.handles: List[FlatParamHandle] = []
+    state.pre_forward_handles: List[RemovableHandle] = []
+    state.post_forward_handles: List[RemovableHandle] = []
+
+    state.module_to_handles: Dict[nn.Module, List[FlatParamHandle]] = (
+        collections.defaultdict(list)
+    )
+
+    # Construct `FlatParamHandle`s -- auto wrap with always wrap policy
+
+
+
+def _register_pre_forward_hooks(
+
+) -> None:
+    """"""
+    ...
+
+
+def _register_post_forward_hooks(
+
+) -> None:
+    """"""
+    ...
+
+def _register_pre_backward_hooks(
+    state: ShardedDataParallelState,
+    output: Any,
+    handles: List[FlatParamHandle],
+) -> None:
+    """"""
+    ...
+
+def _register_post_backward_hooks(
+    state: ShardedDataParallelState,
+    handles: List[FlatParamHandle],
+) -> None:
+    """"""
+    ...
+
+def _register_post_backward_callback(
+
+) -> None:
+    """"""
+    ...
+
+
+def _root_pre_forward(
+    state: ShardedDataParallelState,
+    *args,
+    **kwargs,
+):
+    args, kwargs = _cast_forward_inputs(*args, **kwargs)
+    return args, kwargs
+
+
+def _pre_forward(
+    state: ShardedDataParallelState,
+    handles: List[FlatParamHandle],
+    unshard_fn: Callable,
+    module: nn.Module,
+    input: Any,
+):
+    """
+    """
+    state.training_state = TrainingState_.FORWARD
+    for handle in handles:
+        handle._training_state = HandleTrainingState.FORWARD
+    unshard_fn()
+    _register_post_backward_hooks(state, handles)
+
+
+def _post_forward(
+    state: ShardedDataParallelState,
+    handles: List[FlatParamHandle],
+    reshard_fn: Callable,
+    module: nn.Module,
+    input: Any,
+    output: Any,
+) -> Any:
+    reshard_fn()
+    output = _register_pre_backward_hooks(state, output, handles)
+    state.training_state = TrainingState_.IDLE
+    for handle in handles:
+        handle._training_state = HandleTrainingState.IDLE
+    return output
+

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -824,8 +824,9 @@ class FlatParamHandle:
         in_computation = in_forward or self._training_state == HandleTrainingState.BACKWARD_PRE
         if self._use_orig_params:
             # We use `Tensor` views in the forward so that they are tracked by
-            # autograd, and we use them in the pre-backward to ensure that
-            # post-backward hooks run when using activation checkpointing.
+            # autograd. We use them in the pre-backward as well to support
+            # reentrant activation checkpointing, which needs the views to be
+            # tracked by autograd in the backward pass's recomputed forward.
             self._use_unsharded_views(as_params=(not in_computation))
         elif in_forward:
             self._use_unsharded_views(as_params=False)

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -821,13 +821,13 @@ class FlatParamHandle:
             unsharded_size
         )  # this `.view()` is not autograd visible
         in_forward = self._training_state == HandleTrainingState.FORWARD
-        in_computation = in_forward or self._training_state == HandleTrainingState.BACKWARD_PRE
+        in_pre_backward = self._training_state == HandleTrainingState.BACKWARD_PRE
         if self._use_orig_params:
             # We use `Tensor` views in the forward so that they are tracked by
             # autograd. We use them in the pre-backward as well to support
             # reentrant activation checkpointing, which needs the views to be
             # tracked by autograd in the backward pass's recomputed forward.
-            self._use_unsharded_views(as_params=(not in_computation))
+            self._use_unsharded_views(as_params=(not in_forward and not in_pre_backward))
         elif in_forward:
             self._use_unsharded_views(as_params=False)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#87399 [FSDP] Fix `use_orig_params=True` + AC**

Without this change, the post-backward hooks do not run when using reentrant activation checkpointing. This is what happens when we play with `.data` fire.

The reason the hooks do not run is exactly why we need plain `Tensor` views in the forward pass normally without AC: We need the original parameters to be connected in autograd to the `FlatParameter` via `split()` and `view()` so that the gradients propagate through to the `FlatParameter`'s gradient. Reentrant AC runs the 1st forward pass with [`no_grad()`](https://github.com/pytorch/pytorch/blob/7e83f65ad502992a8d75c91eea2cf3de69bb0b7a/torch/utils/checkpoint.py#L106) and relies on the 2nd recomputed forward pass to autograd visible. Therefore, we need to use `Tensor` views in the backward pass as well, not `nn.Parameter` views.