### PR TITLE
Remove fake_tensors_available

### DIFF
--- a/torch/_dynamo/optimizations/analysis.py
+++ b/torch/_dynamo/optimizations/analysis.py
@@ -10,12 +10,11 @@ from torch.multiprocessing.reductions import StorageWeakRef
 from torch.utils._pytree import tree_map
 
 from .. import config
-from ..utils import clone_inputs, fake_tensors_available
+from ..utils import clone_inputs
 
-if fake_tensors_available:
-    from torch._subclasses import FakeTensorMode  # noqa: F401
+from torch._subclasses import FakeTensorMode  # noqa: F401
 
-    from ..utils import deepcopy_to_fake_tensor
+from ..utils import deepcopy_to_fake_tensor
 
 
 class ShapeAliasingAndMutationProp(ShapeProp):
@@ -121,7 +120,7 @@ def has_mutation(gm, example_inputs, inputs_only=False):
     true, we only check for mutation of inputs"""
     # TODO - moco gives bad accuracy with Aliasing. gm is getting mutated in a bad way.
 
-    if fake_tensors_available and config.fake_tensor_propagation:
+    if config.fake_tensor_propagation:
 
         def _wrap_to_fake_tensor(t, *, f_mode):
             if type(t) in (torch.Tensor, torch.nn.Parameter):

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -24,7 +24,6 @@ from .utils import (
     CleanupHook,
     count_calls,
     counters,
-    fake_tensors_available,
     format_graph_tabular,
 )
 from .variables.builder import VariableBuilder, wrap_fx_proxy
@@ -515,8 +514,7 @@ class OutputGraph(fx.Tracer):
         # some of the tensor objects to be held alive for longer than necessary.
 
         # Clear cache for conversion of real -> fake tensors
-        if fake_tensors_available:
-            self.root_tx.fake_mode.fake_tensor_converter = None
+        self.root_tx.fake_mode.fake_tensor_converter = None
         self.root_tx = None
 
         # Note: generated fx graph will hold a reference to the nn_module,

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -50,7 +50,6 @@ from .source import (
 )
 from .utils import (
     counters,
-    fake_tensors_available,
     graph_break_dup_warning_checker,
     istype,
     proxy_args_kwargs,
@@ -1513,13 +1512,10 @@ class InstructionTranslatorBase(object):
         # Flag to indicate whether tracing is used for export.
         self.export = export
 
-        if fake_tensors_available:
-            with torch._subclasses.FakeTensorMode(
-                throw_on_data_dependent_ops=True,
-                shape_env=output.shape_env,
-            ) as fake_mode:
-                pass
-            self._fake_mode = fake_mode
+        self._fake_mode = torch._subclasses.FakeTensorMode(
+            throw_on_data_dependent_ops=True,
+            shape_env=output.shape_env,
+        )
 
         self.checkpoint = None
         self.random_calls: List[tuple] = []

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -319,8 +319,7 @@ def istensor(obj):
         torch.nn.Parameter,
         *config.traceable_tensor_subclasses,
     )
-    if fake_tensors_available:
-        tensor_list = tensor_list + (torch._subclasses.FakeTensor,)
+    tensor_list = tensor_list + (torch._subclasses.FakeTensor,)
     return istype(obj, tensor_list)
 
 
@@ -690,89 +689,81 @@ def rename_implicit(v):
     return v
 
 
-# FakeTensors were introduced after pytorch 1.12, so gate their use
-# to allow pytorch 1.12 to work
-fake_tensors_available = True
-try:
-    from torch._subclasses import (  # noqa: F401
-        FakeTensorMode,
-        UnsupportedFakeTensorException,
-    )
+from torch._subclasses import (  # noqa: F401
+    FakeTensorMode,
+    UnsupportedFakeTensorException,
+)
 
-    def make_fake_tensor(e, fake_mode, static_shapes=False, tx=None):
-        fake_tensor = fake_mode.from_tensor(e, static_shapes=static_shapes)
-        if tx is not None:
-            from torch._dynamo.guards import TensorReference
+def make_fake_tensor(e, fake_mode, static_shapes=False, tx=None):
+    fake_tensor = fake_mode.from_tensor(e, static_shapes=static_shapes)
+    if tx is not None:
+        from torch._dynamo.guards import TensorReference
 
-            def _record(tensor_ref):
-                if tensor_ref.ref_id not in tx.output.tensor_id_to_sym_shape_ref:
-                    tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id] = set()
-                tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id].add(tensor_ref)
+        def _record(tensor_ref):
+            if tensor_ref.ref_id not in tx.output.tensor_id_to_sym_shape_ref:
+                tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id] = set()
+            tx.output.tensor_id_to_sym_shape_ref[tensor_ref.ref_id].add(tensor_ref)
 
-            def _extract(symbol):
-                if isinstance(symbol, int):
-                    return None
-                sym_expr = symbol.get_pyobj().expr
-                if not isinstance(sym_expr, sympy.Symbol):
-                    return None
-                return sym_expr
+        def _extract(symbol):
+            if isinstance(symbol, int):
+                return None
+            sym_expr = symbol.get_pyobj().expr
+            if not isinstance(sym_expr, sympy.Symbol):
+                return None
+            return sym_expr
 
-            def _record_ref(e, index, symbol, kind):
-                sym_expr = _extract(symbol)
-                if sym_expr:
-                    tensor_ref = TensorReference(id(e), kind, index, sym_expr)
-                    _record(tensor_ref)
+        def _record_ref(e, index, symbol, kind):
+            sym_expr = _extract(symbol)
+            if sym_expr:
+                tensor_ref = TensorReference(id(e), kind, index, sym_expr)
+                _record(tensor_ref)
 
-            for index, symbol in enumerate(fake_tensor.size()):
-                _record_ref(e, index, symbol, "size")
+        for index, symbol in enumerate(fake_tensor.size()):
+            _record_ref(e, index, symbol, "size")
 
-            for index, symbol in enumerate(fake_tensor.stride()):
-                _record_ref(e, index, symbol, "stride")
+        for index, symbol in enumerate(fake_tensor.stride()):
+            _record_ref(e, index, symbol, "stride")
 
-            offset = fake_tensor.storage_offset()
-            _record_ref(e, None, offset, "storage_offset")
+        offset = fake_tensor.storage_offset()
+        _record_ref(e, None, offset, "storage_offset")
 
-        return fake_tensor
+    return fake_tensor
 
-    def wrap_fake_exception(fn):
-        try:
-            return fn()
-        except UnsupportedFakeTensorException as e:
-            from .exc import unimplemented
+def wrap_fake_exception(fn):
+    try:
+        return fn()
+    except UnsupportedFakeTensorException as e:
+        from .exc import unimplemented
 
-            msg = f"Unsupported: {e.reason} with fake tensor propagation. Run with config.fake_tensor_propagation=False"
-            log.warning(msg)
-            raise unimplemented(msg)
+        msg = f"Unsupported: {e.reason} with fake tensor propagation. Run with config.fake_tensor_propagation=False"
+        log.warning(msg)
+        raise unimplemented(msg)
 
-    def wrap_to_fake_tensor(e, fake_mode):
-        if type(e) in (torch.Tensor, torch.nn.Parameter):
-            return wrap_fake_exception(
-                lambda: make_fake_tensor(
-                    e, fake_mode, static_shapes=config.dynamic_shapes is False
-                )
+def wrap_to_fake_tensor(e, fake_mode):
+    if type(e) in (torch.Tensor, torch.nn.Parameter):
+        return wrap_fake_exception(
+            lambda: make_fake_tensor(
+                e, fake_mode, static_shapes=config.dynamic_shapes is False
             )
-        else:
-            return e
+        )
+    else:
+        return e
 
-    def wrap_to_fake_tensor_and_record(e, tx):
-        if type(e) in (torch.Tensor, torch.nn.Parameter):
-            static_shapes = config.dynamic_shapes is False
-            if type(e) is torch.nn.Parameter:
-                # Always static for params
-                static_shapes = True
-            return wrap_fake_exception(
-                lambda: make_fake_tensor(e, tx.fake_mode, static_shapes, tx)
-            )
-        else:
-            return e
+def wrap_to_fake_tensor_and_record(e, tx):
+    if type(e) in (torch.Tensor, torch.nn.Parameter):
+        static_shapes = config.dynamic_shapes is False
+        if type(e) is torch.nn.Parameter:
+            # Always static for params
+            static_shapes = True
+        return wrap_fake_exception(
+            lambda: make_fake_tensor(e, tx.fake_mode, static_shapes, tx)
+        )
+    else:
+        return e
 
-    def deepcopy_to_fake_tensor(obj, fake_mode):
-        with torch._subclasses.fake_tensor.FakeCopyMode(fake_mode):
-            return wrap_fake_exception(lambda: copy.deepcopy(obj))
-
-except ImportError:
-    fake_tensors_available = False
-
+def deepcopy_to_fake_tensor(obj, fake_mode):
+    with torch._subclasses.fake_tensor.FakeCopyMode(fake_mode):
+        return wrap_fake_exception(lambda: copy.deepcopy(obj))
 
 def rmse(ref, res):
     """

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -36,7 +36,6 @@ from ..source import (
 )
 from ..utils import (
     clone_input,
-    fake_tensors_available,
     get_fake_value,
     get_real_value,
     getfile,
@@ -658,13 +657,13 @@ def wrap_fx_proxy_cls(target_cls, tx, proxy, example_value=None, **options):
             options.update(target_cls.specialize(example_value))
         return target_cls(proxy, **options)
 
-    use_fake_tensors = fake_tensors_available and config.fake_tensor_propagation
+    use_fake_tensors = config.fake_tensor_propagation
 
     initial_example_value = example_value
 
     def _clone_input(value):
         if isinstance(value, torch.Tensor):
-            use_fake_tensors = fake_tensors_available and config.fake_tensor_propagation
+            use_fake_tensors = config.fake_tensor_propagation
             # tensor subclasses will not be converted to FakeTensors and need to be cloned
             if not use_fake_tensors or not isinstance(
                 value, torch._subclasses.fake_tensor.FakeTensor

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -11,7 +11,6 @@ from ..guards import GuardBuilder
 from ..source import AttrSource
 
 from ..utils import (
-    fake_tensors_available,
     get_fake_value,
     get_real_value,
     product,
@@ -261,9 +260,7 @@ class TensorVariable(VariableTracker):
             unimplemented(f"Tensor.{name}")
         elif name == "item":
             if config.capture_scalar_outputs:
-                use_fake_tensors = (
-                    fake_tensors_available and config.fake_tensor_propagation
-                )
+                use_fake_tensors = config.fake_tensor_propagation
                 if use_fake_tensors:
                     example_value = get_fake_value(self.proxy.node, tx)
                 else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89646
* #89645
* #89644
* #89643
* #89641
* #89640
* #89639
* #89638
* __->__ #89637
* #89631

As we are one repo now, they are always available.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire