### PR TITLE
[MPS] Do not dispatch empty job in  `bitwise_not` (#87286)

### DIFF
--- a/aten/src/ATen/native/mps/operations/BitwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/BitwiseOps.mm
@@ -302,6 +302,10 @@ at::Tensor& bitwise_not_out_mps (const at::Tensor& self, at::Tensor& output_) {
     }
     return output_;
   }
+  uint32_t length = output.numel();
+  if (length == 0) {
+    return output_;
+  }
   using namespace at::mps;
   MPSStream* stream = getCurrentMPSStream();
   id<MTLComputePipelineState> cplState = getCPLState(MPSDevice::getInstance()->device(),
@@ -309,7 +313,6 @@ at::Tensor& bitwise_not_out_mps (const at::Tensor& self, at::Tensor& output_) {
                                                      getMetalType(self),
                                                      getMetalType(self),
                                                      "bitwise_not");
-  uint32_t length = output.numel();
   dispatch_sync(stream->queue(), ^(){
     id<MTLCommandBuffer> buffer = stream->commandBuffer();
     id<MTLComputeCommandEncoder> commandEncoder = [buffer computeCommandEncoder];


### PR DESCRIPTION
Follows the pattern from https://github.com/pytorch/pytorch/pull/85285 and returns before computing dispatching an empty metal kernel for bitwise not operation.

Fixes crash when invoked with empty MPS tensor on AMD GPU

Pull Request resolved: https://github.com/pytorch/pytorch/pull/87286
Approved by: https://github.com/kulinseth

(cherry picked from commit a79e034d89d3d112fcb8d16f7a6862934a44955d)

Fixes #ISSUE_NUMBER
