### PR TITLE
[inductor] Fix aten.fmod lowering

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -240,7 +240,7 @@ class TritonOverrides(OpOverrides):
 
     @staticmethod
     def fmod(a, b):
-        return f"tl.libdevice.fmod({a}, ({b}).to(tl.float32))"
+        return f"tl.libdevice.fmod({a}, {b})"
 
     @staticmethod
     def pow(a, b):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3298,6 +3298,20 @@ def div_prim(a, b):
     else:
         return div(a, b)
 
+@register_lowering([aten.fmod, prims.fmod])
+def fmod(a, b):
+    is_integral = is_boolean_type(a) or is_integer_type(a)
+
+    if is_integral:
+        def fn(a, b):
+            return ops.mod(a, b)
+    else:
+        def fn(a, b):
+            return ops.fmod(a, b)
+
+    return make_pointwise(fn)(a, b)
+
+
 
 # TODO - enable builtin and disable decomp to lower to ptx instruction
 # Causes compilation to not complete on timm_vision_transformers inference
@@ -3391,7 +3405,6 @@ register_pointwise(
 register_pointwise(aten.remainder)
 register_pointwise(aten.sign, override_fn_when_input_bool="identity")
 register_pointwise(aten.ceil)
-register_pointwise(aten.fmod)
 register_pointwise(aten.signbit, override_return_dtype=torch.bool)
 
 register_pointwise(aten.le, type_promotion_kind=None, override_return_dtype=torch.bool)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3298,19 +3298,22 @@ def div_prim(a, b):
     else:
         return div(a, b)
 
+
 @register_lowering([aten.fmod, prims.fmod])
 def fmod(a, b):
     is_integral = is_boolean_type(a) or is_integer_type(a)
 
     if is_integral:
+
         def fn(a, b):
             return ops.mod(a, b)
+
     else:
+
         def fn(a, b):
             return ops.fmod(a, b)
 
     return make_pointwise(fn)(a, b)
-
 
 
 # TODO - enable builtin and disable decomp to lower to ptx instruction


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88603
* __->__ #88602

Currently the lowering for aten.fmod promotes integral types to float and calls
`tl.libdevice.fmod` whereas the ATen behavior is to use the modulo operator.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire