### PR TITLE
only copy meta if available

### DIFF
--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -707,12 +707,12 @@ class {module_name}(torch.nn.Module):
         fake_mod = torch.nn.Module()
         fake_mod.__dict__ = copy.deepcopy(self.__dict__)
         res = GraphModule(fake_mod, fake_mod.__dict__['_graph'])
-        res.meta = copy.deepcopy(self.meta)
+        res.meta = copy.deepcopy(getattr(self, 'meta', {}))
         return res
 
     def __copy__(self):
         res = GraphModule(self, self.graph)
-        res.meta = self.meta
+        res.meta = getattr(self, 'meta', {})
         return res
 
     @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Test Plan:
```
buck2 test mode/opt //torchmultimodal/tests:tests -- --exact 'torchmultimodal/tests:tests - test_albef.py::test_albef_image_embeddings_momentum'
```
now passes

Reviewed By: malfet

Differential Revision: D42608385

