### PR TITLE
[CI] move parallelnative to periodic (experimental)

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -14,6 +14,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  parallelnative-linux-focal-py3_7-gcc7-build:
+    name: parallelnative-linux-focal-py3.7-gcc7
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: parallelnative-linux-focal-py3.7-gcc7
+      docker-image-name: pytorch-linux-focal-py3.7-gcc7
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
+          { config: "default", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
+        ]}
+
+  parallelnative-linux-focal-py3_7-gcc7-test:
+    name: parallelnative-linux-focal-py3.7-gcc7
+    uses: ./.github/workflows/_linux-test.yml
+    needs: parallelnative-linux-focal-py3_7-gcc7-build
+    with:
+      build-environment: parallelnative-linux-focal-py3.7-gcc7
+      docker-image: ${{ needs.parallelnative-linux-focal-py3_7-gcc7-build.outputs.docker-image }}
+      test-matrix: ${{ needs.parallelnative-linux-focal-py3_7-gcc7-build.outputs.test-matrix }}
+
   linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build:
     name: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck
     uses: ./.github/workflows/_linux-build.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -18,27 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  parallelnative-linux-focal-py3_7-gcc7-build:
-    name: parallelnative-linux-focal-py3.7-gcc7
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: parallelnative-linux-focal-py3.7-gcc7
-      docker-image-name: pytorch-linux-focal-py3.7-gcc7
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
-          { config: "default", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
-        ]}
-
-  parallelnative-linux-focal-py3_7-gcc7-test:
-    name: parallelnative-linux-focal-py3.7-gcc7
-    uses: ./.github/workflows/_linux-test.yml
-    needs: parallelnative-linux-focal-py3_7-gcc7-build
-    with:
-      build-environment: parallelnative-linux-focal-py3.7-gcc7
-      docker-image: ${{ needs.parallelnative-linux-focal-py3_7-gcc7-build.outputs.docker-image }}
-      test-matrix: ${{ needs.parallelnative-linux-focal-py3_7-gcc7-build.outputs.test-matrix }}
-
   # Build PyTorch with BUILD_CAFFE2=ON
   caffe2-linux-focal-py3_7-gcc7-build:
     name: caffe2-linux-focal-py3.7-gcc7


### PR DESCRIPTION
This PR is more of an RFC asking whether we intend to maintain parallelnative in the long term or to allow it to become community-supported.

If we want to maintain parallelnative, then let's close this PR. 
If we do not, then we should remove it from trunk workflows into periodic (or just remove entirely).

Why shouldn't we just allow it to continue on CI regardless?
It adds friction to development! If we do support it, I think the friction is good--it prevents users from breaking what we support! But if not, then it is just another job users have to wait for before landing or another vector for flakiness to arise. 