### PR TITLE
Add `device_idx` to `free_fn` in `CUDAPluggableAllocator`

### DIFF
--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -475,7 +475,7 @@ traces all the memory operations.
       return ptr;
    }
 
-   void my_free(void* ptr, ssize_t size, cudaStream_t stream) {
+   void my_free(void* ptr, ssize_t size, int device, cudaStream_t stream) {
       std::cout<<"free "<<ptr<< " "<<stream<<std::endl;
       cudaFree(ptr);
    }

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -12,14 +12,14 @@ int device_count = 0;
 
 void custom_raw_deleter(void* ptr);
 
-_AllocationMetadata::_AllocationMetadata() : size(0), device_idx(-1), stream(0) {
-}
+_AllocationMetadata::_AllocationMetadata()
+    : size(0), device_idx(-1), stream(0) {}
 
 _AllocationMetadata::_AllocationMetadata(
     size_t size,
     int device_idx,
-    cudaStream_t stream) : size(size), device_idx(device_idx), stream(stream) { 
-}
+    cudaStream_t stream)
+    : size(size), device_idx(device_idx), stream(stream) {}
 
 // This is a fast API to just register allocators
 // based on function pointers (ie. external .so libraries)

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -12,13 +12,22 @@ int device_count = 0;
 
 void custom_raw_deleter(void* ptr);
 
+_AllocationMetadata::_AllocationMetadata() : size(0), device_idx(-1), stream(0) {
+}
+
+_AllocationMetadata::_AllocationMetadata(
+    size_t size,
+    int device_idx,
+    cudaStream_t stream) : size(size), device_idx(device_idx), stream(stream) { 
+}
+
 // This is a fast API to just register allocators
 // based on function pointers (ie. external .so libraries)
 // This avoids having to link against libtorch for C++ based custom allocators
 // And also use this from python
 CUDAPluggableAllocator::CUDAPluggableAllocator(
     std::function<void*(size_t, int, cudaStream_t)> alloc_fn,
-    std::function<void(void*, size_t, cudaStream_t)> free_fn)
+    std::function<void(void*, size_t, int, cudaStream_t)> free_fn)
     : alloc_fn_(alloc_fn), free_fn_(free_fn) {}
 
 CUDAPluggableAllocator::CUDAPluggableAllocator(CUDAPluggableAllocator& other)
@@ -85,7 +94,7 @@ void* CUDAPluggableAllocator::malloc(
   void* r = alloc_fn_(size, device, stream);
   {
     const std::lock_guard<std::mutex> lock(allocator_mutex_);
-    allocation_metadata_.emplace(r, std::make_pair(size, stream));
+    allocation_metadata_.emplace(r, _AllocationMetadata(size, device, stream));
   }
   return r;
 }
@@ -122,18 +131,20 @@ void* CUDAPluggableAllocator::raw_alloc_with_stream(
 
 void CUDAPluggableAllocator::raw_delete(void* ptr) {
   cudaStream_t stream;
+  int device_idx;
   size_t size;
   {
     const std::lock_guard<std::mutex> lock(allocator_mutex_);
     TORCH_CHECK(
         allocation_metadata_.count(ptr),
         "Trying to free a pointer not allocated here");
-    auto pair = allocation_metadata_[ptr];
-    size = pair.first;
-    stream = pair.second;
+    _AllocationMetadata& metadata = allocation_metadata_[ptr];
+    size = metadata.size;
+    device_idx = metadata.device_idx;
+    stream = metadata.stream;
     allocation_metadata_.erase(ptr);
   }
-  free_fn_(ptr, size, stream);
+  free_fn_(ptr, size, device_idx, stream);
 }
 
 void CUDAPluggableAllocator::init(int device_count) {
@@ -292,7 +303,7 @@ getCurrentAllocator() {
 std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
 createCustomAllocator(
     std::function<void*(size_t, int, cudaStream_t)> alloc_fn,
-    std::function<void(void*, size_t, cudaStream_t)> free_fn) {
+    std::function<void(void*, size_t, int, cudaStream_t)> free_fn) {
   std::shared_ptr<CUDAPluggableAllocator> allocator(
       new CUDAPluggableAllocator(alloc_fn, free_fn));
   allocator->init(device_count);

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -27,15 +27,25 @@ getCurrentAllocator();
 std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
 createCustomAllocator(
     std::function<void*(size_t, int, cudaStream_t)> alloc_fn,
-    std::function<void(void*, size_t, cudaStream_t)> free_fn);
+    std::function<void(void*, size_t, int, cudaStream_t)> free_fn);
 void changeCurrentAllocator(
     std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator> allocator);
+
+
+struct _AllocationMetadata {
+   _AllocationMetadata();
+   _AllocationMetadata(size_t size, int device_idx, cudaStream_t stream);
+   size_t size;
+   int device_idx;
+   cudaStream_t stream;
+};
+
 
 struct CUDAPluggableAllocator
     : public c10::cuda::CUDACachingAllocator::CUDAAllocator {
   CUDAPluggableAllocator(
       std::function<void*(size_t, int, cudaStream_t)> alloc_fn,
-      std::function<void(void*, size_t, cudaStream_t)> free_fn);
+      std::function<void(void*, size_t, int, cudaStream_t)> free_fn);
 
   CUDAPluggableAllocator(CUDAPluggableAllocator& other);
 
@@ -112,7 +122,7 @@ struct CUDAPluggableAllocator
 
  protected:
   std::function<void*(size_t, int, cudaStream_t)> alloc_fn_;
-  std::function<void(void*, size_t, cudaStream_t)> free_fn_;
+  std::function<void(void*, size_t, int, cudaStream_t)> free_fn_;
   std::function<void(int)> init_fn_;
   std::function<void()> reset_fn_;
   std::function<void(double, int)> memory_fraction_fn_;
@@ -125,7 +135,7 @@ struct CUDAPluggableAllocator
   std::function<void(int, c10::cuda::MempoolId_t)> capture_destroy_fn_;
   std::mutex allocator_mutex_;
   // We do the bookeeping here in order to simplify custom allocators
-  std::unordered_map<void*, std::pair<size_t, cudaStream_t>>
+  std::unordered_map<void*, _AllocationMetadata>
       allocation_metadata_;
 
   bool initialized_ = false;

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -31,15 +31,13 @@ createCustomAllocator(
 void changeCurrentAllocator(
     std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator> allocator);
 
-
 struct _AllocationMetadata {
-   _AllocationMetadata();
-   _AllocationMetadata(size_t size, int device_idx, cudaStream_t stream);
-   size_t size;
-   int device_idx;
-   cudaStream_t stream;
+  _AllocationMetadata();
+  _AllocationMetadata(size_t size, int device_idx, cudaStream_t stream);
+  size_t size;
+  int device_idx;
+  cudaStream_t stream;
 };
-
 
 struct CUDAPluggableAllocator
     : public c10::cuda::CUDACachingAllocator::CUDAAllocator {
@@ -135,8 +133,7 @@ struct CUDAPluggableAllocator
   std::function<void(int, c10::cuda::MempoolId_t)> capture_destroy_fn_;
   std::mutex allocator_mutex_;
   // We do the bookeeping here in order to simplify custom allocators
-  std::unordered_map<void*, _AllocationMetadata>
-      allocation_metadata_;
+  std::unordered_map<void*, _AllocationMetadata> allocation_metadata_;
 
   bool initialized_ = false;
 };

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -960,7 +960,7 @@ static void registerCudaPluggableAllocator(PyObject* module) {
           });
   m.def("_cuda_customAllocator", [](uint64_t malloc_ptr, uint64_t free_ptr) {
     using MallocFuncType = void*(size_t, int, cudaStream_t);
-    using FreeFuncType = void(void*, size_t, cudaStream_t);
+    using FreeFuncType = void(void*, size_t, int, cudaStream_t);
     std::function<MallocFuncType> malloc_fn =
         reinterpret_cast<MallocFuncType*>(malloc_ptr);
     std::function<FreeFuncType> free_fn =


### PR DESCRIPTION
cc @shwina @leofang 

This was requested by nvidia folks, track also the device_id in the free function.