### PR TITLE
Reenable optimizer overlap tests

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4494,8 +4494,7 @@ class DistributedTest:
                     dist.barrier()
 
         @sandcastle_skip_if(
-            BACKEND == "nccl" or BACKEND == "ucc",
-            "Issues with async error handling, see https://github.com/pytorch/pytorch/issues/73259"
+            BACKEND == "ucc",
         )
         @skip_if_lt_x_gpu(2)
         @parametrize("grad_as_bucket_view", [True, False])
@@ -4521,8 +4520,7 @@ class DistributedTest:
             )
 
         @sandcastle_skip_if(
-            BACKEND == "nccl" or BACKEND == "ucc",
-            "Issues with async error handling, see https://github.com/pytorch/pytorch/issues/73259"
+            BACKEND == "ucc",
         )
         @skip_if_lt_x_gpu(2)
         @parametrize("optimize_subset", [True, False])
@@ -4541,8 +4539,7 @@ class DistributedTest:
             )
 
         @sandcastle_skip_if(
-            BACKEND == "nccl" or BACKEND == "ucc",
-            "Issues with async error handling, see https://github.com/pytorch/pytorch/issues/73259"
+            BACKEND == "ucc",
         )
         @skip_if_lt_x_gpu(2)
         @parametrize("optimize_subset", [True, False])

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4495,6 +4495,7 @@ class DistributedTest:
 
         @sandcastle_skip_if(
             BACKEND == "ucc",
+            "Test not enabled for UCC backend",
         )
         @skip_if_lt_x_gpu(2)
         @parametrize("grad_as_bucket_view", [True, False])
@@ -4521,6 +4522,7 @@ class DistributedTest:
 
         @sandcastle_skip_if(
             BACKEND == "ucc",
+            "Test not enabled for UCC backend",
         )
         @skip_if_lt_x_gpu(2)
         @parametrize("optimize_subset", [True, False])
@@ -4540,6 +4542,7 @@ class DistributedTest:
 
         @sandcastle_skip_if(
             BACKEND == "ucc",
+            "Test not enabled for UCC backend",
         )
         @skip_if_lt_x_gpu(2)
         @parametrize("optimize_subset", [True, False])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88439

Closes https://github.com/pytorch/pytorch/issues/73259. Not sure the root cause but CI seems fine with these tests.