### PR TITLE
[Composable API] Make _StateKey as a str subclass

### DIFF
--- a/torch/distributed/_composable/contract.py
+++ b/torch/distributed/_composable/contract.py
@@ -1,5 +1,6 @@
+import uuid
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Callable, Dict, List, Optional, Type
 
 import torch.nn as nn
 from torch.distributed._composable_state import _State
@@ -8,11 +9,11 @@ from torch.distributed._composable_state import _State
 # use state_slot as key for module.__dict__ to avoid coliding with other
 # properties.
 # TODO: since all composable distributed features can share the same slot.
-class _StateKey:
-
-    # implement operator < to avoid breaking dir()
-    def __lt__(self, other: Any) -> bool:
-        return True if isinstance(other, str) else id(self) < id(other)
+class _StateKey(str):
+    # Make _StateKey as str to satify the assumption that object.__dict__.keys()
+    # are strings.
+    def __new__(cls, string="__composable_api_state_key"):
+        return super().__new__(cls, f"{string}_{str(uuid.uuid4())}")
 
 
 STATE_KEY = _StateKey()


### PR DESCRIPTION
Summary: The keys in `object.__dict__` should be strings. Make the _StateKey be a `str` subclass.

Test Plan:
CI

```
buck2 test mode/opt //caffe2/torch/fb/module_factory/sync_sgd/tests:test_state_dict_model_tracker -- --exact 'caffe2/torch/fb/module_factory/sync_sgd/tests:test_state_dict_model_tracker - caffe2.torch.fb.module_factory.sync_sgd.tests.test_state_dict_model_tracker.FsdpStateDictModelTrackerSkipChildrenEMATest: test_fsdp_state_dict_model_tracker_1gpu'

Buck UI: https://www.internalfb.com/buck2/044bf818-0cdf-4fd9-ba61-09d91cf02902
Test UI: https://www.internalfb.com/intern/testinfra/testrun/5348024700584258
RE: reSessionID-6256a39c-9465-4e75-8975-131e2f4a6f1d  Up: 1.6 GiB  Down: 4.8 GiB
Jobs completed: 342371. Time elapsed: 974.8s. Cache hits: 93%. Commands: 157223 (cached: 146804, remote: 899, local: 9520)
Tests finished: Pass 2. Fail 0. Fatal 0. Skip 0. 0 builds failed
```

Differential Revision: D42194708

