### PR TITLE
WIP [FSDP+dynamo] failing for hf_Bert

### DIFF
--- a/benchmarks/dynamo/dist_util.py
+++ b/benchmarks/dynamo/dist_util.py
@@ -122,11 +122,15 @@ def fsdp_checkpointing_base(model, blocks):
     )
 
 
-# from transformers.models.t5.modeling_t5 import T5Block
+from transformers.models.bert.modeling_bert import (
+    BertForMaskedLM,
+    BertLayer,
+    BertLMPredictionHead,
+)
 
 MODEL_FSDP_WRAP = {
-    ToyModel: (MyModule,)
-    # TODO T5: (T5Block,)
+    ToyModel: (MyModule,),
+    BertForMaskedLM: (BertLayer, BertLMPredictionHead),
 }
 
 
@@ -143,5 +147,5 @@ def apply_fsdp(model, use_checkpointing=False, use_wrap_policy=True):
     model = FSDP(model, auto_wrap_policy=wrap_policy, use_orig_params=True)
     if use_checkpointing:
         fsdp_checkpointing_base(model, blocks)
-
+    print(model)
     return model

--- a/benchmarks/dynamo/distributed.py
+++ b/benchmarks/dynamo/distributed.py
@@ -158,9 +158,16 @@ if __name__ == "__main__":
     model_arg.add_argument(
         "--toy_model", action="store_true", help="use toy model instead"
     )
+    model_arg.add_argument(
+        "--toy_bert", action="store_true", help="use toy model instead"
+    )
     args = parser.parse_args()
 
-    model_name = "ToyModel" if args.toy_model else args.torchbench_model
+    model_name = args.torchbench_model
+    if args.toy_model:
+        model_name =  "ToyModel"
+    elif args.toy_bert:
+        model_name = "BertLMPredictionHead"
     model, inputs = get_model(args)
 
     fn = partial(run_model, args, model, inputs)

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -877,7 +877,8 @@ def aot_module_simplified(mod: nn.Module, *top_args, **top_kwargs) -> nn.Module:
     :func:`aot_module_simplified` removes these overheads.
     """
     #########################################################
-
+    names ='\n'.join([n for n, _ in mod.named_parameters() if 'cls' in n])
+    print(f"aot_ sees params with cls in name:\n{names}")
     params = {
         **dict(_named_parameters(mod, remove_duplicate=False)),
         **dict(_named_buffers(mod, remove_duplicate=False)),

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -877,8 +877,8 @@ def aot_module_simplified(mod: nn.Module, *top_args, **top_kwargs) -> nn.Module:
     :func:`aot_module_simplified` removes these overheads.
     """
     #########################################################
-    names ='\n'.join([n for n, _ in mod.named_parameters() if 'cls' in n])
-    print(f"aot_ sees params with cls in name:\n{names}")
+    names ='\n'.join([n for n, _ in mod.named_parameters()])
+    print(f"aot_ sees params:\n{names}")
     params = {
         **dict(_named_parameters(mod, remove_duplicate=False)),
         **dict(_named_buffers(mod, remove_duplicate=False)),

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1307,6 +1307,7 @@ class FlatParamHandle:
                         param_var = tensor
                 setattr(module, param_name, param_var)
                 if self._use_orig_params and self._training_state == HandleTrainingState.FORWARD:
+                    print(f"flatparam: {module}:{param_name} updated")
                     module._parameters[param_name] = param_var  # type: ignore[assignment]
         for i, (
             param_name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88821
* #88781
* #88523

    Repro:
    
    With naive FSDP (no recursive wrapping)
    `python benchmarks/dynamo/distributed.py --torchbench_model hf_Bert --fsdp --dynamo aot_eager --world_size=1`
    
    With recursive wrapping - wraps (BertLayer, BertLMPredictionHead) by default, edit benchmarks/dynamo/dist_utils.py MODEL_FSDP_WRAP to customize.
    `python benchmarks/dynamo/distributed.py --torchbench_model hf_Bert --fsdp --dynamo aot_eager --world_size=1 --fsdp_wrap`
    
    Should see an error like
    ```
    Exception: Invoking operators with non-Fake Tensor inputs in FakeTensorMode is not yet supported.
    Please convert all Tensors to FakeTensors first. Found in aten.addmm.default(*(tensor([0., 0., 0.,
    ..., 0., 0., 0.], device='cuda:0',
    ```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire