### PR TITLE
Print and zip remaining test logs

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -144,5 +144,7 @@ runs:
         name: usage-log-runattempt${{ github.run_attempt }}-${{ inputs.file-suffix }}.zip
         retention-days: 14
         if-no-files-found: ignore
-        path: usage_log.txt
+        path: |
+          usage_log.txt
+          test/**/*.log
       continue-on-error: true

--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -49,6 +49,9 @@ runs:
         if [ -f 'usage_log.txt' ]; then
             zip "usage-log-${FILE_SUFFIX}.zip" 'usage_log.txt'
         fi
+        if ls test/**/*.log 1> /dev/null 2>&1; then
+            zip -r "usage-log-${FILE_SUFFIX}.zip" test -i '*.log'
+        fi
 
     # Windows zip
     - name: Zip JSONs for upload
@@ -76,7 +79,7 @@ runs:
         FILE_SUFFIX: ${{ inputs.file-suffix }}
       run: |
         # -ir => recursive include all files in pattern
-        7z a "usage-log-$Env:FILE_SUFFIX.zip" 'usage_log.txt'
+        7z a "usage-log-$Env:FILE_SUFFIX.zip" 'usage_log.txt' -ir'!test\*.log'
 
     # S3 upload
     - name: Store Test Downloaded JSONs on S3

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts
-        if: always() && (steps.test.conclusion == 'success' || steps.test.conclusion == 'failure')
+        if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
         with:
           file-suffix: bazel-${{ github.job }}_${{ steps.get-job-id.outputs.job-id }}
 

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -164,7 +164,7 @@ jobs:
           )
           docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && sudo chown -R jenkins /dev && .jenkins/pytorch/test.sh && cp -Lr ./bazel-testlogs ./test/test-reports'
 
-      - name: Print undeleted logs
+      - name: Print remaining test logs
         shell: bash
         if: always()
         run: |

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -167,9 +167,8 @@ jobs:
       - name: Print undeleted logs
         shell: bash
         if: always()
-        continue-on-error: true
         run: |
-          cat test/**/*.log
+          cat test/**/*.log || exit 0
 
       - name: Chown workspace
         uses: ./.github/actions/chown-workspace

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -168,7 +168,7 @@ jobs:
         shell: bash
         if: always()
         run: |
-          cat test/**/*.log || exit 0
+          cat test/**/*.log || true
 
       - name: Chown workspace
         uses: ./.github/actions/chown-workspace

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -164,6 +164,13 @@ jobs:
           )
           docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && sudo chown -R jenkins /dev && .jenkins/pytorch/test.sh && cp -Lr ./bazel-testlogs ./test/test-reports'
 
+      - name: Print undeleted logs
+        shell: bash
+        if: always()
+        continue-on-error: true
+        run: |
+          cat test/**/*.log
+
       - name: Chown workspace
         uses: ./.github/actions/chown-workspace
         if: always()

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts
-        if: always() && (steps.test.conclusion == 'success' || steps.test.conclusion == 'failure')
+        if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
         with:
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
           use-gha: ${{ inputs.use-gha }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -210,7 +210,7 @@ jobs:
         shell: bash
         if: always()
         run: |
-          cat test/**/*.log || exit 0 || exit 0
+          cat test/**/*.log || exit 0
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -206,7 +206,7 @@ jobs:
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
           docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
 
-      - name: Print undeleted logs
+      - name: Print remaining test logs
         shell: bash
         if: always()
         run: |

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -206,6 +206,13 @@ jobs:
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
           docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
 
+      - name: Print undeleted logs
+        shell: bash
+        if: always()
+        continue-on-error: true
+        run: |
+          cat test/**/*.log
+
       - name: Get workflow job id
         id: get-job-id
         uses: ./.github/actions/get-workflow-job-id

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -210,7 +210,7 @@ jobs:
         shell: bash
         if: always()
         run: |
-          cat test/**/*.log || exit 0
+          cat test/**/*.log || true
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -209,9 +209,8 @@ jobs:
       - name: Print undeleted logs
         shell: bash
         if: always()
-        continue-on-error: true
         run: |
-          cat test/**/*.log
+          cat test/**/*.log || exit 0 || exit 0
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts
-        if: always() && (steps.test.conclusion == 'success' || steps.test.conclusion == 'failure')
+        if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
         with:
           use-gha: true
           file-suffix: ${{ github.job }}-mps-1-1-macos-m1-12_${{ steps.get-job-id.outputs.job-id }}

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -82,7 +82,7 @@ jobs:
 
           ${CONDA_RUN} python3 test/run_test.py --mps --verbose
 
-      - name: Print undeleted logs
+      - name: Print remaining test logs
         shell: bash
         if: always()
         run: |

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -86,7 +86,7 @@ jobs:
         shell: bash
         if: always()
         run: |
-          cat test/**/*.log || exit 0
+          cat test/**/*.log || true
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -85,9 +85,8 @@ jobs:
       - name: Print undeleted logs
         shell: bash
         if: always()
-        continue-on-error: true
         run: |
-          cat test/**/*.log
+          cat test/**/*.log || exit 0
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -82,6 +82,13 @@ jobs:
 
           ${CONDA_RUN} python3 test/run_test.py --mps --verbose
 
+      - name: Print undeleted logs
+        shell: bash
+        if: always()
+        continue-on-error: true
+        run: |
+          cat test/**/*.log
+
       - name: Get workflow job id
         id: get-job-id
         uses: ./.github/actions/get-workflow-job-id

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts
-        if: always() && (steps.test.conclusion == 'success' || steps.test.conclusion == 'failure')
+        if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
         with:
           use-gha: true
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -154,7 +154,7 @@ jobs:
         shell: bash
         if: always()
         run: |
-          cat test/**/*.log || exit 0
+          cat test/**/*.log || true
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -150,6 +150,13 @@ jobs:
           ${CONDA_RUN} python3 -mpip install --no-index --no-deps $(echo dist/*.whl)
           ${CONDA_RUN} .jenkins/pytorch/macos-test.sh
 
+      - name: Print undeleted logs
+        shell: bash
+        if: always()
+        continue-on-error: true
+        run: |
+          cat test/**/*.log
+
       - name: Get workflow job id
         id: get-job-id
         uses: ./.github/actions/get-workflow-job-id

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -150,7 +150,7 @@ jobs:
           ${CONDA_RUN} python3 -mpip install --no-index --no-deps $(echo dist/*.whl)
           ${CONDA_RUN} .jenkins/pytorch/macos-test.sh
 
-      - name: Print undeleted logs
+      - name: Print remaining test logs
         shell: bash
         if: always()
         run: |

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -153,9 +153,8 @@ jobs:
       - name: Print undeleted logs
         shell: bash
         if: always()
-        continue-on-error: true
         run: |
-          cat test/**/*.log
+          cat test/**/*.log || exit 0
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts
-        if: always() && (steps.test.conclusion == 'success' || steps.test.conclusion == 'failure')
+        if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
         with:
           use-gha: true
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -196,6 +196,13 @@ jobs:
           # copy test results back to the mounted workspace, needed sudo, resulting permissions were correct
           docker exec -t "${{ env.CONTAINER_NAME }}" sh -c "cd ../pytorch && sudo cp -R test/test-reports ../workspace/test"
 
+      - name: Print undeleted logs
+        shell: bash
+        if: always()
+        continue-on-error: true
+        run: |
+          cat test/**/*.log
+
       - name: Get workflow job id
         id: get-job-id
         uses: ./.github/actions/get-workflow-job-id

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -190,17 +190,17 @@ jobs:
           # jenkins user does not have write permission to mounted workspace; work-around by copying within container to jenkins home
           docker exec -t "${container_name}" sh -c "cd .. && cp -R workspace pytorch && cd pytorch && pip install dist/*.whl && ${TEST_COMMAND}"
 
-      - name: Save test results
-        if: always()
-        run: |
-          # copy test results back to the mounted workspace, needed sudo, resulting permissions were correct
-          docker exec -t "${{ env.CONTAINER_NAME }}" sh -c "cd ../pytorch && sudo cp -R test/test-reports ../workspace/test"
-
       - name: Print undeleted logs
         shell: bash
         if: always()
         run: |
           cat test/**/*.log || exit 0
+
+      - name: Save test results
+        if: always()
+        run: |
+          # copy test results back to the mounted workspace, needed sudo, resulting permissions were correct
+          docker exec -t "${{ env.CONTAINER_NAME }}" sh -c "cd ../pytorch && sudo cp -R test/test-reports ../workspace/test"
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -190,17 +190,17 @@ jobs:
           # jenkins user does not have write permission to mounted workspace; work-around by copying within container to jenkins home
           docker exec -t "${container_name}" sh -c "cd .. && cp -R workspace pytorch && cd pytorch && pip install dist/*.whl && ${TEST_COMMAND}"
 
-      - name: Print undeleted logs
-        shell: bash
-        if: always()
-        run: |
-          cat test/**/*.log || true
-
       - name: Save test results
         if: always()
         run: |
           # copy test results back to the mounted workspace, needed sudo, resulting permissions were correct
           docker exec -t "${{ env.CONTAINER_NAME }}" sh -c "cd ../pytorch && sudo cp -R test/test-reports ../workspace/test"
+
+      - name: Print remaining test logs
+        shell: bash
+        if: always()
+        run: |
+          cat test/**/*.log || true
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -194,7 +194,7 @@ jobs:
         shell: bash
         if: always()
         run: |
-          cat test/**/*.log || exit 0
+          cat test/**/*.log || true
 
       - name: Save test results
         if: always()

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -199,9 +199,8 @@ jobs:
       - name: Print undeleted logs
         shell: bash
         if: always()
-        continue-on-error: true
         run: |
-          cat test/**/*.log
+          cat test/**/*.log || exit 0
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts
-        if: always() && (steps.test.conclusion == 'success' || steps.test.conclusion == 'failure')
+        if: always() && steps.test.conclusion && steps.test.conclusion != 'skipped'
         with:
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -168,7 +168,7 @@ jobs:
         shell: bash
         if: always()
         run: |
-          cat test/**/*.log || exit 0
+          cat test/**/*.log || true
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -164,6 +164,13 @@ jobs:
 
           .jenkins/pytorch/win-test.sh
 
+      - name: Print undeleted logs
+        shell: bash
+        if: always()
+        continue-on-error: true
+        run: |
+          cat test/**/*.log
+
       - name: Get workflow job id
         id: get-job-id
         uses: ./.github/actions/get-workflow-job-id

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -167,9 +167,8 @@ jobs:
       - name: Print undeleted logs
         shell: bash
         if: always()
-        continue-on-error: true
         run: |
-          cat test/**/*.log
+          cat test/**/*.log || exit 0
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -164,7 +164,7 @@ jobs:
 
           .jenkins/pytorch/win-test.sh
 
-      - name: Print undeleted logs
+      - name: Print remaining test logs
         shell: bash
         if: always()
         run: |

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -472,7 +472,7 @@ def run_test(
     with open(log_path, "w") as f:
         ret_code = shell(command, test_directory, stdout=f, stderr=f, env=env)
     print_log_file(test_module, log_path, failed=(ret_code != 0))
-    os.remove(log_path)
+    # os.remove(log_path)
     return ret_code
 
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -472,7 +472,7 @@ def run_test(
     with open(log_path, "w") as f:
         ret_code = shell(command, test_directory, stdout=f, stderr=f, env=env)
     print_log_file(test_module, log_path, failed=(ret_code != 0))
-    # os.remove(log_path)
+    os.remove(log_path)
     return ret_code
 
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -464,7 +464,8 @@ def run_test(
 
     os.makedirs(REPO_ROOT / "test" / "test-reports", exist_ok=True)
     log_fd, log_path = tempfile.mkstemp(dir=REPO_ROOT / "test" / "test-reports",
-                                        prefix="{}_".format(test_module.replace("\\", "-").replace("/", "-")))
+                                        prefix="{}_".format(test_module.replace("\\", "-").replace("/", "-")),
+                                        suffix=".log")
     os.close(log_fd)
     command = (launcher_cmd or []) + executable + argv
     print_to_stderr("Executing {} ... [{}]".format(command, datetime.now()))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -460,7 +460,6 @@ class TestDataLoaderUtils(TestCase):
             dataloader = torch.utils.data.DataLoader(RandomDatasetMock(),
                                                      batch_size=2,
                                                      num_workers=4,
-                                                     multiprocessing_context=torch.multiprocessing.get_context("spawn"),
                                                      shuffle=True)
             return next(iter(dataloader))
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -460,6 +460,7 @@ class TestDataLoaderUtils(TestCase):
             dataloader = torch.utils.data.DataLoader(RandomDatasetMock(),
                                                      batch_size=2,
                                                      num_workers=4,
+                                                     multiprocessing_context=torch.multiprocessing.get_context("spawn"),
                                                      shuffle=True)
             return next(iter(dataloader))
 


### PR DESCRIPTION
When CI times out or gets cancelled, the code to print and delete logs for currently running tests doesn't get run, which makes it hard to debug what's going on, so print the logs in a new step and also zip them into the usage-log zip (which should probably get a name change at some point)