### PR TITLE
Run optimizer tests with fake tensors

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -85,6 +85,7 @@ from .misc import (
 from .nn_module import UnspecializedNNModuleVariable
 from .tensor import (
     DynamicShapeVariable,
+    FakeItemVariable,
     TensorVariable,
     TensorWithTFOverrideVariable,
     UnspecializedNumpyVariable,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89646
* #89645
* #89644
* __->__ #89643
* #89641
* #89640
* #89639
* #89638
* #89637
* #89631

This is a slight regression: RAdam and Adagrad don't appear to
trace at all under fake tensors.  But I think this is a more accurate
reflection of the current state of affairs.

Along the way fix some problems on the fake tensor path.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire