### PR TITLE
[cuBLAS][TF32] Fix TF32 get/set test when `TORCH_ALLOW_TF32_CUBLAS_OVERRIDE` is set

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -644,20 +644,24 @@ class TestCuda(TestCase):
         torch.backends.cuda.matmul.allow_tf32 = orig
 
     def test_float32_matmul_precision_get_set(self):
-        self.assertEqual(torch.get_float32_matmul_precision(), 'highest')
+        orig = torch.get_float32_matmul_precision()
         skip_tf32_cublas = 'TORCH_ALLOW_TF32_CUBLAS_OVERRIDE' in os.environ and\
             int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE'])
+        # this is really just checking that the environment variable is respected during testing
+        # and not overwritten by another function that doesn't revert it to the intitial value
         if not skip_tf32_cublas:
             self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
+            self.assertEqual(torch.get_float32_matmul_precision(), 'highest')
+        else:
+            self.assertTrue(torch.backends.cuda.matmul.allow_tf32)
         for p in ('medium', 'high'):
             torch.set_float32_matmul_precision(p)
             self.assertEqual(torch.get_float32_matmul_precision(), p)
-            if not skip_tf32_cublas:
-                self.assertTrue(torch.backends.cuda.matmul.allow_tf32)
+            self.assertTrue(torch.backends.cuda.matmul.allow_tf32)
         torch.set_float32_matmul_precision('highest')
         self.assertEqual(torch.get_float32_matmul_precision(), 'highest')
-        if not skip_tf32_cublas:
-            self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
+        self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
+        torch.set_float32_matmul_precision(orig)
 
     def test_cublas_allow_fp16_reduced_precision_reduction_get_set(self):
         orig = torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction


### PR DESCRIPTION
Follow up of #85859 to fix the test for when the environment variable is set.

CC @xwang233 @ptrblck 