### PR TITLE
remove default implementation for RoIAlignRotatedOp::RunOnDevice

### DIFF
--- a/caffe2/operators/roi_align_rotated_op.h
+++ b/caffe2/operators/roi_align_rotated_op.h
@@ -35,9 +35,7 @@ class RoIAlignRotatedOp final : public Operator<Context> {
   }
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
-  bool RunOnDevice() override {
-    CAFFE_NOT_IMPLEMENTED;
-  }
+  bool RunOnDevice() override;
 
  protected:
   StorageOrder order_;


### PR DESCRIPTION
Summary: the default implementation is not needed as there are template specialization defined in the cpp and cu files.

Test Plan: CI

Differential Revision: D42697874

