### PR TITLE
Clean up setup-python in setup-win

### DIFF
--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -36,14 +36,3 @@ runs:
       shell: powershell
       run: |
         Add-MpPreference -ExclusionPath $(Get-Location).tostring() -ErrorAction Ignore
-
-    - name: Setup Python3
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-        check-latest: false
-        cache: pip
-        cache-dependency-path: |
-          **/requirements.txt
-          **/.circleci/docker/requirements-ci.txt
-          **/.github/requirements-gha-cache.txt


### PR DESCRIPTION
All dependencies have been added as part of the Windows AMI. This step is redundant and requires network access.

### Testing
All Windows build and tests pass
