### PR TITLE
Add perf check for inductor smoke test

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -308,7 +308,7 @@ test_inductor_benchmark_perf() {
       --output "$TEST_REPORTS_DIR"/inductor_training_$1.csv
     # the reference speedup value is hardcoded in check_hf_bert_perf_csv.py
     # this value needs to be actively maintained to make this check useful
-    python check_hf_bert_perf_csv.py -f inductor_training_$1.csv
+    python check_hf_bert_perf_csv.py -f "$TEST_REPORTS_DIR"/inductor_training_$1.csv
   else
     python benchmarks/dynamo/$1.py --ci --training --performance --disable-cudagraphs\
       --device cuda --inductor --amp $PARTITION_FLAGS  --output "$TEST_REPORTS_DIR"/inductor_training_$1.csv

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -306,8 +306,8 @@ test_inductor_benchmark_perf() {
     python benchmarks/dynamo/torchbench.py --performance --backend inductor --float16 --training \
       --batch-size-file "$(realpath benchmarks/dynamo/torchbench_models_list.txt)" --only hf_Bert \
       --output "$TEST_REPORTS_DIR"/inductor_training_$1.csv
-    # this reference value is hardcoded in check_hf_bert_perf_csv.py
-    # this file needs to be actively maintained to make this check useful
+    # the reference speedup value is hardcoded in check_hf_bert_perf_csv.py
+    # this value needs to be actively maintained to make this check useful
     python check_hf_bert_perf_csv.py -f inductor_training_$1.csv
   else
     python benchmarks/dynamo/$1.py --ci --training --performance --disable-cudagraphs\

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -306,6 +306,9 @@ test_inductor_benchmark_perf() {
     python benchmarks/dynamo/torchbench.py --performance --backend inductor --float16 --training \
       --batch-size-file "$(realpath benchmarks/dynamo/torchbench_models_list.txt)" --only hf_Bert \
       --output "$TEST_REPORTS_DIR"/inductor_training_$1.csv
+    # this reference value is hardcoded in check_hf_bert_perf_csv.py
+    # this file needs to be actively maintained to make this check useful
+    python check_hf_bert_perf_csv.py -f inductor_training_$1.csv
   else
     python benchmarks/dynamo/$1.py --ci --training --performance --disable-cudagraphs\
       --device cuda --inductor --amp $PARTITION_FLAGS  --output "$TEST_REPORTS_DIR"/inductor_training_$1.csv

--- a/benchmarks/dynamo/check_hf_bert_perf_csv.py
+++ b/benchmarks/dynamo/check_hf_bert_perf_csv.py
@@ -1,0 +1,40 @@
+import argparse
+import sys
+import textwrap
+
+import pandas as pd
+
+
+def check_hf_bert_perf_csv(filename):
+    """
+    Basic performance checking.
+    """
+
+    df = pd.read_csv(filename)
+
+    failed = []
+    for _, row in df.iterrows():
+        model_name = row["name"]
+        speedup = row["speedup"]
+        if speedup < 1.185:
+            failed.append(model_name)
+
+        print(f"{model_name:34} {speedup}")
+
+    if failed:
+        print(
+            textwrap.dedent(
+                f"""
+                Error {len(failed)} models performance regressed
+                    {' '.join(failed)}
+                """
+            )
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file", "-f", type=str, help="csv file name")
+    args = parser.parse_args()
+    check_hf_bert_perf_csv(args.file)


### PR DESCRIPTION
Background: performance smoke test job has been setup for inductor https://github.com/pytorch/pytorch/actions/workflows/inductor-perf-smoke-test.yml 
I have used this job to identify that https://github.com/pytorch/pytorch/pull/91254 regressed performance from 1.194x to 1.156x. However, this was by manual checking. 

To automatically flag similar regressions, we will add a reference value (which needs to be actively maintained) so that any speedups falling below the reference would be treated regression. 
 
In the back, two A100 instances from GCP would be running the perf check jobs for every push to upstream. So far these two instances give up to 1.204x and 1.197x, so we interpret any output below 1.185x to be suspicious.  

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire