### PR TITLE
Add `any_chain()` in upstream

### DIFF
--- a/torch/fx/passes/operator_support.py
+++ b/torch/fx/passes/operator_support.py
@@ -8,7 +8,7 @@ from .shape_prop import TensorMetadata
 from .tools_common import get_node_target, CALLABLE_NODE_OPS
 
 
-__all__ = ['OperatorSupportBase', 'OperatorSupport', 'create_op_support', 'chain', 'OpSupports']
+__all__ = ['OperatorSupportBase', 'OperatorSupport', 'create_op_support', 'chain', 'OpSupports', 'any_chain']
 
 # fx.Node.target typename, as returned by `get_node_target()`
 TargetTypeName = str
@@ -158,6 +158,20 @@ def chain(*op_support: OperatorSupportBase) -> OperatorSupportBase:
             for x in op_support
         )
     return create_op_support(_chain)
+
+
+@compatibility(is_backward_compatible=False)
+def any_chain(*op_support: OperatorSupportBase) -> OperatorSupportBase:
+    """Combines a sequence of `OperatorSupportBase` instances to form a single `OperatorSupportBase`
+    instance by evaluating each input `OperatorSupportBase` instance, and returns True if
+    any of it reports True.
+    """
+    def _any_chain(submods, node) -> bool:
+        return any(
+            x.is_node_supported(submods, node)
+            for x in op_support
+        )
+    return create_op_support(_any_chain)
 
 
 @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Summary: I need any chain. Current chain is logical AND.

Test Plan: arc lint, follow-up diffs use it.

Differential Revision: D42078837

