### PR TITLE
Fix pull docs build running with a schedule and increase cpp doc timeout to 4h

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -100,7 +100,8 @@ jobs:
         id: build-docs
         env:
           # After https://github.com/pytorch/pytorch/pull/88373, pull workflow can now be run periodically,
-          # so this can be wrongly set to true
+          # so using a schedule event to determine if the docs should be pushed or not doesn't hold true
+          # anymore
           WITH_PUSH: ${{ inputs.push }}
           DOCKER_IMAGE: ${{ inputs.docker-image }}
           DOCS_TYPE: ${{ matrix.docs_type }}

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -48,16 +48,20 @@ jobs:
             # to the next available tier of 12xlarge. So much memory just to generate cpp
             # doc
             runner: linux.12xlarge
-            # Nightly cpp docs take about 150m to finish, and the number is stable
-            timeout-minutes: 180
+            # TODO: Nightly cpp docs take longer and longer to finish (more than 3h now)
+            # Let's try to figure out how this can be improved
+            timeout-minutes: 240
           - docs_type: python
             runner: linux.2xlarge
             # It takes less than 30m to finish python docs unless there are issues
             timeout-minutes: 30
           - docs_type: functorch
             runner: linux.2xlarge
-            # It takes less than 15m to finish functorch docs unless there are issues
-            timeout-minutes: 15
+            # It takes less than 30m to finish functorch docs unless there are issues
+            timeout-minutes: 30
+    # Set a fixed name for this job instead of using the current matrix-generated name, i.e. build-docs (cpp, linux.12xlarge, 180)
+    # The current name requires updating the Rockset last docs push query from test-infra every time the matrix is updated
+    name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}
     steps:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -57,8 +57,8 @@ jobs:
             timeout-minutes: 30
           - docs_type: functorch
             runner: linux.2xlarge
-            # It takes less than 30m to finish functorch docs unless there are issues
-            timeout-minutes: 30
+            # It takes less than 15m to finish functorch docs unless there are issues
+            timeout-minutes: 15
     # Set a fixed name for this job instead of using the current matrix-generated name, i.e. build-docs (cpp, linux.12xlarge, 180)
     # The current name requires updating the Rockset last docs push query from test-infra every time the matrix is updated
     name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}
@@ -99,7 +99,9 @@ jobs:
         timeout-minutes: ${{ matrix.timeout-minutes }}
         id: build-docs
         env:
-          WITH_PUSH: ${{ github.event_name == 'schedule' || startsWith(github.event.ref, 'refs/tags/v') }}
+          # After https://github.com/pytorch/pytorch/pull/88373, pull workflow can now be run periodically,
+          # so this can be wrongly set to true
+          WITH_PUSH: ${{ inputs.push }}
           DOCKER_IMAGE: ${{ inputs.docker-image }}
           DOCS_TYPE: ${{ matrix.docs_type }}
           RUN_DOXYGEN: ${{ inputs.run-doxygen }}


### PR DESCRIPTION
* After https://github.com/pytorch/pytorch/pull/88373, pull workflow can now be triggered with a schedule. This changes the assumption in the doc build workflow when schedule event is used to determine if the docs should be pushed
* I'll create a follow-up issue to see if it's possible to improve the performance of cpp doc build job.  At the moment, it uses a linux.12xlarge runner and still couldn't finish the job after 3h
