### PR TITLE
[inductor] Added bucketize to decomp table

### DIFF
--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -101,6 +101,7 @@ decompositions = get_decompositions(
         aten.unfold_backward,
         aten.upsample_bilinear2d.vec,
         aten.upsample_nearest2d_backward,
+        aten.bucketize
     ]
 )
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -101,7 +101,7 @@ decompositions = get_decompositions(
         aten.unfold_backward,
         aten.upsample_bilinear2d.vec,
         aten.upsample_nearest2d_backward,
-        aten.bucketize
+        aten.bucketize,
     ]
 )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88338
* #88336
* #88242

These are the benchmark results vs eager

```
[--------------------------- bucketize ----------------------------]
                                                 |  eager  |  decomp
32 threads: --------------------------------------------------------
      ((16384, 1024), (16,)), (True, True)       |    600  |    464
      ((16384, 1024), (16,)), (True, False)      |    542  |    464
      ((16384, 1024), (16,)), (False, True)      |    780  |    731
      ((16384, 1024), (16,)), (False, False)     |    777  |    731
      ((16384, 1024), (64,)), (True, True)       |    624  |    515
      ((16384, 1024), (64,)), (True, False)      |    603  |    515
      ((16384, 1024), (64,)), (False, True)      |    789  |    718
      ((16384, 1024), (64,)), (False, False)     |    786  |    718
      ((16384, 1024), (256,)), (True, True)      |    878  |    820
      ((16384, 1024), (256,)), (True, False)     |    891  |    830
      ((16384, 1024), (256,)), (False, True)     |    897  |    900
      ((16384, 1024), (256,)), (False, False)    |    900  |    900
      ((16384, 1024), (1024,)), (True, True)     |   2000  |   1890
      ((16384, 1024), (1024,)), (True, False)    |   1950  |   1892
      ((16384, 1024), (1024,)), (False, True)    |   1990  |   1962
      ((16384, 1024), (1024,)), (False, False)   |   1990  |   2060
      ((16384, 1024), (4096,)), (True, True)     |   3405  |   3155
      ((16384, 1024), (4096,)), (True, False)    |   3244  |   3154
      ((16384, 1024), (4096,)), (False, True)    |   3282  |   3219
      ((16384, 1024), (4096,)), (False, False)   |   3278  |   3220
      ((16384, 1024), (16384,)), (True, True)    |   4626  |   4672
      ((16384, 1024), (16384,)), (True, False)   |   4629  |   4671
      ((16384, 1024), (16384,)), (False, True)   |   4662  |   4829
      ((16384, 1024), (16384,)), (False, False)  |   4665  |   4824
```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx