### PR TITLE
[torch::deploy] add gpu unit tests to CI

### DIFF
--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -163,7 +163,7 @@ function checkout_install_torchdeploy() {
   git clone --recurse-submodules https://github.com/pytorch/multipy.git
   pushd multipy
   python multipy/runtime/example/generate_examples.py
-  pip install -e --build-arg BUILD_CUDA_TESTS=1 .
+  pip install -e . --install-option="--cudatests"
   popd
   popd
 }

--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -164,7 +164,7 @@ function checkout_install_torchdeploy() {
   pushd multipy
   # with ABI flag change
   python multipy/runtime/example/generate_examples.py
-  pip install -e . --install-option="--abicxx"
+  pip install -e --build-arg BUILD_CUDA_TESTS=1 .
   popd
   popd
 }
@@ -173,6 +173,7 @@ function test_torch_deploy(){
  pushd ..
  pushd multipy
  ./multipy/runtime/build/test_deploy
+ ./multipy/runtime/build/test_deploy_gpu
  popd
  popd
 }

--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -162,7 +162,6 @@ function checkout_install_torchdeploy() {
   pushd ..
   git clone --recurse-submodules https://github.com/pytorch/multipy.git
   pushd multipy
-  # with ABI flag change
   python multipy/runtime/example/generate_examples.py
   pip install -e --build-arg BUILD_CUDA_TESTS=1 .
   popd


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88107

Adds `torch::deploy`'s GPU tests to core CI to make sure core changes don't break them.

Overall, deploy tests take 11 min, so it shouldn't be much of a burden :)  https://github.com/pytorch/pytorch/actions/runs/3364231795/jobs/5578861939

Differential Revision: [D40861442](https://our.internmc.facebook.com/intern/diff/D40861442)