### PR TITLE
Fix: Apply clang-tidy to c10/core

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -38,7 +38,7 @@ performance-*,
 -performance-noexcept-move-constructor,
 -performance-unnecessary-value-param,
 '
-HeaderFilterRegex: 'torch/csrc/(?!deploy/interpreter/cpython).*'
+HeaderFilterRegex: '(c10/(?!test)/|torch/csrc/(?!deploy/interpreter/cpython)).*'
 AnalyzeTemporaryDtors: false
 WarningsAsErrors: '*'
 CheckOptions:

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -209,6 +209,8 @@ command = [
 [[linter]]
 code = 'CLANGTIDY'
 include_patterns = [
+    'c10/core/*.cpp',
+    'c10/core/**/*.cpp',
     'torch/csrc/fx/**/*.cpp',
     'torch/csrc/generic/**/*.cpp',
     'torch/csrc/onnx/**/*.cpp',
@@ -222,6 +224,7 @@ exclude_patterns = [
     # in a follow up PR.
     # /torch/csrc/generic/*.cpp is excluded because those files aren't actually built.
     # that are not easily converted to accepted c++
+    'c10/test/**/*.cpp',
     'torch/csrc/jit/passes/onnx/helper.cpp',
     'torch/csrc/jit/passes/onnx/shape_type_inference.cpp',
     'torch/csrc/jit/serialization/onnx.cpp',

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -50,7 +50,7 @@ std::string DeviceTypeName(DeviceType d, bool lower_case) {
     case DeviceType::IPU:
       return lower_case ? "ipu" : "IPU";
     case DeviceType::PrivateUse1:
-      return get_privateuse1_backend(/*lowercase=*/lower_case);
+      return get_privateuse1_backend(/*lower_case=*/lower_case);
     default:
       TORCH_CHECK(
           false,

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -240,7 +240,7 @@ bool_is_contiguous _compute_contiguous(
   T z = 1;
   // NB: make sure we do signed arithmetic
   for (int64_t d = int64_t(sizes.size()) - 1; d >= 0; d--) {
-    const auto size_d = sizes[d];
+    const auto& size_d = sizes[d];
     if (size_d != 1) {
       if (strides[d] == z) {
         z *= size_d;
@@ -288,7 +288,7 @@ bool_is_channels_last_contiguous _compute_channels_last_contiguous_2d(
     case 4: {
       T expected = 1;
       for (auto& d : {1, 3, 2, 0}) {
-        const auto size_d = sizes[d];
+        const auto& size_d = sizes[d];
         if (size_d != 1) {
           if (strides[d] != expected) {
             return bool_is_channels_last_contiguous(false);
@@ -325,7 +325,7 @@ bool_is_channels_last_3d_contiguous _compute_channels_last_contiguous_3d(
     case 5: {
       T expected = 1;
       for (auto& d : {1, 4, 3, 2, 0}) {
-        const auto size_d = sizes[d];
+        const auto& size_d = sizes[d];
         if (size_d != 1) {
           if (strides[d] != expected) {
             return bool_is_channels_last_3d_contiguous(false);
@@ -394,7 +394,7 @@ bool_is_non_overlapping_and_dense _compute_non_overlapping_and_dense(
   });
   T require_stride = 1;
   for (const auto i : c10::irange(dim)) {
-    const auto size_perm_i = sizes[perm[i]];
+    const auto& size_perm_i = sizes[perm[i]];
     if (size_perm_i < 2) {
       return bool_is_non_overlapping_and_dense(true);
     }
@@ -970,8 +970,8 @@ void TensorImpl::ShareExternalPointer(
 void clone_symvec(SymIntArrayRef src, SymDimVector& dst) {
   dst.clear();
   dst.reserve(src.size());
-  for (size_t i = 0; i < src.size(); i++) {
-    dst.emplace_back(src[i].clone());
+  for (const auto& i : src) {
+    dst.emplace_back(i.clone());
   }
 }
 

--- a/c10/core/impl/SizesAndStrides.cpp
+++ b/c10/core/impl/SizesAndStrides.cpp
@@ -27,8 +27,8 @@ void SizesAndStrides::resizeSlowPath(
     if (isInline()) {
       // CANNOT USE allocateOutOfLineStorage(newSize) HERE! WOULD
       // OVERWRITE inlineStorage_!
-      // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
       int64_t* tempStorage =
+          // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
           static_cast<int64_t*>(malloc(storageBytes(newSize)));
       TORCH_CHECK(
           tempStorage,

--- a/c10/core/impl/TorchDispatchModeTLS.cpp
+++ b/c10/core/impl/TorchDispatchModeTLS.cpp
@@ -21,8 +21,7 @@ const std::shared_ptr<SafePyObject> TorchDispatchModeTLS::pop_stack() {
   TORCH_CHECK(
       torchDispatchModeState.stack_.size() > 0,
       "trying to pop from empty mode stack");
-  const std::shared_ptr<SafePyObject> out =
-      torchDispatchModeState.stack_.back();
+  std::shared_ptr<SafePyObject> out = torchDispatchModeState.stack_.back();
   torchDispatchModeState.stack_.pop_back();
 
   if (torchDispatchModeState.stack_.size() == 0) {


### PR DESCRIPTION
Enables clang-tidy on 'c10/core'. Request by @ezyang to extend coverage of clang-tidy for better performance linting.
