### PR TITLE
[ONNX] Fix potential flaky test in test_verification.py

### DIFF
--- a/test/onnx/test_verification.py
+++ b/test/onnx/test_verification.py
@@ -190,7 +190,7 @@ class TestFindMismatch(pytorch_test_common.ExportTestCase):
         self.opset_version = _constants.ONNX_DEFAULT_OPSET
 
         def incorrect_relu_symbolic_function(g, self):
-            return self
+            return g.op("Add", self, g.op("Constant", value_t=torch.tensor(1.0)))
 
         torch.onnx.register_custom_op_symbolic(
             "aten::relu",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92105

Very low probability, but it is possible to have all values positive throughout the
execution of this test model. The test tries to fake an incorrect export by replacing
relu's output with its input. However, the behavior of the model is the same when 
values are all positive. Hence leading to false test failure.