### PR TITLE
[Lint] Update clang-tidy to 11.1.0

### DIFF
--- a/tools/linter/adapters/s3_init.py
+++ b/tools/linter/adapters/s3_init.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 # String representing the host platform (e.g. Linux, Darwin).
 HOST_PLATFORM = platform.system()
+HOST_PLATFORM_ARCH = platform.system() + "-" + platform.processor()
 
 # PyTorch directory root
 try:
@@ -199,13 +200,15 @@ if __name__ == "__main__":
     config = json.load(open(args.config_json))
     config = config[args.linter]
 
+    # Allow processor specific binaries for platform (namely Intel and M1 binaries for MacOS)
+    platform = HOST_PLATFORM if HOST_PLATFORM in config else HOST_PLATFORM_ARCH
     # If the host platform is not in platform_to_hash, it is unsupported.
-    if HOST_PLATFORM not in config:
-        logging.error(f"Unsupported platform: {HOST_PLATFORM}")
+    if platform not in config:
+        logging.error(f"Unsupported platform: {HOST_PLATFORM}/{HOST_PLATFORM_ARCH}")
         exit(1)
 
-    url = config[HOST_PLATFORM]["download_url"]
-    hash = config[HOST_PLATFORM]["hash"]
+    url = config[platform]["download_url"]
+    hash = config[platform]["hash"]
 
     ok = download(args.output_name, args.output_dir, url, hash)
     if not ok:

--- a/tools/linter/adapters/s3_init.py
+++ b/tools/linter/adapters/s3_init.py
@@ -201,14 +201,14 @@ if __name__ == "__main__":
     config = config[args.linter]
 
     # Allow processor specific binaries for platform (namely Intel and M1 binaries for MacOS)
-    platform = HOST_PLATFORM if HOST_PLATFORM in config else HOST_PLATFORM_ARCH
+    host_platform = HOST_PLATFORM if HOST_PLATFORM in config else HOST_PLATFORM_ARCH
     # If the host platform is not in platform_to_hash, it is unsupported.
-    if platform not in config:
+    if host_platform not in config:
         logging.error(f"Unsupported platform: {HOST_PLATFORM}/{HOST_PLATFORM_ARCH}")
         exit(1)
 
-    url = config[platform]["download_url"]
-    hash = config[platform]["hash"]
+    url = config[host_platform]["download_url"]
+    hash = config[host_platform]["hash"]
 
     ok = download(args.output_name, args.output_dir, url, hash)
     if not ok:

--- a/tools/linter/adapters/s3_init_config.json
+++ b/tools/linter/adapters/s3_init_config.json
@@ -16,13 +16,17 @@
         }
     },
     "clang-tidy": {
-        "Darwin": {
-            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/macos/clang-tidy",
-            "hash": "541797a7b8fa795e2f3c1adcd8236cc336a40aa927028dc5bc79172e1d9eca36"
+        "Darwin-i386": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/macos-i386/11.1.0/clang-tidy",
+            "hash": "00a61e97189d096dc8ff029590fdc38493862993df04980a53a926bdccc80905"
+        },
+        "Darwin-arm": {
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/macos-arm/11.1.0/clang-tidy",
+            "hash": "22b22f5625e030c50fece061fc94bd04d6a884e22859361e5094ef5cf74135f6"
         },
         "Linux": {
-            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/clang-tidy",
-            "hash": "e4a1537ee997aa486a67bcc06d050b1aa6cfb14aa3073c08f19123ac990ab2f7"
+            "download_url": "https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/11.1.0/clang-tidy",
+            "hash": "f0eb93147808e361ea7d42d8868f4feddb53185e878d6cc2a493a4104265d2ee"
         }
     },
     "actionlint": {


### PR DESCRIPTION
Also, add option to download to distinguish between universal/i386 only
and separate i386 and arm binaries for MacOS

Follow up for https://github.com/pytorch/test-infra/pull/1354
