### PR TITLE
[Export] Introduce as_none in ex.Argument union type

### DIFF
--- a/torch/_export/logical_schema.py
+++ b/torch/_export/logical_schema.py
@@ -96,7 +96,9 @@ class ReturnArgument:  # Union, ONLY EXACTLY ONE of the following fields can be 
 # !!! This is a Union struct, but there is no good python construct to model this
 @dataclass
 class Argument:  # Union, ONLY EXACTLY ONE of the following fields can be set
-    # None          # !!! This is used for nullable arguments, is this the right way to handle None?
+    # A special type for representing python None in the arguments
+    # This must only be used for ops that accepts None as an argument, e.g. Tensor?, Scalar?, int?, int[]?
+    as_none: bool = None
 
     as_tensor: TensorArgument = None
     as_tensors: List[TensorArgument] = None   # Tensor[], used by aten.cat, and condition ops
@@ -131,18 +133,6 @@ class Argument:  # Union, ONLY EXACTLY ONE of the following fields can be set
     as_layout: Layout = None
     as_device: Device = None
 
-# !!! How to model optional fields? Is it an operator schema annotation, or an argument type?
-#     Tensor?
-#     Scalar?
-#     ScalarType?
-#     bool?
-#     int?
-#     int[]?
-#     float[]?
-#     SymInt[]?
-#     MemoryFormat?
-#     Layout?
-#     Device?
 
 ################################################################################
 # Following section is the defining the schema of serializing a concrete tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93210

This design has two implications
- We are **NOT** modeling nullable argument types, e.g `Tesnor?`, `int?`, `int[]?` as a special argument type
- Python None is treated as a special argument type, downstream executor/runtime need know to handle this. 

For aten.convolution's schmea, it accepts an optional input: `Tensor? bias`
```
convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor
```

Example: notice the **None** argument in the following fx.node

```
convolution_default = torch.ops.aten.convolution.default(arg0, _param_constant0, None, [2, 2], [3, 3], [1, 1], False, [0, 0], 1)
```

would be exported as 
```
            Node(
                op='call_function',
                target='aten.convolution.default',
                args=[
                    Argument(as_tensor=TensorArgument(name='arg0')),
                    Argument(
                        as_tensor=TensorArgument(name='_param_constant0')
                    ),
                    Argument(as_none=True),
                    Argument(as_ints=[2, 2]),
                    Argument(as_ints=[3, 3]),
                    Argument(as_ints=[1, 1]),
                    Argument(as_bool=False),
                    Argument(as_ints=[0, 0]),
                    Argument(as_int=1)
                ],
                kwargs={},
                outputs=[
                    ReturnArgument(
                        as_tensor=TensorArgument(name='convolution_default')
                    )
                ],
                metadata='Skipped'
            ),
```
