### PR TITLE
Make avgpool2d output shape consistent

### DIFF
--- a/aten/src/ATen/div_rtn.h
+++ b/aten/src/ATen/div_rtn.h
@@ -9,3 +9,12 @@ static inline T div_rtn(T x, T y) {
     --q;
   return q;
 }
+
+template <typename T>
+static inline T div_ceil(T x, T y) {
+  int q = x / y;
+  int r = x % y;
+  if ((r != 0) && ((r > 0) != (y < 0)))
+    ++q;
+  return q;
+}

--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -41,9 +41,9 @@ template<typename T>
 static inline T pooling_output_shape_pad_lr(
         T inputSize, T kernelSize, T pad_l, T pad_r, T stride, T dilation,
         bool ceil_mode) {
-    T outputSize = div_rtn<T>(
-        inputSize + pad_l + pad_r - dilation * (kernelSize - 1) - 1 +
-        (ceil_mode ? stride - 1 : 0), stride) + 1;
+    T outputSize = ceil_mode ? div_ceil<T>(inputSize + pad_l + pad_r, stride) :
+                               div_rtn<T>(
+        inputSize + pad_l + pad_r - dilation * (kernelSize - 1) - 1, stride) + 1;
     if (ceil_mode) {
         // ensure that the last pooling starts inside the image
         // needed to avoid problems in ceil mode

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3663,7 +3663,7 @@ class CommonTemplate:
         self.common(
             fn,
             [
-                torch.randn([1, 1, 20, 15]),
+                torch.randn([1, 1, 21, 16]),
                 torch.randn([1, 1, 20, 15]),
             ],
         )

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -281,6 +281,7 @@ class TestPoolingNN(NNTestCase):
 
     def test_MaxUnpool2d_output_size(self):
         m = nn.MaxPool2d(3, stride=2, return_indices=True)
+        m_ceil = nn.MaxPool2d(3, stride=2, return_indices=True, ceil_mode=True)
         mu = nn.MaxUnpool2d(3, stride=2)
         big_t = torch.rand(1, 1, 6, 6)
         big_t[0][0][4][4] = 100
@@ -291,15 +292,26 @@ class TestPoolingNN(NNTestCase):
         for i in range(0, 4, 2):
             for j in range(0, 4, 2):
                 small_t[:, :, i, j] = 100
+
+        small_t_ceil = torch.rand(1, 1, 3, 3)
+        small_t_ceil[0][0][0][0] = 100
+        small_t_ceil[0][0][0][2] = 100
+        small_t_ceil[0][0][2][0] = 100
+        small_t_ceil[0][0][2][2] = 100
+
         output_small, indices_small = m(small_t)
+        output_small_ceil, indices_small_ceil = m_ceil(small_t_ceil)
         for h in range(3, 10):
             for w in range(3, 10):
-                if 4 <= h <= 6 and 4 <= w <= 6:
+                if 3 <= h <= 6 and 3 <= w <= 6:
                     size = (h, w)
                     if h == 6:
                         size = (1, 1) + size
-
-                    mu(output_small, indices_small, output_size=size)
+                    # This path should go with output indices from ceil_mode=True
+                    if 3 == h or 3 == w:
+                        mu(output_small, indices_small_ceil, output_size=size)
+                    else:
+                        mu(output_small, indices_small, output_size=size)
                 else:
                     self.assertRaises(ValueError, lambda: mu(output_small, indices_small, (h, w)))
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2375,9 +2375,7 @@ def pooling_size(x, i, kernel_size, stride, padding, ceil_mode):
     )
 
     if ceil_mode:
-        x_alt = ir.IndexingDiv(
-            x + 2 * padding[i] - (kernel_size[i] - 1) + 2 * (stride[i] - 1), stride[i]
-        )
+        x_alt = ir.IndexingDiv(x + 2 * padding[i] + (stride[i] - 1), stride[i])
 
         if V.graph.sizevars.size_hint(x_out - x_alt) == 0:
             # ceil mode is actually a no-op, lets guard on that

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1192,21 +1192,37 @@ def div_rtn(x, y):
     return q
 
 
+def div_ceil(x, y):
+    q = x // y
+    r = x % y
+    # WARNING: explicit bool conversion here is necessary;
+    # would be fixed by SymBool
+    if r != 0 and (bool(r > 0) != bool(y < 0)):
+        q += 1
+    return q
+
+
 def pooling_output_shape_pad_lr(
     inputSize, kernelSize, pad_l, pad_r, stride, dilation, ceil_mode
 ):
-    outputSize = (
-        div_rtn(
-            inputSize
-            + pad_l
-            + pad_r
-            - dilation * (kernelSize - 1)
-            - 1
-            + (stride - 1 if ceil_mode else 0),
+    if ceil_mode:
+        outputSize = div_ceil(
+            inputSize + pad_l + pad_r,
             stride,
         )
-        + 1
-    )
+    else:
+        outputSize = (
+            div_rtn(
+                inputSize
+                + pad_l
+                + pad_r
+                - dilation * (kernelSize - 1)
+                - 1
+                + (stride - 1 if ceil_mode else 0),
+                stride,
+            )
+            + 1
+        )
     if ceil_mode:
         if (outputSize - 1) * stride >= inputSize + pad_l:
             outputSize -= 1

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -899,9 +899,9 @@ def _unpool_output_size(
                 )
             )
         for d in range(len(kernel_size)):
-            min_size = default_size[d] - stride[d]
+            min_size = default_size[d] - kernel_size[d] + 1
             max_size = default_size[d] + stride[d]
-            if not (min_size < output_size[d] < max_size):
+            if not (min_size <= output_size[d] < max_size):
                 raise ValueError(
                     'invalid output_size "{}" (dim {} must be between {} and {})'.format(
                         output_size, d, min_size, max_size


### PR DESCRIPTION
Fixes #88144

The root-cause is that the original output shape calculation formula is mixed-up. Fundamentally, dilation is not relevant when in ceiling mode ---- no matter dilation param is 1 or more, the starting point of each pooling window is not impacted. The updated formula for ceiling mode only includes input_size, padding and stride, and then do the ceiling.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire