### PR TITLE
[SDPA] Create stub function for doing SDPA cpp and cuda dispatch

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13699,6 +13699,7 @@
   variants: function
   autogen: _scaled_dot_product_attention.out
 
+# This aten function is kept so that we can test the choice function from Python
 - func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> int
   dispatch:
     CPU, NestedTensorCPU, Meta: _fused_sdp_choice_cpp

--- a/aten/src/ATen/native/transformers/attention.h
+++ b/aten/src/ATen/native/transformers/attention.h
@@ -1,9 +1,16 @@
 #pragma once
 #include <ATen/ATen.h>
 #include <c10/macros/Export.h>
+#include <ATen/native/DispatchStub.h>
+#include <ATen/native/transformers/attention.h>
 
 namespace at {
 namespace native {
+
+using fused_sdp_choice_fn = int64_t (*)(const Tensor& query_, const Tensor& key, const Tensor& value,
+        const c10::optional<Tensor>& attn_mask_, double dropout_p, bool need_attn_weights, bool is_causal);
+
+DECLARE_DISPATCH(fused_sdp_choice_fn, _fused_sdp_choice_stub);
 
 TORCH_API Tensor bmm_nt(const Tensor& a, const Tensor& b);
 TORCH_API Tensor masked_softmax(

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
+#include <ATen/native/DispatchStub.h>
 #include <ATen/NestedTensorImpl.h>
 #include <ATen/TensorAccessor.h>
 
@@ -985,5 +986,8 @@ Tensor triton_scaled_dot_attention(const Tensor& q, const Tensor& k, const Tenso
   TORCH_CHECK(false, "This operator should be overridden in python before use");
   return at::Tensor();
 }
+
+REGISTER_CUDA_DISPATCH(_fused_sdp_choice_stub, &_fused_sdp_choice_cuda);
+
 } // namespace native
 } // namespace at

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1853,6 +1853,10 @@ def meta_scatter_(self, dim, index, src_or_value, reduce=None):
     return self
 
 
+# @register_meta([aten._scaled_dot_product_flash_attention, aten, aten._scaled_dot_product_efficient_attention])
+# def meta__scaled_dot_product(self, k, v, attn_mask, dropout_p, training, out=None):
+#     return self.new_empty(self.shape)
+
 @register_meta([aten.scatter_reduce.two, aten.scatter_reduce.two_out])
 @out_wrapper()
 def meta_scatter_reduce_two(self, dim, index, src, reduce, include_self=True):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1853,9 +1853,15 @@ def meta_scatter_(self, dim, index, src_or_value, reduce=None):
     return self
 
 
-# @register_meta([aten._scaled_dot_product_flash_attention, aten, aten._scaled_dot_product_efficient_attention])
-# def meta__scaled_dot_product(self, k, v, attn_mask, dropout_p, training, out=None):
-#     return self.new_empty(self.shape)
+@register_meta(
+    [
+        aten._scaled_dot_product_flash_attention,
+        aten._scaled_dot_product_efficient_attention,
+    ]
+)
+def meta__scaled_dot_product(self, k, v, attn_mask, dropout_p, training, out=None):
+    return self.new_empty(self.shape)
+
 
 @register_meta([aten.scatter_reduce.two, aten.scatter_reduce.two_out])
 @out_wrapper()

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1937,6 +1937,11 @@ def meta__scaled_dot_product_efficient_backward(
         == value._storage().data_ptr()
     )
 
+    grad_out = grad_out.transpose(1,2)
+    query = query.transpose(1,2)
+    key = key.transpose(1,2)
+    value = value.transpose(1,2)
+
     B = query.size(0)
     M = query.size(1)
     N = key.size(1)
@@ -1957,7 +1962,7 @@ def meta__scaled_dot_product_efficient_backward(
             torch.zeros_like(value) if grad_kv_needs_init else torch.empty_like(value)
         )
 
-    return grad_q, grad_k, grad_v
+    return grad_q.transpose(1,2), grad_k.transpose(1,2), grad_v.transpose(1,2)
 
 
 @register_meta([aten.scatter_reduce.two, aten.scatter_reduce.two_out])


### PR DESCRIPTION
## Summary
Torch.compile was previously not working for transformerencoder because torch.SDPA calls a native function on tensors that returns an int. This PR instead creates a dispatch stub for the function called in order to not create a separate fx node for this native function.
As well this pr adds meta functions for the fused kerenels.