### PR TITLE
Convert tag to string before saving FileWriterTag

### DIFF
--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -423,7 +423,7 @@ class SummaryWriter(object):
         walltime = time.time() if walltime is None else walltime
         fw_logdir = self._get_file_writer().get_logdir()
         for tag, scalar_value in tag_scalar_dict.items():
-            fw_tag = fw_logdir + "/" + main_tag.replace("/", "_") + "_" + tag
+            fw_tag = fw_logdir + "/" + main_tag.replace("/", "_") + "_" + str(tag)
             assert self.all_writers is not None
             if fw_tag in self.all_writers.keys():
                 fw = self.all_writers[fw_tag]


### PR DESCRIPTION
Case in point, I wanted to log my classifier accuracy per class. Each class is defined as an integer, so I log the following:
```
{0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}
```
Every step, it logs successfully - however at the end of the epoch add_scalars is called and it fails to save because the dict keys are not strings. The keys of the dict can be converted as strings as you can see in this commit.

Fixes #ISSUE_NUMBER
