### PR TITLE
move inputs to device on root module only

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -671,8 +671,8 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         with torch.autograd.profiler.record_function(
             "FullyShardedDataParallel.forward"
         ):
+            args, kwargs = _root_pre_forward(self, self, args, kwargs)
             unused = None
-            _root_pre_forward(self, self, unused)
             unshard_fn = functools.partial(_pre_forward_unshard, self, self._handles)
             reshard_fn = functools.partial(_post_forward_reshard, self, self._handles)
             args, kwargs = _pre_forward(


### PR DESCRIPTION
1. No need to move inputs/activations to devices for every nested FSDP instance
2. it also breaks the case when some nested FSDP instances have newly added inputs/activations in the signatures of submodules wrapped by nested FSDP instances, args_tuple[0] and kargs_tuple[0] are not correct to get the inputs/activations for these nested instances
