### PR TITLE
replace vec::vec_scalar_t with at::opmath_type

### DIFF
--- a/aten/src/ATen/cpu/vml.h
+++ b/aten/src/ATen/cpu/vml.h
@@ -2,6 +2,7 @@
 
 #include <ATen/Config.h>
 #include <ATen/Parallel.h>
+#include <ATen/OpMathType.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/complex.h>
@@ -83,7 +84,7 @@ inline void vrsqrt(scalar_t* out, scalar_t* in, int64_t size) {
       c10::BFloat16* out, const c10::BFloat16* in, int64_t size) {                \
     parallel_for(0, size, 2048, [out, in](int64_t begin, int64_t end) {           \
       DL_RUNTIME_BUG_BFLOAT16()                                                   \
-      using vecscalar_t = vec_scalar_t<c10::BFloat16>;                            \
+      using vecscalar_t = at::opmath_type<c10::BFloat16>;                            \
       map([](const Vectorized<vecscalar_t>& x) { return x.op(); },                \
           out + begin,                                                            \
           in + begin,                                                             \
@@ -95,7 +96,7 @@ inline void vrsqrt(scalar_t* out, scalar_t* in, int64_t size) {
   template <typename scalar_t>                                                    \
   inline void v##op(scalar_t* out, const scalar_t* in, int64_t size) {            \
     parallel_for(0, size, 2048, [out, in](int64_t begin, int64_t end) {           \
-      using vecscalar_t = vec_scalar_t<scalar_t>;                                 \
+      using vecscalar_t = at::opmath_type<scalar_t>;                                 \
       map([](const Vectorized<vecscalar_t>& x) { return x.op(); },                \
           out + begin,                                                            \
           in + begin,                                                             \

--- a/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
@@ -26,6 +26,7 @@ inline void reduce_all_impl_vec(
     const scalar_t ident_v,
     func_t op,
     vec_func_t vop) {
+  // TODO: replace vec_scalar_t with at::opmath_type when float16 specialization is done.
   using Vec = Vectorized<vec_scalar_t<scalar_t>>;
   const int64_t input_numel = input.numel();
   auto input_data = input.data_ptr<scalar_t>();
@@ -78,6 +79,7 @@ static void min_all_kernel_impl(Tensor& result, const Tensor& input) {
       [=](int64_t a, int64_t b) -> int64_t { return min_impl(a, b); });
   } else {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(), "min_all", [&] {
+      // TODO: replace vec_scalar_t with at::opmath_type when float16 specialization is done.
       using Vec = Vectorized<vec_scalar_t<scalar_t>>;
       reduce_all_impl_vec<scalar_t>(result, input, upper_bound<scalar_t>(),
         [=] (scalar_t a , scalar_t b) -> scalar_t { return min_impl(a, b); },
@@ -103,6 +105,7 @@ static void max_all_kernel_impl(Tensor& result, const Tensor& input) {
       [=](int64_t a, int64_t b) -> int64_t { return max_impl(a, b); });
   } else {
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(), "max_all", [&] {
+      // TODO: replace vec_scalar_t with at::opmath_type when float16 specialization is done.
       using Vec = Vectorized<vec_scalar_t<scalar_t>>;
       reduce_all_impl_vec<scalar_t>(result, input, lower_bound<scalar_t>(),
         [=] (scalar_t a , scalar_t b) -> scalar_t { return max_impl(a, b); },
@@ -146,6 +149,7 @@ inline void reduce_all_impl_vec_two_outputs(
     func_t reduce_acc_func,
     vec_func_t1 reduce_chunk_func1,
     vec_func_t2 reduce_chunk_func2) {
+  // TODO: replace vec_scalar_t with at::opmath_type when float16 specialization is done.
   using Vec = Vectorized<vec_scalar_t<scalar_t>>;
   using scalar_t_pair = std::pair<scalar_t, scalar_t>;
   const int64_t input_numel = input.numel();
@@ -199,6 +203,7 @@ static void aminmax_allreduce_kernel(
     );
   } else {
     AT_DISPATCH_ALL_TYPES_AND(kBFloat16, input.scalar_type(), "aminmax_cpu", [&] {
+      // TODO: replace vec_scalar_t with at::opmath_type when float16 specialization is done.
       using Vec = Vectorized<vec_scalar_t<scalar_t>>;
       using scalar_t_pair = std::pair<scalar_t, scalar_t>;
       reduce_all_impl_vec_two_outputs<scalar_t>(

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/Tensor.h>
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/native/ReduceOps.h>
@@ -260,7 +261,7 @@ static void norm_kernel_tensor_iterator_impl(
          iter.input_dtype() == kBFloat16)) {
       AT_DISPATCH_FLOATING_TYPES_AND(kBFloat16, iter.input_dtype(), "norm_cpu", [&] {
         // use float as accumulate type for BFloat16
-        using acc_t = vec_scalar_t<scalar_t>;
+        using acc_t = at::opmath_type<scalar_t>;
         binary_kernel_reduce_lastdim(iter, [](char* result_data_bytes, char* self_data_bytes, int64_t size) {
           scalar_t* result_data = (scalar_t*)result_data_bytes;
           scalar_t* self_data = (scalar_t*)self_data_bytes;

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -8,6 +8,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorIterator.h>
+#include <ATen/OpMathType.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
@@ -32,7 +33,7 @@ inline void _vec_log_softmax_lastdim(
     scalar_t* output_data_base,
     int64_t outer_size,
     int64_t dim_size) {
-  using Vec = vec::Vectorized<vec::vec_scalar_t<scalar_t>>;
+  using Vec = vec::Vectorized<at::opmath_type<scalar_t>>;
   static constexpr int64_t CHUNK_SIZE = (128 / sizeof(scalar_t)) * Vec::size();
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
   if (grain_size < CHUNK_SIZE)
@@ -204,7 +205,7 @@ inline void _vec_host_softmax_backward_lastdim(
     scalar_t* output_data_base,
     int64_t outer_size,
     int64_t dim_size) {
-  using Vec = vec::Vectorized<vec::vec_scalar_t<scalar_t>>;
+  using Vec = vec::Vectorized<at::opmath_type<scalar_t>>;
   int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size);
   if (grain_size < 1)
     grain_size = 1;

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -74,7 +74,7 @@ template <typename T>
 void VmlLog(int64_t N, const T* X, T* Y) {
   constexpr int64_t K = Vectorized<T>::size();
   at::parallel_for(0, N, K, [=](int64_t begin, int64_t end) {
-    using VT = vec::vec_scalar_t<T>;
+    using VT = at::opmath_type<T>;
     vec::map(
         [](Vectorized<VT> x_vec) { return x_vec.log(); },
         Y + begin,

--- a/aten/src/ATen/native/cpu/WeightNormKernel.cpp
+++ b/aten/src/ATen/native/cpu/WeightNormKernel.cpp
@@ -4,6 +4,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/EmptyTensor.h>
 #include <ATen/Parallel.h>
+#include <ATen/OpMathType.h>
 #include <ATen/native/cpu/WeightNormKernel.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
@@ -402,7 +403,7 @@ void weight_norm_kernel(
       "fused kernels can only be applied for first or last dim");
   AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, v.scalar_type(),
       "weight_norm_kernel", [&]() {
-    using accscalar_t = vec::vec_scalar_t<scalar_t>;
+    using accscalar_t = at::opmath_type<scalar_t>;
     if (dim == 0) {
       int64_t M = v.size(0);
       int64_t N = v.numel() / M;
@@ -427,7 +428,7 @@ void weight_norm_backward_kernel(
       "fused kernels can only be applied for first or last dim");
   AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, saved_v.scalar_type(),
       "weight_norm_backward_kernel", [&]() {
-    using accscalar_t = vec::vec_scalar_t<scalar_t>;
+    using accscalar_t = at::opmath_type<scalar_t>;
     if (dim == 0) {
       int64_t M = saved_v.size(0);
       int64_t N = saved_v.numel() / M;

--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -6,6 +6,7 @@
 
 #include <ATen/core/Tensor.h>
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/moments_utils.h>
@@ -186,7 +187,7 @@ void LayerNormKernelImpl(
   DCHECK(!beta.defined() || beta.numel() == N);
   AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::BFloat16, X.scalar_type(),
       "LayerNormKernelImpl", [&]() {
-    using acc_t = vec::vec_scalar_t<scalar_t>;
+    using acc_t = at::opmath_type<scalar_t>;
     LayerNormKernelImplInternal<scalar_t, acc_t>(
         X, gamma, beta, M, N, static_cast<acc_t>(eps), Y, mean, rstd);
   });
@@ -204,7 +205,7 @@ void LayerNormBackwardKernelImplInternal(
     Tensor* dX,
     Tensor* dgamma,
     Tensor* dbeta) {
-  using T_ACC = vec::vec_scalar_t<T>;
+  using T_ACC = at::opmath_type<T>;
   using Vec = vec::Vectorized<T_ACC>;
   TORCH_DCHECK_EQ(dY.numel(), M * N);
   TORCH_DCHECK_EQ(X.numel(), M * N);

--- a/aten/src/ATen/native/cpu/moments_utils.h
+++ b/aten/src/ATen/native/cpu/moments_utils.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <ATen/Parallel.h>
+#include <ATen/OpMathType.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/SmallVector.h>
@@ -16,7 +17,7 @@ namespace at {
 namespace native {
 inline namespace CPU_CAPABILITY {
 
-template<typename T> using acc_t = vec::vec_scalar_t<T>;
+template<typename T> using acc_t = at::opmath_type<T>;
 
 constexpr int64_t kChunkSize = 16;
 


### PR DESCRIPTION
### Motivation
The two accumulation types vec::vec_scalar_t and at::opmath_type are duplicated, so we replace vec::vec_scalar_t with at::opmath_type, and vec::vec_scalar_t will be deprecated later.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10