### PR TITLE
remove redundant computation in batchnorm decomposition

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1345,9 +1345,7 @@ def native_batch_norm_helper(
             # This doesn't strictly match eager's numerics, which accumulates var sum and then directly applies the correction
             # But... that would require re-implementing var here, for negligible numerics gain on a tensor whose
             # numerics probably don't matter.
-            unbiased_var = _squeeze_multiple(biased_var, reduction_dims) * (
-               n / (n - 1)
-            )
+            unbiased_var = _squeeze_multiple(biased_var, reduction_dims) * (n / (n - 1))
             new_running_var = momentum * unbiased_var + (1 - momentum) * running_var
             if not functional:
                 running_var.copy_(new_running_var)


### PR DESCRIPTION
This pr is to fix the regression mentioned in https://github.com/pytorch/torchdynamo/issues/1988. After this pr, the inductor performance of Resnet50 training on CPU is ~0.95x that of eager.
