### PR TITLE
stack_module_state should return unrelated parameters

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -3268,6 +3268,25 @@ class TestMakeFunctional(TestCase):
         models = [torch.nn.Linear(in_features, out_features) for i in range(num_models)]
         _ = stack_module_state(models)
 
+    def test_stack_module_state_leaf(self):
+        in_features = 2
+        out_features = 2
+        num_models = 3
+        models = [torch.nn.Linear(in_features, out_features) for i in range(num_models)]
+        params, buffers = stack_module_state(models)
+        for param in params.values():
+            self.assertTrue(param.requires_grad)
+            self.assertTrue(param.is_leaf)
+
+    def test_stack_module_state_mismatch_error(self):
+        in_features = 2
+        out_features = 2
+        num_models = 3
+        models = [torch.nn.Linear(in_features, out_features) for i in range(num_models)]
+        models[0].weight.requires_grad_(False)
+        with self.assertRaisesRegex(RuntimeError, "same .requires_grad"):
+            params, buffers = stack_module_state(models)
+
     def test_stack_module_state_error(self):
         in_features = 2
         out_features = 2

--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -134,6 +134,9 @@ def stack_module_state(models: List[nn.Module]) -> Tuple[Dict[str, Any], Dict[st
 
     Given a list of ``M`` ``nn.Modules`` of the same class, returns two dictionaries
     that stack all of their parameters and buffers together, indexed by name.
+    The stacked parameters are optimizable (i.e. they are new leaf nodes in the
+    autograd history that are unrelated to the original parameters and can be
+    passed directly to an optimizer).
 
     Here's an example of how to ensemble over a very simple model:
 
@@ -189,8 +192,21 @@ def stack_module_state(models: List[nn.Module]) -> Tuple[Dict[str, Any], Dict[st
         raise RuntimeError('stack_module_state: Expected all models to '
                            'be of the same class.')
     all_params = [{k: v for k, v in model.named_parameters()} for model in models]
-    params = {k: torch.stack(tuple(params[k] for params in all_params)) for k in all_params[0]}
+    params = {k: construct_stacked_leaf(tuple(params[k] for params in all_params), k)
+              for k in all_params[0]}
     all_buffers = [{k: v for k, v in model.named_buffers()} for model in models]
-    buffers = {k: torch.stack(tuple(buffers[k] for buffers in all_buffers)) for k in all_buffers[0]}
+    buffers = {k: construct_stacked_leaf(tuple(buffers[k] for buffers in all_buffers), k)
+               for k in all_buffers[0]}
 
     return params, buffers
+
+def construct_stacked_leaf(tensors, name):
+    all_requires_grad = all([t.requires_grad for t in tensors])
+    none_requires_grad = all([not t.requires_grad for t in tensors])
+    if not all_requires_grad and not none_requires_grad:
+        raise RuntimeError(
+            f'Expected {name} from each model to have the same .requires_grad')
+    result = torch.stack(tensors)
+    if all_requires_grad:
+        result = result.detach().requires_grad_()
+    return result


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

`torch.func.stack_module_state` is our replacement for
`functorch.combine_state_for_ensemble`. The most common usage for
combine_state_for_ensemble is to
- create stacked parameters and buffers
- use vmap to run the forward pass
- use regular PyTorch autograd to run the backward pass (e.g.,
Tensor.backwrd)
- optimize directly over the stacked parameters (this is more performant
than optimizing over the unstacked parameters).

Right now, stack_module_state returns stacked parameters that cannot be
optimized directly (only leaf tensors can have a .grad field); this PR
fixes that by turning the stacked parameters back into leaf tensors.

Test Plan:
- new tests