### PR TITLE
generate device context managers in inductor code

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -524,7 +524,7 @@ class TritonFuture:
 
 class AsyncCompile:
     def __init__(self):
-        self._context_keepalive = None
+        pass
 
     @staticmethod
     @functools.lru_cache(1)
@@ -614,9 +614,6 @@ class AsyncCompile:
 
     def triton(self, source_code):
         _compile_start()
-        # if self._context_keepalive is None:
-        #     # Workaround `CUDA: Error- context is destroyed`
-        #     self._context_keepalive = torch.tensor([1], device="cuda")
 
         if config.compile_threads > 1:
             major, minor = torch.cuda.get_device_capability()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -614,9 +614,9 @@ class AsyncCompile:
 
     def triton(self, source_code):
         _compile_start()
-        if self._context_keepalive is None:
-            # Workaround `CUDA: Error- context is destroyed`
-            self._context_keepalive = torch.tensor([1], device="cuda")
+        # if self._context_keepalive is None:
+        #     # Workaround `CUDA: Error- context is destroyed`
+        #     self._context_keepalive = torch.tensor([1], device="cuda")
 
         if config.compile_threads > 1:
             major, minor = torch.cuda.get_device_capability()

--- a/torch/_inductor/codegen/triton_template.py
+++ b/torch/_inductor/codegen/triton_template.py
@@ -234,29 +234,27 @@ class TritonTemplateKernel(TritonKernel):
             OUT_H = self.args_dict["OUT_H"]
             OUT_W = self.args_dict["OUT_W"]
             KERNEL_N = self.args_dict["KERNEL_N"]
-            with code.indent():
-                code.splice(
-                    f"""
-                    def grid_{name}(META):
-                        return (
-                            triton.cdiv({BATCH} * {OUT_H} * {OUT_W}, META["BLOCK_M"]),
-                            triton.cdiv({KERNEL_N}, META["BLOCK_N"]),
-                        )
-                    """
-                )
+            code.splice(
+                f"""
+                def grid_{name}(META):
+                    return (
+                        triton.cdiv({BATCH} * {OUT_H} * {OUT_W}, META["BLOCK_M"]),
+                        triton.cdiv({KERNEL_N}, META["BLOCK_N"]),
+                    )
+                """
+            )
         if isinstance(self.node, ir.MatrixMultiply):
             M = self.args_dict["M"]
             N = self.args_dict["N"]
-            with code.indent():
-                code.splice(
-                    f"""
-                    def grid_{name}(META):
-                        return (
-                            triton.cdiv({M}, META["BLOCK_M"]) * triton.cdiv({N}, META["BLOCK_N"]),
-                            META["SPLIT_K"],
-                        )
-                    """
-                )
+            code.splice(
+                f"""
+                def grid_{name}(META):
+                    return (
+                        triton.cdiv({M}, META["BLOCK_M"]) * triton.cdiv({N}, META["BLOCK_N"]),
+                        META["SPLIT_K"],
+                    )
+                """
+            )
         return code.getvalue()
 
     def call_kernel(self, wrapper, name: str):
@@ -272,7 +270,9 @@ class TritonTemplateKernel(TritonKernel):
             ", " + extra_args if extra_args and len(extra_args) > 0 else ""
         )
         args_kwargs = args + ", " + self_const_kwargs
-        wrapper.writeline(self.gen_grid(name))
+        lines = self.gen_grid(name).split("\n")
+        for l in lines:
+            wrapper.writeline(l)
         wrapper.writeline(f"{name}[grid_{name}]({args_kwargs})")
 
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -91,6 +91,7 @@ class MemoryPlanningState:
         assert not item.is_reused
         self.reuse_pool[key].append(item)
 
+
 @dataclasses.dataclass
 class EnterCudaDeviceContextManagerLine:
     device_idx: int
@@ -98,10 +99,11 @@ class EnterCudaDeviceContextManagerLine:
     def codegen(self, code: IndentedBuffer):
         code.writeline(f"with torch.cuda.device({self.device_idx}):")
 
-class ExitCudaDeviceContextManagerLine:
 
+class ExitCudaDeviceContextManagerLine:
     def codegen(self, code: IndentedBuffer):
         pass
+
 
 class MemoryPlanningLine:
     def plan(self, state: MemoryPlanningState) -> "MemoryPlanningLine":
@@ -532,7 +534,7 @@ class WrapperCodeGen(CodeGen):
                 f"{name} = rand_strided("
                 f"{V.graph.sizevars.codegen_benchmark_shape_tuple(shape)}, "
                 f"{V.graph.sizevars.codegen_benchmark_shape_tuple(stride)}, "
-                f"device='{device.type}', dtype={dtype})"
+                f"device='{device}', dtype={dtype})"
             )
 
         output.writelines(["", "", 'if __name__ == "__main__":'])

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1119,7 +1119,16 @@ class Scheduler:
                     or node.is_template()
                 ):
                     self.flush()
+                if (device != self.current_device):
+                    if device.type == "cuda":
+                        if self.current_device and self.current_device.type == "cuda":
+                            V.graph.wrapper_code.codegen_cuda_device_guard_exit()
+                            # close context manager:
+                        V.graph.wrapper_code.codegen_cuda_device_guard_enter(device.index)
+                    elif self.current_device and self.current_device.type == "cuda":
+                            V.graph.wrapper_code.codegen_cuda_device_guard_exit()
                     self.current_device = device
+
 
             self.buffer_names_to_free.update(node.last_usage)
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -1119,16 +1119,17 @@ class Scheduler:
                     or node.is_template()
                 ):
                     self.flush()
-                if (device != self.current_device):
+                if device != self.current_device:
                     if device.type == "cuda":
                         if self.current_device and self.current_device.type == "cuda":
                             V.graph.wrapper_code.codegen_cuda_device_guard_exit()
-                            # close context manager:
-                        V.graph.wrapper_code.codegen_cuda_device_guard_enter(device.index)
+                        assert device.index is not None, "device should have an index"
+                        V.graph.wrapper_code.codegen_cuda_device_guard_enter(
+                            device.index
+                        )
                     elif self.current_device and self.current_device.type == "cuda":
-                            V.graph.wrapper_code.codegen_cuda_device_guard_exit()
+                        V.graph.wrapper_code.codegen_cuda_device_guard_exit()
                     self.current_device = device
-
 
             self.buffer_names_to_free.update(node.last_usage)
 

--- a/torch/_inductor/triton_ops/autotune.py
+++ b/torch/_inductor/triton_ops/autotune.py
@@ -78,7 +78,6 @@ class CachingAutotuner(KernelInterface):
             )
             return
 
-        torch.cuda.set_device(torch.cuda.current_device())
         with torch.cuda.device(compile_meta["device"]):
             # need to initialize context
             torch.cuda.synchronize(torch.cuda.current_device())

--- a/torch/_inductor/triton_ops/autotune.py
+++ b/torch/_inductor/triton_ops/autotune.py
@@ -78,6 +78,7 @@ class CachingAutotuner(KernelInterface):
             )
             return
 
+        # load binary to the correct device
         with torch.cuda.device(compile_meta["device"]):
             # need to initialize context
             torch.cuda.synchronize(torch.cuda.current_device())


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchdynamo/issues/1717, https://github.com/pytorch/pytorch/issues/93478

<s>TODO: add test with multiple devices, figure out extra context initialization</s>

Problems:
<s>It still initializes context on 0-th device that it shouldn't, I'll take a look where that happens and fix before landing</s>
It adds a python device context manages, that is absurdly slow and takes ~2.5 us (should be nanoseconds). That's not a problem for real models, because it'll be called just once, but it is a bit of an inconvenience for microbenchmarking, we should make that context manager more performant (won't fix in this PR)
It still can have bugs for graphs that run on multiple devices and can have buffers incorrectly shared between multiple device by memory reuse, if that happens that'll need to be solved separately.  

Generated code:
```
def call(args):
    arg0_1, arg1_1 = args
    args.clear()
    with torch.cuda.device(1):
        buf0 = empty_strided((4, ), (1, ), device='cuda', dtype=torch.float32)
        stream1 = get_cuda_stream(1)
        triton_fused_div_0.run(arg0_1, arg1_1, buf0, 4, grid=grid(4), stream=stream1)
        del arg0_1
        del arg1_1
        return (buf0, )
```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire