### PR TITLE
Better __repr__ for ModuleList

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -327,7 +327,7 @@ class ModuleList(Module):
 
     def __repr__(self):
         """A custom repr for ModuleList that compresses repeated module representations"""
-        list_of_reprs = [repr(item) for item in module]
+        list_of_reprs = [repr(item) for item in self]
         repeats = [1]
         repeated_blocks = [list_of_reprs[0]]
         for r in list_of_reprs[1:]:
@@ -338,7 +338,7 @@ class ModuleList(Module):
                 repeated_blocks.append(r)
 
         lines = []
-        main_str = module._get_name() + '('
+        main_str = self._get_name() + '('
         for r, b in zip(repeats, repeated_blocks):
             local_repr = f"{r} x {b}"
             local_repr = _addindent(local_repr, 2)

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -328,19 +328,25 @@ class ModuleList(Module):
     def __repr__(self):
         """A custom repr for ModuleList that compresses repeated module representations"""
         list_of_reprs = [repr(item) for item in self]
-        repeats = [1]
+        start_end_indices = [[0, 0]]
         repeated_blocks = [list_of_reprs[0]]
-        for r in list_of_reprs[1:]:
+        for i, r in enumerate(list_of_reprs[1:], 1):
             if r == repeated_blocks[-1]:
-                repeats[-1] += 1
-            else:
-                repeats.append(1)
-                repeated_blocks.append(r)
+                start_end_indices[-1][1] += 1
+                continue
+
+            start_end_indices.append([i, i])
+            repeated_blocks.append(r)
 
         lines = []
         main_str = self._get_name() + '('
-        for n, b in zip(repeats, repeated_blocks):
-            local_repr = f"{n} x {b}"
+        for (start_id, end_id), b in zip(start_end_indices, repeated_blocks):
+            local_repr = f"({start_id}) {b}"  # default repr
+
+            if start_id != end_id:
+                n = end_id - start_id + 1
+                local_repr = f"({start_id}-{end_id}) {n} x {b}"
+
             local_repr = _addindent(local_repr, 2)
             lines.append(local_repr)
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -339,8 +339,8 @@ class ModuleList(Module):
 
         lines = []
         main_str = self._get_name() + '('
-        for r, b in zip(repeats, repeated_blocks):
-            local_repr = f"{r} x {b}"
+        for n, b in zip(repeats, repeated_blocks):
+            local_repr = f"{n} x {b}"
             local_repr = _addindent(local_repr, 2)
             lines.append(local_repr)
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -15,6 +15,19 @@ __all__ = ['Container', 'Sequential', 'ModuleList', 'ModuleDict', 'ParameterList
 T = TypeVar('T', bound=Module)
 
 
+# Copied from torch.nn.modules.module, required for a cusom __repr__ for ModuleList
+def _addindent(s_, numSpaces):
+    s = s_.split('\n')
+    # don't do anything for single-line stuff
+    if len(s) == 1:
+        return s_
+    first = s.pop(0)
+    s = [(numSpaces * ' ') + line for line in s]
+    s = '\n'.join(s)
+    s = first + '\n' + s
+    return s
+
+
 class Container(Module):
 
     def __init__(self, **kwargs: Any) -> None:
@@ -311,6 +324,29 @@ class ModuleList(Module):
         for i, module in enumerate(chain(self, other)):
             combined.add_module(str(i), module)
         return combined
+
+    def __repr__(module):
+        """A custom repr for ModuleList that compresses repeated module representations"""
+        list_of_reprs = [repr(item) for item in module]
+        repeats = [1]
+        repeated_blocks = [list_of_reprs[0]]
+        for r in list_of_reprs[1:]:
+            if r == repeated_blocks[-1]:
+                repeats[-1] += 1
+            else:
+                repeats.append(1)
+                repeated_blocks.append(r)
+
+        lines = []
+        main_str = module._get_name() + '('
+        for r, b in zip(repeats, repeated_blocks):
+            local_repr = f"{r} x {b}"
+            local_repr = _addindent(local_repr, 2)
+            lines.append(local_repr)
+
+        main_str += '\n  ' + '\n  '.join(lines) + '\n'
+        main_str += ')'
+        return main_str
 
     @_copy_to_script_wrapper
     def __dir__(self):

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -344,11 +344,11 @@ class ModuleList(Module):
         lines = []
         main_str = self._get_name() + '('
         for (start_id, end_id), b in zip(start_end_indices, repeated_blocks):
-            local_repr = f"({start_id}) {b}"  # default repr
+            local_repr = f"({start_id}): {b}"  # default repr
 
             if start_id != end_id:
                 n = end_id - start_id + 1
-                local_repr = f"({start_id}-{end_id}) {n} x {b}"
+                local_repr = f"({start_id}-{end_id}): {n} x {b}"
 
             local_repr = _addindent(local_repr, 2)
             lines.append(local_repr)

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -325,7 +325,7 @@ class ModuleList(Module):
             combined.add_module(str(i), module)
         return combined
 
-    def __repr__(module):
+    def __repr__(self):
         """A custom repr for ModuleList that compresses repeated module representations"""
         list_of_reprs = [repr(item) for item in module]
         repeats = [1]

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -328,6 +328,9 @@ class ModuleList(Module):
     def __repr__(self):
         """A custom repr for ModuleList that compresses repeated module representations"""
         list_of_reprs = [repr(item) for item in self]
+        if len(list_of_reprs) == 0:
+            return self._get_name() + '()'
+
         start_end_indices = [[0, 0]]
         repeated_blocks = [list_of_reprs[0]]
         for i, r in enumerate(list_of_reprs[1:], 1):


### PR DESCRIPTION
## Problem
When models have a lot of complex repeated layers, `print(module)` output becomes unfeasible to work with. For example, current output of `__repr__` for `t5-small` is `715 ` lines long.

## Solution
Using better `__repr__` it becomes `135`. For `t5-large`, current `__repr__` prints `1411` lines. Better `__repr__` — `135`. Same numer as for t5-small, because most of the layers are just repeated. For `EleutherAI/gpt-j-6B` number of lines reduces form `483` to just `24`.

Here's how it works: when ModuleList items have exactly the same `__repr__` instead of printing both of them, it prints f`N x {repr(item)}`. Current code supports cases when the same ModuleList has multiple repeating items, which is especially useful when first/last layer of a block is different from the reset of them.

Better `__repr__` should make model prints smaller, more beautiful and significantly more useful by highlighting the difference between repeated blocks instead of losing it in a wall of text.

## Motivating real-life example.

You can try it out in this [colab notebook](https://colab.research.google.com/drive/1PscpX_K1UemIDotl2raC4QMy_pTqDq7p?usp=sharing).

Current `__repr__` of gpt-j-6b output it too big to add it to this PR description:
```
GPTJModel(
  (wte): Embedding(50400, 4096)
  (drop): Dropout(p=0.0, inplace=False)
  (h): ModuleList(
    (0): GPTJBlock(
      (ln_1): LayerNorm((4096,), eps=1e-05, elementwise_affine=True)
      (attn): GPTJAttention(
        (attn_dropout): Dropout(p=0.0, inplace=False)
        (resid_dropout): Dropout(p=0.0, inplace=False)
        (k_proj): Linear(in_features=4096, out_features=4096, bias=False)
        (v_proj): Linear(in_features=4096, out_features=4096, bias=False)
        (q_proj): Linear(in_features=4096, out_features=4096, bias=False)
        (out_proj): Linear(in_features=4096, out_features=4096, bias=False)
      )
      (mlp): GPTJMLP(
        (fc_in): Linear(in_features=4096, out_features=16384, bias=True)
        (fc_out): Linear(in_features=16384, out_features=4096, bias=True)
        (act): NewGELUActivation()
        (dropout): Dropout(p=0.0, inplace=False)
      )
    )
    (1): GPTJBlock(
      (ln_1): LayerNorm((4096,), eps=1e-05, elementwise_affine=True)
      (attn): GPTJAttention(
        (attn_dropout): Dropout(p=0.0, inplace=False)
        (resid_dropout): Dropout(p=0.0, inplace=False)
        (k_proj): Linear(in_features=4096, out_features=4096, bias=False)
        (v_proj): Linear(in_features=4096, out_features=4096, bias=False)
        (q_proj): Linear(in_features=4096, out_features=4096, bias=False)
        (out_proj): Linear(in_features=4096, out_features=4096, bias=False)
      )
      (mlp): GPTJMLP(
        (fc_in): Linear(in_features=4096, out_features=16384, bias=True)
        (fc_out): Linear(in_features=16384, out_features=4096, bias=True)
        (act): NewGELUActivation()
        (dropout): Dropout(p=0.0, inplace=False)
      )
    )
    (2): GPTJBlock(
...
```

Better `__repr__` output looks like this:
```
GPTJModel(
  (wte): Embedding(50400, 4096)
  (drop): Dropout(p=0.0, inplace=False)
  (h): ModuleList(
    (0-27): 28 x GPTJBlock(
      (ln_1): LayerNorm((4096,), eps=1e-05, elementwise_affine=True)
      (attn): GPTJAttention(
        (attn_dropout): Dropout(p=0.0, inplace=False)
        (resid_dropout): Dropout(p=0.0, inplace=False)
        (k_proj): Linear(in_features=4096, out_features=4096, bias=False)
        (v_proj): Linear(in_features=4096, out_features=4096, bias=False)
        (q_proj): Linear(in_features=4096, out_features=4096, bias=False)
        (out_proj): Linear(in_features=4096, out_features=4096, bias=False)
      )
      (mlp): GPTJMLP(
        (fc_in): Linear(in_features=4096, out_features=16384, bias=True)
        (fc_out): Linear(in_features=16384, out_features=4096, bias=True)
        (act): NewGELUActivation()
        (dropout): Dropout(p=0.0, inplace=False)
      )
    )
  )
  (ln_f): LayerNorm((4096,), eps=1e-05, elementwise_affine=True)
)
```
