### PR TITLE
Reclassify some dynamic aot_eager failures as static failures

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -71,13 +71,18 @@ CI_SKIP_AOT_EAGER_TRAINING = [
     *CI_SKIP_AOT_EAGER_INFERENCE,
     # TorchBench
     "Background_Matting",  # fp64_OOM
+    "hf_T5_base",  # fp64_OOM
+    "mobilenet_v2_quantized_qat",  # fp64_OOM
+    "resnet50_quantized_qat",  # fp64_OOM
     "moco",
     "pytorch_struct",
+    "tacotron2",  # AssertionError: Deduped args out of bounds
     "vision_maskrcnn",
     # Huggingface
     "AlbertForMaskedLM",  # OOM
     "AlbertForQuestionAnswering",  # OOM
     "BigBird",
+    "DebertaV2ForQuestionAnswering",  # OOM
     "M2M100ForConditionalGeneration",  # OOM
     "PegasusForConditionalGeneration",  # OOM
     "XGLMForCausalLM",  # OOM
@@ -86,20 +91,15 @@ CI_SKIP_AOT_EAGER_TRAINING = [
     # TIMM
     "cait_m36_384",  # fp64_OOM
     "convit_base",  # fp64_OOM
+    "levit_128",  # Accuracy (patch_embed.0.c.weight.grad)
     "mobilevit_s",  # Accuracy
+    "sebotnet33ts_256",  # Accuracy (stem.conv1.conv.weight.grad)
     "xcit_large_24_p8_224",  # fp64_OOM
 ]
 
 CI_SKIP_AOT_EAGER_DYNAMIC_TRAINING = [
     *CI_SKIP_AOT_EAGER_TRAINING,
-    "hf_T5_base",  # fp64_OOM
-    "mobilenet_v2_quantized_qat",  # setStorage
-    "resnet50_quantized_qat",  # setStorage
-    "tacotron2",  # aten._thnn_fused_lstm_cell.default
-    "DebertaV2ForQuestionAnswering",  # OOMs (but on CI only; graph breaks?)
     "crossvit_9_240",  # torch._C._nn.upsample_bicubic2d
-    "levit_128",  # Cannot call sizes() on tensor with symbolic sizes/strides
-    "sebotnet33ts_256",  # Accuracy failed for key name stem.conv1.conv.weight.grad
     "twins_pcpvt_base",  # timeout
 ]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92376

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire