### PR TITLE
Revert D41609017: Multisect successfully blamed D41609017 for test or build failures

### DIFF
--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -23,7 +23,6 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
-from torch.distributed._tensor import DTensor
 from torch.distributed.fsdp._common_utils import (
     _set_fsdp_flattened,
     HandleTrainingState,
@@ -1292,12 +1291,6 @@ class FlatParamHandle:
             if hasattr(module, param_name):
                 delattr(module, param_name)
             if self._use_orig_params and as_params:
-                if type(view) is DTensor:
-                    # A `DTensor` `view` is not compatible with assigning
-                    # `param.data = view`, so we cannot preserve the parameter
-                    # variable.
-                    setattr(module, param_name, nn.Parameter(view))
-                    continue
                 param = self.flat_param._params[i]  # type: ignore[index]
                 setattr(module, param_name, param)
                 param.data = view


### PR DESCRIPTION
Summary:
This diff is reverting D41609017
D41609017 has been identified to be causing the following test or build failures:
Tests affected:
- https://www.internalfb.com/intern/test/281475052567659/
- https://www.internalfb.com/intern/test/562950029295825/

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1440332
Here are the tasks that are relevant to this breakage:
T93368156: 5 tests started failing for oncall admarket_predictor_pushmaster in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Test Plan: NA

Reviewed By: zyan0

Differential Revision: D41656946

