### PR TITLE
[JIT] Skip builtins while enumerating class methods

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -448,6 +448,10 @@ def createResolutionCallbackForClassMethods(cls):
         for name in cls.__dict__
         if inspect.isroutine(getattr(cls, name))
     ]
+    # Skip built-ins, as they do not have global scope nor type hints
+    # Needed to support `enum.Enum` derived classes in Python-3.11
+    # That adds `_new_member_` property which is an alias to `__new__`
+    fns = [fn for fn in fns if  not inspect.isbuiltin(fn)]
     captures = {}
 
     for fn in fns:

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -451,7 +451,7 @@ def createResolutionCallbackForClassMethods(cls):
     # Skip built-ins, as they do not have global scope nor type hints
     # Needed to support `enum.Enum` derived classes in Python-3.11
     # That adds `_new_member_` property which is an alias to `__new__`
-    fns = [fn for fn in fns if  not inspect.isbuiltin(fn)]
+    fns = [fn for fn in fns if not inspect.isbuiltin(fn)]
     captures = {}
 
     for fn in fns:


### PR DESCRIPTION
This is needed to support `enum.Enum` derived classes in Python-3.11
that adds `_new_member_` to classdict, see:
https://github.com/python/cpython/blob/15c44789bb125b93e96815a336ec73423c47508e/Lib/enum.py#L529

Following snippet illustrates the problem with the previous iteration of
the code on 3.11:
```python
from enum import Enum
import inspect

class Color(Enum):
    RED = 1
    GREEN = 2

def print_routines(cls):
    print(cls.__name__)
    for name in cls.__dict__:
        fn = getattr(cls, name)
        if inspect.isroutine(fn):
            print(name, fn, f"has_globals: {hasattr(fn, '__globals__')}")

print_routines(Color)
```
