### PR TITLE
cond diff

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -7,6 +7,7 @@ import torch
 
 import torch._dynamo.test_case
 import torch._dynamo.testing
+from functorch.experimental.control_flow import cond
 from torch.fx.experimental.proxy_tensor import make_fx
 
 
@@ -1419,8 +1420,6 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     def test_export_with_module_layer(self):
-        from functorch.experimental.control_flow import cond
-
         class Module(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1455,9 +1454,8 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         dynamo_result_2 = out_graph(pred, x)
         self.assertTrue(torch._dynamo.utils.same(real_result_2, dynamo_result_2))
 
+    @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     def test_export_with_closure_diff(self):
-        from functorch.experimental.control_flow import cond
-
         class Module(torch.nn.Module):
             def forward(self, pred, x):
                 return self.indirection(pred, x)

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -11,8 +11,6 @@ import torch.fx
 import torch.nn
 import torch.onnx.operators
 from torch._dynamo.side_effects import AttributeMutationNew, SideEffects
-from torch._dynamo.utils import get_fake_value
-from torch._dynamo.variables import DynamicShapeVariable
 from torch._dynamo.variables.misc import NewCellVariable
 from torch._guards import GuardsCheckpointState
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92565

Fixes #92561

When different branches of a `cond` reference different functions in outer scope, a spurious diff of side effects may be created because (1) we create new cells for such closure variables (2) we prune these cells per branch based on what's accessed and what's not.

Differential Revision: [D42582702](https://our.internmc.facebook.com/intern/diff/D42582702/)

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire