### PR TITLE
Ablate _torchdynamo_orig_callable in wrap_compiler_fn

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -90,10 +90,7 @@ def wrap_compiler_fn(compiler_fn):
     """WrapperBackend if config.verify_correctness is True"""
     if config.verify_correctness:
         # wrap backend if verify_correctness is True
-        wrapper_backend_compiler_fn = WrapperBackend(compiler_fn)
-
-        wrapper_backend_compiler_fn._torchdynamo_orig_callable = compiler_fn
-        return wrapper_backend_compiler_fn
+        return WrapperBackend(compiler_fn)
 
     return compiler_fn
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89658

Was originally added in https://github.com/pytorch/torchdynamo/pull/849

I'm not really sure why this is needed; Dynamo shouldn't be on
when we're calling the compiler function.  Ablate and see!

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire