### PR TITLE
Add catch socket.gaierror for _matches_machine_hostname

### DIFF
--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -131,7 +131,7 @@ def _matches_machine_hostname(host: str) -> bool:
         host_addr_list = socket.getaddrinfo(
             host, None, proto=socket.IPPROTO_TCP, flags=socket.AI_CANONNAME
         )
-    except ValueError:
+    except (ValueError, socket.gaierror) as _:
         host_addr_list = []
 
     host_ip_list = [


### PR DESCRIPTION
Summary: Add catch `socket.gaierror` for _matches_machine_hostname

Test Plan: Unit tests again

Reviewed By: kurman

Differential Revision: D42152245

