### PR TITLE
Suppress guards on as_strided call only.

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -230,11 +230,7 @@ class FakeTensorConverter(object):
                     constant=t if make_constant else None,
                 )
 
-        ctx = contextlib.nullcontext()
-        if shape_env is not None:
-            ctx = shape_env.suppress_guards()
-        with ctx:
-            out = self.meta_converter(t, shape_env=shape_env, callback=mk_fake_tensor)
+        out = self.meta_converter(t, shape_env=shape_env, callback=mk_fake_tensor)
         if out is NotImplemented:
             raise UnsupportedFakeTensorException("meta converter nyi")
         if make_constant:

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -196,6 +196,34 @@ class MetaConverter:
         arg_cnt = self.arg_cnt
         self.arg_cnt += 1
 
+        # When we make as_strided calls, we end up generating a guard
+        # that the new as_strided tensor is in bounds for the old storage
+        # for the base (since as_strided calls can "bust" out of their
+        # bounding box.)  This guard is unnecessary: if a user is able
+        # to provide us a tensor with the view base setup this way, we
+        # don't need to produce a guard, because the fact that they
+        # were able to produce the view base means its in bounds.
+        #
+        # Now, ordinarily, this guard would be harmless.  However, the
+        # generated guard refers to variables bound on the base variable.
+        # At the moment, Dynamo doesn't actually guard on x._base, because
+        # according to Voz this results in a lot of spurious invalidations,
+        # and also if the user doesn't directly make use of _base, its
+        # pointless anyway (because programs should be parametric over
+        # whether or not the input tensor is a view or not--unless you're
+        # mutating the input, but that's a whole 'nother ballgame).  So
+        # for expediency, we suppress these guards so we don't have to
+        # deal with this (yet, anyway.)
+        #
+        # NB: An old version of this code suppressed guards for ALL operations
+        # happening during meta conversion, not just as_strided calls.
+        # This is too aggressive: we do duck sizing and 0/1 simplification
+        # as we allocate variables, and we do need to register guards for
+        # these cases.
+        maybe_suppress = contextlib.nullcontext()
+        if shape_env is not None:
+            maybe_suppress = shape_env.suppress_guards()
+
         make_symbolic = shape_env is not None
 
         def sym(x):
@@ -308,7 +336,7 @@ class MetaConverter:
                         if safe_is_leaf(t):
                             # Leaf views that track view metadata are created by
                             # creating a view inside a no_grad block
-                            with torch.no_grad():
+                            with torch.no_grad(), maybe_suppress:
                                 r = base.as_strided(
                                     sizes, strides, sym(t.storage_offset())
                                 )
@@ -317,7 +345,7 @@ class MetaConverter:
                         else:
                             if t._base.requires_grad == t.requires_grad:
                                 # Easy case, just run the view op
-                                with torch.enable_grad():
+                                with torch.enable_grad(), maybe_suppress:
                                     r = base.as_strided(
                                         sizes, strides, sym(t.storage_offset())
                                     )
@@ -329,7 +357,7 @@ class MetaConverter:
                                 with torch.no_grad():
                                     mid = base.view(base.shape)
                                 mid.requires_grad = t.requires_grad
-                                with torch.enable_grad():
+                                with torch.enable_grad(), maybe_suppress:
                                     r = mid.as_strided(
                                         sizes, strides, sym(t.storage_offset())
                                     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89604
* #89602
* #89600
* #89599
* #89571
* __->__ #89569

See comment in meta_utils.py for the whole story.

This doesn't have a substantive impact yet, but will in the next
PR on the stack.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>