### PR TITLE
Separate clang-tidy config files for internal and OSS

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 # NOTE there must be no spaces before the '-', so put the comma last.
-# This file is used for internal (Meta) clang-tidy linting. For Pytorch Github repo, use `.clang-tidy-oss`. 
+# This file is used for internal (Meta) clang-tidy linting. For Pytorch Github repo, use `.clang-tidy-oss`.
 InheritParentConfig: true
 Checks: '
 bugprone-*,

--- a/.clang-tidy-oss
+++ b/.clang-tidy-oss
@@ -1,6 +1,6 @@
 ---
 # NOTE there must be no spaces before the '-', so put the comma last.
-# This file is used for internal (Meta) clang-tidy linting. For Pytorch Github repo, use `.clang-tidy-oss`. 
+# This file is used for Pytorch Github clang-tidy linting. Do NOT update it for internal (Meta) code linting.
 InheritParentConfig: true
 Checks: '
 bugprone-*,
@@ -41,5 +41,6 @@ performance-*,
 '
 HeaderFilterRegex: 'torch/csrc/(?!deploy/interpreter/cpython).*'
 AnalyzeTemporaryDtors: false
+WarningsAsErrors: '*'
 CheckOptions:
 ...


### PR DESCRIPTION
 # Summary
 
As a follow up to the [internal discussion](https://fburl.com/xyexl7nz), we want to turn off `WarningsAsErrors` for internal clang-tidy checks. This is because internal linter is now throwing errors for unchanged code in the diffs. However, we still want to keep `WarningsAsErrors` turned on for OSS. 

The solution is to separate out `.clang-tidy` config for internal (meta) and OSS. 

# Test plan

`
lintrunner init
`
`
lintrunner -a
`

# Followup

We want to ensure that these two files do not diverge in future. We want to add a lint action in `lint.yml` to catch any further divergence between the two files


