### PR TITLE
vmap support for torch.trace

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesViews.cpp
+++ b/aten/src/ATen/functorch/BatchRulesViews.cpp
@@ -532,7 +532,7 @@ std::tuple<Tensor, optional<int64_t>> diag_embed_batch_rule(const Tensor& self, 
 
 Tensor trace_decomp(const Tensor& tensor) {
   TORCH_CHECK(tensor.dim() == 2, "trace: expected a matrix, but got tensor with dim ", tensor.dim());
-  return tensor.diagonal().sum() ;
+  return tensor.diagonal().sum();
 }
 
 TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {

--- a/aten/src/ATen/functorch/BatchRulesViews.cpp
+++ b/aten/src/ATen/functorch/BatchRulesViews.cpp
@@ -531,7 +531,8 @@ std::tuple<Tensor, optional<int64_t>> diag_embed_batch_rule(const Tensor& self, 
 }
 
 Tensor trace_decomp(const Tensor& tensor) {
-  return tensor.diagonal().sum();
+  TORCH_CHECK(tensor.dim() == 2, "trace: expected a matrix, but got a tensor with dim ", tensor.dim());
+  return tensor.diagonal().sum() ;
 }
 
 TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {

--- a/aten/src/ATen/functorch/BatchRulesViews.cpp
+++ b/aten/src/ATen/functorch/BatchRulesViews.cpp
@@ -531,7 +531,7 @@ std::tuple<Tensor, optional<int64_t>> diag_embed_batch_rule(const Tensor& self, 
 }
 
 Tensor trace_decomp(const Tensor& tensor) {
-  TORCH_CHECK(tensor.dim() == 2, "trace: expected a matrix, but got a tensor with dim ", tensor.dim());
+  TORCH_CHECK(tensor.dim() == 2, "trace: expected a matrix, but got tensor with dim ", tensor.dim());
   return tensor.diagonal().sum() ;
 }
 

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3494,8 +3494,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('_native_batch_norm_legit'),
         xfail('tril'),  # Exception not raised on error input
         xfail('triu'),  # Exception not raised on error input
-        # The error inputs are vectors, that pass when batched as they are treated as a matrix
-        xfail('trace'),
         xfail('as_strided', 'partial_views'),
     }))
     def test_vmap_exhaustive(self, device, dtype, op):
@@ -3557,7 +3555,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('resize_'),
         xfail('view_as_complex'),
         xfail('matrix_exp'),
-        xfail('trace'),  # Does not support batched tensors
         xfail('bucketize'),
         xfail('fft.ihfft2'),
         xfail('fft.ihfftn'),


### PR DESCRIPTION
Fixes #91404 

As expected

```python
import torch
from functorch import vmap
x = torch.randn(32, 3, 3, 3)
y = vmap(torch.trace)(x)
print(y)
```

Now gives the exact same runtime error as eager mode

```
(sourcetorch) ubuntu@ip-172-31-39-26:~/test$ python functorch_test_pos.py 
Traceback (most recent call last):
  File "functorch_test_pos.py", line 4, in <module>
    y = vmap(torch.trace)(x)
  File "/home/ubuntu/pytorch/torch/_functorch/vmap.py", line 420, in wrapped
    return _flat_vmap(
  File "/home/ubuntu/pytorch/torch/_functorch/vmap.py", line 39, in fn
    return f(*args, **kwargs)
  File "/home/ubuntu/pytorch/torch/_functorch/vmap.py", line 605, in _flat_vmap
    batched_outputs = func(*batched_inputs, **kwargs)
RuntimeError: trace: expected a matrix, but got tensor with dim 3
```

Equivalent eager code

```python
import torch
x = torch.randn(32, 3, 3, 3)
results = []
for xi in x:
  y = torch.trace(xi)
  results.append(y)
```

```
(sourcetorch) ubuntu@ip-172-31-39-26:~/test$ python functorch_test_neg.py 
Traceback (most recent call last):
  File "functorch_test_neg.py", line 5, in <module>
    y = torch.trace(xi)
RuntimeError: trace: expected a matrix, but got tensor with dim 3
```


cc @zou3519 @Chillee @samdow @soumith