### PR TITLE
verify the number of outputs of xla graph

### DIFF
--- a/test/dynamo/test_torchxla_integration.py
+++ b/test/dynamo/test_torchxla_integration.py
@@ -1,18 +1,23 @@
 # Owner(s): ["module: dynamo"]
 import copy
-import functools
-import os
 import unittest
 
 import torch
 
-has_torch_xla = True
+try:
+    from .test_torchxla_util import maybe_skip_torchxla_test
+except ImportError:
+    from test_torchxla_util import maybe_skip_torchxla_test
+
 try:
     import torch._dynamo.optimizations.torchxla_integration as integration
+    import torch_xla.core.xla_model as xm
+    import torch_xla.debug.metrics as metrics
 except ImportError:
-    has_torch_xla = False
+    # tests using torch_xla will be skipped. It's fine to ignore the
+    # importing error here.
+    pass
 
-import torch.utils._pytree as pytree
 from torch import fx, nn
 
 
@@ -81,49 +86,26 @@ def allclose(expected, actual):
         raise RuntimeError("Unexpected types")
 
 
-@functools.lru_cache(None)
-def should_run_torchxla_tests():
-    """
-    Run the tests if torch_xla is available and number of gpu devices is specified.
-    """
-    gpu_device_specified = int(os.environ.get("GPU_NUM_DEVICES", "0")) > 0
-    return has_torch_xla and gpu_device_specified
-
-
 def make_reuse_graph_test(module_class, niter=100):
-    @unittest.skipIf(
-        not should_run_torchxla_tests(),
-        "Skip the tests since torch_xla is not available or XLA devices are not specified",
-    )
+    @maybe_skip_torchxla_test
     def test_wrapper(self):
-        import torch_xla.core.xla_model as xm
-
         xla_dev = xm.xla_device()
-        mod = module_class()
-        xla_module = copy.deepcopy(mod).to(device=xla_dev)
-        inputs = mod.get_random_inputs()
+        xla_module = module_class().to(device=xla_dev)
+        inputs = tuple(x.to(device=xla_dev) for x in xla_module.get_random_inputs())
+        metrics.clear_counters()
         optimized_mod = integration.extract_compiled_graph(
-            fx.symbolic_trace(mod), inputs
+            fx.symbolic_trace(xla_module), inputs
         )
 
         for i in range(niter):
-            rand_args = mod.get_random_inputs()
-            orig_dev = rand_args[0].device
-            rand_args_copy = copy.deepcopy(rand_args)
-
-            # Can not simply call
-            #   expected = mod(*rand_args)
-            # Since we need use xla to calculate expected results
             xla_inputs = tuple(
-                copy.deepcopy(inp).to(device=xla_dev) for inp in rand_args
+                inp.to(device=xla_dev) for inp in xla_module.get_random_inputs()
             )
-            xla_out = xla_module(*xla_inputs)
-            # copy xla_inputs back to rand_args since the model may inplace update
-            # the arguments
-            rand_args = tuple(inp.to(device=orig_dev) for inp in xla_inputs)
-            expected = pytree.tree_map(lambda o: o.to(device=orig_dev), xla_out)
+            xla_inputs_copy = copy.deepcopy(xla_inputs)
 
-            actual = optimized_mod(*rand_args_copy)
+            expected = xla_module(*xla_inputs)
+
+            actual = optimized_mod(*xla_inputs_copy)
 
             if not allclose(expected, actual):
                 print(
@@ -133,7 +115,7 @@ def make_reuse_graph_test(module_class, niter=100):
 
             # make sure arguments match after calling the model forward method
             # to handle inplace updates.
-            if not allclose(rand_args, rand_args_copy):
+            if not allclose(xla_inputs, xla_inputs_copy):
                 print(
                     f"Incorrect updated arguments at iter {i}. expected\n{rand_args}, actual\n{rand_args_copy}"
                 )

--- a/test/dynamo/test_torchxla_num_output.py
+++ b/test/dynamo/test_torchxla_num_output.py
@@ -1,0 +1,120 @@
+# Owner(s): ["module: dynamo"]
+import unittest
+
+import torch
+from torch import nn
+from torch._dynamo.optimizations.torchxla_integration import GraphInputMatcher
+from torch.utils._pytree import tree_map_only
+
+try:
+    from .test_torchxla_util import maybe_skip_torchxla_test
+except ImportError:
+    from test_torchxla_util import maybe_skip_torchxla_test
+
+try:
+    import torch_xla
+    import torch_xla.core.xla_model as xm
+except ImportError:
+    # tests using torch_xla will be skipped. It's fine to ignore the
+    # importing error here.
+    pass
+
+
+class DirectReturnModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, a, b, c):
+        """
+        The XLA graph will only return the first 2 items
+        """
+        return a + b, a + c, b
+
+    def get_example_inputs(self):
+        return (torch.rand(2), torch.rand(2), torch.rand(2))
+
+
+class DirectReturnWithInplaceUpdateModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, a, b, c):
+        """
+        Inplace update on b cause it to be returned in XLA graph
+        """
+        b.zero_()
+        return a + b, a + c, b
+
+    def get_example_inputs(self):
+        return (torch.rand(2), torch.rand(2), torch.rand(2))
+
+
+class DirectReturnWithDuplicatedInplaceUpdateModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, a, b, c):
+        """
+        Even if we return b twice, the XLA graph only return b once.
+        """
+        b.zero_()
+        return a + b, a + c, b, b
+
+    def get_example_inputs(self):
+        return (torch.rand(2), torch.rand(2), torch.rand(2))
+
+
+class TestNumOutput(unittest.TestCase):
+    def do_test(self, model_class, expected_num_output):
+        xla_dev = xm.xla_device()
+        model = model_class().to(device=xla_dev)
+        inputs = tree_map_only(
+            torch.Tensor, lambda x: x.to(device=xla_dev), model.get_example_inputs()
+        )
+
+        xm.mark_step()
+        args_tensor_ids = [
+            torch_xla._XLAC._xla_get_tensor_id(xla_arg) for xla_arg in inputs
+        ]
+        tensor_id_to_arg_idx = {
+            tensor_id: i for i, tensor_id in enumerate(args_tensor_ids)
+        }
+        outputs = model(*inputs)
+        xla_graph_hash = torch_xla._XLAC._get_graph_hash(outputs)
+
+        (
+            graph_input_tensor_ids,
+            graph_input_xla_values,
+        ) = torch_xla._XLAC._get_tensors_xla_device_data_node(outputs)
+
+        graph_input_matcher = GraphInputMatcher(
+            tensor_id_to_arg_idx, graph_input_tensor_ids, graph_input_xla_values
+        )
+        torch_xla._XLAC._xla_sync_multi(outputs, [])
+
+        def run_cached_graph(*inputs):
+            torch_xla._XLAC._xla_sync_multi(inputs, [])
+            xla_graph_inputs = graph_input_matcher(inputs)
+            xla_graph_outputs = torch_xla._XLAC._run_cached_graph(
+                xla_graph_hash, xla_graph_inputs
+            )
+            return xla_graph_outputs
+
+        test_inputs = tree_map_only(
+            torch.Tensor, lambda x: x.to(device=xla_dev), model.get_example_inputs()
+        )
+        self.assertEqual(expected_num_output, len(run_cached_graph(*test_inputs)))
+
+    @maybe_skip_torchxla_test
+    def test_direct_return(self):
+        self.do_test(DirectReturnModule, expected_num_output=2)
+
+    @maybe_skip_torchxla_test
+    def test_direct_return_with_inplace_update(self):
+        self.do_test(DirectReturnWithInplaceUpdateModule, expected_num_output=3)
+
+    @maybe_skip_torchxla_test
+    def test_direct_return_with_duplicated_inplace_update(self):
+        self.do_test(
+            DirectReturnWithDuplicatedInplaceUpdateModule, expected_num_output=3
+        )

--- a/test/dynamo/test_torchxla_util.py
+++ b/test/dynamo/test_torchxla_util.py
@@ -1,0 +1,26 @@
+# Owner(s): ["module: dynamo"]
+import functools
+import os
+import unittest
+
+
+@functools.lru_cache(None)
+def should_run_torchxla_tests():
+    """
+    Run the tests if torch_xla is available and number of gpu devices is specified.
+    """
+    has_torch_xla = True
+    try:
+        import torch_xla  # noqa: F401
+    except ImportError:
+        has_torch_xla = False
+
+    gpu_device_specified = int(os.environ.get("GPU_NUM_DEVICES", "0")) > 0
+    return has_torch_xla and gpu_device_specified
+
+
+def maybe_skip_torchxla_test(test_case):
+    return unittest.skipIf(
+        not should_run_torchxla_tests(),
+        "Skip the tests since torch_xla is not available or XLA devices are not specified",
+    )(test_case)


### PR DESCRIPTION
This PR add tests to verify the behavior of number of outputs returns by an XLA graph. The understanding from this PR will help us fix https://github.com/pytorch/torchdynamo/issues/1908 and enable training for dynamo/torchxla integration eventually. Send this PR separately so Jack could help verify if the behavior is expected and play with it.

List some code snippets here since their behavior is not straightforward at a first glance:
```
    def forward(self, a, b, c):
        """
        The XLA graph will only return the first 2 items
        """
        return a + b, a + c, b
```

```
    def forward(self, a, b, c):
        """
        Inplace update on b cause it to be returned in XLA graph
        """
        b.zero_()
        return a + b, a + c, b
```

```
    def forward(self, a, b, c):
        """
        Even if we return b twice, the XLA graph only return b once.
        """
        b.zero_()
        return a + b, a + c, b, b
```


Here are what observed by the added tests:

1. XLA does not return outputs that are also inputs -- if the tensor is not inplace updated. At first glance people may feel curious why should we consider this kind of 'non-realistic' corner case. But this kind of graphs indeed shows up in AOTAutograd. The main reason is AOTAutograd lift all model parameters/buffers as graph input and may return some of them.  Check ***test_direct_return***
2. if a tensor is inplace updated, XLA will still return it as graph output even if it's also an input.  The only difference compared to item 1 is, the inplace updating on the tensor cause it being returned. This happens for BatchNorm2d since the running_mean/variance tensors will be inplace updated during training. Check ***test_direct_return_with_inplace_update***


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire