### PR TITLE
Expose retrieveDesyncReport() C++ API as internal method to Python

### DIFF
--- a/torch/csrc/distributed/c10d/TraceUtils.h
+++ b/torch/csrc/distributed/c10d/TraceUtils.h
@@ -159,7 +159,7 @@ inline std::string dumpSnapshot(TraceMap& traceMap) {
 }
 
 inline bool parseTraceValue(
-    c10::intrusive_ptr<Store>& store,
+    const c10::intrusive_ptr<Store>& store,
     const std::string& key,
     uint64_t& seq,
     std::string& col) {
@@ -177,7 +177,7 @@ inline bool parseTraceValue(
 }
 
 inline std::string retrieveDesyncReport(
-    c10::intrusive_ptr<Store>& store,
+    const c10::intrusive_ptr<Store>& store,
     const std::string& pgName,
     int myRank,
     int worldSize) {


### PR DESCRIPTION
Summary: This diff exposes desync information from `retrieveDesyncReport()` which is normally used in `ProcessGroupNCCL` implementation, but we are exposing it as an internal API. The API is surfaced from pybind using a newly created pybind module.

Test Plan:
Added a new file and test:

`buck run caffe2/test/distributed/fb:test_c10d_distributed`

Differential Revision: D41237217

