### PR TITLE
Add int64_t, SymInt overloads for all binary operators in C++

### DIFF
--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -235,6 +235,18 @@ inline c10::SymInt multiply_integers(const C& container) {
       [](const c10::SymInt& a, const c10::SymInt& b) { return a * b; });
 }
 
+inline SymInt operator+(int64_t a, const SymInt& b) { return c10::SymInt(a) + b; }
+inline SymInt operator-(int64_t a, const SymInt& b) { return c10::SymInt(a) - b; }
+inline SymInt operator*(int64_t a, const SymInt& b) { return c10::SymInt(a) * b; }
+inline SymInt operator/(int64_t a, const SymInt& b) { return c10::SymInt(a) / b; }
+inline SymInt operator%(int64_t a, const SymInt& b) { return c10::SymInt(a) % b; }
+inline bool operator==(int64_t a, const SymInt& b) { return c10::SymInt(a) == b; }
+inline bool operator!=(int64_t a, const SymInt& b) { return c10::SymInt(a) != b; }
+inline bool operator<(int64_t a, const SymInt& b) { return c10::SymInt(a) < b; }
+inline bool operator<=(int64_t a, const SymInt& b) { return c10::SymInt(a) <= b; }
+inline bool operator>(int64_t a, const SymInt& b) { return c10::SymInt(a) > b; }
+inline bool operator>=(int64_t a, const SymInt& b) { return c10::SymInt(a) >= b; }
+
 C10_API std::ostream& operator<<(std::ostream& os, const SymInt& s);
 C10_API SymInt operator-(const SymInt& s);
 } // namespace c10

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -235,17 +235,39 @@ inline c10::SymInt multiply_integers(const C& container) {
       [](const c10::SymInt& a, const c10::SymInt& b) { return a * b; });
 }
 
-inline SymInt operator+(int64_t a, const SymInt& b) { return c10::SymInt(a) + b; }
-inline SymInt operator-(int64_t a, const SymInt& b) { return c10::SymInt(a) - b; }
-inline SymInt operator*(int64_t a, const SymInt& b) { return c10::SymInt(a) * b; }
-inline SymInt operator/(int64_t a, const SymInt& b) { return c10::SymInt(a) / b; }
-inline SymInt operator%(int64_t a, const SymInt& b) { return c10::SymInt(a) % b; }
-inline bool operator==(int64_t a, const SymInt& b) { return c10::SymInt(a) == b; }
-inline bool operator!=(int64_t a, const SymInt& b) { return c10::SymInt(a) != b; }
-inline bool operator<(int64_t a, const SymInt& b) { return c10::SymInt(a) < b; }
-inline bool operator<=(int64_t a, const SymInt& b) { return c10::SymInt(a) <= b; }
-inline bool operator>(int64_t a, const SymInt& b) { return c10::SymInt(a) > b; }
-inline bool operator>=(int64_t a, const SymInt& b) { return c10::SymInt(a) >= b; }
+inline SymInt operator+(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) + b;
+}
+inline SymInt operator-(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) - b;
+}
+inline SymInt operator*(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) * b;
+}
+inline SymInt operator/(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) / b;
+}
+inline SymInt operator%(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) % b;
+}
+inline bool operator==(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) == b;
+}
+inline bool operator!=(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) != b;
+}
+inline bool operator<(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) < b;
+}
+inline bool operator<=(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) <= b;
+}
+inline bool operator>(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) > b;
+}
+inline bool operator>=(int64_t a, const SymInt& b) {
+  return c10::SymInt(a) >= b;
+}
 
 C10_API std::ostream& operator<<(std::ostream& os, const SymInt& s);
 C10_API SymInt operator-(const SymInt& s);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89038
* #89069
* #89074
* __->__ #89063
* #89062
* #89059

Signed-off-by: Edward Z. Yang <ezyang@fb.com>