### PR TITLE
Pin linux ninja dep to 1.10.2

### DIFF
--- a/.github/workflows/_buck-build-test.yml
+++ b/.github/workflows/_buck-build-test.yml
@@ -34,16 +34,16 @@ jobs:
           max_attempts: 5
           command: |
             conda install -y \
-              cffi \
-              cmake \
-              mkl \
-              mkl-include \
-              ninja \
-              numpy \
-              pyyaml \
-              requests \
-              setuptools \
-              typing_extensions
+              cffi=1.15.1 \
+              cmake=3.22.1 \
+              mkl=2022.1.0 \
+              mkl-include=2022.1.0 \
+              ninja=1.10.2 \
+              numpy=1.23.3 \
+              pyyaml=6.0 \
+              requests=2.28.1 \
+              setuptools=65.5.0 \
+              typing_extensions=4.3.0
 
       - name: Install Buck
         uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482

--- a/.github/workflows/_run_android_tests.yml
+++ b/.github/workflows/_run_android_tests.yml
@@ -21,16 +21,16 @@ jobs:
       - name: Install dependencies
         run: |
           conda install -y \
-            cffi \
-            cmake \
-            mkl \
-            mkl-include \
-            ninja \
-            numpy \
-            pyyaml \
-            requests \
-            setuptools \
-            typing_extensions
+            cffi=1.15.1 \
+            cmake=3.22.1 \
+            mkl=2022.1.0 \
+            mkl-include=2022.1.0 \
+            ninja=1.10.2 \
+            numpy=1.23.3 \
+            pyyaml=6.0 \
+            requests=2.28.1 \
+            setuptools=65.5.0 \
+            typing_extensions=4.3.0
 
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -117,7 +117,7 @@ fi
 
 if [[ "$BUILD_ENVIRONMENT" != *-bazel-* ]] ; then
   # JIT C++ extensions require ninja.
-  pip_install --user ninja
+  pip_install --user "ninja==1.10.2"
   # ninja is installed in $HOME/.local/bin, e.g., /var/lib/jenkins/.local/bin for CI user jenkins
   # but this script should be runnable by any user, including root
   export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
The latest version 1.11.1 breaks PyTorch CI.  A bunch of tests are failing now in master https://hud.pytorch.org/pytorch/pytorch/commit/d1ee0730410ac910760c0a21156e574093a0d15a.  Curiously, the latest commit https://hud.pytorch.org/pytorch/pytorch/commit/81042d3a53335259c60e5aa8c9b9614c3d87b05f looks green, but it's good to pin this dependency anyway

https://github.com/pytorch/pytorch/blob/master/.circleci/docker/requirements-ci.txt#L95-L97 has a curious note about ninja and why it's not part of the docker container (need to revisit this later on):

```
#ninja
#Description: build system.  Note that it install from
#here breaks things so it is commented out
```

This is one more reason to justify the effort to consolidating all pip and conda dependencies to get rid of this family of issue.

