### PR TITLE
Bypass Meta internal code for new pytorch random distribution method

### DIFF
--- a/aten/src/ATen/native/cpu/DistributionKernels.cpp
+++ b/aten/src/ATen/native/cpu/DistributionKernels.cpp
@@ -103,7 +103,7 @@ static void exponential_kernel_default(TensorIteratorBase& iter, double lambda, 
   templates::cpu::exponential_kernel(iter, lambda, generator);
 }
 
-#if !AT_MKL_ENABLED()
+#if (!AT_MKL_ENABLED() || defined(FBCODE_CAFFE2))
 void exponential_kernel(TensorIteratorBase& iter, double lambda, c10::optional<Generator> gen) {
   exponential_kernel_default(iter, lambda, gen);
 }


### PR DESCRIPTION
Summary: After D41587318 introduced new pytorch randomization, filament2 training failed due to chunk size is 0. We gated the new change to external only to fix filament2 package

Test Plan: f402461641 the flow has training successfully finished

Reviewed By: izaitsevfb

Differential Revision: D42501726



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10