### PR TITLE
Support per-parameter test decoration

### DIFF
--- a/test/functorch/test_vmap_registrations.py
+++ b/test/functorch/test_vmap_registrations.py
@@ -8,6 +8,8 @@ from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,
     instantiate_parametrized_tests,
+    parametrize,
+    subtest
 )
 
 from torch._C import (
@@ -327,30 +329,15 @@ xfail_not_implemented = {
 }
 
 
-class dispatch_registrations(_TestParametrizer):
-    def __init__(
-        self,
-        dispatch_key: str,
-        xfails: set,
-        filter_func: typing.Callable = lambda reg: True,
-    ):
-        self.registrations = sorted(get_registrations_for_dispatch_key(dispatch_key))
-        self.xfails = xfails
-        self.filter_func = filter_func
-
-    def _parametrize_test(self, test, generic_cls, device_cls):
-        for registration in self.registrations:
-            if not self.filter_func(registration):
-                continue
-
-            @wraps(test)
-            def test_wrapper(*args, **kwargs):
-                return test(*args, **kwargs)
-
-            if registration in self.xfails:
-                test_wrapper = unittest.expectedFailure(test_wrapper)
-
-            yield (test_wrapper, f"[{registration}]", {"registration": registration})
+def dispatch_registrations(
+        dispatch_key: str, xfails: set, filter_func: typing.Callable = lambda reg: True):
+    registrations = sorted(get_registrations_for_dispatch_key(dispatch_key))
+    subtests = [
+        subtest(reg, name=f"[{reg}]",
+                decorators=([unittest.expectedFailure] if reg in xfails else []))
+        for reg in registrations if filter_func(reg)
+    ]
+    return parametrize("registration", subtests)
 
 
 CompositeImplicitAutogradRegistrations = set(

--- a/test/functorch/test_vmap_registrations.py
+++ b/test/functorch/test_vmap_registrations.py
@@ -1,10 +1,8 @@
 # Owner(s): ["module: functorch"]
-from functools import wraps
 import typing
 import unittest
 
 from torch.testing._internal.common_utils import (
-    _TestParametrizer,
     TestCase,
     run_tests,
     instantiate_parametrized_tests,

--- a/test/test_masked.py
+++ b/test/test_masked.py
@@ -259,7 +259,7 @@ class mask_layouts(_TestParametrizer):
             test(self, layout, device, dtype, op, sample_inputs_generator())
 
         for layout in (torch.strided, torch.sparse_coo, torch.sparse_csr):
-            yield (wrap, str(layout).lstrip('torch.'), {'layout': layout})
+            yield (wrap, str(layout).lstrip('torch.'), {'layout': layout}, lambda _: [])
 
 
 class TestMasked(TestCase):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -26,9 +26,9 @@ from torch.testing._internal.common_device_type import \
      deviceCountAtLeast, ops, expectedFailureMeta, OpDTypes)
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal import opinfo
-from torch.testing._internal.common_dtype import all_types_and_complex_and
-from torch.testing._internal.common_modules import modules, module_db
-from torch.testing._internal.opinfo.core import SampleInput
+from torch.testing._internal.common_dtype import all_types_and_complex_and, floating_types
+from torch.testing._internal.common_modules import modules, module_db, ModuleInfo
+from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInfo
 
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
@@ -1416,6 +1416,12 @@ def _get_test_names_for_test_class(test_cls):
     return sorted(test_names)
 
 
+def _get_test_funcs_for_test_class(test_cls):
+    """ Convenience function to get all (test function, parametrized_name) pairs for a given test class. """
+    test_funcs = [(getattr(test_cls, key), key) for key in test_cls.__dict__ if key.startswith('test_')]
+    return test_funcs
+
+
 class TestTestParametrization(TestCase):
     def test_default_names(self):
 
@@ -1506,6 +1512,48 @@ class TestTestParametrization(TestCase):
         test_names = _get_test_names_for_test_class(TestParametrized)
         self.assertEqual(expected_test_names, test_names)
 
+    def test_apply_param_specific_decorators(self):
+        # Test that decorators can be applied on a per-param basis.
+
+        def test_dec(func):
+            func._decorator_applied = True
+            return func
+
+        class TestParametrized(TestCase):
+            @parametrize("x", [subtest(1, name='one'),
+                               subtest(2, name='two', decorators=[test_dec]),
+                               subtest(3, name='three')])
+            def test_param(self, x):
+                pass
+
+        instantiate_parametrized_tests(TestParametrized)
+
+        for test_func, name in _get_test_funcs_for_test_class(TestParametrized):
+            self.assertEqual(hasattr(test_func, '_decorator_applied'), name == 'test_param_two')
+
+    def test_compose_param_specific_decorators(self):
+        # Test that multiple per-param decorators compose correctly.
+
+        def test_dec(func):
+            func._decorator_applied = True
+            return func
+
+        class TestParametrized(TestCase):
+            @parametrize("x", [subtest(1),
+                               subtest(2, decorators=[test_dec]),
+                               subtest(3)])
+            @parametrize("y", [subtest(False, decorators=[test_dec]),
+                               subtest(True)])
+            def test_param(self, x, y):
+                pass
+
+        instantiate_parametrized_tests(TestParametrized)
+
+        for test_func, name in _get_test_funcs_for_test_class(TestParametrized):
+            # Decorator should be applied whenever either x == 2 or y == False.
+            should_apply = ('x_2' in name) or ('y_False' in name)
+            self.assertEqual(hasattr(test_func, '_decorator_applied'), should_apply)
+
     def test_modules_decorator_misuse_error(self):
         # Test that @modules errors out when used with instantiate_parametrized_tests().
 
@@ -1518,7 +1566,7 @@ class TestTestParametrization(TestCase):
             instantiate_parametrized_tests(TestParametrized)
 
     def test_ops_decorator_misuse_error(self):
-        # Test that @modules errors out when used with instantiate_parametrized_tests().
+        # Test that @ops errors out when used with instantiate_parametrized_tests().
 
         class TestParametrized(TestCase):
             @ops(op_db)
@@ -1697,6 +1745,125 @@ class TestTestParametrizationDeviceType(TestCase):
         test_names = _get_test_names_for_test_class(device_cls)
         self.assertEqual(sorted(expected_test_names), sorted(test_names))
 
+    def test_modules_composition_names(self, device):
+        device = self.device_type
+
+        class TestParametrized(TestCase):
+            @modules(module_db)
+            @parametrize("flag", [False, True], lambda f: 'flag_enabled' if f else 'flag_disabled')
+            def test_module_parametrized(self, device, dtype, module_info, training, flag):
+                pass
+
+        instantiate_device_type_tests(TestParametrized, locals(), only_for=device)
+
+        device_cls = locals()['TestParametrized{}'.format(device.upper())]
+        expected_test_names = []
+        for module_info in module_db:
+            for dtype in module_info.dtypes:
+                for flag_part in ('flag_disabled', 'flag_enabled'):
+                    expected_train_modes = (
+                        ['train_mode', 'eval_mode'] if module_info.train_and_eval_differ else [''])
+                    for training_part in expected_train_modes:
+                        expected_name = '{}.test_module_parametrized_{}{}_{}_{}_{}'.format(
+                            device_cls.__name__, module_info.formatted_name,
+                            '_' + training_part if len(training_part) > 0 else '',
+                            flag_part, device, dtype_name(dtype))
+                        expected_test_names.append(expected_name)
+
+        test_names = _get_test_names_for_test_class(device_cls)
+        self.assertEqual(sorted(expected_test_names), sorted(test_names))
+
+    def test_ops_decorator_applies_op_and_param_specific_decorators(self, device):
+        # Test that decorators can be applied on a per-op / per-param basis.
+
+        # Create a test op, OpInfo entry, and decorator to apply.
+        def test_op(x):
+            return -x
+
+        def test_dec(func):
+            func._decorator_applied = True
+            return func
+
+        test_op_info = OpInfo(
+            'test_op',
+            op=test_op,
+            dtypes=floating_types(),
+            sample_inputs_func=lambda _: [],
+            decorators=[
+                DecorateInfo(test_dec, 'TestParametrized', 'test_op_param',
+                             device_type='cpu', dtypes=[torch.float64],
+                             active_if=lambda p: p['x'] == 2)
+            ])
+
+        class TestParametrized(TestCase):
+            @ops(op_db + [test_op_info])
+            @parametrize("x", [2, 3])
+            def test_op_param(self, device, dtype, op, x):
+                pass
+
+            @ops(op_db + [test_op_info])
+            @parametrize("y", [
+                subtest(4),
+                subtest(5, decorators=[test_dec])])
+            def test_other(self, device, dtype, op, y):
+                pass
+
+        device = self.device_type
+        instantiate_device_type_tests(TestParametrized, locals(), only_for=device)
+        device_cls = locals()['TestParametrized{}'.format(device.upper())]
+
+        for test_func, name in _get_test_funcs_for_test_class(device_cls):
+            should_apply = (name == 'test_op_param_test_op_x_2_cpu_float64' or
+                            ('test_other' in name and 'y_5' in name))
+            self.assertEqual(hasattr(test_func, '_decorator_applied'), should_apply)
+
+    def test_modules_decorator_applies_module_and_param_specific_decorators(self, device):
+        # Test that decorators can be applied on a per-module / per-param basis.
+
+        # Create a test module, ModuleInfo entry, and decorator to apply.
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.x = torch.nn.Parameter(torch.randn(3))
+
+            def forward(self, y):
+                return self.x + y
+
+        def test_dec(func):
+            func._decorator_applied = True
+            return func
+
+        test_module_info = ModuleInfo(
+            TestModule,
+            module_inputs_func=lambda _: [],
+            decorators=[
+                DecorateInfo(test_dec, 'TestParametrized', 'test_module_param',
+                             device_type='cpu', dtypes=[torch.float64],
+                             active_if=lambda p: p['x'] == 2)
+            ])
+
+        class TestParametrized(TestCase):
+            @modules(module_db + [test_module_info])
+            @parametrize("x", [2, 3])
+            def test_module_param(self, device, dtype, module_info, training, x):
+                pass
+
+            @modules(module_db + [test_module_info])
+            @parametrize("y", [
+                subtest(4),
+                subtest(5, decorators=[test_dec])])
+            def test_other(self, device, dtype, module_info, training, y):
+                pass
+
+        device = self.device_type
+        instantiate_device_type_tests(TestParametrized, locals(), only_for=device)
+        device_cls = locals()['TestParametrized{}'.format(device.upper())]
+
+        for test_func, name in _get_test_funcs_for_test_class(device_cls):
+            should_apply = (name == 'test_module_param_TestModule_x_2_cpu_float64' or
+                            ('test_other' in name and 'y_5' in name))
+            self.assertEqual(hasattr(test_func, '_decorator_applied'), should_apply)
+
     def test_dtypes_composition_valid(self, device):
         # Test checks that @parametrize and @dtypes compose as expected when @parametrize
         # doesn't set dtype.
@@ -1756,7 +1923,7 @@ class TestTestParametrizationDeviceType(TestCase):
         class TestParametrized(TestCase):
             @ops(op_db)
             @modules(module_db)
-            def test_param(self, device, dtype, op, module_info):
+            def test_param(self, device, dtype, op, module_info, training):
                 pass
 
         with self.assertRaisesRegex(RuntimeError, "handled multiple times"):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -5,7 +5,7 @@ import runpy
 import threading
 from collections import namedtuple
 from enum import Enum
-from functools import wraps
+from functools import wraps, partial
 from typing import List, Any, ClassVar, Optional, Sequence, Tuple, Union, Dict, Set
 import unittest
 import os
@@ -271,9 +271,17 @@ def _dtype_test_suffix(dtypes):
 
 def _update_param_kwargs(param_kwargs, name, value):
     """ Adds a kwarg with the specified name and value to the param_kwargs dict. """
+    # Make name plural (e.g. devices / dtypes) if the value is composite.
+    plural_name = '{}s'.format(name)
+
+    # Clear out old entries of the arg if any.
+    if name in param_kwargs:
+        del param_kwargs[name]
+    if plural_name in param_kwargs:
+        del param_kwargs[plural_name]
+
     if isinstance(value, list) or isinstance(value, tuple):
-        # Make name plural (e.g. devices / dtypes) if the value is composite.
-        param_kwargs['{}s'.format(name)] = value
+        param_kwargs[plural_name] = value
     elif value is not None:
         param_kwargs[name] = value
 
@@ -312,6 +320,17 @@ class DeviceTypeTestBase(TestCase):
     @classmethod
     def get_primary_device(cls):
         return cls.device_type
+
+    @classmethod
+    def _init_and_get_primary_device(cls):
+        try:
+            return cls.get_primary_device()
+        except Exception:
+            # For CUDATestBase, XLATestBase, and possibly others, the primary device won't be available
+            # until setUpClass() sets it. Call that manually here if needed.
+            if hasattr(cls, 'setUpClass'):
+                cls.setUpClass()
+            return cls.get_primary_device()
 
     # Returns a list of strings representing all available devices of this
     # device type. The primary device must be the first string in the list
@@ -356,19 +375,23 @@ class DeviceTypeTestBase(TestCase):
     @classmethod
     def instantiate_test(cls, name, test, *, generic_cls=None):
 
-        def instantiate_test_helper(cls, name, *, test, param_kwargs=None):
+        def instantiate_test_helper(cls, name, *, test, param_kwargs=None, decorator_fn=lambda _: []):
+            # Add the device param kwarg if the test needs device or devices.
+            param_kwargs = {} if param_kwargs is None else param_kwargs
+            test_sig_params = inspect.signature(test).parameters
+            if 'device' in test_sig_params or 'devices' in test_sig_params:
+                device_arg: str = cls._init_and_get_primary_device()
+                if hasattr(test, 'num_required_devices'):
+                    device_arg = cls.get_all_devices()
+                _update_param_kwargs(param_kwargs, 'device', device_arg)
+
+            # Apply decorators based on param kwargs.
+            for decorator in decorator_fn(param_kwargs):
+                test = decorator(test)
+
             # Constructs the test
             @wraps(test)
             def instantiated_test(self, param_kwargs=param_kwargs):
-                # Add the device param kwarg if the test needs device or devices.
-                param_kwargs = {} if param_kwargs is None else param_kwargs
-                test_sig_params = inspect.signature(test).parameters
-                if 'device' in test_sig_params or 'devices' in test_sig_params:
-                    device_arg: str = cls.get_primary_device()
-                    if hasattr(test, 'num_required_devices'):
-                        device_arg = cls.get_all_devices()
-                    _update_param_kwargs(param_kwargs, 'device', device_arg)
-
                 # Sets precision and runs test
                 # Note: precision is reset after the test is run
                 guard_precision = self.precision
@@ -400,7 +423,7 @@ class DeviceTypeTestBase(TestCase):
 
         def default_parametrize_fn(test, generic_cls, device_cls):
             # By default, no parametrization is needed.
-            yield (test, '', {})
+            yield (test, '', {}, lambda _: [])
 
         # Parametrization decorators set the parametrize_fn attribute on the test.
         parametrize_fn = test.parametrize_fn if hasattr(test, 'parametrize_fn') else default_parametrize_fn
@@ -416,12 +439,12 @@ class DeviceTypeTestBase(TestCase):
 
                     # Note that an empty test suffix is set here so that the dtype can be appended
                     # later after the device.
-                    yield (test, '', param_kwargs)
+                    yield (test, '', param_kwargs, lambda _: [])
 
             parametrize_fn = compose_parametrize_fns(dtype_parametrize_fn, parametrize_fn)
 
         # Instantiate the parametrized tests.
-        for (test, test_suffix, param_kwargs) in parametrize_fn(test, generic_cls, cls):
+        for (test, test_suffix, param_kwargs, decorator_fn) in parametrize_fn(test, generic_cls, cls):
             test_suffix = '' if test_suffix == '' else '_' + test_suffix
             device_suffix = '_' + cls.device_type
 
@@ -432,7 +455,8 @@ class DeviceTypeTestBase(TestCase):
                 dtype_kwarg = param_kwargs['dtypes'] if 'dtypes' in param_kwargs else param_kwargs['dtype']
             test_name = '{}{}{}{}'.format(name, test_suffix, device_suffix, _dtype_test_suffix(dtype_kwarg))
 
-            instantiate_test_helper(cls=cls, name=test_name, test=test, param_kwargs=param_kwargs)
+            instantiate_test_helper(cls=cls, name=test_name, test=test, param_kwargs=param_kwargs,
+                                    decorator_fn=decorator_fn)
 
     def run(self, result=None):
         super().run(result=result)
@@ -817,7 +841,6 @@ class ops(_TestParametrizer):
                 param_kwargs = {'op': op}
                 _update_param_kwargs(param_kwargs, 'dtype', dtype)
 
-                # Wraps instantiated test with op decorators
                 # NOTE: test_wrapper exists because we don't want to apply
                 #   op-specific decorators to the original test.
                 #   Test-specific decorators are applied to the original test,
@@ -827,11 +850,10 @@ class ops(_TestParametrizer):
                     def test_wrapper(*args, **kwargs):
                         return test(*args, **kwargs)
 
-                    for decorator in op.get_decorators(
-                            generic_cls.__name__, test.__name__, device_cls.device_type, dtype):
-                        test_wrapper = decorator(test_wrapper)
+                    decorator_fn = partial(op.get_decorators, generic_cls.__name__,
+                                           test.__name__, device_cls.device_type, dtype)
 
-                    yield (test_wrapper, test_name, param_kwargs)
+                    yield (test_wrapper, test_name, param_kwargs, decorator_fn)
                 except Exception as ex:
                     # Provides an error message for debugging before rethrowing the exception
                     print("Failed to instantiate {0} for op {1}!".format(test_name, op.name))

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -50,7 +50,10 @@ for namespace in MODULE_NAMESPACES:
     for module_name in namespace.__all__:  # type: ignore[attr-defined]
         module_cls = getattr(namespace, module_name)
         namespace_name = namespace.__name__.replace('torch.', '').replace('.modules', '')
-        MODULE_CLASS_NAMES[module_cls] = f'{namespace_name}.{module_name}'
+
+        # Deal with any aliases by preferring earlier names.
+        if module_cls not in MODULE_CLASS_NAMES:
+            MODULE_CLASS_NAMES[module_cls] = f'{namespace_name}.{module_name}'
 
 
 # Specifies the modes (i.e. train, eval) to test over.
@@ -111,20 +114,22 @@ class modules(_TestParametrizer):
                     def test_wrapper(*args, **kwargs):
                         return test(*args, **kwargs)
 
-                    for decorator in module_info.get_decorators(generic_cls.__name__, test.__name__,
-                                                                device_cls.device_type, dtype):
-                        test_wrapper = decorator(test_wrapper)
+                    decorator_fn = partial(module_info.get_decorators, generic_cls.__name__,
+                                           test.__name__, device_cls.device_type, dtype)
 
-                    yield (test_wrapper, test_name, param_kwargs)
+                    yield (test_wrapper, test_name, param_kwargs, decorator_fn)
                 except Exception as ex:
                     # Provides an error message for debugging before rethrowing the exception
                     print("Failed to instantiate {0} for module {1}!".format(test_name, module_info.name))
                     raise ex
 
 
-def get_module_fully_qualified_name(module_cls):
-    """ Returns the common name of the module class formatted for use in test names. """
-    return MODULE_CLASS_NAMES[module_cls]
+def get_module_common_name(module_cls):
+    if module_cls in MODULE_CLASS_NAMES:
+        # Example: "nn.Linear"
+        return MODULE_CLASS_NAMES[module_cls]
+    else:
+        return module_cls.__name__
 
 
 class FunctionInput(object):
@@ -184,11 +189,11 @@ class ModuleInfo(object):
         self.module_memformat_affects_out = module_memformat_affects_out
         self.train_and_eval_differ = train_and_eval_differ
 
-    def get_decorators(self, test_class, test_name, device, dtype):
+    def get_decorators(self, test_class, test_name, device, dtype, param_kwargs):
         result = [set_single_threaded_if_parallel_tbb]
         for decorator in self.decorators:
             if isinstance(decorator, DecorateInfo):
-                if decorator.is_active(test_class, test_name, device, dtype):
+                if decorator.is_active(test_class, test_name, device, dtype, param_kwargs):
                     result.extend(decorator.decorators)
             else:
                 result.append(decorator)
@@ -196,7 +201,7 @@ class ModuleInfo(object):
 
     @property
     def name(self):
-        return get_module_fully_qualified_name(self.module_cls)
+        return get_module_common_name(self.module_cls)
 
     @property
     def formatted_name(self):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -158,11 +158,12 @@ class _TestParametrizer(object):
                 if the tests are not part of a device-specific set
 
         Returns:
-            Generator object returning 3-tuples of:
+            Generator object returning 4-tuples of:
                 test (fn): Parametrized test function; must support a device arg and args for any params
                 test_name (str): Parametrized suffix for the test (e.g. opname_int64); will be appended to
                     the base name of the test
                 param_kwargs (dict): Param kwargs to pass to the test (e.g. {'op': 'add', 'dtype': torch.int64})
+                decorator_fn (callable): Callable[[Dict], List] for list of decorators to apply given param_kwargs
         """
         raise NotImplementedError
 
@@ -196,10 +197,9 @@ def compose_parametrize_fns(old_parametrize_fn, new_parametrize_fn):
     def composite_fn(test, generic_cls, device_cls,
                      old_parametrize_fn=old_parametrize_fn,
                      new_parametrize_fn=new_parametrize_fn):
-        old_tests = [(test, test_name, param_kwargs) for (test, test_name, param_kwargs) in
-                     old_parametrize_fn(test, generic_cls, device_cls)]
-        for (old_test, old_test_name, old_param_kwargs) in old_tests:
-            for (new_test, new_test_name, new_param_kwargs) in \
+        old_tests = list(old_parametrize_fn(test, generic_cls, device_cls))
+        for (old_test, old_test_name, old_param_kwargs, old_dec_fn) in old_tests:
+            for (new_test, new_test_name, new_param_kwargs, new_dec_fn) in \
                     new_parametrize_fn(old_test, generic_cls, device_cls):
                 redundant_params = set(old_param_kwargs.keys()).intersection(new_param_kwargs.keys())
                 if redundant_params:
@@ -211,7 +211,11 @@ def compose_parametrize_fns(old_parametrize_fn, new_parametrize_fn):
                 merged_test_name = '{}{}{}'.format(new_test_name,
                                                    '_' if old_test_name != '' and new_test_name != '' else '',
                                                    old_test_name)
-                yield (new_test, merged_test_name, full_param_kwargs)
+
+                def merged_decorator_fn(param_kwargs, old_dec_fn=old_dec_fn, new_dec_fn=new_dec_fn):
+                    return list(old_dec_fn(param_kwargs)) + list(new_dec_fn(param_kwargs))
+
+                yield (new_test, merged_test_name, full_param_kwargs, merged_decorator_fn)
 
     return composite_fn
 
@@ -250,9 +254,14 @@ def instantiate_parametrized_tests(generic_cls):
             assert not hasattr(generic_cls, name), "Redefinition of test {0}".format(name)
             setattr(generic_cls, name, instantiated_test)
 
-        for (test, test_suffix, param_kwargs) in class_attr.parametrize_fn(
+        for (test, test_suffix, param_kwargs, decorator_fn) in class_attr.parametrize_fn(
                 class_attr, generic_cls=generic_cls, device_cls=None):
             full_name = '{}_{}'.format(test.__name__, test_suffix)
+
+            # Apply decorators based on full param kwargs.
+            for decorator in decorator_fn(param_kwargs):
+                test = decorator(test)
+
             instantiate_test_helper(cls=generic_cls, name=full_name, test=test, param_kwargs=param_kwargs)
     return generic_cls
 
@@ -370,19 +379,18 @@ class parametrize(_TestParametrizer):
             values = check_exhausted_iterator = object()
             for values in self.arg_values:
                 maybe_name = None
+
+                decorators = []
                 if isinstance(values, subtest):
                     sub = values
                     values = sub.arg_values
                     maybe_name = sub.name
 
-                    # Apply decorators.
                     @wraps(test)
                     def test_wrapper(*args, **kwargs):
                         return test(*args, **kwargs)
 
-                    for decorator in sub.decorators:
-                        test_wrapper = decorator(test_wrapper)
-
+                    decorators = sub.decorators
                     gen_test = test_wrapper
                 else:
                     gen_test = test
@@ -401,7 +409,10 @@ class parametrize(_TestParametrizer):
                 if '.' in test_name:
                     raise RuntimeError('Test name cannot contain periods, but got: {}'.format(test_name))
 
-                yield (gen_test, test_name, param_kwargs)
+                def decorator_fn(_, decorators=decorators):
+                    return decorators
+
+                yield (gen_test, test_name, param_kwargs, decorator_fn)
 
             if values is check_exhausted_iterator:
                 raise ValueError('An empty arg_values was passed to @parametrize. '

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -338,7 +338,7 @@ class parametrize(_TestParametrizer):
         name_fn (Callable): Optional function that takes in parameters and returns subtest name.
     """
     def __init__(self, arg_str, arg_values, name_fn=None):
-        self.arg_names: List[str] = [s.strip() for s in arg_str.split(',')]
+        self.arg_names: List[str] = [s.strip() for s in arg_str.split(',') if s != '']
         self.arg_values = arg_values
         self.name_fn = name_fn
 
@@ -371,7 +371,7 @@ class parametrize(_TestParametrizer):
         if len(self.arg_names) == 0:
             # No additional parameters needed for the test.
             test_name = ''
-            yield (test, test_name, {})
+            yield (test, test_name, {}, lambda _: [])
         else:
             # Each "values" item is expected to be either:
             # * A tuple of values with one for each arg. For a single arg, a single item is expected.
@@ -406,8 +406,6 @@ class parametrize(_TestParametrizer):
                 }
 
                 test_name = self._get_subtest_name(values, explicit_name=maybe_name)
-                if '.' in test_name:
-                    raise RuntimeError('Test name cannot contain periods, but got: {}'.format(test_name))
 
                 def decorator_fn(_, decorators=decorators):
                     return decorators

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -97,13 +97,15 @@ class DecorateInfo(object):
             for dtype in self.dtypes:
                 assert isinstance(dtype, torch.dtype)
 
-    def is_active(self, cls_name, test_name, device_type, dtype):
+    def is_active(self, cls_name, test_name, device_type, dtype, param_kwargs):
         return (
             self.active_if
             and (self.cls_name is None or self.cls_name == cls_name)
             and (self.test_name is None or self.test_name == test_name)
             and (self.device_type is None or self.device_type == device_type)
             and (self.dtypes is None or dtype in self.dtypes)
+            # Support callables over kwargs to determine if the decorator is active.
+            and (self.active_if(param_kwargs) if isinstance(self.active_if, Callable) else self.active_if)
         )
 
 
@@ -1201,12 +1203,12 @@ class OpInfo(object):
             self, device, dtype, requires_grad, **kwargs
         )
 
-    def get_decorators(self, test_class, test_name, device, dtype):
+    def get_decorators(self, test_class, test_name, device, dtype, param_kwargs):
         """Returns the decorators targeting the given test."""
         result = []
         for decorator in self.decorators:
             if isinstance(decorator, DecorateInfo):
-                if decorator.is_active(test_class, test_name, device, dtype):
+                if decorator.is_active(test_class, test_name, device, dtype, param_kwargs):
                     result.extend(decorator.decorators)
             else:
                 result.append(decorator)

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -105,7 +105,11 @@ class DecorateInfo(object):
             and (self.device_type is None or self.device_type == device_type)
             and (self.dtypes is None or dtype in self.dtypes)
             # Support callables over kwargs to determine if the decorator is active.
-            and (self.active_if(param_kwargs) if isinstance(self.active_if, Callable) else self.active_if)
+            and (
+                self.active_if(param_kwargs)
+                if isinstance(self.active_if, Callable)
+                else self.active_if
+            )
         )
 
 
@@ -1208,7 +1212,9 @@ class OpInfo(object):
         result = []
         for decorator in self.decorators:
             if isinstance(decorator, DecorateInfo):
-                if decorator.is_active(test_class, test_name, device, dtype, param_kwargs):
+                if decorator.is_active(
+                    test_class, test_name, device, dtype, param_kwargs
+                ):
                     result.extend(decorator.decorators)
             else:
                 result.append(decorator)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91658

Continuation of #79979.

Fixes #79161

This PR does the following:
* Expands the `parametrize_fn()` signature from returning a 3-tuple of `(test, test_name, param_kwargs)` to returning a 4-tuple of `(test, test_name, param_kwargs, decorator_fn)`. Expected signature for the addition is `decorator_fn(param_kwargs) -> List[decorator]` i.e. given the full set of test params, return a list of decorators to apply.
    * `modules`, `ops`, and `parametrize` now fit the new signature, returning `decorator_fn`s instead of applying decorators themselves.
    * `instantiate_parametrized_tests()` and `instantiate_device_type_tests()` now call the returned `decorator_fn`, passing in the full set of `param_kwargs` (after composition + `device` / `dtype` additions) and applying the returned decorators.
    * Composing multiple `parametrize_fn`s also composes the corresponding `decorator_fn`s; the composed `decorator_fn` simply concatenates the decorator lists returned by the constituents.
* Expands `DecorateInfo.is_active` to support callables:
```python
DecorateInfo(
    unittest.expectedFailure, "TestOps", "test_python_ref_executor",
    device_type='cuda', active_if=lambda params: params['executor'] == 'nvfuser'
),
```
* Adds several tests to `test/test_testing.py` ensuring proper decoration using `@parametrize`, `@modules`, and `@ops`.
* (minor) Fixes a couple `ModuleInfo` naming oddities uncovered during testing.