### PR TITLE
[FX][Graph] improve attr_node warning logic to avoid console overflow 

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1317,7 +1317,7 @@ class Graph:
 
         # Check targets are legit
         if self.owning_module:
-            attr_warning_shown = False
+            attr_warning_shown: bool  = False
             for node in self.nodes:
                 if node.op == 'call_function':
                     if not callable(node.target):
@@ -1346,14 +1346,12 @@ class Graph:
                               and atom not in m_itr._buffers):
                             if not attr_warning_shown:
                                 warnings.warn(f'Node {node} target {node.target} {atom} of {seen_qualname} does '
-                                          'not reference an nn.Module, nn.Parameter, or buffer, which is '
-                                          'what \'get_attr\' Nodes typically target.\n This warning only '
-                                          'shows once to avoid console overload.  Please review your graph '
-                                          'for similar issues, or correct this node and re-run the linter ' 
-                                          'to show the next node with similar issue, if any more exist. '
-                                          )
-                                attr_warning_shown = True
-                                
+                                               'not reference an nn.Module, nn.Parameter, or buffer, which is '
+                                               'what \'get_attr\' Nodes typically target.\n This warning only '
+                                               'shows once to avoid console overload.  Please review your graph '
+                                               'for similar issues, or correct this node and re-run the linter '
+                                               'to show the next node with similar issue, if any more exist. ')
+                                attr_warning_shown = True      
                         else:
                             m_itr = new_m_itr
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1317,6 +1317,7 @@ class Graph:
 
         # Check targets are legit
         if self.owning_module:
+            attr_warning_shown = False
             for node in self.nodes:
                 if node.op == 'call_function':
                     if not callable(node.target):
@@ -1343,9 +1344,16 @@ class Graph:
                               and not isinstance(new_m_itr, torch.nn.Module)
                               and not isinstance(new_m_itr, torch.nn.Parameter)
                               and atom not in m_itr._buffers):
-                            warnings.warn(f'Node {node} target {node.target} {atom} of {seen_qualname} does '
+                            if not attr_warning_shown:
+                                warnings.warn(f'Node {node} target {node.target} {atom} of {seen_qualname} does '
                                           'not reference an nn.Module, nn.Parameter, or buffer, which is '
-                                          'what \'get_attr\' Nodes typically target')
+                                          'what \'get_attr\' Nodes typically target.\n This warning only '
+                                          'shows once to avoid console overload.  Please review your graph '
+                                          'for similar issues, or correct this node and re-run the linter ' 
+                                          'to show the next node with similar issue, if any more exist. '
+                                          )
+                                attr_warning_shown = True
+                                
                         else:
                             m_itr = new_m_itr
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1351,7 +1351,7 @@ class Graph:
                                               'shows once to avoid console overload.  Please review your graph '
                                               'for similar issues, or correct this node and re-run the linter '
                                               'to show the next node with similar issue, if any more exist. ')
-                                attr_warning_shown = True      
+                                attr_warning_shown = True
                         else:
                             m_itr = new_m_itr
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1317,7 +1317,7 @@ class Graph:
 
         # Check targets are legit
         if self.owning_module:
-            attr_warning_shown: bool  = False
+            attr_warning_shown: bool = False
             for node in self.nodes:
                 if node.op == 'call_function':
                     if not callable(node.target):
@@ -1346,11 +1346,11 @@ class Graph:
                               and atom not in m_itr._buffers):
                             if not attr_warning_shown:
                                 warnings.warn(f'Node {node} target {node.target} {atom} of {seen_qualname} does '
-                                               'not reference an nn.Module, nn.Parameter, or buffer, which is '
-                                               'what \'get_attr\' Nodes typically target.\n This warning only '
-                                               'shows once to avoid console overload.  Please review your graph '
-                                               'for similar issues, or correct this node and re-run the linter '
-                                               'to show the next node with similar issue, if any more exist. ')
+                                              'not reference an nn.Module, nn.Parameter, or buffer, which is '
+                                              'what \'get_attr\' Nodes typically target.\n This warning only '
+                                              'shows once to avoid console overload.  Please review your graph '
+                                              'for similar issues, or correct this node and re-run the linter '
+                                              'to show the next node with similar issue, if any more exist. ')
                                 attr_warning_shown = True      
                         else:
                             m_itr = new_m_itr


### PR DESCRIPTION
This PR sets the get_attr node warning to display only once, rather than the continuous stream of warnings that in our use case, represent nothing but console overflow that gets in the way.  

Background: 
Currently we (tau compiler) are inserting subgraphs that contain distributed communication collectives, which when traced, translate the distributed classes ReduceOp and ProcessGroup into tensor constants, referenced by get_attr nodes.

However, the graph linter has a warning about get_attr nodes referencing anything but params/buffers. 
<img width="1124" alt="warning_fx_graph" src="https://user-images.githubusercontent.com/46302957/205981634-574acb4d-f3e1-4cdf-8ed2-c82f0a912987.png">


As a result, we continuously get a massive console spew of warnings as each and every get_attr node is warned. 
Example:
<img width="1499" alt="fx_graph_console_overload" src="https://user-images.githubusercontent.com/46302957/205980506-73a8ea7a-674b-45eb-8fc9-f1b138a3f8ec.png">


In talking with Ansley, have determined that a good compromise here is to enable a warn once functionality to blend the goals of alerting a user, while not overflowing users that intentionally have situations that don't match the current well-intentioned warning.

Thus, this PR simply sets an attr_warning_shown flag to show the warning for the first node detected, and then suppresses continous display after that. 
The warning itself has been updated to note that this is only the first node detected and the user should review their graph, and/or fix this node and re-run the linter to check the next offending node, if any. 
That results in a single console output like this:
<img width="1499" alt="fx_graph_single_warning" src="https://user-images.githubusercontent.com/46302957/205980870-c78023ab-2ed6-443f-bf9f-ee0f660c6914.png">

which is much more helpful towards providing info without overflow (imo). 
If there are better ways to resolve this issue, then pls advise but hopefully this PR achieves the desired compromise between warning the user while not overflowing the console of other users who have legit use for get_attr outside the bounds of this warning. 
