### PR TITLE
Re-enable test_hf_bert_fsdp

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -258,8 +258,6 @@ class TestDistributedMultiProc(MultiProcessTestCase):
     # TODO(whc) Investigate why cudagraphs breaks inductor+fsdp for hf_bert
     @patch.object(torch._inductor.config.triton, "cudagraphs", False)
     @patch.object(torch._inductor.config, "fallback_random", True)
-    # TODO(voz): Flaky on CI failure, consistent failure on local master.
-    @unittest.skipIf(True, "Flaky on CI failure, consistent failure on local master")
     def test_hf_bert_fsdp(self):
         from transformers.models.bert.modeling_bert import BertLayer
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #89223

It looks like this failure was actually caused by https://github.com/pytorch/pytorch/pull/88629, see the revert message on that PR. It probably just looked like a flaky test on CI because of how quickly the PR was reverted.