### PR TITLE
Export c10/[macros|util] headers to be used by internal inductor builds

### DIFF
--- a/c10/macros/build.bzl
+++ b/c10/macros/build.bzl
@@ -29,3 +29,12 @@ def define_targets(rules):
             "//conditions:default": [],
         }),
     )
+    rules.filegroup(
+        name = "headers",
+        srcs = rules.glob(
+            ["*.h"],
+            exclude = [
+            ],
+        ),
+        visibility = ["//:__pkg__"],
+    )

--- a/c10/util/build.bzl
+++ b/c10/util/build.bzl
@@ -68,5 +68,5 @@ def define_targets(rules):
             exclude = [
             ],
         ),
-        visibility = ["//c10:__pkg__"],
+        visibility = ["//c10:__pkg__", "//:__pkg__"],
     )


### PR DESCRIPTION
Summary: Fixes package boundary violation that existed in previous implementation

Test Plan: CI

Differential Revision: D41391862

