### PR TITLE
[doesn't work] Update save_on_cpu to handle saving the same possibly wrapped tensor multiple times

### DIFF
--- a/functorch/_src/vmap.py
+++ b/functorch/_src/vmap.py
@@ -24,16 +24,17 @@ out_dims_t = Union[int, Tuple[int, ...]]
 
 
 def doesnt_support_saved_tensors_hooks(f):
-    message = (
-        "functorch transforms don't yet support saved tensor hooks. "
-        "Please open an issue with your use case."
-    )
+    return f
+    # message = (
+    #     "functorch transforms don't yet support saved tensor hooks. "
+    #     "Please open an issue with your use case."
+    # )
 
-    @functools.wraps(f)
-    def fn(*args, **kwargs):
-        with torch.autograd.graph.disable_saved_tensors_hooks(message):
-            return f(*args, **kwargs)
-    return fn
+    # @functools.wraps(f)
+    # def fn(*args, **kwargs):
+    #     with torch.autograd.graph.disable_saved_tensors_hooks(message):
+    #         return f(*args, **kwargs)
+    # return fn
 
 
 # Checks that all args-to-be-batched have the same batch dim size


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89159
* #85849
* #88357

I wanted to see if I could get something to work without having to stash and restore autograd metadata.
It does this by saving the outer most wrapping, and then during unpacking, unwrap to the desired level.
The issue is that this doesn't completely work - when outputs are saved for backward, we save the inner-most
tensors first, and we never know if the current layer of unwrapping is the last layer or not (because there may be a vmap somewhere that changes what the grad layers above end up saving)