### PR TITLE
Support FakeTensors as tensors that ProxyTracer can handle.

### DIFF
--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -231,7 +231,7 @@ def fetch_sym_proxy(tracer):
 def fetch_tensor_proxy(tracer):
     return lambda t: get_proxy_slot(t, tracer, t)
 
-HANDLED_TYPES = (torch.Tensor, torch.nn.Parameter)
+HANDLED_TYPES = (torch.Tensor, torch.nn.Parameter, FakeTensor)
 
 def proxy_call(proxy_mode, func, args, kwargs):
     def can_handle_tensor(x):


### PR DESCRIPTION
Before this PR,  the following snipped would print an empty graph. After the PR it produces the correct graph with torch.ops.aten.mm.default and torch.ops.aten.sigmoid.default ops.

```
from torch import nn
from torch.fx.experimental.proxy_tensor import make_fx
from torch._subclasses.fake_tensor import FakeTensorMode


class MiniModule(nn.Module):
    def __init__(self):
        super().__init__()
        self.p = torch.randn(4, 2)

    def forward(self, x):
        return torch.sigmoid(torch.matmul(x, self.p))


def min_forward(m, x):
    return m(x)


if __name__ == '__main__':
    with FakeTensorMode():
        m = MiniModule()
        fake_x = torch.ones(10, 4)

    gm = make_fx(min_forward)(m, fake_x)
    print(gm)
```