### PR TITLE
[Profiler] Fix SOFT_ASSERT test to not raise on debug builds

### DIFF
--- a/test/cpp/profiler/containers.cpp
+++ b/test/cpp/profiler/containers.cpp
@@ -86,9 +86,5 @@ TEST(ProfilerTest, soft_assert) {
   EXPECT_NO_THROW(SOFT_ASSERT(false));
   // Reset soft assert behavior to default
   torch::profiler::impl::setSoftAssertRaises(c10::nullopt);
-#ifdef NDEBUG
   EXPECT_NO_THROW(SOFT_ASSERT(false));
-#else
-  EXPECT_ANY_THROW(SOFT_ASSERT(false));
-#endif
 }


### PR DESCRIPTION
Summary: There was a patch to not raise SOFT_ASSERT in debug builds. Update this test to match it.

Test Plan: This test passes after this patch.

Differential Revision: D42270123

Pulled By: aaronenyeshi

