### PR TITLE
Add an option to skip loading of debug traces

### DIFF
--- a/caffe2/serialize/inline_container.cc
+++ b/caffe2/serialize/inline_container.cc
@@ -25,6 +25,7 @@
 
 namespace caffe2 {
 namespace serialize {
+constexpr c10::string_view kDebugPklSuffix(".debug_pkl");
 
 size_t istream_read_func(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n) {
   auto self = static_cast<PyTorchStreamReader*>(pOpaque);
@@ -222,6 +223,10 @@ size_t getPadding(
 
 bool PyTorchStreamReader::hasRecord(const std::string& name) {
   std::lock_guard<std::mutex> guard(reader_lock_);
+
+  if ((!load_debug_symbol_) && c10::string_view(name).ends_with(kDebugPklSuffix)) {
+    return false;
+  }
   std::string ss = archive_name_plus_slash_ + name;
   mz_zip_reader_locate_file(ar_.get(), ss.c_str(), nullptr, 0);
   const mz_zip_error err = mz_zip_get_last_error(ar_.get());
@@ -255,8 +260,11 @@ std::vector<std::string> PyTorchStreamReader::getAllRecords() {
           ": ",
           buf);
     }
-    // NOLINTNEXTLINE(modernize-use-emplace)
-    out.push_back(buf + archive_name_plus_slash_.size());
+    if ((load_debug_symbol_) ||
+        (!c10::string_view(buf + archive_name_plus_slash_.size()).ends_with(kDebugPklSuffix))) {
+      // NOLINTNEXTLINE(modernize-use-emplace)
+      out.push_back(buf + archive_name_plus_slash_.size());
+    }
   }
   return out;
 }
@@ -276,6 +284,10 @@ size_t PyTorchStreamReader::getRecordID(const std::string& name) {
 // return dataptr, size
 std::tuple<at::DataPtr, size_t> PyTorchStreamReader::getRecord(const std::string& name) {
   std::lock_guard<std::mutex> guard(reader_lock_);
+  if ((!load_debug_symbol_) && c10::string_view(name).ends_with(kDebugPklSuffix)) {
+    at::DataPtr retval;
+    return std::make_tuple(std::move(retval), 0);
+  }
   size_t key = getRecordID(name);
   mz_zip_archive_file_stat stat;
   mz_zip_reader_file_stat(ar_.get(), key, &stat);

--- a/caffe2/serialize/inline_container.h
+++ b/caffe2/serialize/inline_container.h
@@ -110,6 +110,10 @@ class TORCH_API PyTorchStreamReader final {
     return version_;
   }
 
+  void setShouldLoadDebugSymbol(bool should_load_debug_symbol) {
+    load_debug_symbol_ = should_load_debug_symbol;
+  }
+
  private:
   void init();
   size_t read(uint64_t pos, char* buf, size_t n);
@@ -124,6 +128,7 @@ class TORCH_API PyTorchStreamReader final {
   std::shared_ptr<ReadAdapterInterface> in_;
   int64_t version_;
   std::mutex reader_lock_;
+  bool load_debug_symbol_ = true;
 };
 
 class TORCH_API PyTorchStreamWriter final {

--- a/torch/csrc/jit/serialization/import.h
+++ b/torch/csrc/jit/serialization/import.h
@@ -20,23 +20,27 @@ namespace jit {
 TORCH_API Module import_ir_module(
     std::shared_ptr<CompilationUnit> cu,
     const std::string& filename,
-    c10::optional<c10::Device> device = c10::nullopt);
+    c10::optional<c10::Device> device = c10::nullopt,
+    bool load_debug_files = true);
 
 TORCH_API Module import_ir_module(
     std::shared_ptr<CompilationUnit> cu,
     std::istream& in,
-    c10::optional<c10::Device> device = c10::nullopt);
+    c10::optional<c10::Device> device = c10::nullopt,
+    bool load_debug_files = true);
 
 TORCH_API Module import_ir_module(
     std::shared_ptr<CompilationUnit> cu,
     std::unique_ptr<caffe2::serialize::ReadAdapterInterface> rai,
-    c10::optional<c10::Device> device = c10::nullopt);
+    c10::optional<c10::Device> device = c10::nullopt,
+    bool load_debug_files = true);
 
 TORCH_API Module import_ir_module(
     std::shared_ptr<CompilationUnit> cu,
     const std::string& filename,
     c10::optional<c10::Device> device,
-    ExtraFilesMap& extra_files);
+    ExtraFilesMap& extra_files,
+    bool load_debug_files = true);
 
 // For reading unified serialization format from torch.Package
 TORCH_API Module import_ir_module(
@@ -50,31 +54,37 @@ TORCH_API Module import_ir_module(
     std::shared_ptr<CompilationUnit> cu,
     std::istream& in,
     c10::optional<c10::Device> device,
-    ExtraFilesMap& extra_files);
+    ExtraFilesMap& extra_files,
+    bool load_debug_files = true);
 
 TORCH_API Module import_ir_module(
     std::shared_ptr<CompilationUnit> cu,
     std::unique_ptr<caffe2::serialize::ReadAdapterInterface> rai,
     c10::optional<c10::Device> device,
-    ExtraFilesMap& extra_files);
+    ExtraFilesMap& extra_files,
+    bool load_debug_files = true);
 
 TORCH_API Module import_ir_module(
     std::shared_ptr<CompilationUnit> cu,
     std::shared_ptr<caffe2::serialize::ReadAdapterInterface> rai,
     c10::optional<c10::Device> device,
-    ExtraFilesMap& extra_files);
+    ExtraFilesMap& extra_files,
+    bool load_debug_files = true);
 
 /// Loads a serialized `Module` from the given `istream`.
 ///
 /// The istream must contain a serialized `Module`, exported via
 /// `torch::jit::ExportModule` in C++.
-TORCH_API Module
-load(std::istream& in, c10::optional<c10::Device> device = c10::nullopt);
+TORCH_API Module load(
+    std::istream& in,
+    c10::optional<c10::Device> device = c10::nullopt,
+    bool load_debug_files = true);
 
 TORCH_API Module load(
     std::istream& in,
     c10::optional<c10::Device> device,
-    ExtraFilesMap& extra_files);
+    ExtraFilesMap& extra_files,
+    bool load_debug_files = true);
 
 /// Loads a serialized `Module` from the given `filename`.
 ///
@@ -83,12 +93,14 @@ TORCH_API Module load(
 /// Python or `torch::jit::ExportModule` in C++.
 TORCH_API Module load(
     const std::string& filename,
-    c10::optional<c10::Device> device = c10::nullopt);
+    c10::optional<c10::Device> device = c10::nullopt,
+    bool load_debug_files = true);
 
 TORCH_API Module load(
     const std::string& filename,
     c10::optional<c10::Device> device,
-    ExtraFilesMap& extra_files);
+    ExtraFilesMap& extra_files,
+    bool load_debug_files = true);
 
 /// Loads a serialized `Module` from the given shared_ptr `rai`.
 ///
@@ -97,12 +109,14 @@ TORCH_API Module load(
 /// Python or `torch::jit::ExportModule` in C++.
 TORCH_API Module load(
     std::shared_ptr<caffe2::serialize::ReadAdapterInterface> rai,
-    c10::optional<c10::Device> device = c10::nullopt);
+    c10::optional<c10::Device> device = c10::nullopt,
+    bool load_debug_files = true);
 
 TORCH_API Module load(
     std::shared_ptr<caffe2::serialize::ReadAdapterInterface> rai,
     c10::optional<c10::Device> device,
-    ExtraFilesMap& extra_files);
+    ExtraFilesMap& extra_files,
+    bool load_debug_files = true);
 
 TORCH_API Module jitModuleFromSourceAndConstants(
     const IValue& ivalue,


### PR DESCRIPTION
Summary:
Debug traces consumes lots of memory especially for small models.

Test Plan:
Unit test

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER
