### PR TITLE
Fix a typo in some torch.load error message.

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -773,7 +773,7 @@ def load(
 
     if weights_only:
         if pickle_module is not None:
-            raise RuntimeError("Can not safely load weights when explicit picke_module is specified")
+            raise RuntimeError("Can not safely load weights when explicit pickle_module is specified")
     else:
         if pickle_module is None:
             pickle_module = pickle


### PR DESCRIPTION
Very cosmetic change: only fixes a small typo in an error message that torch.load could raise.
