### PR TITLE
Fix numel() result after resizing a sparse compressed tensor.

### DIFF
--- a/aten/src/ATen/SparseCsrTensorImpl.cpp
+++ b/aten/src/ATen/SparseCsrTensorImpl.cpp
@@ -99,6 +99,7 @@ void SparseCsrTensorImpl::resize_(int64_t nnz, IntArrayRef size) {
   col_indices_.resize_(col_indices_values_size);
   values_.resize_(col_indices_values_size);
   sizes_and_strides_.set_sizes(size);
+  refresh_numel();
 }
 
 void SparseCsrTensorImpl::resize_and_clear_(int64_t sparse_dim, IntArrayRef size) {


### PR DESCRIPTION
Fixes #91830 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91831



cc @alexsamardzic @nikitaved @cpuhrsch @amjames @bhosmer