### PR TITLE
Fix XLASymNode.str() no str() attribute error

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -235,7 +235,7 @@ class SymInt:
         raise AssertionError("type stub not overridden")
 
     def __repr__(self):
-        return self.node.str()
+        return str(self.node)
 
     # For BC; direct access of node is OK too
     def get_pyobj(self):


### PR DESCRIPTION
This fixes https://github.com/pytorch/xla/issues/4199