### PR TITLE
Fix CI docs_test regression

### DIFF
--- a/torch/onnx/_internal/fx/export.py
+++ b/torch/onnx/_internal/fx/export.py
@@ -2,9 +2,7 @@ import copy
 import inspect
 import itertools
 import operator
-from typing import Any, Callable, Dict, Optional, Tuple, Union
-
-import onnx
+from typing import Callable, Dict, Optional, Tuple, Union
 
 import torch
 import torch._C
@@ -418,7 +416,7 @@ def _export(
     *args,
     decomposition_table: Dict[torch._ops.OpOverload, Callable] = None,
     use_binary_format: bool = True,
-) -> Union[Any, bytes]:
+) -> bytes:
     # Export FX graph to ONNX ModelProto.
     if decomposition_table is None:
         # Use default decomposition table.
@@ -433,12 +431,8 @@ def _export(
     onnx_model = _ts_graph_to_onnx_model_in_protobuf(
         ts_graph, ts_initializers, opset_version
     )
-    if use_binary_format:
-        # Return ModelProto in binary format.
-        return onnx_model
-    # Return ModelProto in readable format (printable).
-    model_proto = onnx.ModelProto.FromString(onnx_model)
-    return model_proto
+    # Return ModelProto in binary format.
+    return onnx_model
 
 
 def export(
@@ -446,7 +440,7 @@ def export(
     opset_version,
     *args,
     use_binary_format: bool = True,
-) -> Union[Any, bytes]:
+) -> bytes:
     # args will be converted to symbolic tensor. Let's copy to avoid side effects.
     args = copy.deepcopy(args)
     # Translate callable to FX graph.
@@ -474,7 +468,7 @@ def export_without_kwargs(
     *args,
     use_binary_format: bool = True,
     **kwargs,
-) -> Union[Any, bytes]:
+) -> bytes:
     if isinstance(fn, torch.nn.Module):
         signature = inspect.signature(fn.forward)
     else:

--- a/torch/onnx/_internal/fx/export.py
+++ b/torch/onnx/_internal/fx/export.py
@@ -19,8 +19,6 @@ from torch.onnx._globals import GLOBALS as ONNX_GLOBALS
 from torch.onnx._internal import jit_utils, registration
 from torch.utils import _pytree
 
-# TODO: REMOVE THIS. Dummy comment to trigger CI after merge with master.
-
 
 def _create_op_overload_to_exporter_key_table() -> Dict[torch._ops.OpOverload, str]:
     table: Dict[torch._ops.OpOverload, str] = {}
@@ -361,7 +359,7 @@ def _export_fx_to_ts(fx_module_with_metadata, opset_version):
 
 def _ts_graph_to_onnx_model_in_protobuf(
     ts_graph, ts_name_to_real_tensor, opset_version
-):
+) -> bytes:
     proto, _, _, _ = ts_graph._export_onnx(
         initializers=ts_name_to_real_tensor,
         onnx_opset_version=opset_version,
@@ -420,7 +418,7 @@ def _export(
     *args,
     decomposition_table: Dict[torch._ops.OpOverload, Callable] = None,
     use_binary_format: bool = True,
-):
+) -> Union[onnx.ModelProto, bytes]:
     # Export FX graph to ONNX ModelProto.
     if decomposition_table is None:
         # Use default decomposition table.
@@ -448,7 +446,7 @@ def export(
     opset_version,
     *args,
     use_binary_format: bool = True,
-):
+) -> Union[onnx.ModelProto, bytes]:
     # args will be converted to symbolic tensor. Let's copy to avoid side effects.
     args = copy.deepcopy(args)
     # Translate callable to FX graph.
@@ -476,7 +474,7 @@ def export_without_kwargs(
     *args,
     use_binary_format: bool = True,
     **kwargs,
-):
+) -> Union[onnx.ModelProto, bytes]:
     if isinstance(fn, torch.nn.Module):
         signature = inspect.signature(fn.forward)
     else:

--- a/torch/onnx/_internal/fx/export.py
+++ b/torch/onnx/_internal/fx/export.py
@@ -19,6 +19,8 @@ from torch.onnx._globals import GLOBALS as ONNX_GLOBALS
 from torch.onnx._internal import jit_utils, registration
 from torch.utils import _pytree
 
+# TODO: REMOVE THIS. Dummy comment to trigger CI after merge with master.
+
 
 def _create_op_overload_to_exporter_key_table() -> Dict[torch._ops.OpOverload, str]:
     table: Dict[torch._ops.OpOverload, str] = {}

--- a/torch/onnx/_internal/fx/export.py
+++ b/torch/onnx/_internal/fx/export.py
@@ -1,8 +1,23 @@
+from __future__ import annotations
+
 import copy
 import inspect
 import itertools
 import operator
+from types import ModuleType
 from typing import Callable, Dict, Optional, Tuple, Union
+
+try:
+    import onnx
+except ImportError:
+    onnx = ModuleType("onnx")
+
+    def _onnx_not_available(name):
+        raise RuntimeError(
+            "ONNX is not available. Please install ONNX to use this feature."
+        )
+
+    onnx.__getattr__ = _onnx_not_available
 
 import torch
 import torch._C
@@ -357,7 +372,7 @@ def _export_fx_to_ts(fx_module_with_metadata, opset_version):
 
 def _ts_graph_to_onnx_model_in_protobuf(
     ts_graph, ts_name_to_real_tensor, opset_version
-) -> bytes:
+) -> Union["onnx.ModelProto", bytes]:
     proto, _, _, _ = ts_graph._export_onnx(
         initializers=ts_name_to_real_tensor,
         onnx_opset_version=opset_version,
@@ -416,7 +431,7 @@ def _export(
     *args,
     decomposition_table: Dict[torch._ops.OpOverload, Callable] = None,
     use_binary_format: bool = True,
-) -> bytes:
+) -> Union["onnx.ModelProto", bytes]:
     # Export FX graph to ONNX ModelProto.
     if decomposition_table is None:
         # Use default decomposition table.
@@ -431,8 +446,12 @@ def _export(
     onnx_model = _ts_graph_to_onnx_model_in_protobuf(
         ts_graph, ts_initializers, opset_version
     )
-    # Return ModelProto in binary format.
-    return onnx_model
+    if use_binary_format:
+        # Return ModelProto in binary format.
+        return onnx_model
+    # Return ModelProto in readable format (printable).
+    model_proto = onnx.ModelProto.FromString(onnx_model)
+    return model_proto
 
 
 def export(
@@ -440,7 +459,7 @@ def export(
     opset_version,
     *args,
     use_binary_format: bool = True,
-) -> bytes:
+) -> Union["onnx.ModelProto", bytes]:
     # args will be converted to symbolic tensor. Let's copy to avoid side effects.
     args = copy.deepcopy(args)
     # Translate callable to FX graph.
@@ -468,7 +487,7 @@ def export_without_kwargs(
     *args,
     use_binary_format: bool = True,
     **kwargs,
-) -> bytes:
+) -> Union["onnx.ModelProto", bytes]:
     if isinstance(fn, torch.nn.Module):
         signature = inspect.signature(fn.forward)
     else:

--- a/torch/onnx/_internal/fx/export.py
+++ b/torch/onnx/_internal/fx/export.py
@@ -2,7 +2,7 @@ import copy
 import inspect
 import itertools
 import operator
-from typing import Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import onnx
 
@@ -418,7 +418,7 @@ def _export(
     *args,
     decomposition_table: Dict[torch._ops.OpOverload, Callable] = None,
     use_binary_format: bool = True,
-) -> Union[onnx.ModelProto, bytes]:
+) -> Union[Any, bytes]:
     # Export FX graph to ONNX ModelProto.
     if decomposition_table is None:
         # Use default decomposition table.
@@ -446,7 +446,7 @@ def export(
     opset_version,
     *args,
     use_binary_format: bool = True,
-) -> Union[onnx.ModelProto, bytes]:
+) -> Union[Any, bytes]:
     # args will be converted to symbolic tensor. Let's copy to avoid side effects.
     args = copy.deepcopy(args)
     # Translate callable to FX graph.
@@ -474,7 +474,7 @@ def export_without_kwargs(
     *args,
     use_binary_format: bool = True,
     **kwargs,
-) -> Union[onnx.ModelProto, bytes]:
+) -> Union[Any, bytes]:
     if isinstance(fn, torch.nn.Module):
         signature = inspect.signature(fn.forward)
     else:

--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -1916,14 +1916,14 @@ def verify_model_with_fx_to_onnx_exporter(
 
     if not isinstance(onnx_model, bytes):
         onnx_model = onnx_model.SerializeToString()
-    onnx_model = io.BytesIO(onnx_model)
+    onnx_model_f = io.BytesIO(onnx_model)
 
     with torch.no_grad(), contextlib.ExitStack() as stack:
         tmpdir_path = stack.enter_context(tempfile.TemporaryDirectory())
 
         _compare_onnx_pytorch_model(
             fx_model,
-            onnx_model,
+            onnx_model_f,
             input_args=input_args,
             # Dynamo exporter folds all kwargs into in-graph constants,
             # so we can't specify input_kwargs=input_kwargs.

--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -33,7 +33,6 @@ from typing import (
 )
 
 import numpy as np
-import onnx
 
 import torch
 import torch._C._onnx as _C_onnx
@@ -1915,14 +1914,16 @@ def verify_model_with_fx_to_onnx_exporter(
     onnx_args, onnx_kwargs = _prepare_input_for_pytorch(input_args, input_kwargs)
     onnx_model = fx_onnx.export(model, opset_version, *onnx_args, **onnx_kwargs)
 
+    if not isinstance(onnx_model, bytes):
+        onnx_model = onnx_model.SerializeToString()
+    onnx_model = io.BytesIO(onnx_model)
+
     with torch.no_grad(), contextlib.ExitStack() as stack:
         tmpdir_path = stack.enter_context(tempfile.TemporaryDirectory())
-        model_file_path: str = os.path.join(tmpdir_path, "model.onnx")
-        onnx.save(onnx_model, model_file_path)
 
         _compare_onnx_pytorch_model(
             fx_model,
-            model_file_path,
+            onnx_model,
             input_args=input_args,
             # Dynamo exporter folds all kwargs into in-graph constants,
             # so we can't specify input_kwargs=input_kwargs.


### PR DESCRIPTION
`import onnx` in "verification.py" breaks `docs_test`, since `onnx` is not part of dependency of PyTorch.

Modification is minimized to just fix regression.