### PR TITLE
[inductor] Track if variables are scalars

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -431,7 +431,9 @@ class CSE:
             self.store_cache,
         )
 
-    def generate(self, buffer: IndentedBuffer, expr: str, is_scalar_expr : bool, write=True):
+    def generate(
+        self, buffer: IndentedBuffer, expr: str, is_scalar_expr: bool, write=True
+    ):
         assert isinstance(expr, str), expr
         if expr.startswith(self.name_prefix) and re.match(r"^[a-z0-9_]+$", expr):
             return expr
@@ -443,7 +445,7 @@ class CSE:
                 buffer.writeline(f"{self.prefix}{var} = {expr}{self.suffix}")
         return self.cache[expr]
 
-    def is_scalar(self, var : str):
+    def is_scalar(self, var: str):
         return var.startswith(self.scalar_name_prefix)
 
     def is_output_scalar(self, args):
@@ -453,7 +455,7 @@ class CSE:
         # which will not affect whether the output is a scalar
         return all(type(arg) != str or self.is_scalar(arg) for arg in args)
 
-    def newvar(self, is_scalar : bool) -> str:
+    def newvar(self, is_scalar: bool) -> str:
         prefix = self.scalar_name_prefix if is_scalar else self.name_prefix
         return f"{prefix}{next(self.iter_buffer_ids)}"
 
@@ -540,7 +542,7 @@ class Kernel(CodeGen):
             def __getattr__(name):
                 def inner(*args, **kwargs):
                     scalar_output = self.cse.is_output_scalar(args)
-                    expr =  getattr(parent_handler, name)(*args, **kwargs)
+                    expr = getattr(parent_handler, name)(*args, **kwargs)
                     return self.cse.generate(self.compute, expr, scalar_output)
 
                 return inner

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -358,8 +358,10 @@ class CppKernel(Kernel):
         argmax_or_argmin = reduction_type in {"argmax", "argmin"}
         # Not trackign whether results of reductions are scalar
         tmpvar = self.cse.generate(
-            self.loads, f"reduction {name} {cexpr(index)}",
-            is_scalar_expr=False, write=False
+            self.loads,
+            f"reduction {name} {cexpr(index)}",
+            is_scalar_expr=False,
+            write=False,
         )
         index = self.rename_indexing(index)
         self.reduction_vars[tmpvar] = reduction_type

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -776,7 +776,9 @@ class TritonKernel(Kernel):
         prior = self._load_mask
         if prior:
             # Masks are never scalar
-            mask = self.cse.generate(self.compute, f"{mask} & {prior}", is_scalar_expr=False)
+            mask = self.cse.generate(
+                self.compute, f"{mask} & {prior}", is_scalar_expr=False
+            )
 
         self._load_mask = mask
         with self.swap_buffers(self.compute, self.compute):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88338
* __->__ #88337
* #88242

This fixes https://github.com/pytorch/torchdynamo/issues/1515

It keeps track of which variables in generated code are scalars, and does not include a mask when doing loads generated by these.

It uses variable names (e.g., `tmp_scalar4`) to keep track of which ones are scalars, which makes generated code a little more readable, but is a little hacky. Can try to make it better, but wanted to get some feedback on overall approach first.

This only really matters for triton backend, it would be nice to contain it to `triton.py` by didn't find a nice way of doing that.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @lezcano 