### PR TITLE
add filelock as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1013,6 +1013,7 @@ def print_box(msg):
 def main():
     # the list of runtime dependencies required by this built package
     install_requires = [
+        'filelock',
         'typing_extensions',
         'sympy',
         'networkx',


### PR DESCRIPTION
`filelock` is a dependency now for inductor's caching mechanism and CPU backend.

Add `filelock` as a dependency

Fixes https://github.com/pytorch/pytorch/issues/93499
