### PR TITLE
[WIP] Rand recomputation

### DIFF
--- a/functorch/_src/compile_utils.py
+++ b/functorch/_src/compile_utils.py
@@ -12,10 +12,10 @@ def get_aten_target(node):
     return node.target
 
 
-rand_ops = [aten.dropout, aten._fused_dropout, aten._standard_gamma,
-            aten.bernoulli, aten.multinomial, aten.native_dropout,
-            aten.normal, aten.poisson, aten.binomial, aten.rrelu,
-            aten.rand_like, aten.rand, aten.randint, aten.randn, aten.randperm]
+def is_random_op(n):
+    if isinstance(n.target, torch._ops.OpOverload):
+        return torch.Tag.nondeterministic_seeded in n.target.tags
+    return False
 
 
 # return a new copy of torch.fx.graph.Graph with CSE applied to the input graph
@@ -27,7 +27,7 @@ def fx_graph_cse(fx_g: torch.fx.graph.Graph):
     for n in fx_g.nodes:
         # The placeholder, output, and get_attr nodes are copied to the new grpah without change
         # do not CSE away random operations
-        if n.op == 'placeholder' or n.op == 'output' or n.op == 'get_attr' or get_aten_target(n) in rand_ops:
+        if n.op == 'placeholder' or n.op == 'output' or n.op == 'get_attr' or is_random_op(n):
             new_node = new_graph.node_copy(n, lambda x: env[x])
             env[n] = new_node
         else:  # n.op == 'call_function', should never see n.op == 'call_module' or 'call_method'

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -885,6 +885,9 @@ class _LinalgBackend:
 class ConvBackend(Enum):
     ...
 
+class Tag(Enum):
+    ...
+
 # Defined in `valgrind.h` and `callgrind.h` respecitively.
 def _valgrind_supported_platform() -> _bool: ...  # NVALGRIND
 def _valgrind_toggle() -> None: ...  # CALLGRIND_TOGGLE_COLLECT

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -258,6 +258,7 @@ def _make_prim(
     meta: Callable,
     impl_aten: Callable,
     doc: str,
+    tags: Sequence[torch.Tag] = (),
 ):
     """
     Creates a primitive operation.
@@ -293,6 +294,7 @@ def _make_prim(
 
     _prim_packet = getattr(torch.ops.prims, name)
     _prim = _prim_packet.default
+    _prim._tags = tags
 
     from torch._subclasses.fake_tensor import contains_tensor_types
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88217
* #87641



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire

Still need to add test. Fix for https://github.com/pytorch/pytorch/issues/93578

No cudagraphs, resnet18, before this pr:

cuda train resnet18                           memory: eager: 0.55 GB, dynamo: 0.79 GB, ratio: 0.70
1.082x p=0.00

No cudagraphs, resnet18, with this pr.
cuda train resnet18                           memory: eager: 0.55 GB, dynamo: 0.71 GB, ratio: 0.78
1.075x p=0.00


The memory savings are significant, but it does also introduce a slowdown. Thoughts ?



