### PR TITLE
[Caffe2] Fix merge logic bug

### DIFF
--- a/torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_expr_sort.cpp
@@ -413,9 +413,10 @@ std::vector<ExprGroup*> ExprGroup::getMergeCandidates(
         "Shouldn't still be traversing in fallback mode if a merge was found.");
   }
 
-  std::vector<bool> can_merge(true, neighbors.size());
+  std::vector<bool> can_merge(neighbors.size(), true);
 
-  // Find neighbors with a level that is only 1 differant than this groups level
+  // Find neighbors with a level that is only 1 different than this group's
+  // level
   for (const auto i : c10::irange(neighbors.size())) {
     if (std::abs(neighbors[i]->payload()->level - payload()->level) > 1) {
       can_merge[i] = false;


### PR DESCRIPTION
Summary: `ExprGroup::getMergeCandidates()` had a logic bug. The vector being initialized had its arguments mis-ordered. This didn't trigger a build warning because the warning about implicit cast from an integral type to `bool` wasn't enabled.

Test Plan: `buck test fbsource//arvr/mode/win/vs2019/cuda11/opt fbsource//arvr/mode/hybrid_execution //arvr/libraries/neural_net_inference/TorchScript/...`

Differential Revision: D41488939

