### PR TITLE
Autocast support for scaled_dot_product_attention

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -389,6 +389,8 @@ TORCH_LIBRARY_IMPL(aten, Autocast, m) {
   KERNEL(gru_cell, lower_precision_fp)
   KERNEL(rnn_tanh_cell, lower_precision_fp)
   KERNEL(rnn_relu_cell, lower_precision_fp)
+  KERNEL(_scaled_dot_product_flash_attention, lower_precision_fp)
+  KERNEL(_scaled_dot_product_attention, lower_precision_fp)
 
   // fp32
   KERNEL(acos, fp32)


### PR DESCRIPTION
Summary: Autocast support for scaled_dot_product_attention

Test Plan: sandcastle and guthub cicd

Differential Revision: D42085525



cc @mcarilli @ptrblck @leslie-fang-intel @jgong5