### PR TITLE
[DataLoader2] Fix apply_sharding to accept one sharding_filter per branch

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -2689,8 +2689,8 @@ class TestSharding(TestCase):
 
         actual = list(dp)
         expected = [17, 47, 77]
-        self.assertEquals(expected, actual)
-        self.assertEquals(3, len(dp))
+        self.assertEqual(expected, actual)
+        self.assertEqual(3, len(dp))
 
         dp, _ = construct_sharded_pipe()
         dp.apply_sharding(2, 1, sharding_group=SHARDING_PRIORITIES.DEFAULT)

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -2740,7 +2740,7 @@ class TestSharding(TestCase):
         numbers_dp = dp.iter.IterableWrapper(range(13))
         sharded_dp = numbers_dp.sharding_filter()
         sharded_dp = sharded_dp.sharding_filter()
-        with self.assertRaisesRegex(RuntimeError, "Dynamic sharding can be only"):
+        with self.assertRaisesRegex(RuntimeError, "Sharding twice on a single pipeline"):
             torch.utils.data.graph_settings.apply_sharding(sharded_dp, 3, 0)
 
         # Raises Error when sharding on both data source and branch
@@ -2748,7 +2748,7 @@ class TestSharding(TestCase):
         dp1, dp2 = numbers_dp.fork(2)
         sharded_dp = dp1.sharding_filter()
         zip_dp = dp2.zip(sharded_dp)
-        with self.assertRaisesRegex(RuntimeError, "Dynamic sharding can be only"):
+        with self.assertRaisesRegex(RuntimeError, "Sharding twice on a single pipeline"):
             torch.utils.data.graph_settings.apply_sharding(zip_dp, 3, 0)
 
         # Raises Error when multiple sharding on the branch and end
@@ -2756,7 +2756,7 @@ class TestSharding(TestCase):
         dp1, dp2 = numbers_dp.fork(2)
         sharded_dp = dp1.sharding_filter()
         zip_dp = dp2.zip(sharded_dp).sharding_filter()
-        with self.assertRaisesRegex(RuntimeError, "Dynamic sharding can be only"):
+        with self.assertRaisesRegex(RuntimeError, "Sharding twice on a single pipeline"):
             torch.utils.data.graph_settings.apply_sharding(zip_dp, 3, 0)
 
         # Single sharding_filter on data source

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -48,8 +48,8 @@ def apply_sharding(datapipe: DataPipe,
             if hasattr(dp, 'is_shardable') and dp.is_shardable():
                 if hasattr(dp, 'apply_sharding'):
                     if prev_applied is not None:
-                        raise RuntimeError("Dynamic sharding can be only applied once per branch of DataPipe graph. "
-                                           f"Already applied to {prev_applied} while trying to apply to {dp}")
+                        raise RuntimeError("Sharding twice on a single pipeline is likely unintended and will cause data loss. "
+                                           f"Sharding already applied to {prev_applied} while trying to apply to {dp}")
                     dp.apply_sharding(num_of_instances, instance_id, sharding_group=sharding_group)
                     applied = dp
             if applied is None:


### PR DESCRIPTION
Changes:
- Allow multiple `sharding_filter` in the pipeline as long as they are not on the same branch
- [x] Add test

Example:
```mermaid
graph TD;
DP1-->sharding_filter_1;
sharding_filter_1-->DP3;
DP2-->sharding_filter_2;
sharding_filter_2-->DP4;
DP3-->DP4;
DP4-->output;
```
In order to properly shard `DP1` and `DP2`, we should allow multiple `sharding_filter`s