### PR TITLE
Make ModuleDict derive from MutableMapping[T] and type it appropriately

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -743,8 +743,11 @@ def ignore(drop=False, **kwargs):
     return decorator
 
 
-def _copy_to_script_wrapper(fn):
-    fn._torchscript_modifier = FunctionModifiers.COPY_TO_SCRIPT_WRAPPER
+# Make `_copy_to_script_wrapper` properly pass through types
+F = TypeVar("F")
+
+def _copy_to_script_wrapper(fn: F) -> F:
+    fn._torchscript_modifier = FunctionModifiers.COPY_TO_SCRIPT_WRAPPER  # type: ignore[assignment]
     return fn
 
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -746,8 +746,9 @@ def ignore(drop=False, **kwargs):
 # Make `_copy_to_script_wrapper` properly pass through types
 F = TypeVar("F")
 
+
 def _copy_to_script_wrapper(fn: F) -> F:
-    fn._torchscript_modifier = FunctionModifiers.COPY_TO_SCRIPT_WRAPPER  # type: ignore[assignment]
+    fn._torchscript_modifier = FunctionModifiers.COPY_TO_SCRIPT_WRAPPER  # type: ignore[attr-defined]
     return fn
 
 

--- a/torch/ao/nn/intrinsic/qat/modules/linear_fused.py
+++ b/torch/ao/nn/intrinsic/qat/modules/linear_fused.py
@@ -144,7 +144,8 @@ class LinearBn1d(nn.modules.linear.Linear, nni._FusedModule):
         assert hasattr(mod, 'qconfig'), 'Input float module must have qconfig defined'
         assert mod.qconfig, 'Input float module must have a valid config'
         qconfig = mod.qconfig
-        linear, bn = mod[0], mod[1]
+        linear: nn.modules.linear.Linear = mod[0]
+        bn: nn.modules.batchnorm.BatchNorm1d = mod[1]
         qat_linearbn = cls(linear.in_features, linear.out_features, linear.bias is not None,
                            bn.eps, bn.momentum,
                            False, qconfig)

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -114,6 +114,14 @@ class Sequential(Module):
         idx %= size
         return next(islice(iterator, idx, None))
 
+    @overload
+    def __getitem__(self, idx: int) -> T:
+        ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> 'Sequential':
+        ...
+
     @_copy_to_script_wrapper
     def __getitem__(self, idx: Union[slice, int]) -> Union['Sequential', T]:
         if isinstance(idx, slice):

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -8,7 +8,9 @@ from .module import Module
 from ..parameter import Parameter
 from torch._jit_internal import _copy_to_script_wrapper
 
-from typing import Any, Dict, ItemsView, Iterable, Iterator, Mapping, MutableMapping, Optional, overload, Sequence, Tuple, TypeVar, Union, ValuesView
+from typing import (Any, Dict, ItemsView, Iterable, Iterator, KeysView,
+                    Mapping, MutableMapping, Optional, overload, Sequence,
+                    Tuple, TypeVar, Union, ValuesView)
 
 __all__ = ['Container', 'Sequential', 'ModuleList', 'ModuleDict', 'ParameterList', 'ParameterDict']
 
@@ -502,18 +504,8 @@ class ModuleDict(Module, MutableMapping[str, T]):
         """
         self._modules.clear()
 
-    def pop(self, key: str) -> T:
-        r"""Remove key from the ModuleDict and return its module.
-
-        Args:
-            key (str): key to pop from the ModuleDict
-        """
-        v = self[key]
-        del self[key]
-        return v
-
     @_copy_to_script_wrapper
-    def keys(self) -> Iterable[str]:
+    def keys(self) -> KeysView[str]:
         r"""Return an iterable of the ModuleDict keys.
         """
         return self._modules.keys()

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -8,7 +8,7 @@ from .module import Module
 from ..parameter import Parameter
 from torch._jit_internal import _copy_to_script_wrapper
 
-from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, overload, Sequence, Tuple, TypeVar, Union
+from typing import Any, Dict, ItemsView, Iterable, Iterator, Mapping, MutableMapping, Optional, overload, Sequence, Tuple, TypeVar, Union, ValuesView
 
 __all__ = ['Container', 'Sequential', 'ModuleList', 'ModuleDict', 'ParameterList', 'ParameterDict']
 
@@ -424,7 +424,7 @@ class ModuleList(Module, Sequence[T]):
     # remove forward alltogether to fallback on Module's _forward_unimplemented
 
 
-class ModuleDict(Module):
+class ModuleDict(Module, MutableMapping[str, T]):
     r"""Holds submodules in a dictionary.
 
     :class:`~torch.nn.ModuleDict` can be indexed like a regular Python dictionary,
@@ -468,18 +468,18 @@ class ModuleDict(Module):
                 return x
     """
 
-    _modules: Dict[str, Module]  # type: ignore[assignment]
+    _modules: Dict[str, T]  # type: ignore[assignment]
 
-    def __init__(self, modules: Optional[Mapping[str, Module]] = None) -> None:
+    def __init__(self, modules: Optional[Mapping[str, T]] = None) -> None:
         super(ModuleDict, self).__init__()
         if modules is not None:
             self.update(modules)
 
     @_copy_to_script_wrapper
-    def __getitem__(self, key: str) -> Module:
+    def __getitem__(self, key: str) -> T:
         return self._modules[key]
 
-    def __setitem__(self, key: str, module: Module) -> None:
+    def __setitem__(self, key: str, module: T) -> None:
         self.add_module(key, module)
 
     def __delitem__(self, key: str) -> None:
@@ -494,7 +494,7 @@ class ModuleDict(Module):
         return iter(self._modules)
 
     @_copy_to_script_wrapper
-    def __contains__(self, key: str) -> bool:
+    def __contains__(self, key: Any) -> bool:
         return key in self._modules
 
     def clear(self) -> None:
@@ -502,7 +502,7 @@ class ModuleDict(Module):
         """
         self._modules.clear()
 
-    def pop(self, key: str) -> Module:
+    def pop(self, key: str) -> T:
         r"""Remove key from the ModuleDict and return its module.
 
         Args:
@@ -519,18 +519,18 @@ class ModuleDict(Module):
         return self._modules.keys()
 
     @_copy_to_script_wrapper
-    def items(self) -> Iterable[Tuple[str, Module]]:
+    def items(self) -> ItemsView[str, T]:
         r"""Return an iterable of the ModuleDict key/value pairs.
         """
         return self._modules.items()
 
     @_copy_to_script_wrapper
-    def values(self) -> Iterable[Module]:
+    def values(self) -> ValuesView[T]:
         r"""Return an iterable of the ModuleDict values.
         """
         return self._modules.values()
 
-    def update(self, modules: Mapping[str, Module]) -> None:
+    def update(self, modules: Mapping[str, T]) -> None:
         r"""Update the :class:`~torch.nn.ModuleDict` with the key-value pairs from a
         mapping or an iterable, overwriting existing keys.
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -301,7 +301,8 @@ class ModuleList(Module, Sequence[T]):
         ...
 
     @_copy_to_script_wrapper
-    def __getitem__(self, idx: Union[int, slice]) -> Union[T, 'ModuleList[T]']:
+    # The ignore below is working around a bug: https://github.com/python/mypy/issues/8393
+    def __getitem__(self, idx: Union[int, slice]) -> Union[T, 'ModuleList[T]']:  # type: ignore[override]
         if isinstance(idx, slice):
             return self.__class__(list(self._modules.values())[idx])
         else:

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -9,7 +9,7 @@ from ..parameter import Parameter
 from torch._jit_internal import _copy_to_script_wrapper
 
 from typing import (Any, Dict, ItemsView, Iterable, Iterator, KeysView,
-                    Mapping, MutableMapping, Optional, overload, Sequence,
+                    Mapping, Optional, overload, Sequence,
                     Tuple, TypeVar, Union, ValuesView)
 
 __all__ = ['Container', 'Sequential', 'ModuleList', 'ModuleDict', 'ParameterList', 'ParameterDict']
@@ -425,8 +425,9 @@ class ModuleList(Module, Sequence[T]):
 
     # remove forward alltogether to fallback on Module's _forward_unimplemented
 
-
-class ModuleDict(Module, MutableMapping[str, T]):
+# `Mapping` but not a `MutableMapping` since as currently implemented, the signatures
+# of the mutable methods are incompatible, e.g. `update` acts very differently.
+class ModuleDict(Module, Mapping[str, T]):
     r"""Holds submodules in a dictionary.
 
     :class:`~torch.nn.ModuleDict` can be indexed like a regular Python dictionary,
@@ -503,6 +504,15 @@ class ModuleDict(Module, MutableMapping[str, T]):
         """Remove all items from the ModuleDict.
         """
         self._modules.clear()
+
+    def pop(self, key: str) -> T:
+        r"""Remove key from the ModuleDict and return its module.
+        Args:
+            key (str): key to pop from the ModuleDict
+        """
+        v = self[key]
+        del self[key]
+        return v
 
     @_copy_to_script_wrapper
     def keys(self) -> KeysView[str]:


### PR DESCRIPTION
The ModuleDict version of https://github.com/pytorch/pytorch/pull/89135 (which did this for ModuleList)

Tested with
```
@pytest.mark.mypy_testing
def mypy_test_moduledict() -> None:
    md = torch.nn.ModuleDict({"foo": nn.Linear(10, 10), "bar": nn.Linear(10, 10)})
    reveal_type(md)  # R: torch.nn.modules.container.ModuleDict[torch.nn.modules.linear.Linear]
    reveal_type(md["foo"])  # R: torch.nn.modules.linear.Linear
    # Make sure we know the type of fields on elements in the ModuleList.
    reveal_type(md["foo"].weight)  # R: torch._tensor.Tensor
```