### PR TITLE
Macro Dynamo Progress Bar

### DIFF
--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -1,6 +1,9 @@
 import itertools
 import logging
 import os
+import time
+
+from tqdm import tqdm
 
 # logging level for dynamo generated graphs/bytecode/guards
 logging.CODE = 15
@@ -78,8 +81,21 @@ def init_logging(log_level, log_file_name=None):
 
 _step_counter = itertools.count(1)
 
+# Update num_steps if more phases are added: Dynamo, AOT, Backend
+# This is very inductor centric
+# _inductor.utils.has_triton() gives a circular import error here
+# try:
+#     import triton
+#     num_steps = 3
+# except:
+#     num_steps = 2
+pbar = tqdm(total=3, desc="torch.compile()")
+
 
 def get_step_logger(logger):
+    pbar.set_postfix_str(f"{logger.name}")
+    pbar.update(1)
+    time.sleep(1)
     step = next(_step_counter)
 
     def log(level, msg):

--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -89,7 +89,7 @@ try:
     num_steps = 3
 except:
     num_steps = 2
-pbar = tqdm(total=3, desc="torch.compile()")
+pbar = tqdm(total=num_steps, desc="torch.compile()")
 
 
 def get_step_logger(logger):

--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -83,11 +83,12 @@ _step_counter = itertools.count(1)
 # Update num_steps if more phases are added: Dynamo, AOT, Backend
 # This is very inductor centric
 # _inductor.utils.has_triton() gives a circular import error here
-# try:
-#     import triton
-#     num_steps = 3
-# except:
-#     num_steps = 2
+try:
+    import triton
+
+    num_steps = 3
+except:
+    num_steps = 2
 pbar = tqdm(total=3, desc="torch.compile()")
 
 

--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -1,7 +1,6 @@
 import itertools
 import logging
 import os
-import time
 
 from tqdm import tqdm
 
@@ -95,7 +94,6 @@ pbar = tqdm(total=3, desc="torch.compile()")
 def get_step_logger(logger):
     pbar.set_postfix_str(f"{logger.name}")
     pbar.update(1)
-    time.sleep(1)
     step = next(_step_counter)
 
     def log(level, msg):

--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -2,7 +2,7 @@ import itertools
 import logging
 import os
 
-from tqdm import tqdm
+from torch.hub import tqdm
 
 # logging level for dynamo generated graphs/bytecode/guards
 logging.CODE = 15


### PR DESCRIPTION
Video demo if add a 1s sleep: https://www.loom.com/share/436f988653a4455ba53b0b5067b15ab8

This is the simplest progress bar I could think of, goal is to have something that we can enable by default and merge quickly whereas more detailed progress bars could be enabled at a later date #88384 

An inductor compilation goes through 3 steps whereas most (all) other backends seem to go with just 2 so this meant I had a few choices
1. Since I figured users would be happier if something ends sooner rather than something going from 66% to 100% I opted for having the total always be 3 if triton is installed. This is not ideal if it so happens that triton is installed but if someone is not using the inductor backend
2. Another option would be to have a separate compilation bar just for inductor with 1 step

I feel like 1 bar for now makes the most sense and we can have 2 bars when I instrument the inductor passes. I tried 2 and it wasn't super helpful

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire
![Screen Shot 2022-11-28 at 7 16 09 PM](https://user-images.githubusercontent.com/3282513/204430105-68a5d473-f70a-4e8e-9dfe-24bebf9427a8.png)


