### PR TITLE
Add `torch.compile` implementation

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -613,6 +613,14 @@ Utilities
     vmap
     _assert
 
+Optimizations
+-------------
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    compile
+
 Operator Tags
 ------------------------------------
 .. autoclass:: Tag

--- a/test/inductor/test_smoke.py
+++ b/test/inductor/test_smoke.py
@@ -5,10 +5,7 @@ import unittest
 import torch
 import torch._dynamo as torchdynamo
 import torch._inductor.config as torchinductor_config
-
-torchdynamo.config.log_level = logging.INFO
-torchdynamo.config.verbose = True
-torchinductor_config.debug = True
+from torch.testing._internal.common_utils import IS_LINUX, TestCase
 
 
 class MLP(torch.nn.Module):
@@ -22,9 +19,41 @@ class MLP(torch.nn.Module):
         x = torch.relu(self.l2(x))
         return x
 
+def _test_f(x):
+    return x * x
 
-class SmokeTest(unittest.TestCase):
+class SmokeTest(TestCase):
     def test_mlp(self):
-        mlp = torchdynamo.optimize("inductor")(MLP().cuda())
+        torchdynamo.config.log_level = logging.INFO
+        torchdynamo.config.verbose = True
+        torchinductor_config.debug = True
+
+        mlp = torch.compile(MLP().cuda())
         for _ in range(3):
             mlp(torch.randn(1, device="cuda"))
+
+        torchdynamo.config.verbose = False
+        torchinductor_config.debug = False
+
+    def test_compile_decorator(self):
+        @torch.compile
+        def foo(x):
+            return torch.sin(x) + x.min()
+
+        @torch.compile(mode="reduce-overhead")
+        def bar(x):
+            return x * x
+
+        for _ in range(3):
+            foo(torch.full((3, 4), .7, device="cuda"))
+            bar(torch.rand((2, 2), device="cuda"))
+
+    def test_compile_invalid_options(self):
+        with self.assertRaises(RuntimeError):
+            opt_f = torch.compile(_test_f, mode="ha")
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    if IS_LINUX and torch.cuda.is_available():
+        run_tests()

--- a/test/inductor/test_smoke.py
+++ b/test/inductor/test_smoke.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: inductor"]
 import logging
-import unittest
 
 import torch
 import torch._dynamo as torchdynamo
@@ -19,8 +18,10 @@ class MLP(torch.nn.Module):
         x = torch.relu(self.l2(x))
         return x
 
+
 def _test_f(x):
     return x * x
+
 
 class SmokeTest(TestCase):
     def test_mlp(self):
@@ -45,12 +46,13 @@ class SmokeTest(TestCase):
             return x * x
 
         for _ in range(3):
-            foo(torch.full((3, 4), .7, device="cuda"))
+            foo(torch.full((3, 4), 0.7, device="cuda"))
             bar(torch.rand((2, 2), device="cuda"))
 
     def test_compile_invalid_options(self):
         with self.assertRaises(RuntimeError):
             opt_f = torch.compile(_test_f, mode="ha")
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/inductor/test_smoke.py
+++ b/test/inductor/test_smoke.py
@@ -58,4 +58,5 @@ if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 
     if IS_LINUX and torch.cuda.is_available():
