### PR TITLE
Add error repro test for FSDP ignored modules with mixed precision

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -757,7 +757,6 @@ class TestFSDPMixedPrecisionUnsharded(TestFSDPMixedPrecision):
 instantiate_parametrized_tests(TestFSDPMixedPrecisionSharded)
 
 
-
 class IgnoredModule(nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -785,11 +785,11 @@ class TestFSDPMixedPrecisionIgnoredModules(FSDPTest):
     @skip_if_lt_x_gpu(1)
     def test_mixed_precision_with_ignored_module(self):
         model = Model().cuda()
-        bfloat16 = MixedPrecision(param_dtype=torch.bfloat16)
+        float16 = MixedPrecision(param_dtype=torch.float16)
         model = FSDP(
             model,
             ignored_modules=[model.ignored],
-            mixed_precision=bfloat16,
+            mixed_precision=float16,
         )
 
         x = torch.ones(2, 100, device=torch.cuda.current_device())

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -756,5 +756,48 @@ class TestFSDPMixedPrecisionUnsharded(TestFSDPMixedPrecision):
 
 instantiate_parametrized_tests(TestFSDPMixedPrecisionSharded)
 
+
+
+class IgnoredModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.l = nn.Linear(100, 100)
+
+    def forward(self, x):
+        return self.l(x)
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.l1 = nn.Linear(100, 100)
+        self.ignored = IgnoredModule()
+        self.l2 = nn.Linear(100, 100)
+
+    def forward(self, x):
+        return self.l2(self.ignored(self.l1(x)))
+
+
+class TestFSDPMixedPrecisionIgnoredModules(FSDPTest):
+    @property
+    def world_size(self):
+        return 1
+
+    @skip_if_lt_x_gpu(1)
+    def test_mixed_precision_with_ignored_module(self):
+        model = Model().cuda()
+        bfloat16 = MixedPrecision(param_dtype=torch.bfloat16)
+        model = FSDP(
+            model,
+            ignored_modules=[model.ignored],
+            mixed_precision=bfloat16,
+        )
+
+        x = torch.ones(2, 100, device=torch.cuda.current_device())
+
+        with self.assertRaisesRegex(RuntimeError, "must have the same dtype"):
+            model(x).sum().backward()
+
+
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89971
* #89930

The ignored modules are still using the original precision, which
leads to the following error.

```
RuntimeError: mat1 and mat2 must have the same dtype
```

This is not blocking me at the moment, but the fix seems not too
hard. We can add a pre-forward hook to each ignored module to
convert activations to original precision, and a post-forward hook
to convert it back to the specified precision.

Differential Revision: [D41661029](https://our.internmc.facebook.com/intern/diff/D41661029)