### PR TITLE
torchdynamo: don't always convert input to contiguous when runing aten.convolution fake model

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1542,28 +1542,29 @@ class CommonTemplate:
 
     @unittest.skipIf(HAS_CUDA, "only support cpu channels_last")
     def test_conv2d_channels_last(self):
-        m = torch.nn.Sequential(
-            torch.nn.Conv2d(3, 3, 1, 1),
-            ToTuple(),
-        )
-        # only weight is channels_last
-        self.common(
-            m.to(memory_format=torch.channels_last),
-            (torch.randn([2, 3, 16, 16]),),
-            check_lowp=False,
-        )
-        # only activation is channels_last
-        self.common(
-            m,
-            (torch.randn([2, 3, 16, 16]).to(memory_format=torch.channels_last),),
-            check_lowp=False,
-        )
-        # activation and weight are all channels_last
-        self.common(
-            m.to(memory_format=torch.channels_last),
-            (torch.randn([2, 3, 16, 16]).to(memory_format=torch.channels_last),),
-            check_lowp=False,
-        )
+        for kernel_size in [1, 2]:
+            m = torch.nn.Sequential(
+                torch.nn.Conv2d(3, 3, kernel_size, 1),
+                ToTuple(),
+            )
+            # only weight is channels_last
+            self.common(
+                m.to(memory_format=torch.channels_last),
+                (torch.randn([2, 3, 16, 16]),),
+                check_lowp=False,
+            )
+            # only activation is channels_last
+            self.common(
+                m,
+                (torch.randn([2, 3, 16, 16]).to(memory_format=torch.channels_last),),
+                check_lowp=False,
+            )
+            # activation and weight are all channels_last
+            self.common(
+                m.to(memory_format=torch.channels_last),
+                (torch.randn([2, 3, 16, 16]).to(memory_format=torch.channels_last),),
+                check_lowp=False,
+            )
 
     def test_conv2d_backward_channels_last(self):
         def fn(grad_output, inp, weight):
@@ -1595,25 +1596,34 @@ class CommonTemplate:
 
     @unittest.skipIf(HAS_CUDA, "only support cpu channels_last")
     def test_conv3d_channels_last(self):
-        m = torch.nn.Sequential(
-            torch.nn.Conv3d(3, 3, 1, 1),
-            ToTuple(),
-        )
-        # only weight is channels_last
-        self.common(
-            m.to(memory_format=torch.channels_last_3d),
-            (torch.randn([2, 3, 16, 16, 16]),),
-        )
-        # only activation is channels_last
-        self.common(
-            m,
-            (torch.randn([2, 3, 16, 16, 16]).to(memory_format=torch.channels_last_3d),),
-        )
-        # activation and weight are all channels_last
-        self.common(
-            m.to(memory_format=torch.channels_last_3d),
-            (torch.randn([2, 3, 16, 16, 16]).to(memory_format=torch.channels_last_3d),),
-        )
+        for kernel_size in [1, 2]:
+            m = torch.nn.Sequential(
+                torch.nn.Conv3d(3, 3, kernel_size, 1),
+                ToTuple(),
+            )
+            # only weight is channels_last
+            self.common(
+                m.to(memory_format=torch.channels_last_3d),
+                (torch.randn([2, 3, 16, 16, 16]),),
+            )
+            # only activation is channels_last
+            self.common(
+                m,
+                (
+                    torch.randn([2, 3, 16, 16, 16]).to(
+                        memory_format=torch.channels_last_3d
+                    ),
+                ),
+            )
+            # activation and weight are all channels_last
+            self.common(
+                m.to(memory_format=torch.channels_last_3d),
+                (
+                    torch.randn([2, 3, 16, 16, 16]).to(
+                        memory_format=torch.channels_last_3d
+                    ),
+                ),
+            )
 
     def test_adaptive_avg_pool2d1(self):
         def fn(x):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2259,10 +2259,14 @@ class ExternKernel(InputsKernel):
                     new_args.append(next(it_non_tensors))
             return pytree.tree_unflatten(new_args, args_spec)
 
-        tensor_args = [
-            cls.require_contiguous(cls.realize_input(x)) for x in tensor_args
-        ]
-
+        if kernel == torch.ops.aten.convolution:
+            tensor_args = [
+                cls.require_stride1(cls.realize_input(x)) for x in tensor_args
+            ]
+        else:
+            tensor_args = [
+                cls.require_contiguous(cls.realize_input(x)) for x in tensor_args
+            ]
         # We don't have generic shape formulas, so just burn in the
         # shapes and run an example input.
         # TODO(jansel): replace this with dynamic shape formulas


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88067

Fake Tensor For (Conv) Propagation introduced by https://github.com/pytorch/pytorch/pull/87641, it always convert the inputs to contiguous, it doesn't make sense, we need to use the origin layout to do the Propagation.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx