### PR TITLE
Make TorchElastic timer importable on Windows

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1800,6 +1800,8 @@ class TestImports(TestCase):
             else:
                 ignored_modules.append("torch.distributed.nn.api.")
                 ignored_modules.append("torch.distributed.optim.")
+                ignored_modules.append("torch.distributed.pipeline.")
+                ignored_modules.append("torch.distributed.rpc.")
             ignored_modules.append("torch.testing._internal.dist_utils")
             # And these both end up with transitive dependencies on distributed
             ignored_modules.append("torch.nn.parallel._replicated_tensor_ddp_interop")

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1799,6 +1799,7 @@ class TestImports(TestCase):
                 ignored_modules.append("torch.distributed.")
             else:
                 ignored_modules.append("torch.distributed.nn.api.")
+                ignored_modules.append("torch.distributed.optim.")
             ignored_modules.append("torch.testing._internal.dist_utils")
             # And these both end up with transitive dependencies on distributed
             ignored_modules.append("torch.nn.parallel._replicated_tensor_ddp_interop")

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1794,9 +1794,11 @@ class TestImports(TestCase):
         if not sys.version_info >= (3, 9):
             ignored_modules.append("torch.utils.benchmark")
         if IS_WINDOWS or IS_MACOS:
-            # Distributed should be importable on Windows but not on Mac
+            # Distributed should be importable on Windows(except nn.api.), but not on Mac
             if IS_MACOS:
                 ignored_modules.append("torch.distributed.")
+            else:
+                ignored_modules.append("torch.distributed.nn.api.")
             ignored_modules.append("torch.testing._internal.dist_utils")
             # And these both end up with transitive dependencies on distributed
             ignored_modules.append("torch.nn.parallel._replicated_tensor_ddp_interop")

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1794,8 +1794,9 @@ class TestImports(TestCase):
         if not sys.version_info >= (3, 9):
             ignored_modules.append("torch.utils.benchmark")
         if IS_WINDOWS or IS_MACOS:
-            # Distributed does not work on Windows or by default on Mac
-            ignored_modules.append("torch.distributed.")
+            # Distributed should be importable on Windows but not on Mac
+            if IS_MACOS:
+                ignored_modules.append("torch.distributed.")
             ignored_modules.append("torch.testing._internal.dist_utils")
             # And these both end up with transitive dependencies on distributed
             ignored_modules.append("torch.nn.parallel._replicated_tensor_ddp_interop")

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -10,6 +10,7 @@ import logging
 import os
 import select
 import signal
+import sys
 import threading
 import time
 from typing import Callable, Dict, List, Optional, Set, Tuple
@@ -78,7 +79,8 @@ class FileTimerClient(TimerClient):
         signal: signal, the signal to use to kill the process. Using a
                         negative or zero signal will not kill the process.
     """
-    def __init__(self, file_path: str, signal=signal.SIGKILL) -> None:
+    def __init__(self, file_path: str, signal=(signal.SIGKILL if sys.platform != "win32" else
+                                               signal.CTRL_C_EVENT)) -> None:  # type: ignore[attr-defined]
         super().__init__()
         self._file_path = file_path
         self.signal = signal


### PR DESCRIPTION
Also, add `torch.distributed` to test imports, so that we would not
regress in the future

Fixes https://github.com/pytorch/pytorch/issues/85427