### PR TITLE
[dynamo] mutable local caching to make dynamo faster at tracing mutation

### DIFF
--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -82,7 +82,7 @@ class SideEffects(object):
             keepalive=list(self.keepalive),
         )
 
-    def apply(self, fn, cache=None, skip_fn=None):
+    def apply(self, fn, cache=None, skip_fn=lambda _: False):
         if cache is None:
             cache = dict()
 

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -82,16 +82,16 @@ class SideEffects(object):
             keepalive=list(self.keepalive),
         )
 
-    def apply(self, fn, cache=None):
+    def apply(self, fn, cache=None, skip_fn=None):
         if cache is None:
             cache = dict()
 
         self.id_to_variable = collections.OrderedDict(
-            (k, VariableTracker.apply(fn, v, cache))
+            (k, VariableTracker.apply(fn, v, cache, skip_fn))
             for k, v in self.id_to_variable.items()
         )
         self.store_attr_mutations = collections.OrderedDict(
-            (k, VariableTracker.apply(fn, v, cache))
+            (k, VariableTracker.apply(fn, v, cache, skip_fn))
             for k, v in self.store_attr_mutations.items()
         )
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -306,11 +306,16 @@ class InstructionTranslatorBase(object):
                 return newvar
             return v
 
+        def skip(v: VariableTracker):
+            return oldvar.mutable_local not in v.recursively_contains
+
         cache = dict()
-        self.output.side_effects.apply(repl, cache)
-        self.stack = [VariableTracker.apply(repl, x, cache) for x in self.stack]
+        self.output.side_effects.apply(repl, cache, skip_fn=skip)
+        self.stack = [VariableTracker.apply(repl, x, cache, skip) for x in self.stack]
         for k, x in self.symbolic_locals.items():
-            self.symbolic_locals[k] = VariableTracker.apply(repl, x, cache)
+            self.symbolic_locals[k] = VariableTracker.apply(
+                repl, x, cache, skip_fn=skip
+            )
 
     def replace_all(self, oldvar: VariableTracker, newvar: VariableTracker):
         if isinstance(oldvar.mutable_local, side_effects.MutableSideEffects):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -311,7 +311,9 @@ class InstructionTranslatorBase(object):
 
         cache = dict()
         self.output.side_effects.apply(repl, cache, skip_fn=skip)
-        self.stack = [VariableTracker.apply(repl, x, cache, skip) for x in self.stack]
+        self.stack = [
+            VariableTracker.apply(repl, x, cache, skip_fn=skip) for x in self.stack
+        ]
         for k, x in self.symbolic_locals.items():
             self.symbolic_locals[k] = VariableTracker.apply(
                 repl, x, cache, skip_fn=skip

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -10,17 +10,13 @@ from ..eval_frame import skip_code
 from ..exc import unimplemented
 from ..source import AttrSource, GlobalWeakRefSource
 from ..utils import global_key_name, istensor
-from .base import aggregate_mutable_locals, MutableLocal, VariableTracker
+from .base import MutableLocal, VariableTracker
 from .constant import ConstantVariable
 from .tensor import TensorVariable
 
 
 class ConstDictVariable(VariableTracker):
     def __init__(self, items, user_cls, recursively_contains=None, **kwargs):
-
-        if recursively_contains is None:
-            recursively_contains = aggregate_mutable_locals(items.values())
-
         super(ConstDictVariable, self).__init__(
             recursively_contains=recursively_contains, **kwargs
         )

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -10,14 +10,20 @@ from ..eval_frame import skip_code
 from ..exc import unimplemented
 from ..source import AttrSource, GlobalWeakRefSource
 from ..utils import global_key_name, istensor
-from .base import MutableLocal, VariableTracker
+from .base import aggregate_mutable_locals, MutableLocal, VariableTracker
 from .constant import ConstantVariable
 from .tensor import TensorVariable
 
 
 class ConstDictVariable(VariableTracker):
-    def __init__(self, items, user_cls, **kwargs):
-        super(ConstDictVariable, self).__init__(**kwargs)
+    def __init__(self, items, user_cls, recursively_contains=None, **kwargs):
+
+        if recursively_contains is None:
+            recursively_contains = aggregate_mutable_locals(items.values())
+
+        super(ConstDictVariable, self).__init__(
+            recursively_contains=recursively_contains, **kwargs
+        )
         self.items = items
         self.user_cls = user_cls
 
@@ -112,7 +118,14 @@ class ConstDictVariable(VariableTracker):
                 tx.store_dict_key(global_key_name(k), k)
             newval = collections.OrderedDict(val)
             newval[k] = args[1]
-            return tx.replace_all(self, self.modifed(newval, **options))
+            new_rec_contains = self.recursively_contains.union(
+                args[1].recursively_contains
+            )
+            new_rec_contains.add(args[1].mutable_local)
+            return tx.replace_all(
+                self,
+                self.modifed(newval, recursively_contains=new_rec_contains, **options),
+            )
         elif (
             name in ("pop", "get")
             and args

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -114,13 +114,16 @@ class ConstDictVariable(VariableTracker):
                 tx.store_dict_key(global_key_name(k), k)
             newval = collections.OrderedDict(val)
             newval[k] = args[1]
+
             new_rec_contains = self.recursively_contains.union(
                 args[1].recursively_contains
             )
-            new_rec_contains.add(args[1].mutable_local)
+            if args[1].mutable_local is not None:
+                new_rec_contains.add(args[1].mutable_local)
+
             return tx.replace_all(
                 self,
-                self.modifed(newval, recursively_contains=new_rec_contains, **options),
+                self.modifed(newval, new_rec_contains, **options),
             )
         elif (
             name in ("pop", "get")
@@ -139,7 +142,7 @@ class ConstDictVariable(VariableTracker):
         ):
             newval = collections.OrderedDict(val)
             result = newval.pop(ConstDictVariable.get_key(args[0]))
-            tx.replace_all(self, self.modifed(newval, **options))
+            tx.replace_all(self, self.modifed(newval, None, **options))
             return result.add_options(options)
         elif (
             name == "update"
@@ -149,7 +152,12 @@ class ConstDictVariable(VariableTracker):
         ):
             newval = collections.OrderedDict(val)
             newval.update(args[0].items)
-            result = self.modifed(newval, **options)
+            new_rec_contains = self.recursively_contains.union(
+                args[0].recursively_contains
+            )
+            result = self.modifed(
+                newval, recursively_contains=new_rec_contains, **options
+            )
             return tx.replace_all(self, result)
         elif (
             name in ("get", "__getattr__")
@@ -168,9 +176,11 @@ class ConstDictVariable(VariableTracker):
         else:
             return super().call_method(tx, name, args, kwargs)
 
-    def modifed(self, items, **options):
+    def modifed(self, items, recursively_contains, **options):
         """a copy of self with different items"""
-        return self.clone(items=items, **options)
+        return self.clone(
+            items=items, recursively_contains=recursively_contains, **options
+        )
 
     def unpack_var_sequence(self, tx):
         options = VariableTracker.propagate([self])
@@ -246,7 +256,13 @@ class DefaultDictVariable(ConstDictVariable):
                             f"defaultdict with default_factory = {self.default_factory}"
                         )
                     new_val[k] = default_var
-                    tx.replace_all(self, self.modifed(new_val, **options))
+                    new_rec_contains = self.recursively_contains.union(
+                        default_var.recursively_contains
+                    )
+                    new_rec_contains.add(default_var.mutable_local)
+                    tx.replace_all(
+                        self, self.modifed(new_val, new_rec_contains, **options)
+                    )
                     return default_var
         else:
             return super().call_method(tx, name, args, kwargs)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -8,7 +8,7 @@ from ..bytecode_transformation import create_instruction
 from ..exc import unimplemented
 from ..source import GetItemSource
 from ..utils import namedtuple_fields, proxy_args_kwargs
-from .base import MutableLocal, VariableTracker
+from .base import aggregate_mutable_locals, MutableLocal, VariableTracker
 from .constant import ConstantVariable
 
 
@@ -23,8 +23,15 @@ class BaseListVariable(VariableTracker):
             tuple: TupleVariable,
         }[obj]
 
-    def __init__(self, items: List[VariableTracker], **kwargs):
-        super(BaseListVariable, self).__init__(**kwargs)
+    def __init__(
+        self, items: List[VariableTracker], recursively_contains=None, **kwargs
+    ):
+        if recursively_contains is None:
+            recursively_contains = aggregate_mutable_locals(items)
+
+        super(BaseListVariable, self).__init__(
+            recursively_contains=recursively_contains, **kwargs
+        )
         assert isinstance(items, list)
         assert all(isinstance(x, VariableTracker) for x in items)
         self.items: List[VariableTracker] = items
@@ -145,9 +152,13 @@ class ListVariable(BaseListVariable):
         if name == "append" and self.mutable_local:
             assert not kwargs
             (arg,) = args
+            new_rec_contains = self.recursively_contains.union(arg.recursively_contains)
+            new_rec_contains.add(arg.mutable_local)
             tx.replace_all(
                 self,
-                ListVariable(self.items + [arg], **options),
+                ListVariable(
+                    self.items + [arg], recursively_contains=new_rec_contains, **options
+                ),
             )
             return ConstantVariable(None)
         elif (
@@ -454,8 +465,13 @@ class SliceVariable(BaseListVariable):
 
 
 class ListIteratorVariable(VariableTracker):
-    def __init__(self, items, index: int = 0, **kwargs):
-        super(ListIteratorVariable, self).__init__(**kwargs)
+    def __init__(self, items, index: int = 0, recursively_contains=None, **kwargs):
+        if recursively_contains is None:
+            recursively_contains = aggregate_mutable_locals(items)
+
+        super(ListIteratorVariable, self).__init__(
+            recursively_contains=recursively_contains, **kwargs
+        )
         assert isinstance(items, list)
         # Removing this check as it slows things down too much
         # https://github.com/pytorch/pytorch/pull/87533#issuecomment-1287574492

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -8,7 +8,7 @@ from ..bytecode_transformation import create_instruction
 from ..exc import unimplemented
 from ..source import GetItemSource
 from ..utils import namedtuple_fields, proxy_args_kwargs
-from .base import aggregate_mutable_locals, MutableLocal, VariableTracker
+from .base import MutableLocal, VariableTracker
 from .constant import ConstantVariable
 
 
@@ -26,9 +26,6 @@ class BaseListVariable(VariableTracker):
     def __init__(
         self, items: List[VariableTracker], recursively_contains=None, **kwargs
     ):
-        if recursively_contains is None:
-            recursively_contains = aggregate_mutable_locals(items)
-
         super(BaseListVariable, self).__init__(
             recursively_contains=recursively_contains, **kwargs
         )
@@ -466,9 +463,6 @@ class SliceVariable(BaseListVariable):
 
 class ListIteratorVariable(VariableTracker):
     def __init__(self, items, index: int = 0, recursively_contains=None, **kwargs):
-        if recursively_contains is None:
-            recursively_contains = aggregate_mutable_locals(items)
-
         super(ListIteratorVariable, self).__init__(
             recursively_contains=recursively_contains, **kwargs
         )

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -109,7 +109,8 @@ class ContextWrappingVariable(VariableTracker):
         self.initial_values = initial_values
         self.recursively_contains = (
             set()
-        )  # Workaround so that we don't call apply() on this variable
+        )  # This var doesn't contain any child vars and doesn't support clone() properly,
+        # so don't populate this automatically
 
     def enter(self, tx):
         self._call_func(tx, self.target_values)

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -107,6 +107,9 @@ class ContextWrappingVariable(VariableTracker):
         super(ContextWrappingVariable, self).__init__(**kwargs)
         self.target_values = target_values
         self.initial_values = initial_values
+        self.recursively_contains = (
+            set()
+        )  # Workaround so that we don't call apply() on this variable
 
     def enter(self, tx):
         self._call_func(tx, self.target_values)
@@ -294,7 +297,7 @@ class GradModeVariable(ContextWrappingVariable):
 
 class AutocastModeVariable(ContextWrappingVariable):
     @staticmethod
-    def create(tx, target_values, kwargs):
+    def create(target_values, kwargs):
         values = target_values
         # device_type : str,
         # dtype : Optional[_dtype] = None,
@@ -322,10 +325,10 @@ class AutocastModeVariable(ContextWrappingVariable):
         else:
             values.append(variables.ConstantVariable(None))
 
-        var = AutocastModeVariable(tx, target_values, initial_values=None, **kwargs)
+        var = AutocastModeVariable(target_values, initial_values=None, **kwargs)
         return var
 
-    def __init__(self, tx, target_values, initial_values=None, **kwargs):
+    def __init__(self, target_values, initial_values=None, **kwargs):
         super(AutocastModeVariable, self).__init__(
             target_values=target_values, initial_values=initial_values, **kwargs
         )

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -292,7 +292,7 @@ class TorchVariable(VariableTracker):
                 tensor_with_tf_override.subclass_type,
             )
         elif self.value is torch.amp.autocast_mode.autocast:
-            return AutocastModeVariable.create(tx, target_values=args, kwargs=kwargs)
+            return AutocastModeVariable.create(target_values=args, kwargs=kwargs)
         elif self.value in (
             torch.profiler.profile,
             torch.profiler.record_function,


### PR DESCRIPTION
Make mutation faster to speed up tracing optimizers, helps with https://github.com/pytorch/torchdynamo/issues/1803

`replace_all` no longer iterates over the entire variable tracker data structure  every time a mutation is performed

Each variable tracker internally keeps a set of contained mutable variable trackers, to provide a hint to `replace_all`. This is populated with a call to `apply` from `__post_init__` in the base `VariableTracker`


cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire