### PR TITLE
Switch CI exclusions to use exact match.

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1461,6 +1461,9 @@ def parse_args(args=None):
         "--exclude", "-x", action="append", help="filter benchmarks with regexp"
     )
     parser.add_argument(
+        "--exclude-exact", action="append", help="filter benchmarks with exact match"
+    )
+    parser.add_argument(
         "--total-partitions",
         type=int,
         default=1,
@@ -1818,6 +1821,7 @@ def run(runner, args, original_dir=None):
 
     args.filter = args.filter or [r"."]
     args.exclude = args.exclude or [r"^$"]
+    args.exclude_exact = args.exclude_exact or []
 
     if args.dynamic_ci_skips_only:
         args.dynamic_shapes = True
@@ -1842,7 +1846,7 @@ def run(runner, args, original_dir=None):
                     - set(CI_SKIP_AOT_EAGER_TRAINING)
                 )
             else:
-                args.exclude = (
+                args.exclude_exact = (
                     CI_SKIP_AOT_EAGER_DYNAMIC_TRAINING
                     if args.training and args.dynamic_shapes
                     else CI_SKIP_AOT_EAGER_TRAINING
@@ -1850,7 +1854,7 @@ def run(runner, args, original_dir=None):
                     else CI_SKIP_AOT_EAGER_INFERENCE
                 )
         elif args.inductor:
-            args.exclude = (
+            args.exclude_exact = (
                 CI_SKIP_INDUCTOR_TRAINING
                 if args.training
                 else CI_SKIP_INDUCTOR_INFERENCE

--- a/benchmarks/dynamo/huggingface.py
+++ b/benchmarks/dynamo/huggingface.py
@@ -450,6 +450,7 @@ class HuggingfaceRunner(BenchmarkRunner):
             if (
                 not re.search("|".join(args.filter), model_name, re.I)
                 or re.search("|".join(args.exclude), model_name, re.I)
+                or model_name in args.exclude_exact
                 or model_name in SKIP
             ):
                 continue

--- a/benchmarks/dynamo/timm_models.py
+++ b/benchmarks/dynamo/timm_models.py
@@ -279,6 +279,7 @@ class TimmRunnner(BenchmarkRunner):
             if (
                 not re.search("|".join(args.filter), model_name, re.I)
                 or re.search("|".join(args.exclude), model_name, re.I)
+                or model_name in args.exclude_exact
                 or model_name in self.skip_models
             ):
                 continue

--- a/benchmarks/dynamo/torchbench.py
+++ b/benchmarks/dynamo/torchbench.py
@@ -322,6 +322,7 @@ class TorchBenchmarkRunner(BenchmarkRunner):
             if (
                 not re.search("|".join(args.filter), model_name, re.I)
                 or re.search("|".join(args.exclude), model_name, re.I)
+                or model_name in args.exclude_exact
                 or model_name in SKIP
             ):
                 continue


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92761

Since the CI exclusions are hard-coded in our script, we might as well require them to match exactly. This solved some head scratching where I was like, "this model is not obviously excluded, why is it not showing up in CI."

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire