### PR TITLE
Re-enable CPU tests

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1619,7 +1619,6 @@ class CommonTemplate:
         y = torch.tensor(0)
         self.assertEqual(fn(x, y), x + x)
 
-    @unittest.skipIf(HAS_CPU, "Support GPU so far")
     def test_linear_permute_fusion(self):
         class TestModule(torch.nn.Module):
             def __init__(self, k: int, n: int):
@@ -1644,7 +1643,6 @@ class CommonTemplate:
 
         self.assertTrue(torch.allclose(module(input), traced(input)))
 
-    @unittest.skipIf(HAS_CPU, "Support GPU so far")
     def test_permute_linear_fusion(self):
         class TestModule(torch.nn.Module):
             def __init__(self, k: int, n: int):
@@ -1670,7 +1668,6 @@ class CommonTemplate:
 
         self.assertTrue(torch.allclose(module(input), traced(input)))
 
-    @unittest.skipIf(HAS_CPU, "Support GPU so far")
     def test_permute_bmm_fusion(self):
         class TestModule(torch.nn.Module):
             def __init__(self, batch: int, k: int, n: int):


### PR DESCRIPTION
Summary: re-enable CPU tests. Previously had issues on macos tests.

Test Plan: CI

Differential Revision: D41333423



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire