### PR TITLE
[SDPA] Remove unused rng_engine_inputs

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp
@@ -310,7 +310,6 @@ mha_fwd(const at::Tensor &q,         // total_q x num_heads x head_size, total_q
     // state
     // We use a custom RNG that increases the offset by batch_size * nheads * 32.
     int64_t counter_offset = launch_params.params.b * launch_params.params.h * 32;
-    at::PhiloxCudaState rng_engine_inputs;
 
     if( is_dropout ) {
         // See Note [Acquire lock when using random generators]


### PR DESCRIPTION
The unused variable in `fmha_api.cpp` [here](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp#L313) was causing build failures (internally) due to to the `-Wunused-variable` flag being used. For example:
```
[2023-01-24T20:32:00.241-08:00] Stderr: aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp:313:25: error: unused variable 'rng_engine_inputs' [-Werror,-Wunused-variable]
[CONTEXT] [2023-01-24T20:32:00.241-08:00]     at::PhiloxCudaState rng_engine_inputs;
[CONTEXT] [2023-01-24T20:32:00.241-08:00]                         ^
[2023-01-24T21:09:33.507-08:00] Stderr: aten/src/ATen/native/transformers/cuda/flash_attn/fmha_api.cpp:313:25: error: unused variable 'rng_engine_inputs' [-Werror,-Wunused-variable]
[CONTEXT] [2023-01-24T21:09:33.507-08:00]     at::PhiloxCudaState rng_engine_inputs;
[CONTEXT] [2023-01-24T21:09:33.507-08:00]   
``` 
This PR removes that unused variable. Mirroring this same patch made by @drisspg internally.