### PR TITLE
make dynamo graph break when encountering nested tensors while producing subgraphs for surrounding dense code

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -179,7 +179,7 @@ NestedTensorImpl::NestedTensorImpl(
       "in the near future.");
   auto storage_device = storage_.device();
   TORCH_INTERNAL_ASSERT(
-      storage_device.is_cpu() || storage_device.is_cuda(),
+      storage_device.is_cpu() || storage_device.is_cuda() || storage_device.is_meta(),
       "NestedTensorImpl storage must be either CUDA or CPU but got ",
       storage_device);
   validate_nested_tensor_metadata(nested_size_tensor_, nested_stride_tensor_, storage_offsets_);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5008,7 +5008,7 @@
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: detach
-    NestedTensorCPU, NestedTensorCUDA: detach
+    NestedTensorCPU, NestedTensorCUDA, NestedTensorMeta: detach
 
 # Like `detach()`, but modifies this `Variable` in-place. This method may
 # only be called on non-view `Variable`s. You can use `is_view()` to check
@@ -5724,19 +5724,24 @@
 - func: _nested_tensor_size(Tensor self) -> Tensor
   variants: method
   dispatch:
-    NestedTensorCPU, NestedTensorCUDA: _nested_tensor_size
+    NestedTensorCPU, NestedTensorCUDA, NestedTensorMeta: _nested_tensor_size
   autogen: _nested_tensor_size.out
 
 - func: _nested_tensor_strides(Tensor self) -> Tensor
   variants: method
   dispatch:
-    NestedTensorCPU, NestedTensorCUDA: _nested_tensor_strides
+    NestedTensorCPU, NestedTensorCUDA, NestedTensorMeta: _nested_tensor_strides
   autogen: _nested_tensor_strides.out
 
 - func: _nested_tensor_offsets(Tensor self) -> int[]
   variants: method
   dispatch:
-    NestedTensorCPU, NestedTensorCUDA: _nested_tensor_offsets
+    NestedTensorCPU, NestedTensorCUDA, NestedTensorMeta: _nested_tensor_offsets
+
+- func: _nested_tensor_offsets_tensor(Tensor self) -> Tensor
+  variants: method
+  dispatch:
+    NestedTensorCPU, NestedTensorCUDA, NestedTensorMeta: _nested_tensor_offsets_tensor
 
 # _nested_from_padded is not usable from Python, so
 # _nested_from_padded_and_nested_example is available for testing.
@@ -5751,7 +5756,7 @@
   variants: function
   device_check: NoCheck
   dispatch:
-    CPU, CUDA: _nested_view_from_buffer
+    CPU, CUDA, Meta: _nested_view_from_buffer
 
 - func: _nested_view_from_buffer_copy(Tensor self, Tensor nested_size, Tensor nested_strides, int[] offsets) -> Tensor
   variants: function
@@ -6770,7 +6775,7 @@
   dispatch:
     SparseCPU, SparseCUDA, SparseMeta: values_sparse
     SparseCsrCPU, SparseCsrCUDA: values_sparse_csr
-    NestedTensorCPU, NestedTensorCUDA: values_nested
+    NestedTensorCPU, NestedTensorCUDA, NestedTensorMeta: values_nested
   device_check: NoCheck
   device_guard: False
 
@@ -6824,7 +6829,7 @@
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: unbind
-    CompositeImplicitAutogradNestedTensor: NestedTensor_unbind
+    CompositeImplicitAutogradNestedTensor, NestedTensorMeta: NestedTensor_unbind
 
 - func: unbind.Dimname(Tensor(a -> *) self, Dimname dim) -> Tensor(a)[]
   variants: function, method

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -8,6 +8,7 @@
 #include <ATen/ops/_nested_tensor_size_native.h>
 #include <ATen/ops/_nested_tensor_strides_native.h>
 #include <ATen/ops/_nested_tensor_offsets_native.h>
+#include <ATen/ops/_nested_tensor_offsets_tensor_native.h>
 #include <ATen/ops/chunk_native.h>
 #endif
 
@@ -29,6 +30,11 @@ at::Tensor _nested_tensor_strides(const at::Tensor& self){
 std::vector<int64_t> _nested_tensor_offsets(const at::Tensor& self){
   return get_nested_tensor_impl(self) -> get_storage_offsets();
 }
+
+at::Tensor _nested_tensor_offsets_tensor(const at::Tensor& self){
+  return at::tensor(get_nested_tensor_impl(self) -> get_storage_offsets());
+}
+
 
 // Helper functions for getting information about a nested tensor's shape.
 std::vector<int64_t> NestedTensor_get_max_size_from_size_tensor(

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -153,9 +153,7 @@ _SKIP_PYTHON_BINDINGS = [
     "fill.Scalar",  # only used by the functionalization pass
     "lift.*",
     "normal_functional",  # only used by the functionalization pas
-    "_nested_tensor_strides",  # don't want to expose this to python
     "_nested_tensor_offsets",  # don't want to expose this to python
-    "_nested_view_from_buffer",  # View only version of _nested_from_buffer. This will force users to only use the "safe" version.
     "_nested_view_from_buffer_copy",
 ]
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1049,6 +1049,10 @@ def get_fake_value(node, tx):
             cause, torch._subclasses.fake_tensor.DynamicOutputShapeException
         ):
             unimplemented(f"dynamic shape operator: {cause.func}")
+        elif isinstance(
+            cause, torch._subclasses.fake_tensor.UnsupportedFakeTensorException
+        ):
+            unimplemented(f"unsupported fake operator: {cause.reason}")
         raise TorchRuntimeError() from e
 
 

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -113,8 +113,8 @@ class TensorVariable(VariableTracker):
             "class_type": type(value),
         }
         if not config.dynamic_shapes:
-            props["size"] = tuple(value.size())
-            props["stride"] = tuple(value.stride())
+            props["size"] = tuple(value.size()) if not value.is_nested else None
+            props["stride"] = tuple(value.stride()) if not value.is_nested else None
             props["is_contiguous"] = tuple(
                 [
                     x

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -247,6 +247,25 @@ class MetaConverter:
                         with torch.enable_grad():
                             r = r.clone()
                             r._coalesced_(t.is_coalesced())
+                elif t.is_nested:
+                    is_leaf = safe_is_leaf(t)
+                    sizes = t._nested_tensor_size()
+                    strides = t._nested_tensor_strides()
+                    _storage_offset = t._nested_tensor_offsets_tensor()
+                    numel = t.numel()
+                    # buffer device is propagated to NT device
+                    buffer = torch.empty(numel, device="meta")
+                    r = callback(
+                        lambda: torch._nested_view_from_buffer(
+                            buffer, sizes, strides, _storage_offset.tolist()
+                        )
+                    )
+                    assert safe_is_leaf(r), "the callback you passed in doesn't detach"
+                    if t.requires_grad:
+                        r.requires_grad = True
+                    if t.requires_grad and not is_leaf:
+                        with torch.enable_grad():
+                            r = r.clone()
                 elif t.is_mkldnn:
                     is_leaf = safe_is_leaf(t)
                     sizes, strides, _storage_offset = sym_sizes_strides_storage_offset(
@@ -468,7 +487,7 @@ class MetaConverter:
                     t.is_sparse_csr,
                     t.layout in [torch.sparse_csc, torch.sparse_bsr, torch.sparse_bsc],
                     t.is_quantized,
-                    t.is_nested,
+                    # t.is_nested,
                     t._is_view() and t._base is not None and t._base.is_sparse,
                     torch._is_functional_tensor(t),
                     # these are supported in meta conversion but the fallbacks

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -487,7 +487,6 @@ class MetaConverter:
                     t.is_sparse_csr,
                     t.layout in [torch.sparse_csc, torch.sparse_bsr, torch.sparse_bsc],
                     t.is_quantized,
-                    # t.is_nested,
                     t._is_view() and t._base is not None and t._base.is_sparse,
                     torch._is_functional_tensor(t),
                     # these are supported in meta conversion but the fallbacks

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -720,6 +720,8 @@ class ShapeEnv(object):
                 track_symint(source, t)
                 continue
             assert isinstance(t, torch.Tensor)
+            if (t.is_nested):
+                continue
             for i, s in enumerate(t.size()):
                 track_symint(TensorPropertySource(source, TensorProperty.SIZE, i), s)
             for i, s in enumerate(t.stride()):

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1290,6 +1290,8 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         Tensor.ndimension: lambda self: -1,
         Tensor.nelement: lambda self: -1,
         Tensor._nested_tensor_size: lambda self: -1,
+        Tensor._nested_tensor_strides: lambda self: -1,
+        Tensor._nested_tensor_offsets_tensor: lambda self: -1,
         Tensor.normal_: lambda self: -1,
         Tensor.numpy: lambda self: -1,
         Tensor.permute: lambda self, dim: -1,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #92612

**For the time being, we were hoping to be able to torch.compile models with nested code interspersed in dense code and exploit inductor on the dense code. We will remove this when we start work on properly integrating nested with PT2.**

This PR attempts to make dynamo graph break when encountering nested tensors interspersed within dense code, so that the dense code are compiled as subgraphs. **Very much a dynamo noob so there are definitely major gaps in this PR, feedback on how this could be better achieved would be greatly appreciated.**

The method used by quantized tensors seems to be to [raise UnsupportedFakeTensorException when encountering a quantized tensor](https://github.com/pytorch/pytorch/blob/master/torch/_subclasses/fake_tensor.py#L226-L227). However, following this approach seemed not to compile subgraphs of subsequent dense code. For example, 

```
@torch.compile()
def foo(c):
    # c is nested
    d = torch.tanh(c)
    e = torch.nested.to_padded_tensor(d, padding=0)
    # this is dense code
    g = torch.tanh(e)
    h = torch.sin(e)
    return h
 ```

would produce 0 graphs because the UnsupportedFakeTensorException raised will be converted to Unsupported [here](https://github.com/pytorch/pytorch/blob/b5e3fa567855a24110f909b3273760ffd8fa09f9/torch/_dynamo/utils.py#L705-L713) which is caught [here]( https://github.com/pytorch/pytorch/blob/master/torch/_dynamo/convert_frame.py#L404-L405) and rather than graph breaking the entire function is treated as one frame and no graph is produced. However, the code corresponding to `g` and `h` is dense and further should be fusable, so it would be nice if we could generate a subgraph for that.


The approach taken by this PR is to add some rudimentary meta support for nested tensors and then raise UnsupportedFakeTensorException whenever 
(i) encountering nested tensor constructor
(ii) any argument to a func in FakeTensorMode is nested

Further we catch this [here](https://github.com/pytorch/pytorch/blob/b5e3fa567855a24110f909b3273760ffd8fa09f9/torch/_dynamo/utils.py#L1052-L1055) so that when [`call_function`/`call_method` in `run_node` raises a `RuntimeError` with cause `UnsupportedFakeTensorException`](https://github.com/pytorch/pytorch/blob/b5e3fa567855a24110f909b3273760ffd8fa09f9/torch/_dynamo/utils.py#L1059), a graph break will be triggered [over here](https://github.com/pytorch/pytorch/blob/b5e3fa567855a24110f909b3273760ffd8fa09f9/torch/_dynamo/symbolic_convert.py#L308-L368) and the dynamo will produce subgraphs corresponding to the dense code.

Curiously guards for nested tensors seem to be hit as a result of this PR, which is problematic because of calls to `sizes` and `strides`, advice on how to better avoid this would be appreciated!




cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire