### PR TITLE
[FSDP][Perf] Pre-allocate sharded grad in default stream

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -602,7 +602,7 @@ def _post_backward_hook(
         # computation) to finish before reduce-scattering the gradient
         current_stream = torch.cuda.current_stream()
         state._streams["post_backward"].wait_stream(current_stream)
-        if pre_allocated_unsharded_grad and current_stream != state._streams["default"]:
+        if handle.uses_sharded_strategy and current_stream != state._streams["default"]:
             state._streams["post_backward"].wait_stream(state._streams["default"])
 
         with torch.cuda.stream(state._streams["post_backward"]):

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -566,8 +566,9 @@ def _post_backward_hook(
         if not state._sync_gradients:
             return
 
-        # Only define `padded_unsharded_grad` for sharded strategies
-        pre_allocated_grad = False
+        # Only define `padded_unsharded_grad` and `new_sharded_grad` for
+        # sharded strategies
+        pre_allocated_unsharded_grad = False
         if handle.uses_sharded_strategy:
             if handle._uses_reduce_mixed_precision:
                 grad_dtype = handle._config.low_prec_reduce_dtype
@@ -575,26 +576,33 @@ def _post_backward_hook(
                 grad_dtype = handle._config.low_prec_param_dtype
             else:
                 grad_dtype = param.grad.dtype
-            # Pre-allocate the padded unsharded gradient in the default stream
-            # if the gradient needs padding
+            # Pre-allocate the (padded) sharded gradient and the padded
+            # unsharded gradient if the gradient needs padding, both in the
+            # default stream
             with torch.cuda.stream(state._streams["default"]):
+                new_sharded_grad = torch.empty(
+                    handle.flat_param._sharded_size,
+                    dtype=grad_dtype,
+                    device=handle.device,
+                )
                 padded_unsharded_grad: Optional[torch.Tensor] = (
                     torch.empty(
                         handle.flat_param._padded_unsharded_size,
                         dtype=grad_dtype,
-                        device=state.compute_device,
+                        device=handle.device,
                     )
                     if handle.flat_param._padded_unsharded_size
                     != handle.flat_param._unpadded_unsharded_size
                     else None
                 )
-            pre_allocated_grad = padded_unsharded_grad is not None
+            pre_allocated_unsharded_grad = padded_unsharded_grad is not None
+        pre_allocated_sharded_grad = handle.uses_sharded_strategy
 
         # Wait for all ops in the current stream (e.g. gradient
         # computation) to finish before reduce-scattering the gradient
         current_stream = torch.cuda.current_stream()
         state._streams["post_backward"].wait_stream(current_stream)
-        if pre_allocated_grad and current_stream != state._streams["default"]:
+        if pre_allocated_unsharded_grad and current_stream != state._streams["default"]:
             state._streams["post_backward"].wait_stream(state._streams["default"])
 
         with torch.cuda.stream(state._streams["post_backward"]):
@@ -624,7 +632,7 @@ def _post_backward_hook(
                 numel_to_pad = (
                     state.world_size * chunks[0].numel() - unsharded_grad.numel()
                 )
-                if pre_allocated_grad:
+                if pre_allocated_unsharded_grad:
                     p_assert(
                         padded_unsharded_grad.numel() - unsharded_grad.numel()
                         == numel_to_pad,
@@ -654,8 +662,6 @@ def _post_backward_hook(
                         if needs_cast_to_reduce_dtype
                         else unsharded_grad
                     )
-                # TODO: Move this allocation to the default stream as well.
-                new_sharded_grad = torch.empty_like(chunks[0])  # padded
                 state._communication_hook(
                     state._communication_hook_state,
                     padded_unsharded_grad,
@@ -670,6 +676,7 @@ def _post_backward_hook(
                         grad=new_sharded_grad,
                     )
 
+                # TODO: Move this allocation to the default stream as well.
                 _cast_grad_to_param_dtype(state, handle, new_sharded_grad, param)
 
                 # Save the sharded gradient in `_saved_grad_shard` to support
@@ -712,10 +719,15 @@ def _post_backward_hook(
             _no_dispatch_record_stream(
                 unsharded_grad_data, state._streams["post_backward"]
             )
-            if pre_allocated_grad:
-                # Same pattern for the pre-allocated padded unsharded gradient
+            # Same pattern for the pre-allocated sharded and padded unsharded
+            # gradients
+            if pre_allocated_unsharded_grad:
                 _no_dispatch_record_stream(
                     padded_unsharded_grad, state._streams["post_backward"]
+                )
+            if pre_allocated_sharded_grad:
+                _no_dispatch_record_stream(
+                    new_sharded_grad, state._streams["post_backward"]
                 )
 
             if handle._use_orig_params:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90619 [FSDP][Perf] Pre-allocate full prec sharded param
* #90618 [FSDP][Easy][BE] Minor cleanup of post-backward logic
* **#90617 [FSDP][Perf] Pre-allocate sharded grad in default stream**
* #90616 [FSDP][Perf] Save one copy when downcasting grad
* #90614 [FSDP][Perf] Pre-allocate padded unsharded grad in default stream
* #90631 [FSDP] Sanitize `HandleConfig` for mixed precision
* #90615 [FSDP] Tighten post-bwd cast to `reduce_dtype`
* #90622 [FSDP][Easy] Move to `_storage()` in test file
* #90611 [FSDP] Save `_stream_to_name` for debugging
* #90562 [Reland][FSDP] Another fix for `DTensor`, `use_orig_params=True`

Every sharded strategy always allocates a (padded) sharded gradient as the target tensor for the reduce-scatter. This PR moves that allocation to the default stream instead of the post-backward stream.

Minor: This PR changes from `state.device` to `handle.device`, which has no semantic difference. It is just better to lower as much logic as possible to the `handle` when appropriate.