### PR TITLE
Apply clang-tidy perf improvements to aten and torch/jit/passes/onnx

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -208,7 +208,7 @@ inline void __attribute__((always_inline)) QuantizeAvx2(
     // Note that we cannot implement the same behavior as the vectorized code
     // using std::round because it does rounding away from zero in halfway
     // cases.
-    transformed = zero_point + nearbyint(transformed);
+    transformed = zero_point + std::nearbyint(transformed);
     float clipped =
         std::min(std::max(transformed, float(min_val)), float(max_val));
     dst[i] = clipped;

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -218,7 +218,7 @@ inline void __attribute__((always_inline)) QuantizeAvx512(
     // Note that we cannot implement the same behavior as the vectorized code
     // using std::round because it does rounding away from zero in halfway
     // cases.
-    transformed = zero_point + nearbyint(transformed);
+    transformed = zero_point + std::nearbyint(transformed);
     float clipped =
         std::min(std::max(transformed, float(min_val)), float(max_val));
     dst[i] = clipped;

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -950,7 +950,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
     Vectorized<c10::qint32> retval;
     for (const auto i : c10::irange(size())) {
       retval.vals[i] =
-          nearbyint(static_cast<float>(inp[0].vals[i]) * multiplier) +
+          std::nearbyint(static_cast<float>(inp[0].vals[i]) * multiplier) +
           zero_point;
     }
     return retval;
@@ -1101,7 +1101,7 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
     for (const auto i : c10::irange(int_num_vecs())) {
       for (const auto j : c10::irange(elem_per_int_vec)) {
         int32_t rounded =
-            nearbyint(static_cast<float>(inp[i].vals[j]) * multiplier) +
+            std::nearbyint(static_cast<float>(inp[i].vals[j]) * multiplier) +
             zero_point;
         retval.vals[i * elem_per_int_vec + j] =
             std::min<int32_t>(std::max<int32_t>(rounded, min_val), max_val);
@@ -1234,7 +1234,7 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
     for (const auto i : c10::irange(int_num_vecs())) {
       for (const auto j : c10::irange(elem_per_int_vec)) {
         int32_t rounded =
-            nearbyint(static_cast<float>(inp[i].vals[j]) * multiplier) +
+            std::nearbyint(static_cast<float>(inp[i].vals[j]) * multiplier) +
             zero_point;
         retval.vals[i * elem_per_int_vec + j] =
             std::min<int32_t>(std::max<int32_t>(rounded, min_val), max_val);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -13,6 +13,7 @@
 #include <c10/util/quint8.h>
 
 #include <array>
+#include <cmath>
 
 // This file defines Vectorized<> for the quantized types.
 //

--- a/aten/src/ATen/native/ScatterGatherChecks.h
+++ b/aten/src/ATen/native/ScatterGatherChecks.h
@@ -25,7 +25,7 @@ static void scatter_gather_dtype_check(
   }
 
   if (src_opt.has_value()) {
-    auto src = src_opt.value();
+    const auto& src = src_opt.value();
     TORCH_CHECK(
       self.scalar_type() == src.scalar_type(),
       method_name, "(): Expected self.dtype to be equal to src.dtype"
@@ -89,7 +89,7 @@ static C10_UNUSED void scatter_shape_check(
 
   //  Check: index.size(d) <= src.size(d) for all d if src is Tensor
   if (!is_wrong_shape && src_opt.has_value()) {
-    auto src = src_opt.value();
+    const auto& src = src_opt.value();
     for (const auto d : c10::irange(self_dims)) {
       int64_t index_d_size = ensure_nonempty_size(index, d);
       if (index_d_size > ensure_nonempty_size(src, d)) {
@@ -100,7 +100,7 @@ static C10_UNUSED void scatter_shape_check(
   }
 
   if (src_opt.has_value()) {
-    auto src = src_opt.value();
+    const auto& src = src_opt.value();
 
     TORCH_CHECK(
       ensure_nonempty_dim(src.dim()) == ensure_nonempty_dim(index.dim()),

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -11,6 +11,7 @@
 #include <ATen/core/TensorBase.h>
 #include <ATen/Dispatch.h>
 #include <c10/macros/Macros.h>
+#include <cmath>
 
 namespace at { namespace native {
 
@@ -118,8 +119,8 @@ namespace {
         ix = grid_sampler_unnormalize(x, inp_W, align_corners);
         iy = grid_sampler_unnormalize(y, inp_H, align_corners);
 
-        opmath_t ix_nw = ::floor(ix);
-        opmath_t iy_nw = ::floor(iy);
+        opmath_t ix_nw = std::floor(ix);
+        opmath_t iy_nw = std::floor(iy);
 
         const opmath_t tx = ix - ix_nw;
         const opmath_t ty = iy - iy_nw;
@@ -282,9 +283,9 @@ namespace {
           *out_ptr_NCDHW = out_acc;
         }
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-        index_t ix_nearest = static_cast<index_t>(::round(ix));
-        index_t iy_nearest = static_cast<index_t>(::round(iy));
-        index_t iz_nearest = static_cast<index_t>(::round(iz));
+        index_t ix_nearest = static_cast<index_t>(std::round(ix));
+        index_t iy_nearest = static_cast<index_t>(std::round(iy));
+        index_t iz_nearest = static_cast<index_t>(std::round(iz));
 
         // assign nearest neighor pixel value to output pixel
         auto inp_ptr_NC = input.data + n * inp_sN;
@@ -368,8 +369,8 @@ namespace {
 
       if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
         // get NE, NW, SE, SW pixel values from (x, y)
-        index_t ix_nw = static_cast<index_t>(::floor(ix));
-        index_t iy_nw = static_cast<index_t>(::floor(iy));
+        index_t ix_nw = static_cast<index_t>(std::floor(ix));
+        index_t iy_nw = static_cast<index_t>(std::floor(iy));
         index_t ix_ne = ix_nw + 1;
         index_t iy_ne = iy_nw;
         index_t ix_sw = ix_nw;
@@ -430,8 +431,8 @@ namespace {
         gGrid_ptr_NHW[1] = giy_mult * giy;
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
         if (input_requires_grad) {
-          index_t ix_nearest = static_cast<index_t>(::round(ix));
-          index_t iy_nearest = static_cast<index_t>(::round(iy));
+          index_t ix_nearest = static_cast<index_t>(std::round(ix));
+          index_t iy_nearest = static_cast<index_t>(std::round(iy));
 
           // assign nearest neighor pixel value to output pixel
           scalar_t *gOut_ptr_NCHW = grad_output.data + n * gOut_sN + h * gOut_sH + w * gOut_sW;
@@ -454,8 +455,8 @@ namespace {
         ix = grid_sampler_unnormalize_set_grad(x, inp_W, align_corners, &gix_mult);
         iy = grid_sampler_unnormalize_set_grad(y, inp_H, align_corners, &giy_mult);
 
-        scalar_t ix_nw = ::floor(ix);
-        scalar_t iy_nw = ::floor(iy);
+        scalar_t ix_nw = std::floor(ix);
+        scalar_t iy_nw = std::floor(iy);
 
         const scalar_t tx = ix - ix_nw;
         const scalar_t ty = iy - iy_nw;
@@ -586,9 +587,9 @@ namespace {
         // get corner pixel values from (x, y, z)
         // for 4d, we used north-east-south-west
         // for 5d, we add top-bottom
-        index_t ix_tnw = static_cast<index_t>(::floor(ix));
-        index_t iy_tnw = static_cast<index_t>(::floor(iy));
-        index_t iz_tnw = static_cast<index_t>(::floor(iz));
+        index_t ix_tnw = static_cast<index_t>(std::floor(ix));
+        index_t iy_tnw = static_cast<index_t>(std::floor(iy));
+        index_t iz_tnw = static_cast<index_t>(std::floor(iz));
 
         index_t ix_tne = ix_tnw + 1;
         index_t iy_tne = iy_tnw;
@@ -719,9 +720,9 @@ namespace {
         gGrid_ptr_NDHW[2] = giz_mult * giz;
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
         if (input_requires_grad) {
-          auto ix_nearest = static_cast<index_t>(::round(ix));
-          auto iy_nearest = static_cast<index_t>(::round(iy));
-          auto iz_nearest = static_cast<index_t>(::round(iz));
+          auto ix_nearest = static_cast<index_t>(std::round(ix));
+          auto iy_nearest = static_cast<index_t>(std::round(iy));
+          auto iz_nearest = static_cast<index_t>(std::round(iz));
 
           // assign nearest neighor pixel value to output pixel
           scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -100,8 +100,8 @@ namespace {
           *out_ptr_NCHW = out_acc;
         }
       } else if (interpolation_mode == GridSamplerInterpolation::Nearest) {
-        index_t ix_nearest = static_cast<index_t>(::nearbyint(ix));
-        index_t iy_nearest = static_cast<index_t>(::nearbyint(iy));
+        index_t ix_nearest = static_cast<index_t>(std::nearbyint(ix));
+        index_t iy_nearest = static_cast<index_t>(std::nearbyint(iy));
 
         // assign nearest neighor pixel value to output pixel
         auto inp_ptr_NC = input.data + n * inp_sN;

--- a/aten/src/ATen/native/quantized/cuda/AffineQuantizer.cu
+++ b/aten/src/ATen/native/quantized/cuda/AffineQuantizer.cu
@@ -2,7 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/TensorIterator.h>
 #include <ATen/native/quantized/AffineQuantizer.h>
-#include <math.h>
+#include <cmath>
 #include <ATen/native/cuda/Loops.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS

--- a/aten/src/ATen/native/quantized/cuda/AffineQuantizer.cu
+++ b/aten/src/ATen/native/quantized/cuda/AffineQuantizer.cu
@@ -57,7 +57,7 @@ void quantize_tensor_per_tensor_affine_cuda(
             iter,
             [=] GPU_LAMBDA(float raw_val, scalar_t quantized_val) -> scalar_t {
               int64_t qvalue =
-                  static_cast<int64_t>(nearbyint(raw_val / scale) + zero_point);
+                  static_cast<int64_t>(std::nearbyint(raw_val / scale) + zero_point);
               qvalue = std::max<int64_t>(qvalue, qmin);
               qvalue = std::min<int64_t>(qvalue, qmax);
               quantized_val.val_ = qvalue;
@@ -118,7 +118,7 @@ void quantize_tensor_per_channel_affine_cuda(
           [=] GPU_LAMBDA(float raw_val, scalar_t quantized_val, double scale, int64_t zero_point) -> scalar_t {
 
             int64_t qvalue =
-                static_cast<int64_t>(nearbyint(raw_val/scale) + zero_point);
+                static_cast<int64_t>(std::nearbyint(raw_val/scale) + zero_point);
             qvalue = std::max<int64_t>(qvalue, qmin);
             qvalue = std::min<int64_t>(qvalue, qmax);
             quantized_val.val_ = qvalue;

--- a/aten/src/ATen/native/sparse/SparseBinaryOpIntersectionCommon.h
+++ b/aten/src/ATen/native/sparse/SparseBinaryOpIntersectionCommon.h
@@ -509,7 +509,7 @@ void _sparse_binary_op_intersection_kernel_impl(
 
   const auto res_sparse_dim = source.sparse_dim();
   const auto res_dense_dim = res_values.dim() - 1;
-  const auto res_shape = broadcasted_shape;
+  const auto& res_shape = broadcasted_shape;
   const auto res_nnz = selected_source.numel();
 
   auto* res_sparse_impl = get_sparse_impl(res);

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -92,7 +92,7 @@ void preprocessCaffe2Ops(Block* block) {
       const auto& args = schema.arguments();
       size_t origin_inputs_index = 0;
       for (const auto& arg : args) {
-        auto type = arg.type();
+        const auto& type = arg.type();
         TORCH_INTERNAL_ASSERT(origin_inputs_index < origin_inputs.size());
         const auto& origin_input = origin_inputs[origin_inputs_index++];
         if (type->kind() == TypeKind::OptionalType &&

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -2140,7 +2140,7 @@ void ONNXSetDynamicInputShape(
   std::map<std::string, ::c10::ShapeSymbol> name_to_sym;
 
   for (const auto i : c10::irange(input_names.size())) {
-    auto input_name = input_names[i];
+    const auto& input_name = input_names[i];
     if (dynamic_axes.find(input_name) != dynamic_axes.end()) {
       auto axes_names = dynamic_axes.find(input_name)->second;
       TORCH_INTERNAL_ASSERT(i < graph->inputs().size());


### PR DESCRIPTION
Applies some minor performance fixups to pytorch regarding an implicit promotion and unnecessary copies (when const ref would have worked just as well).


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10