### PR TITLE
[MPS] Fix index_select scalar input with multiple indices

### DIFF
--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -629,6 +629,12 @@ Tensor& index_select_out_mps(const Tensor & self,
   TORCH_CHECK(dim == 0 || dim < self.dim(),
               "index_select(): Indexing dim ", dim, " is out of bounds of tensor");
 
+  // Scalar input
+  if (self.dim() == 0 && self.numel() == 1){
+    output.copy_(self);
+    return output;
+  }
+
   // Derive from MPSCachedGraph
   struct CachedGraph : public MPSCachedGraph
   {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5108,6 +5108,22 @@ class TestNLLLoss(TestCase):
         helper((2, 8, 4, 5), 2, [3, 0, 1])
         helper((2, 8, 4, 5), 3, [2, 3, 0])
         helper((2, 3, 3), -1, [1, 2])
+        helper((), 0, [0])
+
+    def test_index_select_scalar(self):
+        def helper(value, dim, index, idx_dtype=torch.int32):
+            cpu_x = torch.tensor(value, device='cpu', dtype=torch.float, requires_grad=False)
+            x = cpu_x.detach().clone().to('mps')
+
+            cpu_idx = torch.tensor(index, device='cpu', dtype=idx_dtype)
+            idx = cpu_idx.detach().clone().to('mps')
+
+            idx_result = torch.index_select(x, dim=dim, index=idx)
+            idx_result_cpu = torch.index_select(cpu_x, dim=dim, index=cpu_idx)
+
+            self.assertEqual(idx_result, idx_result_cpu)
+
+        helper(0.5, 0, [0, 0])
 
     def test_embedding_dense_backward(self):
         def helper(n, d, m, idx):


### PR DESCRIPTION
Support operations like this:

```
device="mps"
arr = torch.tensor(10, device=device)
indices = torch.tensor([0, 0], device=device)  # multiple indices 
torch.index_select(arr, 0, indices)
```

cc @kulinseth @albanD @malfet @DenisVieriu97 @razarmehr @abhudev