### PR TITLE
Add API logging for interpolate()

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3919,7 +3919,10 @@ def interpolate(input: Tensor, size: Optional[int] = None, scale_factor: Optiona
     # Logging logic
     is_channels_last = input.is_contiguous(memory_format=torch.channels_last)
     is_image_or_mask = input.ndim == 4 and input.shape[1] < 4
-    log_string = f"torch.nn.functional.interpolate_dtype={input.dtype}_mode={mode}_antialias={antialias}_channelslast={is_channels_last}_imageormask={is_image_or_mask}"
+    log_string = (
+            f"torch.nn.functional.interpolate_dtype={input.dtype}_mode={mode}_antialias={antialias}_"
+            f"channelslast={is_channels_last}_imageormask={is_image_or_mask}"
+    )
     torch._C._log_api_usage_once(log_string)
 
     if input.dim() == 3 and mode == "nearest":

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3920,8 +3920,8 @@ def interpolate(input: Tensor, size: Optional[int] = None, scale_factor: Optiona
     is_channels_last = input.is_contiguous(memory_format=torch.channels_last)
     is_image_or_mask = input.ndim == 4 and input.shape[1] < 4
     log_string = (
-            f"torch.nn.functional.interpolate_dtype={input.dtype}_mode={mode}_antialias={antialias}_"
-            f"channelslast={is_channels_last}_imageormask={is_image_or_mask}"
+        f"torch.nn.functional.interpolate_dtype={input.dtype}_mode={mode}_antialias={antialias}_"
+        f"channelslast={is_channels_last}_imageormask={is_image_or_mask}"
     )
     torch._C._log_api_usage_once(log_string)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3916,6 +3916,12 @@ def interpolate(input: Tensor, size: Optional[int] = None, scale_factor: Optiona
     if antialias and not (mode in ("bilinear", "bicubic") and input.ndim == 4):
         raise ValueError("Anti-alias option is only supported for bilinear and bicubic modes")
 
+    # Logging logic
+    is_channels_last = input.is_contiguous(memory_format=torch.channels_last)
+    is_image_or_mask = input.ndim == 4 and input.shape[1] < 4
+    log_string = f"torch.nn.functional.interpolate_dtype={input.dtype}_mode={mode}_antialias={antialias}_channelslast={is_channels_last}_imageormask={is_image_or_mask}"
+    torch._C._log_api_usage_once(log_string)
+
     if input.dim() == 3 and mode == "nearest":
         return torch._C._nn.upsample_nearest1d(input, output_size, scale_factors)
     if input.dim() == 4 and mode == "nearest":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88212


This PR calls `torch._C._log_api_usage_once()` for `torch.nn.functional.interpolate()`. See [this internal post](https://fb.workplace.com/groups/1144215345733672/permalink/2382133531941841/) for more context about the level of details needed in the logger


cc @albanD @mruberry @jbschlosser @walterddr @kshitij12345 @saketh-are