### PR TITLE
[CI] Push `latest` and hash+CUDAver tags

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
       - name: Login to GitHub Container Registry
-        if: ${{ env.WITH_PUSH == 'true' }}
+        # if: ${{ env.WITH_PUSH == 'true' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
       - name: Login to GitHub Container Registry
-        # if: ${{ env.WITH_PUSH == 'true' }}
+        if: ${{ env.WITH_PUSH == 'true' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -92,8 +92,7 @@ jobs:
         run: |
           make -f docker.Makefile "${BUILD_IMAGE_TYPE}-image"
       - name: Push nightly tags
-        # if: ${{ github.event.ref == 'refs/heads/nightly' && matrix.image_type == 'runtime' }}
-        if: ${{ matrix.image_type == 'runtime' }}
+        if: ${{ github.event.ref == 'refs/heads/nightly' && matrix.image_type == 'runtime' }}
         run: |
           PYTORCH_DOCKER_TAG="${PYTORCH_VERSION}-runtime"
           CUDA_VERSION=$(python3 -c "import re;print(re.search('CUDA_VERSION\s+=\s+([0-9\.]+)',open('docker.Makefile').read())[1],end='')")

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -91,6 +91,21 @@ jobs:
         # WITH_PUSH is used here to determine whether or not to add the --push flag
         run: |
           make -f docker.Makefile "${BUILD_IMAGE_TYPE}-image"
+      - name: Push nightly tags
+        # if: ${{ github.event.ref == 'refs/heads/nightly' && matrix.image_type == 'runtime' }}
+        if: ${{ matrix.image_type == 'runtime' }}
+        run: |
+          PYTORCH_DOCKER_TAG=${PYTORCH_VERSION}-runtime
+          CUDA_VERSION=$(python -c "import re;print(re.search('CUDA_VERSION\s+=\s+([0-9\.]+)',open('docker.Makefile').read())[1],end='')")
+          PYTORCH_NIGHTLY_COMMIT=$(docker run ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
+                                          python -c 'import torch; print(torch.version.git_version[:7],end="")')
+          docker tag ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
+                 ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION}
+          docker push ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION}
+
+          docker tag ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION} \
+                 ghcr.io/pytorch/pytorch-nightly:latest
+          docker push ghcr.io/pytorch/pytorch-nightly:latest
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
         if: always()

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -95,15 +95,15 @@ jobs:
         # if: ${{ github.event.ref == 'refs/heads/nightly' && matrix.image_type == 'runtime' }}
         if: ${{ matrix.image_type == 'runtime' }}
         run: |
-          PYTORCH_DOCKER_TAG=${PYTORCH_VERSION}-runtime
-          CUDA_VERSION=$(python -c "import re;print(re.search('CUDA_VERSION\s+=\s+([0-9\.]+)',open('docker.Makefile').read())[1],end='')")
-          PYTORCH_NIGHTLY_COMMIT=$(docker run ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
+          PYTORCH_DOCKER_TAG="${PYTORCH_VERSION}-runtime"
+          CUDA_VERSION=$(python3 -c "import re;print(re.search('CUDA_VERSION\s+=\s+([0-9\.]+)',open('docker.Makefile').read())[1],end='')")
+          PYTORCH_NIGHTLY_COMMIT=$(docker run ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_DOCKER_TAG}" \
                                           python -c 'import torch; print(torch.version.git_version[:7],end="")')
-          docker tag ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
-                 ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION}
-          docker push ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION}
+          docker tag ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_DOCKER_TAG}" \
+                 ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION}"
+          docker push ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION}"
 
-          docker tag ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION} \
+          docker tag ghcr.io/pytorch/pytorch-nightly:"${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION}" \
                  ghcr.io/pytorch/pytorch-nightly:latest
           docker push ghcr.io/pytorch/pytorch-nightly:latest
       - name: Teardown Linux


### PR DESCRIPTION
For nightly docker build to simulate the behavior of `push_nightly_docker_ghcr.yml`

Tested in https://github.com/pytorch/pytorch/actions/runs/3465221336/jobs/5787694933

Fixes https://github.com/pytorch/pytorch/issues/88833

