### PR TITLE
[Perf]: Move shared pointers during casts when possible

### DIFF
--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -391,7 +391,7 @@ std::shared_ptr<Module> Module::shared_from_this_checked() const {
         "module at all by passing /*include_self=*/false "
         "to modules() or named_modules()");
   }
-  return std::const_pointer_cast<Module>(ptr);
+  return std::const_pointer_cast<Module>(std::move(ptr));
 }
 
 std::ostream& operator<<(std::ostream& stream, const nn::Module& module) {

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -680,7 +680,7 @@ std::unique_ptr<ProfilerResult> disableProfiler() {
 
   // Traces are converged via libkineto automatically for ondemand flow
   if (state_ptr->config().global()) {
-    (void)std::static_pointer_cast<KinetoThreadLocalState>(state_ptr)
+    (void)std::static_pointer_cast<KinetoThreadLocalState>(std::move(state_ptr))
         ->finalizeTrace();
     return std::make_unique<ProfilerResult>();
   }
@@ -694,7 +694,7 @@ std::unique_ptr<ProfilerResult> disableProfiler() {
   if (config.state == ProfilerState::KINETO ||
       config.state == ProfilerState::KINETO_GPU_FALLBACK) {
     auto kineto_state_ptr =
-        std::static_pointer_cast<KinetoThreadLocalState>(state_ptr);
+        std::static_pointer_cast<KinetoThreadLocalState>(std::move(state_ptr));
     auto trace = kineto_state_ptr->finalizeTrace();
     result = std::make_unique<ProfilerResult>(
         kineto_state_ptr->start_time_,

--- a/torch/csrc/jit/tensorexpr/fwd_decls.h
+++ b/torch/csrc/jit/tensorexpr/fwd_decls.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <c10/core/ScalarType.h>
 #include <memory>
+#include <utility>
 
 namespace torch {
 namespace jit {
@@ -11,12 +12,12 @@ using NodePtr = std::shared_ptr<Node>;
 
 template <typename To, typename From>
 NodePtr<To> to(NodePtr<From> x) {
-  return std::dynamic_pointer_cast<To>(x);
+  return std::dynamic_pointer_cast<To>(std::move(x));
 }
 
 template <typename To, typename From>
 NodePtr<To> static_to(NodePtr<From> x) {
-  return std::static_pointer_cast<To>(x);
+  return std::static_pointer_cast<To>(std::move(x));
 }
 
 template <typename Node, typename... Args>


### PR DESCRIPTION
Follow up to #93221 since I noticed we aren't efficiently casting our shared_ptr implementations when we should be, this is just strictly more efficient and avoids an atomic lock.

cc @EikanWang @jgong5