### PR TITLE
Register sccache epilogue before starting sccache

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -189,6 +189,7 @@ jobs:
             -e XLA_CLANG_CACHE_S3_BUCKET_NAME \
             -e PYTORCH_TEST_CUDA_MEM_LEAK_CHECK \
             -e PYTORCH_TEST_RERUN_DISABLED_TESTS \
+            -e SKIP_SCCACHE_INITIALIZATION=1 \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
             --ulimit stack=10485760:83886080 \
             --security-opt seccomp=unconfined \

--- a/.jenkins/pytorch/common-build.sh
+++ b/.jenkins/pytorch/common-build.sh
@@ -7,48 +7,52 @@ if [[ "$BUILD_ENVIRONMENT" != *win-* ]]; then
     script_dir="$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )"
 
     if which sccache > /dev/null; then
-    # Save sccache logs to file
-    sccache --stop-server > /dev/null  2>&1 || true
-    rm -f ~/sccache_error.log || true
-    if [[ -n "${SKIP_SCCACHE_INITIALIZATION:-}" ]]; then
-        # sccache --start-server seems to hang forever on self hosted runners for GHA
-        # so let's just go ahead and skip the --start-server altogether since it seems
-        # as though sccache still gets used even when the sscache server isn't started
-        # explicitly
-        echo "Skipping sccache server initialization, setting environment variables"
-        export SCCACHE_IDLE_TIMEOUT=1200
-        export SCCACHE_ERROR_LOG=~/sccache_error.log
-        export RUST_LOG=sccache::server=error
-    elif [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
-        SCCACHE_ERROR_LOG=~/sccache_error.log SCCACHE_IDLE_TIMEOUT=0 sccache --start-server
-    else
-        # increasing SCCACHE_IDLE_TIMEOUT so that extension_backend_test.cpp can build after this PR:
-        # https://github.com/pytorch/pytorch/pull/16645
-        SCCACHE_ERROR_LOG=~/sccache_error.log SCCACHE_IDLE_TIMEOUT=1200 RUST_LOG=sccache::server=error sccache --start-server
-    fi
+        # Save sccache logs to file
+        sccache --stop-server > /dev/null  2>&1 || true
+        rm -f ~/sccache_error.log || true
 
-    # Report sccache stats for easier debugging
-    sccache --zero-stats
-    function sccache_epilogue() {
-        echo "::group::Sccache Compilation Log"
-        echo '=================== sccache compilation log ==================='
-        python "$script_dir/print_sccache_log.py" ~/sccache_error.log 2>/dev/null
-        echo '=========== If your build fails, please take a look at the log above for possible reasons ==========='
-        sccache --show-stats
-        sccache --stop-server || true
-        echo "::endgroup::"
-    }
+        function sccache_epilogue() {
+            echo "::group::Sccache Compilation Log"
+            echo '=================== sccache compilation log ==================='
+            python "$script_dir/print_sccache_log.py" ~/sccache_error.log 2>/dev/null || true
+            echo '=========== If your build fails, please take a look at the log above for possible reasons ==========='
+            sccache --show-stats
+            sccache --stop-server || true
+            echo "::endgroup::"
+        }
 
-    trap_add sccache_epilogue EXIT
+        # Register the function here so that the error log can be printed even when
+        # sccache fails to start, i.e. timeout error
+        trap_add sccache_epilogue EXIT
+
+        if [[ -n "${SKIP_SCCACHE_INITIALIZATION:-}" ]]; then
+            # sccache --start-server seems to hang forever on self hosted runners for GHA
+            # so let's just go ahead and skip the --start-server altogether since it seems
+            # as though sccache still gets used even when the sscache server isn't started
+            # explicitly
+            echo "Skipping sccache server initialization, setting environment variables"
+            export SCCACHE_IDLE_TIMEOUT=1200
+            export SCCACHE_ERROR_LOG=~/sccache_error.log
+            export RUST_LOG=sccache::server=error
+        elif [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
+            SCCACHE_ERROR_LOG=~/sccache_error.log SCCACHE_IDLE_TIMEOUT=0 sccache --start-server
+        else
+            # increasing SCCACHE_IDLE_TIMEOUT so that extension_backend_test.cpp can build after this PR:
+            # https://github.com/pytorch/pytorch/pull/16645
+            SCCACHE_ERROR_LOG=~/sccache_error.log SCCACHE_IDLE_TIMEOUT=1200 RUST_LOG=sccache::server=error sccache --start-server
+        fi
+
+        # Report sccache stats for easier debugging
+        sccache --zero-stats
     fi
 
     if which ccache > /dev/null; then
-    # Report ccache stats for easier debugging
-    ccache --zero-stats
-    ccache --show-stats
-    function ccache_epilogue() {
+        # Report ccache stats for easier debugging
+        ccache --zero-stats
         ccache --show-stats
-    }
-    trap_add ccache_epilogue EXIT
+        function ccache_epilogue() {
+            ccache --show-stats
+        }
+        trap_add ccache_epilogue EXIT
     fi
 fi


### PR DESCRIPTION
Fixing XLA test job flaky with sccache failing to start with a timeout error, for example:

* https://github.com/pytorch/pytorch/actions/runs/3953719143/jobs/6770489428
* https://github.com/pytorch/pytorch/actions/runs/3952860712/jobs/6769339620
* https://github.com/pytorch/pytorch/actions/runs/3946315315/jobs/6754126326

XLA test job actually builds XLA as part of the test ~~, so it needs sccache~~

* Register sccache epilogue before starting sccache, so that any errors when starting sccache can be printed
* Add `-e SKIP_SCCACHE_INITIALIZATION=1` to `_linux_test` workflow, this is the same flag used in `_linux_build` workflow. Quoted the reason from the build script:

> sccache --start-server seems to hang forever on self hosted runners for GHA so let's just go ahead and skip the --start-server altogether since it seems as though sccache still gets used even when the sscache server isn't started explicitly

* Also fix the code alignment in `.jenkins/pytorch/common-build.sh`
* We don't even use sccache in XLA test job, but there is an S3 cache used by bazel there (`XLA_CLANG_CACHE_S3_BUCKET_NAME=ossci-compiler-clang-cache-circleci-xla`)
