### PR TITLE
Print only the driver version from the first GPU

### DIFF
--- a/.github/scripts/install_nvidia_utils_linux.sh
+++ b/.github/scripts/install_nvidia_utils_linux.sh
@@ -36,8 +36,9 @@ install_nvidia_driver_amzn2() {
         # Check if NVIDIA driver has already been installed
         if [ -x "$(command -v nvidia-smi)" ]; then
             set +e
-            # The driver exists, check its version next
-            INSTALLED_DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader)
+            # The driver exists, check its version next. Also check only the first GPU if there are more than one of them
+            # so that the same driver version is not print over multiple lines
+            INSTALLED_DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0)
             NVIDIA_SMI_STATUS=$?
 
             if [ "$NVIDIA_SMI_STATUS" -ne 0 ] && [ "$NVIDIA_SMI_STATUS" -ne 14 ]; then


### PR DESCRIPTION
For example, distributed test has more than one of them:

```
nvidia-smi --query-gpu=driver_version --format=csv,noheader
515.57
515.57
```

while `--id=0` correctly prints:

```
nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0
515.57
```

This is to avoid re-install the same driver as in https://github.com/pytorch/pytorch/actions/runs/3380662072/jobs/5613981088
