### PR TITLE
[Security] Fix for command injection in nvcc_fix_deps.py

### DIFF
--- a/tools/nvcc_fix_deps.py
+++ b/tools/nvcc_fix_deps.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     elif os.name == 'posix':
         escaped_cmd = shlex.quote(cmd)
     else:
-        return 'Could not determine operating system'
+        sys.exit('Could not determine operating system')
     
     # Run command
     ret = subprocess.run(


### PR DESCRIPTION
Users can run arbitrary commands through this script. This PR prevents this by only allowing the user to submit nvcc arguments rather than any arbitrary command. This does not affect the usability of the script in any way.
