### PR TITLE
Fix Vulkan compiling issues on Windows

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Descriptor.cpp
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.cpp
@@ -41,20 +41,14 @@ DescriptorSet& DescriptorSet::operator=(DescriptorSet&& other) noexcept {
 DescriptorSet& DescriptorSet::bind(
     const uint32_t idx,
     const VulkanBuffer& buffer) {
-  add_binding(DescriptorSet::ResourceBinding{
-      idx, // binding_idx
-      shader_layout_signature_[idx], // descriptor_type
-      false, // is_image
-      {
-          // resource_info
-          .buffer_info =
-              {
-                  buffer.handle(), // buffer
-                  buffer.mem_offset(), // offset
-                  buffer.mem_range(), // range
-              },
-      },
-  });
+  DescriptorSet::ResourceBinding binder;
+  binder.binding_idx = idx; // binding_idx
+  binder.descriptor_type = shader_layout_signature_[idx]; // descriptor_type
+  binder.is_image = false; // is_image
+  binder.resource_info.buffer_info.buffer = buffer.handle(); // buffer
+  binder.resource_info.buffer_info.offset = buffer.mem_offset(); // offset
+  binder.resource_info.buffer_info.range = buffer.mem_range(); // range
+  add_binding(std::move(binder));
 
   return *this;
 }
@@ -67,20 +61,14 @@ DescriptorSet& DescriptorSet::bind(
     binding_layout = VK_IMAGE_LAYOUT_GENERAL;
   }
 
-  add_binding(DescriptorSet::ResourceBinding{
-      idx, // binding_idx
-      shader_layout_signature_[idx], // descriptor_type
-      true, // is_image
-      {
-          // resource_info
-          .image_info =
-              {
-                  image.sampler(), // buffer
-                  image.image_view(), // imageView
-                  binding_layout, // imageLayout
-              },
-      },
-  });
+  DescriptorSet::ResourceBinding binder;
+  binder.binding_idx = idx; // binding_idx
+  binder.descriptor_type = shader_layout_signature_[idx]; // descriptor_type
+  binder.is_image = true; // is_image
+  binder.resource_info.image_info.sampler = image.sampler(); // buffer
+  binder.resource_info.image_info.imageView = image.image_view(); // imageView
+  binder.resource_info.image_info.imageLayout = binding_layout; // imageLayout
+  add_binding(std::move(binder));
 
   return *this;
 }

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -234,12 +234,14 @@ template <
     typename T,
     typename FindKey,
     typename ArgumentHash,
-    typename Hasher,
+    typename DetailHasher,
     typename ArgumentEqual,
     typename Equal,
     typename ArgumentAlloc,
     typename EntryAlloc>
-class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
+class sherwood_v3_table : private EntryAlloc,
+                          private DetailHasher,
+                          private Equal {
   using Entry = detailv3::sherwood_v3_entry<T>;
   using AllocatorTraits = std::allocator_traits<EntryAlloc>;
   using EntryPointer = typename AllocatorTraits::pointer;
@@ -264,7 +266,7 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
       const ArgumentHash& hash = ArgumentHash(),
       const ArgumentEqual& equal = ArgumentEqual(),
       const ArgumentAlloc& alloc = ArgumentAlloc())
-      : EntryAlloc(alloc), Hasher(hash), Equal(equal) {
+      : EntryAlloc(alloc), DetailHasher(hash), Equal(equal) {
     rehash(bucket_count);
   }
   sherwood_v3_table(size_type bucket_count, const ArgumentAlloc& alloc)
@@ -351,7 +353,7 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
                 other.get_allocator())) {}
   sherwood_v3_table(const sherwood_v3_table& other, const ArgumentAlloc& alloc)
       : EntryAlloc(alloc),
-        Hasher(other),
+        DetailHasher(other),
         Equal(other),
         _max_load_factor(other._max_load_factor) {
     rehash_for_other_container(other);
@@ -365,14 +367,16 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
   }
   sherwood_v3_table(sherwood_v3_table&& other) noexcept
       : EntryAlloc(std::move(other)),
-        Hasher(std::move(other)),
+        DetailHasher(std::move(other)),
         Equal(std::move(other)) {
     swap_pointers(other);
   }
   sherwood_v3_table(
       sherwood_v3_table&& other,
       const ArgumentAlloc& alloc) noexcept
-      : EntryAlloc(alloc), Hasher(std::move(other)), Equal(std::move(other)) {
+      : EntryAlloc(alloc),
+        DetailHasher(std::move(other)),
+        Equal(std::move(other)) {
     swap_pointers(other);
   }
   sherwood_v3_table& operator=(const sherwood_v3_table& other) {
@@ -391,7 +395,7 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
           *this, other);
     }
     _max_load_factor = other._max_load_factor;
-    static_cast<Hasher&>(*this) = other;
+    static_cast<DetailHasher&>(*this) = other;
     static_cast<Equal&>(*this) = other;
     rehash_for_other_container(other);
     insert(other.begin(), other.end());
@@ -419,7 +423,7 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
         emplace(std::move(elem));
       other.clear();
     }
-    static_cast<Hasher&>(*this) = std::move(other);
+    static_cast<DetailHasher&>(*this) = std::move(other);
     static_cast<Equal&>(*this) = std::move(other);
     return *this;
   }
@@ -870,11 +874,11 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal {
 
   template <typename U>
   uint64_t hash_object(const U& key) {
-    return static_cast<Hasher&>(*this)(key);
+    return static_cast<DetailHasher&>(*this)(key);
   }
   template <typename U>
   uint64_t hash_object(const U& key) const {
-    return static_cast<const Hasher&>(*this)(key);
+    return static_cast<const DetailHasher&>(*this)(key);
   }
   template <typename L, typename R>
   bool compares_equal(const L& lhs, const R& rhs) {


### PR DESCRIPTION
PR based on #61431
Fix USE_VULKAN=1 and USE_VULKAN_WRAPPER=0 not compiling on Windows.
Change designated initializers since they require C++20.
Rename Hasher typename since it's not compiling due to https://developercommunity.visualstudio.com/t/1397858

Fixes #59519
