### PR TITLE
[pytorch profiler] Add step tracker logic to handle multiple sources of step increments

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -28,7 +28,7 @@ __all__ = [
     "profile",
     "ExecutionGraphObserver",
 ]
-
+PROFILER_STEP_NAME = "ProfilerStep"
 
 def supported_activities():
     """
@@ -496,6 +496,9 @@ class profile(_KinetoProfile):
             (ProfilerAction.RECORD, None): [self.stop_trace, self._trace_ready],
             (ProfilerAction.RECORD_AND_SAVE, None): [self.stop_trace, self._trace_ready]
         }
+        # Start tracking increments to profiler step, this will be used
+        # by Kineto
+        prof.KinetoStepTracker.init_step_count(PROFILER_STEP_NAME)
 
     def __enter__(self):
         self.start()
@@ -503,6 +506,7 @@ class profile(_KinetoProfile):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
+        prof.KinetoStepTracker.erase_step_count(PROFILER_STEP_NAME)
 
     def start(self):
         self._transit_action(ProfilerAction.NONE, self.current_action)
@@ -527,8 +531,8 @@ class profile(_KinetoProfile):
         self.current_action = self.schedule(self.step_num)
 
         self._transit_action(prev_action, self.current_action)
+        prof.KinetoStepTracker.increment_step(PROFILER_STEP_NAME)
 
-        prof.kineto_step()
         if self.record_steps:
             self.step_rec_fn = prof.record_function("ProfilerStep#" + str(cur_step))
             self.step_rec_fn.__enter__()


### PR DESCRIPTION

Pull Request resolved: https://github.com/pytorch/pytorch/pull/90880

# Summary 
Enables multiple step trackers. Currently we only had one place to mark that a step() has occurred in the program. This was via pytorch profiler step().
We are now working on adding an Optimizer step hook - https://github.com/pytorch/pytorch/issues/88446 
- This could mean programs that already call profiler.step() every iteration can end up double incrementing steps
- If a model uses multiple optimizers we can also have double or more counting of the step.

## Solution
We fix this by adding a layer of abstraction before calling step() to the kineto library. The idea is to maintain steps per requester in a dictionary
```
{
   "ProfilerStep": 100,  # triggered by profiler step() call
   "Optimizer1Step": 100,   # Optimizer 1 or 2 are just examples, could be SGD, Adam etc
   "Optimizer2Step": 100,
}
```
To figure out the global step count just take max on the dict values (100).
```
{
   "ProfilerStep": 100,  
   "Optimizer1Step": 101,   # Optimizer1 got incremented first say
   "Optimizer2Step": 100,
}
```
Then global step count is 101

## Calling kineto
We only call the kineto step() function when global count increments.

# Test Plan:
Added a unit test
   buck2 run mode/dev-nosan caffe2/test:profiler

Differential Revision: D41751157

