### PR TITLE
Remove try catch in test_torchinductor

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17,6 +17,8 @@ from unittest.mock import patch
 
 import numpy as np
 
+import sympy
+
 import torch
 
 import torch._dynamo
@@ -35,8 +37,6 @@ from torch.testing._internal.common_utils import (
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
-import sympy
-
 importlib.import_module("functorch")
 importlib.import_module("filelock")
 
@@ -48,7 +48,6 @@ from torch._inductor.codegen.cpp import cexpr, CppOverrides, CppVecOverrides
 from torch._inductor.codegen.triton import texpr
 from torch._inductor.compile_fx import compile_fx, complex_memory_overlap
 from torch._inductor.ir import ModularIndexing
-from torch.fx.experimental.symbolic_shapes import FloorDiv
 from torch._inductor.overrides import (
     linear_permute_fusion,
     linear_transpose,
@@ -60,6 +59,7 @@ from torch._inductor.overrides import (
 )
 from torch._inductor.sizevars import SizeVarAllocator
 from torch._inductor.utils import has_torchvision_roi_align, timed
+from torch.fx.experimental.symbolic_shapes import FloorDiv
 
 # This will only pass on pytorch builds newer than roughly 5/15/2022
 assert get_decompositions([torch.ops.aten.trace])

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -35,42 +35,36 @@ from torch.testing._internal.common_utils import (
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
-try:
-    import sympy
+import sympy
 
-    importlib.import_module("functorch")
-    importlib.import_module("filelock")
+importlib.import_module("functorch")
+importlib.import_module("filelock")
 
-    import torch._inductor.config
-    from functorch.compile import config as functorch_config
-    from torch._decomp import get_decompositions
-    from torch._inductor import codecache, config, metrics, test_operators
-    from torch._inductor.codegen.cpp import cexpr, CppOverrides, CppVecOverrides
-    from torch._inductor.codegen.triton import texpr
-    from torch._inductor.compile_fx import compile_fx, complex_memory_overlap
-    from torch._inductor.ir import ModularIndexing
-    from torch.fx.experimental.symbolic_shapes import FloorDiv
-    from torch._inductor.overrides import (
-        linear_permute_fusion,
-        linear_transpose,
-        permute_linear_fusion,
-        permute_matmul_fusion,
-        sink_cat_after_pointwise,
-        transpose_linear,
-        transpose_matmul,
-    )
-    from torch._inductor.sizevars import SizeVarAllocator
-    from torch._inductor.utils import has_torchvision_roi_align, timed
+import torch._inductor.config
+from functorch.compile import config as functorch_config
+from torch._decomp import get_decompositions
+from torch._inductor import codecache, config, metrics, test_operators
+from torch._inductor.codegen.cpp import cexpr, CppOverrides, CppVecOverrides
+from torch._inductor.codegen.triton import texpr
+from torch._inductor.compile_fx import compile_fx, complex_memory_overlap
+from torch._inductor.ir import ModularIndexing
+from torch.fx.experimental.symbolic_shapes import FloorDiv
+from torch._inductor.overrides import (
+    linear_permute_fusion,
+    linear_transpose,
+    permute_linear_fusion,
+    permute_matmul_fusion,
+    sink_cat_after_pointwise,
+    transpose_linear,
+    transpose_matmul,
+)
+from torch._inductor.sizevars import SizeVarAllocator
+from torch._inductor.utils import has_torchvision_roi_align, timed
 
-    # This will only pass on pytorch builds newer than roughly 5/15/2022
-    assert get_decompositions([torch.ops.aten.trace])
-    # Requires functorch
-    from torch._inductor.compile_fx import compile_fx_inner
-except (ImportError, AssertionError) as e:
-    sys.stderr.write(f"{type(e)}: {e}\n")
-    if __name__ == "__main__":
-        sys.exit(0)
-    raise unittest.SkipTest("requires sympy/functorch/filelock") from e
+# This will only pass on pytorch builds newer than roughly 5/15/2022
+assert get_decompositions([torch.ops.aten.trace])
+# Requires functorch
+from torch._inductor.compile_fx import compile_fx_inner
 
 from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #93005
* __->__ #93004
* #93003

I think this was holdover compat code from multiple repros. we should error on failure. 

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire