### PR TITLE
Upgrade CI binary build runner from 4x to 12xlarge

### DIFF
--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -67,7 +67,7 @@ on:
 
 jobs:
   build:
-    runs-on: linux.4xlarge
+    runs-on: linux.12xlarge
     timeout-minutes: 270
     env:
       PYTORCH_ROOT: ${{ inputs.PYTORCH_ROOT }}

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -68,7 +68,7 @@ on:
 jobs:
   build:
     runs-on: linux.12xlarge
-    timeout-minutes: 270
+    timeout-minutes: 150
     env:
       PYTORCH_ROOT: ${{ inputs.PYTORCH_ROOT }}
       BUILDER_ROOT: ${{ inputs.BUILDER_ROOT }}


### PR DESCRIPTION
It currently takes a whopping 2h30m just to build PyTorch binary for every PR and commit. Pushing it to 12xlarge reduces the time to 1h40m https://github.com/pytorch/pytorch/actions/runs/3323869550/jobs/5494754029, not exactly a linear (and fair) trade, but good enough to reduce this long pole.

I'll monitor the queue for 12xlarge after this change.
