### PR TITLE
[FSDP] Clean up `FlatParamHandle` dtypes, post-backward hook

### DIFF
--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -398,7 +398,7 @@ class TestCommunicationHooks(FSDPTest):
         loss_mp = fsdp_with_mp(in_data).sum()
         loss_hook.backward()
         # Make sure grads were cast to the parameter's precision
-        self.assertEqual(fsdp_with_hook.params[0].dtype, state.parameter_type)
+        self.assertEqual(fsdp_with_hook.params[0].grad.dtype, state.parameter_type)
         loss_mp.backward()
         optim_hook.step()
         optim_mp.step()

--- a/test/distributed/fsdp/test_fsdp_flatten_params.py
+++ b/test/distributed/fsdp/test_fsdp_flatten_params.py
@@ -9,7 +9,6 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.flat_param import (
     FlatParamHandle,
     FlatParamShardMetadata,
-    HandleConfig,
     HandleShardingStrategy,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
@@ -39,7 +38,7 @@ class TestFlattenParams(FSDPTest):
         return 1
 
     def _get_default_config(self):
-        return HandleConfig(HandleShardingStrategy.FULL_SHARD, False, None, None, False)
+        return (HandleShardingStrategy.FULL_SHARD, False, None, None, False)
 
     def _get_transformer(self, seed=0):
         torch.manual_seed(seed)  # keep everything deterministic
@@ -149,7 +148,7 @@ class TestFlattenParams(FSDPTest):
                 module,
                 module,
                 torch.device("cuda"),
-                self._get_default_config(),
+                *self._get_default_config(),
                 self.process_group,
                 False,
             )
@@ -222,7 +221,7 @@ class TestFlattenParams(FSDPTest):
             module,
             module,
             torch.device("cuda"),
-            self._get_default_config(),
+            *self._get_default_config(),
             self.process_group,
             False,
         )
@@ -324,7 +323,7 @@ class TestFlattenParams(FSDPTest):
             module,
             module,
             torch.device("cuda"),
-            self._get_default_config(),
+            *self._get_default_config(),
             self.process_group,
             False,
         )

--- a/test/distributed/fsdp/test_fsdp_meta.py
+++ b/test/distributed/fsdp/test_fsdp_meta.py
@@ -2,13 +2,16 @@
 
 import sys
 
+from typing import Union
+
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, MixedPrecision
 from torch.distributed.fsdp.wrap import (
     always_wrap_policy as always_wrap,
     enable_wrap,
+    ModuleWrapPolicy,
     wrap,
 )
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
@@ -342,6 +345,60 @@ class TestFSDPWithMetaDevice(FSDPTest):
             return NestedModel(device="meta")
 
         self._test_bad_arg(meta_module_fn)
+
+    @skip_if_lt_x_gpu(2)
+    def test_meta_device_with_mixed_precision(self):
+        """
+        Tests meta device initialization with a ``param_init_fn`` when
+        specifying mixed precision with ``param_dtype=torch.float32``.
+        """
+
+        class FakeLinear(nn.Module):
+            def __init__(
+                self, in_dim: int, out_dim: int, device: Union[torch.device, str]
+            ) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.randn((in_dim, out_dim), device=device)
+                )
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x @ self.weight
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.lin1 = nn.Linear(5, 5, device="meta")
+                self.lin2 = FakeLinear(5, 5, device="meta")
+                self.relu = nn.ReLU()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.lin2(self.relu(self.lin1(x)))
+
+            def _module_init_fn(self, module: nn.Module):
+                if isinstance(module, nn.Linear):
+                    torch.nn.init.normal_(module.weight, mean=0.0, std=0.1)
+                    if module.bias is not None:
+                        torch.nn.init.zeros_(module.bias)
+
+        def _param_init_fn(module: nn.Module) -> None:
+            # TODO: `module.to_empty()` is not generally correct for meta
+            # device initialization.
+            # https://github.com/pytorch/pytorch/issues/90465
+            module.to_empty(device=torch.device("cuda"))
+            module.apply(model._module_init_fn)
+
+        model = Model()
+        # Wrap only `lin1` and the top level `model`
+        FSDP(
+            model,
+            auto_wrap_policy=ModuleWrapPolicy({nn.Linear}),
+            mixed_precision=MixedPrecision(
+                param_dtype=torch.float32, reduce_dtype=torch.float16
+            ),
+            param_init_fn=_param_init_fn,
+            device_id=torch.cuda.current_device(),
+        )
 
 
 instantiate_parametrized_tests(TestFSDPWithMetaDevice)

--- a/test/distributed/fsdp/test_fsdp_meta.py
+++ b/test/distributed/fsdp/test_fsdp_meta.py
@@ -389,7 +389,8 @@ class TestFSDPWithMetaDevice(FSDPTest):
             module.apply(model._module_init_fn)
 
         model = Model()
-        # Wrap only `lin1` and the top level `model`
+        # Wrap `lin1` and the top level `model` to create nested FSDP instances
+        # where each instance has parameters
         FSDP(
             model,
             auto_wrap_policy=ModuleWrapPolicy({nn.Linear}),

--- a/torch/distributed/algorithms/_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/_comm_hooks/default_hooks.py
@@ -116,9 +116,11 @@ def reduce_scatter_hook(state: DefaultState, grad: torch.Tensor, output: torch.T
         output.div_(state.gradient_postdivide_factor)
 
 def _low_precision_hook(prec: torch.dtype, state: LowPrecisionState, grad: torch.Tensor, output: torch.Tensor):
-    grad.data = grad.data.to(prec)
+    if grad.dtype != prec:
+        grad.data = grad.data.to(prec)
     if output is not None:
-        output.data = output.data.to(prec)
+        if output.dtype != prec:
+            output.data = output.data.to(prec)
         reduce_scatter_hook(state, grad, output)
         _decompress(state, output)
     else:

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -45,7 +45,6 @@ from torch.distributed.fsdp.flat_param import (
     _HandlesKey,
     FlatParameter,
     FlatParamHandle,
-    HandleConfig,
     HandleShardingStrategy,
 )
 from torch.distributed.fsdp.wrap import _FSDPPolicy
@@ -471,19 +470,16 @@ def _init_param_handle_from_params(
 ):
     if len(params) == 0:
         return
-    handle_config = HandleConfig(
-        SHARDING_STRATEGY_MAP[state.sharding_strategy],
-        state.cpu_offload.offload_params,
-        state.mixed_precision.param_dtype,
-        state.mixed_precision.reduce_dtype,
-        state.mixed_precision.keep_low_precision_grads,
-    )
     handle = FlatParamHandle(
         params,
         root_module,
         comm_module,
         state.compute_device,
-        handle_config,
+        SHARDING_STRATEGY_MAP[state.sharding_strategy],
+        state.cpu_offload.offload_params,
+        state.mixed_precision.param_dtype,
+        state.mixed_precision.reduce_dtype,
+        state.mixed_precision.keep_low_precision_grads,
         state.process_group,
         state._use_orig_params,
     )

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
-from torch.distributed.algorithms._comm_hooks import LOW_PRECISION_HOOKS, default_hooks
+from torch.distributed.algorithms._comm_hooks import default_hooks, LOW_PRECISION_HOOKS
 from torch.distributed.fsdp._common_utils import (
     _all_handles,
     _assert_in_training_states,
@@ -34,6 +34,7 @@ RESHARD_AFTER_FORWARD_STRATEGIES = {
     HandleShardingStrategy.FULL_SHARD,
     HandleShardingStrategy.HYBRID_SHARD,
 }
+
 
 @no_type_check
 def _validate_hybrid_shard_setup(fsdp_root: _FSDPState, fsdp_module: nn.Module):
@@ -67,6 +68,7 @@ def _validate_hybrid_shard_setup(fsdp_root: _FSDPState, fsdp_module: nn.Module):
             raise ValueError(
                 f"For {fsdp_root.sharding_strategy}, inter-node process groups do not match"
             )
+
 
 @no_type_check
 def _lazy_init(
@@ -361,7 +363,6 @@ def _post_forward_reshard(
     # with the intention that they are immediately used for backward
     # computation (though this may not be true)
 
-
     free_unsharded_flat_params = [
         not state._is_root
         and handle._config.sharding_strategy in RESHARD_AFTER_FORWARD_STRATEGIES
@@ -572,18 +573,16 @@ def _post_backward_hook(
         state._streams["post_backward"].wait_stream(torch.cuda.current_stream())
 
         with torch.cuda.stream(state._streams["post_backward"]):
-            unsharded_grad_data = param.grad.data
+            autograd_computed_grad = param.grad.data
             if state._exec_order_data.is_first_iter:  # only check once
                 _check_comm_hook(
                     state._communication_hook, state._communication_hook_state
                 )
             if (
-                handle._uses_reduce_mixed_precision
-                and not _low_precision_hook_enabled(state)
-                and param.grad.dtype != handle._config.low_prec_reduce_dtype
+                not _low_precision_hook_enabled(state)
+                and param.grad.dtype != handle._config.reduce_dtype
             ):
-                # TODO: Use the low precision communication hook directly
-                param.grad.data = param.grad.to(handle._config.low_prec_reduce_dtype)
+                param.grad.data = param.grad.to(handle._config.reduce_dtype)
 
             if handle.uses_sharded_strategy:
                 # We clear `.grad` to permit multiple backwards. This avoids a
@@ -593,10 +592,6 @@ def _post_backward_hook(
                 # async and would result in reducing the wrong gradient.
                 unsharded_grad = param.grad.data
                 param.grad = None
-                p_assert(
-                    len(unsharded_grad.size()) == 1,
-                    f"Expects gradient to be flattened but got {unsharded_grad.size()}",
-                )
                 chunks = list(unsharded_grad.chunk(state.world_size))
                 numel_to_pad = (
                     state.world_size * chunks[0].numel() - unsharded_grad.numel()
@@ -612,17 +607,12 @@ def _post_backward_hook(
                     padded_unsharded_grad,
                     new_sharded_grad,
                 )
-                if handle._config.sharding_strategy in (
-                    HandleShardingStrategy.HYBRID_SHARD,
-                    HandleShardingStrategy._HYBRID_SHARD_ZERO2
-                ):
+                if handle._config.sharding_strategy in HYBRID_SHARDING_STRATEGIES:
                     default_hooks.allreduce_hook(
                         state=state._inter_node_state,
                         grad=new_sharded_grad,
                     )
-
-                _cast_grad_to_param_dtype(state, handle, new_sharded_grad, param)
-
+                _cast_grad_to_param_dtype(state, new_sharded_grad, param)
                 # Save the sharded gradient in `_saved_grad_shard` to support
                 # gradient accumulation -- for multiple backwards, the gradient
                 # reductions may happen in arbitrary order
@@ -632,14 +622,14 @@ def _post_backward_hook(
                     param._saved_grad_shard += new_sharded_grad
                 else:
                     param._saved_grad_shard = new_sharded_grad
-                sharded_grad = param._saved_grad_shard
+                grad_to_offload = param._saved_grad_shard
             else:
                 state._communication_hook(state._communication_hook_state, param.grad)
                 # For `NO_SHARD`, we can keep the low precision gradients by
                 # simply omitting the cast altogether
                 if not handle._keep_low_precision_grads:
-                    _cast_grad_to_param_dtype(state, handle, param.grad, param)
-                sharded_grad = param.grad.data
+                    _cast_grad_to_param_dtype(state, param.grad, param)
+                grad_to_offload = param.grad.data
 
             if handle._config.offload_params:
                 # Offload the gradient to CPU to ensure parameters and
@@ -648,20 +638,21 @@ def _post_backward_hook(
                 # using `non_blocking=True` here.
                 non_blocking = handle.uses_sharded_strategy
                 param._cpu_grad.copy_(  # type: ignore[attr-defined]
-                    sharded_grad.detach(), non_blocking=non_blocking
+                    grad_to_offload.detach(), non_blocking=non_blocking
                 )  # synchronized in the post-backward callback
-                # Since the sharded gradient is produced in the post-backward
-                # stream and consumed later in the computation stream, inform
-                # the caching allocator
+                # Since the gradient being offloaded may have been produced in
+                # the computation stream and is being consumed here in the
+                # post-backward stream, inform the caching allocator
                 _no_dispatch_record_stream(
-                    sharded_grad.data, torch.cuda.current_stream()
+                    grad_to_offload.data,
+                    state._streams["post_backward"],
                 )
 
             # Since the unsharded gradient is produced in the computation
             # stream and consumed in the post-backward stream, inform the
             # caching allocator (before it goes out of scope)
             _no_dispatch_record_stream(
-                unsharded_grad_data, state._streams["post_backward"]
+                autograd_computed_grad, state._streams["post_backward"]
             )
 
             if handle._use_orig_params:
@@ -695,7 +686,6 @@ def _should_free_in_backward(
 @no_type_check
 def _cast_grad_to_param_dtype(
     state: _FSDPState,
-    handle: FlatParamHandle,
     sharded_grad: torch.Tensor,
     param: FlatParameter,
 ):
@@ -710,9 +700,7 @@ def _cast_grad_to_param_dtype(
     dtype cast happens in the hook instead.
     """
     _assert_in_training_states(state, [TrainingState.FORWARD_BACKWARD])
-    if not _low_precision_hook_enabled(state) and (
-        handle._uses_param_mixed_precision or handle._uses_reduce_mixed_precision
-    ):
+    if not _low_precision_hook_enabled(state) and sharded_grad.dtype != param.dtype:
         low_prec_grad_data = sharded_grad.data
         sharded_grad.data = sharded_grad.data.to(dtype=param.dtype)
         # Since for `NO_SHARD`, the gradient is produced in the computation

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -607,7 +607,10 @@ def _post_backward_hook(
                     padded_unsharded_grad,
                     new_sharded_grad,
                 )
-                if handle._config.sharding_strategy in HYBRID_SHARDING_STRATEGIES:
+                if handle._config.sharding_strategy in {
+                    HandleShardingStrategy.HYBRID_SHARD,
+                    HandleShardingStrategy._HYBRID_SHARD_ZERO2,
+                }:
                     default_hooks.allreduce_hook(
                         state=state._inter_node_state,
                         grad=new_sharded_grad,

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -607,10 +607,10 @@ def _post_backward_hook(
                     padded_unsharded_grad,
                     new_sharded_grad,
                 )
-                if handle._config.sharding_strategy in {
+                if handle._config.sharding_strategy in (
                     HandleShardingStrategy.HYBRID_SHARD,
                     HandleShardingStrategy._HYBRID_SHARD_ZERO2,
-                }:
+                ):
                     default_hooks.allreduce_hook(
                         state=state._inter_node_state,
                         grad=new_sharded_grad,

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -518,32 +518,15 @@ class FullyShardedDataParallel(nn.Module):
 
         return ret
 
-    def _mixed_precision_enabled_for_params(self) -> bool:
-        """
-        Whether user explicitly enabled mixed precision for
-        parameters or not.
-        """
-        return self.mixed_precision.param_dtype is not None
-
     def _mixed_precision_enabled_for_buffers(self) -> bool:
         """
-        Whether user explicitly enabled mixed precision for
-        buffers or not.
+        Returns if the user explicitly enabled buffer mixed precision.
+
+        NOTE: Unlike parameters and gradient reduction, buffer mixed precision
+        is applied at the FSDP instance level, not the ``FlatParameter`` level,
+        which may be different for the composable code path.
         """
         return self.mixed_precision.buffer_dtype is not None
-
-    def _mixed_precision_enabled_for_reduce(self) -> bool:
-        """
-        Whether user explicitly enabled mixed precision for
-        gradient reduction or not.
-        """
-        return self.mixed_precision.reduce_dtype is not None
-
-    def _mixed_precision_keep_low_precision_grads(self) -> bool:
-        return (
-            self.mixed_precision is not None
-            and self.mixed_precision.keep_low_precision_grads
-        )
 
     def _low_precision_hook_enabled(self) -> bool:
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90678 [FSDP] Pre-allocate all grad tensors in default stream
* **#90660 [FSDP] Clean up `FlatParamHandle` dtypes, post-backward hook**
* #90615 [FSDP] Tighten post-bwd cast to `reduce_dtype`
* #90622 [FSDP][Easy] Move to `_storage()` in test file
* #90611 [FSDP] Save `_stream_to_name` for debugging
* #90562 [Reland][FSDP] Another fix for `DTensor`, `use_orig_params=True`

This PR reworks the internal handling of parameter and gradient reduction mixed precision, cleans up the post-backward hook logic, and adds some minor changes to the communication hooks.

**Overview**
This PR addresses everything in https://github.com/pytorch/pytorch/issues/90657 except renaming `keep_low_precision_grads` to `keep_grads_in_reduce_dtype` since that is BC breaking. I recommend reading the issue before preceding.

For `MixedPrecision(param_dtype, reduce_dtype, ...)`, the exact rule for parameter and gradient reduction mixed precision that we are following is:
> If `param_dtype is not None` and `reduce_dtype is None`, then we infer `reduce_dtype = param_dtype`. Otherwise, we take `param_dtype` and `reduce_dtype` as is.

This PR enforces that, at the `FlatParamHandle` level, `handle._config.fwd_bwd_param_dtype` and `handle._config.reduce_dtype` are never `None`. The way to check if mixed precision is enabled is to compare against the original parameter dtype, which is now stored in `handle._orig_param_dtype`. It is no longer to check against `None`.

This avoids ambiguous cases such as when the user passes `MixedPrecision(param_dtype=torch.float32)`. In that case, our existing implementation mistakenly thinks that parameter mixed precision is enabled and either relies on no-ops silently or errors (such as one case reported by MosaicML).

**Additional Details**
- We remove `FullyShardedDataParallel._mixed_precision_enabled_for_params`, `FullyShardedDataParallel._mixed_precision_enabled_for_reduce`, and `FullyShardedDataParallel._mixed_precision_keep_low_precision_grads` since they are not used.
- The unit test `test_meta_device_with_mixed_precision()` exercises a tricky edge case with meta device initialization, `apply()` (calling into `summon_full_params()`), and `param_dtype=torch.float32` for a nested wrapping case, where each nested instance has parameters.
- We include some minor fixes/improvements to the communication hook implementation.

**Follow-Ups**
- We should get rid of `HandleConfig` and store its fields as attributes on `FlatParamHandle` directly.
- Rename `keep_low_precision_grads` to `keep_grads_in_reduce_dtype`.
