### PR TITLE
[pthreadpool] Don't recreate threadpool if the counts are same

### DIFF
--- a/caffe2/utils/threadpool/pthreadpool-cpp.cc
+++ b/caffe2/utils/threadpool/pthreadpool-cpp.cc
@@ -30,6 +30,11 @@ size_t PThreadPool::get_thread_count() const {
 }
 
 void PThreadPool::set_thread_count(const size_t thread_count) {
+  // No need to do anything if the count is same
+  if (thread_count == get_thread_count()) {
+    return;
+  }
+
   std::lock_guard<std::mutex> lock{mutex_};
 
   // As it stands, pthreadpool is an entirely data parallel framework with no


### PR DESCRIPTION
Summary: Don't do anything if the incoming count and current threadpool size are same

Test Plan: CI

Reviewed By: salilsdesai

Differential Revision: D41628132

