### PR TITLE
Replace log(1 + x) with log1p(x)

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -292,7 +292,7 @@ Tensor& binary_cross_entropy_out_cpu(const Tensor& input, const Tensor& target, 
                 // Binary cross entropy tensor is defined by the equation:
                 // L = -w (y ln(x) + (1-y) ln(1-x))
                 return (target_val - scalar_t(1))
-                    * std::max(scalar_t(std::log(scalar_t(1) - input_val)), scalar_t(-100))
+                    * std::max(scalar_t(std::log1p(-input_val)), scalar_t(-100))
                     - target_val * std::max(scalar_t(std::log(input_val)), scalar_t(-100));
             }
         );
@@ -416,8 +416,8 @@ Tensor& soft_margin_loss_out(const Tensor& input,
     const Tensor& target,
     int64_t reduction,
     Tensor& output) {
-  // compute inplace variant of: output = at::log(1. + at::exp(-input * target));
-  at::neg_out(output, input).mul_(target).exp_().add_(1.).log_();
+  // compute inplace variant of: output = at::log1p(at::exp(-input * target));
+  at::neg_out(output, input).mul_(target).exp_().log1p_();
   if (reduction != Reduction::None) {
     auto tmp = apply_loss_reduction(output, reduction);
     output.resize_({});

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -874,7 +874,7 @@ void logaddexp_kernel(TensorIteratorBase& iter) {
             return a0;
           } else {
             float m0 = std::max(a0, b0);
-            return m0 + std::log(static_cast<float>(1.0) + std::exp(-std::abs(a0 - b0)));
+            return m0 + std::log1p(std::exp(-std::abs(a0 - b0)));
           }
         },
         [=](Vectorized<BFloat16> a, Vectorized<BFloat16> b) {
@@ -882,15 +882,14 @@ void logaddexp_kernel(TensorIteratorBase& iter) {
           std::tie(a0, a1) = convert_bfloat16_float(a);
           std::tie(b0, b1) = convert_bfloat16_float(b);
           Vectorized<float> inf(std::numeric_limits<float>::infinity());
-          Vectorized<float> one(1.0);
           Vectorized<float> m0 = maximum(a0, b0);
           Vectorized<float> m1 = maximum(a1, b1);
           a0 = Vectorized<float>::blendv(
-              m0 + (one + (a0 - b0).abs().neg().exp()).log(),
+              m0 + (a0 - b0).abs().neg().exp().log1p(),
               a0,
               (a0 == b0) & (a0.abs() == inf));
           a1 = Vectorized<float>::blendv(
-              m1 + (one + (a1 - b1).abs().neg().exp()).log(),
+              m1 + (a1 - b1).abs().neg().exp().log1p(),
               a1,
               (a1 == b1) & (a1.abs() == inf));
           return convert_float_bfloat16(a0, a1);
@@ -904,15 +903,14 @@ void logaddexp_kernel(TensorIteratorBase& iter) {
               return a;
             } else {
               scalar_t m = std::max(a, b);
-              return m + std::log(static_cast<scalar_t>(1.0) + std::exp(-std::abs(a - b)));
+              return m + std::log1p(std::exp(-std::abs(a - b)));
             }
           },
           [=](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
             Vectorized<scalar_t> inf(std::numeric_limits<scalar_t>::infinity());
-            Vectorized<scalar_t> one(1.0);
             Vectorized<scalar_t> m = maximum(a, b);
             return Vectorized<scalar_t>::blendv(
-                m + (one + (a - b).abs().neg().exp()).log(),
+                m + (a - b).abs().neg().exp().log1p(),
                 a,
                 (a == b) & (a.abs() == inf));
           });

--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -23,7 +23,7 @@ void logaddexp_kernel_cuda(TensorIteratorBase& iter) {
           }
           else {
             scalar_t m = ::max(a, b);
-            return m + ::log((scalar_t)(1.0) + ::exp(-::abs(a - b)));
+            return m + ::log1p(::exp(-::abs(a - b)));
           }
         });
       });

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -92,7 +92,7 @@ Tensor& binary_cross_entropy_out_cuda(const Tensor& input, const Tensor& target,
         CUDA_KERNEL_ASSERT(input_val >= zero && input_val <= one);
 
         scalar_t log_input_val = std::log(input_val);
-        scalar_t log_1_minus_input_val = std::log(one - input_val);
+        scalar_t log_1_minus_input_val = std::log1p(-input_val);
 
         log_input_val = std::max(log_input_val, neg_100);
         log_1_minus_input_val = std::max(log_1_minus_input_val, neg_100);

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -535,7 +535,7 @@ def binary_cross_entropy(
     #     "all elements of input should be between 0 and 1"
     # )
     loss = (target - 1) * torch.maximum(
-        torch.log(1 - self), self.new_full((), -100)
+        torch.log1p(-self), self.new_full((), -100)
     ) - target * torch.maximum(torch.log(self), self.new_full((), -100))
     if weight is not None:
         loss = loss * weight


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92147
* #92146
* __->__ #92145
* #92144
* #91963

`log1p` offers better precision near zero since `(1 + x) - 1` truncates any
values less than the float epsilon to zero. For `soft_margin_loss` this also
requires one fewer kernel invocation which for numel=1e7 gives me a 1.2x speedup
on CUDA and a 1.1x speedup on CPU.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10