### PR TITLE
Don't redefine __STDC_FORMAT_MACROS

### DIFF
--- a/torch/csrc/cuda/Tensor.cpp
+++ b/torch/csrc/cuda/Tensor.cpp
@@ -1,4 +1,6 @@
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 
 // Order of these includes matters, which should be fixed.
 // clang-format off


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/39608 and https://github.com/pytorch/pytorch/pull/6676

This causes a compile error in our internal build.
