### PR TITLE
[AC] Return `None` from `apply_activation_checkpointing()`

### DIFF
--- a/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
+++ b/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
@@ -268,7 +268,7 @@ def apply_activation_checkpointing(
     # TODO: Importing inside function to avoid circular import issue between FSDP and
     # checkpoint_wrapper. This can be resolved once wrap() APIs are decoupled from FSDP code.
     from torch.distributed.fsdp.wrap import _recursive_wrap, lambda_auto_wrap_policy
-    return _recursive_wrap(
+    _recursive_wrap(
         module=model,
         auto_wrap_policy=partial(lambda_auto_wrap_policy, lambda_fn=check_fn),
         wrapper_cls=checkpoint_wrapper_fn,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#87871 [AC] Return `None` from `apply_activation_checkpointing()`**
* #87812 [FSDP] ufmt FSDP test
* #87811 [FSDP] ufmt /fsdp

`_recursive_wrap()` returns `Tuple[nn.Module, int]`, where the `nn.Module` is the in-place modified module and the `int` is the numel wrapped. In that sense, the return value is not meant to be publicly used. The `apply_activation_checkpointing()` docs already suggest that the function returns `None`, so this PR simply follows that.

**Test Plan**
CI