### PR TITLE
[Experimental] ROCm: Reduce NUM_PROCS to 1 for ROCm tests

### DIFF
--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -14,6 +14,7 @@ NUM_PROCS = (
     else 2
 )
 
+
 class ShardJob:
     def __init__(self, test_times: Dict[str, float]):
         self.test_times = test_times

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -5,8 +5,8 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from tools.stats.import_test_stats import get_disabled_tests, get_slow_tests
 
-NUM_PROCS = 1 if os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1" else 2
-
+NUM_PROCS = 1 if (os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1" or
+                  os.getenv('PYTORCH_TEST_WITH_ROCM', '0') == '1') else 2
 
 class ShardJob:
     def __init__(self, test_times: Dict[str, float]):

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -5,8 +5,14 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from tools.stats.import_test_stats import get_disabled_tests, get_slow_tests
 
-NUM_PROCS = 1 if (os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1" or
-                  os.getenv('PYTORCH_TEST_WITH_ROCM', '0') == '1') else 2
+NUM_PROCS = (
+    1
+    if (
+        os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
+        or os.getenv("PYTORCH_TEST_WITH_ROCM", "0") == "1"
+    )
+    else 2
+)
 
 class ShardJob:
     def __init__(self, test_times: Dict[str, float]):


### PR DESCRIPTION
As per https://github.com/pytorch/pytorch/issues/90940 ROCm runners are timing out frequently.
Setting NUM_PROCS to 1 will disable concurrent run of tests.

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>



cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport