### PR TITLE
xfail maml test, instead of running it without fake tensor prop

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -952,7 +952,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.op_count, 4)
 
     # see: https://github.com/pytorch/pytorch/issues/80067
-    @patch.object(torch._dynamo.config, "fake_tensor_propagation", False)
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     def test_maml_item_capture(self):
         a = torch.randn(5, 1, 28, 28)
@@ -966,7 +965,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         for _ in range(10):
             self.assertTrue(same(opt_model(a, b, c, d), correct))
 
-        self.assertEqual(cnt.frame_count, ifdyn(3, 2))
+        self.assertEqual(cnt.frame_count, ifdyn(4, 3))
         # TODO(jansel): figure out why op count depends on imports
         self.assertIn(cnt.op_count, (36, 35, 34, 29, 28, 27))
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1076,6 +1076,15 @@ def get_fake_value(node, tx):
             cause, torch._subclasses.fake_tensor.DynamicOutputShapeException
         ):
             unimplemented(f"dynamic shape operator: {cause.func}")
+        elif node.target is torch.tensor:
+            # torch.tensor doesn't work very well with fake tensors, so
+            # if it raises an error, we guess that a graph break is better
+            # here.  Possibly we should error out earlier if we detect
+            # we are feeding fake tensors into torch.tensor instead of
+            # attempting and failing; we may also incorrectly suppress
+            # real user errors (but fallback to eager will report the
+            # true error)
+            unimplemented(f"torch.tensor: {cause}")
         raise TorchRuntimeError() from e
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89672
* #89671
* #89670
* #89669
* #89668
* #89666
* #89664
* #89665
* #89662
* #89646
* __->__ #89645
* #89644
* #89643
* #89641
* #89640
* #89639
* #89638
* #89637
* #89631

A previous version of this patch graph breaks when torch.tensor fails, but that causes

```
PYTORCH_TEST_WITH_DYNAMO=1 python test/nn/test_embedding.py -k test_embedding_bag_1D_padding_idx_cpu_float32
```

to start failing. Probably another latent bug that needs investigating.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire