### PR TITLE
Remove hard numpy dep introduced by _inductor/utils.py

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -9,7 +9,6 @@ from importlib import import_module
 from typing import Any, Dict, List
 from unittest import mock
 
-import numpy as np
 import sympy
 
 import torch
@@ -117,8 +116,8 @@ def timed(model, example_inputs, times=1):
 
 
 def print_performance(fn, args=(), times=10, repeat=10, baseline=1.0):
-    timings = [timed(fn, args, times) for _ in range(repeat)]
-    took = np.median(timings)
+    timings = torch.tensor([timed(fn, args, times) for _ in range(repeat)])
+    took = torch.median(timings)
     print(f"{took/baseline:.6f}")
     return took
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90716



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire