### PR TITLE
Use c10::irange in many places

### DIFF
--- a/android/pytorch_android_torchvision/src/main/cpp/pytorch_vision_jni.cpp
+++ b/android/pytorch_android_torchvision/src/main/cpp/pytorch_vision_jni.cpp
@@ -100,8 +100,8 @@ static void imageYUV420CenterCropToFloatBuffer(
     int wr = outOffset;
     int wg = wr + channelSize;
     int wb = wg + channelSize;
-    for (int y = 0; y < tensorHeight; y++) {
-      for (int x = 0; x < tensorWidth; x++) {
+    for (const auto y : c10::irange(tensorHeight)) {
+      for (const auto x : c10::irange(tensorWidth)) {
         xBeforeRtn = cropXAdd + cropXMult * (int)(x * scale);
         yBeforeRtn = cropYAdd + cropYMult * (int)(y * scale);
         yIdx = yBeforeRtn * yRowStride + xBeforeRtn * yPixelStride;
@@ -127,8 +127,8 @@ static void imageYUV420CenterCropToFloatBuffer(
     }
   } else if (memoryFormatCode == kMemoryFormatChannelsLast) {
     int wc = outOffset;
-    for (int y = 0; y < tensorHeight; y++) {
-      for (int x = 0; x < tensorWidth; x++) {
+    for (const auto y : c10::irange(tensorHeight)) {
+      for (const auto x : c10::irange(tensorWidth)) {
         xBeforeRtn = cropXAdd + cropXMult * (int)(x * scale);
         yBeforeRtn = cropYAdd + cropYMult * (int)(y * scale);
         yIdx = yBeforeRtn * yRowStride + xBeforeRtn * yPixelStride;

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -1,5 +1,6 @@
 #include <ATen/DLConvertor.h>
 #include <ATen/Functions.h>
+#include <c10/util/irange.h>
 
 #include <iostream>
 #include <sstream>
@@ -219,7 +220,7 @@ DLManagedTensor* toDLPack(const Tensor& src) {
   // gh-83069
   auto shape = src.sizes();
   auto strides = src.strides().vec();
-  for (int i=0; i<src.dim(); i++) {
+  for (const auto i : c10::irange(src.dim())) {
     if (shape[i] < 2) {
       strides[i] = 1;
     }

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -454,7 +454,7 @@ inline Tensor _sum_to(
   for (const auto i : c10::irange(leading_dims)) {
     reduce_dims.push_back(i);
   }
-  for (int64_t i = leading_dims; i < static_cast<int64_t>(sizes.size()); ++i) {
+  for (const auto i : c10::irange(leading_dims, sizes.size())) {
     if (shape[i - leading_dims] == 1 && sizes[i] != 1) {
       reduce_dims.push_back(i);
     }

--- a/aten/src/ATen/FunctionalInverses.cpp
+++ b/aten/src/ATen/FunctionalInverses.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/ExpandUtils.h>
+#include <c10/util/irange.h>
 namespace at {
 namespace functionalization {
 
@@ -195,7 +196,7 @@ Tensor FunctionalInverses::split_with_sizes_copy_inverse(const Tensor& base, con
     dim = at::maybe_wrap_dim(dim, base.dim());
     auto dim_size = base.sym_size(dim);
     c10::SymInt start = 0;
-    for (auto i = 0; i < mutated_view_idx; ++i) {
+    for (const auto i : c10::irange(mutated_view_idx)) {
         start += split_sizes[i];
     }
     auto end = start + split_sizes[mutated_view_idx];

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -8,6 +8,7 @@
 #include <c10/util/Exception.h>
 #include <c10/core/TensorImpl.h>
 #include <c10/util/Logging.h>
+#include <c10/util/irange.h>
 
 #include <numeric>
 #include <functional>
@@ -116,7 +117,7 @@ inline at::Tensor construct_nested_stride_tensor(const at::Tensor& sizes) {
   at::Tensor strides = sizes.new_empty(sizes.sizes());
   const int64_t* sizes_ptr = sizes.data_ptr<int64_t>();
   int64_t* strides_ptr = strides.data_ptr<int64_t>();
-  for (int64_t i = 0; i < sizes.size(0); i++) {
+  for (C10_UNUSED const auto i : c10::irange(sizes.size(0))) {
     strides_ptr[orig_dim - 1] = 1;
     int64_t product = sizes_ptr[orig_dim - 1];
     for (int64_t j = orig_dim - 2; j >= 0; j--) {

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -232,7 +232,7 @@ inline bool nested_tensor_impl_is_contiguous(const NestedTensorImpl* nt) {
   if (orig_dim == 0) {
     // each scalar must be contiguous
     // if there is blanck memory between underlying scalars
-    for (int64_t i = 0; i < ntensors; i++) {
+    for (const auto i : c10::irange(ntensors)) {
       if (offsets[i] != i) {
         return false;
       }
@@ -243,7 +243,7 @@ inline bool nested_tensor_impl_is_contiguous(const NestedTensorImpl* nt) {
     // if any underlying tensor is noncontiguous
     const int64_t *sizemat_ptr = sizemat.data_ptr<int64_t>(),
                   *stridemat_ptr = stridemat.data_ptr<int64_t>();
-    for (int64_t i = 0; i < ntensors; i++) {
+    for (C10_UNUSED const auto i : c10::irange(ntensors)) {
       if (stridemat_ptr[orig_dim - 1] != 1) {
         return false;
       }
@@ -263,7 +263,7 @@ inline bool nested_tensor_impl_is_contiguous(const NestedTensorImpl* nt) {
     }
     sizemat_ptr = sizemat.data_ptr<int64_t>();
     stridemat_ptr = stridemat.data_ptr<int64_t>();
-    for (int64_t i = 1; i < ntensors; i++) {
+    for (const auto i : c10::irange(1, ntensors)) {
       if (offsets[i] != offsets[i - 1] + *sizemat_ptr * *stridemat_ptr) {
         return false;
       }

--- a/aten/src/ATen/VmapTransforms.cpp
+++ b/aten/src/ATen/VmapTransforms.cpp
@@ -67,7 +67,7 @@ VmapDimVector VmapPhysicalView::getPhysicalDims(OptionalIntArrayRef opt_logical_
       result.push_back(maybe_wrap_dim(dim, logical_ndim) + numBatchDims());
     }
   } else {
-    for (int64_t dim = 0; dim < logical_ndim; dim++) {
+    for (const auto dim : c10::irange(logical_ndim)) {
       result.push_back(dim + numBatchDims());
     }
   }

--- a/aten/src/ATen/WrapDimUtilsMulti.h
+++ b/aten/src/ATen/WrapDimUtilsMulti.h
@@ -34,7 +34,7 @@ static inline std::bitset<dim_bitset_size> dim_list_to_bitset(
       seen[dim] = true;
     }
   } else {
-    for (int64_t dim = 0; dim < ndims; dim++) {
+    for (const auto dim : c10::irange(ndims)) {
       seen[dim] = true;
     }
   }

--- a/aten/src/ATen/core/IListRef_test.cpp
+++ b/aten/src/ATen/core/IListRef_test.cpp
@@ -1,6 +1,7 @@
 #include <ATen/Functions.h>
 #include <ATen/core/IListRef.h>
 #include <ATen/core/Tensor.h>
+#include <c10/util/irange.h>
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <iterator>
@@ -10,7 +11,7 @@ using namespace c10;
 static std::vector<at::Tensor> get_tensor_vector() {
   std::vector<at::Tensor> tensors;
   const size_t SIZE = 5;
-  for (size_t i = 0; i < SIZE; i++) {
+  for (const auto i : c10::irange(SIZE)) {
     tensors.emplace_back(at::empty({0}));
   }
   return tensors;

--- a/aten/src/ATen/core/class_type.cpp
+++ b/aten/src/ATen/core/class_type.cpp
@@ -406,7 +406,7 @@ void ClassType::unsafeRemoveMethod(const std::string& name) {
 ClassTypePtr ClassType::refine(at::ArrayRef<TypePtr> refined_slots) const {
   auto ptr = ClassType::create(name(), compilation_unit_, is_module());
   AT_ASSERT(numAttributes() == refined_slots.size());
-  for (size_t i = 0; i < attributes_.size(); ++i) {
+  for (const auto i : c10::irange(attributes_.size())) {
     AT_ASSERT(refined_slots[i]->isSubtypeOf(*attributes_[i].getType()));
     ptr->addAttribute(attributes_[i].getName(), refined_slots[i], (attributes_[i].getKind() == AttributeKind::PARAMETER),
     (attributes_[i].getKind() == AttributeKind::BUFFER));
@@ -495,7 +495,7 @@ const std::vector<torch::jit::Function*>& ClassType::methods() const {
 
 void ClassType::checkNotExist(const std::string& name, const std::string& what) const {
   // Check no overlap with existing constants
-  for (size_t i = 0; i < constantNames_.size(); ++i) {
+  for (const auto i : c10::irange(constantNames_.size())) {
     TORCH_CHECK(
         name != constantNames_[i],
         "attempting to add ",

--- a/aten/src/ATen/core/class_type.h
+++ b/aten/src/ATen/core/class_type.h
@@ -5,6 +5,7 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/core/jit_type_base.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 namespace torch {
 namespace jit {
@@ -302,7 +303,7 @@ struct TORCH_API ClassType : public NamedType {
   TypePtr createWithContained(std::vector<TypePtr> contained_types) const override {
     auto ptr = ClassType::create(name(), compilation_unit_, is_module());
     AT_ASSERT(numAttributes() == contained_types.size());
-    for(size_t i = 0; i < attributes_.size(); ++i) {
+    for (const auto i : c10::irange(attributes_.size())) {
       AT_ASSERT(attributes_[i].getType()->isSubtypeOf(*contained_types[i]));
       ptr->addAttribute(attributes_[i].getName(), std::move(contained_types[i]));
     }

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -9,6 +9,7 @@
 #include <ATen/record_function.h>
 #include <c10/util/Exception.h>
 #include <c10/util/LeftRight.h>
+#include <c10/util/irange.h>
 #include <list>
 #include <mutex>
 #include <type_traits>
@@ -555,7 +556,7 @@ inline Return Dispatcher::callWithDispatchKeySlowPath(const TypedOperatorHandle<
     // stuck on C++14 rather than C++17, but we could do a backport
     // similar to folly::launder if needed.)
     runRecordFunction(guard, schema_ref, dispatchKey, c10::ArrayRef<const c10::IValue>(reinterpret_cast<IValue *>(boxedArgs), num_boxed_args));
-    for (size_t ii = 0; ii < num_boxed_args; ++ii) {
+    for (const auto ii : c10::irange(num_boxed_args)) {
       reinterpret_cast<IValue *>(&boxedArgs[ii])->~IValue();
     }
   } else {

--- a/aten/src/ATen/core/dynamic_type.cpp
+++ b/aten/src/ATen/core/dynamic_type.cpp
@@ -7,6 +7,7 @@
 #include <ATen/core/jit_type.h>
 #include <ATen/core/type_factory.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 namespace c10 {
 
@@ -64,7 +65,7 @@ DynamicType::Arguments::Arguments(
     c10::ArrayRef<TypePtr> args)
     : Arguments(args) {
   TORCH_INTERNAL_ASSERT(names.size() == args.size());
-  for (size_t i = 0; i < args.size(); i++) {
+  for (const auto i : c10::irange(args.size())) {
     elems[i].label = std::string{names[i]};
   }
 }

--- a/aten/src/ATen/core/dynamic_type.h
+++ b/aten/src/ATen/core/dynamic_type.h
@@ -5,6 +5,7 @@
 
 #include <ATen/core/jit_type_base.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 namespace c10 {
 
@@ -189,7 +190,7 @@ class DynamicType : public SharedType {
     if (arguments_.elems.size() != other.arguments_.elems.size()) {
       return false;
     }
-    for (size_t i = 0; i < arguments_.elems.size(); i++) {
+    for (const auto i : c10::irange(arguments_.elems.size())) {
       if (!f(arguments_.elems[i], other.arguments_.elems[i])) {
         return false;
       }

--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -281,7 +281,7 @@ inline bool FunctionSchema::isForwardCompatibleWith(
   }
 
   // Validate that all new arguments provided has a default value
-  for (size_t i = old_out_start_idx; i < new_out_start_idx; ++i) {
+  for (const auto i : c10::irange(old_out_start_idx, new_out_start_idx)) {
     if (!arguments().at(i).default_value()) {
       if (why_not) {
         why_not
@@ -307,7 +307,7 @@ inline bool FunctionSchema::isForwardCompatibleWith(
   }
 
   // now compare the out args
-  for (size_t i = old_out_start_idx; i < old.arguments().size(); i++) {
+  for (const auto i : c10::irange(old_out_start_idx, old.arguments().size())) {
     if (!arguments()
              .at(i - old_out_start_idx + new_out_start_idx)
              .isForwardCompatibleWith(old.arguments().at(i))) {

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -81,7 +81,7 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
       if (has_valid_strides_info &&
           type_verbosity() >= TypeVerbosity::TypeAndStride) {
         out << ", strides=[";
-        for (size_t i = 0; i < *ndim; ++i) {
+        for (const auto i : c10::irange(*ndim)) {
           if (i > 0) {
             out << ", ";
           }
@@ -141,7 +141,7 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
       out << "NamedTuple";
     }
     out << "(";
-    for(size_t i = 0; i < tup->elements().size(); ++i) {
+    for (const auto i : c10::irange(tup->elements().size())) {
       if(i > 0)
         out << ", ";
       if (tup->schema()) {
@@ -376,7 +376,7 @@ c10::optional<TypePtr> unifyTypesImpl(const TypePtr& t1, const TypePtr& t2, bool
       return c10::nullopt;
     }
     std::vector<TypePtr> elements;
-    for (size_t i = 0; i < tuple1->elements().size(); i++) {
+    for (const auto i : c10::irange(tuple1->elements().size())) {
       if (auto elem = unifyTypes(tuple1->elements().at(i), tuple2->elements().at(i), default_to_union)) {
         elements.push_back(*std::move(elem));
       } else {
@@ -508,7 +508,7 @@ MatchTypeReturn matchTypeVariables(
       if (tp_formal->elements().size() != tp_actual->elements().size()) {
         return MatchTypeReturn("Cannot match tuples of mismatched size");
       }
-      for (size_t i = 0; i < tp_formal->elements().size(); ++i) {
+      for (const auto i : c10::irange(tp_formal->elements().size())) {
         auto result = matchTypeVariables(
             tp_formal->elements()[i], tp_actual->elements()[i], type_env);
         if (!result.success()) {
@@ -709,7 +709,7 @@ TupleTypePtr TupleType::createWithSpec(const c10::optional<c10::QualifiedName>& 
   std::vector<Argument> arguments;
   arguments.reserve(field_names.size());
   auto min_default_idx = field_names.size() - field_defaults.size();
-  for (size_t i = 0; i < field_names.size(); ++i) {
+  for (const auto i : c10::irange(field_names.size())) {
     if (i < min_default_idx) {
       Argument arg{
           /*name=*/std::string{field_names[i]},
@@ -817,7 +817,7 @@ bool TupleType::isSubtypeOfExt(const Type& rhs_, std::ostream* why_not) const {
       return false;
     }
 
-    for (size_t i = 0; i < args_lhs.size(); ++i) {
+    for (const auto i : c10::irange(args_lhs.size())) {
       if (args_lhs[i].name() != args_rhs[i].name()) {
         return false;
       }
@@ -865,7 +865,7 @@ std::string TupleType::str() const {
     ss << name()->qualifiedName();
   } else {
     ss << "(";
-    for(size_t i = 0; i < elements().size(); ++i) {
+    for (const auto i : c10::irange(elements().size())) {
       if(i > 0)
         ss << ", ";
       ss << elements()[i]->str();
@@ -886,7 +886,7 @@ std::string TupleType::annotation_str_impl(TypePrinter printer) const {
       // https://docs.python.org/3/library/typing.html#typing.Tuple
       ss << "()";
     } else {
-      for (size_t i = 0; i < elements().size(); ++i) {
+      for (const auto i : c10::irange(elements().size())) {
         if (i > 0)
           ss << ", ";
         ss << elements()[i]->annotation_str(printer);

--- a/aten/src/ATen/core/union_type.cpp
+++ b/aten/src/ATen/core/union_type.cpp
@@ -378,7 +378,7 @@ std::string UnionType::unionStr(TypePrinter printer, bool is_annotation_str)
 
   ss << "Union" + open_delimeter;
   bool printed = false;
-  for (size_t i = 0; i < types_.size(); ++i) {
+  for (const auto i : c10::irange(types_.size())) {
     if (!can_hold_numbertype || !is_numbertype(types_[i])) {
       if (i > 0) {
         ss << ", ";

--- a/aten/src/ATen/functorch/BatchRulesHelper.h
+++ b/aten/src/ATen/functorch/BatchRulesHelper.h
@@ -15,6 +15,7 @@
 #include <ATen/functorch/PlumbingHelper.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/VmapGeneratedPlumbing.h>
+#include <c10/util/irange.h>
 
 // This file contains helper functions for batching rules.
 
@@ -459,7 +460,7 @@ inline VmapDimVector range(int64_t start, int64_t stop) {
   TORCH_INTERNAL_ASSERT(stop >= start);
   VmapDimVector dims;
   dims.reserve(stop - start);
-  for (int64_t i = start; i < stop; i++) {
+  for (const auto i : c10::irange(start, stop)) {
     dims.emplace_back(i);
   }
   return dims;

--- a/aten/src/ATen/functorch/BatchRulesRandomness.cpp
+++ b/aten/src/ATen/functorch/BatchRulesRandomness.cpp
@@ -7,6 +7,7 @@
 #include <ATen/ATen.h>
 #include <ATen/functorch/DynamicLayer.h>
 #include <ATen/functorch/BatchRulesHelper.h>
+#include <c10/util/irange.h>
 
 // This file contains batching rules for random operations. These are different
 // from our regular batching rules: regular batching rules get registered to the
@@ -118,7 +119,7 @@ Tensor randperm_batching_rule(int64_t n, ExtraArgs... extra_args) {
   if (randomness == RandomnessType::Different) {
     std::vector<at::Tensor> stackedList(batch_size);
     stackedList.reserve(batch_size);
-    for (int64_t idx = 0; idx < batch_size; ++idx) {
+    for (const auto idx : c10::irange(batch_size)) {
       // since this is done in a loop, need to pass by reference for generator to update
       stackedList[idx] = Func(n, extra_args...);
     }

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -12,6 +12,7 @@
 #include <ATen/native/TensorAdvancedIndexing.h>
 #include <ATen/native/IndexKernel.h>
 #include <ATen/native/IndexingUtils.h>
+#include <c10/util/irange.h>
 
 
 namespace at { namespace functorch {
@@ -86,7 +87,7 @@ std::vector<optional<Tensor>> batchIndices(
   int64_t maxLogicalRank = get_max_index_logical_dim(indices, indices_bdims);
   bool indices_batched = any_has_value(indices_bdims);
 
-  for (size_t i = 0; i < indices.size(); i++) {
+  for (const auto i : c10::irange(indices.size())) {
     auto index = indices[i];
     if (index.has_value() && index->numel() != 0) {
       const auto idx_bdim = indices_bdims[i];
@@ -632,7 +633,7 @@ std::tuple<Tensor,optional<int64_t>> index_put_batch_rule(
     batch_size = get_bdim_size2(self, self_bdim, values, values_bdim);
   } else {
     // one or more of the indices is batched.
-    for (size_t i = 0; i < indices.size(); i++) {
+    for (const auto i : c10::irange(indices.size())) {
       if (indices_bdims[i] && indices[i].has_value()) {
         batch_size = indices[i].value().size(*indices_bdims[i]);
         break;

--- a/aten/src/ATen/functorch/BatchedFallback.cpp
+++ b/aten/src/ATen/functorch/BatchedFallback.cpp
@@ -182,7 +182,7 @@ void batchedTensorInplaceForLoopFallback(const c10::OperatorHandle& op, torch::j
 
   // Strategy: For each batch, we are going to push slices (where applicable)
   // of the arguments onto `stack`, and call `op`.
-  for (int64_t linear_idx = 0; linear_idx < num_batches; ++linear_idx) {
+  for (const auto linear_idx : c10::irange(num_batches)) {
     auto index = computeIndex(linear_idx, batch_sizes);
     auto batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
     auto input_physical_views_iter = input_physical_views.begin();
@@ -336,7 +336,7 @@ void batchedTensorForLoopFallback(const c10::OperatorHandle& op, torch::jit::Sta
   // more easily in the next step.
   std::vector<Tensor> output_shards(num_batches * num_returns);
 
-  for (int64_t linear_idx = 0; linear_idx < num_batches; ++linear_idx) {
+  for (const auto linear_idx : c10::irange(num_batches)) {
     auto index = computeIndex(linear_idx, batch_sizes);
     auto batched_tensor_inputs_pos_iter = batched_tensor_inputs_position.begin();
     auto input_physical_views_iter = input_physical_views.begin();

--- a/aten/src/ATen/functorch/TensorWrapper.cpp
+++ b/aten/src/ATen/functorch/TensorWrapper.cpp
@@ -10,6 +10,7 @@
 
 #include <torch/library.h>
 #include <ATen/core/dispatch/Dispatcher.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace functorch {
@@ -43,7 +44,7 @@ void TensorWrapper::refreshMetadata() {
   auto strides = value_.strides();
   storage_offset_ = value_.storage_offset();
   sizes_and_strides_.resize(value_.dim());
-  for (int64_t i = 0; i < dim; i++) {
+  for (const auto i : c10::irange(dim)) {
     sizes_and_strides_.size_at_unchecked(i) = sizes[i];
     sizes_and_strides_.stride_at_unchecked(i) = strides[i];
   }

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -787,7 +787,7 @@ std::tuple<Tensor, Tensor> prelu_backward_cpu(const Tensor& grad_out_, const Ten
     int64_t input_ndim = self.dim();
     reduce_dims.push_back(0);
     if (input_ndim > 2) {
-      for(int64_t i = 2; i < input_ndim; i++) reduce_dims.push_back(i);
+      for (const auto i : c10::irange(2, input_ndim))reduce_dims.push_back(i);
     }
     weight_grad = weight_grad_collector.sum(reduce_dims);
   }

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2961,17 +2961,17 @@ static void linalg_eig_make_complex_eigenvectors_impl(Tensor& result, const Tens
   auto real_vectors_data = real_vectors.data_ptr<scalar_t>();
   auto values_data = complex_values.data_ptr<c10::complex<scalar_t>>();
 
-  for (auto b = decltype(batch_size){0}; b < batch_size; b++) {
+  for (const auto b : c10::irange(decltype(batch_size){0}, batch_size)) {
     scalar_t* vecs = &real_vectors_data[b * matrix_stride];
     c10::complex<scalar_t>* res = &result_data[b * matrix_stride];
     c10::complex<scalar_t>* vals = &values_data[b * n];
     for (auto j = decltype(n){0}; j < n; j++) {
       if (vals[j].imag() == 0.0) {  // eigenvalue is real, then v(j) = VR(:,j)
-        for (auto i = decltype(n){0}; i < n; i++) {
+        for (const auto i : c10::irange(decltype(n){0}, n)) {
           res[j * n + i] = c10::complex<scalar_t>(vecs[j * n + i], 0);
         }
       } else {
-        for (auto i = decltype(n){0}; i < n; i++) {
+        for (const auto i : c10::irange(decltype(n){0}, n)) {
           res[j * n + i] = c10::complex<scalar_t>(vecs[j * n + i],  vecs[(j+1) * n + i]);      // v(j)   = VR(:,j) + i*VR(:,j+1)
           res[(j+1) * n + i] = c10::complex<scalar_t>(vecs[j * n + i], -vecs[(j+1) * n + i]);  // v(j+1) = VR(:,j) - i*VR(:,j+1)
         }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -2084,7 +2084,7 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
         std::vector<Tensor> backend_grad_inputs(params.groups);
         std::vector<Tensor> backend_grad_weights(params.groups);
         std::vector<Tensor> backend_grad_biases(params.groups);
-        for (int g = 0; g < params.groups; ++g) {
+        for (const auto g : c10::irange(params.groups)) {
           auto grad_output_g = subtensor(grad_output, 1, params.groups, g);
           auto input_g = subtensor(input, 1, params.groups, g);
           auto weight_g = subtensor(weight, 0, params.groups, g);

--- a/aten/src/ATen/native/Distributions.h
+++ b/aten/src/ATen/native/Distributions.h
@@ -18,6 +18,7 @@
 #define compat_log1p c10::cuda::compat::log1p
 #elif defined(__HIPCC__)
 #include <c10/hip/HIPMathCompat.h>
+#include <c10/util/irange.h>
 #define compat_exp c10::hip::compat::exp
 #define compat_ceil c10::hip::compat::ceil
 #define compat_floor c10::hip::compat::floor

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -10,6 +10,7 @@
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
 #include <c10/util/MathConstants.h>
+#include <c10/util/irange.h>
 #include <c10/util/math_compat.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/jiterator_macros.h>
@@ -89,7 +90,7 @@ jiterator_also_stringify_as(jiterator_code(
     b0 = array[0];
     b1 = 0;
 
-    for (int i = 1; i < len; ++i) {
+    for (const auto i : c10::irange(1, len)) {
       b2 = b1;
       b1 = b0;
       b0 = x * b1 - b2 + array[i];
@@ -292,7 +293,7 @@ C10_HOST_DEVICE static inline scalar_t zeta(scalar_t x, scalar_t q) __ubsan_igno
   s -= half * b;
   a = one;
   k = zero;
-  for (int i = 0; i < 12; i++) {
+  for (const auto i : c10::irange(12)) {
     a *= x + k;
     b /= w;
     t = a * b / A[i];
@@ -342,7 +343,7 @@ static inline double trigamma(double x) __ubsan_ignore_float_divide_by_zero__ {
     result -= (c10::pi<double> * c10::pi<double>) / (sin_pi_x * sin_pi_x);
     x = 1 - x;
   }
-  for (int i = 0; i < 6; ++i) {
+  for (C10_UNUSED const auto i : c10::irange(6)) {
     result += 1 / (x * x);
     x += 1;
   }
@@ -360,7 +361,7 @@ static inline float trigamma(float x) __ubsan_ignore_float_divide_by_zero__ {
     result -= (c10::pi<float> * c10::pi<float>) / (sin_pi_x * sin_pi_x);
     x = 1 - x;
   }
-  for (int i = 0; i < 6; ++i) {
+  for (C10_UNUSED const auto i : c10::irange(6)) {
     result += 1 / (x * x);
     x += 1;
   }
@@ -1271,7 +1272,7 @@ chbevl(const T x, const T array[], size_t len) {
   b0 = array[0];
   b1 = static_cast<T>(0.0);
 
-  for (size_t i = 1; i < len; ++i) {
+  for (const auto i : c10::irange(1, len)) {
     b2 = b1;
     b1 = b0;
     b0 = x * b1 - b2 + array[i];
@@ -3063,7 +3064,7 @@ static inline C10_HOST_DEVICE T hermite_polynomial_he_forward(T x, int64_t n) {
     T q = x;
     T r;
 
-    for (int64_t k = 1; k < n; k++) {
+    for (const auto k : c10::irange(1, n)) {
         r = x * q - k * p;
         p = q;
         q = r;
@@ -3099,7 +3100,7 @@ static inline C10_HOST_DEVICE T laguerre_polynomial_l_forward(T x, int64_t n) {
     T q = T(1.0) - x;
     T r;
 
-    for (int64_t k = 1; k < n; k++) {
+    for (const auto k : c10::irange(1, n)) {
         r = (((k + k) + (T(1.0) - x)) * q - k * p) / (k + 1);
         p = q;
         q = r;
@@ -3139,7 +3140,7 @@ static inline C10_HOST_DEVICE T legendre_polynomial_p_forward(T x, int64_t n) {
     T q = x;
     T r;
 
-    for (int64_t k = 1; k < n; k++) {
+    for (const auto k : c10::irange(1, n)) {
         r = ((k + k + 1) * x * q - k * p) / (k + 1);
         p = q;
         q = r;

--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -57,7 +57,7 @@ void _segment_reduce_lengths_cpu_kernel1(
   // outer_offset is the size of the outer dimensions of output (before axis)
   // inner_offset is the size of the inner dimensions of output (after axis)
   int64_t outer_offset = 1, inner_offset = 1;
-  for (int64_t d = 0; d < axis; d++)
+  for (const auto d : c10::irange(axis))
       outer_offset *= output.size(d);
   for (int64_t d = axis + 1; d < output.dim(); d++)
       inner_offset *= output.size(d);
@@ -211,7 +211,7 @@ void _segment_reduce_cpu_lengths_backward_kernel1(
   // outer_offset is the size of the outer dimensions of output (before axis)
   // inner_offset is the size of the inner dimensions of output (after axis)
   int64_t outer_offset = 1, inner_offset = 1;
-  for (int64_t d = 0; d < axis; d++)
+  for (const auto d : c10::irange(axis))
       outer_offset *= output_contig.size(d);
   for (int64_t d = axis + 1; d < output_contig.dim(); d++)
       inner_offset *= output_contig.size(d);

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -1593,7 +1593,7 @@ TORCH_IMPL_FUNC(scatter_add)
         index_coords_sizes,
         at::TensorOptions().dtype(at::ScalarType::Long).device(self.device()));
 
-      for (int64_t dim_other = 0; dim_other < self.dim(); dim_other++) {
+      for (const auto dim_other : c10::irange(self.dim())) {
         if (dim_other == dim) {
           continue;
         }

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -481,12 +481,12 @@ Tensor sparse_broadcast_to(const Tensor& self, IntArrayRef size) {
   int64_t nnz_factor = 1;
   int64_t min_broadcast_dim = (sparse_extra_ndim > 0 ? 0: -1);
   int64_t max_unchanged_dim = -1;
-  for (int64_t i=0; i<sparse_extra_ndim; i++) {
+  for (const auto i : c10::irange(sparse_extra_ndim)) {
     auto d = size[i];
     nnz_factor *= d;
     broadcast_sizes.emplace_back(d);
   }
-  for (int64_t i=0; i<self.sparse_dim(); i++) {
+  for (const auto i : c10::irange(self.sparse_dim())) {
     auto d = size[sparse_extra_ndim + i];
     if (self.size(i) != d) {
       TORCH_CHECK(self.size(i) == 1,
@@ -510,7 +510,7 @@ Tensor sparse_broadcast_to(const Tensor& self, IntArrayRef size) {
   bool is_coalesced = self.dim()==0 || (self.is_coalesced() && (max_unchanged_dim < min_broadcast_dim || min_broadcast_dim == -1));
 
   broadcast_dense_sizes.emplace_back(nnz);
-  for (int64_t i=0; i<self.dense_dim(); i++) {
+  for (const auto i : c10::irange(self.dense_dim())) {
     broadcast_dense_sizes.emplace_back(size[sparse_extra_ndim + self.sparse_dim() + i]);
   }
 
@@ -526,7 +526,7 @@ Tensor sparse_broadcast_to(const Tensor& self, IntArrayRef size) {
     // auxilary arange tensors
     Tensor broadcast_indices = at::native::new_ones(indices, broadcast_sizes).nonzero().transpose(0, 1).tile(nnz);
     new_indices.narrow(0, 0, sparse_extra_ndim).copy_(broadcast_indices.narrow(0, 0, sparse_extra_ndim));
-    for (size_t i=0; i<broadcast_dims.size(); i++) {
+    for (const auto i : c10::irange(broadcast_dims.size())) {
       int64_t j=broadcast_dims[i];
       new_indices.select(0, sparse_extra_ndim + j).copy_(broadcast_indices.select(0, sparse_extra_ndim + i));
     }

--- a/aten/src/ATen/native/cpu/AvgPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AvgPoolKernel.cpp
@@ -286,7 +286,7 @@ void cpu_avg_pool_channels_last<BFloat16>(
       if (ih0 >= ih1 || iw0 >= iw1) {
         // since we are not directly using output as the accumulation buffer,
         // in case the kernel window is out of range, need to zero the output buffer here.
-        for (int64_t k = 0; k < size; k++) {
+        for (const auto k : c10::irange(size)) {
           out[k] = 0;
         }
         // move on to next output index

--- a/aten/src/ATen/native/cpu/BlasKernel.cpp
+++ b/aten/src/ATen/native/cpu/BlasKernel.cpp
@@ -48,7 +48,7 @@ auto sum(int64_t N, Func f) {
   for (; i < N; ++i) {
     partial_sums[0] += f(i);
   }
-  for (int k = 1; k < ilp_factor; ++k) {
+  for (const auto k : c10::irange(1, ilp_factor)) {
     partial_sums[0] += partial_sums[k];
   }
   return partial_sums[0];

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -301,7 +301,7 @@ void binary_kernel_reduce_lastdim(TensorIteratorBase& iter, reduce_func_t reduce
   auto loop = [&](char** data, const int64_t* strides, int64_t size) {
     char* out = data[0];
     char* in = data[1];
-    for (int64_t i = 0; i < size; ++i) {
+    for (C10_UNUSED const auto i : c10::irange(size)) {
       reduce_op(out, in, dim_size);
       out += strides[0];
       in += strides[1];

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -271,7 +271,7 @@ static void norm_kernel_tensor_iterator_impl(
             norm_two_reduce_step(acc_vec, data_vec);
           }
           acc_vec.store(buffer);
-          for (int j = 1; j < fVec::size(); j++) {
+          for (const auto j : c10::irange(1, fVec::size())) {
             buffer[0] = buffer[0] + buffer[j];
           }
           for (; d < size; d++) {
@@ -460,7 +460,7 @@ static void argmax_kernel_impl(TensorIterator &iter) {
         scalar_t* self_data = (scalar_t*)self_data_bytes;
 
         arg_t acc = arg_t(lower_bound<scalar_t>(), 0);
-        for (int64_t i = 0; i < size; i++) {
+        for (const auto i : c10::irange(size)) {
           acc = op.reduce(acc, self_data[i], i);
         }
         result_data[0] = acc.second;
@@ -484,7 +484,7 @@ static void argmin_kernel_impl(TensorIterator &iter) {
         scalar_t* self_data = (scalar_t*)self_data_bytes;
 
         arg_t acc = arg_t(upper_bound<scalar_t>(), 0);
-        for (int64_t i = 0; i < size; i++) {
+        for (const auto i : c10::irange(size)) {
           acc = op.reduce(acc, self_data[i], i);
         }
         result_data[0] = acc.second;

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -272,7 +272,7 @@ inline void _vec_softmax_backward(
         std::unique_ptr<scalar_t[]> buffer(new scalar_t[CHUNK_SIZE]);
         scalar_t* tmp_sum_data = buffer.get();
 
-        for (int64_t i = begin; i < end; i++) {
+        for (const auto i : c10::irange(begin, end)) {
           int64_t outer_idx = i / num_chunks;
           int64_t k = i % num_chunks;
           int64_t inner_idx_begin = k * CHUNK_SIZE;
@@ -289,7 +289,7 @@ inline void _vec_softmax_backward(
           }
 
           // compute sum of grad_output * output
-          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+          for (const auto dim_idx : c10::irange(dim_size)) {
             int64_t offset = outer_idx * outer_stride + dim_idx * inner_size +
                 inner_idx_begin;
             scalar_t* grad_output_ptr = grad_output_data_base + offset;
@@ -309,7 +309,7 @@ inline void _vec_softmax_backward(
           }
 
           // compute output * (grad_output - sum)
-          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+          for (const auto dim_idx : c10::irange(dim_size)) {
             int64_t offset = outer_idx * outer_stride + dim_idx * inner_size +
                 inner_idx_begin;
             scalar_t* grad_output_ptr = grad_output_data_base + offset;
@@ -364,7 +364,7 @@ inline void _vec_softmax_backward<BFloat16>(
             new float[dim_size * CHUNK_SIZE]);
         float* output_buffer_data = output_buffer.get();
 
-        for (int64_t i = begin; i < end; i++) {
+        for (const auto i : c10::irange(begin, end)) {
           int64_t outer_idx = i / num_chunks;
           int64_t k = i % num_chunks;
           int64_t inner_idx_begin = k * CHUNK_SIZE;
@@ -382,7 +382,7 @@ inline void _vec_softmax_backward<BFloat16>(
           }
 
           // compute sum of grad_output * output
-          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+          for (const auto dim_idx : c10::irange(dim_size)) {
             int64_t offset = outer_idx * outer_stride + dim_idx * inner_size +
                 inner_idx_begin;
             BFloat16* grad_output_ptr = grad_output_data_base + offset;
@@ -426,7 +426,7 @@ inline void _vec_softmax_backward<BFloat16>(
           }
 
           // compute output * (grad_output - sum)
-          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+          for (const auto dim_idx : c10::irange(dim_size)) {
             BFloat16* grad_input_ptr = grad_input_data_base +
                 outer_idx * outer_stride + dim_idx * inner_size +
                 inner_idx_begin;
@@ -483,7 +483,7 @@ inline void _vec_log_softmax_backward(
         std::unique_ptr<scalar_t[]> buffer(new scalar_t[CHUNK_SIZE]);
         scalar_t* tmp_sum_data = buffer.get();
 
-        for (int64_t i = begin; i < end; i++) {
+        for (const auto i : c10::irange(begin, end)) {
           int64_t outer_idx = i / num_chunks;
           int64_t k = i % num_chunks;
           int64_t inner_idx_begin = k * CHUNK_SIZE;
@@ -500,7 +500,7 @@ inline void _vec_log_softmax_backward(
           }
 
           // compute sum of grad_output
-          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+          for (const auto dim_idx : c10::irange(dim_size)) {
             scalar_t* grad_output_ptr = grad_output_data_base +
                 outer_idx * outer_stride + dim_idx * inner_size +
                 inner_idx_begin;
@@ -518,7 +518,7 @@ inline void _vec_log_softmax_backward(
           }
 
           // compute grad_output - output.exp() * sum
-          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+          for (const auto dim_idx : c10::irange(dim_size)) {
             int64_t offset = outer_idx * outer_stride + dim_idx * inner_size +
                 inner_idx_begin;
             scalar_t* grad_output_ptr = grad_output_data_base + offset;
@@ -570,7 +570,7 @@ inline void _vec_log_softmax_backward<BFloat16>(
             new float[dim_size * CHUNK_SIZE]);
         float* grad_output_buffer_data = grad_output_buffer.get();
 
-        for (int64_t i = begin; i < end; i++) {
+        for (const auto i : c10::irange(begin, end)) {
           int64_t outer_idx = i / num_chunks;
           int64_t k = i % num_chunks;
           int64_t inner_idx_begin = k * CHUNK_SIZE;
@@ -588,7 +588,7 @@ inline void _vec_log_softmax_backward<BFloat16>(
           }
 
           // compute sum of grad_output
-          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+          for (const auto dim_idx : c10::irange(dim_size)) {
             BFloat16* grad_output_ptr = grad_output_data_base +
                 outer_idx * outer_stride + dim_idx * inner_size +
                 inner_idx_begin;
@@ -621,7 +621,7 @@ inline void _vec_log_softmax_backward<BFloat16>(
           }
 
           // compute grad_output - output.exp() * sum
-          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+          for (const auto dim_idx : c10::irange(dim_size)) {
             int64_t offset = outer_idx * outer_stride + dim_idx * inner_size +
                 inner_idx_begin;
             BFloat16* output_ptr = output_data_base + offset;
@@ -895,7 +895,7 @@ inline void _vec_logsoftmax(
     scalar_t* input_max_data = buffer.get();
     scalar_t* tmp_sum_data = buffer.get() + CHUNK_SIZE;
 
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       int64_t outer_idx = i / num_chunks;
       int64_t k = i % num_chunks;
       int64_t inner_idx_begin = k * CHUNK_SIZE;
@@ -915,7 +915,7 @@ inline void _vec_logsoftmax(
       }
 
       // compute max
-      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+      for (const auto dim_idx : c10::irange(dim_size)) {
         scalar_t* input_ptr = input_data_base + outer_idx * dim_size * inner_size
             + dim_idx * inner_size + inner_idx_begin;
 
@@ -934,7 +934,7 @@ inline void _vec_logsoftmax(
       }
 
       // compute sum of (x - max).exp()
-      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+      for (const auto dim_idx : c10::irange(dim_size)) {
         scalar_t* input_ptr = input_data_base + outer_idx * dim_size * inner_size
             + dim_idx * inner_size + inner_idx_begin;
 
@@ -957,7 +957,7 @@ inline void _vec_logsoftmax(
       vec::map([](Vec x) { return x.log(); }, tmp_sum_data, tmp_sum_data, size);
 
       // compute x - max - sum
-      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+      for (const auto dim_idx : c10::irange(dim_size)) {
         int64_t offset = outer_idx * dim_size * inner_size + dim_idx * inner_size + inner_idx_begin;
         scalar_t* input_ptr = input_data_base + offset;
         scalar_t* output_ptr = output_data_base + offset;
@@ -1003,7 +1003,7 @@ inline void _vec_logsoftmax<BFloat16>(
     float* input_buffer_data = input_buffer.get();
 
     // init
-    for (int64_t i = begin; i < end; i++) {
+    for (const auto i : c10::irange(begin, end)) {
       int64_t outer_idx = i / num_chunks;
       int64_t k = i % num_chunks;
       int64_t inner_idx_begin = k * CHUNK_SIZE;
@@ -1024,7 +1024,7 @@ inline void _vec_logsoftmax<BFloat16>(
       }
 
       // compute max
-      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+      for (const auto dim_idx : c10::irange(dim_size)) {
         BFloat16* input_ptr = input_data_base + outer_idx * dim_size * inner_size
             + dim_idx * inner_size + inner_idx_begin;
         float* input_buffer_ptr = input_buffer_data + dim_idx * CHUNK_SIZE;
@@ -1054,7 +1054,7 @@ inline void _vec_logsoftmax<BFloat16>(
       }
 
       // compute sum of (x - max).exp()
-      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+      for (const auto dim_idx : c10::irange(dim_size)) {
         float* input_buffer_ptr = input_buffer_data + dim_idx * CHUNK_SIZE;
 
         int64_t d2 = 0;
@@ -1081,7 +1081,7 @@ inline void _vec_logsoftmax<BFloat16>(
       vec::map([](fVec x) { return x.log(); }, tmp_sum_data, tmp_sum_data, size);
 
       // compute x - max - sum
-      for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+      for (const auto dim_idx : c10::irange(dim_size)) {
         float* input_buffer_ptr = input_buffer_data + dim_idx * CHUNK_SIZE;
         BFloat16* output_ptr = output_data_base + outer_idx * dim_size * inner_size
             + dim_idx * inner_size + inner_idx_begin;

--- a/aten/src/ATen/native/cpu/SparseFactories.cpp
+++ b/aten/src/ATen/native/cpu/SparseFactories.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/cpu/Loops.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -47,7 +48,7 @@ void _spdiags_kernel_cpu(
                 auto* data_read = (diagonals_ptr +
                                    diagonals_index_stride * diag_index +
                                    first_col * diagonals_read_stride);
-                for (int64_t i = 0; i < n_out; ++i) {
+                for (const auto i : c10::irange(n_out)) {
                   rows_start[i] = first_row + i;
                   cols_start[i] = first_col + i;
                   vals_start[i] = data_read[i * diagonals_read_stride];

--- a/aten/src/ATen/native/cpu/Unfold2d.cpp
+++ b/aten/src/ATen/native/cpu/Unfold2d.cpp
@@ -135,14 +135,14 @@ static void unfolded2d_acc_channels_last(
     int64_t output_height,
     int64_t output_width) {
 
-  for (int64_t y = 0; y < output_height; y++) {
-    for (int64_t x = 0; x < output_width; x++) {
+  for (const auto y : c10::irange(output_height)) {
+    for (const auto x : c10::irange(output_width)) {
       scalar_t* src = finput_data + y * output_width * kH * kW * n_input_plane + x * kH * kW * n_input_plane;
       scalar_t* dst = input_data;
 
       if (padW > 0 || padH > 0) {
-        for (int64_t kh = 0; kh < kH; kh++) {
-          for (int64_t kw = 0; kw < kW; kw++) {
+        for (const auto kh : c10::irange(kH)) {
+          for (const auto kw : c10::irange(kW)) {
             int64_t iy = y * dH - padH + kh;
             int64_t ix = x * dW - padW + kw;
             if (iy < 0 || iy >= input_height || ix < 0 || ix >= input_width) {
@@ -157,8 +157,8 @@ static void unfolded2d_acc_channels_last(
           }
         }
       } else {
-        for (int64_t kh = 0; kh < kH; kh++) {
-          for (int64_t kw = 0; kw < kW; kw++) {
+        for (const auto kh : c10::irange(kH)) {
+          for (const auto kw : c10::irange(kW)) {
             int64_t iy = y * dH + kh;
             int64_t ix = x * dW + kw;
             scalar_t* dst_slice = dst + iy * input_width * n_input_plane + ix * n_input_plane;
@@ -359,8 +359,8 @@ static void unfolded2d_copy_channels_last(
       scalar_t* src = input_data;
 
       if (padW > 0 || padH > 0) {
-        for (int64_t kh = 0; kh < kH; kh++) {
-          for (int64_t kw = 0; kw < kW; kw++) {
+        for (const auto kh : c10::irange(kH)) {
+          for (const auto kw : c10::irange(kW)) {
             int64_t iy = y * dH - padH + kh;
             int64_t ix = x * dW - padW + kw;
             if (iy < 0 || iy >= input_height || ix < 0 || ix >= input_width) {
@@ -375,8 +375,8 @@ static void unfolded2d_copy_channels_last(
           }
         }
       } else {
-        for (int64_t kh = 0; kh < kH; kh++) {
-          for (int64_t kw = 0; kw < kW; kw++) {
+        for (const auto kh : c10::irange(kH)) {
+          for (const auto kw : c10::irange(kW)) {
             int64_t iy = y * dH + kh;
             int64_t ix = x * dW + kw;
             memcpy(dst + kh * kW * n_input_plane + kw * n_input_plane,

--- a/aten/src/ATen/native/cpu/UpSampleMoreKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleMoreKernel.cpp
@@ -165,11 +165,11 @@ void cpu_upsample_nearest_backward_channels_last(
 
   auto loop3d = [&](int64_t begin, int64_t end) {
     for (const auto n : c10::irange(begin, end)) {
-      for (int64_t od = 0; od < output_depth; od++) {
+      for (const auto od : c10::irange(output_depth)) {
         int64_t id = nearest_idx_fn(od, input_depth, output_depth, scales[0]);
-        for (int64_t oh = 0; oh < output_height; oh++) {
+        for (const auto oh : c10::irange(output_height)) {
           int64_t ih = nearest_idx_fn(oh, input_height, output_height, scales[1]);
-          for (int64_t ow = 0; ow < output_width; ow++) {
+          for (const auto ow : c10::irange(output_width)) {
             int64_t iw = nearest_idx_fn(ow, input_width, output_width, scales[2]);
             scalar_t* grad_output_ptr = grad_output_data +
                 (n * output_depth * output_height * output_width +

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -734,7 +734,7 @@ inline void batch_norm_cpu_collect_stats_contiguous_internal(
     for (const auto c : c10::irange(begin, end)) {
       float sum_val = float(0);
       fVec sum_fvec = fVec(float(0));
-      for (int64_t n = 0; n < n_batch; n++) {
+      for (const auto n : c10::irange(n_batch)) {
         const BFloat16* input_ptr = input_data + n * n_channel * image_size + c * image_size;
         int64_t d = 0;
         for (; d < image_size - (image_size % bVec::size()); d += bVec::size()) {
@@ -756,7 +756,7 @@ inline void batch_norm_cpu_collect_stats_contiguous_internal(
       float var_val = float(0);
       fVec var_fvec = fVec(float(0));
       fVec mean_fvec = fVec(mean_val);
-      for (int64_t n = 0; n < n_batch; n++) {
+      for (const auto n : c10::irange(n_batch)) {
         const BFloat16* input_ptr = input_data + n * n_channel * image_size + c * image_size;
         int64_t d = 0;
         for (; d < image_size - (image_size % bVec::size()); d += bVec::size()) {

--- a/aten/src/ATen/native/cpu/utils.h
+++ b/aten/src/ATen/native/cpu/utils.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <ATen/cpu/vec/vec.h>
+
+#include <c10/util/irange.h>
 #include <c10/util/llvmMathExtras.h>
 
 #ifdef USE_FBGEMM
@@ -80,8 +82,8 @@ T CeilLog2(const T& x) {
 //   dst has shape of N by M, with leading dimension of ld_dst
 template <typename T>
 inline void transpose(int64_t M, int64_t N, const T* src, int64_t ld_src, T* dst, int64_t ld_dst) {
-  for (int64_t j = 0; j < N; j++) {
-    for (int64_t i = 0; i < M; i++) {
+  for (const auto j : c10::irange(N)) {
+    for (const auto i : c10::irange(M)) {
       dst[j * ld_dst + i] = src[i * ld_src + j];
     }
   }

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -523,7 +523,7 @@ inline static void apply_svd_cusolver_gesvd(const Tensor& A, const Tensor& U, co
                                         : batches.size();
 
 
-  for(int _i = 0; _i < batchsize; _i++){
+  for (const auto _i : c10::irange(batchsize)) {
     int i = calculate_all_batches ? _i : batches[_i];
 
     at::cuda::solver::gesvd<scalar_t>(
@@ -613,7 +613,7 @@ inline static void apply_svd_cusolver_gesvdj(const Tensor& A, const Tensor& U, c
 
   auto dataPtr = allocator.allocate(sizeof(scalar_t)*lwork);
 
-  for(int i = 0; i < batchsize; i++){
+  for (const auto i : c10::irange(batchsize)) {
     at::cuda::solver::gesvdj<scalar_t>(
       handle, jobz, econ, m, n,
       A_data + i * A_stride,
@@ -781,7 +781,7 @@ std::vector<int64_t> _check_gesvdj_convergence(const Tensor& infos, int64_t non_
 
   std::vector<int64_t> res;
 
-  for(int64_t i = 0; i < infos.numel(); i++) {
+  for (const auto i : c10::irange(infos.numel())) {
     int info_for_batch_i = infos_cpu_data[i];
 
     // From cusolver doc, if info < 0, the i-th function call parameter is wrong,
@@ -916,7 +916,7 @@ inline static void apply_cholesky_cusolver_potrf_looped(const Tensor& self_worki
   auto workdata_host = host_allocator.allocate(worksize_host * batch_size);
   void* workdata_host_ptr = workdata_host.get();
 
-  for (int64_t i = 0; i < batch_size; i++) {
+  for (const auto i : c10::irange(batch_size)) {
     at::cuda::solver::xpotrf(
       handle, params, uplo, n, datatype,
       self_working_copy_ptr + i * matrix_stride,
@@ -940,7 +940,7 @@ inline static void apply_cholesky_cusolver_potrf_looped(const Tensor& self_worki
   auto work_data = allocator.allocate(sizeof(scalar_t)*lwork * batch_size);
   scalar_t* work_data_ptr = static_cast<scalar_t*>(work_data.get());
 
-  for (int64_t i = 0; i < batch_size; i++) {
+  for (const auto i : c10::irange(batch_size)) {
     at::cuda::solver::potrf<scalar_t>(
       handle, uplo, n_32,
       self_working_copy_ptr + i * matrix_stride,
@@ -1013,7 +1013,7 @@ inline static void apply_cholesky_cusolver_potrs(Tensor& self_working_copy, cons
   cudaDataType datatype = at::cuda::solver::get_cusolver_datatype<scalar_t>();
   TORCH_CUSOLVER_CHECK(cusolverDnCreateParams(&params));
 
-  for (int64_t i = 0; i < batch_size; i++) {
+  for (const auto i : c10::irange(batch_size)) {
     at::cuda::solver::xpotrs(
       handle, params, uplo, n, nrhs, datatype,
       A_ptr + i * A_matrix_stride,
@@ -1031,7 +1031,7 @@ inline static void apply_cholesky_cusolver_potrs(Tensor& self_working_copy, cons
   int lda_32 = cuda_int_cast(lda, "lda");
   int ldb_32 = cuda_int_cast(ldb, "ldb");
 
-  for (int64_t i = 0; i < batch_size; i++) {
+  for (const auto i : c10::irange(batch_size)) {
     at::cuda::solver::potrs<scalar_t>(
       handle, uplo, n_32, nrhs_32,
       A_ptr + i * A_matrix_stride,
@@ -1272,7 +1272,7 @@ static void apply_ormqr(const Tensor& input, const Tensor& tau, const Tensor& ot
   auto info = at::zeros({1}, input.options().dtype(at::kInt));
   auto info_data = info.data_ptr<int>();
 
-  for (auto i = decltype(batch_size){0}; i < batch_size; i++) {
+  for (const auto i : c10::irange(decltype(batch_size){0}, batch_size)) {
     scalar_t* input_working_ptr = &input_data[i * input_matrix_stride];
     scalar_t* other_working_ptr = &other_data[i * other_matrix_stride];
     scalar_t* tau_working_ptr = &tau_data[i * tau_stride];
@@ -1350,7 +1350,7 @@ inline static void apply_orgqr(Tensor& self, const Tensor& tau) {
   auto info = at::zeros({1}, self.options().dtype(at::kInt));
   auto info_data = info.data_ptr<int>();
 
-  for (auto i = decltype(batchsize){0}; i < batchsize; i++) {
+  for (const auto i : c10::irange(decltype(batchsize){0}, batchsize)) {
     scalar_t* self_working_ptr = &self_data[i * self_matrix_stride];
     scalar_t* tau_working_ptr = &tau_data[i * tau_stride];
     auto handle = at::cuda::getCurrentCUDASolverDnHandle();
@@ -1642,7 +1642,7 @@ void lu_factor_looped_cusolver(const Tensor& self, const Tensor& pivots, const T
     const auto pivots_stride = get_pivots ? pivots.size(-1) : 0;
 
     const auto handle = at::cuda::getCurrentCUDASolverDnHandle();
-    for (auto batch = decltype(batch_size){0}; batch < batch_size; ++batch) {
+    for (const auto batch : c10::irange(decltype(batch_size){0}, batch_size)) {
       at::cuda::solver::getrf<scalar_t>(
         handle, m, n,
         self_data + batch * self_stride,
@@ -1691,7 +1691,7 @@ void lu_solve_looped_cusolver(const Tensor& LU, const Tensor& pivots, const Tens
         batchCount(LU), lu_batch_shape, b_batch_shape);
 
     auto handle = at::cuda::getCurrentCUDASolverDnHandle();
-    for (auto batch = decltype(batch_size){0}; batch < batch_size; ++batch) {
+    for (const auto batch : c10::irange(decltype(batch_size){0}, batch_size)) {
       int64_t lu_index_i = lu_index(batch);
       at::cuda::solver::getrs<scalar_t>(
         handle,

--- a/aten/src/ATen/native/metal/MetalShaders.h
+++ b/aten/src/ATen/native/metal/MetalShaders.h
@@ -547,7 +547,7 @@ kernel void reshape(texture2d_array<half, access::read> in_arr[[texture(0), func
     const ushort n2 = gid.z / slices2; //image index
     const ushort s2 = gid.z - n2 * slices2; // slice offest
     half4 value;
-    for (int idx = 0; idx < 4; ++idx){
+    for (const auto idx : c10::irange(4)) {
         // we compute the "linear index" of the output element,
         // and convert it to the equivalent "linear index" of the input element.
         ushort offset = 4 * s2 + idx;
@@ -621,7 +621,7 @@ kernel void transpose(texture2d_array<half, access::read>in_arr[[texture(0),func
     half4 value;
     ushort4 threadIndexBufferLower{1, 1, 1, 1};
     ushort4 threadIndexBufferUpper{1, 1, 1 ,1};
-    for (int idx = 0; idx < 4; ++idx){
+    for (const auto idx : c10::irange(4)) {
         ushort offset = 4 * s2 + idx;
         size_t linear_idx2 = n2 * C2 * H2 * W2 + offset * H2 * W2 + gid.y * W2 + gid.x;
         if(linear_idx2 >= numel) {
@@ -841,8 +841,8 @@ kernel void roi_align(texture2d_array<half, access::sample> ina[[texture(0), fun
 
     constexpr sampler s2(coord::pixel, address::clamp_to_edge, filter::linear);
 
-    for (int iy = 0; iy < roi_bin_grid_h; iy++) {
-        for (int ix = 0; ix < roi_bin_grid_w; ix++) {
+    for (const auto iy : c10::irange(roi_bin_grid_h)) {
+        for (const auto ix : c10::irange(roi_bin_grid_w)) {
             // Shift the pixel by 0.5. This is critical to achieve high accuracy.
             const half y =
             roi_start_h + ph * bin_size_h + (iy+0.5) * bin_size_h / static_cast<half>(roi_bin_grid_h);

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -410,13 +410,13 @@ struct algorithm_search<miopenConvFwdAlgorithm_t> {
 
     if (force_default) {
         // find default alg
-        for (size_t i=0; i<solution_count; ++i) {
+        for (const auto i : c10::irange(solution_count)) {
             if (solutions[i].algorithm == (miopenConvAlgorithm_t)DEFAULT_ALGO) {
                 return solutions[i];
             }
         }
         // default algo was not found, select first algo without workspace requirement
-        for (size_t i=0; i<solution_count; ++i) {
+        for (const auto i : c10::irange(solution_count)) {
             if (solutions[i].workspace_size == 0) {
                 return solutions[i];
             }
@@ -483,13 +483,13 @@ struct algorithm_search<miopenConvBwdDataAlgorithm_t> {
 
     if (force_default) {
         // find default alg
-        for (size_t i=0; i<solution_count; ++i) {
+        for (const auto i : c10::irange(solution_count)) {
             if (solutions[i].algorithm == (miopenConvAlgorithm_t)DEFAULT_ALGO) {
                 return solutions[i];
             }
         }
         // default algo was not found, select first algo without workspace requirement
-        for (size_t i=0; i<solution_count; ++i) {
+        for (const auto i : c10::irange(solution_count)) {
             if (solutions[i].workspace_size == 0) {
                 return solutions[i];
             }
@@ -556,13 +556,13 @@ struct algorithm_search<miopenConvBwdWeightsAlgorithm_t> {
 
     if (force_default) {
         // find default alg
-        for (size_t i=0; i<solution_count; ++i) {
+        for (const auto i : c10::irange(solution_count)) {
             if (solutions[i].algorithm == (miopenConvAlgorithm_t)DEFAULT_ALGO) {
                 return solutions[i];
             }
         }
         // default algo was not found, select first algo without workspace requirement
-        for (size_t i=0; i<solution_count; ++i) {
+        for (const auto i : c10::irange(solution_count)) {
             if (solutions[i].workspace_size == 0) {
                 return solutions[i];
             }

--- a/aten/src/ATen/native/nested/NestedTensorBackward.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBackward.cpp
@@ -8,6 +8,7 @@
 #include <ATen/native/layer_norm.h>
 #include <ATen/NestedTensorImpl.h>
 #include <c10/core/DispatchKey.h>
+#include <c10/util/irange.h>
 #include <ATen/native/nested/NestedTensorUtils.h>
 
 namespace at {
@@ -138,9 +139,9 @@ Tensor _nested_sum_backward_cpu(
     for (const auto i : c10::irange(ntensors)) {
       int64_t segments = num_segments[i].item<int64_t>();
       int64_t segment_length = segment_lengths[i].item<int64_t>();
-      for (auto j = 0; j < segments; j++) {
+      for (C10_UNUSED const auto j : c10::irange(segments)) {
         scalar_t output_grad = output_grad_data[out_idx];
-        for (auto k = 0; k < segment_length; k++) {
+        for (C10_UNUSED const auto k : c10::irange(segment_length)) {
           self_grad_data[in_idx] = output_grad;
           in_idx += 1;
         }

--- a/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.cpp
@@ -8,6 +8,7 @@
 #include <c10/util/string_view.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -153,7 +154,7 @@ Tensor NestedTensor_softmax_dropout(const Tensor& self, const Tensor& query) {
 
   const auto max_seq_len = self.sizes()[2];
 
-  for (int64_t i = 0; i < num_tensors; i++) {
+  for (const auto i : c10::irange(num_tensors)) {
     auto seq_len = sizes.index({i, 0}).item<int64_t>();
     auto subseq = self.index(
         {i,

--- a/aten/src/ATen/native/nested/NestedTensorUtils.h
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.h
@@ -6,6 +6,7 @@
 #include <c10/core/TensorImpl.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -247,7 +248,7 @@ class _map<F, A, c10::guts::typelist::typelist<Args...>> {
     // Some NestedNodes wrap regular Tensors, some NestedTensors and some other
     // types.
     std::vector<A> result;
-    for (size_t i = 0; i < degree; i++) {
+    for (const auto i : c10::irange(degree)) {
       std::tuple<Args...> children = c10::guts::tuple_map(
           std::forward_as_tuple(nested_node...), [&i](auto a) {
             static_assert(

--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <type_traits>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <ATen/ATen.h>
 #include <ATen/NestedTensorImpl.h>
@@ -325,7 +326,7 @@ bool is_safe_to_get_storage_as_tensor(const NestedTensorImpl* tensor) {
   int64_t offset_constant = (tensor_offsets[1] - tensor_offsets[0]) /
       tensor_size_ptr[0] * tensor_stride_ptr[0];
 
-  for (int64_t i = 2; i < n_tensors; i++) {
+  for (const auto i : c10::irange(2, n_tensors)) {
     int64_t current_offset_constant =
         (tensor_offsets[i] - tensor_offsets[i - 1]) /
         tensor_size_ptr[(i - 1) * tensor_stride_0] *

--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -8,6 +8,7 @@
 #include <cpuinfo.h>
 
 #include <c10/util/CallOnce.h>
+#include <c10/util/irange.h>
 
 using PrimitiveCacheKey = std::tuple<
     double, // input_scale
@@ -369,7 +370,7 @@ static bool is_weight_symmetric_quant(
       is_symmetric = false;
     } else {
       auto output_channels = weight.size(0);
-      for (int i = 0; i < output_channels; ++i) {
+      for (const auto i : c10::irange(output_channels)) {
         auto zp = weight.q_per_channel_zero_points()[i].item<int32_t>();
         is_symmetric &= (zp == 0);
       }

--- a/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
+++ b/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
@@ -17,6 +17,7 @@
 #include <ATen/ops/quantize_per_tensor.h>             // for quantize_per_te...
 #include <ATen/ops/std.h>
 #include <ATen/ops/zeros_like_ops.h>
+#include <c10/util/irange.h>
 #endif
 
 namespace at {
@@ -37,7 +38,7 @@ inline bool is_innnermost_dim(
   maybe_wrap_dims(dims, ndim);
   std::sort(dims.begin(), dims.end(), std::greater<int64_t>());
   bool is_innermost = dims.empty() || dims[0] == ndim - 1;
-  for (size_t i = 1; i < dims.size(); ++i) {
+  for (const auto i : c10::irange(1, dims.size())) {
     is_innermost = is_innermost && (dims[i] == dims[i-1] - 1);
   }
   return is_innermost;

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -428,7 +428,7 @@ int64_t hsum_sq(const uint8_t* A, int len) {
   alignas(64) int32_t temp[16];
   int overflow_threshold = 262144; // 2147483647(max of int32)/(512*512)*8 = 262144
   int loop = len / overflow_threshold + 1;
-  for (const auto j : c10::irange(=loop)) {
+  for (const auto j : c10::irange(loop+1)) {
     for (; ((i < overflow_threshold * j) && (i < len / 32 * 32)); i += 32) {
       // (i31, ..., i0)
       __m256i src_epu8 = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(A + i));
@@ -508,7 +508,7 @@ int64_t hsum_sq(const int8_t* A, int len) {
   int overflow_threshold = 1048576; //2147483647/(256*256)*8 = 1048576
   int loop = len / overflow_threshold + 1;
 
-  for (const auto j : c10::irange(=loop)) {
+  for (const auto j : c10::irange(loop+1)) {
     for (; ((i < overflow_threshold * j) && (i < len / 32 * 32)); i += 32) {
       // (i31, ..., i0)
       __m256i src_epi8 = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(A + i));

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -156,7 +156,7 @@ Tensor qcat_nhwc_kernel(
               auto float_values = inp_vec.dequantize(
                   curr_scale_vec, curr_zero_pt_vec, scale_neg_zp_premul);
               Vec::float_vec_return_type retvals;
-              for (int i = 0; i < Vec::float_num_vecs(); ++i) {
+              for (const auto i : c10::irange(Vec::float_num_vecs())) {
                 if (ReLUFused) {
                   retvals[i] =
                       vec::maximum(float_values[i], Vectorized<float>(0.0f));
@@ -184,7 +184,7 @@ Tensor qcat_nhwc_kernel(
             auto float_values = inp_vec.dequantize(
                 curr_scale_vec, curr_zero_pt_vec, scale_neg_zp_premul);
             Vec::float_vec_return_type retvals;
-            for (int i = 0; i < vec_num; ++i) {
+            for (const auto i : c10::irange(vec_num)) {
               if (ReLUFused) {
                 retvals[i] =
                     vec::maximum(float_values[i], Vectorized<float>(0.0f));
@@ -399,7 +399,7 @@ int64_t hsum_sq(const uint8_t* A, int len) {
   alignas(64) int32_t temp[8];
   int overflow_threshold = 262144; // 2147483647(max of int32)/(256*256)*8 = 262144
   int loop = len / overflow_threshold + 1;
-  for(int j=0; j<=loop; j++){
+  for (const auto j : c10::irange(loop+1)) {
     for (; ((i < overflow_threshold * j) && (i < len / 16 * 16)); i += 16) {
       // (i15, ..., i0)
       __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
@@ -428,7 +428,7 @@ int64_t hsum_sq(const uint8_t* A, int len) {
   alignas(64) int32_t temp[16];
   int overflow_threshold = 262144; // 2147483647(max of int32)/(512*512)*8 = 262144
   int loop = len / overflow_threshold + 1;
-  for(int j=0; j<=loop; j++){
+  for (const auto j : c10::irange(=loop)) {
     for (; ((i < overflow_threshold * j) && (i < len / 32 * 32)); i += 32) {
       // (i31, ..., i0)
       __m256i src_epu8 = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(A + i));
@@ -475,7 +475,7 @@ int64_t hsum_sq(const int8_t* A, int len) {
   int overflow_threshold = 1048576; //2147483647/(128*128)*8 = 1048576
   int loop = len / overflow_threshold + 1;
 
-  for(int j=0; j<=loop; j++){
+  for (const auto j : c10::irange(loop+1)) {
     for (; ((i < overflow_threshold * j) && (i < len / 16 * 16)); i += 16) {
       // (i15, ..., i0)
       __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
@@ -508,7 +508,7 @@ int64_t hsum_sq(const int8_t* A, int len) {
   int overflow_threshold = 1048576; //2147483647/(256*256)*8 = 1048576
   int loop = len / overflow_threshold + 1;
 
-  for(int j=0; j<=loop; j++){
+  for (const auto j : c10::irange(=loop)) {
     for (; ((i < overflow_threshold * j) && (i < len / 32 * 32)); i += 32) {
       // (i31, ..., i0)
       __m256i src_epi8 = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(A + i));
@@ -2768,7 +2768,7 @@ void quantized_normalize_kernel(
               auto dqXVec = qXVec.dequantize(x_fake_scale_vec, x_zp_vec,
                     x_fake_scale_zp_neg_premul_vec);
               int validDqvecLen = (kNonVecRemInChannel - 1) / fVec::size() + 1;
-              for (int i = 0; i < validDqvecLen; ++i) {
+              for (const auto i : c10::irange(validDqvecLen)) {
                 auto &dq = dqXVec[i];
                 dq =
                   (dq - layer_mean_div_scale_xVec) *
@@ -2834,7 +2834,7 @@ void qmean_inner_dim_kernel(
   for (size_t i = 0; i < in_dims.size() - num_dims_to_squeeze; ++i) {
     M *= in_dims[i];
   }
-  for (size_t i = 0; i < num_dims_to_squeeze; ++i) {
+  for (const auto i : c10::irange(num_dims_to_squeeze)) {
     auto idx = out_dims.size() - 1 - i;
     N *= out_dims[idx];
     out_dims[idx] = 1;
@@ -2884,7 +2884,7 @@ void qstd_inner_dim_kernel(
   for (size_t i = 0; i < in_dims.size() - num_dims_to_squeeze; ++i) {
     M *= in_dims[i];
   }
-  for (size_t i = 0; i < num_dims_to_squeeze; ++i) {
+  for (const auto i : c10::irange(num_dims_to_squeeze)) {
     auto idx = out_dims.size() - 1 - i;
     N *= out_dims[idx];
     out_dims[idx] = 1;
@@ -3059,7 +3059,7 @@ void quantized_groupnorm_nhwc_kernel(
               auto qXVec = qVec::loadu(X_ptr + vecStartIdx);
               auto dqXVec = qXVec.dequantize(x_fake_scale_vec, x_zp_vec,
                     x_fake_scale_zp_neg_premul_vec);
-              for (size_t fvecIdx = 0; fvecIdx < dqXVec.size(); ++fvecIdx) {
+              for (const auto fvecIdx : c10::irange(dqXVec.size())) {
                 auto scaleVec = fVec::loadu(scale_ptr + vecStartIdx + fvecIdx * kFloatVLen);
                 auto biasVec = fVec::loadu(bias_ptr + vecStartIdx + fvecIdx * kFloatVLen);
                 dqXVec[fvecIdx] = dqXVec[fvecIdx] * scaleVec + biasVec;
@@ -3106,7 +3106,7 @@ void quantized_groupnorm_nhwc_kernel(
           float* rstd_ptr = mean_ptr + C;
           scalar_t* X_ptr = X_data + nhwIdx * C;
           scalar_t::underlying* X_ptr_underlying = reinterpret_cast<scalar_t::underlying*>(X_ptr);
-          for (int chIdx = 0; chIdx < C; ++chIdx) {
+          for (const auto chIdx : c10::irange(C)) {
             auto x = X_ptr_underlying[chIdx];
             mean_ptr[chIdx] += x;
             rstd_ptr[chIdx] += x * x;
@@ -3183,7 +3183,7 @@ void quantized_groupnorm_nhwc_kernel(
             auto qXVec = qVec::loadu(X_ptr + vecStartIdx);
             auto dqXVec = qXVec.dequantize(x_fake_scale_vec, x_zp_vec,
                   x_fake_scale_zp_neg_premul_vec);
-            for (size_t fvecIdx = 0; fvecIdx < dqXVec.size(); ++fvecIdx) {
+            for (const auto fvecIdx : c10::irange(dqXVec.size())) {
               auto scaleVec = fVec::loadu(scale_ptr + vecStartIdx + fvecIdx * kFloatVLen);
               auto biasVec = fVec::loadu(bias_ptr + vecStartIdx + fvecIdx * kFloatVLen);
               dqXVec[fvecIdx] = dqXVec[fvecIdx] * scaleVec + biasVec;
@@ -3448,7 +3448,7 @@ void dequantize_tensor_arm(
     const int64_t N,
     const float scale,
     const int32_t zero_point) {
-  for (int i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     out[i] = dequantize_val<T>(scale, zero_point, in[i]);
   }
 }

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -384,7 +384,7 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsOnednn<
         "Per Channel Quantization is currently disabled for transposed conv");
     wgt_zero_points.resize(output_channels);
     wgt_scales.resize(output_channels);
-    for (int i = 0; i < output_channels; ++i) {
+    for (const auto i : c10::irange(output_channels)) {
       wgt_zero_points[i] = weight.q_per_channel_zero_points()[i].item<int32_t>();
       TORCH_CHECK(
           wgt_zero_points[i]==0,

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -229,7 +229,7 @@ c10::intrusive_ptr<LinearPackedParamsBase> PackedLinearWeightsOnednn::prepack(
   } else if (qtype == c10::kPerChannelAffine) {
     wgt_zero_points.resize(N);
     wgt_scales.resize(N);
-    for (int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       wgt_zero_points[i] = weight.q_per_channel_zero_points()[i].item<int32_t>();
       TORCH_CHECK(
           wgt_zero_points[i] == 0,

--- a/aten/src/ATen/native/quantized/cpu/qmatmul.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qmatmul.cpp
@@ -4,6 +4,7 @@
 #ifdef USE_RUY_QMATMUL
 #include <ATen/Parallel.h>
 #include <ATen/native/quantized/cpu/RuyUtils.h>
+#include <c10/util/irange.h>
 #include <ruy/ruy.h>
 #endif
 
@@ -139,7 +140,7 @@ Tensor qmatmul(
       const underlying_t* qb_subtensor = qb_data + begin * qb_stride;
       underlying_t* out_subtensor = out_data + begin * out_stride;
 
-      for (int64_t i = begin; i < end; i++) {
+      for (C10_UNUSED const auto i : c10::irange(begin, end)) {
         qa_matrix.set_data(qa_subtensor);
         qb_matrix.set_data(qb_subtensor);
         out_matrix.set_data(out_subtensor);

--- a/aten/src/ATen/native/quantized/cudnn/BinaryOps.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/BinaryOps.cpp
@@ -16,6 +16,7 @@
 #include <c10/core/QScheme.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/util/ArrayRef.h>
+#include <c10/util/irange.h>
 #include <torch/library.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -54,7 +55,7 @@ void setAddParams(
   params->device_id = at::cuda::current_device();
   params->input_dim = input_a.dim();
   params->memory_format = input_a.suggest_memory_format();
-  for (int i = 0; i < params->input_dim; ++i) {
+  for (const auto i : c10::irange(params->input_dim)) {
     params->input_a_size[i] = input_a.sizes()[i];
     params->input_b_size[i] = input_b.sizes()[i];
   }

--- a/aten/src/ATen/native/quantized/cudnn/Linear.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Linear.cpp
@@ -19,6 +19,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAFunctions.h>
+#include <c10/util/irange.h>
 #include <cudnn_frontend.h>
 #include <torch/library.h>
 
@@ -67,10 +68,10 @@ void setLinearParams(
   params->dataType = CUDNN_DATA_INT32;
   params->input_dim = input.dim();
   params->memory_format = input.suggest_memory_format();
-  for (int i = 0; i < params->input_dim; ++i) {
+  for (const auto i : c10::irange(params->input_dim)) {
     params->input_size[i] = input.sizes()[i];
   }
-  for (int i = 0; i < 2; ++i) {
+  for (const auto i : c10::irange(2)) {
     params->weight_size[i] = weight.sizes()[i];
   }
   params->deterministic = deterministic;

--- a/aten/src/ATen/native/sparse/SparseBinaryOpIntersectionKernel.cpp
+++ b/aten/src/ATen/native/sparse/SparseBinaryOpIntersectionKernel.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/sparse/SparseBinaryOpIntersectionCommon.h>
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/native/TensorIterator.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -57,7 +58,7 @@ struct CPUValueSelectionIntersectionKernel {
                   const auto* ptr_rhs_values_bytes = data[3];
                   const auto* ptr_rhs_select_idx_bytes = data[4];
 
-                  for (int64_t i = 0; i < n; ++i) {
+                  for (C10_UNUSED const auto i : c10::irange(n)) {
                     // Exctract data
                     auto* RESTRICT ptr_res_values = reinterpret_cast<scalar_t*>(ptr_res_values_bytes);
                     const auto* ptr_lhs_values = reinterpret_cast<const scalar_t*>(ptr_lhs_values_bytes);

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -50,6 +50,7 @@
 #include <ATen/ops/sparse_dim_native.h>
 #include <ATen/ops/values_native.h>
 #include <ATen/ops/_validate_compressed_sparse_indices.h>
+#include <c10/util/irange.h>
 #endif
 
 namespace at {
@@ -157,7 +158,7 @@ void _validate_sparse_compressed_tensor_args_worker(const Tensor& compressed_ind
       batchsize, ")");
 
   // A tensor constitutes of full blocks, 3.1
-  for (int i=0; i<block_ndim; i++) {
+  for (const auto i : c10::irange(block_ndim)) {
       TORCH_CHECK(size[batch_ndim + i] % blocksize[i] == 0,
                   "tensor shape[", batch_ndim + i, "] (=", size[batch_ndim + i],
                   ") must be divisible with blocksize[", i, "] (=", blocksize[i],
@@ -374,7 +375,7 @@ DimVector _estimate_sparse_compressed_tensor_size(
         size.push_back(plain_dim_size * blocksize[0]);
         size.push_back(compressed_dim_size * blocksize[1]);
       });
-  for (int i=0; i<dense_ndim; i++) {
+  for (const auto i : c10::irange(dense_ndim)) {
     int64_t j = batch_ndim + 1 + block_ndim + i;
     size.push_back((j < values.dim() ? values.size(j) : 1));
   }

--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -950,7 +950,7 @@ Tensor reduce_sparse_csr_dim0_cpu_template(const Tensor& sparse, ReductionOp rop
                             // There is no point in parallelizing the following for-loop
                             // because about 99.3% of the computation time is spent in the
                             // at::_unique call above.
-                            for (int64_t i=0; i<numel; i++) {
+                            for (const auto i : c10::irange(numel)) {
                               index_t col = columns_map_ptr[i];
                               scalar_t val = values_ptr[i];
                               new_values_ptr[col] = rop(new_values_ptr[col], val);
@@ -1027,7 +1027,7 @@ Tensor reduce_sparse_csr_dim1_cpu_template(const Tensor& sparse, ReductionOp rop
     index_t* row_map_ptr = row_map.data_ptr<index_t>();
     int64_t nnz = 0;
     new_crow_indices_ptr[0] = 0;
-    for(int64_t i=0; i<nrows; i++) {
+    for (const auto i : c10::irange(nrows)) {
       if (crow_indices_ptr[i] != crow_indices_ptr[i + 1]) {
         row_map_ptr[i] = nnz;
         nnz++;
@@ -1094,7 +1094,7 @@ In [4]: %timeit torch.sum(t.values())
                                        rop.identity(),
                                        [&](int64_t i_start, int64_t i_end, scalar_t identity) {
                                          scalar_t res = identity;
-                                         for (int64_t i=i_start; i<i_end; i++) {
+                                         for (const auto i : c10::irange(i_start, i_end)) {
                                            scalar_t val = values_ptr[i];
                                            res = rop(res, val);
                                          }

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ArrayRef.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/QuantizedFunctions.h>
+#include <c10/util/irange.h>
 #include <torch/library.h>
 #include <vector>
 
@@ -59,11 +60,11 @@ std::vector<int64_t> broadcast_size(const Tensor& t1, const Tensor& t2) {
 
   std::vector<int64_t> out;
   if (t1_size > t2_size) {
-    for (int64_t i = 0; i < t1_size; i++) {
+    for (const auto i : c10::irange(t1_size)) {
       out.push_back(t1.sizes()[i]);
     }
   } else {
-    for (int64_t i = 0; i < t2_size; i++) {
+    for (const auto i : c10::irange(t2_size)) {
       out.push_back(t2.sizes()[i]);
     }
   }

--- a/aten/src/ATen/native/vulkan/ops/Gru.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Gru.cpp
@@ -12,6 +12,7 @@
 #include <ATen/ops/sigmoid.h>
 #include <ATen/ops/slice.h>
 #include <ATen/ops/tanh.h>
+#include <c10/util/irange.h>
 #endif
 
 namespace at {
@@ -79,7 +80,7 @@ std::tuple<Tensor, Tensor> gru_input(
   // reshape to 2D due to Vulkan at::mm op accepts only 2D
   auto x = input_vk.reshape({batch_size * seq_length, input_vk.size(2)});
 
-  for (int64_t i = 0; i < num_layers; ++i) {
+  for (const auto i : c10::irange(num_layers)) {
     // extract each hidden state and squeeze into 2D dim
     auto h = at::slice(hx_vk, 0, i, i + 1, 1);
     h = h.reshape({h.size(0) * h.size(1), h.size(2)});
@@ -148,7 +149,7 @@ std::vector<c10::intrusive_ptr<LinearPackedContext>> pack_linear_op_contexts(
   std::vector<c10::intrusive_ptr<LinearPackedContext>> linear_op_contexts;
   linear_op_contexts.reserve(num_layers * 6);
 
-  for (int64_t i = 0; i < num_layers; ++i) {
+  for (const auto i : c10::irange(num_layers)) {
     const auto& w_ih = params_cpu.at(i * 4);
     const auto& w_hh = params_cpu.at(i * 4 + 1);
     const auto& b_ih = params_cpu.at(i * 4 + 2);
@@ -251,7 +252,7 @@ const c10::impl::GenericList GruPackedContext::unpack() const {
             .toTensor());
   }
   unpacked_gru_context.emplace_back(params_cpu);
-  for (int64_t i = 1; i < Unpacked::NumArgs; ++i) {
+  for (const auto i : c10::irange(1, Unpacked::NumArgs)) {
     unpacked_gru_context.emplace_back(get_val(i));
   }
 
@@ -308,7 +309,7 @@ std::tuple<Tensor, Tensor> run_gru_context(
   // reshape to 2D due to Vulkan at::mm op accepts only 2D
   auto x = input_vk.reshape({batch_size * seq_length, input_vk.size(2)});
 
-  for (int64_t i = 0; i < num_layers; ++i) {
+  for (const auto i : c10::irange(num_layers)) {
     // extract each hidden state and squeeze into 2D dim
     auto h = at::slice(hx_vk, 0, i, i + 1, 1);
     h = h.reshape({h.size(0) * h.size(1), h.size(2)});

--- a/aten/src/ATen/native/vulkan/ops/Lstm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Lstm.cpp
@@ -11,6 +11,7 @@
 #include <ATen/ops/sigmoid.h>
 #include <ATen/ops/slice.h>
 #include <ATen/ops/tanh.h>
+#include <c10/util/irange.h>
 #endif
 
 namespace at {
@@ -101,7 +102,7 @@ std::tuple<Tensor, Tensor, Tensor> lstm_input(
   h_n_list.reserve(num_layers);
   c_n_list.reserve(num_layers);
 
-  for (int64_t l = 0; l < num_layers; ++l) {
+  for (const auto l : c10::irange(num_layers)) {
     // extract each hidden state and squeeze into 2D dim
     auto h = at::slice(hx_vk, 0, l, l + 1, 1);
     h = h.reshape({h.size(0) * h.size(1), h.size(2)});
@@ -185,7 +186,7 @@ pack_lstm_linear_op_contexts(
   std::vector<c10::intrusive_ptr<LinearPackedContext>> linear_op_contexts;
   linear_op_contexts.reserve(num_layers * 8);
 
-  for (int64_t l = 0; l < num_layers; ++l) {
+  for (const auto l : c10::irange(num_layers)) {
     const auto& w_ih = params_cpu[l * 4];
     const auto& w_hh = params_cpu[l * 4 + 1];
     const auto& b_ih = params_cpu[l * 4 + 2];
@@ -294,7 +295,7 @@ const c10::impl::GenericList LstmPackedContext::unpack() const {
             .toTensor());
   }
   unpacked_lstm_context.emplace_back(params_cpu);
-  for (int64_t i = 1; i < 7; ++i) {
+  for (const auto i : c10::irange(1, 7)) {
     unpacked_lstm_context.emplace_back(get_val(i));
   }
 
@@ -360,7 +361,7 @@ std::tuple<Tensor, Tensor, Tensor> run_lstm_context(
   h_n_list.reserve(num_layers);
   c_n_list.reserve(num_layers);
 
-  for (int64_t l = 0; l < num_layers; ++l) {
+  for (const auto l : c10::irange(num_layers)) {
     // extract each hidden state and squeeze into 2D dim
     auto h = at::slice(hx_vk, 0, l, l + 1, 1);
     h = h.reshape({h.size(0) * h.size(1), h.size(2)});

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -259,7 +259,7 @@ void TestIndexingByScalar() {
   for (const auto i : c10::irange(tensor.numel())) {
     ASSERT_TRUE(tensor[i].equal(one * i));
   }
-  for (size_t i = 0; i < static_cast<uint64_t>(tensor.numel()); ++i) {
+  for (const auto i : c10::irange(static_cast<uint64_t>(tensor.numel()))) {
     ASSERT_TRUE(tensor[i].equal(one * static_cast<int64_t>(i)));
   }
   for (const auto i : c10::irange(tensor.numel())) {

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -457,7 +457,7 @@ namespace {
         CACHE_ALIGN VT expected_vals[vec::size()];
         auto vals = 1 << (vec::size());
         for (const auto val : c10::irange(vals)) {
-          for (int i = 0; i < vec::size(); ++i) {
+          for (const auto i : c10::irange(vec::size())) {
             if (val & (1 << i)) {
               test_vals[i] = std::numeric_limits<VT>::quiet_NaN();
               // All bits are set to 1 if true, otherwise 0.
@@ -750,8 +750,7 @@ namespace {
         auto power_sets = 1 << (vec::size());
         for (const auto expected : c10::irange(power_sets)) {
             // generate test_val based on expected
-            for (int i = 0; i < vec::size(); ++i)
-            {
+            for (const auto i : c10::irange(vec::size())) {
                 if (expected & (1 << i)) {
                     test_vals[i] = (VT)0;
                 }
@@ -777,7 +776,7 @@ namespace {
         CACHE_ALIGN IntVT expected_vals1[vec::size()];
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         CACHE_ALIGN IntVT actual_vals1[vec::size()];
-        for (int64_t i = 0; i < vec::size(); i++) {
+        for (const auto i : c10::irange(vec::size())) {
             input1[i] = (VT)i * (VT)2.1 + (VT)0.5;
             expected_vals1[i] = static_cast<IntVT>(input1[i]);
         }
@@ -795,7 +794,7 @@ namespace {
         CACHE_ALIGN VT expected_vals2[vec::size()];
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         CACHE_ALIGN VT actual_vals2[vec::size()];
-        for (int64_t i = 0; i < vec::size(); i++) {
+        for (const auto i : c10::irange(vec::size())) {
             input2[i] = (IntVT)i * (IntVT)2 + (IntVT)1;
             expected_vals2[i] = (VT)input2[i];
         }
@@ -834,7 +833,7 @@ namespace {
     test_blend(VT expected_val[vec::size()], VT a[vec::size()], VT b[vec::size()]) {
         // generate expected_val
         int64_t m = mask;
-        for (int64_t i = 0; i < vec::size(); i++) {
+        for (const auto i : c10::irange(vec::size())) {
             expected_val[i] = (m & 0x01) ? b[i] : a[i];
             m = m >> 1;
         }
@@ -853,7 +852,7 @@ namespace {
     test_blendv(VT expected_val[vec::size()], VT a[vec::size()], VT b[vec::size()], VT mask[vec::size()]) {
         using bit_rep = BitType<VT>;
         // generate expected_val
-        for (int64_t i = 0; i < vec::size(); i++) {
+        for (const auto i : c10::irange(vec::size())) {
             bit_rep hex_mask = 0;
             hex_mask=bit_cast<bit_rep>(mask[i]);
             expected_val[i] = (hex_mask & 0x01) ? b[i] : a[i];
@@ -865,7 +864,7 @@ namespace {
         auto expected = vec::loadu(expected_val);
         auto actual = vec::blendv(vec_a, vec_b, vec_m);
         auto mask_str = std::string("\nblendv mask: ");
-        for (int64_t i = 0; i < vec::size(); i++) {
+        for (const auto i : c10::irange(vec::size())) {
             mask_str += std::to_string(mask[i]) + " ";
         }
         if (AssertVectorized<vec>(std::string(NAME_INFO(test_blendv)) + mask_str, expected, actual).check()) {
@@ -953,7 +952,7 @@ namespace {
     void test_set(VT expected_val[vec::size()], VT a[vec::size()], VT b[vec::size()], int64_t count){
         if (count < 0) return;
         //generate expected_val
-        for (int64_t i = 0; i < vec::size(); i++) {
+        for (const auto i : c10::irange(vec::size())) {
             expected_val[i] = (i < count) ? b[i] : a[i];
         }
         // test with set
@@ -1000,7 +999,7 @@ namespace {
         CACHE_ALIGN VT expected_val[vec::size()];
         VT base, step;
         arange_init(base, step);
-        for (int64_t i = 0; i < vec::size(); i++) {
+        for (const auto i : c10::irange(vec::size())) {
             expected_val[i] = base + VT((UVT)i) * step;
         }
         auto expected = vec::loadu(expected_val);
@@ -1059,7 +1058,7 @@ namespace {
             float inv_scale = 1.0f / static_cast<float>(scale);
             auto zero_point_val = generator_zp.get();
             int index = 0;
-            for (int j = 0; j < vec::float_num_vecs(); j++) {
+            for (const auto j : c10::irange(vec::float_num_vecs())) {
                 //generate vals
                 for (auto& v : unit_float_vec) {
                     v = gen.get();
@@ -1107,7 +1106,7 @@ namespace {
             int index = 0;
             auto qint_vec = vec::loadu(qint_vals);
             auto actual_float_ret = qint_vec.dequantize(vf_scale, vf_zp, vf_scale_zp);
-            for (int j = 0; j < vec::float_num_vecs(); j++) {
+            for (const auto j : c10::irange(vec::float_num_vecs())) {
                 for (auto& v : unit_exp_vals) {
                     v = dequantize_val(scale, zero_point_val, qint_vals[index]);
                     index++;
@@ -1144,7 +1143,7 @@ namespace {
             float multiplier = 1.f / (generator_sc.get());
             auto zero_point_val = generator.get();
             int index = 0;
-            for (int j = 0; j < vec::float_num_vecs(); j++) {
+            for (const auto j : c10::irange(vec::float_num_vecs())) {
                 //generate vals
                 for (auto& v : unit_int_vec) {
                     v = c10::qint32(generator.get());
@@ -1180,7 +1179,7 @@ namespace {
         for (const auto i : c10::irange(trials)) {
             (void)i; // Suppress unused variable warning
             //generate vals
-            for (int j = 0; j < vec::size(); j++) {
+            for (const auto j : c10::irange(vec::size())) {
                 qint_vals[j] = generator.get();
                 qint_b[j] = generator.get();
                 if (std::is_same<underlying, int>::value) {
@@ -1192,7 +1191,7 @@ namespace {
             auto qint_vec = vec::loadu(qint_vals);
             auto qint_vec_b = vec::loadu(qint_b);
             auto actual_int_ret = qint_vec.widening_subtract(qint_vec_b);
-            for (int j = 0; j < vec::float_num_vecs(); j++) {
+            for (const auto j : c10::irange(vec::float_num_vecs())) {
                 for (auto& v : unit_exp_vals) {
                     v = widening_subtract(qint_vals[index], qint_b[index]);
                     index++;

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -41,7 +41,7 @@ bool checkHardShrink(
 
   float abs_clamp_thresh = std::abs(clamp_thresh);
 
-  for (int i = 0; i < ref.numel(); ++i) {
+  for (const auto i : c10::irange(ref.numel())) {
     float ref_val = ref_ptr[i];
     float out_val = out_ptr[i];
 
@@ -79,7 +79,7 @@ bool checkThreshold(
   float out_max = out.abs().max().item<float>();
   float max_val = std::fmax(ref_max, out_max);
 
-  for (int i = 0; i < ref.numel(); ++i) {
+  for (const auto i : c10::irange(ref.numel())) {
     float ref_val = ref_ptr[i];
     float out_val = out_ptr[i];
 
@@ -3910,7 +3910,7 @@ TEST_F(VulkanAPITest, gru_success) {
   c10::List<at::Tensor> weight_hh_l; // shape (3 * hidden_size, hidden_size)
   c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
-  for (int i = 0; i < num_layers; ++i) {
+  for (const auto i : c10::irange(num_layers)) {
     if (i == 0) {
       weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
     } else {
@@ -3979,7 +3979,7 @@ TEST_F(VulkanAPITest, gru_mclareninputs_success) {
   c10::List<at::Tensor> weight_hh_l; // shape (3 * hidden_size, hidden_size)
   c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
-  for (int i = 0; i < num_layers; ++i) {
+  for (const auto i : c10::irange(num_layers)) {
     if (i == 0) {
       weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
     } else {
@@ -4044,7 +4044,7 @@ TEST_F(VulkanAPITest, gru_invalidinputs_exceptions) {
   c10::List<at::Tensor> weight_hh_l; // shape (3 * hidden_size, hidden_size)
   c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
-  for (int i = 0; i < num_layers; ++i) {
+  for (const auto i : c10::irange(num_layers)) {
     if (i == 0) {
       weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
     } else {
@@ -4139,7 +4139,7 @@ TEST_F(VulkanAPITest, gru_prepack_success) {
   c10::List<at::Tensor> weight_hh_l; // shape (3 * hidden_size, hidden_size)
   c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
-  for (int i = 0; i < num_layers; ++i) {
+  for (const auto i : c10::irange(num_layers)) {
     if (i == 0) {
       weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
     } else {
@@ -4210,7 +4210,7 @@ TEST_F(VulkanAPITest, gru_prepack_invalidinputs_exceptions) {
   c10::List<at::Tensor> weight_hh_l; // shape (3 * hidden_size, hidden_size)
   c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
-  for (int i = 0; i < num_layers; ++i) {
+  for (const auto i : c10::irange(num_layers)) {
     if (i == 0) {
       weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
     } else {
@@ -4386,7 +4386,7 @@ TEST_F(VulkanAPITest, lstm_success) {
   c10::List<at::Tensor> weight_hh_l; // shape (4 * hidden_size, hidden_size)
   c10::List<at::Tensor> bias_ih_l;   // shape (4 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (4 * hidden_size)
-  for (int l = 0; l < num_layers; ++l) {
+  for (const auto l : c10::irange(num_layers)) {
     if (l == 0) {
       weight_ih_l.emplace_back(at::rand({4 * hidden_size, input_size}, at::device(at::kCPU).dtype(at::kFloat)));
     } else {
@@ -4466,7 +4466,7 @@ TEST_F(VulkanAPITest, lstm_mclareninputs_success) {
   c10::List<at::Tensor> weight_hh_l; // shape (4 * hidden_size, hidden_size)
   c10::List<at::Tensor> bias_ih_l;   // shape (4 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (4 * hidden_size)
-  for (int l = 0; l < num_layers; ++l) {
+  for (const auto l : c10::irange(num_layers)) {
     if (l == 0) {
       weight_ih_l.emplace_back(at::rand({4 * hidden_size, input_size}, at::device(at::kCPU).dtype(at::kFloat)));
     } else {
@@ -4542,7 +4542,7 @@ TEST_F(VulkanAPITest, lstm_prepack_success) {
   c10::List<at::Tensor> weight_hh_l; // shape (4 * hidden_size, hidden_size)
   c10::List<at::Tensor> bias_ih_l;   // shape (4 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (4 * hidden_size)
-  for (int l = 0; l < num_layers; ++l) {
+  for (const auto l : c10::irange(num_layers)) {
     if (l == 0) {
       weight_ih_l.emplace_back(at::rand({4 * hidden_size, input_size}, at::device(at::kCPU).dtype(at::kFloat)));
     } else {

--- a/aten/src/ATen/test/xnnpack_test.cpp
+++ b/aten/src/ATen/test/xnnpack_test.cpp
@@ -9,6 +9,7 @@
 #include <ATen/native/xnnpack/Pooling.h>
 #include <c10/core/CPUAllocator.h>
 #include <c10/core/MemoryFormat.h>
+#include <c10/util/irange.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -253,7 +254,7 @@ TEST(TestXNNPackOps, TestConvolution2dMultiThreaded) {
       std::unique_lock<std::mutex> g(lock);
       cond.notify_all();
     }
-    for (int64_t i = 0; i < 30; i++) {
+    for (const auto i : c10::irange(30)) {
       context->run(input_tensor);
     }
     return context->run(input_tensor);

--- a/benchmarks/cpp/nvfuser/heuristic_cache.cpp
+++ b/benchmarks/cpp/nvfuser/heuristic_cache.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/executor.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
@@ -28,10 +29,10 @@ static auto getLayerBackwardNormRuntime(
   const size_t kOuterNumDims = kM - kN;
 
   std::vector<int64_t> outer_shape;
-  for (size_t idx = 0; idx < kOuterNumDims; ++idx) {
+  for (const auto idx : c10::irange(kOuterNumDims)) {
     outer_shape.push_back(shape[idx]);
   }
-  for (size_t idx = kOuterNumDims; idx < kM; ++idx) {
+  for (const auto idx : c10::irange(kOuterNumDims, kM)) {
     outer_shape.push_back(1);
   }
 

--- a/benchmarks/cpp/nvfuser/heuristic_lookup.cpp
+++ b/benchmarks/cpp/nvfuser/heuristic_lookup.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/executor.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
@@ -28,10 +29,10 @@ static auto getLayerBackwardNormRuntime(
   const size_t kOuterNumDims = kM - kN;
 
   std::vector<int64_t> outer_shape;
-  for (size_t idx = 0; idx < kOuterNumDims; ++idx) {
+  for (const auto idx : c10::irange(kOuterNumDims)) {
     outer_shape.push_back(shape[idx]);
   }
-  for (size_t idx = kOuterNumDims; idx < kM; ++idx) {
+  for (const auto idx : c10::irange(kOuterNumDims, kM)) {
     outer_shape.push_back(1);
   }
 

--- a/benchmarks/cpp/nvfuser/layer_norm.cpp
+++ b/benchmarks/cpp/nvfuser/layer_norm.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/executor.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
@@ -92,7 +93,7 @@ static void Baseline_LayerNorm(
       benchmark_state.range(0), benchmark_state.range(1)};
   const size_t kReductionAxis = 1;
   std::vector<int64_t> norm_shape;
-  for (auto idx = kReductionAxis; idx < input_shape.size(); ++idx) {
+  for (const auto idx : c10::irange(kReductionAxis, input_shape.size())) {
     norm_shape.push_back(input_shape[idx]);
   }
 

--- a/benchmarks/cpp/nvfuser/layer_norm_backward.cpp
+++ b/benchmarks/cpp/nvfuser/layer_norm_backward.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/executor.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
@@ -117,7 +118,7 @@ static void Baseline_LayerNorm_BWD(
       benchmark_state.range(0), benchmark_state.range(1)};
   const size_t kReductionAxis = 1;
   std::vector<int64_t> norm_shape;
-  for (auto idx = kReductionAxis; idx < input_shape.size(); ++idx) {
+  for (const auto idx : c10::irange(kReductionAxis, input_shape.size())) {
     norm_shape.push_back(input_shape[idx]);
   }
 

--- a/benchmarks/cpp/nvfuser/lstm_cell.cpp
+++ b/benchmarks/cpp/nvfuser/lstm_cell.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/arith.h>
 #include <torch/csrc/jit/codegen/cuda/executor.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
@@ -19,7 +20,7 @@ static void setupFusion(Fusion* fusion) {
   FusionGuard fg(fusion);
 
   TensorView* tvs[16];
-  for (size_t i = 0; i < 16; i++) {
+  for (const auto i : c10::irange(16)) {
     tvs[i] = makeContigTensor(2, DataType::Float);
     fusion->addInput(tvs[i]);
   }

--- a/benchmarks/cpp/nvfuser/shape_inference.cpp
+++ b/benchmarks/cpp/nvfuser/shape_inference.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/executor.h>
 #include <torch/csrc/jit/codegen/cuda/fusion.h>
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
@@ -28,10 +29,10 @@ static auto getLayerBackwardNormRuntime(
   const size_t kOuterNumDims = kM - kN;
 
   std::vector<int64_t> outer_shape;
-  for (size_t idx = 0; idx < kOuterNumDims; ++idx) {
+  for (const auto idx : c10::irange(kOuterNumDims)) {
     outer_shape.push_back(shape[idx]);
   }
-  for (size_t idx = kOuterNumDims; idx < kM; ++idx) {
+  for (const auto idx : c10::irange(kOuterNumDims, kM)) {
     outer_shape.push_back(1);
   }
 

--- a/benchmarks/cpp/tensorexpr/bench_concat.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_concat.cpp
@@ -52,7 +52,7 @@ class ConcatBench : public benchmark::Fixture {
     size_t num_dims = 2;
 
     std::vector<BufHandle> inputs;
-    for (size_t i = 0; i < num_inputs; ++i) {
+    for (const auto i : c10::irange(num_inputs)) {
       inputs.emplace_back(BufHandle(
           "input" + std::to_string(i),
           {input_sizes_[i][0], input_sizes_[i][1]},
@@ -114,7 +114,7 @@ class ConcatBench : public benchmark::Fixture {
     std::vector<BufHandle> inputs;
     std::vector<StmtPtr> for_stmts(num_inputs);
     int cumulative_input_sizes = 0;
-    for (size_t i = 0; i < num_inputs; ++i) {
+    for (const auto i : c10::irange(num_inputs)) {
       inputs.emplace_back(BufHandle(
           "input" + std::to_string(i),
           {input_sizes_[i][0], input_sizes_[i][1]},

--- a/benchmarks/cpp/tensorexpr/bench_prefix_sum.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_prefix_sum.cpp
@@ -1,5 +1,6 @@
 #include <benchmark/benchmark.h>
 #include "ATen/Functions.h"
+#include <c10/util/irange.h>
 
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
@@ -53,7 +54,7 @@ inline void Log(const __m256i& value) {
   const size_t n = sizeof(__m256i) / sizeof(T);
   T buffer[n];
   _mm256_storeu_si256((__m256i*)buffer, value);
-  for (int i = 0; i < n; i++)
+  for (const auto i : c10::irange(n))
     std::cout << buffer[n - i - 1] << " ";
   std::cout << std::endl;
 }
@@ -162,7 +163,7 @@ class PrefixSumBench : public benchmark::Fixture {
       auto input_data = input_.data_ptr<float>();
       auto output_data = output_.data_ptr<float>();
       float sum = 0.0f;
-      for (int i = 0; i < input_size_; ++i) {
+      for (const auto i : c10::irange(input_size_)) {
         sum = sum + input_data[i];
         output_data[i] = sum;
       }
@@ -176,7 +177,7 @@ class PrefixSumBench : public benchmark::Fixture {
       auto input_data = input_int_.data_ptr<int>();
       auto output_data = output_int_.data_ptr<int>();
       int sum = 0;
-      for (int i = 0; i < input_size_; ++i) {
+      for (const auto i : c10::irange(input_size_)) {
         sum = sum + input_data[i];
         output_data[i] = sum;
       }

--- a/benchmarks/cpp/tensorexpr/bench_reduce.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_reduce.cpp
@@ -202,9 +202,9 @@ static void reduce1d_native_tiled(at::Tensor& A, at::Tensor& B) {
   }
 
   int tile_count = size / kChunkSize / kTileSize;
-  for (int i = 0; i < tile_count; i++) {
+  for (const auto i : c10::irange(tile_count)) {
 #pragma unroll
-    for (int j = 0; j < kTileSize; j++) {
+    for (const auto j : c10::irange(kTileSize)) {
       float* p = pA + (i * kTileSize + j) * kChunkSize;
       __m256 data = _mm256_loadu_ps(p);
       t[j] = _mm256_add_ps(t[j], data);

--- a/c10/core/SymIntArrayRef.h
+++ b/c10/core/SymIntArrayRef.h
@@ -4,6 +4,7 @@
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 #include <array>
 #include <initializer_list>
@@ -49,7 +50,7 @@ inline SymIntArrayRef fromIntArrayRefKnownNonNegative(IntArrayRef array_ref) {
 }
 
 inline SymIntArrayRef fromIntArrayRefSlow(IntArrayRef array_ref) {
-  for (size_t i = 0; i < array_ref.size(); ++i) {
+  for (const auto i : c10::irange(array_ref.size())) {
     TORCH_CHECK(
         SymInt::check_range(array_ref[i]),
         "IntArrayRef contains an int that cannot be represented as a SymInt: ",

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -950,7 +950,7 @@ void TensorImpl::ShareExternalPointer(
 void clone_symvec(SymIntArrayRef src, SymDimVector& dst) {
   dst.clear();
   dst.reserve(src.size());
-  for (size_t i = 0; i < src.size(); i++) {
+  for (const auto i : c10::irange(src.size())) {
     dst.emplace_back(src[i].clone());
   }
 }

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -1,4 +1,5 @@
 #include <c10/core/thread_pool.h>
+#include <c10/util/irange.h>
 
 namespace c10 {
 
@@ -12,7 +13,7 @@ ThreadPool::ThreadPool(
       available_(threads_.size()),
       total_(threads_.size()),
       numa_node_id_(numa_node_id) {
-  for (std::size_t i = 0; i < threads_.size(); ++i) {
+  for (const auto i : c10::irange(threads_.size())) {
     threads_[i] = std::thread([this, i, init_thread]() {
       if (init_thread) {
         init_thread();

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -469,7 +469,7 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
   void emptyCache(void) override {
     std::lock_guard<std::mutex> lk(general_mutex);
 
-    for (int dev = 0; dev < device_count; dev++) {
+    for (const auto dev : c10::irange(device_count)) {
       if (devs_initialized_flags[dev]) {
         CUDAGuard g(dev);
 

--- a/c10/test/util/Bitset_test.cpp
+++ b/c10/test/util/Bitset_test.cpp
@@ -7,7 +7,7 @@ using c10::utils::bitset;
 
 TEST(BitsetTest, givenEmptyBitset_whenGettingBit_thenIsZero) {
   bitset b;
-  for (size_t i = 0; i < bitset::NUM_BITS(); ++i) {
+  for (const auto i : c10::irange(bitset::NUM_BITS())) {
     EXPECT_FALSE(b.get(i));
   }
 }
@@ -15,7 +15,7 @@ TEST(BitsetTest, givenEmptyBitset_whenGettingBit_thenIsZero) {
 TEST(BitsetTest, givenEmptyBitset_whenUnsettingBit_thenIsZero) {
   bitset b;
   b.unset(4);
-  for (size_t i = 0; i < bitset::NUM_BITS(); ++i) {
+  for (const auto i : c10::irange(bitset::NUM_BITS())) {
     EXPECT_FALSE(b.get(i));
   }
 }
@@ -24,7 +24,7 @@ TEST(BitsetTest, givenEmptyBitset_whenSettingAndUnsettingBit_thenIsZero) {
   bitset b;
   b.set(4);
   b.unset(4);
-  for (size_t i = 0; i < bitset::NUM_BITS(); ++i) {
+  for (const auto i : c10::irange(bitset::NUM_BITS())) {
     EXPECT_FALSE(b.get(i));
   }
 }
@@ -41,7 +41,7 @@ TEST(BitsetTest, givenEmptyBitset_whenSettingBit_thenOthersStayUnset) {
   for (const auto i : c10::irange(6)) {
     EXPECT_FALSE(b.get(i));
   }
-  for (size_t i = 7; i < bitset::NUM_BITS(); ++i) {
+  for (const auto i : c10::irange(7, bitset::NUM_BITS())) {
     EXPECT_FALSE(b.get(i));
   }
 }
@@ -63,7 +63,7 @@ TEST(BitsetTest, givenNonemptyBitset_whenSettingBit_thenOthersStayAtOldValue) {
   for (const auto i : c10::irange(7, 30)) {
     EXPECT_FALSE(b.get(i));
   }
-  for (size_t i = 31; i < bitset::NUM_BITS(); ++i) {
+  for (const auto i : c10::irange(31, bitset::NUM_BITS())) {
     EXPECT_FALSE(b.get(i));
   }
 }
@@ -87,7 +87,7 @@ TEST(
     EXPECT_FALSE(b.get(i));
   }
   EXPECT_TRUE(b.get(30));
-  for (size_t i = 31; i < bitset::NUM_BITS(); ++i) {
+  for (const auto i : c10::irange(31, bitset::NUM_BITS())) {
     EXPECT_FALSE(b.get(i));
   }
 }

--- a/c10/test/util/SmallVectorTest.cpp
+++ b/c10/test/util/SmallVectorTest.cpp
@@ -12,6 +12,7 @@
 
 #include <c10/util/ArrayRef.h>
 #include <c10/util/SmallVector.h>
+#include <c10/util/irange.h>
 #include <gtest/gtest.h>
 #include <stdarg.h>
 #include <list>
@@ -181,7 +182,7 @@ class SmallVectorTestBase : public testing::Test {
 
     va_list ap;
     va_start(ap, size);
-    for (size_t i = 0; i < size; ++i) {
+    for (const auto i : c10::irange(size)) {
       int value = va_arg(ap, int);
       EXPECT_EQ(value, v[i].getValue());
     }
@@ -383,7 +384,7 @@ TYPED_TEST(SmallVectorTest, OverflowTest) {
 
   // Test size and values.
   EXPECT_EQ(10u, this->theVector.size());
-  for (int i = 0; i < 10; ++i) {
+  for (const auto i : c10::irange(10)) {
     EXPECT_EQ(i + 1, this->theVector[i].getValue());
   }
 
@@ -840,8 +841,9 @@ TYPED_TEST(DualSmallVectorsTest, MoveAssignment) {
   SCOPED_TRACE("MoveAssignTest-DualVectorTypes");
 
   // Set up our vector with four elements.
-  for (unsigned I = 0; I < 4; ++I)
+  for (const auto I : c10::irange(4)) {
     this->otherVector.push_back(Constructable(I));
+  }
 
   const Constructable* OrigDataPtr = this->otherVector.data();
 

--- a/c10/test/util/Synchronized_test.cpp
+++ b/c10/test/util/Synchronized_test.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/Synchronized.h>
+#include <c10/util/irange.h>
 #include <gtest/gtest.h>
 
 #include <array>
@@ -9,7 +10,7 @@ namespace {
 TEST(Synchronized, TestSingleThreadExecution) {
   c10::Synchronized<int> iv(0);
   const int kMaxValue = 100;
-  for (int i = 0; i < kMaxValue; ++i) {
+  for (const auto i : c10::irange(kMaxValue)) {
     auto ret = iv.withLock([](int& iv) { return ++iv; });
     EXPECT_EQ(ret, i + 1);
   }
@@ -22,7 +23,7 @@ TEST(Synchronized, TestMultiThreadedExecution) {
 #define NUM_LOOP_INCREMENTS 10000
 
   auto thread_cb = [&iv]() {
-    for (int i = 0; i < NUM_LOOP_INCREMENTS; ++i) {
+    for (const auto i : c10::irange(NUM_LOOP_INCREMENTS)) {
       iv.withLock([](int& iv) { ++iv; });
     }
   };

--- a/c10/test/util/ordered_preserving_dict_test.cpp
+++ b/c10/test/util/ordered_preserving_dict_test.cpp
@@ -235,7 +235,7 @@ TEST(OrderedPreservingDictTest, test_range_erase) {
 
   // Check order
   it = map.begin();
-  for (std::size_t i = 0; i < nb_values; i++) {
+  for (const auto i : c10::irange(nb_values)) {
     if (i >= 10 && i < 220) {
       continue;
     }

--- a/c10/util/hash.h
+++ b/c10/util/hash.h
@@ -7,6 +7,7 @@
 
 #include <c10/util/ArrayRef.h>
 #include <c10/util/complex.h>
+#include <c10/util/irange.h>
 
 namespace c10 {
 
@@ -76,7 +77,7 @@ struct sha1 {
     get_digest(digest);
 
     std::ostringstream buf;
-    for (int i = 0; i < 5; ++i) {
+    for (const auto i : c10::irange(5)) {
       buf << std::hex << std::setfill('0') << std::setw(8) << digest[i];
     }
 
@@ -91,14 +92,14 @@ struct sha1 {
   void process_block_impl() {
     unsigned int w[80];
 
-    for (std::size_t i = 0; i < 16; ++i) {
+    for (const auto i : c10::irange(16)) {
       w[i] = (block_[i * 4 + 0] << 24);
       w[i] |= (block_[i * 4 + 1] << 16);
       w[i] |= (block_[i * 4 + 2] << 8);
       w[i] |= (block_[i * 4 + 3]);
     }
 
-    for (std::size_t i = 16; i < 80; ++i) {
+    for (const auto i : c10::irange(16, 80)) {
       w[i] = left_rotate((w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]), 1);
     }
 
@@ -108,7 +109,7 @@ struct sha1 {
     unsigned int d = h_[3];
     unsigned int e = h_[4];
 
-    for (std::size_t i = 0; i < 80; ++i) {
+    for (const auto i : c10::irange(80)) {
       unsigned int f;
       unsigned int k;
 

--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <c10/util/irange.h>
+
 #include <algorithm>
 #include <cassert>
 #include <climits>
@@ -301,8 +303,9 @@ T reverseBits(T Val) {
   unsigned char in[sizeof(Val)];
   unsigned char out[sizeof(Val)];
   std::memcpy(in, &Val, sizeof(Val));
-  for (unsigned i = 0; i < sizeof(Val); ++i)
+  for (const auto i : c10::irange(sizeof(Val))){
     out[(sizeof(Val) - i) - 1] = BitReverseTable256[in[i]];
+  }
   std::memcpy(&Val, out, sizeof(Val));
   return Val;
 }

--- a/caffe2/contrib/fakelowp/lengths_reducer_fused_4bit_rowwise_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_fused_4bit_rowwise_fp16_fake_op.h
@@ -97,7 +97,7 @@ class SparseLengthsFused4BitRowwiseFakeFP16Op final : public Operator<Context> {
         return false;
       }
 
-      for (int i = 0; i < lengths_data[m]; ++i) {
+      for (const auto i : c10::irange(lengths_data[m])) {
         int64_t idx = indices_data[current];
 
         int accIdx = 0;

--- a/caffe2/contrib/fakelowp/lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_fused_8bit_rowwise_fp16_fake_op.h
@@ -93,7 +93,7 @@ class SparseLengthsFused8BitRowwiseFakeFP16Op final : public Operator<Context> {
         return false;
       }
 
-      for (int i = 0; i < lengths_data[m]; ++i) {
+      for (const auto i : c10::irange(lengths_data[m])) {
         int64_t idx = indices_data[current];
 
         int accIdx = 0;

--- a/caffe2/contrib/fakelowp/lengths_reducer_ops.h
+++ b/caffe2/contrib/fakelowp/lengths_reducer_ops.h
@@ -99,7 +99,7 @@ class SparseLengthsReductionFakeFp16Op final : public Operator<CPUContext> {
       if (current + lengths[m] > index_size) {
         return false;
       }
-      for (int i = 0; i < lengths[m]; ++i) {
+      for (const auto i : c10::irange(lengths[m])) {
         int64_t idx = indices[current];
         if (idx < 0 || idx >= data_size) {
           return false;

--- a/caffe2/contrib/gloo/common_world_ops.h
+++ b/caffe2/contrib/gloo/common_world_ops.h
@@ -94,7 +94,7 @@ class CreateCommonWorld final : public Operator<Context> {
 
       // Switch pairs to synchronous mode if configured to do so
       if (sync_) {
-        for (int i = 0; i < context->size; i++) {
+        for (const auto i : c10::irange(context->size)) {
           auto& pair = context->getPair(i);
           if (pair) {
             pair->setSync(true, false);
@@ -186,7 +186,7 @@ class CloneCommonWorld final : public Operator<Context> {
 
       // Switch pairs to synchronous mode if configured to do so
       if (sync_) {
-        for (int i = 0; i < clone->size; i++) {
+        for (const auto i : c10::irange(clone->size)) {
           auto& pair = clone->getPair(i);
           if (pair) {
             pair->setSync(true, false);

--- a/caffe2/contrib/shm_mutex/shm_mutex.h
+++ b/caffe2/contrib/shm_mutex/shm_mutex.h
@@ -302,7 +302,7 @@ class ShmTicketMutex : public ShmProcessMutex<ShmTicketMutex<T>> {
     for (;;) {
       int spintime =
           (slot - this->header_->now.load(std::memory_order_relaxed)) * delay_;
-      for (int i = 0; i < spintime; i++) {
+      for (const auto i : c10::irange(spintime)) {
         // Empty loop
         __asm__ __volatile__("");
       }

--- a/caffe2/contrib/warpctc/ctc_op.h
+++ b/caffe2/contrib/warpctc/ctc_op.h
@@ -96,7 +96,7 @@ class CTCOp final : public Operator<Context> {
     if (is_test_ && labels.size(0) == 0) {
       // compute_ctc_loss doesn't handle empty labels well
       T* costsData = costs->template mutable_data<T>();
-      for (int i = 0; i < costs->numel(); ++i) {
+      for (const auto i : c10::irange(costs->numel())) {
         costsData[i] = 0;
       }
       return true;

--- a/caffe2/core/test_utils.h
+++ b/caffe2/core/test_utils.h
@@ -103,7 +103,7 @@ void fillTensor(
   tensor->Resize(shape);
   CAFFE_ENFORCE_EQ(data.size(), tensor->numel());
   auto ptr = tensor->mutable_data<T>();
-  for (int i = 0; i < tensor->numel(); ++i) {
+  for (const auto i : c10::irange(tensor->numel())) {
     ptr[i] = data[i];
   }
 }
@@ -137,7 +137,7 @@ void constantFillTensor(
     TensorCPU* tensor) {
   tensor->Resize(shape);
   auto ptr = tensor->mutable_data<T>();
-  for (int i = 0; i < tensor->numel(); ++i) {
+  for (const auto i : c10::irange(tensor->numel())) {
     ptr[i] = data;
   }
 }

--- a/caffe2/experiments/operators/fully_connected_op_prune.h
+++ b/caffe2/experiments/operators/fully_connected_op_prune.h
@@ -18,6 +18,7 @@
 #define CAFFE2_OPERATORS_FULLY_CONNECTED_OP_PRUNE_H_
 
 #include <c10/util/Logging.h>
+#include <c10/util/irange.h>
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
@@ -71,8 +72,8 @@ void MaskMatrix<float, CPUContext>(
     int M,
     int N) {
   int offset = 0;
-  for (int i = 0; i < M; ++i) {
-    for (int j = 0; j < N; ++j) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
       mat[offset] = mask[offset] ? mat[offset] : 0;
       offset++;
     }
@@ -114,8 +115,8 @@ int MatrixCompare_LT<float>(
     int N) {
   int seq_len = 0;
   int offset = 0;
-  for (int i = 0; i < M; ++i) {
-    for (int j = 0; j < N; ++j) {
+  for (const auto i : c10::irange(M)) {
+    for (const auto j : c10::irange(N)) {
       if (mat[offset] != 0 && (mat[offset] < thres && mat[offset] > -thres)) {
         mask_seq[seq_len++] = static_cast<float>(offset);
       }

--- a/caffe2/operators/cc_bmm_bg_op.h
+++ b/caffe2/operators/cc_bmm_bg_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/types.h"
 #include "caffe2/utils/math.h"
 #include "c10/util/irange.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 

--- a/caffe2/operators/conv_op_impl.h
+++ b/caffe2/operators/conv_op_impl.h
@@ -40,7 +40,7 @@ bool ConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
       M % G, 0, "The number of output channels is not divisible by group.");
 
   int kernel_size = 1;
-  for (std::size_t i = 0; i < kernel_.size(); ++i) {
+  for (const auto i : c10::irange(kernel_.size())) {
     CAFFE_ENFORCE_EQ(filter.dim32(i + 2), kernel_[i]);
     kernel_size *= kernel_[i];
   }
@@ -215,7 +215,7 @@ bool ConvOp<T, Context>::RunOnDeviceWithOrderNHWC() {
       M % G, 0, "The number of output channels is not divisible by group.");
 
   int kernel_size = 1;
-  for (std::size_t i = 0; i < kernel_.size(); ++i) {
+  for (const auto i : c10::irange(kernel_.size())) {
     CAFFE_ENFORCE_EQ(filter.dim32(i + 1), kernel_[i]);
     kernel_size *= kernel_[i];
   }

--- a/caffe2/operators/copy_rows_to_tensor_op.h
+++ b/caffe2/operators/copy_rows_to_tensor_op.h
@@ -42,7 +42,7 @@ class CopyRowsToTensorOp : public Operator<Context> {
     CAFFE_ENFORCE(
         IsInputOutputAlias(0, 0), "Input 0 and Output 0 should be alias.");
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (size_t i = 0; i < indices.sizes()[0]; ++i) {
+    for (const auto i : c10::irange(indices.sizes()[0])) {
       std::memcpy(
           output_data + indices_data[i] * tensor_width,
           row_data,

--- a/caffe2/operators/feature_maps_ops.h
+++ b/caffe2/operators/feature_maps_ops.h
@@ -4,6 +4,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
 #include "c10/util/irange.h"
+#include <c10/util/irange.h>
 
 namespace caffe2 {
 
@@ -493,8 +494,7 @@ class MergeMultiScalarFeatureTensorsOp : public Operator<Context> {
         const T* inValuesData =
             Input(kNumTensorsPerInput * inputIndex + 2).template data<T>();
         outLengthsData[exampleIndex] += inLengthsData[exampleIndex];
-        for (int featureIndex = 0; featureIndex < inLengthsData[exampleIndex];
-             ++featureIndex) {
+        for (const auto featureIndex : c10::irange(inLengthsData[exampleIndex])) {
           CAFFE_ENFORCE_LT(outKeysOffset, totalNumFeatures);
           CAFFE_ENFORCE_LT(
               inKeysOffset_[inputIndex], Input(inputKeysBlobIdx).numel());
@@ -637,8 +637,7 @@ class MergeMultiListFeatureTensorsOp : public Operator<Context> {
         const auto& inValuesValues =
             Input(kNumTensorsPerInput * inputIndex + 3);
         outLengthsData[exampleIndex] += inLengthsData[exampleIndex];
-        for (int featureIndex = 0; featureIndex < inLengthsData[exampleIndex];
-             ++featureIndex) {
+        for (const auto featureIndex : c10::irange(inLengthsData[exampleIndex])) {
           outKeysData[outKeysOffset] = inKeysData[inKeysOffset_[inputIndex]];
           outValuesLengthsData[outKeysOffset] =
               inValuesLengthsData[inKeysOffset_[inputIndex]];
@@ -739,8 +738,7 @@ class MergeMultiMapFeatureTensorsOp : public Operator<Context> {
         const auto& inValuesValues =
             Input(kNumTensorsPerInput * inputIndex + 4);
         outLengthsData[exampleIndex] += inLengthsData[exampleIndex];
-        for (int featureIndex = 0; featureIndex < inLengthsData[exampleIndex];
-             ++featureIndex) {
+        for (const auto featureIndex : c10::irange(inLengthsData[exampleIndex])) {
           outKeysData[outKeysOffset] = inKeysData[inKeysOffset_[inputIndex]];
           outValuesLengthsData[outKeysOffset] =
               inValuesLengthsData[inKeysOffset_[inputIndex]];
@@ -822,9 +820,7 @@ class MergeMultiListOrMapFeatureTensorsGradientOp : public Operator<Context> {
             Input(kNumTensorsPerInput * inputIndex + 1)
                 .template data<int32_t>();
         int valuesLengthCopy = 0;
-        for (int valuesLengthIndex = 0;
-             valuesLengthIndex < inLengthsData[exampleIndex];
-             ++valuesLengthIndex) {
+        for (const auto valuesLengthIndex : c10::irange(inLengthsData[exampleIndex])) {
           valuesLengthCopy += inValuesLengthsData
               [outValuesLengthOffset[inputIndex] + valuesLengthIndex];
         }

--- a/caffe2/operators/filler_op.h
+++ b/caffe2/operators/filler_op.h
@@ -323,7 +323,7 @@ class ConstantFillOp final : public FillerOp<Context> {
         InputSize(), 2, "constant fill string from tensor is not supported");
     auto value = this->template GetSingleArgument<std::string>("value", "");
     auto* data = output->template mutable_data<std::string>();
-    for (int i = 0; i < output->numel(); ++i) {
+    for (const auto i : c10::irange(output->numel())) {
       data[i] = value;
     }
     return true;

--- a/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_8bit_rowwise_ops.h
@@ -122,7 +122,7 @@ class SparseLengthsFused8BitRowwiseOp : public Operator<Context> {
 
     int64_t current = 0;
     for (const auto m : c10::irange(output_size)) {
-      for (int i = 0; i < lengths_data[m]; ++i) {
+      for (const auto i : c10::irange(lengths_data[m])) {
         CAFFE_ENFORCE_LT(current, index_size);
         IndexType idx = indices_data[current];
         CAFFE_ENFORCE(

--- a/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
+++ b/caffe2/operators/lengths_reducer_fused_nbit_rowwise_ops.h
@@ -138,7 +138,7 @@ class SparseLengthsFusedNBitRowwiseOp final : public Operator<Context> {
     // Error handling
     int64_t current = 0;
     for (const auto m : c10::irange(output_size)) {
-      for (int i = 0; i < lengths_data[m]; ++i) {
+      for (const auto i : c10::irange(lengths_data[m])) {
         CAFFE_ENFORCE_LT(current, index_size);
         IndexType idx = indices_data[current];
         CAFFE_ENFORCE(
@@ -556,7 +556,7 @@ class SparseLengthsNBitRowwiseSparseOp final : public Operator<CPUContext> {
     // Error handling
     int64_t current = 0;
     for (const auto m : c10::irange(output_size)) {
-      for (int i = 0; i < lengths_data[m]; ++i) {
+      for (const auto i : c10::irange(lengths_data[m])) {
         CAFFE_ENFORCE_LT(current, index_size);
         IndexType idx = indices_data[current];
         if (!fallback_to_no_sparse) {

--- a/caffe2/operators/lengths_reducer_ops.h
+++ b/caffe2/operators/lengths_reducer_ops.h
@@ -195,7 +195,7 @@ class CPUSparseLengthsReductionOp : public Operator<CPUContext> {
 
     int64_t current = 0;
     for (const auto m : c10::irange(M)) {
-      for (int i = 0; i < lengths[m]; ++i) {
+      for (const auto i : c10::irange(lengths[m])) {
         CAFFE_ENFORCE_LT(
             current,
             indices_size,

--- a/caffe2/operators/locally_connected_op_impl.h
+++ b/caffe2/operators/locally_connected_op_impl.h
@@ -50,7 +50,7 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   }
 
   int kernel_dims_size = 1;
-  for (std::size_t i = 0; i < kernel_.size(); ++i) {
+  for (const auto i : c10::irange(kernel_.size())) {
     CAFFE_ENFORCE_EQ(filter.dim32(i + image_ndim + 2), kernel_[i]);
     kernel_dims_size *= kernel_[i];
   }
@@ -394,7 +394,7 @@ bool LocallyConnectedGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   ConvPoolOpBase<Context>::ComputePads(input_image_dims);
 
   int kernel_dims_size = 1;
-  for (std::size_t i = 0; i < kernel_.size(); ++i) {
+  for (const auto i : c10::irange(kernel_.size())) {
     CAFFE_ENFORCE_EQ(filter.dim32(i + image_ndim + 2), kernel_[i]);
     kernel_dims_size *= kernel_[i];
   }

--- a/caffe2/operators/pack_rnn_sequence_op.h
+++ b/caffe2/operators/pack_rnn_sequence_op.h
@@ -5,6 +5,7 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
 #include "c10/util/irange.h"
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <vector>
@@ -72,7 +73,7 @@ class PackRNNSequenceOpBase : public Operator<Context> {
 
     int32_t offset = 0;
     for (const auto c : c10::irange(cols)) {
-      for (int r = 0; r < lengths_vec[c]; r++) {
+      for (const auto r : c10::irange(lengths_vec[c])) {
         auto input_offset = Forward ? (offset + r) : (r * cols + c);
         auto output_offset = Forward ? (r * cols + c) : (offset + r);
         context_.CopyItemsSameDevice(

--- a/caffe2/operators/quantized/int8_test_utils.h
+++ b/caffe2/operators/quantized/int8_test_utils.h
@@ -30,7 +30,7 @@ inline std::unique_ptr<int8::Int8TensorCPU> q(
   std::mt19937 gen(rd());
   std::uniform_int_distribution<uint32_t> dis{
       0, std::numeric_limits<uint8_t>::max()};
-  for (auto i = 0; i < r->t.numel(); ++i) {
+  for (const auto i : c10::irange(r->t.numel())) {
     r->t.mutable_data<uint8_t>()[i] = dis(gen);
   }
   return r;
@@ -46,7 +46,7 @@ inline std::unique_ptr<int8::Int8TensorCPU> biasq(
   std::random_device rd;
   std::mt19937 gen(rd());
   std::uniform_real_distribution<float> dis(-1, 1);
-  for (auto i = 0; i < r->t.numel(); ++i) {
+  for (const auto i : c10::irange(r->t.numel())) {
     r->t.mutable_data<int32_t>()[i] =
         static_cast<int32_t>(dis(gen) / scale + r->zero_point);
   }
@@ -56,7 +56,7 @@ inline std::unique_ptr<int8::Int8TensorCPU> biasq(
 inline std::unique_ptr<TensorCPU> dq(const int8::Int8TensorCPU& XQ) {
   auto r = std::make_unique<Tensor>(CPU);
   r->Resize(XQ.t.sizes());
-  for (auto i = 0; i < r->numel(); ++i) {
+  for (const auto i : c10::irange(r->numel())) {
     r->mutable_data<float>()[i] =
         (static_cast<int32_t>(XQ.t.data<uint8_t>()[i]) - XQ.zero_point) *
         XQ.scale;
@@ -67,7 +67,7 @@ inline std::unique_ptr<TensorCPU> dq(const int8::Int8TensorCPU& XQ) {
 inline std::unique_ptr<TensorCPU> biasdq(const int8::Int8TensorCPU& XQ) {
   auto r = std::make_unique<Tensor>(CPU);
   r->Resize(XQ.t.sizes());
-  for (auto i = 0; i < r->numel(); ++i) {
+  for (const auto i : c10::irange(r->numel())) {
     r->mutable_data<float>()[i] =
         (XQ.t.data<int32_t>()[i] - XQ.zero_point) * XQ.scale;
   }

--- a/caffe2/operators/rnn/recurrent_network_op.h
+++ b/caffe2/operators/rnn/recurrent_network_op.h
@@ -9,6 +9,7 @@
 #include "caffe2/utils/conversions.h"
 #include "caffe2/utils/math.h"
 #include "c10/util/irange.h"
+#include <c10/util/irange.h>
 
 C10_DECLARE_bool(caffe2_rnn_executor);
 
@@ -472,12 +473,12 @@ class RecurrentNetworkGradientOp final : public Operator<Context> {
   void renameOpInputOutput(std::string from_name, std::string to_name) {
     for (const auto j : c10::irange(stepNetDef_.op_size())) {
       auto* op = stepNetDef_.mutable_op(j);
-      for (int i = 0; i < op->input_size(); i++) {
+      for (const auto i : c10::irange(op->input_size())) {
         if (op->input(i) == from_name) {
           op->set_input(i, to_name);
         }
       }
-      for (int i = 0; i < op->output_size(); i++) {
+      for (const auto i : c10::irange(op->output_size())) {
         if (op->output(i) == from_name) {
           op->set_output(i, to_name);
         }

--- a/caffe2/operators/segment_reduction_op.h
+++ b/caffe2/operators/segment_reduction_op.h
@@ -312,7 +312,7 @@ class AbstractReduceFrontOrBackOp : public Operator<Context> {
 
     typename Reducer::Meta ctx(FirstDim);
     ctx.observeInput(0, data, num_reduce_dims_);
-    for (int i = 1; i < Reducer::kInputCount; ++i) {
+    for (const auto i : c10::irange(1, Reducer::kInputCount)) {
       auto& aux_in = Input(i);
       ctx.observeInput(i, aux_in, num_reduce_dims_);
     }
@@ -380,7 +380,7 @@ class AbstractReduceFrontOrBackGradientOp : public Operator<Context> {
 
     typename ReducerGradient::Meta ctx(reduction_grad, 0, FirstDim);
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < ReducerGradient::originalInputs().size(); ++i) {
+    for (const auto i : c10::irange(ReducerGradient::originalInputs().size())) {
       auto& aux_in = Input(i);
       ctx.observeOriginalInput(
           ReducerGradient::originalInputs()[i],
@@ -643,7 +643,7 @@ class AbstractSortedSegmentOp : public Operator<Context> {
     // metaprogramming
     typename Reducer::Meta ctx;
     ctx.observeInput(0, dataInput, 1);
-    for (int i = 1; i < Reducer::kInputCount; ++i) {
+    for (const auto i : c10::irange(1, Reducer::kInputCount)) {
       auto& aux_in = Input(i);
       CAFFE_ENFORCE_EQ(
           N,
@@ -746,7 +746,7 @@ class AbstractSortedSegmentGradientOp : public Operator<Context> {
 
     typename ReducerGradient::Meta ctx(segment_grads, 1);
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < ReducerGradient::originalInputs().size(); ++i) {
+    for (const auto i : c10::irange(ReducerGradient::originalInputs().size())) {
       auto& aux_in = Input(i);
       CAFFE_ENFORCE_EQ(
           N,
@@ -1047,7 +1047,7 @@ class AbstractUnsortedSegmentOp : public Operator<Context> {
     // metaprogramming
     typename Reducer::Meta ctx;
     ctx.observeInput(0, data, 1);
-    for (int i = 1; i < Reducer::kInputCount; ++i) {
+    for (const auto i : c10::irange(1, Reducer::kInputCount)) {
       auto& aux_in = Input(i);
       CAFFE_ENFORCE_EQ(
           N,
@@ -1162,7 +1162,7 @@ class AbstractUnsortedSegmentGradientOp : public Operator<Context> {
 
     typename ReducerGradient::Meta ctx(segment_grads, 1);
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < ReducerGradient::originalInputs().size(); ++i) {
+    for (const auto i : c10::irange(ReducerGradient::originalInputs().size())) {
       auto& aux_in = Input(i);
       CAFFE_ENFORCE_EQ(
           N,
@@ -1436,7 +1436,7 @@ class AbstractLengthsOp : public Operator<Context> {
 
     typename Reducer::Meta ctx;
     ctx.observeInput(0, dataInput, 1);
-    for (int i = 1; i < Reducer::kInputCount; ++i) {
+    for (const auto i : c10::irange(1, Reducer::kInputCount)) {
       auto& aux_in = Input(i);
       CAFFE_ENFORCE(
           dataToReduceSize == aux_in.size(0),
@@ -1557,7 +1557,7 @@ class AbstractLengthsGradientOp : public Operator<Context> {
     }
 
     typename ReducerGradient::Meta ctx(segmentGradsInput, 1);
-    for (auto i = 0U; i < ReducerGradient::originalInputs().size(); ++i) {
+    for (const auto i : c10::irange(0U, ReducerGradient::originalInputs().size())) {
       auto& aux_in = Input(i);
       CAFFE_ENFORCE_EQ(
           reducedDataSize,
@@ -1660,7 +1660,7 @@ class AbstractLengthsWithMainInputGradientOp : public Operator<Context> {
 
     typename ReducerGradient::Meta ctx(segmentGradsInput, 1);
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < ReducerGradient::originalInputs().size(); ++i) {
+    for (const auto i : c10::irange(ReducerGradient::originalInputs().size())) {
       int aux_num = ReducerGradient::originalInputs()[i];
       auto& aux_in = Input(i);
       auto* aux_grad = aux_num < OutputSize() ? Output(aux_num) : nullptr;
@@ -1762,7 +1762,7 @@ class AbstractLengthsWithMainInputAndForwardOutputGradientOp
 
     typename ReducerGradient::Meta ctx(segmentGradsInput, 1);
     // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-    for (int i = 0; i < ReducerGradient::originalInputs().size(); ++i) {
+    for (const auto i : c10::irange(ReducerGradient::originalInputs().size())) {
       int aux_num = ReducerGradient::originalInputs()[i];
       auto& aux_in = Input(i);
       auto* aux_grad = aux_num < OutputSize() ? Output(aux_num) : nullptr;
@@ -1928,7 +1928,7 @@ segments, i.e. len(*LENGTHS*).
           for (int d : in[Reducer::kInputCount].dims()) {
             output.add_dims(d);
           }
-          for (int j = 1; j < in[0].dims_size(); j++) {
+          for (const auto j : c10::irange(1, in[0].dims_size())) {
             output.add_dims(in[0].dims(j));
           }
           output.set_data_type(in[0].data_type());

--- a/caffe2/operators/sparse_to_dense_mask_op.h
+++ b/caffe2/operators/sparse_to_dense_mask_op.h
@@ -157,7 +157,7 @@ class SparseToDenseMaskOp : public SparseToDenseMaskBase<Context> {
     int64_t offset = 0;
     for (const auto r : c10::irange(rows)) {
       bool skippedSparseIndex = false;
-      for (int c = 0; c < lengths_vec[r]; c++) {
+      for (const auto c : c10::irange(lengths_vec[r])) {
         const auto sparse_index = sparse_indices_vec[offset + c];
         if (sparse_index < 0 ||
             sparse_index >= std::numeric_limits<TInd>::max()) {

--- a/caffe2/operators/variable_length_sequence_padding.h
+++ b/caffe2/operators/variable_length_sequence_padding.h
@@ -18,7 +18,7 @@ void VariableLengthSequencePadding(
     const T padValue,
     Context* /*context*/) {
   for (const auto j : c10::irange(B)) {
-    for (int i = seqLengths[j]; i < N; i++) {
+    for (const auto i : c10::irange(seqLengths[j], N)) {
       EigenVectorArrayMap<T>(X + B * M * i + M * j, M).setConstant(padValue);
     }
   }

--- a/caffe2/python/pybind_state_dlpack.h
+++ b/caffe2/python/pybind_state_dlpack.h
@@ -93,7 +93,7 @@ class DLPackWrapper {
 
     std::vector<int64_t> dims;
     dims.reserve(dlTensor->ndim);
-    for (int idx = 0; idx < dlTensor->ndim; ++idx) {
+    for (const auto idx : c10::irange(dlTensor->ndim)) {
       dims.push_back(dlTensor->shape[idx]);
     }
 

--- a/caffe2/quantization/server/conv_pool_dnnlowp_op_base.h
+++ b/caffe2/quantization/server/conv_pool_dnnlowp_op_base.h
@@ -102,7 +102,7 @@ class ConvPoolDNNLowPOpBase : public ConvPoolOpBase<CPUContext> {
     float* ref = float_tensor->template mutable_data<float>();
     if (followed_by_ == "Relu" || debug_def().type() == "ConvRelu" ||
         debug_def().type() == "Int8ConvRelu") {
-      for (int i = 0; i < OutputTensorCPU_(0)->numel(); ++i) {
+      for (const auto i : c10::irange(OutputTensorCPU_(0)->numel())) {
         ref[i] = std::max(0.f, ref[i]);
       }
     }

--- a/caffe2/quantization/server/dnnlowp_op.h
+++ b/caffe2/quantization/server/dnnlowp_op.h
@@ -159,7 +159,7 @@ class DNNLowPOp : public Operator<CPUContext> {
         // If dequantize_output_ is true and relu is not fused,
         // dnnlowp op won't clip negative values. Do it here.
         actual_temp.resize(OutputTensorCPU_(0)->numel());
-        for (int i = 0; i < Output(0)->numel(); ++i) {
+        for (const auto i : c10::irange(Output(0)->numel())) {
           actual_temp[i] = std::max(0.f, actual[i]);
         }
         actual = actual_temp.data();
@@ -176,7 +176,7 @@ class DNNLowPOp : public Operator<CPUContext> {
 
     float* ref = Fp32Op_()->Get()->Output(0)->template mutable_data<float>();
     if (followed_by_ == "Relu") {
-      for (int i = 0; i < OutputTensorCPU_(0)->numel(); ++i) {
+      for (const auto i : c10::irange(OutputTensorCPU_(0)->numel())) {
         ref[i] = std::max(0.f, ref[i]);
       }
     }

--- a/caffe2/quantization/server/fb_fc_packed_op.h
+++ b/caffe2/quantization/server/fb_fc_packed_op.h
@@ -92,7 +92,7 @@ class FbFCPackedOperator final : public Operator<Context> {
     if (!W->packed()) {
       if (!packed_w_) {
         std::vector<float> src_mat(W->matSize());
-        for (int i = 0; i < W->matSize(); ++i) {
+        for (const auto i : c10::irange(W->matSize())) {
           src_mat[i] =
             fbgemm::cpu_half2float(W->pmat()[i]);
         }

--- a/caffe2/quantization/server/op_wrapper.h
+++ b/caffe2/quantization/server/op_wrapper.h
@@ -32,7 +32,7 @@ class OpWrapper {
     const OperatorDef& def = op_->debug_def();
     CPUContext context(def.device_option());
 
-    for (int i = 0; i < op_->InputSize(); ++i) {
+    for (const auto i : c10::irange(op_->InputSize())) {
       if (op_->InputIsType<int8::Int8TensorCPU>(i)) {
         const TensorCPU& qtensor = op_->Input<int8::Int8TensorCPU>(i).t;
         TensorCPU* float_tensor =

--- a/caffe2/serialize/crc_alt.h
+++ b/caffe2/serialize/crc_alt.h
@@ -204,7 +204,8 @@ uint32_t crc32_bitwise(const void* data, size_t length, uint32_t previousCrc32)
   {
     crc ^= *current++;
 
-    for (const auto j : c10::irange(8)) {
+    for (int j = 0; j < 8; j++)
+    {
       // branch-free
       crc = (crc >> 1) ^ (-int32_t(crc & 1) & Polynomial);
 
@@ -433,7 +434,8 @@ uint32_t crc32_4x8bytes(const void* data, size_t length, uint32_t previousCrc32)
   // process 4x eight bytes at once (Slicing-by-8)
   while (length >= BytesAtOnce)
   {
-    for (const auto unrolling : c10::irange(Unroll)) {
+    for (size_t unrolling = 0; unrolling < Unroll; unrolling++)
+    {
 #if __BYTE_ORDER == __BIG_ENDIAN
       uint32_t one = *current++ ^ swap(crc);
       uint32_t two = *current++;
@@ -486,7 +488,8 @@ uint32_t crc32_16bytes(const void* data, size_t length, uint32_t previousCrc32)
 
   while (length >= BytesAtOnce)
   {
-    for (const auto unrolling : c10::irange(Unroll)) {
+    for (size_t unrolling = 0; unrolling < Unroll; unrolling++)
+    {
 #if __BYTE_ORDER == __BIG_ENDIAN
     uint32_t one   = *current++ ^ swap(crc);
     uint32_t two   = *current++;
@@ -561,7 +564,8 @@ uint32_t crc32_16bytes_prefetch(const void* data, size_t length, uint32_t previo
   {
     PREFETCH(((const char*) current) + prefetchAhead);
 
-    for (const auto unrolling : c10::irange(Unroll)) {
+    for (size_t unrolling = 0; unrolling < Unroll; unrolling++)
+    {
 #if __BYTE_ORDER == __BIG_ENDIAN
     uint32_t one   = *current++ ^ swap(crc);
     uint32_t two   = *current++;
@@ -679,12 +683,13 @@ uint32_t crc32_combine(uint32_t crcA, uint32_t crcB, size_t lengthB)
 
   // put operator for one zero bit in odd
   odd[0] = Polynomial;    // CRC-32 polynomial
-  for (const auto i : c10::irange(1, CrcBits))
+  for (uint32_t i = 1; i < CrcBits; i++)
     odd[i] = 1 << (i - 1);
 
   // put operator for two zero bits in even
   // same as gf2_matrix_square(even, odd);
-  for (const auto i : c10::irange(CrcBits)) {
+  for (uint32_t i = 0; i < CrcBits; i++)
+  {
     uint32_t vec = odd[i];
     even[i] = 0;
     for (int j = 0; vec != 0; j++, vec >>= 1)
@@ -693,7 +698,8 @@ uint32_t crc32_combine(uint32_t crcA, uint32_t crcB, size_t lengthB)
   }
   // put operator for four zero bits in odd
   // same as gf2_matrix_square(odd, even);
-  for (const auto i : c10::irange(CrcBits)) {
+  for (uint32_t i = 0; i < CrcBits; i++)
+  {
     uint32_t vec = even[i];
     odd[i] = 0;
     for (int j = 0; vec != 0; j++, vec >>= 1)
@@ -708,7 +714,8 @@ uint32_t crc32_combine(uint32_t crcA, uint32_t crcB, size_t lengthB)
   for (; lengthB > 0; lengthB >>= 1)
   {
     // same as gf2_matrix_square(a, b);
-    for (const auto i : c10::irange(CrcBits)) {
+    for (uint32_t i = 0; i < CrcBits; i++)
+    {
       uint32_t vec = b[i];
       a[i] = 0;
       for (int j = 0; vec != 0; j++, vec >>= 1)
@@ -748,14 +755,14 @@ const uint32_t Crc32Lookup[MaxSlice][256] =
   //for (int i = 0; i <= 0xFF; i++)
   //{
   //  uint32_t crc = i;
-  //  for (const auto j : c10::irange(8))
+  //  for (int j = 0; j < 8; j++)
   //    crc = (crc >> 1) ^ ((crc & 1) * Polynomial);
   //  Crc32Lookup[0][i] = crc;
   //}
   //// ... and the following slicing-by-8 algorithm (from Intel):
   //// http://www.intel.com/technology/comms/perfnet/download/CRC_generators.pdf
   //// http://sourceforge.net/projects/slicing-by-8/
-  //for (const auto slice : c10::irange(1, MaxSlice))
+  //for (int slice = 1; slice < MaxSlice; slice++)
   //  Crc32Lookup[slice][i] = (Crc32Lookup[slice - 1][i] >> 8) ^ Crc32Lookup[0][Crc32Lookup[slice - 1][i] & 0xFF];
   {
     // note: the first number of every second row corresponds to the half-byte look-up table !

--- a/caffe2/serialize/crc_alt.h
+++ b/caffe2/serialize/crc_alt.h
@@ -204,8 +204,7 @@ uint32_t crc32_bitwise(const void* data, size_t length, uint32_t previousCrc32)
   {
     crc ^= *current++;
 
-    for (int j = 0; j < 8; j++)
-    {
+    for (const auto j : c10::irange(8)) {
       // branch-free
       crc = (crc >> 1) ^ (-int32_t(crc & 1) & Polynomial);
 
@@ -434,8 +433,7 @@ uint32_t crc32_4x8bytes(const void* data, size_t length, uint32_t previousCrc32)
   // process 4x eight bytes at once (Slicing-by-8)
   while (length >= BytesAtOnce)
   {
-    for (size_t unrolling = 0; unrolling < Unroll; unrolling++)
-    {
+    for (const auto unrolling : c10::irange(Unroll)) {
 #if __BYTE_ORDER == __BIG_ENDIAN
       uint32_t one = *current++ ^ swap(crc);
       uint32_t two = *current++;
@@ -488,8 +486,7 @@ uint32_t crc32_16bytes(const void* data, size_t length, uint32_t previousCrc32)
 
   while (length >= BytesAtOnce)
   {
-    for (size_t unrolling = 0; unrolling < Unroll; unrolling++)
-    {
+    for (const auto unrolling : c10::irange(Unroll)) {
 #if __BYTE_ORDER == __BIG_ENDIAN
     uint32_t one   = *current++ ^ swap(crc);
     uint32_t two   = *current++;
@@ -564,8 +561,7 @@ uint32_t crc32_16bytes_prefetch(const void* data, size_t length, uint32_t previo
   {
     PREFETCH(((const char*) current) + prefetchAhead);
 
-    for (size_t unrolling = 0; unrolling < Unroll; unrolling++)
-    {
+    for (const auto unrolling : c10::irange(Unroll)) {
 #if __BYTE_ORDER == __BIG_ENDIAN
     uint32_t one   = *current++ ^ swap(crc);
     uint32_t two   = *current++;
@@ -683,13 +679,12 @@ uint32_t crc32_combine(uint32_t crcA, uint32_t crcB, size_t lengthB)
 
   // put operator for one zero bit in odd
   odd[0] = Polynomial;    // CRC-32 polynomial
-  for (uint32_t i = 1; i < CrcBits; i++)
+  for (const auto i : c10::irange(1, CrcBits))
     odd[i] = 1 << (i - 1);
 
   // put operator for two zero bits in even
   // same as gf2_matrix_square(even, odd);
-  for (uint32_t i = 0; i < CrcBits; i++)
-  {
+  for (const auto i : c10::irange(CrcBits)) {
     uint32_t vec = odd[i];
     even[i] = 0;
     for (int j = 0; vec != 0; j++, vec >>= 1)
@@ -698,8 +693,7 @@ uint32_t crc32_combine(uint32_t crcA, uint32_t crcB, size_t lengthB)
   }
   // put operator for four zero bits in odd
   // same as gf2_matrix_square(odd, even);
-  for (uint32_t i = 0; i < CrcBits; i++)
-  {
+  for (const auto i : c10::irange(CrcBits)) {
     uint32_t vec = even[i];
     odd[i] = 0;
     for (int j = 0; vec != 0; j++, vec >>= 1)
@@ -714,8 +708,7 @@ uint32_t crc32_combine(uint32_t crcA, uint32_t crcB, size_t lengthB)
   for (; lengthB > 0; lengthB >>= 1)
   {
     // same as gf2_matrix_square(a, b);
-    for (uint32_t i = 0; i < CrcBits; i++)
-    {
+    for (const auto i : c10::irange(CrcBits)) {
       uint32_t vec = b[i];
       a[i] = 0;
       for (int j = 0; vec != 0; j++, vec >>= 1)
@@ -755,14 +748,14 @@ const uint32_t Crc32Lookup[MaxSlice][256] =
   //for (int i = 0; i <= 0xFF; i++)
   //{
   //  uint32_t crc = i;
-  //  for (int j = 0; j < 8; j++)
+  //  for (const auto j : c10::irange(8))
   //    crc = (crc >> 1) ^ ((crc & 1) * Polynomial);
   //  Crc32Lookup[0][i] = crc;
   //}
   //// ... and the following slicing-by-8 algorithm (from Intel):
   //// http://www.intel.com/technology/comms/perfnet/download/CRC_generators.pdf
   //// http://sourceforge.net/projects/slicing-by-8/
-  //for (int slice = 1; slice < MaxSlice; slice++)
+  //for (const auto slice : c10::irange(1, MaxSlice))
   //  Crc32Lookup[slice][i] = (Crc32Lookup[slice - 1][i] >> 8) ^ Crc32Lookup[0][Crc32Lookup[slice - 1][i] & 0xFF];
   {
     // note: the first number of every second row corresponds to the half-byte look-up table !

--- a/caffe2/utils/proto_utils.h
+++ b/caffe2/utils/proto_utils.h
@@ -295,7 +295,7 @@ class C10_EXPORT ArgumentHelper {
     auto it = CAFFE2_ARG_MAP_FIND(arg_map_, name);
     CAFFE_ENFORCE(it != arg_map_.end(), "Cannot find parameter named ", name);
     std::vector<MessageType> messages(it->second.strings_size());
-    for (int i = 0; i < messages.size(); ++i) {
+    for (const auto i : c10::irange(messages.size())) {
       CAFFE_ENFORCE(
           messages[i].ParseFromString(it->second.strings(i)),
           "Failed to parse content from the string");

--- a/functorch/csrc/dim/dim.cpp
+++ b/functorch/csrc/dim/dim.cpp
@@ -17,6 +17,7 @@
 #include <ATen/functorch/BatchedTensorImpl.h>
 #include <ATen/functorch/DynamicLayer.h>
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 #include <memory>
 #include "arena.h"
 #include "python_variable_simple.h"
@@ -382,7 +383,7 @@ static PyObject* DimList_repr(DimList* self) {
     if (self->is_bound()) {
         size_t size = self->dims_.size();
         py::tuple t(size);
-        for(size_t i = 0; i < size; ++i) {
+        for (const auto i : c10::irange(size)) {
             t.set(i, self->dims_[i]);
         }
         return py::repr(t).release();
@@ -571,7 +572,7 @@ static int DimList_init(DimList *self, PyObject *args, PyObject *kwds) {
             std::vector<py::obj<Dim>> dims;
             size_t size = s.size();
             dims.reserve(size);
-            for (size_t i = 0; i < size; ++i) {
+            for (const auto i : c10::irange(size)) {
                 auto r = s[i];
                 if (py::is_int(r)) {
                     dims.emplace_back(Dim::create(py::unicode_from_format("%S%i", self->name_.ptr(), (int)i),  py::to_int(r)));
@@ -1561,7 +1562,7 @@ static PyObject* _dims(PyObject *self,
         return genobject(0).release();
     }
     py::tuple result(specified_ndims);
-    for (int i = 0; i < specified_ndims; ++i) {
+    for (const auto i : c10::irange(specified_ndims)) {
         result.set(i, genobject(i));
     }
     return result.release();

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/core/op_registration/op_registration.h>
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <torch/csrc/autograd/FunctionsManual.h>
@@ -89,7 +90,7 @@ TEST(AutogradAPITests, GradNonLeafTest) {
   Variable y = torch::randn({2, 2}, torch::requires_grad());
   Variable grad_output = torch::ones({2, 2});
 
-  for (int i = 0; i < 5; ++i) {
+  for (const auto i : c10::irange(5)) {
     auto res = simple_fn(x, y);
     auto input_grads = grad({res}, {x}, {grad_output}, {}, true);
 

--- a/test/cpp/api/modulelist.cpp
+++ b/test/cpp/api/modulelist.cpp
@@ -216,7 +216,7 @@ TEST_F(ModuleListTest, IsCloneable) {
   ModuleList clone = std::dynamic_pointer_cast<ModuleListImpl>(list->clone());
   ASSERT_EQ(list->size(), clone->size());
 
-  for (size_t i = 0; i < list->size(); ++i) {
+  for (const auto i : c10::irange(list->size())) {
     // The modules should be the same kind (type).
     ASSERT_EQ(list[i]->name(), clone[i]->name());
     // But not pointer-equal (distinct objects).

--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 #include <test/cpp/api/support.h>
@@ -189,18 +190,18 @@ TEST_F(RNNTest, CheckOutputValuesMatchPyTorch) {
   // Make sure the outputs match pytorch outputs
   LSTM model(2, 2);
   for (auto& v : model->parameters()) {
-    float size = v.numel();
+    const auto size = v.numel();
     auto p = static_cast<float*>(v.storage().data());
-    for (size_t i = 0; i < size; i++) {
-      p[i] = i / size;
+    for (const auto i : c10::irange(size)) {
+      p[i] = i / static_cast<double>(size);
     }
   }
 
   auto x = torch::empty({3, 4, 2}, torch::requires_grad());
-  float size = x.numel();
+  const auto size = x.numel();
   auto p = static_cast<float*>(x.storage().data());
-  for (size_t i = 0; i < size; i++) {
-    p[i] = (size - i) / size;
+  for (const auto i : c10::irange(size)) {
+    p[i] = (size - i) / static_cast<double>(size);
   }
 
   auto out = model->forward(x);
@@ -251,7 +252,7 @@ TEST_F(RNNTest, CheckOutputValuesMatchPyTorch) {
       1.5329,
       1.0931,
       1.4911};
-  for (size_t i = 0; i < 16; i++) {
+  for (const auto i : c10::irange(16)) {
     ASSERT_LT(std::abs(flat[i].item<float>() - h_out[i]), 1e-3);
   }
 }
@@ -473,7 +474,7 @@ void BidirectionalGRUReverseForward(bool cuda) {
   ASSERT_EQ(
       std::get<0>(bi_output).size(0), std::get<0>(reverse_output).size(0));
   auto size = std::get<0>(bi_output).size(0);
-  for (int i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     ASSERT_EQ(
         std::get<0>(bi_output)[i][0][1].item<float>(),
         std::get<0>(reverse_output)[size - 1 - i][0][0].item<float>());
@@ -528,7 +529,7 @@ void BidirectionalLSTMReverseForwardTest(bool cuda) {
   ASSERT_EQ(
       std::get<0>(bi_output).size(0), std::get<0>(reverse_output).size(0));
   auto size = std::get<0>(bi_output).size(0);
-  for (int i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     ASSERT_EQ(
         std::get<0>(bi_output)[i][0][1].item<float>(),
         std::get<0>(reverse_output)[size - 1 - i][0][0].item<float>());
@@ -590,13 +591,13 @@ TEST_F(RNNTest, BidirectionalMultilayerGRU_CPU_vs_CUDA) {
 
   // Assert that the output and state are equal on CPU and CUDA
   ASSERT_EQ(std::get<0>(output_cpu).dim(), std::get<0>(output_cuda).dim());
-  for (int i = 0; i < std::get<0>(output_cpu).dim(); i++) {
+  for (const auto i : c10::irange(std::get<0>(output_cpu).dim())) {
     ASSERT_EQ(
         std::get<0>(output_cpu).size(i), std::get<0>(output_cuda).size(i));
   }
-  for (int i = 0; i < std::get<0>(output_cpu).size(0); i++) {
-    for (int j = 0; j < std::get<0>(output_cpu).size(1); j++) {
-      for (int k = 0; k < std::get<0>(output_cpu).size(2); k++) {
+  for (const auto i : c10::irange(std::get<0>(output_cpu).size(0))) {
+    for (const auto j : c10::irange(std::get<0>(output_cpu).size(1))) {
+      for (const auto k : c10::irange(std::get<0>(output_cpu).size(2))) {
         ASSERT_NEAR(
             std::get<0>(output_cpu)[i][j][k].item<float>(),
             std::get<0>(output_cuda)[i][j][k].item<float>(),
@@ -644,13 +645,13 @@ TEST_F(RNNTest, BidirectionalMultilayerLSTM_CPU_vs_CUDA) {
 
   // Assert that the output and state are equal on CPU and CUDA
   ASSERT_EQ(std::get<0>(output_cpu).dim(), std::get<0>(output_cuda).dim());
-  for (int i = 0; i < std::get<0>(output_cpu).dim(); i++) {
+  for (const auto i : c10::irange(std::get<0>(output_cpu).dim())) {
     ASSERT_EQ(
         std::get<0>(output_cpu).size(i), std::get<0>(output_cuda).size(i));
   }
-  for (int i = 0; i < std::get<0>(output_cpu).size(0); i++) {
-    for (int j = 0; j < std::get<0>(output_cpu).size(1); j++) {
-      for (int k = 0; k < std::get<0>(output_cpu).size(2); k++) {
+  for (const auto i : c10::irange(std::get<0>(output_cpu).size(0))) {
+    for (const auto j : c10::irange(std::get<0>(output_cpu).size(1))) {
+      for (const auto k : c10::irange(std::get<0>(output_cpu).size(2))) {
         ASSERT_NEAR(
             std::get<0>(output_cpu)[i][j][k].item<float>(),
             std::get<0>(output_cuda)[i][j][k].item<float>(),
@@ -701,13 +702,13 @@ TEST_F(RNNTest, BidirectionalMultilayerLSTMProj_CPU_vs_CUDA) {
 
   // Assert that the output and state are equal on CPU and CUDA
   ASSERT_EQ(std::get<0>(output_cpu).dim(), std::get<0>(output_cuda).dim());
-  for (int i = 0; i < std::get<0>(output_cpu).dim(); i++) {
+  for (const auto i : c10::irange(std::get<0>(output_cpu).dim())) {
     ASSERT_EQ(
         std::get<0>(output_cpu).size(i), std::get<0>(output_cuda).size(i));
   }
-  for (int i = 0; i < std::get<0>(output_cpu).size(0); i++) {
-    for (int j = 0; j < std::get<0>(output_cpu).size(1); j++) {
-      for (int k = 0; k < std::get<0>(output_cpu).size(2); k++) {
+  for (const auto i : c10::irange(std::get<0>(output_cpu).size(0))) {
+    for (const auto j : c10::irange(std::get<0>(output_cpu).size(1))) {
+      for (const auto k : c10::irange(std::get<0>(output_cpu).size(2))) {
         ASSERT_NEAR(
             std::get<0>(output_cpu)[i][j][k].item<float>(),
             std::get<0>(output_cuda)[i][j][k].item<float>(),

--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -343,7 +343,7 @@ TEST_F(SequentialTest, IsCloneable) {
       std::dynamic_pointer_cast<SequentialImpl>(sequential->clone());
   ASSERT_EQ(sequential->size(), clone->size());
 
-  for (size_t i = 0; i < sequential->size(); ++i) {
+  for (const auto i : c10::irange(sequential->size())) {
     // The modules should be the same kind (type).
     ASSERT_EQ(sequential[i]->name(), clone[i]->name());
     // But not pointer-equal (distinct objects).

--- a/test/cpp/c10d/ProcessGroupGlooAsyncTest.cpp
+++ b/test/cpp/c10d/ProcessGroupGlooAsyncTest.cpp
@@ -106,7 +106,7 @@ class AsyncInputIsOutputTest : public AsyncTest {
     c10::cuda::CUDAMultiStreamGuard guard(streams_);
 
     // Copy inputs to outputs
-    for (unsigned i = 0; i < gpu_tensors.size(); i++) {
+    for (const auto i : c10::irange(gpu_tensors.size())) {
       outputs[i] = gpu_tensors[i].cpu();
     }
 

--- a/test/cpp/c10d/ProcessGroupMPITest.cpp
+++ b/test/cpp/c10d/ProcessGroupMPITest.cpp
@@ -77,7 +77,7 @@ void testAllreduce(int iter = 1000) {
   for (const auto i : c10::irange(iter)) {
     const auto expected = worldSize * i;
     auto data = outputTensors[i][0].data_ptr<float>();
-    for (auto j = 0; j < outputTensors[i][0].numel(); ++j) {
+    for (const auto j : c10::irange(outputTensors[i][0].numel())) {
       if (data[j] != expected) {
         TORCH_CHECK(false, "BOOM!");
       }
@@ -109,7 +109,7 @@ void testBroadcast(int iter = 10000) {
   for (const auto i : c10::irange(iter)) {
     const auto expected = i;
     auto data = outputTensors[i][0].data_ptr<float>();
-    for (auto j = 0; j < outputTensors[i][0].numel(); ++j) {
+    for (const auto j : c10::irange(outputTensors[i][0].numel())) {
       if (data[j] != expected) {
         TORCH_CHECK(false, "BOOM!");
       }
@@ -139,7 +139,7 @@ void testReduce(int iter = 10000) {
     for (const auto i : c10::irange(iter)) {
       const auto expected = worldSize * i;
       auto data = outputTensors[i][0].data_ptr<float>();
-      for (auto j = 0; j < outputTensors[i][0].numel(); ++j) {
+      for (const auto j : c10::irange(outputTensors[i][0].numel())) {
         if (data[j] != expected) {
           TORCH_CHECK(false, "BOOM!");
         }
@@ -178,7 +178,7 @@ void testAllgather(int iter = 10000) {
     for (const auto j : c10::irange(worldSize)) {
       const auto expected = i * j;
       auto data = outputTensors[i][j].data_ptr<float>();
-      for (auto k = 0; k < outputTensors[i][j].numel(); ++k) {
+      for (const auto k : c10::irange(outputTensors[i][j].numel())) {
         if (data[k] != expected) {
           TORCH_CHECK(false, "BOOM!");
         }
@@ -221,7 +221,7 @@ void testGather(int iter = 10000) {
       for (const auto j : c10::irange(worldSize)) {
         const auto expected = i * j;
         auto data = outputTensors[i][j].data_ptr<float>();
-        for (auto k = 0; k < outputTensors[i][j].numel(); ++k) {
+        for (const auto k : c10::irange(outputTensors[i][j].numel())) {
           if (data[k] != expected) {
             TORCH_CHECK(false, "BOOM!");
           }
@@ -270,7 +270,7 @@ void testScatter(int iter = 1) {
     for (const auto j : c10::irange(worldSize)) {
       const auto expected = i * j;
       auto data = outputTensors[i][0].data_ptr<float>();
-      for (auto k = 0; k < outputTensors[i][0].numel(); ++k) {
+      for (const auto k : c10::irange(outputTensors[i][0].numel())) {
         if (data[k] != expected) {
           TORCH_CHECK(false, "BOOM!");
         }
@@ -330,7 +330,7 @@ void testSendRecv(bool recvAnysource, int iter = 10000) {
     }
     const auto expected = i;
     auto data = outputTensors[i][0].data_ptr<float>();
-    for (auto j = 0; j < outputTensors[i][0].numel(); ++j) {
+    for (const auto j : c10::irange(outputTensors[i][0].numel())) {
       if (data[j] != expected) {
         TORCH_CHECK(false, "BOOM!");
       }

--- a/test/cpp/lazy/test_lazy_ops.cpp
+++ b/test/cpp/lazy/test_lazy_ops.cpp
@@ -1,5 +1,6 @@
 #include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
+#include <c10/util/irange.h>
 #include <gtest/gtest.h>
 #include <test/cpp/lazy/test_lazy_ops_util.h>
 #include <torch/csrc/lazy/core/debug_util.h>
@@ -1158,7 +1159,7 @@ TEST_F(LazyOpsTest, TestKthValue) {
       {4, 5, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   for (int k = 1; k <= 3; ++k) {
     int rank = a.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       for (bool keepdim : {false, true}) {
         auto b = torch::kthvalue(a, k, dim, keepdim);
         ForEachDevice([&](const torch::Device& device) {
@@ -1177,7 +1178,7 @@ TEST_F(LazyOpsTest, TestTopK) {
       {4, 5, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   for (int k = 1; k <= 3; ++k) {
     int rank = a.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       for (bool largest : {false, true}) {
         auto b = torch::topk(a, k, dim, largest, /*sorted=*/true);
         ForEachDevice([&](const torch::Device& device) {
@@ -1195,7 +1196,7 @@ TEST_F(LazyOpsTest, TestSort) {
   torch::Tensor a = torch::rand(
       {4, 5, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   for (int k = 1; k <= 3; ++k) {
-    for (int dim = 0; dim < 3; ++dim) {
+    for (const auto dim : c10::irange(3)) {
       for (bool descending : {false, true}) {
         auto b = torch::sort(a, dim, descending);
         ForEachDevice([&](const torch::Device& device) {
@@ -1226,7 +1227,7 @@ TEST_F(LazyOpsTest, TestArgSort) {
   torch::Tensor a = torch::rand(
       {4, 5, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   for (int k = 1; k <= 3; ++k) {
-    for (int dim = 0; dim < 3; ++dim) {
+    for (const auto dim : c10::irange(3)) {
       for (bool descending : {false, true}) {
         torch::Tensor b = torch::argsort(a, dim, descending);
         ForEachDevice([&](const torch::Device& device) {
@@ -1320,7 +1321,7 @@ TEST_F(LazyOpsTest, TestAllDim) {
       {2, 3, 4},
       torch::TensorOptions(torch::kByte).device(DefaultDevice()));
   int rank = a.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor b = torch::all(a, dim, /*keepdim=*/false);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -1337,7 +1338,7 @@ TEST_F(LazyOpsTest, TestAllDimKeep) {
       {2, 3, 4},
       torch::TensorOptions(torch::kByte).device(DefaultDevice()));
   int rank = a.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor b = torch::all(a, dim, /*keepdim=*/true);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -1352,7 +1353,7 @@ TEST_F(LazyOpsTest, TestAmax) {
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
   for (bool keepdim : {false, true}) {
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor values = torch::amax(input, {dim}, /*keepdim=*/keepdim);
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -1361,8 +1362,8 @@ TEST_F(LazyOpsTest, TestAmax) {
         AllClose(values, lazy_values);
       });
     }
-    for (int dim1 = -rank; dim1 < rank; ++dim1) {
-      for (int dim2 = -rank; dim2 < rank; ++dim2) {
+    for (const auto dim1 : c10::irange(-rank, rank)) {
+      for (const auto dim2 : c10::irange(-rank, rank)) {
         if ((dim1 == dim2) || (dim1 == rank + dim2) || (dim2 == rank + dim1))
           continue;
         torch::Tensor values =
@@ -1385,7 +1386,7 @@ TEST_F(LazyOpsTest, TestAmin) {
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
   for (bool keepdim : {false, true}) {
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor values = torch::amin(input, {dim}, /*keepdim=*/keepdim);
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -1394,8 +1395,8 @@ TEST_F(LazyOpsTest, TestAmin) {
         AllClose(values, lazy_values);
       });
     }
-    for (int dim1 = -rank; dim1 < rank; ++dim1) {
-      for (int dim2 = -rank; dim2 < rank; ++dim2) {
+    for (const auto dim1 : c10::irange(-rank, rank)) {
+      for (const auto dim2 : c10::irange(-rank, rank)) {
         if ((dim1 == dim2) || (dim1 == rank + dim2) || (dim2 == rank + dim1))
           continue;
         torch::Tensor values =
@@ -1444,7 +1445,7 @@ TEST_F(LazyOpsTest, TestAnyDim) {
       {2, 3, 4},
       torch::TensorOptions(torch::kByte).device(DefaultDevice()));
   int rank = a.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor b = torch::any(a, dim, /*keepdim=*/false);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -1461,7 +1462,7 @@ TEST_F(LazyOpsTest, TestAnyDimKeep) {
       {2, 3, 4},
       torch::TensorOptions(torch::kByte).device(DefaultDevice()));
   int rank = a.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor b = torch::any(a, dim, /*keepdim=*/true);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -1498,7 +1499,7 @@ TEST_F(LazyOpsTest, TestMeanInDim) {
   torch::Tensor a = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = a.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor b = torch::mean(a, {dim});
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -1538,7 +1539,7 @@ TEST_F(LazyOpsTest, TestMeanInDimOut) {
   torch::Tensor a = torch::rand(
       {4, 4, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = a.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor b = torch::empty(
         {4, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
     torch::mean_out(b, a, {dim});
@@ -1570,7 +1571,7 @@ TEST_F(LazyOpsTest, TestStdInDim) {
   int rank = a.dim();
   for (auto unbiased : {true, false}) {
     for (auto keepdim : {true, false}) {
-      for (int dim = -rank; dim < rank; ++dim) {
+      for (const auto dim : c10::irange(-rank, rank)) {
         torch::Tensor b = torch::std(a, {dim}, unbiased, keepdim);
         ForEachDevice([&](const torch::Device& device) {
           torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -1660,7 +1661,7 @@ TEST_F(LazyOpsTest, TestSumInDim) {
   torch::Tensor a = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = a.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor b = torch::sum(a, {dim});
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -1783,7 +1784,7 @@ TEST_F(LazyOpsTest, TestMaxInDim) {
   torch::Tensor input = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     for (bool keepdim : {false, true}) {
       auto values_indices = torch::max(input, dim, /*keepdim=*/keepdim);
       ForEachDevice([&](const torch::Device& device) {
@@ -1801,7 +1802,7 @@ TEST_F(LazyOpsTest, TestMinInDim) {
   torch::Tensor input = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     for (bool keepdim : {false, true}) {
       auto values_indices = torch::min(input, dim, /*keepdim=*/keepdim);
       ForEachDevice([&](const torch::Device& device) {
@@ -2321,7 +2322,7 @@ TEST_F(LazyOpsTest, TestCosineSimilarity) {
       {4, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   double eps = 1e-8;
   int rank = x1.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor output = torch::cosine_similarity(x1, x2, dim, eps);
       torch::Tensor lazy_x1 = CopyToDevice(x1, device);
@@ -2557,7 +2558,7 @@ TEST_F(LazyOpsTest, TestProdInDim) {
   torch::Tensor a = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = a.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor b = torch::prod(a, dim);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -2571,7 +2572,7 @@ TEST_F(LazyOpsTest, TestProdInDimKeepCast) {
   torch::Tensor a = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = a.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor b = torch::prod(a, dim, /*keepdim=*/true, torch::kDouble);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -2586,7 +2587,7 @@ TEST_F(LazyOpsTest, TestProdInDimKeep) {
   torch::Tensor a = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = a.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor b = torch::prod(a, dim, /*keepdim=*/true);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -2600,7 +2601,7 @@ TEST_F(LazyOpsTest, TestCumSum) {
   torch::Tensor input = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor result = torch::cumsum(input, dim);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -2614,7 +2615,7 @@ TEST_F(LazyOpsTest, TestCumSumCast) {
   torch::Tensor input = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor result = torch::cumsum(input, dim, torch::kDouble);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -2631,7 +2632,7 @@ TEST_F(LazyOpsTest, TestCumSumLong) {
       {4, 3, 4},
       torch::TensorOptions(torch::kLong).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor result = torch::cumsum(input, dim);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -2645,7 +2646,7 @@ TEST_F(LazyOpsTest, TestCumSumCastLong) {
   torch::Tensor input = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor result = torch::cumsum(input, dim, torch::kLong);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -2659,7 +2660,7 @@ TEST_F(LazyOpsTest, TestCumProd) {
   torch::Tensor input = torch::rand(
       {4, 3, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor result = torch::cumprod(input, dim);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -2676,7 +2677,7 @@ TEST_F(LazyOpsTest, TestCumProdCast) {
           torch::TensorOptions(torch::kFloat).device(DefaultDevice())),
       10);
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor result = torch::cumprod(input, dim, torch::kDouble);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -2691,7 +2692,7 @@ TEST_F(LazyOpsTest, TestCumProdLong) {
   torch::Tensor input = torch::randint(
       7, {2, 3}, torch::TensorOptions(torch::kLong).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor result = torch::cumsum(input, dim);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -2707,7 +2708,7 @@ TEST_F(LazyOpsTest, TestCumProdCastLong) {
           {2, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice())) *
       7;
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor result = torch::cumsum(input, dim, torch::kLong);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -4218,7 +4219,7 @@ TEST_F(LazyOpsTest, TestSize) {
   int rank = input.dim();
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor lazy_input = CopyToDevice(input, device);
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       EXPECT_EQ(torch::size(input, dim), torch::size(lazy_input, dim));
     }
   });
@@ -4227,7 +4228,7 @@ TEST_F(LazyOpsTest, TestSize) {
 TEST_F(LazyOpsTest, TestSelect) {
   std::vector<int64_t> input_sizes = {14, 24, 8};
   int rank = input_sizes.size();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     auto testfn =
         [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
       return torch::select(inputs[0], dim, 0);
@@ -4388,7 +4389,7 @@ TEST_F(LazyOpsTest, TestStack) {
   torch::Tensor c = torch::rand(
       {2, 4, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = a.dim() + 1;
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor d = torch::stack({a, b, c}, dim);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -4424,13 +4425,13 @@ TEST_F(LazyOpsTest, TestUnbind) {
   torch::Tensor input = torch::rand(
       {4, 3, 7}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     std::vector<torch::Tensor> output = torch::unbind(input, dim);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
       std::vector<torch::Tensor> lazy_output = torch::unbind(lazy_input, dim);
       ASSERT_EQ(output.size(), lazy_output.size());
-      for (size_t i = 0; i < output.size(); ++i) {
+      for (const auto i : c10::irange(output.size())) {
         AllClose(output[i], lazy_output[i]);
       }
     });
@@ -4460,8 +4461,8 @@ TEST_F(LazyOpsTest, TestGather) {
       {3, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   torch::Tensor b = torch::empty(
       {3, 3}, torch::TensorOptions(torch::kLong).device(DefaultDevice()));
-  for (int i = 0; i < 3; i++) {
-    for (int j = 0; j < 3; j++) {
+  for (const auto i : c10::irange(3)) {
+    for (const auto j : c10::irange(3)) {
       b[i][j] = (i + j) % 3;
     }
   }
@@ -4483,9 +4484,9 @@ TEST_F(LazyOpsTest, TestScatter) {
       {3, 5}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   torch::Tensor c = torch::empty(
       {3, 5}, torch::TensorOptions(torch::kLong).device(DefaultDevice()));
-  for (int dim = 0; dim < 2; ++dim) {
-    for (int i = 0; i < 3; i++) {
-      for (int j = 0; j < 5; j++) {
+  for (const auto dim : c10::irange(2)) {
+    for (const auto i : c10::irange(3)) {
+      for (const auto j : c10::irange(5)) {
         c[i][j] = (i + j) % c.sizes()[dim];
       }
     }
@@ -4526,9 +4527,9 @@ TEST_F(LazyOpsTest, TestScatterR3) {
       {3, 4, 2}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   torch::Tensor c = torch::empty(
       {3, 4, 2}, torch::TensorOptions(torch::kLong).device(DefaultDevice()));
-  for (int i = 0; i < 3; i++) {
-    for (int j = 0; j < 4; j++) {
-      for (int k = 0; k < 2; k++) {
+  for (const auto i : c10::irange(3)) {
+    for (const auto j : c10::irange(4)) {
+      for (const auto k : c10::irange(2)) {
         c[i][j][k] = (i + j + k) % 4;
       }
     }
@@ -4550,12 +4551,12 @@ TEST_F(LazyOpsTest, TestScatterBiggerSource) {
       {8, 8}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   torch::Tensor c = torch::empty(
       {4, 4}, torch::TensorOptions(torch::kLong).device(DefaultDevice()));
-  for (int i = 0; i < 4; i++) {
-    for (int j = 0; j < 4; j++) {
+  for (const auto i : c10::irange(4)) {
+    for (const auto j : c10::irange(4)) {
       c[i][j] = (i + j) % 4;
     }
   }
-  for (int dim = 0; dim < 2; ++dim) {
+  for (const auto dim : c10::irange(2)) {
     torch::Tensor d = torch::scatter(a, dim, c, b);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -4573,12 +4574,12 @@ TEST_F(LazyOpsTest, TestScatterScalar) {
   torch::Scalar b = 1.0f;
   torch::Tensor c = torch::empty(
       {4, 4}, torch::TensorOptions(torch::kLong).device(DefaultDevice()));
-  for (int i = 0; i < 4; i++) {
-    for (int j = 0; j < 4; j++) {
+  for (const auto i : c10::irange(4)) {
+    for (const auto j : c10::irange(4)) {
       c[i][j] = (i + j) % 4;
     }
   }
-  for (int dim = 0; dim < 2; ++dim) {
+  for (const auto dim : c10::irange(2)) {
     torch::Tensor d = torch::scatter(a, dim, c, b);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_a = CopyToDevice(a, device);
@@ -4596,9 +4597,9 @@ TEST_F(LazyOpsTest, TestScatterReduceAdd) {
       {3, 5}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   torch::Tensor c = torch::empty(
       {3, 5}, torch::TensorOptions(torch::kLong).device(DefaultDevice()));
-  for (int dim = 0; dim < 2; ++dim) {
-    for (int i = 0; i < 3; i++) {
-      for (int j = 0; j < 5; j++) {
+  for (const auto dim : c10::irange(2)) {
+    for (const auto i : c10::irange(3)) {
+      for (const auto j : c10::irange(5)) {
         c[i][j] = (i + j) % c.sizes()[dim];
       }
     }
@@ -4623,9 +4624,9 @@ TEST_F(LazyOpsTest, TestScatterAdd) {
       {3, 5}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   torch::Tensor c = torch::empty(
       {3, 5}, torch::TensorOptions(torch::kLong).device(DefaultDevice()));
-  for (int dim = 0; dim < 2; ++dim) {
-    for (int i = 0; i < 3; i++) {
-      for (int j = 0; j < 5; j++) {
+  for (const auto dim : c10::irange(2)) {
+    for (const auto i : c10::irange(3)) {
+      for (const auto j : c10::irange(5)) {
         c[i][j] = (i + j) % c.sizes()[dim];
       }
     }
@@ -4645,12 +4646,12 @@ TEST_F(LazyOpsTest, TestScatterAddInPlace) {
       {4, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   torch::Tensor c = torch::empty(
       {4, 4}, torch::TensorOptions(torch::kLong).device(DefaultDevice()));
-  for (int i = 0; i < 4; i++) {
-    for (int j = 0; j < 4; j++) {
+  for (const auto i : c10::irange(4)) {
+    for (const auto j : c10::irange(4)) {
       c[i][j] = (i + j) % 4;
     }
   }
-  for (int dim = 0; dim < 2; ++dim) {
+  for (const auto dim : c10::irange(2)) {
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor a = torch::rand(
           {4, 4}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
@@ -4849,7 +4850,7 @@ TEST_F(LazyOpsTest, TestBroadcastTensors) {
     std::vector<torch::Tensor> lazy_c =
         torch::broadcast_tensors({lazy_a, lazy_b});
     ASSERT_EQ(c.size(), lazy_c.size());
-    for (size_t i = 0; i < c.size(); ++i) {
+    for (const auto i : c10::irange(c.size())) {
       AllClose(c[i], lazy_c[i]);
     }
   });
@@ -5744,7 +5745,7 @@ TEST_F(LazyOpsTest, TestIndexFillWithScalar) {
               {3, 4, 5},
               torch::TensorOptions(scalar_type).device(DefaultDevice()));
     int rank = base.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor result = torch::index_fill(base, dim, index, value);
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor lazy_base = CopyToDevice(base, device);
@@ -5769,7 +5770,7 @@ TEST_F(LazyOpsTest, TestIndexFillWithScalarInPlace) {
         torch::kShort,
         torch::kInt,
         torch::kLong}) {
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor base = isFloatingType(scalar_type)
             ? torch::rand(
@@ -5812,7 +5813,7 @@ TEST_F(LazyOpsTest, TestIndexFillWithTensor) {
     torch::Tensor value = torch::scalar_tensor(
         42, torch::TensorOptions(scalar_type).device(DefaultDevice()));
     int rank = base.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor result = torch::index_fill(base, dim, index, value);
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor lazy_base = CopyToDevice(base, device);
@@ -5839,7 +5840,7 @@ TEST_F(LazyOpsTest, TestIndexFillWithTensorInPlace) {
     torch::Tensor value = torch::scalar_tensor(
         42, torch::TensorOptions(scalar_type).device(DefaultDevice()));
     int rank = 3;
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor base = isFloatingType(scalar_type)
             ? torch::rand(
@@ -5883,7 +5884,7 @@ TEST_F(LazyOpsTest, TestIndexFillRank0) {
     torch::Tensor value = torch::scalar_tensor(
         42, torch::TensorOptions(scalar_type).device(DefaultDevice()));
     int rank = base.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor result = torch::index_fill(base, dim, index, value);
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor lazy_base = CopyToDevice(base, device);
@@ -5915,7 +5916,7 @@ TEST_F(LazyOpsTest, TestIndexAdd) {
               {5, 3, 7},
               torch::TensorOptions(scalar_type).device(DefaultDevice()));
     int rank = base.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       for (torch::ScalarType index_scalar_type : {torch::kInt, torch::kLong}) {
         torch::Tensor index = torch::randint(
             0,
@@ -5958,7 +5959,7 @@ TEST_F(LazyOpsTest, TestIndexAddInPlace) {
         torch::kShort,
         torch::kInt,
         torch::kLong}) {
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor base = isFloatingType(scalar_type)
             ? torch::rand(
@@ -6015,7 +6016,7 @@ TEST_F(LazyOpsTest, TestIndexAddRank0) {
               {5, 3, 7},
               torch::TensorOptions(scalar_type).device(DefaultDevice()));
     int rank = base.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor index = torch::randint(
           0,
           base.size(dim),
@@ -6063,7 +6064,7 @@ TEST_F(LazyOpsTest, TestIndexCopy) {
               {5, 3, 7},
               torch::TensorOptions(scalar_type).device(DefaultDevice()));
     int rank = base.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor index = torch::randperm(
           base.size(dim),
           torch::TensorOptions(torch::kLong).device(DefaultDevice()));
@@ -6101,7 +6102,7 @@ TEST_F(LazyOpsTest, TestIndexCopyInPlace) {
         torch::kShort,
         torch::kInt,
         torch::kLong}) {
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor base = isFloatingType(scalar_type)
             ? torch::rand(
@@ -6158,7 +6159,7 @@ TEST_F(LazyOpsTest, TestIndexCopyRank0) {
               {5, 3, 7},
               torch::TensorOptions(scalar_type).device(DefaultDevice()));
     int rank = base.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor index = torch::randint(
           0,
           base.size(dim),
@@ -6691,8 +6692,8 @@ TEST_F(LazyOpsTest, TestWhere) {
       {3, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   torch::Tensor c = torch::empty(
       {3, 3}, torch::TensorOptions(torch::kByte).device(DefaultDevice()));
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 3; ++j) {
+  for (const auto i : c10::irange(3)) {
+    for (const auto j : c10::irange(3)) {
       c[i][j] = i == j;
     }
   }
@@ -6713,8 +6714,8 @@ TEST_F(LazyOpsTest, TestWhereBroadcast) {
       {}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   torch::Tensor c = torch::empty(
       {3, 3}, torch::TensorOptions(torch::kByte).device(DefaultDevice()));
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 3; ++j) {
+  for (const auto i : c10::irange(3)) {
+    for (const auto j : c10::irange(3)) {
       c[i][j] = i == j;
     }
   }
@@ -7308,7 +7309,7 @@ TEST_F(LazyOpsTest, TestLogSoftmax) {
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor lazy_input = CopyToDevice(input, device);
     int rank = input.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor output = torch::log_softmax(input, dim);
       torch::Tensor lazy_output = torch::log_softmax(lazy_input, dim);
       AllClose(output, lazy_output, /*rtol=*/1e-3);
@@ -7323,7 +7324,7 @@ TEST_F(LazyOpsTest, TestLogSoftmaxCast) {
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor lazy_input = CopyToDevice(input, device);
     int rank = input.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor output = torch::log_softmax(input, dim, torch::kDouble);
       torch::Tensor lazy_output =
           torch::log_softmax(lazy_input, dim, torch::kDouble);
@@ -7339,7 +7340,7 @@ TEST_F(LazyOpsTest, TestLogSoftmaxWrapper) {
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor lazy_input = CopyToDevice(input, device);
     int rank = input.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor output =
           torch::_log_softmax(input, dim, /*half_to_float=*/false);
       torch::Tensor lazy_output =
@@ -7356,7 +7357,7 @@ TEST_F(LazyOpsTest, TestSoftmax) {
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor lazy_input = CopyToDevice(input, device);
     int rank = input.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor output = torch::softmax(input, dim);
       torch::Tensor lazy_output = torch::softmax(lazy_input, dim);
       AllClose(output, lazy_output, /*rtol=*/1e-3);
@@ -7371,7 +7372,7 @@ TEST_F(LazyOpsTest, TestSoftmaxCast) {
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor lazy_input = CopyToDevice(input, device);
     int rank = input.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor output = torch::softmax(input, dim, torch::kDouble);
       torch::Tensor lazy_output =
           torch::softmax(lazy_input, dim, torch::kDouble);
@@ -7387,7 +7388,7 @@ TEST_F(LazyOpsTest, TestSoftmaxWrapper) {
   ForEachDevice([&](const torch::Device& device) {
     torch::Tensor lazy_input = CopyToDevice(input, device);
     int rank = input.dim();
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       torch::Tensor output =
           torch::_softmax(input, dim, /*half_to_float=*/false);
       torch::Tensor lazy_output =
@@ -8552,7 +8553,7 @@ TEST_F(LazyOpsTest, TestSqueezeAllInPlace) {
     AllClose(output, lazy_output);
     AllClose(input, lazy_input);
     ASSERT_EQ(input.dim(), lazy_input.dim());
-    for (int64_t dim_idx = 0; dim_idx < input.dim(); ++dim_idx) {
+    for (const auto dim_idx : c10::irange(input.dim())) {
       ASSERT_EQ(input.size(dim_idx), lazy_input.size(dim_idx));
     }
   });
@@ -8563,7 +8564,7 @@ TEST_F(LazyOpsTest, TestSqueezeOne) {
       {2, 1, 3, 1},
       torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor output = torch::squeeze(input, dim);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -8575,7 +8576,7 @@ TEST_F(LazyOpsTest, TestSqueezeOne) {
 
 TEST_F(LazyOpsTest, TestSqueezeOneInPlace) {
   int rank = 4;
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor input = torch::rand(
           {2, 1, 3, 1},
@@ -8586,7 +8587,7 @@ TEST_F(LazyOpsTest, TestSqueezeOneInPlace) {
       AllClose(output, lazy_output);
       AllClose(input, lazy_input);
       ASSERT_EQ(input.dim(), lazy_input.dim());
-      for (int64_t dim_idx = 0; dim_idx < input.dim(); ++dim_idx) {
+      for (const auto dim_idx : c10::irange(input.dim())) {
         ASSERT_EQ(input.size(dim_idx), lazy_input.size(dim_idx));
       }
     });
@@ -8597,7 +8598,7 @@ TEST_F(LazyOpsTest, TestUnsqueeze) {
   torch::Tensor input = torch::rand(
       {2, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim() + 1;
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor output = torch::unsqueeze(input, dim);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -8611,7 +8612,7 @@ TEST_F(LazyOpsTest, TestUnsqueezeInPlace) {
   torch::Tensor input = torch::rand(
       {2, 3}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim() + 1;
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
       torch::Tensor output = input.unsqueeze_(dim);
@@ -8619,7 +8620,7 @@ TEST_F(LazyOpsTest, TestUnsqueezeInPlace) {
       AllClose(output, lazy_output);
       AllClose(input, lazy_input);
       ASSERT_EQ(input.dim(), lazy_input.dim());
-      for (int64_t dim_idx = 0; dim_idx < input.dim(); ++dim_idx) {
+      for (const auto dim_idx : c10::irange(input.dim())) {
         ASSERT_EQ(input.size(dim_idx), lazy_input.size(dim_idx));
       }
     });
@@ -8868,14 +8869,14 @@ TEST_F(LazyOpsTest, TestSplit) {
       {7, 8, 9}, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
   for (int split_size : {2, 3}) {
-    for (int dim = -rank; dim < rank; ++dim) {
+    for (const auto dim : c10::irange(-rank, rank)) {
       std::vector<torch::Tensor> outputs = torch::split(input, split_size, dim);
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor lazy_input = CopyToDevice(input, device);
         std::vector<torch::Tensor> lazy_outputs =
             torch::split(lazy_input, split_size, dim);
         ASSERT_EQ(outputs.size(), lazy_outputs.size());
-        for (size_t i = 0; i < outputs.size(); ++i) {
+        for (const auto i : c10::irange(outputs.size())) {
           AllClose(outputs[i], lazy_outputs[i]);
         }
       });
@@ -8894,7 +8895,7 @@ TEST_F(LazyOpsTest, TestSplitEmpty) {
     std::vector<torch::Tensor> lazy_outputs =
         torch::split(lazy_input, split_size, dim);
     ASSERT_EQ(outputs.size(), lazy_outputs.size());
-    for (size_t i = 0; i < outputs.size(); ++i) {
+    for (const auto i : c10::irange(outputs.size())) {
       AllClose(outputs[i], lazy_outputs[i]);
     }
   });
@@ -8905,7 +8906,7 @@ TEST_F(LazyOpsTest, TestSplitWithSizes) {
       {15, 15, 15},
       torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = input.dim();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     std::vector<torch::Tensor> outputs =
         torch::split_with_sizes(input, {4, 5, 6}, dim);
     ForEachDevice([&](const torch::Device& device) {
@@ -8913,7 +8914,7 @@ TEST_F(LazyOpsTest, TestSplitWithSizes) {
       std::vector<torch::Tensor> lazy_outputs =
           torch::split_with_sizes(lazy_input, {4, 5, 6}, dim);
       ASSERT_EQ(outputs.size(), lazy_outputs.size());
-      for (size_t i = 0; i < outputs.size(); ++i) {
+      for (const auto i : c10::irange(outputs.size())) {
         AllClose(outputs[i], lazy_outputs[i]);
       }
     });
@@ -8945,7 +8946,7 @@ TEST_F(LazyOpsTest, TestCrossExplicitDim) {
   torch::Tensor other = torch::rand(
       dim_size, torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
   int rank = dim_size.size();
-  for (int dim = -rank; dim < rank; ++dim) {
+  for (const auto dim : c10::irange(-rank, rank)) {
     torch::Tensor result = torch::cross(input, other, dim);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -9175,7 +9176,7 @@ TEST_F(LazyOpsTest, TestDiagFlat) {
   torch::Tensor input = torch::rand(
       {4, 3, 6, 7},
       torch::TensorOptions(torch::kFloat).device(DefaultDevice()));
-  for (int diagonal = -10; diagonal < 10; ++diagonal) {
+  for (const auto diagonal : c10::irange(-10, 10)) {
     torch::Tensor output = torch::diagflat(input, diagonal);
     ForEachDevice([&](const torch::Device& device) {
       torch::Tensor lazy_input = CopyToDevice(input, device);
@@ -9263,8 +9264,8 @@ TEST_F(LazyOpsTest, TestDiagonalBatch) {
 TEST_F(LazyOpsTest, TestFlatten) {
   torch::Tensor input = torch::rand({4, 7, 5, 3});
   int rank = input.dim();
-  for (int pos_start_dim = 0; pos_start_dim < rank; ++pos_start_dim) {
-    for (int pos_end_dim = pos_start_dim; pos_end_dim < rank; ++pos_end_dim) {
+  for (const auto pos_start_dim : c10::irange(rank)) {
+    for (const auto pos_end_dim : c10::irange(pos_start_dim, rank)) {
       for (bool negative_start_dim : {false, true}) {
         for (bool negative_end_dim : {false, true}) {
           int start_dim =
@@ -9680,7 +9681,7 @@ TEST_F(LazyOpsTest, TestMeshgrid) {
     torch::Tensor lazy_c = CopyToDevice(c, device);
     auto lazy_d = torch::meshgrid({lazy_a, lazy_b, lazy_c});
     EXPECT_EQ(d.size(), lazy_d.size());
-    for (size_t i = 0; i < d.size(); ++i) {
+    for (const auto i : c10::irange(d.size())) {
       AllClose(d[i], lazy_d[i]);
     }
   });
@@ -10679,7 +10680,7 @@ TEST_F(LazyOpsTest, TestLogSigmoidBackward) {
 }
 
 TEST_F(LazyOpsTest, TestLogSoftmaxBackward) {
-  for (int dim = -4; dim < 4; ++dim) {
+  for (const auto dim : c10::irange(-4, 4)) {
     auto testfn =
         [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
       return torch::log_softmax(inputs[0], dim);
@@ -10701,7 +10702,7 @@ TEST_F(LazyOpsTest, TestLogSoftmaxBackward) {
 }
 
 TEST_F(LazyOpsTest, TestSoftmaxBackward) {
-  for (int dim = -4; dim < 4; ++dim) {
+  for (const auto dim : c10::irange(-4, 4)) {
     auto testfn =
         [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
       return torch::softmax(inputs[0], dim);
@@ -11304,7 +11305,7 @@ TEST_F(LazyOpsTest, TestKlDivBackward) {
 
 TEST_F(LazyOpsTest, TestEmbeddingBackward) {
   int num_weights = 32;
-  for (int padding_idx = -1; padding_idx < num_weights; ++padding_idx) {
+  for (const auto padding_idx : c10::irange(-1, num_weights)) {
     for (bool scale_grad_by_freq : {false, true}) {
       auto testfn =
           [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {

--- a/test/cpp/lazy/test_lazy_ops_util.cpp
+++ b/test/cpp/lazy/test_lazy_ops_util.cpp
@@ -1,5 +1,6 @@
 #include <test/cpp/lazy/test_lazy_ops_util.h>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/lazy/backend/lowering_context.h>
 #include <torch/csrc/lazy/core/ir_builder.h>
 #include <torch/csrc/lazy/core/ir_dump_util.h>
@@ -141,7 +142,7 @@ void TestBackward(
   std::vector<torch::Tensor> xinput_vars;
   std::vector<torch::Tensor> inputs_w_grad;
   std::vector<torch::Tensor> xinputs_w_grad;
-  for (size_t i = 0; i < inputs.size(); ++i) {
+  for (const auto i : c10::irange(inputs.size())) {
     const torch::Tensor& input = inputs[i];
     if (input.defined()) {
       torch::Tensor oinput =
@@ -172,7 +173,7 @@ void TestBackward(
     // Check grad of sum(outs) w.r.t inputs_w_grad.
     torch::Tensor sum = torch::zeros_like(outs[0]).sum();
     torch::Tensor xsum = torch::zeros_like(xouts[0]).sum();
-    for (size_t i = 0; i < outs.size(); ++i) {
+    for (const auto i : c10::irange(outs.size())) {
       if (outs[i].requires_grad()) {
         sum += outs[i].sum();
         xsum += xouts[i].sum();
@@ -194,7 +195,7 @@ void TestBackward(
         /*retain_graph=*/c10::nullopt,
         /*create_graph=*/create_graph,
         /*allow_unused=*/true);
-    for (size_t i = 0; i < outs.size(); ++i) {
+    for (const auto i : c10::irange(outs.size())) {
       ASSERT_EQ(outs[i].defined(), xouts[i].defined());
       if (outs[i].defined()) {
         AllClose(outs[i], xouts[i], rtol, atol);

--- a/test/cpp/lazy/test_shape.cpp
+++ b/test/cpp/lazy/test_shape.cpp
@@ -2,6 +2,7 @@
 
 #include <sstream>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/lazy/core/shape.h>
 
 namespace torch {
@@ -25,7 +26,7 @@ TEST(ShapeTest, Basic2) {
   EXPECT_EQ(shape.scalar_type(), c10::ScalarType::Float);
   EXPECT_EQ(shape.dim(), 3);
   EXPECT_EQ(shape.sizes().size(), 3);
-  for (int64_t i = 0; i < shape.dim(); i++) {
+  for (const auto i : c10::irange(shape.dim())) {
     EXPECT_EQ(shape.sizes()[i], i + 1);
     EXPECT_EQ(shape.size(i), i + 1);
   }

--- a/test/cpp/rpc/e2e_test_base.h
+++ b/test/cpp/rpc/e2e_test_base.h
@@ -4,6 +4,8 @@
 #include <torch/csrc/distributed/autograd/context/context.h>
 #include <torch/csrc/distributed/autograd/engine/dist_engine.h>
 #include <torch/csrc/distributed/autograd/utils.h>
+
+#include <c10/util/irange.h>
 #include <torch/csrc/distributed/c10d/TCPStore.hpp>
 #include <torch/csrc/distributed/rpc/rref_context.h>
 #include <torch/csrc/distributed/rpc/script_call.h>
@@ -138,13 +140,13 @@ class TestE2EBase : public ::testing::Test {
     auto matchedOp = torch::jit::findOperatorFor(full_name);
     ASSERT_TRUE(matchedOp);
 
-    for (size_t i = 0; i < numIters; i++) {
+    for (const auto i : c10::irange(numIters)) {
       // Create the autograd context guard.
       AutogradContextGuard guard;
 
       // Multiple RPCs within one autograd context for the forward pass.
       auto result = remoteAdd(t1, t2, matchedOp);
-      for (size_t j = 0; j < 5; j++) {
+      for (const auto j : c10::irange(5)) {
         result = remoteAdd(t1, result, matchedOp);
       }
 

--- a/test/cpp/tensorexpr/test_base.h
+++ b/test/cpp/tensorexpr/test_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <c10/util/irange.h>
+
 #if defined(USE_GTEST)
 #include <gtest/gtest.h>
 #include <test/cpp/common/support.h>
@@ -52,7 +54,7 @@ void ExpectAllNear(
     V threshold,
     const std::string& name = "") {
   ASSERT_EQ(v1.size(), v2.size());
-  for (size_t i = 0; i < v1.size(); i++) {
+  for (const auto i : c10::irange(v1.size())) {
     ASSERT_NEAR(v1[i], v2[i], threshold);
   }
 }
@@ -63,7 +65,7 @@ void ExpectAllNear(
     const U& val,
     V threshold,
     const std::string& name = "") {
-  for (size_t i = 0; i < vec.size(); i++) {
+  for (const auto i : c10::irange(vec.size())) {
     ASSERT_NEAR(vec[i], val, threshold);
   }
 }
@@ -78,7 +80,7 @@ static void assertAllEqual(const std::vector<T>& vec, const T& val) {
 template <typename T>
 static void assertAllEqual(const std::vector<T>& v1, const std::vector<T>& v2) {
   ASSERT_EQ(v1.size(), v2.size());
-  for (size_t i = 0; i < v1.size(); ++i) {
+  for (const auto i : c10::irange(v1.size())) {
     ASSERT_EQ(v1[i], v2[i]);
   }
 }

--- a/test/cpp/tensorexpr/test_dynamic_shapes.cpp
+++ b/test/cpp/tensorexpr/test_dynamic_shapes.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/code_template.h>
 #include <c10/core/DeviceType.h>
+#include <c10/util/irange.h>
 #include <test/cpp/tensorexpr/test_base.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/irparser.h>
@@ -687,7 +688,7 @@ TEST(DynamicShapes, MultiThreadedExecution) {
     // TensorExprKernel are not changing any state.
     constexpr size_t kNumThreads = 4;
     std::vector<std::thread> threads;
-    for (size_t id = 0; id < kNumThreads; ++id) {
+    for (const auto id : c10::irange(kNumThreads)) {
       threads.emplace_back(run_kernel, id + 5, id + 20);
     }
     for (auto& t : threads) {

--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -91,7 +91,7 @@ TEST(Expr, IsChannelsLastContiguous) {
                           int ndims, shapGenInfo shape_gen_info) -> shapeInfo {
     auto dims_expr_vec = dims_expr_vec_conf.at(ndims);
     std::vector<std::vector<ExprHandle>> strides_expr_vec;
-    for (size_t i = 0; i < strides_expr_vec.size(); i++) {
+    for (const auto i : c10::irange(strides_expr_vec.size())) {
       strides_expr_vec[i].resize(ndims);
     }
 
@@ -104,11 +104,11 @@ TEST(Expr, IsChannelsLastContiguous) {
     };
 
     auto stride_order_vec = shape_gen_info.at(ndims);
-    for (size_t i = 0; i < strides_expr_vec.size(); i++) {
+    for (const auto i : c10::irange(strides_expr_vec.size())) {
       auto stride_order = stride_order_vec[i];
 
       strides_expr_vec[i][stride_order[0]] = 1;
-      for (size_t j = 1; j < stride_order.size(); j++) {
+      for (const auto j : c10::irange(1, stride_order.size())) {
         auto cur_dim_idx = stride_order[j];
         auto adjacent_dim_idx = stride_order[j - 1];
 
@@ -133,36 +133,36 @@ TEST(Expr, IsChannelsLastContiguous) {
   };
 
   // channels-last contigous
-  for (size_t i = 0; i < dims.size(); i++) {
+  for (const auto i : c10::irange(dims.size())) {
     auto shape_info = shape_gen_fn(dims[i], channels_last_cont_shape_conf);
-    for (size_t j = 0; j < shape_info.second.size(); j++) {
+    for (const auto j : c10::irange(shape_info.second.size())) {
       BufHandle buf_handle("a", shape_info.first, shape_info.second[j], kFloat);
       ASSERT_EQ(check_channels_last_fn(dims[i], buf_handle), true);
     }
   }
 
   // channels-last non-contigous
-  for (size_t i = 0; i < dims.size(); i++) {
+  for (const auto i : c10::irange(dims.size())) {
     auto shape_info = shape_gen_fn(dims[i], channels_last_non_cont_shape_conf);
-    for (size_t j = 0; j < shape_info.second.size(); j++) {
+    for (const auto j : c10::irange(shape_info.second.size())) {
       BufHandle buf_handle("a", shape_info.first, shape_info.second[j], kFloat);
       ASSERT_EQ(check_channels_last_fn(dims[i], buf_handle), false);
     }
   }
 
   // contiguous
-  for (size_t i = 0; i < dims.size(); i++) {
+  for (const auto i : c10::irange(dims.size())) {
     auto shape_info = shape_gen_fn(dims[i], cont_shape_conf);
-    for (size_t j = 0; j < shape_info.second.size(); j++) {
+    for (const auto j : c10::irange(shape_info.second.size())) {
       BufHandle buf_handle("a", shape_info.first, shape_info.second[j], kFloat);
       ASSERT_EQ(buf_handle.is_contiguous(), true);
     }
   }
 
   // non-contiguous
-  for (size_t i = 0; i < dims.size(); i++) {
+  for (const auto i : c10::irange(dims.size())) {
     auto shape_info = shape_gen_fn(dims[i], channels_last_cont_shape_conf);
-    for (size_t j = 0; j < shape_info.second.size(); j++) {
+    for (const auto j : c10::irange(shape_info.second.size())) {
       BufHandle buf_handle("a", shape_info.first, shape_info.second[j], kFloat);
       ASSERT_EQ(buf_handle.is_contiguous(), false);
     }

--- a/test/cpp/tensorexpr/test_memdependency.cpp
+++ b/test/cpp/tensorexpr/test_memdependency.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <test/cpp/tensorexpr/test_base.h>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/bounds_overlap.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
 #include <torch/csrc/jit/tensorexpr/ir_printer.h>
@@ -413,7 +414,7 @@ TEST(MemDependency, BoundSubtractMultiDim) {
     if (x.size() != y.size()) {
       return false;
     }
-    for (auto i = 0U; i < x.size(); ++i) {
+    for (const auto i : c10::irange(0U, x.size())) {
       if (!indexBoundsEquals(x[i], y[i])) {
         return false;
       }
@@ -477,7 +478,7 @@ TEST(MemDependency, BoundSubtractMultiDimSymbolic) {
     if (x.size() != y.size()) {
       return false;
     }
-    for (auto i = 0U; i < x.size(); ++i) {
+    for (const auto i : c10::irange(0U, x.size())) {
       if (!indexBoundsEquals(x[i], y[i])) {
         return false;
       }
@@ -633,7 +634,7 @@ TEST(MemDependency, MemDependencyCheckerLoop) {
   MemDependencyChecker analyzer;
 
   /*
-   * for (int x = 0; x < 10; ++x) {
+   * for (const auto x : c10::irange(10)) {
    *   A[x] = x;
    * }
    * B[0] = A[0] + 1;
@@ -675,7 +676,7 @@ TEST(MemDependency, MemDependencyCheckerLoopReduce) {
 
   /*
    * A[0] = 0;
-   * for (int x = 0; x < 10; ++x) {
+   * for (const auto x : c10::irange(10)) {
    *   A[0] = A[x] + 1;
    * }
    * B[0] = A[0];
@@ -732,7 +733,7 @@ TEST(MemDependency, MemDependencyCheckerLoopReduceExpanded) {
 
   /*
    * A[0] = 0;
-   * for (int x = 0; x < 10; ++x) {
+   * for (const auto x : c10::irange(10)) {
    *   A[0] = A[x] + 1;
    * }
    * B[0] = A[0];
@@ -784,7 +785,7 @@ TEST(MemDependency, MemDependencyCheckerInputsOutputs) {
 
   // Here's a Relu.
   /*
-   * for (int x = 0; x < 10; ++x) {
+   * for (const auto x : c10::irange(10)) {
    *   B[x] = Max(A[x], 0);
    * }
    */
@@ -836,7 +837,7 @@ TEST(MemDependency, MemDependencyCheckerOutputDoesntDepend) {
 
   // Here's a dumb Relu.
   /*
-   * for (int x = 0; x < 10; ++x) {
+   * for (const auto x : c10::irange(10)) {
    *   B[x] = Max(x, 0);
    * }
    */
@@ -878,16 +879,16 @@ TEST(MemDependency, MemDependencyCheckerLoopBounds) {
   analyzer.allowLoopExecutionOrderAnalysis();
 
   /*
-   * for (int x = 1; x < 10; ++x) {
+   * for (const auto x : c10::irange(1, 10)) {
    *   B[x] = A[x];
    * }
-   * for (int x = 1; x < 9; ++x) {
+   * for (const auto x : c10::irange(1, 9)) {
    *   B[x] = B[x] * 2;
    * }
-   * for (int x = 3; x < 4; ++x) {
+   * for (const auto x : c10::irange(3, 4)) {
    *   C[x] = A[x];
    * }
-   * for (int x = 0; x < 10; ++x) {
+   * for (const auto x : c10::irange(10)) {
    *   C[x] = B[x];
    * }
    */
@@ -1059,19 +1060,19 @@ TEST(MemDependency, MemDependencyCheckerLoopBoundsIndexShift) {
   analyzer.allowLoopExecutionOrderAnalysis();
 
   /*
-   * for (int x = 1; x < 10; x++) {
+   * for (const auto x : c10::irange(1, 10)) {
    *   A[x] = A[x - 1];
    * }
-   * for (int x = 0; x < 9; x++) {
+   * for (const auto x : c10::irange(9)) {
    *   A[x] = A[x + 1];
    * }
-   * for (int x = 0; x < 9; x++) {
+   * for (const auto x : c10::irange(9)) {
    *   A[9 - x] = A[8 - x];
    * }
-   * for (int x = 0; x < 10; x++) {
+   * for (const auto x : c10::irange(10)) {
    *   A[x] = A[9 - x];
    * }
-   * for (int x = 0; x < 10; x++) {
+   * for (const auto x : c10::irange(10)) {
    *   B[x] = A[x];
    * }
    */
@@ -1244,7 +1245,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   };
 
   {
-    /* for (int y = 0; y < 10; y++) {
+    /* for (const auto y : c10::irange(10)) {
      *   A[y] = (A[y]) + 1;
      * } */
 
@@ -1263,7 +1264,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int y = 0; y < 10; y++) {
+    /* for (const auto y : c10::irange(10)) {
      *   A[y + 1] = (A[y + 1]) + 1;
      * }
      */
@@ -1284,7 +1285,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[0] = (A[0]) + x;
      * }
      */
@@ -1303,7 +1304,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[0] = (B[0]) + x;
      * }
      */
@@ -1323,7 +1324,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[y] = (A[y]) + x;
      * }
      */
@@ -1342,7 +1343,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x] = A[x + 1];
      * }
      */
@@ -1361,7 +1362,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x] = A[x + 1];
      * }
      */
@@ -1379,7 +1380,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 1; x < 10; x++) {
+    /* for (const auto x : c10::irange(1, 10)) {
      *   A[x] = A[x - 1];
      * }
      */
@@ -1394,7 +1395,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 1; x < 10; x++) {
+    /* for (const auto x : c10::irange(1, 10)) {
      *   A[x] = A[x - 1];
      * }
      */
@@ -1412,7 +1413,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 9; x++) {
+    /* for (const auto x : c10::irange(9)) {
      *   A[9 - x] = A[8 - x];
      * }
      */
@@ -1437,7 +1438,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 9; x++) {
+    /* for (const auto x : c10::irange(9)) {
      *   A[8 - x] = A[9 - x];
      * }
      */
@@ -1459,7 +1460,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 9; x++) {
+    /* for (const auto x : c10::irange(9)) {
      *   A[9 - x] = A[8 - x];
      * }
      */
@@ -1480,7 +1481,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 3; x < 10; x++) {
+    /* for (const auto x : c10::irange(3, 10)) {
      *   A[x - 2] = A[x - 1];
      * }
      */
@@ -1500,7 +1501,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 2];
      * }
      */
@@ -1519,7 +1520,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 2 + 1];
      * }
      */
@@ -1541,7 +1542,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 2 - 1];
      * }
      */
@@ -1557,7 +1558,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 2 + 2];
      * }
      */
@@ -1573,7 +1574,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 2 - 2];
      * }
      */
@@ -1589,7 +1590,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 2 + 7];
      * }
      */
@@ -1605,7 +1606,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 2 + 4];
      * }
      */
@@ -1620,7 +1621,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 6] = A[x * 6 + 5];
      * }
      */
@@ -1637,7 +1638,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 6];
      * }
      */
@@ -1654,7 +1655,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 4] = A[x * 2];
      * }
      */
@@ -1670,7 +1671,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 6 + 1];
      * }
      */
@@ -1687,7 +1688,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 6 + 4];
      * }
      */
@@ -1703,7 +1704,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2 + 3] = A[x * 6];
      * }
      */
@@ -1719,7 +1720,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[x * 3 + 1];
      * }
      */
@@ -1734,7 +1735,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x] = A[x + 10];
      * }
      */
@@ -1750,7 +1751,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x] = A[9 - x];
      * }
      */
@@ -1765,7 +1766,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x * 2] = A[19 - x * 2];
      * }
      */
@@ -1783,7 +1784,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x / 2] = A[x / 2];
      * }
      */
@@ -1799,7 +1800,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x / 2] = A[x / 2] + 1;
      * }
      */
@@ -1814,7 +1815,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   A[x % 2] = A[x % 2];
      * }
      */
@@ -1833,7 +1834,7 @@ TEST(MemDependency, MemDependencyCheckerLoopSelfDependency) {
   }
 
   {
-    /* for (int x = y; x < z; x++) {
+    /* for (const auto x : c10::irange(y, z)) {
      *   A[x] = A[x + 1];
      * }
      */
@@ -1929,7 +1930,7 @@ TEST(MemDependency, MemDependencyCheckerLoopBoundsCond) {
   using namespace analysis;
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[x] = A[x];
      * }
      * if (y<5 ? 1 : 0) {
@@ -1962,15 +1963,15 @@ TEST(MemDependency, MemDependencyCheckerLoopBoundsCond) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[x] = A[x];
      * }
      * if (y<5 ? 1 : 0) {
-     *   for (int x = 0; x < 10; x++) {
+     *   for (const auto x : c10::irange(10)) {
      *     C[x] = B[x];
      *   }
      * } else {
-     *   for (int x = 0; x < 10; x++) {
+     *   for (const auto x : c10::irange(10)) {
      *     C[x] = (B[x]) + 1;
      *   }
      * }
@@ -2007,11 +2008,11 @@ TEST(MemDependency, MemDependencyCheckerLoopBoundsCond) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[x] = A[x];
      * }
      * if (y<5 ? 1 : 0) {
-     *   for (int x = 0; x < 10; x++) {
+     *   for (const auto x : c10::irange(10)) {
      *     C[x] = (B[x]) + 1;
      *   }
      * }
@@ -2044,12 +2045,12 @@ TEST(MemDependency, MemDependencyCheckerLoopBoundsCond) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[x] = A[x];
      * }
      * if (y<5 ? 1 : 0) {
      * } else {
-     *   for (int x = 0; x < 10; x++) {
+     *   for (const auto x : c10::irange(10)) {
      *     C[x] = (B[x]) + 1;
      *   }
      * }
@@ -2082,7 +2083,7 @@ TEST(MemDependency, MemDependencyCheckerLoopBoundsCond) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[x] = A[x];
      * }
      * if (C[0]<5 ? 1 : 0) {
@@ -2124,7 +2125,7 @@ TEST(MemDependency, MemDependencyCheckerIfThenElse) {
   using namespace analysis;
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[x] = A[x];
      * }
      * C[0] = (y < 5 ? (B[0]) + 1 : (B[1]) + 1;
@@ -2163,7 +2164,7 @@ TEST(MemDependency, MemDependencyCheckerIfThenElse) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[x] = A[x];
      * }
      * C[0] = (y < 5 ? (B[0]) + 1 : 42;
@@ -2192,7 +2193,7 @@ TEST(MemDependency, MemDependencyCheckerIfThenElse) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[x] = (x < 5 ? B[x] : A[x];
      * }
      */
@@ -2231,7 +2232,7 @@ TEST(MemDependency, MemDependencyCheckerCutLoop) {
   using namespace analysis;
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   B[x] = A[x];
      * }
      * B[5] = 100;
@@ -2256,10 +2257,10 @@ TEST(MemDependency, MemDependencyCheckerCutLoop) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   B[x] = A[x];
      * }
-     * for (int x = 4; x < 7; x++) {
+     * for (const auto x : c10::irange(4, 7)) {
      *   B[x] = B[x] + 3;
      * }
      * B[5] = 100;
@@ -2321,7 +2322,7 @@ TEST(MemDependency, MemDependencyCheckerDynamicShapes) {
   };
 
   {
-    /* for (int x = 0; x < B[0]; x++) {
+    /* for (const auto x : c10::irange(B[0])) {
      *   C[x] = A[x];
      * }
      */
@@ -2359,7 +2360,7 @@ TEST(MemDependency, MemDependencyCheckerDynamicShapes) {
   }
 
   {
-    /* for (int x = B[0]; x < B[1]; x++) {
+    /* for (const auto x : c10::irange(B[0], B[1])) {
      *   C[x] = A[x];
      * }
      */
@@ -2404,7 +2405,7 @@ TEST(MemDependency, MemDependencyCheckerDynamicShapes) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[x] = A[B[x]];
      * }
      */
@@ -2449,7 +2450,7 @@ TEST(MemDependency, MemDependencyCheckerDynamicShapes) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[B[x]] = A[x];
      * }
      */
@@ -2493,7 +2494,7 @@ TEST(MemDependency, MemDependencyCheckerDynamicShapes) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
+    /* for (const auto x : c10::irange(10)) {
      *   C[B[A[x]]] = x;
      * }
      */
@@ -2565,9 +2566,9 @@ TEST(MemDependency, MemDependencyCheckerMultiDim) {
   };
 
   {
-    /* for (int x = 0; x < 10; x++) {
-     *   for (int y = 0; y < 9; y++) {
-     *     for (int z = 0; z < 12; z++) {
+    /* for (const auto x : c10::irange(10)) {
+     *   for (const auto y : c10::irange(9)) {
+     *     for (const auto z : c10::irange(12)) {
      *       B[x, y, z] = A[x, y, z];
      *     }
      *   }
@@ -2611,9 +2612,9 @@ TEST(MemDependency, MemDependencyCheckerMultiDim) {
   }
 
   {
-    /* for (int x = 0; x < 5; x++) {
-     *   for (int y = 0; y < 5; y++) {
-     *     for (int z = 0; z < 5; z++) {
+    /* for (const auto x : c10::irange(5)) {
+     *   for (const auto y : c10::irange(5)) {
+     *     for (const auto z : c10::irange(5)) {
      *       B[x, y, z] = A[x, y, z];
      *     }
      *   }
@@ -2655,8 +2656,8 @@ TEST(MemDependency, MemDependencyCheckerMultiDim) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
-     *   for (int y = 0; y < 12; y++) {
+    /* for (const auto x : c10::irange(10)) {
+     *   for (const auto y : c10::irange(12)) {
      *     B[x, 0, y] = A[x, 0, y];
      *   }
      * }
@@ -2693,9 +2694,9 @@ TEST(MemDependency, MemDependencyCheckerMultiDim) {
   }
 
   {
-    /* for (int x = 0; x < 10; x++) {
-     *   for (int y = 0; y < 100; y++) {
-     *     for (int z = 0; z < 12; z++) {
+    /* for (const auto x : c10::irange(10)) {
+     *   for (const auto y : c10::irange(100)) {
+     *     for (const auto z : c10::irange(12)) {
      *       B[x, 0, z] = (A[x, 0, z]) + (C[x, z]);
      *     }
      *   }
@@ -2754,9 +2755,9 @@ TEST(MemDependency, MemDependencyCheckerMultiDim) {
   }
 
   {
-    /* for (int x = 0; x < 9; x++) {
-     *   for (int y = 0; y < 10; y++) {
-     *     for (int z = 0; z < 12; z++) {
+    /* for (const auto x : c10::irange(9)) {
+     *   for (const auto y : c10::irange(10)) {
+     *     for (const auto z : c10::irange(12)) {
      *       B[x, 0, 0] = (B[x, y, z]) + (A[x, y, z]);
      *     }
      *   }
@@ -2814,16 +2815,16 @@ TEST(MemDependency, MemDependencyCheckerMultiDim) {
 TEST(MemDependency, MemDependencyCheckerComputeAPI) {
   using namespace analysis;
 
-  /* for (int m = 0; m < 4; m++) {
-   *   for (int n = 0; n < 5; n++) {
-   *     for (int k = 0; k < 6; k++) {
+  /* for (const auto m : c10::irange(4)) {
+   *   for (const auto n : c10::irange(5)) {
+   *     for (const auto k : c10::irange(6)) {
    *       broadcast_add[m, n, k] = (a[m, n]) + (b[n, k]);
    *     }
    *   }
    * }
-   * for (int m_1 = 0; m_1 < 4; m_1++) {
-   *   for (int n_1 = 0; n_1 < 5; n_1++) {
-   *     for (int k_1 = 0; k_1 < 6; k_1++) {
+   * for (const auto m_1 : c10::irange(4)) {
+   *   for (const auto n_1 : c10::irange(5)) {
+   *     for (const auto k_1 : c10::irange(6)) {
    *       d[m_1, n_1, k_1] = (broadcast_add(m_1, n_1, k_1)) + float(1);
    *     }
    *   }
@@ -2865,9 +2866,9 @@ TEST(MemDependency, MemDependencyCheckerComputeAPI) {
 TEST(MemDependency, MemDependencyCheckerComputeInline) {
   using namespace analysis;
 
-  /* for (int m = 0; m < 4; m++) {
-   *   for (int n = 0; n < 5; n++) {
-   *     for (int k = 0; k < 6; k++) {
+  /* for (const auto m : c10::irange(4)) {
+   *   for (const auto n : c10::irange(5)) {
+   *     for (const auto k : c10::irange(6)) {
    *       d[m, n, k] = ((a[m, n]) + (b[n, k])) + float(1);
    *     }
    *   }
@@ -2937,7 +2938,7 @@ TEST(MemDependency, MemDependencyCheckerComputeSplit) {
 
   ASSERT_EQ(history_before.size(), history_after.size());
 
-  for (size_t i = 0; i < history_before.size(); ++i) {
+  for (const auto i : c10::irange(history_before.size())) {
     ASSERT_EQ(history_before[i]->type(), history_after[i]->type());
     ASSERT_EQ(history_before[i]->var(), history_after[i]->var());
     ASSERT_EQ(
@@ -2984,7 +2985,7 @@ TEST(MemDependency, MemDependencyCheckerComputeReorder) {
 
   ASSERT_EQ(history_before.size(), history_after.size());
 
-  for (size_t i = 0; i < history_before.size(); ++i) {
+  for (const auto i : c10::irange(history_before.size())) {
     ASSERT_EQ(history_before[i]->type(), history_after[i]->type());
     ASSERT_EQ(history_before[i]->var(), history_after[i]->var());
     ASSERT_EQ(
@@ -3002,17 +3003,17 @@ TEST(MemDependency, MemDependencyCheckerComputeReorder) {
 
 TEST(MemDependency, MemDependencyCheckerComputeReduce) {
   using namespace analysis;
-  /* for (int l2 = 0; l2 < 2; l2++) {
-   *   for (int n1 = 0; n1 < 3; n1++) {
-   *     for (int m1 = 0; m1 < 6; m1++) {
+  /* for (const auto l2 : c10::irange(2)) {
+   *   for (const auto n1 : c10::irange(3)) {
+   *     for (const auto m1 : c10::irange(6)) {
    *       scale[l2, n1, m1] = (b[l2, n1, m1]) * (a[l2, n1, m1]);
    *     }
    *   }
    * }
-   * for (int l1 = 0; l1 < 2; l1++) {
+   * for (const auto l1 : c10::irange(2)) {
    *   sum[l1] = float(0);
-   *   for (int n1_1 = 0; n1_1 < 3; n1_1++) {
-   *     for (int m1_1 = 0; m1_1 < 6; m1_1++) {
+   *   for (const auto n1_1 : c10::irange(3)) {
+   *     for (const auto m1_1 : c10::irange(6)) {
    *       sum[l1] = ReduceOp(sum, (sum[l1]) + (scale(l1, n1_1, m1_1)),
    *                    out_args={l1}, reduce_args={n1, m1});
    *     }
@@ -3185,7 +3186,7 @@ TEST(MemDependency, MemDependencyCheckerComputeGEMM) {
 
     ASSERT_EQ(history_before.size(), history_after.size());
 
-    for (size_t i = 0; i < history_before.size(); ++i) {
+    for (const auto i : c10::irange(history_before.size())) {
       ASSERT_EQ(history_before[i]->type(), history_after[i]->type());
       ASSERT_EQ(history_before[i]->var(), history_after[i]->var());
 

--- a/test/cpp/tensorexpr/test_memplanning.cpp
+++ b/test/cpp/tensorexpr/test_memplanning.cpp
@@ -24,9 +24,9 @@ TEST(BufLiveRange, SingleRangeLine) {
 
   // Construct Stmt:
   // {
-  //   for (int i = 0; i < 32; i++) {
+  //   for (const auto i : c10::irange(32)) {
   //     a[i] = 0;
-  //     for (int j = 0; j < 32; j++) {
+  //     for (const auto j : c10::irange(32)) {
   //       a[i] = (a[i]) + (b[i, j]);
   //     }
   //   }
@@ -52,13 +52,13 @@ TEST(BufLiveRange, MulRangeLine) {
 
   // Construct Stmt:
   // {
-  //   for (int i = 0; i < 32; i++) {
+  //   for (const auto i : c10::irange(32)) {
   //     if (i<10 ? 1 : 0) {
   //       a[i] = i + i;
   //       b[i] = i * i;
   //     }
   //   }
-  //   for (int i = 0; i < 32; i++) {
+  //   for (const auto i : c10::irange(32)) {
   //     if (i>10 ? 1 : 0) {
   //       a[i] = i * i;
   //       b[i] = i + i;
@@ -125,27 +125,27 @@ TEST(MemPlanning, MemReuseWithTypeCast) {
   // different: 'E' type quint8 < 'gemm' type float. We'll reuse 'gemm' for 'E'
   // with typecasting.
   //{
-  //  for (int i = 0; i < 4; i++) {
-  //    for (int i_1 = 0; i_1 < 4; i_1++) {
+  //  for (const auto i : c10::irange(4)) {
+  //    for (const auto i_1 : c10::irange(4)) {
   //      gemm[i, i_1] = float(0);
-  //      for (int i_2 = 0; i_2 < 4; i_2++) {
+  //      for (const auto i_2 : c10::irange(4)) {
   //        gemm[i, i_1] = ReduceOp((gemm[i, i_1]) + (A[i, i_2]) * (B[i_2,
   //        i_1]), reduce_args={i_2});
   //      }
   //    }
   //  }
-  //  for (int i_3 = 0; i_3 < 4; i_3++) {
-  //    for (int i_4 = 0; i_4 < 4; i_4++) {
+  //  for (const auto i_3 : c10::irange(4)) {
+  //    for (const auto i_4 : c10::irange(4)) {
   //      relu[i_3, i_4] = (gemm[i_3, i_4])<0.f ? 0.f : (gemm[i_3, i_4]);
   //    }
   //  }
-  //  for (int i_5 = 0; i_5 < 4; i_5++) {
-  //    for (int i_6 = 0; i_6 < 4; i_6++) {
+  //  for (const auto i_5 : c10::irange(4)) {
+  //    for (const auto i_6 : c10::irange(4)) {
   //      E[i_5, i_6] = quint8((relu[i_5, i_6]) + (relu[i_5, i_6]));
   //    }
   //  }
-  //  for (int i_7 = 0; i_7 < 4; i_7++) {
-  //    for (int i_8 = 0; i_8 < 4; i_8++) {
+  //  for (const auto i_7 : c10::irange(4)) {
+  //    for (const auto i_8 : c10::irange(4)) {
   //      F[i_7, i_8] = E[i_7, i_8];
   //    }
   //  }
@@ -237,28 +237,28 @@ TEST(MemPlanning, NoMemReuseForLargerType) {
   // different: 'E' type float > 'gemm' type int16. We won't reuse 'gemm' for
   // 'E'.
   //{
-  //  for (int i = 0; i < 4; i++) {
-  //    for (int i_1 = 0; i_1 < 4; i_1++) {
+  //  for (const auto i : c10::irange(4)) {
+  //    for (const auto i_1 : c10::irange(4)) {
   //      gemm[i, i_1] = int16_t(0);
-  //      for (int i_2 = 0; i_2 < 4; i_2++) {
+  //      for (const auto i_2 : c10::irange(4)) {
   //        gemm[i, i_1] = ReduceOp((gemm[i, i_1]) + (A[i, i_2]) * (B[i_2,
   //        i_1]), reduce_args={i_2});
   //      }
   //    }
   //  }
-  //  for (int i_3 = 0; i_3 < 4; i_3++) {
-  //    for (int i_4 = 0; i_4 < 4; i_4++) {
+  //  for (const auto i_3 : c10::irange(4)) {
+  //    for (const auto i_4 : c10::irange(4)) {
   //      relu[i_3, i_4] = (gemm[i_3, i_4])<int16_t(0) ? int16_t(0) : (gemm[i_3,
   //      i_4]);
   //    }
   //  }
-  //  for (int i_5 = 0; i_5 < 4; i_5++) {
-  //    for (int i_6 = 0; i_6 < 4; i_6++) {
+  //  for (const auto i_5 : c10::irange(4)) {
+  //    for (const auto i_6 : c10::irange(4)) {
   //      E[i_5, i_6] = float((relu[i_5, i_6]) + (relu[i_5, i_6]));
   //    }
   //  }
-  //  for (int i_7 = 0; i_7 < 4; i_7++) {
-  //    for (int i_8 = 0; i_8 < 4; i_8++) {
+  //  for (const auto i_7 : c10::irange(4)) {
+  //    for (const auto i_8 : c10::irange(4)) {
   //      F[i_7, i_8] = E[i_7, i_8];
   //    }
   //  }
@@ -350,28 +350,28 @@ TEST(MemPlanning, SameBufSizeMemReuse) {
   // add [2, 3] Buffer 'gemm' and 'add' are the same size; we'll reuse 'gemm'
   // for 'add'.
   //{
-  //  for (int M = 0; M < 1024; M++) {
-  //    for (int N = 0; N < 1024; N++) {
+  //  for (const auto M : c10::irange(1024)) {
+  //    for (const auto N : c10::irange(1024)) {
   //      gemm[M, N] = float(0);
-  //      for (int K = 0; K < 2048; K++) {
+  //      for (const auto K : c10::irange(2048)) {
   //        gemm[M, N] = ReduceOp((gemm[M, N]) + (A[M, K]) * (B[K, N]),
   //        reduce_args={K});
   //      }
   //    }
   //  }
-  //  for (int M_1 = 0; M_1 < 1024; M_1++) {
-  //    for (int N_1 = 0; N_1 < 1024; N_1++) {
+  //  for (const auto M_1 : c10::irange(1024)) {
+  //    for (const auto N_1 : c10::irange(1024)) {
   //      relu[M_1, N_1] = (gemm[M_1, N_1])<float(0) ? float(0) : (gemm[M_1,
   //      N_1]);
   //    }
   //  }
-  //  for (int M_2 = 0; M_2 < 1024; M_2++) {
-  //    for (int N_2 = 0; N_2 < 1024; N_2++) {
+  //  for (const auto M_2 : c10::irange(1024)) {
+  //    for (const auto N_2 : c10::irange(1024)) {
   //      add[M_2, N_2] = (relu[M_2, N_2]) + (relu[M_2, N_2]);
   //    }
   //  }
-  //  for (int M_3 = 0; M_3 < 1024; M_3++) {
-  //    for (int N_3 = 0; N_3 < 1024; N_3++) {
+  //  for (const auto M_3 : c10::irange(1024)) {
+  //    for (const auto N_3 : c10::irange(1024)) {
   //      mul[M_3, N_3] = (add[M_3, N_3]) * (add[M_3, N_3]);
   //    }
   //  }
@@ -443,33 +443,33 @@ TEST(MemPlanning, SameBufSizeMultiMemReuses) {
   // add [2, 3], mul [3, 4] Buffer 'gemm', 'relu, ''add' and 'mul' are the same
   // size; we'll reuse 'gemm' for 'add', and reuse 'relu' for 'mul'
   //{
-  //  for (int M = 0; M < 1024; M++) {
-  //    for (int N = 0; N < 1024; N++) {
+  //  for (const auto M : c10::irange(1024)) {
+  //    for (const auto N : c10::irange(1024)) {
   //      gemm[M, N] = float(0);
-  //      for (int K = 0; K < 2048; K++) {
+  //      for (const auto K : c10::irange(2048)) {
   //        gemm[M, N] = ReduceOp((gemm[M, N]) + (A[M, K]) * (B[K, N]),
   //        reduce_args={K});
   //      }
   //    }
   //  }
-  //  for (int M_1 = 0; M_1 < 1024; M_1++) {
-  //    for (int N_1 = 0; N_1 < 1024; N_1++) {
+  //  for (const auto M_1 : c10::irange(1024)) {
+  //    for (const auto N_1 : c10::irange(1024)) {
   //      relu[M_1, N_1] = (gemm[M_1, N_1])<float(0) ? float(0) : (gemm[M_1,
   //      N_1]);
   //    }
   //  }
-  //  for (int M_2 = 0; M_2 < 1024; M_2++) {
-  //    for (int N_2 = 0; N_2 < 1024; N_2++) {
+  //  for (const auto M_2 : c10::irange(1024)) {
+  //    for (const auto N_2 : c10::irange(1024)) {
   //      add[M_2, N_2] = (relu[M_2, N_2]) + (relu[M_2, N_2]);
   //    }
   //  }
-  //  for (int M_3 = 0; M_3 < 1024; M_3++) {
-  //    for (int N_3 = 0; N_3 < 1024; N_3++) {
+  //  for (const auto M_3 : c10::irange(1024)) {
+  //    for (const auto N_3 : c10::irange(1024)) {
   //      mul[M_3, N_3] = (add[M_3, N_3]) * (add[M_3, N_3]);
   //    }
   //  }
-  //  for (int M_4 = 0; M_4 < 1024; M_4++) {
-  //    for (int N_4 = 0; N_4 < 1024; N_4++) {
+  //  for (const auto M_4 : c10::irange(1024)) {
+  //    for (const auto N_4 : c10::irange(1024)) {
   //      sub[M_4, N_4] = (mul[M_4, N_4]) - (add[M_4, N_4]);
   //    }
   //  }
@@ -548,38 +548,38 @@ TEST(MemPlanning, SameBufSizeMultiMemReusesOfOneBuf) {
   // 'sub' are the same size; we'll reuse 'gemm' for 'add', reuse 'relu' for
   // 'mul', and reuse 'gemm' for 'sub'.
   //{
-  //  for (int M = 0; M < 1024; M++) {
-  //    for (int N = 0; N < 1024; N++) {
+  //  for (const auto M : c10::irange(1024)) {
+  //    for (const auto N : c10::irange(1024)) {
   //      gemm[M, N] = float(0);
-  //      for (int K = 0; K < 2048; K++) {
+  //      for (const auto K : c10::irange(2048)) {
   //        gemm[M, N] = ReduceOp((gemm[M, N]) + (A[M, K]) * (B[K, N]),
   //        reduce_args={K});
   //      }
   //    }
   //  }
-  //  for (int M_1 = 0; M_1 < 1024; M_1++) {
-  //    for (int N_1 = 0; N_1 < 1024; N_1++) {
+  //  for (const auto M_1 : c10::irange(1024)) {
+  //    for (const auto N_1 : c10::irange(1024)) {
   //      relu[M_1, N_1] = (gemm[M_1, N_1])<float(0) ? float(0) : (gemm[M_1,
   //      N_1]);
   //    }
   //  }
-  //  for (int M_2 = 0; M_2 < 1024; M_2++) {
-  //    for (int N_2 = 0; N_2 < 1024; N_2++) {
+  //  for (const auto M_2 : c10::irange(1024)) {
+  //    for (const auto N_2 : c10::irange(1024)) {
   //      add[M_2, N_2] = (relu[M_2, N_2]) + (relu[M_2, N_2]);
   //    }
   //  }
-  //  for (int M_3 = 0; M_3 < 1024; M_3++) {
-  //    for (int N_3 = 0; N_3 < 1024; N_3++) {
+  //  for (const auto M_3 : c10::irange(1024)) {
+  //    for (const auto N_3 : c10::irange(1024)) {
   //      mul[M_3, N_3] = (add[M_3, N_3]) * (add[M_3, N_3]);
   //    }
   //  }
-  //  for (int M_4 = 0; M_4 < 1024; M_4++) {
-  //    for (int N_4 = 0; N_4 < 1024; N_4++) {
+  //  for (const auto M_4 : c10::irange(1024)) {
+  //    for (const auto N_4 : c10::irange(1024)) {
   //      sub[M_4, N_4] = (mul[M_4, N_4]) - float(1);
   //    }
   //  }
-  //  for (int M_5 = 0; M_5 < 1024; M_5++) {
-  //    for (int N_5 = 0; N_5 < 1024; N_5++) {
+  //  for (const auto M_5 : c10::irange(1024)) {
+  //    for (const auto N_5 : c10::irange(1024)) {
   //      div[M_5, N_5] = (sub[M_5, N_5]) / float(2);
   //    }
   //  }
@@ -649,28 +649,28 @@ TEST(MemPlanning, SmallerBufSizeNonMemReuse) {
   // add [2, 3] We do not reuse buffer 'gemm' for 'add' because the size of
   // buffer 'gemm' is smaller.
   //{
-  //  for (int M = 0; M < 1024; M++) {
-  //    for (int N = 0; N < 1024; N++) {
+  //  for (const auto M : c10::irange(1024)) {
+  //    for (const auto N : c10::irange(1024)) {
   //      gemm[M, N] = float(0);
-  //      for (int K = 0; K < 2048; K++) {
+  //      for (const auto K : c10::irange(2048)) {
   //        gemm[M, N] = ReduceOp((gemm[M, N]) + (A[M, K]) * (B[K, N]),
   //        reduce_args={K});
   //      }
   //    }
   //  }
-  //  for (int M_1 = 0; M_1 < 1024; M_1++) {
-  //    for (int N_1 = 0; N_1 < 1024; N_1++) {
+  //  for (const auto M_1 : c10::irange(1024)) {
+  //    for (const auto N_1 : c10::irange(1024)) {
   //      relu[M_1, N_1] = (gemm[M_1, N_1])<float(0) ? float(0) : (gemm[M_1,
   //      N_1]);
   //    }
   //  }
-  //  for (int EM = 0; EM < 2048; EM++) {
-  //    for (int EN = 0; EN < 2048; EN++) {
+  //  for (const auto EM : c10::irange(2048)) {
+  //    for (const auto EN : c10::irange(2048)) {
   //      add[EM, EN] = (relu[EM / 2, EN / 2]) + (relu[EM / 2, EN / 2]);
   //    }
   //  }
-  //  for (int FM = 0; FM < 2048; FM++) {
-  //    for (int FN = 0; FN < 2048; FN++) {
+  //  for (const auto FM : c10::irange(2048)) {
+  //    for (const auto FN : c10::irange(2048)) {
   //      mul[FM, FN] = (add[FM, FN]) * (add[FM, FN]);
   //    }
   //  }

--- a/test/cpp/tensorexpr/test_ops.cpp
+++ b/test/cpp/tensorexpr/test_ops.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
 #include <torch/csrc/jit/tensorexpr/expr.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
@@ -25,7 +26,7 @@ TEST(Ops, Sum) {
   constexpr int N = 16;
   std::vector<IntList> testDims = {{0}, {1}, {0, 1}};
   std::vector<std::vector<ExprHandle>> outputShapes = {{N}, {M}, {}};
-  for (unsigned idx = 0; idx < testDims.size(); idx++) {
+  for (const auto idx : c10::irange(testDims.size())) {
     const auto& dims = testDims[idx];
     const auto& outShape = outputShapes[idx];
 
@@ -56,7 +57,7 @@ TEST(Ops, ChannelsLastSum) {
 
   std::vector<std::vector<ExprHandle>> outputShapes = {
       {B, C, D, E}, {A, C, D, E}, {C, D, E}};
-  for (unsigned idx = 0; idx < testDims.size(); idx++) {
+  for (const auto idx : c10::irange(testDims.size())) {
     const auto& dims = testDims[idx];
     const auto& outShape = outputShapes[idx];
 

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -1112,7 +1112,7 @@ TEST(Simplify, SimplifyDiv) {
 
 TEST(Simplify, SimplifyDivWithLoopContext0) {
   // Stmt to simplify:
-  // for (int i = 0; i < 100; i++) {
+  // for (const auto i : c10::irange(100)) {
   //  A[i] = i / 100;
   //}
   VarHandle i("i", kInt);
@@ -1244,7 +1244,7 @@ TEST(Simplify, SimplifyDivWithLoopContext5) {
 TEST(Simplify, SimplifyDivWithLoopContext6) {
   // Stmt to simplify:
   // for (const auto i : c10::irange(6)) {
-  //  for (int j = -1; j < 9; j++) {
+  //  for (const auto j : c10::irange(-1, 9)) {
   //    A[i, j+1] = (i + 6*j) / 6;
   //  }
   //}
@@ -1429,7 +1429,7 @@ TEST(Simplify, SimplifyModWithLoopContext5) {
 TEST(Simplify, SimplifyModWithLoopContext6) {
   // Stmt to simplify:
   // for (const auto i : c10::irange(6)) {
-  //  for (int j = -1; j < 9; j++) {
+  //  for (const auto j : c10::irange(-1, 9)) {
   //    A[i, j+1] = (i + 6*j) % 6;
   //  }
   //}

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -3091,7 +3091,7 @@ Tensor prelu_backward_weight_jvp(
       reduction_dims.push_back(1);
     }
     // reduce over dims which are >= 2.
-    for (int64_t i = 2; i < ndim; ++i) {
+    for (const auto i : c10::irange(2, ndim)) {
       reduction_dims.push_back(i);
     }
   }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -717,8 +717,7 @@ void GraphTask::exec_post_processing() {
 
     // WARNING: Don't use a range-for loop here because more callbacks may be
     // added in between callback calls, so iterators may become invalidated.
-    // NOLINTNEXTLINE(modernize-loop-convert)
-    for (size_t i = 0; i < final_callbacks_.size(); ++i) {
+    for (const auto i : c10::irange(final_callbacks_.size())) {
       cb_lock.unlock();
       final_callbacks_[i]();
       cb_lock.lock();

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -607,7 +607,7 @@ static void _append_subgraph(
 
   std::unordered_map<Value*, Value*> value_map;
   auto value_map_func = [&](Value* v) { return value_map.at(v); };
-  for (size_t i = 0; i < node->inputs().size(); ++i) {
+  for (const auto i : c10::irange(node->inputs().size())) {
     auto subgraph_input = subgraph->addInput();
     subgraph_input->copyMetadata(node->inputs().at(i));
     value_map[node->inputs().at(i)] = subgraph_input;
@@ -625,7 +625,7 @@ static void _append_subgraph(
     torch::jit::Node* node = *it;
     auto* clone_node =
         subgraph->insertNode(subgraph->createClone(node, value_map_func));
-    for (size_t i = 0; i < node->outputs().size(); ++i) {
+    for (const auto i : c10::irange(node->outputs().size())) {
       value_map[node->outputs()[i]] = clone_node->outputs()[i];
       auto trace_it = std::find(
           trace_outputs.begin(), trace_outputs.end(), node->outputs()[i]);

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -325,7 +325,7 @@ PyObject* THCPModule_cudaJiteratorCompileAndLaunchKernel(
     return THPVariable_Wrap(outputs[0]);
   } else {
     PyObject* output_tuple = PyTuple_New(num_outputs);
-    for (int i = 0; i < num_outputs; ++i) {
+    for (const auto i : c10::irange(num_outputs)) {
       PyTuple_SetItem(output_tuple, i, THPVariable_Wrap(outputs[i]));
     }
     return output_tuple;

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -99,24 +99,24 @@ struct CollectiveFingerPrint {
       sizes.reserve(num_tensors);
 
       // 3. Tensor dtypes
-      for (int i = 0; i < num_tensors; i++) {
+      for (const auto i : c10::irange(num_tensors)) {
         dtypes.push_back(serialized_tensor[index].item<int8_t>());
         index++;
       }
       // 4. Device types
-      for (int i = 0; i < num_tensors; i++) {
+      for (const auto i : c10::irange(num_tensors)) {
         device_types.push_back(serialized_tensor[index].item<int8_t>());
         index++;
       }
       // 5. Tensor shapes
-      for (int i = 0; i < num_tensors; i++) {
+      for (const auto i : c10::irange(num_tensors)) {
         // 5a. Shape size
         int size = serialized_tensor[index].item<int>();
         index++;
         // 5b. Shape
         auto shapeVec = std::vector<int64_t>();
         shapeVec.reserve(size);
-        for (int j = 0; j < size; j++) {
+        for (const auto j : c10::irange(size)) {
           shapeVec.push_back(serialized_tensor[index].item<int64_t>());
           index++;
         }
@@ -153,7 +153,7 @@ struct CollectiveFingerPrint {
     for (const auto i : c10::irange(output_tensors.size())) {
       const std::vector<at::Tensor> gathered_tensors = output_tensors[i];
       const at::Tensor reference_tensor = tensors_to_verify[i];
-      for (int rank = 0; rank < gathered_tensors.size(); rank++) {
+      for (const auto rank : c10::irange(gathered_tensors.size())) {
         const auto& rank_tensor = gathered_tensors[rank];
         if (!rank_tensor.equal(reference_tensor)) {
           CollectiveFingerPrint rank_fingerprint =

--- a/torch/csrc/distributed/c10d/UCCUtils.cpp
+++ b/torch/csrc/distributed/c10d/UCCUtils.cpp
@@ -1,5 +1,7 @@
 #ifdef USE_C10D_UCC
 
+
+#include <c10/util/irange.h>
 #include <torch/csrc/distributed/c10d/UCCTracing.hpp>
 #include <torch/csrc/distributed/c10d/UCCUtils.hpp>
 
@@ -46,12 +48,12 @@ ucc_status_t oob_allgather_test(void* req) {
   TORCH_CHECK(info != nullptr);
 
   try {
-    for (int r = 0; r < info->size; r++) {
+    for (const auto r : c10::irange(info->size)) {
       if (!info->store->check({info->getKey(kTeamRank + std::to_string(r))})) {
         return UCC_INPROGRESS;
       }
     }
-    for (int r = 0; r < info->size; r++) {
+    for (const auto r : c10::irange(info->size)) {
       std::vector<uint8_t> data =
           info->store->get(info->getKey(kTeamRank + std::to_string(r)));
       memcpy(

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -2103,7 +2103,7 @@ void verify_params_across_processes(
   std::vector<std::vector<at::Tensor>> param_size_output_tensors;
   param_size_output_tensors.emplace_back(std::vector<at::Tensor>{});
   auto world_size = process_group->getSize();
-  for (size_t i = 0; i < world_size; ++i) {
+  for (const auto i : c10::irange(world_size)) {
     param_size_output_tensors.front().emplace_back(
         at::empty_like(param_size_tensor));
   }
@@ -2112,7 +2112,7 @@ void verify_params_across_processes(
   ops::allgather(process_group, param_size_output_tensors, param_size_vec)
       ->wait();
   auto result_size_tensors = param_size_output_tensors.front();
-  for (size_t i = 0; i < world_size; ++i) {
+  for (const auto i : c10::irange(world_size)) {
     auto param_size_for_rank = result_size_tensors[i][0].item<int>();
     TORCH_CHECK(
         param_size_for_rank == params.size(),

--- a/torch/csrc/functorch/init.cpp
+++ b/torch/csrc/functorch/init.cpp
@@ -16,6 +16,7 @@
 #include <ATen/functorch/PlumbingHelper.h>
 #include <ATen/functorch/TensorWrapper.h>
 #include <c10/core/AutogradState.h>
+#include <c10/util/irange.h>
 
 // This file contains functorch's Python bindings.
 
@@ -110,7 +111,7 @@ static Tensor _movedim(const Tensor& self, int64_t src, int64_t dst) {
   }
   VmapDimVector permutation;
   permutation.reserve(logical_dim);
-  for (int64_t dim = 0; dim < logical_dim; dim++) {
+  for (const auto dim : c10::irange(logical_dim)) {
     if (dim == src) {
       continue;
     }

--- a/torch/csrc/lazy/core/shape.cpp
+++ b/torch/csrc/lazy/core/shape.cpp
@@ -76,7 +76,7 @@ c10::SymbolicShape get_symbolic_shape(at::Tensor& tensor) {
       sizes.size() == is_symbolic->size(),
       "Dims of two values are not consistent");
   std::vector<c10::optional<int64_t>> symbolic_dims;
-  for (int64_t i = 0; i < sizes.size(); i++) {
+  for (const auto i : c10::irange(sizes.size())) {
     if (is_symbolic->at(i)) {
       symbolic_dims.emplace_back(c10::nullopt);
     } else {
@@ -120,7 +120,7 @@ void applySymbolicShapesOnLT(
     TORCH_INTERNAL_ASSERT(
         res_symbolic->size() == result_shapes.size(),
         "Result shape size is not consistent");
-    for (int64_t i = 0; i < res_symbolic->size(); i++) {
+    for (const auto i : c10::irange(res_symbolic->size())) {
       auto sym_dims = res_symbolic->at(i).symbolicDims();
       if (sym_dims.has_value()) {
         result_shapes[i] = result_shapes[i].with_symbolic_dims(*sym_dims);

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -61,6 +61,7 @@
 #include <ATen/native/ReduceOpsUtils.h>
 #include <ATen/native/TensorConversions.h>
 #include <c10/core/ScalarType.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/api/include/torch/enum.h>
 #include <torch/csrc/lazy/core/ops/utils.h>
 #include <torch/csrc/lazy/core/shape.h>
@@ -233,7 +234,7 @@ std::vector<Shape> compute_shape_constant_pad_nd(
       "dimensions.");
 
   std::vector<int64_t> new_shape;
-  for (size_t i = 0; i < (size_t)l_diff; i++) {
+  for (const auto i : c10::irange((size_t)l_diff)) {
     new_shape.emplace_back(input_sizes[i]);
   }
 

--- a/torch/csrc/lazy/ts_backend/tensor_aten_ops.cpp
+++ b/torch/csrc/lazy/ts_backend/tensor_aten_ops.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/InferSize.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/lazy/core/helpers.h>
 #include <torch/csrc/lazy/core/ir_builder.h>
@@ -41,7 +42,7 @@ std::vector<int64_t> GetExpandDimensions(
     std::vector<int64_t> dimensions) {
   TORCH_CHECK_GE(dimensions.size(), shape.dim()) << shape;
   int64_t base = dimensions.size() - shape.dim();
-  for (size_t i = 0; i < shape.dim(); ++i) {
+  for (const auto i : c10::irange(shape.dim())) {
     if (dimensions[base + i] == -1) {
       dimensions[base + i] = shape.size(i);
     }

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
@@ -1,4 +1,5 @@
 #include <c10/core/ScalarType.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/lazy/ts_backend/ts_backend_impl.h>
 #include <torch/csrc/lazy/ts_backend/ts_lowering_context.h>
 #include <torch/csrc/lazy/ts_backend/ts_node.h>
@@ -35,7 +36,7 @@ void TSLoweringContext::Lower(const Node* node) {
     TSOpVector ops = tsnode->Lower(function_, this);
     CHECK(!ops.empty()) << "Failed to lower: " << *node;
     TORCH_CHECK_EQ(node->num_outputs(), ops.size());
-    for (size_t i = 0; i < ops.size(); ++i) {
+    for (const auto i : c10::irange(ops.size())) {
       AssignOutputOp(torch::lazy::Output(node, i), ops[i]);
     }
   } else {

--- a/torch/csrc/lazy/ts_backend/ts_node_lowering.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node_lowering.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/lazy/ts_backend/ts_node_lowering.h>
 
 #include <ATen/Functions.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/sugared_value.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/lazy/backend/backend_interface.h>
@@ -238,7 +239,7 @@ torch::lazy::TSOpVector Narrow::Lower(
   const torch::lazy::Shape& input_shape = input.shape();
   TORCH_CHECK_EQ(sizes.size(), base_indices.size());
   TORCH_CHECK_EQ(input_shape.dim(), base_indices.size());
-  for (size_t dim = 0; dim < base_indices.size(); ++dim) {
+  for (const auto dim : c10::irange(base_indices.size())) {
     int64_t start = base_indices[dim];
     base = GenerateSlice(
         /*base=*/base,
@@ -260,7 +261,7 @@ torch::lazy::TSOpVector NarrowViewUpdate::Lower(
   const torch::lazy::Shape& source_shape = source_argument.shape();
   TORCH_CHECK_EQ(source_shape.dim(), base_indices.size());
   torch::jit::Value* base = dest;
-  for (size_t dim = 0; dim < base_indices.size(); ++dim) {
+  for (const auto dim : c10::irange(base_indices.size())) {
     int64_t start = base_indices[dim];
     base = GenerateSlice(
         /*base=*/base,

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -7,6 +7,7 @@
 #endif
 
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 namespace torch {
 namespace profiler {
@@ -175,7 +176,7 @@ class ExperimentalConfigWrapper {
     configss << "ACTIVITIES_WARMUP_PERIOD_SECS=0\n"
              << "CUPTI_PROFILER_METRICS=";
 
-    for (int i = 0; i < num_metrics; i++) {
+    for (const auto i : c10::irange(num_metrics)) {
       configss << config_.profiler_metrics[i];
       if (num_metrics > 1 && i < (num_metrics - 1)) {
         configss << ",";

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -684,7 +684,7 @@ static bool is_int_list(
     // Make sure none of the later arguments are SymInt
     // NB: do NOT check that the later arguments are ints, as this is
     // BC-breaking for FX
-    for (int i = 1; i < len; i++) {
+    for (const auto i : c10::irange(1, len)) {
       if (torch::is_symint_node(
               py::reinterpret_steal<py::object>(PySequence_GetItem(obj, i)))) {
         if (failed_idx != nullptr) {


### PR DESCRIPTION
Switches to using `c10::irange` for `const` safety and appropriate data type deduction.