### PR TITLE
Fix typo in Dispatcher.h

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -735,4 +735,4 @@ struct hash<c10::OperatorHandle> {
   }
 };
 
-} // hamespace std
+} // namespace std


### PR DESCRIPTION
Fix typo in Dispatcher.h: hamespace -> namespace