### PR TITLE
Do not run inductor perf test with postnightly branch

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     paths:
       - .github/workflows/inductor-perf-test-nightly.yml
+    branches-ignore:
+      - postnightly
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Inductor performance test job would be triggered every night associated with the pull request push event from https://github.com/pytorch/pytorch/pull/27167 
Since we are already running three times a day the job, there is no need to run this test with postnightly branch. Plus, this postnightly branch currently fails dozens of tests due to "docker argument too long error". 

Example workflow: https://github.com/pytorch/pytorch/actions/runs/3731250111