### PR TITLE
[FSDP][Easy] Fix context manager syntax

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -859,11 +859,12 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         # override `_apply()` to have the storage change directly performed on
         # the `FlatParameter`s instead of applying to the original parameters
         # and then writing back to the `FlatParameter`s.
-        with (
+        context = (
             self._deregister_orig_params_ctx()
             if self._use_orig_params
             else contextlib.suppress()
-        ):
+        )
+        with context:
             return super()._apply(*args, **kwargs)
 
     def named_buffers(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#91410 [FSDP][Easy] Fix context manager syntax**
* #91044 [FSDP][7/N] Support `replicate` in `fully_shard`
* #90959 [FSDP][6/N] Add note explaining idioms for `_FSDPState` traversal
* #90874 [FSDP][5/N] Add manual "wrapping" support for `fully_shard`
* #90871 [FSDP][4/N] Refactor func to share state/init handle attrs
* #90945 fully_shard load state_dict

