### PR TITLE
[Fix]: Add some missing moves in 90442

### DIFF
--- a/aten/src/ATen/EmptyTensor.cpp
+++ b/aten/src/ATen/EmptyTensor.cpp
@@ -108,8 +108,8 @@ size_t computeStorageNbytes(
 
 SymInt computeStorageNbytesContiguous(
     SymIntArrayRef sizes,
-    SymInt itemsize_bytes,
-    SymInt storage_offset
+    const SymInt& itemsize_bytes,
+    const SymInt& storage_offset
   ) {
   const auto numel = c10::multiply_integers(sizes);
   return itemsize_bytes * (storage_offset + numel);
@@ -120,8 +120,8 @@ SymInt computeStorageNbytesContiguous(
 SymInt computeStorageNbytes(
     SymIntArrayRef sizes,
     SymIntArrayRef strides,
-    SymInt itemsize_bytes,
-    SymInt storage_offset
+    const SymInt& itemsize_bytes,
+    const SymInt& storage_offset
   ) {
   TORCH_CHECK(
     sizes.size() == strides.size(),

--- a/aten/src/ATen/EmptyTensor.h
+++ b/aten/src/ATen/EmptyTensor.h
@@ -22,8 +22,8 @@ TORCH_API size_t computeStorageNbytesContiguous(
     size_t storage_offset = 0);
 TORCH_API SymInt computeStorageNbytesContiguous(
     SymIntArrayRef sizes,
-    SymInt itemsize,
-    SymInt storage_offset = 0);
+    const SymInt& itemsize,
+    const SymInt& storage_offset = 0);
 TORCH_API size_t computeStorageNbytes(
     IntArrayRef sizes,
     IntArrayRef strides,
@@ -32,8 +32,8 @@ TORCH_API size_t computeStorageNbytes(
 TORCH_API SymInt computeStorageNbytes(
     SymIntArrayRef sizes,
     SymIntArrayRef strides,
-    SymInt itemsize,
-    SymInt storage_offset = 0);
+    const SymInt& itemsize,
+    const SymInt& storage_offset = 0);
 
 TORCH_API TensorBase empty_generic(
     IntArrayRef size,

--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -156,7 +156,7 @@ const Tensor& resize_as_(
 
 void resize_bytes_meta(StorageImpl* storage, c10::SymInt size_bytes) {
   TORCH_CHECK(storage->resizable(), "Trying to resize storage that is not resizable");
-  storage->set_nbytes(size_bytes);
+  storage->set_nbytes(std::move(size_bytes));
 }
 
 static void maybe_resize_storage_meta(TensorImpl* self, c10::SymInt new_size_bytes) {
@@ -173,7 +173,7 @@ static void maybe_resize_storage_meta(TensorImpl* self, c10::SymInt new_size_byt
   if (!storage) {
     TORCH_INTERNAL_ASSERT(0, "NYI, this should only be Caffe2");
   } else if (new_size_bytes > storage.nbytes()) {
-    resize_bytes_meta(storage.unsafeGetStorageImpl(), new_size_bytes);
+    resize_bytes_meta(storage.unsafeGetStorageImpl(), std::move(new_size_bytes));
   }
 }
 
@@ -182,7 +182,7 @@ static void _maybe_resize_storage(TensorImpl* self, int64_t new_size_bytes) {
 }
 
 static void _maybe_resize_storage(TensorImpl* self, c10::SymInt new_size_bytes) {
-  maybe_resize_storage_meta(self, new_size_bytes);
+  maybe_resize_storage_meta(self, std::move(new_size_bytes));
 }
 
 template <typename T>
@@ -209,7 +209,7 @@ TensorImpl* _resize_impl_(
   }
 
   if (resize_storage) {
-    _maybe_resize_storage(self, storage_size);
+    _maybe_resize_storage(self, std::move(storage_size));
   }
 
   return self;


### PR DESCRIPTION
@ezyang Noticed a couple of missing std::move for all the symints from #90442. Also I noticed a couple of helper functions didn't seem like they needed to take ownership.
