### PR TITLE
Improve error messages for sparse methods on tensors with unsupported backends/layouts.

### DIFF
--- a/aten/src/ATen/SparseCsrTensorUtils.h
+++ b/aten/src/ATen/SparseCsrTensorUtils.h
@@ -16,7 +16,7 @@
         return __VA_ARGS__();                                        \
       default:                                                       \
         AT_ERROR(                                                    \
-            #NAME,                                                   \
+            NAME,                                                    \
             " expected sparse compressed tensor layout but got ",    \
             the_layout);                                             \
     }                                                                \
@@ -35,7 +35,7 @@
         return (COLUMN_DIM_ACTION)();                             \
       default:                                                    \
         AT_ERROR(                                                 \
-            #NAME,                                                \
+            NAME,                                                 \
             " expected sparse compressed tensor layout but got ", \
             the_layout);                                          \
     }                                                             \
@@ -54,7 +54,7 @@
         return (BLOCK_ACTION)();                                  \
       default:                                                    \
         AT_ERROR(                                                 \
-            #NAME,                                                \
+            NAME,                                                 \
             " expected sparse compressed tensor layout but got ", \
             the_layout);                                          \
     }                                                             \
@@ -70,7 +70,7 @@
         return (ROW_DIM_ACTION)();                                    \
       default:                                                        \
         AT_ERROR(                                                     \
-            #NAME,                                                    \
+            NAME,                                                     \
             " expected sparse row compressed tensor layout but got ", \
             the_layout);                                              \
     }                                                                 \
@@ -86,7 +86,7 @@
         return (COL_DIM_ACTION)();                                       \
       default:                                                           \
         AT_ERROR(                                                        \
-            #NAME,                                                       \
+            NAME,                                                        \
             " expected sparse column compressed tensor layout but got ", \
             the_layout);                                                 \
     }                                                                    \
@@ -101,7 +101,7 @@
         return (ACTION)();                                                    \
       default:                                                                \
         AT_ERROR(                                                             \
-            #NAME,                                                            \
+            NAME,                                                             \
             " expected sparse compressed (non-block) tensor layout but got ", \
             the_layout);                                                      \
     }                                                                         \
@@ -116,7 +116,7 @@
         return (ACTION)();                                                \
       default:                                                            \
         AT_ERROR(                                                         \
-            #NAME,                                                        \
+            NAME,                                                         \
             " expected sparse compressed block tensor layout but got ",   \
             the_layout);                                                  \
     }                                                                     \

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6739,6 +6739,7 @@
   variants: method
   dispatch:
     SparseCPU, SparseCUDA, SparseMeta: is_coalesced_sparse
+    CompositeExplicitAutograd: is_coalesced_default
   device_check: NoCheck
   device_guard: False
 
@@ -6771,6 +6772,7 @@
   variants: method
   dispatch:
     SparseCPU, SparseCUDA, SparseMeta: indices_sparse
+    CompositeExplicitAutograd: indices_default
   device_check: NoCheck
   device_guard: False
 
@@ -6780,6 +6782,7 @@
     SparseCPU, SparseCUDA, SparseMeta: values_sparse
     SparseCsrCPU, SparseCsrCUDA: values_sparse_csr
     NestedTensorCPU, NestedTensorCUDA: values_nested
+    CompositeExplicitAutograd: values_default
   device_check: NoCheck
   device_guard: False
 
@@ -6787,6 +6790,7 @@
   variants: method
   dispatch:
     SparseCsrCPU, SparseCsrCUDA: crow_indices_sparse_csr
+    CompositeExplicitAutograd: crow_indices_default
   device_check: NoCheck
   device_guard: False
 
@@ -6794,6 +6798,7 @@
   variants: method
   dispatch:
     SparseCsrCPU, SparseCsrCUDA: col_indices_sparse_csr
+    CompositeExplicitAutograd: col_indices_default
   device_check: NoCheck
   device_guard: False
 
@@ -6801,6 +6806,7 @@
   variants: method
   dispatch:
     SparseCsrCPU, SparseCsrCUDA: ccol_indices_sparse_csr
+    CompositeExplicitAutograd: ccol_indices_default
   device_check: NoCheck
   device_guard: False
 
@@ -6808,6 +6814,7 @@
   variants: method
   dispatch:
     SparseCsrCPU, SparseCsrCUDA: row_indices_sparse_csr
+    CompositeExplicitAutograd: row_indices_default
   device_check: NoCheck
   device_guard: False
 

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -693,6 +693,22 @@ Tensor row_indices_sparse_csr(const Tensor& self) {
                                                    [&]{ return get_sparse_csr_impl(self)->plain_indices().alias(); });
 }
 
+Tensor crow_indices_default(const Tensor& self) {
+  TORCH_CHECK(false, "crow_indices expected sparse row compressed tensor layout but got ", self.layout());
+}
+
+Tensor col_indices_default(const Tensor& self) {
+  TORCH_CHECK(false, "col_indices expected sparse row compressed tensor layout but got ", self.layout());
+}
+
+Tensor ccol_indices_default(const Tensor& self) {
+  TORCH_CHECK(false, "ccol_indices expected sparse column compressed tensor layout but got ", self.layout());
+}
+
+Tensor row_indices_default(const Tensor& self) {
+  TORCH_CHECK(false, "row_indices expected sparse column compressed tensor layout but got ", self.layout());
+}
+
 int64_t sparse_dim_sparse_csr(const SparseCsrTensor& self) {
   return get_sparse_csr_impl(self)->sparse_dim();
 }

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -86,6 +86,11 @@ bool is_coalesced_sparse(const SparseTensor& self) {
   return get_sparse_impl(self)->coalesced();
 }
 
+bool is_coalesced_default(const Tensor& self) {
+  TORCH_CHECK(false, "is_coalesced expected sparse coordinate tensor layout but got ", self.layout());
+  return false;
+}
+
 int64_t _nnz_sparse(const SparseTensor& self) {
   return get_sparse_impl(self)->nnz();
 }
@@ -114,11 +119,19 @@ Tensor indices_sparse(const Tensor& self) {
   return get_sparse_impl(self)->indices().alias();
 }
 
+Tensor indices_default(const Tensor& self) {
+  TORCH_CHECK(false, "indices expected sparse coordinate tensor layout but got ", self.layout());
+}
+
 Tensor values_sparse(const Tensor& self) {
   TORCH_CHECK(
       self.is_coalesced(),
       "Cannot get values on an uncoalesced tensor, please call .coalesce() first");
   return get_sparse_impl(self)->values().alias();
+}
+
+Tensor values_default(const Tensor& self) {
+  TORCH_CHECK(false, "values expected sparse tensor layout but got ", self.layout());
 }
 
 /******************************************************************************
@@ -632,6 +645,7 @@ SparseTensor& copy_sparse_(
 }
 
 SparseTensor coalesce(const SparseTensor& self) {
+  TORCH_CHECK(self.layout() == kSparse, "coalesce expected sparse coordinate tensor layout but got ", self.layout());
   // See NOTE: [ coalesce autograd ]
   if (self.is_coalesced()) {
     return self;

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -4488,6 +4488,51 @@ class TestSparseAny(TestCase):
             # we count samples to avoid false-positive test reports
             self.skipTest('no sample inputs')
 
+    @onlyNativeDeviceTypes
+    @suppress_warnings
+    @parametrize("mth", [subtest(mth, name=mth.__name__)
+                         for mth in [torch.Tensor.is_coalesced,
+                                     torch.Tensor.coalesce,
+                                     torch.Tensor.indices,
+                                     torch.Tensor.values,
+                                     torch.Tensor.crow_indices,
+                                     torch.Tensor.col_indices,
+                                     torch.Tensor.ccol_indices,
+                                     torch.Tensor.row_indices,
+                                     ]])
+    @all_sparse_layouts('layout', include_strided=True)
+    def test_unsupported_backend_error_message(self, mth, layout, device):
+        inp = torch.tensor([[1, 2], [3, 4]], device=device).to_sparse(
+            layout=layout,
+            blocksize=(1, 1) if layout in {torch.sparse_bsr, torch.sparse_bsc} else None)
+        assert inp.layout is layout
+
+        expected_behaviour = dict(
+            # <mth name> = (<supported layouts>, <exception message on other layouts>)
+            is_coalesced=({torch.sparse_coo},
+                          "is_coalesced expected sparse coordinate tensor layout but got (Sparse(Csr|Csc|Bsr|Bsc)|Strided)"),
+            coalesce=({torch.sparse_coo},
+                      "coalesce expected sparse coordinate tensor layout but got (Sparse(Csr|Csc|Bsr|Bsc)|Strided)"),
+            indices=({torch.sparse_coo},
+                     "indices expected sparse coordinate tensor layout but got (Sparse(Csr|Csc|Bsr|Bsc)|Strided)"),
+            values=({torch.sparse_coo, torch.sparse_csr, torch.sparse_csc, torch.sparse_bsr, torch.sparse_bsc},
+                    "values expected sparse tensor layout but got Strided"),
+            crow_indices=({torch.sparse_csr, torch.sparse_bsr},
+                          "crow_indices expected sparse row compressed tensor layout but got (Sparse(Csc|Bsc|)|Strided)"),
+            col_indices=({torch.sparse_csr, torch.sparse_bsr},
+                         "col_indices expected sparse row compressed tensor layout but got (Sparse(Csc|Bsc|)|Strided)"),
+            ccol_indices=({torch.sparse_csc, torch.sparse_bsc},
+                          "ccol_indices expected sparse column compressed tensor layout but got (Sparse(Csr|Bsr|)|Strided)"),
+            row_indices=({torch.sparse_csc, torch.sparse_bsc},
+                         "row_indices expected sparse column compressed tensor layout but got (Sparse(Csr|Bsr|)|Strided)"),
+        )[mth.__name__]
+
+        if layout in expected_behaviour[0]:
+            mth(inp)
+        else:
+            with self.assertRaisesRegex(RuntimeError, expected_behaviour[1]):
+                mth(inp)
+
 
 # e.g., TestSparseUnaryUfuncsCPU and TestSparseUnaryUfuncsCUDA
 instantiate_device_type_tests(TestSparseUnaryUfuncs, globals(), except_for='meta')

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -1140,13 +1140,13 @@ class TestSparseCSR(TestCase):
             # error on a strided
             a_strided = a.to_dense()
             with self.assertRaisesRegex(
-                    RuntimeError, r'"resize_as_sparse_compressed_: src " expected sparse compressed tensor layout'):
+                    RuntimeError, r'resize_as_sparse_compressed_: src  expected sparse compressed tensor layout'):
                 b.resize_as_sparse_(a_strided)
 
             # error on b strided
             b_strided = b.to_dense()
             with self.assertRaisesRegex(
-                    RuntimeError, r'"resize_as_sparse_compressed_: self " expected sparse compressed tensor layout'):
+                    RuntimeError, r'resize_as_sparse_compressed_: self  expected sparse compressed tensor layout'):
                 b_strided.resize_as_sparse_(a)
 
             # error if layout does not match, transpose induces layout flip


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/92790

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93149



cc @alexsamardzic @nikitaved @cpuhrsch @amjames @bhosmer