### PR TITLE
Revert "Dont clone unmutated args in triton autotuning (#89519)"

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5018,24 +5018,6 @@ if HAS_CUDA:
 
             self.assertTrue(torch.allclose(module(input), traced(input)))
 
-        @patch.object(config.triton, "autotune", True)
-        def test_inplace_add_alpha_autotune(self):
-            def fn(x, y):
-                aten.add_.Tensor(x, y, alpha=0.55)
-                return (x,)
-
-            x1 = torch.zeros(2, 3, 4, 10, device="cuda")
-            x2 = torch.zeros(2, 3, 4, 10, device="cuda")
-            x3 = torch.zeros(2, 3, 4, 10, device="cuda")
-            y = torch.randn(2, 3, 4, 10, device="cuda").to(
-                memory_format=torch.channels_last
-            )
-            fn_fx = make_fx(fn)(x1, y)
-            fn_compiled = compile_fx_inner(fn_fx, [x1, y])
-            fn(x2, y)
-            fn_compiled([x3, y])
-            assert same(x2, x3)
-
         def test_permute_linear_fusion(self):
             class TestModule(torch.nn.Module):
                 def __init__(self, k: int, n: int):
@@ -5345,7 +5327,6 @@ if HAS_CUDA:
                         meta=meta,
                         configs=configs,
                         save_cache_hook=False,
-                        mutated_arg_names=["in_out_ptr0"],
                     )
 
                 return decorator

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -515,18 +515,11 @@ class TritonKernel(Kernel):
     overrides = TritonOverrides
     sexpr = texpr
 
-    def __init__(
-        self,
-        *groups,
-        mutations=None,
-        pid_cache=None,
-        reduction_hint=ReductionHint.DEFAULT,
-    ):
+    def __init__(self, *groups, pid_cache=None, reduction_hint=ReductionHint.DEFAULT):
         if pid_cache is None:
             pid_cache = {}
         super(TritonKernel, self).__init__()
         self.numels = [V.graph.sizevars.simplify(s) for s in groups]
-        self.mutations = mutations
         self.range_trees = []
         self.range_tree_nodes = {}
         self.iter_vars_count = itertools.count()
@@ -1024,21 +1017,10 @@ class TritonKernel(Kernel):
             )
 
         argdefs, _, signature = self.args.python_argdefs()
-
-        mutated_args = []
-        for mutation in self.mutations:
-            if mutation in self.args.input_buffers:
-                mutated_args.append(self.args.input_buffers[mutation])
-            if mutation in self.args.inplace_buffers:
-                mutated_args.append(self.args.inplace_buffers[mutation])
-            if mutation in self.args.output_buffers:
-                mutated_args.append(self.args.output_buffers[mutation])
-
         triton_meta = {
             "signature": dict(enumerate(map(signature_of, signature))),
             "device": V.graph.scheduler.current_device.index,
             "constants": {},
-            "mutated_arg_names": mutated_args,
         }
 
         for tree in self.range_trees:
@@ -1313,15 +1295,7 @@ class TritonScheduling:
                 reduction_hint_val = ReductionHint.DEFAULT
         else:
             reduction_hint_val = ReductionHint.DEFAULT
-
-        mutations = set()
-        for node in node_schedule:
-            if hasattr(node, "get_mutations"):
-                mutations.update(node.get_mutations())
-
-        with TritonKernel(
-            *tiled_groups, reduction_hint=reduction_hint_val, mutations=mutations
-        ) as kernel:
+        with TritonKernel(*tiled_groups, reduction_hint=reduction_hint_val) as kernel:
             stack = contextlib.ExitStack()
             for node in node_schedule:
                 if node not in (EnableReduction, DisableReduction):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89652

This reverts commit f18f0c70ab10c400947e71be30794e04dcc22acf.

Testing to see if this fixes gmixer_24_224 mixer_b16_224

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire