### PR TITLE
Proposal: Add complex-valued constraints for distributions

### DIFF
--- a/test/distributions/test_constraints.py
+++ b/test/distributions/test_constraints.py
@@ -31,6 +31,8 @@ EXAMPLES = [
 CONSTRAINTS = [
     (constraints.real,),
     (constraints.real_vector,),
+    (constraints.complex,),
+    (constraints.complex_vector,),
     (constraints.positive,),
     (constraints.greater_than, [-10., -2, 0, 2, 10]),
     (constraints.greater_than, 0),

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -3,6 +3,8 @@ The following constraints are implemented:
 
 - ``constraints.boolean``
 - ``constraints.cat``
+- ``constraints.complex``
+- ``constraints.complex_vector``
 - ``constraints.corr_cholesky``
 - ``constraints.dependent``
 - ``constraints.greater_than(lower_bound)``
@@ -305,9 +307,18 @@ class _Real(Constraint):
     Trivially constrain to the extended real line `[-inf, inf]`.
     """
     def check(self, value):
-        return value == value  # False for NANs.
+        return not torch.is_complex(value) and value == value  # False for NaNs.
 
+    
+class _Complex(Constraint):
+    """
+    Trivially constrain to the extended real line `[-inf, inf]` for both the
+    real and imaginary part.
+    """
+    def check(self, value):
+        return torch.is_complex(value) and value == value  # False for NaNs.
 
+    
 class _GreaterThan(Constraint):
     """
     Constrain to a real half line `(lower_bound, inf]`.
@@ -588,6 +599,8 @@ positive_integer = _IntegerGreaterThan(1)
 integer_interval = _IntegerInterval
 real = _Real()
 real_vector = independent(real, 1)
+complex = _Complex()
+complex_vector = independent(complex, 1)
 positive = _GreaterThan(0.)
 nonnegative = _GreaterThanEq(0.)
 greater_than = _GreaterThan

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -309,7 +309,7 @@ class _Real(Constraint):
     Trivially constrain to the extended real line `[-inf, inf]`.
     """
     def check(self, value):
-        return not torch.is_complex(value) and value == value  # False for NaNs.
+        return (torch.is_complex(value) | torch.isnan(value)).logical_not()
 
 
 class _Complex(Constraint):

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -38,6 +38,8 @@ __all__ = [
     'Constraint',
     'boolean',
     'cat',
+    'complex',
+    'complex_vector',
     'corr_cholesky',
     'dependent',
     'dependent_property',

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -311,7 +311,7 @@ class _Real(Constraint):
     def check(self, value):
         return not torch.is_complex(value) and value == value  # False for NaNs.
 
-    
+
 class _Complex(Constraint):
     """
     Trivially constrain to the extended real line `[-inf, inf]` for both the
@@ -320,7 +320,7 @@ class _Complex(Constraint):
     def check(self, value):
         return torch.is_complex(value) and value == value  # False for NaNs.
 
-    
+
 class _GreaterThan(Constraint):
     """
     Constrain to a real half line `(lower_bound, inf]`.

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -318,7 +318,7 @@ class _Complex(Constraint):
     real and imaginary part.
     """
     def check(self, value):
-        return torch.is_complex(value) and value == value  # False for NaNs.
+        return torch.is_complex(value) & torch.isnan(value).logical_not()
 
 
 class _GreaterThan(Constraint):


### PR DESCRIPTION
Also make the `real`/`real-vector` only pass the check if they are not complex-valued.

## Rationale

In some discussions on forums as well es in, for example, #83376 complex-valued distributions were discussed. None of them have been implemented iny mainline PyTorch so far (AFAIK), but a first step would be the ability to express the constraints on these distributions. This is helpful for downstream libraries even if PyTorch never actually implements these in the main codebase. The extension is straight-forward and easy to maintain.

In addition, I noticed that the `real`/`real-vector` would also pass for complex-valued constraints. I suppose that this was not intentional.

## Next steps

If this change is deemed helpful, I'll add the nessesary tests. I think that this does not require more documentation, but please correct me if I am wrong with that.