### PR TITLE
Fix inline ignored warning in layer_norm_kernel.cu

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -283,7 +283,7 @@ __device__ __inline__ void vectorized_layer_norm_kernel_impl(
 
 //to avoid windows SFINAE errors
 template <typename T, typename T_ACC>
-__global__ __inline__ void vectorized_layer_norm_kernel(
+__global__ void vectorized_layer_norm_kernel(
   const int N,
   T_ACC eps,
   const  T* __restrict__ X,


### PR DESCRIPTION
Fixes
```
[1852/2212] Building CUDA object caffe2/CMakeFiles/torch_cuda.dir/__/aten/src/ATen/native/cuda/layer_norm_kernel.cu.o
/home/rbarnes/pytorch/aten/src/ATen/native/cuda/layer_norm_kernel.cu(286): warning: inline qualifier ignored for "__global__" function
```