### PR TITLE
Fix wrong committer when rebase and merge

### DIFF
--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -49,20 +49,11 @@ def rebase_ghstack_onto(pr: GitHubPR, repo: GitRepo, onto_branch: str, dry_run: 
     repo.fetch(orig_ref, orig_ref)
     repo._run_git("rebase", onto_branch, orig_ref)
 
-    # Check the configured name and email, and only set them if they are not set. When
-    # tryrebase is used as part of trymerge, the name and email have already been set
-    # by the merge workflow, so trying to set them again here will wrongly make the
-    # committer to be the author of the original branch instead of PyTorch merge bot
-    email = repo._run_git("config", "user.email")
-    name = repo._run_git("config", "user.name")
-
-    if not email or not name:
-        # Steal the identity of the committer of the commit on the orig branch
-        email = repo._run_git("log", orig_ref, "--pretty=format:%ae", "-1")
-        name = repo._run_git("log", orig_ref, "--pretty=format:%an", "-1")
-
-        repo._run_git("config", "--global", "user.email", email)
-        repo._run_git("config", "--global", "user.name", name)
+    # Steal the identity of the committer of the commit on the orig branch
+    email = repo._run_git("log", orig_ref, "--pretty=format:%ae", "-1")
+    name = repo._run_git("log", orig_ref, "--pretty=format:%an", "-1")
+    repo._run_git("config", "--global", "user.email", email)
+    repo._run_git("config", "--global", "user.name", name)
 
     os.environ["OAUTH_TOKEN"] = os.environ["GITHUB_TOKEN"]
     with open('.ghstackrc', 'w+') as f:
@@ -131,16 +122,31 @@ def main() -> None:
         return
 
     try:
+        email = name = ""
+
         if pr.is_ghstack_pr():
+            # Check the configured name and email, and only set them if they are not set. If
+            # they are available, store them so that we can put them back after rebasing here
+            email = repo._run_git("config", "user.email")
+            name = repo._run_git("config", "user.name")
+
             rebase_ghstack_onto(pr, repo, onto_branch, dry_run=args.dry_run)
-            return
-        rebase_onto(pr, repo, onto_branch, dry_run=args.dry_run)
+        else:
+            rebase_onto(pr, repo, onto_branch, dry_run=args.dry_run)
+
     except Exception as e:
         msg = f"Rebase failed due to {e}"
         run_url = os.getenv("GH_RUN_URL")
         if run_url is not None:
             msg += f"\nRaised by {run_url}"
         gh_post_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
+
+    finally:
+        if email:
+            repo._run_git("config", "--global", "user.email", email)
+
+        if name:
+            repo._run_git("config", "--global", "user.name", name)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -125,8 +125,8 @@ def main() -> None:
         email = name = ""
 
         if pr.is_ghstack_pr():
-            # Check the configured name and email, and only set them if they are not set. If
-            # they are available, store them so that we can put them back after rebasing here
+            # Check the configured name and email. If they are available, store them so that
+            # we can put them back after rebasing here
             email = repo._run_git("config", "user.email")
             name = repo._run_git("config", "user.name")
 


### PR DESCRIPTION
When using in the context of the merge workflow, the committer's name and email have already been set as part of the workflow, i.e. https://github.com/pytorch/pytorch/actions/runs/3754075933/jobs/6377965897:

```
git config --global user.email "pytorchmergebot@users.noreply.github.com"
git config --global user.name "PyTorch MergeBot"
```

Trying to overwrite this in tryrebase's ghstack logic would lead to the wrong committer showing up.  The fix check if the email and name have already been set so that the code doesn't overwrite them.