### PR TITLE
[FSDP] Fix input grad propagation when using param mixed precision

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -757,10 +757,17 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
         )
         # Use an input with dtype not equal to the mixed precision
         # `param_dtype` so that it gets cast
-        x_float = torch.randn(32, 1024, device="cuda", dtype=torch.float32)
-        x_float.requires_grad_()
+        x_float = torch.randn(
+            (32, 1024),
+            device="cuda",
+            dtype=torch.float32,
+            requires_grad=True,
+        )
         fsdp_model(x_float).sum().backward()
         self.assertTrue(x_float.grad is not None)
+        # Check that `x_float` preserves its dtype, meaning that the gradient
+        # propagated via `ToCopyBackward0`
+        self.assertEqual(x_float.grad.dtype, torch.float32)
 
 
 class TestFSDPMixedPrecisionUnsharded(TestFSDPMixedPrecision):

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -456,10 +456,13 @@ def _cast_fp_inputs_to_dtype(
     def cast_fn(x: torch.Tensor) -> torch.Tensor:
         if not torch.is_floating_point(x) or x.dtype == dtype:
             return x
-        # Cast this in-place to ensure that gradients propagate to `x` in the
-        # case that it requires gradients
-        x.data = x.to(dtype)
-        return x
+        # Cast this in-place to ensure that gradients propagate to `x` if it
+        # requires gradient
+        if x.requires_grad:
+            x.data = x.to(dtype)
+            return x
+        # Otherwise, cast this out-of-place
+        return x.to(dtype)
 
     with torch.no_grad():
         return (_apply_to_tensors(cast_fn, args), _apply_to_tensors(cast_fn, kwargs))

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -622,8 +622,6 @@ def _post_backward_hook(
                         state=state._inter_node_state,
                         grad=new_sharded_grad,
                     )
-                if state.rank == 0:
-                    print(f"[Rank 0] flat_param: {flat_param.dtype} new_sharded_grad: {new_sharded_grad.dtype}")
                 _cast_grad_to_param_dtype(state, new_sharded_grad, flat_param)
                 # Save the sharded gradient in `_saved_grad_shard` to support
                 # gradient accumulation -- for multiple backwards, the gradient

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -456,16 +456,9 @@ def _cast_fp_inputs_to_dtype(
     def cast_fn(x: torch.Tensor) -> torch.Tensor:
         if not torch.is_floating_point(x) or x.dtype == dtype:
             return x
-        # Cast this in-place to ensure that gradients propagate to `x` if it
-        # requires gradient
-        if x.requires_grad:
-            x.data = x.to(dtype)
-            return x
-        # Otherwise, cast this out-of-place
         return x.to(dtype)
 
-    with torch.no_grad():
-        return (_apply_to_tensors(cast_fn, args), _apply_to_tensors(cast_fn, kwargs))
+    return (_apply_to_tensors(cast_fn, args), _apply_to_tensors(cast_fn, kwargs))
 
 
 @no_type_check

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -456,12 +456,10 @@ def _cast_fp_inputs_to_dtype(
     def cast_fn(x: torch.Tensor) -> torch.Tensor:
         if not torch.is_floating_point(x) or x.dtype == dtype:
             return x
-        y = x.to(dtype)
-        # Explicitly copy over `requires_grad` since this runs inside
-        # `torch.no_grad()`
-        if x.is_leaf:
-            y.requires_grad = x.requires_grad
-        return y
+        # Cast this in-place to ensure that gradients propagate to `x` in the
+        # case that it requires gradients
+        x.data = x.to(dtype)
+        return x
 
     with torch.no_grad():
         return (_apply_to_tensors(cast_fn, args), _apply_to_tensors(cast_fn, kwargs))
@@ -621,6 +619,8 @@ def _post_backward_hook(
                         state=state._inter_node_state,
                         grad=new_sharded_grad,
                     )
+                if state.rank == 0:
+                    print(f"[Rank 0] flat_param: {flat_param.dtype} new_sharded_grad: {new_sharded_grad.dtype}")
                 _cast_grad_to_param_dtype(state, new_sharded_grad, flat_param)
                 # Save the sharded gradient in `_saved_grad_shard` to support
                 # gradient accumulation -- for multiple backwards, the gradient


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#90921 [FSDP] Fix input grad propagation when using param mixed precision**
* #90858 [FSDP][Easy] ufmt files
* #90840 [FSDP][BE] Remove `_module_to_handles`, `HandleConfig`; use term "fqn"; clarify docs

For parameter mixed precision, we cast the inputs to the low precision parameter dtype. If the input has tensors that require gradient, then we must cast them in place in order for them to receive a gradient. The cast should be tracked by autograd (e.g. with `grad_fn` equal to `ToCopyBackward0`). This removes the `torch.no_grad` context when calling `_apply_to_tensors`.