### PR TITLE
Revert D42051833: Multisect successfully blamed D42051833 for test or build failures

### DIFF
--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -457,19 +457,16 @@ void masked_select_kernel(TensorIterator& iter, int64_t result_stride) {
     });
 }
 
+
 template <typename scalar_t>
 void cpu_hflip_vec(at::TensorIterator& iter) {
 
   auto loop2d = [&](char** base, const int64_t *strides, int64_t size0, int64_t size1) {
 
-    // Here ntensors is defined for output and 1 input. But tensor iterator has defined output, input
-    // and restrided_input (see aten/src/ATen/native/TensorTransformations.cpp#L64-L66) but we use only
-    // output and input.
-    static constexpr int ntensors = 2;
-    const int64_t *outer_strides = &strides[3];
-
+    static constexpr int ntensors = 3;
     std::array<char*, ntensors> data_arr;
     std::copy_n(base, ntensors, data_arr.data());
+    const int64_t *outer_strides = &strides[ntensors];
 
     using Vec = Vectorized<scalar_t>;
 
@@ -517,47 +514,6 @@ void cpu_hflip_vec(at::TensorIterator& iter) {
       }
 
       // advance:
-      for (const auto arg : c10::irange(ntensors)) {
-        data_arr[arg] += outer_strides[arg];
-      }
-    }
-  };
-
-  int64_t grain_size = at::internal::GRAIN_SIZE;
-  iter.for_each(loop2d, grain_size);
-  iter.cast_outputs();
-}
-
-void cpu_vflip_memcpy(at::TensorIterator& iter) {
-  // This is a vertical flip specialization using memcpy to speed-up the runtime
-
-  auto loop2d = [&](char** base, const int64_t *strides, int64_t size0, int64_t size1) {
-
-    // Here ntensors is defined for output and 1 input. But tensor iterator has defined output, input
-    // and restrided_input (see aten/src/ATen/native/TensorTransformations.cpp#L64-L66) but we use only
-    // output and input.
-    static constexpr int ntensors = 2;
-    const int64_t *outer_strides = &strides[3];
-
-    std::array<char*, ntensors> data_arr;
-    std::copy_n(base, ntensors, data_arr.data());
-
-    TORCH_INTERNAL_ASSERT(strides[0] == strides[1]);
-    const int64_t stride = strides[0];
-
-    for (const auto j C10_UNUSED : c10::irange(size1)) {
-
-      char** C10_RESTRICT data_ = data_arr.data();
-      int64_t n = size0;
-
-      char* C10_RESTRICT data[ntensors];
-      for (const auto arg : c10::irange(ntensors)) {
-        data[arg] = data_[arg];
-      }
-
-      memcpy(data[0], data[1], n * stride);
-
-      // advance:
       for (const auto arg : c10::irange(data_arr.size())) {
         data_arr[arg] += outer_strides[arg];
       }
@@ -569,6 +525,7 @@ void cpu_vflip_memcpy(at::TensorIterator& iter) {
   iter.cast_outputs();
 }
 
+
 void flip_kernel(TensorIterator& iter, const bool quantized) {
   if (quantized) {
     AT_DISPATCH_QINT_AND_SUB_BYTE_TYPES(iter.dtype(), "flip_quantized_cpu",
@@ -578,25 +535,27 @@ void flip_kernel(TensorIterator& iter, const bool quantized) {
         });
     });
   } else {
+    // Special case: horizontal flip with vectorization and input is contiguous
+    // Context: horizontal flip leads to strides[0] < 0 and
+    // thus is_contiguous condition is not satisfied and non-vectorized code path is taken.
     auto output_strides = iter.strides(0);
     auto input_strides = iter.strides(1);
-    if (iter.ndim() > 0 && output_strides[0] == -iter.element_size(0) && input_strides[0] == iter.element_size(1)) {
-      // Special case: horizontal flip with vectorization and input is contiguous
-      // Context: horizontal flip leads to strides[0] < 0 and
-      // thus is_contiguous condition is not satisfied and non-vectorized code path is taken.
+    if (iter.ndim() > 0 && output_strides[0] < 0 && input_strides[0] == iter.element_size(1)) {
       auto iter_dtype = iter.dtype();
-      // Ignoring half and bfloat16 as cpu_hflip_vec is slower than cpu_kernel_vec
-      if (isIntegralType(iter_dtype, true) || iter_dtype == kDouble || iter_dtype == kFloat) {
-        AT_DISPATCH_ALL_TYPES_AND(kBool,
-            iter_dtype, "hflip_cpu", [&iter] {
-              cpu_hflip_vec<scalar_t>(iter);
-        });
-        return;
+      if (iter_dtype == kByte) {
+        return cpu_hflip_vec<uint8_t>(iter);
+      } else if (iter_dtype == kFloat) {
+        return cpu_hflip_vec<float>(iter);
+      } else if (iter_dtype == kInt) {
+        return cpu_hflip_vec<int32_t>(iter);
+      } else if (iter_dtype == kShort) {
+        return cpu_hflip_vec<int16_t>(iter);
+      } else if (iter_dtype == kLong) {
+        return cpu_hflip_vec<int64_t>(iter);
+      } else if (iter_dtype == kDouble) {
+        return cpu_hflip_vec<double>(iter);
       }
-      // other dtypes (float16, bfloat16, complex) are handled by cpu_kernel_vec (see below)
-    } else if (iter.has_contiguous_first_dim()) {
-      // Special case: vertical flip using memcpy (faster than generic cpu_kernel_vec)
-      return cpu_vflip_memcpy(iter);
+      // other dtypes are handled below with cpu_kernel_vec
     }
 
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBool, kHalf, kBFloat16, iter.dtype(), "flip_cpu",


### PR DESCRIPTION
Summary:
This diff is reverting D42051833
D42051833 has been identified to be causing the following test or build failures:

Tests affected:
- [//xplat/pytorch_models/build/MultitaskPeopleSegmentation/v7020:MultitaskPeopleSegmentation7020_testAndroid-64bit - runAllTests (com.facebook.xplat.XplatTestRunner)](https://www.internalfb.com/intern/test/281475056077477/)
- [//xplat/pytorch_models/build/MultitaskPeopleSegmentation/v4020:PYTORCH_MODEL_testAndroid-64bit - runAllTests (com.facebook.xplat.XplatTestRunner)](https://www.internalfb.com/intern/test/844425007913475/)

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1478566
Here are the tasks that are relevant to this breakage:
T93205881: 15 tests started failing for oncall ai_infra_mobile_platform in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Test Plan: NA

Differential Revision: D42090396



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10