### PR TITLE
Make `torch.fx` compatible with Python-3.11

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -3336,6 +3336,7 @@ class TestFX(JitTestCase):
         finally:
             del sys.modules["__future__"]
 
+    @unittest.skipIf(sys.version_info > (3, 11), "Does not work in 3.11")
     def test_annotations_empty_tuple(self):
         class Foo(torch.nn.Module):
             def forward(self, x: Tuple[()], y: Tuple[str, Tuple[()]]):
@@ -4118,7 +4119,7 @@ class TestFunctionalTracing(JitTestCase):
 
         def functional_test(self):
             if func_name in self.UNTRACEABLE_FUNCTIONALS_PY38 and \
-                    sys.version_info >= (3, 8) and sys.version_info < (3, 11):
+                    sys.version_info >= (3, 8) and sys.version_info < (3, 12):
                 exc, err = self.UNTRACEABLE_FUNCTIONALS_PY38[func_name]
                 with self.assertRaisesRegex(exc, err):
                     symbolic_trace(fn)

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -119,7 +119,28 @@ def _patch_function(fn: FunctionType, nargs: int) -> FunctionType:
     co = fn.__code__
     co_flags = co.co_flags & ~HAS_VARSTUFF
     co_args: tuple
-    if hasattr(co, "co_posonlyargcount"):
+    if hasattr(co, "co_qualname"):
+        co_args = (
+            nargs,
+            0,
+            0,
+            co.co_nlocals,
+            co.co_stacksize,
+            co_flags,
+            co.co_code,
+            co.co_consts,
+            co.co_names,
+            co.co_varnames,
+            co.co_filename,
+            co.co_name,
+            co.co_qualname,
+            co.co_firstlineno,
+            co.co_lnotab,
+            co.co_exceptiontable,
+            co.co_freevars,
+            co.co_cellvars,
+        )
+    elif hasattr(co, "co_posonlyargcount"):
         co_args = (
             nargs,
             0,

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -120,6 +120,7 @@ def _patch_function(fn: FunctionType, nargs: int) -> FunctionType:
     co_flags = co.co_flags & ~HAS_VARSTUFF
     co_args: tuple
     if hasattr(co, "co_qualname"):
+        # Python-3.11+ code signature
         co_args = (
             nargs,
             0,
@@ -133,10 +134,10 @@ def _patch_function(fn: FunctionType, nargs: int) -> FunctionType:
             co.co_varnames,
             co.co_filename,
             co.co_name,
-            co.co_qualname,
+            co.co_qualname,  # type: ignore[attr-defined]
             co.co_firstlineno,
             co.co_lnotab,
-            co.co_exceptiontable,
+            co.co_exceptiontable,  # type: ignore[attr-defined]
             co.co_freevars,
             co.co_cellvars,
         )

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -64,19 +64,29 @@ def _torchscript_type_to_python_type(ts_type : 'torch._C.JitType') -> Any:
     return eval(ts_type.annotation_str, _type_eval_globals)
 
 def _torchscript_schema_to_signature(ts_schema : torch._C.FunctionSchema) -> inspect.Signature:
-    parameters : List[inspect.Parameter] = []
+    from inspect import Parameter
+    parameters : List[Parameter] = []
     for arg in ts_schema.arguments:
         arg_type = _torchscript_type_to_python_type(arg.type)
-        default = arg.default_value if arg.has_default_value() else inspect.Parameter.empty
+        default = arg.default_value if arg.has_default_value() else Parameter.empty
         # TODO: Figure out if this is safe. It seems like when generating the type signatures for
         # PythonArgParser, we emit signatures with `input` instead of `self` as the first tensor
         # argument name. Downstream, if someone converts that positional argument to a keyword
         # argument, the name mismatch will break things, so here we're going to normalize the
         # name to "input"
-        # In a similar vein, rename `from` to `from_` as former is Python keyword.
-        name = arg.name if arg.name not in ('self', 'from') else ('input' if arg.name == 'self' else 'from_')
-        kind = inspect.Parameter.KEYWORD_ONLY if arg.kwarg_only else inspect.Parameter.POSITIONAL_OR_KEYWORD
-        parameters.append(inspect.Parameter(name=name, kind=kind, default=default, annotation=arg_type))
+        name = arg.name if arg.name != 'self' else 'input'
+        kind = Parameter.KEYWORD_ONLY if arg.kwarg_only else Parameter.POSITIONAL_OR_KEYWORD
+        # "from" is a keyword therefore it must be a POSITIONAL_ONLY argument
+        if name == "from":
+            assert kind == Parameter.POSITIONAL_OR_KEYWORD
+            # ParameterKind type is internal implementation detail to inspec package
+            # which makes it hard to do type annoation
+            kind = Parameter.POSITIONAL_ONLY  # type: ignore[assignment]
+            # This renders all previous arguments to positional only
+            for idx, p in enumerate(parameters):
+                assert p.kind == Parameter.POSITIONAL_OR_KEYWORD
+                parameters[idx] = Parameter(name=p.name, kind=Parameter.POSITIONAL_ONLY, default=p.default, annotation=p.annotation)
+        parameters.append(Parameter(name=name, kind=kind, default=default, annotation=arg_type))
     return_types = [_torchscript_type_to_python_type(ret.type) for ret in ts_schema.returns]
     if len(return_types) == 0:
         return_type = None
@@ -396,7 +406,12 @@ def _args_kwargs_to_normalized_args_kwargs(sig : inspect.Signature, args : Tuple
     supported_parameter_types = {
         inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY}
     if any(p.kind not in supported_parameter_types for p in sig.parameters.values()):
-        return None
+        # Add an exception for one signature, which is common for random/uniform, i.e.:
+        # Tensor(a!) self, float from=0, float to=1, *, Generator? generator=None
+        # `from` is Python keyword and as such functions with that signature should have
+        # positional-only args, but at the same time they could be dispatched as kwargs
+        if list(sig.parameters.keys()) != ['input', 'from', 'to', 'generator']:
+            return None
 
     bound_args = sig.bind(*args, **kwargs)
     bound_args.apply_defaults()

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -73,7 +73,8 @@ def _torchscript_schema_to_signature(ts_schema : torch._C.FunctionSchema) -> ins
         # argument name. Downstream, if someone converts that positional argument to a keyword
         # argument, the name mismatch will break things, so here we're going to normalize the
         # name to "input"
-        name = arg.name if arg.name != 'self' else 'input'
+        # In a similar vein, rename `from` to `from_` as former is Python keyword.
+        name = arg.name if arg.name not in ('self', 'from') else ('input' if arg.name == 'self' else 'from_')
         kind = inspect.Parameter.KEYWORD_ONLY if arg.kwarg_only else inspect.Parameter.POSITIONAL_OR_KEYWORD
         parameters.append(inspect.Parameter(name=name, kind=kind, default=default, annotation=arg_type))
     return_types = [_torchscript_type_to_python_type(ret.type) for ret in ts_schema.returns]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #92787
* __->__ #92895

In 3.11 bytecode size is not constant, so in order to get from `f_lasti` to opcode index, one need to search for the closes offset in disassembled instructions.

Update `_patch_function` to construct code with all the properties that exist in 3.11 runtime.
Update `_torchscript_schema_to_signature` to mark `from` named arg as positional argument only, as this is a reserved keyword in Python and as such checked by `inspect` package in 3.11