### PR TITLE
[FSDP()][1/N] Start refactoring FSDP root pre-forward

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -1,0 +1,82 @@
+from typing import Any, List, Optional, Tuple
+
+import torch
+from torch.distributed.fsdp._utils import _apply_to_tensors
+from torch.distributed.fsdp.flat_param import FlatParamHandle
+from torch.distributed.utils import _to_kwargs
+
+
+def _wait_for_computation_stream(
+    computation_stream: torch.cuda.Stream,
+    unshard_stream: torch.cuda.Stream,
+    pre_unshard_stream: torch.cuda.Stream,
+):
+    """
+    Has the unshard and pre-unshard streams wait for the computation stream.
+    For example, this should be called in the FSDP root's pre-forward to
+    respect optimizer step computation.
+    """
+    unshard_stream.wait_stream(computation_stream)
+    # Having the pre-all-gather stream wait for the current stream even if we
+    # do not leverage the pre-all-gather stream is tolerable since this only
+    # runs once per iteration
+    pre_unshard_stream.wait_stream(computation_stream)
+
+
+def _clear_grads_if_needed(
+    handles: List[FlatParamHandle],
+):
+    """
+    Clears the original parameters' gradients if needed. This method's CPU
+    overhead is minimal, so we may call it throughout FSDP methods, which serve
+    as callsites to free the gradient memory earlier.
+    """
+    for handle in handles:
+        if handle._use_orig_params:
+            handle._clear_grads_if_needed()
+
+
+def _prepare_forward_inputs(
+    device: torch.device,
+    input_dtype: Optional[torch.dtype],
+    *args: Any,
+    **kwargs: Any,
+) -> Tuple[Any, Any]:
+    """
+    Prepares the forward inputs by moving them to ``device`` and casting them
+    to ``input_dtype`` if it is not ``None``.
+    """
+    # TODO: Do not use the side stream for tensor copies for now; investigate
+    # the perf with/without it.
+    # TODO: For mixed precision, move the inputs to the compute device and cast
+    # to reduced-precision in a single `to()` call.
+    args_tuple, kwargs_tuple = _to_kwargs(args, kwargs, device.index, False)
+    args = args_tuple[0]
+    kwargs = kwargs_tuple[0]
+    if input_dtype is not None:
+        args, kwargs = _cast_fp_inputs_to_dtype(input_dtype, *args, **kwargs)
+    return args, kwargs
+
+
+def _cast_fp_inputs_to_dtype(
+    dtype: torch.dtype,
+    *args: Any,
+    **kwargs: Any,
+) -> Tuple[Any, Any]:
+    """
+    Casts floating point tensors in ``args`` and ``kwargs`` to ``input_dtype``.
+    This respects the existing ``requires_grad`` on the tensors.
+    """
+
+    def cast_fn(x: torch.Tensor) -> torch.Tensor:
+        if not torch.is_floating_point(x):
+            return x
+        y = x.to(dtype)
+        # Explicitly copy over `requires_grad` since this runs inside
+        # `torch.no_grad()`
+        if x.is_leaf:
+            y.requires_grad = x.requires_grad
+        return y
+
+    with torch.no_grad():
+        return (_apply_to_tensors(cast_fn, args), _apply_to_tensors(cast_fn, kwargs))

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -37,7 +37,12 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 )
 from torch.distributed.algorithms._comm_hooks import default_hooks, LOW_PRECISION_HOOKS
 from torch.distributed.distributed_c10d import _get_default_group
-from torch.distributed.utils import _sync_params_and_buffers, _to_kwargs
+from torch.distributed.fsdp._runtime_utils import (
+    _clear_grads_if_needed,
+    _prepare_forward_inputs,
+    _wait_for_computation_stream,
+)
+from torch.distributed.utils import _sync_params_and_buffers
 
 from ._optim_utils import (
     _broadcast_pos_dim_tensor_states,
@@ -1687,6 +1692,18 @@ class FullyShardedDataParallel(nn.Module):
             and (not root_only or submodule.check_is_root())
         ]
 
+    @staticmethod
+    def _fsdp_handles(module: nn.Module) -> List[FlatParamHandle]:
+        """
+        Returns all nested FSDP instances' handles in the module hierarchy
+        rooted at ``module``.
+        """
+        return [
+            handle
+            for fsdp_module in FullyShardedDataParallel.fsdp_modules(module)
+            for handle in fsdp_module._handles
+        ]
+
     def apply(self, fn: Callable[[nn.Module], None]) -> "FullyShardedDataParallel":
         r"""Applies ``fn`` recursively to every submodule (as returned by ``.children()``)
         as well as self. Typical use includes initializing the parameters of a model
@@ -1750,31 +1767,6 @@ class FullyShardedDataParallel(nn.Module):
             self._communication_hook is not None
             and self._communication_hook in LOW_PRECISION_HOOKS
         )
-
-    def _cast_fp_inputs_to_dtype(
-        self, dtype: torch.dtype, *args: Any, **kwargs: Any
-    ) -> Tuple[Any, Any]:
-        """
-        Casts floating point tensors in ``args`` and ``kwargs`` to the
-        precision given by ``dtype``, while respecting the existing
-        ``requires_grad`` on the tensors.
-        """
-
-        def cast_fn(x: torch.Tensor) -> torch.Tensor:
-            if not torch.is_floating_point(x):
-                return x
-            y = x.to(dtype)
-            # Explicitly copy over `requires_grad` since this runs inside
-            # `torch.no_grad()`
-            if x.is_leaf:
-                y.requires_grad = x.requires_grad
-            return y
-
-        with torch.no_grad():
-            return (
-                _apply_to_tensors(cast_fn, args),
-                _apply_to_tensors(cast_fn, kwargs),
-            )
 
     def _cast_buffers(
         self,
@@ -2033,21 +2025,6 @@ class FullyShardedDataParallel(nn.Module):
         # Stream for pre-unshard logic, namely allocations and writes for
         # CPU offloading (H2D copy) and mixed precision (low precision cast).
         self._streams["pre_unshard"] = torch.cuda.Stream()
-
-    def _wait_for_previous_optim_step(self) -> None:
-        """
-        The root :class:`FullyShardedDataParallel` instance needs to
-        synchronize with the default stream to ensure that the previous
-        optimizer step is done.
-        """
-        if not self._is_root:
-            return
-        current_stream = torch.cuda.current_stream()
-        self._streams["unshard"].wait_stream(current_stream)
-        # Having the pre-all-gather stream wait for the current stream even if
-        # we do not leverage the pre-all-gather stream is tolerable since this
-        # only runs once per iteration
-        self._streams["pre_unshard"].wait_stream(current_stream)
 
     def _prefetch_handles(
         self,
@@ -2331,7 +2308,8 @@ class FullyShardedDataParallel(nn.Module):
         if torch.cuda.is_available():
             torch.cuda.synchronize()
         self._lazy_init()
-        self._clear_grads_if_needed()
+        if self._is_root:
+            _clear_grads_if_needed(self._fsdp_handles(self))
         if self._state_dict_type == StateDictType.FULL_STATE_DICT:
             # Get config args
             full_state_dict_config = (
@@ -2506,25 +2484,6 @@ class FullyShardedDataParallel(nn.Module):
             handle._training_state = HandleTrainingState.IDLE
         return output
 
-    def _cast_forward_inputs(self, *args, **kwargs):
-        """Moves the forward inputs to the compute device and casts them to the
-        appropriate dtype if needed."""
-        # TODO: Do not use the side stream for tensor copies for now;
-        # investigate the perf with/without it
-        # TODO: For mixed precision, move the inputs to the compute device and
-        # cast to reduced-precision in a single `to()` call
-        args, kwargs = _to_kwargs(args, kwargs, self.compute_device.index, False)
-        args = args[0]
-        kwargs = kwargs[0]
-        if self._mixed_precision_enabled_for_params():
-            input_dtype = self.mixed_precision.param_dtype
-            args, kwargs = self._cast_fp_inputs_to_dtype(
-                input_dtype,
-                *args,
-                **kwargs,
-            )
-        return args, kwargs
-
     def _fsdp_root_pre_forward(self, *args, **kwargs):
         """
         Runs pre-forward logic specific to the root FSDP instance, which should
@@ -2541,24 +2500,21 @@ class FullyShardedDataParallel(nn.Module):
                 handles_key = tuple(fsdp_module._handles)
                 if handles_key:
                     self._needs_pre_forward_unshard[handles_key] = True
-        self._wait_for_previous_optim_step()
-        self._clear_grads_if_needed()
-        args, kwargs = self._cast_forward_inputs(*args, **kwargs)
+        _wait_for_computation_stream(
+            torch.cuda.current_stream(),
+            self._streams["unshard"],
+            self._streams["pre_unshard"],
+        )
+        _clear_grads_if_needed(self._fsdp_handles(self))
+        input_dtype = (
+            self.mixed_precision.param_dtype
+            if self._mixed_precision_enabled_for_params()
+            else None
+        )
+        args, kwargs = _prepare_forward_inputs(
+            self.compute_device, input_dtype, *args, **kwargs
+        )
         return args, kwargs
-
-    def _clear_grads_if_needed(self):
-        """
-        Iterates over all handles to clear original parameter gradients if
-        needed. See :meth:`FlatParamHandle._clear_grads_if_needed` for details.
-        Since this method's CPU overhead is minimal, we may call throughout
-        FSDP methods, which may serve as callsites to free the gradient memory
-        earlier.
-        """
-        if not self._use_orig_params or not self._is_root:
-            return
-        for fsdp_module in self.fsdp_modules(self):
-            for handle in fsdp_module._handles:
-                handle._clear_grads_if_needed()
 
     @staticmethod
     @contextlib.contextmanager
@@ -2707,7 +2663,8 @@ class FullyShardedDataParallel(nn.Module):
         for handle in self._handles:
             handle._training_state = HandleTrainingState.SUMMON_FULL_PARAMS
 
-        self._clear_grads_if_needed()
+        if self._is_root:
+            _clear_grads_if_needed(self._fsdp_handles(self))
         free_unsharded_flat_params = [
             handle.needs_unshard() for handle in self._handles
         ]
@@ -2723,16 +2680,9 @@ class FullyShardedDataParallel(nn.Module):
             self._reshard(self._handles, free_unsharded_flat_params)
             if with_grads:
                 self._reshard_grads(self._handles)
-            try:
-                yield
-            finally:
-                self.training_state = TrainingState_.IDLE
-                for handle in self._handles:
-                    handle._training_state = HandleTrainingState.IDLE
         else:
             # Unflatten the unsharded flattened parameters
             with contextlib.ExitStack() as stack:
-                # Invariant: rank == 0 or !rank0_only
                 for handle in self._handles:
                     if offload_to_cpu and handle.uses_sharded_strategy:
                         stack.enter_context(handle.to_cpu())
@@ -3006,7 +2956,7 @@ class FullyShardedDataParallel(nn.Module):
                 # that it is called after all backward calls complete
                 if self._is_root and not self._post_backward_callback_queued:
                     self._queue_wait_for_post_backward()
-                    self._clear_grads_if_needed()
+                    _clear_grads_if_needed(self._fsdp_handles(self))
                 elif _handles_key:
                     self._assert_state([TrainingState_.IDLE])
                 self.training_state = TrainingState_.BACKWARD_PRE
@@ -3527,12 +3477,16 @@ class FullyShardedDataParallel(nn.Module):
             collective communications.
         """
         self._lazy_init()
-        self._wait_for_previous_optim_step()
         if not self._is_root:
             raise RuntimeError(
                 "`clip_grad_norm_()` should only be called on the root FSDP instance"
             )
         self._assert_state(TrainingState_.IDLE)
+        _wait_for_computation_stream(
+            torch.cuda.current_stream(),
+            self._streams["unshard"],
+            self._streams["pre_unshard"],
+        )
 
         max_norm = float(max_norm)
         norm_type = float(norm_type)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #87942 [FSDP()][27/N] Add forward hook registration
* #87941 [FSDP()][26/N] Move `_lazy_init()` into `_fsdp_root_pre_forward()`
* #87940 [FSDP()][25/N] Add `_post_forward_reshard()`
* #87939 [FSDP()][24/N] Refactor `_lazy_init()`
* #87938 [FSDP()][23/N] Refactor handle attr initialization
* #87937 [FSDP] Simplify `_reset_lazy_init()`
* #87936 [FSDP()][22/N] Refactor `_cast_buffers()` in `_lazy_init()`
* #87935 [FSDP()][21/N] Refactor `_buffer_name_to_orig_dtype` computation
* #87934 [FSDP] Rename `dtype` to `buffer_name_to_dtype`
* #87933 [FSDP] Remove `device` arg from `_cast_buffers()`
* #87932 [FSDP()][20/N][Easy] Move functions in file
* #87931 [FSDP()][18/N] Refactor `pre_forward_unshard()`
* #87930 [FSDP()][17/N] Refactor `_fsdp_root_pre_forward()`
* #87929 [FSDP()][16/N] Refactor post-forward/pre-backward
* #87928 [FSDP()][15/N] Refactor `_init_streams()`
* #87927 [FSDP()][14/N] Refactor pre-forward/post-backward
* #87926 [FSDP()][13/N] Refactor unshard/reshard/grads
* #87925 [FSDP()][12/N] Easy cleanup
* #87924 [FSDP()][10/N][11/N] Introduce composable (ctor only)
* #87923 [FSDP()][9/N] Refactor ctor (continued)
* #87922 [FSDP()][8/N] Refactor limiter's `_FreeEventQueue`
* #87921 [FSDP()][7/N] Refactor most of ctor
* #87920 [FSDP()][6/N] Refactor `CPUOffload` dataclass
* #87919 [FSDP()][5/N] Refactor `MixedPrecision` dataclass
* #87918 [FSDP()][4/N] Refactor `ShardingStrategy` enum
* #87917 [FSDP()][3/N] Refactor `BackwardPrefetch` enum
* #87916 [FSDP()][2/N] Refactor training state
* **#87915 [FSDP()][1/N] Start refactoring FSDP root pre-forward**
* #87812 [FSDP] ufmt FSDP test
* #87811 [FSDP] ufmt /fsdp

Welcome! This PR starts the refactoring journey.