### PR TITLE
[FSDP][state_dict][4/N] Move the core logic of summon full parameters to _unshard_params_utils.py

### DIFF
--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -25,7 +25,7 @@ from torch.distributed.fsdp import (
     StateDictType,
 )
 from torch.distributed.fsdp._shard_utils import _gather_state_dict
-from torch.distributed.fsdp.fully_sharded_data_parallel import FLAT_PARAM
+from torch.distributed.fsdp._unshard_param_utils import FLAT_PARAM
 from torch.distributed.fsdp.wrap import enable_wrap, transformer_auto_wrap_policy, wrap
 from torch.nn import Linear, Module, TransformerDecoderLayer, TransformerEncoderLayer
 from torch.nn.parallel import DistributedDataParallel

--- a/torch/distributed/fsdp/_unshard_param_utils.py
+++ b/torch/distributed/fsdp/_unshard_param_utils.py
@@ -1,0 +1,254 @@
+import contextlib
+import warnings
+from typing import Generator, List
+
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp._common_utils import (
+    _FSDPState,
+    _has_fsdp_params,
+    _module_handles,
+    HandleTrainingState,
+)
+from torch.distributed.fsdp._runtime_utils import (
+    _clear_grads_if_needed,
+    _reshard,
+    _reshard_grads,
+    _unshard,
+    _unshard_grads,
+)
+from ._utils import p_assert
+from .flat_param import FlatParamHandle
+
+FLAT_PARAM = "_flat_param"
+
+
+@torch.no_grad()
+def _writeback_to_local_shard(
+    handles: List[FlatParamHandle],
+    writeback_grad: bool,
+):
+    """
+    For each handle, writes back the this rank's shard of the unsharded
+    flattened parameter to the sharded flattened parameter. If
+    ``writeback_grad=True``, then writes back to the sharded gradient as
+    well.
+
+    Precondition: Each handle's ``FlatParameter`` 's data points to the
+    padded unsharded flattened parameter.
+    """
+    for handle in handles:
+        # For `NO_SHARD`, `_local_shard` is the unsharded flattened
+        # parameter and `grad` is the unsharded gradient, so there is no
+        # need to writeback for either
+        if not handle.uses_sharded_strategy:
+            continue
+        assert (
+            handle.flat_param.ndim == 1
+        ), f"Expects `flat_param` to be flattened but got {handle.flat_param.shape}"
+
+        # Get the unpadded shard instead of the padded shard to persist
+        # user changes to the padding (though FSDP does not explicitly
+        # support this)
+        param_shard, _ = FlatParamHandle._get_unpadded_shard(
+            handle.flat_param,
+            handle.rank,
+            handle.world_size,
+        )
+        handle.flat_param._local_shard[: param_shard.numel()].copy_(param_shard)  # type: ignore[attr-defined]
+        if writeback_grad:
+            existing_grad = handle.sharded_grad
+            if existing_grad is not None:
+                assert handle.flat_param.grad is not None
+                grad_shard, _ = FlatParamHandle._get_unpadded_shard(
+                    handle.flat_param.grad,
+                    handle.rank,
+                    handle.world_size,
+                )
+                existing_grad[: grad_shard.numel()].copy_(grad_shard)
+
+
+def _deregister_flat_param(module, state: _FSDPState):
+    """
+    De-registers the flattened parameter from the wrapped module, hiding it
+    from ``nn.Module`` methods.
+
+    We do not use ``del`` because we want ``FLAT_PARAM`` to always be an
+    attribute but dynamically change whether it is visible to ``nn.Module``
+    methods.
+    """
+    if _has_fsdp_params(module, state):
+        # TODO: figure out the case for the composable APIs.
+        module.module._parameters.pop(FLAT_PARAM, None)
+
+
+def _register_flat_param(module, state: _FSDPState):
+    """
+    Registers the flattened parameter to the wrapped module, making it
+    visible to ``nn.Module`` methods.
+
+    We do not use :meth:`nn.Module.register_parameter` because we want
+    ``FLAT_PARAM`` to always be an attribute but dynamically change whether
+    it is visible to ``nn.Module`` methods.
+    """
+    handles = _module_handles(module, state)
+    if _has_fsdp_params(module, state):
+        # TODO: figure out the case for the composable APIs.
+        module.module._parameters[FLAT_PARAM] = handles[0].flat_param
+
+
+@contextlib.contextmanager
+def _unflatten_as_params(module: nn.Module, state: _FSDPState) -> Generator:
+    """
+    Assumes that the flattened parameter is unsharded. When in the context,
+    de-registers the flattened parameter and unflattens the original
+    parameters as ``nn.Parameter`` views into the flattened parameter.
+    After the context, re-registers the flattened parameter and restores
+    the original parameters as ``Tensor`` views into the flattened
+    parameter.
+    """
+    handles = _module_handles(module, state)
+    if not handles:
+        yield
+    else:
+        _deregister_flat_param(module, state)
+        try:
+            with handles[0].unflatten_as_params():
+                yield
+        finally:
+            if not handles[0]._use_orig_params:
+                _register_flat_param(module, state)
+
+
+@contextlib.contextmanager
+def _unshard_params(
+    module: nn.Module,
+    state: _FSDPState,
+    writeback: bool = True,
+    rank0_only: bool = False,
+    offload_to_cpu: bool = False,
+    with_grads: bool = False,
+):
+    if with_grads and (offload_to_cpu or not state._use_orig_params):
+        raise NotImplementedError(
+            f"with_grads={with_grads} "
+            f"use_orig_params={state._use_orig_params} "
+            f"offload_to_cpu={offload_to_cpu} "
+            f"is not supported yet"
+        )
+    if writeback and rank0_only:
+        raise ValueError(
+            "writeback=True and rank0_only=True is not supported, as model "
+            "parameter shapes will be different across ranks, and writing "
+            "to them can lead to inconsistencies across ranks when the "
+            "context is exited."
+        )
+    if offload_to_cpu and not rank0_only:
+        warnings.warn(
+            "offload_to_cpu and rank0_only=False will result in "
+            "full parameters being redundantly copied to CPU memory for "
+            "GPUs that reside on the same machine, which may incur the risk of "
+            "CPU OOM. It is recommended to use ``offload_to_cpu`` with "
+            "rank0_only=True."
+        )
+
+    torch.cuda.synchronize()
+    # If handles are shared by other module(s), the handle may be already unsharded.
+    handles = [
+        handle
+        for handle in _module_handles(module, state)
+        if handle._training_state != HandleTrainingState.SUMMON_FULL_PARAMS
+    ]
+    if not handles:
+        yield
+        return
+
+    for handle in handles:
+        assert handle._training_state == HandleTrainingState.IDLE
+
+    for handle in handles:
+        handle._training_state = HandleTrainingState.SUMMON_FULL_PARAMS
+
+    _clear_grads_if_needed(handles)
+    free_unsharded_flat_params = [handle.needs_unshard() for handle in handles]
+    # No need to call `wait_stream()` since we unshard in the computation
+    # stream directly
+    computation_stream = torch.cuda.current_stream()
+    _unshard(state, handles, computation_stream, computation_stream)
+    if with_grads:
+        _unshard_grads(handles)
+
+    if rank0_only and state.rank != 0:
+        # Free the unsharded flattened parameter early
+        _reshard(state, handles, free_unsharded_flat_params)
+        if with_grads:
+            _reshard_grads(handles)
+        try:
+            yield
+        finally:
+            # state.training_state = TrainingState.IDLE
+            for handle in handles:
+                handle._training_state = HandleTrainingState.IDLE
+    else:
+        # Unflatten the unsharded flattened parameters
+        with contextlib.ExitStack() as stack:
+            # Invariant: rank == 0 or !rank0_only
+            for handle in handles:
+                if offload_to_cpu and handle.uses_sharded_strategy:
+                    stack.enter_context(handle.to_cpu())
+                    # TODO (awgu): Since PyTorch enforces that a parameter
+                    # and its gradients need to match metadata (e.g.
+                    # device), we must move gradients to CPU *after* we
+                    # move parameters.
+            # TODO (awgu): This FPW call assumes 1 `FlatParameter`
+            if not state._use_orig_params:
+                stack.enter_context(_unflatten_as_params(module, state))
+            try:
+                yield
+            finally:
+                stack.close()
+                if writeback:
+                    _writeback_to_local_shard(handles, with_grads)
+                _reshard(state, handles, free_unsharded_flat_params)
+                if with_grads:
+                    _reshard_grads(handles)
+                for handle in handles:
+                    handle._training_state = HandleTrainingState.IDLE
+
+
+def _deregister_orig_params(module, state: _FSDPState):
+    """
+    Deregisters the original parameters; registers the ``FlatParameter``.
+    """
+    handles = _module_handles(module, state)
+    p_assert(
+        len(handles) <= 1,
+        "Expects <=1 handle per FSDP instance; needs to be refactored "
+        "for >1 handle (e.g. non-recursive wrapping)",
+    )
+    if not handles:
+        return
+    handle = handles[0]
+    p_assert(
+        handle._use_orig_params,
+        f"Inconsistent `_use_orig_params` -- FSDP: {state._use_orig_params} "
+        f"handle: {handle._use_orig_params}",
+    )
+    handle._deregister_orig_params()
+    _register_flat_param(module, state)
+
+
+def _register_orig_params(module, state: _FSDPState):
+    """
+    Deregisters the ``FlatParameter``; registers the original parameters.
+    """
+    handles = _module_handles(module, state)
+    if not handles:
+        return
+    handle = handles[0]
+    _deregister_flat_param(module, state)
+    if handle.is_sharded(handle.flat_param):
+        handle._use_sharded_views()
+        handle._use_sharded_grad_views()
+    else:
+        handle._use_unsharded_views(as_params=True)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -48,18 +48,14 @@ from torch.distributed.fsdp._init_utils import (
     _init_state_dict_state,
 )
 from torch.distributed.fsdp._runtime_utils import (
-    _clear_grads_if_needed,
     _lazy_init,
     _post_forward,
     _post_forward_reshard,
     _pre_forward,
     _pre_forward_unshard,
     _reshard,
-    _reshard_grads,
     _root_pre_forward,
     _should_free_in_backward,
-    _unshard,
-    _unshard_grads,
     _wait_for_computation_stream,
 )
 from torch.distributed.fsdp._wrap_utils import _auto_wrap
@@ -91,6 +87,12 @@ from ._state_dict_utils import (
     _post_load_state_dict_hook,
     _post_state_dict_hook,
     _pre_load_state_dict_hook,
+)
+from ._unshard_param_utils import (
+    _deregister_orig_params,
+    _register_flat_param,
+    _register_orig_params,
+    _unshard_params,
 )
 from ._utils import p_assert
 from .flat_param import FlatParameter, FlatParamHandle
@@ -409,7 +411,7 @@ class FullyShardedDataParallel(nn.Module):
         self._fsdp_wrapped_module = module
         if not use_orig_params:
             _check_orig_params_flattened(self, self._ignored_params)
-            self._register_flat_param()
+            _register_flat_param(self, self)
 
         # Delete to avoid keeping references after the constructor
         delattr(self, "_ignored_params")
@@ -864,153 +866,16 @@ class FullyShardedDataParallel(nn.Module):
                 yield
             return
 
-        torch.cuda.synchronize()
-        _lazy_init(self, self)
-        self._assert_state([TrainingState.IDLE])
-        for handle in self._handles:
-            assert handle._training_state == HandleTrainingState.IDLE
-        self.training_state = TrainingState.SUMMON_FULL_PARAMS
-        for handle in self._handles:
-            handle._training_state = HandleTrainingState.SUMMON_FULL_PARAMS
-
-        if self._is_root:
-            _clear_grads_if_needed(self._fsdp_handles(self))
-        free_unsharded_flat_params = [
-            handle.needs_unshard() for handle in self._handles
-        ]
-        # No need to call `wait_stream()` since we unshard in the computation
-        # stream directly
-        computation_stream = torch.cuda.current_stream()
-        _unshard(self, self._handles, computation_stream, computation_stream)
-        if with_grads:
-            _unshard_grads(self._handles)
-
-        if rank0_only and self.rank != 0:
-            # Free the unsharded flattened parameter early
-            _reshard(self, self._handles, free_unsharded_flat_params)
-            if with_grads:
-                _reshard_grads(self._handles)
-            try:
-                yield
-            finally:
-                self.training_state = TrainingState.IDLE
-                for handle in self._handles:
-                    handle._training_state = HandleTrainingState.IDLE
-        else:
-            # Unflatten the unsharded flattened parameters
-            with contextlib.ExitStack() as stack:
-                # Invariant: rank == 0 or !rank0_only
-                for handle in self._handles:
-                    if offload_to_cpu and handle.uses_sharded_strategy:
-                        stack.enter_context(handle.to_cpu())
-                        # TODO (awgu): Since PyTorch enforces that a parameter
-                        # and its gradients need to match metadata (e.g.
-                        # device), we must move gradients to CPU *after* we
-                        # move parameters.
-                # TODO (awgu): This FPW call assumes 1 `FlatParameter`
-                if not self._use_orig_params:
-                    stack.enter_context(self._unflatten_as_params())
-                try:
-                    yield
-                finally:
-                    stack.close()
-                    if writeback:
-                        self._writeback_to_local_shard(self._handles, with_grads)
-                    _reshard(self, self._handles, free_unsharded_flat_params)
-                    if with_grads:
-                        _reshard_grads(self._handles)
-                    self.training_state = TrainingState.IDLE
-                    for handle in self._handles:
-                        handle._training_state = HandleTrainingState.IDLE
-
-    @torch.no_grad()
-    def _writeback_to_local_shard(
-        self,
-        handles: List[FlatParamHandle],
-        writeback_grad: bool,
-    ):
-        """
-        For each handle, writes back the this rank's shard of the unsharded
-        flattened parameter to the sharded flattened parameter. If
-        ``writeback_grad=True``, then writes back to the sharded gradient as
-        well.
-
-        Precondition: Each handle's ``FlatParameter`` 's data points to the
-        padded unsharded flattened parameter.
-        """
-        for handle in handles:
-            # For `NO_SHARD`, `_local_shard` is the unsharded flattened
-            # parameter and `grad` is the unsharded gradient, so there is no
-            # need to writeback for either
-            if not handle.uses_sharded_strategy:
-                continue
-            assert (
-                handle.flat_param.ndim == 1
-            ), f"Expects `flat_param` to be flattened but got {handle.flat_param.shape}"
-
-            # Get the unpadded shard instead of the padded shard to persist
-            # user changes to the padding (though FSDP does not explicitly
-            # support this)
-            param_shard, _ = FlatParamHandle._get_unpadded_shard(
-                handle.flat_param,
-                handle.rank,
-                handle.world_size,
-            )
-            handle.flat_param._local_shard[: param_shard.numel()].copy_(param_shard)
-            if writeback_grad:
-                existing_grad = handle.sharded_grad
-                if existing_grad is not None:
-                    grad_shard, _ = FlatParamHandle._get_unpadded_shard(
-                        handle.flat_param.grad,
-                        handle.rank,
-                        handle.world_size,
-                    )
-                    existing_grad[: grad_shard.numel()].copy_(grad_shard)
-
-    @contextlib.contextmanager
-    def _unflatten_as_params(self) -> Generator:
-        """
-        Assumes that the flattened parameter is unsharded. When in the context,
-        de-registers the flattened parameter and unflattens the original
-        parameters as ``nn.Parameter`` views into the flattened parameter.
-        After the context, re-registers the flattened parameter and restores
-        the original parameters as ``Tensor`` views into the flattened
-        parameter.
-        """
-        if not self._handles:
+        with _unshard_params(
+            module=self,
+            state=self,
+            writeback=writeback,
+            rank0_only=rank0_only,
+            offload_to_cpu=offload_to_cpu,
+            with_grads=with_grads,
+        ):
+            self.training_state = TrainingState.SUMMON_FULL_PARAMS
             yield
-        else:
-            self._deregister_flat_param()
-            try:
-                with self._handles[0].unflatten_as_params():
-                    yield
-            finally:
-                if not self._handles[0]._use_orig_params:
-                    self._register_flat_param()
-
-    def _register_flat_param(self):
-        """
-        Registers the flattened parameter to the wrapped module, making it
-        visible to ``nn.Module`` methods.
-
-        We do not use :meth:`nn.Module.register_parameter` because we want
-        ``FLAT_PARAM`` to always be an attribute but dynamically change whether
-        it is visible to ``nn.Module`` methods.
-        """
-        if self._has_params:
-            self.module._parameters[FLAT_PARAM] = self._handles[0].flat_param
-
-    def _deregister_flat_param(self):
-        """
-        De-registers the flattened parameter from the wrapped module, hiding it
-        from ``nn.Module`` methods.
-
-        We do not use ``del`` because we want ``FLAT_PARAM`` to always be an
-        attribute but dynamically change whether it is visible to ``nn.Module``
-        methods.
-        """
-        if self._has_params:
-            self.module._parameters.pop(FLAT_PARAM, None)
 
     @contextlib.contextmanager
     def _deregister_orig_params_ctx(self):
@@ -1026,46 +891,12 @@ class FullyShardedDataParallel(nn.Module):
             "`_use_orig_params=True`",
         )
         for fsdp_module in self.fsdp_modules(self):
-            fsdp_module._deregister_orig_params()
+            _deregister_orig_params(fsdp_module, fsdp_module)
         try:
             yield
         finally:
             for fsdp_module in self.fsdp_modules(self):
-                fsdp_module._register_orig_params()
-
-    def _deregister_orig_params(self):
-        """
-        Deregisters the original parameters; registers the ``FlatParameter``.
-        """
-        p_assert(
-            len(self._handles) <= 1,
-            "Expects <=1 handle per FSDP instance; needs to be refactored "
-            "for >1 handle (e.g. non-recursive wrapping)",
-        )
-        if not self._handles:
-            return
-        handle = self._handles[0]
-        p_assert(
-            handle._use_orig_params,
-            f"Inconsistent `_use_orig_params` -- FSDP: {self._use_orig_params} "
-            f"handle: {handle._use_orig_params}",
-        )
-        handle._deregister_orig_params()
-        self._register_flat_param()
-
-    def _register_orig_params(self):
-        """
-        Deregisters the ``FlatParameter``; registers the original parameters.
-        """
-        if not self._handles:
-            return
-        handle = self._handles[0]
-        self._deregister_flat_param()
-        if handle.is_sharded(handle.flat_param):
-            handle._use_sharded_views()
-            handle._use_sharded_grad_views()
-        else:
-            handle._use_unsharded_views(as_params=True)
+                _register_orig_params(fsdp_module, fsdp_module)
 
     def _apply(self, *args, **kwargs):
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88638
* #88637
* __->__ #88636
* #88635
* #88481
* #87900

**What**
`_summon_full_parameters` is required for state_dict. To enable composable FSDP state_dict, `_summon_full_params` must be accessible without FullyShardedDataParall. This PR move the core logic of `_summon_full_params` to `_unshard_params_utils`.
