### PR TITLE
[dtensor] handle the case where output of op is Optional[Tensor]

### DIFF
--- a/torch/distributed/_tensor/dispatch.py
+++ b/torch/distributed/_tensor/dispatch.py
@@ -291,6 +291,8 @@ def operator_dispatch(
                 out_dt._spec = cast(DTensorSpec, output_specs[spec_idx])
                 out_dts.append(out_dt)
                 spec_idx += 1
+
+        assert len(out_dts) >= 1, "out variant should have at least one out arg"
         return tuple(out_dts) if len(out_dts) > 1 else out_dts[0]
     else:
         return wrap(local_results, output_sharding.output_spec)

--- a/torch/distributed/_tensor/utils.py
+++ b/torch/distributed/_tensor/utils.py
@@ -45,8 +45,13 @@ def wrap(res: object, spec: OutputSpecType) -> object:
         assert spec is not None and isinstance(
             spec, tuple
         ), f"output spec does not match with output! Expected tuple, got {spec}"
+
+        # NOTE: local results might return Optional Tensor from ATen op, so we need to
+        # handle that case and make sure we don't wrap None with DTensor.
+        # (i.e. native_layer_norm.backward)
         return tuple(
             dtensor.DTensor(e, s.mesh, s.placements, size=s.shape)
+            if e is not None and s is not None else None
             for e, s in zip(res, spec)
         )
     else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90241
* #90106
* #89970
* #89969
* #89968
* #89967

Observed by @aazzolini, some op might have Optional[Tensor] returns
where it return None (i.e. native_layer_norm_backward), it's a mismatch
between C++ aten op signature and python None, but we need to handle it
in the python side