### PR TITLE
Re-enabled 3 reductions tests on Windows

### DIFF
--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -465,9 +465,7 @@ op_db: List[OpInfo] = [
                 "test_reference_masked",
                 dtypes=(torch.bool, torch.int8, torch.int16, torch.int32),
             ),
-            # integer overflow
             DecorateInfo(
-                unittest.skip("Skipped!"),
                 "TestReductions",
                 "test_ref_small_input",
                 dtypes=(torch.int8, torch.int16, torch.int32),


### PR DESCRIPTION
With PR #88089 the test_ref_small_input_masked_prod with int8,int16 and int32 tests no longer overflows on Windows so they can be re-enable.