### PR TITLE
Re-enable inductor models tests as periodical jobs

### DIFF
--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -1,9 +1,12 @@
 name: inductor
 
 on:
+  schedule:
+    - cron: 45 1,5,9,13,17,21 * * *
   push:
     tags:
       - ciflow/inductor/*
+      - ciflow/periodic/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Run every 4 hour same as periodic, but offset by an hour. This should give us some signals instead of completely disabling these jobs on master after https://github.com/pytorch/pytorch/pull/88374
