### PR TITLE
[pthreadpool] Set max threadlimit to tsan limit

### DIFF
--- a/caffe2/utils/threadpool/ThreadPool.cc
+++ b/caffe2/utils/threadpool/ThreadPool.cc
@@ -103,12 +103,13 @@ size_t getDefaultNumThreads() {
 
   /*
    * For llvm-tsan, holding limit for the number of locks for a single thread
-   * is 64. pthreadpool's worst case is the number of threads in a pool. So we
-   * want to limit the threadpool size to 64 when running with tsan. However,
-   * sometimes it is tricky to detect if we are running under tsan, for now
-   * capping the default threadcount to the tsan limit unconditionally.
+   * is 63 (because of comparison < 64 instead of <=). pthreadpool's worst
+   * case is the number of threads in a pool. So we want to limit the threadpool
+   * size to 64 when running with tsan. However, sometimes it is tricky to
+   * detect if we are running under tsan, for now capping the default
+   * threadcount to the tsan limit unconditionally.
    */
-  int tsanThreadLimit = 64;
+  int tsanThreadLimit = 63;
   numThreads = std::min(numThreads, tsanThreadLimit);
 
   return numThreads;


### PR DESCRIPTION
Summary:
This will make sure we don't run into an internal assert for clang tsan which has a cap of 63 on concurrently held lock count.
Seems like it is failing with 64 since the comparison is `<`, so setting it to 63 here.

```
llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_deadlock_detector.h:67 "((n_all_locks_)) < (((sizeof(all_locks_with_contexts_)/sizeof((all_locks_with_contexts_)[0]))))"
```

Created from CodeHub with https://fburl.com/edit-in-codehub

Test Plan:
CI

Sandcastle run

Reviewed By: kimishpatel, salilsdesai

Differential Revision: D41444710

