### PR TITLE
[FSDP] Clean up post-backward hook

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -633,10 +633,6 @@ def _post_backward_hook(
                 # async and would result in reducing the wrong gradient.
                 unsharded_grad = flat_param.grad.data
                 flat_param.grad = None
-                numel_to_pad = (
-                    handle.flat_param._padded_unsharded_size.numel()
-                    - handle.flat_param._unpadded_unsharded_size.numel()
-                )
                 if pre_allocated_reduce_unsharded_grad:
                     # NOTE: `copy_()` includes the typecast if dtypes differ.
                     reduce_unsharded_grad[: unsharded_grad.numel()].copy_(
@@ -666,6 +662,8 @@ def _post_backward_hook(
                     # Copy from low precision to full precision
                     pre_optim_grad.copy_(reduce_sharded_grad)
                     reduce_sharded_grad.data = pre_optim_grad
+                    # TODO: See if we can avoid the double copy if
+                    # `keep_low_precision_grads=True`.
 
                 # Save the sharded gradient in `_saved_grad_shard` to support
                 # gradient accumulation -- for multiple backwards, the gradient

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -579,7 +579,7 @@ def _post_backward_hook(
         needs_pre_reduce_cast = reduce_dtype != handle._config.low_prec_param_dtype
         needs_pre_optim_copy = (
             not _low_precision_hook_enabled(state)  # done in the hook
-            and handle._orig_param_dtype != handle._config.reduce_dtype
+            and handle._orig_param_dtype != reduce_dtype
         )
         if handle.uses_sharded_strategy:
             with torch.cuda.stream(state._streams["default"]):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#90656 [FSDP] Clean up post-backward hook**
* #90619 [FSDP][Perf] Pre-allocate full prec sharded param
* #90618 [FSDP][Easy][BE] Minor cleanup of post-backward logic
* #90616 [FSDP][Perf] Pre-allocate sharded grad in default stream; save one copy when downcasting grad
* #90614 [FSDP][Perf] Pre-allocate padded unsharded grad in default stream
* #90631 [FSDP] Sanitize `HandleConfig` for mixed precision
* #90615 [FSDP] Tighten post-bwd cast to `reduce_dtype`
* #90622 [FSDP][Easy] Move to `_storage()` in test file
* #90611 [FSDP] Save `_stream_to_name` for debugging
* #90562 [Reland][FSDP] Another fix for `DTensor`, `use_orig_params=True`

