### PR TITLE
Add api to expose operands as an oplist, for copying purposes

### DIFF
--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -87,6 +87,8 @@ Node::Node(
 
     AddOperand(operand.node, operand.index);
   }
+
+  operands_as_oplist_ = operands;
 }
 
 Node::Node(
@@ -149,6 +151,10 @@ const Output& Node::nullable_operand(size_t i) const {
   // We use kNullOutput instead of kNullValue here to avoid implicit casting,
   // which would prevent this method from returning a reference.
   return i < operands_as_outputs_.size() ? operand(i) : kNullOutput;
+}
+
+const OpList& Node::operands_as_oplist() const {
+  return operands_as_oplist_;
 }
 
 std::string Node::ToString() const {

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -62,7 +62,10 @@ bool Node::enableDynamicShape() {
 }
 
 Node::Node(OpKind op, size_t num_outputs)
-    : op_(op), num_outputs_(num_outputs), metadata_(GetMetaDataIfDebugging()) {}
+    : op_(op),
+      num_outputs_(num_outputs),
+      metadata_(GetMetaDataIfDebugging()),
+      operands_as_oplist_(std::nullopt) {}
 
 Node::Node(
     OpKind op,
@@ -88,7 +91,7 @@ Node::Node(
     AddOperand(operand.node, operand.index);
   }
 
-  operands_as_oplist_ = operands;
+  operands_as_oplist_ = std::optional<OpList>(operands);
 }
 
 Node::Node(
@@ -153,7 +156,7 @@ const Output& Node::nullable_operand(size_t i) const {
   return i < operands_as_outputs_.size() ? operand(i) : kNullOutput;
 }
 
-const OpList& Node::operands_as_oplist() const {
+const std::optional<OpList> Node::operands_as_oplist() const {
   return operands_as_oplist_;
 }
 

--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -2,9 +2,9 @@
 
 #include <ATen/core/symbol.h>
 
-#include <optional>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>

--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -137,6 +137,8 @@ class TORCH_API Node {
   // Gets operand at index i if index is valid, or kNullOutput otherwise.
   virtual const Output& nullable_operand(size_t i) const;
 
+  virtual const OpList& operands_as_oplist() const;
+
   // Returns the hash of the dag used to look up the compiled graph
   virtual hash_t hash() const = 0;
 
@@ -180,6 +182,9 @@ class TORCH_API Node {
   // Outputs do not hold references on the nodes, and neither do the uses, since
   // otherwise we get into circular reference counting.
   std::vector<Output> operands_as_outputs_;
+  // In order to make copies of IR nodes, we need to access the operands in the
+  // format which is passed into the constructor.
+  OpList operands_as_oplist_;
 };
 
 inline std::ostream& operator<<(std::ostream& stream, const Node& node) {

--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/symbol.h>
 
+#include <optional>
 #include <functional>
 #include <memory>
 #include <set>
@@ -137,7 +138,7 @@ class TORCH_API Node {
   // Gets operand at index i if index is valid, or kNullOutput otherwise.
   virtual const Output& nullable_operand(size_t i) const;
 
-  virtual const OpList& operands_as_oplist() const;
+  virtual const std::optional<OpList> operands_as_oplist() const;
 
   // Returns the hash of the dag used to look up the compiled graph
   virtual hash_t hash() const = 0;
@@ -184,7 +185,7 @@ class TORCH_API Node {
   std::vector<Output> operands_as_outputs_;
   // In order to make copies of IR nodes, we need to access the operands in the
   // format which is passed into the constructor.
-  OpList operands_as_oplist_;
+  std::optional<OpList> operands_as_oplist_;
 };
 
 inline std::ostream& operator<<(std::ostream& stream, const Node& node) {


### PR DESCRIPTION
This change allows the XLA downstream to clone IR nodes with/without sharding info, enabling the SPMD feature for XLA:TPU. See https://github.com/pytorch/xla/pull/4555