### PR TITLE
[Inductor] Limit g++12 installation to Linux

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -116,7 +116,7 @@ def cpp_compiler_search(search):
                     cxx = install_gcc_via_conda()
             subprocess.check_output([cxx, "--version"])
             return cxx
-        except (subprocess.SubprocessError, FileNotFoundError, ImportError, PermissionError):
+        except (subprocess.SubprocessError, FileNotFoundError, ImportError):
             continue
     raise exc.InvalidCxxCompiler()
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -102,6 +102,10 @@ def cpp_compiler_search(search):
     for cxx in search:
         try:
             if cxx is None:
+                # gxx package is only available for Linux
+                # according to https://anaconda.org/conda-forge/gxx/
+                if sys.platform != "linux":
+                    continue
                 from filelock import FileLock
 
                 lock_dir = get_lock_dir()
@@ -112,7 +116,7 @@ def cpp_compiler_search(search):
                     cxx = install_gcc_via_conda()
             subprocess.check_output([cxx, "--version"])
             return cxx
-        except (subprocess.SubprocessError, FileNotFoundError, ImportError):
+        except (subprocess.SubprocessError, FileNotFoundError, ImportError, PermissionError):
             continue
     raise exc.InvalidCxxCompiler()
 


### PR DESCRIPTION
According to https://anaconda.org/conda-forge/gxx/ its only available on Linux

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire