### PR TITLE
[ROCm] fix hipify mapping for cuDeviceGet

### DIFF
--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -2828,7 +2828,7 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict(
             "cuDevicePrimaryCtxSetFlags",
             ("hipDevicePrimaryCtxSetFlags", CONV_CONTEXT, API_DRIVER),
         ),
-        ("cuDeviceGet", ("hipGetDevice", CONV_DEVICE, API_DRIVER)),
+        ("cuDeviceGet", ("hipDeviceGet", CONV_DEVICE, API_DRIVER)),
         ("cuDeviceGetName", ("hipDeviceGetName", CONV_DEVICE, API_DRIVER)),
         ("cuDeviceGetCount", ("hipGetDeviceCount", CONV_DEVICE, API_DRIVER)),
         ("cuDeviceGetAttribute", ("hipDeviceGetAttribute", CONV_DEVICE, API_DRIVER)),


### PR DESCRIPTION
The mapping was incorrect, but only certain downstream pytorch extensions found this issue.  pytorch CI does not cover this mapping.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport