### PR TITLE
Stft add named windows

### DIFF
--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: fft"]
 
-from curses import window
 import torch
 import unittest
 import math
@@ -27,7 +26,6 @@ from typing import Optional, List
 
 if TEST_NUMPY:
     import numpy as np
-
 
 if TEST_LIBROSA:
     import librosa

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -637,8 +637,8 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
     if window is None:
         warnings.warn(
             "'window' was not specified, so a rectangular window will be applied."
-            "in version 1.15.0, not specifying a window will raise an error."
-            "Consider using an alternative available window, such as 'hann'.",
+            " In version 1.15.0, not specifying a window will raise an error."
+            " Consider using an alternative available window, such as 'hann'.",
             DeprecationWarning
         )
 
@@ -653,7 +653,7 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
         if window not in windows.keys():
             raise ValueError(
                 f"{window} is not a valid window name."
-                f"Available windows are {windows.keys()}")
+                f" Available windows are {windows.keys()}")
         else:
             win_length = n_fft if win_length is None else win_length
             window = windows[window](win_length, device=input.device)


### PR DESCRIPTION
Fixes #88919

As discussed in issue #88919, here is the pull request that adds the option to use a named window for the STFT. This PR

* adds the functionality directly to the Python code on the `functional.py` module. the `bartlett`, `blackman`, `hamming`, `hann`, and `kaiser` windows are supported.
* modifies the documentation to describe this new option and to mention that not specifying a window with throw an error in version 1.15.0 (is this the correct version?).
* adds a warning if a window is not specified
* adds a unit test in `test/test_spectral_ops.py`. The test verifies that using a window string produces the same result as providing a precomputed Tensor window of the same type.

I did my best to follow the contribution guidelines, but as this is my first PR, thank you for pointing out any mistakes I might have made.

@mruberry, should I create these two new issues:
* the first to be solved before 1.15.0, which throws an error if the window is not specified
* the second to be solved before 1.16.0, which changes the default window to `hann`

Best wishes,

Eric

@mruberry @peterbell10