### PR TITLE
[ROCm] Added MIOpen header files to installation package for ROCm.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1064,6 +1064,7 @@ def main():
         'include/ATen/hip/detail/*.cuh',
         'include/ATen/hip/detail/*.h',
         'include/ATen/hip/impl/*.h',
+        'include/ATen/miopen/*.h',
         'include/ATen/detail/*.h',
         'include/ATen/native/*.h',
         'include/ATen/native/cpu/*.h',


### PR DESCRIPTION
Added MIOpen header files to installation package for building Pytorch extensions that requires MIOpen as a dependency.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport