### PR TITLE
add quantize_decomposed_dynamic to op lib

### DIFF
--- a/test/quantization/core/test_quantized_tensor.py
+++ b/test/quantization/core/test_quantized_tensor.py
@@ -14,6 +14,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import TestCase, DeterministicGuard
 import torch.testing._internal.hypothesis_utils as hu
 from torch.testing._internal.common_quantization import get_supported_device_types
+from torch.ao.quantization import MinMaxObserver
 
 hu.assert_deadline_disabled()
 
@@ -1494,6 +1495,30 @@ class TestQuantizedTensor(TestCase):
             X, scale, zero_point, quant_min, quant_max, dtype)
         dequantized_decomposed_X = torch.ops.quantized_decomposed.dequantize_per_tensor(
             quantized_decomposed_X, scale, zero_point, quant_min, quant_max, dtype
+        )
+        self.assertEqual(quantized_X.int_repr(), quantized_decomposed_X)
+        self.assertEqual(dequantized_X, dequantized_decomposed_X)
+
+    def test_decomposed_quantize_dynamic(self):
+        import torch.ao.quantization.fx._decomposed
+        X = torch.randn(5, 10)
+        dtype = torch.uint8
+        qdtype = torch.quint8
+        scale, zero_point = torch._choose_qparams_per_tensor(X, False)
+        quant_min, quant_max = 0, 255
+
+        quantized_X = torch.quantize_per_tensor(X, scale, zero_point, qdtype)
+        dequantized_X = torch.dequantize(quantized_X)
+
+        quantized_decomposed_X = torch.ops.quantized_decomposed.quantize_per_tensor_dynamic(
+            X, quant_min, quant_max, dtype)
+
+        # observer logic is what quantize_per_tensor_dynamic does internally
+        observer = MinMaxObserver(quant_min=quant_min, quant_max=quant_max)
+        observer(X)
+        scale_decomposed, zero_point_decomposed = observer.calculate_qparams()
+        dequantized_decomposed_X = torch.ops.quantized_decomposed.dequantize_per_tensor(
+            quantized_decomposed_X, scale_decomposed, zero_point_decomposed, quant_min, quant_max, dtype
         )
         self.assertEqual(quantized_X.int_repr(), quantized_decomposed_X)
         self.assertEqual(dequantized_X, dequantized_decomposed_X)

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -1,16 +1,13 @@
 import torch
-from torch.library import Library, impl
+from torch.library import impl, Library
+from torch.ao.quantization import MinMaxObserver
 
 # Note: decomposed means decomposed quantized tensor, using decomposed so that the
 # name is not too long
 quantized_decomposed_lib = Library("quantized_decomposed", "DEF")
 
-quantized_decomposed_lib.define(
-    "quantize_per_tensor(Tensor input, float scale, int zero_point, int quant_min, int quant_max, ScalarType dtype) -> Tensor")
-
-@impl(quantized_decomposed_lib, "quantize_per_tensor", "CompositeExplicitAutograd")
-def quantize_per_tensor(input, scale, zero_point, quant_min, quant_max, dtype):
-    assert input.dtype == torch.float32, f"Expecting input to have dtype torch.float32, but got dtype: {input.dtype}"
+# Helper to check the passed in quant min and max are valid for the dtype
+def _quant_min_max_bounds_check(quant_min, quant_max, dtype):
     quant_min_lower_bound = 0
     quant_max_upper_bound = 0
     if dtype == torch.uint8:
@@ -29,6 +26,14 @@ def quantize_per_tensor(input, scale, zero_point, quant_min, quant_max, dtype):
     assert quant_max <= quant_max_upper_bound, \
         "quant_max out of bound for dtype, " \
         f"quant_max_upper_bound: {quant_max_upper_bound} quant_max: {quant_max}"
+
+quantized_decomposed_lib.define(
+    "quantize_per_tensor(Tensor input, float scale, int zero_point, int quant_min, int quant_max, ScalarType dtype) -> Tensor")
+
+@impl(quantized_decomposed_lib, "quantize_per_tensor", "CompositeExplicitAutograd")
+def quantize_per_tensor(input, scale, zero_point, quant_min, quant_max, dtype):
+    assert input.dtype == torch.float32, f"Expecting input to have dtype torch.float32, but got dtype: {input.dtype}"
+    _quant_min_max_bounds_check(quant_min, quant_max, dtype)
 
     inv_scale = 1.0 / scale
     return torch.clamp(torch.round(input * inv_scale) + zero_point, quant_min, quant_max).to(dtype)
@@ -50,3 +55,20 @@ def dequantize_per_tensor(input, scale, zero_point, quant_min, quant_max, dtype)
         return (input.to(torch.float32) - zero_point) * scale
     else:
         raise ValueError(f"Unsupported dtype in dequantize_per_tensor: {dtype}")
+
+quantized_decomposed_lib.define(
+    "quantize_per_tensor_dynamic(Tensor input, int quant_min, int quant_max, ScalarType dtype) -> Tensor")
+
+@impl(quantized_decomposed_lib, "quantize_per_tensor_dynamic", "CompositeExplicitAutograd")
+def quantize_per_tensor_dynamic(input, quant_min, quant_max, dtype):
+    assert input.dtype == torch.float32, f"Expecting input to have dtype torch.float32, but got dtype: {input.dtype}"
+    _quant_min_max_bounds_check(quant_min, quant_max, dtype)
+
+    # Its weird to create an observer manually just to calculate qparams. I tried refactoring this functionality out of observer
+    # into a util and then use that util directly, but I kept running into jit typing errors related to torch.qscheme not
+    # being recognized as a type. TODO: properly refactor this out to avoid observer overhead
+    tensor_dtype_to_observer_dtype = {torch.uint8: torch.quint8, torch.int8: torch.qint8}
+    observer = MinMaxObserver(quant_min=quant_min, quant_max=quant_max, dtype=tensor_dtype_to_observer_dtype[dtype])
+    observer(input)
+    scale, zero_point = observer.calculate_qparams()
+    return torch.ops.quantized_decomposed.quantize_per_tensor(input, scale.item(), zero_point.item(), quant_min, quant_max, dtype)

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -546,7 +546,6 @@ def get_fqn_to_example_inputs(
         torch.nn.Module.__call__ = orig_module_call
     return fqn_to_example_inputs
 
-
 __all__ = [
     "NodePattern",
     "Pattern",


### PR DESCRIPTION
Summary: Needed for dynamic quant reference pattern graphs.

Test Plan: added unittest

Differential Revision: D41205030



cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel