### PR TITLE
Make CPU inductor work with dynamic shapes

### DIFF
--- a/torch/_inductor/mkldnn.py
+++ b/torch/_inductor/mkldnn.py
@@ -8,8 +8,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from torch import sym_int
-
 from torch._dynamo.utils import fake_mode_from_tensors
 from torch.fx.experimental.optimization import (
     matches_module_pattern,
@@ -353,9 +351,7 @@ class PackedLinear(nn.Linear):
 
     def _update_module_params(self, linear, input_size):
         self.__dict__ = copy.deepcopy(linear.__dict__)
-        self.batch_size = sym_int(
-            reduce(lambda x, y: x * y, input_size) / input_size[-1]
-        )
+        self.batch_size = reduce(lambda x, y: x * y, input_size[:-1])
         self.packed_weight = torch.nn.Parameter(
             torch.ops.mkl._mkl_reorder_linear_weight(
                 self.weight.to_mkldnn(), self.batch_size

--- a/torch/_inductor/mkldnn.py
+++ b/torch/_inductor/mkldnn.py
@@ -8,6 +8,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from torch import sym_int
+
 from torch._dynamo.utils import fake_mode_from_tensors
 from torch.fx.experimental.optimization import (
     matches_module_pattern,
@@ -351,7 +353,9 @@ class PackedLinear(nn.Linear):
 
     def _update_module_params(self, linear, input_size):
         self.__dict__ = copy.deepcopy(linear.__dict__)
-        self.batch_size = int(reduce(lambda x, y: x * y, input_size) / input_size[-1])
+        self.batch_size = sym_int(
+            reduce(lambda x, y: x * y, input_size) / input_size[-1]
+        )
         self.packed_weight = torch.nn.Parameter(
             torch.ops.mkl._mkl_reorder_linear_weight(
                 self.weight.to_mkldnn(), self.batch_size

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -4,6 +4,7 @@ import random
 import weakref
 
 import torch
+import torch._dynamo.config as dynamo_config
 import torch.nn as nn
 from torch import _prims
 from torch._dynamo.utils import fake_mode_from_tensors
@@ -87,7 +88,8 @@ def fuse_fx(gm: torch.fx.GraphModule, example_inputs):
     gm = remove_identity(gm)
     gm = fuse_conv_bn(gm)
     # do mkldnn fusion(conv(linear)+unary(binary)
-    gm = mkldnn_fuse_fx(gm, example_inputs)
+    if not dynamo_config.dynamic_shapes:
+        gm = mkldnn_fuse_fx(gm, example_inputs)
     return gm
 
 

--- a/torch/_inductor/overrides.py
+++ b/torch/_inductor/overrides.py
@@ -88,6 +88,10 @@ def fuse_fx(gm: torch.fx.GraphModule, example_inputs):
     gm = remove_identity(gm)
     gm = fuse_conv_bn(gm)
     # do mkldnn fusion(conv(linear)+unary(binary)
+    # This is skipped when dynamic shapes is enabled, as the resulting
+    # mkl packing ops don't support dynamic shapes.  Once they do support,
+    # you can remove this.  A good test case is wav2vec2, see
+    # https://github.com/pytorch/pytorch/issues/91719
     if not dynamo_config.dynamic_shapes:
         gm = mkldnn_fuse_fx(gm, example_inputs)
     return gm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93077

These errors were found by looking at wav2vec2

See https://github.com/pytorch/pytorch/issues/91719

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire