### PR TITLE
WIP Add uint8 support for interpolate on channels_last (1, 3, H,W) CPU images, mode=bilinear, antialias=True

### DIFF
--- a/aten/src/ATen/native/cpu/blah.h
+++ b/aten/src/ATen/native/cpu/blah.h
@@ -1,0 +1,38 @@
+#pragma once // TODO: remove this entire file
+
+
+#define INT16 short
+#define INT32 int
+
+#define UINT16 unsigned INT16
+#define UINT32 unsigned INT32
+
+/* Microsoft compiler doesn't limit intrinsics for an architecture.
+   This macro is set only on x86 and means SSE2 and above including AVX2. */
+#if defined(_M_X64) || _M_IX86_FP == 2
+    #define __SSE4_2__
+#endif
+
+#if defined(__SSE4_2__)
+    #include <emmintrin.h>
+    #include <mmintrin.h>
+    #include <smmintrin.h>
+#endif
+
+#if defined(__AVX2__)
+    #include <immintrin.h>
+#endif
+
+#if defined(__SSE4_2__)
+static __m128i inline
+mm_cvtepu8_epi32(void *ptr) {
+    return _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(INT32 *) ptr));
+}
+#endif
+
+#if defined(__AVX2__)
+static __m256i inline
+mm256_cvtepu8_epi32(void *ptr) {
+    return _mm256_cvtepu8_epi32(_mm_loadl_epi64((__m128i *) ptr));
+}
+#endif

--- a/aten/src/ATen/native/cpu/my_interp.h
+++ b/aten/src/ATen/native/cpu/my_interp.h
@@ -1,0 +1,364 @@
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <ATen/Context.h>
+#include <ATen/Dispatch.h>
+#include <ATen/Parallel.h>
+#include <ATen/TensorIterator.h>
+#include <ATen/cpu/vec/vec.h>
+#include <ATen/native/UpSample.h>
+#include <ATen/native/cpu/utils.h>
+#include <c10/util/irange.h>
+
+#include "resample_simd_horizontal.c"
+#include "resample_simd_vertical.c"
+#include "blah.h"  // TODO: remove
+#include <stdio.h> // TODO: remove
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_native.h>
+#include <ATen/ops/ones.h>
+#endif
+
+#include <iostream>
+
+namespace at {
+namespace native {
+namespace {
+
+
+
+static inline double bilinear_filter(double x) {
+    // TODO: Same as aa_filter()
+    if (x < 0.0) {
+        x = -x;
+    }
+    if (x < 1.0) {
+        return 1.0 - x;
+    }
+    return 0.0;
+}
+
+void unpack_rgb(uint8_t * unpacked, const uint8_t * packed, int num_pixels)
+// TODO: maybe use faster version from https://github.com/python-pillow/Pillow/pull/2693/files
+{
+    int i;
+    for (i = 0; i < num_pixels; i++) {
+        unpacked[0] = packed[0];
+        unpacked[1] = packed[1];
+        unpacked[2] = packed[2];
+        unpacked[3] = 255;
+        unpacked += 4;
+        packed += 3;
+    }
+}
+
+void pack_rgb(uint8_t * packed, const uint8_t* unpacked, int num_pixels)
+// TODO: maybe use faster version from https://github.com/python-pillow/Pillow/pull/2693/files
+{
+    int i;
+    /* RGB triplets */
+    for (i = 0; i < num_pixels; i++) {
+        packed [0] = unpacked[0];
+        packed [1] = unpacked[1];
+        packed [2] = unpacked[2];
+        packed  += 3;
+        unpacked+= 4;
+    }
+}
+
+int precompute_coeffs( // TODO: This is redundant with `compute_indices_weights_aa()`
+    int inSize,
+    int outSize,
+    int **boundsp,
+    double **kkp) {
+    double support, scale, filterscale;
+    double center, ww, ss;
+    int xx, x, ksize, xmin, xmax;
+    int *bounds;
+    double *kk, *k;
+
+    /* prepare for horizontal stretch */
+    filterscale = scale = (double)inSize / outSize;
+    if (filterscale < 1.0) {
+        filterscale = 1.0;
+    }
+    /* determine support size (length of resampling filter) */
+    // support = filterp->support * filterscale;
+    support = filterscale; // bilinear filter support is 1 for pil-simd
+
+    /* maximum number of coeffs */
+    ksize = (int)ceil(support) * 2 + 1;
+
+    // check for overflow
+    if (outSize > INT_MAX / (ksize * (int)sizeof(double))) {
+        // ImagingError_MemoryError();
+        AT_ERROR("BLOP") ;
+        return 0;
+    }
+
+    /* coefficient buffer */
+    /* malloc check ok, overflow checked above */
+    kk = (double *)malloc(outSize * ksize * sizeof(double));
+    if (!kk) {
+        // ImagingError_MemoryError();
+        AT_ERROR("BLIP") ;
+        return 0;
+    }
+
+    /* malloc check ok, ksize*sizeof(double) > 2*sizeof(int) */
+    bounds = (int*)malloc(outSize * 2 * sizeof(int));
+    if (!bounds) {
+        free(kk);
+        // ImagingError_MemoryError();
+        AT_ERROR("BLOOP") ;
+        return 0;
+    }
+
+    for (xx = 0; xx < outSize; xx++) {
+        center = (xx + 0.5) * scale;
+        ww = 0.0;
+        ss = 1.0 / filterscale;
+        // Round the value
+        xmin = (int)(center - support + 0.5);
+        if (xmin < 0) {
+            xmin = 0;
+        }
+        // Round the value
+        xmax = (int)(center + support + 0.5);
+        if (xmax > inSize) {
+            xmax = inSize;
+        }
+        xmax -= xmin;
+        k = &kk[xx * ksize];
+        for (x = 0; x < xmax; x++) {
+            double w = bilinear_filter((x + xmin - center + 0.5) * ss);
+            k[x] = w;
+            ww += w;
+        }
+        for (x = 0; x < xmax; x++) {
+            if (ww != 0.0) {
+                k[x] /= ww;
+            }
+        }
+        // Remaining values should stay empty if they are used despite of xmax.
+        for (; x < ksize; x++) {
+            k[x] = 0;
+        }
+        bounds[xx * 2 + 0] = xmin;
+        bounds[xx * 2 + 1] = xmax;
+    }
+    *boundsp = bounds;
+    *kkp = kk;
+    return ksize;
+}
+
+#define PRECISION_BITS (32 - 8 - 2)
+#define MAX_COEFS_PRECISION (16 - 1)
+
+int normalize_coeffs_8bpc(int outSize, int ksize, double *prekk) {
+    int x;
+    INT16 *kk;
+    int coefs_precision;
+    double maxkk;
+
+    // use the same buffer for normalized coefficients
+    kk = (INT16 *) prekk;
+
+    maxkk = prekk[0];
+    for (x = 0; x < outSize * ksize; x++) {
+        if (maxkk < prekk[x]) {
+            maxkk = prekk[x];
+        }
+    }
+
+    for (coefs_precision = 0; coefs_precision < PRECISION_BITS; coefs_precision += 1) {
+        int next_value = (int) (0.5 + maxkk * (1 << (coefs_precision + 1)));
+        // The next value will be outside of the range, so just stop
+        if (next_value >= (1 << MAX_COEFS_PRECISION))
+            break;
+    }
+
+    for (x = 0; x < outSize * ksize; x++) {
+        if (prekk[x] < 0) {
+            kk[x] = (int) (-0.5 + prekk[x] * (1 << coefs_precision));
+        } else {
+            kk[x] = (int) (0.5 + prekk[x] * (1 << coefs_precision));
+        }
+    }
+    return coefs_precision;
+}
+
+
+ 
+
+void ImagingResampleHorizontal_8bpc(UINT32 * unpacked_output_p , UINT32 * unpacked_input_p, int offset, int ksize, int *bounds, double *prekk, int xout, int yout, int xin) {
+    int ss0;
+    int xx, yy, x, xmin, xmax;
+    INT16 *k, *kk;
+    int coefs_precision;
+
+    // use the same buffer for normalized coefficients
+    kk = (INT16 *) prekk;
+    coefs_precision = normalize_coeffs_8bpc(xout, ksize, prekk);
+
+    yy = 0;
+    for (; yy < yout - 3; yy += 4) {
+        ImagingResampleHorizontalConvolution8u4x(
+            unpacked_output_p + yy * xout,
+            unpacked_output_p + (yy + 1) * xout,
+            unpacked_output_p + (yy + 2) * xout,
+            unpacked_output_p + (yy + 3) * xout,
+            unpacked_input_p + (yy + offset) * xin,
+            unpacked_input_p + (yy + offset + 1) * xin,
+            unpacked_input_p + (yy + offset + 2) * xin,
+            unpacked_input_p + (yy + offset + 3) * xin,
+            xout, bounds, kk, ksize,
+            coefs_precision
+        );
+    }
+    for (; yy < yout; yy++) {
+        ImagingResampleHorizontalConvolution8u(
+            unpacked_output_p + yy * xout,
+            unpacked_input_p + (yy + offset) * xin,
+            xout, bounds, kk, ksize,
+            coefs_precision
+        );
+    }
+}
+
+void ImagingResampleVertical_8bpc(
+    UINT32 * unpacked_output_p , UINT32 * unpacked_input_p, int offset, int ksize, int *bounds, double *prekk, int xout, int yout) {
+    int ss0;
+    int xx, yy, y, ymin, ymax;
+    INT16 *k, *kk;
+    int coefs_precision;
+
+    // use the same buffer for normalized coefficients
+    kk = (INT16 *) prekk;
+    coefs_precision = normalize_coeffs_8bpc(yout, ksize, prekk);
+
+    for (yy = 0; yy < yout; yy++) {
+        k = &kk[yy * ksize];
+        ymin = bounds[yy * 2 + 0];
+        ymax = bounds[yy * 2 + 1];
+        ImagingResampleVerticalConvolution8u(unpacked_output_p + yy * xout, unpacked_input_p, ymin, ymax, k, coefs_precision, xout);
+    }
+}
+
+UINT32 * ImagingResampleInner(UINT32 * unpacked_input_p, int xin, int yin, int xout, int yout) {
+    int i, need_horizontal, need_vertical;
+    int ybox_first, ybox_last;
+    int ksize_horiz, ksize_vert;
+    int *bounds_horiz, *bounds_vert;
+    double *kk_horiz, *kk_vert;
+    UINT32 * unpacked_output_p = NULL;
+    UINT32 * unpacked_output_temp_p = NULL;
+
+    need_horizontal = xout != xin;
+    need_vertical = yout != yin;
+
+    ksize_horiz = precompute_coeffs(xin, xout, &bounds_horiz, &kk_horiz);
+    // if (!ksize_horiz) {
+    //     return NULL;
+    // }
+
+    ksize_vert = precompute_coeffs(yin, yout, &bounds_vert, &kk_vert);
+    // if (!ksize_vert) {
+    //     free(bounds_horiz);
+    //     free(kk_horiz);
+    //     return NULL;
+    // }
+
+    // First used row in the source image
+    ybox_first = bounds_vert[0];
+    // Last used row in the source image
+    ybox_last = bounds_vert[yout * 2 - 2] + bounds_vert[yout * 2 - 1];
+
+    /* two-pass resize, horizontal pass */
+    if (need_horizontal) {
+        // Shift bounds for vertical pass
+        for (i = 0; i < yout; i++) {
+            bounds_vert[i * 2] -= ybox_first;
+        }
+
+        // imTemp = ImagingNewDirty(imIn->mode, xout, ybox_last - ybox_first);
+        // if (imTemp) {
+        //     ResampleHorizontal(
+        //         imTemp, imIn, ybox_first, ksize_horiz, bounds_horiz, kk_horiz);
+        // }
+        unpacked_output_temp_p = (UINT32 *) malloc(sizeof(UINT32) * xout * yin);
+        ImagingResampleHorizontal_8bpc(unpacked_output_temp_p, unpacked_input_p, ybox_first, ksize_horiz, bounds_horiz, kk_horiz, xout, yin, xin);
+        free(bounds_horiz);
+        free(kk_horiz);
+        // if (!imTemp) {
+        //     free(bounds_vert);
+        //     free(kk_vert);
+        //     return NULL;
+        // }
+        // imOut = imIn = imTemp;
+        unpacked_output_p = unpacked_input_p = unpacked_output_temp_p;
+    } else {
+        // Free in any case
+        free(bounds_horiz);
+        free(kk_horiz);
+    }
+
+    /* vertical pass */
+    if (need_vertical) {
+        // imOut = ImagingNewDirty(imIn->mode, imIn->xsize, ysize);
+        unpacked_output_p = (UINT32 *) malloc(sizeof(UINT32) * xout * yout);
+        // if (imOut) {
+            ImagingResampleVertical_8bpc(unpacked_output_p, unpacked_input_p, 0, ksize_vert, bounds_vert, kk_vert, xout, yout);
+        // }
+        // /* it's safe to call ImagingDelete with empty value
+        //    if previous step was not performed. */
+        // ImagingDelete(imTemp);
+        free(unpacked_output_temp_p);
+        free(bounds_vert);
+        free(kk_vert);
+        // if (!imOut) {
+        //     return NULL;
+        // }
+    } else {
+        // Free in any case
+        free(bounds_vert);
+        free(kk_vert);
+    }
+
+    // /* none of the previous steps are performed, copying */
+    // if (!imOut) {
+    //     imOut = ImagingCopy(imIn);
+    // }
+
+    return unpacked_output_p;
+}
+
+void beepidiboop(const Tensor& input, const Tensor& output) {
+  // Assume shape is 1, 3, H, W  and layout is channels_last
+
+   auto xin = input.size(3);
+   auto yin = input.size(2);
+   auto xout = output.size(3);
+   auto yout = output.size(2);
+   auto num_pixels_input = xin * yin;
+   auto num_pixels_output = xout * yout;
+  
+
+  UINT32 * unpacked_input_p = (UINT32 *) malloc(sizeof(UINT32) * num_pixels_input);
+  const uint8_t * packed_input_p = (const uint8_t *) input.data_ptr<uint8_t>();
+  unpack_rgb((uint8_t *)unpacked_input_p, packed_input_p, num_pixels_input);
+
+  UINT32 * unpacked_output_p = ImagingResampleInner(unpacked_input_p, xin, yin, xout, yout);
+
+  uint8_t * packed_output_p = (uint8_t *) output.data_ptr<uint8_t>();
+  pack_rgb(packed_output_p, (const uint8_t *)unpacked_output_p, num_pixels_output);
+}
+
+
+} // anonymous namespace
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/cpu/resample_simd_horizontal.c
+++ b/aten/src/ATen/native/cpu/resample_simd_horizontal.c
@@ -1,0 +1,211 @@
+#pragma once
+#include "blah.h"  // TODO: remove
+
+// TODO: Use stuff in vec.h instead
+namespace {
+
+void ImagingResampleHorizontalConvolution8u4x(
+    UINT32 *lineOut0, UINT32 *lineOut1, UINT32 *lineOut2, UINT32 *lineOut3,
+    UINT32 *lineIn0, UINT32 *lineIn1, UINT32 *lineIn2, UINT32 *lineIn3,
+    int xsize, int *xbounds, INT16 *kk, int kmax, int coefs_precision)
+{
+#ifdef CPU_CAPABILITY_AVX2
+    int xmin, xmax, xx, x;
+    INT16 *k;
+
+
+    for (xx = 0; xx < xsize; xx++) {
+        xmin = xbounds[xx * 2 + 0];
+        xmax = xbounds[xx * 2 + 1];
+        k = &kk[xx * kmax];
+        x = 0;
+
+        __m256i sss0, sss1;
+        __m256i zero = _mm256_setzero_si256();
+        __m256i initial = _mm256_set1_epi32(1 << (coefs_precision-1));
+        sss0 = initial;
+        sss1 = initial;
+
+        for (; x < xmax - 3; x += 4) {
+
+            __m256i pix, mmk0, mmk1, source;
+
+            mmk0 = _mm256_set1_epi32(*(INT32 *) &k[x]);
+            mmk1 = _mm256_set1_epi32(*(INT32 *) &k[x + 2]);
+
+            source = _mm256_inserti128_si256(_mm256_castsi128_si256(
+                _mm_loadu_si128((__m128i *) &lineIn0[x + xmin])),
+                _mm_loadu_si128((__m128i *) &lineIn1[x + xmin]), 1);
+            pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
+                -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0,
+                -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+            sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk0));
+            pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
+                -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8,
+                -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8));
+            sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk1));
+
+            source = _mm256_inserti128_si256(_mm256_castsi128_si256(
+                _mm_loadu_si128((__m128i *) &lineIn2[x + xmin])),
+                _mm_loadu_si128((__m128i *) &lineIn3[x + xmin]), 1);
+            pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
+                -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0,
+                -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+            sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk0));
+            pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
+                -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8,
+                -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8));
+            sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk1));
+        }
+
+        for (; x < xmax - 1; x += 2) {
+            __m256i pix, mmk;
+
+            mmk = _mm256_set1_epi32(*(INT32 *) &k[x]);
+
+            pix = _mm256_inserti128_si256(_mm256_castsi128_si256(
+                _mm_loadl_epi64((__m128i *) &lineIn0[x + xmin])),
+                _mm_loadl_epi64((__m128i *) &lineIn1[x + xmin]), 1);
+            pix = _mm256_shuffle_epi8(pix, _mm256_set_epi8(
+                -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0,
+                -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+            sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk));
+
+            pix = _mm256_inserti128_si256(_mm256_castsi128_si256(
+                _mm_loadl_epi64((__m128i *) &lineIn2[x + xmin])),
+                _mm_loadl_epi64((__m128i *) &lineIn3[x + xmin]), 1);
+            pix = _mm256_shuffle_epi8(pix, _mm256_set_epi8(
+                -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0,
+                -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+            sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk));
+        }
+
+        for (; x < xmax; x ++) {
+
+            __m256i pix, mmk;
+
+            // [16] xx k0 xx k0 xx k0 xx k0 xx k0 xx k0 xx k0 xx k0
+            mmk = _mm256_set1_epi32(k[x]);
+
+            // [16] xx a0 xx b0 xx g0 xx r0 xx a0 xx b0 xx g0 xx r0
+            pix = _mm256_inserti128_si256(_mm256_castsi128_si256(
+                mm_cvtepu8_epi32(&lineIn0[x + xmin])),
+                mm_cvtepu8_epi32(&lineIn1[x + xmin]), 1);
+            sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk));
+
+            pix = _mm256_inserti128_si256(_mm256_castsi128_si256(
+                mm_cvtepu8_epi32(&lineIn2[x + xmin])),
+                mm_cvtepu8_epi32(&lineIn3[x + xmin]), 1);
+            sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk));
+        }
+
+        sss0 = _mm256_srai_epi32(sss0, coefs_precision);
+        sss1 = _mm256_srai_epi32(sss1, coefs_precision);
+        sss0 = _mm256_packs_epi32(sss0, zero);
+        sss1 = _mm256_packs_epi32(sss1, zero);
+        sss0 = _mm256_packus_epi16(sss0, zero);
+        sss1 = _mm256_packus_epi16(sss1, zero);
+        lineOut0[xx] = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss0, 0));
+        lineOut1[xx] = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss0, 1));
+        lineOut2[xx] = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss1, 0));
+        lineOut3[xx] = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss1, 1));
+    }
+#endif // CPU_CAPABILITY_AVX2
+}
+
+
+void
+ImagingResampleHorizontalConvolution8u(UINT32 *lineOut, UINT32 *lineIn,
+    int xsize, int *xbounds, INT16 *kk, int kmax, int coefs_precision)
+{
+#ifdef CPU_CAPABILITY_AVX2
+    int xmin, xmax, xx, x;
+    INT16 *k;
+
+    for (xx = 0; xx < xsize; xx++) {
+      __m128i sss;
+      xmin = xbounds[xx * 2 + 0];
+      xmax = xbounds[xx * 2 + 1];
+      k = &kk[xx * kmax];
+      x = 0;
+
+
+      if (xmax < 8) {
+          sss = _mm_set1_epi32(1 << (coefs_precision-1));
+      } else {
+
+          // Lower part will be added to higher, use only half of the error
+          __m256i sss256 = _mm256_set1_epi32(1 << (coefs_precision-2));
+
+          for (; x < xmax - 7; x += 8) {
+              __m256i pix, mmk, source;
+              __m128i tmp = _mm_loadu_si128((__m128i *) &k[x]);
+              __m256i ksource = _mm256_insertf128_si256(
+                  _mm256_castsi128_si256(tmp), tmp, 1);
+
+              source = _mm256_loadu_si256((__m256i *) &lineIn[x + xmin]);
+
+              pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
+                  -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0,
+                  -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+              mmk = _mm256_shuffle_epi8(ksource, _mm256_set_epi8(
+                  11,10, 9,8, 11,10, 9,8, 11,10, 9,8, 11,10, 9,8,
+                  3,2, 1,0, 3,2, 1,0, 3,2, 1,0, 3,2, 1,0));
+              sss256 = _mm256_add_epi32(sss256, _mm256_madd_epi16(pix, mmk));
+
+              pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
+                  -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8,
+                  -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8));
+              mmk = _mm256_shuffle_epi8(ksource, _mm256_set_epi8(
+                  15,14, 13,12, 15,14, 13,12, 15,14, 13,12, 15,14, 13,12,
+                  7,6, 5,4, 7,6, 5,4, 7,6, 5,4, 7,6, 5,4));
+              sss256 = _mm256_add_epi32(sss256, _mm256_madd_epi16(pix, mmk));
+          }
+
+          for (; x < xmax - 3; x += 4) {
+              __m256i pix, mmk, source;
+              __m128i tmp = _mm_loadl_epi64((__m128i *) &k[x]);
+              __m256i ksource = _mm256_insertf128_si256(
+                  _mm256_castsi128_si256(tmp), tmp, 1);
+
+              tmp = _mm_loadu_si128((__m128i *) &lineIn[x + xmin]);
+              source = _mm256_insertf128_si256(
+                  _mm256_castsi128_si256(tmp), tmp, 1);
+
+              pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
+                  -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8,
+                  -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+              mmk = _mm256_shuffle_epi8(ksource, _mm256_set_epi8(
+                  7,6, 5,4, 7,6, 5,4, 7,6, 5,4, 7,6, 5,4, 
+                  3,2, 1,0, 3,2, 1,0, 3,2, 1,0, 3,2, 1,0));
+              sss256 = _mm256_add_epi32(sss256, _mm256_madd_epi16(pix, mmk));
+          }
+
+          sss = _mm_add_epi32(
+              _mm256_extracti128_si256(sss256, 0),
+              _mm256_extracti128_si256(sss256, 1)
+          );
+      }
+
+      for (; x < xmax - 1; x += 2) {
+          __m128i mmk = _mm_set1_epi32(*(INT32 *) &k[x]);
+          __m128i source = _mm_loadl_epi64((__m128i *) &lineIn[x + xmin]);
+          __m128i pix = _mm_shuffle_epi8(source, _mm_set_epi8(
+              -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+          sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
+      }
+
+      for (; x < xmax; x ++) {
+          __m128i pix = mm_cvtepu8_epi32(&lineIn[x + xmin]);
+          __m128i mmk = _mm_set1_epi32(k[x]);
+          sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
+      }
+      sss = _mm_srai_epi32(sss, coefs_precision);
+      sss = _mm_packs_epi32(sss, sss);
+      lineOut[xx] = _mm_cvtsi128_si32(_mm_packus_epi16(sss, sss));
+    }
+#endif // CPU_CAPABILITY_AVX2
+}
+
+
+} // namespace

--- a/aten/src/ATen/native/cpu/resample_simd_vertical.c
+++ b/aten/src/ATen/native/cpu/resample_simd_vertical.c
@@ -1,0 +1,170 @@
+#pragma once
+#include "blah.h"  // TODO: remove
+
+// TODO: Use stuff in vec.h instead
+namespace {
+
+void ImagingResampleVerticalConvolution8u(
+    UINT32 *lineOut, UINT32 * imIn,
+    int xmin, int xmax, INT16 *k, int coefs_precision, int xin)
+{
+#ifdef CPU_CAPABILITY_AVX2
+    int x;
+    int xx = 0;
+    int xsize = xin;
+
+    __m128i initial = _mm_set1_epi32(1 << (coefs_precision-1));
+    __m256i initial_256 = _mm256_set1_epi32(1 << (coefs_precision-1));
+
+    for (; xx < xsize - 7; xx += 8) {
+        __m256i sss0 = initial_256;
+        __m256i sss1 = initial_256;
+        __m256i sss2 = initial_256;
+        __m256i sss3 = initial_256;
+        x = 0;
+        for (; x < xmax - 1; x += 2) {
+            __m256i source, source1, source2;
+            __m256i pix, mmk;
+
+            // Load two coefficients at once
+            mmk = _mm256_set1_epi32(*(INT32 *) &k[x]);
+            
+            // source1 = _mm256_loadu_si256(  // top line
+            //     (__m256i *) &imIn->image32[x + xmin][xx]);
+            source1 = _mm256_loadu_si256(  // top line
+                (__m256i *) (imIn + (x + xmin) * xin + xx));
+            // source2 = _mm256_loadu_si256(  // bottom line
+            //     (__m256i *) &imIn->image32[x + 1 + xmin][xx]);
+            source2 = _mm256_loadu_si256(  // bottom line
+                (__m256i *) (imIn + (x + 1 + xmin) * xin + xx));
+
+            source = _mm256_unpacklo_epi8(source1, source2);
+            pix = _mm256_unpacklo_epi8(source, _mm256_setzero_si256());
+            sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk));
+            pix = _mm256_unpackhi_epi8(source, _mm256_setzero_si256());
+            sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk));
+
+            source = _mm256_unpackhi_epi8(source1, source2);
+            pix = _mm256_unpacklo_epi8(source, _mm256_setzero_si256());
+            sss2 = _mm256_add_epi32(sss2, _mm256_madd_epi16(pix, mmk));
+            pix = _mm256_unpackhi_epi8(source, _mm256_setzero_si256());
+            sss3 = _mm256_add_epi32(sss3, _mm256_madd_epi16(pix, mmk));
+        }
+        for (; x < xmax; x += 1) {
+            __m256i source, source1, pix, mmk;
+            mmk = _mm256_set1_epi32(k[x]);
+            
+            // source1 = _mm256_loadu_si256(  // top line
+            //     (__m256i *) &imIn->image32[x + xmin][xx]);
+            source1 = _mm256_loadu_si256(  // top line
+                (__m256i *) (imIn + (x + xmin) * xin + xx));
+            
+            source = _mm256_unpacklo_epi8(source1, _mm256_setzero_si256());
+            pix = _mm256_unpacklo_epi8(source, _mm256_setzero_si256());
+            sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk));
+            pix = _mm256_unpackhi_epi8(source, _mm256_setzero_si256());
+            sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk));
+
+            source = _mm256_unpackhi_epi8(source1, _mm256_setzero_si256());
+            pix = _mm256_unpacklo_epi8(source, _mm256_setzero_si256());
+            sss2 = _mm256_add_epi32(sss2, _mm256_madd_epi16(pix, mmk));
+            pix = _mm256_unpackhi_epi8(source, _mm256_setzero_si256());
+            sss3 = _mm256_add_epi32(sss3, _mm256_madd_epi16(pix, mmk));
+        }
+        sss0 = _mm256_srai_epi32(sss0, coefs_precision);
+        sss1 = _mm256_srai_epi32(sss1, coefs_precision);
+        sss2 = _mm256_srai_epi32(sss2, coefs_precision);
+        sss3 = _mm256_srai_epi32(sss3, coefs_precision);
+
+        sss0 = _mm256_packs_epi32(sss0, sss1);
+        sss2 = _mm256_packs_epi32(sss2, sss3);
+        sss0 = _mm256_packus_epi16(sss0, sss2);
+        _mm256_storeu_si256((__m256i *) &lineOut[xx], sss0);
+    }
+
+    for (; xx < xsize - 1; xx += 2) {
+        __m128i sss0 = initial;  // left row
+        __m128i sss1 = initial;  // right row
+        x = 0;
+        for (; x < xmax - 1; x += 2) {
+            __m128i source, source1, source2;
+            __m128i pix, mmk;
+
+            // Load two coefficients at once
+            mmk = _mm_set1_epi32(*(INT32 *) &k[x]);
+
+            // source1 = _mm_loadl_epi64(  // top line
+            //     (__m128i *) &imIn->image32[x + xmin][xx]);
+            source1 = _mm_loadl_epi64(  // top line
+                (__m128i *) (imIn + (x + xmin) * xin + xx));
+            // source2 = _mm_loadl_epi64(  // bottom line
+            //     (__m128i *) &imIn->image32[x + 1 + xmin][xx]);
+            source2 = _mm_loadl_epi64(  // bottom line
+                (__m128i *) (imIn + (x + 1 + xmin) * xin + xx));
+            
+            source = _mm_unpacklo_epi8(source1, source2);
+            pix = _mm_unpacklo_epi8(source, _mm_setzero_si128());
+            sss0 = _mm_add_epi32(sss0, _mm_madd_epi16(pix, mmk));
+            pix = _mm_unpackhi_epi8(source, _mm_setzero_si128());
+            sss1 = _mm_add_epi32(sss1, _mm_madd_epi16(pix, mmk));
+        }
+        for (; x < xmax; x += 1) {
+            __m128i source, source1, pix, mmk;
+            mmk = _mm_set1_epi32(k[x]);
+            
+            // source1 = _mm_loadl_epi64(  // top line
+            //     (__m128i *) &imIn->image32[x + xmin][xx]);
+            source1 = _mm_loadl_epi64(  // top line
+                (__m128i *)(imIn + (x + xmin) * xin + xx) );
+            
+            source = _mm_unpacklo_epi8(source1, _mm_setzero_si128());
+            pix = _mm_unpacklo_epi8(source, _mm_setzero_si128());
+            sss0 = _mm_add_epi32(sss0, _mm_madd_epi16(pix, mmk));
+            pix = _mm_unpackhi_epi8(source, _mm_setzero_si128());
+            sss1 = _mm_add_epi32(sss1, _mm_madd_epi16(pix, mmk));
+        }
+        sss0 = _mm_srai_epi32(sss0, coefs_precision);
+        sss1 = _mm_srai_epi32(sss1, coefs_precision);
+
+        sss0 = _mm_packs_epi32(sss0, sss1);
+        sss0 = _mm_packus_epi16(sss0, sss0);
+        _mm_storel_epi64((__m128i *) &lineOut[xx], sss0);
+    }
+
+    for (; xx < xsize; xx++) {
+        __m128i sss = initial;
+        x = 0;
+        for (; x < xmax - 1; x += 2) {
+            __m128i source, source1, source2;
+            __m128i pix, mmk;
+            
+            // Load two coefficients at once
+            mmk = _mm_set1_epi32(*(INT32 *) &k[x]);
+
+            // source1 = _mm_cvtsi32_si128(  // top line
+            //     *(int *) &imIn->image32[x + xmin][xx]);
+            source1 = _mm_cvtsi32_si128(*(int *) (imIn +  (x + xmin) * xin + xx));
+            // source2 = _mm_cvtsi32_si128(  // bottom line
+            //     *(int *) &imIn->image32[x + 1 + xmin][xx]);
+            source2 = _mm_cvtsi32_si128(  // bottom line
+                *(int *) (imIn + (x + 1 + xmin) * xin + xx));
+            
+            source = _mm_unpacklo_epi8(source1, source2);
+            pix = _mm_unpacklo_epi8(source, _mm_setzero_si128());
+            sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
+        }
+        for (; x < xmax; x++) {
+            // __m128i pix = mm_cvtepu8_epi32(&imIn->image32[x + xmin][xx]);
+            __m128i pix = mm_cvtepu8_epi32(imIn + (x + xmin) * xin + xx);
+            __m128i mmk = _mm_set1_epi32(k[x]);
+            sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
+        }
+        sss = _mm_srai_epi32(sss, coefs_precision);
+        sss = _mm_packs_epi32(sss, sss);
+        lineOut[xx] = _mm_cvtsi128_si32(_mm_packus_epi16(sss, sss));
+    }
+#endif // CPU_CAPABILITY_AVX2
+}
+
+
+} // namespace

--- a/test_interp.py
+++ b/test_interp.py
@@ -1,0 +1,38 @@
+# TODO: Remove file, put that in a proper official test
+import torch
+import pytest
+
+
+
+def check(Hi, Wi, Ho, Wo):
+
+    img = torch.randint(0, 256, (1, 3, Hi, Wi), dtype=torch.uint8)
+    img = img.contiguous(memory_format=torch.channels_last)
+
+    out = torch.nn.functional.interpolate(img, [Ho, Wo], mode="bilinear", antialias=True)
+    out_float = torch.nn.functional.interpolate(img.to(torch.float), [Ho, Wo], mode="bilinear", antialias=True).round().to(torch.uint8)
+
+    # Assert no pixel value differs by more than 1
+    torch.testing.assert_allclose(out, out_float, rtol=0, atol=1)
+
+
+@pytest.mark.parametrize("Hi, Wi, Ho, Wo", (
+    (271, 268, 224, 224),
+    (256, 128, 512, 256),
+    (68, 49, 1549, 2890),
+    (10, 15, 512, 320),
+    (4, 8, 8, 4),
+    (2, 2, 4, 4),
+    (10, 15, 10, 15),
+))
+@pytest.mark.parametrize("reverse", (False, True))
+def test_lol(Hi, Wi, Ho, Wo, reverse):
+    if reverse:
+        Hi, Wi, Ho, Wo = Ho, Wo, Hi, Wi
+    
+    if Hi == Ho and Wi == Wo:
+        pytest.xfail("Segfault lololol")
+
+    check(Hi, Wi, Hi, Wo)  # horizontal
+    check(Hi, Wi, Ho, Wi)  # vertical
+    check(Hi, Wi, Ho, Wo)  # both


### PR DESCRIPTION
This is heavily adapted / ported from PILLOW-SIMD.

This PR adds support for `uint8` images in the following case:
- mode=bilinear, `antialias=True` -- support for other modes is possible
- shape=(1, 3, H, W)  -- can extend to batch_size > 1. Not sure about channels yet.
- layout = channels_last  --- we could easily support contiguous as well, since we have to copy (pack / unpack) the input anyway
- device=CPU

This may sound restrictive, but it's not. This is exactly the setting in which torchvision' `Resize()` is used for training jobs.

This is still WIP with lots of TODOs, but it seems to be working decently. On the inputs I tried and comparing with torchvision's `Resize()` (which first converts uint8 to floats, runs `interpolate()`, and converts back to uint8), I'm getting ~3-5X speedup. It seems correct so far as the absolute difference in the outputs is never `> 1`, and only ~15% of the pixel values differ (by exactly 1).

This addresses https://github.com/pytorch/vision/issues/2289

@vfdev-5 @mingfeima @fmassa I'd love your initial thoughts on this!

cc @VitalyFedyunin @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10