### PR TITLE
Store usage log on GitHub when S3 is not available

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -115,7 +115,7 @@ runs:
       if: inputs.use-gha
       with:
         # Add the run attempt, see [Artifact run attempt]
-        name: test-jsons-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
+        name: test-jsons-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}
         retention-days: 14
         if-no-files-found: warn
         path: test/**/*.json
@@ -125,7 +125,7 @@ runs:
       if: inputs.use-gha
       with:
         # Add the run attempt, see [Artifact run attempt]
-        name: test-reports-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
+        name: test-reports-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}
         retention-days: 14
         if-no-files-found: error
         path: test/**/*.xml
@@ -135,7 +135,7 @@ runs:
       if: inputs.use-gha
       with:
         # Add the run attempt, see [Artifact run attempt]
-        name: usage-log-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
+        name: usage-log-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}
         retention-days: 14
-        if-no-files-found: error
+        if-no-files-found: ignore
         path: usage_log.txt

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -129,3 +129,13 @@ runs:
         retention-days: 14
         if-no-files-found: error
         path: test/**/*.xml
+
+    - name: Store Usage Logs on Github
+      uses: actions/upload-artifact@v3
+      if: inputs.use-gha
+      with:
+        # Add the run attempt, see [Artifact run attempt]
+        name: usage-log-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
+        retention-days: 14
+        if-no-files-found: error
+        path: usage_log.txt

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -115,7 +115,7 @@ runs:
       if: inputs.use-gha
       with:
         # Add the run attempt, see [Artifact run attempt]
-        name: test-jsons-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}
+        name: test-jsons-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
         retention-days: 14
         if-no-files-found: warn
         path: test/**/*.json
@@ -125,7 +125,7 @@ runs:
       if: inputs.use-gha
       with:
         # Add the run attempt, see [Artifact run attempt]
-        name: test-reports-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}
+        name: test-reports-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
         retention-days: 14
         if-no-files-found: error
         path: test/**/*.xml
@@ -135,7 +135,7 @@ runs:
       if: inputs.use-gha
       with:
         # Add the run attempt, see [Artifact run attempt]
-        name: usage-log-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}
+        name: usage-log-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
         retention-days: 14
         if-no-files-found: ignore
         path: usage_log.txt


### PR DESCRIPTION
It turns out that we haven't uploaded the usage log to GitHub when S3 is not available (macos, rocm), for example, https://github.com/pytorch/pytorch/actions/runs/3325822440#artifacts only includes test-report, test-json, sccache stats, and build artifacts.