### PR TITLE
[Profiler] Include more uncategorized events in memory profile.

### DIFF
--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -3,7 +3,6 @@ import functools
 import gc
 import itertools as it
 import textwrap
-import unittest
 from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
 import torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90345

This PR adds handling for allocations / frees which we cannot prove are for Tensors. (And thus aren't assigned an ID.) These events are still important for judging overall utilization.

Differential Revision: [D41790860](https://our.internmc.facebook.com/intern/diff/D41790860/)