### PR TITLE
Assert there are no outstanding side effects before calling cond

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -712,6 +712,16 @@ class TorchPyOperator(VariableTracker):
             # ops - see torch/dispatch/_dispatcher.py
             from .. import config
 
+            # The current recursive export() implementation will
+            # not "see" any side effect updates from the enclosing
+            # context, which can result in possibly incorrect
+            # export.  This assert ensures that there were no
+            # outstanding side effects at the time cond() was called.
+            #
+            # TODO: This assert may be too aggressive; I'm landing it
+            # to see if it is or not.
+            assert tx.output.side_effects.is_empty()
+
             assert len(p_args) == 4
             assert type(args[0]) is TensorVariable  # predicate
             assert type(p_args[1]) is UserFunctionVariable  # true_fn

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -720,7 +720,14 @@ class TorchPyOperator(VariableTracker):
             #
             # TODO: This assert may be too aggressive; I'm landing it
             # to see if it is or not.
-            assert tx.output.side_effects.is_empty()
+            assert tx.output.side_effects.is_empty(), (
+                "Handling a cond operator when there are outstanding "
+                "side effects in the trace is not currently supported.  "
+                "Please file a bug to PyTorch requesting this functionality.  "
+                "You may be able to unblock by removing side effects (e.g., "
+                "mutating Python variables/data structures/etc) from your "
+                "model."
+            )
 
             assert len(p_args) == 4
             assert type(args[0]) is TensorVariable  # predicate


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90208

The current cond implementation is silently incorrect when
there are outstanding side effects, since the locally tracked
side effects are lost when the recursive export call is made.
At least we raise an assert now.

I'm working on a refactor of cond which should be able to sidestep
this problem. Maybe.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire

Differential Revision: [D41746973](https://our.internmc.facebook.com/intern/diff/D41746973)