### PR TITLE
Revert "[Dynamo] More robust pyop support, module properties as args (#87020)"

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1433,44 +1433,6 @@ class ExportTests(torch._dynamo.test_case.TestCase):
                 f, (torch.randn(5)), aten_graph=False, tracing_mode="symbolic"
             )
 
-    @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
-    def test_export_with_module_layer(self):
-        from functorch.experimental.control_flow import cond
-
-        def true_fn(layer, val):
-            return layer(val) * torch.tensor(2)
-
-        def false_fn(layer, val):
-            return layer(val) * torch.tensor(-1)
-
-        class Module(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = torch.nn.Linear(3, 3)
-
-            def forward(self, pred, x):
-                return cond(pred, true_fn, false_fn, [self.linear, x])
-
-        mod = Module()
-        x = torch.randn([3, 3])
-        pred = torch.tensor(x[0][0].item() < 0)
-        real_result = mod.forward(pred, x)
-
-        torch._dynamo.reset()
-
-        exported = torch._dynamo.export(mod.forward, pred, x)
-        out_graph = exported[0]
-
-        dynamo_result = out_graph(pred, x)
-        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
-
-        # New X, just to show we did not specialize
-        x = x * -1
-        pred = torch.tensor(x[0][0].item() < 0)
-        real_result_2 = mod.forward(pred, x)
-        dynamo_result_2 = out_graph(pred, x)
-        self.assertTrue(torch._dynamo.utils.same(real_result_2, dynamo_result_2))
-
     def test_export_meta_val(self):
         def f(x, y, z):
             return x * y + z

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -27,7 +27,6 @@ from ..utils import (
 from .base import VariableTracker
 from .lists import ListVariable, TupleVariable
 from .misc import AutocastModeVariable, NullContextVariable
-from .nn_module import NNModuleVariable
 from .tensor import TensorWithTFOverrideVariable
 
 log = logging.getLogger(__name__)
@@ -632,49 +631,17 @@ class TorchPyOperator(VariableTracker):
                 return arg.get_real_value()
             if isinstance(arg, UserFunctionVariable):
                 return arg.fn
-            if isinstance(arg, NNModuleVariable):
-                return tx.output.get_submodule(arg.module_key)
             if arg.has_unpack_var_sequence(tx):
                 return [
                     unwrap_real(arg_inner) for arg_inner in arg.unpack_var_sequence(tx)
                 ]
             return arg
 
-        def make_attr(name, proxy_args=None):
-            node = tx.output.create_proxy(
-                "get_attr",
-                name,
-                tuple(proxy_args) if proxy_args else tuple(),
-                {},
-            )
-            return node
-
         # Get values
         u_args = [unwrap_real(arg) for arg in args]
 
         def unwrap_proxy(arg):
             try:
-                if isinstance(arg, TensorVariable):
-                    return arg.as_proxy()
-                if isinstance(arg, NNModuleVariable):
-                    name = arg.module_key
-                    mod = unwrap_real(arg)
-                    options = VariableTracker.propagate(self, args, kwargs.values())
-                    tx.output.register_attr_or_module(
-                        mod,
-                        name,
-                        name,
-                        source=NNModuleSource(
-                            GetItemSource(self.source, arg.module_key)
-                        ),
-                        **options,
-                    )
-                    return make_attr(name)
-                if arg.has_unpack_var_sequence(tx):
-                    return [
-                        unwrap_proxy(arg_inner)
-                        for arg_inner in arg.unpack_var_sequence(tx)
-                    ]
                 return arg.as_proxy()
             except NotImplementedError:
                 return arg
@@ -743,8 +710,17 @@ class TorchPyOperator(VariableTracker):
                     true_guards == false_guards
                 ), "Guards for true and false path must be equal."
 
-            true_node = make_attr(true_name, proxy_args)
-            false_node = make_attr(false_name, proxy_args)
+            def make_attr(name):
+                node = tx.output.create_proxy(
+                    "get_attr",
+                    name,
+                    tuple(proxy_args),
+                    {},
+                )
+                return node
+
+            true_node = make_attr(true_name)
+            false_node = make_attr(false_name)
             p_args[1] = true_node
             p_args[2] = false_node
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90253

This reverts commit b8007742c287d792f2e89bbb7af5f87f6afdd2e8.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire