### PR TITLE
Fixes for tracing optimizers with 1000s of parameters

### DIFF
--- a/benchmarks/dynamo/huggingface.py
+++ b/benchmarks/dynamo/huggingface.py
@@ -382,8 +382,6 @@ class HuggingfaceRunner(BenchmarkRunner):
         else:
             model.eval()
 
-        self.init_optimizer(device, model.parameters())
-
         self.validate_model(model, example_inputs)
         return device, model_name, model, example_inputs, batch_size
 

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -249,8 +249,6 @@ class TimmRunnner(BenchmarkRunner):
         else:
             model.eval()
 
-        self.init_optimizer(device, model.parameters())
-
         self.validate_model(model, example_inputs)
 
         return device, model_name, model, example_inputs, batch_size

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -270,8 +270,6 @@ class TorchBenchmarkRunner(BenchmarkRunner):
         gc.collect()
         batch_size = benchmark.batch_size
 
-        self.init_optimizer(device, model.parameters())
-
         # Torchbench has quite different setup for yolov3, so directly passing
         # the right example_inputs
         if model_name == "yolov3":


### PR DESCRIPTION
Currently tracing optimizers with TorchDynamo takes prohibitively long when there are > 1000 parameters. This is an initial attempt at a fix which consists of the following:
- Enables `capturable` and `foreach` flags for Adam to run in benchmarks
- Extract every iteration over all of the parameters into a separate function and disable dynamo on it
- Use the multitensor version of the optimizer which moves any operations over all of the parameters into for_each FX nodes

This mitigates the repro in https://github.com/pytorch/torchdynamo/issues/1803

In the long term, we would need to make similar changes to the rest of the optimizers or speed up dynamo on large loops of parameters, I'm actively exploring both options.

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire