### PR TITLE
Handle the case when a derived SymNodeImpl does not extend PythonSymNodeImpl.

### DIFF
--- a/torch/csrc/utils/pybind.cpp
+++ b/torch/csrc/utils/pybind.cpp
@@ -27,13 +27,14 @@ py::handle type_caster<c10::SymInt>::cast(
   if (si.is_symbolic()) {
     // TODO: generalize this to work with C++ backed class
     
-    // if it's not a python sym node impl, ask pybind11 to cast symnode to pyobject
     auto* py_node =
           dynamic_cast<torch::impl::PythonSymNodeImpl*>(si.toSymNodeImpl().get());
     pybind11::handle pyObj;
     if (py_node != nullptr) {
       pyObj = py_node->getPyObj();
     }else {
+      // If it's not a python sym node impl, ask pybind11 to cast symnode to
+      // pyobject.
       pyObj = py::cast(si.toSymNodeImpl().get()).release().ptr();
     }
     

--- a/torch/csrc/utils/python_symnode.h
+++ b/torch/csrc/utils/python_symnode.h
@@ -27,6 +27,7 @@ namespace impl {
 // this is just an adapter so C++ calls can get to the object.
 class PythonSymNodeImpl : public c10::SymNodeImpl {
  public:
+  PythonSymNodeImpl() = default;
   PythonSymNodeImpl(py::object pyobj) : c10::SymNodeImpl() {
     pyobj_ = std::make_shared<c10::SafePyObject>(
         pyobj.release().ptr(), getPyInterpreter());

--- a/torch/csrc/utils/python_symnode.h
+++ b/torch/csrc/utils/python_symnode.h
@@ -27,7 +27,6 @@ namespace impl {
 // this is just an adapter so C++ calls can get to the object.
 class PythonSymNodeImpl : public c10::SymNodeImpl {
  public:
-  PythonSymNodeImpl() = default;
   PythonSymNodeImpl(py::object pyobj) : c10::SymNodeImpl() {
     pyobj_ = std::make_shared<c10::SafePyObject>(
         pyobj.release().ptr(), getPyInterpreter());


### PR DESCRIPTION
Fixes [#ISSUE_NUMBER](https://github.com/pytorch/xla/issues/4171)

This is to make PyTorch/XLA [PR](https://github.com/pytorch/xla/pull/4180) compile.
