### PR TITLE
Gramatically updated the tech docs

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -680,7 +680,7 @@ class TypedStorage:
         return self._new_wrapped_storage(self._untyped_storage.cpu())
 
     def pin_memory(self):
-        """Coppies the  storage to pinned memory, if it's not already pinned."""
+        """Copies the  storage to pinned memory, if it's not already pinned."""
         _warn_typed_storage_removal()
         return self._new_wrapped_storage(self._untyped_storage.pin_memory())
 


### PR DESCRIPTION
Small typo change in the torch tech docs
<img width="1209" alt="Torch storage doc" src="https://user-images.githubusercontent.com/76240270/214272201-5e9cce2a-13cf-48b7-8806-9c492a0eb665.png">

