### PR TITLE
Use indexing instead of reshape for broadcasting

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1126,7 +1126,6 @@ class TritonKernel(Kernel):
             sizes[i] = ":"
         return f"[{', '.join(sizes)}]"
 
-
     def dense_size_str(self):
         sizes = []
         for tree in self.range_trees:

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -452,8 +452,8 @@ class IterationRangesRoot(IterationRanges):
         return list(reversed(index_vars)), list(reversed(sizes))
 
     def ranges_code(self):
-        size = self.kernel.reshape_size_str(self.index, self.prefix)
-        return f"tl.reshape(tl.arange(0, {self.prefix.upper()}BLOCK), {size})"
+        size = self.kernel.indexing_size_str(self.index, self.prefix)
+        return f"tl.arange(0, {self.prefix.upper()}BLOCK){size}"
 
     def pid_cache_lookup(self, key):
         if key in self.pid_cache:
@@ -882,11 +882,11 @@ class TritonKernel(Kernel):
         masks = [f"{tree.prefix}mask" for tree in self.range_trees]
         if self._load_mask:
             masks.append(self._load_mask)
-        sizes = [f"{tree.prefix.upper()}BLOCK" for tree in self.range_trees]
-        sizes[-1] = "1"
+        sizes = [":" for _ in self.range_trees]
+        sizes[-1] = "None"
         reduction_range_prefix = self.range_trees[-1].prefix
-        reduction_sizes = ["1" for _ in self.range_trees]
-        reduction_sizes[-1] = f"{reduction_range_prefix.upper()}BLOCK"
+        reduction_sizes = ["None" for _ in self.range_trees]
+        reduction_sizes[-1] = ":"
 
         if reduction_type == "any":
             reduction_type = "max"
@@ -933,17 +933,17 @@ class TritonKernel(Kernel):
                 # argmax, argmin
                 self.suffix.writelines(
                     [
-                        f"{accumulator_index}_reduce = tl.reshape(",
-                        f"\ttl.{reduction_type}({accumulator}, {dim}), [{', '.join(sizes)}]).to(tl.int32)",
-                        f"{accumulator_index}_mask = (tl.reshape(tl.arange(0, {reduction_range_prefix.upper()}BLOCK),",
-                        f"\t[{', '.join(reduction_sizes)}]) == {accumulator_index}_reduce)",
-                        f"{result_var} = tl.reshape(tl.sum(",
-                        f"\ttl.where({accumulator_index}_mask, {accumulator_index}, 0), {dim}), [{', '.join(sizes)}])",
+                        f"{accumulator_index}_reduce = "
+                        f"tl.{reduction_type}({accumulator}, {dim})[{', '.join(sizes)}].to(tl.int32)",
+                        f"{accumulator_index}_mask = tl.arange(0, {reduction_range_prefix.upper()}BLOCK)"
+                        f"[{', '.join(reduction_sizes)}] == {accumulator_index}_reduce",
+                        f"{result_var} = tl.sum("
+                        f"tl.where({accumulator_index}_mask, {accumulator_index}, 0), {dim})[{', '.join(sizes)}]",
                     ]
                 )
             else:
                 self.suffix.writeline(
-                    f"{result_var} = tl.reshape(tl.{reduction_type}({accumulator}, {dim}), [{', '.join(sizes)}])"
+                    f"{result_var} = tl.{reduction_type}({accumulator}, {dim})[{', '.join(sizes)}]"
                 )
         else:
             var_name = self.cse.reduction_cache[(src_dtype, reduction_type, value)]
@@ -1120,11 +1120,12 @@ class TritonKernel(Kernel):
                         f"{tree.prefix}numel = {V.graph.sizevars.size_hint(tree.numel)}  # dynamic_shapes=False"
                     )
 
-    def reshape_size_str(self, i=None, x=None):
-        sizes = ["1"] * (len(self.range_trees) - int(self.numels[-1] == 1))
+    def indexing_size_str(self, i=None, x=None):
+        sizes = ["None"] * (len(self.range_trees) - int(self.numels[-1] == 1))
         if i is not None:
-            sizes[i] = f"{x.upper()}BLOCK"
+            sizes[i] = ":"
         return f"[{', '.join(sizes)}]"
+
 
     def dense_size_str(self):
         sizes = []


### PR DESCRIPTION
This is needed for MLIR rewrite
This replaces
```
xindex = xoffset + tl.reshape(tl.arange(0, XBLOCK), [XBLOCK, 1])
``` 
with
```
xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
```
so code is a bit more readable, and compiles with master triton (which doesn't currently support first construct). 



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire