### PR TITLE
Hybrid Sharded Data Parallel

### DIFF
--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -1,0 +1,156 @@
+# Owner(s): ["oncall: distributed"]
+
+import contextlib
+import functools
+from functools import partial
+from collections import Counter
+import sys
+
+import torch
+import torch.distributed as dist
+
+from torch.distributed.distributed_c10d import _rank_not_in_group
+from torch.distributed.fsdp import (
+    FullyShardedDataParallel as FSDP,
+    ShardingStrategy,
+)
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import (
+    CUDAInitMode,
+    FSDPInitMode,
+    FSDPTest,
+    TransformerWithSharedParams,
+)
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
+
+if not dist.is_available():
+    print("Distributed not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+
+@contextlib.contextmanager
+def patch_allreduce(new_allreduce):
+    """
+    Patches dist.all_reduce with a new all_reduce and
+    restores upon exiting.
+    """
+    orig_ar = dist.all_reduce
+    dist.all_reduce = new_allreduce
+    try:
+        yield
+    finally:
+        dist.all_reduce = orig_ar
+
+@contextlib.contextmanager
+def patch_reduce_scatter(new_reduce_scatter):
+        """
+        Patches ``dist.reduce_scatter_tensor`` with ``new_reduce_scatter``
+        while in the context.
+        """
+        orig_reduce_scatter = dist.reduce_scatter_tensor
+        dist.reduce_scatter_tensor = new_reduce_scatter
+        try:
+            yield
+        finally:
+            dist.reduce_scatter_tensor = orig_reduce_scatter
+
+
+class TestFSDPHybridShard(FSDPTest):
+    @property
+    def world_size(self):
+        return torch.cuda.device_count()
+
+    @property
+    def process_group(self):
+        return dist.distributed_c10d._get_default_group()
+
+    @skip_if_lt_x_gpu(2)
+    def test_fsdp_hybrid_shard_basic_setup(self):
+        """
+        Tests basic functionality of HYBRID_SHARD and HYBRID_SHARD_ZERO2:
+            1. Inter and intra-node process groups are correctly setup
+            2. Process groups are the same across FSDP wrapped units
+            3. reduce_scatter and allreduce called the expected no. of times
+        """
+        for sharding_strategy in [
+            ShardingStrategy.HYBRID_SHARD, ShardingStrategy.HYBRID_SHARD_ZERO2
+        ]:
+            with self.subTest(sharding_strategy=sharding_strategy):
+                auto_wrap_policy = functools.partial(
+                    transformer_auto_wrap_policy,
+                    transformer_layer_cls={TransformerEncoderLayer, TransformerDecoderLayer},
+                )
+                fsdp_kwargs = {
+                    "auto_wrap_policy": auto_wrap_policy,
+                    "device_id": torch.cuda.current_device(),
+                    "sharding_strategy": sharding_strategy,
+                }
+                fsdp_model = TransformerWithSharedParams.init(
+                    self.process_group,
+                    FSDPInitMode.RECURSIVE,
+                    CUDAInitMode.CUDA_BEFORE,
+                    fsdp_kwargs,
+                )
+                # All FSDP modules should have state.process_group as the process group over which to
+                # shard (default process group), and state._inter_node_pg (process group containing only
+                # this rank)
+                intra_node_pgs = set()
+                inter_node_pgs = set()
+                for mod in fsdp_model.fsdp_modules(fsdp_model):
+                    self.assertEqual(
+                        dist.get_world_size(mod.process_group),
+                        dist.get_world_size(self.process_group)
+                    )
+                    intra_node_pgs.add(mod.process_group)
+                    inter_node_pg = mod._inter_node_pg
+                    inter_node_pgs.add(inter_node_pg)
+                    self.assertEqual(1, dist.get_world_size(inter_node_pg))
+                    self.assertFalse(_rank_not_in_group(inter_node_pg))
+                    self.assertEqual(
+                        sharding_strategy, mod.sharding_strategy
+                    )
+                # All fsdp modules should share the same process groups
+                self.assertEqual(1, len(intra_node_pgs))
+                self.assertEqual(1, len(inter_node_pgs))
+
+                orig_ar = dist.all_reduce
+                orig_rs = dist.reduce_scatter_tensor
+
+                def patched_collective(orig_collective, counter, *args, **kwargs):
+                    counter[orig_collective] += 1
+                    return orig_collective(*args, **kwargs)
+
+                cntr = Counter()
+                patched_allreduce = partial(patched_collective, orig_ar, cntr)
+                patched_reduce_scatter = partial(patched_collective, orig_rs, cntr)
+                with (
+                    patch_allreduce(patched_allreduce),
+                    patch_reduce_scatter(patched_reduce_scatter),
+                ):
+                    inp = fsdp_model.get_input(device=torch.cuda.current_device())
+                    out = fsdp_model(inp[0], inp[1])
+                    loss = fsdp_model.get_loss(inp, out)
+                    loss.backward()
+
+                num_flat_params = len(list(FSDP._fsdp_handles(fsdp_model)))
+                self.assertEqual(num_flat_params, cntr[orig_ar])
+                self.assertEqual(num_flat_params, cntr[orig_rs])
+                dist.barrier()
+
+instantiate_parametrized_tests(TestFSDPHybridShard)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -124,11 +124,15 @@ class TestFSDPHybridShard(FSDPTest):
         intra_pg = self.process_group
         inter_pg = dist.new_group(ranks=[self.rank])
         # Mismatched process groups
-        model.lin1 = FSDP(model.lin1, process_group=(intra_pg, inter_pg), sharding_strategy=ShardingStrategy.HYBRID_SHARD)
-        model = FSDP(model, process_group=(inter_pg, intra_pg), sharding_strategy=ShardingStrategy.HYBRID_SHARD)
+        model.lin1 = FSDP(
+            model.lin1, process_group=(intra_pg, inter_pg), sharding_strategy=ShardingStrategy.HYBRID_SHARD
+        )
+        model = FSDP(
+            model, process_group=(dist.new_group(), dist.new_group()), sharding_strategy=ShardingStrategy.HYBRID_SHARD
+        )
         # Errors during lazy_init
         inp = torch.randn(4, 10)
-        with self.assertRaisesRegex(ValueError, "do not match"):
+        with self.assertRaisesRegex(AssertionError, "do not match"):
             model(inp)
 
     @skip_if_lt_x_gpu(2)

--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -1,7 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
 import contextlib
-import functools
 from functools import partial
 from collections import Counter
 import sys

--- a/torch/distributed/_composable/fully_shard.py
+++ b/torch/distributed/_composable/fully_shard.py
@@ -49,7 +49,7 @@ def fully_shard(
         raise ValueError(f"Expects an `_FSDPPolicy` but got {policy}")
     state = fully_shard.state(module)
     state = _init_ignored_module_states(state, module, ignored_modules)
-    state = _init_process_group_state(state, process_group, ShardingStrategy.FULL_SHARD)
+    state = _init_process_group_state(state, process_group, ShardingStrategy.FULL_SHARD, policy)
     limit_all_gathers = True
     use_orig_params = True
     backward_prefetch_limit = 1

--- a/torch/distributed/_composable/fully_shard.py
+++ b/torch/distributed/_composable/fully_shard.py
@@ -49,7 +49,7 @@ def fully_shard(
         raise ValueError(f"Expects an `_FSDPPolicy` but got {policy}")
     state = fully_shard.state(module)
     state = _init_ignored_module_states(state, module, ignored_modules)
-    state = _init_process_group_state(state, process_group)
+    state = _init_process_group_state(state, process_group, ShardingStrategy.FULL_SHARD)
     limit_all_gathers = True
     use_orig_params = True
     backward_prefetch_limit = 1

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3543,7 +3543,7 @@ def new_subgroups(
         group_size = torch.cuda.device_count()
     world_size = get_world_size()
     if world_size < group_size:
-        raise ValueError("The arg 'group_size' must not exceed the world size")
+        raise ValueError(f"The arg 'group_size' ({group_size}) must not exceed the world size ({world_size})")
     if world_size % group_size != 0:
         raise ValueError("The world size must be divisible by 'group_size'")
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -106,12 +106,6 @@ def _init_process_group_state(
             assert state._inter_node_pg is not None, "Expected to populate state._inter_node_pg for hybrid shard"
             assert state._inter_node_state is not None, "Expected to populate state._inter_node_state for hybrid shad."
     else:
-        if process_group is not None and (
-            not isinstance(process_group, dist.ProcessGroup) and not issubclass(type(process_group), dist.ProcessGroup)
-        ):
-            raise ValueError(
-                f"process_group should be None or dist.ProcessGroup, but got {type(process_group)}"
-            )
         state.process_group = process_group if process_group is not None else _get_default_group()
 
     state.rank = state.process_group.rank()

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -61,7 +61,7 @@ except ImportError:
 PARAM_BROADCAST_BUCKET_SIZE = int(250 * 1024 * 1024)
 FSDP_SYNCED = "_fsdp_synced"
 # Specification of process groups for hybrid sharding strategies.
-HybridShardProcessGroupType: type = Tuple[dist.ProcessGroup, dist.ProcessGroup]
+HybridShardProcessGroupType = Tuple[dist.ProcessGroup, dist.ProcessGroup]
 # Overall specification of process group.
 ProcessGroupType = Optional[Union[dist.ProcessGroup, HybridShardProcessGroupType]]
 

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -155,15 +155,9 @@ def _is_valid_hybrid_shard_pg_type(process_group: Any) -> bool:
 def _init_intra_node_process_group() -> dist.ProcessGroup:
     """
     Returns a process group across the current node.
-    For example, given each column is a distinct node:
-    0 8
-    1 9
-    2 10
-    3 11
-    4 12
-    5 13
-    6 14
-    7 15
+    For example, given each row is a distinct node:
+    0 1 2 3 4 5 6 7 8
+    9 10 11 12 13 14 15
     This API would return an intra-node subgroup across
     [0, 7] or [8, 15] depending on the process's rank.
     For example, rank 3 would get [0, 7].
@@ -178,14 +172,8 @@ def _init_inter_node_process_group(
     """
     Returns an inter-node process group where each contained rank has
     the same local rank. For example, given each column is a distinct node:
-    0 8
-    1 9
-    2 10
-    3 11
-    4 12
-    5 13
-    6 14
-    7 15
+    0 1 2 3 4 5 6 7 8
+    9 10 11 12 13 14 15
     This API would return inter-node process group {0, 8}, {1, 9}, {2, 10}, and so forth
     depending on the process's rank. For example, rank 1 would get {1, 9}, rank 5
     would get {5, 13}.

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -106,7 +106,9 @@ def _init_process_group_state(
             assert state._inter_node_pg is not None, "Expected to populate state._inter_node_pg for hybrid shard"
             assert state._inter_node_state is not None, "Expected to populate state._inter_node_state for hybrid shad."
     else:
-        if process_group is not None and not isinstance(process_group, dist.ProcessGroup):
+        if process_group is not None and (
+            not isinstance(process_group, dist.ProcessGroup) and not issubclass(type(process_group), dist.ProcessGroup)
+        ):
             raise ValueError(
                 f"process_group should be None or dist.ProcessGroup, but got {type(process_group)}"
             )

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -669,8 +669,8 @@ def _should_free_in_backward(
     # We always free if we are syncing gradients (i.e. not in no_sync) and parameters
     # are sharded.
     free_unsharded = state._sync_gradients and handle.uses_sharded_strategy
-    # For NO_SHARD we don't need to free full parameters, for Zero-2 strategies, we skip
-    # freeing in backward. Note that this also applies for _HYBRID_SHARD_ZERO2.
+    # For NO_SHARD we don't need to free full parameters, for ZeRO-2 strategies, we skip
+    # freeing in backward.
     return free_unsharded or (
         handle._config.sharding_strategy in RESHARD_AFTER_FORWARD_STRATEGIES
     )

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -99,11 +99,13 @@ def _lazy_init(
         if fsdp_module is root_module:
             continue
 
-        _validate_hybrid_shard_setup(state, fsdp_module)
-        # Share the allreduce state across FSDP units. This is not strictly necessary
-        # as each one already uses the same process group, but can slightly save memory
-        # since other FSDP units allreduce state can be garbage collected.
-        fsdp_module._inter_node_state = state._inter_node_state
+        if fsdp_module.sharding_strategy in HYBRID_SHARDING_STRATEGIES:
+            _validate_hybrid_shard_setup(state, fsdp_module)
+            # Share the allreduce state across FSDP units. This is not strictly necessary
+            # as each one already uses the same process group, but can slightly save memory
+            # since other FSDP units allreduce state can be garbage collected.
+            fsdp_module._inter_node_state = state._inter_node_state
+
         # Relax the assert for non-root FSDP instances in case the nested
         # initialized module is wrapped again in FSDP later (e.g. after
         # training to run inference)

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -46,8 +46,16 @@ def _validate_hybrid_shard_setup(state: _FSDPState, fsdp_module: nn.Module):
         if state.sharding_strategy != fsdp_module.sharding_strategy:
             raise ValueError(
                 "When using hybrid sharding strategy, expect sharding strategies"
-                f"to be the same, but got {state.sharding_strategy} vs {fsdp_module.sharding_strategy}"
+                f" to be the same, but got {state.sharding_strategy} vs {fsdp_module.sharding_strategy}"
             )
+
+        # Ensure inter and intra-node process groups are the same
+        assert state.process_group == fsdp_module.process_group, (
+            f"For {state.sharding_strategy} intra-node process groups do not match"
+        )
+        assert state._inter_node_pg == fsdp_module._inter_node_pg, (
+            f"For {state.sharding_strategy}, inter-node process groups do not match"
+        )
 
 @no_type_check
 def _lazy_init(

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -50,6 +50,9 @@ def _validate_hybrid_shard_setup(state: _FSDPState, fsdp_module: nn.Module):
             )
 
         # Ensure inter and intra-node process groups are the same
+        # TODO (rohan-varma) unclear whether these should be asserts or Exceptions
+        # as they can happen due to bug in FSDP process group setup or user passing in
+        # incorrect configuration.
         assert state.process_group == fsdp_module.process_group, (
             f"For {state.sharding_strategy} intra-node process groups do not match"
         )

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -46,8 +46,15 @@ class ShardingStrategy(Enum):
       :class:`DistributedDataParallel` API. For gradients, this strategy
       synchronizes them (via all-reduce) after the backward computation. The
       unsharded optimizer states are updated locally per rank.
-    - ``HYBRID_SHARD``: foo
-    - ``HYBRID_SHARD_ZERO2``: foo
+    - ``HYBRID_SHARD``: Apply ``FULL_SHARD`` within a node, and data parallelism across
+        nodes. This results in reduced communication volume as expensive all-gathers and
+        reduce-scatters are only done within a node, and can be more performant for medium
+        sized models.
+    - ``HYBRID_SHARD_ZERO2``: Apply ``SHARD_GRAD_OP`` within a node, and data parallelism across
+        nodes. This results in reduced communication volume as expensive all-gathers and
+        reduce-scatters are only done within a node, and can be more performant for medium
+        sized models. Compared to ``HYBRID_SHARD``, users may wish to try this for even smaller
+        models that may not have to free full parameters after the forward pass.
     """
 
     FULL_SHARD = auto()

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -46,22 +46,21 @@ class ShardingStrategy(Enum):
       :class:`DistributedDataParallel` API. For gradients, this strategy
       synchronizes them (via all-reduce) after the backward computation. The
       unsharded optimizer states are updated locally per rank.
-    - ``HYBRID_SHARD``: Apply ``FULL_SHARD`` within a node, and data parallelism across
+    - ``HYBRID_SHARD``: Apply ``FULL_SHARD`` within a node, and replicate parameters across
         nodes. This results in reduced communication volume as expensive all-gathers and
-        reduce-scatters are only done within a node, and can be more performant for medium
-        sized models.
-    - ``HYBRID_SHARD_ZERO2``: Apply ``SHARD_GRAD_OP`` within a node, and data parallelism across
-        nodes. This results in reduced communication volume as expensive all-gathers and
-        reduce-scatters are only done within a node, and can be more performant for medium
-        sized models. Compared to ``HYBRID_SHARD``, users may wish to try this for even smaller
-        models that may not have to free full parameters after the forward pass.
+        reduce-scatters are only done within a node, which can be more performant for medium
+        -sized models.
+    - ``_HYBRID_SHARD_ZERO2``: Apply ``SHARD_GRAD_OP`` within a node, and replicate parameters across
+        nodes. This is like ``HYBRID_SHARD``, except this may provide even higher throughput
+        since the unsharded parameters are not freed after the forward pass, saving the
+        all-gathers in the pre-backward.
     """
 
     FULL_SHARD = auto()
     SHARD_GRAD_OP = auto()
     NO_SHARD = auto()
     HYBRID_SHARD = auto()
-    HYBRID_SHARD_ZERO2 = auto()
+    _HYBRID_SHARD_ZERO2 = auto()
 
 
 class BackwardPrefetch(Enum):

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -46,12 +46,15 @@ class ShardingStrategy(Enum):
       :class:`DistributedDataParallel` API. For gradients, this strategy
       synchronizes them (via all-reduce) after the backward computation. The
       unsharded optimizer states are updated locally per rank.
+    - ``HYBRID_SHARD``: foo
+    - ``HYBRID_SHARD_ZERO2``: foo
     """
 
     FULL_SHARD = auto()
     SHARD_GRAD_OP = auto()
     NO_SHARD = auto()
-    # HYBRID_SHARD = auto()
+    HYBRID_SHARD = auto()
+    HYBRID_SHARD_ZERO2 = auto()
 
 
 class BackwardPrefetch(Enum):

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -104,6 +104,8 @@ class HandleShardingStrategy(Enum):
     FULL_SHARD = auto()
     SHARD_GRAD_OP = auto()
     NO_SHARD = auto()
+    HYBRID_SHARD = auto()
+    HYBRID_SHARD_ZERO2 = auto()
 
 
 @dataclass

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -105,7 +105,7 @@ class HandleShardingStrategy(Enum):
     SHARD_GRAD_OP = auto()
     NO_SHARD = auto()
     HYBRID_SHARD = auto()
-    HYBRID_SHARD_ZERO2 = auto()
+    _HYBRID_SHARD_ZERO2 = auto()
 
 
 @dataclass

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -192,8 +192,11 @@ class FullyShardedDataParallel(nn.Module):
     Args:
         module (nn.Module):
             This is the module to be wrapped with FSDP.
-        process_group (Optional[ProcessGroup]):
-            This is the process group used for collective communications.
+        process_group: Optional[Union[ProcessGroup, Tuple[ProcessGroup, ProcessGroup]]]
+            This is the process group used for collective communications and
+            the one over which the model is sharded. For hybrid sharding strategies such as
+            ``ShardingStrategy.HYBRID_SHARD`` or ``ShardingStrategy.HYBRID_SHARD_ZERO2``, users can
+            pass in a tuple of process groups representing the sharding and data parallel groups.
         sharding_strategy (Optional[ShardingStrategy]):
             This configures the sharding strategy used by FSDP, which may trade
             off memory saving and communication overhead. See

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -193,8 +193,9 @@ class FullyShardedDataParallel(nn.Module):
         process_group: Optional[Union[ProcessGroup, Tuple[ProcessGroup, ProcessGroup]]]
             This is the process group used for collective communications and
             the one over which the model is sharded. For hybrid sharding strategies such as
-            ``ShardingStrategy.HYBRID_SHARD`` or ``ShardingStrategy.HYBRID_SHARD_ZERO2``, users can
-            pass in a tuple of process groups representing the sharding and data parallel groups.
+            ``ShardingStrategy.HYBRID_SHARD`` or ``ShardingStrategy._HYBRID_SHARD_ZERO2``, users can
+            pass in a tuple of process groups representing the groups to shard and replicate across,
+            respectively.
         sharding_strategy (Optional[ShardingStrategy]):
             This configures the sharding strategy used by FSDP, which may trade
             off memory saving and communication overhead. See
@@ -370,7 +371,7 @@ class FullyShardedDataParallel(nn.Module):
 
         # Initializes self.process_group, along with rank and world size. This will
         # also set another attribute, _inter_node_pg, to control the process group
-        # over which sharding occurs, if sharding_strategy is {HYBRID_SHARD, HYBRID_SHARD_ZERO2}.
+        # over which sharding occurs, if sharding_strategy is {HYBRID_SHARD, _HYBRID_SHARD_ZERO2}.
         # Note that this is done before auto_wrapping, so that child FSDP modules simply pick up
         # the same process group state as the root FSDP module.
         _init_process_group_state(self, process_group, sharding_strategy, auto_wrap_policy)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -372,7 +372,7 @@ class FullyShardedDataParallel(nn.Module):
         # over which sharding occurs, if sharding_strategy is {HYBRID_SHARD, HYBRID_SHARD_ZERO2}.
         # Note that this is done before auto_wrapping, so that child FSDP modules simply pick up
         # the same process group state as the root FSDP module.
-        _init_process_group_state(self, process_group, sharding_strategy)
+        _init_process_group_state(self, process_group, sharding_strategy, auto_wrap_policy)
         if auto_wrap_policy is not None:
             auto_wrap_kwargs = {
                 "module": module,

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -22,7 +22,6 @@ from typing import (
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed import ProcessGroup
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     _CHECKPOINT_WRAPPED_MODULE,
     ActivationWrapper,
@@ -47,7 +46,6 @@ from torch.distributed.fsdp._init_utils import (
     _init_runtime_state,
     _init_state_dict_state,
     HYBRID_SHARDING_STRATEGIES,
-    HybridShardProcessGroupType,
     ProcessGroupType,
 )
 from torch.distributed.fsdp._runtime_utils import (

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -183,4 +183,3 @@ def _replace_by_prefix(
         new_key = new_prefix + key[len(old_prefix) :]
         state_dict[new_key] = state_dict[key]
         del state_dict[key]
-

--- a/torch/distributed/utils.py
+++ b/torch/distributed/utils.py
@@ -183,3 +183,4 @@ def _replace_by_prefix(
         new_key = new_prefix + key[len(old_prefix) :]
         state_dict[new_key] = state_dict[key]
         del state_dict[key]
+

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -290,11 +290,16 @@ class TransformerWithSharedParams(FSDPTestModel):
                 across constructions.
             add_bn (bool): Whether to include batch norm in the model.
         """
+
         if fsdp_kwargs is None:
             fsdp_kwargs = {}
         if fsdp_init_mode == FSDPInitMode.NO_FSDP:
+            if isinstance(group, tuple):
+                pg = group[0]
+            else:
+                pg = group
             return TransformerWithSharedParams(
-                group, cuda_init_mode, add_bn, deterministic
+                pg, cuda_init_mode, add_bn, deterministic
             )
         elif fsdp_init_mode == FSDPInitMode.RECURSIVE:
             # Default to the `ModuleWrapPolicy`
@@ -307,11 +312,28 @@ class TransformerWithSharedParams(FSDPTestModel):
                 )
             else:
                 auto_wrap_policy = fsdp_kwargs.pop("auto_wrap_policy")
+
+            if (
+                "sharding_strategy" in fsdp_kwargs
+                and fsdp_kwargs["sharding_strategy"] in {
+                    ShardingStrategy.HYBRID_SHARD,
+                    ShardingStrategy.HYBRID_SHARD_ZERO2
+                } and not isinstance(group, tuple)
+            ):
+                fsdp_pg = None
+            else:
+                fsdp_pg = group
+
+            if isinstance(group, tuple):
+                tformer_pg = group[0]
+            else:
+                tformer_pg = group
+
             fsdp_model = FSDP(
                 TransformerWithSharedParams(
-                    group, cuda_init_mode, add_bn, deterministic
+                    tformer_pg, cuda_init_mode, add_bn, deterministic
                 ),
-                group,
+                fsdp_pg,
                 auto_wrap_policy=auto_wrap_policy,
                 **fsdp_kwargs,
             )

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -317,7 +317,7 @@ class TransformerWithSharedParams(FSDPTestModel):
                 "sharding_strategy" in fsdp_kwargs
                 and fsdp_kwargs["sharding_strategy"] in {
                     ShardingStrategy.HYBRID_SHARD,
-                    ShardingStrategy.HYBRID_SHARD_ZERO2
+                    ShardingStrategy._HYBRID_SHARD_ZERO2
                 } and not isinstance(group, tuple)
             ):
                 fsdp_pg = None

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -900,7 +900,7 @@ class DistributedTest:
         @skip_if_no_gpu
         def test_new_subgroups_group_size_exceeds_world_size(self):
             with self.assertRaisesRegex(
-                ValueError, "The arg 'group_size' must not exceed the world size"
+                ValueError, "must not exceed"
             ):
                 dist.new_subgroups(100)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89915

Adds 2 new hybrid sharding strategy to FSDP:
1. HYBRID_SHARD: applies zero-3 style sharding within a node, and data parallel across
2. HYBRID_SHARD_ZERO2: applies zero-2 style sharding within a node, and data parallel across

These are useful for medium sized models and aim to decrease communication volume, tests and benchmarks will be run to understand which workloads are optimal under which sharding strategy.

Hybrid sharding in general works by sharding the model using a process group within a single node, and creating intra-node process groups for replication / data parallelism. The user either needs to pass in a tuple of these process groups, or None, and we generate the process groups appropriately.

** Acknowledgements **
- @awgu 's excellent prototype: https://github.com/awgu/pytorch/commit/5ad3a16d486484c9ab4445126e50655eb19d62ca
- @liangluofb For ideation, feedback, and initial implementation and experimentation