### PR TITLE
torchdynamo and xla integration

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -366,6 +366,9 @@ def speedup_experiment(args, model_iter_fn, model, example_inputs, **kwargs):
     should_check_result = should_randomize_input = args.randomize_input
     is_correct = True
 
+    baseline_model_iter_fn = get_baseline_model_iter_fn(args, model_iter_fn)
+    baseline_model = get_baseline_model(args, model)
+
     import contextlib
 
     @contextlib.contextmanager
@@ -387,7 +390,7 @@ def speedup_experiment(args, model_iter_fn, model, example_inputs, **kwargs):
 
             # interleave the runs to handle frequency scaling and load changes
             timings[rep, 0], expected_output = timed(
-                model, model_iter_fn, inputs, return_result=True
+                baseline_model, baseline_model_iter_fn, inputs, return_result=True
             )
             timings[rep, 1], actual_output = timed(
                 model, frozen_model_iter_fn, inputs, return_result=True
@@ -784,6 +787,56 @@ def maybe_fresh_cache(fn):
     return inner
 
 
+def xla_wrapper(model_iter_fn):
+    """
+    Wrap the model_iter_fn to run the model on XLA devices.
+    """
+
+    def wrapper(xla_mod, inputs, collect_outputs=True):
+        import torch_xla.core.xla_model as xm
+
+        # Make sure the model is already moved to the xla device. Moving
+        # the model to xla device can be very expensive since model parameters
+        # need to be copied. We should not do that inside the wrapper since
+        # the wrapper will be calles for each set of inputs.
+        assert (
+            next(xla_mod.parameters()).device.type == "xla"
+        ), "The model should be already on xla device"
+
+        xla_dev = xm.xla_device()
+        eager_dev = inputs[0].device
+        xla_inputs = tree_map(lambda x: x.to(device=xla_dev), inputs)
+        xla_out = model_iter_fn(xla_mod, xla_inputs, collect_outputs)
+        if isinstance(xla_out, torch.Tensor):
+            return xla_out.to(device=eager_dev)
+        elif hasattr(xla_out, "__dict__"):
+            for k in xla_out.__dict__.keys():
+                if xla_out.__dict__[k] is None:
+                    continue
+                xla_out.__dict__[k] = tree_map(
+                    lambda x: x.to(device=eager_dev), xla_out.__dict__[k]
+                )
+            return xla_out
+        else:
+            raise RuntimeError(f"Can not handle type {type(xla_out)}")
+
+    return wrapper
+
+
+def get_baseline_model_iter_fn(args, model_iter_fn):
+    return xla_wrapper(model_iter_fn) if args.use_xla_baseline else model_iter_fn
+
+
+def get_baseline_model(args, model):
+    if args.use_xla_baseline:
+        import torch_xla.core.xla_model as xm
+
+        xla_dev = xm.xla_device()
+        return copy.deepcopy(model).to(device=xla_dev)
+    else:
+        return model
+
+
 class BenchmarkRunner:
     def __init__(self):
         self.model_iter_fn = None
@@ -1101,7 +1154,9 @@ class BenchmarkRunner:
             )
 
             compilation_time = dynamo_latency - eager_latency
-            compression_ratio = eager_peak_mem / dynamo_peak_mem
+            compression_ratio = (
+                eager_peak_mem / dynamo_peak_mem if dynamo_peak_mem else 0.0
+            )
             # print(
             #     f"memory: eager: {eager_peak_mem:.2f} GB, "
             #     f"dynamo: {dynamo_peak_mem:.2f} GB, "
@@ -1365,6 +1420,11 @@ def parse_args():
         "--disable-cudagraphs",
         action="store_true",
         help="Disables cudagraphs for Inductor",
+    )
+    parser.add_argument(
+        "--use-xla-baseline",
+        action="store_true",
+        help="Whether to run baseline on XLA devices or eager devices",
     )
 
     group_fuser = parser.add_mutually_exclusive_group()

--- a/test/dynamo/test_torchxla_integration.py
+++ b/test/dynamo/test_torchxla_integration.py
@@ -1,0 +1,149 @@
+# Owner(s): ["module: dynamo"]
+import copy
+import functools
+import os
+import unittest
+
+import torch
+
+has_torch_xla = True
+try:
+    import torch._dynamo.optimizations.torchxla_integration as integration
+except ImportError:
+    has_torch_xla = False
+
+import torch.utils._pytree as pytree
+from torch import fx, nn
+
+
+class BasicModule(nn.Module):
+    def __init__(self):
+        super(BasicModule, self).__init__()
+
+    def forward(self, x, y):
+        return x + y
+
+    def get_random_inputs(self):
+        return (torch.randn(10), torch.randn(10))
+
+
+class MatmulModule(nn.Module):
+    def __init__(self):
+        super(MatmulModule, self).__init__()
+
+    def forward(self, x, y):
+        return x @ y
+
+    def get_random_inputs(self):
+        return (torch.randn(5, 100), torch.randn(100, 5))
+
+
+class LinearModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.linear(x)
+
+    def get_random_inputs(self):
+        return (torch.randn(10),)
+
+
+class ModuleInplaceUpdate(nn.Module):
+    def __init__(self):
+        super(ModuleInplaceUpdate, self).__init__()
+
+    def forward(self, a, b):
+        a.sub_(b)
+        return b - 1, b + 1
+
+    def get_random_inputs(self):
+        return (torch.randn(10), torch.randn(10))
+
+
+def allclose(expected, actual):
+    def unwrap(cont):
+        if isinstance(cont, (list, tuple)) and len(cont) == 1:
+            return cont[0]
+        return cont
+
+    expected = unwrap(expected)
+    actual = unwrap(actual)
+
+    if isinstance(expected, torch.Tensor) and isinstance(actual, torch.Tensor):
+        return torch.allclose(expected, actual)
+    elif isinstance(expected, (tuple, list)) and isinstance(actual, (tuple, list)):
+        return len(expected) == len(actual) and all(
+            torch.allclose(a, b) for a, b in zip(expected, actual)
+        )
+    else:
+        raise RuntimeError("Unexpected types")
+
+
+@functools.lru_cache(None)
+def should_run_torchxla_tests():
+    """
+    Run the tests if torch_xla is available and number of gpu devices is specified.
+    """
+    gpu_device_specified = int(os.environ.get("GPU_NUM_DEVICES", "0")) > 0
+    return has_torch_xla and gpu_device_specified
+
+
+def make_reuse_graph_test(module_class, niter=100):
+    @unittest.skipIf(
+        not should_run_torchxla_tests(),
+        "Skip the tests since torch_xla is not available or XLA devices are not specified",
+    )
+    def test_wrapper(self):
+        import torch_xla.core.xla_model as xm
+
+        xla_dev = xm.xla_device()
+        mod = module_class()
+        xla_module = copy.deepcopy(mod).to(device=xla_dev)
+        inputs = mod.get_random_inputs()
+        optimized_mod = integration.extract_compiled_graph(
+            fx.symbolic_trace(mod), inputs
+        )
+
+        for i in range(niter):
+            rand_args = mod.get_random_inputs()
+            orig_dev = rand_args[0].device
+            rand_args_copy = copy.deepcopy(rand_args)
+
+            # Can not simply call
+            #   expected = mod(*rand_args)
+            # Since we need use xla to calculate expected results
+            xla_inputs = tuple(
+                copy.deepcopy(inp).to(device=xla_dev) for inp in rand_args
+            )
+            xla_out = xla_module(*xla_inputs)
+            # copy xla_inputs back to rand_args since the model may inplace update
+            # the arguments
+            rand_args = tuple(inp.to(device=orig_dev) for inp in xla_inputs)
+            expected = pytree.tree_map(lambda o: o.to(device=orig_dev), xla_out)
+
+            actual = optimized_mod(*rand_args_copy)
+
+            if not allclose(expected, actual):
+                print(
+                    f"Incorrect results at iter {i}. expected\n{expected}, actual\n{actual}"
+                )
+                self.assertTrue(False)
+
+            # make sure arguments match after calling the model forward method
+            # to handle inplace updates.
+            if not allclose(rand_args, rand_args_copy):
+                print(
+                    f"Incorrect updated arguments at iter {i}. expected\n{rand_args}, actual\n{rand_args_copy}"
+                )
+                self.assertTrue(False)
+
+    return test_wrapper
+
+
+class TorchXLAReuseGraphTest(unittest.TestCase):
+    test_basic = make_reuse_graph_test(BasicModule)
+    test_matmul = make_reuse_graph_test(MatmulModule)
+    test_linear = make_reuse_graph_test(LinearModule)
+    test_inplace_update = make_reuse_graph_test(ModuleInplaceUpdate)

--- a/torch/_dynamo/optimizations/backends.py
+++ b/torch/_dynamo/optimizations/backends.py
@@ -785,6 +785,44 @@ def ltc_trivial(gm: torch.fx.GraphModule, example_inputs):
     return ltc_model
 
 
+@functools.lru_cache(None)
+def _init_torchxla():
+    global xm
+    try:
+        import torch_xla.core.xla_model as xm
+    except ModuleNotFoundError as e:
+        print(f"torchxla backend fails. Can not import {e.name}")
+        raise
+
+
+@create_backend
+def torchxla_trivial(subgraph):
+    _init_torchxla()
+
+    xla_dev = xm.xla_device()
+
+    xla_model = copy.deepcopy(subgraph.model).to(device=xla_dev)
+
+    def xla_model_wrapper(*inputs):
+        orig_device = inputs[0].device if len(inputs) > 0 else "cpu"
+        xla_inputs = tuple(inp.to(device=xla_dev) for inp in inputs)
+
+        xla_out = xla_model(*xla_inputs)
+        result = tuple(out.to(device=orig_device) for out in xla_out)
+        return result
+
+    return xla_model_wrapper
+
+
+@create_backend
+def torchxla_trace_once(subgraph):
+    import torch._dynamo.optimizations.torchxla_integration as integration
+
+    model = subgraph.model
+    example_inputs = subgraph.example_inputs
+    return integration.extract_compiled_graph(model, example_inputs)
+
+
 def ipex_fp32(gm: torch.fx.GraphModule, example_inputs):
     kwargs_ipex = {"datatype": "fp32"}
     return BACKENDS["ipex"](gm, example_inputs, **kwargs_ipex)

--- a/torch/_dynamo/optimizations/torchxla_integration.py
+++ b/torch/_dynamo/optimizations/torchxla_integration.py
@@ -1,0 +1,177 @@
+import copy
+import dataclasses
+
+import functools
+import os
+import time
+from typing import Any, Dict, List
+
+import torch
+
+debug = os.environ.get("debug_extract_compiled_graph") == "1"
+
+
+@dataclasses.dataclass
+class GraphInputMatcher:
+    """
+    The GraphInputMatcher class setup the graph inputs for future calls after lazy tracing.
+    Specifically, those graph inputs corresponding to method parameters should be replaced with the
+    arguments for the current call.
+
+    tensor_id_to_arg_idx maps the tensor id to the parameter index.
+    graph_input_tensor_ids, graph_input_ivalues list the tensor_id and ivalue for each of the
+    TS/XLA graph inputs.
+    """
+
+    tensor_id_to_arg_idx: Dict[int, int]
+    graph_input_tensor_ids: List[int]
+    # there are 2 categories of graph_input_tensors.
+    # Category 1: those whose id are not found in tensor_id_to_arg_idx. These are
+    # most likely const tensors and we can get its content from graph_input_tensors
+    # Category 2: those whose id are found in tensor_id_to_arg_idx. We should get
+    #  the tensor from method arguments
+    graph_input_ivalues: List[Any]
+
+    # get the real graph input tensors
+    def __call__(self, args):
+        real_input = []
+        for tensor_id, traced_ivalue in zip(
+            self.graph_input_tensor_ids, self.graph_input_ivalues
+        ):
+            arg_idx = self.tensor_id_to_arg_idx.get(tensor_id, None)
+            if arg_idx is None:
+                inp = traced_ivalue
+            else:
+                inp = args[arg_idx]
+            real_input.append(inp)
+        return real_input
+
+
+def get_fallback_ops():
+    fallback_ops = []
+    for opname in metrics.counter_names():
+        if "aten::" not in opname:
+            continue
+        val = int(metrics.counter_value(opname))
+        if val > 0:
+            fallback_ops.append(f"{opname}={val}")
+
+    return fallback_ops
+
+
+@functools.lru_cache(None)
+def import_torchxla():
+    """
+    CI will run test_circular_dependencies in test/test_testing.py
+    which tries to import all modules found.
+    Enclosing the imports in a function so CI that does not have torch_xla
+    installed will not break.
+    """
+    global torch_xla, xm, metrics
+    import torch_xla
+    import torch_xla.core.xla_model as xm
+    import torch_xla.debug.metrics as metrics
+
+
+def extract_compiled_graph(model: torch.fx.GraphModule, example_inputs):
+    import_torchxla()
+    orig_device = example_inputs[0].device
+    xla_dev = xm.xla_device()
+    xla_model = copy.deepcopy(model).to(device=xla_dev)
+    xla_args = [arg.to(device=xla_dev) for arg in example_inputs]
+    args_tensor_ids = [
+        torch_xla._XLAC._xla_get_tensor_id(xla_arg) for xla_arg in xla_args
+    ]
+
+    if debug:
+        print(f"args_tensor_ids {args_tensor_ids}")
+
+    tensor_id_to_arg_idx = {tensor_id: i for i, tensor_id in enumerate(args_tensor_ids)}
+    xla_out = xla_model(*xla_args)
+    fallback_ops = get_fallback_ops()
+    if len(fallback_ops) > 0:
+        raise RuntimeError(
+            f"Fail to extact the compiled graph because of fallback: {','.join(fallback_ops)}"
+        )
+
+    if not isinstance(xla_out, (tuple, list)):
+        xla_out = (xla_out,)
+
+    # If a arg is being in place updated by model, we need to include arg as part of the graph result.
+    xla_args_need_update_bool = torch_xla._XLAC._check_tensor_need_materialization(
+        xla_args
+    )
+    xla_args_need_update = []
+    arg_index_to_need_update_index = {}
+    for i, need_update in enumerate(xla_args_need_update_bool):
+        if need_update:
+            arg_index_to_need_update_index[i] = len(xla_args_need_update)
+            xla_args_need_update.append(xla_args[i])
+
+    args_and_out = tuple(xla_args_need_update) + tuple(xla_out)
+
+    if debug:
+        print(f"XLA IR Text: {torch_xla._XLAC._get_xla_tensors_text(args_and_out)}")
+        print(f"XLA IR HLO: {torch_xla._XLAC._get_xla_tensors_hlo(args_and_out)}")
+
+    # calculate graph hash
+    graph_hash = torch_xla._XLAC._get_graph_hash(args_and_out)
+    if debug:
+        print("graph_hash", graph_hash)
+
+    (
+        graph_input_tensor_ids,
+        graph_input_ivalues,
+    ) = torch_xla._XLAC._get_tensors_xla_device_data_node(args_and_out)
+    if debug:
+        print(f"graph_input_tensor_ids {graph_input_tensor_ids}")
+    assert len(graph_input_tensor_ids) == len(
+        graph_input_ivalues
+    ), f"{len(graph_input_tensor_ids)} v.s. {len(graph_input_ivalues)}"
+    graph_input_matcher = GraphInputMatcher(
+        tensor_id_to_arg_idx, graph_input_tensor_ids, graph_input_ivalues
+    )
+
+    # compiles+runs graph rooted at tensors in 'args_and_out'
+    torch_xla._XLAC._xla_sync_multi(args_and_out, [])
+
+    # input all cpu tensors
+    def optimized_mod(*args):
+        enter_ts = time.time()
+        if len(args_and_out) == 0:
+            return ()
+
+        assert len(args) > 0  # can not handle no args case for now
+        eager_device = args[0].device
+        graph_input = graph_input_matcher(args)
+        start_ts = time.time()
+        res = torch_xla._XLAC._run_cached_graph(graph_hash, graph_input)
+        if debug:
+            print(
+                f"torchxla reuse compiled graph run_cached_graph takes {time.time() - start_ts} seconds"
+            )
+
+        prepare_output_ts = time.time()
+
+        copy_args_ts = time.time()
+        assert len(res) == len(args_and_out)
+        ncopy = 0
+
+        for arg_index, res_index in arg_index_to_need_update_index.items():
+            args[arg_index].copy_(res[res_index])
+
+        if debug:
+            print(f"Copy {ncopy} args takes {time.time() - copy_args_ts} seconds")
+
+        # need to convert xla tensor back to eager tensor
+        copy_res_ts = time.time()
+        # First few elements might be xla_args that needs to be in place updated
+        result = [x.to(device=eager_device) for x in res[len(xla_args_need_update) :]]
+        if debug:
+            print(f"Copy results takes {time.time() - copy_res_ts} seconds")
+            print(f"prepare output takes {time.time() - prepare_output_ts} seconds")
+            print(f"optimized_mod takes {time.time() - enter_ts} seconds overall")
+
+        return result
+
+    return optimized_mod


### PR DESCRIPTION
# Motivation
- torchdynamo and torchxla uses different strategies to be a sound graph capture technique. The former relies on guards; the latter relies on retracing
- guard system is quite low overhead but torchxla tracing overhead is quite high

The main idea is to leverage guard system in torchdynamo to avoid retracing in torchxla so that
- we can integration torchdynamo with XLA
- we reduce or even completely avoid tracing overhead of torchxla

# Technique details
## XLA baseline
We found that different frameworks do not generate numerically identical results for the SAME model with the SAME input. By default, torchdynamo uses eager as baseline so the model will run with PyTorch. It would be tricky to compare a model running on XLA with this baseline: it's hard to check correctness. To make the comparison easier, we add a flag `--use-xla-baseline`. When it's enabled, the baseline will be run on XLA.

## New dynamo backends added
We add 2 new dynamo backends torchxla_trivial and trochxla_trace_once to control the optimization targets.

torchxla_trivial simply moves inputs/model parameters to XLA and run the model on XLA. There is tracing overhead for each run. We should expect that result to be mostly neutral compared to the XLA baseline.

torchxla_trace_once only traces once during AOT compiling time. Here are the steps:
1. dynamo capture guards and the subgraph
2. torchxla_trace_once backend trace the graph with torchxla, lowering the graph and record a hash of the graph for later lookup
3. at inference time, the hash is used directly to lookup the optimized graph and run it.

# Limitations
We can not handle LTC/torchxla fall back right now. If a op misses LTC kernel, we raise and exception and that will results in dynamo fallback (or try another compiler). People have brainstormed the idea of graph breaking and stitching the subgraphs together. But maybe it's easier to add those missing LTC kernels for those models.

# Results
The models we tested are those not causing LTC fallback. We run the tests on **GPU**. We see **1.38x** geomean speedup for trochxla_trace_once  and torchxla_trivial is mostly neutral as expected.
```
| Model                   |   XLA (trace once) |   XLA (trace everytime) |
+=========================+====================+=========================+
| resnet18                |            1.346   |                 1.045   |
+-------------------------+--------------------+-------------------------+
| resnet50                |            1.153   |                 1.007   |
+-------------------------+--------------------+-------------------------+
| resnext50_32x4d         |            1.381   |                 1.039   |
+-------------------------+--------------------+-------------------------+
| alexnet                 |            1.045   |                 1.018   |
+-------------------------+--------------------+-------------------------+
| mobilenet_v2            |            1.562   |                 1.021   |
+-------------------------+--------------------+-------------------------+
| mnasnet1_0              |            1.303   |                 1.069   |
+-------------------------+--------------------+-------------------------+
| squeezenet1_1           |            1.278   |                 1.025   |
+-------------------------+--------------------+-------------------------+
| vgg16                   |            1.076   |                 1.008   |
+-------------------------+--------------------+-------------------------+
| BERT_pytorch            |            2.224   |                 0.978   |
+-------------------------+--------------------+-------------------------+
| timm_vision_transformer |            1.81    |                 1.025   |
+-------------------------+--------------------+-------------------------+
| geomean                 |            1.38101 |                 1.02324 |
+-------------------------+--------------------+-------------------------+
```

The speedup is similar to what we see from previous work for LTC's TorchScript backend (we see 1.40 geomean speedup there):
https://docs.google.com/presentation/d/1G09X8v41u_cLKLtSdf7v6R8G19-iZTPcW_VAdOnvYBI/edit#slide=id.g11bf989cb6b_1_5

# Next steps
- Use AOT autograd to enable training
- Share results on XLA devices
- Do more extensive tests on torchbench models

Example command
```
GPU_NUM_DEVICES=1 python benchmarks/dynamo/torchbench.py --randomize-input --performance --use-xla-baseline --only resnet18 --backend=torchxla_trace_once
```

Thanks @JackCaoG from torchxla team to help debugging various perf issues and merging the torchxla PR! That's super critical for us to get the results above. torchxla side PR: https://github.com/pytorch/xla/pull/4119 

topic: not user facing


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @jansel 

