### PR TITLE
[FSDP] Sanitize `HandleConfig` for mixed precision

### DIFF
--- a/test/distributed/fsdp/test_fsdp_flatten_params.py
+++ b/test/distributed/fsdp/test_fsdp_flatten_params.py
@@ -9,7 +9,6 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.flat_param import (
     FlatParamHandle,
     FlatParamShardMetadata,
-    HandleConfig,
     HandleShardingStrategy,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
@@ -39,7 +38,7 @@ class TestFlattenParams(FSDPTest):
         return 1
 
     def _get_default_config(self):
-        return HandleConfig(HandleShardingStrategy.FULL_SHARD, False, None, None, False)
+        return (HandleShardingStrategy.FULL_SHARD, False, None, None, False)
 
     def _get_transformer(self, seed=0):
         torch.manual_seed(seed)  # keep everything deterministic
@@ -149,7 +148,7 @@ class TestFlattenParams(FSDPTest):
                 module,
                 module,
                 torch.device("cuda"),
-                self._get_default_config(),
+                *self._get_default_config(),
                 self.process_group,
                 False,
             )
@@ -222,7 +221,7 @@ class TestFlattenParams(FSDPTest):
             module,
             module,
             torch.device("cuda"),
-            self._get_default_config(),
+            *self._get_default_config(),
             self.process_group,
             False,
         )
@@ -324,7 +323,7 @@ class TestFlattenParams(FSDPTest):
             module,
             module,
             torch.device("cuda"),
-            self._get_default_config(),
+            *self._get_default_config(),
             self.process_group,
             False,
         )

--- a/test/distributed/fsdp/test_fsdp_meta.py
+++ b/test/distributed/fsdp/test_fsdp_meta.py
@@ -2,13 +2,16 @@
 
 import sys
 
+from typing import Union
+
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, MixedPrecision
 from torch.distributed.fsdp.wrap import (
     always_wrap_policy as always_wrap,
     enable_wrap,
+    ModuleWrapPolicy,
     wrap,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
@@ -342,6 +345,60 @@ class TestFSDPWithMetaDevice(FSDPTest):
             return NestedModel(device="meta")
 
         self._test_bad_arg(meta_module_fn)
+
+    @skip_if_lt_x_gpu(2)
+    def test_meta_device_with_mixed_precision(self):
+        """
+        Tests meta device initialization with a ``param_init_fn`` when
+        specifying mixed precision with ``param_dtype=torch.float32``.
+        """
+
+        class FakeLinear(nn.Module):
+            def __init__(
+                self, in_dim: int, out_dim: int, device: Union[torch.device, str]
+            ) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.randn((in_dim, out_dim), device=device)
+                )
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x @ self.weight
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.lin1 = nn.Linear(5, 5, device="meta")
+                self.lin2 = FakeLinear(5, 5, device="meta")
+                self.relu = nn.ReLU()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.lin2(self.relu(self.lin1(x)))
+
+            def _module_init_fn(self, module: nn.Module):
+                if isinstance(module, nn.Linear):
+                    torch.nn.init.normal_(module.weight, mean=0.0, std=0.1)
+                    if module.bias is not None:
+                        torch.nn.init.zeros_(module.bias)
+
+        def _param_init_fn(module: nn.Module) -> None:
+            # TODO: `module.to_empty()` is not generally correct for meta
+            # device initialization.
+            # https://github.com/pytorch/pytorch/issues/90465
+            module.to_empty(device=torch.device("cuda"))
+            module.apply(model._module_init_fn)
+
+        model = Model()
+        # Wrap only `lin1` and the top level `model`
+        FSDP(
+            model,
+            auto_wrap_policy=ModuleWrapPolicy({nn.Linear}),
+            mixed_precision=MixedPrecision(
+                param_dtype=torch.float32, reduce_dtype=torch.float16
+            ),
+            param_init_fn=_param_init_fn,
+            device_id=torch.cuda.current_device(),
+        )
 
 
 instantiate_parametrized_tests(TestFSDPWithMetaDevice)

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -307,6 +307,8 @@ class TestFSDPMixedPrecision(FSDPTest):
         )
 
         for t in tensors:
+            if self.rank == 0 and expected_dtype != t.dtype:
+                print(f"[Rank 0] expected {expected_dtype} got {t.dtype}")
             self.assertEqual(expected_dtype, t.dtype)
 
         return orig_reduce_scatter(*args, **kwargs)

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -307,8 +307,6 @@ class TestFSDPMixedPrecision(FSDPTest):
         )
 
         for t in tensors:
-            if self.rank == 0 and expected_dtype != t.dtype:
-                print(f"[Rank 0] expected {expected_dtype} got {t.dtype}")
             self.assertEqual(expected_dtype, t.dtype)
 
         return orig_reduce_scatter(*args, **kwargs)

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -45,7 +45,6 @@ from torch.distributed.fsdp.flat_param import (
     _HandlesKey,
     FlatParameter,
     FlatParamHandle,
-    HandleConfig,
     HandleShardingStrategy,
 )
 from torch.distributed.fsdp.wrap import _FSDPPolicy
@@ -471,19 +470,16 @@ def _init_param_handle_from_params(
 ):
     if len(params) == 0:
         return
-    handle_config = HandleConfig(
-        SHARDING_STRATEGY_MAP[state.sharding_strategy],
-        state.cpu_offload.offload_params,
-        state.mixed_precision.param_dtype,
-        state.mixed_precision.reduce_dtype,
-        state.mixed_precision.keep_low_precision_grads,
-    )
     handle = FlatParamHandle(
         params,
         root_module,
         comm_module,
         state.compute_device,
-        handle_config,
+        SHARDING_STRATEGY_MAP[state.sharding_strategy],
+        state.cpu_offload.offload_params,
+        state.mixed_precision.param_dtype,
+        state.mixed_precision.reduce_dtype,
+        state.mixed_precision.keep_low_precision_grads,
         state.process_group,
         state._use_orig_params,
     )

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
-from torch.distributed.algorithms._comm_hooks import LOW_PRECISION_HOOKS, default_hooks
+from torch.distributed.algorithms._comm_hooks import default_hooks, LOW_PRECISION_HOOKS
 from torch.distributed.fsdp._common_utils import (
     _all_handles,
     _assert_in_training_states,
@@ -34,6 +34,7 @@ RESHARD_AFTER_FORWARD_STRATEGIES = {
     HandleShardingStrategy.FULL_SHARD,
     HandleShardingStrategy.HYBRID_SHARD,
 }
+
 
 @no_type_check
 def _validate_hybrid_shard_setup(fsdp_root: _FSDPState, fsdp_module: nn.Module):
@@ -67,6 +68,7 @@ def _validate_hybrid_shard_setup(fsdp_root: _FSDPState, fsdp_module: nn.Module):
             raise ValueError(
                 f"For {fsdp_root.sharding_strategy}, inter-node process groups do not match"
             )
+
 
 @no_type_check
 def _lazy_init(
@@ -361,7 +363,6 @@ def _post_forward_reshard(
     # with the intention that they are immediately used for backward
     # computation (though this may not be true)
 
-
     free_unsharded_flat_params = [
         not state._is_root
         and handle._config.sharding_strategy in RESHARD_AFTER_FORWARD_STRATEGIES
@@ -572,22 +573,15 @@ def _post_backward_hook(
         state._streams["post_backward"].wait_stream(torch.cuda.current_stream())
 
         with torch.cuda.stream(state._streams["post_backward"]):
-            unsharded_grad_data = param.grad.data
+            autograd_computed_grad = param.grad.data
             if state._exec_order_data.is_first_iter:  # only check once
                 _check_comm_hook(
                     state._communication_hook, state._communication_hook_state
                 )
             if (
-                (
-                    (
-                        handle._uses_reduce_mixed_precision
-                        and not _low_precision_hook_enabled(state)
-                    )
-                    or handle._uses_param_mixed_precision  # computed grad dtype differs
-                )
+                not _low_precision_hook_enabled(state)
                 and param.grad.dtype != handle._config.reduce_dtype
             ):
-                # TODO: Use the low precision communication hook directly
                 param.grad.data = param.grad.to(handle._config.reduce_dtype)
 
             if handle.uses_sharded_strategy:
@@ -598,10 +592,6 @@ def _post_backward_hook(
                 # async and would result in reducing the wrong gradient.
                 unsharded_grad = param.grad.data
                 param.grad = None
-                p_assert(
-                    len(unsharded_grad.size()) == 1,
-                    f"Expects gradient to be flattened but got {unsharded_grad.size()}",
-                )
                 chunks = list(unsharded_grad.chunk(state.world_size))
                 numel_to_pad = (
                     state.world_size * chunks[0].numel() - unsharded_grad.numel()
@@ -617,17 +607,12 @@ def _post_backward_hook(
                     padded_unsharded_grad,
                     new_sharded_grad,
                 )
-                if handle._config.sharding_strategy in (
-                    HandleShardingStrategy.HYBRID_SHARD,
-                    HandleShardingStrategy._HYBRID_SHARD_ZERO2
-                ):
+                if handle._config.sharding_strategy in HYBRID_SHARDING_STRATEGIES:
                     default_hooks.allreduce_hook(
                         state=state._inter_node_state,
                         grad=new_sharded_grad,
                     )
-
-                _cast_grad_to_param_dtype(state, handle, new_sharded_grad, param)
-
+                _cast_grad_to_param_dtype(state, new_sharded_grad, param)
                 # Save the sharded gradient in `_saved_grad_shard` to support
                 # gradient accumulation -- for multiple backwards, the gradient
                 # reductions may happen in arbitrary order
@@ -637,14 +622,14 @@ def _post_backward_hook(
                     param._saved_grad_shard += new_sharded_grad
                 else:
                     param._saved_grad_shard = new_sharded_grad
-                sharded_grad = param._saved_grad_shard
+                grad_to_offload = param._saved_grad_shard
             else:
                 state._communication_hook(state._communication_hook_state, param.grad)
                 # For `NO_SHARD`, we can keep the low precision gradients by
                 # simply omitting the cast altogether
                 if not handle._keep_low_precision_grads:
-                    _cast_grad_to_param_dtype(state, handle, param.grad, param)
-                sharded_grad = param.grad.data
+                    _cast_grad_to_param_dtype(state, param.grad, param)
+                grad_to_offload = param.grad.data
 
             if handle._config.offload_params:
                 # Offload the gradient to CPU to ensure parameters and
@@ -653,20 +638,21 @@ def _post_backward_hook(
                 # using `non_blocking=True` here.
                 non_blocking = handle.uses_sharded_strategy
                 param._cpu_grad.copy_(  # type: ignore[attr-defined]
-                    sharded_grad.detach(), non_blocking=non_blocking
+                    grad_to_offload.detach(), non_blocking=non_blocking
                 )  # synchronized in the post-backward callback
-                # Since the sharded gradient is produced in the post-backward
-                # stream and consumed later in the computation stream, inform
-                # the caching allocator
+                # Since the gradient being offloaded may have been produced in
+                # the computation stream and is being consumed here in the
+                # post-backward stream, inform the caching allocator
                 _no_dispatch_record_stream(
-                    sharded_grad.data, torch.cuda.current_stream()
+                    grad_to_offload.data,
+                    state._streams["post_backward"],
                 )
 
             # Since the unsharded gradient is produced in the computation
             # stream and consumed in the post-backward stream, inform the
             # caching allocator (before it goes out of scope)
             _no_dispatch_record_stream(
-                unsharded_grad_data, state._streams["post_backward"]
+                autograd_computed_grad, state._streams["post_backward"]
             )
 
             if handle._use_orig_params:
@@ -700,7 +686,6 @@ def _should_free_in_backward(
 @no_type_check
 def _cast_grad_to_param_dtype(
     state: _FSDPState,
-    handle: FlatParamHandle,
     sharded_grad: torch.Tensor,
     param: FlatParameter,
 ):
@@ -715,10 +700,7 @@ def _cast_grad_to_param_dtype(
     dtype cast happens in the hook instead.
     """
     _assert_in_training_states(state, [TrainingState.FORWARD_BACKWARD])
-    if (
-        not _low_precision_hook_enabled(state)
-        and sharded_grad.dtype != param.dtype
-    ):
+    if not _low_precision_hook_enabled(state) and sharded_grad.dtype != param.dtype:
         low_prec_grad_data = sharded_grad.data
         sharded_grad.data = sharded_grad.data.to(dtype=param.dtype)
         # Since for `NO_SHARD`, the gradient is produced in the computation

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -585,10 +585,10 @@ def _post_backward_hook(
                     )
                     or handle._uses_param_mixed_precision  # computed grad dtype differs
                 )
-                and param.grad.dtype != handle._config.low_prec_reduce_dtype
+                and param.grad.dtype != handle._config.reduce_dtype
             ):
                 # TODO: Use the low precision communication hook directly
-                param.grad.data = param.grad.to(handle._config.low_prec_reduce_dtype)
+                param.grad.data = param.grad.to(handle._config.reduce_dtype)
 
             if handle.uses_sharded_strategy:
                 # We clear `.grad` to permit multiple backwards. This avoids a

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -326,8 +326,6 @@ class FlatParamHandle:
         mp_reduce_dtype (Optional[torch.dtype]): Gradient reduction mixed
             precision setting passed to the FSDP constructor.
         keep_low_prec_grads (bool): Whether to keep gradients in low precision.
-        config (HandleConfig): A config customizing the handle based on FSDP's
-            available features.
         use_orig_params (bool): If ``True``, then FSDP preserves the original
             parameter variables and returns them from ``named_parameters()``
             (e.g. to support different optimizer hyperparameters within one

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -113,9 +113,9 @@ class HandleShardingStrategy(Enum):
 class HandleConfig:
     sharding_strategy: HandleShardingStrategy
     offload_params: bool
-    low_prec_param_dtype: Optional[torch.dtype]
-    reduce_dtype: Optional[torch.dtype]
-    keep_low_prec_grads: bool
+    fwd_bwd_param_dtype: torch.dtype
+    reduce_dtype: torch.dtype
+    keep_low_precision_grads: bool
 
 
 class FlatParameter(nn.Parameter):
@@ -325,7 +325,7 @@ class FlatParamHandle:
             setting passed to the FSDP constructor.
         mp_reduce_dtype (Optional[torch.dtype]): Gradient reduction mixed
             precision setting passed to the FSDP constructor.
-        keep_low_prec_grads (bool): Whether to keep gradients in low precision.
+        keep_low_precision_grads (bool): Whether to keep gradients in low precision.
         use_orig_params (bool): If ``True``, then FSDP preserves the original
             parameter variables and returns them from ``named_parameters()``
             (e.g. to support different optimizer hyperparameters within one
@@ -351,7 +351,7 @@ class FlatParamHandle:
         offload_params: bool,
         mp_param_dtype: Optional[torch.dtype],
         mp_reduce_dtype: Optional[torch.dtype],
-        keep_low_prec_grads: bool,
+        keep_low_precision_grads: bool,
         process_group: dist.ProcessGroup,
         use_orig_params: bool,
     ):
@@ -367,12 +367,12 @@ class FlatParamHandle:
         self._init_flat_param(params, module, use_orig_params)
         self._orig_param_dtype = self.flat_param.dtype
         self._use_unsharded_views(as_params=False)
-        self._config = self._sanitize_config(
+        self._config = self._init_config(
             sharding_strategy,
             offload_params,
             mp_param_dtype,
             mp_reduce_dtype,
-            keep_low_prec_grads,
+            keep_low_precision_grads,
         )
 
     def _init_flat_param(
@@ -513,13 +513,13 @@ class FlatParamHandle:
         flat_param = FlatParameter(flat_param_data, requires_grad=requires_grad)
         return flat_param
 
-    def _sanitize_config(
+    def _init_config(
         self,
         sharding_strategy: HandleShardingStrategy,
         offload_params: bool,
         mp_param_dtype: Optional[torch.dtype],
         mp_reduce_dtype: Optional[torch.dtype],
-        keep_low_prec_grads: bool,
+        keep_low_precision_grads: bool,
     ) -> HandleConfig:
         """
         Precondition: ``self.flat_param`` is set via :meth:`_init_flat_param`.
@@ -536,22 +536,22 @@ class FlatParamHandle:
         low_prec_reduce_dtype_specified = mp_reduce_dtype is not None
         if low_prec_param_dtype_specified and not low_prec_reduce_dtype_specified:
             # Special case: infer gradient reduction mixed precision
-            low_prec_param_dtype = mp_param_dtype
-            low_prec_reduce_dtype = low_prec_param_dtype
+            fwd_bwd_param_dtype = mp_param_dtype
+            reduce_dtype = fwd_bwd_param_dtype
         else:
-            low_prec_param_dtype = mp_param_dtype or self._orig_param_dtype
-            low_prec_reduce_dtype = mp_reduce_dtype or self._orig_param_dtype
-        assert low_prec_param_dtype is not None
-        assert low_prec_reduce_dtype is not None
+            fwd_bwd_param_dtype = mp_param_dtype or self._orig_param_dtype
+            reduce_dtype = mp_reduce_dtype or self._orig_param_dtype
+        assert fwd_bwd_param_dtype is not None
+        assert reduce_dtype is not None
         # TODO (awgu): Get rid of `HandleConfig` and store the attributes
         # directly on the `FlatParamHandle` now that we are processing it
         # instead of just taking what is passed in.
         return HandleConfig(
             sharding_strategy,
             offload_params,
-            low_prec_param_dtype,
-            low_prec_reduce_dtype,
-            keep_low_prec_grads,
+            fwd_bwd_param_dtype,
+            reduce_dtype,
+            keep_low_precision_grads,
         )
 
     ###################################
@@ -815,14 +815,14 @@ class FlatParamHandle:
             flat_param._mp_shard = torch.zeros_like(
                 flat_param._local_shard,
                 device=self.device,
-                dtype=self._config.low_prec_param_dtype,
+                dtype=self._config.fwd_bwd_param_dtype,
             )
             _free_storage(flat_param._mp_shard)
         if self.uses_sharded_strategy:
             # We maintain a padded unsharded tensor that serves as the
             # all-gather destination and owns the original parameter storages.
             unsharded_param_dtype = (
-                self._config.low_prec_param_dtype
+                self._config.fwd_bwd_param_dtype
                 if self._uses_param_mixed_precision
                 else flat_param.dtype
             )  # use low precision if parameter mixed precision is enabled
@@ -957,8 +957,8 @@ class FlatParamHandle:
             # that  `_full_param_padded` is in the low precision
             unsharded_flat_param = flat_param._full_prec_full_param_padded  # type: ignore[attr-defined]
             p_assert(
-                unsharded_flat_param.dtype != self._config.low_prec_param_dtype,
-                f"Expects full precision but got {self._config.low_prec_param_dtype}",
+                unsharded_flat_param.dtype != self._config.fwd_bwd_param_dtype,
+                f"Expects full precision but got {self._config.fwd_bwd_param_dtype}",
             )
         else:
             unsharded_flat_param = flat_param._full_param_padded  # type: ignore[attr-defined]
@@ -1145,7 +1145,7 @@ class FlatParamHandle:
                 # the post-backward callback.
                 local_shard_dtype = flat_param._local_shard.dtype  # type: ignore[attr-defined]
                 if (
-                    self._config.keep_low_prec_grads
+                    self._config.keep_low_precision_grads
                     and sharded_grad.dtype != local_shard_dtype
                 ):
                     sharded_grad.data = sharded_grad.to(local_shard_dtype)
@@ -1166,11 +1166,11 @@ class FlatParamHandle:
         """
 
         def cast_grad_to_param_dtype_if_needed(flat_param):
-            if self._config.keep_low_prec_grads:
+            if self._config.keep_low_precision_grads:
                 assert flat_param.grad is not None  # mypy
-                if flat_param.grad.dtype != self._config.low_prec_param_dtype:
+                if flat_param.grad.dtype != self._config.fwd_bwd_param_dtype:
                     flat_param.grad.data = flat_param.grad.to(
-                        self._config.low_prec_param_dtype
+                        self._config.fwd_bwd_param_dtype
                     )
                     if self._use_orig_params:
                         self._use_sharded_grad_views()
@@ -1992,7 +1992,7 @@ class FlatParamHandle:
 
     @property
     def _uses_param_mixed_precision(self) -> bool:
-        return self._config.low_prec_param_dtype != self._orig_param_dtype
+        return self._config.fwd_bwd_param_dtype != self._orig_param_dtype
 
     @property
     def _uses_reduce_mixed_precision(self) -> bool:
@@ -2000,7 +2000,7 @@ class FlatParamHandle:
 
     @property
     def _keep_low_precision_grads(self) -> bool:
-        return self._config.keep_low_prec_grads
+        return self._config.keep_low_precision_grads
 
     @property
     def _force_full_precision(self) -> bool:

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -518,32 +518,15 @@ class FullyShardedDataParallel(nn.Module):
 
         return ret
 
-    def _mixed_precision_enabled_for_params(self) -> bool:
-        """
-        Whether user explicitly enabled mixed precision for
-        parameters or not.
-        """
-        return self.mixed_precision.param_dtype is not None
-
     def _mixed_precision_enabled_for_buffers(self) -> bool:
         """
-        Whether user explicitly enabled mixed precision for
-        buffers or not.
+        Returns if the user explicitly enabled buffer mixed precision.
+
+        NOTE: Unlike parameters and gradient reduction, buffer mixed precision
+        is applied at the FSDP instance level, not the ``FlatParameter`` level,
+        which may be different for the composable code path.
         """
         return self.mixed_precision.buffer_dtype is not None
-
-    def _mixed_precision_enabled_for_reduce(self) -> bool:
-        """
-        Whether user explicitly enabled mixed precision for
-        gradient reduction or not.
-        """
-        return self.mixed_precision.reduce_dtype is not None
-
-    def _mixed_precision_keep_low_precision_grads(self) -> bool:
-        return (
-            self.mixed_precision is not None
-            and self.mixed_precision.keep_low_precision_grads
-        )
 
     def _low_precision_hook_enabled(self) -> bool:
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90656 [FSDP] Clean up post-backward hook
* #90619 [FSDP][Perf] Pre-allocate full prec sharded param
* #90618 [FSDP][Easy][BE] Minor cleanup of post-backward logic
* #90616 [FSDP][Perf] Pre-allocate sharded grad in default stream; save one copy when downcasting grad
* #90614 [FSDP][Perf] Pre-allocate padded unsharded grad in default stream
* **#90631 [FSDP] Sanitize `HandleConfig` for mixed precision**
* #90615 [FSDP] Tighten post-bwd cast to `reduce_dtype`
* #90622 [FSDP][Easy] Move to `_storage()` in test file
* #90611 [FSDP] Save `_stream_to_name` for debugging
* #90562 [Reland][FSDP] Another fix for `DTensor`, `use_orig_params=True`

This PR reworks the internal handling of parameter and gradient reduction mixed precision.

**Overview**
For `MixedPrecision(param_dtype, reduce_dtype, ...)`, the exact rule for parameter and gradient reduction mixed precision we are following is:
> If `param_dtype is not None` and `reduce_dtype is None`, then we infer `reduce_dtype = param_dtype`. Otherwise, we take `param_dtype` and `reduce_dtype` as is.

This PR enforces that, at the `FlatParamHandle` level, `handle._config.low_prec_param_dtype` and `handle._config.low_prec_reduce_dtype` are never `None`. The way to check if mixed precision is enabled is to compare against the original parameter dtype, which is now stored in `handle._orig_param_dtype`. It is no longer to check against `None`.

This avoids ambiguous cases such as when the user passes `MixedPrecision(param_dtype=torch.float32)`. In that case, our existing implementation mistakenly thinks that parameter mixed precision is enabled and either relies on no-ops silently or errors (such as one case reported by MosaicML).

**Details**
- For `HandleConfig`, we rename `low_prec_reduce_dtype` to `reduce_dtype` because it now represents _exactly_ the dtype for gradient reduction.
- For `HandleConfig`, we rename `keep_low_precision_grads` to `keep_low_prec_grads` since we already use `prec` to abbreviate `precision` and for brevity.
- We remove `FullyShardedDataParallel._mixed_precision_enabled_for_params`, `FullyShardedDataParallel._mixed_precision_enabled_for_reduce`, and `FullyShardedDataParallel._mixed_precision_keep_low_precision_grads` since they are not used.
- The `HandleConfig` sanitization happens in the `FlatParamHandle` constructor. Any top-level initialization just needs to forward the user's arguments faithfully to `FlatParamHandle`.
- The unit test `test_meta_device_with_mixed_precision()` exercises a tricky edge case with meta device initialization, `apply()` (calling into `summon_full_params()`), and `param_dtype=torch.float32` for a nested wrapping case, where each nested instance has parameters.

**Follow-Ups**
- We should get rid of `HandleConfig` now because it is no longer meaningful.
- IMHO, we should rename `keep_low_precision_grads` to `keep_grads_in_reduce_dtype` in the `MixedPrecision` dataclass because the `reduce_dtype` specified to `MixedPrecision` does not actually have to be a low precision. You could pass `param_dtype=torch.float16` and `reduce_dtype=torch.float32`, and `keep_low_precision_grads=True` would actually keep the gradients in FP32.
