### PR TITLE
[SDPA] Create native function for determining which implementation of SDP to call

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13239,6 +13239,10 @@
   variants: function
   autogen: _scaled_dot_product_attention.out
 
+- func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> int
+  dispatch:
+    CPU: _fused_sdp_choice_cpp
+
 # Register the math kernel for cpu
 - func: _scaled_dot_product_attention_forward(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> (Tensor, Tensor)
   variants: function

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13242,6 +13242,7 @@
 - func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> int
   dispatch:
     CPU: _fused_sdp_choice_cpp
+    CUDA: _fused_sdp_choice_cuda
 
 # Register the math kernel for cpu
 - func: _scaled_dot_product_attention_forward(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> (Tensor, Tensor)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13242,7 +13242,7 @@
 - func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> int
   dispatch:
     CPU, NestedTensorCPU, Meta: _fused_sdp_choice_cpp
-    NestedTensorCUDA: _fused_sdp_choice_cuda
+    CUDA, NestedTensorCUDA: _fused_sdp_choice_cuda
 
 # Register the math kernel for cpu
 - func: _scaled_dot_product_attention_forward(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> (Tensor, Tensor)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13241,8 +13241,8 @@
 
 - func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> int
   dispatch:
-    CPU: _fused_sdp_choice_cpp
-    CUDA: _fused_sdp_choice_cuda
+    CPU, NestedTensorCPU, Meta: _fused_sdp_choice_cpp
+    NestedTensorCUDA: _fused_sdp_choice_cuda
 
 # Register the math kernel for cpu
 - func: _scaled_dot_product_attention_forward(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> (Tensor, Tensor)

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -7,6 +7,7 @@
 #include <ATen/TensorIndexing.h>
 #include <ATen/cpu/vec/vec256/vec256.h>
 #include <ATen/native/transformers/attention.h>
+#include <ATen/native/transformers/sdp_utils_cpp.h>
 
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -683,6 +684,11 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention(
           return at::_scaled_dot_product_attention_math(query_, key, value, attn_mask_, dropout_p, need_attn_weights, is_causal);
         }
         return at::_scaled_dot_product_attention_forward(query_, key, value, attn_mask_, dropout_p, need_attn_weights, is_causal);
+}
+
+int64_t _fused_sdp_choice_cpp(const Tensor& query_, const Tensor& key, const Tensor& value,
+        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool need_attn_weights, bool is_causal){
+  return static_cast<int64_t>(sdp::SDPBackend::math);
 }
 
 std::tuple<Tensor, Tensor> _scaled_dot_product_attention_forward_math(

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -789,6 +789,13 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_forward_cuda(
     }
 }
 
+int64_t _fused_sdp_choice_cuda(const Tensor& query_, const Tensor& key, const Tensor& value,
+        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool need_attn_weights, bool is_causal){
+  sdp::sdp_params kernel_params{query_, key, value, attn_mask_.has_value(), dropout_p, need_attn_weights, is_causal};
+  auto backend = select_sdp_backend(kernel_params);
+  return static_cast<int64_t>(backend);
+}
+
 Tensor flash_scaled_dot_product_attention(
     const Tensor& query,
     const Tensor& key,

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -793,6 +793,12 @@ int64_t _fused_sdp_choice_cuda(const Tensor& query_, const Tensor& key, const Te
         const c10::optional<Tensor>& attn_mask_, double dropout_p, bool need_attn_weights, bool is_causal){
   sdp::sdp_params kernel_params{query_, key, value, attn_mask_.has_value(), dropout_p, need_attn_weights, is_causal};
   auto backend = select_sdp_backend(kernel_params);
+  if (backend == sdp::SDPBackend::error) {
+    TORCH_CHECK(
+        false,
+        "No viable backend for scaled_dot_product_attention was found. ",
+        "This is likely due to turning off both the math kernel and the fused kernels.");
+  }
   return static_cast<int64_t>(backend);
 }
 

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -10,6 +10,7 @@
 #include <c10/util/env.h>
 #include <c10/util/irange.h>
 #include <ATen/NestedTensorImpl.h>
+#include <ATen/native/transformers/sdp_utils_cpp.h>
 
 #include <functional>
 #include <unordered_set>
@@ -26,8 +27,6 @@ struct sdp_params {
   bool need_attn_weights;
   bool is_causal;
 };
-
-enum class SDPBackend { flash_attention, efficient_attention, math, error };
 
 template <typename dtype_vector>
 inline bool check_tensor_dtype(

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -1,4 +1,9 @@
 #pragma once
 namespace sdp {
-enum class SDPBackend {math, flash_attention, efficient_attention, error};
+enum class SDPBackend {
+  error = -1,
+  math = 0,
+  flash_attention = 1,
+  efficient_attention = 2
+};
 } // namespace sdp

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -1,0 +1,4 @@
+#pragma once
+namespace sdp {
+enum class SDPBackend {math, flash_attention, efficient_attention, error};
+} // namespace sdp

--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -52,6 +52,8 @@ torch.backends.cuda
 
 .. autofunction:: torch.backends.cuda.preferred_linalg_library
 
+.. autoclass:: torch.backends.cuda.SDPBackend
+
 .. autofunction:: torch.backends.cuda.flash_sdp_enabled
 
 .. autofunction:: torch.backends.cuda.enable_mem_efficient_sdp

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1130,7 +1130,7 @@ class TestTransformers(NNTestCase):
             q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
             assert torch._fused_sdp_choice(q, k, v) == SDPBackend.MATH
 
-        if TEST_CUDA:
+        if TEST_CUDA and not TEST_WITH_ROCM and not IS_WINDOWS:
             batch_size, seq_len, num_heads, head_dim = 32, 64, 16, 64
             shape = (batch_size, seq_len, num_heads, head_dim)
             device = "cuda"

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1144,8 +1144,12 @@ class TestTransformers(NNTestCase):
             value = value.view(batch_size, -1, num_heads, head_dim).transpose(1, 2)
             key = key.view(batch_size, -1, num_heads, head_dim).transpose(1, 2)
 
-            assert torch._fused_sdp_choice(query, key, value) == SDPBackend.FLASH_ATTENTION
+            if SM80OrLater:
+                assert torch._fused_sdp_choice(query, key, value) == SDPBackend.FLASH_ATTENTION
+            else:
+                assert torch._fused_sdp_choice(query, key, value) == SDPBackend.EFFICIENT_ATTENTION
 
+            # Change dtype to float32 so that efficient attention should get chosen
             make_tensor = partial(self.rand_tensor, device=device, dtype=torch.float32, packed=True)
             make_nt = partial(self.rand_nt, device=device, dtype=torch.float32, packed=True)
 

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -173,10 +173,11 @@ class SDPBackend(IntEnum):
     This class needs to stay inline with the enum defined in:
     pytorch/aten/src/ATen/native/transformers/sdp_utils_cpp.h
     """
+    ERROR = -1
     MATH = 0
     FLASH_ATTENTION = 1
     EFFICIENT_ATTENTION = 2
-    ERROR = 3
+
 
 def flash_sdp_enabled():
     r"""

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -1,11 +1,12 @@
 import sys
 import torch
 import contextlib
+from enum import IntEnum
 
 from typing import Union
 
 __all__ = ["is_built", "cuFFTPlanCacheAttrContextProp", "cuFFTPlanCache", "cuFFTPlanCacheManager",
-           "cuBLASModule", "preferred_linalg_library", "cufft_plan_cache", "matmul", "enable_flash_sdp",
+           "cuBLASModule", "preferred_linalg_library", "cufft_plan_cache", "matmul", "SDPBackend", "enable_flash_sdp",
            "flash_sdp_enabled", "enable_mem_efficient_sdp", "mem_efficient_sdp_enabled",
            "math_sdp_enabled", "enable_math_sdp", "sdp_kernel"]
 
@@ -163,6 +164,19 @@ def preferred_linalg_library(backend: Union[None, str, torch._C._LinalgBackend] 
 
     return torch._C._get_linalg_preferred_backend()
 
+
+class SDPBackend(IntEnum):
+    r"""Enum class for the scaled dot product attention backends.
+
+    .. warning:: This flag is experimental and subject to change.'
+
+    This class needs to stay inline with the enum defined in:
+    pytorch/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+    """
+    MATH = 0
+    FLASH_ATTENTION = 1
+    EFFICIENT_ATTENTION = 2
+    ERROR = 3
 
 def flash_sdp_enabled():
     r"""

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -73,6 +73,7 @@ FUNCTIONAL_OPS_THAT_CANNOT_GET_AN_OUT_VARIANT = [
     "record_stream",  # no return
     "sparse_dim",  # returns an int
     "_nested_tensor_offsets",  # returns a vector of ints
+    "_fused_sdp_choice", # returns an int
 ]
 
 INPLACE_OPS_THAT_DONT_GET_GROUPED_PROPERLY = [

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -73,7 +73,7 @@ FUNCTIONAL_OPS_THAT_CANNOT_GET_AN_OUT_VARIANT = [
     "record_stream",  # no return
     "sparse_dim",  # returns an int
     "_nested_tensor_offsets",  # returns a vector of ints
-    "_fused_sdp_choice", # returns an int
+    "_fused_sdp_choice",  # returns an int
 ]
 
 INPLACE_OPS_THAT_DONT_GET_GROUPED_PROPERLY = [


### PR DESCRIPTION
# Summary
Creates a callable native function that can determine which implementation of scaled dot product will get called. This allows to bump re-order the runtime dispatch of SDP to enable autograd.