### PR TITLE
Update ROCm CI builds to 5.4.2

### DIFF
--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -194,7 +194,7 @@ case "$image" in
     PROTOBUF=yes
     DB=yes
     VISION=yes
-    ROCM_VERSION=5.4
+    ROCM_VERSION=5.4.2
     NINJA_VERSION=1.9.0
     CONDA_CMAKE=yes
     ;;

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -83,11 +83,11 @@ jobs:
       docker-image: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-periodic-dynamo-benchmarks-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-periodic-dynamo-benchmarks-build.outputs.test-matrix }}
 
-  linux-focal-rocm5_4-py3_8-build:
-    name: linux-focal-rocm5.4-py3.8
+  linux-focal-rocm5_4_2-py3_8-build:
+    name: linux-focal-rocm5.4.2-py3.8
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-rocm5.4-py3.8
+      build-environment: linux-focal-rocm5.4.2-py3.8
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       test-matrix: |
         { include: [
@@ -100,14 +100,14 @@ jobs:
       #     { config: "slow", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },
       #   ]}
 
-  linux-focal-rocm5_4-py3_8-test:
-    name: linux-focal-rocm5.4-py3.8
+  linux-focal-rocm5_4_2-py3_8-test:
+    name: linux-focal-rocm5.4.2-py3.8
     uses: ./.github/workflows/_rocm-test.yml
-    needs: linux-focal-rocm5_4-py3_8-build
+    needs: linux-focal-rocm5_4_2-py3_8-build
     with:
-      build-environment: linux-focal-rocm5.4-py3.8
-      docker-image: ${{ needs.linux-focal-rocm5_4-py3_8-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-rocm5_4-py3_8-build.outputs.test-matrix }}
+      build-environment: linux-focal-rocm5.4.2-py3.8
+      docker-image: ${{ needs.linux-focal-rocm5_4_2-py3_8-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-rocm5_4_2-py3_8-build.outputs.test-matrix }}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -319,13 +319,13 @@ jobs:
       docker-image-name: pytorch-linux-focal-py3.8-gcc7
       build-generates-artifacts: false
 
-  linux-focal-rocm5_4-py3_8-build:
+  linux-focal-rocm5_4_2-py3_8-build:
     # don't run build twice on master
     if: github.event_name == 'pull_request'
-    name: linux-focal-rocm5.4-py3.8
+    name: linux-focal-rocm5.4.2-py3.8
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-rocm5.4-py3.8
+      build-environment: linux-focal-rocm5.4.2-py3.8
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       sync-tag: rocm-build
       test-matrix: |

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -274,11 +274,11 @@ jobs:
       cuda-version: "11.6"
       test-matrix: ${{ needs.win-vs2019-cuda11_6-py3-build.outputs.test-matrix }}
 
-  linux-focal-rocm5_4-py3_8-build:
-    name: linux-focal-rocm5.4-py3.8
+  linux-focal-rocm5_4_2-py3_8-build:
+    name: linux-focal-rocm5.4.2-py3.8
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-focal-rocm5.4-py3.8
+      build-environment: linux-focal-rocm5.4.2-py3.8
       docker-image-name: pytorch-linux-focal-rocm-n-py3
       sync-tag: rocm-build
       test-matrix: |
@@ -287,14 +287,14 @@ jobs:
           { config: "default", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
         ]}
 
-  linux-focal-rocm5_4-py3_8-test:
-    name: linux-focal-rocm5.4-py3.8
+  linux-focal-rocm5_4_2-py3_8-test:
+    name: linux-focal-rocm5.4.2-py3.8
     uses: ./.github/workflows/_rocm-test.yml
-    needs: linux-focal-rocm5_4-py3_8-build
+    needs: linux-focal-rocm5_4_2-py3_8-build
     with:
-      build-environment: linux-focal-rocm5.4-py3.8
-      docker-image: ${{ needs.linux-focal-rocm5_4-py3_8-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-rocm5_4-py3_8-build.outputs.test-matrix }}
+      build-environment: linux-focal-rocm5.4.2-py3.8
+      docker-image: ${{ needs.linux-focal-rocm5_4_2-py3_8-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-rocm5_4_2-py3_8-build.outputs.test-matrix }}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
PR https://github.com/pytorch/pytorch/pull/92972 was meant to upgrade to ROCm5.4.2, not ROCm5.4. This PR rectifies that.


cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport