### PR TITLE
let inductor generate broadcast  when loading a single value

### DIFF
--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -448,9 +448,9 @@ class CSE:
         if append_broadcast:
             assert isinstance(append_broadcast, str)
             cache_key = expr + append_broadcast
-        if expr not in self.cache:
+        if cache_key not in self.cache:
             var = self.newvar()
-            self.cache[expr] = var
+            self.cache[cache_key] = var
             if write:
                 if V.kernel.current_node:
                     V.kernel.current_node.codegen_originating_info(
@@ -468,7 +468,7 @@ class CSE:
                         f"{self.prefix}{var} = tl.broadcast_to({var}{var_suffix}, {append_broadcast})"
                     )
 
-        return self.cache[expr]
+        return self.cache[cache_key]
 
     def newvar(self) -> CSEVariable:
         var_name = f"{self.name_prefix}{next(self.iter_buffer_ids)}"

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -435,7 +435,11 @@ class CSE:
         )
 
     def generate(
-        self, buffer: IndentedBuffer, expr: typing.Union[str, CSEVariable], write=True, append_broadcast = None
+        self,
+        buffer: IndentedBuffer,
+        expr: typing.Union[str, CSEVariable],
+        write=True,
+        append_broadcast=None,
     ) -> CSEVariable:
         assert isinstance(expr, (str, CSEVariable)), type(expr)
         if isinstance(expr, CSEVariable):
@@ -456,9 +460,13 @@ class CSE:
                     var_suffix = "_load"
                 else:
                     var_suffix = ""
-                buffer.writeline(f"{self.prefix}{var}{var_suffix} = {expr}{self.suffix}")
+                buffer.writeline(
+                    f"{self.prefix}{var}{var_suffix} = {expr}{self.suffix}"
+                )
                 if append_broadcast:
-                    buffer.writeline(f"{self.prefix}{var} = tl.broadcast_to({var}{var_suffix}, {append_broadcast})")
+                    buffer.writeline(
+                        f"{self.prefix}{var} = tl.broadcast_to({var}{var_suffix}, {append_broadcast})"
+                    )
 
         return self.cache[expr]
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -876,9 +876,13 @@ class TritonKernel(Kernel):
         ):
             # can lift a common load outside of reduction loop
             # One exception is when this is an indirect_load.
-            result_var = self.cse.generate(self.body, line, append_broadcast=append_broadcast)
+            result_var = self.cse.generate(
+                self.body, line, append_broadcast=append_broadcast
+            )
         else:
-            result_var = self.cse.generate(self.loads, line, append_broadcast=append_broadcast)
+            result_var = self.cse.generate(
+                self.loads, line, append_broadcast=append_broadcast
+            )
 
         result_var.mask_vars = mask_vars
 


### PR DESCRIPTION
For better perf with MLIR triton.
Changes 
```
tmp32 = tl.load(seed3 + (0 + tl.zeros([XBLOCK, RBLOCK], tl.int32)), None)
```
to 
```
tmp32_load = tl.load(seed3+(0)); tmp32 = tl.broadcast_to(tmp32_load, [XBLOCK, RBLOCK])
```
cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire @Jokeren 
