### PR TITLE
[Pytorch][Vulkan] Update spv generation script to embed shader parameters

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Types.h
+++ b/aten/src/ATen/native/vulkan/api/Types.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+enum class StorageType {
+  BUFFER,
+  TEXTURE_3D,
+  TEXTURE_2D,
+  UNKNOWN,
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -520,7 +520,7 @@ vTensor pack_weights(
   vTensor v_weight{
       api::context(),
       weight_rearranged.sizes(),
-      quantized ? StorageType::TEXTURE_3D : StorageType::TEXTURE_2D,
+      quantized ? api::StorageType::TEXTURE_3D : api::StorageType::TEXTURE_2D,
       weight_arg.options(),
   };
 
@@ -545,7 +545,7 @@ vTensor pack_biases(
   vTensor v_bias{
       api::context(),
       bias_rearranged.sizes(),
-      quantized ? StorageType::TEXTURE_3D : StorageType::TEXTURE_2D,
+      quantized ? api::StorageType::TEXTURE_3D : api::StorageType::TEXTURE_2D,
       weight.options(),
   };
 

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -63,13 +63,13 @@ vTensor::vTensor(
     : view_(std::make_shared<vTensorStorage>(
           context,
           sizes,
-          StorageType::TEXTURE_3D,
+          api::StorageType::TEXTURE_3D,
           options)) {}
 
 vTensor::vTensor(
     api::Context* const context,
     const IntArrayRef sizes,
-    const StorageType storage_type,
+    const api::StorageType storage_type,
     const TensorOptions& options)
     : view_(std::make_shared<vTensorStorage>(
           context,
@@ -86,7 +86,7 @@ vTensor::vTensor(
     : view_(std::make_shared<vTensorStorage>(
           context,
           sizes,
-          StorageType::TEXTURE_3D,
+          api::StorageType::TEXTURE_3D,
           options,
           q_scale,
           q_zero_point)) {}
@@ -94,7 +94,7 @@ vTensor::vTensor(
 vTensor::vTensor(
     api::Context* const context,
     const IntArrayRef sizes,
-    const StorageType storage_type,
+    const api::StorageType storage_type,
     const TensorOptions& options,
     double q_scale,
     int64_t q_zero_point)
@@ -130,7 +130,7 @@ api::VulkanImage& vTensor::image(
 api::VulkanImage allocate_image(
     api::Context* const context_ptr,
     api::utils::uvec3& extents,
-    StorageType storage_type,
+    api::StorageType storage_type,
     const VkFormat image_format) {
   api::Adapter* adapter_ptr = context_ptr->adapter_ptr();
 
@@ -145,14 +145,17 @@ api::VulkanImage allocate_image(
   VkImageViewType image_view_type = VK_IMAGE_VIEW_TYPE_3D;
 
   switch (storage_type) {
-    case StorageType::TEXTURE_3D:
+    case api::StorageType::TEXTURE_3D:
       image_type = VK_IMAGE_TYPE_3D;
       image_view_type = VK_IMAGE_VIEW_TYPE_3D;
       break;
-    case StorageType::TEXTURE_2D:
+    case api::StorageType::TEXTURE_2D:
       image_type = VK_IMAGE_TYPE_2D;
       image_view_type = VK_IMAGE_VIEW_TYPE_2D;
       break;
+    case api::StorageType::BUFFER:
+    case api::StorageType::UNKNOWN:
+      TORCH_CHECK(false, "Requested storage type must be a texture type.");
   }
 
   VkSampler sampler = adapter_ptr->sampler_cache().retrieve(sampler_props);
@@ -170,7 +173,7 @@ api::VulkanImage allocate_image(
 vTensorStorage::vTensorStorage(
     api::Context* const context,
     const IntArrayRef sizes,
-    const StorageType storage_type,
+    const api::StorageType storage_type,
     const TensorOptions& options)
     : context_(context),
       extents_(image_extents(sizes)),
@@ -190,7 +193,7 @@ vTensorStorage::vTensorStorage(
 vTensorStorage::vTensorStorage(
     api::Context* const context,
     const IntArrayRef sizes,
-    const StorageType storage_type,
+    const api::StorageType storage_type,
     const TensorOptions& options,
     double q_scale_in,
     int64_t q_zero_point_in)

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -26,11 +26,6 @@ struct LastAccess {
       : stage{stage_flags}, access{access_flags} {}
 };
 
-enum class StorageType {
-  TEXTURE_3D,
-  TEXTURE_2D,
-};
-
 class vTensorStorage final {
  public:
   // Do not allow empty vTensorStorage construction
@@ -39,12 +34,12 @@ class vTensorStorage final {
   vTensorStorage(
       api::Context* context,
       IntArrayRef sizes,
-      const StorageType storage_type,
+      const api::StorageType storage_type,
       const TensorOptions& options);
   vTensorStorage(
       api::Context* context,
       IntArrayRef sizes,
-      const StorageType storage_type,
+      const api::StorageType storage_type,
       const TensorOptions& options,
       double q_scale,
       int64_t q_zero_point);
@@ -73,7 +68,7 @@ class vTensorStorage final {
   int64_t q_zero_point{0u};
 
   // Image Texture
-  StorageType storage_type_;
+  api::StorageType storage_type_;
   mutable api::VulkanImage image_;
 
   // Last Access - used to insert memory barriers
@@ -108,7 +103,7 @@ class vTensor final {
   vTensor(
       api::Context* context,
       IntArrayRef sizes,
-      const StorageType storage_type,
+      const api::StorageType storage_type,
       const TensorOptions& options);
 
   vTensor(
@@ -121,7 +116,7 @@ class vTensor final {
   vTensor(
       api::Context* const context,
       const IntArrayRef sizes,
-      const StorageType storage_type,
+      const api::StorageType storage_type,
       const TensorOptions& options,
       double q_scale,
       int64_t q_zero_point);
@@ -151,7 +146,7 @@ class vTensor final {
    Texture Access
   */
 
-  inline StorageType storage_type() const {
+  inline api::StorageType storage_type() const {
     return view_->storage_type_;
   }
 

--- a/aten/src/ATen/native/vulkan/ops/Utils.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Utils.cpp
@@ -19,36 +19,48 @@ namespace packing {
 static api::ShaderSource get_nchw_to_image_shader(const vTensor& v_dst) {
   if (v_dst.is_quantized()) {
     switch (v_dst.storage_type()) {
-      case StorageType::TEXTURE_3D:
+      case api::StorageType::TEXTURE_3D:
         return VK_KERNEL(nchw_to_image_quantized);
-      case StorageType::TEXTURE_2D:
+      case api::StorageType::TEXTURE_2D:
         TORCH_CHECK(false, "No kernel available!");
+      case api::StorageType::BUFFER:
+      case api::StorageType::UNKNOWN:
+        TORCH_CHECK(false, "Requested storage type must be a texture type.");
     }
   }
 
   switch (v_dst.storage_type()) {
-    case StorageType::TEXTURE_3D:
+    case api::StorageType::TEXTURE_3D:
       return VK_KERNEL(nchw_to_image);
-    case StorageType::TEXTURE_2D:
+    case api::StorageType::TEXTURE_2D:
       return VK_KERNEL(nchw_to_image2d);
+    case api::StorageType::BUFFER:
+    case api::StorageType::UNKNOWN:
+      TORCH_CHECK(false, "Requested storage type must be a texture type.");
   }
 }
 
 static api::ShaderSource get_image_to_nchw_shader(const vTensor& v_src) {
   if (v_src.is_quantized()) {
     switch (v_src.storage_type()) {
-      case StorageType::TEXTURE_3D:
+      case api::StorageType::TEXTURE_3D:
         return VK_KERNEL(image_to_nchw_quantized);
-      case StorageType::TEXTURE_2D:
+      case api::StorageType::TEXTURE_2D:
         TORCH_CHECK(false, "No kernel available!");
+      case api::StorageType::BUFFER:
+      case api::StorageType::UNKNOWN:
+        TORCH_CHECK(false, "Requested storage type must be a texture type.");
     }
   }
 
   switch (v_src.storage_type()) {
-    case StorageType::TEXTURE_3D:
+    case api::StorageType::TEXTURE_3D:
       return VK_KERNEL(image_to_nchw);
-    case StorageType::TEXTURE_2D:
+    case api::StorageType::TEXTURE_2D:
       return VK_KERNEL(image2d_to_nchw);
+    case api::StorageType::BUFFER:
+    case api::StorageType::UNKNOWN:
+      TORCH_CHECK(false, "Requested storage type must be a texture type.");
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88225
* #88224
* #88223
* __->__ #88222

This diffs adds shader parameters such as tile size, weight storage type and
format to the generated spv.cpp file.
This is used in ShaderInfo struct that ops such as convolution will use to
determine, the workgroup size  and how to pack weights.

Differential Revision: [D40280337](https://our.internmc.facebook.com/intern/diff/D40280337/)