### PR TITLE
[FSDP][Dynamo] Show with revert, Dynamo error disappears

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -453,18 +453,29 @@ class TestDistributedMultiProc(MultiProcessTestCase):
             opt_results = collect_results(opt_model, opt_outputs.logits, opt_loss, inputs_flat)
             self.assertTrue(same(correct_results, opt_results))
 
-            # TODO: Fix compilation error from gradient accumulation without
-            # `no_sync()`:
-            # RuntimeError: assigned grad has data of a different size
-            with self.assertRaises(InternalTorchDynamoError):
-                # Run a second forward to trigger error with the accumulated
-                # gradient, which has sharded size, while the `FlatParameter`
-                # has unsharded size
-                opt_outputs = opt_model(
-                    input_ids=inputs["source_ids"],
-                    attention_mask=inputs["source_mask"],
-                    labels=inputs["target_ids"],
-                )
+            # TODO: With the revert changes, we can run this without any Dynamo
+            # error now.
+            reset_rng_state()
+            correct_outputs = eager_model(
+                input_ids=inputs["source_ids"],
+                attention_mask=inputs["source_mask"],
+                labels=inputs["target_ids"],
+            )
+            correct_loss = correct_outputs["loss"]
+            correct_loss.backward()
+            reset_rng_state()
+            opt_outputs = opt_model(
+                input_ids=inputs["source_ids"],
+                attention_mask=inputs["source_mask"],
+                labels=inputs["target_ids"],
+            )
+            opt_loss = opt_outputs["loss"]
+            opt_loss.backward()
+
+            inputs_flat = [inputs[k] for k in inputs]
+            correct_results = collect_results(eager_model, correct_outputs.logits, correct_loss, inputs_flat)
+            opt_results = collect_results(opt_model, opt_outputs.logits, opt_loss, inputs_flat)
+            self.assertTrue(same(correct_results, opt_results))
 
 
 @requires_nccl()

--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -14,7 +14,6 @@ import torch.distributed as dist
 from contextlib import contextmanager
 from torch import nn
 from torch._dynamo import config
-from torch._dynamo.exc import InternalTorchDynamoError
 from torch._dynamo.utils import same
 from torch._dynamo.testing import collect_results
 from torch._inductor.utils import has_triton

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -45,7 +45,7 @@ torch.set_default_dtype(torch.double)
 from torch._six import inf, nan
 from torch.testing._internal.common_utils import \
     (TestCase, run_tests, set_rng_seed, TEST_WITH_UBSAN, load_tests,
-     gradcheck, skipIfTorchDynamo)
+     gradcheck)
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.autograd import grad
 import torch.autograd.forward_ad as fwAD
@@ -800,7 +800,6 @@ class DistributionsTestCase(TestCase):
         super(DistributionsTestCase, self).setUp()
 
 
-@skipIfTorchDynamo("Not a TorchDynamo suitable test")
 class TestDistributions(DistributionsTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
@@ -915,7 +914,6 @@ class TestDistributions(DistributionsTestCase):
                                  msg='{} example {}/{}, .sample() is not detached'.format(
                                      Dist.__name__, i + 1, len(params)))
 
-    @skipIfTorchDynamo("Not a TorchDynamo suitable test")
     def test_rsample_requires_grad(self):
         for Dist, params in EXAMPLES:
             for i, param in enumerate(params):
@@ -3255,7 +3253,6 @@ class TestDistributions(DistributionsTestCase):
 # These tests are only needed for a few distributions that implement custom
 # reparameterized gradients. Most .rsample() implementations simply rely on
 # the reparameterization trick and do not need to be tested for accuracy.
-@skipIfTorchDynamo("Not a TorchDynamo suitable test")
 class TestRsample(DistributionsTestCase):
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_gamma(self):
@@ -3926,7 +3923,6 @@ class TestDistributionShapes(DistributionsTestCase):
         self.assertEqual(continuous_bernoulli.log_prob(torch.ones(3, 1, 1)).size(), torch.Size((3, 3, 2)))
 
 
-@skipIfTorchDynamo("Not a TorchDynamo suitable test")
 class TestKL(DistributionsTestCase):
 
     def setUp(self):
@@ -4373,7 +4369,6 @@ class TestConstraints(DistributionsTestCase):
                 self.assertTrue(ok.all(), msg=message)
 
 
