### PR TITLE
[Inductor] Build FX Linear + Permute Vertical Fusion in Inductor

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10,6 +10,7 @@ import sys
 import typing
 import unittest
 import weakref
+from typing import Any, Callable
 from unittest.mock import patch
 
 import torch
@@ -18,6 +19,7 @@ import torch._dynamo
 from torch._dynamo.debug_utils import same_two_models
 from torch._dynamo.testing import rand_strided, same
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.passes.shape_prop import ShapeProp
 from torch.nn import functional as F
 from torch.testing._internal.common_utils import (
     TEST_WITH_ASAN,
@@ -39,6 +41,14 @@ try:
     from torch._inductor import codecache, config, metrics
     from torch._inductor.compile_fx import compile_fx, complex_memory_overlap
     from torch._inductor.ir import IndexingDiv, ModularIndexing
+    from torch._inductor.overrides import (
+        linear_permute_fusion,
+        linear_transpose,
+        permute_linear_fusion,
+        permute_matmul_fusion,
+        transpose_linear,
+        transpose_matmul,
+    )
     from torch._inductor.sizevars import SizeVarAllocator
     from torch._inductor.utils import has_torchvision_roi_align, timed
 
@@ -111,6 +121,29 @@ def requires_decomp(fn):
         return maybe_test
 
     return wrap_test
+
+
+PassFunc = Callable[[torch.fx.GraphModule, Any], torch.fx.GraphModule]
+
+
+def chain_passes(*passes: PassFunc) -> PassFunc:
+    def parent_pass(module: torch.fx.GraphModule, input: Any) -> torch.fx.GraphModule:
+        for pass_ in passes:
+            if isinstance(module, torch.fx.GraphModule):
+                ShapeProp(module).propagate(*input)
+            module = pass_(module)
+        return module
+
+    return parent_pass
+
+
+def count_call_function(module: torch.fx.GraphModule, target_op: Any) -> int:
+    return sum(
+        [
+            1 if (n.op == "call_function" and n.target == target_op) else 0
+            for n in module.graph.nodes
+        ]
+    )
 
 
 class TestCase(TorchTestCase):
@@ -1585,6 +1618,79 @@ class CommonTemplate:
         x = torch.tensor(123)
         y = torch.tensor(0)
         self.assertEqual(fn(x, y), x + x)
+
+    def test_linear_permute_fusion(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self, k: int, n: int):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(n, k))
+                self.bias = torch.nn.Parameter(torch.randn(n))
+
+            def forward(self, input: torch.Tensor):
+                a0 = torch.nn.functional.linear(input, self.weight, self.bias)
+                b0 = a0.permute(0, 2, 1)
+                return b0
+
+        m, k, n = 16, 8, 4
+        trace_func = chain_passes(torch.fx.symbolic_trace, linear_permute_fusion)
+        module = TestModule(k, n).eval()
+        input = torch.randn(6, m, k)
+        traced = trace_func(module, [input])
+        num_linear = count_call_function(traced, torch.nn.functional.linear)
+        num_linear_transpose = count_call_function(traced, linear_transpose)
+        self.assertEqual(num_linear, 0)
+        self.assertEqual(num_linear_transpose, 1)
+
+        self.assertTrue(torch.allclose(module(input), traced(input)))
+
+    def test_permute_linear_fusion(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self, k: int, n: int):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(n, k))
+                self.bias = torch.nn.Parameter(torch.randn(n))
+
+            def forward(self, input: torch.Tensor):
+                input1 = input.permute(0, 2, 1)
+                output = torch.nn.functional.linear(input1, self.weight, self.bias)
+                return output
+
+        m, k, n = 16, 8, 4
+
+        trace_func = chain_passes(torch.fx.symbolic_trace, permute_linear_fusion)
+        module = TestModule(k, n).eval()
+        input = torch.randn(6, k, m)
+        traced = trace_func(module, [input])
+        num_linear = count_call_function(traced, torch.nn.functional.linear)
+        num_transpose_linear = count_call_function(traced, transpose_linear)
+        self.assertEqual(num_linear, 0)
+        self.assertEqual(num_transpose_linear, 1)
+
+        self.assertTrue(torch.allclose(module(input), traced(input)))
+
+    def test_permute_bmm_fusion(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self, batch: int, k: int, n: int):
+                super().__init__()
+                self.other = torch.randn(batch, k, n)
+
+            def forward(self, input: torch.Tensor):
+                input1 = input.permute(0, 2, 1)
+                output = torch.bmm(input1, self.other)
+                return output
+
+        batch, m, k, n = 6, 16, 8, 4
+
+        trace_func = chain_passes(torch.fx.symbolic_trace, permute_matmul_fusion)
+        module = TestModule(batch, k, n).eval()
+        input = torch.randn(batch, k, m)
+        traced = trace_func(module, [input])
+        num_bmm = count_call_function(traced, torch.bmm)
+        num_transpose_matmul = count_call_function(traced, transpose_matmul)
+        self.assertEqual(num_bmm, 0)
+        self.assertEqual(num_transpose_matmul, 1)
+
+        self.assertTrue(torch.allclose(module(input), traced(input)))
 
     def test_slice1(self):
         def fn(a):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -75,6 +75,10 @@ dynamo_import = inductor_import.replace("inductor", "dynamo")
 shape_padding = os.environ.get("TORCHINDUCTOR_SHAPE_PADDING", "0") == "1"
 alignment_size = 4
 
+# Fx-based linear/matmul/bmm + permute/transpose vertical fusion
+permute_fusion = os.environ.get("TORCHINDUCTOR_PERMUTE_FUSION", "0") == "1"
+
+
 # config specific to codegen/cpp.pp
 class cpp:
     # set to torch.get_num_threads()

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -19,6 +19,8 @@ from torch.nn.modules.utils import _pair
 from torch.nn.utils.fusion import fuse_conv_bn_eval
 from torch.overrides import TorchFunctionMode
 
+from . import config
+
 log = logging.getLogger(__name__)
 
 
@@ -425,6 +427,14 @@ def check_node_is_add_inplace(node):
 
 
 def fuse_fx(gm: torch.fx.GraphModule, example_inputs):
+    if config.permute_fusion:
+        # For linear permute fusion, we need to check input info to identify
+        # and perform proper permutation/transpose
+        ShapeProp(gm).propagate(*example_inputs)
+        gm = linear_permute_fusion(gm)
+        gm = permute_linear_fusion(gm)
+        gm = permute_matmul_fusion(gm)
+
     # make sure the autograd is disabled.
     if torch.is_grad_enabled():
         return gm
@@ -526,6 +536,195 @@ def _philox_rand_like_meta(input, seed, offset):
 def _philox_rand_like(input, seed, offset):
     # placeholder only used in tracing
     return torch.rand_like(input)
+
+
+class NormalizedLinearNode:
+    def __init__(self, node: torch.fx.Node) -> None:
+        assert node.op == "call_function"
+        assert node.target in [torch.nn.functional.linear]
+        self.node: torch.fx.Node = node
+
+    def get_input(self) -> torch.fx.Node:
+        if len(self.node.args) > 0:
+            return self.node.args[0]
+        else:
+            return self.node.kwargs["input"]
+
+    def get_weight(self) -> torch.fx.Node:
+        if len(self.node.args) > 1:
+            return self.node.args[1]
+        else:
+            return self.node.kwargs["weight"]
+
+    def get_bias(self) -> torch.fx.Node:
+        if len(self.node.args) > 2:
+            return self.node.args[2]
+        else:
+            return self.node.kwargs["bias"]
+
+
+class NormalizedMatmulNode:
+    def __init__(self, node: torch.fx.Node) -> None:
+        assert node.op == "call_function"
+        assert node.target in [torch.bmm, torch.matmul]
+        self.node: torch.fx.Node = node
+
+    def get_input(self) -> torch.fx.Node:
+        if len(self.node.args) > 0:
+            return self.node.args[0]
+        else:
+            return self.node.kwargs["input"]
+
+    def get_other(self) -> torch.fx.Node:
+        if len(self.node.args) > 1:
+            return self.node.args[1]
+        else:
+            return self.node.kwargs["other"]
+
+
+def check_permute(node: torch.fx.Node):
+    ranks = len(node.meta["tensor_meta"].shape)
+    if len(node.args) > 3:
+        permutation = [node.args[i] % ranks for i in range(1, ranks + 1)]
+    elif (
+        "permutation" in node.kwargs
+        and node.kwargs["permutation"] is not None
+        and len(node.kwargs["permutation"]) > 2
+    ):
+        permutation = [i % ranks for i in node.kwargs["permutation"]]
+    else:
+        return False
+    allowed_permutation = list(range(ranks))
+    allowed_permutation[-1] = ranks - 2
+    allowed_permutation[-2] = ranks - 1
+    return permutation == allowed_permutation
+
+
+def linear_permute_fusion(module: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    for node in module.graph.nodes:
+        if (
+            node.op == "call_method"
+            and node.target == "permute"
+            and check_permute(node)
+        ):
+            if len(node.args) > 0:
+                input_node = node.args[0]
+            else:
+                input_node = node.kwargs["input"]
+            if (
+                input_node.op == "call_function"
+                and input_node.target == torch.nn.functional.linear
+            ):
+                normalized = NormalizedLinearNode(input_node)
+                input = normalized.get_input()
+                weight = normalized.get_weight()
+                bias = normalized.get_bias()
+                with module.graph.inserting_before(node):
+                    fused_node = module.graph.call_function(
+                        linear_transpose, args=(input, weight, bias)
+                    )
+                    node.replace_all_uses_with(fused_node)
+
+    module.graph.lint()
+    module.graph.eliminate_dead_code()
+    module.recompile()
+    return module
+
+
+# Y1 = X * W^T + bias
+# Y2 = Y1.permute(0, 2, 1)
+# ---->
+# Y2 = (W * X^T + bias.unsqueeze(-1))^T
+def linear_transpose(
+    input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    return torch.matmul(weight, input.transpose(-1, -2)) + bias.unsqueeze(-1)
+
+
+def permute_linear_fusion(module: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    for node in module.graph.nodes:
+        if node.op == "call_function" and node.target == torch.nn.functional.linear:
+            if len(node.args) > 0:
+                input_node = node.args[0]
+            else:
+                input_node = node.kwargs["input"]
+            if (
+                input_node.op == "call_method"
+                and input_node.target == "permute"
+                and check_permute(input_node)
+            ):
+                normalized = NormalizedLinearNode(node)
+                if len(input_node.args) > 0:
+                    input = input_node.args[0]
+                else:
+                    input = input_node.kwargs["input"]
+                weight = normalized.get_weight()
+                bias = normalized.get_bias()
+                with module.graph.inserting_before(node):
+                    fused_node = module.graph.call_function(
+                        transpose_linear, args=(input, weight, bias)
+                    )
+                    node.replace_all_uses_with(fused_node)
+
+    module.graph.lint()
+    module.graph.eliminate_dead_code()
+    module.recompile()
+    return module
+
+
+def permute_matmul_fusion(module: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    for node in module.graph.nodes:
+        if node.op == "call_function" and (
+            node.target == torch.bmm or node.target == torch.matmul
+        ):
+            normalized = NormalizedMatmulNode(node)
+            A = normalized.get_input()
+            B = normalized.get_other()
+            Atrans = Btrans = False
+            if A.op == "call_method" and A.target == "permute" and check_permute(A):
+                Atrans = True
+                if len(A.args) > 0:
+                    A = A.args[0]
+                else:
+                    A = A.kwargs["input"]
+
+            if B.op == "call_method" and B.target == "permute" and check_permute(B):
+                Btrans = True
+                if len(B.args) > 0:
+                    B = B.args[0]
+                else:
+                    B = B.kwargs["input"]
+
+            if Atrans or Btrans:
+                with module.graph.inserting_before(node):
+                    fused_node = module.graph.call_function(
+                        transpose_matmul,
+                        args=(A, B, Atrans, Btrans),
+                    )
+                node.replace_all_uses_with(fused_node)
+
+    module.graph.lint()
+    module.graph.eliminate_dead_code()
+    module.recompile()
+    return module
+
+
+# X1 = X.permute(0, 2, 1)
+# Y1 = X1 * W1^T + bias1
+# ---->
+# Y2 = X1.transpose(-1, -2) * W1^T + bias1
+def transpose_linear(
+    input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    return torch.matmul(input.transpose(-1, -2), weight.t()) + bias
+
+
+def transpose_matmul(A: torch.Tensor, B: torch.Tensor, Atrans: bool, Btrans: bool):
+    if Atrans:
+        A = A.transpose(-1, -2)
+    if Btrans:
+        B = B.transpose(-1, -2)
+    return torch.matmul(A, B)
 
 
 def replace_and_fuse_for_binary(


### PR DESCRIPTION
Summary:
Build fx-based linear/matmul/bmm + permute/transpose vertical fusion in Inductor

For an internal Ads model: **1.15x -> 1.36x speedup**

Differential Revision: D41071665

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire