### PR TITLE
Deprecate torch.nn.utils.stateless.functional_call

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -23,7 +23,6 @@ import unittest
 import warnings
 import itertools
 from functools import partial
-from torch.nn.utils import stateless
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_methods_invocations import op_db, wrapper_set_seed
 from torch.testing._internal.common_modules import module_db, modules
@@ -2575,7 +2574,7 @@ def _test_aot_autograd_module_helper(self, device, dtype, training, module_info)
                     cur_flat_args[idx] = next(args)
             c_args, c_kwargs = pytree.tree_unflatten(cur_flat_args, args_spec)
             params_and_buffers = {**named_params, **named_buffers}
-            return stateless.functional_call(m, params_and_buffers, c_args, c_kwargs)
+            return torch.func.functional_call(m, params_and_buffers, c_args, c_kwargs)
 
         named_params = dict(_named_parameters(m, remove_duplicate=False))
         named_buffers = dict(_named_buffers(m, remove_duplicate=False))

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -18,7 +18,6 @@ import typing
 import types
 import warnings
 import unittest
-import torch.nn.utils._stateless as _stateless
 from math import sqrt
 from torch.multiprocessing import Process
 from torch.testing import FileCheck
@@ -3065,7 +3064,7 @@ class TestFX(JitTestCase):
                       'l1.bias': bias,
                       'buffer': buffer}
         fx_module = torch.fx.symbolic_trace(module)
-        res = _stateless.functional_call(fx_module, parameters, x)
+        res = torch.func.functional_call(fx_module, parameters, x)
         res.backward()
         self.assertIsNotNone(weight.grad)
         self.assertIsNotNone(bias.grad)

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -4,7 +4,6 @@ from torch.testing._internal.common_utils import TestCase, run_tests, IS_WINDOWS
 import torch
 import unittest
 import warnings
-import torch.nn.utils._stateless as stateless
 import operator
 from collections.abc import Iterable
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
@@ -334,12 +333,12 @@ def forward(self, x_1):
         # An old version of this test called the module directly.  This works
         # for tracing_mode == "real", but for fake tensors, we also have to
         # ensure that the parameters and buffers get wrapped in fake tensors
-        # because free fake tensors are not supported.  Fortunately stateless
+        # because free fake tensors are not supported.  Fortunately functional_call
         # does precisely this for us.
         def f(x, params, buffers):
             for p in params.values():
                 p.grad = None
-            loss = stateless.functional_call(mod, {**params, **buffers}, (x,)).sum()
+            loss = torch.func.functional_call(mod, {**params, **buffers}, (x,)).sum()
             # I could have done this with the functional API, but there is
             # plenty of exercising this; I want to show mutating API still
             # works
@@ -523,7 +522,7 @@ def forward(self, x_1):
         model = Foo()
 
         def f(x, params):
-            out = stateless.functional_call(model, params, x).sum()
+            out = torch.func.functional_call(model, params, x).sum()
             out.backward()
             return list(params.values())
         input = torch.randn(3, 5, requires_grad=True)
@@ -581,7 +580,7 @@ def forward(self, x_1):
             if not isinstance(args, Iterable):
                 args = [args]
             params_and_buffers = {**params, **buffers}
-            out = stateless.functional_call(model, params_and_buffers, args)
+            out = torch.func.functional_call(model, params_and_buffers, args)
             out.sum().backward()
             return [p - 1e-4 * p.grad for p in params.values()]
 

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -2328,7 +2328,7 @@ def aot_module(mod: nn.Module, *args, **kwargs) -> nn.Module:
 
     def functional_call(named_params, named_buffers, *args, **kwargs):
         params_and_buffers = {**named_params, **named_buffers}
-        return stateless.functional_call(mod, params_and_buffers, args, kwargs)
+        return torch.func.functional_call(mod, params_and_buffers, args, kwargs)
 
     named_params = dict(_named_parameters(mod, remove_duplicate=False))
     named_buffers = dict(_named_buffers(mod, remove_duplicate=False))

--- a/torch/_functorch/functional_call.py
+++ b/torch/_functorch/functional_call.py
@@ -123,7 +123,7 @@ def functional_call(
 
         parameters_and_buffers = {k: v for d in parameter_and_buffer_dicts for k, v in d.items()}
 
-    return nn.utils.stateless.functional_call(module, parameters_and_buffers, args, kwargs, tie_weights=tie_weights)
+    return nn.utils.stateless._functional_call(module, parameters_and_buffers, args, kwargs, tie_weights=tie_weights)
 
 
 @exposed_in("torch.func")

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -240,7 +240,7 @@ class RNNBase(Module):
 
     def _weights_have_changed(self):
         # Returns True if the weight tensors have changed since the last forward pass.
-        # This is the case when used with stateless.functional_call(), for example.
+        # This is the case when used with torch.func.functional_call(), for example.
         weights_changed = False
         for ref, name in zip(self._flat_weight_refs, self._flat_weights_names):
             weight = getattr(self, name) if hasattr(self, name) else None

--- a/torch/nn/utils/_per_sample_grad.py
+++ b/torch/nn/utils/_per_sample_grad.py
@@ -1,14 +1,11 @@
 import functools
 
 import torch
-from torch.nn.utils.stateless import functional_call
 from torch.nn.utils._expanded_weights.expanded_weights_impl import ExpandedWeight
 
 from torch.utils._pytree import tree_flatten
 
 
-# dependency on `functional_call` means that this can't be exposed in utils
-# without creating circular dependency
 def call_for_per_sample_grads(module, *, batch_size=None, loss_reduction="sum"):
     r"""
     call_for_per_sample_grads(module, batch_size=None, loss_reduction="sum")
@@ -101,5 +98,5 @@ def call_for_per_sample_grads(module, *, batch_size=None, loss_reduction="sum"):
             wrapper_batch_size = compute_batch_size(*args, **kwargs)
 
         params = {name: maybe_build_expanded_weight(value, wrapper_batch_size) for (name, value) in module.named_parameters()}
-        return functional_call(module, params, args, kwargs)
+        return torch.func.functional_call(module, params, args, kwargs)
     return wrapper

--- a/torch/nn/utils/stateless.py
+++ b/torch/nn/utils/stateless.py
@@ -1,5 +1,6 @@
 import contextlib
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Union, Set, Optional
+import warnings
 
 import torch
 from torch import Tensor
@@ -178,6 +179,12 @@ def functional_call(
     r"""Performs a functional call on the module by replacing the module parameters
     and buffers with the provided ones.
 
+    .. warning::
+
+        This API is deprecated as of PyTorch 2.0.0 and will be removed in a future
+        version of PyTorch. Please use :func:`torch.func.functional_call` instead,
+        which is a drop-in replacement for this API.
+
     .. note:: If the module has active parametrizations, passing a value in the
         :attr:`parameters_and_buffers` argument with the name set to the regular parameter
         name will completely disable the parametrization.
@@ -226,6 +233,23 @@ def functional_call(
     Returns:
         Any: the result of calling ``module``.
     """
+    warnings.warn(
+        "This API is deprecated as of PyTorch 2.0.0 and will be removed in a future "
+        "version of PyTorch. Please use torch.func.functional_call instead "
+        "which is a drop-in replacement for this API.",
+        DeprecationWarning)
+
+    return _functional_call(module, parameters_and_buffers, args, kwargs,
+                            tie_weights=tie_weights)
+
+def _functional_call(
+    module: 'torch.nn.Module',
+    parameters_and_buffers: Dict[str, Tensor],
+    args: Union[Any, Tuple],
+    kwargs: Dict[str, Any] = None,
+    *,
+    tie_weights: bool = True,
+):
     # TODO allow kwargs such as unsafe and others for parametrization
     if (
             torch.jit.is_tracing()

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -20,7 +20,6 @@ import torch.distributed.algorithms.model_averaging.hierarchical_model_averager 
 import torch.distributed.algorithms.model_averaging.utils as model_averaging_utils
 import torch.nn as nn
 import torch.nn.functional as F
-import torch.nn.utils._stateless as _stateless
 from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR
 from torch._utils_internal import TEST_MASTER_PORT as MASTER_PORT
 from torch.cuda.amp import GradScaler, autocast
@@ -9128,7 +9127,7 @@ class DistributedTest:
             prev_weight = module.module.l1.weight.clone()
             prev_buffer = module.module.buffer.clone()
 
-            res = _stateless.functional_call(module, parameters, x)
+            res = torch.func.functional_call(module, parameters, x)
             self.assertEqual(x, res)
             # check that the weight remain unmodified
             cur_weight = module.module.l1.weight


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This PR:
- Updates the docs to say it is deprecated
- Raises a DeprecationWarning (which is surpressed by PyTorch, so most
users won't actually see it)
- Changes most of the callsites inside PyTorch to use
torch.func.functional_call, minus the test_stateless testing.

The motivation behind this is that we can now align behind a single
functional_call API in PyTorch.

Test Plan:
- existing tests