### PR TITLE
Reenable slow gradcheck CI and skip composite compliance tests

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -14,9 +14,6 @@ concurrency:
 
 jobs:
   linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build:
-    # Disable because slow-gradcheck tests take > 4 hrs and time out.
-    # TODO(sdym@meta.com): investigate re-enabling slow-gradcheck tests.
-    if: false
     name: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
     uses: ./.github/workflows/_linux-build.yml
     with:
@@ -29,9 +26,6 @@ jobs:
         ]}
 
   linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-test:
-    # Disable because slow-gradcheck tests take > 4 hrs and time out.
-    # TODO(sdym@meta.com): investigate re-enabling slow-gradcheck tests.
-    if: false
     name: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build

--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -8,8 +8,10 @@ import torch._dynamo
 import torch._dynamo.config
 import torch._dynamo.test_case
 import torch._dynamo.testing
+from torch.testing._internal.common_utils import skipIfSlowGradcheckEnv
 
 
+@skipIfSlowGradcheckEnv
 class RecompileUxTests(torch._dynamo.test_case.TestCase):
     # TODO(whc) dynamo actualy recompiles one more time than the cache limit
     cache_limit = 1

--- a/test/inductor/test_smoke.py
+++ b/test/inductor/test_smoke.py
@@ -5,6 +5,7 @@ import unittest
 import torch
 import torch._dynamo as torchdynamo
 import torch._inductor.config as torchinductor_config
+from torch.testing._internal.common_utils import skipIfSlowGradcheckEnv
 
 torchdynamo.config.log_level = logging.INFO
 torchdynamo.config.verbose = True
@@ -23,6 +24,7 @@ class MLP(torch.nn.Module):
         return x
 
 
+@skipIfSlowGradcheckEnv
 class SmokeTest(unittest.TestCase):
     def test_mlp(self):
         mlp = torchdynamo.optimize("inductor")(MLP().cuda())

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_utils import (
     shell,
     set_cwd,
     parser as common_parser,
+    is_slow_gradcheck_env,
 )
 import torch.distributed as dist
 from torch.multiprocessing import get_context
@@ -628,6 +629,9 @@ def run_doctests(test_module, test_directory, options):
     Assumes the incoming test module is called doctest, and simply executes the
     xdoctest runner on the torch library itself.
     """
+    # Maybe there's a better place to do this skip?
+    if is_slow_gradcheck_env():
+        return 1
     import xdoctest
     import pathlib
     pkgpath = pathlib.Path(torch.__file__).parent

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -8,7 +8,7 @@ import warnings
 
 import torch
 import torch.hub as hub
-from torch.testing._internal.common_utils import retry, IS_SANDCASTLE, TestCase
+from torch.testing._internal.common_utils import retry, IS_SANDCASTLE, TestCase, skipIfSlowGradcheckEnv
 
 
 def sum_of_state_dict(state_dict):
@@ -22,6 +22,7 @@ SUM_OF_HUB_EXAMPLE = 431080
 TORCHHUB_EXAMPLE_RELEASE_URL = 'https://github.com/ailzhang/torchhub_example/releases/download/0.1/mnist_init_ones'
 
 
+@skipIfSlowGradcheckEnv
 @unittest.skipIf(IS_SANDCASTLE, 'Sandcastle cannot ping external')
 class TestHub(TestCase):
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1333,6 +1333,7 @@ class TestCommon(TestCase):
         self.fail(msg)
 
 
+@skipIfSlowGradcheckEnv
 class TestCompositeCompliance(TestCase):
     # Checks if the operator (if it is composite) is written to support most
     # backends and Tensor subclasses. See "CompositeImplicitAutograd Compliance"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #85849
* #79056
* __->__ #88093

Fixes: https://github.com/pytorch/pytorch/issues/88010

~~Composite compliance tests don't use gradcheck, but can be slow: https://raw.githubusercontent.com/pytorch/test-infra/generated-stats/stats/slow-tests.json. The cc tests for pca/svd low-rank combine to increase test time by >30min, so we may want to skip these test for normal CI as well.~~

~~CC forward AD tests can be slow because one is testing all subclass + non-subclass combination for both primal and tangents, e.g. if my function has 3 arguments, I end up running forward AD 2^3 x 2^3 = 64 times.~~

The above might not actually matter because it actually applies to the other slow-gradcheck shard (and indeed its test time has been reduced by 30 minutes). The real issue is that the automatic test sharding doesn't work well when some tests that don't have test time information:

dynamo/test_recompile_ux
inductor/test_smoke
lazy/test_bindings
lazy/test_meta_kernel
test_comparison_utils
test_hub
doctest

test_ops_gradients alone takes 3.3h, but it is in the same shard as the tests above.

Solution 1: just manually shard again:
- this might be the way forward if having tests that don't have timing information is something that we can't avoid
- it just makes the call run_test slightly less clean

Solution 2: allow list instead of block list tests that should run under slow:
- this is good because we won't have to periodically skip slow tests anymore, but runs the risk of accidentally skipping some tests that use gradcheck

Solution 3: skip the tests above (because they don't use gradcheck)
- pros: no risk of skipping tests that use gradcheck
- cons: hard to skip doctest in a super clean way + there might be more tests that don't having timing information, so this might be annoying to do 

The current PR applies solution 3 to minimize the blast radius, solution 1 seems OK also if there are just too many tests that lack timing information, solution 2 may require more thorough investigation to confirm which tests use gradcheck (so I'm less inclined to do that)

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx