### PR TITLE
Clang-Tidy: Prevent implicit promotion in math functions

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -1,18 +1,18 @@
 #pragma once
 
-#include <cstdlib>
-#include <cstdint>
-#include <cmath>
-#include <cfloat>
-#include <limits>
-#include <type_traits>
+#include <ATen/AccumulateType.h>
 #include <ATen/NumericUtils.h>
+#include <ATen/jiterator_macros.h>
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
 #include <c10/util/MathConstants.h>
 #include <c10/util/math_compat.h>
-#include <ATen/AccumulateType.h>
-#include <ATen/jiterator_macros.h>
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <type_traits>
 
 C10_CLANG_DIAGNOSTIC_PUSH()
 #if C10_CLANG_HAS_WARNING("-Wimplicit-float-conversion")
@@ -100,7 +100,7 @@ jiterator_also_stringify_as(jiterator_code(
 
   template <typename T>
   JITERATOR_HOST_DEVICE T calc_i0e(T _x) {
-    T x = fabs(_x);
+    T x = std::fabs(_x);
 
     if (x <= T{8.0}) {
       static const T coefficients[] = {
@@ -140,7 +140,7 @@ jiterator_also_stringify_as(jiterator_code(
         6.88975834691682398426E-5,   3.36911647825569408990E-3,
         8.04490411014108831608E-1};
 
-    return chbevl(T{32.0} / x - T{2.0}, coefficients, int{25}) / sqrt(x);
+    return chbevl(T{32.0} / x - T{2.0}, coefficients, int{25}) / std::sqrt(x);
   }),
   i0e_string); // i0e_string
 }
@@ -265,15 +265,15 @@ C10_HOST_DEVICE static inline scalar_t zeta(scalar_t x, scalar_t q) __ubsan_igno
   }
 
   if (q <= zero) {
-    if (q == ::floor(q)) {
+    if (q == std::floor(q)) {
       return std::numeric_limits<scalar_t>::infinity();
     }
-    if (x != ::floor(x)) {
+    if (x != std::floor(x)) {
       return std::numeric_limits<scalar_t>::quiet_NaN();
     }
   }
 
-  s = ::pow(q, -x);
+  s = std::pow(q, -x);
   a = q;
   i = 0;
   b = zero;
@@ -491,7 +491,7 @@ static inline C10_HOST_DEVICE scalar_t calc_polygamma(scalar_t x, int n) {
   // already blocked if n <= 1
   const auto one = scalar_t{1};
   return ((n % 2) ? one : -one) *
-      ::exp(::lgamma(static_cast<scalar_t>(n) + one)) *
+      std::exp(std::lgamma(static_cast<scalar_t>(n) + one)) *
       zeta<scalar_t, is_cuda>(static_cast<scalar_t>(n + 1), x);
 }
 

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -8,6 +8,7 @@
 
 #include <c10/util/irange.h>
 
+#include <cmath>
 #include <utility>
 
 namespace at {
@@ -312,7 +313,7 @@ float calculate_quant_loss(
   // remainder loop
   for (; i < numel; i++) {
     q_input[i] = std::max(
-        0.0f, std::min<float>(nearbyint((input[i] - xmin) * inverse_scale), qmax));
+        0.0f, std::min<float>(std::nearbyint((input[i] - xmin) * inverse_scale), qmax));
     q_input[i] = q_input[i] * scale + xmin;
     norm += (input[i] - q_input[i]) * (input[i] - q_input[i]);
   }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/tanh.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/tanh.c
@@ -110,7 +110,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_tanh_nc_q8(
     /* Scale tanh(x) by 1 / output scale = 128.0
        Also, offset by the zero_point from the scaled value, as we assume UINT8
     */
-    float scaled_tanh_x = 128.0f * tanh(x) + 128.0f;
+    float scaled_tanh_x = 128.0f * tanhf(x) + 128.0f;
     if (scaled_tanh_x < scaled_min) {
       scaled_tanh_x = scaled_min;
     }


### PR DESCRIPTION
Ensure that accidental promotions in functions does not accidentally occur

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10