### PR TITLE
Add manual cuda deps search logic

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -167,9 +167,9 @@ def _load_global_deps():
 
     try:
         ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
-    except OSError as e:
-        if 'libcublas.so.11' not in e.args[0]:
-            raise e
+    except OSError as err:
+        if 'libcublas.so.11' not in err.args[0]:
+            raise err
         _preload_cuda_deps()
         ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -142,6 +142,20 @@ if sys.platform == 'win32':
     kernel32.SetErrorMode(prev_error_mode)
 
 
+def _preload_cuda_deps():
+    # Should only be called on Linux if default path resolution have failed
+    assert platform.system() == 'Linux', 'Should only be called on Linux'
+    for path in sys.path:
+        nvidia_path = os.path.join(path, 'nvidia')
+        if not os.path.exists(nvidia_path):
+            continue
+        cublas_path = os.path.join(nvidia_path, 'cublas', 'lib', 'libcublas.so.11')
+        cudnn_path = os.path.join(nvidia_path, 'cudnn', 'lib', 'libcudnn.so.8')
+        ctypes.CDLL(cublas_path)
+        ctypes.CDLL(cudnn_path)
+        break
+
+
 # See Note [Global dependencies]
 def _load_global_deps():
     if platform.system() == 'Windows' or sys.executable == 'torch_deploy':
@@ -151,7 +165,13 @@ def _load_global_deps():
     here = os.path.abspath(__file__)
     lib_path = os.path.join(os.path.dirname(here), 'lib', lib_name)
 
-    ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
+    try:
+        ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
+    except OSError as e:
+        if 'libcublas.so.11' not in e.args[0]:
+            raise e
+        _preload_cuda_deps()
+        ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
 
 
 if (USE_RTLD_GLOBAL_WITH_LIBTORCH or os.getenv('TORCH_USE_RTLD_GLOBAL')) and \


### PR DESCRIPTION
If PyTorch is package into a wheel with [nvidia-cublas-cu11](https://pypi.org/project/nvidia-cublas-cu11/), which is designated as PureLib, but `torch` wheel is not, can cause a torch_globals loading problem.

Fix that by searching for `nvidia/cublas/lib/libcublas.so.11` an `nvidia/cudnn/lib/libcudnn.so.8` across all `sys.path` folders.

Test plan:
```
docker pull amazonlinux:2
docker run --rm -t amazonlinux:2 bash -c 'yum install -y python3 python3-devel python3-distutils patch;python3 -m pip install torch==1.13.0;curl -OL https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/90411.diff; pushd /usr/local/lib64/python3.7/site-packages; patch -p1 </90411.diff; popd; python3 -c "import torch;print(torch.__version__, torch.cuda.is_available())"'
```
Output:
```
1.13.0+cu117 True
```

Fixes https://github.com/pytorch/pytorch/issues/88869
