### PR TITLE
[MKLDNN] Rename pooling_avg to pooling_avg_exclude_padding

### DIFF
--- a/aten/src/ATen/native/mkldnn/Pooling.cpp
+++ b/aten/src/ATen/native/mkldnn/Pooling.cpp
@@ -671,7 +671,7 @@ Tensor mkldnn_adaptive_avg_pool2d_backward(
       /*padding*/ {0, 0},
       /*dilation*/{1, 1},
       false,
-      /*algo*/ ideep::algorithm::pooling_avg);
+      /*algo*/ ideep::algorithm::pooling_avg_exclude_padding);
 }
 
 Tensor& mkldnn_adaptive_avg_pool2d_backward_out(

--- a/caffe2/ideep/operators/pool_op.cc
+++ b/caffe2/ideep/operators/pool_op.cc
@@ -28,7 +28,7 @@ class IDEEPPoolOp final : public IDEEPConvPoolOpBase {
     if (operator_def.type().substr(0, 7) == "MaxPool") {
       algo_ = ialgo::pooling_max;
     } else if (operator_def.type().substr(0, 11) == "AveragePool") {
-      algo_ = ialgo::pooling_avg;
+      algo_ = ialgo::pooling_avg_exclude_padding;
     } else {
       LOG(FATAL) << "Unsupported pooling method: " << operator_def.type();
     }
@@ -82,7 +82,7 @@ class IDEEPPoolGradientOp final : public IDEEPConvPoolOpBase {
     if (operator_def.type().substr(0, 15) == "MaxPoolGradient") {
       algo_ = ialgo::pooling_max;
     } else if (operator_def.type().substr(0, 19) == "AveragePoolGradient") {
-      algo_ = ialgo::pooling_avg;
+      algo_ = ialgo::pooling_avg_exclude_padding;
     } else {
       LOG(FATAL) << "Unsupported pooling method: " << operator_def.type();
     }

--- a/caffe2/ideep/operators/quantization/int8_pool_op.cc
+++ b/caffe2/ideep/operators/quantization/int8_pool_op.cc
@@ -25,7 +25,7 @@ class IDEEPInt8PoolOp final : public IDEEPConvPoolOpBase {
     if (operator_def.type().substr(0, 11) == "Int8MaxPool") {
       algo_ = ialgo::pooling_max;
     } else if (operator_def.type().substr(0, 15) == "Int8AveragePool") {
-      algo_ = ialgo::pooling_avg;
+      algo_ = ialgo::pooling_avg_exclude_padding;
     } else {
       LOG(FATAL) << "Unsupported pooling method: " << operator_def.type();
     }


### PR DESCRIPTION
**Summary**
Rename `pooling_avg` to `pooling_avg_exclude_padding` to align with onednn v3.0. It does not affect correctness or performance. Same as https://github.com/pytorch/pytorch/pull/87851 . Looks like https://github.com/pytorch/pytorch/pull/87851 did not cover all occurrences.

**Test plan**
python test/test_mkldnn.py
python caffe2/python/ideep/pool_op_test.py

cc @VitalyFedyunin @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen