### PR TITLE
[FSDP][Perf] Avoid post-bwd pad

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -447,10 +447,9 @@ def _pre_backward_hook(
 
         # If the handles have been prefetched, this `_unshard()` simply
         # switches to using the unsharded parameter
-        handles_to_unshard = _get_handles_executing_backward(_handles)
         _unshard(
             state,
-            handles_to_unshard,
+            _handles,
             state._streams["unshard"],
             state._streams["pre_unshard"],
         )
@@ -846,23 +845,12 @@ def _prefetch_handles(
     handles_to_prefetch, current_training_state = _get_handles_to_prefetch(
         state, current_handles_key
     )
-    is_backward_prefetching = current_training_state in (
-        HandleTrainingState.BACKWARD_PRE,
-        HandleTrainingState.BACKWARD_POST,
-    )
     for handles_key in handles_to_prefetch:
-        # For backward prefetching, only prefetch handles if they are executing
-        # in the current backward
-        handles_to_unshard = (
-            _get_handles_executing_backward(handles_key)
-            if is_backward_prefetching
-            else handles_key
-        )
         # Prefetch the next set of handles without synchronizing to allow
         # the sync to happen as late as possible to maximize overlap
         _unshard(
             state,
-            handles_to_unshard,
+            handles_key,
             state._streams["unshard"],
             state._streams["pre_unshard"],
         )

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -413,7 +413,8 @@ def _pre_backward_hook(
     """
     This is the pre-backward hook to prepare a *module* for the backward pass.
     This includes unsharding ``FlatParameter`` s since the original parameters
-    are needed for gradient computation and prefetching for the next *module*.
+    are needed for gradient computation and includes prefetching for the next
+    *module*.
     """
     _handles_key = tuple(_handles)  # avoid shadowing `handles_key`
     # Only run the pre-backward hook once per group of handles involved in the

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -858,9 +858,7 @@ def _prefetch_handles(
     """
     if not current_handles_key:
         return
-    handles_to_prefetch, current_training_state = _get_handles_to_prefetch(
-        state, current_handles_key
-    )
+    handles_to_prefetch = _get_handles_to_prefetch(state, current_handles_key)
     for handles_key in handles_to_prefetch:
         # Prefetch the next set of handles without synchronizing to allow
         # the sync to happen as late as possible to maximize overlap
@@ -877,11 +875,10 @@ def _prefetch_handles(
 def _get_handles_to_prefetch(
     state: _FSDPState,
     current_handles_key: _HandlesKey,
-) -> Tuple[List[_HandlesKey], HandleTrainingState]:
+) -> List[_HandlesKey]:
     """
     Returns a :class:`list` of the handles keys to prefetch for the next
-    module(s), where ``current_handles_key`` represents the current module, and
-    the current handle training state.
+    module(s), where ``current_handles_key`` represents the current module.
 
     "Prefetching" refers to running the unshard logic early (without
     synchronization), and the "next" modules depend on the recorded execution
@@ -924,7 +921,7 @@ def _get_handles_to_prefetch(
             if state._needs_pre_forward_unshard.get(target_handles_key, False)
             and not state._handles_prefetched.get(target_handles_key, False)
         ]
-    return target_handles_keys, training_state
+    return target_handles_keys
 
 
 def _get_training_state(

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -806,7 +806,10 @@ def _finalize_params(
     """Finalizes the parameters before the next iteration."""
     for handle in state._handles:
         flat_param = handle.flat_param
-        if hasattr(flat_param, "_padded_unsharded_grad"):
+        # Delete the padded unsharded gradient to free memory in case it was
+        # pre-allocated unnecessarily (i.e. pre-backward ran but post-backward
+        # did not). However, for `no_sync()`, we must preserve it.
+        if hasattr(flat_param, "_padded_unsharded_grad") and state._sync_gradients:
             delattr(flat_param, "_padded_unsharded_grad")
         handle._ran_flat_param_pre_backward_hook = False
         if flat_param.requires_grad:

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1030,7 +1030,9 @@ class FlatParamHandle:
             has_grad and flat_param.grad.size() != flat_param._unpadded_unsharded_size
         )
         has_grad_and_in_no_sync = (
-            has_grad and flat_param.grad.size() == flat_param._unpadded_unsharded_size
+            has_grad
+            and flat_param.grad.size() == flat_param._unpadded_unsharded_size
+            and flat_param.grad.size() != flat_param._sharded_size
         )
         has_grad_and_cpu_offloading = (
             has_grad and flat_param.grad.device != flat_param.device

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1087,6 +1087,11 @@ class FlatParamHandle:
                 if self.uses_sharded_strategy
                 else torch.zeros_like(flat_param)
             )
+            p_assert(
+                flat_param.size() == flat_param._unpadded_unsharded_size,
+                "Expects `flat_param` to have unpadded unsharded size "
+                f"{flat_param._unpadded_unsharded_size} but got {flat_param.size()}",
+            )
             # Set the unpadded unsharded gradient to be a view into the padded one,
             # which owns the storage
             flat_param.grad = flat_param._padded_unsharded_grad[  # type: ignore[attr-defined]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#88583 [FSDP][Perf] Avoid post-bwd pad**

**Overview**
This PR adds an additional code path for when the `FlatParameter` must be padded to achieve an unsharded size divisible by the world size to enable the performant `_all_gather_base()` and `_reduce_scatter_base()`.
- In the padded case, we register a new pre-backward hook on the `FlatParameter` itself that _pre-allocates_ the padded unsharded gradient as a zero tensor to avoid doing so in the post-backward hook, which would (1) allocate unsharded memory in the post-backward stream and (2) require a D2D copy, which may incur nontrivial overhead and block the subsequent reduce-scatter.
    - The newly-computed unsharded gradient is added to the pre-allocated zero gradient. From a running time perspective, we tradeoff a GPU `memcpy` kernel with a GPU `add` kernel, so the running time may not decrease. From a memory perspective, we still have the computed gradient from autograd and an existing unsharded gradient in memory.
    - The `handle.prepare_gradient_for_backward()` call is refactored to be in this new pre-backward hook `_flat_param_pre_backward_hook()`. This is to delay the pre-allocation as much as possible. The new hook is guarded by `handle._ran_flat_param_pre_backward_hook` because otherwise the hook may run multiple times per backward. It is reset to `False` in the post-backward hook.
    - ~~This approach leverages the private API `torch._C._will_engine_execute_node(flat_param_acc_grad)` to check if a `FlatParameter` will compute a gradient in the current `backward()`. As a part of this, `FlatParameter`s that are not involved in the current `backward()` are not all-gathered.~~ See Notes section.
- We do not pre-allocate for the non-padded case because that would allocate an extra tensor compared to the existing behavior.
- For both the padded and non-padded cases, this PR changes the sharded gradient allocation to use `torch.empty()` instead of `torch.zeros()` to avoid a `fill` kernel.
- This PR renames `param` to `flat_param` in the post-backward hook for clarity.

**Example: RegNet-3B**
For RegNet-3B using an auto wrap policy that wraps `RegNetYLayer` and world size of 8, there are both `FlatParameter`s that need padding and those that do not.

With this PR (using a batch size of 48, `BACKWARD_PRE` prefetching, FP16 mixed precision, and activation checkpointing):
- The number of `memcpy` kernels per training iteration decreases from 234 to 6.
- [`use_orig_params=False`] The peak reserved memory decreases from 16.625 GB to 16.551 GB.
- [`use_orig_params=False`] The peak active memory decreases from 10.500 GB to 10.363 GB.
- [`use_orig_params=True`] The peak reserved memory decreases from 14.051 GB to 13.977 GB.
- [`use_orig_params=True`] The peak active memory decreases from 10.501 GB to 10.363 GB.

This reduction in peak active memory comes from saving the extra unsharded gradient allocation in the post-backward. (This suggests that the peak memory happens in the backward pass for this workload.)

<details>
    <summary>Example: 2nd ReLU Backward</summary>

As an example, we examine the 2nd ReLU backward. First, we look at the trace for the existing code:
![Screen Shot 2022-11-07 at 9 23 31 AM](https://user-images.githubusercontent.com/31054793/200333826-cde7ba91-32ef-4c22-8f33-df8d26c208a7.png)
![Screen Shot 2022-11-07 at 9 23 22 AM](https://user-images.githubusercontent.com/31054793/200333905-500995bc-6a1f-45e4-b339-778583283392.png)
We see above the `memcpy` kernel. Now, we look at the trace for the new code:
![Screen Shot 2022-11-07 at 9 23 38 AM](https://user-images.githubusercontent.com/31054793/200334043-08cab1b4-7ac5-42cd-a141-3098b4db2f1a.png)
![Screen Shot 2022-11-07 at 9 25 39 AM](https://user-images.githubusercontent.com/31054793/200334476-c53e768b-4b62-4238-851f-a88477cd16c6.png)
We see an `add` kernel above but no more `memcpy` kernel. I am not sure why exactly, but this somehow allows the reduce-scatter to run earlier. (The preceding `BUnaryFunctor` kernel right before the reduce-scatter somehow runs earlier. This behavior is consistent across multiple runs. The `BUnaryFunctor` should be the gradient pre-divide.)

</details>


<details>
<summary> _flat_param_pre_backward_hook() </summary>

This allocates a zero tensor for the padded unsharded gradient, and it runs after the normal pre-backward hook.
![Screen Shot 2022-11-07 at 8 30 24 AM](https://user-images.githubusercontent.com/31054793/200340101-b1b84091-8ff6-4961-96cc-66ad1bbd2a07.png)

</details>

**Notes**
Originally, I had the PR such that we only unshard in the pre-backward if `torch._C._will_engine_execute_node(flat_param_acc_grad)`. However, this breaks with reentrant activation checkpointing when applied as `FSDP(CheckpointWrapper(module))`. This is because when the module-level pre-backward hook runs, the `bool` will return `False`, and instead, the `FlatParameter` gradient is computed later by the explicit `torch.autograd.backward()` call:
https://github.com/pytorch/pytorch/blob/master/torch/utils/checkpoint.py#L157

This is not a major issue, but the consequence of this is that we may unnecessarily unshard `FlatParameter`s (e.g. for mult-modal models), where the pre-backward hook may run but gradients are not computed for the `FlatParameter`.

Differential Revision: [D41137855](https://our.internmc.facebook.com/intern/diff/D41137855)