-@skipIfTorchDynamo("Not a TorchDynamo suitable test")
 class TestNumericalStability(DistributionsTestCase):
     def _test_pdf_score(self,
                         dist_class,

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -713,20 +713,6 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         else:
             return x - 1
 
-    @make_test
-    def test_torch_distributions_functions(x):
-        normal = torch.distributions.Normal(x, torch.tensor(1))
-        independent = torch.distributions.Independent(normal, 1)
-        return independent.log_prob(x)
-
-    @make_test
-    def test_context_wrapping_nested_functions_no_closure(x):
-        @torch.no_grad()
-        def augment(x: torch.Tensor) -> torch.Tensor:
-            return (x + 1) * 2
-
-        return augment(x)
-
     # # This is to test the new syntax for pattern matching
     # # ("match ... case ...") added on python 3.10.
     # # Uncomment these test cases if you run on 3.10+

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1888,7 +1888,6 @@ class TestSparse(TestSparseBase):
         test_shape([3, 4], [1, 4], [4, 4, 4], [3, 4, 4])
         test_shape([3, 4, 0], [1, 4], [4, 4, 4, 0], [3, 4, 4, 0])
 
-    @skipIfTorchDynamo("Not a TorchDynamo suitable test")
     @dtypes(torch.double, torch.cdouble)
     def test_add_noncontiguous(self, device, dtype):
         indices = self.index_tensor([[1, 2], [0, 2]], device=device)

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -9,7 +9,7 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import SM53OrLater, SM80OrLater, TEST_CUSPARSE_GENERIC
 from torch.testing._internal.common_utils import \
     (TEST_WITH_ROCM, TEST_SCIPY, TEST_NUMPY, TEST_MKL, IS_WINDOWS, TestCase, run_tests, load_tests, coalescedonoff, parametrize,
-     subtest, skipIfTorchDynamo)
+     subtest)
 from torch.testing._internal.common_device_type import \
     (ops, instantiate_device_type_tests, dtypes, OpDTypes, dtypesIfCUDA, onlyCPU, onlyCUDA, skipCUDAIfNoSparseGeneric,
      precisionOverride, skipMeta, skipCUDAIf, skipCUDAIfRocm, skipCPUIfNoMklSparse, skipCUDAIfRocmVersionLessThan)
@@ -464,7 +464,6 @@ class TestSparseCompressed(TestCase):
                 return i
         return n
 
-    @skipIfTorchDynamo("Not a TorchDynamo suitable test")
     @all_sparse_compressed_layouts()
     @ops(_sparse_compressed_ops)
     def test_consistency(self, layout, device, dtype, op):
@@ -2486,7 +2485,6 @@ class TestSparseCSR(TestCase):
             self.assertIs(actual, sample.input)
             self.assertEqual(actual, expect)
 
-    @skipIfTorchDynamo("Not a TorchDynamo suitable test")
     @ops(sparse_csr_unary_ufuncs, dtypes=OpDTypes.supported, allowed_dtypes=[torch.double, torch.cdouble])
     def test_autograd_sparse_csr_unary(self, device, dtype, op):
         if op.name not in UNARY_EWISE_CSR_ALLOW_AUTOGRAD:
@@ -2627,7 +2625,6 @@ class TestSparseCSR(TestCase):
             b = make_tensor(sample.args[1].shape, device=device, dtype=dtype, noncontiguous=True, requires_grad=True)
             self.assertTrue(torch.autograd.gradcheck(fn, [c, b], fast_mode=True))
 
-    @skipIfTorchDynamo("Not a TorchDynamo suitable test")
     @ops(binary_ops_with_dense_output, dtypes=OpDTypes.supported, allowed_dtypes=[torch.double, ])
     def test_autograd_dense_output(self, device, dtype, op):
         if op.name == "mv" and no_mkl_sparse and self.device_type == 'cpu':

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -304,7 +304,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         try:
             subobj = self._getattr_static(name)
         except AttributeError:
-            subobj = None
             if isinstance(getattr_fn, types.FunctionType):
                 return variables.UserMethodVariable(
                     getattr_fn, self, source=source, **options
@@ -316,16 +315,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return variables.UserMethodVariable(
                 subobj.fget, self, source=source, **options
             ).call_function(tx, [], {})
-        elif isinstance(subobj, staticmethod):
-            return variables.UserFunctionVariable(
-                subobj.__get__(self.value), source=source, **options
-            )
-        elif isinstance(subobj, classmethod):
-            return variables.UserMethodVariable(
-                subobj.__func__, self, source=source, **options
-            )
-        elif isinstance(subobj, types.FunctionType):
-            return variables.UserMethodVariable(subobj, self, source=source, **options)
 
         if (
             name in getattr(value, "__dict__", {})
@@ -372,6 +361,11 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             ),
         ):
             return UserDefinedObjectVariable(subobj, **options)
+
+        if isinstance(subobj, staticmethod):
+            return variables.UserFunctionVariable(subobj.__get__(self.value), **options)
+        elif isinstance(subobj, classmethod):
+            return variables.UserMethodVariable(subobj.__func__, self, **options)
 
         if name == "__class__":
             return UserDefinedClassVariable(type(self.value), **options)

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -257,7 +257,7 @@ class Distribution(object):
         """
         if not isinstance(sample_shape, torch.Size):
             sample_shape = torch.Size(sample_shape)
-        return torch.Size(sample_shape + self._batch_shape + self._event_shape)
+        return sample_shape + self._batch_shape + self._event_shape
 
     def _validate_sample(self, value: torch.Tensor) -> None:
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#93205 [FSDP][Dynamo] Show with revert, Dynamo error disappears**
* #93204 [FSDP][Dynamo] Show T5-small error

This reverts commit 0ab4ab9f8d1cea9b7fc87ee17e3aacbb39c5f7e0.

**This is not for landing.** This is only meant to show that the commit being reverted caused a regression for FSDP + Dynamo.

There are some Dynamo related errors because PRs were built on top of the one being "reverted" in this PR. E.g.,
https://github.com/pytorch/pytorch/blob/cfb160185eac2110d7202500e510fa0900b23ae2/test/dynamo/test_misc.py#L3038-L3042

```
python test/distributed/test_dynamo_distributed.py
```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire