### PR TITLE
[PT-D][Checkpoint]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests 

### DIFF
--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -265,9 +265,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_load_with_different_shard_plan(self, thread_count) -> None:
-    def test_load_with_different_shard_plan(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_load_with_different_shard_plan(self, thread_count) -> None:
         path = self.get_file_path()
 
         # We hardcode the assumption of how many shards are around
@@ -353,10 +352,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 model_to_save._register_state_dict_hook(state_dict_hook)
                 state_dict_to_save = model_to_save.state_dict()
 
-                # fs_writer = FileSystemWriter(
-                #     path=path, thread_count=thread_count
-                # )
-                fs_writer = FileSystemWriter(path=path)
+                fs_writer = FileSystemWriter(
+                    path=path, thread_count=thread_count
+                )
                 save_state_dict(
                     state_dict=state_dict_to_save, storage_writer=fs_writer
                 )
@@ -387,9 +385,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_load_rowwise_to_colwise(self, thread_count) -> None:
-    def test_load_rowwise_to_colwise(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_load_rowwise_to_colwise(self, thread_count) -> None:
         path = self.get_file_path()
         self.assertEqual(self.world_size, dist.get_world_size())
 
@@ -419,8 +416,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         model_to_save._register_state_dict_hook(state_dict_hook)
         state_dict_to_save = model_to_save.state_dict()
 
-        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        fs_writer = FileSystemWriter(path=path)
+        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         model_to_load = MyShardedModel3(dst_spec).cuda(dist.get_rank())
@@ -450,8 +446,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
         state_dict_to_save = {"bytes0": [1], "bytes1": "string"}
 
-        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        fs_writer = FileSystemWriter(path=path)
+        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         state_dict_to_load = {"bytes0": [2], "bytes1": "other"}
@@ -465,11 +460,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_switch_between_sharded_tensor_to_tensor(
-    #     self, thread_count
-    # ) -> None:
-    def test_switch_between_sharded_tensor_to_tensor(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_switch_between_sharded_tensor_to_tensor(
+        self, thread_count
+    ) -> None:
         path = self.get_file_path()
         tensor_size = 32
 
@@ -527,10 +521,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     "replicated": torch.rand(tensor_size, device=self.rank),
                 }
 
-                # fs_writer = FileSystemWriter(
-                #     path=path, thread_count=thread_count
-                # )
-                fs_writer = FileSystemWriter(path=path)
+                fs_writer = FileSystemWriter(
+                    path=path, thread_count=thread_count
+                )
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors
@@ -560,7 +553,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
-# instantiate_parametrized_tests(TestDistributedReshardOnLoad)
+instantiate_parametrized_tests(TestDistributedReshardOnLoad)
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -119,7 +119,8 @@ class TestDistributedStateDictSaveLoad(TestCase):
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
-            fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+            # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+            fs_writer = FileSystemWriter(path=path)
             save_state_dict(
                 state_dict=state_dict_to_save,
                 storage_writer=fs_writer,
@@ -148,8 +149,12 @@ class TestDistributedStateDictSaveLoad(TestCase):
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
+            # fs_writer = FileSystemWriter(
+            #     path=path, single_file_per_rank=True, thread_count=thread_count
+            # )
             fs_writer = FileSystemWriter(
-                path=path, single_file_per_rank=True, thread_count=thread_count
+                path=path,
+                single_file_per_rank=True,
             )
             save_state_dict(
                 state_dict=state_dict_to_save,
@@ -208,7 +213,8 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
         model_to_save._register_state_dict_hook(state_dict_hook)
         state_dict_to_save = model_to_save.state_dict()
 
-        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        fs_writer = FileSystemWriter(path=path)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         dist.barrier()
@@ -347,9 +353,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 model_to_save._register_state_dict_hook(state_dict_hook)
                 state_dict_to_save = model_to_save.state_dict()
 
-                fs_writer = FileSystemWriter(
-                    path=path, thread_count=thread_count
-                )
+                # fs_writer = FileSystemWriter(
+                #     path=path, thread_count=thread_count
+                # )
+                fs_writer = FileSystemWriter(path=path)
                 save_state_dict(
                     state_dict=state_dict_to_save, storage_writer=fs_writer
                 )
@@ -380,8 +387,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    @parametrize("thread_count", _THREAD_COUNTS)
-    def test_load_rowwise_to_colwise(self, thread_count) -> None:
+    # @parametrize("thread_count", _THREAD_COUNTS)
+    # def test_load_rowwise_to_colwise(self, thread_count) -> None:
+    def test_load_rowwise_to_colwise(self) -> None:
         path = self.get_file_path()
         self.assertEqual(self.world_size, dist.get_world_size())
 
@@ -411,7 +419,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         model_to_save._register_state_dict_hook(state_dict_hook)
         state_dict_to_save = model_to_save.state_dict()
 
-        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        fs_writer = FileSystemWriter(path=path)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         model_to_load = MyShardedModel3(dst_spec).cuda(dist.get_rank())
@@ -441,7 +450,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
         state_dict_to_save = {"bytes0": [1], "bytes1": "string"}
 
-        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        fs_writer = FileSystemWriter(path=path)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         state_dict_to_load = {"bytes0": [2], "bytes1": "other"}
@@ -459,9 +469,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     # def test_switch_between_sharded_tensor_to_tensor(
     #     self, thread_count
     # ) -> None:
-    def test_switch_between_sharded_tensor_to_tensor(
-        self
-    ) -> None:
+    def test_switch_between_sharded_tensor_to_tensor(self) -> None:
         path = self.get_file_path()
         tensor_size = 32
 
@@ -519,9 +527,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     "replicated": torch.rand(tensor_size, device=self.rank),
                 }
 
-                fs_writer = FileSystemWriter(
-                    path=path, thread_count=thread_count
-                )
+                # fs_writer = FileSystemWriter(
+                #     path=path, thread_count=thread_count
+                # )
+                fs_writer = FileSystemWriter(path=path)
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -113,14 +113,14 @@ class MyShardedModel3(torch.nn.Module):
 
 
 class TestDistributedStateDictSaveLoad(TestCase):
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_read_write_only_tensor(self, thread_count) -> None:
-    def test_read_write_only_tensor(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_read_write_only_tensor(self, thread_count) -> None:
+    # def test_read_write_only_tensor(self) -> None:
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
-            # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-            fs_writer = FileSystemWriter(path=path)
+            fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+            # fs_writer = FileSystemWriter(path=path)
             save_state_dict(
                 state_dict=state_dict_to_save,
                 storage_writer=fs_writer,
@@ -149,13 +149,13 @@ class TestDistributedStateDictSaveLoad(TestCase):
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
-            # fs_writer = FileSystemWriter(
-            #     path=path, single_file_per_rank=True, thread_count=thread_count
-            # )
             fs_writer = FileSystemWriter(
-                path=path,
-                single_file_per_rank=True,
+                path=path, single_file_per_rank=True, thread_count=thread_count
             )
+            # fs_writer = FileSystemWriter(
+            #     path=path,
+            #     single_file_per_rank=True,
+            # )
             save_state_dict(
                 state_dict=state_dict_to_save,
                 storage_writer=fs_writer,
@@ -558,7 +558,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     )
 
 
-# instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
+instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
 # instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
 # instantiate_parametrized_tests(TestDistributedReshardOnLoad)
 

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -190,9 +190,9 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     @with_comms(init_rpc=False)
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_read_write_shard_tensor(self, thread_count) -> None:
-    def test_read_write_shard_tensor(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_read_write_shard_tensor(self, thread_count) -> None:
+    # def test_read_write_shard_tensor(self) -> None:
         paths = [tempfile.mkdtemp()]
         dist.broadcast_object_list(paths)
 
@@ -213,8 +213,8 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
         model_to_save._register_state_dict_hook(state_dict_hook)
         state_dict_to_save = model_to_save.state_dict()
 
-        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        fs_writer = FileSystemWriter(path=path)
+        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        # fs_writer = FileSystemWriter(path=path)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         dist.barrier()
@@ -265,9 +265,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_load_with_different_shard_plan(self, thread_count) -> None:
-    def test_load_with_different_shard_plan(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_load_with_different_shard_plan(self, thread_count) -> None:
+    # def test_load_with_different_shard_plan(self) -> None:
         path = self.get_file_path()
 
         # We hardcode the assumption of how many shards are around
@@ -353,10 +353,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 model_to_save._register_state_dict_hook(state_dict_hook)
                 state_dict_to_save = model_to_save.state_dict()
 
-                # fs_writer = FileSystemWriter(
-                #     path=path, thread_count=thread_count
-                # )
-                fs_writer = FileSystemWriter(path=path)
+                fs_writer = FileSystemWriter(
+                    path=path, thread_count=thread_count
+                )
+                # fs_writer = FileSystemWriter(path=path)
                 save_state_dict(
                     state_dict=state_dict_to_save, storage_writer=fs_writer
                 )
@@ -387,9 +387,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_load_rowwise_to_colwise(self, thread_count) -> None:
-    def test_load_rowwise_to_colwise(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_load_rowwise_to_colwise(self, thread_count) -> None:
+    # def test_load_rowwise_to_colwise(self) -> None:
         path = self.get_file_path()
         self.assertEqual(self.world_size, dist.get_world_size())
 
@@ -419,8 +419,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         model_to_save._register_state_dict_hook(state_dict_hook)
         state_dict_to_save = model_to_save.state_dict()
 
-        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        fs_writer = FileSystemWriter(path=path)
+        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        # fs_writer = FileSystemWriter(path=path)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         model_to_load = MyShardedModel3(dst_spec).cuda(dist.get_rank())
@@ -443,15 +443,15 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_save_load_bytes(self, thread_count) -> None:
-    def test_save_load_bytes(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_save_load_bytes(self, thread_count) -> None:
+    # def test_save_load_bytes(self) -> None:
         path = self.get_file_path()
 
         state_dict_to_save = {"bytes0": [1], "bytes1": "string"}
 
-        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        fs_writer = FileSystemWriter(path=path)
+        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        # fs_writer = FileSystemWriter(path=path)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         state_dict_to_load = {"bytes0": [2], "bytes1": "other"}
@@ -465,11 +465,11 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_switch_between_sharded_tensor_to_tensor(
-    #     self, thread_count
-    # ) -> None:
-    def test_switch_between_sharded_tensor_to_tensor(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_switch_between_sharded_tensor_to_tensor(
+        self, thread_count
+    ) -> None:
+    # def test_switch_between_sharded_tensor_to_tensor(self) -> None:
         path = self.get_file_path()
         tensor_size = 32
 
@@ -527,10 +527,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     "replicated": torch.rand(tensor_size, device=self.rank),
                 }
 
-                # fs_writer = FileSystemWriter(
-                #     path=path, thread_count=thread_count
-                # )
-                fs_writer = FileSystemWriter(path=path)
+                fs_writer = FileSystemWriter(
+                    path=path, thread_count=thread_count
+                )
+                # fs_writer = FileSystemWriter(path=path)
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors
@@ -559,8 +559,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
 
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
-# instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
-# instantiate_parametrized_tests(TestDistributedReshardOnLoad)
+instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
+instantiate_parametrized_tests(TestDistributedReshardOnLoad)
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -115,12 +115,10 @@ class MyShardedModel3(torch.nn.Module):
 class TestDistributedStateDictSaveLoad(TestCase):
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_read_write_only_tensor(self, thread_count) -> None:
-    # def test_read_write_only_tensor(self) -> None:
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
             fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-            # fs_writer = FileSystemWriter(path=path)
             save_state_dict(
                 state_dict=state_dict_to_save,
                 storage_writer=fs_writer,
@@ -152,10 +150,6 @@ class TestDistributedStateDictSaveLoad(TestCase):
             fs_writer = FileSystemWriter(
                 path=path, single_file_per_rank=True, thread_count=thread_count
             )
-            # fs_writer = FileSystemWriter(
-            #     path=path,
-            #     single_file_per_rank=True,
-            # )
             save_state_dict(
                 state_dict=state_dict_to_save,
                 storage_writer=fs_writer,
@@ -192,7 +186,6 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_read_write_shard_tensor(self, thread_count) -> None:
-    # def test_read_write_shard_tensor(self) -> None:
         paths = [tempfile.mkdtemp()]
         dist.broadcast_object_list(paths)
 
@@ -214,7 +207,6 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
         state_dict_to_save = model_to_save.state_dict()
 
         fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        # fs_writer = FileSystemWriter(path=path)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         dist.barrier()
@@ -265,9 +257,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_load_with_different_shard_plan(self, thread_count) -> None:
-    def test_load_with_different_shard_plan(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_load_with_different_shard_plan(self, thread_count) -> None:
         path = self.get_file_path()
 
         # We hardcode the assumption of how many shards are around
@@ -353,10 +344,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 model_to_save._register_state_dict_hook(state_dict_hook)
                 state_dict_to_save = model_to_save.state_dict()
 
-                # fs_writer = FileSystemWriter(
-                #     path=path, thread_count=thread_count
-                # )
-                fs_writer = FileSystemWriter(path=path)
+                fs_writer = FileSystemWriter(
+                    path=path, thread_count=thread_count
+                )
                 save_state_dict(
                     state_dict=state_dict_to_save, storage_writer=fs_writer
                 )
@@ -387,9 +377,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_load_rowwise_to_colwise(self, thread_count) -> None:
-    def test_load_rowwise_to_colwise(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_load_rowwise_to_colwise(self, thread_count) -> None:
         path = self.get_file_path()
         self.assertEqual(self.world_size, dist.get_world_size())
 
@@ -419,8 +408,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         model_to_save._register_state_dict_hook(state_dict_hook)
         state_dict_to_save = model_to_save.state_dict()
 
-        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        fs_writer = FileSystemWriter(path=path)
+        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         model_to_load = MyShardedModel3(dst_spec).cuda(dist.get_rank())
@@ -443,15 +431,13 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_save_load_bytes(self, thread_count) -> None:
-    def test_save_load_bytes(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_save_load_bytes(self, thread_count) -> None:
         path = self.get_file_path()
 
         state_dict_to_save = {"bytes0": [1], "bytes1": "string"}
 
-        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        fs_writer = FileSystemWriter(path=path)
+        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         state_dict_to_load = {"bytes0": [2], "bytes1": "other"}
@@ -469,7 +455,6 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     def test_switch_between_sharded_tensor_to_tensor(
         self, thread_count
     ) -> None:
-    # def test_switch_between_sharded_tensor_to_tensor(self) -> None:
         path = self.get_file_path()
         tensor_size = 32
 
@@ -530,7 +515,6 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 fs_writer = FileSystemWriter(
                     path=path, thread_count=thread_count
                 )
-                # fs_writer = FileSystemWriter(path=path)
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors
@@ -560,7 +544,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
-# instantiate_parametrized_tests(TestDistributedReshardOnLoad)
+instantiate_parametrized_tests(TestDistributedReshardOnLoad)
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -113,8 +113,9 @@ class MyShardedModel3(torch.nn.Module):
 
 
 class TestDistributedStateDictSaveLoad(TestCase):
-    @parametrize("thread_count", _THREAD_COUNTS)
-    def test_read_write_only_tensor(self, thread_count) -> None:
+    # @parametrize("thread_count", _THREAD_COUNTS)
+    # def test_read_write_only_tensor(self, thread_count) -> None:
+    def test_read_write_only_tensor(self) -> None:
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
@@ -184,8 +185,9 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     @with_comms(init_rpc=False)
-    @parametrize("thread_count", _THREAD_COUNTS)
-    def test_read_write_shard_tensor(self, thread_count) -> None:
+    # @parametrize("thread_count", _THREAD_COUNTS)
+    # def test_read_write_shard_tensor(self, thread_count) -> None:
+    def test_read_write_shard_tensor(self) -> None:
         paths = [tempfile.mkdtemp()]
         dist.broadcast_object_list(paths)
 
@@ -257,8 +259,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    @parametrize("thread_count", _THREAD_COUNTS)
-    def test_load_with_different_shard_plan(self, thread_count) -> None:
+    # @parametrize("thread_count", _THREAD_COUNTS)
+    # def test_load_with_different_shard_plan(self, thread_count) -> None:
+    def test_load_with_different_shard_plan(self) -> None:
         path = self.get_file_path()
 
         # We hardcode the assumption of how many shards are around
@@ -431,8 +434,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    @parametrize("thread_count", _THREAD_COUNTS)
-    def test_save_load_bytes(self, thread_count) -> None:
+    # @parametrize("thread_count", _THREAD_COUNTS)
+    # def test_save_load_bytes(self, thread_count) -> None:
+    def test_save_load_bytes(self) -> None:
         path = self.get_file_path()
 
         state_dict_to_save = {"bytes0": [1], "bytes1": "string"}
@@ -451,9 +455,12 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    @parametrize("thread_count", _THREAD_COUNTS)
+    # @parametrize("thread_count", _THREAD_COUNTS)
+    # def test_switch_between_sharded_tensor_to_tensor(
+    #     self, thread_count
+    # ) -> None:
     def test_switch_between_sharded_tensor_to_tensor(
-        self, thread_count
+        self
     ) -> None:
         path = self.get_file_path()
         tensor_size = 32
@@ -542,9 +549,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     )
 
 
-instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
-instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
-instantiate_parametrized_tests(TestDistributedReshardOnLoad)
+# instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
+# instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
+# instantiate_parametrized_tests(TestDistributedReshardOnLoad)
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -115,12 +115,10 @@ class MyShardedModel3(torch.nn.Module):
 class TestDistributedStateDictSaveLoad(TestCase):
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_read_write_only_tensor(self, thread_count) -> None:
-        # def test_read_write_only_tensor(self) -> None:
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
             fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-            # fs_writer = FileSystemWriter(path=path)
             save_state_dict(
                 state_dict=state_dict_to_save,
                 storage_writer=fs_writer,
@@ -152,10 +150,6 @@ class TestDistributedStateDictSaveLoad(TestCase):
             fs_writer = FileSystemWriter(
                 path=path, single_file_per_rank=True, thread_count=thread_count
             )
-            # fs_writer = FileSystemWriter(
-            #     path=path,
-            #     single_file_per_rank=True,
-            # )
             save_state_dict(
                 state_dict=state_dict_to_save,
                 storage_writer=fs_writer,
@@ -192,7 +186,6 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_read_write_shard_tensor(self, thread_count) -> None:
-        # def test_read_write_shard_tensor(self) -> None:
         paths = [tempfile.mkdtemp()]
         dist.broadcast_object_list(paths)
 
@@ -214,7 +207,6 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
         state_dict_to_save = model_to_save.state_dict()
 
         fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        # fs_writer = FileSystemWriter(path=path)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         dist.barrier()
@@ -439,9 +431,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    # @parametrize("thread_count", _THREAD_COUNTS)
-    # def test_save_load_bytes(self, thread_count) -> None:
-    def test_save_load_bytes(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_save_load_bytes(self, thread_count) -> None:
         path = self.get_file_path()
 
         state_dict_to_save = {"bytes0": [1], "bytes1": "string"}

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -265,9 +265,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    @parametrize("thread_count", _THREAD_COUNTS)
-    def test_load_with_different_shard_plan(self, thread_count) -> None:
-    # def test_load_with_different_shard_plan(self) -> None:
+    # @parametrize("thread_count", _THREAD_COUNTS)
+    # def test_load_with_different_shard_plan(self, thread_count) -> None:
+    def test_load_with_different_shard_plan(self) -> None:
         path = self.get_file_path()
 
         # We hardcode the assumption of how many shards are around
@@ -353,10 +353,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 model_to_save._register_state_dict_hook(state_dict_hook)
                 state_dict_to_save = model_to_save.state_dict()
 
-                fs_writer = FileSystemWriter(
-                    path=path, thread_count=thread_count
-                )
-                # fs_writer = FileSystemWriter(path=path)
+                # fs_writer = FileSystemWriter(
+                #     path=path, thread_count=thread_count
+                # )
+                fs_writer = FileSystemWriter(path=path)
                 save_state_dict(
                     state_dict=state_dict_to_save, storage_writer=fs_writer
                 )
@@ -387,9 +387,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    @parametrize("thread_count", _THREAD_COUNTS)
-    def test_load_rowwise_to_colwise(self, thread_count) -> None:
-    # def test_load_rowwise_to_colwise(self) -> None:
+    # @parametrize("thread_count", _THREAD_COUNTS)
+    # def test_load_rowwise_to_colwise(self, thread_count) -> None:
+    def test_load_rowwise_to_colwise(self) -> None:
         path = self.get_file_path()
         self.assertEqual(self.world_size, dist.get_world_size())
 
@@ -419,8 +419,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         model_to_save._register_state_dict_hook(state_dict_hook)
         state_dict_to_save = model_to_save.state_dict()
 
-        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        # fs_writer = FileSystemWriter(path=path)
+        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        fs_writer = FileSystemWriter(path=path)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         model_to_load = MyShardedModel3(dst_spec).cuda(dist.get_rank())
@@ -443,15 +443,15 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    @parametrize("thread_count", _THREAD_COUNTS)
-    def test_save_load_bytes(self, thread_count) -> None:
-    # def test_save_load_bytes(self) -> None:
+    # @parametrize("thread_count", _THREAD_COUNTS)
+    # def test_save_load_bytes(self, thread_count) -> None:
+    def test_save_load_bytes(self) -> None:
         path = self.get_file_path()
 
         state_dict_to_save = {"bytes0": [1], "bytes1": "string"}
 
-        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-        # fs_writer = FileSystemWriter(path=path)
+        # fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+        fs_writer = FileSystemWriter(path=path)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         state_dict_to_load = {"bytes0": [2], "bytes1": "other"}
@@ -560,7 +560,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
 instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
-instantiate_parametrized_tests(TestDistributedReshardOnLoad)
+# instantiate_parametrized_tests(TestDistributedReshardOnLoad)
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -115,7 +115,7 @@ class MyShardedModel3(torch.nn.Module):
 class TestDistributedStateDictSaveLoad(TestCase):
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_read_write_only_tensor(self, thread_count) -> None:
-    # def test_read_write_only_tensor(self) -> None:
+        # def test_read_write_only_tensor(self) -> None:
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
@@ -192,7 +192,7 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_read_write_shard_tensor(self, thread_count) -> None:
-    # def test_read_write_shard_tensor(self) -> None:
+        # def test_read_write_shard_tensor(self) -> None:
         paths = [tempfile.mkdtemp()]
         dist.broadcast_object_list(paths)
 
@@ -465,11 +465,11 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    @parametrize("thread_count", _THREAD_COUNTS)
-    def test_switch_between_sharded_tensor_to_tensor(
-        self, thread_count
-    ) -> None:
-    # def test_switch_between_sharded_tensor_to_tensor(self) -> None:
+    # @parametrize("thread_count", _THREAD_COUNTS)
+    # def test_switch_between_sharded_tensor_to_tensor(
+    #     self, thread_count
+    # ) -> None:
+    def test_switch_between_sharded_tensor_to_tensor(self) -> None:
         path = self.get_file_path()
         tensor_size = 32
 
@@ -527,10 +527,10 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     "replicated": torch.rand(tensor_size, device=self.rank),
                 }
 
-                fs_writer = FileSystemWriter(
-                    path=path, thread_count=thread_count
-                )
-                # fs_writer = FileSystemWriter(path=path)
+                # fs_writer = FileSystemWriter(
+                #     path=path, thread_count=thread_count
+                # )
+                fs_writer = FileSystemWriter(path=path)
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors

--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -54,7 +54,10 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 _THREAD_COUNTS = {1, 2}
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
 def assert_state_dict_equal(
     self: TestCase,
     state_dict_1: Dict[str, torch.Tensor],
@@ -109,17 +112,25 @@ class MyShardedModel3(torch.nn.Module):
 
 
 class TestDistributedStateDictSaveLoad(TestCase):
+<<<<<<< HEAD
+=======
+
+>>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_read_write_only_tensor(self, thread_count) -> None:
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
             fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+<<<<<<< HEAD
             save_state_dict(
                 state_dict=state_dict_to_save,
                 storage_writer=fs_writer,
                 no_dist=True,
             )
+=======
+            save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer, no_dist=True)
+>>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
 
             state_dict_to_load_to = MyTestModule().state_dict()
 
@@ -305,12 +316,17 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 model_to_save._register_state_dict_hook(state_dict_hook)
                 state_dict_to_save = model_to_save.state_dict()
 
+<<<<<<< HEAD
                 fs_writer = FileSystemWriter(
                     path=path, thread_count=thread_count
                 )
                 save_state_dict(
                     state_dict=state_dict_to_save, storage_writer=fs_writer
                 )
+=======
+                fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+                save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
+>>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
 
                 dist.barrier()
 
@@ -407,9 +423,13 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend="gloo")
     @parametrize("thread_count", _THREAD_COUNTS)
+<<<<<<< HEAD
     def test_switch_between_sharded_tensor_to_tensor(
         self, thread_count
     ) -> None:
+=======
+    def test_switch_between_sharded_tensor_to_tensor(self, thread_count) -> None:
+>>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
         path = self.get_file_path()
         tensor_size = 32
 
@@ -469,9 +489,13 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     ),
                 }
 
+<<<<<<< HEAD
                 fs_writer = FileSystemWriter(
                     path=path, thread_count=thread_count
                 )
+=======
+                fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+>>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors

--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -27,6 +27,8 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 
 
 from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
     TEST_WITH_DEV_DBG_ASAN,
     run_tests,
 )
@@ -46,6 +48,8 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
+
+_THREAD_COUNTS = {1, 2}
 
 def assert_state_dict_equal(
     self: TestCase,
@@ -100,11 +104,13 @@ class MyShardedModel3(torch.nn.Module):
 
 
 class TestDistributedStateDictSaveLoad(TestCase):
-    def test_read_write_only_tensor(self) -> None:
+
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_read_write_only_tensor(self, thread_count) -> None:
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
-            fs_writer = FileSystemWriter(path=path)
+            fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
             save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer, no_dist=True)
 
             state_dict_to_load_to = MyTestModule().state_dict()
@@ -125,7 +131,8 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
         return 2
 
     @with_comms(init_rpc=False, backend="gloo")
-    def test_read_write_shard_tensor(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_read_write_shard_tensor(self, thread_count) -> None:
         paths = [tempfile.mkdtemp()]
         dist.broadcast_object_list(paths)
 
@@ -146,7 +153,7 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
         model_to_save._register_state_dict_hook(state_dict_hook)
         state_dict_to_save = model_to_save.state_dict()
 
-        fs_writer = FileSystemWriter(path=path)
+        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         dist.barrier()
@@ -187,7 +194,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         return res
 
     @with_comms(init_rpc=False, backend="gloo")
-    def test_load_with_different_shard_plan(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_load_with_different_shard_plan(self, thread_count) -> None:
         path = self.get_file_path()
 
         # We hardcode the assumption of how many shards are around
@@ -273,7 +281,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 model_to_save._register_state_dict_hook(state_dict_hook)
                 state_dict_to_save = model_to_save.state_dict()
 
-                fs_writer = FileSystemWriter(path=path)
+                fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
                 save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
                 dist.barrier()
@@ -299,7 +307,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     )
 
     @with_comms(init_rpc=False, backend="gloo")
-    def test_load_rowwise_to_colwise(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_load_rowwise_to_colwise(self, thread_count) -> None:
         path = self.get_file_path()
         self.assertEqual(self.world_size, dist.get_world_size())
 
@@ -329,7 +338,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         model_to_save._register_state_dict_hook(state_dict_hook)
         state_dict_to_save = model_to_save.state_dict()
 
-        fs_writer = FileSystemWriter(path=path)
+        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         model_to_load = MyShardedModel3(dst_spec).cuda(dist.get_rank())
@@ -349,7 +358,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
 
     @with_comms(init_rpc=False, backend="gloo")
-    def test_save_load_bytes(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_save_load_bytes(self, thread_count) -> None:
         path = self.get_file_path()
 
         state_dict_to_save = {
@@ -357,7 +367,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
             'bytes1': 'string'
         }
 
-        fs_writer = FileSystemWriter(path=path)
+        fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
         state_dict_to_load = {
@@ -373,7 +383,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
 
     @with_comms(init_rpc=False, backend="gloo")
-    def test_switch_between_sharded_tensor_to_tensor(self) -> None:
+    @parametrize("thread_count", _THREAD_COUNTS)
+    def test_switch_between_sharded_tensor_to_tensor(self, thread_count) -> None:
         path = self.get_file_path()
         tensor_size = 32
 
@@ -431,7 +442,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     'replicated': torch.rand(tensor_size, device=f"cpu:{self.rank}")
                 }
 
-                fs_writer = FileSystemWriter(path=path)
+                fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors
@@ -455,6 +466,11 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                         torch.allclose(save_dict['replicated'], load_dict_replicated),
                         f"save-spec {save_spec} load-spec {load_spec}"
                     )
+
+
+instantiate_parametrized_tests(TestDistributedStateDictSaveLoad)
+instantiate_parametrized_tests(TestDistributedStateDictSaveLoadWithSharedTensor)
+instantiate_parametrized_tests(TestDistributedReshardOnLoad)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -54,10 +54,7 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 _THREAD_COUNTS = {1, 2}
 
-<<<<<<< HEAD
 
-=======
->>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
 def assert_state_dict_equal(
     self: TestCase,
     state_dict_1: Dict[str, torch.Tensor],
@@ -112,25 +109,17 @@ class MyShardedModel3(torch.nn.Module):
 
 
 class TestDistributedStateDictSaveLoad(TestCase):
-<<<<<<< HEAD
-=======
-
->>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_read_write_only_tensor(self, thread_count) -> None:
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
             fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-<<<<<<< HEAD
             save_state_dict(
                 state_dict=state_dict_to_save,
                 storage_writer=fs_writer,
                 no_dist=True,
             )
-=======
-            save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer, no_dist=True)
->>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
 
             state_dict_to_load_to = MyTestModule().state_dict()
 
@@ -316,17 +305,12 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 model_to_save._register_state_dict_hook(state_dict_hook)
                 state_dict_to_save = model_to_save.state_dict()
 
-<<<<<<< HEAD
                 fs_writer = FileSystemWriter(
                     path=path, thread_count=thread_count
                 )
                 save_state_dict(
                     state_dict=state_dict_to_save, storage_writer=fs_writer
                 )
-=======
-                fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-                save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
->>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
 
                 dist.barrier()
 
@@ -423,13 +407,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
     @with_comms(init_rpc=False, backend="gloo")
     @parametrize("thread_count", _THREAD_COUNTS)
-<<<<<<< HEAD
     def test_switch_between_sharded_tensor_to_tensor(
         self, thread_count
     ) -> None:
-=======
-    def test_switch_between_sharded_tensor_to_tensor(self, thread_count) -> None:
->>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
         path = self.get_file_path()
         tensor_size = 32
 
@@ -489,13 +469,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                     ),
                 }
 
-<<<<<<< HEAD
                 fs_writer = FileSystemWriter(
                     path=path, thread_count=thread_count
                 )
-=======
-                fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
->>>>>>> [PT-D][Checkpointing]Add MultiThreaded FileSystemWriter for distributed checkpointing and Update tests
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors

--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -9,7 +9,10 @@ from typing import Dict
 import torch
 import torch.distributed as dist
 from torch.distributed._shard import sharded_tensor
-from torch.distributed._shard.sharded_tensor import ShardedTensor, state_dict_hook
+from torch.distributed._shard.sharded_tensor import (
+    ShardedTensor,
+    state_dict_hook,
+)
 from torch.distributed._shard.sharding_spec import (
     ChunkShardingSpec,
     EnumerableShardingSpec,
@@ -22,7 +25,7 @@ from torch.testing._internal.distributed._shard.sharded_tensor import (
     with_comms,
 )
 from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common import (
-    MyShardedModel1
+    MyShardedModel1,
 )
 
 
@@ -51,6 +54,7 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 _THREAD_COUNTS = {1, 2}
 
+
 def assert_state_dict_equal(
     self: TestCase,
     state_dict_1: Dict[str, torch.Tensor],
@@ -77,7 +81,8 @@ def assert_state_dict_equal(
                 )
         elif isinstance(value_1, torch.Tensor):
             self.assertTrue(
-                torch.equal(value_1, value_2), f"Key {key}'s tensor does not match"
+                torch.equal(value_1, value_2),
+                f"Key {key}'s tensor does not match",
             )
 
     return True
@@ -104,25 +109,36 @@ class MyShardedModel3(torch.nn.Module):
 
 
 class TestDistributedStateDictSaveLoad(TestCase):
-
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_read_write_only_tensor(self, thread_count) -> None:
         with tempfile.TemporaryDirectory() as path:
             state_dict_to_save = MyTestModule().state_dict()
 
             fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-            save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer, no_dist=True)
+            save_state_dict(
+                state_dict=state_dict_to_save,
+                storage_writer=fs_writer,
+                no_dist=True,
+            )
 
             state_dict_to_load_to = MyTestModule().state_dict()
 
             with self.assertRaises(AssertionError):
-                assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
+                assert_state_dict_equal(
+                    self, state_dict_to_load_to, state_dict_to_save
+                )
 
             # Load from file without any resharding
             fs_reader = FileSystemReader(path=path)
-            load_state_dict(state_dict=state_dict_to_load_to, storage_reader=fs_reader, no_dist=True)
+            load_state_dict(
+                state_dict=state_dict_to_load_to,
+                storage_reader=fs_reader,
+                no_dist=True,
+            )
 
-            assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
+            assert_state_dict_equal(
+                self, state_dict_to_load_to, state_dict_to_save
+            )
 
 
 class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
@@ -168,11 +184,15 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
         dist.barrier()
 
         with self.assertRaises(AssertionError):
-            assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
+            assert_state_dict_equal(
+                self, state_dict_to_load_to, state_dict_to_save
+            )
 
         # Test load.
         fs_reader = FileSystemReader(path=path)
-        load_state_dict(state_dict=state_dict_to_load_to, storage_reader=fs_reader)
+        load_state_dict(
+            state_dict=state_dict_to_load_to, storage_reader=fs_reader
+        )
 
         assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
         dist.barrier()
@@ -189,7 +209,11 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         return paths[0]
 
     def load_tensor(self, tensor: ShardedTensor) -> torch.Tensor:
-        res = torch.zeros(tensor.shape, device="cpu") if dist.get_rank() == 0 else None
+        res = (
+            torch.zeros(tensor.shape, device="cpu")
+            if dist.get_rank() == 0
+            else None
+        )
         tensor.gather(out=res)
         return res
 
@@ -281,8 +305,12 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                 model_to_save._register_state_dict_hook(state_dict_hook)
                 state_dict_to_save = model_to_save.state_dict()
 
-                fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
-                save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
+                fs_writer = FileSystemWriter(
+                    path=path, thread_count=thread_count
+                )
+                save_state_dict(
+                    state_dict=state_dict_to_save, storage_writer=fs_writer
+                )
 
                 dist.barrier()
 
@@ -303,7 +331,8 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
                 if dist.get_rank() == 0:
                     self.assertTrue(
-                        torch.allclose(store_tensor, load_tensor), msg=f"{s0} vs {s1}"
+                        torch.allclose(store_tensor, load_tensor),
+                        msg=f"{s0} vs {s1}",
                     )
 
     @with_comms(init_rpc=False, backend="gloo")
@@ -347,7 +376,9 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
 
         fs_reader = FileSystemReader(path=path)
 
-        load_state_dict(state_dict=state_dict_to_load_to, storage_reader=fs_reader)
+        load_state_dict(
+            state_dict=state_dict_to_load_to, storage_reader=fs_reader
+        )
 
         # We can't use torch.allclose since each ST has a different sharding spec
         store_tensor = self.load_tensor(model_to_save.sharded_tensor)
@@ -356,35 +387,29 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         if dist.get_rank() == 0:
             self.assertTrue(torch.allclose(store_tensor, load_tensor))
 
-
     @with_comms(init_rpc=False, backend="gloo")
     @parametrize("thread_count", _THREAD_COUNTS)
     def test_save_load_bytes(self, thread_count) -> None:
         path = self.get_file_path()
 
-        state_dict_to_save = {
-            'bytes0': [1],
-            'bytes1': 'string'
-        }
+        state_dict_to_save = {"bytes0": [1], "bytes1": "string"}
 
         fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
         save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
 
-        state_dict_to_load = {
-            'bytes0': [2],
-            'bytes1': 'other'
-        }
+        state_dict_to_load = {"bytes0": [2], "bytes1": "other"}
 
         fs_reader = FileSystemReader(path=path)
         load_state_dict(state_dict=state_dict_to_load, storage_reader=fs_reader)
 
-        self.assertEqual([1], state_dict_to_load['bytes0'])
-        self.assertEqual('string', state_dict_to_load['bytes1'])
-
+        self.assertEqual([1], state_dict_to_load["bytes0"])
+        self.assertEqual("string", state_dict_to_load["bytes1"])
 
     @with_comms(init_rpc=False, backend="gloo")
     @parametrize("thread_count", _THREAD_COUNTS)
-    def test_switch_between_sharded_tensor_to_tensor(self, thread_count) -> None:
+    def test_switch_between_sharded_tensor_to_tensor(
+        self, thread_count
+    ) -> None:
         path = self.get_file_path()
         tensor_size = 32
 
@@ -438,33 +463,41 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         for save_spec in specs:
             for load_spec in specs:
                 save_dict = {
-                    'sharded': sharded_tensor.rand(save_spec, tensor_size),
-                    'replicated': torch.rand(tensor_size, device=f"cpu:{self.rank}")
+                    "sharded": sharded_tensor.rand(save_spec, tensor_size),
+                    "replicated": torch.rand(
+                        tensor_size, device=f"cpu:{self.rank}"
+                    ),
                 }
 
-                fs_writer = FileSystemWriter(path=path, thread_count=thread_count)
+                fs_writer = FileSystemWriter(
+                    path=path, thread_count=thread_count
+                )
                 save_state_dict(state_dict=save_dict, storage_writer=fs_writer)
 
                 # Freaky Friday the tensors
                 load_dict = {
-                    'sharded': torch.zeros(tensor_size, device=f"cpu:{self.rank}"),
-                    'replicated': sharded_tensor.zeros(load_spec, tensor_size)
+                    "sharded": torch.zeros(
+                        tensor_size, device=f"cpu:{self.rank}"
+                    ),
+                    "replicated": sharded_tensor.zeros(load_spec, tensor_size),
                 }
 
                 fs_reader = FileSystemReader(path=path)
                 load_state_dict(state_dict=load_dict, storage_reader=fs_reader)
 
-                save_dict_sharded = self.load_tensor(save_dict['sharded'])
-                load_dict_replicated = self.load_tensor(load_dict['replicated'])
+                save_dict_sharded = self.load_tensor(save_dict["sharded"])
+                load_dict_replicated = self.load_tensor(load_dict["replicated"])
 
                 if dist.get_rank() == 0:
                     self.assertTrue(
-                        torch.allclose(save_dict_sharded, load_dict['sharded']),
-                        f"save-spec {save_spec} load-spec {load_spec}"
+                        torch.allclose(save_dict_sharded, load_dict["sharded"]),
+                        f"save-spec {save_spec} load-spec {load_spec}",
                     )
                     self.assertTrue(
-                        torch.allclose(save_dict['replicated'], load_dict_replicated),
-                        f"save-spec {save_spec} load-spec {load_spec}"
+                        torch.allclose(
+                            save_dict["replicated"], load_dict_replicated
+                        ),
+                        f"save-spec {save_spec} load-spec {load_spec}",
                     )
 
 

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -1,3 +1,8 @@
+from abc import ABC, abstractmethod
+import queue
+import threading
+import collections
+
 from dataclasses import dataclass
 import os
 import dataclasses
@@ -34,13 +39,6 @@ from .planner import (
 from torch.distributed._shard._utils import narrow_tensor_by_index
 
 
-__all__ = [
-    "FileSystemWriter",
-    "SlicedBufferedReader",
-    "FileSystemReader",
-]
-
-
 @dataclass
 class _StorageInfo:
     """
@@ -75,6 +73,160 @@ def _result_from_write_item(
     )
 
 
+class _TensorLoader(ABC):
+    @abstractmethod
+    def add(self, size, obj):
+        pass
+
+    def start_loading(self):
+        pass
+
+    @abstractmethod
+    def values(self):
+        pass
+
+
+class _SerialCpuLoader(_TensorLoader):
+    def __init__(self, resolve_fun):
+        self.resolve_fun = resolve_fun
+        self.items = []
+
+    def add(self, size, obj):
+        self.items.append((size, obj))
+
+    def start_loading(self):
+        pass
+
+    def values(self):
+        for _, obj in self.items:
+            tensor = self.resolve_fun(obj).detach()
+            tensor = tensor.cpu()
+            if tensor.storage().size() != tensor.numel():
+                tensor = tensor.clone()
+            yield (
+                tensor,
+                obj,
+            )
+
+
+class _OverlappingCpuLoader(_TensorLoader):
+    def __init__(self, resolve_fun, stream=None, inflight_threshhold=1_000_000):
+        self.resolve_fun = resolve_fun
+        self.items = []
+        self.inflight_threshhold = inflight_threshhold
+        self.in_flight_data = 0
+        self.current_items: collections.deque = collections.deque()
+        self.idx = 0
+        self.started = False
+        self.stream = stream or torch.cuda.current_stream()
+        if self.stream != torch.cuda.current_stream():
+            self.stream.wait_stream(torch.cuda.current_stream())
+
+    @property
+    def _done(self):
+        return self.idx >= len(self.items)
+
+    def _drain(self):
+        drained = []
+        if self.in_flight_data >= self.inflight_threshhold:
+            self.stream.synchronize()
+        while self.in_flight_data >= self.inflight_threshhold:
+            val = self.current_items.popleft()
+            self.in_flight_data -= val[0].numel() * val[0].element_size()
+            drained.append(val)
+        return drained
+
+    def _refill(self):
+        with torch.cuda.stream(self.stream):
+            while (
+                not self._done
+                and self.in_flight_data < self.inflight_threshhold
+            ):
+                _, obj = self.items[self.idx]
+                self.idx += 1
+                tensor = self.resolve_fun(obj).detach()
+                if tensor.is_cuda:
+                    tensor = tensor.to(device="cpu", non_blocking=True)
+                elif tensor.device == torch.device("cpu"):
+                    if tensor.storage().size() != tensor.numel():
+                        # this forces the tensor to be both contiguous and with minimal storage
+                        tensor = tensor.clone()
+
+                self.current_items.append(
+                    (
+                        tensor,
+                        obj,
+                    )
+                )
+                self.in_flight_data += tensor.numel() * tensor.element_size()
+
+    def _finish(self):
+        assert self._done
+        if len(self.current_items) > 0:
+            self.stream.synchronize()
+        return self.current_items
+
+    def add(self, size, obj):
+        if self.started:
+            raise RuntimeError("cannot add items after loading started")
+        self.items.append((size, obj))
+
+    def start_loading(self):
+        if self.started:
+            return
+        self.started = True
+        self.items.sort(key=lambda x: x[0])
+        self._refill()
+
+    def values(self):
+        self.start_loading()
+        while not self._done:
+            drained = self._drain()
+            self._refill()
+            for obj in drained:
+                yield obj
+
+        for val in self._finish():
+            yield val
+
+
+def _item_size(item: WriteItem) -> int:
+    size = 1
+    assert item.tensor_data is not None
+    # can't use math.prod as PT needs to support older python
+    for s in item.tensor_data.size:
+        size *= s
+
+    dtype = item.tensor_data.properties.dtype
+    return size * torch._utils._element_size(dtype)
+
+
+def _split_by_size_and_type(
+    bins, items: List[WriteItem]
+) -> List[List[WriteItem]]:
+    if bins == 1:
+        return [items]
+
+    bytes_w = [wi for wi in items if wi.type == WriteItemType.BYTE_IO]
+    tensor_w = [wi for wi in items if wi.type != WriteItemType.BYTE_IO]
+
+    buckets: List[List[WriteItem]] = [[] for _ in range(bins)]
+    bucket_sizes = [0 for _ in range(bins)]
+
+    tensor_w.sort(key=_item_size, reverse=True)
+
+    for i, wi in enumerate(bytes_w):
+        buckets[i % bins].append(wi)
+
+    for wi in tensor_w:
+        # TODO replace with headq
+        idx = min(enumerate(bucket_sizes), key=lambda x: x[1])[0]
+        buckets[idx].append(wi)
+        bucket_sizes[idx] += _item_size(wi)
+
+    return buckets
+
+
 def _write_item(stream, data, write_item, storage_key):
     offset = stream.tell()
 
@@ -93,38 +245,57 @@ def _write_item(stream, data, write_item, storage_key):
 
 
 def _write_files_from_queue(
-    file_queue: List,
+    file_queue: queue.Queue,
+    result_queue: queue.Queue,
     planner: SavePlanner,
+    inflight_threshhold: int,
     use_fsync: bool,
 ):
-    write_results = []
+    try:
+        while True:
+            file_name, storage_key, write_items = file_queue.get_nowait()
+            loader: _TensorLoader
 
-    for file_path, file_name, write_items in file_queue:
-        tensor_w = [
-            wi for wi in write_items if wi.type != WriteItemType.BYTE_IO
-        ]
-        bytes_w = [wi for wi in write_items if wi.type == WriteItemType.BYTE_IO]
-
-        with open(file_path, "wb") as stream:
-            for write_item in bytes_w:
-                data = planner.resolve_data(write_item)
-                write_results.append(
-                    _write_item(stream, data, write_item, file_name)
+            if torch.cuda.is_available() and inflight_threshhold > 0:
+                loader = _OverlappingCpuLoader(
+                    lambda x: planner.resolve_data(x),
+                    inflight_threshhold=inflight_threshhold,
+                )
+            else:
+                loader = _SerialCpuLoader(
+                    lambda x: planner.resolve_data(x),
                 )
 
+            tensor_w = [
+                wi for wi in write_items if wi.type != WriteItemType.BYTE_IO
+            ]
             for write_item in tensor_w:
-                tensor = _trim(
-                    cast(torch.Tensor, planner.resolve_data(write_item))
-                )
-                assert not tensor.is_cuda
-                write_results.append(
-                    _write_item(stream, tensor, write_item, file_name)
-                )
+                loader.add(_item_size(write_item), write_item)
+            loader.start_loading()
 
-            if use_fsync:
-                os.fsync(stream.fileno())
+            bytes_w = [
+                wi for wi in write_items if wi.type == WriteItemType.BYTE_IO
+            ]
+            write_results = []
 
-    return write_results
+            with open(file_name, "wb") as stream:
+                for write_item in bytes_w:
+                    data = planner.resolve_data(write_item)
+                    write_results.append(
+                        _write_item(stream, data, write_item, storage_key)
+                    )
+
+                for tensor, write_item in loader.values():
+                    assert not tensor.is_cuda
+                    write_results.append(
+                        _write_item(stream, tensor, write_item, storage_key)
+                    )
+
+                if use_fsync:
+                    os.fsync(stream.fileno())
+            result_queue.put(write_results)
+    except queue.Empty:
+        pass
 
 
 class FileSystemWriter(StorageWriter):
@@ -146,6 +317,8 @@ class FileSystemWriter(StorageWriter):
         path: Union[str, os.PathLike],
         single_file_per_rank: bool = False,
         sync_files: bool = True,
+        thread_count: int = 1,
+        per_thread_copy_ahead: int = 10_000_000,
     ) -> None:
         """
         Initialize the writer pointing to `path`
@@ -153,7 +326,9 @@ class FileSystemWriter(StorageWriter):
         Args:
             path: diretory where the checkpoint will be writen to.
             single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
-            sync_files: force files to be synced to permanent storage. Default to True.
+            sync_files : force files to be synced to permanent storage. Default to True.
+            thread_count: Number of IO threads to use to write. Default to 1.
+            per_thread_copy_ahead: How many bytes to copy from the GPU ahead of saving then. Default 10Mb.
 
         N. B. If sync_files is disabled, there's no guarantee that the checkpoint will be consistent in the case of a failure.
         """
@@ -161,6 +336,8 @@ class FileSystemWriter(StorageWriter):
         self.path = Path(path)
         self.single_file_per_rank = single_file_per_rank
         self.sync_files = sync_files
+        self.thread_count = thread_count
+        self.per_thread_copy_ahead = per_thread_copy_ahead
 
     def init(self, is_coordinator: bool) -> None:
         pass
@@ -194,24 +371,56 @@ class FileSystemWriter(StorageWriter):
             file_count += 1
             return file_name
 
-        file_queue = []
+        file_queue: queue.Queue = queue.Queue()
         if self.single_file_per_rank:
-            file_name = gen_file()
-            file_queue.append((self.path / file_name, file_name, plan.items))
+            for bucket in _split_by_size_and_type(
+                self.thread_count, plan.items
+            ):
+                file_name = gen_file()
+                file_queue.put((self.path / file_name, file_name, bucket))
         else:
             for item in plan.items:
                 file_name = gen_file()
-                file_queue.append((self.path / file_name, file_name, [item]))
+                file_queue.put((self.path / file_name, file_name, [item]))
 
-        results = _write_files_from_queue(
+        result_queue: queue.Queue = queue.Queue()
+
+        threads = []
+        for _ in range(1, self.thread_count):
+            t = threading.Thread(
+                target=_write_files_from_queue,
+                args=(
+                    file_queue,
+                    result_queue,
+                    planner,
+                    self.per_thread_copy_ahead,
+                    self.sync_files,
+                ),
+            )
+            t.start()
+            threads.append(t)
+
+        _write_files_from_queue(
             file_queue=file_queue,
+            result_queue=result_queue,
             planner=planner,
+            inflight_threshhold=self.per_thread_copy_ahead,
             use_fsync=self.sync_files,
         )
 
-        fut: Future[List[WriteResult]] = Future()
-        fut.set_result(results)
-        return fut
+        for t in threads:
+            t.join()
+
+        res = []
+        try:
+            while True:
+                res += result_queue.get_nowait()
+        except queue.Empty:
+            pass
+
+            fut: Future[List[WriteResult]] = Future()
+            fut.set_result(res)
+            return fut
 
     def finish(
         self, metadata: Metadata, results: List[List[WriteResult]]

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -38,6 +38,12 @@ from .planner import (
 
 from torch.distributed._shard._utils import narrow_tensor_by_index
 
+__all__ = [
+    "FileSystemWriter",
+    "SlicedBufferedReader",
+    "FileSystemReader",
+]
+
 
 @dataclass
 class _StorageInfo:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -366,10 +366,8 @@ if TEST_WITH_TSAN:
     TIMEOUT_DEFAULT = 500
 else:
     TIMEOUT_DEFAULT = int(os.getenv('DISTRIBUTED_TESTS_DEFAULT_TIMEOUT', '300'))
-TIMEOUT_OVERRIDE = {
-    "test_ddp_uneven_inputs": 400,
-    "test_file_system_checkpoint": 1200
-}
+TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400}
+
 
 # https://github.com/pytorch/pytorch/issues/75665
 if TEST_WITH_ROCM:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -366,7 +366,10 @@ if TEST_WITH_TSAN:
     TIMEOUT_DEFAULT = 500
 else:
     TIMEOUT_DEFAULT = int(os.getenv('DISTRIBUTED_TESTS_DEFAULT_TIMEOUT', '300'))
-TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400, "test_file_system_checkpoint": 600}
+TIMEOUT_OVERRIDE = {
+    "test_ddp_uneven_inputs": 400,
+    "test_file_system_checkpoint": 1200
+}
 
 # https://github.com/pytorch/pytorch/issues/75665
 if TEST_WITH_ROCM:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -365,8 +365,8 @@ if TEST_WITH_TSAN:
     # TSAN runs much slower.
     TIMEOUT_DEFAULT = 500
 else:
-    TIMEOUT_DEFAULT = int(os.getenv("DISTRIBUTED_TESTS_DEFAULT_TIMEOUT", "300"))
-TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400}
+    TIMEOUT_DEFAULT = int(os.getenv('DISTRIBUTED_TESTS_DEFAULT_TIMEOUT', '300'))
+TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400, "test_file_system_checkpoint": 600}
 
 # https://github.com/pytorch/pytorch/issues/75665
 if TEST_WITH_ROCM:

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -91,6 +91,6 @@ def with_comms(func=None, init_rpc=True, backend="nccl"):
         if backend == "nccl" and torch.cuda.device_count() < self.world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
         self.init_comms(init_rpc=init_rpc, backend=backend)
-        func(self)
+        func(self, *args, **kwargs)
         self.destroy_comms(destroy_rpc=init_rpc)
     return wrapper


### PR DESCRIPTION
This PR includes:

Changes from @kumpera (https://github.com/pytorch/pytorch/pull/86327): adding MultiThreaded FileSystemWriter for distributed checkpointing, which adds two knobs to FileSystemWriter: thread_count and per_thread_copy_ahead. This increases up to 50% performance improvement on 32 GPUS workloads on AWS.
Add parametrize tests to /test/distributed/_shard/checkpoint/test_file_system_checkpoint.py and /test/distributed/_shard/checkpoint/test_file_system_checkpoint_cpu.py
Modify @with_comms in ShardedTensorTestBase to take in *args and **kwargs.
Tests:

```
python3 test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
```

test/distributed/checkpoint/test_file_system_checkpoint.py(GPU tests) runs fine locally but would timeout on CI. We will use thread-based PG and update this test in following PR.

[T134844615]

## Add docstring and update comments in the following PRs.

cc @VitalyFedyunin @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10