### PR TITLE
Update docstring for torch.linalg.lstsq

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1031,7 +1031,7 @@ To choose the best driver on CPU consider:
 
 For CUDA input, the only valid driver is `'gels'`, which assumes that :attr:`A` is full-rank. If the linear system 
 to be solved is underdetermined (i.e. :attr:`A` is "wide" and there are infinitely many solutions),
-then `'gels'` will find the solution which minimizes :math:`\|X\|_F`, the minimum-norm solution.
+then `'gels'` will find the minimum-norm solution.
 
 See also the `full description of these drivers`_
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1015,7 +1015,7 @@ Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batches of matrices, and if the inputs are batches of matrices then
 the output has the same batch dimensions.
 
-:attr:`driver` chooses the LAPACK function that will be used.
+:attr:`driver` chooses the backend function that will be used.
 For CPU inputs the valid values are `'gels'`, `'gelsy'`, `'gelsd`, `'gelss'`.
 To choose the best driver on CPU consider:
 
@@ -1028,13 +1028,10 @@ To choose the best driver on CPU consider:
 
   - `'gelsd'` (tridiagonal reduction and SVD)
   - But if you run into memory issues: `'gelss'` (full SVD).
-  
-For CUDA input, the only valid driver is `'gels'`, which assumes that :attr:`A` is full-rank. If :attr:`A` is not square,
-the following heuristic is used to choose how the system will be solved:
-  - If the linear system to be solved is overdetermined (i.e. :attr:`A` is "tall"), 
-  then `'gels'` will solve the **least squares problem** for the system as described above.
-  - If the linear system to be solved is underdetermined (i.e. :attr:`A` is "wide" and there are infinitely many solutions),
-  then `'gels'` will find the solution which minimizes :math:`\|X\|_F`, the minimum-norm solution.
+
+For CUDA input, the only valid driver is `'gels'`, which assumes that :attr:`A` is full-rank. If the linear system 
+to be solved is underdetermined (i.e. :attr:`A` is "wide" and there are infinitely many solutions),
+then `'gels'` will find the solution which minimizes :math:`\|X\|_F`, the minimum-norm solution.
 
 See also the `full description of these drivers`_
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1029,9 +1029,7 @@ To choose the best driver on CPU consider:
   - `'gelsd'` (tridiagonal reduction and SVD)
   - But if you run into memory issues: `'gelss'` (full SVD).
 
-For CUDA input, the only valid driver is `'gels'`, which assumes that :attr:`A` is full-rank. If the linear system 
-to be solved is underdetermined (i.e. :attr:`A` is "wide" and there are infinitely many solutions),
-then `'gels'` will find the minimum-norm solution.
+For CUDA input, the only valid driver is `'gels'`, which assumes that :attr:`A` is full-rank.
 
 See also the `full description of these drivers`_
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1015,9 +1015,8 @@ Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batches of matrices, and if the inputs are batches of matrices then
 the output has the same batch dimensions.
 
-:attr:`driver` chooses the LAPACK/MAGMA function that will be used.
+:attr:`driver` chooses the LAPACK function that will be used.
 For CPU inputs the valid values are `'gels'`, `'gelsy'`, `'gelsd`, `'gelss'`.
-For CUDA input, the only valid driver is `'gels'`, which assumes that :attr:`A` is full-rank.
 To choose the best driver on CPU consider:
 
 - If :attr:`A` is well-conditioned (its `condition number`_ is not too large), or you do not mind some precision loss.
@@ -1029,6 +1028,13 @@ To choose the best driver on CPU consider:
 
   - `'gelsd'` (tridiagonal reduction and SVD)
   - But if you run into memory issues: `'gelss'` (full SVD).
+  
+For CUDA input, the only valid driver is `'gels'`, which assumes that :attr:`A` is full-rank. If :attr:`A` is not square,
+the following heuristic is used to choose how the system will be solved:
+  - If the linear system to be solved is overdetermined (i.e. :attr:`A` is "tall"), 
+  then `'gels'` will solve the **least squares problem** for the system as described above.
+  - If the linear system to be solved is underdetermined (i.e. :attr:`A` is "wide" and there are infinitely many solutions),
+  then `'gels'` will find the solution which minimizes :math:`\|X\|_F`, the minimum-norm solution.
 
 See also the `full description of these drivers`_
 


### PR DESCRIPTION
Previous documentation lacked details about the handling of over- and underdetermined systems, and made incorrect mention of MAGMA.

Fixes #85021
