### PR TITLE
Skip dynamo benchmark tests under TSAN

### DIFF
--- a/benchmarks/dynamo/test.py
+++ b/benchmarks/dynamo/test.py
@@ -5,8 +5,17 @@ from .common import parse_args, run
 
 from .torchbench import setup_torchbench_cwd, TorchBenchmarkRunner
 
+try:
+    # fbcode only
+    from aiplatform.utils.sanitizer_status import is_asan_or_tsan
+except ImportError:
+
+    def is_asan_or_tsan():
+        return False
+
 
 class TestDynamoBenchmark(unittest.TestCase):
+    @unittest.skipIf(is_asan_or_tsan(), "ASAN/TSAN not supported")
     def test_benchmark_infra_runs(self) -> None:
         """
         Basic smoke test that TorchBench runs.


### PR DESCRIPTION
Summary: Fixes T137546804

Test Plan:
```
buck2 test mode/opt-tsan //caffe2/benchmarks/dynamo:test
buck2 test mode/opt //caffe2/benchmarks/dynamo:test
```

Differential Revision: D41226384



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire