### PR TITLE
Disable slow-gradcheck tests

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -31,7 +31,7 @@ jobs:
   linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-test:
     # Disable because slow-gradcheck tests take > 4 hrs and time out.
     # TODO(sdym@meta.com): investigate re-enabling slow-gradcheck tests.
-    if: false  
+    if: false
     name: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -14,6 +14,9 @@ concurrency:
 
 jobs:
   linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build:
+    # Disable because slow-gradcheck tests take > 4 hrs and time out.
+    # TODO(sdym@meta.com): investigate re-enabling slow-gradcheck tests.
+    if: false
     name: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
     uses: ./.github/workflows/_linux-build.yml
     with:
@@ -26,6 +29,9 @@ jobs:
         ]}
 
   linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-test:
+    # Disable because slow-gradcheck tests take > 4 hrs and time out.
+    # TODO(sdym@meta.com): investigate re-enabling slow-gradcheck tests.
+    if: false  
     name: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build


### PR DESCRIPTION
Disable because slow-gradcheck tests take > 4 hrs and time out. Will need to figure out if and how to re-enable later.

