### PR TITLE
fix DebugInterpreter, use it + functionalization stride debugger unconditionally in aot_eager backend

### DIFF
--- a/torch/_functorch/compilers.py
+++ b/torch/_functorch/compilers.py
@@ -121,8 +121,9 @@ def nop(fx_g: fx.GraphModule, _) -> Callable:
 
 class DebugInterpreter(fx.Interpreter):
     def run(self, *args):
-        self.symbol_mapping = bind_symbols(self.module, *args)
-        super().run(*args)
+        if hasattr(self.module, "shape_env"):
+            self.symbol_mapping = bind_symbols(self.module, *args)
+        return super().run(*args)
 
     def run_node(self, n):
         import sympy


### PR DESCRIPTION
The aot_eager backend now performs to types of stride checks automatically:
(1) at compile time, when running functioanlization we perform stride checks
(2) at runtime, when executing the graph we perform stride checks

Adding these debug asserts so that they always run in the `aot_eager` backend has a small downside: at runtime, the backend will technically be slower than eager mode.

This tentatively seems ok: the main purpose of this backend is for debugging purposes anyway.

This also would have caught a silent correctness error automatically, that was fixed at https://github.com/pytorch/pytorch/pull/91029

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91038
* #91012
* #88816



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire