### PR TITLE
Compile fix for Clang + libc++

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -434,7 +434,8 @@ __device__ __attribute__((noinline)) __attribute__((weak)) void __assert_fail(
 // Warning: __has_trivial_copy for GCC may not always detect the non-POD
 // correctly. For example, T = std::unique_ptr may evaluate to true and be
 // treated as POD. This can cause unexpected behavior.
-#if defined(__GNUG__) && __GNUC__ < 5
+#if defined(__GNUG__) && __GNUC__ < 5 && \
+    !(defined(__clang__) && defined(_LIBCPP_VERSION))
 #define C10_IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
 #else
 #define C10_IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value


### PR DESCRIPTION
Summary:
LLVM 15 has a compile issue with the deprecated __has_trivial_copy. Update the GCC ifdef logic to exclude Clang + libc++.

```
caffe2/c10/util/Optional.h:536:13: error: builtin __has_trivial_copy is deprecated; use __is_trivially_copyable instead [-Werror,-Wdeprecated-builtins]
            C10_IS_TRIVIALLY_COPYABLE(T) &&
            ^
caffe2/c10/macros/Macros.h:438:38: note: expanded from macro 'C10_IS_TRIVIALLY_COPYABLE'
#define C10_IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
```

Test Plan: CI

Reviewed By: kit1980

Differential Revision: D42180203

