### PR TITLE
[pt2] Reset dynamo log level when exiting inductor debug context

### DIFF
--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -233,6 +233,10 @@ class DebugContext:
             dynamo_utils.init_logging()
 
         if config.debug:
+            def reset_log_level(level):
+                dynamo_config.log_level = level
+
+            self._stack.callback(reset_log_level, dynamo_config.log_level)
             dynamo_config.log_level = logging.DEBUG
 
         self._stack.enter_context(V.set_debug_handler(self))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #90474
* __->__ #90473
* #90472



When entering an inductor debug context we increase the log level of
dynamo; I guess this makes sense, since if we're debugging inductor, and
inductor calls into dynamo, we probably want visibility into what dynamo is
doing.

But when we exit that context, we probably want to go back to whatever level of
dynamo-specific logging was in place before.  Dynamo generates lots of debug
info (guards, bytecode), and it's a lot to sift through if you're not
specifically interested in it.

Differential Revision: [D41841879](https://our.internmc.facebook.com/intern/diff/D41841879/)

Differential Revision: [D41841879](https://our.internmc.facebook.com/intern/diff/D41841879)

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire