### PR TITLE
Mark IPU device as not supports_as_strided (#89130)

### DIFF
--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -148,7 +148,8 @@ struct C10_API Device final {
 
   /// Return true if the device supports arbirtary strides.
   bool supports_as_strided() const noexcept {
-    return type_ != DeviceType::XLA && type_ != DeviceType::Lazy;
+    return type_ != DeviceType::IPU && type_ != DeviceType::XLA &&
+        type_ != DeviceType::Lazy;
   }
 
   /// Same string as returned from operator<<.


### PR DESCRIPTION
Link to landed master PR (if applicable):
https://github.com/pytorch/pytorch/pull/89130

Criteria Category:
2: This affects correct behaviour of `IPU` tensors, in the out-of-tree IPU backend.

I'm hoping this is a low-risk change, since it only affects how IPU tensors are tagged, and since the IPU backend is out-of-tree, it shouldn't affect anything here.