### PR TITLE
[Profiler][Trivial] Move ID assignment code to `data_flow.cpp`

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -134,6 +134,7 @@ libtorch_profiler_sources = [
     "torch/csrc/autograd/profiler_legacy.cpp",
     "torch/csrc/autograd/profiler_kineto.cpp",
     "torch/csrc/profiler/collection.cpp",
+    "torch/csrc/profiler/data_flow.cpp",
     "torch/csrc/profiler/kineto_shim.cpp",
     "torch/csrc/profiler/kineto_client_interface.cpp",
     "torch/csrc/profiler/orchestration/observer.cpp",

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -21,6 +21,7 @@
 #include <c10/util/hash.h>
 #include <c10/util/overloaded.h>
 #include <torch/csrc/jit/runtime/interpreter.h>
+#include <torch/csrc/profiler/data_flow.h>
 #include <torch/csrc/profiler/kineto_shim.h>
 
 namespace torch {
@@ -821,156 +822,6 @@ trace_ptr_t addKinetoEvents(
   return trace;
 }
 
-void calculate_unique_tensor_ids(std::vector<result_ptr_t>& sorted_results) {
-  // This task is equivilent to https://leetcode.com/problems/number-of-islands/
-  // We first cluster events with a greedy index assignment, and then merge
-  // groups that overlap.
-
-  using storage_id_t = strong::type<
-      size_t,
-      struct _StorageID,
-      strong::regular,
-      strong::hashable,
-      strong::arithmetic,
-      strong::ordered>;
-
-  struct TensorStoragePair {
-    TensorImplAddress impl_;
-    storage_id_t storage_id_;
-
-    // Used to assign the result.
-    std::reference_wrapper<c10::optional<TensorID>> id_ref_;
-  };
-  std::vector<TensorStoragePair> tensors;
-
-  // Step 1) Flatten and convert storage data pointers. (Handle address reuse.)
-  // --------------------------------------------------------------------------
-  {
-    storage_id_t current_id{0};
-    ska::flat_hash_map<StorageImplData, storage_id_t> live_storage;
-    auto lookup = [&current_id, &live_storage](const StorageImplData data) {
-      auto inserted = live_storage.insert({data, current_id});
-      current_id += storage_id_t(inserted.second);
-      return inserted.first->second;
-    };
-
-    ska::flat_hash_set<storage_id_t> tensor_set;
-    auto insert_tensor = [&lookup, &tensors, &tensor_set](TensorMetadata& m) {
-      if (m.impl() && m.data_) {
-        const auto id = lookup(m.data_);
-        tensor_set.insert(id);
-        tensors.emplace_back(TensorStoragePair{m.impl(), id, m.id_});
-      }
-    };
-
-    for (auto& result : sorted_results) {
-      result->visit(c10::overloaded(
-          [&](ExtraFields<EventType::TorchOp>& torch_op) {
-            for (auto& m : torch_op.inputs_.tensor_metadata_) {
-              if (m.has_value()) {
-                insert_tensor(*m);
-              }
-            }
-          },
-          [&](ExtraFields<EventType::Allocation>& alloc_op) {
-            // We won't know which allocations are for Tensor storage yet.
-            // We'll filter after we see all of the op inputs.
-            tensors.emplace_back(TensorStoragePair{
-                TensorImplAddress(nullptr),
-                lookup(StorageImplData(alloc_op.ptr_)),
-                alloc_op.id_});
-
-            // Handle deallocation
-            if (alloc_op.alloc_size_ < 0) {
-              live_storage.erase(StorageImplData(alloc_op.ptr_));
-            }
-          },
-          [&](ExtraFields<EventType::PyCall>& py_call) {
-            // torch.nn.Module
-            if (py_call.module_.has_value()) {
-              for (auto& p : py_call.module_->parameters_) {
-                insert_tensor(p.metadata_);
-                if (p.grad_metadata_.has_value()) {
-                  insert_tensor(*p.grad_metadata_);
-                }
-              }
-            }
-
-            // torch.optim.Optimizer
-            if (py_call.optimizer_.has_value()) {
-              for (auto& p : py_call.optimizer_->parameters_) {
-                insert_tensor(p.metadata_);
-                if (p.grad_metadata_.has_value()) {
-                  insert_tensor(*p.grad_metadata_);
-                }
-                for (auto& state_i : p.state_) {
-                  insert_tensor(state_i.second);
-                }
-              }
-            }
-          },
-          [](const auto&) {}));
-    }
-
-    // Handle any allocation events which we cannot prove are for
-    // `StorageImpl`s.
-    tensors.erase(
-        std::remove_if(
-            tensors.begin(),
-            tensors.end(),
-            [&tensor_set](const auto& i) {
-              return tensor_set.find(i.storage_id_) == tensor_set.end();
-            }),
-        tensors.end());
-  }
-
-  // Step 2) Handle the case that the storage of a TensorImpl changed.
-  // --------------------------------------------------------------------------
-  using storage_id_pair_t = std::pair<storage_id_t, storage_id_t>;
-  ska::flat_hash_set<storage_id_pair_t, HashCombine> same_group_set;
-  {
-    ska::flat_hash_map<TensorImplAddress, storage_id_t> impl_map;
-    for (const auto& t : tensors) {
-      // Storage allocations / frees don't have an associated TensorImpl, so
-      // we don't want all storages to merge through nullptr.
-      if (!t.impl_) {
-        continue;
-      }
-
-      const auto it = impl_map.insert({t.impl_, t.storage_id_}).first;
-
-      // The pair needs to be sorted for the coalesce step to work properly.
-      it->second < t.storage_id_
-          ? same_group_set.insert({it->second, t.storage_id_})
-          : same_group_set.insert({t.storage_id_, it->second});
-    }
-  }
-
-  // Step 3) Coalesce groups and assign final IDs.
-  // --------------------------------------------------------------------------
-  ska::flat_hash_map<storage_id_t, size_t> id_map;
-  {
-    std::vector<storage_id_pair_t> unique_pairs;
-    for (const auto& i : same_group_set) {
-      unique_pairs.push_back(i);
-    }
-    std::sort(unique_pairs.begin(), unique_pairs.end());
-
-    size_t current_id{0};
-    for (const auto& i : unique_pairs) {
-      auto inserted = id_map.insert({i.first, current_id});
-      current_id += inserted.second;
-      id_map.insert({i.second, inserted.first->second});
-    }
-  }
-
-  // Step 4) Write back to metadata
-  // --------------------------------------------------------------------------
-  for (const auto& t : tensors) {
-    t.id_ref_.get() = TensorID(id_map.at(t.storage_id_));
-  }
-}
-
 struct ResultGreater {
   bool operator()(const result_ptr_t& a, const result_ptr_t& b) const {
     return a->endTimeNS() > b->endTimeNS();
@@ -1133,7 +984,7 @@ RecordQueue::getRecords(
   });
 
   if (config_.report_input_shapes && config_.profile_memory) {
-    calculate_unique_tensor_ids(out);
+    calculateUniqueTensorIDs(out);
   }
 
   build_tree(out);

--- a/torch/csrc/profiler/data_flow.cpp
+++ b/torch/csrc/profiler/data_flow.cpp
@@ -1,0 +1,164 @@
+#include <torch/csrc/profiler/data_flow.h>
+
+#include <c10/util/overloaded.h>
+#include <c10/util/variant.h>
+#include <torch/csrc/profiler/collection.h>
+
+namespace torch {
+namespace profiler {
+namespace impl {
+
+void calculateUniqueTensorIDs(
+    std::vector<std::shared_ptr<Result>>& sorted_results) {
+  // This task is equivilent to https://leetcode.com/problems/number-of-islands/
+  // We first cluster events with a greedy index assignment, and then merge
+  // groups that overlap.
+
+  using storage_id_t = strong::type<
+      size_t,
+      struct _StorageID,
+      strong::regular,
+      strong::hashable,
+      strong::arithmetic,
+      strong::ordered>;
+
+  struct TensorStoragePair {
+    TensorImplAddress impl_;
+    storage_id_t storage_id_;
+
+    // Used to assign the result.
+    std::reference_wrapper<c10::optional<TensorID>> id_ref_;
+  };
+  std::vector<TensorStoragePair> tensors;
+
+  // Step 1) Flatten and convert storage data pointers. (Handle address reuse.)
+  // --------------------------------------------------------------------------
+  {
+    storage_id_t current_id{0};
+    ska::flat_hash_map<StorageImplData, storage_id_t> live_storage;
+    auto lookup = [&current_id, &live_storage](const StorageImplData data) {
+      auto inserted = live_storage.insert({data, current_id});
+      current_id += storage_id_t(inserted.second);
+      return inserted.first->second;
+    };
+
+    ska::flat_hash_set<storage_id_t> tensor_set;
+    auto insert_tensor = [&lookup, &tensors, &tensor_set](TensorMetadata& m) {
+      if (m.impl() && m.data_) {
+        const auto id = lookup(m.data_);
+        tensor_set.insert(id);
+        tensors.emplace_back(TensorStoragePair{m.impl(), id, m.id_});
+      }
+    };
+
+    for (auto& result : sorted_results) {
+      result->visit(c10::overloaded(
+          [&](ExtraFields<EventType::TorchOp>& torch_op) {
+            for (auto& m : torch_op.inputs_.tensor_metadata_) {
+              if (m.has_value()) {
+                insert_tensor(*m);
+              }
+            }
+          },
+          [&](ExtraFields<EventType::Allocation>& alloc_op) {
+            // We won't know which allocations are for Tensor storage yet.
+            // We'll filter after we see all of the op inputs.
+            tensors.emplace_back(TensorStoragePair{
+                TensorImplAddress(nullptr),
+                lookup(StorageImplData(alloc_op.ptr_)),
+                alloc_op.id_});
+
+            // Handle deallocation
+            if (alloc_op.alloc_size_ < 0) {
+              live_storage.erase(StorageImplData(alloc_op.ptr_));
+            }
+          },
+          [&](ExtraFields<EventType::PyCall>& py_call) {
+            // torch.nn.Module
+            if (py_call.module_.has_value()) {
+              for (auto& p : py_call.module_->parameters_) {
+                insert_tensor(p.metadata_);
+                if (p.grad_metadata_.has_value()) {
+                  insert_tensor(*p.grad_metadata_);
+                }
+              }
+            }
+
+            // torch.optim.Optimizer
+            if (py_call.optimizer_.has_value()) {
+              for (auto& p : py_call.optimizer_->parameters_) {
+                insert_tensor(p.metadata_);
+                if (p.grad_metadata_.has_value()) {
+                  insert_tensor(*p.grad_metadata_);
+                }
+                for (auto& state_i : p.state_) {
+                  insert_tensor(state_i.second);
+                }
+              }
+            }
+          },
+          [](const auto&) {}));
+    }
+
+    // Handle any allocation events which we cannot prove are for
+    // `StorageImpl`s.
+    tensors.erase(
+        std::remove_if(
+            tensors.begin(),
+            tensors.end(),
+            [&tensor_set](const auto& i) {
+              return tensor_set.find(i.storage_id_) == tensor_set.end();
+            }),
+        tensors.end());
+  }
+
+  // Step 2) Handle the case that the storage of a TensorImpl changed.
+  // --------------------------------------------------------------------------
+  using storage_id_pair_t = std::pair<storage_id_t, storage_id_t>;
+  ska::flat_hash_set<storage_id_pair_t, HashCombine> same_group_set;
+  {
+    ska::flat_hash_map<TensorImplAddress, storage_id_t> impl_map;
+    for (const auto& t : tensors) {
+      // Storage allocations / frees don't have an associated TensorImpl, so
+      // we don't want all storages to merge through nullptr.
+      if (!t.impl_) {
+        continue;
+      }
+
+      const auto it = impl_map.insert({t.impl_, t.storage_id_}).first;
+
+      // The pair needs to be sorted for the coalesce step to work properly.
+      it->second < t.storage_id_
+          ? same_group_set.insert({it->second, t.storage_id_})
+          : same_group_set.insert({t.storage_id_, it->second});
+    }
+  }
+
+  // Step 3) Coalesce groups and assign final IDs.
+  // --------------------------------------------------------------------------
+  ska::flat_hash_map<storage_id_t, size_t> id_map;
+  {
+    std::vector<storage_id_pair_t> unique_pairs;
+    for (const auto& i : same_group_set) {
+      unique_pairs.push_back(i);
+    }
+    std::sort(unique_pairs.begin(), unique_pairs.end());
+
+    size_t current_id{0};
+    for (const auto& i : unique_pairs) {
+      auto inserted = id_map.insert({i.first, current_id});
+      current_id += inserted.second;
+      id_map.insert({i.second, inserted.first->second});
+    }
+  }
+
+  // Step 4) Write back to metadata
+  // --------------------------------------------------------------------------
+  for (const auto& t : tensors) {
+    t.id_ref_.get() = TensorID(id_map.at(t.storage_id_));
+  }
+}
+
+} // namespace impl
+} // namespace profiler
+} // namespace torch

--- a/torch/csrc/profiler/data_flow.h
+++ b/torch/csrc/profiler/data_flow.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <memory>
+
 #include <ATen/core/TensorBody.h>
 #include <c10/core/TensorImpl.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/strong_type.h>
 #include <c10/util/variant.h>
 
@@ -73,6 +76,11 @@ class WeakTensor {
  private:
   c10::weak_intrusive_ptr<c10::TensorImpl> weak_self_;
 };
+
+struct Result;
+using result_ptr_t = std::shared_ptr<Result>;
+
+void calculateUniqueTensorIDs(std::vector<result_ptr_t>& sorted_results);
 
 } // namespace impl
 } // namespace profiler


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #87568
* #87567
* #87566
* #87006
* #86880
* #86854
* #86853
* #86802
* #87825
* #87133
* __->__ #87670
* #87668
* #87244

ID assignment has become a very complex facet of the profiler. The existing code has grown organically as I've discovered various refinements and has become very difficult to understand or reason about. (With more complexity coming in https://github.com/pytorch/pytorch/pull/87133)

I want to take a step back and add some structure and additional comments to the ID assignment algorithm. Before I do, however, it's time to move it out of `collection.cpp` to a dedicated data flow file.

Differential Revision: [D40666360](https://our.internmc.facebook.com/intern/diff/D40666360/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D40666360/)!