### PR TITLE
add autocast keys to pybind11 DispatchKey object

### DIFF
--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -507,6 +507,10 @@ void initDispatchBindings(PyObject* module) {
       DEF_ONE(FuncTorchDynamicLayerBackMode)
       DEF_ONE(PythonDispatcher)
       DEF_ONE(Functionalize)
+      DEF_ONE(AutocastCPU)
+      DEF_ONE(AutocastXPU)
+      DEF_ONE(AutocastHPU)
+      DEF_ONE(AutocastCUDA)
   // clang-format on
 
 #define DEF_SINGLE(n, prefix) .value(#prefix #n, c10::DispatchKey::prefix##n)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90821

Summary:

This is useful for debugging what autocast is doing when
it's running on top of torchdynamo, without this the Python dispatch
key for autocast prints as `???`.

Test Plan:

```
import torch
dir(torch._C.DispatchKey)
// the autocast keys show up now
```

Reviewers:

Subscribers:

Tasks:

Tags: