### PR TITLE
[FSDP][Dynamo] Show T5-small error

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -144,10 +144,10 @@ def get_hf_t5(rank):
     model = T5ForConditionalGeneration(config).to(device)
     model.train()
     inputs = {
-        "source_ids": torch.randint(1, 32000, (10, 1024,), dtype=torch.long, device=device),
-        "source_mask": torch.randint(1, 32000, (10, 1024,), dtype=torch.long, device=device),
-        "target_ids": torch.randint(1, 32000, (10, 1024,), dtype=torch.long, device=device),
-        "target_mask": torch.randint(1, 32000, (10, 1024,), dtype=torch.long, device=device),
+        "source_ids": torch.randint(0, 32128, (2, 1024,), dtype=torch.long, device=device),
+        "source_mask": torch.randint(0, 2, (2, 1024,), dtype=torch.long, device=device),
+        "target_ids": torch.randint(0, 32128, (2, 1024,), dtype=torch.long, device=device),
+        "target_mask": torch.randint(0, 2, (2, 1024,), dtype=torch.long, device=device),
     }
     return model, inputs
 
@@ -451,8 +451,7 @@ class TestDistributedMultiProc(MultiProcessTestCase):
             inputs_flat = [inputs[k] for k in inputs]
             correct_results = collect_results(eager_model, correct_outputs.logits, correct_loss, inputs_flat)
             opt_results = collect_results(opt_model, opt_outputs.logits, opt_loss, inputs_flat)
-            # TODO: Fix correctness.
-            self.assertFalse(same(correct_results, opt_results))
+            self.assertTrue(same(correct_results, opt_results))
 
             # TODO: Fix compilation error from gradient accumulation without
             # `no_sync()`:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #93205 [FSDP][Dynamo] Show with revert, Dynamo error disappears
* **#93204 [FSDP][Dynamo] Show T5-small error**

**To-Do**
- [ ] Understand why does the `FlatParameter` and its gradient get traced (is this expected?).
- [ ] Understand why does this error not manifest for the HF BERT model in the existing unit test when we similarly add a second forward pass.
- [ ] Understand why there was a regression with respect to this behavior since 12/30 to 1/27 (the error only started after rebasing an old branch based on top of 12/30's `viable/strict` to 1/27's `viable/strict`).

<details>
<summary> Some Details </summary>

Based on memory, this warning may be new after the rebase (unsure if related):
```
torch._dynamo.symbolic_convert: [WARNING] /fsx/users/andgu/work/transformers/src/transformers/models/t5/modeling_t5.py <function T5Attention._relative_position_bucket at 0x7f338b758310> [UnspecializedNNModuleVariable(T5Attention), TensorVariable()] {'bidirectional': ConstantVariable(bool), 'num_buckets': ConstantVariable(int), 'max_distance': ConstantVariable(int)} multiple values for argument 'bidirectional'
```

For the HF BERT model, Dynamo does not appear to trace into the `FlatParameter` and its gradient. We can see this by adding a print in the following branch when `t.shape != t.grad.shape`:
https://github.com/pytorch/pytorch/blob/b74a0fc486250f86282f1bb20d7205d13e7b7094/torch/_subclasses/meta_utils.py#L430-L438
For the HF BERT model, no print happens. For the HF T5 model, we see the following when running with world size 8:
```
r: torch.Size([1836224])
t: torch.Size([1836224])
t.grad: torch.Size([229528])
```
I.e., `r` and `t` have the unsharded size, whereas `t.grad` has the sharded size (from the last backward's reduce-scatter).  For some reason, Dynamo is tracing the `FlatParameter` and its gradient during the (second) forward.

</details>

**Follow-Ups**
Even for the original parameters:
- When inside `no_sync()`, parameter and gradient sizes can mismatch (where parameters are sharded and gradients are unsharded).
    - We assume that the user will run an additional backward outside `no_sync()`, restoring parameter/gradient size parity, before running an optimizer step.
- When using `MixedPrecision(keep_low_precision_grads=True)`, parameter and gradient dtypes can mismatch (where parameters are full precision and gradients are low precision).
    - We assume that the optimizer computation handles the type promotion at the operator level.

We need to test FSDP + Dynamo for these cases and triage from there.