### PR TITLE
[Export] Remove the concept of Scalar in export schema

### DIFF
--- a/torch/_export/logical_schema.py
+++ b/torch/_export/logical_schema.py
@@ -62,7 +62,6 @@ class SymInt:  # Union, ONLY EXACTLY ONE of the following fields can be set
 #     as_flaot: float = None
 #     as_sym: str = None
 
-# Scalar = Union[int, float, bool]
 
 # This is a Tensor Arugment used in the args of an node
 # We intentionally don't store the tensor's storage, nor the tensor's meta data here,
@@ -103,11 +102,6 @@ class Argument:  # Union, ONLY EXACTLY ONE of the following fields can be set
 
     as_symint: SymIntArgument = None         # Symint can be an argument, there are symint in native_function.yaml
     as_symints: List[SymIntArgument] = None   # Symint[] can be an argement, there are symint[] in native_function.yaml
-
-    # !!! Looks like we don't need Scalar type during serialization,
-    # as it will always be a concrete type, one of int, float, bool
-    # as_scalar: Scalar = None
-    # List[Scalar], # !!! Scalar[] is in native_function.yaml, but not used in canonical aten ops yet
 
     as_bool: bool = None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93211

Scalar is a union type of [int, float, bool], it's only needed for the representation of operation schema. 

During export, we always have the concrete argument. As ex.Argument is already an union type, we don't need Scalar type anymore. 

Example
Here's the schema for aten.add.Scalar
```
add.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
```
A fx.node
```
add_tensor: f32[s0, s0] = torch.ops.aten.add.Scalar(arg0, 1.1)
```

would be exported as 
```
            Node(
                op='call_function',
                target='aten.add.Tensor',
                args=[
                    Argument(as_tensor=TensorArgument(name='arg0')),
                    Argument(as_float=1.1)
                ],
                outputs=[
                    ReturnArgument(as_tensor=TensorArgument(name='add_tensor'))
                ]
            )
```


