### PR TITLE
Don't remove files across the whole OS on clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,7 +215,6 @@ build
 build_host_protoc
 build_android
 build_ios
-/build_*
 .build_debug/*
 .build_release/*
 .build_profile/*

--- a/setup.py
+++ b/setup.py
@@ -751,6 +751,9 @@ class clean(setuptools.Command):
                         break
                     # Ignore lines which begin with '#'.
                 else:
+                    # Don't remove absolute paths from the system
+                    wildcard = wildcard.lstrip('./')
+
                     for filename in glob.glob(wildcard):
                         try:
                             os.remove(filename)


### PR DESCRIPTION
setup.py clean now won't remove paths matching .gitignore patterns across the entire OS. Instead, now only files from the repository will be removed.

`/build_*` had to be removed from .gitignore because with the wildcard fixed, build_variables.bzl file was deleted on cleanup.