### PR TITLE
[CI][ROCm] disable file granularity parallelism

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -51,6 +51,7 @@ except ImportError:
 
 
 # Note [ROCm parallel CI testing]
+# !! Temporarily disabled. Running in parallel might be causing hangs.
 # https://github.com/pytorch/pytorch/pull/85770 added file-granularity parallel testing.
 # In .jenkins/pytorch/test.sh, TEST_CONFIG == "default", CUDA and HIP_VISIBLE_DEVICES is set to 0.
 # This results in multiple test files sharing the same GPU.
@@ -62,6 +63,7 @@ except ImportError:
 # Assigning each Pool worker their own dedicated GPU avoids the ROCm oversubscription issues.
 # This should also result in better overall wall clock time since all GPUs can be utilized.
 def maybe_set_hip_visible_devies():
+    return  # disabling
     # Special handling of ROCm GHA runners for parallel (file granularity) tests.
     if torch.version.hip:
         p = current_process()

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -10,24 +10,26 @@ IS_MEM_LEAK_CHECK = os.getenv("PYTORCH_TEST_CUDA_MEM_LEAK_CHECK", "0") == "1"
 NUM_PROCS = 1 if IS_MEM_LEAK_CHECK else 2
 
 # See Note [ROCm parallel CI testing]
+# !! Temporarily disabled. Running in parallel might be causing hangs.
 # Special logic for ROCm GHA runners to query number of GPUs available.
 # torch.version.hip was not available to check if this was a ROCm self-hosted runner.
 # Must check for ROCm runner in another way. We look for /opt/rocm directory.
 if os.path.exists("/opt/rocm") and not IS_MEM_LEAK_CHECK:
-    try:
-        # This is the same logic used in GHA health check, see .github/templates/common.yml.j2
-        lines = (
-            subprocess.check_output(["rocminfo"], encoding="ascii").strip().split("\n")
-        )
-        count = 0
-        for line in lines:
-            if " gfx" in line:
-                count += 1
-        assert count > 0  # there must be at least 1 GPU
-        NUM_PROCS = count
-    except subprocess.CalledProcessError as e:
-        # The safe default for ROCm GHA runners is to run tests serially.
-        NUM_PROCS = 1
+    # try:
+    #     # This is the same logic used in GHA health check, see .github/templates/common.yml.j2
+    #     lines = (
+    #         subprocess.check_output(["rocminfo"], encoding="ascii").strip().split("\n")
+    #     )
+    #     count = 0
+    #     for line in lines:
+    #         if " gfx" in line:
+    #             count += 1
+    #     assert count > 0  # there must be at least 1 GPU
+    #     NUM_PROCS = count
+    # except subprocess.CalledProcessError as e:
+    #     # The safe default for ROCm GHA runners is to run tests serially.
+    #     NUM_PROCS = 1
+    NUM_PROCS = 1
 
 
 class ShardJob:


### PR DESCRIPTION
This is to see if recent timeouts are resolved.  See #90940 .

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport