### PR TITLE
[functorch] Fix proxy unwrapping for cond().

### DIFF
--- a/functorch/experimental/_cond.py
+++ b/functorch/experimental/_cond.py
@@ -37,9 +37,12 @@ cond = PyOperator("cond")
 
 def trace_cond(proxy_mode, func_overload, pred, true_fn, false_fn, operands):
     def _unwrap_proxy(e):
-        if not isinstance(e, (torch.Tensor, torch.SymInt, torch.SymFloat)):
+        if isinstance(e, torch.Tensor):
+            return get_proxy_slot(e, proxy_mode.tracer, e, lambda e: e.proxy)
+        elif isinstance(e, (torch.SymInt, torch.SymFloat)):
+            return get_proxy_slot(e.node, proxy_mode.tracer, e, lambda e: e())
+        else:
             return e
-        return get_proxy_slot(e, proxy_mode.tracer, e, lambda e: e.proxy)
 
     assert isinstance(operands, list), "Cond operands must be a list of tensors"
     assert all(isinstance(o, torch.Tensor) for o in operands), "Cond operands must be a list of tensors"

--- a/functorch/experimental/_cond.py
+++ b/functorch/experimental/_cond.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from functools import partial
 import torch
 from torch.multiprocessing.reductions import StorageWeakRef
 
@@ -10,10 +11,10 @@ from torch._ops import PyOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     get_isolated_graphmodule,
-    get_proxy_slot,
     ProxyTorchDispatchMode,
     make_fx,
     track_tensor_tree,
+    unwrap_proxy,
 )
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
 from torch.utils._python_dispatch import (
@@ -36,14 +37,6 @@ cond = PyOperator("cond")
 
 
 def trace_cond(proxy_mode, func_overload, pred, true_fn, false_fn, operands):
-    def _unwrap_proxy(e):
-        if isinstance(e, torch.Tensor):
-            return get_proxy_slot(e, proxy_mode.tracer, e, lambda e: e.proxy)
-        elif isinstance(e, (torch.SymInt, torch.SymFloat)):
-            return get_proxy_slot(e.node, proxy_mode.tracer, e, lambda e: e())
-        else:
-            return e
-
     assert isinstance(operands, list), "Cond operands must be a list of tensors"
     assert all(isinstance(o, torch.Tensor) for o in operands), "Cond operands must be a list of tensors"
 
@@ -90,7 +83,7 @@ def trace_cond(proxy_mode, func_overload, pred, true_fn, false_fn, operands):
 
     args = (pred, true_graph, false_graph, [operands])
 
-    proxy_args = pytree.tree_map(_unwrap_proxy, args)
+    proxy_args = pytree.tree_map(partial(unwrap_proxy, proxy_mode), args)
 
     out_proxy = proxy_mode.tracer.create_proxy('call_function', func_overload, proxy_args, {},
                                                name="conditional")

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -636,5 +636,19 @@ class TestControlFlowTraced(TestCase):
         res = gm(p, pred, xs, y)
         self.assertEqual(res, main(p, pred, xs, y))
 
+    def test_cond_with_sym_pred(self):
+        def true_fn(x):
+            return x + x
+
+        def false_fn(x):
+            return x * x
+
+        def foo(x):
+            return cond(x.shape[0] == 4, true_fn, false_fn, [x])
+
+        gm = make_fx(foo, tracing_mode="symbolic")(torch.ones(3, 2, 1))
+        x = torch.ones(4, 3, 2)
+        self.assertEqual(foo(x), gm(x))
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -101,6 +101,14 @@ def get_proxy_slot(obj, tracer, default=no_default, transform=lambda x: x):
 def snapshot_fake(val):
     return val.detach()
 
+def unwrap_proxy(proxy_mode, e):
+    if isinstance(e, torch.Tensor):
+        return get_proxy_slot(e, proxy_mode.tracer, e, lambda e: e.proxy)
+    elif isinstance(e, (torch.SymInt, torch.SymFloat)):
+        return get_proxy_slot(e.node, proxy_mode.tracer, e, lambda e: e())
+    else:
+        return e
+
 # What invariants do we have for the 'val' set on the FX node?  It has accurate
 # metadata... but only for metadata that exists "below" all other subsystems
 # (most notably autograd, but also vmap, functorch transforms, etc).  This means


### PR DESCRIPTION
In control_flow.cond(), we unwrap arguments' proxy by using
get_proxy_slot() call which call a lambda in the end to get the stored
proxy. For SymInt and SymFloat we hide the proxy under a thunk instead
of storing proxy on .proxy attribute diretly, therefore we need to
special case SymInt for unwrapping here.

Fixes #ISSUE_NUMBER
