### PR TITLE
Use the old aten underscored function for Predictor

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -580,8 +580,9 @@ std::tuple<Tensor, Tensor> native_multi_head_attention_cuda(
       chunks[2] = (chunks[2].view({x_size_0, -1, num_head, dim_per_head}))
                       .transpose(1, 2);
 
-      auto y = at::scaled_dot_product_attention(
-          chunks[0], chunks[1], chunks[2], mask, 0.0, false);
+      Tensor y, weights;
+      std::tie(y, weights) = at::_scaled_dot_product_attention(
+          chunks[0], chunks[1], chunks[2], mask, 0.0, false, false);
       auto past_sdp = y.transpose(1, 2).reshape({x_size_0, -1, embed_dim});
       return std::make_tuple(
           at::linear(past_sdp, proj_weight, proj_bias), Tensor());

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4862,7 +4862,7 @@ Shape legend:
 def _scaled_dot_product_attention(
         query: Tensor,
         key: Tensor,
-        value,
+        value: Tensor,
         attn_mask: Optional[Tensor] = None,
         dropout_p: float = 0.0,
         need_attn_weights: bool = False,
@@ -4870,7 +4870,7 @@ def _scaled_dot_product_attention(
     r""" TODO This function is for merge purposes only and needs to be removed
     """
     warnings.warn("This function is deprecated please rebuild your models with the public version of sdpa.")
-    return torch._C._nn.scaled_dot_product_attention(query, key, value, attn_mask, dropout_p, need_attn_weights, is_causal)
+    return torch._C._nn._scaled_dot_product_attention(query, key, value, attn_mask, dropout_p, need_attn_weights, is_causal)
 
 def _mha_shape_check(query: Tensor, key: Tensor, value: Tensor,
                      key_padding_mask: Optional[Tensor], attn_mask: Optional[Tensor], num_heads: int):
@@ -5271,7 +5271,7 @@ def multi_head_attention_forward(
         k = k.view(bsz, num_heads, src_len, head_dim)
         v = v.view(bsz, num_heads, src_len, head_dim)
 
-        attn_output = scaled_dot_product_attention(q, k, v, attn_mask, dropout_p, is_causal)
+        attn_output, _ = _scaled_dot_product_attention(q, k, v, attn_mask, dropout_p, False, is_causal)
         attn_output = attn_output.permute(2, 0, 1, 3).contiguous().view(bsz * tgt_len, embed_dim)
 
         attn_output = linear(attn_output, out_proj_weight, out_proj_bias)


### PR DESCRIPTION
Summary:
Errors reported via https://fb.prod.workplace.com/groups/1405155842844877/permalink/6644919482201794/

The problem is that the scriptable op set between predictor and the latest build of master is different.

Test Plan: Sandcastle testing

Differential Revision: D42786069

