### PR TITLE
[dynamo] support specializing NNModule's tensor attribute's size  when expor…

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -381,6 +381,8 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
                 options["guards"].add(source.make_guard(GuardBuilder.TENSOR_MATCH))
 
             def wrap_name(module_key):
+                if self.root_tx.export:
+                    options["size"] = target.size()
                 return wrap_fx_proxy(
                     self.root_tx,
                     self.create_proxy("get_attr", module_key, tuple(), {}),

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -286,7 +286,7 @@ class TensorVariable(VariableTracker):
                 unimplemented(f"Tensor.{name}")
         elif name == "__len__":
             if self.size:
-                assert not config.dynamic_shapes
+                assert not config.dynamic_shapes or tx.export
                 return ConstantVariable(self.size[0], **options)
             else:
                 return wrap_fx_proxy(


### PR DESCRIPTION
We specialize the size of a tensor attribute of a nn module in export mode. This can enable functions such as "len(self.w)" as shown up in DPE model.

Fixes #91901


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire