### PR TITLE
[FSDP][Docs] Simplify `mixed_precision` ctor docs

### DIFF
--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -99,14 +99,16 @@ class MixedPrecision:
             pass. This may be set to ``False`` to save memory if using custom
             optimizers that can perform the optimizer step in ``reduce_dtype``.
 
+    .. note:: This API is experimental and subject to change.
+
+    .. note:: Only floating point tensors are cast to their specified dtypes.
+
     .. note:: In ``summon_full_params``, parameters are forced to full
         precision, but buffers are not.
 
     .. note:: ``state_dict`` checkpoints parameters and buffers in full
         precision. For buffers, this is only supported for
         ``StateDictType.FULL_STATE_DICT``.
-
-    .. note:: This API is experimental and subject to change.
 
     .. note:: Each low precision dtype must be specified explicitly. For
         example, ``MixedPrecision(reduce_dtype=torch.float16)`` only specifies
@@ -116,6 +118,15 @@ class MixedPrecision:
     .. note:: If a ``reduce_dtype`` is not specified, then gradient reduction
         happens in ``param_dtype`` if specified or the original parameter dtype
         otherwise.
+
+    .. note:: If the user passes a model with ``BatchNorm`` modules and an
+        ``auto_wrap_policy`` to the FSDP constructor, then FSDP will disable
+        mixed precision for ``BatchNorm`` modules by wrapping them separately
+        in their own FSDP instance with mixed precision disabled. This is due
+        to some missing low precision ``BatchNorm`` kernels. If the user does
+        not use an ``auto_wrap_policy``, then the user must take care to not
+        use mixed precision for FSDP instances containing ``BatchNorm``
+        modules.
     """
 
     param_dtype: Optional[torch.dtype] = None

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -331,21 +331,11 @@ class FullyShardedDataParallel(nn.Module):
         backward_prefetch (Optional[BackwardPrefetch]):
             This configures explicit backward prefetching of all-gathers. See
             :class:`BackwardPrefetch` for details. (Default: ``BACKWARD_PRE``)
-        mixed_precision (Optional[MixedPrecision]): A ``MixedPrecision`` instance
-            describing the mixed precision training config to be used. ``MixedPrecision``
-            supports configuring parameter, buffer, and gradient communication dtype. Note
-            that only floating point data is cast to the reduced precision. This allows
-            users potential memory saving and training speedup while trading off
-            accuracy during model training. If ``None``, no mixed precision is applied.
-            Note that if ``mixed_precision`` is enabled for FSDP model that
-            contains ``BatchNorm`` with ``auto_wrap_policy``, FSDP will take
-            care to disable mixed precision for ``BatchNorm`` units by wrapping
-            them separately in their own FSDP unit with ``mixed_precision=None``.
-            This is done because several ``BatchNorm`` kernels do not implement
-            reduced type support at the moment. If individually wrapping the model,
-            users must take care to set ``mixed_precision=None`` for
-            ``BatchNorm`` units.
-            (Default: ``None``)
+        mixed_precision (Optional[MixedPrecision]):
+            This configures native mixed precision for FSDP. If this is set to
+            ``None``, then no mixed precision is used. Otherwise, parameter,
+            buffer, and gradient reduction dtypes can be set. See
+            :class:`MixedPrecision` for details. (Default: ``None``)
         ignored_modules (Optional[Iterable[torch.nn.Module]]): Modules whose
             own parameters and child modules' parameters and buffers are
             ignored by this instance. None of the modules directly in


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #88432 [FSDP] Default to `limit_all_gathers=True`
* #88431 [FSDP][Docs] Reword `sharding_strategy` docs and other minor doc changes
* #88430 [FSDP][Docs] Simplify CPU offload docs
* **#88429 [FSDP][Docs] Simplify `mixed_precision` ctor docs**
* #88428 [FSDP] Default to `BACKWARD_PRE`
* #88260 [FSDP()][Easy] Make `fully_shard()` only `FULL_SHARD`
* #88235 [FSDP()] Have `fully_shard()` abide by `@contract`!
* #88234 [FSDP()][Easy] Rename `_State` to `_FSDPState`
* #88233 [FSDP()] Rename to `fully_shard()` and move to `_composable/`
* #88232 [FSDP][Easy] Remove unneeded `TrainingState` transition
* #88123 [FSDP] Rename `unflat_param_name` -> `fqn` for consistency
* #88122 [FSDP] Simplify `_get_buffer_names()`
* #88121 [FSDP] Remove unneeded `torch.no_grad()` context when offloading to CPU
* #88120 [FSDP][Docs] Add note mentioning rate limiter for backward prefetch
* #88040 [FSDP()][27/N] Add forward hook registration
* #87941 [FSDP()][26/N] Move `_lazy_init()` into `_fsdp_root_pre_forward()`
* #87940 [FSDP()][25/N] Add `_post_forward_reshard()`
* #87939 [FSDP()][24/N] Refactor `_lazy_init()`
* #87938 [FSDP()][23/N] Refactor handle attr initialization
* #87935 [FSDP()][21/N] Refactor and fix `_cast_buffers()`
* #87934 [FSDP] Rename `dtype` to `buffer_name_to_dtype`
* #87933 [FSDP] Remove `device` arg from `_cast_buffers()`
* #87932 [FSDP()][20/N][Easy] Move functions in file
* #87931 [FSDP()][18/N] Refactor `pre_forward_unshard()`
* #87930 [FSDP()][17/N] Refactor `_fsdp_root_pre_forward()`
* #87929 [FSDP()][16/N] Refactor post-forward/pre-backward
* #87928 [FSDP()][15/N] Refactor `_init_streams()`
* #87927 [FSDP()][14/N] Refactor pre-forward/post-backward

