### PR TITLE
Use cstdint in CUDAMiscFunctions; fix spacing

### DIFF
--- a/c10/cuda/CUDAMiscFunctions.cpp
+++ b/c10/cuda/CUDAMiscFunctions.cpp
@@ -1,18 +1,19 @@
 #include <c10/cuda/CUDAMiscFunctions.h>
-#include <stdlib.h>
+
+#include <cstdint>
 
 namespace c10 {
 namespace cuda {
 
 const char* get_cuda_check_suffix() noexcept {
-  static char* device_blocking_flag = getenv("CUDA_LAUNCH_BLOCKING");
+  static char* device_blocking_flag = std::getenv("CUDA_LAUNCH_BLOCKING");
   static bool blocking_enabled =
-      (device_blocking_flag && atoi(device_blocking_flag));
+      (device_blocking_flag && std::atoi(device_blocking_flag));
   if (blocking_enabled) {
     return "";
   } else {
     return "\nCUDA kernel errors might be asynchronously reported at some"
-           " other API call,so the stacktrace below might be incorrect."
+           " other API call, so the stacktrace below might be incorrect."
            "\nFor debugging consider passing CUDA_LAUNCH_BLOCKING=1.";
   }
 }


### PR DESCRIPTION
Fixes:
```
inclusion of deprecated C++ header 'stdlib.h'; consider using 'cstdlib' instead
```
Also fixes bad grammar:
```
call,so the
```