### PR TITLE
Do not flag models in dashboard due to NaN values

### DIFF
--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -121,15 +121,15 @@ DASHBOARD_DEFAULTS = {
 
 
 def flag_speedup(x):
-    return pd.isna(x) or x < 0.95
+    return x < 0.95
 
 
 def flag_compilation_latency(x):
-    return pd.isna(x) or x == 0 or x > 120
+    return x > 120
 
 
 def flag_compression_ratio(x):
-    return pd.isna(x) or x < 0.9
+    return x < 0.9
 
 
 FLAG_FNS = {


### PR DESCRIPTION
Title.

Tested by running `python benchmarks/dynamo/runner.py --output-dir ../test-dynamo-runner-logs-4 --training --visualize_logs` on a copy of a recent set of logs.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire