### PR TITLE
fix sort crash when the input is expanded scalar

### DIFF
--- a/aten/src/ATen/native/StridedRandomAccessor.h
+++ b/aten/src/ATen/native/StridedRandomAccessor.h
@@ -140,7 +140,7 @@ public:
   // 2. |other - this| / this.stride is an Integer.
   C10_HOST_DEVICE
   difference_type operator-(const ConstStridedRandomAccessor& other) const {
-    return (ptr - other.ptr) / stride;
+    return (ptr - other.ptr) / std::max(stride, index_t(1));
   }
   // }
 

--- a/aten/src/ATen/native/StridedRandomAccessor.h
+++ b/aten/src/ATen/native/StridedRandomAccessor.h
@@ -140,7 +140,7 @@ public:
   // 2. |other - this| / this.stride is an Integer.
   C10_HOST_DEVICE
   difference_type operator-(const ConstStridedRandomAccessor& other) const {
-    return (ptr - other.ptr) / std::max(stride, index_t(1));
+    return (ptr - other.ptr) / stride;
   }
   // }
 

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -92,6 +92,11 @@ static void sort_kernel(
     bool stable) {
   dim = maybe_wrap_dim(dim, values.dim());
   _fill_indices(indices, dim);
+  if (self.stride(dim) == 0) {
+    // check if stride is zero
+    // https://github.com/pytorch/pytorch/issues/91420
+    return;
+  }
   _dim_apply(
     values, indices, dim,
     "sort_cpu", [&](

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -357,6 +357,16 @@ class TestSortAndSelect(TestCase):
         for shape in shapes:
             test(shape)
 
+    @dtypes(torch.float)
+    def test_sort_expanded_scalar(self, device, dtype):
+        # https://github.com/pytorch/pytorch/issues/91420
+        s0 = torch.scalar_tensor(True, device=device, dtype=dtype)
+        s3 = s0.expand([1, 1, 1])
+        out = torch.sort(s3, stable=True, dim=1, descending=True)
+        t3 = torch.Tensor([[[True]]])
+        expected = torch.sort(t3, stable=True, dim=1, descending=True)
+        self.assertEqual(out, expected)
+
     def test_topk(self, device):
         def topKViaSort(t, k, dim, dir):
             sorted, indices = t.sort(dim, dir)

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -358,13 +358,20 @@ class TestSortAndSelect(TestCase):
             test(shape)
 
     @dtypes(torch.float)
-    def test_sort_expanded_scalar(self, device, dtype):
+    def test_sort_expanded_tensor(self, device, dtype):
         # https://github.com/pytorch/pytorch/issues/91420
-        s0 = torch.scalar_tensor(True, device=device, dtype=dtype)
-        s3 = s0.expand([1, 1, 1])
-        out = torch.sort(s3, stable=True, dim=1, descending=True)
-        t3 = torch.Tensor([[[True]]])
-        expected = torch.sort(t3, stable=True, dim=1, descending=True)
+        data = torch.scalar_tensor(True, device=device, dtype=dtype)
+        data = data.expand([1, 1, 1])
+        ref = torch.Tensor([[[True]]])
+        out = torch.sort(data, stable=True, dim=1, descending=True)
+        expected = torch.sort(ref, stable=True, dim=1, descending=True)
+        self.assertEqual(out, expected)
+
+        data = torch.randn(4, 1, 10, device=device, dtype=dtype)
+        data = data.expand([4, 8, 10])
+        ref = data.contiguous()
+        out = torch.sort(data, stable=True, dim=1, descending=True)
+        expected = torch.sort(ref, stable=True, dim=1, descending=True)
         self.assertEqual(out, expected)
 
     def test_topk(self, device):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #91752

fix https://github.com/pytorch/pytorch/issues/91420





cc @jgong5 @XiaobingSuper @sanchitintel @ashokei @jingxu10