### PR TITLE
[ONNX] Expand `_cast_` symbolic functions

### DIFF
--- a/torch/onnx/_deprecation.py
+++ b/torch/onnx/_deprecation.py
@@ -23,7 +23,7 @@ def deprecated(since: str, removed_in: str, instructions: str):
             warnings.warn(
                 f"'{function.__module__}.{function.__name__}' "
                 f"is deprecated in version {since} and will be "
-                f"removed in version {removed_in}. Please {instructions}.",
+                f"removed in {removed_in}. Please {instructions}.",
                 category=FutureWarning,
                 stacklevel=2,
             )

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -600,7 +600,7 @@ def fake_quantize_per_tensor_affine(
 @_onnx_symbolic("aten::isinf")
 @_beartype.beartype
 def isinf(g: jit_utils.GraphContext, input):
-    return g.op("IsInf", opset9._cast_Double(g, input, False))  # type: ignore[attr-defined]
+    return g.op("IsInf", g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.DOUBLE))
 
 
 @_onnx_symbolic("aten::isfinite")

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -167,7 +167,10 @@ def _try_cast_integer_to_float(g: jit_utils.GraphContext, *args):
     if arg0_type is not None:
         old_type = arg0_type
         if old_type not in floating_scalar_types:
-            args = tuple(g.op("Cast", arg, to_i=_C_onnx.TensorProtoDataType.FLOAT) for arg in args)
+            args = tuple(
+                g.op("Cast", arg, to_i=_C_onnx.TensorProtoDataType.FLOAT)
+                for arg in args
+            )
         else:
             return (None,) + args
     else:

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -34,6 +34,7 @@ import functools
 import warnings
 
 import torch
+from torch._C import _onnx as _C_onnx
 from torch.onnx import _type_utils, errors, symbolic_helper, symbolic_opset9 as opset9
 from torch.onnx._internal import jit_utils, registration
 
@@ -166,11 +167,7 @@ def _try_cast_integer_to_float(g: jit_utils.GraphContext, *args):
     if arg0_type is not None:
         old_type = arg0_type
         if old_type not in floating_scalar_types:
-            # TODO(justinchuby): Remove the type ignore hint once _cast_Float is
-            # properly defined.
-            # NOTE: _cast_Float is generated programmatically so we need to make the
-            # type checker happy with ignore[attr-defined].
-            args = tuple(opset9._cast_Float(g, arg, False) for arg in args)  # type: ignore[attr-defined]
+            args = tuple(g.op("Cast", arg, to_i=_C_onnx.TensorProtoDataType.FLOAT) for arg in args)
         else:
             return (None,) + args
     else:

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -19,6 +19,7 @@ from torch import _C
 # Monkey-patch graph manipulation methods on Graph, used for the ONNX symbolics
 from torch.onnx import (  # noqa: F401
     _constants,
+    _deprecation,
     _patch_torch,
     _type_utils,
     errors,
@@ -3377,54 +3378,99 @@ def _unique2(g: jit_utils.GraphContext, input, sorted, return_inverse, return_co
 
 
 @_onnx_symbolic("aten::_cast_Byte")
+@_deprecation.deprecated(
+    "1.14",
+    "the future",
+    "Avoid using this function and create a Cast node instead",
+)
 @_beartype.beartype
 def _cast_Byte(g: jit_utils.GraphContext, input, non_blocking):
     return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.UINT8)
 
 
 @_onnx_symbolic("aten::_cast_Char")
+@_deprecation.deprecated(
+    "1.14",
+    "the future",
+    "Avoid using this function and create a Cast node instead",
+)
 @_beartype.beartype
 def _cast_Char(g: jit_utils.GraphContext, input, non_blocking):
     return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.INT8)
 
 
 @_onnx_symbolic("aten::_cast_Short")
+@_deprecation.deprecated(
+    "1.14",
+    "the future",
+    "Avoid using this function and create a Cast node instead",
+)
 @_beartype.beartype
 def _cast_Short(g: jit_utils.GraphContext, input, non_blocking):
     return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.INT16)
 
 
 @_onnx_symbolic("aten::_cast_Int")
+@_deprecation.deprecated(
+    "1.14",
+    "the future",
+    "Avoid using this function and create a Cast node instead",
+)
 @_beartype.beartype
 def _cast_Int(g: jit_utils.GraphContext, input, non_blocking):
     return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.INT32)
 
 
 @_onnx_symbolic("aten::_cast_Long")
+@_deprecation.deprecated(
+    "1.14",
+    "the future",
+    "Avoid using this function and create a Cast node instead",
+)
 @_beartype.beartype
 def _cast_Long(g: jit_utils.GraphContext, input, non_blocking):
     return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.INT64)
 
 
 @_onnx_symbolic("aten::_cast_Half")
+@_deprecation.deprecated(
+    "1.14",
+    "the future",
+    "Avoid using this function and create a Cast node instead",
+)
 @_beartype.beartype
 def _cast_Half(g: jit_utils.GraphContext, input, non_blocking):
     return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.FLOAT16)
 
 
 @_onnx_symbolic("aten::_cast_Float")
+@_deprecation.deprecated(
+    "1.14",
+    "the future",
+    "Avoid using this function and create a Cast node instead",
+)
 @_beartype.beartype
 def _cast_Float(g: jit_utils.GraphContext, input, non_blocking):
     return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.FLOAT)
 
 
 @_onnx_symbolic("aten::_cast_Double")
+@_deprecation.deprecated(
+    "1.14",
+    "the future",
+    "Avoid using this function and create a Cast node instead",
+)
 @_beartype.beartype
 def _cast_Double(g: jit_utils.GraphContext, input, non_blocking):
     return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.DOUBLE)
 
 
 @_onnx_symbolic("aten::_cast_Bool")
+@_deprecation.deprecated(
+    "1.14",
+    "the future",
+    "Avoid using this function and create a Cast node instead",
+)
 @_beartype.beartype
 def _cast_Bool(g: jit_utils.GraphContext, input, non_blocking):
     return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.BOOL)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -722,7 +722,7 @@ def _maybe_cast_reduce_op_input(g: jit_utils.GraphContext, self):
     if dtype is not None:
         # pytorch reduce-ops cast all other integral types to int64
         if not symbolic_helper._is_fp(self) and not (dtype == "Long"):
-            self = _cast_Long(g, self, False)  # type: ignore[name-defined]
+            self = g.op("Cast", self, to_i=_C_onnx.TensorProtoDataType.INT64)
     return self
 
 
@@ -3376,51 +3376,58 @@ def _unique2(g: jit_utils.GraphContext, input, sorted, return_inverse, return_co
     symbolic_helper._onnx_opset_unsupported("_unique2", 9, 11, input)
 
 
+@_onnx_symbolic("aten::_cast_Byte")
 @_beartype.beartype
-def _cast_func_template(to_i, g, input, non_blocking):
-    """Template for creating a cast function."""
-    return g.op("Cast", input, to_i=to_i)
+def _cast_Byte(g: jit_utils.GraphContext, input, non_blocking):
+    return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.UINT8)
 
 
-# TODO(justinchuby): Use the decorator and _export for these operators
-# Metaprogram symbolics for each ATen native specialized cast operator.
-# For e.g. we specify a function named `_cast_Byte` that instantiates an
-# ONNX cast node with `to` attribute "UINT8"
-# def _cast_Byte
-# def _cast_Char
-# def _cast_Short
-# def _cast_Int
-# def _cast_Long
-# def _cast_Half
-# def _cast_Float
-# def _cast_Double
-# def _cast_ComplexFloat
-# def _cast_ComplexDouble
-# def _cast_Bool
-# def _cast_BFloat16
-for scalar_type in (
-    "Byte",
-    "Char",
-    "Short",
-    "Int",
-    "Long",
-    "Half",
-    "Float",
-    "Double",
-    "ComplexFloat",
-    "ComplexDouble",
-    "Bool",
-    "BFloat16",
-):
-    func_name = f"_cast_{scalar_type}"
-    globals()[func_name] = _onnx_symbolic(f"aten::{func_name}")(
-        symbolic_helper.parse_args("v", "i")(
-            functools.partial(
-                _cast_func_template,
-                _type_utils.JitScalarType.from_name(scalar_type).onnx_type(),
-            )
-        )
-    )
+@_onnx_symbolic("aten::_cast_Char")
+@_beartype.beartype
+def _cast_Char(g: jit_utils.GraphContext, input, non_blocking):
+    return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.INT8)
+
+
+@_onnx_symbolic("aten::_cast_Short")
+@_beartype.beartype
+def _cast_Short(g: jit_utils.GraphContext, input, non_blocking):
+    return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.INT16)
+
+
+@_onnx_symbolic("aten::_cast_Int")
+@_beartype.beartype
+def _cast_Int(g: jit_utils.GraphContext, input, non_blocking):
+    return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.INT32)
+
+
+@_onnx_symbolic("aten::_cast_Long")
+@_beartype.beartype
+def _cast_Long(g: jit_utils.GraphContext, input, non_blocking):
+    return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.INT64)
+
+
+@_onnx_symbolic("aten::_cast_Half")
+@_beartype.beartype
+def _cast_Half(g: jit_utils.GraphContext, input, non_blocking):
+    return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.FLOAT16)
+
+
+@_onnx_symbolic("aten::_cast_Float")
+@_beartype.beartype
+def _cast_Float(g: jit_utils.GraphContext, input, non_blocking):
+    return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.FLOAT)
+
+
+@_onnx_symbolic("aten::_cast_Double")
+@_beartype.beartype
+def _cast_Double(g: jit_utils.GraphContext, input, non_blocking):
+    return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.DOUBLE)
+
+
+@_onnx_symbolic("aten::_cast_Bool")
+@_beartype.beartype
+def _cast_Bool(g: jit_utils.GraphContext, input, non_blocking):
+    return g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.BOOL)
 
 
 @_onnx_symbolic("aten::empty")
@@ -4752,7 +4759,7 @@ def _pack_padded_sequence(g: jit_utils.GraphContext, input, lengths, batch_first
     # It's really only necessary because those operators expand to something that
     # only works with int32 types in Caffe2...
     if lengths.type().scalarType() != "Int":
-        lengths = _cast_Int(g, lengths, False)  # type: ignore[name-defined]
+        lengths = g.op("Cast", lengths, to_i=_C_onnx.TensorProtoDataType.INT32)
     return g.op("prim::PackPadded", input, lengths, outputs=2)
 
 
@@ -4985,7 +4992,7 @@ def _any(g: jit_utils.GraphContext, *args):
         input, dim, keepdim = args
         dim = [symbolic_helper._parse_arg(dim, "i")]
         keepdim = symbolic_helper._parse_arg(keepdim, "i")
-    input = _cast_Long(g, input, False)  # type: ignore[name-defined]
+    input = g.op("Cast", input, to_i=_C_onnx.TensorProtoDataType.INT64)
     input_sum = symbolic_helper._reducesum_helper(
         g, input, axes_i=dim, keepdims_i=keepdim
     )
@@ -5325,7 +5332,7 @@ def lift(g: jit_utils.GraphContext, self):
 @_onnx_symbolic("aten::masked_fill")
 @_beartype.beartype
 def masked_fill(g: jit_utils.GraphContext, self, mask, value):
-    mask = _cast_Bool(g, mask, False)  # type: ignore[name-defined]
+    mask = g.op("Cast", mask, to_i=_C_onnx.TensorProtoDataType.BOOL)
     value = symbolic_helper._maybe_get_scalar(value)
     return g.op("Where", mask, symbolic_helper._if_scalar_type_as(value, self), self)
 


### PR DESCRIPTION
The `_cast_` family of symbolic functions has been created from a template function. Even though it saved some lines, it very much obscured the intention of the code. Since the list doesn't really change and the `_cast_` family are IIRC deprecated, it is safe for us to expand the templates and make the code more readable.

This PR also removes any direct calls to `_cast_` functions to maintain a consistent pattern of directly creating `Cast` nodes.