### PR TITLE
Data loader initialization performance improvements

### DIFF
--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -7,6 +7,7 @@ static methods.
 import torch
 import random
 import os
+import pickle
 import queue
 from dataclasses import dataclass
 from torch._utils import ExceptionWrapper
@@ -210,7 +211,8 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
                  num_workers, persistent_workers, shared_seed):
     # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on the
     # logic of this function.
-
+    if type(dataset) is bytes:
+        dataset = pickle.loads(dataset)
     try:
         # Initialize C side signal handlers for SIGBUS and SIGSEGV. Python signal
         # module's handlers are executed after Python returns from C low-level


### PR DESCRIPTION
This PR accomplishes two objectives.
1. When a multi-process data loader is created, the dataset is pickled explicitly once before we start creating processes. (It will be pickled again once per thread in https://github.com/python/cpython/blob/3.7/Lib/multiprocessing/popen_forkserver.py#L46 or https://github.com/python/cpython/blob/3.7/Lib/multiprocessing/popen_spawn_posix.py#L46, but that would be much faster with a single 'bytes' object instead of a potentially complex nested Python data structure.)
2. If we are starting multiple subprocesses, we use an intermediate thread pool. The objective here is to allow initial dataset uploads https://github.com/python/cpython/blob/3.7/Lib/multiprocessing/popen_spawn_posix.py#L62 to happen concurrently instead of sequentially.

The two changes combined significantly improve the time it takes to construct the DataLoader in the case of a large complex dataset and a large number of num_workers. (I have a real-world use case, with num_workers=32, and pickled dataset size 2 GB, where these two changes bring the construction time down from ~30 minutes to less than 2 minutes.)