### PR TITLE
Remove USE_CUDA check from CUDADeviceAssertionHost

### DIFF
--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -48,6 +48,8 @@ torch_cuda_based_add_library(c10_cuda ${C10_CUDA_SRCS} ${C10_CUDA_HEADERS})
 set(CUDA_LINK_LIBRARIES_KEYWORD)
 # If building shared library, set dllimport/dllexport proper.
 target_compile_options(c10_cuda PRIVATE "-DC10_CUDA_BUILD_MAIN_LIB")
+# Always enable device assertions.
+target_compile_options(c10_cuda PUBLIC "-DTORCH_USE_CUDA_DSA")
 # Enable hidden visibility if compiler supports it.
 if(${COMPILER_SUPPORTS_HIDDEN_VISIBILITY})
   target_compile_options(c10_cuda PRIVATE "-fvisibility=hidden")

--- a/c10/cuda/CUDADeviceAssertionHost.h
+++ b/c10/cuda/CUDADeviceAssertionHost.h
@@ -7,10 +7,6 @@
 #include <string>
 #include <vector>
 
-#ifdef USE_CUDA
-#define TORCH_USE_CUDA_DSA
-#endif
-
 /// Number of assertion failure messages we can store. If this is too small
 /// threads will fail silently.
 constexpr int C10_CUDA_DSA_ASSERTION_COUNT = 10;

--- a/c10/cuda/test/impl/CUDAAssertionsTest_catches_stream.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_catches_stream.cu
@@ -93,7 +93,7 @@ void cuda_device_assertions_catches_stream() {
 
 TEST(CUDATest, cuda_device_assertions_catches_stream) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_catches_stream();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";

--- a/c10/cuda/test/impl/CUDAAssertionsTest_catches_thread_and_block_and_device.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_catches_thread_and_block_and_device.cu
@@ -78,7 +78,7 @@ void cuda_device_assertions_catches_thread_and_block_and_device() {
 
 TEST(CUDATest, cuda_device_assertions_catches_thread_and_block_and_device) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_catches_thread_and_block_and_device();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";

--- a/c10/cuda/test/impl/CUDAAssertionsTest_from_2_processes.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_from_2_processes.cu
@@ -96,7 +96,7 @@ void cuda_device_assertions_from_2_processes() {
 
 TEST(CUDATest, cuda_device_assertions_from_2_processes) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_from_2_processes();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";

--- a/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_blocks_and_threads.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_blocks_and_threads.cu
@@ -85,7 +85,7 @@ void cuda_device_assertions_multiple_writes_from_blocks_and_threads() {
 
 TEST(CUDATest, cuda_device_assertions_multiple_writes_from_blocks_and_threads) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_multiple_writes_from_blocks_and_threads();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";

--- a/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_multiple_blocks.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_multiple_blocks.cu
@@ -82,7 +82,7 @@ void cuda_device_assertions_multiple_writes_from_multiple_blocks() {
 
 TEST(CUDATest, cuda_device_assertions_multiple_writes_from_multiple_blocks) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_multiple_writes_from_multiple_blocks();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";

--- a/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_same_block.cu
+++ b/c10/cuda/test/impl/CUDAAssertionsTest_multiple_writes_from_same_block.cu
@@ -70,7 +70,7 @@ void cuda_device_assertions_multiple_writes_from_same_block() {
 
 TEST(CUDATest, cuda_device_assertions_multiple_writes_from_same_block) {
 #ifdef TORCH_USE_CUDA_DSA
-  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled = true;
+  c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().enabled_at_runtime = true;
   cuda_device_assertions_multiple_writes_from_same_block();
 #else
   GTEST_SKIP() << "CUDA device-side assertions (DSA) was not enabled at compile time.";


### PR DESCRIPTION
USE_CUDA is not defined in c10/cuda , so it's not even getting compiled by default. It's all CUDA-only code, so the check is redundant.
Once the check is removed, it surfaces test compilation errors (enabled was renamed to enabled_at_runtime).
