### PR TITLE
reland #89222: [Composable API] replicate: change to per module call, remove mark_root_module()

### DIFF
--- a/test/distributed/_composable/test_replicate.py
+++ b/test/distributed/_composable/test_replicate.py
@@ -7,7 +7,7 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from torch import nn
-from torch.distributed._composable.replicate import mark_root_module, replicate
+from torch.distributed._composable.replicate import replicate
 from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import run_tests
 
@@ -91,12 +91,12 @@ class ReplicateTest(MultiProcessTestCase):
 
     def test_replicate_single_module(self):
         model = Net()
-        replicate_model = mark_root_module(replicate(deepcopy(model)))
+        replicate_model = replicate(deepcopy(model))
         self._compare_module(model, replicate_model)
 
     def test_replicate_multi_module(self):
         model = Net()
-        replicate_model = mark_root_module(deepcopy(model))
+        replicate_model = deepcopy(model)
         replicate(replicate_model.fc1)
         replicate(replicate_model.fc2)
         replicate(replicate_model.fc3)

--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -7,11 +7,7 @@ from . import _ddp
 from .contract import contract
 
 
-class DistributedState:
-    ...
-
-
-class ReplicateState(DistributedState):
+class _ReplicateState:
     def __init__(self) -> None:
         self.modules: List[nn.Module] = []
         self.has_initialized: bool = False
@@ -22,6 +18,9 @@ class ReplicateState(DistributedState):
             self.modules.append(module)
             replicate.state(module)._distributed_state = self
             replicate.state(module)._params_collected = False
+            module.register_forward_pre_hook(self.forward_pre_hook)
+            # TODO(@yhcharles): fix type error
+            module.register_forward_hook(self.forward_post_hook)  # type: ignore[arg-type]
 
     def _recursive_collect_params(self, module: nn.Module) -> None:
         # TODO: skip if managed by other APIs
@@ -50,13 +49,13 @@ class ReplicateState(DistributedState):
 
         self._ddp = _ddp.DistributedDataParallel(self._param_list)
 
-    def root_module_forward_pre_hook(
+    def forward_pre_hook(
         self, module: nn.Module, input: Tuple[torch.Tensor]
     ) -> None:
         self.init_helper()
         self._ddp.pre_forward()
 
-    def root_module_forward_post_hook(
+    def forward_post_hook(
         self,
         module: nn.Module,
         input: Tuple[torch.Tensor],
@@ -65,14 +64,9 @@ class ReplicateState(DistributedState):
         return self._ddp.post_forward(output)
 
 
-# TODO(@yhcharles): use a per-model instance instead of a global one
-_default_state = ReplicateState()
-
-
 @contract
 def replicate(
     module: nn.Module,  # NOTE: contract now supports single module only
-    dist_state: ReplicateState = _default_state,
 ) -> nn.Module:
     r"""Replicates module(s)
 
@@ -83,25 +77,5 @@ def replicate(
         >>> module = nn.Linear(3, 3)
         >>> replicate(module)
     """
-    dist_state.mark_modules(module)
-    return module
-
-
-def mark_root_module(
-    module: nn.Module, dist_state: ReplicateState = _default_state
-) -> nn.Module:
-    r"""Mark the root module. Its sub-modules can be replicated.
-
-    Args:
-        modules (torch.nn.Module): root module
-
-    Example::
-        >>> module = nn.Linear(3, 3)
-        >>> replicate(module)
-    """
-    module.register_forward_pre_hook(dist_state.root_module_forward_pre_hook)
-    # TODO(@yhcharles): fix type error
-    module.register_forward_hook(
-        dist_state.root_module_forward_post_hook  # type: ignore[arg-type]
-    )
+    _ReplicateState().mark_modules(module)
     return module


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #90257
* #90255
* __->__ #90254

reland https://github.com/pytorch/pytorch/pull/89222