### PR TITLE
workaround for indexing formulas with negative terms

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -520,7 +520,12 @@ class TestIndexingSimplification(TorchTestCase):
         self.assertEqual(
             sizevars.simplify_with_ranges(expr, var_ranges), i1 + 128 * i2 + 64 * r3
         )
-
+        # if there are negative terms in ModularIndexing base, we cannot replace it with IndexingDiv
+        expr = ModularIndexing(i1 - 15, 1, 64)
+        self.assertEqual(
+            sizevars.simplify_with_ranges(expr, var_ranges),
+            ModularIndexing(i1 - 15, 1, 64),
+        )
         # small terms should be kept if the rest is not guaranteed to be divisible
         self.assertEqual(
             sizevars.simplify_with_ranges(IndexingDiv(r3 + i2 + i1, 32), var_ranges),
@@ -548,6 +553,14 @@ class TestIndexingSimplification(TorchTestCase):
         # the same things happens with symbolic divisor
         self.assertEqual(
             ModularIndexing(i0 + i1 * i2 * r3, i2, r3), ModularIndexing(i0, i2, r3)
+        )
+
+        # if there are negative terms, we cannot optimize away zero terms due to https://github.com/openai/triton/issues/619
+        self.assertEqual(
+            ModularIndexing(-i0 + i1 * 20, 2, 10), ModularIndexing(-i0 + i1 * 20, 2, 10)
+        )
+        self.assertEqual(
+            ModularIndexing(-15 + i1 * 20, 2, 10), ModularIndexing(-15 + i1 * 20, 2, 10)
         )
 
         # Constant fold from divisor into base

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -192,19 +192,21 @@ class ModularIndexing(sympy.Function):
             new_terms = []
             all_positive = True
             for term in base.args:
-                if (isinstance(term, sympy.Integer) and term < 0) or (
-                    isinstance(term, sympy.Mul)
-                    and isinstance(term.args[0], sympy.Integer)
-                    and term.args[0] < 0
-                ):
-                    # workaround for https://github.com/openai/triton/issues/619,
-                    # if there are negative terms, // produces wrong result
-                    # TODO if https://github.com/openai/triton/issues/619 is fixed
-                    # this optimization would become valid
-                    all_positive = False
-                    break
                 if sympy.gcd(term, modulus * divisor) != modulus * divisor:
-                    new_terms.append(term)
+                    if (isinstance(term, sympy.Integer) and term < 0) or (
+                        isinstance(term, sympy.Mul)
+                        and isinstance(term.args[0], sympy.Integer)
+                        and term.args[0] < 0
+                    ):
+                        # workaround for https://github.com/openai/triton/issues/619,
+                        # if there are negative terms, // produces wrong result
+                        # TODO if https://github.com/openai/triton/issues/619 is fixed
+                        # this optimization would become valid
+                        all_positive = False
+                        break
+                    else:
+                        new_terms.append(term)
+
             if len(new_terms) != len(base.args) and all_positive:
                 return ModularIndexing(sum(new_terms), divisor, modulus)
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -190,10 +190,22 @@ class ModularIndexing(sympy.Function):
 
         if isinstance(base, sympy.Add):
             new_terms = []
+            all_positive = True
             for term in base.args:
+                if (isinstance(term, sympy.Integer) and term < 0) or (
+                    isinstance(term, sympy.Mul)
+                    and isinstance(term.args[0], sympy.Integer)
+                    and term.args[0] < 0
+                ):
+                    # workaround for https://github.com/openai/triton/issues/619,
+                    # if there are negative terms, // produces wrong result
+                    # TODO if https://github.com/openai/triton/issues/619 is fixed
+                    # this optimization would become valid
+                    all_positive = False
+                    break
                 if sympy.gcd(term, modulus * divisor) != modulus * divisor:
                     new_terms.append(term)
-            if len(new_terms) != len(base.args):
+            if len(new_terms) != len(base.args) and all_positive:
                 return ModularIndexing(sum(new_terms), divisor, modulus)
 
         if isinstance(base, IndexingDiv):

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -117,6 +117,7 @@ class SizeVarAllocator(object):
         """
         from .ir import IndexingDiv, ModularIndexing
 
+        # return expr
         expr = join_dimensions(self.simplify(expr))
         original_expr = expr
 
@@ -146,6 +147,11 @@ class SizeVarAllocator(object):
                 base_s = base.args[2] - 1
             elif not base.has(ModularIndexing):
                 # actual iteration range is to size-1
+                iter_ranges_zero = {k: 0 for k, v in var_ranges.items()}
+                base_lowest = sympy_subs(base, iter_ranges_zero)
+                if self.maybe_guard_lt(base_lowest, 0):
+                    # can't replace with indexing div if base can be negative
+                    return ModularIndexing(base, divisor, modulus)
                 iter_ranges = {k: v - 1 for k, v in var_ranges.items()}
                 base_s = sympy_subs(base, iter_ranges)
             else:

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -117,7 +117,6 @@ class SizeVarAllocator(object):
         """
         from .ir import IndexingDiv, ModularIndexing
 
-        # return expr
         expr = join_dimensions(self.simplify(expr))
         original_expr = expr
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchdynamo/issues/1928
For  `ModularIndexing` we generate indexing code with `//` and `%` operators. When `ModularIndexing` base is negative (that can happen after valid simplifications), `//` in triton produces wrong results https://github.com/openai/triton/issues/619/. For `//` op coming from pytorch, we have codegen workarounds, but I'm reluctant to apply these workarounds to very common indexing computation patterns, both for code readability and perf considerations.
Similarly, we replace `ModularIndexing` with `IndexingDiv` when we can prove that base is small, but those assumptions break when `ModularIndexing` base is negative (`ModularIndexing` is always positive, `IndexingDiv` isn't). 




cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire