### PR TITLE
Swap file size on BE platform

### DIFF
--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -330,10 +330,7 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
     int64_t tsize; // convert little endian storage to big endian cpu
     tsize = size;
     torch::utils::THP_decodeInt64Buffer(
-        &size,
-        (const uint8_t*)&tsize,
-        torch::utils::THP_nativeByteOrder(),
-        1);
+        &size, (const uint8_t*)&tsize, torch::utils::THP_nativeByteOrder(), 1);
   }
   int64_t nbytes = element_size * size;
   if (!storage.defined()) {

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -324,18 +324,18 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int64_t size;
   doRead(file, &size, sizeof(int64_t));
-  int64_t nbytes = element_size * size;
   if (torch::utils::THP_nativeByteOrder() ==
       torch::utils::THPByteOrder::THP_BIG_ENDIAN) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    int64_t nsize; // convert little endian storage to big endian cpu
-    nsize = nbytes;
+    int64_t tsize; // convert little endian storage to big endian cpu
+    tsize = size;
     torch::utils::THP_decodeInt64Buffer(
-        &nbytes,
-        (const uint8_t*)&nsize,
+        &size,
+        (const uint8_t*)&tsize,
         torch::utils::THP_nativeByteOrder(),
         1);
   }
+  int64_t nbytes = element_size * size;
   if (!storage.defined()) {
     storage = c10::make_intrusive<at::StorageImpl>(
         c10::StorageImpl::use_byte_size_t(),


### PR DESCRIPTION
Fixes #92808 

This PR fixes SIGSEGV on a big-endian machine when reading pickle data.  

The root cause is not to convert `size`, which is read from a file, from little-endian to big-endian while `size` is used in a method. The fix is to convert `size` on a big-endian machine instead of `nbytes`.

I confirmed that the program in the issue works w/o SIGSEGV and the test passes, with this fix in master branch.

```
$ python test/test_autograd.py TestAutograd.test_pickle
.
----------------------------------------------------------------------
Ran 1 test in 0.010s

OK
```
