### PR TITLE
Allows real tensors in FakeTensorProp

### DIFF
--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -35,8 +35,7 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
                 tensor_x = torch.flatten(tensor_x, 1)
                 tensor_x = self.fc1(tensor_x)
                 tensor_x = torch.sigmoid(tensor_x)
-                tensor_x = self.fc2(tensor_x)
-                output = F.log_softmax(tensor_x, dim=1)
+                output = self.fc2(tensor_x)
                 return output
 
         tensor_x = torch.rand((64, 1, 28, 28), dtype=torch.float32)

--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -21,20 +21,20 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
         class MNISTModel(nn.Module):
             def __init__(self):
                 super().__init__()
-                self.conv1 = nn.Conv2d(1, 32, 3, 1, bias=False)
-                self.conv2 = nn.Conv2d(32, 64, 3, 1, bias=False)
-                self.fc1 = nn.Linear(9216, 128, bias=False)
-                self.fc2 = nn.Linear(128, 10, bias=False)
+                self.conv1 = nn.Conv2d(1, 32, 3, 1, bias=True)
+                self.conv2 = nn.Conv2d(32, 64, 3, 1, bias=True)
+                self.fc1 = nn.Linear(9216, 128, bias=True)
+                self.fc2 = nn.Linear(128, 10, bias=True)
 
             def forward(self, tensor_x: torch.Tensor):
                 tensor_x = self.conv1(tensor_x)
-                tensor_x = F.sigmoid(tensor_x)
+                tensor_x = torch.sigmoid(tensor_x)
                 tensor_x = self.conv2(tensor_x)
-                tensor_x = F.sigmoid(tensor_x)
+                tensor_x = torch.sigmoid(tensor_x)
                 tensor_x = F.max_pool2d(tensor_x, 2)
                 tensor_x = torch.flatten(tensor_x, 1)
                 tensor_x = self.fc1(tensor_x)
-                tensor_x = F.sigmoid(tensor_x)
+                tensor_x = torch.sigmoid(tensor_x)
                 tensor_x = self.fc2(tensor_x)
                 output = F.log_softmax(tensor_x, dim=1)
                 return output

--- a/torch/fx/passes/fake_tensor_prop.py
+++ b/torch/fx/passes/fake_tensor_prop.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch.fx
 from torch.fx import Node
 from torch.fx._compatibility import compatibility
@@ -17,7 +19,13 @@ class FakeTensorProp(torch.fx.Interpreter):
 
     Args:
          module (GraphModule): The module to be executed
+         mode (Optional[FakeTensorMode]): The dispatch mode used to execute computation indicated by each FX Node.
     """
+    def __init__(self, module: torch.fx.GraphModule, mode: Optional[FakeTensorMode] = None):
+        super().__init__(module)
+        if mode is None:
+            mode = FakeTensorMode()
+        self._mode = mode
 
     def run_node(self, n: Node):
         result = super().run_node(n)
@@ -25,6 +33,6 @@ class FakeTensorProp(torch.fx.Interpreter):
         return result
 
     def propagate(self, *args):
-        with FakeTensorMode.push() as mode:
-            fake_args = [mode.from_tensor(a) for a in args]
+        with self._mode:
+            fake_args = [self._mode.from_tensor(a) for a in args]
             return super().run(*fake_args)

--- a/torch/onnx/_internal/_fx.py
+++ b/torch/onnx/_internal/_fx.py
@@ -220,11 +220,11 @@ def _export_fx_to_ts(fx_module_with_metadata):
             def register_outputs(
                 ts_outputs: Union[torch._C.Value, Tuple[torch._C.Value, ...]]
             ):
-                if isinstance(ts_outputs, tuple):
+                if isinstance(ts_outputs, torch._C.Value):
+                    g.registerOutput(ts_outputs)
+                else:
                     for ts_output in ts_outputs:
                         g.registerOutput(ts_output)
-                else:
-                    g.registerOutput(ts_outputs)
 
             if isinstance(node.args[0], torch.fx.Node):
                 ts_value_or_ts_value_tuple = fx_name_to_ts_value[node.args[0].name]
@@ -293,8 +293,10 @@ def _export(
         decomposition_table = torch._decomp.decomposition_table
     # Apply decomposition table to the input graph.
     decomposed_module = functorch.make_fx(module, decomposition_table)(*args)
-    decomposed_module.print_readable()
 
+    # Use this mode to
+    # 1. convert nn.Parameter's in nn.Module to FakeTensor
+    # 2. run FakeTensorProp
     fake_tensor_mode = FakeTensorMode()
 
     def to_fake_tensor(x):
@@ -302,12 +304,14 @@ def _export(
             return fake_tensor_mode.from_tensor(x)
         return x
 
+    # "args" are FakeTensor in FakeTensorProp so the parameters and buffers
+    # in model must be converted to FakeTensor as well.
     fake_parameters_and_buffers = {
         k: to_fake_tensor(v)
         for k, v in itertools.chain(module.named_parameters(), module.named_buffers())
     }
-    decomposed_module.print_readable()
 
+    # Shape inference via FakeTensorProp
     with stateless._reparametrize_module(
         decomposed_module, fake_parameters_and_buffers
     ):
@@ -315,10 +319,7 @@ def _export(
         # TODO(wechi): It's possible to get symbolic types (and shapes)
         # for each node's output. Consider to set "tracing_mode=symbolic"
         # when calling make_fx and then remove FakeTensorProp below.
-        if isinstance(args, tuple):
-            FakeTensorProp(decomposed_module).propagate(*args)
-        else:
-            FakeTensorProp(decomposed_module).propagate(*args)
+        FakeTensorProp(decomposed_module, fake_tensor_mode).propagate(*args)
 
     ts_graph, ts_initializers = _export_fx_to_ts(decomposed_module)
     # Export TorchScript graph to ONNX ModelProto.

--- a/torch/onnx/_internal/_fx.py
+++ b/torch/onnx/_internal/_fx.py
@@ -208,7 +208,7 @@ def _export_fx_to_ts(fx_module_with_metadata):
                 v = symbolic_fn(graph_context, *ts_args)
                 assert (
                     v is not None
-                ), f"Node creates None with target={node.target} and name={node.name}"
+                ), f"Node creates None with target={node.target}, name={node.name}, args={ts_args}"
                 # One fx node could produce multiple outputs (e.g., tuple of tensors); in
                 # that case, v is a tuple of TorchScript values.
                 fx_name_to_ts_value[node.name] = v

--- a/torch/onnx/_internal/_fx.py
+++ b/torch/onnx/_internal/_fx.py
@@ -172,6 +172,9 @@ def _export_fx_to_ts(fx_module_with_metadata):
             # Input of graph.
             v = g.addInput(node.name)
             v.setType(torch._C.TensorType.create_from_tensor(node.meta["val"]))
+            assert (
+                v is not None
+            ), f"Node creates None with target={node.target} and name={node.name}"
             fx_name_to_ts_value[node.name] = v
         elif node.op == "call_function":
             # aten ops and other statless functions.
@@ -203,6 +206,9 @@ def _export_fx_to_ts(fx_module_with_metadata):
                 )
                 # The returned value could be a value of a tuple of values.
                 v = symbolic_fn(graph_context, *ts_args)
+                assert (
+                    v is not None
+                ), f"Node creates None with target={node.target} and name={node.name}"
                 # One fx node could produce multiple outputs (e.g., tuple of tensors); in
                 # that case, v is a tuple of TorchScript values.
                 fx_name_to_ts_value[node.name] = v
@@ -210,6 +216,9 @@ def _export_fx_to_ts(fx_module_with_metadata):
                 ts_value_tuple = fx_name_to_ts_value[node.args[0].name]
                 assert isinstance(ts_value_tuple, tuple)
                 v = ts_value_tuple[node.args[1]]
+                assert (
+                    v is not None
+                ), f"Node creates None with target={node.target} and name={node.name}"
                 fx_name_to_ts_value[node.name] = v
             else:
                 raise RuntimeError(
@@ -224,6 +233,9 @@ def _export_fx_to_ts(fx_module_with_metadata):
                     g.registerOutput(ts_outputs)
                 else:
                     for ts_output in ts_outputs:
+                        assert isinstance(
+                            ts_output, torch._C.Value
+                        ), f"ts_output must be a torch._C.Value, not {type(ts_output)}"
                         g.registerOutput(ts_output)
 
             if isinstance(node.args[0], torch.fx.Node):
@@ -231,6 +243,9 @@ def _export_fx_to_ts(fx_module_with_metadata):
                 register_outputs(ts_value_or_ts_value_tuple)
             else:
                 for arg in node.args[0]:
+                    assert isinstance(
+                        arg, torch.fx.Node
+                    ), f"ts_output must be a torch.fx.Node, not {type(arg)}"
                     ts_value_or_ts_value_tuple = fx_name_to_ts_value[arg.name]
                     register_outputs(ts_value_or_ts_value_tuple)
         elif node.op == "call_method":
@@ -255,6 +270,9 @@ def _export_fx_to_ts(fx_module_with_metadata):
 
             v = g.addInput(node.name)
             v.setType(torch._C.TensorType.create_from_tensor(current_attr))
+            assert (
+                v is not None
+            ), f"Node creates None with target={node.target} and name={node.name}"
             fx_name_to_ts_value[node.name] = v
             ts_name_to_real_tensor[v.debugName()] = current_attr
         else:


### PR DESCRIPTION
When turning on the `bias=True` for `nn.Linear`, the underlying `aten::addmm` generates real tensors during `FakeTensorProp` and throws. I tried converting that tensor to `FakeTensor` using `FakeTensorMode.from_tensor` and my test just passes. I am not sure if this is good so I also open #88700 against PyTorch master branch to see if Meta likes it.