### PR TITLE
[FSDP][Easy] ufmt files

### DIFF
--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -1,19 +1,16 @@
 # Owner(s): ["oncall: distributed"]
 
 import contextlib
-from functools import partial
-from collections import Counter
 import sys
+from collections import Counter
+from functools import partial
 
 import torch
-import torch.nn as nn
 import torch.distributed as dist
+import torch.nn as nn
 
 from torch.distributed.distributed_c10d import _rank_not_in_group
-from torch.distributed.fsdp import (
-    FullyShardedDataParallel as FSDP,
-    ShardingStrategy,
-)
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
@@ -54,6 +51,7 @@ def patch_allreduce(new_allreduce):
     finally:
         dist.all_reduce = orig_ar
 
+
 @contextlib.contextmanager
 def patch_reduce_scatter(new_reduce_scatter):
     """
@@ -74,6 +72,7 @@ class MyModel(nn.Module):
         self.lin1 = nn.Linear(10, 10)
         self.lin2 = nn.Linear(10, 10)
         self.lin3 = nn.Linear(10, 10)
+
 
 class TestFSDPHybridShard(FSDPTest):
     @property
@@ -97,24 +96,29 @@ class TestFSDPHybridShard(FSDPTest):
         with err_ctx:
             model = FSDP(model, sharding_strategy=ShardingStrategy._HYBRID_SHARD_ZERO2)
 
-
     @skip_if_lt_x_gpu(2)
     def test_hybrid_shard_strategy_mismatch_raises(self):
         for sharding_strategy in [
             ShardingStrategy._HYBRID_SHARD_ZERO2,
-            ShardingStrategy.HYBRID_SHARD
+            ShardingStrategy.HYBRID_SHARD,
         ]:
             with self.subTest(sharding_strategy=sharding_strategy):
                 model = MyModel().cuda()
                 intra_pg = self.process_group
                 inter_pg = dist.new_group(ranks=[self.rank])
-                model.lin1 = FSDP(model.lin1, process_group=(intra_pg, inter_pg), sharding_strategy=sharding_strategy)
+                model.lin1 = FSDP(
+                    model.lin1,
+                    process_group=(intra_pg, inter_pg),
+                    sharding_strategy=sharding_strategy,
+                )
                 self.assertEqual(model.lin1.process_group, intra_pg)
                 self.assertEqual(model.lin1._inter_node_pg, inter_pg)
                 model = FSDP(model, process_group=intra_pg)
                 inp = torch.randn(4, 10)
                 # Errors during _lazy_init
-                with self.assertRaisesRegex(ValueError, "expect sharding strategies to be the same"):
+                with self.assertRaisesRegex(
+                    ValueError, "expect sharding strategies to be the same"
+                ):
                     model(inp)
 
     @skip_if_lt_x_gpu(2)
@@ -124,25 +128,37 @@ class TestFSDPHybridShard(FSDPTest):
         inter_pg = dist.new_group(ranks=[self.rank])
         # Mismatched process groups for intra-node
         model.lin1 = FSDP(
-            model.lin1, process_group=(intra_pg, inter_pg), sharding_strategy=ShardingStrategy.HYBRID_SHARD
+            model.lin1,
+            process_group=(intra_pg, inter_pg),
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
         )
         model = FSDP(
-            model, process_group=(dist.new_group(), dist.new_group()), sharding_strategy=ShardingStrategy.HYBRID_SHARD
+            model,
+            process_group=(dist.new_group(), dist.new_group()),
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
         )
         # Errors during _lazy_init
         inp = torch.randn(4, 10)
-        with self.assertRaisesRegex(ValueError, "intra-node process groups do not match"):
+        with self.assertRaisesRegex(
+            ValueError, "intra-node process groups do not match"
+        ):
             model(inp)
 
         # Mismatched process groups for inter-node
         model = MyModel().cuda()
         model.lin1 = FSDP(
-            model.lin1, process_group=(intra_pg, inter_pg), sharding_strategy=ShardingStrategy.HYBRID_SHARD
+            model.lin1,
+            process_group=(intra_pg, inter_pg),
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
         )
         model = FSDP(
-            model, process_group=(intra_pg, dist.new_group()), sharding_strategy=ShardingStrategy.HYBRID_SHARD
+            model,
+            process_group=(intra_pg, dist.new_group()),
+            sharding_strategy=ShardingStrategy.HYBRID_SHARD,
         )
-        with self.assertRaisesRegex(ValueError, "inter-node process groups do not match"):
+        with self.assertRaisesRegex(
+            ValueError, "inter-node process groups do not match"
+        ):
             model(inp)
 
     @skip_if_lt_x_gpu(2)
@@ -150,14 +166,13 @@ class TestFSDPHybridShard(FSDPTest):
         pol = ModuleWrapPolicy({nn.Linear})
         model = MyModel().cuda()
         with self.assertRaisesRegex(
-            ValueError,
-            "Expected process_group to be passed in"
+            ValueError, "Expected process_group to be passed in"
         ):
             model = FSDP(
                 model,
                 auto_wrap_policy=pol,
                 process_group=self.process_group,
-                sharding_strategy=ShardingStrategy.HYBRID_SHARD
+                sharding_strategy=ShardingStrategy.HYBRID_SHARD,
             )
 
     # TODO - add test for ZeRO-2 style sharding ensure params are not
@@ -172,7 +187,8 @@ class TestFSDPHybridShard(FSDPTest):
             3. reduce_scatter and allreduce called the expected no. of times
         """
         for sharding_strategy in [
-            ShardingStrategy.HYBRID_SHARD, ShardingStrategy._HYBRID_SHARD_ZERO2
+            ShardingStrategy.HYBRID_SHARD,
+            ShardingStrategy._HYBRID_SHARD_ZERO2,
         ]:
             with self.subTest(sharding_strategy=sharding_strategy):
                 auto_wrap_policy = ModuleWrapPolicy(
@@ -199,16 +215,14 @@ class TestFSDPHybridShard(FSDPTest):
                     # whole world here.
                     self.assertEqual(
                         dist.get_world_size(mod.process_group),
-                        dist.get_world_size(self.process_group)
+                        dist.get_world_size(self.process_group),
                     )
                     intra_node_pgs.add(mod.process_group)
                     inter_node_pg = mod._inter_node_pg
                     inter_node_pgs.add(inter_node_pg)
                     self.assertEqual(1, dist.get_world_size(inter_node_pg))
                     self.assertFalse(_rank_not_in_group(inter_node_pg))
-                    self.assertEqual(
-                        sharding_strategy, mod.sharding_strategy
-                    )
+                    self.assertEqual(sharding_strategy, mod.sharding_strategy)
                 # All fsdp modules should share the same process groups
                 self.assertEqual(1, len(intra_node_pgs))
                 self.assertEqual(1, len(inter_node_pgs))
@@ -223,7 +237,9 @@ class TestFSDPHybridShard(FSDPTest):
                 cntr = Counter()
                 patched_allreduce = partial(patched_collective, orig_ar, cntr)
                 patched_reduce_scatter = partial(patched_collective, orig_rs, cntr)
-                with patch_allreduce(patched_allreduce), patch_reduce_scatter(patched_reduce_scatter):
+                with patch_allreduce(patched_allreduce), patch_reduce_scatter(
+                    patched_reduce_scatter
+                ):
                     inp = fsdp_model.get_input(device=torch.cuda.current_device())
                     out = fsdp_model(inp[0], inp[1])
                     loss = fsdp_model.get_loss(inp, out)
@@ -233,6 +249,7 @@ class TestFSDPHybridShard(FSDPTest):
                 self.assertEqual(num_flat_params, cntr[orig_ar])
                 self.assertEqual(num_flat_params, cntr[orig_rs])
                 dist.barrier()
+
 
 instantiate_parametrized_tests(TestFSDPHybridShard)
 

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -819,7 +819,8 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
         float16 = MixedPrecision(param_dtype=torch.float16)
 
         model = SaveForwardInputsModel(
-            forward_inputs, cast_forward_inputs=False,
+            forward_inputs,
+            cast_forward_inputs=False,
         ).cuda()
         c1, c2 = model.c1, model.c2
         x = torch.zeros(2, 100, device="cuda")
@@ -837,9 +838,7 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
     @skip_if_lt_x_gpu(2)
     def test_float16_on_one_submodule_skip_inputs(self):
         forward_inputs: Dict[nn.Module, torch.Tensor] = {}
-        float16 = MixedPrecision(
-            param_dtype=torch.float16, cast_forward_inputs=False
-        )
+        float16 = MixedPrecision(param_dtype=torch.float16, cast_forward_inputs=False)
 
         model = SaveForwardInputsModel(
             forward_inputs=forward_inputs, cast_forward_inputs=True
@@ -860,9 +859,7 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
     @skip_if_lt_x_gpu(2)
     def test_float16_on_one_submodule_skip_inputs_error(self):
         forward_inputs: Dict[nn.Module, torch.Tensor] = {}
-        float16 = MixedPrecision(
-            param_dtype=torch.float16, cast_forward_inputs=False
-        )
+        float16 = MixedPrecision(param_dtype=torch.float16, cast_forward_inputs=False)
 
         model = SaveForwardInputsModel(
             forward_inputs=forward_inputs, cast_forward_inputs=False
@@ -875,8 +872,7 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
         fsdp = FSDP(model)
 
         with self.assertRaisesRegex(
-            RuntimeError,
-            "mat1 and mat2 must have the same dtype"
+            RuntimeError, "mat1 and mat2 must have the same dtype"
         ):
             fsdp(x).sum().backward()
 

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -231,7 +231,9 @@ class TestFSDPStateDict(FSDPTest):
                 # so bypass the check for now.
                 if isinstance(model, FSDP):
                     self.assertEqual(
-                        fsdp_state_dict, {}, f"Expected empty state_dict but got {fsdp_state_dict} on rank {dist.get_rank()}"
+                        fsdp_state_dict,
+                        {},
+                        f"Expected empty state_dict but got {fsdp_state_dict} on rank {dist.get_rank()}",
                     )
 
     @skip_if_lt_x_gpu(2)

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1374,9 +1374,9 @@ def _gather_orig_param_state(
     This API should only be used when ``use_orig_params`` is True.
     """
     fsdp_state = fsdp_param_info.state
-    assert fsdp_state._use_orig_params, (
-        "_gather_orig_param_state only support use_orig_params=True case"
-    )
+    assert (
+        fsdp_state._use_orig_params
+    ), "_gather_orig_param_state only support use_orig_params=True case"
     flat_param = fsdp_param_info.flat_param
     param_idx = fsdp_param_info.param_indices[fqn]
     if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #90874 [FSDP][5/N] Add manual "wrapping" support for `fully_shard`
* #90871 [FSDP][4/N] Refactor func to share state/init handle attrs
* #90862 [FSDP][3/N] Move `fsdp_modules(root_only=True)` -> `_get_fsdp_root_states()`
* #90861 [FSDP][2/N] Move `fsdp_modules(root_only=False)` -> `_get_fsdp_states()`
* #90864 [FSDP][Easy] Rename `entry` -> `fsdp_module` to be more descriptive
* #90860 [FSDP][1/N] Add `_get_fsdp_states()`
* #90846 [FSDP] Enable mixed hybrid/non-hybrid sharding strategies
* #90859 [FSDP][Easy] Use `run_subtests` for hybrid shard test
* **#90858 [FSDP][Easy] ufmt files**
* #90840 [FSDP][BE] Remove `_module_to_handles`, `HandleConfig`; use term "fqn"; clarify docs

```
ufmt format torch/distributed/fsdp
ufmt format test/distributed/fsdp
```