### PR TITLE
[inductor] Remove flag of bmm's dim m and n in shape padding

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -93,9 +93,6 @@ dynamo_import = inductor_import.replace("inductor", "dynamo")
 # Pad input tensors of matmul/bmm/addmm to leverage Tensor Cores in NVIDIA GPUs
 shape_padding = os.environ.get("TORCHINDUCTOR_SHAPE_PADDING", "0") == "1"
 
-# Pad input tensors in dimension N and M of bmm to leverage Tensor Cores in NVIDIA GPUs
-shape_padding_bmm = os.environ.get("TORCHINDUCTOR_SHAPE_PADDING_BMM", "1") == "1"
-
 # Fx-based linear/matmul/bmm + permute/transpose vertical fusion
 permute_fusion = os.environ.get("TORCHINDUCTOR_PERMUTE_FUSION", "0") == "1"
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -193,6 +193,7 @@ def addmm(input, mat1, mat2, *, beta=1, alpha=1):
 
 
 def pad_addmm(input, mat1, mat2, m_padded_length, k_padded_length, n_padded_length):
+    # addmm decomp with padding will go through pad_addmm multiple times if multiple dimensions are needed to be padded
     if k_padded_length != 0:
         mat1 = pad_dim(mat1, k_padded_length, 1)
         mat2 = pad_dim(mat2, k_padded_length, 0)
@@ -286,8 +287,6 @@ def should_pad_bench(mat1, mat2, op, input=None):
                 fast_flush=True,
             )[0]
         else:
-            if k_padded_length == 0 and not config.shape_padding_bmm:
-                return False
             pad_time = do_bench(
                 lambda: pad_bmm(
                     mat1_pad,
@@ -325,6 +324,7 @@ def mm_decomp(mat1, mat2):
 
 
 def pad_mm(mat1, mat2, m_padded_length, k_padded_length, n_padded_length):
+    # mm_decomp will go through pad_mm multiple times if multiple dimensions are needed to be padded
     if k_padded_length != 0:
         mat1 = pad_dim(mat1, k_padded_length, 1)
         mat2 = pad_dim(mat2, k_padded_length, 0)
@@ -348,20 +348,19 @@ def bmm_decomp(mat1, mat2):
         k_padded_length = get_padded_length(mat1.shape[2], get_alignment_size(mat1))
         n_padded_length = get_padded_length(mat2.shape[2], get_alignment_size(mat2))
 
-        if k_padded_length != 0 or (
-            config.shape_padding_bmm and (n_padded_length != 0 or m_padded_length != 0)
-        ):
+        if k_padded_length != 0 or n_padded_length != 0 or m_padded_length != 0:
             pad_bmm(mat1, mat2, m_padded_length, k_padded_length, n_padded_length)
 
     return NotImplemented  # go directly to lowering
 
 
 def pad_bmm(mat1, mat2, m_padded_length, k_padded_length, n_padded_length):
+    # bmm_decomp will go through pad_bmm multiple times if multiple dimensions are needed to be padded
     if k_padded_length != 0:
         mat1 = pad_dim(mat1, k_padded_length, 2)
         mat2 = pad_dim(mat2, k_padded_length, 1)
         return torch.ops.aten.bmm(mat1, mat2)
-    elif config.shape_padding_bmm and n_padded_length != 0:
+    elif n_padded_length != 0:
         mat2 = pad_dim(mat2, n_padded_length, 2)
         return torch.ops.aten.bmm(mat1, mat2)[:, :, :-n_padded_length].contiguous()
     else:


### PR DESCRIPTION
Summary: There was an OOM issue in two internal models when turning on padding bmm with dim m and n with shape padding optimization, so added a flag to turned on/off for the internal models. The issue was gone now so removing the flag.

Differential Revision: D42074557



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire