### PR TITLE
[MPS] Add testcase for copying cpu tensors into strided mps tensors 

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -51,7 +51,7 @@ std::string getTensorsStringKey(const TensorList& tensors, bool short_dtype = fa
 std::string getArrayRefString(const IntArrayRef s);
 // use has_storage() on the returned tensor to determine if src actually is a view
 Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst);
-Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output);
+Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output, id<MTLBuffer> updatesBuffer = nil);
 
 // The MPSShape could vary based on memory format
 MPSShape* getMPSShape(const Tensor& t, c10::MemoryFormat memory_format = MemoryFormat::Contiguous);

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -51,7 +51,7 @@ std::string getTensorsStringKey(const TensorList& tensors, bool short_dtype = fa
 std::string getArrayRefString(const IntArrayRef s);
 // use has_storage() on the returned tensor to determine if src actually is a view
 Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst);
-Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output, id<MTLBuffer> updatesBuffer = nil);
+Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output);
 
 // The MPSShape could vary based on memory format
 MPSShape* getMPSShape(const Tensor& t, c10::MemoryFormat memory_format = MemoryFormat::Contiguous);

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -207,14 +207,14 @@ static void copy_to_mps_stride_contig(at::Tensor& dst, const at::Tensor& src, bo
 
     void* alignedPtr = pageAlignedBlockPtr(host_src, (NSUInteger)size_to_copy, &alignedLength);
     sourceOffset = uintptr_t(host_src) - uintptr_t(alignedPtr);
-    sourceOffset += src_.storage_offset() * src_.itemsize();
+    sourceOffset += src.storage_offset() * src.itemsize();
 
     id<MTLBuffer> sourceBuffer = nil;
     // If the destination is a strided MPS tensor, we cannot perform a blit directly to copy the
     // memory from the CPU tensor into the MPS tensor. We need to scatter the data into the right indices
-    bool doScatter = (!dst_.is_contiguous() && src.is_contiguous());
+    bool doScatter = (!dst.is_contiguous() && src.is_contiguous());
     if (doScatter) {
-      sourceBuffer = [device newBufferWithBytes:(void*)((uint8_t*)host_src + (src_.storage_offset() * src_.itemsize()))
+      sourceBuffer = [device newBufferWithBytes:(void*)((uint8_t*)host_src + (src.storage_offset() * src.itemsize()))
                                          length:size_to_copy
                                         options:options];
     }
@@ -226,7 +226,7 @@ static void copy_to_mps_stride_contig(at::Tensor& dst, const at::Tensor& src, bo
     }
 
     if (doScatter) {
-      scatterViewTensor(src, dst_, sourceBuffer);
+      scatterViewTensor(src, dst, sourceBuffer);
     } else {
       stream->copy_and_sync(sourceBuffer, destBuffer, size_to_copy, sourceOffset, dst_byte_offset, non_blocking);
     }

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -206,13 +206,30 @@ static void copy_to_mps_stride_contig(at::Tensor& dst, const at::Tensor& src, bo
     NSUInteger sourceOffset = 0;
 
     void* alignedPtr = pageAlignedBlockPtr(host_src, (NSUInteger)size_to_copy, &alignedLength);
-    id<MTLBuffer> sourceBuffer = [device newBufferWithBytesNoCopy:alignedPtr
-                                          length:alignedLength
-                                         options:options
-                                     deallocator:nil];
     sourceOffset = uintptr_t(host_src) - uintptr_t(alignedPtr);
+    sourceOffset += src_.storage_offset() * src_.itemsize();
 
-    stream->copy_and_sync(sourceBuffer, destBuffer, size_to_copy, sourceOffset, dst_byte_offset, non_blocking);
+    id<MTLBuffer> sourceBuffer = nil;
+    // If the destination is a strided MPS tensor, we cannot perform a blit directly to copy the
+    // memory from the CPU tensor into the MPS tensor. We need to scatter the data into the right indices
+    bool doScatter = (!dst_.is_contiguous() && src.is_contiguous());
+    if (doScatter) {
+      sourceBuffer = [device newBufferWithBytes:(void*)((uint8_t*)host_src + (src_.storage_offset() * src_.itemsize()))
+                                         length:size_to_copy
+                                        options:options];
+    }
+    else {
+      sourceBuffer = [device newBufferWithBytesNoCopy:alignedPtr
+                                               length:alignedLength
+                                              options:options
+                                          deallocator:nil];
+    }
+
+    if (doScatter) {
+      scatterViewTensor(src, dst_, sourceBuffer);
+    } else {
+      stream->copy_and_sync(sourceBuffer, destBuffer, size_to_copy, sourceOffset, dst_byte_offset, non_blocking);
+    }
     [sourceBuffer release];
   }
 }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1598,6 +1598,19 @@ class TestMPS(TestCase):
 
         self.assertEqual(x_cpu, x.cpu())
 
+    def test_cpu_to_strided_mps_copy(self):
+        # https://github.com/pytorch/pytorch/issues/86975
+
+        a1 = torch.Tensor([[1,2],[3,4], [5,6]]).to(torch.device("mps"))
+        b1 = torch.Tensor([-1, -1])
+        a1[1:,1] = b1
+
+        a2 = torch.Tensor([[1,2],[3,4], [5,6]]).to(torch.device("mps"))
+        b2 = torch.Tensor([-1, -1]).to(torch.device("mps"))
+        a2[1:,1] = b2
+
+        self.assertEqual(a1, a2)
+
     def test_view_slice(self):
         # https://github.com/pytorch/pytorch/issues/83995
         NUM_SAMPLES = 60
@@ -6990,7 +7003,6 @@ class TestViewOpsMPS(TestCase):
         self.assertRaises(RuntimeError, lambda: tensor.view(7, -1))
         self.assertRaises(RuntimeError, lambda: tensor.view(15, -1, -1))
 
-    # RuntimeError: Invalid device for storage: mps
     def test_contiguous(self, device="mps"):
         x = torch.randn(1, 16, 5, 5, device=device)
         self.assertTrue(x.is_contiguous())

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1601,13 +1601,13 @@ class TestMPS(TestCase):
     def test_cpu_to_strided_mps_copy(self):
         # https://github.com/pytorch/pytorch/issues/86975
 
-        a1 = torch.Tensor([[1,2],[3,4], [5,6]]).to(torch.device("mps"))
+        a1 = torch.Tensor([[1, 2], [3, 4], [5, 6]]).to(torch.device("mps"))
         b1 = torch.Tensor([-1, -1])
-        a1[1:,1] = b1
+        a1[1:, 1] = b1
 
-        a2 = torch.Tensor([[1,2],[3,4], [5,6]]).to(torch.device("mps"))
+        a2 = torch.Tensor([[1, 2], [3, 4], [5, 6]]).to(torch.device("mps"))
         b2 = torch.Tensor([-1, -1]).to(torch.device("mps"))
-        a2[1:,1] = b2
+        a2[1:, 1] = b2
 
         self.assertEqual(a1, a2)
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/86975

If the destination is a strided MPS tensor and the source is a CPU tensor, we cannot perform a blit directly to copy the memory from the CPU tensor into the MPS tensor. We need to scatter the data into the right indices.
```
        a1 = torch.Tensor([[1,2],[3,4], [5,6]]).to(torch.device("mps"))
        b1 = torch.Tensor([-1, -1])
        a1[1:,1] = b1  # strided MPS destination / contiguous CPU source
```