### PR TITLE
[Vulkan] Use EXPECT_EQ instead of ASSERT_TRUE in vulkan_api_test querypool_flushed_shader_log

### DIFF
--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -5116,9 +5116,9 @@ TEST_F(VulkanAPITest, querypool_flushed_shader_log) {
           ->querypool()
           .get_shader_name_and_execution_duration_ns(entry_count - 2);
 
-  ASSERT_TRUE(std::get<0>(add_shader_details) == "vulkan.add");
-  ASSERT_TRUE(std::get<0>(sub_shader_details) == "vulkan.sub");
-  ASSERT_TRUE(std::get<0>(mul_shader_details) == "vulkan.mul");
+  EXPECT_EQ(std::get<0>(add_shader_details), "vulkan.add");
+  EXPECT_EQ(std::get<0>(sub_shader_details), "vulkan.sub");
+  EXPECT_EQ(std::get<0>(mul_shader_details), "vulkan.mul");
 
   if (!op_profiling_enabled_initially) {
     at::native::vulkan::api::context()->reset_querypool();


### PR DESCRIPTION
Summary:
After this change, if the querypool_flushed_shader_log test fails:
1) The test continues after the first failure and checks all three (Because ASSERT was changed to EXPECT)
2) The op names which are compared to vulkan.add, vulkan.sub, and vulkan.mul are shown (rather than not showing what the wrong op name was) (Because we use ..._EQ(a, b) instead of just checking ...(a == b))

This change makes it easier to debug future failures to querypool_flushed_shader_log (it helped me when one of my diffs broke the test)

Test Plan:
Vulkan API Test
- https://www.internalfb.com/intern/aibench/details/959371570734292

Reviewed By: SS-JIA

Differential Revision: D42186371

