### PR TITLE
Fix MPI backend PG initialization

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1534,7 +1534,7 @@ class ProcessGroupWithDispatchedCollectivesTests(MultiProcessTestCase):
 
     def test_init_process_group_for_all_backends(self):
         for backend in dist.Backend.backend_list:
-            # skip is the backend is not available on the system
+            # skip if the backend is not available on the system
             if backend == dist.Backend.UNDEFINED:
                 continue
             elif backend == dist.Backend.MPI:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -972,8 +972,7 @@ def _new_process_group_helper(
             backend_type = ProcessGroup.BackendType.MPI
             if not backend_class:
                 return GroupMember.NON_GROUP_MEMBER
-
-        if backend_str == Backend.GLOO:
+        elif backend_str == Backend.GLOO:
             # TODO: remove this check after lazy initialization is supported
             # if pg_options is not None:
             #     raise RuntimeError("GLOO options not supported")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#92847 Fix MPI backend PG initialization**

Fixes #92573

Add test to check that all default backends can be initialized to prevent the above from regressing in the future.