### PR TITLE
Directly link against MKL::MKL target, instead of doing it from scratch

### DIFF
--- a/cmake/public/mkl.cmake
+++ b/cmake/public/mkl.cmake
@@ -4,9 +4,4 @@ if(NOT TARGET caffe2::mkl)
   add_library(caffe2::mkl INTERFACE IMPORTED)
 endif()
 
-set_property(
-  TARGET caffe2::mkl PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-  ${MKL_INCLUDE_DIR})
-set_property(
-  TARGET caffe2::mkl PROPERTY INTERFACE_LINK_LIBRARIES
-  ${MKL_LIBRARIES})
+target_link_libraries(caffe2::mkl INTERFACE MKL::MKL)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89365

See also https://github.com/pytorch/pytorch/issues/73008

Also fixes https://github.com/pytorch/audio/issues/2784

Signed-off-by: Edward Z. Yang <ezyang@fb.com>