### PR TITLE
[Vulkan] Generate ShaderInfos Directly via Codegen in gen_vulkan_spv

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -16,17 +16,7 @@
   }
 #else
 #include <ATen/native/vulkan/spv.h>
-#define VK_KERNEL(name)                                         \
-  ::at::native::vulkan::api::ShaderInfo {                       \
-    CONCAT_LITERALS(vulkan., name), name##_spv, name##_spv_len, \
-        name##_spv_layout                                       \
-  }
-#define VK_SHADER(name)                                                        \
-  ::at::native::vulkan::api::ShaderInfo {                                      \
-    CONCAT_LITERALS(vulkan., name), name##_spv, name##_spv_len,                \
-        name##_spv_layout, name##_spv_tile_size, name##_spv_bias_storage_type, \
-        name##_spv_weight_storage_type,                                        \
-  }
+#define VK_KERNEL(name) ::at::native::vulkan::name##_spv
 #endif /* USE_VULKAN_SHADERC_RUNTIME */
 
 namespace at {

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -296,13 +296,13 @@ static api::ShaderInfo get_shader(
 
     switch (method) {
       case Conv2dSlidingWindow:
-        shader = VK_SHADER(quantized_conv2d);
+        shader = VK_KERNEL(quantized_conv2d);
         break;
       case Conv2dDepthwise:
-        shader = VK_SHADER(quantized_conv2d_dw);
+        shader = VK_KERNEL(quantized_conv2d_dw);
         break;
       case Conv2dPointwise:
-        shader = VK_SHADER(quantized_conv2d_pw_2x2);
+        shader = VK_KERNEL(quantized_conv2d_pw_2x2);
         break;
         // todo fail for quantized transposed conv
     }
@@ -310,29 +310,29 @@ static api::ShaderInfo get_shader(
   }
 
   if (transposed) {
-    shader = VK_SHADER(conv_transpose2d);
+    shader = VK_KERNEL(conv_transpose2d);
     return shader;
   }
 
   switch (method) {
     case Conv2dSlidingWindow:
-      shader = VK_SHADER(conv2d);
+      shader = VK_KERNEL(conv2d);
       break;
     case Conv2dDepthwise:
-      shader = VK_SHADER(conv2d_dw);
+      shader = VK_KERNEL(conv2d_dw);
       if (kernel_size.size() == 4 && kernel_size[2] == 3 &&
           kernel_size[3] == 3) {
         // 1x1 refers to the output tile size
-        shader = VK_SHADER(conv2d_dw_3x3);
+        shader = VK_KERNEL(conv2d_dw_3x3);
       }
       if (kernel_size.size() == 4 && kernel_size[2] == 5 &&
           kernel_size[3] == 5) {
         // 1x1 refers to the output tile size
-        shader = VK_SHADER(conv2d_dw_5x5);
+        shader = VK_KERNEL(conv2d_dw_5x5);
       }
       break;
     case Conv2dPointwise:
-      shader = VK_SHADER(conv2d_pw_2x2);
+      shader = VK_KERNEL(conv2d_pw_2x2);
       break;
   }
   return shader;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #91918
* #91917
* #91916
* #91915
* #91914
* #91913
* #91912
* __->__ #91911
* #91910

@bypass-github-export-checks

Before this change, we have the data members which make up a ```ShaderInfo``` sitting in ```spv.h/.cpp``` in an unorganized manner. This diff makes the change such that the ```ShaderInfo```s are initialized directly in spv.h/.cpp

Now spv.h looks like
```
#pragma once
#include <stdint.h>
#include <vector>
#include <string>
#include <ATen/native/vulkan/api/Types.h>
#include <ATen/native/vulkan/api/vk_api.h>
namespace at {
namespace native {
namespace vulkan {
namespace api {
struct ShaderInfo;
} // namespace api
extern const api::ShaderInfo adaptive_avg_pool2d_spv;
...
extern const api::ShaderInfo conv2d_pw_2x2_spv;
} // namespace vulkan
} // namespace native
} // namespace at
```
(Full File: P557399150)
and spv.cpp looks like
```
#include <ATen/native/vulkan/spv.h>
#include <ATen/native/vulkan/api/Shader.h>
namespace at {
namespace native {
namespace vulkan {
namespace {
const uint32_t adaptive_avg_pool2d_spv_bin[] = {
  119734787,
  ...
};
...
const uint32_t conv2d_pw_2x2_spv_bin[] = {
  119734787,
  ...
};
} // namespace
const api::ShaderInfo adaptive_avg_pool2d_spv(
  "vulkan.adaptive_avg_pool2d",
  adaptive_avg_pool2d_spv_bin,
  3204,
  {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER},
  std::vector<uint32_t>(),
  api::StorageType::UNKNOWN,
  api::StorageType::UNKNOWN
);
...
const api::ShaderInfo conv2d_pw_2x2_spv(
  "vulkan.conv2d_pw_2x2",
  conv2d_pw_2x2_spv_bin,
  7736,
  {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER},
  {2, 2, 1},
  api::StorageType::TEXTURE_2D,
  api::StorageType::TEXTURE_2D
);
} // namespace vulkan
} // namespace native
} // namespace at

```
(Full File: P584237146)

Differential Revision: [D41354313](https://our.internmc.facebook.com/intern/diff/D41354313/)