### PR TITLE
[Dynamo] Fix Tensor.T trace

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -331,7 +331,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
     @make_test
     def test_T(x):
-        return x.T
+        return torch.ones_like(x.T)
 
     @make_test
     def test_is_sparse(x):

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -330,6 +330,10 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             return x + 1
 
     @make_test
+    def test_T(x):
+        return x.T
+
+    @make_test
     def test_is_sparse(x):
         if not x.is_sparse:
             return x + 1

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -442,7 +442,6 @@ class TensorVariable(VariableTracker):
             args = [variables.ConstantVariable(i) for i in range(self.ndim - 1, -1, -1)]
             result = self.call_method(tx, "permute", args, {})
 
-
         if name == "__class__":
             return TorchVariable(self.python_type(), **options)
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -438,6 +438,10 @@ class TensorVariable(VariableTracker):
             result = self.call_method(tx, "size", [], {})
         elif name == "ndim" and self.ndim is None:
             result = self.call_method(tx, "dim", [], {})
+        elif name == "T":
+            args = [variables.ConstantVariable(i) for i in range(len(self.size) - 1, -1, -1)]
+            result = self.call_method(tx, "permute", args, {})
+
 
         if name == "__class__":
             return TorchVariable(self.python_type(), **options)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -439,7 +439,7 @@ class TensorVariable(VariableTracker):
         elif name == "ndim" and self.ndim is None:
             result = self.call_method(tx, "dim", [], {})
         elif name == "T":
-            args = [variables.ConstantVariable(i) for i in range(len(self.size) - 1, -1, -1)]
+            args = [variables.ConstantVariable(i) for i in range(self.ndim - 1, -1, -1)]
             result = self.call_method(tx, "permute", args, {})
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88642

Summary:

Tensor.T considered T as a GetAttr and didn't progate "example_value"

Via https://pytorch.org/docs/stable/tensors.html#torch.Tensor.T
> If n is the number of dimensions in x, x.T is equivalent to
> x.permute(n-1, n-2, ..., 0).

Fixes pytorch/torchdynamo#1476

Test Plan:

pytest test/dynamo/test_functions.py::FunctionTests::test_T

Reviewers:

Subscribers:

Tasks:

Tags:

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire

Differential Revision: [D41130306](https://our.internmc.facebook.com/intern/diff/D41130306)