### PR TITLE
combine meshgrid native functions

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
+++ b/aten/src/ATen/functorch/BatchRulesDecompositions.cpp
@@ -175,7 +175,6 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatchedDecomposition, m) {
   OP_DECOMPOSE(max_pool1d_with_indices);
   OP_DECOMPOSE(max_pool2d);
   OP_DECOMPOSE(meshgrid);
-  OP_DECOMPOSE2(meshgrid, indexing);
   OP_DECOMPOSE(mH);
   OP_DECOMPOSE2(min, other );
   OP_DECOMPOSE2(moveaxis, intlist);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -3479,14 +3479,13 @@ std::vector<Tensor> unbind(const Tensor& self, Dimname dim) {
   return at::unbind(self, dimname_to_position(self, dim));
 }
 
-std::vector<Tensor> meshgrid(TensorList tensors) {
-  TORCH_WARN_ONCE("torch.meshgrid: in an upcoming release, it will be required to pass the "
-                  "indexing argument.");
-  return native::meshgrid(tensors, /*indexing=*/"ij");
-}
-
 std::vector<Tensor> meshgrid(TensorList tensors,
-                             c10::string_view indexing) {
+                             c10::optional<c10::string_view> maybe_indexing) {
+  if (!maybe_indexing.has_value()) {
+    TORCH_WARN_ONCE("torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument.");
+    maybe_indexing = "ij";
+  }
+  auto indexing = *maybe_indexing;
   int64_t size = tensors.size();
   TORCH_CHECK(size > 0, "meshgrid expects a non-empty TensorList");
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7119,12 +7119,7 @@
   device_check: NoCheck
   device_guard: False
 
-- func: meshgrid(Tensor[] tensors) -> Tensor[]
-
-# TODO: Two weeks after this lands, combine these two overloads,
-#       making "indexing" optional. These are temporarily distinct for
-#       forward-compatibility reasons.
-- func: meshgrid.indexing(Tensor[] tensors, *, str indexing) -> Tensor[]
+- func: meshgrid(Tensor[] tensors, str? indexing=None) -> Tensor[]
 
 - func: cartesian_prod(Tensor[] tensors) -> Tensor
   variants: function


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/93092).
* __->__ #93092

combine meshgrid native functions

Summary: The FC window has long passed, no need to keep them distinct.

Test Plan: Rely on CI.

