### PR TITLE
Add dataclass support to pytree

### DIFF
--- a/torch/fx/_pytree.py
+++ b/torch/fx/_pytree.py
@@ -36,7 +36,6 @@ def _tuple_flatten_spec(d: Tuple[Any], spec: TreeSpec) -> List[Any]:
 def _namedtuple_flatten_spec(d: NamedTuple, spec: TreeSpec) -> List[Any]:
     return [d[i] for i in range(len(spec.children_specs))]
 
-
 register_pytree_flatten_spec(dict, _dict_flatten_spec)
 register_pytree_flatten_spec(list, _list_flatten_spec)
 register_pytree_flatten_spec(tuple, _tuple_flatten_spec)

--- a/torch/fx/_pytree.py
+++ b/torch/fx/_pytree.py
@@ -36,6 +36,7 @@ def _tuple_flatten_spec(d: Tuple[Any], spec: TreeSpec) -> List[Any]:
 def _namedtuple_flatten_spec(d: NamedTuple, spec: TreeSpec) -> List[Any]:
     return [d[i] for i in range(len(spec.children_specs))]
 
+
 register_pytree_flatten_spec(dict, _dict_flatten_spec)
 register_pytree_flatten_spec(list, _list_flatten_spec)
 register_pytree_flatten_spec(tuple, _tuple_flatten_spec)

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -21,6 +21,7 @@ import operator
 from torch.utils._stats import count
 
 from torch.utils._python_dispatch import TorchDispatchMode, _pop_mode_temporarily, _get_current_dispatch_mode
+from torch.utils._pytree import _register_pytree_leaf
 from torch._subclasses import FakeTensor
 from .symbolic_shapes import ShapeEnv, SymDispatchMode, SymNode
 from torch.fx import Proxy
@@ -216,6 +217,9 @@ def maybe_disable_fake_tensor_mode():
 class _ProxyTensor:
     proxy: Proxy
     constant: Optional[torch.Tensor]
+
+
+_register_pytree_leaf(_ProxyTensor)
 
 
 def fetch_sym_proxy(tracer):

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Callable, Any, Tuple, List, Dict, Type, cast, Optional, TypeVar, overload, Union
+from typing import NamedTuple, Callable, Any, Set, Tuple, List, Dict, Type, cast, Optional, TypeVar, overload, Union
 import functools
 from collections import namedtuple, OrderedDict
 from dataclasses import dataclass, fields, is_dataclass
@@ -43,9 +43,13 @@ class NodeDef(NamedTuple):
     unflatten_fn: UnflattenFunc
 
 SUPPORTED_NODES: Dict[Type[Any], NodeDef] = {}
+EXPLICIT_LEAVES: Set[Type[Any]] = set()
 
 def _register_pytree_node(typ: Any, flatten_fn: FlattenFunc, unflatten_fn: UnflattenFunc) -> None:
     SUPPORTED_NODES[typ] = NodeDef(flatten_fn, unflatten_fn)
+
+def _register_pytree_leaf(typ: Any) -> None:
+    EXPLICIT_LEAVES.add(typ)
 
 def _dict_flatten(d: Dict[Any, Any]) -> Tuple[List[Any], Context]:
     return list(d.values()), list(d.keys())
@@ -121,7 +125,7 @@ def _get_node_type(pytree: Any) -> Any:
 
 # A leaf is defined as anything that is not a Node.
 def _is_leaf(pytree: PyTree) -> bool:
-    return _get_node_type(pytree) not in SUPPORTED_NODES.keys()
+    return type(pytree) in EXPLICIT_LEAVES or _get_node_type(pytree) not in SUPPORTED_NODES.keys()
 
 
 # A TreeSpec represents the structure of a pytree. It holds:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #93215
* __->__ #93214

For context, DDP uses pytree to extract tensors from output to insert
`_DDPSink` for delay allreduce. This PR attempts to add dataclass support
to pytree, to enable models without dataclass outputs.

cc @zou3519 @soumith