### PR TITLE
[FSDP] `api.py` -> `_api.py` (only export through `__init__.py`)

### DIFF
--- a/torch/distributed/_composable/fully_shard.py
+++ b/torch/distributed/_composable/fully_shard.py
@@ -4,6 +4,12 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed._composable.contract import contract
+from torch.distributed.fsdp._api import (
+    BackwardPrefetch,
+    CPUOffload,
+    MixedPrecision,
+    ShardingStrategy,
+)
 from torch.distributed.fsdp._init_utils import (
     _init_buffer_state,
     _init_core_state,
@@ -17,12 +23,6 @@ from torch.distributed.fsdp._init_utils import (
 from torch.distributed.fsdp._runtime_utils import (
     _register_post_forward_hooks,
     _register_pre_forward_hooks,
-)
-from torch.distributed.fsdp.api import (
-    BackwardPrefetch,
-    CPUOffload,
-    MixedPrecision,
-    ShardingStrategy,
 )
 
 

--- a/torch/distributed/fsdp/_api.py
+++ b/torch/distributed/fsdp/_api.py
@@ -1,6 +1,7 @@
 """
 This file includes public APIs for FSDP such as the classes used for the
-constructor arguments.
+constructor arguments. We keep this file private and export everything through
+__init__.py.
 """
 
 from dataclasses import dataclass

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -20,6 +20,12 @@ import torch.distributed.fsdp.fully_sharded_data_parallel as fsdp_file
 import torch.nn as nn
 from torch.distributed.algorithms._comm_hooks import default_hooks
 from torch.distributed.distributed_c10d import _get_default_group
+from torch.distributed.fsdp._api import (
+    BackwardPrefetch,
+    CPUOffload,
+    MixedPrecision,
+    ShardingStrategy,
+)
 from torch.distributed.fsdp._common_utils import (
     _FSDPState,
     _get_param_to_fqns,
@@ -30,12 +36,6 @@ from torch.distributed.fsdp._common_utils import (
 from torch.distributed.fsdp._exec_order_utils import _ExecOrderData
 from torch.distributed.fsdp._limiter_utils import _FreeEventQueue
 from torch.distributed.fsdp._wrap_utils import _get_submodule_to_states
-from torch.distributed.fsdp.api import (
-    BackwardPrefetch,
-    CPUOffload,
-    MixedPrecision,
-    ShardingStrategy,
-)
 from torch.distributed.fsdp.flat_param import (
     _HandlesKey,
     FlatParameter,

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -7,6 +7,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 from torch.distributed.algorithms._comm_hooks import LOW_PRECISION_HOOKS
+from torch.distributed.fsdp._api import BackwardPrefetch
 from torch.distributed.fsdp._common_utils import (
     _all_handles,
     _assert_in_training_states,
@@ -19,7 +20,6 @@ from torch.distributed.fsdp._utils import (
     _no_dispatch_record_stream,
     p_assert,
 )
-from torch.distributed.fsdp.api import BackwardPrefetch
 from torch.distributed.fsdp.flat_param import (
     _HandlesKey,
     FlatParameter,

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -30,6 +30,12 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     ActivationWrapper,
 )
 from torch.distributed.algorithms._comm_hooks import LOW_PRECISION_HOOKS
+from torch.distributed.fsdp._api import (
+    BackwardPrefetch,
+    CPUOffload,
+    MixedPrecision,
+    ShardingStrategy,
+)
 from torch.distributed.fsdp._common_utils import (
     _get_param_to_fqns,
     FSDP_PREFIX,
@@ -67,12 +73,6 @@ from torch.distributed.fsdp._runtime_utils import (
     _wait_for_computation_stream,
 )
 from torch.distributed.fsdp._wrap_utils import _auto_wrap
-from torch.distributed.fsdp.api import (
-    BackwardPrefetch,
-    CPUOffload,
-    MixedPrecision,
-    ShardingStrategy,
-)
 
 from ._optim_utils import (
     _broadcast_pos_dim_tensor_states,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#88500 [FSDP] `api.py` -> `_api.py` (only export through `__init__.py`)**

