### PR TITLE
[bazel] Drop linkstatic = True from some places

### DIFF
--- a/aten.bzl
+++ b/aten.bzl
@@ -48,7 +48,6 @@ def intern_build_aten_ops(copts, deps, extra_impls):
                 "-DCPU_CAPABILITY_" + cpu_capability,
             ] + CAPABILITY_COMPILER_FLAGS[cpu_capability],
             deps = deps,
-            linkstatic = 1,
         )
     cc_library(
         name = "ATen_CPU",

--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -6,7 +6,6 @@ def define_targets(rules):
         # This library defines a flag, The use of alwayslink keeps it
         # from being stripped.
         alwayslink = True,
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [
@@ -21,7 +20,6 @@ def define_targets(rules):
     rules.cc_library(
         name = "ScalarType",
         hdrs = ["ScalarType.h"],
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = ["//c10/util:base"],
@@ -30,7 +28,6 @@ def define_targets(rules):
     rules.cc_library(
         name = "alignment",
         hdrs = ["alignment.h"],
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
     )
@@ -42,7 +39,6 @@ def define_targets(rules):
         # This library defines flags, The use of alwayslink keeps them
         # from being stripped.
         alwayslink = True,
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [
@@ -77,7 +73,6 @@ def define_targets(rules):
         # This library uses flags and registration. Do not let the
         # linker remove them.
         alwayslink = True,
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [

--- a/c10/cuda/build.bzl
+++ b/c10/cuda/build.bzl
@@ -22,7 +22,6 @@ def define_targets(rules):
         # This library uses registration. Don't let registered
         # entities be removed.
         alwayslink = True,
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [
@@ -39,7 +38,6 @@ def define_targets(rules):
         name = "Macros",
         srcs = [":cuda_cmake_macros"],
         hdrs = ["CUDAMacros.h"],
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
     )

--- a/c10/macros/build.bzl
+++ b/c10/macros/build.bzl
@@ -9,7 +9,6 @@ def define_targets(rules):
             # public header in this file.
             "Export.h",
         ],
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
     )

--- a/c10/mobile/build.bzl
+++ b/c10/mobile/build.bzl
@@ -3,7 +3,6 @@ def define_targets(rules):
         name = "CPUCachingAllocator",
         srcs = ["CPUCachingAllocator.cpp"],
         hdrs = ["CPUCachingAllocator.h"],
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [
@@ -16,7 +15,6 @@ def define_targets(rules):
         name = "CPUProfilingAllocator",
         srcs = ["CPUProfilingAllocator.cpp"],
         hdrs = ["CPUProfilingAllocator.h"],
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [

--- a/c10/util/build.bzl
+++ b/c10/util/build.bzl
@@ -3,7 +3,6 @@ def define_targets(rules):
         name = "TypeCast",
         srcs = ["TypeCast.cpp"],
         hdrs = ["TypeCast.h"],
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [
@@ -32,7 +31,6 @@ def define_targets(rules):
         # This library uses flags and registration. Do not let the
         # linker remove them.
         alwayslink = True,
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [
@@ -51,7 +49,6 @@ def define_targets(rules):
         name = "typeid",
         srcs = ["typeid.cpp"],
         hdrs = ["typeid.h"],
-        linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
         deps = [


### PR DESCRIPTION
PyTorch uses static variables in a few places (for example for ops registries) and this pattern doesn't play well with the static linking. Namely, in case where there is a diamond dependency the final library will get two copies of the same static variable.

This had lead to a few hard-to-debug investigations in Cruise and we would like to upstream our internal patch that removes most of the `static = True` flags. It's possible that we could leave some of them, however the proposed patch is at least a battle-tested set of flags and given that we don't have an outstanding bazel testing in CI at the moment, that bears some value.