### PR TITLE
fix c10::detail::integer_iterator for C++17

### DIFF
--- a/c10/util/irange.h
+++ b/c10/util/irange.h
@@ -17,7 +17,13 @@ template <
     typename I,
     bool one_sided = false,
     typename std::enable_if<std::is_integral<I>::value, int>::type = 0>
-struct integer_iterator : std::iterator<std::input_iterator_tag, I> {
+struct integer_iterator {
+  using iterator_category = std::input_iterator_tag;
+  using value_type = I;
+  using difference_type = std::ptrdiff_t;
+  using pointer = I*;
+  using reference = I&;
+
   explicit integer_iterator(I value) : value(value) {}
 
   I operator*() const {


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/90174).
* __->__ #90174

fix c10::detail::integer_iterator for C++17

Summary: std::iterator is deprecated.

Test Plan: Rely on CI.

