### PR TITLE
[caffe2] Don't gflags::ParseCommandLineFlags() twice

### DIFF
--- a/c10/util/flags_use_gflags.cpp
+++ b/c10/util/flags_use_gflags.cpp
@@ -30,8 +30,8 @@ C10_EXPORT bool ParseCommandLineFlags(int* pargc, char*** pargv) {
 }
 
 C10_EXPORT bool CommandLineFlagsHasBeenParsed() {
-  // There is no way we query gflags right now, so we will simply return true.
-  return true;
+  // GetArgvs() is only empty if command line args have not been parsed.
+  return !gflags::GetArgvs().empty();
 }
 
 } // namespace c10


### PR DESCRIPTION
Summary:
If `--flagfile=...` is included in the command line, then re-running `gflags::ParseCommandLineFlags()` //even without any parameters// will cause the flagfile to be re-evaluated

As a result, running `my_binary --flagfile=/tmp/flagfile_with_foo_1 --foo=2` renders `--foo=2` ineffective as the `flagfile` because the `--flagfile` is applied a second time.

Reviewed By: luciang

Differential Revision: D42558210

