### PR TITLE
[Fix]: Add missing std::vector reserve in aten and torch/csrc

### DIFF
--- a/aten/src/ATen/core/dynamic_type.cpp
+++ b/aten/src/ATen/core/dynamic_type.cpp
@@ -243,11 +243,13 @@ TypePtr DynamicType::fallback() const {
       return ListType::create(arguments_.elems[0].ty->fallback());
     case Tag::Tuple: {
       std::vector<TypePtr> fallbacks;
+      fallbacks.reserve(arguments_.elems.size());
       for (const auto& elem : arguments_.elems) {
         fallbacks.push_back(elem.ty->fallback());
       }
       if (name_) {
         std::vector<c10::string_view> fields;
+        fields.reserve(arguments_.elems.size());
         for (const auto& elem : arguments_.elems) {
           fields.emplace_back(*elem.label);
         }

--- a/aten/src/ATen/functorch/PlumbingHelper.cpp
+++ b/aten/src/ATen/functorch/PlumbingHelper.cpp
@@ -32,6 +32,7 @@ Tensor makeBatched(const Tensor& tensor, optional<int64_t> bdim, int64_t level) 
 
 std::vector<Tensor> makeBatchedVector(const std::vector<Tensor>& tensors, optional<int64_t> bdim, int64_t level) {
   std::vector<Tensor> res;
+  res.reserve(tensors.size());
   for (const auto & tensor : tensors) {
     res.emplace_back(makeBatched(tensor, bdim, level));
   }

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
@@ -23,6 +23,7 @@ PropagateGradientsReq::PropagateGradientsReq(
 c10::intrusive_ptr<Message> PropagateGradientsReq::toMessageImpl() && {
   std::vector<at::IValue> ivalues;
   // Add all the grad tensors.
+  ivalues.reserve(grads_.size());
   for (const auto& grad : grads_) {
     ivalues.emplace_back(grad);
   }

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
@@ -23,7 +23,7 @@ PropagateGradientsReq::PropagateGradientsReq(
 c10::intrusive_ptr<Message> PropagateGradientsReq::toMessageImpl() && {
   std::vector<at::IValue> ivalues;
   // Add all the grad tensors.
-  ivalues.reserve(grads_.size());
+  ivalues.reserve(grads_.size() + 3);
   for (const auto& grad : grads_) {
     ivalues.emplace_back(grad);
   }

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -220,10 +220,13 @@ std::ostream& operator<<(
     std::vector<std::string> dtype_strs;
     std::vector<std::string> device_type_strs;
     std::vector<std::string> size_strs;
+    dtype_strs.reserve(collective_fingerprint.tensor_dtypes_.size());
     for (const auto& tensor_dtype : collective_fingerprint.tensor_dtypes_) {
       dtype_strs.emplace_back(
           c10::toString(static_cast<at::ScalarType>(tensor_dtype)));
     }
+    device_type_strs.reserve(
+        collective_fingerprint.tensor_device_types_.size());
     for (const auto& tensor_device_type :
          collective_fingerprint.tensor_device_types_) {
       device_type_strs.emplace_back(

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -1200,6 +1200,7 @@ const WorkerInfo& TensorPipeAgent::getWorkerInfo(worker_id_t workerId) const {
 
 std::vector<WorkerInfo> TensorPipeAgent::getWorkerInfos() const {
   std::vector<WorkerInfo> workerInfos;
+  workerInfos.reserve(workerNameToInfo_.size());
   for (auto& item : workerNameToInfo_) {
     workerInfos.emplace_back(item.second);
   }

--- a/torch/csrc/jit/frontend/concrete_module_type.cpp
+++ b/torch/csrc/jit/frontend/concrete_module_type.cpp
@@ -368,6 +368,7 @@ std::vector<std::pair<std::string, std::shared_ptr<ConcreteModuleType>>>
 ConcreteModuleType::getModulesPy() const {
   std::vector<std::pair<std::string, std::shared_ptr<ConcreteModuleType>>> ret;
 
+  ret.reserve(data_.modules_.size());
   for (const auto& info : data_.modules_) {
     ret.emplace_back(std::make_pair(info.name_, info.meta_));
   }

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -602,6 +602,7 @@ SugaredValuePtr IterableTree::getitem(
     Value* idx,
     TypePtr type_hint) {
   std::vector<SugaredValuePtr> child_items;
+  child_items.reserve(children_.size());
   for (const SugaredValuePtr& child : children_) {
     child_items.emplace_back(child->getitem(loc, m, idx));
   }

--- a/torch/csrc/jit/mobile/nnc/context.cpp
+++ b/torch/csrc/jit/mobile/nnc/context.cpp
@@ -169,6 +169,7 @@ c10::IValue Function::serialize() const {
 
   // input_specs_
   std::vector<c10::IValue> input_specs;
+  input_specs.reserve(input_specs_.size());
   for (const auto& input_spec : input_specs_) {
     input_specs.emplace_back(input_spec.serialize());
   }
@@ -176,6 +177,7 @@ c10::IValue Function::serialize() const {
 
   // output_specs_
   std::vector<c10::IValue> output_specs;
+  output_specs.reserve(output_specs_.size());
   for (const auto& output_spec : output_specs_) {
     output_specs.emplace_back(output_spec.serialize());
   }
@@ -186,6 +188,7 @@ c10::IValue Function::serialize() const {
 
   // sym_shape_positions_
   std::vector<c10::IValue> sym_shape_pos_vec;
+  sym_shape_pos_vec.reserve(sym_shape_positions_.size());
   for (const auto& sym_shape_pos : sym_shape_positions_) {
     sym_shape_pos_vec.emplace_back(
         Tup({sym_shape_pos.input_idx_, sym_shape_pos.dim_idx_}));

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -227,6 +227,7 @@ flatbuffers::Offset<mobile::serialization::Function> FlatbufferSerializer::
 
   // instructions
   std::vector<mobile::serialization::Instruction> instruction_vector;
+  instruction_vector.reserve(code.instructions_.size());
   for (const auto& inst : code.instructions_) {
     instruction_vector.emplace_back(inst.op, inst.N, inst.X);
   }


### PR DESCRIPTION
Applies some clang-tidy static analysis fixes to some places where the std::vector could call.reserve() first to allocate the appropriate amount of space.
