### PR TITLE
[Pytorch][quantized] implement lookup table based hardswish for qint8 dtype

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
@@ -1,11 +1,12 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/core/Tensor.h>
 #include <ATen/Context.h>
-#include <torch/library.h>
+#include <ATen/Parallel.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/native/quantized/cpu/QnnpackUtils.h>
 #include <ATen/native/quantized/cpu/QuantizedOps.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
-#include <ATen/native/quantized/cpu/QnnpackUtils.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
+#include <torch/library.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -22,65 +23,78 @@ DEFINE_DISPATCH(qhardswish_stub);
 
 namespace {
 
-#ifdef USE_PYTORCH_QNNPACK
-Tensor qnnpack_hardswish(const Tensor& qx, Tensor& qy) {
-  TORCH_CHECK(qx.ndimension() > 0, "qnnpack_hardswish(): Got empty input tensor");
-  TORCH_CHECK(qx.scalar_type() == c10::kQUInt8,
-                "qnnpack_hardswish(): Expected input data type to be ",
-                toString(c10::kQUInt8),
-                " but got ",
-                toString(qx.scalar_type()));
-  initQNNPACK();
+template <typename DTYPE>
+std::vector<DTYPE> create_hswish_lookup_table(
+    int32_t input_zero_point,
+    float input_scale,
+    int32_t output_zero_point,
+    float output_scale) {
+  DTYPE dtype_min = std::numeric_limits<DTYPE>::min();
+  DTYPE dtype_max = std::numeric_limits<DTYPE>::max();
 
-  size_t num_elems = qx.numel() / qx.size(0);
+  static_assert(
+      std::is_same<DTYPE, int8_t>() || std::is_same<DTYPE, uint8_t>());
+
+  std::vector<DTYPE> lookup_table(256, 0);
+  const float scaled_min = (float)(int32_t)dtype_min;
+  const float scaled_max = (float)(int32_t)dtype_max;
+  const float inv_output_scale = 1.0f / output_scale;
+  for (int32_t i = dtype_min, index = 0; i <= dtype_max; i++, index++) {
+    float x = input_scale * (float)(i - input_zero_point);
+    // hardswish, no min/max functions in C
+    float x2 = x + 3.0f;
+    x2 = x2 > 0.0f ? x2 : 0.0f;
+    x2 = x2 < 6.0f ? x2 : 6.0f;
+    x2 = x * x2 / 6.0f;
+    float scaled_hardswish_x = inv_output_scale * x2 + output_zero_point;
+    if (scaled_hardswish_x < scaled_min) {
+      scaled_hardswish_x = scaled_min;
+    }
+    if (scaled_hardswish_x > scaled_max) {
+      scaled_hardswish_x = scaled_max;
+    }
+    lookup_table[index] = static_cast<DTYPE>(lrintf(scaled_hardswish_x));
+  }
+
+  return lookup_table;
+}
+
+template <typename DTYPE>
+void lookup_hardswish_table(
+    const DTYPE* data,
+    const int64_t num_elements,
+    const std::vector<DTYPE> lookup_table,
+    DTYPE* output_data) {
+  int32_t offset = -std::numeric_limits<DTYPE>::min();
+  at::parallel_for(0, num_elements, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; i++) {
+      const size_t index = (static_cast<int32_t>(data[i]) + offset);
+      output_data[i] = lookup_table.at(index);
+    }
+  });
+}
+
+template <typename DTYPE>
+void hardswish_int8(const Tensor& qx, Tensor& qy) {
+  size_t num_elems = qx.numel();
   const auto i_zero_point = qx.q_zero_point();
   const auto i_scale = qx.q_scale();
   const auto o_zero_point = qy.q_zero_point();
   const auto o_scale = qy.q_scale();
-
-  pytorch_qnnp_operator_t hardswish_op{nullptr};
-  const pytorch_qnnp_status createStatus = pytorch_qnnp_create_hardswish_nc_q8(
-    num_elems, // channels
-    i_zero_point,
-    i_scale,
-    o_zero_point,
-    o_scale,
-    std::numeric_limits<uint8_t>::min(), // output min
-    std::numeric_limits<uint8_t>::max(), // output max
-    0, // flags
-    &hardswish_op);
-
-  std::unique_ptr<pytorch_qnnp_operator, QnnpackOperatorDeleter>
-      qnnpack_uniq_ptr(hardswish_op);
-
-  TORCH_INTERNAL_ASSERT(createStatus == pytorch_qnnp_status_success,
-                        "failed to create QNNPACK Hardswish operator");
-
-  const pytorch_qnnp_status setupStatus = pytorch_qnnp_setup_hardswish_nc_q8(
-    hardswish_op,
-    qx.size(0), // batch size
-    (uint8_t*)qx.data_ptr<c10::quint8>(), // input data
-    num_elems, // input stride
-    (uint8_t*)qy.data_ptr<c10::quint8>(), // output data
-    num_elems); // output stride
-  TORCH_INTERNAL_ASSERT(setupStatus == pytorch_qnnp_status_success,
-                        "failed to setup QNNPACK Hardswish operator");
-
-  pthreadpool_t threadpool = caffe2::pthreadpool_();
-
-  const pytorch_qnnp_status runStatus =
-    pytorch_qnnp_run_operator(hardswish_op, threadpool);
-
-  TORCH_INTERNAL_ASSERT(
-    runStatus == pytorch_qnnp_status_success,
-    "failed to run QNNPACK Hardswish operator");
-  return qy;
+  std::vector<typename DTYPE::underlying> lookup_table =
+      create_hswish_lookup_table<typename DTYPE::underlying>(
+          i_zero_point, i_scale, o_zero_point, o_scale);
+  lookup_hardswish_table(
+      (typename DTYPE::underlying*)qx.data_ptr<DTYPE>(), // input data
+      num_elems, // input stride
+      lookup_table,
+      (typename DTYPE::underlying*)qy.data_ptr<DTYPE>()); // output data
 }
-#endif // USE_PYTORCH_QNNPACK
 
-} // namespace
-
-Tensor quantized_hardswish(const Tensor& qx, double output_scale, int64_t output_zero_point) {
+Tensor quantized_hardswish(
+    const Tensor& qx,
+    double output_scale,
+    int64_t output_zero_point) {
   Tensor qy = at::_empty_affine_quantized(
       qx.sizes(),
       at::device(kCPU).dtype(qx.scalar_type()),
@@ -91,16 +105,26 @@ Tensor quantized_hardswish(const Tensor& qx, double output_scale, int64_t output
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
       qx.scalar_type() == kQUInt8) {
     Tensor qx_contig = qx.contiguous(qx.suggest_memory_format());
-    qnnpack_hardswish(qx_contig, qy);
+    hardswish_int8<c10::quint8>(qx_contig, qy);
     return qy;
   }
-#endif  // USE_PYTORCH_QNNPACK
+#endif // USE_PYTORCH_QNNPACK
+  if (qx.scalar_type() == kQInt8) {
+    Tensor qx_contig = qx.contiguous(qx.suggest_memory_format());
+    hardswish_int8<c10::qint8>(qx_contig, qy);
+    return qy;
+  }
   qhardswish_stub(qx.device().type(), qx, qy);
   return qy;
 }
 
+} // namespace
+
 TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
-  m.impl(TORCH_SELECTIVE_NAME("quantized::hardswish"), TORCH_FN(quantized_hardswish));
+  m.impl(
+      TORCH_SELECTIVE_NAME("quantized::hardswish"),
+      TORCH_FN(quantized_hardswish));
 }
 
-}}  // namespace at::native
+}
+} // namespace at::native

--- a/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qhardswish.cpp
@@ -32,9 +32,6 @@ std::vector<DTYPE> create_hswish_lookup_table(
   DTYPE dtype_min = std::numeric_limits<DTYPE>::min();
   DTYPE dtype_max = std::numeric_limits<DTYPE>::max();
 
-  static_assert(
-      std::is_same<DTYPE, int8_t>() || std::is_same<DTYPE, uint8_t>());
-
   std::vector<DTYPE> lookup_table(256, 0);
   const float scaled_min = (float)(int32_t)dtype_min;
   const float scaled_max = (float)(int32_t)dtype_max;
@@ -81,6 +78,11 @@ void hardswish_int8(const Tensor& qx, Tensor& qy) {
   const auto i_scale = qx.q_scale();
   const auto o_zero_point = qy.q_zero_point();
   const auto o_scale = qy.q_scale();
+
+  static_assert(
+      std::is_same<typename DTYPE::underlying, int8_t>() ||
+      std::is_same<typename DTYPE::underlying, uint8_t>());
+
   std::vector<typename DTYPE::underlying> lookup_table =
       create_hswish_lookup_table<typename DTYPE::underlying>(
           i_zero_point, i_scale, o_zero_point, o_scale);
@@ -126,5 +128,5 @@ TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {
       TORCH_FN(quantized_hardswish));
 }
 
-}
-} // namespace at::native
+} // namespace native
+} // namespace at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92005

Vasiliy added quantized hswish in D20965043. It was only for QUInt8 dtype. This
diff adds support for QInt8 with the same lookup table based approach. Core of
the code is copy pasted from the original diff.

This diff combines QUInt8 and QInt8 into single implementation. Folloup diffs
should remove the special op from qnnpack.

Differential Revision: [D42143118](https://our.internmc.facebook.com/intern/diff/D42143118/)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10