### PR TITLE
[Vulkan] Enable Codegen ShaderInfo Registry from GLSL files (conv2d)

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
@@ -6,6 +6,7 @@
  * TILE_SIZE = (1, 1, 1)
  * WEIGHT_STORAGE = TEXTURE_2D
  * BIAS_STORAGE = TEXTURE_2D
+ * REGISTER_FOR = ('conv2d', ['catchall'])
  */
 
 layout(std430) buffer;

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -316,7 +316,7 @@ static api::ShaderInfo get_shader(
 
   switch (method) {
     case Conv2dSlidingWindow:
-      shader = VK_KERNEL(conv2d);
+      shader = VK_LOOKUP_KERNEL(conv2d);
       break;
     case Conv2dDepthwise:
       shader = VK_KERNEL(conv2d_dw);

--- a/tools/gen_vulkan_spv.py
+++ b/tools/gen_vulkan_spv.py
@@ -12,8 +12,8 @@ import textwrap
 import yaml
 from collections import OrderedDict
 from torchgen.code_template import CodeTemplate
-from dataclasses import dataclass
-from typing import Any, Dict, List
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple, Optional
 from yaml.constructor import ConstructorError
 from yaml.nodes import MappingNode
 
@@ -126,6 +126,7 @@ class ShaderInfo:
     layouts: List[str]
     weight_storage_type: str = ""
     bias_storage_type: str = ""
+    register_for: Optional[Tuple[str, List[str]]] = None
 
 def getName(filePath: str) -> str:
     return os.path.basename(filePath).replace("/", "_").replace(".", "_")
@@ -167,6 +168,19 @@ def getBiasStorageType(lineStr: str) -> str:
         raise AssertionError("matches is None in getBiasStorageType")
     return matches.group(1)
 
+def isRegisterForLine(lineStr: str) -> bool:
+    # Check for Shader Name and a list of at least one Registry Key
+    register_for_id = r"^ \* REGISTER_FOR = \('([A-Za-z0-9_]+)'\s*,\s*\['([A-Za-z0-9_]+)'.*\]\)"
+    return re.search(register_for_id, lineStr) is not None
+
+def findRegisterFor(lineStr: str) -> Tuple[str, List[str]]:
+    register_for_pattern = r"'([A-Za-z0-9_]+)'"
+    matches = re.findall(register_for_pattern, lineStr)
+    if matches is None:
+        raise AssertionError("matches is None in getBiasStorageType")
+    matches_list = list(matches)
+    return (matches_list[0], matches_list[1:])
+
 typeIdMapping = {
     r"image[123]D\b": "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
     r"sampler[123]D\b": "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
@@ -201,6 +215,8 @@ def getShaderInfo(srcFilePath: str) -> ShaderInfo:
                 shader_info.weight_storage_type = getWeightStorageType(line)
             if isBiasStorageTypeLine(line):
                 shader_info.bias_storage_type = getBiasStorageType(line)
+            if isRegisterForLine(line):
+                shader_info.register_for = findRegisterFor(line)
 
     return shader_info
 
@@ -319,6 +335,7 @@ def genCppH(
 
     shader_info_bin_code = []
     shader_info_cpp_code = []
+    shader_info_registry_code = []
 
     for spvPath, srcPath in spvPaths.items():
         name = getName(spvPath).replace("_spv", "")
@@ -364,6 +381,20 @@ def genCppH(
             ),
         )
 
+        if shader_info.register_for is not None:
+            (op_name, registry_keys) = shader_info.register_for
+            for registry_key in registry_keys:
+                shader_info_registry_code.append(
+                    textwrap.indent(
+                        "{{\"{}\", {{{{\"{}\", \"{}\"}}}}}}".format(
+                            op_name,
+                            registry_key,
+                            name,
+                        ),
+                        "        ",
+                    ),
+                )
+
     cpp += anon_ns_begin
     cpp += "\n".join(shader_info_bin_code) + "\n"
     cpp += anon_ns_end
@@ -371,7 +402,9 @@ def genCppH(
     cpp += "const ShaderListing shader_infos = {{\n{}}};\n".format(
         ",\n".join(shader_info_cpp_code),
     )
-    cpp += "ShaderRegistry shader_registry = {\n};\n"
+    cpp += "ShaderRegistry shader_registry = {{\n{}}};\n".format(
+        ",\n".join(shader_info_registry_code),
+    )
     cpp += nsend
 
     with open(hFilePath, "w") as fw:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #91918
* #91917
* #91916
* __->__ #91915
* #91914
* #91913
* #91912
* #91911
* #91910

@bypass-github-export-checks

This diff allows for adding entries to the shader registry by specifying which op names and registry keys should map to a Shader in the Shader's glsl file.

This can be done by adding a REGISTER_FOR line with a tuple of (op name, list of registry keys) to the ShaderInfo comment in the glsl file

Ex.
```
REGISTER_FOR = ('conv2d', ['catchall', ...])
```

This diff also registers the conv2d Shader under ```'conv2d → 'catchall'``` in the registry and uses ```VK_REGISTRY_KERNEL``` to retrieve the shader by look up in the registry

The shader registry generated in spv.cpp now looks like
```
ShaderRegistry shader_registry = {
        {"conv2d", {{"catchall", "conv2d"}}}};
```

Differential Revision: [D42197400](https://our.internmc.facebook.com/intern/diff/D42197400/)