### PR TITLE
[Op Benchmark] Add Pointwise Conv2d Op Benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/configs.py
+++ b/benchmarks/operator_benchmark/pt/configs.py
@@ -62,6 +62,33 @@ conv_2d_configs_long = op_bench.cross_product_configs(
     tags=["long"]
 )
 
+# Configs for Conv2dPointwise
+conv_2d_pw_configs_short = op_bench.config_list(
+    attr_names=[
+        'IC', 'OC', 'stride', 'N', 'H', 'W', 'G', 'pad',
+    ],
+    attrs=[
+        [256, 256, 1, 1, 16, 16, 1, 0],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+    },
+    tags=['short']
+)
+
+conv_2d_pw_configs_long = op_bench.cross_product_configs(
+    IC=[128, 256],
+    OC=[128, 256],
+    stride=[1, 2],
+    N=[4],
+    H=[32],
+    W=[32],
+    G=[1],
+    pad=[0],
+    device=['cpu', 'cuda'],
+    tags=["long"]
+)
+
 # Configs for Conv3d and ConvTranspose3d
 conv_3d_configs_short = op_bench.config_list(
     attr_names=[

--- a/benchmarks/operator_benchmark/pt/conv_test.py
+++ b/benchmarks/operator_benchmark/pt/conv_test.py
@@ -40,7 +40,7 @@ op_bench.generate_pt_test(configs.conv_1d_configs_short + configs.conv_1d_config
 
 
 """
-Microbenchmarks for Conv2d and ConvTranspose2d operators.
+Microbenchmarks for Conv2d, ConvTranspose2d, and Conv2dPointwise operators.
 """
 
 
@@ -70,10 +70,26 @@ class ConvTranspose2dBenchmark(op_bench.TorchBenchmarkBase):
         return self.convtranspose2d(input)
 
 
+class Conv2dPointwiseBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, IC, OC, stride, N, H, W, G, pad, device):
+        self.inputs = {
+            "input": torch.rand(N, IC, H, W, device=device)
+        }
+        # Use 1 as kernel for pointwise convolution
+        self.conv2d = nn.Conv2d(
+            IC, OC, 1, stride=stride, groups=G, padding=pad).to(device=device)
+        self.set_module_name('Conv2dPointwise')
+
+    def forward(self, input):
+        return self.conv2d(input)
+
+
 op_bench.generate_pt_test(configs.conv_2d_configs_short + configs.conv_2d_configs_long,
                           Conv2dBenchmark)
 op_bench.generate_pt_test(configs.conv_2d_configs_short + configs.conv_2d_configs_long,
                           ConvTranspose2dBenchmark)
+op_bench.generate_pt_test(configs.conv_2d_pw_configs_short + configs.conv_2d_pw_configs_long,
+                          Conv2dPointwiseBenchmark)
 
 
 """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91918
* #91917
* #91916
* #91915
* #91914
* #91913
* #91912
* #91911
* #91910

@bypass-github-export-checks

Pointwise Conv2d is one of the ops which we want to benchmark using different Vulkan Shaders (```conv2d_pw_2x2``` vs ```conv2d_pw_1x1```) with

The configs are copied from Conv2d with the kernel parameter removed.

I considered just using the same configs but ignoring the provided kernel and hardcoding the kernel to 1 when initializing nn.Conv2d, but then in the op benchmark title, it would say kernel=3 even if though that would not be the case.

Differential Revision: [D42303453](https://our.internmc.facebook.com/intern/diff/D42303453/)