### PR TITLE
Reduce some ambiguity in Tensor

### DIFF
--- a/torch/csrc/api/include/torch/data/example.h
+++ b/torch/csrc/api/include/torch/data/example.h
@@ -8,7 +8,7 @@ namespace data {
 /// An `Example` from a dataset.
 ///
 /// A dataset consists of data and an associated target (label).
-template <typename Data = Tensor, typename Target = Tensor>
+template <typename Data = at::Tensor, typename Target = at::Tensor>
 struct Example {
   using DataType = Data;
   using TargetType = Target;
@@ -23,7 +23,7 @@ struct Example {
 
 namespace example {
 using NoTarget = void;
-} //  namespace example
+} // namespace example
 
 /// A specialization for `Example` that does not have a target.
 ///
@@ -50,6 +50,6 @@ struct Example<Data, example::NoTarget> {
   Data data;
 };
 
-using TensorExample = Example<Tensor, example::NoTarget>;
+using TensorExample = Example<at::Tensor, example::NoTarget>;
 } // namespace data
 } // namespace torch

--- a/torch/csrc/api/include/torch/data/samplers/random.h
+++ b/torch/csrc/api/include/torch/data/samplers/random.h
@@ -46,7 +46,7 @@ class TORCH_API RandomSampler : public Sampler<> {
   size_t index() const noexcept;
 
  private:
-  Tensor indices_;
+  at::Tensor indices_;
   int64_t index_ = 0;
 };
 } // namespace samplers


### PR DESCRIPTION
Summary:
A lot of other libraries have their own `xyz::Tensor` data structure. Under some rare cases, when they interop with torch, there will be compilation error such as
```
torch/csrc/api/include/torch/data/samplers/random.h(49): error: "Tensor" is ambiguous
```
Making some of the `Tensor` namespace clear will resolve this.

Test Plan: CI

Differential Revision: D42538675

