### PR TITLE
Cleanup Windows pip dependencies

### DIFF
--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -53,14 +53,3 @@ runs:
       run: |
         .circleci/scripts/windows_cuda_install.sh
         .circleci/scripts/windows_cudnn_install.sh
-
-    - name: Setup Python3
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-        check-latest: false
-        cache: pip
-        cache-dependency-path: |
-          **/requirements.txt
-          **/.circleci/docker/requirements-ci.txt
-          **/.github/requirements-gha-cache.txt

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -53,3 +53,14 @@ runs:
       run: |
         .circleci/scripts/windows_cuda_install.sh
         .circleci/scripts/windows_cudnn_install.sh
+
+    - name: Setup Python3
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+        check-latest: false
+        cache: pip
+        cache-dependency-path: |
+          **/requirements.txt
+          **/.circleci/docker/requirements-ci.txt
+          **/.github/requirements-gha-cache.txt

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -93,6 +93,10 @@ jobs:
         id: monitor-script
         shell: bash
         run: |
+          # TODO: activate Miniconda to get Python run time, figure out a way to make this
+          # persistent during the whole workflow
+          .jenkins/pytorch/win-test-helpers/installation-helpers/activate_miniconda3.bat
+
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
@@ -196,6 +200,10 @@ jobs:
           GHA_WORKFLOW_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
         shell: bash
         run: |
+          # TODO: activate Miniconda to get Python run time, figure out a way to make this
+          # persistent during the whole workflow
+          .jenkins/pytorch/win-test-helpers/installation-helpers/activate_miniconda3.bat
+
           set -x
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -74,11 +74,15 @@ jobs:
         with:
           cuda-version: ${{ inputs.cuda-version }}
 
-      - name: Activate conda
-        shell: powershell
+      - name: Setup conda
+        shell: bash
         run: |
-          C:\Jenkins\Miniconda3\shell\condabin\conda-hook.ps1
-          conda activate base
+          # Windows conda is baked into the AMI at this location
+          CONDA="C:\Jenkins\Miniconda3\condabin\conda.bat"
+
+          echo "CONDA_RUN=${CONDA} run --no-capture-output" >> "${GITHUB_ENV}"
+          echo "CONDA_BUILD=${CONDA} run conda-build" >> "${GITHUB_ENV}"
+          echo "CONDA_INSTALL=${CONDA} install" >> "${GITHUB_ENV}"
 
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
@@ -100,7 +104,7 @@ jobs:
         shell: bash
         run: |
           # Windows conda doesn't have python3 binary, only python, but it's python3
-          python -m tools.stats.monitor > usage_log.txt 2>&1 &
+          ${CONDA_RUN} python -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
       - name: Download PyTorch Build Artifacts
@@ -205,7 +209,7 @@ jobs:
         run: |
           set -x
           # Windows conda doesn't have python3 binary, only python, but it's python3
-          python -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
+          ${CONDA_RUN} python -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
 
       - name: Teardown Windows
         uses: ./.github/actions/teardown-win

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -74,6 +74,12 @@ jobs:
         with:
           cuda-version: ${{ inputs.cuda-version }}
 
+      - name: Activate conda
+        shell: powershell
+        run: |
+          C:\Jenkins\Miniconda3\shell\condabin\conda-hook.ps1
+          conda activate base
+
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
         with:
@@ -93,10 +99,6 @@ jobs:
         id: monitor-script
         shell: bash
         run: |
-          # TODO: activate Miniconda to get Python run time, figure out a way to make this
-          # persistent during the whole workflow
-          .jenkins/pytorch/win-test-helpers/installation-helpers/activate_miniconda3.bat
-
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
@@ -200,10 +202,6 @@ jobs:
           GHA_WORKFLOW_JOB_ID: ${{ steps.get-job-id.outputs.job-id }}
         shell: bash
         run: |
-          # TODO: activate Miniconda to get Python run time, figure out a way to make this
-          # persistent during the whole workflow
-          .jenkins/pytorch/win-test-helpers/installation-helpers/activate_miniconda3.bat
-
           set -x
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -80,9 +80,11 @@ jobs:
           # Windows conda is baked into the AMI at this location
           CONDA="C:\Jenkins\Miniconda3\condabin\conda.bat"
 
-          echo "CONDA_RUN=${CONDA} run --no-capture-output" >> "${GITHUB_ENV}"
-          echo "CONDA_BUILD=${CONDA} run conda-build" >> "${GITHUB_ENV}"
-          echo "CONDA_INSTALL=${CONDA} install" >> "${GITHUB_ENV}"
+          {
+            echo "CONDA_RUN=${CONDA} run --no-capture-output";
+            echo "CONDA_BUILD=${CONDA} run conda-build";
+            echo "CONDA_INSTALL=${CONDA} install";
+          } >> "${GITHUB_ENV}"
 
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -99,7 +99,8 @@ jobs:
         id: monitor-script
         shell: bash
         run: |
-          python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
+          # Windows conda doesn't have python3 binary, only python, but it's python3
+          python -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
       - name: Download PyTorch Build Artifacts
@@ -203,7 +204,8 @@ jobs:
         shell: bash
         run: |
           set -x
-          python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
+          # Windows conda doesn't have python3 binary, only python, but it's python3
+          python -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
 
       - name: Teardown Windows
         uses: ./.github/actions/teardown-win

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -93,8 +93,6 @@ jobs:
         id: monitor-script
         shell: bash
         run: |
-          python3 -m pip install psutil==5.9.1
-          python3 -m pip install pynvml==11.4.1
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
@@ -199,8 +197,6 @@ jobs:
         shell: bash
         run: |
           set -x
-          python3 -m pip install -r requirements.txt
-          python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
 
       - name: Teardown Windows

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -35,11 +35,6 @@ call %INSTALLER_DIR%\activate_miniconda3.bat
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 
-:: Install ninja and other deps
-if "%REBUILD%"=="" ( pip install -q "ninja==1.10.0.post1" dataclasses typing_extensions "expecttest==0.1.3" )
-if errorlevel 1 exit /b
-if not errorlevel 0 exit /b
-
 :: Override VS env here
 pushd .
 if "%VC_VERSION%" == "" (
@@ -140,7 +135,7 @@ python setup.py bdist_wheel
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 sccache --show-stats
-python -c "import os, glob; os.system('python -mpip install ' + glob.glob('dist/*.whl')[0] + '[opt-einsum]')"
+python -c "import os, glob; os.system('python -mpip install --no-index --no-deps ' + glob.glob('dist/*.whl')[0])"
 (
   if "%BUILD_ENVIRONMENT%"=="" (
     echo NOTE: To run `import torch`, please make sure to activate the conda environment by running `call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3` in Command Prompt before running Git Bash.

--- a/.jenkins/pytorch/win-test-helpers/install_test_functorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/install_test_functorch.bat
@@ -6,10 +6,6 @@ if not errorlevel 0 (
   exit /b
 )
 
-echo "Installing test dependencies"
-pip install networkx
-if errorlevel 1 exit /b
-
 echo "Test functorch"
 pushd test
 python run_test.py --functorch --shard "%SHARD_NUMBER%" "%NUM_TEST_SHARDS%" --verbose

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/activate_miniconda3.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/activate_miniconda3.bat
@@ -24,13 +24,3 @@ if "%INSTALL_FRESH_CONDA%"=="1" (
 
 :: Activate conda so that we can use its commands, i.e. conda, python, pip
 call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3
-
-if "%INSTALL_FRESH_CONDA%"=="1" (
-  call conda install -y -q numpy"<1.23" cffi pyyaml boto3 libuv
-  if errorlevel 1 exit /b
-  if not errorlevel 0 exit /b
-
-  call conda install -y -q -c conda-forge cmake=3.22.3
-  if errorlevel 1 exit /b
-  if not errorlevel 0 exit /b
-)

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -14,13 +14,6 @@ call %INSTALLER_DIR%\activate_miniconda3.bat
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 
-:: extra conda dependencies for testing purposes
-if NOT "%BUILD_ENVIRONMENT%"=="" (
-    call conda install -y -q mkl protobuf numba scipy=1.6.2 typing_extensions dataclasses
-    if errorlevel 1 exit /b
-    if not errorlevel 0 exit /b
-)
-
 pushd .
 if "%VC_VERSION%" == "" (
     call "C:\Program Files (x86)\Microsoft Visual Studio\%VC_YEAR%\%VC_PRODUCT%\VC\Auxiliary\Build\vcvarsall.bat" x64
@@ -31,14 +24,6 @@ if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 @echo on
 popd
-
-:: The version is fixed to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
-=======
-:: Pin unittest-xml-reporting to freeze printing test summary logic, related: https://github.com/pytorch/pytorch/issues/69014
-
-pip install "ninja==1.10.0.post1" future "hypothesis==5.35.1" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" psutil pillow "unittest-xml-reporting<=3.2.0,>=2.0.0" pytest pytest-xdist pytest-shard pytest-rerunfailures sympy "xdoctest==1.0.2" "pygments==2.12.0" "opt-einsum>=3.3"
-if errorlevel 1 exit /b
-if not errorlevel 0 exit /b
 
 set DISTUTILS_USE_SDK=1
 


### PR DESCRIPTION
The new Windows AMI from https://github.com/pytorch/test-infra/pull/1065 is now ready. All Windows pip dependencies are now part of the Windows AMI and can be cleaned up from the CI