### PR TITLE
Fix JIT test failure on different CUDA toolkit and driver/GPU

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -200,7 +200,15 @@ class TestCppExtensionJIT(common.TestCase):
             archflags["5.0;6.0+PTX;7.0;7.5"] = (['50', '60', '70', '75'], ['60'])
 
         for flags, expected in archflags.items():
-            self._run_jit_cuda_archflags(flags, expected)
+            try:
+                self._run_jit_cuda_archflags(flags, expected)
+            except RuntimeError as e:
+                # Using the device default (empty flags) may fail if the device is newer than the CUDA compiler
+                # This raises a RuntimeError with a specific message which we explictely ignore here
+                if not flags and "Error building" in str(e):
+                    pass
+                else:
+                    raise
 
     @unittest.skipIf(not TEST_CUDNN, "CuDNN not found")
     def test_jit_cudnn_extension(self):

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -209,6 +209,12 @@ class TestCppExtensionJIT(common.TestCase):
                     pass
                 else:
                     raise
+            try:
+                torch.cuda.synchronize()
+            except RuntimeError:
+                # Ignore any error, e.g. unsupported PTX code on current device
+                # to avoid errors from here leaking into other tests
+                pass
 
     @unittest.skipIf(not TEST_CUDNN, "CuDNN not found")
     def test_jit_cudnn_extension(self):


### PR DESCRIPTION
Continuation and extension of #80329

There are 2 ways this test can fail:

1. CUDA toolkit/nvcc/CUDA compiler is newer than the GPU and/or GPU driver: Although this combination works in general the test may fail because it creates a GPU binary with incompatible PTX code
2. CUDA compiler is older than the GPU: Compiling for the "native" compute capability may fail as the compiler may not support it yet


`1.` is caused by the hard-coded architectures and `2.` by the hardcoded "use-the-device-compute-capability"

The 2 commits address each issue individually.

Fixes #51950
