### PR TITLE
Revert "Dynamo, FX, Inductor Progress Bars (#88384)"

### DIFF
--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -2,14 +2,9 @@ import itertools
 import logging
 import os
 
-from torch.hub import tqdm
-
 # logging level for dynamo generated graphs/bytecode/guards
 logging.CODE = 15
 logging.addLevelName(logging.CODE, "CODE")
-
-# Disable progress bar by default, not in dynamo config because otherwise get a circular import
-disable_progress = True
 
 
 # Return all loggers that torchdynamo/torchinductor is responsible for
@@ -83,24 +78,8 @@ def init_logging(log_level, log_file_name=None):
 
 _step_counter = itertools.count(1)
 
-# Update num_steps if more phases are added: Dynamo, AOT, Backend
-# This is very inductor centric
-# _inductor.utils.has_triton() gives a circular import error here
-
-if not disable_progress:
-    try:
-        import triton  # noqa: F401
-
-        num_steps = 3
-    except ImportError:
-        num_steps = 2
-    pbar = tqdm(total=num_steps, desc="torch.compile()", delay=15)
-
 
 def get_step_logger(logger):
-    if not disable_progress:
-        pbar.set_postfix_str(f"{logger.name}")
-        pbar.update(1)
     step = next(_step_counter)
 
     def log(level, msg):

--- a/torch/_dynamo/optimizations/analysis.py
+++ b/torch/_dynamo/optimizations/analysis.py
@@ -21,7 +21,6 @@ class ShapeAliasingAndMutationProp(ShapeProp):
         self.input_alias_groups = set()
         self.storage_to_alias_group = dict()
         self.make_alias_group = itertools.count(1)
-        self.name = "ShapeAliasingAndMutation"
 
     def tensor_alias_group(self, value: torch.Tensor):
         """Assign a unique identifier to the storage of a given tensor"""

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -21,8 +21,6 @@ from time import sleep, time
 from typing import Any, Callable, Dict, List
 
 import torch
-
-from torch.hub import tqdm
 from torch.utils import cpp_extension
 from . import config, cuda_properties, exc
 
@@ -594,7 +592,7 @@ class AsyncCompile:
         if hasattr(pool, "_start_queue_management_thread"):
             pool._start_queue_management_thread()
         else:
-            for _ in range(config.compile_threads):
+            for i in range(config.compile_threads):
                 pool._adjust_process_count()
             pool._start_executor_manager_thread()
         _compile_end()
@@ -635,26 +633,10 @@ class AsyncCompile:
         return self.submit(task)
 
     def wait(self, scope: Dict[str, Any]):
-        num_kernels = len(
-            [
-                value
-                for key, value in scope.items()
-                if isinstance(value, (Future, TritonFuture))
-            ]
-        )
-        pbar = tqdm(
-            total=num_kernels,
-            desc="Inductor Compilation",
-            disable=config.disable_progress,
-            delay=15,
-        )
         if config.compile_threads > 1:
-            for key, result in scope.items():
-                if config.verbose_progress:
-                    pbar.set_postfix_str(key)
+            for key, result in list(scope.items()):
                 if isinstance(result, (Future, TritonFuture)):
                     scope[key] = result.result()
-                    pbar.update(1)
 
         _compile_end()
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -590,8 +590,6 @@ class Kernel(CodeGen):
 
     def __enter__(self):
         class CSEProxy:
-            self.name = "CSEProxy"
-
             @staticmethod
             def __getattr__(name):
                 def inner(*args, **kwargs):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -5,12 +5,6 @@ from functools import lru_cache
 # add some debug printouts
 debug = False
 
-# Whether to disable a progress bar for autotuning
-disable_progress = True
-
-# Whether to enable printing the source code for each future
-verbose_progress = False
-
 # use cpp wrapper instead of python wrapper
 cpp_wrapper = False
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -89,7 +89,6 @@ class GraphLowering(torch.fx.Interpreter):
         self.randomness_seeds = []
         self.name_to_buffer = {}
         self.creation_time = time.time()
-        self.name = "GraphLowering"
         self._can_use_cpp_wrapper = config.cpp_wrapper
 
     def get_dtype(self, buffer_name):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3952,8 +3952,6 @@ class LoopBodyBlock:
             )
 
         class CaptureIndexing(V.WrapperHandler):
-            self.name = "CaptureIndexing"
-
             def load(self, name: str, index: sympy.Expr):
                 index = add_index(index, "reads", name)
                 return self._inner.load(name, index)
@@ -4036,7 +4034,6 @@ class LoopBodyBlock:
                 self.garbage_collect_values = False
                 self.env = {}
                 self.fetch_attr = submodules.__getitem__
-                self.name = V.get_ops_handler().name
 
         return InterpreterShim().run(V.get_ops_handler())
 

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -596,7 +596,6 @@ class SimplifyIndexing(V.WrapperHandler):  # type: ignore[name-defined]
 
     def __init__(self, inner, var_ranges: VarRanges):
         super().__init__(inner)
-        self.name = "SimplifyIndexing"
         self._simplify: Callable[
             [Expr], Expr
         ] = lambda index: V.graph.sizevars.simplify_with_ranges(index, var_ranges)

--- a/torch/_inductor/virtualized.py
+++ b/torch/_inductor/virtualized.py
@@ -57,9 +57,6 @@ def _arg_str(a):
 
 class MockHandler:
     def __getattr__(self, name):
-        if name == "name":
-            return "MockHandler"
-
         def inner(*args, **kwargs):
             fargs = [_arg_str(a) for a in args]
             fargs.extend(f"{k}={v}" for k, v in kwargs.items())

--- a/torch/fx/config.py
+++ b/torch/fx/config.py
@@ -1,6 +1,0 @@
-# Whether to disable showing progress on compilation passes
-# Need to add a new config otherwise wil get a circular import if dynamo config is imported here
-disable_progress = True
-
-# If True this also shows the node names in each pass, for small models this is great but larger models it's quite noisy
-verbose_progress = False

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -4,12 +4,10 @@ from .node import Argument, Node, Target, map_arg, map_aggregate
 from .proxy import Proxy
 from ._symbolic_trace import Tracer
 from ._compatibility import compatibility
-from . import config
 import torch.fx.traceback as fx_traceback
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 import inspect
 from contextlib import contextmanager
-from torch.hub import tqdm
 
 __all__ = ['Interpreter', 'Transformer']
 
@@ -74,7 +72,7 @@ class Interpreter:
         self.module = module
         self.submodules = dict(self.module.named_modules())
         self.env : Dict[Node, Any] = {}
-        self.name = "Interpreter"
+
         self.garbage_collect_values = garbage_collect_values
 
         if self.garbage_collect_values:
@@ -120,9 +118,7 @@ class Interpreter:
             args = self.module.graph.process_inputs(*args)
         self.args_iter : Iterator[Any] = iter(args)
 
-        for node in tqdm(self.module.graph.nodes,
-                         desc=f"{self.name}: {str(list(self.module.graph.nodes)) if config.verbose_progress else ''}",
-                         initial=1, position=0, leave=True, disable=config.disable_progress, delay=15):
+        for node in self.module.graph.nodes:
             if node in self.env:
                 # Short circuit if we have this value. This could
                 # be used, for example, for partial evaluation


### PR DESCRIPTION
This breaks in environments that use the fake tqdm https://github.com/pytorch/pytorch/blob/015b05af18b78ca9c77c997bc277eec66b5b1542/torch/hub.py#L26 which doesn't support the 'desc' kwarg and is not iterable

Original try using pytorchbot did not go through because of a merge
conflict: https://github.com/pytorch/pytorch/pull/88384#issuecomment-1334272489

This reverts commit 011452a2a1c745d4b12f83f89eca039f482d134b.

Fixes #ISSUE_NUMBER


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire