### PR TITLE
[FSDP][Perf] Pre-allocate padded unsharded grad in default stream

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -567,9 +567,36 @@ def _post_backward_hook(
         if not state._sync_gradients:
             return
 
+        # Only define `padded_unsharded_grad` for sharded strategies
+        pre_allocated_grad = False
+        if handle.uses_sharded_strategy:
+            if handle._uses_reduce_mixed_precision:
+                grad_dtype = handle._config.low_prec_reduce_dtype
+            elif handle._uses_param_mixed_precision:
+                grad_dtype = handle._config.low_prec_param_dtype
+            else:
+                grad_dtype = param.grad.dtype
+            # Pre-allocate the padded unsharded gradient in the default stream
+            # if the gradient needs padding
+            with torch.cuda.stream(state._streams["default"]):
+                padded_unsharded_grad: Optional[torch.Tensor] = (
+                    torch.empty(
+                        handle.flat_param._padded_unsharded_size,
+                        dtype=grad_dtype,
+                        device=state.compute_device,
+                    )
+                    if handle.flat_param._padded_unsharded_size
+                    != handle.flat_param._unpadded_unsharded_size
+                    else None
+                )
+            pre_allocated_grad = padded_unsharded_grad is not None
+
         # Wait for all ops in the current stream (e.g. gradient
         # computation) to finish before reduce-scattering the gradient
-        state._streams["post_backward"].wait_stream(torch.cuda.current_stream())
+        current_stream = torch.cuda.current_stream()
+        state._streams["post_backward"].wait_stream(current_stream)
+        if pre_allocated_grad and current_stream != state._streams["default"]:
+            state._streams["post_backward"].wait_stream(state._streams["default"])
 
         with torch.cuda.stream(state._streams["post_backward"]):
             unsharded_grad_data = param.grad.data
@@ -581,6 +608,8 @@ def _post_backward_hook(
                 state
             ):
                 # TODO: Use the low precision communication hook directly
+                # TODO: We can avoid the double copy (first to `reduce_dtype`,
+                # then to `padded_unsharded_grad`) in the padding case.
                 param.grad.data = param.grad.to(state.mixed_precision.reduce_dtype)
 
             if handle.uses_sharded_strategy:
@@ -599,11 +628,30 @@ def _post_backward_hook(
                 numel_to_pad = (
                     state.world_size * chunks[0].numel() - unsharded_grad.numel()
                 )
-                padded_unsharded_grad = (
-                    F.pad(unsharded_grad, [0, numel_to_pad])
-                    if numel_to_pad > 0
-                    else unsharded_grad
-                )
+                if pre_allocated_grad:
+                    p_assert(
+                        padded_unsharded_grad.numel() - unsharded_grad.numel()
+                        == numel_to_pad,
+                        f"Expects {numel_to_pad} numel to pad but got padded "
+                        f"shape {padded_unsharded_grad.shape} and unpadded "
+                        f"shape {unsharded_grad.shape}",
+                    )
+                    p_assert(
+                        unsharded_grad.dtype == padded_unsharded_grad.dtype,
+                        "Expects the padded unsharded gradient to have dtype "
+                        f"{unsharded_grad.dtype} but pre-allocated with dtype "
+                        f"{padded_unsharded_grad.dtype} {handle._config}"
+                    )
+                    padded_unsharded_grad[: unsharded_grad.numel()].copy_(
+                        unsharded_grad
+                    )
+                    # TODO: `clip_grad_norm_()` assumes padding is zeroed. We
+                    # need to trim padding before computing local norms.
+                    padding_numel = padded_unsharded_grad.numel() - unsharded_grad.numel()
+                    padded_unsharded_grad[-padding_numel:].zero_()
+                else:  # does not need padding
+                    padded_unsharded_grad = unsharded_grad
+                # TODO: Move this allocation to the default stream as well.
                 new_sharded_grad = torch.empty_like(chunks[0])  # padded
                 state._communication_hook(
                     state._communication_hook_state,
@@ -661,6 +709,11 @@ def _post_backward_hook(
             _no_dispatch_record_stream(
                 unsharded_grad_data, state._streams["post_backward"]
             )
+            if pre_allocated_grad:
+                # Same pattern for the pre-allocated padded unsharded gradient
+                _no_dispatch_record_stream(
+                    padded_unsharded_grad, state._streams["post_backward"]
+                )
 
             if handle._use_orig_params:
                 # Since the handle's `FlatParameter` completed its gradient


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90656 [FSDP] Clean up post-backward hook
* #90619 [FSDP][Perf] Pre-allocate full prec sharded param
* #90618 [FSDP][Easy][BE] Minor cleanup of post-backward logic
* #90616 [FSDP][Perf] Pre-allocate sharded grad in default stream; save one copy when downcasting grad
* **#90614 [FSDP][Perf] Pre-allocate padded unsharded grad in default stream**
* #90631 [FSDP] Sanitize `HandleConfig` for mixed precision
* #90615 [FSDP] Tighten post-bwd cast to `reduce_dtype`
* #90622 [FSDP][Easy] Move to `_storage()` in test file
* #90611 [FSDP] Save `_stream_to_name` for debugging
* #90562 [Reland][FSDP] Another fix for `DTensor`, `use_orig_params=True`

