### PR TITLE
Fix archive issue impacting summary stat diff

### DIFF
--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -1342,7 +1342,10 @@ if __name__ == "__main__":
             )
             if not args.no_update_archive:
                 archive(
-                    output_dir, args.dashboard_archive_path, args.archive_name, dtypes[0]
+                    output_dir,
+                    args.dashboard_archive_path,
+                    args.archive_name,
+                    dtypes[0],
                 )
 
     if args.update_dashboard:

--- a/benchmarks/dynamo/runner.py
+++ b/benchmarks/dynamo/runner.py
@@ -1340,6 +1340,10 @@ if __name__ == "__main__":
             parse_logs(
                 args, dtypes, suites, devices, compilers, flag_compilers, output_dir
             )
+            if not args.no_update_archive:
+                archive(
+                    output_dir, args.dashboard_archive_path, args.archive_name, dtypes[0]
+                )
 
     if args.update_dashboard:
         DashboardUpdater(args).update()


### PR DESCRIPTION
Summary stat diff was reporting diff between previous day and the day before that, instead of today and previous day. Issue was because summary stats were not uploaded to the archive before the summary stat differ was run.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire