### PR TITLE
Corrected grammar in contribution guide

### DIFF
--- a/docs/source/community/contribution_guide.rst
+++ b/docs/source/community/contribution_guide.rst
@@ -129,7 +129,7 @@ proposed solution. The PyTorch team can provide guidance that saves you
 time.
 
 Issues that are labeled first-new-issue, low, or medium priority provide
-the best entrance point are great places to start.
+the best entrance point and are great places to start.
 
 Adding Tutorials
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Corrected the grammar of a sentence in "Implementing Features or Fixing Bugs" section of the contribution guide.

**Before:**
Issues that are labeled first-new-issue, low, or medium priority provide the best entrance point are great places to start.

**After:**
Issues that are labeled first-new-issue, low, or medium priority provide the best entrance point _and_ are great places to start.
