### PR TITLE
[LTC] Update merge_rules.yaml

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -325,10 +325,10 @@
   - torch/csrc/lazy/**
   - test/cpp/lazy/**
   - test/lazy/**
-  - codegen/api/lazy.py
-  - codegen/dest/lazy_ir.py
-  - codegen/dest/lazy_ts_lowering.py
-  - codegen/gen_lazy_tensor.py
+  - torchgen/api/lazy.py
+  - torchgen/dest/lazy_ir.py
+  - torchgen/dest/lazy_ts_lowering.py
+  - torchgen/gen_lazy_tensor.py
   - aten/src/ATen/native/ts_native_functions.yaml
   approved_by:
   - alanwaketan


### PR DESCRIPTION
Summary:
Some of the LTC code-gen infra has been moved from codegen/ to torchgen/. Update the merge_rules.yaml to reflect that.

Test Plan:
New GH PRs...

cc @JackCaoG @wonjoolee95 
