### PR TITLE
[FX][Quant] Enable FX quant for patterns like x.view(x.size(...), ...)

### DIFF
--- a/torch/ao/quantization/backend_config/_common_operator_config_utils.py
+++ b/torch/ao/quantization/backend_config/_common_operator_config_utils.py
@@ -529,8 +529,6 @@ def _get_share_qparams_op_configs(dtype_configs):
         "resize_",
         "relu",
         "relu_",
-        "shape",
-        "size",
         "squeeze",
         "squeeze_",
         "transpose",
@@ -614,3 +612,16 @@ def _get_embedding_op_configs(dtype_configs: List[DTypeConfig]) -> List[BackendP
                 .set_reference_quantized_module(ref_embedding_op)
                 ._set_input_output_observed(False))  # This is temporary, and will be removed soon
     return embedding_op_configs
+
+def _get_tensor_info_op_configs(dtype_configs):
+    """
+    These ops work on tensors of different dtypes but return non-tensors
+    containing information about the input tensor.
+    """
+
+    def _get_config(op):
+        return BackendPatternConfig(op) \
+            .set_observation_type(ObservationType.INPUT_OUTPUT_NOT_OBSERVED) \
+            .set_dtype_configs(dtype_configs)
+
+    return [_get_config(op) for op in ("shape", "size")]

--- a/torch/ao/quantization/backend_config/backend_config.py
+++ b/torch/ao/quantization/backend_config/backend_config.py
@@ -63,6 +63,11 @@ class ObservationType(Enum):
     example: torch.cat, maxpool
     """
 
+    INPUT_OUTPUT_NOT_OBSERVED = 2
+    """this means the input and output are never observed
+    example: x.shape, x.size
+    """
+
 
 @dataclass
 class DTypeWithConstraints:

--- a/torch/ao/quantization/backend_config/fbgemm.py
+++ b/torch/ao/quantization/backend_config/fbgemm.py
@@ -10,6 +10,7 @@ from ._common_operator_config_utils import (
     _get_linear_configs,
     _get_rnn_op_configs,
     _get_share_qparams_op_configs,
+    _get_tensor_info_op_configs,
 )
 from .backend_config import BackendConfig, DTypeConfig
 
@@ -92,6 +93,7 @@ def get_fbgemm_backend_config() -> BackendConfig:
     default_op_dtype_configs = [fbgemm_default_op_quint8_dtype_config]
     fixed_qparams_op_dtype_configs = [fbgemm_default_op_quint8_dtype_config]
     share_qparams_op_dtype_configs = [fbgemm_default_op_quint8_dtype_config]
+    tensor_info_op_dtype_configs = [fbgemm_default_op_quint8_dtype_config]
     rnn_op_dtype_configs = [
         fbgemm_default_dynamic_int8_dtype_config,
         fbgemm_default_dynamic_float16_dtype_config,
@@ -108,6 +110,7 @@ def get_fbgemm_backend_config() -> BackendConfig:
         .set_backend_pattern_configs(_get_default_op_configs(default_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_fixed_qparams_op_configs(fixed_qparams_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_share_qparams_op_configs(share_qparams_op_dtype_configs)) \
+        .set_backend_pattern_configs(_get_tensor_info_op_configs(tensor_info_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_bn_configs(default_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_rnn_op_configs(rnn_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_embedding_op_configs(embedding_op_dtype_configs))

--- a/torch/ao/quantization/backend_config/native.py
+++ b/torch/ao/quantization/backend_config/native.py
@@ -11,6 +11,7 @@ from ._common_operator_config_utils import (
     _get_ln_configs,
     _get_rnn_op_configs,
     _get_share_qparams_op_configs,
+    _get_tensor_info_op_configs,
 )
 from .backend_config import BackendConfig, DTypeConfig
 
@@ -124,6 +125,9 @@ def get_test_only_legacy_native_backend_config() -> BackendConfig:
         default_op_quint8_dtype_config,
         default_op_fp16_dtype_config
     ]
+    tensor_info_op_dtype_configs = [
+        default_op_quint8_dtype_config,
+    ]
     rnn_op_dtype_configs = [
         default_dynamic_int8_dtype_config,
         default_dynamic_float16_dtype_config,
@@ -141,6 +145,7 @@ def get_test_only_legacy_native_backend_config() -> BackendConfig:
         .set_backend_pattern_configs(_get_default_op_configs(default_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_fixed_qparams_op_configs(fixed_qparams_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_share_qparams_op_configs(share_qparams_op_dtype_configs)) \
+        .set_backend_pattern_configs(_get_tensor_info_op_configs(tensor_info_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_bn_configs(default_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_ln_configs(layer_norm_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_rnn_op_configs(rnn_op_dtype_configs)) \
@@ -161,6 +166,7 @@ def get_native_backend_config() -> BackendConfig:
     default_op_dtype_configs = [default_op_quint8_dtype_config]
     fixed_qparams_op_dtype_configs = [default_op_quint8_dtype_config]
     share_qparams_op_dtype_configs = [default_op_quint8_dtype_config]
+    tensor_info_op_dtype_configs = [default_op_quint8_dtype_config]
     rnn_op_dtype_configs = [
         default_dynamic_int8_dtype_config,
         default_dynamic_float16_dtype_config,
@@ -178,6 +184,7 @@ def get_native_backend_config() -> BackendConfig:
         .set_backend_pattern_configs(_get_default_op_configs(default_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_fixed_qparams_op_configs(fixed_qparams_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_share_qparams_op_configs(share_qparams_op_dtype_configs)) \
+        .set_backend_pattern_configs(_get_tensor_info_op_configs(tensor_info_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_bn_configs(default_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_ln_configs(layer_norm_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_rnn_op_configs(rnn_op_dtype_configs)) \

--- a/torch/ao/quantization/backend_config/tensorrt.py
+++ b/torch/ao/quantization/backend_config/tensorrt.py
@@ -10,6 +10,7 @@ from ._common_operator_config_utils import (
     _get_linear_configs,
     _get_conv_configs,
     _get_share_qparams_op_configs,
+    _get_tensor_info_op_configs,
 )
 
 __all__ = [
@@ -59,6 +60,9 @@ def get_tensorrt_backend_config() -> BackendConfig:
     share_qparams_op_dtype_configs = [
         non_weighted_op_qint8_dtype_config,
     ]
+    tensor_info_op_dtype_configs = [
+        non_weighted_op_qint8_dtype_config,
+    ]
     # there might be things not supported in fx2trt, but it will error out
     # during fx2trt conversion and can support them after that
     return BackendConfig("tensorrt") \
@@ -67,7 +71,8 @@ def get_tensorrt_backend_config() -> BackendConfig:
         .set_backend_pattern_config(cat_config) \
         .set_backend_pattern_configs(_get_linear_configs(linear_dtype_configs)) \
         .set_backend_pattern_configs(_get_binary_op_configs(binary_op_dtype_configs)) \
-        .set_backend_pattern_configs(_get_share_qparams_op_configs(share_qparams_op_dtype_configs))
+        .set_backend_pattern_configs(_get_share_qparams_op_configs(share_qparams_op_dtype_configs)) \
+        .set_backend_pattern_configs(_get_tensor_info_op_configs(tensor_info_op_dtype_configs))
 
 def get_tensorrt_backend_config_dict():
     """

--- a/torch/ao/quantization/backend_config/x86.py
+++ b/torch/ao/quantization/backend_config/x86.py
@@ -10,6 +10,7 @@ from ._common_operator_config_utils import (
     _get_linear_configs,
     _get_rnn_op_configs,
     _get_share_qparams_op_configs,
+    _get_tensor_info_op_configs,
 )
 from .backend_config import BackendConfig, DTypeConfig
 
@@ -89,6 +90,7 @@ def get_x86_backend_config() -> BackendConfig:
     default_op_dtype_configs = [x86_default_op_quint8_dtype_config]
     fixed_qparams_op_dtype_configs = [x86_weighted_op_int8_dtype_config]
     share_qparams_op_dtype_configs = [x86_default_op_quint8_dtype_config]
+    tensor_info_op_dtype_configs = [x86_default_op_quint8_dtype_config]
     rnn_op_dtype_configs = [
         x86_default_dynamic_int8_dtype_config,
         x86_default_dynamic_float16_dtype_config,
@@ -105,6 +107,7 @@ def get_x86_backend_config() -> BackendConfig:
         .set_backend_pattern_configs(_get_default_op_configs(default_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_fixed_qparams_op_configs(fixed_qparams_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_share_qparams_op_configs(share_qparams_op_dtype_configs)) \
+        .set_backend_pattern_configs(_get_tensor_info_op_configs(tensor_info_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_bn_configs(default_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_rnn_op_configs(rnn_op_dtype_configs)) \
         .set_backend_pattern_configs(_get_embedding_op_configs(embedding_op_dtype_configs))

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -194,6 +194,10 @@ def is_getattr_tensor_metadata_node(node):
         node.target == getattr and \
         node.args[1] in ["shape"]
 
+def is_get_tensor_info_node(node):
+    return node.op == "call_method" and \
+        node.target in ["shape", "size"]
+
 def should_skip_lowering(op: torch.fx.node.Node, qconfig_map: Dict[str, QConfigAny]):
     """
     Return True if the op is configured with a None qconfig, False otherwise.
@@ -928,6 +932,21 @@ def _lower_getattr_tensor_metadta_op(model: QuantizedGraphModule):
             args[0] = n.args[0].args[0]
             n.args = tuple(args)
 
+def _lower_get_tensor_info_op(model: QuantizedGraphModule):
+    """ Modified the graph of the model inplace, to skip extra dequantize op before
+    the general tensor shape ops when possible
+    """
+    for n in model.graph.nodes:
+        if not is_get_tensor_info_node(n):
+            continue
+        maybe_dq = n.args[0]
+        if maybe_dq.op != "call_method" or maybe_dq.target != "dequantize":
+            continue
+        # skip the dequantize node
+        args = list(n.args)
+        args[0] = n.args[0].args[0]
+        n.args = tuple(args)
+
 def _lower_to_native_backend(
     model: QuantizedGraphModule,
     qconfig_map: Dict[str, QConfigAny],
@@ -944,6 +963,7 @@ def _lower_to_native_backend(
     _lower_dynamic_weighted_ref_functional(model, qconfig_map)
     _lower_quantized_binary_op(model, qconfig_map)
     _lower_getattr_tensor_metadta_op(model)
+    _lower_get_tensor_info_op(model)
     special_pattern_replacement(model)
     model.graph.eliminate_dead_code()
     model = fold_weight(model, node_name_to_scope)


### PR DESCRIPTION
**Summary**
This work continues with https://github.com/pytorch/pytorch/pull/83784 by @vkuzo and includes all the changes in that PR.
Quote from https://github.com/pytorch/pytorch/pull/83784:
> Issue #83658 reports that ops followed by a certain pattern of `view` and `size` ops were not quantized correctly by FX graph mode quantization.
Before this PR, the "size" op was in the "op shares qparams with input" category, and the code assumed that the input of this op has the same dtype as its output. This led to incorrectly propagating the `int` dtype as the output of whichever op was preceding the `view` op, which in turn made that op blocklisted from quantization.

> The fix is to create a new category of ops which work on different dtypes of tensors but are not observed. This PR does so for `size`, and also for `shape` since it works the same way.

**Note**: This PR needs https://github.com/pytorch/pytorch/pull/91297 to be landed first otherwise there is a UT failure.

**Test plan**
```
python test/test_quantization.py -k test_linear_size_view
python test/test_quantization.py -k test_linear_shape_view
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10