### PR TITLE
feature: adding batch support for narrow_copy operator

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesViews.cpp
+++ b/aten/src/ATen/functorch/BatchRulesViews.cpp
@@ -490,6 +490,20 @@ std::tuple<Tensor, optional<int64_t>> unfold_batch_rule(
   return std::make_tuple(result, 0);
 }
 
+std::tuple<Tensor, optional<int64_t>> narrow_copy_batch_rule(
+    const Tensor &self, optional<int64_t> self_bdim, int64_t dim, c10::SymInt start, c10::SymInt length)
+{
+  TORCH_INTERNAL_ASSERT(self_bdim.has_value());
+  auto self_ = moveBatchDimToFront(self, self_bdim);
+  std::cout << "hello" << std::endl;
+  auto logical_rank = rankWithoutBatchDim(self, self_bdim);
+  std::cout << "logical_rank:" << logical_rank << std::endl;
+  dim = maybe_wrap_dim(dim, logical_rank) + 1;
+  std::cout << "dim:" << dim << std::endl;
+  auto result = self_.narrow_copy_symint(dim, start, length);
+  return std::make_tuple(result, 0);
+}
+
 std::tuple<Tensor, optional<int64_t>> movedim_batch_rule(const Tensor& self, optional<int64_t> self_bdim, IntArrayRef source, IntArrayRef destination) {
   auto self_ = moveBatchDimToFront(self, self_bdim);
   auto source_ = getPhysicalDims(self_, self_bdim.has_value(), source);
@@ -539,6 +553,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   VMAP_SUPPORT2(slice, Tensor, slice_batch_rule);
   VMAP_SUPPORT2(transpose, int, transpose_int_batch_rule);
   VMAP_SUPPORT(diag_embed, diag_embed_batch_rule);
+  VMAP_SUPPORT(narrow_copy, narrow_copy_batch_rule);
 }
 
 }}

--- a/aten/src/ATen/functorch/BatchRulesViews.cpp
+++ b/aten/src/ATen/functorch/BatchRulesViews.cpp
@@ -495,12 +495,10 @@ std::tuple<Tensor, optional<int64_t>> narrow_copy_batch_rule(
 {
   TORCH_INTERNAL_ASSERT(self_bdim.has_value());
   auto self_ = moveBatchDimToFront(self, self_bdim);
-  std::cout << "hello" << std::endl;
   auto logical_rank = rankWithoutBatchDim(self, self_bdim);
-  std::cout << "logical_rank:" << logical_rank << std::endl;
   dim = maybe_wrap_dim(dim, logical_rank) + 1;
-  std::cout << "dim:" << dim << std::endl;
   auto result = self_.narrow_copy_symint(dim, start, length);
+
   return std::make_tuple(result, 0);
 }
 

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3331,7 +3331,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('masked_scatter'),
         xfail('masked_select'),
         xfail('nanquantile'),
-        xfail('narrow_copy'),  # hit the vmap fallback which is currently disabled
         xfail('ormqr'),
         xfail('put'),
         xfail('quantile'),


### PR DESCRIPTION
Implement batch support https://github.com/pytorch/functorch/issues/825 for narrow copy

narrow_copy was already added as an opinfo 

cc @zou3519 @Chillee @samdow @soumith