### PR TITLE
[PT-D][Checkpoint]rename init()

### DIFF
--- a/torch/distributed/checkpoint/default_planner.py
+++ b/torch/distributed/checkpoint/default_planner.py
@@ -81,7 +81,7 @@ class DefaultSavePlanner(SavePlanner):
         self.dedup_replicated_tensors = dedup_replicated_tensors
         self.mappings = {}
 
-    def init(self, state_dict: STATE_DICT_TYPE, is_coordinator: bool) -> None:
+    def set_up_planner(self, state_dict: STATE_DICT_TYPE, is_coordinator: bool) -> None:
         if self.flatten_state_dict:
             state_dict, self.mappings = flatten_state_dict(state_dict)
         if self.flatten_sharded_tensors:
@@ -173,7 +173,7 @@ class DefaultLoadPlanner(LoadPlanner):
         self.original_state_dict = {}
         self.mappings = {}
 
-    def init(
+    def set_up_planner(
         self,
         state_dict: STATE_DICT_TYPE,
         metadata: Metadata,

--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -100,7 +100,7 @@ class SavePlanner(abc.ABC):
 
     A planner subclass can expect the following sequence of calls during save_state_dict:
 
-    1) init - called on all ranks.
+    1) set_up_planner - called on all ranks.
         Signals the start of a checkpoint save.
 
     2) create_local_plan - called on all ranks.
@@ -125,9 +125,9 @@ class SavePlanner(abc.ABC):
 
     >>> # xdoctest: +SKIP("undefined vars")
     >>> class RenamePlanner(DefaultSavePlanner):
-    >>>     def init(self, state_dict, is_coordinator):
+    >>>     def set_up_planner(self, state_dict, is_coordinator):
     >>>         # prefix all keys with `foo_``
-    >>>         super().init(self, {"foo_" + k: v for k, v in state_dict.items()}, is_coordinator)
+    >>>         super().set_up_planner(self, {"foo_" + k: v for k, v in state_dict.items()}, is_coordinator)
 
     Modifying local plan and lookup in tandem. This is useful when fine control of how data is persisted
 
@@ -179,7 +179,7 @@ class SavePlanner(abc.ABC):
     """
 
     @abc.abstractmethod
-    def init(self, state_dict: STATE_DICT_TYPE, is_coordinator: bool) -> None:
+    def set_up_planner(self, state_dict: STATE_DICT_TYPE, is_coordinator: bool) -> None:
         """
         Intialize this planner to save ``state_dict``.
 
@@ -253,7 +253,7 @@ class LoadPlanner:
 
     A planner subclass can expect the following sequence of calls during load_state_dict:
 
-    1) init - called on all ranks.
+    1) set_up_planner - called on all ranks.
         Signals the start of loading a checkpoint.
 
     2) create_local_plan - called on all ranks.
@@ -280,9 +280,9 @@ class LoadPlanner:
 
     >>> # xdoctest: +SKIP("undefined vars")
     >>> class RenamePlanner(DefaultLoadPlanner):
-    >>>     def init(self, state_dict, metadata, is_coordinator):
+    >>>     def set_up_planner(self, state_dict, metadata, is_coordinator):
     >>>         self.original_state_dict = state_dict
-    >>>         super().init(self, {"foo_" + k: v for k, v in state_dict.items()}, is_coordinator)
+    >>>         super().set_up_planner(self, {"foo_" + k: v for k, v in state_dict.items()}, is_coordinator)
     >>>
     >>>     def load_bytes(self, read_item, value):
     >>>         # Remove the "foo_" prefix
@@ -302,7 +302,7 @@ class LoadPlanner:
     """
 
     @abc.abstractmethod
-    def init(
+    def set_up_planner(
         self,
         state_dict: STATE_DICT_TYPE,
         metadata: Metadata,
@@ -318,7 +318,7 @@ class LoadPlanner:
     @abc.abstractmethod
     def create_local_plan(self) -> LoadPlan:
         """
-        Create a LoadPlan based on state_dict and metadata provided by init.
+        Create a LoadPlan based on state_dict and metadata provided by set_up_planner.
 
         . N.B. This is called on every rank.
         """

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -91,7 +91,7 @@ def load_state_dict(
     def local_step():
         assert planner is not None
         metadata = storage_reader.read_metadata()
-        planner.init(state_dict, metadata, distW.is_coordinator)
+        planner.set_up_planner(state_dict, metadata, distW.is_coordinator)
         storage_reader.init(metadata, distW.is_coordinator)
 
         local_plan = planner.create_local_plan()

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -85,7 +85,7 @@ def save_state_dict(
 
     def local_step():
         assert planner is not None
-        planner.init(state_dict, distW.is_coordinator)
+        planner.set_up_planner(state_dict, distW.is_coordinator)
         storage_writer.init(distW.is_coordinator)
         local_plan = planner.create_local_plan()
         local_plan = storage_writer.prepare_local_plan(local_plan)


### PR DESCRIPTION
Fixes [#90346](https://github.com/pytorch/pytorch/issues/90346)

Rename init() method in planner to be set_up_planner() to avoid confusion between __init__() and init().
