### PR TITLE
tools: Update clang-tidy hash

### DIFF
--- a/tools/linter/adapters/s3_init_config.json
+++ b/tools/linter/adapters/s3_init_config.json
@@ -22,7 +22,7 @@
         },
         "Linux": {
             "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/clang-tidy",
-            "hash": "49343a448fcb75cd1e0fb9d6b1f6c2ef4b008b6f91d6ff899d4ac6060f5e52a5"
+            "hash": "e4a1537ee997aa486a67bcc06d050b1aa6cfb14aa3073c08f19123ac990ab2f7"
         }
     },
     "actionlint": {


### PR DESCRIPTION
clang-tidy was updated due to a BE change (https://github.com/pytorch/test-infra/pull/1309), this updates the hash to the latest version through an [automated github action](https://github.com/pytorch/test-infra/actions/runs/3713717677) causing failures since the s3 hash is hardcoded here;

To resolve failures like: ([logs](https://github.com/pytorch/pytorch/actions/runs/3714626185/jobs/6298779282#step:5:81))

```
INFO: Downloaded clang-tidy successfully.
WARNING: Found binary hash does not match reference!

Found hash: e4a1537ee997aa486a67bcc06d050b1aa6cfb14aa3073c08f19123ac990ab2f7
Reference hash: 4[93](https://github.com/pytorch/pytorch/actions/runs/3714626185/jobs/6298779282#step:5:94)43a448fcb75cd1e0fb9d6b1f6c2ef4b008b6f91d6ff899d4ac6060f5e52a5

Deleting .lintbin/clang-tidy just to be safe.

CRITICAL: Downloaded binary clang-tidy failed its hash check
CRITICAL: Unable to initialize clang-tidy
error:        lint initializer for 'CLANGTIDY' failed with non-zero exit code
```

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Fixes #ISSUE_NUMBER
