### PR TITLE
[MPS] Add suport for casting updatesTensor directly in scatter

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -281,18 +281,7 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, boo
   // If the memory is not contiguous, it means that the tensor has strides and we would not be
   // able to do the copy using a single blit
   if (!dst_.is_contiguous()) {
-    Tensor tmp;
-    if (src.dtype() != dst_.dtype()) {
-      id<MTLBuffer> tmpBuffer = sourceBuffer;
-      if (src.element_size() < dst_.element_size()) {
-        tmp = at::native::empty_mps(dst_.sizes(), dst_.scalar_type(), c10::nullopt, kMPS);
-        tmpBuffer = getMTLBufferStorage(tmp);
-      }
-
-      copy_cast_mps(dst_, src, tmpBuffer, sourceBuffer);
-    }
-
-    return scatterViewTensor((src.dtype() != dst_.dtype() && tmp.has_storage()) ? tmp : src, dst_);
+    return scatterViewTensor(src, dst_);
   }
   src._set_conj(src_.is_conj());
   src._set_neg(src_.is_neg());

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -18,10 +18,15 @@ struct ViewCachedGraph : public MPSCachedGraph
   std::vector<MPSGraphTensor*> strideTensors;
 };
 
-static std::string getStridedKey(const ScalarType& dtype, const IntArrayRef& base_shape,
+static std::string getStridedKey(const ScalarType& self_dtype, const ScalarType& updates_dtype, const IntArrayRef& base_shape,
                           const IntArrayRef& new_shape, bool is_scatter)
 {
-  return (is_scatter ? "scatter:" : "gather:") + getMPSTypeString(dtype) + "[" +
+  std::string dtype_key = getMPSTypeString(self_dtype);
+  if (is_scatter) {
+    dtype_key += ":" + getMPSTypeString(updates_dtype);
+  }
+
+  return (is_scatter ? "scatter:" : "gather:") + dtype_key + "[" +
          getArrayRefString(base_shape) + "]:[" + getArrayRefString(new_shape) + "]";
 }
 
@@ -50,7 +55,7 @@ static Tensor& runViewGraph(ViewCachedGraph* cachedGraph, const at::Tensor& src,
     if (needsScatter) {
       feeds[cachedGraph->updatesTensor] = [[[MPSGraphTensorData alloc] initWithMTLBuffer: sourceBuffer
                                                                                    shape: getMPSShape(src.numel())
-                                                                                dataType: inputType] autorelease];
+                                                                                dataType: getMPSDataType(src.scalar_type())] autorelease];
     }
     MPSScalar storageOffsetScalar = getMPSScalar(storage_offset, ScalarType::Int);
     feeds[cachedGraph->storageOffsetTensor] = getMPSGraphTensorFromScalar(stream, storageOffsetScalar);
@@ -81,7 +86,8 @@ static Tensor& runViewGraph(ViewCachedGraph* cachedGraph, const at::Tensor& src,
 static MPSGraphTensor* chainViewOperation(ViewCachedGraph* cachedGraph, const IntArrayRef& size,
                                           const IntArrayRef& stride, int64_t offset,
                                           const IntArrayRef& base_shape, bool needsScatter,
-                                          const bool needsBoolCast)
+                                          const bool needsBoolCast,
+                                          MPSGraphTensor* updatesTensor)
 {
   MPSGraph* mpsGraph = cachedGraph->graph();
   MPSGraphTensor *outputTensor = nil;
@@ -140,7 +146,7 @@ static MPSGraphTensor* chainViewOperation(ViewCachedGraph* cachedGraph, const In
     if (needsScatter) {
       MPSGraphTensor* scatteredTensor = [mpsGraph scatterAlongAxis: (NSInteger) 0
                                                     withDataTensor: reshapedInputTensor
-                                                     updatesTensor: cachedGraph->updatesTensor
+                                                     updatesTensor: updatesTensor
                                                      indicesTensor: reshapedIndicesTensor
                                                               mode: MPSGraphScatterModeSet
                                                               name: nil];
@@ -188,7 +194,7 @@ static MPSGraphTensor* chainViewOperation(ViewCachedGraph* cachedGraph, const In
 //            |    /          \   |
 //            |   /            \  |
 //            NonView T         NonView T
-static ViewCachedGraph* createViewGraph(const Tensor& self, IntArrayRef size, IntArrayRef stride, int64_t storage_offset, bool needsScatter)
+static ViewCachedGraph* createViewGraph(const Tensor& self, const Tensor &updates, IntArrayRef size, IntArrayRef stride, int64_t storage_offset, bool needsScatter)
 {
   IntArrayRef base_shape = get_buffer_shape(self.storage().data());
   if (base_shape.size() == 0) {
@@ -205,7 +211,7 @@ static ViewCachedGraph* createViewGraph(const Tensor& self, IntArrayRef size, In
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
   @autoreleasepool {
-    string key = getStridedKey(self.scalar_type(), base_shape, size, needsScatter);
+    string key = getStridedKey(self.scalar_type(), updates.scalar_type(), base_shape, size, needsScatter);
     ViewCachedGraph* cachedGraph = static_cast<ViewCachedGraph *>(cache_->LookUp(key));
 
     if (!cachedGraph) {
@@ -213,6 +219,7 @@ static ViewCachedGraph* createViewGraph(const Tensor& self, IntArrayRef size, In
         ViewCachedGraph *newCachedGraph = nil;
         @autoreleasepool {
             MPSGraph* mpsGraph = make_mps_graph();
+            MPSGraphTensor* updatesTensor = nil;
             newCachedGraph = new ViewCachedGraph(mpsGraph);
             // Workaround for MPSShaderLibrary bug
             // TODO: Remove once https://github.com/pytorch/pytorch/issues/82305 is resolved
@@ -228,9 +235,16 @@ static ViewCachedGraph* createViewGraph(const Tensor& self, IntArrayRef size, In
               newCachedGraph->strideTensors.push_back(mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[@1]));
             }
             if (needsScatter) {
-              newCachedGraph->updatesTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, inputType);
+              auto updatesType = getMPSScalarType(updates.scalar_type());
+              newCachedGraph->updatesTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, updatesType);
+              updatesTensor = newCachedGraph->updatesTensor;
+              if (inputType != updatesType) {
+                updatesTensor = [mpsGraph castTensor:updatesTensor
+                                              toType:inputType
+                                                name:@"castUpdatesTensor"];
+              }
             }
-            newCachedGraph->outputTensor = chainViewOperation(newCachedGraph, size, stride, storage_offset, base_shape, needsScatter, needsBoolCast);
+            newCachedGraph->outputTensor = chainViewOperation(newCachedGraph, size, stride, storage_offset, base_shape, needsScatter, needsBoolCast, updatesTensor);
         }
         return newCachedGraph;
       }));
@@ -245,7 +259,7 @@ Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst)
 
   const IntArrayRef& base_shape = get_buffer_shape(src.storage().data());
   if (base_shape.size() > 0) {
-    string key = getStridedKey(src.scalar_type(), base_shape, src.sizes(), /*is_scatter*/ false);
+    string key = getStridedKey(src.scalar_type(), dst.scalar_type(), base_shape, src.sizes(), /*is_scatter*/ false);
     cachedGraph = static_cast<ViewCachedGraph *>(MPSGraphCache::getInstance()->LookUp(key));
   }
   // there are cases where gatherViewTensor() is called without having as_strided() called beforehand.
@@ -261,12 +275,13 @@ Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst)
     output = at::native::empty_mps(src.sizes(), src.scalar_type(), c10::nullopt, kMPS);
     requires_sync = true;
   }
+
   return runViewGraph(cachedGraph, src, dst.has_storage() ? dst : output, /*needsScatter*/ false, requires_sync);
 }
 
 Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output)
 {
-  ViewCachedGraph* cachedGraph = createViewGraph(output, output.sizes(), output.strides(),
+  ViewCachedGraph* cachedGraph = createViewGraph(output, src, output.sizes(), output.strides(),
                                                  output.storage_offset(), /*needsScatter*/ true);
   return runViewGraph(cachedGraph, src, output, /*needsScatter*/ true, /*requires_sync*/  true);
 }
@@ -282,7 +297,7 @@ Tensor as_strided_tensorimpl_mps(const Tensor& self, IntArrayRef size, IntArrayR
 
   // 0 sizes won't result in any change in the shape of the Tensor so we can skip it.
   if (size.size() > 0)
-    mps::createViewGraph(self, size, stride, storage_offset, /*needsScatter*/ false);
+    mps::createViewGraph(self, self, size, stride, storage_offset, /*needsScatter*/ false);
 
   return result;
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1343,6 +1343,12 @@ class TestMPS(TestCase):
                 actual_pts[i, j] = X[pts[i, j], j]
                 self.assertEqual(actual_pts[i, j], actual_pts_mps[i, j])
 
+    def test_slice_scatter(self):
+        shape = (4, 4)
+        tensor = torch.randint(10, shape, device="mps")
+        tensor_before = tensor.clone()
+        torch.empty(shape[0], shape[1] * 2, device="mps")[:, ::2].copy_(tensor)
+        torch.testing.assert_close(tensor, tensor_before)
 
     def test_slice(self):
         values = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]


### PR DESCRIPTION
Fixes copies into slices where the input data type is different than the output dtype.

This change removes the cast done before scatter, so we don't have to allocate additional memory to perform the casting. Scatter handles the casting directly now.
```
device = "mps"
shape = (4, 4)
tensor = torch.randint(10, shape, device=device)
tensor_before = tensor.clone()
res = torch.empty(shape[0], shape[1] * 2, device=device)[:, ::2].copy_(tensor)
torch.testing.assert_close(tensor, tensor_before)
```