### PR TITLE
Update Reviewers for PyTorch Distributed team

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -228,9 +228,14 @@
   - wanchaol
   - fduwjj
   - H-Huang
-  - d4l3k
   - aazzolini
   - kwen2501
+  - XilunWu
+  - wz337
+  - awgu
+  - fegin
+  - kumpera
+  - yhcharles
   mandatory_checks_name:
   - EasyCLA
   - Lint


### PR DESCRIPTION
- Reflect PyTorch Distributed team member change on the merge rule
- Added new team members since 2021
- Removed one member no longer on PyTorch Distributed team