### PR TITLE
Ignore macos usage log upload artifact failure

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -139,3 +139,4 @@ runs:
         retention-days: 14
         if-no-files-found: ignore
         path: usage_log.txt
+      continue-on-error: true


### PR DESCRIPTION
I'm not quite sure why GitHub starts to get flaky when we are trying to upload usage_log.txt to it (500 Internal server error). But we can live without it, so let's just ignore this for now, and follow up on this latter.

The failures all come from M1 runner, so it seems to point to a connectivity issue between AWS and GitHub:

* https://github.com/pytorch/pytorch/actions/runs/3373976793/jobs/5599310905
* https://github.com/pytorch/pytorch/actions/runs/3372858660/jobs/5597033598
* https://github.com/pytorch/pytorch/actions/runs/3371548201/jobs/5594274444
* https://github.com/pytorch/pytorch/actions/runs/3370877990/jobs/5592709210
* https://github.com/pytorch/pytorch/actions/runs/3370609384/jobs/5592008430

