### PR TITLE
[Inductor] Add an option to mark wrapper call in PyTorch profiler

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4661,7 +4661,7 @@ class CommonTemplate:
             fn,
             [torch.randn((4, 2)), torch.randn((4))],
         )
-    
+
     @patch.object(config, "profiler_mark_wrapper_call", True)
     def test_profiler_mark_wrapper_call(self):
         from torch.profiler import profile
@@ -4674,7 +4674,9 @@ class CommonTemplate:
         b = torch.rand((100,))
         with profile() as prof:
             fn(a, b)
-        assert "inductor_wrapper_call" in (e.name for e in prof.profiler.function_events)
+        assert "inductor_wrapper_call" in (
+            e.name for e in prof.profiler.function_events
+        )
 
 
 if HAS_CPU:

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4661,6 +4661,20 @@ class CommonTemplate:
             fn,
             [torch.randn((4, 2)), torch.randn((4))],
         )
+    
+    @patch.object(config, "profiler_mark_wrapper_call", True)
+    def test_profiler_mark_wrapper_call(self):
+        from torch.profiler import profile
+
+        @torch._dynamo.optimize("inductor", nopython=True)
+        def fn(a, b):
+            return a + b
+
+        a = torch.rand((100,))
+        b = torch.rand((100,))
+        with profile() as prof:
+            fn(a, b)
+        assert "inductor_wrapper_call" in (e.name for e in prof.profiler.function_events)
 
 
 if HAS_CPU:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 import dataclasses
 import functools
 import hashlib
@@ -330,7 +331,12 @@ class WrapperCodeGen(CodeGen):
         result.splice(self.prefix)
 
         out_names = V.graph.get_output_names()
-        with result.indent():
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(result.indent())
+            if config.profiler_mark_wrapper_call:
+                result.writeline("from torch.profiler import record_function")
+                result.writeline("with record_function('wrapper_call'):")
+                stack.enter_context(result.indent())
             while (
                 self.lines
                 and isinstance(self.lines[-1], MemoryPlanningLine)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -335,7 +335,7 @@ class WrapperCodeGen(CodeGen):
             stack.enter_context(result.indent())
             if config.profiler_mark_wrapper_call:
                 result.writeline("from torch.profiler import record_function")
-                result.writeline("with record_function('wrapper_call'):")
+                result.writeline("with record_function('inductor_wrapper_call'):")
                 stack.enter_context(result.indent())
             while (
                 self.lines

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -88,7 +88,7 @@ alignment_size = 4
 permute_fusion = os.environ.get("TORCHINDUCTOR_PERMUTE_FUSION", "0") == "1"
 
 # Mark the wrapper call in PyTorch profiler
-profiler_mark_wrapper_call = True
+profiler_mark_wrapper_call = False
 
 # config specific to codegen/cpp.pp
 class cpp:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -87,6 +87,8 @@ alignment_size = 4
 # Fx-based linear/matmul/bmm + permute/transpose vertical fusion
 permute_fusion = os.environ.get("TORCHINDUCTOR_PERMUTE_FUSION", "0") == "1"
 
+# Mark the wrapper call in PyTorch profiler
+profiler_mark_wrapper_call = True
 
 # config specific to codegen/cpp.pp
 class cpp:


### PR DESCRIPTION
This PR adds an option `config.profiler_mark_wrapper_call` (disabled by default) to mark the duration of wrapper call in the PyTorch profiler. This makes it easy to identify the duration and start/end of each wrapper call in the profiler output.


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire