### PR TITLE
[Composable API] Move test models to common file

### DIFF
--- a/test/distributed/_composable/test_compose.py
+++ b/test/distributed/_composable/test_compose.py
@@ -7,15 +7,20 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed._composable import checkpoint, fully_shard
-from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.distributed.fsdp.api import ShardingStrategy
+from torch.distributed.fsdp.wrap import ModuleWrapPolicy
+from torch.testing._internal.common_dist_composable import (
+    CompositeModel,
+    CompositeParamModel,
+    UnitModule,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (
-    TEST_WITH_DEV_DBG_ASAN,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
 )
 
 
@@ -30,62 +35,6 @@ if TEST_WITH_DEV_DBG_ASAN:
         file=sys.stderr,
     )
     sys.exit(0)
-
-
-class UnitModule(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.l1 = nn.Linear(100, 100)
-        self.seq = nn.Sequential(
-            nn.ReLU(),
-            nn.Linear(100, 100),
-            nn.ReLU(),
-        )
-        self.l2 = nn.Linear(100, 100)
-
-    def forward(self, x):
-        return self.l2(self.seq(self.l1(x)))
-
-
-class CompositeModel(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.l1 = nn.Linear(100, 100)
-        self.u1 = UnitModule()
-        self.u2 = UnitModule()
-        self.l2 = nn.Linear(100, 100)
-
-    def forward(self, x):
-        return self.l2(self.u2(self.u1(self.l1(x))))
-
-
-class UnitParamModule(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.l = nn.Linear(100, 100)
-        self.seq = nn.Sequential(
-            nn.ReLU(),
-            nn.Linear(100, 100),
-            nn.ReLU(),
-        )
-        self.p = nn.Parameter(torch.randn(100, 100))
-
-    def forward(self, x):
-        return torch.mm(self.seq(self.l(x)), self.p)
-
-
-class CompositeParamModel(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.l = nn.Linear(100, 100)
-        self.u1 = UnitModule()
-        self.u2 = UnitModule()
-        self.p = nn.Parameter(torch.randn(100, 100))
-
-    def forward(self, x):
-        a = self.u2(self.u1(self.l(x)))
-        b = self.p
-        return torch.mm(a, b)
 
 
 class TestFSDPCheckpoint(FSDPTest):
@@ -158,12 +107,8 @@ class TestFSDPCheckpoint(FSDPTest):
             policy=ModuleWrapPolicy({UnitModule}),
         )
 
-        test_model.u1.seq = checkpoint(
-            test_model.u1.seq, use_reentrant=use_reentrant
-        )
-        test_model.u2.seq = checkpoint(
-            test_model.u2.seq, use_reentrant=use_reentrant
-        )
+        test_model.u1.seq = checkpoint(test_model.u1.seq, use_reentrant=use_reentrant)
+        test_model.u2.seq = checkpoint(test_model.u2.seq, use_reentrant=use_reentrant)
 
         self.run_subtests(
             {

--- a/torch/testing/_internal/common_dist_composable.py
+++ b/torch/testing/_internal/common_dist_composable.py
@@ -1,0 +1,60 @@
+# Owner(s): ["oncall: distributed"]
+
+import torch
+import torch.nn as nn
+
+
+class UnitModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.l1 = nn.Linear(100, 100)
+        self.seq = nn.Sequential(
+            nn.ReLU(),
+            nn.Linear(100, 100),
+            nn.ReLU(),
+        )
+        self.l2 = nn.Linear(100, 100)
+
+    def forward(self, x):
+        return self.l2(self.seq(self.l1(x)))
+
+
+class CompositeModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.l1 = nn.Linear(100, 100)
+        self.u1 = UnitModule()
+        self.u2 = UnitModule()
+        self.l2 = nn.Linear(100, 100)
+
+    def forward(self, x):
+        return self.l2(self.u2(self.u1(self.l1(x))))
+
+
+class UnitParamModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.l = nn.Linear(100, 100)
+        self.seq = nn.Sequential(
+            nn.ReLU(),
+            nn.Linear(100, 100),
+            nn.ReLU(),
+        )
+        self.p = nn.Parameter(torch.randn(100, 100))
+
+    def forward(self, x):
+        return torch.mm(self.seq(self.l(x)), self.p)
+
+
+class CompositeParamModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.l = nn.Linear(100, 100)
+        self.u1 = UnitModule()
+        self.u2 = UnitModule()
+        self.p = nn.Parameter(torch.randn(100, 100))
+
+    def forward(self, x):
+        a = self.u2(self.u1(self.l(x)))
+        b = self.p
+        return torch.mm(a, b)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90400 [Composable API][Easy] Use `policy=None` since that is supported
* #90387 [Composable API] Match `fully_shard()` comm. schedule with wrapper FSDP
* #90386 [Composable API] Refactor `test_fully_shard.py` to use common models
* **#90385 [Composable API] Move test models to common file**
* #90384 [FSDP][Easy] ufmt files
* #90201 [FSDP()] Fix `fully_shard` fwd hook registration

