### PR TITLE
Fix exception cause in storage.py

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -738,8 +738,8 @@ class TypedStorage:
     def _pickle_storage_type(self):
         try:
             return _dtype_to_storage_type_map()[self.dtype]
-        except KeyError:
-            raise KeyError(f'dtype {self.dtype} is not recognized')
+        except KeyError as e:
+            raise KeyError(f'dtype {self.dtype} is not recognized') from e
 
     def __reduce__(self):
         b = io.BytesIO()
@@ -996,6 +996,6 @@ class _LegacyStorage(TypedStorage, metaclass=_LegacyStorageMeta):
 def _get_dtype_from_pickle_storage_type(pickle_storage_type: str):
     try:
         return _storage_type_to_dtype_map()[pickle_storage_type]
-    except KeyError:
+    except KeyError as e:
         raise KeyError(
-            f'pickle storage type "{pickle_storage_type}" is not recognized')
+            f'pickle storage type "{pickle_storage_type}" is not recognized') from e


### PR DESCRIPTION
This change causes the correct message to be shown between the two tracebacks when an error is shown.

More context here: https://blog.ram.rachum.com/post/621791438475296768/improving-python-exception-chaining-with