### PR TITLE
Fix inaccuracy in nt constructor documentation + broken rendering

### DIFF
--- a/torch/nested/__init__.py
+++ b/torch/nested/__init__.py
@@ -125,8 +125,8 @@ Constructs a nested tensor with no autograd history (also known as a “leaf ten
 :ref:`Autograd mechanics <autograd-mechanics>`) from :attr:`tensor_list` a list of tensors.
 
 Args:
-    tensor_list (List[array_like]): a list of tensors (or anything that can be passed to torch.tensor)
-    where their first dimension can be of irregular size, but all other dimensions have to be equal.
+    tensor_list (List[array_like]): a list of tensors, or anything that can be passed to torch.tensor,
+    where each element of the list has the same dimensionality.
 
 Keyword arguments:
     dtype (:class:`torch.dtype`, optional): the desired type of returned nested tensor.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #89152

Rendering was broken and docstring seemed to be inaccurate

![Screen Shot 2022-11-16 at 2 16 28 PM](https://user-images.githubusercontent.com/35276741/202273588-a2da5b7b-1a6d-46bb-a74e-c0de9a0fd064.png)


