### PR TITLE
[ONNX] Add symbolic for _convolution_mode

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1163,6 +1163,27 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
 
         self.run_test(TraceModel(), (x1, x2, x3), atol=10e-5)
 
+    def test_conv_str_padding(self):
+        class TraceModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv1d(16, 33, 3, padding="valid")
+                self.conv2 = torch.nn.Conv2d(
+                    16, 33, (3, 5), stride=1, padding="valid", dilation=(3, 1)
+                )
+                self.conv3 = torch.nn.Conv3d(
+                    16, 33, (3, 5, 2), stride=1, padding="same"
+                )
+
+            def forward(self, input1, input2, input3):
+                return self.conv1(input1), self.conv2(input2), self.conv3(input3)
+
+        x1 = torch.randn(20, 16, 50)
+        x2 = torch.randn(20, 16, 50, 50)
+        x3 = torch.randn(20, 16, 10, 50, 50)
+
+        self.run_test(TraceModel(), (x1, x2, x3), atol=10e-5)
+
     def test_conv_shape_inference(self):
         class Model(torch.nn.Module):
             def __init__(self):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2547,7 +2547,7 @@ def _convolution_mode(
         # Catch a more specific exception instead.
         kernel_shape = None
 
-    if kernel_shape is None or any([i is None for i in kernel_shape]):
+    if kernel_shape is None or any(i is None for i in kernel_shape):
         raise errors.SymbolicValueError(
             "Unsupported: ONNX export of convolution for kernel of unknown shape.",
             input,

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2518,6 +2518,72 @@ def _convolution(
         return n
 
 
+@_onnx_symbolic("aten::_convolution_mode")
+@symbolic_helper.parse_args(
+    "v",
+    "v",
+    "v",
+    "is",
+    "s",
+    "is",
+    "i",
+)
+@_beartype.beartype
+def _convolution_mode(
+    g: jit_utils.GraphContext,
+    input,
+    weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+):
+    weight_size = symbolic_helper._get_tensor_sizes(weight)
+    try:
+        kernel_shape = weight_size[2:]
+    except Exception:
+        # FIXME(justinchuby): Avoid catching Exception.
+        # Catch a more specific exception instead.
+        kernel_shape = None
+
+    if kernel_shape is None or any([i is None for i in kernel_shape]):
+        raise errors.SymbolicValueError(
+            "Unsupported: ONNX export of convolution for kernel of unknown shape.",
+            input,
+        )
+
+    args = [input, weight]
+    # ONNX only supports 1D bias
+    if (
+        not symbolic_helper._is_none(bias)
+        and symbolic_helper._get_tensor_rank(bias) == 1
+    ):
+        args.append(bias)
+
+    if padding == "valid":
+        padding = "VALID"
+    elif padding == "same":
+        padding = "SAME_UPPER"
+    kwargs = {
+        "kernel_shape_i": weight_size[2:],
+        "strides_i": stride,
+        "auto_pad_s": padding,
+        "dilations_i": dilation,
+        "group_i": groups,
+    }
+
+    n = g.op("Conv", *args, **kwargs)
+
+    if (
+        not symbolic_helper._is_none(bias)
+        and symbolic_helper._get_tensor_rank(bias) != 1
+    ):
+        return g.op("Add", n, bias)
+    else:
+        return n
+
+
 @_onnx_symbolic("aten::convolution")
 @symbolic_helper.parse_args("v", "v", "v", "is", "is", "is", "i", "is", "i")
 @_beartype.beartype
@@ -2552,75 +2618,117 @@ def convolution(
 
 
 @_onnx_symbolic("aten::conv1d")
-@symbolic_helper.parse_args("v", "v", "v", "is", "is", "is", "i")
+@symbolic_helper.parse_args("v", "v", "v", "is", "v", "is", "i")
 @_beartype.beartype
 def conv1d(
     g: jit_utils.GraphContext, input, weight, bias, stride, padding, dilation, groups
 ):
-    return _convolution(
-        g,
-        input,
-        weight,
-        bias,
-        stride,
-        padding,
-        dilation,
-        False,
-        (),
-        groups,
-        None,
-        None,
-        None,
-        None,
-    )
+    str_padding = symbolic_helper._parse_arg(padding, "s")
+    if str_padding in ["valid", "same"]:
+        return _convolution_mode(
+            g,
+            input,
+            weight,
+            bias,
+            stride,
+            str_padding,
+            dilation,
+            groups,
+        )
+    else:
+        padding = symbolic_helper._parse_arg(padding, "is")
+        return _convolution(
+            g,
+            input,
+            weight,
+            bias,
+            stride,
+            padding,
+            dilation,
+            False,
+            (),
+            groups,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 @_onnx_symbolic("aten::conv2d")
-@symbolic_helper.parse_args("v", "v", "v", "is", "is", "is", "i")
+@symbolic_helper.parse_args("v", "v", "v", "is", "v", "is", "i")
 @_beartype.beartype
 def conv2d(
     g: jit_utils.GraphContext, input, weight, bias, stride, padding, dilation, groups
 ):
-    return _convolution(
-        g,
-        input,
-        weight,
-        bias,
-        stride,
-        padding,
-        dilation,
-        False,
-        (),
-        groups,
-        None,
-        None,
-        None,
-        None,
-    )
+    str_padding = symbolic_helper._parse_arg(padding, "s")
+    if str_padding in ["valid", "same"]:
+        return _convolution_mode(
+            g,
+            input,
+            weight,
+            bias,
+            stride,
+            str_padding,
+            dilation,
+            groups,
+        )
+    else:
+        padding = symbolic_helper._parse_arg(padding, "is")
+        return _convolution(
+            g,
+            input,
+            weight,
+            bias,
+            stride,
+            padding,
+            dilation,
+            False,
+            (),
+            groups,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 @_onnx_symbolic("aten::conv3d")
-@symbolic_helper.parse_args("v", "v", "v", "is", "is", "is", "i")
+@symbolic_helper.parse_args("v", "v", "v", "is", "v", "is", "i")
 @_beartype.beartype
 def conv3d(
     g: jit_utils.GraphContext, input, weight, bias, stride, padding, dilation, groups
 ):
-    return _convolution(
-        g,
-        input,
-        weight,
-        bias,
-        stride,
-        padding,
-        dilation,
-        False,
-        (),
-        groups,
-        None,
-        None,
-        None,
-        None,
-    )
+    str_padding = symbolic_helper._parse_arg(padding, "s")
+    if str_padding in ["valid", "same"]:
+        return _convolution_mode(
+            g,
+            input,
+            weight,
+            bias,
+            stride,
+            str_padding,
+            dilation,
+            groups,
+        )
+    else:
+        padding = symbolic_helper._parse_arg(padding, "is")
+        return _convolution(
+            g,
+            input,
+            weight,
+            bias,
+            stride,
+            padding,
+            dilation,
+            False,
+            (),
+            groups,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 @_onnx_symbolic("aten::conv_transpose1d")


### PR DESCRIPTION
As per #68880
implement the operator _convolution_mode in the ONNX exporter. This will allow user to leverage the padding 'str' mode where it can be set to 'valid' or 'same'.