### PR TITLE
Also include MKL_THREAD_LIB in link libraries for caffe2::mkl

### DIFF
--- a/cmake/public/mkl.cmake
+++ b/cmake/public/mkl.cmake
@@ -9,7 +9,7 @@ set_property(
   ${MKL_INCLUDE_DIR})
 set_property(
   TARGET caffe2::mkl PROPERTY INTERFACE_LINK_LIBRARIES
-  ${MKL_LIBRARIES})
+  ${MKL_LIBRARIES} ${MKL_THREAD_LIB})
 # TODO: This is a hack, it will not pick up architecture dependent
 # MKL libraries correctly; see https://github.com/pytorch/pytorch/issues/73008
 set_property(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89378

Actually fixes https://github.com/pytorch/audio/issues/2784 for
real; in my previous testing I didn't check if I could import
torchaudio; now torchaudio successfully imports.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>