### PR TITLE
[ROCm] Also look for 'Cijk' (rocblas kernel) to verify gemm in test_kineto

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -739,7 +739,7 @@ class TestProfiler(TestCase):
         for e in p.function_events:
             if "aten::mm" in e.name:
                 found_mm = True
-            if "gemm" in e.name:
+            if "gemm" in e.name or "Cijk" in e.name:
                 found_gemm = True
             if "Memcpy" in e.name or "memcpy" in e.name:
                 found_memcpy = True


### PR DESCRIPTION
PR #88207 enabled ActivityType::CUDA for ROCm. TestProfiler.test_kineto needs an update in the test code to look for the correct pattern for gemm kernels for ROCm.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @mwootton 