### PR TITLE
[FSDP][2/N] Remove `params_with_grad`

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3853,13 +3853,6 @@ class FullyShardedDataParallel(nn.Module):
                 )
                 m._sync_gradients = old_flag
 
-    @property
-    def params_with_grad(self) -> List[Parameter]:
-        """
-        Recursively returns a list of all module parameters that have a gradient.
-        """
-        return [p for p in self.parameters() if p.grad is not None]
-
     @torch.no_grad()
     def clip_grad_norm_(
         self, max_norm: Union[float, int], norm_type: Union[float, int] = 2.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#87480 [FSDP][2/N] Remove `params_with_grad`**
* #87479 [FSDP][1/N] Rework `clip_grad_norm_()` and tests
* #87478 [FSDP][Docs] Clarify warnings to mention collectives

This PR removes the property `params_with_grad` from `FullyShardedDataParallel`. It was introduced when implementing `clip_grad_norm_()` but was not consistently used. Personally, I do not think it makes sense for `FullyShardedDataParallel` to expose this helper because it is not a common paradigm.

This PR is technically BC-breaking. However, I checked that no one internally is using this API.


cc @ezyang @gchanan