### PR TITLE
Move PadNd from ATen/native to ATen

### DIFF
--- a/aten/src/ATen/PadNd.h
+++ b/aten/src/ATen/PadNd.h
@@ -11,12 +11,16 @@ enum class padding_mode {
 
 static inline c10::string_view padding_mode_string(padding_mode m) {
   switch (m) {
-    case padding_mode::reflect: return "reflect";
-    case padding_mode::replicate: return "replicate";
-    case padding_mode::circular: return "circular";
-    case padding_mode::constant: return "constant";
+    case padding_mode::reflect:
+      return "reflect";
+    case padding_mode::replicate:
+      return "replicate";
+    case padding_mode::circular:
+      return "circular";
+    case padding_mode::constant:
+      return "constant";
   }
   TORCH_CHECK(false, "Invalid padding mode (", static_cast<int64_t>(m), ")");
 }
 
-}  // namespace at
+} // namespace at

--- a/aten/src/ATen/native/PadNd.cpp
+++ b/aten/src/ATen/native/PadNd.cpp
@@ -1,5 +1,5 @@
 #include <ATen/ATen.h>
-#include <ATen/native/PadNd.h>
+#include <ATen/PadNd.h>
 
 #include <c10/util/irange.h>
 

--- a/torch/csrc/api/include/torch/nn/functional/padding.h
+++ b/torch/csrc/api/include/torch/nn/functional/padding.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ATen/native/PadNd.h>
+#include <ATen/PadNd.h>
 #include <torch/nn/options/padding.h>
 
 namespace torch {


### PR DESCRIPTION
Summary:
This header is being included from both aten/native and torch/csrc, but some of our build configurations don't allow direct dependencies from torch/csrc to atent/native, so put the header in aten where it's always accessible.

Resolves https://github.com/pytorch/pytorch/issues/81198

Test Plan:
CI.
```
./scripts/build_android.sh
env ANDROID_ABI="x86_64" ANDROID_NDK=".../ndk-bundle" CMAKE_CXX_COMPILER_LAUNCHER=ccache CMAKE_C_COMPILER_LAUNCHER=ccache USE_VULKAN=0 ./scripts/build_android.sh
echo '#include <torch/torch.h>' > test.cpp
g++ -E -I $PWD/build_android/install/include/ -I $PWD/build_android/install/include/torch/csrc/api/include test.cpp >/dev/null
```

ghstack-source-id: 8f6f1b9954cd3ae5399db7a0bfe0d5ba70d39823
Pull Request resolved: https://github.com/pytorch/pytorch/pull/82379

