### PR TITLE
[Checkpoint][2D][3/N] Add nested_tensors for distributed checkpoint to core distributed 

### DIFF
--- a/torch/distributed/checkpoint/nested_tensor.py
+++ b/torch/distributed/checkpoint/nested_tensor.py
@@ -1,0 +1,117 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+import copy
+
+import torch.distributed as dist
+from torch.distributed.remote_device import _remote_device
+
+from torch.distributed.checkpoint.metadata import (
+    STATE_DICT_TYPE,
+)
+from torch.distributed._shard.sharded_tensor import (
+    Shard,
+    ShardMetadata,
+    ShardedTensor,
+)
+
+from torch.distributed._shard.sharded_tensor.metadata import (
+    ShardedTensorMetadata,
+)
+
+
+from .traverse import (
+    OBJ_PATH,
+    traverse_state_dict,
+    set_element,
+    STATE_DICT_ITEM,
+)
+
+from .utils import _element_wise_add
+
+
+# TODO: update docstring for nested_tensor.py
+def flatten_sharded_tensors(state_dict: STATE_DICT_TYPE) -> STATE_DICT_TYPE:
+    """
+    Transform ``state_dict`` by flattening all nested ShardedTensor instances found.
+    The resulting ShardedTensor instances are only correct regarding the local shard and
+    MUST not be used for any other purpose but checkpointing, no operator will work with them.
+    This function should be used in conjunction with a state_dict produced by FSDP's
+    StateDictType.SHARDED_STATE_DICT methods.
+    """
+    new_state_dict: STATE_DICT_TYPE = {}
+
+    def rewrite_dict(path: OBJ_PATH, value: STATE_DICT_ITEM) -> None:
+        if not isinstance(value, ShardedTensor):
+            set_element(new_state_dict, path, value)
+            return
+        shards = value.local_shards()
+        if len(shards) == 0:
+            return
+        if len(shards) != 1:
+            raise ValueError(
+                f"Cannot handle outer tensor with more than 1 shard {path} -- {len(shards)}"
+            )
+        outer_shard = shards[0]
+
+        inner_st = outer_shard.tensor
+        if not isinstance(inner_st, ShardedTensor):
+            set_element(new_state_dict, path, value)
+            return
+
+        if len(inner_st.local_shards()) != 1:
+            raise ValueError(
+                "Cannot handle inner tensor with more than 1 shard"
+            )
+        inner_shard = inner_st.local_shards()[0]
+
+        local_shards = [
+            Shard(
+                tensor=inner_shard.tensor,
+                metadata=ShardMetadata(
+                    shard_offsets=_element_wise_add(
+                        outer_shard.metadata.shard_offsets,
+                        inner_shard.metadata.shard_offsets,
+                    ),
+                    shard_sizes=inner_shard.metadata.shard_sizes,
+                    placement=f"rank:{dist.get_rank()}/{inner_shard.tensor.device}",
+                ),
+            )
+        ]
+
+        st_meta: ShardedTensorMetadata = copy.deepcopy(value.metadata())
+        other_rank = 0 if dist.get_rank() > 0 else 1
+        # Remove the outer ST shard the inner ST covers
+        for i, shard_md in enumerate(st_meta.shards_metadata):
+            if shard_md.shard_offsets == outer_shard.metadata.shard_offsets:
+                st_meta.shards_metadata.pop(i)
+                break
+
+        # blame other rank for the other shards
+        for shard_md in st_meta.shards_metadata:
+            shard_md.placement = _remote_device(f"rank:{other_rank}/cuda:0")
+
+        # Add other inner shards from the inner tensor
+        for inner_md in inner_st.metadata().shards_metadata:
+            if inner_md.shard_offsets != inner_shard.metadata.shard_offsets:
+                st_meta.shards_metadata.append(
+                    ShardMetadata(
+                        shard_offsets=_element_wise_add(
+                            outer_shard.metadata.shard_offsets,
+                            inner_md.shard_offsets,
+                        ),
+                        shard_sizes=inner_md.shard_sizes,
+                        placement=f"rank:{other_rank}/cuda:0",
+                    )
+                )
+
+        # Finally add this shard
+        st_meta.shards_metadata.append(local_shards[0].metadata)
+
+        st = ShardedTensor._init_from_local_shards_and_global_metadata(
+            local_shards=local_shards,
+            sharded_tensor_metadata=st_meta,
+        )
+        set_element(new_state_dict, path, st)
+
+    traverse_state_dict(state_dict, rewrite_dict)
+    return new_state_dict

--- a/torch/distributed/checkpoint/utils.py
+++ b/torch/distributed/checkpoint/utils.py
@@ -1,4 +1,14 @@
-from typing import List, Callable, Optional, Union, TypeVar, Dict, Any, cast
+from typing import (
+    List,
+    Callable,
+    Optional,
+    Union,
+    TypeVar,
+    Dict,
+    Any,
+    cast,
+    Sequence,
+)
 import torch.distributed as dist
 from .api import (
     CheckpointException,
@@ -331,3 +341,11 @@ def find_state_dict_object(
             f"FQN: '{index.fqn}' is not a ShardedTensor, can't find by offset: '{index.offset}'"
         )
     return obj
+
+
+def _element_wise_add(a: Sequence[int], b: Sequence[int]) -> List[int]:
+    return [i_a + i_b for i_a, i_b in zip(a, b)]
+
+
+def _element_wise_sub(a: Sequence[int], b: Sequence[int]) -> List[int]:
+    return [i_a - i_b for i_a, i_b in zip(a, b)]


### PR DESCRIPTION
This PR moves nested_tensors to torch.distributed.checkpoint. This is a pre-req for enabling 2D checkpoint.

This flattens sharded tensors in state_dict. It is used when saving and loading FSDP SHARDED_STATE_DICT. 

Docstring, individual and integration test will be added in the following PRs.