### PR TITLE
[inductor] CI improvments

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -154,10 +154,10 @@ CI_SKIP_OPTIMIZER = {
     "convmixer_768_32",  # accuracy
     "sebotnet33ts_256",  # accuracy
     "hrnet_w18",  # Stack issue in fx
-    "tf_mixnet_l",  # This model is non-deterministic with same input + weights,
+    # "tf_mixnet_l",  # This model is non-deterministic with same input + weights,
     # but without optimizing over multiple iterations, this still passes
-    "mixnet_l",  # same as above
-    "ghostnet_100",  # same as above
+    # "mixnet_l",  # same as above
+    # "ghostnet_100",  # same as above
     # TorchBench
     "dlrm",  # symbolic shapes error
     # HF


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91283

Summary:
1) Setting torch.backends.cudnn.deterministic to True helps to
eliminate the eager_variance failures seen on CI
2) Skip Triton failure instead of retry
3) Some minor script cleanup is also included in this PR.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx