### PR TITLE
[ONNX] Extra support for bernoulli export

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2643,6 +2643,23 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         x = torch.empty(2, 3, 3, dtype=torch.double).uniform_(0, 1)
         self.run_test(Bernoulli(), x)
 
+    def test_bernoulli_p(self):
+        class Bernoulli_float(torch.nn.Module):
+            def forward(self, x):
+                return torch.mul(x, torch.bernoulli(x, 0.2).size(0))
+
+        class Bernoulli_tensor(torch.nn.Module):
+            def forward(self, x):
+                return torch.mul(x, torch.rand_like(x).bernoulli_(x).size(0))
+
+        x = torch.rand(3, 3)
+        self.run_test(Bernoulli_float(), x)
+        self.run_test(Bernoulli_tensor(), x)
+
+        x = torch.rand(2, 3, 3, dtype=torch.double)
+        self.run_test(Bernoulli_float(), x)
+        self.run_test(Bernoulli_tensor(), x)
+
     @unittest.skip("Bug in ORT, skip test until rel-1.11.")
     @skipIfUnsupportedMinOpsetVersion(14)
     def test_reshape_allowzero(self):

--- a/torch/onnx/symbolic_opset15.py
+++ b/torch/onnx/symbolic_opset15.py
@@ -54,6 +54,22 @@ def aten__isnot_(g: jit_utils.GraphContext, self, other):
     return aten__is_(g, self, other)
 
 
+@_onnx_symbolic("aten::bernoulli")
+@_beartype.beartype
+def bernoulli(g: jit_utils.GraphContext, input, tensor_or_prob=None, generator=None, out=None):
+    if out is not None and not symbolic_helper._is_none(out):
+        symbolic_helper._unimplemented(
+            "Bernoulli", "out parameter is not supported for bernoulli", input
+        )
+    if generator is not None and not symbolic_helper._is_none(generator):
+        symbolic_helper._unimplemented(
+            "Bernoulli", "generator is not supported for bernoulli", input
+        )
+    if tensor_or_prob is None or symbolic_helper._is_none(tensor_or_prob):
+        return g.op("Bernoulli", input)
+    return opset9.bernoulli(g, input, tensor_or_prob, generator, out)
+
+
 @_onnx_symbolic("prim::unchecked_cast")
 @_beartype.beartype
 def prim_unchecked_cast(g: jit_utils.GraphContext, self):

--- a/torch/onnx/symbolic_opset15.py
+++ b/torch/onnx/symbolic_opset15.py
@@ -56,7 +56,7 @@ def aten__isnot_(g: jit_utils.GraphContext, self, other):
 
 @_onnx_symbolic("aten::bernoulli")
 @_beartype.beartype
-def bernoulli(g: jit_utils.GraphContext, input, tensor_or_prob=None, generator=None, out=None):
+def bernoulli(g: jit_utils.GraphContext, input, p=None, generator=None, out=None):
     if out is not None and not symbolic_helper._is_none(out):
         symbolic_helper._unimplemented(
             "Bernoulli", "out parameter is not supported for bernoulli", input
@@ -65,9 +65,9 @@ def bernoulli(g: jit_utils.GraphContext, input, tensor_or_prob=None, generator=N
         symbolic_helper._unimplemented(
             "Bernoulli", "generator is not supported for bernoulli", input
         )
-    if tensor_or_prob is None or symbolic_helper._is_none(tensor_or_prob):
+    if p is None or symbolic_helper._is_none(p):
         return g.op("Bernoulli", input)
-    return opset9.bernoulli(g, input, tensor_or_prob, generator, out)
+    return opset9.bernoulli(g, input, p, generator, out)
 
 
 @_onnx_symbolic("prim::unchecked_cast")

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -4942,8 +4942,8 @@ def rrelu(g: jit_utils.GraphContext, input, lower, upper, training, generator):
 
 @_onnx_symbolic("aten::bernoulli")
 @_beartype.beartype
-def bernoulli(g: jit_utils.GraphContext, input, generator=None, out=None):
-    if out is not None:
+def bernoulli(g: jit_utils.GraphContext, input, tensor_or_prob=None, generator=None, out=None):
+    if out is not None and not symbolic_helper._is_none(out):
         symbolic_helper._unimplemented(
             "Bernoulli", "out parameter is not supported for bernoulli", input
         )
@@ -4967,7 +4967,10 @@ def bernoulli(g: jit_utils.GraphContext, input, generator=None, out=None):
         low_f=0.0,
         dtype_i=dtype.onnx_type(),
     )
-    output = g.op("Less", p, input)
+    if tensor_or_prob is not None and not symbolic_helper._is_none(tensor_or_prob):
+        output = g.op("Less", p, tensor_or_prob)
+    else:
+        output = g.op("Less", p, input)
     return g.op("Cast", output, to_i=dtype.onnx_type())
 
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -4942,7 +4942,7 @@ def rrelu(g: jit_utils.GraphContext, input, lower, upper, training, generator):
 
 @_onnx_symbolic("aten::bernoulli")
 @_beartype.beartype
-def bernoulli(g: jit_utils.GraphContext, input, tensor_or_prob=None, generator=None, out=None):
+def bernoulli(g: jit_utils.GraphContext, input, p=None, generator=None, out=None):
     if out is not None and not symbolic_helper._is_none(out):
         symbolic_helper._unimplemented(
             "Bernoulli", "out parameter is not supported for bernoulli", input
@@ -4960,17 +4960,15 @@ def bernoulli(g: jit_utils.GraphContext, input, tensor_or_prob=None, generator=N
             "Bernoulli", "input dtype not accessible", input
         )
 
-    p = g.op(
+    rands = g.op(
         "RandomUniformLike",
         input,
         high_f=1.0,
         low_f=0.0,
         dtype_i=dtype.onnx_type(),
     )
-    if tensor_or_prob is not None and not symbolic_helper._is_none(tensor_or_prob):
-        output = g.op("Less", p, tensor_or_prob)
-    else:
-        output = g.op("Less", p, input)
+    prob = p if p is not None and not symbolic_helper._is_none(p) else input
+    output = g.op("Less", rands, prob)
     return g.op("Cast", output, to_i=dtype.onnx_type())
 
 


### PR DESCRIPTION
* add opset 15 support for `bernoulli`.
* add extra export options for different `bernoulli` cases: `x.bernoulli(p)` where `p` is a tensor or float.

Fixes #88299
