### PR TITLE
use pytree to allow any input format for cuda graph

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3985,25 +3985,63 @@ torch.cuda.synchronize()
             self.assertEqual(scaler._scale, scale)
             self.assertEqual(scaler._growth_tracker, growth_tracker)
 
-    @unittest.skipIf((not TEST_CUDA) or
-                     TEST_WITH_ROCM or
-                     int(torch.version.cuda.split(".")[0]) < 11, "CUDA >= 11.0 required for graphs")
-    @parametrize('with_amp,cache_enabled', [(False, False), (True, False), subtest((True, True),
-                 decorators=[unittest.expectedFailure])],
-                 name_fn=lambda x, y: '{}{}'.format({True: "with_amp", False: "without_amp"}[x],
-                                                    {True: "_cache_enabled", False: "_cache_disabled"}[y] if x else ''))
-    def test_graph_make_graphed_callables(self, with_amp, cache_enabled):
+    @unittest.skipIf(
+        (not TEST_CUDA) or TEST_WITH_ROCM or int(torch.version.cuda.split(".")[0]) < 11,
+        "CUDA >= 11.0 required for graphs",
+    )
+    @parametrize(
+        "with_amp,cache_enabled,allow_unused_input",
+        [
+            (False, False, True),
+            (True, False, True),
+            subtest((True, True, True), decorators=[unittest.expectedFailure]),
+            subtest((False, False, False), decorators=[unittest.expectedFailure]),
+        ],
+        name_fn=lambda x, y, z: "{}{}{}".format(
+            {True: "with_amp", False: "without_amp"}[x],
+            {True: "_cache_enabled", False: "_cache_disabled"}[y] if x else "",
+            {True: "_allow_unused_input", False: "_not_allow_unused_input"}[z],
+        ),
+    )
+    def test_graph_make_graphed_callables(
+        self, with_amp, cache_enabled, allow_unused_input
+    ):
         torch.manual_seed(5)
         torch.cuda.manual_seed(5)
 
         N, D_in, H, D_out = 640, 4096, 2048, 1024
 
+        class MLP1(torch.nn.Module):
+            def __init__(self, D_in: int, H: int, D_out: int):
+                super().__init__()
+                self.net_1 = torch.nn.Sequential(
+                    torch.nn.Linear(D_in, H), torch.nn.Dropout(p=0.1)
+                ).cuda()
+                self.net_2 = torch.nn.Sequential(
+                    torch.nn.Linear(H, D_out), torch.nn.Dropout(p=0.2)
+                ).cuda()
+
+            def forward(self, input_dict: dict):
+                x = input_dict["x"]
+                return self.net_2(self.net_1(x))
+
+        class MLP2(torch.nn.Module):
+            def __init__(self, D_in: int, H: int, D_out: int):
+                super().__init__()
+                self.net_1 = torch.nn.Sequential(
+                    torch.nn.Linear(D_in, H), torch.nn.Dropout(p=0.1)
+                ).cuda()
+                self.net_2 = torch.nn.Sequential(
+                    torch.nn.Linear(H, D_out), torch.nn.Dropout(p=0.2)
+                ).cuda()
+
+            def forward(self, x):
+                return {"output": self.net_2(self.net_1(x))}
+
         models = []
         for _ in range(2):
-            model_section1 = torch.nn.Sequential(torch.nn.Linear(D_in, H),
-                                                 torch.nn.Dropout(p=0.1)).cuda()
-            model_section2 = torch.nn.Sequential(torch.nn.Linear(H, D_out),
-                                                 torch.nn.Dropout(p=0.2)).cuda()
+            model_section1 = MLP1(D_in, H, H).cuda()
+            model_section2 = MLP2(H, H, D_out).cuda()
             models.append(torch.nn.Sequential(model_section1, model_section2))
 
         model_graphed = models[0]
@@ -4014,27 +4052,42 @@ torch.cuda.synchronize()
         opt_graphed = torch.optim.SGD(model_graphed.parameters(), lr=0.1)
         opt_control = torch.optim.SGD(model_control.parameters(), lr=0.1)
 
-        x = torch.randn(N, D_in, device='cuda')
-        h = torch.randn(N, H, device='cuda', requires_grad=True)
-        y_pred = torch.randn(N, D_out, device='cuda', requires_grad=True)
-        y = torch.randn(N, D_out, device='cuda')
+        x = torch.randn(N, D_in, device="cuda")
+        h = torch.randn(N, H, device="cuda", requires_grad=True)
+        unused_input = torch.randn(N, H, device="cuda", requires_grad=True)
+        y_pred = torch.randn(N, D_out, device="cuda", requires_grad=True)
+        y = torch.randn(N, D_out, device="cuda")
 
         loss_fn_control = torch.nn.functional.mse_loss
         relu_control = torch.nn.functional.relu
 
         # This is a good stress test. It graphs four callables: two Modules and two python functions.
         with torch.cuda.amp.autocast(with_amp, cache_enabled=cache_enabled):
-            model_graphed[0], model_graphed[1], relu_graphed, loss_fn_graphed = \
-                torch.cuda.make_graphed_callables((model_graphed[0], model_graphed[1], relu_control, loss_fn_control),
-                                                  ((x,), (h,), (y_pred,), (y_pred, y)))
+            (
+                model_graphed[0],
+                model_graphed[1],
+                relu_graphed,
+                loss_fn_graphed,
+            ) = torch.cuda.make_graphed_callables(
+                (model_graphed[0], model_graphed[1], relu_control, loss_fn_control),
+                (
+                    ({"x": x, "unused_input": unused_input},),
+                    (h,),
+                    (y_pred,),
+                    (y_pred, y),
+                ),
+                allow_unused_input=allow_unused_input,
+            )
 
         real_inputs = [torch.rand_like(x) for _ in range(10)]
         real_targets = [torch.rand_like(y) for _ in range(10)]
 
-        for m, opt, relu, loss_fn in zip((model_graphed, model_control),
-                                         (opt_graphed, opt_control),
-                                         (relu_graphed, relu_control),
-                                         (loss_fn_graphed, loss_fn_control)):
+        for m, opt, relu, loss_fn in zip(
+            (model_graphed, model_control),
+            (opt_graphed, opt_control),
+            (relu_graphed, relu_control),
+            (loss_fn_graphed, loss_fn_control),
+        ):
             # Resets RNC states before iterations for graphed and ungraphed models,
             # so dropout math should be bitwise identical for both.
             torch.manual_seed(5)
@@ -4042,7 +4095,7 @@ torch.cuda.synchronize()
             for data, target in zip(real_inputs, real_targets):
                 opt.zero_grad(set_to_none=True)
                 with torch.cuda.amp.autocast(with_amp, cache_enabled=cache_enabled):
-                    y_pred = m(data)
+                    y_pred = m({"x": data, "unused_input": unused_input})["output"]
                     y_pred = relu(y_pred)
                     loss = loss_fn(y_pred, target)
                     loss.backward()
@@ -4054,7 +4107,9 @@ torch.cuda.synchronize()
         # We graphed the models in training mode. Eval should still run ungraphed.
         model_graphed.eval()
         model_control.eval()
-        self.assertEqual(model_graphed(real_inputs[0]), model_control(real_inputs[0]))
+        self.assertEqual(
+            model_graphed({"x": real_inputs[0]}), model_control({"x": real_inputs[0]})
+        )
 
     def _test_graphed_optimizer(self, steps_warmup, steps_train, optimizer_ctor, kwargs):
         for actually_do_graphs in (True, False):

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -2,7 +2,8 @@ import gc
 import torch
 
 from ._utils import _dummy_type
-
+from torch.utils._pytree import tree_flatten as _tree_flatten
+from torch.utils._pytree import tree_unflatten as _tree_unflatten
 
 if not hasattr(torch._C, '_CudaStreamBase'):
     # Define dummy base classes
@@ -177,7 +178,7 @@ class graph(object):
         # returning None should propagate exceptions from either capture_end or stream_ctx.__exit__()
 
 
-def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
+def make_graphed_callables(callables, sample_args, num_warmup_iters=3, allow_unused_input=False):
     r"""
     Accepts callables (functions or :class:`nn.Module<torch.nn.Module>`\ s)
     and returns graphed versions.
@@ -207,6 +208,8 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
             If a tuple of callables was passed, ``sample_args`` must be tuple of tuples of argument Tensors.
         num_warmup_iters (int): The number of warmup iterations. Currently, ``DataDistributedParallel`` needs
             11 iterations for warm up. Default: ``3``.
+        allow_unused_input (bool): If False, specifying inputs that were not used when computing outputs
+            (and therefore their grad is always zero) is an error. Defaults to False.
 
     .. note::
         The ``requires_grad`` state of each Tensor in ``sample_args`` must match the state
@@ -216,8 +219,7 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
         This API is in beta and may change in future releases.
 
     .. warning::
-        ``sample_args`` for each callable must be a tuple of Tensors. Other types and keyword args
-        are not allowed.
+        ``sample_args`` for each callable must contain only Tensors. Other types are not allowed.
 
     .. warning::
         Returned callables do not support higher order differentiation (e.g., double backward).
@@ -242,9 +244,6 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
     .. warning::
         The automatic mixed precision is supported in :func:`~torch.cuda.make_graphed_callables` only with disabled
         caching. The context manager `torch.cuda.amp.autocast()` must have `cache_enabled=False`.
-
-    .. warning::
-        All Tensor outputs of graphed callables must require grad.
     """
     if torch.is_autocast_enabled() and torch.is_autocast_cache_enabled():
         raise RuntimeError("make_graphed_callables does not support the autocast caching. Please set `cache_enabled=False`.")
@@ -256,6 +255,8 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
         callables = (callables,)
         sample_args = (sample_args,)
 
+    flatten_sample_args = []
+
     for c, args in zip(callables, sample_args):
         if isinstance(c, torch.nn.Module):
             assert len(c._backward_hooks) == 0 and len(c._forward_hooks) == 0 and len(c._forward_pre_hooks) == 0, \
@@ -264,16 +265,18 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
             assert all(b.requires_grad is False for b in c.buffers()), "In any :class:`~torch.nn.Module` passed to " + \
                 ":func:`~make_graphed_callables`, only parameters may be trainable. All buffers must have " + \
                 "``requires_grad=False``."
-        assert all(isinstance(arg, torch.Tensor) for arg in args), "In the beta API, sample_args " + \
-            "for each callable must be a tuple of Tensors. Other types and keyword args are not allowed."
+        flatten_arg, _ = _tree_flatten(args)
+        flatten_sample_args.append(tuple(flatten_arg))
+        assert all(isinstance(arg, torch.Tensor) for arg in flatten_arg), "In the beta API, sample_args " + \
+            "for each callable must contain only Tensors. Other types are not allowed."
 
 
     # If a callable is an nn.Module, its graph's full input surface is the args the user explicitly
     # passes to forward (ie, its sample_args) AND the module's parameter attributes.
-    per_callable_len_user_args = [len(args) for args in sample_args]
+    per_callable_len_user_args = [len(args) for args in flatten_sample_args]
     per_callable_module_params = [tuple(c.parameters()) if isinstance(c, torch.nn.Module) else ()
                                   for c in callables]
-    per_callable_static_input_surfaces = [sample_args[i] + per_callable_module_params[i]
+    per_callable_static_input_surfaces = [flatten_sample_args[i] + per_callable_module_params[i]
                                           for i in range(len(callables))]
 
     fwd_graphs = [torch.cuda.CUDAGraph() for _ in range(len(callables))]
@@ -290,13 +293,12 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
                                                     sample_args,
                                                     per_callable_static_input_surfaces):
             for _ in range(num_warmup_iters):
-                outputs = func(*args)
-                outputs = (outputs,) if isinstance(outputs, torch.Tensor) else outputs
-                grad_inputs = torch.autograd.grad(outputs=outputs,
+                outputs, _ = _tree_flatten(func(*args))
+                grad_inputs = torch.autograd.grad(outputs=tuple(o for o in outputs if o.requires_grad),
                                                   inputs=tuple(i for i in static_input_surface if i.requires_grad),
-                                                  grad_outputs=tuple(torch.empty_like(o) for o in outputs),
+                                                  grad_outputs=tuple(torch.empty_like(o) for o in outputs if o.requires_grad),
                                                   only_inputs=True,
-                                                  allow_unused=False)
+                                                  allow_unused=allow_unused_input)
             del outputs, grad_inputs
     torch.cuda.synchronize()
 
@@ -306,21 +308,17 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
 
     # Capture forward graphs
     per_callable_static_outputs = []
-    per_callable_output_was_tensor = []
+    per_callable_output_unflatten_spec = []
     for func, args, fwd_graph in zip(callables,
                                      sample_args,
                                      fwd_graphs):
         with torch.cuda.graph(fwd_graph, pool=mempool):
             outputs = func(*args)
 
-        # Assumes model output is a tensor or tuple of tensors
-        if isinstance(outputs, torch.Tensor):
-            per_callable_output_was_tensor.append(True)
-            outputs = (outputs,)
-        else:
-            per_callable_output_was_tensor.append(False)
+        flatten_outputs, spec = _tree_flatten(outputs)
+        per_callable_static_outputs.append(tuple(flatten_outputs))
+        per_callable_output_unflatten_spec.append(spec)
 
-        per_callable_static_outputs.append(outputs)
 
     # Capture backward graphs in reverse order
     per_callable_static_grad_outputs = []
@@ -332,15 +330,15 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
                 reversed(per_callable_module_params)):
 
         # For now, assumes all static_outputs require grad
-        assert all(o.requires_grad for o in static_outputs), "Outputs of graphed callables must require grad."
-        static_grad_outputs = tuple(torch.empty_like(o) for o in static_outputs)
+        # assert all(o.requires_grad for o in static_outputs), "Outputs of graphed callables must require grad."
+        static_grad_outputs = tuple(torch.empty_like(o) if o.requires_grad else None for o in static_outputs)
 
         with torch.cuda.graph(bwd_graph, pool=mempool):
-            grad_inputs = torch.autograd.grad(outputs=static_outputs,
+            grad_inputs = torch.autograd.grad(outputs=tuple(o for o in static_outputs if o.requires_grad),
                                               inputs=tuple(i for i in static_input_surface if i.requires_grad),
-                                              grad_outputs=static_grad_outputs,
+                                              grad_outputs=tuple(o for o in static_grad_outputs if o is not None),
                                               only_inputs=True,
-                                              allow_unused=False)
+                                              allow_unused=allow_unused_input)
 
         # Constructs a tuple suitable for returning from Graphed.backward:
         # Pads out the actually-needed grads with Nones in gradient slots for inputs that don't require grad.
@@ -367,7 +365,7 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
                                        bwd_graph,
                                        module_params,
                                        len_user_args,
-                                       output_was_tensor,
+                                       output_unflatten_spec,
                                        static_input_surface,
                                        static_outputs,
                                        static_grad_outputs,
@@ -386,10 +384,9 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
             @staticmethod
             @torch.autograd.function.once_differentiable
             def backward(ctx, *grads):
+                assert len(grads) == len(static_grad_outputs)
                 for g, grad in zip(static_grad_outputs, grads):
-                    if g is None:
-                        assert grad is None
-                    else:
+                    if g is not None:
                         # don't copy if autograd gods have been kind and the
                         # incoming grad is already in the right place
                         if g.data_ptr() != grad.data_ptr():
@@ -404,8 +401,9 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
             # Runs the autograd function with inputs == all inputs to the graph that might require grad
             # (explicit user args + module parameters)
             # Assumes module params didn't change since capture.
-            out = Graphed.apply(*(user_args + module_params))
-            return out[0] if output_was_tensor else out
+            flatten_user_args, _ = _tree_flatten(user_args)
+            out = Graphed.apply(*(tuple(flatten_user_args) + module_params))
+            return _tree_unflatten(out, output_unflatten_spec)
 
         return functionalized
 
@@ -416,7 +414,7 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
                                                  bwd_graphs[i],
                                                  per_callable_module_params[i],
                                                  per_callable_len_user_args[i],
-                                                 per_callable_output_was_tensor[i],
+                                                 per_callable_output_unflatten_spec[i],
                                                  per_callable_static_input_surfaces[i],
                                                  per_callable_static_outputs[i],
                                                  per_callable_static_grad_outputs[i],


### PR DESCRIPTION
Summary:
1. use pytree to allow any input format for make_graphed_callables
2. add allow_unused_input argument for make_graphed_callables

Test Plan: buck2 test mode/dev-nosan  //caffe2/test:cuda --  --print-passing-details

Differential Revision: D42077976

