### PR TITLE
[FSDP][Easy] ufmt files

### DIFF
--- a/test/distributed/fsdp/test_fsdp_fx.py
+++ b/test/distributed/fsdp/test_fsdp_fx.py
@@ -4,8 +4,8 @@ import torch
 from torch.distributed.fsdp._trace_utils import _ExecOrderTracer
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
-    TestCase,
     run_tests,
+    TestCase,
 )
 
 

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1087,9 +1087,7 @@ def _map_param_id_to_optim_keys(
     """
     rank = dist.get_rank(group)
     optim_state_key_to_param_id: Dict[_OptimStateKey, int] = {}  # local
-    r0_param_id_to_optim_state_key: Dict[
-        int, _OptimStateKey
-    ] = {}  # rank 0
+    r0_param_id_to_optim_state_key: Dict[int, _OptimStateKey] = {}  # rank 0
 
     for param_id, param in enumerate(param_id_to_param):
         # Do not include parameters without state to avoid empty mappings


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90400 [Composable API][Easy] Use `policy=None` since that is supported
* #90387 [Composable API] Match `fully_shard()` comm. schedule with wrapper FSDP
* #90386 [Composable API] Refactor `test_fully_shard.py` to use common models
* #90385 [Composable API] Move test models to common file
* **#90384 [FSDP][Easy] ufmt files**
* #90201 [FSDP()] Fix `fully_shard` fwd hook registration

