### PR TITLE
[FSDP] Tighten post-bwd cast to `reduce_dtype`

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -577,11 +577,13 @@ def _post_backward_hook(
                 _check_comm_hook(
                     state._communication_hook, state._communication_hook_state
                 )
-            if handle._uses_reduce_mixed_precision and not _low_precision_hook_enabled(
-                state
+            if (
+                handle._uses_reduce_mixed_precision
+                and not _low_precision_hook_enabled(state)
+                and param.grad.dtype != handle._config.low_prec_reduce_dtype
             ):
                 # TODO: Use the low precision communication hook directly
-                param.grad.data = param.grad.to(state.mixed_precision.reduce_dtype)
+                param.grad.data = param.grad.to(handle._config.low_prec_reduce_dtype)
 
             if handle.uses_sharded_strategy:
                 # We clear `.grad` to permit multiple backwards. This avoids a


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90619 [FSDP][Perf] Pre-allocate full prec sharded param
* #90618 [FSDP][Easy][BE] Minor cleanup of post-backward logic
* #90616 [FSDP][Perf] Pre-allocate sharded grad in default stream; save one copy when downcasting grad
* #90614 [FSDP][Perf] Pre-allocate padded unsharded grad in default stream
* #90631 [FSDP] Sanitize `HandleConfig` for mixed precision
* **#90615 [FSDP] Tighten post-bwd cast to `reduce_dtype`**
* #90622 [FSDP][Easy] Move to `_storage()` in test file
* #90611 [FSDP] Save `_stream_to_name` for debugging
* #90562 [Reland][FSDP] Another fix for `DTensor`, `use_orig_params=True`

This lowers the `reduce_dtype` retrieval to the `handle` instead of the `state` in preparation for `fully_shard`, and this adds a guard to avoid a no-op `to()` call.

Note that this change pretty much gets overridden in following PRs.