### PR TITLE
nvprim python runtime dtype correctness patch

### DIFF
--- a/test/test_nvfuser_dynamo.py
+++ b/test/test_nvfuser_dynamo.py
@@ -46,11 +46,12 @@ class TestNvFuserDynamo(TestCase):
         self.assertEqual(eager_result, nvfuser_result)
 
     def test_dtype_correctness(self):
-        input1 = make_tensor((2, 4, 8), device="cuda", dtype=torch.float32)
+        input1 = make_tensor((2, 4, 8), device="cuda", dtype=torch.float16)
 
         @torchdynamo.optimize("nvprims_nvfuser")
         def func(a):
             tmp = a + 1.0
+            # nvfuser would promote output to fp32 in math, FusionDefinition should cast output dtype back
             return torch.where(tmp > 0, tmp, 0.0)
 
         # No warnings and no errors

--- a/test/test_nvfuser_dynamo.py
+++ b/test/test_nvfuser_dynamo.py
@@ -51,7 +51,7 @@ class TestNvFuserDynamo(TestCase):
         @torchdynamo.optimize("nvprims_nvfuser")
         def func(a):
             tmp = a + 1.0
-            return self.where(tmp > 0, tmp, 0.0)
+            return torch.where(tmp > 0, tmp, 0.0)
 
         # No warnings and no errors
         with warnings.catch_warnings(record=True) as w:

--- a/test/test_nvfuser_dynamo.py
+++ b/test/test_nvfuser_dynamo.py
@@ -45,6 +45,21 @@ class TestNvFuserDynamo(TestCase):
         eager_result = func.__wrapped__(input1, input2)
         self.assertEqual(eager_result, nvfuser_result)
 
+    def test_dtype_correctness(self):
+        input1 = make_tensor((2, 4, 8), device="cuda", dtype=torch.float32)
+
+        @torchdynamo.optimize("nvprims_nvfuser")
+        def func(a):
+            tmp = a + 1.0
+            return self.where(tmp > 0, tmp, 0.0)
+
+        # No warnings and no errors
+        with warnings.catch_warnings(record=True) as w:
+            nvfuser_result = func(input1)
+            self.assertEqual(len(w), 0)
+        eager_result = func.__wrapped__(input1)
+        self.assertEqual(eager_result, nvfuser_result)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Cherry-picking: https://github.com/csarofeen/pytorch/pull/2133

- [x] casts FusionDefinition output to original dtype recorded in the GraphModule
- [x] add a python repro with dynamo


cc @kevinstephano @ezyang @mruberry @ngimel @Lezcano @fdrocha @peterbell10