### PR TITLE
[XNNPACK] Enable Memopt for OSS

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -1820,6 +1820,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "-DXNN_NO_X32_OPERATORS",
             "-DXNN_NO_X8_OPERATORS",
             "-DXNN_NO_XX_OPERATORS",
+            "-DXNN_ENABLE_MEMOPT",
         ],
         srcs = [
             "XNNPACK/src/allocator.c",


### PR DESCRIPTION
Summary:
D38543798

Enabled Memopt previously to fix a bug with memory planner

Mirroring the changes we made Internally to OSS

Test Plan: OSS CI

Reviewed By: digantdesai

Differential Revision: D42782958

