### PR TITLE
[testing] fix a key in parse_namespace()

### DIFF
--- a/test/functorch/xfail_suggester.py
+++ b/test/functorch/xfail_suggester.py
@@ -69,7 +69,7 @@ def parse_namespace(base):
         'linalg_': 'linalg',
         '_masked_': '_masked',
         'sparse_': 'sparse',
-        'speical_': 'special',
+        'special_': 'special',
     }
     for heading in mappings.keys():
         if base.startswith(heading):


### PR DESCRIPTION
This PR fixes an incorrect key name of `mappings` dict in `parse_namespace()`