### PR TITLE
[pkg] Improve error message to relect naming collisions

### DIFF
--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -128,13 +128,30 @@ class Importer(ABC):
 
         obj_module_name, obj_location, obj_importer_name = get_obj_info(obj)
         obj2_module_name, obj2_location, obj2_importer_name = get_obj_info(obj2)
-        msg = (
-            f"\n\nThe object provided is from '{obj_module_name}', "
-            f"which is coming from {obj_location}."
-            f"\nHowever, when we import '{obj2_module_name}', it's coming from {obj2_location}."
-            "\nTo fix this, make sure this 'PackageExporter's importer lists "
-            f"{obj_importer_name} before {obj2_importer_name}."
-        )
+        msg = ""
+        if obj_module_name != obj2_module_name:
+            msg += (
+                f"\n\nCan't pickle {obj2}: it's not the same object as {obj_module_name}."
+                f"\nInstead, we are importing {obj2_module_name}. "
+                f"\nUsually these errors occur when trying to package unpicklable objects "
+                f"like decorated functions."
+            )
+        if (obj_location != obj2_location) or (obj_importer_name != obj2_importer_name):
+            msg += (
+                f"\n\nThe object provided is from '{obj_module_name}', "
+                f"which is coming from {obj_location}."
+                f"\nHowever, when we import '{obj2_module_name}', it's coming from {obj2_location}."
+                "\nTo fix this, make sure this 'PackageExporter's importer lists "
+                f"{obj_importer_name} before {obj2_importer_name}."
+            )
+        elif obj_module_name == obj2_module_name:
+            msg += (
+                f"\n\nThe object provided ({obj}) is not the same as the object we import ({obj2}) "
+                f"despite both of them having the name {obj_module_name}', coming from {obj_location}, "
+                f"and using the importer {obj_importer_name}. "
+                "\nPlease report this error to the PyTorch team. "
+            )
+
         raise ObjMismatchError(msg)
 
     def whichmodule(self, obj: Any, name: str) -> str:


### PR DESCRIPTION
Summary:
Improve error logging such that naming collisions are called out. In this case, usually the object is just not picklable and its worth passing that knowledge onto the user.

Furthermore, we block the original error behind collisions of the modules location/importer as its advice is primarily useful then.

If the location, importer, and name do not have collisions, then something odd is going on. Rather than leaving the user without any action items, we tell them to contact the PyTorch team as there is probably a bug.

Differential Revision: D42382596

