### PR TITLE
[MPS] Fix the crash in max_out() caused by cached key conflict

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -1351,7 +1351,7 @@ void min_max_out_mps(const Tensor& input_t,
   auto stream = at::mps::getCurrentMPSStream();
 
   @autoreleasepool {
-    string key = func_name + ":" + to_string(dim_) + ":" + getMPSTypeString(input_t.scalar_type());
+    string key = func_name + getTensorsStringKey({input_t, indices_t}) + ":" + to_string(dim_);
     CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
     if (!cachedGraph) {


### PR DESCRIPTION
The shape of input and indices tensors were missing in the cached key