### PR TITLE
Enable proxy tensor tests for ops that don't support floating point types

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1079,6 +1079,7 @@ make_fx_failures = {
     skip('nn.functional.max_unpool1d', '', device_type='cpu'),
     skip('nn.functional.max_unpool2d', '', device_type='cpu'),
     skip('nn.functional.max_unpool3d', '', device_type='cpu'),
+    xfail('nn.functional.one_hot'),
     skip('linalg.lstsq'),  # flaky, probably just a precision issue
 
     # data-dependent control flow
@@ -1342,6 +1343,13 @@ inplace_symbolic_tensor_failures = {
     # Views
     xfail('t', ''),
     xfail('transpose', ''),
+    xfail('bitwise_right_shift'),
+    xfail('bitwise_or'),
+    xfail('bitwise_not'),
+    xfail('bitwise_left_shift'),
+    xfail('bitwise_xor'),
+    xfail('gcd'),
+    xfail('lcm')
 }
 
 # Copies inputs to inplace operations to avoid inplace modifications

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1348,6 +1348,7 @@ inplace_symbolic_tensor_failures = {
     xfail('bitwise_not'),
     xfail('bitwise_left_shift'),
     xfail('bitwise_xor'),
+    xfail('bitwise_and'),
     xfail('gcd'),
     xfail('lcm')
 }

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -1404,25 +1404,25 @@ def _test_make_fx_helper(self, device, dtype, op, tracing_mode, inplace=False):
         self.assertEqual(new_out, old_out)
 
 class TestProxyTensorOpInfo(TestCase):
-    @ops(op_db, allowed_dtypes=(torch.float,))
+    @ops(op_db, allowed_dtypes=(torch.float,), secondary_allowed_dtypes=(torch.long, torch.cfloat))
     @skipOps('TestProxyTensorOpInfo', 'test_make_fx_exhaustive', make_fx_failures)
     def test_make_fx_exhaustive(self, device, dtype, op):
         _test_make_fx_helper(self, device, dtype, op, "real")
 
-    @ops(op_db, allowed_dtypes=(torch.float,))
+    @ops(op_db, allowed_dtypes=(torch.float,), secondary_allowed_dtypes=(torch.long, torch.cfloat))
     @skipOps('TestProxyTensorOpInfo', 'test_make_fx_fake_exhaustive', make_fx_failures.union(fake_tensor_failures))
     def test_make_fx_fake_exhaustive(self, device, dtype, op):
         _test_make_fx_helper(self, device, dtype, op, "fake")
 
     @skipIfNoSympy
-    @ops(op_db, allowed_dtypes=(torch.float,))
+    @ops(op_db, allowed_dtypes=(torch.float,), secondary_allowed_dtypes=(torch.long, torch.cfloat))
     @skipOps('TestProxyTensorOpInfo', 'test_make_fx_symbolic_exhaustive',
              make_fx_failures | fake_tensor_failures | symbolic_tensor_failures | outplace_symbolic_tensor_failures)
     def test_make_fx_symbolic_exhaustive(self, device, dtype, op):
         _test_make_fx_helper(self, device, dtype, op, "symbolic")
 
     @skipIfNoSympy
-    @ops(op_db, allowed_dtypes=(torch.float,))
+    @ops(op_db, allowed_dtypes=(torch.float,), secondary_allowed_dtypes=(torch.long, torch.cfloat))
     @skipOps('TestProxyTensorOpInfo', 'test_make_fx_symbolic_exhaustive_inplace',
              make_fx_failures | fake_tensor_failures | symbolic_tensor_failures | inplace_symbolic_tensor_failures)
     def test_make_fx_symbolic_exhaustive_inplace(self, device, dtype, op):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -754,10 +754,12 @@ ANY_DTYPE_ORDER = (
 
 class ops(_TestParametrizer):
     def __init__(self, op_list, *, dtypes: Union[OpDTypes, Sequence[torch.dtype]] = OpDTypes.supported,
-                 allowed_dtypes: Optional[Sequence[torch.dtype]] = None):
+                 allowed_dtypes: Optional[Sequence[torch.dtype]] = None,
+                 secondary_allowed_dtypes: Optional[Sequence[torch.dtype]] = None):
         self.op_list = list(op_list)
         self.opinfo_dtypes = dtypes
         self.allowed_dtypes = set(allowed_dtypes) if allowed_dtypes is not None else None
+        self.secondary_allowed_dtypes = set(secondary_allowed_dtypes) if allowed_dtypes is not None else None
 
     def _parametrize_test(self, test, generic_cls, device_cls):
         """ Parameterizes the given test function across each op and its associated dtypes. """
@@ -806,7 +808,10 @@ class ops(_TestParametrizer):
                 raise RuntimeError(f"Unknown OpDType: {self.opinfo_dtypes}")
 
             if self.allowed_dtypes is not None:
-                dtypes = dtypes.intersection(self.allowed_dtypes)
+                op_info_dtypes = dtypes
+                dtypes = op_info_dtypes.intersection(self.allowed_dtypes)
+                if len(dtypes) == 0:
+                    dtypes = op_info_dtypes.intersection(self.secondary_allowed_dtypes)
 
             # Construct the test name; device / dtype parts are handled outside.
             # See [Note: device and dtype suffix placement]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90207

Fixes https://github.com/pytorch/pytorch/issues/89060