### PR TITLE
[inductor] Disable parallel compilation inside fbcode

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -64,7 +64,7 @@ comment_origin = False
 @lru_cache(1)
 def is_fbcode():
     try:
-        import torch.fb
+        import torch.fb  # noqa: F401
     except ImportError:
         return False
     return True

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from functools import lru_cache
 
 # add some debug printouts
 debug = False
@@ -59,15 +60,24 @@ unroll_reductions_threshold = 8
 
 comment_origin = False
 
+@lru_cache(1)
+def is_fbcode():
+    try:
+        import torch.fb
+    except ImportError:
+        return False
+    return True
+
 compile_threads = (
+    1
+    if sys.platform == "win32" or is_fbcode()
+    else
     min(
         32,
         len(os.sched_getaffinity(0))
         if hasattr(os, "sched_getaffinity")
         else os.cpu_count(),
     )
-    if sys.platform != "win32"
-    else 1
 )
 
 # If kernel is fused, the name is generated from the origin node op names

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -60,6 +60,7 @@ unroll_reductions_threshold = 8
 
 comment_origin = False
 
+
 @lru_cache(1)
 def is_fbcode():
     try:
@@ -68,11 +69,11 @@ def is_fbcode():
         return False
     return True
 
+
 compile_threads = (
     1
     if sys.platform == "win32" or is_fbcode()
-    else
-    min(
+    else min(
         32,
         len(os.sched_getaffinity(0))
         if hasattr(os, "sched_getaffinity")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89926

Forking python processes using `multiprocessing` doesn't play nicely
with certain aspects of FB infra, so let's disable it until we find a better
solution.

Differential Revision: [D41618774](https://our.internmc.facebook.com/intern/diff/D41618774/)

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire