### PR TITLE
Add debug handle to xnnpack schema

### DIFF
--- a/torch/csrc/jit/backends/xnnpack/serialization/schema.fbs
+++ b/torch/csrc/jit/backends/xnnpack/serialization/schema.fbs
@@ -54,6 +54,8 @@ union ValueUnion {
 
 table Node {
   node:NodeUnion;
+  // An int which can be linked back to the node in the origin graph
+  debug_handle:uint;
 }
 
 table Value {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89036
* __->__ #89033

As title, add three things to the schema
1. debug handle for each node
2. file identifier, so we can sanity check we are getting the xnnpack schema flatbuffers file, instead of other random binary
3. extension, so the dumped binary will end up with its own extension like `myschema.xnnpack` (maybe can have a better name) instead of the default extension `.bin`

Differential Revision: [D40906970](https://our.internmc.facebook.com/intern/diff/D40906970/)