### PR TITLE
Compiler warning/error on the const qualifier of the map function parameter

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -206,13 +206,20 @@ public:
     }
     return b;
   }
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wignored-qualifiers"
+#if defined(__INTEL_COMPILER)
+  Vectorized<BFloat16> map(__m256 (*const vop)(__m256)) const {
+#else
   Vectorized<BFloat16> map(const __m256 (*const vop)(__m256)) const {
+#endif
     __m256 lo, hi;
     cvtbf16_fp32(values, lo, hi);
     const auto o1 = vop(lo);
     const auto o2 = vop(hi);
     return cvtfp32_bf16(o1, o2);
   }
+  #pragma clang diagnostic pop
   Vectorized<BFloat16> abs() const {
     __m256 lo, hi;
     cvtbf16_fp32(values, lo, hi);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
@@ -283,7 +283,11 @@ public:
   }
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wignored-qualifiers"
+#if defined(__INTEL_COMPILER)
+  Vectorized<BFloat16> map(__m512 (*const vop)(__m512)) const {
+#else
   Vectorized<BFloat16> map(const __m512 (*const vop)(__m512)) const {
+#endif
     __m512 lo, hi;
     cvtbf16_fp32(values, lo, hi);
     const auto o1 = vop(lo);


### PR DESCRIPTION
Currently, Intel compiler reports the following errors:
```
error: argument of type "__m256 (*)(__m256)" is incompatible with parameter of type "const __m256 (*)(__m256)"
error: argument of type "__m512 (*)(__m512)" is incompatible with parameter of type "const __m512 (*)(__m512)"
```

This PR
- Revise `map` parameters to make all compilers (gcc, clang, icc) happy.
- Also suppress clang warning in vec256. Ref: https://github.com/pytorch/pytorch/commit/3219f6a4873f74b2f1a8af9fc81eedac764370ff

cc @VitalyFedyunin @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10