### PR TITLE
Remove a redundant check from code.

### DIFF
--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -46,7 +46,7 @@ class SamplerIterDataPipe(IterDataPipe[T_co]):
 
     def __len__(self) -> int:
         # Dataset has been tested as `Sized`
-        if isinstance(self.sampler, Sized) and len(self.sampler) >= 0:
+        if isinstance(self.sampler, Sized):
             return len(self.sampler)
         raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))
 


### PR DESCRIPTION
In file: combinatorics.py, the comparison of Collection length creates a logical short circuit. 

   if isinstance(self.sampler, Sized) and len(self.sampler) >= 0:

Here, the right side of the comparison will always return true.

I suggested that the Collection length check should be removed since this is redundant. 
 