### PR TITLE
[Quant][Eager] Copy MHA's batch_first attribute in prepare()

### DIFF
--- a/torch/ao/nn/quantizable/modules/activation.py
+++ b/torch/ao/nn/quantizable/modules/activation.py
@@ -98,7 +98,8 @@ class MultiheadAttention(nn.MultiheadAttention):
         observed = cls(other.embed_dim, other.num_heads, other.dropout,
                        (other.in_proj_bias is not None),
                        (other.bias_k is not None),
-                       other.add_zero_attn, other.kdim, other.vdim)
+                       other.add_zero_attn, other.kdim, other.vdim,
+                       other.batch_first)
         observed.bias_k = other.bias_k
         observed.bias_v = other.bias_v
         observed.qconfig = other.qconfig


### PR DESCRIPTION
**Summary**
Fixes #91571
MHA's batch_first attribute is not copied after `torch.quantization.prepare()`. Now we copy MHA's batch_first attribute in torch/ao/nn/quantizable/modules/activation.py: `MultiheadAttention.from_float()`.

**Test plan**
python test/test_quantization.py -k test_mha_batch_first_attr_is_copied_in_prepare

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10