### PR TITLE
[CI] Rename TSAN job

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -157,25 +157,25 @@ jobs:
       docker-image: ${{ needs.linux-bionic-py3_7-clang9-slow-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-py3_7-clang9-slow-build.outputs.test-matrix }}
 
-  linux-focal-py3_7-clang7-tsan-build:
-    name: linux-focal-py3.7-clang7-tsan
+  linux-focal-py3_9-clang7-tsan-build:
+    name: linux-focal-py3.9-clang7-tsan
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-py3.7-clang7-tsan
+      build-environment: linux-focal-py3.9-clang7-tsan
       docker-image-name: pytorch-linux-focal-py3-clang7-asan
       test-matrix: |
         { include: [
           { config: "tsan", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
         ]}
 
-  linux-focal-py3_7-clang7-tsan-test:
-    name: linux-focal-py3.7-clang7-tsan
+  linux-focal-py3_9-clang7-tsan-test:
+    name: linux-focal-py3.9-clang7-tsan
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-focal-py3_7-clang7-tsan-build
+    needs: linux-focal-py3_9-clang7-tsan-build
     with:
-      build-environment: linux-focal-py3.7-clang7-tsan
-      docker-image: ${{ needs.linux-focal-py3_7-clang7-tsan-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-py3_7-clang7-tsan-build.outputs.test-matrix }}
+      build-environment: linux-focal-py3.9-clang7-tsan
+      docker-image: ${{ needs.linux-focal-py3_9-clang7-tsan-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-py3_9-clang7-tsan-build.outputs.test-matrix }}
 
   ios-12-5-1-x86-64:
     name: ios-12-5-1-x86-64


### PR DESCRIPTION
Underlying docker has actually been migrated from py3_7 to py3_9 as part of https://github.com/pytorch/pytorch/pull/92712 but I forgot to update the TSAN names.

I.e. this is a no-op.

