### PR TITLE
Fix TorchInductor benchmarking in fbcode

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -22,7 +22,7 @@ import torch
 import torch._dynamo
 import torch._dynamo.utils
 import torch.distributed
-from microbenchmarks.operator_inp_utils import OperatorInputsMode
+from functorch._src.aot_autograd import set_model_name
 from scipy.stats import gmean, ttest_ind
 from torch._dynamo.optimizations import backends
 from torch._dynamo.optimizations.log_args import conv_args_analysis
@@ -36,11 +36,9 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils._pytree import tree_map
 
 try:
-    from functorch._src.aot_autograd import set_model_name
+    from .microbenchmarks.operator_inp_utils import OperatorInputsMode
 except ImportError:
-
-    def set_model_name(name):
-        pass
+    from microbenchmarks.operator_inp_utils import OperatorInputsMode
 
 
 log = logging.getLogger(__name__)
@@ -1308,8 +1306,7 @@ def help(fn):
     return fn.__doc__
 
 
-def parse_args():
-
+def parse_args(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--filter", "-k", action="append", help="filter benchmarks with regexp"
@@ -1330,7 +1327,10 @@ def parse_args():
         default=0,
         help="ID of the benchmark suite partition to be run. Used to divide CI tasks",
     )
-    parser.add_argument("--devices", "-d", action="append", help="cpu or cuda")
+    parser.add_argument(
+        "--devices", "--device", "-d", action="append", help="cpu or cuda"
+    )
+    parser.add_argument("--device-index", help="CUDA device index")
     parser.add_argument(
         "--repeat", "-n", type=int, default=30, help="number of timing runs"
     )
@@ -1567,8 +1567,7 @@ def parse_args():
     mode_group.add_argument(
         "--performance", action="store_true", help="Measures performance speedup"
     )
-    args = parser.parse_args()
-    return args
+    return parser.parse_args(args)
 
 
 def main(runner, original_dir=None):
@@ -1636,10 +1635,13 @@ def run(runner, args, original_dir=None):
 
         # Some models e.g. yolov3 assert batch size on n_gpus
         if "CUDA_VISIBLE_DEVICES" not in os.environ:
-            os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+            args.device_index = "0"
 
         # Stricter check to disable fallbacks
         args.suppress_errors = False
+
+    if args.device_index is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = args.device_index
 
     elif args.performance:
         # Ensure that we test on real scenarios

--- a/benchmarks/dynamo/test.py
+++ b/benchmarks/dynamo/test.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+
+from .common import parse_args, run
+
+from .torchbench import setup_torchbench_cwd, TorchBenchmarkRunner
+
+
+class TestDynamoBenchmark(unittest.TestCase):
+    def test_benchmark_infra_runs(self) -> None:
+        """
+        Basic smoke test that TorchBench runs.
+
+        This test is mainly meant to check that our setup in fbcode
+        doesn't break.
+
+        If you see a failure here related to missing CPP headers, then
+        you likely need to update the resources list in:
+            //caffe2:inductor
+        """
+        original_dir = setup_torchbench_cwd()
+        try:
+            args = parse_args(
+                [
+                    "-dcpu",
+                    "--inductor",
+                    "--performance",
+                    "--only=BERT_pytorch",
+                    "-n1",
+                    "--batch_size=1",
+                ]
+            )
+            run(TorchBenchmarkRunner(), args, original_dir)
+        finally:
+            os.chdir(original_dir)

--- a/torch/_inductor/cuda_properties.py
+++ b/torch/_inductor/cuda_properties.py
@@ -11,10 +11,15 @@ import torch
 
 @functools.lru_cache(None)
 def _properties():
-    r = {
-        i: torch.cuda.get_device_properties(i) for i in range(torch.cuda.device_count())
-    }
-    return r
+    if not torch.cuda.is_available():
+        return {}
+    try:
+        return {
+            i: torch.cuda.get_device_properties(i)
+            for i in range(torch.cuda.device_count())
+        }
+    except RuntimeError:
+        return {}
 
 
 _compile_worker_current_device = None

--- a/torch/_inductor/triton_ops/autotune.py
+++ b/torch/_inductor/triton_ops/autotune.py
@@ -213,7 +213,8 @@ def load_cached_autotuning(
     if not os.path.exists(cache_filename):
         return None
 
-    best_config = json.loads(open(cache_filename).read())
+    with open(cache_filename, "r") as fd:
+        best_config = json.loads(fd.read())
     if best_config.get("configs_hash") != configs_hash:
         return None
 


### PR DESCRIPTION
Summary: Makes the C++ TorchInductor benchmarking work in fbcode plus some minor fixed to enable that.

Test Plan: Test added

Differential Revision: D41045910



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire