### PR TITLE
[inductor] Trivial smoke-test

### DIFF
--- a/test/inductor/test_smoke.py
+++ b/test/inductor/test_smoke.py
@@ -1,0 +1,27 @@
+import logging
+import unittest
+
+import torch
+import torch._dynamo as torchdynamo
+import torch._inductor.config as torchinductor_config
+
+torchdynamo.config.log_level = logging.INFO
+torchdynamo.config.verbose = True
+torchinductor_config.debug = True
+
+class MLP(torch.nn.Module):
+    def __init__(self):
+        super(MLP, self).__init__()
+        self.l1 = torch.nn.Linear(1, 6)
+        self.l2 = torch.nn.Linear(6, 1)
+
+    def forward(self, x=None):
+        x = torch.relu(self.l1(x))
+        x = torch.relu(self.l2(x))
+        return x
+
+class SmokeTest(unittest.TestCase):
+    def test_mlp(self):
+        mlp = torchdynamo.optimize("inductor")(MLP().cuda())
+        for _ in range(3):
+            mlp(torch.randn(1, device="cuda"))


### PR DESCRIPTION
Summary:
As we're bringing up dynamo+inductor on Meta-internal infra, I keep
wanting a stupidly simple program to run to see if anything at all is working.
This test is that program :-p.

Obviously test_torchinductor.py is more comprehensive but it's also harder to
tell exactly what's going on, whereas this test fits on one screen.

Test Plan:
```
buck2 test mode/dev-nosan //caffe2/test/inductor:smoke
```

Reviewed By: brad-mengchi

Differential Revision: D40595798



cc @jansel @lezcano @fdrocha @mlazos @soumith @voznesenskym @yanboliang