### PR TITLE
[Composable API][Easy] Fix some follow-ups

### DIFF
--- a/test/distributed/_composable/test_compose.py
+++ b/test/distributed/_composable/test_compose.py
@@ -99,7 +99,7 @@ class TestFSDPCheckpoint(FSDPTest):
 
         test_model = copy.deepcopy(model)
         test_model.u1 = fully_shard(test_model.u1, policy=None)
-        test_model.u2 = fully_shard(test_model.u2, policy=None)
+        test_model.u2 = fully_shard(test_model.u2)
 
         test_model.u1.seq = checkpoint(test_model.u1.seq, use_reentrant=use_reentrant)
         test_model.u2.seq = checkpoint(test_model.u2.seq, use_reentrant=use_reentrant)

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -889,9 +889,7 @@ def _register_pre_forward_hooks(
         forward_handle.remove()
     state._pre_forward_handles.clear()
     for module in modules:
-        if module not in state._comm_module_to_handles:
-            continue
-        module_param_handles = state._comm_module_to_handles[module]
+        module_param_handles = state._comm_module_to_handles.get(module, [])
         if module_param_handles:
             unshard_fn = functools.partial(
                 _pre_forward_unshard,
@@ -921,9 +919,7 @@ def _register_post_forward_hooks(
         forward_handle.remove()
     state._post_forward_handles.clear()
     for module in modules:
-        if module not in state._comm_module_to_handles:
-            continue
-        module_param_handles = state._comm_module_to_handles[module]
+        module_param_handles = state._comm_module_to_handles.get(module, [])
         if module_param_handles:
             reshard_fn = functools.partial(
                 _post_forward_reshard,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#90471 [Composable API][Easy] Fix some follow-ups**
* #90400 [Composable API][Easy] Use `policy=None` since that is supported
* #90387 [Composable API] Match `fully_shard()` comm. schedule with wrapper FSDP
* #90386 [Composable API] Refactor `test_fully_shard.py` to use common models
* #90385 [Composable API] Move test models to common file
* #90384 [FSDP][Easy] ufmt files
* #90201 [FSDP()] Fix `fully_shard` fwd hook registration

