### PR TITLE
Fix dynamo not recording slices in graphs

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -749,7 +749,7 @@ def ___make_guard_fn({','.join(closure_vars.keys())}):
             print("GUARDS", code)
         set_guard_fail_hook(guard_fail_hook)
         out = dict()
-        # print("RUNNING PY CODE", py_code)
+        # print("RUNNING PY CODE", code)
         exec(py_code, global_builder.scope, out)
         guard_fn = out["___make_guard_fn"](*closure_vars.values())
         guard_fn.closure_vars = closure_vars

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -749,7 +749,7 @@ def ___make_guard_fn({','.join(closure_vars.keys())}):
             print("GUARDS", code)
         set_guard_fail_hook(guard_fail_hook)
         out = dict()
-        # print("RUNNING PY CODE", code)
+        # print("RUNNING PY CODE", py_code)
         exec(py_code, global_builder.scope, out)
         guard_fn = out["___make_guard_fn"](*closure_vars.values())
         guard_fn.closure_vars = closure_vars

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -70,8 +70,7 @@ class BaseListVariable(VariableTracker):
         options = VariableTracker.propagate(self, args, kwargs.values())
         if name == "__getitem__":
             assert not kwargs and len(args) == 1
-            out = self.getitem_const(args[0])
-            return out
+            return self.getitem_const(args[0])
         elif name == "__add__":
             assert not kwargs and len(args) == 1
             return type(self)(self.items + args[0].items, **options)


### PR DESCRIPTION
Fix dynamo not recording slices in graphs. This led to issues with missing guard installation. By correctly creating proxies for slices, we can ensure shape_env makes the right guards



cc @jansel @mlazos @soumith @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx