### PR TITLE
Remove inductor performance from ciflow/nightly as infra is not ready to handle these jobs…

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -3,14 +3,9 @@ name: inductor-A100-perf
 on:
   schedule:
     - cron: 45 1,9,17 * * *
-  push:
-    tags:
-      - ciflow/nightly/*
   pull_request:
     paths:
       - .github/workflows/inductor-perf-test-nightly.yml
-    branches-ignore:
-      - postnightly
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
… yet.

https://github.com/pytorch/pytorch/actions/workflows/inductor-perf-test-nightly.yml currently shows there are several commits waiting for A100 runners but the infra is not able to automatically respond to these dynamic requests. Therefore disabling ciflow/nightly tag and only use scheduled and workflow_dispatch.

Also remove postnightly filter as the [postnightly pull request ](https://github.com/pytorch/pytorch/pull/27167) is no longer running ci tests. 