### PR TITLE
[BE] Reformat ReduceOps

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -10,6 +10,7 @@
 #include <ATen/native/Pool.h>
 #include <torch/library.h>
 #include <ATen/native/mps/MPSGraphVenturaOps.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -31,53 +32,43 @@ enum MPSReductionType {
   TRACE
 };
 
+using namespace mps;
 
 void set_apparent_shapes(NSMutableArray<NSNumber*> * &apparent_out_shape,
                          NSMutableArray<NSNumber*> * &apparent_in_shape,
                          int64_t num_reduce_dims,
-                         int64_t num_input_dims,
                          int64_t num_output_dims,
                          IntArrayRef& input_shape,
                          NSMutableArray<NSNumber*> * &axes) {
 
-  if(num_reduce_dims == 0) {
+  if (num_reduce_dims == 0) {
     /* Output shape becomes a one
      * Input shape becomes flattened
      * Because 0 reduce dims means all dims are reduced
      */
     apparent_in_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    int64_t num_in_elements = 1;
-    for(int i = 0; i < num_input_dims; i++) {
-        num_in_elements *= input_shape[i];
-    }
+    int64_t num_in_elements = c10::multiply_integers(input_shape);
     apparent_in_shape[0] = [NSNumber numberWithInt:num_in_elements];
 
     apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
     apparent_out_shape[0] = @1;
-  }
-
-  else {
+  } else {
     // num_output_dims in this case is number of input dims
     apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_output_dims];
-    for(int i = 0; i < num_output_dims; i++) {
+    for (const auto i : c10::irange(num_output_dims)) {
       int64_t current_input_dim = input_shape[i];
 
       // If the current dim is to be reduced
       bool is_reduce_dim = false;
 
-      for(int j = 0; j < num_reduce_dims; j++) {
-        if(i == [axes[j] intValue]) {
+      for (const auto j : c10::irange(num_reduce_dims)) {
+        if (i == [axes[j] intValue]) {
           is_reduce_dim = true;
           break;
         }
       }
 
-      if(is_reduce_dim) {
-        apparent_out_shape[i] = @1;
-      }
-      else {
-        apparent_out_shape[i] = [NSNumber numberWithInt:current_input_dim];
-      }
+      apparent_out_shape[i] = is_reduce_dim ? @1 : [NSNumber numberWithInt:current_input_dim];
     }
   }
 
@@ -88,18 +79,17 @@ void set_axes(NSMutableArray<NSNumber *> * &axes,
               int64_t num_reduce_dims,
               OptionalIntArrayRef opt_dim,
               int64_t num_input_dims) {
-    if(num_reduce_dims == 0) {
-      axes = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-      axes[0] = @0;
+  if (num_reduce_dims == 0) {
+    axes = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
+    axes[0] = @0;
+  } else {
+    TORCH_INTERNAL_ASSERT(opt_dim.has_value());
+    IntArrayRef dim = opt_dim.value();
+    axes = [NSMutableArray<NSNumber*> arrayWithCapacity:num_reduce_dims];
+    for (const auto i : c10::irange(num_reduce_dims)) {
+      axes[i] = [NSNumber numberWithInt:maybe_wrap_dim(dim[i], num_input_dims)];
     }
-    else {
-      TORCH_INTERNAL_ASSERT(opt_dim.has_value());
-      IntArrayRef dim = opt_dim.value();
-      axes = [NSMutableArray<NSNumber*> arrayWithCapacity:num_reduce_dims];
-      for(int i = 0; i < num_reduce_dims; i++) {
-        axes[i] = [NSNumber numberWithInt:maybe_wrap_dim(dim[i], num_input_dims)];
-      }
-    }
+  }
 }
 
 // Helper function to prepare axes and tensor shapes
@@ -125,28 +115,26 @@ void set_axes_and_shapes(const Tensor& input_t,
   set_apparent_shapes(apparent_output_shape,
                       apparent_input_shape,
                       num_reduce_dims,
-                      num_input_dims,
                       num_output_dims,
                       input_shape,
                       axes);
 
   // Squeeze dims for output shape
   output_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:0];
-  for(int i=0; i < num_output_dims; i++) {
-    if([apparent_output_shape[i] longValue] != 1) {
+  for (const auto i : c10::irange(num_output_dims)) {
+    if ([apparent_output_shape[i] longValue] != 1) {
       [output_shape addObject:apparent_output_shape[i]];
     }
   }
 }
 
-void reduction_out_mps
-   (const Tensor& input_tensor,
-    OptionalIntArrayRef opt_dim,
-    bool keepdim,
-    c10::optional<ScalarType> dtype,
-    const Tensor& output_t,
-    MPSReductionType reduction_type,
-    const std::string& func_name) {
+void reduction_out_mps(const Tensor& input_tensor,
+                       OptionalIntArrayRef opt_dim,
+                       bool keepdim,
+                       c10::optional<ScalarType> dtype,
+                       const Tensor& output_t,
+                       MPSReductionType reduction_type,
+                       const std::string& func_name) {
 
   auto input_t = (input_tensor.sizes().size() == 0) ? input_tensor.view({1}) : input_tensor;
 
@@ -154,14 +142,12 @@ void reduction_out_mps
 
   if (opt_dim.has_value()) {
     IntArrayRef dim = opt_dim.value();
-    for(int i = 0; i < dim.size(); i++) {
-      auto wrap_dim = maybe_wrap_dim(dim[i], input_shape.size());
+    for (const auto dim_val : dim) {
+      auto wrap_dim = maybe_wrap_dim(dim_val, input_shape.size());
       TORCH_CHECK(wrap_dim < input_shape.size(),
       func_name+": reduction dim must be in the range of input shape")
     }
   }
-
-  namespace native_mps = at::native::mps;
 
   NSMutableArray<NSNumber*> *axes = nil;
   NSMutableArray<NSNumber*> *apparent_input_shape = nil;
@@ -170,7 +156,7 @@ void reduction_out_mps
 
   set_axes_and_shapes(input_t, opt_dim, axes, apparent_input_shape, apparent_output_shape, output_shape);
 
-   auto cache_ = native_mps::MPSGraphCache::getInstance();
+   auto cache_ = MPSGraphCache::getInstance();
 
   if (output_t.numel() == 0 || input_t.numel() == 0) {
     return;
@@ -182,45 +168,46 @@ void reduction_out_mps
 
     // TODO: Make this key proper
     NSString* ns_key = [[axes valueForKey:@"description"] componentsJoinedByString:@","];
-    string key =  func_name+":" + string([ns_key UTF8String]) + ":" + native_mps::getMPSTypeString(input_t.scalar_type()) + ":" + native_mps::getMPSTypeString(output_t.scalar_type());
-    using CachedGraph = native_mps::MPSUnaryCachedGraph;
+    auto key =  func_name+":" + string([ns_key UTF8String]) + ":" + getMPSTypeString(input_t.scalar_type()) + ":" + getMPSTypeString(output_t.scalar_type());
+    using CachedGraph = MPSUnaryCachedGraph;
     auto cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
-    if(!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
 
         CachedGraph *newCachedGraph = nil;
 
         @autoreleasepool {
-          MPSGraph* mpsGraph = native_mps::make_mps_graph();
+          MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor* inputTensor = native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(input_t.scalar_type()));
+          MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input_t.scalar_type()));
 
           MPSGraphTensor* castInputTensor = nil;
 
-          if(input_t.scalar_type() != ScalarType::Float && input_t.scalar_type() != ScalarType::Int)
+          if (input_t.scalar_type() != ScalarType::Float && input_t.scalar_type() != ScalarType::Int) {
             castInputTensor =  [mpsGraph castTensor:inputTensor
                                              toType:MPSDataTypeFloat32
                                                name:@"castInputTensor"];
-          else
+          } else {
             castInputTensor = inputTensor;
+          }
 
           MPSGraphTensor* castOutputTensor = nil;
 
-          if(reduction_type == MPSReductionType::SUM) {
+          if (reduction_type == MPSReductionType::SUM) {
             castOutputTensor = [mpsGraph reductionSumWithTensor:castInputTensor
                                                            axes:axes
                                                            name:nil];
-          } else if(reduction_type == MPSReductionType::PROD) {
+          } else if (reduction_type == MPSReductionType::PROD) {
             castOutputTensor = [mpsGraph reductionProductWithTensor:castInputTensor
                                                                axes:axes
                                                                name:nil];
-          } else if(reduction_type == MPSReductionType::MEAN) {
+          } else if (reduction_type == MPSReductionType::MEAN) {
             castOutputTensor = [mpsGraph meanOfTensor:inputTensor
                                                  axes:axes
                                                  name:nil];
-          } else if(reduction_type == MPSReductionType::COUNT_NONZERO) {
+          } else if (reduction_type == MPSReductionType::COUNT_NONZERO) {
             MPSGraphTensor* zeros = [mpsGraph constantWithScalar:0
                                                         dataType:castInputTensor.dataType];
 
@@ -231,16 +218,15 @@ void reduction_out_mps
             castOutputTensor = [mpsGraph reductionSumWithTensor:nonZeros
                                                            axes:axes
                                                            name:nil];
-          }
-          else if(reduction_type == MPSReductionType::AMAX) {
+          } else if (reduction_type == MPSReductionType::AMAX) {
             castOutputTensor = [mpsGraph reductionMaximumWithTensor:inputTensor
                                                                axes:axes
                                                                name:nil];
-          } else if(reduction_type == MPSReductionType::AMIN) {
+          } else if (reduction_type == MPSReductionType::AMIN) {
             castOutputTensor = [mpsGraph reductionMinimumWithTensor:inputTensor
                                                                axes:axes
                                                                name:nil];
-          } else if(reduction_type == MPSReductionType::TRACE) {
+          } else if (reduction_type == MPSReductionType::TRACE) {
             MPSGraphTensor *bandPartWithTensor = [mpsGraph bandPartWithTensor:inputTensor
                                                                      numLower:0
                                                                      numUpper:0
@@ -252,12 +238,13 @@ void reduction_out_mps
 
           MPSGraphTensor* outputTensor = nil;
 
-          if(output_t.scalar_type() != ScalarType::Float)
+          if (output_t.scalar_type() != ScalarType::Float) {
             outputTensor = [mpsGraph castTensor:castOutputTensor
-                                         toType:(native_mps::getMPSDataType(output_t.scalar_type()))
+                                         toType:getMPSDataType(output_t.scalar_type())
                                            name:@"outputTensor"];
-          else
+          } else {
             outputTensor = castOutputTensor;
+          }
 
           newCachedGraph->inputTensor_ = inputTensor;
           newCachedGraph->outputTensor_ = outputTensor;
@@ -266,14 +253,14 @@ void reduction_out_mps
       });
     }
 
-    auto inputPlaceholder = native_mps::Placeholder();
+    auto inputPlaceholder = Placeholder();
 
     if (apparent_input_shape) {
-      inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t, apparent_input_shape);
+      inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, apparent_input_shape);
     } else {
-      inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
+      inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     }
-    auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t, apparent_output_shape);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_output_shape);
     NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
       inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
     };
@@ -281,7 +268,7 @@ void reduction_out_mps
     NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
-    native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
 
 }
@@ -298,18 +285,18 @@ TORCH_IMPL_FUNC(sum_out_mps)
 
 Tensor trace_mps_out(const Tensor& self) {
 
-    Tensor output_t = at::native::empty_mps(
-                      {},
-                      self.scalar_type(),
-                      c10::nullopt,
-                      kMPS,
-                      c10::nullopt,
-                      c10::nullopt);
+  Tensor output_t = at::native::empty_mps(
+                    {},
+                    self.scalar_type(),
+                    c10::nullopt,
+                    kMPS,
+                    c10::nullopt,
+                    c10::nullopt);
 
-    std::vector<int64_t> dims(self.dim());
-    std::iota(dims.begin(), dims.end(), 0);
+  std::vector<int64_t> dims(self.dim());
+  std::iota(dims.begin(), dims.end(), 0);
 
-    reduction_out_mps(self, IntArrayRef(dims), false, c10::nullopt, const_cast<Tensor&>(output_t), MPSReductionType::TRACE, "trace_mps_out");
+  reduction_out_mps(self, IntArrayRef(dims), false, c10::nullopt, const_cast<Tensor&>(output_t), MPSReductionType::TRACE, "trace_mps_out");
 
   return output_t;
 
@@ -329,10 +316,9 @@ TORCH_IMPL_FUNC(prod_out_mps)
 }
 
 // Taken from ReduceOps.cpp
-inline ScalarType get_dtype_from_self(
-    const Tensor& self,
-    const c10::optional<ScalarType>& dtype,
-    bool promote_integers) {
+inline ScalarType get_dtype_from_self(const Tensor& self,
+                                      const c10::optional<ScalarType>& dtype,
+                                      bool promote_integers) {
   if (dtype.has_value()) {
     return dtype.value();
   }
@@ -380,7 +366,7 @@ Tensor prod_mps(const Tensor &self, c10::optional<ScalarType> opt_dtype) {
 }
 
 
-Tensor count_nonzero_mps(const Tensor& self, IntArrayRef dims){
+Tensor count_nonzero_mps(const Tensor& self, IntArrayRef dims) {
   NSMutableArray<NSNumber*> *axes = nil;
   NSMutableArray<NSNumber*> *apparent_input_shape = nil;
   NSMutableArray<NSNumber*> *apparent_output_shape = nil;
@@ -389,7 +375,7 @@ Tensor count_nonzero_mps(const Tensor& self, IntArrayRef dims){
   set_axes_and_shapes(self, dims, axes, apparent_input_shape, apparent_output_shape, output_shape);
 
   std::vector<int64_t> raw_output_shape([output_shape count]);
-  for(auto i: c10::irange(raw_output_shape.size())) {
+  for (const auto i: c10::irange(raw_output_shape.size())) {
     raw_output_shape[i] = [output_shape[i] longValue];
   }
 
@@ -412,34 +398,29 @@ TORCH_IMPL_FUNC(mean_out_mps)
     bool keepdim,
     c10::optional<ScalarType> dtype,
     const Tensor& output_t) {
-
-    reduction_out_mps(input_t, opt_dim, keepdim, dtype, output_t, MPSReductionType::MEAN, "mean_out_mps");
+  reduction_out_mps(input_t, opt_dim, keepdim, dtype, output_t, MPSReductionType::MEAN, "mean_out_mps");
 }
 
 TORCH_IMPL_FUNC(norm_out_mps)
-(const Tensor& input_tensor,
- const OptionalScalarRef opt_p,
- IntArrayRef dim,
- bool keepdim,
- const Tensor& output_t)
-{
-  if (input_tensor.numel() == 0)
+    (const Tensor& input_tensor,
+     const OptionalScalarRef opt_p,
+     IntArrayRef dim,
+     bool keepdim,
+     const Tensor& output_t) {
+  if (input_tensor.numel() == 0) {
     return;
+  }
 
   auto input_t = (input_tensor.sizes().size() == 0) ? input_tensor.view({1}) : input_tensor;
 
   IntArrayRef input_shape = input_t.sizes();
 
-  for(int i = 0; i < dim.size(); i++) {
-    auto wrap_dim = maybe_wrap_dim(dim[i], input_shape.size());
-    TORCH_CHECK(wrap_dim < input_shape.size(),
-    "norm_out_mps: reduction dim must be in the range of input shape")
+  for (const auto dim_val: dim) {
+    auto wrap_dim = maybe_wrap_dim(dim_val, input_shape.size());
+    TORCH_CHECK(wrap_dim < input_shape.size(), "norm_out_mps: reduction dim must be in the range of input shape")
   }
-  namespace native_mps = at::native::mps;
 
-  using CachedGraph = native_mps::MPSUnaryCachedGraph;
-
-  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
+  auto cache_ = MPSGraphCache::getInstance();
 
   auto p = opt_p.has_value() ? opt_p.get().to<double>() : Scalar(2.0).to<double>();
   auto reciprocal_p = 1 / p;
@@ -463,7 +444,6 @@ TORCH_IMPL_FUNC(norm_out_mps)
   set_apparent_shapes(apparent_output_shape,
                       apparent_input_shape,
                       num_reduce_dims,
-                      num_input_dims,
                       num_output_dims,
                       input_shape,
                       axes);
@@ -476,62 +456,55 @@ TORCH_IMPL_FUNC(norm_out_mps)
   @autoreleasepool {
     NSString* ns_key = [[axes valueForKey:@"description"] componentsJoinedByString:@","];
       string keepdim_info = (keepdim) ? "keepdim=1" : "keepdim=0";
-      string key =  string("norm_out_mps:") + [ns_key UTF8String] + ":" + native_mps::getMPSTypeString(input_t.scalar_type()) + ":p" + to_string(p) + ":" + keepdim_info;
+      string key =  string("norm_out_mps:") + [ns_key UTF8String] + ":" + getMPSTypeString(input_t.scalar_type()) + ":p" + to_string(p) + ":" + keepdim_info;
 
-    auto cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+    auto cachedGraph = cache_->LookUpAs<MPSUnaryCachedGraph>(key);
 
-    if(!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<MPSUnaryCachedGraph>(key, ^ MPSCachedGraph * () {
 
-        CachedGraph *newCachedGraph = nil;
+        MPSUnaryCachedGraph *newCachedGraph = nil;
 
         @autoreleasepool {
-          MPSGraph* mpsGraph = native_mps::make_mps_graph();
-          newCachedGraph = new CachedGraph(mpsGraph);
+          MPSGraph* mpsGraph = make_mps_graph();
+          newCachedGraph = new MPSUnaryCachedGraph(mpsGraph);
 
-          MPSGraphTensor* inputTensor = native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(input_t.scalar_type()));
+          MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input_t.scalar_type()));
 
-          MPSGraphTensor *outputTensor;
+          MPSGraphTensor *outputTensor = nil;
 
-          if (pIsZero)
-          {
+          if (pIsZero) {
               MPSGraphTensor *absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor
                                                                        name:nil];
               MPSGraphTensor *powerValTensor = [mpsGraph constantWithScalar:p
-                                                                   dataType:native_mps::getMPSDataType(input_t.scalar_type())];
+                                                                   dataType:getMPSDataType(input_t.scalar_type())];
               MPSGraphTensor *powerTensor = [mpsGraph powerWithPrimaryTensor:absoluteTensor
                                                              secondaryTensor:powerValTensor
                                                                         name:nil];
               outputTensor = [mpsGraph reductionSumWithTensor:powerTensor
                                                          axes:axes
                                                          name:nil];
-          }
-          else if (pIsPosInf)
-          {
+          } else if (pIsPosInf) {
               MPSGraphTensor *absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor
                                                                        name:nil];
               outputTensor = [mpsGraph reductionMaximumWithTensor:absoluteTensor
                                                              axes:axes
                                                              name:nil];
-          }
-          else if (pIsNegInf)
-          {
+          } else if (pIsNegInf) {
               MPSGraphTensor *absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor
                                                                        name:nil];
               outputTensor = [mpsGraph reductionMinimumWithTensor:absoluteTensor
                                                              axes:axes
                                                              name:nil];
-          }
-          else
-          {
+          } else {
               MPSGraphTensor *absoluteTensor = [mpsGraph absoluteWithTensor:inputTensor
                                                                        name:nil];
 
               MPSGraphTensor *powerValTensor = [mpsGraph constantWithScalar:p
-                                                                   dataType:native_mps::getMPSDataType(input_t.scalar_type())];
+                                                                   dataType:getMPSDataType(input_t.scalar_type())];
 
               MPSGraphTensor *reciprocalPowerValTensor = [mpsGraph constantWithScalar:reciprocal_p
-                                                                             dataType:native_mps::getMPSDataType(input_t.scalar_type())];
+                                                                             dataType:getMPSDataType(input_t.scalar_type())];
 
               MPSGraphTensor *powerTensor = [mpsGraph powerWithPrimaryTensor:absoluteTensor
                                                              secondaryTensor:powerValTensor
@@ -553,14 +526,15 @@ TORCH_IMPL_FUNC(norm_out_mps)
       });
     }
 
-    auto inputPlaceholder = native_mps::Placeholder();
+    auto inputPlaceholder = Placeholder();
 
-    if(apparent_input_shape)
-      inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t, apparent_input_shape);
-    else
-      inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
+    if (apparent_input_shape) {
+      inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, apparent_input_shape);
+    } else {
+      inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
+    }
 
-    auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t, apparent_output_shape);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_output_shape);
 
 
     NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
@@ -571,20 +545,17 @@ TORCH_IMPL_FUNC(norm_out_mps)
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
 
   }
 }
 
-Tensor std_var_common_impl_mps(
-  const Tensor & input_t,
-  at::OptionalIntArrayRef dim,
-  c10::optional<int64_t> correction,
-  bool keepdim,
-  StdVarType stdVarType)
-{
-  namespace native_mps = at::native::mps;
-  using CachedGraph = native_mps::MPSUnaryCachedGraph;
+Tensor std_var_common_impl_mps(const Tensor & input_t,
+                               at::OptionalIntArrayRef dim,
+                               c10::optional<int64_t> correction,
+                               bool keepdim,
+                               StdVarType stdVarType) {
+  using CachedGraph = MPSUnaryCachedGraph;
 
   IntArrayRef input_shape = input_t.sizes();
   int64_t num_input_dims = input_shape.size();
@@ -592,20 +563,19 @@ Tensor std_var_common_impl_mps(
   bool use_dim = dim.has_value();
   IntArrayRef dim_value = use_dim ? dim.value() : NULL;
 
-  if (use_dim)
-  {
-      string errMessage = (stdVarType == STANDARD_DEVIATION) ? "std_mps" : "var_mps";
-      errMessage += ": reduction dim must be in the range of input shape";
-      for(int i = 0; i < dim_value.size(); i++) {
-        auto wrap_dim = maybe_wrap_dim(dim_value[i], input_shape.size());
-        TORCH_CHECK(wrap_dim < input_shape.size(), errMessage.c_str())
+  if (use_dim) {
+    string errMessage = (stdVarType == STANDARD_DEVIATION) ? "std_mps" : "var_mps";
+    errMessage += ": reduction dim must be in the range of input shape";
+    for (const auto dim : dim_value) {
+      auto wrap_dim = maybe_wrap_dim(dim, input_shape.size());
+      TORCH_CHECK(wrap_dim < input_shape.size(), errMessage.c_str())
     }
   }
 
   const auto correction_value = correction.has_value() ? correction.value() : 1;
   int64_t correction_n = 1;
 
-  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
   int64_t num_output_dims = 0;
   NSMutableArray<NSNumber *> *axes = nil;
@@ -613,118 +583,100 @@ Tensor std_var_common_impl_mps(
   NSMutableArray<NSNumber*> *apparent_input_shape = nil;
   std::vector<int64_t> output_shape;
 
-  if ((!keepdim && !use_dim) || (!keepdim && use_dim && dim_value.size() <= 0))
-  {
-      // Flatten the input tensor to reduce it to one value
-      apparent_input_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-      int64_t num_in_elements = 1;
-      for(int i = 0; i < num_input_dims; i++) {
-          num_in_elements *= input_shape[i];
+  if ((!keepdim && !use_dim) || (!keepdim && use_dim && dim_value.size() <= 0)) {
+    // Flatten the input tensor to reduce it to one value
+    apparent_input_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
+    int64_t num_in_elements = c10::multiply_integers(input_shape);
+    apparent_input_shape[0] = [NSNumber numberWithInt:num_in_elements];
+
+    // Output is a single value
+    apparent_output_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
+    apparent_output_shape[0] = @1;
+
+    num_output_dims = 0;
+
+    correction_n = num_in_elements;
+
+    // Reduction axes
+    axes = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
+    axes[0] = @0;
+  } else if (!keepdim && use_dim && dim_value.size() > 0) {
+    int64_t num_reduce_dims = dim_value.size();
+    num_output_dims = num_input_dims;
+
+    set_axes(axes, num_reduce_dims, dim_value, num_input_dims);
+    set_apparent_shapes(apparent_output_shape,
+                         apparent_input_shape,
+                         num_reduce_dims,
+                         num_output_dims,
+                         input_shape,
+                         axes);
+
+    num_output_dims = (num_input_dims >= num_reduce_dims) ? (num_input_dims - num_reduce_dims) : 0; //num_input_dims;
+
+    unsigned int curr_i = 0;
+    for (const auto i: c10::irange(num_input_dims)) {
+      bool found = false;
+      for (const auto j : c10::irange(num_reduce_dims)) {
+        if (i == dim_value[j]) {
+          found = true;
+          break;
+        }
       }
-      apparent_input_shape[0] = [NSNumber numberWithInt:num_in_elements];
-
-      // Output is a single value
-      apparent_output_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-      apparent_output_shape[0] = @1;
-
-      num_output_dims = 0;
-
-      correction_n = num_in_elements;
-
-        // Reduction axes
-      axes = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-      axes[0] = @0;
-
-  }
-  else if (!keepdim && use_dim && dim_value.size() > 0)
-  {
-      int64_t num_reduce_dims = dim_value.size();
-      num_output_dims = num_input_dims;
-
-      set_axes(axes, num_reduce_dims, dim_value, num_input_dims);
-      set_apparent_shapes(apparent_output_shape,
-                           apparent_input_shape,
-                           num_reduce_dims,
-                           num_input_dims,
-                           num_output_dims,
-                           input_shape,
-                           axes);
-
-      num_output_dims = (num_input_dims >= num_reduce_dims) ? (num_input_dims - num_reduce_dims) : 0; //num_input_dims;
-
-      unsigned int curr_i = 0;
-      for (int i = 0; i < num_input_dims; i++)
-      {
-          bool found = false;
-          for (int j = 0; j < num_reduce_dims; j++)
-          {
-              if (i == dim_value[j])
-              {
-                  found = true;
-                  break;
-              }
-          }
-          if (found) continue;
-          output_shape.push_back(input_shape[i]);
-          curr_i += 1;
-          // End loop when output shape is filled
-          if (curr_i == num_output_dims)
-            break;
+      if (found) {
+        continue;
       }
-
-      for(int i = 0; i < num_reduce_dims; i++)
-      {
-          auto wrap_dim = maybe_wrap_dim(dim_value[i], input_shape.size());
-          correction_n *= input_shape[wrap_dim];
+      output_shape.push_back(input_shape[i]);
+      curr_i += 1;
+      // End loop when output shape is filled
+      if (curr_i == num_output_dims) {
+        break;
       }
-      // (3, 4, 5) --> (3, 5)
-  }
-  else if ((keepdim && !use_dim) || (keepdim && use_dim && dim_value.size() <= 0))
-  {
-      num_output_dims = 0;
-      int64_t num_reduce_dims = 0;
-      set_axes(axes, num_reduce_dims, dim_value, input_shape.size());
-      set_apparent_shapes(apparent_output_shape,
-                          apparent_input_shape,
-                           num_reduce_dims,
-                           num_input_dims,
-                           num_output_dims,
-                           input_shape,
-                           axes);
-      num_output_dims = num_input_dims;
-      for (int i = 0; i < num_input_dims; i++)
-      {
-          output_shape.push_back((int64_t) 1);
-          correction_n *= input_shape[i];
-      }
-      // scalar --> vector case [[1.0034567]]
-  }
-  else if (keepdim && use_dim && dim_value.size() > 0)
-  {
-      int64_t num_reduce_dims = dim_value.size();
-      num_output_dims = num_input_dims;
+    }
 
-      set_axes(axes, num_reduce_dims, dim_value, num_input_dims);
-      set_apparent_shapes(apparent_output_shape,
-                           apparent_input_shape,
-                           num_reduce_dims,
-                           num_input_dims,
-                           num_output_dims,
-                           input_shape,
-                           axes);
+    for (const auto dim : dim_value) {
+      auto wrap_dim = maybe_wrap_dim(dim, input_shape.size());
+      correction_n *= input_shape[wrap_dim];
+    }
+    // (3, 4, 5) --> (3, 5)
+  } else if ((keepdim && !use_dim) || (keepdim && use_dim && dim_value.size() <= 0)) {
+    num_output_dims = 0;
+    int64_t num_reduce_dims = 0;
+    set_axes(axes, num_reduce_dims, dim_value, input_shape.size());
+    set_apparent_shapes(apparent_output_shape,
+                        apparent_input_shape,
+                        num_reduce_dims,
+                        num_output_dims,
+                        input_shape,
+                        axes);
+    num_output_dims = num_input_dims;
+    for (const auto i: c10::irange(num_input_dims)) {
+      output_shape.push_back((int64_t) 1);
+      correction_n *= input_shape[i];
+    }
+    // scalar --> vector case [[1.0034567]]
+  } else if (keepdim && use_dim && dim_value.size() > 0) {
+    int64_t num_reduce_dims = dim_value.size();
+    num_output_dims = num_input_dims;
 
-      num_output_dims = num_input_dims;//(num_input_dims >= num_reduce_dims) ? (num_input_dims - num_reduce_dims) : 0;
+    set_axes(axes, num_reduce_dims, dim_value, num_input_dims);
+    set_apparent_shapes(apparent_output_shape,
+                        apparent_input_shape,
+                        num_reduce_dims,
+                        num_output_dims,
+                        input_shape,
+                        axes);
 
-      for(int i = 0; i < num_reduce_dims; i++)
-      {
-          auto wrap_dim = maybe_wrap_dim(dim_value[i], input_shape.size());
-          correction_n *= input_shape[wrap_dim];
-      }
+    num_output_dims = num_input_dims;//(num_input_dims >= num_reduce_dims) ? (num_input_dims - num_reduce_dims) : 0;
 
-      for (int i = 0; i < num_input_dims; i++)
-      {
-          output_shape.push_back([apparent_output_shape[i] longValue]);
-      }
+    for (int i = 0; i < num_reduce_dims; i++) {
+      auto wrap_dim = maybe_wrap_dim(dim_value[i], input_shape.size());
+      correction_n *= input_shape[wrap_dim];
+    }
+
+    for (int i = 0; i < num_input_dims; i++) {
+      output_shape.push_back([apparent_output_shape[i] longValue]);
+    }
   }
 
 
@@ -736,9 +688,8 @@ Tensor std_var_common_impl_mps(
                       c10::nullopt,
                       c10::nullopt);
 
-  if (output_t.numel() == 0 || input_t.numel() == 0)
-  {
-     return output_t;
+  if (output_t.numel() == 0 || input_t.numel() == 0) {
+    return output_t;
   }
 
   double bessel_correction = static_cast<double>(correction_n) / static_cast<double>(correction_n - correction_value);
@@ -751,67 +702,59 @@ Tensor std_var_common_impl_mps(
     string bessel_corrected = "correction_value=" + to_string(correction_value);
     string use_dim_info = (use_dim) ? "use_dim=1:" + to_string(dim_value.size()) : "use_dim=0";
     string keepdim_info = (keepdim) ? "keepdim=1" : "keepdim=0";
-    string key = op_key + use_dim_info + ":" + keepdim_info + ":" + string([ns_key UTF8String]) + ":" + native_mps::getTensorsStringKey(input_t) + ":" + bessel_corrected;
+    string key = op_key + use_dim_info + ":" + keepdim_info + ":" + string([ns_key UTF8String]) + ":" + getTensorsStringKey(input_t) + ":" + bessel_corrected;
 
     auto cachedGraph = cache_->LookUpAs<CachedGraph>(key);
     // Initialize once if configuration not found in cache
-  if(!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
+        CachedGraph *newCachedGraph = nil;
 
-      CachedGraph *newCachedGraph = nil;
-
-      @autoreleasepool {
-          MPSGraph* mpsGraph = native_mps::make_mps_graph();
+        @autoreleasepool {
+          MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor *inputTensor = native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(input_t.scalar_type()));
+          MPSGraphTensor *inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input_t.scalar_type()));
           MPSGraphTensor *outputVarTensor = [mpsGraph varianceOfTensor:inputTensor
-                                                                     axes:axes
-                                                                     name:nil];
+                                                                  axes:axes
+                                                                  name:nil];
           MPSGraphTensor *outputTensor;
 
-          if (correction_value)
-          {
-              MPSGraphTensor *besselTensor= [mpsGraph constantWithScalar:bessel_correction
-                                                    dataType:MPSDataTypeFloat32];
+          if (correction_value) {
+              MPSGraphTensor *besselTensor= [mpsGraph constantWithScalar: bessel_correction
+                                                                dataType: MPSDataTypeFloat32];
               MPSGraphTensor *correctedTensor = [mpsGraph multiplicationWithPrimaryTensor: outputVarTensor
                                                                           secondaryTensor: besselTensor
                                                                                      name: nil];
               outputTensor = (stdVarType == STANDARD_DEVIATION) ?
                     [mpsGraph squareRootWithTensor:correctedTensor name:nil] : correctedTensor;
-          }
-          else
-          {
+          } else {
               outputTensor = (stdVarType == STANDARD_DEVIATION) ?
                     [mpsGraph squareRootWithTensor:outputVarTensor name:nil] : outputVarTensor;
           }
           newCachedGraph->inputTensor_ = inputTensor;
           newCachedGraph->outputTensor_ = outputTensor;
-
-      }
-      return newCachedGraph;
+        }
+        return newCachedGraph;
       });
-  }
-  auto inputPlaceholder = native_mps::Placeholder();
+    }
+    auto inputPlaceholder = Placeholder();
 
-  if(apparent_input_shape)
-  {
-    inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t, apparent_input_shape);
-  }
-  else
-  {
-    inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
-  }
-  auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t, apparent_output_shape);
+    if (apparent_input_shape) {
+      inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, apparent_input_shape);
+    } else {
+      inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
+    }
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_output_shape);
 
-  NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
-      inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
-  };
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
+        inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
+    };
 
-  NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
-      outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
-  };
-  native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
+        outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
+    };
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
 
   return output_t;
@@ -841,53 +784,47 @@ TORCH_IMPL_FUNC(any_out_mps)
    bool keepdim,
    const Tensor& output_t)
 {
-    namespace native_mps = at::native::mps;
-    using CachedGraph = native_mps::MPSUnaryCachedGraph;
+  using CachedGraph = MPSUnaryCachedGraph;
 
-    if (output_t.numel() == 0 || input_t.numel() == 0) {
-      return;
-    }
+  if (output_t.numel() == 0 || input_t.numel() == 0) {
+    return;
+  }
 
-    native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
-    int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
-    native::zero_numel_check_dims(input_t, dim_, "any()");
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
+  int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+  native::zero_numel_check_dims(input_t, dim_, "any()");
 
-    // Calculate the output shape according to keepdim=True
-    // If there is no dim argument, the input shape is flattened
-    IntArrayRef input_shape = input_t.sizes();
-    int64_t num_input_dims = input_shape.size();
-    NSMutableArray<NSNumber*> *apparent_out_shape = nil;
-    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-    for(int i = 0; i < num_input_dims; i++) {
-        if(dim_ == i)
-            apparent_out_shape[i] = @1;
-        else
-            apparent_out_shape[i] = [NSNumber numberWithInt:input_shape[i]];
-    }
+  // Calculate the output shape according to keepdim=True
+  // If there is no dim argument, the input shape is flattened
+  IntArrayRef input_shape = input_t.sizes();
+  int64_t num_input_dims = input_shape.size();
+  NSMutableArray<NSNumber*> *apparent_out_shape = nil;
+  apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+  for (const auto i: c10::irange(num_input_dims)) {
+    apparent_out_shape[i] = dim_ == i ? @1 : [NSNumber numberWithInt:input_shape[i]];
+  }
 
-    auto stream = at::mps::getCurrentMPSStream();
+  auto stream = at::mps::getCurrentMPSStream();
 
-    @autoreleasepool {
-        MPSShape* input_t_shape = native_mps::getMPSShape(input_t);
-        string key = string("any_out_mps:") + native_mps::getMPSShapeString(input_t_shape) + ":" + to_string(dim_) + ":" + native_mps::getMPSTypeString(input_t.scalar_type());
-        CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+  @autoreleasepool {
+    MPSShape* input_t_shape = getMPSShape(input_t);
+    string key = string("any_out_mps:") + getMPSShapeString(input_t_shape) + ":" + to_string(dim_) + ":" + getMPSTypeString(input_t.scalar_type());
+    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
-        if(!cachedGraph) {
-          cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
+        CachedGraph *newCachedGraph = nil;
+        @autoreleasepool {
+          MPSGraph* mpsGraph = make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
 
-            CachedGraph *newCachedGraph = nil;
-            @autoreleasepool {
-              MPSGraph* mpsGraph = native_mps::make_mps_graph();
-              newCachedGraph = new CachedGraph(mpsGraph);
+          MPSGraphTensor* outputTensor;
+          MPSDataType input_type = getMPSDataType(input_t.scalar_type());
+          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
 
-                MPSGraphTensor* outputTensor;
-                MPSDataType input_type = native_mps::getMPSDataType(input_t.scalar_type());
-                MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
-
-                if (input_type != MPSDataTypeInt32 &&
-                    input_type != MPSDataTypeFloat32 &&
-                    input_type != MPSDataTypeFloat16 )
-                {
+          if (input_type != MPSDataTypeInt32 &&
+              input_type != MPSDataTypeFloat32 &&
+              input_type != MPSDataTypeFloat16 ) {
                     MPSGraphTensor* inputCastedTensor = [mpsGraph castTensor:inputTensor
                                                                       toType:MPSDataTypeInt32
                                                                         name:@"any_all"];
@@ -897,72 +834,67 @@ TORCH_IMPL_FUNC(any_out_mps)
                     outputTensor = [mpsGraph castTensor:outputCastedTensor
                                                  toType:MPSDataTypeBool
                                                    name:@"any"];
-                }
-                else
-                {
+          } else {
                     MPSGraphTensor* outputUncastedTensor = [mpsGraph reductionOrWithTensor:inputTensor
                                                                                        axis:dim_
                                                                                        name:nil];
                     outputTensor = [mpsGraph castTensor:outputUncastedTensor
                                                  toType:MPSDataTypeBool
                                                    name:@"any"];
-                }
-                newCachedGraph->inputTensor_ = inputTensor;
-                newCachedGraph->outputTensor_ = outputTensor;
-
-            }
-            return newCachedGraph;
-          });
+          }
+          newCachedGraph->inputTensor_ = inputTensor;
+          newCachedGraph->outputTensor_ = outputTensor;
         }
+        return newCachedGraph;
+      });
+    }
 
