### PR TITLE
Sparse compressed mm: fix for orthogonal inputs

### DIFF
--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -650,22 +650,15 @@ Tensor& _sparse_csr_mm_out(
     const Tensor& mat1,
     const Tensor& mat2,
     Tensor& result) {
-  Tensor zero;
-  if (result.is_sparse_csr()) {
-    // TODO: replace with at::zeros when it's implemented for sparse csr
-    zero = at::empty({mat1.size(0), mat2.size(1)}, mat2.options());
-  } else {
-    zero = at::zeros({mat1.size(0), mat2.size(1)}, mat2.options());
-  }
+  auto zero = at::zeros({mat1.size(0), mat2.size(1)}, mat2.options());
   return at::addmm_out(result, zero, mat1, mat2, 0.0, 1.0);
 }
 
 Tensor _sparse_csr_mm(const Tensor& mat1, const Tensor& mat2) {
   if (mat1.is_sparse_csr() && mat2.is_sparse_csr()) {
     // Return sparse
-    // TODO: replace with at::zeros when it's implemented for sparse csr
     return at::addmm(
-        at::empty({mat1.size(0), mat2.size(1)}, mat2.options()),
+        at::zeros({mat1.size(0), mat2.size(1)}, mat2.options()),
         mat1,
         mat2,
         0.0,

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -1739,8 +1739,18 @@ class TestSparseCSR(TestCase):
                 res_dense = ld @ rd
                 self.assertEqual(res_sparse.to_dense(), res_dense)
 
+        def test_orthogonal_inputs(lhs_layout, rhs_layout):
+            ones = torch.ones(2, 2, device=device, dtype=dtype)
+            zeros = torch.zeros(2, 2, device=device, dtype=dtype)
+            x = torch.cat((ones, zeros), -1).to_sparse(layout=lhs_layout)
+            y = torch.cat((zeros, ones), -2).to_sparse(layout=rhs_layout)
+            res = x @ y
+            res_expected = torch.zeros(*res.shape, device=device, dtype=dtype, layout=res.layout)
+            self.assertEqual(res, res_expected)
+
         for lhs_layout, rhs_layout in itertools.product([torch.sparse_csr, torch.sparse_csc], repeat=2):
             test_empty_inputs(lhs_layout, rhs_layout)
+            test_orthogonal_inputs(lhs_layout, rhs_layout)
 
         for i in [2, 4]:
             for j in [2, 4, 7]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90917
* #90763

Fixes https://github.com/pytorch/pytorch/issues/90836