### PR TITLE
feature: adding the ability to restore shapes after loading a traced model

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -231,6 +231,7 @@ core_sources_full_mobile_no_backend_interface_xplat = [
     "torch/csrc/jit/ir/node_hashing.cpp",
     "torch/csrc/jit/ir/scope.cpp",
     "torch/csrc/jit/ir/subgraph_matcher.cpp",
+    "torch/csrc/jit/ir/graph_utils.cpp",
     "torch/csrc/jit/jit_log.cpp",
     "torch/csrc/jit/jit_opt_limit.cpp",
     "torch/csrc/jit/mobile/nnc/aot_compiler.cpp",

--- a/torch/csrc/jit/ir/graph_utils.cpp
+++ b/torch/csrc/jit/ir/graph_utils.cpp
@@ -1,0 +1,93 @@
+#include <torch/csrc/jit/ir/graph_utils.h>
+
+namespace torch {
+namespace jit {
+
+TypePtr getTensorType(const at::Tensor& t, bool complete) {
+  auto r = TensorType::create(t);
+  if (!complete) {
+    r = r->dimensionedOnly();
+  }
+  return r;
+}
+
+TypePtr inferShapeAndTypeForInput(
+    TypePtr input_type,
+    Stack::const_iterator& s_iter,
+    const Stack::const_iterator& s_iter_end,
+    bool complete) {
+  if (auto tuple_type = input_type->cast<TupleType>()) {
+    std::vector<TypePtr> types;
+    for (const auto& sub_type : tuple_type->containedTypes()) {
+      TORCH_INTERNAL_ASSERT(s_iter != s_iter_end);
+      types.emplace_back(
+          inferShapeAndTypeForInput(sub_type, s_iter, s_iter_end, complete));
+    }
+    return TupleType::create(types);
+  } else if (auto list_type = input_type->cast<ListType>()) {
+    const TypePtr& sub_type = list_type->getElementType();
+    auto elem_type =
+        inferShapeAndTypeForInput(sub_type, s_iter, s_iter_end, complete);
+    return ListType::create(elem_type);
+  } else if (auto tensor_type = input_type->cast<TensorType>()) {
+    auto type = getTensorType(s_iter->toTensor(), complete);
+    s_iter++;
+    return type;
+  } else if (auto optional_type = input_type->cast<OptionalType>()) {
+    const TypePtr& sub_type = optional_type->getElementType();
+    auto elem_type =
+        inferShapeAndTypeForInput(sub_type, s_iter, s_iter_end, complete);
+    return OptionalType::create(elem_type);
+  } else {
+    // Primitive type, keep as is.
+    s_iter++;
+    return input_type;
+  }
+}
+
+void setInputTensorTypes(
+    Graph& g,
+    const Stack& stack,
+    bool complete,
+    const std::vector<int>& param_count_list) {
+  at::ArrayRef<Value*> input_values = g.inputs();
+  auto s_iter = stack.begin();
+  size_t list_idx = 0;
+  if (!param_count_list.empty()) {
+    TORCH_INTERNAL_ASSERT(
+        input_values.size() == param_count_list.size(),
+        " input_values:",
+        input_values.size(),
+        " vs param_count_list:",
+        param_count_list.size());
+  }
+  for (auto v : input_values) {
+    // Leave packed param types alone. This is needed for downstream passes
+    // (like alias analysis) to work properly. This will be unpacked later
+    // in unpackQuantizedWeights.
+    if (auto named_type = v->type()->cast<c10::NamedType>()) {
+      if (auto qualname = named_type->name()) {
+        if (getCustomClass(qualname->qualifiedName())) {
+          if (param_count_list.empty()) {
+            AT_ASSERT(s_iter != stack.end());
+            s_iter++;
+          } else {
+            if (param_count_list[list_idx] > 0) {
+              AT_ASSERT(s_iter != stack.end());
+            }
+            s_iter += param_count_list[list_idx];
+          }
+          list_idx++;
+          continue;
+        }
+      }
+    }
+    auto type =
+        inferShapeAndTypeForInput(v->type(), s_iter, stack.end(), complete);
+    v->setType(type);
+    list_idx++;
+  }
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/ir/graph_utils.h
+++ b/torch/csrc/jit/ir/graph_utils.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+
+#include <vector>
+
+namespace torch {
+namespace jit {
+
+TORCH_API TypePtr getTensorType(const at::Tensor& t, bool complete);
+
+TORCH_API TypePtr inferShapeAndTypeForInput(
+    TypePtr input_type,
+    Stack::const_iterator& s_iter,
+    const Stack::const_iterator& s_iter_end,
+    bool complete);
+
+TORCH_API void setInputTensorTypes(
+    Graph& g,
+    const Stack& stack,
+    bool complete,
+    const std::vector<int>& param_count_list = {});
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -1,3 +1,4 @@
+#include <torch/csrc/jit/ir/graph_utils.h>
 #include <torch/csrc/jit/python/module_python.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/jit/python/python_dict.h>

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -33,6 +33,7 @@
 #include <torch/csrc/jit/frontend/parser.h>
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <torch/csrc/jit/ir/constants.h>
+#include <torch/csrc/jit/ir/graph_utils.h>
 #include <torch/csrc/jit/ir/irparser.h>
 #include <torch/csrc/jit/passes/inliner.h>
 #include <torch/csrc/jit/passes/shape_analysis.h>
@@ -435,91 +436,6 @@ struct VISIBILITY_HIDDEN ModuleSelf : public Self {
  private:
   std::shared_ptr<ConcreteModuleType> concreteType_;
 };
-
-static TypePtr getTensorType(const at::Tensor& t, bool complete) {
-  auto r = TensorType::create(t);
-  if (!complete) {
-    r = r->dimensionedOnly();
-  }
-  return r;
-}
-
-static TypePtr inferShapeAndTypeForInput(
-    TypePtr input_type,
-    Stack::const_iterator& s_iter,
-    const Stack::const_iterator& s_iter_end,
-    bool complete) {
-  if (auto tuple_type = input_type->cast<TupleType>()) {
-    std::vector<TypePtr> types;
-    for (const auto& sub_type : tuple_type->containedTypes()) {
-      TORCH_INTERNAL_ASSERT(s_iter != s_iter_end);
-      types.emplace_back(
-          inferShapeAndTypeForInput(sub_type, s_iter, s_iter_end, complete));
-    }
-    return TupleType::create(types);
-  } else if (auto list_type = input_type->cast<ListType>()) {
-    const TypePtr& sub_type = list_type->getElementType();
-    auto elem_type =
-        inferShapeAndTypeForInput(sub_type, s_iter, s_iter_end, complete);
-    return ListType::create(elem_type);
-  } else if (auto tensor_type = input_type->cast<TensorType>()) {
-    auto type = getTensorType(s_iter->toTensor(), complete);
-    s_iter++;
-    return type;
-  } else if (auto optional_type = input_type->cast<OptionalType>()) {
-    const TypePtr& sub_type = optional_type->getElementType();
-    auto elem_type =
-        inferShapeAndTypeForInput(sub_type, s_iter, s_iter_end, complete);
-    return OptionalType::create(elem_type);
-  } else {
-    // Primitive type, keep as is.
-    s_iter++;
-    return input_type;
-  }
-}
-
-static void setInputTensorTypes(
-    Graph& g,
-    const Stack& stack,
-    bool complete,
-    const std::vector<int>& param_count_list = {}) {
-  at::ArrayRef<Value*> input_values = g.inputs();
-  auto s_iter = stack.begin();
-  size_t list_idx = 0;
-  if (!param_count_list.empty()) {
-    TORCH_INTERNAL_ASSERT(
-        input_values.size() == param_count_list.size(),
-        " input_values:",
-        input_values.size(),
-        " vs param_count_list:",
-        param_count_list.size());
-  }
-  for (auto v : input_values) {
-    // Leave packed param types alone. This is needed for downstream passes
-    // (like alias analysis) to work properly. This will be unpacked later
-    // in unpackQuantizedWeights.
-    if (auto named_type = v->type()->cast<c10::NamedType>()) {
-      if (auto qualname = named_type->name()) {
-        if (getCustomClass(qualname->qualifiedName())) {
-          if (param_count_list.empty()) {
-            AT_ASSERT(s_iter != stack.end());
-            s_iter++;
-          } else {
-            if (param_count_list[list_idx] > 0) {
-              AT_ASSERT(s_iter != stack.end());
-            }
-            s_iter += param_count_list[list_idx];
-          }
-          list_idx++;
-          continue;
-        }
-      }
-    }
-    v->setType(
-        inferShapeAndTypeForInput(v->type(), s_iter, stack.end(), complete));
-    list_idx++;
-  }
-}
 
 static std::shared_ptr<Graph> _propagate_shapes(
     Graph& graph,
@@ -1190,7 +1106,8 @@ void initJitScriptBindings(PyObject* module) {
              const py::function& var_name_lookup_fn,
              bool strict,
              bool force_outplace,
-             const std::vector<std::string>& argument_names) {
+             const std::vector<std::string>& argument_names,
+             bool store_inputs) {
             // prereq: Module's buffers and parameters are unique
             // this was ensured in python before calling this function
             auto typed_inputs = toTraceableStack(input_tuple);
@@ -1208,6 +1125,9 @@ void initJitScriptBindings(PyObject* module) {
             auto fn = self._ivalue()->compilation_unit()->create_function(
                 method_name, graph);
             self.type()->addMethod(fn);
+            if (store_inputs) {
+              self.store_traced_inputs(name, typed_inputs);
+            }
             didFinishEmitModule(self);
           },
           py::arg("name"),
@@ -1216,7 +1136,8 @@ void initJitScriptBindings(PyObject* module) {
           py::arg("var_name_lookup_fn"),
           py::arg("strict"),
           py::arg("force_outplace"),
-          py::arg("argument_names") = std::vector<std::string>())
+          py::arg("argument_names") = std::vector<std::string>(),
+          py::arg("store_inputs"))
       .def(
           "_create_method_from_trace_with_dict",
           [](Module& self,
@@ -1226,7 +1147,8 @@ void initJitScriptBindings(PyObject* module) {
              const py::function& var_name_lookup_fn,
              bool strict,
              bool force_outplace,
-             const std::vector<std::string>& argument_names) {
+             const std::vector<std::string>& argument_names,
+             bool store_inputs) {
             // prereq: Module's buffers and parameters are unique
             // this was ensured in python before calling this function
             auto typed_inputs = toTraceableStack(input_dict);
@@ -1244,6 +1166,9 @@ void initJitScriptBindings(PyObject* module) {
             const auto method_name = QualifiedName(*self.type()->name(), name);
             auto fn = self._ivalue()->compilation_unit()->create_function(
                 method_name, graph);
+            if (store_inputs) {
+              self.store_traced_inputs(name, typed_inputs);
+            }
             self.type()->addMethod(fn);
             didFinishEmitModule(self);
           },
@@ -1253,7 +1178,8 @@ void initJitScriptBindings(PyObject* module) {
           py::arg("var_name_lookup_fn"),
           py::arg("strict"),
           py::arg("force_outplace"),
-          py::arg("argument_names") = std::vector<std::string>())
+          py::arg("argument_names") = std::vector<std::string>(),
+          py::arg("store_inputs"))
       .def(
           "_get_forward_hooks",
           [](const Module& m) {
@@ -1271,6 +1197,11 @@ void initJitScriptBindings(PyObject* module) {
               funcs.emplace_back(m.type()->compilation_unit(), pre_hook);
             }
             return funcs;
+          })
+      .def(
+          "_retrieve_traced_inputs",
+          [](const Module& m) {
+            return ScriptDict(m.retrieve_traced_inputs());
           })
       .def_property_readonly(
           "code",
@@ -1864,7 +1795,8 @@ void initJitScriptBindings(PyObject* module) {
       [](std::shared_ptr<CompilationUnit> cu,
          const std::string& filename,
          py::object map_location,
-         const py::dict& extra_files) {
+         const py::dict& extra_files,
+         bool restore_shapes = false) {
         c10::optional<at::Device> optional_device;
         if (!map_location.is_none()) {
           AT_ASSERT(THPDevice_Check(map_location.ptr()));
@@ -1873,7 +1805,12 @@ void initJitScriptBindings(PyObject* module) {
         }
         ExtraFilesMap extra_files_map = extra_files_from_python(extra_files);
         auto ret = import_ir_module(
-            std::move(cu), filename, optional_device, extra_files_map);
+            std::move(cu),
+            filename,
+            optional_device,
+            extra_files_map,
+            /*load_debug_files*/ true,
+            restore_shapes);
         extra_files_to_python(extra_files_map, extra_files);
         return ret;
       });
@@ -1903,7 +1840,8 @@ void initJitScriptBindings(PyObject* module) {
       [](std::shared_ptr<CompilationUnit> cu,
          const std::string& buffer,
          py::object map_location,
-         const py::dict& extra_files) {
+         const py::dict& extra_files,
+         bool restore_shapes = false) {
         std::istringstream in(buffer);
         c10::optional<at::Device> optional_device;
         if (!map_location.is_none()) {
@@ -1913,7 +1851,12 @@ void initJitScriptBindings(PyObject* module) {
         }
         ExtraFilesMap extra_files_map = extra_files_from_python(extra_files);
         auto ret = import_ir_module(
-            std::move(cu), in, optional_device, extra_files_map);
+            std::move(cu),
+            in,
+            optional_device,
+            extra_files_map,
+            /*load_debug_files*/ true,
+            restore_shapes);
         extra_files_to_python(extra_files_map, extra_files);
         return ret;
       });

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -94,7 +94,8 @@ class TORCH_API ScriptModuleSerializer {
       const std::string& archive_name,
       const std::string& archive_dir,
       const std::string& tensor_dir,
-      bool use_storage_context = false);
+      bool use_storage_context = false,
+      bool skip_tensor_data = false);
   void updateSourceRangeTags(const SourceRangeRecords& ranges);
 
   caffe2::serialize::PyTorchStreamWriter& writer_;

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -481,6 +481,15 @@ void ScriptModuleSerializer::serialize(
         /*archive_dir=*/"",
         /*tensor_dir=*/"constants/");
   }
+  if (module.retrieve_traced_inputs().size() > 0) {
+    writeArchive(
+        module.retrieve_traced_inputs(),
+        /*archive_name=*/"traced_inputs",
+        /*archive_dir=*/"",
+        /*tensor_dir=*/"traced_inputs/",
+        /*use_storage_context*/ false,
+        /*skip_tensor_data*/ true);
+  }
   // Acquires and sets minimum (dynamic) version
   for (auto& item : file_streams_) {
     writer_.setMinVersion(item.value().minVersion());
@@ -492,7 +501,8 @@ void ScriptModuleSerializer::writeArchive(
     const std::string& archive_name,
     const std::string& archive_dir,
     const std::string& tensor_dir,
-    bool use_storage_context) {
+    bool use_storage_context,
+    bool skip_tensor_data) {
   std::vector<char> data;
   // Vector to capture the run-time class types during pickling the IValues
   std::vector<c10::ClassTypePtr> memoizedClassTypes;
@@ -539,7 +549,7 @@ void ScriptModuleSerializer::writeArchive(
 
   for (const auto& td : data_pickle.tensorData()) {
     std::string tensor_name = tensor_names[i++];
-    if (td.is_meta()) {
+    if (td.is_meta() || skip_tensor_data) {
       writer_.writeRecord(tensor_dir + tensor_name, nullptr, 0);
       continue;
     }

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -22,10 +22,12 @@
 #include <torch/csrc/jit/serialization/import_legacy.h>
 #endif
 #include <torch/csrc/jit/frontend/script_type_parser.h>
+#include <torch/csrc/jit/ir/graph_utils.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/mobile/file_format.h>
 #include <torch/csrc/jit/mobile/flatbuffer_loader.h>
 #include <torch/csrc/jit/operator_upgraders/upgraders_entry.h>
+#include <torch/csrc/jit/passes/shape_analysis.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/serialization/import_read.h>
 #include <torch/csrc/jit/serialization/import_source.h>
@@ -122,7 +124,8 @@ class ScriptModuleDeserializer final {
 
   Module deserialize(
       c10::optional<at::Device> device,
-      ExtraFilesMap& extra_files);
+      ExtraFilesMap& extra_files,
+      bool restore_shapes = false);
 
  private:
   IValue readArchive(const std::string& archive_name);
@@ -251,7 +254,8 @@ graph(%x, %packed_params, %stride, %padding, %dilation, %groups, %r_scale, %r_ze
 
 Module ScriptModuleDeserializer::deserialize(
     c10::optional<at::Device> device,
-    ExtraFilesMap& extra_files) {
+    ExtraFilesMap& extra_files,
+    bool restore_shapes) {
   // we populate the upgraders map before any load starts
   populate_upgraders_graph_map();
 
@@ -280,8 +284,31 @@ Module ScriptModuleDeserializer::deserialize(
   for (auto constant : tuple->elements()) {
     constants_table_.push_back(constant.toIValue());
   }
-  auto m = Module(readArchive("data").toObject());
+  auto m_ivalue = readArchive("data");
+  auto m = Module(m_ivalue.toObject());
   rewriteQuantizedConvForBC(m);
+  // Checking for and loading saved traced inputs
+  if (restore_shapes && reader_->hasRecord("traced_inputs.pkl")) {
+    auto dict = readArchive("traced_inputs").toGenericDict();
+    for (const auto& entry : dict) {
+      auto inputs = entry.value().toList().vec();
+      auto g =
+          toGraphFunction(m.get_method(entry.key().toStringRef()).function())
+              .graph();
+      Stack stack(inputs.begin(), inputs.end());
+      // Added the module as the first input if we are missing
+      // an input as traced modules refer to self as an additional input
+      if (g->inputs().size() == stack.size() + 1) {
+        stack.insert(stack.begin(), m_ivalue);
+      }
+      setInputTensorTypes(*g, stack, /*complete=*/true);
+      PropagateInputShapes(g);
+    }
+  } else {
+    if (restore_shapes) {
+      TORCH_WARN("Cannot restore shapes as no traced inputs were stored");
+    }
+  }
   return m;
 }
 } // namespace
@@ -301,7 +328,8 @@ static Module _load_jit_module_from_bytes(
     size_t size,
     std::shared_ptr<CompilationUnit> cu,
     c10::optional<c10::Device> device,
-    ExtraFilesMap& extra_files);
+    ExtraFilesMap& extra_files,
+    bool restore_shapes);
 
 Module parse_and_initialize_jit_module(
     std::shared_ptr<char> data,
@@ -346,7 +374,8 @@ Module import_ir_module(
     std::istream& in,
     c10::optional<at::Device> device,
     ExtraFilesMap& extra_files,
-    bool load_debug_files) {
+    bool load_debug_files,
+    bool restore_shapes) {
   in.seekg(0, in.beg);
   // NOTE: Zipformat can be large files. So using stream version directly
   // instead of reading the file all at once.
@@ -354,12 +383,13 @@ Module import_ir_module(
     auto reader = torch::make_unique<PyTorchStreamReader>(&in);
     reader->setShouldLoadDebugSymbol(load_debug_files);
     ScriptModuleDeserializer deserializer(std::move(cu), std::move(reader));
-    return deserializer.deserialize(device, extra_files);
+    return deserializer.deserialize(device, extra_files, restore_shapes);
   }
   std::shared_ptr<char> data;
   size_t size = 0;
   std::tie(data, size) = get_stream_content(in);
-  return _load_jit_module_from_bytes(data, size, cu, device, extra_files);
+  return _load_jit_module_from_bytes(
+      data, size, cu, device, extra_files, restore_shapes);
 }
 
 // For reading unified serialization format from torch.Package.
@@ -394,19 +424,21 @@ Module import_ir_module(
     const std::string& filename,
     c10::optional<at::Device> device,
     ExtraFilesMap& extra_files,
-    bool load_debug_files) {
+    bool load_debug_files,
+    bool restore_shapes) {
   // NOTE: Zipformat can be large files. So using stream version directly
   // instead of reading the file all at once.
   if (getFileFormat(filename) != FileFormat::FlatbufferFileFormat) {
     auto reader = torch::make_unique<PyTorchStreamReader>(filename);
     reader->setShouldLoadDebugSymbol(load_debug_files);
     ScriptModuleDeserializer deserializer(std::move(cu), std::move(reader));
-    return deserializer.deserialize(device, extra_files);
+    return deserializer.deserialize(device, extra_files, restore_shapes);
   }
   std::shared_ptr<char> data;
   size_t size = 0;
   std::tie(data, size) = get_file_content(filename.c_str());
-  return _load_jit_module_from_bytes(data, size, cu, device, extra_files);
+  return _load_jit_module_from_bytes(
+      data, size, cu, device, extra_files, restore_shapes);
 }
 
 Module import_ir_module(
@@ -503,7 +535,8 @@ Module _load_jit_module_from_bytes(
     size_t size,
     std::shared_ptr<CompilationUnit> cu,
     c10::optional<c10::Device> device,
-    ExtraFilesMap& extra_files) {
+    ExtraFilesMap& extra_files,
+    bool restore_shapes) {
   TORCH_CHECK(size >= kFileFormatHeaderSize, "Unrecognized data format");
   auto format = getFileFormat(data.get());
   switch (format) {
@@ -514,7 +547,7 @@ Module _load_jit_module_from_bytes(
       auto rai = std::make_unique<MemoryReadAdapter>(data.get(), size);
       auto reader = torch::make_unique<PyTorchStreamReader>(std::move(rai));
       ScriptModuleDeserializer deserializer(std::move(cu), std::move(reader));
-      return deserializer.deserialize(device, extra_files);
+      return deserializer.deserialize(device, extra_files, restore_shapes);
     }
 
     default:

--- a/torch/csrc/jit/serialization/import.h
+++ b/torch/csrc/jit/serialization/import.h
@@ -40,7 +40,8 @@ TORCH_API Module import_ir_module(
     const std::string& filename,
     c10::optional<c10::Device> device,
     ExtraFilesMap& extra_files,
-    bool load_debug_files = true);
+    bool load_debug_files = true,
+    bool restore_shapes = false);
 
 // For reading unified serialization format from torch.Package
 TORCH_API Module import_ir_module(
@@ -55,7 +56,8 @@ TORCH_API Module import_ir_module(
     std::istream& in,
     c10::optional<c10::Device> device,
     ExtraFilesMap& extra_files,
-    bool load_debug_files = true);
+    bool load_debug_files = true,
+    bool restore_shapes = false);
 
 TORCH_API Module import_ir_module(
     std::shared_ptr<CompilationUnit> cu,

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -425,7 +425,6 @@ void Pickler::pushLiteralTensor(const IValue& ivalue) {
       "torch._utils", quantized ? "_rebuild_qtensor" : "_rebuild_tensor_v2");
 
   push<PickleOpCode>(PickleOpCode::MARK);
-
   pushStorageOfTensor(tensor);
 
   // storage offset

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -84,7 +84,7 @@ def save(m, f, _extra_files=None):
         f.write(ret)
 
 
-def load(f, map_location=None, _extra_files=None):
+def load(f, map_location=None, _extra_files=None, _restore_shapes=False):
     r"""
     Load a :class:`ScriptModule` or :class:`ScriptFunction` previously
     saved with :func:`torch.jit.save <torch.jit.save>`
@@ -103,6 +103,7 @@ def load(f, map_location=None, _extra_files=None):
         _extra_files (dictionary of filename to content): The extra
             filenames given in the map would be loaded and their content
             would be stored in the provided map.
+        _restore_shapes (bool): Whether or not to retrace the module on load using stored inputs
 
     Returns:
         A :class:`ScriptModule` object.
@@ -159,11 +160,11 @@ def load(f, map_location=None, _extra_files=None):
 
     cu = torch._C.CompilationUnit()
     if isinstance(f, (str, pathlib.Path)):
-        cpp_module = torch._C.import_ir_module(cu, str(f), map_location, _extra_files)
+        cpp_module = torch._C.import_ir_module(cu, str(f), map_location, _extra_files, _restore_shapes)  # type: ignore[call-arg]
     else:
         cpp_module = torch._C.import_ir_module_from_buffer(
-            cu, f.read(), map_location, _extra_files
-        )
+            cu, f.read(), map_location, _extra_files, _restore_shapes
+        )  # type: ignore[call-arg]
 
     # TODO: Pretty sure this approach loses ConstSequential status and such
     return wrap_cpp_module(cpp_module)

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -337,6 +337,7 @@ def _check_trace(
                 _module_class=_module_class,
                 _compilation_unit=torch._C.CompilationUnit(),
                 example_inputs_is_kwarg=example_inputs_is_kwarg,
+                _store_inputs=False
             )
             check_mod_func = check_mod._c._get_method(traced_func.name)
             inputs = inputs[traced_func.name]
@@ -351,6 +352,7 @@ def _check_trace(
                     _force_outplace=force_outplace,
                     _module_class=_module_class,
                     example_kwarg_inputs=_clone_inputs(inputs),
+                    _store_inputs=False
                 )
             else:
                 check_mod = torch.jit.trace(
@@ -360,9 +362,8 @@ def _check_trace(
                     strict=strict,
                     _force_outplace=force_outplace,
                     _module_class=_module_class,
+                    _store_inputs=False
                 )
-
-
             check_mod_func = check_mod
 
         def graph_diagnostic_info():
@@ -621,7 +622,8 @@ def trace(
     _force_outplace=False,
     _module_class=None,
     _compilation_unit=_python_cu,
-    example_kwarg_inputs=None
+    example_kwarg_inputs=None,
+    _store_inputs=True
 ):
     """
     Trace a function and return an executable  or :class:`ScriptFunction`
@@ -800,8 +802,8 @@ def trace(
             _force_outplace,
             _module_class,
             example_inputs_is_kwarg=isinstance(example_kwarg_inputs, dict),
+            _store_inputs=_store_inputs
         )
-
     if (
         hasattr(func, "__self__")
         and isinstance(func.__self__, torch.nn.Module)
@@ -823,6 +825,7 @@ def trace(
             _force_outplace,
             _module_class,
             example_inputs_is_kwarg=isinstance(example_kwarg_inputs, dict),
+            _store_inputs=_store_inputs
         )
 
     # Special case for common case of passing a single Tensor
@@ -908,6 +911,7 @@ def trace_module(
     _module_class=None,
     _compilation_unit=_python_cu,
     example_inputs_is_kwarg=False,
+    _store_inputs=True,
 ):
     """
     Trace a module and return an executable :class:`ScriptModule` that will be optimized
@@ -1043,6 +1047,7 @@ def trace_module(
                     strict,
                     _force_outplace,
                     argument_names,
+                    _store_inputs
                 )
             else:
                 example_inputs = make_tuple(example_inputs)
@@ -1054,6 +1059,7 @@ def trace_module(
                     strict,
                     _force_outplace,
                     argument_names,
+                    _store_inputs
                 )
 
             check_trace_method = module._c._get_method(method_name)


### PR DESCRIPTION
Adds the ability to store inputs used in tracing models when calling torch.jit.save and restore the input shapes using torch.jit.load if the appropriate variables are set.

Fixes [89185](https://github.com/pytorch/pytorch/issues/89185)


cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen