### PR TITLE
Remove DDP import

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/__init__.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/__init__.py
@@ -2,7 +2,6 @@ from enum import Enum
 from functools import partial
 
 import torch.distributed as dist
-from torch.nn.parallel import DistributedDataParallel
 
 from . import (
     debugging_hooks as debugging,
@@ -87,7 +86,7 @@ class DDPCommHookType(Enum):
 
 
 def register_ddp_comm_hook(
-    comm_hook_type: DDPCommHookType, model: DistributedDataParallel, state=None
+    comm_hook_type: DDPCommHookType, model, state=None
 ):
     """
     Registers the hooks of ``torch.distributed.algorithms.ddp_comm_hooks``


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89963
* #89194
* __->__ #89982

This import is only used for typing, removing it to avoid circular ref
in next diffs

Differential Revision: [D41636897](https://our.internmc.facebook.com/intern/diff/D41636897/)