### PR TITLE
(fix): Add some missing std::moves to C10

### DIFF
--- a/c10/core/SymFloat.cpp
+++ b/c10/core/SymFloat.cpp
@@ -1,6 +1,7 @@
 #include <c10/core/SymFloat.h>
 #include <c10/core/SymNodeImpl.h>
 #include <array>
+#include <utility>
 
 namespace c10 {
 
@@ -23,14 +24,14 @@ static std::array<SymNode, 2> normalize_symfloats(SymFloat a_, SymFloat b_) {
   if (!b) {
     b = common->wrap_float(b_.as_float_unchecked());
   }
-  return {a, b};
+  return {std::move(a), std::move(b)};
 }
 
 SymFloat SymFloat::operator+(SymFloat sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymFloat(data_ + sci.data_);
   }
-  auto res = normalize_symfloats(*this, sci);
+  auto res = normalize_symfloats(*this, std::move(sci));
   return SymFloat(res[0]->add(res[1]));
 }
 
@@ -38,7 +39,7 @@ SymFloat SymFloat::operator-(SymFloat sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymFloat(data_ - sci.data_);
   }
-  auto res = normalize_symfloats(*this, sci);
+  auto res = normalize_symfloats(*this, std::move(sci));
   return SymFloat(res[0]->sub(res[1]));
 }
 
@@ -46,7 +47,7 @@ SymFloat SymFloat::operator*(SymFloat sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymFloat(data_ * sci.data_);
   }
-  auto res = normalize_symfloats(*this, sci);
+  auto res = normalize_symfloats(*this, std::move(sci));
   return SymFloat(res[0]->mul(res[1]));
 }
 
@@ -54,7 +55,7 @@ SymFloat SymFloat::operator/(SymFloat sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymFloat(data_ / sci.data_);
   }
-  auto res = normalize_symfloats(*this, sci);
+  auto res = normalize_symfloats(*this, std::move(sci));
   return SymFloat(res[0]->truediv(res[1]));
 }
 

--- a/c10/core/SymFloat.cpp
+++ b/c10/core/SymFloat.cpp
@@ -10,7 +10,9 @@ SymNode SymFloat::toSymNodeImpl() const {
   return SymNode::reclaim_copy(toSymNodeImplUnowned());
 }
 
-static std::array<SymNode, 2> normalize_symfloats(SymFloat a_, SymFloat b_) {
+static std::array<SymNode, 2> normalize_symfloats(
+    const SymFloat& a_,
+    const SymFloat& b_) {
   SymNode a, b;
   if (a_.is_symbolic())
     a = a_.toSymNodeImpl();
@@ -27,39 +29,39 @@ static std::array<SymNode, 2> normalize_symfloats(SymFloat a_, SymFloat b_) {
   return {std::move(a), std::move(b)};
 }
 
-SymFloat SymFloat::operator+(SymFloat sci) const {
+SymFloat SymFloat::operator+(const SymFloat& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymFloat(data_ + sci.data_);
   }
-  auto res = normalize_symfloats(*this, std::move(sci));
+  auto res = normalize_symfloats(*this, sci);
   return SymFloat(res[0]->add(res[1]));
 }
 
-SymFloat SymFloat::operator-(SymFloat sci) const {
+SymFloat SymFloat::operator-(const SymFloat& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymFloat(data_ - sci.data_);
   }
-  auto res = normalize_symfloats(*this, std::move(sci));
+  auto res = normalize_symfloats(*this, sci);
   return SymFloat(res[0]->sub(res[1]));
 }
 
-SymFloat SymFloat::operator*(SymFloat sci) const {
+SymFloat SymFloat::operator*(const SymFloat& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymFloat(data_ * sci.data_);
   }
-  auto res = normalize_symfloats(*this, std::move(sci));
+  auto res = normalize_symfloats(*this, sci);
   return SymFloat(res[0]->mul(res[1]));
 }
 
-SymFloat SymFloat::operator/(SymFloat sci) const {
+SymFloat SymFloat::operator/(const SymFloat& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymFloat(data_ / sci.data_);
   }
-  auto res = normalize_symfloats(*this, std::move(sci));
+  auto res = normalize_symfloats(*this, sci);
   return SymFloat(res[0]->truediv(res[1]));
 }
 
-std::ostream& operator<<(std::ostream& os, SymFloat s) {
+std::ostream& operator<<(std::ostream& os, const SymFloat& s) {
   if (s.is_symbolic()) {
     os << s.toSymNodeImpl()->str();
   } else {

--- a/c10/core/SymFloat.h
+++ b/c10/core/SymFloat.h
@@ -35,10 +35,10 @@ class C10_API SymFloat {
     return data_;
   }
 
-  SymFloat operator+(SymFloat) const;
-  SymFloat operator-(SymFloat) const;
-  SymFloat operator*(SymFloat) const;
-  SymFloat operator/(SymFloat) const;
+  SymFloat operator+(const SymFloat&) const;
+  SymFloat operator-(const SymFloat&) const;
+  SymFloat operator*(const SymFloat&) const;
+  SymFloat operator/(const SymFloat&) const;
 
   // N.B. It's important to keep this definition in the header
   // as we expect if checks to be folded for mobile builds
@@ -57,5 +57,5 @@ class C10_API SymFloat {
   SymNode ptr_;
 };
 
-C10_API std::ostream& operator<<(std::ostream& os, SymFloat s);
+C10_API std::ostream& operator<<(std::ostream& os, const SymFloat& s);
 } // namespace c10

--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -2,6 +2,7 @@
 #include <c10/core/SymInt.h>
 #include <c10/core/SymNodeImpl.h>
 #include <array>
+#include <utility>
 
 namespace c10 {
 
@@ -20,7 +21,7 @@ static std::array<SymNode, 2> normalize_symints(SymInt a_, SymInt b_) {
   if (!b) {
     b = common->wrap_int(b_.as_int_unchecked());
   }
-  return {a, b};
+  return {std::move(a), std::move(b)};
 }
 
 SymNode SymInt::toSymNodeImpl() const {
@@ -55,7 +56,7 @@ SymInt SymInt::operator+(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ + sci.data_);
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return SymInt(res[0]->add(res[1]));
 }
 
@@ -63,7 +64,7 @@ SymInt SymInt::operator-(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ - sci.data_);
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return SymInt(res[0]->sub(res[1]));
 }
 
@@ -71,7 +72,7 @@ SymInt SymInt::operator*(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ * sci.data_);
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return SymInt(res[0]->mul(res[1]));
 }
 
@@ -79,7 +80,7 @@ SymInt SymInt::operator/(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ / sci.data_);
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return SymInt(res[0]->floordiv(res[1]));
 }
 
@@ -87,7 +88,7 @@ SymInt SymInt::operator%(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ % sci.data_);
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return SymInt(res[0]->mod(res[1]));
 }
 
@@ -95,19 +96,19 @@ bool SymInt::operator==(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return data_ == sci.data_;
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return res[0]->eq(res[1])->bool_();
 }
 
 bool SymInt::operator!=(SymInt sci) const {
-  return !(*this == sci);
+  return !(*this == std::move(sci));
 }
 
 bool SymInt::operator<(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return data_ < sci.data_;
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return res[0]->lt(res[1])->bool_();
 }
 
@@ -115,7 +116,7 @@ bool SymInt::operator<=(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return data_ <= sci.data_;
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return res[0]->le(res[1])->bool_();
 }
 
@@ -123,7 +124,7 @@ bool SymInt::operator>(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return data_ > sci.data_;
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return res[0]->gt(res[1])->bool_();
 }
 
@@ -131,7 +132,7 @@ bool SymInt::operator>=(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return data_ >= sci.data_;
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return res[0]->ge(res[1])->bool_();
 }
 
@@ -139,27 +140,27 @@ SymInt SymInt::min(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return std::min(data_, sci.data_);
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return SymInt(res[0]->min(res[1]));
 }
 SymInt SymInt::max(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return std::max(data_, sci.data_);
   }
-  auto res = normalize_symints(*this, sci);
+  auto res = normalize_symints(*this, std::move(sci));
   return SymInt(res[0]->max(res[1]));
 }
 
 void SymInt::operator*=(SymInt sci) {
-  *this = *this * sci;
+  *this = *this * std::move(sci);
 }
 
 void SymInt::operator/=(SymInt sci) {
-  *this = *this / sci;
+  *this = *this / std::move(sci);
 }
 
 void SymInt::operator+=(SymInt sci) {
-  *this = *this + sci;
+  *this = *this + std::move(sci);
 }
 
 bool SymInt::operator<(int64_t sci) const {

--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -6,7 +6,9 @@
 
 namespace c10 {
 
-static std::array<SymNode, 2> normalize_symints(SymInt a_, SymInt b_) {
+static std::array<SymNode, 2> normalize_symints(
+    const SymInt& a_,
+    const SymInt& b_) {
   SymNode a, b;
   if (a_.is_symbolic())
     a = a_.toSymNodeImpl();
@@ -52,115 +54,115 @@ SymInt::operator SymFloat() const {
   return SymFloat(toSymNodeImpl()->sym_float());
 }
 
-SymInt SymInt::operator+(SymInt sci) const {
+SymInt SymInt::operator+(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ + sci.data_);
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return SymInt(res[0]->add(res[1]));
 }
 
-SymInt SymInt::operator-(SymInt sci) const {
+SymInt SymInt::operator-(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ - sci.data_);
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return SymInt(res[0]->sub(res[1]));
 }
 
-SymInt SymInt::operator*(SymInt sci) const {
+SymInt SymInt::operator*(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ * sci.data_);
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return SymInt(res[0]->mul(res[1]));
 }
 
-SymInt SymInt::operator/(SymInt sci) const {
+SymInt SymInt::operator/(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ / sci.data_);
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return SymInt(res[0]->floordiv(res[1]));
 }
 
-SymInt SymInt::operator%(SymInt sci) const {
+SymInt SymInt::operator%(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ % sci.data_);
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return SymInt(res[0]->mod(res[1]));
 }
 
-bool SymInt::operator==(SymInt sci) const {
+bool SymInt::operator==(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return data_ == sci.data_;
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return res[0]->eq(res[1])->bool_();
 }
 
-bool SymInt::operator!=(SymInt sci) const {
-  return !(*this == std::move(sci));
+bool SymInt::operator!=(const SymInt& sci) const {
+  return !(*this == sci);
 }
 
-bool SymInt::operator<(SymInt sci) const {
+bool SymInt::operator<(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return data_ < sci.data_;
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return res[0]->lt(res[1])->bool_();
 }
 
-bool SymInt::operator<=(SymInt sci) const {
+bool SymInt::operator<=(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return data_ <= sci.data_;
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return res[0]->le(res[1])->bool_();
 }
 
-bool SymInt::operator>(SymInt sci) const {
+bool SymInt::operator>(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return data_ > sci.data_;
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return res[0]->gt(res[1])->bool_();
 }
 
-bool SymInt::operator>=(SymInt sci) const {
+bool SymInt::operator>=(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return data_ >= sci.data_;
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return res[0]->ge(res[1])->bool_();
 }
 
-SymInt SymInt::min(SymInt sci) const {
+SymInt SymInt::min(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return std::min(data_, sci.data_);
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return SymInt(res[0]->min(res[1]));
 }
-SymInt SymInt::max(SymInt sci) const {
+SymInt SymInt::max(const SymInt& sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return std::max(data_, sci.data_);
   }
-  auto res = normalize_symints(*this, std::move(sci));
+  auto res = normalize_symints(*this, sci);
   return SymInt(res[0]->max(res[1]));
 }
 
-void SymInt::operator*=(SymInt sci) {
-  *this = *this * std::move(sci);
+void SymInt::operator*=(const SymInt& sci) {
+  *this = *this * sci;
 }
 
-void SymInt::operator/=(SymInt sci) {
-  *this = *this / std::move(sci);
+void SymInt::operator/=(const SymInt& sci) {
+  *this = *this / sci;
 }
 
-void SymInt::operator+=(SymInt sci) {
-  *this = *this + std::move(sci);
+void SymInt::operator+=(const SymInt& sci) {
+  *this = *this + sci;
 }
 
 bool SymInt::operator<(int64_t sci) const {
@@ -191,7 +193,7 @@ SymInt SymInt::operator*(int64_t sci) const {
   return *this * c10::SymInt(sci);
 }
 
-std::ostream& operator<<(std::ostream& os, SymInt s) {
+std::ostream& operator<<(std::ostream& os, const SymInt& s) {
   if (s.is_symbolic()) {
     os << s.toSymNodeImpl()->str();
   } else {
@@ -200,7 +202,7 @@ std::ostream& operator<<(std::ostream& os, SymInt s) {
   return os;
 }
 
-SymInt operator-(SymInt s) {
+SymInt operator-(const SymInt& s) {
   if (s.is_symbolic()) {
     return SymInt(s.toSymNodeImpl()->neg());
   } else {

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <numeric>
+#include <utility>
 
 namespace c10 {
 
@@ -56,7 +57,7 @@ class C10_API SymInt {
       data_ = s.data_;
     }
   }
-  SymInt(SymInt&& s) : data_(s.data_) {
+  SymInt(SymInt&& s) noexcept : data_(s.data_) {
     s.data_ = 0;
   }
 
@@ -70,7 +71,7 @@ class C10_API SymInt {
     }
     return *this;
   }
-  SymInt& operator=(SymInt&& s) {
+  SymInt& operator=(SymInt&& s) noexcept {
     if (this != &s) {
       release_(); // release the current SymNode if any
       data_ = s.data_;
@@ -151,23 +152,23 @@ class C10_API SymInt {
 #endif
   }
 
-  SymInt operator+(SymInt sci) const;
-  SymInt operator-(SymInt sci) const;
-  SymInt operator*(SymInt sci) const;
-  SymInt operator/(SymInt sci) const;
-  SymInt operator%(SymInt sci) const;
-  bool operator==(SymInt sci) const;
-  bool operator!=(SymInt p2) const;
-  bool operator<(SymInt sci) const;
-  bool operator<=(SymInt sci) const;
-  bool operator>(SymInt sci) const;
-  bool operator>=(SymInt sci) const;
-  void operator*=(SymInt sci);
-  void operator+=(SymInt sci);
-  void operator/=(SymInt sci);
+  SymInt operator+(const SymInt& sci) const;
+  SymInt operator-(const SymInt& sci) const;
+  SymInt operator*(const SymInt& sci) const;
+  SymInt operator/(const SymInt& sci) const;
+  SymInt operator%(const SymInt& sci) const;
+  bool operator==(const SymInt& sci) const;
+  bool operator!=(const SymInt& p2) const;
+  bool operator<(const SymInt& sci) const;
+  bool operator<=(const SymInt& sci) const;
+  bool operator>(const SymInt& sci) const;
+  bool operator>=(const SymInt& sci) const;
+  void operator*=(const SymInt& sci);
+  void operator+=(const SymInt& sci);
+  void operator/=(const SymInt& sci);
 
-  SymInt min(SymInt sci) const;
-  SymInt max(SymInt sci) const;
+  SymInt min(const SymInt& sci) const;
+  SymInt max(const SymInt& sci) const;
 
   SymInt operator*(int64_t sci) const;
   bool operator<(int64_t sci) const;
@@ -231,9 +232,9 @@ inline c10::SymInt multiply_integers(const C& container) {
       container.begin(),
       container.end(),
       c10::SymInt(1),
-      [](c10::SymInt a, c10::SymInt b) { return a * b; });
+      [](const c10::SymInt& a, const c10::SymInt& b) { return a * b; });
 }
 
-C10_API std::ostream& operator<<(std::ostream& os, SymInt s);
-C10_API SymInt operator-(SymInt s);
+C10_API std::ostream& operator<<(std::ostream& os, const SymInt& s);
+C10_API SymInt operator-(const SymInt& s);
 } // namespace c10

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -772,7 +772,7 @@ void TensorImpl::Extend(int64_t num, float growthPct) {
   SizesVector newDims(sizes_and_strides.begin(), sizes_and_strides.end());
   newDims[0] += num;
   if (!storage_.data()) {
-    Resize(std::move(newDims));
+    Resize(newDims);
     return;
   }
   const auto newNumel = c10::multiply_integers(newDims.begin(), newDims.end());

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -10,6 +10,8 @@
 #include <c10/util/Optional.h>
 #include <c10/util/irange.h>
 
+#include <utility>
+
 C10_DEFINE_bool(
     caffe2_keep_on_shrink,
     true,
@@ -770,7 +772,7 @@ void TensorImpl::Extend(int64_t num, float growthPct) {
   SizesVector newDims(sizes_and_strides.begin(), sizes_and_strides.end());
   newDims[0] += num;
   if (!storage_.data()) {
-    Resize(newDims);
+    Resize(std::move(newDims));
     return;
   }
   const auto newNumel = c10::multiply_integers(newDims.begin(), newDims.end());
@@ -786,7 +788,7 @@ void TensorImpl::Extend(int64_t num, float growthPct) {
           sizes_and_strides_.size_at_unchecked(0) * (1 + growthPct / 100))));
   auto oldData = std::move(storage_.data_ptr());
   auto oldSize = numel_;
-  Resize(newCapacity);
+  Resize(std::move(newCapacity));
   auto* newData = raw_mutable_data(data_type_);
   if (data_type_.copy()) {
     TORCH_CHECK(
@@ -838,7 +840,7 @@ void TensorImpl::ReserveSpace(int64_t outer_dim) {
   auto oldSize = numel_;
   SmallVector<int64_t, 5> oldDims(
       sizes_and_strides.begin(), sizes_and_strides.end());
-  Resize(newCapacity);
+  Resize(std::move(newCapacity));
   // Allocate new memory but don't copy over the data
   raw_mutable_data(data_type_);
   sizes_and_strides_.set_sizes(oldDims);

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <regex>
 #include <set>
+#include <utility>
 #include <vector>
 
 namespace c10 {
@@ -727,7 +728,7 @@ class DeviceCachingAllocator {
             device_free,
             params.size(),
             params.stream(),
-            context);
+            std::move(context));
       }
       stats.num_ooms += 1;
 
@@ -2034,7 +2035,8 @@ class NativeCachingAllocator : public CUDAAllocator {
       CaptureId_t graph_id,
       MempoolId_t mempool_id) override {
     assertValidDevice(device);
-    device_allocator[device]->notifyCaptureBegin(graph_id, mempool_id);
+    device_allocator[device]->notifyCaptureBegin(
+        graph_id, std::move(mempool_id));
   }
 
   void notifyCaptureAboutToEnd(int device, CaptureId_t graph_id) override {
@@ -2046,7 +2048,7 @@ class NativeCachingAllocator : public CUDAAllocator {
 
   void notifyCaptureDestroy(int device, MempoolId_t mempool_id) override {
     assertValidDevice(device);
-    device_allocator[device]->notifyCaptureDestroy(mempool_id);
+    device_allocator[device]->notifyCaptureDestroy(std::move(mempool_id));
   }
 
   void* raw_alloc(size_t nbytes) override {

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -1,6 +1,8 @@
 #include <c10/util/ThreadLocal.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
 
+#include <utility>
+
 namespace c10 {
 
 C10_DEFINE_TLS_static(std::shared_ptr<ThreadLocalDebugInfo>, tls_debug_info);
@@ -67,7 +69,7 @@ DebugInfoGuard::DebugInfoGuard(
     return;
   }
   prev_info_ = debug_info;
-  ThreadLocalDebugInfo::_push(kind, info);
+  ThreadLocalDebugInfo::_push(kind, std::move(info));
   active_ = true;
 }
 


### PR DESCRIPTION
I saw some missed optimization opportunities in C10 using std::move and thought I would submit a PR to fix them. There are particularly a lot of them dealing with the symbolic operators which are used in quite a few places including in loops.