### PR TITLE
[Easy] Remove outdated code

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -856,19 +856,6 @@ class FakeTensorMode(TorchDispatchMode):
             with self:
                 return decomposition_table[func](*args, **kwargs)
 
-        # prims already wrap FakeTensor inputs to FakeTensor outputs
-        # and do device logic, we dont need do anything but run them
-        # and ensure that Meta kernels are dispatched to (see)
-        # Fake Tensor Dispatch Keys
-        # TODO - we should be use the prim aten impl
-        if (
-            "prims::" in func._schema.name
-            and len(flat_arg_fake_tensors) != 0
-            and hasattr(func, "prim_meta_impl")
-        ):
-            with self:
-                return func.prim_meta_impl(*args, **kwargs)
-
         if has_symbolic_sizes:
             if not self.cpp_meta_supports_symint(func):
                 raise RuntimeError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89018

The prims meta are now registered through the dispatcher, no need to have separate logic for them.