### PR TITLE
[FSDP][BE] Remove `_module_to_handles`, `HandleConfig`; use term "fqn"; clarify docs

### DIFF
--- a/torch/distributed/_composable/fully_shard.py
+++ b/torch/distributed/_composable/fully_shard.py
@@ -98,8 +98,7 @@ def fully_shard(
     for submodule in module.modules():
         if (
             submodule not in state._ignored_modules
-            and _get_module_state(submodule)
-            is not state  # either `None`or different state
+            and _get_module_state(submodule) is None
         ):
             _insert_module_state(submodule, state)
     return module

--- a/torch/distributed/_composable/fully_shard.py
+++ b/torch/distributed/_composable/fully_shard.py
@@ -98,7 +98,8 @@ def fully_shard(
     for submodule in module.modules():
         if (
             submodule not in state._ignored_modules
-            and _get_module_state(submodule) is None
+            and _get_module_state(submodule)
+            is not state  # either `None`or different state
         ):
             _insert_module_state(submodule, state)
     return module

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -68,7 +68,7 @@ def _is_composable(state: _FSDPState):
 
 
 @no_type_check
-def _all_handles(state: _FSDPState) -> List[flat_param_file.FlatParamHandle]:
+def _all_handles(state: _FSDPState) -> List:
     """
     Returns all ``FlatParamHandle`` s managed by ``state``.
     """
@@ -80,9 +80,7 @@ def _all_handles(state: _FSDPState) -> List[flat_param_file.FlatParamHandle]:
 
 
 @no_type_check
-def _module_handles(
-    state: _FSDPState, module: nn.Module
-) -> List[flat_param_file.FlatParamHandle]:
+def _module_handles(state: _FSDPState, module: nn.Module) -> List:
     """
     Returns the ``FlatParamHandle`` s corresponding to ``module``. These are
     the handles that contain some parameter in ``module``.

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -68,7 +68,10 @@ def _is_composable(state: _FSDPState):
 
 
 @no_type_check
-def _all_handles(state: _FSDPState) -> List:
+def _all_handles(state: _FSDPState) -> List[flat_param_file.FlatParamHandle]:
+    """
+    Returns all ``FlatParamHandle`` s managed by ``state``.
+    """
     return (
         state._handles
         if _is_composable(state)
@@ -77,10 +80,12 @@ def _all_handles(state: _FSDPState) -> List:
 
 
 @no_type_check
-def _module_handles(state: _FSDPState, module: nn.Module) -> List:
+def _module_handles(
+    state: _FSDPState, module: nn.Module
+) -> List[flat_param_file.FlatParamHandle]:
     """
-    Given a module and returns the flat handles that map to this module. If the
-    module is FullyShardedDataParallel, the module._handles will be returned.
+    Returns the ``FlatParamHandle`` s corresponding to ``module``. These are
+    the handles that contain some parameter in ``module``.
     """
     if _is_composable(state):
         assert (
@@ -93,7 +98,7 @@ def _module_handles(state: _FSDPState, module: nn.Module) -> List:
 
 @no_type_check
 def _has_fsdp_params(state: _FSDPState, module: nn.Module) -> bool:
-    """Given a module and returns if this module has parameters sharded by FSDP."""
+    """Returns if ``module`` has parameters managed by FSDP."""
     return len(_module_handles(state, module)) > 0
 
 

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1,6 +1,5 @@
 import contextlib
 import warnings
-from dataclasses import dataclass
 from enum import auto, Enum
 from itertools import accumulate, chain
 from typing import (
@@ -44,7 +43,6 @@ __all__ = [
     "FlatParamShardMetadata",
     "ParamInfo",
     "SharedParamInfo",
-    "HandleConfig",
     "HandleShardingStrategy",
 ]
 
@@ -107,15 +105,6 @@ class HandleShardingStrategy(Enum):
     NO_SHARD = auto()
     HYBRID_SHARD = auto()
     _HYBRID_SHARD_ZERO2 = auto()
-
-
-@dataclass
-class HandleConfig:
-    sharding_strategy: HandleShardingStrategy
-    offload_params: bool
-    fwd_bwd_param_dtype: torch.dtype
-    reduce_dtype: torch.dtype
-    keep_low_precision_grads: bool
 
 
 class FlatParameter(nn.Parameter):
@@ -236,7 +225,7 @@ class FlatParameter(nn.Parameter):
         param_infos: List[ParamInfo],
         numels: List[int],
         shapes: List[torch.Size],
-        prefixed_param_names: List[str],
+        fqns: List[str],
         shared_param_infos: List[SharedParamInfo],
         param_extensions: List[Any],
         comm_module_prefix: str,
@@ -260,13 +249,13 @@ class FlatParameter(nn.Parameter):
         """
         assert len(param_infos) == len(numels)
         assert len(param_infos) == len(shapes)
-        assert len(param_infos) == len(prefixed_param_names)
+        assert len(param_infos) == len(fqns)
         assert len(param_infos) == len(param_extensions)
         self._num_params = len(param_infos)
         self._param_infos = tuple(param_infos)
         self._numels = tuple(numels)
         self._shapes = tuple(shapes)
-        self._fqns = tuple(prefixed_param_names)
+        self._fqns = tuple(fqns)
         self._shared_param_infos = tuple(shared_param_infos)
         self._param_extensions = tuple(param_extensions)
         self._comm_module_prefix = comm_module_prefix
@@ -318,8 +307,10 @@ class FlatParamHandle:
         comm_module (nn.Module): The module responsible for the unshard/reshard
             pair for this handle. For the non-module-wrapper code path, this
             is what would have been ``module`` in the module-wrapper equivalent
-            wrapping, which may not be the local FSDP root module. For the
-            module-wrapper code path, this is always the same as ``module``.
+            wrapping, which may not be the local FSDP root module. I.e., this
+            is what becomes ``FullyShardedDataParallel._fsdp_wrapped_module``.
+            For the module-wrapper code path, this is always the same as
+            ``module``. We refer to this as "comm. module" in internal docs.
         device (torch.device): The compute and communication device, which
             should be a non-CPU device. We refer to it as the compute device.
         sharding_strategy (ShardingStrategy): Sharding strategy to apply to
@@ -338,9 +329,9 @@ class FlatParamHandle:
             parameter every iteration and returns the :class:`FlatParameter` s
             from ``named_parameters()``.
 
-    NOTE: We enforce that there is a single "communication module" that is
-    responsible for the unshard/reshard pair for this handle. This invariant
-    holds for both the module-wrapper and non-module-wrapper code paths.
+    NOTE: We enforce that there is a single comm. module that is responsible
+    for the unshard/reshard pair for this handle. This invariant holds for both
+    the module-wrapper and non-module-wrapper code paths.
     """
 
     ##################
@@ -365,20 +356,17 @@ class FlatParamHandle:
         self.process_group = process_group
         self.rank = process_group.rank()
         self.world_size = process_group.size()
+        self._sharding_strategy = sharding_strategy
+        self._offload_params = offload_params
         self._use_orig_params = use_orig_params
+        self._keep_low_precision_grads = keep_low_precision_grads
         self._training_state = HandleTrainingState.IDLE
         self._debug_level = dist.get_debug_level()
         self._comm_module = comm_module
         self._init_flat_param(params, module, comm_module, use_orig_params)
         self._orig_param_dtype = self.flat_param.dtype
         self._use_unsharded_views(as_params=False)
-        self._config = self._init_config(
-            sharding_strategy,
-            offload_params,
-            mp_param_dtype,
-            mp_reduce_dtype,
-            keep_low_precision_grads,
-        )
+        self._init_param_reduce_dtypes(mp_param_dtype, mp_reduce_dtype)
 
     def _init_flat_param(
         self,
@@ -409,7 +397,7 @@ class FlatParamHandle:
         param_infos: List[ParamInfo] = []
         numels: List[int] = []
         shapes: List[torch.Size] = []
-        prefixed_param_names: List[str] = []
+        fqns: List[str] = []
         shared_param_infos: List[SharedParamInfo] = []
         shared_param_memo: Dict[nn.Parameter, Tuple[nn.Module, str, str]] = {}
         params_to_flatten: List[Union[torch.Tensor, nn.Parameter]] = []
@@ -462,12 +450,12 @@ class FlatParamHandle:
                     param_infos.append(ParamInfo(param_name, submodule, submodule_name))
                     numels.append(param.numel())
                     shapes.append(param.shape)
-                    prefixed_param_name = (
+                    fqn = (
                         submodule_name + "." + param_name
                         if submodule_name
                         else param_name
                     )
-                    prefixed_param_names.append(prefixed_param_name)
+                    fqns.append(fqn)
         assert requires_grad is not None, (
             "Passed-in `params` were not found in the module tree\n"
             f"params: {params}\nmodule: {module}"
@@ -489,7 +477,7 @@ class FlatParamHandle:
             param_infos,
             numels,
             shapes,
-            prefixed_param_names,
+            fqns,
             shared_param_infos,
             param_extensions,
             self._get_comm_module_prefix(module, comm_module),
@@ -520,46 +508,33 @@ class FlatParamHandle:
         flat_param = FlatParameter(flat_param_data, requires_grad=requires_grad)
         return flat_param
 
-    def _init_config(
+    def _init_param_reduce_dtypes(
         self,
-        sharding_strategy: HandleShardingStrategy,
-        offload_params: bool,
         mp_param_dtype: Optional[torch.dtype],
         mp_reduce_dtype: Optional[torch.dtype],
-        keep_low_precision_grads: bool,
-    ) -> HandleConfig:
+    ) -> None:
         """
         Precondition: ``self.flat_param`` is set via :meth:`_init_flat_param`.
+        This ensures that this handle's parameters have a single dtype.
 
-        Returns:
-            HandleConfig: The same config as ``handle_config`` except with the
-            low precision dtypes that are ``None`` set to the original
-            parameter dtype. One special case is if the parameter low precision
-            is specified while the gradient reduction low precision is not, in
-            which case the gradient reduction low precision is set to the
-            parameter one.
+        Postcondition: This sets ``self._fwd_bwd_param_dtype`` and
+        ``self._reduce_dtype``. If ``mp_param_dtype`` or ``mp_reduce_dtype``
+        is ``None``, then we assume the original parameter dtype. One special
+        case is if ``mp_param_dtype`` is not ``None`` and ``mp_reduce_dtype``
+        is ``None``, in which case we assume the gradient reduction dtype
+        matches the forward/backward parameter dtype.
         """
         low_prec_param_dtype_specified = mp_param_dtype is not None
         low_prec_reduce_dtype_specified = mp_reduce_dtype is not None
         if low_prec_param_dtype_specified and not low_prec_reduce_dtype_specified:
             # Special case: infer gradient reduction mixed precision
-            fwd_bwd_param_dtype = mp_param_dtype
-            reduce_dtype = fwd_bwd_param_dtype
+            self._fwd_bwd_param_dtype = mp_param_dtype
+            self._reduce_dtype = self._fwd_bwd_param_dtype
         else:
-            fwd_bwd_param_dtype = mp_param_dtype or self._orig_param_dtype
-            reduce_dtype = mp_reduce_dtype or self._orig_param_dtype
-        assert fwd_bwd_param_dtype is not None
-        assert reduce_dtype is not None
-        # TODO (awgu): Get rid of `HandleConfig` and store the attributes
-        # directly on the `FlatParamHandle` now that we are processing it
-        # instead of just taking what is passed in.
-        return HandleConfig(
-            sharding_strategy,
-            offload_params,
-            fwd_bwd_param_dtype,
-            reduce_dtype,
-            keep_low_precision_grads,
-        )
+            self._fwd_bwd_param_dtype = mp_param_dtype or self._orig_param_dtype
+            self._reduce_dtype = mp_reduce_dtype or self._orig_param_dtype
+        assert self._fwd_bwd_param_dtype is not None
+        assert self._reduce_dtype is not None
 
     def _get_comm_module_prefix(
         self,
@@ -817,7 +792,7 @@ class FlatParamHandle:
         """
         flat_param = self.flat_param
         cpu_device = torch.device("cpu")
-        if self._config.offload_params:
+        if self._offload_params:
             p_assert(
                 flat_param.device == cpu_device,
                 "Expects the `FlatParameter` to be offloaded to CPU since CPU "
@@ -825,7 +800,7 @@ class FlatParamHandle:
                 f"model to {flat_param.device} after the FSDP constructor.",
             )
         flat_param._local_shard = flat_param.data
-        if self._config.offload_params:
+        if self._offload_params:
             # Pin the memory for faster H2D transfer
             flat_param._local_shard = flat_param._local_shard.pin_memory()
             # Pre-allocate the sharded gradient on CPU to enable non-blocking
@@ -841,14 +816,14 @@ class FlatParamHandle:
             flat_param._mp_shard = torch.zeros_like(
                 flat_param._local_shard,
                 device=self.device,
-                dtype=self._config.fwd_bwd_param_dtype,
+                dtype=self._fwd_bwd_param_dtype,
             )
             _free_storage(flat_param._mp_shard)
         if self.uses_sharded_strategy:
             # We maintain a padded unsharded tensor that serves as the
             # all-gather destination and owns the original parameter storages.
             unsharded_param_dtype = (
-                self._config.fwd_bwd_param_dtype
+                self._fwd_bwd_param_dtype
                 if self._uses_param_mixed_precision
                 else flat_param.dtype
             )  # use low precision if parameter mixed precision is enabled
@@ -887,14 +862,14 @@ class FlatParamHandle:
             ret = self._writeback_orig_params()
         if (
             self.uses_sharded_strategy
-            and not self._config.offload_params
+            and not self._offload_params
             and not self.needs_unshard()
         ):
             pass  # no-op
         elif self._uses_param_mixed_precision and not self._force_full_precision:
             self._use_low_precision_shard()
             ret = True
-        elif self._config.offload_params and self.flat_param.device != self.device:
+        elif self._offload_params and self.flat_param.device != self.device:
             # NOTE: This creates a new tensor distinct from any attributes.
             self.flat_param_to(self.device, non_blocking=True)
             ret = True
@@ -983,8 +958,8 @@ class FlatParamHandle:
             # that  `_full_param_padded` is in the low precision
             unsharded_flat_param = flat_param._full_prec_full_param_padded  # type: ignore[attr-defined]
             p_assert(
-                unsharded_flat_param.dtype != self._config.fwd_bwd_param_dtype,
-                f"Expects full precision but got {self._config.fwd_bwd_param_dtype}",
+                unsharded_flat_param.dtype != self._fwd_bwd_param_dtype,
+                f"Expects full precision but got {self._fwd_bwd_param_dtype}",
             )
         else:
             unsharded_flat_param = flat_param._full_param_padded  # type: ignore[attr-defined]
@@ -1139,7 +1114,7 @@ class FlatParamHandle:
             self._check_on_compute_device(self.flat_param)
             grad_offloaded = flat_param.grad.device != self.device
             p_assert(
-                not grad_offloaded or self._config.offload_params,
+                not grad_offloaded or self._offload_params,
                 f"Expects the sharded gradient to be on {self.device} "
                 f"but got {flat_param.grad.device}",
             )
@@ -1171,7 +1146,7 @@ class FlatParamHandle:
                 # the post-backward callback.
                 local_shard_dtype = flat_param._local_shard.dtype  # type: ignore[attr-defined]
                 if (
-                    self._config.keep_low_precision_grads
+                    self._keep_low_precision_grads
                     and sharded_grad.dtype != local_shard_dtype
                 ):
                     sharded_grad.data = sharded_grad.to(local_shard_dtype)
@@ -1192,12 +1167,10 @@ class FlatParamHandle:
         """
 
         def cast_grad_to_param_dtype_if_needed(flat_param):
-            if self._config.keep_low_precision_grads:
+            if self._keep_low_precision_grads:
                 assert flat_param.grad is not None  # mypy
-                if flat_param.grad.dtype != self._config.fwd_bwd_param_dtype:
-                    flat_param.grad.data = flat_param.grad.to(
-                        self._config.fwd_bwd_param_dtype
-                    )
+                if flat_param.grad.dtype != self._fwd_bwd_param_dtype:
+                    flat_param.grad.data = flat_param.grad.to(self._fwd_bwd_param_dtype)
                     if self._use_orig_params:
                         self._use_sharded_grad_views()
 
@@ -1325,7 +1298,7 @@ class FlatParamHandle:
     def _use_sharded_flat_param(self) -> None:
         """Switches to using the sharded flattened parameter."""
         flat_param = self.flat_param
-        if self._config.offload_params:
+        if self._offload_params:
             device = flat_param._local_shard.device  # type: ignore[attr-defined]
             p_assert(
                 device == torch.device("cpu"),
@@ -1524,7 +1497,7 @@ class FlatParamHandle:
             p_assert(
                 hasattr(module, param_name),
                 f"{module_name + '.' + param_name if module_name else param_name} is missing",
-            )  # did not save prefixed name
+            )  # did not save FQN info in `_shared_param_infos`
             param = getattr(module, param_name)
             prim_param = getattr(prim_module, prim_param_name)
             if param.shape != prim_param.grad.shape:
@@ -1748,7 +1721,7 @@ class FlatParamHandle:
                 # require gradient writeback.
                 flat_param_grad = (
                     flat_param.grad
-                    if self.uses_sharded_strategy or not self._config.offload_params
+                    if self.uses_sharded_strategy or not self._offload_params
                     else flat_param._cpu_grad  # type: ignore[attr-defined]
                 )
                 needs_grad_writeback = flat_param_grad is None or not _same_storage(
@@ -2064,19 +2037,15 @@ class FlatParamHandle:
     ##############
     @property
     def uses_sharded_strategy(self) -> bool:
-        return self._config.sharding_strategy != HandleShardingStrategy.NO_SHARD
+        return self._sharding_strategy != HandleShardingStrategy.NO_SHARD
 
     @property
     def _uses_param_mixed_precision(self) -> bool:
-        return self._config.fwd_bwd_param_dtype != self._orig_param_dtype
+        return self._fwd_bwd_param_dtype != self._orig_param_dtype
 
     @property
     def _uses_reduce_mixed_precision(self) -> bool:
-        return self._config.reduce_dtype != self._orig_param_dtype
-
-    @property
-    def _keep_low_precision_grads(self) -> bool:
-        return self._config.keep_low_precision_grads
+        return self._reduce_dtype != self._orig_param_dtype
 
     @property
     def _force_full_precision(self) -> bool:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90862 [FSDP][3/N] Move `fsdp_modules(root_only=True)` -> `_get_fsdp_root_states()`
* #90861 [FSDP][2/N] Move `fsdp_modules(root_only=False)` -> `_get_fsdp_states()`
* #90864 [FSDP][Easy] Rename `entry` -> `fsdp_module` to be more descriptive
* #90860 [FSDP][1/N] Add `_get_fsdp_states()`
* #90846 [FSDP] Enable mixed hybrid/non-hybrid sharding strategies
* #90859 [FSDP][Easy] Use `run_subtests` for hybrid shard test
* #90858 [FSDP][Easy] ufmt files
* **#90840 [FSDP][BE] Remove `_module_to_handles`, `HandleConfig`; use term "fqn"; clarify docs**

This PR
- Removes `_module_to_handles` since it is no longer used. We instead use `_comm_module_to_handles`.
- Removes `HandleConfig` and stores its fields directly as attributes on `FlatParamHandle`.
- Uses the term `fqn`/`fqns` uniformly in `flat_param.py` instead of `prefixed_param_name` / `prefixed_param_names`.
- Clarifies some documentation.

I am including all of these BE items in the same PR to save CI.