### PR TITLE
Update CMakeLists.txt since MacOS linker doesn't support whole-archive

### DIFF
--- a/test/edge/CMakeLists.txt
+++ b/test/edge/CMakeLists.txt
@@ -56,7 +56,7 @@ set(TEST_DEPENDENCIES gtest unbox_lib)
 target_link_libraries(test_edge_op_registration PRIVATE
   ${TEST_DEPENDENCIES}
 )
-if(APPLE)
+if((CMAKE_CXX_COMPILER_ID MATCHES "AppleClang") OR (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
   target_link_options(test_edge_op_registration PRIVATE
           "-Wl,-force_load,$<TARGET_FILE:unbox_lib>"
           )

--- a/test/edge/CMakeLists.txt
+++ b/test/edge/CMakeLists.txt
@@ -60,6 +60,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
   target_link_options(test_edge_op_registration PRIVATE
           "-Wl,-force_load,$<TARGET_FILE:unbox_lib>"
           )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if(APPLE)
+    target_link_options(test_edge_op_registration PRIVATE
+            "-Wl,-force_load,$<TARGET_FILE:unbox_lib>"
+            )
+  endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   target_link_options(test_edge_op_registration PRIVATE
           "-Wl,--whole-archive,$<TARGET_FILE:unbox_lib>,--no-whole-archive"

--- a/test/edge/CMakeLists.txt
+++ b/test/edge/CMakeLists.txt
@@ -56,16 +56,10 @@ set(TEST_DEPENDENCIES gtest unbox_lib)
 target_link_libraries(test_edge_op_registration PRIVATE
   ${TEST_DEPENDENCIES}
 )
-if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+if(APPLE)
   target_link_options(test_edge_op_registration PRIVATE
           "-Wl,-force_load,$<TARGET_FILE:unbox_lib>"
           )
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  if(APPLE)
-    target_link_options(test_edge_op_registration PRIVATE
-            "-Wl,-force_load,$<TARGET_FILE:unbox_lib>"
-            )
-  endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   target_link_options(test_edge_op_registration PRIVATE
           "-Wl,--whole-archive,$<TARGET_FILE:unbox_lib>,--no-whole-archive"


### PR DESCRIPTION
--whole-archive is a linker option(notice, that flag is passed as -Wl,--whole-archive), and -force_load is indeed available on MacOS platform (below is the quote from man ld):

 -force_load path_to_archive
        Loads all members of the specified static archive library.  Note:
        -all_load forces all members of all archives to be loaded.  This
        option allows you to target a specific archive.

Quote from malfet