### PR TITLE
MYPYNOFOLLOW for test_utils

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -95,7 +95,6 @@ include_patterns = [
     'test/test_torch.py',
     'test/test_type_hints.py',
     'test/test_type_info.py',
-    'test/test_utils.py',
 ]
 exclude_patterns = [
     'torch/include/**',
@@ -166,6 +165,7 @@ include_patterns = [
     'torch/_dynamo/optimizations/training.py',
     'torch/_inductor/graph.py',
     'torch/_C/_dynamo/**/*.py',
+    'test/test_utils.py',  # used to by in MYPY but after importing op_db and it took 10+ minutes
 ]
 exclude_patterns = [
 ]

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -165,7 +165,7 @@ include_patterns = [
     'torch/_dynamo/optimizations/training.py',
     'torch/_inductor/graph.py',
     'torch/_C/_dynamo/**/*.py',
-    'test/test_utils.py',  # used to by in MYPY but after importing op_db and it took 10+ minutes
+    'test/test_utils.py',  # used to by in MYPY but after importing op_db it took 10+ minutes
 ]
 exclude_patterns = [
 ]

--- a/mypy-nofollow.ini
+++ b/mypy-nofollow.ini
@@ -15,7 +15,8 @@ warn_unused_ignores = False
 disallow_any_generics = True
 
 files =
-    torch/_dynamo
+    torch/_dynamo,
+    test/test_utils.py
 
 # Minimum version supported - variable annotations were introduced
 # in Python 3.7

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,8 +35,7 @@ files =
     test/test_numpy_interop.py,
     test/test_torch.py,
     test/test_type_hints.py,
-    test/test_type_info.py,
-    test/test_utils.py
+    test/test_type_info.py
 
 #
 # `exclude` is a regex, not a list of paths like `files` (sigh)


### PR DESCRIPTION
lintrunner went from 10 minutes to 25 minutes after 333540a458d40603feea84d30e4ad9b96b07318d since test/test_utils.py imports op_db, which takes 10+ minutes to run mypy on, so switch it to the the group of files that doesn't follow imports