### PR TITLE
Only label checks against pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -229,6 +229,7 @@ jobs:
   check-labels:
     name: Check labels
     runs-on: linux.20_04.16x
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master


### PR DESCRIPTION
When a commit is triggered via any mechanism other than a pull request, there will not be a PR to check labels for.  

The job will fail with the error:
```
2022-10-21T17:50:53.2938592Z + python3 .github/scripts/check_labels.py ''
2022-10-21T17:50:53.4758863Z usage: Check PR labels [-h] pr_num
2022-10-21T17:50:53.4759337Z Check PR labels: error: argument pr_num: invalid int value: ''
```

Instead, we should limit the workflow to only run on pull requests