### PR TITLE
[skip ci] documentation update for the kwargs defaults section of fun…

### DIFF
--- a/functorch/_src/eager_transforms.py
+++ b/functorch/_src/eager_transforms.py
@@ -233,7 +233,7 @@ def vjp(func: Callable, *primals, has_aux: bool = False):
 
         >>> x = torch.randn([5])
         >>> def f(x, scale=4.):
-        >>>   return x * 4.
+        >>>   return x * scale
         >>>
         >>> (_, vjpfunc) = functorch.vjp(f, x)
         >>> vjps = vjpfunc(torch.ones_like(x))


### PR DESCRIPTION
In this doc, it's better to multiply the scale instead of the constant 4.0 to illustrate the default of kwargs.

cc @zou3519 @Chillee @samdow @soumith