### PR TITLE
[ao] maintain BC for is_activation_post_process

### DIFF
--- a/torch/ao/quantization/quantize.py
+++ b/torch/ao/quantization/quantize.py
@@ -27,8 +27,12 @@ from torch.ao.quantization.qconfig import (
     float_qparams_weight_only_qconfig_4bit,
     _activation_is_memoryless)
 from torch.nn.utils.parametrize import type_before_parametrizations
-from torch.ao.quantization.observer import _is_activation_post_process
 
+from torch.ao.quantization.observer import (  # noqa: F401
+    _is_activation_post_process,
+    _is_activation_post_process as is_activation_post_process,
+    # TODO remove this once problems from name change are resolved
+)
 __all__ = [
     "get_default_custom_config_dict",
     "propagate_qconfig_",


### PR DESCRIPTION
Summary:
tests https://www.internalfb.com/mlhub/pipelines/runs/fblearner/388380008 and
and https://www.internalfb.com/tasks?t=135543814 are failing due to code packaged with trained models calling now defunct function names (is_activation_post_process).

this diff maintains BC temporarily until the cached code can be refreshed

#cogwheel cogwheel_trainer_gmpp_ig_test

Test Plan: buck2 run //aiplatform/modelstore/model_generation/flow/tests:cogwheel_trainer_gmpp_ig_test-launcher -- --build-fbpkg --run-disabled

Differential Revision: D41394240



cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel