### PR TITLE
Added vectorized flip for uint8

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256.h
@@ -256,8 +256,7 @@ inline Vectorized<int16_t> flip(const Vectorized<int16_t> & v) {
   return _mm256_permute2x128_si256(reversed, reversed, 1);
 }
 
-template<>
-inline Vectorized<int8_t> flip(const Vectorized<int8_t> & v) {
+inline __m256i flip8(const __m256i & v) {
   const __m256i mask_int8 = _mm256_set_epi8(
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
@@ -266,6 +265,15 @@ inline Vectorized<int8_t> flip(const Vectorized<int8_t> & v) {
   return _mm256_permute2x128_si256(reversed, reversed, 1);
 }
 
+template<>
+inline Vectorized<int8_t> flip(const Vectorized<int8_t> & v) {
+  return flip8(v);
+}
+
+template<>
+inline Vectorized<uint8_t> flip(const Vectorized<uint8_t> & v) {
+  return flip8(v);
+}
 
 #endif // (defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
 

--- a/aten/src/ATen/cpu/vec/vec512/vec512.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512.h
@@ -227,8 +227,7 @@ inline Vectorized<int16_t> flip(const Vectorized<int16_t> & v) {
   return _mm512_permutexvar_epi16(mask, v);
 }
 
-template<>
-inline Vectorized<int8_t> flip(const Vectorized<int8_t> & v) {
+inline __m512i flip8(const __m512i & v) {
   const __m512i mask1 = _mm512_set_epi8(
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -238,6 +237,16 @@ inline Vectorized<int8_t> flip(const Vectorized<int8_t> & v) {
   const __m512i mask2 = _mm512_set_epi64(1, 0, 3, 2, 5, 4, 7, 6);
   auto reversed_vec = _mm512_shuffle_epi8(v, mask1);
   return _mm512_permutexvar_epi64(mask2, reversed_vec);
+}
+
+template<>
+inline Vectorized<int8_t> flip(const Vectorized<int8_t> & v) {
+  return flip8(v);
+}
+
+template<>
+inline Vectorized<uint8_t> flip(const Vectorized<uint8_t> & v) {
+  return flip8(v);
 }
 
 #endif // defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)


### PR DESCRIPTION
Following https://github.com/pytorch/pytorch/pull/89414#discussion_r1036224613 just refactoring and adding `flip` method for `Vectorized<uint8>`. This should speed up torch.flip horizontal implementation similarly to what is reported in https://github.com/pytorch/pytorch/pull/89414

## Results

1) Horizontal flip, now faster than Pillow for uint8 🚀 
```
CPU capability usage: AVX2

[------------------------------------------------------------------ Horizontal flip ------------------------------------------------------------------]
                                                   |  torch (1.14.0a0+gitcafae46) PR  |    Pillow (9.3.0)   |  torch (1.14.0.dev20221122+cu116) nightly
1 threads: --------------------------------------------------------------------------------------------------------------------------------------------
      channels=3, size=256, dtype=torch.uint8      |         17.281 (+-0.053)         |   44.535 (+-0.843)  |              53.127 (+-0.115)            
      channels=3, size=520, dtype=torch.uint8      |         57.924 (+-0.127)         |  166.710 (+-1.233)  |             224.323 (+-0.312)            
      channels=3, size=712, dtype=torch.uint8      |        104.426 (+-0.409)         |  306.954 (+-1.562)  |             429.748 (+-0.763)            

      channels=3, size=256, dtype=torch.int8       |         17.077 (+-0.088)         |                     |              89.395 (+-0.118)            
      channels=3, size=520, dtype=torch.int8       |         58.164 (+-0.135)         |                     |             340.087 (+-0.490)            
      channels=3, size=712, dtype=torch.int8       |        103.406 (+-1.240)         |                     |             627.942 (+-0.724)            

      channels=1, size=256, dtype=torch.bool       |         7.762 (+-0.061)          |                     |              38.683 (+-0.080)            
      channels=1, size=520, dtype=torch.bool       |         23.477 (+-0.073)         |                     |             140.212 (+-0.246)            
      channels=1, size=712, dtype=torch.bool       |         37.824 (+-0.085)         |                     |             255.517 (+-0.410)            

      channels=1, size=256, dtype=torch.complex64  |         39.105 (+-0.154)         |                     |              66.315 (+-0.090)            
      channels=1, size=520, dtype=torch.complex64  |        144.264 (+-0.466)         |                     |             248.974 (+-0.523)            
      channels=1, size=712, dtype=torch.complex64  |        266.497 (+-0.794)         |                     |             464.783 (+-5.873)            

Times are in microseconds (us).
```





cc @VitalyFedyunin @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10