### PR TITLE
Fix typos in .md and .rst files

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -3,7 +3,7 @@
 > NOTE: This README contains information for the `.github` directory but cannot be located there because it will overwrite the
 repo README.
 
-This directory contains workflows and scripts to support our CI infrastructure that runs on Github Actions.
+This directory contains workflows and scripts to support our CI infrastructure that runs on GitHub Actions.
 
 ## Workflows
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -281,7 +281,7 @@ need to support these particular versions of software.
 
 In the event a submodule cannot be fast forwarded and a patch must be applied we can take two different approaches:
 
-* (preferred) Fork the said repository under the pytorch Github organization, apply the patches we need there, and then switch our submodule to accept our fork.
+* (preferred) Fork the said repository under the pytorch GitHub organization, apply the patches we need there, and then switch our submodule to accept our fork.
 * Get the dependencies maintainers to support a release branch for us
 
 Editing submodule remotes can be easily done with: (running from the root of the git repository)

--- a/caffe2/contrib/tensorrt/README.md
+++ b/caffe2/contrib/tensorrt/README.md
@@ -15,4 +15,4 @@ For further information please explore `caffe2/python/trt/test_trt.py` test show
 
 ## Questions and Feedback
 
-Please use Github issues (https://github.com/pytorch/pytorch/issues) to ask questions, report bugs, and request new features.
+Please use GitHub issues (https://github.com/pytorch/pytorch/issues) to ask questions, report bugs, and request new features.

--- a/docs/source/community/contribution_guide.rst
+++ b/docs/source/community/contribution_guide.rst
@@ -138,7 +138,7 @@ A great deal of the tutorials on `pytorch.org <https://pytorch.org/>`__
 come from the community itself and we welcome additional contributions.
 To learn more about how to contribute a new tutorial you can learn more
 here: `PyTorch.org Tutorial Contribution Guide on
-Github <https://github.com/pytorch/tutorials/#contributing>`__
+GitHub <https://github.com/pytorch/tutorials/#contributing>`__
 
 Improving Documentation & Tutorials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/masked.rst
+++ b/docs/source/masked.rst
@@ -157,7 +157,7 @@ Binary Operators
 As you may have seen in the tutorial, :class:`MaskedTensor` also has binary operations implemented with the caveat
 that the masks in the two MaskedTensors must match or else an error will be raised. As noted in the error, if you
 need support for a particular operator or have proposed semantics for how they should behave instead, please open
-an issue on Github. For now, we have decided to go with the most conservative implementation to ensure that users
+an issue on GitHub. For now, we have decided to go with the most conservative implementation to ensure that users
 know exactly what is going on and are being intentional about their decisions with masked semantics.
 
 The available binary operators are:

--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -594,7 +594,7 @@ all of the unconvertible ops in one go you can::
 The set is approximated because some ops may be removed during the conversion
 process and don't need to be converted. Some other ops may have partial support
 that will fail conversion with particular inputs, but this should give you a
-general idea of what ops are not supported. Please feel free to open Github Issues
+general idea of what ops are not supported. Please feel free to open GitHub Issues
 for op support requests.
 
 Frequently Asked Questions

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -10,7 +10,7 @@ torch.sparse
 .. warning::
 
   The PyTorch API of sparse tensors is in beta and may change in the near future.
-  We highly welcome feature requests, bug reports and general suggestions as Github issues.
+  We highly welcome feature requests, bug reports and general suggestions as GitHub issues.
 
 Why and when to use sparsity
 ++++++++++++++++++++++++++++
@@ -40,7 +40,7 @@ Like many other performance optimization sparse storage formats are not
 always advantageous. When trying sparse formats for your use case
 you might find your execution time to decrease rather than increase.
 
-Please feel encouraged to open a Github issue if you analytically
+Please feel encouraged to open a GitHub issue if you analytically
 expected to see a stark increase in performance but measured a
 degradation instead. This helps us prioritize the implementation
 of efficient kernels and wider performance optimizations.

--- a/torch/csrc/jit/operator_upgraders/README.md
+++ b/torch/csrc/jit/operator_upgraders/README.md
@@ -226,7 +226,7 @@ def foo(x, y, z=100):
     return x, y, z
 ```
 
-2. To help understanding the BC/FC breakage changes, here are some FC breaking changes examples. The solution to resolve it is not there yet. If it's desired, please report it in either [PyTorch Forum](https://discuss.pytorch.org/) or [PyTorch Github](https://github.com/pytorch/pytorch). We will prioritize it accordingly.
+2. To help understanding the BC/FC breakage changes, here are some FC breaking changes examples. The solution to resolve it is not there yet. If it's desired, please report it in either [PyTorch Forum](https://discuss.pytorch.org/) or [PyTorch GitHub](https://github.com/pytorch/pytorch). We will prioritize it accordingly.
 
     - Adding new default argument:
     - Adding a new default argument not RIGHT BEFORE the out arguments which can be 0 or more.

--- a/torch/csrc/lazy/tutorial.md
+++ b/torch/csrc/lazy/tutorial.md
@@ -283,4 +283,4 @@ This concludes our brief introduction to LT. Hopefully, you'll remember the main
 * It's really tricky to produce such graphs without overburdening a user too much. Think, torch.jit.script, torch.jit.trace! Also, think ifs, fors, "Lions, and Tigers, and Bears, Oh My" We digressed.
 
 
-Please give LT a try and tell us what you think on Github! We are **eager, not lazy** (haha!) to hear from you!
+Please give LT a try and tell us what you think on GitHub! We are **eager, not lazy** (haha!) to hear from you!


### PR DESCRIPTION
This PR fixes typos `Github` in `.md` and `.rst` files.
`Github` -> `GitHub`
