### PR TITLE
Tracking block padding when doing allocation tracing

### DIFF
--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -154,18 +154,23 @@ struct TraceEntry {
       Action action,
       int64_t addr,
       size_t size,
+      size_t rounded_by,
       cudaStream_t stream,
       std::shared_ptr<GatheredContext> context = nullptr)
       : action_(action),
         addr_(addr),
         context_(std::move(context)),
         stream_(stream),
-        size_(size) {}
+        size_(size),
+        rounded_by_(rounded_by) {}
   Action action_;
   int64_t addr_; // for OOM, this is the amount of free bytes reported by cuda
   std::shared_ptr<GatheredContext> context_;
   cudaStream_t stream_;
   int64_t size_;
+  int64_t rounded_by_; // currently only used by ALLOC and FREE_REQUESTED to
+                       // determine block padding as opposed to size_ which
+                       // measures the original size requested
 };
 
 struct SnapshotInfo {

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -800,6 +800,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
   py::str large_s = "large";
   py::str small_s = "small";
   py::str size_s = "size";
+  py::str rounded_by_s = "rounded_by";
   py::str state_s = "state";
   py::str active_allocated_s = "active_allocated";
   py::str active_pending_free_s = "active_pending_free";
@@ -910,6 +911,7 @@ PyObject* THCPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
       trace_entry[TraceEntry::OOM == te.action_ ? device_free_s : addr_s] =
           te.addr_;
       trace_entry[size_s] = te.size_;
+      trace_entry[rounded_by_s] = te.rounded_by_;
       trace_entry[stream_s] = int64_t(te.stream_);
       trace.append(trace_entry);
     }

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -51,6 +51,7 @@ std::string _memory_snapshot_pickled() {
   IValue large_s = "large";
   IValue small_s = "small";
   IValue size_s = "size";
+  IValue rounded_by_s = "rounded_by";
   IValue state_s = "state";
   IValue active_allocated_s = "active_allocated";
   IValue active_pending_free_s = "active_pending_free";
@@ -159,6 +160,7 @@ std::string _memory_snapshot_pickled() {
       trace_entry.insert(
           TraceEntry::OOM == te.action_ ? device_free_s : addr_s, te.addr_);
       trace_entry.insert(size_s, (int64_t)te.size_);
+      trace_entry.insert(rounded_by_s, (int64_t)te.rounded_by_);
       trace_entry.insert(stream_s, int64_t(te.stream_));
       trace.push_back(trace_entry);
     }


### PR DESCRIPTION
Summary:
Currently CUDACachingAllocator tracing records logical sizes for allocations(i.e. the amount of bytes that are being requested by the application). We would like record however the block size as well to show padding from the allocator.

For example the following can be sources of padding:
1) Rounding
https://github.com/pytorch/pytorch/blob/6796979ee1063890fd04bbf21f298f669129df8f/c10/cuda/CUDACachingAllocator.cpp#LL1293-L1304C4

2) As well as further padding when doing new allocations(rounding to kSmallBuffer and kRoundLarge):
https://github.com/pytorch/pytorch/blob/6796979ee1063890fd04bbf21f298f669129df8f/c10/cuda/CUDACachingAllocator.cpp#LL1538-L1546C3

3) When blocks are not being split:
https://github.com/pytorch/pytorch/blob/6796979ee1063890fd04bbf21f298f669129df8f/c10/cuda/CUDACachingAllocator.cpp#LL1528-L1536C4

Test Plan: Added test in test_cuda.py

Differential Revision: D41374700