-        auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
-        auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
-          inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
-        };
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
+      inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
+    };
 
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
-          outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
-        };
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
+      outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
+    };
 
-        native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
-}
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+  }
 }
 
 TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t)
 {
-    namespace native_mps = at::native::mps;
-    using CachedGraph = native_mps::MPSUnaryCachedGraph;
+    using CachedGraph = MPSUnaryCachedGraph;
     if (output_t.numel() == 0 || input_t.numel() == 0) {
       return;
     }
 
-    auto cache_ = native_mps::MPSGraphCache::getInstance();
+    auto cache_ = MPSGraphCache::getInstance();
 
     auto stream = at::mps::getCurrentMPSStream();
 
     @autoreleasepool {
-        MPSShape* input_t_shape = native_mps::getMPSShape(input_t);
-        string key = string("any_all_out_mps:") + native_mps::getMPSShapeString(input_t_shape) +":" + native_mps::getMPSTypeString(input_t.scalar_type());
+        MPSShape* input_t_shape = getMPSShape(input_t);
+        string key = string("any_all_out_mps:") + getMPSShapeString(input_t_shape) +":" + getMPSTypeString(input_t.scalar_type());
         CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
-        if(!cachedGraph) {
-          cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
+        if (!cachedGraph) {
+          cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
 
             CachedGraph *newCachedGraph = nil;
 
             @autoreleasepool {
-              MPSGraph* mpsGraph = native_mps::make_mps_graph();
+              MPSGraph* mpsGraph = make_mps_graph();
               newCachedGraph = new CachedGraph(mpsGraph);
 
               MPSGraphTensor* outputTensor;
-              MPSDataType input_type = native_mps::getMPSDataType(input_t.scalar_type());
-              MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
+              MPSDataType input_type = getMPSDataType(input_t.scalar_type());
+              MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
 
               if (input_type != MPSDataTypeInt32 &&
                   input_type != MPSDataTypeFloat32 &&
-                  input_type != MPSDataTypeFloat16 )
-              {
+                  input_type != MPSDataTypeFloat16 ) {
                   MPSGraphTensor* inputCastedTensor = [mpsGraph castTensor:inputTensor
                                                                     toType:MPSDataTypeInt32
                                                                       name:@"any_all"];
@@ -972,9 +904,7 @@ TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t)
                   outputTensor = [mpsGraph castTensor:outputCastedTensor
                                                toType:MPSDataTypeBool
                                                  name:@"any_all"];
-              }
-              else
-              {
+              } else {
                   MPSGraphTensor* outputUncastedTensor = [mpsGraph reductionOrWithTensor:inputTensor
                                                                                      axes:nil
                                                                                      name:nil];
@@ -990,8 +920,8 @@ TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t)
           });
         }
 
-        auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
-        auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t);
+        auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
+        auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t);
         NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
           inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
         };
