### PR TITLE
[Release only change] Uninstall sympy while running windows tests

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -40,7 +40,7 @@ pip install "ninja==1.10.0.post1" future "hypothesis==5.35.1" "expecttest==0.1.3
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 
-pip uninstall sympy
+pip uninstall -y sympy
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -40,6 +40,10 @@ pip install "ninja==1.10.0.post1" future "hypothesis==5.35.1" "expecttest==0.1.3
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 
+pip uninstall sympy
+if errorlevel 1 exit /b
+if not errorlevel 0 exit /b
+
 set DISTUTILS_USE_SDK=1
 
 if not "%USE_CUDA%"=="1" goto cuda_build_end


### PR DESCRIPTION
Try fix sympy failures on release branch :
Example of failures:
https://github.com/pytorch/pytorch/actions/runs/3585570367/jobs/6034669526

This is needed since window AMI update was performed. The error seems to be related to following update:
https://github.com/pytorch/test-infra/pull/1065