### PR TITLE
[FSDP] Do not include empty state in `_flatten_optim_state_dict()`

### DIFF
--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -1423,8 +1423,8 @@ class TestFSDPOptimState(FSDPTest):
         full_osd = FSDP.full_optim_state_dict(fsdp_model, optim, rank0_only=False)
         sharded_osd = FSDP.shard_full_optim_state_dict(full_osd, fsdp_model)
         optim.load_state_dict(sharded_osd)
-        # `load_state_dict()` will check the 0th parameter to see if "step" is
-        # represented as a tensor or float, so it is imperative that the state
+        # `__setstate__()` will check the 0th parameter to see if "step" is
+        # represented as a tensor or float, so it is imperative that its state
         # is non-empty.
 
         # Run an iteration as a sanity check

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -32,7 +32,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
 )
 
-STATE_DICT_TYPE = [StateDictType.FULL_STATE_DICT, StateDictType.SHARDED_STATE_DICT]
+STATE_DICT_TYPES = [StateDictType.FULL_STATE_DICT, StateDictType.SHARDED_STATE_DICT]
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -491,7 +491,7 @@ class TestFSDPOptimState(FSDPTest):
                         self.assertFalse(value.is_cuda)
 
     @skip_if_lt_x_gpu(2)
-    @parametrize("state_dict_type", STATE_DICT_TYPE)
+    @parametrize("state_dict_type", STATE_DICT_TYPES)
     @parametrize("use_multiple_param_groups", [False, True])
     @parametrize("rank0_only", [False, True])
     @parametrize("use_diff_optim_inputs", [False, True])
@@ -503,7 +503,7 @@ class TestFSDPOptimState(FSDPTest):
         use_diff_optim_inputs: bool,
     ) -> None:
         """
-        Tests :meth:`full_optim_state_dict` and `sharded_optim_state_dict`
+        Tests :meth:`full_optim_state_dict` and meth:`sharded_optim_state_dict`
         by comparing the returned dict for an FSDP-wrapped model with that of
         an equivalent non-wrapped model.
 
@@ -957,7 +957,7 @@ class TestFSDPOptimState(FSDPTest):
             self._step_model(model2, optim2, num_iters=NUM_ITERS)
 
     @skip_if_lt_x_gpu(2)
-    @parametrize("state_dict_type", STATE_DICT_TYPE)
+    @parametrize("state_dict_type", STATE_DICT_TYPES)
     @parametrize("add_to_fsdp_module", [False, True])
     def test_shard_full_optim_state_dict_unmanaged_params(
         self,
@@ -1087,7 +1087,7 @@ class TestFSDPOptimState(FSDPTest):
             optim.load_state_dict(flattened_osd)
 
     @skip_if_lt_x_gpu(2)
-    @parametrize("state_dict_type", STATE_DICT_TYPE)
+    @parametrize("state_dict_type", STATE_DICT_TYPES)
     @parametrize("use_multiple_param_groups", [False, True])
     def test_rekey_optim_state_dict_to_ids(
         self,
@@ -1384,11 +1384,12 @@ class TestFSDPOptimState(FSDPTest):
                 )
 
     @skip_if_lt_x_gpu(2)
-    def test_full_osd_without_first_param_state(self):
+    @parametrize("state_dict_type", STATE_DICT_TYPES)
+    def test_save_load_without_0th_param_state(self, state_dict_type: StateDictType):
         """
-        Tests saving and loading a full optim state dict for Adam optimizer
-        (i.e. any optimizer with a "step" key in its state) when the first
-        parameter does not have optimizer state (e.g. unused or frozen).
+        Tests saving and loading an optim state dict for Adam optimizer (i.e.
+        any optimizer with a "step" key in its state) when the first parameter
+        does not have optimizer state (e.g. unused or frozen).
         """
 
         class Model(nn.Module):
@@ -1420,9 +1421,13 @@ class TestFSDPOptimState(FSDPTest):
         optim.step()
 
         # Check that save and load does not error
-        full_osd = FSDP.full_optim_state_dict(fsdp_model, optim, rank0_only=False)
-        sharded_osd = FSDP.shard_full_optim_state_dict(full_osd, fsdp_model)
-        optim.load_state_dict(sharded_osd)
+        if state_dict_type == StateDictType.FULL_STATE_DICT:
+            fsdp_osd = FSDP.full_optim_state_dict(fsdp_model, optim, rank0_only=False)
+            flattened_osd = FSDP.shard_full_optim_state_dict(fsdp_osd, fsdp_model)
+        elif state_dict_type == StateDictType.SHARDED_STATE_DICT:
+            fsdp_osd = FSDP.sharded_optim_state_dict(fsdp_model, optim)
+            flattened_osd = FSDP.flatten_sharded_optim_state_dict(fsdp_osd, fsdp_model)
+        optim.load_state_dict(flattened_osd)
         # `__setstate__()` will check the 0th parameter to see if "step" is
         # represented as a tensor or float, so it is imperative that its state
         # is non-empty.

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -313,7 +313,9 @@ def _flatten_optim_state_dict(
             )
             key = _OptimStateKey(tuple(unflat_param_names), True)
             if flat_state:
-                flat_osd_state[key] = flat_state  # only include non-empty states
+                # Only include non-empty states since as expected by
+                # `torch.optim.Optimizer` s
+                flat_osd_state[key] = flat_state
         else:  # do not flatten non-FSDP parameters' states
             assert len(unflat_param_names) == 1
             unflat_param_name = unflat_param_names[0]

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -312,7 +312,8 @@ def _flatten_optim_state_dict(
                 shard_state,
             )
             key = _OptimStateKey(tuple(unflat_param_names), True)
-            flat_osd_state[key] = flat_state
+            if flat_state:
+                flat_osd_state[key] = flat_state  # only include non-empty states
         else:  # do not flatten non-FSDP parameters' states
             assert len(unflat_param_names) == 1
             unflat_param_name = unflat_param_names[0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#88353 [FSDP] Do not include empty state in `_flatten_optim_state_dict()`**
* #87941 [FSDP()][26/N] Move `_lazy_init()` into `_fsdp_root_pre_forward()`
* #87940 [FSDP()][25/N] Add `_post_forward_reshard()`
* #87939 [FSDP()][24/N] Refactor `_lazy_init()`
* #87938 [FSDP()][23/N] Refactor handle attr initialization
* #87935 [FSDP()][21/N] Refactor and fix `_cast_buffers()`
* #87934 [FSDP] Rename `dtype` to `buffer_name_to_dtype`
* #87933 [FSDP] Remove `device` arg from `_cast_buffers()`
* #87932 [FSDP()][20/N][Easy] Move functions in file
* #87931 [FSDP()][18/N] Refactor `pre_forward_unshard()`
* #87930 [FSDP()][17/N] Refactor `_fsdp_root_pre_forward()`
* #87929 [FSDP()][16/N] Refactor post-forward/pre-backward
* #87928 [FSDP()][15/N] Refactor `_init_streams()`
* #87927 [FSDP()][14/N] Refactor pre-forward/post-backward

https://github.com/pytorch/pytorch/blob/983c0e7f3101f1543bed6c4ec1539a4d590a94c0/torch/optim/adam.py#L163
The above line requires that a candidate optimizer state dict being loaded via `load_state_dict()` has non-empty state for its 0th parameter (via `state_values[0]`). This PR changes FSDP to only include non-empty mappings in the state returned by `_flatten_optim_state_dict()`, which is the subroutine for both `shard_full_optim_state_dict()` and `flatten_sharded_optim_state_dict()`. 