### PR TITLE
[FSDP][1/N] `_summon_full_params` -> `_unshard_params`

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -35,22 +35,23 @@ class _FSDPState(_State):
     def __init__(self) -> None:
         # TODO: Move all the attributes to this class to enable typing for
         # FSDP/fully_shard.
+        self._ignored_modules: Set[nn.Module] = set()
+        self._ignored_params: Set[nn.Parameter] = set()
+        self.process_group: Optional[dist.ProcessGroup] = None
+        self.rank: int = -1
+        self.world_size: int = -1
+        self.sharding_strategy = ShardingStrategy.FULL_SHARD
         self._use_orig_params: bool = False
+        self.training_state = TrainingState.IDLE
         self._unshard_params_ctx: Dict[nn.Module, Generator] = {}
         self._state_dict_type: StateDictType = StateDictType.FULL_STATE_DICT
         self._state_dict_config: StateDictConfig = FullStateDictConfig()
         self._is_root: Optional[bool] = None
         self._handles: List[flat_param_file.FlatParamHandle] = []
-        self._ignored_modules: Set[nn.Module] = set()
         self._fully_sharded_module_to_handles: Dict[
             nn.Module, flat_param_file.FlatParamHandle
         ] = {}
-        self.rank: int = -1
-        self.world_size: int = -1
-        self.sharding_strategy = ShardingStrategy.FULL_SHARD
         self.compute_device = torch.device("cuda", torch.cuda.current_device())
-        self.process_group: Optional[dist.ProcessGroup] = None
-        self._ignored_params: Set[nn.Parameter] = set()
 
 
 def _get_module_fsdp_state(module: nn.Module) -> Optional[_FSDPState]:

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -60,7 +60,9 @@ def _get_module_fsdp_state(module: nn.Module) -> Optional[_FSDPState]:
     return state
 
 
-def _get_module_fsdp_state_if_comm_module(module: nn.Module) -> Optional[_FSDPState]:
+def _get_module_fsdp_state_if_fully_sharded_module(
+    module: nn.Module,
+) -> Optional[_FSDPState]:
     state = _get_module_fsdp_state(module)
     if state is None:
         return None

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -23,7 +23,7 @@ from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed.fsdp._common_utils import (
     _apply_to_modules,
     _FSDPState,
-    _get_module_fsdp_state_if_comm_module,
+    _get_module_fsdp_state_if_fully_sharded_module,
     _get_param_to_fqns,
     _module_handles,
     clean_tensor_name,
@@ -1405,7 +1405,7 @@ def _get_fqn_to_fsdp_param_info(model: nn.Module) -> Dict[str, FSDPParamInfo]:
     """
 
     def module_fn(module, prefix, fqn_to_param_info):
-        fsdp_state = _get_module_fsdp_state_if_comm_module(module)
+        fsdp_state = _get_module_fsdp_state_if_fully_sharded_module(module)
         if fsdp_state is None:
             return
         _lazy_init(fsdp_state, module)

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -8,7 +8,6 @@ import torch.distributed as dist
 import torch.distributed.algorithms._checkpoint.checkpoint_wrapper as checkpoint_wrapper
 import torch.distributed.fsdp._traversal_utils as traversal_utils
 
-# Import the entire FSDP file to avoid circular imports
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -43,7 +42,7 @@ from ._fsdp_extensions import (
 from ._unshard_param_utils import (
     _deregister_orig_params,
     _register_orig_params,
-    _unshard_params,
+    _unshard_fsdp_state_params,
     FLAT_PARAM,
 )
 from .flat_param import FlatParamHandle
@@ -54,8 +53,7 @@ def _convert_to_wrapped_module_name(module_name: str) -> str:
     module_name = module_name.replace(f"{FSDP_WRAPPED_MODULE}", "")
     if module_name:
         module_name = f"{module_name}."
-    # Activation checkpoint adds a prefix that has to be
-    # removed as well.
+    # `CheckpointWrapper` adds a prefix that has to be removed as well.
     module_name = module_name.replace(checkpoint_wrapper._CHECKPOINT_PREFIX, "")
     return module_name
 
@@ -86,7 +84,6 @@ def _shared_param_fqns(module: nn.Module, fsdp_state) -> Iterator[Tuple[str, str
 def _enter_unshard_params_ctx(
     module: nn.Module,
     fsdp_state: _FSDPState,
-    recurse: bool = False,
     writeback: bool = False,
     rank0_only: bool = False,
     offload_to_cpu: bool = False,
@@ -95,13 +92,13 @@ def _enter_unshard_params_ctx(
     """
     state_dict hooks cannot use the pure context call as the checkpoint flow
     requires to enter the context in the pre-hook but leave the context in the
-    post-hook. This API enters the context of ``_unshard_params``.
+    post-hook. This API enters the context of ``_unshard_fsdp_state_params``.
     """
     assert module not in fsdp_state._unshard_params_ctx, (
-        "Entering the ``_unshard_params`` context but _unshard_params_ctx[module] "
+        "Entering the ``_unshard_fsdp_state_params`` context but _unshard_params_ctx[module] "
         "is not None."
     )
-    fsdp_state._unshard_params_ctx[module] = _unshard_params(
+    fsdp_state._unshard_params_ctx[module] = _unshard_fsdp_state_params(
         module,
         fsdp_state,
         writeback=writeback,
@@ -114,7 +111,7 @@ def _enter_unshard_params_ctx(
 
 @no_type_check
 def _exit_unshard_params_ctx(module: nn.Module, fsdp_state: _FSDPState) -> None:
-    """A helper function to exit ``_unshard_params`` context."""
+    """A helper function to exit ``_unshard_fsdp_state_params`` context."""
     fsdp_state._unshard_params_ctx[module].__exit__(None, None, None)
     fsdp_state._unshard_params_ctx.pop(module)
 
@@ -141,12 +138,11 @@ def _common_unshard_pre_state_dict_hook(
 ) -> None:
     """
     Performs the pre-state_dict tasks shared by all state_dict types that require
-    ``_unshard_params()``. FULL_STATE_DICT and SHARDED_STATE_DICT use this hook.
+    ``_unshard_fsdp_state_params()``. FULL_STATE_DICT and SHARDED_STATE_DICT use this hook.
     """
     _enter_unshard_params_ctx(
         module,
         fsdp_state,
-        recurse=False,
         writeback=False,
         offload_to_cpu=offload_to_cpu,
         rank0_only=rank0_only,
@@ -164,7 +160,7 @@ def _common_unshard_post_state_dict_hook(
 ) -> Dict[str, Any]:
     """
     The post-state_dict flow that shared by all state_dict types that require
-    ``_unshard_params()``. FULL_STATE_DICT and SHARDED_STATE_DICT use this
+    ``_unshard_fsdp_state_params()``. FULL_STATE_DICT and SHARDED_STATE_DICT use this
     hook.
     """
     _replace_by_prefix(state_dict, prefix + f"{FSDP_PREFIX}", prefix)
@@ -239,7 +235,8 @@ def _common_unshard_post_state_dict_hook(
             buffers.append(state_dict[fqn])
     if buffers:
         mixed_precision_enabled_for_buffers = (
-            fsdp_state._mixed_precision_enabled_for_buffers() if not _is_composable(fsdp_state)
+            fsdp_state._mixed_precision_enabled_for_buffers()
+            if not _is_composable(fsdp_state)
             else (fsdp_state.mixed_precision.buffer_dtype is not None)
         )
         if mixed_precision_enabled_for_buffers:
@@ -289,7 +286,7 @@ def _full_post_state_dict_hook(
     """
     Hook that runs after model.state_dict() is called before returning result to
     user. For FSDP, we may have to clone the tensors in state_dict as params go
-    back to sharded version after _unshard_params ends, and also remove
+    back to sharded version after _unshard_fsdp_state_params ends, and also remove
     the ``FSDP_WRAPPED_MODULE`` prefix.
     """
 
@@ -306,7 +303,7 @@ def _full_post_state_dict_hook(
         if clean_key.startswith(clean_prefix):
             clean_key = clean_key[len(clean_prefix) :]
 
-        # Clone parameters before exiting the `_unshard_params()` context.
+        # Clone parameters before exiting the `_unshard_fsdp_state_params()` context.
         if not getattr(state_dict[fqn], "_has_been_cloned", False):
             try:
                 state_dict[fqn] = state_dict[fqn].clone().detach()
@@ -332,7 +329,7 @@ def _full_pre_load_state_dict_hook(
     prefix: str,
 ) -> None:
     _lazy_init(fsdp_state, module)
-    _enter_unshard_params_ctx(module, fsdp_state, recurse=False, writeback=True)
+    _enter_unshard_params_ctx(module, fsdp_state, writeback=True)
     # Add FSDP_PREFIX only for wrapper-based FSDP.
     if not _is_composable(fsdp_state):
         _replace_by_prefix(state_dict, prefix, prefix + f"{FSDP_PREFIX}")

--- a/torch/distributed/fsdp/_traversal_utils.py
+++ b/torch/distributed/fsdp/_traversal_utils.py
@@ -6,7 +6,7 @@ imports. For brevity, we may import the file as ``traversal_utils``.
 """
 
 import collections
-from typing import Deque, List, Set
+from typing import Deque, List, Set, Tuple
 
 import torch.nn as nn
 from torch.distributed._composable.contract import _get_registry
@@ -40,22 +40,27 @@ def _composable(module: nn.Module) -> bool:
     return "replicate" not in _get_registry(module)
 
 
-def _get_fsdp_states(module: nn.Module) -> List[_FSDPState]:
+def _get_fsdp_states_with_modules(
+    module: nn.Module,
+) -> Tuple[List[_FSDPState], List[nn.Module]]:
     """
-    Returns all ``_FSDPState`` instances in the module tree rooted at
+    Returns a tuple containing:
+    1. A list of the ``_FSDPState`` instances in the module tree rooted at
     ``module`` without any duplicates and following the ``module.modules()``
-    traversal order (which is assumed to remain as depth-first). However, the
-    traversal does not proceed into any module annotated by an incompatible
-    API (e.g. ``replicate``).
+    traversal order (which is assumed to remain depth-first).
+    2. A corresponding list of the modules owning the states in the first list.
 
-    For the wrapper code path, this returns all ``FullyShardedDataParallel``
-    instances. For the non-wrapper code path, this returns composable state
-    instances.
+    For the wrapper code path, this returns a list of all
+    ``FullyShardedDataParallel`` instances, and both lists are the same. For
+    the composable code path, this returns a list of all composable state
+    instances and a list of the corresponding fully sharded modules. See [Note:
+    Fully Sharded Module].
 
-    NOTE: For now, we must pass an ``nn.Module`` as the argument because
-    ``_FSDPState`` does not support graph traversal.
+    NOTE: The traversal does not proceed into any module annotated by an
+    incompatible API (e.g. ``replicate``).
     """
     fsdp_states: List[_FSDPState] = []
+    fsdp_modules: List[nn.Module] = []
     # Track the visited FSDP states since multiple modules may share the same
     # one and we want to return a de-duplicated list
     visited_fsdp_states: Set[_FSDPState] = set()
@@ -80,6 +85,13 @@ def _get_fsdp_states(module: nn.Module) -> List[_FSDPState]:
         if optional_state is not None and optional_state not in visited_fsdp_states:
             visited_fsdp_states.add(optional_state)
             fsdp_states.append(optional_state)
+            fsdp_modules.append(submodule)
+    return fsdp_states, fsdp_modules
+
+
+def _get_fsdp_states(module: nn.Module) -> List[_FSDPState]:
+    """See :func:`_get_fsdp_states_with_modules`."""
+    fsdp_states, _ = _get_fsdp_states_with_modules(module)
     return fsdp_states
 
 

--- a/torch/distributed/fsdp/_traversal_utils.py
+++ b/torch/distributed/fsdp/_traversal_utils.py
@@ -50,11 +50,11 @@ def _get_fsdp_states_with_modules(
     traversal order (which is assumed to remain depth-first).
     2. A corresponding list of the modules owning the states in the first list.
 
-    For the wrapper code path, this returns a list of all
-    ``FullyShardedDataParallel`` instances, and both lists are the same. For
-    the composable code path, this returns a list of all composable state
-    instances and a list of the corresponding fully sharded modules. See [Note:
-    Fully Sharded Module].
+    For the wrapper code path, both returned lists are the same, each
+    containing all ``FullyShardedDataParallel`` instances. For the composable
+    code path, this returns a list of all composable state instances and a list
+    of the corresponding fully sharded modules. See [Note: Fully Sharded
+    Module].
 
     NOTE: The traversal does not proceed into any module annotated by an
     incompatible API (e.g. ``replicate``).

--- a/torch/distributed/fsdp/_unshard_param_utils.py
+++ b/torch/distributed/fsdp/_unshard_param_utils.py
@@ -3,15 +3,18 @@ import warnings
 from typing import cast, Generator, List
 
 import torch
+import torch.distributed.fsdp._traversal_utils as traversal_utils
 import torch.nn as nn
 from torch.distributed.fsdp._common_utils import (
     _FSDPState,
     _has_fsdp_params,
     _module_handles,
     HandleTrainingState,
+    TrainingState,
 )
 from torch.distributed.fsdp._runtime_utils import (
     _clear_grads_if_needed,
+    _lazy_init,
     _reshard,
     _reshard_grads,
     _unshard,
@@ -120,38 +123,49 @@ def _unflatten_as_params(state: _FSDPState, module: nn.Module) -> Generator:
                 _register_flat_param(state, module)
 
 
-@contextlib.contextmanager
-def _unshard_params(
-    module: nn.Module,
+def _validate_unshard_params_args(
     state: _FSDPState,
-    writeback: bool = True,
-    rank0_only: bool = False,
-    offload_to_cpu: bool = False,
-    with_grads: bool = False,
-):
+    writeback: bool,
+    rank0_only: bool,
+    offload_to_cpu: bool,
+    with_grads: bool,
+) -> None:
     if with_grads and (offload_to_cpu or not state._use_orig_params):
         raise NotImplementedError(
-            f"with_grads={with_grads} "
-            f"use_orig_params={state._use_orig_params} "
+            f"with_grads={with_grads}, "
+            f"use_orig_params={state._use_orig_params}, "
             f"offload_to_cpu={offload_to_cpu} "
             f"is not supported yet"
         )
     if writeback and rank0_only:
-        raise ValueError(
-            "writeback=True and rank0_only=True is not supported, as model "
-            "parameter shapes will be different across ranks, and writing "
-            "to them can lead to inconsistencies across ranks when the "
-            "context is exited."
-        )
+        # TODO: Rank 0 can broadcast the `FlatParameter` to allow all ranks to
+        # persist the changes.
+        raise ValueError("writeback=True and rank0_only=True is not supported yet")
     if offload_to_cpu and not rank0_only:
         warnings.warn(
-            "offload_to_cpu and rank0_only=False will result in "
-            "full parameters being redundantly copied to CPU memory for "
-            "GPUs that reside on the same machine, which may incur the risk of "
-            "CPU OOM. It is recommended to use ``offload_to_cpu`` with "
-            "rank0_only=True."
+            "offload_to_cpu=True and rank0_only=False may result in the"
+            "unsharded parameters being redundantly copied to CPU memory for "
+            "GPUs sharing the same CPU memory, which risks CPU OOM. We "
+            "recommend using offload_to_cpu=True with rank0_only=True."
         )
 
+
+@contextlib.contextmanager
+def _unshard_fsdp_state_params(
+    module: nn.Module,
+    state: _FSDPState,
+    writeback: bool,
+    rank0_only: bool,
+    offload_to_cpu: bool,
+    with_grads: bool,
+):
+    """
+    Unshards the parameters for a single FSDP state ``state`` that corresponds
+    to ``module``.
+    """
+    _validate_unshard_params_args(
+        state, writeback, rank0_only, offload_to_cpu, with_grads
+    )
     torch.cuda.synchronize()
     # If handles are shared by other module(s), the handle may be already unsharded.
     handles = [
@@ -196,11 +210,10 @@ def _unshard_params(
             for handle in handles:
                 if offload_to_cpu and handle.uses_sharded_strategy:
                     stack.enter_context(handle.to_cpu())
-                    # TODO (awgu): Since PyTorch enforces that a parameter
-                    # and its gradients need to match metadata (e.g.
-                    # device), we must move gradients to CPU *after* we
-                    # move parameters.
-            # TODO (awgu): This FPW call assumes 1 `FlatParameter`
+                    # NOTE: Since PyTorch enforces that a parameter and its
+                    # gradients need to match metadata (e.g. device), we must
+                    # move gradients to CPU *after* we move parameters.
+            # NOTE: This assumes 1 `FlatParameter`
             if not state._use_orig_params:
                 stack.enter_context(_unflatten_as_params(state, module))
             try:
@@ -214,6 +227,53 @@ def _unshard_params(
                     _reshard_grads(handles)
                 for handle in handles:
                     handle._training_state = HandleTrainingState.IDLE
+
+
+@contextlib.contextmanager
+def _unshard_params(
+    module: nn.Module,
+    state: _FSDPState,
+    recurse: bool,
+    writeback: bool,
+    rank0_only: bool,
+    offload_to_cpu: bool,
+    with_grads: bool,
+):
+    _validate_unshard_params_args(
+        state, writeback, rank0_only, offload_to_cpu, with_grads
+    )
+    if recurse:
+        with contextlib.ExitStack() as stack:
+            for state, fsdp_module in zip(
+                *traversal_utils._get_fsdp_states_with_modules(module)
+            ):
+                stack.enter_context(
+                    _unshard_params(
+                        module=fsdp_module,
+                        state=state,
+                        recurse=False,
+                        writeback=writeback,
+                        rank0_only=rank0_only,
+                        offload_to_cpu=offload_to_cpu,
+                        with_grads=with_grads,
+                    )
+                )
+            yield
+        return
+    _lazy_init(state, module)
+    with _unshard_fsdp_state_params(
+        module=module,
+        state=state,
+        writeback=writeback,
+        rank0_only=rank0_only,
+        offload_to_cpu=offload_to_cpu,
+        with_grads=with_grads,
+    ):
+        try:
+            state.training_state = TrainingState.SUMMON_FULL_PARAMS
+            yield
+        finally:
+            state.training_state = TrainingState.IDLE
 
 
 def _deregister_orig_params(state: _FSDPState, module: nn.Module) -> None:

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -91,9 +91,7 @@ from ._unshard_param_utils import (
     _deregister_orig_params,
     _register_flat_param,
     _register_orig_params,
-    _unshard_fsdp_state_params,
     _unshard_params,
-    _validate_unshard_params_args,
 )
 from ._utils import p_assert
 from .flat_param import FlatParameter


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#92235 [FSDP][1/N] `_summon_full_params` -> `_unshard_params`**
* #92031 [FSDP][BE] Improve `device_id` + CPU offload test
* #92028 [FSDP][BE] Rename `prefixed_param_names` -> `fqns` for consolidation
* #92027 [FSDP][BE] Better error msg for incorrect device for training

**Overview**
This PR stack will add support for unsharding FSDP's sharded parameters for `fully_shard`.
- The existing API for wrapper FSDP is the static method `summon_full_params()`, which calls into the helper `_summon_full_params()`.
- This PR refactors `_summon_full_params()` to `_unshard_params()`, which has a `recurse: bool` argument, and renames the previous `_unshard_params()` to `_unshard_fsdp_state_params()`, which applies to a single FSDP state.

**Details**
- This PR introduces `_get_fsdp_states_with_modules()`, which additionally returns the modules along with the FSDP states. The modules are needed for handling `FlatParameter` registration.
    - We may be able to remove this if we clean up the `use_orig_params=True` vs. `False` code paths because for `True`, the `FlatParameter` is not registered, meaning that it does not need to be de-registered.
    - Since `fully_shard` requires `use_orig_params=True`, we may not need `_get_fsdp_states_with_modules()`; however, I prefer to make the separation of FSDP state and module explicit for now.

**Follow-Ups**
- `writeback=True` and `rank0_only=True` raises an error. The previous explanation was:
> is not supported, as model parameter shapes will be different across ranks, and writing to them can lead to inconsistencies across ranks when the context is exited.

I am not exactly sure what the different model parameter shapes refers to. However, I believe that we can support `writeback=True` and `rank0_only=True` by broadcasting the `FlatParameter` from rank 0 in the `finally`, writing back, and freeing. This should not increase the peak memory since rank 0 already holds the unsharded `FlatParameter` in GPU memory before writing back and nonzero ranks do not have any other unsharded `FlatParameter`s in GPU memory.