### PR TITLE
Fix rendering of std/var docs

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10701,11 +10701,12 @@ Args:
 
 Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
-                      Defaults to `Bessel's correction`_, ``correction=1``.
-    .. versionchanged:: 1.14
-        Previously this argument was called ``unbiased`` and was a boolean with
-        ``True`` corresponding to ``correction=1`` and ``False`` being ``correction=0``.
+        Defaults to `Bessel's correction`_, ``correction=1``.
 
+        .. versionchanged:: 1.14
+            Previously this argument was called ``unbiased`` and was a boolean
+            with ``True`` corresponding to ``correction=1`` and ``False`` being
+            ``correction=0``.
     {keepdim}
     {out}
 
@@ -10757,10 +10758,12 @@ Args:
 
 Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
-                      Defaults to `Bessel's correction`_, ``correction=1``.
-    .. versionchanged:: 1.14
-        Previously this argument was called ``unbiased`` and was a boolean with
-        ``True`` corresponding to ``correction=1`` and ``False`` being ``correction=0``.
+        Defaults to `Bessel's correction`_, ``correction=1``.
+
+        .. versionchanged:: 1.14
+            Previously this argument was called ``unbiased`` and was a boolean
+            with ``True`` corresponding to ``correction=1`` and ``False`` being
+            ``correction=0``.
     {keepdim}
     {out}
 
@@ -12175,10 +12178,12 @@ Args:
 
 Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
-                      Defaults to `Bessel's correction`_, ``correction=1``.
-    .. versionchanged:: 1.14
-        Previously this argument was called ``unbiased`` and was a boolean with
-        ``True`` corresponding to ``correction=1`` and ``False`` being ``correction=0``.
+        Defaults to `Bessel's correction`_, ``correction=1``.
+
+        .. versionchanged:: 1.14
+            Previously this argument was called ``unbiased`` and was a boolean
+            with ``True`` corresponding to ``correction=1`` and ``False`` being
+            ``correction=0``.
     {keepdim}
     {out}
 
@@ -12229,10 +12234,12 @@ Args:
 
 Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
-                      Defaults to `Bessel's correction`_, ``correction=1``.
-    .. versionchanged:: 1.14
-        Previously this argument was called ``unbiased`` and was a boolean with
-        ``True`` corresponding to ``correction=1`` and ``False`` being ``correction=0``.
+        Defaults to `Bessel's correction`_, ``correction=1``.
+
+        .. versionchanged:: 1.14
+            Previously this argument was called ``unbiased`` and was a boolean
+            with ``True`` corresponding to ``correction=1`` and ``False`` being
+            ``correction=0``.
     {keepdim}
     {out}
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10703,7 +10703,7 @@ Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
         Defaults to `Bessel's correction`_, ``correction=1``.
 
-        .. versionchanged:: 1.14
+        .. versionchanged:: 2.0
             Previously this argument was called ``unbiased`` and was a boolean
             with ``True`` corresponding to ``correction=1`` and ``False`` being
             ``correction=0``.
@@ -10760,7 +10760,7 @@ Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
         Defaults to `Bessel's correction`_, ``correction=1``.
 
-        .. versionchanged:: 1.14
+        .. versionchanged:: 2.0
             Previously this argument was called ``unbiased`` and was a boolean
             with ``True`` corresponding to ``correction=1`` and ``False`` being
             ``correction=0``.
@@ -12180,7 +12180,7 @@ Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
         Defaults to `Bessel's correction`_, ``correction=1``.
 
-        .. versionchanged:: 1.14
+        .. versionchanged:: 2.0
             Previously this argument was called ``unbiased`` and was a boolean
             with ``True`` corresponding to ``correction=1`` and ``False`` being
             ``correction=0``.
@@ -12236,7 +12236,7 @@ Keyword args:
     correction (int): difference between the sample size and sample degrees of freedom.
         Defaults to `Bessel's correction`_, ``correction=1``.
 
-        .. versionchanged:: 1.14
+        .. versionchanged:: 2.0
             Previously this argument was called ``unbiased`` and was a boolean
             with ``True`` corresponding to ``correction=1`` and ``False`` being
             ``correction=0``.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #91761
* __->__ #91730

Due to the indentation, "versionchanged" is being rendered as if it was an
argument.