### PR TITLE
Add missing overload for ivalue toSym(Int|Float)

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -574,7 +574,8 @@ public:
     return Tag::SymInt == tag;
   }
 
-  c10::SymInt toSymInt() const;
+  c10::SymInt toSymInt() const&;
+  c10::SymInt toSymInt() &&;
 
   IValue(c10::SymFloat i) {
     if (i.is_symbolic()) {
@@ -590,7 +591,8 @@ public:
     return Tag::SymFloat == tag;
   }
 
-  c10::SymFloat toSymFloat() const;
+  c10::SymFloat toSymFloat() const&;
+  c10::SymFloat toSymFloat() &&;
 
   // allow you to pass literals (3, 4) without ambiguity
   IValue(int32_t i) : IValue(static_cast<int64_t>(i)) {}

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -574,8 +574,8 @@ public:
     return Tag::SymInt == tag;
   }
 
-  c10::SymInt toSymInt() const&;
   c10::SymInt toSymInt() &&;
+  c10::SymInt toSymInt() const&;
 
   IValue(c10::SymFloat i) {
     if (i.is_symbolic()) {
@@ -591,8 +591,8 @@ public:
     return Tag::SymFloat == tag;
   }
 
-  c10::SymFloat toSymFloat() const&;
   c10::SymFloat toSymFloat() &&;
+  c10::SymFloat toSymFloat() const&;
 
   // allow you to pass literals (3, 4) without ambiguity
   IValue(int32_t i) : IValue(static_cast<int64_t>(i)) {}

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -216,7 +216,7 @@ inline at::Generator IValue::toGenerator() const& {
   AT_ASSERT(isGenerator(), "Expected Generator but got ", tagKind());
   return at::Generator(toIntrusivePtr<at::GeneratorImpl>());
 }
-inline c10::SymInt IValue::toSymInt() const {
+inline c10::SymInt IValue::toSymInt() const& {
   AT_ASSERT(isSymInt() || isInt(), "Expected SymInt or int but got ", tagKind());
   if (isSymInt()) {
     return c10::SymInt(toIntrusivePtr<c10::SymNodeImpl>());
@@ -225,10 +225,28 @@ inline c10::SymInt IValue::toSymInt() const {
   }
 }
 
-inline c10::SymFloat IValue::toSymFloat() const {
+inline c10::SymInt IValue::toSymInt() && {
+  AT_ASSERT(isSymInt() || isInt(), "Expected SymInt or int but got ", tagKind());
+  if (isSymInt()) {
+    return c10::SymInt(moveToIntrusivePtr<c10::SymNodeImpl>());
+  } else {
+    return c10::SymInt(payload.u.as_int);
+  }
+}
+
+inline c10::SymFloat IValue::toSymFloat() const& {
   AT_ASSERT(isSymFloat() || isDouble(), "Expected SymFloat or double but got ", tagKind());
   if (isSymFloat()) {
     return c10::SymFloat(toIntrusivePtr<c10::SymNodeImpl>());
+  } else {
+    return c10::SymFloat(payload.u.as_double);
+  }
+}
+
+inline c10::SymFloat IValue::toSymFloat() && {
+  AT_ASSERT(isSymFloat() || isDouble(), "Expected SymFloat or double but got ", tagKind());
+  if (isSymFloat()) {
+    return c10::SymFloat(moveToIntrusivePtr<c10::SymNodeImpl>());
   } else {
     return c10::SymFloat(payload.u.as_double);
   }

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -216,15 +216,6 @@ inline at::Generator IValue::toGenerator() const& {
   AT_ASSERT(isGenerator(), "Expected Generator but got ", tagKind());
   return at::Generator(toIntrusivePtr<at::GeneratorImpl>());
 }
-inline c10::SymInt IValue::toSymInt() const& {
-  AT_ASSERT(isSymInt() || isInt(), "Expected SymInt or int but got ", tagKind());
-  if (isSymInt()) {
-    return c10::SymInt(toIntrusivePtr<c10::SymNodeImpl>());
-  } else {
-    return c10::SymInt(payload.u.as_int);
-  }
-}
-
 inline c10::SymInt IValue::toSymInt() && {
   AT_ASSERT(isSymInt() || isInt(), "Expected SymInt or int but got ", tagKind());
   if (isSymInt()) {
@@ -233,20 +224,26 @@ inline c10::SymInt IValue::toSymInt() && {
     return c10::SymInt(payload.u.as_int);
   }
 }
-
-inline c10::SymFloat IValue::toSymFloat() const& {
-  AT_ASSERT(isSymFloat() || isDouble(), "Expected SymFloat or double but got ", tagKind());
-  if (isSymFloat()) {
-    return c10::SymFloat(toIntrusivePtr<c10::SymNodeImpl>());
+inline c10::SymInt IValue::toSymInt() const& {
+  AT_ASSERT(isSymInt() || isInt(), "Expected SymInt or int but got ", tagKind());
+  if (isSymInt()) {
+    return c10::SymInt(toIntrusivePtr<c10::SymNodeImpl>());
   } else {
-    return c10::SymFloat(payload.u.as_double);
+    return c10::SymInt(payload.u.as_int);
   }
 }
-
 inline c10::SymFloat IValue::toSymFloat() && {
   AT_ASSERT(isSymFloat() || isDouble(), "Expected SymFloat or double but got ", tagKind());
   if (isSymFloat()) {
     return c10::SymFloat(moveToIntrusivePtr<c10::SymNodeImpl>());
+  } else {
+    return c10::SymFloat(payload.u.as_double);
+  }
+}
+inline c10::SymFloat IValue::toSymFloat() const& {
+  AT_ASSERT(isSymFloat() || isDouble(), "Expected SymFloat or double but got ", tagKind());
+  if (isSymFloat()) {
+    return c10::SymFloat(toIntrusivePtr<c10::SymNodeImpl>());
   } else {
     return c10::SymFloat(payload.u.as_double);
   }

--- a/c10/core/SymNodeImpl.h
+++ b/c10/core/SymNodeImpl.h
@@ -14,7 +14,7 @@ using SymNode = c10::intrusive_ptr<SymNodeImpl>;
 
 class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
  public:
-  virtual ~SymNodeImpl(){};
+  virtual ~SymNodeImpl() = default;
 
   template <typename T>
   c10::intrusive_ptr<T> dyn_cast() const {

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -678,7 +678,7 @@ std::pair<std::shared_ptr<Operator>, Stack> getOpWithStack(
     stack = createStackForSchema(
         op->schema(), std::move(args), kwargs, c10::nullopt);
 
-    return std::make_pair(op, stack);
+    return std::make_pair(std::move(op), std::move(stack));
   } else {
     std::vector<schema_match_error> errors;
     std::shared_ptr<Operator> found_op = nullptr;
@@ -700,7 +700,7 @@ std::pair<std::shared_ptr<Operator>, Stack> getOpWithStack(
       throw std::runtime_error(ss.str());
     }
 
-    return std::make_pair(found_op, stack);
+    return std::make_pair(std::move(found_op), std::move(stack));
   }
 }
 

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -656,9 +656,9 @@ py::object toPyObject(IValue ivalue) {
     TORCH_CHECK(false, "RRef is only supported with the distributed package");
 #endif
   } else if (ivalue.isSymInt()) {
-    return py::cast(ivalue.toSymInt());
+    return py::cast(std::move(ivalue).toSymInt());
   } else if (ivalue.isSymFloat()) {
-    return py::cast(ivalue.toSymFloat());
+    return py::cast(std::move(ivalue).toSymFloat());
   } else {
     AT_ERROR(
         "Missing cases in 'toPyObject'! Can't convert ",

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -535,9 +535,9 @@ py::object toPyObject(IValue ivalue) {
       return py::cast(autograd::Variable(std::move(tensor)));
     }
   } else if (ivalue.isStorage()) {
-    return py::cast(ivalue.toStorage());
+    return py::cast(std::move(ivalue).toStorage());
   } else if (ivalue.isGenerator()) {
-    return py::cast(ivalue.toGenerator());
+    return py::cast(std::move(ivalue).toGenerator());
   } else if (ivalue.isDouble()) {
     return py::cast(std::move(ivalue).toDouble());
   } else if (ivalue.isComplexDouble()) {


### PR DESCRIPTION
Noticed the toSymFloat / toSymInt overloads always copied the internal pointer of an ivalue even if it was an rvalue unlike other overloads (like toTensor). This fixes that issue by adding the appropriate methods needed to facilitate that.
