### PR TITLE
[MPS] Add MPSHooks interface to enable accessing MPS functions globally

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -21,10 +21,6 @@
 #include <fbgemm/Fbgemm.h>
 #endif // USE_FBGEMM
 
-#ifdef USE_MPS
-#include <ATen/mps/MPSDevice.h>
-#endif
-
 namespace at {
 
 Context::Context() = default;
@@ -265,14 +261,6 @@ bool Context::hasMKL() {
 bool Context::hasMKLDNN() {
 #if AT_MKLDNN_ENABLED()
   return true;
-#else
-  return false;
-#endif
-}
-
-bool Context::hasMPS() {
-#if USE_MPS
-  return at::mps::is_available();
 #else
   return false;
 #endif

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -9,6 +9,7 @@
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <ATen/detail/HIPHooksInterface.h>
 #include <ATen/detail/ORTHooksInterface.h>
+#include <ATen/detail/MPSHooksInterface.h>
 #include <c10/core/QEngine.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/util/CallOnce.h>
@@ -83,6 +84,9 @@ class TORCH_API Context {
   static bool hasHIP() {
     return detail::getHIPHooks().hasHIP();
   }
+  static bool hasMPS() {
+    return detail::getMPSHooks().hasMPS();
+  }
   static bool hasIPU() {
     return c10::impl::hasDeviceGuardImpl(at::DeviceType::IPU);
   }
@@ -92,8 +96,6 @@ class TORCH_API Context {
   static bool hasLazy() {
     return c10::impl::hasDeviceGuardImpl(at::DeviceType::Lazy);
   }
-  static bool hasMPS();
-
   static bool hasORT() {
     return c10::impl::hasDeviceGuardImpl(at::DeviceType::ORT);
   }

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -8,8 +8,8 @@
 #include <ATen/core/LegacyTypeDispatch.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <ATen/detail/HIPHooksInterface.h>
-#include <ATen/detail/ORTHooksInterface.h>
 #include <ATen/detail/MPSHooksInterface.h>
+#include <ATen/detail/ORTHooksInterface.h>
 #include <c10/core/QEngine.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/util/CallOnce.h>

--- a/aten/src/ATen/detail/MPSHooksInterface.cpp
+++ b/aten/src/ATen/detail/MPSHooksInterface.cpp
@@ -1,0 +1,32 @@
+#include <ATen/detail/MPSHooksInterface.h>
+#include <c10/util/Exception.h>
+
+namespace at {
+namespace detail {
+
+const MPSHooksInterface& getMPSHooks() {
+  static std::unique_ptr<MPSHooksInterface> mps_hooks;
+#if !defined C10_MOBILE
+  static std::once_flag once;
+  std::call_once(once, [] {
+    mps_hooks = MPSHooksRegistry()->Create("MPSHooks", MPSHooksArgs{});
+    if (!mps_hooks) {
+      mps_hooks =
+          // NOLINTNEXTLINE(modernize-make-unique)
+          std::unique_ptr<MPSHooksInterface>(new MPSHooksInterface());
+    }
+  });
+#else
+  if (mps_hooks == nullptr) {
+    mps_hooks =
+        // NOLINTNEXTLINE(modernize-make-unique)
+        std::unique_ptr<MPSHooksInterface>(new MPSHooksInterface());
+  }
+#endif
+  return *mps_hooks;
+}
+} // namespace detail
+
+C10_DEFINE_REGISTRY(MPSHooksRegistry, MPSHooksInterface, MPSHooksArgs)
+
+} // namespace at

--- a/aten/src/ATen/detail/MPSHooksInterface.cpp
+++ b/aten/src/ATen/detail/MPSHooksInterface.cpp
@@ -1,5 +1,8 @@
+//  Copyright © 2022 Apple Inc.
+
 #include <ATen/detail/MPSHooksInterface.h>
 #include <c10/util/Exception.h>
+#include <c10/util/CallOnce.h>
 
 namespace at {
 namespace detail {
@@ -7,8 +10,8 @@ namespace detail {
 const MPSHooksInterface& getMPSHooks() {
   static std::unique_ptr<MPSHooksInterface> mps_hooks;
 #if !defined C10_MOBILE
-  static std::once_flag once;
-  std::call_once(once, [] {
+  static c10::once_flag once;
+  c10::call_once(once, [] {
     mps_hooks = MPSHooksRegistry()->Create("MPSHooks", MPSHooksArgs{});
     if (!mps_hooks) {
       mps_hooks =

--- a/aten/src/ATen/detail/MPSHooksInterface.cpp
+++ b/aten/src/ATen/detail/MPSHooksInterface.cpp
@@ -14,16 +14,12 @@ const MPSHooksInterface& getMPSHooks() {
   c10::call_once(once, [] {
     mps_hooks = MPSHooksRegistry()->Create("MPSHooks", MPSHooksArgs{});
     if (!mps_hooks) {
-      mps_hooks =
-          // NOLINTNEXTLINE(modernize-make-unique)
-          std::unique_ptr<MPSHooksInterface>(new MPSHooksInterface());
+      mps_hooks = std::make_unique<MPSHooksInterface>();
     }
   });
 #else
   if (mps_hooks == nullptr) {
-    mps_hooks =
-        // NOLINTNEXTLINE(modernize-make-unique)
-        std::unique_ptr<MPSHooksInterface>(new MPSHooksInterface());
+    mps_hooks = std::make_unique<MPSHooksInterface>();
   }
 #endif
   return *mps_hooks;

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <c10/core/Allocator.h>
+#include <ATen/core/Generator.h>
+#include <c10/util/Exception.h>
+#include <c10/util/Registry.h>
+
+#include <cstddef>
+#include <functional>
+
+namespace at {
+class Context;
+}
+
+namespace at {
+
+struct TORCH_API MPSHooksInterface {
+  virtual ~MPSHooksInterface() {}
+
+  // Initialize the MPS library state
+  virtual void initMPS() const {
+    AT_ERROR("Cannot initialize MPS without MPS backend.");
+  }
+
+  virtual bool hasMPS() const {
+    return false;
+  }
+
+  virtual const Generator& getDefaultMPSGenerator(DeviceIndex device_index = -1) const {
+    (void)device_index; // Suppress unused variable warning
+    AT_ERROR("Cannot get default MPS generator without MPS backend.");
+  }
+
+  virtual Allocator* getMPSDeviceAllocator() const {
+    AT_ERROR("MPSDeviceAllocator requires MPS.");
+  }
+};
+
+struct TORCH_API MPSHooksArgs {};
+
+C10_DECLARE_REGISTRY(MPSHooksRegistry, MPSHooksInterface, MPSHooksArgs);
+#define REGISTER_MPS_HOOKS(clsname) \
+  C10_REGISTER_CLASS(MPSHooksRegistry, clsname, clsname)
+
+namespace detail {
+TORCH_API const MPSHooksInterface& getMPSHooks();
+
+} // namespace detail
+} // namespace at

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -1,3 +1,5 @@
+//  Copyright © 2022 Apple Inc.
+
 #pragma once
 
 #include <c10/core/Allocator.h>
@@ -15,7 +17,7 @@ class Context;
 namespace at {
 
 struct TORCH_API MPSHooksInterface {
-  virtual ~MPSHooksInterface() {}
+  virtual ~MPSHooksInterface() = default;
 
   // Initialize the MPS library state
   virtual void initMPS() const {

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -28,8 +28,7 @@ struct TORCH_API MPSHooksInterface {
     return false;
   }
 
-  virtual const Generator& getDefaultMPSGenerator(DeviceIndex device_index = -1) const {
-    (void)device_index; // Suppress unused variable warning
+  virtual const Generator& getDefaultMPSGenerator(C10_UNUSED DeviceIndex device_index = -1) const {
     AT_ERROR("Cannot get default MPS generator without MPS backend.");
   }
 

--- a/aten/src/ATen/mps/MPSHooks.cpp
+++ b/aten/src/ATen/mps/MPSHooks.cpp
@@ -1,14 +1,7 @@
+//  Copyright © 2022 Apple Inc.
+
 #include <ATen/mps/MPSHooks.h>
-
-#include <ATen/Context.h>
 #include <ATen/mps/MPSDevice.h>
-#include <ATen/detail/MPSHooksInterface.h>
-#include <c10/util/irange.h>
-
-#include <sstream>
-#include <cstddef>
-#include <functional>
-#include <memory>
 
 namespace at {
 namespace mps {

--- a/aten/src/ATen/mps/MPSHooks.cpp
+++ b/aten/src/ATen/mps/MPSHooks.cpp
@@ -1,0 +1,35 @@
+#include <ATen/mps/MPSHooks.h>
+
+#include <ATen/Context.h>
+#include <ATen/mps/MPSDevice.h>
+#include <ATen/detail/MPSHooksInterface.h>
+#include <c10/util/irange.h>
+
+#include <sstream>
+#include <cstddef>
+#include <functional>
+#include <memory>
+
+namespace at {
+namespace mps {
+
+void MPSHooks::initMPS() const {
+  C10_LOG_API_USAGE_ONCE("aten.init.mps");
+  // TODO: initialize MPS devices and streams here
+}
+
+bool MPSHooks::hasMPS() const {
+  return at::mps::is_available();
+}
+
+Allocator* MPSHooks::getMPSDeviceAllocator() const {
+  return at::mps::GetMPSAllocator();
+}
+
+using at::MPSHooksRegistry;
+using at::RegistererMPSHooksRegistry;
+
+REGISTER_MPS_HOOKS(MPSHooks);
+
+} // namespace mps
+} // namespace at

--- a/aten/src/ATen/mps/MPSHooks.h
+++ b/aten/src/ATen/mps/MPSHooks.h
@@ -1,3 +1,5 @@
+//  Copyright © 2022 Apple Inc.
+
 #pragma once
 
 #include <ATen/detail/MPSHooksInterface.h>

--- a/aten/src/ATen/mps/MPSHooks.h
+++ b/aten/src/ATen/mps/MPSHooks.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <ATen/detail/MPSHooksInterface.h>
+#include <ATen/Generator.h>
+#include <c10/util/Optional.h>
+
+namespace at { namespace mps {
+
+// The real implementation of MPSHooksInterface
+struct MPSHooks : public at::MPSHooksInterface {
+  MPSHooks(at::MPSHooksArgs) {}
+  void initMPS() const override;
+  bool hasMPS() const override;
+  Allocator* getMPSDeviceAllocator() const override;
+};
+
+}} // at::mps

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -1112,6 +1112,7 @@ aten_cpu_source_non_codegen_list = [
     "aten/src/ATen/cpu/FlushDenormal.cpp",
     "aten/src/ATen/detail/CPUGuardImpl.cpp",
     "aten/src/ATen/detail/CUDAHooksInterface.cpp",
+    "aten/src/ATen/detail/MPSHooksInterface.cpp",
     "aten/src/ATen/detail/HIPHooksInterface.cpp",
     "aten/src/ATen/detail/ORTHooksInterface.cpp",
     "aten/src/ATen/metal/Context.cpp",


### PR DESCRIPTION
This PR is a prerequisite to the upcoming MPSGenerator changes required for Random Ops.

Add `MPSHooksInterface.cpp` to `aten_cpu_source_non_codegen_list`

Co-authored-by: Nikita Shulga <nikita.shulga@gmail.com>


cc @kulinseth @albanD @malfet @DenisVieriu97 @abhudev