### PR TITLE
update .circleci/docker/common/install_cmake.sh for centos

### DIFF
--- a/.circleci/docker/common/install_cmake.sh
+++ b/.circleci/docker/common/install_cmake.sh
@@ -5,7 +5,19 @@ set -ex
 [ -n "$CMAKE_VERSION" ]
 
 # Remove system cmake install so it won't get used instead
-apt-get remove cmake -y
+ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+case "$ID" in
+  ubuntu)
+    apt-get remove cmake -y
+    ;;
+  centos)
+    yum remove cmake -y
+    ;;
+  *)
+    echo "Unable to determine OS..."
+    exit 1
+    ;;
+esac
 
 # Turn 3.6.3 into v3.6
 path=$(echo "${CMAKE_VERSION}" | sed -e 's/\([0-9].[0-9]\+\).*/v\1/')


### PR DESCRIPTION
Otherwise .circleci/docker/common/install_cmake.sh fails for centos due to use of apt-get instead of yum.