### PR TITLE
[ci] increase timeout time of ios test app build

### DIFF
--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Build TestApp
         if: inputs.ios-platform == 'SIMULATOR'
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           # run the ruby build script
           if ! [ -x "$(command -v xcodebuild)" ]; then


### PR DESCRIPTION
We were timing out; 5 minutes seems a bit short.