### PR TITLE
[PT-D][checkpoint] Resolve no such file or directory issue when checkpointing on multi hosts

### DIFF
--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -349,7 +349,6 @@ class FileSystemWriter(StorageWriter):
         pass
 
     def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
-        # There's no storage input in the local plan
         os.makedirs(self.path, exist_ok=True)
         return plan
 

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -350,6 +350,7 @@ class FileSystemWriter(StorageWriter):
 
     def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
         # There's no storage input in the local plan
+        os.makedirs(self.path, exist_ok=True)
         return plan
 
     def prepare_global_plan(

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -349,14 +349,12 @@ class FileSystemWriter(StorageWriter):
         pass
 
     def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
-        os.makedirs(self.path, exist_ok=True)
+        self.path.mkdir(parents=True, exist_ok=True)
         return plan
 
     def prepare_global_plan(
         self, global_plan: List[SavePlan]
     ) -> List[SavePlan]:
-        self.path.mkdir(parents=True, exist_ok=True)
-
         new_plans = [
             dataclasses.replace(plan, storage_data=_StoragePrefix(f"__{i}_"))
             for i, plan in enumerate(global_plan)


### PR DESCRIPTION
Previously, we only create the directory in rank 0. Therefore, if running on multihosts with multiple GPUs, we would run into issues of "No such file or directory". 

This is the fix for it. 