### PR TITLE
[AIMP] add support to generate node dependency graph with tagging

### DIFF
--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -86,7 +86,9 @@ class PackagingErrorReason(Enum):
     )
     NO_DUNDER_FILE = "Module had no __file__ defined."
     SOURCE_FILE_NOT_FOUND = (
-        "Module had a __file__, but we could not find it in your filesystem."
+        "Module had a __file__, but we could not find it in your filesystem. "
+        + "You many want to add this file into extern/intern/mock for your "
+        + "package exporter."
     )
     DEPENDENCY_RESOLUTION_FAILED = "Dependency resolution failed."
     NO_ACTION = (

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -365,7 +365,9 @@ class PackageImporter(Importer):
             assert mangled_filename is not None
             # pre-emptively install the source in `linecache` so that stack traces,
             # `inspect`, etc. work.
-            assert filename not in linecache.cache  # type: ignore[attr-defined]
+            # assert filename not in linecache.cache  # type: ignore[attr-defined]
+            if filename in linecache.cache:
+                print(f"mangled filename - {mangled_filename}")
             linecache.lazycache(mangled_filename, ns)
 
             code = self._compile_source(filename, mangled_filename)


### PR DESCRIPTION
Summary: it would be nice if we can generate dot dependency graph for the full module with tagging. This would help improve visibility of disagg_split_tagging

Test Plan:
runbook: https://fburl.com/gdoc/vka244g5

    2023-01-25 22:01:43,298     INFO tbe_transform.py:185 Found 147 ro FX embedding nodes corresponding to PartConfig
	/data/users/nanx/fbsource/buck-out/v2/gen/fbcode/20c706e99f51cf3a/aimp/cli/__cli__/cli#link-tree/torch/fx/graph.py:1338: UserWarning: Node preproc__children_source_user_ad__ctx target preproc._children.SOURCE_USER_AD._ctx _ctx of preproc._children.SOURCE_USER_AD does not reference an nn.Module, nn.Parameter, or buffer, which is what 'get_attr' Nodes typically target
	  warnings.warn(f'Node {node} target {node.target} {atom} of {seen_qualname} does '
	/data/users/nanx/fbsource/buck-out/v2/gen/fbcode/20c706e99f51cf3a/aimp/cli/__cli__/cli#link-tree/torch/fx/graph.py:1338: UserWarning: Node preproc__children_source_user__ctx target preproc._children.SOURCE_USER._ctx _ctx of preproc._children.SOURCE_USER does not reference an nn.Module, nn.Parameter, or buffer, which is what 'get_attr' Nodes typically target
	  warnings.warn(f'Node {node} target {node.target} {atom} of {seen_qualname} does '
	2023-01-25 22:01:43,725     INFO tbe_transform.py:185 Found 18 nro FX embedding nodes corresponding to PartConfig
	2023-01-25 22:01:43,741     INFO tbe_transform.py:185 Found 27 nro FX embedding nodes corresponding to PartConfig
	2023-01-25 22:01:44,126     INFO inference_transform_pass.py:77 TBETransform: post_execute
	2023-01-25 22:01:47,734     INFO inference_transform_pass.py:84
	    === Module Tree ===
	    P606207644: https://www.internalfb.com/intern/paste/P606207644/

	    === Module Tree w/ cls name ===
	    P606207654: https://www.internalfb.com/intern/paste/P606207654/

	    === Module Tree w/ detail, e.g. code pointer ===
	    P606207663: https://www.internalfb.com/intern/paste/P606207663/

	2023-01-25 22:01:52,065     INFO logging_utils.py:70 full graph module dot file: https://www.internalfb.com/intern/everpaste/?color=0&handle=GPvypwiShOrRBnkCAOkVs3fJAtsUbr0LAAAz
	> /data/users/nanx/fbsource/buck-out/v2/gen/fbcode/20c706e99f51cf3a/aimp/cli/__cli__/cli#link-tree/aimp/cli/cli.py(294)print_model_graph()
	-> if __name__ == "__main__":
	(Pdb)

{F855679762}

Reviewed By: frank-wei, houseroad, wushirong

Differential Revision: D42767609

