### PR TITLE
Enable oneDNN implementation in LSTM op

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -506,6 +506,7 @@ TORCH_LIBRARY_IMPL(aten, AutocastCPU, m) {
   KERNEL_CPU2(_convolution, deprecated, lower_precision_fp)
   KERNEL_CPU(matmul, lower_precision_fp)
   KERNEL_CPU(conv_tbc, lower_precision_fp)
+  KERNEL_CPU(mkldnn_rnn_layer, lower_precision_fp)
 
   // fp32 cast policy
   KERNEL_CPU(conv_transpose1d, fp32)

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -52,7 +52,6 @@
 #include <ATen/ops/zeros_like.h>
 #include <ATen/ops/zeros_like_ops.h>
 #include <utility>
-#include <ATen/ops/lstm_mkldnn_stub.h>
 #endif
 
 int register_linear_params();

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -75,7 +75,7 @@ bool use_mkldnn(const Tensor& input, const double dropout_p) {
     return false;
   }
   return input.options().backend() == at::Backend::CPU &&
-      input.scalar_type() == kFloat;
+      (input.scalar_type() == kFloat || input.scalar_type() == kBFloat16);
 #endif
   return false;
 }

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1421,6 +1421,7 @@ DEFINE_DISPATCH(lstm_cudnn_stub);
 DEFINE_DISPATCH(lstm_packed_cudnn_stub);
 DEFINE_DISPATCH(lstm_miopen_stub);
 DEFINE_DISPATCH(lstm_packed_miopen_stub);
+DEFINE_DISPATCH(lstm_mkldnn_stub);
 REGISTER_NO_CPU_DISPATCH(lstm_cudnn_stub);
 REGISTER_NO_CPU_DISPATCH(lstm_packed_cudnn_stub);
 REGISTER_NO_CPU_DISPATCH(lstm_miopen_stub);
@@ -1461,8 +1462,10 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
 
   if (use_mkldnn(_input, dropout_p)) {
     std::cout<<"in use_mkldnn\n";
-    return at::lstm_mkldnn_stub(_input, hx, _params, has_biases,
+    Tensor output, hy, cy;
+    lstm_mkldnn_stub(_input.device().type(), output, hy, cy,_input, hx, _params, has_biases,
         num_layers, dropout_p, train, bidirectional, batch_first);
+    return std::make_tuple(std::move(output), std::move(hy), std::move(cy));
   }
 
   check_attributes(_input, _params, hx);

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1461,7 +1461,6 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
 
   if (use_mkldnn(_input, dropout_p)) {
     if (!has_projections) {
-      std::cout<<"in use_mkldnn\n";
       Tensor output, hy, cy;
       lstm_mkldnn_stub(_input.device().type(), output, hy, cy,_input, hx, _params, has_biases,
           num_layers, dropout_p, train, bidirectional, batch_first);

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -69,7 +69,7 @@ bool use_miopen(const at::Tensor& input, const double dropout_state) {
     return is_miopen_acceptable;
 }
 
-bool use_mkldnn(const Tensor& input, const double dropout_p) {
+bool use_mkldnn(const Tensor& input) {
 #if AT_MKLDNN_ENABLED()
   if (!at::globalContext().userEnabledMkldnn()) {
     return false;
@@ -1459,7 +1459,7 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
     }
   }
 
-  if (use_mkldnn(_input, dropout_p)) {
+  if (use_mkldnn(_input)) {
     if (!has_projections) {
       if (hx[0].unsafeGetTensorImpl()->has_symbolic_sizes_strides()) {
         TORCH_WARN_ONCE(

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1460,11 +1460,16 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
   }
 
   if (use_mkldnn(_input, dropout_p)) {
-    std::cout<<"in use_mkldnn\n";
-    Tensor output, hy, cy;
-    lstm_mkldnn_stub(_input.device().type(), output, hy, cy,_input, hx, _params, has_biases,
-        num_layers, dropout_p, train, bidirectional, batch_first);
-    return std::make_tuple(std::move(output), std::move(hy), std::move(cy));
+    if (!has_projections) {
+      std::cout<<"in use_mkldnn\n";
+      Tensor output, hy, cy;
+      lstm_mkldnn_stub(_input.device().type(), output, hy, cy,_input, hx, _params, has_biases,
+          num_layers, dropout_p, train, bidirectional, batch_first);
+      return std::make_tuple(std::move(output), std::move(hy), std::move(cy));
+    } else {
+      TORCH_WARN_ONCE(
+          "LSTM with projections is not supported with oneDNN. Using default implementation.");
+    }
   }
 
   check_attributes(_input, _params, hx);

--- a/aten/src/ATen/native/RNN.h
+++ b/aten/src/ATen/native/RNN.h
@@ -12,6 +12,7 @@ using rnn_packed_fn = void(*)(Tensor&, Tensor&, const Tensor&, const Tensor&, co
 
 DECLARE_DISPATCH(lstm_fn, lstm_cudnn_stub);
 DECLARE_DISPATCH(lstm_fn, lstm_miopen_stub);
+DECLARE_DISPATCH(lstm_fn, lstm_mkldnn_stub);
 DECLARE_DISPATCH(rnn_fn, gru_cudnn_stub);
 DECLARE_DISPATCH(rnn_fn, gru_miopen_stub);
 DECLARE_DISPATCH(rnn_fn, rnn_tanh_cudnn_stub);

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
@@ -10,6 +10,9 @@ namespace at { namespace native {
 
 // Mapping ScalarType to ideep tensor data_type
 TORCH_API ideep::tensor::data_type get_mkldnn_dtype(ScalarType type);
+static inline ideep::tensor::data_type get_mkldnn_dtype(const Tensor& t) {
+  return get_mkldnn_dtype(t.scalar_type());
+}
 
 // Construct aten MKL-DNN tensor given an ideep tensor
 TORCH_API Tensor new_with_itensor_mkldnn(ideep::tensor&& it, c10::optional<ScalarType> dtype, c10::optional<Device> device);

--- a/aten/src/ATen/native/mkldnn/RNN.cpp
+++ b/aten/src/ATen/native/mkldnn/RNN.cpp
@@ -1,0 +1,456 @@
+#include <ATen/native/RNN.h>
+#include <ATen/ATen.h>
+#include <ATen/Config.h>
+#include <ATen/InitialTensorOptions.h>
+#include <ATen/MatrixRef.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/TensorUtils.h>
+#include <c10/util/Exception.h>
+
+#if !AT_MKLDNN_ENABLED()
+
+namespace at { namespace native {
+
+
+std::tuple<Tensor, Tensor, Tensor> lstm_mkldnn_stub(
+    const Tensor& input, TensorList hx, TensorList params, bool has_biases,
+    int64_t num_layers, double dropout_p, bool train, bool bidirectional, bool batch_first) {
+  AT_ERROR("lstm_mkldnn_stub: ATen not compiled with MKLDNN support");
+}
+
+std::tuple<Tensor, Tensor, Tensor, Tensor> mkldnn_rnn_layer(
+const Tensor& input,
+    const Tensor& w0,
+    const Tensor& w1,
+    const Tensor& w2,
+    const Tensor& w3,
+    const Tensor& hx_,
+    const Tensor& cx_,
+    bool reverse,
+    IntArrayRef batch_sizes,
+    int64_t mode,
+    int64_t hidden_size,
+    int64_t num_layers,
+    bool has_biases,
+    bool bidirectional,
+    bool batch_first,
+    bool train) {
+  AT_ERROR("mkldnn_rnn_layer: ATen not compiled with MKLDNN support");
+
+}} // namespace at::native
+
+#else // AT_MKLDNN_EBABLED
+
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
+#include <ATen/native/mkldnn/Utils.h>
+
+namespace at { namespace native {
+
+struct RNNParams {
+  ideep::rnn_kind mode;
+  int64_t seq_length;
+  int64_t mini_batch;
+  int64_t input_size;
+  int64_t hidden_size;
+  int64_t num_directions;
+  int64_t num_layers;
+  bool batch_first;
+  bool train;
+  at::IntArrayRef batch_sizes;
+  int64_t num_gates;
+  int64_t num_bias_gates;
+
+  RNNParams(
+      const at::Tensor& input,
+      at::IntArrayRef batch_sizes_,
+      int64_t mode_,
+      int64_t hidden_size_,
+      int64_t num_layers_,
+      bool bidirectional,
+      bool batch_first_,
+      bool train_) {
+    mode = static_cast<ideep::rnn_kind>(mode_);
+    batch_first = batch_first_;
+    seq_length = input.size(0);
+    mini_batch = input.size(1);
+    input_size = input.size(2);
+    hidden_size = hidden_size_;
+    num_directions = bidirectional ? 2 : 1;
+    num_layers = num_layers_;
+    train = train_;
+    batch_sizes = batch_sizes_;
+    if (mode == ideep::rnn_kind::LSTM) {
+      num_gates = 4;
+      num_bias_gates = 4;
+    } else if (mode == ideep::rnn_kind::GRU) {
+      num_gates = 3;
+      num_bias_gates = 4;
+    } else {
+      // RNN_RELU; RNN_TANH
+      num_gates = 1;
+      num_bias_gates = 1;
+    }
+  }
+
+  bool is_input_packed() const {
+    return batch_sizes.size() != 0;
+  }
+
+  // mkldnn memory descriptors
+  using format = ideep::format_tag;
+  using desc = ideep::tensor::desc;
+  using dtype = ideep::tensor::data_type;
+  desc src_layer_desc(int64_t _input_size, dtype dtype) const {
+    return {{seq_length, mini_batch, _input_size}, dtype, format::tnc};
+  }
+  desc src_iter_desc(dtype dtype) const {
+    return {{1, 1, mini_batch, hidden_size}, dtype, format::ldnc};
+  }
+  desc src_iter_c_desc(dtype dtype) const {
+    return {{1, 1, mini_batch, hidden_size}, dtype, format::ldnc};
+  }
+  // logical size described as ldigo
+  desc weights_layer_desc(int64_t _input_size, dtype dtype) const {
+    return {{1, 1, _input_size, num_gates, hidden_size}, dtype, format::ldgoi};
+  }
+  desc weights_layer_ldigo_desc(int64_t _input_size, dtype dtype) const {
+    return {{1, 1, _input_size, num_gates, hidden_size}, dtype, format::ldigo};
+  }
+  desc weights_iter_desc(dtype dtype) const {
+    return {{1, 1, hidden_size, num_gates, hidden_size}, dtype, format::ldgoi};
+  }
+  desc weights_iter_ldigo_desc(dtype dtype) const {
+    return {{1, 1, hidden_size, num_gates, hidden_size}, dtype, format::ldigo};
+  }
+  desc bias_desc(dtype dtype) const {
+    return {{1, 1, num_bias_gates, hidden_size}, dtype, format::ldgo};
+  }
+  desc dst_layer_desc(dtype dtype) const {
+    return {{seq_length, mini_batch, hidden_size}, dtype, format::tnc};
+  }
+  desc dst_iter_desc(dtype dtype) const {
+    return {{1, 1, mini_batch, hidden_size}, dtype, format::ldnc};
+  }
+  desc dst_iter_c_desc(dtype dtype) const {
+    return {{1, 1, mini_batch, hidden_size}, dtype, format::ldnc};
+  }
+};
+
+std::vector<int64_t> _hidden_size(const RNNParams& rnn) {
+  return {rnn.num_layers * rnn.num_directions, rnn.mini_batch, rnn.hidden_size};
+}
+
+template<bool is_single_direction>
+std::vector<int64_t> _output_size(const RNNParams& rnn) {
+  auto output_channels = is_single_direction ? rnn.hidden_size
+                                             : rnn.hidden_size * rnn.num_directions;
+  return {rnn.seq_length, rnn.mini_batch, output_channels};
+}
+
+// MKLDNN GRU gate order is different from PyTorch's which requires gates shuffle
+// (let rt,zt,nt be reset, update, new gates respectively)
+//
+//   MKLDNN GRU weight_ih/weight_hh gates order: (zt, rt, nt)
+//   PyTorch GRU weight_ih/weight_hh gates order: (rt, zt, nt)
+//
+// MKLDNN GRU bias has 4 gates instead of 3
+//  (PyTorch GRU bias)     (MKLDNN GRU bias)
+//
+//  bias_ih    bias_hh          bias
+//  +-----+    +-----+       +---------+
+//  | rt1 |    | rt2 |       | zt1+zt2 |
+//  |-----|    |-----|       |---------|
+//  | zt1 |    | zt2 |       | rt1+rt2 |
+//  |-----|    |-----|       |---------|
+//  | nt1 |    | nt2 |       |   nt1   |
+//  +-----+    +-----+       |---------|
+//                           |   nt2   |
+//                           +---------+
+//
+Tensor _shuffle_weight(const Tensor& weight, int64_t fn_mode) {
+  auto weight_t = weight.contiguous();
+  if (static_cast<ideep::rnn_kind>(fn_mode) == ideep::rnn_kind::GRU) {
+    std::vector<Tensor> gates = weight_t.chunk(3, /*gates*/0);
+    return at::cat({gates[1], gates[0], gates[2]}, /*gates*/0);
+  }
+  return weight_t;
+};
+
+Tensor _shuffle_bias(const Tensor& bias_ih, const Tensor& bias_hh, int64_t fn_mode) {
+  if (static_cast<ideep::rnn_kind>(fn_mode) == ideep::rnn_kind::GRU) {
+    std::vector<Tensor> b1 = bias_ih.chunk(3, /*output_channels*/0);
+    std::vector<Tensor> b2 = bias_hh.chunk(3, /*output_channels*/0);
+    return at::cat({b1[1] + b2[1], b1[0] + b2[0], b1[2], b2[2]}, /*output_channels*/0);
+  }
+  return bias_ih + bias_hh;
+};
+
+// Create mkldnn memory view from ATen tensor
+static inline ideep::tensor get_mkldnn_tensor(
+    const Tensor& tensor, const ideep::tensor::desc& desc) {
+  return {desc, tensor.data_ptr<float>()};
+}
+
+std::tuple<Tensor, Tensor, Tensor, Tensor> mkldnn_rnn_layer(const Tensor& input,
+    const Tensor& w0,
+    const Tensor& w1,
+    const Tensor& w2,
+    const Tensor& w3,
+    const Tensor& hx_,
+    const Tensor& cx_,
+    bool reverse,
+    IntArrayRef batch_sizes,
+    int64_t mode,
+    int64_t hidden_size,
+    int64_t num_layers,
+    bool has_biases,
+    bool bidirectional,
+    bool batch_first,
+    bool train) {
+        std::cout<<"in lstm_mkldnn_rnn_layer\n";
+  RNNParams rnn(
+      input,
+      batch_sizes,
+      mode,
+      hidden_size,
+      num_layers,
+      bidirectional,
+      batch_first,
+      train);
+
+    std::cout<<"1\n";
+  auto output_size = _output_size</*is_single_direction*/ true>(rnn);
+  auto output = at::empty(output_size, input.options());
+
+  auto hy_ = at::empty(hx_.sizes(), hx_.options());
+  auto cy_ = at::empty(cx_.sizes(), cx_.options());
+
+  auto weight_ih = _shuffle_weight(w0, rnn.mode);
+  auto weight_hh = _shuffle_weight(w1, rnn.mode);
+
+  auto bias = has_biases
+      ? _shuffle_bias(w2, w3, rnn.mode)
+      : at::zeros({rnn.num_bias_gates * rnn.hidden_size}, weight_ih.options());
+std::cout<<"2\n";
+  // per layer input size
+  int64_t input_size = input.size(2);
+  auto x = get_mkldnn_tensor(
+      input,
+      rnn.src_layer_desc(input_size, get_mkldnn_dtype(input.scalar_type())));
+  auto hx = get_mkldnn_tensor(
+      hx_, rnn.src_iter_desc(get_mkldnn_dtype(hx_.scalar_type())));
+  auto cx = get_mkldnn_tensor(
+      cx_, rnn.src_iter_c_desc(get_mkldnn_dtype(cx_.scalar_type())));
+  auto b = get_mkldnn_tensor(
+      bias, rnn.bias_desc(get_mkldnn_dtype(bias.scalar_type())));
+  auto y = get_mkldnn_tensor(
+      output, rnn.dst_layer_desc(get_mkldnn_dtype(output.scalar_type())));
+  auto hy = get_mkldnn_tensor(
+      hy_, rnn.dst_iter_desc(get_mkldnn_dtype(hy_.scalar_type())));
+  auto cy = get_mkldnn_tensor(
+      cy_, rnn.dst_iter_c_desc(get_mkldnn_dtype(cy_.scalar_type())));
+std::cout<<"3\n";
+//   ideep::tensor w1_, w2_;
+  auto w1_ = get_mkldnn_tensor(weight_ih, rnn.weights_layer_desc(input_size, get_mkldnn_dtype(weight_ih.scalar_type())));
+  auto w2_ = get_mkldnn_tensor(weight_hh, rnn.weights_iter_desc(get_mkldnn_dtype(weight_hh.scalar_type())));
+std::cout<<"4\n";
+//   ideep::lstm_forward_inference::compute(x, hx, cx, w1, w2, b, y, hy, cy, reverse);
+
+//   std::vector<at::Tensor> result;
+std::cout<<train<<"\n";
+train=false;
+  if (train) {
+    // at::Tensor workspace = at::Tensor();
+    // auto pd = ideep::lstm_forward_training::prepare(
+    //     x, hx, cx, w1_, w2_, b, y, hy, cy, reverse);
+    // workspace = torch_ipex::cpu::empty_aten_tensor_from_desc(
+    //     pd.workspace_desc(), input.options().dtype(at::kByte));
+    // ideep::tensor mkldnn_workspace;
+    // mkldnn_workspace.init(
+    //     pd.workspace_desc(), workspace.template data_ptr<uint8_t>());
+    // ideep::lstm_forward_training::compute(
+    //     pd, x, hx, cx, w1_, w2_, b, mkldnn_workspace, y, hy, cy, reverse);
+    // result.reserve(4);
+    // result.push_back(output);
+    // result.push_back(hy_);
+    // result.push_back(cy_);
+    // result.push_back(workspace);
+    return std::make_tuple(Tensor(), Tensor(), Tensor(), Tensor());
+  } else {
+    std::cout<<"before compute\n";
+    ideep::lstm_forward_inference::compute(
+        x, hx, cx, w1_, w2_, b, y, hy, cy, reverse);
+    return std::make_tuple(output, hy_, cy_, Tensor());
+    // result.reserve(4);
+    // result.push_back(output);
+    // result.push_back(hy_);
+    // result.push_back(cy_);
+    // result.push_back(Tensor());
+  }
+//   return result;
+}
+
+// MKLDNN RNN integration notes:
+// I. Memory Formats
+//   a. mkldnn will use plain formats for input, hx/cx, output, hy/cy
+//      and possibly use blocked formats for weights depending shape info.
+//   b. All mkldnn memorys are created (in plain format) as views on ATen tensor,
+//      the weight reorder(if any) is handed automatically inside ideep (mkldnn bridge)
+//
+// II. MKLDNN Primitive Mapping
+//   a. mkldnn rnn primitive doesn't support training with dropout or padded input sequence.
+//   b. here break a single RNN module into { num_layers * num_directions } mkldnn rnn primitives
+//      for future need to cover these feature gaps.
+//
+//TODO: a. training with dropout
+//   b. padded sequence input support
+//
+
+std::tuple<Tensor, Tensor, Tensor> mkldnn_rnn(
+    const Tensor& input_, TensorList weight, int64_t weight_stride0,
+    const Tensor& hx_, const Tensor& cx_,
+    int64_t mode, int64_t hidden_size,
+    int64_t num_layers, bool has_biases, bool batch_first, double dropout_p,
+    bool train, bool bidirectional, IntArrayRef batch_sizes) {
+        std::cout<<"in lstm_mkldnn_rnn\n";
+//   return std::make_tuple(Tensor(), Tensor(), Tensor());
+//   TORCH_CHECK(!train || dropout_p == 0.0, "mkldnn_rnn doesn't support dropout");
+  TORCH_CHECK(batch_sizes.size() == 0, "mkldnn_rnn doesn't support packed input");
+  if (static_cast<ideep::rnn_kind>(mode) != ideep::rnn_kind::LSTM) {
+    TORCH_CHECK(!cx_.defined(), "mkldnn_rnn: illegal defined cx for non-LSTM RNN");
+  }
+
+//   RNNParams fn(input_, batch_sizes, mode, hidden_size, num_layers, bidirectional, batch_first, train);
+
+  auto input = input_;
+  bool is_input_packed = batch_sizes.size() != 0;
+  if (batch_first && !is_input_packed) {
+    input = input.transpose(0, 1);
+  }
+  input = input.contiguous();
+
+  auto hx = hx_.contiguous();
+  auto cx = cx_.contiguous();
+//   auto cx = cx_.defined() ? cx_.contiguous() : Tensor();
+
+//   auto hy = at::empty(_hidden_size(fn), hx.options());
+//   // NB: Not allowed to return undefined tensors
+//   auto cy = cx.defined() ? at::empty(_hidden_size(fn), cx.options())
+//                          : at::empty({0}, hx.options());
+
+  MatrixRef<Tensor> weights{weight, static_cast<size_t>(weight_stride0)};
+
+  auto num_directions = bidirectional ? 2 : 1;
+  auto layer_input = input;
+  std::vector<at::Tensor> layer_output(num_directions);
+  std::vector<at::Tensor> layer_hy(num_layers * num_directions);
+  std::vector<at::Tensor> layer_cy(num_layers * num_directions);
+  for (int64_t layer = 0; layer < num_layers; layer++) {
+    // std::vector<Tensor> layer_output(num_directions);
+    for (int64_t direction = 0; direction < num_directions; direction++) {
+      auto index = layer * num_directions + direction;
+      auto layer_weights = weights[index];
+      TORCH_CHECK(layer_weights.size() == 2 || layer_weights.size() == 4);
+      auto layer_hx = hx[index];
+      auto layer_cx = cx[index];
+    //   auto layer_hy = hy[index];
+    //   auto layer_cx = cx.defined() ? cx[index] : Tensor();
+    //   auto layer_cy = cx.defined() ? cy[index] : at::empty({0}, input.options());
+      auto reverse = (direction > 0);
+    //   auto bias_dtype = get_bias_dtype(layer_input, layer_weights[0]);
+      auto outputs = at::mkldnn_rnn_layer(layer_input, layer_weights[0], layer_weights[1],
+                                        has_biases ? layer_weights[2] : at::zeros(layer_weights[0].sizes(), layer_weights[0].options()),
+          has_biases ? layer_weights[3] : at::zeros(layer_weights[1].sizes(), layer_weights[1].options()), layer_hx,
+          layer_cx, reverse, batch_sizes, mode, hidden_size, num_layers, has_biases, bidirectional, batch_first, train);
+    //   layer_output[direction] = mkldnn_rnn_layer(layer_hy, layer_cy, layer_input, layer_weights, layer_hx, layer_cx, reverse, fn);
+      layer_output[direction] = std::get<0>(outputs);
+      layer_hy[index] = std::get<1>(outputs);
+      layer_cy[index] = std::get<2>(outputs);
+    }
+    layer_input = num_directions == 1 ? layer_output[0]
+                                      : at::cat(layer_output, /*output_channels*/-1);
+    if (dropout_p != 0 && train && layer < num_layers - 1) {
+      layer_input = at::dropout(layer_input, dropout_p, /*train=*/true);
+    }
+  }
+  auto output = layer_input;
+  auto hy = at::stack(layer_hy, 0);
+  auto cy = at::stack(layer_cy, 0);
+  if (batch_first && !is_input_packed) {
+    output = output.transpose(0, 1);
+  }
+  return std::make_tuple(output, hy, cy);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//// MKLDNN dispatch for the generic RNN ops (at::lstm, at::gru, ...)
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+// Helpers for working with different hidden types.
+std::tuple<Tensor, Tensor> unpack_hidden(const Tensor& hidden) {
+  return std::make_tuple(hidden, at::Tensor{});
+}
+
+std::tuple<Tensor, Tensor> unpack_hidden(const std::tuple<Tensor, Tensor>& hidden) {
+  return hidden;
+}
+
+template<typename hidden_type>
+hidden_type pack_hidden(const Tensor& hx, const Tensor& cx) {
+  static_assert(std::is_same<hidden_type, void>::value, "pack_hidden not implemented for this type");
+  AT_ERROR("NOT IMPLEMENTED");
+}
+
+template<>
+Tensor pack_hidden<Tensor>(const Tensor& hx, const Tensor& cx) {
+  AT_ASSERT(cx.numel() == 0);
+  return hx;
+}
+
+template<>
+std::tuple<Tensor, Tensor> pack_hidden<std::tuple<Tensor, Tensor>>(const Tensor& hx, const Tensor& cx) {
+  return std::make_tuple(hx, cx);
+}
+
+template<typename hidden_type>
+std::pair<Tensor, hidden_type> mkldnn_impl(
+    const Tensor& input, const hidden_type& hidden,
+    TensorList params, bool has_biases, ideep::rnn_kind mode,
+    int64_t num_layers, double dropout_p, bool train, bool bidirectional, bool batch_first) {
+std::cout<<"in mkldnn_impl\n";
+  Tensor hx, cx;
+  std::tie(hx, cx) = unpack_hidden(hidden);
+  int64_t hidden_size = hx.size(2);
+
+  // mkldnn_output = std::tuple<output, hy, cy, workspace>
+  auto mkldnn_output = mkldnn_rnn(
+      input, params, has_biases ? 4 : 2,
+      hx, cx, static_cast<int>(mode), hidden_size, num_layers, has_biases, batch_first, dropout_p,
+      train, bidirectional, /*batch_sizes*/{});
+
+  return {std::get<0>(mkldnn_output),
+          pack_hidden<hidden_type>(std::get<1>(mkldnn_output), std::get<2>(mkldnn_output))};
+    // return {Tensor(), pack_hidden<hidden_type>(Tensor(), Tensor())};
+}
+
+} // anonymous namespace
+
+std::tuple<Tensor, Tensor, Tensor> lstm_mkldnn_stub(
+    const Tensor& input, TensorList hx, TensorList params, bool has_biases,
+    int64_t num_layers, double dropout_p, bool train, bool bidirectional, bool batch_first) {
+  std::cout<<"in lstm_mkldnn_stub\n";
+
+  auto result = mkldnn_impl(input, std::make_tuple(hx[0], hx[1]), params, has_biases,
+      ideep::rnn_kind::LSTM, num_layers, dropout_p, train, bidirectional, batch_first);
+  auto output = result.first;
+  auto hy = std::get<0>(result.second);
+  auto cy = std::get<1>(result.second);
+
+  return std::make_tuple(output, hy, cy);
+}
+
+}} // namespace at::native
+
+#endif // AT_MKLDNN_EBABLED

--- a/aten/src/ATen/native/mkldnn/RNN.cpp
+++ b/aten/src/ATen/native/mkldnn/RNN.cpp
@@ -472,7 +472,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> mkldnn_rnn_la
   mkldnn_workspace.init(
       forward_hint.workspace_desc(), workspace.template data_ptr<uint8_t>());
   ideep::lstm_backward::compute(forward_hint, x, hx, cx, w1, w2, b, y, hy, cy, diff_y, diff_hy, diff_cy, mkldnn_workspace, diff_x, diff_hx, diff_cx, diff_w1, diff_w2, diff_b, reverse);
-  return std::make_tuple(diff_x_, diff_w1_, diff_w2_, diff_b_, diff_b_, diff_hx_, diff_cx_);
+  auto diff_b2_ = at::clone(diff_b_);
+  return std::make_tuple(diff_x_, diff_w1_, diff_w2_, diff_b_, diff_b2_, diff_hx_, diff_cx_);
 }
 
 // MKLDNN RNN integration notes:

--- a/aten/src/ATen/native/mkldnn/RNN.cpp
+++ b/aten/src/ATen/native/mkldnn/RNN.cpp
@@ -189,7 +189,39 @@ Tensor _shuffle_bias(const Tensor& bias_ih, const Tensor& bias_hh, int64_t fn_mo
 // Create mkldnn memory view from ATen tensor
 static inline ideep::tensor get_mkldnn_tensor(
     const Tensor& tensor, const ideep::tensor::desc& desc) {
-  return {desc, tensor.data_ptr<float>()};
+  TORCH_CHECK(
+      tensor.device().is_cpu(),
+      "get_mkldnn_tensor expects CPU tensor input");
+  TORCH_CHECK(
+      tensor.layout() == at::Layout::Strided,
+      "get_mkldnn_tensor expects dense tensor input");
+  TORCH_CHECK(
+      tensor.scalar_type() == at::ScalarType::Float ||
+          tensor.scalar_type() == at::ScalarType::BFloat16 ||
+          tensor.scalar_type() == at::ScalarType::Half,
+      "get_mkldnn_tensor expects float or bfloat16 tensor input");
+  return {desc, tensor.data_ptr()};
+}
+
+// Init a aten tensor according to ideep tensor's desc.
+static inline Tensor empty_aten_tensor_from_desc(
+    const ideep::tensor::desc& desc,
+    const at::TensorOptions& options) {
+  auto ndims = desc.data.ndims;
+  auto nblks = desc.blocking_desc().inner_nblks;
+  std::vector<int64_t> at_sizes(ndims + nblks);
+  auto padded_dims = desc.padded_dims();
+  auto blk_sizes = desc.blocking_desc().inner_blks;
+  auto blk_idxs = desc.blocking_desc().inner_idxs;
+  std::vector<int64_t> blk_size_per_dim(ndims, 1);
+  for (auto i = 0; i < nblks; i++) {
+    at_sizes[i + ndims] = blk_sizes[i];
+    blk_size_per_dim[blk_idxs[i]] *= blk_sizes[i];
+  }
+  for (auto i = 0; i < ndims; i++) {
+    at_sizes[i] = padded_dims[i] / blk_size_per_dim[i];
+  }
+  return at::empty(at_sizes, options);
 }
 
 std::tuple<Tensor, Tensor, Tensor, Tensor> mkldnn_rnn_layer(const Tensor& input,
@@ -252,27 +284,171 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> mkldnn_rnn_layer(const Tensor& input,
   auto w2_ = get_mkldnn_tensor(weight_hh, rnn.weights_iter_desc(get_mkldnn_dtype(weight_hh.scalar_type())));
 
   if (train) {
-    // at::Tensor workspace = at::Tensor();
-    // auto pd = ideep::lstm_forward_training::prepare(
-    //     x, hx, cx, w1_, w2_, b, y, hy, cy, reverse);
-    // workspace = torch_ipex::cpu::empty_aten_tensor_from_desc(
-    //     pd.workspace_desc(), input.options().dtype(at::kByte));
-    // ideep::tensor mkldnn_workspace;
-    // mkldnn_workspace.init(
-    //     pd.workspace_desc(), workspace.template data_ptr<uint8_t>());
-    // ideep::lstm_forward_training::compute(
-    //     pd, x, hx, cx, w1_, w2_, b, mkldnn_workspace, y, hy, cy, reverse);
-    // result.reserve(4);
-    // result.push_back(output);
-    // result.push_back(hy_);
-    // result.push_back(cy_);
-    // result.push_back(workspace);
-    return std::make_tuple(Tensor(), Tensor(), Tensor(), Tensor());
+    Tensor workspace = Tensor();
+    auto pd = ideep::lstm_forward_training::prepare(
+        x, hx, cx, w1_, w2_, b, y, hy, cy, reverse);
+    workspace = empty_aten_tensor_from_desc(
+        pd.workspace_desc(), input.options().dtype(at::kByte));
+    ideep::tensor mkldnn_workspace;
+    mkldnn_workspace.init(
+        pd.workspace_desc(), workspace.template data_ptr<uint8_t>());
+    ideep::lstm_forward_training::compute(
+        pd, x, hx, cx, w1_, w2_, b, mkldnn_workspace, y, hy, cy, reverse, ideep::prop_kind::forward_training);
+    return std::make_tuple(output, hy_, cy_, workspace);
   } else {
     ideep::lstm_forward_inference::compute(
         x, hx, cx, w1_, w2_, b, y, hy, cy, reverse, ideep::prop_kind::forward_inference);
     return std::make_tuple(output, hy_, cy_, Tensor());
   }
+}
+
+std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> mkldnn_rnn_layer_backward(
+    const Tensor& input,
+    const Tensor& weight0,
+    const Tensor& weight1,
+    const Tensor& weight2,
+    const Tensor& weight3,
+    const Tensor& hx_,
+    const Tensor& cx_tmp,
+    const Tensor& output,
+    const Tensor& hy_,
+    const Tensor& cy_,
+    const c10::optional<Tensor>& grad_output_r_opt,
+    const c10::optional<Tensor>& grad_hy_r_opt,
+    const c10::optional<Tensor>& grad_cy_r_opt,
+    bool reverse,
+    int64_t mode,
+    int64_t hidden_size,
+    int64_t num_layers,
+    bool has_biases,
+    bool train,
+    bool bidirectional,
+    at::IntArrayRef batch_sizes,
+    bool batch_first,
+    const at::Tensor& workspace) {
+  const Tensor& grad_output_r = c10::value_or_else(grad_output_r_opt, [] {return Tensor();});
+  const Tensor& grad_hy_r = c10::value_or_else(grad_hy_r_opt, [] {return Tensor();});
+  const Tensor& grad_cy_r = c10::value_or_else(grad_cy_r_opt, [] {return Tensor();});
+  if (!grad_output_r.defined() && !grad_hy_r.defined() && !grad_cy_r.defined()) {
+      return std::make_tuple(Tensor(), Tensor(), Tensor(), Tensor(), Tensor(), Tensor(), Tensor());
+  }
+  auto grad_output = grad_output_r.defined() ? grad_output_r.contiguous() : at::zeros_like(output, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  auto grad_hy = grad_hy_r.defined() ? grad_hy_r.contiguous() : at::zeros_like(hx_, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  auto grad_cy = cx_tmp.defined() ? (grad_cy_r.defined() ? grad_cy_r.contiguous() : at::zeros_like(cx_tmp, LEGACY_CONTIGUOUS_MEMORY_FORMAT)) : grad_cy_r.contiguous();
+  RNNParams rnn(
+      input,
+      batch_sizes,
+      mode,
+      hidden_size,
+      num_layers,
+      bidirectional,
+      batch_first,
+      train);
+  auto output_size = _output_size</*is_single_direction*/ true>(rnn);
+
+  auto weight_ih = _shuffle_weight(weight0, rnn.mode);
+  auto weight_hh = _shuffle_weight(weight1, rnn.mode);
+  auto bias = has_biases
+      ? _shuffle_bias(weight2, weight3, rnn.mode)
+      : at::zeros({rnn.num_bias_gates * rnn.hidden_size}, weight_ih.options());
+
+  at::Tensor cx_;
+  if (hx_.storage().unsafeGetStorageImpl() ==
+      cx_tmp.storage().unsafeGetStorageImpl()) {
+    cx_ = at::clone(cx_tmp);
+  } else {
+    cx_ = cx_tmp;
+  }
+
+  // per layer input size
+  int64_t input_size = input.size(2);
+  auto x = get_mkldnn_tensor(
+      input,
+      rnn.src_layer_desc(input_size, get_mkldnn_dtype(input.scalar_type())));
+  auto hx = get_mkldnn_tensor(
+      hx_, rnn.src_iter_desc(get_mkldnn_dtype(hx_.scalar_type())));
+  auto cx = get_mkldnn_tensor(
+      cx_, rnn.src_iter_c_desc(get_mkldnn_dtype(cx_.scalar_type())));
+  auto w1 = get_mkldnn_tensor(
+      weight_ih,
+      rnn.weights_layer_desc(
+          input_size, get_mkldnn_dtype(weight_ih.scalar_type())));
+  auto w2 = get_mkldnn_tensor(
+      weight_hh,
+      rnn.weights_iter_desc(get_mkldnn_dtype(weight_hh.scalar_type())));
+  auto b = get_mkldnn_tensor(
+      bias, rnn.bias_desc(get_mkldnn_dtype(bias.scalar_type())));
+  auto y = get_mkldnn_tensor(
+      output, rnn.dst_layer_desc(get_mkldnn_dtype(output.scalar_type())));
+  auto hy = get_mkldnn_tensor(
+      hy_, rnn.dst_iter_desc(get_mkldnn_dtype(hy_.scalar_type())));
+  auto cy = get_mkldnn_tensor(
+      cy_, rnn.dst_iter_c_desc(get_mkldnn_dtype(cy_.scalar_type())));
+
+  // Create diff_* ATen tensor and corresponding ideep tensor as fp32
+  auto diff_x_ =
+      at::empty(input.sizes(), input.options().dtype(at::ScalarType::Float));
+  auto diff_hx_ =
+      at::empty(hx_.sizes(), hx_.options().dtype(at::ScalarType::Float));
+  auto diff_cx_ =
+      at::empty(cx_.sizes(), cx_.options().dtype(at::ScalarType::Float));
+  auto diff_w1_ = at::empty(
+      weight_ih.sizes(), weight_ih.options().dtype(at::ScalarType::Float));
+  auto diff_w2_ = at::empty(
+      weight_hh.sizes(), weight_hh.options().dtype(at::ScalarType::Float));
+  auto diff_b_ =
+      at::empty(bias.sizes(), bias.options().dtype(at::ScalarType::Float));
+
+  auto diff_x = get_mkldnn_tensor(
+      diff_x_, rnn.src_layer_desc(input_size, ideep::tensor::data_type::f32));
+  auto diff_hx = get_mkldnn_tensor(
+      diff_hx_, rnn.src_iter_desc(ideep::tensor::data_type::f32));
+  auto diff_cx = get_mkldnn_tensor(
+      diff_cx_, rnn.src_iter_c_desc(ideep::tensor::data_type::f32));
+  auto diff_w1 = get_mkldnn_tensor(
+      diff_w1_,
+      rnn.weights_layer_desc(input_size, ideep::tensor::data_type::f32));
+  auto diff_w2 = get_mkldnn_tensor(
+      diff_w2_, rnn.weights_iter_desc(ideep::tensor::data_type::f32));
+  auto diff_b = get_mkldnn_tensor(
+      diff_b_, rnn.bias_desc(ideep::tensor::data_type::f32));
+
+  // Convert grad_y, grad_hy, grad_cy to fp32 in non-fp32 backward
+  ideep::tensor diff_y, diff_hy, diff_cy;
+  at::Tensor grad_y_, grad_hy_, grad_cy_;
+  if (input.scalar_type() != at::ScalarType::Float) {
+    grad_y_ = at::empty(
+        grad_output.sizes(),
+        grad_output.options().dtype(at::ScalarType::Float));
+    grad_y_.copy_(grad_output);
+    grad_hy_ = at::empty(
+        grad_hy.sizes(), grad_hy.options().dtype(at::ScalarType::Float));
+    grad_hy_.copy_(grad_hy);
+    grad_cy_ = at::empty(
+        grad_cy.sizes(), grad_cy.options().dtype(at::ScalarType::Float));
+    grad_cy_.copy_(grad_cy);
+
+    diff_y = get_mkldnn_tensor(
+        grad_y_, rnn.dst_layer_desc(get_mkldnn_dtype(grad_y_.scalar_type())));
+    diff_hy = get_mkldnn_tensor(
+        grad_hy_, rnn.dst_iter_desc(get_mkldnn_dtype(grad_hy_.scalar_type())));
+    diff_cy = get_mkldnn_tensor(
+        grad_cy_, rnn.dst_iter_desc(get_mkldnn_dtype(grad_cy_.scalar_type())));
+  } else {
+    diff_y = get_mkldnn_tensor(
+        grad_output, rnn.dst_layer_desc(ideep::tensor::data_type::f32));
+    diff_hy = get_mkldnn_tensor(
+        grad_hy, rnn.dst_iter_desc(ideep::tensor::data_type::f32));
+    diff_cy = get_mkldnn_tensor(
+        grad_cy, rnn.dst_iter_desc(ideep::tensor::data_type::f32));
+  }
+
+  auto forward_hint = ideep::lstm_forward_training::prepare(x, hx, cx, w1, w2, b, y, hy, cy, reverse);
+  ideep::tensor mkldnn_workspace;
+  mkldnn_workspace.init(
+      forward_hint.workspace_desc(), workspace.template data_ptr<uint8_t>());
+  ideep::lstm_backward::compute(forward_hint, x, hx, cx, w1, w2, b, y, hy, cy, diff_y, diff_hy, diff_cy, mkldnn_workspace, diff_x, diff_hx, diff_cx, diff_w1, diff_w2, diff_b, reverse);
+  return std::make_tuple(diff_x_, diff_w1_, diff_w2_, diff_b_, diff_b_, diff_hx_, diff_cx_);
 }
 
 // MKLDNN RNN integration notes:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3741,6 +3741,14 @@
     CompositeExplicitAutograd: mkldnn_convolution
   autogen: mkldnn_convolution.out
 
+- func: lstm_mkldnn_stub(Tensor self, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor, Tensor)
+  dispatch:
+    CPU: lstm_mkldnn_stub
+
+- func: mkldnn_rnn_layer(Tensor input, Tensor weight0, Tensor weight1, Tensor weight2, Tensor weight3, Tensor hx_, Tensor cx_, bool reverse, int[] batch_sizes, int mode, int hidden_size, int num_layers, bool has_biases, bool bidirectional, bool batch_first, bool train) -> (Tensor, Tensor, Tensor, Tensor)
+  dispatch:
+    CPU: mkldnn_rnn_layer
+
 - func: miopen_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor)
   dispatch:
     CUDA: miopen_batch_norm

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3745,6 +3745,10 @@
   dispatch:
     CPU: mkldnn_rnn_layer
 
+- func: mkldnn_rnn_layer_backward(Tensor input, Tensor weight1, Tensor weight2, Tensor weight3, Tensor weight4, Tensor hx_, Tensor cx_tmp, Tensor output, Tensor hy_, Tensor cy_, Tensor? grad_output, Tensor? grad_hy, Tensor? grad_cy, bool reverse, int mode, int hidden_size, int num_layers, bool has_biases, bool train, bool bidirectional, int[] batch_sizes, bool batch_first, Tensor workspace) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)
+  dispatch:
+    CPU: mkldnn_rnn_layer_backward
+
 - func: miopen_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor)
   dispatch:
     CUDA: miopen_batch_norm

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3741,10 +3741,6 @@
     CompositeExplicitAutograd: mkldnn_convolution
   autogen: mkldnn_convolution.out
 
-- func: lstm_mkldnn_stub(Tensor self, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor, Tensor)
-  dispatch:
-    CPU: lstm_mkldnn_stub
-
 - func: mkldnn_rnn_layer(Tensor input, Tensor weight0, Tensor weight1, Tensor weight2, Tensor weight3, Tensor hx_, Tensor cx_, bool reverse, int[] batch_sizes, int mode, int hidden_size, int num_layers, bool has_biases, bool bidirectional, bool batch_first, bool train) -> (Tensor, Tensor, Tensor, Tensor)
   dispatch:
     CPU: mkldnn_rnn_layer

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3744,10 +3744,12 @@
 - func: mkldnn_rnn_layer(Tensor input, Tensor weight0, Tensor weight1, Tensor weight2, Tensor weight3, Tensor hx_, Tensor cx_, bool reverse, int[] batch_sizes, int mode, int hidden_size, int num_layers, bool has_biases, bool bidirectional, bool batch_first, bool train) -> (Tensor, Tensor, Tensor, Tensor)
   dispatch:
     CPU: mkldnn_rnn_layer
+  autogen: mkldnn_rnn_layer.out
 
 - func: mkldnn_rnn_layer_backward(Tensor input, Tensor weight1, Tensor weight2, Tensor weight3, Tensor weight4, Tensor hx_, Tensor cx_tmp, Tensor output, Tensor hy_, Tensor cy_, Tensor? grad_output, Tensor? grad_hy, Tensor? grad_cy, bool reverse, int mode, int hidden_size, int num_layers, bool has_biases, bool train, bool bidirectional, int[] batch_sizes, bool batch_first, Tensor workspace) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)
   dispatch:
     CPU: mkldnn_rnn_layer_backward
+  autogen: mkldnn_rnn_layer_backward.out
 
 - func: miopen_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor)
   dispatch:

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -1154,6 +1154,7 @@ aten_cpu_source_non_codegen_list = [
     "aten/src/ATen/native/mkldnn/Prelu.cpp",
     "aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp",
     "aten/src/ATen/native/mkldnn/Relu.cpp",
+    "aten/src/ATen/native/mkldnn/RNN.cpp",
     "aten/src/ATen/native/mkldnn/SoftMax.cpp",
     "aten/src/ATen/native/mkldnn/TensorFactories.cpp",
     "aten/src/ATen/native/mkldnn/TensorShape.cpp",

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -3,6 +3,8 @@
 import copy
 import itertools
 import functools
+import sys
+import time
 import unittest
 
 try:
@@ -40,6 +42,9 @@ def has_bf16_support():
     return all(word in lines for word in ["avx512bw", "avx512vl", "avx512dq"])
 
 types = [torch.float, torch.bfloat16]
+
+def get_rand_seed():
+    return int(time.time() * 1000000000)
 
 # Comment the line below to find out the CI machines having MKL-DNN build disabled
 @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
@@ -1256,6 +1261,107 @@ class TestMkldnn(TestCase):
     def test_resnext50_32x4d(self):
         model = torchvision.models.resnet.resnext50_32x4d(pretrained=False)
         self._test_imagenet_model(model)
+
+    def _lstm_params_list(self):
+        params_dict = {
+            "input_size": [1, 5],
+            "hidden_size": [5, 16],
+            "num_layers": [1, 3],
+            "bidirectional": [False, True],
+            "bias": [False, True],
+            "batch_first": [False, True],
+            "dropout": [0, 0.4, 0.7, 1],
+            "batch_size": [1, 2],
+            "seq_len": [1, 3],
+            "training": [False, True]
+        }
+
+        params_list = []
+        for _, value in params_dict.items():
+            params_list.append(value)
+        return params_list
+
+    def _cast_dtype(self, input, bf16):
+        if bf16:
+            input = input.to(torch.bfloat16)
+        return input
+
+    def test_lstm(self):
+        rand_seed = int(get_rand_seed())
+        print("{} rand sed: {}".format(sys._getframe().f_code.co_name, rand_seed))
+        torch.manual_seed(rand_seed)
+
+        params_list = self._lstm_params_list()
+        for dtype in types:
+            bf16 = True if dtype == torch.bfloat16 else False
+            rtol=1.3e-6
+            atol=1e-5
+            if bf16:
+                rtol=0.02
+                atol=0.02
+            for input_size, hidden_size, num_layers, bidirectional, bias, batch_first, dropout, batch_size, seq_len, training in itertools.product(*params_list):
+                num_directions = 2 if bidirectional else 1
+                if batch_first:
+                    input = torch.randn(batch_size, seq_len, input_size, dtype=torch.float32)
+                else:
+                    input = torch.randn(seq_len, batch_size, input_size, dtype=torch.float32)
+                h = torch.randn(num_layers * num_directions, batch_size, hidden_size, dtype=torch.float32)
+                c = torch.randn(num_layers * num_directions, batch_size, hidden_size, dtype=torch.float32)
+
+                model = torch.nn.LSTM(input_size, hidden_size, num_layers, bidirectional=bidirectional,
+                                        bias=bias, dropout=dropout, batch_first=batch_first).float()
+                model.train() if training else model.eval()
+                input1 = input.clone().requires_grad_(training)
+                input2 = input.clone().requires_grad_(training)
+
+                h1 = h.clone().requires_grad_(training)
+                h2 = h.clone().requires_grad_(training)
+                c1 = c.clone().requires_grad_(training)
+                c2 = c.clone().requires_grad_(training)
+
+                model1 = copy.deepcopy(model)
+                model2 = copy.deepcopy(model)
+                with torch.cpu.amp.autocast(enabled=bf16, dtype=torch.bfloat16):
+                    torch._C._set_mkldnn_enabled(False)
+                    torch.manual_seed(rand_seed)
+                    output1, (hn1, cn1) = self._cast_dtype(model1, bf16)(self._cast_dtype(input1, bf16), (self._cast_dtype(h1, bf16), self._cast_dtype(c1, bf16)))
+
+                    torch._C._set_mkldnn_enabled(True)
+                    torch.manual_seed(rand_seed)
+                    output2, (hn2, cn2) = model2(input2, (h2, c2))
+                    self.assertEqual(output1, output2, rtol=rtol, atol=atol)
+                    self.assertEqual(hn1, hn2, rtol=rtol, atol=atol)
+                    self.assertEqual(cn1, cn2, rtol=rtol, atol=atol)
+
+                    if training:
+                        torch._C._set_mkldnn_enabled(False)
+                        torch.manual_seed(rand_seed)
+                        output1.sum().backward(retain_graph=True)
+
+                        torch._C._set_mkldnn_enabled(True)
+                        torch.manual_seed(rand_seed)
+                        output2.sum().backward(retain_graph=True)
+
+                        self.assertEqual(input1.grad, input2.grad, rtol=rtol, atol=atol)
+                        for name, para in model1.named_parameters():
+                            self.assertEqual(para, self._cast_dtype(getattr(model2, name), bf16))
+                            self.assertEqual(para.grad, self._cast_dtype(getattr(model2, name).grad, bf16), rtol=rtol, atol=atol)
+
+                        torch._C._set_mkldnn_enabled(False)
+                        torch.manual_seed(rand_seed)
+                        hn1.sum().backward(retain_graph=True)
+                        torch._C._set_mkldnn_enabled(True)
+                        torch.manual_seed(rand_seed)
+                        hn2.sum().backward(retain_graph=True)
+                        self.assertEqual(h1.grad, h2.grad, rtol=rtol, atol=atol)
+
+                        torch._C._set_mkldnn_enabled(False)
+                        torch.manual_seed(rand_seed)
+                        cn1.sum().backward(retain_graph=True)
+                        torch._C._set_mkldnn_enabled(True)
+                        torch.manual_seed(rand_seed)
+                        cn2.sum().backward(retain_graph=True)
+                        self.assertEqual(c1.grad, c2.grad, rtol=rtol, atol=atol)
 
 
 if __name__ == '__main__':

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2598,6 +2598,12 @@
 - name: miopen_rnn_backward(Tensor input, Tensor[] weight, int weight_stride0, Tensor weight_buf, Tensor hx, Tensor? cx, Tensor output, Tensor? grad_output, Tensor? grad_hy, Tensor? grad_cy, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, Tensor? dropout_state, Tensor reserve, bool[4] output_mask) -> (Tensor, Tensor, Tensor, Tensor[])
   dropout_state: non_differentiable
 
+- name: mkldnn_rnn_layer(Tensor input, Tensor weight0, Tensor weight1, Tensor weight2, Tensor weight3, Tensor hx_, Tensor cx_, bool reverse, int[] batch_sizes, int mode, int hidden_size, int num_layers, bool has_biases, bool bidirectional, bool batch_first, bool train) -> (Tensor, Tensor, Tensor, Tensor)
+  output_differentiability: [True, True, True, False]
+  input, weight0, weight1, weight2, weight3, hx_, cx_: "mkldnn_rnn_layer_backward(input, weight0, weight1, weight2, weight3, hx_, cx_, result0, result1, result2, grads[0], grads[1], grads[2], reverse, mode, hidden_size, num_layers, has_biases, train, bidirectional, batch_sizes, batch_first, result3)"
+
+# - name: mkldnn_rnn_layer_backward(Tensor input, Tensor weight1, Tensor weight2, Tensor weight3, Tensor weight4, Tensor hx_, Tensor cx_tmp, Tensor output, Tensor hy_, Tensor cy_, Tensor grad_output, Tensor grad_hy, Tensor grad_cy, bool reverse, int mode, int hidden_size, int num_layers, bool has_biases, bool train, bool bidirectional, int[] batch_sizes, bool batch_first, Tensor workspace) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)
+
 # mkldnn
 - name: mkldnn_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, int[] stride, int[] dilation, int groups) -> Tensor
   self, weight, bias: "grad.defined() ? convolution_backward_symint(grad, self, weight, bias->sym_sizes(), stride, padding, dilation, /*transposed=*/ false, /*output_padding=*/ std::vector<c10::SymInt>(padding.size(), 0), groups, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>()"

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2602,7 +2602,7 @@
   output_differentiability: [True, True, True, False]
   input, weight0, weight1, weight2, weight3, hx_, cx_: "mkldnn_rnn_layer_backward(input, weight0, weight1, weight2, weight3, hx_, cx_, result0, result1, result2, grads[0], grads[1], grads[2], reverse, mode, hidden_size, num_layers, has_biases, train, bidirectional, batch_sizes, batch_first, result3)"
 
-# - name: mkldnn_rnn_layer_backward(Tensor input, Tensor weight1, Tensor weight2, Tensor weight3, Tensor weight4, Tensor hx_, Tensor cx_tmp, Tensor output, Tensor hy_, Tensor cy_, Tensor grad_output, Tensor grad_hy, Tensor grad_cy, bool reverse, int mode, int hidden_size, int num_layers, bool has_biases, bool train, bool bidirectional, int[] batch_sizes, bool batch_first, Tensor workspace) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)
+- name: mkldnn_rnn_layer_backward(Tensor input, Tensor weight1, Tensor weight2, Tensor weight3, Tensor weight4, Tensor hx_, Tensor cx_tmp, Tensor output, Tensor hy_, Tensor cy_, Tensor? grad_output, Tensor? grad_hy, Tensor? grad_cy, bool reverse, int mode, int hidden_size, int num_layers, bool has_biases, bool train, bool bidirectional, int[] batch_sizes, bool batch_first, Tensor workspace) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)
 
 # mkldnn
 - name: mkldnn_convolution(Tensor self, Tensor weight, Tensor? bias, SymInt[] padding, int[] stride, int[] dilation, int groups) -> Tensor

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2346,7 +2346,7 @@ def mkldnn_rnn_layer(
         cy = torch.empty(0, device=input.device)
     else:
         cy = cx_.new_empty(cx_.shape)
-    workspace = input.new_empty([hidden_size * 1024], dtype=torch.uint8)
+    workspace = torch.empty(0, device=input.device, dtype=torch.uint8)
     return output, hy, cy, workspace
 
 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -162,6 +162,7 @@ def get_ignored_functions() -> Set[Callable]:
         torch.mkldnn_max_pool2d,
         torch.mkldnn_max_pool3d,
         torch.mkldnn_linear_backward_weights,
+        torch.mkldnn_rnn_layer,
         torch.normal,
         torch.ones,
         torch.promote_types,


### PR DESCRIPTION
### Description
This PR is to enable oneDNN implementation in LSTM op to improve the performance of it. Both FP32 and BF16 are supported.

### Performance improvement
In CPX 28C, with setting iomp and jemalloc.
We choose 8 LSTM input options (including input_size, hidden_size, num_layers, bidirectional, bias, batch_first, dropout, batch_size, seq_len), and the final option is a real input from train-clean-100 in LibriSpeech dataset. The performance improvements are shown in the following figures. We can see that LSTM with oneDNN implementation can perform better than the original.

In single socket:
![image](https://user-images.githubusercontent.com/61222868/211182994-833debec-518a-4b35-8504-6b0fadb17930.png)

![image](https://user-images.githubusercontent.com/61222868/211183012-31e1253f-2c60-4c92-a656-c239a971b453.png)

In single core:
![image](https://user-images.githubusercontent.com/61222868/211183017-186e5d47-cb9a-4c1e-914f-fa718e769f1c.png)

![image](https://user-images.githubusercontent.com/61222868/211183022-53266857-5a9e-4a95-b300-33fa34811d08.png)



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @mcarilli @ptrblck @leslie-fang-intel