### PR TITLE
Update XLA pin

### DIFF
--- a/.github/ci_commit_pins/xla.txt
+++ b/.github/ci_commit_pins/xla.txt
@@ -1,1 +1,1 @@
-eac4e547138ab22a9b41c6f96208613fd7dd19d5
+frobenius_norm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92806

This should allow re-enabling/reverting https://github.com/pytorch/pytorch/commit/3cc103132205820fc0c571e3e68dd5e9b5b85727