### PR TITLE
[1/n] Thread PG: fix pyre error of class ProcessGroup

### DIFF
--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -82,5 +82,8 @@ else:
     #   python test/test_public_bindings.py -k test_correct_module_names
     # working even when USE_DISTRIBUTED=0.  Feel free to add more
     # stubs as necessary.
-    class ProcessGroup:  # type: ignore[no-redef]
+    # We cannot define stubs directly because they confuse pyre
+
+    class _ProcessGroupStub:
         pass
+    sys.modules["torch.distributed"].ProcessGroup = _ProcessGroupStub  # type: ignore[attr-defined]


### PR DESCRIPTION
Summary: Fix the typing stub of `ProcessGroup` in "torch/distributed/__init__.py", so that it won't confuse pyre, and we can remove a lot of pyre suppression comments.

Test Plan: pyre check

Differential Revision: D40921667

