### PR TITLE
[dtensor] disable gpu tests in op db first

### DIFF
--- a/test/distributed/_tensor/test_dtensor_ops.py
+++ b/test/distributed/_tensor/test_dtensor_ops.py
@@ -563,7 +563,9 @@ skip_bw = [
 
 
 OP_DB_WORLD_SIZE = 4
-DEVICE_TYPE = "cuda" if torch.cuda.is_available() and torch.cuda.device_count() >= OP_DB_WORLD_SIZE else "cpu"
+# DEVICE_TYPE = "cuda" if torch.cuda.is_available() and torch.cuda.device_count() >= OP_DB_WORLD_SIZE else "cpu"
+# TODO: debug cuda illegal memory access issue and re-enable cuda tests
+DEVICE_TYPE = "cpu"
 
 
 class TestDTensorOps(DTensorOpTestBase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92611

There seems to be some issue with the cuda tests where our CI aren't
capturing those failures (probably because of lacking 4 GPUs in CI
environment). Disabling it first and debug later

see https://github.com/pytorch/pytorch/issues/92343