### PR TITLE
extract out the clean workspace test to its own file

### DIFF
--- a/caffe2/python/clean_workspace_test.py
+++ b/caffe2/python/clean_workspace_test.py
@@ -1,0 +1,18 @@
+import unittest
+
+from caffe2.python import workspace
+
+
+# This test is extracted out because it relies on the pristine state of the initial
+# workspace. When tests are run in different orders, this test may become flaky because
+# of global state modifications impacting what the root folder is after a reset.
+class TestWorkspace(unittest.TestCase):
+    def testRootFolder(self):
+        self.assertEqual(workspace.ResetWorkspace(), True)
+        self.assertEqual(workspace.RootFolder(), ".")
+        self.assertEqual(workspace.ResetWorkspace("/tmp/caffe-workspace-test"), True)
+        self.assertEqual(workspace.RootFolder(), "/tmp/caffe-workspace-test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/caffe2/python/workspace_test.py
+++ b/caffe2/python/workspace_test.py
@@ -24,12 +24,6 @@ class TestWorkspace(unittest.TestCase):
         )
         workspace.ResetWorkspace()
 
-    def testRootFolder(self):
-        self.assertEqual(workspace.ResetWorkspace(), True)
-        self.assertEqual(workspace.RootFolder(), ".")
-        self.assertEqual(workspace.ResetWorkspace("/tmp/caffe-workspace-test"), True)
-        self.assertEqual(workspace.RootFolder(), "/tmp/caffe-workspace-test")
-
     def testWorkspaceHasBlobWithNonexistingName(self):
         self.assertEqual(workspace.HasBlob("non-existing"), False)
 


### PR DESCRIPTION
Summary:
This test relies on what the root workspace is before any other code
is run. However, some of the test cases change it. If the order the
tests are run is randomized, then the test can fail if run after one
of them.

Having it on its own ensures that it always sees a pristine state.

Test Plan: Verified locally and confirmed in CI.

Differential Revision: D41030735

