### PR TITLE
Enable `bsr_dense_mm` Triton kernel in `nn.functional.linear`.

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6473,7 +6473,7 @@
 - func: _triton_bsr_dense_mm(Tensor bsr, Tensor dense) -> Tensor
   variants: function
   dispatch:
-    CPU: triton_bsr_dense_mm
+    CUDA: triton_bsr_dense_mm
   autogen: _triton_bsr_dense_mm.out
 
 - func: _addmm_activation.out(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, bool use_gelu=False, Tensor(a!) out) -> Tensor(a!)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6473,7 +6473,7 @@
 - func: _triton_bsr_dense_mm(Tensor bsr, Tensor dense) -> Tensor
   variants: function
   dispatch:
-    CUDA: triton_bsr_dense_mm
+    CPU: triton_bsr_dense_mm
   autogen: _triton_bsr_dense_mm.out
 
 - func: _addmm_activation.out(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, bool use_gelu=False, Tensor(a!) out) -> Tensor(a!)

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -509,6 +509,8 @@ aten::_triton_multi_head_attention
 aten::_triton_multi_head_attention.out
 aten::_triton_scaled_dot_attention
 aten::_triton_scaled_dot_attention.out
+aten::_triton_bsr_dense_mm
+aten::_triton_bsr_dense_mm.out
 aten::_unique
 aten::_unique.out
 aten::_unique2

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -1477,13 +1477,6 @@ class TestSparseCSR(TestCase):
     def test_triton_bsr_dense_bmm(self, device, dtype, index_dtype, block_size):
         from functools import partial
 
-        from torch.sparse._triton_ops import bsr_dense_mm
-
-        if bsr_dense_mm is not None:
-            lib = torch.library.Library("aten", "IMPL")
-            lib.impl("aten::_triton_bsr_dense_mm",
-                     lambda *args, **kwargs: bsr_dense_mm(*args, skip_checks=True, **kwargs), "SparseCsrCUDA")
-
         # Note that each value in a non-zero block is in range block_size * [low^2, high^2).
         tensor = partial(make_tensor, device=device, dtype=dtype, low=0.5, high=1.5)
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1435,3 +1435,9 @@ def _sparse_coo_tensor_unsafe(*args, **kwargs):
                   'use torch.sparse_coo_tensor(..., check_invariants=False) instead.')
     kwargs['check_invariants'] = False
     return torch.sparse_coo_tensor(*args, **kwargs)
+
+
+# dynamic registration of sparse triton kernels
+from torch.sparse import _register_impls
+lib = torch.library.Library("aten", "IMPL")
+_register_impls(lib)

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -898,18 +898,18 @@ class ComplexFloatStorage(_CudaLegacyStorage):
 del _LegacyStorage
 del _CudaLegacyStorage
 
-torch._storage_classes.add(DoubleStorage)
-torch._storage_classes.add(FloatStorage)
-torch._storage_classes.add(LongStorage)
-torch._storage_classes.add(IntStorage)
-torch._storage_classes.add(ShortStorage)
-torch._storage_classes.add(CharStorage)
-torch._storage_classes.add(ByteStorage)
-torch._storage_classes.add(HalfStorage)
-torch._storage_classes.add(BoolStorage)
-torch._storage_classes.add(BFloat16Storage)
-torch._storage_classes.add(ComplexDoubleStorage)
-torch._storage_classes.add(ComplexFloatStorage)
+torch._storage_classes.add(DoubleStorage)  # type: ignore[has-type]
+torch._storage_classes.add(FloatStorage)  # type: ignore[has-type]
+torch._storage_classes.add(LongStorage)  # type: ignore[has-type]
+torch._storage_classes.add(IntStorage)  # type: ignore[has-type]
+torch._storage_classes.add(ShortStorage)  # type: ignore[has-type]
+torch._storage_classes.add(CharStorage)  # type: ignore[has-type]
+torch._storage_classes.add(ByteStorage)  # type: ignore[has-type]
+torch._storage_classes.add(HalfStorage)  # type: ignore[has-type]
+torch._storage_classes.add(BoolStorage)  # type: ignore[has-type]
+torch._storage_classes.add(BFloat16Storage)  # type: ignore[has-type]
+torch._storage_classes.add(ComplexDoubleStorage)  # type: ignore[has-type]
+torch._storage_classes.add(ComplexFloatStorage)  # type: ignore[has-type]
 
 from . import sparse
 from . import profiler

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -4,6 +4,8 @@ from typing import Optional, Tuple, List, Union
 import torch
 from torch._C import _add_docstr, _sparse  # type: ignore[attr-defined]
 from torch import Tensor
+from torch.cuda import _lazy_call
+from torch._inductor.cuda_properties import get_device_capability
 
 # A workaround to support both TorchScript and MyPy:
 from typing import TYPE_CHECKING
@@ -462,3 +464,31 @@ See :func:`torch.sparse.check_sparse_tensor_invariants.enable` for more informat
                 return mth(*args, **kwargs)
 
         return test_mth
+
+
+# Triton registrations
+def _has_triton():
+    if not torch.cuda.is_available():
+        return False
+    try:
+        import triton
+
+        return triton is not None and get_device_capability() >= (7, 0)
+    except ImportError:
+        return False
+
+
+def _register_impls(lib):
+    """This function is called from torch/__init__.py to do any dynamic registrations. """
+
+
+    def register_sparse_cuda_impls(lib=lib):
+        from ._triton_ops import bsr_dense_mm
+
+        if bsr_dense_mm is not None:
+            lib.impl("aten::_triton_bsr_dense_mm",
+                     lambda *args, **kwargs: bsr_dense_mm(*args, skip_checks=True, **kwargs), "SparseCsrCUDA")
+
+    # This code is evaluated on import torch and therefore cannot force initialization of the cuda rt
+    # We must schedule the registration to occur lazily.
+    _lazy_call(register_sparse_cuda_impls)

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -467,17 +467,6 @@ See :func:`torch.sparse.check_sparse_tensor_invariants.enable` for more informat
 
 
 # Triton registrations
-def _has_triton():
-    if not torch.cuda.is_available():
-        return False
-    try:
-        import triton
-
-        return triton is not None and get_device_capability() >= (7, 0)
-    except ImportError:
-        return False
-
-
 def _register_impls(lib):
     """This function is called from torch/__init__.py to do any dynamic registrations. """
 

--- a/torchgen/static_runtime/generator.py
+++ b/torchgen/static_runtime/generator.py
@@ -196,6 +196,7 @@ BLOCKED_OPS = frozenset(
         "unfold_copy",
         "alias_copy",
         "_triton_multi_head_attention",
+        "_triton_bsr_dense_mm",
         "special_airy_ai",
         "special_bessel_j0",
         "special_bessel_j1",


### PR DESCRIPTION
As per title.


cc @alexsamardzic @pearu @cpuhrsch @amjames @bhosmer