### PR TITLE
[not for land] use CI to find tests that will fail with this change

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -183,7 +183,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
             itertools.count(), self.fn.__code__.co_freevars, closure
         ):
             if name == "__class__":
-                source = AttrSource(self.source, "__class__") if self.source else None
+                source = AttrSource(self.source, "__class__")
                 result[name] = variables.UserDefinedClassVariable(
                     cell.cell_contents,
                     source=source,

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -183,7 +183,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
             itertools.count(), self.fn.__code__.co_freevars, closure
         ):
             if name == "__class__":
-                source = AttrSource(self.source, "__class__")
+                source = AttrSource(self.source, "__class__") if self.source else None
                 result[name] = variables.UserDefinedClassVariable(
                     cell.cell_contents,
                     source=source,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92091

Focusing on this test snippet (from test_repros.py -k test_tokenization)

```
        class BatchEncoding(UserDict):
            """
            Copied from tokenization
            """

            def __init__(
                self,
                data,
            ):
                super().__init__(data)

            def __getattr__(self, item: str):
                try:
                    return self.data[item]
                except KeyError as e:
                    raise AttributeError from e

        def tokenization(x):
            encoding = BatchEncoding({"key": x})
            return encoding["key"]

        opt_fn = torch._dynamo.optimize("eager")(tokenization)
```

Dynamo calls [track_object_new](https://github.com/pytorch/pytorch/blob/master/torch/_dynamo/side_effects.py#L216) during inlining, and constructs a UserDefinedObjectVariable with no source.

Then it propagates this 'no source' when creating a UserDefinedMethodVariable to represent `__getattr__`.

If there happened to be a default tensor arg on this method, then we'd be unable to construct a source for it.
cc @jansel @ezyang 