### PR TITLE
Fix Windows cpu_profiling_allocator_test same pointer check flakiness

### DIFF
--- a/aten/src/ATen/test/cpu_profiling_allocator_test.cpp
+++ b/aten/src/ATen/test/cpu_profiling_allocator_test.cpp
@@ -178,7 +178,6 @@ TEST(CPUAllocationPlanTest, with_profiling_alloc) {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   ASSERT_NO_THROW(validate_allocation_plan(false, false, true));
   ASSERT_TRUE(ref_output.equal(output));
-  #endif
 
   // When control flow conditions are different between profiling and evaluation
   // profiling allocator should throw.

--- a/aten/src/ATen/test/cpu_profiling_allocator_test.cpp
+++ b/aten/src/ATen/test/cpu_profiling_allocator_test.cpp
@@ -164,6 +164,12 @@ TEST(CPUAllocationPlanTest, with_profiling_alloc) {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   ASSERT_NO_THROW(validate_allocation_plan(false, false, false));
   ASSERT_TRUE(ref_output.equal(output));
+
+  // Returning the same pointers is not a guarantee when the default
+  // allocator is used. It looks like the underlying memory pointer
+  // can change as long as output and ref_output remain equal. This
+  // has already been confirmed in the previous two tests
+  #ifdef C10_MOBILE
   // Furthermore profiling allocator should return the same pointers
   // back for the intermediate tensors
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
@@ -172,8 +178,8 @@ TEST(CPUAllocationPlanTest, with_profiling_alloc) {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   ASSERT_NO_THROW(validate_allocation_plan(false, false, true));
   ASSERT_TRUE(ref_output.equal(output));
+  #endif
 
-  #ifdef C10_MOBILE
   // When control flow conditions are different between profiling and evaluation
   // profiling allocator should throw.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)


### PR DESCRIPTION
This is a small follow-up from https://github.com/pytorch/pytorch/pull/91727 to fix the flaky same pointer check on Windows https://hud.pytorch.org/failure/%5B%20%20FAILED%20%20%5D%20CPUAllocationPlanTest.with_profiling_alloc.  AFAICT, keeping the same memory pointer is not a guarantee in non-mobile memory allocator (or may be this is Windows-specific behavior).

The test might be flaky when the tensor is copied to a different memory location with the default allocator.  This's ok as long as the values remain equal.