### PR TITLE
[CI] Move parallel native builds to 3.8

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,15 +21,15 @@ jobs:
     name: docs build
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-py3.7-gcc7
-      docker-image-name: pytorch-linux-focal-py3.7-gcc7
+      build-environment: linux-focal-py3.8-gcc7
+      docker-image-name: pytorch-linux-focal-py3.8-gcc7
 
   docs-push:
     name: docs push
     uses: ./.github/workflows/_docs.yml
     needs: docs-build
     with:
-      build-environment: linux-focal-py3.7-gcc7
+      build-environment: linux-focal-py3.8-gcc7
       docker-image: ${{ needs.docs-build.outputs.docker-image }}
       push: ${{ github.event_name == 'schedule' || startsWith(github.event.ref, 'refs/tags/v') }}
       run-doxygen: true

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -14,26 +14,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  parallelnative-linux-focal-py3_7-gcc7-build:
-    name: parallelnative-linux-focal-py3.7-gcc7
+  parallelnative-linux-focal-py3_8-gcc7-build:
+    name: parallelnative-linux-focal-py3.8-gcc7
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: parallelnative-linux-focal-py3.7-gcc7
-      docker-image-name: pytorch-linux-focal-py3.7-gcc7
+      build-environment: parallelnative-linux-focal-py3.8-gcc7
+      docker-image-name: pytorch-linux-focal-py3.8-gcc7
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
           { config: "default", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
         ]}
 
-  parallelnative-linux-focal-py3_7-gcc7-test:
-    name: parallelnative-linux-focal-py3.7-gcc7
+  parallelnative-linux-focal-py3_8-gcc7-test:
+    name: parallelnative-linux-focal-py3.8-gcc7
     uses: ./.github/workflows/_linux-test.yml
-    needs: parallelnative-linux-focal-py3_7-gcc7-build
+    needs: parallelnative-linux-focal-py3_8-gcc7-build
     with:
-      build-environment: parallelnative-linux-focal-py3.7-gcc7
-      docker-image: ${{ needs.parallelnative-linux-focal-py3_7-gcc7-build.outputs.docker-image }}
-      test-matrix: ${{ needs.parallelnative-linux-focal-py3_7-gcc7-build.outputs.test-matrix }}
+      build-environment: parallelnative-linux-focal-py3.8-gcc7
+      docker-image: ${{ needs.parallelnative-linux-focal-py3_8-gcc7-build.outputs.docker-image }}
+      test-matrix: ${{ needs.parallelnative-linux-focal-py3_8-gcc7-build.outputs.test-matrix }}
 
   linux-bionic-cuda11_6-py3-gcc7-slow-gradcheck-build:
     name: linux-bionic-cuda11.6-py3-gcc7-slow-gradcheck


### PR DESCRIPTION
As well as nightly docs builds
Followup after https://github.com/pytorch/pytorch/pull/92928