### PR TITLE
[Do Not Land] Remove Caffe2 Clang Tidy Warnings as Errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,6 +40,5 @@ performance-*,
 '
 HeaderFilterRegex: 'torch/csrc/(?!deploy/interpreter/cpython).*'
 AnalyzeTemporaryDtors: false
-WarningsAsErrors: '*'
 CheckOptions:
 ...


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89428
* #89427
* #89426
* #89425
* #89424
* #89423
* __->__ #89561

Differential Revision: [D41494264](https://our.internmc.facebook.com/intern/diff/D41494264/)