### PR TITLE
Make ops returning non-tensor unimplemented

### DIFF
--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -1,0 +1,1 @@
+functorch/test_vmap.py

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -889,7 +889,7 @@ def wrap_fx_proxy_cls(
         proxy.node.meta["example_value"] = example_value
         return DynamicShapeVariable(proxy, example_value, **options)
     else:
-        raise AssertionError(
+        unimplemented(
             "torch.* op returned non-Tensor "
             + f"{typestr(example_value)} {proxy.node.op} {proxy.node.target}"
         )


### PR DESCRIPTION
Summary: Make ops returning non-tensor unimplemented

Test Plan: ci/cd

Differential Revision: D41881199



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire