### PR TITLE
[inductor] Fix "RuntimeError: Tried to erase Node permute but it still had 3 users in the graph"

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5452,6 +5452,35 @@ if HAS_CUDA:
 
             self.assertTrue(torch.allclose(module(input), traced(input)))
 
+        @patch.object(config, "permute_fusion", True)
+        def test_permute_fusion(self):
+            class Repro(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+
+                def forward(self, view, reshape_2):
+                    permute = view.permute(0, 2, 1)
+                    view = None
+                    reshape = torch.reshape(permute, (-1, 642))
+                    bmm = torch.bmm(permute, reshape_2)
+                    return (bmm,)
+
+            args = [
+                ((1024, 642, 160), (102720, 160, 1), torch.float32, "cuda", True),
+                ((1024, 642, 20), (12840, 20, 1), torch.float32, "cuda", True),
+            ]
+            args = [
+                rand_strided(sh, st, dt, dev).requires_grad_(rg)
+                for (sh, st, dt, dev, rg) in args
+            ]
+
+            mod = Repro()
+            opt_mod = torch._dynamo.optimize("inductor")(mod)
+
+            ref = mod(*args)
+            res = opt_mod(*args)
+            self.assertTrue(same(ref, res))
+
         @patch.object(config.triton, "autotune", True)
         def test_inplace_add_alpha_autotune(self):
             def fn(x, y):

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -357,7 +357,8 @@ def linear_permute_fusion(module: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     )
                     node.replace_all_uses_with(fused_node)
                     module.graph.erase_node(node)
-                    module.graph.erase_node(input_node)
+                    if len(input_node.users) == 0:
+                        module.graph.erase_node(input_node)
 
     module.graph.lint()
     module.recompile()
@@ -399,7 +400,8 @@ def permute_linear_fusion(module: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     )
                     node.replace_all_uses_with(fused_node)
                     module.graph.erase_node(node)
-                    module.graph.erase_node(input_node)
+                    if len(input_node.users) == 0:
+                        module.graph.erase_node(input_node)
 
     module.graph.lint()
     module.recompile()
@@ -447,9 +449,9 @@ def permute_matmul_fusion(module: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     )
                 node.replace_all_uses_with(fused_node)
                 module.graph.erase_node(node)
-                if Atrans:
+                if Atrans and len(input_A_node.users) == 0:
                     module.graph.erase_node(input_A_node)
-                if Btrans:
+                if Btrans and len(input_B_node.users) == 0:
                     module.graph.erase_node(input_B_node)
 
     module.graph.lint()


### PR DESCRIPTION
Summary: Fix "RuntimeError: Tried to erase Node permute but it still had 3 users in the graph" to unblock internal models

Differential Revision: D42213859



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire