### PR TITLE
Improve DDPOptimizer by avoiding small preamble graph

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -84,19 +84,24 @@ def get_custom_model(device):
             super(MyModule, self).__init__()
             mods = [
                 (MyLinear(), torch.nn.ReLU()),
-                # sandwitch the custom in the middle so it comes before and after
+                # sandwich the custom in the middle so it comes before and after
                 (MyCustomLinear(), torch.nn.ReLU()),
                 (MyLinear(), torch.nn.ReLU()),
             ]
             self.seq = torch.nn.Sequential(*[x for items in mods for x in items])
 
-        def forward(self, x):
-            return self.seq(x)
+        def forward(self, x, y):
+            # test special case where the 0th bucket (layers close to graph input) is at capacity, which would
+            # trigger a new bucket, but there are only trivial ops without parameters to put into the new bucket.
+            # optimize this case by fusing that 'empty bucket' back together with the previous full one
+            return self.seq(x + y)
 
     m = MyModule().to(device)
     m.apply(init_weights)
     inputs = torch.rand((512, 512)).to(device)
-    correct_outputs = m(inputs)
+    # test duplicated inputs
+    inputs = (inputs, inputs)
+    correct_outputs = m(*inputs)
     return m, inputs, correct_outputs
 
 def get_hf_bert(rank):
@@ -520,7 +525,7 @@ class TestDistributed(torch._dynamo.test_case.TestCase):
 
         @torch._dynamo.optimize(check_splits_compiler.compile_fn)
         def opt_fn(inputs):
-            return ddp_m(inputs)
+            return ddp_m(*inputs)
 
         opt_outputs = opt_fn(inputs)
         self.assertTrue(same(correct_outputs, opt_outputs))

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -104,43 +104,6 @@ def get_custom_model(device):
     correct_outputs = m(*inputs)
     return m, inputs, correct_outputs
 
-def get_duplicates_model(device):
-
-    class MyLinear(torch.nn.Module):
-        def __init__(self):
-            super(MyLinear, self).__init__()
-            self.linear = torch.nn.Linear(512, 512)
-
-        def forward(self, x):
-            return self.linear(x)
-
-    class MyModule(torch.nn.Module):
-        def __init__(self):
-            super(MyModule, self).__init__()
-            mods = [
-                (MyLinear(), torch.nn.ReLU()),
-                # sandwich the custom in the middle so it comes before and after
-                (MyCustomLinear(), torch.nn.ReLU()),
-                (MyLinear(), torch.nn.ReLU()),
-            ]
-            self.reused_param = torch.nn.Parameter(512, 512)
-            self.seq = torch.nn.Sequential(*[x for items in mods for x in items])
-
-        def forward(self, x, y):
-            # test special case where the 0th bucket (layers close to graph input) is at capacity, which would
-            # trigger a new bucket, but there are only trivial ops without parameters to put into the new bucket.
-            # optimize this case by fusing that 'empty bucket' back together with the previous full one
-            return self.seq(x + y)
-
-    m = MyModule().to(device)
-    m.apply(init_weights)
-    inputs = torch.rand((512, 512)).to(device)
-    # test duplicated inputs
-    inputs = (inputs, inputs)
-    correct_outputs = m(*inputs)
-    return m, inputs, correct_outputs
-
-
 def get_hf_bert(rank):
     # Note: use @import_transformers_or_skip on your test case if you use this
     # in a multiprocessing test

--- a/torch/_dynamo/optimizations/distributed.py
+++ b/torch/_dynamo/optimizations/distributed.py
@@ -183,6 +183,12 @@ class DDPOptimizer:
             # Ignored params still end up in buckets, we just don't count them towards the capacity
             buckets[0].nodes.append(node)
 
+        if len(buckets) > 1 and buckets[0].size == 0:
+            # we collected a small preamble graph with ops that don't include parameters, fuse it back
+            buckets[1].nodes.extend(buckets[0].nodes)
+            assert len(buckets[0].params) == 0, "Params should be empty if size is 0"
+            del buckets[0]
+
         # stash buckets for testing/debugging purposes
         self.buckets = buckets
         log.info(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93162

This optimizes an edge case where some compute-only ops (e.g. add)
could end up in an orphan graph at the input side due to the bucket
for the next graph being full already.  The fix is to fuse this
graph (which is "empty" in parameter count) together with the adjoining
"full" bucket.

Note: i encountered this when trying to repro some suspected duplicate
argument errors, but this is unrelated and I have not yet repro'd
a duplicate arg issue.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire