### PR TITLE
[FSDP][Easy] Move to `_storage()` in test file

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -208,7 +208,7 @@ class LinearMixedPrecision(nn.Module):
                     # Shard is never allocated if param_dtype mixed precision is not
                     # enabled.
                     if mp_config.param_dtype is not None:
-                        cls.assertEqual(0, param._mp_shard.storage().size())
+                        cls.assertEqual(0, param._mp_shard._storage().size())
                     else:
                         cls.assertFalse(hasattr(param, "_mp_shard"))
                 elif param_is_sharded:
@@ -271,7 +271,7 @@ class TestFSDPMixedPrecision(FSDPTest):
         fsdp_units = FSDP.fsdp_modules(fsdp_model)
         for fsdp in fsdp_units:
             for param in fsdp.params:
-                self.assertEqual(0, param._mp_shard.storage().size())
+                self.assertEqual(0, param._mp_shard._storage().size())
 
     def _reduce_scatter_validate_mp(
         self, orig_reduce_scatter, mp_config, *args, **kwargs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90619 [FSDP][Perf] Pre-allocate full prec sharded param
* #90618 [FSDP][Easy][BE] Minor cleanup of post-backward logic
* #90616 [FSDP][Perf] Save one copy when downcasting grad
* #90614 [FSDP][Perf] Pre-allocate padded unsharded grad in default stream
* #90631 [FSDP] Sanitize `HandleConfig` for mixed precision
* #90615 [FSDP] Tighten post-bwd cast to `reduce_dtype`
* **#90622 [FSDP][Easy] Move to `_storage()` in test file**
* #90611 [FSDP] Save `_stream_to_name` for debugging
* #90562 [Reland][FSDP] Another fix for `DTensor`, `use_orig_params=True`

This is to silence some deprecation warnings.