### PR TITLE
JIT pass for ScalarImplicit conversion

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -254,6 +254,7 @@ core_sources_full_mobile_no_backend_interface_xplat = [
     "torch/csrc/jit/passes/concat_opt.cpp",
     "torch/csrc/jit/passes/constant_pooling.cpp",
     "torch/csrc/jit/passes/constant_propagation.cpp",
+    "torch/csrc/jit/passes/convert_scalar_implicit.cpp",
     "torch/csrc/jit/passes/restore_mutation.cpp",
     "torch/csrc/jit/passes/create_autodiff_subgraphs.cpp",
     "torch/csrc/jit/passes/cuda_graph_fuser.cpp",

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11209,6 +11209,20 @@ dedent """
         self.run_pass("erase_number_types", graph)
         FileCheck().check_not("int = prim::Constant").run(str(graph))
 
+
+    def test_convert_scalar_implicit():
+        graph_str = """
+        graph(%a : Float(), %b : Int()):
+            %c : Scalar = aten::ScalarImplicit(%a)
+            %d : Scalar = aten::ScalarImplicit(%b)
+            return (%c, %d)
+        """
+        graph = parse_ir(graph_str)
+        torch._C._jit_pass_convert_scalar_implicit(graph)
+        FileCheck().check("aten::FloatImplicit").run(graph)
+        FileCheck().check("aten::IntImplicit").run(graph)
+
+
     def test_refine_tuple_types(self):
         # TupleConstruct output type is not correct here.
         graph_str = """

--- a/torch/csrc/jit/passes/convert_scalar_implicit.cpp
+++ b/torch/csrc/jit/passes/convert_scalar_implicit.cpp
@@ -1,0 +1,32 @@
+#include <torch/csrc/jit/passes/convert_scalar_implicit.h>
+#include <torch/csrc/jit/runtime/graph_iterator.h>
+
+#include <ATen/core/type_factory.h>
+
+namespace torch {
+namespace jit {
+
+void ConvertScalarImplicit(std::shared_ptr<Graph>& graph) {
+  DepthFirstGraphNodeIterator it(graph);
+  for (auto* node = it.next(); node != nullptr; node = it.next()) {
+    if (node->kind() == c10::aten::ScalarImplicit) {
+      Value * input = node->input(0);
+      auto scalar_type = input->type()->cast<c10::TensorType>()->scalarType();
+      TORCH_CHECK(scalar_type, "scalar type is not defined for input value");
+      Value * output;
+      if (c10::isIntegralType(*scalar_type, false)) {
+        output = graph->insert(c10::aten::IntImplicit, {input});
+      } else if (c10::isFloatingType(*scalar_type)) {
+        output = graph->insert(c10::aten::FloatImplicit, {input});
+      } else {
+        throw std::runtime_error(
+          "Expected isIntegralType or isFloatingType");
+      }
+      node->output()->replaceAllUsesWith(output);
+      node->destroy();
+    }
+  }
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/convert_scalar_implicit.h
+++ b/torch/csrc/jit/passes/convert_scalar_implicit.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+
+// convert ScalarImplicit to IntImplicit or FloatImplicit.
+TORCH_API void ConvertScalarImplicit(std::shared_ptr<Graph>& graph);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -25,6 +25,7 @@
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>
 #include <torch/csrc/jit/passes/constant_propagation.h>
+#include <torch/csrc/jit/passes/convert_scalar_implicit.h>
 #include <torch/csrc/jit/passes/create_autodiff_subgraphs.h>
 #include <torch/csrc/jit/passes/create_functional_graphs.h>
 #include <torch/csrc/jit/passes/cuda_graph_fuser.h>
@@ -632,6 +633,7 @@ void initJITBindings(PyObject* module) {
           "_jit_pass_constant_propagation",
           [](std::shared_ptr<Graph>& g) { return ConstantPropagation(g); },
           py::arg("graph"))
+      .def("_jit_pass_convert_scalar_implicit", ConvertScalarImplicit)
       .def("_jit_pass_erase_shape_information", EraseShapeInformation)
       .def(
           "_jit_object_is_non_holding",


### PR DESCRIPTION
### Description
Added JIT pass to convert `aten::ScalarImplicit` to `aten::IntImplicit` or `aten::FloatImplicit` ops. The problem of ScalarImplicit op is that it produces pythonic output type `torch.number` which is unsupported by most of the backends and should be refined to some other type like `torch.float` or `torch.int`. 

Unfortunately ScalarImplicit appears in all cases when tensor to scalar alignment is triggered ( see https://github.com/pytorch/pytorch/pull/86692 for more details), so it would be great to have a common JIT pass which will handle this conversion for the backends.

