### PR TITLE
[minifier] Continue on assertion for accuracy minification

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -545,7 +545,7 @@ def same_two_models(gm, opt_gm, example_inputs, only_fwd=False):
             (
                 "While minifying the program in accuracy minification mode,"
                 "ran into a runtime exception which is likely an unrelated issue."
-                f" Logging the exception and moving on. Exception: {e}"
+                " Skipping this graph."
             )
         )
         return True
@@ -731,7 +731,7 @@ def backend_accuracy_fails(gm, example_inputs, compiler_fn, only_fwd=False):
             (
                 "While minifying the program in accuracy minification mode,"
                 "ran into a runtime exception which is likely an unrelated issue."
-                f" Logging the exception and moving on. Exception: {e}"
+                " Skipping this graph"
             )
         )
         return False

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -541,7 +541,13 @@ def same_two_models(gm, opt_gm, example_inputs, only_fwd=False):
     except Exception as e:
         # This means that the the minified graph is bad/exposes a different problem.
         # As we are checking accuracy here, lets log the exception and return True.
-        log.warning(f"Unable to run graph because {e}")
+        log.warning(
+            (
+                "While minifying the program in accuracy minification mode,"
+                "ran into a runtime exception which is likely an unrelated issue."
+                f" Logging the exception and moving on. Exception: {e}"
+            )
+        )
         return True
 
     passing = same(ref, res, fp64_ref, tol=0.001, equal_nan=True)
@@ -721,7 +727,13 @@ def backend_accuracy_fails(gm, example_inputs, compiler_fn, only_fwd=False):
     except Exception as e:
         # This means that the the minified graph is bad/exposes a different problem.
         # As we are checking accuracy here, lets log the exception and return False.
-        log.warning(f"Unable to compile the model because {e}")
+        log.warning(
+            (
+                "While minifying the program in accuracy minification mode,"
+                "ran into a runtime exception which is likely an unrelated issue."
+                f" Logging the exception and moving on. Exception: {e}"
+            )
+        )
         return False
 
     return not same_two_models(gm, compiled_gm, example_inputs, only_fwd)

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -536,7 +536,13 @@ def same_two_models(gm, opt_gm, example_inputs, only_fwd=False):
         log.warning("Could not generate fp64 outputs")
         fp64_ref = None
 
-    res = run_fwd_maybe_bwd(opt_gm, example_inputs, only_fwd)
+    try:
+        res = run_fwd_maybe_bwd(opt_gm, example_inputs, only_fwd)
+    except Exception as e:
+        # This means that the the minified graph is bad/exposes a different problem.
+        # As we are checking accuracy here, lets log the exception and return True.
+        log.warning(f"Unable to run graph because {e}")
+        return True
 
     passing = same(ref, res, fp64_ref, tol=0.001, equal_nan=True)
     return passing
@@ -710,7 +716,14 @@ def dump_backend_state(gm, args, compiler_name, check_accuracy=False):
 
 
 def backend_accuracy_fails(gm, example_inputs, compiler_fn, only_fwd=False):
-    compiled_gm = compiler_fn(copy.deepcopy(gm), clone_inputs(example_inputs))
+    try:
+        compiled_gm = compiler_fn(copy.deepcopy(gm), clone_inputs(example_inputs))
+    except Exception as e:
+        # This means that the the minified graph is bad/exposes a different problem.
+        # As we are checking accuracy here, lets log the exception and return False.
+        log.warning(f"Unable to compile the model because {e}")
+        return False
+
     return not same_two_models(gm, compiled_gm, example_inputs, only_fwd)
 
 


### PR DESCRIPTION
During accuracy minification, minifier can create graphs which can cause assertion failures. This PR catches such assertions and let minifier move on, instead of getting stuck in minifying this issue. 

It is possible that such graphs point to some real-although-unrelated issue. So, printing an assertion to flag and debug if needed.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire