### PR TITLE
call contiguous on BMM inputs for NT on CUDA

### DIFF
--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp
@@ -44,16 +44,16 @@ Tensor nested_from_padded_cuda(
     const Tensor& sizes,
     bool do_transform_0213) {
   if (padded.dim() > 1 && padded.dim() < 5) {
+    // Instead of erroring call the generic version
+    if(!(padded.dim() == 4 && do_transform_0213) && !(padded.dim() == 3 && !do_transform_0213)){
+      return at::native::nested_from_padded_generic(padded, sizes, do_transform_0213);
+    }
     if (padded.dtype() != kFloat && padded.dtype() != kHalf) {
       TORCH_WARN_ONCE(
           "nested_from_padded CUDA kernels only support fp32/fp16; falling "
           "back to slower generic kernel");
       return at::native::nested_from_padded_generic(padded, sizes, do_transform_0213);
     }
-    TORCH_CHECK(
-        (padded.dim() == 4 && do_transform_0213) ||
-            (padded.dim() == 3 && !do_transform_0213),
-        "padded tensor size error: ", padded.dim());
     Tensor target_offsets =
         NestedTensor_batch_offsets_from_size_tensor(sizes, 0);
     Tensor padded_sizes_tensor = at::tensor(padded.sizes());

--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cu
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cu
@@ -607,9 +607,13 @@ Tensor bmm_nested_cuda(const Tensor& self, const Tensor& mat2) {
     AT_ERROR(
         "Expected both to be nested, but got a non-nested self and nested other");
   }
+  // TODO currently we only support contiguous NestedTensors
+  auto self_contiguous = self.contiguous();
+  auto mat2_contiguous = mat2.contiguous();
+
   // dispatcher should have guaranteed that at least one is nested
-  auto self_ptr = get_nested_tensor_impl(self);
-  auto mat2_ptr = get_nested_tensor_impl(mat2);
+  auto self_ptr = get_nested_tensor_impl(self_contiguous);
+  auto mat2_ptr = get_nested_tensor_impl(mat2_contiguous);
   TORCH_CHECK(self_ptr->dim() == 3, "batch1 must be a 3D tensor");
   TORCH_CHECK(mat2_ptr->dim() == 3, "batch2 must be a 3D tensor");
   int64_t ntensors = self_ptr->size(0), ntensors2 = mat2_ptr->size(0);

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1765,38 +1765,38 @@ class TestNestedTensorAutograd(TestCase):
     # Note [Gradcheck args check_batched_grad=False] the common_utils testing version of gradcheck
     # includes the default parameters used for testing ops with gradcheck. However nested tensor
     # does not support the stack op therefore we turn it off for these tests
-    def _create_leaf_nested_tensor_from_list(self, requires_grad=False):
-        return torch.nested.nested_tensor([torch.randn(1, 2),
-                                           torch.randn(7, 8)], requires_grad=requires_grad)
+    def _create_leaf_nested_tensor_from_list(self, tensor_device, requires_grad=False):
+        return torch.nested.nested_tensor([torch.randn(1, 2,),
+                                           torch.randn(7, 8)], requires_grad=requires_grad, device=tensor_device)
 
-    def _create_nested_tensor_from_list(self, requires_grad=False):
+    def _create_nested_tensor_from_list(self, tensor_device, requires_grad=False):
         return torch.nested.as_nested_tensor([torch.randn(1, 2, requires_grad=requires_grad),
-                                              torch.randn(7, 8, requires_grad=requires_grad)])
+                                              torch.randn(7, 8, requires_grad=requires_grad)], device=tensor_device)
 
-    def _create_nested_tensor_from_mask(self, requires_grad=False):
-        data = torch.randn(2, 3, 4, requires_grad=requires_grad)
+    def _create_nested_tensor_from_mask(self, tensor_device, requires_grad=False):
+        data = torch.randn(2, 3, 4, requires_grad=requires_grad, device=tensor_device)
         mask = torch.ones_like(data[:, :, 0]).bool()
         return torch._nested_tensor_from_mask(data, mask)
 
-    def test_as_nested_tensor_propagates_gradients(self):
-        a = torch.arange(3, dtype=torch.float)
-        b = torch.arange(5, dtype=torch.float)
+    def test_as_nested_tensor_propagates_gradients(self, device):
+        a = torch.arange(3, dtype=torch.float, device=device)
+        b = torch.arange(5, dtype=torch.float, device=device)
         nt = torch.nested.as_nested_tensor([a, b])
         # tensors with requires_grad=False are leaves
         self.assertTrue(nt.is_leaf)
         self.assertTrue(not nt.requires_grad)
 
-        a = torch.arange(3, dtype=torch.float, requires_grad=True)
-        b = torch.arange(5, dtype=torch.float, requires_grad=True)
+        a = torch.arange(3, dtype=torch.float, requires_grad=True, device=device)
+        b = torch.arange(5, dtype=torch.float, requires_grad=True, device=device)
         nt2 = torch.nested.as_nested_tensor([a, b])
-        fake_grad = torch.nested.nested_tensor([torch.ones_like(a), torch.zeros_like(b)])
+        fake_grad = torch.nested.nested_tensor([torch.ones_like(a), torch.zeros_like(b)], device=device)
         nt2.backward(fake_grad)
         self.assertEqual(a.grad, fake_grad[0])
         self.assertEqual(b.grad, fake_grad[1])
 
-    def test_nested_tensor_generates_leaf(self):
-        a = torch.arange(3, dtype=torch.float, requires_grad=True)
-        b = torch.arange(5, dtype=torch.float, requires_grad=True)
+    def test_nested_tensor_generates_leaf(self, device):
+        a = torch.arange(3, dtype=torch.float, requires_grad=True, device=device)
+        b = torch.arange(5, dtype=torch.float, requires_grad=True, device=device)
 
         nt = torch.nested.nested_tensor([a, b], requires_grad=False)
         self.assertTrue(nt.is_leaf)
@@ -1806,32 +1806,32 @@ class TestNestedTensorAutograd(TestCase):
         self.assertTrue(nt2.is_leaf)
         self.assertTrue(nt2.requires_grad)
 
-        fake_grad = torch.nested.nested_tensor([torch.ones_like(a), torch.zeros_like(b)])
+        fake_grad = torch.nested.nested_tensor([torch.ones_like(a), torch.zeros_like(b)], device=device)
         nt2.backward(fake_grad)
         self.assertEqual(nt2.grad, fake_grad)
         self.assertEqual(a.grad, None)
         self.assertEqual(b.grad, None)
 
-    def test_set_requires_grad_from_list(self):
-        nt = self._create_nested_tensor_from_list()
+    def test_set_requires_grad_from_list(self, device):
+        nt = self._create_nested_tensor_from_list(device)
         nt.requires_grad_()
         assert nt.requires_grad
 
-    def test_set_requires_grad_from_mask(self):
-        nt = self._create_nested_tensor_from_mask()
+    def test_set_requires_grad_from_mask(self, device):
+        nt = self._create_nested_tensor_from_mask(device)
         nt.requires_grad_()
         assert nt.requires_grad
 
-    def test_backward_for_add_op(self):
-        nt_1 = self._create_nested_tensor_from_mask()
-        nt_2 = self._create_nested_tensor_from_mask()
+    def test_backward_for_add_op(self, device):
+        nt_1 = self._create_nested_tensor_from_mask(device)
+        nt_2 = self._create_nested_tensor_from_mask(device)
 
         nt_1.requires_grad_()
         c = nt_1 + nt_2
 
         assert nt_1.requires_grad
         assert c.requires_grad
-        grad_output = self._create_nested_tensor_from_mask()
+        grad_output = self._create_nested_tensor_from_mask(device)
         c.backward(grad_output)
 
         #  Grad check doesn't work with nested yet.
@@ -1839,27 +1839,27 @@ class TestNestedTensorAutograd(TestCase):
         self.assertEqual(nt_1.grad, grad_output)
 
     # Test Factory Functions
-    def test_nested_tensor_to_padded_tensor(self):
+    def test_nested_tensor_to_padded_tensor(self, device):
         for padding_val in [0, 1]:
-            nt = self._create_leaf_nested_tensor_from_list(True)
+            nt = self._create_leaf_nested_tensor_from_list(tensor_device=device, requires_grad=True)
 
             out = torch.nested.to_padded_tensor(nt, padding_val)
-            grad_output = torch.ones(out.shape)
+            grad_output = torch.ones(out.shape, device=device)
             out.backward(grad_output)
 
-            self.assertEqual(nt.grad, torch.nested.nested_tensor([torch.ones(1, 2), torch.ones(7, 8)]))
+            self.assertEqual(nt.grad, torch.nested.nested_tensor([torch.ones(1, 2), torch.ones(7, 8)], device=device))
 
-    def test_nested_tensor_from_mask_and_to_padded(self):
+    def test_nested_tensor_from_mask_and_to_padded(self, device):
         N, L, D = 2, 4, 4
-        mask = torch.ones(N, L)
+        mask = torch.ones(N, L, device=device)
         for i in range(1, N):
-            end = torch.randint(1, L - 1, (1,))
+            end = torch.randint(1, L - 1, (1,), device=device)
             mask[i, end:] = 0
 
         mask[0, :] = 1
         mask = mask.bool()
 
-        data = torch.randn(N, L, D, requires_grad=True, dtype=torch.float64)
+        data = torch.randn(N, L, D, requires_grad=True, dtype=torch.float64, device=device)
 
         def grad_test_func(inpt):
             nt = torch._nested_tensor_from_mask(inpt, mask)
@@ -1867,9 +1867,9 @@ class TestNestedTensorAutograd(TestCase):
             return torch.nested.to_padded_tensor(nt, 0)
         assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
-    def test_nested_tensor_from_padded(self):
+    def test_nested_tensor_from_padded(self, device):
         nested_size = torch.tensor([[1, 2], [2, 2]])
-        padded_tensor = torch.randn(2, 2, 2, dtype=torch.float64)
+        padded_tensor = torch.randn(2, 2, 2, dtype=torch.float64, device=device)
         padded_tensor[0, 1, :] = 0
         padded_tensor.requires_grad_()
 
@@ -1881,9 +1881,9 @@ class TestNestedTensorAutograd(TestCase):
         data = (padded_tensor, nested_size)
         assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
-    def test_nested_tensor_from_padded_fused(self):
+    def test_nested_tensor_from_padded_fused(self, device):
         nested_size = torch.tensor([[1, 8], [2, 8]])
-        padded_tensor = torch.randn(2, 2, 2, 4, dtype=torch.float64)
+        padded_tensor = torch.randn(2, 2, 2, 4, dtype=torch.float64, device=device)
         padded_tensor[0, 1, :] = 0
         padded_tensor.requires_grad_()
 
@@ -1894,11 +1894,11 @@ class TestNestedTensorAutograd(TestCase):
         data = (padded_tensor, nested_size)
         assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
-    def test_nested_tensor_from_list(self):
+    def test_nested_tensor_from_list(self, device):
 
-        a = torch.randn(1, 2, requires_grad=True, dtype=torch.float64)
-        b = torch.randn(2, 2, requires_grad=True, dtype=torch.float64)
-        c = torch.randn(10, 2, requires_grad=True, dtype=torch.float64)
+        a = torch.randn(1, 2, requires_grad=True, dtype=torch.float64, device=device)
+        b = torch.randn(2, 2, requires_grad=True, dtype=torch.float64, device=device)
+        c = torch.randn(10, 2, requires_grad=True, dtype=torch.float64, device=device)
 
         def grad_test_func(a, b, c):
             c = torch.nested.as_nested_tensor([a, b, c])
@@ -1914,11 +1914,11 @@ class TestNestedTensorAutograd(TestCase):
         y.backward(nt.clone().detach())
         self.assertEqual(nt.grad, y)
 
-    def test_nested_tensor_bmm_gradcheck(self):
-        a = torch.randn(2, 6, requires_grad=True, dtype=torch.float64)
-        b = torch.randn(3, 6, requires_grad=True, dtype=torch.float64)
-        c = torch.randn(6, 4, requires_grad=True, dtype=torch.float64)
-        d = torch.randn(6, 5, requires_grad=True, dtype=torch.float64)
+    def test_nested_tensor_bmm_gradcheck(self, device):
+        a = torch.randn(2, 6, requires_grad=True, dtype=torch.float64, device=device)
+        b = torch.randn(3, 6, requires_grad=True, dtype=torch.float64, device=device)
+        c = torch.randn(6, 4, requires_grad=True, dtype=torch.float64, device=device)
+        d = torch.randn(6, 5, requires_grad=True, dtype=torch.float64, device=device)
 
         def grad_test_func(a, b, c, d):
             nt0 = torch.nested.as_nested_tensor([a, b])
@@ -1929,9 +1929,9 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b, c, d)
         assert torch.autograd.gradcheck(grad_test_func, inputs=data)
 
-    def test_nested_tensor_bmm_backward(self):
-        nt0 = torch.nested.nested_tensor([torch.randn((2, 6)), torch.randn((3, 6))], requires_grad=True)
-        nt1 = torch.nested.nested_tensor([torch.randn((6, 4)), torch.randn((6, 5))], requires_grad=True)
+    def test_nested_tensor_bmm_backward(self, device):
+        nt0 = torch.nested.nested_tensor([torch.randn((2, 6)), torch.randn((3, 6))], requires_grad=True, device=device)
+        nt1 = torch.nested.nested_tensor([torch.randn((6, 4)), torch.randn((6, 5))], requires_grad=True, device=device)
         with torch.no_grad():
             pt0 = torch.nested.to_padded_tensor(nt0, 0.0).requires_grad_(True)
             pt1 = torch.nested.to_padded_tensor(nt1, 0.0).requires_grad_(True)
@@ -1944,11 +1944,11 @@ class TestNestedTensorAutograd(TestCase):
         self.assertEqual(torch.nested.to_padded_tensor(nt0.grad, 0.0), pt0.grad)
         self.assertEqual(torch.nested.to_padded_tensor(nt1.grad, 0.0), pt1.grad)
 
-    def test_nested_tensor_matmul_gradcheck(self):
-        a = torch.randn(2, 6, requires_grad=True, dtype=torch.float64)
-        b = torch.randn(3, 6, requires_grad=True, dtype=torch.float64)
-        c = torch.randn(6, 4, requires_grad=True, dtype=torch.float64)
-        d = torch.randn(6, 5, requires_grad=True, dtype=torch.float64)
+    def test_nested_tensor_matmul_gradcheck(self, device):
+        a = torch.randn(2, 6, requires_grad=True, dtype=torch.float64, device=device)
+        b = torch.randn(3, 6, requires_grad=True, dtype=torch.float64, device=device)
+        c = torch.randn(6, 4, requires_grad=True, dtype=torch.float64, device=device)
+        d = torch.randn(6, 5, requires_grad=True, dtype=torch.float64, device=device)
 
         def grad_test_func(a, b, c, d):
             nt0 = torch.nested.as_nested_tensor([a, b])
@@ -1959,9 +1959,9 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b, c, d)
         assert torch.autograd.gradcheck(grad_test_func, inputs=data)
 
-    def test_nested_tensor_matmul_backward(self):
-        nt0 = torch.nested.nested_tensor([torch.randn((7, 2, 6)), torch.randn((7, 3, 6))], requires_grad=True)
-        nt1 = torch.nested.nested_tensor([torch.randn((7, 6, 4)), torch.randn((7, 6, 5))], requires_grad=True)
+    def test_nested_tensor_matmul_backward(self, device):
+        nt0 = torch.nested.nested_tensor([torch.randn((7, 2, 6)), torch.randn((7, 3, 6))], requires_grad=True, device=device)
+        nt1 = torch.nested.nested_tensor([torch.randn((7, 6, 4)), torch.randn((7, 6, 5))], requires_grad=True, device=device)
         with torch.no_grad():
             pt0 = torch.nested.to_padded_tensor(nt0, 0.0).requires_grad_(True)
             pt1 = torch.nested.to_padded_tensor(nt1, 0.0).requires_grad_(True)
@@ -1974,9 +1974,9 @@ class TestNestedTensorAutograd(TestCase):
         self.assertEqual(torch.nested.to_padded_tensor(nt0.grad, 0.0), pt0.grad)
         self.assertEqual(torch.nested.to_padded_tensor(nt1.grad, 0.0), pt1.grad)
 
-    def test_nested_tensor_transpose_gradcheck(self):
-        a = torch.randn(2, 5, requires_grad=True)
-        b = torch.randn(3, 4, requires_grad=True)
+    def test_nested_tensor_transpose_gradcheck(self, device):
+        a = torch.randn(2, 5, requires_grad=True, device=device)
+        b = torch.randn(3, 4, requires_grad=True, device=device)
 
         def grad_test_func(a, b):
             nt = torch.nested.as_nested_tensor([a, b])
@@ -1986,8 +1986,8 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b)
         assert torch.autograd.gradcheck(grad_test_func, inputs=data, eps=1e-3)
 
-    def test_nested_tensor_transpose_backward(self):
-        nt = torch.nested.nested_tensor([torch.randn((2, 5)), torch.randn((3, 4))], requires_grad=True)
+    def test_nested_tensor_transpose_backward(self, device):
+        nt = torch.nested.nested_tensor([torch.randn((2, 5)), torch.randn((3, 4))], requires_grad=True, device=device)
         with torch.no_grad():
             pt = torch.nested.to_padded_tensor(nt, 0.0).requires_grad_(True)
 
@@ -1998,9 +1998,9 @@ class TestNestedTensorAutograd(TestCase):
 
         self.assertEqual(torch.nested.to_padded_tensor(nt.grad, 0.0), pt.grad)
 
-    def test_nested_tensor_reshape_gradcheck(self):
-        a = torch.randn(2, 6, requires_grad=True)
-        b = torch.randn(3, 6, requires_grad=True)
+    def test_nested_tensor_reshape_gradcheck(self, device):
+        a = torch.randn(2, 6, requires_grad=True, device=device)
+        b = torch.randn(3, 6, requires_grad=True, device=device)
 
         def grad_test_func(a, b):
             nt = torch.nested.as_nested_tensor([a, b])
@@ -2022,8 +2022,8 @@ class TestNestedTensorAutograd(TestCase):
 
         self.assertEqual(torch.nested.to_padded_tensor(nt.grad, 0.0), pt.grad)
 
-    def test_nested_tensor_squeeze_backward(self):
-        nt = torch.nested.nested_tensor([torch.randn((2, 6, 1)), torch.randn((3, 6, 1))], requires_grad=True)
+    def test_nested_tensor_squeeze_backward(self, device):
+        nt = torch.nested.nested_tensor([torch.randn((2, 6, 1)), torch.randn((3, 6, 1))], requires_grad=True, device=device)
         with torch.no_grad():
             pt = torch.nested.to_padded_tensor(nt, 0.0).requires_grad_(True)
 
@@ -2034,9 +2034,9 @@ class TestNestedTensorAutograd(TestCase):
 
         self.assertEqual(torch.nested.to_padded_tensor(nt.grad, 0.0), pt.grad)
 
-    def test_nested_tensor_squeeze_gradcheck(self):
-        a = torch.randn((2, 6, 1), dtype=torch.float64, requires_grad=True)
-        b = torch.randn((3, 6, 1), dtype=torch.float64, requires_grad=True)
+    def test_nested_tensor_squeeze_gradcheck(self, device):
+        a = torch.randn((2, 6, 1), dtype=torch.float64, requires_grad=True, device=device)
+        b = torch.randn((3, 6, 1), dtype=torch.float64, requires_grad=True, device=device)
 
         def grad_test_func(a, b):
             nt = torch.nested.as_nested_tensor([a, b])
@@ -2045,8 +2045,8 @@ class TestNestedTensorAutograd(TestCase):
 
         assert torch.autograd.gradcheck(grad_test_func, inputs=(a, b), eps=1e-3)
 
-    def test_nested_tensor_unsqueeze_backward(self):
-        nt = torch.nested.nested_tensor([torch.randn((2, 6)), torch.randn((3, 6))], requires_grad=True)
+    def test_nested_tensor_unsqueeze_backward(self, device):
+        nt = torch.nested.nested_tensor([torch.randn((2, 6)), torch.randn((3, 6))], requires_grad=True, device=device)
         with torch.no_grad():
             pt = torch.nested.to_padded_tensor(nt, 0.0).requires_grad_(True)
 
@@ -2057,9 +2057,9 @@ class TestNestedTensorAutograd(TestCase):
 
         self.assertEqual(torch.nested.to_padded_tensor(nt.grad, 0.0), pt.grad)
 
-    def test_nested_tensor_unsqueeze_gradcheck(self):
-        a = torch.randn((2, 6), dtype=torch.float64, requires_grad=True)
-        b = torch.randn((3, 6), dtype=torch.float64, requires_grad=True)
+    def test_nested_tensor_unsqueeze_gradcheck(self, device):
+        a = torch.randn((2, 6), dtype=torch.float64, requires_grad=True, device=device)
+        b = torch.randn((3, 6), dtype=torch.float64, requires_grad=True, device=device)
 
         def grad_test_func(a, b):
             nt = torch.nested.as_nested_tensor([a, b])
@@ -2068,14 +2068,14 @@ class TestNestedTensorAutograd(TestCase):
 
         assert torch.autograd.gradcheck(grad_test_func, inputs=(a, b), eps=1e-3)
 
-    def test_nested_tensor_linear(self):
+    def test_nested_tensor_linear(self, device):
 
-        a = torch.randn(1, 2, requires_grad=True, dtype=torch.float64)
-        b = torch.randn(2, 2, requires_grad=True, dtype=torch.float64)
-        c = torch.randn(3, 2, requires_grad=True, dtype=torch.float64)
+        a = torch.randn(1, 2, requires_grad=True, dtype=torch.float64, device=device)
+        b = torch.randn(2, 2, requires_grad=True, dtype=torch.float64, device=device)
+        c = torch.randn(3, 2, requires_grad=True, dtype=torch.float64, device=device)
 
-        weight = torch.randn(2, 2, requires_grad=True, dtype=torch.float64)
-        bias = torch.randn(2, requires_grad=True, dtype=torch.float64)
+        weight = torch.randn(2, 2, requires_grad=True, dtype=torch.float64, device=device)
+        bias = torch.randn(2, requires_grad=True, dtype=torch.float64, device=device)
 
         def grad_test_func(a, b, c, weight, bias=None):
             nt = torch.nested.as_nested_tensor([a, b, c])
@@ -2089,10 +2089,10 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b, c, weight)
         assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
-    def test_nested_tensor_softmax(self):
-        a = torch.randn(1, 2, requires_grad=True, dtype=torch.float64)
-        b = torch.randn(2, 2, requires_grad=True, dtype=torch.float64)
-        c = torch.randn(3, 2, requires_grad=True, dtype=torch.float64)
+    def test_nested_tensor_softmax(self, device):
+        a = torch.randn(1, 2, requires_grad=True, dtype=torch.float64, device=device)
+        b = torch.randn(2, 2, requires_grad=True, dtype=torch.float64, device=device)
+        c = torch.randn(3, 2, requires_grad=True, dtype=torch.float64, device=device)
 
         def grad_test_func(a, b, c, dim):
             nt = torch.nested.as_nested_tensor([a, b, c])
@@ -2104,14 +2104,14 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b, c, -1)
         assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
-    def test_nested_tensor_linear_backward(self):
-        a = torch.randn(1, 2, requires_grad=False)
-        b = torch.randn(2, 2, requires_grad=False)
-        c = torch.randn(3, 2, requires_grad=False)
+    def test_nested_tensor_linear_backward(self, device):
+        a = torch.randn(1, 2, requires_grad=False, device=device)
+        b = torch.randn(2, 2, requires_grad=False, device=device)
+        c = torch.randn(3, 2, requires_grad=False, device=device)
 
-        weight = torch.randn(2, 2, requires_grad=True)
-        bias = torch.randn(2, requires_grad=True)
-        nt = torch.nested.as_nested_tensor([a, b, c])
+        weight = torch.randn(2, 2, requires_grad=True, device=device)
+        bias = torch.randn(2, requires_grad=True, device=device)
+        nt = torch.nested.as_nested_tensor([a, b, c], device=device)
 
         out = torch.functional.F.linear(nt, weight, bias)
 
@@ -2124,10 +2124,10 @@ class TestNestedTensorAutograd(TestCase):
         assert b.grad is None
         assert c.grad is None
 
-    def test_values_grad_with_broadcast(self):
-        a = torch.randn(1, 2, 4, requires_grad=True, dtype=torch.float64)
-        b = torch.randn(2, 2, 4, requires_grad=True, dtype=torch.float64)
-        c = torch.randn(3, 2, 4, requires_grad=True, dtype=torch.float64)
+    def test_values_grad_with_broadcast(self, device):
+        a = torch.randn(1, 2, 4, requires_grad=True, dtype=torch.float64, device=device)
+        b = torch.randn(2, 2, 4, requires_grad=True, dtype=torch.float64, device=device)
+        c = torch.randn(3, 2, 4, requires_grad=True, dtype=torch.float64, device=device)
 
         def grad_test_func(a, b, c):
             nt = torch.nested.as_nested_tensor([a, b, c])
@@ -2137,10 +2137,10 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b, c)
         assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
-    def test_to_buffer_series_ops_grad_with_broadcast(self):
-        a = torch.randn(1, 1, 2, requires_grad=True, dtype=torch.float64)
-        b = torch.randn(1, 1, 2, requires_grad=True, dtype=torch.float64)
-        c = torch.randn(1, 1, 2, requires_grad=True, dtype=torch.float64)
+    def test_to_buffer_series_ops_grad_with_broadcast(self, device):
+        a = torch.randn(1, 1, 2, requires_grad=True, dtype=torch.float64, device=device)
+        b = torch.randn(1, 1, 2, requires_grad=True, dtype=torch.float64, device=device)
+        c = torch.randn(1, 1, 2, requires_grad=True, dtype=torch.float64, device=device)
 
         def grad_test_func(a, b, c):
             nt = torch.nested.as_nested_tensor([a, b, c])
@@ -2151,10 +2151,10 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b, c)
         assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
-    def test_unbind_flow_through(self):
-        a = torch.randn(1, 2, 4, requires_grad=True, dtype=torch.float64)
-        b = torch.randn(2, 2, 4, requires_grad=True, dtype=torch.float64)
-        c = torch.randn(3, 2, 4, requires_grad=True, dtype=torch.float64)
+    def test_unbind_flow_through(self, device):
+        a = torch.randn(1, 2, 4, requires_grad=True, dtype=torch.float64, device=device)
+        b = torch.randn(2, 2, 4, requires_grad=True, dtype=torch.float64, device=device)
+        c = torch.randn(3, 2, 4, requires_grad=True, dtype=torch.float64, device=device)
 
         def grad_test_func(a, b, c):
             nt = torch.nested.as_nested_tensor([a, b, c])
@@ -2167,19 +2167,20 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b, c)
         assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
-    def test_indexing_backward(self):
+    def test_indexing_backward(self, device):
         x0 = torch.randn((2, 5))
         x1 = torch.randn((3, 4))
-        nt = torch.nested.nested_tensor([x0, x1], requires_grad=True)
+        nt = torch.nested.nested_tensor([x0, x1], device=device, requires_grad=True)
         self.assertEqual(nt[0], x0)
         self.assertEqual(nt[-1], x1)
-        grad_x0 = torch.randn((2, 5))
+        grad_x0 = torch.randn((2, 5), device=device)
         nt[0].backward(grad_x0)
-        expected_grad = torch.nested.nested_tensor([grad_x0, torch.zeros((3, 4))])
+        expected_grad = torch.nested.nested_tensor([grad_x0, torch.zeros((3, 4), device=device)])
         self.assertEqual(nt.grad, expected_grad)
 
 
 instantiate_device_type_tests(TestNestedTensorDeviceType, globals())
+instantiate_device_type_tests(TestNestedTensorAutograd, globals())
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Fixes #87713

BMM for cpu supports  non-contiguous nested tensor inputs, while BMM for Cuda does not support currently non-contiguous inputs.

The derivative for BMM:
```
- name: bmm(Tensor self, Tensor mat2) -> Tensor
  self: grad.bmm(mat2.transpose(1, 2).conj())
  mat2: self.transpose(1, 2).conj().bmm(grad)
  result: self_t.bmm(mat2_p) + self_p.bmm(mat2_t)
```

When calling backward it was impossible for this function to succeed since the inputs were always discontiguous, regardless of the user input.  This adds contiguous calls to BMM_cuda implementation for nested tensors.

This was not caught by tests because grad_check is currently only done on CPU in test_nestedtensors. This PR updates the autograd test to also be run on GPU.

As a result I found one more issue with the backward for to_padded_tensor erroring instead of calling the generic version.

cc @cpuhrsch @jbschlosser @bhosmer @mikaylagawarecki