### PR TITLE
Cleaned up the nvFuser Python Frontend Batch Norm printing

### DIFF
--- a/torch/_prims/nvfuser_prims.py
+++ b/torch/_prims/nvfuser_prims.py
@@ -214,6 +214,8 @@ _nvfuser_impls["{fname}"] = _{fname}_nvfuser
 def _native_batch_norm_nvfuser(
     fd, input, weight, bias, running_mean, running_var, training, momentum, eps
 ):
+
+    """
     if weight is None:
         weight = fd.define_null_tensor()
     if bias is None:
@@ -222,15 +224,16 @@ def _native_batch_norm_nvfuser(
         running_mean = fd.define_null_tensor()
     if running_var is None:
         running_var = fd.define_null_tensor()
+    """
     return fd.ops.batch_norm(
         input,
         weight,
         bias,
         running_mean,
         running_var,
-        training,
         momentum,
         eps,
+        training,
     )
 
 

--- a/torch/csrc/jit/codegen/cuda/python_frontend/fusion_record.h
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/fusion_record.h
@@ -1476,7 +1476,7 @@ struct BatchNormOpRecord : RecordFunctor {
     fd.setFusionState(outputs_.at(1).index, output.mean);
     fd.setFusionState(outputs_.at(2).index, output.invstd);
   }
-  
+
   virtual void print(std::ostream& os, bool close_function = true) const final {
     RecordFunctor::print(os, false);
     os << ", training=" << (training_ ? "True" : "False");

--- a/torch/csrc/jit/codegen/cuda/python_frontend/fusion_record.h
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/fusion_record.h
@@ -23,7 +23,6 @@ enum class RecordType {
   Constant,
   End,
   Tensor,
-  NullTensor,
   Output,
   ReductionOp,
   Scalar,
@@ -144,13 +143,14 @@ struct RecordFunctor {
         os << ", ";
       }
       if (arg.stype == StateType::Scalar) {
-        os << "S";
+        os << "S" << arg.index;
       } else if (arg.stype == StateType::Tensor) {
-        os << "T";
+        os << "T" << arg.index;
+      } else if (arg.stype == StateType::None) {
+        os << "None";
       } else {
         TORCH_INTERNAL_ASSERT(false, "Unsupported StateType");
       }
-      os << arg.index;
     }
     if (close_function) {
       os << ")";
@@ -974,6 +974,7 @@ struct TensorRecord : RecordFunctor {
       }
     }
     os << "], dtype=" << dtypeToPyString(dtype_);
+    os << ", is_cpu=" << (is_cpu_ ? "True" : "False");
     if (close_function) {
       os << ")";
     }
@@ -991,41 +992,6 @@ struct TensorRecord : RecordFunctor {
   Nvf::DataType dtype_;
   //! Notes a scalar CPU Tensor
   bool is_cpu_;
-};
-
-struct NullTensorRecord : RecordFunctor {
-  NullTensorRecord(std::vector<State> _outputs)
-      : RecordFunctor(
-            {},
-            std::move(_outputs),
-            "null_tensor",
-            RecordType::NullTensor) {}
-  virtual ~NullTensorRecord() = default;
-  virtual RecordFunctor* clone() final {
-    return new NullTensorRecord(*this);
-  }
-
-  //! Nothing extra necessary in hash
-  //! Child specific hash function in lower 32 bits.
-  //! | 31 ---------------------------------------  0 |
-  //! | None                                          |
-  virtual size_t hash() const final {
-    auto result = RecordFunctor::hash();
-    return result;
-  }
-
-  virtual bool operator==(const RecordFunctor& other) const final {
-    auto result = false;
-    if (dynamic_cast<const NullTensorRecord*>(&other)) {
-      result = RecordFunctor::operator==(other);
-    }
-    return result;
-  }
-
-  virtual void operator()(FusionDefinition& fd) final {
-    Nvf::TensorView* tv = nullptr;
-    fd.setFusionState(outputs_.at(0).index, tv);
-  }
 };
 
 //! Specialized Record Functor for recording FusionDefinition outputs.
@@ -1482,12 +1448,18 @@ struct BatchNormOpRecord : RecordFunctor {
 
   void operator()(FusionDefinition& fd) final {
     auto x = fd.getFusionState(args_.at(0).index)->as<Nvf::TensorView>();
-    auto weight = fd.getFusionState(args_.at(1).index)->as<Nvf::TensorView>();
-    auto bias = fd.getFusionState(args_.at(2).index)->as<Nvf::TensorView>();
-    auto running_mean =
-        fd.getFusionState(args_.at(3).index)->as<Nvf::TensorView>();
-    auto running_var =
-        fd.getFusionState(args_.at(4).index)->as<Nvf::TensorView>();
+    auto weight = (args_.at(1).stype == StateType::Tensor)
+        ? fd.getFusionState(args_.at(1).index)->as<Nvf::TensorView>()
+        : nullptr;
+    auto bias = (args_.at(2).stype == StateType::Tensor)
+        ? fd.getFusionState(args_.at(2).index)->as<Nvf::TensorView>()
+        : nullptr;
+    auto running_mean = (args_.at(3).stype == StateType::Tensor)
+        ? fd.getFusionState(args_.at(3).index)->as<Nvf::TensorView>()
+        : nullptr;
+    auto running_var = (args_.at(4).stype == StateType::Tensor)
+        ? fd.getFusionState(args_.at(4).index)->as<Nvf::TensorView>()
+        : nullptr;
     auto momentum = fd.getFusionState(args_.at(5).index)->as<Nvf::Val>();
     auto eps = fd.getFusionState(args_.at(6).index)->as<Nvf::Val>();
     auto output = Nvf::batch_norm(
@@ -1503,6 +1475,15 @@ struct BatchNormOpRecord : RecordFunctor {
     fd.setFusionState(outputs_.at(0).index, output.output);
     fd.setFusionState(outputs_.at(1).index, output.mean);
     fd.setFusionState(outputs_.at(2).index, output.invstd);
+  }
+  
+  virtual void print(std::ostream& os, bool close_function = true) const final {
+    RecordFunctor::print(os, false);
+    os << ", training=" << (training_ ? "True" : "False");
+    os << ", channels_last=" << (channels_last_ ? "True" : "False");
+    if (close_function) {
+      os << ")";
+    }
   }
 
  private:


### PR DESCRIPTION
* Removed `define_null_tensor` usage in favor of using optional arguments for binding.
* Re-ordered the non-State arguments for easier printing.
* Added a printing function to include booleans `training` and `channels_last`
* Fixed `define_tensor` to print `is_cpu`

cc @jjsjann123