### PR TITLE
[symbolic-shapes][dynamo] Pass fake_mode and fake_inputs to aot_autograd - Part 2/4 porting symbolic shapes

### DIFF
--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -916,6 +916,8 @@ def aot_module_simplified(mod: nn.Module, *top_args, **top_kwargs) -> nn.Module:
         decompositions: Optional[Dict] = None,
         hasher_type=None,
         static_argnums=None,
+        fake_mode=None,
+        fake_inputs=None,
     ) -> Callable:
         assert static_argnums is None
         if bw_compiler is None:

--- a/test/dynamo/test_recompile_ux.py
+++ b/test/dynamo/test_recompile_ux.py
@@ -34,7 +34,7 @@ class RecompileUxTests(torch._dynamo.test_case.TestCase):
             nonlocal triggered
             triggered = True
 
-        def compiler(gm, input):
+        def compiler(gm, input, **kwargs):
             nonlocal attached
             f = gm.forward
             assert not attached

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -397,6 +397,9 @@ def clone_tensor(x):
 
 def clone_input(x):
     """copy while preserving strides"""
+    if isinstance(x, torch._subclasses.FakeTensor):
+        # No need to clone fake tensors?
+        return x
     with torch.no_grad():
         needed_size = sum(
             (shape - 1) * stride for shape, stride in zip(x.size(), x.stride())

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -109,6 +109,8 @@ class GraphArg:
     source: Source
     example: Any
     is_unspecialized: bool
+    # Must only be a fake tensor
+    fake_tensor = None
 
     def __post_init__(self):
         if isinstance(self.example, torch._subclasses.fake_tensor.FakeTensor):
@@ -119,6 +121,14 @@ class GraphArg:
 
     def get_examples(self):
         return [self.example]
+
+    def get_fake_examples(self):
+        assert config.fake_tensor_propagation
+        if self.fake_tensor is not None:
+            assert isinstance(
+                self.fake_tensor, torch._subclasses.fake_tensor.FakeTensor
+            )
+        return [self.fake_tensor]
 
     def __len__(self):
         return 1
@@ -541,10 +551,10 @@ class VariableBuilder:
                 # guards=self.make_guards(GuardBuilder.TENSOR_MATCH),
             )
         else:
+            graph_arg = None
             if not is_constant_source(self.get_source()):
-                self.tx.output.graphargs.append(
-                    GraphArg(self.get_source(), value, False)
-                )
+                graph_arg = GraphArg(self.get_source(), value, False)
+                self.tx.output.graphargs.append(graph_arg)
             # Disable __torch_function__ to prevent cloning of `value` to hit
             # us
             with torch._C.DisableTorchFunction():
@@ -564,6 +574,10 @@ class VariableBuilder:
                     guards=self.make_guards(GuardBuilder.TENSOR_MATCH),
                     should_specialize=self.tensor_should_specialize(),
                 )
+            if graph_arg and config.fake_tensor_propagation:
+                example = tensor_variable.proxy.node.meta["example_value"]
+                if isinstance(example, torch._subclasses.fake_tensor.FakeTensor):
+                    graph_arg.fake_tensor = example
             if torch.overrides.has_torch_function_unary(value):
                 subclass_torch_function__func = value.__torch_function__.__func__
                 subclass_type = type(value)


### PR DESCRIPTION
This is part 2 of the split plan for the bigger migration of critical parts of symbolic-shapes branch to master.

The whole can be found here:
https://github.com/pytorch/pytorch/pull/89363
And https://github.com/pytorch/pytorch/pull/89313/files in parts

The meta-description for this stack:

Step 2 of https://docs.google.com/document/u/1/d/1QJ-M4zfMkD-fjHIqW089RptjLl9EgozZGCceUbvmgfY/edit
 Step 1 can be found here: [#87570](https://github.com/pytorch/pytorch/pull/87570)

The problem this PR solves is that today, we have a world wherein dynamo creates guards and installs them, but aot_autograd creates guards... and does not install them. This means that code executed in make_fx can produce new symbolic shape guards, that then do not get used anywhere.

The order today, before this PR, is:

1. Dynamo starts interpresting a frame
2. Dynamo call call_user_compiler which sets up a function which will lazily invoke create_aot_dispatcher_function at runtime
3. Dynamo installs its own guards, pulls in shape_env guards only from dynamo shape_env, installs those as well
4. Dynamo finishes the frame
5. The func made in (2) is invoke, and create_aot_dispatcher_function calls make_fx which can create shape env guards, these guards are not used anywhere

Our solution to this is to ensure that make_fx's guards bubble up to dynamo, in a "unified cache", and we do this by piping a fake_mode down to aot_autograd from dynamo.

The unified cache architecture works by changing the lifecycle of when we compile the the aot_autograd function from runtime, to lowering time. We go from lazily compiling create_aot_dispatcher_function to always invoking it at lowering time. This is sound because the compiled_fn is protected by dynamo's guards. The order, therefore, is now:


1. Dynamo starts interpresting a frame
2. Dynamo call call_user_compiler which invokes compile_fn which invokes create_aot_dispatcher_function
3. create_aot_dispatcher_function calls make_fx which can create shape env guards
4. Dynamo installs its own guards, pulls in shape_env guards, installs those as well
5. Dynamo finishes the frame

As an added bonus, this allows us to remove the duplicate fake tensor conversion code that used to always be invoked in create_aot_dispatcher_function through process_inputs, reusing the fake tensors from dynamo's conversion step. Outside of dynamo's invocation path, we still need this layer to exist, though, as aot_function is a public entry point to aot_autograd, so the process_inputs/fake tensor conversion code gets lifted up to there. 

This also changes the story of create_aot_dispatcher_function - specifically, in that it now MUST be called with fake tensors if we are in fake tensor mode, as it will do no fake tensor conversion of its own. For Dynamo, we rely on the dynamo passing that down, for the public entry point, we rely on aot_function.

One annoying sort of stopgap around this is the parameter story. Dynamo fake-ifys only its inputs, and params get treated a little differently. This is made more confusing by the fact that while create_aot_dispatcher_function takes all fake tensors (params and inputs both), aot_function_simplified still needs real parameters as it uses them as inputs to the compiled aot_function. This means we need to, later on, either fake-ify parameters at dynamo time and pass them alongside the real ones, or to keep the param-only fake tensor conversion where it is in this pr.


— Split Strategy — 

1. **kwargs to all backends
2. Pass fake_mode, fake_tensor inputs to aot_autograd
3. Refactor aot_autograd as per [#87570](https://github.com/pytorch/pytorch/pull/87570) pt1 - replace fake_tensor conversion in aot_autograd w/ fake_tensor from dynamo
4. Refactor aot_autograd as per [#87570](https://github.com/pytorch/pytorch/pull/87570) pt2 - move create_fn to lowering time, introduce a cache

cc @mlazos @soumith @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire