### PR TITLE
[codemod][llvm15] LLVM-15 fixes for caffe2/caffe2/video/video_decoder.h

### DIFF
--- a/caffe2/video/video_decoder.h
+++ b/caffe2/video/video_decoder.h
@@ -508,11 +508,11 @@ class CallbackImpl : public Callback {
   }
 
   void frameDecoded(std::unique_ptr<DecodedFrame> frame) override {
-    frames.push_back(move(frame));
+    frames.push_back(std::move(frame));
   }
 
   void audioDecoded(std::unique_ptr<DecodedAudio> audio_sample) override {
-    audio_samples.push_back(move(audio_sample));
+    audio_samples.push_back(std::move(audio_sample));
   }
 
   void videoDecodingStarted(const VideoMeta& /*videoMeta*/) override {


### PR DESCRIPTION
Summary: This fixes issues which block `caffe2/caffe2/video/video_decoder.h` from compiling with LLVM-15.

Test Plan: Sandcastle

Reviewed By: meyering

Differential Revision: D41603451

