### PR TITLE
[FSDP][1/N] Rework `clip_grad_norm_()` and tests

### DIFF
--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -47,6 +47,7 @@ class TestClipGradNorm(FSDPTest):
     def world_size(self) -> int:
         return 2
 
+    @skip_if_lt_x_gpu(2)
     def test_non_root(self):
         """
         Tests that calling ``clip_grad_norm_()`` on a non-root FSDP instance

--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -145,6 +145,7 @@ class TestClipGradNorm(FSDPTest):
         fsdp_total_norm = fsdp_model.clip_grad_norm_(max_norm=max_norm, norm_type=norm_type)
         self.assertEqual(ddp_total_norm, fsdp_total_norm)
 
+        # Check that the gradients were modified by `clip_grad_norm_()`
         for param, orig_grad in zip(ddp_model.parameters(), orig_ddp_grads):
             assert not torch.equal(param.grad, orig_grad)
         for param, orig_grad in zip(fsdp_model.parameters(), orig_fsdp_grads):

--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -1,30 +1,32 @@
 # Owner(s): ["oncall: distributed"]
 
+import functools
+import itertools
 import sys
-from math import inf
+from typing import Union
 
 import torch
+import torch.nn as nn
 from torch import distributed as dist
+from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload
 from torch.distributed.fsdp.fully_sharded_data_parallel import (
     FullyShardedDataParallel as FSDP,
-    CPUOffload,
-    _calc_grad_norm,
 )
-from torch.nn import utils as nn_utils
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
+from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
-    DeterministicModel,
+    CUDAInitMode,
+    FSDPInitMode,
     FSDPTest,
-    _collect_total_grad_norm_fsdp,
-    _collect_total_grad_norm_local,
+    TransformerWithSharedParams,
 )
 from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
-    run_tests,
-    parametrize,
     instantiate_parametrized_tests,
+    run_tests,
 )
-
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -39,67 +41,131 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestClipGradNorm(FSDPTest):
-    def _run_fsdp_one_iteration(self, norm_type, nested_fsdp, cpu_offload):
-        """Test FSDP with clip grad norm."""
-        fsdp_model = DeterministicModel(nested_fsdp, cpu_offload=cpu_offload)
-        local_model = DeterministicModel(False)
-        input = torch.rand(14, 2, device=self.rank)
-        fsdp_model = FSDP(fsdp_model, cpu_offload=cpu_offload)
-        self.assertTrue(len(input) >= self.world_size)
-        out = local_model(input[: self.world_size])
-        out.sum().backward()
-        in_data = torch.tensor(input[self.rank], device=self.rank)
-        out_fsdp = fsdp_model(in_data)
-        out_fsdp.sum().backward()
-        total_norms_fsdp = _collect_total_grad_norm_fsdp(
-            fsdp_model, norm_type, self.rank
-        )
-        total_norms_local = _collect_total_grad_norm_local(local_model, norm_type)
-        total_norms_local /= self.world_size
-        norm_cap = total_norms_fsdp / 2.0
-        self.assertEqual(total_norms_local, total_norms_fsdp)
-        fsdp_model.clip_grad_norm_(norm_cap, norm_type=norm_type)
-        nn_utils.clip_grad_norm_(
-            local_model.parameters(), norm_cap, norm_type=norm_type
-        )
-        total_norms_after_clip_fsdp = _collect_total_grad_norm_fsdp(
-            fsdp_model, norm_type, self.rank
-        )
-        total_norms_after_clip_local = _collect_total_grad_norm_local(
-            local_model, norm_type
-        )
-        self.assertTrue(total_norms_after_clip_fsdp <= norm_cap)
-        self.assertEqual(total_norms_after_clip_local, total_norms_after_clip_fsdp)
+    """Tests :meth:`FullyShardedDataParallel.clip_grad_norm_`."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_non_root(self):
+        """
+        Tests that calling ``clip_grad_norm_()`` on a non-root FSDP instance
+        raises an error.
+        """
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.lin1 = nn.Linear(5, 5)
+                self.lin2 = nn.Linear(5, 5)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.lin2(self.lin1(x))
+
+        model = Model().cuda()
+        model.lin2 = FSDP(model.lin2)
+        fsdp_model = FSDP(model)
+        fsdp_model(torch.randn((2, 5), device=torch.device("cuda"))).sum().backward()
+        error_regex = "should only be called on the root FSDP instance"
+        with self.assertRaisesRegex(RuntimeError, error_regex):
+            fsdp_model.lin2.clip_grad_norm_(max_norm=2)
 
     @skip_if_lt_x_gpu(2)
-    @parametrize("norm_type", [2.0, inf])
-    @parametrize("nested_fsdp", [True, False])
-    @parametrize(
-        "cpu_offload",
-        [CPUOffload(offload_params=True), CPUOffload(offload_params=False)],
-    )
-    def test_fsdp_clip_grad_norm(self, norm_type, nested_fsdp, cpu_offload):
-        """Test FSDP with clip grad norm."""
-        self._run_fsdp_one_iteration(norm_type, nested_fsdp, cpu_offload)
+    def test_ddp_parity(self):
+        """
+        Tests FSDP with ``FullyShardedDataParallel.clip_grad_norm_()` against
+        DDP with ``torch.nn.utils.clip_grad_norm_()`.
+        """
+        self.run_subtests(
+            {
+                "max_norm": [1, 2.5],
+                "norm_type": [1, 2, float("inf")],
+                "use_orig_params": [False, True],
+                "offload_params": [False, True],
+            },
+            self._test_ddp_parity,
+        )
 
+    def _test_ddp_parity(
+        self,
+        max_norm: Union[float, int],
+        norm_type: Union[float, int],
+        offload_params: bool,
+        use_orig_params: bool,
+    ):
+        local_model = TransformerWithSharedParams.init(
+            self.process_group,
+            FSDPInitMode.NO_FSDP,
+            CUDAInitMode.CUDA_BEFORE,
+            deterministic=True,
+        )
+        ddp_model = DDP(local_model, device_ids=[self.rank])
+        fsdp_kwargs = {
+            "auto_wrap_policy": functools.partial(
+                transformer_auto_wrap_policy,
+                transformer_layer_cls={
+                    TransformerEncoderLayer,
+                    TransformerDecoderLayer,
+                },
+            ),
+            "cpu_offload": CPUOffload(offload_params=offload_params),
+            "use_orig_params": use_orig_params,
+        }
+        fsdp_model = TransformerWithSharedParams.init(
+            self.process_group,
+            FSDPInitMode.RECURSIVE,
+            CUDAInitMode.CUDA_BEFORE,
+            deterministic=True,
+            fsdp_kwargs=fsdp_kwargs,
+        )
+        LR = 1e-2
+        ddp_optim = torch.optim.Adam(ddp_model.parameters(), lr=LR)
+        fsdp_optim = torch.optim.Adam(fsdp_model.parameters(), lr=LR)
+        device = torch.device("cuda")
+        LARGE_FACTOR = 100
+        inp = ddp_model.module.get_input(device)
+        for model in (ddp_model, fsdp_model):
+            out = model(*inp)
+            loss = model.module.get_loss(inp, out)
+            loss.backward()
 
-class TestCalcuGradNorm(FSDPTest):
-    @skip_if_lt_x_gpu(2)
-    @parametrize("norm_type", [2.0, inf, 1.3, 2.5])
-    @parametrize("nested_fsdp", [True, False])
-    def test_fsdp_calc_grad_norm(self, norm_type, nested_fsdp):
-        """Test grad norm cal API."""
-        model = FSDP(DeterministicModel(nested_fsdp))
-        input = torch.rand(15, 2, device=self.rank)
-        out = model(input)
-        out.sum().backward()
-        total_norm = _calc_grad_norm(model.params_with_grad, norm_type)
-        total_norm_expected = _collect_total_grad_norm_local(model, norm_type)
-        self.assertEqual(total_norm, total_norm_expected)
+        # Multiply gradients by a large factor to ensure that gradients will
+        # actually be clipped
+        for param in itertools.chain(ddp_model.parameters(), fsdp_model.parameters()):
+            if param.grad is not None:  # gradients may be `None` for `use_orig_params=True`
+                param.grad *= LARGE_FACTOR
+        orig_ddp_grads = [param.grad.detach().clone() for param in ddp_model.parameters()]
+        orig_fsdp_grads = [
+            param.grad.detach().clone() if param.grad is not None else None
+            for param in fsdp_model.parameters()
+        ]
+
+        ddp_total_norm = torch.nn.utils.clip_grad_norm_(
+            ddp_model.parameters(), max_norm=max_norm, norm_type=norm_type,
+        )
+        fsdp_total_norm = fsdp_model.clip_grad_norm_(max_norm=max_norm, norm_type=norm_type)
+        self.assertEqual(ddp_total_norm, fsdp_total_norm)
+
+        for param, orig_grad in zip(ddp_model.parameters(), orig_ddp_grads):
+            assert not torch.equal(param.grad, orig_grad)
+        for param, orig_grad in zip(fsdp_model.parameters(), orig_fsdp_grads):
+            if param.grad is None:
+                self.assertEqual(param.grad, orig_grad)  # `None`
+            else:
+                assert not torch.equal(param.grad, orig_grad)
+
+        # Run an optimizer step to ensure gradients matched after clipping
+        ddp_optim.step()
+        fsdp_optim.step()
+        with FSDP.summon_full_params(fsdp_model):
+            for (n1, p1), (n2, p2) in zip(
+                ddp_model.module.named_parameters(),
+                fsdp_model.named_parameters(),
+            ):
+                self.assertEqual(n1, n2)
+                self.assertEqual(p1, p2)
 
 
 instantiate_parametrized_tests(TestClipGradNorm)
-instantiate_parametrized_tests(TestCalcuGradNorm)
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3863,11 +3863,11 @@ class FullyShardedDataParallel(nn.Module):
     @torch.no_grad()
     def clip_grad_norm_(
         self, max_norm: Union[float, int], norm_type: Union[float, int] = 2.0
-    ) -> None:
+    ) -> torch.Tensor:
         """
-        Clip all gradients at this point in time. The norm is computed over all
-        gradients together, as if they were concatenated into a single vector.
-        Gradients are modified in-place.
+        Clips the gradient norm of all parameters. The norm is computed over
+        all parameters' gradients as viewed as a single vector, and the
+        gradients are modified in-place.
 
         Args:
             max_norm (float or int): max norm of the gradients
@@ -3889,13 +3889,18 @@ class FullyShardedDataParallel(nn.Module):
         """
         self._lazy_init()
         self._wait_for_previous_optim_step()
-        assert self._is_root, "clip_grad_norm should only be called on the root (parent) instance"
+        if not self._is_root:
+            raise RuntimeError(
+                "`clip_grad_norm_()` should only be called on the root FSDP instance"
+            )
         self._assert_state(TrainingState_.IDLE)
 
         max_norm = float(max_norm)
         norm_type = float(norm_type)
-        # Computes the max norm for this shard's gradients and sync's across workers
-        local_norm = _calc_grad_norm(self.params_with_grad, norm_type).cuda()  # type: ignore[arg-type]
+        # Compute the local gradient norm (only including this rank's shard
+        # of the gradients)
+        local_norm = _get_grad_norm(self.parameters(), norm_type).to(self.compute_device)
+        # Reconstruct the total gradient norm depending on the norm type
         if norm_type == math.inf:
             total_norm = local_norm
             dist.all_reduce(total_norm, op=torch.distributed.ReduceOp.MAX, group=self.process_group)
@@ -3903,16 +3908,21 @@ class FullyShardedDataParallel(nn.Module):
             total_norm = local_norm ** norm_type
             dist.all_reduce(total_norm, group=self.process_group)
             total_norm = total_norm ** (1.0 / norm_type)
-
         if self.cpu_offload.offload_params:
             total_norm = total_norm.cpu()
 
-        clip_coef = torch.tensor(max_norm, dtype=total_norm.dtype, device=total_norm.device) / (total_norm + 1e-6)
-        if clip_coef < 1:
-            # multiply by clip_coef, aka, (max_norm/total_norm).
-            for p in self.params_with_grad:
-                assert p.grad is not None
-                p.grad.detach().mul_(clip_coef.to(p.grad.device))
+        clip_coef = (
+            torch.tensor(max_norm, dtype=total_norm.dtype, device=total_norm.device)
+            / (total_norm + 1e-6)
+        )
+        # Multiplying by the clamped coefficient is meaningless when it is
+        # equal to 1, but it avoids the host-device sync that would result from
+        # `if clip_coef < 1`
+        clip_coef_clamped = torch.clamp(clip_coef, max=1.0)
+        grads = [param.grad for param in self.parameters() if param.grad is not None]
+        for grad in grads:
+            grad.detach().mul_(clip_coef_clamped.to(grad.device))
+        return total_norm
 
     @staticmethod
     def _warn_optim_input(optim_input):
@@ -4565,30 +4575,35 @@ class FullyShardedDataParallel(nn.Module):
         return is_prep_stage
 
 
-def _calc_grad_norm(parameters: List[torch.nn.Parameter], p: float) -> torch.Tensor:
-    r"""Calculate gradient norm of an iterable of parameters.
-    Returns:
-        Total norm of the parameters (viewed as a single vector).
+def _get_grad_norm(
+    params: List[nn.Parameter],
+    norm_type: float,
+) -> torch.Tensor:
     """
-    parameters = [p for p in parameters if p.grad is not None]
-
-    if len(parameters) == 0:
+    Returns the gradient norm of parameters ``param`` s, where the gradients
+    are viewed as a single vector.
+    """
+    params_with_grad = [param for param in params if param.grad is not None]
+    if len(params_with_grad) == 0:
         return torch.tensor(0.0)
-    if p == math.inf:
-        local_norm = torch.tensor(max(par.grad.detach().abs().max() for par in parameters))
-    else:
-        # Compute the norm in full precision no matter what
-        local_norm = torch.linalg.vector_norm(
-            torch.stack(
-                [
-                    torch.linalg.vector_norm(par.grad.detach(), p, dtype=torch.float32)
-                    for par in parameters
-                ]
-            ),
-            p,
-        )
-    local_norm.to(dtype=parameters[0].dtype)
-    return local_norm
+    grads = [param.grad for param in params_with_grad]
+    grad_dtypes = set(grad.dtype for grad in grads)
+    if len(grad_dtypes) != 1:
+        raise ValueError(f"Requires uniform dtype across all gradients but got {grad_dtypes}")
+    # Compute the gradient norm in FP32, where we treat the gradients as a
+    # single vector
+    grad_norm = torch.linalg.vector_norm(
+        torch.stack(
+            [
+                torch.linalg.vector_norm(grad.detach(), norm_type, dtype=torch.float32)
+                for grad in grads
+            ],
+        ),
+        norm_type,
+        dtype=torch.float32,
+    )
+    grad_norm = grad_norm.to(grads[0].dtype)
+    return grad_norm
 
 
 def _get_param_to_unflat_param_names(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #87480 [FSDP][2/N] Remove `params_with_grad`
* **#87479 [FSDP][1/N] Rework `clip_grad_norm_()` and tests**
* #87478 [FSDP][Docs] Clarify warnings to mention collectives

This PR reworks FSDP's `clip_grad_norm_()` and its unit tests. The unit tests in `test_fsdp_core.py` still need to be revisited and will be done in follow-up work.

Some details in arbitrary order:
- This renames `_calc_grad_norm()` to `_get_grad_norm()`. This is to simplify our verb usage in method names. Otherwise, we may diverge to different verbs like "compute", "calculate", "get", "find" etc. I am open to discussion here.
- Because we call `torch.linalg.vector_norm()` as the underlying norm calculation subroutine, which can take infinity as input for the norm type, there is no reason to have a separate conditional branch for the infinity norm.
- This removes a host-device synchronization point from `clip_grad_norm_()` by using the same trick from `torch.nn.utils.clip_grad_norm_()`. This may improve throughput for workloads like metaseq, which computes gradient norms regularly.
- This returns the total norm from `clip_grad_norm_()` as mentioned in the docstring. Before nothing was returned.
- This rewrites the unit tests, which were slightly problematic. Much of the logic to verify gradient norms were computed correctly were exactly the same as the logic used to compute them in FSDP (i.e. `^p`, sum via all-reduce, `^(1/p)`). This defeats the purpose of unit testing. There were some other oddities like `input = torch.rand(14, 2, device=self.rank); in_data = torch.tensor(input[self.rank], device=self.rank)`, where we materialize a full `(14, 2)` shape but only ever use the first two rows (assuming world size 2).