### PR TITLE
Make input casting in root module only in default

### DIFF
--- a/test/distributed/_composable/test_fully_shard.py
+++ b/test/distributed/_composable/test_fully_shard.py
@@ -540,7 +540,7 @@ class TestMixedPrecision(FSDPTest):
     @skip_if_lt_x_gpu(2)
     def test_float16_on_one_submodule(self):
         forward_inputs: Dict[nn.Module, torch.Tensor] = {}
-        float16 = MixedPrecision(param_dtype=torch.float16)
+        float16 = MixedPrecision(param_dtype=torch.float16, cast_forward_inputs=True)
 
         model = SaveForwardInputsModel(
             forward_inputs=forward_inputs,

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -509,6 +509,12 @@ def _root_pre_forward(
     args = args_tuple[0]
     kwargs = kwargs_tuple[0]
 
+    input_dtype: Optional[torch.dtype] = state.mixed_precision.param_dtype
+
+    if state.mixed_precision.cast_root_forward_inputs:
+        args, kwargs = _cast_forward_inputs(
+            input_dtype, *args, **kwargs
+        )
     return args, kwargs
 
 


### PR DESCRIPTION
Make input casting in root module only in default, meanwhile allowing to set different mixed precisions for different submodules