### PR TITLE
Fix inductor fallback_random for dropout/rand_like

### DIFF
--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -40,6 +40,11 @@ def replace_fx(gm: torch.fx.GraphModule):
     # Sometimes patch_functions() misses things already in the graph
     for node in reversed(list(gm.graph.nodes)):
         if node.op == "call_function" and node.target in replacements:
+            if (
+                config.fallback_random
+                and replacements[node.target] in replacements_using_triton_random
+            ):
+                continue
             with gm.graph.inserting_before(node):
                 node.replace_all_uses_with(
                     gm.graph.call_function(
@@ -967,7 +972,9 @@ def rand_like(x, **kwargs):
 
 
 replacements = {torch.nn.functional.dropout: lowmem_dropout, torch.rand_like: rand_like}
-
+# Keep track of any replacement functions that use triton random,
+# so they can be avoided when fallback_random is set
+replacements_using_triton_random = {lowmem_dropout, rand_like}
 
 computation_op_unary_op_fusion_map = {
     nn.Conv2d: fused_conv_unary_eval,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89457
* #89520
* #89523
* #89330
* #89469
* __->__ #89515

- Avoid fx graph rewrite that replaces certain ops with ones using
  triton random
- Keep track of replacement ops using triton random, so it is possible
  to not disable all replacements when using fallback_random

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire