### PR TITLE
[Inductor] Support loop split at given depth in CPP codegen

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5140,7 +5140,6 @@ if HAS_CPU:
                 real_out = fn(value)
                 compiled_out = opt_fn(value)
                 assert same(real_out, compiled_out, equal_nan=True)
-                assert metrics.generated_cpp_vec_kernel_count < 1
 
         @unittest.skipIf(
             not codecache.valid_vec_isa_list(), "Does not support vectorization"

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1513,10 +1513,11 @@ class LoopNestWithSplit:
 
     @cache_on_self
     def max_parallel_depth(self):
-        """Maximal allowed depth for parallelism. That is to the levels without splitting."""
+        """Maximal allowed depth for parallelism: 1) Levels without splitting and 2) All reduction or non-reduction levels"""
         max_depth = 0
         loops = self.root
-        while len(loops) == 1:
+        is_reduction = loops[0].is_reduction() if loops else False
+        while len(loops) == 1 and loops[0].is_reduction() == is_reduction:
             max_depth += 1
             loops = loops[0].inner
         return max_depth

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -684,10 +684,9 @@ class CppKernel(Kernel):
 
             def gen_kernel(kernel):
                 assert kernel
-                with contextlib.ExitStack() as stack:
-                    code.splice(kernel.loads)
-                    code.splice(kernel.compute)
-                    code.splice(kernel.stores)
+                code.splice(kernel.loads)
+                code.splice(kernel.compute)
+                code.splice(kernel.stores)
 
             def gen_loops(loop, in_reduction=False):
                 kernel = loop.get_kernel()
@@ -715,6 +714,7 @@ class CppKernel(Kernel):
                     if loop.is_reduction() and not in_reduction:
                         code.splice(kernel.reduction_suffix)
             
+            stack.enter_context(code.indent())
             if loop_nest.root:
                 for loop in loop_nest.root:
                     gen_loops(loop)


### PR DESCRIPTION
Moved to https://github.com/pytorch/pytorch/pull/91397 with ghstack.

This PR refactors the loop related data structure to support the loop split at a given depth. Before this PR, the loop split is always supported at the inner-most level. With this PR, it is possible to support tiling at outer levels and at more than one levels. The `LoopNest` data structure is extended to support loop splits at various levels and renamed to `LoopNestWithSplit`. The `codegen_loops` function is also rewritten to be general to support arbitrary kernels set at the leaves of the loop structure.

This PR also improves the handling of reduction loops with split. The main loop and tail loop now work on their own reduction variables in parallel without data dependency as previous do. With this, two workarounds can be removed in the `CppVecKernel`.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire