### PR TITLE
Run libtorch trunk build on linux.4xlarge

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -34,6 +34,12 @@ on:
         default: "5.2"
         description: |
           List of CUDA architectures CI build should target.
+      runner:
+        required: false
+        type: string
+        default: "linux.2xlarge"
+        description: |
+          List of CUDA architectures CI build should target.
 
       test-matrix:
         required: false
@@ -55,7 +61,7 @@ jobs:
   build:
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
-    runs-on: [self-hosted, linux.2xlarge]
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 240
     outputs:
       docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -111,6 +111,7 @@ jobs:
       build-environment: libtorch-linux-bionic-cuda11.6-py3.7-gcc7
       docker-image-name: pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7
       build-generates-artifacts: false
+      runner: linux.4xlarge
 
   # no-ops builds test USE_PER_OPERATOR_HEADERS=0 where ATen/ops is not generated
   linux-bionic-cuda11_7-py3_10-gcc7-no-ops-build:


### PR DESCRIPTION
Add optional `runner`  input to `_linux-build.yml`
Move `libtorch-linux-bionic-cuda11_6-py3_7-gcc7-build` to `linux.4xlarge` as it occasionally OOMS on 2xlarge one

