### PR TITLE
Fix binary iOS uploads

### DIFF
--- a/.circleci/scripts/binary_ios_upload.sh
+++ b/.circleci/scripts/binary_ios_upload.sh
@@ -47,7 +47,7 @@ echo "${IOS_NIGHTLY_BUILD_VERSION}" > version.txt
 zip -r ${ZIPFILE} install src version.txt LICENSE
 # upload to aws
 # Install conda then 'conda install' awscli
-curl --retry 3 --retry-all-errors -o ~/conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+curl --retry 3 -o ~/conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 chmod +x ~/conda.sh
 /bin/bash ~/conda.sh -b -p ~/anaconda
 export PATH="~/anaconda/bin:${PATH}"


### PR DESCRIPTION
curl on CircleCI MacOS runners does not support `--retry-all-errors`
Should fix https://app.circleci.com/pipelines/github/pytorch/pytorch/618606/workflows/6f104c19-3a3a-479d-a686-4961ddd87657/jobs/17233205
Yet another fallback of https://github.com/pytorch/pytorch/pull/89157
