### PR TITLE
Revert D40424319: Multisect successfully blamed D40424319 for test or build failures

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -848,17 +848,20 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const optional<int64_t> hop
   const bool return_complex = return_complexOpt.value_or(
       self.is_complex() || (window.defined() && window.is_complex()));
   if (!return_complex) {
-    TORCH_CHECK(return_complexOpt.has_value(),
-        "stft requires the return_complex parameter be given for real inputs, "
-        "and will further require that return_complex=True in a future PyTorch release.");
+    if (!return_complexOpt.has_value()) {
+      TORCH_WARN_ONCE(
+        "stft will soon require the return_complex parameter be given for real inputs, "
+        "and will further require that return_complex=True in a future PyTorch release."
+      );
+    }
 
 
-    TORCH_WARN_ONCE(
-        "stft with return_complex=False is deprecated. In a future pytorch "
-        "release, stft will return complex tensors for all inputs, and "
-        "return_complex=False will raise an error.\n"
-        "Note: you can still call torch.view_as_real on the complex output to "
-        "recover the old return format.");
+    // TORCH_WARN_ONCE(
+    //     "stft with return_complex=False is deprecated. In a future pytorch "
+    //     "release, stft will return complex tensors for all inputs, and "
+    //     "return_complex=False will raise an error.\n"
+    //     "Note: you can still call torch.view_as_real on the complex output to "
+    //     "recover the old return format.");
   }
 
   if (!at::isFloatingType(self.scalar_type()) && !at::isComplexType(self.scalar_type())) {

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1178,8 +1178,9 @@ class TestFFT(TestCase):
     @skipCPUIfNoFFT
     def test_stft_requires_complex(self, device):
         x = torch.rand(100)
-        with self.assertRaisesRegex(RuntimeError, 'stft requires the return_complex parameter'):
-            y = x.stft(10, pad_mode='constant')
+        y = x.stft(10, pad_mode='constant')
+        # with self.assertRaisesRegex(RuntimeError, 'stft requires the return_complex parameter'):
+        #     y = x.stft(10, pad_mode='constant')
 
     @skipCPUIfNoFFT
     def test_fft_input_modification(self, device):

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -612,15 +612,6 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
             a real tensor with an extra last dimension for the real and
             imaginary components.
 
-            .. versionchanged:: 1.14.0
-               ``return_complex`` is now a required argument for real inputs,
-               as the default is being transitioned to ``True``.
-
-            .. deprecated:: 1.14.0
-               ``return_complex=False`` is deprecated, instead use ``return_complex=True``
-               Note that calling :func:`torch.view_as_real` on the output will
-               recover the deprecated output format.
-
     Returns:
         Tensor: A tensor containing the STFT result with shape described above
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4758,16 +4758,11 @@ def sample_inputs_stft(op_info, device, dtype, requires_grad, **kwargs):
     def mt(shape, **kwargs):
         return make_tensor(shape, device=device, dtype=dtype,
                            requires_grad=requires_grad, **kwargs)
-
-    yield SampleInput(mt(100), n_fft=10, return_complex=True)
-    yield SampleInput(mt(100), n_fft=10, return_complex=False)
-    if dtype.is_complex:
-        yield SampleInput(mt(100), n_fft=10)
+    yield SampleInput(mt(100), kwargs=dict(n_fft=10))
 
     for center in [False, True]:
-        yield SampleInput(mt(10), n_fft=7, center=center, return_complex=True)
-        yield SampleInput(mt((10, 100)), n_fft=16, hop_length=4,
-                          center=center, return_complex=True)
+        yield SampleInput(mt(10), kwargs=dict(n_fft=7, center=center))
+        yield SampleInput(mt((10, 100)), kwargs=dict(n_fft=16, hop_length=4, center=center))
 
     window = mt(16, low=.5, high=2.0)
     yield SampleInput(
@@ -4776,8 +4771,7 @@ def sample_inputs_stft(op_info, device, dtype, requires_grad, **kwargs):
         mt((3, 100)), kwargs=dict(n_fft=16, window=window, return_complex=True, center=center))
     if not dtype.is_complex:
         yield SampleInput(
-            mt((10, 100)), n_fft=16, window=window, onesided=False,
-            return_complex=True)
+            mt((10, 100)), kwargs=dict(n_fft=16, window=window, onesided=False))
 
 
 def sample_inputs_istft(op_info, device, dtype, requires_grad, **kwargs):


### PR DESCRIPTION
Summary:
This diff is reverting D40424319
D40424319 has been identified to be causing the following test or build failures:
Tests affected:
- https://www.internalfb.com/intern/test/562950028663203/

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1356750
Here are the tasks that are relevant to this breakage:
T93240038: 7 tests started failing for oncall speech_model_infra in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Test Plan: NA

Differential Revision: D40498925

