### PR TITLE
add memory_tracker tool to help profiling memory usages

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,0 +1,67 @@
+# Owner(s): ["oncall: distributed"]
+
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_utils import (
+    TestCase,
+    run_tests,
+)
+
+import torch
+import torch.nn as nn
+
+from torch.distributed._tools import MemoryTracker
+
+import unittest
+
+
+class TestMemoryTracker(TestCase):
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    def test_local_model(self):
+        """
+        Minimal test case to check the memory tracker can collect the expected
+        memory stats at operator level, as well as can print the summary result
+        without crash.
+        """
+        # Create a model with a hierarchy of modules
+        torch.manual_seed(0)
+        model = nn.Sequential(
+            nn.Sequential(
+                nn.Conv2d(3, 64, kernel_size=(3, 3), padding=(1, 1), bias=False),
+                nn.BatchNorm2d(64),
+                nn.ReLU(inplace=False),
+                nn.AdaptiveAvgPool2d(output_size=(1, 1)),
+            ),
+            nn.Flatten(start_dim=1),
+            nn.Sequential(nn.Linear(64, 2), nn.ReLU(inplace=True)),
+        ).cuda()
+
+        # Run one iteration of forward and backward pass
+        tracker = MemoryTracker()
+        tracker.start_monitor(model)
+
+        x = torch.randn(size=(2, 3, 224, 224), device=torch.device("cuda"))
+        # torch.LongTensor expects cpu device type, not cuda device type in
+        # constructor, so calling .cuda() outside constructor here.
+        target = torch.LongTensor([0, 1]).cuda()
+        criterion = nn.CrossEntropyLoss()
+        criterion(model(x), target).backward()
+
+        self.assertTrue(len(tracker._hooks) > 0)
+
+        tracker.stop()
+
+        self.assertTrue(len(tracker._hooks) == 0)
+
+        tracker.summary()
+
+        self.assertTrue(tracker._op_index > 0)
+        self.assertTrue(len(tracker._operator_names) > 0)
+        self.assertEqual(len(tracker.memories_allocated), tracker._op_index)
+        self.assertEqual(len(tracker.memories_active), tracker._op_index)
+        self.assertEqual(len(tracker.memories_reserved), tracker._op_index)
+        self.assertTrue(len(tracker._markers) == 2)
+        self.assertTrue(tracker._cur_module_name != "")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/_tools/__init__.py
+++ b/torch/distributed/_tools/__init__.py
@@ -1,0 +1,1 @@
+from .memory_tracker import MemoryTracker

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -1,0 +1,261 @@
+from collections import defaultdict
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    no_type_check,
+    Sequence,
+)
+
+import torch
+import torch.nn as nn
+from torch.utils.hooks import RemovableHandle
+from torch.utils._python_dispatch import TorchDispatchMode
+
+BYTES_PER_MB = 1024 * 1024.0
+
+
+class MemoryProfileDispatchMode(TorchDispatchMode):
+    """
+    Run in ``TorchDispatchMode`` to get memory stats at operator level.
+    """
+
+    def __init__(self, memory_tracker) -> None:
+        self.memory_tracker = memory_tracker
+
+    def __torch_dispatch__(self, func, types, args=..., kwargs=None):
+        rs = func(*args, **kwargs)
+        if func == torch.ops.aten.detach.default:
+            return rs
+        func_name: str = (
+            self.memory_tracker._cur_module_name
+            + "."
+            + func.__name__
+            + "_"
+            + str(self.memory_tracker._operator_names[func.__name__])
+        )
+        self.memory_tracker._operator_names[func.__name__] = (
+            self.memory_tracker._operator_names[func.__name__] + 1
+        )
+        self.memory_tracker._record_memory_stats(func_name)
+
+        return rs
+
+
+class MemoryTracker:
+    """
+    Collect and plot the memory stats including ``memories_allocated``, ``memories_active``
+    and ``memories_reserved`` at operator level.
+    It also prints a summary for the top 20 operators that generate the most memories.
+
+    Example usage:
+
+        >>> net.cuda()
+        >>> input = input.cuda()
+
+        >>> mem_tracker = MemoryTracker()
+        >>> mem_tracker.start_monitor(net)
+
+        >>> net.zero_grad(True)
+        >>> loss = net(input)
+        >>> if isinstance(loss, dict):
+        >>>    loss = loss['out']
+        >>> loss.sum().backward()
+        >>> net.zero_grad(set_to_none=True)
+
+        >>> mem_tracker.stop()
+        >>> mem_tracker.summary()
+        >>> mem_tracker.show_traces()
+    """
+
+    def __init__(self) -> None:
+        torch._C._log_api_usage_once("torch.distributed.memory_tracker")
+        self._hooks: List[RemovableHandle] = []
+        self._operator_names: Dict[str, int] = defaultdict(int)
+        self.memories_allocated: Dict[int, Dict[str, float]] = defaultdict(
+            lambda: defaultdict(float)
+        )
+        self.memories_active: Dict[int, Dict[str, float]] = defaultdict(
+            lambda: defaultdict(float)
+        )
+        self.memories_reserved: Dict[int, Dict[str, float]] = defaultdict(
+            lambda: defaultdict(float)
+        )
+        self._markers: Dict[str, int] = defaultdict(int)
+        self._cur_module_name: str = ""
+        self._op_index: int = 0
+
+    @no_type_check
+    def start_monitor(self, root_module: nn.Module) -> None:
+        """
+        Register module hooks and entering ``MemoryProfileDispatchMode``, so that
+        operator level memory stats can be tracked during module runtime.
+        """
+        self._clear_state()
+        root_module.__setattr__("_memory_tracker_is_root", True)
+        for name, m in root_module.named_modules():
+            if m is not root_module:
+                m.__setattr__("_memory_tracker_is_root", False)
+            # fused_proxy_group does not support hooks
+            if ".fused_proxy_grouped_embedding_bag" in name:
+                continue
+            # hook ordering with other hooks added by users is not managed, so
+            # the memory stats tracked here may not completely accurate.
+            h1 = m.register_forward_pre_hook(self._create_pre_forward_hook(name))
+            h2 = m.register_forward_hook(self._create_post_forward_hook(name))
+            h3 = m.register_backward_hook(self._create_backward_hook(name))
+            self._hooks.extend([h1, h2, h3])
+        torch.cuda.empty_cache()
+        assert getattr(self, "profile_mode", None) is None
+        self.profile_mode = MemoryProfileDispatchMode(self)
+        self.profile_mode.__enter__()
+
+    @no_type_check
+    def stop(self) -> None:
+        """
+        Remove module hooks and exit ``MemoryProfileDispatchMode`` to stop
+        tracking memory stats at operator level.
+        """
+        for h in self._hooks:
+            h.remove()
+        self._hooks.clear()
+        assert getattr(self, "profile_mode", None) is not None
+        self.profile_mode.__exit__(None, None, None)
+        self.profile_mode = None
+
+    @no_type_check
+    def summary(self, top: int = 20) -> None:
+        """
+        Print out the top operators that generate the most memories. The number
+        of the top operators can be configured.
+        """
+        op_diff: Dict[str, float] = defaultdict(float)
+        op_name, previous_allocated_memory = self.memories_allocated[0]
+        for i in range(1, self._op_index):
+            op_name, current_allocated_memory = self.memories_allocated[i]
+            op_diff[op_name] = current_allocated_memory - previous_allocated_memory
+            previous_allocated_memory = current_allocated_memory
+
+        print("------------------------------------------------")
+        print(f"Top {top} ops that generates memory are:")
+        for k, v in sorted(op_diff.items(), key=lambda item: item[1], reverse=True)[
+            :top
+        ]:
+            print(f"{k}: {v}MB")
+        print("------------------------------------------------")
+
+    @no_type_check
+    def show_traces(self) -> None:
+        """
+        Show the traces of ``memory_allocated``, ``memory_active`` and ``memory_reserved`` at
+        operator level and the marker 'fw_bw_boundary' at the boundary of forward pass
+        and backward pass.
+        """
+        import matplotlib.pyplot as plt
+
+        y_1 = [mb for (name, mb) in self.memories_allocated.values()]
+        y_2 = [mb for (name, mb) in self.memories_active.values()]
+        y_3 = [mb for (name, mb) in self.memories_reserved.values()]
+        min_val = min(y_1 + y_2 + y_3)
+        max_val = max(y_1 + y_2 + y_3)
+        x = list(i for i in range(len(y_1)))
+        fig = plt.figure(figsize=(16, 8))
+        plt.plot(x, list(y_1), label="memory_allocated")
+        plt.plot(x, list(y_2), label="memory_active")
+        plt.plot(x, list(y_3), label="memory_reserved")
+        plt.xlabel("# Operator Calls")
+        plt.ylabel("Memory (MB)")
+        for marker_name, marker in self._markers.items():
+            if marker_name == "fw_bw_boundary":
+                plt.plot(
+                    [marker, marker], [min_val, max_val], "r", lw=2, label=marker_name
+                )
+            else:
+                plt.plot(
+                    [marker, marker], [min_val, max_val], "k-", lw=2, label=marker_name
+                )
+        plt.legend()
+
+    def _create_pre_forward_hook(self, name: str) -> Callable:
+        """
+        The pre_foward_hook is to insert current module name with forward prefix for the operator
+        name, also it inserts the marker "fw_start" when the forward pass begins.
+        """
+
+        def _pre_forward_hook(module: nn.Module, inputs: Any) -> None:
+            self._cur_module_name = f"{name}.forward"
+            if (
+                hasattr(module, "_memory_tracker_is_root")
+                and module._memory_tracker_is_root
+            ):
+                self._add_marker("fw_start")
+
+        return _pre_forward_hook
+
+    def _create_post_forward_hook(self, name: str) -> Callable:
+        """
+        The post_forward_hook inserts the marker 'fw_bw_boundary' at the boundary
+        of forward pass and backward pass.
+        """
+
+        def _post_forward_hook(
+            module: nn.Module,
+            inputs: Sequence[torch.Tensor],
+            outputs: Sequence[torch.Tensor],
+        ) -> None:
+            if (
+                hasattr(module, "_memory_tracker_is_root")
+                and module._memory_tracker_is_root
+            ):
+                self._add_marker("fw_bw_boundary")
+
+        return _post_forward_hook
+
+    def _create_backward_hook(self, name: str) -> Callable:
+        """
+        The backward_hook inserts the current module name with backward prefix for the operator name.
+        """
+
+        def _backward_hook(
+            module: nn.Module, grad_input: torch.Tensor, grad_output: torch.Tensor
+        ) -> None:
+            self._cur_module_name = f"{name}.backward"
+
+        return _backward_hook
+
+    @no_type_check
+    def _record_memory_stats(self, fn_name: str) -> None:
+        """
+        Record current memory allocated, current memory active and current memory reserved.
+        The memory stats dict is indexed with ``self._op_index``.
+        """
+        memory_allocated: float = torch.cuda.memory_allocated() / BYTES_PER_MB
+        memory_reserved: float = torch.cuda.memory_reserved() / BYTES_PER_MB
+        memory_active: float = (
+            torch.cuda.memory_stats().get("active_bytes.all.current", 0) / BYTES_PER_MB
+        )
+        self.memories_allocated[self._op_index] = (fn_name, memory_allocated)
+        self.memories_reserved[self._op_index] = (fn_name, memory_reserved)
+        self.memories_active[self._op_index] = (fn_name, memory_active)
+        self._op_index += 1
+
+    def _add_marker(self, marker_name: str) -> None:
+        """
+        Set the marker's x-axis value.
+        """
+        marker_val = len(self.memories_allocated.values())
+        self._markers[marker_name] = marker_val
+
+    def _clear_state(self) -> None:
+        """
+        Clear states when start_monitor() is called.
+        """
+        self._operator_names.clear()
+        self.memories_allocated.clear()
+        self.memories_active.clear()
+        self.memories_reserved.clear()
+        self._markers.clear()
+        self._cur_module_name = ""
+        self._op_index = 0

--- a/torch/distributed/examples/memory_tracker_example.py
+++ b/torch/distributed/examples/memory_tracker_example.py
@@ -1,0 +1,32 @@
+import torch
+import torchvision
+
+from torch.distributed._tools import MemoryTracker
+
+
+def run_one_model(net: torch.nn.Module, input: torch.Tensor):
+    net.cuda()
+    input = input.cuda()
+
+    # Create the memory Tracker
+    mem_tracker = MemoryTracker()
+    # start_monitor before the training iteration starts
+    mem_tracker.start_monitor(net)
+
+    # run one traing iteration
+    net.zero_grad(True)
+    loss = net(input)
+    if isinstance(loss, dict):
+        loss = loss["out"]
+    loss.sum().backward()
+    net.zero_grad(set_to_none=True)
+
+    # stop monitoring after the training iteration ends
+    mem_tracker.stop()
+    # print the memory stats summary
+    mem_tracker.summary()
+    # plot the memory traces at operator level
+    mem_tracker.show_traces()
+
+
+run_one_model(torchvision.models.resnet34(), torch.rand(32, 3, 224, 224, device="cuda"))


### PR DESCRIPTION
Adding a memory_tracker API to show operator level memory traces for allocated_memory, active_memory and reserved memory stats, it gave the summary about top 20 operators that generate memories as well. 

The implementation mainly uses torchDispatchMode and module hooks to get traces and add markers.

Will add following up PRs:
1. allow tracing more than 1 iteration
2. dump json data for visualization
3. add unit test for DDP training
4. add unit test for FSDP training
5. add unit test for activation checkpointing + DDP/FSDP training
6. add traces for activation memories and top operators that generate activation memories
7. print summaries for more breakdowns like model size, optimizer states, etc
8. add traces for temporary memories or memories consumed by cuda streams or nccl library if possible
9. connect the tool with OOM memory debugging
10. add dynamic programming (dp) algorithm to find best activation checkpointing locations based on the operator level activation memory traces
11. add same traces & dp algorithm for module level memory stats, as FSDP wrapping depends on module level memories, for some model users/not model authors, if they have to apply activation checkpointing on module level, they need module level memory traces as well 

======================================================

Current test result for the memory_tracker_example.py on notebook:

Top 20 ops that generates memory are:
bn1.forward.cudnn_batch_norm.default_0: 98.0009765625MB
maxpool.forward.max_pool2d_with_indices.default_0: 74.5MB
layer1.0.conv1.backward.max_pool2d_with_indices_backward.default_0: 49.0MB
layer1.0.bn1.forward.cudnn_batch_norm.default_1: 24.5009765625MB
layer1.0.bn2.forward.cudnn_batch_norm.default_2: 24.5009765625MB
layer1.1.bn1.forward.cudnn_batch_norm.default_3: 24.5009765625MB
layer1.1.bn2.forward.cudnn_batch_norm.default_4: 24.5009765625MB
layer1.2.bn1.forward.cudnn_batch_norm.default_5: 24.5009765625MB
layer1.2.bn2.forward.cudnn_batch_norm.default_6: 24.5009765625MB
layer1.0.conv1.forward.convolution.default_1: 24.5MB
layer1.0.conv2.forward.convolution.default_2: 24.5MB
layer1.1.conv1.forward.convolution.default_3: 24.5MB
layer1.1.conv2.forward.convolution.default_4: 24.5MB
layer1.2.conv1.forward.convolution.default_5: 24.5MB
layer1.2.conv2.forward.convolution.default_6: 24.5MB
maxpool.backward.threshold_backward.default_32: 23.5MB
layer2.0.downsample.backward.convolution_backward.default_26: 12.2802734375MB
layer2.0.bn1.forward.cudnn_batch_norm.default_7: 12.2509765625MB
layer2.0.bn2.forward.cudnn_batch_norm.default_8: 12.2509765625MB
layer2.0.downsample.1.forward.cudnn_batch_norm.default_9: 12.2509765625MB

<img width="1079" alt="Screen Shot 2022-11-10 at 10 03 06 AM" src="https://user-images.githubusercontent.com/48731194/201172577-ddfb769c-fb0f-4962-80df-92456b77903e.png">
