### PR TITLE
[PyTorch] Fix missing if constexpr & warning in irange

### DIFF
--- a/c10/util/irange.h
+++ b/c10/util/irange.h
@@ -46,7 +46,7 @@ struct integer_iterator {
   }
 
   bool operator==(const integer_iterator& other) const {
-    if /* constexpr -- we don't have C++17 yet, see #85969 */ (one_sided) {
+    if constexpr (one_sided && std::is_signed_v<I>) {
       // Range-for loops' end test is `begin != end`, not `begin <
       // end`. To handle `c10::irange(n)` where n < 0 (which should be
       // empty), we just make `begin != end` fail whenever `end` is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90571

We should have C++17 now! Also got a complaint that this was throwing a warning when the type was unsigned, so fixing that too.

Differential Revision: [D41889702](https://our.internmc.facebook.com/intern/diff/D41889702/)