### PR TITLE
[FSDP] Fix accidental change in `_test_fsdp_parity`

### DIFF
--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -1029,7 +1029,7 @@ class FSDPTest(MultiProcessTestCase):
         # the DDP parameters are in FP16 (from `half()`) while the FSDP
         # parameters are in FP32 (from `summon_full_params()`) and (2) DDP runs
         # the optimizer in FP16 while FSDP runs it in FP32
-        if mixed_precision is not None:
+        if mixed_precision is None:
             self.assertEqual(
                 ddp_params,
                 fsdp_unsharded_params,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90249 [FSDP] Simplify grad padding logic
* #90248 [FSDP] Have the unsharded `flat_param` use the padded size
* #90251 [FSDP] Clarify loss dtype check in `_test_fsdp_parity`
* #90250 [FSDP][BE] Clean up dead code from `clip_grad_norm_()` testing
* #90290 [FSDP] Test `use_orig_params=True` in `test_fsdp_ignored_modules.py`
* **#90252 [FSDP] Fix accidental change in `_test_fsdp_parity`**

I accidentally changed the semantics of this line when refactoring a while ago. The [previous version](https://github.com/pytorch/pytorch/pull/80873/files#diff-7b5c66f99161fa6a3d9042e80f8c8cc140a64e43445feede46f55e53154f6c3dL635) used to say:
```
if not mixed_precision:
```
which is actually the opposite of
```
if mixed_precision is not None:
```