### PR TITLE
[FSDP()][2/N] Refactor training state

### DIFF
--- a/test/distributed/fsdp/test_fsdp_summon_full_params.py
+++ b/test/distributed/fsdp/test_fsdp_summon_full_params.py
@@ -212,7 +212,7 @@ class TestSummonFullParams(FSDPTest):
 
         model = FSDP(MyModule()).cuda(self.rank)
         with self.assertRaisesRegex(
-            ValueError, "current state is TrainingState_.FORWARD"
+            ValueError, "current state is TrainingState.FORWARD"
         ):
             model(model)
 
@@ -231,7 +231,7 @@ class TestSummonFullParams(FSDPTest):
         output.register_hook(bad_backwards_hook)
 
         with self.assertRaisesRegex(
-            ValueError, "current state is TrainingState_.BACKWARD_PRE"
+            ValueError, "current state is TrainingState.BACKWARD_PRE"
         ):
             output.backward()
 

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -1,0 +1,23 @@
+from enum import auto, Enum
+
+
+class TrainingState(Enum):
+    """
+    An enum that indicates the state of a ``FullyShardedDataParallel` instance.
+    """
+
+    IDLE = auto()
+    FORWARD_BACKWARD = auto()
+    SUMMON_FULL_PARAMS = auto()
+
+
+class HandleTrainingState(Enum):
+    """
+    An enum that indicates the state of a ``FlatParamHandle`.
+    """
+
+    IDLE = auto()
+    FORWARD = auto()
+    BACKWARD_PRE = auto()
+    BACKWARD_POST = auto()
+    SUMMON_FULL_PARAMS = auto()

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -8,7 +8,7 @@ import torch.distributed as dist
 import torch.distributed.algorithms._checkpoint.checkpoint_wrapper as checkpoint_wrapper
 
 # Import the entire FSDP file to avoid circular imports
-import torch.distributed.fsdp.fully_sharded_data_parallel as FSDP
+import torch.distributed.fsdp.fully_sharded_data_parallel as fsdp_file
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed._shard.sharded_tensor import (
@@ -37,8 +37,8 @@ def _full_post_state_dict_hook(
     back to sharded version after _summon_full_params ends, and also remove
     the ``FSDP_WRAPPED_MODULE`` prefix.
     """
-    _replace_by_prefix(state_dict, prefix + f"{FSDP.FSDP_PREFIX}", prefix)
-    module._assert_state([FSDP.TrainingState_.SUMMON_FULL_PARAMS])
+    _replace_by_prefix(state_dict, prefix + f"{fsdp_file.FSDP_PREFIX}", prefix)
+    module._assert_state([fsdp_file.TrainingState.SUMMON_FULL_PARAMS])
     # Return early for trivial cases
     if not state_dict or not module._has_params:
         return state_dict
@@ -52,7 +52,8 @@ def _full_post_state_dict_hook(
     # exiting `summon_full_params()` via the parameter shape. However, for
     # `NO_SHARD`, we cannot tell from the shape, so we do not return early.
     if (
-        not module._use_orig_params and FSDP.FLAT_PARAM in module.module._parameters
+        not module._use_orig_params
+        and fsdp_file.FLAT_PARAM in module.module._parameters
     ) or (
         module._use_orig_params
         and module._handles
@@ -69,7 +70,7 @@ def _full_post_state_dict_hook(
     for fqn, param_name, module_name in module._param_fqns:
         fqn = f"{prefix}{fqn}"
         clean_key = fqn
-        clean_prefix = FSDP.clean_tensor_name(prefix)
+        clean_prefix = fsdp_file.clean_tensor_name(prefix)
         # Strip prefix out of key if needed as buffer names and param names
         # do not have prefix considered as they are not computed in `state_dict`
         # call.
@@ -129,12 +130,12 @@ def _full_pre_load_state_dict_hook(
     # Note that it needs writeback=True to persist.
     module._full_param_ctx = module._summon_full_params(recurse=False, writeback=True)
     module._full_param_ctx.__enter__()
-    _replace_by_prefix(state_dict, prefix, prefix + f"{FSDP.FSDP_PREFIX}")
+    _replace_by_prefix(state_dict, prefix, prefix + f"{fsdp_file.FSDP_PREFIX}")
 
 
 def _full_post_load_state_dict_hook(module, *args, **kwargs) -> None:
     # We should exit summon_full_params context.
-    module._assert_state([FSDP.TrainingState_.SUMMON_FULL_PARAMS])
+    module._assert_state([fsdp_file.TrainingState.SUMMON_FULL_PARAMS])
     assert getattr(module, "_full_param_ctx", None) is not None
     module._full_param_ctx.__exit__(None, None, None)
     module._full_param_ctx = None
@@ -150,7 +151,7 @@ def _local_post_state_dict_hook(
     the state_dict[f"{prefix}{FLAT_PARAM}] with the ShardedTensor. No copy
     will happen. The underlying storage is the same.
     """
-    _replace_by_prefix(state_dict, f"{prefix}{FSDP.FSDP_PREFIX}", prefix)
+    _replace_by_prefix(state_dict, f"{prefix}{fsdp_file.FSDP_PREFIX}", prefix)
     if not module._has_params:
         return state_dict
 
@@ -174,7 +175,7 @@ def _local_post_state_dict_hook(
     )  # type: ignore[assignment]
     if module._state_dict_config.offload_to_cpu:
         sharded_tensor = sharded_tensor.cpu()
-    state_dict[f"{prefix}{FSDP.FLAT_PARAM}"] = sharded_tensor
+    state_dict[f"{prefix}{fsdp_file.FLAT_PARAM}"] = sharded_tensor
     return state_dict
 
 
@@ -192,8 +193,8 @@ def _local_pre_load_state_dict_hook(
     state_dict. The flat_param should be a ShardedTensor. This hook converts
     the ShardedTensor to a tensor. No copy happen unless padding is required.
     """
-    _replace_by_prefix(state_dict, prefix, f"{prefix}{FSDP.FSDP_PREFIX}")
-    fqn = f"{prefix}{FSDP.FSDP_PREFIX}{FSDP.FLAT_PARAM}"
+    _replace_by_prefix(state_dict, prefix, f"{prefix}{fsdp_file.FSDP_PREFIX}")
+    fqn = f"{prefix}{fsdp_file.FSDP_PREFIX}{fsdp_file.FLAT_PARAM}"
     if fqn not in state_dict:
         assert not module._has_params, (
             "No `FlatParameter` in `state_dict` for this FSDP instance "
@@ -232,11 +233,11 @@ def _sharded_post_state_dict_hook(
     The hook replaces the unflattened, unsharded parameter in the state_dict
     with a unflattened, sharded parameter (a ShardedTensor).
     """
-    _replace_by_prefix(state_dict, f"{prefix}{FSDP.FSDP_PREFIX}", prefix)
+    _replace_by_prefix(state_dict, f"{prefix}{fsdp_file.FSDP_PREFIX}", prefix)
     if not module._has_params:
         return state_dict
 
-    assert module.training_state != FSDP.TrainingState_.SUMMON_FULL_PARAMS, (
+    assert module.training_state != fsdp_file.TrainingState.SUMMON_FULL_PARAMS, (
         "Inside _sharded_post_state_dict_hook, the training_state must "
         "not be SUMMON_FULL_PARAMS."
     )
@@ -257,7 +258,7 @@ def _sharded_post_state_dict_hook(
     # For `use_orig_params=True`, the `FlatParameter` is not registered, so
     # there is no entry in the state dict for it to pop.
     if not module._use_orig_params:
-        state_dict.pop(f"{prefix}{FSDP.FLAT_PARAM}")
+        state_dict.pop(f"{prefix}{fsdp_file.FLAT_PARAM}")
     return state_dict
 
 
@@ -275,7 +276,7 @@ def _sharded_pre_load_state_dict_hook(
     The hook combines the unflattened, sharded parameters (ShardedTensor) to
     a new FlatParameter and shards the new FlatParameter to the local chunk.
     """
-    _replace_by_prefix(state_dict, prefix, prefix + f"{FSDP.FSDP_PREFIX}")
+    _replace_by_prefix(state_dict, prefix, prefix + f"{fsdp_file.FSDP_PREFIX}")
     if not module._has_params:
         return
 
@@ -289,7 +290,7 @@ def _sharded_pre_load_state_dict_hook(
     shared_fqns = [fqn for fqn, _, _ in module._shared_param_fqns]
     loaded_shapes = []
     for fqn, _, _ in module._param_fqns:
-        full_fqn = f"{prefix}{FSDP.FSDP_PREFIX}{fqn}"
+        full_fqn = f"{prefix}{fsdp_file.FSDP_PREFIX}{fqn}"
         param = state_dict.pop(full_fqn)
         if fqn in shared_fqns:
             continue
@@ -347,7 +348,9 @@ def _sharded_pre_load_state_dict_hook(
         f"The loaded local chunk has different padding({num_to_pad}) "
         f"from the local chunk {flat_param._shard_numel_padded}."
     )
-    state_dict[f"{prefix}{FSDP.FSDP_PREFIX}{FSDP.FLAT_PARAM}"] = loaded_flat_tensor
+    state_dict[
+        f"{prefix}{fsdp_file.FSDP_PREFIX}{fsdp_file.FLAT_PARAM}"
+    ] = loaded_flat_tensor
     if module._use_orig_params:
         module._deregister_orig_params()
 
@@ -365,11 +368,11 @@ def _post_state_dict_hook(
     what postprocessing will be done.
     """
     _post_state_dict_hook_fn = {
-        FSDP.StateDictType.FULL_STATE_DICT: _full_post_state_dict_hook,
-        FSDP.StateDictType.LOCAL_STATE_DICT: _local_post_state_dict_hook,
-        FSDP.StateDictType.SHARDED_STATE_DICT: _sharded_post_state_dict_hook,
+        fsdp_file.StateDictType.FULL_STATE_DICT: _full_post_state_dict_hook,
+        fsdp_file.StateDictType.LOCAL_STATE_DICT: _local_post_state_dict_hook,
+        fsdp_file.StateDictType.SHARDED_STATE_DICT: _sharded_post_state_dict_hook,
     }
-    fsdp_module = cast(FSDP.FullyShardedDataParallel, module)
+    fsdp_module = cast(fsdp_file.FullyShardedDataParallel, module)
     processed_state_dict = _post_state_dict_hook_fn[fsdp_module._state_dict_type](
         fsdp_module, state_dict, prefix
     )
@@ -395,12 +398,12 @@ def _pre_load_state_dict_hook(
     will be done.
     """
     _pre_load_state_dict_hook_fn = {
-        FSDP.StateDictType.FULL_STATE_DICT: _full_pre_load_state_dict_hook,
-        FSDP.StateDictType.LOCAL_STATE_DICT: _local_pre_load_state_dict_hook,
-        FSDP.StateDictType.SHARDED_STATE_DICT: _sharded_pre_load_state_dict_hook,
+        fsdp_file.StateDictType.FULL_STATE_DICT: _full_pre_load_state_dict_hook,
+        fsdp_file.StateDictType.LOCAL_STATE_DICT: _local_pre_load_state_dict_hook,
+        fsdp_file.StateDictType.SHARDED_STATE_DICT: _sharded_pre_load_state_dict_hook,
     }
     # Code that is common for all state_dict impls
-    fsdp_module = cast(FSDP.FullyShardedDataParallel, module)
+    fsdp_module = cast(fsdp_file.FullyShardedDataParallel, module)
     if torch.cuda.is_available():
         torch.cuda.synchronize()
     # Dispatch into state_dict specific implementation of pre-hook.
@@ -412,12 +415,12 @@ def _pre_load_state_dict_hook(
 @torch.no_grad()
 def _post_load_state_dict_hook(module: nn.Module, *args: Any) -> None:
     _post_load_state_dict_hook_fn = {
-        FSDP.StateDictType.FULL_STATE_DICT: _full_post_load_state_dict_hook,
-        FSDP.StateDictType.LOCAL_STATE_DICT: _local_post_load_state_dict_hook,
-        FSDP.StateDictType.SHARDED_STATE_DICT: _sharded_post_load_state_dict_hook,
+        fsdp_file.StateDictType.FULL_STATE_DICT: _full_post_load_state_dict_hook,
+        fsdp_file.StateDictType.LOCAL_STATE_DICT: _local_post_load_state_dict_hook,
+        fsdp_file.StateDictType.SHARDED_STATE_DICT: _sharded_post_load_state_dict_hook,
     }
     # Code that is common for all state_dict impls
-    fsdp_module = cast(FSDP.FullyShardedDataParallel, module)
+    fsdp_module = cast(fsdp_file.FullyShardedDataParallel, module)
     # Dispatch into state_dict type specific implementation of post-hook for
     # loading state_dict.
     _post_load_state_dict_hook_fn[fsdp_module._state_dict_type](fsdp_module)

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -23,6 +23,7 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
+from torch.distributed.fsdp._common_utils import HandleTrainingState
 
 from ._fsdp_extensions import _ext_post_unflatten_transform, _ext_pre_flatten_transform
 from ._utils import (
@@ -41,7 +42,6 @@ __all__ = [
     "SharedParamInfo",
     "HandleConfig",
     "HandleShardingStrategy",
-    "HandleTrainingState",
 ]
 
 
@@ -101,14 +101,6 @@ class HandleShardingStrategy(Enum):
     FULL_SHARD = auto()
     SHARD_GRAD_OP = auto()
     NO_SHARD = auto()
-
-
-class HandleTrainingState(Enum):
-    IDLE = auto()
-    FORWARD = auto()
-    BACKWARD_PRE = auto()
-    BACKWARD_POST = auto()
-    SUMMON_FULL_PARAMS = auto()
 
 
 @dataclass

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -37,6 +37,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 )
 from torch.distributed.algorithms._comm_hooks import default_hooks, LOW_PRECISION_HOOKS
 from torch.distributed.distributed_c10d import _get_default_group
+from torch.distributed.fsdp._common_utils import HandleTrainingState, TrainingState
 from torch.distributed.fsdp._runtime_utils import (
     _clear_grads_if_needed,
     _prepare_forward_inputs,
@@ -75,7 +76,6 @@ from .flat_param import (
     FlatParamHandle,
     HandleConfig,
     HandleShardingStrategy,
-    HandleTrainingState,
 )
 from .wrap import (
     _or_policy,
@@ -109,7 +109,6 @@ __all__ = [
     "LocalStateDictConfig",
     "ShardedStateDictConfig",
     "OptimStateKeyType",
-    "TrainingState_",
     "clean_tensor_name",
 ]
 
@@ -258,24 +257,6 @@ class BackwardPrefetch(Enum):
     BACKWARD_PRE = auto()
     BACKWARD_POST = auto()
     # TODO, BACKWARD_PRE_CPU, prefetch full parameters and keep them in the CPU memory
-
-
-class TrainingState_(Enum):
-    """
-    Simple enum to indicate what state FSDP is in. Used for asserting
-    to make sure APIs are called in the correct state.
-    ..note::
-        ``BACKWARD_PRE`` and ``BACKWARD_POST`` states are used to ensure we
-        receives backward hooks in the correct order. It is used to catch
-        unexpected order of hooks being called (likely due to our
-        hook registration logic or autograd engine logic changes).
-    """
-
-    IDLE = auto()
-    FORWARD = auto()
-    BACKWARD_PRE = auto()
-    BACKWARD_POST = auto()
-    SUMMON_FULL_PARAMS = auto()
 
 
 class StateDictType(Enum):
@@ -1059,7 +1040,7 @@ class FullyShardedDataParallel(nn.Module):
         self.process_group = process_group or _get_default_group()
         self.rank = self.process_group.rank()
         self.world_size = self.process_group.size()
-        self.training_state = TrainingState_.IDLE
+        self.training_state = TrainingState.IDLE
         self.cpu_offload = cpu_offload or CPUOffload()
         self.backward_prefetch = backward_prefetch
         self.forward_prefetch = forward_prefetch
@@ -1720,7 +1701,7 @@ class FullyShardedDataParallel(nn.Module):
             Module: self
         """
         uninitialized = self._is_root is None
-        self._assert_state(TrainingState_.IDLE)
+        self._assert_state(TrainingState.IDLE)
         with self._summon_full_params(recurse=False, writeback=True):
             ret = super().apply(fn)
 
@@ -1866,7 +1847,7 @@ class FullyShardedDataParallel(nn.Module):
         # The following logic is only run on the root FSDP instance since it
         # will set `_is_root=False` for the non-root instances
         self._is_root = True
-        self._assert_state(TrainingState_.IDLE)
+        self._assert_state(TrainingState.IDLE)
         self._init_streams()
         self._cast_buffers(recurse=True)
         for handle in self._handles:
@@ -2326,7 +2307,7 @@ class FullyShardedDataParallel(nn.Module):
                     offload_to_cpu=offload_to_cpu,
                     rank0_only=rank0_only,
                 )
-                if self.training_state != TrainingState_.SUMMON_FULL_PARAMS
+                if self.training_state != TrainingState.SUMMON_FULL_PARAMS
                 else contextlib.suppress()
             )
             with summon_ctx:
@@ -2420,7 +2401,7 @@ class FullyShardedDataParallel(nn.Module):
             module (nn.Module): Unused; expected by the hook signature.
             input (Any): Unused; expected by the hook signature.
         """
-        self.training_state = TrainingState_.FORWARD
+        self.training_state = TrainingState.FORWARD_BACKWARD
         self._exec_order_data.record_pre_forward(handles, self.training)
         for handle in handles:
             handle._training_state = HandleTrainingState.FORWARD
@@ -2479,7 +2460,7 @@ class FullyShardedDataParallel(nn.Module):
         # Register pre-backward hooks to unshard the flattened parameters
         # for the gradient computation (if needed)
         output = self._register_pre_backward_hooks(output, handles)
-        self.training_state = TrainingState_.IDLE
+        self.training_state = TrainingState.IDLE
         for handle in handles:
             handle._training_state = HandleTrainingState.IDLE
         return output
@@ -2656,10 +2637,10 @@ class FullyShardedDataParallel(nn.Module):
 
         torch.cuda.synchronize()
         self._lazy_init()
-        self._assert_state([TrainingState_.IDLE])
+        self._assert_state([TrainingState.IDLE])
         for handle in self._handles:
             assert handle._training_state == HandleTrainingState.IDLE
-        self.training_state = TrainingState_.SUMMON_FULL_PARAMS
+        self.training_state = TrainingState.SUMMON_FULL_PARAMS
         for handle in self._handles:
             handle._training_state = HandleTrainingState.SUMMON_FULL_PARAMS
 
@@ -2680,6 +2661,12 @@ class FullyShardedDataParallel(nn.Module):
             self._reshard(self._handles, free_unsharded_flat_params)
             if with_grads:
                 self._reshard_grads(self._handles)
+            try:
+                yield
+            finally:
+                self.training_state = TrainingState.IDLE
+                for handle in self._handles:
+                    handle._training_state = HandleTrainingState.IDLE
         else:
             # Unflatten the unsharded flattened parameters
             with contextlib.ExitStack() as stack:
@@ -2702,7 +2689,7 @@ class FullyShardedDataParallel(nn.Module):
                     self._reshard(self._handles, free_unsharded_flat_params)
                     if with_grads:
                         self._reshard_grads(self._handles)
-                    self.training_state = TrainingState_.IDLE
+                    self.training_state = TrainingState.IDLE
                     for handle in self._handles:
                         handle._training_state = HandleTrainingState.IDLE
 
@@ -2879,7 +2866,7 @@ class FullyShardedDataParallel(nn.Module):
         when inside the :meth:`summon_full_params` context manager.
         """
         should_clean_name = (
-            self.training_state == TrainingState_.SUMMON_FULL_PARAMS
+            self.training_state == TrainingState.SUMMON_FULL_PARAMS
             or self._use_orig_params
         )
         for buffer_name, buffer in super().named_buffers(*args, **kwargs):
@@ -2900,7 +2887,7 @@ class FullyShardedDataParallel(nn.Module):
         when inside the :meth:`summon_full_params` context manager.
         """
         should_clean_name = (
-            self.training_state == TrainingState_.SUMMON_FULL_PARAMS
+            self.training_state == TrainingState.SUMMON_FULL_PARAMS
             or self._use_orig_params
         )
         for param_name, param in super().named_parameters(*args, **kwargs):
@@ -2958,8 +2945,8 @@ class FullyShardedDataParallel(nn.Module):
                     self._queue_wait_for_post_backward()
                     _clear_grads_if_needed(self._fsdp_handles(self))
                 elif _handles_key:
-                    self._assert_state([TrainingState_.IDLE])
-                self.training_state = TrainingState_.BACKWARD_PRE
+                    self._assert_state([TrainingState.IDLE])
+                self.training_state = TrainingState.FORWARD_BACKWARD
                 # Queueing the post-backward callback is the only logic that is
                 # not per-handle in the pre-backward hook, so we can return
                 # early here if there are no handles.
@@ -3052,12 +3039,12 @@ class FullyShardedDataParallel(nn.Module):
         with torch.autograd.profiler.record_function(
             "FullyShardedDataParallel._post_backward_hook"
         ):
-            # First hook callback will see PRE state. If we have multiple params,
-            # then subsequent hook callbacks will see POST state.
-            self._assert_state(
-                [TrainingState_.BACKWARD_PRE, TrainingState_.BACKWARD_POST]
+            self._assert_state([TrainingState.FORWARD_BACKWARD])
+            self.training_state = TrainingState.FORWARD_BACKWARD
+            p_assert(
+                handle._training_state == HandleTrainingState.BACKWARD_PRE,
+                f"Expects `BACKWARD_PRE` state but got {handle._training_state}",
             )
-            self.training_state = TrainingState_.BACKWARD_POST
             handle._training_state = HandleTrainingState.BACKWARD_POST
 
             if (
@@ -3230,7 +3217,7 @@ class FullyShardedDataParallel(nn.Module):
         However, if a low precision communication hook is registered, then this
         dtype cast happens in the hook instead.
         """
-        self._assert_state(TrainingState_.BACKWARD_POST)
+        self._assert_state(TrainingState.FORWARD_BACKWARD)
         if not self._low_precision_hook_enabled() and (
             self._mixed_precision_enabled_for_params()
             or self._mixed_precision_enabled_for_reduce()
@@ -3257,7 +3244,7 @@ class FullyShardedDataParallel(nn.Module):
         )
         if self._post_backward_callback_queued:
             return
-        self._assert_state([TrainingState_.IDLE])
+        self._assert_state([TrainingState.IDLE])
         self._post_backward_callback_queued = True
         Variable._execution_engine.queue_callback(self._wait_for_post_backward)
 
@@ -3351,7 +3338,7 @@ class FullyShardedDataParallel(nn.Module):
             _catch_all_reshard(m)
             _finalize_params(m)
             m._ran_pre_backward_hook.clear()
-            m.training_state = TrainingState_.IDLE
+            m.training_state = TrainingState.IDLE
             for handle in m._handles:
                 handle._training_state = HandleTrainingState.IDLE
             m._handles_prefetched.clear()
@@ -3390,12 +3377,12 @@ class FullyShardedDataParallel(nn.Module):
         # TODO (linjianma): Patch the forward of each model in the keys
         # of fsdp_wrap_map based on the information above.
 
-    def _assert_state(self, state: Union[TrainingState_, List[TrainingState_]]) -> None:
+    def _assert_state(self, state: Union[TrainingState, List[TrainingState]]) -> None:
         """Assert we are in the given state."""
         # Since assert can be turned off and this error checking
         # is really important, we use explicit error checking
         # and raise a ValueError if needed.
-        if isinstance(state, TrainingState_):
+        if isinstance(state, TrainingState):
             state = [state]
         if self.training_state not in state:
             msg = (
@@ -3433,7 +3420,7 @@ class FullyShardedDataParallel(nn.Module):
             raise RuntimeError(
                 "`no_sync()` on inner FSDP instances is not supported. Please call `no_sync()` on root FSDP module."
             )
-        self._assert_state(TrainingState_.IDLE)
+        self._assert_state(TrainingState.IDLE)
         old_flags = []
         for m in self.modules():
             if isinstance(m, FullyShardedDataParallel):
@@ -3481,7 +3468,7 @@ class FullyShardedDataParallel(nn.Module):
             raise RuntimeError(
                 "`clip_grad_norm_()` should only be called on the root FSDP instance"
             )
-        self._assert_state(TrainingState_.IDLE)
+        self._assert_state(TrainingState.IDLE)
         _wait_for_computation_stream(
             torch.cuda.current_stream(),
             self._streams["unshard"],

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -14,11 +14,11 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.fsdp import CPUOffload, FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp._common_utils import TrainingState
 from torch.distributed.fsdp.fully_sharded_data_parallel import (
     BackwardPrefetch,
     MixedPrecision,
     ShardingStrategy,
-    TrainingState_,
 )
 from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 from torch.distributed.fsdp.wrap import (
@@ -884,7 +884,7 @@ class FSDPTest(MultiProcessTestCase):
                 model.load_state_dict(state_dict)
 
         if isinstance(model, FSDP):
-            model._assert_state(TrainingState_.IDLE)
+            model._assert_state(TrainingState.IDLE)
         return loss.detach()
 
     def _test_fsdp_parity(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #87942 [FSDP()][27/N] Add forward hook registration
* #87941 [FSDP()][26/N] Move `_lazy_init()` into `_fsdp_root_pre_forward()`
* #87940 [FSDP()][25/N] Add `_post_forward_reshard()`
* #87939 [FSDP()][24/N] Refactor `_lazy_init()`
* #87938 [FSDP()][23/N] Refactor handle attr initialization
* #87937 [FSDP] Simplify `_reset_lazy_init()`
* #87936 [FSDP()][22/N] Refactor `_cast_buffers()` in `_lazy_init()`
* #87935 [FSDP()][21/N] Refactor `_buffer_name_to_orig_dtype` computation
* #87934 [FSDP] Rename `dtype` to `buffer_name_to_dtype`
* #87933 [FSDP] Remove `device` arg from `_cast_buffers()`
* #87932 [FSDP()][20/N][Easy] Move functions in file
* #87931 [FSDP()][18/N] Refactor `pre_forward_unshard()`
* #87930 [FSDP()][17/N] Refactor `_fsdp_root_pre_forward()`
* #87929 [FSDP()][16/N] Refactor post-forward/pre-backward
* #87928 [FSDP()][15/N] Refactor `_init_streams()`
* #87927 [FSDP()][14/N] Refactor pre-forward/post-backward
* #87926 [FSDP()][13/N] Refactor unshard/reshard/grads
* #87925 [FSDP()][12/N] Easy cleanup
* #87924 [FSDP()][10/N][11/N] Introduce composable (ctor only)
* #87923 [FSDP()][9/N] Refactor ctor (continued)
* #87922 [FSDP()][8/N] Refactor limiter's `_FreeEventQueue`
* #87921 [FSDP()][7/N] Refactor most of ctor
* #87920 [FSDP()][6/N] Refactor `CPUOffload` dataclass
* #87919 [FSDP()][5/N] Refactor `MixedPrecision` dataclass
* #87918 [FSDP()][4/N] Refactor `ShardingStrategy` enum
* #87917 [FSDP()][3/N] Refactor `BackwardPrefetch` enum
* **#87916 [FSDP()][2/N] Refactor training state**
* #87915 [FSDP()][1/N] Start refactoring FSDP root pre-forward
* #87812 [FSDP] ufmt FSDP test
* #87811 [FSDP] ufmt /fsdp

This PR actually has meaningful changes. We stratify `TrainingState` into two levels: one is per FSDP instance and one is per `FlatParamHandle`/`FlatParameter`.
- At the FSDP instance level, we only care about `IDLE`, FSDP computation (i.e. `FORWARD_BACKWARD`), or `SUMMON_FULL_PARAMS`. These dynamically modify behavior (e.g. `summon_full_params()` forces full precision).
- At the `FlatParamHandle` level, we care about the training state for invariants and debugging. Hence, we keep `IDLE`, `FORWARD`, `BACKWARD_PRE`, `BACKWARD_POST`, and `SUMMON_FULL_PARAMS`.