### PR TITLE
[pt2.0/inductor] Fix race in cache dir across ranks on the same host

### DIFF
--- a/torch/_inductor/triton_ops/autotune.py
+++ b/torch/_inductor/triton_ops/autotune.py
@@ -1,5 +1,6 @@
 import builtins
 import copy
+import getpass
 import hashlib
 import json
 import logging
@@ -35,6 +36,7 @@ else:
 
 
 class CachingAutotuner(KernelInterface):
+
     """
     Simplified version of Triton autotuner that has no invalidation
     key and caches the best config to disk to improve cold start times.
@@ -51,6 +53,11 @@ class CachingAutotuner(KernelInterface):
         self.configs = configs
         self.launchers = []
         self.lock = threading.Lock()
+        triton_cache_dir = os.path.join(
+            "/tmp", getpass.getuser(), str(self.meta.get("device", 0)), "triton/cache"
+        )
+        os.environ["TRITON_CACHE_DIR"] = triton_cache_dir
+        log.info(f"Triton cache directory: {triton_cache_dir}")
 
     def precompile(self, warm_cache_only_with_cc=None):
         with self.lock:


### PR DESCRIPTION
Summary:
It looks we have some race in the cache directory for triton codegen, when we have multiple processes on the same host:
1. Rank A and B cannot find the code in cache (/tmp/uid/triton/cache) and start compilation separately
2. Most of the times the codegen is the same; but rarely it may produce different llir and different shared memory (in our case it's 544 and 2560, both are valid for the llir/ptx generated). See repro D42584580
3. They both write the compiled so and metadata into the local cache folder, with the same directory name (same hash, without considering device id). There will be a race here even if they grab the file lock, because it only locks each file but not the entire transaction
4. We then load the so and meta data back from the file. What happens can be we load so from rank A and shared memory from rank B and they mismatch.

Test Plan:
Run the faulty program to double check
```
[trainer5]: cache dir: /tmp/root/4951/triton/cache/198ef4405d2e525acd20d5c2d01ad099
[trainer1]: cache dir: /tmp/root/4947/triton/cache/198ef4405d2e525acd20d5c2d01ad099
```

Differential Revision: D42619405



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire