### PR TITLE
[quant][fx] Add support for matching multiple arguments in patterns

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -5486,7 +5486,7 @@ class TestQuantizeFx(QuantizationTestCase):
         transpose (observed) -> reshape -> output (observed) ->
         """
 
-        def _get_pooling_configs():
+        def _get_pattern_configs():
             backend_pattern_configs = []
             observation_type = ObservationType.OUTPUT_SHARE_OBSERVER_WITH_INPUT
             weighted_op_quint8_dtype_config = DTypeConfig(
@@ -5508,7 +5508,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 ._set_root_node_getter(root_node_getter))
             return backend_pattern_configs
 
-        backend_config = BackendConfig().set_backend_pattern_configs(_get_pooling_configs())
+        backend_config = BackendConfig().set_backend_pattern_configs(_get_pattern_configs())
 
         class M(torch.nn.Module):
             def forward(self, x):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -5484,6 +5484,8 @@ class TestQuantizeFx(QuantizationTestCase):
         Pattern:
                            shape \
         transpose (observed) -> reshape -> output (observed) ->
+
+        where `reshape` has two arguments
         """
 
         def _get_pattern_configs():

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -5479,6 +5479,54 @@ class TestQuantizeFx(QuantizationTestCase):
             self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
             self.checkGraphModuleNodes(m_ref, expected_node_occurrence=node_occurrence_ref)
 
+    def test_match_pattern_with_multiple_args(self):
+        """ Test that we can match a pattern that has multiple arguments
+        Pattern:
+                           shape \
+        transpose (observed) -> reshape -> output (observed) ->
+        """
+
+        def _get_pooling_configs():
+            backend_pattern_configs = []
+            observation_type = ObservationType.OUTPUT_SHARE_OBSERVER_WITH_INPUT
+            weighted_op_quint8_dtype_config = DTypeConfig(
+                input_dtype=torch.quint8,
+                output_dtype=torch.quint8,
+                weight_dtype=torch.qint8,
+                bias_dtype=torch.float,
+            )
+            dtype_configs = [weighted_op_quint8_dtype_config]
+
+            def root_node_getter(node_pattern):
+                reshape, transpose, shape = node_pattern
+                return transpose
+
+            backend_pattern_configs.append(
+                BackendPatternConfig((torch.reshape, torch.transpose, MatchAllNode))
+                .set_observation_type(observation_type)  # noqa: E131
+                .set_dtype_configs(dtype_configs)
+                ._set_root_node_getter(root_node_getter))
+            return backend_pattern_configs
+
+        backend_config = BackendConfig().set_backend_pattern_configs(_get_pooling_configs())
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                x = torch.transpose(x, 0, 1)
+                x = torch.reshape(x, (-1,))
+                return x
+
+        m = M().eval()
+        qconfig_mapping = QConfigMapping().set_global(default_qconfig)
+        example_inputs = (torch.randn(1, 3, 3, 3),)
+        m = prepare_fx(m, qconfig_mapping, example_inputs, backend_config=backend_config)
+        node_occurrence = {
+            # one for input of the pattern and one for output of the pattern
+            ns.call_module(MinMaxObserver): 2
+        }
+        self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
+
+
 @skipIfNoFBGEMM
 class TestQuantizeFxOps(QuantizationTestCase):
     def setUp(self):

--- a/torch/ao/quantization/fx/match_utils.py
+++ b/torch/ao/quantization/fx/match_utils.py
@@ -18,7 +18,7 @@ from .graph_module import (
     is_observed_standalone_module,
 )
 from torch.nn.utils.parametrize import type_before_parametrizations
-from typing import Any, Dict, List, Callable, Optional, Tuple, Type, Set
+from typing import Any, Dict, List, Callable, Optional, Tuple, Type, Set, Iterable
 
 
 # TODO: revisit this list. Many helper methods shouldn't be public
@@ -133,6 +133,8 @@ def find_matches(
         if isinstance(node_pattern, Node):
             match_map[node_pattern.name] = (
                 last_node, matched_node_pattern, pattern, match_value)
+        elif not isinstance(node_pattern, Iterable):
+            return
         else:
             for n in node_pattern:
                 _recursive_record_node_in_match_map(last_node, match_map, n, matched_node_pattern, pattern, match_value)
@@ -146,6 +148,7 @@ def find_matches(
             match_map):
         if isinstance(pattern, tuple):
             s, *args = pattern
+            is_single_arg = len(args) == 1
             current_node_pattern: List[Node] = []
             record_match(
                 s,
@@ -162,7 +165,17 @@ def find_matches(
                         current_node_pattern,
                         match_map)
             if len(current_node_pattern) > 1:
-                matched_node_pattern.append(tuple(current_node_pattern))
+                # current_node_pattern is  the node pattern we get from matching
+                # the subpattern with arguments of the node
+                # we use is_single_arg to recover the original structure of the pattern
+                # if the original pattern has a single argument, we will have
+                # (original_op, (original_arg, ...))
+                # otherwise, we'll have a list of arguments
+                # (original_op, arg0, arg1, arg2, ...)
+                if is_single_arg:
+                    matched_node_pattern.append(tuple(current_node_pattern))
+                else:
+                    matched_node_pattern.extend(list(current_node_pattern))
             else:
                 matched_node_pattern.append(current_node_pattern[0])
         else:

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -241,10 +241,13 @@ def _is_pattern_dtype_config_and_qconfig_supported_by_backend(
     assert matched_node_pattern is not None and len(matched_node_pattern) >= 1
     pattern_to_dtype_configs = get_pattern_to_dtype_configs(backend_config)
     dtype_configs: List[DTypeConfig] = pattern_to_dtype_configs.get(pattern, [])
+    pattern_to_root_node_getter = get_fusion_pattern_to_root_node_getter(backend_config)
 
     # TODO: this only works for one input and one output patterns, need to generalize to multiple
     # inputs/output
-    root_node = _default_root_node_getter(matched_node_pattern)
+    # root_node = _default_root_node_getter(matched_node_pattern)
+    root_node_getter = pattern_to_root_node_getter.get(pattern, _default_root_node_getter)
+    root_node = root_node_getter(matched_node_pattern)
     input_node = root_node
     output_node = matched_node_pattern[0]
     for dtype_config in dtype_configs:
@@ -1276,7 +1279,9 @@ def insert_observers_for_model(
                     # TODO: this only works for sequential fusion right now, extend it
                     # it to automatically detect all input nodes based on the pattern
                     # need to change find_matches function to return this information
-                    root_node = _default_root_node_getter(matched_node_pattern)
+                    pattern_to_root_node_getter = get_fusion_pattern_to_root_node_getter(backend_config)
+                    root_node_getter = pattern_to_root_node_getter.get(pattern, _default_root_node_getter)
+                    root_node = root_node_getter(matched_node_pattern)
                     is_input_node_of_the_pattern = node is root_node
                     if is_input_node_of_the_pattern:
                         # this modifies node inplace

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -243,9 +243,6 @@ def _is_pattern_dtype_config_and_qconfig_supported_by_backend(
     dtype_configs: List[DTypeConfig] = pattern_to_dtype_configs.get(pattern, [])
     pattern_to_root_node_getter = get_fusion_pattern_to_root_node_getter(backend_config)
 
-    # TODO: this only works for one input and one output patterns, need to generalize to multiple
-    # inputs/output
-    # root_node = _default_root_node_getter(matched_node_pattern)
     root_node_getter = pattern_to_root_node_getter.get(pattern, _default_root_node_getter)
     root_node = root_node_getter(matched_node_pattern)
     input_node = root_node
@@ -1276,9 +1273,6 @@ def insert_observers_for_model(
                             if user != node and is_user_quantized:
                                 is_quantized_branch = True
 
-                    # TODO: this only works for sequential fusion right now, extend it
-                    # it to automatically detect all input nodes based on the pattern
-                    # need to change find_matches function to return this information
                     pattern_to_root_node_getter = get_fusion_pattern_to_root_node_getter(backend_config)
                     root_node_getter = pattern_to_root_node_getter.get(pattern, _default_root_node_getter)
                     root_node = root_node_getter(matched_node_pattern)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #89986

Summary:
This PR adds support for matching patterns that has multiple arguments, it's needed for quantization in PyTorch 2.0 early prototype

Before this PR, we only support patterns like:
```
x -> conv -> bn -> relu
(relu, (bn, conv))
```
where each operator has a single node, the code breaks when we want to match a pattern that has an op that has multiple arguments, such as:
```
                           shape \
        transpose -> reshape -> output ->
```
where `reshape` has two arguments

Test Plan:
python test/test_quantization.py TestQuantizeFx.test_match_pattern_with_multiple_args

Reviewers:

Subscribers:

Tasks:

Tags:

cc @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel