### PR TITLE
Mark dynamo torchbench dlrm as unsupported

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1618,7 +1618,9 @@ def run(runner, args, original_dir=None):
             # TODO(whc) after enabling DDPOptimizer by default this could be removed or assert
             torch._dynamo.config.optimize_ddp = True
         if args.only == "dlrm":
-            log.error("DLRM+DDP is unsupported as it requires sharding the embedding layer separately from DDP")
+            log.error(
+                "DLRM+DDP is unsupported as it requires sharding the embedding layer separately from DDP"
+            )
             return sys.exit(-1)
     if args.accuracy:
         # Use small batch size. We use >1 batch size to ensure we test

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1617,7 +1617,9 @@ def run(runner, args, original_dir=None):
         else:
             # TODO(whc) after enabling DDPOptimizer by default this could be removed or assert
             torch._dynamo.config.optimize_ddp = True
-
+        if args.only == "dlrm":
+            log.error("DLRM+DDP is unsupported as it requires sharding the embedding layer separately from DDP")
+            return sys.exit(-1)
     if args.accuracy:
         # Use small batch size. We use >1 batch size to ensure we test
         # batch_norm type of operators that work on batch dims.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88523
* __->__ #88712
* #88645

- DLRM requires special configuration of embedding layers which are sparse
  and not compatible with DDP.
- I could mark the embedding params as ignored in DDP
  to make the benchmark pass, but this isn't a representative benchmark.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire