### PR TITLE
[dynamo] support setting compile_threads in the benchmark

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1482,6 +1482,11 @@ def parse_args(args=None):
         help="number of threads to use for eager and inductor",
     )
     parser.add_argument(
+        "--compile-threads",
+        type=int,
+        help="number of threads to use for the compilation of inductor",
+    )
+    parser.add_argument(
         "--nopython", action="store_true", help="Turn graph breaks into errors"
     )
     parser.add_argument(
@@ -1942,6 +1947,9 @@ def run(runner, args, original_dir=None):
 
     if args.threads:
         torch.set_num_threads(args.threads)
+
+    if args.compile_threads:
+        torch._inductor.config.compile_threads = args.compile_threads
 
     if args.verbose:
         torch._dynamo.config.log_level = logging.DEBUG


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92371

When measuring the single thread performance on CPU, the compilation is also done with single thread, which could be slow for some models and raise TIMEOUT exception. This PR provides the flexibility to change the `compile_threads` in case we only want to measure the inference performance but don't really care about the compilation latency measument.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire