### PR TITLE
cond diff (alt fix)

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -7,6 +7,7 @@ import torch
 
 import torch._dynamo.test_case
 import torch._dynamo.testing
+from functorch.experimental.control_flow import cond
 from torch.fx.experimental.proxy_tensor import make_fx
 
 
@@ -1419,8 +1420,6 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
     def test_export_with_module_layer(self):
-        from functorch.experimental.control_flow import cond
-
         class Module(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1434,6 +1433,52 @@ class ExportTests(torch._dynamo.test_case.TestCase):
                     return self.linear(val) * torch.tensor(-1)
 
                 return cond(pred, true_fn, false_fn, [x])
+
+        mod = Module()
+        x = torch.randn([3, 3])
+        pred = torch.tensor(x[0][0].item() < 0)
+        real_result = mod.forward(pred, x)
+
+        torch._dynamo.reset()
+
+        exported = torch._dynamo.export(mod.forward, pred, x)
+        out_graph = exported[0]
+
+        dynamo_result = out_graph(pred, x)
+        self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
+
+        # New X, just to show we did not specialize
+        x = x * -1
+        pred = torch.tensor(x[0][0].item() < 0)
+        real_result_2 = mod.forward(pred, x)
+        dynamo_result_2 = out_graph(pred, x)
+        self.assertTrue(torch._dynamo.utils.same(real_result_2, dynamo_result_2))
+
+    @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
+    def test_export_with_closure_diff(self):
+        class Module(torch.nn.Module):
+            def forward(self, pred, x):
+                return self.indirection(pred, x)
+
+            def indirection(self, pred, x):
+                def true_fn(y):
+                    return y + 2
+
+                def false_fn(y):
+                    return y - 2
+
+                def shallow(x):
+                    return x * 2
+
+                def deep(x):
+                    return cond(
+                        x[0][0] > 0,
+                        true_fn,
+                        false_fn,
+                        [x],
+                    )
+
+                return cond(pred, shallow, deep, [x])
 
         mod = Module()
         x = torch.randn([3, 3])

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -246,8 +246,9 @@ class SideEffects:
         self.keepalive.append(item)
         return variable
 
-    def prune_dead_object_new(self, tx):
-        live_new_objects = set()
+    def prune_dead_object_new(self, tx, live_new_objects=None):
+        if live_new_objects is None:
+            live_new_objects = set()
         skip_obj = None
 
         def visit(var: VariableTracker):

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -761,7 +761,15 @@ class TorchPyOperator(VariableTracker):
                     "output", "output", (tx.output.create_arg((output.as_proxy(),))), {}
                 )
 
-                tx.output.side_effects.prune_dead_object_new(tx)
+                tx.output.side_effects.prune_dead_object_new(
+                    tx,
+                    # New cells are created for all closure variables, including functions in outer scope.
+                    # These "side effects" should not be pruned, o/w it causes a diff between branches.
+                    # We shouldn't care when branches call different sets of functions in outer scope.
+                    live_new_objects=set(
+                        checkpoint.output.side_effects.store_attr_mutations.keys()
+                    ),
+                )
                 state = tx.copy_graphstate()
 
                 guards = state.output.guards


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92644

Fixes https://github.com/pytorch/pytorch/issues/92561

When different branches of a cond reference different functions in outer scope, a spurious diff of side effects may be created because (1) we create new cells for such closure variables (2) we prune these cells per branch based on what's accessed and what's not.

Alternative fix here: https://github.com/pytorch/pytorch/pull/92565

Differential Revision: [D42617685](https://our.internmc.facebook.com/intern/diff/D42617685/)

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire