### PR TITLE
fx Graph should copy meta on deepcopy

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -3553,6 +3553,13 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
         self.assertEqual(str(tracer.graph), str(tracer_after.graph))
         self.assertTrue(not hasattr(tracer_before, 'graph') or str(tracer.graph) != str(tracer_before.graph))
 
+    def test_deepcopy_graphmodule(self):
+        m = symbolic_trace(SimpleTest())
+        m.meta['hello'] = 'world'
+        copy_m = copy.deepcopy(m)
+        self.assertEqual(copy_m.meta['hello'], 'world')
+
+
 def run_getitem_target():
     from torch.fx._symbolic_trace import _wrapped_methods_to_patch
     _wrapped_methods_to_patch.append((torch.Tensor, "__getitem__"))

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -706,10 +706,14 @@ class {module_name}(torch.nn.Module):
     def __deepcopy__(self, memo):
         fake_mod = torch.nn.Module()
         fake_mod.__dict__ = copy.deepcopy(self.__dict__)
-        return GraphModule(fake_mod, fake_mod.__dict__['_graph'])
+        res = GraphModule(fake_mod, fake_mod.__dict__['_graph'])
+        res.meta = copy.deepcopy(self.meta)
+        return res
 
     def __copy__(self):
-        return GraphModule(self, self.graph)
+        res = GraphModule(self, self.graph)
+        res.meta = self.meta
+        return res
 
     @compatibility(is_backward_compatible=False)
     def print_readable(self, print_output=True):


### PR DESCRIPTION
Summary:
fx Graph should copy meta on deepcopy

Test Plan:
Unit test

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER
