### PR TITLE
Build Windows binaries with Visual Studio 2022 Build Tools

### DIFF
--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -8,7 +8,7 @@ export CUDA_VERSION="${DESIRED_CUDA/cu/}"
 export USE_SCCACHE=1
 export SCCACHE_BUCKET=ossci-compiler-cache
 export SCCACHE_IGNORE_SERVER_IO_ERROR=1
-export VC_YEAR=2019
+export VC_YEAR=2022
 
 if [[ "${DESIRED_CUDA}" == *"cu11"* ]]; then
     export BUILD_SPLIT_CUDA=ON

--- a/.circleci/scripts/binary_windows_test.sh
+++ b/.circleci/scripts/binary_windows_test.sh
@@ -4,7 +4,7 @@ set -eux -o pipefail
 source "${BINARY_ENV_FILE:-/c/w/env}"
 
 export CUDA_VERSION="${DESIRED_CUDA/cu/}"
-export VC_YEAR=2019
+export VC_YEAR=2022
 
 pushd "$BUILDER_ROOT"
 

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -144,7 +144,7 @@ class CMake:
             args.append("-GNinja")
         elif IS_WINDOWS:
             generator = os.getenv("CMAKE_GENERATOR", "Visual Studio 15 2017")
-            supported = ["Visual Studio 15 2017", "Visual Studio 16 2019"]
+            supported = ["Visual Studio 16 2019", "Visual Studio 17 2022"]
             if generator not in supported:
                 print("Unsupported `CMAKE_GENERATOR`: " + generator)
                 print("Please set it to one of the following values: ")


### PR DESCRIPTION
This PR enables VS 2022 binaries for build and test jobs. Another PR pytorch/builder#1240 is doing majority of the work.

Closes #87695.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @seemethere @malfet @pytorch/pytorch-dev-infra