### PR TITLE
Make sure we round allocations by at least kMinBlockSize

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1274,9 +1274,6 @@ class DeviceCachingAllocator {
   // them, the values are 1024, 1280, 1536, and 1792. So the function will
   // return 1280 as the nearest ceiling of power-2 divison.
   static size_t roundup_power2_next_division(size_t size, size_t divisions) {
-    if (C10_UNLIKELY(size <= 4 || divisions <= 1)) {
-      return size;
-    }
     if (llvm::isPowerOf2_64(size)) {
       return size;
     }
@@ -1299,7 +1296,7 @@ class DeviceCachingAllocator {
       return kMinBlockSize;
     } else {
       auto divisions = CachingAllocatorConfig::roundup_power2_divisions(size);
-      if (divisions > 0 && size > (kMinBlockSize * divisions)) {
+      if (divisions > 1 && size > (kMinBlockSize * divisions)) {
         return roundup_power2_next_division(size, divisions);
       } else {
         return kMinBlockSize * ((size + kMinBlockSize - 1) / kMinBlockSize);


### PR DESCRIPTION
Summary:
Currently when divisions is set to 1 we enter `roundup_power2_next_division` just to immediately exit returning the original size, thus not aligning the memory allocation to kMinBlockSize

I took this oportunity to remove the if statement inside `roundup_power2_next_division`, becasue:

- `size <= 4` -> this is allready previously satisfied by `if (... && size > (kMinBlockSize * divisions))`
- `divisions <= 1` -> moved this check outside of the function and combined it with the other check on `divisions`, thus we check for`divisions > 1 ` before calling `roundup_power2_next_division`

Test Plan: SandCastle and GitHub tests

Differential Revision: D42481107

