### PR TITLE
[Dynamo] Fix guard bug when np.float used in control flow

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -217,6 +217,9 @@ class GuardBuilder(GuardBuilderBase):
                 np.uint16,
                 np.uint32,
                 np.uint64,
+                np.float16,
+                np.float32,
+                np.float64,
             )
             if HAS_NUMPY
             else ()


### PR DESCRIPTION
Fixes 14k github models: https://github.com/jansel/pytorch-jit-paritybench/blob/master/generated/test_Sanster_lama_cleaner.py#L2392

Error
```
File "/scratch/ybliang/work/repos/pytorch/torch/_dynamo/guards.py", line 263, in CONSTANT_MATCH
    self.EQUALS_MATCH(guard)
  File "/scratch/ybliang/work/repos/pytorch/torch/_dynamo/guards.py", line 197, in EQUALS_MATCH
    assert istype(
AssertionError: float64
```

```np.float``` is unspecialized by default, which has guard on ```TYPE_MATCH```. However, it will be baked when being used in control flow, which has guard on ```EQUALS_MATCH```. We should make ```EQUALS_MATCH``` support ```np.float```.


cc @mlazos @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire