### PR TITLE
Update XLA docker image to v0.8

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -38,7 +38,7 @@ runs:
       id: calculate-tag
       env:
         IS_XLA: ${{ inputs.xla == 'true' && 'true' || '' }}
-        XLA_IMAGE_TAG: v0.6
+        XLA_IMAGE_TAG: v0.8
         DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${{ inputs.docker-image-name }}
       run: |
         if [ -n "${IS_XLA}" ]; then


### PR DESCRIPTION
Given the context in https://github.com/pytorch/xla/pull/4489, we now have a new XLA Docker image `v0.8`. This should fix the flaky sccache initialization failures with XLA.