### PR TITLE
Torchinductor randn_like lowering

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4381,6 +4381,23 @@ class CommonTemplate:
         self.assertTrue((d >= 0).all())
         self.assertTrue((d < 1).all())
 
+    def test_randn_like_empty(self):
+        class Model(torch.nn.Module):
+            def __init__(
+                self,
+            ):
+                super().__init__()
+
+            def forward(self, v1: torch.Tensor):
+                vx = v1.min(dim=1).values
+                v2 = torch.randn_like(vx)
+                return v2
+
+        model = Model()
+        x = torch.rand(10, 3, 0)
+
+        self.common(model, x)
+
     def test_max_pool2d_with_indices_backward(self):
         def fn(a, b, c):
             return aten.max_pool2d_with_indices_backward(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1094,6 +1094,9 @@ def make_rand(fn_name):
 
 fallback_rand = fallback_handler(aten.rand)
 fallback_randn = fallback_handler(aten.randn)
+fallback_randn_like = fallback_handler(aten.randn_like)
+
+
 fast_rand = make_rand("rand")
 fast_randn = make_rand("randn")
 
@@ -1114,6 +1117,20 @@ def randn(*args, **kwargs):
     else:
         kwargs.pop("generator", None)
         return fast_randn(*args, **kwargs)
+
+
+@register_lowering([aten.randn_like])
+def randn_like(x, **kwargs):
+    if config.fallback_random:
+        return fallback_randn_like(*args, **kwargs)
+    else:
+        dtype = kwargs.pop("dtype", None)
+        dtype = x.get_dtype() if dtype is None else dtype
+
+        device = kwargs.pop("device", None)
+        device = x.get_device() if device is None else device
+
+        return fast_randn(x.get_size(), dtype=dtype, device=device, **kwargs)
 
 
 @register_lowering(overrides.philox_seed_like._overloadpacket)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93005
* #93004
* #93003

Add lowering for randn_like, fixes https://github.com/pytorch/pytorch/issues/92368 by virtue of not taking a fallback path, although the 0-element prim stride is still incorrect. Would be nice to submit as a decomposition, but that is blocked by https://github.com/pytorch/pytorch/issues/92920. 


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire