### PR TITLE
[cuDNN] Change `cuDNN` context manager to enable cuDNN as default

### DIFF
--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -124,7 +124,7 @@ def set_flags(_enabled=None, _benchmark=None, _benchmark_limit=None, _determinis
 
 
 @contextmanager
-def flags(enabled=False, benchmark=False, benchmark_limit=10, deterministic=False, allow_tf32=True):
+def flags(enabled=True, benchmark=False, benchmark_limit=10, deterministic=False, allow_tf32=True):
     with __allow_nonbracketed_mutation():
         orig_flags = set_flags(enabled, benchmark, benchmark_limit, deterministic, allow_tf32)
     try:


### PR DESCRIPTION
It seems a little nonsensical to have the `cuDNN` context manager disable `cuDNN` by default, which would make setting the remaining flags useless.

See https://github.com/pytorch/pytorch/blob/7d25a4125180732e8e6882c898bcadd9c9c637a3/test/test_nn.py#L2104 for an example of a nonsense usage. (found by @ptrblck)

Will wait for thorough CI signal in case we uncover real unexpected breakages.

CC @ptrblck @xwang233 @ngimel