### PR TITLE
Add documentation for DCP.

### DIFF
--- a/docs/source/distributed.checkpoint.rst
+++ b/docs/source/distributed.checkpoint.rst
@@ -4,10 +4,6 @@
 Distributed Checkpoint - torch.distributed.checkpoint
 =====================================================
 
-.. py:module:: torch.distributed.checkpoint
-
-.. automodule:: torch.distributed.checkpoint
-.. currentmodule:: torch.distributed.checkpoint
 
 Distributed Checkpoint (DCP) support loading and saving models from multiple ranks in parallel.
 It handles load-time resharding which enables saving in one cluster topology and loading into another.
@@ -17,11 +13,15 @@ DCP is different than `torch.save` and `torch.load` in a few significant ways:
 * It produces multiple files per checkpoint, with at least one per rank.
 * It operates in place, meaning that the model should allocate its data first and DCP uses that storage instead.
 
-
 The entrypoints to load and save a checkpoint are the following:
 
-* :func:`torch.distributed.checkpoint.load_state_dict`
-* :func:`torch.distributed.checkpoint.save_state_dict`
+
+.. automodule:: torch.distributed.checkpoint
+
+.. currentmodule:: torch.distributed.checkpoint
+
+.. autofunction::  load_state_dict
+.. autofunction::  save_state_dict
 
 The following types define the IO interface used during checkpoint:
 

--- a/docs/source/distributed.checkpoint.rst
+++ b/docs/source/distributed.checkpoint.rst
@@ -1,4 +1,63 @@
-Distributed Checkpoint
+Distributed Checkpoint - torch.distributed.checkpoint
 ========================
 
-.. automodule:: torch.distributed.checkpoint
+Distributed Checkpoint (DCP) support loading and saving models from multiple ranks in parallel.
+It handles load-time resharding which enables saving in one cluster topology and loading into another.
+
+DCP is different than `torch.save` and `torch.load` in a few significant ways:
+
+* It produces multiple files per checkpoint, with at least one per rank.
+* It operates in place, meaning that the model should allocate its data first and DCP uses that storage instead.
+
+
+.. currentmodule:: torch.distributed.checkpoint
+
+The entrypoints to load and save a checkpoint are the following:
+
+* :func:`torch.distributed.checkpoint.load_state_dict`
+* :func:`torch.distributed.checkpoint.save_state_dict`
+
+The following types define the IO interface used during checkpoint:
+
+.. autoclass:: torch.distributed.checkpoint.StorageReader
+  :members:
+
+.. autoclass:: torch.distributed.checkpoint.StorageWriter
+  :members:
+
+The following types define the planner interface used during checkpoint:
+
+.. autoclass:: torch.distributed.checkpoint.LoadPlanner
+  :members:
+
+.. autoclass:: torch.distributed.checkpoint.LoadPlan
+  :members:
+
+.. autoclass:: torch.distributed.checkpoint.ReadItem
+  :members:
+
+.. autoclass:: torch.distributed.checkpoint.SavePlanner
+  :members:
+
+.. autoclass:: torch.distributed.checkpoint.SavePlan
+  :members:
+
+.. autoclass:: torch.distributed.checkpoint.WriteItem
+  :members:
+
+We provide a filesystem based storage layer:
+
+.. autoclass:: torch.distributed.checkpoint.FileSystemReader
+  :members:
+
+.. autoclass:: torch.distributed.checkpoint.FileSystemWriter
+  :members:
+
+We provide default implementations of `LoadPlanner` and `SavePlanner` that
+can handle all of torch.distributed constructs such as FSDP, DDP, ShardedTensor and DistributedTensor.
+
+.. autoclass:: torch.distributed.checkpoint.DefaultSavePlanner
+  :members:
+
+.. autoclass:: torch.distributed.checkpoint.DefaultLoadPlanner
+  :members:

--- a/docs/source/distributed.checkpoint.rst
+++ b/docs/source/distributed.checkpoint.rst
@@ -1,5 +1,5 @@
 Distributed Checkpoint - torch.distributed.checkpoint
-========================
+=====================================================
 
 Distributed Checkpoint (DCP) support loading and saving models from multiple ranks in parallel.
 It handles load-time resharding which enables saving in one cluster topology and loading into another.

--- a/docs/source/distributed.checkpoint.rst
+++ b/docs/source/distributed.checkpoint.rst
@@ -1,5 +1,13 @@
+.. role:: hidden
+    :class: hidden-section
+
 Distributed Checkpoint - torch.distributed.checkpoint
 =====================================================
+
+.. py:module:: torch.distributed.checkpoint
+
+.. automodule:: torch.distributed.checkpoint
+.. currentmodule:: torch.distributed.checkpoint
 
 Distributed Checkpoint (DCP) support loading and saving models from multiple ranks in parallel.
 It handles load-time resharding which enables saving in one cluster topology and loading into another.
@@ -9,8 +17,6 @@ DCP is different than `torch.save` and `torch.load` in a few significant ways:
 * It produces multiple files per checkpoint, with at least one per rank.
 * It operates in place, meaning that the model should allocate its data first and DCP uses that storage instead.
 
-
-.. currentmodule:: torch.distributed.checkpoint
 
 The entrypoints to load and save a checkpoint are the following:
 

--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -225,7 +225,7 @@ class SavePlanner(abc.ABC):
         self, write_item: WriteItem
     ) -> Union[torch.Tensor, io.BytesIO]:
         """
-        Lookup the object associated with ``write_item``in `state_dict` and apply any
+        Lookup the object associated with ``write_item`` in ``state_dict`` and apply any
         transformation (such as serialization) prior to the storage layer consuming it.
 
         Called on each rank multiple times, at least once per WriteItem in the final SavePlan.
@@ -237,7 +237,7 @@ class SavePlanner(abc.ABC):
         is called in order to reduce peak memory required by checkpointing.
 
         When returning tensors, they can be on any device or format, they can be views too.
-        It's the storage layer responsiblity to figure out how to save them.
+        It's the storage layer responsibility to figure out how to save them.
         """
         pass
 

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -29,20 +29,20 @@ def load_state_dict(
     instances, each rank only reads data for their local shards.
 
     .. warning::
-    All tensors in ``state_dict`` must be allocated on their
-    destination device *prior to* calling this function.
+        All tensors in ``state_dict`` must be allocated on their
+        destination device *prior to* calling this function.
 
-    All non-tensor data is loaded using `torch.load()` and modified in place
-    on state_dict.
+        All non-tensor data is loaded using `torch.load()` and modified in place
+        on state_dict.
 
     .. warning::
-    Users must call `load_state_dict` on the root module to ensure load
-    pos-processing and non-tensor data properly propagates.
+        Users must call `load_state_dict` on the root module to ensure load
+        pos-processing and non-tensor data properly propagates.
 
     .. note:
-    This function can be used for local inference and load a checkpoint
-    produced by ``save_state_dict`` without having a process group initialized
-    by passing ``no_dist=True`` and by using Tensors instead of ShardedTensors.
+        This function can be used for local inference and load a checkpoint
+        produced by ``save_state_dict`` without having a process group initialized
+        by passing ``no_dist=True`` and by using Tensors instead of ShardedTensors.
 
     Args:
         state_dict (Dict[str, Any]) : The state_dict to load. Note that this

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -30,17 +30,17 @@ def save_state_dict(
     ``ShardedTensor`` by having each rank only save their local shards.
 
     .. warning::
-    There is no guarantees of Backwards Compatibility across PyTorch versions
-    for saved state_dicts.
+        There is no guarantees of Backwards Compatibility across PyTorch versions
+        for saved state_dicts.
 
     .. warning::
-    If using the `process_group` argument, make sure that only its ranks
-    call `save_state_dict` and that all data in state_dict belong to it.
+        If using the `process_group` argument, make sure that only its ranks
+        call `save_state_dict` and that all data in state_dict belong to it.
 
-    .. note:
-    This function can be used to save a state_dict with an intialized process
-    group by passing ``no_dist=True``. This can be used to produce a checkpoint
-    that can consumed by load_state_dict is a SPMD fashion.
+    .. note::
+        This function can be used to save a state_dict with an intialized process
+        group by passing ``no_dist=True``. This can be used to produce a checkpoint
+        that can consumed by load_state_dict is a SPMD fashion.
 
     Args:
         state_dict (Dict[str, Any]): A state_dict


### PR DESCRIPTION
This populates the website with some basic documentation.

It's far from ideal as we should include some basic usage example.

