### PR TITLE
[Checkpoint][2D][5/N] Add checkpoint_utils for distributed checkpoint to testing/_internal/distributed/

### DIFF
--- a/torch/testing/_internal/distributed/checkpoint_utils.py
+++ b/torch/testing/_internal/distributed/checkpoint_utils.py
@@ -17,9 +17,7 @@ def with_temp_dir(
     assert func is not None
 
     @wraps(func)
-    def wrapper(
-        self, *args: Tuple[object], **kwargs: Dict[str, Any]  # type: ignore
-    ) -> None:
+    def wrapper(self, *args: Tuple[object], **kwargs: Dict[str, Any]) -> None:
         # Only create temp_dir when rank is 0
         if dist.get_rank() == 0:
             temp_dir = tempfile.mkdtemp()

--- a/torch/testing/_internal/distributed/checkpoint_utils.py
+++ b/torch/testing/_internal/distributed/checkpoint_utils.py
@@ -8,10 +8,12 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import torch.distributed as dist
 
 
-# wrapper to initialize temp directory for distributed checkpoint
 def with_temp_dir(
     func: Optional[Callable] = None,
 ) -> Optional[Callable]:
+    """
+    Wrapper to initialize temp directory for distributed checkpoint.
+    """
     assert func is not None
 
     @wraps(func)

--- a/torch/testing/_internal/distributed/checkpoint_utils.py
+++ b/torch/testing/_internal/distributed/checkpoint_utils.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+import shutil
+import tempfile
+from functools import wraps
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import torch.distributed as dist
+
+
+# wrapper to initialize temp directory for distributed checkpoint
+def with_temp_dir(
+    func: Optional[Callable] = None,
+) -> Optional[Callable]:
+    assert func is not None
+
+    @wraps(func)
+    def wrapper(
+        self, *args: Tuple[object], **kwargs: Dict[str, Any]  # type: ignore
+    ) -> None:
+        # Only create temp_dir when rank is 0
+        if dist.get_rank() == 0:
+            temp_dir = tempfile.mkdtemp()
+        else:
+            temp_dir = ""
+        object_list = [temp_dir]
+        # Broadcast temp_dir to all the other ranks
+        dist.broadcast_object_list(object_list)
+        self.temp_dir = object_list[0]
+        print(f"Using temp directory: {self.temp_dir }")
+        try:
+            func(self)
+        finally:
+            if dist.get_rank() == 0:
+                shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    return wrapper


### PR DESCRIPTION
Moving checkpoint_utils from Tau: https://github.com/wz337/PiPPy/blob/6acf4054cfd10c8377d65fa1e4f18230d6711edd/spmd/testing/checkpoint_utils.py 

Checkpoint_utils: add a wrapper to initialize a temp directory for checkpoint testing.