### PR TITLE
[BE]: remove old dataclasses install from CI

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -76,10 +76,8 @@ if [[ "$PACKAGE_TYPE" == conda ]]; then
     set +u
     retry conda install \${EXTRA_CONDA_FLAGS} -yq \
       "numpy\${NUMPY_PIN}" \
-      future \
       mkl>=2018 \
       ninja \
-      dataclasses \
       typing-extensions \
       ${PROTOBUF_PACKAGE} \
       six

--- a/.github/requirements-gha-cache.txt
+++ b/.github/requirements-gha-cache.txt
@@ -6,7 +6,6 @@
 #   functorch/docs/requirements.txt
 #   .circleci/docker/requirements-ci.txt
 boto3==1.19.12
-dataclasses==0.6
 jinja2==3.0.1
 lintrunner==0.9.2
 ninja==1.10.0.post1

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -41,7 +41,7 @@ jobs:
           conda activate pr-ci
           conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
                            setuptools cmake=3.22.* typing_extensions boto3 \
-                           future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
+                           six pillow pytest tabulate gitpython git-lfs tqdm psutil
           pip install --pre torch torchvision torchtext -f https://download.pytorch.org/whl/nightly/cu116/torch_nightly.html
       - name: Setup TorchBench branch
         run: |

--- a/benchmarks/dynamo/Makefile
+++ b/benchmarks/dynamo/Makefile
@@ -28,7 +28,7 @@ build-deps: clone-deps
 	# conda create --name torchdynamo -y python=3.8
 	# conda activate torchdynamo
 	conda install -y astunparse numpy scipy ninja pyyaml mkl mkl-include setuptools cmake \
-		typing_extensions future six requests dataclasses protobuf numba cython scikit-learn
+		typing_extensions six requests protobuf numba cython scikit-learn
 	conda install -y -c pytorch magma-cuda116
 	conda install -y -c conda-forge librosa
 	(cd ../../../torchvision && python setup.py clean && python setup.py develop)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,8 @@ requires = [
     "setuptools",
     "cmake",
     "typing_extensions",
-    "future",
     "six",
     "requests",
-    "dataclasses",
 ]
 # Use legacy backend to import local packages in setup.py
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ requires = [
     "setuptools",
     "cmake",
     "typing_extensions",
-    "future ; python_version<3",
     "six",
     "requests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires = [
     "setuptools",
     "cmake",
     "typing_extensions",
+    "future ; python_version<3",
     "six",
     "requests",
 ]


### PR DESCRIPTION
Saw some places we missed some old requirements that are no longer necessary (dataclasses and future). Testing to see if all the CIs still work. We don't need dataclasses anymore now that we are on Python >= 3.7

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire