### PR TITLE
[ao][docs] adding info on weight only quantization

### DIFF
--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -97,8 +97,10 @@ The following table compares the differences between Eager Mode Quantization and
 There are three types of quantization supported:
 
 1. dynamic quantization (weights quantized with activations read/stored in
-   floating point and quantized for compute). Note: weight only quantization (weights quantized, no activations) for ops like embeddings, uses the
-   dynamic quantization APIs
+   floating point and quantized for compute)
+
+    * quantization for embeddings, often called weight only quantization (weights quantized, no activations) uses the
+    dynamic quantization APIs though its technically different
 2. static quantization (weights quantized, activations quantized, calibration
    required post training)
 3. static quantization aware training (weights quantized, activations quantized,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #90979

Summary: see https://github.com/pytorch/pytorch/issues/90553,
embedding/weight only quantization was previously not documented well

Test Plan: see docs tests

Reviewers:

Subscribers:

Tasks:

Tags: