### PR TITLE
Not run inductor test in trunk

### DIFF
--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,9 +1,9 @@
 name: inductor
 
 on:
+  schedule:
+    - cron: 45 0,4,8,12,16,20 * * *
   push:
-    branches:
-      - master
     tags:
       - ciflow/inductor/*
   workflow_dispatch:

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,8 +1,6 @@
 name: inductor
 
 on:
-  schedule:
-    - cron: 45 0,4,8,12,16,20 * * *
   push:
     tags:
       - ciflow/inductor/*


### PR DESCRIPTION
Trying to not run in inductor tests in trunk at the moment because of CUDA issue with G5 runner:

* CUDA GPU not found https://github.com/pytorch/pytorch/actions/runs/3379516207/jobs/5611539300
* NVIDIA driver installation fails https://github.com/pytorch/pytorch/actions/runs/3379922198/jobs/5612458360
* Docker fails to start https://github.com/pytorch/pytorch/actions/runs/3381276196/jobs/5615513348