### PR TITLE
[CUDA 12] Fix the endif guard position for cusparse const descriptors

### DIFF
--- a/aten/src/ATen/cuda/CUDASparseDescriptors.h
+++ b/aten/src/ATen/cuda/CUDASparseDescriptors.h
@@ -133,7 +133,6 @@ class TORCH_CUDA_CPP_API CuSparseDnMatDescriptor
  public:
   explicit CuSparseDnMatDescriptor(const Tensor& input, int64_t batch_offset = -1);
 };
-#endif //AT_USE_HIPSPARSE_GENERIC_52_API() || AT_USE_CUSPARSE_GENERIC_API()
 
 class TORCH_CUDA_CPP_API CuSparseDnVecDescriptor
     : public CuSparseDescriptor<cusparseDnVecDescr, &cusparseDestroyDnVec> {
@@ -144,10 +143,7 @@ class TORCH_CUDA_CPP_API CuSparseDnVecDescriptor
 class TORCH_CUDA_CPP_API CuSparseSpMatDescriptor
     : public CuSparseDescriptor<cusparseSpMatDescr, &cusparseDestroySpMat> {};
 
-class TORCH_CUDA_CPP_API CuSparseSpMatCsrDescriptor
-    : public CuSparseSpMatDescriptor {
- public:
-  explicit CuSparseSpMatCsrDescriptor(const Tensor& input, int64_t batch_offset = -1);
+#endif //AT_USE_HIPSPARSE_GENERIC_52_API() || (AT_USE_CUSPARSE_GENERIC_API() || AT_USE_CUSPARSE_NON_CONST_DESCRIPTORS())
 
 #if AT_USE_CUSPARSE_CONST_DESCRIPTORS()
   class TORCH_CUDA_CPP_API CuSparseDnMatDescriptor
@@ -173,6 +169,11 @@ class TORCH_CUDA_CPP_API CuSparseSpMatCsrDescriptor
             cusparseSpMatDescr,
             &cusparseDestroySpMat> {};
 #endif // AT_USE_CUSPARSE_CONST_DESCRIPTORS()
+
+class TORCH_CUDA_CPP_API CuSparseSpMatCsrDescriptor
+    : public CuSparseSpMatDescriptor {
+ public:
+  explicit CuSparseSpMatCsrDescriptor(const Tensor& input, int64_t batch_offset = -1);
 
 #if defined(USE_ROCM) || (defined(CUDA_VERSION) && CUDA_VERSION >= 11000)
   std::tuple<int64_t, int64_t, int64_t> get_size() {


### PR DESCRIPTION
[CUDA 12] Fix the endif guard position for cusparse const descriptors

Related https://github.com/pytorch/pytorch/pull/90765