### PR TITLE
[profiler] Standard performance event names for the profiler

### DIFF
--- a/torch/csrc/profiler/events.h
+++ b/torch/csrc/profiler/events.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <cstring>
+#include <vector>
+
+namespace torch {
+namespace profiler {
+
+/* A vector type to hold a list of performance counters */
+using perf_counters_t = std::vector<uint64_t>;
+
+/* Standard list of performance events independent of hardware or backend */
+constexpr std::array<const char*, 2> ProfilerPerfEvents = {
+    /*
+     * Number of Processing Elelement (PE) cycles between two points of interest
+     * in time. This should correlate positively with wall-time. Measured in
+     * uint64_t. PE can be non cpu. TBD reporting behavior for multiple PEs
+     * participating (i.e. threadpool).
+     */
+    "cycles",
+
+    /* Number of PE instructions between two points of interest in time. This
+     * should correlate positively with wall time and the amount of computation
+     * (i.e. work). Across repeat executions, the number of instructions should
+     * be more or less invariant. Measured in uint64_t. PE can be non cpu.
+     */
+    "instructions"};
+} // namespace profiler
+} // namespace torch


### PR DESCRIPTION
Summary: The goal is to create a hardware/backend independent event abstraction on which a standard set of tooling can be developed.

Test Plan: CI

Reviewed By: kimishpatel

Differential Revision: D40238034

