### PR TITLE
[codemod][llvm15] LLVM-15 fixes for caffe2/test/cpp/jit/test_module_api.cpp

### DIFF
--- a/test/cpp/jit/test_module_api.cpp
+++ b/test/cpp/jit/test_module_api.cpp
@@ -66,7 +66,7 @@ TEST(ModuleAPITest, MethodRunAsync) {
     mtx.lock();
     ++counter;
     mtx.unlock();
-    at::launch(move(f));
+    at::launch(std::move(f));
   };
 
   auto method = m.get_method("forward");


### PR DESCRIPTION
Summary: This fixes issues which block `caffe2/test/cpp/jit/test_module_api.cpp` from compiling with LLVM-15.

Test Plan: Sandcastle

Reviewed By: meyering

Differential Revision: D41603454

