### PR TITLE
Support unspecialized integers with dynamic shapes

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -137,7 +137,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         res2 = opt_fn(x)
         self.assertTrue(same(res1, res2))
 
-    @patch.object(torch._dynamo.config, "fake_tensor_propagation", False)
+    @patch.object(torch._dynamo.config, "dynamic_shapes", True)
     def test_multiple_consecutive_random_calls_before_graph(self):
         def fn(x):
             dim1 = random.randrange(start=0, stop=5)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -580,7 +580,13 @@ class VariableBuilder:
         if self.name in self.tx.output.unspec_variable_map:
             return self.tx.output.unspec_variable_map[self.name]
         else:
-            wrapped_value = torch.tensor(value)
+            if config.dynamic_shapes and isinstance(value, int):
+                shape_env = self.tx.output.shape_env
+                wrapped_value = shape_env.create_symintnode(shape_env.create_symbol(value))
+                # TODO: Do float
+            else:
+                # TODO: Eliminate this case entirely
+                wrapped_value = torch.tensor(value)
             if not is_constant_source(self.get_source()):
                 self.tx.output.graphargs.append(
                     GraphArg(self.get_source(), wrapped_value, True)
@@ -591,7 +597,8 @@ class VariableBuilder:
             else:
                 options = {}
             options.update({"source": self.get_source()})
-            options.update({"raw_value": value})
+            if isinstance(wrapped_value, torch.Tensor):
+                options.update({"raw_value": value})
 
             proxy = self.tx.output.create_graph_input(
                 re.sub(r"[^a-zA-Z0-9]+", "_", self.name), type(wrapped_value)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -580,9 +580,15 @@ class VariableBuilder:
         if self.name in self.tx.output.unspec_variable_map:
             return self.tx.output.unspec_variable_map[self.name]
         else:
-            if config.dynamic_shapes and isinstance(value, int):
+            if (
+                config.dynamic_shapes
+                and config.fake_tensor_propagation
+                and isinstance(value, int)
+            ):
                 shape_env = self.tx.output.shape_env
-                wrapped_value = shape_env.create_symintnode(shape_env.create_symbol(value))
+                wrapped_value = shape_env.create_symintnode(
+                    shape_env.create_symbol(value)
+                )
                 # TODO: Do float
             else:
                 # TODO: Eliminate this case entirely

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -96,9 +96,7 @@ def meta_randint_low(
 
 
 @register_meta(aten.rand.default)
-def meta_rand_default(
-    size, *, dtype=None, layout=None, device=None, pin_memory=None
-):
+def meta_rand_default(size, *, dtype=None, layout=None, device=None, pin_memory=None):
     return torch.empty(
         size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory
     )

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -95,6 +95,15 @@ def meta_randint_low(
     )
 
 
+@register_meta(aten.rand.default)
+def meta_rand_default(
+    size, *, dtype=None, layout=None, device=None, pin_memory=None
+):
+    return torch.empty(
+        size, dtype=dtype, layout=layout, device=device, pin_memory=pin_memory
+    )
+
+
 @register_meta([aten._fft_c2r.default, aten._fft_c2r.out])
 @out_wrapper()
 def meta_fft_c2r(self, dim, normalization, lastdim):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89646
* #89645
* #89644
* #89643
* #89641
* #89640
* __->__ #89639
* #89638
* #89637
* #89631

Previously, we hackily wrapped unspecialized integers into
tensors and treated them as tensor inputs.  Sometimes, downstream
operations would not be able to deal with the tensor input.  Now,
we wrap them into SymInt, so more correct overload selection occurs.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire