### PR TITLE
Fix and Re-enable test_quantize_fx_lite_script_module.py

### DIFF
--- a/test/mobile/test_quantize_fx_lite_script_module.py
+++ b/test/mobile/test_quantize_fx_lite_script_module.py
@@ -47,7 +47,11 @@ class TestLiteFuseFx(QuantizationLiteTestCase):
 
         for qconfig, node in configs:
             qconfig_dict = {"": qconfig}
-            m = prepare_fx(model, qconfig_dict)
+            m = prepare_fx(
+                model,
+                qconfig_dict,
+                example_inputs=torch.randint(low=0, high=10, size=(20,)),
+            )
             m = convert_fx(m)
             self._compare_script_and_mobile(m, input=indices)
 
@@ -65,7 +69,7 @@ class TestLiteFuseFx(QuantizationLiteTestCase):
 
         m = M().eval()
         qconfig_dict = {"": default_qconfig, "module_name": [("conv1", None)]}
-        m = prepare_fx(m, qconfig_dict)
+        m = prepare_fx(m, qconfig_dict, example_inputs=torch.randn(1, 1, 1, 1))
         data = torch.randn(1, 1, 1, 1)
         m = convert_fx(m)
         # first conv is quantized, second conv is not quantized
@@ -84,7 +88,11 @@ class TestLiteFuseFx(QuantizationLiteTestCase):
                 "": torch.ao.quantization.get_default_qconfig("qnnpack"),
                 **config,
             }
-            model = prepare_fx(model, qconfig_dict)
+            model = prepare_fx(
+                model,
+                qconfig_dict,
+                example_inputs=torch.randn(5, 5),
+            )
             quant = convert_fx(model)
 
             x = torch.randn(5, 5)


### PR DESCRIPTION
Summary: After D35984526 (https://github.com/pytorch/pytorch/commit/416899d1a9fcb9dbc8bb66ed796b86360f573903), ```torch.ao.quantization.quantize_fx.prepare_fx``` requires passing in  ```example_args```. This diff fixes the calls to ```prepare_fx``` in this test by adding in ```example_args``` as necessary.

Test Plan:
```
buck test caffe2/test:fx_quantization_lite
```

```
  ✓ ListingSuccess: caffe2/test:fx_quantization_lite : 3 tests discovered (39.689)
    ✓ Pass: caffe2/test:fx_quantization_lite - test_conv2d (mobile.test_quantize_fx_lite_script_module.TestLiteFuseFx) (44.451)
    ✓ Pass: caffe2/test:fx_quantization_lite - test_embedding (mobile.test_quantize_fx_lite_script_module.TestLiteFuseFx) (45.462)
    ✓ Pass: caffe2/test:fx_quantization_lite - test_submodule (mobile.test_quantize_fx_lite_script_module.TestLiteFuseFx) (45.933)
Summary
  Pass: 3
  ListingSuccess: 1
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/3096224827259146
```

Differential Revision: D41227335

