### PR TITLE
Use sudo when reset NVIDIA devices

### DIFF
--- a/.github/scripts/install_nvidia_utils_linux.sh
+++ b/.github/scripts/install_nvidia_utils_linux.sh
@@ -74,7 +74,8 @@ install_nvidia_driver_amzn2() {
                     DEVICE_ENABLED=$(cat /sys/bus/pci/devices/$PCI_ID/enable)
 
                     echo "Reseting $PCI_ID (enabled state: $DEVICE_ENABLED)"
-                    echo "1" > /sys/bus/pci/devices/$PCI_ID/reset
+                    # This requires sudo permission of course
+                    sudo echo "1" > /sys/bus/pci/devices/$PCI_ID/reset
                     sleep 1
                 done
             fi


### PR DESCRIPTION
Per title, I should have known, i.e. https://ossci-raw-job-status.s3.amazonaws.com/log/9307292415

```
2022-11-04T23:52:18.2921665Z + echo 1
2022-11-04T23:52:18.2921862Z Reseting 0000:00:1e.0 (enabled state: 0)
2022-11-04T23:52:18.2922186Z .github/scripts/install_nvidia_utils_linux.sh: line 77: /sys/bus/pci/devices/0000:00:1e.0/reset: Permission denied
```