### PR TITLE
don't swallow cuda errors

### DIFF
--- a/c10/cuda/CUDADeviceAssertionHost.cpp
+++ b/c10/cuda/CUDADeviceAssertionHost.cpp
@@ -14,7 +14,7 @@
 #include <thread>
 
 #define CHECK_CUDA_API_CALL_WITHOUT_CHECKING_DEVICE_ASSERTS() \
-  c10_cuda_check_implementation(__FILE__, __FUNCTION__, __LINE__, false)
+  c10_cuda_check_implementation(0, __FILE__, __FUNCTION__, __LINE__, false, true)
 
 namespace c10 {
 namespace cuda {

--- a/c10/cuda/CUDADeviceAssertionHost.cpp
+++ b/c10/cuda/CUDADeviceAssertionHost.cpp
@@ -14,7 +14,8 @@
 #include <thread>
 
 #define CHECK_CUDA_API_CALL_WITHOUT_CHECKING_DEVICE_ASSERTS() \
-  c10_cuda_check_implementation(0, __FILE__, __FUNCTION__, __LINE__, false, true)
+  c10_cuda_check_implementation(                              \
+      0, __FILE__, __FUNCTION__, __LINE__, false, true)
 
 namespace c10 {
 namespace cuda {

--- a/c10/cuda/CUDAException.cpp
+++ b/c10/cuda/CUDAException.cpp
@@ -10,11 +10,14 @@ namespace c10 {
 namespace cuda {
 
 void c10_cuda_check_implementation(
+    int err,
     const char* filename,
     const char* function_name,
     const int line_number,
-    const bool include_device_assertions) {
-  const auto cuda_error = cudaGetLastError();
+    const bool include_device_assertions,
+    const bool get_cuda_error) {
+  cudaError_t cuda_error =
+      get_cuda_error ? cudaGetLastError() : static_cast<cudaError_t>(err);
   const auto cuda_kernel_failure = include_device_assertions
       ? c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().has_failed()
       : false;

--- a/c10/cuda/CUDAException.h
+++ b/c10/cuda/CUDAException.h
@@ -26,7 +26,7 @@ class C10_CUDA_API CUDAError : public c10::Error {
 
 #define C10_CUDA_CHECK(EXPR)                                             \
   do {                                                                   \
-    const cudaError_t __err = EXPR;                           \
+    const cudaError_t __err = EXPR;                                      \
     c10::cuda::c10_cuda_check_implementation(                            \
         static_cast<int>(__err),                                         \
         __FILE__,                                                        \

--- a/c10/cuda/CUDAException.h
+++ b/c10/cuda/CUDAException.h
@@ -26,15 +26,15 @@ class C10_CUDA_API CUDAError : public c10::Error {
 
 #define C10_CUDA_CHECK(EXPR)                                             \
   do {                                                                   \
-    /* We get & disarm the error inside of */                            \
-    /* `c10_cuda_check_implementation` */                                \
-    C10_UNUSED const cudaError_t __err = EXPR;                           \
+    const cudaError_t __err = EXPR;                           \
     c10::cuda::c10_cuda_check_implementation(                            \
+        static_cast<int>(__err),                                         \
         __FILE__,                                                        \
         __func__, /* Line number's data type is not well-defined between \
                       compilers, so we perform an explicit cast */       \
         static_cast<uint32_t>(__LINE__),                                 \
-        true);                                                           \
+        true,                                                            \
+        false); /*get_cuda_error */                                      \
   } while (0)
 
 #define C10_CUDA_CHECK_WARN(EXPR)                              \
@@ -93,10 +93,12 @@ namespace cuda {
 /// In the event of a CUDA failure, formats a nice error message about that
 /// failure and also checks for device-side assertion failures
 C10_CUDA_API void c10_cuda_check_implementation(
+    int err,
     const char* filename,
     const char* function_name,
     const int line_number,
-    const bool include_device_assertions);
+    const bool include_device_assertions,
+    const bool get_cuda_error);
 
 } // namespace cuda
 } // namespace c10


### PR DESCRIPTION
Fixes #91758
I'm not in love with casting cudaError to and from int, but I couldn't avoid it without major refactors, and we need to fix this bug soon. 