### PR TITLE
[cuBLAS] Fix default cuBLAS workspace size and parsing for multiple workspaces

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -54,7 +54,7 @@ size_t parseChosenWorkspaceSize() {
     std::sregex_iterator next(config.begin(), config.end(), exp);
     std::sregex_iterator end;
     if (next == end) {
-      TORCH_WARN("Could not parse CUBLAS_WORKSPACE_CONFIG, using default workspace size:", default_size);
+      TORCH_WARN("Could not parse CUBLAS_WORKSPACE_CONFIG, using default workspace size of ", default_size, " bytes.");
       return default_size;
     }
     while (next != end) {

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -72,7 +72,7 @@ size_t parseChosenWorkspaceSize() {
 }
 
 size_t getChosenWorkspaceSize() {
-  static size_t pool_size = parseChosenWorkspaceSize();
+  size_t pool_size = parseChosenWorkspaceSize();
   return pool_size;
 }
 

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -48,19 +48,20 @@ size_t parseChosenWorkspaceSize() {
     std::sregex_iterator next(config.begin(), config.end(), exp);
     std::sregex_iterator end;
     if (next == end) {
-      TORCH_WARN("Could not parse CUBLAS_WORKSPACE_CONFIG, using default workspace size of 4096.");
-      return 4096 * 1024;
+      TORCH_WARN("Could not parse CUBLAS_WORKSPACE_CONFIG, using default workspace size of :4096:8:16:8.");
+      return 4096 * 1024 * 8 + 16 * 1024 * 8;
     }
     while (next != end) {
       std::smatch match = *next;
       TORCH_CHECK(match.size() == 3, "Expected CUBLAS_WORKSPACE_SPACE_CONFIG match of size 3 (Format :SIZE:COUNT)");
       size_t curr_size = (size_t) std::stoi(match.str(1));
-      total_size += curr_size * 1024;
+      size_t count = (size_t) std::stoi(match.str(2));
+      total_size += curr_size * 1024 * count;
       next++;
     }
     return total_size;
-  } else /* :4096:8 */ {
-    return 4096 * 1024;
+  } else /* :4096:8:16:8 */ {
+    return 4096 * 1024 * 8 + 16 * 1024 * 8;
   }
 }
 

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -42,8 +42,7 @@ void clearCublasWorkspaces() {
 size_t parseChosenWorkspaceSize() {
   const char * val = getenv("CUBLAS_WORKSPACE_CONFIG");
   /* :4096:2:16:8 default, 32MiB for Hopper */
-  int device;
-  cudaDeviceProp* properties = at::cuda::getDeviceProperties(cudaGetDevice(&device));
+  cudaDeviceProp* properties = at::cuda::getCurrentDeviceProperties();
   const bool sm90 = properties->major == 9 && properties->minor == 0;
   const size_t default_size = sm90 ? 4096 * 8 * 1024 : 4096 * 1024 * 2 + 16 * 1024 * 8;
 

--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -43,7 +43,7 @@ size_t parseChosenWorkspaceSize() {
   const char * val = getenv("CUBLAS_WORKSPACE_CONFIG");
   /* :4096:2:16:8 default, 32MiB for Hopper */
   cudaDeviceProp* properties = at::cuda::getCurrentDeviceProperties();
-  const bool sm90 = properties->major == 9 && properties->minor == 0;
+  const bool sm90 = properties != nullptr && properties->major == 9 && properties->minor == 0;
   const size_t default_size = sm90 ? 4096 * 8 * 1024 : 4096 * 1024 * 2 + 16 * 1024 * 8;
 
   if (val) {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -600,6 +600,34 @@ class TestCuda(TestCase):
         q_copy[1].fill_(10)
         self.assertEqual(q_copy[3], torch.cuda.IntStorage(10).fill_(10))
 
+    @unittest.skipIf(TEST_CUDAMALLOCASYNC, "temporarily disabled")
+    def test_cublas_workspace_explicit_allocation(self):
+        a = torch.randn(7, 7, device='cuda', requires_grad=False)
+        default_workspace_size = 4096 * 2 * 1024 + 16 * 8 * 1024  # :4096:2:16:8
+        # different size (32 MiB) expected on Hopper GPU
+        if torch.cuda.get_device_capability() == (9, 0):
+            default_workspace_size = 4096 * 8 * 1024
+
+        def check_workspace_size(inp):
+            torch._C._cuda_clearCublasWorkspaces()
+            start = torch.torch.cuda.memory_stats()['active_bytes.all.allocated']
+            with torch.no_grad():
+                torch.matmul(inp, inp)
+            finish = torch.torch.cuda.memory_stats()['active_bytes.all.allocated']
+            return finish - start
+        
+        # check default
+        os.environ['CUBLAS_WORKSPACE_CONFIG'] = ''
+        self.assertTrue(abs(check_workspace_size(a) - default_workspace_size) < 524288)
+
+        # check default with bad user config
+        os.environ['CUBLAS_WORKSPACE_CONFIG'] = '-1'
+        self.assertTrue(abs(check_workspace_size(a) - default_workspace_size) < 524288)
+
+        # check valid config
+        os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':1024:8:512:4:128:8'
+        self.assertTrue(abs(check_workspace_size(a) - (8196 * 1024 + 2048 * 1024 + 1024 * 1024)) < 524288)
+
     def test_cublas_allow_tf32_get_set(self):
         skip_tf32_cublas = 'TORCH_ALLOW_TF32_CUBLAS_OVERRIDE' in os.environ and\
             int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE'])

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -615,7 +615,7 @@ class TestCuda(TestCase):
                 torch.matmul(inp, inp)
             finish = torch.torch.cuda.memory_stats()['active_bytes.all.allocated']
             return finish - start
-        
+
         # check default
         os.environ['CUBLAS_WORKSPACE_CONFIG'] = ''
         self.assertTrue(abs(check_workspace_size(a) - default_workspace_size) < 524288)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -625,8 +625,10 @@ class TestCuda(TestCase):
         self.assertTrue(abs(check_workspace_size(a) - default_workspace_size) < 524288)
 
         # check valid config
-        os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':1024:8:512:4:128:8'
-        self.assertTrue(abs(check_workspace_size(a) - (8196 * 1024 + 2048 * 1024 + 1024 * 1024)) < 524288)
+        os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':128:8:64:16:32:32'
+        self.assertTrue(abs(check_workspace_size(a) - (3072 * 1024)) < 524288)
+
+        torch._C._cuda_clearCublasWorkspaces()
 
     def test_cublas_allow_tf32_get_set(self):
         skip_tf32_cublas = 'TORCH_ALLOW_TF32_CUBLAS_OVERRIDE' in os.environ and\


### PR DESCRIPTION
Follow-up of #86167 ; The number of pools was mistakenly ignored and the default workspace size appears to be too small to match selected cuBLAS kernels before the explicit allocation change.

CC @ptrblck @ngimel 
