### PR TITLE
[LTC] Make some LazyGraphExecutor private data structures protected

### DIFF
--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -473,7 +473,7 @@ void LazyGraphExecutor::MarkStep(const BackendDevice& device) {
   TORCH_LAZY_COUNTER("MarkStep", 1);
   DeviceContextArena::Get()->MarkStep(device);
   ScopePusher::ResetScopes();
-  g_tls_data.Reset();
+  ResetTrimCounter();
   // Move TrieCache's current pointer back to its root
   TrieCache::Get()->ResetCurrent();
 }
@@ -503,7 +503,11 @@ std::vector<at::Tensor> LazyGraphExecutor::GetTensors(
   return GetTensorsFused(tensors);
 }
 
-size_t LazyGraphExecutor::IncTrimCounter() {
+void LazyGraphExecutor::ResetTrimCounter() const {
+  g_tls_data.Reset();
+}
+
+size_t LazyGraphExecutor::IncTrimCounter() const {
   return ++g_tls_data.trim_counter;
 }
 

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -243,17 +243,18 @@ auto LazyGraphExecutor::DeviceLockerArena::Get() -> DeviceLockerArena* {
   return arena;
 }
 
-auto LazyGraphExecutor::DeviceLockerArena::GetLocker(const BackendDevice& device) -> std::shared_ptr<DeviceLocker> {
+auto LazyGraphExecutor::DeviceLockerArena::GetLocker(
+    const BackendDevice& device) -> std::shared_ptr<DeviceLocker> {
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = lockers_.find(device);
   if (it == lockers_.end()) {
-    it = lockers_.emplace(device, std::make_shared<DeviceLocker>(device))
-              .first;
+    it = lockers_.emplace(device, std::make_shared<DeviceLocker>(device)).first;
   }
   return it->second;
 }
 
-void LazyGraphExecutor::DeviceLockerArena::DeviceBarrier(const BackendDevice& device) {
+void LazyGraphExecutor::DeviceLockerArena::DeviceBarrier(
+    const BackendDevice& device) {
   auto locker = DeviceLockerArena::Get()->GetLocker(device);
   locker->Barrier();
 }
@@ -268,7 +269,8 @@ std::vector<ExceptionCleanup> LazyGraphExecutor::DeviceLockerArena::LockDevices(
   return unlocker;
 }
 
-ExceptionCleanup LazyGraphExecutor::DeviceLockerArena::LockDevice(const BackendDevice& device) {
+ExceptionCleanup LazyGraphExecutor::DeviceLockerArena::LockDevice(
+    const BackendDevice& device) {
   VLOG(4) << "Waiting on device barrier for device " << device << " ...";
   std::shared_ptr<DeviceLocker> locker;
   {
@@ -324,17 +326,20 @@ BackendDataPtr LazyGraphExecutor::DataCacheArena::GetDeviceData(
   return GetDeviceData(t, device);
 }
 
-size_t LazyGraphExecutor::DataCacheArena::TensorHasher::operator()(const at::Tensor& tensor) const {
+size_t LazyGraphExecutor::DataCacheArena::TensorHasher::operator()(
+    const at::Tensor& tensor) const {
   return HashReduce(
       HashCombine(GetEnumValue(tensor.scalar_type()), TensorHash(tensor)));
 }
 
-bool LazyGraphExecutor::DataCacheArena::TensorComparer::operator()(const at::Tensor& tensor1, const at::Tensor& tensor2)
-    const {
+bool LazyGraphExecutor::DataCacheArena::TensorComparer::operator()(
+    const at::Tensor& tensor1,
+    const at::Tensor& tensor2) const {
   return TensorCompare(tensor1, tensor2);
 }
 
-auto LazyGraphExecutor::DataCacheArena::GetDataCache(const BackendDevice& device) -> DataCache* {
+auto LazyGraphExecutor::DataCacheArena::GetDataCache(
+    const BackendDevice& device) -> DataCache* {
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = device_caches_.find(device);
   if (it == device_caches_.end()) {

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -162,24 +162,25 @@ class TORCH_API LazyGraphExecutor {
   };
 
   // Locking:
-  // We perform two kinds of operations of tensors, synchronous and asynchronous.
-  // The ApplyPendingGraph() are synchronous, as we need the device data result
-  // immediately. Before the synchronous operations can start, they need to wait
-  // that the pending asynchronous operations have completed.
-  // Synchronous operations do not hold device locks, since they are strictly
-  // sequential, dictated by the PyTorch execution order.
-  // The SyncTensorsGraph() is asynchronous, and returns immediately after having
+  // We perform two kinds of operations of tensors, synchronous and
+  // asynchronous. The ApplyPendingGraph() are synchronous, as we need the
+  // device data result immediately. Before the synchronous operations can
+  // start, they need to wait that the pending asynchronous operations have
+  // completed. Synchronous operations do not hold device locks, since they are
+  // strictly sequential, dictated by the PyTorch execution order. The
+  // SyncTensorsGraph() is asynchronous, and returns immediately after having
   // scheduled the asynchronous operation. While executing, the asynchronous
   // operations will hold locks on all the participating devices (in most common
   // cases there will be only one device).
   // Since asynchronous operations capture device locks, only one asynchronous
-  // operation can execute at the same time, on a given device. Tensor operations
-  // which send data to device do not need to hold any device locks while doing
-  // so. Only operations which _use_ device data (computations, and transfer from
-  // server) need to wait for asynchronous operations to complete (barrier).
+  // operation can execute at the same time, on a given device. Tensor
+  // operations which send data to device do not need to hold any device locks
+  // while doing so. Only operations which _use_ device data (computations, and
+  // transfer from server) need to wait for asynchronous operations to complete
+  // (barrier).
 
   class DeviceLocker {
-  public:
+   public:
     explicit DeviceLocker(BackendDevice device) : device_(std::move(device)) {}
 
     const BackendDevice& device() const {
@@ -190,7 +191,7 @@ class TORCH_API LazyGraphExecutor {
     void Unlock(std::exception_ptr exptr);
     void Barrier();
 
-  private:
+   private:
     void CheckResetException();
 
     BackendDevice device_;
@@ -201,7 +202,7 @@ class TORCH_API LazyGraphExecutor {
   };
 
   class DeviceLockerArena {
-  public:
+   public:
     static DeviceLockerArena* Get();
 
     std::shared_ptr<DeviceLocker> GetLocker(const BackendDevice& device);
@@ -213,7 +214,7 @@ class TORCH_API LazyGraphExecutor {
     std::vector<ExceptionCleanup> LockDevices(
         const std::set<BackendDevice>& devices);
 
-  private:
+   private:
     ExceptionCleanup LockDevice(const BackendDevice& device);
 
     std::mutex mutex_;
@@ -221,7 +222,7 @@ class TORCH_API LazyGraphExecutor {
   };
 
   class DataCacheArena {
-  public:
+   public:
     static DataCacheArena* Get();
 
     BackendDataPtr GetDeviceData(
@@ -233,7 +234,7 @@ class TORCH_API LazyGraphExecutor {
         at::ScalarType scalar_type,
         const BackendDevice& device);
 
-  private:
+   private:
     struct TensorHasher {
       size_t operator()(const at::Tensor& tensor) const;
     };

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -87,7 +87,7 @@ class TORCH_API LazyGraphExecutor {
   // All the tensors must be on the same device.
   std::vector<at::Tensor> GetTensors(std::vector<LazyTensorPtr>* tensors);
 
-  size_t IncTrimCounter();
+  size_t IncTrimCounter() const;
 
   // Dumps the backend specific text of the computation accumulated in the graph
   // which is attached the tensors.
@@ -160,6 +160,8 @@ class TORCH_API LazyGraphExecutor {
     std::vector<BackendDataPtr> parameters_data;
     std::vector<size_t> parameter_sequence;
   };
+
+  void ResetTrimCounter() const;
 
  private:
   struct CompilationResult {

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -161,6 +161,65 @@ class TORCH_API LazyGraphExecutor {
     std::vector<size_t> parameter_sequence;
   };
 
+  // Locking:
+  // We perform two kinds of operations of tensors, synchronous and asynchronous.
+  // The ApplyPendingGraph() are synchronous, as we need the device data result
+  // immediately. Before the synchronous operations can start, they need to wait
+  // that the pending asynchronous operations have completed.
+  // Synchronous operations do not hold device locks, since they are strictly
+  // sequential, dictated by the PyTorch execution order.
+  // The SyncTensorsGraph() is asynchronous, and returns immediately after having
+  // scheduled the asynchronous operation. While executing, the asynchronous
+  // operations will hold locks on all the participating devices (in most common
+  // cases there will be only one device).
+  // Since asynchronous operations capture device locks, only one asynchronous
+  // operation can execute at the same time, on a given device. Tensor operations
+  // which send data to device do not need to hold any device locks while doing
+  // so. Only operations which _use_ device data (computations, and transfer from
+  // server) need to wait for asynchronous operations to complete (barrier).
+
+  class DeviceLocker {
+  public:
+    explicit DeviceLocker(BackendDevice device) : device_(std::move(device)) {}
+
+    const BackendDevice& device() const {
+      return device_;
+    }
+
+    void Lock();
+    void Unlock(std::exception_ptr exptr);
+    void Barrier();
+
+  private:
+    void CheckResetException();
+
+    BackendDevice device_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    bool locked_ = false;
+    std::exception_ptr exptr_;
+  };
+
+  class DeviceLockerArena {
+  public:
+    static DeviceLockerArena* Get();
+
+    std::shared_ptr<DeviceLocker> GetLocker(const BackendDevice& device);
+
+    void DeviceBarrier(const BackendDevice& device);
+
+    // Use a set to impose an order on the device locking sequence (ABBA
+    // prevention).
+    std::vector<ExceptionCleanup> LockDevices(
+        const std::set<BackendDevice>& devices);
+
+  private:
+    ExceptionCleanup LockDevice(const BackendDevice& device);
+
+    std::mutex mutex_;
+    std::map<BackendDevice, std::shared_ptr<DeviceLocker>> lockers_;
+  };
+
   void ResetTrimCounter() const;
 
  private:


### PR DESCRIPTION
Summary:
This pull request makes some LazyGraphExecutor private data structures protected such that XLAGraphExecutor can reuse them.

Here is the list:
1. DeviceLocker.
2. DeviceLockerArena.
3. DataCacheArena.

In addition, it also introduces LazyGraphExecutor::ResetTrimCounter() such that XLAGraphExecutor can reuse the trim counter.

Test Plan:
CI.
