### PR TITLE
[FSDP] Fix `no_sync()`, `use_orig_params=True`, mixed precision, sharded

### DIFF
--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -1073,7 +1073,7 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
         )
 
     def _test_no_sync_correctness(self, sharding_strategy: ShardingStrategy):
-        model = nn.Linear(3, 3, bias=False, device="cuda")
+        model = nn.Linear(3, 3, device="cuda")
         fsdp_kwargs = {
             "sharding_strategy": sharding_strategy,
         }
@@ -1135,7 +1135,9 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
             param.grad.detach().clone() for param in model_use_flat_params.parameters()
         ]
         ref_grads_use_orig_params = [
-            param.grad.detach().clone() for param in model_use_orig_params.parameters()
+            param.grad.detach().clone()
+            for param in model_use_orig_params.parameters()
+            if param.grad is not None
         ]
 
         # Run a forward/backward in `no_sync()`
@@ -1159,7 +1161,9 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
             param.grad.detach().clone() for param in model_use_flat_params.parameters()
         ]
         grads_use_orig_params = [
-            param.grad.detach().clone() for param in model_use_orig_params.parameters()
+            param.grad.detach().clone()
+            for param in model_use_orig_params.parameters()
+            if param.grad is not None
         ]
         for grad, ref_grad in zip(grads_use_flat_params, ref_grads_use_flat_params):
             torch.testing.assert_close(grad, 2 * ref_grad)
@@ -1184,7 +1188,7 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
         )
 
     def _test_no_sync_mixed_precision(self, sharding_strategy: ShardingStrategy):
-        model = nn.Linear(3, 3, bias=False, device="cuda")
+        model = nn.Linear(3, 3, device="cuda")
         mixed_precision = MixedPrecision(
             param_dtype=torch.float16,
             reduce_dtype=torch.float32,

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1486,9 +1486,7 @@ class FlatParamHandle:
                 f"{self.flat_param._fqns[i]} is missing",
             )
             param = getattr(module, param_name)
-            if param.shape != view.shape or (
-                param.dtype != view.dtype and not self.uses_sharded_strategy
-            ):
+            if param.shape != view.shape or param.dtype != view.dtype:
                 # NOTE: This is a hack using `.data` to side step the
                 # check that parameter/gradient sizes and dtypes match. Here,
                 # `param` can have the sharded size, and `grad` can have the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#92874 [FSDP] Fix `no_sync()`, `use_orig_params=True`, mixed precision, sharded**
* #92779 [PT-D][Lint] Include nested directories to ufmt
* #92296 [FSDP][1/N] Split `fully_shard` unit tests

When there is an original parameter with 1D shape that is fully assigned to one rank, then its `param.shape == view.shape` in `_use_unsharded_grad_views()`. In that case, we still want to check whether `param.dtype == view.dtype` and bypass as necessary.

The previous PR had an additional `and not self.uses_sharded_strategy` because the unit test did not require the check for sharded strategies, and I was conservatively adding a minimal fix. This was happenstance and because there was no 1D parameter fully assigned to one rank. Including the bias in the linear layer achieves that case, and removing the `and not self.uses_sharded_strategy` is necessary.