### PR TITLE
Use software approach to catch overflow ( `c10/utils/safe_numerics.h` ) on ARM devices

### DIFF
--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -20,11 +20,14 @@ namespace c10 {
 C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_add_overflow(a, b, out);
-#else
+#elif defined (_M_X64)
   unsigned long long tmp;
   auto carry = _addcarry_u64(0, a, b, &tmp);
   *out = tmp;
   return carry;
+#else
+  *out = a + b;
+  return *out < a;
 #endif
 }
 

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -22,13 +22,13 @@ C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t* out) {
   return __builtin_add_overflow(a, b, out);
 #else
   unsigned long long tmp;
-  #if defined (_M_ARM64) || defined (_M_HYBRID_X86_ARM64) || defined (_M_ARM64EC)
-    tmp = a + b;
-    unsigned long long vector = (a & b) ^ ((a ^ b) & ~tmp);
-    auto carry = vector >> 63;
-  #else
-    auto carry = _addcarry_u64(0, a, b, &tmp);
-  #endif
+#if defined(_M_IX86) || defined(_M_X64)
+  auto carry = _addcarry_u64(0, a, b, &tmp);
+#else
+  tmp = a + b;
+  unsigned long long vector = (a & b) ^ ((a ^ b) & ~tmp);
+  auto carry = vector >> 63;
+#endif
   *out = tmp;
   return carry;
 #endif


### PR DESCRIPTION
Fixes #89040 
