### PR TITLE
ci: Allow nvidia-smi to continue with non-0 exit

### DIFF
--- a/.github/scripts/install_nvidia_utils_linux.sh
+++ b/.github/scripts/install_nvidia_utils_linux.sh
@@ -51,7 +51,18 @@ install_nvidia_driver_amzn2() {
             sudo rm -fv /tmp/nvidia_driver
         fi
 
-        nvidia-smi
+        (
+            set +e
+            nvidia-smi
+            status=$?
+            # Allowable exit statuses for nvidia-smi, see: https://github.com/NVIDIA/gpu-operator/issues/285
+            if [ $status -eq 0 ] || [ $status -eq 14 ]; then
+                echo "INFO: Ignoring allowed status ${status}"
+            else
+                echo "ERROR: nvidia-smi exited with unresolved status ${status}"
+                exit ${status}
+            fi
+        )
     )
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #87464

Allows nvidia-smi to return a non-0 exit status like status 14 since
status 14 is a warning and doesn't affect actual execution

see https://github.com/NVIDIA/gpu-operator/issues/285

Signed-off-by: Eli Uriegas <eliuriegas@meta.com>