### PR TITLE
[static-runtime] clamp fast_sigmoid result into (0,1) range

### DIFF
--- a/torch/csrc/jit/tensorexpr/expr.cpp
+++ b/torch/csrc/jit/tensorexpr/expr.cpp
@@ -193,10 +193,17 @@ ExprHandle fast_sigmoid(const ExprHandle& x) {
   // sigmoid(x) = (tanh(x / 2) + 1) / 2
   ExprHandle one_v = FloatImm::make(1.f);
   ExprHandle half_v = FloatImm::make(0.5f);
+  ExprHandle zero_v = FloatImm::make(0.0f);
   ExprHandle x2 = x * half_v;
   ExprHandle y{fast_tanh(x2)};
   ExprHandle z = (y + one_v) * half_v;
-  return z;
+  // fast_tanh is not precise
+  // but clients rely on the sigmoid return values being probability-like
+  // so clamp them into (0, 1)
+  return Min::make(
+      one_v,
+      Max::make(zero_v, z, /* propagate_nans= */ false),
+      /* propagate_nans= */ false);
 }
 
 ExprHandle fast_log(const ExprHandle& v) {


### PR DESCRIPTION
fast_sigmoid uses fast_tanh under the hood which is not precise;
the op outputs are treated as probability-like numbers;
in a reeeally small percentage of cases the outputs fell out of acceptable range for probabilities

Test Plan: ci

Differential Revision: D42445821



cc @EikanWang @jgong5