### PR TITLE
Remove _ignored_param_names

### DIFF
--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -306,10 +306,8 @@ def _full_post_state_dict_hook(
         if clean_key.startswith(clean_prefix):
             clean_key = clean_key[len(clean_prefix) :]
 
-        # Clone non-ignored parameters before exiting the `_unshard_params()` context.
-        if clean_key not in fsdp_state._ignored_param_names and not getattr(
-            state_dict[fqn], "_has_been_cloned", False
-        ):
+        # Clone parameters before exiting the `_unshard_params()` context.
+        if not getattr(state_dict[fqn], "_has_been_cloned", False):
             try:
                 state_dict[fqn] = state_dict[fqn].clone().detach()
                 state_dict[fqn]._has_been_cloned = True  # type: ignore[attr-defined]


### PR DESCRIPTION
'_ignored_param_names' is only used in 'param_hook' during state_dict() post hook processing to check a parameter key needs to be cloned or not. But it is not needed, as state_dict() post hook only passes fsdp managed parameter keys to 'param_hook', see https://github.com/pytorch/pytorch/blob/master/torch/distributed/fsdp/_state_dict_utils.py#L203. That means the passed parameter keys are always not part of '_ignored_param_names'.

so we should be able to safely remove '_ignored_param_names' and related codes