### PR TITLE
[FSDP] Fix wrapped module changing after ctor

### DIFF
--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -536,11 +536,10 @@ class TestFSDPMisc(FSDPTest):
             offload_to_cpu=False,
             checkpoint_impl=CheckpointImpl.NO_REENTRANT,
         )
-        check_fn = lambda submodule: isinstance(submodule, nn.Linear)
         apply_activation_checkpointing(
             model,
             checkpoint_wrapper_fn=non_reentrant_wrapper,
-            check_fn=check_fn,
+            check_fn=lambda submodule: isinstance(submodule, nn.Linear),
         )
 
         # Check that `seq2[0]` only has a single `FlatParameter` registered and

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -11,7 +11,9 @@ import torch
 import torch.nn as nn
 from torch import distributed as dist
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    apply_activation_checkpointing,
     checkpoint_wrapper,
+    CheckpointImpl,
 )
 from torch.distributed.fsdp import (
     CPUOffload,
@@ -109,10 +111,22 @@ class TestFSDPStateDict(FSDPTest):
     def world_size(self):
         return 2
 
-    def _broadcast_state_dict(self, state_dict):
+    def _broadcast_state_dict(self, model, state_dict):
+        if not isinstance(model, FSDP):
+            # For non-FSDP root, some parts of the model state on rank 0 may
+            # not be on CPU, so we move everything to CPU to avoid issues like:
+            # https://github.com/pytorch/pytorch/issues/77113.
+            for param_name, param in state_dict.items():
+                if param.device != torch.device("cpu"):
+                    state_dict[param_name] = param.cpu()
+
         olist = [state_dict if self.rank == 0 else None]
         dist.broadcast_object_list(olist)
-        return olist[0]
+        state_dict = olist[0]
+        # Ensure that the state is on CUDA
+        for param_name in state_dict.keys():
+            state_dict[param_name] = state_dict[param_name].cuda()
+        return state_dict
 
     def _compare_models(self, model, model_new, assert_fn, check_fp16=False):
         assert assert_fn in (self.assertEqual, self.assertNotEqual)
@@ -220,9 +234,10 @@ class TestFSDPStateDict(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _UNFLATTENED_STATE_DICT_IMPLS)
-    @parametrize("checkpoint_wrap", ["first", "second", "both"])
+    @parametrize("checkpoint_wrap", ["source", "dest", "both", "source_after_wrap"])
+    @parametrize("rank0_only_and_offload", [False, True])
     def test_fsdp_state_dict_with_activation_checkpoint(
-        self, state_dict_type, checkpoint_wrap
+        self, state_dict_type, checkpoint_wrap, rank0_only_and_offload
     ):
         """Tests saving the state dict, zeroing a target model's parameters, and
         loading the state dict, where the source and target models may have a
@@ -231,16 +246,32 @@ class TestFSDPStateDict(FSDPTest):
             partial(self._get_simple_model),
             partial(self._get_simple_nested_model),
         ]:
-            model = model_call(checkpoint_wrap=(checkpoint_wrap in ["first", "both"]))
-            with FSDP.state_dict_type(model, STATE_DICT_MAPPING[state_dict_type]):
+            model = model_call(checkpoint_wrap=(checkpoint_wrap in ["source", "both"]))
+            if checkpoint_wrap == "source_after_wrap":
+                non_reentrant_wrapper = partial(
+                    checkpoint_wrapper,
+                    offload_to_cpu=False,
+                    checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+                )
+                check_fn = lambda submodule: isinstance(submodule, nn.Linear)
+                apply_activation_checkpointing(
+                    model,
+                    checkpoint_wrapper_fn=non_reentrant_wrapper,
+                    check_fn=check_fn,
+                )
+            with self._get_state_dict_mgr(
+                model, state_dict_type, rank0_only_and_offload
+            ):
                 state_dict = _gather_state_dict(_get_state_dict(model, False, False))
                 # Possibly wrap new model in activation checkpoint wrapper to test save/
                 # load with this wrapper
                 model_new = model_call(
-                    checkpoint_wrap=(checkpoint_wrap in ["second", "both"])
+                    checkpoint_wrap=(checkpoint_wrap in ["dest", "both"])
                 )
                 _zero_model(model_new)
                 self._compare_models(model, model_new, self.assertNotEqual)
+                if rank0_only_and_offload:
+                    state_dict = self._broadcast_state_dict(model, state_dict)
                 # Would fail if checkpoint_wrapper did not correctly implement state_dict pre/post hooks
                 model_new.load_state_dict(state_dict, strict=True)
                 self._compare_models(model, model_new, self.assertEqual)
@@ -417,17 +448,7 @@ class TestFSDPStateDict(FSDPTest):
 
             # Verify parameters are the same in the new model.
             if state_dict_rank0_and_offload:
-                # Broadcast the state dict and move it back to GPU in
-                # preparation for loading.
-                if not isinstance(model, FSDP):
-                    # Move everything to CPU to avoid running into
-                    # https://github.com/pytorch/pytorch/issues/77113, some params
-                    # will still be on GPU for non FSDP root modules.
-                    for k in fsdp_state_dict.keys():
-                        fsdp_state_dict[k] = fsdp_state_dict[k].cpu()
-                fsdp_state_dict = self._broadcast_state_dict(fsdp_state_dict)
-                for key in fsdp_state_dict.keys():
-                    fsdp_state_dict[key] = fsdp_state_dict[key].cuda()
+                fsdp_state_dict = self._broadcast_state_dict(model, fsdp_state_dict)
             with FSDP.state_dict_type(model_new, STATE_DICT_MAPPING[state_dict_type]):
                 model_new.load_state_dict(fsdp_state_dict, strict=True)
 
@@ -494,11 +515,7 @@ class TestFSDPStateDict(FSDPTest):
 
         # Load state_dict into zeroed model
         if state_dict_rank0_and_offload:
-            # Broadcast the state dict and move it back to GPU in
-            # preparation for loading.
-            state_dict = self._broadcast_state_dict(state_dict)
-            for key in state_dict.keys():
-                state_dict[key] = state_dict[key].cuda()
+            state_dict = self._broadcast_state_dict(model, state_dict)
 
         with FSDP.state_dict_type(model, STATE_DICT_MAPPING[state_dict_type]):
             model.load_state_dict(state_dict, strict=True)
@@ -675,17 +692,7 @@ class TestFSDPStateDict(FSDPTest):
         # Load fsdp's full state dict into the local and verify params are as
         # expected.
         if state_dict_rank0_and_offload:
-            # Broadcast + CUDA state_dict
-            if not isinstance(model, FSDP):
-                # Some portions of the model on rank 0 might not be on CPU,
-                # move everything to CPU to avoid running into
-                # https://github.com/pytorch/pytorch/issues/77113.
-                for k, t in fsdp_state_dict.items():
-                    if t.device != torch.device("cpu"):
-                        fsdp_state_dict[k] = t.cpu()
-            fsdp_state_dict = self._broadcast_state_dict(fsdp_state_dict)
-            for key in fsdp_state_dict.keys():
-                fsdp_state_dict[key] = fsdp_state_dict[key].cuda()
+            fsdp_state_dict = self._broadcast_state_dict(model, fsdp_state_dict)
 
         # if self.rank == 0:
         blank_local_model.load_state_dict(fsdp_state_dict, strict=True)

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -210,7 +210,7 @@ def _local_pre_load_state_dict_hook(
     assert len(shards), "load_local_state_dict assume one shard per ShardedTensor."
     load_tensor = shards[0].tensor
 
-    # Get the metada of the flat_param to decide whether to pad the loaded
+    # Get the metadata of the flat_param to decide whether to pad the loaded
     # tensor.
     flat_param = module._handles[0].flat_param
     assert flat_param is not None

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1889,6 +1889,8 @@ class FullyShardedDataParallel(nn.Module):
                 # (e.g. applying the activation checkpointing wrapper) and
                 # if so, de-register the `FlatParameter` from the old
                 # wrapped module and register it to the new wrapped module
+                # NOTE: The `FlatParameter`'s FQN metadata is not updated, so
+                # any added wrappers must clean their prefixes from FQNs.
                 flat_param = fsdp_module._handles[0].flat_param
                 target_submodule = None
                 target_name = None

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1884,40 +1884,39 @@ class FullyShardedDataParallel(nn.Module):
         # to non-root instances
         inconsistent_limit_all_gathers = False
         for fsdp_module in self.fsdp_modules(self):
-            if not fsdp_module._use_orig_params:
-                if fsdp_module._has_params:
-                    # Check if the wrapped module changed after construction
-                    # (e.g. applying the activation checkpointing wrapper) and
-                    # if so, de-register the `FlatParameter` from the old
-                    # wrapped module and register it to the new wrapped module
-                    flat_param = fsdp_module._handles[0].flat_param
-                    target_submodule = None
-                    target_name = None
-                    for submodule in fsdp_module.modules():
-                        for param_name, param in submodule._parameters.items():
-                            if flat_param is param:
-                                target_submodule = submodule
-                                target_name = param_name
-                                break
-                    if (
-                        target_submodule is not None
-                        and target_submodule is not fsdp_module.module
-                    ):
-                        assert target_name is not None
-                        if fsdp_module._debug_level == dist.DebugLevel.DETAIL:
-                            warnings.warn(
-                                "The FSDP wrapped module changed from "
-                                f"{target_submodule} to {fsdp_module.module}"
-                            )
-                        target_submodule._parameters.pop(target_name)
-                    elif target_submodule is None:
-                        raise RuntimeError(
-                            "Either the FSDP wrapped module was removed from "
-                            "the model or its `FlatParameter` was manually "
-                            "de-registered. Both of these are invalid behavior."
+            if not fsdp_module._use_orig_params and fsdp_module._has_params:
+                # Check if the wrapped module changed after construction
+                # (e.g. applying the activation checkpointing wrapper) and
+                # if so, de-register the `FlatParameter` from the old
+                # wrapped module and register it to the new wrapped module
+                flat_param = fsdp_module._handles[0].flat_param
+                target_submodule = None
+                target_name = None
+                for submodule in fsdp_module.modules():
+                    for param_name, param in submodule._parameters.items():
+                        if flat_param is param:
+                            target_submodule = submodule
+                            target_name = param_name
+                            break
+                if (
+                    target_submodule is not None
+                    and target_submodule is not fsdp_module.module
+                ):
+                    assert target_name is not None
+                    if fsdp_module._debug_level == dist.DebugLevel.DETAIL:
+                        warnings.warn(
+                            "The FSDP wrapped module changed from "
+                            f"{target_submodule} to {fsdp_module.module}"
                         )
-                    if target_submodule is not fsdp_module.module:
-                        fsdp_module._register_flat_param()
+                    target_submodule._parameters.pop(target_name)  # de-register
+                elif target_submodule is None:
+                    raise RuntimeError(
+                        "Either the FSDP wrapped module was removed from "
+                        "the model or its `FlatParameter` was manually "
+                        "de-registered. Both of these are invalid behavior."
+                    )
+                if target_submodule is not fsdp_module.module:
+                    fsdp_module._register_flat_param()
             if fsdp_module is not self:
                 # Relax the assert for non-root FSDP instances in case the
                 # nested initialized module is wrapped again in FSDP later (e.g.

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1906,14 +1906,16 @@ class FullyShardedDataParallel(nn.Module):
                     if fsdp_module._debug_level == dist.DebugLevel.DETAIL:
                         warnings.warn(
                             "The FSDP wrapped module changed from "
-                            f"{target_submodule} to {fsdp_module.module}"
+                            f"{target_submodule} to {fsdp_module.module} on "
+                            f"rank {fsdp_module.rank}. {fsdp_module}"
                         )
                     target_submodule._parameters.pop(target_name)  # de-register
                 elif target_submodule is None:
                     raise RuntimeError(
                         "Either the FSDP wrapped module was removed from "
                         "the model or its `FlatParameter` was manually "
-                        "de-registered. Both of these are invalid behavior."
+                        f"de-registered on rank {fsdp_module.rank}. Both of "
+                        f"these are invalid behavior. {fsdp_module}"
                     )
                 if target_submodule is not fsdp_module.module:
                     fsdp_module._register_flat_param()

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1884,6 +1884,40 @@ class FullyShardedDataParallel(nn.Module):
         # to non-root instances
         inconsistent_limit_all_gathers = False
         for fsdp_module in self.fsdp_modules(self):
+            if not fsdp_module._use_orig_params:
+                if fsdp_module._has_params:
+                    # Check if the wrapped module changed after construction
+                    # (e.g. applying the activation checkpointing wrapper) and
+                    # if so, de-register the `FlatParameter` from the old
+                    # wrapped module and register it to the new wrapped module
+                    flat_param = fsdp_module._handles[0].flat_param
+                    target_submodule = None
+                    target_name = None
+                    for submodule in fsdp_module.modules():
+                        for param_name, param in submodule._parameters.items():
+                            if flat_param is param:
+                                target_submodule = submodule
+                                target_name = param_name
+                                break
+                    if (
+                        target_submodule is not None
+                        and target_submodule is not fsdp_module.module
+                    ):
+                        assert target_name is not None
+                        if fsdp_module._debug_level == dist.DebugLevel.DETAIL:
+                            warnings.warn(
+                                "The FSDP wrapped module changed from "
+                                f"{target_submodule} to {fsdp_module.module}"
+                            )
+                        target_submodule._parameters.pop(target_name)
+                    elif target_submodule is None:
+                        raise RuntimeError(
+                            "Either the FSDP wrapped module was removed from "
+                            "the model or its `FlatParameter` was manually "
+                            "de-registered. Both of these are invalid behavior."
+                        )
+                    if target_submodule is not fsdp_module.module:
+                        fsdp_module._register_flat_param()
             if fsdp_module is not self:
                 # Relax the assert for non-root FSDP instances in case the
                 # nested initialized module is wrapped again in FSDP later (e.g.

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -2880,7 +2880,8 @@ class FullyShardedDataParallel(nn.Module):
         attribute but dynamically change whether it is visible to ``nn.Module``
         methods.
         """
-        self.module._parameters.pop(FLAT_PARAM, None)
+        if self._has_params:
+            self.module._parameters.pop(FLAT_PARAM, None)
 
     @contextlib.contextmanager
     def _deregister_orig_params_ctx(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#87837 [FSDP] Fix wrapped module changing after ctor**
* #87812 [FSDP] ufmt FSDP test
* #87811 [FSDP] ufmt /fsdp

Recently, I retired `FlattenParamsWrapper`, which meant that FSDP registers its `FlatParameter` on the wrapped module instead of the `FlattenParamsWrapper` instance. This is only relevant for `use_orig_params=False`.

If the user changes an FSDP instance's wrapped module after the FSDP constructor, then the `FlatParameter` is no longer registered on the wrapped module. This can cause issues for full state dict, which checks if the `FlatParameter` is currently registered as an early return condition for `rank0_only=True`.

The solution in this PR is to re-establish the wrapped module in `_lazy_init()`, de-registering from the old wrapped module and re-registering to the new wrapped module, where the assumption is that the user should not modify the module structure upon `_lazy_init()`.

The direct access to the private attribute `_parameters` from `nn.Module` is not ideal, but we already rely on it for the dynamic `FlatParameter` registration. The tradeoff is whether we want an additional `nn.Module` wrapper (`FlattenParamsWrapper`) and use `delattr` plus a singleton list to do the dynamic registration or we want to access `_parameters`. If this becomes a problem, we can work with Core team on a solution.

Differential Revision: [D40799962](https://our.internmc.facebook.com/intern/diff/D40799962)