### PR TITLE
upress Werror introduced by no override #86786 on `bool initialized()`

### DIFF
--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -430,7 +430,7 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
     (void)called;
   }
 
-  bool initialized() {
+  bool initialized() override {
     return devs_initialized_flags.size() > 0;
   }
 


### PR DESCRIPTION
This is forward fix for : https://github.com/pytorch/pytorch/pull/86786
Which generates following error when compiled with `-Werror`:
```
CUDAMallocAsyncAllocator.cpp:433:8: error: 'initialized' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  bool initialized() {
```

See declaration of CUDAAllocator:
https://github.com/pytorch/pytorch/blob/master/c10/cuda/CUDACachingAllocator.h#L186