### PR TITLE
Add single-process DDP accuracy support to dynamo benchmark suite

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1405,7 +1405,7 @@ def parse_args():
     parser.add_argument(
         "--distributed-master-port",
         default="6789",
-        help="Port to bind for master process for torch.distributed.  Don't set unless you are seeing a conflict with another process using this port.",
+        help="Port to bind for for torch.distributed.  Use the default unless it's conflicting with another user",
     )
     parser.add_argument(
         "--dynamic-shapes",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88523
* #88521
* __->__ #88511
* #88480
* #88460
* #88435

- does not intend to support multi-process, as that is more complex
  and we have torchbench scripts for that
- currently only works in accuracy mode as this was the main goal,
  but could be extended for measuring single-gpu perf impact of
  graph breaks

Run with

`python benchmarks/dynamo/torchbench.py --inductor --training --accuracy --only hf_Bert --ddp`

Example output
```
cuda train hf_Bert
[2022-11-04 18:52:08,304] torch._inductor.compile_fx: [WARNING] skipping cudagraphs due to complex input striding
PASS
```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx