### PR TITLE
Add dynamo smoke tests to CI

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -215,7 +215,7 @@ test_dynamo_shard() {
     echo "NUM_TEST_SHARDS must be defined to run a Python test shard"
     exit 1
   fi
-  python tools/dynamo/smoke_test.py
+  python tools/dynamo/verify_dynamo.py
   # Temporarily disable test_fx for dynamo pending the investigation on TTS
   # regression in https://github.com/pytorch/torchdynamo/issues/784
   time python test/run_test.py \

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -215,6 +215,7 @@ test_dynamo_shard() {
     echo "NUM_TEST_SHARDS must be defined to run a Python test shard"
     exit 1
   fi
+  python tools/dynamo/smoke_test.py
   # Temporarily disable test_fx for dynamo pending the investigation on TTS
   # regression in https://github.com/pytorch/torchdynamo/issues/784
   time python test/run_test.py \

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -199,14 +199,12 @@ test_python_shard() {
     exit 1
   fi
 
-  python tools/dynamo/verify_dynamo.py --ci
   time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --shard "$1" "$NUM_TEST_SHARDS" --verbose
 
   assert_git_not_dirty
 }
 
 test_python() {
-  python tools/dynamo/verify_dynamo.py --ci
   time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --verbose
   assert_git_not_dirty
 }
@@ -217,7 +215,7 @@ test_dynamo_shard() {
     echo "NUM_TEST_SHARDS must be defined to run a Python test shard"
     exit 1
   fi
-  python tools/dynamo/verify_dynamo.py --ci
+  python tools/dynamo/verify_dynamo.py
   # Temporarily disable test_fx for dynamo pending the investigation on TTS
   # regression in https://github.com/pytorch/torchdynamo/issues/784
   time python test/run_test.py \
@@ -252,7 +250,7 @@ test_inductor_distributed() {
 }
 
 test_inductor() {
-  python tools/dynamo/verify_dynamo.py --ci
+  python tools/dynamo/verify_dynamo.py
   python test/run_test.py --include test_modules test_ops --verbose
   PYTORCH_TEST_WITH_INDUCTOR=0 python test/run_test.py --include inductor/test_torchinductor --include inductor/test_torchinductor_opinfo --verbose
   # TODO: investigate "RuntimeError: CUDA driver API confirmed a leak"

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -199,12 +199,14 @@ test_python_shard() {
     exit 1
   fi
 
+  python tools/dynamo/verify_dynamo.py
   time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --shard "$1" "$NUM_TEST_SHARDS" --verbose
 
   assert_git_not_dirty
 }
 
 test_python() {
+  python tools/dynamo/verify_dynamo.py
   time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --verbose
   assert_git_not_dirty
 }
@@ -250,6 +252,7 @@ test_inductor_distributed() {
 }
 
 test_inductor() {
+  python tools/dynamo/verify_dynamo.py
   python test/run_test.py --include test_modules test_ops --verbose
   PYTORCH_TEST_WITH_INDUCTOR=0 python test/run_test.py --include inductor/test_torchinductor --include inductor/test_torchinductor_opinfo --verbose
   # TODO: investigate "RuntimeError: CUDA driver API confirmed a leak"

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -199,14 +199,14 @@ test_python_shard() {
     exit 1
   fi
 
-  python tools/dynamo/verify_dynamo.py
+  python tools/dynamo/verify_dynamo.py --ci
   time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --shard "$1" "$NUM_TEST_SHARDS" --verbose
 
   assert_git_not_dirty
 }
 
 test_python() {
-  python tools/dynamo/verify_dynamo.py
+  python tools/dynamo/verify_dynamo.py --ci
   time python test/run_test.py --exclude-jit-executor --exclude-distributed-tests --verbose
   assert_git_not_dirty
 }
@@ -217,7 +217,7 @@ test_dynamo_shard() {
     echo "NUM_TEST_SHARDS must be defined to run a Python test shard"
     exit 1
   fi
-  python tools/dynamo/verify_dynamo.py
+  python tools/dynamo/verify_dynamo.py --ci
   # Temporarily disable test_fx for dynamo pending the investigation on TTS
   # regression in https://github.com/pytorch/torchdynamo/issues/784
   time python test/run_test.py \
@@ -252,7 +252,7 @@ test_inductor_distributed() {
 }
 
 test_inductor() {
-  python tools/dynamo/verify_dynamo.py
+  python tools/dynamo/verify_dynamo.py --ci
   python test/run_test.py --include test_modules test_ops --verbose
   PYTORCH_TEST_WITH_INDUCTOR=0 python test/run_test.py --include inductor/test_torchinductor --include inductor/test_torchinductor_opinfo --verbose
   # TODO: investigate "RuntimeError: CUDA driver API confirmed a leak"

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -94,6 +94,17 @@ def check_dynamo(backend, device, err_msg):
     try:
         import torch._dynamo as dynamo
 
+        if device == "cuda":
+            import torch._inductor.utils as utils
+
+            if not utils.has_triton():
+                print(
+                    f"WARNING: CUDA available but triton cannot be used. "
+                    f"Your GPU may not be supported. "
+                    f"Skipping CUDA check on {backend} backend\n"
+                )
+                return
+
         dynamo.reset()
 
         @dynamo.optimize(backend, nopython=True)
@@ -154,3 +165,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    sys.exit(1)

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 import re
 import subprocess
@@ -150,25 +149,19 @@ _SANITY_CHECK_ARGS = (
 )
 
 
-def main(ci):
-    if not ci:
-        python_ver = check_python()
-        torch_ver = check_torch()
-        cuda_ver = check_cuda()
-        print(
-            f"Python version: {python_ver.major}.{python_ver.minor}.{python_ver.micro}\n"
-            f"`torch` version: {torch_ver}\n"
-            f"CUDA version: {cuda_ver}\n"
-        )
+def main():
+    python_ver = check_python()
+    torch_ver = check_torch()
+    cuda_ver = check_cuda()
+    print(
+        f"Python version: {python_ver.major}.{python_ver.minor}.{python_ver.micro}\n"
+        f"`torch` version: {torch_ver}\n"
+        f"CUDA version: {cuda_ver}\n"
+    )
     for args in _SANITY_CHECK_ARGS:
         check_dynamo(*args)
     print("All required checks passed")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Smoke test for TorchDynamo/TorchInductor"
-    )
-    parser.add_argument("--ci", action="store_true", default=False)
-    args = parser.parse_args()
-    main(args.ci)
+    main()

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -58,7 +58,7 @@ def check_cuda():
     if not torch.cuda.is_available():
         return None
 
-    torch_cuda_ver = packaging.version.parse(str(torch.version.cuda))
+    torch_cuda_ver = packaging.version.parse(torch.version.cuda)
 
     # check if torch cuda version matches system cuda version
     cuda_ver = get_cuda_version()

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import re
 import subprocess
@@ -149,19 +150,25 @@ _SANITY_CHECK_ARGS = (
 )
 
 
-def main():
-    python_ver = check_python()
-    torch_ver = check_torch()
-    cuda_ver = check_cuda()
-    print(
-        f"Python version: {python_ver.major}.{python_ver.minor}.{python_ver.micro}\n"
-        f"`torch` version: {torch_ver}\n"
-        f"CUDA version: {cuda_ver}\n"
-    )
+def main(ci):
+    if not ci:
+        python_ver = check_python()
+        torch_ver = check_torch()
+        cuda_ver = check_cuda()
+        print(
+            f"Python version: {python_ver.major}.{python_ver.minor}.{python_ver.micro}\n"
+            f"`torch` version: {torch_ver}\n"
+            f"CUDA version: {cuda_ver}\n"
+        )
     for args in _SANITY_CHECK_ARGS:
         check_dynamo(*args)
     print("All required checks passed")
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        description="Smoke test for TorchDynamo/TorchInductor"
+    )
+    parser.add_argument("--ci", action="store_true", default=False)
+    args = parser.parse_args()
+    main(args.ci)

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -165,4 +165,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    sys.exit(1)

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -58,7 +58,7 @@ def check_cuda():
     if not torch.cuda.is_available():
         return None
 
-    torch_cuda_ver = packaging.version.parse(torch.version.cuda)
+    torch_cuda_ver = packaging.version.parse(str(torch.version.cuda))
 
     # check if torch cuda version matches system cuda version
     cuda_ver = get_cuda_version()


### PR DESCRIPTION
Add dynamo smoke tests to CI, which checks for python/torch/cuda versions and runs simple dynamo examples on a few backends, including inductor. Smoke tests will run on dynamo and inductor shards.