### PR TITLE
Preset for oemae_long_attr_win_2d_7d_aux_model

### DIFF
--- a/torch/fx/passes/pass_manager.py
+++ b/torch/fx/passes/pass_manager.py
@@ -210,7 +210,7 @@ class PassManager:
         self.constraints.append(constraint)
         self._validated = False
 
-    def remove_pass(self, _passes: List[Callable]):
+    def remove_pass(self, _passes: List[str]):
         if _passes is None:
             return
         passes_left = []


### PR DESCRIPTION
Summary: The pass fuse_permute_linear fails on the model after updating to TRT 8.5. Create a preset to remove this pass.

Test Plan: Benchmark w/ preset passes

Differential Revision: D42455567

