### PR TITLE
Remove --retry-all-errors from environment with old curl

### DIFF
--- a/scripts/buck_setup.sh
+++ b/scripts/buck_setup.sh
@@ -22,16 +22,16 @@ python3 generate-xnnpack-wrappers.py
 # bazel-skylib
 printf "\nDownloading bazel-skylib\n"
 rm -rf bazel-skylib; mkdir bazel-skylib
-curl --retry 3 --retry-all-errors -L $PROXY https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz|tar zx -C bazel-skylib
+curl --retry 3 -L $PROXY https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz|tar zx -C bazel-skylib
 
 # glog
 printf "\nDownloading glog\n"
 rm -rf glog; mkdir glog
-curl --retry 3 --retry-all-errors -L $PROXY https://github.com/google/glog/archive/v0.4.0.tar.gz | tar zx -C glog --strip-components 1
+curl --retry 3 -L $PROXY https://github.com/google/glog/archive/v0.4.0.tar.gz | tar zx -C glog --strip-components 1
 
 # ruy
 printf "\nDownloading ruy\n"
-curl --retry 3 --retry-all-errors -L $PROXY -o /tmp/ruy.zip https://github.com/google/ruy/archive/a09683b8da7164b9c5704f88aef2dc65aa583e5d.zip
+curl --retry 3 -L $PROXY -o /tmp/ruy.zip https://github.com/google/ruy/archive/a09683b8da7164b9c5704f88aef2dc65aa583e5d.zip
 unzip -q /tmp/ruy.zip -d /tmp/
 rm -rf ruy/
 mv /tmp/ruy-a09683b8da7164b9c5704f88aef2dc65aa583e5d ruy/


### PR DESCRIPTION
The version of curl on the `ubuntu-latest` box doesn't support the `--retry-all-errors` param and is breaking periodic builds

Example: https://github.com/pytorch/pytorch/actions/runs/3495466804/jobs/5852265880