### PR TITLE
[BE] Tweak Meta copyright headers

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -818,3 +818,21 @@ init_command = [
     'usort==1.0.2',
 ]
 is_formatter = true
+
+[[linter]]
+code = 'COPYRIGHT'
+include_patterns = ['**']
+exclude_patterns = ['.lintrunner.toml']
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=Confidential and proprietary',
+    '--linter-name=COPYRIGHT',
+    '--error-name=Confidential Code',
+    """--error-description=\
+        Proprietary and confidential source code\
+        should not be contributed to PyTorch codebase\
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]

--- a/android/pytorch_android/src/androidTest/cpp/pytorch_jni_common_test.cpp
+++ b/android/pytorch_android/src/androidTest/cpp/pytorch_jni_common_test.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #include <gtest/gtest.h>
 

--- a/android/pytorch_android/src/androidTest/cpp/pytorch_jni_common_test.cpp
+++ b/android/pytorch_android/src/androidTest/cpp/pytorch_jni_common_test.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <gtest/gtest.h>
 

--- a/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.h
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.h
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #import <Foundation/Foundation.h>
 #include <unordered_map>

--- a/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.h
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.h
@@ -1,4 +1,7 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #import <Foundation/Foundation.h>
 #include <unordered_map>

--- a/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.mm
@@ -1,7 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #import "MetalOpTestRunner.h"
 

--- a/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MetalOpTestRunner.mm
@@ -1,4 +1,7 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+// (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #import "MetalOpTestRunner.h"
 

--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include "test_utils.h"
 

--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -1,4 +1,7 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #include "test_utils.h"
 

--- a/benchmarks/static_runtime/test_utils.h
+++ b/benchmarks/static_runtime/test_utils.h
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/benchmarks/static_runtime/test_utils.h
+++ b/benchmarks/static_runtime/test_utils.h
@@ -1,4 +1,7 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #pragma once
 

--- a/caffe2/utils/knob_patcher.cc
+++ b/caffe2/utils/knob_patcher.cc
@@ -1,7 +1,7 @@
-// (c) Meta Platforms, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and its affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <map>
 

--- a/caffe2/utils/knob_patcher.cc
+++ b/caffe2/utils/knob_patcher.cc
@@ -1,4 +1,7 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+// (c) Meta Platforms, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #include <map>
 

--- a/caffe2/utils/knobs.cc
+++ b/caffe2/utils/knobs.cc
@@ -1,4 +1,4 @@
-// (c) Meta Platforms, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
 // This is a very basic knob implementation that purely uses command line flags.
 // This can be replaced with a more sophisticated implementation for use in

--- a/caffe2/utils/knobs.cc
+++ b/caffe2/utils/knobs.cc
@@ -1,5 +1,5 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
-
+// (c) Meta Platforms, Inc. and its affiliates.
+//
 // This is a very basic knob implementation that purely uses command line flags.
 // This can be replaced with a more sophisticated implementation for use in
 // other production environments.

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
@@ -1,6 +1,6 @@
-// (c) Meta Platforms, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
+// This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
 #include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>

--- a/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
+++ b/torch/csrc/distributed/c10d/ParamCommsUtils.cpp
@@ -1,4 +1,7 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+// (c) Meta Platforms, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
 

--- a/torch/csrc/distributed/c10d/quantization/quantization.h
+++ b/torch/csrc/distributed/c10d/quantization/quantization.h
@@ -1,6 +1,6 @@
-// (c) Meta Platforms, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
+// This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
 #pragma once

--- a/torch/csrc/distributed/c10d/quantization/quantization.h
+++ b/torch/csrc/distributed/c10d/quantization/quantization.h
@@ -1,4 +1,7 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+// (c) Meta Platforms, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/torch/csrc/distributed/c10d/quantization/quantization_gpu.h
+++ b/torch/csrc/distributed/c10d/quantization/quantization_gpu.h
@@ -1,7 +1,7 @@
-// (c) Meta Platforms, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/torch/csrc/distributed/c10d/quantization/quantization_gpu.h
+++ b/torch/csrc/distributed/c10d/quantization/quantization_gpu.h
@@ -1,4 +1,7 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+// (c) Meta Platforms, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #pragma once
 

--- a/torch/csrc/distributed/c10d/quantization/quantization_utils.h
+++ b/torch/csrc/distributed/c10d/quantization/quantization_utils.h
@@ -1,7 +1,7 @@
-// (c) Meta Platforms, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/torch/csrc/distributed/c10d/quantization/quantization_utils.h
+++ b/torch/csrc/distributed/c10d/quantization/quantization_utils.h
@@ -1,4 +1,7 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+// (c) Meta Platforms, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #pragma once
 

--- a/torch/csrc/jit/backends/coreml/cpp/preprocess.cpp
+++ b/torch/csrc/jit/backends/coreml/cpp/preprocess.cpp
@@ -1,7 +1,7 @@
-// (c) Meta Platforms, Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <pybind11/pybind11.h>
 #include <torch/csrc/jit/backends/backend.h>

--- a/torch/csrc/jit/backends/coreml/cpp/preprocess.cpp
+++ b/torch/csrc/jit/backends/coreml/cpp/preprocess.cpp
@@ -1,4 +1,8 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+// (c) Meta Platforms, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
 #include <pybind11/pybind11.h>
 #include <torch/csrc/jit/backends/backend.h>
 #include <torch/csrc/jit/backends/backend_preprocess.h>

--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <caffe2/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h>
 #include <torch/csrc/jit/backends/xnnpack/serialization/schema_generated.h>

--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #include <caffe2/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h>
 #include <torch/csrc/jit/backends/xnnpack/serialization/schema_generated.h>

--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <caffe2/torch/csrc/jit/backends/xnnpack/executor/xnn_executor.h>
 #include <xnnpack.h>

--- a/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h
+++ b/torch/csrc/jit/backends/xnnpack/compiler/xnn_compiler.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #include <caffe2/torch/csrc/jit/backends/xnnpack/executor/xnn_executor.h>
 #include <xnnpack.h>

--- a/torch/csrc/jit/backends/xnnpack/executor/xnn_executor.h
+++ b/torch/csrc/jit/backends/xnnpack/executor/xnn_executor.h
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 #include <xnnpack.h>

--- a/torch/csrc/jit/backends/xnnpack/executor/xnn_executor.h
+++ b/torch/csrc/jit/backends/xnnpack/executor/xnn_executor.h
@@ -1,4 +1,8 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
 #pragma once
 #include <xnnpack.h>
 #include <memory>

--- a/torch/csrc/jit/backends/xnnpack/serialization/serializer.cpp
+++ b/torch/csrc/jit/backends/xnnpack/serialization/serializer.cpp
@@ -1,7 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <caffe2/torch/csrc/jit/backends/xnnpack/serialization/serializer.h>
 #include <torch/csrc/jit/backends/xnnpack/serialization/schema_generated.h>

--- a/torch/csrc/jit/backends/xnnpack/serialization/serializer.cpp
+++ b/torch/csrc/jit/backends/xnnpack/serialization/serializer.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #include <caffe2/torch/csrc/jit/backends/xnnpack/serialization/serializer.h>
 #include <torch/csrc/jit/backends/xnnpack/serialization/schema_generated.h>

--- a/torch/csrc/jit/backends/xnnpack/serialization/serializer.h
+++ b/torch/csrc/jit/backends/xnnpack/serialization/serializer.h
@@ -1,7 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <torch/csrc/jit/backends/xnnpack/serialization/schema_generated.h>
 #include <cstddef>

--- a/torch/csrc/jit/backends/xnnpack/serialization/serializer.h
+++ b/torch/csrc/jit/backends/xnnpack/serialization/serializer.h
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #include <torch/csrc/jit/backends/xnnpack/serialization/schema_generated.h>
 #include <cstddef>

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <caffe2/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h>
 #include <torch/csrc/jit/runtime/graph_iterator.h>

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.cpp
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
 
 #include <caffe2/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h>
 #include <torch/csrc/jit/runtime/graph_iterator.h>

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 //
-// This source code is licensed under the MIT license found in the
-// LICENSE file in the root directory of this source tree
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include <ATen/Functions.h>
 #include <ATen/Utils.h>

--- a/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h
+++ b/torch/csrc/jit/backends/xnnpack/xnnpack_graph_builder.h
@@ -1,4 +1,8 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree
+
 #include <ATen/Functions.h>
 #include <ATen/Utils.h>
 #include <torch/torch.h>


### PR DESCRIPTION
s/Facebook, Inc./Meta Platforms, Inc/
s/Confidential and proprietary./This source code is licensed under the BSD-style license/

Per https://www.internalfb.com/intern/wiki/Open_Source/Licenses/Straight_BSD/

Also, add linter that prevents adding those in the future

Fixes https://github.com/pytorch/pytorch/issues/90187