### PR TITLE
[nnc] Disable opaque pointers mode in LLVM backend to allow getPointerElementType

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -446,6 +446,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
       irb_(getContext()),
       kernel_func_name_(std::move(kernel_func_name)),
       bufsExtAlloc_(ExternalAllocBufFinder::find(stmt)) {
+  context_->setOpaquePointers(false);
   if (!triple) {
     triple = LLVMTargetTriple();
   }

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -446,7 +446,9 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
       irb_(getContext()),
       kernel_func_name_(std::move(kernel_func_name)),
       bufsExtAlloc_(ExternalAllocBufFinder::find(stmt)) {
+#if LLVM_VERSION_MAJOR >= 15
   context_->setOpaquePointers(false);
+#endif
   if (!triple) {
     triple = LLVMTargetTriple();
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88798

As of LLVM 15 typed pointers are going away:
https://llvm.org/docs/OpaquePointers.html.  Thus
`getPointerElementType` is no longer legal, since pointers are all
opaque.  I don't totally remember why we use it so prolifically, or
whether there's an easy change to get rid of it, or whether we'd need
a significant refactor to carry around `Type`s alongside `Value`s.

But in any case, NNC is deprecated (see: TorchInductor) and will
hopefully be gone before LLVM 16 is a thing.  For now, we can apply
the hack of turning off opaque pointer mode on the LLVMContext.

Differential Revision: [D41176215](https://our.internmc.facebook.com/intern/diff/D41176215)

cc @EikanWang @jgong5