### PR TITLE
Correctly test that dtype/device match in generated .out kernels for composites

### DIFF
--- a/aten/src/ATen/templates/CompositeViewCopyKernels.cpp
+++ b/aten/src/ATen/templates/CompositeViewCopyKernels.cpp
@@ -30,16 +30,24 @@ std::vector<at::Tensor> clone_arg(const at::TensorList& t_list) {
     return out;
 }
 
+// duped with gen_resize_out_helper from structured kernels
 void copy_arg(const at::Tensor& dst, const at::Tensor& src) {
+    TORCH_CHECK(src.dtype() == dst.dtype(),
+        "Expected out tensor to have dtype ", src.dtype(), ", but got ", dst.dtype(), " instead");
+    TORCH_CHECK(src.device() == dst.device(),
+        "Expected out tensor to have device ", src.device(), ", but got ", dst.device(), " instead");
     dst.copy_(src);
 }
 
 void copy_arg(const at::TensorList& dst, const at::TensorList& src) {
     TORCH_INTERNAL_ASSERT(dst.size() == src.size());
     for (const auto& i : c10::irange(dst.size())) {
-        dst[i].copy_(src[i]);
+        copy_arg(dst[i], src[i]);
     }
 }
+
+// TODO: this doesn't handle restriding empty tensors correctly; see
+// gen_resize_out_helper for the correct algorithm
 
 void resize_out_helper(const at::Tensor& dst, const at::Tensor& src) {
     at::native::resize_output(dst, src.sizes());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88671
* __->__ #88672

Signed-off-by: Edward Z. Yang <ezyang@fb.com>