### PR TITLE
Limit the memory and CPU of Bazel build to avoid crashing the runner

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -200,11 +200,12 @@ if [[ "$BUILD_ENVIRONMENT" == *-bazel-* ]]; then
   # OOM error instead of crashing the runner and losing all the logs.
   #
   # Leave 1 CPU free and use only up to 80% of memory
-  BAZEL_LIMIT="--local_ram_resources=HOST_RAM*.8 --local_cpu_resources=HOST_CPUS-1"
+  BAZEL_MEM_LIMIT="--local_ram_resources=HOST_RAM*.8"
+  BAZEL_CPU_LIMIT="--local_cpu_resources=HOST_CPUS-1"
 
-  tools/bazel build --config=no-tty ${BAZEL_LIMIT} //...
+  tools/bazel build --config=no-tty "${BAZEL_MEM_LIMIT}" "${BAZEL_CPU_LIMIT}" //...
   # Build torch, the Python module, and tests for CPU-only
-  tools/bazel build --config=no-tty ${BAZEL_LIMIT} --config=cpu-only :torch :_C.so :all_tests
+  tools/bazel build --config=no-tty "${BAZEL_MEM_LIMIT}" "${BAZEL_CPU_LIMIT}" --config=cpu-only :torch :_C.so :all_tests
 
 else
   # check that setup.py would fail with bad arguments

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -192,9 +192,19 @@ if [[ "$BUILD_ENVIRONMENT" == *-bazel-* ]]; then
 
   get_bazel
 
-  tools/bazel build --config=no-tty //...
+  # Bazel build is run on a linux.2xlarge (or c5.2xlarge) runner with 8 CPU and 16GB of memory.
+  # The build job sometimes fails with 'runner lost communication with the server' flaky error
+  # which indicates that something there crashes the runner process. The most likely reason is
+  # that the build runs out of memory. So trying to follow https://bazel.build/docs/user-manual
+  # to limit the memory the CPU and memory usage, so that we will know even if it crashes with
+  # OOM error instead of crashing the runner and losing all the logs.
+  #
+  # Leave 1 CPU free and use only up to 80% of memory
+  BAZEL_LIMIT="--local_ram_resources=HOST_RAM*.8 --local_cpu_resources=HOST_CPUS-1"
+
+  tools/bazel build --config=no-tty ${BAZEL_LIMIT} //...
   # Build torch, the Python module, and tests for CPU-only
-  tools/bazel build --config=no-tty --config=cpu-only :torch :_C.so :all_tests
+  tools/bazel build --config=no-tty ${BAZEL_LIMIT} --config=cpu-only :torch :_C.so :all_tests
 
 else
   # check that setup.py would fail with bad arguments


### PR DESCRIPTION
I'm seeing quite a number of runner errors "i-NUMBER lost communication with the server. Verify the machine is running and has a healthy network connection. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error" with Bazel build and test job, i.e. https://hud.pytorch.org/hud/pytorch/pytorch/master/1?per_page=50&name_filter=bazel

The job runs on normal `linux.2xlarge` runner.  As the error doesn't occur with any other jobs running on the same type of runner with the exception of XLA.  I suspect that this is due to a resource constraint crashing the runner.  So this PR sets a limit to the amount of memory and CPU and bazel can use.  Even if bazel crashes, i.e. with OOM error, it's still better than crashing the whole runner and losing all the logs.

Example failures:

* https://hud.pytorch.org/pytorch/pytorch/commit/33e3c9ac679d95f28b2486ceea14188caa191d5c