### PR TITLE
[xnnpack][executorch] remove unordered_set from xnn_compiler

### DIFF
--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
@@ -4,7 +4,6 @@
 #include <torch/csrc/jit/backends/xnnpack/serialization/schema_generated.h>
 
 #include <ATen/Utils.h>
-#include <unordered_set>
 
 namespace torch {
 namespace jit {
@@ -24,17 +23,8 @@ XNNExecutor XNNCompiler::compileModel(std::string ser_model) {
 
   // create xnnpack subgraph
   xnn_subgraph_t subgraph_ptr = nullptr;
-
-  // TODO: @maxren serialize extern_ids in flatbuffer schema
-  std::unordered_set<uint32_t> extern_ids;
-  for (auto input_id : *flatbuffer_graph->input_ids()) {
-    extern_ids.insert(input_id);
-  }
-  for (auto output_id : *flatbuffer_graph->output_ids()) {
-    extern_ids.insert(output_id);
-  }
   status = xnn_create_subgraph(
-      /*external_value_ids=*/extern_ids.size(),
+      /*external_value_ids=*/flatbuffer_graph->num_externs(),
       /*flags=*/0,
       &subgraph_ptr);
   TORCH_CHECK(xnn_status_success == status, "Failed to create xnn subgraph");

--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h
@@ -3,7 +3,6 @@
 #include <caffe2/torch/csrc/jit/backends/xnnpack/executor/xnn_executor.h>
 #include <xnnpack.h>
 #include <memory>
-#include <string>
 #include <vector>
 
 namespace torch {

--- a/torch/csrc/jit/backends/xnnpack/serialization/schema.fbs
+++ b/torch/csrc/jit/backends/xnnpack/serialization/schema.fbs
@@ -75,6 +75,9 @@ table XNNGraph {
   xnodes:[XNode];
   xvalues:[XValue];
 
+  // Number of external inputs/outputs
+  num_externs:uint;
+
   // Ids of external inputs
   input_ids:[uint];
 

--- a/torch/csrc/jit/backends/xnnpack/serialization/serializer.cpp
+++ b/torch/csrc/jit/backends/xnnpack/serialization/serializer.cpp
@@ -67,12 +67,14 @@ void XNNSerializer::serializeTensorValue(
 
 std::string XNNSerializer::finishAndSerialize(
     std::vector<uint32_t> input_ids,
-    std::vector<uint32_t> output_ids) {
+    std::vector<uint32_t> output_ids,
+    size_t num_extern_ids) {
   auto xnnGraph = CreateXNNGraphDirect(
       _builder,
       _version_sha1,
       &_nodes,
       &_values,
+      num_extern_ids,
       &input_ids,
       &output_ids,
       &_constantBuffer,

--- a/torch/csrc/jit/backends/xnnpack/serialization/serializer.h
+++ b/torch/csrc/jit/backends/xnnpack/serialization/serializer.h
@@ -51,7 +51,8 @@ class XNNSerializer {
   // finish and serialize xnngraph returning serialized data
   std::string finishAndSerialize(
       std::vector<uint32_t> input_ids,
-      std::vector<uint32_t> output_ids);
+      std::vector<uint32_t> output_ids,
+      size_t num_extern_ids);
 
  private:
   // xnnpack version we are serializing

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
@@ -130,16 +130,20 @@ void XNNGraph::checkOpsToDelegate(std::shared_ptr<torch::jit::Graph>& graph) {
 std::string XNNGraph::serializedXNNGraph() {
   std::vector<uint32_t> input_ids;
   std::vector<uint32_t> output_ids;
+  std::unordered_set<uint32_t> num_externs;
 
   for (auto val : _inputs) {
     input_ids.push_back(_val_to_ids[val]);
+    num_externs.emplace(_val_to_ids[val]);
   }
 
   for (auto val : _outputs) {
     output_ids.push_back(_val_to_ids[val]);
+    num_externs.emplace(_val_to_ids[val]);
   }
 
-  return _serializer.finishAndSerialize(input_ids, output_ids);
+  return _serializer.finishAndSerialize(
+      input_ids, output_ids, num_externs.size());
 }
 
 std::vector<std::vector<long>> XNNGraph::getGraphOutputShapes() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89231

Removing unrodered_set from xnncompiler for executorch.

While some STL libraries are unavoidable, and I think it should be ok for delegate to pull these libraries, unordered_set wasn't really needed, and we should be serializing the number of external ids anyways

After this, the backend classes should be good to hg copy into executorch

Differential Revision: [D41227391](https://our.internmc.facebook.com/intern/diff/D41227391/)