### PR TITLE
Add GHA side support for ciflow/inductor-perf-test-nightly

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     paths:
       - .github/workflows/inductor-perf-test-nightly.yml
+  push:
+    tags:
+      - ciflow/inductor-perf-test-nightly/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92693

Signed-off-by: Edward Z. Yang <ezyang@meta.com>