### PR TITLE
Implement `torch._foreach_lerp`

### DIFF
--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -25,6 +25,7 @@
 #include <ATen/ops/_foreach_expm1_native.h>
 #include <ATen/ops/_foreach_floor_native.h>
 #include <ATen/ops/_foreach_frac_native.h>
+#include <ATen/ops/_foreach_lerp_native.h>
 #include <ATen/ops/_foreach_lgamma_native.h>
 #include <ATen/ops/_foreach_log10_native.h>
 #include <ATen/ops/_foreach_log1p_native.h>
@@ -223,23 +224,6 @@ void foreach_tensor_##OP##_scalarlist_slow_(TensorList input, TensorList tensors
         input, tensors1, tensors2, scalars);                               \
   }
 
-#define FOREACH_TERNARY_OP(OP)                                                                                           \
-std::vector<Tensor> foreach_tensor_##OP##_ternary_slow(TensorList tensors1, TensorList tensors2, TensorList tensors3) {  \
-  check_foreach_api_restrictions(tensors1, tensors2, tensors3);                                                          \
-  std::vector<Tensor> result;                                                                                            \
-  for (const auto i : c10::irange(tensors1.size())) {                                                                    \
-    result.emplace_back(tensors1[i].OP(tensors2[i], tensors3[i]));                                                       \
-  }                                                                                                                      \
-  return result;                                                                                                         \
-}                                                                                                                        \
-                                                                                                                         \
-void foreach_tensor_##OP##_ternary_slow_(TensorList tensors1, TensorList tensors2, TensorList tensors3) {                \
-  check_foreach_api_restrictions(tensors1, tensors2, tensors3);                                                          \
-  for (const auto i : c10::irange(tensors1.size())) {                                                                    \
-    tensors1[i].OP##_(tensors2[i], tensors3[i]);                                                                         \
-  }                                                                                                                      \
-}                                                                                                                        \
-
 FOREACH_BINARY_OP_LIST_ALPHA(add);
 FOREACH_BINARY_OP_LIST_ALPHA(sub);
 FOREACH_BINARY_OP_LIST_ALPHA(lerp);
@@ -300,6 +284,23 @@ FOREACH_POINTWISE_OP_SCALARLIST(addcmul);
 
 FOREACH_POINTWISE_OP_TENSOR(addcdiv);
 FOREACH_POINTWISE_OP_TENSOR(addcmul);
+
+#define FOREACH_TERNARY_OP(OP)                                                                                           \
+std::vector<Tensor> foreach_tensor_ternary_##OP##_slow(TensorList tensors1, TensorList tensors2, TensorList tensors3) {  \
+  check_foreach_api_restrictions(tensors1, tensors2, tensors3);                                                          \
+  std::vector<Tensor> result;                                                                                            \
+  for (const auto i : c10::irange(tensors1.size())) {                                                                    \
+    result.emplace_back(tensors1[i].OP(tensors2[i], tensors3[i]));                                                       \
+  }                                                                                                                      \
+  return result;                                                                                                         \
+}                                                                                                                        \
+                                                                                                                         \
+void foreach_tensor_ternary_##OP##_slow_(TensorList tensors1, TensorList tensors2, TensorList tensors3) {                \
+  check_foreach_api_restrictions(tensors1, tensors2, tensors3);                                                          \
+  for (const auto i : c10::irange(tensors1.size())) {                                                                    \
+    tensors1[i].OP##_(tensors2[i], tensors3[i]);                                                                         \
+  }                                                                                                                      \
+}                                                                                                                        \
 
 FOREACH_TERNARY_OP(lerp);
 

--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -223,8 +223,26 @@ void foreach_tensor_##OP##_scalarlist_slow_(TensorList input, TensorList tensors
         input, tensors1, tensors2, scalars);                               \
   }
 
+#define FOREACH_TERNARY_OP(OP)                                                                                           \
+std::vector<Tensor> foreach_tensor_##OP##_ternary_slow(TensorList tensors1, TensorList tensors2, TensorList tensors3) {  \
+  check_foreach_api_restrictions(tensors1, tensors2, tensors3);                                                          \
+  std::vector<Tensor> result;                                                                                            \
+  for (const auto i : c10::irange(tensors1.size())) {                                                                    \
+    result.emplace_back(tensors1[i].OP(tensors2[i], tensors3[i]));                                                       \
+  }                                                                                                                      \
+  return result;                                                                                                         \
+}                                                                                                                        \
+                                                                                                                         \
+void foreach_tensor_##OP##_ternary_slow_(TensorList tensors1, TensorList tensors2, TensorList tensors3) {                \
+  check_foreach_api_restrictions(tensors1, tensors2, tensors3);                                                          \
+  for (const auto i : c10::irange(tensors1.size())) {                                                                    \
+    tensors1[i].OP##_(tensors2[i], tensors3[i]);                                                                         \
+  }                                                                                                                      \
+}                                                                                                                        \
+
 FOREACH_BINARY_OP_LIST_ALPHA(add);
 FOREACH_BINARY_OP_LIST_ALPHA(sub);
+FOREACH_BINARY_OP_LIST_ALPHA(lerp);
 
 FOREACH_BINARY_OP_SCALAR(add);
 FOREACH_BINARY_OP_SCALAR(sub);
@@ -282,6 +300,8 @@ FOREACH_POINTWISE_OP_SCALARLIST(addcmul);
 
 FOREACH_POINTWISE_OP_TENSOR(addcdiv);
 FOREACH_POINTWISE_OP_TENSOR(addcmul);
+
+FOREACH_TERNARY_OP(lerp);
 
 void foreach_tensor_zero_slow_(TensorList tensors) {
   check_foreach_api_restrictions(tensors);

--- a/aten/src/ATen/native/cuda/ForeachFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachFunctors.cuh
@@ -433,5 +433,111 @@ struct PointwiseOpListFunctor {
         }
 };
 
+template<typename T, int depth, int r_args_depth, int res_arg_index>
+struct TernaryOpListFunctor {
+  using opmath_t = at::opmath_type<T>;
+  template<typename Op> __device__ __forceinline__ void operator() (
+      int chunk_size,
+      TensorListMetadata<depth>& tl,
+      Op op) {
+    static_assert(depth == 3 || depth == 4, "");
+    static_assert(depth >= r_args_depth, "");
+    static_assert(res_arg_index == depth - 1 || res_arg_index == 0, "");
+    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    int chunk_idx = tl.block_to_chunk[blockIdx.x];
+    int n = tl.numel_for_tensor[tensor_loc];
+
+    T* args[depth];
+    const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
+
+    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+      for (int i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
+        load_store(r_args[0], args[0], 0, i_start);
+        load_store(r_args[1], args[1], 0, i_start);
+        load_store(r_args[2], args[2], 0, i_start);
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = op(
+              static_cast<opmath_t>(r_args[0][ii]),
+              static_cast<opmath_t>(r_args[1][ii]),
+              static_cast<opmath_t>(r_args[2][ii])
+          );
+        }
+        load_store(args[res_arg_index], r_args[0], i_start, 0);
+      }
+    } else {
+      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
+        load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = op(
+              static_cast<opmath_t>(r_args[0][ii]),
+              static_cast<opmath_t>(r_args[1][ii]),
+              static_cast<opmath_t>(r_args[2][ii])
+          );
+        }
+        store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+      }
+    }
+  }
+};
+
+template<typename T, int depth, int r_args_depth, int res_arg_index>
+struct TernaryOpScalarFunctor {
+  using opmath_t = at::opmath_type<T>;
+  template<typename Op> __device__ __forceinline__ void operator() (
+      int chunk_size,
+      TensorListMetadata<depth>& tl,
+      Op op,
+      opmath_t alpha) {
+    static_assert(depth == 2 || depth == 3, "");
+    static_assert(depth >= r_args_depth, "");
+    static_assert(res_arg_index == depth - 1 || res_arg_index == 0, "");
+    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    int chunk_idx = tl.block_to_chunk[blockIdx.x];
+    int n = tl.numel_for_tensor[tensor_loc];
+
+    T* args[depth];
+    bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
+
+    // to make things simple, we put aligned case in a different code path
+    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+      for(int i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
+        // load
+        load_store(r_args[0], args[0], 0, i_start);
+        load_store(r_args[1], args[1], 0, i_start);
+#pragma unroll
+        for(int ii = 0; ii < kILP; ii++) {
+            r_args[0][ii] = op(
+                static_cast<opmath_t>(r_args[0][ii]),
+                static_cast<opmath_t>(r_args[1][ii]),
+                alpha
+            );
+        }
+        // store
+        load_store(args[res_arg_index], r_args[0], i_start , 0);
+      }
+    }
+    else {
+      for(int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
+        load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
+#pragma unroll
+        for(int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = op(
+              static_cast<opmath_t>(r_args[0][ii]),
+              static_cast<opmath_t>(r_args[1][ii]),
+              alpha
+          );
+        }
+        store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+      }
+    }
+  }
+};
+
 } // namespace
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachTernaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachTernaryOp.cu
@@ -15,17 +15,6 @@
 
 namespace at { namespace native {
 
-// Ref: [GPU Pro Tip: Lerp Faster in C++](https://developer.nvidia.com/blog/lerp-faster-cuda/)
-template<>
-C10_HOST_DEVICE C10_ALWAYS_INLINE float lerp(const float start, const float end, const float weight) {
-  return fma(weight, end, fma(-weight, start, start));
-}
-
-template<>
-C10_HOST_DEVICE C10_ALWAYS_INLINE double lerp(const double start, const double end, const double weight) {
-  return fma(weight, end, fma(-weight, start, start));
-}
-
 template <typename T>
 struct LerpFunctor {
   inline C10_DEVICE T operator()(const T self, const T end, const T weight) {

--- a/aten/src/ATen/native/cuda/ForeachTernaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachTernaryOp.cu
@@ -1,6 +1,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
 #include <ATen/native/ForeachUtils.h>
+#include <ATen/native/Lerp.h>
 #include <ATen/native/cuda/ForeachFunctors.cuh>
 #include <ATen/native/cuda/MultiTensorApply.cuh>
 
@@ -14,149 +15,28 @@
 
 namespace at { namespace native {
 
-template <typename scalar_t>
-inline C10_HOST_DEVICE scalar_t lerp_(const scalar_t start, const scalar_t end, const scalar_t weight) {
-  using opmath_t = at::opmath_type<scalar_t>;
-  opmath_t start_val = start;
-  opmath_t end_val = end;
-  opmath_t weight_val = weight;
-  // Conditional for better numeric. This has been discussed in
-  // https://github.com/pytorch/pytorch/pull/18871
-  return (std::abs(weight_val) < 0.5)
-      ? start_val + weight * (end_val - start_val)
-      : end_val - (end_val - start_val) * (opmath_t{1} - weight_val);
-}
-
 // Ref: [GPU Pro Tip: Lerp Faster in C++](https://developer.nvidia.com/blog/lerp-faster-cuda/)
 template<>
-inline C10_HOST_DEVICE float lerp_(const float start, const float end, const float weight) {
+C10_HOST_DEVICE C10_ALWAYS_INLINE float lerp(const float start, const float end, const float weight) {
   return fma(weight, end, fma(-weight, start, start));
 }
 
 template<>
-inline C10_HOST_DEVICE double lerp_(const double start, const double end, const double weight) {
+C10_HOST_DEVICE C10_ALWAYS_INLINE double lerp(const double start, const double end, const double weight) {
   return fma(weight, end, fma(-weight, start, start));
 }
 
-namespace {
 template <typename T>
 struct LerpFunctor {
   inline C10_DEVICE T operator()(const T self, const T end, const T weight) {
-    return lerp_(self, end, weight);
+    return lerp(self, end, weight);
   }
 };
-
-template<typename T, int depth, int r_args_depth, int res_arg_index>
-struct TernaryOpListFunctor {
-  using opmath_t = at::opmath_type<T>;
-  template<typename Op> __device__ __forceinline__ void operator() (
-      int chunk_size,
-      TensorListMetadata<depth>& tl,
-      Op op) {
-    static_assert(depth == 3 || depth == 4, "");
-    static_assert(depth >= r_args_depth, "");
-    static_assert(res_arg_index == depth - 1 || res_arg_index == 0, "");
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.numel_for_tensor[tensor_loc];
-
-    T* args[depth];
-    const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
-    n -= chunk_idx * chunk_size;
-    T r_args[r_args_depth][kILP];
-
-    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
-      for (int i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
-        load_store(r_args[0], args[0], 0, i_start);
-        load_store(r_args[1], args[1], 0, i_start);
-        load_store(r_args[2], args[2], 0, i_start);
-#pragma unroll
-        for (int ii = 0; ii < kILP; ii++) {
-          r_args[0][ii] = op(
-              static_cast<opmath_t>(r_args[0][ii]),
-              static_cast<opmath_t>(r_args[1][ii]),
-              static_cast<opmath_t>(r_args[2][ii])
-          );
-        }
-        load_store(args[res_arg_index], r_args[0], i_start, 0);
-      }
-    } else {
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
-        load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
-#pragma unroll
-        for (int ii = 0; ii < kILP; ii++) {
-          r_args[0][ii] = op(
-              static_cast<opmath_t>(r_args[0][ii]),
-              static_cast<opmath_t>(r_args[1][ii]),
-              static_cast<opmath_t>(r_args[2][ii])
-          );
-        }
-        store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
-      }
-    }
-  }
-};
-
-template<typename T, int depth, int r_args_depth, int res_arg_index>
-struct TernaryOpScalarFunctor {
-  using opmath_t = at::opmath_type<T>;
-  template<typename Op> __device__ __forceinline__ void operator() (
-      int chunk_size,
-      TensorListMetadata<depth>& tl,
-      Op op,
-      opmath_t alpha) {
-    static_assert(depth == 2 || depth == 3, "");
-    static_assert(depth >= r_args_depth, "");
-    static_assert(res_arg_index == depth - 1 || res_arg_index == 0, "");
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.numel_for_tensor[tensor_loc];
-
-    T* args[depth];
-    bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
-    n -= chunk_idx * chunk_size;
-    T r_args[r_args_depth][kILP];
-
-    // to make things simple, we put aligned case in a different code path
-    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
-      for(int i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
-        // load
-        load_store(r_args[0], args[0], 0, i_start);
-        load_store(r_args[1], args[1], 0, i_start);
-#pragma unroll
-        for(int ii = 0; ii < kILP; ii++) {
-            r_args[0][ii] = op(
-                static_cast<opmath_t>(r_args[0][ii]),
-                static_cast<opmath_t>(r_args[1][ii]),
-                alpha
-            );
-        }
-        // store
-        load_store(args[res_arg_index], r_args[0], i_start , 0);
-      }
-    }
-    else {
-      for(int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
-        load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
-#pragma unroll
-        for(int ii = 0; ii < kILP; ii++) {
-          r_args[0][ii] = op(
-              static_cast<opmath_t>(r_args[0][ii]),
-              static_cast<opmath_t>(r_args[1][ii]),
-              alpha
-          );
-        }
-        store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
-      }
-    }
-  }
-};
-} // namespace
 
 std::vector<at::Tensor> foreach_tensor_lerp_ternary_cuda(TensorList tensors1, TensorList tensors2, TensorList tensors3) {
   check_foreach_api_restrictions(tensors1, tensors2, tensors3);
   if (!can_use_fast_route({tensors1, tensors2, tensors3})) {
-    return foreach_tensor_lerp_ternary_slow(tensors1, tensors2, tensors3);
+    return foreach_tensor_ternary_lerp_slow(tensors1, tensors2, tensors3);
   }
 
   std::vector<at::Tensor> vec_res;
@@ -183,7 +63,7 @@ std::vector<at::Tensor> foreach_tensor_lerp_ternary_cuda(TensorList tensors1, Te
 void foreach_tensor_lerp_ternary_cuda_(TensorList tensors1, TensorList tensors2, TensorList tensors3) {
   check_foreach_api_restrictions(tensors1, tensors2, tensors3);
   if (!can_use_fast_route({tensors1, tensors2, tensors3})) {
-    return foreach_tensor_lerp_ternary_slow_(tensors1, tensors2, tensors3);
+    return foreach_tensor_ternary_lerp_slow_(tensors1, tensors2, tensors3);
   }
 
   std::vector<std::vector<at::Tensor>> tensor_lists {tensors1.vec(), tensors2.vec(), tensors3.vec()};

--- a/aten/src/ATen/native/cuda/ForeachTernaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachTernaryOp.cu
@@ -1,0 +1,249 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/Dispatch.h>
+#include <ATen/native/ForeachUtils.h>
+#include <ATen/native/cuda/ForeachFunctors.cuh>
+#include <ATen/native/cuda/MultiTensorApply.cuh>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_foreach_lerp_native.h>
+
+#include <ATen/ops/empty_like_native.h>
+#endif
+
+namespace at { namespace native {
+
+template <typename scalar_t>
+inline C10_HOST_DEVICE scalar_t lerp_(const scalar_t start, const scalar_t end, const scalar_t weight) {
+  using opmath_t = at::opmath_type<scalar_t>;
+  opmath_t start_val = start;
+  opmath_t end_val = end;
+  opmath_t weight_val = weight;
+  // Conditional for better numeric. This has been discussed in
+  // https://github.com/pytorch/pytorch/pull/18871
+  return (std::abs(weight_val) < 0.5)
+      ? start_val + weight * (end_val - start_val)
+      : end_val - (end_val - start_val) * (opmath_t{1} - weight_val);
+}
+
+// Ref: [GPU Pro Tip: Lerp Faster in C++](https://developer.nvidia.com/blog/lerp-faster-cuda/)
+template<>
+inline C10_HOST_DEVICE float lerp_(const float start, const float end, const float weight) {
+  return fma(weight, end, fma(-weight, start, start));
+}
+
+template<>
+inline C10_HOST_DEVICE double lerp_(const double start, const double end, const double weight) {
+  return fma(weight, end, fma(-weight, start, start));
+}
+
+namespace {
+template <typename T>
+struct LerpFunctor {
+  inline C10_DEVICE T operator()(const T self, const T end, const T weight) {
+    return lerp_(self, end, weight);
+  }
+};
+
+template<typename T, int depth, int r_args_depth, int res_arg_index>
+struct TernaryOpListFunctor {
+  using opmath_t = at::opmath_type<T>;
+  template<typename Op> __device__ __forceinline__ void operator() (
+      int chunk_size,
+      TensorListMetadata<depth>& tl,
+      Op op) {
+    static_assert(depth == 3 || depth == 4, "");
+    static_assert(depth >= r_args_depth, "");
+    static_assert(res_arg_index == depth - 1 || res_arg_index == 0, "");
+    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    int chunk_idx = tl.block_to_chunk[blockIdx.x];
+    int n = tl.numel_for_tensor[tensor_loc];
+
+    T* args[depth];
+    const bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
+
+    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+      for (int i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
+        load_store(r_args[0], args[0], 0, i_start);
+        load_store(r_args[1], args[1], 0, i_start);
+        load_store(r_args[2], args[2], 0, i_start);
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = op(
+              static_cast<opmath_t>(r_args[0][ii]),
+              static_cast<opmath_t>(r_args[1][ii]),
+              static_cast<opmath_t>(r_args[2][ii])
+          );
+        }
+        load_store(args[res_arg_index], r_args[0], i_start, 0);
+      }
+    } else {
+      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
+        load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
+#pragma unroll
+        for (int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = op(
+              static_cast<opmath_t>(r_args[0][ii]),
+              static_cast<opmath_t>(r_args[1][ii]),
+              static_cast<opmath_t>(r_args[2][ii])
+          );
+        }
+        store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+      }
+    }
+  }
+};
+
+template<typename T, int depth, int r_args_depth, int res_arg_index>
+struct TernaryOpScalarFunctor {
+  using opmath_t = at::opmath_type<T>;
+  template<typename Op> __device__ __forceinline__ void operator() (
+      int chunk_size,
+      TensorListMetadata<depth>& tl,
+      Op op,
+      opmath_t alpha) {
+    static_assert(depth == 2 || depth == 3, "");
+    static_assert(depth >= r_args_depth, "");
+    static_assert(res_arg_index == depth - 1 || res_arg_index == 0, "");
+    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    int chunk_idx = tl.block_to_chunk[blockIdx.x];
+    int n = tl.numel_for_tensor[tensor_loc];
+
+    T* args[depth];
+    bool all_aligned = init_args<depth>(args, tl, chunk_idx, chunk_size, tensor_loc);
+    n -= chunk_idx * chunk_size;
+    T r_args[r_args_depth][kILP];
+
+    // to make things simple, we put aligned case in a different code path
+    if (n % kILP == 0 && chunk_size % kILP == 0 && all_aligned) {
+      for(int i_start = threadIdx.x; i_start * kILP < n && i_start * kILP < chunk_size; i_start += blockDim.x) {
+        // load
+        load_store(r_args[0], args[0], 0, i_start);
+        load_store(r_args[1], args[1], 0, i_start);
+#pragma unroll
+        for(int ii = 0; ii < kILP; ii++) {
+            r_args[0][ii] = op(
+                static_cast<opmath_t>(r_args[0][ii]),
+                static_cast<opmath_t>(r_args[1][ii]),
+                alpha
+            );
+        }
+        // store
+        load_store(args[res_arg_index], r_args[0], i_start , 0);
+      }
+    }
+    else {
+      for(int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
+        load_args<r_args_depth>(r_args, args, i_start, chunk_size, n);
+#pragma unroll
+        for(int ii = 0; ii < kILP; ii++) {
+          r_args[0][ii] = op(
+              static_cast<opmath_t>(r_args[0][ii]),
+              static_cast<opmath_t>(r_args[1][ii]),
+              alpha
+          );
+        }
+        store_args(args[res_arg_index], r_args[0], i_start, chunk_size, n);
+      }
+    }
+  }
+};
+} // namespace
+
+std::vector<at::Tensor> foreach_tensor_lerp_ternary_cuda(TensorList tensors1, TensorList tensors2, TensorList tensors3) {
+  check_foreach_api_restrictions(tensors1, tensors2, tensors3);
+  if (!can_use_fast_route({tensors1, tensors2, tensors3})) {
+    return foreach_tensor_lerp_ternary_slow(tensors1, tensors2, tensors3);
+  }
+
+  std::vector<at::Tensor> vec_res;
+  vec_res.reserve(tensors1.size());
+  for (const auto& t : tensors1) {
+    vec_res.emplace_back(at::native::empty_like(t));
+  }
+  std::vector<std::vector<at::Tensor>> tensor_lists {tensors1.vec(), tensors2.vec(), tensors3.vec(), vec_res};
+
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, tensors1[0].scalar_type(), "foreach_tensor_lerp_ternary_cuda",
+      [&]() {
+          using opmath_t = typename at::opmath_type<scalar_t>;
+          multi_tensor_apply<4>(
+              tensor_lists,
+              TernaryOpListFunctor<scalar_t, /* depth */ 4, /* r_args_depth */ 3, /* res_arg_index */ 3>(),
+              LerpFunctor<opmath_t>());
+      }
+  );
+
+  return tensor_lists[3];
+}
+
+void foreach_tensor_lerp_ternary_cuda_(TensorList tensors1, TensorList tensors2, TensorList tensors3) {
+  check_foreach_api_restrictions(tensors1, tensors2, tensors3);
+  if (!can_use_fast_route({tensors1, tensors2, tensors3})) {
+    return foreach_tensor_lerp_ternary_slow_(tensors1, tensors2, tensors3);
+  }
+
+  std::vector<std::vector<at::Tensor>> tensor_lists {tensors1.vec(), tensors2.vec(), tensors3.vec()};
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, tensors1[0].scalar_type(), "foreach_tensor_lerp_ternary_cuda_",
+        [&]() {
+            using opmath_t = typename at::opmath_type<scalar_t>;
+            multi_tensor_apply<3>(
+                tensor_lists,
+                TernaryOpListFunctor<scalar_t, /* depth */ 3, /* r_args_depth */ 3, /* res_arg_index */ 0>(),
+                LerpFunctor<opmath_t>());
+        }
+  );
+}
+
+std::vector<at::Tensor> foreach_tensor_lerp_list_cuda(TensorList tensors1, TensorList tensors2, const Scalar& weight) {
+  check_foreach_api_restrictions(tensors1, tensors2);
+  if (!can_use_fast_route({tensors1, tensors2})) {
+    return foreach_tensor_lerp_list_kernel_slow(tensors1, tensors2, weight);
+  }
+
+  std::vector<at::Tensor> vec_res;
+  vec_res.reserve(tensors1.size());
+  for (const auto& t : tensors1) {
+    vec_res.emplace_back(at::native::empty_like(t));
+  }
+  std::vector<std::vector<at::Tensor>> tensor_lists {tensors1.vec(), tensors2.vec(), vec_res};
+
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, tensors1[0].scalar_type(), "foreach_tensor_lerp_scalar_cuda",
+      [&]() {
+          using opmath_t = typename at::opmath_type<scalar_t>;
+          multi_tensor_apply<3>(
+              tensor_lists,
+              TernaryOpScalarFunctor<scalar_t, /* depth */ 3, /* r_args_depth */ 2, /* res_arg_index */ 2>(),
+              LerpFunctor<opmath_t>(),
+              weight.to<opmath_t>());
+      }
+  );
+
+  return tensor_lists[2];
+}
+
+void foreach_tensor_lerp_list_cuda_(TensorList tensors1, TensorList tensors2, const Scalar& weight) {
+  check_foreach_api_restrictions(tensors1, tensors2);
+  if (!can_use_fast_route({tensors1, tensors2})) {
+    return foreach_tensor_lerp_list_kernel_slow_(tensors1, tensors2, weight);
+  }
+
+  std::vector<std::vector<at::Tensor>> tensor_lists {tensors1.vec(), tensors2.vec()};
+  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+        at::ScalarType::Half, at::ScalarType::BFloat16, tensors1[0].scalar_type(), "foreach_tensor_lerp_scalar_cuda_",
+        [&]() {
+            using opmath_t = typename at::opmath_type<scalar_t>;
+            multi_tensor_apply<2>(
+                tensor_lists,
+                TernaryOpScalarFunctor<scalar_t, /* depth */ 2, /* r_args_depth */ 2, /* res_arg_index */ 0>(),
+                LerpFunctor<opmath_t>(),
+                weight.to<opmath_t>());
+        }
+  );
+}
+} } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -10542,7 +10542,7 @@
   device_check: NoCheck   # foreach kernels fall back to slow path when tensors are on different devices
   variants: function
   dispatch:
-    CPU: foreach_tensor_lerp_ternary_slow
+    CPU: foreach_tensor_ternary_lerp_slow
     CUDA: foreach_tensor_lerp_ternary_cuda
   autogen: _foreach_lerp.List_out
 
@@ -10550,7 +10550,7 @@
   device_check: NoCheck   # foreach kernels fall back to slow path when tensors are on different devices
   variants: function
   dispatch:
-    CPU: foreach_tensor_lerp_ternary_slow_
+    CPU: foreach_tensor_ternary_lerp_slow_
     CUDA: foreach_tensor_lerp_ternary_cuda_
   autogen: _foreach_lerp.List_out
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -10538,6 +10538,38 @@
     CUDA: foreach_tensor_norm_cuda
   autogen: _foreach_norm.Scalar_out
 
+- func: _foreach_lerp.List(Tensor[] self, Tensor[] tensors1, Tensor[] weights) -> Tensor[]
+  device_check: NoCheck   # foreach kernels fall back to slow path when tensors are on different devices
+  variants: function
+  dispatch:
+    CPU: foreach_tensor_lerp_ternary_slow
+    CUDA: foreach_tensor_lerp_ternary_cuda
+  autogen: _foreach_lerp.List_out
+
+- func: _foreach_lerp_.List(Tensor(a!)[] self, Tensor[] tensors1, Tensor[] weights) -> ()
+  device_check: NoCheck   # foreach kernels fall back to slow path when tensors are on different devices
+  variants: function
+  dispatch:
+    CPU: foreach_tensor_lerp_ternary_slow_
+    CUDA: foreach_tensor_lerp_ternary_cuda_
+  autogen: _foreach_lerp.List_out
+
+- func: _foreach_lerp.Scalar(Tensor[] self, Tensor[] tensors1, Scalar weight) -> Tensor[]
+  device_check: NoCheck   # foreach kernels fall back to slow path when tensors are on different devices
+  variants: function
+  dispatch:
+    CPU: foreach_tensor_lerp_list_kernel_slow
+    CUDA: foreach_tensor_lerp_list_cuda
+  autogen: _foreach_lerp.Scalar_out
+
+- func: _foreach_lerp_.Scalar(Tensor(a!)[] self, Tensor[] tensors1, Scalar weight) -> ()
+  device_check: NoCheck   # foreach kernels fall back to slow path when tensors are on different devices
+  variants: function
+  dispatch:
+    CPU: foreach_tensor_lerp_list_kernel_slow_
+    CUDA: foreach_tensor_lerp_list_cuda_
+  autogen: _foreach_lerp.Scalar_out
+
 - func: bucketize.Tensor(Tensor self, Tensor boundaries, *, bool out_int32=False, bool right=False) -> Tensor
   dispatch:
     CPU: bucketize_cpu

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -9,7 +9,7 @@ import unittest
 
 from torch.testing import make_tensor
 from torch.testing._comparison import default_tolerances
-from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_ROCM, TEST_WITH_SLOW, skipIfTorchDynamo
+from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_ROCM, TEST_WITH_SLOW, skipIfTorchDynamo, parametrize
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, onlyCUDA, skipMeta, ops, OpDTypes)
 from torch.testing._internal.common_methods_invocations import (
@@ -80,6 +80,7 @@ class ForeachFuncWrapper:
         ):
             with torch.profiler.profile(activities=(torch.profiler.ProfilerActivity.CPU,)) as p:
                 actual = self.func(*inputs, **kwargs)
+            print(p.key_averages().table(sort_by="cpu_time_total", row_limit=10))
             for e in p.key_averages():
                 if e.key == 'cudaLaunchKernel':
                     if is_fastpath:
@@ -137,136 +138,81 @@ class TestForeach(TestCase):
                 else:
                     self.assertEqual(expected, actual)
 
-    def _test_binary_op_tensorlists(self, device, dtype, opinfo, N, is_fastpath, disable_fastpath):
-        n_expected_cudaLaunchKernels = N if disable_fastpath else 1
-        op, ref, inplace_op, inplace_ref = self._get_funcs(opinfo, n_expected_cudaLaunchKernels)
-        inputs = [
-            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
-            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
-        ]
-        self._binary_test(dtype, op, ref, inputs, is_fastpath, is_inplace=False)
-        self._binary_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath, is_inplace=True)
-        if opinfo.supports_alpha_param:
-            alpha = None
-            if dtype in integral_types():
-                alpha = 3
-            elif dtype.is_complex:
-                alpha = complex(3, 3)
-            else:
-                alpha = 3.14
-            self._binary_test(dtype, op, ref, inputs, is_fastpath, is_inplace=False, alpha=alpha)
-            self._binary_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath, is_inplace=True, alpha=alpha)
-
-        # Tests of implicit broadcasting
-        # When sizes of tensors don't match, foreach functions are supposed to choose slow path
-        # even if this methods's argument `is_fastpath` is True.
-        # `cudaLaunchKernel` will be equal to `N`. For assert in `ForeachFuncWrapper` to pass,
-        # we pass `is_fastpath and disable_fastpath` to `_binary_test`'s argument of is_fastpath.
-        # as n_expected_cudaLaunchKernels is N if disable_fastpath.
-        inputs = [
-            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
-            [
-                make_tensor((N - i, 1), device=device, dtype=dtype, noncontiguous=not is_fastpath) for i in range(N)
-            ],
-        ]
-        self._binary_test(dtype, op, ref, inputs, is_fastpath and disable_fastpath, is_inplace=False)
-        self._binary_test(
-            dtype, inplace_op, inplace_ref, inputs, is_fastpath and disable_fastpath, is_inplace=True)
-
+    # NOTE(crcrpar): foreach_div and foreach_mul launch cuda kernel 19 times for num_tensors==20
+    # when is_fastpath and dtype==torch.float16.
     @skipMeta
     @ops(foreach_binary_op_db)
-    def test_binary_op_tensorlists_fastpath(self, device, dtype, op):
-        for N in N_values:
-            disable_fastpath = op.ref == torch.div and dtype in integral_types_and(torch.bool)
-            if op.ref == torch.add and dtype == torch.bool:
-                disable_fastpath = True
-            self._test_binary_op_tensorlists(device, dtype, op, N, True, disable_fastpath)
+    @parametrize("is_fastpath", (True, False))
+    def test_binary_op_with_SampleInput(self, device, dtype, op, is_fastpath):
+        for sample in op.sample_inputs(device, dtype, noncontiguous=not is_fastpath):
+            rhs_arg, = sample.args
+            kwargs = {} or sample.kwargs
+            alpha = kwargs.pop("alpha", None)
+            disable_fastpath = kwargs.pop("disable_fastpath") if is_fastpath else False
+            n_expected_cudaLaunchKernels = len(sample.input) if disable_fastpath else 1
+            wrapped_op, ref, inplace_op, inplace_ref = self._get_funcs(op, n_expected_cudaLaunchKernels)
+            self._binary_test(
+                dtype, wrapped_op, ref, [sample.input, rhs_arg], is_fastpath, False, alpha=alpha)
+            self._binary_test(
+                dtype, inplace_op, inplace_ref, [sample.input, rhs_arg], is_fastpath, True, alpha=alpha)
 
-    @ops(foreach_binary_op_db)
-    def test_binary_op_tensorlists_slowpath(self, device, dtype, op):
-        for N in N_values:
-            self._test_binary_op_tensorlists(device, dtype, op, N, False, False)
+    @ops(foreach_pointwise_op_db)
+    @parametrize("is_fastpath", (True, False))
+    def test_pointwise_op_with_sampleinput(self, device, dtype, op, is_fastpath):
+        for sample in op.sample_inputs(device, dtype):
+            if not is_fastpath:
+                sample = sample.noncontiguous()
+            assert isinstance(sample.args, tuple)
+            assert len(sample.args) == 2
+            inputs = [sample.input, *sample.args]
+            kwargs = sample.kwargs
+            disable_fastpath = kwargs.pop("disable_fastpath") if is_fastpath else False
+            n_expected_cudaLaunchKernels = len(sample.input) if disable_fastpath else 1
+            wrapped_op, ref, inplace_op, inplace_ref = self._get_funcs(op, n_expected_cudaLaunchKernels)
+            values = kwargs.pop("values")
+            self._pointwise_test(wrapped_op, ref, inputs, is_fastpath, False, values=values)
+            self._pointwise_test(inplace_op, inplace_ref, inputs, is_fastpath, True, values=values)
 
-    def _test_binary_op_scalar(self, device, dtype, opinfo, N, scalar, is_fastpath, disable_fastpath):
-        n_expected_cudaLaunchKernels = N if disable_fastpath else 1
-        inputs = [opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath), scalar]
+            if is_fastpath and isinstance(values, list):
+                sample = sample.transform(lambda t: t.clone().detach() if torch.is_tensor(t) else t)
+                inputs = [sample.input, *sample.args]
+                tensor_values = torch.tensor(values)
+                # 1D Tensor of scalars
+                for is_inplace, op_, ref_ in ((False, wrapped_op, ref), (True, inplace_op, inplace_ref)):
+                    self._pointwise_test(op_, ref_, inputs, is_fastpath, is_inplace, values=tensor_values)
+                    self._pointwise_test(
+                        op_, ref_, inputs, is_fastpath, is_inplace, values=tensor_values[0],
+                        custom_values_err="Expected packed scalar Tensor to be of dimension 1. Got 0 instead.")
+                    if self.is_cuda:
+                        self._pointwise_test(
+                            op_, ref_, inputs, is_fastpath, is_inplace, values=tensor_values.cuda(),
+                            custom_values_err="Expected scalars to be on CPU, got cuda:0 instead.")
+                    self._pointwise_test(
+                        op_, ref_, inputs, is_fastpath, is_inplace, values=tensor_values[:2],
+                        custom_values_err=f"Expected length of scalars to match input of length {len(values)} but got 2 instead.")
+                    self._pointwise_test(
+                        op_, ref_, inputs, is_fastpath, is_inplace, values=torch.tensor([[0, 1], [2, 3]])[:, 1],
+                        custom_values_err="Expected scalars to be contiguous.")
 
-        if disable_fastpath and opinfo.ref in [torch.clamp_min, torch.clamp_max] \
-                and torch.result_type(inputs[0][0], inputs[1]) != dtype:
-            n_expected_cudaLaunchKernels = N * 2  # fallback op launches 2 kernels on these cases
+            # Tests of implicit broadcasting
+            N = len(sample.input)
+            inputs = [
+                [
+                    make_tensor((N, N), device=device, dtype=dtype, noncontiguous=not is_fastpath) for _ in range(N)
+                ],
+                [
+                    make_tensor((N - i, 1), device=device, dtype=dtype, noncontiguous=not is_fastpath) for i in range(N)
+                ],
+                [
+                    make_tensor((1, N - i), device=device, dtype=dtype, noncontiguous=not is_fastpath) for i in range(N)
+                ],
+            ]
+            self._pointwise_test(
+                wrapped_op, ref, inputs, is_fastpath and disable_fastpath, is_inplace=False, values=values)
+            self._pointwise_test(
+                inplace_op, inplace_ref, inputs, is_fastpath and disable_fastpath, is_inplace=True, values=values)
 
-        op, ref, inplace_op, inplace_ref = self._get_funcs(opinfo, n_expected_cudaLaunchKernels)
-        self._binary_test(dtype, op, ref, inputs, is_fastpath, is_inplace=False)
-        self._binary_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath, is_inplace=True)
-
-    @skipMeta
-    @ops(foreach_binary_op_db)
-    def test_binary_op_scalar_fastpath(self, device, dtype, op):
-        for N, scalar in itertools.product(N_values, Scalars):
-            disable_fastpath = op.ref == torch.div and dtype in integral_types_and(torch.bool)
-            if isinstance(scalar, int):
-                disable_fastpath |= dtype == torch.bool
-            if isinstance(scalar, float):
-                disable_fastpath |= dtype in integral_types_and(torch.bool)
-            if isinstance(scalar, bool):
-                disable_fastpath |= dtype == torch.bool
-                if op.ref in (torch.add, torch.mul, torch.clamp_max, torch.clamp_min):
-                    disable_fastpath = False
-            if isinstance(scalar, complex):
-                disable_fastpath |= dtype not in complex_types()
-            self._test_binary_op_scalar(device, dtype, op, N, scalar, True, disable_fastpath)
-
-    @ops(foreach_binary_op_db)
-    def test_binary_op_scalar_slowpath(self, device, dtype, op):
-        for N, scalar in itertools.product(N_values, Scalars):
-            self._test_binary_op_scalar(device, dtype, op, N, scalar, False, False)
-
-    def _test_binary_op_scalarlist(self, device, dtype, opinfo, N, scalarlist, is_fastpath, disable_fastpath):
-        n_expected_cudaLaunchKernels = N if disable_fastpath else 1
-        inputs = [opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath), scalarlist]
-
-        if disable_fastpath and opinfo.ref in [torch.clamp_min, torch.clamp_max] \
-                and torch.result_type(inputs[0][0], inputs[1][0]) != dtype:
-            n_expected_cudaLaunchKernels = N * 2  # fallback op launches 2 kernels on these cases
-
-        op, ref, inplace_op, inplace_ref = self._get_funcs(opinfo, n_expected_cudaLaunchKernels)
-
-        self._binary_test(dtype, op, ref, inputs, is_fastpath, is_inplace=False)
-        self._binary_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath, is_inplace=True)
-
-    # note(mkozuki): Why two functions depending on with/without bool?
-    # `foreach_sub` & `foreach_sub_` do `sub_check(tensors[i], scalars[i])` from i=1...N.
-    # So, if scalarlist has one or more bool values, `foreach_sub` and `foreach_sub_`
-    # raise bool subtraction error before doing any math.
-    # While regular `sub` and `sub_` do some math until they encounter bool.
-    # So, foreach sub's throw bool sub error first. However, regular sub's throw different
-    # errors depending on the order of scalarlist. To keep actual unit test impl simple,
-    # separating mixed scalarlist tests. By setting the first element of scalarlist to bool,
-    # they are expected to throw bool sub error even in inplace test.
-    @skipMeta
-    @ops(foreach_binary_op_db)
-    def test_binary_op_scalarlist_fastpath(self, device, dtype, op):
-        for N in N_values:
-            for type_str, scalarlist in getScalarLists(N):
-                bool_int_div = op.ref == torch.div and dtype in integral_types_and(torch.bool)
-                disable_fastpath = bool_int_div
-                if type_str == "int":
-                    disable_fastpath |= dtype == torch.bool
-                if type_str == "float":
-                    disable_fastpath |= dtype in integral_types_and(torch.bool)
-                if type_str == "complex":
-                    disable_fastpath |= dtype not in complex_types()
-                if type_str == "mixed":
-                    disable_fastpath |= True and dtype not in complex_types()
-                self._test_binary_op_scalarlist(device, dtype, op, N, scalarlist, True, disable_fastpath)
-
-    @ops(foreach_binary_op_db)
-    def test_binary_op_scalarlist_slowpath(self, device, dtype, op):
-        for N in N_values:
-            for _, scalarlist in getScalarLists(N):
-                self._test_binary_op_scalarlist(device, dtype, op, N, scalarlist, False, False)
-
-    def _pointwise_test(self, dtype, op, ref, inputs, is_fastpath, is_inplace, *, values=None, custom_values_err=None):
+    def _pointwise_test(self, op, ref, inputs, is_fastpath, is_inplace, *, values=None, custom_values_err=None):
         ref_inputs = [[t.clone().detach() for t in inputs[0]], inputs[1], inputs[2]] if is_inplace else inputs
         try:
             actual = op(inputs, self.is_cuda, is_fastpath)
