### PR TITLE
Pin onnx-script to a version before they bumped numpy

### DIFF
--- a/.jenkins/onnx/test.sh
+++ b/.jenkins/onnx/test.sh
@@ -61,7 +61,7 @@ if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
   pip install -q --user --no-use-pep517 "git+https://github.com/pytorch/vision.git@$(cat .github/ci_commit_pins/vision.txt)"
   pip install -q --user ninja flatbuffers==2.0 numpy==1.21.5 onnxruntime==1.12.1 beartype==0.10.4 onnx==1.12.0
   # TODO: change this when onnx-script is on testPypi
-  pip install 'onnx-script @ git+https://github.com/microsoft/onnx-script'
+  pip install 'onnx-script @ git+https://github.com/microsoft/onnx-script@4f3ff0d806d0d0f30cecdfd3e8b094b1e492d44a'
   # numba requires numpy <= 1.20, onnxruntime requires numpy >= 1.21.
   # We don't actually need it for our tests, but it's imported if it's present, so uninstall.
   pip uninstall -q --yes numba


### PR DESCRIPTION
Onnx PR https://github.com/microsoft/onnx-script/pull/289 expects numpy to be upgraded. That breaks pytorch's onnx builds.

For now, mitigate by pinning the script to an older version until there's a proper solution