### PR TITLE
[inductor] Fix edge case in stride matching

### DIFF
--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -409,7 +409,9 @@ class SizeVarAllocator(object):
         assert all(isinstance(v, sympy.Symbol) or v == 0 for v in vars)
         var_symbols = [v for v in vars if isinstance(v, sympy.Symbol)]
 
-        stride_symbols = [sympy.Wild(f"stride{i}") for i in range(len(var_symbols))]
+        stride_symbols = [
+            sympy.Wild(f"stride{i}", exclude=vars) for i in range(len(var_symbols))
+        ]
         var_to_stride = {v: s for v, s in zip(var_symbols, stride_symbols)}
         offset_symbol = sympy.Wild("offset")
         index_pattern = offset_symbol + sympy_dot(var_symbols, stride_symbols)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #89877
* __->__ #90434

For the example `index=371712*c0 + 352*c2 + 1`, `maybe_stride_vars`
returned `[371712, 1/c1, 352]` where `1 == (1/c1) * c1` technically matches the
pattern but is not the expected result.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire