### PR TITLE
Revert D41682843: Multisect successfully blamed D41682843 for test or build failures

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -99,11 +99,6 @@ from .torch import (
 from .user_defined import UserDefinedClassVariable, UserDefinedObjectVariable
 
 
-# Names of attributes used to annotate modules for FSDP + Dynamo
-_FSDP_MANAGED_MODULE = "_is_fsdp_managed_module"
-_FSDP_USE_ORIG_PARAMS = "_fsdp_use_orig_params"
-
-
 class _missing:
     pass
 
@@ -324,14 +319,14 @@ class VariableBuilder:
                 return self.tx.output.side_effects.track_object_existing(
                     self.source, value, result
                 )
-            elif getattr(value, _FSDP_MANAGED_MODULE, False) or issubclass(
+            elif getattr(value, "_is_fsdp_managed_module", False) or issubclass(
                 value.__class__, torch.nn.parallel.distributed.DistributedDataParallel
             ):
-                if getattr(value, _FSDP_MANAGED_MODULE, False):
+                if getattr(value, "_is_fsdp_managed_module", False):
                     # Note: we can't do this assert inside FSDP constructor,
                     # since we don't know yet whether dynamo will be used
                     assert getattr(
-                        value, _FSDP_USE_ORIG_PARAMS, False
+                        value, "_fsdp_use_orig_params", False
                     ), "Dynamo only supports FSDP with use_orig_params=True"
 
                 # See note [Dynamo treats FSDP wrapped modules as UnspecializedNNModule]

--- a/torch/distributed/fsdp/_dynamo_utils.py
+++ b/torch/distributed/fsdp/_dynamo_utils.py
@@ -1,7 +1,6 @@
 from typing import Set
 
 import torch.nn as nn
-from torch._dynamo.variables.builder import _FSDP_MANAGED_MODULE, _FSDP_USE_ORIG_PARAMS
 
 
 def _annotate_modules_for_dynamo(
@@ -37,10 +36,10 @@ def _annotate_modules_for_dynamo(
             order for backward to interleave hooks with compute per layer.  UnspecializedNNModule lets us achieve
             this by capturing the module code more 'functionally' and passing parameters in as inputs each time.
             """
-            setattr(submodule, _FSDP_MANAGED_MODULE, True)
+            submodule._is_fsdp_managed_module = True  # type: ignore[assignment]
 
             # Dynamo only supports FSDP with use_orig_params=True.
             # This is hacky, but I could not think of another way to add an assertion to dynamo
             # for this, since Dynamo skips all the FSDP code frames and thus can't inspect the
             # FSDP module directly
-            setattr(submodule, _FSDP_USE_ORIG_PARAMS, use_orig_params)
+            submodule._fsdp_use_orig_params = use_orig_params  # type: ignore[assignment]


### PR DESCRIPTION
Summary:
This diff is reverting D41682843
D41682843 has been identified to be causing the following test or build failures:
Tests affected:
- https://www.internalfb.com/intern/test/281475048939643/

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1444954
Here are the tasks that are relevant to this breakage:
T93770103: 5 tests started failing for oncall assistant_multimodal in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Test Plan: NA

Reviewed By: zyan0, atuljangra, YazhiGao

Differential Revision: D41710749



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire