### PR TITLE
Fix warning: use of bitwise '&' with boolean operands

### DIFF
--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -94,7 +94,7 @@ bool _use_cudnn_ctc_loss(
       // target length < 256 is documented, but we see illegal memory accesses
       // when target lengths > input lengths for CuDNN
       use_cudnn &=
-          (target_lengths[b] < 256) & (target_lengths[b] <= input_lengths[b]);
+          (target_lengths[b] < 256) && (target_lengths[b] <= input_lengths[b]);
     }
   }
   return use_cudnn;

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -88,13 +88,13 @@ bool _use_cudnn_ctc_loss(
     // (they should, but we didn't check yet)
     int64_t max_input_length = log_probs.size(0);
     for (const auto input_length : input_lengths) {
-      use_cudnn &= ((input_length == max_input_length) ? 1 : 0);
+      use_cudnn = use_cudnn && ((input_length == max_input_length) ? 1 : 0);
     }
     for (const auto b : c10::irange(target_lengths.size())) {
       // target length < 256 is documented, but we see illegal memory accesses
       // when target lengths > input lengths for CuDNN
-      use_cudnn &=
-          (target_lengths[b] < 256) && (target_lengths[b] <= input_lengths[b]);
+      use_cudnn =
+          use_cudnn && (target_lengths[b] < 256) && (target_lengths[b] <= input_lengths[b]);
     }
   }
   return use_cudnn;


### PR DESCRIPTION
```
[130/1102] Building CXX object caffe2/CMakeFiles/torch_cuda.dir/__/aten/src/ATen/native/cudnn/LossCTC.cpp.o
/home/gaoxiang/nvfuser5/aten/src/ATen/native/cudnn/LossCTC.cpp:97:11: warning: use of bitwise '&' with boolean operands [-Wbitwise-instead-of-logical]
          (target_lengths[b] < 256) & (target_lengths[b] <= input_lengths[b]);
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                    &&
/home/gaoxiang/nvfuser5/aten/src/ATen/native/cudnn/LossCTC.cpp:97:11: note: cast one or both operands to int to silence this warning
1 warning generated.
```