### PR TITLE
Skip `test_multiple_devices_randint_cuda_(float64 | int64)`

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14209,6 +14209,7 @@ op_db: List[OpInfo] = [
            skips=(
                # Tests that assume input is a tensor or sequence of tensors
                DecorateInfo(unittest.skip("Test expects tensor input"), "TestCommon", "test_noncontiguous_samples"),
+               DecorateInfo(unittest.skip("Test expects tensor input"), "TestCommon", "test_multiple_devices"),
                DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_vmap_exhaustive"),
                DecorateInfo(unittest.skip("Test expects tensor input"), "TestVmapOperatorsOpInfo", "test_op_has_batch_rule"),
                # CPU randint generates different values based on the strides of out tensor


### PR DESCRIPTION
Since the first sample of `randint`'s sample_inputs_func is a Python scalar, `randint` would return a CPU `Tensor`.

Rel: https://github.com/pytorch/pytorch/pull/87231