### PR TITLE
[caffe2] Fix pybind11 native python link error

### DIFF
--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -59,15 +59,8 @@ constexpr bool kPyBindFalse = false;
 namespace py = pybind11;
 
 // NOLINTNEXTLINE(modernize-use-equals-default)
-BlobFetcherBase::~BlobFetcherBase() {}
-// NOLINTNEXTLINE(modernize-use-equals-default)
 BlobFeederBase::~BlobFeederBase() {}
 
-C10_DEFINE_TYPED_REGISTRY(
-    BlobFetcherRegistry,
-    TypeIdentifier,
-    BlobFetcherBase,
-    std::unique_ptr);
 C10_DEFINE_TYPED_REGISTRY(
     BlobFeederRegistry,
     caffe2::DeviceType,

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -14,6 +14,7 @@
 #include "caffe2/core/workspace.h"
 #include "caffe2/proto/caffe2_pb.h"
 #include "caffe2/python/pybind_state_dlpack.h"
+#include "caffe2/python/pybind_workspace.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -55,16 +56,6 @@ Workspace* GetCurrentWorkspace();
 // Get workspace by name. Returns nullptr if none exists by name.
 Workspace* GetWorkspaceByName(const std::string& name);
 
-class C10_EXPORT BlobFetcherBase {
- public:
-  struct FetchedBlob {
-    pybind11::object obj;
-    bool copied;
-  };
-  virtual ~BlobFetcherBase();
-  virtual pybind11::object Fetch(const Blob& blob) = 0;
-};
-
 class BlobFeederBase {
  public:
   virtual ~BlobFeederBase();
@@ -74,17 +65,6 @@ class BlobFeederBase {
       Blob* blob,
       bool in_place = false) = 0;
 };
-
-C10_DECLARE_TYPED_REGISTRY(
-    BlobFetcherRegistry,
-    TypeIdentifier,
-    BlobFetcherBase,
-    std::unique_ptr);
-#define REGISTER_BLOB_FETCHER(id, ...) \
-  C10_REGISTER_TYPED_CLASS(BlobFetcherRegistry, id, __VA_ARGS__)
-inline unique_ptr<BlobFetcherBase> CreateFetcher(TypeIdentifier id) {
-  return BlobFetcherRegistry()->Create(id);
-}
 
 C10_DECLARE_TYPED_REGISTRY(
     BlobFeederRegistry,

--- a/caffe2/python/pybind_workspace.cc
+++ b/caffe2/python/pybind_workspace.cc
@@ -1,7 +1,17 @@
 #include "caffe2/core/workspace.h"
+#include "caffe2/python/pybind_workspace.h"
 
 namespace caffe2 {
 namespace python {
+
+// NOLINTNEXTLINE(modernize-use-equals-default)
+BlobFetcherBase::~BlobFetcherBase() {}
+
+C10_DEFINE_TYPED_REGISTRY(
+    BlobFetcherRegistry,
+    TypeIdentifier,
+    BlobFetcherBase,
+    std::unique_ptr);
 
 // gWorkspace is the pointer to the current workspace. The ownership is kept
 // by the gWorkspaces map.

--- a/caffe2/python/pybind_workspace.h
+++ b/caffe2/python/pybind_workspace.h
@@ -1,5 +1,32 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+//#include <Python.h>
+
 namespace caffe2 {
 namespace python {
+class C10_EXPORT BlobFetcherBase {
+ public:
+  struct FetchedBlob {
+    pybind11::object obj;
+    bool copied;
+  };
+  virtual ~BlobFetcherBase();
+  virtual pybind11::object Fetch(const Blob& blob) = 0;
+};
+
+C10_DECLARE_TYPED_REGISTRY(
+    BlobFetcherRegistry,
+    TypeIdentifier,
+    BlobFetcherBase,
+    std::unique_ptr);
+#define REGISTER_BLOB_FETCHER(id, ...) \
+  C10_REGISTER_TYPED_CLASS(BlobFetcherRegistry, id, __VA_ARGS__)
+inline unique_ptr<BlobFetcherBase> CreateFetcher(TypeIdentifier id) {
+  return BlobFetcherRegistry()->Create(id);
+}
 
 Workspace* GetCurrentWorkspace();
 void SetCurrentWorkspace(Workspace* workspace);


### PR DESCRIPTION
Summary:
Currently, we define some C++ functions in one C++ Python extension
which are used by another.  This happens to work, but isn't guaranteed to.
This diff moves these functions to a separate C++ library rule to fix this.

Followup to D40657708 (https://github.com/pytorch/pytorch/commit/1dad051b05f896a5958e33423ccd3baa10ad1072).

Test Plan: CI

Reviewed By: BrandonTheBuilder

Differential Revision: D40854142

