### PR TITLE
[inductor] Clean up TRITON_CACHE_DIR

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -507,13 +507,6 @@ class PyCodeCache:
         return cls.cache[key]
 
 
-@functools.lru_cache(None)
-def patch_triton_dir():
-    os.environ["TRITON_CACHE_DIR"] = os.environ.get(
-        "TRITON_CACHE_DIR", os.path.join(cache_dir(), "triton")
-    )
-
-
 class TritonCodeCache:
     @staticmethod
     def get_name(mod):
@@ -522,7 +515,6 @@ class TritonCodeCache:
 
     @classmethod
     def load(cls, source_code):
-        patch_triton_dir()
         mod = PyCodeCache.load(source_code)
         return getattr(mod, cls.get_name(mod))
 


### PR DESCRIPTION
Summary:
As a follow up in https://github.com/pytorch/pytorch/pull/92664 (D42619405 (https://github.com/pytorch/pytorch/commit/e6a8267cf54af30e33de1ef22625e972afbf03ff)), clean up the TRITON_CACHE_DIR settings. There are a few places touching TRITON_CACHE_DIR:

1. triton/fb/triton_util.py: when import triton
2. caffe2/torch/_inductor/codecache.py
3. caffe2/torch/_inductor/triton_ops/autotune.py
4. triton/triton/python/triton/compiler.py

IIUC there are two entry points:
* kernel.run(args): 1 -> 3 -> 4
* async_compile(kernel): 1 -> 2 -> 3 -> 4
* calling triton jit-annoated func directly: 4

I'm removing the TRITON_CACHE_DIR in 1 and 2.

Test Plan: Run local repro

Differential Revision: D42694374



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire