### PR TITLE
Include dispatch key in wrapper symbol name

### DIFF
--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -294,7 +294,7 @@ class RegisterDispatchKey:
     ) -> Union[NativeSignature, DispatcherSignature]:
         # The prefix is just to ensure uniqueness. The Dispatcher API doesn't guarantee unique kernel names.
         return DispatcherSignature.from_schema(
-            f.func, prefix=f"wrapper_{f.func.name.overload_name}_", symint=self.symint
+            f.func, prefix=f"wrapper_{self.backend_index.dispatch_key}_{f.func.name.overload_name}_", symint=self.symint
         )
 
     def gen_out_inplace_wrapper(
@@ -760,7 +760,7 @@ resize_out(out, sizes, strides, options);
         kern = self.backend_index.get_kernel(f)
         sig = NativeSignature(
             f.func,
-            prefix="wrapper_",
+            prefix=f"wrapper_{self.backend_index.dispatch_key}_",
             symint=kern is not None and kern.supports_symint(),
         )
 

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -294,7 +294,9 @@ class RegisterDispatchKey:
     ) -> Union[NativeSignature, DispatcherSignature]:
         # The prefix is just to ensure uniqueness. The Dispatcher API doesn't guarantee unique kernel names.
         return DispatcherSignature.from_schema(
-            f.func, prefix=f"wrapper_{self.backend_index.dispatch_key}_{f.func.name.overload_name}_", symint=self.symint
+            f.func,
+            prefix=f"wrapper_{self.backend_index.dispatch_key}_{f.func.name.overload_name}_",
+            symint=self.symint,
         )
 
     def gen_out_inplace_wrapper(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90674

When looking at gdb traces, this makes it easier to tell that
you're looking at the CPU wrapper vs CUDA wrapper, etc.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D42088744](https://our.internmc.facebook.com/intern/diff/D42088744)