### PR TITLE
[tools] expose selective build library

### DIFF
--- a/tools/BUCK.bzl
+++ b/tools/BUCK.bzl
@@ -62,10 +62,11 @@ def define_tools_targets(
             ("code_analyzer", "gen_oplist.py"),
             ("code_analyzer", "gen_op_registration_allowlist.py"),
         ]),
-        base_module = "",
+        base_module = "tools.code_analyzer",
         tests = [
             ":gen_oplist_test",
         ],
+        visibility = ["PUBLIC"],
         deps = [
             ":gen_selected_mobile_ops_header",
             torchgen_deps,
@@ -75,7 +76,7 @@ def define_tools_targets(
 
     python_binary(
         name = "gen_oplist",
-        main_module = "gen_oplist",
+        main_module = "tools.code_analyzer.gen_oplist",
         visibility = ["PUBLIC"],
         deps = [
             ":gen_oplist_lib",

--- a/tools/code_analyzer/gen_oplist.py
+++ b/tools/code_analyzer/gen_oplist.py
@@ -127,7 +127,7 @@ def main(argv: List[Any]) -> None:
         default=False,
         required=False,
     )
-    options = parser.parse_args()
+    options = parser.parse_args(argv)
 
     if os.path.isfile(options.model_file_list_path):
         print("Processing model file: ", options.model_file_list_path)
@@ -186,4 +186,4 @@ def main(argv: List[Any]) -> None:
 
 
 if __name__ == "__main__":
-    main(sys.argv)
+    main(sys.argv[1:])

--- a/tools/test/gen_oplist_test.py
+++ b/tools/test/gen_oplist_test.py
@@ -4,7 +4,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from gen_oplist import throw_if_any_op_includes_overloads
+from tools.code_analyzer.gen_oplist import throw_if_any_op_includes_overloads
 
 
 class GenOplistTest(unittest.TestCase):


### PR DESCRIPTION
Change the base module and visibility of `tools:gen_oplist_lib` so that it can be reused.

