### PR TITLE
[package] Add better debugging for torch.package

### DIFF
--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -247,6 +247,8 @@ class TestDependencyAPI(PackageTestCase):
                 * Module did not match against any action pattern. Extern, mock, or intern it.
                     package_a
                     package_a.subpackage
+
+                Set debug=True when invoking PackageExporter for a visualization of where broken modules are coming from!
                 """
             ),
         )
@@ -294,6 +296,8 @@ class TestDependencyAPI(PackageTestCase):
                 * Module is a C extension module. torch.package supports Python modules only.
                     foo
                     bar
+
+                Set debug=True when invoking PackageExporter for a visualization of where broken modules are coming from!
                 """
             ),
         )
@@ -313,6 +317,8 @@ class TestDependencyAPI(PackageTestCase):
                 * Dependency resolution failed.
                     foo
                       Context: attempted relative import beyond top-level package
+
+                Set debug=True when invoking PackageExporter for a visualization of where broken modules are coming from!
                 """
             ),
         )


### PR DESCRIPTION
Summary:
Makes torch.package debugging more transparent by
1. Pointing out not implictily externed modules in the standard library.
2. Creating a debug mode for users to find the source of broken modules.

Test Plan: Run package tests

Differential Revision: D42728753

