### PR TITLE
Also running the default mode in periodic workflows

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -125,6 +125,9 @@ def set_periodic_modes(test_matrix: Dict[str, List[Any]]) -> Dict[str, List[Any]
     }
 
     for config in test_matrix.get("include", []):
+        # Also need to run the default mode
+        scheduled_test_matrix["include"].append(config.copy())
+
         for mode in SUPPORTED_PERIODICAL_MODES:
             cfg = config.copy()
             cfg[mode] = mode

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -109,7 +109,7 @@ class TestConfigFilter(TestCase):
             test_matrix = yaml.safe_load(case["test_matrix"])
             scheduled_test_matrix = set_periodic_modes(test_matrix)
             self.assertEqual(
-                len(test_matrix["include"]) * len(SUPPORTED_PERIODICAL_MODES),
+                len(test_matrix["include"]) * (len(SUPPORTED_PERIODICAL_MODES) + 1),
                 len(scheduled_test_matrix["include"])
             )
 


### PR DESCRIPTION
In additional to `mem_leak_check`, `rerun_disabled_tests`, and other modes.  I'm not quite sure if this is a bug or a feature. 
 For example, periodic https://hud.pytorch.org/pytorch/pytorch/commit/4ad7b17fabd2a2b6873bc369bd223223ff1e628b now run `mem_leak_check` mode.  If this is a feature, we can close this PR.  But it seems that we should run `mem_leak_check` in additional to the default periodic jobs.