### PR TITLE
Move the pin to latest to unbreak the xla CI

### DIFF
--- a/.github/ci_commit_pins/xla.txt
+++ b/.github/ci_commit_pins/xla.txt
@@ -1,1 +1,1 @@
-frobenius_norm
+5714e03fdd9d86b9bd9ca684631e95ea2cf65c4f


### PR DESCRIPTION
This should unbreak the XLA CI since we disabled the failing test on our end.

@malfet 