### PR TITLE
[1/N] Adapt DTensor's test_pointwise_ops To Using MultiThreadedTestCase

### DIFF
--- a/test/distributed/_tensor/test_pointwise_ops.py
+++ b/test/distributed/_tensor/test_pointwise_ops.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Optional, Sequence
 from unittest import skip
 
 import torch
+import torch.distributed as dist
 
 import torch.utils._pytree as pytree
 from torch import Tensor
@@ -19,11 +20,9 @@ from torch.distributed._tensor.placement_types import (
 from torch.distributed.distributed_c10d import ReduceOp
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
-    DTensorTestBase,
     skip_unless_torch_gpu,
-    with_comms,
 )
-
+from torch.testing._internal.common_distributed import MultiThreadedTestCase, DEFAULT_WORLD_SIZE
 
 def no_op():
     return None
@@ -73,7 +72,18 @@ def deepcopy_convert_from_dtensor(val: Any) -> Any:
     return pytree.tree_map(f, [val])[0]
 
 
-class DistElementwiseOpsTest(DTensorTestBase):
+class DistElementwiseOpsTest(MultiThreadedTestCase):
+    @property
+    def world_size(self) -> int:
+        return DEFAULT_WORLD_SIZE
+
+    @property
+    def device_type(self) -> str:
+        return "cuda" if torch.cuda.is_available() else "cpu"
+
+    def build_device_mesh(self):
+        return DeviceMesh(self.device_type, list(range(self.world_size)))
+
     def _compare_pairwise_ops(
         self,
         *,
@@ -144,7 +154,6 @@ class DistElementwiseOpsTest(DTensorTestBase):
             kwargs=kwargs,
         )
 
-    @with_comms
     def test_activations(self):
         device_mesh = self.build_device_mesh()
         self._run_sharded_elementwise_ops(
@@ -184,13 +193,12 @@ class DistElementwiseOpsTest(DTensorTestBase):
             op=torch.sigmoid,
         )
 
-    @with_comms
     @skip("testing RNG based ops is broken: https://github.com/pytorch/tau/issues/494")
     def test_dropout(self):
         device_mesh = self.build_device_mesh()
 
         def _reset_random_seed():
-            torch.manual_seed(self.rank + 4)
+            torch.manual_seed(dist.get_rank() + 4)
 
         self._run_sharded_elementwise_ops(
             device_mesh=device_mesh,
@@ -211,7 +219,6 @@ class DistElementwiseOpsTest(DTensorTestBase):
             training=True,
         )
 
-    @with_comms
     @skip_unless_torch_gpu
     def test_dropout_backward(self):
         device_mesh = self.build_device_mesh()
@@ -244,7 +251,6 @@ class DistElementwiseOpsTest(DTensorTestBase):
             ),
         )
 
-    @with_comms
     def test_dropout_errors(self):
         device_mesh = self.build_device_mesh()
         with self.assertRaisesRegex(RuntimeError, "supported"):
@@ -255,10 +261,9 @@ class DistElementwiseOpsTest(DTensorTestBase):
                 op=torch.nn.functional.dropout,
             )
 
-    @with_comms
     def test_mul_out(self):
         device_mesh = self.build_device_mesh()
-        torch.manual_seed(self.rank)
+        torch.manual_seed(dist.get_rank())
         shard_spec = [Shard(0)]
         input_size = (8, 4)
         input_tensor = torch.randn(*input_size, device=self.device_type)

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -115,14 +115,14 @@ class DeviceMesh(object):
         # check default pg backend, should support device_type
         if device_type == "cpu":
             assert (
-                self._backend == "gloo"
+                self._backend == "gloo" or self._backend == "local"
             ), f"ProcessGroup backend: {self._backend} not supporting CPU!"
         elif device_type == "cuda":
             if self._backend == "gloo":
                 warnings.warn(
                     "We recommend using nccl backend for cuda device type, gloo backend might only have partial support!"
                 )
