### PR TITLE
Make test_binary_shape_functions actually test the ops

### DIFF
--- a/test/jit/test_symbolic_shape_analysis.py
+++ b/test/jit/test_symbolic_shape_analysis.py
@@ -163,7 +163,6 @@ class TestSymbolicShapeAnalysis(JitTestCase):
             inputs[1].setType(inputs[1].type().with_sizes(size_2))
             torch._C._jit_pass_propagate_shapes_on_graph(t.graph)
             self.assertEqual(next(t.graph.outputs()).type().symbolic_sizes(), [4, 4, 8])
-            break
 
     def test_binary_shape_fns_inplace(self):
         def div_inplace_tensor(x: torch.Tensor, y: torch.Tensor):


### PR DESCRIPTION
Because of the break, only operator.__mul__ was actually tested.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0e6aaa1</samp>

> _`break` statement gone_
> _loop tests all shape functions_
> _symbolic winter_