### PR TITLE
[Quant] make x86 the default quantization backend (qengine)

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -304,7 +304,12 @@ at::QEngine Context::qEngine() const {
 
 #ifdef USE_FBGEMM
     if (fbgemm::fbgemmSupportedCPU()) {
-      qengine = at::kFBGEMM;
+      /* X86 is enabled if and only if fbgemm is available.
+       * It combines goodness of fbgemm and onednn by dispatching.
+       * If onednn not available, always dispatch to fbgemm.
+       * Make it default qengine for X86 CPU platforms.
+      */
+      qengine = at::kX86;
     }
 #endif
     return qengine;


### PR DESCRIPTION
**Summary**
Make x86 the default quantization backend (qengine) for X86 CPU platforms.
X86 is a unified quantization backend combining goodness of fbgemm and onednn. For more details please see https://github.com/pytorch/pytorch/issues/83888

**Test plan**
python test/test_quantization.py


cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @leslie-fang-intel @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10