### PR TITLE
[FSDP][Perf] Compute `flat_param.grad` with padded size directly

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -542,6 +542,10 @@ def _post_backward_hook(
                 numel_to_pad = (
                     state.world_size * chunks[0].numel() - unsharded_grad.numel()
                 )
+                p_assert(
+                    numel_to_pad == 0,
+                    f"Expects no padding needed but requires {numel_to_pad} numel",
+                )
                 padded_unsharded_grad = (
                     F.pad(unsharded_grad, [0, numel_to_pad])
                     if numel_to_pad > 0

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -1029,7 +1029,7 @@ class FSDPTest(MultiProcessTestCase):
         # the DDP parameters are in FP16 (from `half()`) while the FSDP
         # parameters are in FP32 (from `summon_full_params()`) and (2) DDP runs
         # the optimizer in FP16 while FSDP runs it in FP32
-        if mixed_precision is not None:
+        if mixed_precision is None:
             self.assertEqual(
                 ddp_params,
                 fsdp_unsharded_params,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90249 [FSDP] Simplify grad padding logic
* **#90248 [FSDP] Have the unsharded `flat_param` use the padded size**
* #90251 [FSDP] Clarify loss dtype check in `_test_fsdp_parity`
* #90250 [FSDP][BE] Clean up dead code from `clip_grad_norm_()` testing
* #90290 [FSDP] Test `use_orig_params=True` in `test_fsdp_ignored_modules.py`
* #90252 [FSDP] Fix accidental change in `_test_fsdp_parity`

**Overview**
This PR enforces that the `flat_param` uses the *padded* unsharded size during FSDP-managed computation, not the *unpadded* unsharded size. As a result, the gradient is computed directly with padding, avoiding the need for manual padding in the post-backward hook, which requires an unsharded memory allocation in the post-backward stream and a copy.

**Approach**
We achieve this by defining `FORWARD`, `BACKWARD_PRE`, `BACKWARD_POST`, and `IDLE` to be "computation" states. (We include `IDLE` to accommodate prefetching.) Conversely, we define `SUMMON_FULL_PARAMS` to _not_ be a "computation" state.

In theory, we do not expect users to inspect the unsharded `flat_param` in `summon_full_params()` since they should only care about the unsharded original parameters in that context. However, for the `use_orig_params=False` code path, the `flat_param` is inevitably exposed, and it is reasonable for users to access it in `summon_full_params()`. To handle this, we trim the padding in `summon_full_params()`. Notably, this does not affect gradient computation.

The workhorse for creating the unsharded views is the static method `FlatParamHandle_get_unflat_views(flat_param, tensor=None)`, which is for the `FlatParameter`, its gradient, and optimizer states. For simplicity, we want to preserve that the unsharded optimizer state does not need padding. We do this by defining an invariant: If the user specifies a non-`None` `tensor` argument, then `tensor` has the *unpadded* unsharded size, which may require manual trimming (e.g. for the gradient). If the user specifies `tensor=None`, then the method uses the `flat_param` and expects it to be padded.

**Details**
`flat_param._padded_unsharded_size` is only defined for sharded strategies and after lazy attribute initialization (via `_lazy_init()` -> `init_flat_param_attributes()`). To handle the window between initialization and lazy initialization and the difference between sharded and non-sharded strategies, we define `flat_param._unsharded_size_for_comp` that always return the unsharded size for computation, hiding the complex branching.

Even with this attribute, developers should be wary which unsharded size they are using. For any all-gathers, the unsharded size is `flat_param._padded_unsharded_size` (which is only defined for sharded strategies). For any uses outside computation or uses that require padding trimmed, the unsharded size is `flat_param._unpadded_unsharded_size` (which is _always_ defined).