### PR TITLE
Revert #92688 and #92348 (aot autograd explicitly errors on double backward)

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -332,65 +332,6 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cc.frame_count, 1)
         self.assertTrue(failure_reason is None)
 
-    def test_double_backward_errors(self):
-        # Remove this test after we get double backward to actually work
-        for grad_output in (torch.tensor(1.0, requires_grad=True), None):
-            # See @once_differentiable docs for why there are two different errors
-            x = torch.tensor(1.0, requires_grad=True)
-            err = "torch.compile with aot_autograd does not currently support double backward"
-
-            # The following cases should be equivalent:
-
-            # (1) double backward entirely inside compiled function
-            def f1(x):
-                y = x.sin().exp()
-                (gx,) = torch.autograd.grad(
-                    y, x, create_graph=True, grad_outputs=grad_output
-                )
-                gx.backward()
-                return gx
-
-            compiled_f1 = torch.compile(backend="aot_eager")(f1)
-            f1(x)
-            with self.assertRaisesRegex(RuntimeError, err):
-                compiled_f1(x)
-
-            # (2) the second half of double backward outside compiled function
-            def f2(x):
-                y = x.sin().exp()
-                (gx,) = torch.autograd.grad(
-                    y, x, create_graph=True, grad_outputs=grad_output
-                )
-                return gx
-
-            compiled_f2 = torch.compile(backend="aot_eager")(f2)
-            gx = compiled_f2(x)
-            with self.assertRaisesRegex(RuntimeError, err):
-                gx.backward()
-
-            # (3) double backward entirely outside compiled function
-            def f3(x):
-                y = x.sin().exp()
-                return y
-
-            compiled_f3 = torch.compile(backend="aot_eager")(f3)
-            y = compiled_f3(x)
-            (gx,) = torch.autograd.grad(
-                y, x, create_graph=True, grad_outputs=grad_output
-            )
-            with self.assertRaisesRegex(RuntimeError, err):
-                gx.backward()
-
-        # create_graph=False
-        def f4(x):
-            y = x.sin().exp()
-            return y
-
-        compiled_f4 = torch.compile(backend="aot_eager")(f4)
-        x = torch.tensor(1.0, requires_grad=True)
-        y = compiled_f4(x)
-        (gx,) = torch.autograd.grad(y, x, create_graph=False, grad_outputs=grad_output)
-
     @patch("torch._functorch.config.debug_assert", True)
     def test_arg_dupe_via_dynamo_recompiles(self):
         class F(torch.nn.Module):

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1858,44 +1858,22 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig):
                 list(ctx.symints) + list(ctx.saved_tensors) + list(contiguous_args)
             )
             del contiguous_args
+            if CompiledFunction.compiled_bw is None:
+                # TODO - pass in fake tensors ?
+                context = disable_autocast_manager if disable_amp else nullcontext
+                with context(), track_graph_compiling(aot_config, "backward"):
+                    CompiledFunction.compiled_bw = aot_config.bw_compiler(
+                        bw_module, all_args
+                    )
 
-            def call_compiled_backward(all_args):
-                all_args_list = list(all_args)
-                if CompiledFunction.compiled_bw is None:
-                    # TODO - pass in fake tensors ?
-                    context = disable_autocast_manager if disable_amp else nullcontext
-                    with context(), track_graph_compiling(aot_config, "backward"):
-                        CompiledFunction.compiled_bw = aot_config.bw_compiler(
-                            bw_module, all_args_list
-                        )
-
-                ctx.maybe_clear_saved_tensors()
-                out = call_func_with_args(
-                    CompiledFunction.compiled_bw,
-                    all_args_list,
-                    steal_args=True,
-                    disable_amp=disable_amp,
-                )
-                return tuple(out)
-
-            if torch.is_grad_enabled() and any(t.requires_grad for t in all_args if isinstance(t, torch.Tensor)):
-                # If backward pass was run with create_graph=True, ensure that the graph is
-                # properly connected, but errors when the user performs double backward.
-                # See comment for why once_differentiable is not sufficient:
-                # https://github.com/pytorch/pytorch/pull/92348/files#r1072962107
-                class CompiledFunctionBackward(torch.autograd.Function):
-                    @staticmethod
-                    def forward(ctx, *all_args):
-                        return call_compiled_backward(all_args)
-
-                    @staticmethod
-                    def backward(ctx, *args):
-                        raise RuntimeError("torch.compile with aot_autograd does not currently support double backward")
-
-                out = CompiledFunctionBackward.apply(*all_args)
-            else:
-                out = call_compiled_backward(all_args)
-            return out
+            ctx.maybe_clear_saved_tensors()
+            out = call_func_with_args(
+                CompiledFunction.compiled_bw,
+                all_args,
+                steal_args=True,
+                disable_amp=disable_amp,
+            )
+            return tuple(out)
 
     @wraps(CompiledFunction.apply)
     def compiled_function(*args):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92604
* #92734
* __->__ #92863


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire