### PR TITLE
Reland "AOT Autograd refactor + cleanup, handle intermediate views of bases, use view replay, fix non-tensor input handling"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ log
 usage_log.txt
 test-reports/
 test/*.bak
+test/**/*.bak
 test/.coverage
 test/.hypothesis/
 test/cpp/api/mnist

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -340,8 +340,10 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
                 y = y.t_()
                 return (x + y,)
 
-        x = torch.randn(3, 3, requires_grad=True).clone()
-        y = torch.randn(3, 3, requires_grad=True).clone()
+        x = torch.randn(3, 3, requires_grad=True)
+        x1, x2, x3, x4 = x.clone(), x.clone(), x.clone(), x.clone()
+        y = torch.randn(3, 3, requires_grad=True)
+        y1, y2, y4 = y.clone(), y.clone(), y.clone()
 
         cc = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
 
@@ -352,8 +354,11 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
             failure_reason = failure[0]
 
         fxy = torch._dynamo.optimize(cc, guard_fail_fn=guard_fail_fn)(F())
-        fxy(x, y)
-        fxy(x, y)
+        # Note: to prevent a recompilation between the two calls,
+        # we need to clone x and y on each use.
+        # fxy mutates the input's metadata, so otherwise dynamo will end up recompiling.
+        fxy(x1, y1)
+        fxy(x2, y2)
 
         self.assertTrue(failure_reason is None)
 
@@ -366,23 +371,19 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
         cc = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
 
         fxx = torch._dynamo.optimize(cc, guard_fail_fn=guard_fail_fn)(F())
-        fxx(x, x)
-        fxx(x, y)
+        fxx(x3, x3)
+        fxx(x4, y4)
         self.assertEqual(cc.frame_count, 2)
         self.assertEqual(failure_reason, "x is y")
 
     @patch("torch._functorch.config.debug_assert", True)
-    def test_arg_dupe_via_dynamo_recompiles_many_args(self):
+    def test_arg_metadata_mutation_on_input_causes_recompile(self):
         class F(torch.nn.Module):
-            def forward(self, a, b, c, d):
+            def forward(self, a):
                 a.t_()
-                b.t_()
-                c.t_()
-                d.t_()
-                return (a + b + c + d,)
+                return (a * 2,)
 
         a = torch.randn(3, 3, requires_grad=True).clone()
-        b = torch.randn(3, 3, requires_grad=True).clone()
 
         failure_reason = None
 
@@ -395,8 +396,44 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
         cc = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
 
         f = torch._dynamo.optimize(cc, guard_fail_fn=guard_fail_fn)(F())
-        f(a, a, a, a)
-        f(a, b, b, b)
+        f(a)
+        f(a)
+        self.assertEqual(cc.frame_count, 2)
+        self.assertEqual(
+            failure_reason,
+            "tensor 'a' strides mismatch at index 0. expected 3, actual 1",
+        )
+
+        torch._dynamo.reset()
+
+    @patch("torch._functorch.config.debug_assert", True)
+    def test_arg_dupe_via_dynamo_recompiles_many_args(self):
+        class F(torch.nn.Module):
+            def forward(self, a, b, c, d):
+                a.t_()
+                b.t_()
+                c.t_()
+                d.t_()
+                return (a + b + c + d,)
+
+        a = torch.randn(3, 3, requires_grad=True)
+        b = torch.randn(3, 3, requires_grad=True)
+        a1, a2, a3, a4 = a.clone(), a.clone(), a.clone(), a.clone()
+        b1, b2, b3, b4 = b.clone(), b.clone(), b.clone(), b.clone()
+
+        failure_reason = None
+
+        def guard_fail_fn(failure):
+            nonlocal failure_reason
+            failure_reason = failure[0]
+
+        self.assertTrue(failure_reason is None)
+
+        cc = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
+
+        f = torch._dynamo.optimize(cc, guard_fail_fn=guard_fail_fn)(F())
+        f(a1, a1, a1, a1)
+        f(a2, b2, b2, b2)
         self.assertEqual(cc.frame_count, 2)
         self.assertEqual(failure_reason, "a is b")
 
@@ -404,12 +441,14 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
 
         cc = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
 
-        c = torch.randn(3, 3, requires_grad=True).clone()
-        d = torch.randn(3, 3, requires_grad=True).clone()
+        c = torch.randn(3, 3, requires_grad=True)
+        d = torch.randn(3, 3, requires_grad=True)
+        c3, c4 = c.clone(), c.clone()
+        d3, d4 = d.clone(), d.clone()
 
         f = torch._dynamo.optimize(cc, guard_fail_fn=guard_fail_fn)(F())
-        f(a, b, c, c)
-        f(a, b, c, d)
+        f(a3, b3, c3, c3)
+        f(a4, b4, c4, d4)
         self.assertEqual(cc.frame_count, 2)
         self.assertEqual(failure_reason, "c is d")
 

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -243,6 +243,7 @@ class TestPythonKey(AOTTestCase):
         grads2 = [a.grad for a in mod.parameters()]
         self.assertEqual(grads, grads2)
 
+
 class TestAOTAutograd(AOTTestCase):
     # test_mutation will:
     # - Ensure that inputs are non-leaves, so our graphs can mutate them
@@ -253,7 +254,6 @@ class TestAOTAutograd(AOTTestCase):
         inp: Union[Callable, List[Any]],
         *,
         test_mutation: bool = False,
-        return_fw_graph: bool = False,
         decompositions: Optional[Dict] = None,
     ):
         # Some tests pass in a callable for inp, to generate the inputs
@@ -275,9 +275,12 @@ class TestAOTAutograd(AOTTestCase):
                     inp_copy.append(inp_copy[x_dupe_idx])
                 else:
                     dupes_map[x] = i
-                    x_copy = x.clone().detach().requires_grad_(x.requires_grad)
-                    if x.requires_grad and not x.is_leaf:
-                        x_copy = x_copy.clone()
+                    if not isinstance(x, torch.Tensor):
+                        x_copy = x
+                    else:
+                        x_copy = x.clone().detach().requires_grad_(x.requires_grad)
+                        if x.requires_grad and not x.is_leaf:
+                            x_copy = x_copy.clone()
                     inp_copy.append(x_copy)
 
             if test_mutation:
@@ -322,9 +325,15 @@ class TestAOTAutograd(AOTTestCase):
         for ref_i, test_i in zip(inp, inp_copy):
             if isinstance(ref_i, torch.Tensor):
                 self.assertEqual(ref_i.requires_grad, test_i.requires_grad)
-                self.assertEqual(ref_i, test_i)
-        if return_fw_graph:
-            return fw_graph_cell[0]
+            self.assertEqual(ref_i, test_i)
+        return fw_graph_cell[0]
+
+    def test_non_tensor_and_none_inputs(self):
+        # int, None, Tensor
+        def f(a, b, c):
+            return a * c
+        inp = [2, None, torch.ones(3, 3, dtype=torch.float32, requires_grad=True)]
+        self.verify_aot_autograd(f, inp)
 
     def test_single_output(self):
         def f(a, b):
@@ -374,13 +383,14 @@ class TestAOTAutograd(AOTTestCase):
         y = torch.arange(3)
         self.verify_aot_autograd(F(), [x, y])
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_simple(self):
         def f(a):
             a.mul_(2)
             return a * 3
         inp = [torch.ones(3, 3, requires_grad=True)]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         # Things to note:
         # - the extra clone is because we need to pass the pre-mutated input to grad(),
         #   but autograd operates above functionalization so we need to manually clone.
@@ -404,19 +414,21 @@ def forward(self, primals_1):
         out_test = f_compiled(*inp)
         self.assertEqual(out_ref, out_test)
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_is_output(self):
         def f(a):
             a.mul_(2)
             return a
         inp = [torch.ones(3, 3, requires_grad=True)]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     mul = torch.ops.aten.mul.Tensor(clone, 2);  clone = None
-    return [mul]""")
+    return [mul, mul]""")
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_multiple(self):
         def f(a, b, c):
             a.mul_(2)
@@ -429,7 +441,7 @@ def forward(self, primals_1):
             torch.ones(3, 3, requires_grad=True),
         ]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1, primals_2, primals_3):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
@@ -440,6 +452,7 @@ def forward(self, primals_1, primals_2, primals_3):
     add_1 = torch.ops.aten.add.Tensor(add, mul_1);  add = None
     return [mul, mul_1, add_1]""")
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_metadata(self):
         def f(a, b):
             a.transpose_(1, 0)
@@ -449,8 +462,9 @@ def forward(self, primals_1, primals_2, primals_3):
             torch.ones(3, 3, requires_grad=True),
         ]
 
-        self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        self.verify_aot_autograd(f, inp, test_mutation=True)
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_metadata2(self):
         def f(a):
             a.transpose_(1, 0)
@@ -458,8 +472,9 @@ def forward(self, primals_1, primals_2, primals_3):
             return a + 1
         inp = [torch.ones(3, 3, requires_grad=True)]
 
-        self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        self.verify_aot_autograd(f, inp, test_mutation=True)
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_resize_smaller(self):
         def f(a, b):
             a.resize_(2, 2)
@@ -470,8 +485,9 @@ def forward(self, primals_1, primals_2, primals_3):
             torch.ones(2, 2, requires_grad=True),
         ]
 
-        self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        self.verify_aot_autograd(f, inp, test_mutation=True)
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_batchnorm(self):
         def f(inpt, weight, bias, running_mean, running_var):
             # This is additionally a good test, because the input tensors that we mutate
@@ -493,8 +509,9 @@ def forward(self, primals_1, primals_2, primals_3):
             torch.ops.aten._native_batch_norm_legit_functional,
             torch.ops.aten.native_batch_norm_backward,
         ])
-        self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True, decompositions=decompositions)
+        self.verify_aot_autograd(f, inp, test_mutation=True, decompositions=decompositions)
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_output_view_simple(self):
         def f(a):
             return a.view(-1)
@@ -502,12 +519,14 @@ def forward(self, primals_1, primals_2, primals_3):
             torch.ones(2, 2, requires_grad=True).add(1),
         ]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         # Outputs that alias inputs are pulled out of the graph entirely, so we don't compile anything here
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1):
-    return [4, 1, 0]""")
+    view = torch.ops.aten.view.default(primals_1, [-1]);  primals_1 = None
+    return [view]""")
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_output_view_mutate_multiple(self):
         def f(a, b, c):
             a.mul_(2)
@@ -519,7 +538,7 @@ def forward(self, primals_1):
             torch.ones(2, 2, requires_grad=True).add(1),
         ]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         # The original function returned two outputs, both of which aliased inputs.
         # We expect two outputs in the functional graph, a_updated and c_updated.
         # The actual aliased outputs themselves aren't in the compiled forward graph;
@@ -530,8 +549,11 @@ def forward(self, primals_1, primals_2, primals_3):
     clone_1 = torch.ops.aten.clone.default(primals_3);  primals_3 = None
     mul = torch.ops.aten.mul.Tensor(clone, 2);  clone = None
     mul_1 = torch.ops.aten.mul.Tensor(clone_1, 3);  clone_1 = None
-    return [mul, mul_1, 2, 2, 2, 1, 0, 2, 2, 2, 1, 0]""")
+    view = torch.ops.aten.view.default(primals_2, [2, 2]);  primals_2 = None
+    view_2 = torch.ops.aten.view.default(mul_1, [2, 2])
+    return [mul, mul_1, view, view_2]""")
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_output_view_metadata_mutate_multiple(self):
         def f(a, b, c):
             b.mul_(3)
@@ -543,7 +565,7 @@ def forward(self, primals_1, primals_2, primals_3):
             torch.ones(2, 2, requires_grad=True).add(1),
         ]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         # Important thing to check here: of the three inputs:
         # Only the b.mul_(3) should show up in the graph (we functionalize it and return it).
         # Everything else that does not show up in the graph includes:
@@ -552,9 +574,15 @@ def forward(self, primals_1, primals_2, primals_3):
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1, primals_2, primals_3):
     clone = torch.ops.aten.clone.default(primals_2);  primals_2 = None
+    view = torch.ops.aten.view.default(primals_3, [2, 2]);  primals_3 = None
     mul = torch.ops.aten.mul.Tensor(clone, 3);  clone = None
-    return [mul, 2, 2, 1, 2, 0, 2, 2, 2, 1, 0, 2, 2, 2, 1, 0, 2, 2, 1, 2, 0]""")
+    t = torch.ops.aten.t.default(view);  view = None
+    view_1 = torch.ops.aten.view.default(primals_1, [2, 2]);  primals_1 = None
+    view_3 = torch.ops.aten.view.default(t, [2, 2])
+    view_4 = torch.ops.aten.view.default(mul, [2, 2])
+    return [mul, t, view_1, view_4, view_3]""")
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_and_output_view(self):
         def f(a):
             a.add_(1)
@@ -563,7 +591,7 @@ def forward(self, primals_1, primals_2, primals_3):
             torch.ones(2, 2, requires_grad=True).add(1),
         ]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         # Here, total # of outputs is 1 because:
         # - num_mutated_inps = 1 (a_updated)
         # - num_fw_outputs = 0 (the output is an alias of the input, so we move it outside the compiled fw)
@@ -571,9 +599,11 @@ def forward(self, primals_1, primals_2, primals_3):
 def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
     add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
-    return [add, 4, 1, 0]""")
+    view_1 = torch.ops.aten.view.default(add, [-1])
+    return [add, view_1]""")
 
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_output_view_multiple(self):
         def f(a, b, c, d):
             b.transpose_(1, 0)
@@ -586,16 +616,221 @@ def forward(self, primals_1):
             torch.ones(2, 2, requires_grad=True).add(1),
         ]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1, primals_2, primals_3, primals_4):
+    view = torch.ops.aten.view.default(primals_2, [2, 2]);  primals_2 = None
     clone = torch.ops.aten.clone.default(primals_3);  primals_3 = None
+    transpose = torch.ops.aten.transpose.int(view, 1, 0);  view = None
     add = torch.ops.aten.add.Tensor(clone, 1);  clone = None
     add_1 = torch.ops.aten.add.Tensor(primals_4, 1);  primals_4 = None
+    diagonal = torch.ops.aten.diagonal.default(transpose)
     add_2 = torch.ops.aten.add.Tensor(primals_1, add);  primals_1 = None
-    return [add, add_1, add_2, 2, 2, 1, 2, 0, 2, 3, 0]""")
+    return [transpose, add, add_1, diagonal, add_2]""")
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_single(self):
+        def f(a):
+            out = torch.mul(a, 3)
+            return out.view(-1)
+        inp = [torch.ones(3, 3, requires_grad=True)]
+
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
+        # In AOTAutograd, we are obligated to make the compiled forward directly return `out`,
+        # and reconstruct `out.view(-1)` as a fresh output.
+        self.assertExpectedInline(fw_graph.code.strip(), """\
+def forward(self, primals_1):
+    mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
+    view = torch.ops.aten.view.default(mul, [-1])
+    return [view, mul]""")
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_no_grad(self):
+        def f(a, b):
+            out = torch.mul(a, 3)
+            # First output is an alias of an intermediate that doesn't require grad
+            return out.view(-1), b.add(1)
+        inp = [torch.ones(3, 3), torch.ones(3, 3, requires_grad=True)]
+
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
+        # important bit: we don't bother generating an intermediate base as an output in the graph,
+        # because the intermediate base itself didn't require gradients.
+        # (the only problematic case is when both the base and the aliasesed output require gradients).
+        self.assertExpectedInline(fw_graph.code.strip(), """\
+def forward(self, primals_1, primals_2):
+    mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
+    view = torch.ops.aten.view.default(mul, [-1]);  mul = None
+    add = torch.ops.aten.add.Tensor(primals_2, 1);  primals_2 = None
+    return [view, add]""")
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_returned_multiple_times(self):
+        def f(a):
+            out = torch.mul(a, 3)
+            out_view = out.view(-1)
+            return out, out_view, out
+        inp = [torch.ones(3, 3, requires_grad=True)]
+
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_multiple(self):
+        def f(a):
+            out = torch.mul(a, 3)
+            # AOTAutograd should manually generate these two output views in the epilogue.
+            return out.view(-1), out.view(-1)
+        inp = [torch.ones(3, 3, requires_grad=True)]
+
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
+        self.assertExpectedInline(fw_graph.code.strip(), """\
+def forward(self, primals_1):
+    mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
+    view = torch.ops.aten.view.default(mul, [-1])
+    view_1 = torch.ops.aten.view.default(mul, [-1])
+    return [view, view_1, mul]""")
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_and_returned(self):
+        def f(a):
+            out = torch.mul(a, 3)
+            # AOTAutograd should manually generate the first output (a view of an intermediate)
+            # but not the second (which is itself the intermediate for the first)
+            return out.view(-1), out
+        inp = [torch.ones(3, 3, requires_grad=True)]
+
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
+        self.assertExpectedInline(fw_graph.code.strip(), """\
+def forward(self, primals_1):
+    mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
+    view = torch.ops.aten.view.default(mul, [-1])
+    return [view, mul]""")
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_and_returned_flipped(self):
+        def f(a):
+            out = torch.mul(a, 3)
+            # AOTAutograd should manually generate the first output (a view of an intermediate)
+            # but not the second (which is itself the intermediate for the first)
+            return out, out.view(-1)
+        inp = [torch.ones(3, 3, requires_grad=True)]
+
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
+        self.assertExpectedInline(fw_graph.code.strip(), """\
+def forward(self, primals_1):
+    mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
+    view = torch.ops.aten.view.default(mul, [-1])
+    return [mul, view]""")
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_and_returned_different_grad(self):
+        def f(a):
+            out = torch.mul(a, 3)
+            # AOTAutograd should manually generate the first output (a view of an intermediate)
+            # but not the second (which is itself the intermediate for the first)
+            return out.view(-1), out, out[0].detach()
+        inp = [torch.ones(3, 3, requires_grad=True)]
+
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
+        self.assertExpectedInline(fw_graph.code.strip(), """\
+def forward(self, primals_1):
+    mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
+    view = torch.ops.aten.view.default(mul, [-1])
+    select = torch.ops.aten.select.int(mul, 0, 0)
+    detach = torch.ops.aten.detach.default(select);  select = None
+    return [view, mul, detach]""")
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_inplace_view(self):
+        def f(a):
+            out = torch.mul(a, 3)
+            out.t_()
+            return out
+        inp = [torch.ones(2, 4, requires_grad=True)]
+
+        # TODO: fix this test.
+        # See <github issue link>
+        # self.verify_aot_autograd(f, inp, test_mutation=True)
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_inplace_view_with_detach(self):
+        def f(a):
+            out = torch.mul(a, 3)
+            out.t_()
+            out.detach_()
+            # Thanks to the detach_() AOT Autograd doesn't need to do anything.
+            # `out` will show up as having OutputType.non_alias,
+            # and ._is_view() == False
+            return out
+        inp = [torch.ones(2, 4, requires_grad=True)]
+
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
+        self.assertExpectedInline(fw_graph.code.strip(), """\
+def forward(self, primals_1):
+    mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
+    t = torch.ops.aten.t.default(mul);  mul = None
+    return [t]""")
 
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_inplace_view_and_view(self):
+        def f(a):
+            out = torch.mul(a, 3)
+            out_view = out.unsqueeze(0)
+            out.t_()
+            out_view2 = out.unsqueeze(0)
+            return out_view, out, out_view2
+        inp = [torch.ones(2, 4, requires_grad=True)]
+
+        # TODO: fix this test.
+        # See <github issue link>
+        # self.verify_aot_autograd(f, inp, test_mutation=True)
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_intermediate_multiple_mixed(self):
+        def f(a):
+            out1 = torch.mul(a, 3)
+            out2 = torch.mul(a, 4)
+            # AOTAutograd should manually generate these two output views in the epilogue.
+            return out1.view(-1), out2.transpose(1, 0), out1.transpose(1, 0)
+        inp = [torch.ones(3, 3, requires_grad=True)]
+
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
+        self.assertExpectedInline(fw_graph.code.strip(), """\
+def forward(self, primals_1):
+    mul = torch.ops.aten.mul.Tensor(primals_1, 3)
+    mul_1 = torch.ops.aten.mul.Tensor(primals_1, 4);  primals_1 = None
+    view = torch.ops.aten.view.default(mul, [-1])
+    transpose = torch.ops.aten.transpose.int(mul_1, 1, 0)
+    transpose_1 = torch.ops.aten.transpose.int(mul, 1, 0)
+    return [view, transpose, transpose_1, mul, mul_1]""")
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_all_alias_types(self):
+        # There are 3 types of aliasing that require us to return metadata in the compiled fw:
+        # (1) outputs that are views of inputs
+        # (2) outputs that are views of intermediates
+        # (3) inputs that get metadata mutations
+        # test all 3 of them here
+        def f(a):
+            a.transpose_(1, 0)
+            tmp = a.mul(2)
+            return tmp.squeeze(), tmp.transpose(1, 0), a.unsqueeze(0)
+        inp = [torch.ones(1, 2, 4, requires_grad=True)]
+
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
+        # TODO: make this test run with dynamic shapes so it is more meaningful
+        # metadata output order: (a_updated_meta, out1_meta, out2_meta, out3_meta)
+        self.assertExpectedInline(fw_graph.code.strip(), """\
+def forward(self, primals_1):
+    view = torch.ops.aten.view.default(primals_1, [1, 2, 4]);  primals_1 = None
+    transpose = torch.ops.aten.transpose.int(view, 1, 0);  view = None
+    mul = torch.ops.aten.mul.Tensor(transpose, 2)
+    squeeze = torch.ops.aten.squeeze.default(mul)
+    transpose_1 = torch.ops.aten.transpose.int(mul, 1, 0)
+    unsqueeze = torch.ops.aten.unsqueeze.default(transpose, 0)
+    return [transpose, squeeze, transpose_1, unsqueeze, mul]""")
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_data_and_metadata_mutation(self):
         def f(a):
             a.t_()
@@ -603,7 +838,7 @@ def forward(self, primals_1, primals_2, primals_3, primals_4):
             return a.view(a.shape)
         inp = [torch.ones(3, 3, requires_grad=True)]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
@@ -613,9 +848,12 @@ def forward(self, primals_1):
     t_1 = torch.ops.aten.t.default(clone);  clone = None
     select_scatter = torch.ops.aten.select_scatter.default(t_1, mul, 0, 0);  t_1 = mul = None
     t_2 = torch.ops.aten.t.default(select_scatter);  select_scatter = None
-    t_4 = torch.ops.aten.t.default(t_2);  t_2 = None
-    return [t_4, 3, 3, 1, 3, 0]""")
+    t_4 = torch.ops.aten.t.default(t_2)
+    t_6 = torch.ops.aten.t.default(t_2);  t_2 = None
+    view_1 = torch.ops.aten.view.default(t_6, [3, 3]);  t_6 = None
+    return [t_4, view_1]""")
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_view_and_inplace_view(self):
         def f(a, b):
             a.t_()
@@ -625,11 +863,16 @@ def forward(self, primals_1):
             torch.ones(3, 3, requires_grad=True)
         ]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1, primals_2):
-    return [3, 3, 1, 3, 0, 3, 3, 3, 1, 0, 3, 3, 1, 3, 0]""")
+    view = torch.ops.aten.view.default(primals_1, [3, 3]);  primals_1 = None
+    t = torch.ops.aten.t.default(view);  view = None
+    view_1 = torch.ops.aten.view.default(primals_2, [3, 3]);  primals_2 = None
+    view_2 = torch.ops.aten.view.default(t, [3, 3])
+    return [t, view_1, view_2]""")
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_view_detach(self):
         def f(a):
             tmp = a.detach()
@@ -639,8 +882,9 @@ def forward(self, primals_1, primals_2):
             torch.ones(3, 3, requires_grad=True),
         ]
 
-        self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        self.verify_aot_autograd(f, inp, test_mutation=True)
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_inplace_requires_grad_true(self):
         def f(a, b):
             a.requires_grad_(True)
@@ -651,45 +895,54 @@ def forward(self, primals_1, primals_2):
             torch.ones(3, 3, requires_grad=True),
         ]
 
-        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp, test_mutation=True)
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1, primals_2):
     mul = torch.ops.aten.mul.Tensor(primals_1, 3);  primals_1 = None
     mul_1 = torch.ops.aten.mul.Tensor(primals_2, 4);  primals_2 = None
     return [mul, mul_1]""")
 
