### PR TITLE
Make dynamo.export preserve user input/output format

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -5,7 +5,6 @@ import torch
 
 import torch._dynamo.test_case
 import torch._dynamo.testing
-import torch.utils._pytree as pytree
 from torch.fx.experimental.proxy_tensor import make_fx
 
 
@@ -116,9 +115,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -141,9 +139,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -184,9 +181,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -211,9 +207,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -231,9 +226,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -251,9 +245,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -273,7 +266,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps)
+        
 
         dynamo_result = out_graph(*flat_input)
 
@@ -296,7 +289,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps)
+        
 
         dynamo_result = out_graph(*flat_input)
 
@@ -319,7 +312,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps)
+        
 
         dynamo_result = out_graph(*flat_input)
 
@@ -343,7 +336,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps)
+        
 
         dynamo_result = out_graph(*flat_input)
 
@@ -367,9 +360,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps_rand)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps_rand)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -392,9 +384,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps_rand)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps_rand)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -417,9 +408,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps_rand)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps_rand)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -442,9 +432,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps_rand)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps_rand)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -471,9 +460,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps_rand)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps_rand)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -496,9 +484,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps_rand)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps_rand)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -581,9 +568,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -606,9 +592,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -651,9 +636,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -678,9 +662,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -698,9 +681,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -718,9 +700,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, inp, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inp)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -740,9 +721,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(inp)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -763,7 +743,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps)
+        
 
         dynamo_result = out_graph(*flat_input)
 
@@ -786,7 +766,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps)
+        
 
         dynamo_result = out_graph(*flat_input)
 
@@ -810,7 +790,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps)
+        
 
         dynamo_result = out_graph(*flat_input)
 
@@ -834,9 +814,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps_rand)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps_rand)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -863,9 +842,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps_rand)
-
-        dynamo_result = out_graph(*flat_input)
+        
+        dynamo_result = out_graph(*inps_rand)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -888,9 +866,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps, aten_graph=True)
         out_graph = exported[0]
-        flat_input, _ = pytree.tree_flatten(inps_rand)
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps_rand)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -266,9 +266,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -289,9 +288,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -312,9 +310,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -336,9 +333,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -722,7 +718,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         exported = torch._dynamo.export(func, *inps, aten_graph=True)
         out_graph = exported[0]
 
-        dynamo_result = out_graph(inp)
+        dynamo_result = out_graph(*inps)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -743,9 +739,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps, aten_graph=True)
         out_graph = exported[0]
-        
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -766,9 +761,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps, aten_graph=True)
         out_graph = exported[0]
-        
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -790,9 +784,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps)
         out_graph = exported[0]
-        
 
-        dynamo_result = out_graph(*flat_input)
+        dynamo_result = out_graph(*inps)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
 
@@ -842,7 +835,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         exported = torch._dynamo.export(func, *inps, aten_graph=True)
         out_graph = exported[0]
-        
+
         dynamo_result = out_graph(*inps_rand)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -8,7 +8,7 @@ import unittest
 from abc import ABC
 from collections import namedtuple
 from copy import deepcopy
-from typing import Dict, List, Tuple
+from typing import Dict, List
 from unittest.mock import patch
 
 import numpy as np

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -2210,6 +2210,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         )
         self.assertEqual(gm(inp).shape, f(inp).shape)
 
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -8,7 +8,7 @@ import unittest
 from abc import ABC
 from collections import namedtuple
 from copy import deepcopy
-from typing import Dict, List
+from typing import List
 from unittest.mock import patch
 
 import numpy as np
@@ -2209,17 +2209,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             f, torch.randn(4, 5), aten_graph=True, tracing_mode="symbolic"
         )
         self.assertEqual(gm(inp).shape, f(inp).shape)
-
-    def test_input_container_type(self):
-        def f(x: torch.Tensor, y: List[torch.Tensor]) -> Dict[str, torch.Tensor]:
-            return {"a": x.sum() + sum(y).sum()}
-
-        inp = (torch.randn(6, 5), [torch.randn(6, 5), torch.randn(6, 5)])
-
-        gm, _ = torch._dynamo.export(f, *inp, aten_graph=True, tracing_mode="symbolic")
-
-        self.assertEqual(gm(*inp), f(*inp))
-
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -633,7 +633,7 @@ class _PyTreeCodeGen(CodeGen):
         if self.pytree_info is None:
             return super().gen_fn_def(free_vars, maybe_return_annotation)
         function_args = self.pytree_info.orig_args
-        has_orig_self = (function_args[0] == 'self')
+        has_orig_self = (function_args[0] == 'self') if len(function_args) > 0 else False
         if has_orig_self:
             free_vars.insert(0, 'self')
         function_definition = super().gen_fn_def(function_args[:], maybe_return_annotation)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90884


Currently, dynamo flattens the user input so when user reuses the input they use for tracing, exported graph wouldn't work as it would expect flat args.  This PR changes this behaviour by explicitly wrapping the dynamo produced graph with correct user input/output format. 

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire