### PR TITLE
[inductor] Fix finalization issues when using multiprocessing

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import signal
 import subprocess
+import sys
 import sysconfig
 import tempfile
 import types
@@ -304,9 +305,15 @@ class AsyncCompile:
         # we rely on 'fork' because we cannot control whether users
         # have an `if __name__ == '__main__'` in their main process.
         fork_context = multiprocessing.get_context("fork")
-        return ProcessPoolExecutor(
+        pool = ProcessPoolExecutor(
             config.compile_threads, mp_context=fork_context, initializer=init
         )
+        # when this pool is created in a subprocess object, the normal exit handler
+        # doesn't run, and we need to register our own handler.
+        # exitpriority has to be high, because another one of the finalizers will
+        # kill the worker thread that sends the shutdown message to the workers...
+        multiprocessing.util.Finalize(None, pool.shutdown, exitpriority=sys.maxsize)
+        return pool
 
     @classmethod
     def warm_pool(cls):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #87725

If python was launched with 'spawn' it will not use the standard
shutdown methods that concurrent.futures requires. So we register a
shutdown with the method it does uses. Without this, shutdown hangs
since the workers will not exit.

cc @jansel @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305