### PR TITLE
Extend torch-trition conda to 3.11

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -49,7 +49,7 @@ def build_triton(commit_hash: str, build_conda: bool = False, py_version : Optio
 
             if py_version is None:
                 py_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-            check_call(["conda", "build", "--python", py_version, "--output-folder", tmpdir, "."], cwd=triton_basedir)
+            check_call(["conda", "build", "--python", py_version, "-c", "pytorch-nightly", "--output-folder", tmpdir, "."], cwd=triton_basedir)
             conda_path = list(Path(tmpdir).glob("linux-64/torchtriton*.bz2"))[0]
             shutil.copy(conda_path, Path.cwd())
             return Path.cwd() / conda_path.name

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -49,7 +49,8 @@ def build_triton(commit_hash: str, build_conda: bool = False, py_version : Optio
 
             if py_version is None:
                 py_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-            check_call(["conda", "build", "--python", py_version, "-c", "pytorch-nightly", "--output-folder", tmpdir, "."], cwd=triton_basedir)
+            check_call(["conda", "build", "--python", py_version,
+                        "-c", "pytorch-nightly", "--output-folder", tmpdir, "."], cwd=triton_basedir)
             conda_path = list(Path(tmpdir).glob("linux-64/torchtriton*.bz2"))[0]
             shutil.copy(conda_path, Path.cwd())
             return Path.cwd() / conda_path.name

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -21,12 +21,12 @@ concurrency:
 
 jobs:
   build-wheel:
-    name: "Build Trition Wheel"
+    name: "Build Triton Wheel"
     runs-on: [self-hosted, linux.2xlarge]
     strategy:
       fail-fast: false
       matrix:
-        py_vers: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        py_vers: [ "3.8", "3.9", "3.10", "3.11" ]
     timeout-minutes: 40
     env:
       DOCKER_IMAGE: pytorch/manylinux-builder:cuda11.6
@@ -108,11 +108,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.github-token }}
     steps:
-      - name: Download Build Artifacts (3.7)
-        uses: actions/download-artifact@v3
-        with:
-          name: "pytorch-triton-wheel-3.7"
-          path: "${{ runner.temp }}/artifacts/"
       - name: Download Build Artifacts (3.8)
         uses: actions/download-artifact@v3
         with:
@@ -149,12 +144,12 @@ jobs:
               aws s3 cp --no-progress --acl public-read "${pkg}" "${s3_dir}"
              done
   build-conda:
-    name: "Build Trition Conda"
+    name: "Build Triton Conda"
     runs-on: [self-hosted, linux.2xlarge]
     strategy:
       fail-fast: false
       matrix:
-        py_vers: [ "3.7", "3.8", "3.9", "3.10" ]
+        py_vers: [ "3.8", "3.9", "3.10", "3.11" ]
     timeout-minutes: 40
     env:
       DOCKER_IMAGE: pytorch/conda-builder:cuda11.6

--- a/.github/workflows/build-triton-wheel.yml
+++ b/.github/workflows/build-triton-wheel.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   build-wheel:
+    name: "Build Trition Wheel"
     runs-on: [self-hosted, linux.2xlarge]
     strategy:
       fail-fast: false
@@ -148,6 +149,7 @@ jobs:
               aws s3 cp --no-progress --acl public-read "${pkg}" "${s3_dir}"
              done
   build-conda:
+    name: "Build Trition Conda"
     runs-on: [self-hosted, linux.2xlarge]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Also drop 3.7 from both builds and add proper names to the steps
Add `pytorch-nightly` for `conda` builds to test the installation against `pytorch` from the nightly channel as well as get [`filelock`](https://anaconda.org/pytorch-nightly/filelock) dependency for 3.11)