### PR TITLE
[FSDP] Test FSDP + AC composability

### DIFF
--- a/test/distributed/fsdp/test_fsdp_checkpoint.py
+++ b/test/distributed/fsdp/test_fsdp_checkpoint.py
@@ -110,10 +110,15 @@ class TestFSDPCheckpoint(FSDPTest):
         sharding_strategy: ShardingStrategy,
     ) -> bool:
         if fsdp_checkpoint_model_init_fn in (
-            self._init_fsdp_checkpoint_model4,
             self._init_fsdp_checkpoint_model5,
             self._init_fsdp_checkpoint_model6,
             self._init_fsdp_checkpoint_model7,
+        ):
+            return True
+        if (
+            fsdp_checkpoint_model_init_fn == self._init_fsdp_checkpoint_model4
+            and checkpoint_fn
+            in (_checkpoint_wrapper_reentrant, _utils_checkpoint_reentrant)
         ):
             return True
         return False

--- a/test/distributed/fsdp/test_fsdp_checkpoint.py
+++ b/test/distributed/fsdp/test_fsdp_checkpoint.py
@@ -110,15 +110,16 @@ class TestFSDPCheckpoint(FSDPTest):
         sharding_strategy: ShardingStrategy,
     ) -> bool:
         if fsdp_checkpoint_model_init_fn in (
-            self._init_fsdp_checkpoint_model5,
             self._init_fsdp_checkpoint_model6,
             self._init_fsdp_checkpoint_model7,
         ):
             return True
-        if (
-            fsdp_checkpoint_model_init_fn == self._init_fsdp_checkpoint_model4
-            and checkpoint_fn
-            in (_checkpoint_wrapper_reentrant, _utils_checkpoint_reentrant)
+        if fsdp_checkpoint_model_init_fn in (
+            self._init_fsdp_checkpoint_model4,
+            self._init_fsdp_checkpoint_model5,
+        ) and checkpoint_fn in (
+            _checkpoint_wrapper_reentrant,
+            _utils_checkpoint_reentrant,
         ):
             return True
         return False

--- a/test/distributed/fsdp/test_fsdp_checkpoint.py
+++ b/test/distributed/fsdp/test_fsdp_checkpoint.py
@@ -109,9 +109,15 @@ class TestFSDPCheckpoint(FSDPTest):
         use_orig_params: bool,
         sharding_strategy: ShardingStrategy,
     ) -> bool:
-        if fsdp_checkpoint_model_init_fn in (
-            self._init_fsdp_checkpoint_model6,
-            self._init_fsdp_checkpoint_model7,
+        if fsdp_checkpoint_model_init_fn in (self._init_fsdp_checkpoint_model6,):
+            return True
+        if (
+            fsdp_checkpoint_model_init_fn == self._init_fsdp_checkpoint_model7
+            and checkpoint_fn
+            in (
+                _checkpoint_wrapper_nonreentrant,
+                _utils_checkpoint_nonreentrant,
+            )
         ):
             return True
         if fsdp_checkpoint_model_init_fn in (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#92935 [FSDP] Test FSDP + AC composability**
* #92779 [PT-D][Lint] Include nested directories to ufmt
* #92296 [FSDP][1/N] Split `fully_shard` unit tests

**Overview**
We do not necessarily need to land this PR. The purpose is to test the different ways to compose FSDP with AC and see what breaks and how. This PR excludes the new composable APIs (`fully_shard` and `checkpoint`), which add further dimensionality to the combinations. Those can be explored in future work.

We see that there are cases where reentrant checkpoint works but non-reentrant does not, as well as vice versa. There are also cases where `NO_SHARD` does not raise an error but silently gives incorrect results (possibly because the post-backward hook running all-reduce does not fire).

Each added test that ends with `_raises` marks one module structure and type of checkpoint implementation that raises an error.

**Analysis**
See [`CompositeParamModel`](https://github.com/pytorch/pytorch/blob/aec09eeb3a570bb79c642e8ae540b3981e7d69cd/torch/testing/_internal/common_dist_composable.py#L51) for the base model, which is `model` in the below code snippets.

Strict submodule:
```
model.u1 = checkpoint_fn(model.u1)
return FSDP(model, **fsdp_kwargs)
```
- Reentrant raises error for sharded strategies and has silent correctness errors intermittently
- Non-reentrant works

Consecutive (but not all) submodules:
```
model.u1.l1 = FSDP(model.u1.l1, **fsdp_kwargs)
model.u1.seq = FSDP(model.u1.seq, **fsdp_kwargs)
model.u1 = checkpoint_fn(model.u1)  # FSDP is not applied to `model.u1.l2`
return FSDP(model, **fsdp_kwargs)
```
- Reentrant raises error for sharded strategies and has silent correctness errors intermittently
- Non-reentrant works

Non-consecutive submodules:
```
model.u1.l1 = FSDP(model.u1.l1, **fsdp_kwargs)
model.u1.l2 = FSDP(model.u1.l2, **fsdp_kwargs)
model.u1 = checkpoint_fn(model.u1)
return FSDP(model, **fsdp_kwargs)
```
- Reentrant raises error for sharded strategies and has silent correctness errors intermittently
- Non-reentrant raises error for all strategies (each with a different error message but possibly due to the same root cause)

All consecutive submodules:
```
model.u1.l1 = FSDP(model.u1.l1, **fsdp_kwargs)
model.u1.seq = FSDP(model.u1.seq, **fsdp_kwargs)
model.u1.l2 = FSDP(model.u1.l2, **fsdp_kwargs)
model.u1 = checkpoint_fn(model.u1)
return FSDP(model, **fsdp_kwargs)
```
- Reentrant works
- Non-reentrant raises error (with a different error message for sharded vs. non-sharded strategies but possibly due to the same root cause)

For this PR, `checkpoint_wrapper` and `utils.checkpoint` had the safe behavior. However, we should be cautious when composing with `fully_shard`, which does not have the `FullyShardedDataParallel` to wrap modules and uses forward hooks. Those differences may affect the composability.