### PR TITLE
Fix consistentcy of histc on CPU and CUDA

### DIFF
--- a/aten/src/ATen/native/cpu/HistogramKernel.cpp
+++ b/aten/src/ATen/native/cpu/HistogramKernel.cpp
@@ -166,8 +166,8 @@ void histogramdd_cpu_contiguous(Tensor& hist, const TensorList& bin_edges,
                      * the appropriate bin via simple division.
                      */
                     pos = static_cast<int64_t>((elt - leftmost_edge[dim])
-                            / (rightmost_edge[dim] - leftmost_edge[dim])
-                            * (num_bin_edges[dim] - 1));
+                            * (num_bin_edges[dim] - 1)
+                            / (rightmost_edge[dim] - leftmost_edge[dim]));
 
                     /* Ensures consistency with bin_edges by checking the bins to the left and right
                      * of the selected position. Necessary for cases in which an element very close

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2813,6 +2813,14 @@ class TestReductions(TestCase):
             torch.histc(torch.tensor([1., 2., 3.], dtype=torch.float, device=device),
                         bins=4, min=5, max=1)
 
+        # test consistency between CPU and GPU
+        actual = torch.histc(
+            torch.linspace(0, 0.99, 1001, dtype=torch.float32).to(device),
+            bins=10, min=0, max=0.99)
+        self.assertEqual(
+            torch.tensor([101, 99, 101, 99, 101, 99, 100, 100, 100, 101], dtype=torch.float, device=device),
+            actual)
+
         # test against numpy.histogram()
         def test_against_np(tensor, bins=100, min=0, max=0):
             if min == 0 and max == 0:
@@ -2842,13 +2850,6 @@ class TestReductions(TestCase):
 
         expanded = torch.randn(1, 5, 1, 2, device=device).expand(3, 5, 7, 2)
         test_against_np(expanded)
-
-        if torch.cuda.is_available():
-            linear = torch.linspace(0, 0.99, 1001)
-            self.assertEqual(
-                torch.histc(linear, bins=10, min=0, max=0.99),
-                torch.histc(linear.cuda(), bins=10, min=0, max=0.99)
-            )
 
     @onlyCPU
     def test_histc_bfloat16(self, device):

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2813,14 +2813,6 @@ class TestReductions(TestCase):
             torch.histc(torch.tensor([1., 2., 3.], dtype=torch.float, device=device),
                         bins=4, min=5, max=1)
 
-        # test consistency between CPU and GPU
-        actual = torch.histc(
-            torch.linspace(0, 0.99, 1001, dtype=torch.float32).to(device),
-            bins=10, min=0, max=0.99)
-        self.assertEqual(
-            torch.tensor([101, 99, 101, 99, 101, 99, 100, 100, 100, 101], dtype=torch.float, device=device),
-            actual)
-
         # test against numpy.histogram()
         def test_against_np(tensor, bins=100, min=0, max=0):
             if min == 0 and max == 0:
@@ -2850,6 +2842,9 @@ class TestReductions(TestCase):
 
         expanded = torch.randn(1, 5, 1, 2, device=device).expand(3, 5, 7, 2)
         test_against_np(expanded)
+
+        linear = torch.linspace(0, 0.99, 101, dtype=torch.float32).to(device)
+        test_against_np(linear, bins=20, min=0, max=0.99 + 5.0e-8)
 
     @onlyCPU
     def test_histc_bfloat16(self, device):

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2846,7 +2846,7 @@ class TestReductions(TestCase):
         if torch.cuda.is_available():
             linear = torch.linspace(0, 0.99, 1001)
             self.assertEqual(
-                torch.histc(linear, bins=10, min=0, max=0.99), 
+                torch.histc(linear, bins=10, min=0, max=0.99),
                 torch.histc(linear.cuda(), bins=10, min=0, max=0.99)
             )
 

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2843,6 +2843,13 @@ class TestReductions(TestCase):
         expanded = torch.randn(1, 5, 1, 2, device=device).expand(3, 5, 7, 2)
         test_against_np(expanded)
 
+        if torch.cuda.is_available():
+            linear = torch.linspace(0, 0.99, 1001)
+            self.assertEqual(
+                torch.histc(linear, bins=10, min=0, max=0.99), 
+                torch.histc(linear.cuda(), bins=10, min=0, max=0.99)
+            )
+
     @onlyCPU
     def test_histc_bfloat16(self, device):
         actual = torch.histc(

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2843,8 +2843,8 @@ class TestReductions(TestCase):
         expanded = torch.randn(1, 5, 1, 2, device=device).expand(3, 5, 7, 2)
         test_against_np(expanded)
 
-        linear = torch.linspace(0, 0.99, 101, dtype=torch.float32).to(device)
-        test_against_np(linear, bins=20, min=0, max=0.99 + 5.0e-8)
+        linear = torch.linspace(0, 0.99 - 5.0e-7, 101).to(device)
+        test_against_np(linear, bins=20, min=0, max=0.99)
 
     @onlyCPU
     def test_histc_bfloat16(self, device):


### PR DESCRIPTION
Fixes #87657

The main reason why `histc` returns slightly different outputs is the difference on how bin position is calculate.
The CPU calculates it as: https://github.com/pytorch/pytorch/blob/449778a939f2adc8867c5035b08be4e2d88339d8/aten/src/ATen/native/cpu/HistogramKernel.cpp#L168-L170
which is basically `(i - a) / (b - a) * N`, while cuda code https://github.com/pytorch/pytorch/blob/449778a939f2adc8867c5035b08be4e2d88339d8/aten/src/ATen/native/cuda/SummaryOps.cu#L41
 which is `(i - a) * N / (b - a)`. 

For some cases like in #87657 the order of arithmetic operations matters due to the floating point round-off. 

________________

Not sure where would be the most appropriate place to put the unit test. Hope `test_reductions::test_histc` will do. 



cc @VitalyFedyunin @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10