### PR TITLE
[Inductor CI] Use string format for cuda-arch-list input to prevent 8.0/9.0/10.0 etc from being interpreted as 8/9/10

### DIFF
--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       build-environment: linux-bionic-cuda11.6-py3.10-gcc7-sm86
       docker-image-name: pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7
-      cuda-arch-list: 8.6
+      cuda-arch-list: '8.6'
       test-matrix: |
         { include: [
           { config: "inductor", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },


### PR DESCRIPTION
Currently or in future whenever we change the cuda-arch-list to num.0, github action or some agent would pass just num to TORCH_CUDA_ARCH_LIST

This num is not regex matched during cuda arch analysis phase. (here: https://github.com/pytorch/pytorch/blob/c5fafb4e1694f141d8a1a31142cce4049d9057ed/cmake/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake#L229)
Example failure: https://github.com/weiwangmeta/pytorch/actions/runs/3495656108/jobs/5852735299
  Unknown CUDA Architecture Name 8 in CUDA_SELECT_NVCC_ARCH_FLAGS
This change reminds us to use e.g. '8.0', '9.0', '10.0' etc instead of 8.0, 9.0, 10.0 as GHA or some other agent may erroneously truncate it to pure numbers. 