### PR TITLE
[reland][quant] Explictly set default quantized engine instead of relying on the order of supported_qengines (#89804)

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -296,7 +296,7 @@ bool Context::hasLAPACK() {
 
 at::QEngine Context::qEngine() const {
   static auto _quantized_engine = []() {
-    at::QEngine qengine = at::kNoEngine;
+    at::QEngine qengine = at::kNoQEngine;
 #if defined(C10_MOBILE) && defined(USE_PYTORCH_QNNPACK)
     qengine = at::kQNNPACK;
 #endif

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -295,8 +295,24 @@ bool Context::hasLAPACK() {
 }
 
 at::QEngine Context::qEngine() const {
-  // If wasn't explicitly set - take the last one available
-  return quantized_engine.value_or(supportedQEngines().back());
+  static auto _quantized_engine = []() {
+    at::QEngine qengine = at::kNoEngine;
+#if defined(C10_MOBILE) && defined(USE_PYTORCH_QNNPACK)
+    qengine = at::kQNNPACK;
+#endif
+
+#if AT_MKLDNN_ENABLED()
+    qengine = at::kONEDNN;
+#endif
+
+#ifdef USE_FBGEMM
+    if (fbgemm::fbgemmSupportedCPU()) {
+      qengine = at::kFBGEMM;
+    }
+#endif
+    return qengine;
+  }();
+  return quantized_engine.value_or(_quantized_engine);
 }
 
 void Context::setQEngine(at::QEngine e) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90036

Summary:
Fixes: https://github.com/pytorch/pytorch/issues/86404

Test Plan:
ossci + sandcastle
Reviewers:

Subscribers:

Tasks:

Tags: