### PR TITLE
Disable torch_jit_fuser_te for dynamo CI

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -2807,4 +2807,7 @@ instantiate_device_type_tests(TestLoopnestRandomization, globals(), only_for=("c
 
 
 if __name__ == '__main__':
-    run_tests()
+    if os.getenv("PYTORCH_TEST_WITH_DYNAMO", "0") == "1":
+        print("Crashes with Dynamo, see  https://github.com/pytorch/pytorch/issues/92942")
+    else:
+        run_tests()


### PR DESCRIPTION
Not clear, what caused SIGIOT, but we need to get signal from other tests (and NNC+Dynamo is probably not the most important usecase)