### PR TITLE
fixed typo error

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,15 +14,15 @@ Features described in this documentation are classified by release status:
 
   *Stable:*  These features will be maintained long-term and there should generally
   be no major performance limitations or gaps in documentation.
-  We also expect to maintain backwards compatibility (although
+  We also expect to maintain backward compatibility (although
   breaking changes can happen and notice will be given one release ahead
   of time).
 
   *Beta:*  These features are tagged as Beta because the API may change based on
-  user feedback, because the performance needs to improve, or because
+  user feedback because the performance needs to improve, or because
   coverage across operators is not yet complete. For Beta features, we are
   committing to seeing the feature through to the Stable classification.
-  We are not, however, committing to backwards compatibility.
+  We are not, however, committing to backward compatibility.
 
   *Prototype:*  These features are typically not available as part of
   binary distributions like PyPI or Conda, except sometimes behind run-time


### PR DESCRIPTION
corrected spelling mistakes.

![Screenshot (461)](https://user-images.githubusercontent.com/110167551/210833314-39a657bd-9f49-444d-9c46-e3c4fa165048.png)

