### PR TITLE
[FSDP] Enable mixed hybrid/non-hybrid sharding strategies

### DIFF
--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -1,19 +1,17 @@
 # Owner(s): ["oncall: distributed"]
 
 import contextlib
-from functools import partial
-from collections import Counter
 import sys
+from collections import Counter
+from functools import partial
 
 import torch
-import torch.nn as nn
 import torch.distributed as dist
+import torch.nn as nn
 
 from torch.distributed.distributed_c10d import _rank_not_in_group
-from torch.distributed.fsdp import (
-    FullyShardedDataParallel as FSDP,
-    ShardingStrategy,
-)
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy
+from torch.distributed.fsdp._init_utils import HYBRID_SHARDING_STRATEGIES
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
@@ -54,6 +52,7 @@ def patch_allreduce(new_allreduce):
     finally:
         dist.all_reduce = orig_ar
 
+
 @contextlib.contextmanager
 def patch_reduce_scatter(new_reduce_scatter):
     """
@@ -74,6 +73,7 @@ class MyModel(nn.Module):
         self.lin1 = nn.Linear(10, 10)
         self.lin2 = nn.Linear(10, 10)
         self.lin3 = nn.Linear(10, 10)
+
 
 class TestFSDPHybridShard(FSDPTest):
     @property
@@ -97,26 +97,6 @@ class TestFSDPHybridShard(FSDPTest):
         with err_ctx:
             model = FSDP(model, sharding_strategy=ShardingStrategy._HYBRID_SHARD_ZERO2)
 
-
-    @skip_if_lt_x_gpu(2)
-    def test_hybrid_shard_strategy_mismatch_raises(self):
-        for sharding_strategy in [
-            ShardingStrategy._HYBRID_SHARD_ZERO2,
-            ShardingStrategy.HYBRID_SHARD
-        ]:
-            with self.subTest(sharding_strategy=sharding_strategy):
-                model = MyModel().cuda()
-                intra_pg = self.process_group
-                inter_pg = dist.new_group(ranks=[self.rank])
-                model.lin1 = FSDP(model.lin1, process_group=(intra_pg, inter_pg), sharding_strategy=sharding_strategy)
-                self.assertEqual(model.lin1.process_group, intra_pg)
-                self.assertEqual(model.lin1._inter_node_pg, inter_pg)
-                model = FSDP(model, process_group=intra_pg)
-                inp = torch.randn(4, 10)
-                # Errors during _lazy_init
-                with self.assertRaisesRegex(ValueError, "expect sharding strategies to be the same"):
-                    model(inp)
-
     @skip_if_lt_x_gpu(2)
     def test_hybrid_shard_pg_mismatch_raises(self):
         model = MyModel().cuda()
@@ -124,25 +104,37 @@ class TestFSDPHybridShard(FSDPTest):
         inter_pg = dist.new_group(ranks=[self.rank])
         # Mismatched process groups for intra-node
         model.lin1 = FSDP(
-            model.lin1, process_group=(intra_pg, inter_pg), sharding_strategy=ShardingStrategy.HYBRID_SHARD
+            model.lin1,
+            process_group=(intra_pg, inter_pg),
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
         )
         model = FSDP(
-            model, process_group=(dist.new_group(), dist.new_group()), sharding_strategy=ShardingStrategy.HYBRID_SHARD
+            model,
+            process_group=(dist.new_group(), dist.new_group()),
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
         )
         # Errors during _lazy_init
         inp = torch.randn(4, 10)
-        with self.assertRaisesRegex(ValueError, "intra-node process groups do not match"):
+        with self.assertRaisesRegex(
+            ValueError, "intra-node process groups do not match"
+        ):
             model(inp)
 
         # Mismatched process groups for inter-node
         model = MyModel().cuda()
         model.lin1 = FSDP(
-            model.lin1, process_group=(intra_pg, inter_pg), sharding_strategy=ShardingStrategy.HYBRID_SHARD
+            model.lin1,
+            process_group=(intra_pg, inter_pg),
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
         )
         model = FSDP(
-            model, process_group=(intra_pg, dist.new_group()), sharding_strategy=ShardingStrategy.HYBRID_SHARD
+            model,
+            process_group=(intra_pg, dist.new_group()),
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
         )
-        with self.assertRaisesRegex(ValueError, "inter-node process groups do not match"):
+        with self.assertRaisesRegex(
+            ValueError, "inter-node process groups do not match"
+        ):
             model(inp)
 
     @skip_if_lt_x_gpu(2)
@@ -150,14 +142,13 @@ class TestFSDPHybridShard(FSDPTest):
         pol = ModuleWrapPolicy({nn.Linear})
         model = MyModel().cuda()
         with self.assertRaisesRegex(
-            ValueError,
-            "Expected process_group to be passed in"
+            ValueError, "Expected process_group to be passed in"
         ):
             model = FSDP(
                 model,
                 auto_wrap_policy=pol,
                 process_group=self.process_group,
-                sharding_strategy=ShardingStrategy.HYBRID_SHARD
+                sharding_strategy=ShardingStrategy.HYBRID_SHARD,
             )
 
     # TODO - add test for ZeRO-2 style sharding ensure params are not
@@ -171,68 +162,137 @@ class TestFSDPHybridShard(FSDPTest):
             2. Process groups are the same across FSDP wrapped instances
             3. reduce_scatter and allreduce called the expected no. of times
         """
-        for sharding_strategy in [
-            ShardingStrategy.HYBRID_SHARD, ShardingStrategy._HYBRID_SHARD_ZERO2
-        ]:
-            with self.subTest(sharding_strategy=sharding_strategy):
-                auto_wrap_policy = ModuleWrapPolicy(
-                    {TransformerEncoderLayer, TransformerDecoderLayer},
-                )
-                fsdp_kwargs = {
-                    "auto_wrap_policy": auto_wrap_policy,
-                    "device_id": torch.cuda.current_device(),
-                    "sharding_strategy": sharding_strategy,
-                }
-                fsdp_model = TransformerWithSharedParams.init(
-                    self.process_group,
-                    FSDPInitMode.RECURSIVE,
-                    CUDAInitMode.CUDA_BEFORE,
-                    fsdp_kwargs,
-                )
-                # All FSDP modules should have state.process_group as the process group over which to
-                # shard (default process group), and state._inter_node_pg (process group containing only
-                # this rank)
-                intra_node_pgs = set()
-                inter_node_pgs = set()
-                for mod in fsdp_model.fsdp_modules(fsdp_model):
-                    # process_group should be across the node, which is just the
-                    # whole world here.
-                    self.assertEqual(
-                        dist.get_world_size(mod.process_group),
-                        dist.get_world_size(self.process_group)
-                    )
-                    intra_node_pgs.add(mod.process_group)
-                    inter_node_pg = mod._inter_node_pg
-                    inter_node_pgs.add(inter_node_pg)
-                    self.assertEqual(1, dist.get_world_size(inter_node_pg))
-                    self.assertFalse(_rank_not_in_group(inter_node_pg))
-                    self.assertEqual(
-                        sharding_strategy, mod.sharding_strategy
-                    )
-                # All fsdp modules should share the same process groups
-                self.assertEqual(1, len(intra_node_pgs))
-                self.assertEqual(1, len(inter_node_pgs))
+        self.run_subtests(
+            {
+                "hsdp_sharding_strategy": [
+                    ShardingStrategy.HYBRID_SHARD,
+                    # ShardingStrategy._HYBRID_SHARD_ZERO2,
+                ],
+                "init_mode": ["mixed"],
+            },
+            self._test_fsdp_hybrid_shard_basic_setup,
+        )
 
-                orig_ar = dist.all_reduce
-                orig_rs = dist.reduce_scatter_tensor
+    def _test_fsdp_hybrid_shard_basic_setup(
+        self,
+        hsdp_sharding_strategy: ShardingStrategy,
+        init_mode: str,
+    ):
+        auto_wrap_policy = ModuleWrapPolicy(
+            {TransformerEncoderLayer, TransformerDecoderLayer},
+        )
+        fsdp_kwargs = {
+            "auto_wrap_policy": auto_wrap_policy,
+            "device_id": torch.cuda.current_device(),
+            "sharding_strategy": hsdp_sharding_strategy,
+        }
+        fsdp_model = TransformerWithSharedParams.init(
+            self.process_group,
+            FSDPInitMode.RECURSIVE,
+            CUDAInitMode.CUDA_BEFORE,
+            fsdp_kwargs,
+        )
+        fsdp_model = self._init_hsdp_model(hsdp_sharding_strategy, init_mode)
+        # All FSDP modules should have state.process_group as the process group over which to
+        # shard (default process group), and state._inter_node_pg (process group containing only
+        # this rank)
+        intra_node_pgs = set()
+        inter_node_pgs = set()
+        for fsdp_module in fsdp_model.fsdp_modules(fsdp_model):
+            # TODO: This needs to be replaced if we deprecate
+            # `FSDP.sharding_strategy` to only use the handle one.
+            if fsdp_module.sharding_strategy not in HYBRID_SHARDING_STRATEGIES:
+                self.assertEqual(init_mode, "mixed")
+                continue
+            # process_group should be across the node, which is just the
+            # whole world here.
+            self.assertEqual(
+                dist.get_world_size(fsdp_module.process_group),
+                dist.get_world_size(self.process_group),
+            )
+            intra_node_pgs.add(fsdp_module.process_group)
+            inter_node_pg = fsdp_module._inter_node_pg
+            inter_node_pgs.add(inter_node_pg)
+            self.assertEqual(1, dist.get_world_size(inter_node_pg))
+            self.assertFalse(_rank_not_in_group(inter_node_pg))
+            self.assertEqual(hsdp_sharding_strategy, fsdp_module.sharding_strategy)
+        # All fsdp modules should share the same process groups
+        self.assertEqual(1, len(intra_node_pgs))
+        self.assertEqual(1, len(inter_node_pgs))
 
-                def patched_collective(orig_collective, counter, *args, **kwargs):
-                    counter[orig_collective] += 1
-                    return orig_collective(*args, **kwargs)
+        orig_ar = dist.all_reduce
+        orig_rs = dist.reduce_scatter_tensor
 
-                cntr = Counter()
-                patched_allreduce = partial(patched_collective, orig_ar, cntr)
-                patched_reduce_scatter = partial(patched_collective, orig_rs, cntr)
-                with patch_allreduce(patched_allreduce), patch_reduce_scatter(patched_reduce_scatter):
-                    inp = fsdp_model.get_input(device=torch.cuda.current_device())
-                    out = fsdp_model(inp[0], inp[1])
-                    loss = fsdp_model.get_loss(inp, out)
-                    loss.backward()
+        def patched_collective(orig_collective, counter, *args, **kwargs):
+            counter[orig_collective] += 1
+            return orig_collective(*args, **kwargs)
 
-                num_flat_params = len(list(FSDP._fsdp_handles(fsdp_model)))
-                self.assertEqual(num_flat_params, cntr[orig_ar])
-                self.assertEqual(num_flat_params, cntr[orig_rs])
-                dist.barrier()
+        cntr = Counter()
+        patched_allreduce = partial(patched_collective, orig_ar, cntr)
+        patched_reduce_scatter = partial(patched_collective, orig_rs, cntr)
+        with patch_allreduce(patched_allreduce), patch_reduce_scatter(
+            patched_reduce_scatter
+        ):
+            inp = fsdp_model.get_input(device=torch.cuda.current_device())
+            out = fsdp_model(inp[0], inp[1])
+            loss = fsdp_model.get_loss(inp, out)
+            loss.backward()
+
+        if init_mode == "uniform":
+            num_flat_params = len(list(FSDP._fsdp_handles(fsdp_model)))
+            self.assertEqual(num_flat_params, cntr[orig_ar])
+            self.assertEqual(num_flat_params, cntr[orig_rs])
+        elif init_mode == "mixed":
+            num_hsdp_flat_params = len(list(FSDP._fsdp_handles(fsdp_model.transformer)))
+            num_flat_params = len(list(FSDP._fsdp_handles(fsdp_model)))
+            self.assertEqual(num_hsdp_flat_params, cntr[orig_ar])
+            self.assertEqual(num_flat_params, cntr[orig_rs])
+
+    def _init_hsdp_model(
+        self,
+        hsdp_sharding_strategy: ShardingStrategy,
+        init_mode: str,
+    ):
+        if init_mode == "uniform":
+            auto_wrap_policy = ModuleWrapPolicy(
+                {TransformerEncoderLayer, TransformerDecoderLayer},
+            )
+            fsdp_kwargs = {
+                "auto_wrap_policy": auto_wrap_policy,
+                "device_id": torch.cuda.current_device(),
+                "sharding_strategy": hsdp_sharding_strategy,
+            }
+            fsdp_model = TransformerWithSharedParams.init(
+                self.process_group,
+                FSDPInitMode.RECURSIVE,
+                CUDAInitMode.CUDA_BEFORE,
+                fsdp_kwargs,
+            )
+        elif init_mode == "mixed":
+            model = TransformerWithSharedParams.init(
+                self.process_group,
+                FSDPInitMode.NO_FSDP,
+                CUDAInitMode.CUDA_BEFORE,
+                {},
+            )
+            transformer_auto_wrap_policy = ModuleWrapPolicy(
+                {TransformerEncoderLayer, TransformerDecoderLayer},
+            )
+            # Use the HSDP strategy for the transformer module
+            model.transformer = FSDP(
+                model.transformer,
+                auto_wrap_policy=transformer_auto_wrap_policy,
+                device_id=torch.cuda.current_device(),
+                sharding_strategy=hsdp_sharding_strategy,
+            )
+            # Use `FULL_SHARD` for the embedding and output projection
+            fsdp_model = FSDP(
+                model,
+                device_id=torch.cuda.current_device(),
+                sharding_strategy=ShardingStrategy.FULL_SHARD,
+            )
+        return fsdp_model
+
 
 instantiate_parametrized_tests(TestFSDPHybridShard)
 

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -37,37 +37,41 @@ RESHARD_AFTER_FORWARD_STRATEGIES = {
 
 
 @no_type_check
-def _validate_hybrid_shard_setup(fsdp_root: _FSDPState, fsdp_module: nn.Module):
+def _validate_and_get_hybrid_shard_state(root_module: nn.Module):
     """
-    Performs validation that hybrid sharding strategy is setup. In particular, we:
-    1) Ensure root and passed in FSDP module have the same hybrid sharding strategy,
-    i.e. both should be using the same hybrid shard strategy or no hybrid shard at all.
-    2) Ensure that inter and intra-node process groups are the same across root and
-    this FSDP module.
+    Precondition: ``root_module`` is a ``FullyShardedDataParallel`` instance.
+
+    This checks that all instances using a hybrid sharding strategy have the
+    same intra- and inter-node process groups.
+
+    Returns:
+        Tuple[HookState]: One of the instances' inter-node state (does not
+        matter which since they will share the same one).
     """
-    if (
-        fsdp_root.sharding_strategy in HYBRID_SHARDING_STRATEGIES
-        or fsdp_module.sharding_strategy in HYBRID_SHARDING_STRATEGIES
-    ):
-        if fsdp_root.sharding_strategy != fsdp_module.sharding_strategy:
-            raise ValueError(
-                "When using hybrid sharding strategy, expect sharding strategies"
-                f" to be the same, but got {fsdp_root.sharding_strategy} vs {fsdp_module.sharding_strategy}"
-            )
-
-        # Ensure inter and intra-node process groups are the same
-        # TODO (rohan-varma) unclear whether these should be asserts or Exceptions
-        # as they can happen due to bug in FSDP process group setup or user passing in
-        # incorrect configuration.
-        if fsdp_root.process_group != fsdp_module.process_group:
-            raise ValueError(
-                f"For {fsdp_root.sharding_strategy} intra-node process groups do not match"
-            )
-
-        if fsdp_root._inter_node_pg != fsdp_module._inter_node_pg:
-            raise ValueError(
-                f"For {fsdp_root.sharding_strategy}, inter-node process groups do not match"
-            )
+    intra_node_pgs = set()
+    inter_node_pgs = set()
+    inter_node_states = set()
+    for fsdp_module in root_module.fsdp_modules(root_module):
+        # TODO: Change this to handle's sharding strategy if we deprecate
+        # `ShardingStrategy` internally.
+        if fsdp_module.sharding_strategy in HYBRID_SHARDING_STRATEGIES:
+            intra_node_pgs.add(fsdp_module.process_group)
+            inter_node_pgs.add(fsdp_module._inter_node_pg)
+            inter_node_states.add(fsdp_module._inter_node_state)
+    if len(intra_node_pgs) == 0 and len(inter_node_pgs) == 0:
+        # No instances use a hybrid sharding strategy
+        return None
+    error_prefix = "At least one instance uses a hybrid sharding strategy but has no "
+    if len(intra_node_pgs) > 0 and len(inter_node_pgs) == 0:
+        raise AssertionError(error_prefix + "inter-node proces group set")
+    if len(intra_node_pgs) == 0 and len(inter_node_pgs) > 0:
+        raise AssertionError(error_prefix + "intra-node process group set")
+    error_prefix = "Some instances use a hybrid sharding strategy, but "
+    if len(intra_node_pgs) != 1:
+        raise ValueError(error_prefix + "intra-node process groups do not match")
+    if len(inter_node_pgs) != 1:
+        raise ValueError(error_prefix + "inter-node process groups do not match")
+    return next(iter(inter_node_states))
 
 
 @no_type_check
@@ -108,16 +112,17 @@ def _lazy_init(
     # non-root instances
     assert state is root_module
     inconsistent_limit_all_gathers = False
+    inter_node_state = _validate_and_get_hybrid_shard_state(root_module)
     for fsdp_module in state.fsdp_modules(root_module):
         if fsdp_module is root_module:
             continue
 
         if fsdp_module.sharding_strategy in HYBRID_SHARDING_STRATEGIES:
-            _validate_hybrid_shard_setup(state, fsdp_module)
             # Share the allreduce state across FSDP units. This is not strictly necessary
             # as each one already uses the same process group, but can slightly save memory
             # since other FSDP units allreduce state can be garbage collected.
-            fsdp_module._inter_node_state = state._inter_node_state
+            assert inter_node_state is not None, "Implementation error"
+            fsdp_module._inter_node_state = inter_node_state
 
         # Relax the assert for non-root FSDP instances in case the nested
         # initialized module is wrapped again in FSDP later (e.g. after


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90874 [FSDP][5/N] Add manual "wrapping" support for `fully_shard`
* #90871 [FSDP][4/N] Refactor func to share state/init handle attrs
* #90862 [FSDP][3/N] Move `fsdp_modules(root_only=True)` -> `_get_fsdp_root_states()`
* #90861 [FSDP][2/N] Move `fsdp_modules(root_only=False)` -> `_get_fsdp_states()`
* #90864 [FSDP][Easy] Rename `entry` -> `fsdp_module` to be more descriptive
* #90860 [FSDP][1/N] Add `_get_fsdp_states()`
* **#90846 [FSDP] Enable mixed hybrid/non-hybrid sharding strategies**
* #90859 [FSDP][Easy] Use `run_subtests` for hybrid shard test
* #90858 [FSDP][Easy] ufmt files
* #90840 [FSDP][BE] Remove `_module_to_handles`, `HandleConfig`; use term "fqn"; clarify docs

In the context of hybrid sharding strategies, we only need to enforce the same process groups among the instances using a hybrid sharding strategy, not all instances. We can even mix and match the two different hybrid sharding strategies. This PR relaxes the validation to support this.