### PR TITLE
cudagraph tapes

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -3,7 +3,10 @@ import functools
 import itertools
 import logging
 import sys
-from typing import List
+import threading
+
+import weakref
+from typing import Any, Dict, List, Optional, Tuple
 
 import functorch
 from functorch._src.aot_autograd import make_boxed_func
@@ -11,7 +14,7 @@ from functorch.compile import min_cut_rematerialization_partition
 
 import torch.fx
 from torch._subclasses.fake_tensor import FakeTensor
-
+from torch.utils import _pytree as pytree
 from . import config, overrides
 from .debug import DebugContext
 from .decomposition import select_decomp_table
@@ -23,6 +26,8 @@ from .utils import (
     has_incompatible_cudagraph_ops,
 )
 from .virtualized import V
+
+WeakRef = Any
 
 log = logging.getLogger(__name__)
 ALIGNMENT = 16
@@ -219,88 +224,630 @@ def remove_unaligned_input_idxs(inputs, static_input_idxs):
     return static_input_idxs
 
 
-def cudagraphify_impl(model, inputs, static_input_idxs=()):
-    """
-    Assumes inputs[static_input_idxs[i]] are always the same memory address
-    """
-    static_input_idxs = remove_unaligned_input_idxs(inputs, static_input_idxs)
+@dataclasses.dataclass(frozen=True)
+class GraphID:
+    id: int
 
+
+class CUDAGraphTapeManger(object):
+    """
+    Groups individual recordings or executions of cuda graphs into a tape of multiple cuda graphs
+    and checks required invariants.
+
+    When graphs are recorded in the same tape, it enforces subsequent execution
+    to follow the same order and have the same output tensor livespans. To remove
+    unnecessary coupling of cuda graphs (and additional imposed invariants),
+    the tape manager will end a currently recording tape whenever it is valid  - when
+    the memory pool no longer has any live allocations.
+    """
+
+    def __init__(self):
+        self.tapes: List[CUDAGraphTape] = []
+
+        self.active_executing_idx: Optional[int] = None
+        self.active_recording_idx: Optional[int] = None
+
+        self.head_to_tape_idx: Dict[GraphID, int] = {}
+
+        self.counter = itertools.count(0)
+        self.cuda_graphs_thread_pool = torch.cuda.graph_pool_handle()
+
+        self.debug_fail_counter = 0
+
+    def increment_recording_tape(self) -> GraphID:
+        if self.in_execution:
+            # checked prior to invocation
+            assert self.executing_tape.valid_end_of_execution()
+            self.executing_tape.reset_execution_state()
+            self.active_executing_idx = None
+
+        # if we're recording, we want to end the tape when the previous tape no longer
+        # has live outputs to avoid unnecessary coupling
+        if self.in_recording and self.recording_tape.valid_end_of_recording():
+            self.active_recording_idx = None
+
+        if not self.in_recording:
+            self.tapes.append(CUDAGraphTape(self))
+            self.active_recording_idx = len(self.tapes) - 1
+
+        graph_id = GraphID(next(self.counter))
+        self.recording_tape.increment_recording_tape(graph_id)
+
+        if len(self.head_to_tape_idx) < len(self.tapes):
+            self.head_to_tape_idx[graph_id] = self.active_recording_idx
+
+        return graph_id
+
+    # returns True if the execution tape is valid to increment
+    def increment_execution_tape(self, id: GraphID) -> bool:
+        if self.in_recording:
+            if not self.recording_tape.valid_end_of_recording():
+                return False
+            self.active_recording_idx = None
+
+        if not self.in_execution and id not in self.head_to_tape_idx:
+            return False
+
+        if id in self.head_to_tape_idx:
+            if self.in_execution:
+                if not self.executing_tape.valid_end_of_execution():
+                    return False
+
+                self.executing_tape.reset_execution_state()
+
+            self.active_executing_idx = self.head_to_tape_idx[id]
+
+        return self.executing_tape.increment_execution_tape(id)
+
+    def record_graph_outputs(self, outputs: List[Optional[torch.Tensor]]) -> None:
+        self.recording_tape.record_graph_outputs(outputs)
+
+    def add_executed_outputs(self, outputs: List[Optional[torch.Tensor]]):
+        return self.executing_tape.add_executed_outputs(outputs)
+
+    def valid_begin_of_recording(self):
+        return not self.in_execution or self.executing_tape.valid_end_of_execution()
+
+    def valid_end_of_execution(self) -> bool:
+        return self.executing_tape.valid_end_of_execution()
+
+    def valid_end_of_recording(self) -> bool:
+        return self.recording_tape.valid_end_of_recording()
+
+    def check_execution_liveness_after_graph(self) -> bool:
+        return self.executing_tape.check_execution_liveness_after_graph()
+
+    def is_cuda_graph_recorded_tensor(self, tensor) -> bool:
+        return self.recording_tape.is_cuda_graph_recorded_tensor(tensor)
+
+    @property
+    def in_execution(self):
+        return self.active_executing_idx is not None
+
+    @property
+    def in_recording(self):
+        return self.active_recording_idx is not None
+
+    @property
+    def executing_tape(self):
+        assert self.in_execution
+        return self.tapes[self.active_executing_idx]
+
+    @property
+    def recording_tape(self):
+        assert self.in_recording
+        return self.tapes[self.active_recording_idx]
+
+
+class CUDAGraphTape(object):
+    """
+    A CUDAGraph Tape records a trace of separate invocations of cudagraphs using the same memory pool.
+    On the initial recording, the CUDA Caching allocator will behaves as if in eager - when tensors are freed,
+    their memory is reclaimed and re-used for other allocations in the recording. Those memory addresses are
+    frozen in to the cuda graph.
+
+    The tape records what Graphs are invoked in what order, and the liveness of all tensors that are allocated
+    to its memory pool. On execution, it ensures that execution matches recording, and the cuda graphs are valid
+    to be replayed.
+
+    The execution of the tape may be interleaved with arbitrary non-cudagraph'd python. We need to check that
+    memory invariants between the end of one graph and the beginning of the next (arbitrary python), and
+    memory invariants from before graph execution and after.
+    """
+
+    def __init__(self, tape_manager):
+
+        self.tape_manager = tape_manager
+        self.recorded_tape: List[GraphID] = []
+        self.executed_tape: List[GraphID] = []
+
+        # TODO - use storages
+        self.recorded_outputs_weakrefs: List[List[WeakRef[torch.Tensor]]] = []
+        self.executed_outputs_weakrefs: List[List[WeakRef[torch.Tensor]]] = []
+
+        self.recorded_liveness_before_graph: List[List[bool]] = []
+        self.recorded_liveness_after_graph: List[List[bool]] = []
+
+        # indices into graph i for output j
+        self.expected_dead_indices_before_graph: List[Tuple[int, int]] = []
+        self.expected_dead_indices_after_graph: List[Tuple[int, int]] = []
+
+        self.outputs_live_at_last_tape: List[Tuple[int, int]] = []
+
+    def increment_recording_tape(self, graph_id: GraphID) -> None:
+        self.recorded_tape.append(graph_id)
+
+        if len(self.recorded_tape) == 1:
+            self.recorded_liveness_before_graph.append([])
+            self.expected_dead_indices_before_graph.append([])
+            return
+
+        previous_liveness = self.recorded_liveness_after_graph[-1]
+        curr_liveness = self.get_liveness(self.recorded_outputs_weakrefs)
+
+        liveness_delta = self.liveness_delta(previous_liveness, curr_liveness)
+
+        self.recorded_liveness_before_graph.append(curr_liveness)
+        self.expected_dead_indices_before_graph.append(liveness_delta)
+
+    def record_graph_outputs(self, outputs: List[Optional[torch.Tensor]]) -> None:
+
+        prev_liveness = self.recorded_liveness_before_graph[-1]
+        curr_liveness = self.get_liveness(self.recorded_outputs_weakrefs)
+
+        delta = self.liveness_delta(prev_liveness, curr_liveness)
+        self.expected_dead_indices_after_graph.append(delta)
+
+        self.recorded_outputs_weakrefs.append([self.map_to_ref(o) for o in outputs])
+        self.recorded_liveness_after_graph.append(
+            self.get_liveness(self.recorded_outputs_weakrefs)
+        )
+
+    @staticmethod
+    def map_to_ref(t):
+        if not isinstance(t, torch.Tensor):
+            assert t is None
+            return None
+        return weakref.ref(t)
+
+    def increment_execution_tape(self, graph_id: GraphID) -> bool:
+        self.executed_tape.append(graph_id)
+        idx = len(self.executed_tape) - 1
+        if self.executed_tape[-1] != self.recorded_tape[idx]:
+            return False
+
+        if not self.check_liveness(
+            self.expected_dead_indices_before_graph[idx], self.executed_outputs_weakrefs
+        ):
+            return False
+
+        return True
+
+    def add_executed_outputs(self, outputs):
+        self.executed_outputs_weakrefs.append([self.map_to_ref(t) for t in outputs])
+
+    def check_execution_liveness_after_graph(self):
+        return self.check_liveness(
+            self.expected_dead_indices_after_graph[len(self.executed_tape) - 1],
+            self.executed_outputs_weakrefs,
+        )
+
+    @staticmethod
+    def get_liveness(output_weakrefs) -> List[List[bool]]:
+        if len(output_weakrefs) == 0:
+            return []
+
+        def is_live(weak_ref):
+            if weak_ref is None:
+                return False
+            return weak_ref() is not None
+
+        return [pytree.tree_map(is_live, outputs) for outputs in output_weakrefs]
+
+    @staticmethod
+    def liveness_delta(
+        prev: List[List[bool]], curr: List[List[bool]]
+    ) -> List[Tuple[int, int]]:
+        dead_indices = []
+        assert len(prev) <= len(curr)
+        for i, (outputs1, outputs2) in enumerate(zip(prev, curr)):
+            assert len(outputs1) == len(outputs2)
+            for j, (output1, output2) in enumerate(zip(outputs1, outputs2)):
+                if output1 != output2:
+                    dead_indices.append((i, j))
+
+        return dead_indices
+
+    @staticmethod
+    def check_liveness(indices: List[Tuple[int, int]], output_refs: List[List[bool]]):
+        for i, j in indices:
+            if output_refs[i][j]() is not None:
+                return False
+        return True
+
+    def valid_end_of_execution(self):
+        return len(self.executed_tape) == len(
+            self.recorded_tape
+        ) and self.check_liveness(
+            self.outputs_live_at_last_tape, self.executed_outputs_weakrefs
+        )
+
+    def reset_execution_state(self):
+        self.executed_tape = []
+        self.executed_outputs_weakrefs = []
+
+    def valid_end_of_recording(self):
+        for outputs in self.recorded_outputs_weakrefs:
+            for out in outputs:
+                if out is not None and out() is not None:
+                    return False
+
+        live_outputs = []
+        final_recorded_liveness = self.recorded_liveness_after_graph[-1]
+        for i in range(len(final_recorded_liveness)):
+            for j in range(len(final_recorded_liveness[i])):
+                if final_recorded_liveness[i][j]:
+                    live_outputs.append((i, j))
+
+        self.outputs_live_at_last_tape = live_outputs
+        return True
+
+    def is_cuda_graph_recorded_tensor(self, tensor):
+        cuda_graph_managed_tensors = []
+        for i in range(len(self.recorded_outputs_weakrefs)):
+            for j in range(len(self.recorded_outputs_weakrefs[i])):
+                output = self.recorded_outputs_weakrefs[i][j]
+                if output is not None and output() is tensor:
+                    return True
+
+        return False
+
+
+class TapeManagerContainer(object):
+    """
+    Manages the lifetime of the tape manager. Like `PrivatePool` in cuda caching allocator,
+    the tape and its corresponding memory pool should be kept alive as long as any outstanding
+    graph or tensor which is an output of a graph remains alive.
+    """
+
+    def __init__(self):
+        self.tape_manager = None
+        self.alive_cudagraphify_objs = 0
+
+        # only set in the case where the CudaGraphify objects die while their
+        # tensor outputs remain live
+        self.live_tensors_count = 0
+        # Used to keep alive the memory pool if the CudaGraph object dies
+        self.graph = None
+        self.lock = threading.Lock()
+
+    def finalize_tensor(self):
+        with self.lock:
+            self.live_tensors_count -= 1
+            if self.live_tensors_count == 0:
+                self.tape_manager = None
+                self.graph = None
+
+    def finalize_cuda_graphify(self, obj_ref):
+        assert obj_ref() is not None
+        obj = obj_ref()
+        with self.lock:
+            self.alive_cudagraphify_objs -= 1
+            if self.alive_cudagraphify_objs != 0:
+                return
+            live_tensors = self.live_cuda_graph_managed_tensors()
+            self.graph = obj.graph
+            if not live_tensors:
+                self.tape_manager = None
+                return
+
+            for t in live_tensors:
+                self.live_tensors_count += 1
+                weakref.finalize(t, self.finalize_tensor)
+
+    def get_tape_manager(self, obj: Optional["CudaGraphify"] = None):
+        if self.live_tensors_count:
+            return None
+
+        if isinstance(obj, CudaGraphify):
+            with self.lock:
+                self.alive_cudagraphify_objs += 1
+
+            # needs to be weak refs otherwise finalizer would keep obj alive
+            obj_ref = weakref.ref(obj)
+            finalize_fn = functools.partial(
+                self.finalize_cuda_graphify, obj_ref=obj_ref
+            )
+            weakref.finalize(obj, finalize_fn)
+
+        if self.tape_manager is None:
+            self.tape_manager = CUDAGraphTapeManger()
+        return self.tape_manager
+
+    def live_cuda_graph_managed_tensors(self):
+        if not self.tape_manager:
+            return []
+
+        if self.tape_manager.in_execution:
+            if self.tape_manager.valid_end_of_execution():
+                return []
+
+            tape = self.tape_manager.executing_tape
+            output_refs = tape.executed_outputs_weakrefs
+        else:
+            assert self.tape_manager.in_recording
+            if self.tape_manager.valid_end_of_recording():
+                return []
+
+            tape = self.tape_manager.recording_tape
+            output_refs = tape.recorded_outputs_weakrefs
+
+        return [
+            t
+            for sublist in output_refs
+            for t in sublist
+            if t is not None and t() is not None
+        ]
+
+
+# TODO - actually make thread local - need to register at TLS that gets copied over
+# in aten/ThreadLocalState
+tape_manager_container = TapeManagerContainer()
+
+
+class CudaGraphify(object):
+    def __init__(self, model, inputs, static_input_idxs=()):
+
+        assert isinstance(inputs, (list, tuple))
+        self.tape_manager = tape_manager_container.get_tape_manager(self)
+        assert self.tape_manager is not None
+        self.graph_id = self.tape_manager.increment_recording_tape()
+        self.model = model
+        static_input_idxs = remove_unaligned_input_idxs(inputs, static_input_idxs)
+
+        # tensors which are outputs of previous graphs in the tape - assume these stay stable
+        self.cudagraph_managed_idxs = [
+            idx
+            for idx, t in enumerate(inputs)
+            if self.tape_manager.is_cuda_graph_recorded_tensor(t)
+        ]
+
+        static_input_idxs = list(
+            set(static_input_idxs) | set(self.cudagraph_managed_idxs)
+        )
+        self.static_input_idxs = static_input_idxs
+
+        self.static_input_data_ptrs = [
+            (inputs[i].data_ptr() if i in static_input_idxs else None)
+            for i in range(len(inputs))
+        ]
+        self.expanded_dims = [
+            get_expanded_dims(x) if idx not in static_input_idxs else []
+            for idx, x in enumerate(inputs)
+        ]
+
+        stream = torch.cuda.Stream()
+
+        # graph needs to be kept alive, otherwise the memory pool would be freed
+        self.inps_alloc_graph = torch.cuda.CUDAGraph()
+
+        # we allocate non-static inputs within the same memory pool as the CUDAGraph
+        # which we will record the model with. For memory efficiency, it is important
+        # to reclaim the input memory when the inputs are no longer live. To accomplish this,
+        # we record the metadata needed to reconstruct the inputs at their correct memory location,
+        # but do not keep them live during the cuda graph recording.
+
+        recording_inputs = self.allocate_recording_inputs(inputs)
+        self.non_static_inputs_metadata = [
+            (
+                self.tensor_metadata(x)
+                if idx not in (self.static_input_idxs + self.cudagraph_managed_idxs)
+                else None
+            )
+            for idx, x in enumerate(recording_inputs)
+        ]
+
+        self.warmup(model, stream, recording_inputs)
+        self.graph = torch.cuda.CUDAGraph()
+
+        # on the first invocation, return the first recorded outputs, because their memory
+        # is correctly accounted for in the CUDAGraphs caching allocator, so on subsequent cudagraph
+        # recording we are tracing with a valid caching allocator state
+        # TODO - consider checkpointing the current cudagraph memory pool state,
+        # so that cudagraphs can have multiple, different cudagraph invocation paths
+        self.recording_outputs = self.record(model, stream, recording_inputs)
+        self.outputs_metadata = []
+
+        # As with inputs, we do not want to keep the outputs permanently alive because that would prevent
+        # their memory being reclaimed in subsequent cuda graph recordings. We record the tensor metadata
+        # needed to reconstruct instead.
+        for out in self.recording_outputs:
+            if isinstance(out, torch.Tensor):
+                self.outputs_metadata.append(
+                    self.tensor_metadata(out, ignore_storage_offset=False)
+                )
+            else:
+                assert out is None
+                self.outputs_metadata.append(None)
+
+    def allocate_recording_inputs(self, inputs):
+        torch.cuda.synchronize()
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        recording_inputs = []
+
+        # inputs should be allocated in the cuda graph memory pool
+        with torch.cuda.graph(
+            self.inps_alloc_graph,
+            pool=self.tape_manager.cuda_graphs_thread_pool,
+            stream=stream,
+        ):
+            for i, inp in enumerate(inputs):
+                if i not in self.static_input_idxs:
+                    recording_inputs.append(self.static_input(inp))
+                else:
+                    recording_inputs.append(inp)
+
+        # TODO: more memory efficient to allocate new input and deallocate
+        # old input, one by one
+
+        # Now that the Graph is no longer recording, zero out inputs
+        # since they may be used in indexing in graph warmup
+        for i, inp in enumerate(recording_inputs):
+            if i not in self.static_input_idxs:
+                inp.zero_()
+
+        return recording_inputs
+
+    def warmup(self, model, stream, inps):
+        # TODO - optimize memory of warmup (deallocate previous inputs, re-use existing memory for running kernels)
+        torch.cuda.synchronize()
+        stream.wait_stream(torch.cuda.current_stream())
+        # copy inputs because list will get cleared in model invocation
+        with torch.cuda.stream(stream):
+            model(list(inps))
+        stream.synchronize()
+        torch.cuda.current_stream().wait_stream(stream)
+        torch.cuda.synchronize()
+
+    def record(self, model, stream, inputs):
+        with torch.cuda.graph(
+            self.graph, stream=stream, pool=self.tape_manager.cuda_graphs_thread_pool
+        ):
+            static_outputs = model(inputs)
+
+        # running model should reclaim memory
+        assert len(inputs) == 0
+
+        if not isinstance(static_outputs, (list, tuple)):
+            static_outputs = (static_outputs,)
+
+        return static_outputs
+
+    def run(self, new_inputs):
+
+        # TODO: mark globally not to attempt to run tape ?
+        if self.recording_outputs is None and not self.check_invariants(new_inputs):
+            return self.model(new_inputs)
+
+        assert len(self.static_input_data_ptrs) == len(new_inputs)
+        for idx, data_ptr in enumerate(self.static_input_data_ptrs):
+            # these are checked in check_invariants
+            if idx in self.cudagraph_managed_idxs:
+                continue
+            if data_ptr is not None:
+                assert data_ptr == new_inputs[idx].data_ptr()
+            else:
+                dst = self.reconstruct_from_tensor_metadata(
+                    self.non_static_inputs_metadata[idx]
+                )
+                src = new_inputs[idx]
+                expanded_dims = self.expanded_dims[idx]
+
+                dst = index_expanded_dims(dst, expanded_dims)
+                src = index_expanded_dims(src, expanded_dims)
+                # TODO - one jit kernel across multiple inputs
+                dst.copy_(src)
+
+        new_inputs.clear()
+        self.graph.replay()
+
+        # outputs is not None on first execution
+        # TODO - refactor
+        if self.recording_outputs is not None:
+            outputs = self.recording_outputs
+            self.recording_outputs = None
+            self.tape_manager.record_graph_outputs(outputs)
+            return outputs
+
+        # TODO - share the same storage object across aliased outputs
+        outputs = [
+            self.reconstruct_from_tensor_metadata(metadata)
+            for metadata in self.outputs_metadata
+        ]
+
+        self.tape_manager.add_executed_outputs(outputs)
+
+        return outputs
+
+    def check_invariants(self, inputs):
+        success = self._check_invariants_impl(inputs)
+        if not success:
+            self.tape_manager.debug_fail_counter += 1
+        return success
+
+    def _check_invariants_impl(self, inputs):
+        # previously managed data pointers remain stable
+        for idx in self.cudagraph_managed_idxs:
+            if inputs[idx].data_ptr() != self.static_input_data_ptrs[idx]:
+                return False
+
+        # same order of execution, previous outputs dead
+        if not self.tape_manager.increment_execution_tape(self.graph_id):
+            return False
+
+        # the cudagraph managed tensors which died upon recording must also die upon
+        # this invocation. it is too late to check after we've replayed the graph,
+        # because we would have already written over their memory.
+        for idx in self.cudagraph_managed_idxs:
+            inputs[idx] = None
+        if not self.tape_manager.check_execution_liveness_after_graph():
+            for idx in self.self.cudagraph_managed_idxs:
+                inputs[idx] = self.reconstruct_from_tensor_metadata(
+                    self.non_static_inputs_metadata[idx]
+                )
+            return False
+
+        return True
+
+    @staticmethod
     def static_input(x):
         """
-        Copy and input while preserving strides
+        Copy input while preserving strides
         """
-        # TODO(jansel): figure out why this version doesn't work:
-        # return torch.empty_strided(x.size(), x.stride(), dtype=x.dtype, device=x.device)
         needed_size = (
             sum((shape - 1) * stride for shape, stride in zip(x.size(), x.stride())) + 1
         )
-        buffer = torch.zeros(needed_size, dtype=x.dtype, device=x.device)
+        buffer = torch.empty((needed_size,), dtype=x.dtype, device=x.device)
         return torch.as_strided(buffer, x.size(), x.stride())
 
-    assert isinstance(inputs, (list, tuple))
-    static_inputs = [
-        static_input(x) if idx not in static_input_idxs else x.detach()
-        for idx, x in enumerate(inputs)
-    ]
+    @staticmethod
+    def tensor_metadata(x, ignore_storage_offset=True):
+        assert isinstance(x, torch.Tensor)
+        # We ignore the storage offset for inputs, but not for outputs
+        # TODO: - should we make the storage resizable ?
+        return {
+            "nbytes": x.storage().nbytes(),
+            "data_ptr": x.storage().data_ptr(),
+            "size": x.shape,
+            "stride": x.stride(),
+            "dtype": x.dtype,
+            "device": x.device,
+            "storage_offset": x.storage_offset() if not ignore_storage_offset else 0,
+        }
 
-    inps_expanded_dims = [
-        get_expanded_dims(x) if idx not in static_input_idxs else []
-        for idx, x in enumerate(inputs)
-    ]
+    @staticmethod
+    def reconstruct_from_tensor_metadata(metadata):
+        s = torch._C._construct_storage_from_data_pointer(
+            metadata["data_ptr"], metadata["device"], metadata["nbytes"]
+        )
+        t = torch.empty([0], device=metadata["device"], dtype=metadata["dtype"])
+        t.set_(
+            source=s,
+            storage_offset=metadata["storage_offset"],
+            size=metadata["size"],
+            stride=metadata["stride"],
+        )
+        return t
 
-    # warmup
-    torch.cuda.synchronize()
-    stream = torch.cuda.Stream()
-    stream.wait_stream(torch.cuda.current_stream())
-    # copy static_inputs because it will be cleared in model
-    with torch.cuda.stream(stream):
-        model(list(static_inputs))
-    stream.synchronize()
-    torch.cuda.current_stream().wait_stream(stream)
-    torch.cuda.synchronize()
 
-    # record
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph, stream=stream):
-        static_outputs = model(list(static_inputs))
-    if not isinstance(static_outputs, (list, tuple)):
-        static_outputs = (static_outputs,)
+def cudagraphify_impl(model, inputs, static_input_idxs=()):
+    manager = tape_manager_container.get_tape_manager()
 
-    if config.size_asserts:
+    if manager is None or not manager.valid_begin_of_recording():
+        return model
 
-        def run(new_inputs):
-            assert len(static_inputs) == len(new_inputs)
-            for idx, (dst, src, expanded_dims) in enumerate(
-                zip(static_inputs, new_inputs, inps_expanded_dims)
-            ):
-                if idx in static_input_idxs:
-                    assert dst.data_ptr() == src.data_ptr()
-                else:
-                    # TODO - could make one single op of multiple slices
-                    # and avoid dispatch.
-                    # Could also pre-index the `dst` tensors
-                    dst = index_expanded_dims(dst, expanded_dims)
-                    src = index_expanded_dims(src, expanded_dims)
-                    dst.copy_(src)
-            new_inputs.clear()
-            graph.replay()
-            return static_outputs
-
-    else:
-        copy_indices = [
-            idx for idx in range(len(static_inputs)) if idx not in static_input_idxs
-        ]
-
-        def run(new_inputs):
-            for idx in copy_indices:
-                src = index_expanded_dims(static_inputs[idx], inps_expanded_dims[idx])
-                dst = index_expanded_dims(new_inputs[idx], inps_expanded_dims[idx])
-                dst.copy_(src)
-            new_inputs.clear()
-            graph.replay()
-            return static_outputs
-
-    return run
+    return CudaGraphify(model, inputs, static_input_idxs).run
 
 
 def count_tangents(fx_g: torch.fx.GraphModule):

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1491,6 +1491,11 @@ Call this whenever a new thread is created in order to propagate values from
     return at::globalContext().linalgPreferredBackend();
   });
 
+  py_module.def("_construct_storage_from_data_pointer", [](int64_t data_ptr, c10::Device device, size_t size_bytes) {
+    return c10::Storage(c10::Storage::use_byte_size_t(), size_bytes, at::DataPtr(reinterpret_cast<void*>(data_ptr), device));
+  });
+
+
 #ifdef USE_CUDA
   PyObject* has_cuda = Py_True;
 #else


### PR DESCRIPTION
This is a first PR implementing the following plan of POR:

- We will use a single Memory Pool across all cudagraphs. The memory pool will contain inputs (?), intermediates, and outputs. CUDAGraphs memory pool ensures that memory allocated within graph capture is not allocated outside of the memory pool, so that memory addresses remain static during graph replay. However, within the memory pool, normal storage allocation occurs, so there is no memory overhead. So long as we invoke separate CUDAGraphs in a consistent order as they are recorded, and do not retain extraneous references to Tensors, there should be no overhead. We will keep a global tape of the initial graph recordings and subsequent usages. Enforcing consistent CUDAGraph usage will also allow us to avoid copying over inputs to a CUDAGraph that are the outputs of a prior one. 
- To avoid “static outputs” being permanently allocated, which interferes with both memory being reclaimed within CUDAGraphs and [gradient stealing](https://github.com/pytorch/pytorch/blob/master/torch/csrc/autograd/functions/accumulate_grad.h#L52), we will reconstruct output tensors Tensors with the appropriate fixed storage data pointers and other metadata on each cudagraph invocation. 
- When a CUDAGraph usage diverges from the existing tape we can 1. free the memory pool to the rest of the cuda allocator, invalidating the CUDAGraphs of our tape but keeping the existing Tensors alive or 2. Run torch inductor without cudagraphs for the remainder of the tape. The latter would have some memory penalty because it would not use memory from the memory pool 
- Because cudagraphs freeze memory addresses, the invocation of a cudagraph will replace whatever values the memory had previously. To avoid overwriting the live output values of a previous invocation, we can either check that the backward has been run for a cudagraph forward (not clear to me this is sufficient ?). We potentially could also do weak-ref ref counting.

Not everything is implemented yet, and I will not land this pr without subsequent follow ups. 

Follows ups, for correctness/minimal viable product in terms of priority include :
- Registering the cudagraphs as thread local state that needs to be copied over in autograd
- Ensuring clean up works successfully
- Adding tests for all the edge cases provided reviewers are okay with approach
- Handling subsequent usage when a graph invariant is broken, i.e. moving cuda graph allocations from the private memory pool to eager

And then further work would be:
- Allowing multiple, separate cudagraph paths by making the cuda caching allocator resumable and doing new recordings. 
- Adding configs to weaken some of the correctness conditions (for power user who can verify correctness)




cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire