### PR TITLE
fix with statement in test_fsdp_hybrid_shard.py

### DIFF
--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -223,10 +223,7 @@ class TestFSDPHybridShard(FSDPTest):
                 cntr = Counter()
                 patched_allreduce = partial(patched_collective, orig_ar, cntr)
                 patched_reduce_scatter = partial(patched_collective, orig_rs, cntr)
-                with (
-                    patch_allreduce(patched_allreduce),
-                    patch_reduce_scatter(patched_reduce_scatter),
-                ):
+                with patch_allreduce(patched_allreduce), patch_reduce_scatter(patched_reduce_scatter):
                     inp = fsdp_model.get_input(device=torch.cuda.current_device())
                     out = fsdp_model(inp[0], inp[1])
                     loss = fsdp_model.get_loss(inp, out)


### PR DESCRIPTION
Fixes PR #89915.  The following syntax was not permitted until 3.10:

```
with (
    patch_allreduce(patched_allreduce),
    patch_reduce_scatter(patched_reduce_scatter),
):
```
