### PR TITLE
Implement guard_source on RandomValueSource

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -59,6 +59,7 @@ class GuardSource(enum.Enum):
     LOCAL_NN_MODULE = 2
     GLOBAL_NN_MODULE = 3
     CONSTANT = 4
+    RANDOM_VALUE = 5
 
     def select(self, locals_, globals_):
         if self in (GuardSource.LOCAL, GuardSource.LOCAL_NN_MODULE):

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -75,6 +75,9 @@ class LocalSource(Source):
 class RandomValueSource(Source):
     random_call_index: int
 
+    def guard_source(self):
+        return GuardSource.RANDOM_VALUE
+
     def reconstruct(self, codegen):
         return [
             codegen.create_load(codegen.tx.output.random_values_var),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89711

I audited the pattern matches on the enum and it didn't
look like this one should apply there.

Sorry, no test, I know this matters on symbolic-shapes branch
but I haven't had time to extract out a minimal reproducer.
Take my word for it.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire