### PR TITLE
Sparse compressed mm: fix for empty inputs

### DIFF
--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -544,6 +544,13 @@ Tensor& addmm_out_sparse_compressed_cpu(
   }
 
   if (result.numel() == 0) {
+    // If result gets resized and is sparse compressed,
+    // it's compressed_indices tensor will contain junk values
+    // so the whole tensor is not a valid compressed tensor.
+    // To combat that, result needs to get zeroed out.
+    if (at::sparse_csr::is_sparse_compressed(result)) {
+      result.zero_();
+    }
     return result;
   }
 

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -1726,6 +1726,22 @@ class TestSparseCSR(TestCase):
                     y = gen_y(y_shape, nnz1, device=device, dtype=dtype, index_dtype=index_dtype)
                     _test_mm(x, y)
 
+        def test_empty_inputs(lhs_layout, rhs_layout):
+            xd = torch.rand(10, 0, device=device, dtype=dtype)
+            yd = xd.transpose(-2, -1)
+            zd = torch.rand(0, 0, device=device, dtype=dtype)
+
+            xls, yls, zls = [t.to_sparse(layout=lhs_layout) for t in (xd, yd, zd)]
+            xrs, yrs, zrs = [t.to_sparse(layout=rhs_layout) for t in (xd, yd, zd)]
+
+            for ls, rs, ld, rd in [(xls, yrs, xd, yd), (xls, zrs, xd, zd), (zls, yrs, zd, yd), (zls, zrs, zd, zd)]:
+                res_sparse = ls @ rs
+                res_dense = ld @ rd
+                self.assertEqual(res_sparse.to_dense(), res_dense)
+
+        for lhs_layout, rhs_layout in itertools.product([torch.sparse_csr, torch.sparse_csc], repeat=2):
+            test_empty_inputs(lhs_layout, rhs_layout)
+
         for i in [2, 4]:
             for j in [2, 4, 7]:
                 for k in [2, 3, 7]:


### PR DESCRIPTION
ghstack-source-id: 8c75102547ce99425613fddf7ad27e13f16dcace
Pull Request resolved: https://github.com/pytorch/pytorch/pull/90763

Fixes [#90693
](https://github.com/pytorch/pytorch/issues/90693)