### PR TITLE
[FSDP][4/N] Add `_ExecOrderBasePolicy`

### DIFF
--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -6,7 +6,18 @@
 import contextlib
 import functools
 from abc import ABC, abstractmethod
-from typing import Any, Callable, cast, Dict, Generator, Optional, Set, Tuple, Type, no_type_check
+from typing import (
+    Any,
+    Callable,
+    cast,
+    Dict,
+    Generator,
+    no_type_check,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+)
 
 import torch.nn as nn
 from torch.nn.modules.batchnorm import _BatchNorm

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -6,7 +6,7 @@
 import contextlib
 import functools
 from abc import ABC, abstractmethod
-from typing import Any, Callable, cast, Dict, Generator, Optional, Set, Tuple, Type
+from typing import Any, Callable, cast, Dict, Generator, Optional, Set, Tuple, Type, no_type_check
 
 import torch.nn as nn
 from torch.nn.modules.batchnorm import _BatchNorm
@@ -55,11 +55,11 @@ def _module_wrap_policy(
     module_classes: Set[Type[nn.Module]],
 ) -> bool:
     """
-    This auto wrap policy wraps every module that is an instance of any type in
-    ``module_classes`` as its own FSDP instance. The root module given by
-    ``module`` is always wrapped as an FSDP instance regardless. Since the
-    wrapping proceeds bottom up, each FSDP instance manages the parameters in
-    its subtree excluding any already managed by a child FSDP instance.
+    This policy wraps every module that is an instance of any type in
+    ``module_classes``. The root module given by ``module`` is always wrapped
+    regardless. Since the wrapping proceeds following a post-order traversal
+    (~bottom up), each wrap includes the parameters in its subtree excluding
+    any already assigned to a child wrap.
 
     Args:
         module (nn.Module): Current module being considered.
@@ -84,10 +84,48 @@ class ModuleWrapPolicy(_FSDPPolicy):
     """This is a wrapper around :func:`_module_wrap_policy`."""
 
     def __init__(self, module_classes: Set[Type[nn.Module]]):
+        super().__init__()
         self._policy: Callable = functools.partial(
             _module_wrap_policy,
             module_classes=module_classes,
         )
+
+    @property
+    def policy(self):
+        return self._policy
+
+
+@no_type_check
+def _exec_order_base_policy(
+    module: nn.Module,
+    recurse: bool,
+    nonwrapped_numel: int,
+):
+    """
+    This policy wraps every module, excluding those with type in
+    ``EXCLUDE_MODULE_CLASSES`` and forcing those with type in
+    ``FORCE_LEAF_MODULE_CLASSES`` to be wrapped without further recursing. This
+    is meant to be the first iteration base policy for ``ExecOrderPolicy``.
+    """
+    if recurse:
+        return not isinstance(module, _exec_order_base_policy.FORCE_LEAF_MODULE_CLASSES)
+    return not isinstance(module, _exec_order_base_policy.EXCLUDE_MODULE_CLASSES)
+
+
+_exec_order_base_policy.EXCLUDE_MODULE_CLASSES = (nn.ModuleList, nn.ModuleDict)
+# Force any modules with external parameters to be leafs
+_exec_order_base_policy.FORCE_LEAF_MODULE_CLASSES = (nn.MultiheadAttention,)
+
+
+class _ExecOrderBasePolicy(_FSDPPolicy):
+    """
+    This is a wrapper around :func:`_exec_order_base_policy` and is meant for
+    testing.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._policy = _exec_order_base_policy
 
     @property
     def policy(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #89229 [FSDP][Easy] Remove unused methods
* #89227 [FSDP][Easy] Remove internal default arg
* #89217 [FSDP][Easy] Remove outdated TODO
* **#89215 [FSDP][4/N] Add `_ExecOrderBasePolicy`**
* #89182 [FSDP][3/N] Integrate LCA into `fully_shard`
* #89181 [FSDP][2/N] Add util for computing LCAs for shared params
* #89180 [FSDP][1/N] Refactor module materialization

**Overview**
This PR adds `_ExecOrderBasePolicy: _FSDPPolicy` that wraps `_exec_order_base_policy` and represents the 1st iteration base policy for the upcoming `ExecOrderPolicy`. This policy is like `always_wrap_policy` with the exclude and force-leaf ability from `size_based_auto_wrap_policy`.

Notably, we must force `nn.MultiheadAttention` to be a leaf because it has _external parameters_. This refers to the case when there is a `module` whose `forward()` uses parameters from its `submodule` without calling `submodule.forward()`. In that case, we must not wrap `submodule` separately from `module`, or else `submodule`'s parameters will not be unsharded for `module.forward()`.

By adding this policy, I can simplify a unit test from the previous PR to use `TransformerWithSharedParams` from `common_fsdp.py` instead of writing a separate model with similar structure except does not use `nn.MultiheadAttention`.

**Discussion**
I keep this policy and its exclude/force-leaf lists distinct from those of `size_based_auto_wrap_policy` since this policy is experimental and may change. We should also not change `always_wrap_policy` since it may be used for other recursive wrapping (like `apply_activation_checkpoint`), and I would like to preserve BC with this PR.