### PR TITLE
[Composable API] Refactor `test_fully_shard.py` to use common models

### DIFF
--- a/test/distributed/_composable/test_compose.py
+++ b/test/distributed/_composable/test_compose.py
@@ -70,7 +70,7 @@ class TestFSDPCheckpoint(FSDPTest):
     @skip_if_lt_x_gpu(2)
     @parametrize("use_reentrant", [True, False])
     def test_wrap_same_submodule(self, use_reentrant: bool):
-        model = UnitModule().to("cuda")
+        model = UnitModule(device=torch.device("cuda"))
 
         base_model = copy.deepcopy(model)
 
@@ -93,7 +93,7 @@ class TestFSDPCheckpoint(FSDPTest):
         )
 
     def _test_checkpoint_fsdp_submodules(self, use_reentrant):
-        model = CompositeModel().to(torch.device("cuda"))
+        model = CompositeModel(device=torch.device("cuda"))
 
         base_model = copy.deepcopy(model)
 
@@ -134,7 +134,7 @@ class TestFSDPCheckpoint(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     def test_checkpoint_fsdp_submodules_with_param(self):
-        model = CompositeParamModel().to(torch.device("cuda"))
+        model = CompositeParamModel(device=torch.device("cuda"))
 
         base_model = copy.deepcopy(model)
 
@@ -155,7 +155,7 @@ class TestFSDPCheckpoint(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     def test_checkpoint_fsdp_submodules_with_param_no_shard(self):
-        model = CompositeParamModel().to(torch.device("cuda"))
+        model = CompositeParamModel(device=torch.device("cuda"))
 
         base_model = copy.deepcopy(model)
 

--- a/test/distributed/_composable/test_fully_shard.py
+++ b/test/distributed/_composable/test_fully_shard.py
@@ -2,7 +2,7 @@
 
 import copy
 import sys
-from typing import Any, Tuple
+from typing import Optional
 
 import torch
 import torch.distributed as dist
@@ -10,13 +10,14 @@ import torch.nn as nn
 from torch.distributed._composable import fully_shard
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp._common_utils import _is_fsdp_flattened
-from torch.distributed.fsdp.wrap import ModuleWrapPolicy
+from torch.distributed.fsdp.wrap import _FSDPPolicy, ModuleWrapPolicy
+from torch.testing._internal.common_dist_composable import (
+    CompositeParamModel,
+    UnitModule,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
-from torch.testing._internal.common_utils import (
-    run_tests,
-    TEST_WITH_DEV_DBG_ASAN,
-)
+from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -30,42 +31,6 @@ if TEST_WITH_DEV_DBG_ASAN:
     sys.exit(0)
 
 
-class SubModel(nn.Module):
-    def __init__(self, device) -> None:
-        super().__init__()
-        torch.manual_seed(0)
-        self.lin1 = nn.Linear(5, 5, bias=False, device=device)
-        self.lin2 = nn.Linear(5, 5, bias=False, device=device)
-        self.relu = nn.ReLU()
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        z = self.relu(self.lin1(x))
-        z = self.relu(self.lin2(z))
-        return z
-
-
-class Model(nn.Module):
-    def __init__(self, device) -> None:
-        super().__init__()
-        torch.manual_seed(0)
-        self.sub1 = SubModel(device=device)
-        self.sub2 = SubModel(device=device)
-        self.lin = nn.Linear(5, 5, device=device)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        z = self.sub1(x)
-        z = self.sub2(z)
-        z = self.lin(z)
-        return z
-
-    @staticmethod
-    def policy():
-        return ModuleWrapPolicy({SubModel})
-
-    def get_input(self, device=torch.device) -> Tuple[Any, ...]:
-        return (torch.randn((8, 5), device=device),)
-
-
 class TestFSDPInitialization(FSDPTest):
     """Tests composable FSDP initialization."""
 
@@ -73,19 +38,25 @@ class TestFSDPInitialization(FSDPTest):
     def world_size(self) -> int:
         return 2
 
-    def _test_auto_wrap_policy(self, auto_wrap_policy):
-        """Tests passing an ``auto_wrap_policy``."""
+    @skip_if_lt_x_gpu(2)
+    def test_policy(self):
+        """Tests passing a ``policy`` for pseudo-auto-wrapping."""
+        self.run_subtests(
+            {"policy": [None, ModuleWrapPolicy({UnitModule})]},
+            self._test_policy,
+        )
 
-        local_model = Model(device=torch.device("cuda"))
+    def _test_policy(self, policy: Optional[_FSDPPolicy]):
+        local_model = CompositeParamModel(torch.device("cuda"))
         fsdp_wrapped_model = FSDP(
             copy.deepcopy(local_model),
-            auto_wrap_policy=auto_wrap_policy,
+            auto_wrap_policy=policy,
             use_orig_params=True,
         )
         composable_module = copy.deepcopy(local_model)
         fully_shard(
             composable_module,
-            policy=auto_wrap_policy,
+            policy=policy,
         )
 
         # Check that the composable module has the same names as the local
@@ -124,22 +95,17 @@ class TestFSDPInitialization(FSDPTest):
         self.assertEqual(local_module_classes, composable_module_classes)
 
     @skip_if_lt_x_gpu(2)
-    def test_auto_wrap_policy(self):
-        self.run_subtests(
-            {"auto_wrap_policy": [None, Model.policy()]},
-            self._test_auto_wrap_policy,
-        )
-
-    @skip_if_lt_x_gpu(2)
     def test_device_id(self):
         """Tests passing a ``device_id``."""
         cpu_device = torch.device("cpu")
-        composable_module = Model(device=cpu_device)
+        composable_module = CompositeParamModel(device=cpu_device)
         for param in composable_module.parameters():
-            assert param.device == cpu_device
+            assert (
+                param.device == cpu_device
+            ), "Expects module to be initialized on CPU for this unit test"
         fully_shard(
             composable_module,
-            policy=Model.policy(),
+            policy=ModuleWrapPolicy({UnitModule}),
             device_id=self.rank,
         )
         for param in composable_module.parameters():
@@ -148,7 +114,7 @@ class TestFSDPInitialization(FSDPTest):
     @skip_if_lt_x_gpu(2)
     def test_sync_module_states(self):
         """Tests passing ``sync_module_states=True``."""
-        local_model = Model(device=torch.device("cuda"))
+        local_model = CompositeParamModel(device=torch.device("cuda"))
         composable_module = copy.deepcopy(local_model)
         # Check that the parameters are broadcast from rank 0 by comparing
         # against an equivalent FSDP-wrapped module
@@ -156,14 +122,15 @@ class TestFSDPInitialization(FSDPTest):
             for param in composable_module.parameters():
                 with torch.no_grad():
                     param.zero_()
+        policy = ModuleWrapPolicy({UnitModule})
         fsdp_wrapped_model = FSDP(
             copy.deepcopy(local_model),
-            auto_wrap_policy=Model.policy(),
+            auto_wrap_policy=policy,
             use_orig_params=True,
         )
         fully_shard(
             composable_module,
-            policy=Model.policy(),
+            policy=policy,
             sync_module_states=True,
         )
         for (composable_param, fsdp_wrapped_param) in zip(
@@ -180,37 +147,54 @@ class TestFSDPInitialization(FSDPTest):
             """
             This is an example ``param_init_fn`` for composable FSDP.
 
-            TODO: This function is not satisfactory because this requires
-            guarding with ``_is_fsdp_flattened()``. This guard is needed to
-            avoid re-initializing parameters for nested cases since some
-            initialization methods strictly require non-1D shape (e.g.
-            ``kaiming_uniform_()``), while FSDP replaces the original
-            parameters with their 1D shards.
+            TODO: This function is not satisfactory because:
+            (1) This requires guarding with ``_is_fsdp_flattened()``. This
+            guard is needed to avoid re-initializing parameters for nested
+            cases since some initialization methods strictly require non-1D
+            shape (e.g. ``kaiming_uniform_()``), while FSDP replaces the
+            original parameters with their 1D shards.
+            (2) This requires module-by-module traversal and manual ``setattr``
+            usage as opposed to first calling ``module.to_empty()`` and then
+            initializing each parameter after. The latter will override the
+            initialization of already-initialized nested parameters. In other
+            words, this parameter initialization function must strictly modify
+            only the parameters on meta device.
             """
-            is_meta = any(param.is_meta for param in module.parameters())
-            if is_meta:
-                module.to_empty(device=torch.cuda.current_device())
             torch.manual_seed(0)
-            for param in module.parameters():
-                if not _is_fsdp_flattened(param):
-                    nn.init.uniform_(param)
+            for submodule in module.modules():
+                for param_name, param in submodule.named_parameters(recurse=False):
+                    if not _is_fsdp_flattened(param) and param.is_meta:
+                        materialized_param = nn.Parameter(
+                            torch.empty_like(param, device=torch.device("cuda"))
+                        )
+                        nn.init.uniform_(materialized_param)
+                        setattr(submodule, param_name, materialized_param)
 
-        composable_module = Model(device="meta")
+        composable_module = CompositeParamModel(device=torch.device("meta"))
+        meta_model = CompositeParamModel(device=torch.device("meta"))
         fsdp_wrapped_model = FSDP(
-            Model(device="meta"),
-            auto_wrap_policy=Model.policy(),
+            meta_model,
+            auto_wrap_policy=ModuleWrapPolicy({UnitModule}),
             param_init_fn=_param_init_fn,
             use_orig_params=True,
         )
         fully_shard(
             composable_module,
-            policy=Model.policy(),
+            policy=ModuleWrapPolicy({UnitModule}),
             param_init_fn=_param_init_fn,
         )
-        for (composable_param, fsdp_wrapped_param) in zip(
-            composable_module.parameters(),
-            fsdp_wrapped_model.parameters(),
+        for (
+            (composable_param_name, composable_param),
+            (fsdp_wrapped_param_name, fsdp_wrapped_param),
+        ) in zip(
+            composable_module.named_parameters(),
+            fsdp_wrapped_model.named_parameters(),
         ):
+            self.assertEqual(composable_param_name, fsdp_wrapped_param_name)
+            self.assertEqual(
+                composable_param.device,
+                torch.device("cuda", torch.cuda.current_device()),
+            )
             self.assertEqual(composable_param, fsdp_wrapped_param)
 
 
@@ -225,30 +209,30 @@ class TestFSDPRuntime(FSDPTest):
     def test_training(self):
         """Tests training (forward, backward, optimizer)."""
         device = torch.device("cuda")
-        local_model = Model(device=device)
+        local_model = CompositeParamModel(device=device)
         fsdp_wrapped_model = FSDP(
             copy.deepcopy(local_model),
-            auto_wrap_policy=Model.policy(),
+            auto_wrap_policy=ModuleWrapPolicy({UnitModule}),
             use_orig_params=True,
         )
         composable_module = copy.deepcopy(local_model)
         fully_shard(
             composable_module,
-            policy=Model.policy(),
+            policy=ModuleWrapPolicy({UnitModule}),
         )
         del local_model  # not needed anymore
         LR = 1e-2
         fsdp_wrapped_optim = torch.optim.Adam(fsdp_wrapped_model.parameters(), lr=LR)
         composable_optim = torch.optim.Adam(composable_module.parameters(), lr=LR)
         for _ in range(5):
-            inp = composable_module.get_input(device)
+            inp = torch.randn(2, 100, device="cuda")
             losses = []
             for model, optim in (
                 (fsdp_wrapped_model, fsdp_wrapped_optim),
                 (composable_module, composable_optim),
             ):
                 optim.zero_grad(set_to_none=True)
-                out = model(*inp)
+                out = model(inp)
                 loss = out.sum()
                 losses.append(loss)
                 loss.backward()

--- a/torch/testing/_internal/common_dist_composable.py
+++ b/torch/testing/_internal/common_dist_composable.py
@@ -5,54 +5,54 @@ import torch.nn as nn
 
 
 class UnitModule(nn.Module):
-    def __init__(self):
+    def __init__(self, device: torch.device):
         super().__init__()
-        self.l1 = nn.Linear(100, 100)
+        self.l1 = nn.Linear(100, 100, device=device)
         self.seq = nn.Sequential(
             nn.ReLU(),
-            nn.Linear(100, 100),
+            nn.Linear(100, 100, device=device),
             nn.ReLU(),
         )
-        self.l2 = nn.Linear(100, 100)
+        self.l2 = nn.Linear(100, 100, device=device)
 
     def forward(self, x):
         return self.l2(self.seq(self.l1(x)))
 
 
 class CompositeModel(nn.Module):
-    def __init__(self):
+    def __init__(self, device: torch.device):
         super().__init__()
-        self.l1 = nn.Linear(100, 100)
-        self.u1 = UnitModule()
-        self.u2 = UnitModule()
-        self.l2 = nn.Linear(100, 100)
+        self.l1 = nn.Linear(100, 100, device=device)
+        self.u1 = UnitModule(device)
+        self.u2 = UnitModule(device)
+        self.l2 = nn.Linear(100, 100, device=device)
 
     def forward(self, x):
         return self.l2(self.u2(self.u1(self.l1(x))))
 
 
 class UnitParamModule(nn.Module):
-    def __init__(self):
+    def __init__(self, device: torch.device):
         super().__init__()
-        self.l = nn.Linear(100, 100)
+        self.l = nn.Linear(100, 100, device=device)
         self.seq = nn.Sequential(
             nn.ReLU(),
-            nn.Linear(100, 100),
+            nn.Linear(100, 100, device=device),
             nn.ReLU(),
         )
-        self.p = nn.Parameter(torch.randn(100, 100))
+        self.p = nn.Parameter(torch.randn((100, 100), device=device))
 
     def forward(self, x):
         return torch.mm(self.seq(self.l(x)), self.p)
 
 
 class CompositeParamModel(nn.Module):
-    def __init__(self):
+    def __init__(self, device: torch.device):
         super().__init__()
-        self.l = nn.Linear(100, 100)
-        self.u1 = UnitModule()
-        self.u2 = UnitModule()
-        self.p = nn.Parameter(torch.randn(100, 100))
+        self.l = nn.Linear(100, 100, device=device)
+        self.u1 = UnitModule(device)
+        self.u2 = UnitModule(device)
+        self.p = nn.Parameter(torch.randn((100, 100), device=device))
 
     def forward(self, x):
         a = self.u2(self.u1(self.l(x)))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90400 [Composable API][Easy] Use `policy=None` since that is supported
* #90387 [Composable API] Match `fully_shard()` comm. schedule with wrapper FSDP
* **#90386 [Composable API] Refactor `test_fully_shard.py` to use common models**
* #90385 [Composable API] Move test models to common file
* #90384 [FSDP][Easy] ufmt files
* #90201 [FSDP()] Fix `fully_shard` fwd hook registration

Unlike for FSDP, where we already diverged to using per-test-file models, let us try to use the same set of models for the composable API effort. This can improve debugging efficiency because we know which module structures we support and which we do not _across all of our composable APIs_.

This PR had to perform some surgery for `test_materialize_meta_module`. Writing a correct parameter initialization function for meta device initialization is not easy, and we should revisit this. The old implementation, which followed the style of the previous unit tests--namely, using `module.to_empty()`--is actually incorrect for nested FSDP applications because `module.to_empty()` will re-initialize already materialized parameters and the module materialization proceeds bottom up. The existing unit test in `test_fsdp_meta.py` passes because it sets every parameter to ones (`self.weight.fill_(1)`), which is idempotent to re-initialization.