### PR TITLE
Minor sympy usage fix in fbcode

### DIFF
--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -105,9 +105,7 @@ class ValueRangeAnalysis(object):
     @staticmethod
     def bool_handler(*args, **kwargs):
         # just assuming bools can have both values
-        return ValueRanges(
-            sympy.logic.boolalg.BooleanFalse, sympy.logic.boolalg.BooleanTrue
-        )
+        return ValueRanges(sympy.false, sympy.true)
 
     @staticmethod
     def default_handler(*args, **kwargs):
@@ -273,7 +271,7 @@ class ValueRangeAnalysis(object):
         else:
 
             def fn(x):
-                return sympy.core.numbers.Float(fn_int(x))
+                return sympy.Float(fn_int(x))
 
         return ValueRanges.increasing_map(x, fn)
 


### PR DESCRIPTION
Summary: To supports older versions of sympy.

Test Plan:
```
buck2 run @//mode/opt @//mode/inplace -c python.package_style=inplace -c fbcode.enable_gpu_sections=true //caffe2/benchmarks/dynamo:torchbench -- -dcuda --performance --inductor --only hf_T5
```

Differential Revision: D42812188



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire