### PR TITLE
Revert "Propagate sources in VariableBuilder and add SuperSource (#91729)"

### DIFF
--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -211,9 +211,7 @@ class SideEffects:
     ):
         obj = object_new(user_cls)
         variable = variable_cls(
-            obj,
-            mutable_local=AttributeMutationNew(None, cls_source),
-            **options,
+            obj, mutable_local=AttributeMutationNew(None, cls_source), **options
         )
         self.id_to_variable[id(obj)] = variable
         self.keepalive.append(obj)

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -252,30 +252,6 @@ class TypeSource(Source):
 
 
 @dataclasses.dataclass
-class SuperSource(Source):
-    type: Source
-    obj: Source
-
-    def __post_init__(self):
-        assert self.type is not None
-        assert self.obj is not None
-
-    def reconstruct(self, codegen):
-        codegen.load_import_from("builtins", "super")
-        return (
-            self.type.reconstruct(codegen)
-            + self.obj.reconstruct(codegen)
-            + [create_instruction("CALL_FUNCTION", 2)]
-        )
-
-    def guard_source(self):
-        return self.obj.guard_source()
-
-    def name(self):
-        return f"super({self.type.name()}, {self.obj.name()})"
-
-
-@dataclasses.dataclass
 class ODictGetItemSource(Source):
     base: Source
     index: Any

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -15,7 +15,7 @@ from ..allowed_functions import is_allowed
 from ..exc import unimplemented, Unsupported
 from ..guards import GuardBuilder
 from ..replay_record import DummyModule
-from ..source import AttrSource, is_constant_source, SuperSource, TypeSource
+from ..source import AttrSource, is_constant_source, TypeSource
 from ..utils import (
     check_constant_args,
     check_unspec_python_args,
@@ -598,12 +598,7 @@ class BuiltinVariable(VariableTracker):
         return variables.ConstantVariable(val)
 
     def call_super(self, tx, a, b):
-        source = (
-            None
-            if a.source is None or b.source is None
-            else SuperSource(a.source, b.source)
-        )
-        return variables.SuperVariable(a, b, source=source)
+        return variables.SuperVariable(a, b)
 
     def call_next(self, tx, arg):
         if isinstance(arg, variables.ListIteratorVariable):

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -148,11 +148,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
             itertools.count(), self.fn.__code__.co_freevars, closure
         ):
             if name == "__class__":
-                source = AttrSource(self.source, "__class__") if self.source else None
-                result[name] = variables.UserDefinedClassVariable(
-                    cell.cell_contents,
-                    source=source,
-                )
+                result[name] = variables.UserDefinedClassVariable(cell.cell_contents)
             else:
                 var = tx.match_nested_cell(name, cell)
                 if var is not None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #93203 [FSDP][Dynamo] Show T5-small error
* **#93202 Revert "Propagate sources in VariableBuilder and add SuperSource (#91729)"**
* #93201 Revert "Handle tensor default func args when inlining (#90575)"
* #93200 [WIP] `fully_shard` + PT2

This reverts commit 8e2e648f846f21aae7a8eeadf6964d8a9467af1b.