### PR TITLE
fix order accumulation for parallel sum

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -88,7 +88,7 @@ def reduction_combine(reduction_type, var, next_value, threads_num=0):
         if threads_num == 0:
             return f"{var} += {next_value}"
         else:
-            var_with_id = var.replace(f"[{threads_num}]", f"[tid]")
+            var_with_id = var.replace(f"[{threads_num}]", "[tid]")
             return f"{var_with_id} += {next_value}"
     if reduction_type == "any":
         return f"{var} = {var} || {next_value}"
@@ -100,7 +100,7 @@ def reduction_combine_vec(reduction_type, var, next_value, threads_num=0):
         if threads_num == 0:
             return f"{var} += {next_value}"
         else:
-            var_with_id = var.replace(f"[{threads_num}]", f"[tid]")
+            var_with_id = var.replace(f"[{threads_num}]", "[tid]")
             return f"{var_with_id} += {next_value}"
     elif reduction_type == "max":
         return f"{var} = at::vec::maximum({var}, {next_value})"
@@ -652,7 +652,7 @@ class CppKernel(Kernel):
             max_threads = parallel_num_threads()
             tmpvar_to_accumulate = f"{tmpvar}_acc[{max_threads}]"
             tmpvar_to_accumulate_with_idx = tmpvar_to_accumulate.replace(
-                f"[{max_threads}]", f"[i]"
+                f"[{max_threads}]", "[i]"
             )
         index = self.rename_indexing(index)
         self.reduction_vars[tmpvar] = reduction_type
@@ -691,9 +691,9 @@ class CppKernel(Kernel):
                 )
                 if not hasattr(self.parallel_accumulation_stores, "has_tid"):
                     self.parallel_accumulation_stores.writeline(
-                        None, f"int tid = omp_get_thread_num();"
+                        None, "int tid = omp_get_thread_num();"
                     )
-                    setattr(self.parallel_accumulation_stores, "has_tid", True)
+                    self.parallel_accumulation_stores.has_tid = True
                 self.parallel_accumulation_stores.writeline(
                     None,
                     f"{reduction_combine(reduction_type, tmpvar_to_accumulate, value, max_threads)};",
@@ -959,10 +959,10 @@ class CppVecKernel(CppKernel):
                 f"at::vec::Vectorized<{DTYPE_TO_CPP[dtype]}> {tmpvar_vec_to_accumulate};"
             )
             tmpvar_to_accumulate_with_idx = tmpvar_to_accumulate.replace(
-                f"[{max_threads}]", f"[i]"
+                f"[{max_threads}]", "[i]"
             )
             tmpvar_vec_to_accumulate_with_idx = tmpvar_vec_to_accumulate.replace(
-                f"[{max_threads}]", f"[i]"
+                f"[{max_threads}]", "[i]"
             )
             self.parallel_accumulation_prefix.writelines(
                 [
@@ -975,9 +975,9 @@ class CppVecKernel(CppKernel):
             )
             if not hasattr(self.parallel_accumulation_stores, "has_tid"):
                 self.parallel_accumulation_stores.writeline(
-                    None, f"int tid = omp_get_thread_num();"
+                    None, "int tid = omp_get_thread_num();"
                 )
-                setattr(self.parallel_accumulation_stores, "has_tid", True)
+                self.parallel_accumulation_stores.has_tid = True
             self.parallel_accumulation_stores.writeline(
                 None,
                 f"{reduction_combine_vec(reduction_type, tmpvar_vec_to_accumulate, value, max_threads)};",


### PR DESCRIPTION
Fixes [#1774](https://github.com/pytorch/pytorch/issues/93582).

Since `#pragma omp for reduction(+:var)` will not guarantee a fixed reduce order for accumulation. and different reduce order for accumulation will leads to different results. We can choose to achieve fixed order reduce sum without OMP native support.

For `test_dense_mask_index`, generated CPP codes with OMP interface:
```cpp
extern "C" void kernel(const float* __restrict__ in_ptr0,
                       const float* __restrict__ in_ptr1,
                       float* __restrict__ out_ptr0)
{
    {
        float tmp3 = 0;
        auto tmp3_vec = at::vec::Vectorized<float>(tmp3);
        float tmp3_acc[64];
        at::vec::Vectorized<float> tmp3_vec_acc[64];
        for (int i = 0; i < 64; i++) 
        {
            tmp3_acc[i] = 0;
            tmp3_vec_acc[i] = at::vec::Vectorized<float>(tmp3);
        }
        #pragma omp parallel num_threads(64)
        {
            #pragma omp for  
            for(long i0=0; i0<6400; i0+=1)
            {
                auto tmp0 = at::vec::Vectorized<float>::loadu(in_ptr0 + 16*i0);
                auto tmp1 = at::vec::Vectorized<float>(in_ptr1[2]);
                auto tmp2 = tmp0 * tmp1;
                int tid = omp_get_thread_num();
                tmp3_vec_acc[tid] += tmp2;
            }
            tmp3 = at::vec::vec_reduce_all<float>([](at::vec::Vectorized<float>& x, at::vec::Vectorized<float>&y) {return x + y;}, tmp3_vec);
            #pragma omp for simd simdlen(8)  
            for(long i0=102400; i0<102400; i0+=1)
            {
                auto tmp0 = in_ptr0[i0];
                auto tmp1 = in_ptr1[2];
                auto tmp2 = tmp0 * tmp1;
                int tid = omp_get_thread_num();
                tmp3_acc[tid] += tmp2;
            }
        }
        for (int i = 0; i < 64; i++)
            tmp3_vec += tmp3_vec_acc[i];
        tmp3 = at::vec::vec_reduce_all<float>([](at::vec::Vectorized<float>& x, at::vec::Vectorized<float>&y) {return x + y;}, tmp3_vec);
        for (int i = 0; i < 64; i++)
            tmp3 += tmp3_acc[i];
        out_ptr0[0] = tmp3;
    }
}
```

This PR will only add reduction prefix/suffix when parallel + reduction both happens. For those cases with multiple loops and parallel happened on most outer loop + reduction happened on most inner loop. They naively do not have this problem and we will not add reduction prefix/suffix to avoid overhead.

For example,
```python
    def test_sum1(self):
        def fn(a, b):
            return ((a + b).sum(-1),)

        self.common(fn, (torch.randn(8, 8), torch.randn(8, 8)))
```

The generated code will be:
```cpp
extern "C" void kernel(const float* __restrict__ in_ptr0,
                       const float* __restrict__ in_ptr1,
                       float* __restrict__ out_ptr0)
{
    #pragma omp parallel num_threads(64)
    {
        #pragma omp for 
        for(long i0=0; i0<8; i0+=1)
        {
            {
                {
                    float tmp3 = 0;
                    for(long i1=0; i1<8; i1+=1)
                    {
                        {
                            auto tmp0 = in_ptr0[i1 + (8*i0)];
                            auto tmp1 = in_ptr1[i1 + (8*i0)];
                            auto tmp2 = tmp0 + tmp1;
                            tmp3 += tmp2;
                        }
                    }
                    out_ptr0[i0] = tmp3;
                }
            }
        }
    }
}
```


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire @mlazos @yanboliang @chunyuan-w