### PR TITLE
Set cmake PATH on macos to address libzstd flakiness

### DIFF
--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -95,7 +95,24 @@ test_libtorch() {
   fi
 }
 
+debug_cmake() {
+  CMAKE_EXEC="$(which cmake)"
+  echo "$CMAKE_EXEC"
+  otool -l "$CMAKE_EXEC" | grep RPATH -A2
+
+  CONDA_INSTALLATION_DIR="$(dirname $CMAKE_EXEC)"
+  echo "$CONDA_INSTALLATION_DIR"
+  ls -la "$CONDA_INSTALLATION_DIR"
+  ls -la "$CONDA_INSTALLATION_DIR/../lib"
+
+  ls -la /Users/ec2-user/runner/_work/_temp/miniconda
+  ls -la /Users/ec2-user/runner/_work/_temp/miniconda/bin
+  ls -la /Users/ec2-user/runner/_work/_temp/miniconda/lib
+}
+
 test_custom_backend() {
+  debug_cmake
+
   echo "Testing custom backends"
   pushd test/custom_backend
   rm -rf build && mkdir build
@@ -116,6 +133,8 @@ test_custom_backend() {
 }
 
 test_custom_script_ops() {
+  debug_cmake
+
   echo "Testing custom script operators"
   pushd test/custom_operator
   # Build the custom operator library.
@@ -136,6 +155,8 @@ test_custom_script_ops() {
 }
 
 test_jit_hooks() {
+  debug_cmake
+
   echo "Testing jit hooks in cpp"
   pushd test/jit_hooks
   # Build the custom operator library.
@@ -157,7 +178,7 @@ test_jit_hooks() {
 if [[ "${TEST_CONFIG}" == *functorch* ]]; then
   test_functorch
 elif [[ $NUM_TEST_SHARDS -gt 1 ]]; then
-  test_python_shard "${SHARD_NUMBER}"
+  # test_python_shard "${SHARD_NUMBER}"
   if [[ "${SHARD_NUMBER}" == 1 ]]; then
     test_libtorch
     test_custom_script_ops


### PR DESCRIPTION
This is to address the recent flakiness issue on MacOS ARM64 https://hud.pytorch.org/failure/Library%20not%20loaded%3A%20%40rpath%2Flibzstd.1.dylib.  

From what I see, the immediate cause is that `cmake` exec under `/Users/ec2-user/runner/_work/_temp/miniconda/pkgs/cmake-3.22.1-hae769c0_0/bin/` is used instead of the expected one under the temp CONDA_ENV, i.e. `/Users/ec2-user/runner/_work/_temp/conda_environment_3736476178/bin`.  I'm not quite sure what is the reason behind this flaky behavior, so I want to try a catch-all fix by setting the cmake PATH correctly

This PR also prints some debugging information w.r.t cmake PATH, and cleans up some legacy code in `macos-test.sh` script.
