### PR TITLE
Refactor ShapeEnv to distinguish ivar and var

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -121,9 +121,9 @@ class FakeSymbolicTensor(torch.Tensor):
         raise RuntimeError(f"operator {func_overload} not supported")
 
 
-def create_symbolic_tensor(name, arg, shape_env, storage_offset=0):
-    sym_shapes, sym_strides = shape_env.create_symbolic_sizes_strides(arg)
-    return FakeSymbolicTensor(sym_shapes, sym_strides, arg.dtype, arg.layout, arg.requires_grad, arg.device, storage_offset)
+def create_symbolic_tensor(name, arg, shape_env):
+    sym_shapes, sym_strides, sym_storage_offset = shape_env.create_symbolic_sizes_strides_storage_offset(arg)
+    return FakeSymbolicTensor(sym_shapes, sym_strides, arg.dtype, arg.layout, arg.requires_grad, arg.device, sym_storage_offset)
 
 def create_symint(shape_env, i):
     return shape_env.create_symint(i)
@@ -179,15 +179,9 @@ class TestPySymInt(TestCase):
         self.assertTrue(x.size(2) == 3)
         self.assertTrue(isinstance(x.size(2), SymInt))
 
-        offset = create_symint(shape_env, 2)
-        y = create_symbolic_tensor("x", torch.randn(5, 4, 3), shape_env, offset)
+        y = create_symbolic_tensor("x", torch.randn(5, 4, 3)[1:], shape_env)
         self.assertTrue(isinstance(y.storage_offset(), SymInt))
-        self.assertTrue(y.storage_offset() == 2)
-
-        offset = 2
-        z = create_symbolic_tensor("z", torch.randn(5, 4, 3), shape_env, offset)
-        self.assertTrue(isinstance(z.storage_offset(), int))
-        self.assertTrue(z.storage_offset() == 2)
+        self.assertTrue(y.storage_offset() == 12)
 
     @skipIfNoSympy
     def test_binary(self):
@@ -285,7 +279,7 @@ class TestPySymInt(TestCase):
         else:
             result = expand_x + expand_x
 
-        gt_op = shape_env.guards[0][0]
+        gt_op, _bt = shape_env.guards[-1]
         self.assertTrue(isinstance(gt_op, sympy.core.relational.StrictGreaterThan))
         self.assertTrue(str(x.shape[0]), str(gt_op.args[0]))
         self.assertTrue(str(expand_x.shape[1]), str(x.shape[0]))
@@ -344,7 +338,7 @@ class TestPySymInt(TestCase):
         shape_env = ShapeEnv()
         a0 = create_symint(shape_env, 2)
         self.assertEqual(guard_int(a0), 2)
-        self.assertEqual(str(shape_env.guards[0][0]), "Eq(s0, 2)")
+        self.assertEqual(str(shape_env.guards[-1][0]), "Eq(s0, 2)")
 
     @skipIfNoSympy
     def test_sym_int(self):
@@ -353,22 +347,19 @@ class TestPySymInt(TestCase):
         r = sym_int(a0)
         self.assertEqual(r, 5)
         self.assertIsInstance(r, torch.SymInt, msg=type(r))
-        self.assertEqual(str(shape_env.guards[0][0]), "Eq(s0, 5)")
+        self.assertEqual(str(shape_env.guards[-1][0]), "Eq(s0, 5)")
 
         a1 = create_symint(shape_env, 7)
         r = sym_int(a1 / 2)
         self.assertEqual(guard_int(r), 3)
         self.assertIsInstance(r, torch.SymInt, msg=type(r))
-        self.assertEqual(str(shape_env.guards[1][0]), "Eq(floor(s1/2), 3)")
+        self.assertEqual(str(shape_env.guards[-1][0]), "Eq(floor(s1/2), 3)")
 
-        # Temporarily disabled pending negated base variable support
-        """
         a2 = create_symint(shape_env, -3)
         r = sym_int(a2 / 2)
         self.assertEqual(guard_int(r), -1)
         self.assertIsInstance(r, torch.SymInt, msg=type(r))
-        self.assertEqual(str(shape_env.guards[2][0]), "Eq(ceiling(-s2/2), -1)")
-        """
+        self.assertEqual(str(shape_env.guards[-1][0]), "Eq(ceiling(-s2/2), -1)")
 
     @skipIfNoSympy
     def test_sym_sqrt(self):
@@ -377,7 +368,7 @@ class TestPySymInt(TestCase):
         r = sym_sqrt(a0)
         self.assertEqual(r, 2)
         self.assertIsInstance(r, torch.SymFloat, msg=type(r))
-        self.assertEqual(str(shape_env.guards[0][0]), "Eq(sqrt(s0), 2)")
+        self.assertEqual(str(shape_env.guards[-1][0]), "Eq(sqrt(s0), 2)")
 
     @skipIfNoSympy
     def test_sym_floor(self):
@@ -386,7 +377,7 @@ class TestPySymInt(TestCase):
         r = math.floor(a0 / 2)
         self.assertEqual(r, 2)
         self.assertIsInstance(r, torch.SymInt, msg=type(r))
-        self.assertEqual(str(shape_env.guards[0][0]), "Eq(floor(s0/2), 2)")
+        self.assertEqual(str(shape_env.guards[-1][0]), "Eq(floor(s0/2), 2)")
 
     @skipIfNoSympy
     def test_int_conversion(self):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -231,6 +231,9 @@ class SymInt:
     def __ge__(self, other) -> builtins.bool:
         raise AssertionError("type stub not overridden")
 
+    def __mul__(self, other: Union["SymInt", builtins.int]) -> "SymInt":
+        raise AssertionError("type stub not overridden")
+
     def __sym_float__(self):
         raise AssertionError("type stub not overridden")
 

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -325,24 +325,24 @@ class MetaConverter:
                         # So we may have to do *two* views out of the base to
                         # recreate this situation.
 
-                        sizes, strides, storage_offset = sym_sizes_strides_storage_offset(t)
+                        (
+                            sizes,
+                            strides,
+                            storage_offset,
+                        ) = sym_sizes_strides_storage_offset(t)
 
                         if safe_is_leaf(t):
                             # Leaf views that track view metadata are created by
                             # creating a view inside a no_grad block
                             with torch.no_grad(), maybe_suppress:
-                                r = base.as_strided(
-                                    sizes, strides, storage_offset
-                                )
+                                r = base.as_strided(sizes, strides, storage_offset)
                             # As it's a leaf, we can directly assign requires_grad
                             r.requires_grad = t.requires_grad
                         else:
                             if t._base.requires_grad == t.requires_grad:
                                 # Easy case, just run the view op
                                 with torch.enable_grad(), maybe_suppress:
-                                    r = base.as_strided(
-                                        sizes, strides, storage_offset
-                                    )
+                                    r = base.as_strided(sizes, strides, storage_offset)
                             else:
                                 # Obscure case.  Create a leaf view and give it the
                                 # correct requires_grad, then do the final view.
@@ -352,9 +352,7 @@ class MetaConverter:
                                     mid = base.view(base.shape)
                                 mid.requires_grad = t.requires_grad
                                 with torch.enable_grad(), maybe_suppress:
-                                    r = mid.as_strided(
-                                        sizes, strides, storage_offset
-                                    )
+                                    r = mid.as_strided(sizes, strides, storage_offset)
                     finally:
                         torch._C._dispatch_tls_set_dispatch_key_excluded(
                             torch._C.DispatchKey.ADInplaceOrView, old_exclude

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -3,6 +3,7 @@ import torch.utils._pytree as pytree
 from typing import Set, Dict, List, Type, Optional, cast, Union
 import sys
 import operator
+import itertools
 import builtins
 import math
 import functools
@@ -435,6 +436,43 @@ def _lru_cache(fn, maxsize=None):
 class ShapeEnv(object):
     def __init__(self):
         self.guards = []
+        # We have two types of symbols
+
+        # Input symbols aka ivar (t0.size(0), t1.stride(2), t2.storage_offset(), etc)
+        # are bound for input tensors and show up solely in guards, where
+        # they encode things like 0/1 specialization (t0.size(0) == 1)
+        # duck sizing (t1.size(0) == t2.size(1)) or duck striding
+        # (t1.stride(0) == t1.size(0) * t1.stride(1)).  They NEVER show
+        # up in intermediate size expressions; instead...
+
+        # Compute symbols aka var (s0, s1, etc) are guaranteed to be greater than one,
+        # and are used for our actual size expressions.  After allocating
+        # an input symbol, we immediately either guard on it being zero
+        # or one (eliminating the symbol entirely), or we introduce a companion
+        # compute symbol t0.size(0) == s0.  Multiple input symbols may map
+        # to the same compute symbol.  There is always at least one input symbol
+        # equal to any given compute symbol (so that given inputs only, you can
+        # evaluate expressions involving compute symbols).
+        #
+        # TODO: As a future performance optimization, we intend for compute
+        # symbols to be guaranteed to be greater than zero, giving us the
+        # representation t0.size(0) + 1 == s0.  This will prevent us from
+        # needing to create a new shape_env in _maybe_evaluate_static, at the
+        # cost of uglier SymPy expressions (but you should be able to simplify
+        # for printing)
+
+        # Original concrete values for ivars.  Probably technically not
+        # necessary
+        self.ivar_to_val: Dict["sympy.Symbol", "sympy.Integer"] = {}
+        # The ivar chosen to represent a given var.  There may be multiple
+        # ivars that are valid but only one is necessary; the rest have
+        # guards asserting they're equal
+        self.var_to_ivar: Dict["sympy.Symbol", "sympy.Symbol"] = {}
+        # We want to give ivars more meaningful names for debugging
+        # purposes, so we keep track of tensors/symints separately
+        self.next_ivar_tensor = itertools.count()
+        self.next_ivar_symint = itertools.count()
+
         # Maps symbolic ints to their original concrete values
         # Currently populated from tensors
         self.var_to_val: Dict["sympy.Symbol", "sympy.Integer"] = {}
@@ -466,76 +504,95 @@ class ShapeEnv(object):
         """
         return (len(self.replacements), len(self.divisible))
 
-    def create_symbolic_sizes_strides(self, ex: torch.Tensor):
+    def _build_symint(self, ivar, expr):
+        if not self._suppress_guards_tls():
+            stack = ''.join(traceback.format_list(traceback.extract_stack()[:-1]))
+            self._add_guard(
+                sympy.Eq(ivar, expr),
+                stack
+            )
+        return SymInt(SymNode(expr, ivar, self, int))
+
+    def create_symbolic_sizes_strides_storage_offset(self, ex: torch.Tensor):
         """
         Returns a list of symbolic sizes and strides for the given tensor.
-        We try our best to express stride in terms of the sizes, so that
-        we can immediately eliminate fresh symbolic variables.
+        After allocating ivars, we try to allocate a minimal amount of compute
+        variables, e.g., by expressing stride in terms of sizes.
         """
-        size = [self.create_symint(i) for i in ex.size()]
+        tid = next(self.next_ivar_tensor)
 
-        # Our strategy is we allocate symbols for all the strides,
-        # but we will then try to immediate generate equalities
-        # with size that will allow us to immediately simplify away
-        # these symbols
-        sym_stride = [self.create_symint(i) for i in ex.stride()]
-        stride: List[Optional[SymInt]] = [None] * len(size)
+        dim = ex.dim()
+        size = [self._create_symint(f"t{tid}.size({i})", v) for i, v in enumerate(ex.size())]
+        storage_offset = self._create_symint(f"t{tid}.storage_offset()", ex.storage_offset())
 
-        def guard_stride_at(i):
-            b = sym_stride[i] == stride[i]
-            assert b
+        # Don't create full symints (which would allocate compute vars) for
+        # these immediately, we may be able to avoid allocating a size var for
+        # them
+        stride_ivars = [self.create_ivar(f"t{tid}.stride({i})", v) for i, v in enumerate(ex.stride())]
 
-        # TODO: create_symbol probably did this already so this is
-        # technically unnecessary
+        size_exprs: List[sympy.Expr] = [s.node.expr for s in size]
+        stride_exprs: List[Optional[sympy.Expr]] = [None] * len(size)
+
+        def duck_stride(i, expr):
+            stride_exprs[i] = expr
+
         for i, val in enumerate(ex.stride()):
             if val in (0, 1):
-                stride[i] = val
-                guard_stride_at(i)
+                duck_stride(i, sympy.Integer(val))
 
-        while any(x is None for x in stride):
+        while any(x is None for x in stride_exprs):
             candidates = {
-                ex.size(i) * ex.stride()[i]: size[i] * stride[i]
-                for i in range(len(size))
-                if stride[i] is not None and ex.stride()[i] >= 0
+                ex.size(i) * ex.stride(i): size_exprs[i] * stride_exprs[i]
+                for i in range(dim)
+                if stride_exprs[i] is not None and ex.stride(i) >= 0
             }
             # iterate over unbound strides in sorted order
             val_list = sorted(
-                [(ex.stride()[i], i) for i in range(len(stride)) if stride[i] is None]
+                [(ex.stride(i), i) for i in range(dim) if stride_exprs[i] is None]
             )
             for _, i in val_list:
-                if stride[i] is None and ex.stride()[i] in candidates:
-                    stride[i] = candidates[ex.stride()[i]]
-                    guard_stride_at(i)
-                    candidates[ex.size(i) * ex.stride()[i]] = size[i] * stride[i]
-            if any(x is None for x in stride):
+                if stride_exprs[i] is None and ex.stride(i) in candidates:
+                    r = candidates[ex.stride(i)]
+                    duck_stride(i, r)
+                    candidates[ex.size(i) * ex.stride(i)] = size_exprs[i] * r
+            if any(x is None for x in stride_exprs):
                 # bind the smallest unbound stride to a new variable
                 val, i = min(
                     [
-                        (ex.stride()[i], i)
-                        for i in range(len(stride))
-                        if stride[i] is None
+                        (ex.stride(i), i)
+                        for i in range(dim)
+                        if stride_exprs[i] is None
                     ]
                 )
-                stride[i] = sym_stride[i]
-        assert all(x is not None for x in stride)
-        return size, sym_stride
+                fresh_var = self.create_var(ex.stride(i))
+                duck_stride(i, fresh_var)
+        assert all(x is not None for x in stride_exprs)
+        stride = [self._build_symint(ivar, expr) for ivar, expr in zip(stride_ivars, stride_exprs)]
+        return size, stride, storage_offset
 
     def create_symint(self, val: int) -> SymInt:
-        symbol = self._create_symbol(val)
-        return SymInt(SymNode(symbol, symbol, self, int))
+        sid = next(self.next_ivar_symint)
+        return self._create_symint(f"v{sid}", val)
 
-    def _create_symbol(self, val: int) -> "sympy.Symbol":
+    def _create_symint(self, ivar_name: str, val: int) -> SymInt:
+        ivar = self.create_ivar(ivar_name, val)
+        symbol = self.create_var(val)
+        return self._build_symint(ivar, symbol)
+
+    def create_ivar(self, ivar_name: str, val: int) -> "sympy.Symbol":
+        # NB: not guaranteed to be positive, could be zero
+        r = sympy.Symbol(ivar_name, integer=True)
+        self.ivar_to_val[r] = val
+        return r
+
+    def create_var(self, val: int) -> "sympy.Symbol":
         if not HAS_SYMPY:
             raise RuntimeError("Need sympy installed to create symbolic shapes")
-        # Handling negative base variables may be necessary (if a user
-        # has a bare SymInt input) but it is annoying to do as you need
-        # to know how to map it to the negated base variable.  Disallow
-        # for now.
-        assert val >= 0
+        if val < 0:
+            # all sympy base variables must be positive and > 1
+            return -self.create_var(-val)
         # This implements duck-shaping: input sizes that match are assigned
         # the same symint
-        # TODO: Create a guard whenever this happens
-        # TODO: But how do I represent the guard in this case?
         # Note: val_to_var is also initialized with 0/1 mapping to constants, so
         # this also ensures that all symbols are > 1
         if val in self.val_to_var:
@@ -551,7 +608,9 @@ class ShapeEnv(object):
         # and wrap_fake_symbolic
         meta_converter = MetaConverter()
         pytree.tree_map_only(torch.Tensor, partial(meta_converter, shape_env=new_env), args)
-        return all(guard.xreplace(new_env.var_to_val) for guard, _ in self.guards)
+        subst = new_env.var_to_val.copy()
+        subst.update(new_env.ivar_to_val)
+        return all(guard.xreplace(subst) for guard, _ in self.guards)
 
     def get_guard_expr(self):
         """
@@ -561,16 +620,21 @@ class ShapeEnv(object):
         """
         return sympy.And(*[guard for guard, _ in self.guards])
 
-    def get_nontrivial_guards(self):
-        return [self.simplify(guard) for guard, _ in self.guards if self._maybe_evaluate_static(guard) is None]
-
-    def format_guards(self, verbose=False):
+    def format_guards(self, verbose=False, *, exclude_ivar=False):
         def format_tb(tb):
             if not verbose:
                 return ""
             return f"\n   Guarded at:\n{textwrap.indent(tb, '   ')}"
 
-        return '\n'.join(f" - {guard}{format_tb(tb)}" for guard, tb in self.guards)
+        def pred(expr):
+            if not exclude_ivar:
+                return True
+            if isinstance(expr, sympy.Eq):
+                if expr.lhs in self.ivar_to_val:
+                    return False
+            return True
+
+        return '\n'.join(f" - {guard}{format_tb(tb)}" for guard, tb in self.guards if pred(guard))
 
     def get_shape_groups(self):
         shape_groups = collections.defaultdict(list)
@@ -586,6 +650,10 @@ class ShapeEnv(object):
         expr = self.simplify(expr)
         # Simplifies assuming that shape vars > 1 (since we cache on 0/1 shape values)
         symbols = list(expr.free_symbols)
+        for s in symbols:
+            assert self.var_to_val[s] > 1, \
+                f"{s} which is {self.var_to_val[s]} in nontrivial expression {expr}, " \
+                "but as a 0/1 constant it should already have been eliminated"
         new_shape_env = {
             k: sympy.Symbol(f"shape_{idx}", positive=True, integer=True) + 1
             for idx, k in enumerate(symbols)
@@ -691,6 +759,11 @@ class ShapeEnv(object):
                 except NotImplementedError:
                     pass
             return
+
+    def _add_guard(self, expr, tb):
+        if not self._suppress_guards_tls():
+            assert expr is not sympy.false
+            self.guards.append((expr, tb))
 
     @lru_cache(256)
     def evaluate_expr(self, expr: "sympy.Expr"):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89604
* #89602
* __->__ #89600
* #89599
* #89571
* #89569

Read the new top level comment in torch/fx/experimental/symbolic_shapes.py first.

The most heavy lifting is in create_symbolic_sizes_strides_storage_offset for setting up strides. We very carefully do NOT allocate vars for strides unless we are sure we need it. (But all strides get ivars.)

Some of the more tactical pieces:

- create_symbolic_sizes_strides is now create_symbolic_sizes_strides_storage_offset which also handles allocating storage_offset, which is helpful since we can setup the name on the ivar more easily. Subsequently, storage_offset on create_symbolic_tensor is no more; just properly pass in a tensor with storage offset to test it.
- Many tests look at the first guard; I change them to look at the last guard, as the early guards are typically some sort of ivar shenanigans
- format_guards has new option exclude_ivar, which deletes the ivar guards. This is useful when you don't care about the administrative guards for ivar to var.
- I deleted get_nontrivial_guards because it's annoying to work out how to do this correctly with ivars, and it's only used in one spot.

There are a bunch of new methods on ShapeEnv. The organization:

- create_symbolic_sizes_strides_storage_offset - create fresh SymInts for the named Tensor properties
- create_symint - creates a fresh SymInt corresponding to a non-size/stride/storage offset Tensor property
- _create_symint - a helper function used by the two create functions above; returns a SymInt
- _build_symint - an even lower level helper function that everyone uses
- _add_guard - low level API for adding a guard without all the stuff in the normal path
- create_ivar - creates an ivar Symbol
- create_var - creates a var Symbol

Signed-off-by: Edward Z. Yang <ezyang@fb.com>