### PR TITLE
Fix non-existing parameters in docstrings

### DIFF
--- a/caffe2/python/dataio.py
+++ b/caffe2/python/dataio.py
@@ -52,8 +52,8 @@ class Reader(object):
         """Setup nets to run at task initialization and cleanup time.
 
         Args:
-            global_init_net: A net invoked at task init time.
-            global_finish_net: A net invoked at task cleanup time.
+            init_net: A net invoked at task init time.
+            finish_net: A net invoked at task cleanup time.
         """
         pass
 

--- a/torch/ao/nn/quantized/modules/conv.py
+++ b/torch/ao/nn/quantized/modules/conv.py
@@ -245,8 +245,8 @@ class _ConvNd(WeightedQuantizedModule):
     def from_reference(cls, ref_qconv, output_scale, output_zero_point):
         r"""Create a (fbgemm/qnnpack) quantized module from a reference quantized module
         Args:
-            ref_module (Module): a reference quantized  module, either produced by torch.ao.quantization
-                          utilities or provided by the user
+            ref_qconv (Module): a reference quantized  module, either produced by torch.ao.quantization
+                                utilities or provided by the user
             output_scale (float): scale for output Tensor
             output_zero_point (int): zero point for output Tensor
         """
@@ -635,8 +635,8 @@ class _ConvTransposeNd(_ConvNd):
     def from_reference(cls, ref_qconvt, output_scale, output_zero_point):
         r"""Create a (fbgemm/qnnpack) quantized module from a reference quantized module
         Args:
-            ref_module (Module): a reference quantized  module, either produced by torch.ao.quantization
-                          utilities or provided by the user
+            ref_qconvt (Module): a reference quantized  module, either produced by torch.ao.quantization
+                                 utilities or provided by the user
             output_scale (float): scale for output Tensor
             output_zero_point (int): zero point for output Tensor
         """

--- a/torch/ao/ns/_numeric_suite_fx.py
+++ b/torch/ao/ns/_numeric_suite_fx.py
@@ -479,9 +479,9 @@ def add_loggers(
     Instrument model A and model B with loggers.
 
     Args:
-        model_name_a: string name of model A to use in results
+        name_a: string name of model A to use in results
         model_a: model A
-        model_name_b: string name of model B to use in results
+        name_b: string name of model B to use in results
         model_b: model B
         logger_cls: class of Logger to use
         base_name_to_sets_of_related_ops: optional override of subgraph base nodes, subject to change
@@ -635,9 +635,9 @@ def add_shadow_loggers(
     Instrument model A and model B with shadow loggers.
 
     Args:
-        model_name_a: string name of model A to use in results
+        name_a: string name of model A to use in results
         model_a: model A
-        model_name_b: string name of model B to use in results
+        name_b: string name of model B to use in results
         model_b: model B
         logger_cls: class of Logger to use
         should_log_inputs: whether to log inputs

--- a/torch/ao/quantization/fx/_model_report/detector.py
+++ b/torch/ao/quantization/fx/_model_report/detector.py
@@ -282,7 +282,7 @@ class PerChannelDetector(DetectorBase):
         Each entry maps the fully-qualified-name to information on whether per_channel quantization.
 
         Args:
-            module: The current module that is being checked to see if it is per_channel qunatizable
+            model: The current module that is being checked to see if it is per_channel quantizable
 
         Returns dictionary mapping fqns to if per_channel quantization is possible
         """

--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -73,10 +73,10 @@ def replicate(
     module: nn.Module,  # NOTE: contract now supports single module only
     **kwargs,
 ) -> nn.Module:
-    r"""Replicates module(s)
+    r"""Replicates a module
 
     Args:
-        modules (torch.nn.Module): modules to replicate
+        module (torch.nn.Module): module to replicate
 
     Example::
         >>> module = nn.Linear(3, 3)

--- a/torch/distributed/_shard/sharded_tensor/reshard.py
+++ b/torch/distributed/_shard/sharded_tensor/reshard.py
@@ -101,7 +101,7 @@ def reshuffle_local_shard(
     the new shard directly based on the resharding spec.
 
     Args:
-        local_tensor (Tensor): Local tensor stored in the current rank.
+        local_shard (Tensor): Local tensor stored in the current rank.
         st_size (torch.Size): The size of the sharded tensor.
         sharding_spec (:class:`torch.distributed._shard.sharding_spec.ShardingSpec`): The
             specification describing how the tensor is sharded originally.

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -270,11 +270,11 @@ class DeviceMesh(object):
         scatter a list of tensors to a device mesh dimension. We by default
         use the first rank of the mesh dimension as the source of truth, i.e
         for a 2d mesh [[0, 1], [2, 3]], if we scatter on mesh_dim = 1, we will
-        scatter the tensor list on rank 0 to rank 0/1, and tensor lista on rank
+        scatter the tensor list on rank 0 to rank 0/1, and tensor list on rank
         2 to rank 2/3.
 
         Args:
-            tensor (torch.Tensor): the tensor to receive the scattered list.
+            output (torch.Tensor): the tensor to receive the scattered list.
             scatter_list (List[torch.Tensor]): the tensor list to be scattered.
             mesh_dim (int, optional): indicate which mesh dimension we want
                 to scatter on, we by default choose the first rank on the

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -162,7 +162,7 @@ def all_to_all(output_tensor_list, input_tensor_list, group=group.WORLD):
     return gathered list of tensors in output list.
 
     Arguments:
-        out_tensor_list (list[Tensor]): list of tensors to gather one per rank.
+        output_tensor_list (list[Tensor]): list of tensors to gather one per rank.
         input_tensor_list (list[Tensor]): List of tensors to scatter one per rank.
         group (ProcessGroup, optional): The process group to work on.
 

--- a/torch/distributed/rpc/options.py
+++ b/torch/distributed/rpc/options.py
@@ -108,12 +108,12 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
         device placement configurations.
 
         Args:
-            worker_name (str): Callee name.
+            to (str): Callee name.
             device_map (Dict of int, str, or torch.device): Device placement
                 mappings from this worker to the callee. This map must be
                 invertible.
 
-        Example::
+        Example:
             >>> # xdoctest: +SKIP("distributed")
             >>> # both workers
             >>> def add(x, y):

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -379,7 +379,7 @@ def _args_kwargs_to_normalized_args_kwargs(sig : inspect.Signature, args : Tuple
 
     Args:
 
-        target (inspect.Signature): Signature object for the target
+        sig (inspect.Signature): Signature object for the target
         args (Tuple): Arguments that appear at the callsite for `target`
         kwargs (Dict): Keyword arguments that appear at the callsite for `target`
         normalize_to_only_use_kwargs (bool): Whether to normalize to only use kwargs.

--- a/torch/fx/passes/operator_support.py
+++ b/torch/fx/passes/operator_support.py
@@ -67,8 +67,8 @@ class OperatorSupport(OperatorSupportBase):
     ) -> bool:
         """
         Args:
-            `sumodules`: mapping from module name to the module. This can be
-                         retrieved by calling model.named_modules().
+            `submodules`: mapping from module name to the module. This can be
+                          retrieved by calling model.named_modules().
 
             `node`: a Fx node that we want to determine whether it's supported.
 

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -198,9 +198,10 @@ def replace_pattern_with_filters(
     See replace_pattern for documentation. This function is an overload with an additional match_filter argument.
 
     Args:
-        ``match_filter``: A function that takes in (match: InternalMatch, original_graph: Graph, pattern_graph: Graph)
-            and returns a boolean indicating whether the match satisfies the condition. See matcher_utils.py for
-            definition of InternalMatch.
+        ``match_filters``: A list of functions that take in
+            (match: InternalMatch, original_graph: Graph, pattern_graph: Graph) and return a boolean indicating
+            whether the match satisfies the condition.
+            See matcher_utils.py for definition of InternalMatch.
     """
 
     return _replace_pattern(gm, pattern, replacement, match_filters)

--- a/torch/jit/_async.py
+++ b/torch/jit/_async.py
@@ -89,7 +89,7 @@ def wait(future):
     Forces completion of a `torch.jit.Future[T]` asynchronous task, returning the
     result of the task. See :func:`~fork` for docs and examples.
     Args:
-        func (torch.jit.Future[T]): an asynchronous task reference, created through `torch.jit.fork`
+        future (torch.jit.Future[T]): an asynchronous task reference, created through `torch.jit.fork`
     Returns:
         `T`: the return value of the the completed task
     """

--- a/torch/onnx/_internal/jit_utils.py
+++ b/torch/onnx/_internal/jit_utils.py
@@ -207,7 +207,7 @@ def _add_op(
     This function is monkey-patched onto Graph.
 
     Args:
-        g: The Torch Graph or Block.
+        graph_context: The Torch Graph or Block.
         opname: The ONNX operator name, e.g., `Abs` or `Add`, or an operator qualified
             with a namespace, e.g., `aten::add`.
         args: The inputs to the operator; usually provided

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1689,7 +1689,7 @@ def resolve_name(f):
 
     Arguments
     ---------
-    callable : Callable
+    f : Callable
         Function to resolve the name of.
 
     Returns

--- a/torch/utils/tensorboard/_utils.py
+++ b/torch/utils/tensorboard/_utils.py
@@ -8,7 +8,7 @@ def figure_to_image(figures, close=True):
     Note that this requires the ``matplotlib`` package.
 
     Args:
-        figure (matplotlib.pyplot.figure) or list of figures: figure or a list of figures
+        figures (matplotlib.pyplot.figure or list of figures): figure or a list of figures
         close (bool): Flag to automatically close the figure
 
     Returns:


### PR DESCRIPTION
Continuation after https://github.com/pytorch/pytorch/pull/90163.

Here is a script I used to find all the non-existing arguments in the docstrings (the script can give false positives in presence of *args/**kwargs or decorators):

_Edit:_ 
I've realized that the indentation is wrong for the last `break` in the script, so the script only gives output for a function if the first docstring argument is wrong. I'll create a separate PR if I find more issues with corrected script.

``` python
import ast
import os
import docstring_parser

for root, dirs, files in os.walk('.'):
    for name in files:
        if root.startswith("./.git/") or root.startswith("./third_party/"):
            continue
        if name.endswith(".py"):
            full_name = os.path.join(root, name)
            with open(full_name, "r") as source:
                tree = ast.parse(source.read())
                for node in ast.walk(tree):
                    if isinstance(node, ast.FunctionDef):
                        all_node_args = node.args.args
                        if node.args.vararg is not None:
                            all_node_args.append(node.args.vararg)
                        if node.args.kwarg is not None:
                            all_node_args.append(node.args.kwarg)
                        if node.args.posonlyargs is not None:
                            all_node_args.extend(node.args.posonlyargs)
                        if node.args.kwonlyargs is not None:
                            all_node_args.extend(node.args.kwonlyargs)
                        args = [a.arg for a in all_node_args]
                        docstring = docstring_parser.parse(ast.get_docstring(node))
                        doc_args = [a.arg_name for a in docstring.params]
                        clean_doc_args = []
                        for a in doc_args:
                            clean_a = ""
                            for c in a.split()[0]:
                                if c.isalnum() or c == '_':
                                    clean_a += c
                            if clean_a:
                                clean_doc_args.append(clean_a)
                        doc_args = clean_doc_args
                        for a in doc_args:
                            if a not in args:
                                print(full_name, node.lineno, args, doc_args)
                            break

```