### PR TITLE
Add NVTX markers that dump additional information for nvprim_nvfuser Dynamo graphs

### DIFF
--- a/torch/_prims/nvfuser_executor.py
+++ b/torch/_prims/nvfuser_executor.py
@@ -30,9 +30,11 @@ else:
 
 import os
 
+
 @lru_cache(None)
 def get_nvprim_dump_nvtx():
     return os.getenv("PYTORCH_NVFUSER_DUMP_NVTX")
+
 
 DEFAULT_NVFUSER_PYTHON_CONFIG = MappingProxyType(
     {

--- a/torch/_prims/nvfuser_executor.py
+++ b/torch/_prims/nvfuser_executor.py
@@ -32,7 +32,7 @@ import os
 
 @lru_cache(None)
 def get_nvprim_dump_nvtx():
-  return os.getenv("PYTORCH_NVFUSER_DUMP_NVTX")
+    return os.getenv("PYTORCH_NVFUSER_DUMP_NVTX")
 
 DEFAULT_NVFUSER_PYTHON_CONFIG = MappingProxyType(
     {

--- a/torch/_prims/nvfuser_executor.py
+++ b/torch/_prims/nvfuser_executor.py
@@ -28,6 +28,8 @@ if torch.cuda.is_available():
 else:
     DataType = None
 
+import os
+
 DEFAULT_NVFUSER_PYTHON_CONFIG = MappingProxyType(
     {
         "use_python_fusion_cache": True,
@@ -247,10 +249,18 @@ def nvfuser_execute(gm: GraphModule, *args, executor_parameters=None):
             arg for arg in flat_args if isinstance(arg, (torch.Tensor, Number))
         )
 
-        return tree_unflatten(
+        if os.getenv('PYTORCH_NVFUSER_DUMP_NVTX'): torch.cuda.nvtx.range_push("fusion: {0}, graph: {1}".format(fusion.id(),
+                str([{
+                    'op': n.op,
+                    'name': n.name,
+                    'args': n.args
+                } for n in gm.graph.nodes])))
+        result = tree_unflatten(
             fusion.execute(concrete_fusion_inputs),  # type: ignore[has-type]
             unflatten_spec,  # type: ignore[has-type]
         )
+        if os.getenv('PYTORCH_NVFUSER_DUMP_NVTX'): torch.cuda.nvtx.range_pop()
+        return result
     else:
         warn(
             "nvfuser_executor is executed with non-cuda args, fallback to aten executor"
@@ -420,6 +430,12 @@ def maybe_partition_graph(
     else:
         return gm, any_unsupported
 
+class NVTXInterpreter(torch.fx.Interpreter):
+    def run_node(self, n):
+        torch.cuda.nvtx.range_push("name: {0}, args: {1}, op: {2}, meta: {3}".format(n.name, n.args, n.op, n.meta))
+        result = super().run_node(n)
+        torch.cuda.nvtx.range_pop()
+        return result
 
 def nvfuser_execute_partitioned(gm: GraphModule, *args, executor_parameters=None):
     executor_parameters = executor_parameters or DEFAULT_NVFUSER_PYTHON_CONFIG
@@ -440,6 +456,9 @@ def nvfuser_execute_partitioned(gm: GraphModule, *args, executor_parameters=None
         use_python_fusion_cache=use_python_fusion_cache,
     )
     if is_partitioned:
-        return gm(*args)
+        if os.getenv('PYTORCH_NVFUSER_DUMP_NVTX'):
+            return NVTXInterpreter(gm).run(*args)
+        else:
+            return gm(*args)
     else:
         return nvfuser_execute(gm, *args, executor_parameters=executor_parameters)

--- a/torch/_prims/nvfuser_executor.py
+++ b/torch/_prims/nvfuser_executor.py
@@ -29,8 +29,9 @@ else:
     DataType = None
 
 import os
+
 dump_nvtx = False
-if os.getenv('PYTORCH_NVFUSER_DUMP_NVTX'):
+if os.getenv("PYTORCH_NVFUSER_DUMP_NVTX"):
     dump_nvtx = True
 
 
@@ -254,14 +255,22 @@ def nvfuser_execute(gm: GraphModule, *args, executor_parameters=None):
         )
 
         if dump_nvtx:
-            torch.cuda.nvtx.range_push("fusion: {0}, graph: {1}".format(
-                fusion.id(),
-                str([{
-                    'op': n.op,
-                    'name': n.name,
-                    'args': n.args,
-                    'kwargs': n.kwargs
-                } for n in gm.graph.nodes])))
+            torch.cuda.nvtx.range_push(
+                "fusion: {0}, graph: {1}".format(
+                    fusion.id(),
+                    str(
+                        [
+                            {
+                                "op": n.op,
+                                "name": n.name,
+                                "args": n.args,
+                                "kwargs": n.kwargs,
+                            }
+                            for n in gm.graph.nodes
+                        ]
+                    ),
+                )
+            )
         result = tree_unflatten(
             fusion.execute(concrete_fusion_inputs),  # type: ignore[has-type]
             unflatten_spec,  # type: ignore[has-type]
@@ -438,12 +447,18 @@ def maybe_partition_graph(
     else:
         return gm, any_unsupported
 
+
 class NVTXInterpreter(torch.fx.Interpreter):
     def run_node(self, n):
-        torch.cuda.nvtx.range_push("name: {0}, args: {1}, op: {2}, kwargs: {3}".format(n.name, n.args, n.op, n.kwargs))
+        torch.cuda.nvtx.range_push(
+            "name: {0}, args: {1}, op: {2}, kwargs: {3}".format(
+                n.name, n.args, n.op, n.kwargs
+            )
+        )
         result = super().run_node(n)
         torch.cuda.nvtx.range_pop()
         return result
+
 
 def nvfuser_execute_partitioned(gm: GraphModule, *args, executor_parameters=None):
     executor_parameters = executor_parameters or DEFAULT_NVFUSER_PYTHON_CONFIG


### PR DESCRIPTION
dump information on graphs that NVFuser JIT compiles:
- the markers show the list of ops, args, and inputs that make up the graph

also dumps information on FX nodes that are not touched by NVFuser:
- the markers show the op, name, and arg list of the node

cc @kevinstephano @jjsjann123