### PR TITLE
Add deprecation messages for functorch.* function transforms

### DIFF
--- a/functorch/__init__.py
+++ b/functorch/__init__.py
@@ -12,18 +12,16 @@ from . import _C
 # - very experimental things should go into functorch.experimental
 # - compilation related things should go into functorch.compile
 
-# functorch transforms
-from torch._functorch.vmap import vmap
-from torch._functorch.eager_transforms import (
-    grad, grad_and_value, vjp, jacrev, jvp, jacfwd, hessian, functionalize
-)
+# Was never documented
 from torch._functorch.python_key import make_fx
+
+from torch._functorch.deprecated import (
+    vmap, grad, grad_and_value, vjp, jvp, jacrev, jacfwd, hessian, functionalize,
+    make_functional, make_functional_with_buffers, combine_state_for_ensemble,
+)
 
 # utilities. Maybe these should go in their own namespace in the future?
 from torch._functorch.make_functional import (
-    make_functional_with_buffers,
-    make_functional,
-    combine_state_for_ensemble,
     FunctionalModule,
     FunctionalModuleWithBuffers,
 )

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2699,6 +2699,34 @@ class TestHelpers(TestCase):
 
 
 class TestComposability(TestCase):
+    def test_deprecation_vmap(self, device):
+        x = torch.randn(3, device=device)
+
+        # functorch version of the API is deprecated
+        with self.assertWarnsRegex(DeprecationWarning, "Please use torch.vmap"):
+            vmap(torch.sin)
+
+        # the non-functorch version is not
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            torch.vmap(torch.sin)
+
+    @parametrize('transform', [
+        'grad', 'jacrev', 'jacfwd', 'grad_and_value', 'hessian', 'functionalize'
+    ])
+    def test_deprecation_transforms(self, device, transform):
+        api = getattr(functorch, transform)
+        new_api = getattr(torch.func, transform)
+
+        # functorch version of the API is deprecated
+        with self.assertWarnsRegex(DeprecationWarning, f"Please use torch.func.{transform}"):
+            api(torch.sin)
+
+        # the non-functorch version is not
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            new_api(torch.sin)
+
     def test_grad_grad(self, device):
         x = torch.randn([], device=device)
         y = grad(grad(torch.sin))(x)

--- a/torch/_functorch/deprecated.py
+++ b/torch/_functorch/deprecated.py
@@ -1,0 +1,107 @@
+import torch._functorch.vmap as _vmap_impl
+import torch._functorch.eager_transforms as _impl
+import torch._functorch.make_functional as _nn_impl
+import textwrap
+import warnings
+
+"""
+The APIs in this file are exposed as `functorch.*`. They are thin wrappers
+around the torch.func.* APIs that have deprecation warnings -- we're trying
+to move people to the torch.func.* equivalents.
+"""
+
+def get_warning(api, new_api=None, replace_newlines=False):
+    if new_api is None:
+        new_api = f'torch.func.{api}'
+    warning = (
+        f"We've integrated functorch into PyTorch. As the final step of the \n"
+        f"integration, functorch.{api} is deprecated as of PyTorch \n"
+        f"2.0.0 and will be deleted in a future version of PyTorch >= 2.3.0. \n"
+        f"Please use {new_api} instead; see the PyTorch 2.0.0 release notes \n"
+        f"and/or the torch.func migration guide for more details."
+    )
+    if replace_newlines:
+        warning = warning.replace("\n", "")
+    return warning
+
+
+def warn_deprecated(api, new_api=None):
+    warning = get_warning(api, new_api, replace_newlines=True)
+    warnings.warn(warning, DeprecationWarning)
+
+
+def setup_docs_annotations(functorch_api, torch_func_api=None, new_api_name=None):
+    api_name = functorch_api.__name__
+    if torch_func_api is None:
+        torch_func_api = getattr(_impl, api_name)
+
+    functorch_api.__annotations__ = torch_func_api.__annotations__
+
+    warning = get_warning(api_name, new_api_name)
+    warning_note = "\n.. warning::\n\n" + textwrap.indent(warning, "    ")
+    warning_note = textwrap.indent(warning_note, "    ")
+    functorch_api.__doc__ = torch_func_api.__doc__ + warning_note
+
+def vmap(*args, **kwargs):
+    warn_deprecated('vmap', 'torch.vmap')
+    return _vmap_impl.vmap(*args, **kwargs)
+
+def grad(*args, **kwargs):
+    warn_deprecated('grad')
+    return _impl.grad(*args, **kwargs)
+
+def grad_and_value(*args, **kwargs):
+    warn_deprecated('grad_and_value')
+    return _impl.grad_and_value(*args, **kwargs)
+
+def vjp(*args, **kwargs):
+    warn_deprecated('vjp')
+    return _impl.vjp(*args, **kwargs)
+
+def jvp(*args, **kwargs):
+    warn_deprecated('jvp')
+    return _impl.jvp(*args, **kwargs)
+
+def jacrev(*args, **kwargs):
+    warn_deprecated('jacrev')
+    return _impl.jacrev(*args, **kwargs)
+
+def jacfwd(*args, **kwargs):
+    warn_deprecated('jacfwd')
+    return _impl.jacfwd(*args, **kwargs)
+
+def hessian(*args, **kwargs):
+    warn_deprecated('hessian')
+    return _impl.hessian(*args, **kwargs)
+
+def functionalize(*args, **kwargs):
+    warn_deprecated('functionalize')
+    return _impl.functionalize(*args, **kwargs)
+
+def make_functional(*args, **kwargs):
+    warn_deprecated('make_functional', 'torch.func.functional_call')
+    return _nn_impl.make_functional(*args, **kwargs)
+
+def make_functional_with_buffers(*args, **kwargs):
+    warn_deprecated('make_functional_with_buffers', 'torch.func.functional_call')
+    return _nn_impl.make_functional_with_buffers(*args, **kwargs)
+
+def combine_state_for_ensemble(*args, **kwargs):
+    warn_deprecated('combine_state_for_ensemble', 'torch.func.stack_module_state')
+    return _nn_impl.combine_state_for_ensemble(*args, **kwargs)
+
+setup_docs_annotations(vmap, _vmap_impl.vmap, 'torch.vmap')
+setup_docs_annotations(grad)
+setup_docs_annotations(grad_and_value)
+setup_docs_annotations(vjp)
+setup_docs_annotations(jvp)
+setup_docs_annotations(jacrev)
+setup_docs_annotations(jacfwd)
+setup_docs_annotations(hessian)
+setup_docs_annotations(functionalize)
+setup_docs_annotations(make_functional, _nn_impl.make_functional,
+                       'torch.func.functional_call')
+setup_docs_annotations(make_functional_with_buffers, _nn_impl.make_functional,
+                       'torch.func.functional_call')
+setup_docs_annotations(combine_state_for_ensemble, _nn_impl.combine_state_for_ensemble,
+                       'torch.func.stack_module_state')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This PR:
- adds deprecation warnings when calling the functorch APIs
- adds documentation saying that those APIs are deprecated

It does this by creating thin wrappers around the original APIs that (1)
raise deprecation warnings and (2) have an additional line in their
documentation that they are deprecated.

NB:
- PyTorch actually suppresses all DeprecationWarning by default.
So the warnings themselves are less important than the docs.

Test Plan:
- New tests
- the functorch.* APIs are still tested for correctness because that's
what test/functorch/* use (as opposed to directly calling the
torch.func.* APIs)