### PR TITLE
symbolic shapes: add parenthesis around FloorDiv expression

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -888,9 +888,8 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(opt_fn(input1), correct1))
         self.assertTrue(same(opt_fn(input2), correct2))
 
-        # Dyn recompiles are due to changes in hidden_state (Should we be guarding on this?)
-        self.assertEqual(cnt.frame_count, ifdyn(4, 2))
-        self.assertEqual(cnt.op_count, ifdyn(76, 4))
+        self.assertEqual(cnt.frame_count, 2)
+        self.assertEqual(cnt.op_count, ifdyn(38, 4))
 
     def test_hf_t5_forward(self):
         input = torch.randn([1, 2048, 512])

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 try:
     import sympy  # type: ignore[import]
-    from sympy.printing.precedence import precedence  # type: ignore[import]
+    from sympy.printing.precedence import precedence  # type: ignore[import] # noqa: F401
     from sympy.printing.str import StrPrinter  # type: ignore[import]
     HAS_SYMPY = True
 except ImportError:
@@ -217,17 +217,13 @@ if HAS_SYMPY:
         2. Printing out the expression is nicer (compared to say, representing a//b as (a - a % b) / b)
         """
         nargs = (2,)
+        precedence = 50  # precedence of mul  # noqa: F811
 
         def _sympystr(self, printer):
             lhs = self.args[0]
             rhs = self.args[1]
-            lhs_str = printer._print(lhs)
-            rhs_str = printer._print(rhs)
-            if precedence(lhs) < precedence(sympy.div):
-                lhs_str = f"({lhs_str})"
-            if precedence(rhs) < precedence(sympy.div):
-                rhs_str = f"({rhs_str})"
-
+            lhs_str = printer.parenthesize(lhs, self.precedence)
+            rhs_str = printer.parenthesize(rhs, self.precedence)
             return f"{lhs_str}//{rhs_str}"
 
         @classmethod


### PR DESCRIPTION
Before it would print the guard expression like:
`2*3//2`
and now:
`2*(3//2)`

```python
print(2*3//2)   # 3
print(2*(3//2)) # 2
```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire @ezyang