### PR TITLE
Update Reviewers for CPU-related Modules

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -272,6 +272,7 @@
   - aten/src/ATen/native/quantized/cpu/**
   - aten/src/ATen/native/Convolution*.cpp
   - aten/src/ATen/native/mkldnn/**
+  - test/test_mkldnn.py
   approved_by:
   - mingfeima
   - XiaobingSuper

--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -247,7 +247,6 @@
   - XiaobingSuper
   - jgong5
   - mingfeima
-  - ashokei
   mandatory_checks_name:
   - EasyCLA
   - Lint

--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -241,9 +241,13 @@
   - third_party/ideep
   - caffe2/ideep/**
   - caffe2/python/ideep/**
+  - cmake/Modules/FindMKLDNN.cmake
+  - third_party/mkl-dnn.BUILD
   approved_by:
   - XiaobingSuper
-  - yanbing-j
+  - jgong5
+  - mingfeima
+  - ashokei
   mandatory_checks_name:
   - EasyCLA
   - Lint
@@ -256,6 +260,7 @@
   approved_by:
   - sanchitintel
   - chunyuan-w
+  - jgong5
   mandatory_checks_name:
   - EasyCLA
   - Lint
@@ -271,6 +276,7 @@
   approved_by:
   - mingfeima
   - XiaobingSuper
+  - jgong5
   mandatory_checks_name:
   - EasyCLA
   - Lint
@@ -283,7 +289,7 @@
   - test/test_mkldnn.py
   approved_by:
   - leslie-fang-intel
-  - CaoE
+  - jgong5
   mandatory_checks_name:
   - EasyCLA
   - Lint
@@ -297,7 +303,18 @@
   - test/test_autocast.py
   approved_by:
   - leslie-fang-intel
-  - CaoE
+  - jgong5
+  mandatory_checks_name:
+  - EasyCLA
+  - Lint
+  - pull
+
+- name: NNC
+  patterns:
+  - torch/csrc/jit/tensorexpr/**
+  approved_by:
+  - EikanWang
+  - jgong5
   mandatory_checks_name:
   - EasyCLA
   - Lint


### PR DESCRIPTION
This PR updates the reviewers responsible for CPU related modules: "IDEEP", "oneDNN graph", "CPU ATen backend", "CPU frontend" and "Autocast". It also adds "NNC" and adds the corresponding reviewers.
