### PR TITLE
Tweak formatting of note on macros

### DIFF
--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -130,14 +130,21 @@ NOTE: The CUDA_VERSION macro, cudaRuntimeGetVersion and cudaDriverGetVersion API
 semantically map to the same values as HIP_VERSION macro, hipRuntimeGetVersion and
 hipDriverGetVersion APIs. Please do not use them interchangeably when doing version checks.
 
-Eg: Instead of
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
-If it is desired to not take the code path for ROCm/HIP:
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000 && !defined(USE_ROCM)
-If it is desired to take the code path for ROCm/HIP:
-#if (defined(CUDA_VERSION) && CUDA_VERSION >= 11000) || defined(USE_ROCM)
-If it is desired to take the code path for ROCm/HIP only for specific HIP versions:
-#if (defined(CUDA_VERSION) && CUDA_VERSION >= 11000) || (defined(USE_ROCM) && ROCM_VERSION >= 40300)
+For example: Instead of using
+
+``#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000`` to implicitly exclude ROCm/HIP,
+
+use the following to not take the code path for ROCm/HIP:
+
+``#if defined(CUDA_VERSION) && CUDA_VERSION >= 11000 && !defined(USE_ROCM)``
+
+Alternatively, if it is desired to take the code path for ROCm/HIP:
+
+``#if (defined(CUDA_VERSION) && CUDA_VERSION >= 11000) || defined(USE_ROCM)``
+
+Or if it is desired to take the code path for ROCm/HIP only for specific HIP versions:
+
+``#if (defined(CUDA_VERSION) && CUDA_VERSION >= 11000) || (defined(USE_ROCM) && ROCM_VERSION >= 40300)``
 
 
 Refer to CUDA Semantics doc


### PR DESCRIPTION
For readability when viewing the rendered file e.g., from the browser.
