### PR TITLE
Move XLA test job to 4xlarge

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -206,10 +206,13 @@ jobs:
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
 
           if [[ $TEST_CONFIG == 'xla' ]]; then
-            # Spare one CPU for the runner
-            MAX_CPUS_COUNT=$(($(nproc) - 1))
-
-          docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
+            # Spare one CPU for the runner to avoid crashing it
+            MAX_CPU_COUNT=$(($(nproc) - 1))
+            # https://docs.docker.com/config/containers/resource_constraints/
+            docker exec --cpus="${MAX_CPU_COUNT}" -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
+          else
+            docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
+          fi
 
       - name: Print remaining test logs
         shell: bash

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -159,14 +159,6 @@ jobs:
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[\'\"]}"
           export PR_BODY="${PR_BODY//[\'\"]}"
 
-          # Spare one CPU for the runner to avoid crashing it
-          CPU_COUNT=$(nproc)
-          echo "The runner has ${CPU_COUNT} CPUs"
-
-          if [[ $TEST_CONFIG == 'xla' ]]; then
-            CPU_COUNT=$((CPU_COUNT - 1))
-          fi
-
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice
@@ -198,7 +190,6 @@ jobs:
             -e PYTORCH_TEST_CUDA_MEM_LEAK_CHECK \
             -e PYTORCH_TEST_RERUN_DISABLED_TESTS \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
-            --cpus="${CPU_COUNT}" \
             --ulimit stack=10485760:83886080 \
             --security-opt seccomp=unconfined \
             --cap-add=SYS_PTRACE \
@@ -213,7 +204,6 @@ jobs:
             "${DOCKER_IMAGE}"
           )
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
-
           docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
 
       - name: Print remaining test logs

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -204,6 +204,11 @@ jobs:
             "${DOCKER_IMAGE}"
           )
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
+
+          if [[ $TEST_CONFIG == 'xla' ]]; then
+            # Spare one CPU for the runner
+            MAX_CPUS_COUNT=$(($(nproc) - 1))
+
           docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
 
       - name: Print remaining test logs

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -159,6 +159,14 @@ jobs:
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[\'\"]}"
           export PR_BODY="${PR_BODY//[\'\"]}"
 
+          # Spare one CPU for the runner to avoid crashing it
+          CPU_COUNT=$(nproc)
+          echo "The runner has ${CPU_COUNT} CPUs"
+
+          if [[ $TEST_CONFIG == 'xla' ]]; then
+            CPU_COUNT=$((CPU_COUNT - 1))
+          fi
+
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice
@@ -190,6 +198,7 @@ jobs:
             -e PYTORCH_TEST_CUDA_MEM_LEAK_CHECK \
             -e PYTORCH_TEST_RERUN_DISABLED_TESTS \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
+            --cpus="${CPU_COUNT}" \
             --ulimit stack=10485760:83886080 \
             --security-opt seccomp=unconfined \
             --cap-add=SYS_PTRACE \
@@ -205,14 +214,7 @@ jobs:
           )
           echo "DOCKER_CONTAINER_ID=${container_name}" >> "${GITHUB_ENV}"
 
-          if [[ $TEST_CONFIG == 'xla' ]]; then
-            # Spare one CPU for the runner to avoid crashing it
-            MAX_CPU_COUNT=$(($(nproc) - 1))
-            # https://docs.docker.com/config/containers/resource_constraints/
-            docker exec --cpus="${MAX_CPU_COUNT}" -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
-          else
-            docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
-          fi
+          docker exec -t "${container_name}" sh -c "pip install $(echo dist/*.whl)[opt-einsum] && ${TEST_COMMAND}"
 
       - name: Print remaining test logs
         shell: bash

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -217,7 +217,7 @@ jobs:
       docker-image-name: xla_base
       test-matrix: |
         { include: [
-          { config: "xla", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
+          { config: "xla", shard: 1, num_shards: 1, runner: "linux.4xlarge" },
         ]}
 
   linux-bionic-py3_7-clang8-xla-test:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -217,7 +217,7 @@ jobs:
       docker-image-name: xla_base
       test-matrix: |
         { include: [
-          { config: "xla", shard: 1, num_shards: 1, runner: "linux.4xlarge" },
+          { config: "xla", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
         ]}
 
   linux-bionic-py3_7-clang8-xla-test:


### PR DESCRIPTION
Per the discussion with @clee2000 , I'm trying to look into XLA flaky failures.  It's tricky because the runner crashes losing all the logs.  The only guess I have comes from the test insight information of XLA test job, i.e. https://hud.pytorch.org/test/insights?jobName=linux-bionic-py3_7-clang8-xla%20%2F%20test%20(xla%2C%201%2C%201%2C%20linux.2xlarge)&workflowId=3919472559&jobId=10650151864

* Memory looks fine. It peaks at ~14GB when building, then dropping when testing
* CPU spikes at 100% at the end, which I suspect to be the reason causing the runner to crash

So the fix is to try to limit the test to nCPU - 1, so there is always one core left for the runner.