### PR TITLE
feat: adding greater_equal Scalar variant

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
+++ b/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
@@ -124,6 +124,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatchedDecomposition, m) {
   OP_DECOMPOSE2(gradient, tensorarrayint);
   OP_DECOMPOSE2(gradient, tensorarray);
   OP_DECOMPOSE2(greater_equal, Tensor );
+  OP_DECOMPOSE2(greater_equal, Scalar );
   OP_DECOMPOSE2(greater, Tensor );
   OP_DECOMPOSE(grid_sampler);
   OP_DECOMPOSE(group_norm);

--- a/test/functorch/test_vmap_registrations.py
+++ b/test/functorch/test_vmap_registrations.py
@@ -138,7 +138,6 @@ xfail_not_implemented = {
     "aten::greater.Scalar",
     "aten::greater_.Scalar",
     "aten::greater_.Tensor",
-    "aten::greater_equal.Scalar",
     "aten::greater_equal_.Scalar",
     "aten::greater_equal_.Tensor",
     "aten::gru.data",


### PR DESCRIPTION
Fixes https://github.com/pytorch/functorch/issues/1080

```py
import torch
from functorch import vmap

def f(x):
    return torch.greater_equal(torch.cumsum(x, dim=0), .5 * 10)

x = torch.randn([10,10])
vmap(f)(x)
```


