### PR TITLE
[xnnpack][lite-int] Handle Constant Data

### DIFF
--- a/test/jit/xnnpack/test_xnnpack_delegate.py
+++ b/test/jit/xnnpack/test_xnnpack_delegate.py
@@ -8,6 +8,34 @@ import torch._C
 torch.ops.load_library("//caffe2:xnnpack_backend")
 
 class TestXNNPackBackend(unittest.TestCase):
+    def test_xnnpack_constant_data(self):
+        class Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._constant = torch.ones(4, 4, 4)
+
+            def forward(self, x):
+                return x + self._constant
+
+        scripted_module = torch.jit.script(Module())
+
+        lowered_module = torch._C._jit_to_backend(
+            "xnnpack",
+            scripted_module,
+            {
+                "forward": {
+                    "inputs" : [torch.randn(4, 4, 4)],
+                    "outputs": [torch.randn(4, 4, 4)]
+                }
+            }
+        )
+
+        for i in range(0, 20):
+            sample_input = torch.randn(4, 4, 4)
+            actual_output = scripted_module(sample_input)
+            expected_output = lowered_module(sample_input)
+            self.assertTrue(torch.allclose(actual_output, expected_output, atol=1e-03, rtol=1e-03))
+
     def test_xnnpack_lowering(self):
         class Module(torch.nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
@@ -51,8 +51,8 @@ void XNNCompiler::compileModel(
         const auto& constant_buffer = *flatbuffer_graph->constant_buffer();
         auto buffer_idx = tensor_value->constant_buffer_idx();
         const auto buffer_ptr = buffer_idx == 0
-                ? nullptr
-                : constant_buffer[buffer_idx]->storage()->data();
+            ? nullptr
+            : constant_buffer[buffer_idx]->storage()->data();
         status = xnn_define_tensor_value(
             /*subgraph=*/subgraph_ptr,
             /*datatype=*/xnn_datatype_fp32,

--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
@@ -42,24 +42,23 @@ void XNNCompiler::compileModel(
       case fb_xnnpack::XValueUnion::XNNTensorValue: {
         auto tensor_value = value->xvalue_as_XNNTensorValue();
 
-        const void* data_ptr = nullptr;
-        auto buffer_idx = tensor_value->constant_buffer_idx();
-        if (buffer_idx != 0) {
-          // TODO: @maxren implement data handling
-          TORCH_CHECK(false, "Constant data handling not yet implemented")
-        }
         std::vector<size_t> dims_data;
         for (auto dim : *tensor_value->dims()) {
           dims_data.push_back(static_cast<size_t>(dim));
         }
 
         uint32_t id = XNN_INVALID_VALUE_ID;
+        const auto& constant_buffer = *flatbuffer_graph->constant_buffer();
+        auto buffer_idx = tensor_value->constant_buffer_idx();
+        const auto buffer_ptr = buffer_idx == 0
+                ? nullptr
+                : constant_buffer[buffer_idx]->storage()->data();
         status = xnn_define_tensor_value(
             /*subgraph=*/subgraph_ptr,
             /*datatype=*/xnn_datatype_fp32,
             /*num_dims=*/tensor_value->num_dims(),
             /*dims=*/dims_data.data(),
-            /*data=*/data_ptr,
+            /*data=*/buffer_ptr,
             /*external_id=*/tensor_value->external_id(),
             /*flags=*/tensor_value->flags(),
             /*id_out=*/&id);

--- a/torch/csrc/jit/backends/xnnpack/serialization/serializer.cpp
+++ b/torch/csrc/jit/backends/xnnpack/serialization/serializer.cpp
@@ -24,26 +24,33 @@ void XNNSerializer::serializeAddNode(
   _nodes.push_back(flatbufferNode);
 }
 
+size_t XNNSerializer::serializeData(const uint8_t* data_ptr, size_t num_bytes) {
+  size_t constant_buffer_idx = 0;
+  // Handling the tensor _values with data
+  if (data_ptr != nullptr) {
+    // steps:
+    // 1. creating flatbuffer byte-vector for tensor data
+    auto storage = _builder.CreateVector(data_ptr, num_bytes);
+
+    // 2. put it in the common buffer
+    constant_buffer_idx = _constantBuffer.size();
+    _constantBuffer.emplace_back(CreateBuffer(_builder, storage));
+
+    // 3. record size into bufferSizes
+    _bufferSizes.push_back(num_bytes);
+    assert(_bufferSizes.size() == _constantBuffer.size());
+  }
+  return constant_buffer_idx;
+}
+
 void XNNSerializer::serializeTensorValue(
     uint32_t xnn_datatype,
     size_t num_dims,
     std::vector<size_t> dims,
-    void* data,
+    size_t data_buffer_idx,
     uint32_t external_id,
     uint32_t flags,
     uint32_t id_out) {
-  // we will reserve buffers without data to index 0
-  int constant_buffer_idx = 0;
-  // Handling the tensor _values with data
-  // TODO @maxren fill out when handling tensors with data
-  if (data != nullptr) {
-    assert(false); // not supported yet
-    // steps:
-    // 1. creating buffer to store the 16 bit aligned data
-    // 2. increment buffer_idx, to reflect no buffer being added
-    // 3. record size into bufferSizes
-  }
-
   std::vector<uint32_t> serialized_dims;
   serialized_dims.reserve(dims.size());
   for (auto dim : dims) {
@@ -55,7 +62,7 @@ void XNNSerializer::serializeTensorValue(
       XNNDatatype(xnn_datatype),
       num_dims,
       &serialized_dims,
-      constant_buffer_idx,
+      data_buffer_idx,
       external_id,
       flags,
       id_out);

--- a/torch/csrc/jit/backends/xnnpack/serialization/serializer.h
+++ b/torch/csrc/jit/backends/xnnpack/serialization/serializer.h
@@ -13,7 +13,6 @@ namespace delegate {
 
 using namespace fb_xnnpack; // Specified in the schema
 
-
 class XNNSerializer {
  public:
   // Constructors
@@ -26,8 +25,9 @@ class XNNSerializer {
       : _builder(bufferSize),
         _nodes(),
         _values(),
-        _constantBuffer(
-            {CreateBuffer(_builder, {})}), // index 0 is reserved for non-const data
+        _constantBuffer({CreateBuffer(
+            _builder,
+            {})}), // index 0 is reserved for non-const data
         _bufferSizes({0}) {}
 
   // Serializing Nodes

--- a/torch/csrc/jit/backends/xnnpack/serialization/serializer.h
+++ b/torch/csrc/jit/backends/xnnpack/serialization/serializer.h
@@ -13,19 +13,22 @@ namespace delegate {
 
 using namespace fb_xnnpack; // Specified in the schema
 
+
 class XNNSerializer {
  public:
   // Constructors
   // initial buffersize of 1024 which will grow
-  // automatically
+  // automatically, constant buffer and buffer sizes initialized with dummy
+  // values as 0 index is reserved for non-constant tensors
   XNNSerializer() : XNNSerializer(1024) {}
 
   explicit XNNSerializer(size_t bufferSize)
       : _builder(bufferSize),
         _nodes(),
         _values(),
-        _constantBuffer(),
-        _bufferSizes() {}
+        _constantBuffer(
+            {CreateBuffer(_builder, {})}), // index 0 is reserved for non-const data
+        _bufferSizes({0}) {}
 
   // Serializing Nodes
 
@@ -43,7 +46,7 @@ class XNNSerializer {
       uint32_t xnn_datatype,
       size_t num_dims,
       std::vector<size_t> dims,
-      void* data,
+      size_t buffer_data_idx,
       uint32_t external_id,
       uint32_t flags,
       uint32_t id_out);
@@ -53,6 +56,12 @@ class XNNSerializer {
       std::vector<uint32_t> input_ids,
       std::vector<uint32_t> output_ids,
       size_t num_extern_ids);
+
+  // decoupled data serialization with tensor values. This way constant tensor
+  // data can be referenced by multiple intermediate tensors. This call
+  // serializes the num_bytes of the data_ptr and returns the index it was
+  // placed in.
+  size_t serializeData(const uint8_t* data_ptr, size_t num_bytes);
 
  private:
   // xnnpack version we are serializing


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89445

Handling constant data for xnnpack delegation. This allows us to handle new modules like such:

```
class Module(torch.nn.Module):
            def __init__(self):
                super().__init__()
                self._constant = torch.ones(4, 4, 4)

            def forward(self, x):
                return x + self._constant
```

this is the precursor work to handling convolution, as we need to serialize constant data(weights)

Differential Revision: [D41050349](https://our.internmc.facebook.com/intern/diff/D41050349/)