### PR TITLE
Let SyncBatchNorm fallback to BN if not using distributed training

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5435,11 +5435,12 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             helper(self, shape, torch.bfloat16, False)
             helper(self, shape, torch.bfloat16, True)
 
-    def test_batchnorm_non_contig_cpu(self):
+    @parametrize_test('bn_module', [torch.nn.BatchNorm2d, torch.nn.SyncBatchNorm])
+    def test_batchnorm_non_contig_cpu(self, bn_module):
         input = torch.arange(6, dtype=torch.float).reshape(1, 3, 2, 1).cpu()
         input = input.permute(0, 2, 1, 3)
 
-        bn = torch.nn.BatchNorm2d(2).cpu().float().eval()
+        bn = bn_module(2).cpu().float().eval()
         bn.weight.data.uniform_()
         bn.bias.data.uniform_()
 
@@ -5457,7 +5458,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         input_bf = torch.arange(24, dtype=torch.bfloat16).reshape(1, 3, 2, 4)
         input_bf = input_bf.permute(0, 2, 1, 3)
         input_f = input_bf.float()
-        bn_mix = torch.nn.BatchNorm2d(2).float().eval()
+        bn_mix = bn_module(2).float().eval()
         ref_bn_f = deepcopy(bn_mix)
         out_bf = bn_mix(input_bf)
         ref_out_bf = ref_bn_f(input_f)

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -681,10 +681,6 @@ class SyncBatchNorm(_BatchNorm):
             )
 
     def forward(self, input: Tensor) -> Tensor:
-        # currently only GPU input is supported
-        if not input.is_cuda:
-            raise ValueError("SyncBatchNorm expected input tensor to be on GPU")
-
         self._check_input_dim(input)
         self._check_non_zero_input_channels(input)
 
@@ -730,6 +726,10 @@ class SyncBatchNorm(_BatchNorm):
         need_sync = (bn_training and self.training and
                      torch.distributed.is_available() and torch.distributed.is_initialized())
         if need_sync:
+            # currently only GPU input is supported
+            if not input.is_cuda:
+                raise ValueError("SyncBatchNorm expected input tensor to be on GPU")
+
             process_group = torch.distributed.group.WORLD
             if self.process_group:
                 process_group = self.process_group

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -727,7 +727,8 @@ class SyncBatchNorm(_BatchNorm):
         )
 
         # Don't sync batchnorm stats in inference mode (model.eval()).
-        need_sync = (bn_training and self.training)
+        need_sync = (bn_training and self.training and
+                     torch.distributed.is_available() and torch.distributed.is_initialized())
         if need_sync:
             process_group = torch.distributed.group.WORLD
             if self.process_group:


### PR DESCRIPTION
Fixes #63662