### PR TITLE
[Inductor] Add option to build without OpenMP

### DIFF
--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -3,7 +3,9 @@
 #include <cmath>
 #include <cstdlib>
 #include <limits>
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 #include <ATen/core/PhiloxRNGEngine.h>
 #if defined(CPU_CAPABILITY_AVX512) || defined(CPU_CAPABILITY_AVX2)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -101,6 +101,8 @@ class cpp:
         "g++",
         "g++.par",
     )
+    cxx_flags = "-std=c++14 -Wall -Wno-unused-variable"
+    cxx_opt_flags = "-march=native -O3 -ffast-math -fno-finite-math-only"
 
 
 # config specific to codegen/triton.py


### PR DESCRIPTION
Move compiler standard/optimization flags to `config.cpp` class
Add option to disable OpenMP integration if `config.cpp.threads` is set to 1

Guard `#include <omp.h>` with `#ifdef _OPENMP`, which according to [OpenMP Spec](https://www.openmp.org/spec-html/5.0/openmpse10.html) should be defined if compiler supports OpenMP pragmas

This unblocks testing Inductor on M1 machines by making following tweaks to config:
```
import torch._inductor.config as config
config.cpp.threads=1
config.cpp.cxx_opt_flags = config.cpp.cxx_opt_flags.replace("-march=native","")
config.cpp.cxx=("clang++")
```

On MacOS, compiler does not support `-fopenmp` by default

Fixes #ISSUE_NUMBER


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire