### PR TITLE
don't use prims.unsqueeze in group_norm

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2800,6 +2800,11 @@ def _unsqueeze_multiple(x: TensorLikeType, dimensions: List[int]) -> TensorLikeT
         x = torch.unsqueeze(x, dim)
     return x
 
+def _squeeze_multiple(x: TensorLikeType, dimensions: List[int]) -> TensorLikeType:
+    for idx in reversed(sorted(dimensions)):
+        x = torch.squeeze(x, idx)
+    return x
+
 
 @register_decomposition(torch.ops.aten.native_group_norm.default)
 def native_group_norm(
@@ -2849,8 +2854,8 @@ def native_group_norm(
     rstd = _maybe_convert_to_dtype(rstd, input.dtype)  # type: ignore[assignment]
 
     # remove broadcast dimensions from mean and rstd
-    mean = prims.squeeze(mean, reduction_dims)
-    rstd = prims.squeeze(rstd, reduction_dims)
+    mean = _squeeze_multiple(mean, reduction_dims)
+    rstd = _squeeze_multiple(rstd, reduction_dims)
     return (out, mean, rstd)
 
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2800,9 +2800,10 @@ def _unsqueeze_multiple(x: TensorLikeType, dimensions: List[int]) -> TensorLikeT
         x = torch.unsqueeze(x, dim)
     return x
 
+
 def _squeeze_multiple(x: TensorLikeType, dimensions: List[int]) -> TensorLikeType:
-    for idx in reversed(sorted(dimensions)):
-        x = torch.squeeze(x, idx)
+    for dim in reversed(sorted(dimensions)):
+        x = torch.squeeze(x, dim)
     return x
 
 


### PR DESCRIPTION
inductor doesn't have prims.squeeze lowering, so this breaks it. Longer term, `squeeze` with multiple dimensions is not a prim, nvfuser implements it with a loop, inductor uses `_squeeze_multiple` helper which turns it into a loop. Prim should accept only a single dimension. 
cc @ezyang @mruberry @Lezcano @fdrocha @peterbell10, @IvanYashchuk 