### PR TITLE
[Checkpoint][2D][1/N] Add dedup_tensors for distributed checkpoint to core distributed

### DIFF
--- a/test/distributed/checkpoint/test_dedup_tensors.py
+++ b/test/distributed/checkpoint/test_dedup_tensors.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates
+# Owner(s): ["oncall: distributed"]
 
 import dataclasses
 import torch
@@ -7,7 +7,7 @@ from torch.distributed.checkpoint.planner_helpers import (
     _create_write_item_for_tensor,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
-from spmd.checkpoint import dedup_tensors
+from torch.distributed.checkpoint import dedup_tensors
 
 
 # TODO: add comments for create_plan

--- a/test/distributed/checkpoint/test_dedup_tensors.py
+++ b/test/distributed/checkpoint/test_dedup_tensors.py
@@ -2,12 +2,12 @@
 
 import dataclasses
 import torch
+from torch.distributed.checkpoint.dedup_tensors import dedup_tensors
 from torch.distributed.checkpoint.planner import SavePlan, WriteItemType
 from torch.distributed.checkpoint.planner_helpers import (
     _create_write_item_for_tensor,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
-from torch.distributed.checkpoint import dedup_tensors
 
 
 # TODO: add comments for create_plan

--- a/test/distributed/checkpoint/test_dedup_tensors.py
+++ b/test/distributed/checkpoint/test_dedup_tensors.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+import dataclasses
+import torch
+from torch.distributed.checkpoint.planner import SavePlan, WriteItemType
+from torch.distributed.checkpoint.planner_helpers import (
+    _create_write_item_for_tensor,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+from spmd.checkpoint import dedup_tensors
+
+
+# TODO: add comments for create_plan
+def create_plan(second_fqn) -> SavePlan:
+    # the first write item is for a duplicated shard (that covers the whole tensor)
+    write_item_1 = _create_write_item_for_tensor("tensor_0", torch.rand(4))
+    write_item_1 = dataclasses.replace(write_item_1, type=WriteItemType.SHARD)
+
+    # the second write item has different keys
+    write_item_2 = _create_write_item_for_tensor(second_fqn, torch.rand(10))
+
+    return SavePlan([write_item_1, write_item_2])
+
+
+# TODO: add comments for TestDedupTensor
+class TestDedupTensor(TestCase):
+    def test_dedup_shards(self):
+        rank0 = create_plan("r0")
+        rank1 = create_plan("r1")
+
+        dedup_plans = dedup_tensors([rank0, rank1])
+
+        self.assertEqual(2, len(dedup_plans[0].items))
+        self.assertEqual(1, len(dedup_plans[1].items))
+
+        self.assertIn(
+            "tensor_0", (item.index.fqn for item in dedup_plans[0].items)
+        )
+        self.assertIn("r0", (item.index.fqn for item in dedup_plans[0].items))
+
+        self.assertIn("r1", (item.index.fqn for item in dedup_plans[1].items))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/checkpoint/__init__.py
+++ b/torch/distributed/checkpoint/__init__.py
@@ -19,3 +19,5 @@ from .planner import (
     ReadItem,
     WriteItem,
 )
+
+from .dedup_tensors import dedup_tensors

--- a/torch/distributed/checkpoint/__init__.py
+++ b/torch/distributed/checkpoint/__init__.py
@@ -19,5 +19,3 @@ from .planner import (
     ReadItem,
     WriteItem,
 )
-
-from .dedup_tensors import dedup_tensors

--- a/torch/distributed/checkpoint/dedup_tensors.py
+++ b/torch/distributed/checkpoint/dedup_tensors.py
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+from typing import Dict, List
+import dataclasses
+
+from torch.distributed.checkpoint.metadata import MetadataIndex
+from torch.distributed.checkpoint.planner import SavePlan
+
+__all__ = ["dedup_tensors"]
+
+# TODO add docstring for dedup_tensors
+def dedup_tensors(all_plans: List[SavePlan]) -> List[SavePlan]:
+    all_plans = list(all_plans)
+    key_to_plan: Dict[MetadataIndex, List[int]] = {}
+    for plan_idx, plan in enumerate(all_plans):
+        for wi in plan.items:
+            key_to_plan.setdefault(wi.index, []).append(plan_idx)
+
+    replicated_items = {k: v for k, v in key_to_plan.items() if len(v) > 1}
+
+    # Remove deplicates by always keeping the first entry.
+    # Compute the per-rank remove set.
+    plan_to_keys: Dict[int, List[MetadataIndex]] = {}
+    for key, plans in replicated_items.items():
+        for plan_idx in plans[1:]:
+            plan_to_keys.setdefault(plan_idx, []).append(key)
+
+    for plan_idx, keys in plan_to_keys.items():
+        key_set = set(keys)
+        # rewrite items and remove elements
+        new_items = [
+            wi for wi in all_plans[plan_idx].items if wi.index not in key_set
+        ]
+        all_plans[plan_idx] = dataclasses.replace(
+            all_plans[plan_idx], items=new_items
+        )
+
+    return all_plans


### PR DESCRIPTION
This PR moves dedup_tensors and its test to torch.distributed.checkpoint. This is a pre-req for enabling 2D checkpoint.

This removes duplicated shards in list of SavePlan. It is used when saving DT with replicated placement. 

Docstring and comments will be added in the following PRs.