### PR TITLE
ci: Switch merge / revert flow to our own infra

### DIFF
--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   do_revert:
     name: try_revert_pr_${{ github.event.client_payload.pr_num }}
-    runs-on: linux.20_04.4x
+    runs-on: linux.large.ephemeral
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   do_merge:
     name: try_merge_pr_${{ github.event.client_payload.pr_num }}
-    runs-on: linux.20_04.4x
+    runs-on: linux.large.ephemeral
     env:
         GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:


### PR DESCRIPTION
[ci skip]

Switches our revert and merge workflows to utilize ephemeral runners within our own infra to facilitate merging since it appears as though using Custom hosted runners resulted in longer queueing times than expected

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Fixes #ISSUE_NUMBER
