### PR TITLE
[CI] Calculate-docker-image should push by default

### DIFF
--- a/.circleci/docker/build_docker.sh
+++ b/.circleci/docker/build_docker.sh
@@ -47,7 +47,6 @@ fi
 if [ "${DOCKER_SKIP_PUSH:-true}" = "false" ]; then
   # Only push if docker image doesn't exist already.
   # ECR image tags are immutable so this will avoid pushing if only just testing if the docker jobs work
-  # NOTE: The only workflow that should push these images should be the docker-builds.yml workflow
   if ! docker manifest inspect "${image}:${tag}" >/dev/null 2>/dev/null; then
     docker push "${image}:${tag}"
   fi

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -18,12 +18,9 @@ inputs:
     description: If set to any value, run `docker pull`` on the calculated image.
     required: false
   skip_push:
-    description: If set to true value, skip will be pushed, default is to skip so that pushing will be explicit
+    description: If set to true value, push will be skipped, default is to push
     required: false
-    default: "true"
-  force_push:
-    description: If set to any value, always run the push
-    required: false
+    default: "false"
 
 outputs:
   docker-image:
@@ -60,7 +57,6 @@ runs:
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
         DOCKER_IMAGE: ${{ steps.calculate-tag.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-tag.outputs.docker-tag }}
-        DOCKER_FORCE_PUSH: ${{ inputs.force_push }}
       run: |
         set -x
         # Check if image already exists, if it does then skip building it

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -72,7 +72,6 @@ jobs:
         with:
           docker-image-name: ${{ matrix.docker-image-name }}
           always-rebuild: true
-          skip_push: false
           force_push: true
 
       - name: Pull docker image


### PR DESCRIPTION
This should avoid situations, when docker configs have changed, but PR is based against older commit or if build is scheduled/finished earlier then respective docker-build job.

Github Actions always rebase workflow files against latest trunk, so it's possible to have new definitions of workflows building against older commit. In that case, build job will rebuild the docker config, but it would not be available to the test jobs.

It wouldn't solve the problem of the out-of-date build definitions. I.e. if docker config is not defined in `docker/build.sh` it will use default configuration setting.
