### PR TITLE
[dynamo] Skip frame when graph break in a loop

### DIFF
--- a/test/dynamo/test_optimizers.py
+++ b/test/dynamo/test_optimizers.py
@@ -1,7 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
 import inspect
-import sys
 import unittest
 
 import torch
@@ -126,7 +125,7 @@ class End2EndTests(torch._dynamo.test_case.TestCase):
         batch = {"x": input1, "y": input2}
         for _ in range(2):
             opt_training_iter_fn(batch, net, optimizer)
-        self.assertEqual(cnts.frame_count, (2 if sys.version_info < (3, 8) else 6))
+        self.assertEqual(cnts.frame_count, 2)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -257,7 +257,7 @@ class InstructionTranslatorBase(object):
                 "POP_JUMP_IF_TRUE",
                 "POP_JUMP_IF_FALSE",
             ):
-                jump_offset = inst.arg
+                jump_offset = inst.argval
                 if jump_offset < cur_offset:
                     return True
         return False


### PR DESCRIPTION
This fixes excessing recompilation issue in tacotron2 but has few caveats - https://github.com/pytorch/torchdynamo/issues/330

For tacotron2, the repro is something like this

~~~
        def inner(x):
            return torch.sin(x)

        def fn(x):
            for _ in range(100):
                inner(x)
                torch._dynamo.graph_break()
            return x
~~~


The problem here is that Dynamo has guards on the TUPLE_ITERATOR_LEN whenever a graph break happens. Therefore, we keep on recompiling.

This PR checks if there is a backedge (helps with while loop) in presence of a graph break. If there is, Dynamo skips processing this frame. Therefore, Dynamo gets called when inner is called, and we compile only once.

Note that, if there was no graph break, we will unroll the original loop, and see one graph with 100 sin operations (just as before, so no changes there).

The caveat is - We are skipping the frame, so if we have something like this

~~~
        def fn(x):
            for _ in range(100):
                # 1000s of lines of PyTorch code
                torch._dynamo.graph_break()
            return x
~~~

Dynamo will skip processing this frame, and might miss on the optimization. 

Completely open for suggestions. Happy to re-implement if there is a better way to handle this.



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire