### PR TITLE
Implement an empty_nested function 

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -263,24 +263,7 @@ int64_t NestedTensorImpl::numel_custom() const {
   if (nested_sizes_.dim() == 0) {
     return 0;
   }
-  constexpr auto numel_max = std::min(
-      static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
-      static_cast<uint64_t>(std::numeric_limits<size_t>::max()));
-
-  const auto nt_dim = nested_sizes_.size(1);
-  const int64_t* sizes_ptr = nested_sizes_.data_ptr<int64_t>();
-  uint64_t num_elements{0};
-
-  for (const auto i : c10::irange(nested_sizes_.size(0))) {
-    uint64_t n = 1;
-    const auto start{sizes_ptr + i * nt_dim};
-    const auto end{start + nt_dim};
-    bool overflows = c10::safe_multiplies_u64(start, end, &n);
-    num_elements += n;
-    overflows |= (num_elements > numel_max);
-    TORCH_CHECK(!overflows, "numel: integer multiplication overflow");
-  }
-  return static_cast<int64_t>(num_elements);
+  return get_numel_from_nested_size_tensor(nested_sizes_);
 }
 
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13527,6 +13527,12 @@
   python_module: nested
   variants: function
 
+- func: empty_nested(Tensor nested_tensor_size, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+  variants: function
+  python_module: nested
+  dispatch:
+    CPU: empty_nested
+
 ## Functions that are only for testing
 # It is undocumented and should not be used outside of tests.
 - func: _test_serialization_subcmul(Tensor self, Tensor other, Scalar alpha=1) -> Tensor


### PR DESCRIPTION
# Summary 
Creates an empty_nested function that allows users to construct a NestedTensor that is unfilled. 
I want this because I want to be able to write a triton implementation of contiguous and I want an empty_tensor that is constructed from another- empty_like will match the strides.

 I could have done clone of input for this use case. But what if I wanted to construct an NT that was a different shape than the original due to some reduction op.  

cc @cpuhrsch @jbschlosser @bhosmer @mikaylagawarecki