### PR TITLE
[inductor] Deterministic kernel names

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1306,7 +1306,7 @@ class TritonScheduling:
                 if config.triton.descriptive_kernel_names
                 else ""
             )
-            kernel_name = "triton_" + fused_name + wrapper.next_kernel_suffix()
+            kernel_name = "_".join(["triton", fused_name, wrapper.next_kernel_suffix()])
             wrapper.kernels[src_code] = kernel_name
             subs_name = kernel_name if config.triton.ordered_kernel_names else "triton_"
             src_code = src_code.replace("KERNEL_NAME", subs_name)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -270,8 +270,8 @@ def get_fused_kernel_name(node_schedule):
                     ],
                 )
                 if origin.op == "call_function"
-            ][0 : config.kernel_name_max_ops]
-        )
+            ]
+        )[0 : config.kernel_name_max_ops]
     )
 
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -258,14 +258,20 @@ def cache_on_self(fn):
 def get_fused_kernel_name(node_schedule):
     return "_".join(
         ["fused"]
-        + [
-            str(origin.name)
-            for origin in functools.reduce(
-                operator.or_,
-                [node.node.origins for node in node_schedule if hasattr(node, "node")],
-            )
-            if origin.op == "call_function"
-        ][0 : config.kernel_name_max_ops]
+        + sorted(
+            [
+                str(origin.name)
+                for origin in functools.reduce(
+                    operator.or_,
+                    [
+                        node.node.origins
+                        for node in node_schedule
+                        if hasattr(node, "node")
+                    ],
+                )
+                if origin.op == "call_function"
+            ][0 : config.kernel_name_max_ops]
+        )
     )
 
 


### PR DESCRIPTION
`node.origins` is a set and does not have an order. Therefore, inductor w and w/o cudagraphs experiments generate different kernel names, making it hard to debug.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire