### PR TITLE
Fix torchelastic import error due to unsupported signal SIGKILL on Windows

### DIFF
--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -15,6 +15,8 @@ import time
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from torch.distributed.elastic.timer.api import TimerClient, TimerRequest
+from torch.distributed.elastic.multiprocessing.api import _get_kill_signal
+
 
 __all__ = ["FileTimerClient", "FileTimerRequest", "FileTimerServer"]
 
@@ -81,7 +83,7 @@ class FileTimerClient(TimerClient):
     def __init__(self, file_path: str, signal: Optional[_signal.Signals] = None) -> None:
         super().__init__()
         self._file_path = file_path
-        self.signal = _signal.SIGKILL if signal is None else signal
+        self.signal = _get_kill_signal() if signal is None else signal
 
     def _open_non_blocking(self) -> Optional[io.TextIOWrapper]:
         try:

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -14,8 +14,8 @@ import threading
 import time
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from torch.distributed.elastic.timer.api import TimerClient, TimerRequest
 from torch.distributed.elastic.multiprocessing.api import _get_kill_signal
+from torch.distributed.elastic.timer.api import TimerClient, TimerRequest
 
 
 __all__ = ["FileTimerClient", "FileTimerRequest", "FileTimerServer"]

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -9,7 +9,7 @@ import json
 import logging
 import os
 import select
-import signal
+import signal as _signal
 import threading
 import time
 from typing import Callable, Dict, List, Optional, Set, Tuple
@@ -78,10 +78,10 @@ class FileTimerClient(TimerClient):
         signal: singal, the signal to use to kill the process. Using a
                         negative or zero signal will not kill the process.
     """
-    def __init__(self, file_path: str, signal=signal.SIGKILL) -> None:
+    def __init__(self, file_path: str, signal: Optional[_signal.Signals] = None) -> None:
         super().__init__()
         self._file_path = file_path
-        self.signal = signal
+        self.signal = _signal.SIGKILL if signal is None else signal
 
     def _open_non_blocking(self) -> Optional[io.TextIOWrapper]:
         try:


### PR DESCRIPTION
Fixes #85427

The signal `signal.SIGKILL` is not supported on Windows. Since this was included in a type hint, an error is raised directly at import time of `distributed/elastic`. The fix in this PR proposes the default None and choosing the SIGKILL default only at runtime.

cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @peterjc123 @mszhanyi @skyline75489 @nbcsm