### PR TITLE
Fix torch.testing.assert_close not exported from module

### DIFF
--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -1,4 +1,4 @@
-from ._comparison import assert_close
-from torch._C import FileCheck
-from ._creation import make_tensor
+from ._comparison import assert_close as assert_close
+from torch._C import FileCheck as FileCheck
+from ._creation import make_tensor as make_tensor
 from ._deprecated import *  # noqa: F403


### PR DESCRIPTION
For pylance/pyright static typechecking
"Imported symbols are considered private by default. If they use the “import A as A” (a redundant module alias), “from X import A as A” (a redundant symbol alias)" https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#library-interface

torch.testing.assert_close not exported from module https://github.com/microsoft/pylance-release/issues/3526

Fixes #ISSUE_NUMBER
