### PR TITLE
Guarantee symbol allocation for all sizes/strides/storage offset

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -1614,8 +1614,8 @@ class TestAOTModuleSimplified(AOTTestCase):
         res[0].sum().backward()
 
         self.assertExpectedInline(shape_env.format_guards(), """\
- - Eq(s1, 20)
- - Eq(s2, 30)""")
+ - Eq(s3, 20)
+ - Eq(s9, 30)""")
 
         assert torch.allclose(ref[0], res[0])
         assert torch.allclose(inputs[0].grad, cloned_inputs[0].grad)

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -344,7 +344,7 @@ class TestPySymInt(TestCase):
         shape_env = ShapeEnv()
         a0 = create_symint(shape_env, 2)
         self.assertEqual(guard_int(a0), 2)
-        self.assertEqual(str(shape_env.guards[0][0]), "Eq(s0, 2)")
+        self.assertExpectedInline(str(shape_env.guards[0][0]), """Eq(s1, 2)""")
 
     @skipIfNoSympy
     def test_sym_int(self):
@@ -353,19 +353,19 @@ class TestPySymInt(TestCase):
         r = sym_int(a0)
         self.assertEqual(r, 5)
         self.assertIsInstance(r, torch.SymInt, msg=type(r))
-        self.assertEqual(str(shape_env.guards[0][0]), "Eq(s0, 5)")
+        self.assertExpectedInline(str(shape_env.guards[0][0]), """Eq(s1, 5)""")
 
         a1 = create_symint(shape_env, 7)
         r = sym_int(a1 / 2)
         self.assertEqual(guard_int(r), 3)
         self.assertIsInstance(r, torch.SymInt, msg=type(r))
-        self.assertEqual(str(shape_env.guards[1][0]), "Eq(floor(s1/2), 3)")
+        self.assertExpectedInline(str(shape_env.guards[1][0]), """Eq(floor(s3/2), 3)""")
 
         a2 = create_symint(shape_env, -3)
         r = sym_int(a2 / 2)
         self.assertEqual(guard_int(r), -1)
         self.assertIsInstance(r, torch.SymInt, msg=type(r))
-        self.assertEqual(str(shape_env.guards[2][0]), "Eq(ceiling(-s2/2), -1)")
+        self.assertExpectedInline(str(shape_env.guards[2][0]), """Eq(ceiling(-s5/2), -1)""")
 
     @skipIfNoSympy
     def test_sym_sqrt(self):
@@ -374,7 +374,7 @@ class TestPySymInt(TestCase):
         r = sym_sqrt(a0)
         self.assertEqual(r, 2)
         self.assertIsInstance(r, torch.SymFloat, msg=type(r))
-        self.assertEqual(str(shape_env.guards[0][0]), "Eq(sqrt(s0), 2)")
+        self.assertExpectedInline(str(shape_env.guards[0][0]), """Eq(sqrt(s1), 2)""")
 
     @skipIfNoSympy
     def test_sym_floor(self):
@@ -383,7 +383,7 @@ class TestPySymInt(TestCase):
         r = math.floor(a0 / 2)
         self.assertEqual(r, 2)
         self.assertIsInstance(r, torch.SymInt, msg=type(r))
-        self.assertEqual(str(shape_env.guards[0][0]), "Eq(floor(s0/2), 2)")
+        self.assertExpectedInline(str(shape_env.guards[0][0]), """Eq(floor(s1/2), 2)""")
 
     @skipIfNoSympy
     def test_int_conversion(self):
@@ -430,18 +430,18 @@ class TestPySymInt(TestCase):
 
         self.assertExpectedInline(mock_stdout.getvalue().strip(), """\
 class f(torch.nn.Module):
-    def forward(self, a_1: f32[s0, s1], b_1: f32[s2, s1]):
+    def forward(self, a_1: f32[s1, s3], b_1: f32[s8, s3]):
         # No stacktrace found for following nodes
-        sym_size: Sym(s0) = torch.ops.aten.sym_size(a_1, 0)
-        sym_size_1: Sym(s2) = torch.ops.aten.sym_size(b_1, 0)
-        add: Sym(s0 + s2) = sym_size + sym_size_1;  sym_size = sym_size_1 = None
-        sym_size_2: Sym(s1) = torch.ops.aten.sym_size(a_1, 1)
-        sym_size_3: Sym(s1) = torch.ops.aten.sym_size(b_1, 1);  b_1 = None
-        add_1: Sym(2*s1) = sym_size_2 + sym_size_3;  sym_size_2 = sym_size_3 = None
-        new_empty: f32[s0 + s2, 2*s1] = torch.ops.aten.new_empty.default(a_1, [add, add_1], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False);  a_1 = add = add_1 = None
+        sym_size: Sym(s1) = torch.ops.aten.sym_size(a_1, 0)
+        sym_size_1: Sym(s8) = torch.ops.aten.sym_size(b_1, 0)
+        add: Sym(s1 + s8) = sym_size + sym_size_1;  sym_size = sym_size_1 = None
+        sym_size_2: Sym(s3) = torch.ops.aten.sym_size(a_1, 1)
+        sym_size_3: Sym(s3) = torch.ops.aten.sym_size(b_1, 1);  b_1 = None
+        add_1: Sym(2*s3) = sym_size_2 + sym_size_3;  sym_size_2 = sym_size_3 = None
+        new_empty: f32[s1 + s8, 2*s3] = torch.ops.aten.new_empty.default(a_1, [add, add_1], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False);  a_1 = add = add_1 = None
         native_dropout = torch.ops.aten.native_dropout.default(new_empty, 0.5, True);  new_empty = None
-        getitem: f32[s0 + s2, 2*s1] = native_dropout[0]
-        getitem_1: b8[s0 + s2, 2*s1] = native_dropout[1];  native_dropout = None
+        getitem: f32[s1 + s8, 2*s3] = native_dropout[0]
+        getitem_1: b8[s1 + s8, 2*s3] = native_dropout[1];  native_dropout = None
         return (getitem, getitem_1)""")  # noqa: B950
 
 # This environment variable controls whether or not we print expected failure

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -987,7 +987,7 @@ def forward(self, a_1):
             assert b.shape[0] == 8
             return a.cos()
         fx_g = make_fx(f, tracing_mode="symbolic")(torch.randn(16), torch.randn(8))
-        self.assertExpectedInline(str(fx_g.shape_env.get_guard_expr()), "Eq(s1, 8) & Eq(s0, 2*s1)")
+        self.assertExpectedInline(str(fx_g.shape_env.get_guard_expr()), """Eq(s5, 8) & Eq(s1, 2*s5)""")
 
     def test_sym_storage_offset(self):
         def f(x, y):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1,6 +1,6 @@
 import torch
 import torch.utils._pytree as pytree
-from typing import Set, Dict, List, Type, Optional, cast, Union
+from typing import Set, Dict, List, Type, Optional, cast
 import sys
 import operator
 import builtins
@@ -148,11 +148,18 @@ class SymNode:
     This is a type erased SymInt/SymFloat which we use to do actual operations.
     End users don't touch this.  Magic methods are NOT defined on this object.
     """
-    def __init__(self, expr, shape_env, pytype, constant=None):
+    def __init__(self, expr, shape_env, pytype, constant=None, symbol=None):
         self._expr = expr
         self.shape_env = shape_env
         self.pytype = pytype
         self.constant = constant
+        # Unlike expr, sympy.Symbol is guaranteed to either be a
+        # symbol or its negation a symbol, and it never gets simplified into a
+        # constant or another symbol.  This only exists for freshly
+        # create_symint; intermediate values are None.  The usage of this
+        # property is fairly short-lived: it lives long enough so that Dynamo
+        # can get its hands on symbols and setup Source associations
+        self.symbol: Optional[sympy.Expr] = symbol
 
     @property
     def expr(self):
@@ -499,30 +506,59 @@ class ShapeEnv(object):
                 )
                 stride[i] = self.create_symbol(val)
         assert all(x is not None for x in stride)
-        return [self.create_symintnode(i) for i in size], [self.create_symintnode(i) for i in stride]  # type: ignore[arg-type]
+        sym_size = [self.create_symintnode(i) for i in size]
+        sym_stride = []
+        for stride_expr in stride:
+            # NB: Don't duck size the stride; instead use the expression
+            # we computed
+            # TODO: We actually allocated an unnecessary extra symbol
+            # here in the smallest unbound stride case, but it's not
+            # a big deal because the non-0/1 symbol immediately
+            # evaporates from its duck-sizing simplification
+            s = self.create_symbol(val, simplify=False)
+            assert stride_expr is not None
+            assert isinstance(s, sympy.Symbol)
+            self.replacements[s] = stride_expr
+            sym_stride.append(self.create_symintnode(s))
+        return sym_size, sym_stride
 
-    def create_symintnode(self, expr: Union["sympy.Expr", int]):
-        return SymInt(SymNode(expr, self, int))
+    def create_symintnode(self, sym: "sympy.Expr"):
+        assert isinstance(sym, sympy.Symbol) or isinstance(-sym, sympy.Symbol)
+        return SymInt(SymNode(sym.xreplace(self.replacements), self, int, symbol=sym))
 
-    def create_symbol(self, val: int) -> "sympy.Expr":
+    # This is guaranteed to return a symbol or its negation is a sympy.Symbol,
+    # but there may be a replacement that allows it to be immediately
+    # simplified
+    def create_symbol(self, val: int, *, simplify: bool = True) -> "sympy.Expr":
         if not HAS_SYMPY:
             raise RuntimeError("Need sympy installed to create symbolic shapes")
+
         if val < 0:
-            # all sympy base variables must be positive and > 1
-            return -self.create_symbol(-val)
+            return -self.create_symbol(-val, simplify=simplify)
+
+        symbol = sympy.Symbol(f"s{len(self.var_to_val)}", positive=True, integer=True)
+        self.var_to_val[symbol] = sympy.Integer(val)
+
+        if not simplify:
+            return symbol
+
+        # Now attempt to simplify this symbol
+        # TODO: Create a guard whenever this happens
+        # TODO: Do this duck sizing lazily later
+
         # This implements duck-shaping: input sizes that match are assigned
         # the same symint
-        # TODO: Create a guard whenever this happens
-        # TODO: But how do I represent the guard in this case?
-        # Note: val_to_var is also initialized with 0/1 mapping to constants, so
-        # this also ensures that all symbols are > 1
-        if val in self.val_to_var:
-            return self.val_to_var[val]
-        sympy_expr = sympy.Symbol(f"s{len(self.var_to_val)}", positive=True, integer=True)
-        self.var_to_val[sympy_expr] = sympy.Integer(val)
-        self.val_to_var[val] = sympy_expr
-        self.definitely_not_01.add(sympy_expr)
-        return sympy_expr
+        if val not in self.val_to_var:
+            sympy_expr = sympy.Symbol(f"s{len(self.var_to_val)}", positive=True, integer=True)
+            self.var_to_val[sympy_expr] = sympy.Integer(val)
+            self.val_to_var[val] = sympy_expr
+            self.definitely_not_01.add(sympy_expr)
+
+        self.replacements[symbol] = self.val_to_var[val]
+
+        # Return the *symbol*; you're expected to apply the replacement to get
+        # the simplified variable
+        return symbol
 
     def evaluate_guards_for_args(self, *args):
         new_env = ShapeEnv()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89962
* #89919
* __->__ #89879
* #89871

We may need to express guards on the size/stride/storage offset of
a tensor, but we cannot do this if it's already been duck sized.
This PR guarantees that we allocate a symbol (or negation of the
symbol) whenever we ask to create a SymInt, and propagates this
symbol to SymNode so that Dynamo can look at it (not in this PR).

This PR doesn't actually add guards, nor does Dynamo do anything
with these symbols.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>