### PR TITLE
[PoC][FSDP] Async reduce-scatter

### DIFF
--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -342,6 +342,7 @@ def _init_runtime_state(
     # Used to prevent running the pre-backward hook multiple times
     _ran_pre_backward_hook: Dict[_HandlesKey, bool] = {}
     state._ran_pre_backward_hook = _ran_pre_backward_hook
+    state._reduce_scatter_handles = []
     return state
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#91865 [PoC][FSDP] Async reduce-scatter**
* #91767 [FSDP] Do not clean FQNs even for `use_orig_params=True`
* #91193 [FSDP] Test `use_orig_params=True`, `no_sync()`, mixed precision
* #91192 [FSDP] Re-support model dtype change after FSDP init
* #91044 [FSDP][7/N] Support `replicate` in `fully_shard`
* #90959 [FSDP][6/N] Add note explaining idioms for `_FSDPState` traversal
* #90874 [FSDP][5/N] Add manual "wrapping" support for `fully_shard`
* #90871 [FSDP][4/N] Refactor func to share state/init handle attrs
* #90945 fully_shard load state_dict

The post-backward logic probably needs to be refactored...