### PR TITLE
[FSDP] Clarify loss dtype check in `_test_fsdp_parity`

### DIFF
--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -1003,9 +1003,7 @@ class FSDPTest(MultiProcessTestCase):
                 self.assertEqual(param.device, cpu_device)
             fsdp_loss = fsdp_loss.cuda()
         fsdp_unsharded_params = get_full_params(fsdp_model)
-        # TODO: Are mismatching dtypes actually ok here or did this pass silently before, because `check_dtype=False`
-        #  was the default?
-        torch.testing.assert_close(ref_loss, fsdp_loss, check_dtype=False)
+        torch.testing.assert_close(ref_loss, fsdp_loss, check_dtype=True)
         # Do not check for parameter parity if using mixed precision since (1)
         # the DDP parameters are in FP16 (from `half()`) while the FSDP
         # parameters are in FP32 (from `summon_full_params()`) and (2) DDP runs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90249 [FSDP] Simplify grad padding logic
* #90248 [FSDP] Have the unsharded `flat_param` use the padded size
* **#90251 [FSDP] Clarify loss dtype check in `_test_fsdp_parity`**
* #90250 [FSDP][BE] Clean up dead code from `clip_grad_norm_()` testing
* #90290 [FSDP] Test `use_orig_params=True` in `test_fsdp_ignored_modules.py`
* #90252 [FSDP] Fix accidental change in `_test_fsdp_parity`

A recent PR deprecated `torch.testing.assert_allclose` in favor of `torch.testing.assert_close` and left a `TODO`. This PR follows up to confirm that we do intend to have `check_dtype=False`.