### PR TITLE
Set correct size of `attr::output_layouts` when the graph has multiple outputs in JIT oneDNN fuser 

### DIFF
--- a/test/test_jit_llga_fuser.py
+++ b/test/test_jit_llga_fuser.py
@@ -774,6 +774,33 @@ class TestEnableDisableLlgaFuser(JitTestCase):
         self.assertGraphContainsExactly(t_jit_3.graph_for(x, y), LLGA_FUSION_GROUP, 0)
 
 
+@unittest.skipIf(LLGA_NOT_ENABLED, "MKL-DNN build is disabled")
+class TestDynamoAOT(JitTestCase):
+    def test_dynamo_aot_ts_onednn(self):
+        class Seq(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.Sequential(
+                    nn.Linear(10, 10),
+                    nn.ReLU(),
+                    nn.Linear(10, 10),
+                    nn.ReLU(),
+                )
+
+            def forward(self, x):
+                return self.layers(x)
+
+        mod = Seq()
+
+        import torch._dynamo
+        aot_mod = torch._dynamo.optimize("aot_ts", nopython=True)(mod)
+
+        for _ in range(10):
+            with torch.jit.fuser("fuser3"):
+                loss = aot_mod(torch.rand([10, 10])).sum()
+                loss.backward()
+
+
 @unittest.skipIf(IS_AVX512_UNSUPPORTED, "This test fails for BF16 on machines without AVX512.")
 @unittest.skipIf(LLGA_NOT_ENABLED, "MKL-DNN build is disabled")
 class TestModel(JitLlgaTestCase):

--- a/test/test_jit_llga_fuser.py
+++ b/test/test_jit_llga_fuser.py
@@ -775,6 +775,7 @@ class TestEnableDisableLlgaFuser(JitTestCase):
 
 
 @unittest.skipIf(LLGA_NOT_ENABLED, "MKL-DNN build is disabled")
+@unittest.skip("Enable when integration with dynamo aot_autograd is more stable")
 class TestDynamoAOT(JitTestCase):
     def test_dynamo_aot_ts_onednn(self):
         class Seq(nn.Module):

--- a/test/test_jit_llga_fuser.py
+++ b/test/test_jit_llga_fuser.py
@@ -800,6 +800,8 @@ class TestDynamoAOT(JitTestCase):
                 loss = aot_mod(torch.rand([10, 10])).sum()
                 loss.backward()
 
+        torch._dynamo.reset()
+
 
 @unittest.skipIf(IS_AVX512_UNSUPPORTED, "This test fails for BF16 on machines without AVX512.")
 @unittest.skipIf(LLGA_NOT_ENABLED, "MKL-DNN build is disabled")

--- a/torch/csrc/jit/codegen/onednn/graph_helper.cpp
+++ b/torch/csrc/jit/codegen/onednn/graph_helper.cpp
@@ -594,7 +594,7 @@ void LlgaNodeWrapper::setOpaqueLayout(size_t offset) {
       ")");
   auto& layouts =
       const_cast<std::vector<int64_t>&>(n->is(attr::output_layouts)); // NOLINT
-  layouts.at(offset) = MKLDNN_LAYOUT;
+  layouts.at(offset) = OPAQUE_LAYOUT;
 }
 
 bool LlgaNodeWrapper::useOpaqueLayout(size_t offset) const {
@@ -606,7 +606,7 @@ bool LlgaNodeWrapper::useOpaqueLayout(size_t offset) const {
       " for attr::output_layouts with size ",
       num_output,
       ")");
-  return n->is(attr::output_layouts)[offset] == MKLDNN_LAYOUT;
+  return n->is(attr::output_layouts)[offset] == OPAQUE_LAYOUT;
 }
 
 } // namespace onednn

--- a/torch/csrc/jit/codegen/onednn/graph_helper.cpp
+++ b/torch/csrc/jit/codegen/onednn/graph_helper.cpp
@@ -505,7 +505,6 @@ Node* LlgaGraphHelper::createSingletonSubgraph(Node* n, AliasDb& aliasDb) {
   auto group = SubgraphUtils::createSingletonSubgraphAndUpdateAliasing(
       n, prim::oneDNNFusionGroup, aliasDb);
   opToOwningPartition_.add(group, partitionId);
-  LlgaNodeWrapper(group).initOutputLayouts();
   return group;
 }
 
@@ -585,25 +584,29 @@ LlgaNodeWrapper::LlgaNodeWrapper(const Node* node)
 }
 
 void LlgaNodeWrapper::setOpaqueLayout(size_t offset) {
-  TORCH_CHECK(offset < n->outputs().size(), "Invalid output offset ", offset);
+  const auto num_output = n->is(attr::output_layouts).size();
+  TORCH_CHECK(
+      offset < num_output,
+      "Out of range. (Invalid index ",
+      offset,
+      " for attr::output_layouts with size ",
+      num_output,
+      ")");
   auto& layouts =
       const_cast<std::vector<int64_t>&>(n->is(attr::output_layouts)); // NOLINT
   layouts.at(offset) = 1;
 }
 
 bool LlgaNodeWrapper::useOpaqueLayout(size_t offset) const {
-  TORCH_CHECK(offset < n->outputs().size(), "Invalid output offset ", offset);
+  const auto num_output = n->is(attr::output_layouts).size();
+  TORCH_CHECK(
+      offset < num_output,
+      "Out of range. (Invalid index ",
+      offset,
+      " for attr::output_layouts with size ",
+      num_output,
+      ")");
   return n->is(attr::output_layouts)[offset] == 1;
-}
-
-void LlgaNodeWrapper::initOutputLayouts() {
-  if (n->hasAttribute(attr::output_layouts)) {
-    return;
-  }
-
-  // Init all output layouts as undef
-  std::vector<int64_t> layouts(n->outputs().size(), 0);
-  n->is_(attr::output_layouts, layouts);
 }
 
 } // namespace onednn

--- a/torch/csrc/jit/codegen/onednn/graph_helper.cpp
+++ b/torch/csrc/jit/codegen/onednn/graph_helper.cpp
@@ -594,7 +594,7 @@ void LlgaNodeWrapper::setOpaqueLayout(size_t offset) {
       ")");
   auto& layouts =
       const_cast<std::vector<int64_t>&>(n->is(attr::output_layouts)); // NOLINT
-  layouts.at(offset) = 1;
+  layouts.at(offset) = MKLDNN_LAYOUT;
 }
 
 bool LlgaNodeWrapper::useOpaqueLayout(size_t offset) const {
@@ -606,7 +606,7 @@ bool LlgaNodeWrapper::useOpaqueLayout(size_t offset) const {
       " for attr::output_layouts with size ",
       num_output,
       ")");
-  return n->is(attr::output_layouts)[offset] == 1;
+  return n->is(attr::output_layouts)[offset] == MKLDNN_LAYOUT;
 }
 
 } // namespace onednn

--- a/torch/csrc/jit/codegen/onednn/graph_helper.h
+++ b/torch/csrc/jit/codegen/onednn/graph_helper.h
@@ -92,8 +92,6 @@ class LlgaNodeWrapper {
   friend class LlgaGraphHelper;
 
  private:
-  void initOutputLayouts();
-
   Node* n;
 };
 

--- a/torch/csrc/jit/codegen/onednn/graph_helper.h
+++ b/torch/csrc/jit/codegen/onednn/graph_helper.h
@@ -11,7 +11,7 @@ namespace fuser {
 namespace onednn {
 
 #define STRIDED_LAYOUT 0
-#define MKLDNN_LAYOUT 1
+#define OPAQUE_LAYOUT 1
 
 struct OpPartitionMap {
   void add(uint64_t opId, uint64_t partitionId) {

--- a/torch/csrc/jit/codegen/onednn/graph_helper.h
+++ b/torch/csrc/jit/codegen/onednn/graph_helper.h
@@ -10,6 +10,9 @@ namespace jit {
 namespace fuser {
 namespace onednn {
 
+#define STRIDED_LAYOUT 0
+#define MKLDNN_LAYOUT 1
+
 struct OpPartitionMap {
   void add(uint64_t opId, uint64_t partitionId) {
     opmap_[opId] = partitionId;

--- a/torch/csrc/jit/codegen/onednn/layout_propagation.cpp
+++ b/torch/csrc/jit/codegen/onednn/layout_propagation.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/codegen/onednn/graph_helper.h>
 #include <torch/csrc/jit/codegen/onednn/layout_propagation.h>
+#include <torch/csrc/jit/jit_log.h>
 
 namespace torch {
 namespace jit {
@@ -9,6 +10,14 @@ namespace onednn {
 void LayoutPropagation(Node* n) {
   if (!LlgaGraphHelper::isLlgaSubgraph(n))
     return;
+
+  // initial attr::output_layouts if undefined
+  if (!n->hasAttribute(attr::output_layouts)) {
+    const auto num_output = n->outputs().size();
+    GRAPH_DEBUG("Initial output_layouts of size ", num_output);
+    std::vector<int64_t> layouts(num_output, 0);
+    n->is_(attr::output_layouts, layouts);
+  }
 
   for (auto input : n->inputs()) {
     auto prev = input->node();

--- a/torch/csrc/jit/codegen/onednn/layout_propagation.cpp
+++ b/torch/csrc/jit/codegen/onednn/layout_propagation.cpp
@@ -15,7 +15,7 @@ void LayoutPropagation(Node* n) {
   if (!n->hasAttribute(attr::output_layouts)) {
     const auto num_output = n->outputs().size();
     GRAPH_DEBUG("Initial output_layouts of size ", num_output);
-    std::vector<int64_t> layouts(num_output, 0);
+    std::vector<int64_t> layouts(num_output, STRIDED_LAYOUT);
     n->is_(attr::output_layouts, layouts);
   }
 


### PR DESCRIPTION
Bug:
Previously, `initOutputLayouts()` was called after creating a graph and before merging other nodes. It is a vector with one element. So when a graph contains multiple outputs, e.g. using AOTAutograd compile in my case, layout_propagation pass try to access out of range elements in the vector. Then it comes to the second bug in `useOpaqueLayout()`, the out of range checks the index with the updated output size instead of the size of the vector. Then used `[]` to access the element, which is out of range.   

Fixes the above two issues:

1. check the offset is within range with the size of `attr::output_layouts` vector instead of another variable. This check catches the error now.
2. change the place to initial `attr::output_layouts` after node merging. The graph may change with node merging. Thus we moved the initialization in layout_propagation with the complete graph. 

Added test time:
`Ran 1 test in 0.383s`

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @VitalyFedyunin @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen