### PR TITLE
implemented test and Changed assert to TORCH_CHECK #88808

### DIFF
--- a/aten/src/ATen/cuda/detail/TensorInfo.cuh
+++ b/aten/src/ATen/cuda/detail/TensorInfo.cuh
@@ -50,7 +50,7 @@ TensorInfo<T, IndexType>::TensorInfo(T* p,
                                      IndexType st[MAX_TENSORINFO_DIMS]) {
   data = p;
   dims = dim;
-  AT_ASSERT(dims < MAX_TENSORINFO_DIMS);
+  TORCH_CHECK(dims < MAX_TENSORINFO_DIMS, "CUDA Tensors cannot have more than 25 dimensions");
 
   for (int i = 0; i < dim; ++i) {
     sizes[i] = sz[i];

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2393,6 +2393,17 @@ def error_inputs_masked_select(op_info, device, **kwargs):
                      error_type=RuntimeError,
                      error_regex='unsupported operation')
 
+def error_inputs_median(op_info, device, **kwargs):
+    x = torch.tensor([[[[[[[[[[[[[[[[[[[[[[[[[nan],
+                               [nan]]]]]]]]]]]]]]]]]]]]]]]]], device=device)
+    if device == 'cuda':
+        yield ErrorInput(SampleInput(x, kwargs=dict(dim=(-1))),
+                         error_type=RuntimeError,
+                         error_regex='CUDA Tensors cannot have more than 25 dimensions')
+    else:
+        return
+
+
 def error_inputs_index_select(op_info, device, **kwargs):
     x = torch.rand((1, 6), device=device).expand((2, 6))
     y = torch.rand((3, 6), device=device)
@@ -10322,6 +10333,7 @@ op_db: List[OpInfo] = [
            supports_out=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
+           error_inputs_func=error_inputs_median,
            sample_inputs_func=partial(sample_inputs_reduction, supports_multiple_dims=False)),
     OpInfo('nanmedian',
            dtypes=all_types_and(torch.bfloat16),


### PR DESCRIPTION
Fixes #88808
Replaced

`AT_ASSERT(dims < MAX_TENSORINFO_DIMS) `
in aten/src/ATen/cuda/detail/TensorInfo.cuh by

```
  data = p;
  dims = dim;
  TORCH_CHECK(dims < MAX_TENSORINFO_DIMS, "CUDA Tensors cannot have more than 25 dimensions");
    }

```

In : torch/testing/_internal/common_methods_invocations.py

```
def error_inputs_median(op_info, device, **kwargs):
    x = torch.tensor([[[[[[[[[[[[[[[[[[[[[[[[[nan],
                               [nan]]]]]]]]]]]]]]]]]]]]]]]]], device=device)
    if device=='cuda':
        yield ErrorInput(SampleInput(x, kwargs=dict(dim=(-1))),
                        error_type=RuntimeError,
                        error_regex='CUDA Tensors cannot have more than 25 dimensions')
    else:
        return

```
And

```
    OpInfo('median',
           ...
           error_inputs_func=error_inputs_median,
           ...

```