### PR TITLE
[ROCm] Move ROCm trunk jobs to unstable

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -291,31 +291,6 @@ jobs:
       cuda-version: "11.6"
       test-matrix: ${{ needs.win-vs2019-cuda11_6-py3-build.outputs.test-matrix }}
 
-  linux-focal-rocm5_3-py3_8-build:
-    name: linux-focal-rocm5.3-py3.8
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: linux-focal-rocm5.3-py3.8
-      docker-image-name: pytorch-linux-focal-rocm5.3-py3.8
-      sync-tag: rocm-build
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
-        ]}
-
-  linux-focal-rocm5_3-py3_8-test:
-    name: linux-focal-rocm5.3-py3.8
-    uses: ./.github/workflows/_rocm-test.yml
-    needs: linux-focal-rocm5_3-py3_8-build
-    with:
-      build-environment: linux-focal-rocm5.3-py3.8
-      docker-image: ${{ needs.linux-focal-rocm5_3-py3_8-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-rocm5_3-py3_8-build.outputs.test-matrix }}
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
-
   android-emulator-build-test:
     name: android-emulator-build-test
     uses: ./.github/workflows/_run_android_tests.yml

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -29,5 +29,30 @@ jobs:
           echo " PR to trigger this workflow. That can be done either manually or"
           echo " automatically using PyTorch auto-label bot."
           echo
-          echo "Once the jobs are deemed stable enough (% red signal < 20% and TTS < 3h),"
+          echo "Once the jobs are deemed stable enough (% red signal < 5% and TTS < 3h),"
           echo " they can graduate and move back to pull or trunk."
+
+  linux-focal-rocm5_3-py3_8-build:
+    name: linux-focal-rocm5.3-py3.8
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-focal-rocm5.3-py3.8
+      docker-image-name: pytorch-linux-focal-rocm5.3-py3.8
+      sync-tag: rocm-build
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
+        ]}
+
+  linux-focal-rocm5_3-py3_8-test:
+    name: linux-focal-rocm5.3-py3.8
+    uses: ./.github/workflows/_rocm-test.yml
+    needs: linux-focal-rocm5_3-py3_8-build
+    with:
+      build-environment: linux-focal-rocm5.3-py3.8
+      docker-image: ${{ needs.linux-focal-rocm5_3-py3_8-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-rocm5_3-py3_8-build.outputs.test-matrix }}
+    secrets:
+      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
+      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This PR temporarily moves ROCm trunk jobs to the new unstable workflow, which is run for every commit in trunk but won't block merge.  The reason is that we are seeing regression on ROCm runner reliability recently.  While waiting for AMD to investigate, we want to have a backup plan to not blocking PR while still gathering trunk signals from ROCm.

The unstable workflow can also be run as part of the PR using `ciflow/unstable` label (I'll add a `ciflow/unstable` auto-label for ROCm later if the jobs are moved here)

![Red % on trunk (ROCm v s  Pull and trunk jobs v s  Pull and trunk jobs without ROCm)](https://user-images.githubusercontent.com/475357/212439403-92499ab4-8dff-4aef-822b-4f41d223ef75.png)

Per the discussion on https://github.com/pytorch/pytorch/issues/90940, we might not need this at all after https://github.com/pytorch/pytorch/pull/92101.  Let's continue monitoring this for the next few days

- [x] Allow `ciflow/unstable` as a valid tag https://github.com/pytorch/test-infra/pull/1394
- [x] Create the unstable workflow on PyTorch https://github.com/pytorch/pytorch/pull/92106
- [x] Gather reliability metrics of ROCm runner
- [x] Decide if we want to move ROCMs trunk jobs to the unstable workflow https://github.com/pytorch/pytorch/pull/92186
- [ ] Add redness metrics for the unstable workflow

