### PR TITLE
[CUDA][CUBLAS][BFloat16] Tenatively disable reduced precision reductions for some matmul tests

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -55,6 +55,11 @@ class TestMatmulCuda(TestCase):
         #
         # Get dims
         n, m, p = (size + 1, size, size + 2)
+        # Disable reduced precision reductions in BFloat16 to bypass some kernels
+        # which fail the threshold check
+        orig = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+        if dtype == torch.bfloat16 and torch.cuda.get_device_capability() >= (8, 6):
+            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
         # Make random tensors on CPU (seed set on common_utils.py import)
         # (Not using numpy because it does not support bfloat16)
         make_arg = partial(make_tensor, dtype=dtype, device="cpu")
@@ -93,6 +98,7 @@ class TestMatmulCuda(TestCase):
         res_cuda = res_cuda.to("cpu")
         # Compare
         self.assertEqual(res_cpu, res_cuda)
+        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = orig
 
     @onlyCUDA
     @unittest.skipIf(not CUDA11OrLater, "Only CUDA 11+ is supported")


### PR DESCRIPTION
We've observed some failures in numerical checks on newer compute capabilities stemming from cuBLAS allowing reduced precision reductions.

CC @ptrblck @ngimel 