### PR TITLE
[inductor][compilation time] Fallback when kernel size for avg/max pool is large

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1871,6 +1871,7 @@ class CommonTemplate:
         self.common(
             fn,
             (torch.randn(2, 4, 16, 16),),
+            check_lowp=False,
         )
 
         # lowering to avg_pool2d case
@@ -1888,12 +1889,13 @@ class CommonTemplate:
     def test_adaptive_avg_pool2d2(self):
         # Big kernel size, use fallback
         def fn(x):
-            return aten._adaptive_avg_pool2d(x, (1, 1))
+            return aten._adaptive_avg_pool2d(x, (4, 4))
 
         torch._inductor.metrics.generated_kernel_count = 0
         self.common(
             fn,
-            (torch.randn(2, 4, 16, 16),),
+            (torch.randn(2, 4, 21, 21),),
+            check_lowp=False,
         )
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 0)
 
@@ -2018,7 +2020,7 @@ class CommonTemplate:
         torch._inductor.metrics.generated_kernel_count = 0
         self.common(
             fn,
-            (-torch.arange(1 * 14 * 14, dtype=torch.float32).view(1, 1, 14, 14),),
+            (-torch.arange(1 * 24 * 24, dtype=torch.float32).view(1, 1, 24, 24),),
         )
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 0)
 
@@ -3932,7 +3934,7 @@ class CommonTemplate:
             )
 
         torch._inductor.metrics.generated_kernel_count = 0
-        x = torch.randn([2, 64, 16, 16])
+        x = torch.randn([2, 64, 20, 20])
         result, indices = aten.max_pool2d_with_indices(
             x,
             [13, 13],
@@ -4033,9 +4035,10 @@ class CommonTemplate:
         self.common(
             fn,
             [
-                torch.randn([1, 16, 2, 2]),
-                torch.randn([1, 16, 14, 14]),
+                torch.randn([1, 16, 12, 12]),
+                torch.randn([1, 16, 24, 24]),
             ],
+            check_lowp=False,
         )
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 0)
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -88,7 +88,9 @@ def dynamo_timed(func):
             compilation_metrics[key] = []
         t0 = time.time()
         r = func(*args, **kwargs)
-        compilation_metrics[key].append(time.time() - t0)
+        latency = time.time() - t0
+        # print(f"Dynamo timer: key={key}, latency={latency:.2f} sec")
+        compilation_metrics[key].append(latency)
         return r
 
     return time_wrapper

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -22,7 +22,6 @@ from typing import Any, Callable, Dict, List
 
 import torch
 from torch.utils import cpp_extension
-
 from . import config, cuda_properties, exc
 
 LOCK_TIMEOUT = 600
@@ -449,17 +448,30 @@ def _load_kernel(source_code):
     return kernel
 
 
+def _load_kernel_name(source_code):
+    return TritonCodeCache.get_name(PyCodeCache.load(source_code))
+
+
 class TritonFuture:
     def __init__(self, source_code, future):
         self.source_code = source_code
         self.future = future
 
+    # @dynamo_utils.dynamo_timed
     def result(self):
+        t0 = time()
         if hasattr(self, "kernel"):
             return self.kernel
         # If the worker failed this will throw an exception.
         self.future.result()
         kernel = self.kernel = _load_kernel(self.source_code)
+        latency = time() - t0
+        if latency > 50:
+            name = _load_kernel_name(self.source_code)
+            log.warning(
+                f"Detected long compilation time of {latency} seconds for kernel name {name}"
+            )
+            log.warning(self.source_code)
         del self.source_code, self.future
         return kernel
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2544,6 +2544,9 @@ def pooling_size(x, i, kernel_size, stride, padding, ceil_mode):
     return x_out, ceil_mode
 
 
+fallback_max_pool2d_with_indices = fallback_handler(aten.max_pool2d_with_indices)
+
+
 @register_lowering(aten.max_pool2d_with_indices, type_promotion_kind=None)
 def max_pool2d_with_indices(
     x, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False
@@ -2572,6 +2575,13 @@ def max_pool2d_with_indices(
         x_loader = x.make_loader()
 
     new_size = list(batch) + [h_out, w_out]
+    window_size = kernel_size[0] * kernel_size[1]
+
+    if window_size > 25:
+        # Kernel size too big. Results in hard-to-optimize Triton code. Use fallback.
+        return fallback_max_pool2d_with_indices(
+            x, kernel_size, stride, padding, dilation, ceil_mode
+        )
 
     def fn(idx, return_index):
         *prefix, bh, bw = idx
@@ -2607,6 +2617,11 @@ def max_pool2d_with_indices(
     )
     # TODO(jansel): should we force these to be realized?
     return r1, r2
+
+
+fallback_max_pool2d_with_indices_backward = fallback_handler(
+    aten.max_pool2d_with_indices_backward
+)
 
 
 @register_lowering(aten.max_pool2d_with_indices_backward, type_promotion_kind=None)
@@ -2648,6 +2663,14 @@ def max_pool2d_with_indices_backward(
             for w in range(kernel_size[1] * 2)
         ]
     )
+
+    window_size = h_window_size * w_window_size
+
+    if window_size > 25:
+        # Kernel size too big. Results in hard-to-optimize Triton code. Use fallback.
+        return fallback_max_pool2d_with_indices_backward(
+            grad_output, x, kernel_size, stride, padding, dilation, ceil_mode, indices
+        )
 
     def fn(idx):
         *prefix, h, w = idx
@@ -2771,6 +2794,9 @@ def _adaptive_pooling_idx_sum(kernel_maxes, start_index_fns, end_index_fns):
     return fn_sum
 
 
+fallback_adaptive_avg_pool2d = fallback_handler(aten._adaptive_avg_pool2d)
+
+
 @register_lowering(aten._adaptive_avg_pool2d)
 def _adaptive_avg_pool2d(x, output_size):
     assert isinstance(x, TensorBox)
@@ -2809,6 +2835,11 @@ def _adaptive_avg_pool2d(x, output_size):
 
     w_start_index = functools.partial(start_index, out_dim=w_out, inp_dim=w_in)
     w_end_index = functools.partial(end_index, out_dim=w_out, inp_dim=w_in)
+
+    window_size = h_kernel_max * w_kernel_max
+    if window_size > 25:
+        # Kernel size too big. Results in hard-to-optimize Triton code. Use fallback.
+        return fallback_adaptive_avg_pool2d(x, output_size)
 
     fn_sum = _adaptive_pooling_idx_sum(
         [h_kernel_max, w_kernel_max],
@@ -2880,6 +2911,9 @@ def upsample_nearest2d_backward(
     return rv
 
 
+fallback_avg_pool2d = fallback_handler(aten.avg_pool2d)
+
+
 @register_lowering(aten.avg_pool2d, type_promotion_kind=None)
 def avg_pool2d(
     x,
@@ -2916,6 +2950,19 @@ def avg_pool2d(
 
     new_size = list(batch) + [h_out, w_out]
     dtype = x.get_dtype()
+
+    window_size = kernel_size[0] * kernel_size[1]
+    if window_size > 25:
+        # Kernel size too big. Results in hard-to-optimize Triton code. Use fallback.
+        return fallback_avg_pool2d(
+            x,
+            kernel_size,
+            stride,
+            padding,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
 
     def fn_sum(idx, loader):
         *prefix, bh, bw = idx
@@ -2954,6 +3001,9 @@ def avg_pool2d(
     )
     # TODO(jansel): should we force these to be realized?
     return rv
+
+
+fallback_avg_pool2d_backward = fallback_handler(aten.avg_pool2d_backward)
 
 
 @register_lowering(aten.avg_pool2d_backward, type_promotion_kind=None)
@@ -3008,6 +3058,20 @@ def avg_pool2d_backward(
             for w in range(kernel_size[1] * 2)
         ]
     )
+
+    window_size = h_window_size * w_window_size
+    if window_size > 25:
+        # Kernel size too big. Results in hard-to-optimize Triton code. Use fallback.
+        return fallback_avg_pool2d_backward(
+            grad_output,
+            x,
+            kernel_size,
+            stride,
+            padding,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
 
     def compute_pool_size_without_padding(ph, pw):
         """


### PR DESCRIPTION
This fixes compilation time for yolov3 from 400 seconds to 48 seconds. yolov3 has a 13x13 max_pool2d kernel, which was creating really large Triton code. 

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire