### PR TITLE
[FSDP] Fix context manager syntax for Python <3.9

### DIFF
--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -223,9 +223,8 @@ class TestFSDPHybridShard(FSDPTest):
                 cntr = Counter()
                 patched_allreduce = partial(patched_collective, orig_ar, cntr)
                 patched_reduce_scatter = partial(patched_collective, orig_rs, cntr)
-                with (
-                    patch_allreduce(patched_allreduce),
-                    patch_reduce_scatter(patched_reduce_scatter),
+                with patch_allreduce(patched_allreduce), patch_reduce_scatter(
+                    patched_reduce_scatter
                 ):
                     inp = fsdp_model.get_input(device=torch.cuda.current_device())
                     out = fsdp_model(inp[0], inp[1])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90582 [FSDP][Easy] ufmt files
* **#90581 [FSDP] Fix context manager syntax for Python <3.9**

