### PR TITLE
[Profiler] Don't raise SOFT_ASSERT in debug builds.

### DIFF
--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -94,13 +94,7 @@ void setSoftAssertRaises(c10::optional<bool> value) {
 }
 
 bool softAssertRaises() {
-  return soft_assert_raises_.value_or(
-#ifdef NDEBUG
-      false
-#else
-      true
-#endif
-  );
+  return soft_assert_raises_.value_or(false);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89240

Enough people are hitting this issue that we need to turn off hard failures until the fire rate is zero in steady state. (via scuba logging.)

Differential Revision: [D41382914](https://our.internmc.facebook.com/intern/diff/D41382914/)