### PR TITLE
Raise runtime error if dynamo is imported on 3.11+

### DIFF
--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -1,3 +1,7 @@
+import sys
+if sys.version_info >= (3, 11):
+    raise RuntimeError("torch._dynamo does not work on Python-3.11+ yet")
+
 from . import allowed_functions, convert_frame, eval_frame, resume_execution
 from .convert_frame import replay
 from .eval_frame import (


### PR DESCRIPTION
IMO better than:
```
  File "/opt/conda/envs/py_3.11/lib/python3.11/site-packages/torch/_dynamo/__init__.py", line 1, in <module>
    from . import allowed_functions, convert_frame, eval_frame, resume_execution
  File "/opt/conda/envs/py_3.11/lib/python3.11/site-packages/torch/_dynamo/convert_frame.py", line 14, in <module>
    from .bytecode_analysis import remove_dead_code, remove_pointless_jumps
  File "/opt/conda/envs/py_3.11/lib/python3.11/site-packages/torch/_dynamo/bytecode_analysis.py", line 8, in <module>
    dis.opmap["JUMP_ABSOLUTE"],
    ~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'JUMP_ABSOLUTE'
```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire