### PR TITLE
Remove jansel/voz from dynamo CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -106,11 +106,3 @@ torch/csrc/autograd/profiler* @robieta
 torch/autograd/profiler* @robieta
 torch/csrc/profiler/ @robieta
 torch/profiler/ @robieta
-
-# TorchDynamo
-benchmarks/dynamo @jansel @voznesenskym
-test/dynamo @jansel @voznesenskym
-test/inductor @jansel @voznesenskym
-torch/csrc/dynamo @jansel @voznesenskym
-torch/_dynamo @jansel @voznesenskym
-torch/_inductor @jansel @voznesenskym


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #87430

Now that CC bot is working on PRs this is no longer needed.