### PR TITLE
[FSDP][Docs] Simplify CPU offload docs

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -289,13 +289,9 @@ class FullyShardedDataParallel(nn.Module):
             off between memory saving and communication overhead. ``FULL_SHARD``
             will be chosen if sharding_strategy is not specified.
         cpu_offload (Optional[CPUOffload]):
-            CPU offloading config. Currently, only parameter and gradient CPU
-            offload is supported. It can be enabled via passing in
-            ``cpu_offload=CPUOffload(offload_params=True)``. Note that this
-            currently implicitly enables gradient offloading to CPU in order for
-            params and grads to be on same device to work with optimizer. This
-            API is subject to change. Default is ``None`` in which case there
-            will be no offloading.
+            This configures CPU offloading. If this is set to ``None``, then
+            no CPU offloading happens. See :class:`CPUOffload` for details.
+            (Default: ``None``)
         auto_wrap_policy (Optional[Callable[[nn.Module, bool, int], bool]]):
             A callable specifying a policy to recursively wrap layers with FSDP.
             Note that this policy currently will only apply to child modules of


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #88432 [FSDP] Default to `limit_all_gathers=True`
* #88431 [FSDP][Docs] Reword `sharding_strategy` docs and other minor doc changes
* **#88430 [FSDP][Docs] Simplify CPU offload docs**
* #88429 [FSDP][Docs] Simplify `mixed_precision` ctor docs
* #88428 [FSDP] Default to `BACKWARD_PRE`
* #88260 [FSDP()][Easy] Make `fully_shard()` only `FULL_SHARD`
* #88235 [FSDP()] Have `fully_shard()` abide by `@contract`!
* #88234 [FSDP()][Easy] Rename `_State` to `_FSDPState`
* #88233 [FSDP()] Rename to `fully_shard()` and move to `_composable/`
* #88232 [FSDP][Easy] Remove unneeded `TrainingState` transition
* #88123 [FSDP] Rename `unflat_param_name` -> `fqn` for consistency
* #88122 [FSDP] Simplify `_get_buffer_names()`
* #88121 [FSDP] Remove unneeded `torch.no_grad()` context when offloading to CPU
* #88120 [FSDP][Docs] Add note mentioning rate limiter for backward prefetch
* #88040 [FSDP()][27/N] Add forward hook registration
* #87941 [FSDP()][26/N] Move `_lazy_init()` into `_fsdp_root_pre_forward()`
* #87940 [FSDP()][25/N] Add `_post_forward_reshard()`
* #87939 [FSDP()][24/N] Refactor `_lazy_init()`
* #87938 [FSDP()][23/N] Refactor handle attr initialization
* #87935 [FSDP()][21/N] Refactor and fix `_cast_buffers()`
* #87934 [FSDP] Rename `dtype` to `buffer_name_to_dtype`
* #87933 [FSDP] Remove `device` arg from `_cast_buffers()`
* #87932 [FSDP()][20/N][Easy] Move functions in file
* #87931 [FSDP()][18/N] Refactor `pre_forward_unshard()`
* #87930 [FSDP()][17/N] Refactor `_fsdp_root_pre_forward()`
* #87929 [FSDP()][16/N] Refactor post-forward/pre-backward
* #87928 [FSDP()][15/N] Refactor `_init_streams()`
* #87927 [FSDP()][14/N] Refactor pre-forward/post-backward

