### PR TITLE
Allow ROCm runners to have 2 or more gpus

### DIFF
--- a/.github/actions/setup-rocm/action.yml
+++ b/.github/actions/setup-rocm/action.yml
@@ -35,8 +35,13 @@ runs:
       shell: bash
       run: |
         ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-        if [[ $ngpu -lt 2 ]]; then
-            echo "Failed to detect at least 2 GPUs on the runner"
+        if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+            if [[ $ngpu -eq 0 ]]; then
+              echo "Error: Failed to detect any GPUs on the runner"
+            else
+              echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+            fi
+            echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
             exit 1
         fi
 

--- a/.github/actions/setup-rocm/action.yml
+++ b/.github/actions/setup-rocm/action.yml
@@ -35,8 +35,8 @@ runs:
       shell: bash
       run: |
         ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-        if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-            echo "Failed to detect GPUs on the runner"
+        if [[ $ngpu -lt 2 ]]; then
+            echo "Failed to detect at least 2 GPUs on the runner"
             exit 1
         fi
 

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -77,8 +77,8 @@ concurrency:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -77,8 +77,13 @@ concurrency:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -844,8 +844,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -987,8 +992,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1130,8 +1140,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1273,8 +1288,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -844,8 +844,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -987,8 +987,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1130,8 +1130,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1273,8 +1273,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -844,8 +844,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -987,8 +992,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1130,8 +1140,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1273,8 +1288,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -844,8 +844,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -987,8 +987,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1130,8 +1130,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1273,8 +1273,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -336,8 +336,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -476,8 +481,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -854,8 +864,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -994,8 +1009,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1372,8 +1392,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1512,8 +1537,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1890,8 +1920,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -2030,8 +2065,13 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ $ngpu -lt 2 ]]; then
-              echo "Failed to detect at least 2 GPUs on the runner"
+          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
+              if [[ $ngpu -eq 0 ]]; then
+                echo "Error: Failed to detect any GPUs on the runner"
+              else
+                echo "Error: Detected $ngpu GPUs on the runner, when only 2 or 4 were expected"
+              fi
+              echo "Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
               exit 1
           fi
       - name: Runner health check disconnect on failure

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -336,8 +336,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -476,8 +476,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -854,8 +854,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -994,8 +994,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1372,8 +1372,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1512,8 +1512,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -1890,8 +1890,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure
@@ -2030,8 +2030,8 @@ jobs:
         if: always()
         run: |
           ngpu=$(rocminfo | grep -c -E 'Name:.*\sgfx')
-          if [[ "x$ngpu" != "x2" && "x$ngpu" != "x4" ]]; then
-              echo "Failed to detect GPUs on the runner"
+          if [[ $ngpu -lt 2 ]]; then
+              echo "Failed to detect at least 2 GPUs on the runner"
               exit 1
           fi
       - name: Runner health check disconnect on failure


### PR DESCRIPTION
[This run](https://github.com/pytorch/pytorch/actions/runs/3432340660/jobs/5721731207) failed claiming that it couldn't detect GPUs on the runner. Inspecting the rocminfo output (higher up in logs) show that it in fact had three GPUs, but the workflow is currently setup to expect either 2 or 4 gpus.

The workflow files currently have no way of specifying wither it'll get a 2 gpu or a 4 gpu machine, so really 2 is all any test can expect to get. [This old PR](https://github.com/pytorch/pytorch/pull/72142/files) shows that historically ROCm runners only had 4 gpus, then later the logic was extended to expect 2 GPU runners as well.

It's not clear how the ROCm runner ended up with 3 gpus instead of 2 or 4 (something for ROCm folks to look into) but there doesn't seem to be a good reason for ROCm workflows to fail if 3 (or 5) gpus ever show up on a machine. This PR makes the workflows resilient to ROCm having these alternate GPU counts

Also filed https://github.com/pytorch/pytorch/issues/89012 against the ROCm team to explore why the runner only had 3 gpus

cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport