### PR TITLE
[inductor] Remove import check for fast_flush

### DIFF
--- a/torch/_inductor/triton_ops/autotune.py
+++ b/torch/_inductor/triton_ops/autotune.py
@@ -132,14 +132,9 @@ class CachingAutotuner(KernelInterface):
                 stream=stream,
             )
 
-        import inspect
-
         from triton.testing import do_bench
 
-        if "fast_flush" in inspect.signature(do_bench).parameters.keys():
-            return do_bench(kernel_call, rep=40, fast_flush=True)
-        else:
-            return do_bench(kernel_call, rep=40)
+        return do_bench(kernel_call, rep=40, fast_flush=True)
 
     @dynamo_utils.dynamo_timed
     def autotune_to_one_config(self, *args, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88812

https://github.com/pytorch/pytorch/pull/88557/ has a guard to make sure that triton's `do_bench` includes the `fast_flush` argument.  Since we've updated Triton to a sufficiently recent revision, we can remove that guard.

Differential Revision: [D41185280](https://our.internmc.facebook.com/intern/diff/D41185280/)

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire