### PR TITLE
Stable topk for CPU 

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -53,7 +53,7 @@ namespace meta {
 using namespace native;
 
 TORCH_META_FUNC(topk)
-(const Tensor& self, int64_t k, int64_t dim_, bool largest, bool sorted) {
+(const Tensor& self, int64_t k, int64_t dim_, bool largest, bool sorted, bool stable) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
   TORCH_CHECK(
       k >= 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
@@ -832,6 +832,7 @@ TORCH_IMPL_FUNC(topk_out_cpu)
     int64_t dim_,
     bool largest,
     bool sorted,
+    bool stable,
     const Tensor& values,
     const Tensor& indices) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
@@ -843,7 +844,7 @@ TORCH_IMPL_FUNC(topk_out_cpu)
     values.copy_(self);
     indices.zero_();
   } else {
-    topk_stub(kCPU, values, indices, self, k, dim, largest, sorted);
+    topk_stub(kCPU, values, indices, self, k, dim, largest, sorted, stable);
   }
 }
 

--- a/aten/src/ATen/native/Sorting.h
+++ b/aten/src/ATen/native/Sorting.h
@@ -19,7 +19,7 @@ enum class QUANTILE_INTERPOLATION_MODE : uint8_t {
 };
 
 using sort_fn = void(*)(const TensorBase&, const TensorBase&, const TensorBase&, int64_t, bool, bool);
-using topk_fn = void(*)(const TensorBase&, const TensorBase&, const TensorBase&, int64_t, int64_t, bool, bool);
+using topk_fn = void(*)(const TensorBase&, const TensorBase&, const TensorBase&, int64_t, int64_t, bool, bool, bool);
 
 DECLARE_DISPATCH(sort_fn, sort_stub);
 DECLARE_DISPATCH(topk_fn, topk_stub);

--- a/aten/src/ATen/native/TopKImpl.h
+++ b/aten/src/ATen/native/TopKImpl.h
@@ -50,14 +50,14 @@ void topk_impl_loop(
         std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
             if ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first)) return true;
-            if ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first)) return false;
+            else if (!(x.first >= y.first)) return false;
             return x.second < y.second;
           });
       } else {
         std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
             if ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first)) return true;
-            if ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first)) return false;
+            else if (!(x.first <= y.first)) return false;
             return x.second < y.second;
           });
       }
@@ -67,7 +67,7 @@ void topk_impl_loop(
           std::sort(queue.begin(), queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
             if ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first)) return true;
-            if ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first)) return false;
+            else if (!(x.first >= y.first)) return false;
             return x.second < y.second;
           });
         }
@@ -88,7 +88,7 @@ void topk_impl_loop(
           std::sort(queue.begin(), queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
             if ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first)) return true;
-            if ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first)) return false;
+            else if (!(x.first <= y.first)) return false;
             return x.second < y.second;
           });
         }

--- a/aten/src/ATen/native/TopKImpl.h
+++ b/aten/src/ATen/native/TopKImpl.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/NumericUtils.h>
-
 namespace at {
 namespace native {
 
@@ -50,12 +49,16 @@ void topk_impl_loop(
       if (largest) {
         std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
-            return (((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first)) || (x.second < y.second));
+            if ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first)) return true;
+            if ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first)) return false;
+            return x.second < y.second;
           });
       } else {
         std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
-            return (((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first)) || (x.second < y.second));
+            if ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first)) return true;
+            if ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first)) return false;
+            return x.second < y.second;
           });
       }
     } else {
@@ -63,7 +66,9 @@ void topk_impl_loop(
         if (stable) {
           std::sort(queue.begin(), queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
-            return (((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first)) || (x.second < y.second));
+            if ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first)) return true;
+            if ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first)) return false;
+            return x.second < y.second;
           });
         }
         else {
@@ -82,7 +87,9 @@ void topk_impl_loop(
         if (stable) {
           std::sort(queue.begin(), queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
-            return (((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first)) || (x.second < y.second));
+            if ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first)) return true;
+            if ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first)) return false;
+            return x.second < y.second;
           });
         }
         else {

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -144,7 +144,8 @@ static void topk_kernel(
     int64_t k,
     int64_t dim,
     bool largest,
-    bool sorted) {
+    bool sorted,
+    bool stable) {
   auto sizes = self.sizes();
   auto iter = TensorIteratorConfig()
     .check_all_same_dtype(false)
@@ -164,11 +165,11 @@ static void topk_kernel(
       if (self.scalar_type() == ScalarType::BFloat16) {
         return topk_impl_loop<scalar_t, float>(
             mode_values_stride, mode_indices_stride, tmp_values_stride,
-            k, sizes[dim], largest, sorted, data, strides, n);
+            k, sizes[dim], largest, sorted, stable, data, strides, n);
       } else {
         return topk_impl_loop<scalar_t, scalar_t>(
             mode_values_stride, mode_indices_stride, tmp_values_stride,
-            k, sizes[dim], largest, sorted, data, strides, n);
+            k, sizes[dim], largest, sorted, stable, data, strides, n);
       }
     };
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cpp
+++ b/aten/src/ATen/native/cuda/TensorTopK.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/cuda/TensorTopK.h>
 
@@ -48,9 +49,13 @@ bool should_use_sort(const Tensor& self, int64_t dim) {
 
 TORCH_IMPL_FUNC(topk_out_cuda)
   (const Tensor& self,
-   int64_t k, int64_t dim, bool largest, bool sorted,
+   int64_t k, int64_t dim, bool largest, bool sorted, bool stable,
    const Tensor& values,
    const Tensor& indices) {
+
+  std::cout << "================ stable: " << stable << std::endl;
+  TORCH_CHECK(!stable, "stable=True is not implemented on CUDA yet.");
+
   TensorArg topK_arg{values, "topK", 1}, indices_arg{indices, "indices", 2}, input_arg{self, "self", 3};
   checkAllSameGPU(__func__, {topK_arg, indices_arg, input_arg});
 

--- a/aten/src/ATen/native/cuda/TensorTopK.cpp
+++ b/aten/src/ATen/native/cuda/TensorTopK.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/cuda/TensorTopK.h>
 
@@ -52,8 +51,6 @@ TORCH_IMPL_FUNC(topk_out_cuda)
    int64_t k, int64_t dim, bool largest, bool sorted, bool stable,
    const Tensor& values,
    const Tensor& indices) {
-
-  std::cout << "================ stable: " << stable << std::endl;
   TORCH_CHECK(!stable, "stable=True is not implemented on CUDA yet.");
 
   TensorArg topK_arg{values, "topK", 1}, indices_arg{indices, "indices", 2}, input_arg{self, "self", 3};

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9383,14 +9383,14 @@
 - func: argsort.dimname(Tensor self, Dimname dim, bool descending=False) -> Tensor
   variants: method, function
 
-- func: topk.values(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
+- func: topk.values(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, bool stable=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   structured: True
   dispatch:
     CPU: topk_out_cpu
     CUDA: topk_out_cuda
     MPS: topk_out_mps
 
-- func: topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)
+- func: topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, bool stable=False) -> (Tensor values, Tensor indices)
   variants: method, function
   structured_delegate: topk.values
   dispatch:

--- a/aten/src/ATen/native/quantized/cpu/QuantizedOps.h
+++ b/aten/src/ATen/native/quantized/cpu/QuantizedOps.h
@@ -150,7 +150,7 @@ using qcat_nhwc_fn = Tensor (*)(
     int64_t dim,
     double scale,
     int64_t zero_point);
-using qtopk_fn = void(*)(Tensor&, Tensor&, const Tensor&, int64_t, int64_t, bool, bool);
+using qtopk_fn = void(*)(Tensor&, Tensor&, const Tensor&, int64_t, int64_t, bool, bool, bool);
 
 using qbatch_norm_fn = void(*)(int64_t, int64_t, int64_t, int64_t, int64_t, const Tensor&, const Tensor&, const Tensor&, Tensor&);
 

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2268,7 +2268,8 @@ void qtopk_kernel(Tensor& values,
     int64_t k,
     int64_t dim,
     bool largest,
-    bool sorted) {
+    bool sorted,
+    bool stable) {
   auto sizes = self.sizes();
   auto iter = TensorIteratorConfig()
     .check_all_same_dtype(false)
@@ -2289,7 +2290,7 @@ void qtopk_kernel(Tensor& values,
       static_assert(sizeof(scalar_t) == sizeof(underlying_t), "");
       return topk_impl_loop<underlying_t, underlying_t>(
           mode_values_stride, mode_indices_stride, tmp_values_stride,
-          k, sizes[dim], largest, sorted, data, strides, n);
+          k, sizes[dim], largest, sorted, stable, data, strides, n);
     };
 
     int64_t grain_size = internal::GRAIN_SIZE / std::max(int64_t{1}, sizes[dim]);

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -795,24 +795,28 @@ class TestSortAndSelect(TestCase):
                 x = torch.tensor([0, 1] * ncopies, dtype=dtype)
                 if partial_sort:
                     x = torch.unsqueeze(x, 0)
-                    k = int(ncopies/32)
+                    k = int(ncopies / 32)
                 else:
-                    k = ncopies*2
+                    k = ncopies * 2
                 val, idx = torch.topk(x, k=k, largest=largest, stable=True)
                 if largest:
                     if partial_sort:
                         expected_val = torch.ones((1, k), dtype=dtype)
-                        expected_idx = torch.unsqueeze(torch.arange(start=1, end=k*2, step=2, dtype=torch.int64), 0)
+                        expected_idx = torch.unsqueeze(torch.arange(start=1, end=k * 2, step=2, dtype=torch.int64), 0)
                     else:
-                        expected_val = torch.cat((torch.tensor([1] * int(k/2), dtype=dtype), torch.tensor([0] * int(k/2), dtype=dtype)))
-                        expected_idx = torch.cat((torch.arange(start=1, end=k, step=2, dtype=torch.int64), torch.arange(start=0, end=k, step=2, dtype=torch.int64)))
+                        expected_val = torch.cat((torch.tensor([1] * int(k / 2), dtype=dtype),
+                                                  torch.tensor([0] * int(k / 2), dtype=dtype)))
+                        expected_idx = torch.cat((torch.arange(start=1, end=k, step=2, dtype=torch.int64),
+                                                  torch.arange(start=0, end=k, step=2, dtype=torch.int64)))
                 else:
                     if partial_sort:
                         expected_val = torch.zeros((1, k), dtype=dtype)
-                        expected_idx = torch.unsqueeze(torch.arange(start=0, end=k*2, step=2, dtype=torch.int64), 0)
+                        expected_idx = torch.unsqueeze(torch.arange(start=0, end=k * 2, step=2, dtype=torch.int64), 0)
                     else:
-                        expected_val = torch.cat((torch.tensor([0] * int(k/2), dtype=dtype), torch.tensor([1] * int(k/2), dtype=dtype)))
-                        expected_idx = torch.cat((torch.arange(start=0, end=k, step=2, dtype=torch.int64), torch.arange(start=1, end=k, step=2, dtype=torch.int64)))
+                        expected_val = torch.cat((torch.tensor([0] * int(k / 2), dtype=dtype),
+                                                  torch.tensor([1] * int(k / 2), dtype=dtype)))
+                        expected_idx = torch.cat((torch.arange(start=0, end=k, step=2, dtype=torch.int64),
+                                                  torch.arange(start=1, end=k, step=2, dtype=torch.int64)))
                 self.assertEqual(val, expected_val)
                 self.assertEqual(idx, expected_idx)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1617,7 +1617,7 @@
   self: tanh_backward(grad, result)
   result: auto_element_wise
 
-- name: topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)
+- name: topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, bool stable=False) -> (Tensor values, Tensor indices)
   self: value_selecting_reduction_backward_symint(grad, dim, indices, self.sym_sizes(), true)
   output_differentiability: [True, False]
   values: gather(self_t, dim, indices)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11595,9 +11595,11 @@ Example::
     torch.return_types.topk(values=tensor([5., 4., 3.]), indices=tensor([4, 3, 2]))
     >>> x = torch.tensor([0, 1] * 9)
     >>> torch.topk(x, 18)
-    torch.return_types.topk(values=tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]), indices=tensor([17,  3,  1,  5,  7, 11, 13, 15,  9,  8,  6, 16,  2, 14,  4, 10,  0, 12]))
+    torch.return_types.topk(values=tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                            indices=tensor([17,  3,  1,  5,  7, 11, 13, 15,  9,  8,  6, 16,  2, 14,  4, 10,  0, 12]))
     >>> torch.topk(x, 18, stable=True)
-    torch.return_types.topk(values=tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]), indices=tensor([ 1,  3,  5,  7,  9, 11, 13, 15, 17,  0,  2,  4,  6,  8, 10, 12, 14, 16]))
+    torch.return_types.topk(values=tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                            indices=tensor([ 1,  3,  5,  7,  9, 11, 13, 15, 17,  0,  2,  4,  6,  8, 10, 12, 14, 16]))
 """.format(
         **common_args
     ),

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11552,7 +11552,7 @@ Alias for :func:`torch.nn.functional.softmax`.
 add_docstr(
     torch.topk,
     r"""
-topk(input, k, dim=None, largest=True, sorted=True, *, out=None) -> (Tensor, LongTensor)
+topk(input, k, dim=None, largest=True, sorted=True, stable=False, *, out=None) -> (Tensor, LongTensor)
 
 Returns the :attr:`k` largest elements of the given :attr:`input` tensor along
 a given dimension.
@@ -11560,6 +11560,9 @@ a given dimension.
 If :attr:`dim` is not given, the last dimension of the `input` is chosen.
 
 If :attr:`largest` is ``False`` then the `k` smallest elements are returned.
+
+If :attr:`stable` is ``True`` then the sorting routine becomes stable, preserving
+the order of equivalent elements.
 
 A namedtuple of `(values, indices)` is returned with the `values` and
 `indices` of the largest `k` elements of each row of the `input` tensor in the
@@ -11576,6 +11579,8 @@ Args:
            smallest elements
     sorted (bool, optional): controls whether to return the elements
            in sorted order
+    stable (bool, optional): makes the sorting routine stable, which guarantees that the order
+       of equivalent elements is preserved.
 
 Keyword args:
     out (tuple, optional): the output tuple of (Tensor, LongTensor) that can be
@@ -11588,6 +11593,11 @@ Example::
     tensor([ 1.,  2.,  3.,  4.,  5.])
     >>> torch.topk(x, 3)
     torch.return_types.topk(values=tensor([5., 4., 3.]), indices=tensor([4, 3, 2]))
+    >>> x = torch.tensor([0, 1] * 9)
+    >>> torch.topk(x, 18)
+    torch.return_types.topk(values=tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]), indices=tensor([17,  3,  1,  5,  7, 11, 13, 15,  9,  8,  6, 16,  2, 14,  4, 10,  0, 12]))
+    >>> torch.topk(x, 18, stable=True)
+    torch.return_types.topk(values=tensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]), indices=tensor([ 1,  3,  5,  7,  9, 11, 13, 15, 17,  0,  2,  4,  6,  8, 10, 12, 14, 16]))
 """.format(
         **common_args
     ),

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11562,7 +11562,7 @@ If :attr:`dim` is not given, the last dimension of the `input` is chosen.
 If :attr:`largest` is ``False`` then the `k` smallest elements are returned.
 
 If :attr:`stable` is ``True`` then the sorting routine becomes stable, preserving
-the order of equivalent elements.
+the order of equivalent elements. Currently `stable` is supported for CPU only, and error on CUDA tensors.
 
 A namedtuple of `(values, indices)` is returned with the `values` and
 `indices` of the largest `k` elements of each row of the `input` tensor in the

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -37,7 +37,7 @@ void wrapDim(int64_t& dim, const std::vector<int64_t>& sizes) {
 bool needTrimGrad(Node* n) {
   static OperatorSet need_trim_grad_ops = {
       "aten::kthvalue(Tensor self, int k, int dim, bool keepdim) -> (Tensor, Tensor)",
-      "aten::topk(Tensor self, int k, int dim, bool largest, bool sorted) -> (Tensor, Tensor)",
+      "aten::topk(Tensor self, int k, int dim, bool largest, bool sorted, bool stable) -> (Tensor, Tensor)",
       "aten::max_pool2d(Tensor self, int[] kernel_size, int[] stride, int[] padding, int[] dilation, bool ceil_mode) -> Tensor",
       "aten::max_pool2d_with_indices(Tensor self, int[] kernel_size, int[] stride, int[] padding, int[] dilation, bool ceil_mode) -> (Tensor, Tensor)"};
   if (n->isMemberOf(need_trim_grad_ops)) {

--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -2974,7 +2974,7 @@ const OperatorMap<std::string>& GetShapeFunctionMappings() {
     {"aten::argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor", "argmax"},
     {"aten::bmm(Tensor self, Tensor mat2) -> Tensor", "bmm"},
     {"aten::_shape_as_tensor(Tensor self) -> Tensor", "_shape_as_tensor"},
-    {"aten::topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)", "topk"},
+    {"aten::topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, bool stable=False) -> (Tensor values, Tensor indices)", "topk"},
     {"aten::nll_loss_forward(Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index) -> (Tensor output, Tensor total_weight)", "nll_loss_forward"},
     {"aten::native_layer_norm(Tensor input, int[] normalized_shape, Tensor? weight, Tensor? bias, float eps) -> (Tensor, Tensor, Tensor)", "native_layer_norm"},
     {"aten::native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)", "native_batch_norm"},

--- a/torch/jit/_shape_functions.py
+++ b/torch/jit/_shape_functions.py
@@ -1119,7 +1119,7 @@ add_shape_compute_mapping("quantized::add(Tensor qa, Tensor qb, float scale, int
 add_shape_compute_mapping("aten::argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor", argmax)
 add_shape_compute_mapping("aten::bmm(Tensor self, Tensor mat2) -> Tensor", bmm)
 add_shape_compute_mapping("aten::_shape_as_tensor(Tensor self) -> Tensor", _shape_as_tensor)
-add_shape_compute_mapping("aten::topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)", topk)
+add_shape_compute_mapping("aten::topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, bool stable=False) -> (Tensor values, Tensor indices)", topk)
 add_shape_compute_mapping("aten::nll_loss_forward(Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index) -> (Tensor output, Tensor total_weight)", nll_loss_forward)
 add_shape_compute_mapping("aten::native_layer_norm(Tensor input, int[] normalized_shape, Tensor? weight, Tensor? bias, float eps) -> (Tensor, Tensor, Tensor)", native_layer_norm)
 add_shape_compute_mapping("aten::native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)", native_batch_norm)


### PR DESCRIPTION
Fixes #88227 #27542
 
Adds `stable` flag to `torch.topk`.
Expected behavior for duplicates is defined as lower indices have higher priority.

cc @ezyang @gchanan @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @VitalyFedyunin