### PR TITLE
Fix straggler logging.CODE

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -560,7 +560,7 @@ class OutputGraph(fx.Tracer):
                     else format_graph_tabular(gm.graph)
                 )
                 log.log(
-                    logging.CODE,  # type: ignore[attr-defined]
+                    logging.INFO,  # type: ignore[attr-defined]
                     f"TRACED GRAPH\n {name} {gm.forward.__code__.co_filename} {graph_str}\n",
                 )
         except ImportError:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #90575
* __->__ #90572

- logging.CODE was entirely removed, this was left behind

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire