### PR TITLE
Emit torch.cuda.synchronize() after every kernel call in inductor

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1370,6 +1370,9 @@ class CppScheduling:
 
         kernel_group.finalize_kernel(cpp_kernel_proxy, None)
 
+    def codegen_sync(self):
+        pass
+
     def flush(self):
         self.kernel_group.codegen_define_and_call(V.graph.wrapper_code)
         self.get_kernel_group()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1353,6 +1353,9 @@ class TritonScheduling:
         kernel.call_kernel(wrapper, kernel_name)
         self.scheduler.free_buffers()
 
+    def codegen_sync(self):
+        V.graph.wrapper_code.writeline("torch.cuda.synchronize()")
+
     @staticmethod
     @functools.lru_cache(32)
     def candidate_tilings(node):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -323,6 +323,8 @@ class WrapperCodeGen(CodeGen):
             """
         )
         with self.wrapper_call.indent():
+            if config.triton.debug_sync_graph:
+                self.wrapper_call.writeline("torch.cuda.synchronize()")
             inp_len = len(V.graph.graph_inputs.keys())
             if inp_len != 0:
                 lhs = f"{', '.join(V.graph.graph_inputs.keys())}{'' if inp_len != 1 else ','}"
@@ -469,6 +471,8 @@ class WrapperCodeGen(CodeGen):
                     self.wrapper_call.writeline(line)
 
             output_refs = [x.codegen_reference() for x in V.graph.graph_outputs]
+            if config.triton.debug_sync_graph:
+                self.wrapper_call.writeline("torch.cuda.synchronize()")
             self.generate_return(output_refs)
 
         with result.indent():

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -132,6 +132,12 @@ class triton:
     # Use cudagraphs on output code
     cudagraphs = True
 
+    # Synchronize before and after every compiled graph.
+    debug_sync_graph = False
+
+    # Synchronize after every kernel launch, to help pinpoint bugs
+    debug_sync_kernel = False
+
     # choose conv backend, "aten" or "triton" or "autotune"
     convolution = "aten"
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1131,6 +1131,9 @@ class Scheduler:
                 assert isinstance(node, NopKernelSchedulerNode)
                 node.allocate()
 
+            if config.triton.debug_sync_kernel:
+                self.get_backend(device).codegen_sync()
+
             self.available_buffer_names.update(node.get_names())
 
         self.flush()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #90474
* #90473
* __->__ #90472



Debugging illegal memory access is hard; even CUDA_LAUNCH_BLOCKING=1
and using C10_CUDA_KERNEL_LAUNCH_CHECK doesn't guarantee a useful stack trace.
doesn't necessarily guarantee that you'll get a stack trace pointing to the
right kernel.  This diff adds a config option to force a CUDA synchronize after
every kernel call in inductor, for debugging those tricky cases.

Differential Revision: [D41744967](https://our.internmc.facebook.com/intern/diff/D41744967/)

Differential Revision: [D41744967](https://our.internmc.facebook.com/intern/diff/D41744967)

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire