### PR TITLE
Remove quantized models from dynamic skip list

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -93,8 +93,6 @@ CI_SKIP_AOT_EAGER_TRAINING = [
 CI_SKIP_AOT_EAGER_DYNAMIC_TRAINING = [
     *CI_SKIP_AOT_EAGER_TRAINING,
     "hf_T5_base",  # fp64_OOM
-    "mobilenet_v2_quantized_qat",  # setStorage
-    "resnet50_quantized_qat",  # setStorage
     "tacotron2",  # aten._thnn_fused_lstm_cell.default
     "DebertaV2ForQuestionAnswering",  # OOMs (but on CI only; graph breaks?)
     "crossvit_9_240",  # torch._C._nn.upsample_bicubic2d


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92271

These fail but... I don't see how they could possibly be working even on non-dynamic shapes? It seems like somehow they are being skipped by some other mechanism.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire