### PR TITLE
extract pytorch non-api C++ tests to a new contbuild

### DIFF
--- a/test/cpp/lite_interpreter_runtime/test_mobile_profiler.cpp
+++ b/test/cpp/lite_interpreter_runtime/test_mobile_profiler.cpp
@@ -11,6 +11,8 @@
 
 #include <torch/csrc/profiler/events.h>
 
+#include "tools/cxx/Resources.h"
+
 #ifdef EDGE_PROFILER_USE_KINETO
 namespace torch {
 namespace jit {
@@ -42,16 +44,14 @@ bool checkMetaData(
 } // namespace
 
 TEST(MobileProfiler, ModuleHierarchy) {
-  std::string filePath(__FILE__);
-  auto testModelFile = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  testModelFile.append("to_be_profiled_module.ptl");
+  auto testModelFile = build::getResourcePath("caffe2/test/cpp/lite_interpreter_runtime/to_be_profiled_module.ptl");
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
   inputs.emplace_back(at::rand({64, 64}));
   std::string trace_file_name("/tmp/test_trace.trace");
 
-  mobile::Module bc = _load_for_mobile(testModelFile);
+  mobile::Module bc = _load_for_mobile(testModelFile.string());
   {
     KinetoEdgeCPUProfiler profiler(
         bc,
@@ -95,16 +95,14 @@ TEST(MobileProfiler, ModuleHierarchy) {
 }
 
 TEST(MobileProfiler, Backend) {
-  std::string filePath(__FILE__);
-  auto testModelFile = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  testModelFile.append("test_backend_for_profiling.ptl");
+  auto testModelFile = build::getResourcePath("caffe2/test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
   inputs.emplace_back(at::rand({64, 64}));
   std::string trace_file_name("/tmp/test_trace_backend.trace");
 
-  mobile::Module bc = _load_for_mobile(testModelFile);
+  mobile::Module bc = _load_for_mobile(testModelFile.string());
   {
     KinetoEdgeCPUProfiler profiler(
         bc,
@@ -130,16 +128,14 @@ TEST(MobileProfiler, Backend) {
 }
 
 TEST(MobileProfiler, BackendMemoryEvents) {
-  std::string filePath(__FILE__);
-  auto testModelFile = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  testModelFile.append("test_backend_for_profiling.ptl");
+  auto testModelFile = build::getResourcePath("caffe2/test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
   inputs.emplace_back(at::rand({64, 64}));
   std::string trace_file_name("/tmp/test_trace_backend_memory.trace");
 
-  mobile::Module bc = _load_for_mobile(testModelFile);
+  mobile::Module bc = _load_for_mobile(testModelFile.string());
   {
     mobile::KinetoEdgeCPUProfiler profiler(
         bc,
@@ -163,13 +159,7 @@ TEST(MobileProfiler, BackendMemoryEvents) {
 }
 
 TEST(MobileProfiler, ProfilerEvent) {
-  /*
-   * TODO: Using __FILE__ is unreliable e.g. it fails to resolve correctly when
-   * using buck2, works ok with buck1
-   */
-  std::string filePath(__FILE__);
-  auto testModelFile = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  testModelFile.append("test_backend_for_profiling.ptl");
+  auto testModelFile = build::getResourcePath("caffe2/test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
@@ -180,7 +170,7 @@ TEST(MobileProfiler, ProfilerEvent) {
       torch::profiler::ProfilerPerfEvents.begin(),
       torch::profiler::ProfilerPerfEvents.end());
 
-  mobile::Module bc = _load_for_mobile(testModelFile);
+  mobile::Module bc = _load_for_mobile(testModelFile.string());
   {
     // Bail if something goes wrong here
     try {

--- a/test/cpp/lite_interpreter_runtime/test_mobile_profiler.cpp
+++ b/test/cpp/lite_interpreter_runtime/test_mobile_profiler.cpp
@@ -44,7 +44,8 @@ bool checkMetaData(
 } // namespace
 
 TEST(MobileProfiler, ModuleHierarchy) {
-  auto testModelFile = build::getResourcePath("caffe2/test/cpp/lite_interpreter_runtime/to_be_profiled_module.ptl");
+  auto testModelFile = build::getResourcePath(
+      "caffe2/test/cpp/lite_interpreter_runtime/to_be_profiled_module.ptl");
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
@@ -95,7 +96,8 @@ TEST(MobileProfiler, ModuleHierarchy) {
 }
 
 TEST(MobileProfiler, Backend) {
-  auto testModelFile = build::getResourcePath("caffe2/test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
+  auto testModelFile = build::getResourcePath(
+      "caffe2/test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
@@ -128,7 +130,8 @@ TEST(MobileProfiler, Backend) {
 }
 
 TEST(MobileProfiler, BackendMemoryEvents) {
-  auto testModelFile = build::getResourcePath("caffe2/test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
+  auto testModelFile = build::getResourcePath(
+      "caffe2/test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));
@@ -159,7 +162,8 @@ TEST(MobileProfiler, BackendMemoryEvents) {
 }
 
 TEST(MobileProfiler, ProfilerEvent) {
-  auto testModelFile = build::getResourcePath("caffe2/test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
+  auto testModelFile = build::getResourcePath(
+      "caffe2/test/cpp/lite_interpreter_runtime/test_backend_for_profiling.ptl");
 
   std::vector<IValue> inputs;
   inputs.emplace_back(at::rand({64, 64}));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88966

We are breaking up the pytorch_core contbuild which is timing out when
converting to buck2.

Differential Revision: [D39769126](https://our.internmc.facebook.com/intern/diff/D39769126/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D39769126/)!