### PR TITLE
Nested profiling support for Linux-perf Profiler

### DIFF
--- a/torch/csrc/profiler/perf-inl.h
+++ b/torch/csrc/profiler/perf-inl.h
@@ -54,6 +54,18 @@ inline uint64_t PerfProfiler::CalcDelta(uint64_t start, uint64_t end) const {
   return end - start;
 }
 
+inline void PerfProfiler::StartCounting() const {
+  for (auto& e: events_) {
+    e.Enable();
+  }
+}
+
+inline void PerfProfiler::StopCounting() const {
+   for (auto& e: events_) {
+    e.Disable();
+  }
+}
+
 } // namespace linux_perf
 } // namespace impl
 } // namespace profiler

--- a/torch/csrc/profiler/perf.cpp
+++ b/torch/csrc/profiler/perf.cpp
@@ -166,29 +166,44 @@ void PerfProfiler::Configure(std::vector<std::string>& event_names) {
     events_.emplace_back(name);
     events_.back().Init();
   }
-  start_values_.resize(events_.size(), 0);
   ResetPThreadPool();
 }
 
 void PerfProfiler::Enable() {
-  TORCH_CHECK(!is_enabled_, "Nested perf event counting is not supported yet");
-  for (int i = 0; i < events_.size(); ++i) {
-    start_values_[i] = events_[i].ReadCounter();
-    events_[i].Enable();
+  if (start_values_.size()) {
+    StopCounting();
   }
-  is_enabled_ = true;
+
+  start_values_.emplace(events_.size(), 0);
+
+  auto& sv = start_values_.top();
+  for (int i = 0; i < events_.size(); ++i) {
+    sv[i] = events_[i].ReadCounter();
+  }
+  StartCounting();
 }
 
 void PerfProfiler::Disable(perf_counters_t& vals) {
+  StopCounting();
   TORCH_CHECK(
       vals.size() == events_.size(),
       "Can not fit all perf counters in the supplied container");
-  TORCH_CHECK(is_enabled_, "Perf Profiler is not enabled");
+  TORCH_CHECK(
+      start_values_.size() > 0,
+      "PerfProfiler must be enabled before disabling");
+
+  /* Always connecting this disable event to the last enable event i.e. using
+   * whatever is on the top of the start counter value stack. */
+  perf_counters_t& sv = start_values_.top();
   for (int i = 0; i < events_.size(); ++i) {
-    events_[i].Disable();
-    vals[i] = CalcDelta(start_values_[i], events_[i].ReadCounter());
+    vals[i] = CalcDelta(sv[i], events_[i].ReadCounter());
   }
-  is_enabled_ = false;
+  start_values_.pop();
+
+  // Restore it for a parent
+  if (start_values_.size()) {
+    StartCounting();
+  }
 }
 } // namespace linux_perf
 } // namespace impl

--- a/torch/csrc/profiler/perf.h
+++ b/torch/csrc/profiler/perf.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <stack>
 
 #include <torch/csrc/profiler/events.h>
 
@@ -92,10 +93,11 @@ class PerfProfiler {
 
  private:
   uint64_t CalcDelta(uint64_t start, uint64_t end) const;
+  void StartCounting() const;
+  void StopCounting() const;
 
-  bool is_enabled_{false};
   std::vector<PerfEvent> events_;
-  perf_counters_t start_values_;
+  std::stack<perf_counters_t> start_values_;
 };
 } // namespace linux_perf
 } // namespace impl


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #87879
* __->__ #87878
* #87877
* #87876
* #87874
* #87866

Add a stack of start counter values, and attribute each disable to the last enable

Differential Revision: [D40539212](https://our.internmc.facebook.com/intern/diff/D40539212/)