### PR TITLE
Give linting steps a unique prefix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
             --tags-path aten/src/ATen/native/tags.yaml \
             --deprecated-functions-path "tools/autograd/deprecated.yaml"
 
-      - name: Run lintrunner on all files
+      - name: Run lint - Run lintrunner on all files
         run: |
           set +e
           if ! lintrunner --force-color --all-files --tee-json=lint.json; then
@@ -98,20 +98,20 @@ jobs:
           # NB: We use 'printf' below rather than '\u000a' since bash pre-4.2
           # does not support the '\u000a' syntax (which is relevant for local linters)
           (! git --no-pager grep -In "$(printf '\xC2\xA0')" -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
-      - name: Ensure cross-OS compatible file names
+      - name: Run lint - Ensure cross-OS compatible file names
         if: always()
         run: |
           (! git ls-files | grep -E '([<>:"|?*]|[ .]$)' || (echo "The above file names are not valid across all operating systems. Please ensure they don't contain the characters '<>:""|?*' and don't end with a white space or a '.' "; false))
-      - name: Ensure no versionless Python shebangs
+      - name: Run lint - Ensure no versionless Python shebangs
         if: always()
         run: |
           (! git --no-pager grep -In '#!.*python$' -- . || (echo "The above lines have versionless Python shebangs; please specify either python2 or python3"; false))
-      - name: C++ docs check
+      - name: Run lint - C++ docs check
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
           sudo apt-get install -y doxygen
           cd docs/cpp/source && ./check-doxygen.sh
-      - name: CUDA kernel launch check
+      - name: Run lint - CUDA kernel launch check
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
           set -eux
@@ -128,7 +128,7 @@ jobs:
         with:
           submodules: false
           fetch-depth: -1
-      - name: PR size check
+      - name: Run lint - PR size check
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
@@ -162,10 +162,10 @@ jobs:
       - name: Install Jinja2
         run: |
           pip install Jinja2==3.0.1 --user
-      - name: Regenerate workflows
+      - name: Run lint - Regenerate workflows
         id: generate_workflows
         run: .github/scripts/generate_ci_workflows.py
-      - name: Assert that regenerating the workflows didn't change them
+      - name: Run lint - Assert that regenerating the workflows didn't change them
         run: |
           if ! .github/scripts/report_git_status.sh .github/workflows; then
             echo
@@ -179,7 +179,7 @@ jobs:
             echo 'onto a more recent commit from the PyTorch master branch.'
             false
           fi
-      - name: Check that jobs will be cancelled
+      - name: Run lint - Check that jobs will be cancelled
         if: ${{ always() && steps.generate_workflows.outcome == 'success' }}
         run: |
           .github/scripts/ensure_actions_will_cancel.py
@@ -202,7 +202,7 @@ jobs:
         uses: actions/setup-node@v3
       - name: Install markdown-toc
         run: npm install -g markdown-toc
-      - name: Regenerate ToCs and check that they didn't change
+      - name: Run lint - Regenerate ToCs and check that they didn't change
         run: |
           set -eu
           export PATH=~/.npm-global/bin:"$PATH"
@@ -262,7 +262,7 @@ jobs:
           pip install -r requirements.txt --user
           pip install mypy==0.960 --user
           make setup_lint
-      - name: Test tools
+      - name: Run lint - Test tools
         run: |
           python3 -m unittest discover -vs tools/test -p 'test_*.py'
           python3 -m unittest discover -vs .github/scripts -p 'test_*.py'
@@ -308,7 +308,7 @@ jobs:
           pip install -r requirements.txt
           # Doesn't really matter what torch version, we just need ANY torch installed
           pip install 'torch==1.*'
-      - name: Run collect_env.py
+      - name: Run lint - Run collect_env.py
         run: |
           # All we need to see is that it passes
           python3 torch/utils/collect_env.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ on:
       - landchecks/*
   workflow_dispatch:
 
+# The names of steps that actually test the code should be prefixed with `[nonretryable]`.
+# When any other step fails, it's job will be retried once by retryBot.
 jobs:
   lintrunner:
     runs-on: linux.20_04.16x

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
       - landchecks/*
   workflow_dispatch:
 
-# The names of steps that actually test the code should be prefixed with `[nonretryable]`.
+# The names of steps that actually test the code should be prefixed with `(nonretryable)`.
 # When any other step fails, it's job will be retried once by retryBot.
 jobs:
   lintrunner:
@@ -48,7 +48,7 @@ jobs:
             --tags-path aten/src/ATen/native/tags.yaml \
             --deprecated-functions-path "tools/autograd/deprecated.yaml"
 
-      - name: [nonretryable] Run lintrunner on all files
+      - name: (nonretryable) Run lintrunner on all files
         run: |
           set +e
           if ! lintrunner --force-color --all-files --tee-json=lint.json; then
@@ -100,20 +100,20 @@ jobs:
           # NB: We use 'printf' below rather than '\u000a' since bash pre-4.2
           # does not support the '\u000a' syntax (which is relevant for local linters)
           (! git --no-pager grep -In "$(printf '\xC2\xA0')" -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
-      - name: [nonretryable] Ensure cross-OS compatible file names
+      - name: (nonretryable) Ensure cross-OS compatible file names
         if: always()
         run: |
           (! git ls-files | grep -E '([<>:"|?*]|[ .]$)' || (echo "The above file names are not valid across all operating systems. Please ensure they don't contain the characters '<>:""|?*' and don't end with a white space or a '.' "; false))
-      - name: [nonretryable] Ensure no versionless Python shebangs
+      - name: (nonretryable) Ensure no versionless Python shebangs
         if: always()
         run: |
           (! git --no-pager grep -In '#!.*python$' -- . || (echo "The above lines have versionless Python shebangs; please specify either python2 or python3"; false))
-      - name: [nonretryable] C++ docs check
+      - name: (nonretryable) C++ docs check
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
           sudo apt-get install -y doxygen
           cd docs/cpp/source && ./check-doxygen.sh
-      - name: [nonretryable] CUDA kernel launch check
+      - name: (nonretryable) CUDA kernel launch check
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
           set -eux
@@ -130,7 +130,7 @@ jobs:
         with:
           submodules: false
           fetch-depth: -1
-      - name: [nonretryable] PR size check
+      - name: (nonretryable) PR size check
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
@@ -164,10 +164,10 @@ jobs:
       - name: Install Jinja2
         run: |
           pip install Jinja2==3.0.1 --user
-      - name: [nonretryable] Regenerate workflows
+      - name: (nonretryable) Regenerate workflows
         id: generate_workflows
         run: .github/scripts/generate_ci_workflows.py
-      - name: [nonretryable] Assert that regenerating the workflows didn't change them
+      - name: (nonretryable) Assert that regenerating the workflows didn't change them
         run: |
           if ! .github/scripts/report_git_status.sh .github/workflows; then
             echo
@@ -181,7 +181,7 @@ jobs:
             echo 'onto a more recent commit from the PyTorch master branch.'
             false
           fi
-      - name: [nonretryable] Check that jobs will be cancelled
+      - name: (nonretryable) Check that jobs will be cancelled
         if: ${{ always() && steps.generate_workflows.outcome == 'success' }}
         run: |
           .github/scripts/ensure_actions_will_cancel.py
@@ -204,7 +204,7 @@ jobs:
         uses: actions/setup-node@v3
       - name: Install markdown-toc
         run: npm install -g markdown-toc
-      - name: [nonretryable] Regenerate ToCs and check that they didn't change
+      - name: (nonretryable) Regenerate ToCs and check that they didn't change
         run: |
           set -eu
           export PATH=~/.npm-global/bin:"$PATH"
@@ -264,7 +264,7 @@ jobs:
           pip install -r requirements.txt --user
           pip install mypy==0.960 --user
           make setup_lint
-      - name: [nonretryable] Test tools
+      - name: (nonretryable) Test tools
         run: |
           python3 -m unittest discover -vs tools/test -p 'test_*.py'
           python3 -m unittest discover -vs .github/scripts -p 'test_*.py'
@@ -310,7 +310,7 @@ jobs:
           pip install -r requirements.txt
           # Doesn't really matter what torch version, we just need ANY torch installed
           pip install 'torch==1.*'
-      - name: [nonretryable] Run collect_env.py
+      - name: (nonretryable) Run collect_env.py
         run: |
           # All we need to see is that it passes
           python3 torch/utils/collect_env.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
             --tags-path aten/src/ATen/native/tags.yaml \
             --deprecated-functions-path "tools/autograd/deprecated.yaml"
 
-      - name: Run lint - Run lintrunner on all files
+      - name: [nonretryable] Run lintrunner on all files
         run: |
           set +e
           if ! lintrunner --force-color --all-files --tee-json=lint.json; then
@@ -98,20 +98,20 @@ jobs:
           # NB: We use 'printf' below rather than '\u000a' since bash pre-4.2
           # does not support the '\u000a' syntax (which is relevant for local linters)
           (! git --no-pager grep -In "$(printf '\xC2\xA0')" -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
-      - name: Run lint - Ensure cross-OS compatible file names
+      - name: [nonretryable] Ensure cross-OS compatible file names
         if: always()
         run: |
           (! git ls-files | grep -E '([<>:"|?*]|[ .]$)' || (echo "The above file names are not valid across all operating systems. Please ensure they don't contain the characters '<>:""|?*' and don't end with a white space or a '.' "; false))
-      - name: Run lint - Ensure no versionless Python shebangs
+      - name: [nonretryable] Ensure no versionless Python shebangs
         if: always()
         run: |
           (! git --no-pager grep -In '#!.*python$' -- . || (echo "The above lines have versionless Python shebangs; please specify either python2 or python3"; false))
-      - name: Run lint - C++ docs check
+      - name: [nonretryable] C++ docs check
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
           sudo apt-get install -y doxygen
           cd docs/cpp/source && ./check-doxygen.sh
-      - name: Run lint - CUDA kernel launch check
+      - name: [nonretryable] CUDA kernel launch check
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
           set -eux
@@ -128,7 +128,7 @@ jobs:
         with:
           submodules: false
           fetch-depth: -1
-      - name: Run lint - PR size check
+      - name: [nonretryable] PR size check
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
@@ -162,10 +162,10 @@ jobs:
       - name: Install Jinja2
         run: |
           pip install Jinja2==3.0.1 --user
-      - name: Run lint - Regenerate workflows
+      - name: [nonretryable] Regenerate workflows
         id: generate_workflows
         run: .github/scripts/generate_ci_workflows.py
-      - name: Run lint - Assert that regenerating the workflows didn't change them
+      - name: [nonretryable] Assert that regenerating the workflows didn't change them
         run: |
           if ! .github/scripts/report_git_status.sh .github/workflows; then
             echo
@@ -179,7 +179,7 @@ jobs:
             echo 'onto a more recent commit from the PyTorch master branch.'
             false
           fi
-      - name: Run lint - Check that jobs will be cancelled
+      - name: [nonretryable] Check that jobs will be cancelled
         if: ${{ always() && steps.generate_workflows.outcome == 'success' }}
         run: |
           .github/scripts/ensure_actions_will_cancel.py
@@ -202,7 +202,7 @@ jobs:
         uses: actions/setup-node@v3
       - name: Install markdown-toc
         run: npm install -g markdown-toc
-      - name: Run lint - Regenerate ToCs and check that they didn't change
+      - name: [nonretryable] Regenerate ToCs and check that they didn't change
         run: |
           set -eu
           export PATH=~/.npm-global/bin:"$PATH"
@@ -262,7 +262,7 @@ jobs:
           pip install -r requirements.txt --user
           pip install mypy==0.960 --user
           make setup_lint
-      - name: Run lint - Test tools
+      - name: [nonretryable] Test tools
         run: |
           python3 -m unittest discover -vs tools/test -p 'test_*.py'
           python3 -m unittest discover -vs .github/scripts -p 'test_*.py'
@@ -308,7 +308,7 @@ jobs:
           pip install -r requirements.txt
           # Doesn't really matter what torch version, we just need ANY torch installed
           pip install 'torch==1.*'
-      - name: Run lint - Run collect_env.py
+      - name: [nonretryable] Run collect_env.py
         run: |
           # All we need to see is that it passes
           python3 torch/utils/collect_env.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
       - landchecks/*
   workflow_dispatch:
 
-# The names of steps that actually test the code should be prefixed with `(nonretryable)`.
+# The names of steps that actually test the code should be suffixed with `(nonretryable)`.
 # When any other step fails, it's job will be retried once by retryBot.
 jobs:
   lintrunner:
@@ -48,7 +48,7 @@ jobs:
             --tags-path aten/src/ATen/native/tags.yaml \
             --deprecated-functions-path "tools/autograd/deprecated.yaml"
 
-      - name: (nonretryable) Run lintrunner on all files
+      - name: Run lintrunner on all files (nonretryable)
         run: |
           set +e
           if ! lintrunner --force-color --all-files --tee-json=lint.json; then
@@ -100,20 +100,20 @@ jobs:
           # NB: We use 'printf' below rather than '\u000a' since bash pre-4.2
           # does not support the '\u000a' syntax (which is relevant for local linters)
           (! git --no-pager grep -In "$(printf '\xC2\xA0')" -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
-      - name: (nonretryable) Ensure cross-OS compatible file names
+      - name: Ensure cross-OS compatible file names (nonretryable)
         if: always()
         run: |
           (! git ls-files | grep -E '([<>:"|?*]|[ .]$)' || (echo "The above file names are not valid across all operating systems. Please ensure they don't contain the characters '<>:""|?*' and don't end with a white space or a '.' "; false))
-      - name: (nonretryable) Ensure no versionless Python shebangs
+      - name: Ensure no versionless Python shebangs (nonretryable)
         if: always()
         run: |
           (! git --no-pager grep -In '#!.*python$' -- . || (echo "The above lines have versionless Python shebangs; please specify either python2 or python3"; false))
-      - name: (nonretryable) C++ docs check
+      - name: C++ docs check (nonretryable)
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
           sudo apt-get install -y doxygen
           cd docs/cpp/source && ./check-doxygen.sh
-      - name: (nonretryable) CUDA kernel launch check
+      - name: CUDA kernel launch check (nonretryable)
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
           set -eux
@@ -130,7 +130,7 @@ jobs:
         with:
           submodules: false
           fetch-depth: -1
-      - name: (nonretryable) PR size check
+      - name: PR size check (nonretryable)
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
@@ -164,10 +164,10 @@ jobs:
       - name: Install Jinja2
         run: |
           pip install Jinja2==3.0.1 --user
-      - name: (nonretryable) Regenerate workflows
+      - name: Regenerate workflows (nonretryable)
         id: generate_workflows
         run: .github/scripts/generate_ci_workflows.py
-      - name: (nonretryable) Assert that regenerating the workflows didn't change them
+      - name: Assert that regenerating the workflows didn't change them (nonretryable)
         run: |
           if ! .github/scripts/report_git_status.sh .github/workflows; then
             echo
@@ -181,7 +181,7 @@ jobs:
             echo 'onto a more recent commit from the PyTorch master branch.'
             false
           fi
-      - name: (nonretryable) Check that jobs will be cancelled
+      - name: Check that jobs will be cancelled (nonretryable)
         if: ${{ always() && steps.generate_workflows.outcome == 'success' }}
         run: |
           .github/scripts/ensure_actions_will_cancel.py
@@ -204,7 +204,7 @@ jobs:
         uses: actions/setup-node@v3
       - name: Install markdown-toc
         run: npm install -g markdown-toc
-      - name: (nonretryable) Regenerate ToCs and check that they didn't change
+      - name: Regenerate ToCs and check that they didn't change (nonretryable)
         run: |
           set -eu
           export PATH=~/.npm-global/bin:"$PATH"
@@ -264,7 +264,7 @@ jobs:
           pip install -r requirements.txt --user
           pip install mypy==0.960 --user
           make setup_lint
-      - name: (nonretryable) Test tools
+      - name: Test tools (nonretryable)
         run: |
           python3 -m unittest discover -vs tools/test -p 'test_*.py'
           python3 -m unittest discover -vs .github/scripts -p 'test_*.py'
@@ -310,7 +310,7 @@ jobs:
           pip install -r requirements.txt
           # Doesn't really matter what torch version, we just need ANY torch installed
           pip install 'torch==1.*'
-      - name: (nonretryable) Run collect_env.py
+      - name: Run collect_env.py (nonretryable)
         run: |
           # All we need to see is that it passes
           python3 torch/utils/collect_env.py


### PR DESCRIPTION
Give a unique prefix to all steps in lint.yml which catch valid linter errors. This will let retrybot identify lint.yml steps which should not be retried.

This is a prelude to https://github.com/pytorch/test-infra/pull/1275 which extends the retry-on-failure behavior to all PRs in addition to trunk.  

This hadn't been an issue previously since we would always only linter failures on `master`, where linter failures were always safe to retry since legitimate linter failures there are virtually non-existent 