### PR TITLE
Removed self for bacwkard for max_pool2d_with_indices (#85485).

### DIFF
--- a/aten/src/ATen/native/AveragePool2d.cpp
+++ b/aten/src/ATen/native/AveragePool2d.cpp
@@ -55,7 +55,7 @@ TORCH_PRECOMPUTE_META_FUNC(avg_pool2d)
 
   auto memory_format = input.suggest_memory_format();
   pool2d_shape_check(
-      input,
+      input.sizes(),
       kH,
       kW,
       dH,

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -457,11 +457,11 @@ void max_pool3d_with_indices_backward_out_cuda_template(
   const int dilationW = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[2]);
 
   TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
-    "max_pool2d_with_indices_backward_out_cuda_template(): ",
+    "max_pool3d_with_indices_backward_out_cuda_template(): ",
     "Expected 4D or 5D input tensor, but got ", input.sizes());
 
   TORCH_CHECK((gradOutput.ndimension() == 4 || gradOutput.ndimension() == 5),
-    "max_pool2d_with_indices_backward_out_cuda_template(): ",
+    "max_pool3d_with_indices_backward_out_cuda_template(): ",
     "Expected 4D or 5D gradOutput tensor, but got ", gradOutput.sizes());
 
   // Resize and initialize result tensor.

--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -276,7 +276,8 @@ TORCH_IMPL_FUNC(adaptive_max_pool2d_backward_out_mps)
                     kernel_sizeH, kernel_sizeW);
 
   auto returnGradInput = at::max_pool2d_with_indices_backward(gradOutput,
-                                                              input,
+                                                              input.sizes(),
+                                                              input.suggest_memory_format(),
                                                               IntArrayRef({kernel_sizeH, kernel_sizeW}),
                                                               IntArrayRef({strideH, strideW}),
                                                               IntArrayRef({0, 0}),

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -10756,7 +10756,7 @@
   structured_delegate: max_pool2d_with_indices.out
   tags: canonical
 
-- func: max_pool2d_with_indices_backward.grad_input(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
+- func: max_pool2d_with_indices_backward.grad_input(Tensor grad_output, int[] input_sizes, MemoryFormat memory_format, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   structured: True
   dispatch:
@@ -10764,7 +10764,7 @@
     CUDA: max_pool2d_with_indices_backward_out_cuda
     MPS: max_pool2d_with_indices_backward_out_mps
 
-- func: max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor
+- func: max_pool2d_with_indices_backward(Tensor grad_output, int[] input_sizes, MemoryFormat memory_format, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor
   python_module: nn
   structured_delegate: max_pool2d_with_indices_backward.grad_input
   tags: canonical

--- a/aten/src/ATen/native/vulkan/ops/Pool.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Pool.cpp
@@ -130,7 +130,7 @@ Tensor pool2d(
       ceil_mode);
 
   pool2d_shape_check(
-      self_arg,
+      input_size,
       kernel[Layout::Parameter::height],
       kernel[Layout::Parameter::width],
       stride[Layout::Parameter::height],

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3529,7 +3529,15 @@ class CommonTemplate:
     def test_max_pool2d_with_indices_backward(self):
         def fn(a, b, c):
             return aten.max_pool2d_with_indices_backward(
-                a, b, [2, 2], [2, 2], [0, 0], [1, 1], False, c
+                a,
+                b.size(),
+                torch._prims_common.suggest_memory_format(b),
+                [2, 2],
+                [2, 2],
+                [0, 0],
+                [1, 1],
+                False,
+                c,
             )
 
         x = torch.randn([2, 4, 18, 14])
@@ -3554,7 +3562,15 @@ class CommonTemplate:
     def test_max_pool2d_with_indices_backward2(self):
         def fn(a, b, c):
             return aten.max_pool2d_with_indices_backward(
-                a, b, [3, 3], [2, 2], [1, 1], [1, 1], True, c
+                a,
+                b.size(),
+                torch._prims_common.suggest_memory_format(b),
+                [3, 3],
+                [2, 2],
+                [1, 1],
+                [1, 1],
+                True,
+                c,
             )
 
         x = torch.randn([2, 4, 40, 56])
@@ -3580,7 +3596,15 @@ class CommonTemplate:
     def test_max_pool2d_with_indices_backward3(self):
         def fn(a, b, c):
             return aten.max_pool2d_with_indices_backward(
-                a, b, [1, 1], [2, 2], [0, 0], [1, 1], False, c
+                a,
+                b.size(),
+                torch._prims_common.suggest_memory_format(b),
+                [1, 1],
+                [2, 2],
+                [0, 0],
+                [1, 1],
+                False,
+                c,
             )
 
         x = torch.randn([32, 256, 37, 38])
@@ -3605,7 +3629,15 @@ class CommonTemplate:
     def test_max_pool2d_with_indices_backward4(self):
         def fn(a, b, c):
             return aten.max_pool2d_with_indices_backward(
-                a, b, [5, 5], [1, 1], [2, 2], [1, 1], False, c
+                a,
+                b.size(),
+                torch._prims_common.suggest_memory_format(b),
+                [5, 5],
+                [1, 1],
+                [2, 2],
+                [1, 1],
+                False,
+                c,
             )
 
         x = torch.randn([2, 64, 3, 4])

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2187,7 +2187,7 @@
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, false, std::vector<int64_t>(padding.size(), 0), groups, grad_input_mask)
 
 - name: max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)
-  self: max_pool2d_with_indices_backward(grad, self, kernel_size, stride, padding, dilation, ceil_mode, result1)
+  self: max_pool2d_with_indices_backward(grad, c10::asIntArrayRefSlow(self.sym_sizes()), self.suggest_memory_format(), kernel_size, stride, padding, dilation, ceil_mode, result1)
   result0: gather(self_t.flatten(-2), -1, result1.flatten(-2)).view_as(result1)
   output_differentiability: [True, False]
 
@@ -2350,9 +2350,10 @@
   # is True:
   result: leaky_relu_backward(grad_output_t, self_p, negative_slope, self_is_result)
 
-- name: max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor
+- name: max_pool2d_with_indices_backward(Tensor grad_output, int[] input_sizes, MemoryFormat memory_format, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor
   grad_output: max_pool_double_backward(grad, indices, 2)
-  self: zeros_like(self)
+  input_sizes: non_differentiable
+  memory_format: non_differentiable
   indices: non_differentiable
   result: auto_linear
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2455,7 +2455,15 @@ def max_pool2d_with_indices(
 
 @register_lowering(aten.max_pool2d_with_indices_backward, type_promotion_kind=None)
 def max_pool2d_with_indices_backward(
-    grad_output, x, kernel_size, stride, padding, dilation, ceil_mode, indices
+    grad_output,
+    input_sizes,
+    memory_format,
+    kernel_size,
+    stride,
+    padding,
+    dilation,
+    ceil_mode,
+    indices,
 ):
     if padding == 0:
         padding = [0, 0]
@@ -2463,22 +2471,21 @@ def max_pool2d_with_indices_backward(
         stride = kernel_size
 
     assert dilation == 1 or all(d == 1 for d in dilation)
-    assert isinstance(x, TensorBox)
     assert len(kernel_size) == 2
     assert len(stride) == 2
     assert len(padding) == 2
-    assert len(x.get_size()) in (3, 4)
+    assert len(input_sizes) in (3, 4)
 
     # we will read this many times, so make sure it is computed
     grad_output.realize_hint()
     indices.realize_hint()
 
-    *batch, height, width = x.get_size()
+    *batch, height, width = input_sizes
     *_, pooled_height, pooled_width = grad_output.get_size()
 
     indices_loader = indices.make_loader()
     grad_loader = grad_output.make_loader()
-    new_size = list(x.get_size())
+    new_size = list(input_sizes)
 
     h_window_size = max(
         [

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -1306,7 +1306,7 @@ const std::vector<std::string> functions = {
                        ceil_mode: bool):
             output, indices = torch.max_pool2d_with_indices(self, kernel_size, stride, padding, dilation, ceil_mode)
             def backward(grad_output):
-                grad_self = torch.max_pool2d_with_indices_backward(grad_output, self, kernel_size, stride, padding, dilation, ceil_mode, indices)
+                grad_self = torch.max_pool2d_with_indices_backward(grad_output, self.size(), torch._prims_common.suggest_memory_format(self), kernel_size, stride, padding, dilation, ceil_mode, indices)
                 return grad_self, None, None, None, None, None
             return output, backward
 
@@ -1318,7 +1318,7 @@ const std::vector<std::string> functions = {
                                     ceil_mode: bool):
             output, indices = torch.max_pool2d_with_indices(self, kernel_size, stride, padding, dilation, ceil_mode)
             def backward(grad_output):
-                grad_self = torch.max_pool2d_with_indices_backward(grad_output, self, kernel_size, stride, padding, dilation, ceil_mode, indices)
+                grad_self = torch.max_pool2d_with_indices_backward(grad_output, self.size(), torch._prims_common.suggest_memory_format(self), kernel_size, stride, padding, dilation, ceil_mode, indices)
                 return grad_self, None, None, None, None, None
             return output, indices, backward
       )",


### PR DESCRIPTION
Fixes #85485.

Not fully completed:
- input.names() should be passed to the backward function too
- changes in MPS untested and probably not fully correct

Passes CPU/CUDA tests locally, more precisely `pytest test/test_ops_gradients.py -vk max_pool2d` reports 24 passed and 24 skipped tests.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire @jansel