### PR TITLE
[dynamo] Add ao.nn to skipfiles inline allowlist

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -96,6 +96,7 @@ skipfiles_inline_module_allowlist = {
     torch.nn,
     torch.distributions,
     torch.testing,
+    torch.ao.nn,
 }
 if HAS_REFS_PRIMS:
     skipfiles_inline_module_allowlist |= {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #87820

Summary:

Allow torch.ao.nn module to be inlined

Test Plan:

Tested manually for https://github.com/pytorch/torchdynamo/issues/1737

Reviewers:

Subscribers:

Tasks:

Tags:

cc @jansel @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx

Differential Revision: [D40768679](https://our.internmc.facebook.com/intern/diff/D40768679)