@@ -291,99 +237,13 @@ class TestForeach(TestCase):
                 expected = ref(ref_inputs, values=values)
                 self.assertEqual(expected, actual)
 
-    def _test_pointwise_op(self, device, dtype, opinfo, N, is_fastpath, disable_fastpath, *, values=None, custom_values_err=None):
-        n_expected_cudaLaunchKernels = N if disable_fastpath else 1
-        op, ref, inplace_op, inplace_ref = self._get_funcs(opinfo, n_expected_cudaLaunchKernels)
-        inputs = [
-            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
-            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
-            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
-        ]
-        self._pointwise_test(dtype, op, ref, inputs, is_fastpath, is_inplace=False,
-                             values=values, custom_values_err=custom_values_err)
-        self._pointwise_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath,
-                             is_inplace=True, values=values, custom_values_err=custom_values_err)
-
-        # Tests of implicit broadcasting
-        inputs = [
-            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath, same_size=True),
-            [
-                make_tensor((N - i, 1), device=device, dtype=dtype, noncontiguous=not is_fastpath) for i in range(N)
-            ],
-            [
-                make_tensor((1, N - i), device=device, dtype=dtype, noncontiguous=not is_fastpath) for i in range(N)
-            ],
-        ]
-        self._pointwise_test(dtype, op, ref, inputs, is_fastpath and disable_fastpath,
-                             is_inplace=False, values=values, custom_values_err=custom_values_err)
-        self._pointwise_test(
-            dtype, inplace_op, inplace_ref, inputs, is_fastpath and disable_fastpath,
-            is_inplace=True, values=values, custom_values_err=custom_values_err)
-
-    @skipMeta
-    @ops(foreach_pointwise_op_db)
-    def test_pointwise_op_fastpath(self, device, dtype, op):
-        disable_fastpath = dtype in integral_types_and(torch.bool)
-        # for N, scalar in itertools.product(N_values, Scalars):
-        for N in N_values:
-            self._test_pointwise_op(device, dtype, op, N, True, disable_fastpath)
-            for scalar in Scalars:
-                self._test_pointwise_op(device, dtype, op, N, True, disable_fastpath, values=scalar)
-            for case, scalarlist in getScalarLists(N):
-                self._test_pointwise_op(
-                    device, dtype, op, N, True, disable_fastpath, values=scalarlist)
-                self._test_pointwise_op(
-                    device, dtype, op, N, True, disable_fastpath, values=torch.tensor(scalarlist))
-                self._test_pointwise_op(
-                    device, dtype, op, N, True, disable_fastpath, values=torch.tensor(scalarlist)[0],
-                    custom_values_err="Expected packed scalar Tensor to be of dimension 1. Got 0 instead.")
-                if device == "cuda":
-                    self._test_pointwise_op(
-                        device, dtype, op, N, True, disable_fastpath, values=torch.tensor(scalarlist, device="cuda"),
-                        custom_values_err="Expected scalars to be on CPU, got cuda:0 instead.")
-                self._test_pointwise_op(
-                    device, dtype, op, N, True, disable_fastpath, values=torch.tensor(scalarlist)[:2],
-                    custom_values_err=f"Expected length of scalars to match input of length {len(scalarlist)} but got 2 instead.")
-                self._test_pointwise_op(
-                    device, dtype, op, N, True, disable_fastpath, values=torch.tensor([[0, 1], [2, 3]])[:, 1],
-                    custom_values_err="Expected scalars to be contiguous.")
-
-    @ops(foreach_pointwise_op_db)
-    def test_pointwise_op_slowpath(self, device, dtype, op):
-        # for N, scalar in itertools.product(N_values, Scalars):
-        for N in N_values:
-            self._test_pointwise_op(device, dtype, op, N, False, False)
-            for scalar in Scalars:
-                self._test_pointwise_op(device, dtype, op, N, False, False, values=scalar)
-            for case, scalarlist in getScalarLists(N):
-                self._test_pointwise_op(
-                    device, dtype, op, N, False, False, values=scalarlist)
-                self._test_pointwise_op(
-                    device, dtype, op, N, False, False, values=torch.tensor(scalarlist))
-
-    # note(mkozuki): fastpath test uses dtypes which fastpath implementation supports.
-    # To confirm the dtypes of `OpInfo` cover the dtypes that the function support,
-    # this test does not use `try-except` for fastpath.
-    def _regular_unary_test(self, dtype, op, ref, inputs, is_fastpath):
-        if is_fastpath:
-            self.assertEqual(ref(inputs), op(inputs, self.is_cuda, is_fastpath))
-            return
-        try:
-            actual = op(inputs, self.is_cuda, is_fastpath)
-        except RuntimeError as e:
-            with self.assertRaisesRegex(type(e), re.escape(str(e))):
-                ref(inputs)
-        else:
-            expected = ref(inputs)
-            self.assertEqual(actual, expected)
-
     # note(mkozuki): why `try-except` for both fastpath?
     # - inputs for fastpath can be integer tensors.
-    #    - this is becase opinfo dtypes are configured for outpulace implementation
+    #    - this is because opinfo dtypes are configured for out-place implementation
     # - for integer inputs, trigonometric functions and exponential function returns float outputs,
     #   which causes "result type Float can't be case to the desired type" error.
     # Thus, `try-except` is used even if `is_fastpath` is `True`.
-    def _inplace_unary_test(self, dtype, inplace, inplace_ref, inputs, is_fastpath):
+    def _inplace_unary_test(self, inplace, inplace_ref, inputs, is_fastpath):
         copied_inputs = [[t.clone().detach() for t in tensors] for tensors in inputs]
         try:
             inplace(inputs, self.is_cuda, is_fastpath)
@@ -394,45 +254,80 @@ class TestForeach(TestCase):
             inplace_ref(copied_inputs),
             self.assertEqual(copied_inputs, inputs)
 
-    def _test_unary(self, device, dtype, opinfo, N, is_fastpath):
-        op, ref, inplace_op, inplace_ref = self._get_funcs(opinfo, 1)
-        inputs = opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
-        # note(mkozuki): Complex inputs for `_foreach_abs` go through slowpath.
-        if opinfo.name == "_foreach_abs" and dtype in complex_types():
-            is_fastpath = False
-        self._regular_unary_test(dtype, op, ref, inputs, is_fastpath)
-        self._inplace_unary_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath)
-
     @skipMeta
     @ops(foreach_unary_op_db)
-    def test_unary_fastpath(self, device, dtype, op):
-        for N in N_values:
-            self._test_unary(device, dtype, op, N, is_fastpath=True)
+    @parametrize("is_fastpath", (True, False))
+    def test_unary_op(self, device, dtype, op, is_fastpath):
+        wrapped_op, ref, inplace_op, inplace_ref = self._get_funcs(op, 1)
+        samples = op.sample_inputs(device, dtype)
+        disable_fastpath = op.name == "_foreach_abs" and dtype in complex_types()
+        for sample in samples:
+            if not is_fastpath:
+                sample = sample.noncontiguous()
+            inputs = [sample.input]
+            self.assertEqual(ref(inputs), wrapped_op(inputs, self.is_cuda, is_fastpath and not disable_fastpath))
+            self._inplace_unary_test(inplace_op, inplace_ref, [sample.input], is_fastpath and not disable_fastpath)
 
-    @ops(foreach_unary_op_db, dtypes=all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
-    def test_unary_slowpath(self, device, dtype, op):
-        for N in N_values:
-            self._test_unary(device, dtype, op, N, is_fastpath=False)
+    def _minmax_test(self, opinfo, inputs, is_fastpath, n_expected_cudaLaunchKernels):
+        op, ref, inplace_op, _ = self._get_funcs(opinfo, n_expected_cudaLaunchKernels)
+        expected = ref(inputs)
+        self.assertEqual(expected, op(inputs, self.is_cuda, is_fastpath))
 
-    def _reduce_test(self, opinfo, inputs, ord, is_fastpath, n_expected_cudaLaunchKernels):
-        op, ref, _, _ = self._get_funcs(opinfo, n_expected_cudaLaunchKernels)
-        self.assertEqual(ref(inputs, ord=ord), op(inputs, self.is_cuda, is_fastpath, ord=ord))
+        inplace_inputs = [[t.clone() for t in inputs[0]], inputs[1]]
+        inplace_op(inplace_inputs, self.is_cuda, is_fastpath)
+        self.assertEqual(expected, inplace_inputs[0])
 
-    @ops(foreach_reduce_op_db)
-    def test_reduce_fastpath(self, device, dtype, op):
-        for N, ord in itertools.product(N_values, (0, 1, 2, -1, -2)):
-            if ord in (1, 2) and dtype in floating_types_and(torch.half, torch.bfloat16):
-                n_expected_cudaLaunchKernels = 3
+    # note(crcrpar): `torch.maximum` and `torch.minimum` support `out` arg but there seem to be no inplace versions.
+    # So, compare `inplace_op` results with `ref`'s outputs.
+    @ops(foreach_minmax_op_db)
+    @parametrize("is_fastpath", (True, False))
+    def test_minmax_op(self, device, dtype, op, is_fastpath):
+        for sample in op.sample_inputs(device, dtype):
+            if not is_fastpath:
+                sample = sample.noncontiguous()
+            inputs = (sample.input, sample.args[0])
+            if is_fastpath:
+                n_expected_cudaLaunchKernels = 1 if dtype != torch.bool else len(inputs[0])
             else:
-                n_expected_cudaLaunchKernels = N
-            inputs = op.sample_inputs(device, dtype, N, noncontiguous=False),
-            self._reduce_test(op, inputs, ord, True, n_expected_cudaLaunchKernels)
+                n_expected_cudaLaunchKernels = len(inputs[0]) - 1
+            self._minmax_test(op, inputs, is_fastpath, n_expected_cudaLaunchKernels)
+
+    # note(mkozuki): ForeachFuncInfo's of both `_foreach_maximum` and `_foreach_minimum` include integer types.
+    # so, manually limit dtypes to fp types for inf&nan tests.
+    @ops(foreach_minmax_op_db, dtypes=floating_types_and(torch.half, torch.bfloat16))
+    def test_minmax_float_inf_nan(self, device, dtype, op):
+        inputs = (
+            [
+                torch.tensor([float('inf')], device=device, dtype=dtype),
+                torch.tensor([-float('inf')], device=device, dtype=dtype),
+                torch.tensor([float('nan')], device=device, dtype=dtype),
+                torch.tensor([float('nan')], device=device, dtype=dtype)
+            ],
+            [
+                torch.tensor([-float('inf')], device=device, dtype=dtype),
+                torch.tensor([float('inf')], device=device, dtype=dtype),
+                torch.tensor([float('inf')], device=device, dtype=dtype),
+                torch.tensor([float('nan')], device=device, dtype=dtype)
+            ],
+        )
+        self._minmax_test(op, inputs, True, 1)
 
     @ops(foreach_reduce_op_db)
-    def test_reduce_slowpath(self, device, dtype, op):
-        for N, ord in itertools.product(N_values, (0, 1, 2, -1, -2)):
-            inputs = op.sample_inputs(device, dtype, N, noncontiguous=True),
-            self._reduce_test(op, inputs, ord, False, 1)
+    @parametrize("is_fastpath", (True, False))
+    def test_reduce_op(self, device, dtype, op, is_fastpath):
+        for sample in op.sample_inputs(device, dtype):
+            if not is_fastpath:
+                sample = sample.noncontiguous()
+            ord = sample.kwargs.pop("ord")
+            disable_fastpath = sample.kwargs.pop("disable_fastpath", False)
+            if is_fastpath:
+                n_expected_cudaLaunchKernels = len(sample.input) if disable_fastpath else 3
+            else:
+                n_expected_cudaLaunchKernels = len(sample.input) - 1
+
+            inputs = (sample.input,)
+            wrapped_op, ref, _, _ = self._get_funcs(op, n_expected_cudaLaunchKernels)
+            self.assertEqual(ref(inputs, ord=ord), wrapped_op(inputs, self.is_cuda, is_fastpath, ord=ord))
 
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     def test_add_scalar_with_empty_list_and_empty_tensor(self, device, dtype):
@@ -607,7 +502,7 @@ class TestForeach(TestCase):
     def test_unary_op_tensors_on_different_devices(self, device, dtype, op):
         method, ref, inplace_method, ref_inplace = self._get_funcs(op, 1)
         # tensors: ['cuda', 'cpu]
-        tensors = op.sample_inputs(device, dtype, 2)
+        tensors = list(op.sample_inputs(device, dtype, num_input_tensors=[2]))[0].input
         tensors[1] = tensors[1].to('cpu')
         try:
             actual = method((tensors,), False, False)
@@ -631,8 +526,8 @@ class TestForeach(TestCase):
     def test_binary_op_tensors_on_different_devices(self, device, dtype, op):
         # `tensors1`: ['cuda', 'cpu']
         # `tensors2`: ['cuda', 'cpu']
-        _cuda_tensors = op.sample_inputs(device, dtype, 2, same_size=True)
-        _cpu_tensors = op.sample_inputs('cpu', dtype, 2, same_size=True)
+        _cuda_tensors = list(op.sample_inputs(device, dtype, num_input_tensors=[2], same_size=True))[0].input
+        _cpu_tensors = list(op.sample_inputs("cpu", dtype, num_input_tensors=[2], same_size=True))[0].input
         tensors1, tensors2 = list(tensors for tensors in zip(_cuda_tensors, _cpu_tensors))
 
         foreach_op, foreach_op_ = op.method_variant, op.inplace_variant
@@ -659,8 +554,8 @@ class TestForeach(TestCase):
         # tensors1: ['cuda', 'cpu]
         # tensors2: ['cuda', 'cpu]
         # tensors3: ['cuda', 'cpu]
-        _cuda_tensors = op.sample_inputs(device, dtype, 3, same_size=True)
-        _cpu_tensors = op.sample_inputs('cpu', dtype, 3, same_size=True)
+        _cuda_tensors = list(op.sample_inputs(device, dtype, num_input_tensors=[3], same_size=True))[0].input
+        _cpu_tensors = list(op.sample_inputs("cpu", dtype, num_input_tensors=[3], same_size=True))[0].input
         tensors1, tensors2, tensors3 = list(tensors for tensors in zip(_cuda_tensors, _cpu_tensors))
 
         foreach_op, foreach_op_, native_op = op.method_variant, op.inplace_variant, op.ref
@@ -680,7 +575,7 @@ class TestForeach(TestCase):
         ord, N = 2, 10
         max_value = torch.finfo(dtype).max
         scaler = torch.tensor([max_value]).sqrt().to(device=device, dtype=dtype)
-        inputs = [t * scaler for t in op.sample_inputs(device, dtype, N, noncontiguous=False, low=1)],
+        inputs = [t * scaler for t in list(op.sample_inputs(device, dtype, [N], low=1))[0].input],
         # make sure that the min. of squared L2 norm value per tensor is greater than the max value of `dtype`.
         self.assertTrue(scaler * scaler * N > max_value)
         fn, ref_fn, *_ = self._get_funcs(op, 3)
@@ -693,40 +588,36 @@ class TestForeach(TestCase):
             self.assertTrue(all(torch.isinf(e) for e in expect))
         self.assertEqual(expect, actual, equal_nan=False)
 
-    def _test_lerp_impl(self, device, dtype, opinfo, use_tensors_as_weight, N, is_fastpath):
-        op, ref, inplace_op, _ = self._get_funcs(opinfo, 1)
-        inputs = [
-            opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath)
-            for _ in range(2 + use_tensors_as_weight)
-        ]
-        weight = random.random() if not use_tensors_as_weight else None
-        kwargs = ref_kwargs = {} if use_tensors_as_weight else {"weight": weight}
-
-        if (
-            dtype in integral_types() or
-            dtype == torch.bool or
-            (not self.is_cuda and dtype == torch.half)
-        ):
-            with self.assertRaises(RuntimeError):
-                op(inputs, self.is_cuda, is_fastpath, **kwargs)
-            return
-        actual = op(inputs, self.is_cuda, is_fastpath, **kwargs)
-        expected = ref(inputs, **ref_kwargs)
-        self.assertEqual(actual, expected)
-
-        inplace_inputs = [[t.clone() for t in inputs[0]]] + inputs[1:]
-        inplace_actual = inplace_op(inplace_inputs, self.is_cuda, is_fastpath, **kwargs)
-        self.assertEqual(inplace_actual, expected)
-
+    @parametrize("is_fastpath", (True, False))
     @ops(foreach_lerp_op_db)
-    def test_lerp_fastpath(self, device, dtype, op):
-        for use_tensors_as_weight, N in itertools.product((True, False), N_values):
-            self._test_lerp_impl(device, dtype, op, use_tensors_as_weight, N, True)
+    def test_lerp(self, device, dtype, op, is_fastpath):
+        for sample in op.sample_inputs(device, dtype, noncontiguous=not is_fastpath):
+            wrapped_op, ref, inplace_op, _ = self._get_funcs(op, 1)
 
-    @ops(foreach_lerp_op_db, dtypes=all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
-    def test_lerp_slowpath(self, device, dtype, op):
-        for use_tensors_as_weight, N in itertools.product((True, False), N_values):
-            self._test_lerp_impl(device, dtype, op, use_tensors_as_weight, N, False)
+            args = [*sample.args]
+            inputs = [sample.input, args[0]]
+
+            kwargs, ref_kwargs = {}, {}
+            if isinstance(args[1], list):
+                inputs.append(args[1])
+            else:
+                kwargs = ref_kwargs = {"weight": args[1]}
+
+            if (
+                dtype in integral_types() or
+                dtype == torch.bool or
+                (not self.is_cuda and dtype == torch.half)
+            ):
+                with self.assertRaises(RuntimeError):
+                    wrapped_op(inputs, self.is_cuda, is_fastpath, **kwargs)
+                return
+            actual = wrapped_op(inputs, self.is_cuda, is_fastpath, **kwargs)
+            expected = ref(inputs, **ref_kwargs)
+            self.assertEqual(actual, expected)
+
+            inplace_inputs = [[t.clone() for t in inputs[0]]] + inputs[1:]
+            inplace_actual = inplace_op(inplace_inputs, self.is_cuda, is_fastpath, **kwargs)
+            self.assertEqual(inplace_actual, expected)
 
 instantiate_device_type_tests(TestForeach, globals())
 

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1,4 +1,4 @@
-# Owner(s): ["modiule: mta"]
+# Owner(s): ["module: mta"]
 
 from numbers import Number
 import random

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -32,7 +32,7 @@ from torch.testing._internal.common_utils import (
     make_fullrank_matrices_with_distinct_singular_values,
     TEST_WITH_ROCM, IS_WINDOWS, IS_MACOS, TEST_SCIPY,
     torch_to_numpy_dtype_dict, TEST_WITH_ASAN,
-    GRADCHECK_NONDET_TOL, freeze_rng_state, slowTest
+    GRADCHECK_NONDET_TOL, freeze_rng_state, slowTest, TEST_WITH_SLOW
 )
 
 import torch._refs as refs  # noqa: F401

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7918,6 +7918,14 @@ foreach_reduce_op_db: List[ForeachFuncInfo] = [
     ),
 ]
 
+foreach_lerp_op_db: List[ForeachFuncInfo] = [
+    ForeachFuncInfo(
+        "lerp",
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
+        dtypesIfROCM=floating_and_complex_types_and(torch.half, torch.bfloat16),
+    ),
+]
+
 def reference_sign(x):
     if x.dtype == np.bool_:
         # `np.sign` doesn't support `bool`.

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7,6 +7,7 @@ import operator
 import random
 import unittest
 import math
+import enum
 
 import torch
 import numpy as np
@@ -7733,98 +7734,324 @@ def sample_inputs_max_unpool_grad(op_info, device, dtype, requires_grad, **kwarg
         if indices.unique().numel() == indices.numel():
             yield sample
 
+
+# Includes some values such that N * N won't be a multiple of 4,
+# which should ensure we test the vectorized and non-vectorized
+# kernel code paths.
+foreach_num_tensors = [20, 23] if not TEST_WITH_SLOW else [23, 30, 300]
+class ForeachRightmostArgType(enum.Enum):
+    TensorList = 1
+    ScalarList = 2
+    Scalar = 3
+foreach_scalars = (
+    random.randint(1, 10),
+    1.0 - random.random(),
+    True,
+    complex(1.0 - random.random(), 1.0 - random.random()),
+)
+_foreach_inputs_default_kwargs = {"noncontiguous": False, "same_size": False, "low": None, "high": None}
+# TODO(crcrpar): Update to return `n_expected_cudaLaunchKernels` as well
+class foreach_inputs_sample_func:
+    def __init__(
+        self,
+        arity: int,
+        rightmost_supports_scalar: bool,
+        rightmost_supports_scalarlist: bool,
+    ) -> None:
+        self.arity = arity
+        self._set_rightmost_arg_types(rightmost_supports_scalar, rightmost_supports_scalarlist)
+
+    def _set_rightmost_arg_types(
+        self,
+        rightmost_supports_scalar: bool,
+        rightmost_supports_scalarlist: bool,
+    ) -> None:
+        self._rightmost_arg_types = [ForeachRightmostArgType.TensorList]
+        if self.arity > 1:
+            if rightmost_supports_scalar:
+                self._rightmost_arg_types.append(ForeachRightmostArgType.Scalar)
+            if rightmost_supports_scalarlist:
+                self._rightmost_arg_types.append(ForeachRightmostArgType.ScalarList)
+
+    def _sample_rightmost_arg(self, rightmost_arg_type, device, dtype, num_tensors, **_foreach_inputs_kwargs):
+        if rightmost_arg_type == ForeachRightmostArgType.TensorList:
+            return [sample_inputs_foreach(None, device, dtype, num_tensors, **_foreach_inputs_kwargs)]
+        if rightmost_arg_type == ForeachRightmostArgType.ScalarList:
+            return [
+                [random.randint(0, 9) + 1 for _ in range(num_tensors)],
+                [1.0 - random.random() for _ in range(num_tensors)],
+                [complex(1.0 - random.random(), 1.0 - random.random()) for _ in range(num_tensors)],
+                [True for _ in range(num_tensors)],
+                [1, 2.0, 3.0 + 4.5j] + [3.0 for _ in range(num_tensors - 3)],
+                [True, 1, 2.0, 3.0 + 4.5j] + [3.0 for _ in range(num_tensors - 4)],
+            ]
+        if rightmost_arg_type == ForeachRightmostArgType.Scalar:
+            return foreach_scalars
+        raise AssertionError(f"Invalid rightmost_arg_type of {rightmost_arg_type}")
+
+    def _should_disable_fastpath(self, opinfo, rightmost_arg, rightmost_arg_type, dtype):
+        if self.arity < 2:
+            return None
+        if rightmost_arg_type == ForeachRightmostArgType.TensorList:
+            disable_fastpath = "foreach_div" in opinfo.name and dtype in integral_types_and(torch.bool)
+            if "foreach_add" in opinfo.name and dtype == torch.bool:
+                disable_fastpath = True
+            return disable_fastpath
+        elif rightmost_arg_type == ForeachRightmostArgType.Scalar:
+            disable_fastpath = "foreach_div" in opinfo.name and dtype in integral_types_and(torch.bool)
+            if isinstance(rightmost_arg, bool):
+                disable_fastpath |= dtype == torch.bool
+                if opinfo.ref in (torch.add, torch.mul):
+                    disable_fastpath = False
+            elif isinstance(rightmost_arg, int):
+                disable_fastpath |= dtype == torch.bool
+            elif isinstance(rightmost_arg, float):
+                disable_fastpath |= dtype in integral_types_and(torch.bool)
+            elif isinstance(rightmost_arg, complex):
+                disable_fastpath |= dtype not in complex_types()
+            else:
+                raise AssertionError(f"Invalid scalar of type {rightmost_arg_type = } - {rightmost_arg = }")
+            return disable_fastpath
+        elif rightmost_arg_type == ForeachRightmostArgType.ScalarList:
+            disable_fastpath = opinfo.ref == torch.div and dtype in integral_types_and(torch.bool)
+            elmt_t = type(rightmost_arg[0])
+            has_same_type = all(isinstance(v, elmt_t) for v in rightmost_arg)
+            if not has_same_type:
+                return dtype not in complex_types()
+            if isinstance(rightmost_arg[0], bool):
+                if ("foreach_add" in opinfo.name or "foreach_mul" in opinfo.name) and dtype == torch.bool:
+                    disable_fastpath = False
+            elif isinstance(rightmost_arg[0], int):
+                disable_fastpath |= dtype == torch.bool
+            elif isinstance(rightmost_arg[0], float):
+                disable_fastpath |= dtype in integral_types_and(torch.bool)
+            elif isinstance(rightmost_arg[0], complex):
+                disable_fastpath |= dtype not in complex_types()
+            else:
+                raise AssertionError(f"Invalid scalarlist of {rightmost_arg}")
+            return disable_fastpath
+        else:
+            raise AssertionError(f"Invalid rightmost_arg_type of {rightmost_arg_type}")
+
+    def _sample_kwargs(self, opinfo, rightmost_arg, rightmost_arg_type, dtype):
+        kwargs = {}
+        if rightmost_arg_type == ForeachRightmostArgType.TensorList and opinfo.supports_alpha_param:
+            if dtype in integral_types_and(torch.bool):
+                kwargs["alpha"] = 3
+            elif dtype.is_complex:
+                kwargs["alpha"] = complex(3, 3)
+            else:
+                kwargs["alpha"] = 3.14
+        if self.arity > 1:
+            kwargs["disable_fastpath"] = self._should_disable_fastpath(opinfo, rightmost_arg, rightmost_arg_type, dtype)
+        return kwargs
+
+    def __call__(self, opinfo, device, dtype, requires_grad, **kwargs):
+        num_input_tensors = kwargs.pop("num_input_tensors", foreach_num_tensors)
+        assert isinstance(num_input_tensors, list)
+        _foreach_inputs_kwargs = {k: kwargs.pop(k, v) for k, v in _foreach_inputs_default_kwargs.items()}
+
+        for num_tensors in num_input_tensors:
+            for rightmost_arg_type in self._rightmost_arg_types:
+                input = sample_inputs_foreach(None, device, dtype, num_tensors, **_foreach_inputs_kwargs)
+                args = []
+                kwargs = {}
+                if self.arity > 1:
+                    args = [
+                        sample_inputs_foreach(None, device, dtype, num_tensors, **_foreach_inputs_kwargs)
+                        for _ in range(self.arity - 2)
+                    ]
+                    rightmost_arg_list = self._sample_rightmost_arg(
+                        rightmost_arg_type, device, dtype, num_tensors, **_foreach_inputs_kwargs)
+                    for rightmost_arg in rightmost_arg_list:
+                        args.append(rightmost_arg)
+                        kwargs = self._sample_kwargs(opinfo, rightmost_arg, rightmost_arg_type, dtype)
+                        yield SampleInput(input, *args, **kwargs)
+                        args.pop()
+                else:
+                    yield SampleInput(input, *args, **kwargs)
+
+
+class foreach_norm_sample_func(foreach_inputs_sample_func):
+    def __call__(self, opinfo, device, dtype, requires_grad, **kwargs):
+        num_input_tensors = kwargs.pop("num_input_tensors", foreach_num_tensors)
+        assert isinstance(num_input_tensors, list)
+        _foreach_inputs_kwargs = {k: kwargs.pop(k, v) for k, v in _foreach_inputs_default_kwargs.items()}
+
+        for num_tensors, ord in product(num_input_tensors, (0, 1, 2, -1, -2)):
+            input = sample_inputs_foreach(None, device, dtype, num_tensors, **_foreach_inputs_kwargs)
+            disable_fastpath = True
+            if ord in (1, 2) and dtype in floating_types_and(torch.half, torch.bfloat16):
+                disable_fastpath = False
+            yield SampleInput(input, **{"ord": ord, "disable_fastpath": disable_fastpath})
+
+
+class foreach_lerp_sample_func(foreach_inputs_sample_func):
+    def _sample_rightmost_arg(self, rightmost_arg_type, device, dtype, num_tensors, **_foreach_inputs_kwargs):
+        if rightmost_arg_type == ForeachRightmostArgType.TensorList:
+            return [sample_inputs_foreach(None, device, dtype, num_tensors, **_foreach_inputs_kwargs)]
+        if rightmost_arg_type == ForeachRightmostArgType.ScalarList:
+            return [
+                [random.randint(0, 9) + 1 for _ in range(num_tensors)],
+                [1.0 - random.random() for _ in range(num_tensors)],
+                [complex(1.0 - random.random(), 1.0 - random.random()) for _ in range(num_tensors)],
+                [True for _ in range(num_tensors)],
+                [1, 2.0, 3.0 + 4.5j] + [3.0 for _ in range(num_tensors - 3)],
+                [True, 1, 2.0, 3.0 + 4.5j] + [3.0 for _ in range(num_tensors - 4)],
+            ]
+        if rightmost_arg_type == ForeachRightmostArgType.Scalar:
+            return [random.random()]
+        raise AssertionError(f"Invalid rightmost_arg_type of {rightmost_arg_type}")
+
+
+
+class foreach_pointwise_sample_func(foreach_inputs_sample_func):
+
+    def __init__(
+        self,
+        arity: int = 3,
+        rightmost_supports_scalar: bool = False,
+        rightmost_supports_scalarlist: bool = False,
+    ):
+        super().__init__(3 + 1, True, True)
+
+    def _should_disable_fastpath(self, opinfo, rightmost_arg, rightmost_arg_type, dtype):
+        return dtype in integral_types_and(torch.bool)
+
+    def __call__(self, opinfo, device, dtype, requires_grad, **kwargs):
+        num_input_tensors = kwargs.pop("num_input_tensors", foreach_num_tensors)
+        assert isinstance(num_input_tensors, list)
+        _foreach_inputs_kwargs = {k: kwargs.pop(k, v) for k, v in _foreach_inputs_default_kwargs.items()}
+
+        for num_tensors in num_input_tensors:
+            for rightmost_arg_type in self._rightmost_arg_types:
+                input = sample_inputs_foreach(None, device, dtype, num_tensors, **_foreach_inputs_kwargs)
+                args = [
+                    sample_inputs_foreach(None, device, dtype, num_tensors, **_foreach_inputs_kwargs)
+                    for _ in range(2 - int(rightmost_arg_type == ForeachRightmostArgType.TensorList))
+                ]
+                rightmost_arg_list = self._sample_rightmost_arg(
+                    rightmost_arg_type, device, dtype, num_tensors, **_foreach_inputs_kwargs)
+                for rightmost_arg in rightmost_arg_list:
+                    kwargs = {}
+                    if rightmost_arg_type == ForeachRightmostArgType.TensorList:
+                        args.append(rightmost_arg)
+                        kwargs["values"] = None
+                    else:
+                        kwargs["values"] = rightmost_arg
+                    kwargs.update(
+                        self._sample_kwargs(
+                            opinfo, kwargs["values"] or rightmost_arg, rightmost_arg_type, dtype)
+                    )
+                    assert hasattr(kwargs, "values")
+                    assert len(args) == 2
+                    yield SampleInput(input, *args, **kwargs)
+
+
 foreach_unary_op_db: List[OpInfo] = [
-    ForeachFuncInfo('exp'),
-    ForeachFuncInfo('acos'),
-    ForeachFuncInfo('asin'),
-    ForeachFuncInfo('atan'),
-    ForeachFuncInfo('cos'),
-    ForeachFuncInfo('cosh'),
-    ForeachFuncInfo('log'),
-    ForeachFuncInfo('log10'),
-    ForeachFuncInfo('log2'),
-    ForeachFuncInfo('tan'),
-    ForeachFuncInfo('tanh'),
-    ForeachFuncInfo('sin'),
-    ForeachFuncInfo('sinh'),
+    ForeachFuncInfo('exp', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('acos', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('asin', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('atan', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('cos', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('cosh', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('log', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('log10', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('log2', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('tan', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('tanh', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('sin', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
+    ForeachFuncInfo('sinh', sample_inputs_func=foreach_inputs_sample_func(1, False, False)),
 
     ForeachFuncInfo(
         'neg',
         dtypes=all_types_and_complex(),
         dtypesIfCUDA=all_types_and_complex(),
-        sample_inputs_func=sample_inputs_foreach,
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'sqrt',
         dtypes=floating_and_complex_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_and_complex_types_and(torch.half),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'ceil',
         dtypes=all_types_and(torch.bfloat16),
         dtypesIfCUDA=all_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'erf',
         dtypes=floating_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'erfc',
         dtypes=floating_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'expm1',
         dtypes=floating_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'floor',
         dtypes=all_types_and(torch.bfloat16),
         dtypesIfCUDA=all_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'log1p',
         dtypes=floating_and_complex_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_and_complex_types_and(torch.half),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'round',
         dtypes=all_types_and(torch.bfloat16),
         dtypesIfCUDA=all_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'frac',
         dtypes=floating_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'reciprocal',
         dtypes=floating_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.half),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'sigmoid',
         dtypes=floating_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.half),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
         'trunc',
         dtypes=all_types_and(torch.bfloat16),
         dtypesIfCUDA=all_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 
     ForeachFuncInfo(
@@ -7833,6 +8060,7 @@ foreach_unary_op_db: List[OpInfo] = [
         dtypesIfCUDA=all_types_and_complex_and(torch.bfloat16, torch.half, torch.bool),
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
+        sample_inputs_func=foreach_inputs_sample_func(1, False, False),
     ),
 ]
 
@@ -7842,12 +8070,14 @@ foreach_binary_op_db: List[OpInfo] = [
         dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
         dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
         supports_alpha_param=True,
+        sample_inputs_func=foreach_inputs_sample_func(2, True, True),
     ),
     ForeachFuncInfo(
         "sub",
         dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
         dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
         supports_alpha_param=True,
+        sample_inputs_func=foreach_inputs_sample_func(2, True, True),
     ),
     ForeachFuncInfo(
         "mul",
@@ -7858,7 +8088,8 @@ foreach_binary_op_db: List[OpInfo] = [
             DecorateInfo(unittest.skip("Unable to reproduce failure locally"), "TestForeach",
                          "test_binary_op_scalarlist_fastpath",
                          device_type='cuda', dtypes=(torch.float16,)),
-        )
+        ),
+        sample_inputs_func=foreach_inputs_sample_func(2, True, True),
     ),
     ForeachFuncInfo(
         "div",
@@ -7869,7 +8100,8 @@ foreach_binary_op_db: List[OpInfo] = [
             DecorateInfo(unittest.skip("Unable to reproduce failure locally"), "TestForeach",
                          "test_binary_op_scalarlist_fastpath",
                          device_type='cuda', dtypes=(torch.float16,)),
-        )
+        ),
+        sample_inputs_func=foreach_inputs_sample_func(2, True, True),
     ),
     ForeachFuncInfo(
         "clamp_min",
@@ -7902,19 +8134,40 @@ foreach_pointwise_op_db: List[ForeachFuncInfo] = [
         "addcmul",
         dtypes=all_types_and_complex(),
         dtypesIfCUDA=all_types_and_complex_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_pointwise_sample_func(3, False, False),
     ),
     ForeachFuncInfo(
         "addcdiv",
         dtypes=all_types_and_complex(),
         dtypesIfCUDA=all_types_and_complex_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_pointwise_sample_func(3, False, False),
     ),
 ]
 
+<<<<<<< HEAD
+=======
+foreach_minmax_op_db: List[ForeachFuncInfo] = [
+    ForeachFuncInfo(
+        "maximum",
+        dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
+        dtypesIfCUDA=all_types_and(torch.float16, torch.bool),
+        sample_inputs_func=foreach_inputs_sample_func(2, False, False),
+    ),
+    ForeachFuncInfo(
+        "minimum",
+        dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
+        dtypesIfCUDA=all_types_and(torch.float16, torch.bool),
+        sample_inputs_func=foreach_inputs_sample_func(2, False, False),
+    ),
+]
+
+>>>>>>> bdc5db8548... Use `SampleInput` for `test_foreach.py`
 foreach_reduce_op_db: List[ForeachFuncInfo] = [
     ForeachFuncInfo(
         "norm",
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
         dtypesIfCUDA=floating_and_complex_types_and(torch.float16, torch.bfloat16),
+        sample_inputs_func=foreach_norm_sample_func(1, False, False),
     ),
 ]
 
@@ -7923,6 +8176,7 @@ foreach_lerp_op_db: List[ForeachFuncInfo] = [
         "lerp",
         dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
         dtypesIfROCM=floating_and_complex_types_and(torch.half, torch.bfloat16),
+        sample_inputs_func=foreach_lerp_sample_func(3, True, False),
     ),
 ]
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7810,7 +7810,7 @@ class foreach_inputs_sample_func:
             elif isinstance(rightmost_arg, complex):
                 disable_fastpath |= dtype not in complex_types()
             else:
-                raise AssertionError(f"Invalid scalar of type {rightmost_arg_type = } - {rightmost_arg = }")
+                raise AssertionError(f"Invalid scalar of type {rightmost_arg_type} - {rightmost_arg}")
             return disable_fastpath
         elif rightmost_arg_type == ForeachRightmostArgType.ScalarList:
             disable_fastpath = opinfo.ref == torch.div and dtype in integral_types_and(torch.bool)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8096,24 +8096,28 @@ foreach_binary_op_db: List[OpInfo] = [
         dtypes=all_types_and(torch.bfloat16),
         dtypesIfCUDA=all_types_and(torch.bfloat16, torch.float16),
         supports_alpha_param=False,
+        sample_inputs_func=foreach_inputs_sample_func(2, True, True),
     ),
     ForeachFuncInfo(
         "clamp_max",
         dtypes=all_types_and(torch.bfloat16),
         dtypesIfCUDA=all_types_and(torch.bfloat16, torch.float16),
         supports_alpha_param=False,
+        sample_inputs_func=foreach_inputs_sample_func(2, True, True),
     ),
     ForeachFuncInfo(
         "minimum",
         dtypes=all_types_and(torch.bfloat16),
         dtypesIfCUDA=all_types_and(torch.bfloat16, torch.float16),
         supports_alpha_param=False,
+        sample_inputs_func=foreach_inputs_sample_func(2, True, True),
     ),
     ForeachFuncInfo(
         "maximum",
         dtypes=all_types_and(torch.bfloat16),
         dtypesIfCUDA=all_types_and(torch.bfloat16, torch.float16),
         supports_alpha_param=False,
+        sample_inputs_func=foreach_inputs_sample_func(2, True, True),
     ),
 ]
 
@@ -8132,24 +8136,6 @@ foreach_pointwise_op_db: List[ForeachFuncInfo] = [
     ),
 ]
 
-<<<<<<< HEAD
-=======
-foreach_minmax_op_db: List[ForeachFuncInfo] = [
-    ForeachFuncInfo(
-        "maximum",
-        dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-        dtypesIfCUDA=all_types_and(torch.float16, torch.bool),
-        sample_inputs_func=foreach_inputs_sample_func(2, False, False),
-    ),
-    ForeachFuncInfo(
-        "minimum",
-        dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-        dtypesIfCUDA=all_types_and(torch.float16, torch.bool),
-        sample_inputs_func=foreach_inputs_sample_func(2, False, False),
-    ),
-]
-
->>>>>>> bdc5db8548... Use `SampleInput` for `test_foreach.py`
 foreach_reduce_op_db: List[ForeachFuncInfo] = [
     ForeachFuncInfo(
         "norm",

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8083,24 +8083,12 @@ foreach_binary_op_db: List[OpInfo] = [
         "mul",
         dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
         dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
-        skips=(
-            # Ref: https://github.com/pytorch/pytorch/issues/77946
-            DecorateInfo(unittest.skip("Unable to reproduce failure locally"), "TestForeach",
-                         "test_binary_op_scalarlist_fastpath",
-                         device_type='cuda', dtypes=(torch.float16,)),
-        ),
         sample_inputs_func=foreach_inputs_sample_func(2, True, True),
     ),
     ForeachFuncInfo(
         "div",
         dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
         dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
-        skips=(
-            # Ref: https://github.com/pytorch/pytorch/issues/77946
-            DecorateInfo(unittest.skip("Unable to reproduce failure locally"), "TestForeach",
-                         "test_binary_op_scalarlist_fastpath",
-                         device_type='cuda', dtypes=(torch.float16,)),
-        ),
         sample_inputs_func=foreach_inputs_sample_func(2, True, True),
     ),
     ForeachFuncInfo(


### PR DESCRIPTION
As per title.

- [ ] ~~Q: Do we want `torch._foreach_lerp.ScalarList` as well?~~
- [ ] ~~we might want to have `ATen/native/cuda/lerp.cuh` and include it in `ATen/native/cuda/Lerp.cu` and `ATen/native/cuda/ForeachTernaryOp.cu`~~

Related:
- https://github.com/pytorch/pytorch/issues/58833
- https://github.com/pytorch/pytorch/issues/71683

cc @vadimkantorov @ptrblck 