### PR TITLE
Fix sharded_tensor test_sharded_tensor_to_cpu

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -1565,8 +1565,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         # check the spec is still ChunkShardingSpec
         spec_after_move = new_st.sharding_spec()
         self.assertIsInstance(spec_after_move, ChunkShardingSpec)
-        # now it should be ProcessGroupGloo since it's on CPU
-        self.assertIsInstance(new_st._process_group, distributed_c10d.ProcessGroupGloo)
+        self.assertIsInstance(new_st._process_group, distributed_c10d.ProcessGroup)
         # test specs before and after the move almost the same except placement device
         self.assertEqual(spec_before_move.dim, spec_after_move.dim)
         self.assertEqual(len(spec_before_move.placements), len(spec_after_move.placements))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#91453 Fix sharded_tensor test_sharded_tensor_to_cpu**
* #91409 check_forward_backward_compatibility C10D APIs

Fixes https://github.com/pytorch/pytorch/issues/91381

Assert needs to be updated in the test. Run `ciflow/periodic` to run the multigpu tests
