### PR TITLE
[WIP] Fix for not properly capturing closure variables in cond / export

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1426,11 +1426,13 @@ class ExportTests(torch._dynamo.test_case.TestCase):
                 self.linear = torch.nn.Linear(3, 3)
 
             def forward(self, pred, x):
+                y = x + x
+
                 def true_fn(val):
-                    return self.linear(val) * torch.tensor(2)
+                    return self.linear(val) * (x + y)
 
                 def false_fn(val):
-                    return self.linear(val) * torch.tensor(-1)
+                    return val * (y - x)
 
                 return cond(pred, true_fn, false_fn, [x])
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -81,7 +81,6 @@ from .variables.misc import (
 )
 from .variables.nn_module import NNModuleVariable
 from .variables.tensor import DynamicShapeVariable, TensorVariable
-from torch._dynamo.variables.tensor import TensorVariable
 
 from .variables.torch import TorchVariable
 from .variables.user_defined import UserDefinedVariable

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 
 import math
@@ -767,9 +766,20 @@ class TorchPyOperator(VariableTracker):
 
                 guards = state.output.guards
                 # Create attributes to store closure variables.
-                # See compiling and calling convention for closure variables in the implementation of InliningInstructionTranslator.LOAD_REF
-                closure_values = [(tx.symbolic_locals[item.name], list(tx.symbolic_locals.keys()).index(item.name)) for item in args[ix].closure.items]
-                closure_vars = {f"closure_{i}": v for (v, i) in closure_values if isinstance(v, TensorVariable)}
+                # See compiling and calling convention for closure variables in
+                # the implementation of InliningInstructionTranslator.LOAD_REF
+                closure_values = [
+                    (
+                        tx.symbolic_locals[item.name],
+                        list(tx.symbolic_locals.keys()).index(item.name),
+                    )
+                    for item in args[ix].closure.items
+                ]
+                closure_vars = {
+                    f"closure_{i}": v
+                    for (v, i) in closure_values
+                    if isinstance(v, TensorVariable)
+                }
                 nn_modules = {**closure_vars, **state.output.nn_modules}
 
                 # Nub out bits of state that we don't require to be

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 
 import math
@@ -765,7 +766,11 @@ class TorchPyOperator(VariableTracker):
                 state = tx.copy_graphstate()
 
                 guards = state.output.guards
-                nn_modules = state.output.nn_modules
+                # Create attributes to store closure variables.
+                # See compiling and calling convention for closure variables in the implementation of InliningInstructionTranslator.LOAD_REF
+                closure_values = [(tx.symbolic_locals[item.name], list(tx.symbolic_locals.keys()).index(item.name)) for item in args[ix].closure.items]
+                closure_vars = {f"closure_{i}": v for (v, i) in closure_values if isinstance(v, TensorVariable)}
+                nn_modules = {**closure_vars, **state.output.nn_modules}
 
                 # Nub out bits of state that we don't require to be
                 # equal


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #91981

Fixes https://github.com/pytorch/pytorch/issues/90469

Let's say we call `cond` with a `true_fn` / `false_fn` that captures variables in the scope of the call. The instructions emitted in the graphs for the nested functions naively refer to the names of the nodes in the outer graph as if the nested functions were "inlined," but unfortunately this can clash with variables declared in the nested function itself. Moreover, the values of these closed variables need to be bound late at call time.

In this diff we propose a fix for this problem by passing around the closure environment as attributes in the graph module. Details of the compiling / calling protocol are in comments.

Differential Revision: [D42353499](https://our.internmc.facebook.com/intern/diff/D42353499/)

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire