### PR TITLE
Update the doc as per from-source install update [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ git submodule update --init --recursive
 
 If you want to have no-op incremental rebuilds (which are fast), see [Make no-op build fast](#make-no-op-build-fast) below.
 
-3. Follow the instructions for [installing PyTorch from source](https://github.com/pytorch/pytorch#from-source), but instead of installing PyTorch via `python setup.py install`, use `python setup.py develop`.
+3. Follow the instructions for [installing PyTorch from source](https://github.com/pytorch/pytorch#from-source).
 
 This mode will symlink the Python files from the current local source
 tree into the Python install.  This way when you modify a Python file, you


### PR DESCRIPTION
The `from source` installation instructions were updated in the https://github.com/pytorch/pytorch/pull/88507
So the current step for contributors  to use `develop` instead of `install` can be confusing, and it is no longer needed.


