### PR TITLE
[dynamo] Skip mutation detection for inference mode

### DIFF
--- a/torch/_dynamo/optimizations/training.py
+++ b/torch/_dynamo/optimizations/training.py
@@ -65,7 +65,7 @@ def is_aot_autograd_safe_to_run(gm, example_inputs):
             else:
                 mutated = has_mutation(gm, example_inputs)
         else:
-            log.warning(
+            log.info(
                 "inference_mode enabled. TorchDynamo could not check for mutation."
             )
     except NotImplementedError as e:

--- a/torch/_dynamo/optimizations/training.py
+++ b/torch/_dynamo/optimizations/training.py
@@ -51,18 +51,23 @@ def is_aot_autograd_safe_to_run(gm, example_inputs):
     # 2) Mutation in the graph
     mutated = False
     try:
-        if functorch.compile.config.use_functionalize:
-            # There are two problematic classes we still exclude for now with
-            # functionalization:
-            #   - data mutation of inputs (fixed when we stop recording the
-            #   copy_ directly into the graph)
-            #   - metadata mutation of inputs (fixed if we do an extra partition
-            #   to avoid AotAutograd on the mutated inputs, or if we some how
-            #   get custom autograd function to reflect metadata changes to the
-            #   original tensor)
-            mutated = has_mutation(gm, example_inputs, inputs_only=True)
+        if not torch.is_inference_mode_enabled():
+            if functorch.compile.config.use_functionalize:
+                # There are two problematic classes we still exclude for now with
+                # functionalization:
+                #   - data mutation of inputs (fixed when we stop recording the
+                #   copy_ directly into the graph)
+                #   - metadata mutation of inputs (fixed if we do an extra partition
+                #   to avoid AotAutograd on the mutated inputs, or if we some how
+                #   get custom autograd function to reflect metadata changes to the
+                #   original tensor)
+                mutated = has_mutation(gm, example_inputs, inputs_only=True)
+            else:
+                mutated = has_mutation(gm, example_inputs)
         else:
-            mutated = has_mutation(gm, example_inputs)
+            log.warning(
+                "inference_mode enabled. TorchDynamo could not check for mutation."
+            )
     except NotImplementedError as e:
         if "SparseTensorImpl" not in str(e):
             # TODO - TorchDynamo mutation analysis cannot handle sparse tensors.


### PR DESCRIPTION
Skip the mutation detection for inference_mode, and raise a warning. This helps one internal model

Related to https://github.com/pytorch/torchdynamo/issues/1768

@ezyang What do you think about this? The issue that Dynamo mutation detector uses version counter to detect mutation.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx