### PR TITLE
[GHA] Decrease Windows test timeout to 120 minutes

### DIFF
--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -56,7 +56,7 @@ jobs:
       matrix: ${{ fromJSON(needs.filter.outputs.test-matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 300
+    timeout-minutes: 120
     steps:
       - name: Enable git symlinks on Windows
         shell: bash


### PR DESCRIPTION
This PR decreases the Windows tests pipelines timeout to 120 mins per discusison as requested at https://github.com/pytorch/pytorch/issues/73489#issuecomment-1322539593

Closes #73489.