### PR TITLE
Support pickle version 4 by adding missing ops

### DIFF
--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -648,7 +648,7 @@ class PackageExporter:
                         field = arg
                         memo[memo_count] = arg
                     elif (
-                        opcode.name == "BINGET_LONG"
+                        opcode.name == "LONG_BINGET"
                         or opcode.name == "BINGET"
                         or opcode.name == "GET"
                     ):
@@ -658,6 +658,9 @@ class PackageExporter:
                     elif opcode.name == "MEMOIZE":
                         memo_count += 1
                     elif opcode.name == "STACK_GLOBAL":
+                        if module is None:
+                            # If not module was passed on in the entries preceeding this one, continue.
+                            continue
                         assert isinstance(module, str)
                         if module not in all_dependencies:
                             all_dependencies.append(module)


### PR DESCRIPTION
Summary:
In this logic, we are traversing the entries to find the module for STACK_GLOBAL entries.

According to https://github.com/python/cpython/blob/2837241f22be33a5597707b2aa723cb2cf6f3967/Lib/pickletools.py#L1799 we need to look for GET, BINGET and LONG_BINGET.

So this diff updates that. Also while testing, I found some cases of empty modules, for cases such as tanh. For this I added the option to skip processing when this is the case.

Test Plan: Tested with f392778829

Differential Revision: D41748595

