### PR TITLE
Fix NVML visible device parsing

### DIFF
--- a/test/test_cuda_nvml_based_avail.py
+++ b/test/test_cuda_nvml_based_avail.py
@@ -63,6 +63,67 @@ class TestExtendedCUDAIsAvail(TestCase):
                 assert in_bad_fork
 
 
+class TestVisibleDeviceParses(TestCase):
+
+    def test_env_var_parsing(self):
+        def _parse_visible_devices(val):
+            from torch.cuda import _parse_visible_devices as _pvd
+            with patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": val}, clear=True):
+                return _pvd()
+
+        # rest of the string is ignored
+        self.assertEqual(_parse_visible_devices("1gpu2,2ampere"), [1, 2])
+        # Negatives abort parsing
+        self.assertEqual(_parse_visible_devices("0, 1, 2, -1, 3"), [0, 1, 2])
+        # Double mention of ordinal returns empty set
+        self.assertEqual(_parse_visible_devices("0, 1, 2, 1"), [])
+        # Unary pluses and minuses
+        self.assertEqual(_parse_visible_devices("2, +3, -0, 5"), [2, 3, 0, 5])
+        # Random string is used as empty set
+        self.assertEqual(_parse_visible_devices("one,two,3,4"), [])
+        # Random string is used as separator
+        self.assertEqual(_parse_visible_devices("4,3,two,one"), [4, 3])
+        # GPU ids are parsed
+        self.assertEqual(_parse_visible_devices("GPU-9e8d35e3"), ["GPU-9e8d35e3"])
+        # Ordinals are not included in GPUid set
+        self.assertEqual(_parse_visible_devices("GPU-123, 2"), ["GPU-123"])
+        # MIG ids are parsed
+        self.assertEqual(_parse_visible_devices("MIG-89c850dc"), ["MIG-89c850dc"])
+
+    def test_partial_uuid_resolver(self):
+        from torch.cuda import _transform_uuid_to_ordinals
+        uuids = ['GPU-9942190a-aa31-4ff1-4aa9-c388d80f85f1',
+                 'GPU-9e8d35e3-a134-0fdd-0e01-23811fdbd293',
+                 'GPU-e429a63e-c61c-4795-b757-5132caeb8e70',
+                 'GPU-eee1dfbc-0a0f-6ad8-5ff6-dc942a8b9d98',
+                 'GPU-bbcd6503-5150-4e92-c266-97cc4390d04e',
+                 'GPU-472ea263-58d7-410d-cc82-f7fdece5bd28',
+                 'GPU-e56257c4-947f-6a5b-7ec9-0f45567ccf4e',
+                 'GPU-1c20e77d-1c1a-d9ed-fe37-18b8466a78ad']
+        self.assertEqual(_transform_uuid_to_ordinals(["GPU-9e8d35e3"], uuids), [1])
+        self.assertEqual(_transform_uuid_to_ordinals(["GPU-e4", "GPU-9e8d35e3"], uuids), [2, 1])
+        self.assertEqual(_transform_uuid_to_ordinals("GPU-9e8d35e3,GPU-1,GPU-47".split(","), uuids), [1, 7, 5])
+        # First invalid UUID aborts parsing
+        self.assertEqual(_transform_uuid_to_ordinals(["GPU-123", "GPU-9e8d35e3"], uuids), [])
+        self.assertEqual(_transform_uuid_to_ordinals(["GPU-9e8d35e3", "GPU-123", "GPU-47"], uuids), [1])
+        # First ambigous UUID aborts parsing
+        self.assertEqual(_transform_uuid_to_ordinals(["GPU-9e8d35e3", "GPU-e", "GPU-47"], uuids), [1])
+        # Duplicate UUIDs result in empty set
+        self.assertEqual(_transform_uuid_to_ordinals(["GPU-9e8d35e3", "GPU-47", "GPU-9e8"], uuids), [])
+
+    def test_ordinal_parse_visible_devices(self):
+        def _device_count_nvml(val):
+            from torch.cuda import _device_count_nvml as _dc
+            with patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": val}, clear=True):
+                return _dc()
+
+        with patch.object(torch.cuda, '_raw_device_count_nvml', return_value=2):
+            self.assertEqual(_device_count_nvml("1, 0"), 2)
+            # Ordinal out of bounds aborts parsing
+            self.assertEqual(_device_count_nvml("1, 5, 0"), 1)
+
+
+
 instantiate_parametrized_tests(TestExtendedCUDAIsAvail)
 
 if __name__ == '__main__':

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -16,7 +16,7 @@ import traceback
 import warnings
 import threading
 from functools import lru_cache
-from typing import Any, List, Optional, Set, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union, cast
 from ._utils import _get_device_index, _dummy_type
 from .._utils import classproperty
 from .graphs import CUDAGraph, graph_pool_handle, graph, \
@@ -487,46 +487,131 @@ def set_stream(stream: Stream):
         return
     torch._C._cuda_setStream(stream_id=stream.stream_id, device_index=stream.device_index, device_type=stream.device_type)
 
-def _parse_visible_devices() -> Set[int]:
+
+def _parse_visible_devices() -> Union[List[int], List[str]]:
     """Parse CUDA_VISIBLE_DEVICES environment variable."""
     var = os.getenv("CUDA_VISIBLE_DEVICES")
     if var is None:
-        return set(range(64))
+        return list(range(64))
 
     def _strtoul(s: str) -> int:
         """Return -1 or positive integer sequence string starts with,"""
         if not s:
             return -1
         for idx, c in enumerate(s):
-            if not c.isdigit():
+            if not (c.isdigit() or (idx == 0 and c in '+-')):
                 break
             if idx + 1 == len(s):
                 idx += 1
         return int(s[:idx]) if idx > 0 else -1
 
+    def parse_list_with_prefix(prefix):
+        rcs: List[str] = []
+        for elem in var.split(","):
+            # Repeated id results in empty set
+            if elem in rcs:
+                return cast(List[str], [])
+            # Anything other but prefix is ignored
+            if not elem.startswith(prefix):
+                break
+            rcs.append(elem)
+        return rcs
+
+    if var.startswith("GPU-"):
+        return parse_list_with_prefix("GPU-")
+    if var.startswith("MIG-"):
+        return parse_list_with_prefix("MIG-")
     # CUDA_VISIBLE_DEVICES uses something like strtoul
     # which makes `1gpu2,2ampere` is equivalent to `1,2`
-    rc: Set[int] = set()
+    rc: List[int] = []
     for elem in var.split(","):
-        rc.add(_strtoul(elem.strip()))
+        x = _strtoul(elem.strip())
+        # Repeated ordinal results in empty set
+        if x in rc:
+            return cast(List[int], [])
+        # Negative value aborts the sequence
+        if x < 0:
+            break
+        rc.append(x)
     return rc
+
 
 def _raw_device_count_nvml() -> int:
     """Return number of devices as reported by NVML
     or negative value if NVML discovery/initialization failed."""
-    from ctypes import CDLL, c_int
+    from ctypes import CDLL, c_int, byref
     nvml_h = CDLL("libnvidia-ml.so.1")
     rc = nvml_h.nvmlInit()
     if rc != 0:
         warnings.warn("Can't initialize NVML")
         return -1
-    dev_arr = (c_int * 1)(-1)
-    rc = nvml_h.nvmlDeviceGetCount_v2(dev_arr)
+    dev_count = c_int(-1)
+    rc = nvml_h.nvmlDeviceGetCount_v2(byref(dev_count))
     if rc != 0:
         warnings.warn("Can't get nvml device count")
         return -1
     del nvml_h
-    return dev_arr[0]
+    return dev_count.value
+
+
+def _raw_device_uuid_nvml() -> Optional[List[str]]:
+    """Return list of device UUID as reported by NVML
+    or None if NVM discovery/initialization failed."""
+    from ctypes import CDLL, c_int, c_void_p, create_string_buffer, byref
+    nvml_h = CDLL("libnvidia-ml.so.1")
+    rc = nvml_h.nvmlInit()
+    if rc != 0:
+        warnings.warn("Can't initialize NVML")
+        return None
+    dev_count = c_int(-1)
+    rc = nvml_h.nvmlDeviceGetCount_v2(byref(dev_count))
+    if rc != 0:
+        warnings.warn("Can't get nvml device count")
+        return None
+    uuids: List[str] = []
+    for idx in range(dev_count.value):
+        dev_id = c_void_p()
+        rc = nvml_h.nvmlDeviceGetHandleByIndex_v2(idx, byref(dev_id))
+        if rc != 0:
+            warnings.warn("Can't get device handle")
+            return None
+        buf_len = 96
+        buf = create_string_buffer(buf_len)
+        rc = nvml_h.nvmlDeviceGetUUID(dev_id, buf, buf_len)
+        if rc != 0:
+            warnings.warn("Can't get device UUID")
+            return None
+        uuids.append(buf.raw.decode("ascii").strip('\0'))
+    del nvml_h
+    return uuids
+
+
+def _transform_uuid_to_ordinals(candidates: List[str], uuids: List[str]) -> List[int]:
+    """Given the set of partial uuids and list of known uuids builds
+    a set of ordinals excluding ambiguous partials IDs"""
+    def uuid_to_orinal(candidate: str, uuids: List[str]) -> int:
+        best_match = -1
+        for idx, uuid in enumerate(uuids):
+            if not uuid.startswith(candidate):
+                continue
+            # Ambigous candidate
+            if best_match != -1:
+                return -1
+            best_match = idx
+        return best_match
+
+    rc: List[int] = []
+    for candidate in candidates:
+        idx = uuid_to_orinal(candidate, uuids)
+        # First invalid ordinal stops parsing
+        if idx < 0:
+            break
+        # Duplicates result in empty set
+        if idx in rc:
+            return cast(List[int], [])
+        rc.append(idx)
+    return rc
+
 
 def _device_count_nvml() -> int:
     """Return number of devices as reported by NVML taking CUDA_VISIBLE_DEVICES into account.
@@ -535,14 +620,27 @@ def _device_count_nvml() -> int:
     if not visible_devices:
         return 0
     try:
-        raw_cnt = _raw_device_count_nvml()
+        if type(visible_devices[0]) is str:
+            # Skip MIG parsing
+            if any(d.startswith("MIG-") for d in visible_devices):
+                return -1
+            uuids = _raw_device_uuid_nvml()
+            if uuids is None:
+                return -1
+            visible_devices = _transform_uuid_to_ordinals(visible_devices, uuids)
+        else:
+            raw_cnt = _raw_device_count_nvml()
+            if raw_cnt <= 0:
+                return raw_cnt
+            # Trim the list up to a maximum available device
+            for idx, val in enumerate(visible_devices):
+                if val >= raw_cnt:
+                    return idx
     except OSError:
         return -1
     except AttributeError:
         return -1
-    if raw_cnt <= 0:
-        return raw_cnt
-    return len(set(range(raw_cnt)).intersection(visible_devices))
+    return len(visible_devices)
 
 @lru_cache(maxsize=1)
 def device_count() -> int:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -505,7 +505,7 @@ def _parse_visible_devices() -> Union[List[int], List[str]]:
                 idx += 1
         return int(s[:idx]) if idx > 0 else -1
 
-    def parse_list_with_prefix(lst:str, prefix: str) -> List[str]:
+    def parse_list_with_prefix(lst: str, prefix: str) -> List[str]:
         rcs: List[str] = []
         for elem in lst.split(","):
             # Repeated id results in empty set


### PR DESCRIPTION
`CUDA_VISIBLE_DEVICES` can contain either ordinals or UUIDs Extend the logic to be able to parse it by UUID

Added unit test to validate that parser and matcher behavior matches that of 525.60.13  driver

Skip MIG- device parsing

Fixes https://github.com/pytorch/pytorch/issues/90543
