### PR TITLE
skip embedding_bag since its backward is not compatible to cudagraph

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 import numpy
 
 import torch._C
+import torch._inductor.config as inductor_config
 import torch.nn
 import torch.onnx.operators
 
@@ -171,6 +172,11 @@ class TorchVariable(VariableTracker):
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
     ) -> "VariableTracker":
         from . import ConstantVariable, GradModeVariable, TensorVariable
+
+        if inductor_config.triton.cudagraphs and self.value.__name__ in [
+            "embedding_bag"
+        ]:
+            unimplemented(f"Skipping {self.value.__name__}")
 
         constant_args = check_constant_args(args, kwargs)
         unspec_python_args = check_unspec_python_args(args, kwargs)


### PR DESCRIPTION
Summary:
Work around that the bwd of embedding_bag doesn't work with cudagraph with the following error:

RuntimeError: unique_by_key: failed to synchronize: cudaErrorStreamCaptureUnsupported: operation not permitted when stream is capturing

and then cuda memory error

Differential Revision: D40625081



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire