### PR TITLE
Add an option to allow passing ignored_parameters to FSDP

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -50,6 +50,7 @@ class _FSDPState(_State):
         self.sharding_strategy = ShardingStrategy.FULL_SHARD
         self.compute_device = torch.device("cuda", torch.cuda.current_device())
         self.process_group: Optional[dist.ProcessGroup] = None
+        self._ignored_params: Set[nn.Parameter] = set()
 
 
 def _get_module_fsdp_state(module: nn.Module) -> Optional[_FSDPState]:


### PR DESCRIPTION
This is mainly to resolve composability issue btw TorchRec and FSDP. 

For some types of sharded modules in TorchRec, their named_parameters() and named_modules() are overridden by TorchRec and do not follow the PyTorch named_parameters() and named_modules() convention. 

For such cases, ignored_modules do not work well as the parameters extracted from ignored_modules() may not match sparse sharded parameters in TorchRec.dmp_wrapped_module.parameters(). 

One solution is to allow users to pass ignored_parameters directly to FSDP.  e.g. they can call sharded_parameter_names() API in TorchRec to get the right ignored_parameters and then pass them to FSDP. The parameters returned from sharded_parameter_names() will match sparse sharded parameters in TorchRec.dmp_wrapped_module..parameters(), as both of they are offerred/overriden by TorchRec.

In this PR, we do not allow users to pass both ignored_modules and ignored_parameters for simplicity (in theory, it should work, but no need to add complexity for tests and possibly edge cases? especially we do not have a real use case to use both yet). 