### PR TITLE
Chore: fix clang warning - mismatched tags

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -336,7 +336,7 @@ private:
  * to lookup a kernel for a certain set of arguments.
  */
 class TORCH_API OperatorHandle {
-  template <typename T> friend class std::hash;
+  template <typename T> friend struct std::hash;
 
 public:
   OperatorHandle(OperatorHandle&&) noexcept = default;


### PR DESCRIPTION
Fixes a clang warning about mismatched tags when building PyTorch. Seems like an easy fix / oversight.