### PR TITLE
replace memset with value-initialization

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp
@@ -64,7 +64,7 @@ void set_params_fprop(FMHA_fprop_params &params,
                       bool is_causal) {
 
     // Reset the parameters
-    memset(&params, 0, sizeof(params));
+    params = {};
 
     params.is_bf16 = q.dtype() == at::kBFloat16;
 


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/90048).
* #89865
* #89852
* #89851
* __->__ #90048

replace memset with value-initialization

Summary:
This is equivalent to zero initialization for any members that are
scalar or have implicit default constructors.

Note that aside from the reset at the beginning, blockmask and
philox_args are not touched by this function.

Test Plan: Rely on CI.

