### PR TITLE
Run jit legacy tests sequentially

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1105,7 +1105,8 @@ def must_serial(file: str) -> bool:
         "distributed" in file or
         file in CUSTOM_HANDLERS or
         file in RUN_PARALLEL_BLOCKLIST or
-        file in CI_SERIAL_LIST
+        file in CI_SERIAL_LIST or
+        file in JIT_EXECUTOR_TESTS
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/91457.  I have been re-running the 2 tests `test_jit_legacy` and `test_jit_fuser_legacy` in `jit_legacy` shard multiple times (100+) without any flaky issues found.  I suspect that we might have a test parallelization flakiness here.  So this PR runs these 2 tests serially.  They takes less than 5 minutes to finish, so running them sequentially won't be an issue (https://hud.pytorch.org/hud/pytorch/pytorch/master/1?per_page=50&name_filter=jit_legacy)
