### PR TITLE
Regularize mask handling for attn_mask and key_padding_mask

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1459,6 +1459,24 @@ class TestSDPA(NNTestCase):
                 _ = torch.nn.functional.scaled_dot_product_attention(
                     q, k, v, None, 0.0, False)
 
+    def test_incompatible_mask(self):
+        def ones_tensor(*shape):
+            return torch.ones(shape, dtype=torch.float32)
+        S, L, E, H = 1, 2, 4, 1
+        qkv = ones_tensor(S, L, E)
+
+        mha = nn.MultiheadAttention(E, H)
+        mha.in_proj_weight = Parameter(torch.ones((E * 3, E)))
+        mha.out_proj.weight = Parameter(torch.ones((E, E)))
+        qkv = qkv.to(float)
+        kpm = ones_tensor(S, L) * float("-inf")
+        am = ones_tensor(L, L).to(bool)
+
+        def func():
+            return mha(qkv, qkv, qkv, need_weights=False, key_padding_mask=kpm, attn_mask=am)
+
+        self.assertRaises(RuntimeError, func)
+
 # TODO: Replace this with instantiate_device_type_tests() to take advantage of test framework support for
 # cross device / dtype testing.
 instantiate_parametrized_tests(TestTransformers)

--- a/torch/ao/nn/quantizable/modules/activation.py
+++ b/torch/ao/nn/quantizable/modules/activation.py
@@ -253,9 +253,7 @@ class MultiheadAttention(nn.MultiheadAttention):
             See "Attention Is All You Need" for more details.
         key_padding_mask: if provided, specified padding elements in the key will
             be ignored by the attention. When given a binary mask and a value is True,
-            the corresponding value on the attention layer will be ignored. When given
-            a byte mask and a value is non-zero, the corresponding value on the attention
-            layer will be ignored
+            the corresponding value on the attention layer will be ignored.
         need_weights: output attn_output_weights.
         attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
             the batches while a 3D mask allows to specify a different mask for the entries of each batch.
@@ -269,14 +267,12 @@ class MultiheadAttention(nn.MultiheadAttention):
         - value: :math:`(S, N, E)` where S is the source sequence length, N is the batch size, E is
           the embedding dimension. :math:`(N, S, E)` if ``batch_first`` is ``True``.
         - key_padding_mask: :math:`(N, S)` where N is the batch size, S is the source sequence length.
-          If a ByteTensor is provided, the non-zero positions will be ignored while the position
-          with the zero positions will be unchanged. If a BoolTensor is provided, the positions with the
+          If a BoolTensor is provided, the positions with the
           value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
         - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length, S is the source sequence length.
           3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
           S is the source sequence length. attn_mask ensure that position i is allowed to attend the unmasked
-          positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
-          while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
+          positions. If a BoolTensor is provided, positions with ``True``
           is not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
           is provided, it will be added to the attention weight.
         - is_causal: If specified, applies a causal mask as attention mask. Mutually exclusive with providing attn_mask.
@@ -339,12 +335,11 @@ class MultiheadAttention(nn.MultiheadAttention):
         q = self.q_scaling_product.mul_scalar(q, scaling)
 
         if attn_mask is not None:
-            assert attn_mask.dtype == torch.float32 or attn_mask.dtype == torch.float64 or \
-                attn_mask.dtype == torch.float16 or attn_mask.dtype == torch.uint8 or attn_mask.dtype == torch.bool, \
-                'Only float, byte, and bool types are supported for attn_mask, not {}'.format(attn_mask.dtype)
             if attn_mask.dtype == torch.uint8:
                 warnings.warn("Byte tensor for attn_mask in nn.MultiheadAttention is deprecated. Use bool tensor instead.")
                 attn_mask = attn_mask.to(torch.bool)
+            assert attn_mask.is_floating_point() or attn_mask.dtype == torch.bool, \
+                'Only float and bool types are supported for attn_mask, not {}'.format(attn_mask.dtype)
 
             if attn_mask.dim() == 2:
                 attn_mask = attn_mask.unsqueeze(0)

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -356,6 +356,17 @@ def fold(input: Tensor, output_size: _size_any_t, kernel_size: _size_any_t, dila
          stride: _size_any_t = ...) -> Tensor: ...
 
 
+def _canonical_mask(
+        mask: Optional[Tensor],
+        mask_name: str,
+        other_type: Optional[_dtype],
+        other_name: str,
+        target_type: _dtype,
+        check_other: bool = True,
+) -> Optional[Tensor]: ...
+
+def _none_or_dtype(input: Optional[Tensor]) -> Optional[_dtype]: ...
+
 def multi_head_attention_forward(query: Tensor,
                                  key: Tensor,
                                  value: Tensor,

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1037,7 +1037,7 @@ class MultiheadAttention(Module):
             See "Attention Is All You Need" for more details.
         key_padding_mask: If specified, a mask of shape :math:`(N, S)` indicating which elements within ``key``
             to ignore for the purpose of attention (i.e. treat as "padding"). For unbatched `query`, shape should be :math:`(S)`.
-            Binary and byte masks are supported.
+            Binary and float masks are supported.
             For a binary mask, a ``True`` value indicates that the corresponding ``key`` value will be ignored for
             the purpose of attention. For a float mask, it will be directly added to the corresponding ``key`` value.
         need_weights: If specified, returns ``attn_output_weights`` in addition to ``attn_outputs``.
@@ -1046,10 +1046,10 @@ class MultiheadAttention(Module):
             :math:`(L, S)` or :math:`(N\cdot\text{num\_heads}, L, S)`, where :math:`N` is the batch size,
             :math:`L` is the target sequence length, and :math:`S` is the source sequence length. A 2D mask will be
             broadcasted across the batch while a 3D mask allows for a different mask for each entry in the batch.
-            Binary, byte, and float masks are supported. For a binary mask, a ``True`` value indicates that the
-            corresponding position is not allowed to attend. For a byte mask, a non-zero value indicates that the
+            Binary and float masks are supported. For a binary mask, a ``True`` value indicates that the
             corresponding position is not allowed to attend. For a float mask, the mask values will be added to
             the attention weight.
+            If both attn_mask and key_padding_mask are supplied, their types should match.
         is_causal: If specified, applies a causal mask as attention mask. Mutually exclusive with providing attn_mask.
             Default: ``False``.
         average_attn_weights: If true, indicates that the returned ``attn_weights`` should be averaged across
@@ -1074,11 +1074,15 @@ class MultiheadAttention(Module):
             raise AssertionError("Only allow causal mask or attn_mask")
 
         is_batched = query.dim() == 3
-        if key_padding_mask is not None:
-            _kpm_dtype = key_padding_mask.dtype
-            if _kpm_dtype != torch.bool and not torch.is_floating_point(key_padding_mask):
-                raise AssertionError(
-                    "only bool and floating types of key_padding_mask are supported")
+
+        key_padding_mask = F._canonical_mask(
+            mask=key_padding_mask,
+            mask_name="key_padding_mask",
+            other_type=F._none_or_dtype(attn_mask),
+            other_name="attn_mask",
+            target_type=query.dtype
+        )
+
         why_not_fast_path = ''
         if not is_batched:
             why_not_fast_path = f"input not batched; expected query.dim() of 3 but got {query.dim()}"
@@ -1210,6 +1214,16 @@ class MultiheadAttention(Module):
         """
         mask_type: Optional[int] = None
         merged_mask: Optional[Tensor] = None
+
+        attn_mask = F._canonical_mask(
+            mask=attn_mask,
+            mask_name="attn_mask",
+            other_type=F._none_or_dtype(key_padding_mask),
+            other_name="key_padding_mask",
+            target_type=query.dtype,
+            check_other=False,
+        )
+
         if attn_mask is not None:
             mask_type = 0
             merged_mask = attn_mask
@@ -1223,7 +1237,7 @@ class MultiheadAttention(Module):
             key_padding_mask_expanded = key_padding_mask.view(batch_size, 1, 1, seq_len) \
                                                         .expand(-1, self.num_heads, -1, -1)
             attn_mask_expanded = attn_mask.view(1, 1, seq_len, seq_len).expand(batch_size, self.num_heads, -1, -1)
-            merged_mask = attn_mask_expanded.logical_or(key_padding_mask_expanded)
+            merged_mask = attn_mask_expanded + key_padding_mask_expanded
         return merged_mask, mask_type
 
 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -200,6 +200,8 @@ def get_ignored_functions() -> Set[Callable]:
         torch.nn.functional.sigmoid,
         torch.nn.functional.hardsigmoid,
         torch.nn.functional.tanh,
+        torch.nn.functional._canonical_mask,
+        torch.nn.functional._none_or_dtype,
         # Doesn't actually take or return tensor arguments
         torch.nn.init.calculate_gain,
         # These are deprecated; don't test them


### PR DESCRIPTION
Summary:
Regularize mask handling for attn_mask and key_padding_mask
* Update documentation to remove reference to byte masks (which were deprecated long ago)
* Introduce check and warn about deprecation if attn_mask and key_padding_mask types mismatch
* Convert all masks to float before combining
* Combine by adding

Test Plan: sandcastle & github CI

Differential Revision: D42653215

