### PR TITLE
[LTC] Restore default ctor for LazyTensor

### DIFF
--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -61,7 +61,9 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
   // have to check both lazy_tensor_ptr && *lazy_tensor_ptr, so everywhere that
   // used to rely on a LazyTensor obj with a null Data can now rely on a null
   // LazyTensorPtr instead.
-  LazyTensor() = delete;
+  // TODO(alanwaketan): This is a temporarily change to make XLA LTC migration
+  // easier. Restore it back to delete.
+  LazyTensor() = default;
 
   size_t generation() const {
     return data()->generation;


### PR DESCRIPTION
Summary:
This pull request introduced a temporarily change that make XLA's LTC migration easier. One step among is to make XLATensor naively inherits LazyTensor and that requires LazyTensor to have a default constructor.

Test Plan:
CI.