### PR TITLE
[Vulkan] Enable including GLSL files from custom locations in gen_vulkan_spv

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -110,6 +110,35 @@ def get_static_dispatch_backend():
         return []
     return static_dispatch_backend.split(";")
 
+def get_glsl_paths():
+    paths = [
+        "//xplat/caffe2:aten_vulkan_glsl_src_path",
+        "aten/src/ATen/native/vulkan/glsl",
+    ] + [
+        p
+        for p in read_config("gen_vulkan_spv", "additional_glsl_paths", "").split(" ")
+        if p
+    ]
+
+    if len(paths) % 2 != 0:
+        fail(
+            "gen_vulkan_spv.additional_glsl_paths must contain an even number of elements"
+        )
+
+    return " ".join(
+        [
+            "$(location {})/{}".format(
+                paths[i],
+                paths[i + 1],
+            )
+            for i in range(
+                0,
+                len(paths),
+                2,
+            )
+        ]
+    )
+
 # @lint-ignore BUCKRESTRICTEDSYNTAX
 IS_OSS = read_config("pt", "is_oss", "0") == "1"  # True for OSS BUCK build, and False for internal BUCK build
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #91918
* #91917
* #91916
* #91915
* #91914
* __->__ #91913
* #91912
* #91911
* #91910

@bypass-github-export-checks

To include custom locations when building with buck, use a ```-c gen_vulkan_spv.additional_glsl_paths="..."``` flag where ... is a list of filegroups and source directory paths separated by spaces,

ex. to include the sources added in D41413913, you would use

```
buck build ... -c gen_vulkan_spv.additional_glsl_paths="//xplat/caffe2:test_glsl_src_path_a test_src/a //xplat/caffe2:test_glsl_src_path_b test_src/b"
```

(as shown in the test plan)

Differential Revision: [D41413914](https://our.internmc.facebook.com/intern/diff/D41413914/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D41413914/)!