### PR TITLE
Add tests for custom pybind type_casters

### DIFF
--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -27,6 +27,10 @@ bool function_taking_optional(c10::optional<torch::Tensor> tensor) {
   return tensor.has_value();
 }
 
+torch::Tensor random_tensor() {
+  return torch::randn({1});
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("sigmoid_add", &sigmoid_add, "sigmoid(x) + sigmoid(y)");
   m.def(
@@ -37,4 +41,16 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def(py::init<int, int>())
       .def("forward", &MatrixMultiplier::forward)
       .def("get", &MatrixMultiplier::get);
+
+  m.def("get_complex", []() { return c10::complex<double>(1.0, 2.0); });
+  m.def("get_device", []() { return at::device_of(random_tensor()).value(); });
+  m.def("get_generator", []() { return at::detail::getDefaultCPUGenerator(); });
+  m.def("get_intarrayref", []() { return at::IntArrayRef({1, 2, 3}); });
+  m.def("get_memory_format", []() { return c10::get_contiguous_memory_format(); });
+  m.def("get_storage", []() { return random_tensor().storage(); });
+  m.def("get_symfloat", []() { return c10::SymFloat(1.0); });
+  m.def("get_symint", []() { return c10::SymInt(1); });
+  m.def("get_symint_symbolic", []() { return c10::SymInt(c10::SymInt::UNCHECKED, INT64_MIN); });
+  m.def("get_symintarrayref", []() { return at::SymIntArrayRef({1, 2, 3}); });
+  m.def("get_tensor", []() { return random_tensor(); });
 }

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -1,6 +1,10 @@
 # Owner(s): ["module: cpp-extensions"]
 
+from itertools import repeat
 import os
+import re
+import sys
+from typing import Union
 import unittest
 
 import torch.testing._internal.common_utils as common
@@ -9,6 +13,16 @@ from torch.testing._internal.common_cuda import TEST_CUDA
 import torch
 import torch.backends.cudnn
 import torch.utils.cpp_extension
+
+if sys.version_info >= (3, 8):
+    from typing import get_args, get_origin
+else:
+    def get_args(tp):
+        return tp.__args__
+
+    def get_origin(tp):
+        if hasattr(tp, "__origin__"):
+            return tp.__origin__
 
 try:
     import pytest
@@ -132,6 +146,99 @@ class TestCppExtensionAOT(common.TestCase):
         ref = a + b
         test = cuda_dlink.add(a, b)
         self.assertEqual(test, ref)
+
+
+class TestPybindTypeCasters(common.TestCase):
+    """Pybind tests for ahead-of-time cpp extensions
+
+    These tests verify the types returned from cpp code using custom type
+    casters. By exercising pybind, we also verify that the type casters work
+    properly.
+
+    For each type caster in `torch/csrc/utils/pybind.h` we create a pybind
+    function that takes no arguments and returns the type_caster type. The
+    second argument to `PYBIND11_TYPE_CASTER` should be the type we expect to
+    receive in python, in these tests we verify this at run-time.
+    """
+    @staticmethod
+    def expected_return_type(func):
+        """
+        Our Pybind functions have a signature of the form `() -> return_type`.
+        """
+        # Imports needed for the `eval` below.
+        from typing import List, Tuple  # noqa: F401
+
+        return eval(re.search("-> (.*)\n", func.__doc__).group(1))
+
+    def check(self, func):
+        val = func()
+        expected = self.expected_return_type(func)
+        origin = get_origin(expected)
+        if origin is list:
+            self.check_list(val, expected)
+        elif origin is tuple:
+            self.check_tuple(val, expected)
+        else:
+            self.assertIsInstance(val, expected)
+
+    def check_list(self, vals, expected):
+        self.assertIsInstance(vals, list)
+        list_type = get_args(expected)[0]
+        for val in vals:
+            self.assertIsInstance(val, list_type)
+
+    def check_tuple(self, vals, expected):
+        self.assertIsInstance(vals, tuple)
+        tuple_types = get_args(expected)
+        if tuple_types[1] is ...:
+            tuple_types = repeat(tuple_types[0])
+        for val, tuple_type in zip(vals, tuple_types):
+            self.assertIsInstance(val, tuple_type)
+
+    def check_union(self, funcs):
+        """Special handling for Union type casters.
+
+        A single cpp type can sometimes be cast to different types in python.
+        In these cases we expect to get exactly one function per python type.
+        """
+        # Verify that all functions have the same return type.
+        union_type = set(self.expected_return_type(f) for f in funcs)
+        assert len(union_type) == 1
+        union_type = union_type.pop()
+        self.assertIs(Union, get_origin(union_type))
+        expected_types = set(get_args(union_type))
+        for func in funcs:
+            val = func()
+            for tp in expected_types:
+                if isinstance(val, tp):
+                    expected_types.remove(tp)
+                    break
+            else:
+                raise AssertionError(f"{val} is not an instance of {expected_types}")
+        self.assertFalse(expected_types, f"Missing functions for types {expected_types}")
+
+    def test_pybind_return_types(self):
+        functions = [
+            cpp_extension.get_complex,
+            cpp_extension.get_device,
+            cpp_extension.get_generator,
+            cpp_extension.get_intarrayref,
+            cpp_extension.get_memory_format,
+            cpp_extension.get_storage,
+            cpp_extension.get_symfloat,
+            cpp_extension.get_symintarrayref,
+            cpp_extension.get_tensor,
+        ]
+        union_functions = [
+            [cpp_extension.get_symint, cpp_extension.get_symint_symbolic],
+        ]
+        for func in functions:
+            with self.subTest(msg=f"check {func.__name__}"):
+                self.check(func)
+        for funcs in union_functions:
+            with self.subTest(msg=f"check {[f.__name__ for f in funcs]}"):
+                self.check_union(funcs)
+
 
 class TestORTTensor(common.TestCase):
     def test_unregistered(self):

--- a/torch/csrc/DynamicTypes.h
+++ b/torch/csrc/DynamicTypes.h
@@ -9,6 +9,7 @@
 #include <c10/core/Layout.h>
 #include <c10/core/ScalarType.h>
 #include <c10/core/ScalarTypeToTypeMeta.h>
+#include <torch/csrc/Export.h>
 
 #include <memory>
 #include <string>
@@ -24,7 +25,7 @@ namespace torch {
 void registerDtypeObject(THPDtype* dtype, at::ScalarType scalarType);
 void registerLayoutObject(THPLayout* thp_layout, at::Layout layout);
 
-PyObject* createPyObject(const at::Storage& storage);
+TORCH_PYTHON_API PyObject* createPyObject(const at::Storage& storage);
 at::Storage createStorage(PyObject* obj);
 at::Storage createStorageGetType(
     PyObject* obj,

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -51,7 +51,7 @@ template <>
 struct type_caster<at::Storage> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
-  PYBIND11_TYPE_CASTER(at::Storage, _("torch.storage._StorageBase"));
+  PYBIND11_TYPE_CASTER(at::Storage, _("torch.StorageBase"));
 
   bool load(handle src, bool) {
     PyObject* obj = src.ptr();
@@ -97,7 +97,7 @@ template <>
 struct TORCH_PYTHON_API type_caster<at::IntArrayRef> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
-  PYBIND11_TYPE_CASTER(at::IntArrayRef, _("typing.Tuple[int, ...]"));
+  PYBIND11_TYPE_CASTER(at::IntArrayRef, _("Tuple[int, ...]"));
 
   bool load(handle src, bool);
   static handle cast(
@@ -113,7 +113,7 @@ template <>
 struct TORCH_PYTHON_API type_caster<at::SymIntArrayRef> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
-  PYBIND11_TYPE_CASTER(at::SymIntArrayRef, _("at::SymIntArrayRef"));
+  PYBIND11_TYPE_CASTER(at::SymIntArrayRef, _("List[int]"));
 
   bool load(handle src, bool);
   static handle cast(
@@ -126,7 +126,7 @@ struct TORCH_PYTHON_API type_caster<at::SymIntArrayRef> {
 };
 
 template <>
-struct TORCH_PYTHON_API type_caster<at::MemoryFormat> {
+struct type_caster<at::MemoryFormat> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   PYBIND11_TYPE_CASTER(at::MemoryFormat, _("torch.memory_format"));
@@ -204,9 +204,9 @@ struct type_caster<c10::DispatchKey>
 };
 
 template <>
-struct type_caster<c10::SymInt> {
+struct TORCH_PYTHON_API type_caster<c10::SymInt> {
  public:
-  PYBIND11_TYPE_CASTER(c10::SymInt, _("torch._prims_common.IntLike"));
+  PYBIND11_TYPE_CASTER(c10::SymInt, _("Union[int, torch.SymInt]"));
   bool load(py::handle src, bool);
 
   static py::handle cast(
@@ -216,9 +216,9 @@ struct type_caster<c10::SymInt> {
 };
 
 template <>
-struct type_caster<c10::SymFloat> {
+struct TORCH_PYTHON_API type_caster<c10::SymFloat> {
  public:
-  PYBIND11_TYPE_CASTER(c10::SymFloat, _("torch._prims_common.FloatLike"));
+  PYBIND11_TYPE_CASTER(c10::SymFloat, _("float"));
   bool load(py::handle src, bool);
 
   static py::handle cast(
@@ -231,7 +231,7 @@ template <typename T>
 struct type_caster<c10::complex<T>> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
-  PYBIND11_TYPE_CASTER(c10::complex<T>, _("torch._complex.complex"));
+  PYBIND11_TYPE_CASTER(c10::complex<T>, _("complex"));
 
   bool load(handle src, bool) {
     PyObject* obj = src.ptr();

--- a/torch/csrc/utils/tensor_memoryformats.h
+++ b/torch/csrc/utils/tensor_memoryformats.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <c10/core/MemoryFormat.h>
+#include <torch/csrc/Export.h>
 #include <torch/csrc/utils/python_stub.h>
 
 namespace torch {
 namespace utils {
 
 void initializeMemoryFormats();
-PyObject* getTHPMemoryFormat(c10::MemoryFormat);
+TORCH_PYTHON_API PyObject* getTHPMemoryFormat(c10::MemoryFormat);
 
 } // namespace utils
 } // namespace torch


### PR DESCRIPTION
This is a followup to #89115 which Fixes #88958

This adds tests to verify at runtime that the types returned by custom pybind type_casters are correctly specified in the second argument to `PYBIND11_TYPE_CASTER`.