### PR TITLE
Fix missing return statement for test_it_returns_empty_list_when_model_contains_supported_inplace_ops in #89299

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -130,6 +130,7 @@ class TestUnconvertibleOps(pytorch_test_common.ExportTestCase):
                 out = x
                 out += x
                 out = torch.nn.functional.relu(out, inplace=True)
+                return out
 
         module = SkipConnectionModule()
         x = torch.randn(4, 4)


### PR DESCRIPTION
Follow-up to #89299 where the return statement is missing in the test case