### PR TITLE
[BE]: Replace string compares with more efficient cpp comparisons

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -1709,7 +1709,7 @@ bool Reducer::rebuild_buckets() {
   bucket_size_limits.push_back(bucket_bytes_cap_);
   std::vector<size_t> per_bucket_size_limits;
   auto ddp_set_last_bucket_as_small =
-      (parse_env("DDP_SET_LAST_BUCKET_CAP").compare("1") == 0);
+      (parse_env("DDP_SET_LAST_BUCKET_CAP") == "1");
 
   if (ddp_set_last_bucket_as_small) {
     // Reverse so that first_bucket_bytes_cap_ (smaller bucket) becomes the last

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -179,8 +179,7 @@ bool PythonRpcHandler::isRemoteException(const py::object& obj) {
   auto type = obj.get_type();
   auto moduleName = type.attr("__module__").cast<std::string>();
   auto qualName = type.attr("__qualname__").cast<std::string>();
-  return moduleName.compare(kInternalModule) == 0 &&
-      qualName.compare("RemoteException") == 0;
+  return moduleName == kInternalModule && qualName == "RemoteException";
 }
 
 TypePtr PythonRpcHandler::parseTypeFromStr(const std::string& type_str) {

--- a/torch/csrc/distributed/rpc/script_call.cpp
+++ b/torch/csrc/distributed/rpc/script_call.cpp
@@ -143,7 +143,7 @@ std::shared_ptr<Operator> ScriptCall::matchOperator(
   auto symbol = at::Symbol::fromQualString(schema.name());
 
   for (auto op : torch::jit::getAllOperatorsFor(symbol)) {
-    if (toString(op->schema()).compare(str_schema) == 0) {
+    if (toString(op->schema()) == str_schema) {
       return op;
     }
   }

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -1199,7 +1199,7 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     return std::make_shared<FunctionValue>(callee->function_);
   } else if (py::isinstance<py::module>(obj)) {
     std::string obj_name = py::cast<py::str>(py::getattr(obj, "__name__"));
-    if (obj_name.compare("torch.cuda") == 0) {
+    if (obj_name == "torch.cuda") {
       return std::make_shared<CUDAPythonModuleValue>(obj);
     }
     return std::make_shared<PythonModuleValue>(obj);

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -269,7 +269,7 @@ Module ScriptModuleDeserializer::deserialize(
           std::string(static_cast<char*>(meta_ptr.get()), meta_size);
     }
   }
-  if (reader_->hasRecord("model.json") && code_prefix_.compare("code/") == 0) {
+  if (reader_->hasRecord("model.json") && code_prefix_ == "code/") {
 #if !defined(C10_MOBILE) && !defined(C10_DISABLE_LEGACY_IMPORT)
     return torch::jit::LEGACY_deserialize(compilation_unit_, reader_, device_);
 #else

--- a/torch/csrc/jit/serialization/import_read.cpp
+++ b/torch/csrc/jit/serialization/import_read.cpp
@@ -33,7 +33,7 @@ IValue readArchiveAndTensors(
   };
 
   std::string tensor_dir_path =
-      (tensor_prefix.compare("") != 0) ? tensor_prefix : archive_name + "/";
+      (tensor_prefix != "") ? tensor_prefix : archive_name + "/";
 
   auto read_record = [&](const std::string& name) {
     std::string ss = tensor_dir_path + name;

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -1037,7 +1037,7 @@ void LazyGraphExecutor::TensorCollectionBarrier(SyncTensorCollection* coll) {
   if (coll) {
     static const std::string invalid_device(
         "Unknown0"); /* Temp solution to idetify unassigned devices */
-    if (coll->device.toString().compare(invalid_device) == 0 ||
+    if (coll->device.toString() == invalid_device ||
         coll->unlocker.size() > 0) {
       return;
     }


### PR DESCRIPTION
Replace cpp string comparisons with more efficient equality operators. These string comparisons are not just more readable, but they also allow for short-circuiting for faster string equality checks.