### PR TITLE
[FSDP][BE] Clean up dead code from `clip_grad_norm_()` testing

### DIFF
--- a/test/distributed/fsdp/test_fsdp_core.py
+++ b/test/distributed/fsdp/test_fsdp_core.py
@@ -138,14 +138,10 @@ class TestParityWithDDP(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @parametrize(params, configs, subtest_name)
-    # TODO (awgu): 2.0 fails tests
-    # @parametrize("norm_type", [2.0, None])
-    @parametrize("norm_type", [None])
     def test_nested_always_wrap_model(
         self,
         cpu_offload: CPUOffload,
         sharding_strategy: Optional[ShardingStrategy],
-        norm_type: Optional[float],
     ):
         self.run_subtests(
             self._get_subtest_config(cpu_offload),
@@ -154,19 +150,14 @@ class TestParityWithDDP(FSDPTest):
             FSDPInitMode.RECURSIVE,
             cpu_offload=cpu_offload,
             sharding_strategy=sharding_strategy,
-            norm_type=norm_type,
         )
 
     @skip_if_lt_x_gpu(2)
     @parametrize(params, configs, subtest_name)
-    # TODO (awgu): 2.0 fails tests
-    # @parametrize("norm_type", [2.0, None])
-    @parametrize("norm_type", [None])
     def test_transformer(
         self,
         cpu_offload: CPUOffload,
         sharding_strategy: Optional[ShardingStrategy],
-        norm_type: Optional[float],
     ):
         self.run_subtests(
             self._get_subtest_config(cpu_offload),
@@ -174,7 +165,6 @@ class TestParityWithDDP(FSDPTest):
             TransformerWithSharedParams,
             FSDPInitMode.RECURSIVE,
             cpu_offload=cpu_offload,
-            norm_type=norm_type,
             sharding_strategy=sharding_strategy,
         )
 
@@ -228,14 +218,10 @@ class TestParityWithDDP(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @parametrize(params, configs, subtest_name)
-    # TODO (awgu): 2.0 fails tests
-    # @parametrize("norm_type", [2.0, None])
-    @parametrize("norm_type", [None])
     def test_mixture_of_experts(
         self,
         cpu_offload: CPUOffload,
         sharding_strategy: Optional[ShardingStrategy],
-        norm_type: Optional[float],
     ):
         self.run_subtests(
             self._get_subtest_config(cpu_offload),
@@ -245,7 +231,6 @@ class TestParityWithDDP(FSDPTest):
             ref_init_fn=self._dummy_ddp_fn,
             cpu_offload=cpu_offload,
             sharding_strategy=sharding_strategy,
-            norm_type=norm_type,
         )
 
     @skip_if_lt_x_gpu(2)

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -796,7 +796,6 @@ class FSDPTest(MultiProcessTestCase):
         autocast: bool,
         lr: float = 0.01,
         fsdp_cpu_offload: Optional[CPUOffload] = None,
-        norm_type: Optional[Union[float, int]] = None,
         save_model: bool = False,
         mixed_precision: Optional[MixedPrecision] = None,
         enable_sharded_grad_scaler: bool = False,
@@ -843,21 +842,6 @@ class FSDPTest(MultiProcessTestCase):
                 else:
                     self.assertEqual(loss.dtype, torch.float32)
             model.module.run_backward(loss)
-            if norm_type is not None:
-                max_norm = 0.3
-                if isinstance(model, FSDP):
-                    model.clip_grad_norm_(max_norm, norm_type)
-                    total_norm_after_clip = _collect_total_grad_norm_fsdp(
-                        model, norm_type, self.rank
-                    )
-                else:
-                    torch.nn.utils.clip_grad_norm_(
-                        model.parameters(), max_norm, norm_type
-                    )
-                    total_norm_after_clip = _collect_total_grad_norm_local(
-                        model, norm_type
-                    )
-                self.assertTrue(total_norm_after_clip <= max_norm)
             # Post-backward, if CPU offloading model params should be on CPU.
             if cpu_offload_params and isinstance(model, FSDP):
                 for p in model.parameters():
@@ -895,7 +879,6 @@ class FSDPTest(MultiProcessTestCase):
         use_orig_params: bool = False,
         enable_sharded_grad_scaler: bool = False,
         use_pure_fp16: bool = False,
-        norm_type: Optional[Union[float, int]] = None,
         init_kwargs: Optional[Dict[str, Any]] = None,
         **fsdp_kwargs,
     ):
@@ -941,7 +924,6 @@ class FSDPTest(MultiProcessTestCase):
             lr=lr,
             fsdp_cpu_offload=cpu_offload,
             mixed_precision=mixed_precision,
-            norm_type=norm_type,
             enable_sharded_grad_scaler=enable_sharded_grad_scaler,
             use_pure_fp16=use_pure_fp16,
         )
@@ -1008,7 +990,6 @@ class FSDPTest(MultiProcessTestCase):
                 fsdp_cpu_offload=cpu_offload,
                 save_model=save_model,
                 mixed_precision=mixed_precision,
-                norm_type=norm_type,
                 enable_sharded_grad_scaler=enable_sharded_grad_scaler,
                 use_pure_fp16=use_pure_fp16,
             )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90249 [FSDP] Simplify grad padding logic
* #90248 [FSDP] Have the unsharded `flat_param` use the padded size
* #90251 [FSDP] Clarify loss dtype check in `_test_fsdp_parity`
* **#90250 [FSDP][BE] Clean up dead code from `clip_grad_norm_()` testing**
* #90290 [FSDP] Test `use_orig_params=True` in `test_fsdp_ignored_modules.py`
* #90252 [FSDP] Fix accidental change in `_test_fsdp_parity`

`FSDP.clip_grad_norm_()` is tested separately in `test_fsdp_clip_grad_norm.py`. This PR removes the dead non-run code from `common_fsdp.py` and `test_fsdp_core.py` related to `clip_grad_norm_()`.