### PR TITLE
[optim] Improve adadelta foreach, group tensors to maximize fast path

### DIFF
--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -45,4 +45,5 @@ time python test/run_test.py --verbose -i distributed/_shard/test_partial_tensor
 time python test/run_test.py --verbose -i distributed/_shard/test_replicated_tensor
 # Other tests
 time python test/run_test.py --verbose -i test_cuda_primary_ctx
+time python test/run_test.py --verbose -i test_optim -- -k optimizers_with_varying_tensors
 assert_git_not_dirty

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -729,6 +729,7 @@ class TestOptim(TestCase):
                     [0.1, 0.2, 0.3, 0.4, 0.5, 0.6], dtype=torch.float64, device=device
                 ).reshape(3, 2)
 
+                torch.manual_seed(1)
                 model = torch.nn.Sequential(
                     torch.nn.Linear(2, 3),
                     torch.nn.Sigmoid(),


### PR DESCRIPTION
Old behavior would have adadelta foreach sending tensors to the slow path if they were not all the same dtype nor on the same device.

This PR adds grouping for adadelta optimizer so that it would run foreach in batches, allowing more users to benefit from foreach perf.

Of course, we should ensure that the new implementation works, so there are new tests to ensure this behavior is not broken.