### PR TITLE
Add bad status management for get_workflow_job_id

### DIFF
--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -7,14 +7,14 @@ import os
 import argparse
 
 
-def handle_bad_status(response):
+def handle_bad_status(response) -> None:
     if response.status_code != 200:
         exception_message = (
             "Is github alright?",
             f"Recieved status code '{response.status_code}' when attempting to retrieve runs:\n",
             f"{response.content}"
         )
-        raise Exception(exception_message)
+        raise RuntimeError(exception_message)
 
 
 # Our strategy is to retrieve the parent workflow run, then filter its jobs on

--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -6,8 +6,7 @@ import requests
 import os
 import argparse
 
-
-def handle_bad_status(response) -> None:
+def handle_bad_status(response: requests.Response) -> None:
     if response.status_code != 200:
         exception_message = (
             "Is github alright?",

--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -11,7 +11,7 @@ def handle_bad_status(response: requests.Response) -> None:
         exception_message = (
             "Is github alright?",
             f"Recieved status code '{response.status_code}' when attempting to retrieve runs:\n",
-            f"{response.content}"
+            f"{response.content.decode()}"
         )
         raise RuntimeError(exception_message)
 

--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -6,6 +6,17 @@ import requests
 import os
 import argparse
 
+
+def handle_bad_status(response):
+    if response.status_code != 200:
+        exception_message = (
+            "Is github alright?",
+            f"Recieved status code '{response.status_code}' when attempting to retrieve runs:\n",
+            f"{response.content}"
+        )
+        raise Exception(exception_message)
+
+
 # Our strategy is to retrieve the parent workflow run, then filter its jobs on
 # RUNNER_NAME to figure out which job we're currently running.
 #
@@ -44,10 +55,12 @@ response = requests.get(
     f"{PYTORCH_GITHUB_API}/actions/runs/{args.workflow_run_id}/jobs?per_page=100",
     headers=REQUEST_HEADERS,
 )
+handle_bad_status(response)
 
 jobs = response.json()["jobs"]
 while "next" in response.links.keys():
     response = requests.get(response.links["next"]["url"], headers=REQUEST_HEADERS)
+    handle_bad_status(response)
     jobs.extend(response.json()["jobs"])
 
 # Sort the jobs list by start time, in descending order. We want to get the most


### PR DESCRIPTION
To help resolve issues like:
```
++ python3 .github/scripts/get_workflow_job_id.py 3736406815 i-08b8fd3e605729ed9
+ GHA_WORKFLOW_JOB_ID=
Warning: Attempt 2 failed. Reason: Child_process exited with error code 1
```

This should only happen when github actions is experiencing degraded service

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
