### PR TITLE
Make job names match BUILD_ENVIRONMENT

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -36,51 +36,29 @@ jobs:
       test-matrix: ${{ needs.linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build.outputs.test-matrix }}
       timeout-minutes: 300
 
-  linux-focal-rocm5_3-py3_8-slow-build:
-    name: linux-focal-rocm5.3-py3.8-slow
+  linux-focal-rocm5_3-py3_8-build:
+    name: linux-focal-rocm5.3-py3.8
     uses: ./.github/workflows/_linux-build.yml
+    if: false
     with:
       build-environment: linux-focal-rocm5.3-py3.8
       docker-image-name: pytorch-linux-focal-rocm5.3-py3.8
       test-matrix: |
         { include: [
+          # { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
+          # { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
           { config: "slow", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },
         ]}
 
-  linux-focal-rocm5_3-py3_8-slow-test:
-    name: linux-focal-rocm5.3-py3.8-slow
+  linux-focal-rocm5_3-py3_8-test:
+    name: linux-focal-rocm5.3-py3.8
     uses: ./.github/workflows/_rocm-test.yml
-    needs: linux-focal-rocm5_3-py3_8-slow-build
-    with:
-      build-environment: linux-focal-rocm5.3-py3.8
-      docker-image: ${{ needs.linux-focal-rocm5_3-py3_8-slow-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-rocm5_3-py3_8-slow-build.outputs.test-matrix }}
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
-
-  linux-focal-rocm5_3-py3_8-distributed-build:
-    name: linux-focal-rocm5.3-py3.8-distributed
-    uses: ./.github/workflows/_linux-build.yml
     if: false
+    needs: linux-focal-rocm5_3-py3_8-build
     with:
       build-environment: linux-focal-rocm5.3-py3.8
-      docker-image-name: pytorch-linux-focal-rocm5.3-py3.8
-      test-matrix: |
-        { include: [
-          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
-          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
-        ]}
-
-  linux-focal-rocm5_3-py3_8-distributed-test:
-    name: linux-focal-rocm5.3-py3.8-distributed
-    uses: ./.github/workflows/_rocm-test.yml
-    needs: linux-focal-rocm5_3-py3_8-distributed-build
-    if: false
-    with:
-      build-environment: linux-focal-rocm5.3-py3.8
-      docker-image: ${{ needs.linux-focal-rocm5_3-py3_8-distributed-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-rocm5_3-py3_8-distributed-build.outputs.test-matrix }}
+      docker-image: ${{ needs.linux-focal-rocm5_3-py3_8-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-rocm5_3-py3_8-build.outputs.test-matrix }}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -44,10 +44,14 @@ jobs:
       docker-image-name: pytorch-linux-focal-rocm5.3-py3.8
       test-matrix: |
         { include: [
-          # { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
-          # { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
           { config: "slow", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },
         ]}
+      # test-matrix: |
+      #   { include: [
+      #     { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
+      #     { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
+      #     { config: "slow", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },
+      #   ]}
 
   linux-focal-rocm5_3-py3_8-test:
     name: linux-focal-rocm5.3-py3.8

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -56,7 +56,6 @@ jobs:
   linux-focal-rocm5_3-py3_8-test:
     name: linux-focal-rocm5.3-py3.8
     uses: ./.github/workflows/_rocm-test.yml
-    if: false
     needs: linux-focal-rocm5_3-py3_8-build
     with:
       build-environment: linux-focal-rocm5.3-py3.8

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -39,7 +39,6 @@ jobs:
   linux-focal-rocm5_3-py3_8-build:
     name: linux-focal-rocm5.3-py3.8
     uses: ./.github/workflows/_linux-build.yml
-    if: false
     with:
       build-environment: linux-focal-rocm5.3-py3.8
       docker-image-name: pytorch-linux-focal-rocm5.3-py3.8

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -78,7 +78,7 @@ jobs:
       test-matrix: ${{ needs.linux-bionic-cuda11_7-py3_10-gcc7-build.outputs.test-matrix }}
 
   linux-bionic-cuda11_6-py3_10-gcc7-sm86-build:
-    name: cuda11.6-py3.10-gcc7-sm86
+    name: linux-bionic-cuda11.6-py3.10-gcc7-sm86
     uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-bionic-cuda11.6-py3.10-gcc7-sm86
@@ -96,7 +96,7 @@ jobs:
         ]}
 
   linux-bionic-cuda11_6-py3_10-gcc7-sm86-test:
-    name: cuda11.6-py3.10-gcc7-sm86
+    name: linux-bionic-cuda11.6-py3.10-gcc7-sm86
     uses: ./.github/workflows/_linux-test.yml
     needs: linux-bionic-cuda11_6-py3_10-gcc7-sm86-build
     with:


### PR DESCRIPTION
test-times.json uses the job name as the key, but when looking up the the times in CI, the BUILD_ENVIRONMENT is used because we don't have a good way of getting the job name (it usually turns out to be just "test" or "build" instead of "linux-cuda..."), so having the job names match the BUILD_ENVIRONMENT is necessary for sharding to work

Another solution might be to make the lookup more robust or look up the job name similar to how we get the job id.