### PR TITLE
[profiler] Add Performance events support in Kineto profiler

### DIFF
--- a/test/cpp/profiler/perf_events.cpp
+++ b/test/cpp/profiler/perf_events.cpp
@@ -1,0 +1,52 @@
+
+#include <gtest/gtest.h>
+
+#include <torch/csrc/profiler/events.h>
+#include <torch/csrc/profiler/perf.h>
+
+double calc_pi() {
+  volatile double pi = 1.0;
+  for (int i = 3; i < 100000; i += 2) {
+    pi += (((i + 1) >> 1) % 2) ? 1.0 / i : -1.0 / i;
+  }
+  return pi * 4.0;
+}
+
+TEST(ProfilerTest, LinuxPerf) {
+  torch::profiler::impl::linux_perf::PerfProfiler profiler;
+
+  std::vector<std::string> standard_events(
+      std::begin(torch::profiler::ProfilerPerfEvents),
+      std::end(torch::profiler::ProfilerPerfEvents));
+  torch::profiler::perf_counters_t counters;
+  counters.resize(standard_events.size(), 0);
+
+  // Use try..catch HACK to check TORCH_CHECK because we don't yet fail
+  // gracefully if the syscall were to fail
+  try {
+    profiler.Configure(standard_events);
+
+    profiler.Enable();
+    auto pi = calc_pi();
+    profiler.Disable(counters);
+  } catch (const c10::Error&) {
+    // Bail here if something bad happened during the profiling, we don't want
+    // to make the test fail
+    return;
+  } catch (...) {
+    // something else went wrong - this should be reported
+    ASSERT_EQ(0, 1);
+  }
+
+  // Should have counted something if worked, so lets test that
+  // And if it not supported the counters should be zeros.
+#if defined(__ANDROID__) || defined(__linux__)
+  for (auto counter : counters) {
+    ASSERT_GT(counter, 0);
+  }
+#else /* __ANDROID__ || __linux__ */
+  for (auto counter : counters) {
+    ASSERT_EQ(counter, 0);
+  }
+#endif /* __ANDROID__ || __linux__ */
+}

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <torch/csrc/autograd/profiler_kineto.h>
 
@@ -12,6 +13,8 @@
 #include <torch/csrc/profiler/api.h>
 #include <torch/csrc/profiler/collection.h>
 #include <torch/csrc/profiler/containers.h>
+#include <torch/csrc/profiler/perf.h>
+#include <torch/csrc/profiler/events.h>
 #include <torch/csrc/profiler/kineto_shim.h>
 #include <torch/csrc/profiler/orchestration/observer.h>
 #include <torch/csrc/profiler/standalone/itt_observer.h>
@@ -134,10 +137,12 @@ struct AddTensorboardFields : public MetadataBase {
 };
 
 struct AddGenericMetadata : public MetadataBase {
-  AddGenericMetadata(std::shared_ptr<Result>& result, const bool verbose)
-      : MetadataBase(result) {
+  AddGenericMetadata(
+      std::shared_ptr<Result>& result,
+      const torch::profiler::impl::ProfilerConfig* config)
+      : MetadataBase(result), config_(config) {
     result->visit(*this);
-    if (verbose) {
+    if (config->experimental_config.verbose) {
       result->visit_if_base<PyExtraFieldsBase>(
           [&, this](const auto& i) -> void {
             this->addMetadata("Python thread", std::to_string(i.python_tid_));
@@ -154,6 +159,15 @@ struct AddGenericMetadata : public MetadataBase {
     auto& dtypes = op_event.inputs_.dtypes_;
     if (!dtypes.empty()) {
       addMetadata("Input type", dtypesToStr(dtypes));
+    }
+
+    if (config_ && !config_->experimental_config.performance_events.empty()) {
+      auto& event_names = config_->experimental_config.performance_events;
+      for (auto i = 0; i < op_event.perf_event_counters_->size(); ++i) {
+        addMetadata(
+            event_names[i],
+            std::to_string((*op_event.perf_event_counters_)[i]));
+      }
     }
 
     // add information about an associated forward op, if a sequence number
@@ -197,6 +211,10 @@ struct AddGenericMetadata : public MetadataBase {
 
   template <typename T>
   void operator()(const T&) {}
+
+ private:
+  /* To get names of the performance events */
+  const torch::profiler::impl::ProfilerConfig* config_;
 };
 
 // Assumption: Total threads number will not exceed 2^16-1, and total ops will
@@ -315,7 +333,7 @@ struct KinetoThreadLocalState : public ProfilerStateBase {
 
         kineto_events_.emplace_back(e, config_.experimental_config.verbose);
         AddTensorboardFields add_tb(e, kineto_events_.back());
-        AddGenericMetadata add_generic(e, config_.experimental_config.verbose);
+        AddGenericMetadata add_generic(e, &config_);
 
         // It is not safe to use the activity after post processing.
         e->kineto_activity_ = nullptr;
@@ -433,6 +451,10 @@ void onFunctionExit(
   TORCH_INTERNAL_ASSERT(kineto_ctx_ptr != nullptr);
   kineto_ctx_ptr->event_->end_time_ =
       torch::profiler::impl::getApproximateTime();
+  if (!config.experimental_config.performance_events.empty()) {
+    state_ptr->record_queue_.getSubqueue()->disable_perf_profiler(
+        *kineto_ctx_ptr->event_->counters_);
+  }
   kineto_ctx_ptr->event_->basic_fields_.end_tid_ =
       at::RecordFunction::currentThreadId();
   if (config.state == ProfilerState::KINETO_GPU_FALLBACK) {
@@ -518,6 +540,33 @@ void prepareProfiler(
       "Supported only in Kineto profiler");
   torch::profiler::impl::kineto::prepareTrace(
       /*cpuOnly=*/!at::hasCUDA(), activities, config.experimental_config);
+
+  if (config.experimental_config.performance_events.size()) {
+    /* For now only CPU activity is supported */
+    TORCH_CHECK(
+        activities.count(torch::autograd::profiler::ActivityType::CPU),
+        "Cannot run cpu hardware profiler without CPU activities, please only use CPU activity type");
+    /*
+     * Sending a warning and passing the non-standard event to the backend
+     * Backend can abort if the event is not supported.
+     * TODO Should we gracefully drop the invalid event if we have atleast one
+     * valid?
+     */
+    auto is_standard_event = [](const std::string& event) -> bool {
+      for (auto e : torch::profiler::ProfilerPerfEvents) {
+        if (!std::strcmp(event.c_str(), e)) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    for (const auto& e : config.experimental_config.performance_events) {
+      if (!is_standard_event(e)) {
+        TORCH_WARN("Forwarding a non-standard CPU performance event : ", e);
+      }
+    }
+  }
 }
 
 void enableProfilerWithEventPostProcess(
@@ -707,6 +756,21 @@ int64_t KinetoEvent::cudaElapsedUs() const {
                  << e.what();
   }
   return -1;
+}
+
+void KinetoEvent::getPerfEventCounters(std::vector<uint64_t>& in) const {
+  return result_->visit(c10::overloaded(
+      [&in](const ExtraFields<EventType::TorchOp>& e) -> void {
+        const size_t n = e.perf_event_counters_->size();
+        // should be rare
+        if (in.size() < n) {
+          in.resize(n, 0);
+        }
+        for (size_t i = 0; i < n; ++i) {
+          in[i] = (*e.perf_event_counters_)[i];
+        }
+      },
+      [](const auto&) -> void { return; }));
 }
 
 #define FORWARD_FROM_RESULT(method_name, result_expr)                        \

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -6,6 +6,7 @@
 #include <torch/csrc/profiler/api.h>
 #include <torch/csrc/profiler/stubs/base.h>
 #include <torch/csrc/profiler/util.h>
+#include <torch/csrc/profiler/events.h>
 
 namespace torch {
 namespace profiler {
@@ -54,6 +55,7 @@ struct TORCH_API KinetoEvent {
   std::string backend() const;
   bool isPythonFunction() const;
   int64_t cudaElapsedUs() const;
+  void getPerfEventCounters(torch::profiler::perf_counters_t&) const;
 
  private:
   torch::profiler::impl::ProfilerEventStub fallbackStart() const;

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -246,6 +246,11 @@ std::unique_ptr<KinetoObserverContext> ThreadLocalSubqueue::begin_op(
 
   event->start_time_ = torch::profiler::impl::getApproximateTime();
   event->allow_tf32_cublas_ = at::globalContext().allowTF32CuBLAS();
+  if (!config_.experimental_config.performance_events.empty()) {
+    const size_t n = config_.experimental_config.performance_events.size();
+    event->counters_ = std::make_unique<perf_counters_t>(n, 0);
+    perf_profiler_->Enable();
+  }
   return out;
 }
 
@@ -327,7 +332,9 @@ void ThreadLocalSubqueue::TorchOpStorage::materialize(
         jit_module(),
         extra_args(),
         gpu_fallback(),
-        event->allow_tf32_cublas_};
+        event->allow_tf32_cublas_,
+        std::move(event->counters_)};
+
 
     out.emplace_back(Result::create(
         time_converter(event->start_time_), tid, kineto_info, std::move(e)));
@@ -468,6 +475,10 @@ ThreadLocalSubqueue::ThreadLocalSubqueue(
     const ProfilerConfig& config)
     : tid_{tid}, config_{config}, kineto_info_{kineto::kineto_ids()} {
   torch::profiler::impl::kineto::recordThreadInfo();
+  if (config_.experimental_config.performance_events.size()) {
+    perf_profiler_ = std::make_unique<torch::profiler::impl::linux_perf::PerfProfiler>();
+    perf_profiler_->Configure(config_.experimental_config.performance_events);
+  }
 }
 
 RecordQueue::RecordQueue(

--- a/torch/csrc/profiler/orchestration/observer.cpp
+++ b/torch/csrc/profiler/orchestration/observer.cpp
@@ -14,10 +14,12 @@ using GlobalManager = GlobalStateManager<ProfilerStateBase>;
 ExperimentalConfig::ExperimentalConfig(
     std::vector<std::string> profiler_metrics,
     bool profiler_measure_per_kernel,
-    bool verbose)
+    bool verbose,
+    std::vector<std::string> performance_events)
     : profiler_metrics{profiler_metrics},
       profiler_measure_per_kernel{profiler_measure_per_kernel},
-      verbose{verbose} {}
+      verbose{verbose},
+      performance_events(std::move(performance_events)){}
 
 /*explicit*/ ExperimentalConfig::operator bool() const {
   return !profiler_metrics.empty();

--- a/torch/csrc/profiler/orchestration/observer.h
+++ b/torch/csrc/profiler/orchestration/observer.h
@@ -40,13 +40,19 @@ struct TORCH_API ExperimentalConfig {
   ExperimentalConfig(
       std::vector<std::string> profiler_metrics = {},
       bool profiler_measure_per_kernel = false,
-      bool verbose = false);
+      bool verbose = false,
+      std::vector<std::string> performance_events = {});
   ~ExperimentalConfig() = default;
   explicit operator bool() const;
 
   std::vector<std::string> profiler_metrics;
   bool profiler_measure_per_kernel;
   bool verbose;
+  /*
+   * List of performance events to be profiled.
+   * An empty list will disable performance event based profiling altogether.
+   */
+  std::vector<std::string> performance_events;
 };
 
 struct TORCH_API ProfilerConfig {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

* Wiring to allow user to pass event names to profiler and reflect the count to the chrometrace
* If not used, the runtime and size overhead should be neglegible
* For now, primary user will be KinetoEdgeCPUProfiler but the impl does not assume that
* Not exposed to python yet

Differential Revision: [D40238032](https://our.internmc.facebook.com/intern/diff/D40238032/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D40238032/)!