### PR TITLE
[xnnpack][executorch] Pass xnnexecutor pointer to compileModel()

### DIFF
--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h
@@ -16,7 +16,10 @@ class XNNCompiler {
   // Takes Flatbuffer Serialized XNNPack Model and rebuilds the xnn-subgraph
   // returns an executor object that holds the xnn runtime object which we
   // can then use to set inputs and run inference using the xnn graph.
-  static XNNExecutor compileModel(const void* buffer_pointer, size_t num_bytes);
+  static void compileModel(
+      const void* buffer_pointer,
+      size_t num_bytes,
+      XNNExecutor* executor);
 };
 
 } // namespace delegate

--- a/torch/csrc/jit/backends/xnnpack/executor/xnn_executor.h
+++ b/torch/csrc/jit/backends/xnnpack/executor/xnn_executor.h
@@ -1,5 +1,5 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
-
+#pragma once
 #include <xnnpack.h>
 #include <memory>
 #include <vector>
@@ -11,14 +11,15 @@ namespace delegate {
 
 class XNNExecutor {
  private:
-  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> runtime_;
+  std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> runtime_{
+      nullptr,
+      &xnn_delete_runtime};
   std::vector<uint32_t> input_ids_;
   std::vector<uint32_t> output_ids_;
   std::vector<xnn_external_value> externals_;
 
  public:
-  XNNExecutor(xnn_runtime_t runtime_ptr)
-      : runtime_(runtime_ptr, xnn_delete_runtime){};
+  XNNExecutor() = default;
 
   template <typename T>
   bool set_inputs(std::vector<T*>& inputs, std::vector<T*>& outputs) {
@@ -41,7 +42,7 @@ class XNNExecutor {
     }
 
     return true;
-  };
+  }
 
   bool forward() {
     xnn_status status =
@@ -58,7 +59,7 @@ class XNNExecutor {
     }
 
     return true;
-  };
+  }
 
   friend class XNNCompiler;
 };

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_backend_lib.cpp
@@ -41,8 +41,8 @@ class XNNPackBackend : public PyTorchBackendInterface {
 
     // Compiling and wrapping exeuction object
     const std::string& ser_model = dict.at("ser_model").toStringRef();
-    XNNExecutor executor =
-        XNNCompiler::compileModel(ser_model.data(), ser_model.length());
+    XNNExecutor executor;
+    XNNCompiler::compileModel(ser_model.data(), ser_model.length(), &executor);
 
     auto model_ptr = c10::make_intrusive<XNNModelWrapper>(std::move(executor));
     auto runtime_handle = IValue::make_capsule(model_ptr);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89090
* #89089
* #88863

Here we pass XNNExecutor* to compile model so that XNNExecutor can be allocated by runtime. This signature change is for executorch:

```
XNNExecutor compileModel(void* buffer) --> void compileModel(void* buffer, XNNExecutor* executor)
```

The intended usecase for allocating Executor and Compiling the serialized flatbuffer:

```
XNNExecutor* executor = runtime_allocator->allocateList<jit::xnnpack::delegate::XNNExecutor>(1);
XNNCompiler::compileModel(processed.buffer, executor);

```

Differential Revision: [D41208387](https://our.internmc.facebook.com/intern/diff/D41208387/)