### PR TITLE
Disable win vs2019 cpu build+test until we figure out the linker crash

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -230,6 +230,7 @@ jobs:
       test-matrix: ${{ needs.linux-bionic-py3_7-clang8-xla-build.outputs.test-matrix }}
 
   win-vs2019-cpu-py3-build:
+    if: false
     name: win-vs2019-cpu-py3
     uses: ./.github/workflows/_win-build.yml
     with:
@@ -243,6 +244,7 @@ jobs:
         ]}
 
   win-vs2019-cpu-py3-test:
+    if: false
     name: win-vs2019-cpu-py3
     uses: ./.github/workflows/_win-test.yml
     needs: win-vs2019-cpu-py3-build


### PR DESCRIPTION
`win-vs2019-cpu-py3 / build` builds are failing consistently right now with a linker crash.  Tracked by sev https://github.com/pytorch/pytorch/issues/91933

Disable those workflows for to mitigate the damage until we figure out a root cause

Example: [win-vs2019-cpu-py3 / build](https://github.com/pytorch/pytorch/actions/runs/3877976332/jobs/6614897752#logs)

Exact error:
```
FAILED: bin/torch_python.dll lib/torch_python.lib 
cmd.exe /C "cd . && C:\Jenkins\Miniconda3\Library\bin\cmake.exe -E vs_link_dll --intdir=caffe2\torch\CMakeFiles\torch_python.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~2\2019\BUILDT~1\VC\Tools\MSVC\1428~1.293\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\torch_python.rsp  /out:bin\torch_python.dll /implib:lib\torch_python.lib /pdb:bin\torch_python.pdb /dll /version:0.0 /machine:x64 /ignore:4049 /ignore:4217 /ignore:4099 /INCREMENTAL:NO  /NODEFAULTLIB:LIBCMT.LIB  -WHOLEARCHIVE:C:/actions-runner/_work/pytorch/pytorch/build/lib/onnx.lib  && cd ."
LINK: command "C:\PROGRA~2\MICROS~2\2019\BUILDT~1\VC\Tools\MSVC\1428~1.293\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\torch_python.rsp /out:bin\torch_python.dll /implib:lib\torch_python.lib /pdb:bin\torch_python.pdb /dll /version:0.0 /machine:x64 /ignore:4049 /ignore:4217 /ignore:4099 /INCREMENTAL:NO /NODEFAULTLIB:LIBCMT.LIB -WHOLEARCHIVE:C:/actions-runner/_work/pytorch/pytorch/build/lib/onnx.lib /MANIFEST /MANIFESTFILE:bin\torch_python.dll.manifest" failed (exit code 0) with the following output:

LINK : fatal error LNK1000: Internal error during CImplib::EmitImportThunk
Access violation
ninja: build stopped: subcommand failed.
```