### PR TITLE
[symbolic-shapes][dynamo] Add **kwargs to dynamo backends - Part 1/4 porting symbolic shapes

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -560,12 +560,12 @@ def overhead_experiment(*args, model_iter_fn):
     return speedup_experiment(*args, model_iter_fn)
 
 
-def print_fx(gm, example_inputs):
+def print_fx(gm, example_inputs, **kwargs):
     print(gm.graph)
     return gm
 
 
-def print_aten_ops(gm, example_inputs):
+def print_aten_ops(gm, example_inputs, **kwargs):
     from functorch.compile import aot_module
 
     def trace_printer(gm, _):

--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -956,7 +956,7 @@ def aot_module_simplified(mod: nn.Module, *top_args, **top_kwargs) -> nn.Module:
 
     else:
 
-        def forward(*args):
+        def forward(*args, **kwargs):
             return compiled_f(
                 *params_flat,
                 *args,

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -9,8 +9,8 @@ from torch._dynamo.optimizations.training import is_aot_autograd_safe_to_run
 from torch._dynamo.testing import CompileCounter, rand_strided
 
 
-def compiler_safe_fn(gm, example_inputs, is_safe):
-    is_safe[0] = is_aot_autograd_safe_to_run(gm, example_inputs)
+def compiler_safe_fn(gm, example_inputs, is_safe, **kwargs):
+    is_safe[0] = is_aot_autograd_safe_to_run(gm, example_inputs, **kwargs)
     return gm.forward
 
 
@@ -233,7 +233,7 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
         gms = []
         counter = CompileCounter()
 
-        def capturing_fn(gm, inputs):
+        def capturing_fn(gm, inputs, **kwargs):
             nonlocal gms
             gms.append(gm)
             return counter(gm, inputs)

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -937,7 +937,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         torch._dynamo.reset()
 
-        def compiler(gm, sample_inputs):
+        def compiler(gm, sample_inputs, **kwargs):
             aten_gm = make_fx(gm)(*sample_inputs)
 
             self.assertEqual(len(aten_gm.graph.nodes), len(out_graph.graph.nodes))

--- a/test/dynamo/test_minifier.py
+++ b/test/dynamo/test_minifier.py
@@ -19,7 +19,7 @@ class DynamoCompileError(Exception):
     pass
 
 @register_backend
-def test_relu_compile_error(gm: torch.fx.GraphModule, example_inputs):
+def test_relu_compile_error(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     for node in gm.graph.nodes:
         if node.target == torch.relu:
             raise DynamoCompileError("relu found")
@@ -31,7 +31,7 @@ import copy
 from torch._dynamo.optimizations.backends import register_backend
 
 @register_backend
-def test_relu_runtime_error(gm: torch.fx.GraphModule, example_inputs):
+def test_relu_runtime_error(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     gm = copy.deepcopy(gm)
     for node in gm.graph.nodes:
         if node.target == torch.relu:
@@ -46,7 +46,7 @@ import copy
 from torch._dynamo.optimizations.backends import register_backend
 
 @register_backend
-def test_relu_accuracy_error(gm: torch.fx.GraphModule, example_inputs):
+def test_relu_accuracy_error(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     gm = copy.deepcopy(gm)
     for node in gm.graph.nodes:
         if node.target == torch.relu:
@@ -61,7 +61,7 @@ RELU_CUSTOM_ERROR_BACKEND = """\
 class CustomError(Exception):
     pass
 
-def test_relu_custom_error(gm: torch.fx.GraphModule, example_inputs):
+def test_relu_custom_error(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     for node in gm.graph.nodes:
         if node.target == torch.relu:
             raise CustomError("relu found")

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1835,7 +1835,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         # which contains the modules. remove the reference in this backend
         # and test that no additional references are being held.
         class NoLeakBackend:
-            def __call__(self, gm: torch.fx.GraphModule, example_inputs):
+            def __call__(self, gm: torch.fx.GraphModule, example_inputs, **kwargs):
                 gm.mod = None
 
                 def foo(*args, **kwargs):

--- a/test/dynamo/test_optimizations.py
+++ b/test/dynamo/test_optimizations.py
@@ -95,7 +95,7 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
             x.fill_(2)
             return x
 
-        def compiler_fn(graph, example_inputs):
+        def compiler_fn(graph, example_inputs, **kwargs):
             self.assertTrue(has_mutation(graph, example_inputs))
             return graph
 
@@ -107,7 +107,7 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
             b, c = bc
             return a / d - b / c
 
-        def compiler_fn(graph, example_inputs):
+        def compiler_fn(graph, example_inputs, **kwargs):
             nonlocal r1
             r1 = graph(*example_inputs)[0]
             return graph.forward

--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -34,7 +34,7 @@ class RecompileUxTests(torch._dynamo.test_case.TestCase):
             nonlocal triggered
             triggered = True
 
-        def compiler(gm, input):
+        def compiler(gm, input, **kwargs):
             nonlocal attached
             f = gm.forward
             assert not attached

--- a/test/dynamo/test_verify_correctness.py
+++ b/test/dynamo/test_verify_correctness.py
@@ -85,7 +85,7 @@ class TestVerifyCorrectness(torch._dynamo.test_case.TestCase):
             b, c = bc
             return a / d - b / c
 
-        def compiler_fn(graph, example_inputs):
+        def compiler_fn(graph, example_inputs, **kwargs):
             nonlocal r1
             r1 = graph(*example_inputs)[0]
             return graph.forward
@@ -123,7 +123,7 @@ class TestVerifyCorrectness(torch._dynamo.test_case.TestCase):
         i1 = torch.randn(10)
         i2 = torch.randn(10)
 
-        def incorrect_compile_fn(gm, example_inputs):
+        def incorrect_compile_fn(gm, example_inputs, **kwargs):
             return transform(gm).forward
 
         toy_example(i1, i2)
@@ -146,7 +146,7 @@ class TestVerifyCorrectness(torch._dynamo.test_case.TestCase):
         i1 = torch.randn(10)
         i2 = torch.randn(10)
 
-        def incorrect_compile_fn(gm, example_inputs):
+        def incorrect_compile_fn(gm, example_inputs, **kwargs):
             return transform(gm).forward
 
         r1 = toy_example(i1, i2)

--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -17,8 +17,8 @@ aten = torch.ops.aten
 
 
 @register_backend
-def count_bytes_inductor(gm, example_inputs):
-    return compile_fx(gm, example_inputs, inner_compile=count_bytes_inner)
+def count_bytes_inductor(gm, example_inputs, **kwargs):
+    return compile_fx(gm, example_inputs, inner_compile=count_bytes_inner, **kwargs)
 
 
 @torch._dynamo.optimize("count_bytes_inductor")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -282,7 +282,7 @@ def check_model(
 
     called = False
 
-    def compile_fx_wrapper(model_, example_inputs_):
+    def compile_fx_wrapper(model_, example_inputs_, **kwargs):
         nonlocal called
         called = True
         return compile_fx(model_, example_inputs_)

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -872,7 +872,7 @@ def wrap_backend_debug(compiler_fn, compiler_name: str):
 
 
 @register_backend
-def dynamo_minifier_backend(gm, example_inputs, compiler_name):
+def dynamo_minifier_backend(gm, example_inputs, compiler_name, **kwargs):
     from functorch.compile import minifier
 
     from .eval_frame import lookup_backend
@@ -880,7 +880,7 @@ def dynamo_minifier_backend(gm, example_inputs, compiler_name):
     compiler_fn = lookup_backend(compiler_name)
 
     try:
-        compiled_gm = compiler_fn(gm, example_inputs)
+        compiled_gm = compiler_fn(gm, example_inputs, **kwargs)
         run_fwd_maybe_bwd(compiled_gm, example_inputs)
         raise ValueError("No issue was detected")
     except Exception as exc:
@@ -907,7 +907,7 @@ def dynamo_minifier_backend(gm, example_inputs, compiler_name):
 
 
 @register_backend
-def dynamo_accuracy_minifier_backend(gm, example_inputs, compiler_name):
+def dynamo_accuracy_minifier_backend(gm, example_inputs, compiler_name, **kwargs):
     from functorch.compile import minifier
 
     from torch._dynamo.optimizations.backends import BACKENDS

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -328,7 +328,7 @@ class WrapperBackend:
     def example_inputs(self):
         return clone_inputs(self.original_example_inputs)
 
-    def __call__(self, gm: torch.fx.GraphModule, example_inputs):
+    def __call__(self, gm: torch.fx.GraphModule, example_inputs, **kwargs):
 
         self.restore = checkpoint_params(gm)
         self.original_example_inputs = clone_inputs(example_inputs)
@@ -475,7 +475,9 @@ def explain(f, *args, **kwargs):
     op_count = 0
     break_reasons = []
 
-    def dynamo_graph_accumulating_compiler(gm: torch.fx.GraphModule, example_inputs):
+    def dynamo_graph_accumulating_compiler(
+        gm: torch.fx.GraphModule, example_inputs, **kwargs
+    ):
         nonlocal graphs
         nonlocal op_count
         nonlocal ops_per_graph
@@ -589,7 +591,7 @@ def export(
         out_guards = guards
 
     def dynamo_normalization_capturing_compiler(
-        gm: torch.fx.GraphModule, example_inputs
+        gm: torch.fx.GraphModule, example_inputs, **kwargs
     ):
         nonlocal graph
 

--- a/torch/_dynamo/optimizations/analysis.py
+++ b/torch/_dynamo/optimizations/analysis.py
@@ -116,7 +116,7 @@ class ShapeAliasingAndMutationProp(ShapeProp):
             self.env.clear()
 
 
-def has_mutation(gm, example_inputs, inputs_only=False):
+def has_mutation(gm, example_inputs, inputs_only=False, **kwargs):
     """Check if the graph module has any form of mutation.  If inputs_only is
     true, we only check for mutation of inputs"""
     # TODO - moco gives bad accuracy with Aliasing. gm is getting mutated in a bad way.

--- a/torch/_dynamo/optimizations/backends.py
+++ b/torch/_dynamo/optimizations/backends.py
@@ -62,12 +62,12 @@ def create_backend(fn):
 
 
 @create_backend
-def eager(subgraph):
+def eager(subgraph, **kwargs):
     return subgraph.model
 
 
 @create_backend
-def ts(subgraph):
+def ts(subgraph, **kwargs):
     return subgraph.scripted
 
 
@@ -88,42 +88,42 @@ def reload_jit_model_ofi(subgraph):
 
 
 @create_backend
-def nnc(subgraph):
+def nnc(subgraph, **kwargs):
     with torch.jit.fuser("fuser1"):
         return reload_jit_model(subgraph)
 
 
 @create_backend
-def nnc_ofi(subgraph):
+def nnc_ofi(subgraph, **kwargs):
     with torch.jit.fuser("fuser1"):
         return reload_jit_model_ofi(subgraph)
 
 
 @create_backend
-def ts_nvfuser(subgraph):
+def ts_nvfuser(subgraph, **kwargs):
     with torch.jit.fuser("fuser2"):
         return reload_jit_model(subgraph)
 
 
 @create_backend
-def ts_nvfuser_ofi(subgraph):
+def ts_nvfuser_ofi(subgraph, **kwargs):
     with torch.jit.fuser("fuser2"):
         return reload_jit_model_ofi(subgraph)
 
 
 @create_backend
-def onednn(subgraph):
+def onednn(subgraph, **kwargs):
     with torch.jit.fuser("fuser3"):
         return reload_jit_model(subgraph)
 
 
 @create_backend
-def ofi(subgraph):
+def ofi(subgraph, **kwargs):
     return torch.jit.optimize_for_inference(subgraph.scripted)
 
 
 @create_backend
-def static_runtime(subgraph):
+def static_runtime(subgraph, **kwargs):
     scripted = subgraph.scripted
     if hasattr(scripted, "_c"):
         static_module = torch._C._jit_to_static_module(scripted._c)
@@ -177,17 +177,17 @@ def onnxrt_common(subgraph, provider, onnx_filename=None):
 
 
 @create_backend
-def onnxrt_cpu(subgraph):
+def onnxrt_cpu(subgraph, **kwargs):
     return onnxrt_common(subgraph, provider="CPUExecutionProvider")
 
 
 @create_backend
-def onnxrt_cuda(subgraph):
+def onnxrt_cuda(subgraph, **kwargs):
     return onnxrt_common(subgraph, provider="CUDAExecutionProvider")
 
 
 @create_backend
-def onnx2tensorrt(subgraph):
+def onnx2tensorrt(subgraph, **kwargs):
     if subgraph.will_tensorrt_barf():
         # TensorRT fails violently with an abort() on this
         return None
@@ -196,7 +196,7 @@ def onnx2tensorrt(subgraph):
 
 
 @create_backend
-def onnxrt_cpu_numpy(subgraph, provider="CPUExecutionProvider"):
+def onnxrt_cpu_numpy(subgraph, provider="CPUExecutionProvider", **kwargs):
     """Alternate version that integrates via numpy"""
     import onnxruntime
 
@@ -222,7 +222,7 @@ def onnxrt_cpu_numpy(subgraph, provider="CPUExecutionProvider"):
 
 
 @create_backend
-def onnxrt(subgraph):
+def onnxrt(subgraph, **kwargs):
     if subgraph.is_cuda:
         return onnxrt_cuda(subgraph)
     else:
@@ -241,7 +241,7 @@ def _init_tensorflow():
 
 
 @create_backend
-def onnx2tf(subgraph):
+def onnx2tf(subgraph, **kwargs):
     import onnx
     from onnx_tf.backend import prepare
 
@@ -278,7 +278,7 @@ def onnx2tf(subgraph):
 
 
 @create_backend
-def taso(subgraph):
+def taso(subgraph, **kwargs):
     taso_filename = subgraph.filename("taso")
     subprocess.check_call(
         [
@@ -412,7 +412,7 @@ def fx2trt(subgraph, **kwargs):
 
 
 @create_backend
-def torch2trt(subgraph):
+def torch2trt(subgraph, **kwargs):
     if subgraph.will_tensorrt_barf():
         # TensorRT fails violently with an abort() on this
         return None
@@ -430,7 +430,7 @@ def torch2trt(subgraph):
 
 
 @create_backend
-def tensorrt(subgraph):
+def tensorrt(subgraph, **kwargs):
     if subgraph.will_tensorrt_barf():
         # TensorRT fails violently with an abort() on this
         return None
@@ -442,7 +442,7 @@ def tensorrt(subgraph):
 
 
 @create_backend
-def onnx2tensorrt_alt(subgraph):
+def onnx2tensorrt_alt(subgraph, **kwargs):
     if subgraph.will_tensorrt_barf():
         # TensorRT fails violently with an abort() on this
         return None
@@ -481,7 +481,7 @@ def onnx2tensorrt_alt(subgraph):
 
 
 @create_backend
-def cudagraphs(subgraph):
+def cudagraphs(subgraph, **kwargs):
     model = subgraph.model
     inputs = subgraph.example_inputs
     assert subgraph.is_cuda
@@ -489,7 +489,7 @@ def cudagraphs(subgraph):
 
 
 @create_backend
-def cudagraphs_ts(subgraph):
+def cudagraphs_ts(subgraph, **kwargs):
     assert subgraph.is_cuda
     model = subgraph.scripted
     inputs = subgraph.example_inputs
@@ -502,7 +502,7 @@ def cudagraphs_ts(subgraph):
 
 
 @create_backend
-def cudagraphs_ts_ofi(subgraph):
+def cudagraphs_ts_ofi(subgraph, **kwargs):
     assert subgraph.is_cuda
     model = torch.jit.optimize_for_inference(torch.jit.freeze(subgraph.scripted))
     inputs = subgraph.example_inputs
@@ -579,7 +579,7 @@ def tvm_compile(jit_mod, example_inputs, log_file=None, **kwargs):
 
 
 @create_backend
-def tvm(subgraph):
+def tvm(subgraph, **kwargs):
     return subgraph.wrap_returns(
         tvm_compile_inner(
             subgraph.scripted,
@@ -591,7 +591,7 @@ def tvm(subgraph):
 
 
 @create_backend
-def ansor(subgraph):
+def ansor(subgraph, **kwargs):
     """
     WARNING: this backend takes hours or days to train and
     often produces a slower result than the default schedule.
@@ -608,7 +608,7 @@ def ansor(subgraph):
 
 
 @create_backend
-def tvm_meta_schedule(subgraph):
+def tvm_meta_schedule(subgraph, **kwargs):
     return subgraph.wrap_returns(
         tvm_compile_inner(
             subgraph.scripted,
@@ -796,7 +796,7 @@ def _init_torchxla():
 
 
 @create_backend
-def torchxla_trivial(subgraph):
+def torchxla_trivial(subgraph, **kwargs):
     _init_torchxla()
 
     xla_dev = xm.xla_device()
@@ -815,7 +815,7 @@ def torchxla_trivial(subgraph):
 
 
 @create_backend
-def torchxla_trace_once(subgraph):
+def torchxla_trace_once(subgraph, **kwargs):
     import torch._dynamo.optimizations.torchxla_integration as integration
 
     model = subgraph.model

--- a/torch/_dynamo/optimizations/backends.py
+++ b/torch/_dynamo/optimizations/backends.py
@@ -764,12 +764,12 @@ def _init_ltc():
         raise
 
 
-def ltc_reuse_graph(gm: torch.fx.GraphModule, example_inputs):
+def ltc_reuse_graph(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     ltc = _init_ltc()
     return ltc.extract_compiled_graph.extract_compiled_graph(gm, example_inputs)
 
 
-def ltc_trivial(gm: torch.fx.GraphModule, example_inputs):
+def ltc_trivial(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     ltc = _init_ltc()
     lazy_model = copy.deepcopy(gm).to(device="lazy")
     ltc.extract_compiled_graph.force_lazy_device(lazy_model)
@@ -823,17 +823,17 @@ def torchxla_trace_once(subgraph, **kwargs):
     return integration.extract_compiled_graph(model, example_inputs)
 
 
-def ipex_fp32(gm: torch.fx.GraphModule, example_inputs):
+def ipex_fp32(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     kwargs_ipex = {"datatype": "fp32"}
     return BACKENDS["ipex"](gm, example_inputs, **kwargs_ipex)
 
 
-def ipex_bf16(gm: torch.fx.GraphModule, example_inputs):
+def ipex_bf16(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     kwargs_ipex = {"datatype": "bf16"}
     return BACKENDS["ipex"](gm, example_inputs, **kwargs_ipex)
 
 
-def fx2trt_compiler_fp16(gm: torch.fx.GraphModule, example_inputs):
+def fx2trt_compiler_fp16(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     kwargs_fx2trt = {"fp16_mode": True}
     trt_compiled = BACKENDS["fx2trt"](gm, example_inputs, **kwargs_fx2trt)
     if trt_compiled is not None:
@@ -845,7 +845,7 @@ def fx2trt_compiler_fp16(gm: torch.fx.GraphModule, example_inputs):
         return gm.forward
 
 
-def fx2trt_compiler(gm: torch.fx.GraphModule, example_inputs):
+def fx2trt_compiler(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     kwargs_fx2trt = {"fp16_mode": False}
     trt_compiled = BACKENDS["fx2trt"](gm, example_inputs, **kwargs_fx2trt)
     if trt_compiled is not None:

--- a/torch/_dynamo/optimizations/distributed.py
+++ b/torch/_dynamo/optimizations/distributed.py
@@ -131,7 +131,9 @@ class DDPOptimizer:
     def _ignore_parameter(self, parameter):
         return hasattr(parameter, "_ddp_ignored") and parameter._ddp_ignored
 
-    def compile_fn(self, gm: fx.GraphModule, example_inputs: List[torch.Tensor]):
+    def compile_fn(
+        self, gm: fx.GraphModule, example_inputs: List[torch.Tensor], **kwargs
+    ):
         """
         Implements graph splitting, first determining a set of of buckets by counting
         parameter sizes in reverse graph order, then invoking the user/backend compiler
@@ -182,7 +184,7 @@ class DDPOptimizer:
 
         if len(buckets) == 1:
             # bypass split/fuse logic if there is only one bucket
-            return self.backend_compile_fn(gm, example_inputs)
+            return self.backend_compile_fn(gm, example_inputs, **kwargs)
 
         # 2: partition the graphmodule according to bucket capacity
         partition_map = {}

--- a/torch/_dynamo/optimizations/inference.py
+++ b/torch/_dynamo/optimizations/inference.py
@@ -123,7 +123,7 @@ class TorchScriptStrategy(object):
     """Common base for backend strategies that use TorchScript"""
 
     @classmethod
-    def compile_fn(cls, gm: torch.fx.GraphModule, example_inputs):
+    def compile_fn(cls, gm: torch.fx.GraphModule, example_inputs, **kwargs):
         if count_calls(gm.graph) < 2:
             return gm.forward  # no point for tiny graphs
         return cls(gm, example_inputs).verified_candidate()

--- a/torch/_dynamo/optimizations/inference.py
+++ b/torch/_dynamo/optimizations/inference.py
@@ -23,7 +23,7 @@ from .normalize import long_name, normalize_ir
 log = logging.getLogger(__name__)
 
 
-def string_key(gm: torch.fx.GraphModule, example_inputs):
+def string_key(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     out = io.StringIO()
     node_to_id = defaultdict(iter(itertools.count()).__next__)
 
@@ -59,13 +59,13 @@ def string_key(gm: torch.fx.GraphModule, example_inputs):
     return out.getvalue()
 
 
-def graph_hash(gm: torch.fx.GraphModule, example_inputs):
+def graph_hash(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     return "g" + base64.urlsafe_b64encode(
         hashlib.sha256(string_key(gm, example_inputs).encode("utf-8")).digest()
     )[:39].decode("utf-8")
 
 
-def folder_name(gm: torch.fx.GraphModule, example_inputs):
+def folder_name(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     base = os.path.join(config.base_dir, "subgraphs")
     if not os.path.exists(base):
         os.mkdir(base)
@@ -128,7 +128,7 @@ class TorchScriptStrategy(object):
             return gm.forward  # no point for tiny graphs
         return cls(gm, example_inputs).verified_candidate()
 
-    def __init__(self, gm: torch.fx.GraphModule, example_inputs):
+    def __init__(self, gm: torch.fx.GraphModule, example_inputs, **kwargs):
         super(TorchScriptStrategy, self).__init__()
         self.restore = checkpoint_params(gm)
         self.original_example_inputs = example_inputs

--- a/torch/_dynamo/optimizations/training.py
+++ b/torch/_dynamo/optimizations/training.py
@@ -22,7 +22,7 @@ from .normalize import normalize_ir
 log = logging.getLogger(__name__)
 
 
-def is_aot_autograd_safe_to_run(gm, example_inputs):
+def is_aot_autograd_safe_to_run(gm, example_inputs, **kwargs):
     """
     There are some known issues with Aot Autograd. This is a workaround to catch
     such cases, and fallback to eager. We should fix these quickly.
@@ -88,10 +88,10 @@ class AotAutogradStrategy(object):
     """Base class for backend strategies that use AOT Autograd"""
 
     @classmethod
-    def compile_fn(cls, gm: torch.fx.GraphModule, example_inputs):
+    def compile_fn(cls, gm: torch.fx.GraphModule, example_inputs, **kwargs):
         if count_calls(gm.graph) < 2:
             return gm  # no point for tiny graphs
-        return cls(gm, example_inputs).verified_candidate()
+        return cls(gm, example_inputs, **kwargs).verified_candidate()
 
     def __init__(self, gm: torch.fx.GraphModule, example_inputs):
         import functorch.compile

--- a/torch/_dynamo/profiler.py
+++ b/torch/_dynamo/profiler.py
@@ -150,7 +150,7 @@ def shapes_of(it):
         return [tuple(getattr(x, "shape", [])) for x in it]
 
 
-def fx_insert_profiling(gm: torch.fx.GraphModule, example_inputs: List[Any]):
+def fx_insert_profiling(gm: torch.fx.GraphModule, example_inputs: List[Any], **kwargs):
     input_shapes = shapes_of(example_inputs)
     output_shapes = None
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -145,7 +145,7 @@ class CompileCounter:
         self.frame_count = 0
         self.op_count = 0
 
-    def __call__(self, gm: torch.fx.GraphModule, example_inputs):
+    def __call__(self, gm: torch.fx.GraphModule, example_inputs, **kwargs):
         self.frame_count += 1
         for node in gm.graph.nodes:
             if "call" in node.op:
@@ -163,14 +163,14 @@ class CompileCounterWithBackend:
         self.op_count = 0
         self.backend = backend
 
-    def __call__(self, gm: torch.fx.GraphModule, example_inputs):
+    def __call__(self, gm: torch.fx.GraphModule, example_inputs, **kwargs):
         from torch._dynamo.eval_frame import lookup_backend
 
         self.frame_count += 1
         for node in gm.graph.nodes:
             if "call" in node.op:
                 self.op_count += 1
-        return lookup_backend(self.backend)(gm, example_inputs)
+        return lookup_backend(self.backend)(gm, example_inputs, **kwargs)
 
 
 def standard_test(self, fn, nargs, expected_ops=None, expected_ops_dynamic=None):

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -944,7 +944,7 @@ class CompileProfiler:
         self.op_count = 0
         self.backend_ctx_ctor = lambda: disable_cache_limit()
 
-    def __call__(self, gm: torch.fx.GraphModule, example_inputs):
+    def __call__(self, gm: torch.fx.GraphModule, example_inputs, **kwargs):
         self.frame_count += 1
         for node in gm.graph.nodes:
             if "call" in node.op:

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -108,6 +108,7 @@ def compile_fx_inner(
     num_fixed=0,
     is_backward=False,
     graph_id=None,
+    **kwargs,
 ):
     if dynamo_utils.count_calls(gm.graph) == 0:
         return make_boxed_func(gm.forward)
@@ -346,6 +347,7 @@ def compile_fx(
     model_: torch.fx.GraphModule,
     example_inputs_: List[torch.Tensor],
     inner_compile=compile_fx_inner,
+    **kwargs,
 ):
     """Main entrypoint to a compile given FX graph"""
 
@@ -374,6 +376,7 @@ def compile_fx(
             num_fixed=fixed,
             cudagraphs=cudagraphs,
             graph_id=graph_id,
+            **kwargs,
         )
 
     @dynamo_utils.dynamo_timed
@@ -386,6 +389,7 @@ def compile_fx(
             cudagraphs=cudagraphs,
             is_backward=True,
             graph_id=graph_id,
+            **kwargs,
         )
 
     with overrides.patch_functions():
@@ -402,4 +406,5 @@ def compile_fx(
             partition_fn=functools.partial(
                 min_cut_rematerialization_partition, compiler="inductor"
             ),
+            **kwargs,
         )

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -426,7 +426,7 @@ def check_node_is_add_inplace(node):
     )
 
 
-def fuse_fx(gm: torch.fx.GraphModule, example_inputs):
+def fuse_fx(gm: torch.fx.GraphModule, example_inputs, **kwargs):
     is_cpu = all(
         example_input.device == torch.device("cpu") for example_input in example_inputs
     )


### PR DESCRIPTION
This is part 1 of the split plan for the bigger migration of critical parts of symbolic-shapes branch to master.

The whole can be found here:
https://github.com/pytorch/pytorch/pull/89363
And https://github.com/pytorch/pytorch/pull/89313/files in parts

The meta-description for this stack:

Step 2 of https://docs.google.com/document/u/1/d/1QJ-M4zfMkD-fjHIqW089RptjLl9EgozZGCceUbvmgfY/edit Step 
1 can be found here: [#87570](https://github.com/pytorch/pytorch/pull/87570)

The problem this PR solves is that today, we have a world wherein dynamo creates guards and installs them, but aot_autograd creates guards... and does not install them. This means that code executed in make_fx can produce new symbolic shape guards, that then do not get used anywhere.

The order today, before this PR, is:

1. Dynamo starts interpresting a frame
2. Dynamo call call_user_compiler which sets up a function which will lazily invoke create_aot_dispatcher_function at runtime
3. Dynamo installs its own guards, pulls in shape_env guards only from dynamo shape_env, installs those as well
4. Dynamo finishes the frame
5. The func made in (2) is invoke, and create_aot_dispatcher_function calls make_fx which can create shape env guards, these guards are not used anywhere

Our solution to this is to ensure that make_fx's guards bubble up to dynamo, in a "unified cache", and we do this by piping a fake_mode down to aot_autograd from dynamo.

The unified cache architecture works by changing the lifecycle of when we compile the the aot_autograd function from runtime, to lowering time. We go from lazily compiling create_aot_dispatcher_function to always invoking it at lowering time. This is sound because the compiled_fn is protected by dynamo's guards. The order, therefore, is now:


1. Dynamo starts interpresting a frame
2. Dynamo call call_user_compiler which invokes compile_fn which invokes create_aot_dispatcher_function
3. create_aot_dispatcher_function calls make_fx which can create shape env guards
4. Dynamo installs its own guards, pulls in shape_env guards, installs those as well
5. Dynamo finishes the frame

As an added bonus, this allows us to remove the duplicate fake tensor conversion code that used to always be invoked in create_aot_dispatcher_function through process_inputs, reusing the fake tensors from dynamo's conversion step. Outside of dynamo's invocation path, we still need this layer to exist, though, as aot_function is a public entry point to aot_autograd, so the process_inputs/fake tensor conversion code gets lifted up to there. 

This also changes the story of create_aot_dispatcher_function - specifically, in that it now MUST be called with fake tensors if we are in fake tensor mode, as it will do no fake tensor conversion of its own. For Dynamo, we rely on the dynamo passing that down, for the public entry point, we rely on aot_function.

One annoying sort of stopgap around this is the parameter story. Dynamo fake-ifys only its inputs, and params get treated a little differently. This is made more confusing by the fact that while create_aot_dispatcher_function takes all fake tensors (params and inputs both), aot_function_simplified still needs real parameters as it uses them as inputs to the compiled aot_function. This means we need to, later on, either fake-ify parameters at dynamo time and pass them alongside the real ones, or to keep the param-only fake tensor conversion where it is in this pr.


— Split Strategy — 

1. **kwargs to all backends
2. Pass fake_mode, fake_tensor inputs to aot_autograd
3. Refactor aot_autograd as per [#87570](https://github.com/pytorch/pytorch/pull/87570) pt1 - replace fake_tensor conversion in aot_autograd w/ fake_tensor from dynamo
4. Refactor aot_autograd as per [#87570](https://github.com/pytorch/pytorch/pull/87570) pt2 - move create_fn to lowering time, introduce a cache

cc @mlazos @soumith @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire