### PR TITLE
Allow to disable TORCH_COMPILE_DEBUG and TORCHDYNAMO_SUPPRESS_ERRORS by setting them to 0

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -91,11 +91,11 @@ traceable_tensor_subclasses = set()
 # This is a good way to get your model to work one way or another, but you may
 # lose optimization opportunities this way.  Devs, if your benchmark model is failing
 # this way, you should figure out why instead of suppressing it.
-suppress_errors = bool(os.environ.get("TORCHDYNAMO_SUPPRESS_ERRORS", False))
+suppress_errors = os.environ.get("TORCHDYNAMO_SUPPRESS_ERRORS", "0") == "1"
 
 # Record and write an execution record of the current frame to a file
 # if an exception is encountered
-replay_record_enabled = bool(os.environ.get("TORCH_COMPILE_DEBUG", False))
+replay_record_enabled = os.environ.get("TORCH_COMPILE_DEBUG", "0") == "1"
 
 # Rewrite assert statement in python with torch._assert
 rewrite_assert_with_torch_assert = True

--- a/torch/_dynamo/logging.py
+++ b/torch/_dynamo/logging.py
@@ -4,6 +4,8 @@ import os
 
 from torch.hub import _Faketqdm, tqdm
 
+from . import config
+
 # logging level for dynamo generated graphs/bytecode/guards
 logging.CODE = 15
 logging.addLevelName(logging.CODE, "CODE")
@@ -72,7 +74,7 @@ def init_logging(log_level, log_file_name=None):
             for logger in get_loggers():
                 logger.addHandler(log_file)
 
-        if bool(os.environ.get("TORCH_COMPILE_DEBUG", False)):
+        if config.replay_record_enabled:
             from .utils import get_debug_dir
 
             log_level = logging.DEBUG

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -176,7 +176,7 @@ def create_fx_from_snodes(snodes: List[BaseSchedulerNode]) -> fx.Graph:
 
 @contextlib.contextmanager
 def enable_aot_logging():
-    compile_debug = bool(os.environ.get("TORCH_COMPILE_DEBUG", False))
+    compile_debug = config.trace.enabled
     debug_graphs = functorch_config.debug_graphs
     debug_joint_graphs = functorch_config.debug_joint
 


### PR DESCRIPTION
Summary:
Converting "0" to bool results in True, change it to explicitly
check for "0" and "1" values to be consistent with the rest of the codebase.

```
$ export TORCHDYNAMO_SUPPRESS_ERRORS=1; python3 -c 'import os; print(bool(os.environ.get("TORCHDYNAMO_SUPPRESS_ERRORS", False)))'
True
$ export TORCHDYNAMO_SUPPRESS_ERRORS=0; python3 -c 'import os; print(bool(os.environ.get("TORCHDYNAMO_SUPPRESS_ERRORS", False)))'
True
```

Differential Revision: D42501779



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @anijain2305 @mlazos @soumith @yanboliang @chunyuan-w @desertfire