### PR TITLE
Docs push fix .netrc sometimes a directory

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -95,6 +95,8 @@ jobs:
         env:
           GITHUB_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |
+          # sometimes .netrc exists as a directory even though this is the temp folder
+          rm -rf "${RUNNER_TEMP}/.netrc"
           # set credentials for https pushing
           echo "machine github.com" > "${RUNNER_TEMP}/.netrc"
           echo "login pytorchbot" >> "${RUNNER_TEMP}/.netrc"


### PR DESCRIPTION
Sometimes .netrc is a directory even though it's in the temp folder.

AFAIK there's nothing in the folder https://github.com/pytorch/pytorch/actions/runs/3842987245/jobs/6544919416