### PR TITLE
Add factory functions to python frontend

### DIFF
--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -364,6 +364,16 @@ class TorchRefsNvfuserCapabilityMode(TorchRefsMode):
         )
         return result
 
+    def _is_full(self, func):
+        result = "torch.full" == torch.overrides.resolve_name(func) or (
+            func
+            in [
+                torch.ops.aten.full,
+                torch.ops.aten.full.names,
+            ]
+        )
+        return result
+
     def __torch_function__(
         self,
         orig_func: Callable,
@@ -415,6 +425,9 @@ class TorchRefsNvfuserCapabilityMode(TorchRefsMode):
             if len(kwargs) > 0:
                 warn("rand_like has ignored kwargs!")
             return torch.ops.nvprims.rand_like(*args)
+
+        if self._is_full(orig_func):
+            return torch.ops.nvprims.full(*args, **kwargs)
 
         # Then we use TorchRefsMode to interpret the rest
         return super().__torch_function__(orig_func, types, args, kwargs)

--- a/torch/_prims/nvfuser_prims.py
+++ b/torch/_prims/nvfuser_prims.py
@@ -387,10 +387,6 @@ def register_full():
         "full(SymInt[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, "
         + "bool? pin_memory=None, bool? requires_grad=None) -> Tensor"
     )
-    nvprim.define(
-        "full.names(int[] size, Scalar fill_value, *, Dimname[]? names, "
-        + "ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor"
-    )
 
     def _meta_impl(
         size,
@@ -435,27 +431,6 @@ def register_full():
 
     nvprim_impl.impl(name, _prim_impl)
     nvprim_meta_impl.impl(name, _meta_impl)
-
-    def _names_overload_impl(
-        size,
-        fill_value,
-        *,
-        names=None,
-        dtype=None,
-        layout=None,
-        device=None,
-        pin_memory=False,
-    ):
-        return prim(
-            size,
-            fill_value,
-            dtype=dtype,
-            layout=layout,
-            device=device,
-            pin_memory=pin_memory,
-        )
-
-    nvprim_implicit_impl.impl("full.names", _names_overload_impl)
 
     prim_packet = getattr(torch.ops.nvprims, name)
     prim = prim_packet.default

--- a/torch/_prims/nvfuser_prims.py
+++ b/torch/_prims/nvfuser_prims.py
@@ -343,11 +343,21 @@ def _clone_nvfuser(fd: Any, input: TensorLikeType, *, memory_format=None):
 
 
 def _full_nvfuser(
-    fd: Any, shape: ShapeType, fill_value: NumberType, *, dtype: torch.dtype
+    fd: Any,
+    shape: ShapeType,
+    fill_value: NumberType,
+    *,
+    dtype: Optional[torch.dtype] = None,
+    layout: Optional[torch.layout] = None,
+    device: Optional[torch.device] = None,
+    pin_memory: bool = False,
 ):
-    constant = fd.define_constant(fill_value)
+    assert device != torch.device("cpu")
+    assert layout is None
+    assert pin_memory is False
+    dtype = torch.float32 if dtype is None else dtype
     nvfuser_dtype = getnvFuserDtype(dtype)
-    return fd.full(shape, constant, nvfuser_dtype)
+    return fd.full(shape, fill_value, nvfuser_dtype)
 
 
 _nvfuser_impls["native_batch_norm"] = _native_batch_norm_nvfuser

--- a/torch/_prims/nvfuser_prims.py
+++ b/torch/_prims/nvfuser_prims.py
@@ -360,7 +360,7 @@ def _full_nvfuser(
     assert requires_grad is False
     dtype = dtype if dtype is not None else utils.type_to_dtype(type(fill_value))
     nvfuser_dtype = getnvFuserDtype(dtype)
-    return fd.full(shape, fill_value, nvfuser_dtype)
+    return fd.ops.full(shape, fill_value, nvfuser_dtype)
 
 
 _nvfuser_impls["native_batch_norm"] = _native_batch_norm_nvfuser

--- a/torch/_prims/nvfuser_prims.py
+++ b/torch/_prims/nvfuser_prims.py
@@ -355,7 +355,7 @@ def _full_nvfuser(
     requires_grad: bool = False,
 ):
     assert device != torch.device("cpu")
-    assert layout is None
+    assert layout is None or layout is torch.strided
     assert pin_memory is False
     assert requires_grad is False
     dtype = dtype if dtype is not None else utils.type_to_dtype(type(fill_value))

--- a/torch/_prims/nvfuser_prims.py
+++ b/torch/_prims/nvfuser_prims.py
@@ -454,6 +454,7 @@ def register_full():
         p.impl_nvfuser = _nvfuser_impls["full"]
         p.return_type = torch._prims_common.RETURN_TYPE.NEW  # type: ignore[attr-defined]
 
+
 # functorch.compile.min_cut_rematerialization_partition accepts a list of
 # operators that can be recomputed in the backward pass. This list is used to
 # determine which operators can be recomputed. If an operator is not in this

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -20,6 +20,7 @@ if hasattr(torch._C, "_nvfuser"):
         torch.bfloat16: DataType.BFloat16,
         torch.long: DataType.Int,
         torch.int: DataType.Int32,
+        torch.uint8: DataType.Int32,
         torch.bool: DataType.Bool,
         # Python scalars
         complex: DataType.ComplexDouble,

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4620,8 +4620,9 @@ def full_like(
     requires_grad: bool = False,
     memory_format: torch.memory_format = torch.preserve_format,
 ) -> TensorLikeType:
-    e = torch.empty_like(
-        a,
+    return full(
+        a.shape,
+        fill_value,
         dtype=dtype,
         layout=layout,
         device=device,
@@ -4629,7 +4630,6 @@ def full_like(
         requires_grad=requires_grad,
         memory_format=memory_format,
     )
-    return fill(e, fill_value)
 
 
 zeros_like = partial(full_like, fill_value=False)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4620,9 +4620,8 @@ def full_like(
     requires_grad: bool = False,
     memory_format: torch.memory_format = torch.preserve_format,
 ) -> TensorLikeType:
-    return full(
-        a.shape,
-        fill_value,
+    e = torch.empty_like(
+        a,
         dtype=dtype,
         layout=layout,
         device=device,
@@ -4630,6 +4629,7 @@ def full_like(
         requires_grad=requires_grad,
         memory_format=memory_format,
     )
+    return fill(e, fill_value)
 
 
 zeros_like = partial(full_like, fill_value=False)

--- a/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
@@ -264,6 +264,24 @@ void initNvFuserPythonBindings(PyObject* module) {
           py::arg("is_cpu") = false,
           py::return_value_policy::reference)
       .def(
+          "full",
+          [](nvfuser::FusionDefinition& fd,
+             std::vector<int64_t>& size,
+             nvfuser::Scalar arg,
+             Nvf::DataType dtype) -> nvfuser::Tensor {
+            nvfuser::Tensor output = fd.defineTensor();
+            fd.defineRecord(new nvfuser::FullOpRecord(
+                {fd.recordingState(arg())},
+                {fd.recordingState(output())},
+                size,
+                dtype));
+            return output;
+          },
+          py::arg("size"),
+          py::arg("arg"),
+          py::arg("dtype"),
+          py::return_value_policy::reference)
+      .def(
           "define_constant",
           [](nvfuser::FusionDefinition& self, double val) -> nvfuser::Scalar {
             FUSER_PERF_SCOPE("FusionDefinition.define_constant (double)");

--- a/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
@@ -264,24 +264,6 @@ void initNvFuserPythonBindings(PyObject* module) {
           py::arg("is_cpu") = false,
           py::return_value_policy::reference)
       .def(
-          "full",
-          [](nvfuser::FusionDefinition& fd,
-             std::vector<int64_t>& size,
-             nvfuser::Scalar arg,
-             Nvf::DataType dtype) -> nvfuser::Tensor {
-            nvfuser::Tensor output = fd.defineTensor();
-            fd.defineRecord(new nvfuser::FullOpRecord(
-                {fd.recordingState(arg())},
-                {fd.recordingState(output())},
-                size,
-                dtype));
-            return output;
-          },
-          py::arg("size"),
-          py::arg("arg"),
-          py::arg("dtype"),
-          py::return_value_policy::reference)
-      .def(
           "define_constant",
           [](nvfuser::FusionDefinition& self, double val) -> nvfuser::Scalar {
             FUSER_PERF_SCOPE("FusionDefinition.define_constant (double)");
@@ -1228,7 +1210,6 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::arg("arg"),
       py::arg("dims"),
       py::return_value_policy::reference);
-
   nvf_ops.def(
       "squeeze",
       [](nvfuser::FusionDefinition::Operators& self,
@@ -1268,7 +1249,24 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::arg("original_shape"),
       py::arg("new_shape"),
       py::return_value_policy::reference);
-
+  nvf_ops.def(
+      "full",
+      [](nvfuser::FusionDefinition& fd,
+         std::vector<int64_t>& size,
+         nvfuser::Scalar arg,
+         Nvf::DataType dtype) -> nvfuser::Tensor {
+        nvfuser::Tensor output = fd.defineTensor();
+        fd.defineRecord(new nvfuser::FullOpRecord(
+            {fd.recordingState(arg())},
+            {fd.recordingState(output())},
+            size,
+            dtype));
+        return output;
+      },
+      py::arg("size"),
+      py::arg("arg"),
+      py::arg("dtype"),
+      py::return_value_policy::reference);
   nvf_ops.def(
       "var",
       [](nvfuser::FusionDefinition::Operators& self,

--- a/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
@@ -1251,14 +1251,15 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::return_value_policy::reference);
   nvf_ops.def(
       "full",
-      [](nvfuser::FusionDefinition& fd,
+      [](nvfuser::FusionDefinition::Operators& self,
          std::vector<int64_t>& size,
          nvfuser::Scalar arg,
          Nvf::DataType dtype) -> nvfuser::Tensor {
-        nvfuser::Tensor output = fd.defineTensor();
-        fd.defineRecord(new nvfuser::FullOpRecord(
-            {fd.recordingState(arg())},
-            {fd.recordingState(output())},
+        nvfuser::FusionDefinition* fd = self.fusion_definition;
+        nvfuser::Tensor output = fd->defineTensor();
+        fd->defineRecord(new nvfuser::FullOpRecord(
+            {fd->recordingState(arg())},
+            {fd->recordingState(output())},
             size,
             dtype));
         return output;


### PR DESCRIPTION
- Add `full` nvprim to support factory functions because the full reference uses `empty` and `fill` while we have a full factory function.
- Change `full_like` reference to call `full` to avoid defining another nvprim.
- Enable support for new_zeros to enable `cudnn_batch_norm` decomposition.


cc @ezyang @mruberry @ngimel @Lezcano @fdrocha @peterbell10