### PR TITLE
SymIntify convolution backend calculation

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -83,10 +83,11 @@ constexpr int MIOPEN_DIM_MAX = 5;
 namespace at { namespace native {
 
 // Check workload to activate fast depthwise FP16 cudnn conv kernels
+template <typename T>
 bool check_cudnn_depthwise_workload(const at::Tensor& input, int stride) {
-  int w = input.size(3);  // same as h
-  int ch = input.size(1);
-  int bs = input.size(0);
+  auto w = at::symint::size<T>(input, 3);  // same as h
+  auto ch = at::symint::size<T>(input, 1);
+  auto bs = at::symint::size<T>(input, 0);
   if (stride==1) {
     if (w >= 7) {
       // All batch sizes and nb_channels
@@ -205,27 +206,28 @@ bool check_cudnn_depthwise_workload(const at::Tensor& input, int stride) {
 }
 
 // simplified version for cudnn 8.2 and above
+template <typename T>
 bool check_cudnn_depthwise_workload_with_filter(const at::Tensor& input, int stride, const at::Tensor& weight) {
   // 1D conv
-  if(input.size(2) == 1 && stride == 1){
+  if(at::symint::size<T>(input, 2) == 1 && stride == 1){
     return true;
   }
 
   // 2d conv
   // only square filters
-  if (weight.size(2) != weight.size(3)) return false;
-  int filter = weight.size(3);
+  if (at::symint::size<T>(weight, 2) != at::symint::size<T>(weight, 3)) return false;
+  auto filter = at::symint::size<T>(weight, 3);
   // only 1/3/5 filter
   if (filter != 1 && filter != 3 && filter != 5) return false;
   // we don't enforce square input but only check width to reduce heuristic space
-  if (input.size(3) < 7) return false; // min width 7
-  int w = input.size(3);
+  if (at::symint::size<T>(input, 3) < 7) return false; // min width 7
+  auto w = at::symint::size<T>(input, 3);
   // only 1/2 stride, use cudnn for all stride 1
   if (stride == 1) return true;
   if (stride != 2) return false;
 
-  int ch = input.size(1);
-  int bs = input.size(0);
+  auto ch = at::symint::size<T>(input, 1);
+  auto bs = at::symint::size<T>(input, 0);
   // special case since bs1 show good perf in lots of cases
   if (bs == 1) {
     if (filter == 1 && w <= 28) return true;
@@ -241,12 +243,16 @@ bool check_cudnn_depthwise_workload_with_filter(const at::Tensor& input, int str
 
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+// This struct is templated so that we can run backend selection in a dynamic
+// shapes context; all of the real kernel selection in eager mode runs with
+// int64_t
+template <typename T>
 struct ConvParams {
   std::vector<int64_t> stride;
-  std::vector<int64_t> padding;
+  std::vector<T> padding;
   std::vector<int64_t> dilation;
   bool transposed;
-  std::vector<int64_t> output_padding;
+  std::vector<T> output_padding;
   int groups;
   bool benchmark;
   bool deterministic;
@@ -322,12 +328,12 @@ struct ConvParams {
 #if defined(__ARM_NEON__)
     // Currently only 3x3 depthwise convolutions on tensors of float are supported.
     return (input.ndimension() == 4) &&
-           (input.size(1) == groups) &&
+           (at::symint::size<T>(input, 1) == groups) &&
            (weight.ndimension() == 4 ) &&
-           (weight.size(0) % input.size(1) == 0) &&
-           (weight.size(1) == 1) &&
-           (weight.size(2) == 3) &&
-           (weight.size(3) == 3) &&
+           (at::symint::size<T>(weight, 0) % at::symint::size<T>(input, 1) == 0) &&
+           (at::symint::size<T>(weight, 1) == 1) &&
+           (at::symint::size<T>(weight, 2) == 3) &&
+           (at::symint::size<T>(weight, 3) == 3) &&
            (input.device().is_cpu()) &&
            (input.scalar_type() == at::kFloat) &&
            input.is_contiguous() &&
@@ -345,23 +351,23 @@ struct ConvParams {
 
   bool needs_64bit_indexing_no_split(const at::Tensor& input, const at::Tensor& weight) const {
     constexpr int64_t int_max = std::numeric_limits<int>::max();
-    int64_t numel_input = input.numel();
+    auto numel_input = at::symint::numel<T>(input);
     // empty input
     if (numel_input == 0) {
       return false;
     }
     // input size can not be reduced to the range of int by splitting the batch dim
-    int64_t n = input.size(0);
+    auto n = at::symint::size<T>(input, 0);
     if (numel_input / n > int_max) {
       return true;
     }
     // output size can not be reduced to the range of int by splitting the batch dim
-    int64_t outsize = 1;
+    T outsize = 1;
     if (transposed) {
-      std::vector<int64_t> o = conv_input_size(input.sizes(), weight.sizes(), padding, output_padding, stride, dilation, groups);
+      auto o = conv_input_size(at::symint::sizes<T>(input), at::symint::sizes<T>(weight), padding, output_padding, stride, dilation, groups);
       outsize = c10::multiply_integers(o.begin() + 1, o.end());
     } else {
-      std::vector<int64_t> o = conv_output_size(input.sizes(), weight.sizes(), padding, stride, dilation);
+      auto o = conv_output_size(at::symint::sizes<T>(input), at::symint::sizes<T>(weight), padding, stride, dilation);
       outsize = c10::multiply_integers(o.begin() + 1, o.end());
     }
     return outsize > int_max;
@@ -417,10 +423,10 @@ struct ConvParams {
                              is_depthwise(input, weight) &&
                              input.ndimension() == 4 &&   // TODO: 5-D contiguous depthwise is not supported yet, need benchmarks
                              !is_dilated() && // no dilation supported
-                             (stride[0] == stride[1] || input.size(2) == 1) && // square or 1d
-                             input.size(1) >= 32); // min 32 channels supported)
+                             (stride[0] == stride[1] || at::symint::size<T>(input, 2) == 1) && // square or 1d
+                             at::symint::size<T>(input, 1) >= 32); // min 32 channels supported)
         if (kernel_cond) {
-          return check_cudnn_depthwise_workload_with_filter(input, stride[1], weight);
+          return check_cudnn_depthwise_workload_with_filter<T>(input, stride[1], weight);
         }
       }
       // keep (7600 <= cudnn < 8200) code unchanged
@@ -430,14 +436,14 @@ struct ConvParams {
                            weight.scalar_type() == kHalf &&
                            is_depthwise(input, weight) &&
                            input.ndimension() == 4 &&   // TODO: 5-D contiguous depthwise is not supported yet, need benchmarks
-                           weight.size(2) == weight.size(3) && // only square kernels
-                           input.size(2) >= 7 && // min width/height 7
+                           at::symint::size<T>(weight, 2) == at::symint::size<T>(weight, 3) && // only square kernels
+                           at::symint::size<T>(input, 2) >= 7 && // min width/height 7
                            !is_dilated() && // no dilation supported
                            stride[0] == stride[1] && // equal strides
-                           ((weight.size(3) == 3) || (weight.size(3) == 1)) &&
-                           input.size(1) >= 32); // min 32 channels supported)
+                           ((at::symint::size<T>(weight, 3) == 3) || (at::symint::size<T>(weight, 3) == 1)) &&
+                           at::symint::size<T>(input, 1) >= 32); // min 32 channels supported)
       if (kernel_cond) {
-        return check_cudnn_depthwise_workload(input, stride[0]);
+        return check_cudnn_depthwise_workload<T>(input, stride[0]);
       } else {
         return false;
       }
@@ -473,12 +479,12 @@ struct ConvParams {
        !transposed && // or transposed tensors
        // For 1x1 filters, MKLDNN is faster than THNN when multi-threaded,
        // but THNN is faster when single-threaded.
-       (is_strided() || is_dilated() || input.size(0) >= 16 ||
-        weight.size(-1) != 1 || weight.size(-2) != 1 || at::get_num_threads() > 1) &&
+       (is_strided() || is_dilated() || at::symint::size<T>(input, 0) >= 16 ||
+        at::symint::size<T>(weight, -1) != 1 || at::symint::size<T>(weight, -2) != 1 || at::get_num_threads() > 1) &&
        (groups > 1
-        || (weight.size(-1) > 3 && weight.size(-2) > 3)
-        || input.size(0) > 1
-        || input.size(0)*input.size(1)*input.size(2)*input.size(3) > 20480) // for some case, native is faster
+        || (at::symint::size<T>(weight, -1) > 3 && at::symint::size<T>(weight, -2) > 3)
+        || at::symint::size<T>(input, 0) > 1
+        || at::symint::size<T>(input, 0)*at::symint::size<T>(input, 1)*at::symint::size<T>(input, 2)*at::symint::size<T>(input, 3) > 20480) // for some case, native is faster
         );
 
 #endif
@@ -493,19 +499,19 @@ struct ConvParams {
            !transposed &&   // or transposed tensors
            input.ndimension() == 4 && // must be in NCHW format
            weight.ndimension() == 4 &&
-           (weight.size(2) < 17) && (weight.size(3) < 17) // NNPACK only supports kernels up to 16x16
+           (at::symint::size<T>(weight, 2) < 17) && (at::symint::size<T>(weight, 3) < 17) // NNPACK only supports kernels up to 16x16
 #if !defined(C10_MOBILE)
-           && input.size(0) >= 16 // ensure large enough batch size to ensure perf, tuneable
+           && at::symint::size<T>(input, 0) >= 16 // ensure large enough batch size to ensure perf, tuneable
 #endif
        ;
 #endif
     return false;
   }
   bool use_xnnpack(const at::Tensor& input, const at::Tensor& weight,
-                   const at::OptionalIntArrayRef bias_sizes_opt) const {
+                   const at::OptionalArrayRef<T> bias_sizes_opt) const {
 #if defined(C10_MOBILE)
     if (!transposed) {
-      return (input.size(1) == groups) &&
+      return (at::symint::size<T>(input, 1) == groups) &&
               xnnpack::use_convolution2d(
                   input,
                   weight,
@@ -543,32 +549,11 @@ struct ConvParams {
     return input.is_cuda() &&
            !transposed &&
            (input.ndimension() == 4 || input.ndimension() == 5) &&
-           input.size(1) == groups &&
+           at::symint::size<T>(input, 1) == groups &&
            groups > 1 && // no point if there is only a single group
-           weight.size(0) % input.size(1) == 0; // output channels must be a multiple of input channels
+           at::symint::size<T>(weight, 0) % at::symint::size<T>(input, 1) == 0; // output channels must be a multiple of input channels
   }
 };
-
-// Function to select the convolution backend based on the inputs and params.
-// This overload is used within the convolution internals but not exposed to python.
-// NB: The forward pass provides a bias tensor while the backward pass provides
-// a bool indicating whether the bias is defined. This is done to save memory by
-// avoiding saving the full bias tensor for backward.
-ConvBackend _select_conv_backend(
-    const Tensor& input,
-    const Tensor& weight,
-    const c10::optional<Tensor>& bias_opt,
-    const at::OptionalIntArrayRef bias_sizes_opt,
-    const bool need_backward,
-    const ConvParams& params);
-
-// For BC reasons, have a copy that does not require bias_opt
-ConvBackend select_conv_backend(
-    const Tensor& input,
-    const Tensor& weight,
-    const at::OptionalIntArrayRef bias_sizes_opt,
-    const bool need_backward,
-    const ConvParams& params);
 
 DEFINE_DISPATCH(conv_depthwise2d_backward_stub);
 DEFINE_DISPATCH(conv_depthwise3d_backward_stub);
@@ -591,13 +576,14 @@ REGISTER_NO_CPU_DISPATCH(miopen_convolution_backward_stub);
 REGISTER_NO_CPU_DISPATCH(miopen_convolution_transpose_backward_stub);
 REGISTER_NO_CPU_DISPATCH(miopen_depthwise_convolution_backward_stub);
 
-std::ostream& operator<<(std::ostream & out, const ConvParams& params) {
+template <typename T>
+std::ostream& operator<<(std::ostream & out, const ConvParams<T>& params) {
   out << "ConvParams {"
       << "  stride = " << IntArrayRef{params.stride}
-      << "  padding = " << IntArrayRef{params.padding}
+      << "  padding = " << ArrayRef<T>{params.padding}
       << "  dilation = " << IntArrayRef{params.dilation}
       << "  transposed = " << params.transposed
-      << "  output_padding = " << IntArrayRef{params.output_padding}
+      << "  output_padding = " << ArrayRef<T>{params.output_padding}
       << "  groups = " << params.groups
       << "  benchmark = " << params.benchmark
       << "  deterministic = " << params.deterministic
@@ -607,9 +593,10 @@ std::ostream& operator<<(std::ostream & out, const ConvParams& params) {
   return out;
 }
 
+template <typename T>
 static void check_shape_forward(const at::Tensor& input,
-                                const c10::IntArrayRef& weight_sizes, const at::Tensor& bias,
-                                const ConvParams& params) {
+                                const c10::ArrayRef<T>& weight_sizes, const at::Tensor& bias,
+                                const ConvParams<T>& params) {
   int64_t k = input.ndimension();
   int64_t weight_dim = weight_sizes.size();
   int64_t groups = params.groups;
@@ -624,7 +611,7 @@ static void check_shape_forward(const at::Tensor& input,
   TORCH_CHECK(weight_dim == k,
            "Expected ", weight_dim, "-dimensional input for ", weight_dim,
            "-dimensional weight ", weight_sizes, ", but got ", k, "-dimensional input of size ",
-           input.sizes(), " instead");
+           at::symint::sizes<T>(input), " instead");
   TORCH_CHECK(weight_sizes[0] >= groups,
            "Given groups=", groups, ", expected weight to be at least ", groups,
            " at dimension 0, but got weight of size ", weight_sizes, " instead");
@@ -634,23 +621,23 @@ static void check_shape_forward(const at::Tensor& input,
            "] instead");
 
   if (!transposed) {
-    std::vector<int64_t> input_shape;
-    std::vector<int64_t> kernel_shape;
+    std::vector<T> input_shape;
+    std::vector<T> kernel_shape;
     bool kernel_size_correct = true;
 
-    TORCH_CHECK(input.size(1) == (weight_sizes[1] * groups),
+    TORCH_CHECK(at::symint::size<T>(input, 1) == (weight_sizes[1] * groups),
                 "Given groups=", groups, ", weight of size ", weight_sizes,
                 ", expected input", input.sizes(), " to have ",
-                (weight_sizes[1] * groups), " channels, but got ", input.size(1),
+                (weight_sizes[1] * groups), " channels, but got ", at::symint::size<T>(input, 1),
                 " channels instead");
 
-    TORCH_CHECK(!bias.defined() || (bias.ndimension() == 1 && bias.size(0) == weight_sizes[0]),
+    TORCH_CHECK(!bias.defined() || (bias.ndimension() == 1 && at::symint::size<T>(bias, 0) == weight_sizes[0]),
              "Given weight of size ", weight_sizes,
              ", expected bias to be 1-dimensional with ", weight_sizes[0], " elements",
-             ", but got bias of size ", bias.sizes(), " instead");
+             ", but got bias of size ", at::symint::sizes<T>(bias), " instead");
 
     for (const auto i : c10::irange(2, k)) {
-      input_shape.push_back(input.size(i) + 2 * padding[i-2]);
+      input_shape.push_back(at::symint::size<T>(input, i) + 2 * padding[i-2]);
       // log new kernel size considering dilation
       kernel_shape.push_back(dilation[i-2] * (weight_sizes[i]-1) + 1);
       if (input_shape.back() < kernel_shape.back()) {
@@ -676,22 +663,23 @@ static void check_shape_forward(const at::Tensor& input,
                "Kernel size: (", kernel_ss.str(), "). Kernel size can't be greater than actual input size");
     }
   } else { // transposed
-    TORCH_CHECK(input.size(1) == weight_sizes[0],
+    TORCH_CHECK(at::symint::size<T>(input, 1) == weight_sizes[0],
              "Given transposed=", transposed, ", weight of size ", weight_sizes,
              ", expected input", input.sizes(), " to have ", weight_sizes[0],
-             " channels, but got ", input.size(1), " channels instead");
-    TORCH_CHECK(!bias.defined() || (bias.ndimension() == 1 && bias.size(0) == weight_sizes[1] * groups),
+             " channels, but got ", at::symint::size<T>(input, 1), " channels instead");
+    TORCH_CHECK(!bias.defined() || (bias.ndimension() == 1 && at::symint::size<T>(bias, 0) == weight_sizes[1] * groups),
              "Given transposed=", transposed, ", weight of size ", weight_sizes,
              ", expected bias to be 1-dimensional with ", weight_sizes[1] * groups, " elements",
              ", but got bias of size ", bias.sizes(), " instead");
   }
 }
 
+template <typename T>
 static void check_shape_backward(
     const at::Tensor& input,
-    const c10::IntArrayRef& weight_sizes,
-    const ConvParams& params) {
-  check_shape_forward(input, weight_sizes, /*bias=*/ Tensor(), params);
+    const c10::ArrayRef<T>& weight_sizes,
+    const ConvParams<T>& params) {
+  check_shape_forward<T>(input, weight_sizes, /*bias=*/ Tensor(), params);
 }
 
 // Given an input tensor and an expected number of spatial dimensions, checks that the
@@ -1149,70 +1137,24 @@ at::Tensor convolution_overrideable(
   TORCH_CHECK_NOT_IMPLEMENTED(false, "convolution_overrideable not implemented. You are likely triggering this with tensor backend other than CPU/CUDA/MKLDNN, if this is intended, please use TORCH_LIBRARY_IMPL to override this function ");
 }
 
-// Selects a backend for convolution based on the inputs and params.
-ConvBackend select_conv_backend(
-    const Tensor& input_r, const Tensor& weight_r, const c10::optional<Tensor>& bias_opt,
-    IntArrayRef stride_, IntArrayRef padding_, IntArrayRef dilation_,
-    bool transposed_, IntArrayRef output_padding_, int64_t groups_, const at::OptionalIntArrayRef bias_sizes_opt) {
-  c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
-  const Tensor& bias = *bias_maybe_owned;
-
-  auto& ctx = at::globalContext();
-  auto k = weight_r.ndimension();
-  int64_t dim = k - 2;
-  ConvParams params;
-  params.stride = expand_param_if_needed(stride_, "stride", dim);
-  params.padding = expand_param_if_needed(padding_, "padding", dim);
-  params.dilation = expand_param_if_needed(dilation_, "dilation", dim);
-  params.transposed = transposed_;
-  params.output_padding = expand_param_if_needed(output_padding_, "output_padding", dim);
-  params.groups = groups_;
-  params.benchmark = ctx.benchmarkCuDNN();
-  params.deterministic = ctx.deterministicCuDNN() || ctx.deterministicAlgorithms();
-  params.cudnn_enabled = ctx.userEnabledCuDNN();
-  params.allow_tf32 = ctx.allowTF32CuDNN();
-
-  auto input = input_r;
-  auto weight = weight_r;
-  check_shape_forward(input, weight.sizes(), bias, params);
-
-  // Expand 1d -> 2d.
-  // This is only done for backends that don't natively support 1d spatial input.
-  if (k == 3 && !input.is_mkldnn() && !input.is_xpu()) {
-    // avoid accidentally going through NHWC for permuted 3d input.
-    input = input.contiguous();
-    params.view1d_as_2d();
-    input = view4d(input);
-    weight = view4d(weight);
-  }
-
-  auto bias_sizes = bias.defined() ? c10::optional<IntArrayRef>(bias.sizes()) : bias_sizes_opt;
-  bool need_backward = GradMode::is_enabled() &&
-      (input.requires_grad() || weight.requires_grad() || (bias.defined() && bias.requires_grad()));
-  return _select_conv_backend(input, weight, bias, bias_sizes, need_backward, params);
-}
-
-ConvBackend select_conv_backend(
-    const Tensor& input,
-    const Tensor& weight,
-    const at::OptionalIntArrayRef bias_sizes_opt,
-    const bool need_backward,
-    const ConvParams& params) {
-  return _select_conv_backend(input, weight, {}, bias_sizes_opt, need_backward, params);
-}
-
+// Function to select the convolution backend based on the inputs and params.
+// This overload is used within the convolution internals but not exposed to python.
+// NB: The forward pass provides a bias tensor while the backward pass provides
+// a bool indicating whether the bias is defined. This is done to save memory by
+// avoiding saving the full bias tensor for backward.
+template <typename T>
 ConvBackend _select_conv_backend(
     const Tensor& input,
     const Tensor& weight,
     const c10::optional<Tensor>& bias,
-    const at::OptionalIntArrayRef bias_sizes_opt,
+    const at::OptionalArrayRef<T> bias_sizes_opt,
     const bool need_backward,
-    const ConvParams& params) {
+    const ConvParams<T>& params) {
 
   // don't send empty inputs through backends
   if (input.size(0) == 0 || input.size(1) == 0) {
     return input.is_mkldnn() ? ConvBackend::MkldnnEmpty : ConvBackend::Empty;
-  } else if (input.numel() == 0) {
+  } else if (at::symint::numel<T>(input) == 0) {
     TORCH_CHECK(false, "Only zero batch or zero channel inputs are supported, but got input shape: ", input.sizes());
   }
 
@@ -1305,12 +1247,65 @@ ConvBackend _select_conv_backend(
   AT_ERROR("unsupported ConvNd parameters");
 }
 
+// Selects a backend for convolution based on the inputs and params.
+ConvBackend select_conv_backend(
+    const Tensor& input_r, const Tensor& weight_r, const c10::optional<Tensor>& bias_opt,
+    IntArrayRef stride_, SymIntArrayRef padding_, IntArrayRef dilation_,
+    bool transposed_, SymIntArrayRef output_padding_, int64_t groups_, const at::OptionalSymIntArrayRef bias_sizes_opt) {
+  c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
+  const Tensor& bias = *bias_maybe_owned;
+
+  auto& ctx = at::globalContext();
+  auto k = weight_r.ndimension();
+  int64_t dim = k - 2;
+  ConvParams<c10::SymInt> params;
+  params.stride = expand_param_if_needed(stride_, "stride", dim);
+  params.padding = expand_param_if_needed(padding_, "padding", dim);
+  params.dilation = expand_param_if_needed(dilation_, "dilation", dim);
+  params.transposed = transposed_;
+  params.output_padding = expand_param_if_needed(output_padding_, "output_padding", dim);
+  params.groups = groups_;
+  params.benchmark = ctx.benchmarkCuDNN();
+  params.deterministic = ctx.deterministicCuDNN() || ctx.deterministicAlgorithms();
+  params.cudnn_enabled = ctx.userEnabledCuDNN();
+  params.allow_tf32 = ctx.allowTF32CuDNN();
+
+  auto input = input_r;
+  auto weight = weight_r;
+  check_shape_forward(input, weight.sym_sizes(), bias, params);
+
+  // Expand 1d -> 2d.
+  // This is only done for backends that don't natively support 1d spatial input.
+  if (k == 3 && !input.is_mkldnn() && !input.is_xpu()) {
+    // avoid accidentally going through NHWC for permuted 3d input.
+    input = input.contiguous();
+    params.view1d_as_2d();
+    input = view4d(input);
+    weight = view4d(weight);
+  }
+
+  auto bias_sizes = bias.defined() ? c10::optional<SymIntArrayRef>(bias.sym_sizes()) : bias_sizes_opt;
+  bool need_backward = GradMode::is_enabled() &&
+      (input.requires_grad() || weight.requires_grad() || (bias.defined() && bias.requires_grad()));
+  return _select_conv_backend(input, weight, bias, bias_sizes, need_backward, params);
+}
+
+// For BC reasons, have a copy that does not require bias_opt
+ConvBackend select_conv_backend(
+    const Tensor& input,
+    const Tensor& weight,
+    const at::OptionalIntArrayRef bias_sizes_opt,
+    const bool need_backward,
+    const ConvParams<int64_t>& params) {
+  return _select_conv_backend(input, weight, {}, bias_sizes_opt, need_backward, params);
+}
+
 at::Tensor _convolution_nogroup_backend(
     const Tensor& input,
     const Tensor& weight,
     const Tensor& bias,
     const ConvBackend backend,
-    const ConvParams& params) {
+    const ConvParams<int64_t>& params) {
   auto kernel_size = weight.sizes().slice(2);
   switch(backend) {
     case ConvBackend::NnpackSpatial:
@@ -1341,7 +1336,7 @@ at::Tensor _convolution_nogroup_backend(
 static inline std::vector<int64_t> calc_output_size(
     const Tensor& input,
     const Tensor& weight,
-    const ConvParams& params) {
+    const ConvParams<int64_t>& params) {
   std::vector<int64_t> output_size = params.transposed ?
     conv_input_size(input.sizes(), weight.sizes(), params.padding, params.output_padding,
         params.stride, params.dilation, params.groups) :
@@ -1422,7 +1417,7 @@ at::Tensor _convolution(
   TORCH_CHECK(dim > 0, "weight should have at least three dimensions");
   TORCH_CHECK(groups_ > 0, "non-positive groups is not supported");
 
-  ConvParams params;
+  ConvParams<int64_t> params;
   params.stride = expand_param_if_needed(stride_, "stride", dim);
   params.padding = expand_param_if_needed(padding_, "padding", dim);
   params.dilation = expand_param_if_needed(dilation_, "dilation", dim);
@@ -1450,7 +1445,7 @@ at::Tensor _convolution(
   auto bias_sizes_opt = bias.defined() ? c10::optional<IntArrayRef>(bias.sizes()) : c10::nullopt;
   bool need_backward = GradMode::is_enabled() &&
       (input.requires_grad() || weight.requires_grad() || (bias.defined() && bias.requires_grad()));
-  ConvBackend backend = _select_conv_backend(input, weight, bias, bias_sizes_opt, need_backward, params);
+  ConvBackend backend = _select_conv_backend(input, weight, bias, c10::OptionalIntArrayRef(bias_sizes_opt), need_backward, params);
   at::MemoryFormat backend_memory_format = determine_backend_memory_format(input, weight, backend);
 
   // Call the backend.
@@ -1663,7 +1658,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
   auto weight = weight_r;
 
   int64_t dim = weight.ndimension() - 2;
-  ConvParams params;
+  ConvParams<int64_t> params;
   params.stride = expand_param_if_needed(stride_, "stride", dim);
   params.padding = expand_param_if_needed(padding_, "padding", dim);
   params.dilation = expand_param_if_needed(dilation_, "dilation", dim);
@@ -1726,7 +1721,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
   if (ggI.defined()) {
 
     // Modified params with correct padding
-    ConvParams gw_conv_params(params);
+    ConvParams<int64_t> gw_conv_params(params);
 
     // Disable groups as they are handled separately
     auto groups = gw_conv_params.groups;
@@ -1795,7 +1790,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
   Tensor gI;
   if (input.numel() != 0) {
     if (ggW.defined()) {
-      ConvParams gi_conv_params(params);
+      ConvParams<int64_t> gi_conv_params(params);
       gi_conv_params.transposed = !params.transposed;
 
       if (params.transposed) {
@@ -1851,7 +1846,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> _convolution_backward_nogroup_bac
     const Tensor& weight,
     const std::array<bool, 3> output_mask,
     const ConvBackend backend,
-    const ConvParams& params) {
+    const ConvParams<int64_t>& params) {
   auto kernel_size = weight.sizes().slice(2);
   switch(backend) {
     case ConvBackend::Slow2d:
@@ -1916,7 +1911,7 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward(
   TORCH_CHECK(dim > 0, "weight should have at least three dimensions");
 
   auto& ctx = at::globalContext();
-  ConvParams params;
+  ConvParams<int64_t> params;
   params.stride = expand_param_if_needed(stride, "stride", dim);
   params.padding = expand_param_if_needed(padding, "padding", dim);
   params.dilation = expand_param_if_needed(dilation, "dilation", dim);

--- a/aten/src/ATen/native/utils/ParamUtils.h
+++ b/aten/src/ATen/native/utils/ParamUtils.h
@@ -6,12 +6,13 @@
 namespace at {
 namespace native {
 
-inline std::vector<int64_t> expand_param_if_needed(
-    IntArrayRef list_param,
+template <typename T>
+inline std::vector<T> expand_param_if_needed(
+    ArrayRef<T> list_param,
     const char* param_name,
     int64_t expected_dim) {
   if (list_param.size() == 1) {
-    return std::vector<int64_t>(expected_dim, list_param[0]);
+    return std::vector<T>(expected_dim, list_param[0]);
   } else if ((int64_t)list_param.size() != expected_dim) {
     std::ostringstream ss;
     ss << "expected " << param_name << " to be a single integer value or a "

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -235,6 +235,19 @@ inline c10::SymInt multiply_integers(const C& container) {
       [](const c10::SymInt& a, const c10::SymInt& b) { return a * b; });
 }
 
+template <
+    typename Iter,
+    typename = std::enable_if_t<std::is_same<
+        typename std::iterator_traits<Iter>::value_type,
+        c10::SymInt>::value>>
+inline c10::SymInt multiply_integers(Iter begin, Iter end) {
+  return std::accumulate(
+      begin,
+      end,
+      c10::SymInt(1),
+      [](const c10::SymInt& a, const c10::SymInt& b) { return a * b; });
+}
+
 inline SymInt operator+(int64_t a, const SymInt& b) {
   return c10::SymInt(a) + b;
 }

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1408,10 +1408,10 @@ Call this whenever a new thread is created in order to propagate values from
          const at::Tensor& weight,
          const c10::optional<at::Tensor>& bias_opt,
          at::IntArrayRef stride_,
-         at::IntArrayRef padding_,
+         at::SymIntArrayRef padding_,
          at::IntArrayRef dilation_,
          bool transposed_,
-         at::IntArrayRef output_padding_,
+         at::SymIntArrayRef output_padding_,
          int64_t groups_) {
         return at::native::select_conv_backend(
             input,
@@ -1442,13 +1442,13 @@ Call this whenever a new thread is created in order to propagate values from
          const at::Tensor& weight,
          const c10::optional<at::Tensor>& bias,
          at::IntArrayRef stride_,
-         at::IntArrayRef padding_,
+         at::SymIntArrayRef padding_,
          at::IntArrayRef dilation_,
          bool transposed_,
-         at::IntArrayRef output_padding_,
+         at::SymIntArrayRef output_padding_,
          int64_t groups_,
-         c10::optional<std::vector<int64_t>> bias_sizes_opt) {
-        c10::OptionalArrayRef<int64_t> ref = c10::nullopt;
+         c10::optional<std::vector<c10::SymInt>> bias_sizes_opt) {
+        c10::OptionalArrayRef<c10::SymInt> ref = c10::nullopt;
         if (bias_sizes_opt) {
           ref = (*bias_sizes_opt);
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89038
* __->__ #89069
* #89074
* #89063
* #89062
* #89059

We will need this to implement a convolution meta function that
is SymInt aware.  I use templates so that regular convolution code
is not affected by the change.  No tests for symbolic ints directly; that will
come in a subsequent PR which also needs to refactor fake tensors.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @VitalyFedyunin @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10