### PR TITLE
Update pybind11 to v2.10.2

### DIFF
--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -141,6 +141,7 @@ PyRRef::PyRRef(const py::object& value, const py::object& type_hint)
 
 PyRRef::~PyRRef() {
   if (type_.has_value()) {
+    pybind11::gil_scoped_acquire ag;
     (*type_).dec_ref();
     // explicitly setting PyObject* to nullptr to prevent py::object's dtor to
     // decref on the PyObject again.


### PR DESCRIPTION
I am a pybind11 maintainer and contributor to PyTorch so making sure we have the latest and greatest. This minor release is mostly cmake related bugfixes, but also include some nice optin Eigen bindings, better control of docstring generation, and better typing.

One change so far that has proven helpful is additional debug utils that detect refcount increments or decrements that occur without the GIL being locked which can cause really nasty UB behavior. It seems to have triggered on the PyTorch codebase.

cc @soumith since he approved the last PR related to updating pybind11, or maybe @ezyang 