### PR TITLE
Fix oneDNN double checkout issue and Upgrade oneDNN to v2.7.3

### DIFF
--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -55,8 +55,8 @@ template_rule(
     substitutions = {
         "@DNNL_VERSION_MAJOR@": "2",
         "@DNNL_VERSION_MINOR@": "7",
-        "@DNNL_VERSION_PATCH@": "2",
-        "@DNNL_VERSION_HASH@": "fbec3e25a559ee252022ae066817b204e106a6ba",
+        "@DNNL_VERSION_PATCH@": "3",
+        "@DNNL_VERSION_HASH@": "7710bdc92064a08b985c5cbdb09de773b19cba1f",
     },
 )
 


### PR DESCRIPTION
### Descriotion

This PR is to fix oneDNN double checkout issue that mentioned in https://github.com/pytorch/pytorch/pull/87061#issuecomment-1284384276, and upgrade oneDNN to v2.7.3 to fix #92138.

### Performance test

Use TorchBench test in ICX with 40 cores
Intel OpenMP & jemalloc were preloaded
![image](https://user-images.githubusercontent.com/61222868/212634378-b91c20b5-0e85-474f-861c-c1d2f6962de1.png)



cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @Guobing-Chen @Xia-Weiwen