### PR TITLE
[inductor] Pattern match cat->view*->pointwise and hoist pointwise

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -51,6 +51,7 @@ try:
         linear_transpose,
         permute_linear_fusion,
         permute_matmul_fusion,
+        sink_cat_after_pointwise,
         transpose_linear,
         transpose_matmul,
     )
@@ -143,13 +144,18 @@ def chain_passes(*passes: PassFunc) -> PassFunc:
     return parent_pass
 
 
-def count_call_function(module: torch.fx.GraphModule, target_op: Any) -> int:
+def count_call(module: torch.fx.GraphModule, op: str, target_op: Any) -> int:
     return sum(
-        [
-            1 if (n.op == "call_function" and n.target == target_op) else 0
-            for n in module.graph.nodes
-        ]
+        [1 if (n.op == op and n.target == target_op) else 0 for n in module.graph.nodes]
     )
+
+
+def count_call_function(module: torch.fx.GraphModule, target_op: Any) -> int:
+    return count_call(module, "call_function", target_op)
+
+
+def count_call_method(module: torch.fx.GraphModule, target_op: Any) -> int:
+    return count_call(module, "call_method", target_op)
 
 
 class TestCase(TorchTestCase):
@@ -5326,6 +5332,21 @@ if HAS_CUDA:
             self.common(
                 fn, (torch.randn(2, 3, 10, 5, 6, device="cuda")[:, :, 2::2, :, :],)
             )
+
+        def test_sink_cat_after_pointwise(self):
+            class TestModule(torch.nn.Module):
+                def forward(self, x, y):
+                    return torch.cat([x, y], dim=-1).view(-1).view(128).tanh()
+
+            trace_func = chain_passes(torch.fx.symbolic_trace, sink_cat_after_pointwise)
+            inputs = [
+                torch.randn(8, 8, device="cuda"),
+                torch.randn(8, 8, device="cuda"),
+            ]
+            module = TestModule()
+            traced = trace_func(module, inputs)
+            self.assertTrue(torch.allclose(module(*inputs), traced(*inputs)))
+            self.assertEqual(count_call_method(traced, "tanh"), 2)
 
         def test_linear_permute_fusion(self):
             class TestModule(torch.nn.Module):

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -533,6 +533,7 @@ def fuse_fx(gm: torch.fx.GraphModule, example_inputs):
 
     fake_mode = fake_mode_from_tensors(example_inputs)
 
+    gm = sink_cat_after_pointwise(gm)
     if config.permute_fusion and not is_cpu:
         # For linear permute fusion, we need to check input info to identify
         # and perform proper permutation/transpose
@@ -813,6 +814,49 @@ def check_permute(node: torch.fx.Node):
     allowed_permutation[-1] = ranks - 2
     allowed_permutation[-2] = ranks - 1
     return permutation == allowed_permutation
+
+
+def sink_cat_after_pointwise(module: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    def one_user(node):
+        users = list(node.users)
+        return users[0] if len(users) == 1 else None
+
+    def is_view(node):
+        view = {"view"}
+        return node.op == "call_method" and node.target in view
+
+    def is_pointwise_unary(node):
+        pointwise = {torch.relu, torch.tanh, "relu", "tanh"}
+        return node.op in {"call_function", "call_method"} and node.target in pointwise
+
+    g = module.graph
+    for node in g.nodes:
+        if node.op != "call_function" or node.target != torch.cat:
+            continue
+
+        cat_or_view = node
+        while True:
+            user = one_user(cat_or_view)
+            if not user or not is_view(user):
+                break
+            cat_or_view = user
+
+        if user and is_pointwise_unary(user):
+            with g.inserting_before(node):
+                new_args = (
+                    [
+                        g.create_node(
+                            user.op, user.target, args=(arg,), kwargs=user.kwargs
+                        )
+                        for arg in node.args[0]
+                    ],
+                )
+                node.args = new_args
+                user.replace_all_uses_with(cat_or_view)
+                g.erase_node(user)
+    g.lint()
+    module.recompile()
+    return module
 
 
 def linear_permute_fusion(module: torch.fx.GraphModule) -> torch.fx.GraphModule:


### PR DESCRIPTION
Summary:
Inductor can't fuse pointwise into the output of concat, but it can
fuse into the inputs, and that's the same thing.  So we hoist pointwise through
a concat (followed by an optional series of views).

Test Plan: New unit test

Differential Revision: D41901656



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire