### PR TITLE
Consider updating pin to CMake version 3.23.1 on run_torchbench CI

### DIFF
--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -39,10 +39,8 @@ jobs:
           # shellcheck source=/dev/null
           . "${SETUP_SCRIPT}"
           conda activate pr-ci
-          # pin cmake version to 3.22 since 3.23 breaks pytorch build
-          # see details at: https://github.com/pytorch/pytorch/issues/74985
           conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
-                           setuptools cmake=3.22 cffi typing_extensions boto3 \
+                           setuptools cmake cffi typing_extensions boto3 \
                            future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
           pip install --pre torch torchvision torchtext -f https://download.pytorch.org/whl/nightly/cu116/torch_nightly.html
       - name: Setup TorchBench branch

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -40,7 +40,7 @@ jobs:
           . "${SETUP_SCRIPT}"
           conda activate pr-ci
           conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
-                           setuptools cmake=3.23.1 cffi typing_extensions boto3 \
+                           setuptools cmake=3.22.* cffi typing_extensions boto3 \
                            future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
           pip install --pre torch torchvision torchtext -f https://download.pytorch.org/whl/nightly/cu116/torch_nightly.html
       - name: Setup TorchBench branch

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -40,7 +40,7 @@ jobs:
           . "${SETUP_SCRIPT}"
           conda activate pr-ci
           conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
-                           setuptools cmake cffi typing_extensions boto3 \
+                           setuptools cmake=3.23.1 cffi typing_extensions boto3 \
                            future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
           pip install --pre torch torchvision torchtext -f https://download.pytorch.org/whl/nightly/cu116/torch_nightly.html
       - name: Setup TorchBench branch


### PR DESCRIPTION
### Issues Affected
Fixes #74985 and #75705

### Description
Unpinned cmake initially used version 3.23.0 which broke a build https://github.com/pytorch/pytorch/issues/74985#issue-1187048138. This previously led to a necessary pin to cmake version 3.22. With the release of cmake 3.23.1, it is no longer necessary to pin cmake https://github.com/pytorch/pytorch/issues/74985#issuecomment-1102355302. 

CMake unpin change has not been added to `.jenkins/pytorch/win-test-helpers/installation-helpers/install_miniconda3.bat` because Windows dependencies were refactored away https://github.com/pytorch/pytorch/pull/88862.


### How is this Tested?
This change is tested using "RUN_TORCHBENCH:" in the PR body https://github.com/pytorch/pytorch/pull/77577#issuecomment-1128048251.

### People with Relevant Context
@janeyx99

RUN_TORCHBENCH: