### PR TITLE
cpp docs push fix

### DIFF
--- a/.circleci/scripts/cpp_doc_push_script.sh
+++ b/.circleci/scripts/cpp_doc_push_script.sh
@@ -98,10 +98,7 @@ git commit -m "Generate C++ docs from pytorch/pytorch@${GITHUB_SHA}" || true
 git status
 
 if [[ "${WITH_PUSH:-}" == true ]]; then
-  # push to a temp branch first to trigger CLA check and satisfy branch protections
-  git push -u origin HEAD:pytorchbot/temp-branch-cpp -f
-  sleep 30
-  git push -u origin master
+  git push -u origin
 fi
 
 popd

--- a/.circleci/scripts/cpp_doc_push_script.sh
+++ b/.circleci/scripts/cpp_doc_push_script.sh
@@ -101,7 +101,7 @@ if [[ "${WITH_PUSH:-}" == true ]]; then
   # push to a temp branch first to trigger CLA check and satisfy branch protections
   git push -u origin HEAD:pytorchbot/temp-branch-cpp -f
   sleep 30
-  git push -u origin
+  git push -u origin master
 fi
 
 popd


### PR DESCRIPTION
currently failing with
```
To https://github.com/pytorch/cppdocs
 + 2825b2745bb...80ec4daa657 HEAD -> pytorchbot/temp-branch-cpp (forced update)
Branch 'master' set up to track remote branch 'pytorchbot/temp-branch-cpp' from 'origin'.
++ sleep 30
++ git push -u origin
fatal: The upstream branch of your current branch does not match
the name of your current branch.  To push to the upstream branch
on the remote, use

    git push origin HEAD:pytorchbot/temp-branch-cpp

To push to the branch of the same name on the remote, use

    git push origin HEAD

```

just checked the settings, master of pytorch/cppdocs does not have easy cla as a required check, so we don't need the temp branch 