### PR TITLE
Remove deprecated flatten_params_wrapper.py from lintrunner config

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -107,7 +107,6 @@ exclude_patterns = [
     'torch/distributed/distributed_c10d.py',
     # TODO(suo): these exclusions were added just to get lint clean on master.
     # Follow up to do more target suppressions and remove them.
-    'torch/distributed/fsdp/flatten_params_wrapper.py',
     'torch/ao/quantization/fx/convert.py',
     'torch/ao/quantization/_dbr/function_fusion.py',
     'test/test_datapipe.py',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90154
* #90151
* #90079
* #90078
* #90041

