### PR TITLE
Revert "Revert "Put Python Dispatcher cache in dict, clear it on new registrations. (#88329)""

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -243,6 +243,8 @@ class OpOverload(PyOperatorABC):
         op.__module__ = overloadpacket.__module__
         self.__qualname__ = self._name
         self.__annotations__ = {}
+        # NB: This name is hard-coded in torch/csrc/autograd/python_variable.cpp
+        self._dispatch_cache = {}
 
     # it's a no-op since OpOverload object is immutable and must be unique for a given op overload.
     def __deepcopy__(self, memo=None):
@@ -289,6 +291,7 @@ class OpOverload(PyOperatorABC):
                 assert mode not in self.python_key_mode_table
                 # TODO(voz): Should we replace setting torch._C.DispatchKey.Python entirely with setting mode keys?
                 self.python_key_mode_table[mode] = fn
+                self._dispatch_cache.clear()
                 return fn
 
             assert isinstance(dispatch_key_or_mode, torch._C.DispatchKey)
@@ -301,23 +304,19 @@ class OpOverload(PyOperatorABC):
                     f"Trying to override a python impl for {dispatch_key_or_mode} on operator {self._name}"
                 )
             self.py_kernels[dispatch_key_or_mode] = fn
+            self._dispatch_cache.clear()
             return fn
 
         return inner
 
     # This implements the pre-computation logic for the Python dispatcher.
-    def __getattr__(self, attr):
-        if len(attr) == 0 or not attr[0].isupper():
-            raise AttributeError()
-
-        try:
-            key = torch._C._dispatch_key_parse(attr)
-        except Exception as e:
-            raise AttributeError()
+    def _get_dispatch(self, key):
+        # This is only called upon a cache miss
+        assert key not in self._dispatch_cache
 
         if key == torch._C.DispatchKey.Python:
             if not self.python_key_mode_table:
-                setattr(self, attr, key)
+                self._dispatch_cache[key] = key
                 return key
 
             def handler(*args, **kwargs):
@@ -336,12 +335,12 @@ class OpOverload(PyOperatorABC):
                 # TODO(voz): The idea behind this is that we do not yet support dispatch by key + mode, only key.
                 return self.python_key_mode_table[curr_mode](*args, **kwargs)
 
-            setattr(self, attr, handler)
+            self._dispatch_cache[key] = handler
             return handler
 
         key = resolve_key(self, key)
         r = self.py_kernels.get(key, key)
-        setattr(self, attr, r)
+        self._dispatch_cache[key] = r
         return r
 
     def name(self):

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -338,8 +338,8 @@ class OpOverload(PyOperatorABC):
             self._dispatch_cache[key] = handler
             return handler
 
-        key = resolve_key(self, key)
-        r = self.py_kernels.get(key, key)
+        final_key = resolve_key(self, key)
+        r = self.py_kernels.get(final_key, final_key)
         self._dispatch_cache[key] = r
         return r
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88489

The bug was that I was accidentally caching at the wrong key name, so
we were never actually hitting the cache.  I've renamed the resolved
key to final_key to avoid shadowing in this way.

This reverts commit 410ce96a23a3496a45478e0b25ffac53aa3c116f.