### PR TITLE
[NVFuser] undo v100 OOM skips

### DIFF
--- a/torch/csrc/jit/codegen/cuda/test/test_gpu1.cpp
+++ b/torch/csrc/jit/codegen/cuda/test/test_gpu1.cpp
@@ -7177,9 +7177,6 @@ TEST_F(NVFuserTest, FusionComputeAtExprOrder2_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionComputeAtExprOrder3_CUDA) {
-#ifdef FBCODE_CAFFE2
-  GTEST_SKIP() << "OOM on V100 32gb";
-#endif
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -9794,9 +9791,6 @@ TEST_F(NVFuserTest, FusionSmemDynamicReductionSymbolicArg_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionSmemDynamicPwiseMulSymbolicArgWAR_CUDA) {
-#ifdef FBCODE_CAFFE2
-  GTEST_SKIP() << "OOM on V100 32gb";
-#endif
   Fusion fusion;
   FusionGuard fg(&fusion);
 

--- a/torch/csrc/jit/codegen/cuda/test/test_gpu2.cpp
+++ b/torch/csrc/jit/codegen/cuda/test/test_gpu2.cpp
@@ -2704,9 +2704,6 @@ TEST_F(NVFuserTest, FusionWelfordOp_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionBlockWelfordOp_CUDA) {
-#ifdef FBCODE_CAFFE2
-  GTEST_SKIP() << "OOM on V100 32gb";
-#endif
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -6339,9 +6336,6 @@ TEST_F(NVFuserTest, FusionWelfordOuterPersistence_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionSegmentIslands_CUDA) {
-#ifdef FBCODE_CAFFE2
-  GTEST_SKIP() << "OOM on V100 32gb";
-#endif
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 

--- a/torch/csrc/jit/codegen/cuda/test/test_gpu3.cpp
+++ b/torch/csrc/jit/codegen/cuda/test/test_gpu3.cpp
@@ -5945,9 +5945,6 @@ TEST_F(NVFuserTest, AsyncCompilation_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionMergeBroadcastingTrivialReduction1_CUDA) {
-#ifdef FBCODE_CAFFE2
-  GTEST_SKIP() << "OOM on V100 32gb";
-#endif
   std::unique_ptr<Fusion> fusion_ptr = std::make_unique<Fusion>();
   auto fusion = fusion_ptr.get();
   FusionGuard fg(fusion);

--- a/torch/csrc/jit/codegen/cuda/test/test_gpu_fused_reduction.cpp
+++ b/torch/csrc/jit/codegen/cuda/test/test_gpu_fused_reduction.cpp
@@ -1561,9 +1561,6 @@ TEST_F(NVFuserTest, FusionGroupedReductionReEntrant1_CUDA) {
 // Channels-last batch norm with vectorization. Relies on re-entrant
 // GroupedGridReduction
 TEST_F(NVFuserTest, FusionGroupedReductionChannelsLastBatchNormLike_CUDA) {
-#ifdef FBCODE_CAFFE2
-  GTEST_SKIP() << "OOM on V100 32gb";
-#endif
   Fusion fusion;
   FusionGuard fg(&fusion);
 

--- a/torch/csrc/jit/codegen/cuda/test/test_gpu_shift.cpp
+++ b/torch/csrc/jit/codegen/cuda/test/test_gpu_shift.cpp
@@ -2621,9 +2621,6 @@ TEST_F(NVFuserTest, FusionGather4_CUDA) {
 }
 
 TEST_F(NVFuserTest, FusionGather5_CUDA) {
-#ifdef FBCODE_CAFFE2
-  GTEST_SKIP() << "OOM on V100 32gb";
-#endif
   Fusion fusion;
   FusionGuard fg(&fusion);
 

--- a/torch/csrc/jit/codegen/cuda/test/test_gpu_tensorcore.cpp
+++ b/torch/csrc/jit/codegen/cuda/test/test_gpu_tensorcore.cpp
@@ -2815,9 +2815,6 @@ TEST_F(NVFuserTest, FusionAmpereMatmulLargeLoad_CUDA) {
 
 // Matmul test for Turing MMA: across supported layouts
 TEST_F(NVFuserTest, FusionTuringMatmulLargeLoad_CUDA) {
-#ifdef FBCODE_CAFFE2
-  GTEST_SKIP() << "OOM on V100 32gb";
-#endif
   // Keep multiples of 8 to keep vectorizable.
   int M = 504, N = 136, K = 248;
 

--- a/torch/csrc/jit/codegen/cuda/test/test_gpu_transpose.cpp
+++ b/torch/csrc/jit/codegen/cuda/test/test_gpu_transpose.cpp
@@ -335,9 +335,6 @@ TEST_F(NVFuserTest, FusionScheduleTransposeMultipleOutput_CUDA) {
  * t1
  */
 TEST_F(NVFuserTest, FusionScheduleTransposeMultipleInputOutput_CUDA) {
-#ifdef FBCODE_CAFFE2
-  GTEST_SKIP() << "OOM on V100 32gb";
-#endif
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -997,9 +994,6 @@ TEST_F(NVFuserTest, FusionScheduleTransposeSmallInnerSize3_CUDA) {
 
 // x->sin->transpose->cos->y
 TEST_F(NVFuserTest, FusionScheduleTranspose2DSmallInnerSize_CUDA) {
-#ifdef FBCODE_CAFFE2
-  GTEST_SKIP() << "OOM on V100 32gb";
-#endif
   std::array<std::vector<int64_t>, 2> shapes{
       std::vector<int64_t>{1024 * 1024 * 128, 2},
       std::vector<int64_t>{2, 1024 * 1024 * 128}};


### PR DESCRIPTION
Summary: I think these were just caused by parallel tests. After adjusting test settings to 1 thread, these stopped OOMing.

Test Plan:
```
$ buck2 test -j 1 mode/dev-nosan //caffe2/torch/csrc/jit/codegen/cuda:nvfuser
```
https://www.internalfb.com/intern/testinfra/testrun/6473924590389963

Differential Revision: D41643827

