### PR TITLE
Update Module.__setattr__ to respect property setters

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -2,6 +2,7 @@
 
 from itertools import product
 from inspect import signature, isgenerator
+from collections import OrderedDict
 from copy import deepcopy
 import tempfile
 from operator import methodcaller
@@ -714,6 +715,34 @@ class TestModule(TestCase):
                                     "for this ModuleInfo entry.")
                 else:
                     raise e
+
+    def test_setattr_respects_property_setters(self):
+        class Foo(torch.nn.Module):
+            def __init__(self, bar=None):
+                super().__init__()
+                self._bar = bar
+
+            @property
+            def bar(self):
+                return self._bar
+
+            @bar.setter
+            def bar(self, bar):
+                self._bar = bar
+
+        foo = Foo()
+        # Assigning a module with a property setter.
+        module_value = torch.nn.Module()
+        foo.bar = module_value
+        self.assertIs(foo.bar, module_value)
+        self.assertEqual(foo._modules, OrderedDict([("_bar", module_value)]))
+        # Assigning a parameter.
+        param_value = torch.nn.Parameter(torch.ones(2))
+        foo.bar = param_value
+        self.assertIs(foo.bar, param_value)
+        self.assertEqual(foo._parameters, OrderedDict([("_bar", param_value)]))
+        self.assertEqual(foo._modules, OrderedDict())
+
 
 instantiate_device_type_tests(TestModule, globals())
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1592,6 +1592,11 @@ class Module:
             type(self).__name__, name))
 
     def __setattr__(self, name: str, value: Union[Tensor, 'Module']) -> None:
+        # Check if a property setter exists. If it does, use it.
+        class_attr = getattr(self.__class__, name, None)
+        if isinstance(class_attr, property) and class_attr.fset is not None:
+            return class_attr.fset(self, value)
+
         def remove_from(*dicts_or_sets):
             for d in dicts_or_sets:
                 if name in d:


### PR DESCRIPTION
Fixes #52664. Checks if the attribute is a property that defines a setter and uses fset in __setattr__ rather than registering an inaccessible module / parameter.

This is BC-breaking as the attribute setters on nn.Module properties used to be ignored and now will be called properly.

cc @ezyang @gchanan