### PR TITLE
[quant][fx] Add support for matching constant in the custom matcher code in quantization

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -714,8 +714,6 @@ class TestQuantizeFx(QuantizationTestCase):
                 self.assertTrue(is_match(modules, n, pattern))
 
     def test_pattern_match_constant(self):
-        """ test matching constant
-        """
         class M(torch.nn.Module):
             def forward(self, x):
                 x, _ = torch.ops.aten.max_pool2d_with_indices.default(x)

--- a/torch/ao/quantization/fx/match_utils.py
+++ b/torch/ao/quantization/fx/match_utils.py
@@ -53,6 +53,9 @@ def is_match(modules, node, pattern, max_uses=sys.maxsize):
     if isinstance(self_match, type) and issubclass(self_match, MatchAllNode):
         return True
 
+    if node == pattern:
+        return True
+
     if not isinstance(node, Node) or len(node.users) > max_uses:
         return False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90092

Summary:
att

Test Plan:
python test/test_quantization.py TestQuantizeFx.test_pattern_match_constant

Reviewers:

Subscribers:

Tasks:

Tags: