### PR TITLE
Store graphargs on dynamo produced GraphModule

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -480,6 +480,9 @@ class OutputGraph(fx.Tracer):
         gm = fx.GraphModule(root, self.graph)
         gm.recompile()
         gm.compile_subgraph_reason = self.compile_subgraph_reason
+        # graphargs contains useful information about variable
+        # source, so we propagate them to backend
+        gm.graphargs = self.graphargs
         name = unique_id("__compiled_fn")
 
         compiled_fn = self.call_user_compiler(gm)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89709

When debugging, I found having access to graphargs useful.  I propose
we always propagate them.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire