### PR TITLE
Perf: Apply more clang-tidy fixups to torch headers

### DIFF
--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -502,8 +502,8 @@ static inline bool is_expandable_to(
     return false;
   }
   for (const auto i : c10::irange(ndim)) {
-    auto size = shape[ndim - i - 1];
-    auto target = desired[target_dim - i - 1];
+    const auto& size = shape[ndim - i - 1];
+    const auto& target = desired[target_dim - i - 1];
     if (size != target && size != 1) {
       return false;
     }

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -31,7 +31,7 @@ enum class TensorIndexType { None, Ellipsis, Integer, Boolean, Slice, Tensor };
 constexpr c10::nullopt_t None = c10::nullopt;
 
 struct TORCH_API EllipsisIndexType final {
-  EllipsisIndexType() {}
+  EllipsisIndexType() = default;
 };
 TORCH_API extern const EllipsisIndexType Ellipsis;
 

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -738,7 +738,7 @@ class TORCH_API TensorIteratorConfig final {
   friend struct TensorIteratorBase;
   friend struct TensorIterator;
 
-  TensorIteratorConfig() {}
+  TensorIteratorConfig() = default;
 
   C10_DISABLE_COPY_AND_ASSIGN(TensorIteratorConfig);
 
@@ -936,7 +936,7 @@ class TORCH_API TensorIteratorConfig final {
 /// the original TensorIterator.
 struct TORCH_API SplitUntil32Bit {
   struct TORCH_API iterator {
-    iterator(){};
+    iterator() = default;
     iterator(const TensorIteratorBase& iter);
     iterator(iterator&&) = default;
 

--- a/aten/src/ATen/TensorMeta.h
+++ b/aten/src/ATen/TensorMeta.h
@@ -129,7 +129,7 @@ struct TORCH_API MetaBase {
   const Tensor& maybe_get_output() {
     return maybe_get_output(0);
   }
-  virtual ~MetaBase() {}
+  virtual ~MetaBase() = default;
 };
 
 } // namespace impl

--- a/aten/src/ATen/core/Generator.h
+++ b/aten/src/ATen/core/Generator.h
@@ -59,7 +59,7 @@ namespace at {
 class Tensor;
 
 struct TORCH_API Generator {
-  Generator() {}
+  Generator() = default;
 
   explicit Generator(c10::intrusive_ptr<c10::GeneratorImpl> gen_impl)
    : impl_(std::move(gen_impl)) {

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -152,7 +152,7 @@ void swap(ListElementReference<T, Iterator>&& lhs, ListElementReference<T, Itera
 
 template<class T, class Iterator>
 bool operator==(const ListElementReference<T, Iterator>& lhs, const T& rhs) {
-  T lhs_tmp = lhs;
+  const T& lhs_tmp = lhs;
   return lhs_tmp == rhs;
 }
 

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -203,10 +203,7 @@ class TORCH_API TensorBase {
     impl_.reset();
   }
 
-  TensorBase& operator=(const TensorBase& x) & {
-    impl_ = x.impl_;
-    return *this;
-  };
+  TensorBase& operator=(const TensorBase& x) & = default;
   TensorBase& operator=(TensorBase&& x) & {
     impl_ = std::move(x.impl_);
     return *this;

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -203,7 +203,10 @@ class TORCH_API TensorBase {
     impl_.reset();
   }
 
-  TensorBase& operator=(const TensorBase& x) & = default;
+  TensorBase& operator=(const TensorBase& x) & {
+    impl_ = x.impl_;
+    return *this;
+  };
   TensorBase& operator=(TensorBase&& x) & {
     impl_ = std::move(x.impl_);
     return *this;

--- a/aten/src/ATen/core/builtin_function.h
+++ b/aten/src/ATen/core/builtin_function.h
@@ -72,7 +72,7 @@ struct BuiltinOpFunction : public Function {
     return false;
   }
 
-  ~BuiltinOpFunction() override {}
+  ~BuiltinOpFunction() override = default;
 
  private:
   c10::QualifiedName name_;

--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -40,7 +40,7 @@ struct AnnotatedKernel final {
     , inferred_function_schema(std::move(s))
     , debug(std::move(d))
     {}
-  AnnotatedKernel() {}
+  AnnotatedKernel() = default;
   KernelFunction kernel;
   std::unique_ptr<FunctionSchema> inferred_function_schema;
   // A little debug string to help us identify the kernel in question.

--- a/aten/src/ATen/core/function.h
+++ b/aten/src/ATen/core/function.h
@@ -101,7 +101,7 @@ struct TORCH_API Function {
     return false;
   }
 
-  virtual ~Function() {}
+  virtual ~Function() = default;
 };
 } // namespace jit
 } // namespace torch

--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -418,6 +418,7 @@ inline void FunctionSchema::checkAndNormalizeInputs(
   }
   if (consumed_kwargs != kwargs.size()) {
     std::vector<std::string> names;
+    names.reserve(kwargs.size());
     for(const auto& k : kwargs) {
       names.emplace_back(k.first);
     }

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -68,7 +68,7 @@ struct ComplexHolder : c10::intrusive_ptr_target {
     ComplexHolder(c10::complex<T> c) {
       val = convert<decltype(val), c10::complex<T>>(c);
     }
-    ComplexHolder() {}
+    ComplexHolder() = default;
     c10::complex<double> val;
 };
 } // namespace ivalue
@@ -82,7 +82,7 @@ template <typename T>
 struct OptionalArray {
   c10::optional<std::vector<T>> list;
 
-  OptionalArray(){}
+  OptionalArray()= default;
   OptionalArray(std::vector<T> val) : list(std::move(val)) {}
 
   // Used when saving an argument for the backwards pass.

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1135,6 +1135,7 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
     c10::OptionalDeviceGuard deviceGuard(currentDevice_);
 
     std::vector<c10::Stream> streams;
+    streams.reserve(devices_.size());
     for (const c10::Device& device : devices_) {
       streams.push_back(impl_.getStreamFromGlobalPool(device));
     }

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1502,7 +1502,7 @@ struct ivalue::PyObjectHolder : c10::intrusive_ptr_target {
   virtual std::string toStr() = 0;
   virtual std::vector<at::Tensor> extractTensors() = 0;
 
-  virtual ~PyObjectHolder(){};
+  virtual ~PyObjectHolder()= default;
 };
 
 struct ivalue::EnumHolder : c10::intrusive_ptr_target {

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -270,7 +270,7 @@ inline c10::optional<T> merge_primitive(
 // the stride is precisely 1, otherwise a contiguity marker means that $stride_n
 // = size_{n-1}*stride_{n-1}$
 struct TORCH_API Stride {
-  Stride() {}
+  Stride() = default;
   Stride(
       const c10::optional<size_t>& stride_index,
       c10::optional<bool> contiguous,

--- a/aten/src/ATen/core/qualified_name.h
+++ b/aten/src/ATen/core/qualified_name.h
@@ -10,7 +10,7 @@ namespace c10 {
 
 // Represents a name of the form "foo.bar.baz"
 struct QualifiedName {
-  QualifiedName() {}
+  QualifiedName() = default;
 
   // `name` can be a dotted string, like "foo.bar.baz", or just a bare name.
   /* implicit */ QualifiedName(const std::string& name) {

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -13,6 +13,7 @@
 #include <c10/util/quint8.h>
 
 #include <array>
+#include <cmath>
 #include <iostream>
 
 // This file defines Vectorized<> for the quantized types.
@@ -941,7 +942,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
     Vectorized<c10::qint32> retval;
     for (const auto i : c10::irange(size())) {
       retval.vals[i] =
-          nearbyint(static_cast<float>(inp[0].vals[i]) * multiplier) +
+          std::nearbyint(static_cast<float>(inp[0].vals[i]) * multiplier) +
           zero_point;
     }
     return retval;
@@ -1093,7 +1094,7 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
     for (const auto i : c10::irange(int_num_vecs())) {
       for (const auto j : c10::irange(elem_per_int_vec)) {
         int32_t rounded =
-            nearbyint(static_cast<float>(inp[i].vals[j]) * multiplier) +
+            std::nearbyint(static_cast<float>(inp[i].vals[j]) * multiplier) +
             zero_point;
         retval.vals[i * elem_per_int_vec + j] =
             std::min<int32_t>(std::max<int32_t>(rounded, min_val), max_val);
@@ -1227,7 +1228,7 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
     for (const auto i : c10::irange(int_num_vecs())) {
       for (const auto j : c10::irange(elem_per_int_vec)) {
         int32_t rounded =
-            nearbyint(static_cast<float>(inp[i].vals[j]) * multiplier) +
+            std::nearbyint(static_cast<float>(inp[i].vals[j]) * multiplier) +
             zero_point;
         retval.vals[i * elem_per_int_vec + j] =
             std::min<int32_t>(std::max<int32_t>(rounded, min_val), max_val);

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -67,7 +67,7 @@ constexpr const char* CUDA_HELP =
 struct TORCH_API CUDAHooksInterface {
   // This should never actually be implemented, but it is used to
   // squelch -Werror=non-virtual-dtor
-  virtual ~CUDAHooksInterface() {}
+  virtual ~CUDAHooksInterface() = default;
 
   // Initialize THCState and, transitively, the CUDA state
   virtual void initCUDA() const {

--- a/aten/src/ATen/detail/HIPHooksInterface.h
+++ b/aten/src/ATen/detail/HIPHooksInterface.h
@@ -24,7 +24,7 @@ namespace at {
 struct TORCH_API HIPHooksInterface {
   // This should never actually be implemented, but it is used to
   // squelch -Werror=non-virtual-dtor
-  virtual ~HIPHooksInterface() {}
+  virtual ~HIPHooksInterface() = default;
 
   // Initialize the HIP library state
   virtual void initHIP() const {

--- a/aten/src/ATen/detail/ORTHooksInterface.h
+++ b/aten/src/ATen/detail/ORTHooksInterface.h
@@ -14,7 +14,7 @@ namespace at {
 struct TORCH_API ORTHooksInterface {
   // This should never actually be implemented, but it is used to
   // squelch -Werror=non-virtual-dtor
-  virtual ~ORTHooksInterface() {}
+  virtual ~ORTHooksInterface() = default;
 
   virtual std::string showConfig() const {
     TORCH_CHECK(false, "Cannot query detailed ORT version information.", ORT_HELP);

--- a/aten/src/ATen/functorch/DynamicLayer.cpp
+++ b/aten/src/ATen/functorch/DynamicLayer.cpp
@@ -83,7 +83,7 @@ RandomnessType DynamicLayer::randomness() const {
 // this layer of indirection.
 class FuncTorchTLS : public FuncTorchTLSBase {
  public:
-  FuncTorchTLS() {}
+  FuncTorchTLS() = default;
 
   std::unique_ptr<FuncTorchTLSBase> deepcopy() const override {
     auto result = std::make_unique<FuncTorchTLS>();

--- a/aten/src/ATen/native/quantized/cpu/conv_serialization.h
+++ b/aten/src/ATen/native/quantized/cpu/conv_serialization.h
@@ -95,7 +95,7 @@ ConvParamsSerializationTypeV3 parse_conv_serialized_state(c10::IValue v) {
       if (firstElement.isTensor()) {
         version = 1;
       } else if (firstElement.isString()) {
-        std::string version_str = firstElement.toStringRef();
+        const std::string& version_str = firstElement.toStringRef();
         // note: not parsing the string to automatically handle bad
         // inputs
         if (version_str == "2") {

--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -91,7 +91,7 @@ constexpr std::size_t kSoftLimitCallbacks = 4;
 // An abstract base class for various observer contexts that can be attached to
 // the RecordFunction.
 struct ObserverContext {
-  virtual ~ObserverContext() {}
+  virtual ~ObserverContext() = default;
 
  protected:
   ObserverContext() {}
@@ -709,7 +709,7 @@ class TORCH_API RecordFunctionGuard {
 class TORCH_API DisableRecordFunctionGuard : public RecordFunctionGuard {
  public:
   DisableRecordFunctionGuard() : RecordFunctionGuard(false) {}
-  virtual ~DisableRecordFunctionGuard() {}
+  virtual ~DisableRecordFunctionGuard() = default;
 };
 
 struct TORCH_API RecordFunctionTLS {

--- a/c10/core/CPUAllocator.h
+++ b/c10/core/CPUAllocator.h
@@ -21,7 +21,7 @@ C10_API void NoDelete(void*);
 // deallocation status and out-of-memory events to the profiler
 class C10_API ProfiledCPUMemoryReporter {
  public:
-  ProfiledCPUMemoryReporter() {}
+  ProfiledCPUMemoryReporter() = default;
   void New(void* ptr, size_t nbytes);
   void OutOfMemory(size_t nbytes);
   void Delete(void* ptr);

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -10,7 +10,7 @@ namespace c10 {
 struct FunctionalityOffsetAndMask {
   // empty constructor shouldn't be used; only needed to initialize
   // the array before populating it.
-  FunctionalityOffsetAndMask() {}
+  FunctionalityOffsetAndMask() = default;
   FunctionalityOffsetAndMask(uint16_t offset, uint16_t mask)
       : offset(offset), mask(mask) {}
   // This needs to big enough to cover the size of the operator table.

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -8,7 +8,7 @@ struct C10_API Storage {
  public:
   struct use_byte_size_t {};
 
-  Storage() {}
+  Storage() = default;
   Storage(c10::intrusive_ptr<StorageImpl> ptr)
       : storage_impl_(std::move(ptr)) {}
 

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -20,7 +20,7 @@ struct C10_API Storage {
       bool resizable = false)
       : storage_impl_(c10::make_intrusive<StorageImpl>(
             StorageImpl::use_byte_size_t(),
-            size_bytes,
+            std::move(size_bytes),
             allocator,
             resizable)) {}
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -216,7 +216,7 @@ enum class PyInterpreterStatus {
 } // namespace impl
 
 struct C10_API NamedTensorMetaInterface {
-  virtual ~NamedTensorMetaInterface(){};
+  virtual ~NamedTensorMetaInterface() = default;
   virtual std::unique_ptr<NamedTensorMetaInterface> clone() const {
     TORCH_INTERNAL_ASSERT(
         false, "Not implemented: NamedTensorMetaInterface::clone");
@@ -265,7 +265,7 @@ struct C10_API ExtraMeta {
   bool_is_non_overlapping_and_dense is_non_overlapping_and_dense_{true};
   std::unique_ptr<c10::NamedTensorMetaInterface> named_tensor_meta_ = nullptr;
 
-  ExtraMeta() {}
+  ExtraMeta() = default;
 
   ExtraMeta(
       SymDimVector sizes,

--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -213,7 +213,7 @@ struct C10_API DeviceGuardImplInterface {
 // examples are CPU and Meta.
 template <DeviceType D>
 struct NoOpDeviceGuardImpl final : public DeviceGuardImplInterface {
-  NoOpDeviceGuardImpl() {}
+  NoOpDeviceGuardImpl() = default;
   DeviceType type() const override {
     return D;
   }

--- a/c10/core/impl/PyInterpreter.h
+++ b/c10/core/impl/PyInterpreter.h
@@ -122,7 +122,7 @@ struct C10_API PyInterpreter;
 // another word consider doing this!
 
 struct C10_API PyInterpreterVTable {
-  virtual ~PyInterpreterVTable() {}
+  virtual ~PyInterpreterVTable() = default;
 
   // Report the name of this interpreter
   virtual std::string name() const = 0;

--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -36,7 +36,7 @@ class C10_API TaskThreadPoolBase {
    */
   virtual bool inThreadPool() const = 0;
 
-  virtual ~TaskThreadPoolBase() noexcept {}
+  virtual ~TaskThreadPoolBase() noexcept = default;
 
   static size_t defaultNumThreads() {
     auto num_threads = std::thread::hardware_concurrency();

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -255,7 +255,7 @@ template <typename T>
 std::ostream& operator<<(std::ostream& out, ArrayRef<T> list) {
   int i = 0;
   out << "[";
-  for (auto e : list) {
+  for (const auto& e : list) {
     if (i++ > 0)
       out << ", ";
     out << e;

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -630,8 +630,7 @@ class optional : private OptionalBase<T> {
   typedef T value_type;
 
   // 20.5.5.1, constructors
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  constexpr optional() noexcept : OptionalBase<T>(){};
+  constexpr optional() noexcept = default;
   constexpr optional(nullopt_t) noexcept : OptionalBase<T>(){};
 
   optional(const optional& rhs) = default;

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -630,6 +630,7 @@ class optional : private OptionalBase<T> {
   typedef T value_type;
 
   // 20.5.5.1, constructors
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   constexpr optional() noexcept : OptionalBase<T>(){};
   constexpr optional(nullopt_t) noexcept : OptionalBase<T>(){};
 

--- a/c10/util/OptionalArrayRef.h
+++ b/c10/util/OptionalArrayRef.h
@@ -21,7 +21,7 @@ class OptionalArrayRef final {
  public:
   // Constructors
 
-  constexpr OptionalArrayRef() noexcept {}
+  constexpr OptionalArrayRef() noexcept = default;
 
   constexpr OptionalArrayRef(nullopt_t) noexcept {}
 

--- a/c10/util/Registry.h
+++ b/c10/util/Registry.h
@@ -127,6 +127,7 @@ class Registry {
    */
   std::vector<SrcType> Keys() const {
     std::vector<SrcType> keys;
+    keys.reserve(registry_.size());
     for (const auto& it : registry_) {
       keys.push_back(it.first);
     }

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -22,7 +22,7 @@ enum class C10_API_ENUM DebugInfoKind : uint8_t {
 
 class C10_API DebugInfoBase {
  public:
-  DebugInfoBase() {}
+  DebugInfoBase() = default;
   virtual ~DebugInfoBase() = default;
 };
 

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -258,7 +258,7 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
   using pointer = value_type*;
   using const_pointer = const value_type*;
 
-  sherwood_v3_table() {}
+  sherwood_v3_table() = default;
   explicit sherwood_v3_table(
       size_type bucket_count,
       const ArgumentHash& hash = ArgumentHash(),
@@ -1948,7 +1948,7 @@ class flat_hash_map
   using mapped_type = V;
 
   using Table::Table;
-  flat_hash_map() {}
+  flat_hash_map() = default;
 
   inline V& operator[](const K& key) {
     return emplace(key, convertible_to_value()).first->second;
@@ -2061,7 +2061,7 @@ class flat_hash_set
   using key_type = T;
 
   using Table::Table;
-  flat_hash_set() {}
+  flat_hash_set() = default;
 
   template <typename... Args>
   std::pair<typename Table::iterator, bool> emplace(Args&&... args) {

--- a/c10/util/order_preserving_flat_hash_map.h
+++ b/c10/util/order_preserving_flat_hash_map.h
@@ -263,7 +263,7 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
   using pointer = value_type*;
   using const_pointer = const value_type*;
 
-  sherwood_v3_table() {}
+  sherwood_v3_table() = default;
   explicit sherwood_v3_table(
       size_type bucket_count,
       const ArgumentHash& hash = ArgumentHash(),
@@ -2072,7 +2072,7 @@ class order_preserving_flat_hash_map
   using mapped_type = V;
 
   using Table::Table;
-  order_preserving_flat_hash_map() {}
+  order_preserving_flat_hash_map() = default;
 
   inline V& operator[](const K& key) {
     return emplace(key, convertible_to_value()).first->second;
@@ -2189,7 +2189,7 @@ class flat_hash_set
   using key_type = T;
 
   using Table::Table;
-  flat_hash_set() {}
+  flat_hash_set() = default;
 
   template <typename... Args>
   std::pair<typename Table::iterator, bool> emplace(Args&&... args) {

--- a/torch/csrc/distributed/c10d/HashStore.hpp
+++ b/torch/csrc/distributed/c10d/HashStore.hpp
@@ -12,7 +12,7 @@ namespace c10d {
 
 class TORCH_API HashStore : public Store {
  public:
-  ~HashStore() override {}
+  ~HashStore() override = default;
 
   void set(const std::string& key, const std::vector<uint8_t>& data) override;
 

--- a/torch/csrc/distributed/c10d/PrefixStore.hpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.hpp
@@ -11,7 +11,7 @@ class TORCH_API PrefixStore : public Store {
       std::string  prefix,
       c10::intrusive_ptr<Store> store);
 
-  virtual ~PrefixStore(){};
+  virtual ~PrefixStore()= default;
 
   using Store::set;
   void set(const std::string& key, const std::vector<uint8_t>& value) override;

--- a/torch/csrc/distributed/c10d/Types.hpp
+++ b/torch/csrc/distributed/c10d/Types.hpp
@@ -15,7 +15,7 @@ namespace c10d {
 
 // Base class for supplementary data potentially needed by ReduceOps
 struct TORCH_API _SupplementBase : torch::CustomClassHolder {
-  virtual ~_SupplementBase() {}
+  virtual ~_SupplementBase() = default;
 };
 
 // Supplementary data specific to NCCL PREMUL_SUM
@@ -46,7 +46,7 @@ struct TORCH_API ReduceOp : torch::CustomClassHolder {
     UNUSED = 9
   };
 
-  ReduceOp() {}
+  ReduceOp() = default;
 
   ReduceOp(RedOpType op) : op_(op) {
     TORCH_INTERNAL_ASSERT(

--- a/torch/csrc/jit/frontend/mini_environment.h
+++ b/torch/csrc/jit/frontend/mini_environment.h
@@ -41,6 +41,7 @@ struct MiniEnvironment {
 
   std::vector<std::string> definedVariables() {
     std::vector<std::string> result;
+    result.reserve(table.size());
     for (auto& kv : table) {
       result.push_back(kv.first);
     }

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -252,6 +252,7 @@ struct TORCH_API SugaredTupleValue : public SugaredValue {
 
   Value* asValue(const SourceRange& loc, GraphFunction& m) override {
     std::vector<Value*> vec;
+    vec.reserve(tup_.size());
     for (const auto& sv : tup_) {
       vec.push_back(sv->asValue(loc, m));
     }

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -858,6 +858,7 @@ struct TORCH_API Node {
   // The names are returned in order, since name actually is the index.
   std::vector<Symbol> attributeNames() const {
     std::vector<Symbol> names;
+    names.reserve(values_.size());
     for (const AVPtr& a : values_) {
       names.push_back(a->name);
     }
@@ -865,6 +866,7 @@ struct TORCH_API Node {
   }
   std::vector<const char*> attributeNamesS() const {
     std::vector<const char*> names;
+    names.reserve(values_.size());
     for (const AVPtr& a : values_) {
       names.push_back(a->name.toUnqualString());
     }

--- a/torch/csrc/jit/passes/onnx/naming.cpp
+++ b/torch/csrc/jit/passes/onnx/naming.cpp
@@ -99,7 +99,7 @@ class NodeNameGenerator {
   std::shared_ptr<Graph> graph_;
   const std::string layer_separator_ = "/";
 };
-NodeNameGenerator::~NodeNameGenerator(){};
+NodeNameGenerator::~NodeNameGenerator() = default;
 
 class ScopedNodeNameGenerator : public NodeNameGenerator {
  public:

--- a/torch/csrc/jit/runtime/calculate_necessary_args.h
+++ b/torch/csrc/jit/runtime/calculate_necessary_args.h
@@ -23,7 +23,7 @@ inline std::pair<int64_t, int64_t> CalculateNecessaryArgs(
   if (allow_trailing_out_args) {
     // skip over out arguments in the end.
     while (schema_idx >= 0) {
-      auto current_arg = schema_args.at(schema_idx);
+      const auto& current_arg = schema_args.at(schema_idx);
       if (!current_arg.is_out()) {
         break;
       }

--- a/torch/csrc/jit/runtime/interpreter/code_impl.h
+++ b/torch/csrc/jit/runtime/interpreter/code_impl.h
@@ -241,7 +241,7 @@ struct CodeImpl {
   }
 
   void createBailoutBlock(size_t jf_index) {
-    bailout_blocks_.emplace_back(BailoutBlock{jf_index});
+    bailout_blocks_.emplace_back(jf_index);
     auto& bailout_instructions = bailout_blocks_.back().instructions;
 
     bailout_instructions.insert(

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -302,8 +302,8 @@ inline bool tensor_list_equal(
   }
 
   for (const auto i : c10::irange(a.size())) {
-    at::Tensor a_element = a[i];
-    at::Tensor b_element = b[i];
+    const at::Tensor& a_element = a[i];
+    const at::Tensor& b_element = b[i];
     // This preserves Python's semantics, which uses eq() to compare two
     // elements, then passes the result to bool().
     // see: https://docs.python.org/3.4/reference/datamodel.html#object.__ge__

--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -160,7 +160,7 @@ class StmtsReadingBuf : public IRVisitor {
  private:
   bool readsBuffer(StmtPtr s) {
     auto loads = NodeFinder<Load>::find(s);
-    for (auto l : loads) {
+    for (const auto& l : loads) {
       if (l->buf() == target_) {
         return true;
       }
@@ -302,22 +302,22 @@ class BufLiveRange : public IRVisitor {
 
   bool hasBufReads(StmtPtr s) {
     auto loads1 = NodeFinder<Load>::find(s);
-    for (auto l : loads1) {
+    for (const auto& l : loads1) {
       if (l->buf() == buf_) {
         return true;
       }
     }
     auto loads2 = NodeFinder<ExternalCall>::find(s);
-    for (auto l : loads2) {
-      for (auto lb : l->buf_args()) {
+    for (const auto& l : loads2) {
+      for (const auto& lb : l->buf_args()) {
         if (lb == buf_) {
           return true;
         }
       }
     }
     auto loads3 = NodeFinder<ExternalCallWithAlloc>::find(s);
-    for (auto l : loads3) {
-      for (auto lb : l->buf_args()) {
+    for (const auto& l : loads3) {
+      for (const auto& lb : l->buf_args()) {
         if (lb == buf_) {
           return true;
         }
@@ -328,20 +328,20 @@ class BufLiveRange : public IRVisitor {
 
   bool hasBufWrites(StmtPtr s) {
     auto writes1 = NodeFinder<Store>::find(s);
-    for (auto w : writes1) {
+    for (const auto& w : writes1) {
       if (w->buf() == buf_) {
         return true;
       }
     }
     auto writes2 = NodeFinder<ExternalCall>::find(s);
-    for (auto w : writes2) {
+    for (const auto& w : writes2) {
       if (w->buf() == buf_) {
         return true;
       }
     }
     auto writes3 = NodeFinder<ExternalCallWithAlloc>::find(s);
-    for (auto w : writes3) {
-      for (auto wb : w->buf_out_args()) {
+    for (const auto& w : writes3) {
+      for (const auto& wb : w->buf_out_args()) {
         if (wb == buf_) {
           return true;
         }
@@ -361,7 +361,7 @@ class BufLiveRange : public IRVisitor {
   }
 
   void visit(BlockPtr v) override {
-    for (StmtPtr s : *v) {
+    for (const StmtPtr& s : *v) {
       curr_index_ += 1;
       findAccAndUpdateLiveRange(s);
     }

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -30,7 +30,7 @@ Dtype promoteTypesVec(ExprPtr s, std::vector<ExprType>& v) {
   Dtype t = s->dtype();
   bool first = true;
 
-  for (auto e : v) {
+  for (const auto& e : v) {
     if (first) {
       t = Dtype(t.scalar_type(), e->dtype().lanes());
       first = false;
@@ -47,7 +47,7 @@ Dtype promoteTypesVec(std::vector<ExprType>& v) {
   }
 
   Dtype t = v[0]->dtype();
-  for (auto e : v) {
+  for (const auto& e : v) {
     t = promoteTypes(t, e->dtype());
   }
   return t;

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
@@ -303,7 +303,7 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
   DependencySet getAllReadsWithin(StmtOrExprPtr v) {
     DependencySet reads;
     auto insertAllReads = [&](const auto& nodes) {
-      for (auto l : nodes) {
+      for (const auto& l : nodes) {
         auto bound = exprToAccess_.equal_range(l);
         for (auto it = bound.first; it != bound.second; ++it) {
           if (it->second->isRead()) {
@@ -328,7 +328,7 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
 
     // writes just Store currently.
     auto stores = NodeFinder<Store>::find(v);
-    for (auto s : stores) {
+    for (const auto& s : stores) {
       auto bound = stmtToAccess_.equal_range(s);
       for (auto it = bound.first; it != bound.second; ++it) {
         if (it->second->isWrite()) {

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -195,7 +195,7 @@ class TORCH_API Block : public StmtNode<Block> {
   }
 
   void clear() {
-    for (auto s : stmts_) {
+    for (const auto& s : stmts_) {
       set_parent(s, nullptr);
     }
     stmts_.clear();
@@ -247,7 +247,7 @@ class TORCH_API Block : public StmtNode<Block> {
   }
 
   void splice(Block::iterator it, BlockPtr other) {
-    for (StmtPtr s : *other) {
+    for (const StmtPtr& s : *other) {
       set_parent(s, this);
     }
 
@@ -293,7 +293,7 @@ class TORCH_API Block : public StmtNode<Block> {
   std::list<StmtPtr> stmts_;
 
   void init(const std::vector<StmtPtr>& stmts) {
-    for (StmtPtr s : stmts) {
+    for (const StmtPtr& s : stmts) {
       if (!s) {
         continue;
       }

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -135,8 +135,8 @@ inline std::vector<VarHandle> create_index_vars(
   std::vector<VarHandle> vars;
   vars.reserve(dims.size());
   for (const ExprHandle& dim : dims) {
-    vars.push_back(VarHandle(alloc<Var>(
-        "i", dim.dtype().scalar_type() == ScalarType::Long ? kLong : kInt)));
+    vars.emplace_back(alloc<Var>(
+        "i", dim.dtype().scalar_type() == ScalarType::Long ? kLong : kInt));
   }
   return vars;
 }

--- a/torch/csrc/jit/tensorexpr/var_substitutor.h
+++ b/torch/csrc/jit/tensorexpr/var_substitutor.h
@@ -42,7 +42,7 @@ class VarSubMutator : public IRMutator {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     std::vector<VarPtr> new_inner;
 
-    for (auto v : var->reduce_args()) {
+    for (const auto& v : var->reduce_args()) {
       ExprPtr e = v->accept_mutator(this);
       if (VarPtr new_var = to<Var>(e)) {
         new_inner.push_back(new_var);

--- a/torch/csrc/jit/tensorexpr/var_substitutor.h
+++ b/torch/csrc/jit/tensorexpr/var_substitutor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <torch/csrc/jit/tensorexpr/analysis.h>
@@ -25,7 +26,7 @@ class VarSubMutator : public IRMutator {
       if (!key_var) {
         throw malformed_input("missing key in VarSubMutator");
       }
-      var_mapping_[key_var] = value;
+      var_mapping_[std::move(key_var)] = std::move(value);
     }
   }
 
@@ -45,7 +46,7 @@ class VarSubMutator : public IRMutator {
     for (const auto& v : var->reduce_args()) {
       ExprPtr e = v->accept_mutator(this);
       if (VarPtr new_var = to<Var>(e)) {
-        new_inner.push_back(new_var);
+        new_inner.push_back(std::move(new_var));
       } else {
         VarFinder varFinder;
         e->accept(&varFinder);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -549,7 +549,7 @@ inline std::vector<c10::SymInt> PythonArgs::symintlist(int i) {
       jit::tracer::ArgumentStash::stashIntArrayRefElem(
           signature.params[i].name, size2, idx, var);
       try {
-        res.push_back(var.item<int64_t>());
+        res.emplace_back(var.item<int64_t>());
         continue;
       } catch (std::exception& e) {
         throw_intlist_exception(this, i, obj, idx);
@@ -573,7 +573,7 @@ inline std::vector<c10::SymInt> PythonArgs::symintlist(int i) {
           if (is_symint(py::handle(obj))) {
             res.push_back(py::handle(obj).cast<c10::SymInt>());
           } else {
-            res.push_back(c10::SymInt(THPUtils_unpackIndex(obj)));
+            res.emplace_back(THPUtils_unpackIndex(obj));
           }
         } catch (std::exception& e) {
           throw_intlist_exception(this, i, obj, idx);


### PR DESCRIPTION
Applies so more fixes to headers that may have been missed before for performance optimization.cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @EikanWang @ezyang since this more in the series of the clang-tidy fixup 

This is PR fixes 3 main issues:
1. Use emplacement more in headers
1. Avoid unnecessary copies and use const ref when possible
1. Default any special functions when possible to make them potentially trivial and more readable.
1. There is also one change in this PR that tries to prevent unnecessary math promotion, the rest of these changes are in another PR