### PR TITLE
Load and store data in torch.jit.load() and torch.jit.save() on a big-endian machine

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -620,6 +620,7 @@ libtorch_lite_eager_symbolication = [
     "torch/csrc/jit/serialization/pickle.cpp",
     "torch/csrc/jit/serialization/pickler.cpp",
     "torch/csrc/jit/serialization/unpickler.cpp",
+    "torch/csrc/utils/byte_order.cpp",
 ]
 
 # TODO: core_trainer_sources is not necessary for libtorch lite

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -525,21 +525,9 @@ void Pickler::pushSpecializedList(
   push<PickleOpCode>(PickleOpCode::REDUCE);
 }
 
-static inline double swapDouble(double value) {
-  const char* bytes = reinterpret_cast<const char*>(&value);
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  double flipped;
-  char* out_bytes = reinterpret_cast<char*>(&flipped);
-  for (const auto i : c10::irange(sizeof(double))) {
-    out_bytes[i] = bytes[sizeof(double) - i - 1];
-  }
-  return *reinterpret_cast<double*>(out_bytes);
-}
-
 void Pickler::pushDouble(double value) {
   push<PickleOpCode>(PickleOpCode::BINFLOAT);
-  // Python pickle format is big endian, swap.
-  push<double>(swapDouble(value));
+  push<double>(value);
 }
 void Pickler::pushComplexDouble(const IValue& value) {
   c10::complex<double> d = value.toComplexDouble();

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -209,18 +209,8 @@ IValue Unpickler::parse_ivalue() {
 
 double Unpickler::readFloat() {
   AT_ASSERT(sizeof(double) == 8);
-  double big_endian = read<double>();
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  double little_endian;
-
-  // Pickle floats are big endian, so reverse the bytes
-  auto big_endian_ptr = reinterpret_cast<const char*>(&big_endian);
-  std::reverse_copy(
-      big_endian_ptr,
-      big_endian_ptr + sizeof(big_endian),
-      reinterpret_cast<char*>(&little_endian));
-
-  return little_endian;
+  double value = read<double>();
+  return value;
 }
 
 void Unpickler::run() {

--- a/torch/csrc/utils/byte_order.cpp
+++ b/torch/csrc/utils/byte_order.cpp
@@ -65,14 +65,14 @@ THPByteOrder THP_nativeByteOrder() {
 #if defined(_WIN32) || defined(_WIN64)
   return THP_LITTLE_ENDIAN;
 #elif defined(__BYTE_ORDER__)
-  #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    return THP_LITTLE_ENDIAN;
-  #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-    return THP_BIG_ENDIAN;
-  #else
-    uint32_t x = 1;
-    return *(uint8_t*)&x ? THP_LITTLE_ENDIAN : THP_BIG_ENDIAN;
-  #endif
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return THP_LITTLE_ENDIAN;
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  return THP_BIG_ENDIAN;
+#else
+  uint32_t x = 1;
+  return *(uint8_t*)&x ? THP_LITTLE_ENDIAN : THP_BIG_ENDIAN;
+#endif
 #else
   uint32_t x = 1;
   return *(uint8_t*)&x ? THP_LITTLE_ENDIAN : THP_BIG_ENDIAN;

--- a/torch/csrc/utils/byte_order.cpp
+++ b/torch/csrc/utils/byte_order.cpp
@@ -11,64 +11,6 @@
 
 namespace {
 
-static inline void swapBytes16(void* ptr) {
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  uint16_t output;
-  memcpy(&output, ptr, sizeof(uint16_t));
-#if defined(_MSC_VER) && !defined(_DEBUG)
-  output = _byteswap_ushort(output);
-#elif defined(__llvm__) || defined(__GNUC__) && !defined(__ICC)
-  output = __builtin_bswap16(output);
-#else
-  uint16_t Hi = output >> 8;
-  uint16_t Lo = output << 8;
-  output = Hi | Lo;
-#endif
-  memcpy(ptr, &output, sizeof(uint16_t));
-}
-
-static inline void swapBytes32(void* ptr) {
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  uint32_t output;
-  memcpy(&output, ptr, sizeof(uint32_t));
-#if defined(_MSC_VER) && !defined(_DEBUG)
-  output = _byteswap_ulong(output);
-#elif defined(__llvm__) || defined(__GNUC__) && !defined(__ICC)
-  output = __builtin_bswap32(output);
-#else
-  uint32_t Byte0 = output & 0x000000FF;
-  uint32_t Byte1 = output & 0x0000FF00;
-  uint32_t Byte2 = output & 0x00FF0000;
-  uint32_t Byte3 = output & 0xFF000000;
-  output = (Byte0 << 24) | (Byte1 << 8) | (Byte2 >> 8) | (Byte3 >> 24);
-#endif
-  memcpy(ptr, &output, sizeof(uint32_t));
-}
-
-static inline void swapBytes64(void* ptr) {
-  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  uint64_t output;
-  memcpy(&output, ptr, sizeof(uint64_t));
-#if defined(_MSC_VER)
-  output = _byteswap_uint64(output);
-#elif defined(__llvm__) || defined(__GNUC__) && !defined(__ICC)
-  output = __builtin_bswap64(output);
-#else
-  uint64_t Byte0 = output & 0x00000000000000FF;
-  uint64_t Byte1 = output & 0x000000000000FF00;
-  uint64_t Byte2 = output & 0x0000000000FF0000;
-  uint64_t Byte3 = output & 0x00000000FF000000;
-  uint64_t Byte4 = output & 0x000000FF00000000;
-  uint64_t Byte5 = output & 0x0000FF0000000000;
-  uint64_t Byte6 = output & 0x00FF000000000000;
-  uint64_t Byte7 = output & 0xFF00000000000000;
-  output = (Byte0 << (7 * 8)) | (Byte1 << (5 * 8)) | (Byte2 << (3 * 8)) |
-      (Byte3 << (1 * 8)) | (Byte7 >> (7 * 8)) | (Byte6 >> (5 * 8)) |
-      (Byte5 >> (3 * 8)) | (Byte4 >> (1 * 8));
-#endif
-  memcpy(ptr, &output, sizeof(uint64_t));
-}
-
 static inline uint16_t decodeUInt16LE(const uint8_t* data) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   uint16_t output;

--- a/torch/csrc/utils/byte_order.cpp
+++ b/torch/csrc/utils/byte_order.cpp
@@ -9,6 +9,12 @@
 #include <stdlib.h>
 #endif
 
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <machine/endian.h>
+#elif !defined(_WIN32) && !defined(_WIN64)
+#include <endian.h>
+#endif
+
 namespace {
 
 static inline uint16_t decodeUInt16LE(const uint8_t* data) {
@@ -56,8 +62,21 @@ namespace torch {
 namespace utils {
 
 THPByteOrder THP_nativeByteOrder() {
+#if defined(_WIN32) || defined(_WIN64)
+  return THP_LITTLE_ENDIAN;
+#elif defined(__BYTE_ORDER__)
+  #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    return THP_LITTLE_ENDIAN;
+  #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    return THP_BIG_ENDIAN;
+  #else
+    uint32_t x = 1;
+    return *(uint8_t*)&x ? THP_LITTLE_ENDIAN : THP_BIG_ENDIAN;
+  #endif
+#else
   uint32_t x = 1;
   return *(uint8_t*)&x ? THP_LITTLE_ENDIAN : THP_BIG_ENDIAN;
+#endif
 }
 
 void THP_decodeInt16Buffer(

--- a/torch/csrc/utils/byte_order.h
+++ b/torch/csrc/utils/byte_order.h
@@ -6,6 +6,68 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace {
+
+static inline void swapBytes16(void* ptr) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  uint16_t output;
+  memcpy(&output, ptr, sizeof(uint16_t));
+#if defined(_MSC_VER) && !defined(_DEBUG)
+  output = _byteswap_ushort(output);
+#elif defined(__llvm__) || defined(__GNUC__) && !defined(__ICC)
+  output = __builtin_bswap16(output);
+#else
+  uint16_t Hi = output >> 8;
+  uint16_t Lo = output << 8;
+  output = Hi | Lo;
+#endif
+  memcpy(ptr, &output, sizeof(uint16_t));
+}
+
+static inline void swapBytes32(void* ptr) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  uint32_t output;
+  memcpy(&output, ptr, sizeof(uint32_t));
+#if defined(_MSC_VER) && !defined(_DEBUG)
+  output = _byteswap_ulong(output);
+#elif defined(__llvm__) || defined(__GNUC__) && !defined(__ICC)
+  output = __builtin_bswap32(output);
+#else
+  uint32_t Byte0 = output & 0x000000FF;
+  uint32_t Byte1 = output & 0x0000FF00;
+  uint32_t Byte2 = output & 0x00FF0000;
+  uint32_t Byte3 = output & 0xFF000000;
+  output = (Byte0 << 24) | (Byte1 << 8) | (Byte2 >> 8) | (Byte3 >> 24);
+#endif
+  memcpy(ptr, &output, sizeof(uint32_t));
+}
+
+static inline void swapBytes64(void* ptr) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  uint64_t output;
+  memcpy(&output, ptr, sizeof(uint64_t));
+#if defined(_MSC_VER)
+  output = _byteswap_uint64(output);
+#elif defined(__llvm__) || defined(__GNUC__) && !defined(__ICC)
+  output = __builtin_bswap64(output);
+#else
+  uint64_t Byte0 = output & 0x00000000000000FF;
+  uint64_t Byte1 = output & 0x000000000000FF00;
+  uint64_t Byte2 = output & 0x0000000000FF0000;
+  uint64_t Byte3 = output & 0x00000000FF000000;
+  uint64_t Byte4 = output & 0x000000FF00000000;
+  uint64_t Byte5 = output & 0x0000FF0000000000;
+  uint64_t Byte6 = output & 0x00FF000000000000;
+  uint64_t Byte7 = output & 0xFF00000000000000;
+  output = (Byte0 << (7 * 8)) | (Byte1 << (5 * 8)) | (Byte2 << (3 * 8)) |
+      (Byte3 << (1 * 8)) | (Byte7 >> (7 * 8)) | (Byte6 >> (5 * 8)) |
+      (Byte5 >> (3 * 8)) | (Byte4 >> (1 * 8));
+#endif
+  memcpy(ptr, &output, sizeof(uint64_t));
+}
+
+} // anonymous namespace
+
 namespace torch {
 namespace utils {
 


### PR DESCRIPTION
Fixes #92910 Fixes #92987 

This PR fixes handling loading and storing data for `.pkl` files in a file regarding `torch.jit.load()` and `torch.jit.save()`.   

`torch.jit.save()` generated incorrect `.pkl` files in a ZIP-format file. On a big-endian machine, values for 16/32/64-bit integer fields are stored as big-endian while the pickle format requires little-endian. Float values are stored as little-endian while the pickle format requires big-endian.
`torch.jit.load()` assumed that values for 16/32/64-bit integer fields are stored as big-endian and Float values are stored as little-endian on a big-endian machine.

This PR enables `torch.jit.save()` to store values for 16/32/64-bit integer fields as little-endian and values for float fields as big-endian on little- and big-endian machines. This PR also enables that `torch.jit.load()` loads values for 16/32/64-bit integer fields as little-endian and values for float as big-endian on little- and big-endian machines. So, the files generated by `torch.jit.save()` are portable among different endian machines.

This PR also evaluate a return value in `THP_nativeByteOrder()` as constant in a compilation time

**Note**: Downside of this PR is that the files, that were previously generated by `torch.jit.save()`, cannot be read by PyTorch with this PR. Do we need an option (e.g. declaring an environment variable `READ_OLD_TORCH_JIT_SAVE`) for backward compatibility?

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel