### PR TITLE
[Inductor] Do not install g++12 by default

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -16,6 +16,7 @@ BUILD_RENAMED_DIR="build_renamed"
 BUILD_BIN_DIR="$BUILD_DIR"/bin
 
 export VALGRIND=ON
+export TORCH_INDUCTOR_INSTALL_GXX=ON
 if [[ "$BUILD_ENVIRONMENT" == *clang9* ]]; then
   # clang9 appears to miscompile code involving c10::optional<c10::SymInt>,
   # such that valgrind complains along these lines:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -112,6 +112,9 @@ def cpp_compiler_search(search):
                 # according to https://anaconda.org/conda-forge/gxx/
                 if sys.platform != "linux":
                     continue
+                # Do not install GXX by default
+                if not os.getenv("TORCH_INDUCTOR_INSTALL_GXX"):
+                   continue
                 from filelock import FileLock
 
                 lock_dir = get_lock_dir()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -114,7 +114,7 @@ def cpp_compiler_search(search):
                     continue
                 # Do not install GXX by default
                 if not os.getenv("TORCH_INDUCTOR_INSTALL_GXX"):
-                   continue
+                    continue
                 from filelock import FileLock
 
                 lock_dir = get_lock_dir()


### PR DESCRIPTION
Unless `TORCH_INDUCTOR_INSTALL_GXX` environment variable is define
(which is the case for CI)

Fixes #ISSUE_NUMBER


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire