### PR TITLE
[Vulkan][Optimize for Mobile] Avoid dereferencing element [0] if the vector is empty

### DIFF
--- a/torch/csrc/jit/passes/vulkan_rewrite.cpp
+++ b/torch/csrc/jit/passes/vulkan_rewrite.cpp
@@ -105,7 +105,8 @@ void transferInputOutputBackends(std::shared_ptr<Graph>& graph) {
   // Move inputs to Vulkan backend
   for (Value* input : graph->inputs()) {
     NamedValue named_input = NamedValue("", input);
-    if (named_input.type()->kind() == TypeKind::TensorType) {
+    if (named_input.type()->kind() == TypeKind::TensorType &&
+        !input->uses().empty()) {
       // find the insertion point
       WithInsertPoint ip(input->uses()[0].user->prev());
       Value* replaced_input = graph->insert(


### PR DESCRIPTION
Summary:
Avoid dereferencing element [0] if the vector is empty.
___

In ```transferInputOutputBackends```, one of the rewrite passes for Vulkan ```optimize_for_mobile```, an out of bounds access happens when trying to insert a backend transfer for an input if that input's ```uses()``` is empty. This diff corrects that issue.

Test Plan:
Run tests
___

Phabricator + CI Tests

Reviewed By: SS-JIA

Differential Revision: D41296037

