### PR TITLE
Disable label auto-removal

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
+        sync-labels: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/88126

Without this, if any tag defined in https://github.com/pytorch/pytorch/blob/master/.github/labeler.yml  is added to a PR, but the files in that PR don't match the patterns described under that tag, github-actions bot auto-removes that label

This change will allow the label to remain