### PR TITLE
[LTC] Restore GetPythonFrames

### DIFF
--- a/test/lazy/test_debug_util.py
+++ b/test/lazy/test_debug_util.py
@@ -25,14 +25,14 @@ class DebugUtilTest(TestCase):
         # graph. However, we cannot save the whole stack for comparison given
         # it depends on a lot of things.
         partial_graph = (r"Python Stacktrace:.*"
-                         r"mark_step \(/home/jwtan/work/pytorch/torch/_lazy/__init__.py:[0-9]+\).*"
-                         r"_run_linear \(/home/jwtan/work/pytorch/test/lazy/test_debug_util.py:[0-9]+\).*"
-                         r"test_get_python_frames \(/home/jwtan/work/pytorch/test/lazy/test_debug_util.py:[0-9]+\)")
+                         r"mark_step \(.*/torch/_lazy/__init__.py:[0-9]+\).*"
+                         r"_run_linear \(.*/test/lazy/test_debug_util.py:[0-9]+\).*"
+                         r"test_get_python_frames \(.*/test/lazy/test_debug_util.py:[0-9]+\)")
 
-        with tempfile.NamedTemporaryFile() as graph_file:
+        with tempfile.NamedTemporaryFile(mode="r+", encoding="utf-8") as graph_file:
             os.environ["LTC_SAVE_TENSORS_FILE"] = graph_file.name
             self._run_linear()
-            file = str(graph_file.read())
+            file = graph_file.read()
             self.assertNotEqual(re.search(partial_graph, file, re.DOTALL), None)
 
 

--- a/test/lazy/test_debug_util.py
+++ b/test/lazy/test_debug_util.py
@@ -25,9 +25,9 @@ class DebugUtilTest(TestCase):
         # graph. However, we cannot save the whole stack for comparison given
         # it depends on a lot of things.
         partial_graph = (r"Python Stacktrace:.*"
-                         r"mark_step \(.*/_lazy/__init__.py:[0-9]+\).*"
-                         r"_run_linear \(.*lazy/test_debug_util.py:[0-9]+\).*"
-                         r"test_get_python_frames \(.*lazy/test_debug_util.py:[0-9]+\)")
+                         r"mark_step \(.*__init__.py:[0-9]+\).*"
+                         r"_run_linear \(.*test_debug_util.py:[0-9]+\).*"
+                         r"test_get_python_frames \(.*test_debug_util.py:[0-9]+\)")
 
         with tempfile.NamedTemporaryFile(mode="r+", encoding="utf-8") as graph_file:
             os.environ["LTC_SAVE_TENSORS_FILE"] = graph_file.name

--- a/test/lazy/test_debug_util.py
+++ b/test/lazy/test_debug_util.py
@@ -1,0 +1,40 @@
+# Owner(s): ["oncall: jit"]
+
+import os
+import re
+import tempfile
+import torch.nn as nn
+
+import torch._lazy
+import torch._lazy.ts_backend
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+torch._lazy.ts_backend.init()
+
+
+class DebugUtilTest(TestCase):
+    def _run_linear(self):
+        device = "lazy"
+        model = nn.Linear(5, 5).to(device)
+        output = model(torch.randn(1, 5).to(device))
+        torch._lazy.mark_step()
+
+
+    def test_get_python_frames(self):
+        # We only care about the first "Python Stacktrace" part of the saved
+        # graph. However, we cannot save the whole stack for comparison given
+        # it depends on a lot of things.
+        partial_graph = (r"Python Stacktrace:.*"
+                         r"mark_step \(/home/jwtan/work/pytorch/torch/_lazy/__init__.py:[0-9]+\).*"
+                         r"_run_linear \(/home/jwtan/work/pytorch/test/lazy/test_debug_util.py:[0-9]+\).*"
+                         r"test_get_python_frames \(/home/jwtan/work/pytorch/test/lazy/test_debug_util.py:[0-9]+\)")
+
+        with tempfile.NamedTemporaryFile() as graph_file:
+            os.environ["LTC_SAVE_TENSORS_FILE"] = graph_file.name
+            self._run_linear()
+            file = str(graph_file.read())
+            self.assertNotEqual(re.search(partial_graph, file, re.DOTALL), None)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/lazy/test_debug_util.py
+++ b/test/lazy/test_debug_util.py
@@ -25,9 +25,9 @@ class DebugUtilTest(TestCase):
         # graph. However, we cannot save the whole stack for comparison given
         # it depends on a lot of things.
         partial_graph = (r"Python Stacktrace:.*"
-                         r"mark_step \(.*/torch/_lazy/__init__.py:[0-9]+\).*"
-                         r"_run_linear \(.*/test/lazy/test_debug_util.py:[0-9]+\).*"
-                         r"test_get_python_frames \(.*/test/lazy/test_debug_util.py:[0-9]+\)")
+                         r"mark_step \(.*/_lazy/__init__.py:[0-9]+\).*"
+                         r"_run_linear \(.*/lazy/test_debug_util.py:[0-9]+\).*"
+                         r"test_get_python_frames \(.*/lazy/test_debug_util.py:[0-9]+\)")
 
         with tempfile.NamedTemporaryFile(mode="r+", encoding="utf-8") as graph_file:
             os.environ["LTC_SAVE_TENSORS_FILE"] = graph_file.name

--- a/test/lazy/test_debug_util.py
+++ b/test/lazy/test_debug_util.py
@@ -33,7 +33,7 @@ class DebugUtilTest(TestCase):
             os.environ["LTC_SAVE_TENSORS_FILE"] = graph_file.name
             self._run_linear()
             file = graph_file.read()
-            if re.search(partial_graph, file, re.DOTALL) == None:
+            if re.search(partial_graph, file, re.DOTALL) is None:
                 print(file)
                 self.assertTrue(False)
 

--- a/test/lazy/test_debug_util.py
+++ b/test/lazy/test_debug_util.py
@@ -25,9 +25,9 @@ class DebugUtilTest(TestCase):
         # graph. However, we cannot save the whole stack for comparison given
         # it depends on a lot of things.
         partial_graph = (r"Python Stacktrace:.*"
-                         r"mark_step \(.*__init__.py:[0-9]+\).*"
-                         r"_run_linear \(.*test_debug_util.py:[0-9]+\).*"
-                         r"test_get_python_frames \(.*test_debug_util.py:[0-9]+\)")
+                         r"mark_step \(.*/_lazy/__init__.py:[0-9]+\).*"
+                         r"_run_linear \(.*lazy/test_debug_util.py:[0-9]+\).*"
+                         r"test_get_python_frames \(.*lazy/test_debug_util.py:[0-9]+\)")
 
         with tempfile.NamedTemporaryFile(mode="r+", encoding="utf-8") as graph_file:
             os.environ["LTC_SAVE_TENSORS_FILE"] = graph_file.name

--- a/test/lazy/test_debug_util.py
+++ b/test/lazy/test_debug_util.py
@@ -4,14 +4,16 @@ import os
 import re
 import tempfile
 import torch.nn as nn
+import unittest
 
 import torch._lazy
 import torch._lazy.ts_backend
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 
 torch._lazy.ts_backend.init()
 
 
+@unittest.skipIf(IS_WINDOWS, "To be fixed")
 class DebugUtilTest(TestCase):
     def _run_linear(self):
         device = "lazy"

--- a/test/lazy/test_debug_util.py
+++ b/test/lazy/test_debug_util.py
@@ -26,8 +26,8 @@ class DebugUtilTest(TestCase):
         # it depends on a lot of things.
         partial_graph = (r"Python Stacktrace:.*"
                          r"mark_step \(.*/_lazy/__init__.py:[0-9]+\).*"
-                         r"_run_linear \(.*/lazy/test_debug_util.py:[0-9]+\).*"
-                         r"test_get_python_frames \(.*/lazy/test_debug_util.py:[0-9]+\)")
+                         r"_run_linear \(.*lazy/test_debug_util.py:[0-9]+\).*"
+                         r"test_get_python_frames \(.*lazy/test_debug_util.py:[0-9]+\)")
 
         with tempfile.NamedTemporaryFile(mode="r+", encoding="utf-8") as graph_file:
             os.environ["LTC_SAVE_TENSORS_FILE"] = graph_file.name

--- a/test/lazy/test_debug_util.py
+++ b/test/lazy/test_debug_util.py
@@ -33,7 +33,9 @@ class DebugUtilTest(TestCase):
             os.environ["LTC_SAVE_TENSORS_FILE"] = graph_file.name
             self._run_linear()
             file = graph_file.read()
-            self.assertNotEqual(re.search(partial_graph, file, re.DOTALL), None)
+            if re.search(partial_graph, file, re.DOTALL) == None:
+                print(file)
+                self.assertTrue(False)
 
 
 if __name__ == "__main__":

--- a/torch/csrc/lazy/python/init.cpp
+++ b/torch/csrc/lazy/python/init.cpp
@@ -306,9 +306,9 @@ void initLazyBindings(PyObject* module) {
         return result;
       });
 
-    // When libtorch_python is loaded, we register the python frame getter
-    // otherwise, debug util simply omits python frames
-    GetPythonFramesFunction() = GetPythonFrames;
+  // When libtorch_python is loaded, we register the python frame getter
+  // otherwise, debug util simply omits python frames
+  GetPythonFramesFunction() = GetPythonFrames;
 }
 
 } // namespace lazy

--- a/torch/csrc/lazy/python/init.cpp
+++ b/torch/csrc/lazy/python/init.cpp
@@ -305,6 +305,10 @@ void initLazyBindings(PyObject* module) {
 #endif // !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
         return result;
       });
+
+    // When libtorch_python is loaded, we register the python frame getter
+    // otherwise, debug util simply omits python frames
+    GetPythonFramesFunction() = GetPythonFrames;
 }
 
 } // namespace lazy


### PR DESCRIPTION
Summary:
pytorch/pytorch@936e930 delete the registration of GetPythonFramesFunction. Restore that and add a test case to prevent regression.

Test Plan:
python test/lazy/test_debug_util.py

Fixes pytorch/xla#4206.
