### PR TITLE
[Vulkan] Add Override Mechanism to Shader Registry

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Registry.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Registry.cpp
@@ -32,22 +32,26 @@ const api::ShaderInfo& look_up_shader_info(const std::string& op_name) {
 
   const RegistryKeyMap& registry_key_map = registry_iterator->second;
 
-  // Look for "catchall" key
-  const RegistryKeyMap::const_iterator registry_key_iterator =
-      registry_key_map.find("catchall");
-  if (registry_key_iterator != registry_key_map.end()) {
-    const ShaderListing::const_iterator shader_infos_iterator =
-        get_shader_infos().find(registry_key_iterator->second);
+  // Look for "override" and "catchall" keys
+  for (const std::string& key : {"override", "catchall"}) {
+    const RegistryKeyMap::const_iterator registry_key_iterator =
+        registry_key_map.find(key);
+    if (registry_key_iterator != registry_key_map.end()) {
+      const ShaderListing::const_iterator shader_infos_iterator =
+          get_shader_infos().find(registry_key_iterator->second);
 
-    TORCH_CHECK(
-        shader_infos_iterator != get_shader_infos().end(),
-        "Could not get ShaderInfo named ",
-        registry_key_iterator->second,
-        " (listed under ",
-        op_name,
-        " -> catchall in shader registry)");
+      TORCH_CHECK(
+          shader_infos_iterator != get_shader_infos().end(),
+          "Could not get ShaderInfo named ",
+          registry_key_iterator->second,
+          " (listed under ",
+          op_name,
+          " -> ",
+          key,
+          " in shader registry)");
 
-    return shader_infos_iterator->second;
+      return shader_infos_iterator->second;
+    }
   }
 
   TORCH_CHECK(
@@ -55,6 +59,26 @@ const api::ShaderInfo& look_up_shader_info(const std::string& op_name) {
       "Could not look up ShaderInfo for ",
       op_name,
       " with a valid key in shader registry");
+}
+
+void set_registry_override(
+    const std::string& op_name,
+    const std::string& shader_name) {
+  const ShaderRegistry::iterator registry_iterator =
+      get_shader_registry().find(op_name);
+
+  TORCH_CHECK(
+      registry_iterator != get_shader_registry().end(),
+      "Could not look up ShaderInfo for ",
+      op_name,
+      " in shader registry");
+
+  TORCH_CHECK(
+      get_shader_infos().find(shader_name) != get_shader_infos().end(),
+      "Could not get ShaderInfo named ",
+      shader_name);
+
+  registry_iterator->second["override"] = shader_name;
 }
 
 } // namespace vulkan

--- a/aten/src/ATen/native/vulkan/ops/Registry.h
+++ b/aten/src/ATen/native/vulkan/ops/Registry.h
@@ -22,6 +22,10 @@ const api::ShaderInfo& get_shader_info(const std::string& shader_name);
  */
 const api::ShaderInfo& look_up_shader_info(const std::string& op_name);
 
+void set_registry_override(
+    const std::string& op_name,
+    const std::string& shader_name);
+
 } // namespace vulkan
 } // namespace native
 } // namespace at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #91918
* __->__ #91917
* #91916
* #91915
* #91914
* #91913
* #91912
* #91911
* #91910

@bypass-github-export-checks

Setting overrides in the Vulkan Shader Registry will be used with the Op Benchmark Tool to benchmark different shaders on different devices.

Differential Revision: [D41738945](https://our.internmc.facebook.com/intern/diff/D41738945/)