### PR TITLE
[inductor] only check mutations attr for TritonKernel

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5017,10 +5017,11 @@ class CommonTemplate:
 
     @unittest.skipIf(HAS_CUDA, "test in_out_ptr for CppKernel")
     def test_in_out_buffer(self):
-        def fn(x):
-            return aten.as_strided(x + 1, (8, 8, 64), (8 * 64, 64, 1), 0) + 2
+        def fn(x, y):
+            z = torch.matmul(x, y.transpose(-1, -2)) / 8.
+            return z
 
-        inps = [torch.randn(64, 64)]
+        inps = [torch.randn(1, 2, 8, 4), torch.randn(1, 2, 8, 4)]
         fn_opt = torch._dynamo.optimize("inductor")(fn)
         code = run_and_get_cpp_code(fn_opt, inps)
         self.assertTrue("in_out_ptr" in code)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5018,7 +5018,7 @@ class CommonTemplate:
     @unittest.skipIf(HAS_CUDA, "test in_out_ptr for CppKernel")
     def test_in_out_buffer(self):
         def fn(x, y):
-            z = torch.matmul(x, y.transpose(-1, -2)) / 8.
+            z = torch.matmul(x, y.transpose(-1, -2)) / 8.0
             return z
 
         inps = [torch.randn(1, 2, 8, 4), torch.randn(1, 2, 8, 4)]

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -261,8 +261,8 @@ def clone_preserve_strides(x):
 @patch.object(config, "debug", True)
 def run_and_get_cpp_code(fn, args):
     torch._dynamo.reset()
-    from contextlib import redirect_stdout
     import io
+    from contextlib import redirect_stdout
 
     f = io.StringIO()
     with redirect_stdout(f):
@@ -5018,9 +5018,7 @@ class CommonTemplate:
     @unittest.skipIf(HAS_CUDA, "test in_out_ptr for CppKernel")
     def test_in_out_buffer(self):
         def fn(x):
-            return (
-                aten.as_strided(x + 1, (8, 8, 64), (8 * 64, 64, 1), 0) + 2,
-            )
+            return aten.as_strided(x + 1, (8, 8, 64), (8 * 64, 64, 1), 0) + 2
 
         inps = [torch.randn(64, 64)]
         fn_opt = torch._dynamo.optimize("inductor")(fn)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -258,6 +258,19 @@ def clone_preserve_strides(x):
     return out
 
 
+@patch.object(config, "debug", True)
+def run_and_get_cpp_code(fn, args):
+    torch._dynamo.reset()
+    from contextlib import redirect_stdout
+    import io
+
+    f = io.StringIO()
+    with redirect_stdout(f):
+        fn(*args)
+    s = f.getvalue()
+    return s
+
+
 @patch.object(torch._inductor.config.triton, "cudagraphs", False)
 def check_model(
     self: TestCase,
@@ -5001,6 +5014,19 @@ class CommonTemplate:
             fn,
             [torch.randn((4, 2)), torch.randn((4))],
         )
+
+    @unittest.skipIf(HAS_CUDA, "test in_out_ptr for CppKernel")
+    def test_in_out_buffer(self):
+        def fn(x):
+            return (
+                aten.as_strided(x + 1, (8, 8, 64), (8 * 64, 64, 1), 0) + 2,
+            )
+
+        inps = [torch.randn(64, 64)]
+        fn_opt = torch._dynamo.optimize("inductor")(fn)
+        code = run_and_get_cpp_code(fn_opt, inps)
+        self.assertTrue("in_out_ptr" in code)
+        self.assertEqual(fn_opt(*inps), fn(*inps))
 
     @patch.object(config, "profiler_mark_wrapper_call", True)
     def test_profiler_mark_wrapper_call(self):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -297,7 +297,10 @@ class SchedulerNode(BaseSchedulerNode):
         ):
             return super().allocate()
 
-        if config.inplace_buffers and getattr(V.kernel, "mutations", None) is not None:
+        if config.inplace_buffers and (
+            isinstance(V.kernel, torch._inductor.codegen.cpp.CppKernel)
+            or getattr(V.kernel, "mutations", None) is not None
+        ):            
             from .codegen.wrapper import buffer_reuse_key
 
             ordered_reads = sorted(self.read_writes.reads, key=lambda x: x.name)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -300,7 +300,7 @@ class SchedulerNode(BaseSchedulerNode):
         if config.inplace_buffers and (
             isinstance(V.kernel, torch._inductor.codegen.cpp.CppKernel)
             or getattr(V.kernel, "mutations", None) is not None
-        ):            
+        ):
             from .codegen.wrapper import buffer_reuse_key
 
             ordered_reads = sorted(self.read_writes.reads, key=lambda x: x.name)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -298,7 +298,7 @@ class SchedulerNode(BaseSchedulerNode):
             return super().allocate()
 
         if config.inplace_buffers and (
-            isinstance(V.kernel, torch._inductor.codegen.cpp.CppKernel)
+            not isinstance(V.kernel, torch._inductor.codegen.triton.TritonKernel)
             or getattr(V.kernel, "mutations", None) is not None
         ):
             from .codegen.wrapper import buffer_reuse_key


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92277

Fixes https://github.com/pytorch/pytorch/issues/93506.

In https://github.com/pytorch/pytorch/pull/91575, for in-place buffers reuse, a check has been added on the `mutations` attr of the kernel:
https://github.com/pytorch/pytorch/blob/5e0d3458eb58d21081f64d6a2347c5462453c2da/torch/_inductor/scheduler.py#L300

While `mutations` are not tracked in cpp kernels, `getattr(V.kernel, "mutations", None) is not None` will always be `False`.
This PR only checks the `mutations` attr for TritonKernel.

UT is added to guarantee that `in_out_ptr` is in the generated code.
#### Cpp code before this fix:
```python
kernel_cpp_0 = async_compile.cpp('''
#include "/tmp/torchinductor_chunyuan/77/c7773nj5pwikpmm2pwa62rcudlf7p3if7eyqb5k4sjsvewwje4le.h"
extern "C" void kernel(const float* __restrict__ in_ptr0,
                       float* __restrict__ out_ptr0)
{
    #pragma omp parallel num_threads(64)
    {
        {
            #pragma omp for 
            for(long i0=0; i0<8; i0+=1)
            {
                auto tmp0 = at::vec::Vectorized<float>::loadu(in_ptr0 + 16*i0);
                auto tmp1 = at::vec::Vectorized<float>(static_cast<float>(8.0));
                auto tmp2 = tmp0 / tmp1;
                tmp2.store(out_ptr0 + 16*i0);
            }
            #pragma omp for simd simdlen(8) 
            for(long i0=128; i0<128; i0+=1)
            {
                auto tmp0 = in_ptr0[i0];
                auto tmp1 = static_cast<float>(8.0);
                auto tmp2 = tmp0 / tmp1;
                out_ptr0[i0] = tmp2;
            }
        }
    }
}
''')


async_compile.wait(globals())
del async_compile

def call(args):
    arg0_1, arg1_1 = args
    args.clear()
    buf0 = empty_strided((2, 8, 8), (64, 8, 1), device='cpu', dtype=torch.float32)
    extern_kernels.bmm(as_strided(arg0_1, (2, 8, 4), (32, 4, 1)), as_strided(arg1_1, (2, 4, 8), (32, 1, 4)), out=buf0)
    del arg0_1
    del arg1_1
    buf1 = empty_strided((1, 2, 8, 8), (128, 64, 8, 1), device='cpu', dtype=torch.float32)
    kernel_cpp_0(c_void_p(buf0.data_ptr()), c_void_p(buf1.data_ptr()))
    return (buf1, )
```
#### Cpp code after this fix:
```python
kernel_cpp_0 = async_compile.cpp('''
#include "/tmp/torchinductor_chunyuan/77/c7773nj5pwikpmm2pwa62rcudlf7p3if7eyqb5k4sjsvewwje4le.h"
extern "C" void kernel(float* __restrict__ in_out_ptr0)
{
    #pragma omp parallel num_threads(64)
    {
        {
            #pragma omp for 
            for(long i0=0; i0<8; i0+=1)
            {
                auto tmp0 = at::vec::Vectorized<float>::loadu(in_out_ptr0 + 16*i0);
                auto tmp1 = at::vec::Vectorized<float>(static_cast<float>(8.0));
                auto tmp2 = tmp0 / tmp1;
                tmp2.store(in_out_ptr0 + 16*i0);
            }
            #pragma omp for simd simdlen(8) 
            for(long i0=128; i0<128; i0+=1)
            {
                auto tmp0 = in_out_ptr0[i0];
                auto tmp1 = static_cast<float>(8.0);
                auto tmp2 = tmp0 / tmp1;
                in_out_ptr0[i0] = tmp2;
            }
        }
    }
}
''')


async_compile.wait(globals())
del async_compile

def call(args):
    arg0_1, arg1_1 = args
    args.clear()
    buf0 = empty_strided((2, 8, 8), (64, 8, 1), device='cpu', dtype=torch.float32)
    extern_kernels.bmm(as_strided(arg0_1, (2, 8, 4), (32, 4, 1)), as_strided(arg1_1, (2, 4, 8), (32, 1, 4)), out=buf0)
    del arg0_1
    del arg1_1
    buf1 = as_strided(buf0, (1, 2, 8, 8), (128, 64, 8, 1)); del buf0  # reuse
    kernel_cpp_0(c_void_p(buf1.data_ptr()))
    return (buf1, )
```
cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire