### PR TITLE
Add generator argument to torch.rand docstring

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8996,8 +8996,8 @@ Example::
 add_docstr(
     torch.rand,
     """
-rand(*size, *, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False, \
-pin_memory=False) -> Tensor
+rand(*size, *, generator=None, out=None, dtype=None, layout=torch.strided, device=None, \
+requires_grad=False, pin_memory=False) -> Tensor
 """
     + r"""
 Returns a tensor filled with random numbers from a uniform distribution


### PR DESCRIPTION
The documentation of `torch.rand` was missing the `generator` keyword argument in the function signature. However, the argument is explained in the documentation and `torch.rand` accepts that argument. 

cc @svekars @carljparker