### PR TITLE
fixing flag to skip nvfuser_tests build

### DIFF
--- a/third_party/nvfuser/CMakeLists.txt
+++ b/third_party/nvfuser/CMakeLists.txt
@@ -284,7 +284,8 @@ target_include_directories(${NVFUSER_CODEGEN} PRIVATE "${CMAKE_BINARY_DIR}/inclu
 
 # -- build tests
 
-if(BUILD_TEST)
+# note: ideally we don't need USE_CUDA here, but our cpp tests are not ROCM compatible.
+if(BUILD_TEST AND USE_CUDA)
   set(NVFUSER_TESTS "${PROJECT_NAME}_tests")
   set(JIT_TEST_SRCS)
   list(APPEND JIT_TEST_SRCS ${NVFUSER_SRCS_DIR}/python_frontend/test/test_nvfuser_fusion_definition.cpp)

--- a/third_party/nvfuser/CMakeLists.txt
+++ b/third_party/nvfuser/CMakeLists.txt
@@ -284,7 +284,7 @@ target_include_directories(${NVFUSER_CODEGEN} PRIVATE "${CMAKE_BINARY_DIR}/inclu
 
 # -- build tests
 
-if(USE_CUDA)
+if(BUILD_TEST)
   set(NVFUSER_TESTS "${PROJECT_NAME}_tests")
   set(JIT_TEST_SRCS)
   list(APPEND JIT_TEST_SRCS ${NVFUSER_SRCS_DIR}/python_frontend/test/test_nvfuser_fusion_definition.cpp)


### PR DESCRIPTION
Slowly pushing cmake cleanup to upstream.

avoids building nvfuser_tests when BUILD_TEST is disabled.
nvfuser_tests uses googletest from pytorch, which is only dragged when BUILD_TEST is enabled.