### PR TITLE
Rename codegen triton kernel to be more visibile in pytorch profiler

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1276,7 +1276,7 @@ class TritonScheduling:
         else:
             kernel_name = wrapper.next_kernel_name()
             wrapper.kernels[src_code] = kernel_name
-            subs_name = kernel_name if config.triton.ordered_kernel_names else "kernel"
+            subs_name = kernel_name if config.triton.ordered_kernel_names else "triton_kernel"
             src_code = src_code.replace("KERNEL_NAME", subs_name)
             # TODO(voz): Ostensibly, we should not need this. But there are cases where C++ codegen does
             # not use BracesBuffer, so we have no good indicator of a C++ buffer atm.

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1276,7 +1276,9 @@ class TritonScheduling:
         else:
             kernel_name = wrapper.next_kernel_name()
             wrapper.kernels[src_code] = kernel_name
-            subs_name = kernel_name if config.triton.ordered_kernel_names else "triton_kernel"
+            subs_name = (
+                kernel_name if config.triton.ordered_kernel_names else "triton_kernel"
+            )
             src_code = src_code.replace("KERNEL_NAME", subs_name)
             # TODO(voz): Ostensibly, we should not need this. But there are cases where C++ codegen does
             # not use BracesBuffer, so we have no good indicator of a C++ buffer atm.


### PR DESCRIPTION
Fixes part of https://github.com/pytorch/pytorch/issues/93717 so we can instead have `triton_kernel_*` instead of the below
![Screen Shot 2022-10-31 at 2 08 21 PM](https://user-images.githubusercontent.com/3282513/199110971-da44606b-5051-42ba-bd8e-341f59b3a3ac.png)

