### PR TITLE
[ONNX] Fix ListType infer shape and type for input in Scripting

### DIFF
--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -459,9 +459,7 @@ static TypePtr inferShapeAndTypeForInput(
     }
     return TupleType::create(types);
   } else if (auto list_type = input_type->cast<ListType>()) {
-    const TypePtr& sub_type = list_type->getElementType();
-    auto elem_type =
-        inferShapeAndTypeForInput(sub_type, s_iter, s_iter_end, complete);
+    const TypePtr& elem_type = list_type->getElementType();
     return ListType::create(elem_type);
   } else if (auto tensor_type = input_type->cast<TensorType>()) {
     auto type = getTensorType(s_iter->toTensor(), complete);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88797
* __->__ #88796

With the previous logic, ListType seems to be capturing the first element in input list, leading to a wrong type of input.

Fix #81388 

