### PR TITLE
[CUDA12] Clean up deprecated APIs

### DIFF
--- a/aten/src/ATen/cuda/CUDASparseDescriptors.h
+++ b/aten/src/ATen/cuda/CUDASparseDescriptors.h
@@ -143,9 +143,9 @@ class TORCH_CUDA_CPP_API CuSparseDnVecDescriptor
 class TORCH_CUDA_CPP_API CuSparseSpMatDescriptor
     : public CuSparseDescriptor<cusparseSpMatDescr, &cusparseDestroySpMat> {};
 
-#endif //AT_USE_HIPSPARSE_GENERIC_52_API() || (AT_USE_CUSPARSE_GENERIC_API() || AT_USE_CUSPARSE_NON_CONST_DESCRIPTORS())
+//AT_USE_HIPSPARSE_GENERIC_52_API() || (AT_USE_CUSPARSE_GENERIC_API() && AT_USE_CUSPARSE_NON_CONST_DESCRIPTORS())
 
-#if AT_USE_CUSPARSE_CONST_DESCRIPTORS()
+#elif AT_USE_CUSPARSE_CONST_DESCRIPTORS()
   class TORCH_CUDA_CPP_API CuSparseDnMatDescriptor
       : public ConstCuSparseDescriptor<
             cusparseDnMatDescr,

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cpp
@@ -163,9 +163,9 @@ void _csrmm2(
     descA, descB,
     beta,
     descC,
-    cusparse_value_type,  /* data type in which the computation is executed */
-    CUSPARSE_SPMM_CSR_ALG1,  /* default computing algorithm for CSR sparse matrix format */
-    &bufferSize           /* output */
+    cusparse_value_type,      /* data type in which the computation is executed */
+    CUSPARSE_SPMM_CSR_ALG1,   /* default computing algorithm for CSR sparse matrix format */
+    &bufferSize               /* output */
   ));
 
   auto& allocator = *c10::cuda::CUDACachingAllocator::get();
@@ -177,9 +177,9 @@ void _csrmm2(
     descA, descB,
     beta,
     descC,
-    cusparse_value_type,  /* data type in which the computation is executed */
-    CUSPARSE_SPMM_CSR_ALG1,  /* default computing algorithm for CSR sparse matrix format */
-    dataPtr.get()         /* external buffer */
+    cusparse_value_type,      /* data type in which the computation is executed */
+    CUSPARSE_SPMM_CSR_ALG1,   /* default computing algorithm for CSR sparse matrix format */
+    dataPtr.get()             /* external buffer */
   ));
 
   TORCH_CUDASPARSE_CHECK(cusparseDestroySpMat(descA));


### PR DESCRIPTION
See #91122
Summary:
Some APIs are deprecated in newer version of CUDA.
* cudaGraphInstantiate:
From:
```
cudaGraphInstantiate ( cudaGraphExec_t* pGraphExec, cudaGraph_t graph, cudaGraphNode_t* pErrorNode, char* pLogBuffer, size_t bufferSize )
```
To
```
__host__​cudaError_t cudaGraphInstantiate ( cudaGraphExec_t* pGraphExec, cudaGraph_t graph, unsigned long long flags = 0 )
```
* cudaProfilerInitialize: deprecated in cuda 11 and removed in cuda 12

Test Plan: GH CI

Differential Revision: D41469051

