### PR TITLE
Don't overwrite torch::nn::Sequential module names when cloning

### DIFF
--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -370,27 +370,31 @@ TEST_F(SequentialTest, IsCloneable) {
 
   // Test that named submodule labels are propagated
   Sequential sequential_named(
-    { {"layer1", Linear(10, 5)}, 
-      {"activation1", ReLU()},
-      {"layer2", Linear(5, 3)},
-      {"layer2norm", BatchNorm1d(2)},
-      {"activation2", ReLU()} });
+      {{"layer1", Linear(10, 5)},
+       {"activation1", ReLU()},
+       {"layer2", Linear(5, 3)},
+       {"layer2norm", BatchNorm1d(2)},
+       {"activation2", ReLU()}});
 
-  Sequential clone_named = std::dynamic_pointer_cast<SequentialImpl>(sequential_named->clone());
+  Sequential clone_named =
+      std::dynamic_pointer_cast<SequentialImpl>(sequential_named->clone());
   ASSERT_EQ(sequential_named->size(), clone_named->size());
   for (std::size_t i = 0; i < sequential_named->size(); ++i) {
     ASSERT_EQ(sequential_named[i]->name(), clone_named[i]->name());
     ASSERT_NE(sequential_named[i], clone_named[i]);
   }
   ASSERT_EQ(c10::str(sequential_named), c10::str(clone_named));
-  
 
-  Sequential sequential_name_mix({{"layer1", Linear(10, 5)},});
+  // Mix named and unnamed submodules
+  Sequential sequential_name_mix({
+      {"layer1", Linear(10, 5)},
+  });
   sequential_name_mix->push_back(ReLU());
   sequential_name_mix->push_back("layer2", Linear(5, 3));
   sequential_name_mix->push_back("layer2norm", BatchNorm1d(2));
   sequential_name_mix->push_back(ReLU());
-  Sequential clone_mix = std::dynamic_pointer_cast<SequentialImpl>(sequential_name_mix->clone());
+  Sequential clone_mix =
+      std::dynamic_pointer_cast<SequentialImpl>(sequential_name_mix->clone());
 
   ASSERT_EQ(sequential_name_mix->size(), clone_mix->size());
   for (std::size_t i = 0; i < sequential_name_mix->size(); ++i) {

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -557,6 +557,8 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   template <typename ModuleType, typename... ArgumentTypes>
   friend struct AnyModuleHolder;
 
+  friend class SequentialImpl;
+
   /// Pretty prints the given `Module` into the `ostream`.
   TORCH_API friend std::ostream& operator<<(
       std::ostream& stream,

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -557,6 +557,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   template <typename ModuleType, typename... ArgumentTypes>
   friend struct AnyModuleHolder;
 
+  // declared friend to access `children_`
   friend class SequentialImpl;
 
   /// Pretty prints the given `Module` into the `ostream`.

--- a/torch/csrc/api/include/torch/nn/modules/container/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/sequential.h
@@ -9,6 +9,7 @@
 #include <torch/types.h>
 
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <cstdint>
 #include <memory>
@@ -157,8 +158,8 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
     // key values, this will result in a runtime error if we have two submodules
     // of the same type, e.g.:
     // `Sequential sequential(Linear(3, 4), ReLU(), Linear(4, 1), ReLU())`
-    std::vector<std::string> registered_names = children_.keys();
-    for (std::size_t i = 0; i < modules_.size(); ++i) {
+    const std::vector<std::string> registered_names = children_.keys();
+    for (const auto& i : c10::irange(modules_.size())) {
       clone->push_back(registered_names[i], modules_[i].clone(device));
     }
     return clone;

--- a/torch/csrc/api/include/torch/nn/modules/container/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/sequential.h
@@ -95,9 +95,28 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   using Iterator = std::vector<AnyModule>::iterator;
   using ConstIterator = std::vector<AnyModule>::const_iterator;
 
+  ///
+  /// constructors
+  ///
+
   SequentialImpl() = default;
 
-  /// Constructs the `Sequential` from a variadic list of modules.
+  /*
+   *  Constructs `Sequential` from a variadic list of modules. Arguments are 
+   *  registered as submodules of `Sequential` with names corresponding to 
+   *  order of insertion, e.g. `Linear`, `ReLU`, and `BatchNorm1d` have names
+   *  `0`, `1`, and `2` respectively below:
+   *  ```
+   *  Sequential sequential(Linear(3, 4), ReLU(), BatchNorm1d(3));
+   *  ```
+   *  Arguments' RTTI names aren't used since submodules are added to the member
+   *  variable `OrderedDict children_`, which will runtime error with duplicate
+   *  keys (will occur if you have two arguments of the same type).
+   *
+   *  A variadic template is used to support the passing arguments by any type 
+   *  supported by the `push_back()` methods, e.g. `AnyModule`, 
+   *  `std::shared_ptr<ModuleType>`. Parameters expanded by private `push_back()`.
+   */
   template <typename... Modules>
   explicit SequentialImpl(Modules&&... modules) {
     modules_.reserve(sizeof...(Modules));

--- a/torch/csrc/api/include/torch/nn/modules/container/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/sequential.h
@@ -102,8 +102,8 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   SequentialImpl() = default;
 
   /*
-   *  Constructs `Sequential` from a variadic list of modules. Arguments are 
-   *  registered as submodules of `Sequential` with names corresponding to 
+   *  Constructs `Sequential` from a variadic list of modules. Arguments are
+   *  registered as submodules of `Sequential` with names corresponding to
    *  order of insertion, e.g. `Linear`, `ReLU`, and `BatchNorm1d` have names
    *  `0`, `1`, and `2` respectively below:
    *  ```
@@ -113,9 +113,10 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
    *  variable `OrderedDict children_`, which will runtime error with duplicate
    *  keys (will occur if you have two arguments of the same type).
    *
-   *  A variadic template is used to support the passing arguments by any type 
-   *  supported by the `push_back()` methods, e.g. `AnyModule`, 
-   *  `std::shared_ptr<ModuleType>`. Parameters expanded by private `push_back()`.
+   *  A variadic template is used to support the passing arguments by any type
+   *  supported by the `push_back()` methods, e.g. `AnyModule`,
+   *  `std::shared_ptr<ModuleType>`. Parameters expanded by private
+   *  `push_back()`.
    */
   template <typename... Modules>
   explicit SequentialImpl(Modules&&... modules) {
@@ -154,7 +155,7 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
     // We don't want to use `modules_[i].ptr->name()` since this can return
     // just the type name via RTTI. Since an `OrderedDict` cannot have duplicate
     // key values, this will result in a runtime error if we have two submodules
-    // of the same type, e.g.: 
+    // of the same type, e.g.:
     // `Sequential sequential(Linear(3, 4), ReLU(), Linear(4, 1), ReLU())`
     std::vector<std::string> registered_names = children_.keys();
     for (std::size_t i = 0; i < modules_.size(); ++i) {
@@ -373,7 +374,7 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
    *  behavior, modules are given zero-indexed labels in order of insertion.
    *
    *  @requires: At least two parameters in the variadic template. The base case
-   *  of 1 parameter is addressed below. Oberve that the case of 0 parameters 
+   *  of 1 parameter is addressed below. Oberve that the case of 0 parameters
    *  __is not needed__ since the default constructor would be called.
    *
    *  @param idx: Label given to the next parameter to unpack
@@ -382,17 +383,19 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
    *  @param rest: Rest of the parameter pack to recursively process
    *
    */
-  template <
-      typename First,
-      typename Second,
-      typename... Rest>
-  void push_back(std::size_t idx, First&& first, Second&& second, Rest&&... rest) {
-    // recursively unpack the parameter pack whilst iterating each module's name 
+  template <typename First, typename Second, typename... Rest>
+  void push_back(
+      std::size_t idx,
+      First&& first,
+      Second&& second,
+      Rest&&... rest) {
+    // recursively unpack the parameter pack whilst iterating each module's name
     // to avoid duplicate labels, and conform to existing behavior
     push_back(c10::to_string(idx), std::forward<First>(first));
-    push_back(idx + 1, std::forward<Second>(second), std::forward<Rest>(rest)...);
+    push_back(
+        idx + 1, std::forward<Second>(second), std::forward<Rest>(rest)...);
   }
-  
+
   /*
    *  Base case of 1 parameter for the variadic `push_back()` expansion above
    */


### PR DESCRIPTION
__What?__
Fixes #71069

Further changes:
1. Changed the parameters of the private `torch::nn::Sequential::push_back()` method used to unpack the parameters from the variadic constructor
2. Added documentation to said constructor

__Why?__
1. I initially changed the private `push_back()` method to solve what turned out to be a non-issue. Afterwards, I found these changes made it easier to understand. Also, now we don't need to rely on any public `push_back()` methods in unpacking: originally, the base case of 1 parameter in the variadic template was covered by the public `push_back(M&& module)`.

__Further Development?__
Possible changes with C++17 (lmk if there's a wish list for that):
* Replace `c10::optional` with `std::optional`
* Add fine-grained type-checking with type traits in `class Sequential`; will save following the dependency chain

__P.S.__
I think you guys squash commits; if not, I can smash them.