### PR TITLE
Fix for RNN/LSTM/GRU modules to work with stateless.functional_call()

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2298,6 +2298,7 @@ aot_autograd_module_failures = set({
 })
 
 symbolic_aot_autograd_module_failures = {
+    torch.nn.GRU,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.TransformerEncoderLayer,  # RuntimeError: tried to get Double out of SymFloat
     torch.nn.TransformerDecoderLayer,  # RuntimeError: tried to get Double out of SymFloat
     torch.nn.GaussianNLLLoss,  # NotImplementedError: local_scalar_dense/item NYI for torch.bool

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2287,9 +2287,6 @@ class TestEagerFusionOpInfo(AOTTestCase):
 
 
 aot_autograd_module_failures = set({
-    torch.nn.RNN,  # See https://github.com/pytorch/pytorch/issues/90500
-    torch.nn.LSTM,  # See https://github.com/pytorch/pytorch/issues/90500
-    torch.nn.GRU,  # See https://github.com/pytorch/pytorch/issues/90500
     torch.nn.GaussianNLLLoss,  # RuntimeError: It appears that you're trying to get value out
                                # of a tracing tensor with aten._local_scalar_dense.default -
                                # erroring out! It's likely that this is caused by data-dependent
@@ -2303,12 +2300,6 @@ aot_autograd_module_failures = set({
 symbolic_aot_autograd_module_failures = {
     torch.nn.TransformerEncoderLayer,  # RuntimeError: tried to get Double out of SymFloat
     torch.nn.TransformerDecoderLayer,  # RuntimeError: tried to get Double out of SymFloat
-    torch.nn.RNN,  # Exception: Invoking operators with non-Fake Tensor inputs in FakeTensorMode
-                   # is not yet supported. Please convert all Tensors to FakeTensors first.
-    torch.nn.LSTM,  # Exception: Invoking operators with non-Fake Tensor inputs in FakeTensorMode
-                    # is not yet supported. Please convert all Tensors to FakeTensors first.
-    torch.nn.GRU,  # Exception: Invoking operators with non-Fake Tensor inputs in FakeTensorMode
-                   # is not yet supported. Please convert all Tensors to FakeTensors first.
     torch.nn.GaussianNLLLoss,  # NotImplementedError: local_scalar_dense/item NYI for torch.bool
     torch.nn.CrossEntropyLoss,  # Cannot call sizes() on tensor with symbolic sizes/strides
     torch.nn.Bilinear,  # Cannot call sizes() on tensor with symbolic sizes/strides

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -1,6 +1,7 @@
 import math
 import warnings
 import numbers
+import weakref
 from typing import List, Tuple, Optional, overload
 
 import torch
@@ -56,6 +57,7 @@ class RNNBase(Module):
         self.dropout = float(dropout)
         self.bidirectional = bidirectional
         self.proj_size = proj_size
+        self._flat_weight_refs: List[Optional[weakref.ReferenceType["Parameter"]]] = []
         num_directions = 2 if bidirectional else 1
 
         if not isinstance(dropout, numbers.Number) or not 0 <= dropout <= 1 or \
@@ -128,7 +130,10 @@ class RNNBase(Module):
         self.reset_parameters()
 
     def _init_flat_weights(self):
-        self._flat_weights = [getattr(self, wn, None) for wn in self._flat_weights_names]
+        self._flat_weights = [getattr(self, wn) if hasattr(self, wn) else None
+                              for wn in self._flat_weights_names]
+        self._flat_weight_refs = [weakref.ref(w) if w is not None else None
+                                  for w in self._flat_weights]
         self.flatten_parameters()
 
     def __setattr__(self, attr, value):
@@ -235,9 +240,9 @@ class RNNBase(Module):
         # Returns True if the weight tensors have changed since the last forward pass.
         # This is the case when used with stateless.functional_call(), for example.
         weights_changed = False
-        for flat_weight, name in zip(self._flat_weights, self._flat_weights_names):
-            weight = getattr(self, name, None)
-            if weight is not flat_weight:
+        for ref, name in zip(self._flat_weight_refs, self._flat_weights_names):
+            weight = getattr(self, name) if hasattr(self, name) else None
+            if weight is not None and ref is not None and ref() is not weight:
                 weights_changed = True
                 break
         return weights_changed
@@ -270,6 +275,12 @@ class RNNBase(Module):
             s += ', bidirectional={bidirectional}'
         return s.format(**self.__dict__)
 
+    def __getstate__(self):
+        # Don't serialize the weight references.
+        state = self.__dict__.copy()
+        del state['_flat_weight_refs']
+        return state
+
     def __setstate__(self, d):
         super(RNNBase, self).__setstate__(d)
         if 'all_weights' in d:
@@ -280,33 +291,36 @@ class RNNBase(Module):
         if 'proj_size' not in d:
             self.proj_size = 0
 
-        if isinstance(self._all_weights[0][0], str):
-            return
-        num_layers = self.num_layers
-        num_directions = 2 if self.bidirectional else 1
-        self._flat_weights_names = []
-        self._all_weights = []
-        for layer in range(num_layers):
-            for direction in range(num_directions):
-                suffix = '_reverse' if direction == 1 else ''
-                weights = ['weight_ih_l{}{}', 'weight_hh_l{}{}', 'bias_ih_l{}{}',
-                           'bias_hh_l{}{}', 'weight_hr_l{}{}']
-                weights = [x.format(layer, suffix) for x in weights]
-                if self.bias:
-                    if self.proj_size > 0:
-                        self._all_weights += [weights]
-                        self._flat_weights_names.extend(weights)
+        if not isinstance(self._all_weights[0][0], str):
+            num_layers = self.num_layers
+            num_directions = 2 if self.bidirectional else 1
+            self._flat_weights_names = []
+            self._all_weights = []
+            for layer in range(num_layers):
+                for direction in range(num_directions):
+                    suffix = '_reverse' if direction == 1 else ''
+                    weights = ['weight_ih_l{}{}', 'weight_hh_l{}{}', 'bias_ih_l{}{}',
+                               'bias_hh_l{}{}', 'weight_hr_l{}{}']
+                    weights = [x.format(layer, suffix) for x in weights]
+                    if self.bias:
+                        if self.proj_size > 0:
+                            self._all_weights += [weights]
+                            self._flat_weights_names.extend(weights)
+                        else:
+                            self._all_weights += [weights[:4]]
+                            self._flat_weights_names.extend(weights[:4])
                     else:
-                        self._all_weights += [weights[:4]]
-                        self._flat_weights_names.extend(weights[:4])
-                else:
-                    if self.proj_size > 0:
-                        self._all_weights += [weights[:2]] + [weights[-1:]]
-                        self._flat_weights_names.extend(weights[:2] + [weights[-1:]])
-                    else:
-                        self._all_weights += [weights[:2]]
-                        self._flat_weights_names.extend(weights[:2])
-        self._flat_weights = [getattr(self, wn, None) for wn in self._flat_weights_names]
+                        if self.proj_size > 0:
+                            self._all_weights += [weights[:2]] + [weights[-1:]]
+                            self._flat_weights_names.extend(weights[:2] + [weights[-1:]])
+                        else:
+                            self._all_weights += [weights[:2]]
+                            self._flat_weights_names.extend(weights[:2])
+            self._flat_weights = [getattr(self, wn) if hasattr(self, wn) else None
+                                  for wn in self._flat_weights_names]
+
+        self._flat_weight_refs = [weakref.ref(w) if w is not None else None
+                                  for w in self._flat_weights]
 
     @property
     def all_weights(self) -> List[List[Parameter]]:

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -456,8 +456,9 @@ class RNN(RNNBase):
         pass
 
     def forward(self, input, hx=None):  # noqa: F811
-        if self._weights_have_changed():
-            self._init_flat_weights()
+        if not torch.jit.is_scripting():
+            if self._weights_have_changed():
+                self._init_flat_weights()
 
         orig_input = input
         if isinstance(orig_input, PackedSequence):
@@ -749,8 +750,9 @@ class LSTM(RNNBase):
         pass
 
     def forward(self, input, hx=None):  # noqa: F811
-        if self._weights_have_changed():
-            self._init_flat_weights()
+        if not torch.jit.is_scripting():
+            if self._weights_have_changed():
+                self._init_flat_weights()
 
         orig_input = input
         # xxx: isinstance check needs to be in conditional for TorchScript to compile
@@ -944,8 +946,9 @@ class GRU(RNNBase):
         pass
 
     def forward(self, input, hx=None):  # noqa: F811
-        if self._weights_have_changed():
-            self._init_flat_weights()
+        if not torch.jit.is_scripting():
+            if self._weights_have_changed():
+                self._init_flat_weights()
 
         orig_input = input
         # xxx: isinstance check needs to be in conditional for TorchScript to compile

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -1,6 +1,7 @@
 import math
 import warnings
 import numbers
+import weakref
 from typing import List, Tuple, Optional, overload
 
 import torch
@@ -56,6 +57,7 @@ class RNNBase(Module):
         self.dropout = float(dropout)
         self.bidirectional = bidirectional
         self.proj_size = proj_size
+        self._flat_weight_refs: List[Optional[weakref.ReferenceType["Parameter"]]] = []
         num_directions = 2 if bidirectional else 1
 
         if not isinstance(dropout, numbers.Number) or not 0 <= dropout <= 1 or \
@@ -123,10 +125,15 @@ class RNNBase(Module):
                 self._flat_weights_names.extend(param_names)
                 self._all_weights.append(param_names)
 
-        self._flat_weights = [(lambda wn: getattr(self, wn) if hasattr(self, wn) else None)(wn) for wn in self._flat_weights_names]
-        self.flatten_parameters()
+        self._init_flat_weights()
 
         self.reset_parameters()
+
+    def _init_flat_weights(self):
+        self._flat_weights = [(lambda wn: getattr(self, wn) if hasattr(self, wn) else None)(wn) for wn in self._flat_weights_names]
+        self._flat_weight_refs = [weakref.ref(w) if w is not None else None
+                                  for w in self._flat_weights]
+        self.flatten_parameters()
 
     def __setattr__(self, attr, value):
         if hasattr(self, "_flat_weights_names") and attr in self._flat_weights_names:
@@ -189,9 +196,7 @@ class RNNBase(Module):
         # Resets _flat_weights
         # Note: be v. careful before removing this, as 3rd party device types
         # likely rely on this behavior to properly .to() modules like LSTM.
-        self._flat_weights = [(lambda wn: getattr(self, wn) if hasattr(self, wn) else None)(wn) for wn in self._flat_weights_names]
-        # Flattens params (on CUDA)
-        self.flatten_parameters()
+        self._init_flat_weights()
 
         return ret
 
@@ -230,6 +235,17 @@ class RNNBase(Module):
         if hx.size() != expected_hidden_size:
             raise RuntimeError(msg.format(expected_hidden_size, list(hx.size())))
 
+    def _weights_have_changed(self):
+        # Returns True if the weight tensors have changed since the last forward pass.
+        # This is the case when used with stateless.functional_call(), for example.
+        weights_changed = False
+        for ref, name in zip(self._flat_weight_refs, self._flat_weights_names):
+            weight = getattr(self, name) if hasattr(self, name) else None
+            if weight is not None and ref is not None and ref() is not weight:
+                weights_changed = True
+                break
+        return weights_changed
+
     def check_forward_args(self, input: Tensor, hidden: Tensor, batch_sizes: Optional[Tensor]):
         self.check_input(input, batch_sizes)
         expected_hidden_size = self.get_expected_hidden_size(input, batch_sizes)
@@ -258,6 +274,12 @@ class RNNBase(Module):
             s += ', bidirectional={bidirectional}'
         return s.format(**self.__dict__)
 
+    def __getstate__(self):
+        # Don't serialize the weight references.
+        state = self.__dict__.copy()
+        del state['_flat_weight_refs']
+        return state
+
     def __setstate__(self, d):
         super(RNNBase, self).__setstate__(d)
         if 'all_weights' in d:
@@ -268,33 +290,32 @@ class RNNBase(Module):
         if 'proj_size' not in d:
             self.proj_size = 0
 
-        if isinstance(self._all_weights[0][0], str):
-            return
-        num_layers = self.num_layers
-        num_directions = 2 if self.bidirectional else 1
-        self._flat_weights_names = []
-        self._all_weights = []
-        for layer in range(num_layers):
-            for direction in range(num_directions):
-                suffix = '_reverse' if direction == 1 else ''
-                weights = ['weight_ih_l{}{}', 'weight_hh_l{}{}', 'bias_ih_l{}{}',
-                           'bias_hh_l{}{}', 'weight_hr_l{}{}']
-                weights = [x.format(layer, suffix) for x in weights]
-                if self.bias:
-                    if self.proj_size > 0:
-                        self._all_weights += [weights]
-                        self._flat_weights_names.extend(weights)
+        if not isinstance(self._all_weights[0][0], str):
+            num_layers = self.num_layers
+            num_directions = 2 if self.bidirectional else 1
+            self._flat_weights_names = []
+            self._all_weights = []
+            for layer in range(num_layers):
+                for direction in range(num_directions):
+                    suffix = '_reverse' if direction == 1 else ''
+                    weights = ['weight_ih_l{}{}', 'weight_hh_l{}{}', 'bias_ih_l{}{}',
+                               'bias_hh_l{}{}', 'weight_hr_l{}{}']
+                    weights = [x.format(layer, suffix) for x in weights]
+                    if self.bias:
+                        if self.proj_size > 0:
+                            self._all_weights += [weights]
+                            self._flat_weights_names.extend(weights)
+                        else:
+                            self._all_weights += [weights[:4]]
+                            self._flat_weights_names.extend(weights[:4])
                     else:
-                        self._all_weights += [weights[:4]]
-                        self._flat_weights_names.extend(weights[:4])
-                else:
-                    if self.proj_size > 0:
-                        self._all_weights += [weights[:2]] + [weights[-1:]]
-                        self._flat_weights_names.extend(weights[:2] + [weights[-1:]])
-                    else:
-                        self._all_weights += [weights[:2]]
-                        self._flat_weights_names.extend(weights[:2])
-        self._flat_weights = [(lambda wn: getattr(self, wn) if hasattr(self, wn) else None)(wn) for wn in self._flat_weights_names]
+                        if self.proj_size > 0:
+                            self._all_weights += [weights[:2]] + [weights[-1:]]
+                            self._flat_weights_names.extend(weights[:2] + [weights[-1:]])
+                        else:
+                            self._all_weights += [weights[:2]]
+                            self._flat_weights_names.extend(weights[:2])
+        self._init_flat_weights()
 
     @property
     def all_weights(self) -> List[List[Parameter]]:
@@ -435,6 +456,9 @@ class RNN(RNNBase):
         pass
 
     def forward(self, input, hx=None):  # noqa: F811
+        if self._weights_have_changed():
+            self._init_flat_weights()
+
         orig_input = input
         if isinstance(orig_input, PackedSequence):
             input, batch_sizes, sorted_indices, unsorted_indices = input
@@ -725,6 +749,9 @@ class LSTM(RNNBase):
         pass
 
     def forward(self, input, hx=None):  # noqa: F811
+        if self._weights_have_changed():
+            self._init_flat_weights()
+
         orig_input = input
         # xxx: isinstance check needs to be in conditional for TorchScript to compile
         batch_sizes = None
@@ -917,6 +944,9 @@ class GRU(RNNBase):
         pass
 
     def forward(self, input, hx=None):  # noqa: F811
+        if self._weights_have_changed():
+            self._init_flat_weights()
+
         orig_input = input
         # xxx: isinstance check needs to be in conditional for TorchScript to compile
         if isinstance(orig_input, PackedSequence):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91111

Fixes #90500

The change here checks for parameter changes at the beginning of each `forward()` call; if the parameters are found to be different tensors than last time, `self._flat_weights` is re-initialized with the new values. Thus, swapping parameter values using `stateless.functional_call()` will re-initialize `self._flat_weights` during the `forward()` call, and the provided parameters will be used for module computation as expected.

NB: There are still some changes needed for symbolic shapes to work with `nn.GRU` (will address in a follow-up PR).

cc @albanD @mruberry @walterddr @kshitij12345 @saketh-are