### PR TITLE
complex: register c10::complex with py::cast

### DIFF
--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -227,6 +227,35 @@ struct type_caster<c10::SymFloat> {
       handle /* parent */);
 };
 
+template <typename T>
+struct type_caster<c10::complex<T>> {
+ public:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+  PYBIND11_TYPE_CASTER(c10::complex<T>, _("torch._complex.complex"));
+
+  bool load(handle src, bool) {
+    PyObject* obj = src.ptr();
+
+    // Refered from `THPUtils_unpackComplexDouble`
+    Py_complex py_complex = PyComplex_AsCComplex(obj);
+    if (py_complex.real == -1.0 && PyErr_Occurred()) {
+      return false;
+    }
+
+    // Python's Complex is always double precision.
+    value = c10::complex<double>(py_complex.real, py_complex.imag);
+    return true;
+  }
+
+  static handle cast(
+      const c10::complex<T>& complex,
+      return_value_policy /* policy */,
+      handle /* parent */) {
+    // Python only know double precision complex.
+    return handle(PyComplex_FromDoubles(complex.real(), complex.imag()));
+  }
+};
+
 // Pybind11 bindings for our optional and variant types.
 // http://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#c-17-library-containers
 template <typename T>

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -251,7 +251,7 @@ struct type_caster<c10::complex<T>> {
       const c10::complex<T>& complex,
       return_value_policy /* policy */,
       handle /* parent */) {
-    // Python only know double precision complex.
+    // Python only knows double precision complex.
     return handle(PyComplex_FromDoubles(complex.real(), complex.imag()));
   }
 };


### PR DESCRIPTION
Fixes #77134

TODO:
* [x] Add test (tested locally with script below) (Are there similar tests in the test-suite?)

```c++
#include <torch/torch.h>
#include <torch/csrc/utils/pybind.h>
#include <iostream>
#include <vector>
#include <pybind11/pybind11.h>
#include <pybind11/embed.h>
#include <cassert>


namespace py = pybind11;

int main() {
    py::scoped_interpreter guard{}; // start the interpreter
    auto casted_cdouble = py::cast(c10::complex<double>(1.0, 2.0));
    assert(
        (c10::complex<double>(1.0, 2.0) ==
         py::cast<c10::complex<double>>(casted_cdouble)));

    auto casted_cfloat = py::cast(c10::complex<float>(1.0, 2.0));
    assert(
        (c10::complex<double>(1.0, 2.0) ==
         py::cast<c10::complex<double>>(casted_cfloat)));

    auto casted_chalf = py::cast(c10::complex<at::Half>(1.0, 2.0));
    assert(
        (c10::complex<double>(1.0, 2.0) ==
         py::cast<c10::complex<double>>(casted_chalf)));
}


```