+    # This is a torture test:
+    # a and b get turned into a synthetic base in the compiled graph
+    # One gets a data mutation, the other gets a metadata mutation.
+    # We need to make sure that the metadata mutation gets propagated
+    # back to the original input.
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_data_and_metadata_mutation_aliases_other_input(self):
         # a and b are aliased
         def f(a, b):
-            a.t_()
-            b.mul_(2)
-            return a.mul(3)
+            a.mul_(2)
+            b.t_()
+            return a.mul(b)
 
         def inp_callable():
             base = torch.ones(2, 2, requires_grad=True)
             # Note: in our test, the add() is important because we need the graph inputs to be non-leaves so we can mutate them.
             x = base.add(1)
-            inp1 = x.view(-1)
-            inp2 = x.view(-1)
+            inp1 = x[0]
+            inp2 = x[1]
             return [base], [inp1, inp2]
 
-        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True, return_fw_graph=True)
-        # Important parts of the graph:
-        # - the compiled graph takes in a base, and we generate a and b (the views) off of the base
-        # - clone() is still in the graph, because we need to call grad() on the original (non-mutated) inputs
-        # - We re-generate the views *after* the clone, to preserve view relationships.
-        self.assertExpectedInline(fw_graph.code.strip(), """\
-def forward(self, primals_1):
-    clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
-    as_strided_1 = torch.ops.aten.as_strided.default(clone, [4], [1], 0)
-    mul = torch.ops.aten.mul.Tensor(as_strided_1, 2);  as_strided_1 = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, mul, [4], [1], 0);  clone = mul = None
-    as_strided_3 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
-    as_strided_6 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0);  as_strided_scatter = None
-    t_1 = torch.ops.aten.t.default(as_strided_6);  as_strided_6 = None
-    mul_1 = torch.ops.aten.mul.Tensor(t_1, 3);  t_1 = None
-    return [as_strided_3, mul_1, 4, 1, 0]""")
+        self.verify_aot_autograd(f, inp_callable, test_mutation=True)
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
+    def test_output_aliases_multiple_inputs_get_correct_one(self):
+        # a and b are aliased, but have different shapes
+        # The first output should view off the the first input, the 2nd output should view off the 2nd input
+        def f(a, b):
+            return a.view(a.shape), b.view(b.shape)
+
+        def inp_callable():
+            base = torch.ones(2, 2, requires_grad=True)
+            # Note: in our test, the add() is important because we need the graph inputs to be non-leaves so we can mutate them.
+            x = base.mul(2)
+            inp1 = x.view(-1)
+            inp2 = x[0]
+            return [base], [inp1, inp2]
+
+        self.verify_aot_autograd(f, inp_callable, test_mutation=True)
+
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_aliases_other_input(self):
         def f(a, b):
             a.add_(1)
@@ -703,7 +956,7 @@ def forward(self, primals_1):
             inp2 = x[1]
             return [base], [inp1, inp2]
 
-        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True)
         # Important parts of the graph:
         # - the compiled graph takes in a base, and we generate a and b (the views) off of the base
         # - clone() is still in the graph, because we need to call grad() on the original (non-mutated) inputs
@@ -711,14 +964,20 @@ def forward(self, primals_1):
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
-    as_strided = torch.ops.aten.as_strided.default(clone, [2], [1], 0)
-    add = torch.ops.aten.add.Tensor(as_strided, 1);  as_strided = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [2], [1], 0);  clone = add = None
-    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
-    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 2);  as_strided_scatter = None
-    add_1 = torch.ops.aten.add.Tensor(as_strided_2, as_strided_5);  as_strided_5 = None
-    return [as_strided_2, add_1]""")
+    as_strided = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_1 = torch.ops.aten.as_strided.default(as_strided, [2], [1], 0);  as_strided = None
+    add = torch.ops.aten.add.Tensor(as_strided_1, 1);  as_strided_1 = None
+    as_strided_4 = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(as_strided_4, add, [2], [1], 0);  as_strided_4 = add = None
+    as_strided_scatter_1 = torch.ops.aten.as_strided_scatter.default(clone, as_strided_scatter, [2, 2], [2, 1], 0);  clone = as_strided_scatter = None
+    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0)
+    as_strided_6 = torch.ops.aten.as_strided.default(as_strided_5, [2], [1], 0);  as_strided_5 = None
+    as_strided_11 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0);  as_strided_scatter_1 = None
+    as_strided_12 = torch.ops.aten.as_strided.default(as_strided_11, [2], [1], 2);  as_strided_11 = None
+    add_1 = torch.ops.aten.add.Tensor(as_strided_6, as_strided_12);  as_strided_12 = None
+    return [as_strided_6, add_1]""")  # noqa: B950
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_aliases_other_input2(self):
         def f(a, b):
             a.add_(1)
@@ -732,23 +991,27 @@ def forward(self, primals_1):
             inp2 = x
             return [base], [inp1, inp2]
 
-        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True)
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
-    as_strided = torch.ops.aten.as_strided.default(clone, [2], [1], 0)
-    add = torch.ops.aten.add.Tensor(as_strided, 1);  as_strided = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [2], [1], 0);  clone = add = None
-    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [2], [1], 0)
-    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [2, 2], [2, 1], 0);  as_strided_scatter = None
-    add_1 = torch.ops.aten.add.Tensor(as_strided_2, as_strided_5);  as_strided_5 = None
-    return [as_strided_2, add_1]""")
+    as_strided = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_1 = torch.ops.aten.as_strided.default(as_strided, [2], [1], 0);  as_strided = None
+    add = torch.ops.aten.add.Tensor(as_strided_1, 1);  as_strided_1 = None
+    as_strided_3 = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(as_strided_3, add, [2], [1], 0);  as_strided_3 = add = None
+    as_strided_scatter_1 = torch.ops.aten.as_strided_scatter.default(clone, as_strided_scatter, [2, 2], [2, 1], 0);  clone = as_strided_scatter = None
+    as_strided_4 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0)
+    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_4, [2], [1], 0);  as_strided_4 = None
+    as_strided_9 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0);  as_strided_scatter_1 = None
+    add_1 = torch.ops.aten.add.Tensor(as_strided_5, as_strided_9);  as_strided_9 = None
+    return [as_strided_5, add_1]""")  # noqa: B950
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_aliases_and_output_alias(self):
         def f(a, b):
             # Here, we need to take care:that because and b are aliased
-            # (1) since a and b are aliased, we generate a view off of "updated b"
-            # (2) We're returning a view, which doesn't show up in the graph
+            # since a and b are aliased, we generate a view off of "updated b"
             a.add_(1)
             return b.view(b.shape)
 
@@ -757,16 +1020,24 @@ def forward(self, primals_1):
             x = base.add(1)
             return [base], [x.view(-1), x.view(-1)]
 
-        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True)
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
-    as_strided = torch.ops.aten.as_strided.default(clone, [4], [1], 0)
-    add = torch.ops.aten.add.Tensor(as_strided, 1);  as_strided = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [4], [1], 0);  clone = add = None
-    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0);  as_strided_scatter = None
-    return [as_strided_2, 4, 1, 0]""")
+    as_strided = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_1 = torch.ops.aten.as_strided.default(as_strided, [4], [1], 0);  as_strided = None
+    add = torch.ops.aten.add.Tensor(as_strided_1, 1);  as_strided_1 = None
+    as_strided_4 = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(as_strided_4, add, [4], [1], 0);  as_strided_4 = add = None
+    as_strided_scatter_1 = torch.ops.aten.as_strided_scatter.default(clone, as_strided_scatter, [2, 2], [2, 1], 0);  clone = as_strided_scatter = None
+    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0)
+    as_strided_6 = torch.ops.aten.as_strided.default(as_strided_5, [4], [1], 0);  as_strided_5 = None
+    as_strided_28 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0);  as_strided_scatter_1 = None
+    as_strided_29 = torch.ops.aten.as_strided.default(as_strided_28, [4], [1], 0);  as_strided_28 = None
+    view_1 = torch.ops.aten.view.default(as_strided_29, [4]);  as_strided_29 = None
+    return [as_strided_6, view_1]""")  # noqa: B950
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_aliased_with_mutation_output_alias(self):
         def f(a, b, c):
             # a and c alias
@@ -784,17 +1055,25 @@ def forward(self, primals_1):
             y = base2.add(1)
             return [base1, base2], [x.view(-1), y, x.view(-1)]
 
-        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True)
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1, primals_2):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
-    as_strided_1 = torch.ops.aten.as_strided.default(clone, [4], [1], 0)
-    mul = torch.ops.aten.mul.Tensor(as_strided_1, 2);  as_strided_1 = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, mul, [4], [1], 0);  clone = mul = None
-    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0);  as_strided_scatter = None
+    as_strided_2 = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_3 = torch.ops.aten.as_strided.default(as_strided_2, [4], [1], 0);  as_strided_2 = None
+    mul = torch.ops.aten.mul.Tensor(as_strided_3, 2);  as_strided_3 = None
+    as_strided_4 = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(as_strided_4, mul, [4], [1], 0);  as_strided_4 = mul = None
+    as_strided_scatter_1 = torch.ops.aten.as_strided_scatter.default(clone, as_strided_scatter, [2, 2], [2, 1], 0);  clone = as_strided_scatter = None
+    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0)
+    as_strided_6 = torch.ops.aten.as_strided.default(as_strided_5, [4], [1], 0);  as_strided_5 = None
     add = torch.ops.aten.add.Tensor(primals_2, 1);  primals_2 = None
-    return [as_strided_2, add, 4, 1, 0]""")
+    as_strided_26 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0);  as_strided_scatter_1 = None
+    as_strided_27 = torch.ops.aten.as_strided.default(as_strided_26, [4], [1], 0);  as_strided_26 = None
+    view_1 = torch.ops.aten.view.default(as_strided_27, [-1]);  as_strided_27 = None
+    return [as_strided_6, add, view_1]""")  # noqa: B950
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_metadata_mutation_aliases(self):
         def f(a, b):
             # a and b alias, and we do a metadata mutation on a
@@ -808,15 +1087,16 @@ def forward(self, primals_1, primals_2):
             x = base.add(1)
             return [base], [x.view(-1), x.view(-1)]
 
-        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True)
         # Expectation: fwd() takes in 2 args, and we don't construct a synthetic base.
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1, primals_2):
     view = torch.ops.aten.view.default(primals_1, [4]);  primals_1 = None
     t = torch.ops.aten.t.default(view);  view = None
-    add = torch.ops.aten.add.Tensor(t, primals_2);  t = primals_2 = None
-    return [add, 4, 1, 0]""")
+    add = torch.ops.aten.add.Tensor(t, primals_2);  primals_2 = None
+    return [t, add]""")
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_aliases_and_none_require_gradients(self):
         def f(a, b, c):
             # a and b alias, but neither require gradients (so they don't have a _base)
@@ -830,19 +1110,25 @@ def forward(self, primals_1, primals_2):
             x = base.add(1)
             return [base, c_arg], [x.view(-1), x.view(-1), c_arg]
 
-        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True)
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1, primals_2):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
-    as_strided = torch.ops.aten.as_strided.default(clone, [4], [1], 0)
-    mul = torch.ops.aten.mul.Tensor(as_strided, 2);  as_strided = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, mul, [4], [1], 0);  clone = mul = None
-    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
-    as_strided_3 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0);  as_strided_scatter = None
-    add = torch.ops.aten.add.Tensor(as_strided_3, 1);  as_strided_3 = None
+    as_strided = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_1 = torch.ops.aten.as_strided.default(as_strided, [4], [1], 0);  as_strided = None
+    mul = torch.ops.aten.mul.Tensor(as_strided_1, 2);  as_strided_1 = None
+    as_strided_4 = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(as_strided_4, mul, [4], [1], 0);  as_strided_4 = mul = None
+    as_strided_scatter_1 = torch.ops.aten.as_strided_scatter.default(clone, as_strided_scatter, [2, 2], [2, 1], 0);  clone = as_strided_scatter = None
+    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0)
+    as_strided_6 = torch.ops.aten.as_strided.default(as_strided_5, [4], [1], 0);  as_strided_5 = None
+    as_strided_7 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0);  as_strided_scatter_1 = None
+    as_strided_8 = torch.ops.aten.as_strided.default(as_strided_7, [4], [1], 0);  as_strided_7 = None
+    add = torch.ops.aten.add.Tensor(as_strided_8, 1);  as_strided_8 = None
     add_1 = torch.ops.aten.add.Tensor(primals_2, 1);  primals_2 = None
-    return [as_strided_2, add, add_1]""")
+    return [as_strided_6, add, add_1]""")  # noqa: B950
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_aliases_bases_out_of_order(self):
         # This tests our calling convention: if b and d are aliased, then the outer calling convention
         # that we send to the compiled forward becomes:
@@ -862,7 +1148,7 @@ def forward(self, primals_1, primals_2):
             # a and c alias, b and d alias
             return [base1, base2], [x1.view(-1), x2.view(-1), x1.view(-1), x2.view(-1)]
 
-        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True)
         # 3 graph inputs: (b_d_base, a, c)
         # 2 returns: (b_updated, a+c+d)
         # (there are 2 original fw outs, but one is a view of b so it's not part of the graph)
@@ -870,29 +1156,35 @@ def forward(self, primals_1, primals_2):
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1, primals_2, primals_3):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
-    as_strided = torch.ops.aten.as_strided.default(clone, [4], [1], 0)
-    add = torch.ops.aten.add.Tensor(as_strided, 1);  as_strided = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, add, [4], [1], 0);  clone = add = None
-    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
+    as_strided = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_1 = torch.ops.aten.as_strided.default(as_strided, [4], [1], 0);  as_strided = None
+    add = torch.ops.aten.add.Tensor(as_strided_1, 1);  as_strided_1 = None
+    as_strided_4 = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(as_strided_4, add, [4], [1], 0);  as_strided_4 = add = None
+    as_strided_scatter_1 = torch.ops.aten.as_strided_scatter.default(clone, as_strided_scatter, [2, 2], [2, 1], 0);  clone = as_strided_scatter = None
+    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0)
+    as_strided_6 = torch.ops.aten.as_strided.default(as_strided_5, [4], [1], 0);  as_strided_5 = None
     add_1 = torch.ops.aten.add.Tensor(primals_2, primals_3);  primals_2 = primals_3 = None
-    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0);  as_strided_scatter = None
-    t_1 = torch.ops.aten.t.default(as_strided_5);  as_strided_5 = None
-    add_2 = torch.ops.aten.add.Tensor(add_1, t_1);  add_1 = t_1 = None
-    return [as_strided_2, add_2, 4, 1, 0, 4, 1, 0]""")
+    as_strided_11 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0)
+    as_strided_12 = torch.ops.aten.as_strided.default(as_strided_11, [4], [1], 0);  as_strided_11 = None
+    t_1 = torch.ops.aten.t.default(as_strided_12);  as_strided_12 = None
+    add_2 = torch.ops.aten.add.Tensor(add_1, t_1);  add_1 = None
+    as_strided_38 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0);  as_strided_scatter_1 = None
+    as_strided_39 = torch.ops.aten.as_strided.default(as_strided_38, [4], [1], 0);  as_strided_38 = None
+    view_1 = torch.ops.aten.view.default(as_strided_39, [-1]);  as_strided_39 = None
+    return [as_strided_6, t_1, add_2, view_1]""")  # noqa: B950
 
     # Mondo test that tests a combination of:
     # input is mutated, that aliases another input (so we make a synthetic base)
     # an output is an alias of another output
     # an output is an alias of an intermediate
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_input_mutation_alias_everything(self):
         # a and c are aliased
         def f(a, b, c):
             c.mul_(2)  # mutates c
             b.t_()  # metadata mutate b
             tmp = a + c
-            # TODO: this test doesn't test "alias of an intermediate" yet,
-            # delete this line later and get that to be tested
-            return tmp, b.t(), a
             out1 = tmp.view(-1)
             out2 = b.t()
             out3 = out1.unsqueeze(0)
@@ -911,7 +1203,7 @@ def forward(self, primals_1, primals_2, primals_3):
             c = base1_.view(-1)
             return [base1, base2], [a, b, c]
 
-        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True, return_fw_graph=True)
+        fw_graph = self.verify_aot_autograd(f, inp_callable, test_mutation=True)
         # Expected:
         # - 2 inputs in the forward: synthetic_base_a_c, b
         # - 1 output in the forward: "tmp"
@@ -920,14 +1212,25 @@ def forward(self, primals_1, primals_2, primals_3):
         self.assertExpectedInline(fw_graph.code.strip(), """\
 def forward(self, primals_1, primals_2):
     clone = torch.ops.aten.clone.default(primals_1);  primals_1 = None
-    as_strided_1 = torch.ops.aten.as_strided.default(clone, [4], [1], 0)
-    mul = torch.ops.aten.mul.Tensor(as_strided_1, 2);  as_strided_1 = None
-    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(clone, mul, [4], [1], 0);  clone = mul = None
-    as_strided_2 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0)
-    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter, [4], [1], 0);  as_strided_scatter = None
-    add = torch.ops.aten.add.Tensor(as_strided_5, as_strided_2);  as_strided_5 = None
-    return [as_strided_2, add, 2, 2, 1, 2, 0, 2, 2, 2, 1, 0]""")
+    view = torch.ops.aten.view.default(primals_2, [2, 2]);  primals_2 = None
+    as_strided_2 = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_3 = torch.ops.aten.as_strided.default(as_strided_2, [4], [1], 0);  as_strided_2 = None
+    mul = torch.ops.aten.mul.Tensor(as_strided_3, 2);  as_strided_3 = None
+    as_strided_4 = torch.ops.aten.as_strided.default(clone, [2, 2], [2, 1], 0)
+    as_strided_scatter = torch.ops.aten.as_strided_scatter.default(as_strided_4, mul, [4], [1], 0);  as_strided_4 = mul = None
+    as_strided_scatter_1 = torch.ops.aten.as_strided_scatter.default(clone, as_strided_scatter, [2, 2], [2, 1], 0);  clone = as_strided_scatter = None
+    as_strided_5 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0)
+    as_strided_6 = torch.ops.aten.as_strided.default(as_strided_5, [4], [1], 0);  as_strided_5 = None
+    t = torch.ops.aten.t.default(view);  view = None
+    as_strided_11 = torch.ops.aten.as_strided.default(as_strided_scatter_1, [2, 2], [2, 1], 0);  as_strided_scatter_1 = None
+    as_strided_12 = torch.ops.aten.as_strided.default(as_strided_11, [4], [1], 0);  as_strided_11 = None
+    add = torch.ops.aten.add.Tensor(as_strided_12, as_strided_6);  as_strided_12 = None
+    view_1 = torch.ops.aten.view.default(add, [-1])
+    t_1 = torch.ops.aten.t.default(t)
+    unsqueeze = torch.ops.aten.unsqueeze.default(view_1, 0)
+    return [t, as_strided_6, view_1, t_1, unsqueeze, add]""")  # noqa: B950
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_no_grad_input_output(self):
         def f(a, b):
             return a.cos(), b.cos(), a * b
@@ -937,6 +1240,7 @@ def forward(self, primals_1, primals_2):
             inps = [i() for i in inps]
             self.verify_aot_autograd(f, inps)
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_some_output_requires_grad_input_doesnt(self):
         def f(a, b):
             a_view = a.view(-1)
@@ -945,12 +1249,14 @@ def forward(self, primals_1, primals_2):
         inp = [torch.randn(3, 3), torch.randn(3, 3, requires_grad=True)]
         self.verify_aot_autograd(f, inp)
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_some_outputs_dont_require_grad_view(self):
         def f(a, b):
             return a.detach(), b
         inp = [torch.randn(3, 3, requires_grad=True), torch.randn(3, 3, requires_grad=True)]
         self.verify_aot_autograd(f, inp)
 
+    @patch("functorch.compile.config.use_fake_tensor", True)
     def test_some_outputs_dont_require_grad_non_view(self):
         def f(a, b):
             return a.add(1).detach(), b
@@ -1005,8 +1311,11 @@ def forward(self, primals_1, primals_2):
                 new_d[k] = x[k] * 2
             return new_d
 
+        a = torch.randn(3, requires_grad=True)
+        b = torch.randn(3, requires_grad=True)
+
         def inp_callable():
-            inps = [{'a': torch.randn(3, requires_grad=True), 'b': torch.randn(3, requires_grad=True)}]
+            inps = [{'a': a, 'b': b}]
             return inps, inps
 
         self.verify_aot_autograd(f, inp_callable)
@@ -1583,10 +1892,14 @@ class TestPartitioning(AOTTestCase):
         (compiled_outs[0].sum() + compiled_outs[2].sum()).backward()
         bw_graph = bw_graph_cell[0]
 
-        # 12 outs because:
-        # - 5 original outputs -> 4 graph outputs (the 3rd output is an input alias, gets moved outside)
+        # in the fwd graph, 13 outs because:
+        # - 5 original outputs (sb is a tuple, gets expanded to 2 symints)
         # - 8 saved outputs for backward: 5 tensors, 3 symints
-        self.assertEqual(get_num_ins_outs(fw_graph), (4, 12))
+        self.assertEqual(get_num_ins_outs(fw_graph), (4, 13))
+        # in the bwd graph, 12 inputs (grad outs) because:
+        # - The fwd graph had 13 outputs
+        # - 1 was a view of an input, which gets regenerated outside of the graph
+        #   and doesn't participate in the backward
         self.assertEqual(get_num_ins_outs(bw_graph), (12, 4))
         _, fw_graph_out_nodes = get_ins_outs(fw_graph)
         self.assertEqual(
@@ -1596,7 +1909,7 @@ class TestPartitioning(AOTTestCase):
             # i just made the test pass based on what default partition did
             # Of the 5 original forward outputs, the 4th (c) is an input,
             # which won't show up in the compiled forward graph
-            [False, True, True, False] + [False] * 4 + [True] * 4,
+            [False, True, True, False, False] + [False] * 4 + [True] * 4,
             [is_sym_node(n) for n in fw_graph_out_nodes]
         )
 
@@ -1644,14 +1957,14 @@ class TestPartitioning(AOTTestCase):
         (compiled_outs[0].sum() + compiled_outs[2].sum()).backward()
         bw_graph = bw_graph_cell[0]
 
-        self.assertEqual(get_num_ins_outs(fw_graph), (4, 12))
+        self.assertEqual(get_num_ins_outs(fw_graph), (4, 13))
         self.assertEqual(get_num_ins_outs(bw_graph), (12, 4))
         _, fw_graph_out_nodes = get_ins_outs(fw_graph)
         self.assertEqual(
             # fw outputs include b.size() which expands to 2 symints,
             # then 4 tensors (transposes of matricies used for mm) are saved
             # finally 4 symints are saved
-            [False, True, True, False] + [False] * 4 + [True] * 4,
+            [False, True, True, False, False] + [False] * 4 + [True] * 4,
             [is_sym_node(n) for n in fw_graph_out_nodes]
         )
 

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -273,6 +273,7 @@ inductor_expected_failures_single_sample["cuda"] = {
     "allclose": {f16, f32, f64},
     "angle": {f32, f64},
     "argwhere": {b8, f16, f32, f64, i32, i64},
+    "as_strided.partial_views": {f16, f32, f64},
     "baddbmm": {f16},
     "bernoulli": {f16, f32, f64},
     "bincount": {i32, i64},

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -355,10 +355,10 @@ def min_cut_rematerialization_partition(
         # key in their meta dict, but that isn't always true today (see proxy_tensor.py)
         return 'tensor_meta' in x.meta or ('val' in x.meta and isinstance(x.meta['val'], torch.Tensor))
 
-    # networkx blows up on graphs with no tensor outputs.
+    # networkx blows up on graphs with no required backward nodes
     # Since there's nothing to partition anyway, and the default partitioner can "handle"
     # this case, send our graph over to the default partitioner.
-    if not any(is_tensor_node(x) for x in orig_fw_outputs):
+    if len(required_bw_nodes) == 0:
         return default_partition(joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs)
 
     for node in reversed(joint_module.graph.nodes):

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -699,24 +699,23 @@ static PyObject* THPVariable_view_func(PyObject* self_, PyObject* arg) {
   const auto& new_base = THPVariable_Unpack(arg);
 
   // Ensure that self is indeed a backward differentiable view
+  // If not, we return an undefined Tensor (None) and let the user handle it.
   auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(self);
-  TORCH_CHECK(
-      diff_view_meta && diff_view_meta->has_bw_view(),
-      "_view_func can only be called on "
-      "a Tensor that is a backward differentiable view.");
-  const auto& view_info = diff_view_meta->get_backward_view();
-  // Ensure that the newly provided base is similar to the original base
-  TORCH_CHECK(
-      torch::autograd::utils::has_same_meta(new_base, view_info.base_),
-      "The new base passed to _view_func must have the same metadata as the Tensors's base");
-
-  // Do the actual view replay
-  if (view_info.has_view_fn()) {
-    return THPVariable_Wrap(view_info.view_fn()(new_base));
-  } else {
-    return THPVariable_Wrap(new_base.as_strided(
-        self.sizes(), self.strides(), self.storage_offset()));
+  at::Tensor out;
+  if (diff_view_meta && diff_view_meta->has_bw_view()) {
+    const auto& view_info = diff_view_meta->get_backward_view();
+    // Ensure that the newly provided base is similar to the original base
+    if (torch::autograd::utils::has_same_meta(new_base, view_info.base_)) {
+      // Do the actual view replay
+      if (view_info.has_view_fn()) {
+        out = view_info.view_fn()(new_base);
+      } else {
+        out = new_base.as_strided(
+            self.sizes(), self.strides(), self.storage_offset());
+      }
+    }
   }
+  return THPVariable_Wrap(out);
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -4097,9 +4097,10 @@ def outs_and_grads(fn, graph_inps, inps):
     for out in pytree.tree_flatten(outs)[0]:
         if isinstance(out, torch.Tensor) and out.requires_grad:
             out.sum().backward(retain_graph=True)
-    grads = [inp.grad for inp in pytree.tree_flatten(inps)[0]]
+    grads = [inp.grad for inp in pytree.tree_flatten(inps)[0] if isinstance(inp, torch.Tensor)]
     for inp in pytree.tree_flatten(inps)[0]:
-        inp.grad = None
+        if isinstance(inp, torch.Tensor):
+            inp.grad = None
     return outs, grads
 
 def compare_equal_outs_and_grads(test, m1, m2, inps):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92076

Original PR: https://github.com/pytorch/pytorch/pull/89532

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire