### PR TITLE
Use scalar implementation to keep the precision in linspace of integral types

### DIFF
--- a/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
+++ b/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
@@ -54,7 +54,9 @@ static void linspace_kernel(TensorIterator& iter, const Scalar& scalar_start, co
     at::parallel_for(0, steps, internal::GRAIN_SIZE, [&](int64_t p_begin, int64_t p_end) {
       int64_t idx(p_begin);
       TensorIterator it(iter);
-      cpu_serial_kernel_vec(
+      // Remove vectorization implementation, due to the precision issue between integer and double.
+      // Will not harm the performance.
+      cpu_serial_kernel(
           it,
           [start, end, step, halfway, steps, &idx]() -> scalar_t {
             if (idx < halfway) {
@@ -62,17 +64,6 @@ static void linspace_kernel(TensorIterator& iter, const Scalar& scalar_start, co
             } else {
               return end - step * (steps - (idx++) - 1);
             }
-          },
-          [start, end, step, halfway, steps, &idx]() -> Vectorized<scalar_t> {
-            Vectorized<scalar_t> res;
-            if (idx < halfway) {
-              res = Vectorized<scalar_t>::arange(start + step * idx, step);
-            } else {
-              res = Vectorized<scalar_t>::arange(
-                  end - step * (steps - idx - 1), step);
-            }
-            idx += Vectorized<scalar_t>::size();
-            return res;
           }, {p_begin, p_end});
     });
   });

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -21,7 +21,7 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA, skipCPUIf, dtypesIfCUDA, skipMeta)
 from torch.testing._internal.common_dtype import (
     all_types_and_complex_and, all_types_and, floating_and_complex_types,
-    floating_types, floating_and_complex_types_and, integral_types_and, get_all_dtypes
+    floating_types, floating_and_complex_types_and, integral_types, integral_types_and, get_all_dtypes
 )
 from torch.testing._creation import float_to_corresponding_complex_type_map
 
@@ -2538,6 +2538,19 @@ class TestTensorCreation(TestCase):
         end = .0315315723419189453125 + (0.444444444444j if dtype.is_complex else 0)
 
         for steps in [1, 2, 3, 5, 11, 256, 257, 2**22]:
+            t = torch.linspace(start, end, steps, device=device, dtype=dtype)
+            a = np.linspace(start, end, steps, dtype=torch_to_numpy_dtype_dict[dtype])
+            t = t.cpu()
+            self.assertEqual(t, torch.from_numpy(a))
+            self.assertTrue(t[0].item() == a[0])
+            self.assertTrue(t[steps - 1].item() == a[steps - 1])
+
+    @dtypes(*integral_types())
+    def test_linspace_vs_numpy_integral(self, device, dtype):
+        start = 1
+        end = 127
+
+        for steps in [25, 50]:
             t = torch.linspace(start, end, steps, device=device, dtype=dtype)
             a = np.linspace(start, end, steps, dtype=torch_to_numpy_dtype_dict[dtype])
             t = t.cpu()


### PR DESCRIPTION
Fixes #88652

In the CPU implementation of linspace of integral types, `base` type in vectorized implementation is `int64_t`, which will drop the precision when `base` comes from a floating number. Meanwhile, its vectorized implementation tends to suffer from the catastrophic cancellation of floating point arithemtic since both the `base (start + step * idx)` and the `step` are not exact. Its scalar implementation is fine since start is always an integer and the result would be truncated to integer as well.

Therefore, in this PR , we will skip the vectorized implementation since the vec doesn't contribute to performance anyway. And now the behaviors between CPU and GPU are the same. In some cases, the results are the same as numpy's. In some other cases, the results are different from numpy's, but it is not related to the devices (CPU and GPU). https://github.com/pytorch/pytorch/issues/81996#issuecomment-1192980485

cc @VitalyFedyunin @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10