### PR TITLE
[Profiler] Account for caching when assigning IDs

### DIFF
--- a/torch/csrc/profiler/data_flow.cpp
+++ b/torch/csrc/profiler/data_flow.cpp
@@ -82,7 +82,7 @@ void calculateUniqueTensorIDs(
           },
           [&](ExtraFields<EventType::PyCall>& py_call) {
             // torch.nn.Module
-            if (py_call.module_.has_value()&&
+            if (py_call.module_.has_value() &&
                 seen_modules.insert(py_call.module_->self_).second) {
               for (auto& p : py_call.module_->parameters_) {
                 raw_tensors(p.metadata_);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #88926
* #88925
* #88924
* #88653
* #87568
* #87567
* #87566
* #87006
* #86880
* #86854
* #86853
* __->__ #88917

The python tracer caches information about module and optimizer state. That means that for subsequent calls, the presence of a Tensor in these fields does not imply that the Tensor is still live; just that it was live during the first call. (I should perhaps rename the fields to something like `stale_parameters` to convey this.) Unless we discard subsequent calls ID assignment get tripped up when it see's a Tensor that was already released.

Differential Revision: [D41226827](https://our.internmc.facebook.com/intern/diff/D41226827/)