### PR TITLE
[ao] maintain BC for is_activation_post_process

### DIFF
--- a/torch/ao/quantization/quantize.py
+++ b/torch/ao/quantization/quantize.py
@@ -27,7 +27,12 @@ from torch.ao.quantization.qconfig import (
     float_qparams_weight_only_qconfig_4bit,
     _activation_is_memoryless)
 from torch.nn.utils.parametrize import type_before_parametrizations
-from torch.ao.quantization.observer import _is_activation_post_process
+
+from torch.ao.quantization.observer import ( # noqa
+    _is_activation_post_process,
+    _is_activation_post_process as is_activation_post_process,
+    # TODO remove this once problems from name change are resolved
+)
 
 __all__ = [
     "get_default_custom_config_dict",

--- a/torch/ao/quantization/quantize.py
+++ b/torch/ao/quantization/quantize.py
@@ -28,7 +28,7 @@ from torch.ao.quantization.qconfig import (
     _activation_is_memoryless)
 from torch.nn.utils.parametrize import type_before_parametrizations
 
-from torch.ao.quantization.observer import ( # noqa: F401
+from torch.ao.quantization.observer import (  # noqa: F401
     _is_activation_post_process,
     _is_activation_post_process as is_activation_post_process,
     # TODO remove this once problems from name change are resolved

--- a/torch/ao/quantization/quantize.py
+++ b/torch/ao/quantization/quantize.py
@@ -28,7 +28,7 @@ from torch.ao.quantization.qconfig import (
     _activation_is_memoryless)
 from torch.nn.utils.parametrize import type_before_parametrizations
 
-from torch.ao.quantization.observer import ( # noqa
+from torch.ao.quantization.observer import ( # noqa: F401
     _is_activation_post_process,
     _is_activation_post_process as is_activation_post_process,
     # TODO remove this once problems from name change are resolved


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89260

Summary: tests are failing due to code packaged with trained models calling now defunct function names (is_activation_post_process).

this diff maintains BC temporarily until the cached code can be refreshed

Test Plan: no functional change

Reviewers:

Subscribers:

Tasks:

Tags:

cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel