### PR TITLE
Enable `USE_CUDA`

### DIFF
--- a/c10/cuda/build.bzl
+++ b/c10/cuda/build.bzl
@@ -25,6 +25,7 @@ def define_targets(rules):
         linkstatic = True,
         local_defines = ["C10_BUILD_MAIN_LIB"],
         visibility = ["//visibility:public"],
+        defines = ["USE_CUDA"],
         deps = [
             ":Macros",
             "@cuda",

--- a/c10/cuda/test/impl/CUDAAssertionsTest_catches_stream.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_catches_stream.cu
@@ -93,7 +93,7 @@ void cuda_device_assertions_catches_stream() {
 
 TEST(CUDATest, cuda_device_assertions_catches_stream) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_catches_stream();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";

--- a/c10/cuda/test/impl/CUDAAssertionsTest_catches_thread_and_block_and_device.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_catches_thread_and_block_and_device.cu
@@ -78,7 +78,7 @@ void cuda_device_assertions_catches_thread_and_block_and_device() {
 
 TEST(CUDATest, cuda_device_assertions_catches_thread_and_block_and_device) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_catches_thread_and_block_and_device();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";

--- a/c10/cuda/test/impl/CUDAAssertionsTest_from_2_processes.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_from_2_processes.cu
@@ -96,7 +96,7 @@ void cuda_device_assertions_from_2_processes() {
 
 TEST(CUDATest, cuda_device_assertions_from_2_processes) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_from_2_processes();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";

--- a/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_blocks_and_threads.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_blocks_and_threads.cu
@@ -85,7 +85,7 @@ void cuda_device_assertions_multiple_writes_from_blocks_and_threads() {
 
 TEST(CUDATest, cuda_device_assertions_multiple_writes_from_blocks_and_threads) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_multiple_writes_from_blocks_and_threads();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";

--- a/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_multiple_blocks.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_multiple_blocks.cu
@@ -82,7 +82,7 @@ void cuda_device_assertions_multiple_writes_from_multiple_blocks() {
 
 TEST(CUDATest, cuda_device_assertions_multiple_writes_from_multiple_blocks) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_multiple_writes_from_multiple_blocks();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";

--- a/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_same_block.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_same_block.cu
@@ -70,7 +70,7 @@ void cuda_device_assertions_multiple_writes_from_same_block() {
 
 TEST(CUDATest, cuda_device_assertions_multiple_writes_from_same_block) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_multiple_writes_from_same_block();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";


### PR DESCRIPTION
Summary: `USE_CUDA` is needed in the bazel definitions to ensure that `USE_CUDA` is applied everywhere it should be.

We also fix some test code to use the correct properties.

Test Plan: Sandcastle

Differential Revision: D42616147

