### PR TITLE
Point to README.md#from-source instead of duplicate instructions in CONTRIBUTING.md#developing-pytorc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,6 @@
 
 - [Contributing to PyTorch](#contributing-to-pytorch)
 - [Developing PyTorch](#developing-pytorch)
-  - [Prerequisites](#prerequisites)
-  - [Instructions](#instructions)
   - [Tips and Debugging](#tips-and-debugging)
 - [Nightly Checkout & Pull](#nightly-checkout--pull)
 - [Codebase structure](#codebase-structure)
@@ -79,20 +77,11 @@ to PyTorch.  For more non-technical guidance about how to contribute to
 PyTorch, see the [Contributing Guide](docs/source/community/contribution_guide.rst).
 
 ## Developing PyTorch
+Follow the instructions for [installing PyTorch from source](https://github.com/pytorch/pytorch#from-source). If you get stuck when developing PyTorch on your machine, check out the [tips and debugging](#tips-and-debugging) section below for common solutions.
 
-A full set of instructions on installing PyTorch from source is here:
-https://github.com/pytorch/pytorch#from-source
+### Tips and Debugging
 
-To develop PyTorch on your machine, here are some tips:
-
-### Prerequisites
-* CMake. You can install it via `pip install cmake`
-* Python >= 3.7 (3.7.6+ recommended)
-
-### Instructions
-_**Note**: If you get stuck at any step, check out the [tips and debugging](#tips-and-debugging) section below for common solutions_
-
-1. Uninstall all existing PyTorch installs. You may need to run `pip
+* Uninstall all existing PyTorch installs. You may need to run `pip
 uninstall torch` multiple times. You'll know `torch` is fully
 uninstalled when you see `WARNING: Skipping torch as it is not
 installed`. (You should only have to `pip uninstall` a few times, but
@@ -104,48 +93,34 @@ conda uninstall pytorch -y
 yes | pip uninstall torch
 ```
 
-2. Clone a copy of PyTorch from source:
+* If you want to have no-op incremental rebuilds (which are fast), see [Make no-op build fast](#make-no-op-build-fast) below.
 
-```bash
-git clone https://github.com/pytorch/pytorch
-cd pytorch
-```
+* Instead of installing PyTorch via `python setup.py install`, use `python setup.py develop`.
 
-If you already have PyTorch from source, update it:
+  This mode will symlink the Python files from the current local source
+  tree into the Python install.  This way when you modify a Python file, you
+  won't need to reinstall PyTorch again and again.  This is especially
+  useful if you are only changing Python files.
 
-```bash
-git pull --rebase
-git submodule sync --recursive
-git submodule update --init --recursive
-```
+  For example:
+  - Install local PyTorch in `develop` mode
+  - modify your Python file `torch/__init__.py` (for example)
+  - test functionality
 
-If you want to have no-op incremental rebuilds (which are fast), see [Make no-op build fast](#make-no-op-build-fast) below.
+  You do not need to repeatedly install after modifying Python files (`.py`). However, you would need to reinstall
+  if you modify Python interface (`.pyi`, `.pyi.in`) or non-Python files (`.cpp`, `.cc`, `.cu`, `.h`, ...).
 
-3. Follow the instructions for [installing PyTorch from source](https://github.com/pytorch/pytorch#from-source), but instead of installing PyTorch via `python setup.py install`, use `python setup.py develop`.
+  In case you want to reinstall, make sure that you uninstall PyTorch
+  first by running `pip uninstall torch` until you see `WARNING: Skipping
+  torch as it is not installed`; next run `python setup.py clean`. After
+  that, you can install in `develop` mode again.
 
-This mode will symlink the Python files from the current local source
-tree into the Python install.  This way when you modify a Python file, you
-won't need to reinstall PyTorch again and again.  This is especially
-useful if you are only changing Python files.
 
-For example:
-- Install local PyTorch in `develop` mode
-- modify your Python file `torch/__init__.py` (for example)
-- test functionality
-
-You do not need to repeatedly install after modifying Python files (`.py`). However, you would need to reinstall
-if you modify Python interface (`.pyi`, `.pyi.in`) or non-Python files (`.cpp`, `.cc`, `.cu`, `.h`, ...).
-
-In case you want to reinstall, make sure that you uninstall PyTorch
-first by running `pip uninstall torch` until you see `WARNING: Skipping
-torch as it is not installed`; next run `python setup.py clean`. After
-that, you can install in `develop` mode again.
-
-### Tips and Debugging
 * If a commit is simple and doesn't affect any code (keep in mind that some docstrings contain code
   that is used in tests), you can add `[skip ci]` (case sensitive) somewhere in your commit message to
   [skip all build / test steps](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/).
   Note that changing the pull request body or title on GitHub itself has no effect.
+
 * If you run into errors when running `python setup.py develop`, here are some debugging steps:
   1. Run `printf '#include <stdio.h>\nint main() { printf("Hello World");}'|clang -x c -; ./a.out` to make sure
   your CMake works and can compile this simple Hello World program without errors.
@@ -154,18 +129,19 @@ that, you can install in `develop` mode again.
   `rm -rf build` from the toplevel `pytorch` directory and start over.
   3. If you have made edits to the PyTorch repo, commit any change you'd like to keep and clean the repo with the
   following commands (note that clean _really_ removes all untracked files and changes.):
-  ```bash
-  git submodule deinit -f .
-  git clean -xdf
-  python setup.py clean
-  git submodule update --init --recursive # very important to sync the submodules
-  python setup.py develop                 # then try running the command again
-  ```
+      ```bash
+      git submodule deinit -f .
+      git clean -xdf
+      python setup.py clean
+      git submodule update --init --recursive # very important to sync the submodules
+      python setup.py develop                 # then try running the command again
+      ```
   4. The main step within `python setup.py develop` is running `make` from the `build` directory. If you want to
-  experiment with some environment variables, you can pass them into the command:
-  ```bash
-  ENV_KEY1=ENV_VAL1[, ENV_KEY2=ENV_VAL2]* python setup.py develop
-  ```
+    experiment with some environment variables, you can pass them into the command:
+      ```bash
+      ENV_KEY1=ENV_VAL1[, ENV_KEY2=ENV_VAL2]* python setup.py develop
+      ```
+
 * If you run into issue running `git submodule update --init --recursive`. Please try the following:
   - If you encounter an error such as
     ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,40 +81,27 @@ Follow the instructions for [installing PyTorch from source](https://github.com/
 
 ### Tips and Debugging
 
-* Uninstall all existing PyTorch installs. You may need to run `pip
-uninstall torch` multiple times. You'll know `torch` is fully
-uninstalled when you see `WARNING: Skipping torch as it is not
-installed`. (You should only have to `pip uninstall` a few times, but
-you can always `uninstall` with `timeout` or in a loop if you're feeling
-lazy.)
-
-```bash
-conda uninstall pytorch -y
-yes | pip uninstall torch
-```
-
 * If you want to have no-op incremental rebuilds (which are fast), see [Make no-op build fast](#make-no-op-build-fast) below.
 
-* Instead of installing PyTorch via `python setup.py install`, use `python setup.py develop`.
+* When installing with `python setup.py develop` (in contrast to `python setup.py install`) you will symlink
+   the Python files from the current local source-tree into the Python install.
+  This way you do not need to repeatedly install after modifying Python files (`.py`).
+  However, you would need to reinstall if you modify Python interface (`.pyi`, `.pyi.in`) or
+   non-Python files (`.cpp`, `.cc`, `.cu`, `.h`, ...).
 
-  This mode will symlink the Python files from the current local source
-  tree into the Python install.  This way when you modify a Python file, you
-  won't need to reinstall PyTorch again and again.  This is especially
-  useful if you are only changing Python files.
+  To reinstall, first uninstall all existing PyTorch installs. You may need to run `pip
+  uninstall torch` multiple times. You'll know `torch` is fully
+  uninstalled when you see `WARNING: Skipping torch as it is not
+  installed`. (You should only have to `pip uninstall` a few times, but
+  you can always `uninstall` with `timeout` or in a loop if you're feeling
+  lazy.)
 
-  For example:
-  - Install local PyTorch in `develop` mode
-  - modify your Python file `torch/__init__.py` (for example)
-  - test functionality
+  ```bash
+  conda uninstall pytorch -y
+  yes | pip uninstall torch
+  ```
 
-  You do not need to repeatedly install after modifying Python files (`.py`). However, you would need to reinstall
-  if you modify Python interface (`.pyi`, `.pyi.in`) or non-Python files (`.cpp`, `.cc`, `.cu`, `.h`, ...).
-
-  In case you want to reinstall, make sure that you uninstall PyTorch
-  first by running `pip uninstall torch` until you see `WARNING: Skipping
-  torch as it is not installed`; next run `python setup.py clean`. After
-  that, you can install in `develop` mode again.
-
+  Next run `python setup.py clean`. After that, you can install in `develop` mode again.
 
 * If a commit is simple and doesn't affect any code (keep in mind that some docstrings contain code
   that is used in tests), you can add `[skip ci]` (case sensitive) somewhere in your commit message to


### PR DESCRIPTION
**Idea:** [README.md#from-source](https://github.com/pytorch/pytorch/blob/master/README.md#from-source) should be the place that describes how I as a developer builds from source. 

Currently, `CONTRIBUTING.md` suggests an incomplete set of install instructions that predates those in `README.md`. 

This PR tries to simplify and remove a dead end from the developer onboarding funnel by pointing to [README.md#from-source](https://github.com/pytorch/pytorch/blob/master/README.md#from-source).

### Details
Without touching this codebase for years I tried to build repo for local development and run unit tests. I tried to capitalise on the confusion by documenting it:
1. I go to [README.md#from-source](https://github.com/pytorch/pytorch/blob/master/README.md#from-source) 
2. Since it doesn't suggest how I run unit test I follow [README.md#releases-and-contributing to ](https://github.com/pytorch/pytorch/blob/master/README.md#releases-and-contributing) to [CONTRIBUTING.md#developing-pytorch](https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md#developing-pytorch) which is written as if it's _the_ set up dev env instruction:
https://github.com/pytorch/pytorch/blob/73e5379fab05c40ff6f42500309cdc17ee57548c/CONTRIBUTING.md?plain=1#L88-L90
   But this section gives competing and incomplete install instructions that does not work for me. Ex, it doesn't mention `ninja` or `pyaml` required for `python setup.py develop`. 
5. Going back to the original [README.md#from-source](https://github.com/pytorch/pytorch/blob/master/README.md#from-source) setup instructions that (mostly) worked.
https://github.com/pytorch/pytorch/blob/73e5379fab05c40ff6f42500309cdc17ee57548c/README.md?plain=1#L187

#### TODO

- [x] verify that it does not break any link to other documentation
[skip ci]