@@ -1000,201 +930,175 @@ TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t)
           outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
         };
 
-        native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+        runMPSGraph(stream, cachedGraph->graph(), feeds, results);
     }
 }
 
-TORCH_IMPL_FUNC(all_out_mps)
-  (const Tensor& input_t,
-   int64_t dim,
-   bool keepdim,
-   const Tensor& output_t)
-{
-    namespace native_mps = at::native::mps;
-    using CachedGraph = native_mps::MPSUnaryCachedGraph;
+TORCH_IMPL_FUNC(all_out_mps)(const Tensor& input_t,
+                             int64_t dim,
+                             bool keepdim,
+                             const Tensor& output_t) {
+  using CachedGraph = MPSUnaryCachedGraph;
 
-    if (output_t.numel() == 0 || input_t.numel() == 0) {
-      return;
-    }
+  if (output_t.numel() == 0 || input_t.numel() == 0) {
+    return;
+  }
 
-    native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
-    int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
-    native::zero_numel_check_dims(input_t, dim_, "all()");
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
+  int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+  native::zero_numel_check_dims(input_t, dim_, "all()");
 
-    // Calculate the output shape according to keepdim=True
-    // If there is no dim argument, the input shape is flattened
-    IntArrayRef input_shape = input_t.sizes();
-    int64_t num_input_dims = input_shape.size();
-    NSMutableArray<NSNumber*> *apparent_out_shape = nil;
-    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-    for(int i = 0; i < num_input_dims; i++) {
-        if(dim_ == i)
-            apparent_out_shape[i] = @1;
-        else
-            apparent_out_shape[i] = [NSNumber numberWithInt:input_shape[i]];
-    }
+  // Calculate the output shape according to keepdim=True
+  // If there is no dim argument, the input shape is flattened
+  IntArrayRef input_shape = input_t.sizes();
+  int64_t num_input_dims = input_shape.size();
+  NSMutableArray<NSNumber*> *apparent_out_shape = nil;
+  apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+  for (const auto i : c10::irange(num_input_dims)) {
+      apparent_out_shape[i] = dim_ == i ? @1 : [NSNumber numberWithInt:input_shape[i]];
+  }
 
-    auto stream = at::mps::getCurrentMPSStream();
+  auto stream = at::mps::getCurrentMPSStream();
 
-    @autoreleasepool {
-        MPSShape* input_t_shape = native_mps::getMPSShape(input_t);
-        string key = string("all_out_mps:") + native_mps::getMPSShapeString(input_t_shape) + ":" + to_string(dim_) + ":" + native_mps::getMPSTypeString(input_t.scalar_type());
-        CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+  @autoreleasepool {
+    MPSShape* input_t_shape = getMPSShape(input_t);
+    string key = string("all_out_mps:") + getMPSShapeString(input_t_shape) + ":" + to_string(dim_) + ":" + getMPSTypeString(input_t.scalar_type());
+    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
-        if(!cachedGraph) {
-          cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
+        CachedGraph *newCachedGraph = nil;
+        @autoreleasepool {
+          MPSGraph* mpsGraph = make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
 
-            CachedGraph *newCachedGraph = nil;
-            @autoreleasepool {
-              MPSGraph* mpsGraph = native_mps::make_mps_graph();
-              newCachedGraph = new CachedGraph(mpsGraph);
+          MPSGraphTensor* outputTensor;
+          MPSDataType input_type = getMPSDataType(input_t.scalar_type());
+          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
 
-                MPSGraphTensor* outputTensor;
-                MPSDataType input_type = native_mps::getMPSDataType(input_t.scalar_type());
-                MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
-
-                if (input_type != MPSDataTypeInt32 &&
-                    input_type != MPSDataTypeFloat32 &&
-                    input_type != MPSDataTypeFloat16 )
-                {
-                    MPSGraphTensor* inputCastedTensor = [mpsGraph castTensor:inputTensor
-                                                                      toType:MPSDataTypeInt32
-                                                                        name:@"all_all"];
-                    MPSGraphTensor* outputCastedTensor = [mpsGraph reductionAndWithTensor:inputCastedTensor
-                                                                                     axis:dim_
-                                                                                     name:nil];
-                    outputTensor = [mpsGraph castTensor:outputCastedTensor
-                                                 toType:MPSDataTypeBool
-                                                   name:@"all"];
-                }
-                else
-                {
-                    MPSGraphTensor* outputUncastedTensor = [mpsGraph reductionAndWithTensor:inputTensor
-                                                                                       axis:dim_
-                                                                                       name:nil];
-                    outputTensor = [mpsGraph castTensor:outputUncastedTensor
-                                                 toType:MPSDataTypeBool
-                                                   name:@"all"];
-                }
-                newCachedGraph->inputTensor_ = inputTensor;
-                newCachedGraph->outputTensor_ = outputTensor;
-
-            }
-            return newCachedGraph;
-          });
+          if (input_type != MPSDataTypeInt32 &&
+              input_type != MPSDataTypeFloat32 &&
+              input_type != MPSDataTypeFloat16 ) {
+              MPSGraphTensor* inputCastedTensor = [mpsGraph castTensor:inputTensor
+                                                                toType:MPSDataTypeInt32
+                                                                  name:@"all_all"];
+              MPSGraphTensor* outputCastedTensor = [mpsGraph reductionAndWithTensor:inputCastedTensor
+                                                                               axis:dim_
+                                                                                name:nil];
+              outputTensor = [mpsGraph castTensor:outputCastedTensor
+                                           toType:MPSDataTypeBool
+                                             name:@"all"];
+          } else {
+              MPSGraphTensor* outputUncastedTensor = [mpsGraph reductionAndWithTensor:inputTensor
+                                                                                 axis:dim_
+                                                                                 name:nil];
+              outputTensor = [mpsGraph castTensor:outputUncastedTensor
+                                           toType:MPSDataTypeBool
+                                             name:@"all"];
+          }
+          newCachedGraph->inputTensor_ = inputTensor;
+          newCachedGraph->outputTensor_ = outputTensor;
         }
+        return newCachedGraph;
+      });
+    }
 
-        auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
-        auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
-          inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
-        };
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
+      inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
+    };
 
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
-          outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
-        };
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
+      outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
+    };
 
-        native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
   }
 }
 
-TORCH_IMPL_FUNC(all_all_out_mps)(const Tensor& input_t, const Tensor& output_t)
-{
-    namespace native_mps = at::native::mps;
-    using CachedGraph = native_mps::MPSUnaryCachedGraph;
-    if (output_t.numel() == 0 || input_t.numel() == 0) {
-      return;
-    }
+TORCH_IMPL_FUNC(all_all_out_mps)(const Tensor& input_t, const Tensor& output_t) {
+  using CachedGraph = MPSUnaryCachedGraph;
+  if (output_t.numel() == 0 || input_t.numel() == 0) {
+    return;
+  }
 
-    native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
-    auto stream = at::mps::getCurrentMPSStream();
+  auto stream = at::mps::getCurrentMPSStream();
 
-    @autoreleasepool {
-        MPSShape* input_t_shape = native_mps::getMPSShape(input_t);
-        string key = string("all_all_out_mps:") + native_mps::getMPSShapeString(input_t_shape) +":" + native_mps::getMPSTypeString(input_t.scalar_type());
-        CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+  @autoreleasepool {
+    MPSShape* input_t_shape = getMPSShape(input_t);
+    string key = string("all_all_out_mps:") + getMPSShapeString(input_t_shape) +":" + getMPSTypeString(input_t.scalar_type());
+    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
-        if(!cachedGraph) {
-          cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
+        CachedGraph *newCachedGraph = nil;
+        @autoreleasepool {
+          MPSGraph* mpsGraph = make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
 
-            CachedGraph *newCachedGraph = nil;
+          MPSGraphTensor* outputTensor;
+          MPSDataType input_type = getMPSDataType(input_t.scalar_type());
+          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
 
-            @autoreleasepool {
-              MPSGraph* mpsGraph = native_mps::make_mps_graph();
-              newCachedGraph = new CachedGraph(mpsGraph);
+          if (input_type != MPSDataTypeInt32 &&
+              input_type != MPSDataTypeFloat32 &&
+              input_type != MPSDataTypeFloat16 ) {
+              MPSGraphTensor* inputCastedTensor = [mpsGraph castTensor:inputTensor
+                                                                toType:MPSDataTypeInt32
+                                                                  name:@"all_all"];
+              MPSGraphTensor* outputCastedTensor = [mpsGraph reductionAndWithTensor:inputCastedTensor
+                                                                               axes:nil
+                                                                               name:nil];
+              outputTensor = [mpsGraph castTensor:outputCastedTensor
+                                           toType:MPSDataTypeBool
+                                             name:@"all_all"];
+          } else {
+              MPSGraphTensor* outputUncastedTensor = [mpsGraph reductionAndWithTensor:inputTensor
+                                                                                 axes:nil
+                                                                                 name:nil];
+              outputTensor = [mpsGraph castTensor:outputUncastedTensor
+                                           toType:MPSDataTypeBool
+                                             name:@"all_all"];
+          }
+          newCachedGraph->inputTensor_ = inputTensor;
+          newCachedGraph->outputTensor_ = outputTensor;
 
-              MPSGraphTensor* outputTensor;
-              MPSDataType input_type = native_mps::getMPSDataType(input_t.scalar_type());
-              MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
-
-              if (input_type != MPSDataTypeInt32 &&
-                  input_type != MPSDataTypeFloat32 &&
-                  input_type != MPSDataTypeFloat16 )
-              {
-                  MPSGraphTensor* inputCastedTensor = [mpsGraph castTensor:inputTensor
-                                                                    toType:MPSDataTypeInt32
-                                                                      name:@"all_all"];
-                  MPSGraphTensor* outputCastedTensor = [mpsGraph reductionAndWithTensor:inputCastedTensor
-                                                                                   axes:nil
-                                                                                   name:nil];
-                  outputTensor = [mpsGraph castTensor:outputCastedTensor
-                                               toType:MPSDataTypeBool
-                                                 name:@"all_all"];
-              }
-              else
-              {
-                  MPSGraphTensor* outputUncastedTensor = [mpsGraph reductionAndWithTensor:inputTensor
-                                                                                     axes:nil
-                                                                                     name:nil];
-                  outputTensor = [mpsGraph castTensor:outputUncastedTensor
-                                               toType:MPSDataTypeBool
-                                                 name:@"all_all"];
-              }
-              newCachedGraph->inputTensor_ = inputTensor;
-              newCachedGraph->outputTensor_ = outputTensor;
-
-            }
-            return newCachedGraph;
-          });
         }
-
-        auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
-        auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t);
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
-          inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
-        };
-
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
-          outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
-        };
-
-        native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+        return newCachedGraph;
+      });
     }
+
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t);
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
+      inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
+    };
+
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
+      outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
+    };
+
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+  }
 }
 
 //-----------------------------------------------------------------------
 // Min and max functions
 
-Tensor min_max_mps
-  (const Tensor& input_t,
-   MPSReductionType reduction_type,
-   const std::string& func_name) {
+Tensor min_max_mps(const Tensor& input_t,
+                   MPSReductionType reduction_type,
+                   const std::string& func_name) {
+  using CachedGraph = MPSUnaryCachedGraph;
 
-  namespace native_mps = at::native::mps;
-  using CachedGraph = native_mps::MPSUnaryCachedGraph;
-
-  native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
-
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   IntArrayRef input_shape = input_t.sizes();
-  int64_t num_input_dims = input_shape.size();
 
   // Flatten the input tensor to reduce it to one value
   NSMutableArray<NSNumber*> *apparent_input_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-  int64_t num_in_elements = 1;
-  for(int i = 0; i < num_input_dims; i++) {
-      num_in_elements *= input_shape[i];
-  }
+  int64_t num_in_elements = c10::multiply_integers(input_shape);
   apparent_input_shape[0] = [NSNumber numberWithInt:num_in_elements];
 
   Tensor output_t = at::native::empty_mps({}, input_t.scalar_type(), c10::nullopt, kMPS, c10::nullopt, c10::nullopt);
@@ -1207,38 +1111,36 @@ Tensor min_max_mps
     string key = func_name + mps::getTensorsStringKey(input_t);
     CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
     // Initialize once if configuration not found in cache
-    if(!cachedGraph) {
-      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
-
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
         CachedGraph *newCachedGraph = nil;
-
         @autoreleasepool {
-          MPSGraph* mpsGraph = native_mps::make_mps_graph();
+          MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor* inputTensor = native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(input_t.scalar_type()));
+          MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input_t.scalar_type()));
 
           MPSGraphTensor* outputTensor = nil;
 
-          if(reduction_type == MPSReductionType::MAX)
-            outputTensor = [mpsGraph reductionMaximumWithTensor:inputTensor
-                                                           axes:@[@0]
-                                                           name:nil];
-          else if(reduction_type == MPSReductionType::MIN)
-            outputTensor = [mpsGraph reductionMinimumWithTensor:inputTensor
-                                                           axes:@[@0]
-                                                           name:nil];
+          if (reduction_type == MPSReductionType::MAX) {
+            outputTensor = [mpsGraph reductionMaximumWithTensor: inputTensor
+                                                           axes: @[@0]
+                                                           name: nil];
+          } else if (reduction_type == MPSReductionType::MIN) {
+            outputTensor = [mpsGraph reductionMinimumWithTensor: inputTensor
+                                                           axes: @[@0]
+                                                           name: nil];
+          }
 
           newCachedGraph->inputTensor_ = inputTensor;
           newCachedGraph->outputTensor_ = outputTensor;
-
         }
         return newCachedGraph;
       });
     }
 
-    auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t, apparent_input_shape);
-    auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t, @[@1]);
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, apparent_input_shape);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, @[@1]);
 
     NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
       inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
@@ -1248,7 +1150,7 @@ Tensor min_max_mps
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    native_mps::runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
+    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
   }
 
   return output_t;
@@ -1266,130 +1168,121 @@ Tensor min_mps(const Tensor& input_t) {
   return min_max_mps(input_t, MPSReductionType::MIN, "min_mps");
 }
 
-void min_max_out_mps
-  (const Tensor& input_t,
-  int64_t dim,
-  bool keepdim,
-  const Tensor& output_t,
-  const Tensor& indices_t,
-  MPSReductionType reduction_type,
-  const std::string& func_name) {
+void min_max_out_mps(const Tensor& input_t,
+                     int64_t dim,
+                     bool keepdim,
+                     const Tensor& output_t,
+                     const Tensor& indices_t,
+                     MPSReductionType reduction_type,
+                     const std::string& func_name) {
 
-    namespace native_mps = at::native::mps;
+  if (output_t.numel() == 0) {
+    return;
+  }
+  if (input_t.numel() == 1 && input_t.dim() == 0) {
+    output_t.fill_(input_t);
+    indices_t.fill_(0);
+    return;
+  }
 
-    if (output_t.numel() == 0) {
-      return;
+  // Derive from MPSCachedGraph
+  struct CachedGraph : public MPSCachedGraph
+  {
+    CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
+    MPSGraphTensor *inputTensor_ = nil;
+    MPSGraphTensor *outputTensor_ = nil;
+    MPSGraphTensor *indicesTensor_ = nil;
+  };
+
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
+
+  int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+
+  // Calculate the output shape according to keepdim=True
+  // If there is no dim argument, the input shape is flattened
+  IntArrayRef input_shape = input_t.sizes();
+  int64_t num_input_dims = input_shape.size();
+  NSMutableArray<NSNumber*> *apparent_out_shape = nil;
+
+  apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+  for (const auto i: c10::irange(num_input_dims)) {
+    apparent_out_shape[i] = dim_ == i ? @1: [NSNumber numberWithInt:input_shape[i]];
+  }
+
+  auto stream = at::mps::getCurrentMPSStream();
+
+  @autoreleasepool {
+    string key = func_name + ":" + to_string(dim_) + ":" + getMPSTypeString(input_t.scalar_type());
+    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
+        CachedGraph *newCachedGraph = nil;
+        @autoreleasepool {
+          MPSGraph* mpsGraph = make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
+
+          MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input_t.scalar_type()));
+          MPSGraphTensor* outputTensor = nil;
+          if (reduction_type == MPSReductionType::MAX) {
+            outputTensor = [mpsGraph reductionMaximumWithTensor:inputTensor
+                                                           axis:(NSInteger)dim_
+                                                           name:nil];
+          } else if (reduction_type == MPSReductionType::MIN) {
+            outputTensor = [mpsGraph reductionMinimumWithTensor:inputTensor
+                                                           axis:(NSInteger)dim_
+                                                           name:nil];
+          }
+
+          MPSGraphTensor* castInputTensor = nil;
+
+          if (input_t.scalar_type() != ScalarType::Float &&
+              input_t.scalar_type() != ScalarType::Int   &&
+              input_t.scalar_type() != ScalarType::Half) {
+            castInputTensor =  [mpsGraph castTensor:inputTensor
+                                             toType:MPSDataTypeFloat32
+                                               name:@"castInputTensor"];
+          } else {
+            castInputTensor = inputTensor;
+         }
+
+          MPSGraphTensor* argreduceOutTensor = nil;
+          if (reduction_type == MPSReductionType::MAX) {
+            argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor: castInputTensor
+                                                                    axis: (NSInteger)dim_
+                                                                    name: @"argmax_out"];
+          } else if (reduction_type == MPSReductionType::MIN) {
+            argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor: castInputTensor
+                                                                    axis: (NSInteger)dim_
+                                                                    name: @"argmax_out"];
+          }
+          MPSGraphTensor *indicesTensor = [mpsGraph castTensor: argreduceOutTensor
+                                                        toType: MPSDataTypeInt64
+                                                          name: @"cast_out"];
+
+          newCachedGraph->inputTensor_ = inputTensor;
+          newCachedGraph->outputTensor_ = outputTensor;
+          newCachedGraph->indicesTensor_ = indicesTensor;
+        }
+        return newCachedGraph;
+      });
     }
-    if (input_t.numel() == 1 && input_t.dim() == 0) {
-      output_t.fill_(input_t);
-      indices_t.fill_(0);
-      return;
-    }
 
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
+    auto indicesPlaceholder = Placeholder(cachedGraph->indicesTensor_, indices_t, apparent_out_shape);
 
-    // Derive from MPSCachedGraph
-    struct CachedGraph : public native_mps::MPSCachedGraph
-    {
-      CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
-      MPSGraphTensor *inputTensor_ = nil;
-      MPSGraphTensor *outputTensor_ = nil;
-      MPSGraphTensor *indicesTensor_ = nil;
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
+      inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
     };
 
-    native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
+      outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
+      indicesPlaceholder.getMPSGraphTensor() : indicesPlaceholder.getMPSGraphTensorData()
+    };
 
-    int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
-
-    // Calculate the output shape according to keepdim=True
-    // If there is no dim argument, the input shape is flattened
-    IntArrayRef input_shape = input_t.sizes();
-    int64_t num_input_dims = input_shape.size();
-    NSMutableArray<NSNumber*> *apparent_out_shape = nil;
-
-    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-    for(int i = 0; i < num_input_dims; i++) {
-        if(dim_ == i)
-            apparent_out_shape[i] = @1;
-        else
-            apparent_out_shape[i] = [NSNumber numberWithInt:input_shape[i]];
-    }
-
-    auto stream = at::mps::getCurrentMPSStream();
-
-    @autoreleasepool {
-        string key = func_name + ":" + to_string(dim_) + ":" + native_mps::getMPSTypeString(input_t.scalar_type());
-        CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-
-        if(!cachedGraph) {
-          cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
-
-            CachedGraph *newCachedGraph = nil;
-
-            @autoreleasepool {
-              MPSGraph* mpsGraph = native_mps::make_mps_graph();
-              newCachedGraph = new CachedGraph(mpsGraph);
-
-              MPSGraphTensor* inputTensor = native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(input_t.scalar_type()));
-              MPSGraphTensor* outputTensor = nil;
-              if(reduction_type == MPSReductionType::MAX)
-                outputTensor = [mpsGraph reductionMaximumWithTensor:inputTensor
-                                                               axis:(NSInteger)dim_
-                                                               name:nil];
-              else if(reduction_type == MPSReductionType::MIN)
-                outputTensor = [mpsGraph reductionMinimumWithTensor:inputTensor
-                                                               axis:(NSInteger)dim_
-                                                               name:nil];
-
-              MPSGraphTensor* castInputTensor = nil;
-
-              if(input_t.scalar_type() != ScalarType::Float &&
-                 input_t.scalar_type() != ScalarType::Int   &&
-                 input_t.scalar_type() != ScalarType::Half)
-                castInputTensor =  [mpsGraph castTensor:inputTensor
-                                                 toType:MPSDataTypeFloat32
-                                                   name:@"castInputTensor"];
-              else
-                castInputTensor = inputTensor;
-
-              MPSGraphTensor* argreduceOutTensor = nil;
-              if(reduction_type == MPSReductionType::MAX)
-                argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor:castInputTensor
-                                                                        axis:(NSInteger)dim_
-                                                                        name:@"argmax_out"];
-              else if(reduction_type == MPSReductionType::MIN)
-                argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor:castInputTensor
-                                                                        axis:(NSInteger)dim_
-                                                                        name:@"argmax_out"];
-
-              MPSGraphTensor *indicesTensor = [mpsGraph castTensor:argreduceOutTensor
-                                                            toType:MPSDataTypeInt64
-                                                              name:@"cast_out"];
-
-              newCachedGraph->inputTensor_ = inputTensor;
-              newCachedGraph->outputTensor_ = outputTensor;
-              newCachedGraph->indicesTensor_ = indicesTensor;
-            }
-            return newCachedGraph;
-          });
-        }
-
-        auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
-        auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
-        auto indicesPlaceholder = native_mps::Placeholder(cachedGraph->indicesTensor_, indices_t, apparent_out_shape);
-
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
-          inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
-        };
-
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
-          outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
-          indicesPlaceholder.getMPSGraphTensor() : indicesPlaceholder.getMPSGraphTensorData()
-        };
-
-        native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
-
-    }
-
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+  }
 }
 
 // Max out with dim
@@ -1420,131 +1313,121 @@ TORCH_IMPL_FUNC(min_out_mps)
     min_max_out_mps(input_t, dim, keepdim, output_t, indices_t, MPSReductionType::MIN, "min_out_mps");
 }
 
-void argmax_argmin_out_mps
-   (const Tensor& input_t,
-    c10::optional<int64_t> dim,
-    bool keepdim,
-    const Tensor& output_t,
-    MPSReductionType reduction_type,
-    const std::string& func_name) {
-    namespace native_mps = at::native::mps;
-    using CachedGraph = native_mps::MPSUnaryCachedGraph;
+void argmax_argmin_out_mps(const Tensor& input_t,
+                           c10::optional<int64_t> dim,
+                           bool keepdim,
+                           const Tensor& output_t,
+                           MPSReductionType reduction_type,
+                           const std::string& func_name) {
+  using CachedGraph = MPSUnaryCachedGraph;
 
-    native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
+  auto cache_ = MPSGraphCache::getInstance();
 
-    int64_t dim_;
+  int64_t dim_ = -1;
 
-    if (dim.has_value()) {
-        dim_ = maybe_wrap_dim(dim.value(), input_t.dim());
-        zero_numel_check_dims(input_t, dim_, reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()");
+  if (dim.has_value()) {
+      dim_ = maybe_wrap_dim(dim.value(), input_t.dim());
+      zero_numel_check_dims(input_t, dim_, reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()");
+  } else {
+      TORCH_CHECK_INDEX(
+      input_t.numel() != 0,
+      reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()" , ": Expected reduction dim to be specified for input.numel() == 0.");
+      // Since input will be flattened, take argmax or argmin along 0'th dimension
+      dim_ = 0;
+  }
+
+  // Calculate the output shape according to keepdim=True
+  // If there is no dim argument, the input shape is flattened
+  IntArrayRef input_shape = input_t.sizes();
+  int64_t num_input_dims = input_shape.size();
+  NSMutableArray<NSNumber*> *apparent_in_shape = nil;
+  NSMutableArray<NSNumber*> *apparent_out_shape = nil;
+
+  if (dim.has_value()) {
+      apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+      for (const auto i : c10::irange(num_input_dims)) {
+        apparent_out_shape[i] = dim_ == i ? @1 : [NSNumber numberWithInt:input_shape[i]];
+      }
+  } else {
+    apparent_in_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
+    int64_t num_in_elements = c10::multiply_integers(input_shape);
+    apparent_in_shape[0] = [NSNumber numberWithInt:num_in_elements];
+
+    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
+    apparent_out_shape[0] = @1;
+  }
+
+  if (output_t.numel() == 0) {
+      return;
+  }
+
+  auto stream = at::mps::getCurrentMPSStream();
+
+  @autoreleasepool {
+    string key = func_name + to_string(dim_) + ":" + getTensorsStringKey(input_t);
+    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
+        CachedGraph *newCachedGraph = nil;
+        @autoreleasepool {
+          MPSGraph* mpsGraph = make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
+
+          MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input_t.scalar_type()));
+
+          MPSGraphTensor* castInputTensor = nil;
+          MPSGraphTensor* argreduceOutTensor = nil;
+
+          if (input_t.scalar_type() != ScalarType::Float &&
+              input_t.scalar_type() != ScalarType::Int   &&
+              input_t.scalar_type() != ScalarType::Half) {
+            castInputTensor =  [mpsGraph castTensor: inputTensor
+                                             toType: MPSDataTypeFloat32
+                                               name: @"castInputTensor"];
+          } else {
+            castInputTensor = inputTensor;
+          }
+
+          if (reduction_type == MPSReductionType::MAX) {
+            argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor: castInputTensor
+                                                                    axis: (NSInteger)dim_
+                                                                    name: nil];
+          } else {
+            argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor: castInputTensor
+                                                                    axis: (NSInteger)dim_
+                                                                    name: nil];
+          }
+          MPSGraphTensor* outputTensor = [mpsGraph castTensor: argreduceOutTensor
+                                                       toType: MPSDataTypeInt64
+                                                         name: @"castOutpuTensor"];
+
+          newCachedGraph->inputTensor_ = inputTensor;
+          newCachedGraph->outputTensor_ = outputTensor;
+        }
+        return newCachedGraph;
+      });
+    }
+
+    Placeholder inputPlaceholder = Placeholder();
+    if (apparent_in_shape) {
+      inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, apparent_in_shape);
     } else {
-        TORCH_CHECK_INDEX(
-        input_t.numel() != 0,
-        reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()" , ": Expected reduction dim to be specified for input.numel() == 0.");
-        // Since input will be flattened, take argmax or argmin along 0'th dimension
-        dim_ = 0;
+      inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
     }
 
-    // Calculate the output shape according to keepdim=True
-    // If there is no dim argument, the input shape is flattened
-    IntArrayRef input_shape = input_t.sizes();
-    int64_t num_input_dims = input_shape.size();
-    NSMutableArray<NSNumber*> *apparent_in_shape = nil;
-    NSMutableArray<NSNumber*> *apparent_out_shape = nil;
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
 
-    if(dim.has_value()) {
-        apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-        for(int i = 0; i < num_input_dims; i++) {
-            if(dim_ == i)
-                apparent_out_shape[i] = @1;
-            else
-                apparent_out_shape[i] = [NSNumber numberWithInt:input_shape[i]];
-        }
-    }
-    else {
-        apparent_in_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-        int64_t num_in_elements = 1;
-        for(int i = 0; i < num_input_dims; i++) {
-            num_in_elements *= input_shape[i];
-        }
-        apparent_in_shape[0] = [NSNumber numberWithInt:num_in_elements];
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
+      inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
+    };
 
-        apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-        apparent_out_shape[0] = @1;
-    }
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
+      outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
+    };
 
-    if (output_t.numel() == 0) {
-        return;
-    }
-
-    auto stream = at::mps::getCurrentMPSStream();
-
-    @autoreleasepool {
-        string key = func_name + to_string(dim_) + ":" + native_mps::getTensorsStringKey(input_t);
-        CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
-
-        if(!cachedGraph) {
-          cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
-
-            CachedGraph *newCachedGraph = nil;
-
-            @autoreleasepool {
-              MPSGraph* mpsGraph = native_mps::make_mps_graph();
-              newCachedGraph = new CachedGraph(mpsGraph);
-
-              MPSGraphTensor* inputTensor = native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(input_t.scalar_type()));
-
-              MPSGraphTensor* castInputTensor = nil;
-              MPSGraphTensor* argreduceOutTensor = nil;
-
-              if(input_t.scalar_type() != ScalarType::Float &&
-                 input_t.scalar_type() != ScalarType::Int   &&
-                 input_t.scalar_type() != ScalarType::Half)
-                castInputTensor =  [mpsGraph castTensor:inputTensor
-                                                 toType:MPSDataTypeFloat32
-                                                   name:@"castInputTensor"];
-              else
-                castInputTensor = inputTensor;
-
-              if (reduction_type == MPSReductionType::MAX) {
-                argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor:castInputTensor
-                                                                        axis:(NSInteger)dim_
-                                                                        name:nil];
-              }
-              else {
-                argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor:castInputTensor
-                                                                        axis:(NSInteger)dim_
-                                                                        name:nil];
-              }
-              MPSGraphTensor* outputTensor = [mpsGraph castTensor:argreduceOutTensor
-                                                           toType:MPSDataTypeInt64
-                                                             name:@"castOutpuTensor"];
-
-              newCachedGraph->inputTensor_ = inputTensor;
-              newCachedGraph->outputTensor_ = outputTensor;
-            }
-            return newCachedGraph;
-          });
-        }
-
-        native_mps::Placeholder inputPlaceholder = native_mps::Placeholder();
-        if(apparent_in_shape)
-            inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t, apparent_in_shape);
-        else
-            inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
-
-        auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
-
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
-          inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
-        };
-
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
-          outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
-        };
-
-        native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
-    }
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+  }
 }
 
 TORCH_IMPL_FUNC(argmax_out_mps)
@@ -1567,181 +1450,156 @@ TORCH_IMPL_FUNC(argmin_out_mps)
 
 
 // Min/Max with dim
-std::tuple<Tensor, Tensor> min_max_mps
-   (const Tensor& input_t,
-    int64_t dim,
-    bool keepdim,
-    MPSReductionType reduction_type,
-    const std::string& func_name) {
+std::tuple<Tensor, Tensor> min_max_mps(const Tensor& input_t,
+                                       int64_t dim,
+                                       bool keepdim,
+                                       MPSReductionType reduction_type,
+                                       const std::string& func_name) {
 
-    namespace native_mps = at::native::mps;
+  int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+  native::zero_numel_check_dims(input_t, dim_, "max()");
 
-    int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
-    native::zero_numel_check_dims(input_t, dim_, "max()");
+  // Calculate the output shape according to keepdim=True
+  // If there is no dim argument, the input shape is flattened
+  IntArrayRef input_shape = input_t.sizes();
+  int64_t num_input_dims = input_shape.size();
+  NSMutableArray<NSNumber*> *apparent_out_shape = nil;
+  // Use this if keepdim is false
+  int64_t num_output_dims = num_input_dims - 1;
 
-    // Calculate the output shape according to keepdim=True
-    // If there is no dim argument, the input shape is flattened
-    IntArrayRef input_shape = input_t.sizes();
-    int64_t num_input_dims = input_shape.size();
-    NSMutableArray<NSNumber*> *apparent_out_shape = nil;
-    // Use this if keepdim is false
-    int64_t num_output_dims = num_input_dims - 1;
+  std::vector<int64_t> vec_apparent_out_shape(num_input_dims);
+  std::vector<int64_t> vec_out_shape(num_output_dims);
 
-    std::vector<int64_t> vec_apparent_out_shape(num_input_dims);
-    std::vector<int64_t> vec_out_shape(num_output_dims);
-
-    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-    // Counter for shape when keepdim is false
-    int out_i = 0;
-    for(int i = 0; i < num_input_dims; i++) {
-        if(dim_ == i) {
-            apparent_out_shape[i] = @1;
-            vec_apparent_out_shape[i] = 1;
-        }
-        else {
-            apparent_out_shape[i] = [NSNumber numberWithInt:input_shape[i]];
-            vec_apparent_out_shape[i] = input_shape[i];
-            vec_out_shape[out_i] = input_shape[i];
-            out_i++;
-        }
-    }
-
-    Tensor output_t;
-    Tensor indices_t;
-    if(!keepdim) {
-     output_t = at::native::empty_mps(
-                      IntArrayRef(vec_out_shape),
-                      input_t.scalar_type(),
-                      c10::nullopt,
-                      kMPS,
-                      c10::nullopt,
-                      c10::nullopt);
-     indices_t = at::native::empty_mps(
-                      IntArrayRef(vec_out_shape),
-                      ScalarType::Long,
-                      c10::nullopt,
-                      kMPS,
-                      c10::nullopt,
-                      c10::nullopt);
+  apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+  // Counter for shape when keepdim is false
+  int out_i = 0;
+  for (const auto i: c10::irange(num_input_dims)) {
+    if (dim_ == i) {
+      apparent_out_shape[i] = @1;
+      vec_apparent_out_shape[i] = 1;
     } else {
-      output_t = at::native::empty_mps(
-                      IntArrayRef(vec_apparent_out_shape),
-                      input_t.scalar_type(),
-                      c10::nullopt,
-                      kMPS,
-                      c10::nullopt,
-                      c10::nullopt);
-     indices_t = at::native::empty_mps(
-                      IntArrayRef(vec_apparent_out_shape),
-                      ScalarType::Long,
-                      c10::nullopt,
-                      kMPS,
-                      c10::nullopt,
-                      c10::nullopt);
+      apparent_out_shape[i] = [NSNumber numberWithInt:input_shape[i]];
+      vec_apparent_out_shape[i] = input_shape[i];
+      vec_out_shape[out_i] = input_shape[i];
+      out_i++;
     }
+  }
 
-    if (output_t.numel() == 0 || input_t.numel() == 0) {
-        return std::tuple<Tensor, Tensor>{output_t, indices_t};
-    }
+  Tensor output_t;
+  Tensor indices_t;
+  if (!keepdim) {
+   output_t = at::native::empty_mps(
+                    IntArrayRef(vec_out_shape),
+                    input_t.scalar_type(),
+                    c10::nullopt,
+                    kMPS,
+                    c10::nullopt,
+                    c10::nullopt);
+   indices_t = at::native::empty_mps(
+                    IntArrayRef(vec_out_shape),
+                    ScalarType::Long,
+                    c10::nullopt,
+                    kMPS,
+                    c10::nullopt,
+                    c10::nullopt);
+  } else {
+    output_t = at::native::empty_mps(
+                    IntArrayRef(vec_apparent_out_shape),
+                    input_t.scalar_type(),
+                    c10::nullopt,
+                    kMPS,
+                    c10::nullopt,
+                    c10::nullopt);
+   indices_t = at::native::empty_mps(
+                    IntArrayRef(vec_apparent_out_shape),
+                    ScalarType::Long,
+                    c10::nullopt,
+                    kMPS,
+                    c10::nullopt,
+                    c10::nullopt);
+  }
 
-    min_max_out_mps(input_t, dim, keepdim, output_t, indices_t, reduction_type, func_name);
+  if (output_t.numel() == 0 || input_t.numel() == 0) {
+      return std::tuple<Tensor, Tensor>{output_t, indices_t};
+  }
 
-    return std::tuple<Tensor, Tensor>{output_t, indices_t};
+  min_max_out_mps(input_t, dim, keepdim, output_t, indices_t, reduction_type, func_name);
+
+  return std::tuple<Tensor, Tensor>{output_t, indices_t};
 }
 
 // Max with dim
-std::tuple<Tensor, Tensor> max_mps
-   (const Tensor& input_t,
-    int64_t dim,
-    bool keepdim) {
-
-    return min_max_mps(input_t, dim, keepdim, MPSReductionType::MAX, "max_mps");
+std::tuple<Tensor, Tensor> max_mps(const Tensor& input_t, int64_t dim, bool keepdim) {
+  return min_max_mps(input_t, dim, keepdim, MPSReductionType::MAX, "max_mps");
 }
 
 // Min with dim
-std::tuple<Tensor, Tensor> min_mps
-   (const Tensor& input_t,
-    int64_t dim,
-    bool keepdim) {
-
-    return min_max_mps(input_t, dim, keepdim, MPSReductionType::MIN, "min_mps");
+std::tuple<Tensor, Tensor> min_mps(const Tensor& input_t, int64_t dim, bool keepdim) {
+  return min_max_mps(input_t, dim, keepdim, MPSReductionType::MIN, "min_mps");
 }
 
 // Median of entire tensor into scalar result
 Tensor median_mps(const Tensor& input_t) {
 
-  if(!is_macos_13_or_newer()){
-        TORCH_WARN_ONCE("MPS: median op is supported natively starting from macOS 13.0. ",
-                    "Falling back on CPU. This may have performace implications.");
-        return at::median(input_t.to("cpu"));
+  if (!is_macos_13_or_newer()){
+    TORCH_WARN_ONCE("MPS: median op is supported natively starting from macOS 13.0. ",
+                "Falling back on CPU. This may have performace implications.");
+    return at::median(input_t.to("cpu"));
   }
 
-    TORCH_INTERNAL_ASSERT(input_t.scalar_type() != ScalarType::Long, "median not supported for Long dtype on MPS");
+  TORCH_INTERNAL_ASSERT(input_t.scalar_type() != ScalarType::Long, "median not supported for Long dtype on MPS");
 
-    namespace native_mps = at::native::mps;
-    using CachedGraph = native_mps::MPSUnaryCachedGraph;
+  using CachedGraph = MPSUnaryCachedGraph;
 
-    native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
-    IntArrayRef input_shape = input_t.sizes();
-    int64_t num_input_dims = input_shape.size();
+  IntArrayRef input_shape = input_t.sizes();
 
-    // calculate total no. of elements in the input tensor to reduce it to one dimension
-    NSMutableArray<NSNumber*> *apparent_input_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    int64_t num_in_elements = 1;
-    for(int i = 0; i < num_input_dims; i++) {
-        num_in_elements *= input_shape[i];
-    }
+  // calculate total no. of elements in the input tensor to reduce it to one dimension
+  NSMutableArray<NSNumber*> *apparent_input_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
+  int64_t num_in_elements = c10::multiply_integers(input_shape);
 
-    apparent_input_shape[0] = [NSNumber numberWithInt:num_in_elements];
+  apparent_input_shape[0] = [NSNumber numberWithInt:num_in_elements];
 
-    Tensor output_t = at::native::empty_mps({}, input_t.scalar_type(), c10::nullopt, kMPS, c10::nullopt, c10::nullopt);
+  Tensor output_t = at::native::empty_mps({}, input_t.scalar_type(), c10::nullopt, kMPS, c10::nullopt, c10::nullopt);
 
-    if (output_t.numel() == 0 || num_in_elements == 0) {
-        return output_t;
-    }
+  if (output_t.numel() == 0 || num_in_elements == 0) {
+    return output_t;
+  }
 
   @autoreleasepool {
     string key = "median_mps:"+ mps::getMPSTypeString(input_t.scalar_type())  + mps::getTensorsStringKey(input_t);
     CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
     // Initialize once if configuration not found in cache
-    if(!cachedGraph) {
-      native_mps::MPSCachedGraph *tmpCachedGraph = cache_->CreateCachedGraph(key, ^ native_mps::MPSCachedGraph * () {
-
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
         CachedGraph *newCachedGraph = nil;
-
         @autoreleasepool {
-            MPSGraph* mpsGraph = native_mps::make_mps_graph();
-            newCachedGraph = new CachedGraph(mpsGraph);
+          MPSGraph* mpsGraph = make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
 
-            MPSGraphTensor* inputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+          auto inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+          auto reshapedTensor = [mpsGraph reshapeTensor: inputTensor
+                                              withShape: @[@-1]
+                                                   name: nil];
+          auto sortedTensor = [mpsGraph sortWithTensor: reshapedTensor
+                                                  axis: ((NSUInteger) (int)0)
+                                                  name: nil];
+          auto outputTensor = [mpsGraph sliceTensor: sortedTensor
+                                          dimension: 0
+                                              start: ((NSUInteger) (int)((num_in_elements+1)/2 ) - 1)
+                                             length: 1
+                                               name: nil];
 
-            MPSGraphTensor* outputTensor = nil;
-
-            MPSGraphTensor * reshapedTensor = [mpsGraph reshapeTensor:inputTensor
-                                                            withShape:@[@-1]
-                                                                  name:nil];
-            MPSGraphTensor * sortedTensor = [mpsGraph
-                                                  sortWithTensor:reshapedTensor
-                                                  axis:((NSUInteger) (int)0)
-                                                  name:nil];
-
-            outputTensor = [mpsGraph sliceTensor:sortedTensor
-                                                        dimension:0
-                                                        start:((NSUInteger) (int)((num_in_elements+1)/2 ) - 1)
-                                                        length:1
-                                                        name:nil];
-
-            newCachedGraph->inputTensor_ = inputTensor;
-            newCachedGraph->outputTensor_ = outputTensor;
+          newCachedGraph->inputTensor_ = inputTensor;
+          newCachedGraph->outputTensor_ = outputTensor;
         }
         return newCachedGraph;
       });
-      cachedGraph = static_cast<CachedGraph *>(tmpCachedGraph);
     }
 
-    auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
-    auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t, @[@1]);
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, @[@1]);
 
     NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
       inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
@@ -1751,233 +1609,219 @@ Tensor median_mps(const Tensor& input_t) {
       outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData()
     };
 
-    native_mps::runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
+    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, results);
   }
 
   return output_t;
 }
 
 
-void median_out_mps
-  (const Tensor& input_t,
-  int64_t dim,
-  bool keepdim,
-  const Tensor& output_t,
-  const Tensor& indices_t,
-  const std::string& func_name) {
+void median_out_mps(const Tensor& input_t,
+                    int64_t dim,
+                    bool keepdim,
+                    const Tensor& output_t,
+                    const Tensor& indices_t,
+                    const std::string& func_name) {
 
-    namespace native_mps = at::native::mps;
+  if (output_t.numel() == 0) {
+    return;
+  }
 
-    if (output_t.numel() == 0) {
-      return;
-    }
-    if (input_t.numel() == 1 && input_t.dim() == 0) {
-      output_t.fill_(input_t);
-      indices_t.fill_(0);
-      return;
-    }
+  if (input_t.numel() == 1 && input_t.dim() == 0) {
+    output_t.fill_(input_t);
+    indices_t.fill_(0);
+    return;
+  }
 
-    // Derive from MPSCachedGraph
-    struct CachedGraph : public native_mps::MPSCachedGraph
-    {
-      CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
-      MPSGraphTensor *inputTensor_ = nil;
-      MPSGraphTensor *outputTensor_ = nil;
-      MPSGraphTensor *indicesTensor_ = nil;
-    };
+  // Derive from MPSCachedGraph
+  struct CachedGraph : public MPSCachedGraph
+  {
+    CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
+    MPSGraphTensor *inputTensor_ = nil;
+    MPSGraphTensor *outputTensor_ = nil;
+    MPSGraphTensor *indicesTensor_ = nil;
+  };
 
-    native_mps::MPSGraphCache* cache_ = native_mps::MPSGraphCache::getInstance();
+  auto cache_ = MPSGraphCache::getInstance();
 
-    int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+  int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
 
-    // Calculate the output shape according to keepdim=True
-    // If there is no dim argument, the input shape is flattened
-    IntArrayRef input_shape = input_t.sizes();
-    int64_t num_input_dims = input_shape.size();
-    NSMutableArray<NSNumber*> *apparent_out_shape = nil;
+  // Calculate the output shape according to keepdim=True
+  // If there is no dim argument, the input shape is flattened
+  IntArrayRef input_shape = input_t.sizes();
+  int64_t num_input_dims = input_shape.size();
+  NSMutableArray<NSNumber*> *apparent_out_shape = nil;
 
-    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-    for(int i = 0; i < num_input_dims; i++) {
-        if(dim_ == i)
-            apparent_out_shape[i] = @1;
-        else
-            apparent_out_shape[i] = [NSNumber numberWithInt:input_shape[i]];
-    }
-    int dim_total_elements = input_shape[dim_];
+  apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+  for (const int i : c10::irange(num_input_dims)) {
+    apparent_out_shape[i] = dim_ == i ? @1 : [NSNumber numberWithInt:input_shape[i]];
+  }
+  int dim_total_elements = input_shape[dim_];
 
-    auto stream = at::mps::getCurrentMPSStream();
+  auto stream = at::mps::getCurrentMPSStream();
 
-    @autoreleasepool {
-        string key = func_name + ":" + to_string(dim_) + ":" + native_mps::getTensorsStringKey(input_t);
-        CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
+  @autoreleasepool {
+    string key = func_name + ":" + to_string(dim_) + ":" + getTensorsStringKey(input_t);
+    CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
-        if(!cachedGraph) {
-          cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ native_mps::MPSCachedGraph * () {
+    if (!cachedGraph) {
+      cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
+        CachedGraph *newCachedGraph = nil;
 
-            CachedGraph *newCachedGraph = nil;
+        @autoreleasepool {
+          auto mpsGraph = make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
 
-            @autoreleasepool {
-              MPSGraph* mpsGraph = native_mps::make_mps_graph();
-              newCachedGraph = new CachedGraph(mpsGraph);
-
-              MPSGraphTensor* inputTensor = native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(input_t.scalar_type()));
-              MPSGraphTensor* outputTensor = nil;
-              MPSGraphTensor * sortedTensor = [mpsGraph
-                                                  sortWithTensor:inputTensor
-                                                  axis:((NSUInteger) (int)dim_)
+          MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input_t.scalar_type()));
+          auto sortedTensor = [mpsGraph sortWithTensor: inputTensor
+                                                  axis: (NSUInteger)dim_
+                                                  name: nil];
+          const NSUInteger midpoint = (dim_total_elements + 1) / 2 - 1;
+          auto outputTensor = [mpsGraph sliceTensor:sortedTensor
+                                          dimension:dim_
+                                              start:midpoint
+                                             length:1
+                                               name:nil];
+          auto argreduceOutTensor = [mpsGraph argSortWithTensor:inputTensor
+                                                           axis:(NSInteger)dim_
+                                                           name:@"argmax_out"];
+          auto argOutputTensor = [mpsGraph sliceTensor:argreduceOutTensor
+                                             dimension:dim_
+                                                 start:midpoint
+                                                length:1
                                                   name:nil];
 
-              outputTensor = [mpsGraph sliceTensor:sortedTensor
-                                                        dimension:dim_
-                                                        start:((NSUInteger) (int)((dim_total_elements+1)/2 ) - 1)
-                                                        length:1
-                                                        name:nil];
-              MPSGraphTensor* argreduceOutTensor = nil;
-                argreduceOutTensor = [mpsGraph argSortWithTensor:inputTensor
-                                                                        axis:(NSInteger)dim_
-                                                                        name:@"argmax_out"];
-              MPSGraphTensor* argOutputTensor = [mpsGraph sliceTensor:argreduceOutTensor
-                                                        dimension:dim_
-                                                        start:((NSUInteger) (int)((dim_total_elements+1)/2 ) - 1)
-                                                        length:1
-                                                        name:nil];
-
-              newCachedGraph->inputTensor_ = inputTensor;
-              newCachedGraph->outputTensor_ = outputTensor;
-              newCachedGraph->indicesTensor_ = argOutputTensor;
-            }
-            return newCachedGraph;
-          });
+          newCachedGraph->inputTensor_ = inputTensor;
+          newCachedGraph->outputTensor_ = outputTensor;
+          newCachedGraph->indicesTensor_ = argOutputTensor;
         }
-
-        auto inputPlaceholder = native_mps::Placeholder(cachedGraph->inputTensor_, input_t);
-        auto outputPlaceholder = native_mps::Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
-        auto indicesPlaceholder = native_mps::Placeholder(cachedGraph->indicesTensor_, indices_t, apparent_out_shape);
-
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
-          inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
-        };
-
-        NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
-          outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
-          indicesPlaceholder.getMPSGraphTensor() : indicesPlaceholder.getMPSGraphTensorData()
-        };
-
-        native_mps::runMPSGraph(stream, cachedGraph->graph(), feeds, results);
-
+        return newCachedGraph;
+      });
     }
 
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
+    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
+    auto indicesPlaceholder = Placeholder(cachedGraph->indicesTensor_, indices_t, apparent_out_shape);
+
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
+      inputPlaceholder.getMPSGraphTensor() : inputPlaceholder.getMPSGraphTensorData(),
+    };
+
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
+      outputPlaceholder.getMPSGraphTensor() : outputPlaceholder.getMPSGraphTensorData(),
+      indicesPlaceholder.getMPSGraphTensor() : indicesPlaceholder.getMPSGraphTensorData()
+    };
+
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+  }
 }
 
 // in case mps sortWithTensor do not supported on macOS
-std::tuple<Tensor&, Tensor&> median_from_cpu(
-    const Tensor& self,
-    int64_t dim,
-    bool keepdim, Tensor & valuesI, Tensor & indicesI, IntArrayRef vec_out_shape, IntArrayRef vec_apparent_out_shape) {
-      // Tensor a = at::median(self.to("cpu"));
-      Tensor values;
-      Tensor indices;
-    if (!keepdim){
-        values = at::empty({vec_out_shape}, self.options());
-        indices = at::empty({vec_out_shape}, self.options().dtype(kLong));
-
-      }
-      else{
-          values = at::empty({vec_apparent_out_shape}, self.options());
-          indices = at::empty({vec_apparent_out_shape}, self.options().dtype(kLong));
-      }
-      at::median_out(values, indices, self, dim, keepdim);
+std::tuple<Tensor&, Tensor&> median_from_cpu(const Tensor& self,
+                                             int64_t dim,
+                                             bool keepdim,
+                                             Tensor & valuesI,
+                                             Tensor & indicesI,
+                                             IntArrayRef vec_out_shape,
+                                             IntArrayRef vec_apparent_out_shape) {
+  Tensor values;
+  Tensor indices;
+  if (!keepdim) {
+    values = at::empty({vec_out_shape}, self.options());
+    indices = at::empty({vec_out_shape}, self.options().dtype(kLong));
+  } else {
+    values = at::empty({vec_apparent_out_shape}, self.options());
+    indices = at::empty({vec_apparent_out_shape}, self.options().dtype(kLong));
+  }
+  at::median_out(values, indices, self, dim, keepdim);
 
   valuesI.copy_(values);
   indicesI.copy_(indices);
   return std::forward_as_tuple(valuesI, indicesI);
 }
 
-TORCH_API ::std::tuple<at::Tensor &,at::Tensor &> median_out_mps
-    (const at::Tensor & input_t,
-    int64_t dim,
-    bool keepdim,
-    at::Tensor & values,
-    at::Tensor & indices){
+TORCH_API ::std::tuple<at::Tensor &,at::Tensor &> median_out_mps (const at::Tensor & input_t,
+                                                                  int64_t dim,
+                                                                  bool keepdim,
+                                                                  at::Tensor & values,
+                                                                  at::Tensor & indices) {
 
   TORCH_INTERNAL_ASSERT(input_t.scalar_type() != ScalarType::Long, "median not supported for Long dtype on MPS");
 
-  namespace native_mps = at::native::mps;
-    int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
-    native::zero_numel_check_dims(input_t, dim_, "max()");
+  int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+  native::zero_numel_check_dims(input_t, dim_, "max()");
 
-    // Calculate the output shape according to keepdim=True
-    // If there is no dim argument, the input shape is flattened
-    IntArrayRef input_shape = input_t.sizes();
-    int64_t num_input_dims = input_shape.size();
-    NSMutableArray<NSNumber*> *apparent_out_shape = nil;
-    // Use this if keepdim is false
-    int64_t num_output_dims = num_input_dims - 1;
+  // Calculate the output shape according to keepdim=True
+  // If there is no dim argument, the input shape is flattened
+  IntArrayRef input_shape = input_t.sizes();
+  int64_t num_input_dims = input_shape.size();
+  NSMutableArray<NSNumber*> *apparent_out_shape = nil;
+  // Use this if keepdim is false
+  int64_t num_output_dims = num_input_dims - 1;
 
-    std::vector<int64_t> vec_apparent_out_shape(num_input_dims);
-    std::vector<int64_t> vec_out_shape(num_output_dims);
+  std::vector<int64_t> vec_apparent_out_shape(num_input_dims);
+  std::vector<int64_t> vec_out_shape(num_output_dims);
 
-    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-    // Counter for shape when keepdim is false
-    int out_i = 0;
-    for(int i = 0; i < num_input_dims; i++) {
-        if(dim_ == i) {
-            apparent_out_shape[i] = @1;
-            vec_apparent_out_shape[i] = 1;
-        }
-        else {
-            apparent_out_shape[i] = [NSNumber numberWithInt:input_shape[i]];
-            vec_apparent_out_shape[i] = input_shape[i];
-            vec_out_shape[out_i] = input_shape[i];
-            out_i++;
-        }
-    }
-
-    if(!keepdim) {
-     values = at::native::empty_mps(
-                      IntArrayRef(vec_out_shape),
-                      input_t.scalar_type(),
-                      c10::nullopt,
-                      kMPS,
-                      c10::nullopt,
-                      c10::nullopt);
-     indices = at::native::empty_mps(
-                      IntArrayRef(vec_out_shape),
-                      ScalarType::Long,
-                      c10::nullopt,
-                      kMPS,
-                      c10::nullopt,
-                      c10::nullopt);
+  apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+  // Counter for shape when keepdim is false
+  int out_i = 0;
+  for (const auto i: c10::irange(num_input_dims)) {
+    if (dim_ == i) {
+      apparent_out_shape[i] = @1;
+      vec_apparent_out_shape[i] = 1;
     } else {
-      values = at::native::empty_mps(
-                      IntArrayRef(vec_apparent_out_shape),
-                      input_t.scalar_type(),
-                      c10::nullopt,
-                      kMPS,
-                      c10::nullopt,
-                      c10::nullopt);
-     indices = at::native::empty_mps(
-                      IntArrayRef(vec_apparent_out_shape),
-                      ScalarType::Long,
-                      c10::nullopt,
-                      kMPS,
-                      c10::nullopt,
-                      c10::nullopt);
+      apparent_out_shape[i] = [NSNumber numberWithInt:input_shape[i]];
+      vec_apparent_out_shape[i] = input_shape[i];
+      vec_out_shape[out_i] = input_shape[i];
+      out_i++;
     }
-
-    if (values.numel() == 0 || input_t.numel() == 0) {
-        return std::tuple<Tensor&, Tensor&>{values, indices};
-    }
-
-    if(!is_macos_13_or_newer()){
-      TORCH_WARN_ONCE("MPS: median op is supported natively starting from macOS 13.0.",
-                    "Falling back on CPU. This may have performace implications.");
-    return median_from_cpu(input_t.to("cpu"), dim, keepdim, values, indices, IntArrayRef(vec_out_shape),IntArrayRef(vec_apparent_out_shape) );
   }
 
-    median_out_mps(input_t, dim, keepdim, values, indices, "median_out_mps");
+  if (!keepdim) {
+   values = at::native::empty_mps(
+                    IntArrayRef(vec_out_shape),
+                    input_t.scalar_type(),
+                    c10::nullopt,
+                    kMPS,
+                    c10::nullopt,
+                    c10::nullopt);
+   indices = at::native::empty_mps(
+                    IntArrayRef(vec_out_shape),
+                    ScalarType::Long,
+                    c10::nullopt,
+                    kMPS,
+                    c10::nullopt,
+                    c10::nullopt);
+  } else {
+    values = at::native::empty_mps(
+                    IntArrayRef(vec_apparent_out_shape),
+                    input_t.scalar_type(),
+                    c10::nullopt,
+                    kMPS,
+                    c10::nullopt,
+                    c10::nullopt);
+   indices = at::native::empty_mps(
+                    IntArrayRef(vec_apparent_out_shape),
+                    ScalarType::Long,
+                    c10::nullopt,
+                    kMPS,
+                    c10::nullopt,
+                    c10::nullopt);
+  }
 
-    return std::tuple<Tensor&, Tensor&>{values, indices};
+  if (values.numel() == 0 || input_t.numel() == 0) {
+      return std::tuple<Tensor&, Tensor&>{values, indices};
+  }
+
+  if (!is_macos_13_or_newer()) {
+    TORCH_WARN_ONCE("MPS: median op is supported natively starting from macOS 13.0.",
+                   "Falling back on CPU. This may have performace implications.");
+    return median_from_cpu(input_t.to("cpu"), dim, keepdim, values, indices, IntArrayRef(vec_out_shape),IntArrayRef(vec_apparent_out_shape));
+  }
+
+  median_out_mps(input_t, dim, keepdim, values, indices, "median_out_mps");
+
+  return std::tuple<Tensor&, Tensor&>{values, indices};
 }
 
 } // native


### PR DESCRIPTION
Use curly braces even after single line `if`
Use whitespace between `if` and condition
Use `c10::irange`
Also, use `c10::multiply_integers` instead of explicit for loop of elements of `IntArrayRef`
Do not pass `num_input_dims` to `set_apparent_shapes` as it is always equal to the length of `input_shape` array
