### PR TITLE
[FSDP][5/N] Add manual "wrapping" support for `fully_shard`

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -72,6 +72,17 @@ def _get_fsdp_states(module: nn.Module) -> List[_FSDPState]:
     return fsdp_states
 
 
+def _get_fsdp_handles(module: nn.Module) -> List:
+    """
+    Returns all ``FlatParamHandle`` s in the module tree rooted at ``module``.
+    """
+    return [
+        handle
+        for fsdp_state in _get_fsdp_states(module)
+        for handle in fsdp_state._handles
+    ]
+
+
 class TrainingState(Enum):
     """
     An enum that indicates the state of a ``FullyShardedDataParallel` instance.
@@ -97,18 +108,6 @@ class HandleTrainingState(Enum):
 def _is_composable(state: _FSDPState):
     # TODO: This is a temporary hack for differentiate between code paths.
     return not isinstance(state, nn.Module)
-
-
-@no_type_check
-def _all_handles(state: _FSDPState) -> List:
-    """
-    Returns all ``FlatParamHandle`` s managed by ``state``.
-    """
-    return (
-        state._handles
-        if _is_composable(state)
-        else state._fsdp_handles(state)  # `FullyShardedDataParallel`
-    )
 
 
 @no_type_check

--- a/torch/distributed/fsdp/_exec_order_utils.py
+++ b/torch/distributed/fsdp/_exec_order_utils.py
@@ -1,14 +1,14 @@
 import itertools
 import warnings
 from enum import auto, Enum
-from typing import cast, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.fsdp._common_utils import (
-    _all_handles,
     _FSDPState,
+    _get_fsdp_handles,
     _get_param_to_fqns,
 )
 from torch.distributed.fsdp.flat_param import FlatParameter, FlatParamHandle
@@ -67,7 +67,7 @@ class _ExecOrderData:
         # same across ranks for the execution order validation to work
         self.handle_to_handle_index: Dict[FlatParamHandle, int] = {}
         # Names are prefixed from the root module
-        self.flat_param_to_prefixed_param_names: Dict[FlatParameter, List[str]] = {}
+        self.param_to_fqn: Dict[FlatParameter, List[str]] = {}
         # Current index in the pre-forward execution order
         self.current_order_index = 0
         self.warn_status = _ExecOrderWarnStatus.NONE
@@ -87,14 +87,15 @@ class _ExecOrderData:
         self.rank = process_group.rank()
         self.world_size = process_group.size()
         # Fix an order over the handles, which should be the same across ranks
-        for handle in _all_handles(state):
+        for handle in _get_fsdp_handles(root_module):
             index = len(self.all_handles)
             self.all_handles.append(handle)
             self.handle_to_handle_index[handle] = index
-        self.flat_param_to_prefixed_param_names = cast(
-            Dict[FlatParameter, List[str]],
-            _get_param_to_fqns(root_module),
-        )
+        self.param_to_fqn = _get_param_to_fqns(root_module)
+        if self.rank == 0:
+            print(
+                f"[Rank 0] param_to_fqn: {[(param.shape, fqn) for param, fqn in self.param_to_fqn.items()]}"
+            )
         # TODO (awgu): We can broadcast the metadata of rank 0's `all_handles`
         # to check that all ranks have the same handles in the same order.
         # https://github.com/pytorch/pytorch/issues/79620
@@ -218,6 +219,10 @@ class _ExecOrderData:
             optional_local_indices: Tuple[
                 Optional[int], ...
             ] = self._get_handle_indices(handles_key)
+            if dist.get_rank() == 0:
+                print(
+                    f"[Rank 0] handles_key: {[h.flat_param._fqns for h in handles_key]}"
+                )
             device = handles_key[0].device  # guaranteed to be non-CPU
             num_valid_indices = sum(
                 (index is not None) for index in optional_local_indices
@@ -253,6 +258,8 @@ class _ExecOrderData:
             world_indices = torch.zeros(  # type: ignore[call-overload]
                 self.world_size * num_valid_indices, **tensor_kwargs
             )
+            if dist.get_rank() == 0:
+                print(f"[Rank 0] optional_local_indices: {optional_local_indices}")
             local_indices = torch.tensor(optional_local_indices, **tensor_kwargs)  # type: ignore[arg-type]
             dist.all_gather_into_tensor(
                 world_indices, local_indices, group=self.process_group
@@ -349,9 +356,7 @@ class _ExecOrderData:
                 continue
             handle = self.all_handles[index]
             flat_param = handle.flat_param
-            prefixed_param_names.append(
-                self.flat_param_to_prefixed_param_names[flat_param]
-            )
+            prefixed_param_names.append(self.param_to_fqn[flat_param])
         return prefixed_param_names
 
     def _get_names_from_handles(
@@ -366,11 +371,9 @@ class _ExecOrderData:
         prefixed_param_names: List[List[str]] = []
         for handle in handles_key:
             flat_param = handle.flat_param
-            if flat_param not in self.flat_param_to_prefixed_param_names:
+            if flat_param not in self.param_to_fqn:
                 continue
-            prefixed_param_names.append(
-                self.flat_param_to_prefixed_param_names[flat_param]
-            )
+            prefixed_param_names.append(self.param_to_fqn[flat_param])
         return prefixed_param_names
 
     def next_iter(self):

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -17,8 +17,8 @@ from torch.distributed._shard.sharded_tensor import (
     ShardedTensor,
 )
 from torch.distributed.fsdp._common_utils import (
-    _all_handles,
     _FSDPState,
+    _get_fsdp_handles,
     _has_fsdp_params,
     _is_composable,
     _module_handles,
@@ -130,7 +130,7 @@ def _common_pre_state_dict_hook(
     _lazy_init(fsdp_state, module)
     # TODO: change to this call after pre_state_dict_hook is in `nn.Module`.
     if fsdp_state._is_root:
-        _clear_grads_if_needed(_all_handles(fsdp_state))
+        _clear_grads_if_needed(_get_fsdp_handles(module))
 
 
 def _common_unshard_pre_state_dict_hook(

--- a/torch/distributed/fsdp/_wrap_utils.py
+++ b/torch/distributed/fsdp/_wrap_utils.py
@@ -5,6 +5,7 @@ from typing import Any, Deque, Dict, List, NamedTuple, Set, Tuple
 
 import torch
 import torch.nn as nn
+from torch.distributed.fsdp._common_utils import _is_fsdp_flattened
 from torch.distributed.fsdp._utils import (
     _contains_batchnorm,
     _override_batchnorm_mixed_precision,
@@ -139,7 +140,7 @@ def _get_submodule_to_states(
         while len(queue) > 0:
             module, prefix = queue.popleft()
             for param_name, param in module.named_parameters(recurse=False):
-                if param not in visited_params:
+                if param not in visited_params and not _is_fsdp_flattened(param):
                     params.append(param)
                     visited_params.add(param)
                     param_names.append(prefix + param_name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#90872 [FSDP][5/N] Add manual "wrapping" support for `fully_shard`**
* #90871 [FSDP][4/N] Refactor func to share state/init handle attrs
* #90862 [FSDP][3/N] Move `fsdp_modules(root_only=True)` -> `_get_fsdp_root_states()`
* #90861 [FSDP][2/N] Move `fsdp_modules(root_only=False)` -> `_get_fsdp_states()`
* #90864 [FSDP][Easy] Rename `entry` -> `fsdp_module` to be more descriptive
* #90860 [FSDP][1/N] Add `_get_fsdp_states()`
* #90846 [FSDP] Enable mixed hybrid/non-hybrid sharding strategies
* #90859 [FSDP][Easy] Use `run_subtests` for hybrid shard test
* #90858 [FSDP][Easy] ufmt files
* #90840 [FSDP][BE] Remove `_module_to_handles`, `HandleConfig`; use term "fqn"; clarify docs

