### PR TITLE
Add a shortcut in Makefile for updating triton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,7 @@ lint:
 
 quicklint:
 	lintrunner
+
+triton:
+	$(PIP) uninstall -y triton
+	$(PIP) install -U "git+https://github.com/openai/triton@$(shell cat .github/ci_commit_pins/triton.txt)#subdirectory=python"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88318

Summary: Local triton installation needs to be updated after we migrate
to a newer version of triton, e.g.
https://github.com/pytorch/pytorch/pull/88242. The Makefile shortcut
makes that easier.