### PR TITLE
Call module's function rather than module class's

### DIFF
--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -218,13 +218,12 @@ class NNModuleVariable(VariableTracker):
                     "Must provide a valid source in order to inline, "
                     "since inlined function may have default args which must be guarded."
                 )
-                class_source = AttrSource(self.source, "__class__")
                 if is_lazy:
-                    fn = mod.__class__.__call__
-                    fn_source = AttrSource(class_source, "__call__")
+                    fn = mod.__call__.__func__
+                    fn_source = AttrSource(AttrSource(self.source, "__call__"), "__func__")
                 else:
-                    fn = mod.__class__.forward
-                    fn_source = AttrSource(class_source, "forward")
+                    fn = mod.forward.__func__
+                    fn_source = AttrSource(AttrSource(self.source, "forward"), "__func__")
                 options["source"] = fn_source
                 return tx.inline_user_function_return(
                     variables.UserFunctionVariable(fn, **options),

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -218,13 +218,16 @@ class NNModuleVariable(VariableTracker):
                     "Must provide a valid source in order to inline, "
                     "since inlined function may have default args which must be guarded."
                 )
-                class_source = AttrSource(self.source, "__class__")
                 if is_lazy:
-                    fn = mod.__class__.__call__
-                    fn_source = AttrSource(class_source, "__call__")
+                    fn = mod.__call__.__func__
+                    fn_source = AttrSource(
+                        AttrSource(self.source, "__call__"), "__func__"
+                    )
                 else:
-                    fn = mod.__class__.forward
-                    fn_source = AttrSource(class_source, "forward")
+                    fn = mod.forward.__func__
+                    fn_source = AttrSource(
+                        AttrSource(self.source, "forward"), "__func__"
+                    )
                 options["source"] = fn_source
                 return tx.inline_user_function_return(
                     variables.UserFunctionVariable(fn, **options),


### PR DESCRIPTION
Fixes cases where users patch a module's forward function which is originally unimplemented. 

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire