### PR TITLE
[inductor] Update CI model tests

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -262,9 +262,14 @@ test_inductor_huggingface() {
   # will bark about file not found later on
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
+  # Check inference with --float32
+  python benchmarks/dynamo/huggingface.py --ci --accuracy \
+    --device cuda --inductor --float32 --output "$TEST_REPORTS_DIR"/inductor_inference_huggingface.csv
+  python benchmarks/dynamo/check_csv.py -f "$TEST_REPORTS_DIR"/inductor_inference_huggingface.csv
+  # Check training with --amp
   python benchmarks/dynamo/huggingface.py --ci --training --accuracy \
-    --device cuda --inductor --float32 --output "$TEST_REPORTS_DIR"/inductor_huggingface.csv
-  python benchmarks/dynamo/check_csv.py -f "$TEST_REPORTS_DIR"/inductor_huggingface.csv
+    --device cuda --inductor --amp --output "$TEST_REPORTS_DIR"/inductor_training_huggingface.csv
+  python benchmarks/dynamo/check_csv.py -f "$TEST_REPORTS_DIR"/inductor_training_huggingface.csv
 }
 
 test_inductor_timm_shard() {
@@ -277,18 +282,29 @@ test_inductor_timm_shard() {
   # will bark about file not found later on
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
-  python benchmarks/dynamo/timm_models.py --ci --training --accuracy \
+  # Check inference with --float32
+  python benchmarks/dynamo/timm_models.py --ci --accuracy \
     --device cuda --inductor --float32 --total-partitions 2 --partition-id "$1" \
-    --output "$TEST_REPORTS_DIR"/inductor_timm_"$1".csv
-  python benchmarks/dynamo/check_csv.py -f "$TEST_REPORTS_DIR"/inductor_timm_"$1".csv
+    --output "$TEST_REPORTS_DIR"/inductor_inference_timm_"$1".csv
+  python benchmarks/dynamo/check_csv.py -f "$TEST_REPORTS_DIR"/inductor_inference_timm_"$1".csv
+  # Check training with --amp
+  python benchmarks/dynamo/timm_models.py --ci --training --accuracy \
+    --device cuda --inductor --amp --total-partitions 2 --partition-id "$1" \
+    --output "$TEST_REPORTS_DIR"/inductor_training_timm_"$1".csv
+  python benchmarks/dynamo/check_csv.py -f "$TEST_REPORTS_DIR"/inductor_training_timm_"$1".csv
 }
 
 test_inductor_torchbench() {
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   mkdir -p "$TEST_REPORTS_DIR"
+  # Check inference with --float32
+  PYTHONPATH=$(pwd)/torchbench python benchmarks/dynamo/torchbench.py --ci --accuracy \
+    --device cuda --inductor --float32 --output "$TEST_REPORTS_DIR"/inductor_inference_torchbench.csv
+  python benchmarks/dynamo/check_csv.py -f "$TEST_REPORTS_DIR"/inductor_inference_torchbench.csv
+  # Check training with --amp
   PYTHONPATH=$(pwd)/torchbench python benchmarks/dynamo/torchbench.py --ci --training --accuracy \
-    --device cuda --inductor --float32 --output "$TEST_REPORTS_DIR"/inductor_torchbench.csv
-  python benchmarks/dynamo/check_csv.py -f "$TEST_REPORTS_DIR"/inductor_torchbench.csv
+    --device cuda --inductor --amp --output "$TEST_REPORTS_DIR"/inductor_training_torchbench.csv
+  python benchmarks/dynamo/check_csv.py -f "$TEST_REPORTS_DIR"/inductor_training_torchbench.csv
 }
 
 test_python_gloo_with_tls() {

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -92,7 +92,9 @@ CI_SKIP_INDCUTOR_INFERENCE = [
     "hf_BigBird",  # accuracy
     "hf_GPT2_large",  # OOM
     "maml",  # accuracy
+    "mobilenet_v2_quantized_qat",  # The eval test only supports CPU
     "moco",  # accuracy
+    "pytorch_struct",  # Test eval is not implemented
     "pyhpc_equation_of_state",  # Accuracy
     "pyhpc_turbulent_kinetic_energy",  # Accuracy
     "tacotron2",
@@ -108,9 +110,11 @@ CI_SKIP_INDUCTOR_TRAINING = [
     *CI_SKIP_INDCUTOR_INFERENCE,
     # TorchBench
     "Background_Matting",  # fp64_OOM
-    "mobilenet_v3_large",   # accuracy
+    "mobilenet_v3_large",  # accuracy
+    "resnet50_quantized_qat",  # Eager model failed to run
     # Huggingface
     "BlenderbotForCausalLM",  # OOM
+    "GoogleFnet",  # Eager model failed to run
     "M2M100ForConditionalGeneration",  # OOM
     "XGLMForCausalLM",  # OOM
     # TIMM
@@ -122,10 +126,9 @@ CI_SKIP_INDUCTOR_TRAINING = [
     "resnest101e",  # accuracy
     "rexnet_100",  # accuracy
     "spnasnet_100",  # accuracy
-    "swin_base_patch4_window7_224",    # accuracy
+    "swin_base_patch4_window7_224",  # accuracy
     "xcit_large_24_p8_224",  # fp64_OOM
 ]
-
 
 
 def model_specified_by_path(path_and_class_str):

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -103,17 +103,9 @@ CI_SKIP_INDCUTOR_INFERENCE = [
 ]
 
 CI_SKIP_INDUCTOR_TRAINING = [
-    # CI does not check accuracy for inductor training yet
-    # *CI_SKIP_AOT_EAGER_TRAINING,
-    # *CI_SKIP_INDCUTOR_INFERENCE,
+    *CI_SKIP_INDCUTOR_INFERENCE,
     # TorchBench
-    "DALLE2_pytorch",
-    "detectron2",
-    "functorch_dp_cifar10",
     "mobilenet_v3_large",
-    "moco",
-    "tacotron2",
-    "vision_maskrcnn",  # from functionalization
     # OOM
     "Background_Matting",
     "fastNLP_Bert",

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -86,23 +86,20 @@ CI_SKIP_AOT_EAGER_TRAINING = [
 CI_SKIP_INDCUTOR_INFERENCE = [
     *CI_SKIP_AOT_EAGER_INFERENCE,
     # TorchBench
+    "DALLE2_pytorch",
     "detectron2",
-    "hf_Reformer",
+    "hf_T5",  # accuracy
+    "maml",  # accuracy
     "moco",  # accuracy
     "pyhpc_equation_of_state",  # Accuracy
     "pyhpc_turbulent_kinetic_energy",  # Accuracy
     "tacotron2",
     "vision_maskrcnn",  # accuracy
-    "yolov3",  # Accuracy
     # Huggingface
-    "BigBird",
-    "YituTechConvBert",
+    "DebertaV2ForQuestionAnswering",  # OOM
     # TIMM
     "cait_m36_384",  # Accuracy
     "ghostnet_100",  # Accuracy
-    "swin_base_patch4_window7_224",  # Accuracy
-    # Trying to get CI working - https://github.com/pytorch/pytorch/pull/87588
-    "visformer_small",  # fails accuracy on CI but passes locally
 ]
 
 CI_SKIP_INDUCTOR_TRAINING = [
@@ -138,21 +135,23 @@ CI_SKIP_INDUCTOR_TRAINING = [
     "DebertaV2ForMaskedLM",  # OOM
     "DebertaV2ForQuestionAnswering",  # OOM
     # OOM
-    "BigBird",
     "TrOCRForCausalLM",
     "AlbertForQuestionAnswering",
     # TIMM
     "cait_m36_384",  # fp64_OOM
     "coat_lite_mini",  # time out
     "convit_base",  # fp64_OOM
+    "eca_halonext26ts",  # accuracy
+    "fbnetv3_b",  # accuracy
     "gernet_l",  # accuracy
     "gluon_xception65",
     "hrnet_w18",  # accuracy
     "lcnet_0500",  # accuracy
     "levit_128",  # levit_128
-    "poolformer_m36",
+    "res2net101_26w_4s",  # accuracy
+    "resnest101e",  # accuracy
     "rexnet_100",  # accuracy
-    "swin_base_patch4_window7_224",
+    "spnasnet_100",  # accuracy
     "twins_pcpvt_base",  # time out
     "xcit_large_24_p8_224",  # fp64_OOM
 ]

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -107,8 +107,25 @@ CI_SKIP_INDCUTOR_INFERENCE = [
 CI_SKIP_INDUCTOR_TRAINING = [
     *CI_SKIP_INDCUTOR_INFERENCE,
     # TorchBench
-    # OOM
+    "Background_Matting",  # fp64_OOM
+    "mobilenet_v3_large",   # accuracy
+    # Huggingface
+    "BlenderbotForCausalLM",  # OOM
+    "M2M100ForConditionalGeneration",  # OOM
+    "XGLMForCausalLM",  # OOM
+    # TIMM
+    "convit_base",  # fp64_OOM
+    "eca_halonext26ts",  # accuracy
+    "fbnetv3_b",  # accuracy
+    "levit_128",  # fp64_OOM
+    "res2net101_26w_4s",  # accuracy
+    "resnest101e",  # accuracy
+    "rexnet_100",  # accuracy
+    "spnasnet_100",  # accuracy
+    "swin_base_patch4_window7_224",    # accuracy
+    "xcit_large_24_p8_224",  # fp64_OOM
 ]
+
 
 
 def model_specified_by_path(path_and_class_str):

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -105,7 +105,6 @@ CI_SKIP_INDCUTOR_INFERENCE = [
 CI_SKIP_INDUCTOR_TRAINING = [
     *CI_SKIP_INDCUTOR_INFERENCE,
     # TorchBench
-    "mobilenet_v3_large",
     # OOM
     "Background_Matting",
     "fastNLP_Bert",

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -89,6 +89,8 @@ CI_SKIP_INDCUTOR_INFERENCE = [
     "DALLE2_pytorch",
     "detectron2",
     "hf_T5",  # accuracy
+    "hf_BigBird",  # accuracy
+    "hf_GPT2_large",  # OOM
     "maml",  # accuracy
     "moco",  # accuracy
     "pyhpc_equation_of_state",  # Accuracy
@@ -106,45 +108,6 @@ CI_SKIP_INDUCTOR_TRAINING = [
     *CI_SKIP_INDCUTOR_INFERENCE,
     # TorchBench
     # OOM
-    "Background_Matting",
-    "fastNLP_Bert",
-    "hf_BigBird",
-    "hf_T5_base",  # fp64_OOM
-    "mobilenet_v2",
-    "mobilenet_v2_quantized_qat",
-    "resnet50_quantized_qat",
-    "timm_regnet",
-    # Huggingface
-    "AllenaiLongformerBase",
-    "AlbertForMaskedLM",  # OOM
-    "BartForConditionalGeneration",  # OOM
-    "M2M100ForConditionalGeneration",  # OOM
-    "MBartForConditionalGeneration",  # OOM
-    "MT5ForConditionalGeneration",  # OOM
-    "PegasusForConditionalGeneration",  # OOM
-    "XGLMForCausalLM",  # fp64_OOM
-    "DebertaV2ForMaskedLM",  # OOM
-    "DebertaV2ForQuestionAnswering",  # OOM
-    # OOM
-    "TrOCRForCausalLM",
-    "AlbertForQuestionAnswering",
-    # TIMM
-    "cait_m36_384",  # fp64_OOM
-    "coat_lite_mini",  # time out
-    "convit_base",  # fp64_OOM
-    "eca_halonext26ts",  # accuracy
-    "fbnetv3_b",  # accuracy
-    "gernet_l",  # accuracy
-    "gluon_xception65",
-    "hrnet_w18",  # accuracy
-    "lcnet_0500",  # accuracy
-    "levit_128",  # levit_128
-    "res2net101_26w_4s",  # accuracy
-    "resnest101e",  # accuracy
-    "rexnet_100",  # accuracy
-    "spnasnet_100",  # accuracy
-    "twins_pcpvt_base",  # time out
-    "xcit_large_24_p8_224",  # fp64_OOM
 ]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89499

Summary:
1) Add model inference test
2) Switch model training test to use AMP

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx