### PR TITLE
fixing test_batch_norm_implicit_dtype_promotion (__main__.TestNvFuserDynamo)

### DIFF
--- a/torch/_prims/nvfuser_prims.py
+++ b/torch/_prims/nvfuser_prims.py
@@ -396,6 +396,7 @@ def register_full():
         dtype=None,
         layout=None,
         device=None,
+        pin_memory=False,
         requires_grad=False,
     ):
         strides = make_contiguous_strides_for(size)


### PR DESCRIPTION
patches the missing pin_memory argument on full::meta_impl. This is not a functional break, but it does give test failure, which asserts on no warning. vvv
`python test/test_nvfuser_dynamo.py -k test_batch_norm_implicit_dtype_promotion`