-        run_tests()
+        if torch.cuda.get_device_properties(0).major > 5:
+            run_tests()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1163,7 +1163,7 @@ def compile(model: Optional[Callable] = None, *,
     from torch._dynamo.eval_frame import lookup_backend
     from torch._inductor.config import InductorConfigContext
     if mode is not None and passes is not None:
-        raise RuntimeError("Either mode or passes can be specified")
+        raise RuntimeError("Either mode or passes can be specified, but both can't be specified at the same time.")
     if mode is None and passes is None:
         mode = "default"
     if backend == "inductor":

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1141,7 +1141,7 @@ def compile(model: Optional[Callable] = None, *,
                        - rematerialize-acc-threshold
 
     Example::
-    @torch.compile(passes={"matmiul-padding": True}, fullgraph=True)
+    @torch.compile(passes={"matmul-padding": True}, fullgraph=True)
     def foo(x):
         return torch.sin(x) + torch.cos(x)
     """

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1120,6 +1120,31 @@ def compile(model: Optional[Callable] = None, *,
             mode: Union[str, None] = None,
             passes: Optional[Dict[str, Union[str, builtins.int, builtins.bool]]] = None,
             **kwargs) -> Callable:
+    """
+    Optimizes given model/function using Dynamo and specified backend
+
+    Args:
+       model (Callable): Module/function to optimize
+       fullgraph (bool): Whether it is ok to break model into several subgraphs
+       dynamic (bool): Use dynamic shape tracing
+       backend: (str or Callable): backend to be used
+       mode: (str): Can be either "default", "reduce-overhead" or "max-autotune"
+       passes: (dict): A dictionary of passes to the backend. Passes currently recognized by inductor backend:
+                       - static-memory
+                       - matmul-tune
+                       - matmul-padding
+                       - trition-autotune
+                       - trition-bmm
+                       - triton-mm
+                       - trition-convolution
+                       - rematerialize-threshold
+                       - rematerialize-acc-threshold
+
+    Example::
+    @torch.compile(passes={"matmiul-padding": True}, fullgraph=True)
+    def foo(x):
+        return torch.sin(x) + torch.cos(x)
+    """
     # Decorator mode
     if model is None:
         def fn(model: Callable):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1127,9 +1127,9 @@ def compile(model: Optional[Callable] = None, *,
        model (Callable): Module/function to optimize
        fullgraph (bool): Whether it is ok to break model into several subgraphs
        dynamic (bool): Use dynamic shape tracing
-       backend: (str or Callable): backend to be used
-       mode: (str): Can be either "default", "reduce-overhead" or "max-autotune"
-       passes: (dict): A dictionary of passes to the backend. Passes currently recognized by inductor backend:
+       backend (str or Callable): backend to be used
+       mode (str): Can be either "default", "reduce-overhead" or "max-autotune"
+       passes (dict): A dictionary of passes to the backend. Passes currently recognized by inductor backend:
                        - static-memory
                        - matmul-tune
                        - matmul-padding

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -29,7 +29,7 @@ else:
 
 from ._six import string_classes as _string_classes
 
-from typing import Set, Type, TYPE_CHECKING, Union, Callable, Any
+from typing import Any, Callable, Dict, Optional, Set, Type, TYPE_CHECKING, Union
 import builtins
 
 __all__ = [
@@ -48,6 +48,7 @@ __all__ = [
     'set_deterministic_debug_mode', 'get_deterministic_debug_mode',
     'set_float32_matmul_precision', 'get_float32_matmul_precision',
     'set_warn_always', 'is_warn_always_enabled', 'SymInt', 'SymFloat',
+    'compile',
 ]
 
 ################################################################################
@@ -1111,6 +1112,47 @@ from ._linalg_utils import (  # type: ignore[misc]
     solve,
     lstsq,
 )
+
+def compile(model: Optional[Callable] = None, *,
+            fullgraph: builtins.bool = False,
+            dynamic: builtins.bool = False,
+            backend: Union[str, Callable] = "inductor",
+            mode: Union[str, None] = None,
+            passes: Optional[Dict[str, Union[str, builtins.int, builtins.bool]]] = None,
+            **kwargs) -> Callable:
+    # Decorator mode
+    if model is None:
+        def fn(model: Callable):
+            if model is None:
+                raise RuntimeError("Model can't be None")
+            return compile(model,
+                           fullgraph=fullgraph,
+                           dynamic=dynamic,
+                           backend=backend,
+                           mode=mode,
+                           passes=passes,
+                           **kwargs)
+        return fn
+
+    import torch._dynamo
+    from torch._dynamo.eval_frame import lookup_backend
+    from torch._inductor.config import InductorConfigContext
+    if mode is not None and passes is not None:
+        raise RuntimeError("Either mode or passes can be specified")
+    if mode is None and passes is None:
+        mode = "default"
+    if backend == "inductor":
+        compile_fn = lookup_backend(backend)
+        cm = InductorConfigContext(mode if mode is not None else passes)
+
+        def _compile_fn(model_, inputs_):
+            with cm:
+                return compile_fn(model_, inputs_)
+
+        _compile_fn._torchdynamo_orig_callable = compile_fn  # type: ignore[attr-defined]
+        backend = _compile_fn
+    return torch._dynamo.optimize(backend=backend, nopython=fullgraph, dynamic=dynamic, **kwargs)(model)
+
 
 def _register_device_module(device_type, module):
     r"""Register an external runtime module of the specific :attr:`device_type`

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1133,10 +1133,10 @@ def compile(model: Optional[Callable] = None, *,
                        - static-memory
                        - matmul-tune
                        - matmul-padding
-                       - trition-autotune
-                       - trition-bmm
+                       - triton-autotune
+                       - triton-bmm
                        - triton-mm
-                       - trition-convolution
+                       - triton-convolution
                        - rematerialize-threshold
                        - rematerialize-acc-threshold
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1141,9 +1141,11 @@ def compile(model: Optional[Callable] = None, *,
                        - rematerialize-acc-threshold
 
     Example::
-    @torch.compile(passes={"matmul-padding": True}, fullgraph=True)
-    def foo(x):
-        return torch.sin(x) + torch.cos(x)
+
+        @torch.compile(passes={"matmul-padding": True}, fullgraph=True)
+        def foo(x):
+            return torch.sin(x) + torch.cos(x)
+
     """
     # Decorator mode
     if model is None:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -199,10 +199,10 @@ class InductorConfigContext:
     static_memory: bool
     matmul_tune: str
     matmul_padding: bool
-    trition_autotune: bool
-    trition_bmm: bool
-    trition_mm: str
-    trition_convolution: str
+    triton_autotune: bool
+    triton_bmm: bool
+    triton_mm: str
+    triton_convolution: str
     rematerialize_threshold: int
     rematerialize_acc_threshold: int
 
@@ -244,8 +244,8 @@ class InductorConfigContext:
             def max_autotune():
                 self.static_memory = False
                 self.matmul_padding = True
-                self.trition_convolution = "autotune"
-                self.trition_mm = "autotune"
+                self.triton_convolution = "autotune"
+                self.triton_mm = "autotune"
                 self.matmul_padding = True
 
             modes = {

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -234,18 +234,29 @@ class InductorConfigContext:
             return
         # Handle mode
         if type(arg) is str:
-            if arg == "default":
+
+            def default():
                 self.static_memory = False
-            elif arg == "reduce-overhead":
+
+            def reduce_overhead():
                 self.static_memory = True
-            elif arg == "max-autotune":
+
+            def max_autotune():
                 self.static_memory = False
                 self.matmul_padding = True
                 self.trition_convolution = "autotune"
                 self.trition_mm = "autotune"
                 self.matmul_padding = True
-            else:
-                raise RuntimeError(f"Unrecognized mode {arg}, expected ")
+
+            modes = {
+                x.__name__.replace("_", "-"): x
+                for x in [default, reduce_overhead, max_autotune]
+            }
+            if arg not in modes:
+                raise RuntimeError(
+                    f"Unrecognized mode {arg}, should be one of {', '.join(modes.keys())}"
+                )
+            modes[arg]()
             return
         # Handle passes
         for (name, val) in arg.items():

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -133,6 +133,7 @@ def get_ignored_functions() -> Set[Callable]:
         torch.blackman_window,
         torch.broadcast_shapes,
         torch.can_cast,
+        torch.compile,
         torch.cudnn_affine_grid_generator,
         torch.cudnn_batch_norm,
         torch.cudnn_convolution,


### PR DESCRIPTION
`torch.compile` can be used either as decorator or to optimize model directly, for example:
```
@torch.compile
def foo(x):
  return torch.sin(x) + x.max()
```
or
```
mod = torch.nn.ReLU()
optimized_mod = torch.compile(mod, mode="max-autotune")
```


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire