### PR TITLE
[SDPA] Fix alignment check for efficient_attention

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/gemm_kernel_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/gemm_kernel_utils.h
@@ -162,7 +162,7 @@ struct DefaultGemmType<
         cutlass::sizeof_bits<scalar_t>::value == 16>::type> {
   static constexpr int ThreadK = 32;
   static constexpr int WarpK = 32;
-  static constexpr int kMinimumAlignment = 4;
+  static constexpr int kMinimumAlignment = 8;
   using OpClass = cutlass::arch::OpClassTensorOp;
   using InstructionShape = cutlass::gemm::GemmShape<16, 8, 8>;
   using Operator = cutlass::arch::OpMultiplyAdd;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -204,7 +204,7 @@ inline bool check_head_dim_size_mem_efficient(sdp_params params, bool debug) {
         !debug,
         "Mem efficient attention requires last dimension of inputs to be divisible by ",
         alignment,
-        ".",
+        ". ",
         "Got Query.size(-1): ",
         query_size_last,
         ", Key.size(-1): ",

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -146,8 +146,10 @@ inline bool check_tensor_shapes(sdp_params params, bool debug) {
 
 inline bool check_head_dim_size(sdp_params params, bool debug) {
   const int64_t query_size_last = params.query.size(-1);
+  const int64_t key_size_last = params.key.size(-1);
   if (!(query_size_last == params.key.size(-1) && query_size_last % 8 == 0 &&
-        query_size_last <= 128)) {
+        query_size_last <= 128 && key_size_last % 8 == 0 &&
+        key_size_last <= 128)) {
     TORCH_CHECK(
         !debug,
         "Flash attention requires last dimension of inputs to be a multiple of 8 and less than or equal to 128.",
@@ -193,9 +195,11 @@ inline int64_t minimum_gemm_alignment(sdp_params params) {
 
 inline bool check_head_dim_size_mem_efficient(sdp_params params, bool debug) {
   const int64_t query_size_last = params.query.size(-1);
+  const int64_t key_size_last = params.key.size(-1);
   const int64_t alignment = minimum_gemm_alignment(params);
   if (!(query_size_last == params.key.size(-1) &&
-        query_size_last % alignment == 0)) {
+        query_size_last % alignment == 0 && query_size_last >= 8 &&
+        key_size_last % alignment == 0 && key_size_last >= 8)) {
     TORCH_CHECK(
         !debug,
         "Mem efficient attention requires last dimension of inputs to be divisible by ",

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -58,7 +58,7 @@ inline bool check_for_attn_weights(sdp_params params, bool debug) {
   // This can be returned form flash attention but care is needed
   // to convert from flash_attn format to attn_weights
   if (params.need_attn_weights) {
-    TORCH_CHECK(!debug, "Flash Attention does not support need attn weights");
+    TORCH_CHECK(!debug, "Both fused kernels do not support need_attn_weights=True.");
     return false;
   }
   return true;
@@ -120,7 +120,7 @@ inline bool check_requires_grad_and_nested(sdp_params params, bool debug) {
 
 inline bool check_for_attn_mask(sdp_params params, bool debug) {
   if (params.has_attn_mask) {
-    TORCH_CHECK(!debug, "Flash Attention does not support attention mask.");
+    TORCH_CHECK(!debug, "Both fused kernels do not support non-null attn_mask.");
     return false;
   }
   return true;
@@ -146,10 +146,10 @@ inline bool check_tensor_shapes(sdp_params params, bool debug) {
 
 inline bool check_head_dim_size(sdp_params params, bool debug) {
   const int64_t query_size_last = params.query.size(-1);
-  const int64_t key_size_last = params.key.size(-1);
+  const int64_t value_size_last = params.value.size(-1);
   if (!(query_size_last == params.key.size(-1) && query_size_last % 8 == 0 &&
-        query_size_last <= 128 && key_size_last % 8 == 0 &&
-        key_size_last <= 128)) {
+        query_size_last <= 128 && value_size_last % 8 == 0 &&
+        value_size_last <= 128)) {
     TORCH_CHECK(
         !debug,
         "Flash attention requires last dimension of inputs to be a multiple of 8 and less than or equal to 128.",
@@ -195,11 +195,11 @@ inline int64_t minimum_gemm_alignment(sdp_params params) {
 
 inline bool check_head_dim_size_mem_efficient(sdp_params params, bool debug) {
   const int64_t query_size_last = params.query.size(-1);
-  const int64_t key_size_last = params.key.size(-1);
+  const int64_t value_size_last = params.value.size(-1);
   const int64_t alignment = minimum_gemm_alignment(params);
   if (!(query_size_last == params.key.size(-1) &&
-        query_size_last % alignment == 0 && query_size_last >= 8 &&
-        key_size_last % alignment == 0 && key_size_last >= 8)) {
+        query_size_last % alignment == 0 && query_size_last > 0 &&
+        value_size_last % alignment == 0 && value_size_last > 0)) {
     TORCH_CHECK(
         !debug,
         "Mem efficient attention requires last dimension of inputs to be divisible by ",

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -146,8 +146,7 @@ inline bool check_tensor_shapes(sdp_params params, bool debug) {
 
 inline bool check_head_dim_size(sdp_params params, bool debug) {
   const int64_t query_size_last = params.query.size(-1);
-  if (!(query_size_last == params.key.size(-1) &&
-        query_size_last == params.value.size(-1) && query_size_last % 8 == 0 &&
+  if (!(query_size_last == params.key.size(-1) && query_size_last % 8 == 0 &&
         query_size_last <= 128)) {
     TORCH_CHECK(
         !debug,
@@ -164,13 +163,44 @@ inline bool check_head_dim_size(sdp_params params, bool debug) {
   return true;
 }
 
+inline bool use_tensor_cores(
+    sdp_params params,
+    cudaDeviceProp* dprops,
+    bool is_half) {
+  if (dprops->major >= 8) {
+    return true;
+  }
+  if (dprops->major >= 7) {
+    return is_half;
+  }
+  return false;
+}
+inline int64_t minimum_gemm_alignment(sdp_params params) {
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+  bool is_half = (params.query.dtype() == at::kHalf) ||
+      (params.query.dtype() == at::kBFloat16);
+  bool use_tc = use_tensor_cores(params, dprops, is_half);
+  int64_t matmul_alignment_mn = 1;
+  if (dprops->major >= 8) {
+    matmul_alignment_mn = 4;
+  }
+  int64_t bits_per_scalar = is_half ? 16 : 32;
+  if (use_tc) {
+    matmul_alignment_mn = std::max(matmul_alignment_mn, 128 / bits_per_scalar);
+  }
+  return matmul_alignment_mn;
+}
+
 inline bool check_head_dim_size_mem_efficient(sdp_params params, bool debug) {
   const int64_t query_size_last = params.query.size(-1);
+  const int64_t alignment = minimum_gemm_alignment(params);
   if (!(query_size_last == params.key.size(-1) &&
-        query_size_last == params.value.size(-1) && query_size_last >= 8)) {
+        query_size_last % alignment == 0)) {
     TORCH_CHECK(
         !debug,
-        "Mem efficient attention requires last dimension of inputs to be >= 8.",
+        "Mem efficient attention requires last dimension of inputs to be divisible by ",
+        alignment,
+        ".",
         "Got Query.size(-1): ",
         query_size_last,
         ", Key.size(-1): ",

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1280,6 +1280,17 @@ class TestTransformers(NNTestCase):
         model(x, x, x)
         # completes without error
 
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_unaligned_tensors(self):
+        device = 'cuda'
+        dtype = torch.float16
+        size = (2, 2, 8, 5)
+        q = torch.randn(size, device=device, dtype=dtype)
+        k = torch.randn(size, device=device, dtype=dtype)
+        v = torch.randn(size, device=device, dtype=dtype)
+        with sdp_kernel(enable_flash=False, enable_mem_efficient=True, enable_math=False):
+            self.assertRaises(RuntimeError, lambda: torch.nn.functional._scaled_dot_product_attention(
+                q, k, v, None, 0.0, False, False))
 
 # TODO: Replace this with instantiate_device_type_tests() to take advantage of test framework support for
 # cross device / dtype testing.

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1280,7 +1280,7 @@ class TestTransformers(NNTestCase):
         model(x, x, x)
         # completes without error
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @unittest.skipIf(not TEST_CUDA or not SM80OrLater, "CUDA unavailable")
     def test_unaligned_tensors(self):
         device = 'cuda'
         dtype = torch.float16

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1280,7 +1280,7 @@ class TestTransformers(NNTestCase):
         model(x, x, x)
         # completes without error
 
-    @unittest.skipIf(not TEST_CUDA or not SM80OrLater, "CUDA unavailable")
+    @unittest.skipIf(not TEST_CUDA or not SM80OrLater or TEST_WITH_ROCM, "CUDA unavailable")
     def test_unaligned_tensors(self):
         device = 'cuda'
         dtype = torch.float16

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4189,6 +4189,7 @@ new_module_tests = [
         # RuntimeError: The size of tensor a (6) must match the size of tensor b (4)
         # at non-singleton dimension 2
         check_batched_grad=False,
+        check_gradgrad=False,
     ),
     dict(
         module_name='TransformerEncoderLayer',


### PR DESCRIPTION
Fixes a bug found using head_dim_size==100 on an a100 gpu. This PR contains stricter guards on the input shape. These constraints are taken from xformers: https://github.com/facebookresearch/xformers/blob/gh/danthe3rd/60/orig/xformers/ops/fmha/cutlass.py#L23