### PR TITLE
Revert D42257039: Multisect successfully blamed D42257039 for test or build failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -981,7 +981,6 @@ def main():
         'typing_extensions',
         'sympy',
         'networkx',
-        'packaging'
     ]
 
     extras_require = {

--- a/torch/utils/tensorboard/__init__.py
+++ b/torch/utils/tensorboard/__init__.py
@@ -1,12 +1,12 @@
 import tensorboard
-from packaging import version  # type: ignore[import]
+from distutils.version import LooseVersion
 
-if not hasattr(tensorboard, "__version__") or version.parse(
+if not hasattr(tensorboard, "__version__") or LooseVersion(
     tensorboard.__version__
-) < version.Version("1.15"):
+) < LooseVersion("1.15"):
     raise ImportError("TensorBoard logging requires TensorBoard version 1.15 or above")
 
-del version
+del LooseVersion
 del tensorboard
 
 from .writer import FileWriter, SummaryWriter  # noqa: F401


### PR DESCRIPTION
Summary:
This diff is reverting D42257039
D42257039 has been identified to be causing the following test or build failures:

Tests affected:
- [assistant/neural_dm/rl/modules/tests:action_mask_classifier_test - main](https://www.internalfb.com/intern/test/281475048940766/)

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1493969
Here are the tasks that are relevant to this breakage:
T93770103: 1 test started failing for oncall assistant_multimodal in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Test Plan: NA

Reviewed By: weiwangmeta

Differential Revision: D42272391

