### PR TITLE
Use batch sizes from txt file by default for dynamo torchbench models

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1459,7 +1459,7 @@ def help(fn):
     return fn.__doc__
 
 
-def parse_args(args=None):
+def parse_args(args=None, default_batchsize_fn=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--filter", "-k", action="append", help="filter benchmarks with regexp"
@@ -1536,7 +1536,10 @@ def parse_args(args=None):
     )
     parser.add_argument("--batch_size", type=int, help="batch size for benchmarking")
     parser.add_argument(
-        "--batch-size-file", type=str, help="String to load batch size from"
+        "--batch-size-file",
+        type=str,
+        help="String to load batch size from",
+        default=default_batchsize_fn,
     )
     parser.add_argument("--cosine", action="store_true", help="use cosine similarity")
     parser.add_argument(
@@ -1812,10 +1815,10 @@ def parse_args(args=None):
     return parser.parse_args(args)
 
 
-def main(runner, original_dir=None):
+def main(runner, original_dir=None, default_batchsize_fn=None):
     if original_dir:
         os.chdir(original_dir)
-    args = parse_args()
+    args = parse_args(default_batchsize_fn=default_batchsize_fn)
 
     if args.diff_branch:
         import git

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -374,7 +374,7 @@ class TorchBenchmarkRunner(BenchmarkRunner):
 
 if __name__ == "__main__":
     default_batchsize_fn = abspath(
-        os.path.join(dirname(sys.argv[0]), "/torchbench_models_list.txt")
+        os.path.join(dirname(sys.argv[0]), "torchbench_models_list.txt")
     )
     original_dir = setup_torchbench_cwd()
     logging.basicConfig(level=logging.WARNING)

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 import warnings
-from os.path import abspath, exists
+from os.path import abspath, dirname, exists
 
 import torch
 
@@ -373,8 +373,10 @@ class TorchBenchmarkRunner(BenchmarkRunner):
 
 
 if __name__ == "__main__":
-
+    default_batchsize_fn = abspath(
+        os.path.join(dirname(sys.argv[0]), "/torchbench_models_list.txt")
+    )
     original_dir = setup_torchbench_cwd()
     logging.basicConfig(level=logging.WARNING)
     warnings.filterwarnings("ignore")
-    main(TorchBenchmarkRunner(), original_dir)
+    main(TorchBenchmarkRunner(), original_dir, default_batchsize_fn)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92719
* #92713

This makes it consistent with what happens for timm and huggingface
models.

Saves us from having to type `--batch-size-file $(realpath benchmarks/dynamo/torchbench_models_list.txt)` all the time.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire