### PR TITLE
Don't print fatal:... in generate_torch_version.py

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -27,9 +27,9 @@ def get_tag(pytorch_root: Union[str, Path]) -> str:
     try:
         tag = (
             subprocess.run(
-                ["git", "describe", "--tags", "--exact"], 
+                ["git", "describe", "--tags", "--exact"],
                 cwd=pytorch_root,
-                capture_output=True
+                capture_output=True,
             )
             .decode("ascii")
             .strip()

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -26,8 +26,10 @@ def get_sha(pytorch_root: Union[str, Path]) -> str:
 def get_tag(pytorch_root: Union[str, Path]) -> str:
     try:
         tag = (
-            subprocess.check_output(
-                ["git", "describe", "--tags", "--exact"], cwd=pytorch_root
+            subprocess.run(
+                ["git", "describe", "--tags", "--exact"], 
+                cwd=pytorch_root,
+                capture_output=True
             )
             .decode("ascii")
             .strip()

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -25,15 +25,12 @@ def get_sha(pytorch_root: Union[str, Path]) -> str:
 
 def get_tag(pytorch_root: Union[str, Path]) -> str:
     try:
-        tag = (
-            subprocess.run(
-                ["git", "describe", "--tags", "--exact"],
-                cwd=pytorch_root,
-                capture_output=True,
-            )
-            .decode("ascii")
-            .strip()
-        )
+        tag = subprocess.run(
+            ["git", "describe", "--tags", "--exact"],
+            cwd=pytorch_root,
+            encoding="ascii",
+            capture_output=True,
+        ).stdout.strip()
         if RELEASE_PATTERN.match(tag):
             return tag
         else:


### PR DESCRIPTION
During build, users commonly see a message like
```
fatal: no tag exactly matches 'd8b4f33324b1eb6c1103874764116fb68e0d0af4'
```
which is usually ignored when builds succeed, but has confused users when build fails (due to a different issue). This PR removes the red herring, since this usually prints for local development when tags are not found. 

We catch the exception anyway and handle it under the hood, so we don't need to print it and confuse the user.

Test plan:
Note that builds on trunk current have this line, cmd-F 'fatal: no tag exactly matches' in https://github.com/pytorch/pytorch/actions/runs/3379162092/jobs/5610355820.

Then check in the PR build to see that the line no longer appears.

I also tagged my commit locally and printed what tag would be--this code and the old code printed the same results for what tag would be.