### PR TITLE
Add MTIA DeviceType for Meta training and inference devices

### DIFF
--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -54,6 +54,7 @@ enum class Backend {
   MPS,
   HPU,
   Lazy,
+  MTIA,
   PrivateUse1,
   NumOptions
 };
@@ -111,6 +112,8 @@ static inline Backend dispatchKeyToBackend(DispatchKey t) {
     return Backend::QuantizedXPU;
   } else if (t == DispatchKey::HPU || t == DispatchKey::AutogradHPU) {
     return Backend::HPU;
+  } else if (t == DispatchKey::MTIA) {
+    return Backend::MTIA;
   } else if (t == DispatchKey::PrivateUse1) {
     return Backend::PrivateUse1;
   } else if (t == DispatchKey::Undefined) {
@@ -174,6 +177,8 @@ static inline DispatchKey backendToDispatchKey(Backend b) {
       return DispatchKey::MPS;
     case Backend::HPU:
       return DispatchKey::HPU;
+    case Backend::MTIA:
+      return DispatchKey::MTIA;
     case Backend::PrivateUse1:
       return DispatchKey::PrivateUse1;
     default:
@@ -232,6 +237,8 @@ static inline DeviceType backendToDeviceType(Backend b) {
       return DeviceType::MPS;
     case Backend::HPU:
       return DeviceType::HPU;
+    case Backend::MTIA:
+      return DeviceType::MTIA;
     case Backend::PrivateUse1:
       return DeviceType::PrivateUse1;
     case Backend::Undefined:
@@ -296,6 +303,8 @@ static inline const char* toString(Backend b) {
       return "QuantizedXPU";
     case Backend::HPU:
       return "HPU";
+    case Backend::MTIA:
+      return "MTIA";
     case Backend::PrivateUse1:
       return "PrivateUseOne";
     default:

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -36,6 +36,7 @@ DeviceType parse_type(const std::string& device_string) {
           {"mps", DeviceType::MPS},
           {"meta", DeviceType::Meta},
           {"hpu", DeviceType::HPU},
+          {"mtia", DeviceType::MTIA},
           {"privateuseone", DeviceType::PrivateUse1},
       }};
   auto device = std::find_if(

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -49,6 +49,8 @@ std::string DeviceTypeName(DeviceType d, bool lower_case) {
       return lower_case ? "hpu" : "HPU";
     case DeviceType::IPU:
       return lower_case ? "ipu" : "IPU";
+    case DeviceType::MTIA:
+      return lower_case ? "mtia" : "MTIA";
     case DeviceType::PrivateUse1:
       return get_privateuse1_backend(/*lower_case=*/lower_case);
     default:
@@ -93,6 +95,7 @@ bool isValidDeviceType(DeviceType d) {
     case DeviceType::Meta:
     case DeviceType::HPU:
     case DeviceType::IPU:
+    case DeviceType::MTIA:
     case DeviceType::PrivateUse1:
       return true;
     default:

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -27,6 +27,7 @@ namespace c10 {
   _(VE, extra)                                    \
   _(Lazy, extra)                                  \
   _(Meta, extra)                                  \
+  _(MTIA, extra)                                  \
   _(PrivateUse1, extra)
 
 enum class DeviceType : int8_t {
@@ -49,12 +50,13 @@ enum class DeviceType : int8_t {
   VE = 16, // SX-Aurora / NEC
   Lazy = 17, // Lazy Tensors
   IPU = 18, // Graphcore IPU
-  PrivateUse1 = 19, // PrivateUse1 device
+  MTIA = 19, // Meta training and inference devices
+  PrivateUse1 = 20, // PrivateUse1 device
   // NB: If you add more devices:
   //  - Change the implementations of DeviceTypeName and isValidDeviceType
   //    in DeviceType.cpp
   //  - Change the number below
-  COMPILE_TIME_MAX_DEVICE_TYPES = 20,
+  COMPILE_TIME_MAX_DEVICE_TYPES = 21,
 };
 
 constexpr DeviceType kCPU = DeviceType::CPU;
@@ -72,6 +74,7 @@ constexpr DeviceType kHPU = DeviceType::HPU;
 constexpr DeviceType kVE = DeviceType::VE;
 constexpr DeviceType kLazy = DeviceType::Lazy;
 constexpr DeviceType kIPU = DeviceType::IPU;
+constexpr DeviceType kMTIA = DeviceType::MTIA;
 constexpr DeviceType kPrivateUse1 = DeviceType::PrivateUse1;
 
 // define explicit int constant
@@ -79,7 +82,7 @@ constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =
     static_cast<int>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
 
 static_assert(
-    COMPILE_TIME_MAX_DEVICE_TYPES <= 20,
+    COMPILE_TIME_MAX_DEVICE_TYPES <= 21,
     "Hey!  You seem to be adding a lot of new DeviceTypes.  The intent was "
     "for this constant to reflect the actual number of DeviceTypes we support "
     "in PyTorch; it's important that this number is not too large as we "

--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -29,6 +29,8 @@ const char* toString(BackendComponent t) {
       return "HPUBit";
     case BackendComponent::VEBit:
       return "VEBit";
+    case BackendComponent::MTIABit:
+      return "MTIA";
     case BackendComponent::PrivateUse1Bit:
       return "PrivateUse1Bit";
     case BackendComponent::PrivateUse2Bit:
@@ -77,6 +79,8 @@ const char* toString(DispatchKey t) {
       return "MPS";
     case DispatchKey::HPU:
       return "HPU";
+    case DispatchKey::MTIA:
+      return "MTIA";
 
     case DispatchKey::Quantized:
       return "Quantized";
@@ -303,6 +307,7 @@ c10::DispatchKey parseDispatchKey(const std::string& k) {
       {"IPU", c10::DispatchKey::IPU},
       {"HPU", c10::DispatchKey::HPU},
       {"Lazy", c10::DispatchKey::Lazy},
+      {"MTIA", c10::DispatchKey::MTIA},
       {"NestedTensor", c10::DispatchKey::NestedTensor},
       {"NestedTensorCPU", c10::DispatchKey::NestedTensorCPU},
       {"NestedTensorCUDA", c10::DispatchKey::NestedTensorCUDA},

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -39,6 +39,7 @@ namespace c10 {
   _(VE, extra)                                  \
   _(Lazy, extra)                                \
   _(Meta, extra)                                \
+  _(MTIA, extra)                                \
   _(PrivateUse1, extra)                         \
   _(PrivateUse2, extra)                         \
   _(PrivateUse3, extra)


### PR DESCRIPTION
Summary: This adds a new MTIA DeviceType which is associated with the MTIA DispatchKey and will be used for the Meta in-house training and inference accelerators.

Test Plan: All CI should pass.

Differential Revision: D42526044

