### PR TITLE
[Fix]: remove unnecessary copies in aten, c10, and torch bindings

### DIFF
--- a/aten/src/ATen/EmptyTensor.cpp
+++ b/aten/src/ATen/EmptyTensor.cpp
@@ -354,7 +354,7 @@ TensorBase empty_symint_meta(
   at::detail::raise_warning_for_complex_half(scalar_type);
   caffe2::TypeMeta dtype = scalarTypeToTypeMeta(scalar_type);
   SymInt size_bytes = dtype.itemsize();
-  for (auto s : size) {
+  for (const auto& s : size) {
     size_bytes = size_bytes * s;
   }
   auto storage_impl = c10::make_intrusive<StorageImpl>(

--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -612,7 +612,7 @@ void functionalize_op_helper(const c10::OperatorHandle& op, torch::jit::Stack* s
   for (uint64_t idx = 0; idx < num_arguments; ++idx) {
     const auto& ivalue = arguments[idx];
     if (ivalue.isTensor()) {
-      auto t = ivalue.toTensor();
+      const auto& t = ivalue.toTensor();
       if (t.defined()) {
         TORCH_INTERNAL_ASSERT(!at::functionalization::impl::isFunctionalTensor(t),
           "The composite op functionalization fallback expects its inputs all not to be functional tensors");
@@ -659,7 +659,7 @@ void functionalize_op_helper(const c10::OperatorHandle& op, torch::jit::Stack* s
   for (const auto idx : c10::irange(num_returns)) {
     const auto& ivalue = returns[idx];
     if (ivalue.isTensor()) {
-      auto t = ivalue.toTensor();
+      const auto& t = ivalue.toTensor();
       if (!t.defined()) continue;
       at::functionalization::impl::sync(t);
       auto t_new = c10::IValue(at::functionalization::impl::from_functional_tensor(t));

--- a/aten/src/ATen/FunctionalizeFallbackKernel.cpp
+++ b/aten/src/ATen/FunctionalizeFallbackKernel.cpp
@@ -40,7 +40,7 @@ namespace {
       const auto& ivalue = arguments[idx];
       if (ivalue.isTensor()) {
         any_tensor_inputs = true;
-        auto t = ivalue.toTensor();
+        const auto& t = ivalue.toTensor();
         if (t.defined() && at::functionalization::impl::isFunctionalTensor(t)) {
           any_functional_inputs = true;
           at::functionalization::impl::sync(t);
@@ -81,7 +81,7 @@ namespace {
     for (const auto idx : c10::irange(num_returns)) {
       const auto& ivalue = returns[idx];
       if (ivalue.isTensor() && should_wrap_outputs) {
-        auto t = ivalue.toTensor();
+        const auto& t = ivalue.toTensor();
         if (!t.defined()) continue;
         auto t_new = c10::IValue(at::functionalization::impl::to_functional_tensor(t));
         (*stack)[returns_begin + idx] = t_new;

--- a/aten/src/ATen/core/Vitals.cpp
+++ b/aten/src/ATen/core/Vitals.cpp
@@ -60,7 +60,7 @@ std::string APIVitals::readVitals() {
   }
 
   std::stringstream buf;
-  for (auto x : name_map_) {
+  for (const auto& x : name_map_) {
     buf << x.second;
   }
   return buf.str();

--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -169,7 +169,7 @@ OperatorHandle Dispatcher::findOrRegisterName_(const OperatorName& op_name) {
 // Windows build doesn't produce the destructor symbol in PyTorch libs
 // causing a linker failure in downstream projects.
 // x-ref https://github.com/pytorch/pytorch/issues/70032
-OperatorHandle::~OperatorHandle() = default;
+
 
 RegistrationHandleRAII Dispatcher::registerLibrary(std::string ns, std::string debug) {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -169,7 +169,8 @@ OperatorHandle Dispatcher::findOrRegisterName_(const OperatorName& op_name) {
 // Windows build doesn't produce the destructor symbol in PyTorch libs
 // causing a linker failure in downstream projects.
 // x-ref https://github.com/pytorch/pytorch/issues/70032
-
+// NOLINTNEXTLINE(performance-trivially-destructible)
+OperatorHandle::~OperatorHandle() = default;
 
 RegistrationHandleRAII Dispatcher::registerLibrary(std::string ns, std::string debug) {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -343,7 +343,7 @@ public:
   OperatorHandle& operator=(OperatorHandle&&) noexcept = default;
   OperatorHandle(const OperatorHandle&) = default;
   OperatorHandle& operator=(const OperatorHandle&) = default;
-  ~OperatorHandle() = default;
+  ~OperatorHandle();
 
   const OperatorName& operator_name() const {
     return operatorDef_->op.operator_name();

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -343,7 +343,7 @@ public:
   OperatorHandle& operator=(OperatorHandle&&) noexcept = default;
   OperatorHandle(const OperatorHandle&) = default;
   OperatorHandle& operator=(const OperatorHandle&) = default;
-  ~OperatorHandle();
+  ~OperatorHandle() = default;
 
   const OperatorName& operator_name() const {
     return operatorDef_->op.operator_name();

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -450,7 +450,7 @@ bool IValue::isOptionalTensorList() const {
     return false;
   }
   const auto& ty = static_cast<detail::ListImpl*>(payload.u.as_intrusive_ptr)->elementType;
-  const auto expected_ty = c10::getTypePtr<c10::optional<at::Tensor>>();
+  const auto& expected_ty = c10::getTypePtr<c10::optional<at::Tensor>>();
   return expected_ty == ty;
 }
 

--- a/aten/src/ATen/functorch/ADInterpreters.cpp
+++ b/aten/src/ATen/functorch/ADInterpreters.cpp
@@ -144,7 +144,7 @@ static void autogradBasedTransformSendToNext(
       if (!ivalue.isTensor()) {
         continue; // only input that can be aliased is a tensor, not a tensor list (expect in ops without returns)
       }
-      const auto tensor = ivalue.toTensor();
+      const auto& tensor = ivalue.toTensor();
       auto* maybe_tensor_wrapper = maybeGetTensorWrapper(tensor);
       if (!maybe_tensor_wrapper || maybe_tensor_wrapper->is_immutable()) {
         // if the input is immutable, we find if it aliases anything, noting that

--- a/aten/src/ATen/functorch/BatchRulesLoss.cpp
+++ b/aten/src/ATen/functorch/BatchRulesLoss.cpp
@@ -258,7 +258,7 @@ at::Tensor nll_loss_backward_decomposition(
 
   Tensor weight_;
   if (weight && weight->defined()) {
-    auto self_ = self;
+    const auto& self_ = self;
     auto shape = weight->sizes();
     VmapDimVector new_shape(self_.dim(), 1);
     new_shape[channel_dim] = shape[0];

--- a/aten/src/ATen/functorch/BatchRulesNorm.cpp
+++ b/aten/src/ATen/functorch/BatchRulesNorm.cpp
@@ -55,9 +55,9 @@ batch_norm_batch_rule(
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
   c10::MaybeOwned<Tensor> running_mean_maybe_owned = at::borrow_from_optional_tensor(running_mean_opt);
-  auto running_mean = *running_mean_maybe_owned;
+  const auto& running_mean = *running_mean_maybe_owned;
   c10::MaybeOwned<Tensor> running_var_maybe_owned = at::borrow_from_optional_tensor(running_var_opt);
-  auto running_var = *running_var_maybe_owned;
+  const auto& running_var = *running_var_maybe_owned;
   TORCH_CHECK(!training || (!input_bdim || ((!running_mean.defined() || running_mean_bdim) && (!running_var.defined() || running_var_bdim))),
       "Batch norm got a batched tensor as input while the running_mean or running_var, which will be updated in place, ",
       "were not batched.\nIf you are using a module and do not need eval mode, please set `track_running_stats` to be False.",

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -315,7 +315,7 @@ struct ConvParams {
 
   bool is_output_padding_neg() const {
     bool is_non_neg = false;
-    for (auto p : output_padding) {
+    for (const auto& p : output_padding) {
       is_non_neg |= (p < 0);
     }
     return is_non_neg;
@@ -331,7 +331,7 @@ struct ConvParams {
 
   bool is_padding_neg() const {
     bool is_non_neg = false;
-    for (auto p : padding) {
+    for (const auto& p : padding) {
       is_non_neg |= (p < 0);
     }
     return is_non_neg;

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -46,7 +46,7 @@ Tensor embedding_symint(const Tensor & weight, const Tensor & indices,
   }
 
   auto size = indices.sym_sizes().vec();
-  for (auto d : weight.sym_sizes().slice(1)) {
+  for (const auto& d : weight.sym_sizes().slice(1)) {
     size.push_back(d);
   }
 

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -306,7 +306,7 @@ Tensor einsum(c10::string_view equation, TensorList operands, at::OptionalIntArr
   // We do this after parsing labels to make it more readable and simpler
   // to compute the number of dimensions covered by ellipsis.
   for(const auto i : c10::irange(num_ops)) {
-    const auto operand = operands[i];
+    const auto& operand = operands[i];
     const auto labels = op_labels[i];
     const auto ndims = operand.dim();
     int64_t nlabels = static_cast<int64_t>(labels.size());

--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -225,7 +225,7 @@ Tensor pad_sequence(TensorList sequences, bool batch_first, double padding_value
 
   Tensor out = at::full(out_dims, padding_value, sequences[0].options());
   for (const auto i : c10::irange(sequences_size)) {
-    const Tensor currseq = sequences[i];
+    const Tensor& currseq = sequences[i];
     const int64_t length_i = currseq.size(0);
     // use index notation to prevent duplicate references to the tensor
     if (batch_first) {

--- a/aten/src/ATen/native/PadNd.cpp
+++ b/aten/src/ATen/native/PadNd.cpp
@@ -118,9 +118,9 @@ Tensor _pad_circular_symint(const Tensor &self, c10::SymIntArrayRef padding) {
 
   // Get shape of padded tensor
   for (const auto i : c10::irange(ndim)) {
-    const auto pad_l = padding[2 * (ndim - i - 1) + 0];
-    const auto pad_r = padding[2 * (ndim - i - 1) + 1];
-    const auto size = in_shape[2 + i];
+    const auto& pad_l = padding[2 * (ndim - i - 1) + 0];
+    const auto& pad_r = padding[2 * (ndim - i - 1) + 1];
+    const auto& size = in_shape[2 + i];
     out_shape[2 + i] = size + pad_l + pad_r;
 
     TORCH_CHECK(
@@ -139,8 +139,8 @@ Tensor _pad_circular_symint(const Tensor &self, c10::SymIntArrayRef padding) {
   const SymInt zero = 0;
   for (const auto i : c10::irange(ndim)) {
     const auto dim = ndim - i + 1;
-    const auto pad_l = padding[2*i + 0];
-    const auto pad_r = padding[2*i + 1];
+    const auto& pad_l = padding[2*i + 0];
+    const auto& pad_r = padding[2*i + 1];
     out_slice = out_slice.slice_symint(dim, std::max(pad_l, zero), out_shape[dim] - std::max(pad_r, zero));
     in_slice = in_slice.slice_symint(dim, std::max(-pad_l, zero), in_shape[dim] - std::max(-pad_r, zero));
   }
@@ -154,8 +154,8 @@ Tensor _pad_circular_symint(const Tensor &self, c10::SymIntArrayRef padding) {
   // is required.
   for (const auto i : c10::irange(ndim)) {
     const auto dim = ndim - i + 1;
-    const auto pad_l = padding[2*i + 0];
-    const auto pad_r = padding[2*i + 1];
+    const auto& pad_l = padding[2*i + 0];
+    const auto& pad_r = padding[2*i + 1];
 
     if (pad_l > 0) {
       out_slice = out.slice_symint(dim, 0, pad_l);

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1060,7 +1060,7 @@ std::vector<Tensor> gradient_helper_float(const Tensor& self, ArrayRef<Scalar> s
   std::vector<Tensor> result;
   for (const auto i : c10::irange(dim.size())) {
       int64_t direction = maybe_wrap_dim(dim[i], self.dim());
-      auto ax_dx = spacing[i];
+      const auto& ax_dx = spacing[i];
       Tensor prepend, append;
       auto center  = (at::slice(self,direction, 2   ) - at::slice(self, direction, 0, -2 ) ) / ax_dx;
       if (edge_order==1) {

--- a/aten/src/ATen/native/TensorIteratorReduce.cpp
+++ b/aten/src/ATen/native/TensorIteratorReduce.cpp
@@ -41,7 +41,7 @@ static bool use_two_pass_reduction(TensorIteratorBase& iter) {
 static void two_pass_reduction(TensorIteratorBase& iter, loop2d_t loop) {
   const int max_threads = at::get_num_threads();
 
-  auto dst = iter.output(0);
+  const auto& dst = iter.output(0);
   auto unsqueezed = dst.unsqueeze(0);
   auto buffer_shape = DimVector(unsqueezed.sizes());
   buffer_shape[0] = max_threads;

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -240,7 +240,7 @@ bool_is_contiguous _compute_contiguous(
   T z = 1;
   // NB: make sure we do signed arithmetic
   for (int64_t d = int64_t(sizes.size()) - 1; d >= 0; d--) {
-    const auto size_d = sizes[d];
+    const auto& size_d = sizes[d];
     if (size_d != 1) {
       if (strides[d] == z) {
         z *= size_d;
@@ -288,7 +288,7 @@ bool_is_channels_last_contiguous _compute_channels_last_contiguous_2d(
     case 4: {
       T expected = 1;
       for (auto& d : {1, 3, 2, 0}) {
-        const auto size_d = sizes[d];
+        const auto& size_d = sizes[d];
         if (size_d != 1) {
           if (strides[d] != expected) {
             return bool_is_channels_last_contiguous(false);
@@ -325,7 +325,7 @@ bool_is_channels_last_3d_contiguous _compute_channels_last_contiguous_3d(
     case 5: {
       T expected = 1;
       for (auto& d : {1, 4, 3, 2, 0}) {
-        const auto size_d = sizes[d];
+        const auto& size_d = sizes[d];
         if (size_d != 1) {
           if (strides[d] != expected) {
             return bool_is_channels_last_3d_contiguous(false);
@@ -394,7 +394,7 @@ bool_is_non_overlapping_and_dense _compute_non_overlapping_and_dense(
   });
   T require_stride = 1;
   for (const auto i : c10::irange(dim)) {
-    const auto size_perm_i = sizes[perm[i]];
+    const auto& size_perm_i = sizes[perm[i]];
     if (size_perm_i < 2) {
       return bool_is_non_overlapping_and_dense(true);
     }

--- a/c10/util/Backtrace.cpp
+++ b/c10/util/Backtrace.cpp
@@ -121,7 +121,7 @@ c10::optional<FrameInformation> parse_frame_information(
   // `<object-file>(<mangled-function-name>+<offset-into-function>)
   // [<return-address>]`
 
-  auto function_name_start = frame_string.find("(");
+  auto function_name_start = frame_string.find('(');
   if (function_name_start == std::string::npos) {
     return c10::nullopt;
   }

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -905,7 +905,7 @@ std::vector<Tensor> cat_tensors_backward(
       grad_inputs[i] = at::zeros({0}, grad_val.options());
       continue;
     }
-    auto size = shape[dim];
+    const auto& size = shape[dim];
     accumulate += size;
     grad_inputs[i] = grad_val.narrow_symint(dim, accumulate - size, size);
   }
@@ -1410,7 +1410,7 @@ Tensor repeat_backward(
   at::SymDimVector grad_size;
   at::DimVector sum_dims;
   for (const auto dim : c10::irange(input_dims)) {
-    auto repeat = repeats[dim + num_unsqueezed];
+    const auto& repeat = repeats[dim + num_unsqueezed];
     // Reshape gradient (repeat > 1)
     // Index:      [..., dim    , ...]    [..., dim   ,  dim+1        , ...]
     // Shape: From [..., dimsize, ...] to [..., repeat, dimsize/repeat, ...]
@@ -1625,7 +1625,7 @@ Tensor masked_scatter_backward(
     const Tensor& mask,
     c10::SymIntArrayRef sizes) {
   c10::SymInt numel = 1;
-  for (auto size : sizes) {
+  for (const auto& size : sizes) {
     numel *= size;
   }
   auto mask_selected = grad.masked_select(mask);
@@ -1825,7 +1825,7 @@ Tensor split_with_sizes_backward(
     if (grads[j].defined()) {
       grads_all_defined[j] = grads[j];
     } else {
-      auto length = split_sizes[j];
+      const auto& length = split_sizes[j];
       auto grad_size = sizes.vec();
       grad_size[dim] = length;
       grads_all_defined[j] = at::zeros_symint(grad_size, options);
@@ -1843,7 +1843,7 @@ Tensor split_backward(
     c10::SymIntArrayRef sym_sizes,
     const at::TensorOptions& options) {
   dim = at::maybe_wrap_dim(dim, sym_sizes.size());
-  auto dim_size = sym_sizes[dim];
+  const auto& dim_size = sym_sizes[dim];
   int64_t num_splits = grads.size();
   std::vector<c10::SymInt> split_sizes(num_splits, split_size);
   split_sizes[num_splits - 1] =
@@ -2732,7 +2732,7 @@ static inline bool _maybe_overlapping_memory(
 
     c10::SymInt max_index_in_slice = 0;
     for (auto i : argsort) {
-      auto stride_ = strides[i];
+      const auto& stride_ = strides[i];
       if (stride_ <= max_index_in_slice) {
         return true;
       }
@@ -2751,7 +2751,7 @@ static inline c10::SymInt _min_storage_size(
   c10::SymInt storage_size = storage_offset + 1;
   int64_t dim = sizes.size();
   for (const auto i : c10::irange(dim)) {
-    auto size_i = sizes[i];
+    const auto& size_i = sizes[i];
     if (size_i == 0) {
       return storage_offset;
     }
@@ -2783,8 +2783,8 @@ Tensor as_strided_backward(
   out_sizes_.reserve(odim);
   out_strides_.reserve(odim);
   for (int64_t i = odim - 1; i >= 0; i--) {
-    auto size_i = sym_sizes[i];
-    auto stride_i = sym_strides[i];
+    const auto& size_i = sym_sizes[i];
+    const auto& stride_i = sym_strides[i];
     if (size_i == 0) {
       return at::zeros_symint(input_geometry.sym_sizes(), grad.options());
     } else if (size_i == 1) {
@@ -2814,8 +2814,8 @@ Tensor as_strided_backward(
   inp_sizes_.reserve(idim);
   inp_strides_.reserve(idim);
   for (int64_t i = idim - 1; i >= 0; i--) {
-    auto size_i = inp_sizes[i];
-    auto stride_i = inp_strides[i];
+    const auto& size_i = inp_sizes[i];
+    const auto& stride_i = inp_strides[i];
     if (size_i == 0) {
       return at::zeros_symint(input_geometry.sym_sizes(), grad.options());
     } else if (size_i != 1) {

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -376,7 +376,7 @@ static IValue addInput(
 
     // Unpack the list values statically
     for (const auto& entry : dict) {
-      IValue key = entry.key();
+      const IValue& key = entry.key();
       auto static_key = state->graph->insertConstant(key);
       auto static_value =
           state->graph->insert(aten::__getitem__, {value, static_key});

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -428,7 +428,7 @@ c10::optional<at::Tensor> ComputeConstantFolding(Node* n, int opset_version) {
         n, inputTensorValues, opset_version);
   } catch (const std::exception& ex) {
     auto ex_str = std::string(ex.what());
-    ex_str = ex_str.substr(0, ex_str.find("\n"));
+    ex_str = ex_str.substr(0, ex_str.find('\n'));
     TORCH_WARN("Constant folding in symbolic shape inference fails: ", ex_str);
     return c10::nullopt;
   }

--- a/torch/csrc/jit/passes/quantization/dedup_module_uses.cpp
+++ b/torch/csrc/jit/passes/quantization/dedup_module_uses.cpp
@@ -95,7 +95,7 @@ class ModuleUseDeduper {
         module, std::vector<std::string>(path.begin(), path.end() - 1));
 
     // Original name of the child module
-    std::string original_name = path[path.size() - 1];
+    const std::string& original_name = path[path.size() - 1];
     int uid = 0;
     std::string child_name = original_name + "_" + c10::to_string(uid++);
     while (parent_of_leaf.hasattr(child_name)) {

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -568,7 +568,7 @@ RegisterOperators reg_guard({
             }
           }
 
-          for (auto type : types) {
+          for (const auto& type : types) {
             auto tt = type->expect<TensorType>();
             auto ss = tt->symbolic_sizes();
             TORCH_INTERNAL_ASSERT(ss.rank());
@@ -720,7 +720,7 @@ void runTensorExprDynamicGroup(const Code& code, Stack& stack) {
 }
 
 Operation createTensorExprDynamicGroup(const Node* node) {
-  auto graph = node->g(attr::Subgraph);
+  const auto& graph = node->g(attr::Subgraph);
   Code code(graph, "");
   // This implementation creates a Code object and InterpreterState on every
   // call to TensorExprDynamicGroup, which affects performance. Ideally, we

--- a/torch/csrc/jit/tensorexpr/block_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/block_codegen.cpp
@@ -309,7 +309,7 @@ void BlockPrinter::visit(StorePtr v) {
 void BlockPrinter::visit(BlockPtr v) {
   os() << "{" << std::endl;
   indent_++;
-  for (StmtPtr s : v->stmts()) {
+  for (const StmtPtr& s : v->stmts()) {
     s->accept(this);
   }
   indent_--;

--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -76,7 +76,7 @@ std::unordered_map<VarPtr, BufPtr> getAllBufs(StmtPtr s) {
   std::unordered_map<VarPtr, BufPtr> varToBuf;
 
   auto bufs = NodeFinder<Buf>::find(s);
-  for (auto b : bufs) {
+  for (const auto& b : bufs) {
     varToBuf[b->base_handle()] = b;
   }
   return varToBuf;
@@ -86,7 +86,7 @@ std::unordered_map<VarPtr, BufPtr> getAllBufs(ExprPtr e) {
   std::unordered_map<VarPtr, BufPtr> varToBuf;
 
   auto bufs = NodeFinder<Buf>::find(e);
-  for (auto b : bufs) {
+  for (const auto& b : bufs) {
     varToBuf[b->base_handle()] = b;
   }
   return varToBuf;

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
@@ -326,7 +326,7 @@ std::vector<IndexBounds> subtractIndicesBounds(
 
     Bound remaining = A[i];
 
-    for (auto slice : slices) {
+    for (const auto& slice : slices) {
       IndexBounds newRegion;
       newRegion.reserve(A.size());
       TORCH_INTERNAL_ASSERT(

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -139,7 +139,7 @@ std::vector<std::pair<BufPtr, BufPtr>> AllocBufsWithMemReuse(
                                           BufPtr b1, BufPtr b2) -> bool {
     return std::get<1>(buf_ranges.at(b1)) < std::get<1>(buf_ranges.at(b2));
   };
-  for (auto buf : bufs_sorted) {
+  for (const auto& buf : bufs_sorted) {
     // If the buf has dynamic shapes, we'll skip it (i.e., allocate memory for
     // it, and there are no future reuses on its memory).
     // TODO: reuse memory for bufs with dynamic shapes
@@ -282,17 +282,17 @@ void CodeGen::allocIntermediateBufs() {
   // Identify intermediate buffers that are not allocated yet.
   auto bufs = NodeFinder<Buf>::find(stmt_);
   std::unordered_set<BufPtr> bufs_allocated;
-  for (auto b : buffer_args_) {
+  for (const auto& b : buffer_args_) {
     bufs_allocated.insert(b.buf());
   }
   auto allocs = NodeFinder<Allocate>::find(stmt_);
-  for (auto a : allocs) {
+  for (const auto& a : allocs) {
     bufs_allocated.insert(a->buf());
   }
 
   std::unordered_set<BufPtr> interm_bufs;
   std::unordered_map<BufPtr, std::tuple<int32_t, int32_t>> interm_buf_ranges;
-  for (auto buf : bufs) {
+  for (const auto& buf : bufs) {
     if (!bufs_allocated.count(buf) && !interm_bufs.count(buf)) {
       interm_bufs.insert(buf);
 

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -431,13 +431,13 @@ class SimpleIREvaluatorImpl : public IRVisitor {
   TORCH_API void visit(BlockPtr v) override {
     BlockPtr last = scope_;
     scope_ = v;
-    for (StmtPtr s : v->stmts()) {
+    for (const StmtPtr& s : v->stmts()) {
       s->accept(this);
     }
 
     auto it = var_by_scope_.find(v);
     if (it != var_by_scope_.end()) {
-      for (ExprPtr v : it->second) {
+      for (const ExprPtr& v : it->second) {
         eval_context_.erase(v);
       }
       var_by_scope_.erase(it);
@@ -847,7 +847,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
     std::vector<int8_t> buf_dtypes;
     std::vector<int64_t> extra_args;
 
-    for (BufPtr b : bufs) {
+    for (const BufPtr& b : bufs) {
       auto iter = buffer_mapping_.find(b);
       if (iter == buffer_mapping_.end()) {
         throw malformed_input("could not find buf", v);
@@ -856,7 +856,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
       buf_ptrs.push_back(iter->second);
       buf_ranks.push_back(b->dims().size());
       buf_dtypes.push_back((int8_t)b->dtype().scalar_type());
-      for (ExprPtr dim_expr : b->dims()) {
+      for (const ExprPtr& dim_expr : b->dims()) {
         dim_expr->accept(this);
         buf_dims.push_back(value().intValue());
       }
@@ -865,7 +865,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
         buf_strides.push_back(value().intValue());
       }
     }
-    for (ExprPtr a : v->args()) {
+    for (const ExprPtr& a : v->args()) {
       a->accept(this);
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t val;

--- a/torch/csrc/jit/tensorexpr/hash_provider.cpp
+++ b/torch/csrc/jit/tensorexpr/hash_provider.cpp
@@ -159,7 +159,7 @@ void HashProvider::visit(LoadPtr v) {
   CACHE_GUARD();
   v->base_handle()->accept(this);
   SimplifierHashType indices_hash;
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     ind->accept(this);
     indices_hash = hash_combine(indices_hash, hashOf(ind));
   }
@@ -170,7 +170,7 @@ void HashProvider::visit(StorePtr v) {
   CACHE_GUARD();
   v->base_handle()->accept(this);
   SimplifierHashType indices_hash;
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     ind->accept(this);
     indices_hash = hash_combine(indices_hash, hashOf(ind));
   }
@@ -185,7 +185,7 @@ void HashProvider::visit(BlockPtr v) {
   CACHE_GUARD();
   SimplifierHashType hash;
 
-  for (StmtPtr s : *v) {
+  for (const StmtPtr& s : *v) {
     s->accept(this);
     hash = hash_combine(hash, hashOf(s));
   }
@@ -258,7 +258,7 @@ void HashProvider::visit(AllocatePtr v) {
       hash_combine("allocate", hashOf(buffer_var), v->dtype());
 
   std::vector<ExprPtr> dims = v->dims();
-  for (ExprPtr dim : dims) {
+  for (const ExprPtr& dim : dims) {
     dim->accept(this);
     hash = hash_combine(hash, hashOf(dim));
   }
@@ -298,7 +298,7 @@ void HashProvider::visit(TermPtr v) {
   v->scalar()->accept(this);
 
   SimplifierHashType hash = hash_combine("term", hashOf(v->scalar()));
-  for (auto c : v->variables()) {
+  for (const auto& c : v->variables()) {
     c->accept(this);
     hash = hash_combine(hash, hashOf(c));
   }
@@ -311,7 +311,7 @@ void HashProvider::visit(PolynomialPtr v) {
   v->scalar()->accept(this);
 
   SimplifierHashType hash = hash_combine("term", hashOf(v->scalar()));
-  for (auto c : v->variables()) {
+  for (const auto& c : v->variables()) {
     c->accept(this);
     hash = hash_combine(hash, hashOf(c));
   }
@@ -327,7 +327,7 @@ void HashProvider::visit(MaxTermPtr v) {
     hash = hash_combine(hash, hashOf(v->scalar()));
   }
 
-  for (auto c : v->variables()) {
+  for (const auto& c : v->variables()) {
     c->accept(this);
     hash = hash_combine(hash, hashOf(c));
   }
@@ -343,7 +343,7 @@ void HashProvider::visit(MinTermPtr v) {
     hash = hash_combine(hash, hashOf(v->scalar()));
   }
 
-  for (auto c : v->variables()) {
+  for (const auto& c : v->variables()) {
     c->accept(this);
     hash = hash_combine(hash, hashOf(c));
   }

--- a/torch/csrc/jit/tensorexpr/ir_cloner.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_cloner.cpp
@@ -141,7 +141,7 @@ ExprPtr IRCloner::mutate(RampPtr v) {
 ExprPtr IRCloner::mutate(LoadPtr v) {
   std::vector<ExprPtr> indices_new;
   indices_new.reserve(v->indices().size());
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     indices_new.push_back(ind->accept_mutator(this));
   }
   BufPtr buf_new = to<Buf>(v->buf()->accept_mutator(this));
@@ -180,7 +180,7 @@ ExprPtr IRCloner::mutate(IfThenElsePtr v) {
 ExprPtr IRCloner::mutate(IntrinsicsPtr v) {
   std::vector<ExprPtr> params_new;
   params_new.reserve(v->nparams());
-  for (auto param : v->params()) {
+  for (const auto& param : v->params()) {
     params_new.push_back(param->accept_mutator(this));
   }
   return alloc<Intrinsics>(v->op_type(), v->dtype(), params_new);
@@ -191,7 +191,7 @@ ExprPtr IRCloner::mutate(TermPtr v) {
 
   std::vector<ExprPtr> variables_new;
   variables_new.reserve(v->variables().size());
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     variables_new.push_back(t->accept_mutator(this));
   }
   return alloc<Term>(v->hasher(), scalar_new, variables_new);
@@ -202,7 +202,7 @@ ExprPtr IRCloner::mutate(PolynomialPtr v) {
 
   std::vector<TermPtr> variables_new;
   variables_new.reserve(v->variables().size());
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     variables_new.push_back(static_to<Term>(t->accept_mutator(this)));
   }
   return alloc<Polynomial>(v->hasher(), scalar_new, variables_new);
@@ -219,7 +219,7 @@ ExprPtr IRCloner::mutate(MaxTermPtr v) {
 
   std::vector<ExprPtr> variables_new;
   variables_new.reserve(v->variables().size());
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     variables_new.push_back(t->accept_mutator(this));
   }
   return alloc<MaxTerm>(
@@ -232,7 +232,7 @@ ExprPtr IRCloner::mutate(MinTermPtr v) {
 
   std::vector<ExprPtr> variables_new;
   variables_new.reserve(v->variables().size());
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     variables_new.push_back(t->accept_mutator(this));
   }
   return alloc<MinTerm>(
@@ -244,7 +244,7 @@ ExprPtr IRCloner::mutate(ReduceOpPtr v) {
 
   std::vector<VarPtr> reduce_args_new;
   reduce_args_new.reserve(v->reduce_args().size());
-  for (auto r : v->reduce_args()) {
+  for (const auto& r : v->reduce_args()) {
     reduce_args_new.push_back(static_to<Var>(r->accept_mutator(this)));
   }
 
@@ -262,7 +262,7 @@ StmtPtr IRCloner::mutate(ForPtr v) {
 StmtPtr IRCloner::mutate(BlockPtr v) {
   std::vector<StmtPtr> stmts_new;
   stmts_new.reserve(v->nstmts());
-  for (StmtPtr stmt : *v) {
+  for (const StmtPtr& stmt : *v) {
     stmts_new.push_back(stmt->accept_mutator(this));
   }
   return alloc<Block>(stmts_new);
@@ -271,7 +271,7 @@ StmtPtr IRCloner::mutate(BlockPtr v) {
 StmtPtr IRCloner::mutate(StorePtr v) {
   std::vector<ExprPtr> indices_new;
   indices_new.reserve(v->indices().size());
-  for (auto ind : v->indices()) {
+  for (const auto& ind : v->indices()) {
     indices_new.push_back(ind->accept_mutator(this));
   }
   auto value_new = v->value()->accept_mutator(this);
@@ -282,7 +282,7 @@ StmtPtr IRCloner::mutate(StorePtr v) {
 StmtPtr IRCloner::mutate(AtomicAddPtr v) {
   std::vector<ExprPtr> indices_new;
   indices_new.reserve(v->indices().size());
-  for (auto ind : v->indices()) {
+  for (const auto& ind : v->indices()) {
     indices_new.push_back(ind->accept_mutator(this));
   }
   auto value_new = v->value()->accept_mutator(this);
@@ -309,12 +309,12 @@ StmtPtr IRCloner::mutate(ExternalCallPtr v) {
 
   std::vector<BufPtr> buf_args_new;
   buf_args_new.reserve(v->buf_args().size());
-  for (BufPtr buf_arg : v->buf_args()) {
+  for (const BufPtr& buf_arg : v->buf_args()) {
     buf_args_new.push_back(to<Buf>(buf_arg->accept_mutator(this)));
   }
   std::vector<ExprPtr> args_new;
   args_new.reserve(v->args().size());
-  for (ExprPtr arg : v->args()) {
+  for (const ExprPtr& arg : v->args()) {
     args_new.push_back(arg->accept_mutator(this));
   }
 

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -160,7 +160,7 @@ ExprPtr IRMutator::mutate(LoadPtr v) {
   bool any_index_changed = false;
   std::vector<ExprPtr> indices_new;
   indices_new.reserve(v->indices().size());
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     ExprPtr new_ind = ind->accept_mutator(this);
     if (new_ind != ind) {
       any_index_changed = true;
@@ -269,7 +269,7 @@ ExprPtr IRMutator::mutate(TermPtr v) {
   ExprPtr newScalar = v->scalar()->accept_mutator(this);
 
   std::vector<ExprPtr> variables;
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     variables.push_back(t->accept_mutator(this));
   }
   return alloc<Term>(v->hasher(), newScalar, variables);
@@ -279,7 +279,7 @@ ExprPtr IRMutator::mutate(PolynomialPtr v) {
   ExprPtr newScalar = v->scalar()->accept_mutator(this);
 
   std::vector<TermPtr> variables;
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     variables.push_back(static_to<Term>(t->accept_mutator(this)));
   }
   return alloc<Polynomial>(v->hasher(), newScalar, variables);
@@ -297,7 +297,7 @@ ExprPtr IRMutator::mutate(MaxTermPtr v) {
   }
 
   std::vector<ExprPtr> variables;
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     variables.push_back(t->accept_mutator(this));
   }
   return alloc<MaxTerm>(v->hasher(), newScalar, v->propagate_nans(), variables);
@@ -310,7 +310,7 @@ ExprPtr IRMutator::mutate(MinTermPtr v) {
   }
 
   std::vector<ExprPtr> variables;
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     variables.push_back(t->accept_mutator(this));
   }
   return alloc<MinTerm>(v->hasher(), newScalar, v->propagate_nans(), variables);
@@ -320,7 +320,7 @@ ExprPtr IRMutator::mutate(ReduceOpPtr v) {
   ExprPtr body_new = v->body()->accept_mutator(this);
 
   std::vector<VarPtr> new_reduce_args;
-  for (auto r : v->reduce_args()) {
+  for (const auto& r : v->reduce_args()) {
     new_reduce_args.push_back(static_to<Var>(r->accept_mutator(this)));
   }
 
@@ -360,7 +360,7 @@ StmtPtr IRMutator::mutate(BlockPtr v) {
   bool any_change = false;
 
   std::vector<StmtPtr> stmts;
-  for (StmtPtr stmt : *v) {
+  for (const StmtPtr& stmt : *v) {
     StmtPtr stmt_new = stmt->accept_mutator(this);
     if (stmt != stmt_new) {
       any_change = true;
@@ -382,7 +382,7 @@ StmtPtr IRMutator::mutate(StorePtr v) {
 
   bool any_index_changed = false;
   std::vector<ExprPtr> indices_new;
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     ExprPtr new_ind = ind->accept_mutator(this);
     if (new_ind != ind) {
       any_index_changed = true;
@@ -410,7 +410,7 @@ StmtPtr IRMutator::mutate(AtomicAddPtr v) {
 
   bool any_index_changed = false;
   std::vector<ExprPtr> indices_new;
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     ExprPtr new_ind = ind->accept_mutator(this);
     if (new_ind != ind) {
       any_index_changed = true;
@@ -446,7 +446,7 @@ StmtPtr IRMutator::mutate(ExternalCallPtr v) {
   bool buf_args_changed = false;
   std::vector<BufPtr> buf_args_new;
   buf_args_new.reserve(v->buf_args().size());
-  for (BufPtr buf_arg : v->buf_args()) {
+  for (const BufPtr& buf_arg : v->buf_args()) {
     BufPtr buf_arg_new = to<Buf>(buf_arg->accept_mutator(this));
     TORCH_INTERNAL_ASSERT(
         buf_arg_new, buildErrorMessage("IRMutator produced null for Buf."));
@@ -457,7 +457,7 @@ StmtPtr IRMutator::mutate(ExternalCallPtr v) {
   bool args_changed = false;
   std::vector<ExprPtr> args_new;
   args_new.reserve(v->args().size());
-  for (ExprPtr arg : v->args()) {
+  for (const ExprPtr& arg : v->args()) {
     ExprPtr arg_new = arg->accept_mutator(this);
     args_new.push_back(arg_new);
     args_changed |= arg_new != arg;

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -293,7 +293,7 @@ void IRPrinter::visit(LoadPtr v) {
   } else {
     os() << *v->base_handle() << "[";
     size_t i = 0;
-    for (ExprPtr ind : v->indices()) {
+    for (const ExprPtr& ind : v->indices()) {
       if (i++) {
         os() << ", ";
       }
@@ -329,7 +329,7 @@ void IRPrinter::visit(IntrinsicsPtr v) {
 void IRPrinter::visit(TermPtr v) {
   os() << "Term(";
   v->scalar()->accept(this);
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     os() << ",";
     t->accept(this);
   }
@@ -339,7 +339,7 @@ void IRPrinter::visit(TermPtr v) {
 void IRPrinter::visit(PolynomialPtr v) {
   bool first = true;
   os() << "Polynomial(";
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     if (!first) {
       os() << " + ";
     }
@@ -398,7 +398,7 @@ void IRPrinter::visit(ReduceOpPtr v) {
 
   bool first = true;
   os() << "reduce_args={";
-  for (auto d : v->reduce_args()) {
+  for (const auto& d : v->reduce_args()) {
     if (!first) {
       os() << ", ";
     }
@@ -423,7 +423,7 @@ void IRPrinter::visit(StorePtr v) {
 
   os() << *v->base_handle() << "[";
   size_t i = 0;
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     if (i++) {
       os() << ", ";
     }
@@ -456,7 +456,7 @@ void IRPrinter::visit(BlockPtr v) {
   os() << "{\n";
   indent_++;
 
-  for (StmtPtr s : *v) {
+  for (const StmtPtr& s : *v) {
     emitIndent();
     os() << *s << "\n";
   }
@@ -526,7 +526,7 @@ void IRPrinter::visit(CondPtr v) {
 void IRPrinter::visit(AtomicAddPtr v) {
   os() << "atomicAdd(&" << *v->base_handle() << "[";
   size_t i = 0;
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     if (i++) {
       os() << ", ";
     }
@@ -547,7 +547,7 @@ void IRPrinter::visit(ExternalCallPtr v) {
 
   os() << "buf_args={";
   int i = 0;
-  for (BufPtr buf_arg : v->buf_args()) {
+  for (const BufPtr& buf_arg : v->buf_args()) {
     if (i++ > 0) {
       os() << ", ";
     }
@@ -556,7 +556,7 @@ void IRPrinter::visit(ExternalCallPtr v) {
 
   os() << "}, args={";
   i = 0;
-  for (ExprPtr arg : v->args()) {
+  for (const ExprPtr& arg : v->args()) {
     if (i++ > 0) {
       os() << ", ";
     }

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -88,7 +88,7 @@ bool isMultilanePrimitive(ExprPtr e) {
 
 SimplifierHashType Term::hashVars() const {
   SimplifierHashType hash;
-  for (auto v : variables_) {
+  for (const auto& v : variables_) {
     hash = hasher_.hash_combine(hash, hasher_.hash(v));
   }
 
@@ -114,7 +114,7 @@ void Term::sort() {
 
 SimplifierHashType Polynomial::hashVars() const {
   SimplifierHashType hash;
-  for (auto v : variables_) {
+  for (const auto& v : variables_) {
     hash = hasher_.hash_combine(hash, hasher_.hash(v));
   }
   return hash;
@@ -311,10 +311,10 @@ ExprPtr PolynomialTransformer::addPolynomials(
   // to combine terms that have the same vars but different scalar components.
   std::unordered_map<SimplifierHashType, TermPtr> varmap;
 
-  for (auto lt : lhs->variables()) {
+  for (const auto& lt : lhs->variables()) {
     addOrUpdateTerm(varmap, lt);
   }
-  for (auto rt : rhs->variables()) {
+  for (const auto& rt : rhs->variables()) {
     addOrUpdateTerm(varmap, rt);
   }
 
@@ -329,7 +329,7 @@ ExprPtr PolynomialTransformer::insertTerm(PolynomialPtr poly, TermPtr term) {
   std::vector<TermPtr> newVars;
 
   bool found = false;
-  for (auto v : poly->variables()) {
+  for (const auto& v : poly->variables()) {
     if (v->hashVars() == tHash) {
       ExprPtr newScalar = evaluateOp(alloc<Add>(term->scalar(), v->scalar()));
       found = true;
@@ -520,11 +520,11 @@ ExprPtr PolynomialTransformer::subPolynomials(
   // to combine terms that have the same vars but different scalar components.
   std::unordered_map<SimplifierHashType, TermPtr> varmap;
 
-  for (auto lt : lhs->variables()) {
+  for (const auto& lt : lhs->variables()) {
     addOrUpdateTerm(varmap, lt);
   }
 
-  for (auto rt : rhs->variables()) {
+  for (const auto& rt : rhs->variables()) {
     // Polynomials add their terms, so negate the RHS's Terms.
     ExprPtr negated = evaluateOp(alloc<Mul>(immLike(rt, -1), rt->scalar()));
     TermPtr newRHS = alloc<Term>(hasher_, negated, rt->variables());
@@ -614,7 +614,7 @@ ExprPtr PolynomialTransformer::mutate(SubPtr v) {
     ExprPtr negateScalar = evaluateOp(alloc<Mul>(minusOne, rhsPoly->scalar()));
 
     std::vector<TermPtr> variables;
-    for (auto t : rhsPoly->variables()) {
+    for (const auto& t : rhsPoly->variables()) {
       ExprPtr negate = evaluateOp(alloc<Mul>(minusOne, t->scalar()));
       variables.push_back(alloc<Term>(hasher_, negate, t->variables()));
     }
@@ -643,7 +643,7 @@ ExprPtr PolynomialTransformer::mutate(SubPtr v) {
     // Negate each term in the Polynomial RHS.
     ExprPtr minusOne = immLike(rhsPoly, -1);
     std::vector<TermPtr> variables;
-    for (auto t : rhsPoly->variables()) {
+    for (const auto& t : rhsPoly->variables()) {
       ExprPtr negate = evaluateOp(alloc<Mul>(minusOne, t->scalar()));
       variables.push_back(alloc<Term>(hasher_, negate, t->variables()));
     }
@@ -709,7 +709,7 @@ ExprPtr PolynomialTransformer::mutate(SubPtr v) {
 
     // Negate each term in the Polynomial RHS.
     std::vector<TermPtr> variables;
-    for (auto t : rhsPoly->variables()) {
+    for (const auto& t : rhsPoly->variables()) {
       ExprPtr negate = evaluateOp(alloc<Mul>(minusOne, t->scalar()));
       variables.push_back(alloc<Term>(hasher_, negate, t->variables()));
     }
@@ -733,14 +733,14 @@ TermPtr PolynomialTransformer::mulTerms(TermPtr lhs, TermPtr rhs) {
   std::vector<ExprPtr> variables;
   std::vector<ExprPtr> multilaneVariables;
   // For now don't handle exponents.
-  for (auto c : lhs->variables()) {
+  for (const auto& c : lhs->variables()) {
     if (isMultilanePrimitive(c)) {
       multilaneVariables.push_back(c);
     } else {
       variables.push_back(c);
     }
   }
-  for (auto c : rhs->variables()) {
+  for (const auto& c : rhs->variables()) {
     if (isMultilanePrimitive(c)) {
       multilaneVariables.push_back(c);
     } else {
@@ -750,7 +750,7 @@ TermPtr PolynomialTransformer::mulTerms(TermPtr lhs, TermPtr rhs) {
 
   // Merge all the multilane vars:
   ExprPtr lastNode{nullptr};
-  for (auto node : multilaneVariables) {
+  for (const auto& node : multilaneVariables) {
     if (lastNode == nullptr) {
       lastNode = node;
     } else {
@@ -778,7 +778,7 @@ ExprPtr PolynomialTransformer::polyByTerm(PolynomialPtr poly, TermPtr term) {
   // First, multiply all variables (terms) in the polynomial by the input
   // term.
   std::vector<TermPtr> newTerms;
-  for (auto var : poly->variables()) {
+  for (const auto& var : poly->variables()) {
     TermPtr newTerm = mulTerms(var, term);
     if (newTerm) {
       newTerms.push_back(newTerm);
@@ -854,7 +854,7 @@ ExprPtr PolynomialTransformer::insertIntoTerm(TermPtr term, ExprPtr expr) {
 
   // Search for RoundOffs.
   bool merged{false};
-  for (auto component : term->variables()) {
+  for (const auto& component : term->variables()) {
     if (auto roundoff = isRoundOff(component, expr)) {
       vars.push_back(roundoff);
       merged = true;
@@ -1137,7 +1137,7 @@ ExprPtr PolynomialTransformer::mutate(ModPtr v) {
     }
 
     // (x * y * z) % x => 0.
-    for (auto component : lhsTerm->variables()) {
+    for (const auto& component : lhsTerm->variables()) {
       if (hasher_.hash(component) == hasher_.hash(rhs_new)) {
         return immLike(v, 0);
       }
@@ -1205,10 +1205,10 @@ ExprPtr combineMinMaxTerms(
   auto combine_opterms = [&](NodePtr<OpTerm> m1, NodePtr<OpTerm> m2) {
     ExprPtr scalar = combine_scalars(m1->scalar(), m2->scalar());
     std::vector<ExprPtr> variables;
-    for (auto v : m1->variables()) {
+    for (const auto& v : m1->variables()) {
       variables.push_back(v);
     }
-    for (auto v : m2->variables()) {
+    for (const auto& v : m2->variables()) {
       variables.push_back(v);
     }
     return alloc<OpTerm>(hasher, scalar, propagate_nans, std::move(variables));
@@ -1469,7 +1469,7 @@ ExprPtr PolynomialTransformer::mutate(IntrinsicsPtr v) {
   std::vector<ExprPtr> new_params;
   bool changed = false;
   bool allConstant = true;
-  for (auto p : v->params()) {
+  for (const auto& p : v->params()) {
     ExprPtr new_child = p->accept_mutator(this);
     new_params.push_back(new_child);
 
@@ -1489,7 +1489,7 @@ ExprPtr PolynomialTransformer::mutate(IntrinsicsPtr v) {
   // we're evaluating, but the evaluator only supports float intrinsics.
   std::vector<ExprPtr> const_params;
   changed = false;
-  for (auto p : new_params) {
+  for (const auto& p : new_params) {
     if (p->dtype().scalar_type() == ScalarType::Float) {
       const_params.push_back(p);
     } else {
@@ -1616,7 +1616,7 @@ StmtPtr handleForCondReordering(ForPtr loop, CondPtr cond) {
   }
 
   auto condition_vars = VarFinder::find(cond->condition());
-  for (auto v : condition_vars) {
+  for (const auto& v : condition_vars) {
     // If the condition depends on a Var that is modified in the loop body, it
     // may not be safe to reorder.
     if (ModifiesVarChecker::check(loop, v)) {
@@ -1691,7 +1691,7 @@ StmtPtr PolynomialBase::mutate(BlockPtr v) {
   std::vector<StmtPtr> stmts;
   // Flatten sub-blocks:
   bool stmts_changed = false;
-  for (StmtPtr stmt : *v) {
+  for (const StmtPtr& stmt : *v) {
     StmtPtr stmt_new = stmt->accept_mutator(this);
     stmts_changed |= stmt != stmt_new;
     if (stmt_new == nullptr) {
@@ -1730,7 +1730,7 @@ ExprPtr TermExpander::mutate(TermPtr v) {
 
   // Assume we can reorder here because we wont merge floating terms.
   ExprPtr lastNode{nullptr};
-  for (auto var : v->variables()) {
+  for (const auto& var : v->variables()) {
     ExprPtr node = var->accept_mutator(this);
     if (MulPtr mul = to<Mul>(node)) {
       // If the sub-Expr resolved to a multiplication, lift it into this
@@ -1755,7 +1755,7 @@ ExprPtr TermExpander::mutate(TermPtr v) {
     }
   }
 
-  for (auto node : multilaneVars) {
+  for (const auto& node : multilaneVars) {
     if (lastNode == nullptr) {
       lastNode = node;
     } else {
@@ -1766,7 +1766,7 @@ ExprPtr TermExpander::mutate(TermPtr v) {
     }
   }
 
-  for (auto node : vars) {
+  for (const auto& node : vars) {
     if (lastNode == nullptr) {
       lastNode = node;
     } else {
@@ -1817,7 +1817,7 @@ ExprPtr polyGCD(PolynomialPtr poly) {
   // value in factorizing 6x + 4y into 2 * (3x + 2y) since we don't save work.
   int opsSaved = 1; // default to saving the scalar.
   long GCD = std::abs(immediateAs<long>(scalar));
-  for (auto t : variables) {
+  for (const auto& t : variables) {
     long termScalar = std::abs(immediateAs<long>(t->scalar()));
     long newGCD = gcd(std::max(GCD, termScalar), std::min(GCD, termScalar));
     if (newGCD == 1) {
@@ -1877,7 +1877,7 @@ c10::optional<class ModRound> isModRound(TermPtr e) {
   ExprPtr scalar{nullptr};
   ExprPtr other{nullptr};
 
-  for (auto m : e->variables()) {
+  for (const auto& m : e->variables()) {
     if (m->expr_type() == IRNodeType::kMod) {
       // TODO: currently only identify terms with one variable being mod; it is
       // possible to extend this if we have to handle terms like (t/(x%2 * y) %
@@ -1983,7 +1983,7 @@ ExprPtr simplifyRoundModPattern(PolynomialPtr poly) {
   std::vector<TermPtr> others;
 
   // Split out the Mod, ModRounds and RoundOffs operations so we can inspect.
-  for (auto c : poly->variables()) {
+  for (const auto& c : poly->variables()) {
     if (c->variables().size() > 1) {
       if (auto a = isModRound(c)) {
         mod_rounds.push_back(c);
@@ -2147,7 +2147,7 @@ TermPtr PolynomialBase::factorizePolynomial(PolynomialPtr poly) {
   // Create new struture.
   std::vector<TermPtr> newPolyTerms;
   newPolyTerms.reserve(variables.size());
-  for (auto t : variables) {
+  for (const auto& t : variables) {
     // New term with the scalar divided by the GCD.
     newPolyTerms.push_back(alloc<Term>(
         poly->hasher(),
@@ -2192,7 +2192,7 @@ ExprPtr TermExpander::mutate(PolynomialPtr v) {
   });
 
   // partition the terms into a list to add and list to subtract.
-  for (auto node : vars) {
+  for (const auto& node : vars) {
     if (immediateIsNegative(node->scalar())) {
       subTerms.push_back(node);
     } else if (!immediateEquals(node->scalar(), 0)) {
@@ -2204,7 +2204,7 @@ ExprPtr TermExpander::mutate(PolynomialPtr v) {
   // The last node constructed.
   ExprPtr lastNode{nullptr};
 
-  for (auto node : addTerms) {
+  for (const auto& node : addTerms) {
     ExprPtr simpleNode = node->accept_mutator(this);
 
     if (lastNode == nullptr) {
@@ -2237,7 +2237,7 @@ ExprPtr TermExpander::mutate(PolynomialPtr v) {
     }
   }
 
-  for (auto node : subTerms) {
+  for (const auto& node : subTerms) {
     // Can still be first node if scalarVal is 0.
     if (lastNode == nullptr) {
       lastNode = node->accept_mutator(this);
@@ -2392,7 +2392,7 @@ BlockPtr TermExpander::fuseConditions(BlockPtr v) {
   bool did_anything = false;
   CondPtr prev_cond = nullptr;
 
-  for (auto s : *v) {
+  for (const auto& s : *v) {
     CondPtr cond = to<Cond>(s);
     if (!cond) {
       prev_cond = nullptr;
@@ -2456,7 +2456,7 @@ BlockPtr TermExpander::fuseConditions(BlockPtr v) {
   }
 
   // clean up parents.
-  for (auto s : stmts) {
+  for (const auto& s : stmts) {
     if (s->get_parent() == v) {
       v->remove_stmt(s);
     }
@@ -2472,7 +2472,7 @@ StmtPtr TermExpander::fuseSyncThreads(BlockPtr block) {
   std::vector<StmtPtr> stmts;
   bool did_anything = false;
 
-  for (auto s : *block) {
+  for (const auto& s : *block) {
     SyncThreadsPtr sync = to<SyncThreads>(s);
     if (!sync) {
       first = false;
@@ -2501,7 +2501,7 @@ StmtPtr TermExpander::fuseSyncThreads(BlockPtr block) {
   }
 
   // clean up parents.
-  for (auto s : stmts) {
+  for (const auto& s : stmts) {
     if (s->get_parent() == block) {
       block->remove_stmt(s);
     }

--- a/torch/csrc/jit/tensorexpr/ir_verifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_verifier.cpp
@@ -178,7 +178,7 @@ void IRVerifier::visit(ForPtr v) {
 }
 
 void IRVerifier::visit(BlockPtr v) {
-  for (StmtPtr s : v->stmts()) {
+  for (const StmtPtr& s : v->stmts()) {
     if (s->get_parent() != v) {
       throw malformed_ir("Broken child-parent link inside a Block");
     }

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -97,7 +97,7 @@ void IRVisitor::visit(RampPtr v) {
 
 void IRVisitor::visit(LoadPtr v) {
   v->buf()->accept(this);
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     ind->accept(this);
   }
 }
@@ -114,7 +114,7 @@ void IRVisitor::visit(BufPtr v) {
 
 void IRVisitor::visit(StorePtr v) {
   v->buf()->accept(this);
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     ind->accept(this);
   }
   v->value()->accept(this);
@@ -122,7 +122,7 @@ void IRVisitor::visit(StorePtr v) {
 
 void IRVisitor::visit(AtomicAddPtr v) {
   v->buf()->accept(this);
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     ind->accept(this);
   }
   v->value()->accept(this);
@@ -132,10 +132,10 @@ void IRVisitor::visit(SyncThreadsPtr v) {}
 
 void IRVisitor::visit(ExternalCallPtr v) {
   v->buf()->accept(this);
-  for (BufPtr buf_arg : v->buf_args()) {
+  for (const BufPtr& buf_arg : v->buf_args()) {
     buf_arg->accept(this);
   }
-  for (ExprPtr arg : v->args()) {
+  for (const ExprPtr& arg : v->args()) {
     arg->accept(this);
   }
 }
@@ -159,7 +159,7 @@ void IRVisitor::visit(FreeExtPtr v) {
 }
 
 void IRVisitor::visit(BlockPtr v) {
-  for (StmtPtr s : *v) {
+  for (const StmtPtr& s : *v) {
     s->accept(this);
   }
 }
@@ -192,7 +192,7 @@ void IRVisitor::visit(IntrinsicsPtr v) {
 void IRVisitor::visit(AllocatePtr v) {
   v->buffer_var()->accept(this);
   std::vector<ExprPtr> dims = v->dims();
-  for (ExprPtr dim : dims) {
+  for (const ExprPtr& dim : dims) {
     dim->accept(this);
   }
 }
@@ -226,14 +226,14 @@ void IRVisitor::visit(CondPtr v) {
 
 void IRVisitor::visit(TermPtr v) {
   v->scalar()->accept(this);
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     t->accept(this);
   }
 }
 
 void IRVisitor::visit(PolynomialPtr v) {
   v->scalar()->accept(this);
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     t->accept(this);
   }
 }
@@ -247,7 +247,7 @@ void IRVisitor::visit(MaxTermPtr v) {
   if (v->scalar()) {
     v->scalar()->accept(this);
   }
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     t->accept(this);
   }
 }
@@ -256,7 +256,7 @@ void IRVisitor::visit(MinTermPtr v) {
   if (v->scalar()) {
     v->scalar()->accept(this);
   }
-  for (auto t : v->variables()) {
+  for (const auto& t : v->variables()) {
     t->accept(this);
   }
 }
@@ -264,7 +264,7 @@ void IRVisitor::visit(MinTermPtr v) {
 void IRVisitor::visit(ReduceOpPtr v) {
   v->body()->accept(this);
 
-  for (auto r : v->reduce_args()) {
+  for (const auto& r : v->reduce_args()) {
     r->accept(this);
   }
 }

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -845,7 +845,7 @@ StmtPtr TensorExprKernel::transformLoops(BackendType backendType, StmtPtr st) {
   }
 
   if (backendType == kCudaCodeGen) {
-    for (auto buf : bufOutputs_) {
+    for (const auto& buf : bufOutputs_) {
       std::vector<ForPtr> loops = l.getLoopStmtsFor(buf);
       if (loops.empty()) {
         // This happens when Buf is 0-dim
@@ -893,7 +893,7 @@ StmtPtr TensorExprKernel::transformLoops(BackendType backendType, StmtPtr st) {
   }
 
   if (backendType == kBlockCodeGen) {
-    for (auto buf : bufOutputs_) {
+    for (const auto& buf : bufOutputs_) {
       const int default_fp16_blocksize = 16;
       const int default_uint8_blocksize = 32;
       int blockSize = default_fp16_blocksize;
@@ -1294,8 +1294,7 @@ Tensor TensorExprKernel::convertSymbolicOutputToCorrectStrides(
         std::vector<ExprHandle> new_axes(
             sorted_stride_indices_descending.size());
         for (size_t stride_index : sorted_stride_indices_descending) {
-          auto size = sizes[stride_index];
-          auto stride = strides[stride_index];
+          const auto& stride = strides[stride_index];
           auto index = absolute_position / ExprHandle(stride);
           // XXX, in symbolic output ordering, we do not the arbitrary
           // ordering of strides as in usual output ordering, just
@@ -1466,7 +1465,7 @@ std::vector<BufPtr> TensorExprKernel::preAllocIntermediateBufs(
     const std::vector<BufPtr>& interm_bufs) {
   std::vector<BufPtr> remaining_interm_bufs;
   std::vector<std::pair<BufPtr, void*>> allocated_bufs;
-  for (auto buf : interm_bufs) {
+  for (const auto& buf : interm_bufs) {
     // Check if buf shape is static and compute its size if static.
     bool is_static = true;
     size_t size =
@@ -1838,7 +1837,7 @@ void TensorExprKernel::compile() {
   BackendType backendType = inferBackendTypeFromDevice(device_);
   stmt_ = transformLoops(backendType, block);
 
-  for (auto c : constants_) {
+  for (const auto& c : constants_) {
     bufferArgs_.emplace_back(BufHandle(c.buf));
   }
 
@@ -2016,7 +2015,7 @@ std::vector<CodeGen::CallArg> TensorExprKernel::prepareRunArgs(
     }
   }
 
-  for (auto c : constants_) {
+  for (const auto& c : constants_) {
     runArgs.emplace_back(c.ptr);
   }
 
@@ -2060,7 +2059,7 @@ void TensorExprKernel::runFast(
   args.insert(args.end(), outputs.begin(), outputs.end());
 
   // TODO: we can consider preallocating and pre-filling the args vector.
-  for (auto c : constants_) {
+  for (const auto& c : constants_) {
     args.push_back(c.ptr);
   }
 

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -68,7 +68,7 @@ std::vector<BufPtr> LoopNest::getIntermediateBufs() const {
   std::unordered_set<BufPtr> result_set;
   auto input_bufs = getInputBufs();
   auto bufs = NodeFinder<Buf>::find(root_stmt_);
-  for (auto buf : bufs) {
+  for (const auto& buf : bufs) {
     if (!output_bufs_.count(buf) && !input_bufs.count(buf) &&
         !result_set.count(buf)) {
       result.push_back(buf);
@@ -512,7 +512,7 @@ class Vectorizer : public IRMutator {
     // TODO: Can we change the logic of vectorizer so that we don't need this?
     bool any_change = false;
     std::vector<StmtPtr> stmts;
-    for (StmtPtr stmt : *v) {
+    for (const StmtPtr& stmt : *v) {
       StmtPtr stmt_new = stmt->accept_mutator(this);
       if (stmt != stmt_new) {
         any_change = true;
@@ -594,7 +594,7 @@ bool LoopNest::vectorize(ForPtr f) {
 
   // Can't vectorize reduction axes.
   auto reductions = NodeFinder<ReduceOp>::find(f);
-  for (auto r : reductions) {
+  for (const auto& r : reductions) {
     if (std::find(r->reduce_args().begin(), r->reduce_args().end(), f->var()) !=
         r->reduce_args().end()) {
       return false;
@@ -626,12 +626,12 @@ bool LoopNest::vectorize(ForPtr f) {
 void LoopNest::initialize(
     const std::vector<Tensor>& output_tensors,
     const std::vector<Tensor>& tensors_to_compute) {
-  for (auto t : output_tensors) {
+  for (const auto& t : output_tensors) {
     output_bufs_.insert(t.buf());
   }
 
   std::vector<StmtPtr> loops;
-  for (Tensor t : tensors_to_compute) {
+  for (const Tensor& t : tensors_to_compute) {
     StmtPtr loop = t.stmt();
     if (loop->get_parent()) {
       std::cerr << "Error: creating a loopnest from already used Tensors\n";
@@ -640,7 +640,7 @@ void LoopNest::initialize(
     }
     // Flatten initializers.
     if (BlockPtr block = to<Block>(loop)) {
-      for (auto s : block->stmts()) {
+      for (const auto& s : block->stmts()) {
         block->remove_stmt(s);
         loops.push_back(s);
       }
@@ -659,7 +659,7 @@ class FunctionInliner : public IRMutator {
         producer_(producer),
         outputs_(std::move(outputs)) {
     success_ = true;
-    for (auto i : producer->indices()) {
+    for (const auto& i : producer->indices()) {
       if (auto index_var = to<Var>(i)) {
         index_vars_.insert(index_var);
         producer_index_vars_.push_back(index_var);
@@ -719,11 +719,11 @@ class FunctionInliner : public IRMutator {
         "ComputeInline: After rewriting body: ", std::to_string(result));
 
     // Remove the mappings we created for this function parameters.
-    for (auto v : index_vars) {
+    for (const auto& v : index_vars) {
       for (auto& pair : random_bindings_) {
         if (pair.second.erase(v)) {
           ExprPtr inlined = inline_mapping_[v];
-          for (auto nv : VarFinder::find(inlined)) {
+          for (const auto& nv : VarFinder::find(inlined)) {
             pair.second.insert(nv);
           }
         }
@@ -820,7 +820,7 @@ class FunctionInliner : public IRMutator {
       return v;
     }
     std::vector<StmtPtr> stmts;
-    for (StmtPtr stmt : *v) {
+    for (const StmtPtr& stmt : *v) {
       StmtPtr stmt_new = stmt->accept_mutator(this);
       if (!stmt_new) {
         continue;
@@ -855,7 +855,7 @@ class FunctionInliner : public IRMutator {
       }
     }
 
-    for (auto l : bindings_this_loop) {
+    for (const auto& l : bindings_this_loop) {
       res->body()->prepend_stmt(l);
       random_bindings_.erase(l);
     }
@@ -898,7 +898,7 @@ StmtPtr computeInlineImpl(
   // Find producers.
   StorePtr relevant_store{nullptr};
   auto stores = NodeFinder<Store>::find(stmt);
-  for (auto s : stores) {
+  for (const auto& s : stores) {
     if (s->buf() == b) {
       auto reductions = NodeFinder<ReduceOp>::find(s);
       if (!reductions.empty()) {
@@ -966,7 +966,7 @@ void LoopNest::inlineIntermediateBufs(bool allow_duplicated_work) {
     auto buf_load_store_uses = findLoadOrStoreUses(root_stmt_);
     auto input_bufs = getInputBufs();
 
-    for (auto buf : intermediate_bufs) {
+    for (const auto& buf : intermediate_bufs) {
       TORCH_INTERNAL_ASSERT(
           buf_load_store_uses.count(buf),
           buildErrorMessage(
@@ -1011,7 +1011,7 @@ void LoopNest::inlineIntermediateBufs(bool allow_duplicated_work) {
     bufs_to_inline.insert(output_bufs_.begin(), output_bufs_.end());
   }
 
-  for (auto b : bufs_to_inline) {
+  for (const auto& b : bufs_to_inline) {
     computeInline(b);
   }
 }
@@ -1041,7 +1041,7 @@ class LoadOrStoreUseFinder : public IRVisitor {
     }
     last_stmt_ = (StmtPtr)v;
 
-    for (BufPtr input_buf : v->buf_args()) {
+    for (const BufPtr& input_buf : v->buf_args()) {
       if (loads_[input_buf].insert(last_stmt_).second) {
         uses_[input_buf].push_back({last_stmt_, false});
       }
@@ -1120,13 +1120,13 @@ class ContainedStmtsFinder : public IRVisitor {
 
 bool containsAll(const std::vector<BufLoadOrStoreUse>& uses, BlockPtr b) {
   std::unordered_set<StmtPtr> not_found;
-  for (auto use : uses) {
+  for (const auto& use : uses) {
     not_found.insert(use.s);
   }
 
   ContainedStmtsFinder csf;
   const std::unordered_set<StmtPtr>& contained = csf.findContainedStmts(b);
-  for (auto s : contained) {
+  for (const auto& s : contained) {
     not_found.erase(s);
   }
   return not_found.empty();
@@ -1160,7 +1160,7 @@ class StmtDeleter : public IRMutator {
   StmtPtr mutate(BlockPtr v) override {
     std::vector<StmtPtr> stmts;
 
-    for (auto s : v->stmts()) {
+    for (const auto& s : v->stmts()) {
       if (targets_.count(s) == 0) {
         StmtPtr ns = s->accept_mutator(this);
         if (ns) {
@@ -1182,7 +1182,7 @@ void LoopNest::eliminateDeadStores() {
 
   std::unordered_set<StmtPtr> deadStores;
   std::vector<std::shared_ptr<AccessInfo>> outputAccesses;
-  for (auto o : getOutputBufs()) {
+  for (const auto& o : getOutputBufs()) {
     outputAccesses.push_back(checker.output(o));
   }
 
@@ -1316,7 +1316,7 @@ bool isConditionalFromCat(
 bool areConstantsAndSorted(const std::vector<ExprPtr>& comp_values) {
   std::vector<int> comp_consts;
   comp_consts.reserve(comp_values.size());
-  for (auto c : comp_values) {
+  for (const auto& c : comp_values) {
     if (!c->isConstant()) {
       return false;
     }
@@ -1332,7 +1332,7 @@ bool LoopNest::optimizeConditionals() {
   // conditionals in that store.
   auto stores = NodeFinder<Store>::find(root_stmt_);
   std::unordered_set<ForPtr> split_fors;
-  for (auto store : stores) {
+  for (const auto& store : stores) {
     VarPtr cond_var = nullptr;
     // `comp_values` represent the list of compared values that will be
     // collected as we check for the expected pattern. Since that will
@@ -1439,7 +1439,7 @@ void LoopNest::vectorizeInnerLoops() {
       BlockPtr b = blocks.back();
       blocks.pop_back();
 
-      for (StmtPtr s : *b) {
+      for (const StmtPtr& s : *b) {
         if (ForPtr f = to<For>(s)) {
           worklist.push_back(f);
         } else if (BlockPtr b2 = to<Block>(s)) {
@@ -1457,7 +1457,7 @@ void LoopNest::vectorizeInnerLoops() {
 
     bool containsSubLoops = false;
     if (BlockPtr body = to<Block>(f->body())) {
-      for (StmtPtr s2 : *body) {
+      for (const StmtPtr& s2 : *body) {
         if (ForPtr f2 = to<For>(s2)) {
           containsSubLoops = true;
           worklist.push_back(f2);
@@ -1471,7 +1471,7 @@ void LoopNest::vectorizeInnerLoops() {
   }
 
   // vectorize inner loops.
-  for (ForPtr loop : innerLoops) {
+  for (const ForPtr& loop : innerLoops) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     ForPtr split1;
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
@@ -1803,7 +1803,7 @@ bool areEqual(ExprPtr expr1, ExprPtr expr2) {
 bool doesExprContainAnyVar(
     ExprPtr expr,
     const std::unordered_set<VarPtr>& vars) {
-  for (auto v : VarFinder::find(expr)) {
+  for (const auto& v : VarFinder::find(expr)) {
     if (vars.count(v)) {
       return true;
     }
@@ -1822,8 +1822,8 @@ bool areIndicesLoopIndependent(
     return false;
   }
   for (size_t i = 0; i < expr_list1.size(); ++i) {
-    auto expr1 = expr_list1[i];
-    auto expr2 = expr_list2[i];
+    const auto& expr1 = expr_list1[i];
+    const auto& expr2 = expr_list2[i];
     if (doesExprContainAnyVar(expr1, outer_loop_vars) ||
         doesExprContainAnyVar(expr2, outer_loop_vars)) {
       if (!areEqual(expr1, expr2)) {
@@ -1840,7 +1840,7 @@ bool LoopNest::hasLoopCarriedDependence(ForPtr loop) {
 
   std::unordered_set<VarPtr> outer_loop_vars = {loop->var()};
   auto outer_loops = LoopNest::getEnclosingLoopNest(loop);
-  for (auto l : outer_loops) {
+  for (const auto& l : outer_loops) {
     outer_loop_vars.insert(l->var());
   }
 
@@ -1943,7 +1943,7 @@ bool LoopNest::unsafeFuseLoops(
 
   // Check if all the loops have the same parent.
   auto root = loops.front()->get_parent();
-  for (auto l : loops) {
+  for (const auto& l : loops) {
     auto par = l->get_parent();
     if (par == nullptr) {
       return false;
@@ -1971,14 +1971,14 @@ bool LoopNest::unsafeFuseLoops(
       it != root_block->end(),
       buildErrorMessage(
           "Could not find the given loop in the root stmt in unsafeFuseLoop the fuser."));
-  for (auto l : loops) {
+  for (const auto& l : loops) {
     if (*it != l) {
       return false;
     }
     ++it;
   }
 
-  auto first_loop = loops.front();
+  const auto& first_loop = loops.front();
   // Fuse the loops by taking all the statements from the second loops
   // onwards and moving them into the first loop's body.
   // This way the final fused loop will be the same as the first loop.
@@ -2003,11 +2003,11 @@ bool LoopNest::fuseLoops(const std::vector<ForPtr>& loops, ForPtr* fused) {
   }
 
   // Check if bounds are the same for all the loops.
-  auto first_loop = loops.front();
+  const auto& first_loop = loops.front();
   auto first_loop_start = IRSimplifier::simplify(first_loop->start());
   auto first_loop_stop = IRSimplifier::simplify(first_loop->stop());
   for (size_t i = 1; i < loops.size(); ++i) {
-    auto curr_loop = loops[i];
+    const auto& curr_loop = loops[i];
     auto curr_loop_start = IRSimplifier::simplify(curr_loop->start());
     auto curr_loop_stop = IRSimplifier::simplify(curr_loop->stop());
     if (!areEqual(curr_loop_start, first_loop_start)) {
@@ -2099,7 +2099,7 @@ void LoopNest::reorderAxis(ForPtr a, ForPtr b) {
   BlockPtr body = alloc<Block>(std::vector<StmtPtr>({}));
   body->splice(body->end(), inner->body());
 
-  ForPtr before{outer};
+  const ForPtr& before{outer};
   ForPtr after{nullptr};
   ForPtr last = internal_axes.front();
   StmtPtr newInner = body;
@@ -2132,7 +2132,7 @@ void LoopNest::reorderAxis(ForPtr a, ForPtr b) {
   // When reordering loop i and j we need to ensure that Statement A and C are
   // still both executed with the loop extents of i, and that the three
   // statements are not reordered (as much as possible).
-  for (auto loop : internal_axes) {
+  for (const auto& loop : internal_axes) {
     // If the inner loop had a component after the loop we must wrap it in a For
     // loop matching this level of the tree.
     if (after != nullptr) {
@@ -2174,7 +2174,7 @@ void LoopNest::reorderAxis(ForPtr a, ForPtr b) {
   std::swap(internal_axes.front(), internal_axes.back());
 
   // Create the reordered internals:
-  for (auto loop : internal_axes) {
+  for (const auto& loop : internal_axes) {
     newInner = loop->cloneWithNewBody(newInner);
   }
 
@@ -2356,7 +2356,7 @@ void LoopNest::fullUnroll(ForPtr f, StmtPtr* unrolled) {
   int start_val = immediateAs<int>(start_expr);
   int stop_val = immediateAs<int>(stop_expr);
   for (int current = start_val; current < stop_val; ++current) {
-    for (auto stmt : f->body()->stmts()) {
+    for (const auto& stmt : f->body()->stmts()) {
       unrolled_stmts.push_back(SubstituteInClone(
           stmt, {{f->var(), getImmediateByType(f->var()->dtype(), current)}}));
     }
@@ -2542,17 +2542,17 @@ void LoopNest::compressBuffer(BufPtr buf, StmtPtr stmt) {
       parent,
       buildErrorMessage(
           "Expected parent stmt to be a non-null block in compressBuffer in the fuser."));
-  for (auto w : writes) {
+  for (const auto& w : writes) {
     parent = Block::getSharedParent(parent, w);
   }
-  for (auto r : reads) {
+  for (const auto& r : reads) {
     parent = Block::getSharedParent(parent, r);
   }
 
   // Collect all the loops that are above the common parent.
   auto loops = LoopNest::getEnclosingLoopNest(parent);
   std::unordered_set<VarPtr> loop_vars;
-  for (auto l : loops) {
+  for (const auto& l : loops) {
     loop_vars.insert(l->var());
   }
 
@@ -2569,7 +2569,7 @@ void LoopNest::compressBuffer(BufPtr buf, StmtPtr stmt) {
             "Expected ranks to match in compressBuffer in the fuser."));
     for (size_t i = 0; i < indices.size(); ++i) {
       auto index_vars = NodeFinder<Var>::find(indices[i]);
-      for (auto iv : index_vars) {
+      for (const auto& iv : index_vars) {
         if (loop_vars.count(iv) == 0) {
           // A variable in this index is not in loop_vars.
           // This implies that this dimension cannot be optimized away.
@@ -2579,12 +2579,12 @@ void LoopNest::compressBuffer(BufPtr buf, StmtPtr stmt) {
       }
     }
   };
-  for (auto s : stores) {
+  for (const auto& s : stores) {
     if (s->buf() == buf) {
       check_indices(s->indices());
     }
   }
-  for (auto l : loads) {
+  for (const auto& l : loads) {
     if (l->buf() == buf) {
       check_indices(l->indices());
     }
@@ -2620,12 +2620,12 @@ void LoopNest::compressBuffer(BufPtr buf, StmtPtr stmt) {
     }
     return new_indices;
   };
-  for (auto s : stores) {
+  for (const auto& s : stores) {
     if (s->buf() == buf) {
       s->set_indices(get_new_indices(s->indices()));
     }
   }
-  for (auto l : loads) {
+  for (const auto& l : loads) {
     if (l->buf() == buf) {
       l->set_indices(get_new_indices(l->indices()));
     }
@@ -2633,7 +2633,7 @@ void LoopNest::compressBuffer(BufPtr buf, StmtPtr stmt) {
 }
 
 void LoopNest::compressAllBuffers(StmtPtr stmt) {
-  for (auto buf : BufFinder::find(stmt)) {
+  for (const auto& buf : BufFinder::find(stmt)) {
     compressBuffer(buf, stmt);
   }
 }
@@ -2679,7 +2679,7 @@ StmtPtr LoopNest::getLoopBodyFor(BufPtr buf) const {
   }
 
   StmtPtr res = nullptr;
-  for (auto s : writes) {
+  for (const auto& s : writes) {
     if (!res) {
       res = s;
       continue;
@@ -2722,7 +2722,7 @@ std::vector<ForPtr> LoopNest::getAllInnermostLoopsWritingToBuf(
   auto writes = getAllWritesToBuf(buf);
   std::vector<ForPtr> innermost_loops;
   innermost_loops.reserve(writes.size());
-  for (auto w : writes) {
+  for (const auto& w : writes) {
     innermost_loops.push_back(LoopNest::getParentLoop(w));
   }
   return innermost_loops;
@@ -2733,7 +2733,7 @@ std::vector<std::vector<ForPtr>> LoopNest::getAllLoopNestsWritingToBuf(
   auto writes = getAllWritesToBuf(buf);
   std::vector<std::vector<ForPtr>> loopnests;
   loopnests.reserve(writes.size());
-  for (auto w : writes) {
+  for (const auto& w : writes) {
     loopnests.emplace_back(LoopNest::getEnclosingLoopNest(w));
   }
   return loopnests;
@@ -2782,7 +2782,7 @@ static StorePtr getStoreStmtOfProducer(StmtPtr s) {
     return st;
   }
   if (BlockPtr b = to<Block>(s)) {
-    for (StmtPtr ss : *b) {
+    for (const StmtPtr& ss : *b) {
       if (StorePtr st = to<Store>(ss)) {
         return st;
       }
@@ -2869,7 +2869,7 @@ LoopNest::AccessResult LoopNest::cacheAccesses(
     StmtPtr consumer) {
   ReduceOpPtr reduceOp{nullptr};
   auto stores = NodeFinder<Store>::find(consumer);
-  for (auto store : stores) {
+  for (const auto& store : stores) {
     if (auto ro = to<ReduceOp>(store->value())) {
       if (store->buf() != producer) {
         continue;
@@ -2948,10 +2948,10 @@ LoopNest::AccessResult LoopNest::cacheAccesses(
     std::set<VarPtr> reduce_args(
         reduceOp->reduce_args().begin(), reduceOp->reduce_args().end());
     std::set<VarPtr> enclosing_vars;
-    for (auto enclosing_for_stmt : NodeFinder<For>::find(consumer)) {
+    for (const auto& enclosing_for_stmt : NodeFinder<For>::find(consumer)) {
       enclosing_vars.insert(enclosing_for_stmt->var());
     }
-    for (auto reduce_arg : reduce_args) {
+    for (const auto& reduce_arg : reduce_args) {
       if (enclosing_vars.find(reduce_arg) == enclosing_vars.end()) {
         on_reduce_axis = true;
       }
@@ -3274,7 +3274,7 @@ class RfactorStoreRewriter : public IRMutator {
     ExprPtr body_new = v->body()->accept_mutator(this);
 
     std::vector<VarPtr> new_reduce_args;
-    for (auto r : v->reduce_args()) {
+    for (const auto& r : v->reduce_args()) {
       if (r != reduction_var_) {
         new_reduce_args.push_back(r);
       }

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -263,10 +263,10 @@ MemDependencyChecker::MemDependencyChecker() {
 MemDependencyChecker::MemDependencyChecker(
     const std::unordered_set<BufPtr>& inputs,
     const std::unordered_set<BufPtr>& outputs) {
-  for (auto s : inputs) {
+  for (const auto& s : inputs) {
     inputs_[s] = nullptr;
   }
-  for (auto s : outputs) {
+  for (const auto& s : outputs) {
     outputs_[s] = nullptr;
   }
 
@@ -509,7 +509,7 @@ void MemDependencyChecker::visit(StorePtr v) {
   lastStmt_ = v;
   v->value()->accept(this);
 
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     ind->accept(this);
   }
   lastStmt_ = last;
@@ -543,7 +543,7 @@ void MemDependencyChecker::visit(LoadPtr v) {
       std::make_shared<Scope>(currentScope_->block, currentScope_);
   currentScope_ = indicesScope;
 
-  for (ExprPtr ind : v->indices()) {
+  for (const ExprPtr& ind : v->indices()) {
     ind->accept(this);
   }
 
@@ -1042,7 +1042,7 @@ void MemDependencyChecker::insertBuffers(
     BufPtr b = pair.first;
     VarPtr var = b->base_handle();
     IndexBounds bounds;
-    for (auto d : b->dims()) {
+    for (const auto& d : b->dims()) {
       bounds.push_back(
           {immLike(d, 0),
            IRSimplifier::simplify(alloc<Sub>(d, immLike(d, 1)))});
@@ -1070,11 +1070,11 @@ void MemDependencyChecker::visit(BlockPtr v) {
     currentScope_ = std::make_shared<Scope>((BlockPtr)v, prev_scope);
   }
 
-  for (auto s : *v) {
+  for (const auto& s : *v) {
     s->accept(this);
   }
 
-  for (auto v : currentScope_->localVars) {
+  for (const auto& v : currentScope_->localVars) {
     knownVarBounds_.erase(v);
   }
   for (auto& pair : currentScope_->shadowedVarBounds) {
@@ -1313,7 +1313,7 @@ std::vector<Bound> MemDependencyChecker::getIndicesBounds(
   std::vector<Bound> bounds;
   bounds.reserve(indices.size());
   VarBoundBinder binder(knownVarBounds_);
-  for (auto s : indices) {
+  for (const auto& s : indices) {
     bounds.push_back(binder.getBounds(s));
   }
   return bounds;

--- a/torch/csrc/jit/tensorexpr/operators/quantization.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/quantization.cpp
@@ -696,8 +696,8 @@ Tensor computeUpsampleNearest2d(
     const c10::optional<ScalarType>& outputType,
     at::Device) {
   auto A = c10::get<BufHandle>(inputs[0]);
-  auto output_height = outputShape[2];
-  auto output_width = outputShape[3];
+  const auto& output_height = outputShape[2];
+  const auto& output_width = outputShape[3];
   auto input_height = ExprHandle(A.dim(2));
   auto input_width = ExprHandle(A.dim(3));
 

--- a/torch/csrc/jit/tensorexpr/operators/softmax.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/softmax.cpp
@@ -64,7 +64,7 @@ Tensor computeSoftmax(
   // appropriate position.
   auto move_softmax_dim_index_to_pos = [&](const ParameterList& indices) {
     std::vector<ExprHandle> new_indices;
-    for (auto ind : indices) {
+    for (const auto& ind : indices) {
       new_indices.push_back(ind);
     }
     for (size_t i = softmax_dim; i < indices.size() - 1; ++i) {

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -708,7 +708,7 @@ LazyGraphExecutor::PostOrderData LazyGraphExecutor::RunPostOrder(
     SyncTensorCollection* coll) {
   std::vector<const Node*> roots;
   roots.reserve(ir_values.size());
-  for (auto ir_value : ir_values) {
+  for (const auto& ir_value : ir_values) {
     roots.push_back(ir_value.node.get());
   }
   PostOrderData po_data;
@@ -772,7 +772,7 @@ LazyGraphExecutor::CompilationResult LazyGraphExecutor::Compile(
       coll.device,
       po_data->post_order,
       std::move(po_data->emission_map));
-  for (auto ir_value : ir_values) {
+  for (const auto& ir_value : ir_values) {
     lowering_ctx->AddResult(ir_value);
   }
 

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -623,7 +623,7 @@ class TransferEvents {
     static const auto prefix = fmt::format("\"{}\": ", indexKey);
     auto pos = metadata_json.find(prefix);
     return (pos == std::string::npos) ? unmatchedIndex : [&]() {
-      auto end = metadata_json.find(",", pos);
+      auto end = metadata_json.find(',', pos);
       end = (end == std::string::npos) ? metadata_json.size() : end;
       return std::stoll(metadata_json.substr(pos + prefix.size(), end));
     }();
@@ -994,7 +994,7 @@ RecordQueue::getRecords(
   }
 
   if (python_tracer_) {
-    for (auto i : python_tracer_->getEvents(
+    for (const auto& i : python_tracer_->getEvents(
              converter, python_enters, end_time_us * 1000)) {
       out.push_back(i);
     }


### PR DESCRIPTION
Applies various automated fixes that reduces the number of spurious copies in torch, aten, and c10. I also inlined any default dtors that would have made the type trivially destructible.

Follow up to #89000 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @EikanWang