### PR TITLE
[WIP] dedupe tensors saved by save_on_cpu when running  grad(grad

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1952,6 +1952,13 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     refresh_contiguous();
   }
 
+  virtual std::tuple<c10::optional<c10::intrusive_ptr<TensorImpl>>, std::function<c10::intrusive_ptr<TensorImpl>(c10::intrusive_ptr<TensorImpl>)>> unwrap() {
+    auto fn = [=](c10::intrusive_ptr<TensorImpl> t) -> c10::intrusive_ptr<TensorImpl> {
+      return t;
+    };
+    return std::tuple<c10::optional<c10::intrusive_ptr<TensorImpl>>, std::function<c10::intrusive_ptr<TensorImpl>(c10::intrusive_ptr<TensorImpl>)>>(c10::nullopt, fn);
+  }
+
   // Inference tensor doesn't have version counter,
   // set_version_counter is no-op for them.
   void set_version_counter(const c10::VariableVersion& version_counter) {
@@ -2988,6 +2995,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // Call into Python for layout()
   bool python_custom_layout_ : 1;
 
+ public:
   // The set of DispatchKeys which describe this tensor.  NB: this
   // does NOT include Autograd (historically, it did, but
   // not anymore!)

--- a/functorch/_src/vmap.py
+++ b/functorch/_src/vmap.py
@@ -24,16 +24,17 @@ out_dims_t = Union[int, Tuple[int, ...]]
 
 
 def doesnt_support_saved_tensors_hooks(f):
-    message = (
-        "functorch transforms don't yet support saved tensor hooks. "
-        "Please open an issue with your use case."
-    )
+    return f
+    # message = (
+    #     "functorch transforms don't yet support saved tensor hooks. "
+    #     "Please open an issue with your use case."
+    # )
 
-    @functools.wraps(f)
-    def fn(*args, **kwargs):
-        with torch.autograd.graph.disable_saved_tensors_hooks(message):
-            return f(*args, **kwargs)
-    return fn
+    # @functools.wraps(f)
+    # def fn(*args, **kwargs):
+    #     with torch.autograd.graph.disable_saved_tensors_hooks(message):
+    #         return f(*args, **kwargs)
+    # return fn
 
 
 # Checks that all args-to-be-batched have the same batch dim size


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88976
* #85849
* #88357

TODO: still need to stash and replay autograd metadata! 

I don't think I want to continue with this exact approach, I'd rather do more things in python like in https://github.com/pytorch/pytorch/pull/89159, but we still need some API in python to stash and restore autograd information. This feels like .data again... because what we really want to do here is replace the value_ tensor from underneath the TensorWrapper.

```
import torch
from functorch import grad
from torch.autograd.graph import save_on_cpu

x = torch.tensor(3., requires_grad=True)

def fn(x):
    return x.sin().sin()

with save_on_cpu():
    grad(fn)(x)
```