### PR TITLE
[dtensor] remove torchgen function schema and parse manually

### DIFF
--- a/test/distributed/_tensor/test_common_rules.py
+++ b/test/distributed/_tensor/test_common_rules.py
@@ -16,13 +16,10 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
 )
-from torchgen.model import FunctionSchema
+from torch._C import parse_schema
 
 
 class CommonRulesTest(DTensorTestBase):
-    def parse_schema(self, schema_str):
-        return FunctionSchema.parse(schema_str)
-
     @property
     def world_size(self) -> int:
         # hard code world size to 4 as we need to test
@@ -34,7 +31,7 @@ class CommonRulesTest(DTensorTestBase):
         # plain einsum, mm
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
-        func_schema = self.parse_schema("aten::mm(Tensor self, Tensor mat2) -> Tensor")
+        func_schema = parse_schema("aten::mm(Tensor self, Tensor mat2) -> Tensor")
         # propagate col-wise sharding
         mat1, mat2 = [-1, -1], [-1, 0]
         mat1_spec = DTensorSpec.from_dim_map(mesh, mat1, [], shape=torch.Size([8, 4]))
@@ -75,7 +72,7 @@ class CommonRulesTest(DTensorTestBase):
     def test_einop_pointwise_propagation(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
-        func_schema = self.parse_schema(
+        func_schema = parse_schema(
             "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"
         )
         # addition
@@ -126,7 +123,7 @@ class CommonRulesTest(DTensorTestBase):
         )
         mesh = DeviceMesh(self.device_type, mesh_shape)
 
-        func_schema = self.parse_schema("aten::mm(Tensor self, Tensor mat2) -> Tensor")
+        func_schema = parse_schema("aten::mm(Tensor self, Tensor mat2) -> Tensor")
 
         mat1, mat2 = [0, -1], [-1, 1]
         mat1_spec = DTensorSpec.from_dim_map(mesh, mat1, [], shape=torch.Size([8, 4]))
@@ -146,7 +143,7 @@ class CommonRulesTest(DTensorTestBase):
         )
         mesh = DeviceMesh(self.device_type, mesh_shape)
 
-        mm_func_schema = self.parse_schema(
+        mm_func_schema = parse_schema(
             "aten::mm(Tensor self, Tensor mat2) -> Tensor"
         )
 
@@ -180,7 +177,7 @@ class CommonRulesTest(DTensorTestBase):
 
         # einop prop with linearity on point-wise, should give back suggestion
         # on converting placements to partial
-        add_func_schema = self.parse_schema(
+        add_func_schema = parse_schema(
             "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"
         )
         mat1, mat2 = [0, -1], [0, -1]
@@ -205,7 +202,7 @@ class CommonRulesTest(DTensorTestBase):
         mesh_shape = torch.arange(self.world_size)
         mesh = DeviceMesh(self.device_type, mesh_shape)
 
-        func_schema = self.parse_schema("aten::mm(Tensor self, Tensor mat2) -> Tensor")
+        func_schema = parse_schema("aten::mm(Tensor self, Tensor mat2) -> Tensor")
         mat1, mat2 = [0, -1], [0, -1]
         mat1_spec = DTensorSpec.from_dim_map(mesh, mat1, [], shape=torch.Size([8, 12]))
         mat2_spec = DTensorSpec.from_dim_map(mesh, mat2, [], shape=torch.Size([12, 4]))
@@ -229,7 +226,7 @@ class CommonRulesTest(DTensorTestBase):
         )
         mesh = DeviceMesh(self.device_type, mesh_shape)
 
-        func_schema = self.parse_schema(
+        func_schema = parse_schema(
             "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"
         )
         mat1, mat2 = [0, -1], [1, -1]
@@ -243,7 +240,7 @@ class CommonRulesTest(DTensorTestBase):
     def test_pointwise_rules_broadcasting(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
-        func_schema = self.parse_schema(
+        func_schema = parse_schema(
             "where.self(Tensor condition, Tensor self, Tensor other) -> Tensor"
         )
         inp1, inp2, inp3 = [0], [], [-1, -1]
@@ -265,7 +262,7 @@ class CommonRulesTest(DTensorTestBase):
     def test_pointwise_rules_suggestion(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
-        func_schema = self.parse_schema(
+        func_schema = parse_schema(
             "aten::lerp.Scalar(Tensor self, Tensor end, Scalar weight) -> Tensor"
         )
         # propagate point-wise sharding
@@ -293,7 +290,7 @@ class CommonRulesTest(DTensorTestBase):
         )
         mesh = DeviceMesh(self.device_type, mesh_shape)
 
-        func_schema = self.parse_schema(
+        func_schema = parse_schema(
             "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"
         )
 
@@ -337,7 +334,7 @@ class CommonRulesTest(DTensorTestBase):
         )
         mesh = DeviceMesh(self.device_type, mesh_shape)
 
-        func_schema = self.parse_schema(
+        func_schema = parse_schema(
             "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)"
         )
 
@@ -366,7 +363,7 @@ class CommonRulesTest(DTensorTestBase):
     def test_reduction_rule(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
-        func_schema = self.parse_schema(
+        func_schema = parse_schema(
             "aten::sum(Tensor self, *, ScalarType? dtype=None) -> Tensor"
         )
         # reduction on a 2d mat

--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -2,8 +2,6 @@
 from dataclasses import dataclass
 from typing import Callable, cast, Dict, List, Optional, Tuple
 
-from torchgen.model import FunctionSchema, SchemaKind
-
 import torch
 
 import torch.distributed._tensor.api as dtensor
@@ -68,20 +66,20 @@ class OpSchema(object):
           placements will get implicitly changed and it's error-prone.
     """
 
-    func_schema: FunctionSchema
+    func_schema: torch._C.FunctionSchema
     args_schema: Tuple[object, ...]
     kwargs_schema: Dict[str, object]
+
     is_inplace: bool = False
     is_out_variant: bool = False
 
+
     def __post_init__(self) -> None:
-        schema_kind = self.func_schema.kind()
-        self.is_inplace = (
-            schema_kind == SchemaKind.inplace  # pyre-ignore [16] pyre bad at enum
-        )
-        self.is_out_variant = (
-            schema_kind == SchemaKind.out  # pyre-ignore [16] pyre bad at enum
-        )
+        # simple analysis of function schema to determine
+        # if this is an inplace/out variant, it might not
+        # be entirely correct, but it's good enough for now.
+        self.is_inplace = self.func_schema.name[-1] == "_"
+        self.is_out_variant = self.func_schema.overload_name == "out"
 
     @property
     def args_spec(self) -> Tuple[DTensorSpec, ...]:
@@ -158,13 +156,11 @@ def propagate_input_sharding(
     kwargs: Dict[str, object],
     op_to_rules: Dict[str, Callable[[OpSchema], OutputSharding]],
 ) -> Tuple[OpSchema, bool, Optional[OutputSharding]]:
-    # parse the operator schema
-    func_schema = FunctionSchema.parse(str(op_call._schema))
     # unwrap the args/kwargs schema
     args_schema = tree_map(unwrap_schema, args)
     kwargs_schema = tree_map(unwrap_schema, kwargs)
 
-    op_schema = OpSchema(func_schema, args_schema, kwargs_schema)
+    op_schema = OpSchema(op_call._schema, args_schema, kwargs_schema)
 
     if _DEBUG_VERBOSE and torch.distributed.get_rank() == 0:
         print(f"{op_call}({op_schema})")
@@ -288,10 +284,13 @@ def operator_dispatch(
             else output_sharding.output_spec
         )
         out_dts = []
-        for i, out in enumerate(target_schema.func_schema.arguments.out):
-            out_dt = cast(dtensor.DTensor, kwargs[out.name])
-            out_dt._spec = cast(DTensorSpec, output_specs[i])
-            out_dts.append(out_dt)
+        spec_idx = 0
+        for arg in target_schema.func_schema.arguments:
+            if arg.is_out:
+                out_dt = cast(dtensor.DTensor, kwargs[arg.name])
+                out_dt._spec = cast(DTensorSpec, output_specs[spec_idx])
+                out_dts.append(out_dt)
+                spec_idx += 1
         return tuple(out_dts) if len(out_dts) > 1 else out_dts[0]
     else:
         return wrap(local_results, output_sharding.output_spec)

--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -79,7 +79,7 @@ class OpSchema(object):
         # if this is an inplace/out variant, it might not
         # be entirely correct, but it's good enough for now.
         self.is_inplace = self.func_schema.name[-1] == "_"
-        self.is_out_variant = self.func_schema.overload_name == "out"
+        self.is_out_variant = "out" in self.func_schema.overload_name
 
     @property
     def args_spec(self) -> Tuple[DTensorSpec, ...]:
@@ -291,6 +291,8 @@ def operator_dispatch(
                 out_dt._spec = cast(DTensorSpec, output_specs[spec_idx])
                 out_dts.append(out_dt)
                 spec_idx += 1
+
+        assert len(out_dts) >= 1, "out variant should have at least one out arg"
         return tuple(out_dts) if len(out_dts) > 1 else out_dts[0]
     else:
         return wrap(local_results, output_sharding.output_spec)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #90241
* __->__ #90106
* #89970
* #89969
* #89968
* #89967

This PR get rids of torchgen FunctionSchema parsing and parse
it manually, it should resolve torchgen package issue and also
provide some perf wins when running DTensor eagerly