### PR TITLE
[FSDP] Define `flat_grad_to()` helper

### DIFF
--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1726,6 +1726,11 @@ class FlatParamHandle:
 
     def flat_grad_to(self, *args, **kwargs):
         """Wraps an in-place call to ``to()`` for ``self.flat_param.grad``."""
+        p_assert(
+            self.flat_param.grad is not None,
+            "Expects `flat_param.grad` to not be `None`",
+        )
+        assert self.flat_param.grad is not None  # mypy
         self.flat_param.grad.data = self.flat_param.grad.to(*args, **kwargs)
         if self._use_orig_params:
             # Refresh the views because their storage may have changed

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1093,11 +1093,7 @@ class FlatParamHandle:
             if self._config.keep_low_precision_grads:
                 assert flat_param.grad is not None  # mypy
                 if flat_param.grad.dtype != self._config.low_prec_param_dtype:
-                    flat_param.grad.data = flat_param.grad.to(
-                        self._config.low_prec_param_dtype
-                    )
-                    if self._use_orig_params:
-                        self._use_sharded_grad_views()
+                    self.flat_grad_to(self._config.low_prec_param_dtype)
 
         flat_param = self.flat_param
         # TODO (awgu): We should replace these conditional checks to encode
@@ -1727,6 +1723,16 @@ class FlatParamHandle:
                 self._use_sharded_views()
             else:
                 self._use_unsharded_views(as_params=True)
+
+    def flat_grad_to(self, *args, **kwargs):
+        """Wraps an in-place call to ``to()`` for ``self.flat_param.grad``."""
+        self.flat_param.grad.data = self.flat_param.grad.to(*args, **kwargs)
+        if self._use_orig_params:
+            # Refresh the views because their storage may have changed
+            if self.is_sharded(self.flat_param.grad):
+                self._use_sharded_grad_views()
+            else:
+                self._use_unsharded_grad_views()
 
     def _get_modules(self) -> Set[nn.Module]:
         """Returns a :class:`set` of the modules whose parameters are included


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90028 [FSDP] Fix `clip_grad_norm_()` for low prec grads
* **#90030 [FSDP] Define `flat_grad_to()` helper**
* #90027 [FSDP] Fix `keep_low_precision_grads=True` for `use_orig_params=True`
* #89308 [FSDP] Remove unneeded stream sync from `clip_grad_norm_()`

This formalizes the `flat_param.grad.data = flat_param.grad.to(...)` idiom into a helper `flat_grad_to()` just like for `flat_param.data = flat_param.to(...)` and `flat_param_to()`. Currently, `flat_grad_to()` is only used when the gradient is sharded, so one branch is unused.