### PR TITLE
[tp] ufmt test/distributed/tensor

### DIFF
--- a/test/distributed/tensor/parallel/test_view_sharding_dim_change.py
+++ b/test/distributed/tensor/parallel/test_view_sharding_dim_change.py
@@ -2,14 +2,14 @@
 # Owner(s): ["oncall: distributed"]
 
 import torch
+from torch.distributed._tensor import DeviceMesh, DTensor, Shard
+from torch.distributed.tensor.parallel._view_with_dim_change import (
+    _view_with_sharding_dim_change,
+)
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
-)
-from torch.distributed._tensor import DeviceMesh, DTensor, Shard
-from torch.distributed.tensor.parallel._view_with_dim_change import (
-    _view_with_sharding_dim_change,
 )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89970
* #89969
* #89968
* #89967

formatting stack to make dtensor and tp align with pytorch format standard.

cmd: `ufmt format test/distributed/tensor`