### PR TITLE
Fix GroupNorm backward prop on CUDA

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8309,24 +8309,25 @@ class TestNNDeviceType(NNTestCase):
 
     @onlyNativeDeviceTypes
     def test_GroupNorm_memory_format(self, device):
-        import copy
         # Tests for regression reported in https://github.com/pytorch/pytorch/issues/92166
-        def helper(input_format, grad_format, B=2, C=4, W=4, H=4):
-            net_orig=torch.nn.GroupNorm(B, C).to(device=device)
-            net = copy.deepcopy(net_orig)
-            x_orig=torch.rand(B,C,W,H, device=device, requires_grad=True)
-            grad_orig=torch.rand(B,C,W,H,device=device)
-            x=x_orig.clone().detach().to(memory_format=input_format).requires_grad_(True)
-            grad=grad_orig.detach().to(memory_format=grad_format)
 
-            y=net(x)
+        def helper(input_format, grad_format, B=2, C=4, W=4, H=4):
+            import copy
+            net_orig = torch.nn.GroupNorm(B, C).to(device=device)
+            net = copy.deepcopy(net_orig)
+            x_orig = torch.rand(B, C, W, H, device=device, requires_grad=True)
+            grad_orig = torch.rand(B, C, W, H, device=device)
+            x = x_orig.clone().detach().to(memory_format=input_format).requires_grad_(True)
+            grad = grad_orig.detach().to(memory_format=grad_format)
+
+            y = net(x)
             y.backward(grad)
 
             y_orig = net_orig(x_orig)
             y_orig.backward(grad_orig)
 
             self.assertEqual(y, y_orig)
-            #TODO: Fix me, CPU should produce valid results here, but it is not
+            # TODO: Fix me, CPU should produce valid results here, but it is not
             if device != "cpu":
                 self.assertEqual(x.grad, x_orig.grad)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8308,6 +8308,33 @@ class TestNNDeviceType(NNTestCase):
         helper(self, (2, 60, 7, 200, 15), 3, torch.channels_last_3d, True)
 
     @onlyNativeDeviceTypes
+    def test_GroupNorm_memory_format(self, device):
+        import copy
+        # Tests for regression reported in https://github.com/pytorch/pytorch/issues/92166
+        def helper(input_format, grad_format, B=2, C=4, W=4, H=4):
+            net_orig=torch.nn.GroupNorm(B, C).to(device=device)
+            net = copy.deepcopy(net_orig)
+            x_orig=torch.rand(B,C,W,H, device=device, requires_grad=True)
+            grad_orig=torch.rand(B,C,W,H,device=device)
+            x=x_orig.clone().detach().to(memory_format=input_format).requires_grad_(True)
+            grad=grad_orig.detach().to(memory_format=grad_format)
+
+            y=net(x)
+            y.backward(grad)
+
+            y_orig = net_orig(x_orig)
+            y_orig.backward(grad_orig)
+
+            self.assertEqual(y, y_orig)
+            #TODO: Fix me, CPU should produce valid results here, but it is not
+            if device != "cpu":
+                self.assertEqual(x.grad, x_orig.grad)
+
+        for input_format in [torch.contiguous_format, torch.channels_last]:
+            for grad_format in [torch.contiguous_format, torch.channels_last]:
+                helper(input_format, grad_format)
+
+    @onlyNativeDeviceTypes
     def test_GroupNorm_numeric(self, device):
         def group_norm_ref(X, gamma, beta, groups, channels, eps):
             batch_size = X.size()[0]

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1168,7 +1168,7 @@
   rstd: not_implemented("native_layer_norm_backward rstd")
 
 - name: native_group_norm(Tensor input, Tensor? weight, Tensor? bias, SymInt N, SymInt C, SymInt HxW, int group, float eps) -> (Tensor, Tensor, Tensor)
-  input, weight, bias: "GradMode::is_enabled() || grads[1].defined() || grads[2].defined() ? infinitely_differentiable_native_group_norm_backward(grads[0], grads[1], grads[2], input, result1, result2, weight, N, C, HxW, group, eps, grad_input_mask) : (grads[0].defined() ? native_group_norm_backward_symint(grads[0].device().is_xpu() ? grads[0] : grads[0].contiguous(grads[0].suggest_memory_format()), input.device().is_xpu() ? input : input.contiguous(input.suggest_memory_format()), result1, result2, weight, N, C, HxW, group, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>())"
+  input, weight, bias: "GradMode::is_enabled() || grads[1].defined() || grads[2].defined() ? infinitely_differentiable_native_group_norm_backward(grads[0], grads[1], grads[2], input, result1, result2, weight, N, C, HxW, group, eps, grad_input_mask) : (grads[0].defined() ? native_group_norm_backward_symint(grads[0].device().is_xpu() ? grads[0] : grads[0].contiguous(grads[0].device().is_cpu() ? grads[0].suggest_memory_format() : c10::MemoryFormat::Contiguous), input.device().is_xpu() ? input : input.contiguous(input.device().is_cpu() ? input.suggest_memory_format() : c10::MemoryFormat::Contiguous), result1, result2, weight, N, C, HxW, group, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>())"
   result0: group_norm_jvp(input_p, input_t, weight_p, weight_t, bias_p, bias_t, result1, result2, group)
   result1: group_norm_mean_jvp(input_t, result1, group)
   result2: group_norm_invstd_jvp(input_p, input_t, result1, result2, group)


### PR DESCRIPTION
Fixes regression introduced by https://github.com/pytorch/pytorch/pull/89485

Adds test to prevent those regressions from happening in the future In process, discovered that GroupNormBackwards on CPU does not produce the same results if input and gradient memory_format is different

Fixes #92166
