### PR TITLE
[CI][ROCm] prune all stopped containers

### DIFF
--- a/.github/actions/setup-rocm/action.yml
+++ b/.github/actions/setup-rocm/action.yml
@@ -16,6 +16,8 @@ runs:
         # ignore expansion of "docker ps -q" since it could be empty
         # shellcheck disable=SC2046
         docker stop $(docker ps -q) || true
+        # Prune all stopped containers.
+        docker container prune -f
 
     - name: Runner health check system info
       if: always()

--- a/.github/actions/teardown-rocm/action.yml
+++ b/.github/actions/teardown-rocm/action.yml
@@ -12,6 +12,8 @@ runs:
         # ignore expansion of "docker ps -q" since it could be empty
         # shellcheck disable=SC2046
         docker stop $(docker ps -q) || true
+        # Prune all stopped containers.
+        docker container prune -f
         # Prune everything docker if there are more than 10 images (~200GB).
         # This is easier than using a time filter, e.g., "until=24h".
         # Might fail if a prune is already in progress by another runner.


### PR DESCRIPTION
After #91740, stopped containers remained and consumed disk space.  Avoid no space left on device errors by removing all stopped containers any time we stop them.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport