### PR TITLE
logaddexp2: Use log1p and exp2

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -920,6 +920,7 @@ void logaddexp_kernel(TensorIteratorBase& iter) {
 
 void logaddexp2_kernel(TensorIteratorBase& iter) {
   if (iter.dtype() == kBFloat16) {
+    constexpr auto inv_log_2 = static_cast<float>(1.0 / c10::ln_2<double>);
     cpu_kernel_vec(
         iter,
         [=](BFloat16 a, BFloat16 b) -> BFloat16 {
@@ -929,7 +930,7 @@ void logaddexp2_kernel(TensorIteratorBase& iter) {
             return a0;
           } else {
             float m0 = std::max(a0, b0);
-            return m0 + std::log2(static_cast<float>(1.0) + std::pow(static_cast<float>(2), -std::abs(a0 - b0)));
+            return m0 + std::log1p(std::exp2(-std::abs(a0 - b0))) * inv_log_2;
           }
         },
         [=](Vectorized<BFloat16> a, Vectorized<BFloat16> b) {
@@ -937,22 +938,22 @@ void logaddexp2_kernel(TensorIteratorBase& iter) {
           std::tie(a0, a1) = convert_bfloat16_float(a);
           std::tie(b0, b1) = convert_bfloat16_float(b);
           Vectorized<float> inf(std::numeric_limits<float>::infinity());
-          Vectorized<float> one(1.0);
-          Vectorized<float> two(2.0);
+          Vectorized<float> inv_log_2_vec(inv_log_2);
           Vectorized<float> m0 = maximum(a0, b0);
           Vectorized<float> m1 = maximum(a1, b1);
           a0 = Vectorized<float>::blendv(
-              m0 + (one + two.pow((a0 - b0).abs().neg())).log2(),
+              m0 + (a0 - b0).abs().neg().exp2().log1p() * inv_log_2_vec,
               a0,
               (a0 == b0) & (a0.abs() == inf));
           a1 = Vectorized<float>::blendv(
-              m1 + (one + two.pow((a1 - b1).abs().neg())).log2(),
+              m1 + (a1 - b1).abs().neg().exp2().log1p() * inv_log_2_vec,
               a1,
               (a1 == b1) & (a1.abs() == inf));
           return convert_float_bfloat16(a0, a1);
         });
   } else {
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "logaddexp2_cpu", [&]() {
+      constexpr auto inv_log_2 = static_cast<scalar_t>(1.0 / c10::ln_2<double>);
       cpu_kernel_vec(
           iter,
           [=](scalar_t a, scalar_t b) -> scalar_t {
@@ -960,16 +961,15 @@ void logaddexp2_kernel(TensorIteratorBase& iter) {
               return a;
             } else {
               scalar_t m = std::max(a, b);
-              return m + std::log2(static_cast<scalar_t>(1.0) + std::pow(static_cast<scalar_t>(2), -std::abs(a - b)));
+              return m + std::log1p(std::exp2(-std::abs(a - b))) * inv_log_2;
             }
           },
           [=](Vectorized<scalar_t> a, Vectorized<scalar_t> b) {
             Vectorized<scalar_t> inf(std::numeric_limits<scalar_t>::infinity());
-            Vectorized<scalar_t> one(1.0);
-            Vectorized<scalar_t> two(2.0);
+            Vectorized<scalar_t> inv_log_2_vec(inv_log_2);
             Vectorized<scalar_t> m = maximum(a, b);
             return Vectorized<scalar_t>::blendv(
-                m + (one + two.pow((a - b).abs().neg())).log2(),
+                m + (a - b).abs().neg().exp2().log1p() * inv_log_2_vec,
                 a,
                 (a == b) & (a.abs() == inf));
           });

--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -5,6 +5,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/AccumulateType.h>
+#include <c10/util/MathConstants.h>
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
@@ -35,13 +36,14 @@ void logaddexp2_kernel_cuda(TensorIteratorBase& iter) {
       iter.dtype(), "logaddexp2_cuda",
       [&]() {
         using accscalar_t = at::acc_type<scalar_t, /*is_cuda=*/true>;
-        gpu_kernel(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
+        const auto inv_log_2 = static_cast<accscalar_t>(1.0 / c10::ln_2<double>);
+        gpu_kernel(iter, [inv_log_2] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
           if (::isinf(static_cast<accscalar_t>(a)) && a == b) {
             return a;
           }
           else {
             scalar_t m = ::max(a, b);
-            return m + ::log2((scalar_t)(1.0) + ::pow((scalar_t)(2.0), -::abs(a - b)));
+            return m + ::log1p(::exp2(-::abs(a - b))) * inv_log_2;
           }
         });
       });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92147
* #92146
* #92145
* #92144
* #91963

This replaces `log2(1 + x)` with `log1p(x) * (1 / log(2))` which improves
precision when `x` is small by avoiding the truncation from calculating
`(1 + x) - 1`. Noting that `x` is always `<= 1` in this formula.

This also replaces `pow(2, x)` with `exp2(x)` which improves performance,
particularly on CPU where the constant value cannot be inlined into Sleef.
With numel=1e7 for example, I see a 1.35x speedup on CPU.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10