### PR TITLE
[FSDP][1/N] `fully_shard` state dict

### DIFF
--- a/test/distributed/_composable/test_fully_shard.py
+++ b/test/distributed/_composable/test_fully_shard.py
@@ -4,7 +4,7 @@ import contextlib
 import copy
 import functools
 import sys
-from typing import Callable, Iterable, List, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -412,7 +412,6 @@ class TestFSDPRuntime(FSDPTest):
 
 
 class TestMixedPrecision(FSDPTest):
-
     @property
     def world_size(self):
         return 2
@@ -423,7 +422,8 @@ class TestMixedPrecision(FSDPTest):
         float16 = MixedPrecision(param_dtype=torch.float16)
 
         model = SaveForwardInputsModel(
-            forward_inputs=forward_inputs, cast_forward_inputs=False,
+            forward_inputs=forward_inputs,
+            cast_forward_inputs=False,
         ).cuda()
         c1, c2 = model.c1, model.c2
         x = torch.zeros(2, 100, device="cuda")
@@ -442,6 +442,54 @@ class TestMixedPrecision(FSDPTest):
             self.assertEqual(forward_inputs[model].dtype, torch.float32)
             self.assertEqual(forward_inputs[c1].dtype, torch.float32)
             self.assertEqual(forward_inputs[c2].dtype, torch.float16)
+
+
+class TestFSDPModelCheckpointing(FSDPTest):
+    """Tests composable FSDP model checkpointing."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    def test_state_dict_root_fully_shard(self):
+        """
+        Tests that the full state dict saved from a module with ``fully_shard``
+        applied at the global root matches that of an equivalent local module.
+        """
+        local_model = CompositeParamModel(device=torch.device("cuda"))
+        composable_module = copy.deepcopy(local_model)
+        fully_shard(composable_module, policy=ModuleWrapPolicy({UnitModule}))
+        local_sd = local_model.state_dict()
+        composable_sd = composable_module.state_dict()
+        self._check_state_dict_parity(local_sd, composable_sd)
+
+    @skip_if_lt_x_gpu(2)
+    def test_state_dict_submodule_fully_shard(self):
+        """
+        Tests that the full state dict saved from a module with ``fully_shard``
+        applied at the global root matches that of an equivalent local module.
+        """
+        local_model = CompositeParamModel(device=torch.device("cuda"))
+        composable_module = copy.deepcopy(local_model)
+        fully_shard(composable_module.u1)
+        fully_shard(composable_module.u2)
+        local_sd = local_model.state_dict()
+        composable_sd = composable_module.state_dict()
+        self._check_state_dict_parity(local_sd, composable_sd)
+
+    def _check_state_dict_parity(self, local_sd: Dict, composable_sd: Dict):
+        """Checks that ``local_sd`` and ``composable_sd`` are the same."""
+        # Check that all keys match
+        for k1, k2 in zip(composable_sd.keys(), local_sd.keys()):
+            self.assertEqual(k1, k2)
+        # Check that all values match
+        for v1, v2 in zip(composable_sd.values(), local_sd.values()):
+            self.assertEqual(v1.shape, v2.shape)
+        # Check that all keys and values are aligned
+        for (k1, v1), (k2, v2) in zip(composable_sd.items(), local_sd.items()):
+            self.assertEqual(k1, k2)
+            self.assertEqual(v1, v2)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_composable/test_fully_shard.py
+++ b/test/distributed/_composable/test_fully_shard.py
@@ -455,7 +455,7 @@ class TestFSDPModelCheckpointing(FSDPTest):
     def test_state_dict_root_fully_shard(self):
         """
         Tests that the full state dict saved from a module with ``fully_shard``
-        applied at the global root matches that of an equivalent local module.
+        applied to the global root matches that of an equivalent local module.
         """
         local_model = CompositeParamModel(device=torch.device("cuda"))
         composable_module = copy.deepcopy(local_model)
@@ -468,7 +468,7 @@ class TestFSDPModelCheckpointing(FSDPTest):
     def test_state_dict_submodule_fully_shard(self):
         """
         Tests that the full state dict saved from a module with ``fully_shard``
-        applied at the global root matches that of an equivalent local module.
+        applied on submodules matches that of an equivalent local module.
         """
         local_model = CompositeParamModel(device=torch.device("cuda"))
         composable_module = copy.deepcopy(local_model)

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -68,7 +68,10 @@ def _module_handles(state: _FSDPState, module: nn.Module) -> List:
     module is FullyShardedDataParallel, the module._handles will be returned.
     """
     if _is_composable(state):
-        return state._module_to_handles[module][:]
+        assert (
+            module in state._comm_module_to_handles
+        ), f"Expects a `comm_module` but got {module} on rank {state.rank}"
+        return state._comm_module_to_handles[module][:]
     else:
         return module._handles[:]
 

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -1,3 +1,4 @@
+import functools
 import math
 import warnings
 from typing import Any, Callable, cast, Dict, Iterator, no_type_check, Tuple
@@ -19,6 +20,7 @@ from torch.distributed.fsdp._common_utils import (
     _all_handles,
     _FSDPState,
     _has_fsdp_params,
+    _is_composable,
     _module_handles,
     clean_tensor_name,
     FSDP_PREFIX,
@@ -129,6 +131,7 @@ def _common_pre_state_dict_hook(
     # TODO: change to this call after pre_state_dict_hook is in `nn.Module`.
     if fsdp_state._is_root:
         _clear_grads_if_needed(_all_handles(fsdp_state))
+
 
 def _common_unshard_pre_state_dict_hook(
     module: nn.Module,
@@ -609,6 +612,7 @@ def _sharded_pre_load_state_dict_hook(
 @no_type_check
 @torch.no_grad()
 def _post_state_dict_hook(
+    fsdp_state: _FSDPState,
     module: nn.Module,
     state_dict: Dict[str, Any],
     prefix: str,
@@ -619,8 +623,6 @@ def _post_state_dict_hook(
     FSDP module is executed. ``fsdp_state._state_dict_type`` is used to decide
     what postprocessing will be done.
     """
-    # TODO: get the composable state from module
-    fsdp_state: _FSDPState = module
     _post_state_dict_hook_fn = {
         StateDictType.FULL_STATE_DICT: _full_post_state_dict_hook,
         StateDictType.LOCAL_STATE_DICT: _local_post_state_dict_hook,
@@ -631,43 +633,47 @@ def _post_state_dict_hook(
     )
     return processed_state_dict
 
+
 @no_type_check
 @torch.no_grad()
 def _pre_state_dict_hook(
+    fsdp_state: _FSDPState,
     module: nn.Module,
     *args,
     **kwargs,
 ) -> None:
     """
-    _pre_state_dict_hook() is called before the state_dict() of this
-    FSDP module is executed. ``fsdp_state._state_dict_type`` is used to decide
-    what postprocessing will be done.
+    This is called before the core state dict saving logic of ``module``.
+    ``fsdp_state._state_dict_type`` is used to decide what postprocessing will
+    be done.
     """
-    fsdp_state: _FSDPState = module
     _pre_state_dict_hook_fn = {
         StateDictType.FULL_STATE_DICT: _full_pre_state_dict_hook,
         StateDictType.LOCAL_STATE_DICT: _local_pre_state_dict_hook,
         StateDictType.SHARDED_STATE_DICT: _sharded_pre_state_dict_hook,
     }
     _pre_state_dict_hook_fn[fsdp_state._state_dict_type](
-        fsdp_state, module, *args, **kwargs,
+        fsdp_state,
+        module,
+        *args,
+        **kwargs,
     )
+
 
 @no_type_check
 @torch.no_grad()
 def _pre_load_state_dict_hook(
+    fsdp_state: _FSDPState,
     module: nn.Module,
     state_dict: Dict[str, Any],
     prefix: str,
     *args: Any,
 ) -> None:
     """
-    ``_pre_state_dict_hook` is called before ``module._load_from_state_dict()``
-    is called. ``fsdp_state._state_dict_type`` is used to decide what preprocessing
-    will be done.
+    This is called before ``module._load_from_state_dict()``.
+    ``fsdp_state._state_dict_type`` is used to decide what preprocessing will
+    be done.
     """
-    # TODO: get the composable state from module
-    fsdp_state: _FSDPState = module
     _pre_load_state_dict_hook_fn = {
         StateDictType.FULL_STATE_DICT: _full_pre_load_state_dict_hook,
         StateDictType.LOCAL_STATE_DICT: _local_pre_load_state_dict_hook,
@@ -684,9 +690,11 @@ def _pre_load_state_dict_hook(
 
 @no_type_check
 @torch.no_grad()
-def _post_load_state_dict_hook(module: nn.Module, *args: Any) -> None:
-    # TODO: get the composable state from module
-    fsdp_state: _FSDPState = module
+def _post_load_state_dict_hook(
+    fsdp_state: _FSDPState,
+    module: nn.Module,
+    *args: Any,
+) -> None:
     _post_load_state_dict_hook_fn = {
         StateDictType.FULL_STATE_DICT: _full_post_load_state_dict_hook,
         StateDictType.LOCAL_STATE_DICT: _local_post_load_state_dict_hook,
@@ -696,3 +704,53 @@ def _post_load_state_dict_hook(module: nn.Module, *args: Any) -> None:
     # Dispatch into state_dict type specific implementation of post-hook for
     # loading state_dict.
     _post_load_state_dict_hook_fn[fsdp_state._state_dict_type](module, fsdp_state)
+
+
+def _register_state_dict_pre_hooks(state: _FSDPState) -> None:
+    """Registers the pre-save state dict hooks."""
+    if not _is_composable(state):
+        state.register_state_dict_pre_hook(
+            functools.partial(_pre_state_dict_hook, state)
+        )
+        return
+    for handle in state._handles:
+        handle._comm_module.register_state_dict_pre_hook(
+            functools.partial(_pre_state_dict_hook, state)
+        )
+
+
+def _register_state_dict_hooks(state: _FSDPState) -> None:
+    """Registers the post-save state dict hooks."""
+    if not _is_composable(state):
+        state._register_state_dict_hook(functools.partial(_post_state_dict_hook, state))
+        return
+    for handle in state._handles:
+        handle._comm_module._register_state_dict_hook(
+            functools.partial(_post_state_dict_hook, state)
+        )
+
+
+def _register_load_state_dict_pre_hooks(state: _FSDPState) -> None:
+    """Registers the pre-load state dict hooks."""
+    if not _is_composable(state):
+        state._register_load_state_dict_pre_hook(
+            functools.partial(_pre_load_state_dict_hook, state), with_module=True
+        )
+        return
+    for handle in state._handles:
+        handle._comm_module._register_load_state_dict_pre_hook(
+            functools.partial(_pre_load_state_dict_hook, state), with_module=True
+        )
+
+
+def _register_load_state_dict_post_hooks(state: _FSDPState) -> None:
+    """Registers the post-load state dict hooks."""
+    if not _is_composable(state):
+        state.register_load_state_dict_post_hook(
+            functools.partial(_post_load_state_dict_hook, state)
+        )
+        return
+    for handle in state._handles:
+        handle._comm_module.register_load_state_dict_post_hook(
+            functools.partial(_post_load_state_dict_hook, state)
+        )

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -706,6 +706,7 @@ def _post_load_state_dict_hook(
     _post_load_state_dict_hook_fn[fsdp_state._state_dict_type](module, fsdp_state)
 
 
+@no_type_check
 def _register_state_dict_pre_hooks(state: _FSDPState) -> None:
     """Registers the pre-save state dict hooks."""
     if not _is_composable(state):
@@ -719,6 +720,7 @@ def _register_state_dict_pre_hooks(state: _FSDPState) -> None:
         )
 
 
+@no_type_check
 def _register_state_dict_hooks(state: _FSDPState) -> None:
     """Registers the post-save state dict hooks."""
     if not _is_composable(state):
@@ -730,6 +732,7 @@ def _register_state_dict_hooks(state: _FSDPState) -> None:
         )
 
 
+@no_type_check
 def _register_load_state_dict_pre_hooks(state: _FSDPState) -> None:
     """Registers the pre-load state dict hooks."""
     if not _is_composable(state):
@@ -743,6 +746,7 @@ def _register_load_state_dict_pre_hooks(state: _FSDPState) -> None:
         )
 
 
+@no_type_check
 def _register_load_state_dict_post_hooks(state: _FSDPState) -> None:
     """Registers the post-load state dict hooks."""
     if not _is_composable(state):

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -167,6 +167,9 @@ class FlatParameter(nn.Parameter):
             (i.e. some per-parameter state) used to customize pre-flatten and
             post-unflatten behavior. This is experimental, and users should not
             depend on its existence in the future.
+        _comm_module_prefix (str): Module name prefix starting from ``module``
+            to ``comm_module`` as passed to :class:`FlatParamHandle`, including
+            a trailing '.'.
         _modules (Set[nn.Module]): Modules that contain some original parameter
             that is flattened into the ``FlatParameter``.
 
@@ -236,6 +239,7 @@ class FlatParameter(nn.Parameter):
         prefixed_param_names: List[str],
         shared_param_infos: List[SharedParamInfo],
         param_extensions: List[Any],
+        comm_module_prefix: str,
         params: Optional[List[nn.Parameter]],
         shared_params: Optional[List[nn.Parameter]],
     ) -> None:
@@ -265,6 +269,7 @@ class FlatParameter(nn.Parameter):
         self._fqns = tuple(prefixed_param_names)
         self._shared_param_infos = tuple(shared_param_infos)
         self._param_extensions = tuple(param_extensions)
+        self._comm_module_prefix = comm_module_prefix
         self._modules = set(pi.module for pi in self._param_infos).union(
             set(spi.module for spi in self._shared_param_infos)
         )
@@ -364,7 +369,7 @@ class FlatParamHandle:
         self._training_state = HandleTrainingState.IDLE
         self._debug_level = dist.get_debug_level()
         self._comm_module = comm_module
-        self._init_flat_param(params, module, use_orig_params)
+        self._init_flat_param(params, module, comm_module, use_orig_params)
         self._orig_param_dtype = self.flat_param.dtype
         self._use_unsharded_views(as_params=False)
         self._config = self._init_config(
@@ -379,6 +384,7 @@ class FlatParamHandle:
         self,
         params: Sequence[Optional[nn.Parameter]],
         module: nn.Module,
+        comm_module: nn.Module,
         use_orig_params: bool,
     ) -> None:
         """
@@ -486,6 +492,7 @@ class FlatParamHandle:
             prefixed_param_names,
             shared_param_infos,
             param_extensions,
+            self._get_comm_module_prefix(module, comm_module),
             convert_to_params(params_to_flatten) if use_orig_params else None,
             convert_to_params(shared_params) if use_orig_params else None,
         )
@@ -552,6 +559,25 @@ class FlatParamHandle:
             fwd_bwd_param_dtype,
             reduce_dtype,
             keep_low_precision_grads,
+        )
+
+    def _get_comm_module_prefix(
+        self,
+        local_root_module: nn.Module,
+        comm_module: nn.Module,
+    ) -> str:
+        """
+        Returns the prefix from ``local_root_module`` to ``comm_module``. For
+        example, if we have ``local_root.submodule.comm_module``, then the
+        returned prefix is ``local_root.submodule.`` (with the trailing '.').
+        """
+        if local_root_module is comm_module:
+            return ""
+        for submodule_name, submodule in local_root_module.named_modules():
+            if submodule is comm_module:
+                return submodule_name + "."
+        raise AssertionError(
+            "Expects `comm_module` to be in `local_root_module`'s subtree"
         )
 
     ###################################
@@ -1831,7 +1857,13 @@ class FlatParamHandle:
         sharded_size = self.flat_param._sharded_size  # type: ignore[attr-defined]
         return tensor.size() == sharded_size
 
+    # NOTE: These two methods to get parameter and module names are used for
+    # `state_dict()`, which constructs a prefix starting from the module on
+    # which `state_dict()` is called. Since the comm. module is the module that
+    # saves its managed parameters, we must strip the comm. module prefix to
+    # align with the state-dict prefix.
     def parameter_module_names(self) -> Iterator[Tuple[str, str]]:
+        comm_module_prefix = self.flat_param._comm_module_prefix
         shared_param_infos = [
             ParamInfo(param_name, module, module_name)
             for (
@@ -1846,9 +1878,17 @@ class FlatParamHandle:
         for param_name, _, module_name in chain(
             self.flat_param._param_infos, shared_param_infos
         ):
-            yield (param_name, module_name)
+            assert module_name.startswith(comm_module_prefix), (
+                f"module_name: {module_name} comm_module_prefix: "
+                f"{comm_module_prefix}"
+            )
+            module_name_prefixed_from_comm_module = module_name[
+                len(comm_module_prefix) :
+            ]
+            yield (param_name, module_name_prefixed_from_comm_module)
 
     def shared_parameter_module_names(self) -> Iterator[Tuple[str, str]]:
+        comm_module_prefix = self.flat_param._comm_module_prefix
         for param_name, _, module_name in [
             ParamInfo(param_name, module, module_name)
             for (
@@ -1860,7 +1900,14 @@ class FlatParamHandle:
                 _,
             ) in self.flat_param._shared_param_infos
         ]:
-            yield (param_name, module_name)
+            assert module_name.startswith(comm_module_prefix), (
+                f"module_name: {module_name} comm_module_prefix: "
+                f"{comm_module_prefix}"
+            )
+            module_name_prefixed_from_comm_module = module_name[
+                len(comm_module_prefix) :
+            ]
+            yield (param_name, module_name_prefixed_from_comm_module)
 
     @property
     def _fqns_in_shard(self) -> List[str]:

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -169,7 +169,7 @@ class FlatParameter(nn.Parameter):
             depend on its existence in the future.
         _comm_module_prefix (str): Module name prefix starting from ``module``
             to ``comm_module`` as passed to :class:`FlatParamHandle`, including
-            a trailing '.'.
+            a trailing '.' if this is not the empty string.
         _modules (Set[nn.Module]): Modules that contain some original parameter
             that is flattened into the ``FlatParameter``.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90777 [FSDP][2/N] Refactor state dict hook registration
* **#90767 [FSDP][1/N] `fully_shard` state dict**
* #90660 [FSDP] Clean up `FlatParamHandle` dtypes, post-backward hook

Co-authored with @rohan-varma.

**Overview**
This adds preliminary `state_dict()` support for `fully_shard`.
- The only explicit branching between composable and wrapper code paths happens in the state dict hook registration, which is inevitable.
- We introduce a `_comm_module_prefix` to match the FQNs between the two code paths. This is needed since for composable, the FQNs are prefixed from the local FSDP root, whereas for state dict purposes, we want them to be prefixed from the comm. module. Thus, we need this `_comm_module_prefix` to be stripped during state dict.
    - In my understanding, the alternative to not use the `prefix` argument in `state_dict()` does not support the case when `fully_shard` is applied to a submodule (i.e. not the global root module) since we still need _part_ of `prefix` then.

**Follow-Ups**
- We can retire the `functools.partial` usage once @fegin's PR lands.
- We should add more thorough testing (e.g. sharded state dict, save and load together etc.).