### PR TITLE
Make __deepcopy__ of GraphModule able to handle circular reference.

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -3602,6 +3602,11 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
         copy_m = copy.deepcopy(m)
         self.assertEqual(copy_m.meta['hello'], 'world')
 
+    def test_deepcopy_no_recursion(self):
+        m = symbolic_trace(SimpleTest())
+        m.meta['hello'] = m  # circular reference
+        copy_m = copy.deepcopy(m)  # finishes
+
 
 def run_getitem_target():
     from torch.fx._symbolic_trace import _wrapped_methods_to_patch

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -705,10 +705,11 @@ class {module_name}(torch.nn.Module):
     # and cause symbolic tracing to occur every time we try to copy the object
     def __deepcopy__(self, memo):
         fake_mod = torch.nn.Module()
-        fake_mod.__dict__ = copy.deepcopy(self.__dict__)
+        fake_mod.__dict__ = copy.deepcopy(self.__dict__, memo)
         res = GraphModule(fake_mod, fake_mod.__dict__['_graph'])
-        res.meta = copy.deepcopy(getattr(self, 'meta', {}))
+        res.meta = copy.deepcopy(getattr(self, 'meta', {}), memo)
         return res
+
 
     def __copy__(self):
         res = GraphModule(self, self.graph)


### PR DESCRIPTION
Summary:
One of such places where circular reference can occur is: _load_state_dict_pre_hooks contains a _WrappedHook, _WrappedHook has a weakref to the same module.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER
