### PR TITLE
Use test/test-reports for inductor

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -271,7 +271,7 @@ test_inductor_huggingface_shard() {
   # Use test-reports directory under test folder will allow the CI to automatically pick up
   # the test reports and upload them to S3. Need to use full path here otherwise the script
   # will bark about file not found later on
-  TEST_REPORTS_DIR=`pwd`/test/test-reports
+  TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
   python benchmarks/dynamo/huggingface.py --ci --training --accuracy \
     --device cuda --inductor --float32 --total-partitions 1 --partition-id "$1" \
@@ -287,7 +287,7 @@ test_inductor_timm_shard() {
   # Use test-reports directory under test folder will allow the CI to automatically pick up
   # the test reports and upload them to S3. Need to use full path here otherwise the script
   # will bark about file not found later on
-  TEST_REPORTS_DIR=`pwd`/test/test-reports
+  TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
   python benchmarks/dynamo/timm_models.py --ci --training --accuracy \
     --device cuda --inductor --float32 --total-partitions 5 --partition-id "$1" \

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -269,8 +269,9 @@ test_inductor_huggingface_shard() {
     exit 1
   fi
   # Use test-reports directory under test folder will allow the CI to automatically pick up
-  # the test reports and upload them to S3
-  TEST_REPORTS_DIR=test/test-reports/
+  # the test reports and upload them to S3. Need to use full path here otherwise the script
+  # will bark about file not found later on
+  TEST_REPORTS_DIR=`pwd`/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
   python benchmarks/dynamo/huggingface.py --ci --training --accuracy \
     --device cuda --inductor --float32 --total-partitions 1 --partition-id "$1" \
@@ -284,8 +285,9 @@ test_inductor_timm_shard() {
     exit 1
   fi
   # Use test-reports directory under test folder will allow the CI to automatically pick up
-  # the test reports and upload them to S3
-  TEST_REPORTS_DIR=test/test-reports/
+  # the test reports and upload them to S3. Need to use full path here otherwise the script
+  # will bark about file not found later on
+  TEST_REPORTS_DIR=`pwd`/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
   python benchmarks/dynamo/timm_models.py --ci --training --accuracy \
     --device cuda --inductor --float32 --total-partitions 5 --partition-id "$1" \

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -252,12 +252,12 @@ test_dynamo_shard() {
 test_inductor_distributed() {
   # this runs on both single-gpu and multi-gpu instance. It should be smart about skipping tests that aren't supported
   # with if required # gpus aren't available
-  PYTORCH_TEST_WITH_INDUCTOR=0 PYTORCH_TEST_WITH_INDUCTOR=0 python test/run_test.py --include distributed/test_dynamo_distributed
+  PYTORCH_TEST_WITH_INDUCTOR=0 PYTORCH_TEST_WITH_INDUCTOR=0 python test/run_test.py --include distributed/test_dynamo_distributed --verbose
   assert_git_not_dirty
 }
 
 test_inductor() {
-  python test/test_modules.py --verbose
+  python test/run_test.py --include test_modules --verbose
   # TODO: investigate "RuntimeError: CUDA driver API confirmed a leak"
   # seen intest_ops_gradients.py
   # pytest test/test_ops_gradients.py --verbose -k "not _complex and not test_inplace_grad_acos_cuda_float64"
@@ -268,7 +268,9 @@ test_inductor_huggingface_shard() {
     echo "NUM_TEST_SHARDS must be defined to run a Python test shard"
     exit 1
   fi
-  TEST_REPORTS_DIR=/tmp/test-reports
+  # Use test-reports directory under test folder will allow the CI to automatically pick up
+  # the test reports and upload them to S3
+  TEST_REPORTS_DIR=test/test-reports/
   mkdir -p "$TEST_REPORTS_DIR"
   python benchmarks/dynamo/huggingface.py --ci --training --accuracy \
     --device cuda --inductor --float32 --total-partitions 1 --partition-id "$1" \
@@ -281,7 +283,9 @@ test_inductor_timm_shard() {
     echo "NUM_TEST_SHARDS must be defined to run a Python test shard"
     exit 1
   fi
-  TEST_REPORTS_DIR=/tmp/test-reports
+  # Use test-reports directory under test folder will allow the CI to automatically pick up
+  # the test reports and upload them to S3
+  TEST_REPORTS_DIR=test/test-reports/
   mkdir -p "$TEST_REPORTS_DIR"
   python benchmarks/dynamo/timm_models.py --ci --training --accuracy \
     --device cuda --inductor --float32 --total-partitions 5 --partition-id "$1" \


### PR DESCRIPTION
So that the test reports can be picked up automatically by the CI and uploaded to S3. Later on, this will allows the querying of these test reports from our Rockset DB.

For example https://github.com/pytorch/pytorch/actions/runs/3382363153/jobs/5617382531 `Upload test statistics` shows:

```
+ python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
No tests in reports found in test
```

https://hud.pytorch.org/pytorch/pytorch/commit/678d038001b0bd61501739ea97989d28f758343e inductor artifacts are also empty zip at the moment
