### PR TITLE
Make Inductor accepts opaque callable

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2933,7 +2933,7 @@ class DynamicScalar(IRNode):
         return ()
 
 def get_callable_name(callable):
-    return = f"{callable.__name__}_{callable.__hash__()}"
+    return f"{callable.__name__}_{callable.__hash__()}"
 
 @dataclasses.dataclass
 class FallbackKernel(ExternKernelAlloc):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -13,6 +13,7 @@ from inspect import signature
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Set, Tuple, Union
 from unittest.mock import patch
 
+import types
 import numpy
 import sympy
 from sympy import Expr, Integer
@@ -2931,6 +2932,8 @@ class DynamicScalar(IRNode):
     def get_reads(self):
         return ()
 
+def get_callable_name(callable):
+    return = f"{callable.__name__}_{callable.__hash__()}"
 
 @dataclasses.dataclass
 class FallbackKernel(ExternKernelAlloc):
@@ -2950,10 +2953,13 @@ class FallbackKernel(ExternKernelAlloc):
         )
         if getattr(torch.ops.aten, kernel.__name__, None) is kernel:
             self.kernel = f"aten.{kernel.__name__}"
-        else:
+        elif "._ops." in kernel.__module__:
             self.kernel = (
                 f"{kernel.__module__.replace('._ops.', '.ops.')}.{kernel.__name__}"
             )
+        else:
+            self.kernel = get_callable_name(kernel)
+
         self.unflatten_args = unflatten_args
         self.kwargs = {} if kwargs is None else kwargs
         if self.kernel not in ("aten.convolution_backward",):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90356

This is an experiment to make Inductor accepts opaque callable. 
Opaque callable could used for custom op, kernels generated by another backend. 
Opaque callable should fallback, and wrapper codegen need handle forward the call the original callable. 

For following fx graph, 
```
class <lambda>(torch.nn.Module):
    def forward(self, arg0_1: f32[3, 3]):
        # No stacktrace found for following nodes
        sin: f32[3, 3] = inductor_test_torchinductor_opaque_func(arg0_1);  arg0_1 = None
        mm: f32[3, 3] = torch.ops.aten.mm.default(sin, sin);  sin = None
        return [mm]

```
Inductor would generate
```
def call(args):
    arg0_1, = args
    args.clear()
    buf0 = opaque_func_8736875164326(arg0_1)
    del arg0_1
    buf1 = buf0
    assert_size_stride(buf1, (3, 3), (3, 1))
    del buf0
    buf2 = empty_strided((3, 3), (3, 1), device='cpu', dtype=torch.float32)
    aten.mm.out(buf1, buf1, out=buf2)
    return (buf2, )
```

Fixes #94836

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire