### PR TITLE
[Vulkan][TCC] Add tests for quantized add, sub, mul and div

### DIFF
--- a/aten/src/ATen/test/vulkan_quantized_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_quantized_api_test.cpp
@@ -121,14 +121,27 @@ int64_t rand_pos_int(const int max_val) {
 
 at::Tensor produce_random_tensor(
     const at::IntArrayRef tensor_shape,
-    const float a,
-    const float b,
-    const float c) {
-  return (a + b * at::rand({1}, at::device(at::kCPU).dtype(at::kFloat))) *
-         (at::rand(tensor_shape, at::device(at::kCPU).dtype(at::kFloat)) - c);
+    const float s_min = 1.0,
+    const float s_max = 100.0,
+    const float shift = 0.45) {
+  // tensor is randomly generated with values in the range
+  // [-shift * s, (1-shift) * s), where s is randomly generated in the range
+  // [s_min, s_max]
+  // with these default values, s is randomly generated in the range [1, 100]
+  // this means that the range of the tensor values could be as narrow as
+  // [-0.45, 0.55) or as wide as [-45.0, 55.0)
+  TORCH_CHECK(s_min > 0, "scalar lower bound must be positive");
+  TORCH_CHECK(s_min <= s_max, "scalar lower bound must be <= upper bound");
+  const auto scalar = s_min + (s_max - s_min) * (float)rand()/(float)RAND_MAX;
+  return scalar *
+    (at::rand(tensor_shape, at::device(at::kCPU).dtype(at::kFloat)) - shift);
 }
 
-double produce_random_scale(const double scale_min, const double scale_max) {
+double produce_random_scale(
+    const double scale_min = 0.001,
+    const double scale_max = 2.0) {
+  TORCH_CHECK(scale_min <= scale_max, "scale min must be <= scale max");
+  // scale is randomly generated in the range [scale_min, scale_max)
   return rand01() * (scale_max - scale_min) + scale_min;
 }
 
@@ -1278,6 +1291,278 @@ TEST_F(VulkanAPITest, quantized_upsample_nearest2d) {
   }
 
   ASSERT_TRUE(check);
+}
+
+std::tuple<double, double, int64_t, int64_t> produce_inputs_for_binary_op(
+    const bool compute_quantization_params,
+    const bool random_quantization_params,
+    const char* op_name,
+    const at::IntArrayRef input1_shape,
+    const at::IntArrayRef input2_shape,
+    double in1_scale, double in2_scale,
+    int in1_zero_point, int in2_zero_point,
+    at::Tensor& input1_cpu, at::Tensor& input1_cpu_q,
+    at::Tensor& input1_cpu_deq,
+    at::Tensor& input1_vk, at::Tensor& input1_vk_q,
+    at::Tensor& input1_vk_deq, at::Tensor& input1_vk_deq_cpu,
+    at::Tensor& input2_cpu, at::Tensor& input2_cpu_q,
+    at::Tensor& input2_cpu_deq,
+    at::Tensor& input2_vk, at::Tensor& input2_vk_q,
+    at::Tensor& input2_vk_deq, at::Tensor& input2_vk_deq_cpu) {
+
+  int num_attempts = 5;
+    // in order to make sure we start with input tensors that are numerically
+    // the same (cpu vs vulkan), we allow multiple attempts when randomly
+    // generating the inputs. If the cpu quantized tensor and the vk quantized
+    // tensors are not the same (maybe off by 1 due to differences in rounding
+    // and precision), we try again.
+  for (int i = 0; i < num_attempts; i += 1) {
+    // produce random inputs
+    input1_cpu = produce_random_tensor(input1_shape);
+    input2_cpu = produce_random_tensor(input1_shape);
+
+    if (compute_quantization_params) {
+      // compute appropiate scale and zero point for inputs
+      const auto in1_quant_params = compute_quant_params(input1_cpu);
+      in1_scale = std::get<0>(in1_quant_params);
+      in1_zero_point = std::get<1>(in1_quant_params);
+
+      const auto in2_quant_params = compute_quant_params(input2_cpu);
+      in2_scale = std::get<0>(in2_quant_params);
+      in2_zero_point = std::get<1>(in2_quant_params);
+    } else if (random_quantization_params) {
+      // produce random scale and zero point for inputs
+      in1_scale = produce_random_scale();
+      in1_zero_point = produce_random_zero_point(c10::ScalarType::QUInt8);
+
+      in2_scale = produce_random_scale();
+      in2_zero_point = produce_random_zero_point(c10::ScalarType::QUInt8);
+    }
+
+    // we do this, to avoid dividing by zero
+    if (strcmp(op_name, "quantized::div") == 0) {
+      const auto non_zero_sign = input2_cpu.sign() - input2_cpu.sign().abs() + 1;
+        // non_zero_sign = 1 if the value is non negative, and -1 if it is negative
+      input2_cpu = input2_cpu + in2_scale * non_zero_sign;
+        // this will force abs(input2_cpu) >= in2_scale, which means that none of
+        // the quantized values of the second input will be equal to the zero point.
+
+      // we might end up dividing by 0, if we allow random scale and zero point
+      // of the divisor.
+      if (random_quantization_params) {
+        const auto in2_quant_params = compute_quant_params(input2_cpu);
+        in2_scale = std::get<0>(in2_quant_params);
+        in2_zero_point = std::get<1>(in2_quant_params);
+      }
+    }
+
+    // quantize cpu inputs
+    input1_cpu_q = at::quantize_per_tensor(
+        input1_cpu, in1_scale, in1_zero_point, c10::ScalarType::QUInt8);
+    input2_cpu_q = at::quantize_per_tensor(
+        input2_cpu, in2_scale, in2_zero_point, c10::ScalarType::QUInt8);
+
+    // dequantize quantized cpu inputs
+    input1_cpu_deq = at::dequantize(input1_cpu_q);
+    input2_cpu_deq = at::dequantize(input2_cpu_q);
+
+    // vulkan quantized inputs
+    input1_vk = input1_cpu.vulkan();
+    input1_vk_q = at::quantize_per_tensor(
+        input1_vk, in1_scale, in1_zero_point, c10::ScalarType::QUInt8);
+    input2_vk = input2_cpu.vulkan();
+    input2_vk_q = at::quantize_per_tensor(
+        input2_vk, in2_scale, in2_zero_point, c10::ScalarType::QUInt8);
+
+    // dequantize quantized vulkan inputs
+    input1_vk_deq = at::dequantize(input1_vk_q);
+    input2_vk_deq = at::dequantize(input2_vk_q);
+
+    input1_vk_deq_cpu = input1_vk_deq.cpu();
+    input2_vk_deq_cpu = input2_vk_deq.cpu();
+
+    const float input1_dif = at::abs(input1_cpu_deq - input1_vk_deq_cpu).max().item<float>();
+    const float input2_dif = at::abs(input2_cpu_deq - input2_vk_deq_cpu).max().item<float>();
+    if (input1_dif < 1e-5 && input2_dif < 1e-5 && input1_dif < in1_scale/2 && input2_dif < in2_scale/2) {
+      break;
+    }
+  }
+
+  return {in1_scale, in2_scale, in1_zero_point, in2_zero_point};
+}
+
+at::Tensor apply_cpu_quantized_binary_op(
+    const char* op_name,
+    at::Tensor input1_cpu_deq,
+    at::Tensor input2_cpu_deq) {
+  if (strcmp(op_name, "quantized::add") == 0) {
+    return at::add(input1_cpu_deq, input2_cpu_deq);
+  } else if (strcmp(op_name, "quantized::sub") == 0) {
+    return at::sub(input1_cpu_deq, input2_cpu_deq);
+  } else if (strcmp(op_name, "quantized::mul") == 0) {
+    return at::mul(input1_cpu_deq, input2_cpu_deq);
+  } else if (strcmp(op_name, "quantized::div") == 0) {
+    return at::div(input1_cpu_deq, input2_cpu_deq);
+  } else {
+    TORCH_CHECK(false, "Invalid op");
+  }
+}
+
+at::Tensor apply_vulkan_quantized_binary_op(
+    const char* op_name,
+    at::Tensor input1_vk_q,
+    at::Tensor input2_vk_q,
+    double out_scale,
+    int64_t out_zero_point) {
+  if (strcmp(op_name, "quantized::add") == 0) {
+    return at::native::vulkan::ops::quantized_add(
+      input1_vk_q, input2_vk_q, out_scale, out_zero_point);
+  } else if (strcmp(op_name, "quantized::sub") == 0) {
+    return at::native::vulkan::ops::quantized_sub(
+      input1_vk_q, input2_vk_q, out_scale, out_zero_point);
+  } else if (strcmp(op_name, "quantized::mul") == 0) {
+    return at::native::vulkan::ops::quantized_mul(
+      input1_vk_q, input2_vk_q, out_scale, out_zero_point);
+  } else if (strcmp(op_name, "quantized::div") == 0) {
+    return at::native::vulkan::ops::quantized_div(
+      input1_vk_q, input2_vk_q, out_scale, out_zero_point);
+  } else {
+    TORCH_CHECK(false, "Invalid op");
+  }
+}
+
+void test_quantized_binary_op(
+    const bool compute_quantization_params,
+    const bool random_quantization_params,
+    const char* op_name,
+    const at::IntArrayRef input1_shape,
+    const at::IntArrayRef input2_shape,
+    double in1_scale_default = 0.103,
+    double in2_scale_default = 0.171,
+    double out_scale_default = 0.139,
+    int64_t in1_zero_point_default = 11,
+    int64_t in2_zero_point_default = 9,
+    int64_t out_zero_point_default = 17) {
+
+  // produce inputs
+  at::Tensor input1_cpu, input1_cpu_q, input1_cpu_deq;
+  at::Tensor input1_vk, input1_vk_q, input1_vk_deq, input1_vk_deq_cpu;
+  at::Tensor input2_cpu, input2_cpu_q, input2_cpu_deq;
+  at::Tensor input2_vk, input2_vk_q, input2_vk_deq, input2_vk_deq_cpu;
+
+  auto input_params = produce_inputs_for_binary_op(
+    compute_quantization_params, random_quantization_params, op_name,
+    input1_shape, input2_shape,
+    in1_scale_default, in2_scale_default,
+    in1_zero_point_default, in2_zero_point_default,
+    input1_cpu, input1_cpu_q, input1_cpu_deq,
+    input1_vk, input1_vk_q, input1_vk_deq, input1_vk_deq_cpu,
+    input2_cpu, input2_cpu_q, input2_cpu_deq,
+    input2_vk, input2_vk_q, input2_vk_deq, input2_vk_deq_cpu);
+
+  double in1_scale = std::get<0>(input_params);
+  double in2_scale = std::get<1>(input_params);
+  int64_t in1_zero_point = std::get<2>(input_params);
+  int64_t in2_zero_point = std::get<3>(input_params);
+
+  double out_scale = out_scale_default;
+  int64_t out_zero_point = out_zero_point_default;
+
+  // apply op on dequantized cpu tensors
+  at::Tensor output_cpu = apply_cpu_quantized_binary_op(
+    op_name, input1_cpu_deq, input2_cpu_deq);
+
+  if (compute_quantization_params || random_quantization_params) {
+    // compute appropiate scale and zero point for output
+    const auto out_quant_params = compute_quant_params(output_cpu);
+    out_scale = std::get<0>(out_quant_params);
+    out_zero_point = std::get<1>(out_quant_params);
+  }
+
+  // quantize and dequantize cpu output
+  const auto output_cpu_q = at::quantize_per_tensor(
+      output_cpu, out_scale, out_zero_point, c10::ScalarType::QUInt8);
+  const auto output_cpu_deq = at::dequantize(output_cpu_q);
+
+  // vulkan quantized output
+  at::Tensor output_vk_q = apply_vulkan_quantized_binary_op(
+    op_name, input1_vk_q, input2_vk_q, out_scale, out_zero_point);
+
+  const auto output_vk_deq = at::dequantize(output_vk_q);
+  const auto output_vk_deq_cpu = output_vk_deq.cpu();
+
+  // check
+  const float tolerance =
+    (compute_quantization_params || random_quantization_params) ? out_scale : 0;
+  const auto check = almostEqual(output_cpu_deq, output_vk_deq_cpu, tolerance);
+
+  if (!check) {
+    const auto vk_q_error = at::abs(output_vk_deq_cpu - output_cpu_deq).max().item<float>();
+    std::cout << "Binary op " << op_name << " failed with inputs: " << std::endl;
+    std::cout << "input1: shape " << input1_shape << " scale " << in1_scale
+              << " and zero point " << in1_zero_point << std::endl;
+    std::cout << "input2: shape " << input2_shape << " scale " << in2_scale
+              << " and zero point " << in2_zero_point << std::endl;
+    std::cout << "output scale " << out_scale
+              << " and zero point " << out_zero_point << std::endl;
+    std::cout << "error: " << vk_q_error << std::endl;
+  }
+  ASSERT_TRUE(check);
+}
+
+void quantized_binary_op_test_set(
+    const char* op_name) {
+  // fixed params
+  test_quantized_binary_op(false, false, op_name, {1, 1, 1, 1}, {1, 1, 1, 1});
+  test_quantized_binary_op(false, false, op_name, {1, 1, 8, 8}, {1, 1, 8, 8});
+  test_quantized_binary_op(false, false, op_name, {1, 1, 12, 17}, {1, 1, 12, 17});
+  test_quantized_binary_op(false, false, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
+  test_quantized_binary_op(false, false, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
+  test_quantized_binary_op(false, false, op_name, {7, 1, 6, 17}, {7, 5, 6, 17}); // broadcasting
+
+  // compute params
+  test_quantized_binary_op(true, false, op_name, {1, 1, 1, 1}, {1, 1, 1, 1});
+  test_quantized_binary_op(true, false, op_name, {1, 1, 8, 8}, {1, 1, 8, 8});
+  test_quantized_binary_op(true, false, op_name, {1, 1, 12, 17}, {1, 1, 12, 17});
+  test_quantized_binary_op(true, false, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
+  test_quantized_binary_op(true, false, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
+  test_quantized_binary_op(true, false, op_name, {7, 1, 6, 17}, {7, 5, 6, 17}); // broadcasting
+
+  // random params
+  test_quantized_binary_op(false, true, op_name, {1, 1, 1, 1}, {1, 1, 1, 1});
+  test_quantized_binary_op(false, true, op_name, {1, 1, 8, 8}, {1, 1, 8, 8});
+  test_quantized_binary_op(false, true, op_name, {1, 1, 12, 17}, {1, 1, 12, 17});
+  test_quantized_binary_op(false, true, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
+  test_quantized_binary_op(false, true, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
+  test_quantized_binary_op(false, true, op_name, {7, 1, 6, 17}, {7, 5, 6, 17}); // broadcasting
+
+  // random shape and params
+  for (int i = 0; i < 10; i += 1) {
+    const at::IntArrayRef tensor_shape =
+      {
+        rand_pos_int(30),
+        rand_pos_int(30),
+        rand_pos_int(100),
+        rand_pos_int(100)
+      };
+    test_quantized_binary_op(false, true, op_name, tensor_shape, tensor_shape);
+  }
+}
+
+TEST_F(VulkanAPITest, quantized_add_tests) {
+  quantized_binary_op_test_set("quantized::add");
+}
+
+TEST_F(VulkanAPITest, quantized_sub_tests) {
+  quantized_binary_op_test_set("quantized::sub");
+}
+
+TEST_F(VulkanAPITest, quantized_mul_tests) {
+  quantized_binary_op_test_set("quantized::mul");
+}
+
+TEST_F(VulkanAPITest, quantized_div_tests) {
+  quantized_binary_op_test_set("quantized::div");
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Added randomized test for quantized add, sub, mul and div

Test Plan:
On Mac
```
cd ~/fbsource
buck1 run -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64
```

On Android
```
cd ~/fbsource
buck1 build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_quantized_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_quantized_api_test
adb shell "/data/local/tmp/vulkan_quantized_api_test"
```

Differential Revision: D41047094

