### PR TITLE
Dynamo DDP accuracy bench uses find_unused_parameters

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1069,7 +1069,7 @@ class BenchmarkRunner:
         def deepcopy_and_maybe_ddp(model):
             model = copy.deepcopy(model)
             if self.args.ddp:
-                model = DDP(model)
+                model = DDP(model, find_unused_parameters=True)
             return model
 
         # Collect the fp64 reference outputs to be used later for accuracy checking.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88523
* __->__ #88645

- find_unused_parameters adds a slight overhead, but is required
  in cases where users do not manually specify parameters to ignore
  which will not receive grads.  In some models, some parameters
  do not receive grads, and this causes DDP to throw an exception
  as it waits for a grad for each parameter

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire