### PR TITLE
add special case for power of 0.5

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2201,7 +2201,7 @@ class CommonTemplate:
     def test_pow3(self):
         # power of 0.5 is special-cased, arbitrary power would still produce triton codegen error
         def fn(x):
-            z = torch.tensor(0.123, device="cuda")
+            z = torch.tensor(0.123, device=self.device)
             w = z + x
             return torch.pow(w, 0.5)
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2201,15 +2201,13 @@ class CommonTemplate:
     def test_pow3(self):
         # power of 0.5 is special-cased, arbitrary power would still produce triton codegen error
         def fn(x):
-            z = torch.tensor(.123, device="cuda")
+            z = torch.tensor(0.123, device="cuda")
             w = z + x
-            return torch.pow(w, .5)
+            return torch.pow(w, 0.5)
 
         opt = torch._dynamo.optimize("inductor")(fn)
         input = torch.rand(())
         self.assertTrue(same(opt(input), fn(input)))
-
-
 
     def test_glu(self):
         def fn(x):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2198,6 +2198,19 @@ class CommonTemplate:
             rtol=3e-05,
         )
 
+    def test_pow3(self):
+        # power of 0.5 is special-cased, arbitrary power would still produce triton codegen error
+        def fn(x):
+            z = torch.tensor(.123, device="cuda")
+            w = z + x
+            return torch.pow(w, .5)
+
+        opt = torch._dynamo.optimize("inductor")(fn)
+        input = torch.rand(())
+        self.assertTrue(same(opt(input), fn(input)))
+
+
+
     def test_glu(self):
         def fn(x):
             return aten.glu(x, -1), aten.glu(x, 1), aten.glu(x, 2)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3121,6 +3121,8 @@ def pow(a, b):
         ), "Pow input must be floating point."
     if isinstance(b, float) and b == int(b):
         return pow(a, int(b))
+    elif isinstance(b, float) and b == 0.5:
+        return sqrt(a)
     elif isinstance(b, int) and b == 1:
         return a
     elif isinstance(b, int) and -32 < b < 32:


### PR DESCRIPTION
Workaround for https://github.com/pytorch/torchdynamo/issues/1775, and calling sqrt is better in any case, but `libdevice.pow` still for some reason doesn't work if both arguments are scalars

cc @jansel @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @mreso, can you please check if that takes you further with diffusers

cc @jansel @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx