### PR TITLE
[Checkpoint][2D][2/N] Add traverse for distributed checkpoint to core distributed

### DIFF
--- a/test/distributed/checkpoint/test_traverse.py
+++ b/test/distributed/checkpoint/test_traverse.py
@@ -1,0 +1,348 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+
+from collections import OrderedDict
+import torch
+from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE
+from torch.testing._internal.common_utils import run_tests, TestCase
+import torch.distributed.checkpoint.traverse as tv
+
+
+class TestTraverse(TestCase):
+    def test_traverse_shallow(self) -> None:
+        state_dict = {
+            "key0": 1,
+            "key1": [1, 2],
+            "key2": {1: 2, 2: 3},
+            "key3": torch.tensor([1]),
+        }
+
+        data = {}
+
+        def collect_data(path, value):
+            nonlocal data
+            data[path] = value
+
+        tv.traverse_state_dict(state_dict, collect_data)
+
+        self.assertIn(("key0",), data)
+        self.assertEqual(data[("key0",)], 1)
+
+        self.assertIn(("key1",), data)
+        self.assertEqual(data[("key1",)], [1, 2])
+
+        self.assertIn(("key2",), data)
+        self.assertEqual(data[("key2",)], {1: 2, 2: 3})
+
+        self.assertIn(("key3",), data)
+        self.assertEqual(data[("key3",)], torch.tensor([1]))
+
+    def test_traverse_nested_list(self) -> None:
+        state_dict = {
+            "key1": [
+                torch.tensor([1]),
+                [
+                    33,
+                    torch.tensor([2]),
+                    [44, 55],
+                ],
+                [66, 77],
+            ],
+        }
+
+        data = {}
+
+        def collect_data(path, value):
+            nonlocal data
+            data[path] = value
+
+        tv.traverse_state_dict(state_dict, collect_data)
+
+        self.assertNotIn(("key1",), data)
+
+        self.assertIn(
+            (
+                "key1",
+                0,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key1",
+                    0,
+                )
+            ],
+            torch.tensor([1]),
+        )
+
+        self.assertIn(
+            (
+                "key1",
+                1,
+                0,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key1",
+                    1,
+                    0,
+                )
+            ],
+            33,
+        )
+
+        self.assertIn(
+            (
+                "key1",
+                1,
+                1,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key1",
+                    1,
+                    1,
+                )
+            ],
+            torch.tensor([2]),
+        )
+
+        self.assertIn(
+            (
+                "key1",
+                1,
+                2,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key1",
+                    1,
+                    2,
+                )
+            ],
+            [44, 55],
+        )
+        self.assertNotIn(("key1", 1, 2, 0), data)
+
+        self.assertIn(
+            (
+                "key1",
+                2,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key1",
+                    2,
+                )
+            ],
+            [66, 77],
+        )
+
+    def test_traverse_nested_dict(self) -> None:
+        state_dict = {
+            "key0": {
+                "key1": 99,
+                "key2": torch.tensor([1]),
+            },
+        }
+
+        data = {}
+
+        def collect_data(path, value):
+            nonlocal data
+            data[path] = value
+
+        tv.traverse_state_dict(state_dict, collect_data)
+
+        self.assertNotIn(("key0",), data)
+
+        self.assertIn(
+            (
+                "key0",
+                "key1",
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key0",
+                    "key1",
+                )
+            ],
+            99,
+        )
+
+        self.assertIn(
+            (
+                "key0",
+                "key2",
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key0",
+                    "key2",
+                )
+            ],
+            torch.tensor([1]),
+        )
+
+    def test_traverse_doesnt_ignore_intermediate_collections(self) -> None:
+        state_dict: STATE_DICT_TYPE = {
+            "key0": [{"key1": {"key2": torch.tensor([1])}}]
+        }
+
+        data = {}
+
+        def collect_data(path, value):
+            nonlocal data
+            data[path] = value
+
+        tv.traverse_state_dict(state_dict, collect_data)
+
+        self.assertIn(
+            (
+                "key0",
+                0,
+                "key1",
+                "key2",
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key0",
+                    0,
+                    "key1",
+                    "key2",
+                )
+            ],
+            torch.tensor([1]),
+        )
+
+    def test_traverse_with_ordered_dict(self) -> None:
+        state_dict = OrderedDict(
+            {
+                "key0": [
+                    99,
+                    torch.tensor([3]),
+                ]
+            }
+        )
+
+        data = {}
+
+        def collect_data(path, value):
+            nonlocal data
+            data[path] = value
+
+        tv.traverse_state_dict(state_dict, collect_data)
+
+        self.assertIn(
+            (
+                "key0",
+                0,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key0",
+                    0,
+                )
+            ],
+            99,
+        )
+
+        self.assertIn(
+            (
+                "key0",
+                1,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key0",
+                    1,
+                )
+            ],
+            torch.tensor([3]),
+        )
+
+    def test_set_element(self) -> None:
+        state_dict: STATE_DICT_TYPE = {}
+
+        tv.set_element(state_dict, ("k",), 10)
+        self.assertEqual(state_dict["k"], 10)
+
+        tv.set_element(state_dict, ("k1", 2), 1)
+        self.assertEqual(state_dict["k1"], [None, None, 1])
+
+        tv.set_element(state_dict, ("k1", 1), 99)
+        self.assertEqual(state_dict["k1"], [None, 99, 1])
+
+        tv.set_element(state_dict, ("k1", 3), 88)
+        self.assertEqual(state_dict["k1"], [None, 99, 1, 88])
+
+        tv.set_element(state_dict, ("k2", "k3"), 3)
+        self.assertEqual(state_dict["k2"], {"k3": 3})
+
+        tv.set_element(state_dict, ("k2", "k4", 0, 0), 99)
+        self.assertEqual(state_dict["k2"]["k4"][0], [99])
+
+    def test_get_element(self) -> None:
+        state_dict = {"a": [0, 1], "b": [2, {"c": "d"}]}
+        self.assertEqual(tv.get_element(state_dict, ("a",)), [0, 1])
+        self.assertEqual(
+            tv.get_element(
+                state_dict,
+                (
+                    "b",
+                    0,
+                ),
+            ),
+            2,
+        )
+        self.assertEqual(
+            tv.get_element(
+                state_dict,
+                (
+                    "b",
+                    1,
+                    "c",
+                ),
+            ),
+            "d",
+        )
+
+        self.assertIsNone(tv.get_element(state_dict, ("c",)))
+        self.assertIsNone(tv.get_element(state_dict, ("a", 33)))
+        self.assertIsNone(tv.get_element(state_dict, ("b", 88)))
+        self.assertIsNone(tv.get_element(state_dict, ("b", 0, 2)))
+        self.assertIsNone(tv.get_element(state_dict, ("b", 1, 2)))
+        self.assertIsNone(tv.get_element(state_dict, ("b", 1, "d")))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/checkpoint/test_traverse.py
+++ b/test/distributed/checkpoint/test_traverse.py
@@ -42,11 +42,7 @@ class TestTraverse(TestCase):
         state_dict = {
             "key1": [
                 torch.tensor([1]),
-                [
-                    33,
-                    torch.tensor([2]),
-                    [44, 55],
-                ],
+                [33, torch.tensor([2]), [44, 55]],
                 [66, 77],
             ],
         }
@@ -75,17 +71,11 @@ class TestTraverse(TestCase):
         self.assertNotIn(("key1", 1, 2, 0), data)
 
         self.assertIn(("key1", 2), data)
-        self.assertEqual(
-            data[("key1", 2)],
-            [66, 77],
-        )
+        self.assertEqual(data[("key1", 2)], [66, 77])
 
     def test_traverse_nested_dict(self) -> None:
         state_dict = {
-            "key0": {
-                "key1": 99,
-                "key2": torch.tensor([1]),
-            },
+            "key0": {"key1": 99, "key2": torch.tensor([1])},
         }
 
         data = {}

--- a/test/distributed/checkpoint/test_traverse.py
+++ b/test/distributed/checkpoint/test_traverse.py
@@ -3,9 +3,10 @@
 from collections import OrderedDict
 import torch
 
-import torch.distributed.checkpoint.traverse as tv
+import torch.distributed.checkpoint.traverse as traverse
 from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE
 from torch.testing._internal.common_utils import run_tests, TestCase
+
 
 # TODO: add comments for TestTraverse
 class TestTraverse(TestCase):
@@ -23,7 +24,7 @@ class TestTraverse(TestCase):
             nonlocal data
             data[path] = value
 
-        tv.traverse_state_dict(state_dict, collect_data)
+        traverse.traverse_state_dict(state_dict, collect_data)
 
         self.assertIn(("key0",), data)
         self.assertEqual(data[("key0",)], 1)
@@ -56,99 +57,26 @@ class TestTraverse(TestCase):
             nonlocal data
             data[path] = value
 
-        tv.traverse_state_dict(state_dict, collect_data)
+        traverse.traverse_state_dict(state_dict, collect_data)
 
-        self.assertNotIn(("key1",), data)
+        self.assertNotIn(("key1"), data)
 
-        self.assertIn(
-            (
-                "key1",
-                0,
-            ),
-            data,
-        )
-        self.assertEqual(
-            data[
-                (
-                    "key1",
-                    0,
-                )
-            ],
-            torch.tensor([1]),
-        )
+        self.assertIn(("key1", 0), data)
+        self.assertEqual(data[("key1", 0)], torch.tensor([1]))
 
-        self.assertIn(
-            (
-                "key1",
-                1,
-                0,
-            ),
-            data,
-        )
-        self.assertEqual(
-            data[
-                (
-                    "key1",
-                    1,
-                    0,
-                )
-            ],
-            33,
-        )
+        self.assertIn(("key1", 1, 0), data)
+        self.assertEqual(data[("key1", 1, 0)], 33)
 
-        self.assertIn(
-            (
-                "key1",
-                1,
-                1,
-            ),
-            data,
-        )
-        self.assertEqual(
-            data[
-                (
-                    "key1",
-                    1,
-                    1,
-                )
-            ],
-            torch.tensor([2]),
-        )
+        self.assertIn(("key1", 1, 1), data)
+        self.assertEqual(data[("key1", 1, 1)], torch.tensor([2]))
 
-        self.assertIn(
-            (
-                "key1",
-                1,
-                2,
-            ),
-            data,
-        )
-        self.assertEqual(
-            data[
-                (
-                    "key1",
-                    1,
-                    2,
-                )
-            ],
-            [44, 55],
-        )
+        self.assertIn(("key1", 1, 2), data)
+        self.assertEqual(data[("key1", 1, 2)], [44, 55])
         self.assertNotIn(("key1", 1, 2, 0), data)
 
-        self.assertIn(
-            (
-                "key1",
-                2,
-            ),
-            data,
-        )
+        self.assertIn(("key1", 2), data)
         self.assertEqual(
-            data[
-                (
-                    "key1",
-                    2,
-                )
-            ],
+            data[("key1", 2)],
             [66, 77],
         )
 
@@ -166,43 +94,15 @@ class TestTraverse(TestCase):
             nonlocal data
             data[path] = value
 
-        tv.traverse_state_dict(state_dict, collect_data)
+        traverse.traverse_state_dict(state_dict, collect_data)
 
         self.assertNotIn(("key0",), data)
 
-        self.assertIn(
-            (
-                "key0",
-                "key1",
-            ),
-            data,
-        )
-        self.assertEqual(
-            data[
-                (
-                    "key0",
-                    "key1",
-                )
-            ],
-            99,
-        )
+        self.assertIn(("key0", "key1"), data)
+        self.assertEqual(data[("key0", "key1")], 99)
 
-        self.assertIn(
-            (
-                "key0",
-                "key2",
-            ),
-            data,
-        )
-        self.assertEqual(
-            data[
-                (
-                    "key0",
-                    "key2",
-                )
-            ],
-            torch.tensor([1]),
-        )
+        self.assertIn(("key0", "key2"), data)
+        self.assertEqual(data[("key0", "key2")], torch.tensor([1]))
 
     def test_traverse_doesnt_ignore_intermediate_collections(self) -> None:
         state_dict: STATE_DICT_TYPE = {
@@ -215,26 +115,11 @@ class TestTraverse(TestCase):
             nonlocal data
             data[path] = value
 
-        tv.traverse_state_dict(state_dict, collect_data)
+        traverse.traverse_state_dict(state_dict, collect_data)
 
-        self.assertIn(
-            (
-                "key0",
-                0,
-                "key1",
-                "key2",
-            ),
-            data,
-        )
+        self.assertIn(("key0", 0, "key1", "key2"), data)
         self.assertEqual(
-            data[
-                (
-                    "key0",
-                    0,
-                    "key1",
-                    "key2",
-                )
-            ],
+            data[("key0", 0, "key1", "key2")],
             torch.tensor([1]),
         )
 
@@ -254,94 +139,47 @@ class TestTraverse(TestCase):
             nonlocal data
             data[path] = value
 
-        tv.traverse_state_dict(state_dict, collect_data)
+        traverse.traverse_state_dict(state_dict, collect_data)
 
-        self.assertIn(
-            (
-                "key0",
-                0,
-            ),
-            data,
-        )
-        self.assertEqual(
-            data[
-                (
-                    "key0",
-                    0,
-                )
-            ],
-            99,
-        )
+        self.assertIn(("key0", 0), data)
+        self.assertEqual(data[("key0", 0)], 99)
 
-        self.assertIn(
-            (
-                "key0",
-                1,
-            ),
-            data,
-        )
-        self.assertEqual(
-            data[
-                (
-                    "key0",
-                    1,
-                )
-            ],
-            torch.tensor([3]),
-        )
+        self.assertIn(("key0", 1), data)
+        self.assertEqual(data[("key0", 1)], torch.tensor([3]))
 
     def test_set_element(self) -> None:
         state_dict: STATE_DICT_TYPE = {}
 
-        tv.set_element(state_dict, ("k",), 10)
+        traverse.set_element(state_dict, ("k",), 10)
         self.assertEqual(state_dict["k"], 10)
 
-        tv.set_element(state_dict, ("k1", 2), 1)
+        traverse.set_element(state_dict, ("k1", 2), 1)
         self.assertEqual(state_dict["k1"], [None, None, 1])
 
-        tv.set_element(state_dict, ("k1", 1), 99)
+        traverse.set_element(state_dict, ("k1", 1), 99)
         self.assertEqual(state_dict["k1"], [None, 99, 1])
 
-        tv.set_element(state_dict, ("k1", 3), 88)
+        traverse.set_element(state_dict, ("k1", 3), 88)
         self.assertEqual(state_dict["k1"], [None, 99, 1, 88])
 
-        tv.set_element(state_dict, ("k2", "k3"), 3)
+        traverse.set_element(state_dict, ("k2", "k3"), 3)
         self.assertEqual(state_dict["k2"], {"k3": 3})
 
-        tv.set_element(state_dict, ("k2", "k4", 0, 0), 99)
+        traverse.set_element(state_dict, ("k2", "k4", 0, 0), 99)
         self.assertEqual(state_dict["k2"]["k4"][0], [99])
 
     def test_get_element(self) -> None:
         state_dict = {"a": [0, 1], "b": [2, {"c": "d"}]}
-        self.assertEqual(tv.get_element(state_dict, ("a",)), [0, 1])
-        self.assertEqual(
-            tv.get_element(
-                state_dict,
-                (
-                    "b",
-                    0,
-                ),
-            ),
-            2,
-        )
-        self.assertEqual(
-            tv.get_element(
-                state_dict,
-                (
-                    "b",
-                    1,
-                    "c",
-                ),
-            ),
-            "d",
-        )
+        self.assertEqual(traverse.get_element(state_dict, ("a",)), [0, 1])
+        self.assertEqual(traverse.get_element(state_dict, ("b", 0)), 2)
+        self.assertEqual(traverse.get_element(state_dict, ("b", 1, "c")), "d")
 
-        self.assertIsNone(tv.get_element(state_dict, ("c",)))
-        self.assertIsNone(tv.get_element(state_dict, ("a", 33)))
-        self.assertIsNone(tv.get_element(state_dict, ("b", 88)))
-        self.assertIsNone(tv.get_element(state_dict, ("b", 0, 2)))
-        self.assertIsNone(tv.get_element(state_dict, ("b", 1, 2)))
-        self.assertIsNone(tv.get_element(state_dict, ("b", 1, "d")))
+        self.assertIsNone(traverse.get_element(state_dict, ("c",)))
+        self.assertIsNone(traverse.get_element(state_dict, ("a", 33)))
+        self.assertIsNone(traverse.get_element(state_dict, ("b", 88)))
+        self.assertIsNone(traverse.get_element(state_dict, ("b", 0, 2)))
+        self.assertIsNone(traverse.get_element(state_dict, ("b", 1, 2)))
+        self.assertIsNone(traverse.get_element(state_dict, ("b", 1, "d")))
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_traverse.py
+++ b/test/distributed/checkpoint/test_traverse.py
@@ -8,6 +8,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 import torch.distributed.checkpoint.traverse as tv
 
 
+# TODO: add comments for TestTraverse
 class TestTraverse(TestCase):
     def test_traverse_shallow(self) -> None:
         state_dict = {

--- a/test/distributed/checkpoint/test_traverse.py
+++ b/test/distributed/checkpoint/test_traverse.py
@@ -1,12 +1,11 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates
-
+# Owner(s): ["oncall: distributed"]
 
 from collections import OrderedDict
 import torch
+
+import torch.distributed.checkpoint.traverse as tv
 from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE
 from torch.testing._internal.common_utils import run_tests, TestCase
-import torch.distributed.checkpoint.traverse as tv
-
 
 # TODO: add comments for TestTraverse
 class TestTraverse(TestCase):

--- a/torch/distributed/checkpoint/traverse.py
+++ b/torch/distributed/checkpoint/traverse.py
@@ -17,7 +17,7 @@ from torch.distributed.checkpoint.metadata import (
     STATE_DICT_TYPE,
 )
 from torch.distributed._shard.sharded_tensor.api import ShardedTensor
-from torch.distributed._tensor import DTensor as DT
+from torch.distributed._tensor import DTensor
 
 PATH_ITEM = Union[str, int]
 OBJ_PATH = Tuple[PATH_ITEM, ...]
@@ -152,12 +152,12 @@ def _print_nested(
                 f"{shard.metadata.shard_offsets} ",
                 print_fun=print_fun,
             )
-    elif type(value) is (DT):
+    elif type(value) is (DTensor):
         print_fun(f"{padding}{prefix} DistributedTensor size {value.size()}")
+        # TODO: add local offset for _local_tensor in print_nested.
         _print_nested(
             value._local_tensor,
             f"{padding}\t",
-            "(offset ???) ",
             print_fun=print_fun,
         )
     elif isinstance(value, torch.Tensor):

--- a/torch/distributed/checkpoint/traverse.py
+++ b/torch/distributed/checkpoint/traverse.py
@@ -1,0 +1,178 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import torch
+
+from typing import (
+    Callable,
+    Collection,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+from torch.distributed.checkpoint.metadata import (
+    STATE_DICT_TYPE,
+)
+from torch.distributed._shard.sharded_tensor.api import ShardedTensor
+from torch.distributed._tensor import DTensor as DT
+
+PATH_ITEM = Union[str, int]
+OBJ_PATH = Tuple[PATH_ITEM, ...]
+T = TypeVar("T")
+
+STATE_DICT_ITEM = object
+CONTAINER_TYPE = MutableMapping[PATH_ITEM, STATE_DICT_ITEM]
+
+__all__ = ["traverse_state_dict", "set_element", "get_element", "print_tensor"]
+
+
+def _keep_visiting_tensors(value: STATE_DICT_ITEM) -> bool:
+    return isinstance(value, torch.Tensor)
+
+
+def traverse_state_dict(
+    state_dict: STATE_DICT_TYPE,
+    visitor: Callable[[OBJ_PATH, STATE_DICT_ITEM], None],
+    keep_traversing: Callable[[STATE_DICT_ITEM], bool] = _keep_visiting_tensors,
+) -> None:
+    """
+    Invoke ``visitor`` for each value recursively in ``state_dict``.
+    Traversal is short-circuited when if finds a collection for which ``keep_visiting_tensors`` evaluates
+    to false for all elements.
+    By default, all collections with at least one ``torch.Tensor`` element are traversed.
+    Visitor takes a path argument that is a tuple of the keys used to reach it.
+    """
+    # a value is terminal if it has no other containers values inside it
+    def _is_terminal(value: STATE_DICT_ITEM) -> bool:
+        values: Collection[STATE_DICT_ITEM]
+        if isinstance(value, Mapping):
+            values = value.values()
+        elif isinstance(value, list):
+            values = value
+        else:
+            return True
+
+        for entry in values:
+            if isinstance(
+                entry,
+                (
+                    Mapping,
+                    list,
+                ),
+            ) and not _is_terminal(entry):
+                return False
+            if keep_traversing is not None and keep_traversing(entry):
+                return False
+        return True
+
+    def _traverse_obj(path: OBJ_PATH, value: STATE_DICT_ITEM) -> None:
+        if _is_terminal(value):
+            visitor(path, value)
+        elif isinstance(value, Mapping):
+            for k, v in value.items():
+                _traverse_obj(path + (str(k),), v)
+        elif isinstance(value, list):
+            for i, v in enumerate(value):
+                _traverse_obj(path + (i,), v)
+
+    for key, value in state_dict.items():
+        _traverse_obj((str(key),), value)
+
+
+def set_element(
+    root_dict: STATE_DICT_TYPE, path: OBJ_PATH, value: STATE_DICT_ITEM
+) -> None:
+    """
+    Set ``value`` in ``root_dict`` along the ``path`` object path.
+    """
+    cur_container = cast(CONTAINER_TYPE, root_dict)
+
+    def extend_list(lst: List[STATE_DICT_ITEM], idx: int) -> None:
+        while len(lst) <= idx:
+            lst.append(None)
+
+    for i in range(1, len(path)):
+        prev_key = path[i - 1]
+        key = path[i]
+        def_val = cast(STATE_DICT_ITEM, {} if type(key) == str else [])
+
+        if isinstance(cur_container, Mapping):
+            cur_container = cast(
+                CONTAINER_TYPE, cur_container.setdefault(prev_key, def_val)
+            )
+        else:
+            extend_list(cur_container, prev_key)  # type: ignore
+            if cur_container[prev_key] is None:
+                cur_container[prev_key] = def_val
+            cur_container = cur_container[prev_key]  # type: ignore
+
+    key = path[-1]
+    if type(key) == int:
+        extend_list(cast(List[STATE_DICT_ITEM], cur_container), key)
+
+    cur_container[key] = value
+
+
+def get_element(
+    root_dict: STATE_DICT_TYPE,
+    path: OBJ_PATH,
+    default_value: Optional[T] = None,
+) -> Optional[T]:
+    """
+    Retrieve the value at ``path``from ``root_dict``, returning ``default_value`` if not found.
+    """
+    cur_value = cast(CONTAINER_TYPE, root_dict)
+    for part in path:
+        if type(part) is int:
+            if not isinstance(cur_value, list) or len(cur_value) < part:
+                return default_value
+        elif not isinstance(cur_value, Mapping) or part not in cur_value:
+            return default_value
+
+        cur_value = cast(CONTAINER_TYPE, cur_value[part])
+    return cast(Optional[T], cur_value)
+
+
+def _print_nested(
+    value: STATE_DICT_ITEM,
+    padding: str = "",
+    prefix: str = "",
+    print_fun: Callable[[str], None] = print,
+) -> None:
+    if type(value) is ShardedTensor:
+        print_fun(f"{padding}{prefix} ShardedTensor size {value.size()}")
+        for shard in value.local_shards():
+            _print_nested(
+                shard.tensor,
+                f"{padding}\t",
+                f"{shard.metadata.shard_offsets} ",
+                print_fun=print_fun,
+            )
+    elif type(value) is (DT):
+        print_fun(f"{padding}{prefix} DistributedTensor size {value.size()}")
+        _print_nested(
+            value._local_tensor,
+            f"{padding}\t",
+            "(offset ???) ",
+            print_fun=print_fun,
+        )
+    elif isinstance(value, torch.Tensor):
+        print_fun(f"{padding}{prefix} Tensor size {value.size()}")
+    else:
+        print_fun(f"{padding}{prefix} Type {type(value)}")
+
+
+def print_tensor(
+    path: OBJ_PATH,
+    value: STATE_DICT_ITEM,
+    print_fun: Callable[[str], None] = print,
+) -> None:
+    """
+    Callback that can be used with travese_state_dict to print its content.
+    By default the content is printed using the builtin ``print`` but this can
+    be change by passing a different ``print_fun` callable.
+    """
+    _print_nested(value, prefix=str(path), print_fun=print_fun)

--- a/torch/distributed/checkpoint/traverse.py
+++ b/torch/distributed/checkpoint/traverse.py
@@ -105,10 +105,10 @@ def set_element(
                 CONTAINER_TYPE, cur_container.setdefault(prev_key, def_val)
             )
         else:
-            extend_list(cur_container, prev_key)  # type: ignore
+            extend_list(cur_container, prev_key)
             if cur_container[prev_key] is None:
                 cur_container[prev_key] = def_val
-            cur_container = cur_container[prev_key]  # type: ignore
+            cur_container = cur_container[prev_key]
 
     key = path[-1]
     if type(key) == int:

--- a/torch/distributed/checkpoint/traverse.py
+++ b/torch/distributed/checkpoint/traverse.py
@@ -133,31 +133,28 @@ def get_element(
 
 def _print_nested(
     value: STATE_DICT_ITEM,
-    padding: str = "",
     prefix: str = "",
     print_fun: Callable[[str], None] = print,
 ) -> None:
     if type(value) is ShardedTensor:
-        print_fun(f"{padding}{prefix} ShardedTensor size {value.size()}")
+        print_fun(f"{prefix} ShardedTensor size: {value.size()}")
         for shard in value.local_shards():
             _print_nested(
                 shard.tensor,
-                f"{padding}\t",
                 f"{shard.metadata.shard_offsets} ",
                 print_fun=print_fun,
             )
     elif type(value) is (DTensor):
-        print_fun(f"{padding}{prefix} DistributedTensor size {value.size()}")
+        print_fun(f"{prefix} DistributedTensor size: {value.size()}")
         # TODO: add local offset for _local_tensor in print_nested.
         _print_nested(
             value._local_tensor,
-            f"{padding}\t",
             print_fun=print_fun,
         )
     elif isinstance(value, torch.Tensor):
-        print_fun(f"{padding}{prefix} Tensor size {value.size()}")
+        print_fun(f"{prefix} Tensor size: {value.size()}")
     else:
-        print_fun(f"{padding}{prefix} Type {type(value)}")
+        print_fun(f"{prefix} Type: {type(value)}")
 
 
 def print_tensor(

--- a/torch/distributed/checkpoint/traverse.py
+++ b/torch/distributed/checkpoint/traverse.py
@@ -33,7 +33,7 @@ def _keep_visiting_tensors(value: STATE_DICT_ITEM) -> bool:
     return isinstance(value, torch.Tensor)
 
 
-# update docstring for traverse.py
+# TODO: update docstring for traverse.py
 def traverse_state_dict(
     state_dict: STATE_DICT_TYPE,
     visitor: Callable[[OBJ_PATH, STATE_DICT_ITEM], None],

--- a/torch/distributed/checkpoint/traverse.py
+++ b/torch/distributed/checkpoint/traverse.py
@@ -57,13 +57,7 @@ def traverse_state_dict(
             return True
 
         for entry in values:
-            if isinstance(
-                entry,
-                (
-                    Mapping,
-                    list,
-                ),
-            ) and not _is_terminal(entry):
+            if isinstance(entry, (Mapping, list)) and not _is_terminal(entry):
                 return False
             if keep_traversing is not None and keep_traversing(entry):
                 return False

--- a/torch/distributed/checkpoint/traverse.py
+++ b/torch/distributed/checkpoint/traverse.py
@@ -33,6 +33,7 @@ def _keep_visiting_tensors(value: STATE_DICT_ITEM) -> bool:
     return isinstance(value, torch.Tensor)
 
 
+# update docstring for traverse.py
 def traverse_state_dict(
     state_dict: STATE_DICT_TYPE,
     visitor: Callable[[OBJ_PATH, STATE_DICT_ITEM], None],


### PR DESCRIPTION
This PR moves traverse and its test to torch.distributed.checkpoint. This is a pre-req for enabling 2D checkpoint.

This is used when flatten nested dict and flatten sharded tensors. 

Docstring and comments will be added in the following PRs.

Test:
```
python3 test/distributed/_tensor/parallel/test_2d_parallel.py
```
and CI