### PR TITLE
aot autograd: perform input mutations in no_grad()

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -387,6 +387,18 @@ def forward(self, primals_1):
         out_test = f_compiled(*inp)
         self.assertEqual(out_ref, out_test)
 
+    def test_input_mutation_of_leaf_in_no_grad_doesnt_error(self):
+        def f(a):
+            with torch.no_grad():
+                a.add_(1)
+            return a
+        inp = [torch.ones(3, 3, requires_grad=True)]
+
+        f_compiled = aot_function(f, nop)
+        out_ref = f(*inp)
+        out_test = f_compiled(*inp)
+        self.assertEqual(out_ref, out_test)
+
     def test_input_mutation_is_output(self):
         def f(a):
             a.mul_(2)

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1803,7 +1803,8 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Tensor], aot_config: AOTConfi
                             updated_inpt.stride(),
                             updated_inpt.storage_offset(),
                         )
-                    original_inpt.copy_(updated_inpt)
+                    with torch.no_grad():
+                        original_inpt.copy_(updated_inpt)
         else:
             fw_outs = outs
 


### PR DESCRIPTION
This is a (potential) fix for https://github.com/pytorch/pytorch/issues/90844.

What's kinda unfortunate is that `aot_module()` won't error out anymore when you try to mutate leaves that require grad. I added a test that confirms that dynamo will still error out.

I think we agreed that `aot_module()` is a private API, so maybe this separation is acceptable? Open to feedback. I think getting the error to show up in aot autograd properly will take some more work.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90850



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire