### PR TITLE
Fix typo under docs directory

### DIFF
--- a/docs/source/dynamo/faq.rst
+++ b/docs/source/dynamo/faq.rst
@@ -231,7 +231,7 @@ generated:
 How are you speeding up my code?
 --------------------------------
 
-There are 3 major ways to accelerat PyTorch code:
+There are 3 major ways to accelerate PyTorch code:
 
 1. Kernel fusion via vertical fusions which fuse sequential operations to avoid
    excessive read/writes. For example, fuse 2 subsequent cosines means you

--- a/docs/source/dynamo/guards-overview.rst
+++ b/docs/source/dynamo/guards-overview.rst
@@ -275,7 +275,7 @@ mind:
 
 -  It stores the variable ``source`` of type ``Source``, from
    ``torchdynamo/source.py``. This source type is a relatively self
-   contained class that helps us organize and bookeep where the original
+   contained class that helps us organize and bookkeep where the original
    source came from, and helps provide convenience methods for things
    like getting the name, and importantly for us, producing guards.
 

--- a/docs/source/dynamo/troubleshooting.rst
+++ b/docs/source/dynamo/troubleshooting.rst
@@ -650,7 +650,7 @@ to detect bugs in our codegen or with a backend compiler.
 File an Issue
 ~~~~~~~~~~~~~
 
-If you experience problems with TorchDynamo, `file a github
+If you experience problems with TorchDynamo, `file a GitHub
 issue <https://github.com/pytorch/torchdynamo/issues>`__.
 
 Before filing an issue, read over the `README <../README.md>`__,

--- a/docs/source/elastic/kubernetes.rst
+++ b/docs/source/elastic/kubernetes.rst
@@ -1,5 +1,5 @@
 TorchElastic Kubernetes
 ==========================
 
-Please refer to our github's `Kubernetes README <https://github.com/pytorch/elastic/tree/master/kubernetes>`_
+Please refer to our GitHub's `Kubernetes README <https://github.com/pytorch/elastic/tree/master/kubernetes>`_
 for more information on Elastic Job Controller and custom resource definition.

--- a/docs/source/func.rst
+++ b/docs/source/func.rst
@@ -13,7 +13,7 @@ torch.func, previously known as "functorch", is
    may change under user feedback and we don't have full coverage over PyTorch operations.
 
    If you have suggestions on the API or use-cases you'd like to be covered, please
-   open an github issue or reach out. We'd love to hear about how you're using the library.
+   open an GitHub issue or reach out. We'd love to hear about how you're using the library.
 
 What are composable function transforms?
 ----------------------------------------

--- a/docs/source/hub.rst
+++ b/docs/source/hub.rst
@@ -6,7 +6,7 @@ Publishing models
 -----------------
 
 Pytorch Hub supports publishing pre-trained models(model definitions and pre-trained weights)
-to a github repository by adding a simple ``hubconf.py`` file;
+to a GitHub repository by adding a simple ``hubconf.py`` file;
 
 ``hubconf.py`` can have multiple entrypoints. Each entrypoint is defined as a python function
 (example: a pre-trained model you want to publish).
@@ -49,7 +49,7 @@ You can see the full script in
   are the allowed positional/keyword arguments. It's highly recommended to add a few examples here.
 - Entrypoint function can either return a model(nn.module), or auxiliary tools to make the user workflow smoother, e.g. tokenizers.
 - Callables prefixed with underscore are considered as helper functions which won't show up in :func:`torch.hub.list()`.
-- Pretrained weights can either be stored locally in the github repo, or loadable by
+- Pretrained weights can either be stored locally in the GitHub repo, or loadable by
   :func:`torch.hub.load_state_dict_from_url()`. If less than 2GB, it's recommended to attach it to a `project release <https://help.github.com/en/articles/distributing-large-binaries>`_
   and use the url from the release.
   In the example above ``torchvision.models.resnet.resnet18`` handles ``pretrained``, alternatively you can put the following logic in the entrypoint definition.
@@ -57,7 +57,7 @@ You can see the full script in
 ::
 
     if pretrained:
-        # For checkpoint saved in local github repo, e.g. <RELATIVE_PATH_TO_CHECKPOINT>=weights/save.pth
+        # For checkpoint saved in local GitHub repo, e.g. <RELATIVE_PATH_TO_CHECKPOINT>=weights/save.pth
         dirname = os.path.dirname(__file__)
         checkpoint = os.path.join(dirname, <RELATIVE_PATH_TO_CHECKPOINT>)
         state_dict = torch.load(checkpoint)
@@ -131,7 +131,7 @@ By default, we don't clean up files after loading it. Hub uses the cache by defa
 directory returned by :func:`~torch.hub.get_dir()`.
 
 Users can force a reload by calling ``hub.load(..., force_reload=True)``. This will delete
-the existing github folder and downloaded weights, reinitialize a fresh download. This is useful
+the existing GitHub folder and downloaded weights, reinitialize a fresh download. This is useful
 when updates are published to the same branch, users can keep up with the latest release.
 
 
@@ -144,7 +144,7 @@ This also means that you may have import errors when importing different models
 from different repos, if the repos have the same sub-package names (typically, a
 ``model`` subpackage). A workaround for these kinds of import errors is to
 remove the offending sub-package from the ``sys.modules`` dict; more details can
-be found in `this github issue
+be found in `this GitHub issue
 <https://github.com/pytorch/hub/issues/243#issuecomment-942403391>`_.
 
 A known limitation that is worth mentioning here: users **CANNOT** load two different branches of

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -144,7 +144,7 @@ Features described in this documentation are classified by release status:
    TorchServe <https://pytorch.org/serve>
    torchtext <https://pytorch.org/text/stable>
    torchvision <https://pytorch.org/vision/stable>
-   PyTorch on XLA Devices <http://pytorch.org/xla/>
+   PyTorch on XLA Devices <https://pytorch.org/xla/>
 
 Indices and tables
 ==================

--- a/docs/source/jit_language_reference_v2.rst
+++ b/docs/source/jit_language_reference_v2.rst
@@ -1847,11 +1847,11 @@ only usable within TorchScript:
 - ``torch.jit.fork()``
     - Creates an asynchronous task executing func and a reference to the value of the result of this execution. Fork will return immediately.
     - Synonymous to ``torch.jit._fork()``, which is only kept for backward compatibility reasons.
-    - More deatils about its usage and examples can be found in :meth:`~torch.jit.fork`.
+    - More details about its usage and examples can be found in :meth:`~torch.jit.fork`.
 - ``torch.jit.wait()``
     - Forces completion of a ``torch.jit.Future[T]`` asynchronous task, returning the result of the task.
     - Synonymous to ``torch.jit._wait()``, which is only kept for backward compatibility reasons.
-    - More deatils about its usage and examples can be found in :meth:`~torch.jit.wait`.
+    - More details about its usage and examples can be found in :meth:`~torch.jit.wait`.
 
 
 .. _torch_apis_in_torchscript_annotation:

--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -258,7 +258,7 @@ PTSQ API Example::
   # attach a global qconfig, which contains information about what kind
   # of observers to attach. Use 'x86' for server inference and 'qnnpack'
   # for mobile inference. Other quantization configurations such as selecting
-  # symmetric or assymetric quantization and MinMax or L2Norm calibration techniques
+  # symmetric or asymmetric quantization and MinMax or L2Norm calibration techniques
   # can be specified here.
   # Note: the old 'fbgemm' is still available but 'x86' is the recommended default
   # for server inference.
@@ -357,7 +357,7 @@ QAT API Example::
   # attach a global qconfig, which contains information about what kind
   # of observers to attach. Use 'x86' for server inference and 'qnnpack'
   # for mobile inference. Other quantization configurations such as selecting
-  # symmetric or assymetric quantization and MinMax or L2Norm calibration techniques
+  # symmetric or asymmetric quantization and MinMax or L2Norm calibration techniques
   # can be specified here.
   # Note: the old 'fbgemm' is still available but 'x86' is the recommended default
   # for server inference.


### PR DESCRIPTION
This PR fixes typo and URL (`http -> https`) in `rst` files under `docs` directory
