### PR TITLE
[inductor] Temporarily disable functorch_dp_cifar10 test in TorchBench

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -111,6 +111,7 @@ CI_SKIP_INDUCTOR_TRAINING = [
     # *CI_SKIP_INDCUTOR_INFERENCE,
     # TorchBench
     "detectron2",
+    "functorch_dp_cifar10",
     "mobilenet_v3_large",
     "moco",
     "tacotron2",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89281

Summary: The failure wasn't caught because of a land race. Skip the test
for now.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx