### PR TITLE
[quantized] [executorch] typo

### DIFF
--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -319,7 +319,7 @@ def dequantize_per_channel(
        reserved for pattern matching)
 
     Returns:
-       dquantized float32 Tensor
+       dequantized float32 Tensor
     """
     assert input.dtype == dtype, f"Expecting input to have dtype torch.float32, but got dtype: {input.dtype}"
     assert axis < input.dim(), f"Expecting axis to be < {input.dim()}"


### PR DESCRIPTION
Summary: Inefficient impl in python

Test Plan: buck2 test mode/dev //caffe2/test/quantization:test_quantization -- --exact 'caffe2/test/quantization:test_quantization - test_quantized_embedding_byte (caffe2.test.quantization.core.test_quantized_tensor.TestQuantizedTensor)'

Differential Revision: D41627744



cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel