### PR TITLE
[Vulkan] Enable copying QInt8 and QInt32 tensors from cpu to vulkan.

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/image_to_nchw_int32.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/image_to_nchw_int32.glsl
@@ -1,0 +1,52 @@
+#version 450 core
+#define PRECISION $precision
+
+layout(std430) buffer;
+
+/*
+ * Input Sampler
+ */
+layout(set = 0, binding = 0) uniform PRECISION isampler3D uImage;
+
+/*
+ * Output Buffer
+ */
+layout(set = 0, binding = 1) buffer PRECISION restrict writeonly Buffer {
+  int data[];
+}
+uBuffer;
+
+/*
+ * Params Buffer
+ */
+layout(set = 0, binding = 2) uniform PRECISION restrict Block {
+  // xyz contain the extents of the input texture, w contains HxW to help
+  // calculate buffer offsets
+  ivec4 in_extents;
+}
+uBlock;
+
+/*
+ * Local Work Group in_extents
+ */
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (any(greaterThanEqual(pos, uBlock.in_extents.xyz))) {
+    return;
+  }
+
+  const ivec4 intex = texelFetch(uImage, pos, 0);
+
+  const int base_index =
+      pos.x + uBlock.in_extents.x * pos.y + (4 * uBlock.in_extents.w) * pos.z;
+  const ivec4 buf_indices =
+      base_index + ivec4(0, 1, 2, 3) * uBlock.in_extents.w;
+
+  uBuffer.data[buf_indices.x] = intex.x;
+  uBuffer.data[buf_indices.y] = intex.y;
+  uBuffer.data[buf_indices.z] = intex.z;
+  uBuffer.data[buf_indices.w] = intex.w;
+}

--- a/aten/src/ATen/native/vulkan/glsl/nchw_to_image_int32.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/nchw_to_image_int32.glsl
@@ -7,15 +7,15 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 /*
- * Input Sampler
+ * Output Image
  */
-layout(set = 0, binding = 0, rgba8ui) uniform PRECISION restrict writeonly uimage3D uImage;
+layout(set = 0, binding = 0, rgba32i) uniform PRECISION restrict writeonly iimage3D uImage;
 
 /*
- * Output Buffer
+ * Input Buffer
  */
 layout(set = 0, binding = 1) buffer PRECISION restrict readonly Buffer {
-  uint data[];
+  int data[];
 }
 uBuffer;
 
@@ -46,26 +46,10 @@ void main() {
   const ivec4 buf_indices =
       base_index + ivec4(0, 1, 2, 3) * uBlock.out_extents.w;
 
-  int shift = (1 << 8) - 1;
-  ivec4 masks;
-  masks.x = shift << 8 * (buf_indices.x % 4);
-  masks.y = shift << 8 * (buf_indices.y % 4);
-  masks.z = shift << 8 * (buf_indices.z % 4);
-  masks.w = shift << 8 * (buf_indices.w % 4);
+  int val_x = uBuffer.data[buf_indices.x];
+  int val_y = uBuffer.data[buf_indices.y];
+  int val_z = uBuffer.data[buf_indices.z];
+  int val_w = uBuffer.data[buf_indices.w];
 
-  uint buf_in_1 = uBuffer.data[buf_indices.x / 4];
-  uint a_v = (buf_in_1 & masks.x) >> 8 * (buf_indices.x % 4);
-
-  uint buf_in_2 = uBuffer.data[buf_indices.y / 4];
-  uint b_v = (buf_in_2 & masks.y) >> 8 * (buf_indices.y % 4);
-
-  uint buf_in_3 = uBuffer.data[buf_indices.z / 4];
-  uint g_v = (buf_in_3 & masks.z) >> 8 * (buf_indices.z % 4);
-
-  uint buf_in_4 = uBuffer.data[buf_indices.w / 4];
-  uint r_v = (buf_in_4 & masks.w) >> 8 * (buf_indices.w % 4);
-
-  uvec4 texel = uvec4(a_v, b_v, g_v, r_v);
-
-  imageStore(uImage, pos, texel);
+  imageStore(uImage, pos, ivec4(val_x, val_y, val_z, val_w));
 }

--- a/aten/src/ATen/native/vulkan/glsl/nchw_to_image_int8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/nchw_to_image_int8.glsl
@@ -1,0 +1,85 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+/*
+ * Output Image
+ */
+layout(set = 0, binding = 0, rgba8i) uniform PRECISION restrict writeonly iimage3D uImage;
+
+/*
+ * Input Buffer
+ */
+layout(set = 0, binding = 1) buffer PRECISION restrict readonly Buffer {
+  int data[];
+}
+uBuffer;
+
+/*
+ * Params Buffer
+ */
+layout(set = 0, binding = 2) uniform PRECISION restrict Block {
+  // xyz contain the extents of the input texture, w contains HxW to help
+  // calculate buffer offsets
+  ivec4 out_extents;
+}
+uBlock;
+
+/*
+ * Local Work Group Size
+ */
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+/*
+ * Extends sign of int8
+ */
+int extend_sign(int x) {
+  if (x >> 7 == 1) {
+    return x | 0xFFFFFF00;
+  }
+  return x;
+}
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (any(greaterThanEqual(pos, uBlock.out_extents.xyz))) {
+    return;
+  }
+
+  const int base_index =
+      pos.x + uBlock.out_extents.x * pos.y + (4 * uBlock.out_extents.w) * pos.z;
+  const ivec4 buf_indices =
+      base_index + ivec4(0, 1, 2, 3) * uBlock.out_extents.w;
+
+  int shift = (1 << 8) - 1;
+  ivec4 masks;
+  masks.x = shift << 8 * (buf_indices.x % 4);
+  masks.y = shift << 8 * (buf_indices.y % 4);
+  masks.z = shift << 8 * (buf_indices.z % 4);
+  masks.w = shift << 8 * (buf_indices.w % 4);
+
+  int buf_in_1 = uBuffer.data[buf_indices.x / 4];
+  int a_v = (buf_in_1 & masks.x) >> 8 * (buf_indices.x % 4);
+  a_v = extend_sign(a_v);
+
+  int buf_in_2 = uBuffer.data[buf_indices.y / 4];
+  int b_v = (buf_in_2 & masks.y) >> 8 * (buf_indices.y % 4);
+  b_v = extend_sign(b_v);
+
+  int buf_in_3 = uBuffer.data[buf_indices.z / 4];
+  int g_v = (buf_in_3 & masks.z) >> 8 * (buf_indices.z % 4);
+  g_v = extend_sign(g_v);
+
+  int buf_in_4 = uBuffer.data[buf_indices.w / 4];
+  int r_v = (buf_in_4 & masks.w) >> 8 * (buf_indices.w % 4);
+  r_v = extend_sign(r_v);
+
+  ivec4 texel = ivec4(a_v, b_v, g_v, r_v);
+
+  imageStore(uImage, pos, texel);
+}

--- a/aten/src/ATen/native/vulkan/glsl/nchw_to_image_uint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/nchw_to_image_uint8.glsl
@@ -1,0 +1,71 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+/*
+ * Output Image
+ */
+layout(set = 0, binding = 0, rgba8ui) uniform PRECISION restrict writeonly uimage3D uImage;
+
+/*
+ * Input Buffer
+ */
+layout(set = 0, binding = 1) buffer PRECISION restrict readonly Buffer {
+  uint data[];
+}
+uBuffer;
+
+/*
+ * Params Buffer
+ */
+layout(set = 0, binding = 2) uniform PRECISION restrict Block {
+  // xyz contain the extents of the input texture, w contains HxW to help
+  // calculate buffer offsets
+  ivec4 out_extents;
+}
+uBlock;
+
+/*
+ * Local Work Group Size
+ */
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (any(greaterThanEqual(pos, uBlock.out_extents.xyz))) {
+    return;
+  }
+
+  const int base_index =
+      pos.x + uBlock.out_extents.x * pos.y + (4 * uBlock.out_extents.w) * pos.z;
+  const ivec4 buf_indices =
+      base_index + ivec4(0, 1, 2, 3) * uBlock.out_extents.w;
+
+  int shift = (1 << 8) - 1;
+  ivec4 masks;
+  masks.x = shift << 8 * (buf_indices.x % 4);
+  masks.y = shift << 8 * (buf_indices.y % 4);
+  masks.z = shift << 8 * (buf_indices.z % 4);
+  masks.w = shift << 8 * (buf_indices.w % 4);
+
+  uint buf_in_1 = uBuffer.data[buf_indices.x / 4];
+  uint a_v = (buf_in_1 & masks.x) >> 8 * (buf_indices.x % 4);
+
+  uint buf_in_2 = uBuffer.data[buf_indices.y / 4];
+  uint b_v = (buf_in_2 & masks.y) >> 8 * (buf_indices.y % 4);
+
+  uint buf_in_3 = uBuffer.data[buf_indices.z / 4];
+  uint g_v = (buf_in_3 & masks.z) >> 8 * (buf_indices.z % 4);
+
+  uint buf_in_4 = uBuffer.data[buf_indices.w / 4];
+  uint r_v = (buf_in_4 & masks.w) >> 8 * (buf_indices.w % 4);
+
+  uvec4 texel = uvec4(a_v, b_v, g_v, r_v);
+
+  imageStore(uImage, pos, texel);
+}


### PR DESCRIPTION
Summary:
Copying QInt8 and QInt32 from cpu to vulkan:
 - Added shader nchw_to_image_int8
 - Added shader nchw_to_image_int32

Copying QInt8 and QInt32 from vulkan to cpu
Note: This functionality is currently disabled until issues on Android are resolved.
- Added shader image_to_nchw_int32
- QInt8 works with the same existing image_to_nchw_quantized shaders

Added multiple tests for each supported dtype:
- cpu_to_vulkan_and_dequantize:
These tests check the correctness of copying quantized cpu tensor to vulkan by comparing the output of the following:
  - cpu float tensor -> quantize -> to vulkan -> dequantize -> to cpu
  - cpu float tensor -> quantize -> dequantize
- cpu_to_vulkan_and_vulkan_to_cpu
(currently disabled until copying vulkan quantized to cpu is enabled):
These tests check the correctness of copying from cpu to vulkan and from vulkan to cpu by creating a random cpu float tensor, quantizing it, then copying it to vulkan, then back to cpu and comparing the output tensor to the original quantized tensor.
- quantize_per_tensor_and_vulkan_to_cpu
(currently disabled until copying vulkan quantized to cpu is enabled):
These tests check the correctness of copying quantized tensor from vulkan to cpu by comparing the output of the following:
  - cpu float tensor -> to vulkan -> quantize -> to cpu
  - cpu float tensor -> quantize

Test Plan:
On Mac
```
cd ~/fbsource
buck1 run -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64
```

On Android
```
cd ~/fbsource
buck1 build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_quantized_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_quantized_api_test
adb shell "/data/local/tmp/vulkan_quantized_api_test"
```

Reviewed By: kimishpatel

Differential Revision: D41654287

