### PR TITLE
Run MPS PR tests on both Ventura and Monterey

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -16,6 +16,7 @@ self-hosted-runner:
     - bm-runner
     - linux.rocm.gpu
     - macos-m1-12
+    - macos-m1-13
     - macos-12-xl
     - macos-12
     - macos12.3-m1

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -14,11 +14,16 @@ on:
         description: |
           If this is set, our linter will use this to make sure that every other
           job with the same `sync-tag` is identical.
+      runs-on:
+        required: false
+        type: string
+        default: "macos-m1-12"
+        description: Hardware to run tests on
 
 jobs:
   run_mps_test:
     name: "Run MPS tests"
-    runs-on: macos-m1-12
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout PyTorch
         uses: malfet/checkout@silent-checkout

--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -37,3 +37,11 @@ jobs:
     with:
       sync-tag: macos-12-py3-arm64-mps-test
       build-environment: macos-12-py3-arm64
+
+  macos-13-py3-arm64-mps-test:
+    name: macos-13-py3-arm64-mps
+    uses: ./.github/workflows/_mac-test-mps.yml
+    needs: macos-12-py3-arm64-build
+    with:
+      build-environment: macos-12-py3-arm64
+      runs-on: macos-m1-13


### PR DESCRIPTION
Add `runs-on` input parameter to _mac-test-mps.yml and run `ciflow/mps` on both Monterey and Ventura machines