### PR TITLE
Add debug asserts to AOTAutograd for input consistency with compilation

### DIFF
--- a/functorch/_src/aot_autograd.py
+++ b/functorch/_src/aot_autograd.py
@@ -1480,6 +1480,7 @@ def aot_dispatch_deduplicated_autograd(flat_fn, flat_args: List[Tensor], aot_con
         return compiled_function
 
     flat_requires_grad = [a.requires_grad if isinstance(a, Tensor) else None for a in flat_args]
+
     @wraps(compiled_function)
     def debug_compiled_function(*args):
         # TODO: Check aliasing relationships

--- a/functorch/_src/config.py
+++ b/functorch/_src/config.py
@@ -14,6 +14,11 @@ use_functionalize = True
 # TODO Benchmark
 use_fake_tensor = False
 
+# Enables optional asserts in hotpath code to check for errors.  If
+# you are seeing weird accuracy problems, try turning this on.
+# For now, to more easily identify bugs, this is turned on by default.
+debug_assert = True
+
 debug_fake_cross_ref = os.environ.get('AOT_FAKE_CROSSREF', False)
 
 debug_partitioner = os.environ.get('AOT_PARTITIONER_DEBUG', False)

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -984,6 +984,48 @@ def forward(self, primals_1, primals_2):
         x = torch.randn(3, 3, requires_grad=True)
         self.verify_aot_autograd(f, [x, x])
 
+    @patch("functorch._src.config.debug_assert", True)
+    def test_invalid_dupe(self):
+        class F(torch.nn.Module):
+            def forward(self, x, y):
+                return (x + y,)
+
+        x = torch.randn(3, 3, requires_grad=True)
+        y = torch.randn(3, 3, requires_grad=True)
+
+        fxy = aot_module_simplified(F(), nop)
+        fxy(x, y)
+        self.assertRaises(AssertionError, lambda: fxy(x, x))
+
+        fxx = aot_module_simplified(F(), nop)
+        fxx(x, x)
+        self.assertRaises(AssertionError, lambda: fxx(x, y))
+
+    @patch("functorch._src.config.debug_assert", True)
+    def test_invalid_requires_grad(self):
+        class F(torch.nn.Module):
+            def forward(self, x, y):
+                return (x + y,)
+
+        x = torch.randn(3, 3, requires_grad=True)
+        y = torch.randn(3, 3, requires_grad=True)
+        z = torch.randn(3, 3, requires_grad=False)
+
+        # Non-mutating please!
+        def compare(m1, m2, inps):
+            r1, g1 = _outs_and_grads(m1, inps, inps)
+            r2, g2 = _outs_and_grads(m2, inps, inps)
+            self.assertEqual(r1, r2)
+            self.assertEqual(g1, g2)
+
+        fxy = aot_module_simplified(F(), nop)
+        compare(F(), fxy, (x, y))
+        compare(F(), fxy, (x, z))
+
+        fxz = aot_module_simplified(F(), nop)
+        compare(F(), fxz, (x, z))
+        self.assertRaises(AssertionError, lambda: fxz(x, y))  # not OK
+
     def test_resize_input(self):
         def f(x, y):
             y.resize_(4)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89710
* __->__ #89702
* #89701

Fixes https://github.com/pytorch/torchdynamo/issues/1927

Signed-off-by: Edward Z. Yang <ezyang@fb.com>