### PR TITLE
Disable non-deterministic models for optimizers

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -153,11 +153,14 @@ CI_SKIP_OPTIMIZER = {
     # TIMM
     "convmixer_768_32",  # accuracy
     "sebotnet33ts_256",  # accuracy
+    "hrnet_w18",  # Stack issue in fx
     "tf_mixnet_l",  # This model is non-deterministic with same input + weights,
     # but without optimizing over multiple iterations, this still passes
+    "mixnet_l",  # same as above
+    "ghostnet_100"  # same as above
     # TorchBench
     "dlrm",  # symbolic shapes error
-    "hrnet_w18",  # Stack issue in fx
+    # HF
     "pnasnet5large",  # Stack issue in fx
     "MobileBertForMaskedLM",  # Stack issue in fx
     "MobileBertForQuestionAnswering",  # Stack issue in fx

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -157,7 +157,7 @@ CI_SKIP_OPTIMIZER = {
     "tf_mixnet_l",  # This model is non-deterministic with same input + weights,
     # but without optimizing over multiple iterations, this still passes
     "mixnet_l",  # same as above
-    "ghostnet_100"  # same as above
+    "ghostnet_100",  # same as above
     # TorchBench
     "dlrm",  # symbolic shapes error
     # HF
@@ -942,7 +942,9 @@ class BenchmarkRunner:
             self.autocast = torch.cuda.amp.autocast
 
     def init_optimizer(self, name, device, params):
+        print(name)
         if device == "cuda" and self.args.training and name not in CI_SKIP_OPTIMIZER:
+            print("INIT OPTIMIZER")
             self.optimizer = torch.optim.SGD(params, lr=0.01)
         else:
             self.optimizer = None


### PR DESCRIPTION
These two models are non-deterministic even with constant inputs + weights and sometimes fail with variations between the fp64 and fp32 models in CI very rarely as a result.

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire