### PR TITLE
Set INTERFACE_LINK_DIRECTORIES on caffe2::mkl

### DIFF
--- a/cmake/public/mkl.cmake
+++ b/cmake/public/mkl.cmake
@@ -10,3 +10,8 @@ set_property(
 set_property(
   TARGET caffe2::mkl PROPERTY INTERFACE_LINK_LIBRARIES
   ${MKL_LIBRARIES})
+# TODO: This is a hack, it will not pick up architecture dependent
+# MKL libraries correctly; see https://github.com/pytorch/pytorch/issues/73008
+set_property(
+  TARGET caffe2::mkl PROPERTY INTERFACE_LINK_DIRECTORIES
+  ${MKL_ROOT}/lib)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89359

This ensures that subsequent link commands involving mkl libraries
know where to find the libraries if they are in a non-standard
location (which is the case if you installed mkl via conda, which
is what our standard instructions recommend.)

This is kind of a hack, because the MKL libraries are not actually
guaranteed to be in $MKL_ROOT/lib (they are for the conda install
though).  The real fix is to properly use the MKL targets from
FindMKL.cmake but thats its own can of fish.  See
https://github.com/pytorch/pytorch/issues/73008

This fixes https://github.com/pytorch/audio/issues/2784

Signed-off-by: Edward Z. Yang <ezyang@fb.com>