### PR TITLE
Keep only test config filtering logic in workflow build step

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -54,8 +54,11 @@ on:
         value: ${{ jobs.build.outputs.docker-image }}
         description: The docker image containing the built PyTorch.
       test-matrix:
-        value: ${{ inputs.test-matrix }}
+        value: ${{ jobs.build.outputs.test-matrix }}
         description: An optional JSON description of what test configs to run later on.
+      is-test-matrix-empty:
+        value: ${{ jobs.build.outputs.is-test-matrix-empty }}
+        description: True if the filtered test configs matrix is empty. False otherwise.
 
 jobs:
   build:
@@ -65,6 +68,8 @@ jobs:
     timeout-minutes: 240
     outputs:
       docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
+      test-matrix: ${{ steps.filter.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ steps.filter.outputs.is-test-matrix-empty }}
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -38,7 +38,6 @@ env:
 
 jobs:
   test:
-    needs: filter
     # Don't run on forked repos or empty test matrix
     if: github.repository_owner == 'pytorch' && inputs.is-test-matrix-empty == 'False'
     strategy:

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -13,7 +13,7 @@ on:
         description: JSON description of what test configs to run.
       is-test-matrix-empty:
         required: true
-        type: boolean
+        type: string
         description: True if the filtered test configs matrix is empty. False otherwise.
       docker-image:
         required: true

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
         description: JSON description of what test configs to run.
+      is-test-matrix-empty:
+        required: true
+        type: boolean
+        description: True if the filtered test configs matrix is empty. False otherwise.
       docker-image:
         required: true
         type: string
@@ -33,33 +37,12 @@ env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:
-  # This needs to be run right before the test starts so that it can gather the
-  # latest labels from the PR
-  filter:
-    runs-on: [self-hosted, linux.large]
-    outputs:
-      test-matrix: ${{ steps.filter.outputs.test-matrix }}
-      is-test-matrix-empty: ${{ steps.filter.outputs.is-test-matrix-empty }}
-    steps:
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-        with:
-          fetch-depth: 1
-          submodules: false
-
-      - name: Select all requested test configurations
-        id: filter
-        uses: ./.github/actions/filter-test-configs
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          test-matrix: ${{ inputs.test-matrix }}
-
   test:
     needs: filter
     # Don't run on forked repos or empty test matrix
-    if: github.repository_owner == 'pytorch' && needs.filter.outputs.is-test-matrix-empty == 'False'
+    if: github.repository_owner == 'pytorch' && inputs.is-test-matrix-empty == 'False'
     strategy:
-      matrix: ${{ fromJSON(needs.filter.outputs.test-matrix) }}
+      matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -47,8 +47,11 @@ on:
 
     outputs:
       test-matrix:
-        value: ${{ inputs.test-matrix }}
+        value: ${{ jobs.build.outputs.test-matrix }}
         description: An optional JSON description of what test configs to run later on.
+      is-test-matrix-empty:
+        value: ${{ jobs.build.outputs.is-test-matrix-empty }}
+        description: True if the filtered test configs matrix is empty. False otherwise.
       build-outcome:
         value: ${{ jobs.build.outputs.build-outcome }}
         description: The outcome of the build step. This is used to influence test filtering logic later on.
@@ -73,6 +76,8 @@ jobs:
       BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
     outputs:
       build-outcome: ${{ steps.build.outcome }}
+      test-matrix: ${{ steps.filter.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ steps.filter.outputs.is-test-matrix-empty }}
     steps:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -13,7 +13,7 @@ on:
         description: JSON description of what test configs to run.
       is-test-matrix-empty:
         required: true
-        type: boolean
+        type: string
         description: True if the filtered test configs matrix is empty. False otherwise.
       sync-tag:
         required: false

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
         description: JSON description of what test configs to run.
+      is-test-matrix-empty:
+        required: true
+        type: boolean
+        description: True if the filtered test configs matrix is empty. False otherwise.
       sync-tag:
         required: false
         type: string
@@ -33,38 +37,17 @@ on:
         description: secret acess key for test stats upload
 
 jobs:
-  # This needs to be run right before the test starts so that it can gather the
-  # latest labels from the PR
-  filter:
-    runs-on: [self-hosted, linux.large]
-    outputs:
-      test-matrix: ${{ steps.filter.outputs.test-matrix }}
-      is-test-matrix-empty: ${{ steps.filter.outputs.is-test-matrix-empty }}
-    steps:
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-        with:
-          fetch-depth: 1
-          submodules: false
-
-      - name: Select all requested test configurations
-        id: filter
-        uses: ./.github/actions/filter-test-configs
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          test-matrix: ${{ inputs.test-matrix }}
-
   test:
     needs: filter
     # Don't run on forked repos or empty test matrix
-    if: github.repository_owner == 'pytorch' && needs.filter.outputs.is-test-matrix-empty == 'False'
+    if: github.repository_owner == 'pytorch' && inputs.is-test-matrix-empty == 'False'
     # For setup-miniconda, see https://github.com/conda-incubator/setup-miniconda/issues/179
     # Also ensure that we always run with the right architecture
     defaults:
       run:
         shell: arch -arch ${{ inputs.arch }} bash -e -l {0}
     strategy:
-      matrix: ${{ fromJSON(needs.filter.outputs.test-matrix) }}
+      matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 240

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -38,7 +38,6 @@ on:
 
 jobs:
   test:
-    needs: filter
     # Don't run on forked repos or empty test matrix
     if: github.repository_owner == 'pytorch' && inputs.is-test-matrix-empty == 'False'
     # For setup-miniconda, see https://github.com/conda-incubator/setup-miniconda/issues/179

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -44,7 +44,6 @@ env:
 
 jobs:
   test:
-    needs: filter
     # Don't run on forked repos or empty test matrix
     if: github.repository_owner == 'pytorch' && inputs.is-test-matrix-empty == 'False'
     timeout-minutes: 300

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
         description: JSON description of what test configs to run.
+      is-test-matrix-empty:
+        required: true
+        type: boolean
+        description: True if the filtered test configs matrix is empty. False otherwise.
       docker-image:
         required: true
         type: string
@@ -39,34 +43,13 @@ env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:
-  # This needs to be run right before the test starts so that it can gather the
-  # latest labels from the PR
-  filter:
-    runs-on: [self-hosted, linux.large]
-    outputs:
-      test-matrix: ${{ steps.filter.outputs.test-matrix }}
-      is-test-matrix-empty: ${{ steps.filter.outputs.is-test-matrix-empty }}
-    steps:
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-        with:
-          fetch-depth: 1
-          submodules: false
-
-      - name: Select all requested test configurations
-        id: filter
-        uses: ./.github/actions/filter-test-configs
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          test-matrix: ${{ inputs.test-matrix }}
-
   test:
     needs: filter
     # Don't run on forked repos or empty test matrix
-    if: github.repository_owner == 'pytorch' && needs.filter.outputs.is-test-matrix-empty == 'False'
+    if: github.repository_owner == 'pytorch' && inputs.is-test-matrix-empty == 'False'
     timeout-minutes: 300
     strategy:
-      matrix: ${{ fromJSON(needs.filter.outputs.test-matrix) }}
+      matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -17,7 +17,7 @@ on:
         description: JSON description of what test configs to run.
       is-test-matrix-empty:
         required: true
-        type: boolean
+        type: string
         description: True if the filtered test configs matrix is empty. False otherwise.
       docker-image:
         required: true

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -33,8 +33,11 @@ on:
 
     outputs:
       test-matrix:
-        value: ${{ inputs.test-matrix }}
+        value: ${{ jobs.build.outputs.test-matrix }}
         description: An optional JSON description of what test configs to run later on.
+      is-test-matrix-empty:
+        value: ${{ jobs.build.outputs.is-test-matrix-empty }}
+        description: True if the filtered test configs matrix is empty. False otherwise.
 
 env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -45,6 +48,9 @@ jobs:
     if: github.repository_owner == 'pytorch'
     runs-on: [self-hosted, windows.4xlarge]
     timeout-minutes: 240
+    outputs:
+      test-matrix: ${{ steps.filter.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ steps.filter.outputs.is-test-matrix-empty }}
     steps:
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -17,7 +17,7 @@ on:
         description: JSON description of what test configs to run.
       is-test-matrix-empty:
         required: true
-        type: boolean
+        type: string
         description: True if the filtered test configs matrix is empty. False otherwise.
       sync-tag:
         required: false

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -32,7 +32,6 @@ env:
 
 jobs:
   test:
-    needs: filter
     # Don't run on forked repos or empty test matrix
     if: github.repository_owner == 'pytorch' && inputs.is-test-matrix-empty == 'False'
     strategy:

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
         description: JSON description of what test configs to run.
+      is-test-matrix-empty:
+        required: true
+        type: boolean
+        description: True if the filtered test configs matrix is empty. False otherwise.
       sync-tag:
         required: false
         type: string
@@ -27,33 +31,12 @@ env:
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:
-  # This needs to be run right before the test starts so that it can gather the
-  # latest labels from the PR
-  filter:
-    runs-on: [self-hosted, linux.large]
-    outputs:
-      test-matrix: ${{ steps.filter.outputs.test-matrix }}
-      is-test-matrix-empty: ${{ steps.filter.outputs.is-test-matrix-empty }}
-    steps:
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-        with:
-          fetch-depth: 1
-          submodules: false
-
-      - name: Select all requested test configurations
-        id: filter
-        uses: ./.github/actions/filter-test-configs
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          test-matrix: ${{ inputs.test-matrix }}
-
   test:
     needs: filter
     # Don't run on forked repos or empty test matrix
-    if: github.repository_owner == 'pytorch' && needs.filter.outputs.is-test-matrix-empty == 'False'
+    if: github.repository_owner == 'pytorch' && inputs.is-test-matrix-empty == 'False'
     strategy:
-      matrix: ${{ fromJSON(needs.filter.outputs.test-matrix) }}
+      matrix: ${{ fromJSON(inputs.test-matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 300

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -39,3 +39,4 @@ jobs:
       build-environment: linux-bionic-cuda11.6-py3.10-gcc7-sm86
       docker-image: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-inductor-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-inductor-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-inductor-build.outputs.is-test-matrix-empty }}

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -34,6 +34,7 @@ jobs:
       build-environment: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
       docker-image: ${{ needs.linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build.outputs.is-test-matrix-empty }}
       timeout-minutes: 300
 
   linux-focal-rocm5_2-py3_8-slow-build:
@@ -55,6 +56,7 @@ jobs:
       build-environment: linux-focal-rocm5.2-py3.8
       docker-image: ${{ needs.linux-focal-rocm5_2-py3_8-slow-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-rocm5_2-py3_8-slow-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-focal-rocm5_2-py3_8-slow-build.outputs.is-test-matrix-empty }}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
@@ -79,6 +81,7 @@ jobs:
       build-environment: linux-focal-rocm5.2-py3.8
       docker-image: ${{ needs.linux-focal-rocm5_2-py3_8-distributed-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-rocm5_2-py3_8-distributed-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-focal-rocm5_2-py3_8-distributed-build.outputs.is-test-matrix-empty }}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
@@ -103,6 +106,7 @@ jobs:
       build-environment: linux-bionic-cuda11.6-py3.9-gcc7
       docker-image: ${{ needs.linux-bionic-cuda11_6-py3_9-gcc7-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_6-py3_9-gcc7-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-cuda11_6-py3_9-gcc7-build.outputs.is-test-matrix-empty }}
 
   linux-bionic-cuda11_6-py3_7-gcc7-debug-build:
     name: linux-bionic-cuda11.6-py3.7-gcc7-debug
@@ -127,6 +131,7 @@ jobs:
       build-environment: linux-bionic-cuda11.6-py3.7-gcc7-debug
       docker-image: ${{ needs.linux-bionic-cuda11_6-py3_7-gcc7-debug-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_6-py3_7-gcc7-debug-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-cuda11_6-py3_7-gcc7-debug-build.outputs.is-test-matrix-empty }}
 
   linux-bionic-cuda11_7-py3_7-gcc7-debug-build:
     name: linux-bionic-cuda11.7-py3.7-gcc7-debug
@@ -151,6 +156,7 @@ jobs:
       build-environment: linux-bionic-cuda11.7-py3.7-gcc7-debug
       docker-image: ${{ needs.linux-bionic-cuda11_7-py3_7-gcc7-debug-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_7-py3_7-gcc7-debug-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-cuda11_7-py3_7-gcc7-debug-build.outputs.is-test-matrix-empty }}
 
   libtorch-linux-bionic-cuda11_7-py3_7-gcc7-build:
     name: libtorch-linux-bionic-cuda11.7-py3.7-gcc7
@@ -182,6 +188,7 @@ jobs:
       build-environment: win-vs2019-cuda11.7-py3
       cuda-version: "11.7"
       test-matrix: ${{ needs.win-vs2019-cuda11_7-py3-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.win-vs2019-cuda11_7-py3-build.outputs.is-test-matrix-empty }}
 
   ios-12-5-1-x86-64-coreml:
     name: ios-12-5-1-x86-64-coreml

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -43,6 +43,7 @@ jobs:
       build-environment: linux-focal-py3.7-gcc7
       docker-image: ${{ needs.linux-focal-py3_7-gcc7-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-py3_7-gcc7-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-focal-py3_7-gcc7-build.outputs.is-test-matrix-empty }}
 
   linux-docs:
     name: linux-docs
@@ -90,6 +91,7 @@ jobs:
       build-environment: linux-focal-py3.7-clang7-asan
       docker-image: ${{ needs.linux-focal-py3_7-clang7-asan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-py3_7-clang7-asan-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-focal-py3_7-clang7-asan-build.outputs.is-test-matrix-empty }}
 
   linux-focal-py3_7-clang10-onnx-build:
     name: linux-focal-py3.7-clang10-onnx
@@ -111,6 +113,7 @@ jobs:
       build-environment: linux-focal-py3.7-clang10-onnx
       docker-image: ${{ needs.linux-focal-py3_7-clang10-onnx-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-py3_7-clang10-onnx-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-focal-py3_7-clang10-onnx-build.outputs.is-test-matrix-empty }}
 
   linux-bionic-py3_7-clang9-build:
     name: linux-bionic-py3.7-clang9
@@ -137,6 +140,7 @@ jobs:
       build-environment: linux-bionic-py3.7-clang9
       docker-image: ${{ needs.linux-bionic-py3_7-clang9-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-py3_7-clang9-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-py3_7-clang9-build.outputs.is-test-matrix-empty }}
 
   linux-vulkan-bionic-py3_7-clang9-build:
     name: linux-vulkan-bionic-py3.7-clang9
@@ -157,6 +161,7 @@ jobs:
       build-environment: linux-vulkan-bionic-py3.7-clang9
       docker-image: ${{ needs.linux-vulkan-bionic-py3_7-clang9-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-vulkan-bionic-py3_7-clang9-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-vulkan-bionic-py3_7-clang9-build.outputs.is-test-matrix-empty }}
 
   linux-bionic-cuda11_6-py3_10-gcc7-build:
     name: linux-bionic-cuda11.6-py3.10-gcc7
@@ -185,6 +190,7 @@ jobs:
       build-environment: linux-bionic-cuda11.6-py3.10-gcc7
       docker-image: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-build.outputs.is-test-matrix-empty }}
 
   linux-focal-py3-clang7-mobile-build:
     name: linux-focal-py3-clang7-mobile-build
@@ -228,6 +234,7 @@ jobs:
       build-environment: linux-bionic-py3_7-clang8-xla
       docker-image: ${{ needs.linux-bionic-py3_7-clang8-xla-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-py3_7-clang8-xla-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-py3_7-clang8-xla-build.outputs.is-test-matrix-empty }}
 
   win-vs2019-cpu-py3-build:
     name: win-vs2019-cpu-py3
@@ -250,6 +257,7 @@ jobs:
       build-environment: win-vs2019-cpu-py3
       cuda-version: cpu
       test-matrix: ${{ needs.win-vs2019-cpu-py3-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.win-vs2019-cpu-py3-build.outputs.is-test-matrix-empty }}
 
   win-vs2019-cuda11_6-py3-build:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -67,7 +67,6 @@ jobs:
       build-environment: linux-focal-py3.7-gcc7-pch
       docker-image-name: pytorch-linux-focal-py3.7-gcc7
 
-
   linux-focal-py3_7-clang7-asan-build:
     name: linux-focal-py3.7-clang7-asan
     uses: ./.github/workflows/_linux-build.yml

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -83,6 +83,7 @@ jobs:
           { config: "functorch", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
         ]}
 
+
   linux-focal-py3_7-clang7-asan-test:
     name: linux-focal-py3.7-clang7-asan
     uses: ./.github/workflows/_linux-test.yml

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -83,7 +83,6 @@ jobs:
           { config: "functorch", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
         ]}
 
-
   linux-focal-py3_7-clang7-asan-test:
     name: linux-focal-py3.7-clang7-asan
     uses: ./.github/workflows/_linux-test.yml

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -67,6 +67,7 @@ jobs:
       build-environment: linux-focal-py3.7-gcc7-pch
       docker-image-name: pytorch-linux-focal-py3.7-gcc7
 
+
   linux-focal-py3_7-clang7-asan-build:
     name: linux-focal-py3.7-clang7-asan
     uses: ./.github/workflows/_linux-build.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -38,6 +38,7 @@ jobs:
       build-environment: parallelnative-linux-focal-py3.7-gcc7
       docker-image: ${{ needs.parallelnative-linux-focal-py3_7-gcc7-build.outputs.docker-image }}
       test-matrix: ${{ needs.parallelnative-linux-focal-py3_7-gcc7-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.parallelnative-linux-focal-py3_7-gcc7-build.outputs.is-test-matrix-empty }}
 
   # Build PyTorch with BUILD_CAFFE2=ON
   caffe2-linux-focal-py3_7-gcc7-build:
@@ -76,6 +77,7 @@ jobs:
       build-environment: linux-bionic-cuda11.7-py3.10-gcc7
       docker-image: ${{ needs.linux-bionic-cuda11_7-py3_10-gcc7-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_7-py3_10-gcc7-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-cuda11_7-py3_10-gcc7-build.outputs.is-test-matrix-empty }}
 
   linux-bionic-cuda11_6-py3_10-gcc7-sm86-build:
     name: cuda11.6-py3.10-gcc7-sm86
@@ -103,6 +105,7 @@ jobs:
       build-environment: linux-bionic-cuda11.6-py3.10-gcc7-sm86
       docker-image: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-sm86-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-sm86-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-sm86-build.outputs.is-test-matrix-empty }}
 
   libtorch-linux-bionic-cuda11_6-py3_7-gcc7-build:
     name: libtorch-linux-bionic-cuda11.6-py3.7-gcc7
@@ -147,6 +150,7 @@ jobs:
       build-environment: linux-bionic-py3.7-clang9-slow
       docker-image: ${{ needs.linux-bionic-py3_7-clang9-slow-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-py3_7-clang9-slow-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-bionic-py3_7-clang9-slow-build.outputs.is-test-matrix-empty }}
 
   linux-focal-py3_7-clang7-tsan-build:
     name: linux-focal-py3.7-clang7-tsan
@@ -167,6 +171,7 @@ jobs:
       build-environment: linux-focal-py3.7-clang7-tsan
       docker-image: ${{ needs.linux-focal-py3_7-clang7-tsan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-py3_7-clang7-tsan-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-focal-py3_7-clang7-tsan-build.outputs.is-test-matrix-empty }}
 
   ios-12-5-1-x86-64:
     name: ios-12-5-1-x86-64
@@ -201,6 +206,7 @@ jobs:
     with:
       build-environment: macos-12-py3-x86-64
       test-matrix: ${{ needs.macos-12-py3-x86-64-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.macos-12-py3-x86-64-build.outputs.is-test-matrix-empty }}
       arch: x86_64
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
@@ -259,6 +265,7 @@ jobs:
     with:
       build-environment: macos-12-py3-arm64
       test-matrix: ${{ needs.macos-12-py3-arm64-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.macos-12-py3-arm64-build.outputs.is-test-matrix-empty }}
       arch: arm64
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
@@ -290,6 +297,7 @@ jobs:
       build-environment: win-vs2019-cuda11.6-py3
       cuda-version: "11.6"
       test-matrix: ${{ needs.win-vs2019-cuda11_6-py3-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.win-vs2019-cuda11_6-py3-build.outputs.is-test-matrix-empty }}
 
   linux-focal-rocm5_2-py3_8-build:
     name: linux-focal-rocm5.2-py3.8
@@ -312,6 +320,7 @@ jobs:
       build-environment: linux-focal-rocm5.2-py3.8
       docker-image: ${{ needs.linux-focal-rocm5_2-py3_8-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-rocm5_2-py3_8-build.outputs.test-matrix }}
+      is-test-matrix-empty: ${{ needs.linux-focal-rocm5_2-py3_8-build.outputs.is-test-matrix-empty }}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Originally, the filtering logic was applied twice, first in the build step (doesn't show up in GitHub signal box) and latter as a separate job before testing (show up in GitHub signal box), so that PR authors had plenty of time to add the necessary label(s).  This PR tweaks this and keeps only the first part:

* **This is to reduce the number of jobs on GitHub signal box, which might be limited by GitHub**.  This PR is needed only when the limit is too low (100) and cannot be raised.
* After this change, PR authors have a smaller window to set the `test-config` labels, i.e. when creating the PR. This should be ok as an advance feature.  The filter logic is applied dynamically given all labels available at the time it runs.
* This shouldn't change the way `mem_leak_check` and `rerun_disabled_tests` jobs run.  They depends on the filtering step to work.