### PR TITLE
[reland] add save and load stats in memory_tracker

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,5 +1,5 @@
 # Owner(s): ["oncall: distributed"]
-
+import os
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
     TestCase,
@@ -52,7 +52,12 @@ class TestMemoryTracker(TestCase):
 
         self.assertTrue(len(tracker._hooks) == 0)
 
+        path = "memory.trace"
+        tracker.save_stats(path)
+        tracker.load(path)
         tracker.summary()
+        if os.path.exists(path):
+            os.remove(path)
 
         self.assertTrue(tracker._op_index > 0)
         self.assertTrue(len(tracker._operator_names) > 0)

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+import pickle
+
 from typing import (
     Any,
     Callable,
@@ -74,15 +76,9 @@ class MemoryTracker:
         torch._C._log_api_usage_once("torch.distributed.memory_tracker")
         self._hooks: List[RemovableHandle] = []
         self._operator_names: Dict[str, int] = defaultdict(int)
-        self.memories_allocated: Dict[int, Dict[str, float]] = defaultdict(
-            lambda: defaultdict(float)
-        )
-        self.memories_active: Dict[int, Dict[str, float]] = defaultdict(
-            lambda: defaultdict(float)
-        )
-        self.memories_reserved: Dict[int, Dict[str, float]] = defaultdict(
-            lambda: defaultdict(float)
-        )
+        self.memories_allocated: Dict[int, Dict[str, float]] = defaultdict()
+        self.memories_active: Dict[int, Dict[str, float]] = defaultdict()
+        self.memories_reserved: Dict[int, Dict[str, float]] = defaultdict()
         self._markers: Dict[str, int] = defaultdict(int)
         self._cur_module_name: str = ""
         self._op_index: int = 0
@@ -179,6 +175,34 @@ class MemoryTracker:
                     [marker, marker], [min_val, max_val], "k-", lw=2, label=marker_name
                 )
         plt.legend()
+
+    def save_stats(self, path: str) -> None:
+        """
+        Save the stats using pickle during runtime if users want to plot the traces
+        in other places like notebook.
+        """
+        stats = {
+            "memories_allocated": self.memories_allocated,
+            "memories_active": self.memories_active,
+            "memories_reserved": self.memories_reserved,
+            "markers": self._markers,
+        }
+
+        with open(path, "wb") as f:
+            pickle.dump(stats, f)
+
+    def load(self, path: str) -> None:
+        """
+        Load the pickled memory stats to plot the traces or print the summary.
+        """
+
+        with open(path, "rb") as f:
+            stats = pickle.load(f)
+
+        self.memories_allocated = stats["memories_allocated"]
+        self.memories_active = stats["memories_active"]
+        self.memories_reserved = stats["memories_reserved"]
+        self._markers = stats["markers"]
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """


### PR DESCRIPTION
reland https://github.com/pytorch/pytorch/pull/90144, this PR removed temporary path "memory.trace" in the unit test