### PR TITLE
initialise the members boolean_ and integer_ of at::indexing::TensorIndex

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -195,8 +195,8 @@ struct TORCH_API TensorIndex final {
   }
 
  private:
-  int64_t integer_;
-  bool boolean_;
+  int64_t integer_ = 0;
+  bool boolean_ = false;
   Slice slice_;
   Tensor tensor_;
   TensorIndexType type_;


### PR DESCRIPTION
initialise the members boolean_ and integer_ of at::indexing::TensorIndex to false and 0 respectively, because the compiler generated copy-ctor accesses them which is UB.  This resolves a compile time warning, a runtime error from UBSan + gcc, and a runtime error from MSVC when compiling debug.

Fixes #90951 
