### PR TITLE
Revert "Mark XLA Linux jobs as unstable temporarily (#92634)"

### DIFF
--- a/.github/ci_commit_pins/xla.txt
+++ b/.github/ci_commit_pins/xla.txt
@@ -1,1 +1,1 @@
-eac4e547138ab22a9b41c6f96208613fd7dd19d5
+frobenius_norm

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -209,6 +209,26 @@ jobs:
       docker-image-name: pytorch-linux-focal-py3-clang7-android-ndk-r19c
       build-generates-artifacts: false
 
+  linux-bionic-py3_7-clang8-xla-build:
+    name: linux-bionic-py3_7-clang8-xla
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-bionic-py3_7-clang8-xla
+      docker-image-name: xla_base
+      test-matrix: |
+        { include: [
+          { config: "xla", shard: 1, num_shards: 1, runner: "linux.4xlarge" },
+        ]}
+
+  linux-bionic-py3_7-clang8-xla-test:
+    name: linux-bionic-py3_7-clang8-xla
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-bionic-py3_7-clang8-xla-build
+    with:
+      build-environment: linux-bionic-py3_7-clang8-xla
+      docker-image: ${{ needs.linux-bionic-py3_7-clang8-xla-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-bionic-py3_7-clang8-xla-build.outputs.test-matrix }}
+
   win-vs2019-cpu-py3-build:
     name: win-vs2019-cpu-py3
     uses: ./.github/workflows/_win-build.yml

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -31,23 +31,3 @@ jobs:
           echo
           echo "Once the jobs are deemed stable enough (% red signal < 20% and TTS < 3h),"
           echo " they can graduate and move back to pull or trunk."
-
-  linux-bionic-py3_7-clang8-xla-build:
-    name: linux-bionic-py3_7-clang8-xla
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: linux-bionic-py3_7-clang8-xla
-      docker-image-name: xla_base
-      test-matrix: |
-        { include: [
-          { config: "xla", shard: 1, num_shards: 1, runner: "linux.4xlarge" },
-        ]}
-
-  linux-bionic-py3_7-clang8-xla-test:
-    name: linux-bionic-py3_7-clang8-xla
-    uses: ./.github/workflows/_linux-test.yml
-    needs: linux-bionic-py3_7-clang8-xla-build
-    with:
-      build-environment: linux-bionic-py3_7-clang8-xla
-      docker-image: ${{ needs.linux-bionic-py3_7-clang8-xla-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-bionic-py3_7-clang8-xla-build.outputs.test-matrix }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92805

This reverts commit 3cc103132205820fc0c571e3e68dd5e9b5b85727.

It also updates the pin to point to the forward fix in https://github.com/pytorch/xla/pull/4490#issuecomment-1399933008

cc @bdhirsh