### PR TITLE
Skip some unittests

### DIFF
--- a/test/test_schema_check.py
+++ b/test/test_schema_check.py
@@ -4,6 +4,7 @@ import os
 import sys
 import torch
 from torch.utils._pytree import tree_map
+import unittest
 
 from torch.testing._internal.common_utils import run_tests
 from torch.fx.operator_schemas import normalize_function

--- a/test/test_schema_check.py
+++ b/test/test_schema_check.py
@@ -229,6 +229,7 @@ class TestSchemaCheck(JitTestCase):
         self.assertEqual(expected, actual)
 
     # Tests that SchemaCheckMode wraps torch.Tensor when there is a kwarg tensor input
+    @unittest.SkipIf(not torch._C.has_spectral, "ATen not built with FFT.")
     def test_schema_check_mode_functionality_kwarg_tensor(self):
         x = torch.rand((3, 5))
         w = torch.rand((4))

--- a/test/test_schema_check.py
+++ b/test/test_schema_check.py
@@ -229,7 +229,7 @@ class TestSchemaCheck(JitTestCase):
         self.assertEqual(expected, actual)
 
     # Tests that SchemaCheckMode wraps torch.Tensor when there is a kwarg tensor input
-    @unittest.SkipIf(not torch._C.has_spectral, "ATen not built with FFT.")
+    @unittest.skipIf(not torch._C.has_spectral, "ATen not built with FFT.")
     def test_schema_check_mode_functionality_kwarg_tensor(self):
         x = torch.rand((3, 5))
         w = torch.rand((4))

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11938,7 +11938,7 @@ op_db: List[OpInfo] = [
                             active_if=(not IS_MACOS)),
                DecorateInfo(unittest.skip("Skipped!"), 'TestBwdGradients', 'test_fn_gradgrad'),
                DecorateInfo(unittest.skip("Skipped!"), 'TestBwdGradients', 'test_fn_grad'),
-               DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_forward_ad'),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestCompositeCompliance', 'test_forward_ad'),
            )),
     OpInfo('nn.functional.max_unpool3d',
            variant_test_name='grad',

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -31,7 +31,7 @@ from torch.testing._internal.common_utils import (
     make_fullrank_matrices_with_distinct_singular_values,
     TEST_WITH_ROCM, IS_WINDOWS, IS_MACOS, TEST_SCIPY,
     torch_to_numpy_dtype_dict, TEST_WITH_ASAN,
-    GRADCHECK_NONDET_TOL, freeze_rng_state,
+    GRADCHECK_NONDET_TOL, freeze_rng_state, slowTest
 )
 
 import torch._refs as refs  # noqa: F401
@@ -13901,6 +13901,7 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, "TestNormalizeOperators", "test_normalize_operator_exhaustive"),
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),
                DecorateInfo(unittest.skip('output is non-deterministic'), 'TestCommon', 'test_compare_cpu'),
+               DecorateInfo(slowTest, 'TestCompositeCompliance', 'test_forward_ad'),
            )),
     OpInfo('pca_lowrank',
            op=lambda *args, **kwargs: wrapper_set_seed(


### PR DESCRIPTION
* Skip a unittest that needs FFT if not built with FFT
* Mark a test with "slow": `python test/test_ops.py -k TestCompositeComplianceCUDA.test_forward_ad_svd_lowrank_cuda_float32` took >5min on my machine.
* Skip a flaky test that's marked "expectedFailure", similar to #90233