### PR TITLE
[JIT] Fix torch.jit.script for functions with many decorators

### DIFF
--- a/test/jit/test_misc.py
+++ b/test/jit/test_misc.py
@@ -361,3 +361,22 @@ class TestMisc(JitTestCase):
         ret = func()
         self.assertTrue(ret.numel() == 1)
         self.assertTrue(len(ret.size()) == 1)
+
+
+    def test_script_many_decorators(self):
+        def no_op_decorator(f):
+            return f
+
+        @no_op_decorator
+        @no_op_decorator
+        @no_op_decorator
+        @no_op_decorator
+        @no_op_decorator
+        def foo(x, dim: int):
+            return x.unsqueeze(dim)
+
+        x = torch.randn(1,)
+        expected = foo(x, 0)
+        scripted = torch.jit.script(foo)
+        actual = scripted(x, 0)
+        torch.testing.assert_allclose(expected, actual)

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -324,7 +324,7 @@ def build_class_def(ctx, py_def, methods, properties, self_name, assigns):
 
 def build_def(ctx, py_def, type_line, def_name, self_name=None, pdt_arg_types=None):
     body = py_def.body
-    r = ctx.make_range(py_def.lineno + len(py_def.decorator_list),
+    r = ctx.make_range(py_def.lineno,
                        py_def.col_offset,
                        py_def.col_offset + len("def"))
 


### PR DESCRIPTION
Summary:
Python's function parsing from the `ast` module records the line number of the function definition, not the first decorator. So this diff fixes crashes like this:

```
IndexError: vector::_M_range_check: __n (which is 10) >= this->size() (which is 8)
```

Test Plan: New unit test

Differential Revision: D40726352

