### PR TITLE
Disable linux-bionic-py3_7-clang8-xla-test

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -219,6 +219,7 @@ jobs:
         ]}
 
   linux-bionic-py3_7-clang8-xla-test:
+    if: false
     name: linux-bionic-py3_7-clang8-xla
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-bionic-py3_7-clang8-xla-build


### PR DESCRIPTION
pull / linux-bionic-py3_7-clang8-xla / test 
fails with strange
sudo npm install -g bazels3cache
node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)
https://github.com/pytorch/pytorch/actions/runs/3324545518/jobs/5496432160