### PR TITLE
[sharded tensor] skip empty local tensor in gather

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -476,9 +476,10 @@ class ShardedTensor(ShardedTensorBase):
             data = torch.empty(max_rank_size, device=self._get_preferred_device())
 
             for shard in local_shards:
-                src = shard.tensor.flatten()
-                shard_offset = shard_placement[shard.metadata][1]
-                data[shard_offset: shard_offset + src.numel()].copy_(src)
+                if shard.tensor.numel() > 0:
+                    src = shard.tensor.flatten()
+                    shard_offset = shard_placement[shard.metadata][1]
+                    data[shard_offset: shard_offset + src.numel()].copy_(src)
 
         dist.gather(
             tensor=data,


### PR DESCRIPTION
Summary: local tensor can be empty and cause the gather to fail

Test Plan: jeevg will verify this in a E2E test

Differential Revision: D42103140

