### PR TITLE
[FSDP][2/N] Add util for computing LCAs for shared params

### DIFF
--- a/test/distributed/fsdp/test_shared_param_utils.py
+++ b/test/distributed/fsdp/test_shared_param_utils.py
@@ -1,0 +1,109 @@
+# Owner(s): ["oncall: distributed"]
+
+import torch
+import torch.nn as nn
+from torch.distributed.fsdp._shared_param_utils import (
+    get_lca_query,
+    get_shared_param_info_to_lca,
+    SharedParamInfo,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class Root(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.inner1 = Inner()
+        self.inner2 = Inner()
+        self.inner3 = Inner()
+        self.inner4 = Inner()
+        self.inner5 = Inner()
+        self.leaf = Leaf()
+        # (1) Same depth cousin sharing: LCA = `root`
+        self.inner1.child1.p = self.inner2.child2.p
+        # (2) Diferent depth cousin sharing: LCA = `root`
+        self.inner1.p = self.inner2.child1.p
+        # (3) Sibling (same depth) sharing: LCA = `inner3`
+        self.inner3.child1.p = self.inner3.child2.p
+        # (4, 5, 6) Three-way sharing: LCA = `root`
+        # Only two of (4, 5, 6) should be present since order does not matter,
+        # where in general for k-way sharing, we expect k-1 entries
+        self.inner2.p = self.leaf.p
+        self.inner3.p = self.leaf.p
+        # (7) Parent-child sharing: LCA = `inner4`
+        self.inner4.child1.p = self.inner4.p
+        # Parent-child sharing to be ignored
+        self.inner5.child1.p = self.inner5.p
+
+
+class Inner(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.p = nn.Parameter(torch.randn((1, 1)))
+        self.child1 = Leaf()
+        self.child2 = Leaf()
+
+
+class Leaf(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.p = nn.Parameter(torch.randn((1, 1)))
+
+
+class TestSharedParamUtils(TestCase):
+    def test_get_shared_param_info_to_lca(self):
+        """
+        Tests ``get_shared_param_info_to_lca()``, which computes the lowest
+        common ancestor for shared parameters.
+        """
+        root = Root()
+        ignored_params = set(root.inner5.parameters())
+        shared_param_info_to_lca = get_shared_param_info_to_lca(root, ignored_params)
+        # Expect 6 since (1) through (7) with only two out of (4, 5, 6) and
+        # `inner5` ignored
+        self.assertEqual(len(shared_param_info_to_lca), 6)
+        # (1)
+        query1 = get_lca_query(root.inner1.child1, root.inner2.child2)
+        spi1 = SharedParamInfo(*query1, root.inner1.child1.p)
+        lca1 = root
+        # (2)
+        query2 = get_lca_query(root.inner1, root.inner2.child1)
+        spi2 = SharedParamInfo(*query2, root.inner1.p)
+        lca2 = root
+        # (3)
+        query3 = get_lca_query(root.inner3.child1, root.inner3.child2)
+        spi3 = SharedParamInfo(*query3, root.inner3.child1.p)
+        lca3 = root.inner3
+        # (4, 5, 6)
+        query4 = get_lca_query(root.inner2, root.leaf)
+        spi4 = SharedParamInfo(*query4, root.inner2.p)
+        query5 = get_lca_query(root.inner3, root.leaf)
+        spi5 = SharedParamInfo(*query5, root.inner2.p)
+        query6 = get_lca_query(root.inner2, root.inner3)
+        spi6 = SharedParamInfo(*query6, root.inner2.p)
+        lca4 = lca5 = lca6 = root
+        # (7)
+        query7 = get_lca_query(root.inner4.child1, root.inner4)
+        spi7 = SharedParamInfo(*query7, root.inner4.p)
+        lca7 = root.inner4
+
+        # Check that the keys are present and map to the expected LCA values
+        for spi, lca in ((spi1, lca1), (spi2, lca2), (spi3, lca3), (spi7, lca7)):
+            self.assertIn(spi, shared_param_info_to_lca)
+            self.assertEqual(shared_param_info_to_lca[spi], lca)
+        # (4, 5, 6) should only contribute 2 entries, where it does not matter
+        # which pair (4, 5), (5, 6), (4, 6) is excluded
+        check_in_bools = []
+        check_equal_bools = []
+        for spi, lca in ((spi4, lca4), (spi5, lca5), (spi6, lca6)):
+            has_entry = spi in shared_param_info_to_lca
+            check_in_bools.append(has_entry)
+            check_equal_bools.append(
+                shared_param_info_to_lca[spi] == lca if has_entry else False
+            )
+        self.assertGreaterEqual(sum(check_in_bools), 2)
+        self.assertGreaterEqual(sum(check_equal_bools), 2)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/fsdp/_shared_param_utils.py
+++ b/torch/distributed/fsdp/_shared_param_utils.py
@@ -1,0 +1,141 @@
+import collections
+
+from typing import Dict, List, NamedTuple, Set, Tuple
+
+import torch.nn as nn
+
+
+class SharedParamInfo(NamedTuple):
+    """
+    This includes information about shared parameters needed for high-level
+    FSDP initialization (i.e. choosing which parameters to flatten together).
+    This differs from the shared parameter info needed for ``FlatParamHandle``
+    initialization (where the parameters to flatten have already been chosen).
+    """
+
+    module1: nn.Module
+    module2: nn.Module
+    param: nn.Parameter
+
+
+def get_shared_param_info_to_lca(
+    root_module: nn.Module,
+    ignored_params: Set[nn.Parameter],
+) -> Dict[SharedParamInfo, nn.Module]:
+    """
+    Computes the lowest common ancestor modules for the queries encoded by
+    ``shared_param_infos``, where each entry in the list gives two modules,
+    which each represent a vertex in the module tree.
+
+    This follows a simple version of Tarjan's offline lowest common ancestor
+    algorithm based on a union-find data structure.
+    """
+    shared_param_infos = get_shared_param_infos(root_module, ignored_params)
+    # Construct edge list representing the LCA query graph
+    module_to_sharing_modules: Dict[
+        nn.Module, List[nn.Module]
+    ] = collections.defaultdict(list)
+    for module1, module2, _ in shared_param_infos:
+        module_to_sharing_modules[module1].append(module2)
+        module_to_sharing_modules[module2].append(module1)
+
+    module_to_parent: Dict[nn.Module, nn.Module] = {}
+    module_to_rank: Dict[nn.Module, int] = {}
+    module_to_ancestor: Dict[nn.Module, nn.Module] = {}
+    visited_modules: Set[nn.Module] = set()
+    lca_query_to_lca: Dict[Tuple[nn.Module, nn.Module], nn.Module] = {}
+
+    def tarjan_lca(module: nn.Module):
+        make_set(module, module_to_parent, module_to_rank)
+        for child_module in module.children():
+            tarjan_lca(child_module)
+            union(module, child_module, module_to_parent, module_to_rank)
+            module_to_ancestor[find(module, module_to_parent)] = module
+        visited_modules.add(module)
+        if module not in module_to_sharing_modules:
+            return
+        for other_module in module_to_sharing_modules[module]:
+            if other_module in visited_modules:
+                lca_query = get_lca_query(module, other_module)
+                if lca_query in lca_query_to_lca:
+                    continue  # already computed
+                lca_query_to_lca[lca_query] = module_to_ancestor[
+                    find(other_module, module_to_parent)
+                ]
+
+    tarjan_lca(root_module)  # compute the LCAs
+    shared_param_info_to_lca: Dict[SharedParamInfo, nn.Module] = {}
+    for shared_param_info in shared_param_infos:
+        module1, module2, _ = shared_param_info
+        lca_query = get_lca_query(module1, module2)
+        assert lca_query in lca_query_to_lca, f"Missing LCA query: {lca_query}"
+        shared_param_info_to_lca[shared_param_info] = lca_query_to_lca[lca_query]
+    return shared_param_info_to_lca
+
+
+def get_shared_param_infos(
+    root_module: nn.Module,
+    ignored_params: Set[nn.Parameter],
+) -> List[SharedParamInfo]:
+    """
+    Returns a list of shared parameter information in the module tree rooted at
+    ``root_module`` and ignoring ``ignored_params``.
+    """
+    visited_param_to_module: Dict[nn.Parameter, nn.Module] = {}
+    shared_param_infos: List[SharedParamInfo] = []
+    for module in root_module.modules():
+        for param in module.parameters(recurse=False):
+            if param in ignored_params:
+                continue
+            if param in visited_param_to_module:  # shared parameter
+                query = get_lca_query(visited_param_to_module[param], module)
+                shared_param_infos.append(SharedParamInfo(*query, param))
+            else:
+                visited_param_to_module[param] = module
+    return shared_param_infos
+
+
+def get_lca_query(
+    module1: nn.Module,
+    module2: nn.Module,
+) -> Tuple[nn.Module, nn.Module]:
+    """
+    Returns an LCA query, where we fix an order for any two modules to avoid
+    duplicates due to reordering and to ensure consistent dict lookups.
+    """
+    return (module1, module2) if id(module1) < id(module2) else (module2, module1)
+
+
+def make_set(
+    module: nn.Module,
+    module_to_parent: Dict[nn.Module, nn.Module],
+    module_to_rank: Dict[nn.Module, int],
+) -> None:
+    module_to_parent[module] = module
+    module_to_rank[module] = 1
+
+
+def union(
+    module1: nn.Module,
+    module2: nn.Module,
+    module_to_parent: Dict[nn.Module, nn.Module],
+    module_to_rank: Dict[nn.Module, int],
+) -> None:
+    root1 = find(module1, module_to_parent)
+    root2 = find(module2, module_to_parent)
+    if module_to_rank[root1] > module_to_rank[root2]:
+        module_to_parent[root2] = root1
+    elif module_to_rank[root1] < module_to_rank[root2]:
+        module_to_parent[root1] = root2
+    else:
+        module_to_parent[root2] = root1
+        module_to_rank[root1] += 1
+
+
+def find(
+    module: nn.Module,
+    module_to_parent: Dict[nn.Module, nn.Module],
+) -> nn.Module:
+    if module_to_parent[module] != module:
+        module_to_parent[module] = find(module_to_parent[module], module_to_parent)
+    return module_to_parent[module]

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1307,7 +1307,10 @@ class FlatParamHandle:
                         assert tensor is not None  # mypy
                         param_var = tensor
                 setattr(module, param_name, param_var)
-                if self._use_orig_params and self._training_state == HandleTrainingState.FORWARD:
+                if (
+                    self._use_orig_params
+                    and self._training_state == HandleTrainingState.FORWARD
+                ):
                     module._parameters[param_name] = param_var  # type: ignore[assignment]
         for i, (
             param_name,
@@ -1339,7 +1342,10 @@ class FlatParamHandle:
                 module.register_parameter(param_name, prim_param)
             else:
                 setattr(module, param_name, prim_param)
-                if self._use_orig_params and self._training_state == HandleTrainingState.FORWARD:
+                if (
+                    self._use_orig_params
+                    and self._training_state == HandleTrainingState.FORWARD
+                ):
                     module._parameters[param_name] = prim_param  # type: ignore[assignment]
 
     def _use_unsharded_grad_views(self) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #89229 [FSDP][Easy] Remove unused methods
* #89227 [FSDP][Easy] Remove internal default arg
* #89217 [FSDP][Easy] Remove outdated TODO
* #89215 [FSDP][4/N] Add `_ExecOrderBasePolicy`
* #89182 [FSDP][3/N] Integrate LCA into `fully_shard`
* **#89181 [FSDP][2/N] Add util for computing LCAs for shared params**
* #89180 [FSDP][1/N] Refactor module materialization

**Overview**
- This PR implements a utility function `get_shared_param_info_to_lca()` that returns a `Dict[SharedParamInfo, nn.Module]` mapping `SharedParamInfo` (representing a shared parameter) to its lowest common ancestor (LCA) module.
- This function can be used as a subroutine for assigning shared parameters to their LCA modules during FSDP initialization (for the composable code path in the short term).

**Details**
The implementation follows a simple version of [Tarjan's offline LCA algorithm](https://en.wikipedia.org/wiki/Tarjan%27s_off-line_lowest_common_ancestors_algorithm) that is based on a union-find data structure. We can use this algorithm because the set of LCA queries is fixed a priori (i.e. this is offline).

Each module represents a vertex in the module tree, where there is a directed edge from parent module to child module (i.e. `p` is a parent of `c` if `c` is returned from `p.children()`). The LCA module `lca` of two modules `a` and `b` is the lowest (i.e. greatest depth) module that includes both `a` and `b` in its subtree.


**Addendum**
The change to `flat_param.py` is purely formatting (from running `ufmt`).

For the unit test, here is a visualization of the module tree:
![tree](https://user-images.githubusercontent.com/31054793/202576843-688694dc-ccbd-4d98-9cf8-b82d51d05e8e.png)

