### PR TITLE
Change make_fx interface for allowing non-fake inputs

### DIFF
--- a/functorch/__init__.py
+++ b/functorch/__init__.py
@@ -17,7 +17,7 @@ from torch._functorch.vmap import vmap
 from torch._functorch.eager_transforms import (
     grad, grad_and_value, vjp, jacrev, jvp, jacfwd, hessian, functionalize
 )
-from torch._functorch.python_key import make_fx
+from torch._functorch.python_key import make_fx, make_fx_allow_non_fake_inputs
 
 # utilities. Maybe these should go in their own namespace in the future?
 from torch._functorch.make_functional import (

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 
 import torch
 import torch.utils._pytree as pytree
-from torch.fx.experimental.proxy_tensor import make_fx
+from torch.fx.experimental.proxy_tensor import make_fx, make_fx_allow_non_fake_inputs
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
 from torch.nn.parallel.distributed import DistributedDataParallel
 
@@ -670,12 +670,12 @@ def export(
             with torch.fx.traceback.override_stack_trace():
                 return torch.fx.Interpreter(graph).run(*args)
 
-        graph = make_fx(
-            graph_with_interpreter,
-            decomposition_table=decomposition_table,
-            tracing_mode=tracing_mode,
-            _allow_non_fake_inputs=True,
-        )(*graph_captured_input)
+        with make_fx_allow_non_fake_inputs():
+            graph = make_fx(
+                graph_with_interpreter,
+                decomposition_table=decomposition_table,
+                tracing_mode=tracing_mode,
+            )(*graph_captured_input)
 
     new_graph = ChangeInputOutputSignature(
         graph,

--- a/torch/_functorch/python_key.py
+++ b/torch/_functorch/python_key.py
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-__all__ = ["make_fx", "dispatch_trace", "PythonKeyTracer", "pythonkey_decompose"]
-from torch.fx.experimental.proxy_tensor import make_fx, dispatch_trace, PythonKeyTracer, decompose
+__all__ = ["make_fx", "make_fx_allow_non_fake_inputs", "dispatch_trace", "PythonKeyTracer", "pythonkey_decompose"]
+from torch.fx.experimental.proxy_tensor import make_fx, make_fx_allow_non_fake_inputs, dispatch_trace, PythonKeyTracer, decompose
 
 pythonkey_decompose = decompose


### PR DESCRIPTION
Summary:
We want to tweak the UI so that when we re-enter make_fx(), the
configuration of allowing non-fake tensor inputs is inherited from the toplevel
make_fx call.

Test Plan: CI

Differential Revision: D42378689



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire