### PR TITLE
Don't enable debug_fake_crossref for TORCH_COMPILE_DEBUG

### DIFF
--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -182,7 +182,6 @@ def enable_aot_logging():
     # and the log level of the file logger to DEBUG
 
     stack = contextlib.ExitStack()
-    stack.enter_context(patch("functorch.compile.config.debug_fake_cross_ref", True))
     stack.enter_context(patch("functorch.compile.config.debug_partitioner", True))
     stack.enter_context(patch("functorch.compile.config.debug_graphs", True))
     stack.enter_context(patch("functorch.compile.config.debug_joint", True))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90666

It is kind of flaky, it doesn't work with dynamic shapes, and I think the debug interpreter is a better way to detect if you've had a size/stride propagation accident.

Fixes https://github.com/pytorch/pytorch/issues/90652

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire