### PR TITLE
Disallow torch.jit in graph, so that it is properly handled by skipfiles

### DIFF
--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -149,6 +149,7 @@ def _allowed_function_ids():
             "torch._C.inductor.",
             "torch.fx.",
             "torch.distributed.fsdp.",
+            "torch.jit",
         )
         allowed_modules_dot = tuple([x + "." for x in allowed_modules])
         module = inspect.getmodule(obj)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/90774 by graph breaking on torch.jit* properly

I attempted to add support for torch.jit.isinstance, but it ended up requiring allowing all of torch.jit tracing which seems non-productive, graph breaking on it allows compilation to succeed.

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire