### PR TITLE
[Composable API][Easy] Use `policy=None` since that is supported

### DIFF
--- a/test/distributed/_composable/test_compose.py
+++ b/test/distributed/_composable/test_compose.py
@@ -98,14 +98,8 @@ class TestFSDPCheckpoint(FSDPTest):
         base_model = copy.deepcopy(model)
 
         test_model = copy.deepcopy(model)
-        test_model.u1 = fully_shard(
-            test_model.u1,
-            policy=ModuleWrapPolicy({UnitModule}),
-        )
-        test_model.u2 = fully_shard(
-            test_model.u2,
-            policy=ModuleWrapPolicy({UnitModule}),
-        )
+        test_model.u1 = fully_shard(test_model.u1, policy=None)
+        test_model.u2 = fully_shard(test_model.u2, policy=None)
 
         test_model.u1.seq = checkpoint(test_model.u1.seq, use_reentrant=use_reentrant)
         test_model.u2.seq = checkpoint(test_model.u2.seq, use_reentrant=use_reentrant)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90471 [Composable API][Easy] Fix some follow-ups
* **#90400 [Composable API][Easy] Use `policy=None` since that is supported**
* #90387 [Composable API] Match `fully_shard()` comm. schedule with wrapper FSDP
* #90386 [Composable API] Refactor `test_fully_shard.py` to use common models
* #90385 [Composable API] Move test models to common file
* #90384 [FSDP][Easy] ufmt files
* #90201 [FSDP()] Fix `fully_shard` fwd hook registration

I believe that @mrshenli used `ModuleWrapPolicy({UnitModule})` when applying `fully_shard` to `UnitModule`s because `policy=None` was not supported. However, he added that support in a previous PR, so this PR simplifies to using `policy=None` to make the intention more clear.