### PR TITLE
[BE] Refactor get_workflow_job_id

### DIFF
--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -2,18 +2,73 @@
 # workflow. GitHub does not provide this information to workflow runs, so we
 # need to figure it out based on what they *do* provide.
 
-import requests
-import os
 import argparse
+import json
+import os
+import re
+import urllib
 
-def handle_bad_status(response: requests.Response) -> None:
-    if response.status_code != 200:
+from typing import Any, Callable, Dict, List, Optional
+from urllib.request import Request, urlopen
+
+def parse_json_and_links(conn):
+    links = {}
+    # Extract links which GH uses for pagination
+    # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
+    if "Link" in conn.headers:
+        for elem in re.split(", *<", conn.headers["Link"]):
+            try:
+                url, params = elem.split(";", 1)
+            except ValueError:
+                continue
+            url = urllib.parse.unquote(url.strip("<> "))
+            params = urllib.parse.parse_qs(params.strip(), separator=";")
+            for k,v in params.items():
+                if type(v) is list and len(v)==1:
+                    params[k] = v[0].strip('""')
+            params["url"] = url
+            if "rel" in params:
+                links[params["rel"]] = params
+
+    return json.load(conn), links
+
+def fetch_url(url: str, *,
+               headers: Optional[Dict[str, str]] = None,
+               reader: Callable[[Any], Any] = lambda x: x.read()) -> Any:
+    if headers is None:
+        headers = {}
+    try:
+        with urlopen(Request(url, headers=headers)) as conn:
+            return reader(conn)
+    except urllib.error.HTTPError as err:
         exception_message = (
             "Is github alright?",
-            f"Recieved status code '{response.status_code}' when attempting to retrieve runs:\n",
-            f"{response.content.decode()}"
+            f"Recieved status code '{err.code}' when attempting to retrieve {url}:\n",
+            f"{err.reason}\n\nheaders={err.headers}"
         )
-        raise RuntimeError(exception_message)
+        raise RuntimeError(exception_message) from err
+
+def parse_args() -> Any:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "workflow_run_id", help="The id of the workflow run, should be GITHUB_RUN_ID"
+    )
+    parser.add_argument(
+        "runner_name",
+        help="The name of the runner to retrieve the job id, should be RUNNER_NAME",
+    )
+
+    return parser.parse_args()
+
+
+def fetch_jobs(url: str, headers: Dict[str, str]) -> List[Any]:
+    response, links = fetch_url(url, headers=headers, reader=parse_json_and_links)
+    jobs = response["jobs"]
+    while "next" in links.keys():
+        response, links = fetch_url(links["next"]["url"], headers=headers, reader=parse_json_and_links)
+        jobs.extend(response["jobs"])
+
+    return jobs
 
 
 # Our strategy is to retrieve the parent workflow run, then filter its jobs on
@@ -29,46 +84,31 @@ def handle_bad_status(response: requests.Response) -> None:
 # since only one job can be scheduled on a runner at a time, we know that
 # looking for RUNNER_NAME will uniquely identify the job we're currently
 # running.
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "workflow_run_id", help="The id of the workflow run, should be GITHUB_RUN_ID"
-)
-parser.add_argument(
-    "runner_name",
-    help="The name of the runner to retrieve the job id, should be RUNNER_NAME",
-)
 
-args = parser.parse_args()
+def main() -> None:
+    # From https://docs.github.com/en/actions/learn-github-actions/environment-variables
+    PYTORCH_REPO = os.environ.get("GITHUB_REPOSITORY", "pytorch/pytorch")
+    PYTORCH_GITHUB_API = f"https://api.github.com/repos/{PYTORCH_REPO}"
+    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+    REQUEST_HEADERS = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": "token " + GITHUB_TOKEN,
+    }
 
+    args = parse_args()
+    url = f"{PYTORCH_GITHUB_API}/actions/runs/{args.workflow_run_id}/jobs?per_page=100"
+    jobs = fetch_jobs(url, REQUEST_HEADERS)
 
-# From https://docs.github.com/en/actions/learn-github-actions/environment-variables
-PYTORCH_REPO = os.environ.get("GITHUB_REPOSITORY", "pytorch/pytorch")
-PYTORCH_GITHUB_API = f"https://api.github.com/repos/{PYTORCH_REPO}"
-GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-REQUEST_HEADERS = {
-    "Accept": "application/vnd.github.v3+json",
-    "Authorization": "token " + GITHUB_TOKEN,
-}
+    # Sort the jobs list by start time, in descending order. We want to get the most
+    # recently scheduled job on the runner.
+    jobs.sort(key=lambda job: job["started_at"], reverse=True)
 
-response = requests.get(
-    f"{PYTORCH_GITHUB_API}/actions/runs/{args.workflow_run_id}/jobs?per_page=100",
-    headers=REQUEST_HEADERS,
-)
-handle_bad_status(response)
+    for job in jobs:
+        if job["runner_name"] == args.runner_name:
+            print(job["id"])
+            return
 
-jobs = response.json()["jobs"]
-while "next" in response.links.keys():
-    response = requests.get(response.links["next"]["url"], headers=REQUEST_HEADERS)
-    handle_bad_status(response)
-    jobs.extend(response.json()["jobs"])
+    exit(1)
 
-# Sort the jobs list by start time, in descending order. We want to get the most
-# recently scheduled job on the runner.
-jobs.sort(key=lambda job: job["started_at"], reverse=True)
-
-for job in jobs:
-    if job["runner_name"] == args.runner_name:
-        print(job["id"])
-        exit(0)
-
-exit(1)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92193
* #92192
* __->__ #92191

A noop change that refactors existing codebase and prints a bit more
verbose error message when request fails.

Get rid of `requests` as it inevitable results in flakiness

TODO: Remove in a few days after PR is landed
https://github.com/pytorch/pytorch/blob/4af5939d7ac70cba7f130ab74705080cbda68d7b/.github/actions/get-workflow-job-id/action.yml#L29