### PR TITLE
Update torchrun and TorchElastic to take optional `local_addr` param to allow skip local IP lookup if specified

### DIFF
--- a/torch/distributed/elastic/rendezvous/api.py
+++ b/torch/distributed/elastic/rendezvous/api.py
@@ -132,6 +132,8 @@ class RendezvousParameters:
             The minimum number of nodes to admit to the rendezvous.
         max_nodes:
             The maximum number of nodes to admit to the rendezvous.
+        local_addr:
+            The address of the local node.
         **kwargs:
             Additional parameters for the specified backend.
     """
@@ -143,6 +145,7 @@ class RendezvousParameters:
         run_id: str,
         min_nodes: int,
         max_nodes: int,
+        local_addr: Optional[str] = None,
         **kwargs,
     ):
         if not backend:
@@ -164,6 +167,7 @@ class RendezvousParameters:
         self.min_nodes = min_nodes
         self.max_nodes = max_nodes
         self.config = kwargs
+        self.local_addr = local_addr
 
     def get(self, key: str, default: Any = None) -> Any:
         """Returns the value for ``key`` if ``key`` exists, else ``default``."""

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -61,7 +61,8 @@ class LaunchConfig:
                 or a mapping keyed by local_rank to selectively redirect.
         tee: configuration to "tee" stdout/stderr to console + log file.
         metrics_cfg: configuration to initialize metrics.
-
+        local_addr: address of the local node if any. If not set, a lookup on the local
+                machine's FQDN will be performed.
     ..note:
         `rdzv_timeout` is a legacy argument that will be removed in future.
         Set the timeout via `rdzv_configs['timeout']`
@@ -84,6 +85,7 @@ class LaunchConfig:
     redirects: Union[Std, Dict[int, Std]] = Std.NONE
     tee: Union[Std, Dict[int, Std]] = Std.NONE
     metrics_cfg: Dict[str, str] = field(default_factory=dict)
+    local_addr: Optional[str] = None
 
     def __post_init__(self):
         default_timeout = 900
@@ -207,6 +209,7 @@ def launch_agent(
         run_id=config.run_id,
         min_nodes=config.min_nodes,
         max_nodes=config.max_nodes,
+        local_addr=config.local_addr,
         **config.rdzv_configs,
     )
 
@@ -224,6 +227,7 @@ def launch_agent(
         tee=config.tee,
         master_addr=master_addr,
         master_port=master_port,
+        local_addr=config.local_addr,
     )
 
     agent = LocalElasticAgent(


### PR DESCRIPTION
Summary:
Update dynamic renderzvous nodes to use rendezvous hostname if provided.
For PR: https://github.com/pytorch/pytorch/issues/85300

Before:
For dynamic renderzvous, it always grab the `fqdn` from socket for each node even if user specified the address.
For example,
https://github.com/pytorch/pytorch/blob/master/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py#L248-L256
```
return _NodeDesc(socket.getfqdn(), os.getpid(), local_id)
```

Now:
If user specifies the hostname, each node will respect the given hostname.
For example, `socket.getfqdn(<hostname>) `

Test Plan: Unit tests.

Differential Revision: D41204028

