### PR TITLE
[dynamo][api] Better support of torch.nn.Module

### DIFF
--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -962,54 +962,6 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         for (p1, p2) in zip(mod.parameters(), opt_mod.parameters()):
             self.assertTrue(id(p1) == id(p2))
 
-        mod_params = {}
-        for (name, param) in mod.named_parameters():
-            mod_params[name] = param
-        for (name, param) in mod.named_buffers():
-            mod_params[name] = param
-
-        opt_mod_params = {}
-        for (name, param) in mod.named_parameters():
-            opt_mod_params[name] = param
-        for (name, param) in mod.named_buffers():
-            opt_mod_params[name] = param
-
-        self.assertTrue(mod_params.keys() == opt_mod_params.keys())
-        self.assertTrue(
-            all(
-                [a is b for (a, b) in zip(mod_params.values(), opt_mod_params.values())]
-            )
-        )
-
-        # Check get_parameter and get_buffer
-        self.assertTrue(id(mod.get_buffer("buf0")) == id(opt_mod.get_buffer("buf0")))
-        self.assertTrue(
-            id(mod.get_parameter("linear.weight"))
-            == id(opt_mod.get_parameter("linear.weight"))
-        )
-
-        # Check modules
-        for (p1, p2) in zip(mod.modules(), opt_mod.modules()):
-            self.assertTrue(id(p1) == id(p2))
-
-        mod_modules = {}
-        for (name, module) in mod.named_modules():
-            mod_modules[name] = module
-
-        opt_mod_modules = {}
-        for (name, module) in mod.named_modules():
-            opt_mod_modules[name] = module
-
-        self.assertTrue(mod_modules.keys() == opt_mod_modules.keys())
-        self.assertTrue(
-            all(
-                [
-                    a is b
-                    for (a, b) in zip(mod_modules.values(), opt_mod_modules.values())
-                ]
-            )
-        )
-
     def test_recursion(self):
         mod = MockModule()
         cnt = torch._dynamo.testing.CompileCounter()

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -7,6 +7,7 @@ from .eval_frame import (
     export,
     optimize,
     optimize_assert,
+    OptimizedModule,
     reset_code,
     run,
     skip,
@@ -25,6 +26,7 @@ __all__ = [
     "reset",
     "list_backends",
     "skip",
+    "OptimizedModule",
 ]
 
 

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -486,7 +486,15 @@ def same_two_models(gm, opt_gm, example_inputs, only_fwd=False):
     """
     Check two models have same accuracy.
     """
+    from .eval_frame import OptimizedModule
+    from .testing import named_parameters_for_optimized_module
     from .utils import same
+
+    if isinstance(gm, OptimizedModule):
+        gm.named_parameters = named_parameters_for_optimized_module(gm)
+
+    if isinstance(opt_gm, OptimizedModule):
+        opt_gm.named_parameters = named_parameters_for_optimized_module(opt_gm)
 
     ref = run_fwd_maybe_bwd(gm, example_inputs, only_fwd)
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -32,6 +32,17 @@ def clone_me(x):
     return x.detach().clone().requires_grad_(x.requires_grad)
 
 
+def named_parameters_for_optimized_module(mod):
+    assert isinstance(mod, eval_frame.OptimizedModule)
+    return mod._orig_mod.named_parameters
+
+
+def remove_optimized_module_prefix(name):
+    prefix = "_orig_mod."
+    assert name.startswith(prefix)
+    return name[len(prefix) :]
+
+
 def collect_results(model, prediction, loss, example_inputs):
     results = []
     results.append(prediction)
@@ -44,6 +55,8 @@ def collect_results(model, prediction, loss, example_inputs):
     grads = dict()
     params = dict()
     for name, param in model.named_parameters():
+        if isinstance(model, eval_frame.OptimizedModule):
+            name = remove_optimized_module_prefix(name)
         param_copy = param
         grad = param.grad
         # Treat None and zero grad as same


### PR DESCRIPTION
This is an API change, so please review carefully.

With this PR, torchdynamo returns an `OptimizedModule` class object, a subclass of `torch.nn.Module`, when asked to optimize a `nn.Module` object. Most of the methods are redirected to the original `nn.Module`, which is installed as `_mod` in the `OptimizedModule`. 

This is helpful for many cases

```
mod = MockModule()

opt_mod = torch._dynamo.optimize()(mod)

print(opt_mod) # Works

opt_mod = opt_mod.to(device="cuda")
print(opt_mod) # Works
opt_mod(input) # Triggers recompile if necessary, earlier we were shedding the TorchDynamo wrapper

opt_mod.parameters() # Refers to the original module

```

Topics unclear to me
* I have overridden many methods to raise NotImplementedError. A careful review of those will be good.
* hooks
* For the optimized forward, should we call torchdynamo optimization on `__call__` or `forward`
* What else to test



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire