### PR TITLE
[BE] Use nested namespaces in .cpp/.cu files

### DIFF
--- a/aten/src/ATen/ConjugateFallback.cpp
+++ b/aten/src/ATen/ConjugateFallback.cpp
@@ -1,8 +1,7 @@
 #include <ATen/native/MathBitsFallback.h>
 #include <ATen/native/MathBitFallThroughLists.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 struct ConjFallback : MathOpFallback {
   ConjFallback() : MathOpFallback(DispatchKey::Conjugate, "conjugate") {}
   bool is_bit_set(const Tensor& tensor) override {
@@ -63,5 +62,4 @@ TORCH_LIBRARY_IMPL(aten, Conjugate, m) {
   TORCH_VIEW_FNS_NATIVE_FN_REGISTRATION(m)
 }
 
-}
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/Dispatch.cpp
+++ b/aten/src/ATen/Dispatch.cpp
@@ -1,7 +1,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/record_function.h>
 
-namespace at { namespace detail {
+namespace at::detail {
 
 void record_kernel_function_dtype(std::string name) {
   RECORD_FUNCTION_WITH_SCOPE(
@@ -10,4 +10,4 @@ void record_kernel_function_dtype(std::string name) {
         c10::ArrayRef<const c10::IValue>{});
 }
 
-}}  // namespace at::detail
+}  // namespace at::detail

--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -19,8 +19,7 @@
 
 #include <c10/core/Scalar.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -1403,5 +1402,4 @@ REGISTER_DISPATCH(mish_backward_stub, &mish_backward_kernel);
 REGISTER_DISPATCH(prelu_stub, &prelu_kernel);
 REGISTER_DISPATCH(prelu_backward_stub, &prelu_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/AdaptiveAvgPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AdaptiveAvgPoolKernel.cpp
@@ -8,7 +8,7 @@
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -413,4 +413,4 @@ void adapative_avg_pool2d_backward_kernel_impl(
 REGISTER_DISPATCH(adaptive_avg_pool2d_kernel, &adaptive_avg_pool2d_kernel_impl);
 REGISTER_DISPATCH(adaptive_avg_pool2d_backward_kernel, &adapative_avg_pool2d_backward_kernel_impl);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cpu/AdaptiveMaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AdaptiveMaxPoolKernel.cpp
@@ -8,7 +8,7 @@
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -485,4 +485,4 @@ void adaptive_max_pool2d_backward_kernel_impl(
 REGISTER_DISPATCH(adaptive_max_pool2d_kernel, &adaptive_max_pool2d_kernel_impl);
 REGISTER_DISPATCH(adaptive_max_pool2d_backward_kernel, &adaptive_max_pool2d_backward_kernel_impl);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cpu/AvgPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/AvgPoolKernel.cpp
@@ -7,7 +7,7 @@
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -549,4 +549,4 @@ void avg_pool2d_backward_kernel_impl(
 REGISTER_DISPATCH(avg_pool2d_kernel, &avg_pool2d_kernel_impl);
 REGISTER_DISPATCH(avg_pool2d_backward_kernel, &avg_pool2d_backward_kernel_impl);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -15,8 +15,7 @@
 #include <c10/util/TypeSafeSignMath.h>
 #include <c10/util/copysign.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -1273,5 +1272,4 @@ REGISTER_DISPATCH(shifted_chebyshev_polynomial_u_stub, &shifted_chebyshev_polyno
 REGISTER_DISPATCH(shifted_chebyshev_polynomial_v_stub, &shifted_chebyshev_polynomial_v_kernel);
 REGISTER_DISPATCH(shifted_chebyshev_polynomial_w_stub, &shifted_chebyshev_polynomial_w_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/BlasKernel.cpp
+++ b/aten/src/ATen/native/cpu/BlasKernel.cpp
@@ -4,8 +4,7 @@
 #include <c10/util/irange.h>
 #include <c10/util/Unroll.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace cpublas {
 namespace {
 
@@ -248,4 +247,4 @@ REGISTER_DISPATCH(cpublas::gemm_stub, &cpublas::cpublas_gemm_impl);
 REGISTER_DISPATCH(cpublas::axpy_stub, &cpublas::cpublas_axpy_impl);
 REGISTER_DISPATCH(cpublas::copy_stub, &cpublas::cpublas_copy_impl);
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cpu/CatKernel.cpp
+++ b/aten/src/ATen/native/cpu/CatKernel.cpp
@@ -7,7 +7,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -65,4 +65,4 @@ void cat_serial_kernel(const Tensor& result, const MaterializedITensorListRef& t
 
 REGISTER_DISPATCH(cat_serial_stub, &cat_serial_kernel);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cpu/ChannelShuffleKernel.cpp
+++ b/aten/src/ATen/native/cpu/ChannelShuffleKernel.cpp
@@ -8,7 +8,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -113,4 +113,4 @@ void channel_shuffle_kernel_impl(
 
 REGISTER_DISPATCH(channel_shuffle_kernel, &channel_shuffle_kernel_impl);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cpu/ComplexKernel.cpp
+++ b/aten/src/ATen/native/cpu/ComplexKernel.cpp
@@ -4,8 +4,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void complex_kernel(TensorIterator& iter) {
@@ -29,5 +28,4 @@ void polar_kernel(TensorIterator& iter) {
 REGISTER_DISPATCH(complex_stub, &complex_kernel);
 REGISTER_DISPATCH(polar_stub, &polar_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -8,8 +8,7 @@
 #include <ATen/TensorIteratorInternal.h>
 #include <ATen/Parallel.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 inline namespace CPU_CAPABILITY {
 void neg_kernel(TensorIteratorBase &iter);
 void conj_kernel(TensorIteratorBase &iter);
@@ -271,5 +270,4 @@ void copy_kernel(TensorIterator& iter, bool /*non_blocking*/) {
 
 REGISTER_DISPATCH(copy_stub, &copy_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/CrossKernel.cpp
+++ b/aten/src/ATen/native/cpu/CrossKernel.cpp
@@ -11,7 +11,8 @@
 #include <ATen/Parallel.h>
 #include <ATen/TensorIterator.h>
 #include <c10/util/irange.h>
-namespace at { namespace native { namespace {
+namespace at::native {
+namespace {
 
 template<typename scalar_t>
 static void apply_cross(const Tensor& result, const Tensor& a, const Tensor& b, const int64_t dim) {
@@ -77,4 +78,4 @@ static void cross_kernel_impl(const Tensor& result, const Tensor& a, const Tenso
 
 REGISTER_DISPATCH(cross_stub, &cross_kernel_impl);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
+++ b/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
@@ -15,8 +15,7 @@
 #include <arm_neon.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 struct Arguments final {
@@ -313,5 +312,4 @@ Tensor _convolution_depthwise3x3_winograd(
 
 REGISTER_DISPATCH(convolution_depthwise3x3_winograd_stub, &_convolution_depthwise3x3_winograd);
 
-}  // namespace native
-}  // namespace at
+}  // namespace at::native

--- a/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
@@ -10,7 +10,8 @@
 #include <ATen/cpu/vec/functional.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native { namespace {
+namespace at::native {
+namespace {
 
 template<typename scalar_t>
 struct Dist {
@@ -447,4 +448,4 @@ REGISTER_DISPATCH(pdist_backward_stub, &pdist_backward_kernel_impl);
 REGISTER_DISPATCH(cdist_stub, &cdist_kernel_impl);
 REGISTER_DISPATCH(cdist_backward_stub, &cdist_backward_kernel_impl);
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cpu/DistributionKernels.cpp
+++ b/aten/src/ATen/native/cpu/DistributionKernels.cpp
@@ -23,7 +23,7 @@
 #include <cpuinfo.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
 
 static void cauchy_kernel(TensorIteratorBase& iter, double median, double sigma, c10::optional<Generator> gen) {
@@ -237,5 +237,4 @@ REGISTER_DISPATCH(random_from_to_stub, &random_from_to_kernel);
 REGISTER_DISPATCH(random_full_64_bits_range_stub, &random_full_64_bits_range_kernel);
 REGISTER_DISPATCH(random_stub, &random_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/FillKernel.cpp
+++ b/aten/src/ATen/native/cpu/FillKernel.cpp
@@ -9,7 +9,7 @@
 #include <ATen/native/Fill.h>
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
 
 
@@ -58,5 +58,4 @@ void fill_kernel(TensorIterator& iter, const Scalar& value_scalar) {
 
 REGISTER_DISPATCH(fill_stub, &fill_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/FunctionOfAMatrixUtilsKernel.cpp
+++ b/aten/src/ATen/native/cpu/FunctionOfAMatrixUtilsKernel.cpp
@@ -11,7 +11,7 @@
 #define RESTRICT __restrict__
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -54,4 +54,4 @@ void _compute_linear_combination_cpu_kernel(
 
 REGISTER_DISPATCH(_compute_linear_combination_stub, &_compute_linear_combination_cpu_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -14,7 +14,7 @@
 #include <cstring>
 #include <type_traits>
 
-namespace at { namespace native { namespace {
+namespace at::native { namespace {
 
 /**  NOTE [ Grid Sample CPU Kernels ]
  *
@@ -1319,4 +1319,4 @@ REGISTER_DISPATCH(grid_sampler_2d_cpu_kernel, &grid_sampler_2d_cpu_kernel_impl);
 REGISTER_DISPATCH(grid_sampler_2d_backward_cpu_kernel, &grid_sampler_2d_backward_cpu_kernel_impl);
 
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cpu/HistogramKernel.cpp
+++ b/aten/src/ATen/native/cpu/HistogramKernel.cpp
@@ -19,7 +19,7 @@
 #include <numeric>
 #include <functional>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -288,4 +288,4 @@ REGISTER_DISPATCH(histogramdd_stub, &histogramdd_kernel_impl);
 
 REGISTER_DISPATCH(histogramdd_linear_stub, &histogramdd_linear_kernel_impl);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -15,7 +15,7 @@
 #include <c10/util/irange.h>
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
 
 using namespace vec;
@@ -584,4 +584,4 @@ REGISTER_DISPATCH(masked_select_stub, &masked_select_kernel);
 REGISTER_DISPATCH(masked_scatter_stub, &masked_scatter_kernel);
 REGISTER_DISPATCH(flip_stub, &flip_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp
@@ -8,7 +8,7 @@
 #include <ATen/native/cpu/Loops.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native { namespace {
+namespace at::native { namespace {
 
 void addr_kernel(TensorIterator &iter,
                  const Scalar& beta, const Scalar& alpha) {
@@ -86,4 +86,4 @@ void addr_kernel(TensorIterator &iter,
 } // anonymous namespace
 
 REGISTER_DISPATCH(addr_stub, &addr_kernel);
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
@@ -9,7 +9,7 @@
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -508,4 +508,4 @@ void max_pool2d_backward_kernel_impl(
 REGISTER_DISPATCH(max_pool2d_kernel, &max_pool2d_kernel_impl);
 REGISTER_DISPATCH(max_pool2d_backward_kernel, &max_pool2d_backward_kernel_impl);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cpu/MaxPooling.cpp
+++ b/aten/src/ATen/native/cpu/MaxPooling.cpp
@@ -6,8 +6,7 @@
 #include <ATen/native/MaxPooling.h>
 #include <c10/util/irange.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -57,5 +56,4 @@ void max_pool1d_impl(
 
 REGISTER_DISPATCH(max_pool1d_stub, &max_pool1d_impl);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxUnpoolKernel.cpp
@@ -9,7 +9,7 @@
 
 #include <c10/util/Optional.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -269,4 +269,4 @@ void max_unpool3d_kernel_impl(
 REGISTER_DISPATCH(max_unpool2d_kernel, &max_unpool2d_kernel_impl);
 REGISTER_DISPATCH(max_unpool3d_kernel, &max_unpool3d_kernel_impl);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cpu/MultinomialKernel.cpp
+++ b/aten/src/ATen/native/cpu/MultinomialKernel.cpp
@@ -15,8 +15,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 template <typename scalar_t>
@@ -241,5 +240,4 @@ static void multinomial_with_replacement_kernel_impl(
 REGISTER_DISPATCH(
     multinomial_with_replacement_stub,
     &multinomial_with_replacement_kernel_impl);
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/PixelShuffleKernel.cpp
+++ b/aten/src/ATen/native/cpu/PixelShuffleKernel.cpp
@@ -8,7 +8,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -250,4 +250,4 @@ void pixel_unshuffle_kernel_impl(
 REGISTER_DISPATCH(pixel_shuffle_kernel, &pixel_shuffle_kernel_impl);
 REGISTER_DISPATCH(pixel_unshuffle_kernel, &pixel_unshuffle_kernel_impl);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cpu/PointwiseOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/PointwiseOpsKernel.cpp
@@ -6,8 +6,7 @@
 #include <ATen/native/cpu/Loops.h>
 #include <c10/core/Scalar.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 static void addcmul_cpu_kernel(TensorIteratorBase& iter, const Scalar& value) {
@@ -242,5 +241,4 @@ REGISTER_DISPATCH(smooth_l1_backward_stub, &smooth_l1_backward_cpu_kernel);
 REGISTER_DISPATCH(huber_backward_stub, &huber_backward_cpu_kernel);
 REGISTER_DISPATCH(mse_backward_stub, &mse_backward_cpu_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/PowKernel.cpp
+++ b/aten/src/ATen/native/cpu/PowKernel.cpp
@@ -9,7 +9,7 @@
 
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 inline namespace CPU_CAPABILITY {
 
@@ -151,4 +151,4 @@ void pow_tensor_scalar_kernel(
 REGISTER_DISPATCH(pow_tensor_tensor_stub, &CPU_CAPABILITY::pow_tensor_tensor_kernel);
 REGISTER_DISPATCH(pow_tensor_scalar_stub, &CPU_CAPABILITY::pow_tensor_scalar_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
+++ b/aten/src/ATen/native/cpu/RangeFactoriesKernel.cpp
@@ -13,7 +13,7 @@
 
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
 
 using namespace vec;
@@ -74,4 +74,4 @@ static void linspace_kernel(TensorIterator& iter, const Scalar& scalar_start, co
 REGISTER_DISPATCH(arange_stub, &arange_kernel);
 REGISTER_DISPATCH(linspace_stub, &linspace_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
@@ -14,7 +14,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
 
 using namespace vec;
@@ -228,4 +228,4 @@ REGISTER_DISPATCH(min_all_stub, &min_all_kernel_impl);
 REGISTER_DISPATCH(max_all_stub, &max_all_kernel_impl);
 REGISTER_DISPATCH(aminmax_allreduce_stub, &aminmax_allreduce_kernel);
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -23,7 +23,7 @@
 #include <c10/util/irange.h>
 #include <ATen/AccumulateType.h>
 
-namespace at { namespace native { namespace {
+namespace at::native { namespace {
 
 using namespace vec;
 
@@ -497,4 +497,4 @@ REGISTER_DISPATCH(cumprod_stub, &cumprod_cpu_kernel);
 REGISTER_DISPATCH(cumsum_stub, &cumsum_cpu_kernel);
 REGISTER_DISPATCH(logcumsumexp_stub, &logcumsumexp_cpu_kernel);
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cpu/RenormKernel.cpp
+++ b/aten/src/ATen/native/cpu/RenormKernel.cpp
@@ -7,8 +7,7 @@
 
 #include <ATen/Dispatch.h>
 
-namespace at {
-namespace native{
+namespace at::native {
 namespace {
 
 void renorm_scale_factor_impl(TensorIteratorBase& iter, double maxnorm) {
@@ -36,4 +35,4 @@ void renorm_scale_factor_impl(TensorIteratorBase& iter, double maxnorm) {
 
 REGISTER_DISPATCH(renorm_scale_factor_stub, &renorm_scale_factor_impl);
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cpu/SampledAddmmKernel.cpp
+++ b/aten/src/ATen/native/cpu/SampledAddmmKernel.cpp
@@ -9,7 +9,7 @@
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -96,4 +96,4 @@ void sampled_addmm_sparse_csr_kernel(
 
 REGISTER_DISPATCH(sampled_addmm_sparse_csr_stub, &sampled_addmm_sparse_csr_kernel);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -12,7 +12,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -922,4 +922,4 @@ REGISTER_DISPATCH(scatter_add_expanded_index_stub, &scatter_add_expanded_index_k
 REGISTER_DISPATCH(scatter_reduce_expanded_index_stub, &scatter_reduce_expanded_index_kernel);
 REGISTER_DISPATCH(gather_expanded_index_stub, &gather_expanded_index_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -24,7 +24,7 @@
 // a very rough approximation of the number of computations per dim_size element
 // by counting simple computations (*, +, -) as 1 and exp or log as 4.
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
 
 template <typename scalar_t>
@@ -1289,4 +1289,4 @@ REGISTER_DISPATCH(softmax_backward_kernel, &softmax_backward_kernel_impl);
 REGISTER_DISPATCH(
     log_softmax_backward_kernel,
     &log_softmax_backward_kernel_impl);
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -11,7 +11,7 @@
 #include <c10/core/WrapDimMinimal.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -182,4 +182,4 @@ static void topk_kernel(
 REGISTER_DISPATCH(sort_stub, &sort_kernel);
 REGISTER_DISPATCH(topk_stub, &topk_kernel);
 
-}} //at::native
+} //at::native

--- a/aten/src/ATen/native/cpu/SparseFactories.cpp
+++ b/aten/src/ATen/native/cpu/SparseFactories.cpp
@@ -8,8 +8,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 void _spdiags_kernel_cpu(
@@ -63,5 +62,4 @@ void _spdiags_kernel_cpu(
 
 REGISTER_DISPATCH(spdiags_kernel_stub, &_spdiags_kernel_cpu)
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/StackKernel.cpp
+++ b/aten/src/ATen/native/cpu/StackKernel.cpp
@@ -6,8 +6,7 @@
 #include <ATen/native/cpu/StackKernel.h>
 #include <ATen/native/cpu/SerialStackImpl.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -22,5 +21,4 @@ void stack_serial_kernel(Tensor& result, TensorList tensors, int64_t dim) {
 
 REGISTER_DISPATCH(stack_serial_stub, &stack_serial_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -9,8 +9,7 @@
 
 #include <algorithm>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 // Load vector from a smaller type (more elements) to a larger type (fewer elements),
@@ -640,4 +639,4 @@ REGISTER_DISPATCH(nansum_stub, &nansum_kernel_impl);
 REGISTER_NO_AVX512_DISPATCH(nansum_stub);
 #endif
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -26,7 +26,7 @@
 #include <ATen/ops/result_type.h>
 #endif
 
-namespace at { namespace native { namespace {
+namespace at::native { namespace {
 
 template <typename scalar_t, typename scalar_t_2 = int64_t, typename loop1d_t>
 static inline void compare_base_kernel_core(
@@ -404,4 +404,4 @@ REGISTER_DISPATCH(clamp_min_scalar_stub, &clamp_min_scalar_kernel_impl);
 REGISTER_DISPATCH(clamp_max_scalar_stub, &clamp_max_scalar_kernel_impl);
 REGISTER_DISPATCH(isin_default_stub, &isin_default_kernel_cpu);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -28,8 +28,7 @@
 #include <mkl.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 inline namespace CPU_CAPABILITY {
 
@@ -800,5 +799,4 @@ IMPLEMENT_FLOAT_KERNEL(trunc)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 IMPLEMENT_FLOAT_KERNEL(lgamma)
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/Unfold2d.cpp
+++ b/aten/src/ATen/native/cpu/Unfold2d.cpp
@@ -8,8 +8,7 @@
 #include <ATen/native/cpu/utils.h>
 #include <cmath>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -449,5 +448,4 @@ void unfolded2d_copy_kernel(
 REGISTER_DISPATCH(unfolded2d_copy_stub, &unfolded2d_copy_kernel);
 REGISTER_DISPATCH(unfolded2d_acc_stub, &unfolded2d_acc_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/UnfoldBackwardKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnfoldBackwardKernel.cpp
@@ -53,8 +53,7 @@
 // and then the corresponding value of grad_in[...,i_in_dim,...,i_in_last_dim]
 // gets added up to grad_out[...,i_out_dim,...].
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -150,4 +149,4 @@ void unfold_backward_cpu_kernel(
 
 REGISTER_DISPATCH(unfold_backward_stub, &unfold_backward_cpu_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -17,8 +17,7 @@
 #include <ATen/ops/ones.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 using scale_t = std::vector<c10::optional<double>>;
@@ -1587,5 +1586,4 @@ REGISTER_DISPATCH(upsample_trilinear3d_kernel, &upsample_trilinear3d_kernel_impl
 REGISTER_DISPATCH(upsample_bicubic2d_kernel, &upsample_bicubic2d_kernel_impl);
 REGISTER_DISPATCH(_upsample_bicubic2d_aa_kernel, &upsample_bicubic2d_aa_kernel_impl);
 REGISTER_DISPATCH(_upsample_bicubic2d_aa_backward_kernel, &upsample_bicubic2d_aa_backward_kernel_impl);
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/UpSampleMoreKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleMoreKernel.cpp
@@ -9,8 +9,7 @@
 #include <c10/util/irange.h>
 #include <ATen/cpu/vec/vec.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 using scale_t = std::vector<c10::optional<double>>;
@@ -599,5 +598,4 @@ REGISTER_DISPATCH(upsample_linear1d_backward_kernel, &upsample_linear1d_backward
 REGISTER_DISPATCH(upsample_bilinear2d_backward_kernel, &upsample_bilinear2d_backward_kernel_impl);
 REGISTER_DISPATCH(upsample_trilinear3d_backward_kernel, &upsample_trilinear3d_backward_kernel_impl);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/WeightNormKernel.cpp
+++ b/aten/src/ATen/native/cpu/WeightNormKernel.cpp
@@ -10,7 +10,7 @@
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/irange.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -446,4 +446,4 @@ void weight_norm_backward_kernel(
 REGISTER_DISPATCH(weight_norm_stub, &weight_norm_kernel);
 REGISTER_DISPATCH(weight_norm_backward_stub, &weight_norm_backward_kernel);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cpu/airy_ai.cpp
+++ b/aten/src/ATen/native/cpu/airy_ai.cpp
@@ -7,20 +7,18 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 
-namespace at {
-    namespace native {
-        inline namespace CPU_CAPABILITY {
-            static void airy_ai_kernel(TensorIteratorBase& iterator) {
-                TORCH_INTERNAL_ASSERT(iterator.ntensors() == 2);
+namespace at::native {
+inline namespace CPU_CAPABILITY {
+static void airy_ai_kernel(TensorIteratorBase& iterator) {
+    TORCH_INTERNAL_ASSERT(iterator.ntensors() == 2);
 
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "airy_ai_cpu", [&]() {
-                    cpu_kernel(iterator, [](scalar_t x) {
-                        return airy_ai_forward(x);
-                    });
-                });
-            } // airy_ai_kernel(TensorIteratorBase& iterator)
-        } // namespace CPU_CAPABILITY
+    AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "airy_ai_cpu", [&]() {
+        cpu_kernel(iterator, [](scalar_t x) {
+            return airy_ai_forward(x);
+        });
+    });
+} // airy_ai_kernel(TensorIteratorBase& iterator)
+} // namespace CPU_CAPABILITY
 
-        REGISTER_DISPATCH(special_airy_ai_stub, &CPU_CAPABILITY::airy_ai_kernel);
-    } // namespace native
-} // namespace at
+REGISTER_DISPATCH(special_airy_ai_stub, &CPU_CAPABILITY::airy_ai_kernel);
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -21,7 +21,7 @@
 #include <ATen/ops/zeros.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
 
 using namespace vec;
@@ -1297,4 +1297,4 @@ REGISTER_DISPATCH(batch_norm_cpu_stub, &batch_norm_cpu_kernel);
 REGISTER_DISPATCH(batch_norm_cpu_collect_stats_stub, &batch_norm_cpu_collect_stats_kernel);
 REGISTER_DISPATCH(batch_norm_cpu_backward_stub, &batch_norm_cpu_backward_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/group_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/group_norm_kernel.cpp
@@ -21,8 +21,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -1410,5 +1409,4 @@ void GroupNormBackwardKernelImpl(
 REGISTER_DISPATCH(GroupNormKernel, &GroupNormKernelImpl);
 REGISTER_DISPATCH(GroupNormBackwardKernel, &GroupNormBackwardKernelImpl);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -19,8 +19,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -401,5 +400,4 @@ void LayerNormBackwardKernelImpl(
 REGISTER_DISPATCH(LayerNormKernel, &LayerNormKernelImpl);
 REGISTER_DISPATCH(LayerNormBackwardKernel, &LayerNormBackwardKernelImpl);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/scaled_modified_bessel_k0.cpp
+++ b/aten/src/ATen/native/cpu/scaled_modified_bessel_k0.cpp
@@ -7,20 +7,18 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 
-namespace at {
-    namespace native {
-        inline namespace CPU_CAPABILITY {
-            static void scaled_modified_bessel_k0_kernel(TensorIteratorBase& iterator) {
-                TORCH_INTERNAL_ASSERT(iterator.ntensors() == 2);
+namespace at::native {
+inline namespace CPU_CAPABILITY {
+    static void scaled_modified_bessel_k0_kernel(TensorIteratorBase& iterator) {
+        TORCH_INTERNAL_ASSERT(iterator.ntensors() == 2);
 
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "scaled_modified_bessel_k0_cpu", [&]() {
-                    cpu_kernel(iterator, [](scalar_t x) {
-                        return scaled_modified_bessel_k0_forward(x);
-                    });
-                });
-            } // scaled_modified_bessel_k0_kernel(TensorIteratorBase& iterator)
-        } // namespace CPU_CAPABILITY
+        AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "scaled_modified_bessel_k0_cpu", [&]() {
+            cpu_kernel(iterator, [](scalar_t x) {
+                return scaled_modified_bessel_k0_forward(x);
+            });
+        });
+    } // scaled_modified_bessel_k0_kernel(TensorIteratorBase& iterator)
+} // namespace CPU_CAPABILITY
 
-        REGISTER_DISPATCH(special_scaled_modified_bessel_k0_stub, &CPU_CAPABILITY::scaled_modified_bessel_k0_kernel);
-    } // namespace native
-} // namespace at
+REGISTER_DISPATCH(special_scaled_modified_bessel_k0_stub, &CPU_CAPABILITY::scaled_modified_bessel_k0_kernel);
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/scaled_modified_bessel_k1.cpp
+++ b/aten/src/ATen/native/cpu/scaled_modified_bessel_k1.cpp
@@ -7,20 +7,18 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 
-namespace at {
-    namespace native {
-        inline namespace CPU_CAPABILITY {
-            static void scaled_modified_bessel_k1_kernel(TensorIteratorBase& iterator) {
-                TORCH_INTERNAL_ASSERT(iterator.ntensors() == 2);
+namespace at::native {
+inline namespace CPU_CAPABILITY {
+    static void scaled_modified_bessel_k1_kernel(TensorIteratorBase& iterator) {
+        TORCH_INTERNAL_ASSERT(iterator.ntensors() == 2);
 
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "scaled_modified_bessel_k1_cpu", [&]() {
-                    cpu_kernel(iterator, [](scalar_t x) {
-                        return scaled_modified_bessel_k1_forward(x);
-                    });
-                });
-            } // scaled_modified_bessel_k1_kernel(TensorIteratorBase& iterator)
-        } // namespace CPU_CAPABILITY
+        AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "scaled_modified_bessel_k1_cpu", [&]() {
+            cpu_kernel(iterator, [](scalar_t x) {
+                return scaled_modified_bessel_k1_forward(x);
+            });
+        });
+    } // scaled_modified_bessel_k1_kernel(TensorIteratorBase& iterator)
+} // namespace CPU_CAPABILITY
 
-        REGISTER_DISPATCH(special_scaled_modified_bessel_k1_stub, &CPU_CAPABILITY::scaled_modified_bessel_k1_kernel);
-    } // namespace native
-} // namespace at
+REGISTER_DISPATCH(special_scaled_modified_bessel_k1_stub, &CPU_CAPABILITY::scaled_modified_bessel_k1_kernel);
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/spherical_bessel_j0.cpp
+++ b/aten/src/ATen/native/cpu/spherical_bessel_j0.cpp
@@ -7,20 +7,18 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 
-namespace at {
-    namespace native {
-        inline namespace CPU_CAPABILITY {
-            static void spherical_bessel_j0_kernel(TensorIteratorBase& iterator) {
-                TORCH_INTERNAL_ASSERT(iterator.ntensors() == 2);
+namespace at::native {
+inline namespace CPU_CAPABILITY {
+    static void spherical_bessel_j0_kernel(TensorIteratorBase& iterator) {
+        TORCH_INTERNAL_ASSERT(iterator.ntensors() == 2);
 
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "spherical_bessel_j0_cpu", [&]() {
-                    cpu_kernel(iterator, [](scalar_t x) {
-                        return spherical_bessel_j0_forward(x);
-                    });
-                });
-            } // spherical_bessel_j0_kernel(TensorIteratorBase& iterator)
-        } // namespace CPU_CAPABILITY
+        AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "spherical_bessel_j0_cpu", [&]() {
+            cpu_kernel(iterator, [](scalar_t x) {
+                return spherical_bessel_j0_forward(x);
+           });
+        });
+    } // spherical_bessel_j0_kernel(TensorIteratorBase& iterator)
+} // namespace CPU_CAPABILITY
 
-        REGISTER_DISPATCH(special_spherical_bessel_j0_stub, &CPU_CAPABILITY::spherical_bessel_j0_kernel);
-    } // namespace native
-} // namespace at
+REGISTER_DISPATCH(special_spherical_bessel_j0_stub, &CPU_CAPABILITY::spherical_bessel_j0_kernel);
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/AbsKernel.cu
+++ b/aten/src/ATen/native/cuda/AbsKernel.cu
@@ -6,7 +6,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 template<typename scalar_t>
 struct AbsFunctor {
@@ -48,4 +48,4 @@ void abs_kernel_cuda(TensorIteratorBase& iter) {
 
   REGISTER_DISPATCH(abs_stub, &abs_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Activation.cpp
+++ b/aten/src/ATen/native/cuda/Activation.cpp
@@ -20,7 +20,7 @@
 #include <ATen/ops/log_sigmoid_forward_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 // -----------------------------------
 // glu backward
@@ -105,4 +105,4 @@ TORCH_IMPL_FUNC(gelu_backward_out_cuda) (
   GeluBackwardCUDAKernelImpl(*this, get_gelutype_enum(approximate));
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationEluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationEluKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void elu_kernel(
@@ -84,5 +83,4 @@ void elu_backward_kernel(
 REGISTER_DISPATCH(elu_stub, &elu_kernel);
 REGISTER_DISPATCH(elu_backward_stub, &elu_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 void GeluCUDAKernelImpl(TensorIteratorBase& it, GeluType approximate) {
   if (approximate == GeluType::Tanh) {
@@ -86,5 +85,4 @@ void GeluBackwardCUDAKernelImpl(TensorIteratorBase& it, GeluType approximate) {
   }
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationGluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGluKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // -----------------------------------
 // glu forward
@@ -139,5 +138,4 @@ void launch_glu_backward_kernel(
 REGISTER_DISPATCH(glu_stub, &glu_kernel);
 REGISTER_DISPATCH(glu_jvp_stub, &glu_jvp_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationHardshrinkKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardshrinkKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void hardshrink_kernel(TensorIteratorBase& iter, const Scalar& value) {
@@ -37,5 +36,4 @@ void hardshrink_kernel(TensorIteratorBase& iter, const Scalar& value) {
 
 REGISTER_DISPATCH(hardshrink_stub, &hardshrink_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationHardsigmoidKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardsigmoidKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void hardsigmoid_kernel(TensorIteratorBase& iter) {
@@ -72,5 +71,4 @@ void hardsigmoid_backward_kernel(TensorIteratorBase& iter) {
 REGISTER_DISPATCH(hardsigmoid_stub, &hardsigmoid_kernel);
 REGISTER_DISPATCH(hardsigmoid_backward_stub, &hardsigmoid_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationHardswishKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardswishKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void hardswish_kernel(TensorIterator& iter) {
@@ -61,5 +60,4 @@ void hardswish_backward_kernel(TensorIterator& iter) {
 REGISTER_DISPATCH(hardswish_stub, &hardswish_kernel);
 REGISTER_DISPATCH(hardswish_backward_stub, &hardswish_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationHardtanhKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationHardtanhKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void hardtanh_backward_kernel(
@@ -43,5 +42,4 @@ void hardtanh_backward_kernel(
 
 REGISTER_DISPATCH(hardtanh_backward_stub, &hardtanh_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationLeakyReluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationLeakyReluKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void leaky_relu_kernel(TensorIteratorBase& iter, const Scalar& negval_) {
@@ -60,5 +59,4 @@ void leaky_relu_backward_kernel(
 REGISTER_DISPATCH(leaky_relu_stub, &leaky_relu_kernel);
 REGISTER_DISPATCH(leaky_relu_backward_stub, &leaky_relu_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationLogSigmoidKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationLogSigmoidKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // -----------------------------------
 // log_sigmoid forward
@@ -62,5 +61,4 @@ void log_sigmoid_backward_kernel(TensorIterator& iter) {
 
 REGISTER_DISPATCH(log_sigmoid_backward_stub, &log_sigmoid_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationMishKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationMishKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void mish_kernel(TensorIteratorBase& iter) {
@@ -62,5 +61,4 @@ void mish_backward_kernel(TensorIterator& iter) {
 REGISTER_DISPATCH(mish_stub, &mish_kernel);
 REGISTER_DISPATCH(mish_backward_stub, &mish_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationPreluKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // -----------------------------------
 // prelu
@@ -46,5 +45,4 @@ void prelu_backward_kernel(TensorIterator &iter) {
 REGISTER_DISPATCH(prelu_stub, &prelu_kernel);
 REGISTER_DISPATCH(prelu_backward_stub, &prelu_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationSiluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSiluKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void silu_kernel(TensorIteratorBase& iter) {
@@ -57,5 +56,4 @@ void silu_backward_kernel(TensorIteratorBase& iter) {
 REGISTER_DISPATCH(silu_stub, &silu_kernel);
 REGISTER_DISPATCH(silu_backward_stub, &silu_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSoftplusKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void softplus_kernel(
@@ -72,5 +71,4 @@ void softplus_backward_kernel(
 REGISTER_DISPATCH(softplus_stub, &softplus_kernel);
 REGISTER_DISPATCH(softplus_backward_stub, &softplus_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationSoftshrinkKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSoftshrinkKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void softshrink_kernel(TensorIteratorBase& iter, const Scalar& value) {
@@ -56,5 +55,4 @@ void shrink_backward_kernel(TensorIteratorBase& iter, const Scalar& value) {
 REGISTER_DISPATCH(softshrink_stub, &softshrink_kernel);
 REGISTER_DISPATCH(shrink_backward_stub, &shrink_backward_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ActivationThresholdKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationThresholdKernel.cu
@@ -16,8 +16,7 @@
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 template <typename scalar_t>
@@ -50,5 +49,4 @@ static void threshold_kernel_cuda(
 
 REGISTER_DISPATCH(threshold_stub, &threshold_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -36,8 +36,7 @@
 #define CUDA_MAX_THREADS 1024 // this is safe, in reality 256 is our limit
 #define BLOCK_STRIDE 2 // increasing block_stride to lower # of blocks launched
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -800,8 +799,7 @@ namespace {
     return gradInput;
   }
 
-} // at::native
-} // at
+} // namespace at::native
 
 #undef BLOCK_STRIDE
 #undef CUDA_MAX_THREADS

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling3d.cu
@@ -25,8 +25,7 @@
 #include <cmath>
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -543,5 +542,4 @@ Tensor adaptive_avg_pool3d_backward_cuda(
   return gradInput;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -23,8 +23,7 @@
 #include <cmath>
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -472,5 +471,4 @@ TORCH_IMPL_FUNC(adaptive_max_pool2d_backward_out_cuda)
     gradInput.copy_(gradInput_c);
   }
  }
-} // at::native
-} // at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -23,8 +23,7 @@
 #include <cmath>
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -482,5 +481,4 @@ TORCH_IMPL_FUNC(adaptive_max_pool3d_backward_out_cuda)
         });
   }
  }
-} // at::native
-} // at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/AmpKernels.cu
+++ b/aten/src/ATen/native/cuda/AmpKernels.cu
@@ -35,8 +35,7 @@ static __host__ __device__ __forceinline__ int isfinite_ensure_cuda_math(float v
 }
 }
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 // Single-tensor fallback for _amp_foreach_non_finite_check_and_unscale_cuda_.
@@ -246,4 +245,4 @@ Tensor& _amp_update_scale_cuda_(Tensor& current_scale,
   return current_scale;
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/AveragePool2d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool2d.cu
@@ -18,8 +18,7 @@
 #include <ATen/ops/avg_pool2d_backward_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 __device__ inline int min(int a, int b) {
@@ -456,5 +455,4 @@ TORCH_IMPL_FUNC(avg_pool2d_backward_out_cuda) (
   );
 }
 
-} // at::native
-} // at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/AveragePool3d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool3d.cu
@@ -21,8 +21,7 @@
 #endif
 
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 __device__ inline int min(int a, int b) {
@@ -605,4 +604,3 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_cuda) (
 }
 
 } // at::native
-} // at

--- a/aten/src/ATen/native/cuda/BinaryBitwiseOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryBitwiseOpsKernels.cu
@@ -8,7 +8,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 template<typename scalar_t>
 struct BitwiseAndFunctor {
@@ -78,4 +78,4 @@ REGISTER_DISPATCH(bitwise_or_stub, &bitwise_or_kernel_cuda);
 REGISTER_DISPATCH(bitwise_xor_stub, &bitwise_xor_kernel_cuda);
 
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryDivFloorKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryDivFloorKernel.cu
@@ -14,8 +14,7 @@
 
 #include <type_traits>
 
-namespace at {
-namespace native {
+namespace at { namespace native {
 namespace binary_internal {
 
 void div_floor_kernel_cuda(TensorIteratorBase& iter) {
@@ -108,5 +107,4 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(div_floor_stub, &binary_internal::div_floor_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryDivFloorKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryDivFloorKernel.cu
@@ -14,7 +14,7 @@
 
 #include <type_traits>
 
-namespace at { namespace native {
+namespace at::native {
 namespace binary_internal {
 
 void div_floor_kernel_cuda(TensorIteratorBase& iter) {

--- a/aten/src/ATen/native/cuda/BinaryDivTrueKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryDivTrueKernel.cu
@@ -58,5 +58,4 @@ void div_true_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(div_true_stub, &binary_internal::div_true_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryDivTrueKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryDivTrueKernel.cu
@@ -13,8 +13,7 @@
 
 #include <type_traits>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace binary_internal {
 
 const char div_name[] = "div_kernel";

--- a/aten/src/ATen/native/cuda/BinaryDivTruncKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryDivTruncKernel.cu
@@ -12,8 +12,7 @@
 
 #include <type_traits>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace binary_internal {
 
 void div_trunc_kernel_cuda(TensorIteratorBase& iter) {
@@ -51,5 +50,4 @@ void div_trunc_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(div_trunc_stub, &binary_internal::div_trunc_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryGeometricKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryGeometricKernels.cu
@@ -8,7 +8,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 void atan2_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -36,4 +36,4 @@ void hypot_kernel_cuda(TensorIteratorBase& iter) {
 REGISTER_DISPATCH(atan2_stub, &atan2_kernel_cuda);
 REGISTER_DISPATCH(hypot_stub, &hypot_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryLogicalOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryLogicalOpsKernels.cu
@@ -9,7 +9,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 const char logical_and_name[] = "logical_and_kernel";
 void logical_and_kernel_cuda(TensorIterator& iter) {
@@ -125,4 +125,4 @@ REGISTER_DISPATCH(logical_or_stub, &logical_or_kernel_cuda);
 REGISTER_DISPATCH(logical_xor_stub, &logical_xor_kernel_cuda);
 
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryMiscBackwardOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscBackwardOpsKernels.cu
@@ -13,8 +13,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char sigmoid_backward_name[] = "sigmoid_backward";
 void sigmoid_backward_kernel_cuda(TensorIteratorBase& iter) {
@@ -129,5 +128,4 @@ REGISTER_DISPATCH(sigmoid_backward_stub, &sigmoid_backward_kernel_cuda);
 REGISTER_DISPATCH(logit_backward_stub, &logit_backward_kernel_cuda);
 REGISTER_DISPATCH(tanh_backward_stub, &tanh_backward_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -10,7 +10,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 void smooth_l1_kernel_cuda(TensorIteratorBase& iter, double beta) {
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "smooth_l1_cuda", [&iter, beta]() {
@@ -78,4 +78,4 @@ REGISTER_DISPATCH(xlog1py_stub, &xlog1py_kernel_cuda);
 // DO NOT ADD ANY NEW KERNELS HERE
 // CUDA compilation times grow quickly.  It's perfectly acceptable to have a file per kernel.
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryMulKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulKernel.cu
@@ -16,8 +16,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char mul_name[] = "mul_kernel";
 void mul_kernel_cuda(TensorIteratorBase& iter) {
@@ -46,5 +45,4 @@ void mul_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(mul_stub, &mul_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
@@ -11,7 +11,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 void remainder_kernel_cuda(TensorIteratorBase& iter) {
   if (isIntegralType(iter.common_dtype(), /*includeBool*/ false)) {
@@ -58,4 +58,4 @@ void fmod_kernel_cuda(TensorIteratorBase& iter) {
 REGISTER_DISPATCH(remainder_stub, &remainder_kernel_cuda);
 REGISTER_DISPATCH(fmod_stub, &fmod_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryShiftOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryShiftOpsKernels.cu
@@ -8,7 +8,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 
 void lshift_kernel_cuda(TensorIteratorBase& iter) {
@@ -32,4 +32,4 @@ void rshift_kernel_cuda(TensorIteratorBase& iter) {
 REGISTER_DISPATCH(lshift_stub, &lshift_kernel_cuda);
 REGISTER_DISPATCH(rshift_stub, &rshift_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -30,7 +30,7 @@
 #include <ATen/ops/vdot_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -647,4 +647,4 @@ TORCH_IMPL_FUNC(addmv_out_cuda)(const Tensor &self, const Tensor &mat, const Ten
   }
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Bucketization.cu
+++ b/aten/src/ATen/native/cuda/Bucketization.cu
@@ -15,8 +15,7 @@
 #include <ATen/ops/searchsorted_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // Implement a numpy like searchsorted and a TF like bucketize function running on cuda
 // See details in ATen/nativate/Bucketization.cpp
@@ -219,4 +218,4 @@ Tensor bucketize_cuda(const Scalar& self, const Tensor& boundaries, bool out_int
   return bucketize_cuda(searchsorted_scalar_tensor(self, boundaries.device()), boundaries, out_int32, right);
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -10,8 +10,7 @@
 
 #include <ATen/cuda/CUDAContext.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Scalar _local_scalar_dense_cuda(const Tensor& self) {
   Scalar r;
@@ -25,4 +24,4 @@ Scalar _local_scalar_dense_cuda(const Tensor& self) {
   return r;
 }
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cuda/Col2Im.cu
+++ b/aten/src/ATen/native/cuda/Col2Im.cu
@@ -20,8 +20,7 @@
 #include <ATen/ops/im2col_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void col2im_out_cuda_template(
@@ -169,5 +168,4 @@ Tensor col2im_cuda(
   return output;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/CompareEQKernel.cu
+++ b/aten/src/ATen/native/cuda/CompareEQKernel.cu
@@ -9,7 +9,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native { namespace {
+namespace at::native { namespace {
 
 enum class EqOpType {EQ, NE};
 
@@ -47,4 +47,4 @@ void ne_kernel_cuda(TensorIteratorBase& iter) {
 REGISTER_DISPATCH(eq_stub, &eq_kernel_cuda);
 REGISTER_DISPATCH(ne_stub, &ne_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/CompareKernels.cu
+++ b/aten/src/ATen/native/cuda/CompareKernels.cu
@@ -9,7 +9,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native { namespace {
+namespace at::native { namespace {
 
 enum class OpType {GE, GT, LE, LT};
 
@@ -100,4 +100,4 @@ REGISTER_DISPATCH(gt_stub, &gt_kernel_cuda);
 REGISTER_DISPATCH(le_stub, &le_kernel_cuda);
 REGISTER_DISPATCH(lt_stub, &lt_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ComplexKernel.cu
+++ b/aten/src/ATen/native/cuda/ComplexKernel.cu
@@ -7,8 +7,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 void complex_kernel_cuda(TensorIterator& iter) {
@@ -34,5 +33,4 @@ void polar_kernel_cuda(TensorIterator& iter) {
 REGISTER_DISPATCH(complex_stub, &complex_kernel_cuda);
 REGISTER_DISPATCH(polar_stub, &polar_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ConvolutionMM2d.cu
+++ b/aten/src/ATen/native/cuda/ConvolutionMM2d.cu
@@ -18,7 +18,7 @@
 #include <ATen/ops/sum.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
 
 void slow_conv2d_shape_check(
@@ -499,5 +499,4 @@ std::tuple<Tensor, Tensor, Tensor> slow_conv2d_backward_cuda(
       grad_bias);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -19,8 +19,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAStream.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 void neg_kernel_cuda(TensorIteratorBase &iter);
 void conj_kernel_cuda(TensorIteratorBase &iter);
@@ -283,5 +282,4 @@ static void copy_kernel_cuda(TensorIterator& iter, bool non_blocking) {
 
 REGISTER_DISPATCH(copy_stub, &copy_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/CopysignKernel.cu
+++ b/aten/src/ATen/native/cuda/CopysignKernel.cu
@@ -18,7 +18,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 void copysign_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "copysign_cuda", [&]() {
@@ -30,4 +30,4 @@ void copysign_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(copysign_stub, &copysign_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/CrossKernel.cu
+++ b/aten/src/ATen/native/cuda/CrossKernel.cu
@@ -5,7 +5,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/core/Tensor.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 template <typename T, typename OffsetCalc, typename StrideType>
 __global__ void cross_kernel(
@@ -89,4 +89,4 @@ void cross_impl(const Tensor& result, const Tensor& x1, const Tensor& x2, int64_
 
 REGISTER_DISPATCH(cross_stub, &cross_impl);
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/CumminmaxKernel.cu
+++ b/aten/src/ATen/native/cuda/CumminmaxKernel.cu
@@ -8,7 +8,7 @@
 #include <limits>
 #include <functional>
 
-namespace at { namespace native {
+namespace at::native {
 
 void launch_cummax_cuda_kernel(const TensorBase& self, const TensorBase& values, const TensorBase& indices, int64_t dim) {
   AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16,
@@ -26,4 +26,4 @@ void launch_cummin_cuda_kernel(const TensorBase& self, const TensorBase& values,
   });
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/CumprodKernel.cu
+++ b/aten/src/ATen/native/cuda/CumprodKernel.cu
@@ -5,7 +5,7 @@
 #include <ATen/native/cuda/ScanKernels.h>
 #include <ATen/native/cuda/ScanUtils.cuh>
 
-namespace at { namespace native {
+namespace at::native {
 
 void launch_cumprod_cuda_kernel(const TensorBase& result, const TensorBase& self, int64_t dim) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
@@ -20,4 +20,4 @@ void launch_cumprod_cuda_kernel(const TensorBase& result, const TensorBase& self
       });
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/CumsumKernel.cu
+++ b/aten/src/ATen/native/cuda/CumsumKernel.cu
@@ -5,7 +5,7 @@
 #include <ATen/native/cuda/ScanKernels.h>
 #include <ATen/native/cuda/ScanUtils.cuh>
 
-namespace at { namespace native {
+namespace at::native {
 
 void launch_cumsum_cuda_kernel(const TensorBase& result, const TensorBase& self, int64_t dim) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
@@ -22,4 +22,4 @@ void launch_cumsum_cuda_kernel(const TensorBase& result, const TensorBase& self,
       });
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
@@ -18,8 +18,7 @@
 #include <ATen/ops/_conv_depthwise2d_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 using at::cuda::detail::CUDA_NUM_THREADS;
 using at::cuda::detail::GET_BLOCKS;
@@ -633,5 +632,4 @@ std::tuple<Tensor, Tensor> conv_depthwise2d_backward_cuda(
 
 REGISTER_CUDA_DISPATCH(conv_depthwise2d_backward_stub, &conv_depthwise2d_backward_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
@@ -19,8 +19,7 @@
 #include <tuple>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 template <typename scalar_t, typename accscalar_t,
@@ -698,5 +697,4 @@ REGISTER_CUDA_DISPATCH(conv_depthwise3d_backward_stub, &conv_depthwise3d_backwar
 #undef NODEF_OR_EQUAL_3
 #undef NODEF_OR_EQUAL
 
-}
-}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -21,8 +21,7 @@
 #include <ATen/ops/max_pool2d_with_indices_backward_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 __device__ inline int min(int a, int b) {
@@ -566,4 +565,3 @@ const Tensor& gradInput) {
 }
 
 } // at::native
-} // at

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -24,8 +24,7 @@
 #include <ATen/ops/zeros_like.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 __device__ inline int min(int a, int b) {
@@ -652,4 +651,3 @@ Tensor max_pool3d_with_indices_backward_cuda(
 }
 
 } // at::native
-} // at

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -19,7 +19,7 @@
 
 #include <c10/macros/Macros.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -362,4 +362,4 @@ REGISTER_DISPATCH(pdist_backward_stub, &pdist_backward_kernel_impl);
 REGISTER_DISPATCH(cdist_stub, &cdist_kernel_impl);
 REGISTER_DISPATCH(cdist_backward_stub, &cdist_backward_kernel_impl);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cuda/DistributionBernoulli.cu
+++ b/aten/src/ATen/native/cuda/DistributionBernoulli.cu
@@ -21,7 +21,7 @@
 #include <utility>
 #include <type_traits>
 
-namespace at { namespace native {
+namespace at::native {
 
 void bernoulli_tensor_kernel(const TensorBase &self, const TensorBase &p_, c10::optional<Generator> gen_) {
   auto generator = get_generator_or_default<CUDAGeneratorImpl>(gen_, cuda::detail::getDefaultCUDAGenerator());
@@ -37,4 +37,4 @@ void bernoulli_scalar_kernel(const TensorBase &self, double p, c10::optional<Gen
 REGISTER_DISPATCH(bernoulli_tensor_stub, &bernoulli_tensor_kernel);
 REGISTER_DISPATCH(bernoulli_scalar_stub, &bernoulli_scalar_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/DistributionCauchyKernel.cu
+++ b/aten/src/ATen/native/cuda/DistributionCauchyKernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/cuda/DistributionTemplates.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 void cauchy_kernel(TensorIteratorBase& iter, double median, double sigma, c10::optional<Generator> gen) {
   auto generator = get_generator_or_default<CUDAGeneratorImpl>(gen, cuda::detail::getDefaultCUDAGenerator());
@@ -12,4 +12,4 @@ void cauchy_kernel(TensorIteratorBase& iter, double median, double sigma, c10::o
 
 REGISTER_DISPATCH(cauchy_stub, &cauchy_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/DistributionExponentialKernel.cu
+++ b/aten/src/ATen/native/cuda/DistributionExponentialKernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/cuda/DistributionTemplates.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 void exponential_kernel(TensorIteratorBase& iter, double lambda, c10::optional<Generator> gen) {
   auto generator = get_generator_or_default<CUDAGeneratorImpl>(gen, cuda::detail::getDefaultCUDAGenerator());
@@ -12,4 +12,4 @@ void exponential_kernel(TensorIteratorBase& iter, double lambda, c10::optional<G
 
 REGISTER_DISPATCH(exponential_stub, &exponential_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/DistributionGeometricKernel.cu
+++ b/aten/src/ATen/native/cuda/DistributionGeometricKernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/cuda/DistributionTemplates.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 void geometric_kernel(TensorIteratorBase& iter, double p_, c10::optional<Generator> gen) {
   auto generator = get_generator_or_default<CUDAGeneratorImpl>(gen, cuda::detail::getDefaultCUDAGenerator());
@@ -12,4 +12,4 @@ void geometric_kernel(TensorIteratorBase& iter, double p_, c10::optional<Generat
 
 REGISTER_DISPATCH(geometric_stub, &geometric_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/DistributionLogNormalKernel.cu
+++ b/aten/src/ATen/native/cuda/DistributionLogNormalKernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/cuda/DistributionTemplates.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 void log_normal_kernel(TensorIteratorBase& iter, double mean, double std, c10::optional<Generator> gen) {
   auto generator = get_generator_or_default<CUDAGeneratorImpl>(gen, cuda::detail::getDefaultCUDAGenerator());
@@ -12,4 +12,4 @@ void log_normal_kernel(TensorIteratorBase& iter, double mean, double std, c10::o
 
 REGISTER_DISPATCH(log_normal_stub, &log_normal_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/DistributionNormal.cu
+++ b/aten/src/ATen/native/cuda/DistributionNormal.cu
@@ -3,7 +3,7 @@
 #include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <ATen/native/cuda/DistributionTemplates.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 void normal_kernel(const TensorBase &self, double mean, double std, c10::optional<Generator> gen) {
   auto generator = get_generator_or_default<CUDAGeneratorImpl>(gen, cuda::detail::getDefaultCUDAGenerator());
@@ -12,4 +12,4 @@ void normal_kernel(const TensorBase &self, double mean, double std, c10::optiona
 
 REGISTER_DISPATCH(normal_stub, &normal_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/DistributionRandomKernel.cu
+++ b/aten/src/ATen/native/cuda/DistributionRandomKernel.cu
@@ -3,7 +3,7 @@
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/cuda/DistributionTemplates.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 void random_from_to_kernel(TensorIteratorBase& iter, uint64_t range, int64_t base, c10::optional<Generator> gen_) {
   auto gen = get_generator_or_default<CUDAGeneratorImpl>(gen_, cuda::detail::getDefaultCUDAGenerator());
@@ -24,4 +24,4 @@ REGISTER_DISPATCH(random_from_to_stub, &random_from_to_kernel);
 REGISTER_DISPATCH(random_stub, &random_kernel);
 REGISTER_DISPATCH(random_full_64_bits_range_stub, &random_full_64_bits_range_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/DistributionUniform.cu
+++ b/aten/src/ATen/native/cuda/DistributionUniform.cu
@@ -3,7 +3,7 @@
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/cuda/DistributionTemplates.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 void uniform_kernel(TensorIteratorBase& iter, double from, double to, c10::optional<Generator> gen) {
   auto generator = get_generator_or_default<CUDAGeneratorImpl>(gen, cuda::detail::getDefaultCUDAGenerator());
@@ -12,4 +12,4 @@ void uniform_kernel(TensorIteratorBase& iter, double from, double to, c10::optio
 
 REGISTER_DISPATCH(uniform_stub, &uniform_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Distributions.cpp
+++ b/aten/src/ATen/native/cuda/Distributions.cpp
@@ -16,7 +16,7 @@
 #include <ATen/ops/poisson_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 Tensor _s_poisson_cuda(const Tensor& lambda, c10::optional<Generator> gen_) {
   auto gen = get_generator_or_default<CUDAGeneratorImpl>(gen_, cuda::detail::getDefaultCUDAGenerator());
@@ -81,4 +81,4 @@ Tensor _dirichlet_grad_cuda(const Tensor& x, const Tensor& alpha, const Tensor& 
   return ret;
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -128,7 +128,7 @@ void gamma_cuda_kernel(
 
 } // namespace
 
-namespace at { namespace native {
+namespace at::native {
 
 void launch_dirichlet_kernel(at::TensorIteratorBase &iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16,
@@ -205,4 +205,4 @@ void launch_dirichlet_grad_kernel(TensorIteratorBase &iter) {
   });
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -25,8 +25,7 @@
 #include <ATen/ops/zeros_like.h>
 #endif
 
-namespace at{
-namespace native{
+namespace at::native {
 
 namespace {
 
@@ -414,5 +413,4 @@ Tensor masked_scale_cuda(const Tensor& self, const Tensor& mask, double scale){
   return dropout_backward_cuda<uint8_t>(self, mask, scale);
 }
 
-}
-}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -31,7 +31,7 @@
 #include <ATen/ops/zeros.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -392,4 +392,4 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
 }
 
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -21,8 +21,7 @@
 #include <ATen/ops/zeros.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -362,4 +361,4 @@ Tensor embedding_backward_cuda_kernel(
   return grad_weight;
 }
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -34,8 +34,7 @@
 #include <thrust/iterator/reverse_iterator.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 #if !CUB_SUPPORTS_SCAN_BY_KEY()
 template<typename index_t>
@@ -560,5 +559,4 @@ Tensor _embedding_bag_per_sample_weights_backward_cuda(
   return output;
 }
 
-}
-}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Equal.cpp
+++ b/aten/src/ATen/native/cuda/Equal.cpp
@@ -10,7 +10,7 @@
 #include <ATen/ops/equal_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 bool cuda_equal(const Tensor& self, const Tensor &src) {
   if (!at::namedinference::are_names_equal(
@@ -29,4 +29,4 @@ bool cuda_equal(const Tensor& self, const Tensor &src) {
   return at::cuda::eq(self, src).all().item().to<bool>();
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/FillKernel.cu
+++ b/aten/src/ATen/native/cuda/FillKernel.cu
@@ -6,7 +6,7 @@
 #include <ATen/native/Fill.h>
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 template<typename scalar_t>
 struct FillFunctor {
@@ -26,5 +26,4 @@ void fill_kernel_cuda(TensorIterator& iter, const Scalar& value) {
 
 REGISTER_DISPATCH(fill_stub, &fill_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu
@@ -17,7 +17,7 @@
 #include <ATen/ops/empty_like_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 template<typename T, template<class> class Op>
 std::vector<Tensor> foreach_tensor_list_op(TensorList tensors1, TensorList tensors2, const Scalar& alpha = 1) {
@@ -133,4 +133,4 @@ FOREACH_BINARY_OP_LIST(all_types_complex_bool_half_bfloat16, div, std::divides, 
 FOREACH_BINARY_OP_LIST(all_types_half_bfloat16, clamp_max, minimum, /*division_op*/ false);
 FOREACH_BINARY_OP_LIST(all_types_half_bfloat16, clamp_min, maximum, /*division_op*/ false);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalar.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalar.cu
@@ -18,7 +18,7 @@
 #include <ATen/ops/empty_like_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 template<typename T, template<class> class Op>
 std::vector<Tensor> foreach_binary_op(TensorList tensors, const Scalar& scalar) {
@@ -142,4 +142,4 @@ std::vector<Tensor> foreach_tensor_sub_scalar_kernel_cuda(TensorList tensors, co
 FOREACH_BINARY_OP_SCALAR(all_types_half_bfloat16, clamp_max, minimum, false);
 FOREACH_BINARY_OP_SCALAR(all_types_half_bfloat16, clamp_min, maximum, false);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu
@@ -18,7 +18,7 @@
 #include <ATen/ops/empty_like_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 template<typename T, template<class> class Op>
 std::vector<Tensor> foreach_binary_op(TensorList tensors, at::ArrayRef<Scalar> scalars) {
@@ -145,4 +145,4 @@ std::vector<Tensor> foreach_tensor_sub_scalarlist_kernel_cuda(TensorList tensors
 FOREACH_BINARY_OP_SCALARLIST(all_types_half_bfloat16, clamp_max, minimum, false);
 FOREACH_BINARY_OP_SCALARLIST(all_types_half_bfloat16, clamp_min, maximum, false);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -19,7 +19,7 @@
 #include <ATen/ops/empty_like_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 template<template<class> class Op>
 std::vector<Tensor> foreach_pointwise_op(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {
@@ -200,4 +200,4 @@ FOREACH_POINTWISE_OP_SCALARLIST(addcdiv, std::divides);
 FOREACH_POINTWISE_OP_TENSOR(addcdiv, std::divides);
 FOREACH_POINTWISE_OP_TENSOR(addcmul, std::multiplies);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -19,8 +19,7 @@
 #endif
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template<typename T, int NormType, int depth=1, int r_args_depth=1, int res_arg_index=0>
 struct LpNormFunctor {
@@ -186,5 +185,4 @@ std::vector<Tensor> foreach_tensor_norm_cuda(TensorList tensors, const Scalar& o
   return result;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachTernaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachTernaryOp.cu
@@ -13,7 +13,7 @@
 #include <ATen/ops/empty_like_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 template <typename T>
 struct LerpFunctor {
@@ -115,4 +115,4 @@ void foreach_tensor_lerp_list_cuda_(TensorList tensors1, TensorList tensors2, co
         }
   );
 }
-} } // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -39,7 +39,7 @@
 #include <ATen/ops/empty_like_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 template <typename scalar_t, template<class> class Op> std::vector<Tensor> foreach_unary_op(TensorList tensors) {
     std::vector<std::vector<at::Tensor>> tensor_lists;
@@ -326,4 +326,4 @@ void foreach_tensor_zero_cuda_(TensorList tensors) {
     });
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -24,8 +24,7 @@
 #include <cfloat>
 #include <cmath>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 using namespace at::cuda::detail;
 
@@ -271,4 +270,3 @@ TORCH_IMPL_FUNC(fractional_max_pool2d_backward_cuda)(
 }
 
 }// at::native
-}// at

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -27,8 +27,7 @@
 #include <cfloat>
 #include <cmath>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 using namespace at::cuda::detail;
 
@@ -341,5 +340,4 @@ Tensor fractional_max_pool3d_backward_cuda(
     return gradInput;
  }
 
-}// native
-}// at
+}// namespace at::native

--- a/aten/src/ATen/native/cuda/FunctionOfAMatrixUtilsKernel.cu
+++ b/aten/src/ATen/native/cuda/FunctionOfAMatrixUtilsKernel.cu
@@ -7,7 +7,7 @@
 #include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -111,4 +111,4 @@ void _compute_linear_combination_cuda_kernel(
 
 REGISTER_DISPATCH(_compute_linear_combination_stub, &_compute_linear_combination_cuda_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/FusedAdamKernel.cu
+++ b/aten/src/ATen/native/cuda/FusedAdamKernel.cu
@@ -6,7 +6,7 @@
 #include <c10/util/Exception.h>
 
 
-namespace at { namespace native {
+namespace at::native {
 
 // note(crcrpar): To observe the CI rules, i.e. 20 minutes per file to compile, defensively split instantiations into _impl files.
 // this is only for CUDA 11.3 for which it took about 20 minutes and 28 minutes in my workstation and CI, respectively.
@@ -42,4 +42,4 @@ void _fused_adam_kernel_cuda_(
   }
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/GcdLcmKernel.cu
+++ b/aten/src/ATen/native/cuda/GcdLcmKernel.cu
@@ -11,7 +11,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 // See note [Jiterator]
 const char gcd_name[] = "gcd";
@@ -55,4 +55,4 @@ void lcm_kernel_cuda(TensorIteratorBase& iter) {
 REGISTER_DISPATCH(gcd_stub, &gcd_kernel_cuda);
 REGISTER_DISPATCH(lcm_stub, &lcm_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/GridSampler.cpp
+++ b/aten/src/ATen/native/cuda/GridSampler.cpp
@@ -14,8 +14,7 @@
 #include <ATen/ops/zeros_like.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Tensor grid_sampler_2d_cuda(const Tensor& input, const Tensor& grid,
                             int64_t interpolation_mode, int64_t padding_mode,
@@ -80,4 +79,4 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input,
   return std::make_tuple(grad_input, grad_grid);
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -13,7 +13,7 @@
 #include <c10/macros/Macros.h>
 #include <cmath>
 
-namespace at { namespace native {
+namespace at::native {
 
 using namespace at::cuda::detail;
 
@@ -950,4 +950,4 @@ void launch_grid_sampler_3d_backward_kernel(
   }
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/IGammaKernel.cu
+++ b/aten/src/ATen/native/cuda/IGammaKernel.cu
@@ -531,7 +531,7 @@ struct CalcIgamma{
 
 // end of regularized lower & upper incomplete gamma
 
-namespace at { namespace native {
+namespace at::native {
 
 void igamma_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "igamma_cuda", [&]() {
@@ -551,4 +551,4 @@ REGISTER_DISPATCH(igammac_stub, &igammac_kernel_cuda);
 // DO NOT ADD ANY NEW KERNELS HERE
 // CUDA compilation times grow quickly.  It's perfectly acceptable to have a file per kernel.
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Im2Col.cu
+++ b/aten/src/ATen/native/cuda/Im2Col.cu
@@ -20,8 +20,7 @@
 #include <ATen/ops/im2col_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 static void im2col_out_cuda_template(
@@ -163,5 +162,4 @@ Tensor im2col_cuda(
   return output;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/IndexKernel.cpp
+++ b/aten/src/ATen/native/cuda/IndexKernel.cpp
@@ -19,8 +19,7 @@
 #endif
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 static Tensor & masked_select_out_cuda_impl(Tensor & result, const Tensor & self, const Tensor & mask) {
   NoNamesGuard guard;
@@ -85,4 +84,4 @@ Tensor & masked_scatter__cuda(Tensor& self, const Tensor& mask, const Tensor& so
   return self;
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -16,7 +16,7 @@
 
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 static constexpr int launch_bound2 = 4;
 
@@ -469,4 +469,4 @@ REGISTER_DISPATCH(flip_stub, &flip_kernel);
 
 REGISTER_CUDA_DISPATCH(index_put_kernel_quantized_stub, &index_put_kernel_quantized_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -184,7 +184,7 @@ __global__ void indexing_backward_kernel_quantized(
 }
 
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -1668,5 +1668,4 @@ Tensor index_select_sparse_cuda(const Tensor& self, int64_t dim, const Tensor& i
 }
 
 
-} // native
-} // at
+} // at::native

--- a/aten/src/ATen/native/cuda/LegacyThrustHelpers.cu
+++ b/aten/src/ATen/native/cuda/LegacyThrustHelpers.cu
@@ -17,7 +17,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/iterator/constant_iterator.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 void index_put_with_sort_kernel_thrust_helper(Tensor &linearIndex, Tensor &orig_indices, Tensor &sorted_indices, int64_t num_indices) {
   sorted_indices.copy_(linearIndex);
@@ -110,4 +110,4 @@ int64_t embedding_backward_cuda_kernel_unique_by_key<int>(const Tensor &sorted_i
 template
 int64_t embedding_backward_cuda_kernel_unique_by_key<int64_t>(const Tensor &sorted_indices, Tensor &segment_offsets);
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Lerp.cu
+++ b/aten/src/ATen/native/cuda/Lerp.cu
@@ -6,8 +6,7 @@
 #include <ATen/native/cuda/JitLoops.cuh>
 #include <ATen/OpMathType.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 const char lerp_tensor_name[] = "lerp_tensor";
@@ -125,5 +124,4 @@ void lerp_scalar_kernel(at::TensorIteratorBase& iter, const c10::Scalar& weight)
 REGISTER_DISPATCH(lerp_kernel_tensor_weight, &lerp_tensor_kernel);
 REGISTER_DISPATCH(lerp_kernel_scalar_weight, &lerp_scalar_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -9,7 +9,7 @@
 #include <ATen/native/ReduceOps.h>
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -139,4 +139,4 @@ void unpack_pivots_cuda_kernel(TensorIterator& iter, const int64_t dim_size, con
 
 REGISTER_DISPATCH(unpack_pivots_stub, &unpack_pivots_cuda_kernel);
 REGISTER_DISPATCH(addr_stub, &addr_kernel_cuda);
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/LinearAlgebraStubs.cpp
+++ b/aten/src/ATen/native/cuda/LinearAlgebraStubs.cpp
@@ -29,8 +29,7 @@ struct MagmaInitializer {
 }  // namespace (anonymous)
 #endif
 #endif
-namespace at {
-namespace native {
+namespace at::native {
 #if defined(BUILD_LAZY_CUDA_LINALG)
 namespace {
 cuda::detail::LinalgDispatch disp = {_symeig_helper_cuda,
@@ -183,4 +182,4 @@ std::tuple<Tensor, Tensor> _symeig_helper_cuda(const Tensor& self, bool eigenvec
 
 #endif /*defined(BUILD_LAZY_CUDA_LINALG)*/
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -9,7 +9,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 void logaddexp_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -50,4 +50,4 @@ void logaddexp2_kernel_cuda(TensorIteratorBase& iter) {
 REGISTER_DISPATCH(logaddexp_stub, &logaddexp_kernel_cuda);
 REGISTER_DISPATCH(logaddexp2_stub, &logaddexp2_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogcumsumexpKernel.cu
@@ -9,7 +9,7 @@
 #include <cmath>
 #include <limits>
 
-namespace at { namespace native {
+namespace at::native {
 
 void launch_logcumsumexp_cuda_kernel(const TensorBase& result, const TensorBase& self, int64_t dim) {
   AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -34,4 +34,4 @@ void launch_logcumsumexp_cuda_kernel(const TensorBase& result, const TensorBase&
       });
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -58,7 +58,7 @@ void binary_cross_entropy_backward_out_kernel(Tensor& grad_input, const Tensor& 
 
 } // namespace
 
-namespace at { namespace native {
+namespace at::native {
 
 Tensor binary_cross_entropy_cuda(const Tensor& input, const Tensor& target, const c10::optional<Tensor>& weight_opt, int64_t reduction) {
   // See [Note: hacky wrapper removal for optional tensor]
@@ -611,4 +611,4 @@ TORCH_IMPL_FUNC(nll_loss_backward_out_cuda)
       reduction,
       ignore_index);
 }
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -36,8 +36,7 @@
 #include <type_traits>
 #include <numeric>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -781,4 +780,4 @@ Tensor ctc_loss_backward_gpu(const Tensor& grad, const Tensor& log_probs, const 
     });
 }
 
-} } // at::native
+} // at::native

--- a/aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu
+++ b/aten/src/ATen/native/cuda/MaxMinElementwiseKernel.cu
@@ -9,7 +9,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 void maximum_kernel_cuda(TensorIteratorBase& iter) {
   if (iter.dtype() == ScalarType::Bool) {
@@ -95,4 +95,4 @@ REGISTER_DISPATCH(minimum_stub, &minimum_kernel_cuda);
 REGISTER_DISPATCH(fmax_stub, &fmax_kernel_cuda);
 REGISTER_DISPATCH(fmin_stub, &fmin_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/MaxUnpooling.cu
+++ b/aten/src/ATen/native/cuda/MaxUnpooling.cu
@@ -18,8 +18,7 @@
 #include <ATen/ops/empty_like.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 using namespace at::cuda::detail;
 
@@ -610,5 +609,4 @@ at::Tensor max_unpooling3d_backward_cuda(
   return grad_input;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/MultiLabelMarginCriterion.cu
+++ b/aten/src/ATen/native/cuda/MultiLabelMarginCriterion.cu
@@ -18,8 +18,7 @@
 #endif
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 const int MULTILABELMARGIN_THREADS = 128;
@@ -441,5 +440,4 @@ Tensor multilabel_margin_loss_backward_cuda(
   return grad_input;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/MultiMarginLoss.cu
+++ b/aten/src/ATen/native/cuda/MultiMarginLoss.cu
@@ -16,8 +16,7 @@
 #include <ATen/ops/multi_margin_loss_backward_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 constexpr int MULTIMARGIN_THREADS = 128;
 
@@ -392,4 +391,4 @@ Tensor multi_margin_loss_cuda_backward(
   return grad_input;
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -26,7 +26,7 @@
 #include <curand_kernel.h>
 #include <curand_philox4x32_x.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -457,4 +457,4 @@ void multinomial_with_replacement_kernel_impl(
 REGISTER_DISPATCH(
     multinomial_with_replacement_stub,
     &multinomial_with_replacement_kernel_impl);
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/NLLLoss2d.cu
+++ b/aten/src/ATen/native/cuda/NLLLoss2d.cu
@@ -22,8 +22,7 @@
 #include <ATen/ops/nll_loss2d_backward_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -526,5 +525,4 @@ Tensor nll_loss2d_backward_cuda(
   return grad_input;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
@@ -23,8 +23,7 @@
 #include <ATen/ops/slow_conv_transpose2d_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 static inline void slow_conv_transpose2d_shape_check(
@@ -831,5 +830,4 @@ std::tuple<Tensor, Tensor, Tensor> slow_conv_transpose2d_backward_cuda(
 
 REGISTER_CUDA_DISPATCH(slow_conv_transpose2d_backward_stub, &slow_conv_transpose2d_backward_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
@@ -22,8 +22,7 @@
 #include <ATen/ops/slow_conv_transpose3d_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 static inline void slow_conv_transpose3d_shape_check(
@@ -1014,5 +1013,4 @@ std::tuple<Tensor, Tensor, Tensor> slow_conv_transpose3d_backward_cuda(
 
 REGISTER_CUDA_DISPATCH(slow_conv_transpose3d_backward_stub, &slow_conv_transpose3d_backward_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
+++ b/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
@@ -22,8 +22,7 @@
 
 #include <tuple>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -612,5 +611,4 @@ std::tuple<Tensor, Tensor, Tensor> slow_conv_dilated3d_backward_cuda(
 REGISTER_CUDA_DISPATCH(slow_conv_dilated2d_backward_stub, &slow_conv_dilated2d_backward_cuda);
 REGISTER_CUDA_DISPATCH(slow_conv_dilated3d_backward_stub, &slow_conv_dilated3d_backward_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Nonzero.cu
+++ b/aten/src/ATen/native/cuda/Nonzero.cu
@@ -16,8 +16,7 @@
 #endif
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace{
 template<typename T>
@@ -128,5 +127,4 @@ Tensor nonzero_cuda(const Tensor& self){
   Tensor out = at::detail::empty_cuda({0}, self.options().dtype(kLong));
   return at::native::nonzero_out_cuda(self, out);
 }
-} //namespace::native
-} //namespace::at
+} //namespace at::native

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -26,7 +26,7 @@
 #include <ATen/ops/scalar_tensor.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -736,4 +736,4 @@ std::tuple<Tensor, Tensor> batch_norm_update_stats_cuda(
   return std::tuple<Tensor, Tensor>(save_mean, save_var);
 }
 
-} } // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -9,7 +9,7 @@
 #include <ATen/native/PointwiseOps.h>
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 const char addcmul_name[] = "addcmul";
 void addcmul_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
@@ -148,4 +148,4 @@ REGISTER_DISPATCH(addcmul_stub, &addcmul_cuda_kernel);
 REGISTER_DISPATCH(smooth_l1_backward_stub, &smooth_l1_backward_cuda_kernel);
 REGISTER_DISPATCH(huber_backward_stub, &huber_backward_cuda_kernel);
 REGISTER_DISPATCH(mse_backward_stub, &mse_backward_cuda_kernel);
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/PowKernel.cu
+++ b/aten/src/ATen/native/cuda/PowKernel.cu
@@ -9,7 +9,7 @@
 #include <ATen/native/Pow.h>
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 // Forward declare some unary kernels
 void rsqrt_kernel_cuda(TensorIteratorBase& iter);
@@ -206,4 +206,4 @@ void pow_tensor_scalar_kernel(TensorIteratorBase& iter, const Scalar& exp_scalar
 REGISTER_DISPATCH(pow_tensor_tensor_stub, &pow_tensor_tensor_kernel);
 REGISTER_DISPATCH(pow_tensor_scalar_stub, &pow_tensor_scalar_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/RNN.cu
+++ b/aten/src/ATen/native/cuda/RNN.cu
@@ -19,7 +19,7 @@
 #include <ATen/ops/_thnn_fused_gru_cell_backward_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -646,4 +646,4 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_gru_cell_backward
   return std::make_tuple(grad_input_gates, grad_hidden_gates, grad_hx, grad_input_bias, grad_hidden_bias);
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Randperm.cu
+++ b/aten/src/ATen/native/cuda/Randperm.cu
@@ -18,8 +18,7 @@
 
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // [Algorithm of randperm]
 //
@@ -131,4 +130,4 @@ Tensor& randperm_out_cuda(int64_t n, c10::optional<Generator> generator, Tensor&
   return result;
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -67,8 +67,7 @@ void gpu_kernel_with_index(at::Tensor &output, func_t f) {
 
 }  // namespace
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps, Tensor& result) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
@@ -272,4 +271,4 @@ Tensor& arange_cuda_out(const Scalar& start, const Scalar& end, const Scalar& st
   return result;
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/RecordStream.cu
+++ b/aten/src/ATen/native/cuda/RecordStream.cu
@@ -8,9 +8,9 @@
 #include <ATen/ops/record_stream_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 void record_stream_cuda(Tensor& self, c10::Stream stream) {
   struct c10::StreamData3 data = stream.pack3();
   c10::cuda::CUDACachingAllocator::recordStream(self.storage().data_ptr(), at::cuda::CUDAStream::unpack3(data.stream_id, data.device_index, data.device_type));
 }
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/Reduce.cu
+++ b/aten/src/ATen/native/cuda/Reduce.cu
@@ -5,7 +5,7 @@
 #include <iostream>
 
 
-namespace at { namespace native {
+namespace at::native {
 
 static inline std::ostream& operator<<(std::ostream& out, dim3 dim) {
   if (dim.y == 1 && dim.z == 1) {
@@ -53,4 +53,4 @@ std::ostream& operator<<(std::ostream& out, const ReduceConfig& config) {
   return out;
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceAMinMaxKernel.cu
@@ -15,8 +15,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template <typename scalar_t>
 void _min_max_values_kernel_cuda_impl(TensorIterator& iter) {
@@ -47,5 +46,4 @@ void aminmax_launch_kernel(TensorIterator& iter) {
       });
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMaxKernel.cu
@@ -15,8 +15,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template <typename scalar_t, typename acc_t = scalar_t>
 void argmax_kernel_cuda_impl(TensorIterator& iter) {
@@ -44,5 +43,4 @@ void argmax_kernel_cuda(TensorIterator& iter) {
 
 REGISTER_DISPATCH(argmax_stub, &argmax_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceArgMinKernel.cu
@@ -15,8 +15,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template <typename scalar_t, typename acc_t = scalar_t>
 void argmin_kernel_cuda_impl(TensorIterator& iter) {
@@ -44,5 +43,4 @@ void argmin_kernel_cuda(TensorIterator& iter) {
 
 REGISTER_DISPATCH(argmin_stub, &argmin_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReduceLogicKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceLogicKernel.cu
@@ -6,7 +6,7 @@
 #include <ATen/native/ReduceOps.h>
 #include <ATen/Dispatch.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 void and_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
@@ -35,4 +35,4 @@ void or_kernel_cuda(TensorIterator& iter) {
 REGISTER_DISPATCH(and_stub, &and_kernel_cuda);
 REGISTER_DISPATCH(or_stub, &or_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMaxValuesKernel.cu
@@ -15,8 +15,7 @@
 #include <ATen/NumericUtils.h>
 #include <ATen/cuda/NumericLimits.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template <typename acc_t>
 struct MaxNanFunctor {
@@ -59,5 +58,4 @@ void max_all_launch_kernel(TensorIterator &iter) {
 
 REGISTER_DISPATCH(max_values_stub, &max_values_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinValuesKernel.cu
@@ -16,7 +16,7 @@
 #include <ATen/cuda/NumericLimits.cuh>
 
 
-namespace at { namespace native {
+namespace at::native {
 
 template <typename acc_t>
 struct MinNanFunctor {
@@ -55,4 +55,4 @@ void min_all_launch_kernel(TensorIterator &iter) {
 
 REGISTER_DISPATCH(min_values_stub, &min_values_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMomentKernel.cu
@@ -8,7 +8,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/native/ReduceOps.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 template <typename scalar_t, typename out_t=scalar_t>
 void std_var_kernel_impl(TensorIterator& iter, int32_t correction, bool take_sqrt) {
@@ -70,4 +70,4 @@ static void mean_kernel_cuda(TensorIterator& iter) {
 REGISTER_DISPATCH(std_var_stub, &std_var_kernel_cuda);
 REGISTER_DISPATCH(mean_stub, &mean_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReduceNormKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceNormKernel.cu
@@ -8,7 +8,7 @@
 #include <ATen/native/LinearAlgebra.h>
 #include <c10/core/Scalar.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 // This reduction accumulates results as the type `acc_t`. By default, when
 // `scalar_t` is complex, `acc_t` is the downgraded real number type.
@@ -48,4 +48,4 @@ void norm_launch_kernel(TensorIterator& iter, double ord) {
   });
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReduceOps.cpp
+++ b/aten/src/ATen/native/cuda/ReduceOps.cpp
@@ -24,7 +24,7 @@
 #include <ATen/ops/where.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
 
 void norm_kernel_cuda(TensorIterator& iter, const Scalar& val) {
@@ -97,4 +97,4 @@ REGISTER_CUDA_DISPATCH(aminmax_stub, &aminmax_kernel_impl);
 
 REGISTER_CUDA_DISPATCH(norm_stub, &norm_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu
@@ -8,7 +8,7 @@
 #include <ATen/jit_macros.h>
 #include <ATen/OpMathType.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 template <typename scalar_t, typename acc_t = scalar_t, typename out_t = scalar_t>
 struct sum_functor {
@@ -184,4 +184,4 @@ REGISTER_DISPATCH(sum_stub, &sum_kernel_cuda);
 REGISTER_DISPATCH(nansum_stub, &nansum_kernel_cuda);
 REGISTER_DISPATCH(prod_stub, &prod_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -24,8 +24,7 @@
 
 #include <thrust/pair.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 using at::cuda::detail::canUse32BitIndexMath;
@@ -678,5 +677,4 @@ TORCH_IMPL_FUNC(reflection_pad3d_backward_out_cuda) (
       });
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/RenormKernel.cu
+++ b/aten/src/ATen/native/cuda/RenormKernel.cu
@@ -5,8 +5,7 @@
 
 #include <ATen/Dispatch.h>
 
-namespace at {
-namespace native{
+namespace at::native {
 namespace {
 
 void renorm_scale_factor_impl(TensorIteratorBase& iter, double maxnorm) {
@@ -27,4 +26,4 @@ void renorm_scale_factor_impl(TensorIteratorBase& iter, double maxnorm) {
 
 REGISTER_DISPATCH(renorm_scale_factor_stub, &renorm_scale_factor_impl);
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/Repeat.cu
+++ b/aten/src/ATen/native/cuda/Repeat.cu
@@ -50,8 +50,7 @@ static void compute_cuda(
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Tensor repeat_interleave_cuda(
     const Tensor& repeat,
@@ -65,5 +64,4 @@ Tensor repeat_interleave_cuda(
   return output;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -27,8 +27,7 @@
 #include <cmath>
 
 
-namespace at {
-namespace native {
+namespace at::native {
 __host__ __device__ __forceinline__ int imin(int a, int b) {
   return a > b ? b : a;
 }
@@ -751,4 +750,3 @@ Tensor replication_pad3d_backward_cuda(
 }
 
 } // at::native
-} // at

--- a/aten/src/ATen/native/cuda/Resize.cpp
+++ b/aten/src/ATen/native/cuda/Resize.cpp
@@ -11,8 +11,7 @@
 #include <ATen/ops/resize_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes) {
   TORCH_CHECK(storage->resizable(), "Trying to resize storage that is not resizable");
@@ -66,5 +65,4 @@ const Tensor& resize_cuda_(
   }
   return self;
 }
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/RreluWithNoise.cu
+++ b/aten/src/ATen/native/cuda/RreluWithNoise.cu
@@ -14,7 +14,7 @@
 #endif
 
 
-namespace at { namespace native {
+namespace at::native {
 
 template <typename scalar_t, int unroll_factor, typename F>
 #if __CUDA_ARCH__ >= 350 || defined USE_ROCM
@@ -192,4 +192,4 @@ Tensor& rrelu_with_noise_cuda_(
       self, noise, lower, upper, training, generator, self);
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/ScanKernels.cpp
+++ b/aten/src/ATen/native/cuda/ScanKernels.cpp
@@ -16,7 +16,7 @@
 #include <ATen/ops/empty_like.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 
 static c10::MaybeOwned<Tensor> contiguous_out_arg(const Tensor &tensor) {
   if (tensor.is_contiguous()) {
@@ -112,4 +112,4 @@ void cumprod_cuda_kernel(const Tensor& result, const Tensor& self, int64_t dim) 
 REGISTER_CUDA_DISPATCH(cumsum_stub, &cumsum_cuda_kernel);
 REGISTER_CUDA_DISPATCH(cumprod_stub, &cumprod_cuda_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
+++ b/aten/src/ATen/native/cuda/ScatterGatherKernel.cu
@@ -15,7 +15,7 @@
 #include <ATen/cuda/Atomic.cuh>
 #include <ATen/cuda/CUDAContext.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 // Implement as functors since lambdas don't get optimized.
 class ReduceMultiply {
@@ -563,4 +563,4 @@ REGISTER_DISPATCH(scatter_reduce_stub, &scatter_reduce_cuda_kernel);
 REGISTER_DISPATCH(scatter_scalar_reduce_stub, &scatter_scalar_reduce_cuda_kernel);
 REGISTER_DISPATCH(scatter_reduce_two_stub, &scatter_reduce_two_cuda_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/SegmentReduce.cu
+++ b/aten/src/ATen/native/cuda/SegmentReduce.cu
@@ -17,8 +17,7 @@
 #include <ATen/ops/cumsum.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 struct CustomMax {
@@ -620,5 +619,4 @@ REGISTER_DISPATCH(
   _segment_reduce_offsets_backward_stub,
   &_segment_reduce_offsets_backward_cuda_kernel);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -21,8 +21,7 @@
 #include <ATen/ops/narrow.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 constexpr int CAT_ARRAY_BATCH_SIZE = 128;
 constexpr int CAT_ARRAY_MAX_INPUT_DIMS = 4;
@@ -321,5 +320,4 @@ TORCH_IMPL_FUNC(cat_out_cuda)
   }
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -28,8 +28,7 @@
 #include <ATen/ops/_softmax_backward_data.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -1113,5 +1112,5 @@ Tensor masked_softmax_backward_cuda(
   }
   return grad_input;
 }
-}
-}
+
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Sort.cpp
+++ b/aten/src/ATen/native/cuda/Sort.cpp
@@ -21,7 +21,7 @@
 
 #include <limits>
 
-namespace at { namespace native {
+namespace at::native {
 
 std::vector<int64_t> infer_dense_strides_dim_last(const Tensor & self, int64_t dim);
 
@@ -124,4 +124,4 @@ void sort_cuda_kernel(
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_CUDA_DISPATCH(sort_stub, &sort_cuda_kernel);
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -13,7 +13,7 @@
 #include <limits>
 #include <c10/core/DeviceArray.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 template <typename T>
 static int minimum_grid_for_occupancy(T kernel, int max_block_size) {
@@ -280,4 +280,4 @@ void sortKeyValueInplace(
   }
 }
 
-}}  // namespace at::native
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/SortImpl.cu
+++ b/aten/src/ATen/native/cuda/SortImpl.cu
@@ -3,7 +3,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/sort.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 std::vector<int64_t> infer_dense_strides_dim_last(const Tensor & self, int64_t dim) {
   int64_t ndim = self.dim();
@@ -34,4 +34,4 @@ std::vector<int64_t> infer_dense_strides_dim_last(const Tensor & self, int64_t d
   return new_strides_unsort;
 }
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/SortStable.cu
+++ b/aten/src/ATen/native/cuda/SortStable.cu
@@ -15,8 +15,7 @@
 #include <c10/core/DeviceArray.h>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -295,5 +294,5 @@ void launch_stable_sort_kernel(
             });
       });
 }
-} // namespace native
-} // namespace at
+
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Sorting.cpp
+++ b/aten/src/ATen/native/cuda/Sorting.cpp
@@ -23,8 +23,7 @@
 #include <ATen/ops/where.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cuda(
@@ -205,5 +204,4 @@ Tensor nanmedian_cuda(const Tensor& self) {
   return median_impl(self, /*ignore_nan=*/true);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Sorting.cu
+++ b/aten/src/ATen/native/cuda/Sorting.cu
@@ -15,8 +15,7 @@
 #include <cassert>
 #include <cstdlib>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -278,5 +277,4 @@ void launch_median_kernel(
       });
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/SparseBinaryOpIntersectionKernel.cu
+++ b/aten/src/ATen/native/cuda/SparseBinaryOpIntersectionKernel.cu
@@ -5,8 +5,7 @@
 #include <ATen/native/cuda/KernelUtils.cuh>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -147,4 +146,4 @@ void mul_sparse_sparse_out_cuda_kernel(
 
 REGISTER_CUDA_DISPATCH(mul_sparse_sparse_out_stub, &mul_sparse_sparse_out_cuda_kernel);
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/SparseMM.cu
+++ b/aten/src/ATen/native/cuda/SparseMM.cu
@@ -8,7 +8,7 @@
 #include <ATen/ops/sspaddmm_native.h>
 #endif
 
-namespace at { namespace native {
+namespace at::native {
 // sparse, sparse, sparse, dense, real, real -> sparse
 Tensor& _sspaddmm_out_only_sparse_cuda(const Tensor& self,
     const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha, Tensor& result) {
@@ -18,4 +18,4 @@ Tensor& _sspaddmm_out_cuda(const Tensor& self,
     const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha, Tensor& result) {
   AT_ERROR("NYI: CUDA sspaddmm is not implemented");
 }
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -30,7 +30,7 @@
 #include <vector>
 
 
-namespace at { namespace native {
+namespace at::native {
 
 using namespace at::native::detail;
 
@@ -534,4 +534,4 @@ Tensor& _fft_c2c_cufft_out(const Tensor& self, IntArrayRef dim,
 }
 
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -11,7 +11,7 @@
 #include <vector>
 
 
-namespace at { namespace native {
+namespace at::native {
 
 // Offset calculator for indexing in Hermitian mirrored order.
 // In mirrored dims, maps linear index i to (n - i) % n
@@ -121,4 +121,4 @@ void _fft_fill_with_conjugate_symmetry_cuda_(
 
 REGISTER_DISPATCH(fft_fill_with_conjugate_symmetry_stub, &_fft_fill_with_conjugate_symmetry_cuda_);
 
-}} // at::native
+} // at::native

--- a/aten/src/ATen/native/cuda/StepKernel.cu
+++ b/aten/src/ATen/native/cuda/StepKernel.cu
@@ -9,7 +9,7 @@
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at::native {
 
 void nextafter_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND(kBFloat16, iter.common_dtype(), "nextafter_cuda", [&]() {
@@ -30,4 +30,4 @@ void heaviside_kernel_cuda(TensorIteratorBase& iter) {
 REGISTER_DISPATCH(nextafter_stub, &nextafter_kernel_cuda);
 REGISTER_DISPATCH(heaviside_stub, &heaviside_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/TensorCompare.cpp
+++ b/aten/src/ATen/native/cuda/TensorCompare.cpp
@@ -2,7 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/TensorCompare.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -20,4 +20,4 @@ void isin_default_kernel_gpu(
 
 REGISTER_CUDA_DISPATCH(isin_default_stub, &isin_default_kernel_gpu);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -7,7 +7,7 @@
 #include <c10/core/Scalar.h>
 
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -125,4 +125,4 @@ void _assert_async_cuda(const Tensor& self_tensor) {
   });
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -28,8 +28,7 @@
 #include <cmath>
 #include <cstddef>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Tensor& eye_out_cuda(int64_t n, Tensor& result) {
   // the default value of `m` equals to `n`
@@ -384,4 +383,4 @@ Tensor triu_indices_cuda(
   return tensor;
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/TensorModeKernel.cpp
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cpp
@@ -11,8 +11,7 @@ constexpr int MAX_BLOCK_SIZE = AT_ROCM_ENABLED() ? 256 : 1024;
 // Maximum size per grid dimension that we assume (compute capability >= 2.0)
 constexpr int64_t MAX_GRID_SIZE = 65535LL;
 
-namespace at {
-namespace native {
+namespace at::native {
 
 void mode_kernel_impl(
     Tensor& values,
@@ -98,5 +97,4 @@ void mode_kernel_impl(
 }
 
 REGISTER_CUDA_DISPATCH(mode_stub, &mode_kernel_impl);
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/TensorModeKernel.cu
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cu
@@ -18,8 +18,7 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template <typename scalar_t>
 struct ModeImpl {
@@ -283,5 +282,4 @@ void launch_apply_mode_kernel(const TensorBase &values, const TensorBase &indice
   });
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/TensorShapeCUDA.cpp
+++ b/aten/src/ATen/native/cuda/TensorShapeCUDA.cpp
@@ -10,8 +10,7 @@
 #include <ATen/ops/set_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // this needs to be split along CPU/CUDA lines because we don't have a consistent
 // way of getting the allocator to use for a device (c10::GetAllocator is not
@@ -39,5 +38,4 @@ Tensor& set_storage_cuda_(Tensor& result, Storage storage, int64_t storage_offse
   return result;
 }
 
-}
-}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/TensorTopK.cpp
+++ b/aten/src/ATen/native/cuda/TensorTopK.cpp
@@ -17,8 +17,7 @@
 #include <ATen/ops/topk_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // TODO: remove this when CUDA <11.6 is no longer supported
 void topk_out_with_sort(
@@ -95,4 +94,4 @@ TORCH_IMPL_FUNC(topk_out_cuda)
   }
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -19,8 +19,7 @@
 
 using namespace at::native;
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // TODO: remove this when CUDA <11.6 is no longer supported
 bool disable_sort_for_topk() {
@@ -895,4 +894,3 @@ void launch_gather_topk_kernel(
 }
 
 } // at::native
-} // at

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -18,8 +18,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 template <typename scalar_t, typename IndexType>
 #if __CUDA_ARCH__ >= 350 || defined(USE_ROCM)
@@ -152,4 +151,4 @@ Tensor roll_cuda(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
   return out_tensor;
 }
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/TriangularOps.cu
+++ b/aten/src/ATen/native/cuda/TriangularOps.cu
@@ -19,8 +19,7 @@
 
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ triu/tril ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -107,5 +106,4 @@ Tensor trace_cuda(const Tensor& self) {
   return self.diagonal().sum();
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryComplexKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryComplexKernels.cu
@@ -9,7 +9,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 // We manually overload angle because std::arg does not work with types other than c10::complex.
 template<typename scalar_t>
@@ -96,4 +96,4 @@ void conj_kernel_cuda(TensorIteratorBase& iter) {
 REGISTER_DISPATCH(angle_stub, &angle_kernel_cuda);
 REGISTER_DISPATCH(conj_physical_stub, &conj_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
@@ -8,7 +8,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Math.cuh>
 
-namespace at { namespace native {
+namespace at::native {
 
 // We manually overload ceil because std::ceil does not work with std::complex types.
 template <typename scalar_t>
@@ -196,4 +196,4 @@ REGISTER_DISPATCH(round_stub, &round_kernel_cuda);
 REGISTER_DISPATCH(round_decimals_stub, &round_decimals_kernel_cuda);
 REGISTER_DISPATCH(trunc_stub, &trunc_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGammaKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryGammaKernels.cu
@@ -10,7 +10,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/Math.h>
 
-namespace at { namespace native {
+namespace at::native {
 
 // See note [Jiterator]
 const char digamma_name[] = "digamma";
@@ -105,4 +105,4 @@ REGISTER_DISPATCH(digamma_stub, &digamma_kernel_cuda);
 REGISTER_DISPATCH(polygamma_stub, &polygamma_kernel_cuda);
 REGISTER_DISPATCH(lgamma_stub, &lgamma_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricAcosKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAcosKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char acos_name[] = "acos";
 void acos_kernel_cuda(TensorIteratorBase& iter) {
@@ -52,5 +51,4 @@ void acos_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(acos_stub, &acos_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricAcoshKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAcoshKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char acosh_name[] = "acosh";
 void acosh_kernel_cuda(TensorIteratorBase& iter) {
@@ -52,5 +51,4 @@ void acosh_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(acosh_stub, &acosh_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricAsinKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAsinKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char asin_name[] = "asin";
 void asin_kernel_cuda(TensorIteratorBase& iter) {
@@ -48,5 +47,4 @@ void asin_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(asin_stub, &asin_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricAsinhKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAsinhKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char asinh_name[] = "asinh";
 void asinh_kernel_cuda(TensorIteratorBase& iter) {
@@ -52,5 +51,4 @@ void asinh_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(asinh_stub, &asinh_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricAtanKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAtanKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char atan_name[] = "atan";
 void atan_kernel_cuda(TensorIteratorBase& iter) {
@@ -52,5 +51,4 @@ void atan_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(atan_stub, &atan_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricAtanhKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAtanhKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char atanh_name[] = "atanh";
 void atanh_kernel_cuda(TensorIteratorBase& iter) {
@@ -52,5 +51,4 @@ void atanh_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(atanh_stub, &atanh_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricCosKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricCosKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char cos_name[] = "cos";
 void cos_kernel_cuda(TensorIteratorBase& iter) {
@@ -51,5 +50,4 @@ void cos_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(cos_stub, &cos_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricCoshKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricCoshKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char cosh_name[] = "cosh";
 void cosh_kernel_cuda(TensorIteratorBase& iter) {
@@ -52,5 +51,4 @@ void cosh_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(cosh_stub, &cosh_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricSinKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricSinKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char sin_name[] = "sin";
 void sin_kernel_cuda(TensorIteratorBase& iter) {
@@ -51,5 +50,4 @@ void sin_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(sin_stub, &sin_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricSinhKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricSinhKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char sinh_name[] = "sinh";
 void sinh_kernel_cuda(TensorIteratorBase& iter) {
@@ -52,5 +51,4 @@ void sinh_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(sinh_stub, &sinh_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricTanKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricTanKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char tan_name[] = "tan";
 void tan_kernel_cuda(TensorIteratorBase& iter) {
@@ -51,5 +50,4 @@ void tan_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(tan_stub, &tan_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryGeometricTanhKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricTanhKernel.cu
@@ -9,8 +9,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char tanh_name[] = "tanh";
 void tanh_kernel_cuda(TensorIteratorBase& iter) {
@@ -52,5 +51,4 @@ void tanh_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(tanh_stub, &tanh_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryLogKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryLogKernels.cu
@@ -10,7 +10,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Math.cuh>
 
-namespace at { namespace native {
+namespace at::native {
 
 const char log_name[] = "log_kernel";
 void log_kernel_cuda(TensorIteratorBase& iter) {
@@ -115,4 +115,4 @@ REGISTER_DISPATCH(log10_stub, &log10_kernel_cuda);
 REGISTER_DISPATCH(log2_stub, &log2_kernel_cuda);
 REGISTER_DISPATCH(log1p_stub, &log1p_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -18,8 +18,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/util/complex.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 void bitwise_not_kernel_cuda(TensorIteratorBase& iter) {
   if (iter.dtype() == ScalarType::Bool) {
@@ -257,5 +256,4 @@ REGISTER_DISPATCH(sqrt_stub, &sqrt_kernel_cuda);
 REGISTER_DISPATCH(nan_to_num_stub, &nan_to_num_kernel_cuda);
 REGISTER_DISPATCH(frexp_stub, &frexp_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -12,7 +12,7 @@
 
 #include <type_traits>
 
-namespace at { namespace native {
+namespace at::native {
 
 void logical_not_kernel_cuda(TensorIteratorBase& iter) {
   // error check -- this is just ensuring we don't dispatch on types that aren't in ALL_TYPES_AND_COMPLEX_AND3(...)
@@ -134,4 +134,4 @@ REGISTER_DISPATCH(sign_stub, &sign_kernel_cuda);
 REGISTER_DISPATCH(signbit_stub, &signbit_kernel_cuda);
 REGISTER_DISPATCH(sgn_stub, &sgn_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnarySpecialOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnarySpecialOpsKernel.cu
@@ -17,8 +17,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 const char exp2_name[] = "exp2_kernel";
 void exp2_kernel_cuda(TensorIteratorBase& iter) {
@@ -394,5 +393,4 @@ REGISTER_DISPATCH(special_ndtri_stub, &ndtri_kernel_cuda);
 REGISTER_DISPATCH(special_log_ndtr_stub, &log_ndtr_kernel_cuda);
 REGISTER_DISPATCH(special_erfcx_stub, &erfcx_kernel_cuda);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UnfoldBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/UnfoldBackwardKernel.cu
@@ -15,7 +15,7 @@
 // unfold_backward, the algorithm is described in
 // /native/cpu/UnfoldBackwardKernel.cpp
 
-namespace at { namespace native {
+namespace at::native {
 
 namespace {
 
@@ -159,4 +159,4 @@ void unfold_backward_cuda_kernel(
 
 REGISTER_DISPATCH(unfold_backward_stub, &unfold_backward_cuda_kernel);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -29,8 +29,7 @@
 
 #include <ATen/native/cuda/UniqueCub.cuh>
 
-namespace at {
-namespace native{
+namespace at::native {
 
 namespace {
 
@@ -233,5 +232,4 @@ unique_consecutive_cuda(const Tensor& self, const bool return_inverse, const boo
   return unique_dim_consecutive_cuda(self, dim.value(), return_inverse, return_counts);
 }
 
-}  // namespace native
-}  // namespace at
+}  // namespace at::native

--- a/aten/src/ATen/native/cuda/UniqueCub.cu
+++ b/aten/src/ATen/native/cuda/UniqueCub.cu
@@ -16,9 +16,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-namespace at {
-namespace native {
-namespace internal {
+namespace at::native::internal {
 
 namespace {
 
@@ -340,6 +338,4 @@ INSTANTIATE_UNIQUE_CUDA_TEMPLATE(at::Half);
 
 #undef INSTANTIATE
 
-} // namespace internal
-} // namespace native
-} // namespace at
+} // namespace at::native::internal

--- a/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu
@@ -16,8 +16,7 @@
 #include <ATen/ops/upsample_bicubic2d_backward_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 template <typename scalar_t, typename accscalar_t>
@@ -295,5 +294,4 @@ TORCH_IMPL_FUNC(upsample_bicubic2d_backward_out_cuda) (
       grad_input, grad_output, output_size, input_size, align_corners, scales_h, scales_w);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
@@ -27,8 +27,7 @@
 #include <ATen/ops/zeros.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 template <typename scalar_t, typename accscalar_t>
@@ -915,5 +914,4 @@ TORCH_IMPL_FUNC(_upsample_bicubic2d_aa_backward_out_cuda) (
       grad_input, grad_output, output_size, input_size, align_corners, scales_h, scales_w);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -19,8 +19,7 @@
 #include <ATen/ops/upsample_linear1d_backward_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 template <typename scalar_t, typename accscalar_t>
@@ -228,5 +227,4 @@ TORCH_IMPL_FUNC(upsample_linear1d_backward_out_cuda) (
       grad_input, grad_output, output_size, input_size, align_corners, scales);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
@@ -18,8 +18,7 @@
 #include <ATen/ops/_upsample_nearest_exact1d_backward_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 #define MAX_THREADS 512
@@ -236,5 +235,4 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact1d_backward_out_cuda) (
       grad_input, grad_output, output_size, input_size, scales);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
@@ -22,8 +22,7 @@
 #include <ATen/ops/upsample_nearest2d_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 #define MAX_THREADS 512
@@ -485,5 +484,4 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact2d_backward_out_cuda) (
       grad_input, grad_output, output_size, input_size, scales_h, scales_w);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
@@ -24,8 +24,7 @@
 #include <ATen/ops/_upsample_nearest_exact3d_backward_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 #define MAX_THREADS 512
@@ -337,5 +336,4 @@ TORCH_IMPL_FUNC(_upsample_nearest_exact3d_backward_out_cuda) (
 using at::native::upsample::compute_output_size;
 using at::native::upsample_cuda::get_scale_value;
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
@@ -21,8 +21,7 @@
 #include <ATen/ops/upsample_trilinear3d_backward_native.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 __device__ __forceinline__ size_t
@@ -394,5 +393,4 @@ TORCH_IMPL_FUNC(upsample_trilinear3d_backward_out_cuda) (
       grad_input, grad_output, output_size, input_size, align_corners, scales_d, scales_h, scales_w);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ValidateCompressedIndicesKernel.cu
+++ b/aten/src/ATen/native/cuda/ValidateCompressedIndicesKernel.cu
@@ -2,8 +2,7 @@
 #include <ATen/native/sparse/ValidateCompressedIndicesCommon.h>
 #include <ATen/native/cuda/Loops.cuh>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -27,4 +26,4 @@ void _validate_compressed_sparse_indices_cuda(
       is_crow, cidx, idx, cdim, dim, nnz);
 }
 
-}}
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/WeightNorm.cu
+++ b/aten/src/ATen/native/cuda/WeightNorm.cu
@@ -19,8 +19,7 @@
 #endif
 
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace {
 
 // Block size for weight_norm_*_first_dim_kernel.
@@ -523,5 +522,4 @@ std::tuple<Tensor, Tensor> weight_norm_backward_cuda
 #undef TILE_W
 #undef TILE_H
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/ZetaKernel.cu
+++ b/aten/src/ATen/native/cuda/ZetaKernel.cu
@@ -7,7 +7,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at { namespace native {
+namespace at::native {
 namespace {
 
 /*
@@ -36,4 +36,4 @@ void zeta_kernel_cuda(TensorIteratorBase& iter) {
 
 REGISTER_DISPATCH(zeta_stub, &zeta_kernel_cuda);
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/airy_ai.cu
+++ b/aten/src/ATen/native/cuda/airy_ai.cu
@@ -18,26 +18,25 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
-        namespace {
-            const char airy_ai_name[] = "airy_ai_forward";
+namespace at::native {
+namespace {
+const char airy_ai_name[] = "airy_ai_forward";
 
-            void airy_ai_kernel_cuda(TensorIteratorBase& iterator) {
+void airy_ai_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "airy_ai_cuda", [&]() {
-                    jitted_gpu_kernel<airy_ai_name, scalar_t, scalar_t, 1>(iterator, airy_ai_string);
-                });
+    AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "airy_ai_cuda", [&]() {
+        jitted_gpu_kernel<airy_ai_name, scalar_t, scalar_t, 1>(iterator, airy_ai_string);
+    });
 #else
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "airy_ai_cuda", [&]() {
-                    gpu_kernel(iterator, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-                        return airy_ai_forward(a);
-                    });
-                });
+    AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "airy_ai_cuda", [&]() {
+        gpu_kernel(iterator, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+            return airy_ai_forward(a);
+        });
+    });
 #endif // AT_USE_JITERATOR()
-            }
-        }
+}
 
-        REGISTER_DISPATCH(special_airy_ai_stub, &airy_ai_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // anonymous namespace
+
+REGISTER_DISPATCH(special_airy_ai_stub, &airy_ai_kernel_cuda);
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/bessel_j0.cu
+++ b/aten/src/ATen/native/cuda/bessel_j0.cu
@@ -18,26 +18,25 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
-        namespace {
-            const char bessel_j0_name[] = "bessel_j0_forward";
+namespace at::native {
+namespace {
+const char bessel_j0_name[] = "bessel_j0_forward";
 
-            void bessel_j0_kernel_cuda(TensorIteratorBase& iterator) {
+void bessel_j0_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "bessel_j0_cuda", [&]() {
-                    jitted_gpu_kernel<bessel_j0_name, scalar_t, scalar_t, 1>(iterator, bessel_j0_string);
-                });
+    AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "bessel_j0_cuda", [&]() {
+        jitted_gpu_kernel<bessel_j0_name, scalar_t, scalar_t, 1>(iterator, bessel_j0_string);
+    });
 #else
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "bessel_j0_cuda", [&]() {
-                    gpu_kernel(iterator, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-                        return bessel_j0_forward(a);
-                    });
-                });
+    AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "bessel_j0_cuda", [&]() {
+        gpu_kernel(iterator, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+            return bessel_j0_forward(a);
+        });
+    });
 #endif // AT_USE_JITERATOR()
-            }
-        }
+}
 
-        REGISTER_DISPATCH(special_bessel_j0_stub, &bessel_j0_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // anonymous namespace
+
+REGISTER_DISPATCH(special_bessel_j0_stub, &bessel_j0_kernel_cuda);
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/bessel_j1.cu
+++ b/aten/src/ATen/native/cuda/bessel_j1.cu
@@ -18,26 +18,25 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
-        namespace {
-            const char bessel_j1_name[] = "bessel_j1_forward";
+namespace at::native {
+namespace {
+const char bessel_j1_name[] = "bessel_j1_forward";
 
-            void bessel_j1_kernel_cuda(TensorIteratorBase& iterator) {
+void bessel_j1_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "bessel_j1_cuda", [&]() {
-                    jitted_gpu_kernel<bessel_j1_name, scalar_t, scalar_t, 1>(iterator, bessel_j1_string);
-                });
+    AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "bessel_j1_cuda", [&]() {
+        jitted_gpu_kernel<bessel_j1_name, scalar_t, scalar_t, 1>(iterator, bessel_j1_string);
+    });
 #else
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "bessel_j1_cuda", [&]() {
-                    gpu_kernel(iterator, []GPU_LAMBDA(scalar_t a) -> scalar_t {
-                        return bessel_j1_forward(a);
-                    });
-                });
+    AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "bessel_j1_cuda", [&]() {
+        gpu_kernel(iterator, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+            return bessel_j1_forward(a);
+        });
+    });
 #endif // AT_USE_JITERATOR()
-            }
-        }
+}
 
-        REGISTER_DISPATCH(special_bessel_j1_stub, &bessel_j1_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // anonymous namespace
+
+REGISTER_DISPATCH(special_bessel_j1_stub, &bessel_j1_kernel_cuda);
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/bessel_y0.cu
+++ b/aten/src/ATen/native/cuda/bessel_y0.cu
@@ -18,8 +18,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char bessel_y0_name[] = "bessel_y0_forward";
 
@@ -39,5 +38,4 @@ namespace at {
         }
 
         REGISTER_DISPATCH(special_bessel_y0_stub, &bessel_y0_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/bessel_y1.cu
+++ b/aten/src/ATen/native/cuda/bessel_y1.cu
@@ -18,8 +18,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char bessel_y1_name[] = "bessel_y1_forward";
 
@@ -39,5 +38,4 @@ namespace at {
         }
 
         REGISTER_DISPATCH(special_bessel_y1_stub, &bessel_y1_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/chebyshev_polynomial_t.cu
+++ b/aten/src/ATen/native/cuda/chebyshev_polynomial_t.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char chebyshev_polynomial_t_name[] = "chebyshev_polynomial_t_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(chebyshev_polynomial_t_stub, &chebyshev_polynomial_t_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/chebyshev_polynomial_u.cu
+++ b/aten/src/ATen/native/cuda/chebyshev_polynomial_u.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char chebyshev_polynomial_u_name[] = "chebyshev_polynomial_u_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(chebyshev_polynomial_u_stub, &chebyshev_polynomial_u_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/chebyshev_polynomial_v.cu
+++ b/aten/src/ATen/native/cuda/chebyshev_polynomial_v.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char chebyshev_polynomial_v_name[] = "chebyshev_polynomial_v_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(chebyshev_polynomial_v_stub, &chebyshev_polynomial_v_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/chebyshev_polynomial_w.cu
+++ b/aten/src/ATen/native/cuda/chebyshev_polynomial_w.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char chebyshev_polynomial_w_name[] = "chebyshev_polynomial_w_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(chebyshev_polynomial_w_stub, &chebyshev_polynomial_w_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_amsgrad_impl.cu
@@ -6,7 +6,7 @@
 #include <ATen/native/cuda/MultiTensorApply.cuh>
 #include <vector>
 
-namespace at { namespace native {
+namespace at::native {
 
 void _fused_adam_cuda_impl_(
     at::TensorList params,
@@ -49,4 +49,4 @@ void _fused_adam_cuda_impl_(
         });
 }
 
-} } // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/fused_adam_impl.cu
+++ b/aten/src/ATen/native/cuda/fused_adam_impl.cu
@@ -6,7 +6,7 @@
 #include <ATen/native/cuda/MultiTensorApply.cuh>
 #include <vector>
 
-namespace at { namespace native {
+namespace at::native {
 
 void _fused_adam_cuda_impl_(
     at::TensorList params,
@@ -48,4 +48,4 @@ void _fused_adam_cuda_impl_(
         });
 }
 
-} } // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -21,8 +21,7 @@
 #include <ATen/ops/empty.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -994,5 +993,4 @@ void GroupNormBackwardKernelImpl(
 REGISTER_DISPATCH(GroupNormKernel, &GroupNormKernelImpl);
 REGISTER_DISPATCH(GroupNormBackwardKernel, &GroupNormBackwardKernelImpl);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/hermite_polynomial_h.cu
+++ b/aten/src/ATen/native/cuda/hermite_polynomial_h.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char hermite_polynomial_h_name[] = "hermite_polynomial_h_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(hermite_polynomial_h_stub, &hermite_polynomial_h_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/hermite_polynomial_he.cu
+++ b/aten/src/ATen/native/cuda/hermite_polynomial_he.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char hermite_polynomial_he_name[] = "hermite_polynomial_he_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(hermite_polynomial_he_stub, &hermite_polynomial_he_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/jit_utils.cpp
+++ b/aten/src/ATen/native/cuda/jit_utils.cpp
@@ -38,7 +38,7 @@
 #endif
 
 
-namespace at { namespace cuda { namespace jit {
+namespace at::cuda::jit {
 
 // hiprtc already includes some traits, so this removes duplicate definitions of
 // integral_constant, is_same, is_integral, enable_if, is_floating_point, is_arithmetic.
@@ -1657,4 +1657,4 @@ void launch_jitted_pwise_function(
 }
 
 
-}}} // at::cuda::jit
+} // at::cuda::jit

--- a/aten/src/ATen/native/cuda/laguerre_polynomial_l.cu
+++ b/aten/src/ATen/native/cuda/laguerre_polynomial_l.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char laguerre_polynomial_l_name[] = "laguerre_polynomial_l_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(laguerre_polynomial_l_stub, &laguerre_polynomial_l_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -28,8 +28,7 @@
 #include <c10/util/env.h>
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 
@@ -1447,5 +1446,4 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cuda(
 
 REGISTER_DISPATCH(LayerNormKernel, &LayerNormKernelImpl);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/legendre_polynomial_p.cu
+++ b/aten/src/ATen/native/cuda/legendre_polynomial_p.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char legendre_polynomial_p_name[] = "legendre_polynomial_p_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(legendre_polynomial_p_stub, &legendre_polynomial_p_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -67,8 +67,7 @@ const bool use_magma_ = false;
 
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 #if defined(BUILD_LAZY_CUDA_LINALG)
 // All registrations with PyTorch runtime should be done dynamically
 // so if library is lazy loaded it must not export anything, otherwise
@@ -2805,6 +2804,6 @@ struct DispatchInitializer {
 
 }  // namespace lazy_linalg
 #endif
-}}  // namespace at::native
+}  // namespace at::native
 
 #undef ALLOCATE_ARRAY

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -27,8 +27,7 @@
 #include <ATen/ops/zeros.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 cublasOperation_t to_cublas(TransposeType trans) {
   switch (trans) {
@@ -1744,4 +1743,4 @@ void lu_solve_looped_cusolver(const Tensor& LU, const Tensor& pivots, const Tens
 
 #endif  // USE_CUSOLVER
 
-}} // namespace at::native
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
@@ -6,9 +6,7 @@
 
 #ifdef CUDART_VERSION
 
-namespace at {
-namespace cuda {
-namespace solver {
+namespace at::cuda::solver {
 
 template <>
 void getrf<double>(
@@ -1955,8 +1953,6 @@ void xsyevd<c10::complex<double>, double>(
 }
 #endif // USE_CUSOLVER_64_BIT
 
-} // namespace solver
-} // namespace cuda
-} // namespace at
+} // namespace at::cuda::solver
 
 #endif // CUDART_VERSION

--- a/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
@@ -3,7 +3,7 @@
 
 #ifdef CUDART_VERSION
 
-namespace at { namespace cuda {
+namespace at::cuda {
 namespace {
 
 void createCusolverDnHandle(cusolverDnHandle_t *handle) {
@@ -47,6 +47,6 @@ cusolverDnHandle_t getCurrentCUDASolverDnHandle() {
   return handle;
 }
 
-}} // namespace at::cuda
+} // namespace at::cuda
 
 #endif // CUDART_VERSION

--- a/aten/src/ATen/native/cuda/modified_bessel_i0.cu
+++ b/aten/src/ATen/native/cuda/modified_bessel_i0.cu
@@ -18,8 +18,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char modified_bessel_i0_name[] = "modified_bessel_i0_forward";
 
@@ -39,5 +38,4 @@ namespace at {
         }
 
         REGISTER_DISPATCH(special_modified_bessel_i0_stub, &modified_bessel_i0_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/modified_bessel_i1.cu
+++ b/aten/src/ATen/native/cuda/modified_bessel_i1.cu
@@ -18,8 +18,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char modified_bessel_i1_name[] = "modified_bessel_i1_forward";
 
@@ -39,5 +38,4 @@ namespace at {
         }
 
         REGISTER_DISPATCH(special_modified_bessel_i1_stub, &modified_bessel_i1_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/modified_bessel_k0.cu
+++ b/aten/src/ATen/native/cuda/modified_bessel_k0.cu
@@ -18,8 +18,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char modified_bessel_k0_name[] = "modified_bessel_k0_forward";
 
@@ -39,5 +38,4 @@ namespace at {
         }
 
         REGISTER_DISPATCH(special_modified_bessel_k0_stub, &modified_bessel_k0_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/modified_bessel_k1.cu
+++ b/aten/src/ATen/native/cuda/modified_bessel_k1.cu
@@ -18,8 +18,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char modified_bessel_k1_name[] = "modified_bessel_k1_forward";
 
@@ -39,5 +38,4 @@ namespace at {
         }
 
         REGISTER_DISPATCH(special_modified_bessel_k1_stub, &modified_bessel_k1_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/scaled_modified_bessel_k0.cu
+++ b/aten/src/ATen/native/cuda/scaled_modified_bessel_k0.cu
@@ -18,8 +18,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char scaled_modified_bessel_k0_name[] = "scaled_modified_bessel_k0_forward";
 
@@ -39,5 +38,4 @@ namespace at {
         }
 
         REGISTER_DISPATCH(special_scaled_modified_bessel_k0_stub, &scaled_modified_bessel_k0_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/scaled_modified_bessel_k1.cu
+++ b/aten/src/ATen/native/cuda/scaled_modified_bessel_k1.cu
@@ -18,8 +18,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char scaled_modified_bessel_k1_name[] = "scaled_modified_bessel_k1_forward";
 
@@ -39,5 +38,4 @@ namespace at {
         }
 
         REGISTER_DISPATCH(special_scaled_modified_bessel_k1_stub, &scaled_modified_bessel_k1_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_t.cu
+++ b/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_t.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char shifted_chebyshev_polynomial_t_name[] = "shifted_chebyshev_polynomial_t_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(shifted_chebyshev_polynomial_t_stub, &shifted_chebyshev_polynomial_t_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_u.cu
+++ b/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_u.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char shifted_chebyshev_polynomial_u_name[] = "shifted_chebyshev_polynomial_u_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(shifted_chebyshev_polynomial_u_stub, &shifted_chebyshev_polynomial_u_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_v.cu
+++ b/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_v.cu
@@ -8,26 +8,25 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
-        namespace {
-            const char shifted_chebyshev_polynomial_v_name[] = "shifted_chebyshev_polynomial_v_forward";
+namespace at::native {
+namespace {
+const char shifted_chebyshev_polynomial_v_name[] = "shifted_chebyshev_polynomial_v_forward";
 
-            void shifted_chebyshev_polynomial_v_kernel_cuda(TensorIteratorBase& iterator) {
+void shifted_chebyshev_polynomial_v_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "shifted_chebyshev_polynomial_v_cuda", [&]() {
-                    opmath_jitted_gpu_kernel_with_scalars<shifted_chebyshev_polynomial_v_name, scalar_t, scalar_t>(iterator, shifted_chebyshev_polynomial_v_string);
-                });
+    AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "shifted_chebyshev_polynomial_v_cuda", [&]() {
+        opmath_jitted_gpu_kernel_with_scalars<shifted_chebyshev_polynomial_v_name, scalar_t, scalar_t>(iterator, shifted_chebyshev_polynomial_v_string);
+    });
 #else
-                AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "shifted_chebyshev_polynomial_v_cuda", [&]() {
-                    gpu_kernel_with_scalars(iterator, []GPU_LAMBDA(scalar_t x, scalar_t n) -> scalar_t {
-                        return shifted_chebyshev_polynomial_v_forward<scalar_t, true>(x, n);
-                    });
-                });
+    AT_DISPATCH_FLOATING_TYPES(iterator.common_dtype(), "shifted_chebyshev_polynomial_v_cuda", [&]() {
+        gpu_kernel_with_scalars(iterator, []GPU_LAMBDA(scalar_t x, scalar_t n) -> scalar_t {
+            return shifted_chebyshev_polynomial_v_forward<scalar_t, true>(x, n);
+        });
+    });
 #endif
-            } // shifted_chebyshev_polynomial_v_kernel_cuda
-        } // namespace (anonymous)
+} // shifted_chebyshev_polynomial_v_kernel_cuda
 
-        REGISTER_DISPATCH(shifted_chebyshev_polynomial_v_stub, &shifted_chebyshev_polynomial_v_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace (anonymous)
+
+REGISTER_DISPATCH(shifted_chebyshev_polynomial_v_stub, &shifted_chebyshev_polynomial_v_kernel_cuda);
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_w.cu
+++ b/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_w.cu
@@ -8,8 +8,7 @@
 #include <ATen/native/cuda/Math.cuh>
 #include <ATen/native/cuda/jit_utils.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char shifted_chebyshev_polynomial_w_name[] = "shifted_chebyshev_polynomial_w_forward";
 
@@ -29,5 +28,4 @@ namespace at {
         } // namespace (anonymous)
 
         REGISTER_DISPATCH(shifted_chebyshev_polynomial_w_stub, &shifted_chebyshev_polynomial_w_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/spherical_bessel_j0.cu
+++ b/aten/src/ATen/native/cuda/spherical_bessel_j0.cu
@@ -18,8 +18,7 @@
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/complex.h>
 
-namespace at {
-    namespace native {
+namespace at::native {
         namespace {
             const char spherical_bessel_j0_name[] = "spherical_bessel_j0_forward";
 
@@ -39,5 +38,4 @@ namespace at {
         }
 
         REGISTER_DISPATCH(special_spherical_bessel_j0_stub, &spherical_bessel_j0_kernel_cuda);
-    } // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -3,9 +3,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/mps/MPSAllocator.h>
 
-namespace at {
-namespace native {
-namespace mps {
+namespace at::native::mps {
 
 void runMPSGraph(MPSStream* mpsStream, MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results) {
   mpsStream->executeMPSGraph(mpsGraph, feeds, results, SyncType::COMMIT_ADAPTIVE);
@@ -409,6 +407,4 @@ private:
 
 REGISTER_MPS_ALLOCATOR_CALLBACK("mps_graph_cache_callback", MPSGraphCacheCallback);
 
-} // namespace mps
-} // namespace native
-} // namespace at
+} // namespace at::native::mps

--- a/aten/src/ATen/native/mps/TensorFactory.cpp
+++ b/aten/src/ATen/native/mps/TensorFactory.cpp
@@ -9,7 +9,7 @@
 #include <ATen/native/Resize.h>
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/TensorFactory.h>
-namespace at { namespace native {
+namespace at::native {
 
 static inline void maybe_resize_storage_mps(TensorImpl* self, uint64_t new_size) {
   if (new_size == 0) {
@@ -133,5 +133,5 @@ Tensor& set_storage_mps_(Tensor& result, Storage storage, int64_t storage_offset
   at::native::resize_impl_mps_(result.unsafeGetTensorImpl(), size, stride_opt);
   return result;
 }
-} // namespace native
-} // namespace at
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -13,8 +13,7 @@
 
 using namespace at::mps;
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Tensor relu_mps(const Tensor& self) {
   using namespace mps;
@@ -2322,5 +2321,4 @@ Tensor hardswish_backward_mps(const Tensor& grad_output, const Tensor& self) {
   }
   return grad_input;
 }
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
+++ b/aten/src/ATen/native/mps/operations/AdaptivePooling.mm
@@ -9,8 +9,7 @@
 #include <ATen/native/Pool.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 
 void set_kernel_params
@@ -288,5 +287,4 @@ TORCH_IMPL_FUNC(adaptive_max_pool2d_backward_out_mps)
 
 }
 
-}
-}
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -9,8 +9,7 @@
 #include <c10/util/Optional.h>
 #include <ATen/native/BinaryOps.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 struct BinaryOpCachedGraph : public MPSCachedGraph
@@ -349,5 +348,4 @@ TORCH_IMPL_FUNC(logaddexp2_out_mps) (const Tensor& self, const Tensor& other, co
   mps::binaryOpTensor(self, other, Scalar(1.0), output, "logaddexp2_out_mps", logaddexp2_op_block);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Blas.mm
+++ b/aten/src/ATen/native/mps/operations/Blas.mm
@@ -13,8 +13,7 @@
 #endif
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 
 Tensor dot_mps(
@@ -215,5 +214,4 @@ TORCH_IMPL_FUNC(addmv_out_mps)(const Tensor &self, const Tensor &mat, const Tens
   addmv_out_mps_impl(self, mat, vec, beta_, alpha_, const_cast<Tensor&>(result));
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/ConstantOps.mm
+++ b/aten/src/ATen/native/mps/operations/ConstantOps.mm
@@ -2,8 +2,7 @@
 
 #include <ATen/native/mps/OperationUtils.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Tensor& fill_scalar_mps_impl(Tensor& self, const Scalar& value) {
   using namespace mps;
@@ -112,5 +111,4 @@ Tensor& fill_tensor_mps_(Tensor& self, const Tensor& value) {
   return fill_scalar_mps_impl(self, scalar_value);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -9,8 +9,7 @@
 #include <ATen/native/ConvUtils.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // Create convolution descriptor
 void fill_conv_desc(MPSGraphConvolution2DOpDescriptor* descriptor_,
@@ -532,5 +531,4 @@ std::tuple<Tensor,Tensor> mps_convolution_transpose_backward(
 }
 
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -13,8 +13,7 @@
 #include <c10/util/Optional.h>
 
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 void* pageAlignedBlockPtr(
@@ -335,5 +334,5 @@ Tensor _copy_from_mps(const at::Tensor& self, const at::Tensor& dst, bool non_bl
 {
   return mps::mps_copy_(const_cast<Tensor&>(dst), self, non_blocking);
 }
-} // namespace native
-} // namespace at
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/CrossKernel.mm
+++ b/aten/src/ATen/native/mps/operations/CrossKernel.mm
@@ -3,8 +3,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/Cross.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 static const char* METAL_CROSS = R"CROSS_METAL(
 
@@ -203,5 +202,4 @@ void cross_mps_impl(const Tensor& out, const Tensor& input, const Tensor& other,
 
 REGISTER_DISPATCH(cross_stub, &cross_mps_impl);
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -7,8 +7,7 @@
 #include <ATen/mps/MPSGeneratorImpl.h>
 #include <ATen/native/TensorFactories.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 struct RandomCachedGraph : public MPSCachedGraph
@@ -636,5 +635,4 @@ Tensor multinomial_mps(
   return result;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Eye.mm
+++ b/aten/src/ATen/native/mps/operations/Eye.mm
@@ -30,8 +30,7 @@
 //
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Tensor& eye_out_mps(int64_t n, Tensor& result) {
   // the default value of `m` equals to `n`
@@ -115,5 +114,4 @@ Tensor& eye_out_mps(int64_t n, int64_t m, Tensor& result) {
 }
 
 
-}
-}
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Indexing.mm
+++ b/aten/src/ATen/native/mps/operations/Indexing.mm
@@ -27,8 +27,7 @@
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 static
 bool dispatchIndexKernel(TensorIteratorBase& iter,
@@ -883,5 +882,4 @@ Tensor & masked_fill__mps(Tensor& self, const Tensor & mask, const Tensor & valu
 
 REGISTER_DISPATCH(index_stub, &index_kernel_mps);
 REGISTER_DISPATCH(index_put_stub, &index_put_kernel_mps);
-} // native
-} // at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Inverse.mm
+++ b/aten/src/ATen/native/mps/operations/Inverse.mm
@@ -5,8 +5,7 @@
 #include <c10/util/Optional.h>
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 TORCH_IMPL_FUNC(linalg_inv_ex_out_mps)(const Tensor& A, bool check_errors, const Tensor& result, const Tensor& info)
 {
@@ -83,5 +82,5 @@ TORCH_IMPL_FUNC(linalg_inv_ex_out_mps)(const Tensor& A, bool check_errors, const
         }
     }
 }
-}
-}
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -2,8 +2,7 @@
 
 #include <ATen/native/mps/OperationUtils.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 using namespace mps;
 
@@ -349,5 +348,4 @@ std::tuple<Tensor, Tensor, Tensor> mps_linear_backward(
   return std::tuple<Tensor, Tensor, Tensor>{grad_input, grad_weight, grad_bias};
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -13,8 +13,7 @@
 #endif
 
 
-namespace at {
-namespace native {
+namespace at::native {
 
 /*
  * Helper functions to be used for mm/addmm for detecting the Transpositions
@@ -597,5 +596,4 @@ Tensor &addbmm_mps_(Tensor& self, const Tensor& batch1, const Tensor& batch2, co
   return addbmm_out_mps(self, batch1, batch2, beta, alpha, self);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -9,8 +9,7 @@
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 string reductionToString(int64_t reduction)
@@ -1615,5 +1614,4 @@ Tensor nll_loss2d_backward_mps(
 }
 
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -10,8 +10,7 @@
 #include <ATen/native/layer_norm.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 void get_shapes(MPSShape* input_shape_readonly,
                 NSMutableArray<NSNumber*>* &input_shape,
@@ -1269,5 +1268,4 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(
 
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -3,8 +3,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <c10/util/Optional.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 // Pad operations (1D/2D/3D forward and backward)
@@ -398,5 +397,4 @@ Tensor constant_pad_nd_mps(const Tensor& self, IntArrayRef pad, const Scalar& va
   return mps::pad_out_template(output, self, pad, c10::nullopt, MPSGraphPaddingModeConstant, value.toDouble(), __func__);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/PointwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/PointwiseOps.mm
@@ -2,8 +2,7 @@
 
 #include <ATen/native/mps/OperationUtils.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 // scope the MPS's internal methods to not expose them to at::native
 namespace mps {
 
@@ -114,5 +113,4 @@ TORCH_IMPL_FUNC(addcdiv_out_mps)
   mps::addc_mul_div_out_mps(self, tensor1, tensor2, value, const_cast<Tensor&>(output), true, "addcdiv_out_mps");
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -3,8 +3,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/Pool.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 struct PoolingCachedGraph : public MPSCachedGraph
@@ -345,5 +344,4 @@ TORCH_IMPL_FUNC(avg_pool2d_backward_out_mps) (
                        std::string("avg_pool2d_backward") + (count_include_pad ? "_include_pad" : ""));
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -10,8 +10,7 @@
 #include <cmath>
 #include <limits>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 namespace {
 struct RangeCachedGraph : public mps::MPSCachedGraph {
@@ -192,4 +191,5 @@ Tensor& linspace_out_mps(const Scalar& start, const Scalar& end, int64_t steps, 
   }
   return result;
 }
-}} // namespace at::native
+
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -12,8 +12,7 @@
 #include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <c10/util/irange.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 typedef MPSGraphTensor* (^NormOpBlock)(mps::MPSBinaryCachedGraph*, MPSGraphTensor*, MPSGraphTensor*);
 #define NormOpFn(graph, primary, secondary) MPSGraphTensor* (mps::MPSBinaryCachedGraph* graph, MPSGraphTensor* primary, MPSGraphTensor* secondary)
@@ -1974,5 +1973,4 @@ TORCH_API ::std::tuple<at::Tensor &,at::Tensor &> median_out_mps(
   return std::tuple<Tensor&, Tensor&>{values, indices};
 }
 
-} // native
-} // at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -13,8 +13,7 @@
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Tensor permute_mps(const Tensor& self, IntArrayRef dims) {
   auto nDims = self.dim();
@@ -114,5 +113,4 @@ Tensor repeat_mps(const Tensor& self, IntArrayRef repeats) {
   return result;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at:;native

--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -12,8 +12,7 @@
 #import <MetalPerformanceShadersGraph/MPSGraphRNNOps.h>
 #include <torch/library.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 std::vector<long long> getTensorShape(MPSGraphTensor* mpsTensor) {
     std::vector<long long> output_dimensions = {};
@@ -511,4 +510,5 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
 
     }
 }
-}}//at::native
+
+} //namespace at::native

--- a/aten/src/ATen/native/mps/operations/Scalar.mm
+++ b/aten/src/ATen/native/mps/operations/Scalar.mm
@@ -16,8 +16,7 @@
 
 using namespace at::mps;
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Scalar _local_scalar_dense_mps(const Tensor& self) {
   Scalar r;
@@ -35,5 +34,4 @@ Scalar _local_scalar_dense_mps(const Tensor& self) {
 }
 
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -2,8 +2,7 @@
 
 #include <ATen/native/mps/OperationUtils.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 TORCH_IMPL_FUNC(gather_out_mps)
 (const Tensor & self_arg,
@@ -413,5 +412,4 @@ TORCH_IMPL_FUNC(scatter_add_mps_out)
   scatter_mps_general(self, dim, index, src, output, "scatter_add_mps_out", "add");
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Shape.mm
+++ b/aten/src/ATen/native/mps/operations/Shape.mm
@@ -6,8 +6,7 @@
 #include <ATen/native/TensorShape.h>
 #include <ATen/native/mps/OperationUtils.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 // topk
 TORCH_IMPL_FUNC(topk_out_mps)
@@ -375,5 +374,4 @@ TORCH_IMPL_FUNC(cat_out_mps)
   }
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/SoftMax.mm
+++ b/aten/src/ATen/native/mps/operations/SoftMax.mm
@@ -13,8 +13,7 @@
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
 #endif
 
-namespace at {
-namespace native {
+namespace at::native {
 
 void get_shapes(MPSShape* input_shape_readonly,
                 NSMutableArray<NSNumber*>* &input_shape,
@@ -272,5 +271,4 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
   }
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/SummaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/SummaryOps.mm
@@ -2,8 +2,7 @@
 
 #include <ATen/native/mps/OperationUtils.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 Tensor& bincount_mps_impl(const Tensor& self,
                           const Tensor& weights,
@@ -151,5 +150,4 @@ Tensor _bincount_mps(const Tensor& self, const c10::optional<Tensor>& weights_op
   return bincount_mps_impl(self, weights_, output);
 }
 
-}
-}
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/TensorCompare.mm
+++ b/aten/src/ATen/native/mps/operations/TensorCompare.mm
@@ -4,8 +4,7 @@
 #include <ATen/native/TensorCompare.h>
 #include <ATen/native/Resize.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 struct CachedGraph : public MPSCachedGraph
@@ -515,5 +514,4 @@ Tensor& nan_to_num_out_mps(const Tensor& self,
   return result;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/TriangularOps.mm
+++ b/aten/src/ATen/native/mps/operations/TriangularOps.mm
@@ -11,8 +11,7 @@
 
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 
 TORCH_IMPL_FUNC(triu_mps_out)
 (const Tensor& self,
@@ -172,5 +171,4 @@ TORCH_IMPL_FUNC(tril_mps_out)
 
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -3,8 +3,7 @@
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/MPSGraphVenturaOps.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 typedef MPSGraphTensor* (^UnaryOpBlock)(MPSGraph*, MPSGraphTensor*);
@@ -270,5 +269,4 @@ TORCH_IMPL_FUNC(cumsum_out_mps)
     });
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Unique.mm
+++ b/aten/src/ATen/native/mps/operations/Unique.mm
@@ -5,8 +5,7 @@
 #include <ATen/native/Resize.h>
 #include <ATen/mps/MPSAllocator.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 struct UniqueCachedGraph : public MPSCachedGraph
@@ -360,5 +359,4 @@ _unique2_mps(const Tensor& self, const bool sorted, const bool return_inverse, c
   return _unique_impl_mps(self, return_inverse, return_counts, false, c10::nullopt);
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/UpSample.mm
+++ b/aten/src/ATen/native/mps/operations/UpSample.mm
@@ -4,8 +4,7 @@
 #include <ATen/native/mps/MPSGraphVenturaOps.h>
 #include <ATen/native/UpSample.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 // Upsampling operations (1D/2D forward and backward)
@@ -389,5 +388,4 @@ TORCH_IMPL_FUNC(upsample_bilinear2d_backward_out_mps) (
   }
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -4,8 +4,7 @@
 #include <ATen/native/Resize.h>
 #include <ATen/mps/MPSAllocator.h>
 
-namespace at {
-namespace native {
+namespace at::native {
 namespace mps {
 
 struct ViewCachedGraph : public MPSCachedGraph
@@ -743,5 +742,4 @@ Tensor as_strided_tensorimpl_mps(const Tensor& self, IntArrayRef size, IntArrayR
   return result;
 }
 
-} // namespace native
-} // namespace at
+} // namespace at::native

--- a/torch/csrc/jit/api/function_impl.cpp
+++ b/torch/csrc/jit/api/function_impl.cpp
@@ -12,8 +12,7 @@
 #include <torch/csrc/jit/passes/autocast.h>
 #endif
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 namespace {
 c10::FunctionSchema defaultSchemaFor(const GraphFunction& function) {
   std::vector<c10::Argument> args;
@@ -148,5 +147,4 @@ const GraphFunction& toGraphFunction(const Function& function) {
   return toGraphFunctionImpl<const GraphFunction>(function);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -19,8 +19,7 @@
 #include <torch/csrc/jit/passes/inliner.h>
 #include <torch/csrc/jit/runtime/operator.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 namespace {
 
@@ -625,8 +624,7 @@ void Module::dump(
             << std::endl;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit
 
 namespace c10 {
 

--- a/torch/csrc/jit/api/module_save.cpp
+++ b/torch/csrc/jit/api/module_save.cpp
@@ -1,8 +1,7 @@
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/serialization/export.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 void Module::save(std::ostream& out, const ExtraFilesMap& extra_files) const {
   ExportModule(*this, out, extra_files, false /* bytecode_format */);
@@ -41,5 +40,4 @@ void Module::_save_for_mobile(
       use_flatbuffer);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/api/object.cpp
+++ b/torch/csrc/jit/api/object.cpp
@@ -5,8 +5,7 @@
 #include <torch/csrc/jit/frontend/resolver.h>
 #include <torch/csrc/jit/frontend/sugared_value.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 Object::Object(
     std::shared_ptr<CompilationUnit> cu,
@@ -38,5 +37,4 @@ Object Object::deepcopy() const {
   return Object(_ivalue()->deepcopy());
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/builtin_functions.cpp
+++ b/torch/csrc/jit/frontend/builtin_functions.cpp
@@ -5,8 +5,7 @@
 #include <torch/csrc/api/include/torch/jit.h>
 #include <torch/csrc/jit/frontend/resolver.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 auto scalar_operators_source = at::jit::CodeTemplate(
     R"SCRIPT(
@@ -183,5 +182,4 @@ const std::vector<Function*>& getAllBuiltinFunctionsFor(Symbol name) {
   return registry.getAllBuiltinFunctionsFor(name);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/canonicalize_modified_loop.cpp
+++ b/torch/csrc/jit/frontend/canonicalize_modified_loop.cpp
@@ -7,8 +7,7 @@
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/ir_views.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 // Transforms a Loop that has both a trip count specified and a loop
 // body condition so that the iter count is no longer specified
@@ -66,5 +65,4 @@ TORCH_API void CanonicalizeModifiedLoops(std::shared_ptr<Graph>& graph) {
   canonicalizeModifiedLoops(graph->block());
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/concrete_module_type.cpp
+++ b/torch/csrc/jit/frontend/concrete_module_type.cpp
@@ -3,8 +3,7 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 ClassTypePtr ConcreteModuleTypeBuilder::createTypeFromThis() const {
   auto cu = get_python_cu();
@@ -374,5 +373,4 @@ ConcreteModuleType::getModulesPy() const {
   return ret;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/convert_to_ssa.cpp
+++ b/torch/csrc/jit/frontend/convert_to_ssa.cpp
@@ -6,8 +6,7 @@
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/ir_views.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 // At the beginning of the pass the Graph has already undergone type checking,
 // and writes or reads to a variable are emitted as Loads and Stores in the
@@ -345,5 +344,4 @@ void ConvertToSSA(std::shared_ptr<Graph>& graph) {
   TransformExits(graph);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/edit_distance.cpp
+++ b/torch/csrc/jit/frontend/edit_distance.cpp
@@ -3,8 +3,7 @@
 #include <cstring>
 #include <memory>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 // computes levenshtein edit distance between two words
 // returns maxEditDistance + 1 if the edit distance exceeds MaxEditDistance
@@ -53,5 +52,4 @@ size_t ComputeEditDistance(
   return result;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/error_report.cpp
+++ b/torch/csrc/jit/frontend/error_report.cpp
@@ -4,8 +4,7 @@
 #include <torch/csrc/jit/frontend/tree.h>
 #include <torch/csrc/utils/memory.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 // Avoid storing objects with destructor in thread_local for mobile build.
 #ifndef C10_MOBILE
@@ -82,5 +81,4 @@ const char* ErrorReport::what() const noexcept {
   return the_message.c_str();
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/exit_transforms.cpp
+++ b/torch/csrc/jit/frontend/exit_transforms.cpp
@@ -8,8 +8,7 @@
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/runtime/graph_iterator.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 // WILL states that a node/block must hit the exit, MIGHT that it may happen,
 // WONT that it will not happen. THROWS states that a node/block always throws,
@@ -846,5 +845,5 @@ void TransformExits(std::shared_ptr<Graph>& graph) {
   inlineConsecutiveIfs(graph->block());
   convertWithBlocksToEnterExitNodes(graph);
 }
-} // namespace jit
-} // namespace torch
+
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -23,8 +23,7 @@ using c10::make_right;
 using c10::OperatorName;
 using c10::OptionalType;
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 namespace {
 struct SchemaParser {
@@ -390,5 +389,4 @@ OperatorName parseName(const std::string& name) {
   return std::move(parsed.left());
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/inline_loop_condition.cpp
+++ b/torch/csrc/jit/frontend/inline_loop_condition.cpp
@@ -6,8 +6,7 @@
 #include <torch/csrc/jit/frontend/inline_loop_condition.h>
 #include <torch/csrc/jit/ir/ir.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 void InlineBlockBeforeNode(Node* before_node, Block* block) {
   for (auto it = block->nodes().begin(); it != block->nodes().end();) {
@@ -61,5 +60,4 @@ void InlineLoopCondition(std::shared_ptr<Graph>& graph) {
   inlineLoopCondition(graph->block());
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -43,8 +43,7 @@
 #include <set>
 #include <stack>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 using FunctionTable = std::unordered_map<std::string, Function&>;
 using ValueTable = std::unordered_map<std::string, SugaredValuePtr>;
@@ -5682,5 +5681,4 @@ void CompilationUnit::define_interface(
   this->register_type(iface);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/lexer.cpp
+++ b/torch/csrc/jit/frontend/lexer.cpp
@@ -6,8 +6,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 static const std::unordered_map<int, int> binary_prec = {
     {TK_IF, 1},
@@ -103,5 +102,4 @@ C10_EXPORT SharedParserData& sharedParserData() {
   return data;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/name_mangler.cpp
+++ b/torch/csrc/jit/frontend/name_mangler.cpp
@@ -1,7 +1,6 @@
 #include <torch/csrc/jit/frontend/name_mangler.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 c10::QualifiedName NameMangler::mangle(const c10::QualifiedName& name) {
   static const std::string manglePrefix = "___torch_mangle_";
@@ -34,5 +33,4 @@ c10::QualifiedName NameMangler::mangle(const c10::QualifiedName& name) {
   return c10::QualifiedName(atoms);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/parser.cpp
+++ b/torch/csrc/jit/frontend/parser.cpp
@@ -6,8 +6,7 @@
 #include <torch/csrc/jit/frontend/tree.h>
 #include <torch/csrc/jit/frontend/tree_views.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 Decl mergeTypesFromTypeComment(
     const Decl& decl,
@@ -822,5 +821,4 @@ Expr Parser::parseExp() {
   return pImpl->parseExp();
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -14,8 +14,7 @@
 #include <torch/csrc/jit/operator_upgraders/version_map.h>
 #include <torch/csrc/jit/runtime/operator.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 static inline TypePtr unwrapOptional(TypePtr opt_type) {
   if (auto dyn = opt_type->castRaw<c10::DynamicType>()) {
@@ -777,5 +776,4 @@ Value* emitBuiltinCall(
   }
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -40,8 +40,7 @@ using c10::TupleType;
 using c10::UnionType;
 using c10::VarType;
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 TypePtr SchemaTypeParser::parseBaseType() {
   static std::unordered_map<std::string, TypePtr> type_map = {
@@ -462,5 +461,4 @@ void SchemaTypeParser::parseList(
     L.expect(end);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -5,8 +5,7 @@
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/custom_class.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 namespace {
 
 bool isTorch(const Expr& expr) {
@@ -484,5 +483,4 @@ c10::IValue ScriptTypeParser::parseClassConstant(const Assign& assign) {
   return *default_val.begin();
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/source_range.cpp
+++ b/torch/csrc/jit/frontend/source_range.cpp
@@ -2,8 +2,7 @@
 #include <torch/csrc/jit/frontend/source_range.h>
 #include <torch/csrc/jit/serialization/source_range_serialization.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 // A stringlike class backed by a vector of string_view
 // the string represented are logically the concatenation of  the string_views
@@ -333,5 +332,4 @@ void SourceRange::print_with_context(
   }
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/strtod.cpp
+++ b/torch/csrc/jit/frontend/strtod.cpp
@@ -28,8 +28,7 @@
 #include <cstring>
 #include <locale>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 #ifdef _MSC_VER
 double strtod_c(const char* nptr, char** endptr) {
@@ -48,5 +47,4 @@ float strtof_c(const char* nptr, char** endptr) {
   return (float)strtod_c(nptr, endptr);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -6,8 +6,7 @@
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/passes/constant_propagation.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 struct NoneValue : SugaredValue {
   NoneValue() = default;
@@ -775,5 +774,4 @@ SugaredValuePtr SugaredEnumClass::iter(
   return enum_values_list_constant;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -26,9 +26,7 @@
 #include <sstream>
 #include <string>
 
-namespace torch {
-namespace jit {
-namespace tracer {
+namespace torch::jit::tracer {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Recording the traces
@@ -1114,6 +1112,4 @@ void _do_warn(const char* _reason, const char* _kind) {
 void setWarn(warn_fn_type fn) {
   warn_callback.store(fn);
 }
-} // namespace tracer
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tracer

--- a/torch/csrc/jit/frontend/tree_views.cpp
+++ b/torch/csrc/jit/frontend/tree_views.cpp
@@ -1,7 +1,6 @@
 #include <torch/csrc/jit/frontend/tree_views.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 namespace {
 void collectUnresolvedNames(
@@ -53,5 +52,4 @@ std::vector<std::string> getUnresolvedClassAttributes(const ClassDef& def) {
        Maybe<List<Assign>>::create(range, assigns)}));
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/frontend/versioned_symbols.cpp
+++ b/torch/csrc/jit/frontend/versioned_symbols.cpp
@@ -5,8 +5,7 @@
 
 #include <unordered_map>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 // Note [Versioned Symbols]
 // When the schema or behavior of a symbol changes, serialized Torchscript
 // programs using that symbol are likely to break. To prevent those breaks,
@@ -106,5 +105,4 @@ uint64_t get_min_version_for_kind(const NodeKind& kind) {
   return it->second;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -11,8 +11,7 @@
 #include <torch/csrc/utils/memory.h>
 #include <fstream>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 namespace {
 
@@ -1981,5 +1980,4 @@ void Lint(const AliasDb* db) {
   // - All container values have contained elements
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/ir/attributes.cpp
+++ b/torch/csrc/jit/ir/attributes.cpp
@@ -2,8 +2,7 @@
 #include <torch/csrc/jit/ir/attributes.h>
 #include <torch/csrc/jit/ir/ir.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 AttributeValue::Ptr GraphAttr::clone() const {
   return Ptr(new GraphAttr(name, value_->copy()));
@@ -17,5 +16,4 @@ std::unique_ptr<AttributeValue> GraphsAttr::clone() const {
   return Ptr(new GraphsAttr(name, std::move(copy)));
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/ir/constants.cpp
+++ b/torch/csrc/jit/ir/constants.cpp
@@ -6,8 +6,7 @@
 #include <torch/csrc/jit/runtime/custom_operator.h>
 #include <torch/csrc/jit/runtime/operator.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 bool insertableTensor(const at::Tensor& ten) {
   // bail if tensor has no storage i.e. opaque tensor used in MKLdnn.
@@ -214,5 +213,4 @@ c10::optional<IValue> toIValue(const Value* v) {
   }
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -23,8 +23,7 @@
 #include <unordered_set>
 #include <utility>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 namespace utils {
 std::string getNodesModuleHierarchy(const Node& n) {
@@ -2315,5 +2314,4 @@ bool Node::isMemberOf(const OperatorSet& os) const {
   return false;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/ir/irparser.cpp
+++ b/torch/csrc/jit/ir/irparser.cpp
@@ -16,8 +16,7 @@
 #include <string>
 #include <vector>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 struct VarWithType;
 struct ParsedLiteral;
@@ -649,5 +648,4 @@ Value* IRParser::findValueInVMap(const std::string& name) {
   return vmap.at(name);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/ir/node_hashing.cpp
+++ b/torch/csrc/jit/ir/node_hashing.cpp
@@ -11,8 +11,7 @@
 #include <torch/csrc/jit/ir/node_hashing.h>
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 namespace {
 
@@ -238,7 +237,7 @@ size_t HashNode::operator()(const Node* k) const {
       fmap(k->outputs(), [](const Value* v) { return v->type()->kind(); }),
       fmap(k->inputs(), [](const Value* v) { return v->unique(); }),
       constant_hash);
-};
+}
 
 // Checks that two nodes have the same inputs, output types
 // and node attributes.
@@ -285,7 +284,6 @@ bool EqualNode::operator()(const Node* lhs, const Node* rhs) const {
   }
 
   return true;
-};
+}
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/ir/scope.cpp
+++ b/torch/csrc/jit/ir/scope.cpp
@@ -3,8 +3,7 @@
 #include <ATen/core/class_type.h>
 #include <ATen/core/function.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 // util functions
 namespace utils {
 
@@ -197,5 +196,4 @@ ModuleInstanceInfo::ModuleInstanceInfo(
     std::string instance_name)
     : module_type_(std::move(module_type)),
       instance_name_(std::move(instance_name)) {}
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/ir/subgraph_matcher.cpp
+++ b/torch/csrc/jit/ir/subgraph_matcher.cpp
@@ -5,8 +5,7 @@
 #include <regex>
 #include <stack>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 namespace {
 
 /**
@@ -367,5 +366,4 @@ std::vector<Match> findPatternMatches(const Graph& pattern, Graph& graph) {
   return matches;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/ir/type_hashing.cpp
+++ b/torch/csrc/jit/ir/type_hashing.cpp
@@ -6,8 +6,7 @@
 #include <c10/util/hash.h>
 #include <torch/csrc/jit/ir/ir.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 namespace {
 size_t hashType(const Type& type) {
@@ -41,5 +40,4 @@ bool EqualType::operator()(
   return *a == *b;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -119,8 +119,7 @@
 #include <tuple>
 #include <utility>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 using c10::AliasInfo;
 using c10::Argument;
@@ -1998,5 +1997,5 @@ void initJITBindings(PyObject* module) {
   atexit.attr("register")(
       py::cpp_function([]() { setPrintHandler(getDefaultPrintHandler()); }));
 }
-} // namespace jit
-} // namespace torch
+
+} // namespace torch::jit

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -12,8 +12,7 @@
 
 #include <limits>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 static thread_local bool allow_numbers_as_tensors = false;
 
@@ -789,5 +788,4 @@ py::object _get_operation_for_overload_or_packet(
   return invokeOperatorFromPython(operations, args, kwargs, dk);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/python/python_arg_flatten.cpp
+++ b/torch/csrc/jit/python/python_arg_flatten.cpp
@@ -5,9 +5,7 @@
 
 #include <torch/csrc/autograd/grad_mode.h>
 
-namespace torch {
-namespace jit {
-namespace python {
+namespace torch::jit::python {
 
 using namespace torch::autograd;
 using namespace at;
@@ -194,6 +192,4 @@ PyObject* unflatten(ArrayRef<Variable> vars, const IODescriptor& desc) {
   return output.release().ptr();
 }
 
-} // namespace python
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::python

--- a/torch/csrc/jit/python/python_custom_class.cpp
+++ b/torch/csrc/jit/python/python_custom_class.cpp
@@ -4,8 +4,7 @@
 
 #include <fmt/format.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 struct CustomMethodProxy;
 struct CustomObjectProxy;
@@ -98,5 +97,4 @@ void initPythonCustomClassBindings(PyObject* module) {
       });
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/python/python_dict.cpp
+++ b/torch/csrc/jit/python/python_dict.cpp
@@ -8,8 +8,7 @@
 #include <sstream>
 #include <stdexcept>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 IValue ScriptDictIterator::next() {
   if (iter_ == end_) {
@@ -198,5 +197,4 @@ void initScriptDictBindings(PyObject* module) {
                                    // long as the iterator
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/python/python_interpreter.cpp
+++ b/torch/csrc/jit/python/python_interpreter.cpp
@@ -23,8 +23,7 @@
 
 namespace py = pybind11;
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 namespace {
 
@@ -84,5 +83,4 @@ RegisterOperators reg({Operator(
     aliasAnalysisIsSpecialCase())});
 
 } // namespace
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -23,8 +23,7 @@
 #include <sstream>
 #include <utility>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 // Controls whether graph source ranges are printed by default
 bool global_print_source_ranges = true;
@@ -1145,5 +1144,4 @@ void initPythonIRBindings(PyObject* module_) {
             return g.graph_output_to_symbolic_shape_dim_;
           });
 }
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/python/python_list.cpp
+++ b/torch/csrc/jit/python/python_list.cpp
@@ -7,8 +7,7 @@
 #include <torch/csrc/utils/pybind.h>
 #include <stdexcept>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 IValue ScriptListIterator::next() {
   if (iter_ == end_) {
@@ -313,5 +312,4 @@ void initScriptListBindings(PyObject* module) {
           }));
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -18,8 +18,7 @@
 
 #include <Python.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 std::string typeString(py::handle h) {
   return py::str(h.get_type().attr("__name__"));
@@ -1373,5 +1372,4 @@ std::shared_ptr<SugaredValue> toSugaredValue(
 
   return std::make_shared<PythonValue>(obj);
 }
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/python/python_tracer.cpp
+++ b/torch/csrc/jit/python/python_tracer.cpp
@@ -18,9 +18,7 @@ using namespace torch::autograd;
 using namespace torch::jit;
 using namespace torch::jit::tracer;
 
-namespace torch {
-namespace jit {
-namespace tracer {
+namespace torch::jit::tracer {
 
 // Python interpreter retrieval routine adapted from
 // https://stackoverflow.com/a/8706144
@@ -285,6 +283,4 @@ void initPythonTracerBindings(PyObject* module) {
   });
 }
 
-} // namespace tracer
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tracer

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -10,8 +10,7 @@
 
 namespace py = pybind11;
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 c10::optional<std::string> maybeConvertToString(const py::object& obj) {
   if (obj.is_none()) {
@@ -409,5 +408,4 @@ void initTreeViewBindings(PyObject* module) {
           [](const SourceRange& range) { return Maybe<Expr>::create(range); }));
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -70,8 +70,7 @@
 #include <utility>
 #include <vector>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 using ::c10::Argument;
 using ::c10::FunctionSchema;
@@ -2388,5 +2387,5 @@ void initJitScriptBindings(PyObject* module) {
   initScriptDictBindings(module);
   initScriptListBindings(module);
 }
-} // namespace jit
-} // namespace torch
+
+} // namespace torch::jit

--- a/torch/csrc/jit/python/update_graph_executor_opt.cpp
+++ b/torch/csrc/jit/python/update_graph_executor_opt.cpp
@@ -1,7 +1,6 @@
 #include <torch/csrc/jit/python/update_graph_executor_opt.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 thread_local bool kOptimize = true;
 void setGraphExecutorOptimize(bool o) {
@@ -10,5 +9,5 @@ void setGraphExecutorOptimize(bool o) {
 bool getGraphExecutorOptimize() {
   return kOptimize;
 }
-} // namespace jit
-} // namespace torch
+
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
+++ b/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
@@ -3,8 +3,7 @@
 #include <torch/csrc/jit/serialization/callstack_debug_info_serialization.h>
 #include <torch/csrc/jit/serialization/pickle.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 namespace {
 const int64_t kInvalidSourceRangeTag = -1;
@@ -248,5 +247,4 @@ ska::flat_hash_map<int64_t, DebugInfoTuple> CallStackDebugInfoUnpickler::
   return callstack_ptrs;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -35,8 +35,7 @@ C10_DIAGNOSTIC_POP()
 #include <string>
 #include <vector>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 void writeArchiveAndTensors(
     const std::string& archive_name,
@@ -1394,5 +1393,4 @@ void check_onnx_proto(const std::string& proto_string, bool full_check) {
   }
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/export_bytecode.cpp
+++ b/torch/csrc/jit/serialization/export_bytecode.cpp
@@ -30,8 +30,7 @@
 
 #include <caffe2/serialize/inline_container.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 std::vector<Method> gatherGetSetStates(ObjectPtr obj) {
   std::vector<Method> methods;
@@ -401,5 +400,4 @@ mobile::Module jitModuleToMobile(
   return m;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -38,8 +38,7 @@
 #include <unordered_set>
 #include <vector>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 CompilationOptions getOptionsFromGlobal() {
   CompilationOptions compilation_options;
@@ -976,5 +975,4 @@ void BytecodeEmitMode::set_default_emit_promoted_ops_enabled(bool enabled) {
   emitDefaultEmitPromotedOps = enabled;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -29,8 +29,7 @@ namespace flatbuffers = flatbuffers_fbsource;
 #include <torch/csrc/jit/serialization/mobile_bytecode_generated.h> // NOLINT
 #endif
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 using flatbuffers::FlatBufferBuilder;
 using mobile::serialization::CreateArg;
@@ -831,5 +830,4 @@ bool register_flatbuffer_serializer() {
   return true;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/flatbuffer_serializer_jit.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer_jit.cpp
@@ -12,12 +12,10 @@
 #include <torch/csrc/jit/serialization/flatbuffer_serializer.h>
 #include <torch/csrc/jit/serialization/import.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 bool register_flatbuffer_all() {
   return true;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -41,8 +41,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 using caffe2::serialize::FileAdapter;
 using caffe2::serialize::IStreamAdapter;
@@ -593,5 +592,4 @@ Module jitModuleFromSourceAndConstants(
   return m;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/import_export_helpers.cpp
+++ b/torch/csrc/jit/serialization/import_export_helpers.cpp
@@ -8,8 +8,7 @@
 
 #include <algorithm>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 static const std::string kExportSuffix = "py";
 
@@ -53,5 +52,4 @@ std::shared_ptr<Source> findSourceInArchiveFromQualifier(
       gen_ranges);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -18,8 +18,7 @@
 #include <ATen/ATen.h>
 #include <c10/util/irange.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 using caffe2::serialize::PyTorchStreamReader;
 void postSetStateValidate(const IValue& v);
@@ -399,5 +398,4 @@ Module LEGACY_deserialize(
   return deserializer.LEGACY_deserialize();
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/import_read.cpp
+++ b/torch/csrc/jit/serialization/import_read.cpp
@@ -1,8 +1,7 @@
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/jit/serialization/import_read.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 IValue readArchiveAndTensors(
     const std::string& archive_name,
@@ -73,5 +72,4 @@ bool check_zip_file(
   return !(first_short[0] == first_slot && first_short[1] == second_slot);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -9,8 +9,7 @@
 
 #include <regex>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 struct OpsValue : public SugaredValue {
   OpsValue(size_t version) : version_(version) {}
@@ -794,5 +793,4 @@ void SourceImporter::LEGACY_import_methods(
 }
 SourceImporter::~SourceImporter() = default;
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/onnx.cpp
+++ b/torch/csrc/jit/serialization/onnx.cpp
@@ -4,8 +4,8 @@
 
 #include <sstream>
 #include <string>
-namespace torch {
-namespace jit {
+
+namespace torch::jit {
 
 namespace {
 namespace onnx_torch = ::torch::onnx;
@@ -239,5 +239,4 @@ std::string prettyPrint(const ::ONNX_NAMESPACE::ModelProto& model) {
   return ss.str();
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/pickle.cpp
+++ b/torch/csrc/jit/serialization/pickle.cpp
@@ -6,8 +6,7 @@
 #include <torch/csrc/jit/serialization/export.h>
 #include <torch/csrc/jit/serialization/import_read.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 void pickle(
     std::function<void(const char* data_start, size_t data_len)> writer,
@@ -151,5 +150,4 @@ IValue unpickle(
       type_parser);
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -10,8 +10,7 @@
 #include <string>
 #include <type_traits>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 using ::c10::IValue;
 
@@ -788,5 +787,4 @@ bool checkHasValidSetGetState(const std::shared_ptr<c10::ClassType>& cls) {
   return true;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -22,8 +22,7 @@
 
 using c10::QualifiedName;
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 static bool isValidIdentifierChar(char c, size_t pos) {
   return islower(c) || isupper(c) || c == '_' || (pos > 0 && isdigit(c));
@@ -1755,5 +1754,4 @@ void jitModuleToPythonCodeAndConstants(
   }
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/source_range_serialization.cpp
+++ b/torch/csrc/jit/serialization/source_range_serialization.cpp
@@ -7,8 +7,7 @@
 #include <torch/csrc/jit/serialization/pickle.h>
 #include <algorithm>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 // "Whether to emit compact debug_pkl when saving a model to .pt file."
 // "Compact file is smaller but cannot be loaded by old torch binaries."
@@ -252,5 +251,4 @@ TORCH_API void setShouldUseFormatWithStringTable(
   should_use_format_with_string_table_ = should_use_format_with_string_table;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/type_name_uniquer.cpp
+++ b/torch/csrc/jit/serialization/type_name_uniquer.cpp
@@ -1,7 +1,7 @@
 #include <torch/csrc/jit/serialization/type_name_uniquer.h>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
+
 c10::QualifiedName TypeNameUniquer::getUniqueName(c10::ConstNamedTypePtr t) {
   auto it = name_map_.find(t);
   if (it != name_map_.cend()) {
@@ -28,5 +28,5 @@ c10::QualifiedName TypeNameUniquer::getUniqueName(c10::ConstNamedTypePtr t) {
   used_names_.insert(mangled);
   return mangled;
 }
-} // namespace jit
-} // namespace torch
+
+} // namespace torch::jit

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -10,8 +10,7 @@
 #include <torch/csrc/jit/serialization/unpickler.h>
 #include <string>
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 
 using ::c10::IValue;
 
@@ -1111,5 +1110,4 @@ std::string Unpickler::readString() {
   return ss;
 }
 
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit

--- a/torch/csrc/jit/tensorexpr/block_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/block_codegen.cpp
@@ -6,9 +6,7 @@
 #include <torch/csrc/jit/tensorexpr/exceptions.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 std::string blockDtypeCppString(const Dtype& dtype) {
   switch (dtype.scalar_type()) {
@@ -367,6 +365,4 @@ void BlockCodeGen::call_raw(const std::vector<void*>& args) {
 BlockCodeGen::~BlockCodeGen() = default;
 RegisterCodeGen<BlockCodeGen> block_codegen_reg("block_codegen");
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -10,9 +10,7 @@
 
 #include <c10/util/irange.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 using namespace analysis;
 
@@ -369,6 +367,4 @@ bool isOverlapping(
   return hasConflictingOverlap(sBounds, lBounds, kStore, kLoad);
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
@@ -3,10 +3,7 @@
 #include <torch/csrc/jit/tensorexpr/ir_visitor.h>
 #include <torch/csrc/jit/tensorexpr/stmt.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
-namespace analysis {
+namespace torch::jit::tensorexpr::analysis {
 
 // Returns true if the given expression is guaranteed to be positive.
 bool mustBePositive(ExprPtr e) {
@@ -368,7 +365,4 @@ subtractIndicesBounds(const IndexBounds& A, const IndexBounds& B) {
   return subtractIndicesBounds(A, B, overlaps(A, B));
 }
 
-} // namespace analysis
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr::analysis

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -4,9 +4,7 @@
 
 #include <sstream>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 CodeGen::CodeGen(
     StmtPtr stmt,
@@ -319,6 +317,4 @@ void CodeGen::allocIntermediateBufs() {
   GRAPH_DEBUG("\nMemory Allocation:\n\n", *stmt(), "\n");
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/cpp_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cpp_codegen.cpp
@@ -7,9 +7,7 @@
 #include <torch/csrc/jit/tensorexpr/external_functions_registry.h>
 #include <torch/csrc/jit/tensorexpr/types.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 // Rewrites the variables' name according to valid C++ naming convention.
 // E.g. in Graph IR, variable name may contain '.', in C++, they are replaced
@@ -403,6 +401,4 @@ void CppCodeGen::call_raw(const std::vector<void*>& args) {
 
 RegisterCodeGen<CppCodeGen> cpp_codegen_reg("cpp_codegen");
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -15,9 +15,7 @@
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 #include <torch/csrc/jit/tensorexpr/registerizer.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 // A RAII wrapper to manage a variable and name pair in the look-up table.
 // TODO: move this to a more shared place.
@@ -1390,6 +1388,4 @@ CudaCodeGen::~CudaCodeGen() = default;
 
 RegisterCodeGen<CudaCodeGen> cuda_codegen_reg("cuda_codegen");
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -6,9 +6,7 @@
 
 #include <c10/util/irange.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 RegisterCodeGen<SimpleIREvaluator> ir_eval_codegen_reg("simple_ir_eval");
 
@@ -1311,6 +1309,4 @@ c10::optional<int64_t> evalInt(ExprPtr e) {
   }
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/expr.cpp
+++ b/torch/csrc/jit/tensorexpr/expr.cpp
@@ -3,9 +3,7 @@
 #include <torch/csrc/jit/tensorexpr/ir.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 ExprHandle ExprHandle::operator+(const ExprHandle& other) const {
   return Add::make(*this, other);
@@ -565,6 +563,4 @@ ExprHandle expr_to_vec(ExprHandle v, int lanes) {
   }
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -23,9 +23,7 @@
 #include <torch/csrc/jit/tensorexpr/external_functions_registry.h>
 #include <utility>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 c10::MemoryFormat deduce_memory_format(
     c10::IntArrayRef strides,
@@ -1635,6 +1633,4 @@ const static RegisterNNCExternalFunction reg_nnc_prepacked_conv2d_clamp_run(
 } // extern "C"
 #endif
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/external_functions_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions_codegen.cpp
@@ -7,9 +7,7 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/external_functions_registry.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 #ifdef C10_MOBILE
 extern "C" {
@@ -3301,6 +3299,4 @@ const static RegisterNNCExternalFunction nnc_linalg_solve(
 } // extern "C"
 #endif
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/external_functions_core.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions_core.cpp
@@ -1,8 +1,6 @@
 #include <torch/csrc/jit/tensorexpr/external_functions_core.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 #ifdef C10_MOBILE
 extern "C" {
@@ -36,6 +34,4 @@ void nnc_aten_free(int64_t bufs_num, void** ptrs) noexcept {
 } // extern "C"
 #endif
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/external_functions_registry.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions_registry.cpp
@@ -1,14 +1,10 @@
 #include <torch/csrc/jit/tensorexpr/external_functions_registry.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 std::unordered_map<std::string, NNCExternalFunction>& getNNCFunctionRegistry() {
   static std::unordered_map<std::string, NNCExternalFunction> func_registry_;
   return func_registry_;
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/graph_opt.cpp
+++ b/torch/csrc/jit/tensorexpr/graph_opt.cpp
@@ -6,9 +6,7 @@
 #include <torch/csrc/jit/runtime/symbolic_shape_registry_util.h>
 #include <torch/csrc/jit/tensorexpr/kernel.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 // Move the given user of `aten::cat` op to its inputs.
 Node* moveCatAfterUse(Node* cat, Node* user, std::shared_ptr<Graph> subgraph) {
@@ -488,6 +486,4 @@ std::shared_ptr<Graph> trimGraph(
   return graph;
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/hash_provider.cpp
+++ b/torch/csrc/jit/tensorexpr/hash_provider.cpp
@@ -4,9 +4,7 @@
 
 #include <c10/util/irange.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 bool SimplifierHashType::operator==(const SimplifierHashType& other) const {
   return _h == other._h;
@@ -351,6 +349,4 @@ void HashProvider::visit(MinTermPtr v) {
   putHash(v, hash);
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/intrinsic_symbols.cpp
+++ b/torch/csrc/jit/tensorexpr/intrinsic_symbols.cpp
@@ -127,9 +127,7 @@ __m256d Sleef_fmodd4(__m256d, __m256d);
 #endif // __cplusplus
 #endif // !defined(_MSC_VER) && defined(__x86_64__)
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 c10::ArrayRef<SymbolAddress> getIntrinsicSymbols() {
   static SymbolAddress symbolAddresses[] = {
@@ -285,7 +283,5 @@ c10::ArrayRef<SymbolAddress> getIntrinsicSymbols() {
   return c10::ArrayRef<SymbolAddress>(symbolAddresses);
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr
 #endif // TORCH_ENABLE_LLVM

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -6,9 +6,7 @@
 
 #include <utility>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 static Dtype ChooseDtype(const Dtype& buffer_dtype, const Dtype& index_dtype) {
   return Dtype(buffer_dtype, index_dtype.lanes());
@@ -294,6 +292,4 @@ bool immediateIsZero(const ExprPtr& e) {
   return false;
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/ir_cloner.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_cloner.cpp
@@ -6,9 +6,7 @@
 
 #include <c10/util/irange.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 template <
     typename Op,
@@ -369,6 +367,4 @@ ExprPtr Expr::clone(ExprPtr e) {
   return e->accept_mutator(&cloner);
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -7,9 +7,7 @@
 
 #include <c10/util/irange.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 template <
     typename Op,
@@ -615,6 +613,4 @@ StmtPtr IRMutator::mutate(CondPtr v) {
   return v;
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -6,9 +6,7 @@
 
 #include <c10/util/irange.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 std::string IRPrinter::dtypeToCppString(const Dtype& dtype) {
   return dtype.ToCppString();
@@ -667,9 +665,7 @@ void print(const Tensor& t) {
   std::cout << std::to_string(t);
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr
 
 namespace std {
 std::string to_string(ExprPtr expr) {

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -5,9 +5,7 @@
 
 #include <utility>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 // Creates a new Expr of the given type with the provided lhs and rhs.
 inline ExprPtr newBinaryOpOfType(
@@ -3122,6 +3120,4 @@ StmtPtr IRSimplifier::simplify(StmtPtr s) {
   return s;
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/ir_verifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_verifier.cpp
@@ -5,9 +5,7 @@
 #include <torch/csrc/jit/tensorexpr/reduction.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 namespace detail {
 template <typename T>
@@ -204,6 +202,4 @@ void verify(ExprHandle e) {
   verify(e.node());
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -7,9 +7,7 @@
 
 #include <c10/util/irange.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 template <
     typename Op,
@@ -269,6 +267,4 @@ void IRVisitor::visit(ReduceOpPtr v) {
   }
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -23,9 +23,7 @@
 using namespace torch::jit;
 using namespace torch::jit::tensorexpr;
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 std::string buildErrorMessage(const std::string& s) {
   static const std::string generic_error_message =
@@ -388,9 +386,7 @@ bool matmulIsSupported(const torch::jit::Node* node) {
   return true;
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr
 
 static at::ScalarType tensorType(BufPtr b) {
   return static_cast<at::ScalarType>(b->dtype().scalar_type());

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -74,9 +74,7 @@ C10_DEFINE_bool(
     false,
     "Use fast (but slightly less accurate) implementations of tanh and sigmoid");
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 c10::optional<std::string>& LLVMTargetTriple() {
   static c10::optional<std::string> triple = c10::nullopt;
@@ -348,9 +346,7 @@ class LLVMCodeGenImpl : public IRVisitor {
   }
 };
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr
 
 LLVMCodeGen::~LLVMCodeGen() = default;
 

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -31,9 +31,7 @@
 #include <unordered_set>
 #include <vector>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 LoopNest::LoopNest(const LoopNest& other)
     : root_stmt_(Stmt::clone(other.root_stmt_)),
@@ -3428,6 +3426,4 @@ bool LoopNest::rfactor(
   return true;
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
@@ -11,9 +11,7 @@
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 namespace randomization_helper {
 
@@ -745,6 +743,4 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
   return;
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -6,9 +6,7 @@
 #include <ATen/native/Activation.h>
 #include <ATen/native/mkldnn/Common.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 FunctionSchemaMap<NNCLoweringFunction>& getNNCLoweringRegistry() {
   static FunctionSchemaMap<NNCLoweringFunction> lowering_registry_;
@@ -2000,6 +1998,4 @@ NNCLoweringFunction getStandardLoweringFor(const std::string& schema_str) {
   return nullptr;
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -4,10 +4,7 @@
 
 #include <fstream>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
-namespace analysis {
+namespace torch::jit::tensorexpr::analysis {
 
 const char* AccessToString(AccessType a) {
   switch (a) {
@@ -1318,7 +1315,4 @@ std::vector<Bound> MemDependencyChecker::getIndicesBounds(
   return bounds;
 }
 
-} // namespace analysis
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr::analysis

--- a/torch/csrc/jit/tensorexpr/reduction.cpp
+++ b/torch/csrc/jit/tensorexpr/reduction.cpp
@@ -2,9 +2,7 @@
 #include <torch/csrc/jit/tensorexpr/reduction.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 ExprHandle Reducer::operator()(
     BufHandle result_buf,
@@ -65,6 +63,4 @@ ExprHandle ReduceOp::make(
       reducer));
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -1,8 +1,6 @@
 #include <torch/csrc/jit/tensorexpr/registerizer.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 namespace registerizer {
 
 // AccessInfo
@@ -795,6 +793,4 @@ StmtPtr registerize(StmtPtr s) {
   return s;
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/tensor.cpp
+++ b/torch/csrc/jit/tensorexpr/tensor.cpp
@@ -4,9 +4,7 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/reduction.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 StmtPtr Tensor::constructStmt(
     const std::vector<VarPtr>& args,
@@ -258,6 +256,4 @@ Tensor Reduce(
   return Reduce(name, dims, c10::nullopt, reducer, tensor, reduce_dims);
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -20,8 +20,7 @@ template <>
 struct pybind11::detail::type_caster<torch::jit::tensorexpr::ArgValue>
     : public type_caster_base<torch::jit::tensorexpr::ArgValue> {};
 
-namespace torch {
-namespace jit {
+namespace torch::jit {
 using namespace torch::jit::tensorexpr;
 
 ArgValue convertPyToArgValue(py::handle inp) {
@@ -921,5 +920,5 @@ void initTensorExprBindings(PyObject* module) {
   });
 #endif
 }
-} // namespace jit
-} // namespace torch
+
+} // namespace torch::jit

--- a/torch/csrc/jit/tensorexpr/types.cpp
+++ b/torch/csrc/jit/tensorexpr/types.cpp
@@ -5,9 +5,7 @@
 
 #include <c10/util/Logging.h>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 Dtype Dtype::scalar_dtype() const {
   return ToDtype(scalar_type_);
@@ -95,9 +93,7 @@ std::string Dtype::ToCppString() const {
   return "invalid";
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr
 
 namespace std {
 

--- a/torch/csrc/jit/tensorexpr/unique_name_manager.cpp
+++ b/torch/csrc/jit/tensorexpr/unique_name_manager.cpp
@@ -4,9 +4,7 @@
 #include <torch/csrc/jit/tensorexpr/ir.h>
 #include <cctype>
 
-namespace torch {
-namespace jit {
-namespace tensorexpr {
+namespace torch::jit::tensorexpr {
 
 const std::string& UniqueNameManager::get_unique_name(VarPtr v) {
   // Find if we have already encountered this variable.
@@ -44,6 +42,4 @@ const std::string& UniqueNameManager::get_unique_name(const VarHandle& v) {
   return get_unique_name(v.node());
 }
 
-} // namespace tensorexpr
-} // namespace jit
-} // namespace torch
+} // namespace torch::jit::tensorexpr


### PR DESCRIPTION
As we live in C++17 world

This is a functional no-op, just 
- `s/namespace at { namespace native {/namespace at::native {/`
- `s/namespace torch { namespace jit {/namespace torch::jit {/`

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @EikanWang