### PR TITLE
[bazel] change visibility for //c10:headers

### DIFF
--- a/c10/BUILD.bazel
+++ b/c10/BUILD.bazel
@@ -48,4 +48,5 @@ cc_library(
         ":using_glog": ["@com_github_glog//:glog"],
         "//conditions:default": [],
     }),
+    visibility = ["//visibility:public"],
 )

--- a/c10/BUILD.bazel
+++ b/c10/BUILD.bazel
@@ -48,5 +48,4 @@ cc_library(
         ":using_glog": ["@com_github_glog//:glog"],
         "//conditions:default": [],
     }),
-    visibility = ["//:__pkg__"],
 )


### PR DESCRIPTION
At Cruise we are actively depending on the c10 headers, I'm not certain what is the reason to hide them to the pkg level.