### PR TITLE
[xnnpack][Bug Fix] Pass serialized model by reference

### DIFF
--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
@@ -11,9 +11,9 @@ namespace jit {
 namespace xnnpack {
 namespace delegate {
 
-XNNExecutor XNNCompiler::compileModel(std::string ser_model) {
-  const char* buffer_pointer = ser_model.data();
-
+XNNExecutor XNNCompiler::compileModel(
+    const void* buffer_pointer,
+    size_t num_bytes) {
   auto output_min = -std::numeric_limits<float>::infinity();
   auto output_max = std::numeric_limits<float>::infinity();
 

--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h
@@ -16,7 +16,7 @@ class XNNCompiler {
   // Takes Flatbuffer Serialized XNNPack Model and rebuilds the xnn-subgraph
   // returns an executor object that holds the xnn runtime object which we
   // can then use to set inputs and run inference using the xnn graph.
-  static XNNExecutor compileModel(std::string ser_model);
+  static XNNExecutor compileModel(const void* buffer_pointer, size_t num_bytes);
 };
 
 } // namespace delegate

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
@@ -40,8 +40,9 @@ class XNNPackBackend : public PyTorchBackendInterface {
     auto dict = processed.toGenericDict();
 
     // Compiling and wrapping exeuction object
-    std::string ser_model = dict.at("ser_model").toStringRef();
-    XNNExecutor executor = XNNCompiler::compileModel(ser_model);
+    const std::string& ser_model = dict.at("ser_model").toStringRef();
+    XNNExecutor executor =
+        XNNCompiler::compileModel(ser_model.data(), ser_model.length());
 
     auto model_ptr = c10::make_intrusive<XNNModelWrapper>(std::move(executor));
     auto runtime_handle = IValue::make_capsule(model_ptr);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89090
* __->__ #89089
* #88863

Two changes
- Remove XNNCompiler Dependence on std::string by passing void*
- Grab ser_model by reference: This bug was causing data pointers given to xnn_runtime to be freed because ser_model was on the stack.

Differential Revision: [D41208380](https://our.internmc.facebook.com/intern/diff/D41208380/)