### PR TITLE
fix biasadd OMP perf issue for the packed MKL SGEMM

### DIFF
--- a/aten/src/ATen/native/mkldnn/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/Linear.cpp
@@ -1,6 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/core/Tensor.h>
 #include <ATen/Config.h>
+#include <ATen/Parallel.h>
 #include <ATen/core/Tensor.h>
 #include <torch/library.h>
 
@@ -389,18 +389,11 @@ Tensor mkl_linear(
     if (bias.defined()) {
       auto bias_ = bias.is_contiguous() ? bias : bias.contiguous();
       auto bias_ptr = bias_.data_ptr<float>();
-#ifdef _OPENMP
-#if (_OPENMP >= 201307)
-#pragma omp parallel for simd schedule( \
-    static) if (omp_get_max_threads() > 1 && !omp_in_parallel())
-#else
-#pragma omp parallel for schedule( \
-    static) if (omp_get_max_threads() > 1 && !omp_in_parallel())
-#endif
-#endif
-      for (int64_t i = 0; i < M; ++i) {
-        memcpy(out_ptr + i * N, bias_ptr, sizeof(float) * N);
-      }
+      at::parallel_for(0, M, 1, [&](int64_t begin, int64_t end) {
+        for (const auto d : c10::irange(begin, end)) {
+          memcpy(out_ptr + d * N, bias_ptr, sizeof(float) * N);
+        }
+      });
     }
     cblas_sgemm_compute(
         CblasRowMajor,


### PR DESCRIPTION
Currently the biasadd of MKL SGEMM was executed using OpenMP macro, this will lead to a performance issue if the SGEMM size is very small (e.g., M = 1, K = 80, N = 256) when we are using many threads.
The reason is that in such case `num_task < num_thread`, and the task cost is too small (e.g., ~1-2 cycles for memcpy), the thread synchronization cost would be very large. Thus it is better to use `at::parallel_for` to run on the main thread directly.
Packed MKL SGEMM (1x80x256) | OpenMP biasadd | `at::parallel_for` biasadd
-- | -- | --
Latency | 2000 us | 21 us


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10