### PR TITLE
Make TorchElastic timer importable on Windows (#88522)

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -18,7 +18,7 @@ import torch
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_utils import \
-    (IS_FBCODE, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, skipIfRocm, slowTest,
+    (IS_FBCODE, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, skipIfRocm, slowTest,
      parametrize, subtest, instantiate_parametrized_tests, dtype_name, TEST_WITH_ROCM)
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
@@ -1782,9 +1782,15 @@ class TestImports(TestCase):
         # See https://github.com/pytorch/pytorch/issues/77801
         if not sys.version_info >= (3, 9):
             ignored_modules.append("torch.utils.benchmark")
-        if IS_WINDOWS:
-            # Distributed does not work on Windows
-            ignored_modules.append("torch.distributed.")
+        if IS_WINDOWS or IS_MACOS:
+            # Distributed should be importable on Windows(except nn.api.), but not on Mac
+            if IS_MACOS:
+                ignored_modules.append("torch.distributed.")
+            else:
+                ignored_modules.append("torch.distributed.nn.api.")
+                ignored_modules.append("torch.distributed.optim.")
+                ignored_modules.append("torch.distributed.pipeline.")
+                ignored_modules.append("torch.distributed.rpc.")
             ignored_modules.append("torch.testing._internal.dist_utils")
 
         torch_dir = os.path.dirname(torch.__file__)

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -10,6 +10,7 @@ import logging
 import os
 import select
 import signal
+import sys
 import threading
 import time
 from typing import Callable, Dict, List, Optional, Set, Tuple
@@ -78,7 +79,8 @@ class FileTimerClient(TimerClient):
         signal: singal, the signal to use to kill the process. Using a
                         negative or zero signal will not kill the process.
     """
-    def __init__(self, file_path: str, signal=signal.SIGKILL) -> None:
+    def __init__(self, file_path: str, signal=(signal.SIGKILL if sys.platform != "win32" else
+                                               signal.CTRL_C_EVENT)) -> None:  # type: ignore[attr-defined]
         super().__init__()
         self._file_path = file_path
         self.signal = signal


### PR DESCRIPTION
Cherry pick for 1.13.1
Original PR: #88522
---

Also, add `torch.distributed` to test imports, so that we would not regress in the future

Fixes https://github.com/pytorch/pytorch/issues/85427 Pull Request resolved: https://github.com/pytorch/pytorch/pull/88522 Approved by: https://github.com/d4l3k

(cherry picked from commit f98edfcc48c903d0d22a0105b0fafe4ca58121e6)

Fixes #ISSUE_NUMBER
