### PR TITLE
[Composable API] Match `fully_shard()` comm. schedule with wrapper FSDP

### DIFF
--- a/test/distributed/_composable/test_compose.py
+++ b/test/distributed/_composable/test_compose.py
@@ -122,9 +122,12 @@ class TestFSDPCheckpoint(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     def test_checkpoint_fsdp_submodules_use_reentrant(self):
+        # Escape the brackets like `\[` since `[` has special meaning in regex
         with self.assertRaisesRegex(
-            AssertionError,
-            "Expects `Tensor` to have been saved in forward",
+            RuntimeError,
+            r"setStorage: sizes \[100, 100\], strides \[100, 1\], storage "
+            "offset 0, and itemsize 4 requiring a storage size of 40000 are "
+            "out of bounds for storage of size 0",
         ):
             self._test_checkpoint_fsdp_submodules(True)
 

--- a/test/distributed/fsdp/test_fsdp_flatten_params.py
+++ b/test/distributed/fsdp/test_fsdp_flatten_params.py
@@ -147,6 +147,7 @@ class TestFlattenParams(FSDPTest):
             FlatParamHandle(
                 [],
                 module,
+                module,
                 torch.device("cuda"),
                 self._get_default_config(),
                 self.process_group,
@@ -218,6 +219,7 @@ class TestFlattenParams(FSDPTest):
         params_to_flatten = list(module.parameters())
         flat_param_handle = FlatParamHandle(
             params_to_flatten,
+            module,
             module,
             torch.device("cuda"),
             self._get_default_config(),
@@ -319,6 +321,7 @@ class TestFlattenParams(FSDPTest):
         params_to_flatten = list(module.parameters())
         flat_param_handle = FlatParamHandle(
             params_to_flatten,
+            module,
             module,
             torch.device("cuda"),
             self._get_default_config(),

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -747,7 +747,8 @@ def _catch_all_reshard(
                 continue
             free_unsharded_flat_params.append(_should_free_in_backward(state, handle))
             handles_to_reshard.append(handle)
-        _reshard(state, handles_to_reshard, free_unsharded_flat_params)
+        if handles_to_reshard:
+            _reshard(state, handles_to_reshard, free_unsharded_flat_params)
     except Exception as e:
         p_assert(
             False,
@@ -888,7 +889,9 @@ def _register_pre_forward_hooks(
         forward_handle.remove()
     state._pre_forward_handles.clear()
     for module in modules:
-        module_param_handles = state._root_module_to_handles[module]
+        if module not in state._comm_module_to_handles:
+            continue
+        module_param_handles = state._comm_module_to_handles[module]
         if module_param_handles:
             unshard_fn = functools.partial(
                 _pre_forward_unshard,
@@ -918,7 +921,9 @@ def _register_post_forward_hooks(
         forward_handle.remove()
     state._post_forward_handles.clear()
     for module in modules:
-        module_param_handles = state._root_module_to_handles[module]
+        if module not in state._comm_module_to_handles:
+            continue
+        module_param_handles = state._comm_module_to_handles[module]
         if module_param_handles:
             reshard_fn = functools.partial(
                 _post_forward_reshard,

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -24,7 +24,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 from torch.distributed.fsdp._common_utils import (
-    _get_root_modules,
     _set_fsdp_flattened,
     HandleTrainingState,
 )
@@ -167,11 +166,6 @@ class FlatParameter(nn.Parameter):
             depend on its existence in the future.
         _modules (Set[nn.Module]): Modules that contain some original parameter
             that is flattened into the ``FlatParameter``.
-        _root_modules (Set[nn.Module]): Modules in ``self._modules`` that are
-            root modules (i.e. parent-less) with respect to ``self._modules``.
-            These are the modules for which we register pre/post-forward hooks
-            in the composable code path. There will be one unshard/reshard pair
-            for each root module in this set.
 
         _shard_param_offsets (List[Tuple[int, int])): [start, end] offsets (in
             units of numel) giving this rank's part of each flattened original
@@ -271,7 +265,6 @@ class FlatParameter(nn.Parameter):
         self._modules = set(pi.module for pi in self._param_infos).union(
             set(spi.module for spi in self._shared_param_infos)
         )
-        self._root_modules = _get_root_modules(self._modules)
         assert (params is None) == (shared_params is None)
         if params is not None:
             assert shared_params is not None and len(shared_params) == len(
@@ -310,9 +303,15 @@ class FlatParamHandle:
         params (Sequence[nn.Parameter]): The parameters to use for the
             flattened parameter.
         module (nn.Module): A module that is the root of the subtree containing
-            all parameters in ``params``; for non-recursive wrapping, this must
-            be the top-level module, while for recursive wrapping, this may not
-            necessarily be the top-level module.
+            all parameters in ``params``. For the non-module-wrapper code path,
+            this should be the local FSDP root module, while for the
+            module-wrapper code path, this may not necessarily be the local
+            FSDP root module (i.e. when there is nested wrapping).
+        comm_module (nn.Module): The module responsible for the unshard/reshard
+            pair for this handle. For the non-module-wrapper code path, this
+            is what would have been ``module`` in the module-wrapper equivalent
+            wrapping, which may not be the local FSDP root module. For the
+            module-wrapper code path, this is always the same as ``module``.
         device (torch.device): The compute and communication device, which
             should be a non-CPU device. We refer to it as the compute device.
         config (HandleConfig): A config customizing the handle based on FSDP's
@@ -323,6 +322,10 @@ class FlatParamHandle:
             :class:`FlatParameter`). If ``False``, then FSDP reconstructs the
             parameter every iteration and returns the :class:`FlatParameter` s
             from ``named_parameters()``.
+
+    NOTE: We enforce that there is a single "communication module" that is
+    responsible for the unshard/reshard pair for this handle. This invariant
+    holds for both the module-wrapper and non-module-wrapper code paths.
     """
 
     ##################
@@ -332,6 +335,7 @@ class FlatParamHandle:
         self,
         params: Sequence[nn.Parameter],
         module: nn.Module,
+        comm_module: nn.Module,
         device: torch.device,
         config: HandleConfig,
         process_group: dist.ProcessGroup,
@@ -346,6 +350,7 @@ class FlatParamHandle:
         self._use_orig_params = use_orig_params
         self._training_state = HandleTrainingState.IDLE
         self._debug_level = dist.get_debug_level()
+        self._comm_module = comm_module
         self._init_flat_param(params, module, use_orig_params)
         self._use_unsharded_views(as_params=False)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90471 [Composable API][Easy] Fix some follow-ups
* #90400 [Composable API][Easy] Use `policy=None` since that is supported
* **#90387 [Composable API] Match `fully_shard()` comm. schedule with wrapper FSDP**
* #90386 [Composable API] Refactor `test_fully_shard.py` to use common models
* #90385 [Composable API] Move test models to common file
* #90384 [FSDP][Easy] ufmt files
* #90201 [FSDP()] Fix `fully_shard` fwd hook registration

- This PR introduces a new concept, the _communication module_ (denoted `comm_module`), that represents the module responsible for the unshard/reshard pair for a `FlatParamHandle`. This is well-defined because the current design assumes that each `FlatParamHandle` only has _one_ unshard/reshard pair for either the forward or backward pass.
    - For the wrapper code path, the `comm_module` is exactly the module already being passed to the `FlatParamHandle` constructor.
    - For the composable code path, the `comm_module` is not necessarily the module already being passed to the `FlatParamHandle`. This is because the module already being passed is always the local FSDP root module to give complete FQNs, instead of local FQNs. Distinguishing the communication module from the local FSDP root module can provide more flexibility for non-recursive wrapping designs in the future.
- This PR adds a unit test `test_unshard_reshard_order` that explicitly checks that `_unshard` and `_reshard` are called in the exactly the same order across the two code paths.
- This PR does not fix `test_checkpoint_fsdp_submodules_use_reentrant`. However, the error message changes, so this PR accommodates that.
    - The error is now the same as if we used the equivalent wrapper FSDP:
    ```
    test_model.u1 = FSDP(test_model.u1, use_orig_params=True)
    test_model.u2 = FSDP(test_model.u2, use_orig_params=True)
    ```
    - The error is also the same as if we used wrapper FSDP with `use_orig_params=False`, so it is not unique to `use_orig_params=True`.

---

**`comm_module` Example**

```
model = Model(
    seq1: nn.Sequential(
        nn.Linear
        nn.ReLU
        nn.Linear
        nn.ReLU
    )
    seq2: nn.Sequential(
        nn.Linear
        nn.ReLU
        nn.Linear
        nn.ReLU
    )
)
policy = ModuleWrapPolicy({nn.Sequential})
fully_shard(model, policy=policy)
FullyShardedDataParallel(model, auto_wrap_policy=policy)
```
- This policy constructs two `FlatParamHandle`s, one for `seq1` and one for `seq2`.
- `FullyShardedDataParallel` will pass `seq1` and `seq2` as the `module` argument to the two `FlatParamHandle`s, respectively.
- `fully_shard()` will pass `model` as the `module` argument to every `FlatParamHandle`.
- `FullyShardedDataParallel` will pass `seq1` and `seq2` as the `comm_module` argument to the two `FlatParamHandle`s, respectively.
- `fully_shard()` will pass `seq1` and `seq2` as the `comm_module` argument to the two `FlatParamHandle`s, respectively.
