### PR TITLE
Add arguments to collect_results

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -529,7 +529,7 @@ def run_fwd_maybe_bwd(gm, args, only_fwd=False):
     if requires_bwd_pass(out):
         loss = reduce_to_scalar_loss(out)
         loss.backward()
-    return collect_results(gm, out, None, [])
+    return collect_results(gm, out, None, args)
 
 
 def same_two_models(gm, opt_gm, example_inputs, only_fwd=False):


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchdynamo/issues/1901. Test script:
```python
import copy

import torch
import torch._dynamo as dynamo
import torch._dynamo.config

dynamo.config.repro_after = "dynamo"
dynamo.config.repro_level = 4

def custom_backend(gm: torch.fx.GraphModule, example_inputs):
    gm = copy.deepcopy(gm)
    for node in gm.graph.nodes:
        if len(node.args) > 1:
            node.target = torch.add
            node.args = (node.args[0], 0)
    gm.recompile()
    return gm

inp = torch.ones(5)
inp.requires_grad_(True)

@dynamo.optimize(custom_backend)
def foo(x):
    x = x * x
    return x.sum()

y = foo(inp)
print(y)
y.backward()
print(inp.grad)
```
Before, the script will finish but output an incorrect gradient. After the change, the accuracy minifier is triggered.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire