### PR TITLE
[Nested Tensor] do not use at::cuda::getDefaultCUDAStream(), again

### DIFF
--- a/aten/src/ATen/native/nested/cuda/NestedTensorBinaryOps.cu
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorBinaryOps.cu
@@ -60,7 +60,7 @@ void nested_op_dense_kernelLauncher(
 {
   dim3 grid;
   grid.x = batch_size;
-  const auto stream = at::cuda::getDefaultCUDAStream();
+  const auto stream = at::cuda::getCurrentCUDAStream();
 
   op_dense_esuhm<<<grid, BLOCK_DIM, 0, stream>>>(
       input,


### PR DESCRIPTION
Otherwise, Nested Tensor kernels won't sync with current stream, resulting in flaky unit tests in test_nestedtensor.py.

This is the second time the wrong streams have been used in NestedTensor code. See #84134 for another example.