### PR TITLE
[easy] unequal states report empty diff

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -119,7 +119,7 @@ class InstructionTranslatorGraphState(NamedTuple):
 
     def diff(self, other: "InstructionTranslatorGraphState") -> Optional[str]:
         for k in self._fields:
-            if k == "output":
+            if k == "output" and self.output != other.output:
                 return self.output.diff(other.output, prefix=f"{k}.")
             sv = getattr(self, k)
             ov = getattr(other, k)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92673

Encountered when, e.g., `state.symbolic locals` differ across two branches of a `cond`, yet  the diff reported in the thrown exception is `None`. Surely this is unintended?

Differential Revision: [D42628056](https://our.internmc.facebook.com/intern/diff/D42628056/)

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire