### PR TITLE
[codemod][llvm15] LLVM-15 fixes for caffe2/aten/src/ATen/native/cudnn/LossCTC.cpp

### DIFF
--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -94,7 +94,7 @@ bool _use_cudnn_ctc_loss(
       // target length < 256 is documented, but we see illegal memory accesses
       // when target lengths > input lengths for CuDNN
       use_cudnn &=
-          (target_lengths[b] < 256) & (target_lengths[b] <= input_lengths[b]);
+          (target_lengths[b] < 256) && (target_lengths[b] <= input_lengths[b]);
     }
   }
   return use_cudnn;


### PR DESCRIPTION
Summary: This fixes issues which block `caffe2/aten/src/ATen/native/cudnn/LossCTC.cpp` from compiling with LLVM-15.

Test Plan: Sandcastle

Reviewed By: meyering

Differential Revision: D41603378

