### PR TITLE
Initialize Kineto at startup when running in a daemon mode

### DIFF
--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -74,6 +74,12 @@ struct RegisterLibKinetoClient {
     }
 
     libkineto::api().registerClient(&client);
+
+    // For CUDA profiling, CuPTI callback is going to initialize it
+    // But for CPU profiling we need to do it explicitly
+    if (!libkineto::api().isProfilerInitialized()) {
+      libkineto::api().initProfilerIfRegistered();
+    }
   }
 } register_libkineto_client;
 


### PR DESCRIPTION
To the best of my understanding, when running with `KINETO_USE_DAEMON=1` the flow is as follows:
1. Static initializer registers profiler with kineto
2. Kineto installs CuPTI callback
3. Any CUDA operation triggers CuPTI callback
4. The callback initializes the rest of Kineto, including config update thread.

This doesn't work for CPU only workloads and in fact daemon mode seems to be broken there.

I'm not sure what's the right place to put the initialization is. This PR puts it in a static initializer that seems workable but potentially dangerous (creating background threads there). Open to suggestions there (wire to ATen::Context?).

Testing: it's non-trivial to run a unittest (forking and such), so tested manually with CPU-only build of PyTorch.