### PR TITLE
Deprecating DataPipes

### DIFF
--- a/torch/utils/data/datapipes/iter/__init__.py
+++ b/torch/utils/data/datapipes/iter/__init__.py
@@ -20,7 +20,6 @@ from torch.utils.data.datapipes.iter.filelister import (
     FileListerIterDataPipe as FileLister,
 )
 from torch.utils.data.datapipes.iter.fileopener import (
-    FileLoaderIterDataPipe as FileLoader,
     FileOpenerIterDataPipe as FileOpener,
 )
 from torch.utils.data.datapipes.iter.grouping import (
@@ -44,7 +43,6 @@ __all__ = ['Batcher',
            'Concater',
            'Demultiplexer',
            'FileLister',
-           'FileLoader',
            'FileOpener',
            'Filter',
            'Forker',

--- a/torch/utils/data/datapipes/iter/fileopener.py
+++ b/torch/utils/data/datapipes/iter/fileopener.py
@@ -3,11 +3,10 @@ from typing import Iterable, Tuple, Optional
 
 from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data.datapipes.datapipe import IterDataPipe
-from torch.utils.data.datapipes.utils.common import get_file_binaries_from_pathnames, _deprecation_warning
+from torch.utils.data.datapipes.utils.common import get_file_binaries_from_pathnames
 
 __all__ = [
     "FileOpenerIterDataPipe",
-    "FileLoaderIterDataPipe",
 ]
 
 
@@ -71,19 +70,3 @@ class FileOpenerIterDataPipe(IterDataPipe[Tuple[str, IOBase]]):
         if self.length == -1:
             raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))
         return self.length
-
-
-class FileLoaderIterDataPipe(IterDataPipe[Tuple[str, IOBase]]):
-
-    def __new__(
-            cls,
-            datapipe: Iterable[str],
-            mode: str = 'b',
-            length: int = -1):
-        _deprecation_warning(
-            cls.__name__,
-            deprecation_version="1.12",
-            removal_version="1.13",
-            new_class_name="FileOpener",
-        )
-        return FileOpenerIterDataPipe(datapipe=datapipe, mode=mode, length=length)


### PR DESCRIPTION
Summary: per title

Test Plan:
`buck2 test buck2 test //caffe2/test:datapipe` https://www.internalfb.com/intern/testinfra/testconsole/testrun/6473924589747074/
`buck2 test mode/opt //pytorch/data/test:tests`

Differential Revision: D41563765

---
`FileLoader` was deprecated and now removed. Please use `FileOpener` instead.