### PR TITLE
Fix typos under .github directory

### DIFF
--- a/.github/requirements/README.md
+++ b/.github/requirements/README.md
@@ -4,7 +4,7 @@ At the moment, the installation of conda and pip dependencies happens at
 different places in the CI depending at the whim of different
 developers, which makes it very challenging to handle issues like
 network flakiness or upstream dependency failures gracefully. So, this
-center directory is created to gradually include all the conda enviroment
+center directory is created to gradually include all the conda environment
 and pip requirement files that are used to setup CI jobs. Not only it
 gives a clear picture of all the dependencies required by different CI
 jobs, but it also allows them to be cached properly to improve CI

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -36,7 +36,7 @@ New generated binary workflows can be added in the `.github/scripts/generate_ci_
 examples from that script in order to add the workflow to the stream that is relevant to what you particularly
 care about.
 
-Different parameters can be used to acheive different goals, i.e. running jobs on a cron, running only on trunk, etc.
+Different parameters can be used to achieve different goals, i.e. running jobs on a cron, running only on trunk, etc.
 
 #### ciflow (trunk)
 


### PR DESCRIPTION
This PR fixes typos in `.md` files under .github directory
