### PR TITLE
fix: pytree - better handling of scalar values 

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -210,6 +210,8 @@ class TestPytree(TestCase):
     def test_broadcast_to_and_flatten(self):
         cases = [
             (1, (), []),
+            (1, 1, [1]),
+            (None, [1], [None]),
 
             # Same (flat) structures
             ((1,), (0,), [1]),

--- a/torch/_functorch/vmap.py
+++ b/torch/_functorch/vmap.py
@@ -152,20 +152,9 @@ def _unwrap_batched(
             f'out_dims has structure {tree_flatten(out_dims)[1]} but outputs '
             f'has structure {output_spec}.')
 
-    if isinstance(batched_outputs, torch.Tensor):
-        # Some weird edge case requires us to spell out the following
-        # see test_out_dims_edge_case
-        if isinstance(out_dims, int):
-            flat_out_dims = [out_dims]
-        elif isinstance(out_dims, tuple) and len(out_dims) == 1:
-            flat_out_dims = out_dims
-            out_dims = out_dims[0]
-        else:
-            incompatible_error()
-    else:
-        flat_out_dims = _broadcast_to_and_flatten(out_dims, output_spec)
-        if flat_out_dims is None:
-            incompatible_error()
+    flat_out_dims = _broadcast_to_and_flatten(out_dims, output_spec)
+    if flat_out_dims is None:
+        incompatible_error()
 
     flat_outputs = [
         _remove_batch_dim(batched_output, vmap_level, batch_size, out_dim)

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -304,7 +304,9 @@ def _broadcast_to_and_flatten(pytree: PyTree, spec: TreeSpec) -> Optional[List[A
     if _is_leaf(pytree):
         return [pytree] * spec.num_leaves
     if isinstance(spec, LeafSpec):
-        return pytree
+        if isinstance(pytree, (list,tuple)):
+            return list(pytree)
+        return [pytree]
     node_type = _get_node_type(pytree)
     if node_type != spec.type:
         return None

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -304,7 +304,7 @@ def _broadcast_to_and_flatten(pytree: PyTree, spec: TreeSpec) -> Optional[List[A
     if _is_leaf(pytree):
         return [pytree] * spec.num_leaves
     if isinstance(spec, LeafSpec):
-        return None
+        return pytree
     node_type = _get_node_type(pytree)
     if node_type != spec.type:
         return None

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -304,7 +304,7 @@ def _broadcast_to_and_flatten(pytree: PyTree, spec: TreeSpec) -> Optional[List[A
     if _is_leaf(pytree):
         return [pytree] * spec.num_leaves
     if isinstance(spec, LeafSpec):
-        if isinstance(pytree, (list,tuple)):
+        if isinstance(pytree, (list, tuple)):
             return list(pytree)
         return [pytree]
     node_type = _get_node_type(pytree)

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -305,6 +305,8 @@ def _broadcast_to_and_flatten(pytree: PyTree, spec: TreeSpec) -> Optional[List[A
         return [pytree] * spec.num_leaves
     if isinstance(spec, LeafSpec):
         if isinstance(pytree, (list, tuple)):
+            if len(pytree) != 1:
+                return None
             return list(pytree)
         return [pytree]
     node_type = _get_node_type(pytree)


### PR DESCRIPTION
Part of https://github.com/pytorch/functorch/issues/1082 and https://github.com/pytorch/functorch/issues/439

This removes the need for `Some weird edge case requires us to spell out the following see test_out_dims_edge_case`

I found this when trying to add support for None values:

`_broadcast_to_and_flatten([1], *)` should return `[1]` but instead returns `None`

Current behaviour
```py
In [2]: a,b = pytree.tree_flatten(1)
In [3]: c, d = pytree.tree_flatten([1])

In [4]: pytree._broadcast_to_and_flatten(1, b)
Out[4]: [1]

In [5]: pytree._broadcast_to_and_flatten(1, d)
Out[5]: [1]

In [6]: pytree._broadcast_to_and_flatten([1], b)
Out[6]: None
In [7]: pytree._broadcast_to_and_flatten([1], d)
Out[7]: [1]
```
Behaviour after PR:
```py

In [1]: from torch.utils import _pytree  as pytree

In [2]: a,b = pytree.tree_flatten(1)
In [3]: c, d = pytree.tree_flatten([1])

In [4]: pytree._broadcast_to_and_flatten(1, b)
Out[4]: [1]
In [5]: pytree._broadcast_to_and_flatten(1, d)
Out[5]: [1]

In [6]: pytree._broadcast_to_and_flatten([1], b)
Out[6]: [1]
In [7]: pytree._broadcast_to_and_flatten([1], d)
Out[7]: [1]
```

