### PR TITLE
[Vulkan][TCC] Fix quantized shaders

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/quantize_per_tensor.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantize_per_tensor.glsl
@@ -19,11 +19,13 @@ layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
   if (all(lessThan(pos, uBlock.size.xyz))) {
-    vec4 ret = texelFetch(uInput, pos, 0) / uBlock.scale.x + uBlock.zero_point.x;
-    uvec4 texel = uvec4(int(ret.x), int(ret.y), int(ret.z), int(ret.w));
+    vec4 q_res = roundEven(texelFetch(uInput, pos, 0) / uBlock.scale.x) + uBlock.zero_point.x;
+
+    uvec4 ret = uvec4(q_res);
+
     imageStore(
         uOutput,
         pos,
-        texel);
+        ret);
   }
 }

--- a/aten/src/ATen/native/vulkan/glsl/quantized_add.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_add.glsl
@@ -34,9 +34,9 @@ void main() {
     vec4 deq_in_1 = uBlock.in_scale.y * (texel1 - uBlock.in_zero_point.y);
 
     vec4 res = deq_in_0 + deq_in_1;
-    vec4 q_res = res / uBlock.out_scale.x + uBlock.out_zero_point.x;
+    vec4 q_res = roundEven(res / uBlock.out_scale.x) + uBlock.out_zero_point.x;
 
-    uvec4 ret = uvec4(int(q_res.x), int(q_res.y), int(q_res.z), int(q_res.w));
+    uvec4 ret = uvec4(q_res);
 
     imageStore(
         uOutput,

--- a/aten/src/ATen/native/vulkan/glsl/quantized_conv2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_conv2d.glsl
@@ -64,7 +64,7 @@ vec4 dequantize(vec4 tex, float scale, int zero_point) {
  * Quantizes a float texel based on a scale and zero point.
  */
 uvec4 quantize(vec4 tex, float scale, int zero_point) {
-  return uvec4(tex / scale + zero_point);
+  return uvec4(roundEven(tex / scale) + zero_point);
 }
 
 /*

--- a/aten/src/ATen/native/vulkan/glsl/quantized_conv2d_dw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_conv2d_dw.glsl
@@ -65,7 +65,7 @@ vec4 dequantize(vec4 tex, float scale, int zero_point) {
  * Quantizes a float texel based on a scale and zero point.
  */
 uvec4 quantize(vec4 tex, float scale, int zero_point) {
-  return uvec4(tex / scale + zero_point);
+  return uvec4(roundEven(tex / scale) + zero_point);
 }
 
 void main() {

--- a/aten/src/ATen/native/vulkan/glsl/quantized_conv2d_pw_2x2.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_conv2d_pw_2x2.glsl
@@ -60,7 +60,7 @@ vec4 dequantize(vec4 tex, float scale, int zero_point) {
  * Quantizes a float texel based on a scale and zero point.
  */
 uvec4 quantize(vec4 tex, float scale, int zero_point) {
-  return uvec4(tex / scale + zero_point);
+  return uvec4(roundEven(tex / scale) + zero_point);
 }
 
 /*

--- a/aten/src/ATen/native/vulkan/glsl/quantized_div.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_div.glsl
@@ -34,9 +34,9 @@ void main() {
     vec4 deq_in_1 = uBlock.in_scale.y * (texel1 - uBlock.in_zero_point.y);
 
     vec4 res = deq_in_0 / deq_in_1;
-    vec4 q_res = res / uBlock.out_scale.x + uBlock.out_zero_point.x;
+    vec4 q_res = roundEven(res / uBlock.out_scale.x) + uBlock.out_zero_point.x;
 
-    uvec4 ret = uvec4(int(q_res.x), int(q_res.y), int(q_res.z), int(q_res.w));
+    uvec4 ret = uvec4(q_res);
 
     imageStore(
         uOutput,

--- a/aten/src/ATen/native/vulkan/glsl/quantized_mul.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_mul.glsl
@@ -34,9 +34,9 @@ void main() {
     vec4 deq_in_1 = uBlock.in_scale.y * (texel1 - uBlock.in_zero_point.y);
 
     vec4 res = deq_in_0 * deq_in_1;
-    vec4 q_res = res / uBlock.out_scale.x + uBlock.out_zero_point.x;
+    vec4 q_res = roundEven(res / uBlock.out_scale.x) + uBlock.out_zero_point.x;
 
-    uvec4 ret = uvec4(int(q_res.x), int(q_res.y), int(q_res.z), int(q_res.w));
+    uvec4 ret = uvec4(q_res);
 
     imageStore(
         uOutput,

--- a/aten/src/ATen/native/vulkan/glsl/quantized_sub.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_sub.glsl
@@ -34,9 +34,9 @@ void main() {
     vec4 deq_in_1 = uBlock.in_scale.y * (texel1 - uBlock.in_zero_point.y);
 
     vec4 res = deq_in_0 - deq_in_1;
-    vec4 q_res = res / uBlock.out_scale.x + uBlock.out_zero_point.x;
+    vec4 q_res = roundEven(res / uBlock.out_scale.x) + uBlock.out_zero_point.x;
 
-    uvec4 ret = uvec4(int(q_res.x), int(q_res.y), int(q_res.z), int(q_res.w));
+    uvec4 ret = uvec4(q_res);
 
     imageStore(
         uOutput,

--- a/aten/src/ATen/native/vulkan/glsl/quantized_upsample_nearest2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_upsample_nearest2d.glsl
@@ -25,8 +25,7 @@ void main() {
         ivec2(0),
         uBlock.isize);
 
-    vec4 texel = texelFetch(uInput, ivec3(ipos, pos.z), 0);
-    uvec4 ret = uvec4(int(texel.r), int(texel.g), int(texel.b), int(texel.a));
+    uvec4 ret = texelFetch(uInput, ivec3(ipos, pos.z), 0);
 
     imageStore(
         uOutput,


### PR DESCRIPTION
Summary: Fix rounding issue in quantized shaders

Test Plan:
On Mac
```
cd ~/fbsource
buck1 run -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64
```

On Android
```
cd ~/fbsource
buck1 build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_quantized_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_quantized_api_test
adb shell "/data/local/tmp/vulkan_quantized_api_test"
```

Reviewed By: salilsdesai

Differential Revision: D41047095

