### PR TITLE
[SDPA] Return empty attention weights when need_atten_weights = False

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -730,9 +730,7 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention(
       }
       return std::make_tuple(
           std::move(std::get<0>(out_and_lse)),
-          at::empty_symint(
-              c10::SymIntArrayRef{query_.sym_size(0), query_.sym_size(1), query_.sym_size(2), key.sym_size(2)},
-              query_.options()));
+          at::empty_symint({0}, query_.options()));
     }
     case sdp::SDPBackend::math:
       return at::_scaled_dot_product_attention_math(
@@ -802,9 +800,7 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math(
     // TODO: Need to fix when we have empty for nested tensors.
     attn = need_attn_weights || query_.is_nested()
         ? attn
-        : at::empty_symint(
-              c10::SymIntArrayRef{query_.sym_size(0), query_.sym_size(1), query_.sym_size(2), key.sym_size(2)},
-              query_.options());
+        : at::empty_symint({0}, query_.options());
     return std::make_tuple(output, attn);
 }
 

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp
@@ -198,9 +198,10 @@ mha_fwd(const at::Tensor &q,         // total_q x num_heads x head_size, total_q
     if (loop) { o_tmp = at::empty({total_q, num_heads, head_size}, opts.dtype(at::kFloat)); }
 
     auto softmax_lse = at::empty({batch_size, num_heads, max_seqlen_q}, opts.dtype(at::kFloat));
-    // auto softmax_lse = torch::full({batch_size, num_heads, max_seqlen_k}, -std::numeric_limits<float>::infinity(), opts.dtype(at::kFloat));
 
-    at::Tensor s;
+    //  It appears that FlashAttention can return attention weights, but we don't use them. Since we are currently
+    //  filtering this out in the dispatch mechanism. Investigate this ouput against the math impl.
+    at::Tensor s = at::empty({0}, opts);
     if (return_softmax) { s = at::empty({ batch_size, num_heads, max_seqlen_q, max_seqlen_k }, opts); }
 
     if( zero_tensors ) {

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2015,6 +2015,11 @@ def meta__scaled_dot_product_flash(
         dtype=query.dtype,
         device=query.device,
     )
+    softmax = torch.empty(
+        0,
+        dtype=query.dtype,
+        device=query.device,
+    )
     return ouput, logsumexp, softmax
 
 


### PR DESCRIPTION
# Summary
This PR updates the second return value from SDPA to return an empty tensor of size 0 not what it would be if need_attn_weights is True. Also updates the meta function to account for this change.


cc @ngimel