### PR TITLE
[fx] Change TensorMetadata to dataclass

### DIFF
--- a/test/expect/TestFXAPIBackwardCompatibility.test_class_member_back_compat-fx_backcompat_class_members.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_class_member_back_compat-fx_backcompat_class_members.expect
@@ -1,7 +1,7 @@
 torch.fx._symbolic_trace.ProxyableClassMeta []
 torch.fx._symbolic_trace.Tracer ['call_module', 'create_arg', 'create_args_for_root', 'getattr', 'is_leaf_module', 'path_of_module', 'trace']
 torch.fx.graph.Graph ['call_function', 'call_method', 'call_module', 'create_node', 'eliminate_dead_code', 'erase_node', 'get_attr', 'graph_copy', 'inserting_after', 'inserting_before', 'lint', 'node_copy', 'nodes', 'on_generate_code', 'output', 'owning_module', 'placeholder', 'print_tabular', 'process_inputs', 'process_outputs', 'python_code', 'set_codegen']
-torch.fx.graph.PythonCode []
+torch.fx.graph.PythonCode ['globals', 'src']
 torch.fx.graph_module.GraphModule ['add_submodule', 'code', 'delete_all_unused_submodules', 'delete_submodule', 'graph', 'print_readable', 'recompile', 'to_folder']
 torch.fx.immutable_collections.immutable_dict ['clear', 'pop', 'popitem', 'update']
 torch.fx.immutable_collections.immutable_list ['append', 'clear', 'extend', 'insert', 'pop', 'remove']

--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -1,15 +1,18 @@
+from dataclasses import dataclass
+
 import torch
 import torch.fx
 import traceback
 
 from torch.fx.node import Node, map_aggregate
-from typing import Any, Tuple, NamedTuple, Optional, Dict
+from typing import Any, Tuple, Optional, Dict
 from torch.fx._compatibility import compatibility
 
 __all__ = ['TensorMetadata', 'ShapeProp']
 
 @compatibility(is_backward_compatible=True)
-class TensorMetadata(NamedTuple):
+@dataclass
+class TensorMetadata:
     # TensorMetadata is a structure containing pertinent information
     # about a tensor within a PyTorch program.
 


### PR DESCRIPTION
This breaks BC since TensorMetadata used to be a namedtuple.
```
tm._replace(field) --> dataclasses.replace(tm, field)
tm._asdict() --> dataclasses.asdict(tm)
```

Test Plan: CI

Differential Revision: D41418727

