### PR TITLE
[LTC] Overlap data creation and ir_value setting

### DIFF
--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -688,13 +688,37 @@ std::vector<Value> LazyGraphExecutor::CollectRoots(
   return roots;
 }
 
-std::vector<BackendDataPtr> LazyGraphExecutor::FetchTensorData(
+void LazyGraphExecutor::ExtractIRAndPrepareTensorData(
     std::vector<LazyTensorPtr>* tensors,
     const SyncTensorsConfig& config,
-    c10::ArrayRef<size_t> indices) {
+    c10::ArrayRef<size_t> indices,
+    std::vector<Value>& ir_values,
+    std::vector<BackendDataPtr>& tensor_data_vec) {
+  ir_values.reserve(indices.size());
+  tensor_data_vec.reserve(indices.size());
+  for (auto index : indices) {
+    LazyTensorPtr& tensor = (*tensors)[index];
+    Value ir_value = tensor->CurrentIrValue();
+    ir_values.push_back(ir_value);
+    const BackendDevice& tensor_device = tensor->GetDevice();
+    BackendDataPtr handle = getBackend()->CreateDataPlaceholder(
+        tensor_device, std::move(tensor->shape()));
+    tensor_data_vec.push_back(handle);
+    if (tensor->CurrentDataHandle() == nullptr && config.sync_ltc_data) {
+      tensor->AssignIrValue(Value());
+    }
+  }
+}
+
+std::vector<torch::lazy::BackendDataPtr> LazyGraphExecutor::SetTensorData(
+    std::vector<LazyTensorPtr>* tensors,
+    const SyncTensorsConfig& config,
+    c10::ArrayRef<size_t> indices,
+    const std::vector<BackendDataPtr>& tensor_data_vec) {
   std::vector<BackendDataPtr> tensors_data;
   tensors_data.reserve(indices.size());
-  for (auto index : indices) {
+  for (int i = 0; i < indices.size(); i++) {
+    auto index = indices[i];
     LazyTensorPtr& tensor = (*tensors)[index];
     // If the config.force_ltc_data flag is true, the purpose of this tensor
     // sync operation is to truncate the IR graph and materialize device data in
@@ -707,11 +731,12 @@ std::vector<BackendDataPtr> LazyGraphExecutor::FetchTensorData(
     // completes.
     BackendDataPtr handle = tensor->CurrentDataHandle();
     if (handle == nullptr && config.force_ltc_data) {
-      const BackendDevice& tensor_device = tensor->GetDevice();
-      handle = getBackend()->CreateDataPlaceholder(
-          tensor_device, std::move(tensor->shape()));
-
-      tensor->SetDataHandle(handle, config.sync_ltc_data);
+      handle = tensor_data_vec[i];
+      // Note: We are not using SetHandleData method here since that method
+      // resets the ir_value. We have already done the resetting as part
+      // of ExtractIRAndPrepareTensorData to overlap with previous execution.
+      tensor->data()->handle = handle;
+      tensor->data()->tensor_data = c10::nullopt;
     }
     tensors_data.emplace_back(std::move(handle));
   }
@@ -719,12 +744,11 @@ std::vector<BackendDataPtr> LazyGraphExecutor::FetchTensorData(
 }
 
 LazyGraphExecutor::PostOrderData LazyGraphExecutor::RunPostOrder(
-    const std::vector<LazyTensorPtr>& tensors,
+    const std::vector<Value>& ir_values,
     SyncTensorCollection* coll) {
   std::vector<const Node*> roots;
-  roots.reserve(coll->indices.size());
-  for (auto index : coll->indices) {
-    Value ir_value = tensors.at(index)->CurrentIrValue();
+  roots.reserve(ir_values.size());
+  for (auto ir_value : ir_values) {
     roots.push_back(ir_value.node.get());
   }
   PostOrderData po_data;
@@ -755,7 +779,8 @@ LazyGraphExecutor::PostOrderData LazyGraphExecutor::RunPostOrder(
 std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::TryRunCachedSync(
     std::vector<LazyTensorPtr>* tensors,
     SyncTensorCollection* coll,
-    PostOrderData* po_data) {
+    PostOrderData* po_data,
+    const std::vector<BackendDataPtr>& tensor_data_vec) {
   ComputationCache::TypePtr cached_computation =
       LookupCachedCompile(coll->hash);
   if (cached_computation == nullptr) {
@@ -772,21 +797,22 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::TryRunCachedSync(
       tensors,
       coll,
       std::move(po_data->parameters_data),
-      std::move(cached_computation));
+      std::move(cached_computation),
+      tensor_data_vec);
 }
 
 LazyGraphExecutor::CompilationResult LazyGraphExecutor::Compile(
     const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<std::string> devices,
     const SyncTensorCollection& coll,
-    PostOrderData* po_data) {
+    PostOrderData* po_data,
+    const std::vector<Value>& ir_values) {
   auto lowering_ctx = LoweringContext::Create(
       "SyncTensorsGraph",
       coll.device,
       po_data->post_order,
       std::move(po_data->emission_map));
-  for (auto index : coll.indices) {
-    Value ir_value = tensors[index]->CurrentIrValue();
+  for (auto ir_value : ir_values) {
     lowering_ctx->AddResult(ir_value);
   }
 
@@ -851,17 +877,23 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
     TensorCollectionBarrier(&coll);
     return nullptr;
   }
-  PostOrderData po_data = RunPostOrder(*tensors, &coll);
   DebugUtil::SaveTensorsGraphInfo(
       "ScheduleSyncTensorsGraph", *tensors, &coll.indices);
+  std::vector<Value> ir_values;
+  std::vector<BackendDataPtr> tensor_data_vec;
+  ExtractIRAndPrepareTensorData(
+      tensors, coll.config, coll.indices, ir_values, tensor_data_vec);
+  PostOrderData po_data = RunPostOrder(ir_values, &coll);
   coll.hash = HashCombine(coll.hash, Hash(po_data.parameter_sequence));
   VLOG(4) << "Parameter sequence graph hash " << HashToString(coll.hash);
-  std::shared_ptr<Async> async = TryRunCachedSync(tensors, &coll, &po_data);
+  std::shared_ptr<Async> async =
+      TryRunCachedSync(tensors, &coll, &po_data, tensor_data_vec);
   if (async != nullptr) {
     return async;
   }
 
-  CompilationResult compile_result = Compile(*tensors, devices, coll, &po_data);
+  CompilationResult compile_result =
+      Compile(*tensors, devices, coll, &po_data, ir_values);
   if (GRAPH_DUMP_ENABLED) {
     auto* comp = compile_result.computation.get();
     LOG(ERROR) << "Add a cached computation with hash " << coll.hash
@@ -880,7 +912,8 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
       tensors,
       &coll,
       std::move(compile_result.parameters_data),
-      std::move(cached_computation));
+      std::move(cached_computation),
+      tensor_data_vec);
 }
 
 std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
@@ -953,8 +986,10 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
         std::vector<LazyTensorPtr>* tensors,
         SyncTensorCollection* coll,
         std::vector<BackendDataPtr> parameters_data,
-        ComputationCache::TypePtr cached_computation) {
-  auto tensors_data = FetchTensorData(tensors, coll->config, coll->indices);
+        ComputationCache::TypePtr cached_computation,
+        const std::vector<BackendDataPtr>& tensor_data_vec) {
+  auto tensors_data =
+      SetTensorData(tensors, coll->config, coll->indices, tensor_data_vec);
   return ScheduleSyncTensorsGraph(
       coll,
       std::move(parameters_data),
@@ -1074,7 +1109,12 @@ hash_t LazyGraphExecutor::GetGraphHash(
   config.sync_ltc_data = false;
 
   auto coll = CollectSyncTensors(tensors, config);
-  auto po_data = RunPostOrder(tensors, &coll);
+  std::vector<Value> ir_values;
+  for (auto index : coll.indices) {
+    Value ir_value = tensors[index]->CurrentIrValue();
+    ir_values.push_back(ir_value);
+  }
+  auto po_data = RunPostOrder(ir_values, &coll);
   coll.hash = HashCombine(coll.hash, Hash(po_data.parameter_sequence));
   return coll.hash;
 }

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -196,24 +196,35 @@ class TORCH_API LazyGraphExecutor {
       const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<size_t> indices);
 
-  std::vector<BackendDataPtr> FetchTensorData(
+  std::vector<BackendDataPtr> SetTensorData(
       std::vector<LazyTensorPtr>* tensors,
       const SyncTensorsConfig& config,
-      c10::ArrayRef<size_t> indices);
+      c10::ArrayRef<size_t> indices,
+      const std::vector<torch::lazy::BackendDataPtr>& tensor_data_vec);
+
+  void ExtractIRAndPrepareTensorData(
+      std::vector<LazyTensorPtr>* tensors,
+      const SyncTensorsConfig& config,
+      c10::ArrayRef<size_t> indices,
+      std::vector<Value>& ir_values,
+      std::vector<BackendDataPtr>& tensor_data_vec);
 
   PostOrderData RunPostOrder(
-      const std::vector<LazyTensorPtr>& tensors,
+      const std::vector<Value>& ir_values,
       SyncTensorCollection* coll);
+
   std::shared_ptr<Async> TryRunCachedSync(
       std::vector<LazyTensorPtr>* tensors,
       SyncTensorCollection* coll,
-      PostOrderData* po_data);
+      PostOrderData* po_data,
+      const std::vector<BackendDataPtr>& tensor_data_vec);
 
   CompilationResult Compile(
       const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<std::string> devices,
       const SyncTensorCollection& coll,
-      PostOrderData* po_data);
+      PostOrderData* po_data,
+      const std::vector<Value>& ir_values);
 
   ComputationCache::TypePtr LookupCachedCompile(const hash_t& hash);
 
@@ -235,7 +246,8 @@ class TORCH_API LazyGraphExecutor {
       std::vector<LazyTensorPtr>* tensors,
       SyncTensorCollection* coll,
       std::vector<BackendDataPtr> parameters_data,
-      ComputationCache::TypePtr cached_computation);
+      ComputationCache::TypePtr cached_computation,
+      const std::vector<BackendDataPtr>& tensor_data_vec);
 
   std::vector<at::Tensor> GetTensorsFused(std::vector<LazyTensorPtr>* tensors);
 

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -123,6 +123,8 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
   // Applies the queue of operations in preparation for using the data.
   void ApplyPendingGraph();
 
+  void AssignIrValue(Value ir_value) const;
+
  private:
   LazyTensor(const at::Tensor& tensor, const BackendDevice& device);
   LazyTensor(Value ir_value, const BackendDevice& device);
@@ -132,8 +134,6 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
   std::shared_ptr<Data> data_ptr() const {
     return data_;
   }
-
-  void AssignIrValue(Value ir_value) const;
 
   void SetTensorData(at::Tensor tensor_data);
 


### PR DESCRIPTION
Summary:
Upstreaming changes from torch_xla to lazy tensor core: https://github.com/pytorch/xla/pull/4011.
It overlaps data creation and ir_value setting with previous executions.

To be noted, this is a clone of https://github.com/pytorch/pytorch/pull/87119, and the author is @aws-rhsoln.

Test Plan:
CI.