### PR TITLE
Enable tracing of Vulkan models with the model tracer

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -1286,6 +1286,7 @@ def define_buck_targets(
         ] + ([] if IS_OSS else ["//xplat/folly:molly"]),
         exported_deps = [
             ":aten_cpu",
+            ":aten_vulkan",
             ":torch_common",
         ] + ([] if IS_OSS else [
             "//xplat/caffe2/fb/custom_ops/batch_box_cox:batch_box_cox",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88427

Adds `aten_vulkan` to the `torch_model_tracer` which allows Vulkan models to be traced.

Note that there are some caveats, the

```
LD_LIBRARY_PATH=~/fbsource/third-party/swiftshader/lib/linux-x64/
```

env var has to be set whenever a Vulkan model is traced. This is to ensure that the Vulkan drivers can be loaded.

Differential Revision: [D40775049](https://our.internmc.facebook.com/intern/diff/D40775049/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D40775049/)!