### PR TITLE
[Inductor] fix issue: redeclaration of float g_tmp_buffer_xxx

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5089,6 +5089,17 @@ if HAS_CPU:
                 assert same(real_out, compiled_out, equal_nan=True)
                 assert metrics.generated_cpp_vec_kernel_count >= 1
 
+        def test_load_same_bool_tensor_twice(self):
+            @torch._dynamo.optimize("inductor")
+            def fn(a, b):
+                x = torch.masked_fill(a, b, -33.0)
+                y = torch.masked_fill(a, b, -33.0)
+                return x, y
+
+            value = torch.randn((2, 17))
+            mask = torch.randint(0, 1, size=(2, 17), dtype=torch.uint8).to(torch.bool)
+            fn(value, mask)
+
         def test_cpu_vec_cosim(self):
             cpp_vec_op_list = []
             cpp_op_list = []

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -789,15 +789,16 @@ class CppVecKernel(CppKernel):
             line = f"at::vec::Vectorized<float>({var}[{cexpr(index)}])"
         else:
             if V.graph.get_dtype(name) in [torch.bool, torch.uint8]:
-                g_tmp_buf = f"g_tmp_buffer_{var}"
                 nelements = codecache.pick_vec_isa().nelements()
                 if var not in self.var_vec_buf_map:
                     self.var_vec_buf_map[var] = f"g_tmp_buffer_{var}"
-                    self.loads.writeline(f"float {g_tmp_buf}[{nelements}] = {{0}};")
+                    self.loads.writeline(
+                        f"float {self.var_vec_buf_map[var]}[{nelements}] = {{0}};"
+                    )
                 self.loads.writeline(
-                    f"flag_to_float({var} + {cexpr(new_index)}, {g_tmp_buf}, {nelements});"
+                    f"flag_to_float({var} + {cexpr(new_index)}, {self.var_vec_buf_map[var]}, {nelements});"
                 )
-                line = f"at::vec::Vectorized<float>::loadu({g_tmp_buf})"
+                line = f"at::vec::Vectorized<float>::loadu({self.var_vec_buf_map[var]})"
             else:
                 line = f"at::vec::Vectorized<float>::loadu({var} + {cexpr(new_index)})"
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -790,7 +790,8 @@ class CppVecKernel(CppKernel):
             if V.graph.get_dtype(name) in [torch.bool, torch.uint8]:
                 g_tmp_buf = f"g_tmp_buffer_{var}"
                 nelements = codecache.pick_vec_isa().nelements()
-                self.loads.writeline(f"float {g_tmp_buf}[{nelements}] = {{0}};")
+                if f"float {g_tmp_buf}[{nelements}] = {{0}};" not in self.loads._lines:
+                    self.loads.writeline(f"float {g_tmp_buf}[{nelements}] = {{0}};")
                 self.loads.writeline(
                     f"flag_to_float({var} + {cexpr(new_index)}, {g_tmp_buf}, {nelements});"
                 )


### PR DESCRIPTION
This pr is to fix the issue: redeclaration of 'float g_tmp_buffer_in_ptr1[16] = {0};'
If a bool or uint8 tensor is used by multiple op, this tensor will be loaded multiple times. On load, it writes the declaration of this variable, i.e., `self.loads.writeline(f"float {g_tmp_buf}[{nelements}] = {{0}};")`, which will introduce redeclaration error.

![image](https://user-images.githubusercontent.com/69951214/205869956-5c325761-dc09-4aa8-a9ed-fad7f4c85917.png)
![image](https://user-images.githubusercontent.com/69951214/205870695-ee252f17-8f54-484f-9b0a-3a424c479327.png)


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @Guobing-Chen @chunyuan-w @zhuhaozhe @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire