### PR TITLE
Cleanup macos common conda installation

### DIFF
--- a/.github/requirements/conda-env-macOS-ARM64
+++ b/.github/requirements/conda-env-macOS-ARM64
@@ -8,10 +8,16 @@ dataclasses=0.8
 pip=22.2.2
 six=1.16.0
 pillow=9.2.0
-libuv=1.40.0
 pkg-config=0.29.2
 wheel=0.37.1
 expecttest=0.1.3
 
 # Not pinning certifi so that we can always get the latest certificates
 certifi
+
+# TODO: Figure out a way to pin this dependency. At the moment, it could
+# not be pinned because cross-compiling arm64 from x86-64 picks up 1.40.0
+# while testing on arm64 itself only has up to 1.39.0 from upstream conda.
+# Thus, pinning the version to either leads to a conda package conflict.
+# Both versions work though, so it's ok to keep it like this.
+libuv

--- a/.github/requirements/conda-env-macOS-ARM64
+++ b/.github/requirements/conda-env-macOS-ARM64
@@ -2,15 +2,16 @@ numpy=1.22.3
 pyyaml=6.0
 setuptools=61.2.0
 cmake=3.22.1
-cffi=1.15.1
+cffi=
 typing_extensions=4.3.0
 dataclasses=0.8
 pip=22.2.2
-six=1.16.0
+six
 pillow=9.2.0
-libuv=1.39.0
+libuv
 pkg-config=0.29.2
 wheel=0.37.1
+expecttest=0.1.3
 
 # Not pinning certifi so that we can always get the latest certificates
 certifi

--- a/.github/requirements/conda-env-macOS-ARM64
+++ b/.github/requirements/conda-env-macOS-ARM64
@@ -2,7 +2,7 @@ numpy=1.22.3
 pyyaml=6.0
 setuptools=61.2.0
 cmake=3.22.1
-cffi=
+cffi
 typing_extensions=4.3.0
 dataclasses=0.8
 pip=22.2.2

--- a/.github/requirements/conda-env-macOS-ARM64
+++ b/.github/requirements/conda-env-macOS-ARM64
@@ -2,13 +2,13 @@ numpy=1.22.3
 pyyaml=6.0
 setuptools=61.2.0
 cmake=3.22.1
-cffi
+cffi=1.15.1
 typing_extensions=4.3.0
 dataclasses=0.8
 pip=22.2.2
-six
+six=1.16.0
 pillow=9.2.0
-libuv
+libuv=1.40.0
 pkg-config=0.29.2
 wheel=0.37.1
 expecttest=0.1.3

--- a/.github/requirements/conda-env-macOS-ARM64
+++ b/.github/requirements/conda-env-macOS-ARM64
@@ -15,9 +15,6 @@ expecttest=0.1.3
 # Not pinning certifi so that we can always get the latest certificates
 certifi
 
-# TODO: Figure out a way to pin this dependency. At the moment, it could
-# not be pinned because cross-compiling arm64 from x86-64 picks up 1.40.0
-# while testing on arm64 itself only has up to 1.39.0 from upstream conda.
-# Thus, pinning the version to either leads to a conda package conflict.
-# Both versions work though, so it's ok to keep it like this.
-libuv
+# Cross-compiling arm64 from x86-64 picks up 1.40.0 while testing on arm64
+# itself only has up to 1.39.0 from upstream conda. Both work though
+libuv>=1.39.0,<=1.40.0

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -33,6 +33,10 @@ on:
         default: "3.8"
         description: |
           The python version to be used. Will be 3.8 by default
+      environment-file:
+        required: false
+        type: string
+        description: Set the conda environment file used to setup macOS build.
       test-matrix:
         required: false
         type: string
@@ -83,10 +87,20 @@ jobs:
           fi
 
       - name: Setup miniconda
+        if: inputs.environment-file == ''
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
           python-version: ${{ inputs.python_version }}
           environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
+
+      # This option is used when cross-compiling arm64 from x86-64. Specifically, we need arm64 conda
+      # environment even though the arch is x86-64
+      - name: Setup miniconda using the provided environment file
+        if: inputs.environment-file != ''
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        with:
+          python-version: ${{ inputs.python_version }}
+          environment-file: ${{ inputs.environment-file }}
 
       - name: Install macOS homebrew dependencies
         run: |

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -86,6 +86,7 @@ jobs:
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
           python-version: ${{ inputs.python_version }}
+          environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install macOS homebrew dependencies
         run: |

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -41,6 +41,7 @@ jobs:
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
           python-version: 3.9
+          environment-file: .github/requirements/conda-env-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install PyTorch
         env:

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -51,7 +51,6 @@ jobs:
         run: |
           # shellcheck disable=SC1090
           set -ex
-          ${CONDA_INSTALL} expecttest numpy=1.22.3 pyyaml=6.0
           ${CONDA_RUN} python3 -mpip install "unittest-xml-reporting<=3.2.0,>=2.0.0"
           # As wheels are cross-compiled they are reported as x86_64 ones
           ORIG_WHLNAME=$(ls -1 dist/*.whl); ARM_WHLNAME=${ORIG_WHLNAME/x86_64/arm64}; mv ${ORIG_WHLNAME} ${ARM_WHLNAME}

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -22,6 +22,10 @@ jobs:
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
       python_version: 3.9.12
+      # We need to set the environment file here instead of trying to detect it automatically because
+      # MacOS arm64 is cross-compiled from x86-64. Specifically, it means that arm64 conda environment
+      # is needed when building PyTorch MacOS arm64 from x86-64
+      environment-file: .github/requirements/conda-env-macOS-ARM64
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -226,6 +226,10 @@ jobs:
       build-generates-artifacts: true
       # To match the one pre-installed in the m1 runners
       python_version: 3.9.12
+      # We need to set the environment file here instead of trying to detect it automatically because
+      # MacOS arm64 is cross-compiled from x86-64. Specifically, it means that arm64 conda environment
+      # is needed when building PyTorch MacOS arm64 from x86-64
+      environment-file: .github/requirements/conda-env-macOS-ARM64
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 2, runner: "macos-m1-12" },

--- a/.jenkins/pytorch/macos-common.sh
+++ b/.jenkins/pytorch/macos-common.sh
@@ -7,52 +7,6 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 sysctl -a | grep machdep.cpu
 
-if [[ ${BUILD_ENVIRONMENT} = *arm64* ]]; then
-  # We use different versions here as the arm build/tests runs on python 3.9
-  # while the x86 one runs on python 3.8
-  retry conda install -y \
-    numpy=1.22.3 \
-    pyyaml=6.0 \
-    setuptools=61.2.0 \
-    cmake=3.22.1 \
-    cffi \
-    ninja \
-    typing_extensions \
-    dataclasses \
-    pip
-else
-  # NOTE: mkl 2021.3.0+ cmake requires sub-command PREPEND, may break the build
-  retry conda install -y \
-    mkl=2021.2.0 \
-    mkl-include=2021.2.0 \
-    numpy=1.18.5 \
-    pyyaml=5.3 \
-    setuptools=46.0.0 \
-    cmake=3.22.1 \
-    cffi \
-    ninja \
-    typing_extensions \
-    dataclasses \
-    pip
-fi
-
-# The torch.hub tests make requests to GitHub.
-#
-# The certifi package from conda-forge is new enough to make the
-# following error disappear (included for future reference):
-#
-# > ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
-# > certificate verify failed: unable to get local issuer certificate
-# > (_ssl.c:1056)
-#
-retry conda install -y -c conda-forge certifi wheel=0.36.2
-
-# Needed by torchvision, which is imported from TestHub in test_utils.py.
-retry conda install -y pillow
-
-# Building with USE_DISTRIBUTED=1 requires libuv (for Gloo).
-retry conda install -y libuv pkg-config
-
 # These are required for both the build job and the test job.
 # In the latter to test cpp extensions.
 export MACOSX_DEPLOYMENT_TARGET=10.9

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -4,7 +4,6 @@
 # shellcheck source=./macos-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/macos-common.sh"
 
-conda install -y six
 if [[ ${BUILD_ENVIRONMENT} = *arm64* ]]; then
   pip install hypothesis "expecttest==0.1.3" "librosa>=0.6.2" "numba==0.56.0" psutil "scipy==1.9.0"
 else


### PR DESCRIPTION
The conda dependencies have all been installed for `_mac-test` in https://github.com/pytorch/pytorch/pull/87541.  I missed the same step for `_mac-build` and `_mac-test-mps` workflows, so both are also updated here. Note that arm64 is cross-compiled from x86, so the env file needs to be set explicitly in that case

After this one, I have a WIP PR to consolidate macos pip dependencies next