### PR TITLE
[MPS] Fix multinomial crash for negative values in bandOP 

### DIFF
--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -394,11 +394,10 @@ Tensor& multinomial_with_replacement_mps_kernel(
           MPSGraphTensor *ones = [mpsGraph constantWithScalar:1.0f
                                                         shape:@[ns_numCategories, ns_numCategories]
                                                      dataType:prob_dtype];
-          auto zeroTensor = [mpsGraph constantWithScalar: 0.0f
-                                                dataType: MPSDataTypeInt32];
-          auto minusOneTensor = [mpsGraph constantWithScalar: -1.0f
-                                                    dataType: MPSDataTypeInt32];
-
+          MPSGraphTensor *zeroTensor = [mpsGraph constantWithScalar:0.0f
+                                                          dataType:MPSDataTypeInt32];
+          MPSGraphTensor *minusOneTensor = [mpsGraph constantWithScalar:-1.0f
+                                                              dataType:MPSDataTypeInt32];
           MPSGraphTensor *upperTriangle = [mpsGraph bandPartWithTensor:ones
                                                         numLowerTensor:zeroTensor
                                                         numUpperTensor:minusOneTensor


### PR DESCRIPTION
Fixes multinomial crash happening on AMD:
```
test_multinomial (__main__.TestNLLLoss) ... 2022-10-21 10:55:57.184 python3[96212:646664] Error getting visible function:
 (null) error: invalid qualified function name 'bandPartOp_0_m-2147483648__f
```