### PR TITLE
[Composable API] Make _StateKey as a str subclass

### DIFF
--- a/torch/distributed/_composable/contract.py
+++ b/torch/distributed/_composable/contract.py
@@ -1,5 +1,6 @@
+import uuid
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Callable, Dict, List, Optional, Type
 
 import torch.nn as nn
 from torch.distributed._composable_state import _State
@@ -8,11 +9,11 @@ from torch.distributed._composable_state import _State
 # use state_slot as key for module.__dict__ to avoid coliding with other
 # properties.
 # TODO: since all composable distributed features can share the same slot.
-class _StateKey:
-
-    # implement operator < to avoid breaking dir()
-    def __lt__(self, other: Any) -> bool:
-        return True if isinstance(other, str) else id(self) < id(other)
+class _StateKey(str):
+    # Make _StateKey as str to satify the assumption that object.__dict__.keys()
+    # are strings.
+    def __new__(cls, string="__composable_api_state_key"):
+        return super().__new__(cls, f"{string}_{str(uuid.uuid4())}")
 
 
 STATE_KEY = _StateKey()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91279

The keys in object.__dict__ should be strings. Make the _StateKey be a str subclass.

Differential Revision: [D42200244](https://our.internmc.facebook.com/intern/diff/D42200244/)