### PR TITLE
Integrate `ncclCommInitRankConfig`

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -357,8 +357,16 @@ ncclComm_t comm_init_rank(int nranks, const ncclUniqueId& comm_id, int rank) {
   using namespace torch::cuda::nccl::detail;
   ncclComm_t comm;
   ncclUniqueId id = comm_id;
+#if defined(ENABLE_NCCL_FAULT_TOLERANCE)
+  // TODO(crcrpar): Accept & reflect `blocking`.
+  // Currently this call is no different from the one below.
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  NCCL_CHECK(ncclCommInitRankConfig(
+      &(comm->ncclComm_), numRanks, commId, rank, &config));
+#else
   NCCL_CHECK(ncclCommInitRank(
       to_nccl_comm(&comm), nranks, *(to_nccl_unique_id(&id)), rank));
+#endif
   return comm;
 #else
   return nullptr;

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -18,6 +18,15 @@
 #define HAS_NCCL_BF16_DATATYPE 0
 #endif
 
+#if !defined(USE_ROCM)
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && defined(NCCL_MINOR) && \
+    (NCCL_MINOR >= 14)
+#define ENABLE_NCCL_FAULT_TOLERANCE
+#elif defined(NCCL_MAJOR) && (NCCL_MAJOR >= 3)
+#define ENABLE_NCCL_FAULT_TOLERANCE
+#endif
+#endif
+
 namespace torch {
 namespace cuda {
 namespace nccl {


### PR DESCRIPTION
Use `ncclCommInitRankConfig` instead of `ncclCommInitRank` if it's not ROCm and the available NCCL >= 2.14.3.

Ref:
- https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#c.ncclCommInitRankConfig
- https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html#creating-a-communication-with-options

future work
- take and reflect `blocking` parameter

Signed-off-by: Masaki Kozuki <mkozuki@nvidia.com>