### PR TITLE
Update autocast policy list on CPU

### DIFF
--- a/aten/src/ATen/autocast_mode.cpp
+++ b/aten/src/ATen/autocast_mode.cpp
@@ -507,11 +507,11 @@ TORCH_LIBRARY_IMPL(aten, AutocastCPU, m) {
   KERNEL_CPU(matmul, lower_precision_fp)
   KERNEL_CPU(conv_tbc, lower_precision_fp)
   KERNEL_CPU(mkldnn_rnn_layer, lower_precision_fp)
+  KERNEL_CPU(conv_transpose1d, lower_precision_fp)
+  KERNEL_CPU2(conv_transpose2d, input, lower_precision_fp)
+  KERNEL_CPU2(conv_transpose3d, input, lower_precision_fp)
 
   // fp32 cast policy
-  KERNEL_CPU(conv_transpose1d, fp32)
-  KERNEL_CPU2(conv_transpose2d, input, fp32)
-  KERNEL_CPU2(conv_transpose3d, input, fp32)
   KERNEL_CPU(avg_pool3d, fp32)
   KERNEL_CPU(binary_cross_entropy, fp32)
   KERNEL_CPU(grid_sampler, fp32)

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -314,11 +314,11 @@ class AutocastCPUTestLists:
                           torch.randn((5, 3, 5), device=dev, dtype=torch.float32),
                           torch.randn(5, device=dev, dtype=torch.float32),
                           0)),
+            ("conv_transpose1d", conv_args_fp32[0]),
+            ("conv_transpose2d", conv_args_fp32[1]),
+            ("conv_transpose3d", conv_args_fp32[2]),
         ]
         self.torch_fp32 = [
-            ("conv_transpose1d", conv_args_bf16[0]),
-            ("conv_transpose2d", conv_args_bf16[1]),
-            ("conv_transpose3d", conv_args_bf16[2]),
             ("poisson_nll_loss", mat0_bf16 + mat1_bf16 + (True, False, 1.e-8, torch.nn._reduction.get_enum('mean'))),
             ("cosine_embedding_loss", (torch.tensor([[1, 2, 3]], device=dev, dtype=torch.bfloat16),
                                        torch.tensor([[1, 3, 4]], device=dev, dtype=torch.bfloat16),


### PR DESCRIPTION
### Motivation
Move conv_transpose1d, conv_transpose2d, and conv_transpose3d from fp32 cast policy to lower precision cast policy on AutocastCPU since conv_transposeNd supports BFloat16 : 
  * Before: Within the scope of torch.cpu.amp.autocast(dtype=torch.bfloat16) , conv_transpose1d, conv_transpose2d, and conv_transpose3d will be forced to run with fp32 data type.
  * After:  Within the scope of torch.cpu.amp.autocast(dtype=torch.bfloat16) , conv_transpose1d, conv_transpose2d, and conv_transpose3d will be forced to run with bf16 data type.

Using lower precisiondata type can achieve better performance but there will be a certain precision loss. Moving  conv_transpose to lower precision cast policy like conv might affect the accuracy for models which include such Ops running with BFloat16 via amp. 

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5