### PR TITLE
Fix CODE level usage in dynamo config.py

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -7,7 +7,7 @@ from types import ModuleType
 import torch
 
 # needed so that CODE is registered as a level in logging
-from . import logging as torchdynamo_logging # type: ignore[import]
+from . import logging as torchdynamo_logging  # noqa: F401
 
 try:
     import torch._prims
@@ -22,7 +22,8 @@ except ImportError:
 # logging.DEBUG print full traces <-- lowest level + print tracing of every instruction
 # logging.CODE print compiled functions + graphs
 # logging.INFO print the steps that dynamo is running
-# logging.WARN print warnings (including graph breaks)o# logging.ERROR print exceptions (and what user code was being processed when it occurred)
+# logging.WARN print warnings (including graph breaks)
+# logging.ERROR print exceptions (and what user code was being processed when it occurred)
 # NOTE: changing log_level will automatically update the levels of all torchdynamo loggers
 log_level = logging.WARNING
 

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -5,7 +5,9 @@ from os.path import abspath, dirname
 from types import ModuleType
 
 import torch
-from .logging import CODE
+
+# needed so that CODE is registered as a level in logging
+from . import logging as torchdynamo_logging # type: ignore[import]
 
 try:
     import torch._prims
@@ -18,11 +20,9 @@ except ImportError:
 
 # log level (levels print what it says + all levels listed below it)
 # logging.DEBUG print full traces <-- lowest level + print tracing of every instruction
-# CODE print compiled functions + graphs
-# NOTE: user code should use torch._dynamo.logging.CODE
+# logging.CODE print compiled functions + graphs
 # logging.INFO print the steps that dynamo is running
-# logging.WARN print warnings (including graph breaks)
-# logging.ERROR print exceptions (and what user code was being processed when it occurred)
+# logging.WARN print warnings (including graph breaks)o# logging.ERROR print exceptions (and what user code was being processed when it occurred)
 # NOTE: changing log_level will automatically update the levels of all torchdynamo loggers
 log_level = logging.WARNING
 

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -20,7 +20,7 @@ except ImportError:
 
 # log level (levels print what it says + all levels listed below it)
 # logging.DEBUG print full traces <-- lowest level + print tracing of every instruction
-# logging.CODE print compiled functions + graphs
+# logging.CODE print compiled functions + graphs (NOTE: can only be used after importing torch._dynamo.logging)
 # logging.INFO print the steps that dynamo is running
 # logging.WARN print warnings (including graph breaks)
 # logging.ERROR print exceptions (and what user code was being processed when it occurred)

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -5,6 +5,7 @@ from os.path import abspath, dirname
 from types import ModuleType
 
 import torch
+from .logging import CODE
 
 try:
     import torch._prims
@@ -17,7 +18,8 @@ except ImportError:
 
 # log level (levels print what it says + all levels listed below it)
 # logging.DEBUG print full traces <-- lowest level + print tracing of every instruction
-# torchdynamo.logging.CODE print compiled functions + graphs
+# CODE print compiled functions + graphs
+# NOTE: user code should use torch._dynamo.logging.CODE
 # logging.INFO print the steps that dynamo is running
 # logging.WARN print warnings (including graph breaks)
 # logging.ERROR print exceptions (and what user code was being processed when it occurred)

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -11,7 +11,7 @@ from typing import Callable
 import torch
 from torch.fx.graph_module import _forward_from_src as original_forward_from_src
 
-from . import config, exc, logging as torchdynamo_logging
+from . import config, exc
 from .allowed_functions import is_allowed
 from .bytecode_analysis import remove_dead_code, remove_pointless_jumps
 from .bytecode_transformation import is_generator, transform_code_object
@@ -395,7 +395,7 @@ def _compile(
         output_codes.add(out_code)
 
         log.log(
-            torchdynamo_logging.CODE,
+            logging.CODE,
             format_bytecode(
                 "ORIGINAL BYTECODE",
                 code.co_name,
@@ -405,7 +405,7 @@ def _compile(
             ),
         )
         log.log(
-            torchdynamo_logging.CODE,
+            logging.CODE,
             format_bytecode(
                 "MODIFIED BYTECODE",
                 code.co_name,
@@ -423,7 +423,7 @@ def _compile(
         guard_str = "GUARDS:\n"
         guard_str += "\n".join([f" - {str(guard)}" for guard in sorted(output.guards)])
 
-        log.log(torchdynamo_logging.CODE, guard_str)
+        log.log(logging.CODE, guard_str)
 
         if guard_export_fn is not None:
             guard_export_fn(output.guards)

--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -3,8 +3,8 @@ import logging
 import os
 
 # logging level for dynamo generated graphs/bytecode/guards
-CODE = 15
-logging.addLevelName(CODE, "CODE")
+logging.CODE = 15
+logging.addLevelName(logging.CODE, "CODE")
 
 
 # Return all loggers that torchdynamo/torchinductor is responsible for

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -403,7 +403,7 @@ class OutputGraph(fx.Tracer):
             # the call to tabulate can cause a lot of memory to be allocated
             if config.log_level <= logging.INFO:
                 log.log(
-                    torchdynamo_logging.CODE,
+                    logging.CODE,
                     f"TRACED GRAPH\n {name} {gm.forward.__code__.co_filename} {format_graph_tabular(gm.graph)}\n",
                 )
         except ImportError:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -15,7 +15,6 @@ import torch
 from .. import config, ir, scheduler
 from ..ir import ReductionHint
 from ..utils import (
-    dynamo_logging,
     free_symbol_startswith,
     instance_descriptor,
     sympy_product,
@@ -1226,7 +1225,7 @@ class TritonScheduling:
                     f"unexpected group: ({numel}, {rnumel}) != {node.group[1]}"
                 )
 
-        log.log(dynamo_logging.CODE, "schedule: %s", node_schedule)
+        log.log(logging.CODE, "schedule: %s", node_schedule)
         return self.codegen_node_schedule(node_schedule, numel, rnumel)
 
     @staticmethod

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -21,7 +21,7 @@ from .exc import (
 from .ir import Constant, FixedLayout, InputBuffer, TensorBox
 from .lowering import lowerings, make_fallback, needs_realized_inputs
 from .sizevars import SizeVarAllocator
-from .utils import dynamo_logging, dynamo_utils
+from .utils import dynamo_utils
 from .virtualized import V
 
 log = logging.getLogger(__name__)
@@ -329,7 +329,7 @@ class GraphLowering(torch.fx.Interpreter):
         for name, value in self.constants.items():
             setattr(mod, name, value)
 
-        log.log(dynamo_logging.CODE, "Output code: %s", mod.__file__)
+        log.log(logging.CODE, "Output code: %s", mod.__file__)
         V.debug.output_code(mod.__file__)
         V.debug.rename(os.path.splitext(mod.__file__)[0] + ".debug")
         return mod


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchdynamo/issues/1718.

Tested by changing `log_level = logging.WARNING` in config.py to `log_level = logging.CODE` and running a test script that doesn't touch `log_level`.

cc @jansel @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @lezcano @fdrocha