### PR TITLE
Remove deadline to fix test

### DIFF
--- a/test/quantization/core/test_quantized_functional.py
+++ b/test/quantization/core/test_quantized_functional.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 import numpy as np
 
 # Testing utils
-from hypothesis import assume, given
+from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 from torch.testing._internal.common_quantization import (
     QuantizationTestCase,
@@ -84,6 +84,7 @@ class TestQuantizedFunctionalOps(QuantizationTestCase):
            use_bias=st.booleans(),
            use_channelwise=st.booleans(),
            qengine=st.sampled_from(("qnnpack", "fbgemm")))
+    @settings(deadline=None)
     def test_conv1d_api(
         self, batch_size, in_channels_per_group, L, out_channels_per_group,
         groups, kernel, stride, pad, dilation,


### PR DESCRIPTION
Summary:
# Summary

When trying to land D42315413, we noticed a unit test failing with deadline exceeded errors. After discussing with oncall andrewor14, we decided to remove the deadline requirements to fix the test.

Test Plan:
```
buck2 test mode/dev //caffe2/test/quantization:test_quantization -- --exact 'caffe2/test/quantization:test_quantization - test_conv1d_api (caffe2.test.quantization.core.test_quantized_functional.TestQuantizedFunctionalOps)'
```

Test UI: https://www.internalfb.com/intern/testinfra/testrun/281475258078448

Differential Revision: D42355074

