### PR TITLE
Restore RNG states for composable reentrant activation checkpointing

### DIFF
--- a/test/distributed/_composable/test_checkpoint.py
+++ b/test/distributed/_composable/test_checkpoint.py
@@ -57,6 +57,16 @@ class ToyModel(nn.Module):
         return self.seq(self.l1(x))
 
 
+class RandomModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.p = nn.Parameter(torch.randn(100, 100))
+
+    def forward(self, x):
+        y = torch.matmul(self.p, torch.randn(100, 100, device=self.p.device))
+        return torch.matmul(x, y)
+
+
 class TestCheckpoint(TestCase):
     def _get_graph_size(self, out: torch.Tensor) -> int:
         q = deque([out.grad_fn])
@@ -119,6 +129,20 @@ class TestCheckpoint(TestCase):
         net = ToyModel().to("cuda:0")
         self._test_tensor_only(net, x, use_reentrant)
 
+    def test_random_cpu(self):
+        x1 = torch.randn(20, 100, requires_grad=True)
+        x2 = x1.clone()
+
+        net1 = RandomModel()
+        net2 = deepcopy(net1)
+
+        cpu_rng_state = torch.get_rng_state()
+        net1(x1).sum().backward()
+        torch.set_rng_state(cpu_rng_state)
+        checkpoint(net2)(x2).sum().backward()
+
+        for p1, p2 in zip(net1.parameters(), net2.parameters()):
+            self.assertEqual(p1.grad, p2.grad)
 
 instantiate_parametrized_tests(TestCheckpoint)
 

--- a/torch/distributed/_composable/checkpoint_activation.py
+++ b/torch/distributed/_composable/checkpoint_activation.py
@@ -1,11 +1,15 @@
-import torch
-import torch.nn as nn
-from torch.utils.checkpoint import detach_variable
-
 from contextlib import contextmanager
 from functools import partial
 from typing import Any, List, Optional, Tuple
-from weakref import ReferenceType, WeakKeyDictionary, ref
+from weakref import ref, ReferenceType, WeakKeyDictionary
+
+import torch
+import torch.nn as nn
+from torch.utils.checkpoint import (
+    detach_variable,
+    get_device_states,
+    set_device_states,
+)
 
 from .contract import contract
 
@@ -66,9 +70,22 @@ class _ModuleHookCheckpointFunction(torch.autograd.Function):
         for i, idx in enumerate(tensor_indices):
             inputs[idx] = tensors[i]
 
-        detached_inputs = detach_variable(tuple(inputs))
-        with torch.enable_grad(), _no_hook(ctx.module):
-            outputs = ctx.module(*detached_inputs)
+        # Stash the surrounding rng state, and mimic the state that was
+        # present at this time during forward.  Restore the surrounding state
+        # when we're done.
+        rng_devices = []
+        if checkpoint.state(ctx.module).had_cuda_in_fwd:
+            rng_devices = checkpoint.state(ctx.module).fwd_gpu_devices
+        with torch.random.fork_rng(devices=rng_devices, enabled=True):
+            torch.set_rng_state(checkpoint.state(ctx.module).fwd_cpu_state)
+            if checkpoint.state(ctx.module).had_cuda_in_fwd:
+                set_device_states(
+                    checkpoint.state(ctx.module).fwd_gpu_devices,
+                    checkpoint.state(ctx.module).fwd_gpu_states,
+                )
+            detached_inputs = detach_variable(tuple(inputs))
+            with torch.enable_grad(), _no_hook(ctx.module):
+                outputs = ctx.module(*detached_inputs)
 
         if isinstance(outputs, torch.Tensor):
             outputs = (outputs,)
@@ -97,7 +114,6 @@ class _ModuleHookCheckpointFunction(torch.autograd.Function):
             inp.grad if isinstance(inp, torch.Tensor) else None
             for inp in detached_inputs
         )
-
         # The two None is for forward argument module and output respectively.
         return (None, None) + grads
 
@@ -205,6 +221,19 @@ def checkpoint(module: nn.Module, *, use_reentrant: bool = True) -> nn.Module:
             checkpoint.state(module).orig_grad_enabled = torch.is_grad_enabled()
             if checkpoint.state(module).use_reentrant:
                 torch.set_grad_enabled(False)
+                checkpoint.state(module).fwd_cpu_state = torch.get_rng_state()
+                # Don't eagerly initialize the cuda context by accident.
+                # (If the user intends that the context is initialized later, within their
+                # run_function, we SHOULD actually stash the cuda state here.  Unfortunately,
+                # we have no way to anticipate this will happen before we run the function.)
+                checkpoint.state(module).had_cuda_in_fwd = False
+                if torch.cuda._initialized:
+                    checkpoint.state(module).had_cuda_in_fwd = True
+                    (
+                        checkpoint.state(module).fwd_gpu_devices,
+                        checkpoint.state(module).fwd_gpu_states,
+                    ) = get_device_states(*inputs)
+
             else:
                 # The Holder object for each of the saved object is saved
                 # directly on the SavedVariable and is cleared when reset_data()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91265

This allows ops like randperm to behave the same during re-computation.

Differential Revision: [D42196758](https://our.internmc.facebook.com/intern/diff/D42196758/)