### PR TITLE
Apply noexcept to relevant move methods to improve performance

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -207,14 +207,14 @@ class TORCH_API TensorBase {
     impl_ = x.impl_;
     return *this;
   };
-  TensorBase& operator=(TensorBase&& x) & {
+  TensorBase& operator=(TensorBase&& x) & noexcept {
     impl_ = std::move(x.impl_);
     return *this;
   }
 
   // Ban assignment to rvalues, since at::Tensor (weirdly) performs a deep copy here
   TensorBase& operator=(const TensorBase&) && = delete;
-  TensorBase& operator=(TensorBase&&) && = delete;
+  TensorBase& operator=(TensorBase&&) && noexcept = delete;
 
   bool is_same(const TensorBase& other) const noexcept {
     return impl_ == other.impl_;

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -207,7 +207,7 @@ class TORCH_API TensorBase {
     impl_ = x.impl_;
     return *this;
   };
-  TensorBase& operator=(TensorBase&& x) noexcept & {
+  TensorBase& operator=(TensorBase&& x) & {
     impl_ = std::move(x.impl_);
     return *this;
   }

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -207,7 +207,7 @@ class TORCH_API TensorBase {
     impl_ = x.impl_;
     return *this;
   };
-  TensorBase& operator=(TensorBase&& x) & {
+  TensorBase& operator=(TensorBase&& x) noexcept & {
     impl_ = std::move(x.impl_);
     return *this;
   }

--- a/c10/core/Event.h
+++ b/c10/core/Event.h
@@ -50,8 +50,8 @@ struct Event final {
   Event& operator=(const Event&) = delete;
 
   // Move constructor and move assignment operator
-  Event(Event&& other) : impl_{std::move(other.impl_)} {}
-  Event& operator=(Event&& other) {
+  Event(Event&& other) noexcept : impl_{std::move(other.impl_)} {}
+  Event& operator=(Event&& other) noexcept {
     impl_.swap(std::move(other.impl_));
     return *this;
   }

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -152,7 +152,7 @@ class C10_API Scalar {
     return Tag::HAS_si == tag || Tag::HAS_sd == tag;
   }
 
-  C10_ALWAYS_INLINE Scalar& operator=(Scalar&& other) {
+  C10_ALWAYS_INLINE Scalar& operator=(Scalar&& other) noexcept {
     if (&other == this) {
       return *this;
     }

--- a/c10/core/impl/InlineEvent.h
+++ b/c10/core/impl/InlineEvent.h
@@ -21,11 +21,11 @@ struct InlineEvent final {
   InlineEvent& operator=(const InlineEvent&) = delete;
 
   // Move constructor and move assignment operator
-  InlineEvent(InlineEvent&& other)
+  InlineEvent(InlineEvent&& other) noexcept
       : InlineEvent(other.device_type_, other.flag_) {
     swap(std::move(other));
   }
-  InlineEvent& operator=(InlineEvent&& other) {
+  InlineEvent& operator=(InlineEvent&& other) noexcept {
     swap(std::move(other));
     return *this;
   }

--- a/c10/util/tempfile.h
+++ b/c10/util/tempfile.h
@@ -68,7 +68,7 @@ struct TempFile {
   }
 
   TempFile& operator=(const TempFile&) = delete;
-  TempFile& operator=(TempFile&& other) {
+  TempFile& operator=(TempFile&& other) noexcept {
     fd = other.fd;
     name = std::move(other.name);
     other.fd = -1;
@@ -98,7 +98,7 @@ struct TempDir {
   }
 
   TempDir& operator=(const TempDir&) = delete;
-  TempDir& operator=(TempDir&& other) {
+  TempDir& operator=(TempDir&& other) noexcept {
     name = std::move(other.name);
     other.name.clear();
     return *this;

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -167,7 +167,7 @@ struct python_error : public std::exception {
     Py_XINCREF(traceback);
   }
 
-  python_error(python_error&& other)
+  python_error(python_error&& other) noexcept
       : type(other.type),
         value(other.value),
         traceback(other.traceback),

--- a/torch/csrc/lazy/core/util.h
+++ b/torch/csrc/lazy/core/util.h
@@ -36,7 +36,7 @@ class Cleanup {
 
   Cleanup& operator=(const Cleanup&) = delete;
 
-  Cleanup& operator=(Cleanup&& ref) {
+  Cleanup& operator=(Cleanup&& ref) noexcept {
     if (this != &ref) {
       func_ = std::move(ref.func_);
       status_ = std::move(ref.status_);

--- a/torch/csrc/utils/invalid_arguments.cpp
+++ b/torch/csrc/utils/invalid_arguments.cpp
@@ -109,7 +109,7 @@ struct Option {
   Option(bool is_variadic, bool has_out)
       : arguments(), is_variadic(is_variadic), has_out(has_out){};
   Option(const Option&) = delete;
-  Option(Option&& other)
+  Option(Option&& other) noexcept
       : arguments(std::move(other.arguments)),
         is_variadic(other.is_variadic),
         has_out(other.has_out){};


### PR DESCRIPTION
This clang-tidy check is disabled globally due to false positives on containers, but there are a few places here where adding clang-tidy would actually improve performance (by allowing STL containers to use the move operator / assignment)


cc @ngimel @jbschlosser