### PR TITLE
Fix typo under docs directory 

### DIFF
--- a/docs/source/dynamo/faq.rst
+++ b/docs/source/dynamo/faq.rst
@@ -67,7 +67,7 @@ inference.
 
 Future work will include tracing communication operations into graphs,
 coordinating these operations with compute optimizations, and optimizing
-the communciation operations.
+the communication operations.
 
 Why is my code crashing?
 ------------------------

--- a/docs/source/dynamo/guards-overview.rst
+++ b/docs/source/dynamo/guards-overview.rst
@@ -193,7 +193,7 @@ instruction and doing *something* with it.
 .. note:: These are real instructions processed by TorchDynamo’s
    ``transform_code_object``, and it is pretty cool.
 
-.. note:: This section purposly skips the details of
+.. note:: This section purposely skips the details of
    `dis.get_instructions <https://docs.python.org/3/library/dis.html>`__.
 
 For the example above, here is a snippet of a what a few
@@ -317,7 +317,7 @@ Here is what this code does:
    the only thing pushed onto and popped from our stack are
    ``VariableTracker``\ s.
 
-3) The function calls ``VariableTracker.propogate``. This
+3) The function calls ``VariableTracker.propagate``. This
    takes the guards from every single item popped off the stack in 2,
    and recursively traverses it and combines all the guards into
    ``options``: ``py  return {      "guards": guards,  }``

--- a/docs/source/dynamo/troubleshooting.rst
+++ b/docs/source/dynamo/troubleshooting.rst
@@ -217,7 +217,7 @@ torchdynamo. It is important to note that errors can occur during this
 tracing and also while TorchInductor lowers the forward and backward
 graphs to GPU code or C++. A model can often consist of hundreds or
 thousands of FX nodes, so narrowing the exact nodes where this problem
-occurred can be very difficult. Fortunately, there are tools availabe to
+occurred can be very difficult. Fortunately, there are tools available to
 automatically minify these input graphs to the nodes which are causing
 the issue. The first step is to determine whether the error occurs
 during tracing of the backward graph with AOTAutograd or during

--- a/docs/source/mobile_optimizer.rst
+++ b/docs/source/mobile_optimizer.rst
@@ -14,7 +14,7 @@ For CPU Backend, by default, if optimization blocklist is None or empty, ``optim
     - **Dropout removal** (blocklisting option `MobileOptimizerType::REMOVE_DROPOUT`): This optimization pass removes ``dropout`` and ``dropout_`` nodes from this module when training is false.
     - **Conv packed params hoisting** (blocklisting option `MobileOptimizerType::HOIST_CONV_PACKED_PARAMS`): This optimization pass moves convolution packed params to the root module, so that the convolution structs can be deleted. This decreases model size without impacting numerics.
 
-for Vulkan Backend, by default, if optimization blocklist is None or empty, ``optimize_for_mobile`` will run the folllwing optimization:
+for Vulkan Backend, by default, if optimization blocklist is None or empty, ``optimize_for_mobile`` will run the following optimization:
     - **Automatic GPU Transfer** (blocklisting option `MobileOptimizerType::VULKAN_AUTOMATIC_GPU_TRANSFER`): This optimization pass rewrites the graph such that inputs are transferred to Vulkan backend, and outputs are transferred to CPU backend
 
 ``optimize_for_mobile`` will also invoke freeze_module pass which only preserves ``forward`` method. If you have other method to that needed to be preserved,  add them into the preserved method list and pass into the method.

--- a/docs/source/notes/autograd.rst
+++ b/docs/source/notes/autograd.rst
@@ -339,7 +339,7 @@ Non-determinism
 ^^^^^^^^^^^^^^^
 
 If you are calling ``backward()`` from multiple threads concurrently and have
-shared inputs (i.e. Hogwild CPU training), then non-determinsim should be expected.
+shared inputs (i.e. Hogwild CPU training), then non-determinism should be expected.
 This can occur because parameters are automatically shared across threads,
 as such, multiple threads may access and try to accumulate the same ``.grad``
 attribute during gradient accumulation. This is technically not safe, and

--- a/docs/source/notes/ddp.rst
+++ b/docs/source/notes/ddp.rst
@@ -211,7 +211,7 @@ TorchDynamo DDPOptimizer
 
 DDP's performance advantage comes from overlapping allreduce collectives with computations during backwards.
 AotAutograd prevents this overlap when used with TorchDynamo for compiling a whole forward and whole backward graph,
-becuase allreduce ops are launched by autograd hooks _after_ the whole optimized backwards computation finishes.
+because allreduce ops are launched by autograd hooks _after_ the whole optimized backwards computation finishes.
 
 TorchDynamo's DDPOptimizer helps by breaking the forward graph at the logical boundaries of DDP's allreduce buckets
 during backwards.  Note: the goal is to break the graph during backwards, and the simplest implementation is to


### PR DESCRIPTION
This PR fixes typo in '.rst' files under 'docs' directory
