### PR TITLE
Test FSDP with submodule non-reentrant checkpointing

### DIFF
--- a/test/distributed/fsdp/test_fsdp_checkpoint.py
+++ b/test/distributed/fsdp/test_fsdp_checkpoint.py
@@ -333,7 +333,7 @@ class TestFSDPCheckpointSubmodule(FSDPTest):
         self.assertTrue(model_ac.m1.s1.checkpoint)
         self.assertTrue(model_ac.m2.s2.checkpoint)
 
-
+        # Wrap no checkpointing model submodules with FSDP
         model.m1 = FSDP(
             module=model.m1,
             device_id=torch.cuda.current_device(),
@@ -345,6 +345,7 @@ class TestFSDPCheckpointSubmodule(FSDPTest):
             sharding_strategy=ShardingStrategy.NO_SHARD,
         )
 
+        # Wrap checkpointing model submodules with FSDP
         model_ac.m1 = FSDP(
             module=model_ac.m1,
             device_id=torch.cuda.current_device(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89781

With combining FSDP with reentrant checkpointing, the post backward
hook might run twice, and then hit [this
error](https://github.com/pytorch/pytorch/blob/e20ec44544c17d6d3d411f88b870e05043bda731/torch/distributed/fsdp/_runtime_utils.py#L487).
This is because reentrant backward uses nested autograd GraphTasks.
The inner GraphTask is not aware of the outer one and therefore
will flush pending `AccumulateGrad` invocations on exit, which in
turn triggers the post backward hooks registered by FSDP. Later,
the outer GraphTask will trigger that again, leading to the above
error.

PR #89791 relaxes the FSDP training state check, but we still run
into grad value check failures occasionally. Therefore, this PR only
lands the test for non-reentrant test, and we can enable the
reentrant test when the accuracy issues are addressed.