### PR TITLE
[pruning][core][feature] Add in SaliencyPruner to pruner._experimental

### DIFF
--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -14,7 +14,10 @@ from ao.sparsity.test_parametrization import TestFakeSparsity  # noqa: F401
 from ao.sparsity.test_sparsifier import TestBaseSparsifier  # noqa: F401
 from ao.sparsity.test_sparsifier import TestWeightNormSparsifier  # noqa: F401
 from ao.sparsity.test_sparsifier import TestNearlyDiagonalSparsifier  # noqa: F401
+
+# Structured Pruning
 from ao.sparsity.test_structured_sparsifier import TestBaseStructuredSparsifier  # noqa: F401
+from ao.sparsity.test_structured_sparsifier import TestSaliencyPruner # noqa: F401
 
 # Scheduler
 from ao.sparsity.test_scheduler import TestScheduler  # noqa: F401

--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -16,9 +16,7 @@ from ao.sparsity.test_sparsifier import TestWeightNormSparsifier  # noqa: F401
 from ao.sparsity.test_sparsifier import TestNearlyDiagonalSparsifier  # noqa: F401
 
 # Structured Pruning
-from ao.sparsity.test_structured_sparsifier import (
-    TestBaseStructuredSparsifier,
-)  # noqa: F401
+from ao.sparsity.test_structured_sparsifier import TestBaseStructuredSparsifier  # noqa: F401
 from ao.sparsity.test_structured_sparsifier import TestSaliencyPruner  # noqa: F401
 
 # Scheduler
@@ -42,9 +40,7 @@ from ao.sparsity.test_data_sparsifier import TestQuantizationUtils  # noqa: F401
 from ao.sparsity.test_data_scheduler import TestBaseDataScheduler  # noqa: F401
 
 # Activation Sparsifier
-from ao.sparsity.test_activation_sparsifier import (
-    TestActivationSparsifier,
-)  # noqa: F401
+from ao.sparsity.test_activation_sparsifier import TestActivationSparsifier  # noqa: F401
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_ao_sparsity.py
+++ b/test/test_ao_sparsity.py
@@ -16,8 +16,10 @@ from ao.sparsity.test_sparsifier import TestWeightNormSparsifier  # noqa: F401
 from ao.sparsity.test_sparsifier import TestNearlyDiagonalSparsifier  # noqa: F401
 
 # Structured Pruning
-from ao.sparsity.test_structured_sparsifier import TestBaseStructuredSparsifier  # noqa: F401
-from ao.sparsity.test_structured_sparsifier import TestSaliencyPruner # noqa: F401
+from ao.sparsity.test_structured_sparsifier import (
+    TestBaseStructuredSparsifier,
+)  # noqa: F401
+from ao.sparsity.test_structured_sparsifier import TestSaliencyPruner  # noqa: F401
 
 # Scheduler
 from ao.sparsity.test_scheduler import TestScheduler  # noqa: F401
@@ -40,7 +42,9 @@ from ao.sparsity.test_data_sparsifier import TestQuantizationUtils  # noqa: F401
 from ao.sparsity.test_data_scheduler import TestBaseDataScheduler  # noqa: F401
 
 # Activation Sparsifier
-from ao.sparsity.test_activation_sparsifier import TestActivationSparsifier  # noqa: F401
+from ao.sparsity.test_activation_sparsifier import (
+    TestActivationSparsifier,
+)  # noqa: F401
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_tests()

--- a/torch/ao/pruning/_experimental/pruner/__init__.py
+++ b/torch/ao/pruning/_experimental/pruner/__init__.py
@@ -3,3 +3,4 @@ from .parametrization import (
     FakeStructuredSparsity,
     BiasHook,
 )
+from .saliency_pruner import SaliencyPruner

--- a/torch/ao/pruning/_experimental/pruner/saliency_pruner.py
+++ b/torch/ao/pruning/_experimental/pruner/saliency_pruner.py
@@ -1,0 +1,20 @@
+from .base_structured_sparsifier import BaseStructuredSparsifier
+
+class SaliencyPruner(BaseStructuredSparsifier):
+     """
+     Prune filters based on the saliency
+     The saliency for a filter is given by the sum of the L1 norms of all of its weights
+     """
+
+     def update_mask(self, module, tensor_name, **kwargs):
+        # tensor_name will give you the FQN, all other entries in sparse config is present in kwargs
+         weights = getattr(module, tensor_name)
+         mask = getattr(module.parametrizations, tensor_name)[0].mask
+
+         # use negative weights so we can use topk (we prune out the smallest)
+         saliency = -weights.norm(dim=tuple(range(1, weights.dim())), p=1)
+         num_to_pick = int(len(mask) * kwargs["sparsity_level"])
+         prune = saliency.topk(num_to_pick).indices
+
+         # Set the mask to be false for the rows we want to prune
+         mask.data[prune] = False

--- a/torch/ao/pruning/_experimental/pruner/saliency_pruner.py
+++ b/torch/ao/pruning/_experimental/pruner/saliency_pruner.py
@@ -1,20 +1,27 @@
 from .base_structured_sparsifier import BaseStructuredSparsifier
 
+
 class SaliencyPruner(BaseStructuredSparsifier):
-     """
-     Prune filters based on the saliency
-     The saliency for a filter is given by the sum of the L1 norms of all of its weights
-     """
+    """
+    Prune rows based on the saliency (L1 norm) of each row.
 
-     def update_mask(self, module, tensor_name, **kwargs):
+    This pruner works on N-Dimensional weight tensors.
+    For each row, we will calculate the saliency, whic is the sum the L1 norm of all weights in that row.
+    We expect that the resulting saliency vector has the same shape as our mask.
+    We then pick elements to remove until we reach the target sparsity_level.
+    """
+
+    def update_mask(self, module, tensor_name, **kwargs):
         # tensor_name will give you the FQN, all other entries in sparse config is present in kwargs
-         weights = getattr(module, tensor_name)
-         mask = getattr(module.parametrizations, tensor_name)[0].mask
+        weights = getattr(module, tensor_name)
+        mask = getattr(module.parametrizations, tensor_name)[0].mask
 
-         # use negative weights so we can use topk (we prune out the smallest)
-         saliency = -weights.norm(dim=tuple(range(1, weights.dim())), p=1)
-         num_to_pick = int(len(mask) * kwargs["sparsity_level"])
-         prune = saliency.topk(num_to_pick).indices
+        # use negative weights so we can use topk (we prune out the smallest)
+        saliency = -weights.norm(dim=tuple(range(1, weights.dim())), p=1)
+        assert saliency.shape == mask.shape
 
-         # Set the mask to be false for the rows we want to prune
-         mask.data[prune] = False
+        num_to_pick = int(len(mask) * kwargs["sparsity_level"])
+        prune = saliency.topk(num_to_pick).indices
+
+        # Set the mask to be false for the rows we want to prune
+        mask.data[prune] = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91814

Summary:

This PR adds in SaliencyPruner, an implementation of L1 norm pruning for structured pruning, as well as additional tests for the SaliencyPruner
The README.md references this file but I forgot to add it in earlier when writing the tutorial.

Test Plan:
```
python test/test_ao_sparsity.py -- TestSaliencyPruner
```

Reviewers:

Subscribers:

Tasks:

Tags: