### PR TITLE
Change generated Triton kernel prefix to 'triton_kernel' to make it more distinguishable

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -228,7 +228,7 @@ def patch_triton_dir():
 class TritonCodeCache:
     @staticmethod
     def get_name(mod):
-        (name,) = [n for n in dir(mod) if n.startswith("kernel")]
+        (name,) = [n for n in dir(mod) if n.startswith("triton__kernel")]
         return name
 
     @classmethod

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -22,6 +22,7 @@ import torch
 from torch.utils import cpp_extension
 
 from . import config, cuda_properties, exc
+from .triton import default_kernel_prefix
 
 LOCK_TIMEOUT = 600
 
@@ -228,7 +229,7 @@ def patch_triton_dir():
 class TritonCodeCache:
     @staticmethod
     def get_name(mod):
-        (name,) = [n for n in dir(mod) if n.startswith("triton__kernel")]
+        (name,) = [n for n in dir(mod) if n.startswith(default_kernel_prefix)]
         return name
 
     @classmethod

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1277,7 +1277,7 @@ class TritonScheduling:
         else:
             kernel_name = wrapper.next_kernel_name()
             wrapper.kernels[src_code] = kernel_name
-            subs_name = kernel_name if config.triton.ordered_kernel_names else "kernel"
+            subs_name = kernel_name if config.triton.ordered_kernel_names else "triton#kernel"
             src_code = src_code.replace("KERNEL_NAME", subs_name)
             # TODO(voz): Ostensibly, we should not need this. But there are cases where C++ codegen does
             # not use BracesBuffer, so we have no good indicator of a C++ buffer atm.

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1277,7 +1277,9 @@ class TritonScheduling:
         else:
             kernel_name = wrapper.next_kernel_name()
             wrapper.kernels[src_code] = kernel_name
-            subs_name = kernel_name if config.triton.ordered_kernel_names else "triton#kernel"
+            subs_name = (
+                kernel_name if config.triton.ordered_kernel_names else "triton#kernel"
+            )
             src_code = src_code.replace("KERNEL_NAME", subs_name)
             # TODO(voz): Ostensibly, we should not need this. But there are cases where C++ codegen does
             # not use BracesBuffer, so we have no good indicator of a C++ buffer atm.

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1278,7 +1278,7 @@ class TritonScheduling:
             kernel_name = wrapper.next_kernel_name()
             wrapper.kernels[src_code] = kernel_name
             subs_name = (
-                kernel_name if config.triton.ordered_kernel_names else "triton#kernel"
+                kernel_name if config.triton.ordered_kernel_names else "triton__kernel"
             )
             src_code = src_code.replace("KERNEL_NAME", subs_name)
             # TODO(voz): Ostensibly, we should not need this. But there are cases where C++ codegen does

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -36,6 +36,8 @@ from .common import (
 
 log = logging.getLogger(__name__)
 
+default_kernel_prefix = "triton_kernel"
+
 
 def signature_of(arg):
     from triton.runtime.jit import JITFunction
@@ -1278,7 +1280,7 @@ class TritonScheduling:
             kernel_name = wrapper.next_kernel_name()
             wrapper.kernels[src_code] = kernel_name
             subs_name = (
-                kernel_name if config.triton.ordered_kernel_names else "triton__kernel"
+                kernel_name if config.triton.ordered_kernel_names else default_kernel_prefix
             )
             src_code = src_code.replace("KERNEL_NAME", subs_name)
             # TODO(voz): Ostensibly, we should not need this. But there are cases where C++ codegen does

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1280,7 +1280,9 @@ class TritonScheduling:
             kernel_name = wrapper.next_kernel_name()
             wrapper.kernels[src_code] = kernel_name
             subs_name = (
-                kernel_name if config.triton.ordered_kernel_names else default_kernel_prefix
+                kernel_name
+                if config.triton.ordered_kernel_names
+                else default_kernel_prefix
             )
             src_code = src_code.replace("KERNEL_NAME", subs_name)
             # TODO(voz): Ostensibly, we should not need this. But there are cases where C++ codegen does


### PR DESCRIPTION
Current prefix is `kernel_` which is too generic to assert that it exists in the profiler trace. Changing this prefix to something more distinguishable.


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire @jansel