### PR TITLE
[pytorch][nnc][static runtime] Do not use NNC if LLVM newer than 12.0

### DIFF
--- a/torch/csrc/jit/runtime/static/te_wrapper.cpp
+++ b/torch/csrc/jit/runtime/static/te_wrapper.cpp
@@ -19,7 +19,7 @@ using namespace torch::jit::tensorexpr;
 // contains FP divide, which is single-ported.
 static constexpr int kVectorWidth = 16;
 
-#ifdef TORCH_ENABLE_LLVM
+#ifdef STATIC_RUNTIME_USE_LLVM
 
 void TEWrapper::update(std::unique_ptr<LLVMCodeGen>&& cg_) {
   cg = std::move(cg_);

--- a/torch/csrc/jit/runtime/static/te_wrapper.h
+++ b/torch/csrc/jit/runtime/static/te_wrapper.h
@@ -6,6 +6,13 @@
 #include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
 
+#ifdef TORCH_ENABLE_LLVM
+#include <llvm/Config/llvm-config.h>
+#if LLVM_VERSION_MAJOR <= 12
+#define STATIC_RUNTIME_USE_LLVM 1
+#endif
+#endif
+
 namespace torch {
 namespace jit {
 
@@ -16,19 +23,19 @@ class TEWrapper {
 
   template <typename ExpectedType>
   bool checkInput(const at::Tensor& t) {
-#ifdef TORCH_ENABLE_LLVM
+#ifdef STATIC_RUNTIME_USE_LLVM
     return t.is_contiguous() && t.dtype().Match<ExpectedType>();
 #else
     return false;
 #endif
   }
 
-#ifdef TORCH_ENABLE_LLVM
+#ifdef STATIC_RUNTIME_USE_LLVM
   void update(std::unique_ptr<tensorexpr::LLVMCodeGen>&& cg_);
 #endif
 
  private:
-#ifdef TORCH_ENABLE_LLVM
+#ifdef STATIC_RUNTIME_USE_LLVM
   std::unique_ptr<tensorexpr::LLVMCodeGen> cg;
 #endif
 };


### PR DESCRIPTION
Summary:
NNC's LLVM JIT crashes with LLVM 15; since NNC is deprecated, let's
just not fix it.

Test Plan: `buck test mode/dev-nosan //caffe2/test:static_runtime`

Differential Revision: D40664404

