### PR TITLE
[Dynamo][TIMM][Benchmarks] Fix TIMM `0.8.0dev` breaking the `timm_models.py` script's data config

### DIFF
--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -218,7 +218,7 @@ class TimmRunnner(BenchmarkRunner):
         self.num_classes = model.num_classes
 
         data_config = resolve_data_config(
-            vars(self._args) if timmversion > "0.7.0" else self._args,
+            vars(self._args) if timmversion >= "0.8.0" else self._args,
             model=model,
             use_test_size=not is_training,
         )

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -25,6 +25,7 @@ except ModuleNotFoundError:
     print("Installing Pytorch Image Models...")
     pip_install("git+https://github.com/rwightman/pytorch-image-models")
 finally:
+    from timm import __version__ as timmversion
     from timm.data import resolve_data_config
     from timm.models import create_model
 
@@ -217,7 +218,9 @@ class TimmRunnner(BenchmarkRunner):
         self.num_classes = model.num_classes
 
         data_config = resolve_data_config(
-            self._args, model=model, use_test_size=not is_training
+            vars(self._args) if timmversion > "0.7.0" else self._args,
+            model=model,
+            use_test_size=not is_training,
         )
         input_size = data_config["input_size"]
         recorded_batch_size = TIMM_MODELS[model_name]


### PR DESCRIPTION
It seems `0.8.0dev` breaks the current argument passing by expecting a dictionary instead of a namespace after https://github.com/rwightman/pytorch-image-models/commit/0dadb4a6e9e245c30653db2a48752423df98fa44

CC @desertfire @ngimel 

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire