### PR TITLE
Fix for tryrebase after PR was merged

### DIFF
--- a/.github/scripts/test_tryrebase.py
+++ b/.github/scripts/test_tryrebase.py
@@ -3,10 +3,11 @@ from test_trymerge import mocked_gh_graphql
 from trymerge import GitHubPR
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from typing import Any
-from tryrebase import rebase_onto
+from tryrebase import rebase_onto, rebase_ghstack_onto
 
 def mocked_rev_parse(branch: str) -> str:
     return branch
+
 class TestRebase(TestCase):
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
@@ -57,6 +58,18 @@ class TestRebase(TestCase):
         self.assertTrue(
             "Tried to rebase and push PR #31093, but it was already up to date" in mocked_post_comment.call_args[0][3])
 
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    @mock.patch('gitutils.GitRepo._run_git')
+    @mock.patch('gitutils.GitRepo.rev_parse', side_effect=lambda branch: "same sha")
+    @mock.patch('tryrebase.gh_post_comment')
+    def test_same_sha(self, mocked_post_comment: Any, mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
+        "Tests rebase results in same sha"
+        pr = GitHubPR("pytorch", "pytorch", 31093)
+        repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+        with self.assertRaisesRegex(Exception, 'same sha as the target branch'):
+            rebase_onto(pr, repo, 'master')
+        with self.assertRaisesRegex(Exception, 'same sha as the target branch'):
+            rebase_ghstack_onto(pr, repo, 'master')
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_tryrebase.py
+++ b/.github/scripts/test_tryrebase.py
@@ -5,13 +5,15 @@ from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from typing import Any
 from tryrebase import rebase_onto
 
-
+def mocked_rev_parse(branch: str) -> str:
+    return branch
 class TestRebase(TestCase):
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
     @mock.patch('gitutils.GitRepo._run_git')
+    @mock.patch('gitutils.GitRepo.rev_parse', side_effect=mocked_rev_parse)
     @mock.patch('tryrebase.gh_post_comment')
-    def test_rebase(self, mocked_post_comment: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
+    def test_rebase(self, mocked_post_comment: Any,  mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
         "Tests rebase successfully"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
@@ -25,8 +27,9 @@ class TestRebase(TestCase):
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
     @mock.patch('gitutils.GitRepo._run_git')
+    @mock.patch('gitutils.GitRepo.rev_parse', side_effect=mocked_rev_parse)
     @mock.patch('tryrebase.gh_post_comment')
-    def test_rebase_to_stable(self, mocked_post_comment: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
+    def test_rebase_to_stable(self, mocked_post_comment: Any, mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
         "Tests rebase to viable/strict successfully"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
@@ -40,8 +43,9 @@ class TestRebase(TestCase):
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
     @mock.patch('gitutils.GitRepo._run_git', return_value="Everything up-to-date")
+    @mock.patch('gitutils.GitRepo.rev_parse', side_effect=mocked_rev_parse)
     @mock.patch('tryrebase.gh_post_comment')
-    def test_no_need_to_rebase(self, mocked_post_comment: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
+    def test_no_need_to_rebase(self, mocked_post_comment: Any,  mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
         "Tests branch already up to date"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())

--- a/.github/scripts/test_tryrebase.py
+++ b/.github/scripts/test_tryrebase.py
@@ -13,7 +13,7 @@ class TestRebase(TestCase):
     @mock.patch('gitutils.GitRepo._run_git')
     @mock.patch('gitutils.GitRepo.rev_parse', side_effect=mocked_rev_parse)
     @mock.patch('tryrebase.gh_post_comment')
-    def test_rebase(self, mocked_post_comment: Any,  mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
+    def test_rebase(self, mocked_post_comment: Any, mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
         "Tests rebase successfully"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
@@ -45,7 +45,7 @@ class TestRebase(TestCase):
     @mock.patch('gitutils.GitRepo._run_git', return_value="Everything up-to-date")
     @mock.patch('gitutils.GitRepo.rev_parse', side_effect=mocked_rev_parse)
     @mock.patch('tryrebase.gh_post_comment')
-    def test_no_need_to_rebase(self, mocked_post_comment: Any,  mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
+    def test_no_need_to_rebase(self, mocked_post_comment: Any, mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
         "Tests branch already up to date"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -10,7 +10,7 @@ from trymerge import gh_post_pr_comment as gh_post_comment, GitHubPR
 
 SAME_SHA_ERROR = (
     "\n```\nAborting rebase because rebasing the branch resulted in the same sha as the target branch.\n" +
-    "This usually happens because the PR was already been merged.  Please rebase locally and push.\n```"
+    "This usually happens because the PR has already been merged.  Please rebase locally and push.\n```"
 )
 
 def parse_args() -> Any:


### PR DESCRIPTION
rebasing certain merged prs results in the rebased branch pointing at the target branch b/c git believes the pr has already been included in the branch.  Git does not replay the changes onto the target branch because the change is already in the target branch

This usually affects PRs with only 1 commit (more commits -> trymerge squashes them when merged -> git believes that the change is not in the target branch b/c the squashed commit is different from the individual changes).

It might also affect ghstack changes b/c behind the scenes the ghstack PRs are all contained within one commit on the orig branch, but I'm not sure about this.

helps w/ https://github.com/pytorch/test-infra/issues/836
looks like https://github.com/clee2000/random-testing/pull/44#issuecomment-1363439534