### PR TITLE
Fix torch.distributed.run init connect timeout by comparing `host` with the current IP list

### DIFF
--- a/test/distributed/elastic/rendezvous/utils_test.py
+++ b/test/distributed/elastic/rendezvous/utils_test.py
@@ -12,6 +12,7 @@ import socket
 from datetime import timedelta
 from typing import List
 from unittest import TestCase
+from unittest.mock import patch
 
 from torch.distributed.elastic.rendezvous.utils import (
     _PeriodicTimer,
@@ -253,6 +254,26 @@ class UtilsTest(TestCase):
                 time2 = time.monotonic()
 
                 self.assertGreaterEqual(time2 - time1, 0.2)
+
+
+    @patch('socket.getaddrinfo', side_effect=[
+        [(None, None, 0, 'a_host', ('1.2.3.4', 0))],
+        [(None, None, 0, 'a_different_host', ('1.2.3.4', 0))]])
+    def test_matches_machine_hostname_returns_true_if_ip_address_match_between_hosts(
+        self,
+        _0,
+    ) -> None:
+        self.assertTrue(_matches_machine_hostname("a_host"))
+
+
+    @patch('socket.getaddrinfo', side_effect=[
+        [(None, None, 0, 'a_host', ('1.2.3.4', 0))],
+        [(None, None, 0, 'another_host_with_different_ip', ('1.2.3.5', 0))]])
+    def test_matches_machine_hostname_returns_false_if_ip_address_not_match_between_hosts(
+        self,
+        _0,
+    ) -> None:
+        self.assertFalse(_matches_machine_hostname("a_host"))
 
 
 class PeriodicTimerTest(TestCase):

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -127,6 +127,18 @@ def _matches_machine_hostname(host: str) -> bool:
     if addr and addr.is_loopback:
         return True
 
+    try:
+        host_addr_list = socket.getaddrinfo(
+            host, None, proto=socket.IPPROTO_TCP, flags=socket.AI_CANONNAME
+        )
+    except ValueError:
+        host_addr_list = []
+
+    host_ip_list = [
+        host_addr_info[4][0]
+        for host_addr_info in host_addr_list
+    ]
+
     this_host = socket.gethostname()
     if host == this_host:
         return True
@@ -138,9 +150,14 @@ def _matches_machine_hostname(host: str) -> bool:
         # If we have an FQDN in the addr_info, compare it to `host`.
         if addr_info[3] and addr_info[3] == host:
             return True
+
         # Otherwise if `host` represents an IP address, compare it to our IP
         # address.
         if addr and addr_info[4][0] == str(addr):
+            return True
+
+        # If the IP address matches one of the provided host's IP addresses
+        if addr_info[4][0] in host_ip_list:
             return True
 
     return False


### PR DESCRIPTION
Summary:
Pull Request: https://github.com/pytorch/pytorch/issues/79388

Fix torch.distributed.run init connect timeout by comparing `host` with the current IP list.

Test Plan: unit tests

Differential Revision: D41373962

