### PR TITLE
[Vulkan] Add Basic Shader Registry

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -6,9 +6,12 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/vulkan/api/api.h>
 #include <ATen/native/vulkan/ops/Convert.h>
-#include <ATen/native/vulkan/spv.h>
+#include <ATen/native/vulkan/ops/Registry.h>
 
-#define VK_KERNEL(name) ::at::native::vulkan::name##_spv
+#define VK_KERNEL(shader_name) \
+  ::at::native::vulkan::get_shader_info(#shader_name)
+#define VK_LOOKUP_KERNEL(op_name) \
+  ::at::native::vulkan::look_up_shader_info(#op_name)
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/vulkan/ops/Registry.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Registry.cpp
@@ -1,0 +1,64 @@
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Shader.h>
+#include <ATen/native/vulkan/ops/Registry.h>
+#include <ATen/native/vulkan/spv.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+const api::ShaderInfo& get_shader_info(const std::string& shader_name) {
+  const ShaderListing::const_iterator shader_infos_iterator =
+      get_shader_infos().find(shader_name);
+
+  TORCH_CHECK(
+      shader_infos_iterator != get_shader_infos().end(),
+      "Could not get ShaderInfo named ",
+      shader_name);
+
+  return shader_infos_iterator->second;
+}
+
+const api::ShaderInfo& look_up_shader_info(const std::string& op_name) {
+  const ShaderRegistry::iterator registry_iterator =
+      get_shader_registry().find(op_name);
+
+  TORCH_CHECK(
+      registry_iterator != get_shader_registry().end(),
+      "Could not look up ShaderInfo for ",
+      op_name,
+      " in shader registry");
+
+  const RegistryKeyMap& registry_key_map = registry_iterator->second;
+
+  // Look for "catchall" key
+  const RegistryKeyMap::const_iterator registry_key_iterator =
+      registry_key_map.find("catchall");
+  if (registry_key_iterator != registry_key_map.end()) {
+    const ShaderListing::const_iterator shader_infos_iterator =
+        get_shader_infos().find(registry_key_iterator->second);
+
+    TORCH_CHECK(
+        shader_infos_iterator != get_shader_infos().end(),
+        "Could not get ShaderInfo named ",
+        registry_key_iterator->second,
+        " (listed under ",
+        op_name,
+        " -> catchall in shader registry)");
+
+    return shader_infos_iterator->second;
+  }
+
+  TORCH_CHECK(
+      false,
+      "Could not look up ShaderInfo for ",
+      op_name,
+      " with a valid key in shader registry");
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif // USE_VULKAN_API

--- a/aten/src/ATen/native/vulkan/ops/Registry.h
+++ b/aten/src/ATen/native/vulkan/ops/Registry.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <string>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+// Forward declaration of ShaderInfo
+struct ShaderInfo;
+} // namespace api
+
+/**
+ * Get the shader with a given name
+ */
+const api::ShaderInfo& get_shader_info(const std::string& shader_name);
+
+/**
+ * Look up which shader to use for a given op in the shader registry
+ */
+const api::ShaderInfo& look_up_shader_info(const std::string& op_name);
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif // USE_VULKAN_API


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #91918
* #91917
* #91916
* #91915
* __->__ #91914
* #91913
* #91912
* #91911
* #91910

@bypass-github-export-checks

We want to be able to look-up which shader to use in a registry given a particular op/algorithm name, which is what this diff enables. This is done with the newly added ```shader_registry``` map and ```look_up_shader_info``` function.

After this change, Shaders can be retrieved either with the ```VK_KERNEL``` macro, which gets the Shader with a specified name directly, or with the ```VK_REGISTRY_KERNEL``` macro, which looks up what Shader should be used for a specified algorithm name in the registry.

For now, the registry is empty and unused. In the next diffs in this stack, I will be adding support for registering a shader in the registry in GLSL and GLSLT + Params Yaml files.

I also
- Adjusted the formatting of spv.h and spv.cpp so that they are closer to what clang wants, which makes them easier to read. (proper indentation, proper order of includes, etc.)
- Moved the codegen spv/registry code from at::native::vulkan to at::native::vulkan::api (since registry.cpp / .h are in ```ATen/native/vulkan/api```)

Now spv.h looks like
```
#pragma once
#include <ATen/native/vulkan/api/Types.h>
#include <ATen/native/vulkan/api/vk_api.h>
#include <c10/util/flat_hash_map.h>
#include <string>
namespace at {
namespace native {
namespace vulkan {
namespace api {
struct ShaderInfo;
} // namespace api
typedef ska::flat_hash_map<std::string, api::ShaderInfo> ShaderListing;
typedef ska::flat_hash_map<std::string, std::string> RegistryKeyMap;
typedef ska::flat_hash_map<std::string, RegistryKeyMap> ShaderRegistry;
extern const ShaderListing shader_infos;
extern ShaderRegistry shader_registry;
inline const ShaderListing& get_shader_infos() {
  return shader_infos;
}
inline ShaderRegistry& get_shader_registry() {
  return shader_registry;
}
} // namespace vulkan
} // namespace native
} // namespace at
```
and spv.cpp looks like
```
#include <ATen/native/vulkan/api/Shader.h>
#include <ATen/native/vulkan/spv.h>
#include <stdint.h>
#include <vector>
namespace at {
namespace native {
namespace vulkan {
namespace {
const uint32_t adaptive_avg_pool2d_bin[] = {
  119734787,
  ...
};
...
const uint32_t conv2d_pw_2x2_bin[] = {
  119734787,
  ...
};
} // namespace
const ShaderListing shader_infos = {
    {"adaptive_avg_pool2d",
     api::ShaderInfo(
         "vulkan.adaptive_avg_pool2d",
         adaptive_avg_pool2d_bin,
         3204,
         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER},
         std::vector<uint32_t>(),
         api::StorageType::UNKNOWN,
         api::StorageType::UNKNOWN)},
    ...
    {"conv2d_pw_2x2",
     api::ShaderInfo(
         "vulkan.conv2d_pw_2x2",
         conv2d_pw_2x2_bin,
         7736,
         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER},
         {2, 2, 1},
         api::StorageType::TEXTURE_2D,
         api::StorageType::TEXTURE_2D)}};
ShaderRegistry shader_registry = {
};
} // namespace vulkan
} // namespace native
} // namespace at

```
(Full File: P594112814)

Differential Revision: [D41594453](https://our.internmc.facebook.com/intern/diff/D41594453/)