### PR TITLE
address multiple definition of kDefaultTimeout linker error with gcc 11

### DIFF
--- a/torch/csrc/distributed/c10d/HashStore.hpp
+++ b/torch/csrc/distributed/c10d/HashStore.hpp
@@ -24,7 +24,7 @@ class TORCH_API HashStore : public Store {
   std::vector<uint8_t> get(const std::string& key) override;
 
   void wait(const std::vector<std::string>& keys) override {
-    wait(keys, Store::kDefaultTimeout);
+    wait(keys, Store::c10d_kDefaultTimeout);
   }
 
   void wait(

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -9,7 +9,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <gloo/rendezvous/store.h>
 #include <gloo/algorithm.h>
 #include <gloo/common/error.h>
 #include <gloo/context.h>
@@ -125,7 +124,7 @@ class TORCH_API ProcessGroupGloo : public Backend {
     }
 
     void wait(const std::vector<std::string>& keys) override {
-      store_->wait(keys, Store::kDefaultTimeout);
+      store_->wait(keys, c10d::Store::c10d_kDefaultTimeout);
     }
 
     void wait(

--- a/torch/csrc/distributed/c10d/Store.cpp
+++ b/torch/csrc/distributed/c10d/Store.cpp
@@ -2,7 +2,7 @@
 
 namespace c10d {
 
-constexpr std::chrono::milliseconds Store::kDefaultTimeout;
+constexpr std::chrono::milliseconds Store::c10d_kDefaultTimeout;
 constexpr std::chrono::milliseconds Store::kNoTimeout;
 
 // Define destructor symbol for abstract base class.

--- a/torch/csrc/distributed/c10d/Store.hpp
+++ b/torch/csrc/distributed/c10d/Store.hpp
@@ -18,12 +18,12 @@ using WatchKeyCallback =
 
 class TORCH_API Store : public torch::CustomClassHolder {
  public:
-  static constexpr std::chrono::milliseconds kDefaultTimeout =
+  static constexpr std::chrono::milliseconds c10d_kDefaultTimeout =
       std::chrono::seconds(300);
   static constexpr std::chrono::milliseconds kNoTimeout =
       std::chrono::milliseconds::zero();
 
-  Store() : timeout_(kDefaultTimeout) {}
+  Store() : timeout_(c10d_kDefaultTimeout) {}
 
   explicit Store(const std::chrono::milliseconds& timeout)
       : timeout_(timeout) {}

--- a/torch/csrc/distributed/c10d/TCPStore.hpp
+++ b/torch/csrc/distributed/c10d/TCPStore.hpp
@@ -29,7 +29,7 @@ struct TCPStoreOptions {
   bool isServer = false;
   c10::optional<std::size_t> numWorkers = c10::nullopt;
   bool waitWorkers = true;
-  std::chrono::milliseconds timeout = Store::kDefaultTimeout;
+  std::chrono::milliseconds timeout = Store::c10d_kDefaultTimeout;
 
   // A boolean value indicating whether multiple store instances can be
   // initialized with the same host:port pair.
@@ -45,7 +45,7 @@ class TORCH_API TCPStore : public Store {
       std::uint16_t masterPort,
       c10::optional<int> numWorkers = c10::nullopt,
       bool isServer = false,
-      const std::chrono::milliseconds& timeout = kDefaultTimeout,
+      const std::chrono::milliseconds& timeout = c10d_kDefaultTimeout,
       bool waitWorkers = true);
 
   virtual ~TCPStore();

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1135,7 +1135,7 @@ Example::
           // prevents accidental implicit conversion to bool
           py::arg("is_master").noconvert() = false,
           py::arg("timeout") =
-              std::chrono::milliseconds(::c10d::Store::kDefaultTimeout),
+              std::chrono::milliseconds(::c10d::Store::c10d_kDefaultTimeout),
           py::arg("wait_for_workers") = true,
           py::arg("multi_tenant") = false)
       .def_property_readonly(


### PR DESCRIPTION
Changes necessary to build locally with gcc v11.3 see issue linked below for description of ld error encountered with post v9.5 of gcc.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>

Fixes #91328

