### PR TITLE
[cuDNN][cuDNN V8 API] Enable `cuDNN` for `BFloat16` depthwise convolutions

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -87,7 +87,7 @@ constexpr int MIOPEN_DIM_MAX = 5;
 
 namespace at { namespace native {
 
-// Check workload to activate fast depthwise FP16 cudnn conv kernels
+// Check workload to activate fast depthwise cudnn conv kernels
 template <typename T>
 bool check_cudnn_depthwise_workload(const at::Tensor& input, int stride) {
   auto w = at::symint::size<T>(input, 3);  // same as h
@@ -447,7 +447,7 @@ struct ConvParams {
     if (detail::getCUDAHooks().supportsDepthwiseConvolutionWithCuDNN()) {
       long cudnn_version = detail::getCUDAHooks().versionCuDNN();
       if (cudnn_version >= 8200) {
-        bool type_cond = (input.scalar_type() == kHalf && // only for FP16
+        bool type_cond = (input.scalar_type() == kHalf &&
                              weight.scalar_type() == kHalf) || 
                          (input.scalar_type() == kBFloat16 && 
                              weight.scalar_type() == kBFloat16);

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -448,8 +448,8 @@ struct ConvParams {
       long cudnn_version = detail::getCUDAHooks().versionCuDNN();
       if (cudnn_version >= 8200) {
         bool type_cond = (input.scalar_type() == kHalf &&
-                             weight.scalar_type() == kHalf) || 
-                         (input.scalar_type() == kBFloat16 && 
+                             weight.scalar_type() == kHalf) ||
+                         (input.scalar_type() == kBFloat16 &&
                              weight.scalar_type() == kBFloat16);
         bool kernel_cond =  (use_cudnn(input, weight) &&
                              type_cond &&

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -450,7 +450,7 @@ struct ConvParams {
         bool type_cond = (input.scalar_type() == kHalf &&
                              weight.scalar_type() == kHalf) ||
                          (input.scalar_type() == kBFloat16 &&
-                             weight.scalar_type() == kBFloat16 && 
+                             weight.scalar_type() == kBFloat16 &&
                              at::cuda::getCurrentDeviceProperties()->major >= 8);
         bool kernel_cond =  (use_cudnn(input, weight) &&
                              type_cond &&

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -451,7 +451,7 @@ struct ConvParams {
                              weight.scalar_type() == kHalf) ||
                          (input.scalar_type() == kBFloat16 &&
                              weight.scalar_type() == kBFloat16 &&
-                             at::cuda::getCurrentDeviceProperties()->major >= 8);
+                             detail::getCUDAHooks().supportsBFloat16ConvolutionWithCuDNNv8());
         bool kernel_cond =  (use_cudnn(input, weight) &&
                              type_cond &&
                              is_depthwise(input, weight) &&

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -447,9 +447,12 @@ struct ConvParams {
     if (detail::getCUDAHooks().supportsDepthwiseConvolutionWithCuDNN()) {
       long cudnn_version = detail::getCUDAHooks().versionCuDNN();
       if (cudnn_version >= 8200) {
+        bool type_cond = (input.scalar_type() == kHalf && // only for FP16
+                             weight.scalar_type() == kHalf) || 
+                         (input.scalar_type() == kBFloat16 && 
+                             weight.scalar_type() == kBFloat16);
         bool kernel_cond =  (use_cudnn(input, weight) &&
-                             input.scalar_type() == kHalf && // only for FP16
-                             weight.scalar_type() == kHalf &&
+                             type_cond &&
                              is_depthwise(input, weight) &&
                              input.ndimension() == 4 &&   // TODO: 5-D contiguous depthwise is not supported yet, need benchmarks
                              !is_dilated() && // no dilation supported

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -450,7 +450,8 @@ struct ConvParams {
         bool type_cond = (input.scalar_type() == kHalf &&
                              weight.scalar_type() == kHalf) ||
                          (input.scalar_type() == kBFloat16 &&
-                             weight.scalar_type() == kBFloat16);
+                             weight.scalar_type() == kBFloat16 && 
+                             at::cuda::getCurrentDeviceProperties()->major >= 8);
         bool kernel_cond =  (use_cudnn(input, weight) &&
                              type_cond &&
                              is_depthwise(input, weight) &&


### PR DESCRIPTION
Creating this PR for testing purposes, we need to revisit the handwritten condition for `use_cudnn` to check if the reflect current `cuDNN` support.

CC @ptrblck @ngimel

cc @csarofeen @ptrblck @xwang233 @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10