### PR TITLE
[FSDP] Save `_stream_to_name` for debugging

### DIFF
--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -282,6 +282,8 @@ def _init_core_state(
     state._is_root = None
     _streams: Dict[str, torch.cuda.Stream] = {}
     state._streams = _streams
+    _stream_to_name: Dict[torch.cuda.Stream, str] = {}
+    state._stream_to_name = _stream_to_name
     state._free_event_queue = _FreeEventQueue()
     state._debug_level = dist.get_debug_level()
     state._exec_order_data = _ExecOrderData(

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -127,6 +127,7 @@ def _lazy_init(
         )
         fsdp_module._is_root = False
         fsdp_module._streams = state._streams
+        fsdp_module._stream_to_name = state._stream_to_name
         fsdp_module._exec_order_data = state._exec_order_data
         if fsdp_module.limit_all_gathers != state.limit_all_gathers:
             # Prefer the root's value
@@ -165,6 +166,14 @@ def _init_streams(
     # Stream for pre-unshard logic, namely allocations and writes for CPU
     # offloading (H2D copy) and mixed precision (low precision cast).
     state._streams["pre_unshard"] = torch.cuda.Stream()
+    # Default stream for computation
+    state._streams["default"] = torch.cuda.current_stream()
+    state._stream_to_name = {
+        torch.cuda.current_stream(): "default",
+        state._streams["unshard"]: "unshard",
+        state._streams["pre_unshard"]: "pre_unshard",
+        state._streams["post_backward"]: "post_backward",
+    }
 
 
 @no_type_check


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90619 [FSDP][Perf] Pre-allocate full prec sharded param
* #90618 [FSDP][Easy][BE] Minor cleanup of post-backward logic
* #90616 [FSDP][Perf] Save one copy when downcasting grad
* #90614 [FSDP][Perf] Pre-allocate padded unsharded grad in default stream
* #90631 [FSDP] Sanitize `HandleConfig` for mixed precision
* #90615 [FSDP] Tighten post-bwd cast to `reduce_dtype`
* #90622 [FSDP][Easy] Move to `_storage()` in test file
* **#90611 [FSDP] Save `_stream_to_name` for debugging**
* #90562 [Reland][FSDP] Another fix for `DTensor`, `use_orig_params=True`

This saves a data structure `_stream_to_name: Dict[torch.cuda.Stream, str]` that maps each FSDP stream to its name. This can help in debugging by checking `_stream_to_name[torch.cuda.current_stream()]` to see if it is `"default"` or `"unshard"` in the post-backward hook for example. 