### PR TITLE
Allow FSDP to have ignored modules out of wrapped root

### DIFF
--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -588,7 +588,7 @@ def _get_ignored_params(
             # This is useful when user apply FSDP manually to different
             # submodules with the same global set of ignored parameters.
             warnings.warn(
-                f"Paramter {name} is in the ignored modules passed to FSDP, "
+                f"Parameter {name} is in the ignored modules passed to FSDP, "
                 "but it's not under the root module wrapped by FSDP."
             )
             continue

--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -570,8 +570,11 @@ def _get_ignored_params(
     excluding any :class:`FlatParameter` s, and their fully prefixed names,
     both as :class:`set` s.
     """
-    ignored_params = set(
-        p for m in ignored_modules for p in m.parameters() if not _is_fsdp_flattened(p)
+    ignored_params_to_names = dict(
+        (p, n)
+        for m in ignored_modules
+        for n, p in m.named_parameters()
+        if not _is_fsdp_flattened(p)
     )
     # Conservatively include all shared parameters' names
     param_to_unflat_param_names = _get_param_to_fqns(
@@ -579,14 +582,24 @@ def _get_ignored_params(
         dedup_shared_params=False,
     )
     ignored_param_names = set()
-    for param in ignored_params:
+    for param, name in ignored_params_to_names.items():
+        if param not in param_to_unflat_param_names:
+            # Allow users to pass parameters not under FSDP root module.
+            # This is useful when user apply FSDP manually to different
+            # submodules with the same global set of ignored parameters.
+            warnings.warn(
+                f"Paramter {name} is in the ignored modules passed to FSDP, "
+                "but it's not under the root module wrapped by FSDP."
+            )
+            continue
+
         unflat_param_names = param_to_unflat_param_names[param]
         clean_names = []
         for k in unflat_param_names:
             # Clean any module wrapper prefixes in case of nested wrapping
             clean_names.append(clean_tensor_name(k))
         ignored_param_names.update(clean_names)
-    return ignored_params, ignored_param_names
+    return set(ignored_params_to_names.keys()), ignored_param_names
 
 
 def _get_buffer_names(root_module: nn.Module) -> Set[str]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91079

Motivations for this change:

1. TorchRec returns inconsistent results on `m.named_parameters()`
   and `m.m1.named_parameters()` if m1 is a `ShardedModule`. Basically,
   `ShardedModule` appears in `m.named_modules()`, but its parameters
   are not in `m.named_parameters()`. As a result, when we identify
   `ShardedModule` and pass them as `ignored_modules` to FSDP, FSDP
   complains about key error in `_get_ignored_params`.
2. If users are manually wrapping submodules with FSDP, it could be
   easier for them to keep a global set of ignored parameters, instead
   of create a new collection for every FSDP invocation.

Given the above two reasons, we allow FSDP to have ignored modules
out of the wrapped root module.

Differential Revision: [D42132394](https://our.internmc.facebook.com/intern/diff/D42132394)