### PR TITLE
[fx] Throw error when symbolically tracing control flow ops

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -19,6 +19,7 @@ import types
 import warnings
 import unittest
 from math import sqrt
+from functorch.experimental import control_flow
 from torch.multiprocessing import Process
 from torch.testing import FileCheck
 from torch.testing._internal.common_methods_invocations import op_db
@@ -311,6 +312,18 @@ class TestFX(JitTestCase):
         inp = torch.randn(3)
         self.assertEqual(mod(inp), rmatmul_f(inp))
 
+    def test_control_flow_tracing(self):
+        def true(x, y):
+            return x + y
+
+        def false(x, y):
+            return x - y
+
+        def f(x, y):
+            x = control_flow.cond(x[0] == 0, true, false, [x, y])
+
+        with self.assertRaisesRegex(RuntimeError, "Unable to symbolically trace PyOperators"):
+            _ = symbolic_trace(f)
 
     def test_disallow_override(self):
         # Custom delegate to disallow in-place tensor operations

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -334,6 +334,9 @@ class Proxy:
         if torch.overrides.is_tensor_method_or_property(orig_method):
             return tracer.create_proxy('call_method', orig_method.__name__, args, kwargs)
         else:
+            if orig_method.__name__ in {"cond", "map"}:
+                # TODO: symbolically trace control flow ops
+                raise RuntimeError("Unable to symbolically trace control flow ops")
             return tracer.create_proxy('call_function', orig_method, args, kwargs,
                                        name=tracer.graph._target_to_str(orig_method.__name__))
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -334,9 +334,9 @@ class Proxy:
         if torch.overrides.is_tensor_method_or_property(orig_method):
             return tracer.create_proxy('call_method', orig_method.__name__, args, kwargs)
         else:
-            if orig_method.__name__ in {"cond", "map"}:
-                # TODO: symbolically trace control flow ops
-                raise RuntimeError("Unable to symbolically trace control flow ops")
+            if isinstance(orig_method, torch._ops.PyOperator):
+                # TODO: Define how to symbolically trace PyOperators
+                raise RuntimeError("Unable to symbolically trace PyOperators")
             return tracer.create_proxy('call_function', orig_method, args, kwargs,
                                        name=tracer.graph._target_to_str(orig_method.__name__))
 


### PR DESCRIPTION
Throws a better error when symbolically tracing control flow ops. Right now it throws an error when creating the function arguments.