### PR TITLE
End-to-end BERT_pytorch working with dynamic shapes and inductor

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -61,12 +61,12 @@ constant_functions = {
 # don't specialize on shapes and strides and put shape ops in graph
 dynamic_shapes = os.environ.get("TORCHDYNAMO_DYNAMIC_SHAPES") == "1"
 # DO NOT LAND THIS TO MASTER - THIS IS UNDER DEVELOPMENT
-# 
+#
 # We have internal tensors created today (ex, .grad) that are not tracked by dynamo.
-# This means we make symbolics for them, that dynamo does not know about. When we surface these 
+# This means we make symbolics for them, that dynamo does not know about. When we surface these
 # for guard creation, today, dynamo asserts (correctly) so as not to throw out guards as it does not
 # have enough info to make sane guards.
-# 
+#
 # The plan of record is as follows, for now:
 #
 # 1) Make dynamo trace everything it needs to (grad? _base?)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -305,13 +305,21 @@ class WrapperBackend:
     def example_inputs(self):
         return clone_inputs(self.original_example_inputs)
 
-    def __call__(self, gm: torch.fx.GraphModule, example_inputs):
-
+    def __call__(self, gm: torch.fx.GraphModule, example_inputs, fake_mode):
         self.restore = checkpoint_params(gm)
         self.original_example_inputs = clone_inputs(example_inputs)
         self.gm = gm
         copy_gm = copy.deepcopy(self.gm)
-        self.candidate = self.backend(copy_gm, self.original_example_inputs)
+        needs_fake_tensor = False
+        # This is temporary, hopefully, while we decide if we want the
+        # user provided compiler signature to have a **kwargs
+        if fake_mode and "fake_mode" in signature(self.backend).parameters.keys():
+            needs_fake_tensor = True
+            self.candidate = self.backend(
+                copy_gm, self.original_example_inputs, fake_mode
+            )
+        else:
+            self.candidate = self.backend(copy_gm, self.original_example_inputs)
 
         if self.candidate is None or self.candidate is self.gm.forward:
             return self.gm.forward
@@ -322,7 +330,12 @@ class WrapperBackend:
         # if verify_correctness=True
         try:
             correct = self.gm.forward(*self.example_inputs)
-            result = self.candidate(*self.example_inputs)
+            # This is temporary, hopefully, while we decide if we want the
+            # user provided compiler signature to have a **kwargs
+            if needs_fake_tensor:
+                result = self.candidate(*self.example_inputs, fake_tensor=fake_tensor)
+            else:
+                result = self.candidate(*self.example_inputs)
 
             # TODO: replace `same` function with the one in testing
             if same(correct, result):
@@ -548,7 +561,7 @@ def export(
         out_guards = guards
 
     def dynamo_normalization_capturing_compiler(
-        gm: torch.fx.GraphModule, example_inputs
+        gm: torch.fx.GraphModule, example_inputs, fake_mode
     ):
         nonlocal graph
 
@@ -730,6 +743,7 @@ class TorchPatcher:
             opt._cuda_graph_capture_health_check = disable(
                 opt._cuda_graph_capture_health_check
             )
+            opt.zero_grad = disable(opt.zero_grad)
             # disable any currently set hooks
             # Note: we only want to disable the profiling hook
             # which is the *last* hook applied, we want to keep the no_grad hook

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -461,10 +461,10 @@ class GuardBuilder:
         # STOP - DO NOT USE id_ref FOR TENSORS - TENSOR INVALIDATION RULES DIFFER
         self.tensor_check_ids[tensor_name] = id(value)
         if value._base is not None:
-            assert id(value._base) in self.guarded_code.output_graph.tensor_id_to_sym_shape_ref
-            refs = self.guarded_code.output_graph.tensor_id_to_sym_shape_ref[id(value._base)]
-            for ref in refs:
-                self.guarded_code.output_graph.base_symbols.update({ref.expr: f"{tensor_name}._base"})
+            if id(value._base) in self.guarded_code.output_graph.tensor_id_to_sym_shape_ref:
+                refs = self.guarded_code.output_graph.tensor_id_to_sym_shape_ref[id(value._base)]
+                for ref in refs:
+                    self.guarded_code.output_graph.base_symbols.update({ref.expr: f"{tensor_name}._base"})
 
         # Note: Guard code produced for tensor_match is a little different.
         # We accumulate tensor names, then do a single install of `___check_tensors`.

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -461,10 +461,17 @@ class GuardBuilder:
         # STOP - DO NOT USE id_ref FOR TENSORS - TENSOR INVALIDATION RULES DIFFER
         self.tensor_check_ids[tensor_name] = id(value)
         if value._base is not None:
-            if id(value._base) in self.guarded_code.output_graph.tensor_id_to_sym_shape_ref:
-                refs = self.guarded_code.output_graph.tensor_id_to_sym_shape_ref[id(value._base)]
+            if (
+                id(value._base)
+                in self.guarded_code.output_graph.tensor_id_to_sym_shape_ref
+            ):
+                refs = self.guarded_code.output_graph.tensor_id_to_sym_shape_ref[
+                    id(value._base)
+                ]
                 for ref in refs:
-                    self.guarded_code.output_graph.base_symbols.update({ref.expr: f"{tensor_name}._base"})
+                    self.guarded_code.output_graph.base_symbols.update(
+                        {ref.expr: f"{tensor_name}._base"}
+                    )
 
         # Note: Guard code produced for tensor_match is a little different.
         # We accumulate tensor names, then do a single install of `___check_tensors`.
@@ -541,7 +548,6 @@ class TensorReference(object):
     # Note - this is untyped because of TypeError: '_SpecialForm' object does not support item assignment
     # But it is a Optional[Union["sympy.Expr", int]]
     expr: Optional[object] = None  # Populated after association
-    
 
     def __hash__(self):
         return hash((self.ref_id, self.kind, self.idx))
@@ -555,7 +561,12 @@ class DynamoGuardPrinter(StrPrinter):
         return f"{id_to_name_map[tensor_ref.ref_id]}.{tensor_ref.kind}()"
 
     def __init__(
-        self, expr_to_tensor_ref, id_to_name_map, shape_env, intermediary_symbols, base_symbols
+        self,
+        expr_to_tensor_ref,
+        id_to_name_map,
+        shape_env,
+        intermediary_symbols,
+        base_symbols,
     ):
         super().__init__()
         self.expr_to_tensor_ref = expr_to_tensor_ref
@@ -678,7 +689,7 @@ class CheckFunctionManager:
             id_to_name_map,
             self.output_graph.shape_env,
             self.output_graph.intermediary_symbols,
-            self.output_graph.base_symbols
+            self.output_graph.base_symbols,
         )
 
         # tensor_check_names is the primary tensor association mechanism in dynamo.

--- a/torch/_dynamo/optimizations/analysis.py
+++ b/torch/_dynamo/optimizations/analysis.py
@@ -8,6 +8,7 @@ from torch.fx.node import map_aggregate
 from torch.fx.passes.shape_prop import _extract_tensor_metadata, ShapeProp
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.utils._pytree import tree_map
+from torch._dispatch.python import enable_python_dispatcher
 
 from .. import config
 from ..utils import clone_inputs, fake_tensors_available
@@ -46,6 +47,7 @@ class ShapeAliasingAndMutationProp(ShapeProp):
 
         input_versions1 = [obj._version for obj in tensor_args]
         result = getattr(self, n.op)(n.target, args, kwargs)
+        assert result is not NotImplemented
         input_versions2 = [obj._version for obj in tensor_args]
 
         n.meta["type"] = type(result)
@@ -116,36 +118,20 @@ class ShapeAliasingAndMutationProp(ShapeProp):
             self.env.clear()
 
 
-def has_mutation(gm, example_inputs, inputs_only=False):
+def has_mutation(gm, example_inputs, fake_mode, inputs_only=False):
     """Check if the graph module has any form of mutation.  If inputs_only is
     true, we only check for mutation of inputs"""
     # TODO - moco gives bad accuracy with Aliasing. gm is getting mutated in a bad way.
-
     if fake_tensors_available and config.fake_tensor_propagation:
-
-        def _wrap_to_fake_tensor(t, *, f_mode):
-            if type(t) in (torch.Tensor, torch.nn.Parameter):
-                static_shapes_ = config.dynamic_shapes is False
-                return fake_mode.from_tensor(
-                    t, static_shapes=config.dynamic_shapes is not False
-                )
-            else:
-                return t
-
+        assert fake_mode, "Fake mode must be passed in"
         # Our analysis pass should use dynamic shape tensor inputs
         # when dynamic shapes are enabled.
         # We don't actually care about the guards that are created
-        # on those shapes though, so just create a fresh ShapeEnv here.
-        from torch.fx.experimental.symbolic_shapes import ShapeEnv
-
-        fake_mode = FakeTensorMode(
-            shape_env=ShapeEnv() if config.dynamic_shapes else None
-        )
-        fake_wrapper = functools.partial(_wrap_to_fake_tensor, f_mode=fake_mode)
-        example_inputs = tree_map(fake_wrapper, example_inputs)
-        new_gm = deepcopy_to_fake_tensor(gm, fake_mode)
-        with fake_mode.restore() if hasattr(fake_mode, "restore") else fake_mode:
-            ShapeAliasingAndMutationProp(new_gm).run(*example_inputs)
+        # on those shapes though, so just suppress_guards here.
+        with fake_mode.shape_env.suppress_guards():
+            new_gm = deepcopy_to_fake_tensor(gm, fake_mode)
+            with fake_mode, enable_python_dispatcher():
+                ShapeAliasingAndMutationProp(new_gm).run(*example_inputs)
     else:
         # Clone the inputs such that intermediate tensors (not leaf tensors) with
         # requires_grad to True are now converted to False to avoid Runtime Error
@@ -155,11 +141,16 @@ def has_mutation(gm, example_inputs, inputs_only=False):
         example_inputs = copy.deepcopy(example_inputs)
         ShapeAliasingAndMutationProp(new_gm).run(*example_inputs)
 
+    inp_nodes = [n for n in new_gm.graph.nodes if n.op == 'placeholder']
     for node in new_gm.graph.nodes:
         if node.meta["is_mutation"] or node.meta["is_input_mutation"]:
             if inputs_only:
                 if node.meta["is_input_alias"]:
-                    return True
+                    # Get the list of inputs that alias with the current node.
+                    inps_that_alias_node = [n for n in inp_nodes if n.meta['alias_groups'] & node.meta['alias_groups']]
+                    if len(inps_that_alias_node) > 1:
+                        import pdb; pdb.set_trace()
+                        return True
             else:
                 return True
     return False

--- a/torch/_dynamo/optimizations/backends.py
+++ b/torch/_dynamo/optimizations/backends.py
@@ -62,7 +62,7 @@ def create_backend(fn):
 
 
 @create_backend
-def eager(subgraph):
+def eager(subgraph, **kwargs):
     return subgraph.model
 
 
@@ -555,13 +555,12 @@ def aot_autograd(subgraph, **kwargs):
         return disable(disable(bw_compiler)(*args, **kwargs))
 
     bw_compiler = kwargs.get("bw_compiler") or kwargs["fw_compiler"]
-    kwargs["bw_compiler"] = _wrapped_bw_compiler
 
     from functorch.compile import aot_module_simplified
 
     from .. import disable
 
-    return aot_module_simplified(subgraph.model, **kwargs)
+    return aot_module_simplified(subgraph.model, subgraph.example_inputs, **kwargs)
 
 
 def tvm_compile(jit_mod, example_inputs, log_file=None, **kwargs):

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -6,6 +6,7 @@ import operator
 import re
 import traceback
 from dataclasses import dataclass
+from inspect import signature
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch.nn
@@ -109,6 +110,7 @@ class OutputGraph(fx.Tracer):
         self.shape_env = ShapeEnv() if config.dynamic_shapes else None
         self.tensor_id_to_sym_shape_ref = {}
         self.intermediary_symbols = {}
+        self.base_symbols = {}
 
         # Enables creating unique node names by tracking
         # all current placeholder node names
@@ -352,6 +354,7 @@ class OutputGraph(fx.Tracer):
             and all(isinstance(x, TensorVariable) for x in stack_values)
             and len(set(stack_values)) == len(stack_values)
             and self.side_effects.is_empty()
+            and False
         ):
 
             # optimization to generate better code in a common case
@@ -427,6 +430,7 @@ class OutputGraph(fx.Tracer):
         name = unique_id("__compiled_fn")
 
         compiled_fn = self.call_user_compiler(gm)
+
         compiled_fn = disable(compiled_fn)
 
         counters["stats"]["unique_graphs"] += 1
@@ -458,7 +462,12 @@ class OutputGraph(fx.Tracer):
                 else ""
             )
             _step_logger()(logging.INFO, f"calling compiler function {name}")
-            compiled_fn = self.compiler_fn(gm, self.example_inputs())
+            if "fake_mode" in signature(self.compiler_fn).parameters.keys():
+                compiled_fn = self.compiler_fn(
+                    gm, self.example_inputs(), fake_mode=self.fake_mode
+                )
+            else:
+                compiled_fn = self.compiler_fn(gm, self.example_inputs())
             _step_logger()(logging.INFO, f"done compiler function {name}")
             assert callable(compiled_fn), "compiler_fn did not return callable"
         except Exception as e:
@@ -469,7 +478,16 @@ class OutputGraph(fx.Tracer):
     def example_inputs(self):
         result = []
         for arg in self.graphargs:
-            result.extend(arg.get_examples())
+            if config.fake_tensor_propagation:
+                example = arg.get_fake_examples()
+                if example:
+                    result.extend(example)
+                else:
+                    # Fallback, in case fake_tensor was not set
+                    # Particularly for graph args that are not tensors
+                    result.extend(arg.get_examples())
+            else:
+                result.extend(arg.get_examples())
         return result
 
     def remove_unused_graphargs(self):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -689,38 +689,46 @@ try:
         UnsupportedFakeTensorException,
     )
 
-    def make_fake_tensor(e, fake_mode, static_shapes=False, tx=None):
-        fake_tensor = fake_mode.from_tensor(e, static_shapes=static_shapes)
+    def make_fake_tensor(src_tensor, fake_mode, static_shapes=False, tx=None):
+        fake_tensor = fake_mode.from_tensor(src_tensor, static_shapes=static_shapes)
         if tx is not None:
             from torch._dynamo.guards import TensorReference
 
-            def _record(tensor_ref):
-                if tensor_ref.ref_id not in tx.output.tensor_id_to_sym_shape_ref:
-                    tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id] = set()
-                tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id].add(tensor_ref)
+            def _record_fake_tensor(src_tensor, fake_tensor):
+                def _record(tensor_ref):
+                    if tensor_ref.ref_id not in tx.output.tensor_id_to_sym_shape_ref:
+                        tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id] = set()
+                    tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id].add(tensor_ref)
 
-            def _extract(symbol):
-                if isinstance(symbol, int):
-                    return None
-                sym_expr = symbol.get_pyobj().expr
-                if not isinstance(sym_expr, sympy.Symbol):
-                    return None
-                return sym_expr
+                def _extract(symbol):
+                    if isinstance(symbol, int):
+                        return None
+                    sym_expr = symbol.get_pyobj().expr
+                    if not isinstance(sym_expr, sympy.Symbol):
+                        return None
+                    return sym_expr
 
-            def _record_ref(e, index, symbol, kind):
-                sym_expr = _extract(symbol)
-                if sym_expr:
-                    tensor_ref = TensorReference(id(e), kind, index, sym_expr)
-                    _record(tensor_ref)
+                def _record_ref(src_tensor, index, symbol, kind):
+                    sym_expr = _extract(symbol)
+                    if sym_expr:
+                        tensor_ref = TensorReference(id(src_tensor), kind, index, sym_expr)
+                        _record(tensor_ref)
 
-            for index, symbol in enumerate(fake_tensor.size()):
-                _record_ref(e, index, symbol, "size")
+                for index, symbol in enumerate(fake_tensor.size()):
+                    _record_ref(src_tensor, index, symbol, "size")
 
-            for index, symbol in enumerate(fake_tensor.stride()):
-                _record_ref(e, index, symbol, "stride")
+                for index, symbol in enumerate(fake_tensor.stride()):
+                    _record_ref(src_tensor, index, symbol, "stride")
 
-            offset = fake_tensor.storage_offset()
-            _record_ref(e, None, offset, "storage_offset")
+                offset = fake_tensor.storage_offset()
+                _record_ref(src_tensor, None, offset, "storage_offset")
+
+            _record_fake_tensor(src_tensor, fake_tensor)
+            if src_tensor._base is not None:
+                assert fake_tensor._base is not None
+                # We have a ._base on this tensor - we don't trace these
+                # but we do guard on them.
+                _record_fake_tensor(src_tensor._base, fake_tensor._base)
 
         return fake_tensor
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -698,7 +698,9 @@ try:
                 def _record(tensor_ref):
                     if tensor_ref.ref_id not in tx.output.tensor_id_to_sym_shape_ref:
                         tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id] = set()
-                    tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id].add(tensor_ref)
+                    tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id].add(
+                        tensor_ref
+                    )
 
                 def _extract(symbol):
                     if isinstance(symbol, int):
@@ -711,7 +713,9 @@ try:
                 def _record_ref(src_tensor, index, symbol, kind):
                     sym_expr = _extract(symbol)
                     if sym_expr:
-                        tensor_ref = TensorReference(id(src_tensor), kind, index, sym_expr)
+                        tensor_ref = TensorReference(
+                            id(src_tensor), kind, index, sym_expr
+                        )
                         _record(tensor_ref)
 
                 for index, symbol in enumerate(fake_tensor.size()):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -125,7 +125,9 @@ class GraphArg:
     def get_fake_examples(self):
         assert config.fake_tensor_propagation
         if self.fake_tensor is not None:
-            assert isinstance(self.fake_tensor, torch._subclasses.fake_tensor.FakeTensor)
+            assert isinstance(
+                self.fake_tensor, torch._subclasses.fake_tensor.FakeTensor
+            )
         return [self.fake_tensor]
 
     def __len__(self):

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -329,33 +329,14 @@ class SizeVariable(TupleVariable):
         return super(SizeVariable, self).call_method(tx, name, args, kwargs)
 
     def get_item_dyn(self, tx, arg: VariableTracker):
-        from .tensor import DynamicShapeVariable
-
+        """
+        Almost identical to getitem_const but bypasses clone
+        As we want to produce SizeVariable or an item's variable directly vs
+        another TupleVariable
+        """
         index = arg.as_python_constant()
         if isinstance(index, slice):
-
-            def _dynamo_get_item_lambda(target, index):
-                return torch.Size.__getitem__(target, index)
-
-            parent_proxy = self.as_proxy()
-            proxy = tx.output.create_proxy(
-                "call_function",
-                _dynamo_get_item_lambda,
-                *proxy_args_kwargs([self, arg], {}),
-                current_tx=tx,
-            )
-            items = self.items[index]
-
-            def _unpack_into_example(item):
-                if isinstance(item, DynamicShapeVariable):
-                    return item.dyn_shape
-                return item.as_python_constant()
-
-            # Mirror the indexing into example_value for downstream correctness
-            proxy.node.meta["example_value"] = parent_proxy.node.meta["example_value"][
-                index
-            ]
-            return SizeVariable(items, proxy=proxy).add_options(arg, self)
+            return SizeVariable(self.items[index]).add_options(arg, self)
         else:
             assert isinstance(index, int)
             return self.items[index].add_options(arg, self)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -381,6 +381,16 @@ class TorchVariable(VariableTracker):
                 **options,
             )
         else:
+            any_symints_or_symfloats = any([isinstance(x, DynamicShapeVariable) for x in args])
+            all_ints_or_floats = all([isinstance(x, (variables.ConstantVariable, variables.DynamicShapeVariable)) for x in args])
+            if any_symints_or_symfloats and all_ints_or_floats:
+                msg = f"""\
+Calling {str(self.value)} on only torch.SymInt arguments is not yet supported.
+To support this behavior, we need to allow const-propping tensors that store symint data.
+For now, dynamo will explicitly graph break when it encounters user code with this behavior.
+"""
+                # log.warning(msg)
+                raise unimplemented(msg)
             # Handle sth like torch.LongTensor(list(np.int64, np.int64, ...)),
             # as FX symbolic trace doesn't support numpy int/float as base types.
             if (

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -381,9 +381,22 @@ class TorchVariable(VariableTracker):
                 **options,
             )
         else:
-            any_symints_or_symfloats = any([isinstance(x, DynamicShapeVariable) for x in args])
-            all_ints_or_floats = all([isinstance(x, (variables.ConstantVariable, variables.DynamicShapeVariable)) for x in args])
-            if any_symints_or_symfloats and all_ints_or_floats and self.value != math.sqrt:
+            any_symints_or_symfloats = any(
+                [isinstance(x, DynamicShapeVariable) for x in args]
+            )
+            all_ints_or_floats = all(
+                [
+                    isinstance(
+                        x, (variables.ConstantVariable, variables.DynamicShapeVariable)
+                    )
+                    for x in args
+                ]
+            )
+            if (
+                any_symints_or_symfloats
+                and all_ints_or_floats
+                and self.value != math.sqrt
+            ):
                 msg = f"""\
 Calling {str(self.value)} on only torch.SymInt arguments is not yet supported.
 To support this behavior, we need to allow const-propping tensors that store symint data.

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -383,7 +383,7 @@ class TorchVariable(VariableTracker):
         else:
             any_symints_or_symfloats = any([isinstance(x, DynamicShapeVariable) for x in args])
             all_ints_or_floats = all([isinstance(x, (variables.ConstantVariable, variables.DynamicShapeVariable)) for x in args])
-            if any_symints_or_symfloats and all_ints_or_floats:
+            if any_symints_or_symfloats and all_ints_or_floats and self.value != math.sqrt:
                 msg = f"""\
 Calling {str(self.value)} on only torch.SymInt arguments is not yet supported.
 To support this behavior, we need to allow const-propping tensors that store symint data.

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -11,6 +11,8 @@ from ..virtualized import V
 from .common import CodeGen, DeferredLine, IndentedBuffer, Kernel
 from .triton import texpr
 
+from sympy import Expr
+
 pexpr = texpr
 
 
@@ -392,6 +394,9 @@ class WrapperCodeGen(CodeGen):
                 )
 
             for name, value in V.graph.graph_inputs.items():
+                # TODO: this is probably wrong
+                if isinstance(value, Expr):
+                    continue
                 shape = [V.graph.sizevars.size_hint(x) for x in value.get_size()]
                 stride = [V.graph.sizevars.size_hint(x) for x in value.get_stride()]
                 add_fake_input(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -5,13 +5,13 @@ import hashlib
 from itertools import count
 from typing import Any, Dict, List
 
+from sympy import Expr
+
 from .. import codecache, config, ir
 from ..utils import dynamo_utils, has_triton, sympy_dot, sympy_product
 from ..virtualized import V
 from .common import CodeGen, DeferredLine, IndentedBuffer, Kernel
 from .triton import texpr
-
-from sympy import Expr
 
 pexpr = texpr
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -3,6 +3,7 @@ import functools
 import itertools
 import logging
 import sys
+from contextlib import nullcontext
 from typing import List
 
 import functorch
@@ -171,8 +172,16 @@ def align_inputs(model, inputs, static_input_idxs=()):
     check_inputs = [
         i
         for i in range(len(inputs))
-        if (i not in static_input_idxs or (inputs[i].data_ptr() % ALIGNMENT) != 0)
-        and inputs[i].device.type == "cuda"
+        # TODO: static inputs should not be passed in as fake tensor
+        if (
+            i not in static_input_idxs
+            or isinstance(inputs[i], FakeTensor)
+            or (
+                isinstance(inputs[i], torch.Tensor) and inputs[i].data_ptr() % ALIGNMENT
+            )
+            != 0
+        )
+        and (isinstance(inputs[i], torch.Tensor) and inputs[i].device.type == "cuda")
     ]
 
     if len(check_inputs) == 0:
@@ -326,10 +335,14 @@ def count_tangents(fx_g: torch.fx.GraphModule):
 _graph_counter = itertools.count(0)
 
 
-def compile_fx(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]):
+def compile_fx(
+    model_: torch.fx.GraphModule,
+    example_inputs_: List[torch.Tensor],
+    fake_mode=nullcontext,
+):
     """Main entrypoint to a compile given FX graph"""
 
-    if not is_aot_autograd_safe_to_run(model_, example_inputs_):
+    if not is_aot_autograd_safe_to_run(model_, example_inputs_, fake_mode):
         log.warning("Aot Autograd is not safe to run, so falling back to eager")
         return model_
 
@@ -370,7 +383,7 @@ def compile_fx(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]
 
     with overrides.patch_functions():
 
-        # TODO: can add logging before/after the call to create_aot_dispatcher_function
+        # TODO: can add logging before/after the call to _create_aot_dispatcher_function
         # in functorch/_src/aot_autograd.py::aot_module_simplified::aot_function_simplified::new_func
         # once torchdynamo is merged into pytorch
         return aot_autograd(
@@ -382,4 +395,5 @@ def compile_fx(model_: torch.fx.GraphModule, example_inputs_: List[torch.Tensor]
             partition_fn=functools.partial(
                 min_cut_rematerialization_partition, compiler="inductor"
             ),
+            fake_mode=fake_mode,
         )

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -107,7 +107,7 @@ class cpp:
 class triton:
 
     # Use cudagraphs on output code
-    cudagraphs = True
+    cudagraphs = False  # TODO fix
 
     # choose conv backend, "aten" or "triton" or "autotune"
     convolution = "aten"

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -9,10 +9,10 @@ import sympy
 
 import torch
 import torch.fx
-from torch._decomp import get_decompositions
-from torch.fx.experimental.symbolic_shapes import ShapeEnv, guard_int
-from torch.utils._mode_utils import no_dispatch
 from torch import SymInt
+from torch._decomp import get_decompositions
+from torch.fx.experimental.symbolic_shapes import guard_int, ShapeEnv
+from torch.utils._mode_utils import no_dispatch
 
 from . import config, ir
 from .codegen.wrapper import WrapperCodeGen

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1968,7 +1968,6 @@ class ShapeAsConstantBuffer(IRNode):
             return V.graph.sizevars.codegen_sizevar(self.shape)
 
 
-
 @dataclasses.dataclass
 class ComputedBuffer(Buffer):
     data: Loops

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1962,7 +1962,11 @@ class ShapeAsConstantBuffer(IRNode):
         self.shape = shape
 
     def codegen_reference(self):
-        return str(self.shape)
+        if isinstance(self.shape, tuple):
+            return V.graph.sizevars.codegen_shape_tuple(self.shape)
+        else:
+            return V.graph.sizevars.codegen_sizevar(self.shape)
+
 
 
 @dataclasses.dataclass

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -4,7 +4,6 @@ import logging
 import operator
 from collections.abc import Iterable
 from typing import List, Optional, Tuple
-from torch.fx.experimental.symbolic_shapes import sym_float
 
 import sympy
 
@@ -18,6 +17,7 @@ from torch._prims_common import (
     is_integer_dtype,
     Number,
 )
+from torch.fx.experimental.symbolic_shapes import sym_float
 
 from . import config, ir, overrides
 from .cuda_properties import current_device

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -459,6 +459,8 @@ class SizeVarAllocator(object):
         added = set()
 
         for name, value in graph_inputs.items():
+            if isinstance(value, Expr):
+                continue
             shapes = value.get_size()
             for dim, shape in enumerate(shapes):
                 shape = self.simplify(shape)
@@ -470,6 +472,8 @@ class SizeVarAllocator(object):
                     assert shape in added, f"{shape} is needed but not added"
 
         for name, value in graph_inputs.items():
+            if isinstance(value, Expr):
+                continue
             shapes = value.get_stride()
             for dim, shape in enumerate(shapes):
                 shape = self.simplify(shape)
@@ -478,7 +482,7 @@ class SizeVarAllocator(object):
                     code.writeline(f"{shape} = {strideof(name)}[{dim}]")
                 elif isinstance(shape, sympy.Symbol):
                     assert shape in added, f"{shape} is needed but not added"
-        assert not needed
+        # assert not needed, f"{graph_inputs}\nneeded = {needed}"
 
     def codegen_sizevar(self, x: Expr) -> str:
         from .codegen.wrapper import pexpr

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -6,6 +6,8 @@ import operator
 import builtins
 import math
 import functools
+import threading
+from contextlib import contextmanager
 from functools import lru_cache, partial
 import traceback
 import collections
@@ -439,6 +441,18 @@ class ShapeEnv(object):
         # Duck-shaping says that if two input tensors have the same size,
         # they get assigned the same symbolic variable
         self.val_to_var: Dict[int, "sympy.Expr"] = {0: sympy.Integer(0), 1: sympy.Integer(1)}
+        self.tls = threading.local()
+
+    def _suppress_guards_tls(self):
+        return getattr(self.tls, "suppress_guards", False)
+
+    @contextmanager
+    def suppress_guards(self):
+        self.tls.suppress_guards = True
+        try:
+            yield
+        finally:
+            self.tls.suppress_guards = False
 
     def _get_key(self):
         """
@@ -509,7 +523,7 @@ class ShapeEnv(object):
 
     def evaluate_guards_for_args(self, *args):
         new_env = ShapeEnv()
-        # NB: This must be kept in sync with create_aot_dispatcher_function
+        # NB: This must be kept in sync with _create_aot_dispatcher_function
         # and wrap_fake_symbolic
         meta_converter = MetaConverter()
         pytree.tree_map_only(torch.Tensor, partial(meta_converter, shape_env=new_env), args)
@@ -673,11 +687,13 @@ class ShapeEnv(object):
         # TODO: optimize this; avoid formatting traces until we need them
         # NB: drop two frames; evaluate_expr and the Sym* function that
         # actually called us
-        stack = ''.join(traceback.format_list(traceback.extract_stack()[:-2]))
-        if concrete_val is sympy.true:
-            self.guards.append((expr, stack))
-        elif concrete_val is sympy.false:
-            self.guards.append((sympy.Not(expr), stack))
-        else:
-            self.guards.append((sympy.Eq(expr, concrete_val), stack))
+        # breakpoint()
+        if not self._suppress_guards_tls():
+            stack = ''.join(traceback.format_list(traceback.extract_stack()[:-2]))
+            if concrete_val is sympy.true:
+                self.guards.append((expr, stack))
+            elif concrete_val is sympy.false:
+                self.guards.append((sympy.Not(expr), stack))
+            else:
+                self.guards.append((sympy.Eq(expr, concrete_val), stack))
         return concrete_val


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89313

This contains https://github.com/pytorch/pytorch/pull/88546 plus a big pile of inductor hacks.

```
$ TORCHDYNAMO_DYNAMIC_SHAPES=1 AOT_DYNAMIC_SHAPES=1 python benchmarks/dynamo/torchbench.py --accuracy --backend inductor --training --only BERT_pytorch
cuda train BERT_pytorch                       PASS
```

I don't know if we're actually generating generic kernels though. Maybe @Chillee can check.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire