### PR TITLE
Get rid of dedicated inductor dynamic_shapes config

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -909,7 +909,6 @@ class CommonTemplate:
         for i in inputs:
             self.common(fn, (i,))
 
-    @patch.object(config, "dynamic_shapes", False)
     def test_unroll_small_reduction(self):
         def fn(x):
             val1, index1 = x.min(-1)
@@ -5344,7 +5343,6 @@ def make_dynamic_cls(cls):
         cls,
         "DynamicShapes",
         "_dynamic_shapes",
-        (config, "dynamic_shapes", True),
         (torch._dynamo.config, "dynamic_shapes", True),
         (functorch_config, "use_dynamic_shapes", True),
     )
@@ -5496,7 +5494,6 @@ if HAS_CPU:
         @unittest.skipIf(
             not codecache.valid_vec_isa_list(), "Does not support vectorization"
         )
-        @patch.object(config, "dynamic_shapes", True)
         @patch.object(torch._dynamo.config, "dynamic_shapes", True)
         @patch.object(functorch_config, "use_dynamic_shapes", True)
         def test_vec_dynamic_shapes(self):
@@ -6226,7 +6223,6 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))
 
         # TODO: Abstract this out, test more extensively
-        @patch.object(config, "dynamic_shapes", True)
         @patch.object(torch._dynamo.config, "dynamic_shapes", True)
         @patch.object(functorch_config, "use_dynamic_shapes", True)
         def test_dynamic_shapes(self):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1134,7 +1134,7 @@ class TritonKernel(Kernel):
         code.writeline(f"def {name or 'KERNEL_NAME'}({', '.join(argdefs)}):")
         self.codegen_body()
         with code.indent():
-            if not config.dynamic_shapes:
+            if not dynamo_config.dynamic_shapes:
                 self.codegen_static_numels(code)
             for old, new in self.args.aliases():
                 code.writeline(f"{old} = {new}")
@@ -1166,7 +1166,7 @@ class TritonKernel(Kernel):
                     code.writeline(
                         f"{tree.prefix}numel = {V.graph.sizevars.size_hint(tree.numel)}"
                     )
-                elif not config.dynamic_shapes:
+                elif not dynamo_config.dynamic_shapes:
                     code.writeline(
                         f"{tree.prefix}numel = {V.graph.sizevars.size_hint(tree.numel)}  # dynamic_shapes=False"
                     )
@@ -1398,7 +1398,7 @@ class TritonScheduling:
                     stack.close()
                 else:
                     # TODO - mostly works but needs a couple fixes
-                    if not config.dynamic_shapes:
+                    if not dynamo_config.dynamic_shapes:
                         # TODO - use split ranges ?
                         indexing_dtype_strength_reduction(node._body)
                     index_vars = kernel.split_and_set_ranges(node.get_ranges())

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -18,6 +18,7 @@ from torch._dynamo.utils import fake_mode_from_tensors
 from torch._functorch.aot_autograd import make_boxed_func
 from torch._subclasses.fake_tensor import FakeTensor
 
+import torch._dynamo.config as dynamo_config
 from . import config, metrics, overrides
 from .debug import DebugContext
 from .decomposition import select_decomp_table
@@ -375,7 +376,7 @@ def compile_fx(
         model_ = overrides.replace_fx(model_)
         model_ = overrides.fuse_fx(model_, example_inputs_)
     num_example_inputs = len(example_inputs_)
-    cudagraphs = BoxedBool(config.triton.cudagraphs and not config.dynamic_shapes)
+    cudagraphs = BoxedBool(config.triton.cudagraphs and not dynamo_config.dynamic_shapes)
 
     graph_id = next(_graph_counter)
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -9,6 +9,8 @@ from typing import List
 import functorch
 from functorch.compile import min_cut_rematerialization_partition
 
+import torch._dynamo.config as dynamo_config
+
 import torch.fx
 
 from torch._dynamo import logging as dynamo_logging, utils as dynamo_utils
@@ -17,8 +19,6 @@ from torch._dynamo.optimizations.training import aot_autograd
 from torch._dynamo.utils import fake_mode_from_tensors
 from torch._functorch.aot_autograd import make_boxed_func
 from torch._subclasses.fake_tensor import FakeTensor
-
-import torch._dynamo.config as dynamo_config
 from . import config, metrics, overrides
 from .debug import DebugContext
 from .decomposition import select_decomp_table
@@ -376,7 +376,9 @@ def compile_fx(
         model_ = overrides.replace_fx(model_)
         model_ = overrides.fuse_fx(model_, example_inputs_)
     num_example_inputs = len(example_inputs_)
-    cudagraphs = BoxedBool(config.triton.cudagraphs and not dynamo_config.dynamic_shapes)
+    cudagraphs = BoxedBool(
+        config.triton.cudagraphs and not dynamo_config.dynamic_shapes
+    )
 
     graph_id = next(_graph_counter)
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -16,11 +16,6 @@ cpp_wrapper = False
 # dead code elimination
 dce = False
 
-# assume input tensors are dynamic
-dynamic_shapes = (
-    os.environ.get("TORCHDYNAMO_DYNAMIC_SHAPES") == "1"
-)  # Use dynamic shapes if torchdynamo dynamic shapes is set
-
 # assume weight tensors are fixed size
 static_weight_shapes = True
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -265,7 +265,7 @@ class GraphLowering(torch.fx.Interpreter):
             config.static_weight_shapes
             and (
                 len(self.graph_inputs) < self.num_static_inputs
-                or not config.dynamic_shapes
+                or not dynamo_config.dynamic_shapes
             )
             and not example._has_symbolic_sizes_strides
         ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93076

Instead, use Dynamo dynamic_shapes config

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire