### PR TITLE
Fix NumPy-compat broadcasting in the derivative of linalg.solve

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5708,7 +5708,7 @@ std::tuple<Tensor, Tensor> linalg_solve_backward(
     gA_ = left ? -gB_.matmul(X_.mH()) : -X_.mH().matmul(gB_);
   }
   return std::make_tuple(
-      A_requires_grad ? matrix_to_vector(gA_) : Tensor{},
+      A_requires_grad ? gA_ : Tensor{},
       B_requires_grad ? matrix_to_vector(gB_) : Tensor{});
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #91460
* __->__ #91456

Fixes https://github.com/pytorch/pytorch/issues/89761

cc @albanD