### PR TITLE
Removed unecessary check in `select_nested`

### DIFF
--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -502,11 +502,6 @@ Tensor select_nested(const Tensor& self, int64_t dim, int64_t index) {
   int64_t ntensors = self_ptr->size(0);
   TORCH_CHECK_INDEX(ntensors > 0, "You can only select when the NT is not empty.");
   int64_t ndims = static_cast<long>(sizes[0].size());
-  TORCH_CHECK(
-    positive_dim == 0 || positive_dim == 1,
-    "NestedTensor can only be selected along dimension 0 or 1",
-    "got dimension ", dim, " instead."
-  );
   if (positive_dim == 0) {
     TORCH_CHECK_INDEX(
         index >= -ntensors && index < ntensors,
@@ -534,13 +529,16 @@ Tensor select_nested(const Tensor& self, int64_t dim, int64_t index) {
           size_ptr[dim_idx] = sizes[i][j];
           stride_ptr[dim_idx] = strides[i][j];
           ++dim_idx;
-        }
-        else {
+        } else {
           TORCH_CHECK_INDEX(
               index >= 0 && index < sizes[i][j],
               "index ",
               index,
-              " is out of bounds for irregular dimension 1 with size ",
+              " is out of bounds for dimension ",
+              j,
+              " of the ",
+              i,
+              "th constituent tensor with size ",
               sizes[i][j]);
           new_offsets[i] = offsets[i] + index * strides[i][j];
         }

--- a/docs/source/nested.rst
+++ b/docs/source/nested.rst
@@ -201,7 +201,7 @@ NestedTensor and any constraints they have.
    Supports addition of a scalar to a nested tensor."
    :func:`torch.mul`; "Supports elementwise multiplication of two nested tensors.
    Supports multiplication of a nested tensor by a scalar."
-   :func:`torch.select`; "Supports selecting along all dimensions.")."
+   :func:`torch.select`; "Supports selecting along all dimensions."
    :func:`torch.clone`; "Behavior is the same as on regular tensors."
    :func:`torch.detach`; "Behavior is the same as on regular tensors."
    :func:`torch.unbind`; "Supports unbinding along ``dim=0`` only."

--- a/docs/source/nested.rst
+++ b/docs/source/nested.rst
@@ -201,7 +201,7 @@ NestedTensor and any constraints they have.
    Supports addition of a scalar to a nested tensor."
    :func:`torch.mul`; "Supports elementwise multiplication of two nested tensors.
    Supports multiplication of a nested tensor by a scalar."
-   :func:`torch.select`; "Supports selecting along ``dim=0`` only (analogously ``nt[i]``)."
+   :func:`torch.select`; "Supports selecting along all dimensions.")."
    :func:`torch.clone`; "Behavior is the same as on regular tensors."
    :func:`torch.detach`; "Behavior is the same as on regular tensors."
    :func:`torch.unbind`; "Supports unbinding along ``dim=0`` only."

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -800,10 +800,13 @@ class TestNestedTensorDeviceType(TestCase):
         self.assertEqual(nt[1, ...], x1)
         self.assertRaises(IndexError, lambda: nt[1, 4, 2])
         self.assertRaises(NotImplementedError, lambda: nt[:, 1, 1])
-        # test select on the irregular dimension only
+        # test select on non-batch dimensions
         self.assertEqual(nt.select(1, 0)[0], x0.select(0, 0))
         self.assertEqual(nt.select(1, 0)[1], x1.select(0, 0))
         self.assertRaises(IndexError, lambda: nt.select(1, 3))
+        self.assertEqual(nt.select(2, 0)[0], x0.select(1, 0))
+        self.assertEqual(nt.select(2, 0)[1], x1.select(1, 0))
+        self.assertRaises(IndexError, lambda: nt.select(2, 5))
         # make sure indexing returns a view
         nt[0].fill_(100.0)
         answer = torch.tensor(100.0, device=device, dtype=dtype).expand((2, 5))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #89150

Implementation in  #88585 should work for all dimensions. Removed unnecessary check that constrained select to dims 0 and 1
