### PR TITLE
[FSDP][1/N] Refactor module materialization

### DIFF
--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -192,32 +192,24 @@ class TestGetSubmoduleToStates(TestCase):
         self.assertEqual(submodules[0], model)
         root_states = submodule_to_states[submodules[0]]
         self.assertEqual(root_states.params, [model.lin.weight])
-        self.assertEqual(root_states.param_names, ["lin.weight"])
         self.assertEqual(root_states.buffers, [])
-        self.assertEqual(root_states.buffer_names, [])
         # # - `seq2`
         self.assertEqual(submodules[1], model.seq2)
         seq2_states = submodule_to_states[submodules[1]]
         self.assertEqual(seq2_states.params, [model.seq2[1].weight])
-        self.assertEqual(seq2_states.param_names, ["1.weight"])
         self.assertEqual(seq2_states.buffers, [model.seq2[1].seq2_1_buffer])
-        self.assertEqual(seq2_states.buffer_names, ["1.seq2_1_buffer"])
         # - `seq2[0]`
         self.assertEqual(submodules[2], model.seq2[0])
         seq2_0_states = submodule_to_states[submodules[2]]
         self.assertEqual(seq2_0_states.params, [])  # shared parameter
-        self.assertEqual(seq2_0_states.param_names, [])
         self.assertEqual(seq2_0_states.buffers, [])
-        self.assertEqual(seq2_0_states.buffer_names, [])
         # - `seq1`
         self.assertEqual(submodules[3], model.seq1)
         seq1_states = submodule_to_states[submodules[3]]
         self.assertEqual(
             seq1_states.params, [model.seq1[0].weight, model.seq1[1].weight]
         )
-        self.assertEqual(seq1_states.param_names, ["0.weight", "1.weight"])
         self.assertEqual(seq1_states.buffers, [model.seq1.seq1_buffer])
-        self.assertEqual(seq1_states.buffer_names, ["seq1_buffer"])
 
 
 instantiate_parametrized_tests(TestUtils)

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -234,13 +234,18 @@ def _init_param_handle_from_module(
     """
     _check_single_device_module(root_module, state._ignored_params)
     device_from_device_id = _get_device_from_device_id(device_id, state.rank)
-    _materialize_module(
-        root_module,
-        param_init_fn,
-        state._ignored_params,
-        device_from_device_id,
-        lambda k: not isinstance(k, module_wrapper_cls),
+    is_meta_module, is_torchdistX_deferred_init = _need_to_materialize_module(
+        root_module, state._ignored_params
     )
+    # Materialize the module if needed
+    if (is_meta_module or is_torchdistX_deferred_init) and param_init_fn is not None:
+        _materialize_with_param_init_fn(root_module, param_init_fn)
+    elif is_meta_module:
+        _materialize_meta_module(root_module, device_id)
+    elif is_torchdistX_deferred_init:
+        deferred_init.materialize_module(
+            root_module, check_fn=lambda k: not isinstance(k, module_wrapper_cls)
+        )
     # TODO: Investigate refactoring `_move_module_to_device()` to
     # `_move_states_to_device()` to avoid the `device_id` + CPU offload hack
     _move_module_to_device(root_module, state._ignored_params, device_from_device_id)
@@ -283,19 +288,31 @@ def _init_param_handles_from_module(
     # Initialize and shard `FlatParamHandle`s one by one following bottom-up
     # order (hence the `reversed`) to avoid increasing peak GPU memory usage
     materialized_module = False
-    for submodule, (params, buffers, param_names, buffer_names) in reversed(
-        submodule_to_states.items()
-    ):
-        materialized_module |= _materialize_module(
-            submodule,
-            param_init_fn,
-            state._ignored_params,
-            device_from_device_id,
-            lambda _: True,
+    for submodule, (params, buffers) in reversed(submodule_to_states.items()):
+        # Materialize the module if needed
+        is_meta_module, is_torchdistX_deferred_init = _need_to_materialize_module(
+            submodule, state._ignored_params
         )
+        if is_meta_module or is_torchdistX_deferred_init:
+            materialized_module = True
+            # Save the parameter and buffer names to reacquire references after
+            # after materialization since their variables may change
+            param_names, buffer_names = _get_state_names_for_states(
+                submodule, params, buffers
+            )
+        if (
+            is_meta_module or is_torchdistX_deferred_init
+        ) and param_init_fn is not None:
+            _materialize_with_param_init_fn(submodule, param_init_fn)
+        elif is_meta_module:
+            _materialize_meta_module(submodule, device_id)
+        elif is_torchdistX_deferred_init:
+            deferred_init.materialize_module(
+                root_module,
+                check_fn=lambda _: True,
+            )
         if materialized_module:
-            # Materializing from meta device can change the parameter/buffer
-            # variables, so reacquire references
+            # Reacquire references using the pre-computed state names
             params = [submodule.get_parameter(param_name) for param_name in param_names]
             buffers = [
                 submodule.get_buffer(buffer_name) for buffer_name in buffer_names
@@ -351,6 +368,37 @@ def _init_param_handle_from_params(
     cpu_device = torch.device("cpu")
     if state.cpu_offload.offload_params and handle.flat_param.device != cpu_device:
         handle.flat_param_to(cpu_device)
+
+
+def _get_state_names_for_states(
+    module: nn.Module,
+    params: List[nn.Parameter],
+    buffers: List[torch.Tensor],
+) -> Tuple[List[str], List[str]]:
+    """
+    Returns the parameter and buffer names of the given ``params`` and
+    ``buffers``, where the names are prefixed starting from ``module``. This
+    function assumes that the parameters and buffers are in the module tree.
+    """
+    param_names: List[str] = []
+    buffer_names: List[str] = []
+    param_to_param_name = {
+        param: param_name for param_name, param in module.named_parameters()
+    }
+    buffer_to_buffer_name = {
+        buffer: buffer_name for buffer_name, buffer in module.named_buffers()
+    }
+    for param in params:
+        assert (
+            param in param_to_param_name
+        ), f"Parameter not in the module tree:\n{module}\n{param}"
+        param_names.append(param_to_param_name[param])
+    for buffer in buffers:
+        assert (
+            buffer in buffer_to_buffer_name
+        ), f"Buffer not in the module tree:\n{module}\n{buffer}"
+        buffer_names.append(buffer_to_buffer_name[buffer])
+    return param_names, buffer_names
 
 
 def _get_ignored_modules(
@@ -476,28 +524,15 @@ def _get_device_from_device_id(
     return device
 
 
-def _materialize_module(
+def _need_to_materialize_module(
     module: nn.Module,
-    param_init_fn: Optional[Callable[[nn.Module], None]],
     ignored_params: Set[nn.Parameter],
-    device_from_device_id: Optional[torch.device],
-    deferred_init_check_fn: Callable,
-) -> bool:
+) -> Tuple[bool, bool]:
     """
-    Materializes the wrapped module ``module`` in place if needed: either
-    if the module has parameters that use meta device or are torchdistX
-    fake tensors.
-
-    This method uses ``param_init_fn`` to materialize the module if the
-    function is not ``None`` and falls back to default behavior otherwise.
-    For meta device, this moves the module to ``device_from_device_id`` if
-    it is not ``None`` or the current device otherwise and calls
-    ``reset_parameters()``, and for torchdistX fake tensors, this calls
-    ``deferred_init.materialize_module()``.
-
-    Returns:
-        bool: ``True`` if ``module`` was materialized and ``False`` if this was
-        a no-op.
+    Returns if ``module`` has parameters on meta device and if ``module`` is
+    using torchdistX deferred initialization. At most of the returned bools can
+    be ``True``. If either is ``True``, then ``module`` needs to be
+    materialized.
     """
     managed_params = _get_orig_params(module, ignored_params)
     is_meta_module = any(param.is_meta for param in managed_params)
@@ -506,35 +541,39 @@ def _materialize_module(
         and _TORCHDISTX_AVAIL
         and any(fake.is_fake(param) for param in managed_params)
     )
-    if (is_meta_module or is_torchdistX_deferred_init) and param_init_fn is not None:
-        if not callable(param_init_fn):
-            raise ValueError(
-                f"Expected {param_init_fn} to be callable but got {type(param_init_fn)}"
-            )
-        param_init_fn(module)
-        return True
-    elif is_meta_module:
-        # Run default meta device initialization
-        materialization_device = device_from_device_id or torch.device(
-            torch.cuda.current_device()
+    return is_meta_module, is_torchdistX_deferred_init
+
+
+def _materialize_with_param_init_fn(
+    module: nn.Module,
+    param_init_fn,
+) -> None:
+    if not callable(param_init_fn):
+        raise ValueError(
+            f"Expected {param_init_fn} to be callable but got {type(param_init_fn)}"
         )
-        module.to_empty(device=materialization_device)
-        try:
-            with torch.no_grad():
-                module.reset_parameters()  # type: ignore[operator]
-        except BaseException as e:
-            warnings.warn(
-                "Unable to call `reset_parameters()` for module on meta "
-                f"device with error {str(e)}. Please ensure your "
-                "module implements a `reset_parameters()` method."
-            )
-            raise e
-        return True
-    elif is_torchdistX_deferred_init:
-        # Run default torchdistX initialization
-        deferred_init.materialize_module(module, check_fn=deferred_init_check_fn)
-        return True
-    return False
+    param_init_fn(module)
+
+
+def _materialize_meta_module(
+    module: nn.Module,
+    device_from_device_id: Optional[torch.device],
+):
+    # Run default meta device initialization
+    materialization_device = device_from_device_id or torch.device(
+        torch.cuda.current_device()
+    )
+    module.to_empty(device=materialization_device)
+    try:
+        with torch.no_grad():
+            module.reset_parameters()  # type: ignore[operator]
+    except BaseException as e:
+        warnings.warn(
+            "Unable to call `reset_parameters()` for module on meta "
+            f"device with error {str(e)}. Please ensure your "
+            "module implements a `reset_parameters()` method."
+        )
+        raise e
 
 
 def _move_module_to_device(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #89229 [FSDP][Easy] Remove unused methods
* #89227 [FSDP][Easy] Remove internal default arg
* #89217 [FSDP][Easy] Remove outdated TODO
* #89215 [FSDP][4/N] Add `_ExecOrderBasePolicy`
* #89182 [FSDP][3/N] Integrate LCA into `fully_shard`
* #89181 [FSDP][2/N] Add util for computing LCAs for shared params
* **#89180 [FSDP][1/N] Refactor module materialization**

**Overview**
This refactors module materialization (i.e. meta device or `torchdistX` deferred initialization) to compute the parameter and buffer names as needed instead of pre-computing them. These are needed to reacquire references to the states (e.g. `module.get_parameter(param_name)`) after materialization since the materialization may create new variables.

This refactor simplifies `_get_submodule_to_states()` (the core function for "pseudo auto wrapping") to better enable lowest common ancestor (LCA) module computation for shared parameters, for which tracking parameter and buffer names may complicate the already non-obvious implementation.

**Discussion**
The tradeoff is a worst case quadratic traversal over modules if materializing all of them. However, since (1) the number of modules is relatively small, (2) the computation per module in the quadratic traversal is negligible, (3) this runs only once per training session, and (4) module materialization targets truly large models, I think this tradeoff is tolerable.

**For Reviewers**
- `_init_param_handle_from_module()` initializes _one_ `FlatParamHandle` from a _subroot_ module and represents the module wrapper code path. For this code path, there is no need to reacquire references to the parameters/buffers for now since the managed parameters are only computed after materialization. This works because the managed parameters have a simple definition: any parameter in the local root module's tree excluding those already marked as flattened by FSDP. Similarly, FSDP marks buffers to indicate that they have already been processed (synced if `sync_module_states`).
- `_init_param_handles_from_module()` initializes _all_ `FlatParamHandle`s from a _local root_ module and represents the composable code path (and later non-recursive wrapping code path as well). For this code path, we must reacquire references to parameters/buffers because each logical wrapping is specified as a list of parameters/buffers to group together by those variables and because materialization may create new variables.

Example to clarify terminology:
```
Module(
    Submodule(
        Subsubmodule,
        Subsubmodule,
    ),
    Submodule(
        Subsubmodule,
        Subsubmodule,
    ),
)
```
Suppose we apply FSDP to `Module` and each `Submodule`. 
- I am calling each `Submodule` a _subroot_ because when applying FSDP to it, it is the root of the subtree in consideration -- there are still child `Subsubmodule`s in the subtree.
- I am calling `Module` the _local root_ because it is the module whose FSDP instance has `_is_root = True` but, in general, `Module` may be part of a larger module tree, in which case it may not be the global root.