### PR TITLE
[Reland] aot autograd explicitly errors on double backward 

### DIFF
--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1860,22 +1860,46 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig):
                 list(ctx.symints) + list(ctx.saved_tensors) + list(contiguous_args)
             )
             del contiguous_args
-            if CompiledFunction.compiled_bw is None:
-                # TODO - pass in fake tensors ?
-                context = disable_autocast_manager if disable_amp else nullcontext
-                with context(), track_graph_compiling(aot_config, "backward"):
-                    CompiledFunction.compiled_bw = aot_config.bw_compiler(
-                        bw_module, all_args
-                    )
 
-            ctx.maybe_clear_saved_tensors()
-            out = call_func_with_args(
-                CompiledFunction.compiled_bw,
-                all_args,
-                steal_args=True,
-                disable_amp=disable_amp,
-            )
-            return tuple(out)
+            def call_compiled_backward(all_args):
+                if CompiledFunction.compiled_bw is None:
+                    # TODO - pass in fake tensors ?
+                    context = disable_autocast_manager if disable_amp else nullcontext
+                    with context(), track_graph_compiling(aot_config, "backward"):
+                        CompiledFunction.compiled_bw = aot_config.bw_compiler(
+                            bw_module, all_args
+                        )
+
+                ctx.maybe_clear_saved_tensors()
+                out = call_func_with_args(
+                    CompiledFunction.compiled_bw,
+                    all_args,
+                    steal_args=True,
+                    disable_amp=disable_amp,
+                )
+
+                return tuple(out)
+
+            if torch.is_grad_enabled() and any(t.requires_grad for t in all_args if isinstance(t, torch.Tensor)):
+                # If backward pass was run with create_graph=True, ensure that the graph is
+                # properly connected, but errors when the user performs double backward.
+                # See comment for why once_differentiable is not sufficient:
+                # https://github.com/pytorch/pytorch/pull/92348/files#r1072962107
+                class CompiledFunctionBackward(torch.autograd.Function):
+                    @staticmethod
+                    def forward(ctx, *all_args):
+                        all_args_list = list(all_args)
+                        del all_args
+                        return call_compiled_backward(all_args_list)
+
+                    @staticmethod
+                    def backward(ctx, *args):
+                        raise RuntimeError("torch.compile with aot_autograd does not currently support double backward")
+
+                out = CompiledFunctionBackward.apply(*all_args)
+            else:
+                out = call_compiled_backward(all_args)
+            return out
 
     @wraps(CompiledFunction.apply)
     def compiled_function(*args):

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1886,15 +1886,14 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig):
                 # https://github.com/pytorch/pytorch/pull/92348/files#r1072962107
                 class CompiledFunctionBackward(torch.autograd.Function):
                     @staticmethod
-                    def forward(ctx, unused):
-                        del unused
+                    def forward(ctx, *unused_args):
                         return call_compiled_backward()
 
                     @staticmethod
                     def backward(ctx, *args):
                         raise RuntimeError("torch.compile with aot_autograd does not currently support double backward")
-                # Pass a tensor that requires grad so autograd Function knows to create the graph
-                out = CompiledFunctionBackward.apply(torch.empty([], requires_grad=True))
+                # Pass args even though they're unused, so that the graph is built
+                out = CompiledFunctionBackward.apply(*all_args)
             else:
                 out = call_compiled_backward()
             return out


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #92893

This reverts commit fb980581a7b41a5ea570fcb03829463b806b3bbc.

Testing: `python benchmarks/dynamo/timm_models.py  --float32 --training --only=mobilevit_s --performance --inductor --disable-cudagraphs`

```
main:               memory: eager: 12.30 GB, dynamo: 12.28 GB, ratio: 1.00
+ #90896 reverted:  memory: eager: 12.30 GB, dynamo: 8.81 GB, ratio: 1.40
+ this PR:          memory: eager: 12.30 GB, dynamo: 8.81 GB, ratio: 1.40
```

For comparison, if we apply old version of this PR instead:
```
main: 
+ #90896 reverted:         memory: eager: 12.30 GB, dynamo: 8.81 GB, ratio: 1.40
+ old version of this PR   memory: eager: 12.30 GB, dynamo: 10.36 GB, ratio: 1.19
```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire