### PR TITLE
Remove CircleCI ios PR jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1447,27 +1447,4 @@ workflows:
             branches:
               only:
                 - postnightly
-      - pytorch_ios_build:
-          build_environment: ios-12-5-1-x86-64
-          filters:
-            branches:
-              ignore:
-                - nightly
-                - postnightly
-          ios_arch: x86_64
-          ios_platform: SIMULATOR
-          lite_interpreter: "1"
-          name: ios-12-5-1-x86-64
-      - pytorch_ios_build:
-          build_environment: ios-12-5-1-x86-64-coreml
-          filters:
-            branches:
-              ignore:
-                - nightly
-                - postnightly
-          ios_arch: x86_64
-          ios_platform: SIMULATOR
-          lite_interpreter: "1"
-          name: ios-12-5-1-x86-64-coreml
-          use_coreml: "1"
     when: << pipeline.parameters.run_build >>

--- a/.circleci/generate_config_yml.py
+++ b/.circleci/generate_config_yml.py
@@ -14,7 +14,6 @@ import cimodel.data.simple.docker_definitions
 import cimodel.data.simple.mobile_definitions
 import cimodel.data.simple.nightly_ios
 import cimodel.data.simple.anaconda_prune_defintions
-import cimodel.data.simple.ios_definitions
 import cimodel.lib.miniutils as miniutils
 import cimodel.lib.miniyaml as miniyaml
 
@@ -141,7 +140,6 @@ def gen_build_workflows_tree():
         cimodel.data.simple.mobile_definitions.get_workflow_jobs,
         cimodel.data.simple.nightly_ios.get_workflow_jobs,
         cimodel.data.simple.anaconda_prune_defintions.get_workflow_jobs,
-        cimodel.data.simple.ios_definitions.get_workflow_jobs,
     ]
     build_jobs = [f() for f in build_workflows_functions]
     build_jobs.extend(


### PR DESCRIPTION
We added this because we wanted to burn our extra CIrcleCI credits, but now that it's the next year, those should be gone.