### PR TITLE
Improve noexcept spec of some c10 containers

### DIFF
--- a/c10/util/SmallVector.h
+++ b/c10/util/SmallVector.h
@@ -18,6 +18,7 @@
 // added SmallVector::at
 // added operator<< for std::ostream
 // added C10_API to export SmallVectorBase
+// added move noexcept specifiers
 
 #pragma once
 
@@ -1022,7 +1023,8 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
 
   SmallVectorImpl& operator=(const SmallVectorImpl& RHS);
 
-  SmallVectorImpl& operator=(SmallVectorImpl&& RHS);
+  SmallVectorImpl& operator=(SmallVectorImpl&& RHS) noexcept(
+      std::is_nothrow_move_assignable_v<T>);
 
   bool operator==(const SmallVectorImpl& RHS) const {
     if (this->size() != RHS.size())
@@ -1127,7 +1129,8 @@ SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(
 }
 
 template <typename T>
-SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(SmallVectorImpl<T>&& RHS) {
+SmallVectorImpl<T>& SmallVectorImpl<T>::operator=(
+    SmallVectorImpl<T>&& RHS) noexcept(std::is_nothrow_move_assignable_v<T>) {
   // Avoid self-assignment.
   if (this == &RHS)
     return *this;
@@ -1339,7 +1342,8 @@ class /* LLVM_GSL_OWNER */ SmallVector : public SmallVectorImpl<T>,
     return *this;
   }
 
-  SmallVector(SmallVector&& RHS) : SmallVectorImpl<T>(N) {
+  SmallVector(SmallVector&& RHS) noexcept(std::is_nothrow_move_assignable_v<T>)
+      : SmallVectorImpl<T>(N) {
     if (!RHS.empty())
       SmallVectorImpl<T>::operator=(::std::move(RHS));
   }
@@ -1365,17 +1369,21 @@ class /* LLVM_GSL_OWNER */ SmallVector : public SmallVectorImpl<T>,
     return *this;
   }
 
-  SmallVector(SmallVectorImpl<T>&& RHS) : SmallVectorImpl<T>(N) {
+  SmallVector(SmallVectorImpl<T>&& RHS) noexcept(
+      std::is_nothrow_move_assignable_v<SmallVectorImpl<T>>)
+      : SmallVectorImpl<T>(N) {
     if (!RHS.empty())
       SmallVectorImpl<T>::operator=(::std::move(RHS));
   }
 
-  SmallVector& operator=(SmallVector&& RHS) {
+  SmallVector& operator=(SmallVector&& RHS) noexcept(
+      std::is_nothrow_move_assignable_v<SmallVectorImpl<T>>) {
     SmallVectorImpl<T>::operator=(::std::move(RHS));
     return *this;
   }
 
-  SmallVector& operator=(SmallVectorImpl<T>&& RHS) {
+  SmallVector& operator=(SmallVectorImpl<T>&& RHS) noexcept(
+      std::is_nothrow_move_assignable_v<SmallVectorImpl<T>>) {
     SmallVectorImpl<T>::operator=(::std::move(RHS));
     return *this;
   }

--- a/c10/util/either.h
+++ b/c10/util/either.h
@@ -78,7 +78,7 @@ class either final {
     return *this;
   }
 
-  either<Left, Right>& operator=(either<Left, Right>&& rhs) {
+  either<Left, Right>& operator=(either<Left, Right>&& rhs) noexcept {
     _destruct();
     _side = rhs._side;
     if (_side == Side::left) {

--- a/c10/util/sparse_bitset.h
+++ b/c10/util/sparse_bitset.h
@@ -442,7 +442,7 @@ class SparseBitVector {
 
   SparseBitVector(const SparseBitVector& RHS)
       : Elements(RHS.Elements), CurrElementIter(Elements.begin()) {}
-  SparseBitVector(SparseBitVector&& RHS)
+  SparseBitVector(SparseBitVector&& RHS) noexcept
       : Elements(std::move(RHS.Elements)), CurrElementIter(Elements.begin()) {}
 
   // Clear.
@@ -459,7 +459,7 @@ class SparseBitVector {
     CurrElementIter = Elements.begin();
     return *this;
   }
-  SparseBitVector& operator=(SparseBitVector&& RHS) {
+  SparseBitVector& operator=(SparseBitVector&& RHS) noexcept {
     Elements = std::move(RHS.Elements);
     CurrElementIter = Elements.begin();
     return *this;

--- a/c10/util/sparse_bitset.h
+++ b/c10/util/sparse_bitset.h
@@ -442,7 +442,8 @@ class SparseBitVector {
 
   SparseBitVector(const SparseBitVector& RHS)
       : Elements(RHS.Elements), CurrElementIter(Elements.begin()) {}
-  SparseBitVector(SparseBitVector&& RHS) noexcept
+  SparseBitVector(SparseBitVector&& RHS) noexcept(
+      std::is_no_throw_move_constructible_v(ElementList))
       : Elements(std::move(RHS.Elements)), CurrElementIter(Elements.begin()) {}
 
   // Clear.
@@ -459,7 +460,8 @@ class SparseBitVector {
     CurrElementIter = Elements.begin();
     return *this;
   }
-  SparseBitVector& operator=(SparseBitVector&& RHS) noexcept {
+  SparseBitVector& operator=(SparseBitVector&& RHS) noexcept(
+      std::is_nothrow_move_assignable_v(ElementList)) {
     Elements = std::move(RHS.Elements);
     CurrElementIter = Elements.begin();
     return *this;

--- a/c10/util/sparse_bitset.h
+++ b/c10/util/sparse_bitset.h
@@ -443,7 +443,7 @@ class SparseBitVector {
   SparseBitVector(const SparseBitVector& RHS)
       : Elements(RHS.Elements), CurrElementIter(Elements.begin()) {}
   SparseBitVector(SparseBitVector&& RHS) noexcept(
-      std::is_no_throw_move_constructible_v(ElementList))
+      std::is_no_throw_move_constructible_v<ElementList>)
       : Elements(std::move(RHS.Elements)), CurrElementIter(Elements.begin()) {}
 
   // Clear.
@@ -461,7 +461,7 @@ class SparseBitVector {
     return *this;
   }
   SparseBitVector& operator=(SparseBitVector&& RHS) noexcept(
-      std::is_nothrow_move_assignable_v(ElementList)) {
+      std::is_nothrow_move_assignable_v<ElementList>) {
     Elements = std::move(RHS.Elements);
     CurrElementIter = Elements.begin();
     return *this;

--- a/c10/util/sparse_bitset.h
+++ b/c10/util/sparse_bitset.h
@@ -443,7 +443,7 @@ class SparseBitVector {
   SparseBitVector(const SparseBitVector& RHS)
       : Elements(RHS.Elements), CurrElementIter(Elements.begin()) {}
   SparseBitVector(SparseBitVector&& RHS) noexcept(
-      std::is_no_throw_move_constructible_v<ElementList>)
+      std::is_nothrow_move_constructible_v<ElementList>)
       : Elements(std::move(RHS.Elements)), CurrElementIter(Elements.begin()) {}
 
   // Clear.


### PR DESCRIPTION
* c10:either had a noexcept move ctor, but should also have noexcept move assignment.
* sparseBitVector should be noexcept since the contained type is always trivially movable (and move is implemented by swapping the pointers to containers).