### PR TITLE
[FSDP][state_dict][3/N] Change how state_dict utils access attributes in _FSDPState

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -61,6 +61,24 @@ def _all_handles(state: _FSDPState) -> List:
     )
 
 
+@no_type_check
+def _module_handles(module: nn.Module, state: _FSDPState) -> List:
+    """
+    Given a module and returns the flat handles that map to this module. If the
+    module is FullyShardedDataParallel, the module._handles will be returned.
+    """
+    if module == state:
+        return module._handles[:]
+    else:
+        return state._module_to_handles[module][:]
+
+
+@no_type_check
+def _has_fsdp_params(module: nn.Module, state: _FSDPState) -> bool:
+    """Given a module and returns if this module has parameters sharded by FSDP."""
+    return len(_module_handles(module, state)) > 0
+
+
 def clean_tensor_name(tensor_name: str) -> str:
     """
     Cleans the parameter or buffer name by removing any module wrapper

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -62,21 +62,21 @@ def _all_handles(state: _FSDPState) -> List:
 
 
 @no_type_check
-def _module_handles(module: nn.Module, state: _FSDPState) -> List:
+def _module_handles(state: _FSDPState, module: nn.Module) -> List:
     """
     Given a module and returns the flat handles that map to this module. If the
     module is FullyShardedDataParallel, the module._handles will be returned.
     """
-    if module == state:
-        return module._handles[:]
-    else:
+    if _is_composable(state):
         return state._module_to_handles[module][:]
+    else:
+        return module._handles[:]
 
 
 @no_type_check
-def _has_fsdp_params(module: nn.Module, state: _FSDPState) -> bool:
+def _has_fsdp_params(state: _FSDPState, module: nn.Module) -> bool:
     """Given a module and returns if this module has parameters sharded by FSDP."""
-    return len(_module_handles(module, state)) > 0
+    return len(_module_handles(state, module)) > 0
 
 
 def clean_tensor_name(tensor_name: str) -> str:

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -55,9 +55,9 @@ def _convert_to_wrapped_module_name(module_name: str) -> str:
 
 
 def _param_fqns(module, fsdp_state: _FSDPState) -> Iterator[Tuple[str, str, str]]:
-    if not _has_fsdp_params(module, fsdp_state):
+    if not _has_fsdp_params(fsdp_state, module):
         return
-    for param_name, module_name in _module_handles(module, fsdp_state)[
+    for param_name, module_name in _module_handles(fsdp_state, module)[
         0
     ].parameter_module_names():
         module_name = _convert_to_wrapped_module_name(module_name)
@@ -66,7 +66,7 @@ def _param_fqns(module, fsdp_state: _FSDPState) -> Iterator[Tuple[str, str, str]
 
 
 def _shared_param_fqns(module, fsdp_state) -> Iterator[Tuple[str, str, str]]:
-    for param_name, module_name in _module_handles(module, fsdp_state)[
+    for param_name, module_name in _module_handles(fsdp_state, module)[
         0
     ].shared_parameter_module_names():
         module_name = _convert_to_wrapped_module_name(module_name)
@@ -131,8 +131,8 @@ def _common_pre_state_dict_hook(
     # TODO: change to this call after pre_state_dict_hook is in `nn.Module`.
     # if fsdp_state.is_root:
     #    _clear_grads_if_needed(_all_handles(fsdp_state))
-    if _has_fsdp_params(module, fsdp_state):
-        _clear_grads_if_needed([_module_handles(module, fsdp_state)[0]])
+    if _has_fsdp_params(fsdp_state, module):
+        _clear_grads_if_needed([_module_handles(fsdp_state, module)[0]])
 
 
 def _common_summon_pre_state_dict_hook(
@@ -172,7 +172,7 @@ def _common_summon_post_state_dict_hook(
         fsdp_state.training_state == TrainingState.SUMMON_FULL_PARAMS
     ), "Inside the post_state_dict_hook but the state is not SUMMON_FULL_PARAMS."
     # Return early for trivial cases
-    if not state_dict or not _has_fsdp_params(module, fsdp_state):
+    if not state_dict or not _has_fsdp_params(fsdp_state, module):
         _exit_full_param_ctx(fsdp_state)
         return state_dict
 
@@ -360,8 +360,8 @@ def _local_pre_state_dict_hook(
     `_local_post_state_dict_hook()` to simulate the case.
     """
     if (
-        _has_fsdp_params(module, fsdp_state)
-        and not _module_handles(module, fsdp_state)[0].uses_sharded_strategy
+        _has_fsdp_params(fsdp_state, module)
+        and not _module_handles(fsdp_state, module)[0].uses_sharded_strategy
     ):
         raise RuntimeError(
             "``local_state_dict`` can only be used when parameters are flatten "
@@ -386,15 +386,15 @@ def _local_post_state_dict_hook(
     _local_pre_state_dict_hook(module, fsdp_state, state_dict, prefix)
 
     _replace_by_prefix(state_dict, f"{prefix}{FSDP_PREFIX}", prefix)
-    if not _has_fsdp_params(module, fsdp_state):
+    if not _has_fsdp_params(fsdp_state, module):
         return state_dict
 
     # state_dict[f"{prefix}{FLAT_PARAM}"] exists and has the same tensor
     # value as the flat_param but it is a pure Tensor because
     # nn.Module.state_dict() will detach the parameter. Therefore, we need
     # to get flat_param to get the metadata.
-    assert _module_handles(module, fsdp_state), "Should have returned early"
-    flat_param = _module_handles(module, fsdp_state)[0].flat_param
+    assert _module_handles(fsdp_state, module), "Should have returned early"
+    flat_param = _module_handles(fsdp_state, module)[0].flat_param
     # Construct a ShardedTensor from the flat_param.
     full_numel = flat_param._unpadded_unsharded_size.numel()  # type: ignore[attr-defined]
     shard_offset = flat_param.numel() * fsdp_state.rank
@@ -433,7 +433,7 @@ def _local_pre_load_state_dict_hook(
     _replace_by_prefix(state_dict, prefix, f"{prefix}{FSDP_PREFIX}")
     fqn = f"{prefix}{FSDP_PREFIX}{fsdp_file.FLAT_PARAM}"
     if fqn not in state_dict:
-        assert not _has_fsdp_params(module, fsdp_state), (
+        assert not _has_fsdp_params(fsdp_state, module), (
             "No `FlatParameter` in `state_dict` for this FSDP instance "
             "but it has parameters"
         )
@@ -450,7 +450,7 @@ def _local_pre_load_state_dict_hook(
 
     # Get the metadata of the flat_param to decide whether to pad the loaded
     # tensor.
-    flat_param = _module_handles(module, fsdp_state)[0].flat_param
+    flat_param = _module_handles(fsdp_state, module)[0].flat_param
     assert flat_param is not None
     if flat_param._shard_numel_padded not in (0, flat_param.numel()):
         assert load_tensor.numel() < flat_param.numel(), (
@@ -472,8 +472,8 @@ def _sharded_pre_state_dict_hook(
     ``_full_pre_load_state_dict_hook`` for the detail.
     """
     if (
-        _has_fsdp_params(module, fsdp_state)
-        and not _module_handles(module, fsdp_state)[0].uses_sharded_strategy
+        _has_fsdp_params(fsdp_state, module)
+        and not _module_handles(fsdp_state, module)[0].uses_sharded_strategy
     ):
         raise RuntimeError(
             "``sharded_state_dict`` can only be used when parameters are flatten "
@@ -542,10 +542,10 @@ def _sharded_pre_load_state_dict_hook(
     a new FlatParameter and shards the new FlatParameter to the local chunk.
     """
     _replace_by_prefix(state_dict, prefix, prefix + f"{FSDP_PREFIX}")
-    if not _has_fsdp_params(module, fsdp_state):
+    if not _has_fsdp_params(fsdp_state, module):
         return
 
-    if not _module_handles(module, fsdp_state)[0].uses_sharded_strategy:
+    if not _module_handles(fsdp_state, module)[0].uses_sharded_strategy:
         raise RuntimeError(
             "load_sharded_state_dict can only be called when parameters "
             "are flatten and sharded."
@@ -590,7 +590,7 @@ def _sharded_pre_load_state_dict_hook(
         nonsharded_tensors.append(tensor)
 
     # Create a new flat_param from the loaded, non-sharded tensors.
-    flat_param = _module_handles(module, fsdp_state)[0].flat_param
+    flat_param = _module_handles(fsdp_state, module)[0].flat_param
     loaded_flat_param = FlatParamHandle.flatten_params(
         nonsharded_tensors, requires_grad=False
     )

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -126,8 +126,8 @@ def _common_pre_state_dict_hook(
     """Performs the pre-state_dict tasks shared by all state_dict types."""
     if torch.cuda.is_available():
         torch.cuda.synchronize()
-    if fsdp_state.is_root:
-        _lazy_init(fsdp_state, module)
+    # TODO: need to check if this is always correct for composable FSDP.
+    _lazy_init(fsdp_state, module)
     # TODO: change to this call after pre_state_dict_hook is in `nn.Module`.
     # if fsdp_state.is_root:
     #    _clear_grads_if_needed(_all_handles(fsdp_state))

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -1,7 +1,7 @@
 import functools
 import math
 import warnings
-from typing import Any, Callable, cast, Dict, Iterator, Tuple
+from typing import Any, Callable, cast, Dict, Iterator, no_type_check, Tuple
 
 import torch
 import torch.distributed as dist
@@ -18,6 +18,9 @@ from torch.distributed._shard.sharded_tensor import (
     ShardedTensor,
 )
 from torch.distributed.fsdp._common_utils import (
+    _FSDPState,
+    _has_fsdp_params,
+    _module_handles,
     clean_tensor_name,
     FSDP_PREFIX,
     FSDP_WRAPPED_MODULE,
@@ -51,24 +54,28 @@ def _convert_to_wrapped_module_name(module_name: str) -> str:
     return module_name
 
 
-def _param_fqns(module) -> Iterator[Tuple[str, str, str]]:
-    if not module._has_params:
+def _param_fqns(module, fsdp_state: _FSDPState) -> Iterator[Tuple[str, str, str]]:
+    if not _has_fsdp_params(module, fsdp_state):
         return
-    for param_name, module_name in module._handles[0].parameter_module_names():
+    for param_name, module_name in _module_handles(module, fsdp_state)[
+        0
+    ].parameter_module_names():
         module_name = _convert_to_wrapped_module_name(module_name)
         fqn = f"{module_name}{param_name}"
         yield fqn, param_name, module_name
 
 
-def _shared_param_fqns(module) -> Iterator[Tuple[str, str, str]]:
-    for param_name, module_name in module._handles[0].shared_parameter_module_names():
+def _shared_param_fqns(module, fsdp_state) -> Iterator[Tuple[str, str, str]]:
+    for param_name, module_name in _module_handles(module, fsdp_state)[
+        0
+    ].shared_parameter_module_names():
         module_name = _convert_to_wrapped_module_name(module_name)
         fqn = f"{module_name}{param_name}"
         yield fqn, param_name, module_name
 
 
 def _enter_full_param_ctx(
-    module,
+    fsdp_state: _FSDPState,
     recurse: bool = False,
     writeback: bool = False,
     rank0_only: bool = False,
@@ -80,53 +87,56 @@ def _enter_full_param_ctx(
     requires to enter the context in the pre-hook but leave the context in the
     post-hook. This API enters the context of ``summon_full_params``.
     """
-    assert module._full_param_ctx is None, (
-        "Entering the ``summon_full_params`` context but module._full_param_ctx "
+    assert fsdp_state._full_param_ctx is None, (
+        "Entering the ``summon_full_params`` context but fsdp_state._full_param_ctx "
         "is not None."
     )
-    assert module.training_state != TrainingState.SUMMON_FULL_PARAMS, (
+    assert fsdp_state.training_state != TrainingState.SUMMON_FULL_PARAMS, (
         "Entering the summon_full_params context but the state is already "
         "SUMMON_FULL_PARAMS."
     )
-    module._full_param_ctx = module._summon_full_params(
+    fsdp_state._full_param_ctx = fsdp_state._summon_full_params(
         recurse=recurse,
         writeback=writeback,
         rank0_only=rank0_only,
         offload_to_cpu=offload_to_cpu,
         with_grads=with_grads,
     )
-    module._full_param_ctx.__enter__()
+    fsdp_state._full_param_ctx.__enter__()
 
 
-def _exit_full_param_ctx(module) -> None:
+@no_type_check
+def _exit_full_param_ctx(fsdp_state: _FSDPState) -> None:
     """A helper function to exit ``summon_full_params`` context."""
-    assert module.training_state == TrainingState.SUMMON_FULL_PARAMS, (
+    assert fsdp_state.training_state == TrainingState.SUMMON_FULL_PARAMS, (
         "Exiting the summon_full_params context but the state is not "
         "SUMMON_FULL_PARAMS."
     )
-    assert module._full_param_ctx is not None
-    module._full_param_ctx.__exit__(None, None, None)
-    module._full_param_ctx = None
+    assert fsdp_state._full_param_ctx is not None
+    fsdp_state._full_param_ctx.__exit__(None, None, None)
+    fsdp_state._full_param_ctx = None
 
 
 def _common_pre_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
     """Performs the pre-state_dict tasks shared by all state_dict types."""
     if torch.cuda.is_available():
         torch.cuda.synchronize()
-    _lazy_init(module, module)
+    if fsdp_state.is_root:
+        _lazy_init(fsdp_state, module)
     # TODO: change to this call after pre_state_dict_hook is in `nn.Module`.
-    # if module.is_root:
-    #    _clear_grads_if_needed(module._fsdp_handles(module))
-    if module._has_params:
-        _clear_grads_if_needed([module._handles[0]])
+    # if fsdp_state.is_root:
+    #    _clear_grads_if_needed(_all_handles(fsdp_state))
+    if _has_fsdp_params(module, fsdp_state):
+        _clear_grads_if_needed([_module_handles(module, fsdp_state)[0]])
 
 
 def _common_summon_pre_state_dict_hook(
-    module,
+    fsdp_state: _FSDPState,
     offload_to_cpu: bool,
     rank0_only: bool,
 ) -> None:
@@ -135,7 +145,7 @@ def _common_summon_pre_state_dict_hook(
     ``summon_full_params()``. FULL_STATE_DICT and SHARDED_STATE_DICT use this hook.
     """
     _enter_full_param_ctx(
-        module,
+        fsdp_state,
         recurse=False,
         writeback=False,
         offload_to_cpu=offload_to_cpu,
@@ -144,8 +154,10 @@ def _common_summon_pre_state_dict_hook(
 
 
 # TODO: change to the decorator style. See ``_full_pre_state_dict_hook``.
+@no_type_check
 def _common_summon_post_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
     param_hook: Callable,
@@ -157,17 +169,17 @@ def _common_summon_post_state_dict_hook(
     """
     _replace_by_prefix(state_dict, prefix + f"{FSDP_PREFIX}", prefix)
     assert (
-        module.training_state == TrainingState.SUMMON_FULL_PARAMS
+        fsdp_state.training_state == TrainingState.SUMMON_FULL_PARAMS
     ), "Inside the post_state_dict_hook but the state is not SUMMON_FULL_PARAMS."
     # Return early for trivial cases
-    if not state_dict or not module._has_params:
-        _exit_full_param_ctx(module)
+    if not state_dict or not _has_fsdp_params(module, fsdp_state):
+        _exit_full_param_ctx(fsdp_state)
         return state_dict
 
     # TODO: Once pre_state_dict hook is supported, this pop should be removed.
     # For `use_orig_params=True`, the `FlatParameter` is not registered, so
     # there is no entry in the state dict for it to pop.
-    if not module._use_orig_params:
+    if not fsdp_state._use_orig_params:
         state_dict.pop(f"{prefix}{fsdp_file.FLAT_PARAM}")
 
     # If a rank does not have unsharded parameters(when `rank0_only=True`
@@ -175,25 +187,25 @@ def _common_summon_post_state_dict_hook(
     # all-gather and does not need to save the # state dict. We simply check
     # rank0_only to ensure this issue.
     rank0_only = (
-        module._state_dict_type == StateDictType.FULL_STATE_DICT
-        and cast(FullStateDictConfig, module._state_dict_config).rank0_only
+        fsdp_state._state_dict_type == StateDictType.FULL_STATE_DICT
+        and cast(FullStateDictConfig, fsdp_state._state_dict_config).rank0_only
     )
     # no_fsdp_return means the state_dict returned by this rank should contain
     # only non-FSDP controlled parameters and buffers.
-    no_fsdp_return = rank0_only and module.rank != 0
-    if no_fsdp_return and not module._use_orig_params:
-        for clean_key in module._buffer_names:
+    no_fsdp_return = rank0_only and fsdp_state.rank != 0
+    if no_fsdp_return and not fsdp_state._use_orig_params:
+        for clean_key in fsdp_state._buffer_names:
             # This is a hack to support activation checkpoint.
             clean_key = clean_key.replace(
                 f"{checkpoint_wrapper._CHECKPOINT_PREFIX}.", ""
             )
             state_dict.pop(f"{prefix}{clean_key}", None)
-        _exit_full_param_ctx(module)
+        _exit_full_param_ctx(fsdp_state)
         return state_dict
 
     # Loop only the parameters saved in this instance's wrapped module to
     # avoid processing buffers.
-    for fqn, param_name, module_name in _param_fqns(module):
+    for fqn, param_name, module_name in _param_fqns(module, fsdp_state):
         # TODO: remove the parameter retrieval. See ``_full_pre_state_dict_hook``.
         param = functools.reduce(getattr, fqn.split("."), module.module)
         fqn = f"{prefix}{fqn}"
@@ -205,16 +217,16 @@ def _common_summon_post_state_dict_hook(
             f"FSDP assumes {fqn} is in the state_dict but the state_dict only "
             f"has {state_dict.keys()}. "
             f"prefix={prefix}, module_name={module_name}, "
-            f"param_name={param_name} rank={module.rank}."
+            f"param_name={param_name} rank={fsdp_state.rank}."
         )
 
-        param_hook(module, state_dict, prefix, fqn)
-    _exit_full_param_ctx(module)
+        param_hook(state_dict, prefix, fqn)
+    _exit_full_param_ctx(fsdp_state)
 
     cpu_device = torch.device("cpu")
     buffer_clean_fqns = []
     buffers = []
-    for clean_key in module._buffer_names:
+    for clean_key in fsdp_state._buffer_names:
         # This is a hack to support activation checkpoint.
         clean_key = clean_tensor_name(clean_key)
         fqn = f"{prefix}{clean_key}"
@@ -225,22 +237,29 @@ def _common_summon_post_state_dict_hook(
             state_dict.pop(fqn)
         else:
             buffer = state_dict[fqn]
-            if module._state_dict_config.offload_to_cpu and buffer.device != cpu_device:
+            if (
+                fsdp_state._state_dict_config.offload_to_cpu
+                and buffer.device != cpu_device
+            ):
                 state_dict[fqn] = buffer.to(cpu_device)
             # TODO: for composable FSDP, this should be clean_tensor_name(clean_key),
             buffer_clean_fqns.append(clean_key)
             buffers.append(state_dict[fqn])
-    if buffers and module._mixed_precision_enabled_for_buffers():
-        buffer_dtypes = _get_buffer_dtypes(module, buffer_clean_fqns)
-        _cast_buffers_to_dtype_and_device(buffers, buffer_dtypes, module.compute_device)
+    if buffers and fsdp_state._mixed_precision_enabled_for_buffers():
+        buffer_dtypes = _get_buffer_dtypes(fsdp_state, buffer_clean_fqns)
+        _cast_buffers_to_dtype_and_device(
+            buffers, buffer_dtypes, fsdp_state.compute_device
+        )
         for buffers, clean_fqn in zip(buffers, buffer_clean_fqns):
             fqn = f"{prefix}{clean_fqn}"
             state_dict[fqn] = buffer.clone()
     return state_dict
 
 
+@no_type_check
 def _full_pre_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
@@ -254,16 +273,18 @@ def _full_pre_state_dict_hook(
     TODO: clean the callsites and hacks after ``pre_state_dict_hook` ` is supported
     in ``nn.Module``.
     """
-    _common_pre_state_dict_hook(module, state_dict, prefix)
+    _common_pre_state_dict_hook(module, fsdp_state, state_dict, prefix)
     _common_summon_pre_state_dict_hook(
-        module,
-        offload_to_cpu=module._state_dict_config.offload_to_cpu,
-        rank0_only=cast(FullStateDictConfig, module._state_dict_config).rank0_only,
+        fsdp_state,
+        offload_to_cpu=fsdp_state._state_dict_config.offload_to_cpu,
+        rank0_only=cast(FullStateDictConfig, fsdp_state._state_dict_config).rank0_only,
     )
 
 
+@no_type_check
 def _full_post_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> Dict[str, Any]:
@@ -274,10 +295,9 @@ def _full_post_state_dict_hook(
     the ``FSDP_WRAPPED_MODULE`` prefix.
     """
     # TODO: remove the hack. See ``_full_pre_state_dict_hook``.
-    _full_pre_state_dict_hook(module, state_dict, prefix)
+    _full_pre_state_dict_hook(module, fsdp_state, state_dict, prefix)
 
     def param_hook(
-        module,
         state_dict: Dict[str, Any],
         prefix: str,
         fqn: str,
@@ -292,7 +312,7 @@ def _full_post_state_dict_hook(
 
         # Clone non-ignored parameters before exiting the
         # `_summon_full_params()` context
-        if clean_key not in module._ignored_param_names and not getattr(
+        if clean_key not in fsdp_state._ignored_param_names and not getattr(
             state_dict[fqn], "_has_been_cloned", False
         ):
             try:
@@ -300,31 +320,37 @@ def _full_post_state_dict_hook(
                 state_dict[fqn]._has_been_cloned = True  # type: ignore[attr-defined]
             except BaseException as e:
                 warnings.warn(
-                    f"Failed to clone() tensor with name {fqn} on rank {module.rank}. "
+                    f"Failed to clone() tensor with name {fqn} on rank {fsdp_state.rank}. "
                     "This may mean that this state_dict entry could point to invalid "
                     "memory regions after returning from state_dict() call if this "
                     "parameter is managed by FSDP. Please check clone "
                     f"implementation of {fqn}. Error: {str(e)}"
                 )
 
-    return _common_summon_post_state_dict_hook(module, state_dict, prefix, param_hook)
+    return _common_summon_post_state_dict_hook(
+        module, fsdp_state, state_dict, prefix, param_hook
+    )
 
 
 def _full_pre_load_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
-    _enter_full_param_ctx(module, recurse=False, writeback=True)
+    _enter_full_param_ctx(fsdp_state, recurse=False, writeback=True)
     _replace_by_prefix(state_dict, prefix, prefix + f"{FSDP_PREFIX}")
 
 
-def _full_post_load_state_dict_hook(module, *args, **kwargs) -> None:
-    _exit_full_param_ctx(module)
+def _full_post_load_state_dict_hook(
+    module, fsdp_state: _FSDPState, *args, **kwargs
+) -> None:
+    _exit_full_param_ctx(fsdp_state)
 
 
 def _local_pre_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
@@ -333,16 +359,21 @@ def _local_pre_state_dict_hook(
     hook is not supported by the PyTorch core. So this API is called from
     `_local_post_state_dict_hook()` to simulate the case.
     """
-    if module._has_params and not module._handles[0].uses_sharded_strategy:
+    if (
+        _has_fsdp_params(module, fsdp_state)
+        and not _module_handles(module, fsdp_state)[0].uses_sharded_strategy
+    ):
         raise RuntimeError(
             "``local_state_dict`` can only be used when parameters are flatten "
             "and sharded."
         )
-    _common_pre_state_dict_hook(module, state_dict, prefix)
+    _common_pre_state_dict_hook(module, fsdp_state, state_dict, prefix)
 
 
+@no_type_check
 def _local_post_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> Dict[str, Any]:
@@ -352,42 +383,45 @@ def _local_post_state_dict_hook(
     will happen. The underlying storage is the same.
     """
     # TODO: remove the hack. See ``_full_pre_state_dict_hook``.
-    _local_pre_state_dict_hook(module, state_dict, prefix)
+    _local_pre_state_dict_hook(module, fsdp_state, state_dict, prefix)
 
     _replace_by_prefix(state_dict, f"{prefix}{FSDP_PREFIX}", prefix)
-    if not module._has_params:
+    if not _has_fsdp_params(module, fsdp_state):
         return state_dict
 
     # state_dict[f"{prefix}{FLAT_PARAM}"] exists and has the same tensor
     # value as the flat_param but it is a pure Tensor because
     # nn.Module.state_dict() will detach the parameter. Therefore, we need
     # to get flat_param to get the metadata.
-    assert module._handles, "Should have returned early"
-    flat_param = module._handles[0].flat_param
+    assert _module_handles(module, fsdp_state), "Should have returned early"
+    flat_param = _module_handles(module, fsdp_state)[0].flat_param
     # Construct a ShardedTensor from the flat_param.
     full_numel = flat_param._unpadded_unsharded_size.numel()  # type: ignore[attr-defined]
-    shard_offset = flat_param.numel() * module.rank
+    shard_offset = flat_param.numel() * fsdp_state.rank
     valid_data_size = flat_param.numel() - flat_param._shard_numel_padded
     if valid_data_size > 0 and flat_param._shard_numel_padded > 0:
         flat_param = flat_param.narrow(0, 0, valid_data_size)
     local_shards = [
-        Shard.from_tensor_and_offsets(flat_param, [shard_offset], module.rank)
+        Shard.from_tensor_and_offsets(flat_param, [shard_offset], fsdp_state.rank)
     ]
     sharded_tensor = init_from_local_shards(
-        local_shards, full_numel, process_group=module.process_group
+        local_shards, full_numel, process_group=fsdp_state.process_group
     )  # type: ignore[assignment]
-    if module._state_dict_config.offload_to_cpu:
+    if fsdp_state._state_dict_config.offload_to_cpu:
         sharded_tensor = sharded_tensor.cpu()
     state_dict[f"{prefix}{fsdp_file.FLAT_PARAM}"] = sharded_tensor
     return state_dict
 
 
-def _local_post_load_state_dict_hook(module, *args, **kwargs) -> None:
+def _local_post_load_state_dict_hook(
+    module, fsdp_state: _FSDPState, *args, **kwargs
+) -> None:
     pass
 
 
 def _local_pre_load_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
@@ -399,7 +433,7 @@ def _local_pre_load_state_dict_hook(
     _replace_by_prefix(state_dict, prefix, f"{prefix}{FSDP_PREFIX}")
     fqn = f"{prefix}{FSDP_PREFIX}{fsdp_file.FLAT_PARAM}"
     if fqn not in state_dict:
-        assert not module._has_params, (
+        assert not _has_fsdp_params(module, fsdp_state), (
             "No `FlatParameter` in `state_dict` for this FSDP instance "
             "but it has parameters"
         )
@@ -416,7 +450,7 @@ def _local_pre_load_state_dict_hook(
 
     # Get the metadata of the flat_param to decide whether to pad the loaded
     # tensor.
-    flat_param = module._handles[0].flat_param
+    flat_param = _module_handles(module, fsdp_state)[0].flat_param
     assert flat_param is not None
     if flat_param._shard_numel_padded not in (0, flat_param.numel()):
         assert load_tensor.numel() < flat_param.numel(), (
@@ -429,6 +463,7 @@ def _local_pre_load_state_dict_hook(
 
 def _sharded_pre_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
@@ -436,23 +471,28 @@ def _sharded_pre_state_dict_hook(
     Hook that runs before model.state_dict() is called. Check
     ``_full_pre_load_state_dict_hook`` for the detail.
     """
-    if module._has_params and not module._handles[0].uses_sharded_strategy:
+    if (
+        _has_fsdp_params(module, fsdp_state)
+        and not _module_handles(module, fsdp_state)[0].uses_sharded_strategy
+    ):
         raise RuntimeError(
             "``sharded_state_dict`` can only be used when parameters are flatten "
             "and sharded."
         )
-    _common_pre_state_dict_hook(module, state_dict, prefix)
+    _common_pre_state_dict_hook(module, fsdp_state, state_dict, prefix)
     # Setting offload_to_cpu here does not work even if offload_to_cpu is True.
     # We have to create ShardedTensor first then move it to CPU.
     _common_summon_pre_state_dict_hook(
-        module,
+        fsdp_state,
         offload_to_cpu=False,
         rank0_only=False,
     )
 
 
+@no_type_check
 def _sharded_post_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> Dict[str, Any]:
@@ -462,31 +502,38 @@ def _sharded_post_state_dict_hook(
     """
 
     # TODO: remove the hack. See ``_full_pre_state_dict_hook``.
-    _sharded_pre_state_dict_hook(module, state_dict, prefix)
+    _sharded_pre_state_dict_hook(module, fsdp_state, state_dict, prefix)
 
-    def param_hook(module, state_dict: Dict[str, Any], prefix: str, fqn: str):
+    def param_hook(state_dict: Dict[str, Any], prefix: str, fqn: str):
         param = state_dict[fqn]
         sharded_tensor = _ext_chunk_tensor(
             tensor=param,
-            rank=module.rank,
-            world_size=module.world_size,
+            rank=fsdp_state.rank,
+            world_size=fsdp_state.world_size,
             num_devices_per_node=torch.cuda.device_count(),
-            pg=module.process_group,
+            pg=fsdp_state.process_group,
         )
-        if module._state_dict_config.offload_to_cpu:
+        if fsdp_state._state_dict_config.offload_to_cpu:
             sharded_tensor = sharded_tensor.cpu()
         state_dict[fqn] = sharded_tensor
 
-    return _common_summon_post_state_dict_hook(module, state_dict, prefix, param_hook)
+    return _common_summon_post_state_dict_hook(
+        module, fsdp_state, state_dict, prefix, param_hook
+    )
 
 
-def _sharded_post_load_state_dict_hook(module, *args, **kwargs) -> None:
-    if module._use_orig_params:
-        module._register_orig_params()
+@no_type_check
+def _sharded_post_load_state_dict_hook(
+    module, fsdp_state: _FSDPState, *args, **kwargs
+) -> None:
+    if fsdp_state._use_orig_params:
+        fsdp_state._register_orig_params()
 
 
+@no_type_check
 def _sharded_pre_load_state_dict_hook(
     module,
+    fsdp_state: _FSDPState,
     state_dict: Dict[str, Any],
     prefix: str,
 ) -> None:
@@ -495,19 +542,19 @@ def _sharded_pre_load_state_dict_hook(
     a new FlatParameter and shards the new FlatParameter to the local chunk.
     """
     _replace_by_prefix(state_dict, prefix, prefix + f"{FSDP_PREFIX}")
-    if not module._has_params:
+    if not _has_fsdp_params(module, fsdp_state):
         return
 
-    if not module._handles[0].uses_sharded_strategy:
+    if not _module_handles(module, fsdp_state)[0].uses_sharded_strategy:
         raise RuntimeError(
             "load_sharded_state_dict can only be called when parameters "
             "are flatten and sharded."
         )
 
     nonsharded_tensors = []
-    shared_fqns = [fqn for fqn, _, _ in _shared_param_fqns(module)]
+    shared_fqns = [fqn for fqn, _, _ in _shared_param_fqns(module, fsdp_state)]
     loaded_shapes = []
-    for fqn, _, _ in _param_fqns(module):
+    for fqn, _, _ in _param_fqns(module, fsdp_state):
         full_fqn = f"{prefix}{FSDP_PREFIX}{fqn}"
         param = state_dict.pop(full_fqn)
         if fqn in shared_fqns:
@@ -517,12 +564,12 @@ def _sharded_pre_load_state_dict_hook(
         loaded_shapes.append(param.size())
         assert len(shards) < 2, (
             "Expects 0 or 1 shard per rank "
-            f"but got {len(shards)} shards on rank {module.rank}."
+            f"but got {len(shards)} shards on rank {fsdp_state.rank}."
         )
         param_numel = param.size().numel()
         dim_0_size = param.size()[0]
         chunk_size = (
-            math.ceil(dim_0_size / module.world_size) * param_numel // dim_0_size
+            math.ceil(dim_0_size / fsdp_state.world_size) * param_numel // dim_0_size
         )
         if len(shards) == 1:
             local_tensor = shards[0].tensor.flatten()
@@ -534,14 +581,16 @@ def _sharded_pre_load_state_dict_hook(
         else:
             local_tensor = torch.zeros(chunk_size, dtype=param.dtype).cuda()
         tensor = torch.empty(
-            chunk_size * module.world_size, dtype=local_tensor.dtype
+            chunk_size * fsdp_state.world_size, dtype=local_tensor.dtype
         ).cuda()
-        dist.all_gather_into_tensor(tensor, local_tensor, group=module.process_group)
+        dist.all_gather_into_tensor(
+            tensor, local_tensor, group=fsdp_state.process_group
+        )
         tensor = tensor.narrow(0, 0, param_numel).reshape(param.size())
         nonsharded_tensors.append(tensor)
 
     # Create a new flat_param from the loaded, non-sharded tensors.
-    flat_param = module._handles[0].flat_param
+    flat_param = _module_handles(module, fsdp_state)[0].flat_param
     loaded_flat_param = FlatParamHandle.flatten_params(
         nonsharded_tensors, requires_grad=False
     )
@@ -549,8 +598,8 @@ def _sharded_pre_load_state_dict_hook(
     # Get the chunk from the loaded flat_param for the local rank.
     loaded_flat_tensor, num_to_pad = FlatParamHandle._get_shard(
         loaded_flat_param,
-        module.rank,
-        module.world_size,
+        fsdp_state.rank,
+        fsdp_state.world_size,
     )
     loaded_flat_tensor.to(flat_param.device)
     assert all(s1 == s2 for s1, s2 in zip(loaded_shapes, flat_param._shapes)), (
@@ -567,10 +616,11 @@ def _sharded_pre_load_state_dict_hook(
         f"from the local chunk {flat_param._shard_numel_padded}."
     )
     state_dict[f"{prefix}{FSDP_PREFIX}{fsdp_file.FLAT_PARAM}"] = loaded_flat_tensor
-    if module._use_orig_params:
-        module._deregister_orig_params()
+    if fsdp_state._use_orig_params:
+        fsdp_state._deregister_orig_params()
 
 
+@no_type_check
 @torch.no_grad()
 def _post_state_dict_hook(
     module: nn.Module,
@@ -580,21 +630,24 @@ def _post_state_dict_hook(
 ) -> Dict[str, Any]:
     """
     _post_state_dict_hook() is called after the state_dict() of this
-    FSDP module is executed. ``module._state_dict_type`` is used to decide
+    FSDP module is executed. ``fsdp_state._state_dict_type`` is used to decide
     what postprocessing will be done.
     """
+    # TODO: get the composable state from module
+    fsdp_state: _FSDPState = module
     _post_state_dict_hook_fn = {
         StateDictType.FULL_STATE_DICT: _full_post_state_dict_hook,
         StateDictType.LOCAL_STATE_DICT: _local_post_state_dict_hook,
         StateDictType.SHARDED_STATE_DICT: _sharded_post_state_dict_hook,
     }
     fsdp_module = cast(fsdp_file.FullyShardedDataParallel, module)
-    processed_state_dict = _post_state_dict_hook_fn[fsdp_module._state_dict_type](
-        fsdp_module, state_dict, prefix
+    processed_state_dict = _post_state_dict_hook_fn[fsdp_state._state_dict_type](
+        fsdp_module, fsdp_state, state_dict, prefix
     )
     return processed_state_dict
 
 
+@no_type_check
 @torch.no_grad()
 def _pre_load_state_dict_hook(
     module: nn.Module,
@@ -604,9 +657,11 @@ def _pre_load_state_dict_hook(
 ) -> None:
     """
     ``_pre_state_dict_hook` is called before ``module._load_from_state_dict()``
-    is called. ``module._state_dict_type`` is used to decide what preprocessing
+    is called. ``fsdp_state._state_dict_type`` is used to decide what preprocessing
     will be done.
     """
+    # TODO: get the composable state from module
+    fsdp_state: _FSDPState = module
     _pre_load_state_dict_hook_fn = {
         StateDictType.FULL_STATE_DICT: _full_pre_load_state_dict_hook,
         StateDictType.LOCAL_STATE_DICT: _local_pre_load_state_dict_hook,
@@ -617,13 +672,16 @@ def _pre_load_state_dict_hook(
     if torch.cuda.is_available():
         torch.cuda.synchronize()
     # Dispatch into state_dict specific implementation of pre-hook.
-    _pre_load_state_dict_hook_fn[fsdp_module._state_dict_type](
-        fsdp_module, state_dict, prefix
+    _pre_load_state_dict_hook_fn[fsdp_state._state_dict_type](
+        fsdp_module, fsdp_state, state_dict, prefix
     )
 
 
+@no_type_check
 @torch.no_grad()
 def _post_load_state_dict_hook(module: nn.Module, *args: Any) -> None:
+    # TODO: get the composable state from module
+    fsdp_state: _FSDPState = module
     _post_load_state_dict_hook_fn = {
         StateDictType.FULL_STATE_DICT: _full_post_load_state_dict_hook,
         StateDictType.LOCAL_STATE_DICT: _local_post_load_state_dict_hook,
@@ -633,4 +691,4 @@ def _post_load_state_dict_hook(module: nn.Module, *args: Any) -> None:
     fsdp_module = cast(fsdp_file.FullyShardedDataParallel, module)
     # Dispatch into state_dict type specific implementation of post-hook for
     # loading state_dict.
-    _post_load_state_dict_hook_fn[fsdp_module._state_dict_type](fsdp_module)
+    _post_load_state_dict_hook_fn[fsdp_state._state_dict_type](fsdp_module, fsdp_state)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88638
* #88637
* #88636
* __->__ #88635
* #88481
* #87900

**What This PR Does**
_state_dict_utils currently accesses the FSDP states through module. To enable composable FSDP state_dict, these accesses need to go through _FSDPState. module is still required for most APIs as state_dict has to access per-module information.
