### PR TITLE
[Vulkan] Merge ShaderSource into ShaderInfo

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -40,7 +40,7 @@ Context::~Context() {
 
 DescriptorSet Context::submit_compute_prologue(
     CommandBuffer& command_buffer,
-    const ShaderSource& shader_descriptor,
+    const ShaderInfo& shader_descriptor,
     const utils::uvec3& local_workgroup_size) {
   const VkDescriptorSetLayout shader_layout =
       shader_layout_cache().retrieve(shader_descriptor.kernel_layout);

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -167,7 +167,7 @@ class Context final {
 
   DescriptorSet submit_compute_prologue(
       CommandBuffer&,
-      const ShaderSource&,
+      const ShaderInfo&,
       const utils::uvec3&);
 
   void submit_compute_epilogue(
@@ -189,7 +189,7 @@ class Context final {
 
   template <typename... Arguments>
   void submit_compute_job(
-      const ShaderSource&,
+      const ShaderInfo&,
       const PipelineBarrier&,
       const utils::uvec3&,
       const utils::uvec3&,
@@ -394,7 +394,7 @@ inline void Context::submit_copy(
 
 template <typename... Arguments>
 inline void Context::submit_compute_job(
-    const ShaderSource& shader,
+    const ShaderInfo& shader,
     const PipelineBarrier& pipeline_barrier,
     const utils::uvec3& global_work_group,
     const utils::uvec3& local_work_group_size,

--- a/aten/src/ATen/native/vulkan/api/Shader.h
+++ b/aten/src/ATen/native/vulkan/api/Shader.h
@@ -44,7 +44,7 @@ class ShaderLayout final {
   friend void swap(ShaderLayout& lhs, ShaderLayout& rhs) noexcept;
 };
 
-struct ShaderSource final {
+struct ShaderInfo final {
   enum class Type { GLSL, SPIRV } type;
 
   union {
@@ -64,25 +64,17 @@ struct ShaderSource final {
   // Shader Metadata
   utils::uvec3 out_tile_size{1u, 1u, 1u};
 
-  explicit ShaderSource();
-  explicit ShaderSource(std::string, const char*);
-  explicit ShaderSource(
-      std::string,
-      const uint32_t*,
-      const uint32_t,
-      const std::vector<VkDescriptorType>&);
-};
-
-bool operator==(const ShaderSource& _1, const ShaderSource& _2);
-
-struct ShaderInfo final {
-  ShaderSource shader_src;
   c10::SmallVector<uint32_t, 4> tile_size;
   StorageType bias_storage_type{StorageType::UNKNOWN};
   StorageType weight_storage_type{StorageType::UNKNOWN};
 
-  explicit ShaderInfo() = default;
+  explicit ShaderInfo();
   explicit ShaderInfo(std::string, const char*);
+  explicit ShaderInfo(
+      std::string,
+      const uint32_t*,
+      const uint32_t,
+      const std::vector<VkDescriptorType>&);
   explicit ShaderInfo(
       std::string,
       const uint32_t*,
@@ -93,9 +85,11 @@ struct ShaderInfo final {
       const StorageType weight_storage_type);
 };
 
+bool operator==(const ShaderInfo& _1, const ShaderInfo& _2);
+
 class ShaderModule final {
  public:
-  explicit ShaderModule(const VkDevice device, const ShaderSource& source);
+  explicit ShaderModule(const VkDevice device, const ShaderInfo& source);
 
   ShaderModule(const ShaderModule&) = delete;
   ShaderModule& operator=(const ShaderModule&) = delete;
@@ -172,11 +166,11 @@ class ShaderCache final {
 
   ~ShaderCache();
 
-  using Key = ShaderSource;
+  using Key = ShaderInfo;
   using Value = ShaderModule;
 
   struct Hasher {
-    inline size_t operator()(const ShaderSource& source) const {
+    inline size_t operator()(const ShaderInfo& source) const {
       return c10::get_hash(
           source.type, source.src_code.spirv.bin, source.src_code.spirv.size);
     }

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -95,7 +95,7 @@ Tensor arithmetic_scalar(
     const Tensor& self_arg,
     const Scalar& other,
     const c10::optional<Scalar>& alpha_arg,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   api::Context* const context = api::context();
 
   const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
@@ -147,7 +147,7 @@ Tensor& arithmetic_scalar_(
     Tensor& self_arg,
     const Scalar& other,
     const c10::optional<Scalar>& alpha_arg,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   TORCH_CHECK(
       self_arg.is_vulkan(),
       "Vulkan: In-place operator is only supported on Vulkan tensors.");
@@ -195,7 +195,7 @@ Tensor arithmetic_tensor(
     const Tensor& self_arg,
     const Tensor& other_arg,
     const c10::optional<Scalar>& alpha_arg,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   check_inputs(self_arg, other_arg);
   api::Context* const context = api::context();
 
@@ -262,7 +262,7 @@ Tensor quantized_arithmetic_tensor(
     const Tensor& other_arg,
     const double scale,
     const int64_t zero_point,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   check_inputs(self_arg, other_arg);
   api::Context* const context = api::context();
 
@@ -349,7 +349,7 @@ Tensor& arithmetic_tensor_(
     Tensor& self_arg,
     const Tensor& other_arg,
     const c10::optional<Scalar>& alpha_arg,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   TORCH_CHECK(
       get_dim<Dim4D::Batch>(self_arg) >= get_dim<Dim4D::Batch>(other_arg) &&
           get_dim<Dim4D::Channel>(self_arg) >=

--- a/aten/src/ATen/native/vulkan/ops/Clamp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clamp.cpp
@@ -13,7 +13,7 @@ Tensor _clamp(
     const Tensor& self_arg,
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   TORCH_CHECK(min || max, "At least one of 'min' or 'max' must not be None");
 
   api::Context* const context = api::context();
@@ -77,7 +77,7 @@ Tensor& _clamp_(
     Tensor& self_arg,
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   TORCH_CHECK(min || max, "At least one of 'min' or 'max' must not be None");
 
   TORCH_CHECK(
@@ -143,7 +143,7 @@ Tensor& clamp_(
 
 Tensor activation(
     const Tensor& self_arg,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   api::Context* const context = api::context();
 
   const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
@@ -191,7 +191,7 @@ Tensor activation(
 
 Tensor& activation_(
     Tensor& self_arg,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   TORCH_CHECK(
       self_arg.is_vulkan(),
       "Vulkan: In-place operator is only supported on Vulkan tensors.");
@@ -268,7 +268,7 @@ Tensor& hardsigmoid_(Tensor& self) {
 Tensor activation_scalar(
     const Tensor& self_arg,
     const Scalar& scalar_arg,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   api::Context* const context = api::context();
 
   const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
@@ -319,7 +319,7 @@ Tensor activation_scalar(
 Tensor& activation_scalar_(
     Tensor& self_arg,
     const Scalar& scalar_arg,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   TORCH_CHECK(
       self_arg.is_vulkan(),
       "Vulkan: In-place operator is only supported on Vulkan tensors.");

--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -11,13 +11,13 @@
 #ifdef USE_VULKAN_SHADERC_RUNTIME
 #include <ATen/native/vulkan/glsl.h>
 #define VK_KERNEL(name)                          \
-  ::at::native::vulkan::api::ShaderSource {      \
+  ::at::native::vulkan::api::ShaderInfo {        \
     CONCAT_LITERALS(vulkan., name), name##_glsl, \
   }
 #else
 #include <ATen/native/vulkan/spv.h>
 #define VK_KERNEL(name)                                         \
-  ::at::native::vulkan::api::ShaderSource {                     \
+  ::at::native::vulkan::api::ShaderInfo {                       \
     CONCAT_LITERALS(vulkan., name), name##_spv, name##_spv_len, \
         name##_spv_layout                                       \
   }

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -279,7 +279,7 @@ at::Tensor rearrange_bias(
 // Shader and Workgroup size determination
 //
 
-static api::ShaderSource get_shader(
+static api::ShaderInfo get_shader(
     const IntArrayRef kernel_size,
     const IntArrayRef stride,
     const IntArrayRef padding,
@@ -306,12 +306,12 @@ static api::ShaderSource get_shader(
         break;
         // todo fail for quantized transposed conv
     }
-    return shader.shader_src;
+    return shader;
   }
 
   if (transposed) {
     shader = VK_SHADER(conv_transpose2d);
-    return shader.shader_src;
+    return shader;
   }
 
   switch (method) {
@@ -335,7 +335,7 @@ static api::ShaderSource get_shader(
       shader = VK_SHADER(conv2d_pw_2x2);
       break;
   }
-  return shader.shader_src;
+  return shader;
 }
 
 //
@@ -357,7 +357,7 @@ struct Params final {
 
 void record_op(
     api::Context* const context,
-    api::ShaderSource& compute_shader,
+    api::ShaderInfo& compute_shader,
     vTensor& v_output,
     const vTensor& v_input,
     const vTensor& v_weight,
@@ -430,7 +430,7 @@ struct QParams final {
 
 void record_quantized_op(
     api::Context* const context,
-    api::ShaderSource& compute_shader,
+    api::ShaderInfo& compute_shader,
     vTensor& v_output,
     const vTensor& v_input,
     const vTensor& v_weight,

--- a/aten/src/ATen/native/vulkan/ops/Convolution.h
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.h
@@ -55,7 +55,7 @@ class Conv2dPackedContext final : virtual public VulkanPackedContext,
                                   public torch::jit::CustomClassHolder {
  private:
   c10::impl::GenericList unpacked_;
-  api::ShaderSource compute_shader_{};
+  api::ShaderInfo compute_shader_{};
 
  public:
   Conv2dPackedContext(
@@ -120,7 +120,7 @@ class Conv2dPackedContext final : virtual public VulkanPackedContext,
     return unpacked_;
   }
 
-  inline api::ShaderSource& compute_shader() {
+  inline api::ShaderInfo& compute_shader() {
     return compute_shader_;
   }
 };

--- a/aten/src/ATen/native/vulkan/ops/Padding.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Padding.cpp
@@ -13,7 +13,7 @@ using namespace api::utils;
 Tensor pad2d(
     const Tensor& self_arg,
     IntArrayRef padding,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   const int pad_dim = padding.size();
   const IntArrayRef input_size = self_arg.sizes();
   const int input_dim = input_size.size();

--- a/aten/src/ATen/native/vulkan/ops/Pool.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Pool.cpp
@@ -91,7 +91,7 @@ Tensor pool2d(
     const IntArrayRef padding_arg,
     const IntArrayRef dilation_arg,
     const bool ceil_mode,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   if (stride_arg.empty()) {
     stride_arg = kernel_arg;
   }

--- a/aten/src/ATen/native/vulkan/ops/QuantizedTensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/QuantizedTensor.cpp
@@ -10,7 +10,7 @@ namespace ops {
 
 using namespace api::utils;
 
-static api::ShaderSource get_quantize_per_tensor_shader(
+static api::ShaderInfo get_quantize_per_tensor_shader(
     const c10::ScalarType dtype) {
   switch (dtype) {
     case c10::ScalarType::QUInt8:
@@ -32,7 +32,7 @@ Tensor quantize_per_tensor(
     const double scale,
     const int64_t zero_point,
     const c10::ScalarType dtype) {
-  api::ShaderSource compute_shader = get_quantize_per_tensor_shader(dtype);
+  api::ShaderInfo compute_shader = get_quantize_per_tensor_shader(dtype);
 
   api::Context* const context = api::context();
 

--- a/aten/src/ATen/native/vulkan/ops/Softmax.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Softmax.cpp
@@ -14,7 +14,7 @@ Tensor softmax_internal(
     const at::Tensor& input_arg,
     const int64_t dim,
     const bool half_to_float,
-    const api::ShaderSource& shader_descriptor) {
+    const api::ShaderInfo& shader_descriptor) {
   TORCH_CHECK(
       input_arg.dim() == 4, "Vulkan softmax expects 4-dimensional input!");
 

--- a/aten/src/ATen/native/vulkan/ops/Utils.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Utils.cpp
@@ -16,7 +16,7 @@ namespace ops {
 
 namespace packing {
 
-static api::ShaderSource get_nchw_to_image_shader(const vTensor& v_dst) {
+static api::ShaderInfo get_nchw_to_image_shader(const vTensor& v_dst) {
   if (v_dst.is_quantized()) {
     switch (v_dst.storage_type()) {
       case api::StorageType::TEXTURE_3D:
@@ -51,7 +51,7 @@ static api::ShaderSource get_nchw_to_image_shader(const vTensor& v_dst) {
   }
 }
 
-static api::ShaderSource get_image_to_nchw_shader(const vTensor& v_src) {
+static api::ShaderInfo get_image_to_nchw_shader(const vTensor& v_src) {
   if (v_src.is_quantized()) {
     auto plane_size =
         get_dim<Dim4D::Height>(v_src) * get_dim<Dim4D::Width>(v_src);
@@ -97,7 +97,7 @@ struct ToFromTextureParams final {
 
 void record_nchw_to_image_op(
     api::Context* const context,
-    api::ShaderSource& compute_shader,
+    api::ShaderInfo& compute_shader,
     api::VulkanBuffer& src_buffer,
     vTensor& v_dst,
     api::PipelineBarrier pipeline_barrier,
@@ -140,7 +140,7 @@ void record_nchw_to_image_op(
 
 void record_image_to_nchw_op(
     api::Context* const context,
-    api::ShaderSource& compute_shader,
+    api::ShaderInfo& compute_shader,
     vTensor& v_src,
     api::VulkanBuffer& dst_buffer,
     api::PipelineBarrier pipeline_barrier,
@@ -450,8 +450,7 @@ void pack_buffer_to_vtensor(
     packing::record_nchw_to_buffer_op(
         context, buffer, v_self, pipeline_barrier, VK_NULL_HANDLE);
   } else {
-    api::ShaderSource compute_shader =
-        packing::get_nchw_to_image_shader(v_self);
+    api::ShaderInfo compute_shader = packing::get_nchw_to_image_shader(v_self);
     packing::record_nchw_to_image_op(
         context,
         compute_shader,
@@ -478,8 +477,7 @@ void pack_vtensor_to_staging(
     packing::record_buffer_to_nchw_op(
         context, v_self, staging, pipeline_barrier, fence_handle);
   } else {
-    api::ShaderSource compute_shader =
-        packing::get_image_to_nchw_shader(v_self);
+    api::ShaderInfo compute_shader = packing::get_image_to_nchw_shader(v_self);
     packing::record_image_to_nchw_op(
         context,
         compute_shader,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #91918
* #91917
* #91916
* #91915
* #91914
* #91913
* #91912
* #91911
* __->__ #91910

@bypass-github-export-checks

```ShaderInfo``` was added by Kimish in D40280338 to be an extension of ```ShaderSource``` with extra fields. In this diff, I merge the two into one struct, using the combined struct in place of wherever either of the two was used before

Differential Revision: [D41197273](https://our.internmc.facebook.com/intern/diff/D41197273/)