### PR TITLE
Fix transformer masks usage

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5171,7 +5171,7 @@ def multi_head_attention_forward(
         elif attn_mask.dtype == torch.bool:
             attn_mask = attn_mask.logical_or(key_padding_mask)
         else:
-            attn_mask = attn_mask.masked_fill(key_padding_mask, float("-inf"))
+            attn_mask = attn_mask.add(key_padding_mask)
 
     # convert mask to float
     if attn_mask is not None and attn_mask.dtype == torch.bool:

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -163,6 +163,29 @@ class Transformer(Module):
             mask = torch.isinf(mask)
         return mask
 
+    @staticmethod
+    def generate_padding_mask(unpadded_lengths: List, max_len: int, use_bool_type: bool = True):
+        r"""Generate a padding mask for the batch. The masked positions are filled with True, and
+        unmasked positions with False.
+            With use_bool_type = False, reverts to deprecated float usage: masked positions are filled
+        with float('-inf'), and unmasked positions with float(0.0).
+
+        Args:
+            unpadded_lengths: List of each sequence's length in the batch.
+            max_len: The length of sequences after padding.
+
+        """
+        batch_size = len(unpadded_lengths)
+        fill_value = float(-inf)
+
+        mask = torch.zeros(batch_size, max_len)
+        for i in range(batch_size):
+            mask[i, unpadded_lengths[i]:] = fill_value
+
+        if use_bool_type:
+            mask = torch.isinf(mask)
+        return mask
+
     def _reset_parameters(self):
         r"""Initiate parameters in the transformer model."""
 

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -151,11 +151,17 @@ class Transformer(Module):
         return output
 
     @staticmethod
-    def generate_square_subsequent_mask(sz: int, device='cpu') -> Tensor:
-        r"""Generate a square mask for the sequence. The masked positions are filled with float('-inf').
-            Unmasked positions are filled with float(0.0).
+    def generate_square_subsequent_mask(sz: int, device='cpu', use_bool_type: bool = True) -> Tensor:
+        r"""Generate a square mask for the sequence. The masked positions are filled with True, and
+        unmasked positions with False.
+            With use_bool_type = False, reverts to deprecated float usage: masked positions are filled
+        with float('-inf'), and unmasked positions with float(0.0).
         """
-        return torch.triu(torch.full((sz, sz), float('-inf'), device=device), diagonal=1)
+        mask = torch.triu(torch.full((sz, sz), float('-inf'), device=device), diagonal=1)
+
+        if use_bool_type:
+            mask = torch.isinf(mask)
+        return mask
 
     def _reset_parameters(self):
         r"""Initiate parameters in the transformer model."""


### PR DESCRIPTION
Fixes Issue #92554 

The float usage in masks for the Transformer is considered deprecated, but still accepted.

 - `key_padding_mask` was ignored in the Transformer's multihead attention in the case where user creates a float mask. Fixing the float case.
 - Transformer's function `generate_square_subsequent_mask` generates float masks by default. Changing to bool mask.
 - Also adding a new `generate_padding_mask` in the Transformer, to help user create correct masks.

Don't hesitate to correct me for the computation efficiency.