### PR TITLE
[optim][adam] use fastest impl whenever possible, add util

### DIFF
--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 
-from .optimizer import (Optimizer, _use_grad_for_differentiable, _default_to_foreach,
+from .optimizer import (Optimizer, _use_grad_for_differentiable, _default_to_fused_or_foreach,
                         _differentiable_doc, _foreach_doc, _maximize_doc)
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 from typing import List, Optional
@@ -193,7 +193,8 @@ def adadelta(
 
     # We still respect when the user inputs False for foreach.
     if foreach is None:
-        foreach = _default_to_foreach([params, grads, square_avgs, acc_deltas], differentiable=differentiable)
+        foreach = _default_to_fused_or_foreach([params, grads, square_avgs, acc_deltas],
+                                               differentiable, has_fused = False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -193,8 +193,8 @@ def adadelta(
 
     # We still respect when the user inputs False for foreach.
     if foreach is None:
-        foreach = _default_to_fused_or_foreach([params, grads, square_avgs, acc_deltas],
-                                               differentiable, has_fused=False)[1]
+        _, foreach = _default_to_fused_or_foreach([params, grads, square_avgs, acc_deltas],
+                                                  differentiable, has_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -194,7 +194,7 @@ def adadelta(
     # We still respect when the user inputs False for foreach.
     if foreach is None:
         foreach = _default_to_fused_or_foreach([params, grads, square_avgs, acc_deltas],
-                                               differentiable, has_fused = False)[1]
+                                               differentiable, has_fused=False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -2,7 +2,7 @@ import torch
 from torch import Tensor
 
 from .optimizer import (Optimizer, _use_grad_for_differentiable, _get_value,
-                        _default_to_foreach, _differentiable_doc, _foreach_doc, _maximize_doc)
+                        _default_to_fused_or_foreach, _differentiable_doc, _foreach_doc, _maximize_doc)
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 from typing import List, Optional
 
@@ -210,7 +210,8 @@ def adagrad(
         )
 
     if foreach is None:
-        foreach = _default_to_foreach([params, grads, state_sums, state_steps], differentiable=differentiable)
+        foreach = _default_to_fused_or_foreach([params, grads, state_sums, state_steps],
+                                               differentiable, has_fused = False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -210,8 +210,8 @@ def adagrad(
         )
 
     if foreach is None:
-        foreach = _default_to_fused_or_foreach([params, grads, state_sums, state_steps],
-                                               differentiable, has_fused=False)[1]
+        _, foreach = _default_to_fused_or_foreach([params, grads, state_sums, state_steps],
+                                                  differentiable, has_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -211,7 +211,7 @@ def adagrad(
 
     if foreach is None:
         foreach = _default_to_fused_or_foreach([params, grads, state_sums, state_steps],
-                                               differentiable, has_fused = False)[1]
+                                               differentiable, has_fused=False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -312,7 +312,7 @@ def adam(params: List[Tensor],
     if fused is None and foreach is None:
         fused, foreach = _default_to_fused_or_foreach(
             [params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, state_steps],
-            differentiable, has_fused = True)
+            differentiable, has_fused=True)
 
     if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError("API has changed, `state_steps` argument must contain a list of singleton tensors")

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -2,7 +2,7 @@ import torch
 from torch import Tensor
 
 from .optimizer import (Optimizer, _use_grad_for_differentiable, _get_value, _stack_if_compiling,
-                        _default_to_foreach, _differentiable_doc, _maximize_doc, _foreach_doc)
+                        _default_to_fused_or_foreach, _differentiable_doc, _maximize_doc, _foreach_doc)
 from typing import List, Optional
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
@@ -206,8 +206,8 @@ def adamax(
         )
 
     if foreach is None:
-        foreach = _default_to_foreach([params, grads, exp_avgs, exp_infs, state_steps],
-                                      differentiable=differentiable)
+        foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_infs, state_steps],
+                                               differentiable, has_fused = False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -207,7 +207,7 @@ def adamax(
 
     if foreach is None:
         foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_infs, state_steps],
-                                               differentiable, has_fused = False)[1]
+                                               differentiable, has_fused=False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -206,8 +206,8 @@ def adamax(
         )
 
     if foreach is None:
-        foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_infs, state_steps],
-                                               differentiable, has_fused=False)[1]
+        _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_infs, state_steps],
+                                                  differentiable, has_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -1,7 +1,8 @@
 import torch
 from torch import Tensor
-from .optimizer import (Optimizer, _use_grad_for_differentiable, _get_value, _dispatch_sqrt, _stack_if_compiling,
-                        _capturable_doc, _differentiable_doc, _foreach_doc, _maximize_doc, _default_to_foreach)
+from .optimizer import (Optimizer, _use_grad_for_differentiable, _get_value, _dispatch_sqrt,
+                        _stack_if_compiling, _capturable_doc, _differentiable_doc, _foreach_doc,
+                        _maximize_doc, _default_to_fused_or_foreach)
 from typing import List, Optional
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
@@ -251,9 +252,9 @@ def adamw(
 
     # Respect when the user inputs False/True for foreach.
     if foreach is None:
-        foreach = _default_to_foreach(
+        foreach = _default_to_fused_or_foreach(
             [params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, state_steps],
-            differentiable=differentiable)
+            differentiable, has_fused = False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -254,7 +254,7 @@ def adamw(
     if foreach is None:
         foreach = _default_to_fused_or_foreach(
             [params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, state_steps],
-            differentiable, has_fused = False)[1]
+            differentiable, has_fused=False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -252,9 +252,9 @@ def adamw(
 
     # Respect when the user inputs False/True for foreach.
     if foreach is None:
-        foreach = _default_to_fused_or_foreach(
+        _, foreach = _default_to_fused_or_foreach(
             [params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, state_steps],
-            differentiable, has_fused=False)[1]
+            differentiable, has_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -1,8 +1,8 @@
 import torch
 from torch import Tensor
 
-from .optimizer import (Optimizer, _use_grad_for_differentiable, _get_value,
-                        _default_to_foreach, _differentiable_doc, _foreach_doc, _maximize_doc)
+from .optimizer import (Optimizer, _use_grad_for_differentiable, _get_value, _default_to_fused_or_foreach,
+                        _differentiable_doc, _foreach_doc, _maximize_doc)
 from torch._utils import is_compiling
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 from typing import List, Optional
@@ -185,8 +185,8 @@ def asgd(
     """
 
     if foreach is None:
-        foreach = _default_to_foreach([params, grads, axs, mus, etas, state_steps],
-                                      differentiable=differentiable)
+        foreach = _default_to_fused_or_foreach([params, grads, axs, mus, etas, state_steps],
+                                               differentiable, has_fused = False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -185,8 +185,8 @@ def asgd(
     """
 
     if foreach is None:
-        foreach = _default_to_fused_or_foreach([params, grads, axs, mus, etas, state_steps],
-                                               differentiable, has_fused=False)[1]
+        _, foreach = _default_to_fused_or_foreach([params, grads, axs, mus, etas, state_steps],
+                                                  differentiable, has_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -186,7 +186,7 @@ def asgd(
 
     if foreach is None:
         foreach = _default_to_fused_or_foreach([params, grads, axs, mus, etas, state_steps],
-                                               differentiable, has_fused = False)[1]
+                                               differentiable, has_fused=False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 from .optimizer import (Optimizer, _use_grad_for_differentiable, _get_value, _dispatch_sqrt, _stack_if_compiling,
-                        _differentiable_doc, _foreach_doc, _default_to_foreach)
+                        _differentiable_doc, _foreach_doc, _default_to_fused_or_foreach)
 from typing import List, Optional
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
@@ -187,8 +187,8 @@ def nadam(params: List[Tensor],
         raise RuntimeError("API has changed, `mu_products` argument must contain a list of singleton tensors")
 
     if foreach is None:
-        foreach = _default_to_foreach([params, grads, exp_avgs, exp_avg_sqs,
-                                       mu_products, state_steps], differentiable=differentiable)
+        foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, mu_products, state_steps],
+                                               differentiable, has_fused = False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError('torch.jit.script not supported with foreach optimizers')

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -188,7 +188,7 @@ def nadam(params: List[Tensor],
 
     if foreach is None:
         foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, mu_products, state_steps],
-                                               differentiable, has_fused = False)[1]
+                                               differentiable, has_fused=False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError('torch.jit.script not supported with foreach optimizers')

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -187,8 +187,8 @@ def nadam(params: List[Tensor],
         raise RuntimeError("API has changed, `mu_products` argument must contain a list of singleton tensors")
 
     if foreach is None:
-        foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, mu_products, state_steps],
-                                               differentiable, has_fused=False)[1]
+        _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, mu_products, state_steps],
+                                                  differentiable, has_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError('torch.jit.script not supported with foreach optimizers')

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -3,7 +3,7 @@ import torch
 from torch import Tensor
 
 from .optimizer import (Optimizer, _use_grad_for_differentiable, _get_value, _dispatch_sqrt, _stack_if_compiling,
-                        _default_to_foreach, _differentiable_doc, _foreach_doc)
+                        _default_to_fused_or_foreach, _differentiable_doc, _foreach_doc)
 from typing import List, Optional
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
 
@@ -209,8 +209,8 @@ def radam(
         )
 
     if foreach is None:
-        foreach = _default_to_foreach([params, grads, exp_avgs, exp_avg_sqs, state_steps],
-                                      differentiable=differentiable)
+        foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, state_steps],
+                                               differentiable, has_fused = False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -210,7 +210,7 @@ def radam(
 
     if foreach is None:
         foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, state_steps],
-                                               differentiable, has_fused = False)[1]
+                                               differentiable, has_fused=False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -209,8 +209,8 @@ def radam(
         )
 
     if foreach is None:
-        foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, state_steps],
-                                               differentiable, has_fused=False)[1]
+        _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, state_steps],
+                                                  differentiable, has_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from .optimizer import (Optimizer, _default_to_foreach, _use_grad_for_differentiable,
+from .optimizer import (Optimizer, _default_to_fused_or_foreach, _use_grad_for_differentiable,
                         _differentiable_doc, _foreach_doc, _maximize_doc)
 from typing import List, Optional
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
@@ -220,8 +220,8 @@ def rmsprop(
     """
 
     if foreach is None:
-        foreach = _default_to_foreach([params, grads, square_avgs, grad_avgs, momentum_buffer_list],
-                                      differentiable=differentiable)
+        foreach = _default_to_fused_or_foreach([params, grads, square_avgs, grad_avgs, momentum_buffer_list],
+                                               differentiable, has_fused = False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -221,7 +221,7 @@ def rmsprop(
 
     if foreach is None:
         foreach = _default_to_fused_or_foreach([params, grads, square_avgs, grad_avgs, momentum_buffer_list],
-                                               differentiable, has_fused = False)[1]
+                                               differentiable, has_fused=False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -220,8 +220,8 @@ def rmsprop(
     """
 
     if foreach is None:
-        foreach = _default_to_fused_or_foreach([params, grads, square_avgs, grad_avgs, momentum_buffer_list],
-                                               differentiable, has_fused=False)[1]
+        _, foreach = _default_to_fused_or_foreach([params, grads, square_avgs, grad_avgs, momentum_buffer_list],
+                                                  differentiable, has_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from .optimizer import (Optimizer, _use_grad_for_differentiable, _default_to_foreach,
+from .optimizer import (Optimizer, _use_grad_for_differentiable, _default_to_fused_or_foreach,
                         _differentiable_doc, _foreach_doc, _maximize_doc)
 from typing import List, Optional
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
@@ -192,7 +192,8 @@ def rprop(
     """
 
     if foreach is None:
-        foreach = _default_to_foreach([params, grads, prevs, step_sizes], differentiable=differentiable)
+        foreach = _default_to_fused_or_foreach([params, grads, prevs, step_sizes],
+                                               differentiable, has_fused = False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -192,8 +192,8 @@ def rprop(
     """
 
     if foreach is None:
-        foreach = _default_to_fused_or_foreach([params, grads, prevs, step_sizes],
-                                               differentiable, has_fused=False)[1]
+        _, foreach = _default_to_fused_or_foreach([params, grads, prevs, step_sizes],
+                                                  differentiable, has_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -193,7 +193,7 @@ def rprop(
 
     if foreach is None:
         foreach = _default_to_fused_or_foreach([params, grads, prevs, step_sizes],
-                                               differentiable, has_fused = False)[1]
+                                               differentiable, has_fused=False)[1]
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from .optimizer import (Optimizer, required, _use_grad_for_differentiable, _default_to_foreach,
+from .optimizer import (Optimizer, required, _use_grad_for_differentiable, _default_to_fused_or_foreach,
                         _differentiable_doc, _foreach_doc, _maximize_doc)
 from typing import List, Optional
 from torch.utils._foreach_utils import _group_tensors_by_device_and_dtype
@@ -207,7 +207,8 @@ def sgd(params: List[Tensor],
         # why must we be explicit about an if statement for torch.jit.is_scripting here?
         # because JIT can't handle Optionals nor fancy conditionals when scripting
         if not torch.jit.is_scripting():
-            foreach = _default_to_foreach([params, d_p_list, momentum_buffer_list])
+            foreach = _default_to_fused_or_foreach([params, d_p_list, momentum_buffer_list],
+                                                   differentiable = False, has_fused = False)[1]
         else:
             foreach = False
 

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -208,7 +208,7 @@ def sgd(params: List[Tensor],
         # because JIT can't handle Optionals nor fancy conditionals when scripting
         if not torch.jit.is_scripting():
             foreach = _default_to_fused_or_foreach([params, d_p_list, momentum_buffer_list],
-                                                   differentiable = False, has_fused = False)[1]
+                                                   differentiable=False, has_fused=False)[1]
         else:
             foreach = False
 

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -207,8 +207,8 @@ def sgd(params: List[Tensor],
         # why must we be explicit about an if statement for torch.jit.is_scripting here?
         # because JIT can't handle Optionals nor fancy conditionals when scripting
         if not torch.jit.is_scripting():
-            foreach = _default_to_fused_or_foreach([params, d_p_list, momentum_buffer_list],
-                                                   differentiable=False, has_fused=False)[1]
+            _, foreach = _default_to_fused_or_foreach([params, d_p_list, momentum_buffer_list],
+                                                      differentiable=False, has_fused=False)
         else:
             foreach = False
 


### PR DESCRIPTION
This allows it so that ONLY when the users don't set anything for foreach or fused do we switch the default and cascades adam so that we default to fused, then foreach, then single-tensor. 

To clarify:
* if the user puts True in foreach _only_, it will run the foreach implementation.
* if the user puts True in fused _only_, it will run the fused implementation.
* if the user puts True in foreach AND for fused, it will run the fused implementation.

And:
* if the user puts False in foreach _only_, it will run the single tensor implementation.
* if the user puts False in fused _only_, it will still run the single tensor implementation.
* if the user puts False in foreach AND for fused, it will run the single tensor implementation.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93184

I also didn't trust myself that much with the helper function, so I ran some local asserts on _default_to_fused_or_foreach. The only point left to really test is the type(p) -- torch.Tensor but I think the distributed tests will catch that in CI.
```
cuda_only_fp_list = [
    torch.rand((1, 2), device="cuda", dtype=torch.float32),
    torch.rand((1, 2), device="cuda", dtype=torch.float64),
    torch.rand((1, 2), device="cuda", dtype=torch.float16),
    torch.rand((1, 2), device="cuda", dtype=torch.bfloat16),
]

cuda_only_int_list = [
    torch.randint(1024, (1, 2), device="cuda", dtype=torch.int64),
]

cpu_list = [
    torch.rand((1, 2), device="cpu", dtype=torch.float32),
    torch.rand((1, 2), device="cpu", dtype=torch.float64),
    torch.rand((1, 2), device="cpu", dtype=torch.float16),
]

none_list = [None]

# differentiable should always make it return false for both
assert _default_to_fused_or_foreach([cuda_only_fp_list], True, True) == (False, False)
assert _default_to_fused_or_foreach([cuda_only_fp_list], True, False) == (False, False)

# cpu lists should always make it return false for both
assert _default_to_fused_or_foreach([cuda_only_fp_list, cpu_list], False, True) == (False, False)
assert _default_to_fused_or_foreach([cpu_list], False, True) == (False, False)
assert _default_to_fused_or_foreach([cuda_only_fp_list, cpu_list], False, False) == (False, False)
assert _default_to_fused_or_foreach([cpu_list], False, False) == (False, False)

# has fused triggers correctly
assert _default_to_fused_or_foreach([cuda_only_fp_list], False, True) == (True, False)
assert _default_to_fused_or_foreach([cuda_only_fp_list], False, False) == (False, True)

# ints always goes to foreach
assert _default_to_fused_or_foreach([cuda_only_fp_list, cuda_only_int_list], False, True) == (False, True)
assert _default_to_fused_or_foreach([cuda_only_fp_list, cuda_only_int_list], False, False) == (False, True)

# Nones don't error
assert _default_to_fused_or_foreach([cuda_only_fp_list, none_list], False, True) == (True, False)
assert _default_to_fused_or_foreach([cuda_only_fp_list, cuda_only_int_list, none_list], False, True) == (False, True)
assert _default_to_fused_or_foreach([none_list], False, True) == (True, False)
assert _default_to_fused_or_foreach([none_list], False, False) == (False, True)
```

cc @ezyang @gchanan