### PR TITLE
correctly set strides for expanded/unsqueezed dimensions

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -364,7 +364,7 @@ def assert_ref_meta_equal(test_case, func, meta_rs, rs, msg_callable):
         if should_check_strides(func) == CheckStrides.ALL:
             same_strides, _ = torch._prims_common.check_all_strides(meta_r, r)
             test_assert(same_strides, f"but real stride was {r.stride()}")
-        if should_check_strides(func) == CheckStrides.SIGNIFICANT:
+        elif should_check_strides(func) == CheckStrides.SIGNIFICANT:
             same_strides, _ = torch._prims_common.check_significant_strides(meta_r, r)
             test_assert(same_strides, f"but real stride was {r.stride()}")
         test_assert(

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -289,8 +289,7 @@ CHECK_STRIDES = {
 }
 
 CHECK_ALL_STRIDES = {
-    torch.Tensor.expand,
-    torch.unsqueeze
+    aten.unsqueeze.default
 }
 
 CHECK_STRIDES_SKIPS = {
@@ -363,7 +362,6 @@ def assert_ref_meta_equal(test_case, func, meta_rs, rs, msg_callable):
         test_assert(meta_r.shape == r.shape, f"but real shape was {r.shape}")
         # See https://github.com/pytorch/pytorch/issues/78050
         if should_check_strides(func) == CheckStrides.ALL:
-            print("strides", meta_r.stride(), r.stride())
             same_strides, _ = torch._prims_common.check_all_strides(meta_r, r)
             test_assert(same_strides, f"but real stride was {r.stride()}")
         if should_check_strides(func) == CheckStrides.SIGNIFICANT:

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -288,6 +288,11 @@ CHECK_STRIDES = {
     torch.Tensor.__getitem__,
 }
 
+CHECK_ALL_STRIDES = {
+    torch.Tensor.expand,
+    torch.unsqueeze
+}
+
 CHECK_STRIDES_SKIPS = {
     aten._conj_physical.default,
     aten._fft_c2c.default,
@@ -319,22 +324,29 @@ CHECK_STRIDES_SKIPS = {
     # aten.view.default,  # repro with test_dispatch_symbolic_meta_outplace_all_strides_unflatten_cuda_float32
 }
 
+class CheckStrides(Enum):
+    NONE = 0
+    SIGNIFICANT = 1
+    ALL = 2
+
 def should_check_strides(func):
+    if func in CHECK_ALL_STRIDES:
+        return CheckStrides.ALL
     if func in CHECK_STRIDES:
-        return True
+        return CheckStrides.SIGNIFICANT
     if func in CHECK_STRIDES_SKIPS:
-        return False
+        return CheckStrides.NONE
     if not isinstance(func, torch._ops.OpOverload):
-        return False
+        return CheckStrides.NONE
     # Prims are expected to model strides correctly
     if func.namespace == "prims":
-        return True
+        return CheckStrides.SIGNIFICANT
     # Check if it's a view, by testing if any of the returns have
     # a non-empty alias set
     if any(r.alias_info.before_set for r in func._schema.returns if r.alias_info):
-        return True
+        return CheckStrides.SIGNIFICANT
     # TODO: check for TensorIterator
-    return True
+    return CheckStrides.SIGNIFICANT
 
 def assert_ref_meta_equal(test_case, func, meta_rs, rs, msg_callable):
     flat_meta_rs, _ = tree_flatten(meta_rs)
@@ -350,7 +362,11 @@ def assert_ref_meta_equal(test_case, func, meta_rs, rs, msg_callable):
         test_assert(meta_r.dtype == r.dtype, f"but real dtype was {r.dtype}")
         test_assert(meta_r.shape == r.shape, f"but real shape was {r.shape}")
         # See https://github.com/pytorch/pytorch/issues/78050
-        if should_check_strides(func):
+        if should_check_strides(func) == CheckStrides.ALL:
+            print("strides", meta_r.stride(), r.stride())
+            same_strides, _ = torch._prims_common.check_all_strides(meta_r, r)
+            test_assert(same_strides, f"but real stride was {r.stride()}")
+        if should_check_strides(func) == CheckStrides.SIGNIFICANT:
             same_strides, _ = torch._prims_common.check_significant_strides(meta_r, r)
             test_assert(same_strides, f"but real stride was {r.stride()}")
         test_assert(

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -1233,6 +1233,12 @@ def _broadcast_in_dim_meta(
             original_idx = original_idx + 1
         else:
             new_strides.append(0)
+            if shape[idx] != 1:
+                new_strides.append(0)
+            elif original_idx == a.ndim:
+                new_strides.append(1)
+            else:
+                new_strides.append(a.stride()[original_idx] * a.size()[original_idx])
 
     return a.as_strided(shape, new_strides, a.storage_offset())
 

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -1232,7 +1232,6 @@ def _broadcast_in_dim_meta(
                 new_strides.append(a.stride()[original_idx])
             original_idx = original_idx + 1
         else:
-            new_strides.append(0)
             if shape[idx] != 1:
                 new_strides.append(0)
             elif original_idx == a.ndim:


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchdynamo/issues/1959, #90260
However, I wasn't able to make existing stride tests fail before the fix, even though I'm comparing all, not just significant strides. 
Separately running refs on meta tensors produces wrong strides as shown in #90260, however, it looks like in meta tests some other way of computing meta info is used (I've been running 
```
pytest -s -v test/test_meta.py -k test_meta_outplace_expand_cuda_float64
```
and verified that it has sample input that should fail, and that it indeed compares all the strides, but the produced `meta_rs` results somehow still had correct strides).

Edit: @SherlockNoMad helped me figure out how to fail the tests, and now I've set the correct ops for checking. `expand` fails for some test inputs because it special-cases 0-dim input case, correctly modeling it in prims would require a lot of changes, so skipping that for now.

cc @SherlockNoMad 
