### PR TITLE
[xnnpack][lite-int][on-device] rebuild serialized modules at runtime

### DIFF
--- a/test/jit/xnnpack/test_xnnpack_delegate.py
+++ b/test/jit/xnnpack/test_xnnpack_delegate.py
@@ -91,7 +91,7 @@ class TestXNNPackBackend(unittest.TestCase):
             add_module,
             {
                 "forward": {
-                    "inputs" : [sample_inputs[0], sample_inputs[1]],
+                    "inputs" : [sample_inputs[0].clone(), sample_inputs[1].clone()],
                     "outputs": [sample_output]
                 }
             }

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
@@ -1,14 +1,26 @@
+#include <ATen/Functions.h>
 #include <ATen/Utils.h>
 #include <c10/core/TensorImpl.h>
 #include <torch/csrc/jit/backends/backend.h>
 #include <torch/csrc/jit/backends/backend_exception.h>
 
-#include <xnnpack.h>
+#include <caffe2/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h>
+#include <torch/csrc/jit/backends/xnnpack/serialization/schema_generated.h>
 
 namespace torch {
 namespace jit {
 namespace xnnpack {
 namespace delegate {
+
+class XNNModelWrapper : public CustomClassHolder {
+ public:
+  XNNExecutor executor_;
+  XNNModelWrapper(XNNExecutor executor) : executor_(std::move(executor)){};
+
+  XNNModelWrapper() = delete;
+
+  XNNModelWrapper(const XNNModelWrapper& oldObject) = delete;
+};
 
 class XNNPackBackend : public PyTorchBackendInterface {
  public:
@@ -26,9 +38,27 @@ class XNNPackBackend : public PyTorchBackendInterface {
       c10::IValue processed,
       c10::impl::GenericDict method_compile_spec) override {
     auto dict = processed.toGenericDict();
+
+    // Compiling and wrapping exeuction object
+    std::string ser_model = dict.at("ser_model").toStringRef();
+    XNNExecutor executor = XNNCompiler::compileModel(ser_model);
+
+    auto model_ptr = c10::make_intrusive<XNNModelWrapper>(std::move(executor));
+    auto runtime_handle = IValue::make_capsule(model_ptr);
+    auto wrapper = c10::static_intrusive_pointer_cast<XNNModelWrapper>(
+        runtime_handle.toCapsule());
+
+    // Packing outputs into generic dict
     c10::Dict<c10::IValue, c10::IValue> handles(
         c10::StringType::get(), c10::AnyType::get());
-    handles.insert("forward", dict);
+
+    c10::Dict<c10::IValue, c10::IValue> ret(
+        c10::StringType::get(), c10::AnyType::get());
+
+    ret.insert("runtime", runtime_handle);
+    ret.insert("output_shapes", dict.at("outputs"));
+
+    handles.insert("forward", ret);
 
     return handles;
   }
@@ -41,9 +71,39 @@ class XNNPackBackend : public PyTorchBackendInterface {
   c10::impl::GenericList execute(
       c10::IValue handle,
       c10::impl::GenericList inputs) override {
-    auto answer = handle.toGenericDict().at("Answer");
+    auto dict = handle.toGenericDict();
+    auto output_shapes = dict.at("output_shapes").toList();
 
-    return answer.toList();
+    auto capsule = dict.at("runtime").toCapsule();
+    auto model_wrapper =
+        c10::static_intrusive_pointer_cast<XNNModelWrapper>(capsule);
+
+    XNNExecutor& executor = model_wrapper->executor_;
+
+    std::vector<float*> input_pointers;
+    for (int i = 0; i < inputs.size(); ++i) {
+      at::IValue val = inputs.get(i);
+      TORCH_CHECK(val.isTensor(), "Non-tensor inputs not supported");
+      input_pointers.push_back(val.toTensor().data_ptr<float>());
+    }
+
+    std::vector<at::Tensor> output_tensors;
+    std::vector<float*> output_pointers;
+    output_tensors.reserve(output_shapes.size());
+    for (int i = 0; i < output_shapes.size(); i++) {
+      auto o_shape = output_shapes.get(i).toIntVector();
+      auto output = at::empty(o_shape, c10::ScalarType::Float);
+      output_tensors.push_back(output);
+      output_pointers.push_back(output.data_ptr<float>());
+    }
+
+    TORCH_CHECK(
+        executor.set_inputs(input_pointers, output_pointers),
+        "Number of inputs/outputs does not match expected number of inputs/outputs");
+    TORCH_CHECK(executor.forward(), "Failed to invoke XNNPack runtime");
+
+    c10::List<at::Tensor> output_list(output_tensors);
+    return c10::impl::toList(output_list);
   }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88780
* #88779
* #88778

This is the on-device runtime work. We modify the compile and execute from our hacky solution from before to what will actually be running at runtime.

First we rebuild our graph from the serialized flatbuffer string. We also introduce a runtime wrapper that inherits CustomClassHolder that allows us to forward along the built xnngraph runtime to our execute function

Once the subgraph object has been rebuilt by our we pass it along to the runtime wrapper for us to forward along to execute

At execute we prep the input/outputs and invoke the runtime using our runtime wrapper. Finally we forward those results to our execution

Differential Revision: [D39413031](https://our.internmc.facebook.com/intern/diff/D39413031/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D39413031/)!