### PR TITLE
Add missing args to DDP constructor in distributed.pyi

### DIFF
--- a/torch/nn/parallel/distributed.pyi
+++ b/torch/nn/parallel/distributed.pyi
@@ -1,7 +1,7 @@
-from ..modules import Module
 from typing import Any, Optional
-from .common_types import _devices_t, _device_t
 
+from ..modules import Module
+from .common_types import _device_t, _devices_t
 
 class DistributedDataParallel(Module):
     process_group: Any = ...
@@ -15,7 +15,17 @@ class DistributedDataParallel(Module):
     bucket_bytes_cap: float = ...
 
     # TODO type process_group once `distributed` module is stubbed
-    def __init__(self, module: Module, device_ids: Optional[_devices_t] = ...,
-                 output_device: Optional[_device_t] = ..., dim: int = ...,
-                 broadcast_buffers: bool = ..., process_group: Optional[Any] = ..., bucket_cap_mb: float = ...,
-                 find_unused_parameters: bool = ..., check_reduction: bool = ...) -> None: ...
+    def __init__(
+        self,
+        module: Module,
+        device_ids: Optional[_devices_t] = ...,
+        output_device: Optional[_device_t] = ...,
+        dim: int = ...,
+        broadcast_buffers: bool = ...,
+        process_group: Optional[Any] = ...,
+        bucket_cap_mb: float = ...,
+        find_unused_parameters: bool = ...,
+        check_reduction: bool = ...,
+        gradient_as_bucket_view: bool = ...,
+        static_graph: bool = ...,
+    ) -> None: ...


### PR DESCRIPTION
Summary: As title. And remove all unnecessary `pyre-fixme` for the unknown arg in call-site.

Test Plan: CI

Differential Revision: D40874013

