### PR TITLE
Handle Tensor.__deepcopy__ via clone(), on IPU (#89129)

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -113,7 +113,8 @@ class Tensor(torch._C._TensorBase):
             # Update the test in test_serialization if you remove 'meta' from here
             if (
                 self.is_sparse
-                or self.device.type in ["lazy", "xla", "mps", "ort", "meta", "hpu"]
+                or self.device.type
+                in ["lazy", "xla", "mps", "ort", "meta", "hpu", "ipu"]
                 or (
                     not torch._C._has_storage(self)
                     and self.device.type == "privateuseone"


### PR DESCRIPTION
Link to landed master PR (if applicable):
https://github.com/pytorch/pytorch/pull/89129

Criteria Category:
2: This affects correct behaviour of `IPU` tensors, in the out-of-tree IPU backend.

I'm hoping this is a low-risk change, since it only affects how IPU tensors are tagged, and since the IPU backend is out-of-tree, it shouldn't affect anything here.