### PR TITLE
[Docker] Factor GHCR push into its own step

### DIFF
--- a/.circleci/docker/build_docker.sh
+++ b/.circleci/docker/build_docker.sh
@@ -18,7 +18,6 @@ tag="${DOCKER_TAG}"
 
 registry="308535385114.dkr.ecr.us-east-1.amazonaws.com"
 image="${registry}/pytorch/${IMAGE_NAME}"
-ghcr_image="ghcr.io/pytorch/ci-image"
 
 login() {
   aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].authorizationToken' |
@@ -51,13 +50,6 @@ if [ "${DOCKER_SKIP_PUSH:-true}" = "false" ]; then
   # NOTE: The only workflow that should push these images should be the docker-builds.yml workflow
   if ! docker manifest inspect "${image}:${tag}" >/dev/null 2>/dev/null; then
     docker push "${image}:${tag}"
-  fi
-
-  if [ "${PUSH_GHCR_IMAGE:-}" = "true" ]; then
-    # Push docker image to the ghcr.io
-    echo $GHCR_PAT | docker login ghcr.io -u pytorch --password-stdin
-    docker tag "${image}:${tag}" "${ghcr_image}:${IMAGE_NAME}-${tag}"
-    docker push "${ghcr_image}:${IMAGE_NAME}-${tag}"
   fi
 fi
 

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -24,9 +24,6 @@ inputs:
   force_push:
     description: If set to any value, always run the push
     required: false
-  push-ghcr-image:
-    description: If set to any value, push docker image to the ghcr.io.
-    required: false
 
 outputs:
   docker-image:
@@ -106,8 +103,6 @@ runs:
         # Skip push if we don't need it, or if specified in the inputs
         DOCKER_SKIP_PUSH: ${{ steps.check.outputs.skip_push || inputs.skip_push }}
         DOCKER_TAG: ${{ steps.calculate-tag.outputs.docker-tag }}
-        PUSH_GHCR_IMAGE: ${{ inputs.push-ghcr-image }}
-        GHCR_PAT: ${{ env.GHCR_PAT }}
       working-directory: .circleci/docker
       shell: bash
       run: |

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -65,19 +65,37 @@ jobs:
       - name: Build docker image
         id: build-docker-image
         uses: ./.github/actions/calculate-docker-image
-        env:
-          GHCR_PAT: ${{ secrets.GHCR_PAT }}
         with:
           docker-image-name: ${{ matrix.docker-image-name }}
           always-rebuild: true
           skip_push: false
           force_push: true
-          push-ghcr-image: ${{ github.event_name == 'push' }}
 
       - name: Pull docker image
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main
         with:
           docker-image: ${{ steps.build-docker-image.outputs.docker-image }}
+
+      - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
+        name: Push to https://https://ghcr.io/
+        id: push-to-ghcr-io
+        if: ${{ github.event_name == 'push' }}
+        env:
+          ECR_DOCKER_IMAGE: ${{ steps.build-docker-image.outputs.docker-image }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          IMAGE_NAME: ${{ matrix.docker-image-name }}
+        with:
+          shell: bash
+          timeout_minutes: 15
+          max_attempts: 5
+          retry_wait_seconds: 90
+          command: |
+            ghcr_image="ghcr.io/pytorch/ci-image"
+            tag=${ECR_DOCKER_IMAGE##*:}
+            # Push docker image to the ghcr.io
+            echo $GHCR_PAT | docker login ghcr.io -u pytorch --password-stdin
+            docker tag "${ECR_DOCKER_IMAGE}" "${ghcr_image}:${IMAGE_NAME}-${tag}"
+            docker push "${ghcr_image}:${IMAGE_NAME}-${tag}"
 
       - name: Chown workspace
         uses: ./.github/actions/chown-workspace


### PR DESCRIPTION
As I had a really hard time figuring out what is failing in https://github.com/pytorch/pytorch/actions/runs/3987520975/jobs/6837450121

Together with https://github.com/pytorch/pytorch/pull/92816 it will ensure, that even if ghcr upload fails, CI will continue to work

Per @ZainRizvi suggestion added retry logic for the upload step

Test plan: push temp change(https://github.com/pytorch/pytorch/pull/92832/commits/0fe7f8c2ed923827283611b19fe6c1d1910bfdd1)  to validate that this portion of the workflow actually doing the job