### PR TITLE
[FSDP] Enable `use_orig_params=True` test

### DIFF
--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -240,7 +240,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         "sharding_strategy_str",
         ["no_shard", "shard_grad_op", "full_shard"],
     )
-    def _test_diff_hyperparams_cpu_offload(self, sharding_strategy_str: str):
+    def test_diff_hyperparams_cpu_offload(self, sharding_strategy_str: str):
         """
         Tests FSDP parity with DDP when using multiple parameter groups with
         different hyperparameter settings with CPU offloading enabled. This is

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -236,6 +236,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
             sharding_strategy=sharding_strategy,
         )
 
+    @skip_if_lt_x_gpu(2)
     @parametrize(
         "sharding_strategy_str",
         ["no_shard", "shard_grad_op", "full_shard"],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#88034 [FSDP] Enable `use_orig_params=True` test**
* #87916 [FSDP()][2/N] Refactor training state
* #87915 [FSDP()][1/N] Start refactoring FSDP root pre-forward
* #87812 [FSDP] ufmt FSDP test
* #87811 [FSDP] ufmt /fsdp

I accidentally committed the `use_orig_params` PR with this test disabled. This PR simply re-enables it. It passes locally, so if CI is green, then this is an easy land.