### PR TITLE
[1.13.1] Update XLA pin

### DIFF
--- a/.github/ci_commit_pins/xla.txt
+++ b/.github/ci_commit_pins/xla.txt
@@ -1,1 +1,1 @@
-f2b36df6a1a80137eff7644e6d0f4eeb7ff429d6
+r1.13


### PR DESCRIPTION
We should have updated both when branch was created
TODO:
 - Update the release runbook (cc: @atalman )