### PR TITLE
fix: update error when tensor escapes vmap

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesHelper.h
+++ b/aten/src/ATen/functorch/BatchRulesHelper.h
@@ -123,7 +123,12 @@ void boxed_tensor_inputs_batch_rule(const c10::OperatorHandle& op, torch::jit::S
 
   c10::impl::ExcludeDispatchKeyGuard guard(DispatchKey::FuncTorchBatched);
   auto maybe_layer = maybeCurrentDynamicLayer();
-  TORCH_INTERNAL_ASSERT(maybe_layer.has_value());
+  TORCH_CHECK(
+    maybe_layer.has_value(),
+    "oops your boxed tensor escaped from vmap ",
+    "See https://pytorch.org/functorch/stable/ux_limitations.html"
+  )
+
   int64_t cur_level = maybe_layer->layerId();
 
   auto orig_arguments = torch::jit::last(*stack, num_arguments);

--- a/aten/src/ATen/functorch/PlumbingHelper.cpp
+++ b/aten/src/ATen/functorch/PlumbingHelper.cpp
@@ -13,9 +13,11 @@ namespace at { namespace functorch {
 void vmap_check_escaped(optional<DynamicLayer> layer, const char* what) {
   TORCH_CHECK(
     layer.has_value(),
-    "your tensor may have escaped from vmap. This could also be an internal error (from ",
+    "Either your tensor may have escaped from inside a function being vmapped and this is a user error ",
+    "(see https://pytorch.org/functorch/stable/ux_limitations.html), "
+    "or there is an internal functorch error in `",
     what,
-    ") See https://pytorch.org/functorch/stable/ux_limitations.html"
+    "` Please file an issue if it looks like the latter"
   )
 }
 

--- a/aten/src/ATen/functorch/PlumbingHelper.cpp
+++ b/aten/src/ATen/functorch/PlumbingHelper.cpp
@@ -10,7 +10,7 @@
 
 namespace at { namespace functorch {
 
-void vmap_check_escaped(optional<DynamicLayer> layer, const char* what) {
+void vmap_check_escaped(const optional<DynamicLayer> &layer, const char* what) {
   TORCH_CHECK(
     layer.has_value(),
     "Either your tensor may have escaped from inside a function being vmapped and this is a user error ",

--- a/aten/src/ATen/functorch/PlumbingHelper.cpp
+++ b/aten/src/ATen/functorch/PlumbingHelper.cpp
@@ -10,6 +10,15 @@
 
 namespace at { namespace functorch {
 
+void vmap_check_escaped(optional<DynamicLayer> layer, const char* what) {
+  TORCH_CHECK(
+    layer.has_value(),
+    "your tensor may have escaped from vmap. This could also be an internal error (from ",
+    what,
+    ") See https://pytorch.org/functorch/stable/ux_limitations.html"
+  )
+}
+
 Tensor makeBatched(const Tensor& tensor, optional<int64_t> bdim, int64_t level) {
   if (bdim.has_value()) {
     TORCH_INTERNAL_ASSERT(*bdim >= 0);

--- a/aten/src/ATen/functorch/PlumbingHelper.h
+++ b/aten/src/ATen/functorch/PlumbingHelper.h
@@ -26,7 +26,7 @@
 
 namespace at { namespace functorch {
 
-void vmap_check_escaped(optional<DynamicLayer> layer, const char* what);
+void vmap_check_escaped(const optional<DynamicLayer> &layer, const char* what);
 
 // Create a BatchedTensor given a tensor, bdim, and level
 TORCH_API Tensor makeBatched(const Tensor& tensor, optional<int64_t> bdim, int64_t level);

--- a/aten/src/ATen/functorch/PlumbingHelper.h
+++ b/aten/src/ATen/functorch/PlumbingHelper.h
@@ -26,6 +26,8 @@
 
 namespace at { namespace functorch {
 
+void vmap_check_escaped(optional<DynamicLayer> layer, const char* what);
+
 // Create a BatchedTensor given a tensor, bdim, and level
 TORCH_API Tensor makeBatched(const Tensor& tensor, optional<int64_t> bdim, int64_t level);
 

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3938,7 +3938,7 @@ class TestVmapOperatorsOpInfo(TestCase):
         with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from inplace\).*"):
             escaped.mul_(1)
 
-        vmap(f)(torch.tensor([[0,0],[0,0]], dtype=torch.int))
+        vmap(f)(torch.tensor([[0, 0], [0, 0]], dtype=torch.int))
         with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from no returns\).*"):
             torch.ops.aten._linalg_check_errors(escaped, 'linalg.inv', is_matrix=False)
 

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3920,6 +3920,7 @@ class TestVmapOperatorsOpInfo(TestCase):
 
     def test_vmap_escaped_error(self):
         escaped = None
+
         def f(x):
             nonlocal escaped
             escaped = x
@@ -3933,6 +3934,7 @@ class TestVmapOperatorsOpInfo(TestCase):
 
     def test_vmap_escaped_error_boxed(self):
         escaped = None
+
         def f(x):
             nonlocal escaped
             escaped = x

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3938,11 +3938,9 @@ class TestVmapOperatorsOpInfo(TestCase):
         with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from inplace\).*"):
             escaped.mul_(1)
 
-        # FIXME: this gives: 'infos.scalar_type() == kInt INTERNAL ASSERT FAILED'
-        # _linalg_check_errors is the only op that uses the 'non returned' piping
-        # how do I create a tensor with kInt dtype?
-        # with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from no returns\).*"):
-        #     torch.ops.aten._linalg_check_errors(x, 'linalg.inv', is_matrix=False)
+        vmap(f)(torch.tensor([[0,0],[0,0]], dtype=torch.int))
+        with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from no returns\).*"):
+            torch.ops.aten._linalg_check_errors(escaped, 'linalg.inv', is_matrix=False)
 
 class TestRandomness(TestCase):
     def _reset_random(self, generator, orig_state, use_generator, seed):

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3928,21 +3928,21 @@ class TestVmapOperatorsOpInfo(TestCase):
         x = torch.randn(3)
         vmap(f)(x)
 
-        with self.assertRaisesRegex(RuntimeError, "your tensor escaped from vmap"):
+        with self.assertRaisesRegex(RuntimeError, "your  tensor escaped from vmap"):
             escaped.sin()
 
-    def test_vmap_escaped_error_inplace(self):
+    def test_vmap_escaped_error_boxed(self):
         escaped = None
         def f(x):
             nonlocal escaped
-            escaped = x.sin_()
+            escaped = x
             return x ** 2
 
         x = torch.randn(3)
         vmap(f)(x)
 
-        with self.assertRaisesRegex(RuntimeError, "your tensor escaped from vmap"):
-            escaped.sin()
+        with self.assertRaisesRegex(RuntimeError, "your boxed tensor escaped from vmap"):
+            escaped.sin_()
 
 
 

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3929,24 +3929,11 @@ class TestVmapOperatorsOpInfo(TestCase):
         x = torch.randn(3)
         vmap(f)(x)
 
-        with self.assertRaisesRegex(RuntimeError, "your  tensor escaped from vmap"):
+        with self.assertRaisesRegex(RuntimeError, "your tensor escaped from vmap"):
             escaped.sin()
-
-    def test_vmap_escaped_error_boxed(self):
-        escaped = None
-
-        def f(x):
-            nonlocal escaped
-            escaped = x
-            return x ** 2
-
-        x = torch.randn(3)
-        vmap(f)(x)
 
         with self.assertRaisesRegex(RuntimeError, "your boxed tensor escaped from vmap"):
             escaped.sin_()
-
-
 
 class TestRandomness(TestCase):
     def _reset_random(self, generator, orig_state, use_generator, seed):

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3929,17 +3929,19 @@ class TestVmapOperatorsOpInfo(TestCase):
         x = torch.randn(3)
         vmap(f)(x)
 
-        with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from vmap plumbing\).*"):
+        common_message = r"your tensor may have escaped from inside a function being vmapped.*{0}.*"
+
+        with self.assertRaisesRegex(RuntimeError, common_message.format("gen_vmap_plumbing")):
             escaped.sin()
 
-        with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from boxed_tensor_inputs_batch_rule\).*"):
+        with self.assertRaisesRegex(RuntimeError, common_message.format("boxed_tensor_inputs_batch_rule")):
             escaped.sin_()
 
-        with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from inplace\).*"):
+        with self.assertRaisesRegex(RuntimeError, common_message.format("gen_vmap_inplace_plumbing")):
             escaped.mul_(1)
 
         vmap(f)(torch.tensor([[0, 0], [0, 0]], dtype=torch.int))
-        with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from no returns\).*"):
+        with self.assertRaisesRegex(RuntimeError, common_message.format("gen_vmap_plumbing_no_returns")):
             torch.ops.aten._linalg_check_errors(escaped, 'linalg.inv', is_matrix=False)
 
 class TestRandomness(TestCase):

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3932,7 +3932,7 @@ class TestVmapOperatorsOpInfo(TestCase):
         with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from vmap plumbing\).*"):
             escaped.sin()
 
-        with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from boxed inputs\).*"):
+        with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from boxed_tensor_inputs_batch_rule\).*"):
             escaped.sin_()
 
         with self.assertRaisesRegex(RuntimeError, r"your tensor may have escaped from vmap.*\(from inplace\).*"):

--- a/torchgen/gen_vmap_plumbing.py
+++ b/torchgen/gen_vmap_plumbing.py
@@ -135,7 +135,7 @@ def is_mutated_arg(argument: Argument) -> bool:
 def gen_check_escaped(check: str, what: str) -> str:
     return f"""TORCH_CHECK(
 {check},
-"oops your{what} tensor escaped from vmap ",
+"your tensor may have escaped from vmap. This could also be an internal error (from {what}) ",
 "See https://pytorch.org/functorch/stable/ux_limitations.html"
   );"""
 
@@ -169,7 +169,7 @@ def gen_vmap_inplace_plumbing(native_function: NativeFunction) -> Optional[str]:
 
     unwraps, unwrapped_arg_list = gen_unwraps(schema.arguments.flat_all, cur_level_var)
     bdims_all_none_case = gen_case_where_all_bdims_are_none(sig, schema, cur_level_var)
-    check_escaped = gen_check_escaped("maybe_layer.has_value()", " (inplace)")
+    check_escaped = gen_check_escaped("maybe_layer.has_value()", "inplace")
 
     return f"""\
 template <typename batch_rule_t, batch_rule_t batch_rule>
@@ -192,7 +192,7 @@ def gen_vmap_plumbing_no_returns(native_function: NativeFunction) -> str:
 
     unwraps, unwrapped_arg_list = gen_unwraps(schema.arguments.flat_all, cur_level_var)
     bdims_all_none_case = gen_case_where_all_bdims_are_none(sig, schema, cur_level_var)
-    check_escaped = gen_check_escaped("maybe_layer.has_value()", " (non returned)")
+    check_escaped = gen_check_escaped("maybe_layer.has_value()", "no returns")
 
     return f"""\
 template <typename batch_rule_t, batch_rule_t batch_rule>
@@ -237,7 +237,7 @@ def gen_vmap_plumbing(native_function: NativeFunction) -> Optional[str]:
     bdims_all_none_case = gen_case_where_all_bdims_are_none(sig, schema, cur_level_var)
 
     wrapped_returns = gen_returns(returns, cur_level_var, results_var)
-    check_escaped = gen_check_escaped("maybe_layer.has_value()", "")
+    check_escaped = gen_check_escaped("maybe_layer.has_value()", "vmap plumbing")
     return f"""\
 template <typename batch_rule_t, batch_rule_t batch_rule>
 {sig.decl(name=schema.name.unambiguous_name() + '_generated_plumbing')} {{

--- a/torchgen/gen_vmap_plumbing.py
+++ b/torchgen/gen_vmap_plumbing.py
@@ -132,12 +132,13 @@ def is_mutated_arg(argument: Argument) -> bool:
     return argument.annotation is not None and argument.annotation.is_write
 
 
-def gen_check_escaped(check, what):
-  return f"""TORCH_CHECK(
+def gen_check_escaped(check: str, what: str) -> str:
+    return f"""TORCH_CHECK(
 {check},
 "oops your {what} tensor escaped from vmap ",
 "See https://pytorch.org/functorch/stable/ux_limitations.html"
   );"""
+
 
 def gen_vmap_inplace_plumbing(native_function: NativeFunction) -> Optional[str]:
     # Assumptions:

--- a/torchgen/gen_vmap_plumbing.py
+++ b/torchgen/gen_vmap_plumbing.py
@@ -131,6 +131,7 @@ def accepts_at_least_one_tensor_input(schema: FunctionSchema) -> bool:
 def is_mutated_arg(argument: Argument) -> bool:
     return argument.annotation is not None and argument.annotation.is_write
 
+
 def gen_vmap_inplace_plumbing(native_function: NativeFunction) -> Optional[str]:
     # Assumptions:
     # - only one argument is being modified in-place
@@ -166,7 +167,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
 {sig.decl(name=schema.name.unambiguous_name() + '_generated_plumbing')} {{
   c10::impl::ExcludeDispatchKeyGuard guard(DispatchKey::FuncTorchBatched);
   auto maybe_layer = maybeCurrentDynamicLayer();
-  vmap_check_escaped(maybe_layer, "inplace");
+  vmap_check_escaped(maybe_layer, "gen_vmap_inplace_plumbing");
   int64_t {cur_level_var} = maybe_layer->layerId();
 {textwrap.indent(bdims_all_none_case, "  ")}
 {textwrap.indent(unwraps, "  ")}
@@ -188,7 +189,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
 {sig.decl(name=schema.name.unambiguous_name() + '_generated_plumbing')} {{
   c10::impl::ExcludeDispatchKeyGuard guard(DispatchKey::FuncTorchBatched);
   auto maybe_layer = maybeCurrentDynamicLayer();
-  vmap_check_escaped(maybe_layer, "no returns");
+  vmap_check_escaped(maybe_layer, "gen_vmap_plumbing_no_returns");
   int64_t {cur_level_var} = maybe_layer->layerId();
 {textwrap.indent(bdims_all_none_case, "  ")}
 {textwrap.indent(unwraps, "  ")}
@@ -231,7 +232,7 @@ template <typename batch_rule_t, batch_rule_t batch_rule>
 {sig.decl(name=schema.name.unambiguous_name() + '_generated_plumbing')} {{
   c10::impl::ExcludeDispatchKeyGuard guard(DispatchKey::FuncTorchBatched);
   auto maybe_layer = maybeCurrentDynamicLayer();
-  vmap_check_escaped(maybe_layer, "vmap plumbing");
+  vmap_check_escaped(maybe_layer, "gen_vmap_plumbing");
   int64_t {cur_level_var} = maybe_layer->layerId();
 {textwrap.indent(bdims_all_none_case, "  ")}
 {textwrap.indent(unwraps, "  ")}

--- a/torchgen/gen_vmap_plumbing.py
+++ b/torchgen/gen_vmap_plumbing.py
@@ -135,7 +135,7 @@ def is_mutated_arg(argument: Argument) -> bool:
 def gen_check_escaped(check: str, what: str) -> str:
     return f"""TORCH_CHECK(
 {check},
-"oops your {what} tensor escaped from vmap ",
+"oops your{what} tensor escaped from vmap ",
 "See https://pytorch.org/functorch/stable/ux_limitations.html"
   );"""
 
@@ -169,7 +169,7 @@ def gen_vmap_inplace_plumbing(native_function: NativeFunction) -> Optional[str]:
 
     unwraps, unwrapped_arg_list = gen_unwraps(schema.arguments.flat_all, cur_level_var)
     bdims_all_none_case = gen_case_where_all_bdims_are_none(sig, schema, cur_level_var)
-    check_escaped = gen_check_escaped("maybe_layer.has_value()", "(inplace)")
+    check_escaped = gen_check_escaped("maybe_layer.has_value()", " (inplace)")
 
     return f"""\
 template <typename batch_rule_t, batch_rule_t batch_rule>
@@ -192,7 +192,7 @@ def gen_vmap_plumbing_no_returns(native_function: NativeFunction) -> str:
 
     unwraps, unwrapped_arg_list = gen_unwraps(schema.arguments.flat_all, cur_level_var)
     bdims_all_none_case = gen_case_where_all_bdims_are_none(sig, schema, cur_level_var)
-    check_escaped = gen_check_escaped("maybe_layer.has_value()", "(non returned)")
+    check_escaped = gen_check_escaped("maybe_layer.has_value()", " (non returned)")
 
     return f"""\
 template <typename batch_rule_t, batch_rule_t batch_rule>


### PR DESCRIPTION
Fixes https://github.com/pytorch/functorch/issues/1054


@zou3519, I played around with it, but I am unsure of how to repro the cases for gen_vmap_inplace_plumbing and below in gen_vmap_plumbing_no_returns

I've also seen that there are 24 other instances of the `TORCH_INTERNAL_ASSERT(maybe_layer.has_value());` assert, should I change all of these and add tests?

