### PR TITLE
Use standard __func__ macro in symbolic shape.

### DIFF
--- a/torch/csrc/utils/python_symnode.h
+++ b/torch/csrc/utils/python_symnode.h
@@ -94,78 +94,78 @@ class PythonSymNodeImpl : public c10::SymNodeImpl {
   }
 
   c10::SymNode add(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode sub(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode mul(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode truediv(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode pow(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode floordiv(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode mod(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode eq(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode gt(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode lt(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode le(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode ge(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode min(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
   c10::SymNode max(const c10::SymNode& other) override {
-    return dispatch_common_(__FUNCTION__, other);
+    return dispatch_common_(__func__, other);
   }
 
   c10::SymNode ceil() override {
-    return dispatch_common_(__FUNCTION__);
+    return dispatch_common_(__func__);
   }
 
   c10::SymNode floor() override {
-    return dispatch_common_(__FUNCTION__);
+    return dispatch_common_(__func__);
   }
 
   c10::SymNode neg() override {
-    return dispatch_common_(__FUNCTION__);
+    return dispatch_common_(__func__);
   }
 
   c10::SymNode clone() override {
-    return dispatch_common_(__FUNCTION__);
+    return dispatch_common_(__func__);
   }
 
   c10::SymNode sym_float() override {
-    return dispatch_common_(__FUNCTION__);
+    return dispatch_common_(__func__);
   }
 
   py::handle getPyObj() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89264

Summary:
I saw the following issue only on Windows build in PR #88767:
```
RuntimeError: AttributeError: 'SymNode' object has no attribute 'torch::impl::PythonSymNodeImpl::ge'
```
It's only on Windows because we get the attributes of SymNode in C++ with
`__FUNCTION__` macro, which is not in C++ standard, therefore has platform specific behavior.
In this case, MSVC will include a function's namespace and class name, which is not intended here.

Instead we should use `__func__`. see: https://en.cppreference.com/w/cpp/language/function#Function_definition

godbolt example to show the difference: https://godbolt.org/z/PGfvecxPx

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags: