### PR TITLE
Increase test multiprocessing waiting time

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -24,7 +24,7 @@ load_tests = load_tests
 
 TEST_REPEATS = 30
 HAS_SHM_FILES = os.path.isdir('/dev/shm')
-MAX_WAITING_TIME_IN_SECONDS = 5
+MAX_WAITING_TIME_IN_SECONDS = 30
 TEST_CUDA_IPC = torch.cuda.is_available() and \
     sys.platform != 'darwin' and \
     sys.platform != 'win32' and \
@@ -260,26 +260,40 @@ class TestMultiprocessing(TestCase):
             x = torch.zeros(5, 5).to(device, dtype)
             q = ctx.Queue()
             e = ctx.Event()
+
             data = [x, x[:, 1]]
             q.put(data)
+
             p = ctx.Process(target=simple_fill, args=(q, e))
             p.daemon = True
             lc.check_pid(p.pid)
             p.start()
-            e.wait(10)
-            self.assertTrue(e.is_set())
+
+            total_waiting_time = 0
+            waiting_time = 0.5
+            is_set = False
+            # Once the child process is done, it will set the event to notify the
+            # parent accordingly
+            while total_waiting_time <= MAX_WAITING_TIME_IN_SECONDS and not is_set:
+                time.sleep(waiting_time)
+                is_set = e.is_set()
+
+            self.assertTrue(is_set)
             self.assertTrue(data[0].eq(4).all())
             self.assertTrue(data[1].eq(4).all())
+
             p.join(100)
             self.assertFalse(p.is_alive())
 
         def test_receive():
             q = ctx.Queue()
             e = ctx.Event()
+
             p = ctx.Process(target=send_tensor, args=(q, e, device, dtype))
             p.daemon = True
             lc.check_pid(p.pid)
             p.start()
+
             t1 = q.get()
             t2 = q.get()
             self.assertTrue(t1.eq(1).all())
@@ -288,9 +302,12 @@ class TestMultiprocessing(TestCase):
             self.assertEqual(type(s1), type(s2))
             self.assertEqual(s1.data_ptr(), s1.data_ptr())
             self.assertEqual(s1, s2)
+
             # We need to delete this tensors to allow producer (child process)
             # collect them properly
             del t1, t2
+
+            # Mark the event as done and join the process
             e.set()
             p.join(100)
             self.assertFalse(p.is_alive())

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -276,6 +276,7 @@ class TestMultiprocessing(TestCase):
             # parent accordingly
             while total_waiting_time <= MAX_WAITING_TIME_IN_SECONDS and not is_set:
                 time.sleep(waiting_time)
+                total_waiting_time += waiting_time
                 is_set = e.is_set()
 
             self.assertTrue(is_set)

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -16,7 +16,7 @@ import torch.utils.hooks
 from torch.nn import Parameter
 from torch.testing._internal.common_utils import (TestCase, run_tests, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, TEST_WITH_ASAN,
                                                   load_tests, slowTest, TEST_WITH_TSAN, TEST_WITH_TORCHDYNAMO,
-                                                  TEST_WITH_ROCM)
+                                                  TEST_WITH_ROCM, IS_MACOS)
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -376,7 +376,10 @@ class TestMultiprocessing(TestCase):
                      "Fail to clean up temporary /dev/shm/torch_* file, see https://github.com/pytorch/pytorch/issues/91467")
     def test_fs_sharing(self):
         with fs_sharing():
-            self._test_sharing(repeat=TEST_REPEATS)
+            # The test works but is very slow on MacOS, see https://github.com/pytorch/pytorch/pull/93183,
+            # so run it only once there
+            repeat = 1 if IS_MACOS else TEST_REPEATS
+            self._test_sharing(repeat=repeat)
 
     @unittest.skipIf(TEST_WITH_TORCHDYNAMO,
                      "Fail to clean up temporary /dev/shm/torch_* file, see https://github.com/pytorch/pytorch/issues/91467")

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -377,7 +377,7 @@ class TestMultiprocessing(TestCase):
     def test_fs_sharing(self):
         with fs_sharing():
             # The test works but is very slow on MacOS, see https://github.com/pytorch/pytorch/pull/93183,
-            # so run it only once there
+            # so run it only once there. The delay is in waiting for the child process to terminate (join)
             repeat = 1 if IS_MACOS else TEST_REPEATS
             self._test_sharing(repeat=repeat)
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/67002

This is a follow-up from https://github.com/pytorch/pytorch/pull/91459 which fixed the flaky test everywhere excepts ROCm and MacOS.