### PR TITLE
[SDPA] Guard mem efficient attention in deterministic mode

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -33,6 +33,24 @@ from torch.testing._internal.common_cuda import TEST_CUDA, SM80OrLater
 if TEST_FAIRSEQ:
     import fairseq.models.transformer as fairseq_transformer
 
+PLATFORM_SUPPORTS_FUSED_SDPA: bool = TEST_CUDA and not TEST_WITH_ROCM and not IS_WINDOWS
+
+@contextlib.contextmanager
+def use_deterministic_algorithims(mode: bool, warn_only: bool):
+    r"""
+    This context manager can be used to temporarily enable or disable deterministic algorithms.
+    Upon exiting the context manager, the previous state of the flag will be restored.
+    """
+    previous_mode: bool = torch.are_deterministic_algorithms_enabled()
+    previous_warn_only: bool = torch.is_deterministic_algorithms_warn_only_enabled()
+    try:
+        torch.use_deterministic_algorithms(mode, warn_only=warn_only)
+        yield{}
+    except RuntimeError as err:
+        raise err
+    finally:
+        torch.use_deterministic_algorithms(previous_mode, warn_only=previous_warn_only)
+
 class TestTransformers(NNTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
@@ -950,7 +968,7 @@ class TestTransformers(NNTestCase):
         size = (batch, seq_len, num_heads, head_dim) if not packed else (batch, seq_len, 3 * num_heads * head_dim)
         return torch.randn(size, device=device, dtype=dtype, requires_grad=requires_grad)
 
-    @unittest.skipIf(not TEST_CUDA or TEST_WITH_ROCM or IS_WINDOWS, "Flash Attention was not built for this system")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Flash Attention was not built for this system")
     @parametrize("type", ["dense", "nested"])
     @parametrize("is_contiguous", [True, False])
     def test_scaled_dot_product_attention_fused_kernels(self, type: str, is_contiguous: bool):
@@ -994,7 +1012,7 @@ class TestTransformers(NNTestCase):
 
         self.assertEqual(actual[0].contiguous(), math_ref[0].contiguous(), atol=1e-3, rtol=1e-2)
 
-    @unittest.skipIf(not TEST_CUDA or TEST_WITH_ROCM or IS_WINDOWS, "Flash Attention was not built for this system")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Flash Attention was not built for this system")
     @parametrize("type", ["dense", "nested"])
     @parametrize("is_contiguous", [True, False])
     def test_scaled_dot_product_attention_fused_kernels_packed(self, type: str, is_contiguous: bool):
@@ -1027,7 +1045,7 @@ class TestTransformers(NNTestCase):
 
         self.assertEqual(actual[0].contiguous(), math_ref[0].contiguous(), atol=2e-3, rtol=1e-2)
 
-    @unittest.skipIf(not TEST_CUDA or TEST_WITH_ROCM or IS_WINDOWS, "Flash Attention was not built for this system")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Flash Attention was not built for this system")
     @parametrize("type", ["dense", "nested"])
     @parametrize("fused_kernel", ["flash", "mem_efficient"])
     def test_scaled_dot_product_attention_fused_kernels_packed_accuracy(self, type: str, fused_kernel: str):
@@ -1105,7 +1123,7 @@ class TestTransformers(NNTestCase):
         self.assertEqual(math_ref_test, math_ref_lp_test, atol=7e-3, rtol=7e-3)
         self.assertEqual(actual_test, math_ref_test, atol=5e-3, rtol=5e-3)
 
-    @unittest.skipIf(not TEST_CUDA or TEST_WITH_ROCM or IS_WINDOWS, "Flash Attention was not built for this system")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Flash Attention was not built for this system")
     @parametrize("contiguous_inputs", [True, False])
     def test_sdp_math_gradcheck(self, contiguous_inputs: bool):
 
@@ -1130,7 +1148,7 @@ class TestTransformers(NNTestCase):
                              (query, key, value, None, 0.0, False, False)
                              )
 
-    @unittest.skipIf(not TEST_CUDA or TEST_WITH_ROCM or IS_WINDOWS, "Flash Attention was not built for this system")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Flash Attention was not built for this system")
     @parametrize("contiguous_inputs", [True, False])
     def test_sdp_fused_grad_against_math(self, contiguous_inputs: bool):
         batch_size, seq_len, num_heads, head_dim = 4, 4, 2, 16
@@ -1185,7 +1203,7 @@ class TestTransformers(NNTestCase):
             q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
             assert torch._fused_sdp_choice(q, k, v) == SDPBackend.MATH
 
-        if TEST_CUDA and not TEST_WITH_ROCM and not IS_WINDOWS:
+        if PLATFORM_SUPPORTS_FUSED_SDPA:
             batch_size, seq_len, num_heads, head_dim = 32, 64, 16, 64
             shape = (batch_size, seq_len, num_heads, head_dim)
             device = "cuda"
@@ -1217,8 +1235,21 @@ class TestTransformers(NNTestCase):
 
             assert torch._fused_sdp_choice(query, key, value) == SDPBackend.EFFICIENT_ATTENTION
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "CUDA unavailable")
+    @parametrize("warn_only", [True, False])
+    def test_sdp_choice_with_determinism(self, warn_only):
+        # If we are only warning we still expect that efficient_attention will still be called.
+        batch_size, seq_len, num_heads, head_dim = 1, 64, 8, 64
+        shape = (batch_size, seq_len, num_heads, head_dim)
+        make_tensor = partial(self.rand_tensor, device="cuda", dtype=torch.float32, packed=False)
+        query, key, value = make_tensor(shape), make_tensor(shape), make_tensor(shape)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+        with use_deterministic_algorithims(True, warn_only=warn_only):
+            with sdp_kernel(enable_flash=False, enable_math=True, enable_mem_efficient=True):
+                assert torch._fused_sdp_choice(query, key, value) == (
+                    SDPBackend.EFFICIENT_ATTENTION if warn_only else SDPBackend.MATH)
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "CUDA unavailable")
     def test_sdp_runtime_dispatch(self):
         # We will test all the constraints that we know will cause a failure
         # The problem is that any code path that goes down flash_attention
@@ -1285,7 +1316,7 @@ class TestTransformers(NNTestCase):
         model(x, x, x)
         # completes without error
 
-    @unittest.skipIf(not TEST_CUDA or not SM80OrLater or TEST_WITH_ROCM, "CUDA unavailable")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA or not SM80OrLater, "CUDA unavailable")
     def test_unaligned_tensors(self):
         device = 'cuda'
         dtype = torch.float16
@@ -1297,7 +1328,7 @@ class TestTransformers(NNTestCase):
             self.assertRaises(RuntimeError, lambda: torch.nn.functional._scaled_dot_product_attention(
                 q, k, v, None, 0.0, False, False))
 
-    @unittest.skipIf(not TEST_CUDA or not SM80OrLater or TEST_WITH_ROCM, "CUDA unavailable")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA or not SM80OrLater, "CUDA unavailable")
     def test_flash_fail_fp32t(self):
         device = 'cuda'
         dtype = torch.float
@@ -1309,7 +1340,7 @@ class TestTransformers(NNTestCase):
             self.assertRaises(RuntimeError, lambda: torch.nn.functional._scaled_dot_product_attention(
                 q, k, v, None, 0.0, False, False))
 
-    @unittest.skipIf(not TEST_CUDA or not SM80OrLater or TEST_WITH_ROCM, "CUDA unavailable")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA or not SM80OrLater, "CUDA unavailable")
     def test_flash_autocast_fp32_float16(self):
         device = 'cuda'
         dtype = torch.float
@@ -1322,7 +1353,7 @@ class TestTransformers(NNTestCase):
                 _ = torch.nn.functional._scaled_dot_product_attention(
                     q, k, v, None, 0.0, False, False)
 
-    @unittest.skipIf(not TEST_CUDA or not SM80OrLater or TEST_WITH_ROCM, "CUDA unavailable")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA or not SM80OrLater, "CUDA unavailable")
     def test_flash_autocast_fp32_bfloat16(self):
         device = 'cuda'
         dtype = torch.float
@@ -1360,7 +1391,6 @@ class TestTransformers(NNTestCase):
             loss = criterion(outputs[:, 0:2, :], inputs[:, 0:2, :])
             loss.backward()
             optimizer.step()
-
 
 # TODO: Replace this with instantiate_device_type_tests() to take advantage of test framework support for
 # cross device / dtype testing.


### PR DESCRIPTION
# Summary
Memory efficient attention is a non deterministic algorithm. 

This PR ensures that the sdp_choice will allow for mem-efficient  to be used as the backend to SDPA if we are in warn only mode.  Otherwise  if we have enabled determinism and and set warn_only to False sdp_choice will not return memory efficient attention as the backend.