### PR TITLE
Make GenLazyNativeFuncDefinition generator to be customizable in lazy codegen

### DIFF
--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -172,7 +172,6 @@ class GenLazyIR(ABC):
     backend_index: BackendIndex
     backend_name: str
     node_base: str
-    shape_class: str
 
     @method_with_native_function
     def __call__(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> List[str]:
@@ -254,7 +253,7 @@ class GenLazyIR(ABC):
         ctor_args = [f"const {i.lazy_type.cpp_type()}& {i.name}" for i in all_args]
         reuse_ctor_args = ", ".join(ctor_args)
         if schema.properties.ShapePrecompute:
-            ctor_args.append(f"std::vector<{self.shape_class}>&& shapes")
+            ctor_args.append("std::vector<torch::lazy::Shape>&& shapes")
         node_ctor_args = ", ".join(ctor_args)
 
         scalar_initializers = ",\n        ".join(

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -172,6 +172,7 @@ class GenLazyIR(ABC):
     backend_index: BackendIndex
     backend_name: str
     node_base: str
+    shape_class: str
 
     @method_with_native_function
     def __call__(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> List[str]:
@@ -253,7 +254,7 @@ class GenLazyIR(ABC):
         ctor_args = [f"const {i.lazy_type.cpp_type()}& {i.name}" for i in all_args]
         reuse_ctor_args = ", ".join(ctor_args)
         if schema.properties.ShapePrecompute:
-            ctor_args.append("std::vector<torch::lazy::Shape>&& shapes")
+            ctor_args.append(f"std::vector<{self.shape_class}>&& shapes")
         node_ctor_args = ", ".join(ctor_args)
 
         scalar_initializers = ",\n        ".join(

--- a/torchgen/gen_lazy_tensor.py
+++ b/torchgen/gen_lazy_tensor.py
@@ -23,7 +23,7 @@ import torchgen.dest as dest
 
 from torchgen.api.lazy import setValueT
 from torchgen.api.types import BaseCppType
-from torchgen.dest.lazy_ir import GenLazyIR, GenTSLazyIR, GenLazyNativeFuncDefinition
+from torchgen.dest.lazy_ir import GenLazyIR, GenLazyNativeFuncDefinition, GenTSLazyIR
 from torchgen.gen import get_grouped_native_functions, parse_native_yaml
 
 from torchgen.model import NativeFunction, NativeFunctionsGroup, OperatorName
@@ -201,7 +201,9 @@ class default_args:
     tensor_class_hdr: str = "torch/csrc/lazy/core/tensor.h"
     shape_class: str = "torch::lazy::Shape"
     lazy_ir_generator: Type[GenLazyIR] = GenLazyIR
-    native_func_definition_generator: Type[GenLazyNativeFuncDefinition] = GenLazyNativeFuncDefinition
+    native_func_definition_generator: Type[
+        GenLazyNativeFuncDefinition
+    ] = GenLazyNativeFuncDefinition
     backend_name: str = "TorchScript"
 
 
@@ -275,7 +277,9 @@ def main() -> None:
     lazy_ir_generator: Type[GenLazyIR] = default_args.lazy_ir_generator
     if options.gen_ts_lowerings:
         lazy_ir_generator = GenTSLazyIR
-    native_func_definition_generator: Type[GenLazyNativeFuncDefinition] = default_args.native_func_definition_generator
+    native_func_definition_generator: Type[
+        GenLazyNativeFuncDefinition
+    ] = default_args.native_func_definition_generator
 
     run_gen_lazy_tensor(
         aten_path,
@@ -308,7 +312,9 @@ def run_gen_lazy_tensor(
     shape_inference_hdr: str = default_args.shape_inference_hdr,
     shape_class: str = default_args.shape_class,
     lazy_ir_generator: Type[GenLazyIR] = default_args.lazy_ir_generator,
-    native_func_definition_generator: Type[GenLazyNativeFuncDefinition] = GenLazyNativeFuncDefinition,
+    native_func_definition_generator: Type[
+        GenLazyNativeFuncDefinition
+    ] = GenLazyNativeFuncDefinition,
     # build_in_tree is true for TS backend and affects include paths
     build_in_tree: bool = False,
     # per_operator_headers changes whether ATen/Functions.h or individual operator headers are used

--- a/torchgen/gen_lazy_tensor.py
+++ b/torchgen/gen_lazy_tensor.py
@@ -199,6 +199,7 @@ class default_args:
     shape_inference_hdr: str = "torch/csrc/lazy/core/shape_inference.h"
     tensor_class: str = "torch::lazy::LazyTensor"
     tensor_class_hdr: str = "torch/csrc/lazy/core/tensor.h"
+    shape_class: str = "torch::lazy::Shape"
     lazy_ir_generator: Type[GenLazyIR] = GenLazyIR
     backend_name: str = "TorchScript"
 
@@ -254,6 +255,12 @@ def main() -> None:
         help="Path to header file defining custom Lazy Tensor class",
     )
     parser.add_argument(
+        "--shape_class",
+        type=str,
+        default=default_args.shape_class,
+        help="Name of backend specific customer Shape class",
+    )
+    parser.add_argument(
         "--backend_name",
         type=str,
         default=default_args.backend_name,
@@ -278,6 +285,7 @@ def main() -> None:
         options.node_base_hdr,
         options.tensor_class,
         options.tensor_class_hdr,
+        options.shape_class,
         options.shape_inference_hdr,
         lazy_ir_generator,
         options.backend_name,
@@ -295,6 +303,7 @@ def run_gen_lazy_tensor(
     tensor_class: str = default_args.tensor_class,
     tensor_class_hdr: str = default_args.tensor_class_hdr,
     shape_inference_hdr: str = default_args.shape_inference_hdr,
+    shape_class: str = default_args.shape_class,
     lazy_ir_generator: Type[GenLazyIR] = default_args.lazy_ir_generator,
     # build_in_tree is true for TS backend and affects include paths
     build_in_tree: bool = False,
@@ -318,6 +327,8 @@ def run_gen_lazy_tensor(
     lazy_tensor_ptr: str = "LazyTensorPtr",
     get_device_fn: str = "torch::lazy::GetBackendDevice",
 ) -> None:
+    print("WONJOO: at gen_lazy_tensor.py")
+
     lv_tokens = lazy_value_class.split("::")
     lv_class = lv_tokens[-1]
     lv_ns = "::".join(lv_tokens[:-1])
@@ -523,7 +534,7 @@ def run_gen_lazy_tensor(
     )
     # Generate IR node classes
     lazy_ir_obj = lazy_ir_generator(
-        backend_indices[backend_key], backend_name, node_base
+        backend_indices[backend_key], backend_name, node_base, shape_class
     )
 
     fm.write_with_template(

--- a/torchgen/gen_lazy_tensor.py
+++ b/torchgen/gen_lazy_tensor.py
@@ -199,7 +199,6 @@ class default_args:
     shape_inference_hdr: str = "torch/csrc/lazy/core/shape_inference.h"
     tensor_class: str = "torch::lazy::LazyTensor"
     tensor_class_hdr: str = "torch/csrc/lazy/core/tensor.h"
-    shape_class: str = "torch::lazy::Shape"
     lazy_ir_generator: Type[GenLazyIR] = GenLazyIR
     native_func_definition_generator: Type[
         GenLazyNativeFuncDefinition
@@ -258,12 +257,6 @@ def main() -> None:
         help="Path to header file defining custom Lazy Tensor class",
     )
     parser.add_argument(
-        "--shape_class",
-        type=str,
-        default=default_args.shape_class,
-        help="Name of backend specific customer Shape class",
-    )
-    parser.add_argument(
         "--backend_name",
         type=str,
         default=default_args.backend_name,
@@ -292,7 +285,6 @@ def main() -> None:
         options.tensor_class,
         options.tensor_class_hdr,
         options.shape_inference_hdr,
-        options.shape_class,
         lazy_ir_generator,
         native_func_definition_generator,
         options.backend_name,
@@ -310,7 +302,6 @@ def run_gen_lazy_tensor(
     tensor_class: str = default_args.tensor_class,
     tensor_class_hdr: str = default_args.tensor_class_hdr,
     shape_inference_hdr: str = default_args.shape_inference_hdr,
-    shape_class: str = default_args.shape_class,
     lazy_ir_generator: Type[GenLazyIR] = default_args.lazy_ir_generator,
     native_func_definition_generator: Type[
         GenLazyNativeFuncDefinition
@@ -542,7 +533,7 @@ def run_gen_lazy_tensor(
     )
     # Generate IR node classes
     lazy_ir_obj = lazy_ir_generator(
-        backend_indices[backend_key], backend_name, node_base, shape_class
+        backend_indices[backend_key], backend_name, node_base
     )
 
     fm.write_with_template(

--- a/torchgen/gen_lazy_tensor.py
+++ b/torchgen/gen_lazy_tensor.py
@@ -305,7 +305,7 @@ def run_gen_lazy_tensor(
     lazy_ir_generator: Type[GenLazyIR] = default_args.lazy_ir_generator,
     native_func_definition_generator: Type[
         GenLazyNativeFuncDefinition
-    ] = GenLazyNativeFuncDefinition,
+    ] = default_args.native_func_definition_generator,
     # build_in_tree is true for TS backend and affects include paths
     build_in_tree: bool = False,
     # per_operator_headers changes whether ATen/Functions.h or individual operator headers are used

--- a/torchgen/gen_lazy_tensor.py
+++ b/torchgen/gen_lazy_tensor.py
@@ -331,8 +331,6 @@ def run_gen_lazy_tensor(
     lazy_tensor_ptr: str = "LazyTensorPtr",
     get_device_fn: str = "torch::lazy::GetBackendDevice",
 ) -> None:
-    print("WONJOO: at gen_lazy_tensor.py")
-
     lv_tokens = lazy_value_class.split("::")
     lv_class = lv_tokens[-1]
     lv_ns = "::".join(lv_tokens[:-1])


### PR DESCRIPTION
As part of the ongoing LTC migration effort, PyTorch/XLA is updating its codegen to use `xla::Shape` instead of `torch::lazy::Shape`. To achieve this, this PR updates the codegen to make the `GenLazyNativeFuncDefinition` generator customizable. 

The existing `GenLazyNativeFuncDefinition` is kept by using the initial default values, so this change should not introduce any new behaviors to the existing codegen in PyTorch. 