### PR TITLE
[FSDP][BE] Move dynamo annotation to separate file

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -15,10 +15,6 @@ import numpy as np
 from functorch.experimental.ops import PyOperator
 
 import torch
-from torch.distributed.fsdp._dynamo_utils import (
-    FSDP_MANAGED_MODULE,
-    FSDP_USE_ORIG_PARAMS,
-)
 from torch.fx.immutable_collections import immutable_list
 
 from .. import config, mutation_guard, replay_record, skipfiles
@@ -311,14 +307,14 @@ class VariableBuilder:
                 return self.tx.output.side_effects.track_object_existing(
                     self.source, value, result
                 )
-            elif getattr(value, FSDP_MANAGED_MODULE, False) or issubclass(
+            elif getattr(value, "_is_fsdp_managed_module", False) or issubclass(
                 value.__class__, torch.nn.parallel.distributed.DistributedDataParallel
             ):
-                if getattr(value, FSDP_MANAGED_MODULE, False):
+                if getattr(value, "_is_fsdp_managed_module", False):
                     # Note: we can't do this assert inside FSDP constructor,
                     # since we don't know yet whether dynamo will be used
                     assert getattr(
-                        value, FSDP_USE_ORIG_PARAMS, False
+                        value, "_fsdp_use_orig_params", False
                     ), "Dynamo only supports FSDP with use_orig_params=True"
 
                 # See note [Dynamo treats FSDP wrapped modules as UnspecializedNNModule]

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -15,6 +15,10 @@ import numpy as np
 from functorch.experimental.ops import PyOperator
 
 import torch
+from torch.distributed.fsdp._dynamo_utils import (
+    FSDP_MANAGED_MODULE,
+    FSDP_USE_ORIG_PARAMS,
+)
 from torch.fx.immutable_collections import immutable_list
 
 from .. import config, mutation_guard, replay_record, skipfiles
@@ -307,14 +311,14 @@ class VariableBuilder:
                 return self.tx.output.side_effects.track_object_existing(
                     self.source, value, result
                 )
-            elif getattr(value, "_is_fsdp_managed_module", False) or issubclass(
+            elif getattr(value, FSDP_MANAGED_MODULE, False) or issubclass(
                 value.__class__, torch.nn.parallel.distributed.DistributedDataParallel
             ):
-                if getattr(value, "_is_fsdp_managed_module", False):
+                if getattr(value, FSDP_MANAGED_MODULE, False):
                     # Note: we can't do this assert inside FSDP constructor,
                     # since we don't know yet whether dynamo will be used
                     assert getattr(
-                        value, "_fsdp_use_orig_params", False
+                        value, FSDP_USE_ORIG_PARAMS, False
                     ), "Dynamo only supports FSDP with use_orig_params=True"
 
                 # See note [Dynamo treats FSDP wrapped modules as UnspecializedNNModule]

--- a/torch/distributed/fsdp/_dynamo_utils.py
+++ b/torch/distributed/fsdp/_dynamo_utils.py
@@ -36,10 +36,10 @@ def _annotate_modules_for_dynamo(
             order for backward to interleave hooks with compute per layer.  UnspecializedNNModule lets us achieve
             this by capturing the module code more 'functionally' and passing parameters in as inputs each time.
             """
-            submodule._is_fsdp_managed_module = True
+            submodule._is_fsdp_managed_module = True  # type: ignore[assignment]
 
             # Dynamo only supports FSDP with use_orig_params=True.
             # This is hacky, but I could not think of another way to add an assertion to dynamo
             # for this, since Dynamo skips all the FSDP code frames and thus can't inspect the
             # FSDP module directly
-            submodule._fsdp_use_orig_params = use_orig_params
+            submodule._fsdp_use_orig_params = use_orig_params  # type: ignore[assignment]

--- a/torch/distributed/fsdp/_dynamo_utils.py
+++ b/torch/distributed/fsdp/_dynamo_utils.py
@@ -1,0 +1,48 @@
+from typing import Set
+
+import torch.nn as nn
+
+FSDP_MANAGED_MODULE = "_is_fsdp_managed_module"
+FSDP_USE_ORIG_PARAMS = "_fsdp_use_orig_params"
+
+
+def _annotate_modules(
+    module: nn.Module,
+    ignored_modules: Set[nn.Module],
+    use_orig_params: bool,
+):
+    """
+    Annotates the submodules in ``module`` 's tree except those in
+    ``ignored_modules``, indicating that they are FSDP-managed and saving the
+    ``use_orig_params`` setting passed to the FSDP constructor.
+    """
+    for submodule in module.modules():
+        if submodule not in ignored_modules:
+            """[note: Dynamo treats FSDP wrapped modules as UnspecializedNNModule]
+
+            Dynamo doesn't get to see this instance (FullyShardedDataParallel) during tracing, since
+            it skips tracing all the torch.distributed.fsdp code.
+                - Why? Running the FSDP code eagerly avoids lots of issues trying to trace complex hooks, and also
+                gets us graph-breaks on FSDP module boundaries which we want anyway for comm ops.
+                - However, we _also_ want dynamo to treat the wrapped module inside FSDP 'unspecially' (*),
+                and we need a way to indicate to dynamo which modules are wrapped by FSDP.
+
+            (*) UnspecializedNNModules in dynamo are traced-through without any assumptions, and with thorough
+            guards.  NNModules otherwise are 'specialized', meaning there is less overhead due to assuming
+            their code is well-behaved.
+
+            One particular issue with specialized NNModules for FSDP is that the
+            views created for orig_params are captured into the compiled graph on the first iteration, and while
+            they are always going to point to the correct flatparameter and give correct results, their order
+            of creation influences the order of backward execution, preventing overlap of comm and computation
+            during backward.  We need to _use_ the new parameter views created on each forward iteration, in
+            order for backward to interleave hooks with compute per layer.  UnspecializedNNModule lets us achieve
+            this by capturing the module code more 'functionally' and passing parameters in as inputs each time.
+            """
+            setattr(submodule, FSDP_MANAGED_MODULE, True)
+
+            # Dynamo only supports FSDP with use_orig_params=True.
+            # This is hacky, but I could not think of another way to add an assertion to dynamo
+            # for this, since Dynamo skips all the FSDP code frames and thus can't inspect the
+            # FSDP module directly
+            setattr(submodule, FSDP_USE_ORIG_PARAMS, use_orig_params)

--- a/torch/distributed/fsdp/_dynamo_utils.py
+++ b/torch/distributed/fsdp/_dynamo_utils.py
@@ -36,10 +36,10 @@ def _annotate_modules_for_dynamo(
             order for backward to interleave hooks with compute per layer.  UnspecializedNNModule lets us achieve
             this by capturing the module code more 'functionally' and passing parameters in as inputs each time.
             """
-            setattr(submodule, "_is_fsdp_managed_module", True)
+            submodule._is_fsdp_managed_module = True
 
             # Dynamo only supports FSDP with use_orig_params=True.
             # This is hacky, but I could not think of another way to add an assertion to dynamo
             # for this, since Dynamo skips all the FSDP code frames and thus can't inspect the
             # FSDP module directly
-            setattr(submodule, "_fsdp_use_orig_params", use_orig_params)
+            submodule._fsdp_use_orig_params = use_orig_params

--- a/torch/distributed/fsdp/_dynamo_utils.py
+++ b/torch/distributed/fsdp/_dynamo_utils.py
@@ -2,9 +2,6 @@ from typing import Set
 
 import torch.nn as nn
 
-FSDP_MANAGED_MODULE = "_is_fsdp_managed_module"
-FSDP_USE_ORIG_PARAMS = "_fsdp_use_orig_params"
-
 
 def _annotate_modules_for_dynamo(
     module: nn.Module,
@@ -39,10 +36,10 @@ def _annotate_modules_for_dynamo(
             order for backward to interleave hooks with compute per layer.  UnspecializedNNModule lets us achieve
             this by capturing the module code more 'functionally' and passing parameters in as inputs each time.
             """
-            setattr(submodule, FSDP_MANAGED_MODULE, True)
+            setattr(submodule, "_is_fsdp_managed_module", True)
 
             # Dynamo only supports FSDP with use_orig_params=True.
             # This is hacky, but I could not think of another way to add an assertion to dynamo
             # for this, since Dynamo skips all the FSDP code frames and thus can't inspect the
             # FSDP module directly
-            setattr(submodule, FSDP_USE_ORIG_PARAMS, use_orig_params)
+            setattr(submodule, "_fsdp_use_orig_params", use_orig_params)

--- a/torch/distributed/fsdp/_dynamo_utils.py
+++ b/torch/distributed/fsdp/_dynamo_utils.py
@@ -6,15 +6,15 @@ FSDP_MANAGED_MODULE = "_is_fsdp_managed_module"
 FSDP_USE_ORIG_PARAMS = "_fsdp_use_orig_params"
 
 
-def _annotate_modules(
+def _annotate_modules_for_dynamo(
     module: nn.Module,
     ignored_modules: Set[nn.Module],
     use_orig_params: bool,
 ):
     """
-    Annotates the submodules in ``module`` 's tree except those in
-    ``ignored_modules``, indicating that they are FSDP-managed and saving the
-    ``use_orig_params`` setting passed to the FSDP constructor.
+    Annotates the submodules in ``module`` 's tree, except those in
+    ``ignored_modules``, indicating that the submodules are FSDP-managed and
+    saving the ``use_orig_params`` setting passed to the FSDP constructor.
     """
     for submodule in module.modules():
         if submodule not in ignored_modules:

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -35,7 +35,7 @@ from torch.distributed.fsdp._common_utils import (
     HandleTrainingState,
     TrainingState,
 )
-from torch.distributed.fsdp._dynamo_utils import _annotate_modules
+from torch.distributed.fsdp._dynamo_utils import _annotate_modules_for_dynamo
 from torch.distributed.fsdp._init_utils import (
     _check_orig_params_flattened,
     _get_default_comm_hook,
@@ -334,7 +334,7 @@ class FullyShardedDataParallel(nn.Module):
         _init_ignored_module_states(self, module, ignored_modules)
 
         # Add module annotations for Dynamo support (see function for details)
-        _annotate_modules(module, self._ignored_modules, use_orig_params)
+        _annotate_modules_for_dynamo(module, self._ignored_modules, use_orig_params)
 
         if auto_wrap_policy is not None:
             auto_wrap_kwargs = {

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -35,6 +35,7 @@ from torch.distributed.fsdp._common_utils import (
     HandleTrainingState,
     TrainingState,
 )
+from torch.distributed.fsdp._dynamo_utils import _annotate_modules
 from torch.distributed.fsdp._init_utils import (
     _check_orig_params_flattened,
     _get_default_comm_hook,
@@ -332,37 +333,8 @@ class FullyShardedDataParallel(nn.Module):
         super().__init__()
         _init_ignored_module_states(self, module, ignored_modules)
 
-        # Add module annotations for Dynamo support
-        for submodule in module.modules():
-            if submodule not in self._ignored_modules:
-                """[note: Dynamo treats FSDP wrapped modules as UnspecializedNNModule]
-
-                Dynamo doesn't get to see this instance (FullyShardedDataParallel) during tracing, since
-                it skips tracing all the torch.distributed.fsdp code.
-                 - Why? Running the FSDP code eagerly avoids lots of issues trying to trace complex hooks, and also
-                   gets us graph-breaks on FSDP module boundaries which we want anyway for comm ops.
-                 - However, we _also_ want dynamo to treat the wrapped module inside FSDP 'unspecially' (*),
-                   and we need a way to indicate to dynamo which modules are wrapped by FSDP.
-
-                (*) UnspecializedNNModules in dynamo are traced-through without any assumptions, and with thorough
-                guards.  NNModules otherwise are 'specialized', meaning there is less overhead due to assuming
-                their code is well-behaved.
-
-                One particular issue with specialized NNModules for FSDP is that the
-                views created for orig_params are captured into the compiled graph on the first iteration, and while
-                they are always going to point to the correct flatparameter and give correct results, their order
-                of creation influences the order of backward execution, preventing overlap of comm and computation
-                during backward.  We need to _use_ the new parameter views created on each forward iteration, in
-                order for backward to interleave hooks with compute per layer.  UnspecializedNNModule lets us achieve
-                this by capturing the module code more 'functionally' and passing parameters in as inputs each time.
-                """
-                submodule._is_fsdp_managed_module = True
-
-                # Dynamo only supports FSDP with use_orig_params=True.
-                # This is hacky, but I could not think of another way to add an assertion to dynamo
-                # for this, since Dynamo skips all the FSDP code frames and thus can't inspect the
-                # FSDP module directly
-                submodule._fsdp_use_orig_params = use_orig_params
+        # Add module annotations for Dynamo support (see function for details)
+        _annotate_modules(module, self._ignored_modules, use_orig_params)
 
         if auto_wrap_policy is not None:
             auto_wrap_kwargs = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #89913 [FSDP][Dynamo] Define annotation attributes as globals
* **#89890 [FSDP][BE] Move dynamo annotation to separate file**

This PR makes two minor changes: It (1) moves the recently-added module annotation logic for dynamo support to a separate file `torch/distributed/fsdp/_dynamo_utils.py` and ~~(2) saves the annotated attribute names to global variables `FSDP_MANAGED_MODULE` and `FSDP_USE_ORIG_PARAMS`~~.
Update: Since the distributed package may not be included in some builds, it is not safe to import from `torch.distributed...` to a file in `_dynamo/`. I will not include change (2) in this PR. The alternative is to define those globals (privately) in the dynamo file and import from there in the FSDP file.
- The first change is mainly a personal choice, where I wanted to avoid the dynamo explanation from dominating the FSDP constructor space-wise. I added the `(see function for details)` to the inline comment to forward interested readers.
- The second change follows the custom we have taken in the past for such attributes (e.g. `FSDP_FLATTENED`). My understanding (in the past as well as currently) is that this is a good practice.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire