### PR TITLE
[SDPA] implement ordering

### DIFF
--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -1,5 +1,8 @@
 #pragma once
+#include <cstdint>
 namespace sdp {
+
+constexpr int32_t num_backends = 3;
 enum class SDPBackend {
   error = -1,
   math = 0,


### PR DESCRIPTION
# Summary

In some cases, dependent on input, flash-attention is not the fastest fused kernel and memory-efficient attention is better. This implements a simple heuristic function for deciding the ordering of kernel functions.  This was based off of the xformer function found here: https://github.com/fairinternal/xformers/blob/15bff4986c3a4376176a4e6fa3dc0f2a120fa0bb/xformers/ops/fmha/dispatch.py#L13

cc @ngimel