### PR TITLE
Add unbacked symints support; item works now

### DIFF
--- a/aten/src/ATen/native/Scalar.cpp
+++ b/aten/src/ATen/native/Scalar.cpp
@@ -15,7 +15,7 @@ namespace at {
 namespace native {
 
 Scalar item(const Tensor& self) {
-  int64_t numel = self.numel();
+  auto numel = self.sym_numel();
   TORCH_CHECK(numel == 1, "a Tensor with ", numel, " elements cannot be converted to Scalar");
   if (self.is_sparse()) {
     if (self._nnz() == 0) return Scalar(0);

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -423,12 +423,15 @@ def forward(self, x_1):
         def f(a, b):
             return torch.allclose(a, b)
 
-        self.assertRaises(
-            DataDependentOutputException,
-            lambda: make_fx(f, tracing_mode=self.tracing_mode)(
+        def test_f():
+            make_fx(f, tracing_mode=self.tracing_mode)(
                 torch.zeros(3), torch.zeros(3)
             )
-        )
+
+        if self.tracing_mode == "symbolic":
+            self.assertRaises(DataDependentOutputException, test_f)
+        else:
+            self.assertRaisesRegex(RuntimeError, "data-dependent", test_f)
 
     def test_constant_proxy_tensor_mut(self):
         def f():

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -342,15 +342,6 @@ static int64_t dispatch_to_CLong(const Tensor & self) {
   return self.item<int64_t>();
 }
 
-static bool dispatch_to_Bool(const Tensor & self) {
-  pybind11::gil_scoped_release no_gil;
-  OptionalDeviceGuard device_guard(device_of(self));
-  if (self.sym_numel() != 1) {
-    throw ValueError("only one element tensors can be converted to Python scalars");
-  }
-  return self.item<bool>();
-}
-
 static PyObject * THPVariable_float_scalar(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   if (check_has_torch_function(self)) {

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -47,6 +47,7 @@
 #include <ATen/Functions.h>
 #else
 $ops_headers
+#include <ATen/ops/_local_scalar_dense.h>
 #endif
 
 using at::DeviceGuard;
@@ -317,7 +318,7 @@ static Tensor dispatch_copy_(const Tensor & self, const Tensor & other, bool non
 static double dispatch_to_CDouble(const Tensor & self) {
   pybind11::gil_scoped_release no_gil;
   OptionalDeviceGuard device_guard(device_of(self));
-  if (self.numel() != 1) {
+  if (self.sym_numel() != 1) {
     throw ValueError("only one element tensors can be converted to Python scalars");
   }
   return self.item<double>();
@@ -326,7 +327,7 @@ static double dispatch_to_CDouble(const Tensor & self) {
 static c10::complex<double> dispatch_to_CComplexDouble(const Tensor & self) {
   pybind11::gil_scoped_release no_gil;
   OptionalDeviceGuard device_guard(device_of(self));
-  if (self.numel() != 1) {
+  if (self.sym_numel() != 1) {
     throw ValueError("only one element tensors can be converted to Python scalars");
   }
   return self.item<c10::complex<double>>();
@@ -335,7 +336,7 @@ static c10::complex<double> dispatch_to_CComplexDouble(const Tensor & self) {
 static int64_t dispatch_to_CLong(const Tensor & self) {
   pybind11::gil_scoped_release no_gil;
   OptionalDeviceGuard device_guard(device_of(self));
-  if (self.numel() != 1) {
+  if (self.sym_numel() != 1) {
     throw ValueError("only one element tensors can be converted to Python scalars");
   }
   return self.item<int64_t>();
@@ -344,7 +345,7 @@ static int64_t dispatch_to_CLong(const Tensor & self) {
 static bool dispatch_to_Bool(const Tensor & self) {
   pybind11::gil_scoped_release no_gil;
   OptionalDeviceGuard device_guard(device_of(self));
-  if (self.numel() != 1) {
+  if (self.sym_numel() != 1) {
     throw ValueError("only one element tensors can be converted to Python scalars");
   }
   return self.item<bool>();
@@ -399,7 +400,7 @@ static PyObject * THPVariable_index_scalar(PyObject* self, PyObject* args) {
   auto& self_ = THPVariable_Unpack(self);
   // TODO: change the condition to `self_.dim() != 0` once we expose scalars
   // in PyTorch.
-  if (!isIntegralType(self_.scalar_type(), /*includeBool=*/true) || self_.numel() != 1) {
+  if (!isIntegralType(self_.scalar_type(), /*includeBool=*/true) || self_.sym_numel() != 1) {
     throw TypeError("only integer tensors of a single element can be converted to an index");
   }
   return wrap(dispatch_to_CLong(self_));
@@ -883,15 +884,7 @@ static PyObject * THPVariable_item(PyObject* self, PyObject* args)
   }
   jit::tracer::warn("Converting a tensor to a Python number", jit::tracer::WARN_PYTHON_DATAFLOW);
   auto& self_ = THPVariable_Unpack(self);
-  if (self_.is_floating_point()) {
-    return wrap(dispatch_to_CDouble(self_));
-  } else if (self_.is_complex()) {
-    return wrap(dispatch_to_CComplexDouble(self_));
-  } else if (self_.scalar_type() == ScalarType::Bool) {
-    return wrap(dispatch_to_Bool(self_));
-  } else {
-    return wrap(dispatch_to_CLong(self_));
-  }
+  return py::cast(self_.item()).release().ptr();
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -9,13 +9,13 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Un
 
 import torch
 from torch._ops import OpOverload
+from torch._prims_common import is_float_dtype, is_integer_dtype
 from torch._subclasses.meta_utils import MetaConverter, WeakTensorRefKey
 from torch.fx.operator_schemas import normalize_function
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.overrides import TorchFunctionMode
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._python_dispatch import TorchDispatchMode
-from torch._prims_common import is_float_dtype, is_integer_dtype
 
 from torch.utils._pytree import PyTree, tree_flatten, tree_map
 
@@ -376,9 +376,7 @@ def dyn_shape(fake_mode, func, *args, **kwargs):
     raise DynamicOutputShapeException(func)
 
 
-@register_op_impl(
-    lambda func: func is torch.ops.aten._local_scalar_dense.default
-)
+@register_op_impl(lambda func: func is torch.ops.aten._local_scalar_dense.default)
 def local_scalar_dense(fake_mode, func, arg):
     if fake_mode.shape_env is None:
         # Without symints/symfloats, cannot handle this

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -15,6 +15,7 @@ from torch.multiprocessing.reductions import StorageWeakRef
 from torch.overrides import TorchFunctionMode
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._python_dispatch import TorchDispatchMode
+from torch._prims_common import is_float_dtype, is_integer_dtype
 
 from torch.utils._pytree import PyTree, tree_flatten, tree_map
 
@@ -375,6 +376,22 @@ def dyn_shape(fake_mode, func, *args, **kwargs):
     raise DynamicOutputShapeException(func)
 
 
+@register_op_impl(
+    lambda func: func is torch.ops.aten._local_scalar_dense.default
+)
+def local_scalar_dense(fake_mode, func, arg):
+    if fake_mode.shape_env is None:
+        # Without symints/symfloats, cannot handle this
+        raise DataDependentOutputException(func)
+    if is_float_dtype(arg.dtype):
+        return fake_mode.shape_env.create_unbacked_symfloat()
+    elif is_integer_dtype(arg.dtype):
+        return fake_mode.shape_env.create_unbacked_symint()
+    else:
+        raise NotImplementedError(f"local_scalar_dense/item NYI for {arg.dtype}")
+
+
+# NB: this must be ordered after local_scalar_dense
 @register_op_impl(
     lambda func: torch.Tag.data_dependent_output in func.tags  # type: ignore[attr-defined]
 )

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -138,6 +138,10 @@ c10::SymIntArrayRef LTCTensorImpl::sym_sizes_custom() const {
   return c10::fromIntArrayRefKnownNonNegative(sizes_custom());
 }
 
+c10::SymInt LTCTensorImpl::sym_numel_custom() const {
+  return numel_custom();
+}
+
 void LTCTensorImpl::setup_size_properties() {
   size_t generation = tensor_->generation();
   if (generation != generation_) {

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -48,6 +48,7 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
 
   c10::SymIntArrayRef sym_sizes_custom() const override;
   c10::SymIntArrayRef sym_strides_custom() const override;
+  c10::SymInt sym_numel_custom() const override;
 
  private:
   void setup_size_properties();

--- a/torch/csrc/utils/pybind.cpp
+++ b/torch/csrc/utils/pybind.cpp
@@ -79,5 +79,26 @@ py::handle type_caster<c10::SymFloat>::cast(
   }
 }
 
+bool type_caster<c10::Scalar>::load(py::handle src, bool) {
+  TORCH_INTERNAL_ASSERT(0, "pybind11 loading for c10::Scalar NYI (file a bug if you need it)");
+}
+
+py::handle type_caster<c10::Scalar>::cast(
+    c10::Scalar scalar,
+    return_value_policy /* policy */,
+    handle /* parent */) {
+  if (scalar.isIntegral(/*includeBool*/ false)) {
+    return py::cast(scalar.toSymInt()).release();
+  } else if (scalar.isFloatingPoint()) {
+    return py::cast(scalar.toSymFloat()).release();
+  } else if (scalar.isBoolean()) {
+    return py::cast(scalar.toBool()).release();
+  } else if (scalar.isComplex()) {
+    return py::cast(scalar.toComplexDouble()).release();
+  } else {
+    TORCH_INTERNAL_ASSERT(0, "unrecognized scalar type ", scalar.type());
+  }
+}
+
 } // namespace detail
 } // namespace pybind11

--- a/torch/csrc/utils/pybind.cpp
+++ b/torch/csrc/utils/pybind.cpp
@@ -80,11 +80,12 @@ py::handle type_caster<c10::SymFloat>::cast(
 }
 
 bool type_caster<c10::Scalar>::load(py::handle src, bool) {
-  TORCH_INTERNAL_ASSERT(0, "pybind11 loading for c10::Scalar NYI (file a bug if you need it)");
+  TORCH_INTERNAL_ASSERT(
+      0, "pybind11 loading for c10::Scalar NYI (file a bug if you need it)");
 }
 
 py::handle type_caster<c10::Scalar>::cast(
-    c10::Scalar scalar,
+    const c10::Scalar& scalar,
     return_value_policy /* policy */,
     handle /* parent */) {
   if (scalar.isIntegral(/*includeBool*/ false)) {

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -204,6 +204,18 @@ struct type_caster<c10::DispatchKey>
 };
 
 template <>
+struct TORCH_PYTHON_API type_caster<c10::Scalar> {
+ public:
+  PYBIND11_TYPE_CASTER(c10::Scalar, _("Union[Number, torch.SymInt, torch.SymFloat]"));
+  bool load(py::handle src, bool);
+
+  static py::handle cast(
+      c10::Scalar si,
+      return_value_policy /* policy */,
+      handle /* parent */);
+};
+
+template <>
 struct TORCH_PYTHON_API type_caster<c10::SymInt> {
  public:
   PYBIND11_TYPE_CASTER(c10::SymInt, _("Union[int, torch.SymInt]"));

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -206,11 +206,13 @@ struct type_caster<c10::DispatchKey>
 template <>
 struct TORCH_PYTHON_API type_caster<c10::Scalar> {
  public:
-  PYBIND11_TYPE_CASTER(c10::Scalar, _("Union[Number, torch.SymInt, torch.SymFloat]"));
+  PYBIND11_TYPE_CASTER(
+      c10::Scalar,
+      _("Union[Number, torch.SymInt, torch.SymFloat]"));
   bool load(py::handle src, bool);
 
   static py::handle cast(
-      c10::Scalar si,
+      const c10::Scalar& si,
       return_value_policy /* policy */,
       handle /* parent */);
 };

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -565,9 +565,9 @@ inline std::vector<c10::SymInt> PythonArgs::symintlist(int i) {
                 var.dtype().toScalarType(), /*include_bool*/ true)) {
           throw_intlist_exception(this, i, obj, idx);
         }
-        // TODO: ideally, if this was a fake tensor this would
-        // result in a SymInt, but we don't have the API to do this
-        res.push_back(var.item<int64_t>());
+        auto scalar = var.item();
+        TORCH_CHECK(scalar.isIntegral(/*include bool*/ false));
+        res.push_back(scalar.toSymInt());
       } else {
         try {
           if (is_symint(py::handle(obj))) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90624

The big idea is to add `create_unbacked_symfloat` and `create_unbacked_symint` to ShapeEnv, allowing you to allocate symbolic floats/ints corresponding to data you don't know about at compile time. Then, instead of immediately erroring out when you try to call local_scalar_dense on a FakeTensor, we instead create a fresh symint/symfloat and return that.

There a bunch of odds and ends that need to be handled:

* A number of `numel` calls converted to `sym_numel`
* When we finally return from item(), we need to ensure we actually produce a SymInt/SymFloat when appropriate. The previous binding code assumed that you would have to get a normal Python item. I add a pybind11 binding for Scalar (to PyObject only) and refactor the code to use that. There is some trickiness where you are NOT allowed to go through c10::SymInt if there isn't actually any SymInt involved. See comment.
* One of our unit tests tripped an implicit data dependent access which occurs when you pass a Tensor as an argument to a sizes parameter. This is also converted to support symbolic shapes
* We now support tracking bare SymInt/SymFloat returns in proxy tensor mode (this was already in symbolic-shapes branch)
* Whenever we allocate an unbacked symint, we record the stack trace it was allocated at. These get printed when you attempt data dependent access on the symint (e.g., you try to guard on it)
* Subtlety: unbacked symints are not necessarily > 1. I added a test for this.

These unbacked symints are not very useful right now as you will almost always immediately raise an error later when you try to guard on them. The next logical step is adding an assertion refinement system that lets ShapeEnv learn facts about unbacked symints so it can do a better job eliding guards that are unnecessary.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>