### PR TITLE
Test ROCm wheel builder libtinfo6 fix

### DIFF
--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Checkout pytorch/builder to builder dir
         uses: malfet/checkout@silent-checkout
         with:
-          ref: libtinfo6_test
+          ref: libtinfo_update_jataylo
           submodules: recursive
           repository: jataylo/builder
           path: builder

--- a/.github/workflows/_binary-build-linux.yml
+++ b/.github/workflows/_binary-build-linux.yml
@@ -158,9 +158,9 @@ jobs:
       - name: Checkout pytorch/builder to builder dir
         uses: malfet/checkout@silent-checkout
         with:
-          ref: main
+          ref: libtinfo6_test
           submodules: recursive
-          repository: pytorch/builder
+          repository: jataylo/builder
           path: builder
           quiet-checkout: true
       - name: Clean pytorch/builder checkout


### PR DESCRIPTION
Testing an update to ROCm wheel building for libtorch
https://github.com/pytorch/builder/compare/main...jataylo:builder:libtinfo_update_jataylo

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport