### PR TITLE
Fix and update type hints for `make_functional.py`

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -108,7 +108,6 @@ exclude_patterns = [
     'torch/_functorch/eager_transforms.py',
     'torch/_functorch/fx_minifier.py',
     'torch/_functorch/partitioners.py',
-    'torch/_functorch/make_functional.py',
     'torch/_functorch/top_operators_github_usage.py',
     'torch/_functorch/vmap.py',
     'torch/distributed/elastic/agent/server/api.py',
@@ -830,6 +829,7 @@ include_patterns = [
     'torchgen/**/*.py',
     'functorch/functorch/_src/aot_autograd.py',
     'functorch/functorch/_src/compilers.py',
+    'torch/_functorch/make_functional.py',
     'torch/testing/*.py',
 ]
 command = [

--- a/torch/_functorch/make_functional.py
+++ b/torch/_functorch/make_functional.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
-from collections import OrderedDict
 from typing import (
     Any,
     Callable,
@@ -82,20 +81,20 @@ def create_names_map(
     This function creates a mapping from the names in named_params to the
     names in tied_named_params: {'A': [['A']], 'B': [['B'], ['B_tied']]}.
     """
-    named_params = OrderedDict(named_params)
-    tied_named_params = OrderedDict(tied_named_params)
+    named_params = dict(named_params)
+    tied_named_params = dict(tied_named_params)
 
     tensors_dict_keys = set(named_params.keys())
     tied_tensors_dict_keys = set(tied_named_params.keys())
     assert tensors_dict_keys.issubset(tied_tensors_dict_keys)
 
-    tensor_to_mapping: Dict[Tensor, Tuple[str, List[List[str]]]] = OrderedDict()
+    tensor_to_mapping: Dict[Tensor, Tuple[str, List[List[str]]]] = {}
     for key, tensor in named_params.items():
         tensor_to_mapping[tensor] = (key, [])
     for key, tensor in tied_named_params.items():
         assert tensor in tensor_to_mapping
         tensor_to_mapping[tensor][1].append(key.split('.'))
-    return OrderedDict(tensor_to_mapping.values())
+    return dict(tensor_to_mapping.values())
 
 
 def _extract_members(
@@ -293,7 +292,7 @@ class FunctionalModuleWithBuffers(nn.Module):
         self.param_names = param_names
         self.buffer_names = buffer_names
 
-        self.all_names_map = OrderedDict(param_names_map)
+        self.all_names_map = dict(param_names_map)
         self.all_names_map.update(buffer_names_map)
 
     @staticmethod


### PR DESCRIPTION
Changes in details:

- Fix and update some out-of-date type hints in `_functorch/make_functional.py`.
- ~Explicitly use `OrderedDict` for order-sensitive mappings.~

	In `create_names_map()`, `_swap_state()`, and `FunctionalModuleWithBuffers.__init__()`, the unordered `dict` was used. The key order should be preserved for `dict.items()` while it is required to `zip` with a tuple of `params`/`buffers`. Although since Python 3.6, the built-in dictionary is insertion ordered ([PEP 468](https://peps.python.org/pep-0468)). Explicit is better than implicit.

cc @zou3519