### PR TITLE
Fix #92108

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3074,9 +3074,7 @@ class Convolution(ExternKernelAlloc):
 
     def codegen(self, wrapper):
         if self.kernel.startswith("triton_ops."):
-            wrapper.header.writeline(
-                f"from {config.inductor_import} import triton_ops"
-            )
+            wrapper.header.writeline(f"from {config.inductor_import} import triton_ops")
         wrapper.writeline(
             f"{self.get_name()} = {self.kernel}({', '.join(self.codegen_args())})"
         )

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3073,9 +3073,9 @@ class Convolution(ExternKernelAlloc):
         self.preferred_stride_order = preferred_stride_order
 
     def codegen(self, wrapper):
-        if self.kernel == "triton_ops.conv":
+        if self.kernel.startswith("triton_ops."):
             wrapper.header.writeline(
-                f"import {config.inductor_import}.triton_ops.conv as {self.kernel}"
+                f"from {config.inductor_import} import triton_ops"
             )
         wrapper.writeline(
             f"{self.get_name()} = {self.kernel}({', '.join(self.codegen_args())})"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92870

You can easily test this by adding

```
@patch.object(config.triton, "convolution", "triton")
```

to test_convolution1 but it takes a long time to autotune so
I don't want to add it to the unit tests.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire