### PR TITLE
Mark IPU device as not supports_as_strided

### DIFF
--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -148,7 +148,8 @@ struct C10_API Device final {
 
   /// Return true if the device supports arbirtary strides.
   bool supports_as_strided() const noexcept {
-    return type_ != DeviceType::XLA && type_ != DeviceType::Lazy;
+    return type_ != DeviceType::IPU && type_ != DeviceType::XLA &&
+        type_ != DeviceType::Lazy;
   }
 
   /// Same string as returned from operator<<.


### PR DESCRIPTION
Currently causes issues in calls to `.to`.