### PR TITLE
Force numpy prod to use 64 bit integers on Windows in some tests

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -105,6 +105,7 @@ from torch.testing._internal.opinfo.refs import (  # NOQA: F401
 from torch.testing._internal.opinfo.utils import (
     np_unary_ufunc_integer_promotion_wrapper,
     reference_reduction_numpy,
+    numpy_prod_with_int64
 )
 from torch.testing._internal import opinfo
 from torch.testing._internal.opinfo.definitions.linalg import (
@@ -16468,7 +16469,7 @@ op_db: List[OpInfo] = [
         dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16),
         dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16, torch.chalf),
         sample_inputs_func=sample_inputs_prod,
-        ref=reference_reduction_numpy(np.prod),
+        ref=numpy_prod_with_int64(),
         skips=(
             # FIXME: prod does not support passing keepdim without passing dim
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_default_keepdim'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -105,7 +105,7 @@ from torch.testing._internal.opinfo.refs import (  # NOQA: F401
 from torch.testing._internal.opinfo.utils import (
     np_unary_ufunc_integer_promotion_wrapper,
     reference_reduction_numpy,
-    numpy_prod_with_int64
+    prod_numpy
 )
 from torch.testing._internal import opinfo
 from torch.testing._internal.opinfo.definitions.linalg import (
@@ -16469,7 +16469,7 @@ op_db: List[OpInfo] = [
         dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16),
         dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16, torch.chalf),
         sample_inputs_func=sample_inputs_prod,
-        ref=numpy_prod_with_int64(),
+        ref=prod_numpy,
         skips=(
             # FIXME: prod does not support passing keepdim without passing dim
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_default_keepdim'),

--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -26,10 +26,7 @@ from torch.testing._internal.opinfo.core import (
     sample_inputs_reduction,
     SampleInput,
 )
-from torch.testing._internal.opinfo.utils import (
-    reference_reduction_numpy,
-    numpy_prod_with_int64
-)
+from torch.testing._internal.opinfo.utils import prod_numpy, reference_reduction_numpy
 
 # Used for log_softmax, softmax, softmin
 def sample_inputs_softmax_variant(
@@ -436,7 +433,7 @@ op_db: List[OpInfo] = [
     ),
     ReductionOpInfo(
         "masked.prod",
-        ref=numpy_prod_with_int64(),
+        ref=prod_numpy,
         method_variant=None,
         identity=1,
         nan_policy="propagate",

--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -26,8 +26,10 @@ from torch.testing._internal.opinfo.core import (
     sample_inputs_reduction,
     SampleInput,
 )
-from torch.testing._internal.opinfo.utils import reference_reduction_numpy
-
+from torch.testing._internal.opinfo.utils import (
+    reference_reduction_numpy,
+    numpy_prod_with_int64
+)
 
 # Used for log_softmax, softmax, softmin
 def sample_inputs_softmax_variant(
@@ -434,7 +436,7 @@ op_db: List[OpInfo] = [
     ),
     ReductionOpInfo(
         "masked.prod",
-        ref=reference_reduction_numpy(np.prod),
+        ref=numpy_prod_with_int64(),
         method_variant=None,
         identity=1,
         nan_policy="propagate",

--- a/torch/testing/_internal/opinfo/utils.py
+++ b/torch/testing/_internal/opinfo/utils.py
@@ -259,13 +259,22 @@ def reference_reduction_numpy(f, supports_keepdims=True):
 
     return wrapper
 
-def numpy_prod_with_int64(): 
-    g = reference_reduction_numpy(np.prod)
 
-    @wraps(g)
-    def wrapper(x: np.ndarray, *args, **kwargs):
-        if x.dtype == np.int8 or x.dtype == np.int16 or x.dtype == np.int32:
-            kwargs["dtype"] = np.int64
-        return g(x, *args, **kwargs)
+def prod_numpy(a, *args, **kwargs):
+    """
+    The function will call np.prod with type as np.int64 if the input type
+    is int or uint64 if is uint. This is necessary because windows np.prod uses by default
+    int32 while on linux it uses int64.
+    This is for fixing integer overflow https://github.com/pytorch/pytorch/issues/77320
 
-    return wrapper
+    Returns:
+        np.prod of input
+    """
+    if "dtype" not in kwargs:
+        if np.issubdtype(a.dtype, np.signedinteger):
+            a = a.astype(np.int64)
+        elif np.issubdtype(a.dtype, np.unsignedinteger):
+            a = a.astype(np.uint64)
+
+    fn = reference_reduction_numpy(np.prod)
+    return fn(a, *args, **kwargs)

--- a/torch/testing/_internal/opinfo/utils.py
+++ b/torch/testing/_internal/opinfo/utils.py
@@ -258,3 +258,14 @@ def reference_reduction_numpy(f, supports_keepdims=True):
         return result
 
     return wrapper
+
+def numpy_prod_with_int64(): 
+    g = reference_reduction_numpy(np.prod)
+
+    @wraps(g)
+    def wrapper(x: np.ndarray, *args, **kwargs):
+        if x.dtype == np.int8 or x.dtype == np.int16 or x.dtype == np.int32:
+            kwargs["dtype"] = np.int64
+        return g(x, *args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
This fixes some prod and masked.prod tests on Windows. 

np.prod uses int32 on Windows so it overflows.

On Linux it uses by default int64.

Fixes #77305 
Fixes #77320 
Fixes #77334 
Fixes #77335 
Fixes #77336 
Fixes #77337