-            assert self._backend == "gloo" or self._backend == "nccl"
+            assert self._backend == "gloo" or self._backend == "nccl" or self._backend == "local"
         else:
             raise RuntimeError(
                 f"DeviceMesh only support cpu or cuda device type, but got {device_type}"

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -935,6 +935,7 @@ class MultiThreadedTestCase(TestCase):
     def threaded_run_test(self):
         self.perThreadSetUp()
         try:
+            # TODO: use @spawn_threads_and_init_comms wrapper instead in tests?
             _run_test_with_mt_pg(
                 self=self,
                 timeout=TIMEOUT_DEFAULT,

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -25,11 +25,13 @@ TODO:
 Lots of missing collectives.
 Collectives validation.
 Make timeout robust by making collectives respect the test deadline.
-Make tests robuts by making collectives interruptible.
+Make tests robust by making collectives interruptible.
 We need some synchronization around cleanup to ensure that timedout ranks don't cause spurious failures.
 
 """
 
+# TODO: what's the good formula for Collective's timeout from test deadline (TIMEOUT_DEFAULT)?
+COLLECTIVE_TIMEOUT_DEFAULT = 1
 
 def flatten_list(lst):
     return tree_flatten(lst)[0]
@@ -125,11 +127,11 @@ class Broadcast:
             out_tensor_list = flatten_list(data[i])
             for j in range(len(in_tensor_list)):
                 with torch.no_grad():
-                    out_tensor_list[j].copy_(in_tensor_list[j])
+                    out_tensor_list[j].copy_(in_tensor_list[j]) #index out of range on rank 0 for DistElementwiseOpsTest.test_dropout_backward
 
 
 class Collective:
-    def __init__(self, world_size, collective):
+    def __init__(self, world_size, collective, pg):
         self._world_size = world_size
         self._collective = collective
 
@@ -139,6 +141,8 @@ class Collective:
         self._data = [None] * world_size
         self._count = 0
         self._done = False
+
+        self._pg = pg
 
     def join(self, rank, data):
         with self._start_cond:
@@ -151,14 +155,19 @@ class Collective:
                     self._start_cond.notify()
 
             if rank == 0:
-                while self._count < self._world_size:
-                    self._start_cond.wait()
+                while self._count < self._world_size and not self._pg._terminate:
+                    self._start_cond.wait(COLLECTIVE_TIMEOUT_DEFAULT)
+                if self._pg._terminate:
+                    raise RuntimeError("Test fails due to early termination of thread!")
 
         with self._done_cond:
             # wait for rank 0 to finish
             if rank > 0:
-                while not self._done:
-                    self._done_cond.wait()
+                while not self._done and not self._pg._terminate:
+                    self._done_cond.wait(COLLECTIVE_TIMEOUT_DEFAULT)
+                if self._pg._terminate:
+                    raise RuntimeError("Test fails due to early termination of thread!")
+
             else:
                 # copy data around
                 self._collective.work(self._data)
@@ -175,6 +184,8 @@ class ProcessLocalGroup(dist.ProcessGroup):
 
     _coll_lock = threading.Lock()
     _cur_coll = None
+
+    _terminate = False
 
     @classmethod
     def _register(cls, pg):
@@ -194,7 +205,7 @@ class ProcessLocalGroup(dist.ProcessGroup):
                     f"world not ready, only {cls._count} PG's registered but world has {world_size} ranks"
                 )
             if cls._cur_coll is None:
-                cls._cur_coll = Collective(world_size, collective)
+                cls._cur_coll = Collective(world_size, collective, cls)
             return cls._cur_coll
 
     @classmethod
@@ -203,6 +214,17 @@ class ProcessLocalGroup(dist.ProcessGroup):
         with cls._coll_lock:
             if cls._cur_coll == collective:
                 cls._cur_coll = None
+
+
+    @classmethod
+    def exception_handle(cls, exc):
+        with cls._pg_lock:
+            cls._terminate = True
+
+    @classmethod
+    def reset_terminate(cls):
+        with cls._pg_lock:
+            cls._terminate = False
 
     def allreduce(self, tensor_list, opts=AllreduceOptions()):
         coll = ProcessLocalGroup._start_coll(self._world, AllReduce(opts.reduceOp))
@@ -339,6 +361,8 @@ def run_with_threaded_pg(world_size, timeout, callback):
             callback()
         except BaseException as ex:
             exception_queue.put((rank, sys.exc_info()))
+            # notify all threads to throw exception.
+            world.default_pg.exception_handle(ex)
         finally:
             if world_is_valid():
                 dist.destroy_process_group()
@@ -366,6 +390,7 @@ def run_with_threaded_pg(world_size, timeout, callback):
                         ),
                     )
                 )
+        ProcessLocalGroup.reset_terminate()
         failed_ranks = []
         while not exception_queue.empty():
             failure = exception_queue.get()


### PR DESCRIPTION
This series of PRs aim to adapt existing DTensor pointwise ops unit test from using `MultiProcessTestCase` to `MultiThreadedTestCase`. Currently we found a set of issues in `MultiThreadedTestCase` (#89941) which restrains it due to some potential negative consequences. In this case, there're mainly two issues:

1. Inconsistent random seed set up among ranks. This is because of the blank implementation of `setUp()` within `MultiThreadedTestCase`.
2. A single failure case causes the whole test hang until timeout. This is because the `join()` function of multi-threaded ProcessGroup's `Collective` class uses a blocking `wait()` without passing a `timeout` argument. 

This PR is the first in stack of PRs and focuses on adapting DTensor pointwise ops unit test to using `MultiThreadedTestCase` and solving the hanging issue, to unblock fixing other issues that prevents us to adapt `MultiThreadedTestCase`.