### PR TITLE
[FSDP] Allow nested FSDP wrapper to use different mixed precision

### DIFF
--- a/test/distributed/_composable/test_fully_shard.py
+++ b/test/distributed/_composable/test_fully_shard.py
@@ -16,13 +16,17 @@ from torch.distributed.fsdp._common_utils import (
     _FSDPState,
     _is_fsdp_flattened,
 )
+from torch.distributed.fsdp.api import MixedPrecision
 from torch.distributed.fsdp.flat_param import _HandlesKey, FlatParamHandle
 from torch.distributed.fsdp.wrap import _FSDPPolicy, ModuleWrapPolicy
 from torch.testing._internal.common_dist_composable import (
     CompositeParamModel,
     UnitModule,
 )
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_distributed import (
+    ModelWithCheckPrecisionModule,
+    skip_if_lt_x_gpu,
+)
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
 
@@ -405,6 +409,43 @@ class TestFSDPRuntime(FSDPTest):
             self.assertEqual(len(composable_fqns), len(wrapped_fqns))
             for composable_fqn, wrapped_fqn in zip(composable_fqns, wrapped_fqns):
                 self.assertTrue(composable_fqn.endswith(wrapped_fqn))
+
+
+class TestMixedPrecision(FSDPTest):
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+
+class TestFSDPDifferentSubmodulePrecision(FSDPTest):
+    @property
+    def world_size(self):
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_float16_on_one_submodule(self):
+        forward_inputs: Dict[str, nn.Module] = {}
+        float16 = MixedPrecision(param_dtype=torch.float16)
+
+        model = ModelWithCheckPrecisionModule(forward_inputs).cuda()
+        c1, c2 = model.c1, model.c2
+        x = torch.zeros(2, 100, device="cuda")
+
+        # float16 on one submodule and float32 on everything else
+        model.c2 = fully_shard(model.c2, mixed_precision=float16)
+        fsdp = fully_shard(model)
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "cannot assign 'torch.cuda.FloatTensor' as parameter 'weight'",
+        ):
+            # FIXME: fully_shard() does not support nested wrapping yet.
+            fsdp(x).sum().backward()
+
+            self.assertEqual(forward_inputs[model].dtype, torch.float32)
+            self.assertEqual(forward_inputs[c1].dtype, torch.float32)
+            self.assertEqual(forward_inputs[c2].dtype, torch.float16)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/test_fully_shard.py
+++ b/test/distributed/_composable/test_fully_shard.py
@@ -24,7 +24,7 @@ from torch.testing._internal.common_dist_composable import (
     UnitModule,
 )
 from torch.testing._internal.common_distributed import (
-    ModelWithCheckPrecisionModule,
+    SaveForwardInputsModel,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_fsdp import FSDPTest
@@ -414,12 +414,6 @@ class TestFSDPRuntime(FSDPTest):
 class TestMixedPrecision(FSDPTest):
 
     @property
-    def world_size(self) -> int:
-        return 2
-
-
-class TestFSDPDifferentSubmodulePrecision(FSDPTest):
-    @property
     def world_size(self):
         return 2
 
@@ -428,7 +422,7 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
         forward_inputs: Dict[str, nn.Module] = {}
         float16 = MixedPrecision(param_dtype=torch.float16)
 
-        model = ModelWithCheckPrecisionModule(forward_inputs).cuda()
+        model = SaveForwardInputsModel(forward_inputs).cuda()
         c1, c2 = model.c1, model.c2
         x = torch.zeros(2, 100, device="cuda")
 

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -23,7 +23,7 @@ from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy
 from torch.nn.modules.batchnorm import _BatchNorm
 from torch.testing._internal.common_cuda import CUDA11OrLater
 from torch.testing._internal.common_distributed import (
-    ModelWithCheckPrecisionModule,
+    SaveForwardInputsModel,
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_fsdp import (
@@ -818,7 +818,7 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
         forward_inputs: Dict[str, nn.Module] = {}
         float16 = MixedPrecision(param_dtype=torch.float16)
 
-        model = ModelWithCheckPrecisionModule(forward_inputs).cuda()
+        model = SaveForwardInputsModel(forward_inputs).cuda()
         c1, c2 = model.c1, model.c2
         x = torch.zeros(2, 100, device="cuda")
 

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -266,7 +266,7 @@ def _pre_forward(
     handles: List[FlatParamHandle],
     unshard_fn: Callable,
     module: nn.Module,
-    args: Tuple[Any],
+    args: Tuple[Any, ...],
     kwargs: Dict[str, Any],
 ) -> Tuple[Tuple[Any], Dict[str, Any]]:
     """
@@ -282,7 +282,7 @@ def _pre_forward(
             sharded parameters or ``None`` to not do any unsharding.
         module (nn.Module): Module whose forward this method runs right before;
             expected by the hook signature.
-        args (Tuple[Any]): Module forward ``args``.
+        args (Tuple[Any, ...]): Module forward ``args``.
         kwargs (Dict[str, Any]): Module forward ``kwargs``.
     """
     state.training_state = TrainingState.FORWARD_BACKWARD
@@ -451,7 +451,7 @@ def _cast_fp_inputs_to_dtype(
     """
 
     def cast_fn(x: torch.Tensor) -> torch.Tensor:
-        if not torch.is_floating_point(x):
+        if not torch.is_floating_point(x) or x.dtype == dtype:
             return x
         y = x.to(dtype)
         # Explicitly copy over `requires_grad` since this runs inside

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -699,12 +699,12 @@ class FullyShardedDataParallel(nn.Module):
         with torch.autograd.profiler.record_function(
             "FullyShardedDataParallel.forward"
         ):
-            args, kwargs = _root_pre_forward(self, self, args, kwargs)
             unused = None
+            _root_pre_forward(self, self, unused)
             unshard_fn = functools.partial(_pre_forward_unshard, self, self._handles)
             reshard_fn = functools.partial(_post_forward_reshard, self, self._handles)
-            _pre_forward(
-                self, self._handles, unshard_fn, self._fsdp_wrapped_module, unused
+            args, kwargs = _pre_forward(
+                self, self._handles, unshard_fn, self._fsdp_wrapped_module, args, kwargs
             )
             for handle in self._handles:
                 p_assert(

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -16,11 +16,12 @@ from datetime import timedelta
 from enum import Enum
 from functools import partial, reduce, wraps
 from io import StringIO
-from typing import NamedTuple, Optional, Union
+from typing import Dict, NamedTuple, Optional, Union
 
 import torch
 import torch.cuda.nccl
 import torch.distributed as c10d
+import torch.nn as nn
 from torch.testing._internal.common_utils import (
     FILE_SCHEMA,
     find_free_port,
@@ -953,3 +954,26 @@ class MultiThreadedTestCase(TestCase):
     @property
     def world_size(self) -> int:
         raise RuntimeError("world size not implemented")
+
+
+class CheckPrecisionModule(nn.Module):
+    def __init__(self, forward_inputs: Dict[nn.Module, torch.Tensor]) -> None:
+        super().__init__()
+        self.l = nn.Linear(100, 100)
+        self.forward_inputs = forward_inputs
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self.forward_inputs[self] = x
+        return self.l(x)
+
+
+class ModelWithCheckPrecisionModule(nn.Module):
+    def __init__(self, forward_inputs: Dict[nn.Module, torch.Tensor]) -> None:
+        super().__init__()
+        self.c1 = CheckPrecisionModule(forward_inputs)
+        self.c2 = CheckPrecisionModule(forward_inputs)
+        self.forward_inputs = forward_inputs
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self.forward_inputs[self] = x
+        return self.c2(self.c1(x))

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -956,7 +956,7 @@ class MultiThreadedTestCase(TestCase):
         raise RuntimeError("world size not implemented")
 
 
-class CheckPrecisionModule(nn.Module):
+class SaveForwardInputsModule(nn.Module):
     def __init__(self, forward_inputs: Dict[nn.Module, torch.Tensor]) -> None:
         super().__init__()
         self.l = nn.Linear(100, 100)
@@ -967,11 +967,11 @@ class CheckPrecisionModule(nn.Module):
         return self.l(x)
 
 
-class ModelWithCheckPrecisionModule(nn.Module):
+class SaveForwardInputsModel(nn.Module):
     def __init__(self, forward_inputs: Dict[nn.Module, torch.Tensor]) -> None:
         super().__init__()
-        self.c1 = CheckPrecisionModule(forward_inputs)
-        self.c2 = CheckPrecisionModule(forward_inputs)
+        self.c1 = SaveForwardInputsModule(forward_inputs)
+        self.c2 = SaveForwardInputsModule(forward_inputs)
         self.forward_inputs = forward_inputs
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90523

The main change is to move `args` and `kwargs` dtype convertion
from `_root_pre_forward` to `_pre_forward`, so that every
FSDP has a chance to apply its own precision.

Differential Revision: [D41883717](https://our.internmc.facebook.com/intern/diff/D41883717)