### PR TITLE
Preserve original GraphArgs for shape guard codegen

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1959,6 +1959,77 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             self.assertEqual(f(x, x), opt_f(x, x))
             self.assertEqual(f(x, y), opt_f(x, y))
 
+    def test_reformer_remove_unused_args(self):
+        # This test case is very interesting.  First, let's describe
+        # the bug this is testing for.  The bug we fixed is twofold:
+        #
+        # - We prune GraphArgs that aren't used in the output graph.
+        #   However, sometimes it is possible for those GraphArgs to be
+        #   utilized in shape guards (you could imagine this happening if
+        #   dynamo poked some shape variables without recording them in the
+        #   graph.)  If we prune those GraphArgs, we get a
+        #   "s1 not in ..." error as we can no longer codegen the
+        #   requested guards.
+        #
+        # - But in practice, Dynamo usually traces size accesses into the
+        #   graph, preventing the GraphArg from getting pruned.  So how
+        #   come we were running into this in practice with hf_Reformer?
+        #   The answer is checkpointing!
+        #
+        # This brings us to the following test case.  Here's what it does:
+        #
+        # 1. It traces some operations, and then checkpoints before inlining
+        #    the function call to g
+        #
+        # 2. g traces some more operations (triggering the shape guard
+        #    to be created), but then it graph breaks
+        #
+        # 3. Because you can't graph break in an inlining function, we roll
+        #    back to the outer checkpoint ("undoing" the operation that
+        #    induced the shape guard) and then immediately generate a
+        #    subgraph at that point.
+        #
+        # If we failed to checkpoint the ShapeEnv, it can still have guards
+        # from the aborted speculation, which we will then still attempt to
+        # codegen.
+        #
+        # There's an additional nuance: suppose x is used but y is not.
+        # If you create a guard like y == x * 2, you will accidentally avoid
+        # the "s1 not in ..." error, as y will get substituted with x * 2,
+        # but x is still a GraphArg (it's used) and you don't end up with
+        # the error.  This is why we must show y + y == x, not vice versa.
+        # Similarly, it is also why we must not do a simple guard like x == y
+        #
+        # Can we actually demonstrate that checkpointing the ShapeEnv is
+        # necessary?  It's not so easy to induce this case.  Dynamo is very
+        # eager about adding locals to GraphArgs; any local that is in scope,
+        # even if it isn't used, is added to GraphArgs (see also
+        # https://github.com/pytorch/torchdynamo/issues/1925 ).  So long
+        # as Dynamo eagerly guards in this way, we have an invariant that
+        # all locals are guaranteed to show up in GraphArgs before the
+        # inlining function call, in which case we will always have enough
+        # information to codegen our guards so long as we don't prune the
+        # unused GraphArgs away (and indeed, the direct fix for this bug
+        # was to make sure we use original GraphArgs).  Non locals,
+        # conversely, typically are static, and so won't have guards allocated
+        # for them.  That being said, there may still be a way to trigger
+        # this error.
+
+        def g(x, y):
+            r = torch.cat((y, y)) + x
+            print("foo")
+            return r
+
+        def f(x, y):
+            x = x * 3
+            return g(x, y)
+
+        opt_f = torch._dynamo.optimize("aot_eager")(f)
+
+        x = torch.randn(4)
+        y = torch.randn(2)
+        self.assertEqual(f(x, y), opt_f(x, y))
+
     def test_while_loop_graph_break(self):
         # Repro of tacotron2 cache_size_recompilation
         def inner(x):

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -645,10 +645,13 @@ class CheckFunctionManager:
         # shape variables to sources from GraphArgs.  This must happen after
         # tensor checks.
         # NB: self.output_graph can be None in the debug_nops tests
-        # TODO: What about grapharg pruning?  This could be problematic if we
-        # guarded on a tensor that isn't actually used as an input in the end.
         if self.output_graph and self.output_graph.shape_env:
-            graphargs = self.output_graph.graphargs
+            # NB: use orig_graphargs, as we can have created guards for
+            # inputs that are ultimately unused in the graph, but we
+            # are still on the hook for guarding on them (because, e.g.,
+            # Dynamo may have gone down a different conditional branch
+            # because of it.)
+            graphargs = self.output_graph.orig_graphargs
             expr_as_str = self.output_graph.shape_env.codegen_guards(
                 [a.fake_tensor for a in graphargs if a.is_tensor],
                 [a.source.name() for a in graphargs if a.is_tensor],

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -719,7 +719,7 @@ class ShapeEnv(object):
             try:
                 exprs.append(ShapeGuardPrinter(symbol_to_source).doprint(g))
             except Exception:
-                logging.warning(f"failing guard allocated at {tb}")
+                logging.warning(f"Failing guard allocated at:\n{tb}")
                 raise
 
         # 3. Every symbol must not be equal to 0/1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90665
* #90664

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire