### PR TITLE
Allow Process Group to support multiple backends (#88330)

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLTest.cpp
@@ -22,7 +22,7 @@ class NCCLTestBase {
  public:
   NCCLTestBase(
       const std::string& path,
-      const std::chrono::milliseconds pgTimeout = kProcessGroupDefaultTimeout)
+      const std::chrono::milliseconds pgTimeout = kBackendDefaultTimeout)
       : path_(path), pgTimeout_(pgTimeout) {}
 
   NCCLTestBase(NCCLTestBase&& other) {
@@ -56,7 +56,7 @@ class NCCLTest : public NCCLTestBase {
   NCCLTest(
       const std::string& path,
       int worldSize,
-      std::chrono::milliseconds pgTimeout = kProcessGroupDefaultTimeout)
+      std::chrono::milliseconds pgTimeout = kBackendDefaultTimeout)
       : NCCLTestBase(path, pgTimeout),
         numDevices_(cudaNumDevices()),
         worldSize_(worldSize) {

--- a/test/distributed/algorithms/ddp_comm_hooks/test_ddp_hooks.py
+++ b/test/distributed/algorithms/ddp_comm_hooks/test_ddp_hooks.py
@@ -71,6 +71,16 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
         except OSError:
             pass
 
+    def _get_process_group_nccl(self):
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        return dist.distributed_c10d._get_default_group()
+
     @property
     def world_size(self):
         return 2
@@ -116,8 +126,7 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
         This unit test verifies the ``allreduce`` hook registered case gives same result
         with no hook registered case.
         """
-        store = dist.FileStore(self.file_name, self.world_size)
-        process_group = dist.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group_nccl()
 
         # No hook registered case, get the reference grads.
         reference_grads = self._get_grads(process_group, None)
@@ -133,8 +142,7 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
         This unit test verifies the ``fp16 compress`` hook registered case
         gives close result with no hook registered case.
         """
-        store = dist.FileStore(self.file_name, self.world_size)
-        process_group = dist.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group_nccl()
 
         # No hook registered case, get the reference grads.
         reference_grads = self._get_grads(process_group, None)
@@ -150,8 +158,7 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
         This unit test verifies the ``quantize per tensor`` hook registered case
         gives close result with no hook registered case.
         """
-        store = dist.FileStore(self.file_name, self.world_size)
-        process_group = dist.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group_nccl()
 
         # No hook registered case, get the reference grads.
         reference_grads = self._get_grads(process_group, None)
@@ -167,8 +174,7 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
         This unit test verifies the ``quantize per channel`` hook registered case
         gives close result with no hook registered case.
         """
-        store = dist.FileStore(self.file_name, self.world_size)
-        process_group = dist.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group_nccl()
 
         # No hook registered case, get the reference grads.
         reference_grads = self._get_grads(process_group, None)
@@ -187,8 +193,7 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
         This unit test verifies the ``noop`` hook registered case and a subsequent allreduce
         gives same result with no hook registered case.
         """
-        store = dist.FileStore(self.file_name, self.world_size)
-        process_group = dist.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group_nccl()
 
         # No hook registered case, get the reference grads.
         reference_grads = self._get_grads(process_group, None)
@@ -203,9 +208,7 @@ class DistributedDataParallelCommHookTest(MultiProcessTestCase):
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
     def test_is_last_hook(self):
-
-        store = dist.FileStore(self.file_name, self.world_size)
-        process_group = dist.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group_nccl()
 
         def hook(flags, bucket):
             flags.append(bucket.is_last())

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -642,7 +642,8 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
             pg.gather(output_ts, tensors, opts)
 
         with self.assertRaisesRegex(
-            RuntimeError, "Tensor list must be nonempty"
+            # throws error message from dispatcher
+            RuntimeError, "There were no tensor arguments to this function"
         ):
             opts = c10d.GatherOptions()
             opts.rootRank = 0
@@ -776,7 +777,8 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
             pg.scatter(tensors, scatter_list, opts)
 
         with self.assertRaisesRegex(
-            RuntimeError, "Tensor list must be nonempty"
+            # throws error message from dispatcher
+            RuntimeError, "There were no tensor arguments to this function"
         ):
             opts = c10d.ScatterOptions()
             opts.rootRank = 0
@@ -1039,13 +1041,13 @@ class DistributedDataParallelTest(
 
     def _get_process_group(self):
         store = self._get_store()
-        return c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        c10d.init_process_group("nccl", store=store, rank=self.rank, world_size=self.world_size)
+        return c10d.distributed_c10d._get_default_group()
 
     def _test_nccl_backend(
         self, devices, device_ids, multi_device=False, gradient_as_bucket_view=False
     ):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
         self._test_ddp_with_process_group(
             process_group, devices, device_ids, multi_device, gradient_as_bucket_view
         )
@@ -1157,8 +1159,7 @@ class DistributedDataParallelTest(
 
         self.assertTrue(len(gpus) >= 2, "expecting at least 2 gpus per process")
 
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         gpus = gpus[:2]
         model = DoubleGpuNet(gpus)
@@ -1194,8 +1195,7 @@ class DistributedDataParallelTest(
             )
 
     def _test_fp16(self, gradient_as_bucket_view=False):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         gpus = gpus_for_rank(self.world_size)[self.rank]
         model = nn.Linear(1, 1, bias=False).cuda(gpus[0]).half()
@@ -1236,8 +1236,7 @@ class DistributedDataParallelTest(
         Note: this test can be sped up by only running it on a CPU module
         once DistributedDataParallel supports them.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         class ForwardReturnValueModule(nn.Module):
             def __init__(self):
@@ -1335,8 +1334,7 @@ class DistributedDataParallelTest(
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
     def test_ddp_with_lazy_parameters(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
         with self.assertRaisesRegex(
             RuntimeError, "Modules with uninitialized parameters"
         ):
@@ -1502,8 +1500,7 @@ class DistributedDataParallelTest(
         Note: this test can be sped up by only running it on a CPU module
         once DistributedDataParallel supports them.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         class MultipleOutputModule(nn.Module):
             def __init__(self):
@@ -1565,8 +1562,7 @@ class DistributedDataParallelTest(
         Note: this test can be sped up by only running it on a CPU module
         once DistributedDataParallel supports them.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         class NoGradModule(nn.Module):
             def __init__(self):
@@ -1612,8 +1608,7 @@ class DistributedDataParallelTest(
         # module.
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
         devices = [torch.device("cuda:" + str(i)) for i in int_devices]
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
         global_batch_size = self.world_size
 
         model, ddp_model, input, target = self._prepare_single_device_module(
@@ -1672,8 +1667,7 @@ class DistributedDataParallelTest(
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
     def test_failure_recovery(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         # need to create a separate file for the recovered FileStore, because
         # the original one will be deleted when destructing the first FileStore.
@@ -1718,11 +1712,11 @@ class DistributedDataParallelTest(
             loss.backward()
 
         del ddp
-        del process_group
-        del store  # this will delete self.file_name
+        c10d.destroy_process_group(process_group)
 
         store = c10d.FileStore(recovery_filename, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        c10d.init_process_group("nccl", store=store, rank=self.rank, world_size=self.world_size)
+        process_group = c10d.distributed_c10d._get_default_group()
         ddp = DistributedDataParallel(
             model,
             device_ids=[device_id],
@@ -1753,8 +1747,7 @@ class DistributedDataParallelTest(
         self.assertFalse(dist.is_initialized())
 
     def _test_grad_layout(self, replica_devices, layer_devs, local_batch_size):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         global_batch_size = local_batch_size * self.world_size
 
@@ -1909,8 +1902,7 @@ class DistributedDataParallelTest(
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
     def test_param_layout_mismatch_error(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         dev0 = torch.device("cuda:" + str(gpus_for_rank(self.world_size)[self.rank][0]))
         layer_devs = dev0
@@ -1965,8 +1957,7 @@ class DistributedDataParallelTest(
         This unit test verifies whether the Future object is passed properly using nccl backend.
         The hook callback function creates a Future object and sets a value to it.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         # Get GPU model with simple_hook registered.
         gpu_model = self._gpu_model_with_ddp_comm_hook(process_group, self._simple_hook)
@@ -1984,8 +1975,7 @@ class DistributedDataParallelTest(
         Without the then callback, the future_value in reducer is no longer
         a PyObject, and this unit test verifies future_value is properly checked.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         def allreduce_hook(
             state: object, bucket: dist.GradBucket
@@ -2010,8 +2000,7 @@ class DistributedDataParallelTest(
         This unit test verifies whether default Python DDP communication hooks ALLREDUCE, FP16_COMPRESS
         and BF16_COMPRESS, can give the same result with the case of no hook registered.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         # For these default DDP comm hooks, the only state is process group.
         state = process_group
@@ -2039,8 +2028,7 @@ class DistributedDataParallelTest(
         This unit test verifies whether wrapping the ALLREDUCE and POWER_SGD hooks with
         the FP16_WRAPPER can give the same result as when there is no hook registered.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
         powerSGD_state = powerSGD.PowerSGDState(process_group=process_group)
 
         hook_args = [
@@ -2064,8 +2052,7 @@ class DistributedDataParallelTest(
         This unit test verifies whether wrapping the ALLREDUCE and POWER_SGD hooks with
         the BF16_WRAPPER can give the same result as when there is no hook registered.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
         powerSGD_state = powerSGD.PowerSGDState(process_group=process_group)
 
         hook_args = [
@@ -2089,8 +2076,7 @@ class DistributedDataParallelTest(
         This unit test verifies whether Python DDP communication hook POWER_SGD
         can give the same result with the case of no hook registered.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         # Get GPU model with the hook registered.
         # Test the hook with different algorithmic configs.
@@ -2117,8 +2103,7 @@ class DistributedDataParallelTest(
         This unit test verifies whether built-in C++ DDP communication hooks ALLREDUCE and FP16_COMPRESS
         can give the same result with the case of no hook registered.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         for comm_hook_type in [
             dist.BuiltinCommHookType.ALLREDUCE,
@@ -2214,8 +2199,7 @@ class DistributedDataParallelTest(
         This unit test verifies whether a DDP communication hook that calls allreduce and then
         multiplies the result by ten and divides by two gives the expected result.
         """
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         def allreduce_with_then_hook(
             state: object, bucket: dist.GradBucket
@@ -2254,8 +2238,7 @@ class DistributedDataParallelTest(
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
     def test_ddp_weight_sharing(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
 
         size = 2048 * 2048
         dev = self.rank
@@ -2358,8 +2341,7 @@ class DistributedDataParallelTest(
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
     def test_channels_last_contig(self):
-        store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        process_group = self._get_process_group()
         device = torch.device(f"cuda:{self.rank}")
         tensor = torch.ones((2, 16, 768, 1152), dtype=torch.float32, device=device).to(memory_format=torch.channels_last)
         process_group.broadcast([tensor]).wait()
@@ -2659,7 +2641,8 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
     @skip_if_lt_x_gpu(2)
     def test_broadcast_coalesced_nccl(self):
         store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        c10d.init_process_group(backend="nccl", store=store, rank=self.rank, world_size=self.world_size)
+        process_group = c10d.distributed_c10d._get_default_group()
         device = torch.device("cuda:%d" % self.rank)
         ranks = [0, 1]
         for root_rank in ranks:
@@ -2669,7 +2652,8 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
     @skip_if_lt_x_gpu(2)
     def test_all_reduce_coalesced_nccl(self):
         store = c10d.FileStore(self.file_name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        c10d.init_process_group(backend="nccl", store=store, rank=self.rank, world_size=self.world_size)
+        process_group = c10d.distributed_c10d._get_default_group()
         device = torch.device("cuda:%d" % self.rank)
         tensors = [torch.full((60 + i,), self.rank + 1 + i, device=device, dtype=torch.float) for i in range(5)]
         torch.distributed.all_reduce_coalesced(tensors, group=process_group)
@@ -2718,8 +2702,6 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
 
         # Test with new_group
         pg = c10d.new_group([0, 1], pg_options=pg_opts)
-        # test if the process group constructed with high priority stream
-        self.assertTrue(pg.options.is_high_priority_stream)
         # test the process group works as expected
         t = torch.tensor([self.rank + 1] * 10).cuda(self.rank)
         pg.allreduce(t).wait()

--- a/test/distributed/test_c10d_spawn_ucc.py
+++ b/test/distributed/test_c10d_spawn_ucc.py
@@ -29,7 +29,8 @@ if sys.version_info < (3, 9):
         @classmethod
         def _init_pg_ucc(cls, rank, filename, world_size):
             store = c10d.FileStore(filename, world_size)
-            return c10d.ProcessGroupUCC(store, rank, world_size)
+            c10d.init_process_group(backend="ucc", store=store, rank=rank, world_size=world_size)
+            return c10d.distributed_c10d._get_default_group()
 
         @sandcastle_skip_if(not TEST_MULTIGPU, "At least 2 CUDA GPUS needed")
         @sandcastle_skip_if(NO_UCC, "UCC needed")

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -286,6 +286,8 @@ ALLOW_LIST = [
     ("aten::sym_numel", datetime.date(2022, 10, 1)),
     ("aten::_flash_scaled_dot_product_attention", datetime.date(2022, 11, 1)),
     ("aten::_scaled_dot_product_attention", datetime.date(2022, 11, 1)),
+    # Distributed c10d ops are all going to be updated
+    ("c10d::.*", datetime.date(2022, 12, 31)),
     ("aten::to_padded_tensor", datetime.date(2022, 10, 1)),
     ("aten::nested_to_padded_tensor", datetime.date(2022, 10, 1)),
     ("aten::nested_tensor", datetime.date(2022, 10, 15)),

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -449,3 +449,10 @@ def _verify_params_across_processes(
     logger: Optional[Logger],
 ): ...
 def _make_nccl_premul_sum(factor: Union[float, List[Tensor]]) -> ReduceOp: ...
+
+class Backend:
+    def __init__(
+        self,
+        rank: int,
+        size: int,
+    ): ...

--- a/torch/csrc/distributed/c10d/Backend.cpp
+++ b/torch/csrc/distributed/c10d/Backend.cpp
@@ -4,7 +4,8 @@
 
 namespace c10d {
 
-Backend::Backend(int rank, int size) : rank_(rank), size_(size) {
+Backend::Backend(int rank, int size)
+    : rank_(rank), size_(size), dist_debug_level_(debug_level()) {
   C10_LOG_API_USAGE_ONCE("c10d.backend");
 }
 

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -10,39 +10,56 @@
 #include <ATen/ATen.h>
 #include <c10/macros/Macros.h>
 
-#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/Work.hpp>
 #include <torch/csrc/distributed/c10d/Types.hpp>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 #include <torch/csrc/distributed/c10d/debug.h>
 #include <torch/csrc/distributed/c10d/sequence_num.hpp>
 
-constexpr auto kDefaultTimeout =
+constexpr auto kBackendDefaultTimeout =
     std::chrono::milliseconds(30 * 60 * 1000);
 
 namespace c10d {
 
-// Options is a base struct that defines the basic options
-// when constructing a Backend. Each Backend subclass should
-// extend this struct and define its options if it wants to provide more
-// config options (beyond basic ones defined here) to end user.
-struct TORCH_API Options : torch::CustomClassHolder {
-  explicit Options(
-      std::string backend,
-      std::chrono::milliseconds timeout = kDefaultTimeout)
-      : timeout(timeout), backend(backend) {}
-  virtual ~Options() = default;
-
-  std::chrono::milliseconds timeout;
-
-  // backend name
-  const std::string backend;
-};
-
 class TORCH_API Backend : public torch::CustomClassHolder {
  public:
+
+  // Backend Options is a base struct that defines the basic options
+  // when constructing a Backend. Each Backend subclass should
+  // extend this struct and define its options if it wants to provide more
+  // config options (beyond basic ones defined here) to end user.
+  struct TORCH_API Options : torch::CustomClassHolder {
+    explicit Options(
+        std::string backend,
+        std::chrono::milliseconds timeout = kBackendDefaultTimeout)
+        : timeout(timeout), backend(backend) {}
+    virtual ~Options() = default;
+
+    std::chrono::milliseconds timeout;
+
+    // backend name
+    const std::string backend;
+  };
+
   explicit Backend(int rank, int size);
   virtual ~Backend() = 0;
+
+  int getRank() const {
+    return rank_;
+  }
+
+  int getSize() const {
+    return size_;
+  }
+
+  virtual void startCoalescing() {
+    // no-op for backends that have not implemented startCoalescing
+  }
+
+  virtual void endCoalescing(
+      std::vector<c10::intrusive_ptr<Work>>& /* reqs */) {
+    // no-op for backends that have not implemented endCoalescing
+  }
 
   // Subclasses must override this method to return the backend name
   virtual const std::string getBackendName() const {
@@ -255,14 +272,6 @@ class TORCH_API Backend : public torch::CustomClassHolder {
         c10::str("Backend ", getBackendName(), "does not support barrier"));
   }
 
-  int getRank() const {
-    return rank_;
-  }
-
-  int getSize() const {
-    return size_;
-  }
-
  protected:
   // Implementations of this interface need to call this to setup
   // appropriate logging etc.
@@ -272,6 +281,9 @@ class TORCH_API Backend : public torch::CustomClassHolder {
   c10::optional<c10d::SequenceNum> sequenceNum_ = c10::nullopt;
   const int rank_;
   const int size_;
+  // Debug level setting. It is parsed once when ProcessGroup is constructed and
+  // remains the same across use of this process group.
+  DebugLevel dist_debug_level_;
 };
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/Ops.cpp
+++ b/torch/csrc/distributed/c10d/Ops.cpp
@@ -8,238 +8,6 @@
 namespace c10d {
 namespace {
 
-std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> broadcast_(
-    at::TensorList tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    int64_t root_rank,
-    int64_t root_tensor,
-    int64_t timeout) {
-  auto tensor_vec = tensors.vec();
-  auto work = process_group->broadcast(
-      tensor_vec,
-      BroadcastOptions{
-          root_rank, root_tensor, std::chrono::milliseconds(timeout)});
-
-  return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      std::move(tensor_vec), work);
-}
-
-std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> allreduce_(
-    at::TensorList tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const c10::intrusive_ptr<ReduceOp>& reduce_op,
-    int64_t timeout) {
-  auto tensor_vec = tensors.vec();
-  auto work = process_group->allreduce(
-      tensor_vec,
-      AllreduceOptions{*reduce_op.get(), std::chrono::milliseconds(timeout)});
-
-  // Return input tensors as output tensors to make inplace allreduce look like
-  // a functional API, so that make_fx can correctly build the dependencies in
-  // the graph later.
-  return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      std::move(tensor_vec), work);
-}
-
-c10::intrusive_ptr<Work> allreduce_coalesced_(
-    at::TensorList tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const c10::intrusive_ptr<ReduceOp>& reduce_op,
-    int64_t timeout) {
-  auto tensor_vec = tensors.vec();
-  AllreduceCoalescedOptions opts = AllreduceCoalescedOptions{};
-  opts.reduceOp = *reduce_op.get();
-  opts.timeout = std::chrono::milliseconds(timeout);
-
-  return process_group->allreduce_coalesced(tensor_vec, opts);
-}
-
-c10::intrusive_ptr<Work> reduce_(
-    at::TensorList tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const c10::intrusive_ptr<ReduceOp>& reduce_op,
-    int64_t root_rank,
-    int64_t root_tensor,
-    int64_t timeout) {
-  auto tensor_vec = tensors.vec();
-  return process_group->reduce(
-      tensor_vec,
-      ReduceOptions{
-          *reduce_op.get(),
-          root_rank,
-          root_tensor,
-          std::chrono::milliseconds(timeout)});
-}
-
-std::tuple<std::vector<std::vector<at::Tensor>>, c10::intrusive_ptr<Work>>
-allgather_(
-    const std::vector<std::vector<at::Tensor>>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    int64_t timeout) {
-  auto work = process_group->allgather(
-      const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
-      const_cast<std::vector<at::Tensor>&>(input_tensors),
-      AllgatherOptions{std::chrono::milliseconds(timeout)});
-
-  // Copy output tensors (not storage) so that this can be used in a functional
-  // manner
-  return std::
-      tuple<std::vector<std::vector<at::Tensor>>, c10::intrusive_ptr<Work>>(
-          output_tensors, work);
-}
-
-std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_(
-    at::Tensor& output_tensor,
-    at::Tensor& input_tensor,
-    const c10::intrusive_ptr<ProcessGroup>& process_group) {
-  auto work = process_group->_allgather_base(output_tensor, input_tensor);
-
-  return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(output_tensor, work);
-}
-
-c10::intrusive_ptr<Work> allgather_coalesced_(
-    const std::vector<std::vector<at::Tensor>>& output_lists,
-    const std::vector<at::Tensor>& input_list,
-    const c10::intrusive_ptr<ProcessGroup>& process_group) {
-  return process_group->allgather_coalesced(
-      const_cast<std::vector<std::vector<at::Tensor>>&>(output_lists),
-      const_cast<std::vector<at::Tensor>&>(input_list));
-}
-
-std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> reduce_scatter_(
-    const std::vector<at::Tensor>& output_tensors,
-    const std::vector<std::vector<at::Tensor>>& input_tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const c10::intrusive_ptr<ReduceOp>& reduce_op,
-    int64_t timeout) {
-  auto work = process_group->reduce_scatter(
-      const_cast<std::vector<at::Tensor>&>(output_tensors),
-      const_cast<std::vector<std::vector<at::Tensor>>&>(input_tensors),
-      ReduceScatterOptions{
-          *reduce_op.get(), std::chrono::milliseconds(timeout)});
-
-  return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      output_tensors, work);
-}
-
-std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _reduce_scatter_base_(
-    at::Tensor& output_tensor,
-    at::Tensor& input_tensor,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const c10::intrusive_ptr<ReduceOp>& reduce_op,
-    int64_t timeout) {
-  auto work = process_group->_reduce_scatter_base(
-      output_tensor,
-      input_tensor,
-      ReduceScatterOptions{
-          *reduce_op.get(), std::chrono::milliseconds(timeout)});
-
-  return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(output_tensor, work);
-}
-
-c10::intrusive_ptr<Work> gather_(
-    const std::vector<std::vector<at::Tensor>>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    int64_t root_rank,
-    int64_t timeout) {
-  return process_group->gather(
-      const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
-      const_cast<std::vector<at::Tensor>&>(input_tensors),
-      GatherOptions{root_rank, std::chrono::milliseconds(timeout)});
-}
-
-std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> scatter_(
-    const std::vector<at::Tensor>& output_tensors,
-    const std::vector<std::vector<at::Tensor>>& input_tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    int64_t root_rank,
-    int64_t timeout) {
-  auto work = process_group->scatter(
-      const_cast<std::vector<at::Tensor>&>(output_tensors),
-      const_cast<std::vector<std::vector<at::Tensor>>&>(input_tensors),
-      ScatterOptions{root_rank, std::chrono::milliseconds(timeout)});
-
-  return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      output_tensors, work);
-}
-
-std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> alltoall_(
-    const std::vector<at::Tensor>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    int64_t timeout) {
-  auto work = process_group->alltoall(
-      const_cast<std::vector<at::Tensor>&>(output_tensors),
-      const_cast<std::vector<at::Tensor>&>(input_tensors),
-      AllToAllOptions{std::chrono::milliseconds(timeout)});
-  return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      output_tensors, work);
-}
-
-c10::intrusive_ptr<Work> alltoall_base_(
-    at::Tensor& output,
-    at::Tensor& input,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    std::vector<int64_t> output_split_sizes,
-    std::vector<int64_t> input_split_sizes,
-    int64_t timeout) {
-  return process_group->alltoall_base(
-      output,
-      input,
-      output_split_sizes,
-      input_split_sizes,
-      AllToAllOptions{std::chrono::milliseconds(timeout)});
-}
-
-c10::intrusive_ptr<Work> barrier(
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const std::vector<int64_t>& device_ids,
-    int64_t timeout) {
-  return process_group->barrier(
-      BarrierOptions{device_ids, std::chrono::milliseconds(timeout)});
-}
-
-void monitored_barrier_(
-    at::Tensor /* unused */,
-    const c10::intrusive_ptr<::c10d::ProcessGroup>& process_group,
-    const std::vector<int64_t>& device_ids,
-    int64_t timeout,
-    bool wait_all_ranks) {
-  process_group->monitoredBarrier(
-      BarrierOptions{device_ids, std::chrono::milliseconds(timeout)},
-      wait_all_ranks);
-}
-
-c10::intrusive_ptr<Work> send(
-    at::TensorList tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    int64_t dstRank,
-    int64_t tag) {
-  auto tensor_vec = tensors.vec();
-  return process_group->send(
-      tensor_vec, static_cast<int>(dstRank), static_cast<int>(tag));
-}
-
-c10::intrusive_ptr<Work> recv_(
-    at::TensorList tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    int64_t srcRank,
-    int64_t tag) {
-  auto tensor_vec = tensors.vec();
-  return process_group->recv(
-      tensor_vec, static_cast<int>(srcRank), static_cast<int>(tag));
-}
-
-c10::intrusive_ptr<Work> recv_any_source_(
-    at::TensorList tensors,
-    const c10::intrusive_ptr<ProcessGroup>& process_group,
-    int64_t tag) {
-  auto tensor_vec = tensors.vec();
-  return process_group->recvAnysource(tensor_vec, static_cast<int>(tag));
-}
-
 TORCH_LIBRARY(c10d, m) {
   // The following ProcessGroup, Work, and ReduceOp definitions are more like
   // declarations. They don't expose the details of the two classes into
@@ -249,63 +17,42 @@ TORCH_LIBRARY(c10d, m) {
       .def(torch::init<>())
       .def("wait", [](const c10::intrusive_ptr<Work>& self) { self->wait(); });
   m.class_<ReduceOp>("ReduceOp").def(torch::init<>());
-  // It's important to register the op to the CompositeExplicitAutograd key
-  // instead of the CompositeImplicitAutograd key to enable
-  // __torch_dispatch__.
   m.def(
-      "broadcast_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, broadcast_));
+      "broadcast_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int root_rank, int root_tensor, int timeout) -> (Tensor[], __torch__.torch.classes.c10d.Work)");
   m.def(
-      "allreduce_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, allreduce_));
+      "allreduce_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, int timeout) -> (Tensor[], __torch__.torch.classes.c10d.Work)");
   m.def(
-      "allreduce_coalesced_",
-      dispatch(
-          c10::DispatchKey::CompositeExplicitAutograd, allreduce_coalesced_));
+      "allreduce_coalesced_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, int timeout) -> __torch__.torch.classes.c10d.Work");
   m.def(
-      "allgather_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, allgather_));
+      "allgather_(Tensor[][] output_tensors, Tensor[] input_tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int timeout) -> (Tensor[][], __torch__.torch.classes.c10d.Work)");
   m.def(
-      "_allgather_base_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, _allgather_base_));
+      "_allgather_base_(Tensor output_tensor, Tensor input_tensor, __torch__.torch.classes.c10d.ProcessGroup process_group) -> (Tensor, __torch__.torch.classes.c10d.Work)");
   m.def(
-      "allgather_coalesced_",
-      dispatch(
-          c10::DispatchKey::CompositeExplicitAutograd, allgather_coalesced_));
+      "allgather_coalesced_(Tensor[][] output_lists, Tensor[] input_list, __torch__.torch.classes.c10d.ProcessGroup process_group) -> __torch__.torch.classes.c10d.Work");
   m.def(
-      "reduce_scatter_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, reduce_scatter_));
+      "reduce_scatter_(Tensor[] output_tensors, Tensor[][] input_tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, int timeout) -> (Tensor[], __torch__.torch.classes.c10d.Work)");
   m.def(
-      "_reduce_scatter_base_",
-      dispatch(
-          c10::DispatchKey::CompositeExplicitAutograd, _reduce_scatter_base_));
+      "_reduce_scatter_base_(Tensor output_tensor, Tensor input_tensor, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, int timeout) -> (Tensor, __torch__.torch.classes.c10d.Work)");
   m.def(
-      "reduce_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, reduce_));
+      "reduce_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, __torch__.torch.classes.c10d.ReduceOp reduce_op, int root_rank, int root_tensor, int timeout) -> __torch__.torch.classes.c10d.Work");
   m.def(
-      "gather_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, gather_));
+      "gather_(Tensor[][] output_tensors, Tensor[] input_tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int root_rank, int timeout) -> __torch__.torch.classes.c10d.Work");
   m.def(
-      "scatter_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, scatter_));
+      "scatter_(Tensor[] output_tensors, Tensor[][] input_tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int root_rank, int timeout) -> (Tensor[], __torch__.torch.classes.c10d.Work)");
   m.def(
-      "alltoall_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, alltoall_));
+      "alltoall_(Tensor[] output_tensors, Tensor[] input_tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int timeout) -> (Tensor[], __torch__.torch.classes.c10d.Work)");
   m.def(
-      "alltoall_base_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, alltoall_base_));
+      "alltoall_base_(Tensor output, Tensor input, __torch__.torch.classes.c10d.ProcessGroup process_group, int[] output_split_sizes, int[] input_split_sizes, int timeout) -> __torch__.torch.classes.c10d.Work");
   m.def(
-      "barrier",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, barrier));
+      "barrier(Tensor tensor, __torch__.torch.classes.c10d.ProcessGroup process_group, int[] device_ids, int timeout) -> __torch__.torch.classes.c10d.Work");
   m.def(
-      "monitored_barrier_",
-      dispatch(
-          c10::DispatchKey::CompositeExplicitAutograd, monitored_barrier_));
-  m.def("send", dispatch(c10::DispatchKey::CompositeExplicitAutograd, send));
-  m.def("recv_", dispatch(c10::DispatchKey::CompositeExplicitAutograd, recv_));
+      "monitored_barrier_(Tensor tensor, __torch__.torch.classes.c10d.ProcessGroup process_group, int[] device_ids, int timeout, bool wait_all_ranks) -> ()");
   m.def(
-      "recv_any_source_",
-      dispatch(c10::DispatchKey::CompositeExplicitAutograd, recv_any_source_));
+      "send(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int dst, int tag) -> __torch__.torch.classes.c10d.Work");
+  m.def(
+      "recv_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int src, int tag) -> __torch__.torch.classes.c10d.Work");
+  m.def(
+      "recv_any_source_(Tensor[] tensors, __torch__.torch.classes.c10d.ProcessGroup process_group, int tag) -> __torch__.torch.classes.c10d.Work");
 }
 } // namespace
 
@@ -315,6 +62,14 @@ c10::intrusive_ptr<Work> broadcast(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     at::TensorList tensors,
     const BroadcastOptions& opts) {
+  // TODO: handles the case of using a PythonProcessGroup which is used in
+  // Reducer.cpp This can be removed once
+  // https://github.com/pytorch/pytorch/issues/90659 is resolved
+  if (!process_group->hasBackends()) {
+    auto tensor_vec = tensors.vec();
+    return process_group->broadcast(tensor_vec, opts);
+  }
+
   static auto op =
       c10::Dispatcher::singleton()
           .findSchemaOrThrow("c10d::broadcast_", "")
@@ -339,6 +94,14 @@ c10::intrusive_ptr<Work> allreduce(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     at::TensorList tensors,
     const AllreduceOptions& opts) {
+  // TODO: handles the case of using a PythonProcessGroup which is used in
+  // Reducer.cpp This can be removed once
+  // https://github.com/pytorch/pytorch/issues/90659 is resolved
+  if (!process_group->hasBackends()) {
+    auto tensor_vec = tensors.vec();
+    return process_group->allreduce(tensor_vec, opts);
+  }
+
   static auto op =
       c10::Dispatcher::singleton()
           .findSchemaOrThrow("c10d::allreduce_", "")
@@ -377,17 +140,29 @@ c10::intrusive_ptr<Work> allreduce_coalesced(
 c10::intrusive_ptr<Work> allgather(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const std::vector<std::vector<at::Tensor>>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    at::TensorList input_tensors,
     const AllgatherOptions& opts) {
+  // TODO: handles the case of using a PythonProcessGroup which is used in
+  // Reducer.cpp This can be removed once
+  // https://github.com/pytorch/pytorch/issues/90659 is resolved
+  if (!process_group->hasBackends()) {
+    auto input_tensors_vec = input_tensors.vec();
+    return process_group->allgather(
+        const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
+        input_tensors_vec,
+        opts);
+  }
+
   static auto op = c10::Dispatcher::singleton()
                        .findSchemaOrThrow("c10d::allgather_", "")
                        .typed<std::tuple<
                            std::vector<std::vector<at::Tensor>>,
                            c10::intrusive_ptr<Work>>(
                            const std::vector<std::vector<at::Tensor>>&,
-                           const std::vector<at::Tensor>&,
+                           at::TensorList,
                            const c10::intrusive_ptr<::c10d::ProcessGroup>&,
                            int64_t)>();
+
   return std::get<1>(op.call(
       output_tensors, input_tensors, process_group, opts.timeout.count()));
 }
@@ -410,13 +185,13 @@ c10::intrusive_ptr<Work> _allgather_base(
 c10::intrusive_ptr<Work> allgather_coalesced(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const std::vector<std::vector<at::Tensor>>& output_lists,
-    const std::vector<at::Tensor>& input_list,
+    const at::TensorList& input_list,
     const AllgatherOptions& opts) {
   static auto op = c10::Dispatcher::singleton()
                        .findSchemaOrThrow("c10d::allgather_coalesced_", "")
                        .typed<c10::intrusive_ptr<Work>(
                            const std::vector<std::vector<at::Tensor>>&,
-                           const std::vector<at::Tensor>&,
+                           const at::TensorList&,
                            const c10::intrusive_ptr<::c10d::ProcessGroup>&)>();
 
   return op.call(output_lists, input_list, process_group);
@@ -424,14 +199,14 @@ c10::intrusive_ptr<Work> allgather_coalesced(
 
 c10::intrusive_ptr<Work> reduce_scatter(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const std::vector<at::Tensor>& output_tensors,
+    const at::TensorList& output_tensors,
     const std::vector<std::vector<at::Tensor>>& input_tensors,
     const ReduceScatterOptions& opts) {
   static auto op =
       c10::Dispatcher::singleton()
           .findSchemaOrThrow("c10d::reduce_scatter_", "")
           .typed<std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-              const std::vector<at::Tensor>&,
+              const at::TensorList&,
               const std::vector<std::vector<at::Tensor>>&,
               const c10::intrusive_ptr<::c10d::ProcessGroup>&,
               const c10::intrusive_ptr<::c10d::ReduceOp>&,
@@ -490,13 +265,13 @@ c10::intrusive_ptr<Work> reduce(
 c10::intrusive_ptr<Work> gather(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const std::vector<std::vector<at::Tensor>>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    const at::TensorList& input_tensors,
     const GatherOptions& opts) {
   static auto op = c10::Dispatcher::singleton()
                        .findSchemaOrThrow("c10d::gather_", "")
                        .typed<c10::intrusive_ptr<::c10d::Work>(
                            const std::vector<std::vector<at::Tensor>>&,
-                           const std::vector<at::Tensor>&,
+                           const at::TensorList&,
                            const c10::intrusive_ptr<::c10d::ProcessGroup>&,
                            int64_t,
                            int64_t)>();
@@ -510,14 +285,14 @@ c10::intrusive_ptr<Work> gather(
 
 c10::intrusive_ptr<Work> scatter(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const std::vector<at::Tensor>& output_tensors,
+    const at::TensorList& output_tensors,
     const std::vector<std::vector<at::Tensor>>& input_tensors,
     const ScatterOptions& opts) {
   static auto op =
       c10::Dispatcher::singleton()
           .findSchemaOrThrow("c10d::scatter_", "")
           .typed<std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-              const std::vector<at::Tensor>&,
+              const at::TensorList&,
               const std::vector<std::vector<at::Tensor>>&,
               const c10::intrusive_ptr<::c10d::ProcessGroup>&,
               int64_t,
@@ -532,15 +307,15 @@ c10::intrusive_ptr<Work> scatter(
 
 c10::intrusive_ptr<Work> alltoall(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const std::vector<at::Tensor>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    const at::TensorList& output_tensors,
+    const at::TensorList& input_tensors,
     const AllToAllOptions& opts) {
   static auto op =
       c10::Dispatcher::singleton()
           .findSchemaOrThrow("c10d::alltoall_", "")
           .typed<std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-              const std::vector<at::Tensor>&,
-              const std::vector<at::Tensor>&,
+              const at::TensorList&,
+              const at::TensorList&,
               const c10::intrusive_ptr<::c10d::ProcessGroup>&,
               int64_t)>();
   return std::get<1>(op.call(
@@ -597,13 +372,28 @@ void monitored_barrier(
 c10::intrusive_ptr<Work> barrier(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const BarrierOptions& opts) {
+  static at::Tensor tensor;
+  // TODO: if nccl was specified then use it
+  if (process_group->getBackendType() ==
+      c10d::ProcessGroup::BackendType::NCCL) {
+    // set cuda tensor
+    tensor = at::empty(
+        {1}, at::TensorOptions().device(at::DeviceType::CUDA).dtype(at::kByte));
+  } else {
+    // Default to using cpu implementation
+    tensor = at::empty(
+        {1}, at::TensorOptions().device(at::DeviceType::CPU).dtype(at::kByte));
+  }
+
   static auto op = c10::Dispatcher::singleton()
                        .findSchemaOrThrow("c10d::barrier", "")
                        .typed<c10::intrusive_ptr<::c10d::Work>(
+                           at::Tensor,
                            const c10::intrusive_ptr<::c10d::ProcessGroup>&,
                            const std::vector<int64_t>&,
                            int64_t)>();
-  return op.call(process_group, opts.device_ids, opts.timeout.count());
+
+  return op.call(tensor, process_group, opts.device_ids, opts.timeout.count());
 }
 
 c10::intrusive_ptr<Work> send(
@@ -658,8 +448,8 @@ c10::intrusive_ptr<Work> send_cpu(
     int64_t dstRank,
     int64_t tag) {
   auto tensor_vec = tensors.vec();
-  return process_group->send(
-      tensor_vec, static_cast<int>(dstRank), static_cast<int>(tag));
+  return process_group->getBackend(c10::DeviceType::CPU)
+      ->send(tensor_vec, static_cast<int>(dstRank), static_cast<int>(tag));
 }
 
 c10::intrusive_ptr<Work> send_cuda(
@@ -668,8 +458,8 @@ c10::intrusive_ptr<Work> send_cuda(
     int64_t dstRank,
     int64_t tag) {
   auto tensor_vec = tensors.vec();
-  return process_group->send(
-      tensor_vec, static_cast<int>(dstRank), static_cast<int>(tag));
+  return process_group->getBackend(c10::DeviceType::CUDA)
+      ->send(tensor_vec, static_cast<int>(dstRank), static_cast<int>(tag));
 }
 
 c10::intrusive_ptr<Work> recv_cpu_(
@@ -678,8 +468,8 @@ c10::intrusive_ptr<Work> recv_cpu_(
     int64_t srcRank,
     int64_t tag) {
   auto tensor_vec = tensors.vec();
-  return process_group->recv(
-      tensor_vec, static_cast<int>(srcRank), static_cast<int>(tag));
+  return process_group->getBackend(c10::DeviceType::CPU)
+      ->recv(tensor_vec, static_cast<int>(srcRank), static_cast<int>(tag));
 }
 
 c10::intrusive_ptr<Work> recv_cuda_(
@@ -688,8 +478,8 @@ c10::intrusive_ptr<Work> recv_cuda_(
     int64_t srcRank,
     int64_t tag) {
   auto tensor_vec = tensors.vec();
-  return process_group->recv(
-      tensor_vec, static_cast<int>(srcRank), static_cast<int>(tag));
+  return process_group->getBackend(c10::DeviceType::CUDA)
+      ->recv(tensor_vec, static_cast<int>(srcRank), static_cast<int>(tag));
 }
 
 c10::intrusive_ptr<Work> recv_any_source_cpu_(
@@ -697,7 +487,8 @@ c10::intrusive_ptr<Work> recv_any_source_cpu_(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     int64_t tag) {
   auto tensor_vec = tensors.vec();
-  return process_group->recvAnysource(tensor_vec, static_cast<int>(tag));
+  return process_group->getBackend(c10::DeviceType::CPU)
+      ->recvAnysource(tensor_vec, static_cast<int>(tag));
 }
 
 c10::intrusive_ptr<Work> recv_any_source_cuda_(
@@ -705,7 +496,8 @@ c10::intrusive_ptr<Work> recv_any_source_cuda_(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     int64_t tag) {
   auto tensor_vec = tensors.vec();
-  return process_group->recvAnysource(tensor_vec, static_cast<int>(tag));
+  return process_group->getBackend(c10::DeviceType::CUDA)
+      ->recvAnysource(tensor_vec, static_cast<int>(tag));
 }
 
 c10::intrusive_ptr<Work> reduce_cpu_(
@@ -716,13 +508,14 @@ c10::intrusive_ptr<Work> reduce_cpu_(
     int64_t root_tensor,
     int64_t timeout) {
   auto tensor_vec = tensors.vec();
-  return process_group->reduce(
-      tensor_vec,
-      ReduceOptions{
-          *reduce_op.get(),
-          root_rank,
-          root_tensor,
-          std::chrono::milliseconds(timeout)});
+  return process_group->getBackend(c10::DeviceType::CPU)
+      ->reduce(
+          tensor_vec,
+          ReduceOptions{
+              *reduce_op.get(),
+              root_rank,
+              root_tensor,
+              std::chrono::milliseconds(timeout)});
 }
 
 c10::intrusive_ptr<Work> reduce_cuda_(
@@ -733,13 +526,14 @@ c10::intrusive_ptr<Work> reduce_cuda_(
     int64_t root_tensor,
     int64_t timeout) {
   auto tensor_vec = tensors.vec();
-  return process_group->reduce(
-      tensor_vec,
-      ReduceOptions{
-          *reduce_op.get(),
-          root_rank,
-          root_tensor,
-          std::chrono::milliseconds(timeout)});
+  return process_group->getBackend(c10::DeviceType::CUDA)
+      ->reduce(
+          tensor_vec,
+          ReduceOptions{
+              *reduce_op.get(),
+              root_rank,
+              root_tensor,
+              std::chrono::milliseconds(timeout)});
 }
 
 std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> broadcast_cpu_(
@@ -749,10 +543,12 @@ std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> broadcast_cpu_(
     int64_t root_tensor,
     int64_t timeout) {
   auto tensor_vec = tensors.vec();
-  auto work = process_group->broadcast(
-      tensor_vec,
-      BroadcastOptions{
-          root_rank, root_tensor, std::chrono::milliseconds(timeout)});
+  auto work =
+      process_group->getBackend(c10::DeviceType::CPU)
+          ->broadcast(
+              tensor_vec,
+              BroadcastOptions{
+                  root_rank, root_tensor, std::chrono::milliseconds(timeout)});
 
   return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
       std::move(tensor_vec), work);
@@ -765,10 +561,12 @@ std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> broadcast_cuda_(
     int64_t root_tensor,
     int64_t timeout) {
   auto tensor_vec = tensors.vec();
-  auto work = process_group->broadcast(
-      tensor_vec,
-      BroadcastOptions{
-          root_rank, root_tensor, std::chrono::milliseconds(timeout)});
+  auto work =
+      process_group->getBackend(c10::DeviceType::CUDA)
+          ->broadcast(
+              tensor_vec,
+              BroadcastOptions{
+                  root_rank, root_tensor, std::chrono::milliseconds(timeout)});
 
   return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
       std::move(tensor_vec), work);
@@ -780,9 +578,12 @@ std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> allreduce_cpu_(
     const c10::intrusive_ptr<ReduceOp>& reduce_op,
     int64_t timeout) {
   auto tensor_vec = tensors.vec();
-  auto work = process_group->allreduce(
-      tensor_vec,
-      AllreduceOptions{*reduce_op.get(), std::chrono::milliseconds(timeout)});
+  auto work =
+      process_group->getBackend(c10::DeviceType::CPU)
+          ->allreduce(
+              tensor_vec,
+              AllreduceOptions{
+                  *reduce_op.get(), std::chrono::milliseconds(timeout)});
 
   // Return input tensors as output tensors to make inplace allreduce look like
   // a functional API, so that make_fx can correctly build the dependencies in
@@ -797,9 +598,12 @@ std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> allreduce_cuda_(
     const c10::intrusive_ptr<ReduceOp>& reduce_op,
     int64_t timeout) {
   auto tensor_vec = tensors.vec();
-  auto work = process_group->allreduce(
-      tensor_vec,
-      AllreduceOptions{*reduce_op.get(), std::chrono::milliseconds(timeout)});
+  auto work =
+      process_group->getBackend(c10::DeviceType::CUDA)
+          ->allreduce(
+              tensor_vec,
+              AllreduceOptions{
+                  *reduce_op.get(), std::chrono::milliseconds(timeout)});
 
   // Return input tensors as output tensors to make inplace allreduce look like
   // a functional API, so that make_fx can correctly build the dependencies in
@@ -818,7 +622,8 @@ c10::intrusive_ptr<Work> allreduce_coalesced_cpu_(
   opts.reduceOp = *reduce_op.get();
   opts.timeout = std::chrono::milliseconds(timeout);
 
-  return process_group->allreduce_coalesced(tensor_vec, opts);
+  return process_group->getBackend(c10::DeviceType::CPU)
+      ->allreduce_coalesced(tensor_vec, opts);
 }
 
 c10::intrusive_ptr<Work> allreduce_coalesced_cuda_(
@@ -831,19 +636,23 @@ c10::intrusive_ptr<Work> allreduce_coalesced_cuda_(
   opts.reduceOp = *reduce_op.get();
   opts.timeout = std::chrono::milliseconds(timeout);
 
-  return process_group->allreduce_coalesced(tensor_vec, opts);
+  return process_group->getBackend(c10::DeviceType::CUDA)
+      ->allreduce_coalesced(tensor_vec, opts);
 }
 
 std::tuple<std::vector<std::vector<at::Tensor>>, c10::intrusive_ptr<Work>>
 allgather_cpu_(
     const std::vector<std::vector<at::Tensor>>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    at::TensorList input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     int64_t timeout) {
-  auto work = process_group->allgather(
-      const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
-      const_cast<std::vector<at::Tensor>&>(input_tensors),
-      AllgatherOptions{std::chrono::milliseconds(timeout)});
+  auto input_tensors_vec = input_tensors.vec();
+  auto work =
+      process_group->getBackend(c10::DeviceType::CPU)
+          ->allgather(
+              const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
+              input_tensors_vec,
+              AllgatherOptions{std::chrono::milliseconds(timeout)});
 
   // Copy output tensors (not storage) so that this can be used in a functional
   // manner
@@ -855,13 +664,16 @@ allgather_cpu_(
 std::tuple<std::vector<std::vector<at::Tensor>>, c10::intrusive_ptr<Work>>
 allgather_cuda_(
     const std::vector<std::vector<at::Tensor>>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    at::TensorList input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     int64_t timeout) {
-  auto work = process_group->allgather(
-      const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
-      const_cast<std::vector<at::Tensor>&>(input_tensors),
-      AllgatherOptions{std::chrono::milliseconds(timeout)});
+  auto input_tensors_vec = input_tensors.vec();
+  auto work =
+      process_group->getBackend(c10::DeviceType::CUDA)
+          ->allgather(
+              const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
+              input_tensors_vec,
+              AllgatherOptions{std::chrono::milliseconds(timeout)});
 
   // Copy output tensors (not storage) so that this can be used in a functional
   // manner
@@ -874,7 +686,8 @@ std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_cpu_(
     at::Tensor& output_tensor,
     at::Tensor& input_tensor,
     const c10::intrusive_ptr<ProcessGroup>& process_group) {
-  auto work = process_group->_allgather_base(output_tensor, input_tensor);
+  auto work = process_group->getBackend(c10::DeviceType::CPU)
+                  ->_allgather_base(output_tensor, input_tensor);
 
   return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(output_tensor, work);
 }
@@ -883,61 +696,72 @@ std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _allgather_base_cuda_(
     at::Tensor& output_tensor,
     at::Tensor& input_tensor,
     const c10::intrusive_ptr<ProcessGroup>& process_group) {
-  auto work = process_group->_allgather_base(output_tensor, input_tensor);
+  auto work = process_group->getBackend(c10::DeviceType::CUDA)
+                  ->_allgather_base(output_tensor, input_tensor);
 
   return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(output_tensor, work);
 }
 
 c10::intrusive_ptr<Work> allgather_coalesced_cpu_(
     const std::vector<std::vector<at::Tensor>>& output_lists,
-    const std::vector<at::Tensor>& input_list,
+    const at::TensorList& input_list,
     const c10::intrusive_ptr<ProcessGroup>& process_group) {
-  return process_group->allgather_coalesced(
-      const_cast<std::vector<std::vector<at::Tensor>>&>(output_lists),
-      const_cast<std::vector<at::Tensor>&>(input_list));
+  auto input_list_vec = input_list.vec();
+  return process_group->getBackend(c10::DeviceType::CPU)
+      ->allgather_coalesced(
+          const_cast<std::vector<std::vector<at::Tensor>>&>(output_lists),
+          input_list_vec);
 }
 
 c10::intrusive_ptr<Work> allgather_coalesced_cuda_(
     const std::vector<std::vector<at::Tensor>>& output_lists,
-    const std::vector<at::Tensor>& input_list,
+    const at::TensorList& input_list,
     const c10::intrusive_ptr<ProcessGroup>& process_group) {
-  return process_group->allgather_coalesced(
-      const_cast<std::vector<std::vector<at::Tensor>>&>(output_lists),
-      const_cast<std::vector<at::Tensor>&>(input_list));
+  auto input_list_vec = input_list.vec();
+  return process_group->getBackend(c10::DeviceType::CUDA)
+      ->allgather_coalesced(
+          const_cast<std::vector<std::vector<at::Tensor>>&>(output_lists),
+          input_list_vec);
 }
 
 std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>
 reduce_scatter_cpu_(
-    const std::vector<at::Tensor>& output_tensors,
+    const at::TensorList& output_tensors,
     const std::vector<std::vector<at::Tensor>>& input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const c10::intrusive_ptr<ReduceOp>& reduce_op,
     int64_t timeout) {
-  auto work = process_group->reduce_scatter(
-      const_cast<std::vector<at::Tensor>&>(output_tensors),
-      const_cast<std::vector<std::vector<at::Tensor>>&>(input_tensors),
-      ReduceScatterOptions{
-          *reduce_op.get(), std::chrono::milliseconds(timeout)});
+  auto output_tensors_vec = output_tensors.vec();
+  auto work =
+      process_group->getBackend(c10::DeviceType::CPU)
+          ->reduce_scatter(
+              output_tensors_vec,
+              const_cast<std::vector<std::vector<at::Tensor>>&>(input_tensors),
+              ReduceScatterOptions{
+                  *reduce_op.get(), std::chrono::milliseconds(timeout)});
 
   return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      output_tensors, work);
+      output_tensors_vec, work);
 }
 
 std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>
 reduce_scatter_cuda_(
-    const std::vector<at::Tensor>& output_tensors,
+    const at::TensorList& output_tensors,
     const std::vector<std::vector<at::Tensor>>& input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const c10::intrusive_ptr<ReduceOp>& reduce_op,
     int64_t timeout) {
-  auto work = process_group->reduce_scatter(
-      const_cast<std::vector<at::Tensor>&>(output_tensors),
-      const_cast<std::vector<std::vector<at::Tensor>>&>(input_tensors),
-      ReduceScatterOptions{
-          *reduce_op.get(), std::chrono::milliseconds(timeout)});
+  auto output_tensors_vec = output_tensors.vec();
+  auto work =
+      process_group->getBackend(c10::DeviceType::CUDA)
+          ->reduce_scatter(
+              output_tensors_vec,
+              const_cast<std::vector<std::vector<at::Tensor>>&>(input_tensors),
+              ReduceScatterOptions{
+                  *reduce_op.get(), std::chrono::milliseconds(timeout)});
 
   return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      output_tensors, work);
+      output_tensors_vec, work);
 }
 
 std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _reduce_scatter_base_cpu_(
@@ -946,11 +770,13 @@ std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _reduce_scatter_base_cpu_(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const c10::intrusive_ptr<ReduceOp>& reduce_op,
     int64_t timeout) {
-  auto work = process_group->_reduce_scatter_base(
-      output_tensor,
-      input_tensor,
-      ReduceScatterOptions{
-          *reduce_op.get(), std::chrono::milliseconds(timeout)});
+  auto work =
+      process_group->getBackend(c10::DeviceType::CPU)
+          ->_reduce_scatter_base(
+              output_tensor,
+              input_tensor,
+              ReduceScatterOptions{
+                  *reduce_op.get(), std::chrono::milliseconds(timeout)});
 
   return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(output_tensor, work);
 }
@@ -961,93 +787,110 @@ std::tuple<at::Tensor, c10::intrusive_ptr<Work>> _reduce_scatter_base_cuda_(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const c10::intrusive_ptr<ReduceOp>& reduce_op,
     int64_t timeout) {
-  auto work = process_group->_reduce_scatter_base(
-      output_tensor,
-      input_tensor,
-      ReduceScatterOptions{
-          *reduce_op.get(), std::chrono::milliseconds(timeout)});
+  auto work =
+      process_group->getBackend(c10::DeviceType::CUDA)
+          ->_reduce_scatter_base(
+              output_tensor,
+              input_tensor,
+              ReduceScatterOptions{
+                  *reduce_op.get(), std::chrono::milliseconds(timeout)});
 
   return std::tuple<at::Tensor, c10::intrusive_ptr<Work>>(output_tensor, work);
 }
 
 c10::intrusive_ptr<Work> gather_cpu_(
     const std::vector<std::vector<at::Tensor>>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    const at::TensorList& input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     int64_t root_rank,
     int64_t timeout) {
-  return process_group->gather(
-      const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
-      const_cast<std::vector<at::Tensor>&>(input_tensors),
-      GatherOptions{root_rank, std::chrono::milliseconds(timeout)});
+  auto input_tensors_vec = input_tensors.vec();
+  return process_group->getBackend(c10::DeviceType::CPU)
+      ->gather(
+          const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
+          input_tensors_vec,
+          GatherOptions{root_rank, std::chrono::milliseconds(timeout)});
 }
-
 c10::intrusive_ptr<Work> gather_cuda_(
     const std::vector<std::vector<at::Tensor>>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    const at::TensorList& input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     int64_t root_rank,
     int64_t timeout) {
-  return process_group->gather(
-      const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
-      const_cast<std::vector<at::Tensor>&>(input_tensors),
-      GatherOptions{root_rank, std::chrono::milliseconds(timeout)});
+  auto input_tensors_vec = input_tensors.vec();
+  return process_group->getBackend(c10::DeviceType::CUDA)
+      ->gather(
+          const_cast<std::vector<std::vector<at::Tensor>>&>(output_tensors),
+          input_tensors_vec,
+          GatherOptions{root_rank, std::chrono::milliseconds(timeout)});
 }
 
 std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> scatter_cpu_(
-    const std::vector<at::Tensor>& output_tensors,
+    const at::TensorList& output_tensors,
     const std::vector<std::vector<at::Tensor>>& input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     int64_t root_rank,
     int64_t timeout) {
-  auto work = process_group->scatter(
-      const_cast<std::vector<at::Tensor>&>(output_tensors),
-      const_cast<std::vector<std::vector<at::Tensor>>&>(input_tensors),
-      ScatterOptions{root_rank, std::chrono::milliseconds(timeout)});
+  auto output_tensors_vec = output_tensors.vec();
+  auto work =
+      process_group->getBackend(c10::DeviceType::CPU)
+          ->scatter(
+              output_tensors_vec,
+              const_cast<std::vector<std::vector<at::Tensor>>&>(input_tensors),
+              ScatterOptions{root_rank, std::chrono::milliseconds(timeout)});
 
   return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      output_tensors, work);
+      std::move(output_tensors_vec), work);
 }
 
 std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> scatter_cuda_(
-    const std::vector<at::Tensor>& output_tensors,
+    const at::TensorList& output_tensors,
     const std::vector<std::vector<at::Tensor>>& input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     int64_t root_rank,
     int64_t timeout) {
-  auto work = process_group->scatter(
-      const_cast<std::vector<at::Tensor>&>(output_tensors),
-      const_cast<std::vector<std::vector<at::Tensor>>&>(input_tensors),
-      ScatterOptions{root_rank, std::chrono::milliseconds(timeout)});
+  auto output_tensors_vec = output_tensors.vec();
+  auto work =
+      process_group->getBackend(c10::DeviceType::CUDA)
+          ->scatter(
+              output_tensors_vec,
+              const_cast<std::vector<std::vector<at::Tensor>>&>(input_tensors),
+              ScatterOptions{root_rank, std::chrono::milliseconds(timeout)});
 
   return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      output_tensors, work);
+      std::move(output_tensors_vec), work);
 }
 
 std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> alltoall_cpu_(
-    const std::vector<at::Tensor>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    const at::TensorList& output_tensors,
+    const at::TensorList& input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     int64_t timeout) {
-  auto work = process_group->alltoall(
-      const_cast<std::vector<at::Tensor>&>(output_tensors),
-      const_cast<std::vector<at::Tensor>&>(input_tensors),
-      AllToAllOptions{std::chrono::milliseconds(timeout)});
+  auto output_tensors_vec = output_tensors.vec();
+  auto input_tensors_vec = input_tensors.vec();
+  auto work = process_group->getBackend(c10::DeviceType::CPU)
+                  ->alltoall(
+                      output_tensors_vec,
+                      input_tensors_vec,
+                      AllToAllOptions{std::chrono::milliseconds(timeout)});
   return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      output_tensors, work);
+      std::move(output_tensors_vec), work);
 }
 
 std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> alltoall_cuda_(
-    const std::vector<at::Tensor>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    const at::TensorList& output_tensors,
+    const at::TensorList& input_tensors,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     int64_t timeout) {
-  auto work = process_group->alltoall(
-      const_cast<std::vector<at::Tensor>&>(output_tensors),
-      const_cast<std::vector<at::Tensor>&>(input_tensors),
-      AllToAllOptions{std::chrono::milliseconds(timeout)});
+  auto output_tensors_vec = output_tensors.vec();
+  auto input_tensors_vec = input_tensors.vec();
+  auto work = process_group->getBackend(c10::DeviceType::CUDA)
+                  ->alltoall(
+                      output_tensors_vec,
+                      input_tensors_vec,
+                      AllToAllOptions{std::chrono::milliseconds(timeout)});
   return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      output_tensors, work);
+      std::move(output_tensors_vec), work);
 }
 
 c10::intrusive_ptr<Work> alltoall_base_cpu_(
@@ -1057,12 +900,13 @@ c10::intrusive_ptr<Work> alltoall_base_cpu_(
     std::vector<int64_t> output_split_sizes,
     std::vector<int64_t> input_split_sizes,
     int64_t timeout) {
-  return process_group->alltoall_base(
-      output,
-      input,
-      output_split_sizes,
-      input_split_sizes,
-      AllToAllOptions{std::chrono::milliseconds(timeout)});
+  return process_group->getBackend(c10::DeviceType::CPU)
+      ->alltoall_base(
+          output,
+          input,
+          output_split_sizes,
+          input_split_sizes,
+          AllToAllOptions{std::chrono::milliseconds(timeout)});
 }
 
 c10::intrusive_ptr<Work> alltoall_base_cuda_(
@@ -1072,28 +916,31 @@ c10::intrusive_ptr<Work> alltoall_base_cuda_(
     std::vector<int64_t> output_split_sizes,
     std::vector<int64_t> input_split_sizes,
     int64_t timeout) {
-  return process_group->alltoall_base(
-      output,
-      input,
-      output_split_sizes,
-      input_split_sizes,
-      AllToAllOptions{std::chrono::milliseconds(timeout)});
+  return process_group->getBackend(c10::DeviceType::CUDA)
+      ->alltoall_base(
+          output,
+          input,
+          output_split_sizes,
+          input_split_sizes,
+          AllToAllOptions{std::chrono::milliseconds(timeout)});
 }
 
 c10::intrusive_ptr<Work> barrier_cpu(
+    at::Tensor /* unused */,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const std::vector<int64_t>& device_ids,
     int64_t timeout) {
-  return process_group->barrier(
-      BarrierOptions{device_ids, std::chrono::milliseconds(timeout)});
+  return process_group->getBackend(c10::DeviceType::CPU)
+      ->barrier(BarrierOptions{device_ids, std::chrono::milliseconds(timeout)});
 }
 
 c10::intrusive_ptr<Work> barrier_cuda(
+    at::Tensor /* unused */,
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const std::vector<int64_t>& device_ids,
     int64_t timeout) {
-  return process_group->barrier(
-      BarrierOptions{device_ids, std::chrono::milliseconds(timeout)});
+  return process_group->getBackend(c10::DeviceType::CUDA)
+      ->barrier(BarrierOptions{device_ids, std::chrono::milliseconds(timeout)});
 }
 
 void monitored_barrier_cpu_(
@@ -1102,9 +949,10 @@ void monitored_barrier_cpu_(
     const std::vector<int64_t>& device_ids,
     int64_t timeout,
     bool wait_all_ranks) {
-  process_group->monitoredBarrier(
-      BarrierOptions{device_ids, std::chrono::milliseconds(timeout)},
-      wait_all_ranks);
+  process_group->getBackend(c10::DeviceType::CPU)
+      ->monitoredBarrier(
+          BarrierOptions{device_ids, std::chrono::milliseconds(timeout)},
+          wait_all_ranks);
 }
 
 // register functions to dispatcher

--- a/torch/csrc/distributed/c10d/Ops.hpp
+++ b/torch/csrc/distributed/c10d/Ops.hpp
@@ -29,7 +29,7 @@ TORCH_API c10::intrusive_ptr<Work> allreduce_coalesced(
 TORCH_API c10::intrusive_ptr<Work> allgather(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const std::vector<std::vector<at::Tensor>>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    at::TensorList input_tensors,
     const AllgatherOptions& opts = {});
 
 TORCH_API c10::intrusive_ptr<Work> _allgather_base(
@@ -41,12 +41,12 @@ TORCH_API c10::intrusive_ptr<Work> _allgather_base(
 TORCH_API c10::intrusive_ptr<Work> allgather_coalesced(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const std::vector<std::vector<at::Tensor>>& output_lists,
-    const std::vector<at::Tensor>& input_list,
+    const at::TensorList& input_list,
     const AllgatherOptions& opts = {});
 
 TORCH_API c10::intrusive_ptr<Work> reduce_scatter(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const std::vector<at::Tensor>& output_tensors,
+    const at::TensorList& output_tensors,
     const std::vector<std::vector<at::Tensor>>& input_tensors,
     const ReduceScatterOptions& opts = {});
 
@@ -64,12 +64,12 @@ TORCH_API c10::intrusive_ptr<Work> reduce(
 TORCH_API c10::intrusive_ptr<Work> gather(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const std::vector<std::vector<at::Tensor>>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    const at::TensorList& input_tensors,
     const GatherOptions& opts = {});
 
 TORCH_API c10::intrusive_ptr<Work> scatter(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const std::vector<at::Tensor>& output_tensors,
+    const at::TensorList& output_tensors,
     const std::vector<std::vector<at::Tensor>>& input_tensors,
     const ScatterOptions& opts = {});
 
@@ -83,8 +83,8 @@ TORCH_API c10::intrusive_ptr<Work> alltoall_base(
 
 TORCH_API c10::intrusive_ptr<Work> alltoall(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
-    const std::vector<at::Tensor>& output_tensors,
-    const std::vector<at::Tensor>& input_tensors,
+    const at::TensorList& output_tensors,
+    const at::TensorList& input_tensors,
     const AllToAllOptions& opts = {});
 
 TORCH_API c10::intrusive_ptr<Work> barrier(

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -8,14 +9,10 @@
 #include <vector>
 
 #include <ATen/ATen.h>
+#include <ATen/core/dispatch/Dispatcher.h>
 #include <c10/macros/Macros.h>
 
-#include <torch/csrc/distributed/c10d/Types.hpp>
-#include <torch/csrc/distributed/c10d/Utils.hpp>
 #include <torch/csrc/distributed/c10d/Work.hpp>
-#include <torch/csrc/distributed/c10d/debug.h>
-#include <torch/csrc/distributed/c10d/sequence_num.hpp>
-
 // *************************************************************************
 // PROCESS GROUP collective communication API IS BEING CHANGED BETWEEN
 // versions 1.7 and 1.8.
@@ -67,7 +64,24 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
     const std::string backend;
   };
 
+  enum BackendType {
+    UNDEFINED = 0,
+    GLOO = 1,
+    NCCL = 2,
+    UCC = 3,
+    MPI = 4,
+    CUSTOM = 5,
+  };
+
+  // Not used, set for backwards compatibility and only used for TypeDef in
+  // Ops.cpp
   explicit ProcessGroup(int rank, int size);
+
+  explicit ProcessGroup(
+      const c10::intrusive_ptr<::c10d::Store>& store,
+      int rank,
+      int size,
+      c10::intrusive_ptr<Options> options);
   virtual ~ProcessGroup();
 
   int getRank() const {
@@ -78,69 +92,136 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
     return size_;
   }
 
-  // Subclasses must override this method to return the backend name
   virtual const std::string getBackendName() const {
-    TORCH_INTERNAL_ASSERT(false, "getBackendName is not implemented.");
+    return options_->backend;
   };
 
-  virtual void startCoalescing() {
-    // no-op for backends that have not implemented startCoalescing
+  BackendType getBackendType() const {
+    return backendType_;
+  };
+
+  virtual void startCoalescing(c10::DeviceType deviceType) {
+    // only nccl has implemented startCoalescing so only execute for nccl
+    // backends
+    if (getBackendType() == BackendType::NCCL) {
+      getBackend(deviceType)->startCoalescing();
+    }
   }
 
   virtual void endCoalescing(
-      std::vector<c10::intrusive_ptr<Work>>& /* reqs */) {
-    // no-op for backends that have not implemented endCoalescing
+      c10::DeviceType deviceType,
+      std::vector<c10::intrusive_ptr<Work>>& reqs) {
+    // only nccl has implemented startCoalescing so only execute for nccl
+    // backends
+    if (getBackendType() == BackendType::NCCL) {
+      getBackend(deviceType)->endCoalescing(reqs);
+    }
   }
 
-  // Consider using ops in Ops.hpp instead of the below, which route things
-  // to the dispatcher.
-  // TODO: Find a way to force the above rule programmatically.
   virtual c10::intrusive_ptr<Work> broadcast(
-      std::vector<at::Tensor>& /* tensors */,
-      const BroadcastOptions& /* opts */ = BroadcastOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ", getBackendName(), " does not support broadcast"));
+      std::vector<at::Tensor>& tensors,
+      const BroadcastOptions& opts = BroadcastOptions()) {
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("c10d::broadcast_", "")
+            .typed<
+                std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
+                    at::TensorList,
+                    const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                    int64_t,
+                    int64_t,
+                    int64_t)>();
+    // It's awakward to unbox the opts here and box them again in the custom C++
+    // op. But it's also complicated to make opts as a CustomClassHolder. Leave
+    // it as it is now.
+    return std::get<1>(op.call(
+        tensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        opts.rootRank,
+        opts.rootTensor,
+        opts.timeout.count()));
   }
 
   virtual c10::intrusive_ptr<Work> allreduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceOptions& /* opts */ = AllreduceOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ", getBackendName(), " does not support allreduce"));
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) {
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("c10d::allreduce_", "")
+            .typed<
+                std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
+                    at::TensorList,
+                    const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                    const c10::intrusive_ptr<::c10d::ReduceOp>&,
+                    int64_t)>();
+
+    return std::get<1>(op.call(
+        tensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        c10::make_intrusive<ReduceOp>(opts.reduceOp),
+        opts.timeout.count()));
   }
 
   virtual c10::intrusive_ptr<Work> allreduce_coalesced(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceCoalescedOptions& /* opts */ =
-          AllreduceCoalescedOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ",
-            getBackendName(),
-            " does not support allreduce_coalesced"));
+      std::vector<at::Tensor>& tensors,
+      const AllreduceCoalescedOptions& opts = AllreduceCoalescedOptions()) {
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::allreduce_coalesced_", "")
+                         .typed<c10::intrusive_ptr<::c10d::Work>(
+                             at::TensorList,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             const c10::intrusive_ptr<::c10d::ReduceOp>&,
+                             int64_t)>();
+
+    return op.call(
+        tensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+
+        c10::make_intrusive<ReduceOp>(opts.reduceOp),
+        opts.timeout.count());
   }
 
   virtual c10::intrusive_ptr<Work> reduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const ReduceOptions& /* opts */ = ReduceOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str("ProcessGroup ", getBackendName(), "does not support reduce"));
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) {
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::reduce_", "")
+                         .typed<c10::intrusive_ptr<::c10d::Work>(
+                             at::TensorList,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             const c10::intrusive_ptr<::c10d::ReduceOp>&,
+                             int64_t,
+                             int64_t,
+                             int64_t)>();
+    return op.call(
+        tensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+
+        c10::make_intrusive<ReduceOp>(opts.reduceOp),
+        opts.rootRank,
+        opts.rootTensor,
+        opts.timeout.count());
   }
 
   virtual c10::intrusive_ptr<Work> allgather(
-      std::vector<std::vector<at::Tensor>>& /* outputTensors */,
-      std::vector<at::Tensor>& /* inputTensors */,
-      const AllgatherOptions& /* opts */ = AllgatherOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ", getBackendName(), " does not support allgather"));
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllgatherOptions& opts = AllgatherOptions()) {
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::allgather_", "")
+                         .typed<std::tuple<
+                             std::vector<std::vector<at::Tensor>>,
+                             c10::intrusive_ptr<Work>>(
+                             const std::vector<std::vector<at::Tensor>>&,
+                             at::TensorList,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             int64_t)>();
+
+    return std::get<1>(op.call(
+        outputTensors,
+        inputTensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        opts.timeout.count()));
   }
 
   // Gathers a single tensor inputBuffer into a single buffer outputBuffer that
@@ -148,15 +229,21 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // For implementers of ProcessGroup API and advanced users only.
   // Note: this function will be deprecated in near future.
   virtual c10::intrusive_ptr<Work> _allgather_base(
-      at::Tensor& /* outputBuffer */,
-      at::Tensor& /* inputBuffer */,
-      const AllgatherOptions& /* opts */ = AllgatherOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ",
-            getBackendName(),
-            " does not support _allgather_base"));
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const AllgatherOptions& opts = AllgatherOptions()) {
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("c10d::_allgather_base_", "")
+            .typed<c10::intrusive_ptr<Work>(
+                at::Tensor&,
+                at::Tensor&,
+                const c10::intrusive_ptr<::c10d::ProcessGroup>&)>();
+
+    return op.call(
+        outputBuffer,
+        inputBuffer,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this));
   }
 
   // This function is deprecated and will be moved out of ProcessGroup to comms:
@@ -164,158 +251,340 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // * do not implement it in your ProcessGroup, implement _allgather_base
   //   instead.
   virtual c10::intrusive_ptr<Work> allgather_coalesced(
-      std::vector<std::vector<at::Tensor>>& /* outputTensorLists */,
-      std::vector<at::Tensor>& /* inputTensors */,
-      const AllgatherOptions& /* opts */ = AllgatherOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ",
-            getBackendName(),
-            " does not support allgather_coalesced"));
+      std::vector<std::vector<at::Tensor>>& outputTensorLists,
+      std::vector<at::Tensor>& inputTensors,
+      const AllgatherOptions& opts = AllgatherOptions()) {
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("c10d::allgather_coalesced_", "")
+            .typed<c10::intrusive_ptr<Work>(
+                const std::vector<std::vector<at::Tensor>>&,
+                const at::TensorList&,
+                const c10::intrusive_ptr<::c10d::ProcessGroup>&)>();
+
+    return op.call(
+        outputTensorLists,
+        inputTensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this));
   }
 
   virtual c10::intrusive_ptr<Work> gather(
-      std::vector<std::vector<at::Tensor>>& /* outputTensors */,
-      std::vector<at::Tensor>& /* inputTensors */,
-      const GatherOptions& /* opts */ = GatherOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ", getBackendName(), " does not support gather"));
+      std::vector<std::vector<at::Tensor>>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const GatherOptions& opts = GatherOptions()) {
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::gather_", "")
+                         .typed<c10::intrusive_ptr<::c10d::Work>(
+                             const std::vector<std::vector<at::Tensor>>&,
+                             const at::TensorList&,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             int64_t,
+                             int64_t)>();
+    return op.call(
+        outputTensors,
+        inputTensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        opts.rootRank,
+        opts.timeout.count());
   }
 
   virtual c10::intrusive_ptr<Work> scatter(
-      std::vector<at::Tensor>& /* outputTensors */,
-      std::vector<std::vector<at::Tensor>>& /* inputTensors */,
-      const ScatterOptions& /* opts */ = ScatterOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ", getBackendName(), " does not support scatter"));
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ScatterOptions& opts = ScatterOptions()) {
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("c10d::scatter_", "")
+            .typed<
+                std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
+                    const at::TensorList&,
+                    const std::vector<std::vector<at::Tensor>>&,
+                    const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                    int64_t,
+                    int64_t)>();
+    return std::get<1>(op.call(
+        outputTensors,
+        inputTensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        opts.rootRank,
+        opts.timeout.count()));
   }
 
   virtual c10::intrusive_ptr<Work> reduce_scatter(
-      std::vector<at::Tensor>& /* outputTensors */,
-      std::vector<std::vector<at::Tensor>>& /* inputTensors */,
-      const ReduceScatterOptions& /* opts */ = ReduceScatterOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ",
-            getBackendName(),
-            " does not support reduce_scatter"));
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) {
+    static auto op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("c10d::reduce_scatter_", "")
+            .typed<
+                std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
+                    const at::TensorList&,
+                    const std::vector<std::vector<at::Tensor>>&,
+                    const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                    const c10::intrusive_ptr<::c10d::ReduceOp>&,
+                    int64_t)>();
+    return std::get<1>(op.call(
+        outputTensors,
+        inputTensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        c10::make_intrusive<::c10d::ReduceOp>(opts.reduceOp),
+        opts.timeout.count()));
   }
 
   virtual c10::intrusive_ptr<Work> _reduce_scatter_base(
-      at::Tensor& /* outputBuffer */,
-      at::Tensor& /* inputBuffer */,
-      const ReduceScatterOptions& /* opts */ = ReduceScatterOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ",
-            getBackendName(),
-            " does not support _reduce_scatter_base"));
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) {
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::_reduce_scatter_base_", "")
+                         .typed<c10::intrusive_ptr<Work>(
+                             at::Tensor&,
+                             at::Tensor&,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             const c10::intrusive_ptr<::c10d::ReduceOp>&,
+                             int64_t)>();
+    return op.call(
+        outputBuffer,
+        inputBuffer,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        c10::make_intrusive<::c10d::ReduceOp>(opts.reduceOp),
+        opts.timeout.count());
   }
 
   virtual c10::intrusive_ptr<Work> alltoall_base(
-      at::Tensor& /* outputBuffer */,
-      at::Tensor& /* inputBuffer */,
-      std::vector<int64_t>& /* outputSplitSizes */,
-      std::vector<int64_t>& /* inputSplitSizes */,
-      const AllToAllOptions& /* opts */ = AllToAllOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ",
-            getBackendName(),
-            " does not support alltoall_base"));
+      at::Tensor& outputBuffer,
+      at::Tensor& inputBuffer,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) {
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::alltoall_base_", "")
+                         .typed<c10::intrusive_ptr<::c10d::Work>(
+                             at::Tensor&,
+                             at::Tensor&,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             std::vector<int64_t>,
+                             std::vector<int64_t>,
+                             int64_t)>();
+    return op.call(
+        outputBuffer,
+        inputBuffer,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        outputSplitSizes,
+        inputSplitSizes,
+        opts.timeout.count());
   }
 
   virtual c10::intrusive_ptr<Work> alltoall(
-      std::vector<at::Tensor>& /* outputTensors */,
-      std::vector<at::Tensor>& /* inputTensors */,
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
       const AllToAllOptions& opts = AllToAllOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ", getBackendName(), " does not support alltoall"));
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::alltoall_", "")
+                         .typed<c10::intrusive_ptr<::c10d::Work>(
+                             at::TensorList,
+                             at::TensorList,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             int64_t)>();
+    return op.call(
+        outputTensors,
+        inputTensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        opts.timeout.count());
   }
 
   virtual void monitoredBarrier(
-      const BarrierOptions& /* unused */,
-      bool /* unused */ = false) {
-    auto backendName = getBackendName();
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ",
-            backendName,
-            " does not support monitoredBarrier, only GLOO supports monitored barrier."));
+      const BarrierOptions& opts,
+      bool wait_all_ranks = false) {
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::monitored_barrier_", "")
+                         .typed<void(
+                             at::Tensor,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             const std::vector<int64_t>&,
+                             int64_t,
+                             bool)>();
+    // Default to using cpu implementation, monitored barrier is only for GLOO
+    at::Tensor tensor = at::empty({0}, at::TensorOptions().device(at::kCPU));
+    op.call(
+        tensor,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        opts.device_ids,
+        opts.timeout.count(),
+        wait_all_ranks);
   }
 
   // Agrees on an initial sequence number for the whole group by having rank 0
   // create it and broadcast it to other ranks using the store. Only implemented
   // for GLOO and NCCL backends currently.
   virtual void setSequenceNumberForGroup() {
-    auto backendName = getBackendName();
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ",
-            backendName,
-            " does not yet support sequence numbers."));
+    auto backendType = getBackendType();
+    // TODO: HACK for backend name to get sequence number for that backend.
+    if (backendType == ProcessGroup::BackendType::GLOO ||
+        backendType == ProcessGroup::BackendType::NCCL ||
+        backendType == ProcessGroup::BackendType::UCC) {
+      getDefaultBackend()->setSequenceNumberForGroup();
+    } else {
+      TORCH_CHECK(
+          false,
+          c10::str(
+              "ProcessGroup ",
+              getBackendName(),
+              " does not yet support sequence numbers."));
+    }
   }
 
   // Retrieves the current sequence number for the whole group, which should be
   // in sync. If the returned number is not consistent across the group, it
   // may indicate that there is some sort of collective desynchronization.
   virtual uint64_t getSequenceNumberForGroup() {
-    auto backendName = getBackendName();
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ",
-            backendName,
-            " does not yet support sequence numbers."));
+    auto backendType = getBackendType();
+
+    // TODO: HACK for backend name to get sequence number for that backend.
+    if (backendType == ProcessGroup::BackendType::GLOO ||
+        backendType == ProcessGroup::BackendType::NCCL ||
+        backendType == ProcessGroup::BackendType::UCC) {
+      return getDefaultBackend()->getSequenceNumberForGroup();
+    } else {
+      TORCH_CHECK(
+          false,
+          c10::str(
+              "ProcessGroup ",
+              getBackendName(),
+              " does not yet support sequence numbers."));
+    }
   }
 
   virtual c10::intrusive_ptr<Work> send(
-      std::vector<at::Tensor>& /* tensors */,
-      int /* dstRank */,
-      int /* tag */) {
-    TORCH_CHECK(
-        false,
-        c10::str("ProcessGroup ", getBackendName(), " does not support send"));
+      std::vector<at::Tensor>& tensors,
+      int dstRank,
+      int tag) {
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::send", "")
+                         .typed<c10::intrusive_ptr<::c10d::Work>(
+                             at::TensorList,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             int64_t,
+                             int64_t)>();
+    return op.call(
+        tensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        dstRank,
+        tag);
   }
 
   virtual c10::intrusive_ptr<Work> recv(
-      std::vector<at::Tensor>& /* tensors */,
-      int /* srcRank */,
-      int /* tag */) {
-    TORCH_CHECK(
-        false,
-        c10::str("ProcessGroup ", getBackendName(), " does not support recv"));
+      std::vector<at::Tensor>& tensors,
+      int srcRank,
+      int tag) {
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::recv_", "")
+                         .typed<c10::intrusive_ptr<::c10d::Work>(
+                             at::TensorList,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             int64_t,
+                             int64_t)>();
+    return op.call(
+        tensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        srcRank,
+        tag);
   }
 
   virtual c10::intrusive_ptr<Work> recvAnysource(
-      std::vector<at::Tensor>& /* tensors */,
-      int /* tag */) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ",
-            getBackendName(),
-            " does not support recvAnysource"));
+      std::vector<at::Tensor>& tensors,
+      int tag) {
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::recv_any_source_", "")
+                         .typed<c10::intrusive_ptr<::c10d::Work>(
+                             at::TensorList,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             int64_t)>();
+    return op.call(
+        tensors,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        tag);
   }
 
   virtual c10::intrusive_ptr<Work> barrier(
-      const BarrierOptions& /* opts */ = BarrierOptions()) {
+      const BarrierOptions& opts = BarrierOptions()) {
+    static at::Tensor tensor;
+    // TODO: if nccl was specified then use it
+    if (backendType_ == c10d::ProcessGroup::BackendType::NCCL) {
+      // set cuda tensor
+      tensor = at::empty(
+          {1},
+          at::TensorOptions().device(at::DeviceType::CUDA).dtype(at::kByte));
+    } else {
+      // Default to using cpu implementation
+      tensor = at::empty(
+          {1},
+          at::TensorOptions().device(at::DeviceType::CPU).dtype(at::kByte));
+    }
+
+    static auto op = c10::Dispatcher::singleton()
+                         .findSchemaOrThrow("c10d::barrier", "")
+                         .typed<c10::intrusive_ptr<::c10d::Work>(
+                             at::Tensor,
+                             const c10::intrusive_ptr<::c10d::ProcessGroup>&,
+                             const std::vector<int64_t>&,
+                             int64_t)>();
+
+    return op.call(
+        tensor,
+        c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(this),
+        opts.device_ids,
+        opts.timeout.count());
+  }
+
+  c10::intrusive_ptr<Options> getOptions() {
+    return options_;
+  }
+
+  bool hasBackends() {
+    return !deviceTypeToBackendType_.empty();
+  }
+
+  void setBackend(
+      c10::DeviceType deviceType,
+      BackendType backendType,
+      const c10::optional<c10::intrusive_ptr<Backend>>& backend) {
+    deviceTypeToBackendType_[deviceType] = backendType;
+    // if the backendType is already set then reuse it for this device
+    if (backendTypeToBackend_.find(backendType) !=
+        backendTypeToBackend_.end()) {
+      auto existingBackend = backendTypeToBackend_.at(backendType);
+      deviceTypeToBackend_[deviceType] = existingBackend;
+    } else {
+      // check if backend has value
+      if (backend.has_value()) {
+        deviceTypeToBackend_[deviceType] = backend.value();
+        backendTypeToBackend_[backendType] = backend.value();
+      }
+    }
+  }
+
+  c10::intrusive_ptr<Backend> getDefaultBackend() const {
     TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ", getBackendName(), " does not support barrier"));
+        backendTypeToBackend_.find(backendType_) != backendTypeToBackend_.end(),
+        "Could not find the default backend type ",
+        backendType_,
+        " for Process Group with name ",
+        getBackendName(),
+        ".");
+    return backendTypeToBackend_.at(backendType_);
+  }
+
+  c10::intrusive_ptr<Backend> getBackend(c10::DeviceType deviceType);
+
+  c10::intrusive_ptr<Backend> getBackend(BackendType backendType) const {
+    TORCH_CHECK(
+        backendTypeToBackend_.find(backendType) != backendTypeToBackend_.end(),
+        "Could not find backend type ",
+        backendType,
+        ".");
+    return backendTypeToBackend_.at(backendType);
   }
 
  protected:
@@ -323,13 +592,24 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // appropriate logging etc.
   void init();
 
+  const c10::intrusive_ptr<c10d::Store> store_;
   const int rank_;
   const int size_;
+  const c10::intrusive_ptr<Options> options_;
+  const BackendType backendType_;
   // Optional sequence number structure for matching collectives.
   c10::optional<c10d::SequenceNum> sequenceNum_ = c10::nullopt;
+
   // Debug level setting. It is parsed once when ProcessGroup is constructed and
   // remains the same across use of this process group.
   DebugLevel dist_debug_level_;
+
+  // Backend classes for this ProcessGroup
+  std::unordered_map<c10::DeviceType, BackendType> deviceTypeToBackendType_;
+  std::unordered_map<c10::DeviceType, c10::intrusive_ptr<Backend>>
+      deviceTypeToBackend_;
+  std::unordered_map<BackendType, c10::intrusive_ptr<Backend>>
+      backendTypeToBackend_;
 };
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -4,6 +4,7 @@
 #ifdef USE_C10D_GLOO
 
 #include <torch/csrc/distributed/c10d/GlooDeviceFactory.hpp>
+#include <torch/csrc/distributed/c10d/PrefixStore.hpp>
 #include <chrono>
 #include <exception>
 #include <ratio>
@@ -608,7 +609,7 @@ void ProcessGroupGloo::RecvWork::abort() {
 }
 
 ProcessGroupGloo::Options::Options(std::chrono::milliseconds timeout)
-    : ProcessGroup::Options(GLOO_BACKEND_NAME, timeout), threads(2) {}
+    : Backend::Options(GLOO_BACKEND_NAME, timeout), threads(2) {}
 
 namespace {
 
@@ -731,7 +732,7 @@ ProcessGroupGloo::ProcessGroupGloo(
     int rank,
     int size,
     c10::intrusive_ptr<Options> options)
-    : ProcessGroup(rank, size),
+    : Backend(rank, size),
       store_(new GlooStore(store)),
       options_(options),
       stop_(false),

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -18,7 +18,7 @@
 
 #include <c10/util/hash.h>
 
-#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <torch/csrc/distributed/c10d/Store.hpp>
 #include <torch/csrc/distributed/c10d/Types.hpp>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
@@ -50,7 +50,7 @@ constexpr const char* GLOO_BACKEND_NAME = "gloo";
 // number can be automatically tuned, but only if we let a single
 // process take charge, and have it broadcast the limits.
 //
-class TORCH_API ProcessGroupGloo : public ProcessGroup {
+class TORCH_API ProcessGroupGloo : public Backend {
  public:
   // AsyncWork is the Gloo specific superclass for asynchronous work items.
   // We can split asynchronous work into 3 phases:
@@ -178,13 +178,13 @@ class TORCH_API ProcessGroupGloo : public ProcessGroup {
     int srcRank_;
   };
 
-  struct TORCH_API Options : public ProcessGroup::Options {
+  struct TORCH_API Options : public Backend::Options {
     explicit Options(
-        std::chrono::milliseconds timeout = kProcessGroupDefaultTimeout);
+        std::chrono::milliseconds timeout = kBackendDefaultTimeout);
 
     // return intrusive_ptr of the object
     static c10::intrusive_ptr<Options> create(
-        std::chrono::milliseconds timeout = kProcessGroupDefaultTimeout) {
+        std::chrono::milliseconds timeout = kBackendDefaultTimeout) {
       return c10::make_intrusive<Options>(timeout);
     }
 
@@ -213,6 +213,13 @@ class TORCH_API ProcessGroupGloo : public ProcessGroup {
   // If that fails (i.e. the hostname doesn't resolve to an address), it
   // falls back to binding to the loopback address.
   static std::shared_ptr<::gloo::transport::Device> createDefaultDevice();
+
+  // Create ProcessGroupGloo instance.
+  static c10::intrusive_ptr<ProcessGroupGloo> createProcessGroupGloo(
+    const c10::intrusive_ptr<Store>& store,
+    int rank,
+    int size,
+    std::chrono::milliseconds timeout);
 
   explicit ProcessGroupGloo(
       const c10::intrusive_ptr<Store>& store,

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -305,7 +305,7 @@ c10::intrusive_ptr<ProcessGroupMPI> ProcessGroupMPI::createProcessGroupMPI(
 }
 
 ProcessGroupMPI::ProcessGroupMPI(int rank, int size, MPI_Comm pgComm)
-    : ProcessGroup(rank, size), stop_(false), pgComm_(pgComm) {
+    : Backend(rank, size), stop_(false), pgComm_(pgComm) {
   if (pgComm_ == MPI_COMM_NULL) {
     TORCH_CHECK(false, "pgComm_ must not be MPI_COMM_NULL");
   }

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
@@ -13,7 +13,7 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/core/ivalue_inl.h>
 
-#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <torch/csrc/distributed/c10d/Types.hpp>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 
@@ -80,7 +80,7 @@ struct WorkEntry {
 //
 // CUDA tensor can be supported if the MPI used is CUDA-aware MPI, and
 // ProcessGroupMPI will automatically detect this support.
-class TORCH_API ProcessGroupMPI : public ProcessGroup {
+class TORCH_API ProcessGroupMPI : public Backend {
  public:
   class WorkMPI : public Work {
    public:

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -608,7 +608,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     int rank,
     int size,
     c10::intrusive_ptr<Options> options)
-    : ProcessGroup(rank, size),
+    : Backend(rank, size),
       store_(store),
       options_(options),
       ncclCommCounter_(0),
@@ -693,7 +693,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
 
   if (uccLib_ != nullptr) {
     LOG(INFO) << "[Rank " << rank_ << "] torch_ucc.so loaded";
-    typedef c10::intrusive_ptr<ProcessGroup> fn(
+    typedef c10::intrusive_ptr<Backend> fn(
         const c10::intrusive_ptr<Store>& store, int rank, int size);
     auto createProcessGroupUCC =
         reinterpret_cast<fn*>(uccLib_->sym("createProcessGroupUCC"));
@@ -1488,7 +1488,7 @@ void ProcessGroupNCCL::workEnqueue(
 }
 
 ProcessGroupNCCL::Options::Options(bool is_high_priority_stream)
-    : ProcessGroup::Options(NCCL_BACKEND_NAME),
+    : Backend::Options(NCCL_BACKEND_NAME),
       is_high_priority_stream(is_high_priority_stream) {}
 
 void ProcessGroupNCCL::startCoalescing() {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -10,7 +10,7 @@
 #include <unordered_map>
 
 #include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
-#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <torch/csrc/distributed/c10d/Store.hpp>
 #include <torch/csrc/distributed/c10d/UCCForNCCL.hpp>
 
@@ -83,7 +83,7 @@ enum ErrorHandlingMode { NoHandling = 0, TearDown = 1, CleanUpOnly = 2 };
 //   work->wait()
 //
 //   // Now continue on other work in the current stream.
-class TORCH_API ProcessGroupNCCL : public ProcessGroup {
+class TORCH_API ProcessGroupNCCL : public Backend {
  public:
   class WorkNCCL : public Work,
     public std::enable_shared_from_this<WorkNCCL> {
@@ -244,7 +244,7 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
     friend class ProcessGroupNCCL;
   };
 
-  struct Options : ProcessGroup::Options {
+  struct Options : Backend::Options {
     // NOTE: timeout in ProcessGroupNCCL::Options denote the timeout for
     // operations. This is only used when blockingWait_ is enabled.
     explicit Options(
@@ -685,7 +685,7 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
 #ifdef USE_NCCL_WITH_UCC
   // ProcessGroupUCC shared library handle and ProcessGroup pointer
   static std::shared_ptr<at::DynamicLibrary> uccLib_;
-  c10::intrusive_ptr<ProcessGroup> uccPG_;
+  c10::intrusive_ptr<Backend> uccPG_;
 #endif
 };
 

--- a/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.cpp
@@ -5,7 +5,7 @@ namespace c10d {
 ProcessGroupRoundRobin::ProcessGroupRoundRobin(
     int rank,
     int size,
-    std::vector<c10::intrusive_ptr<ProcessGroup>> processGroups)
+    std::vector<c10::intrusive_ptr<Backend>> processGroups)
     : ProcessGroup(rank, size), processGroups_(std::move(processGroups)) {
   TORCH_WARN(
       "ProcessGroupRoundRobin is deprecated and scheduled to be removed after this current release (1.13). ",
@@ -114,7 +114,7 @@ c10::intrusive_ptr<Work> ProcessGroupRoundRobin::barrier(
   TORCH_CHECK(false, "ProcessGroupRoundRobin does not support barrier");
 };
 
-const c10::intrusive_ptr<ProcessGroup>& ProcessGroupRoundRobin::next() {
+const c10::intrusive_ptr<Backend>& ProcessGroupRoundRobin::next() {
   auto& processGroup = *iterator_;
   iterator_++;
   if (iterator_ == processGroups_.end()) {

--- a/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.hpp
@@ -23,7 +23,7 @@ class TORCH_API ProcessGroupRoundRobin final : public ProcessGroup {
   explicit ProcessGroupRoundRobin(
       int rank,
       int size,
-      std::vector<c10::intrusive_ptr<ProcessGroup>> processGroups);
+      std::vector<c10::intrusive_ptr<Backend>> processGroups);
 
   ~ProcessGroupRoundRobin() override;
 
@@ -103,11 +103,11 @@ class TORCH_API ProcessGroupRoundRobin final : public ProcessGroup {
       const BarrierOptions& opts = BarrierOptions()) override;
 
  private:
-  std::vector<c10::intrusive_ptr<ProcessGroup>> processGroups_;
-  std::vector<c10::intrusive_ptr<ProcessGroup>>::const_iterator iterator_;
+  std::vector<c10::intrusive_ptr<Backend>> processGroups_;
+  std::vector<c10::intrusive_ptr<Backend>>::const_iterator iterator_;
 
   // Returns the next ProcessGroup to use.
-  const c10::intrusive_ptr<ProcessGroup>& next();
+  const c10::intrusive_ptr<Backend>& next();
 };
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.cpp
@@ -564,7 +564,7 @@ ProcessGroupUCC::ProcessGroupUCC(
     int rank,
     int size,
     std::chrono::duration<float> timeout)
-    : ProcessGroup(rank, size), timeout_(timeout) {
+    : Backend(rank, size), timeout_(timeout) {
   c10::call_once(torch_ucc_config.flag, read_config);
   oob = std::make_shared<torch_ucc_oob_coll_info_t>();
   oob->rank = rank;
@@ -1585,7 +1585,7 @@ uint64_t ProcessGroupUCC::getSequenceNumberForGroup() {
   return seq_;
 }
 
-c10::intrusive_ptr<ProcessGroup> ProcessGroupUCC::createProcessGroupUCC(
+c10::intrusive_ptr<Backend> ProcessGroupUCC::createProcessGroupUCC(
     const c10::intrusive_ptr<::c10d::Store>& store,
     int rank,
     int size,

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.hpp
@@ -11,7 +11,7 @@
 #include <thread>
 #include <vector>
 
-#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <torch/csrc/distributed/c10d/Store.hpp>
 #include <torch/csrc/distributed/c10d/Types.hpp>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
@@ -53,7 +53,7 @@ struct event_pool_t {
 class Comm;
 
 // UCC does not support multiple CUDA devices per process.
-class TORCH_API ProcessGroupUCC : public ProcessGroup {
+class TORCH_API ProcessGroupUCC : public Backend {
  private:
   void set_timeout(ucc_coll_args_t& args);
 
@@ -153,7 +153,7 @@ class TORCH_API ProcessGroupUCC : public ProcessGroup {
       const c10::intrusive_ptr<Store>& store,
       int rank = -1,
       int size = -1,
-      std::chrono::duration<float> timeout = kProcessGroupDefaultTimeout);
+      std::chrono::duration<float> timeout = kBackendDefaultTimeout);
 
   void initComm(c10::Device dev);
 
@@ -266,7 +266,7 @@ class TORCH_API ProcessGroupUCC : public ProcessGroup {
   // may indicate that there is some sort of collective desynchronization.
   uint64_t getSequenceNumberForGroup() override;
 
-  static c10::intrusive_ptr<ProcessGroup> createProcessGroupUCC(
+  static c10::intrusive_ptr<Backend> createProcessGroupUCC(
       const c10::intrusive_ptr<::c10d::Store>& store,
       int rank,
       int size,

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -62,7 +62,7 @@ struct CollectiveFingerPrint {
       const CollectiveFingerPrint& collective_fingerprint);
 
   // Executes and verifies the collective fingerprint.
-  void verify(c10::intrusive_ptr<ProcessGroup> pg) {
+  void verify(c10::intrusive_ptr<Backend> backend) {
     at::Tensor serialized_tensor = serialize_fingerprint();
     std::vector<at::Tensor> inp{serialized_tensor};
     // First verify tensor shapes. This is needed because if e.g. tensor dim
@@ -72,9 +72,9 @@ struct CollectiveFingerPrint {
     // the shape will be a single int k_i and we need to make sure k_i is
     // consistent across the whole world.
     std::vector<at::Tensor> sp = c10d::getTensorShapes(inp);
-    verify_tensors(sp, pg);
+    verify_tensors(sp, backend);
     // Now verify consistency for the actual tensor.
-    verify_tensors(inp, pg);
+    verify_tensors(inp, backend);
   }
 
   // Takes a serialized fingerprint from
@@ -129,7 +129,7 @@ struct CollectiveFingerPrint {
  private:
   void verify_tensors(
       std::vector<at::Tensor>& tensors_to_verify,
-      c10::intrusive_ptr<ProcessGroup>& pg) {
+      c10::intrusive_ptr<Backend>& backend) {
     // Create output tensor data structure to pass into allgather.
     std::vector<std::vector<at::Tensor>> output_tensors;
     // output tensors: [<tensor 0 outputs>, <tensor 1 outputs>, ..., <tensor n
@@ -140,15 +140,15 @@ struct CollectiveFingerPrint {
       // <tensor 0 outputs>: [<rank 0 tensor>, <rank 1 tensor>, ..., <rank n
       // tensor>]
       std::vector<at::Tensor> outputs;
-      outputs.reserve(pg->getSize());
-      for (const auto i : c10::irange(pg->getSize())) {
+      outputs.reserve(backend->getSize());
+      for (const auto i : c10::irange(backend->getSize())) {
         std::ignore = i; // Suppress unused variable warning
         outputs.emplace_back(at::zeros_like(tensor_shape));
       }
       output_tensors.emplace_back(outputs);
     }
     // Allgather tensor shapes.
-    pg->allgather(output_tensors, tensors_to_verify)->wait();
+    backend->allgather(output_tensors, tensors_to_verify)->wait();
     // Verify equivalence
     for (const auto i : c10::irange(output_tensors.size())) {
       const std::vector<at::Tensor> gathered_tensors = output_tensors[i];
@@ -160,7 +160,7 @@ struct CollectiveFingerPrint {
               deserialize_fingerprint(rank_tensor);
           std::stringstream ss;
           ss << "Detected mismatch between collectives on ranks. Rank "
-             << pg->getRank() << " is running collective: " << *this
+             << backend->getRank() << " is running collective: " << *this
              << ", but Rank " << rank
              << " is running collective: " << rank_fingerprint << ".";
           TORCH_CHECK(false, ss.str());
@@ -263,29 +263,31 @@ std::ostream& operator<<(
 } // namespace
 
 ProcessGroupWrapper::ProcessGroupWrapper(
-    c10::intrusive_ptr<ProcessGroup> pg,
-    c10::intrusive_ptr<ProcessGroupGloo> glooPg)
-    : ProcessGroup(pg->getRank(), pg->getSize()), pg_(pg), glooPg_(glooPg) {
+    c10::intrusive_ptr<Backend> backend,
+    c10::intrusive_ptr<Backend> glooBackend)
+    : Backend(backend->getRank(), backend->getSize()),
+      backend_(backend),
+      glooBackend_(glooBackend) {
   // Set the sequence number for the underlying process group.
-  pg_->setSequenceNumberForGroup();
+  backend_->setSequenceNumberForGroup();
 }
 
 const std::string ProcessGroupWrapper::getBackendName() const {
-  return pg_->getBackendName();
+  return backend_->getBackendName();
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::broadcast(
     std::vector<at::Tensor>& data,
     const BroadcastOptions& opts) {
   runCollectiveChecks(OpType::BROADCAST, data);
-  return pg_->broadcast(data, opts);
+  return backend_->broadcast(data, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::allreduce(
     std::vector<at::Tensor>& data,
     const AllreduceOptions& opts) {
   runCollectiveChecks(OpType::ALLREDUCE, data);
-  return pg_->allreduce(data, opts);
+  return backend_->allreduce(data, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::allreduce_coalesced(
@@ -296,14 +298,14 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::allreduce_coalesced(
   // inconsistent shapes, see python implementation in distributed_c10d for
   // details.
   runCollectiveChecks(OpType::ALLREDUCE_COALESCED, {});
-  return pg_->allreduce_coalesced(tensors, opts);
+  return backend_->allreduce_coalesced(tensors, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::reduce(
     std::vector<at::Tensor>& tensors,
     const ReduceOptions& opts) {
   runCollectiveChecks(OpType::REDUCE, tensors);
-  return pg_->reduce(tensors, opts);
+  return backend_->reduce(tensors, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::allgather(
@@ -311,7 +313,7 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::allgather(
     std::vector<at::Tensor>& inputTensors,
     const AllgatherOptions& opts) {
   runCollectiveChecks(OpType::ALLGATHER, inputTensors);
-  return pg_->allgather(outputTensors, inputTensors, opts);
+  return backend_->allgather(outputTensors, inputTensors, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::_allgather_base(
@@ -320,7 +322,7 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::_allgather_base(
     const AllgatherOptions& opts) {
   std::vector<at::Tensor> inputTensors({inputBuffer});
   runCollectiveChecks(OpType::_ALLGATHER_BASE, inputTensors);
-  return pg_->_allgather_base(outputBuffer, inputBuffer, opts);
+  return backend_->_allgather_base(outputBuffer, inputBuffer, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::allgather_coalesced(
@@ -332,7 +334,7 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::allgather_coalesced(
   // inconsistent shapes, see python implementation in distributed_c10d for
   // details.
   runCollectiveChecks(OpType::ALLGATHER_COALESCED, {});
-  return pg_->allgather_coalesced(outputTensorLists, inputTensors, opts);
+  return backend_->allgather_coalesced(outputTensorLists, inputTensors, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::gather(
@@ -340,7 +342,7 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::gather(
     std::vector<at::Tensor>& inputTensors,
     const GatherOptions& opts) {
   runCollectiveChecks(OpType::GATHER, inputTensors);
-  return pg_->gather(outputTensors, inputTensors, opts);
+  return backend_->gather(outputTensors, inputTensors, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::scatter(
@@ -348,7 +350,7 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::scatter(
     std::vector<std::vector<at::Tensor>>& inputTensors,
     const ScatterOptions& opts) {
   runCollectiveChecks(OpType::SCATTER, outputTensors);
-  return pg_->scatter(outputTensors, inputTensors, opts);
+  return backend_->scatter(outputTensors, inputTensors, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::reduce_scatter(
@@ -356,7 +358,7 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::reduce_scatter(
     std::vector<std::vector<at::Tensor>>& inputTensors,
     const ReduceScatterOptions& opts) {
   runCollectiveChecks(OpType::REDUCE_SCATTER, outputTensors);
-  return pg_->reduce_scatter(outputTensors, inputTensors, opts);
+  return backend_->reduce_scatter(outputTensors, inputTensors, opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::alltoall_base(
@@ -367,7 +369,7 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::alltoall_base(
     const AllToAllOptions& opts) {
   // alltoall supports uneven split, so don't enforce shape checking.
   runCollectiveChecks(OpType::ALLTOALL_BASE, {});
-  return pg_->alltoall_base(
+  return backend_->alltoall_base(
       outputTensor, inputTensor, outputSplitSizes, inputSplitSizes, opts);
 }
 
@@ -377,51 +379,51 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::alltoall(
     const AllToAllOptions& opts) {
   // alltoall supports uneven split, so don't enforce shape checking.
   runCollectiveChecks(OpType::ALLTOALL, {});
-  return pg_->alltoall(outputTensors, inputTensors, opts);
+  return backend_->alltoall(outputTensors, inputTensors, opts);
 }
 
 void ProcessGroupWrapper::monitoredBarrier(
     const BarrierOptions& opts,
     bool waitAllRanks) {
-  return pg_->monitoredBarrier(opts, waitAllRanks);
+  return backend_->monitoredBarrier(opts, waitAllRanks);
 }
 
 void ProcessGroupWrapper::setSequenceNumberForGroup() {
   // Set underlying pg's sequence number if it is not set.
-  if (pg_->getSequenceNumberForGroup() == 0) {
+  if (backend_->getSequenceNumberForGroup() == 0) {
     // Set the sequence number for the underlying process group.
-    pg_->setSequenceNumberForGroup();
+    backend_->setSequenceNumberForGroup();
   }
 }
 
 uint64_t ProcessGroupWrapper::getSequenceNumberForGroup() {
-  return pg_->getSequenceNumberForGroup();
+  return backend_->getSequenceNumberForGroup();
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::send(
     std::vector<at::Tensor>& tensors,
     int dstRank,
     int tag) {
-  return pg_->send(tensors, dstRank, tag);
+  return backend_->send(tensors, dstRank, tag);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::recv(
     std::vector<at::Tensor>& tensors,
     int srcRank,
     int tag) {
-  return pg_->recv(tensors, srcRank, tag);
+  return backend_->recv(tensors, srcRank, tag);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::recvAnysource(
     std::vector<at::Tensor>& tensors,
     int tag) {
-  return pg_->recvAnysource(tensors, tag);
+  return backend_->recvAnysource(tensors, tag);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::barrier(
     const BarrierOptions& opts) {
   runCollectiveChecks(OpType::BARRIER, {});
-  return pg_->barrier(opts);
+  return backend_->barrier(opts);
 }
 
 c10::intrusive_ptr<Work> ProcessGroupWrapper::_reduce_scatter_base(
@@ -430,11 +432,11 @@ c10::intrusive_ptr<Work> ProcessGroupWrapper::_reduce_scatter_base(
     const ReduceScatterOptions& opts) {
   runCollectiveChecks(
       OpType::_REDUCE_SCATTER_BASE, {inputBuffer, outputBuffer});
-  return pg_->_reduce_scatter_base(outputBuffer, inputBuffer, opts);
+  return backend_->_reduce_scatter_base(outputBuffer, inputBuffer, opts);
 }
 
-c10::intrusive_ptr<ProcessGroup> ProcessGroupWrapper::getWrappedPg() const {
-  return pg_;
+c10::intrusive_ptr<Backend> ProcessGroupWrapper::getWrappedPg() const {
+  return backend_;
 }
 
 void ProcessGroupWrapper::runCollectiveChecks(
@@ -442,11 +444,11 @@ void ProcessGroupWrapper::runCollectiveChecks(
     const std::vector<at::Tensor>& tensors) const {
   // first perform a monitored barrier to ensure all ranks can synchronize.
   c10d::BarrierOptions options;
-  // TODO: we should use wrapped pg_'s timeout here, but C++ ProcessGroup API
-  // does not expose timeout.
+  // TODO: we should use wrapped backend_'s timeout here, but C++ ProcessGroup
+  // API does not expose timeout.
   auto finger_print = CollectiveFingerPrint(op_type, tensors);
   try {
-    glooPg_->monitoredBarrier(options, /* waitAllRanks */ true);
+    glooBackend_->monitoredBarrier(options, /* waitAllRanks */ true);
   } catch (const std::runtime_error& e) {
     // Attach collective info to the exception and re-raise.
     std::stringstream ss;
@@ -460,7 +462,7 @@ void ProcessGroupWrapper::runCollectiveChecks(
     TORCH_CHECK(false, err_msg);
   }
   // Will throw if an ill-formed collective is detected.
-  finger_print.verify(glooPg_);
+  finger_print.verify(glooBackend_);
 }
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -2,18 +2,17 @@
 
 #ifdef USE_C10D_GLOO
 
-#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroupGloo.hpp>
 #include <torch/csrc/distributed/c10d/Types.hpp>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 
 namespace c10d {
 
-class TORCH_API ProcessGroupWrapper : public ProcessGroup {
+class TORCH_API ProcessGroupWrapper : public Backend {
  public:
   explicit ProcessGroupWrapper(
-      c10::intrusive_ptr<ProcessGroup> pg,
-      c10::intrusive_ptr<ProcessGroupGloo> glooPg);
+      c10::intrusive_ptr<Backend> backend,
+      c10::intrusive_ptr<Backend> glooBackend);
 
   const std::string getBackendName() const override;
 
@@ -116,15 +115,15 @@ class TORCH_API ProcessGroupWrapper : public ProcessGroup {
       at::Tensor& inputBuffer,
       const ReduceScatterOptions& opts) override;
 
-  c10::intrusive_ptr<ProcessGroup> getWrappedPg() const;
+  c10::intrusive_ptr<Backend> getWrappedPg() const;
 
  private:
   // Underlying process group that actual application collectives will be
   // dispatched to
-  c10::intrusive_ptr<ProcessGroup> pg_;
+  c10::intrusive_ptr<Backend> backend_;
   // Gloo process group responsible for internal coordination such as monitored
   // barrier, sequence number checking, collective fingerprint collecting.
-  c10::intrusive_ptr<ProcessGroupGloo> glooPg_;
+  c10::intrusive_ptr<Backend> glooBackend_;
   // Conducts several checks to ensure that the underlying collective is well
   // formed with the goal of notifying the user about incorrect collective use
   // in the application.

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -73,6 +73,16 @@ inline void assertSameType(
   }
 }
 
+inline std::vector<std::string> split(char separator, const std::string& string) {
+  std::vector<std::string> pieces;
+  std::stringstream ss(string);
+  std::string item;
+  while (std::getline(ss, item, separator)) {
+    pieces.push_back(std::move(item));
+  }
+  return pieces;
+}
+
 inline int parseEnvVarInt(const char* envVarName) {
   char* stringValue = std::getenv(envVarName);
   if (stringValue != nullptr) {

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -107,16 +107,6 @@ namespace c10d {
 
 namespace {
 
-std::vector<std::string> split(char separator, const std::string& string) {
-  std::vector<std::string> pieces;
-  std::stringstream ss(string);
-  std::string item;
-  while (std::getline(ss, item, separator)) {
-    pieces.push_back(std::move(item));
-  }
-  return pieces;
-}
-
 template <typename T>
 using shared_ptr_class_ = py::class_<T, std::shared_ptr<T>>;
 
@@ -1170,10 +1160,17 @@ Arguments:
           c10::intrusive_ptr<::c10d::ProcessGroup>,
           ::c10d::PyProcessGroup>(module, "ProcessGroup")
           .def(py::init<int, int>())
+          .def(
+              py::init<
+                  const c10::intrusive_ptr<::c10d::Store>&,
+                  int,
+                  int,
+                  c10::intrusive_ptr<::c10d::ProcessGroup::Options>>(),
+              py::call_guard<py::gil_scoped_release>())
           .def("rank", &::c10d::ProcessGroup::getRank)
           .def("size", &::c10d::ProcessGroup::getSize)
           .def("name", &::c10d::ProcessGroup::getBackendName)
-
+          .def_property_readonly("options", &::c10d::ProcessGroup::getOptions)
           .def(
               "broadcast",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
@@ -1396,7 +1393,7 @@ Arguments:
           .def(
               "reduce_scatter",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
-                 const std::vector<at::Tensor>& output_tensors,
+                 std::vector<at::Tensor>& output_tensors,
                  const std::vector<std::vector<at::Tensor>>& input_tensors,
                  const ::c10d::ReduceScatterOptions& opts) {
                 return ::c10d::ops::reduce_scatter(
@@ -1419,8 +1416,8 @@ Arguments:
                 opts.reduceOp = op;
                 return ::c10d::ops::reduce_scatter(self, outputs, inputs, opts);
               },
-              py::arg("output_tensors"),
-              py::arg("input_tensor"),
+              py::arg("output"),
+              py::arg("input"),
               py::arg("op") = ::c10d::ReduceOp::SUM,
               py::call_guard<py::gil_scoped_release>())
 
@@ -1558,13 +1555,53 @@ Arguments:
               py::call_guard<py::gil_scoped_release>())
           .def(
               "_start_coalescing",
-              &::c10d::ProcessGroup::startCoalescing,
+              [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+                 const c10::Device& device) {
+                self->startCoalescing(device.type());
+              },
+              py::arg("device_type"),
               py::call_guard<py::gil_scoped_release>())
           .def(
               "_end_coalescing",
-              &::c10d::ProcessGroup::endCoalescing,
+              [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+                 const c10::Device& device,
+                 std::vector<c10::intrusive_ptr<::c10d::Work>>& reqs) {
+                self->endCoalescing(device.type(), reqs);
+              },
+              py::arg("device_type"),
               py::arg("reqs"),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_register_backend",
+              [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+                 const c10::Device& device,
+                 const ::c10d::ProcessGroup::BackendType& backendType,
+                 const c10::optional<c10::intrusive_ptr<::c10d::Backend>>&
+                     backend) {
+                self->setBackend(device.type(), backendType, backend);
+              },
+              py::arg("device"),
+              py::arg("backend_type"),
+              py::arg("backend") =
+                  c10::optional<c10::intrusive_ptr<::c10d::Backend>>(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_get_backend",
+              [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+                 const c10::Device& device) {
+                return self->getBackend(device.type());
+              },
+              py::arg("device"),
               py::call_guard<py::gil_scoped_release>());
+
+  py::enum_<::c10d::ProcessGroup::BackendType>(processGroup, "BackendType")
+      .value("UNDEFINED", ::c10d::ProcessGroup::BackendType::UNDEFINED)
+      .value("GLOO", ::c10d::ProcessGroup::BackendType::GLOO)
+      .value("NCCL", ::c10d::ProcessGroup::BackendType::NCCL)
+      .value("UCC", ::c10d::ProcessGroup::BackendType::UCC)
+      .value("MPI", ::c10d::ProcessGroup::BackendType::MPI)
+      .value("CUSTOM", ::c10d::ProcessGroup::BackendType::CUSTOM)
+      .export_values();
 
   // base ProcessGroup::Options binding
   auto processGroupOptions =
@@ -1575,13 +1612,22 @@ Arguments:
 Base class for all processs group options implementations, such as the nccl
 options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
 )")
+          .def(
+              py::init([](const std::string& backend,
+                          const std::chrono::milliseconds& timeout) {
+                return c10::make_intrusive<::c10d::ProcessGroup::Options>(
+                    backend, timeout);
+              }),
+              py::arg("backend"),
+              py::arg("timeout") = kProcessGroupDefaultTimeout,
+              py::call_guard<py::gil_scoped_release>())
           .def_readonly("backend", &::c10d::ProcessGroup::Options::backend)
           .def_readwrite("_timeout", &::c10d::ProcessGroup::Options::timeout);
 
 #ifndef _WIN32
   module.def(
       "_round_robin_process_groups",
-      [](std::vector<c10::intrusive_ptr<::c10d::ProcessGroup>> processGroups)
+      [](std::vector<c10::intrusive_ptr<::c10d::Backend>> processGroups)
           -> c10::intrusive_ptr<::c10d::ProcessGroup> {
         if (processGroups.size() == 0) {
           throw std::invalid_argument("Specify at least 1 process group");
@@ -1594,12 +1640,304 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
       py::call_guard<py::gil_scoped_release>());
 #endif
 
+  // TODO: The collection definitions handles direct instantiation of
+  // ProcessGroup subclasses (e.g. dist.ProcessGroupGloo). This is not supported
+  // and should be removed once all tests are transitioned
+  auto backend =
+      py::class_<::c10d::Backend, c10::intrusive_ptr<::c10d::Backend>>(
+          module, "Backend")
+          .def("rank", &::c10d::Backend::getRank)
+          .def("size", &::c10d::Backend::getSize)
+          .def("name", &::c10d::Backend::getBackendName)
+          .def(
+              "broadcast",
+              &::c10d::Backend::broadcast,
+              py::arg("tensors"),
+              py::arg("opts") = ::c10d::BroadcastOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "broadcast",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 at::Tensor& x,
+                 int rootRank) {
+                ::c10d::BroadcastOptions opts;
+                opts.rootRank = rootRank;
+                std::vector<at::Tensor> xs = {x};
+                return self->broadcast(xs, opts);
+              },
+              py::arg("tensor"),
+              py::arg("root"),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "allreduce",
+              &::c10d::Backend::allreduce,
+              py::arg("tensors"),
+              py::arg("opts") = ::c10d::AllreduceOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "allreduce",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 std::vector<at::Tensor>& xs,
+                 ::c10d::ReduceOp op) {
+                ::c10d::AllreduceOptions opts;
+                opts.reduceOp = op;
+                return self->allreduce(xs, opts);
+              },
+              py::arg("tensors"),
+              py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "allreduce",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 at::Tensor& x,
+                 ::c10d::ReduceOp op) {
+                ::c10d::AllreduceOptions opts;
+                opts.reduceOp = op;
+                std::vector<at::Tensor> xs = {x};
+                return self->allreduce(xs, opts);
+              },
+              py::arg("tensor"),
+              py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "allreduce_coalesced",
+              &::c10d::Backend::allreduce_coalesced,
+              py::arg("tensors"),
+              py::arg("opts") = ::c10d::AllreduceCoalescedOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "reduce",
+              &::c10d::Backend::reduce,
+              py::arg("tensors"),
+              py::arg("opts") = ::c10d::ReduceOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "reduce",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 at::Tensor& x,
+                 int rootRank,
+                 ::c10d::ReduceOp op) {
+                ::c10d::ReduceOptions opts;
+                opts.reduceOp = op;
+                opts.rootRank = rootRank;
+                std::vector<at::Tensor> xs = {x};
+                return self->reduce(xs, opts);
+              },
+              py::arg("tensor"),
+              py::arg("root"),
+              py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "allgather",
+              &::c10d::Backend::allgather,
+              py::arg("output_tensors"),
+              py::arg("input_tensors"),
+              py::arg("opts") = ::c10d::AllgatherOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_allgather_base",
+              &::c10d::Backend::_allgather_base,
+              py::arg("output"),
+              py::arg("input"),
+              py::arg("opts") = ::c10d::AllgatherOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "allgather",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 std::vector<at::Tensor>& output,
+                 at::Tensor& input) {
+                std::vector<std::vector<at::Tensor>> outputs = {output};
+                std::vector<at::Tensor> inputs = {input};
+                return self->allgather(
+                    outputs, inputs, ::c10d::AllgatherOptions());
+              },
+              py::arg("output_tensors"),
+              py::arg("input_tensor"),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "allgather_coalesced",
+              &::c10d::Backend::allgather_coalesced,
+              py::arg("output_lists"),
+              py::arg("input_list"),
+              py::arg("opts") = ::c10d::AllgatherOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "gather",
+              &::c10d::Backend::gather,
+              py::arg("output_tensors"),
+              py::arg("input_tensors"),
+              py::arg("opts") = ::c10d::GatherOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "gather",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 std::vector<at::Tensor>& output,
+                 at::Tensor& input,
+                 int rootRank) {
+                ::c10d::GatherOptions opts;
+                opts.rootRank = rootRank;
+                std::vector<std::vector<at::Tensor>> outputs = {output};
+                std::vector<at::Tensor> inputs = {input};
+                return self->gather(outputs, inputs, opts);
+              },
+              py::arg("output_tensors"),
+              py::arg("input_tensor"),
+              py::arg("root"),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "scatter",
+              &::c10d::Backend::scatter,
+              py::arg("output_tensors"),
+              py::arg("input_tensors"),
+              py::arg("opts") = ::c10d::ScatterOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "scatter",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 at::Tensor& output,
+                 std::vector<at::Tensor>& input,
+                 int rootRank) {
+                ::c10d::ScatterOptions opts;
+                opts.rootRank = rootRank;
+                std::vector<std::vector<at::Tensor>> inputs = {input};
+                std::vector<at::Tensor> outputs = {output};
+                return self->scatter(outputs, inputs, opts);
+              },
+              py::arg("output_tensor"),
+              py::arg("input_tensors"),
+              py::arg("root"),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "reduce_scatter",
+              &::c10d::Backend::reduce_scatter,
+              py::arg("output_tensors"),
+              py::arg("input_tensors"),
+              py::arg("opts") = ::c10d::ReduceScatterOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "reduce_scatter",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 at::Tensor& output,
+                 std::vector<at::Tensor>& input,
+                 ::c10d::ReduceOp op) {
+                std::vector<at::Tensor> outputs = {output};
+                std::vector<std::vector<at::Tensor>> inputs = {input};
+                ::c10d::ReduceScatterOptions opts;
+                opts.reduceOp = op;
+                return self->reduce_scatter(outputs, inputs, opts);
+              },
+              py::arg("output_tensors"),
+              py::arg("input_tensor"),
+              py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_reduce_scatter_base",
+              &::c10d::Backend::_reduce_scatter_base,
+              py::arg("outputTensor"),
+              py::arg("inputTensor"),
+              py::arg("opts") = ::c10d::ReduceScatterOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "alltoall_base",
+              &::c10d::Backend::alltoall_base,
+              py::arg("output_tensor"),
+              py::arg("input_tensor"),
+              py::arg("output_split_sizes"),
+              py::arg("input_split_sizes"),
+              py::arg("opts") = ::c10d::AllToAllOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "alltoall_base",
+              [](::c10d::Backend& self,
+                 at::Tensor& output,
+                 at::Tensor& input,
+                 std::vector<int64_t> outputSplitSizes,
+                 std::vector<int64_t> inputSplitSizes) {
+                return self.alltoall_base(
+                    output,
+                    input,
+                    outputSplitSizes,
+                    inputSplitSizes,
+                    ::c10d::AllToAllOptions());
+              },
+              py::arg("output"),
+              py::arg("input"),
+              py::arg("output_split_sizes"),
+              py::arg("input_split_sizes"),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "alltoall",
+              &::c10d::Backend::alltoall,
+              py::arg("output_tensor"),
+              py::arg("input_tensor"),
+              py::arg("opts") = ::c10d::AllToAllOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "send",
+              &::c10d::Backend::send,
+              py::arg("tensors"),
+              py::arg("dstRank"),
+              py::arg("tag"),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "recv",
+              &::c10d::Backend::recv,
+              py::arg("tensors"),
+              py::arg("srcRank"),
+              py::arg("tag"),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "recv_anysource",
+              &::c10d::Backend::recvAnysource,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "barrier",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 const ::c10d::BarrierOptions& opts) {
+                return self->barrier(opts);
+              },
+              py::arg("opts") = ::c10d::BarrierOptions(),
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_set_sequence_number_for_group",
+              &::c10d::Backend::setSequenceNumberForGroup,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_get_sequence_number_for_group",
+              &::c10d::Backend::getSequenceNumberForGroup,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "monitored_barrier",
+              [](const c10::intrusive_ptr<::c10d::Backend>& self,
+                 const std::chrono::milliseconds& timeout,
+                 bool waitAllRanks) {
+                ::c10d::BarrierOptions opts;
+                opts.timeout = timeout;
+                return self->monitoredBarrier(opts, waitAllRanks);
+              },
+              py::arg("timeout") = ::c10d::kUnsetTimeout,
+              py::arg("wait_all_ranks") = false,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_get_backend_name",
+              &::c10d::Backend::getBackendName,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_start_coalescing",
+              &::c10d::Backend::startCoalescing,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_end_coalescing",
+              &::c10d::Backend::endCoalescing,
+              py::arg("reqs"),
+              py::call_guard<py::gil_scoped_release>());
+
 #ifdef USE_C10D_GLOO
   static const std::string GLOO_SOCKET_IFNAME_ENV = "GLOO_SOCKET_IFNAME";
 
   auto processGroupGloo =
       intrusive_ptr_no_gil_destructor_class_<::c10d::ProcessGroupGloo>(
-          module, "ProcessGroupGloo", processGroup);
+          module, "ProcessGroupGloo", backend);
 
   shared_ptr_class_<::gloo::transport::Device>(processGroupGloo, "Device");
 
@@ -1649,7 +1987,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
             // Use interfaces listed in "GLOO_SOCKET_IFNAME", if set.
             char* ifnameEnv = getenv(GLOO_SOCKET_IFNAME_ENV.c_str());
             if (ifnameEnv && strlen(ifnameEnv) > 1) {
-              for (const auto& iface : split(',', ifnameEnv)) {
+              for (const auto& iface : ::c10d::split(',', ifnameEnv)) {
                 options->devices.push_back(
                     ::c10d::ProcessGroupGloo::createDeviceForInterface(iface));
               }
@@ -1679,16 +2017,16 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
   // checking the op type and input tensor shapes.
   auto processGroupWrapper =
       intrusive_ptr_no_gil_destructor_class_<::c10d::ProcessGroupWrapper>(
-          module, "_ProcessGroupWrapper", processGroup)
+          module, "_ProcessGroupWrapper", backend)
           .def(
-              py::init([](const c10::intrusive_ptr<::c10d::ProcessGroup>& pg,
-                          const c10::intrusive_ptr<::c10d::ProcessGroupGloo>&
-                              gloo_pg) {
-                return c10::make_intrusive<::c10d::ProcessGroupWrapper>(
-                    pg, gloo_pg);
-              }),
-              py::arg("pg"),
-              py::arg("gloo_pg"),
+              py::init(
+                  [](const c10::intrusive_ptr<::c10d::Backend>& backend,
+                     const c10::intrusive_ptr<::c10d::Backend>& gloo_backend) {
+                    return c10::make_intrusive<::c10d::ProcessGroupWrapper>(
+                        backend, gloo_backend);
+                  }),
+              py::arg("backend"),
+              py::arg("gloo_backend"),
               py::call_guard<py::gil_scoped_release>())
           .def_property_readonly(
               "wrapped_pg", &::c10d::ProcessGroupWrapper::getWrappedPg);
@@ -1697,7 +2035,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
 #ifdef USE_C10D_NCCL
   auto processGroupNCCL =
       intrusive_ptr_no_gil_destructor_class_<::c10d::ProcessGroupNCCL>(
-          module, "ProcessGroupNCCL", processGroup)
+          module, "ProcessGroupNCCL", backend)
           .def(
               py::init<
                   const c10::intrusive_ptr<::c10d::Store>&,
@@ -1759,7 +2097,7 @@ Example::
 #ifdef USE_C10D_MPI
   auto processGroupMPI =
       intrusive_ptr_no_gil_destructor_class_<::c10d::ProcessGroupMPI>(
-          module, "ProcessGroupMPI", processGroup);
+          module, "ProcessGroupMPI", backend);
 
   // Define static create function instead of a constructor, because
   // this function may return null. This happens if this process is not
@@ -1775,7 +2113,7 @@ Example::
 #ifdef USE_C10D_UCC
   auto processGroupUCC =
       intrusive_ptr_no_gil_destructor_class_<::c10d::ProcessGroupUCC>(
-          module, "ProcessGroupUCC", processGroup)
+          module, "ProcessGroupUCC", backend)
           .def(
               py::init([](const c10::intrusive_ptr<::c10d::Store>& store,
                           int rank,

--- a/torch/csrc/distributed/c10d/logger.cpp
+++ b/torch/csrc/distributed/c10d/logger.cpp
@@ -92,8 +92,10 @@ void Logger::set_env_variables() {
         parse_env("GLOO_DEVICE_TRANSPORT");
 
 #ifdef USE_C10D_GLOO
-    auto gloo_pg =
-        static_cast<c10d::ProcessGroupGloo*>(reducer_->process_group_.get());
+    auto gloo_pg = static_cast<c10d::ProcessGroupGloo*>(
+        reducer_->process_group_
+            ->getBackend(c10d::ProcessGroup::BackendType::GLOO)
+            .get());
     auto n_threads = gloo_pg->getNumThreads();
     ddp_logging_data_->ints_map["gloo_num_threads"] = n_threads;
 #endif

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -28,6 +28,7 @@ if is_available():
         FileStore,
         TCPStore,
         ProcessGroup,
+        Backend as _Backend,
         PrefixStore,
         Reducer,
         Logger,

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -39,12 +39,12 @@ from .c10d_error_logger import _get_or_create_logger
 from .rendezvous import register_rendezvous_handler, rendezvous  # noqa: F401
 
 __all__ = [
-    'Backend', 'GroupMember', 'P2POp', 'all_gather', 'all_gather_coalesced',
+    'Backend', 'BackendConfig', 'GroupMember', 'P2POp', 'all_gather', 'all_gather_coalesced',
     'all_gather_multigpu', 'all_gather_object', 'all_reduce',
     'all_reduce_coalesced', 'all_reduce_multigpu', 'all_to_all',
     'all_to_all_single', 'barrier', 'batch_isend_irecv', 'broadcast',
     'broadcast_multigpu', 'broadcast_object_list', 'destroy_process_group',
-    'dist_backend', 'gather', 'gather_object', 'get_backend', 'get_rank',
+    'dist_backend', 'gather', 'gather_object', 'get_backend_config', 'get_backend', 'get_rank',
     'get_world_size', 'group', 'init_process_group', 'irecv',
     'is_gloo_available', 'is_initialized', 'is_mpi_available',
     'is_nccl_available', 'is_torchelastic_launched', 'is_ucc_available',
@@ -176,6 +176,8 @@ class Backend(object):
 
     _plugins: Dict[str, _BackendPlugin] = {}
 
+    backend_list = [UNDEFINED, GLOO, NCCL, UCC, MPI]
+
     def __new__(cls, name: str):
         if not isinstance(name, string_classes):
             raise ValueError("Backend name must be a string, but got: {}".format(name))
@@ -187,8 +189,6 @@ class Backend(object):
                 "Gloo or MPI backend for collective operations "
                 "on CPU tensors."
             )
-        elif value == Backend.UNDEFINED:
-            raise ValueError("Invalid backend: '{}'".format(name))
         elif value != Backend.GLOO and value != Backend.NCCL and value != Backend.UCC and value != Backend.MPI:
             value = name.lower()
         return value
@@ -227,8 +227,44 @@ class Backend(object):
         )
 
         setattr(Backend, name.upper(), name.upper())
+        Backend.backend_list.append(name.lower())
         Backend._plugins[name.upper()] = Backend._BackendPlugin(func, extended_api)
 
+class BackendConfig(object):
+
+    def __init__(self, backend: Union[str, Backend]):
+        self.device_backend_map: Dict[torch.device, Backend] = {}
+        # error check to make sure the config string is valid
+
+        # Cases for when backend is a single string (without device types)
+        if backend == Backend.UNDEFINED:
+            # default config when backend is not specified
+            self.device_backend_map = {
+                "cpu": Backend.GLOO,
+                "cuda": Backend.NCCL,
+            }
+        elif backend.lower() in Backend.backend_list:
+            # backend applies to all devices (e.g. "NCCL", "GLOO", "UCC", "MPI", "custom_backend")
+            backend_val = Backend(backend)
+            self.device_backend_map = {
+                "cpu": backend_val,
+                "cuda": backend_val,
+            }
+        else:
+            # custom backend string in format of "{device_type1}:{backend1},{device_type2}:{backend2}"
+            # TODO
+            pass
+
+        required_devices = ["cpu", "cuda"]
+        for device in required_devices:
+            assert device in self.device_backend_map
+
+    def __repr__(self):
+        # string with all the device:backend pairs separared by commas
+        return ",".join(f"{device}:{backend}" for device, backend in self.device_backend_map.items())
+
+    def get_device_backend_map(self):
+        return self.device_backend_map
 
 # `_backend`, `dist_backend`, and `reduce_op` are here to maintain backward
 # compatibility with pre-c10d distributed package.
@@ -267,6 +303,8 @@ reduce_op = _reduce_op()
 _pg_map: Dict[ProcessGroup, Tuple[str, Optional[Store]]] = {}
 _pg_names: Dict[ProcessGroup, str] = {}
 _pg_group_ranks: Dict[ProcessGroup, Dict[int, int]] = {}
+# For a pg, it is a map from ProcessGroup to BackendConfig
+_pg_backend_map: Dict[ProcessGroup, str] = {}
 _group_count = 0
 
 class _World:
@@ -679,6 +717,17 @@ def _get_default_store():
 def _update_default_pg(pg):
     _world.default_pg = pg
 
+def get_backend_config(group: Optional[ProcessGroup] = None) -> str:
+    if group is None:
+        pg = _get_default_group()
+    else:
+        pg = group
+    if _rank_not_in_group(pg):
+        raise RuntimeError("Invalid process group specified")
+    backend_config = _pg_backend_map.get(pg, None)
+    assert backend_config is not None
+    return str(backend_config)
+
 def get_backend(group: Optional[ProcessGroup] = None) -> str:
     """
     Returns the backend of the given process group.
@@ -704,7 +753,7 @@ def get_backend(group: Optional[ProcessGroup] = None) -> str:
 
 
 def init_process_group(
-    backend: Union[str, Backend],
+    backend: Union[str, Backend] = None,
     init_method: Optional[str] = None,
     timeout: timedelta = default_pg_timeout,
     world_size: int = -1,
@@ -805,7 +854,10 @@ def init_process_group(
     elif init_method is None:
         init_method = "env://"
 
-    backend = Backend(backend)
+    if backend:
+        backend = Backend(backend)
+    else:
+        backend = Backend("undefined")
 
     if backend == Backend.MPI:
         if world_size != -1 or rank != -1:
@@ -816,7 +868,7 @@ def init_process_group(
             )
 
         default_pg = _new_process_group_helper(
-            -1, -1, [], Backend.MPI, None, group_name=group_name, timeout=timeout
+            -1, -1, [], backend, None, group_name=group_name, timeout=timeout
         )
         _update_default_pg(default_pg)
     else:
@@ -858,9 +910,6 @@ def init_process_group(
         # Use store based barrier here since barrier() used a bunch of
         # default devices and messes up NCCL internal state.
         _store_based_barrier(rank, store, timeout)
-        # Set sequence numbers for gloo and nccl process groups.
-        if get_backend(default_pg) in [Backend.GLOO, Backend.NCCL]:
-            default_pg._set_sequence_number_for_group()
 
 
 def _new_process_group_helper(
@@ -880,7 +929,7 @@ def _new_process_group_helper(
     the calling process is not part of the newly created group. In that case,
     this function returns GroupMember.NON_GROUP_MEMBER.
 
-    This function is called with ``group_ranks == []`` for the default group.
+    This function is called with ``global_ranks_in_group == []`` for the default group.
     """
     global _world
 
@@ -902,35 +951,42 @@ def _new_process_group_helper(
     # The list of group ranks is empty if we're creating the default group.
     is_default_group = len(global_ranks_in_group) == 0
 
-    backend = Backend(backend)
-    pg: Union[ProcessGroupGloo, ProcessGroupMPI, ProcessGroupNCCL, ProcessGroupUCC]
-    if backend == Backend.MPI:
-        if not is_mpi_available():
-            raise RuntimeError(
-                "Distributed package doesn't have MPI built in."
-                " MPI is only included if you build PyTorch from"
-                " source on a host that has MPI installed."
-            )
-        pg = ProcessGroupMPI.create(global_ranks_in_group)
-        if not pg:
+    # If this is a subgroup (which means group_ranks is specified),
+    # we check if the current process is a member of the new group.
+    if not is_default_group:
+        global_rank = _get_default_group().rank()
+        if global_rank not in global_ranks_in_group:
             return GroupMember.NON_GROUP_MEMBER
-    else:
-        # If this is a subgroup (which means group_ranks is specified),
-        # we check if the current process is a member of the new group.
-        if not is_default_group:
-            global_rank = _get_default_group().rank()
-            if global_rank not in global_ranks_in_group:
-                return GroupMember.NON_GROUP_MEMBER
 
+    prefix_store = PrefixStore(f"{group_name}/", store)
+    base_pg_options = ProcessGroup.Options(backend=str(backend))
+    base_pg_options._timeout = timeout
+    pg: ProcessGroup = ProcessGroup(prefix_store, group_rank, group_size, base_pg_options)
+    backend_config = BackendConfig(backend)
+    for device, backend_str in backend_config.get_device_backend_map().items():
         # Use the group name as prefix in the default store, such that
         # a single store can be reused by multiple groups.
-        prefix_store = PrefixStore(group_name, store)
+        backend_prefix_store = PrefixStore(f"{device}/", prefix_store)
 
-        if backend == Backend.GLOO:
-            if pg_options is not None:
-                raise RuntimeError("GLOO options not supported")
-            pg = ProcessGroupGloo(prefix_store, group_rank, group_size, timeout=timeout)
-        elif backend == Backend.NCCL:
+        if backend_str == Backend.MPI:
+            if not is_mpi_available():
+                raise RuntimeError(
+                    "Distributed package doesn't have MPI built in."
+                    " MPI is only included if you build PyTorch from"
+                    " source on a host that has MPI installed."
+                )
+            backend_class = ProcessGroupMPI.create(global_ranks_in_group)
+            backend_type = ProcessGroup.BackendType.MPI
+            if not backend_class:
+                return GroupMember.NON_GROUP_MEMBER
+
+        if backend_str == Backend.GLOO:
+            # TODO: remove this check after lazy initialization is supported
+            # if pg_options is not None:
+            #     raise RuntimeError("GLOO options not supported")
+            backend_class = ProcessGroupGloo(backend_prefix_store, group_rank, group_size, timeout=timeout)
+            backend_type = ProcessGroup.BackendType.GLOO
+        elif backend_str == Backend.NCCL:
             if not is_nccl_available():
                 raise RuntimeError("Distributed package doesn't have NCCL " "built in")
             if pg_options is not None:
@@ -943,60 +999,83 @@ def _new_process_group_helper(
                 pg_options.is_high_priority_stream = False
                 pg_options._timeout = timeout
 
-            pg = ProcessGroupNCCL(prefix_store, group_rank, group_size, pg_options)
-        elif backend == Backend.UCC and is_ucc_available():
+            backend_class = ProcessGroupNCCL(backend_prefix_store, group_rank, group_size, pg_options)
+            backend_type = ProcessGroup.BackendType.NCCL
+        elif backend_str == Backend.UCC and is_ucc_available():
             # TODO: once UCC plugin is fully deprecated, remove
             # is_ucc_available() from above elif-condition and raise
             # RuntimeError if is_ucc_available() returns false.
 
-            pg = ProcessGroupUCC(prefix_store, group_rank, group_size, timeout=timeout)
+            backend_class = ProcessGroupUCC(backend_prefix_store, group_rank, group_size, timeout=timeout)
+            backend_type = ProcessGroup.BackendType.UCC
         else:
-            assert backend.upper() in Backend._plugins, (
-                f"Unknown c10d backend type {backend.upper()}"
+            assert backend_str.upper() in Backend._plugins, (
+                f"Unknown c10d backend type {backend_str.upper()}"
             )
 
-            backend_plugin = Backend._plugins[backend.upper()]
+            backend_plugin = Backend._plugins[backend_str.upper()]
             creator_fn = backend_plugin.creator_fn
             extended_api = backend_plugin.extended_api
 
             if not extended_api:
-                pg = creator_fn(prefix_store, group_rank, group_size, timeout)
+                backend_class = creator_fn(backend_prefix_store, group_rank, group_size, timeout)
             else:
                 dist_backend_opts = _DistributedBackendOptions()
-                dist_backend_opts.store = prefix_store
+                dist_backend_opts.store = backend_prefix_store
                 dist_backend_opts.group_rank = group_rank
                 dist_backend_opts.group_size = group_size
                 dist_backend_opts.timeout = timeout
                 dist_backend_opts.group_id = group_name
                 dist_backend_opts.global_ranks_in_group = global_ranks_in_group
 
-                pg = creator_fn(dist_backend_opts, pg_options)
+                backend_class = creator_fn(dist_backend_opts, pg_options)
 
-    # Process group wrapper initialization for supported PGs when TORCH_DISTRIBUTED_DEBUG is set
-    if backend in [Backend.GLOO, Backend.NCCL, Backend.UCC]:
-        # In debug mode and if GLOO is available, wrap in a wrapper PG that
-        # enables enhanced collective checking for debuggability.
-        if get_debug_level() == DebugLevel.DETAIL:
-            if not _GLOO_AVAILABLE:
-                logger.info(
-                    """TORCH_DISTRIBUTED_DEBUG was set to DETAIL, but
-                            GLOO is not available. Build with Gloo to
-                            create a wrapper process group in debug mode
-                            to aid collective desynchronization debugging."""
-                )
-            else:
-                pg = _create_process_group_wrapper(
-                    wrapped_pg=pg,
-                    store_prefix=group_name,
-                    store=store,
-                    rank=group_rank,
-                    world_size=group_size,
-                    timeout=timeout,
-                )
+        # Set sequence numbers for gloo and nccl backends.
+        if backend_str in [Backend.GLOO, Backend.NCCL]:
+            backend_class._set_sequence_number_for_group()
+        # If the type is a sublcass of ProcessGroup then return this process group immediately
+        # TODO: This defaults to the old behavior for PythonProcessGroups which overwrites the
+        # ProcessGroup instance
+        if issubclass(type(backend_class), ProcessGroup):
+            pg = backend_class
+            break
+
+        # Process group wrapper initialization for supported PGs when TORCH_DISTRIBUTED_DEBUG is set
+        if backend_str in [Backend.GLOO, Backend.NCCL, Backend.UCC]:
+            # In debug mode and if GLOO is available, wrap in a wrapper PG that
+            # enables enhanced collective checking for debuggability.
+            if get_debug_level() == DebugLevel.DETAIL:
+                if not _GLOO_AVAILABLE:
+                    logger.info(
+                        """TORCH_DISTRIBUTED_DEBUG was set to DETAIL, but
+                                GLOO is not available. Build with Gloo to
+                                create a wrapper process group in debug mode
+                                to aid collective desynchronization debugging."""
+                    )
+                else:
+                    backend_class = _create_process_group_wrapper(
+                        wrapped_pg=backend_class,
+                        store_prefix=group_name,
+                        store=backend_prefix_store,
+                        rank=group_rank,
+                        world_size=group_size,
+                        timeout=timeout,
+                    )
+
+        # only create single backend pg when backend is set to gloo, nccl, mpi, and ucc
+        if backend in [Backend.GLOO, Backend.NCCL, Backend.UCC, Backend.MPI]:
+            for device in backend_config.get_device_backend_map().keys():
+                pg._register_backend(torch.device(device), backend_type, backend_class)
+
+            # break out of outer loop to not create any more backends
+            break
+        else:
+            pg._register_backend(torch.device(device), backend_type, backend_class)
 
     # update global state
-    _world.pg_map[pg] = (backend, store)
+    _world.pg_map[pg] = (backend, prefix_store)
     _world.pg_names[pg] = group_name
+    _pg_backend_map[pg] = str(backend_config)
     return pg
 
 
@@ -1011,6 +1090,7 @@ def destroy_process_group(group: Optional[ProcessGroup] = None):
                                         be destroyed.
     """
     global _world
+    global _pg_backend_map
 
     if group == GroupMember.NON_GROUP_MEMBER:
         return
@@ -1029,6 +1109,7 @@ def destroy_process_group(group: Optional[ProcessGroup] = None):
         _world.pg_map.clear()
         _world.pg_names.clear()
         _world.pg_group_ranks.clear()
+        _pg_backend_map.clear()
 
         # when process group doesn't have an explicit name (only WORLD (default)
         # process group can have an explicit name), we use global _world.group_count
@@ -1043,6 +1124,7 @@ def destroy_process_group(group: Optional[ProcessGroup] = None):
         del _world.pg_map[pg]
         del _world.pg_names[pg]
         del _world.pg_group_ranks[pg]
+        del _pg_backend_map[pg]
 
 
 def get_rank(group: Optional[ProcessGroup] = None) -> int:
@@ -1271,14 +1353,14 @@ class P2POp(object):
 
 
 @contextlib.contextmanager
-def _coalescing_manager(group, reqs):
+def _coalescing_manager(group, device, reqs):
     if group is None:
         group = _get_default_group()
-    group._start_coalescing()
+    group._start_coalescing(device)
     try:
         yield
     finally:
-        group._end_coalescing(reqs)
+        group._end_coalescing(device, reqs)
 
 
 def batch_isend_irecv(p2p_op_list):
@@ -1323,8 +1405,9 @@ def batch_isend_irecv(p2p_op_list):
     """
     _check_p2p_op_list(p2p_op_list)
     group = p2p_op_list[0].group
+    device = p2p_op_list[0].tensor.device
     reqs = []
-    with _coalescing_manager(group, reqs):
+    with _coalescing_manager(group, device, reqs):
         for p2p_op in p2p_op_list:
             op = p2p_op.op
             tensor = p2p_op.tensor
@@ -1875,7 +1958,7 @@ def _check_for_nccl_backend(group):
 
     return (
         is_nccl_available() and
-        isinstance(pg, ProcessGroupNCCL)
+        pg.name() == Backend.NCCL
     )
 
 @exception_handler
@@ -3435,12 +3518,6 @@ def new_group(ranks=None, timeout=default_pg_timeout, backend=None, pg_options=N
         # Use store based barrier here since barrier() used a bunch of
         # default devices and messes up NCCL internal state.
         _store_based_barrier(global_rank, default_store, timeout)
-        # Set sequence numbers for gloo and nccl process groups.
-        if pg != GroupMember.NON_GROUP_MEMBER and get_backend(pg) in [
-            Backend.GLOO,
-            Backend.NCCL,
-        ]:
-            pg._set_sequence_number_for_group()
 
     return pg
 

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -721,10 +721,6 @@ class DistributedTest:
             backend = BACKEND.lower()
             self.assertEqual(dist.Backend(BACKEND.upper()), backend)
             self.assertEqual(dist.Backend(BACKEND), backend)
-            with self.assertRaisesRegex(ValueError, "Invalid backend: 'undefined'"):
-                dist.Backend("undefined")
-            with self.assertRaisesRegex(ValueError, "Invalid backend: 'xYz'"):
-                dist.Backend("xYz")
             with self.assertRaises(ValueError):
                 dist.Backend(None)
             with self.assertRaises(ValueError):


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/88330

### Implementation
Move backend-specific (NCCL, Gloo, etc) collective implementations to corresponding `Backend` class. Update ProcessGroup to support multiple backends and use dispatcher to calls backends based on tensor device type.

### Changes

#### c++ changes (ProcessGroup files, `Ops.cpp`, `init.cpp`)
- Update pybind definitions for new process group base class and new backend class
- Update pybinded backend class with collective definitions to keep BC with Python PG instances (e.g. `dist.ProcessGroupGloo`, `dist.ProcessGroupNCCL`) which are used in tests
- Switch `ProcessGroupGloo`, `ProcessGroupNCCL`, `ProcessGroupMPI`, `ProcessGroupUCC` to derive from the `Backend` class.
- Update CPU/CUDA `Ops.cpp` and `OpsImpl.cpp` to perform this dispatching by querying the backend using the device type
- Update internal dispatched implementation of `barrier` to use a tensor which allows operation to be dispatched.
- Update `allgather` collective to use `TensorList`. For some reason it was using the default implementation of `allgather` rather than dispatching it correctly. I still don't understand why and had originally filed an issue in 85122.

#### python changes (`distributed_c10d.py`, test files)
- Add BackendConfig class to specify the default configurations of backends and `get_backend_config()` API
- `get_backend()` deprecation warning
- `init_process_group` how returns a generic `ProcessGroup` object, it contains a list of backends (the ones stated above) which it will dispatch operations to.
- `new_group` updated to return the same as above
- Update `test_c10d_gloo.py`, Update `DistributedDataParallelTest` to use `init_process_group`, Update `ReducerTest`, update `test_broadcast_coalesced_gloo` to move from PG instance and gloo options
- Update `test_c10d_nccl.py`, Update `DistributedDataParallelTest` to use `init_process_group`
- Specific tests updated: `test_Backend_enum_class`

### Changes missing
- lazy initialization of backends
- support parsing of BackendConfig

### open questions
- Pure Python PG extensions (https://github.com/pytorch/pytorch/pull/66338)

# Example

This is a basic script (using 2 backends within a process group)

```python
# python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 basic_scenario.py
import torch.distributed as dist
import torch
import os

if __name__ == "__main__":
    rank = os.environ.get("RANK")
    # initialize with both gloo and nccl
    dist.init_process_group()
    # with gloo
    dist.all_reduce(torch.tensor([1.0]))
    print(f"Rank {rank} finished")
    # with nccl
    dist.all_reduce(torch.tensor([1.0], device=f"cuda:{rank}"))
```

Test Plan: Imported from OSS

Differential Revision: D42069829

Pulled By: H-Huang

