### PR TITLE
[Vulkan] Partially fix and then disable copying of vulkan quantized tensors to cpu

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/image_to_nchw_quantized.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/image_to_nchw_quantized.glsl
@@ -11,7 +11,7 @@ layout(set = 0, binding = 0) uniform PRECISION isampler3D uImage;
 /*
  * Output Buffer
  */
-layout(set = 0, binding = 1) buffer PRECISION Buffer {
+layout(set = 0, binding = 1) buffer PRECISION restrict writeonly Buffer {
   uint data[];
 }
 uBuffer;
@@ -33,55 +33,47 @@ layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
-  if (pos.y == 0 && pos.z == 0) {
-    ivec4 texture_pos = ivec4(0, 1, 2, 3) + 4 * pos.x;
+    // each instance of the shader writes out a single element of the output
+    // the global size matches the size of the output, in other words:
+    // global size = {div_up(numel, 4), 1u, 1u}
+    // pos = {pos.x, 1, 1} where pos.x is the index of the output element
 
-    ivec4 last_eight;
-    last_eight.z = texture_pos.x / (uBlock.in_extents.x * uBlock.in_extents.y);
-    last_eight.w = texture_pos.x % (uBlock.in_extents.x * uBlock.in_extents.y);
-    last_eight.y = last_eight.w / uBlock.in_extents.x;
-    last_eight.x = last_eight.w % uBlock.in_extents.x;
+  ivec4 input_pos = ivec4(0, 1, 2, 3) + 4 * pos.x;
+    // each output element is a uint32 made up four consecutive uint8 from the
+    // input in nchw format. input_pos contains the positions of these four
+    // elements from the input in nchw format.
 
-    ivec4 sec_last_eight;
-    sec_last_eight.z =
-        texture_pos.y / (uBlock.in_extents.x * uBlock.in_extents.y);
-    sec_last_eight.w =
-        texture_pos.y % (uBlock.in_extents.x * uBlock.in_extents.y);
-    sec_last_eight.y = sec_last_eight.w / uBlock.in_extents.x;
-    sec_last_eight.x = sec_last_eight.w % uBlock.in_extents.x;
+  ivec4 nc_pos = input_pos / uBlock.in_extents.w;
+    // we divide by HxW (uBlock.in_extents.w), to find the position along the
+    // batch/channel axis of these four elements.
 
-    ivec4 thr_last_eight;
-    thr_last_eight.z =
-        texture_pos.z / (uBlock.in_extents.x * uBlock.in_extents.y);
-    thr_last_eight.w =
-        texture_pos.z % (uBlock.in_extents.x * uBlock.in_extents.y);
-    thr_last_eight.y = thr_last_eight.w / uBlock.in_extents.x;
-    thr_last_eight.x = thr_last_eight.w % uBlock.in_extents.x;
+  ivec4 w_pos = input_pos % uBlock.in_extents.w;
+    // we compute the reminder mod HxW, to find the positions in the flatten
+    // out HxW plane.
 
-    ivec4 four_last_eight;
-    four_last_eight.z =
-        texture_pos.w / (uBlock.in_extents.x * uBlock.in_extents.y);
-    four_last_eight.w =
-        texture_pos.w % (uBlock.in_extents.x * uBlock.in_extents.y);
-    four_last_eight.y = four_last_eight.w / uBlock.in_extents.x;
-    four_last_eight.x = four_last_eight.w % uBlock.in_extents.x;
+  ivec4 x_pos = w_pos % uBlock.in_extents.x;
+  ivec4 y_pos = w_pos / uBlock.in_extents.x;
+    // we divide this "flatten out position" by H, to find the positions along
+    // the y-axis (height) and we compute its reminder mod H, to find the
+    // position along the x-axis (width).
 
-    ivec3 last_eight_pos = ivec3(last_eight.x, last_eight.y, last_eight.z / 4);
-    ivec3 sec_last_eight_pos =
-        ivec3(sec_last_eight.x, sec_last_eight.y, sec_last_eight.z / 4);
-    ivec3 thr_last_eight_pos =
-        ivec3(thr_last_eight.x, thr_last_eight.y, thr_last_eight.z / 4);
-    ivec3 four_last_eight_pos =
-        ivec3(four_last_eight.x, four_last_eight.y, four_last_eight.z / 4);
+  ivec4 z_pos = nc_pos / 4;
+  ivec4 ix = nc_pos % 4;
+    // z_pos contains the texel positions along the z-axis, and ix the
+    // indices inside each texel.
 
-    int texel_1 = texelFetch(uImage, last_eight_pos, 0)[last_eight.z];
-    int texel_2 = texelFetch(uImage, sec_last_eight_pos, 0)[sec_last_eight.z];
-    int texel_3 = texelFetch(uImage, thr_last_eight_pos, 0)[thr_last_eight.z];
-    int texel_4 = texelFetch(uImage, four_last_eight_pos, 0)[four_last_eight.z];
+  // now we fetch each uint8 element from the input, and we write out a uint32
+  // whose binary representation is equal to: tex3 tex2 tex1 tex0
 
-    uint ui32 = (uint(texel_4 & 0xFF) << 24) | (uint(texel_3 & 0xFF) << 16) |
-        (uint(texel_2 & 0xFF) << 8) | (uint(texel_1 & 0xFF));
+  int tex0 = texelFetch(uImage, ivec3(x_pos[0], y_pos[0], z_pos[0]), 0)[ix[0]];
+  int tex1 = texelFetch(uImage, ivec3(x_pos[1], y_pos[1], z_pos[1]), 0)[ix[1]];
+  int tex2 = texelFetch(uImage, ivec3(x_pos[2], y_pos[2], z_pos[2]), 0)[ix[2]];
+  int tex3 = texelFetch(uImage, ivec3(x_pos[3], y_pos[3], z_pos[3]), 0)[ix[3]];
 
-    uBuffer.data[texture_pos.x / 4] = ui32;
-  }
+  uint ui32 = (uint(tex3 & 0xFF) << 24)
+            | (uint(tex2 & 0xFF) << 16)
+            | (uint(tex1 & 0xFF) << 8)
+            | (uint(tex0 & 0xFF));
+
+  uBuffer.data[pos.x] = ui32;
 }

--- a/aten/src/ATen/native/vulkan/glsl/image_to_nchw_quantized_mul4.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/image_to_nchw_quantized_mul4.glsl
@@ -1,0 +1,75 @@
+#version 450 core
+#define PRECISION $precision
+
+layout(std430) buffer;
+
+/*
+ * Input Sampler
+ */
+layout(set = 0, binding = 0) uniform PRECISION isampler3D uImage;
+
+/*
+ * Output Buffer
+ */
+layout(set = 0, binding = 1) buffer PRECISION restrict writeonly Buffer {
+  uint data[];
+}
+uBuffer;
+
+/*
+ * Params Buffer
+ */
+layout(set = 0, binding = 2) uniform PRECISION restrict Block {
+  // xyz contain the extents of the input texture, w contains HxW to help
+  // calculate buffer offsets
+  ivec4 in_extents;
+}
+uBlock;
+
+/*
+ * Local Work Group in_extents
+ */
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+    // each instance of the shader writes out four elements of the output
+    // by processing 4 consecutive texels at the same depth.
+    // global size = {HxW / 4, 1u, z_extent}.
+    // this shader requires HxW to be a multiple of 4, so that multiple
+    // planes can be processed in parallel
+
+  if (4 * pos.x >= uBlock.in_extents.w ||
+      pos.y > 0 ||
+      pos.z >= uBlock.in_extents.z) {
+    return;
+  }
+
+  ivec4 xy_pos = ivec4(0, 1, 2, 3) + 4 * pos.x;
+    // each output element is a uint32 made up four consecutive uint8 from the
+    // input in nchw format. xy_pos contains the positions of these four
+    // elements from the input in the flatten out HxW plane.
+
+  ivec4 x_pos = xy_pos % uBlock.in_extents.x;
+  ivec4 y_pos = xy_pos / uBlock.in_extents.x;
+    // we divide this "flatten out position" by H, to find the positions along
+    // the y-axis (height) and we compute its reminder mod H, to find the
+    // position along the x-axis (width).
+
+  const ivec4 intex0 = texelFetch(uImage, ivec3(x_pos[0], y_pos[0], pos.z), 0);
+  const ivec4 intex1 = texelFetch(uImage, ivec3(x_pos[1], y_pos[1], pos.z), 0);
+  const ivec4 intex2 = texelFetch(uImage, ivec3(x_pos[2], y_pos[2], pos.z), 0);
+  const ivec4 intex3 = texelFetch(uImage, ivec3(x_pos[3], y_pos[3], pos.z), 0);
+
+  const int base_index = 4 * pos.x + 4 * uBlock.in_extents.w * pos.z;
+  const ivec4 buf_indices =
+      base_index + ivec4(0, 1, 2, 3) * uBlock.in_extents.w;
+
+  for (int i = 0; i < 4; i += 1) {
+    uint ui32 = (uint(intex3[i] & 0xFF) << 24)
+              | (uint(intex2[i] & 0xFF) << 16)
+              | (uint(intex1[i] & 0xFF) << 8)
+              | (uint(intex0[i] & 0xFF));
+    uBuffer.data[buf_indices[i] / 4] = ui32;
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -173,6 +173,9 @@ void pack_cpu_to_vulkan(const Tensor& src, vTensor& dst) {
 }
 
 void pack_vulkan_to_cpu(vTensor& src, Tensor& dst) {
+  TORCH_CHECK(
+      !src.is_quantized(),
+      "Copy of vulkan quantized tensors to cpu is currently disabled!");
   api::Context* const context = api::context();
 
   // Refer to the comment in pack_cpu_to_vulkan for why at::kFloat is specified

--- a/aten/src/ATen/test/vulkan_quantized_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_quantized_api_test.cpp
@@ -341,7 +341,8 @@ TEST_F(VulkanAPITest, copy_to_buffer_channels_last) {
   }
 }
 
-TEST_F(VulkanAPITest, support_vulkan) {
+// TODO: Fix vulkan to cpu on Android
+TEST_F(VulkanAPITest, DISABLED_support_vulkan) {
   const double scale = 0.1;
   const int64_t zero_point = 10;
 
@@ -379,7 +380,77 @@ TEST_F(VulkanAPITest, support_vulkan) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, quantize_per_tensor) {
+void test_cpu_to_vulkan_and_vulkan_to_cpu(
+    const at::IntArrayRef input_shape,
+    const double scale,
+    const int zero_point) {
+
+  // produce random quantized cpu tensor
+  auto in_cpu = produce_random_tensor(input_shape);
+  auto in_q_cpu = at::quantize_per_tensor(
+      in_cpu, scale, zero_point, c10::ScalarType::QUInt8);
+
+  // copy quantized cpu tensor to vulkan
+  auto in_q_cpu_vk = cpu_to_vulkan(in_q_cpu);
+
+  // copy quantized vulkan tensor to cpu
+  auto out_q_cpu = vulkan_to_cpu(in_q_cpu_vk, in_q_cpu);
+
+  // check that the copy equals the original
+  const auto diff = at::native::int_repr_quantized_cpu(in_q_cpu)
+                    - at::native::int_repr_quantized_cpu(out_q_cpu);
+
+  const int error = diff.abs().max().item<int>();
+
+  const auto check = (error == 0);
+
+  if (!check) {
+    std::cout
+      << "Copy to vulkan and back to cpu failed with input shape: "
+      << input_shape << " scale: " << scale << " and zero point: "
+      << zero_point << std::endl;
+    std::cout << "Error: " << error << std::endl;
+  }
+
+  ASSERT_TRUE(check);
+}
+
+void test_cpu_to_vulkan_and_vulkan_to_cpu_random() {
+  const double scale = produce_random_scale();
+  const int64_t zero_point = produce_random_zero_point(c10::ScalarType::QUInt8);
+  const at::IntArrayRef tensor_shape =
+    {rand_pos_int(30), rand_pos_int(30), rand_pos_int(100), rand_pos_int(100)};
+  test_cpu_to_vulkan_and_vulkan_to_cpu(tensor_shape, scale, zero_point);
+}
+
+// TODO: Fix vulkan to cpu on Android
+TEST_F(VulkanAPITest, DISABLED_cpu_to_vulkan_and_vulkan_to_cpu) {
+  test_cpu_to_vulkan_and_vulkan_to_cpu({1, 1, 1, 1}, 0.13, 21);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({1, 1, 1, 4}, 0.3, 87);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({1, 1, 4, 1}, 0.2, 120);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({1, 1, 7, 7}, 0.3, 87);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({1, 1, 8, 8}, 0.1, 10);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({3, 5, 8, 8}, 0.04, 97);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({1, 1, 11, 17}, 0.07, 15);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({1, 1, 12, 17}, 0.1, 10);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({3, 5, 12, 17}, 0.1, 10);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({1, 1, 17, 12}, 0.1, 10);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({2, 4, 17, 12}, 0.1, 10);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({1, 1, 10, 14}, 0.0001, 101);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({3, 5, 10, 14}, 0.009, 43);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({3, 5, 10, 15}, 0.1, 19);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({4, 4, 9, 17}, 0.1, 19);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({3, 5, 25, 29}, 0.1, 19);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({4, 4, 25, 29}, 0.1, 19);
+  test_cpu_to_vulkan_and_vulkan_to_cpu({11, 17, 25, 29}, 0.027, 89);
+
+  for (int i = 0; i < 20; i += 1) {
+    test_cpu_to_vulkan_and_vulkan_to_cpu_random();
+  }
+}
+
+// TODO: Fix vulkan to cpu on Android
+TEST_F(VulkanAPITest, DISABLED_quantize_per_tensor) {
   const auto in_cpu =
       at::rand({2, 13, 32, 27}, at::device(at::kCPU).dtype(at::kFloat)) * 6;
   const auto in_vulkan = in_cpu.vulkan();
@@ -405,6 +476,79 @@ TEST_F(VulkanAPITest, quantize_per_tensor) {
   }
 
   ASSERT_TRUE(check);
+}
+
+void test_quantize_per_tensor_and_vulkan_to_cpu(
+    const at::IntArrayRef input_shape,
+    const double input_scale,
+    const int input_zero_point,
+    const int tolerance = 1) {
+  // tolerance = 1, to allow for precision differences after dividing by random
+  // scale which could result on a difference of 1 unit in the quantized result
+
+  at::Tensor input = produce_random_tensor(input_shape);
+
+  // quantize tensor
+  at::Tensor out_q_cpu = at::quantize_per_tensor(
+    input, input_scale, input_zero_point, c10::ScalarType::QUInt8);
+
+  at::Tensor out_q_vk = at::quantize_per_tensor(
+    input.vulkan(), input_scale, input_zero_point, c10::ScalarType::QUInt8);
+
+  // copy vulkan tensor to cpu
+  at::Tensor out_q_vk_cpu = vulkan_to_cpu(out_q_vk, out_q_cpu);
+
+  const auto diff = at::native::int_repr_quantized_cpu(out_q_vk_cpu)
+                    - at::native::int_repr_quantized_cpu(out_q_cpu);
+
+  const int error = diff.abs().max().item<int>();
+
+  const auto check = (error <= tolerance);
+
+  if (!check) {
+    std::cout
+      << "Quantize and copy to cpu failed with input shape: " << input_shape
+      << " scale: " << input_scale << " and zero point: " << input_zero_point
+    << std::endl;
+    std::cout << "Error: " << error << std::endl;
+  }
+
+  ASSERT_TRUE(check);
+}
+
+void test_quantize_per_tensor_and_vulkan_to_cpu_random() {
+  const double scale = produce_random_scale();
+  const int64_t zero_point = produce_random_zero_point(c10::ScalarType::QUInt8);
+  const at::IntArrayRef tensor_shape =
+    {rand_pos_int(30), rand_pos_int(30), rand_pos_int(100), rand_pos_int(100)};
+  test_quantize_per_tensor_and_vulkan_to_cpu(tensor_shape, scale, zero_point);
+}
+
+// TODO: Fix vulkan to cpu on Android
+TEST_F(VulkanAPITest, DISABLED_quantize_per_tensor_and_vulkan_to_cpu) {
+  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 1, 1}, 0.13, 21);
+  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 1, 4}, 0.3, 87);
+  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 4, 1}, 0.2, 120);
+  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 7, 7}, 0.3, 87);
+  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 8, 8}, 0.1, 10);
+  test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 8, 8}, 0.04, 97);
+  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 11, 17}, 0.07, 15);
+  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 12, 17}, 0.1, 10);
+  test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 12, 17}, 0.1, 10);
+  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 17, 12}, 0.1, 10);
+  test_quantize_per_tensor_and_vulkan_to_cpu({2, 4, 17, 12}, 0.1, 10);
+  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 10, 14}, 0.0001, 101);
+  test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 10, 14}, 0.009, 43);
+  test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 10, 15}, 0.1, 19);
+  test_quantize_per_tensor_and_vulkan_to_cpu({4, 4, 9, 17}, 0.1, 19);
+  test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 25, 29}, 0.1, 19);
+  test_quantize_per_tensor_and_vulkan_to_cpu({4, 4, 25, 29}, 0.1, 19);
+  test_quantize_per_tensor_and_vulkan_to_cpu({11, 17, 25, 29}, 0.027, 89);
+  test_quantize_per_tensor_and_vulkan_to_cpu({3, 16, 77, 54}, 0.204173, 229);
+
+  for (int i = 0; i < 20; i += 1) {
+    test_quantize_per_tensor_and_vulkan_to_cpu_random();
+  }
 }
 
 TEST_F(VulkanAPITest, quantize_dequantize) {
@@ -762,7 +906,6 @@ TEST_F(VulkanAPITest, quantized_add_broadcast2) {
 
   ASSERT_TRUE(check);
 }
-
 
 TEST_F(VulkanAPITest, quantized_add_broadcast3) {
   if (!at::is_vulkan_available()) {


### PR DESCRIPTION
Summary:
Before this diff, copying of vulkan quantized tensors to cpu was broken. This was mainly caused because the shader only works properly with specific global and local work group sizes, and those specific sizes had been modified in earlier refactoring.

As part of this fix, an optimized version of the shader that performs the copying was written, to take advantage of the special case when the plane size (x*y) is multiple of 4).

After fixing this, and writing comprehensive tests, it was discovered that the copying still has issues on Android for specific input sizes, e.g. [1, 1, 11, 17]. These issues are currently unresolved, so, copying of quantized vulkan tensors to cpu has been disabled.

What is contained in this diff?
- Fix for existing issue
- New optimized shader (image_to_nchw_quantized_mul4)
- New comprehensive tests (which have been disabled)
- Disable the copying of quantized vulkan tensors to cpu until issues on Android are fixed.

Test Plan:
On Mac
```
cd ~/fbsource
buck1 run -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64
```

On Android
```
cd ~/fbsource
buck1 build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_quantized_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_quantized_api_test
adb shell "/data/local/tmp/vulkan_quantized_api_test"
```

Reviewed By: kimishpatel

Differential Revision: D41047098

