### PR TITLE
[Dynamo] modify IPEX backend

### DIFF
--- a/test/dynamo/test_optimizations.py
+++ b/test/dynamo/test_optimizations.py
@@ -119,8 +119,7 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
         r1 = model(input)
         for dynamic_shapes in [True, False]:
             torch._dynamo.reset()
-            torch._dynamo.config.dynamic_shapes = dynamic_shapes
-            opt_model = torch._dynamo.optimize("ipex")(model)
+            opt_model = torch._dynamo.optimize("ipex", dynamic=dynamic_shapes)(model)
             with torch.no_grad():
                 for _ in range(3):
                     r2 = opt_model(input)
@@ -136,8 +135,7 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
         r1 = model(input)
         for dynamic_shapes in [True, False]:
             torch._dynamo.reset()
-            torch._dynamo.config.dynamic_shapes = dynamic_shapes
-            opt_model = torch._dynamo.optimize("ipex")(model)
+            opt_model = torch._dynamo.optimize("ipex", dynamic=dynamic_shapes)(model)
             with torch.no_grad(), torch.cpu.amp.autocast():
                 for _ in range(3):
                     r2 = opt_model(input)

--- a/test/dynamo/test_optimizations.py
+++ b/test/dynamo/test_optimizations.py
@@ -7,7 +7,6 @@ import torch
 
 import torch._dynamo
 import torch._dynamo.test_case
-from torch._dynamo.optimizations import backends
 from torch._dynamo.testing import same
 from torch.testing._internal.inductor_utils import HAS_CUDA
 
@@ -118,11 +117,15 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
         model = model.eval()
         input = torch.randn(8, 3, 64, 64).contiguous(memory_format=torch.channels_last)
         r1 = model(input)
-        opt_model = torch._dynamo.optimize(backends.ipex_fp32)(model)
-        with torch.no_grad():
-            r2 = opt_model(input)
-        self.assertTrue(same(r1, r2))
-        self.assertEqual(r2.dtype, torch.float32)
+        for dynamic_shapes in [True, False]:
+            torch._dynamo.reset()
+            torch._dynamo.config.dynamic_shapes = dynamic_shapes
+            opt_model = torch._dynamo.optimize("ipex")(model)
+            with torch.no_grad():
+                for _ in range(3):
+                    r2 = opt_model(input)
+            self.assertTrue(same(r1, r2))
+            self.assertEqual(r2.dtype, torch.float32)
 
     @unittest.skipIf(not has_ipex(), "requires ipex")
     def test_ipex_bf16(self):
@@ -131,11 +134,15 @@ class TestOptimizations(torch._dynamo.test_case.TestCase):
         model = model.eval()
         input = torch.randn(8, 3, 64, 64).contiguous(memory_format=torch.channels_last)
         r1 = model(input)
-        opt_model = torch._dynamo.optimize(backends.ipex_bf16)(model)
-        with torch.no_grad(), torch.cpu.amp.autocast():
-            r2 = opt_model(input)
-        self.assertTrue(same(r1, r2.float(), tol=0.1))
-        self.assertEqual(r2.dtype, torch.bfloat16)
+        for dynamic_shapes in [True, False]:
+            torch._dynamo.reset()
+            torch._dynamo.config.dynamic_shapes = dynamic_shapes
+            opt_model = torch._dynamo.optimize("ipex")(model)
+            with torch.no_grad(), torch.cpu.amp.autocast():
+                for _ in range(3):
+                    r2 = opt_model(input)
+            self.assertTrue(same(r1, r2.float(), tol=0.1))
+            self.assertEqual(r2.dtype, torch.bfloat16)
 
     def _check_backend_works(self, backend):
         model = Seq().eval()

--- a/torch/_dynamo/optimizations/backends.py
+++ b/torch/_dynamo/optimizations/backends.py
@@ -523,7 +523,9 @@ def ipex(subgraph):
     try:
         import intel_extension_for_pytorch  # type: ignore[import]  # noqa: F401
     except ImportError:
-        log.exception("ipex backend fails. Cannot import intel_extension_for_pytorch")
+        log.exception(
+            "Unable to import Intel Extension for PyTorch (IPEX). Please install the right version of IPEX that matches the PyTorch version being used. Refer to https://github.com/intel/intel-extension-for-pytorch for details."
+        )
         raise
 
     from torch.utils._mode_utils import no_dispatch

--- a/torch/_dynamo/optimizations/backends.py
+++ b/torch/_dynamo/optimizations/backends.py
@@ -147,27 +147,6 @@ def onnxrt(subgraph):
         return onnxrt_cpu(subgraph)
 
 
-@create_backend
-def ipex(subgraph, **kwargs):
-    import intel_extension_for_pytorch as ipex  # type: ignore[import]
-
-    inputs = subgraph.example_inputs
-    model = subgraph.model
-    with torch.no_grad():
-        model.eval()
-        if kwargs["datatype"] == "bf16":
-            model = ipex.optimize(model, dtype=torch.bfloat16)
-        else:
-            model = ipex.optimize(model, dtype=torch.float32)
-        try:
-            traced_model = torch.jit.trace(model, inputs).eval()
-            traced_model = torch.jit.freeze(traced_model)
-            return traced_model
-        except Exception:
-            log.warning("JIT trace failed during the 'ipex' optimize process.")
-            return model
-
-
 def _raise_timeout(signum, frame):
     raise TimeoutError()
 
@@ -539,14 +518,35 @@ def tvm_compile_inner(
         return jit_mod  # explicit fall back to eager
 
 
-def ipex_fp32(gm: torch.fx.GraphModule, example_inputs):
-    kwargs_ipex = {"datatype": "fp32"}
-    return ipex(gm, example_inputs, **kwargs_ipex)
+@create_backend
+def ipex(subgraph):
+    import intel_extension_for_pytorch  # type: ignore[import]  # noqa: F401
 
+    from torch.utils._mode_utils import no_dispatch
 
-def ipex_bf16(gm: torch.fx.GraphModule, example_inputs):
-    kwargs_ipex = {"datatype": "bf16"}
-    return ipex(gm, example_inputs, **kwargs_ipex)
+    model = subgraph.model
+    inputs = subgraph.example_inputs
+    with no_dispatch():
+        static_inputs = []
+        for x in inputs:
+            if x._has_symbolic_sizes_strides:
+                size = [s.node.shape_env.size_hint(s.node.expr) for s in x.size()]
+                stride = [s.node.shape_env.size_hint(s.node.expr) for s in x.stride()]
+                static_inputs.append(
+                    torch.as_strided(
+                        torch.zeros(size, dtype=x.dtype, device=x.device), size, stride
+                    )
+                )
+            else:
+                static_inputs.append(torch.zeros_like(x))
+    try:
+        with torch.no_grad():
+            traced_model = torch.jit.trace(model.eval(), static_inputs)
+            traced_model = torch.jit.freeze(traced_model)
+        return traced_model
+    except Exception:
+        log.warning("JIT trace failed during the 'ipex' optimize process.")
+        return model
 
 
 def fx2trt_compiler_fp16(gm: torch.fx.GraphModule, example_inputs):

--- a/torch/_dynamo/optimizations/backends.py
+++ b/torch/_dynamo/optimizations/backends.py
@@ -524,7 +524,9 @@ def ipex(subgraph):
         import intel_extension_for_pytorch  # type: ignore[import]  # noqa: F401
     except ImportError:
         log.exception(
-            "Unable to import Intel Extension for PyTorch (IPEX). Please install the right version of IPEX that matches the PyTorch version being used. Refer to https://github.com/intel/intel-extension-for-pytorch for details."
+            "Unable to import Intel Extension for PyTorch (IPEX). "
+            "Please install the right version of IPEX that matches the PyTorch version being used. "
+            "Refer to https://github.com/intel/intel-extension-for-pytorch for details."
         )
         raise
 

--- a/torch/_dynamo/optimizations/backends.py
+++ b/torch/_dynamo/optimizations/backends.py
@@ -520,7 +520,11 @@ def tvm_compile_inner(
 
 @create_backend
 def ipex(subgraph):
-    import intel_extension_for_pytorch  # type: ignore[import]  # noqa: F401
+    try:
+        import intel_extension_for_pytorch  # type: ignore[import]  # noqa: F401
+    except ImportError:
+        log.exception("ipex backend fails. Cannot import intel_extension_for_pytorch")
+        raise
 
     from torch.utils._mode_utils import no_dispatch
 


### PR DESCRIPTION
1. Combine the two backends ‘ipex_fp32’ and ‘ipex_bf16’ into one backend ‘ipex’.
2. Modify IPEX backend to work in fake mode and symbolic mode.


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @desertfire