### PR TITLE
Add warning if tensor cores are not used

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -317,7 +317,7 @@ def lookup_backend(compiler_fn):
         ):
             warnings.warn(
                 "Tensor cores are available but not enabled."
-                "Consider setting torch.backends.cuda.matmul.allow_tf32 == True in your python script for speedups"
+                "Consider setting torch.backends.cuda.matmul.allow_tf32 = True in your python script for speedups"
             )
 
         compiler_fn = import_module(f"{config.inductor_import}.compile_fx").compile_fx

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -316,7 +316,8 @@ def lookup_backend(compiler_fn):
             and torch.cuda.get_device_capability() >= (8, 0)
         ):
             warnings.warn(
-                "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. Consider setting `torch.set_float32_matmul_precision('HIGH')`"
+                "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled."
+                "Consider setting `torch.set_float32_matmul_precision('HIGH')`"
             )
 
         compiler_fn = import_module(f"{config.inductor_import}.compile_fx").compile_fx

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -316,8 +316,7 @@ def lookup_backend(compiler_fn):
             and torch.cuda.get_device_capability() >= (8, 0)
         ):
             warnings.warn(
-                "Tensor cores are available but not enabled."
-                "Consider setting torch.backends.cuda.matmul.allow_tf32 = True in your python script for speedups"
+                "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. Consider setting `torch.set_float32_matmul_precision('HIGH')`"
             )
 
         compiler_fn = import_module(f"{config.inductor_import}.compile_fx").compile_fx

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -312,11 +312,12 @@ def lookup_backend(compiler_fn):
     """Expand backend strings to functions"""
     if compiler_fn == "inductor":
         if (
-            torch.backends.cuda.matmul.allow_tf32 == False
+            torch.backends.cuda.matmul.allow_tf32 is False
             and torch.cuda.get_device_capability() >= (7, 0)
         ):
             warnings.warn(
-                "Tensor cores are available but not enabled. Consider setting torch.backends.cuda.matmul.allow_tf32 == True in your python script for speedups"
+                "Tensor cores are available but not enabled."
+                "Consider setting torch.backends.cuda.matmul.allow_tf32 == True in your python script for speedups"
             )
 
         compiler_fn = import_module(f"{config.inductor_import}.compile_fx").compile_fx

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -310,7 +310,7 @@ def get_compiler_fn(compiler_fn):
 @functools.lru_cache(1)
 def lookup_backend(compiler_fn):
     """Expand backend strings to functions"""
-    if compiler_fn == "inductor":
+    if compiler_fn == "inductor" and torch.cuda.is_available():
         if (
             torch.backends.cuda.matmul.allow_tf32 is False
             and torch.cuda.get_device_capability() >= (8, 0)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -317,7 +317,7 @@ def lookup_backend(compiler_fn):
         ):
             warnings.warn(
                 "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled."
-                "Consider setting `torch.set_float32_matmul_precision('HIGH')`"
+                "Consider setting `torch.set_float32_matmul_precision('high')`"
             )
 
         compiler_fn = import_module(f"{config.inductor_import}.compile_fx").compile_fx

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -313,7 +313,7 @@ def lookup_backend(compiler_fn):
     if compiler_fn == "inductor":
         if (
             torch.backends.cuda.matmul.allow_tf32 is False
-            and torch.cuda.get_device_capability() >= (7, 0)
+            and torch.cuda.get_device_capability() >= (8, 0)
         ):
             warnings.warn(
                 "Tensor cores are available but not enabled."

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -311,6 +311,14 @@ def get_compiler_fn(compiler_fn):
 def lookup_backend(compiler_fn):
     """Expand backend strings to functions"""
     if compiler_fn == "inductor":
+        if (
+            torch.backends.cuda.matmul.allow_tf32 == False
+            and torch.cuda.get_device_capability() >= (7, 0)
+        ):
+            warnings.warn(
+                "Tensor cores are available but not enabled. Consider setting torch.backends.cuda.matmul.allow_tf32 == True in your python script for speedups"
+            )
+
         compiler_fn = import_module(f"{config.inductor_import}.compile_fx").compile_fx
     elif isinstance(compiler_fn, str):
         from .optimizations import BACKENDS

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -310,15 +310,16 @@ def get_compiler_fn(compiler_fn):
 @functools.lru_cache(1)
 def lookup_backend(compiler_fn):
     """Expand backend strings to functions"""
-    if compiler_fn == "inductor" and torch.cuda.is_available():
-        if (
-            torch.backends.cuda.matmul.allow_tf32 is False
-            and torch.cuda.get_device_capability() >= (8, 0)
-        ):
-            warnings.warn(
-                "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled."
-                "Consider setting `torch.set_float32_matmul_precision('high')`"
-            )
+    if compiler_fn == "inductor":
+        if torch.cuda.is_available():
+            if (
+                torch.backends.cuda.matmul.allow_tf32 is False
+                and torch.cuda.get_device_capability() >= (8, 0)
+            ):
+                warnings.warn(
+                    "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled."
+                    "Consider setting `torch.set_float32_matmul_precision('high')`"
+                )
 
         compiler_fn = import_module(f"{config.inductor_import}.compile_fx").compile_fx
     elif isinstance(compiler_fn, str):


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchdynamo/issues/1839

Should I do this for all backends or just inductor?

## Test
On a V100 I got from AWS

```python
from torch._dynamo import optimize
import torch

def fn(x, y):
    a = torch.cos(x)
    b = torch.sin(y)
    return a + b

new_fn = optimize("inductor")(fn)

a = new_fn(torch.Tensor(1),torch.Tensor(1))
print(a)
```

## New logs
```
(sourcetorch) ubuntu@ip-172-31-31-152:~/test$ python test.py 
/home/ubuntu/pytorch/torch/_dynamo/eval_frame.py:318: UserWarning: Tensor cores are available but not enabled. Consider setting torch.backends.cuda.matmul.allow_tf32 == True in your python script for speedups
  warnings.warn(
tensor([1.3717])
```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire