### PR TITLE
Make the state dict of CyclicLR scheduler pickleable

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -5,6 +5,7 @@ import math
 import unittest
 import functools
 import itertools
+import pickle
 from copy import deepcopy
 
 import torch
@@ -3157,6 +3158,11 @@ class TestLRScheduler(TestCase):
         ref = test()
         assert ref() is None
         gc.enable()
+
+    def test_cycle_lr_state_dict_picklable(self):
+        adam_opt = optim.Adam(self.net.parameters())
+        scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False)
+        pickle.dumps(scheduler.state_dict())
 
     def test_onecycle_lr_invalid_anneal_strategy(self):
         with self.assertRaises(ValueError):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -3170,7 +3170,7 @@ class TestLRScheduler(TestCase):
 
     def test_cycle_lr_scale_fn_restored_from_state_dict(self):
         adam_opt = optim.Adam(self.net.parameters())
-        
+
         # Case 1: Built-in mode
         scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False, mode="triangular2")
         restored_scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False)
@@ -3178,13 +3178,15 @@ class TestLRScheduler(TestCase):
         assert restored_scheduler.mode == scheduler.mode == "triangular2"
         assert restored_scheduler._scale_fn_ref is not None and scheduler._scale_fn_ref is not None
         assert restored_scheduler._scale_fn_custom is scheduler._scale_fn_custom is None
-        
+
         # Case 2: Custom `scale_fn`
-        scale_fn = lambda _: 0.5
+        def scale_fn(_):
+            return 0.5
+
         scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False, scale_fn=scale_fn)
         restored_scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False, scale_fn=scale_fn)
         restored_scheduler.load_state_dict(scheduler.state_dict())
-        assert scheduler._scale_fn_custom is scale_fn 
+        assert scheduler._scale_fn_custom is scale_fn
         assert restored_scheduler._scale_fn_custom is scale_fn
 
     def test_onecycle_lr_invalid_anneal_strategy(self):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -3163,9 +3163,9 @@ class TestLRScheduler(TestCase):
     def test_cycle_lr_state_dict_picklable(self):
         adam_opt = optim.Adam(self.net.parameters())
         scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False)
-        assert isinstance(scheduler._scale_fn_ref, weakref.WeakMethod)
+        self.assertIsInstance(scheduler._scale_fn_ref, weakref.WeakMethod)
         state = scheduler.state_dict()
-        assert "_scale_fn_ref" not in state
+        self.assertNotIn("_scale_fn_ref", state)
         pickle.dumps(state)
 
     def test_cycle_lr_scale_fn_restored_from_state_dict(self):
@@ -3175,9 +3175,10 @@ class TestLRScheduler(TestCase):
         scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False, mode="triangular2")
         restored_scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False)
         restored_scheduler.load_state_dict(scheduler.state_dict())
-        assert restored_scheduler.mode == scheduler.mode == "triangular2"
-        assert restored_scheduler._scale_fn_ref is not None and scheduler._scale_fn_ref is not None
-        assert restored_scheduler._scale_fn_custom is scheduler._scale_fn_custom is None
+        self.assertTrue(restored_scheduler.mode == scheduler.mode == "triangular2")
+        self.assertIsNotNone(restored_scheduler._scale_fn_ref) and self.assertIsNotNone(scheduler._scale_fn_ref)
+        self.assertIs(restored_scheduler._scale_fn_custom, None)
+        self.assertIs(scheduler._scale_fn_custom, None)
 
         # Case 2: Custom `scale_fn`
         def scale_fn(_):
@@ -3186,8 +3187,8 @@ class TestLRScheduler(TestCase):
         scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False, scale_fn=scale_fn)
         restored_scheduler = CyclicLR(adam_opt, base_lr=1, max_lr=5, cycle_momentum=False, scale_fn=scale_fn)
         restored_scheduler.load_state_dict(scheduler.state_dict())
-        assert scheduler._scale_fn_custom is scale_fn
-        assert restored_scheduler._scale_fn_custom is scale_fn
+        self.assertIs(scheduler._scale_fn_custom, scale_fn)
+        self.assertIs(restored_scheduler._scale_fn_custom, scale_fn)
 
     def test_onecycle_lr_invalid_anneal_strategy(self):
         with self.assertRaises(ValueError):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1220,21 +1220,10 @@ class CyclicLR(LRScheduler):
         self.mode = mode
         self.gamma = gamma
 
-        if scale_fn is None:
-            self._scale_fn_custom = None
-            if self.mode == 'triangular':
-                self._scale_fn_ref = weakref.WeakMethod(self._triangular_scale_fn)
-                self.scale_mode = 'cycle'
-            elif self.mode == 'triangular2':
-                self._scale_fn_ref = weakref.WeakMethod(self._triangular2_scale_fn)
-                self.scale_mode = 'cycle'
-            elif self.mode == 'exp_range':
-                self._scale_fn_ref = weakref.WeakMethod(self._exp_range_scale_fn)
-                self.scale_mode = 'iterations'
-        else:
-            self._scale_fn_custom = scale_fn
-            self._scale_fn_ref = None
-            self.scale_mode = scale_mode
+        self._scale_fn_ref = None
+        self._scale_fn_custom = scale_fn
+        self.scale_mode = scale_mode
+        self._init_scale_fn()
 
         self.cycle_momentum = cycle_momentum
         if cycle_momentum:
@@ -1250,6 +1239,19 @@ class CyclicLR(LRScheduler):
 
         super(CyclicLR, self).__init__(optimizer, last_epoch, verbose)
         self.base_lrs = base_lrs
+
+    def _init_scale_fn(self):
+        if self._scale_fn_custom is not None:
+            return
+        if self.mode == 'triangular':
+            self._scale_fn_ref = weakref.WeakMethod(self._triangular_scale_fn)
+            self.scale_mode = 'cycle'
+        elif self.mode == 'triangular2':
+            self._scale_fn_ref = weakref.WeakMethod(self._triangular2_scale_fn)
+            self.scale_mode = 'cycle'
+        elif self.mode == 'exp_range':
+            self._scale_fn_ref = weakref.WeakMethod(self._exp_range_scale_fn)
+            self.scale_mode = 'iterations'
 
     def _format_param(self, name, optimizer, param):
         """Return correctly formatted lr/momentum for each param group."""
@@ -1318,6 +1320,14 @@ class CyclicLR(LRScheduler):
                 param_group['momentum'] = momentum
 
         return lrs
+
+    def state_dict(self):
+        return {key: value for key, value in self.__dict__.items() if key not in ("optimizer", "_scale_fn_ref")}
+
+    def load_state_dict(self, state_dict):
+        self.__dict__.update(state_dict)
+        self._init_scale_fn()
+
 
 
 class CosineAnnealingWarmRestarts(LRScheduler):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1322,8 +1322,8 @@ class CyclicLR(LRScheduler):
         return lrs
 
     def state_dict(self):
-        # We are dropping the `_scale_fn_ref` attribute because it is a `weakref.WeakMethod` and can't be pickled
         state = super().state_dict()
+        # We are dropping the `_scale_fn_ref` attribute because it is a `weakref.WeakMethod` and can't be pickled
         state.pop("_scale_fn_ref")
         return state
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1323,10 +1323,12 @@ class CyclicLR(LRScheduler):
 
     def state_dict(self):
         # We are dropping the `_scale_fn_ref` attribute because it is a `weakref.WeakMethod` and can't be pickled
-        return {key: value for key, value in self.__dict__.items() if key not in ("optimizer", "_scale_fn_ref")}
+        state = super().state_dict()
+        state.pop("_scale_fn_ref")
+        return state
 
     def load_state_dict(self, state_dict):
-        self.__dict__.update(state_dict)
+        super().load_state_dict(state_dict)
         self._init_scale_fn()
 
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1322,6 +1322,7 @@ class CyclicLR(LRScheduler):
         return lrs
 
     def state_dict(self):
+        # We are dropping the `_scale_fn_ref` attribute because it is a `weakref.WeakMethod` and can't be pickled
         return {key: value for key, value in self.__dict__.items() if key not in ("optimizer", "_scale_fn_ref")}
 
     def load_state_dict(self, state_dict):


### PR DESCRIPTION
Fixes #90414

This PR drops the unpicklable `weakref.WeakMethod` object from CyclicLR scheduler from the state dict, and re-inits the object again once the state dict gets loaded. This makes the state picklable so you can include it in your checkpoint. Also fixes https://github.com/Lightning-AI/lightning/issues/15901

A simple test was added that `pickle.dumps(state)` the state.
