### PR TITLE
[benchmarks] Clamp loss value for TIMM models

### DIFF
--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -296,7 +296,8 @@ class TimmRunnner(BenchmarkRunner):
     def compute_loss(self, pred):
         # High loss values make gradient checking harder, as small changes in
         # accumulation order upsets accuracy checks.
-        return self.loss(pred, self.target) / 10.0
+        loss = self.loss(pred, self.target) / 10.0
+        return torch.min(loss, torch.tensor(0.5))
 
     def forward_pass(self, mod, inputs, collect_outputs=True):
         return mod(*inputs)


### PR DESCRIPTION
This is somewhat questionable. I am seeing that the loss value is quite high for TIMM models. This could be because we are using randomly generated data (with no preprocessing) and target.

With large loss values, in the backward pass, any changes in the ordering of accumulation can result in accuracy deviations. This can happen with AOT Autograd (which uses custom `autograd.Function` object, which does not guarantee same grad accumulation order as eager) and with Inductor as well as it reorders the operations. 

Controlling the loss value resolves the error seen for `deit_base_distilled_patch16_224` model. This model was failing accuracy for Inductor with no_cudagraphs, but passes for Inductor with cudagraphs. This is unexpected, because we expect same kernels for both scenarios. So, we inspected the generated kernels - https://www.diffchecker.com/U6NhXkKw/. We observe small triton kernel code changes, but the maths is still same with arguments just flipped around (i.e `a + b` is now `b + a`). 

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire