### PR TITLE
Revert "Revert "Change convolution to use symbolic shapes for propagation (#92397)""

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -32,7 +32,12 @@ from .lowering import (
     needs_realized_inputs,
 )
 from .sizevars import CppSizeVarAllocator, SizeVarAllocator
-from .utils import gather_origins, get_dtype_size, sympy_product
+from .utils import (
+    convert_shape_to_inductor,
+    gather_origins,
+    get_dtype_size,
+    sympy_product,
+)
 from .virtualized import V
 
 log = logging.getLogger(__name__)
@@ -62,8 +67,9 @@ class GraphLowering(torch.fx.Interpreter):
         have the same size they get assigned the same symbolic variable.
         """
         if self.reuse_shape_env:
-            size = ex.size()
-            stride = ex.stride()
+            return convert_shape_to_inductor(ex.size()), convert_shape_to_inductor(
+                ex.stride()
+            )
         else:
             size, stride = self._shape_env.create_symbolic_sizes_strides(ex)
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -9,7 +9,7 @@ import tempfile
 import textwrap
 import time
 from io import StringIO
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from unittest import mock
 
 import sympy
@@ -77,6 +77,31 @@ def unique(it):
 def ceildiv(numer: int, denom: int):
     assert isinstance(numer, int) and isinstance(denom, int)
     return -(numer // -denom)
+
+
+def convert_shape_to_inductor(lst: List[Union[int, torch.SymInt]]) -> List[sympy.Expr]:
+    """
+    Gets the shape and stride of a tensor. For non-symbolic tensors, this is
+    trivial. But for symbolic tensors, we need to map from SymIntNode into
+    sympy.Expr.
+    """
+    return [
+        i.node.expr if isinstance(i, torch.SymInt) else sympy.Integer(i) for i in lst
+    ]
+
+
+def convert_shape_to_symint(
+    lst: List[Union[int, sympy.Expr]]
+) -> List[Union[torch.SymInt]]:
+    """
+    Takes a list of shapes from Inductor and converts them into symints (or just
+    ints if all shapes are static).
+    """
+    if all(isinstance(i, int) for i in lst):
+        return lst
+    if all(isinstance(i, sympy.Integer) for i in lst):
+        return [int(i) for i in lst]
+    return [V.graph.sizevars.shape_env.create_symintnode(i) for i in lst]
 
 
 def gen_gm_and_inputs(target, args, kwargs):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -215,6 +215,8 @@ class SymNode:
 
     # Today we error on calling int on a symbolic shape, as this is a very accessible footgun.
     def int_(self):
+        if len(self.expr.free_symbols) == 0:
+            return int(self.expr)
         raise RuntimeError("Trying to extract a concrete int out of a symbolic int")
 
     # You can manually trigger a guard with this function


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #92768
* __->__ #92767
* #91952
* #92667
* #92766

This reverts commit c8da6166af1fbf17626786ddbcd2998913c1c46c.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire