### PR TITLE
[autograd.Function] enable the extended Function feature flag by default

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -545,6 +545,15 @@ class TestAutograd(TestCase):
         with self.assertRaisesRegex(RuntimeError, "expects an grad_fn"):
             torch._C._will_engine_execute_node(out)
 
+    def test_autograd_function_extension_enabled_by_default(self):
+        # This feature flag is enabled by default. We're not deleting it yet
+        # so we can easily turn the feature off, but we want it enabled by
+        # default so that people can begin to test with it.
+        # We'll keep it around until approx. after next PyTorch release.
+        # Tracking issue: https://github.com/pytorch/pytorch/issues/90224
+        enabled = torch._C._is_autograd_function_extension_enabled()
+        self.assertTrue(enabled)
+
     def test_custom_function_setup_context_simple(self):
         class MySquare(Function):
             @staticmethod

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -104,7 +104,7 @@ void deleteNode(Node* function) {
 }
 
 namespace {
-bool kAutogradFunctionExtensionEnabled = false;
+bool kAutogradFunctionExtensionEnabled = true;
 }
 
 bool isAutogradFunctionExtensionEnabled() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #91452
* __->__ #91441

The autograd.Function <> functorch interaction is in a mostly completed
state now. There are some minor action items remaining
(https://github.com/pytorch/pytorch/issues/90224), but I want to enable
the feature by default so that PyTorch CI / other parties / etc can
begin testing to see if there is any impact on the original
autograd.Function API (there shouldn't be).

The longer-term plan for the feature flag is:
- keep it around until at least the next release (so that people can
turn off the feature if it breaks something in existing code)
- delete the flag then (either before or after the release, I haven't
decided yet)

Test Plan:
- new test
- wait for CI