### PR TITLE
Fix binary ios builds

### DIFF
--- a/.circleci/scripts/binary_ios_build.sh
+++ b/.circleci/scripts/binary_ios_build.sh
@@ -8,7 +8,7 @@ PROJ_ROOT=/Users/distiller/project
 export TCLLIBPATH="/usr/local/lib"
 
 # Install conda
-curl --retry 3 --retry-all-errors -o ~/conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+curl --retry 3 -o ~/conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 chmod +x ~/conda.sh
 /bin/bash ~/conda.sh -b -p ~/anaconda
 export PATH="~/anaconda/bin:${PATH}"


### PR DESCRIPTION
curl on CircleCI MacOS runners does not support `--retry-all-errors`

Should fix https://app.circleci.com/pipelines/github/pytorch/pytorch/616842/workflows/5d1162c8-eeae-4627-a1b2-17b493b15b59/jobs/17230369?invite=true#step-105-62


Cleanup after https://github.com/pytorch/pytorch/pull/89157 that were missed by https://github.com/pytorch/pytorch/pull/89298
