### PR TITLE
Reenable mobilevit_s in CI, seems to pass

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -92,7 +92,6 @@ CI_SKIP_AOT_EAGER_TRAINING = [
     "cait_m36_384",  # fp64_OOM
     "convit_base",  # fp64_OOM
     "levit_128",  # Accuracy (patch_embed.0.c.weight.grad)
-    "mobilevit_s",  # Accuracy
     "sebotnet33ts_256",  # Accuracy (stem.conv1.conv.weight.grad)
     "xcit_large_24_p8_224",  # fp64_OOM
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92585

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire