### PR TITLE
Dont clone unmutated args in triton autotuning

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5126,6 +5126,7 @@ if HAS_CUDA:
                         meta=meta,
                         configs=configs,
                         save_cache_hook=False,
+                        mutated_arg_names=["in_out_ptr0"],
                     )
 
                 return decorator

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -59,7 +59,7 @@ unroll_reductions_threshold = 8
 
 comment_origin = False
 
-compile_threads = min(32, os.cpu_count()) if sys.platform != "win32" else 1
+compile_threads = 1  # min(32, os.cpu_count()) if sys.platform != "win32" else 1
 
 # If kernel is fused, the name is generated from the origin node op names
 # for larger kernels limit this
@@ -93,12 +93,12 @@ class cpp:
     simdlen = None
     min_chunk_size = 4096
     cxx = (
+        "g++",
         None,  # download gcc12 from conda-forge if conda is installed
         "g++-12",
         "g++-11",
         "g++-10",
         "clang++",
-        "g++",
         "g++.par",
     )
 
@@ -107,7 +107,7 @@ class cpp:
 class triton:
 
     # Use cudagraphs on output code
-    cudagraphs = True
+    cudagraphs = False
 
     # choose conv backend, "aten" or "triton" or "autotune"
     convolution = "aten"

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -59,7 +59,7 @@ unroll_reductions_threshold = 8
 
 comment_origin = False
 
-compile_threads = 1  # min(32, os.cpu_count()) if sys.platform != "win32" else 1
+compile_threads = min(32, os.cpu_count()) if sys.platform != "win32" else 1
 
 # If kernel is fused, the name is generated from the origin node op names
 # for larger kernels limit this
@@ -93,12 +93,12 @@ class cpp:
     simdlen = None
     min_chunk_size = 4096
     cxx = (
-        "g++",
         None,  # download gcc12 from conda-forge if conda is installed
         "g++-12",
         "g++-11",
         "g++-10",
         "clang++",
+        "g++",
         "g++.par",
     )
 
@@ -107,7 +107,7 @@ class cpp:
 class triton:
 
     # Use cudagraphs on output code
-    cudagraphs = False
+    cudagraphs = True
 
     # choose conv backend, "aten" or "triton" or "autotune"
     convolution = "aten"

--- a/torch/_inductor/triton_ops/autotune.py
+++ b/torch/_inductor/triton_ops/autotune.py
@@ -42,11 +42,12 @@ class CachingAutotuner(KernelInterface):
     configs, and does not rely on the Triton JIT.
     """
 
-    def __init__(self, fn, meta, configs, save_cache_hook):
+    def __init__(self, fn, meta, configs, save_cache_hook, mutated_arg_names):
         super().__init__()
         self.fn = fn
         self.meta = meta
         self.save_cache_hook = save_cache_hook
+        self.mutated_arg_names = mutated_arg_names
         self.configs = configs
         self.launchers = []
         self.lock = threading.Lock()
@@ -141,12 +142,17 @@ class CachingAutotuner(KernelInterface):
         """Do the actual autotuning"""
         from ..compile_fx import clone_preserve_strides
 
-        # clone the input args to avoid autotune contaminating them if
-        # the kernel does in-place stores
-        cloned_args = [
-            clone_preserve_strides(arg) if isinstance(arg, torch.Tensor) else arg
-            for arg in args
-        ]
+        # clone inplace buffers to avoid autotune contaminating them if
+        # the kernel does in-place stores. avoid cloning other buffers because
+        # it leads to increase memory use
+        cloned_args = []
+        for i, arg in enumerate(args):
+            if self.fn.arg_names[i] in self.mutated_arg_names:
+                assert isinstance(arg, torch.Tensor)
+                cloned_args.append(clone_preserve_strides(arg))
+            else:
+                cloned_args.append(arg)
+
         timings = {
             launcher: self.bench(launcher, *cloned_args, **kwargs)
             for launcher in self.launchers
@@ -251,9 +257,15 @@ def cached_autotune(
     else:
         save_cache_hook = None
 
+    mutated_arg_names = meta.pop("mutated_arg_names", ())
+
     def decorator(fn):
         return CachingAutotuner(
-            fn, meta=meta, configs=configs, save_cache_hook=save_cache_hook
+            fn,
+            meta=meta,
+            configs=configs,
+            save_cache_hook=save_cache_hook,
+            mutated_arg_names=mutated_arg_names,
         )
 
     return decorator


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89519

Improves first memory compression on pytorch struct from .55 -> .73. However, it doesn't totally eliminate the overhead from autotuning. Any other pointers on where the overhead is coming from in autotuning would be great.

Edit: i think it's just the triton cache clearing https://github.com/openai/triton/blob/44f577984d28ee979f704e2c28a1dcbac9639840/python/triton/testing.py#L159

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire