### PR TITLE
[quant][executorch] Support quant fusion for cat in quant in executorch stack

### DIFF
--- a/torch/ao/quantization/backend_config/executorch.py
+++ b/torch/ao/quantization/backend_config/executorch.py
@@ -200,6 +200,14 @@ def _get_bn_configs() -> List[BackendPatternConfig]:
             .set_dtype_configs(dtype_configs))
     return bn_configs
 
+def _get_cat_configs() -> List[BackendPatternConfig]:
+    dtype_configs = [executorch_default_op_quint8_dtype_config]
+    cat_configs = []
+    cat_configs.append(
+        BackendPatternConfig(torch.cat)
+        .set_observation_type(ObservationType.OUTPUT_SHARE_OBSERVER_WITH_INPUT)
+        .set_dtype_configs(dtype_configs))
+    return cat_configs
 
 # =====================
 # |  BACKEND CONFIGS  |
@@ -214,4 +222,5 @@ def get_executorch_backend_config() -> BackendConfig:
         .set_backend_pattern_configs(_get_conv_configs()) \
         .set_backend_pattern_configs(_get_binary_ops_configs()) \
         .set_backend_pattern_configs(_get_share_qparams_ops_configs()) \
-        .set_backend_pattern_configs(_get_bn_configs())
+        .set_backend_pattern_configs(_get_bn_configs()) \
+        .set_backend_pattern_configs(_get_cat_configs())


### PR DESCRIPTION
Summary:
* added cat in executorch backend config
* added quant fusion for "dq - cat - q" pattern

Test Plan: buck run executorch/exir/tests:quant_fusion_pass -- "executorch.exir.tests.test_quant_fusion_pass.TestQuantFusionPass.test_cat"

Reviewed By: qihqi

Differential Revision: D41111054



cc @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel