### PR TITLE
[bazel] Change visibility to `c10::headers` to public

### DIFF
--- a/c10/BUILD.bazel
+++ b/c10/BUILD.bazel
@@ -48,5 +48,5 @@ cc_library(
         ":using_glog": ["@com_github_glog//:glog"],
         "//conditions:default": [],
     }),
-    visibility = ["//:__pkg__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Followup after https://github.com/pytorch/pytorch/pull/91422

