### PR TITLE
[torch package] Treat builtins as default extern module

### DIFF
--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -39,6 +39,9 @@ IMPLICIT_IMPORT_ALLOWLIST: Iterable[str] = [
     "numpy",
     "numpy.core",
     "numpy.core._multiarray_umath",
+    # FX GraphModule might depend on builtins module and users usually
+    # don't extern builtins. Here we import it here by default.
+    "builtins",
 ]
 
 


### PR DESCRIPTION
Summary: When using torch deploy, if we do fx transformation and then try to pickle/unpickle a fx GraphModule, it's possible that the GraphModule's code depends on `builtins` but we didn't add it to extern module.

Reviewed By: PaliC

Differential Revision: D40958730

