### PR TITLE
Revert "Disable dynamo tracing torchrec.distributed (#90087)"

### DIFF
--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -146,10 +146,7 @@ def add(import_name: str):
     if isinstance(import_name, types.ModuleType):
         return add(import_name.__name__)
     assert isinstance(import_name, str)
-    try:
-        module_spec = importlib.util.find_spec(import_name)
-    except Exception:
-        return
+    module_spec = importlib.util.find_spec(import_name)
     if not module_spec:
         return
     origin = module_spec.origin
@@ -192,7 +189,6 @@ for _name in (
     "tvm",
     "fx2trt_oss",
     "xarray",
-    "torchrec.distributed",
 ):
     add(_name)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90416

This reverts commit 7e9a8a1361a090cee86544a3c029b9b4ed622e9c.

This revert fixes a torchbench dlrm amp crash.  Auto revert fails due to conflict.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire