### PR TITLE
fix citation file in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include MANIFEST.in
 include CMakeLists.txt
-include CITATION
+include CITATION.cff
 include LICENSE
 include NOTICE
 include .gitmodules


### PR DESCRIPTION
#86200 changed the `CITATION` file to `CITATION.cff`, but this change was not reflected in the `MANIFEST.in`. Meaning, `CITATION.cff` will not be included in wheels.

cc @malfet @seemethere