### PR TITLE
Apply Clang-Tidy readability-container-size-empty

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,6 +39,7 @@ modernize-*,
 performance-*,
 -performance-noexcept-move-constructor,
 -performance-unnecessary-value-param,
+readability-container-size-empty,
 '
 HeaderFilterRegex: '^(c10/(?!test)|torch/csrc/(?!deploy/interpreter/cpython)).*$'
 AnalyzeTemporaryDtors: false

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -106,7 +106,7 @@ struct strided_tensor_iter {
 };
 
 inline bool _all_equal_numel(at::ArrayRef<Tensor> tensors) {
-  if (tensors.size() == 0)
+  if (tensors.empty())
     return true;
   int64_t all_numel = tensors[0].numel();
   for (const auto i : c10::irange(1, tensors.size())) {

--- a/aten/src/ATen/FunctionalStorageImpl.cpp
+++ b/aten/src/ATen/FunctionalStorageImpl.cpp
@@ -46,6 +46,7 @@ const Tensor apply_update(const FunctionalStorageImpl::Update& update, const Ten
   if (update.view_metas.empty()) return t;
 
   std::vector<at::Tensor> tmp_values({base});
+  tmp_values.reserve(update.view_metas.size());
   for (size_t i = 0; i < update.view_metas.size() - 1; ++i) {
     at::Tensor next_view = update.view_metas[i].forward_fn(tmp_values.back(), update.view_metas[i].out_index);
     // NB: We only actually need tmp_values for ops like select/slice/diagonal/squeeze/as_strided

--- a/aten/src/ATen/FunctionalStorageImpl.cpp
+++ b/aten/src/ATen/FunctionalStorageImpl.cpp
@@ -43,7 +43,7 @@ ViewMeta ViewMeta::to_out_idx(int64_t out_idx) {
 const Tensor apply_update(const FunctionalStorageImpl::Update& update, const Tensor& base) {
   at::Tensor t = update.new_val;
   TORCH_INTERNAL_ASSERT(!at::functionalization::impl::isFunctionalTensor(t));
-  if (update.view_metas.size() == 0) return t;
+  if (update.view_metas.empty()) return t;
 
   std::vector<at::Tensor> tmp_values({base});
   for (size_t i = 0; i < update.view_metas.size() - 1; ++i) {
@@ -113,7 +113,7 @@ bool FunctionalStorageImpl::apply_updates() {
   // It adds the Functionalize key into TLS before redispatching to the functionalization kernels,
   // which means that we need to explicitly exclude it here before doing any other work underneath the pass.
   at::AutoDispatchSkipFunctionalize guard;
-  bool any_updates = updates_.size() > 0;
+  bool any_updates = !updates_.empty();
   for (auto& update_data: updates_) {
     base_ = apply_update(update_data, base_);
   }

--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -132,7 +132,7 @@ FunctionalTensorWrapper::FunctionalTensorWrapper(const Tensor& view_value, const
 {
   set_constructor_metadata();
   // Copy the original tensor's ViewMeta vector and push the current one.
-  if (base->view_metas_.size() > 0) {
+  if (!base->view_metas_.empty()) {
       view_metas_ = base->view_metas_;  // copy
   }
   view_metas_.push_back(meta);
@@ -238,7 +238,7 @@ void FunctionalTensorWrapper::maybe_replace_storage(const Tensor& other) {
   //
   // Given all of the above, for now we're just banning the above usage.
   TORCH_CHECK(storage().use_count() == 1, "Attempted to resize a view tensor to a larger size. This is not allowed in the functionalization pass");
-  TORCH_CHECK(view_metas_.size() == 0, "Attempted to resize a view tensor to a larger size. This is not allowed in the functionalization pass");
+  TORCH_CHECK(view_metas_.empty(), "Attempted to resize a view tensor to a larger size. This is not allowed in the functionalization pass");
   // If this tensor is not a view (and has no outstanding views taken out on it),
   // Then it's safe to throw out the old storage and replace it with the new, larger one.
   storage_ = c10::Storage(c10::make_intrusive<functionalization::FunctionalStorageImpl>(other));
@@ -508,7 +508,7 @@ bool isFunctionalTensor(const c10::optional<Tensor>& t) {
 }
 
 bool isFunctionalTensor(const c10::List<c10::optional<Tensor>>& t_list) {
-  if (t_list.size() == 0) return false;
+  if (t_list.empty()) return false;
   auto functional_count = 0;
   for (const auto i : c10::irange(t_list.size())) {
     if (!t_list[i].has_value() || !t_list[i]->defined()) continue;

--- a/aten/src/ATen/LegacyBatchedFallback.cpp
+++ b/aten/src/ATen/LegacyBatchedFallback.cpp
@@ -156,7 +156,7 @@ void batchedTensorInplaceForLoopFallback(const c10::OperatorHandle& op, torch::j
     batched_tensor_inputs.push_back(tensor);
     batched_tensor_inputs_position.push_back(idx);
   }
-  TORCH_INTERNAL_ASSERT(batched_tensor_inputs.size() > 0);
+  TORCH_INTERNAL_ASSERT(!batched_tensor_inputs.empty());
 
   // MultiBatchVmapTransform the BatchedTensor arguments. This returns
   // VmapPhysicalViews that contain all of the batch dimensions.
@@ -290,7 +290,7 @@ void batchedTensorForLoopFallback(const c10::OperatorHandle& op, torch::jit::Sta
     batched_tensor_inputs.push_back(tensor);
     batched_tensor_inputs_position.push_back(idx);
   }
-  TORCH_INTERNAL_ASSERT(batched_tensor_inputs.size() > 0);
+  TORCH_INTERNAL_ASSERT(!batched_tensor_inputs.empty());
 
   // MultiBatchVmapTransform the BatchedTensor arguments. This returns
   // VmapPhysicalViews that contain all of the batch dimensions.

--- a/aten/src/ATen/LegacyVmapTransforms.cpp
+++ b/aten/src/ATen/LegacyVmapTransforms.cpp
@@ -239,7 +239,7 @@ MultiBatchVmapTransform::logicalToPhysical(ITensorListRef logical_tensors) {
 
 static std::pair<std::bitset<kVmapNumLevels>,int64_t>
 getLevelsAndLargestLogicalDim(TensorList logical_tensors) {
-  TORCH_INTERNAL_ASSERT(logical_tensors.size() > 0);
+  TORCH_INTERNAL_ASSERT(!logical_tensors.empty());
   std::bitset<kVmapNumLevels> levels;
   int64_t largest_logical_dim = -1;
   for (const auto& tensor : logical_tensors) {

--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -207,7 +207,7 @@ void propagate_names_for_reduction(const Tensor& result, const Tensor& src, IntA
     return;
   }
   // This actually means "full reduction"
-  if (reduced_dims.size() == 0) {
+  if (reduced_dims.empty()) {
     return;
   }
   propagate_names_except(result, src, reduced_dims);
@@ -303,7 +303,7 @@ static int64_t num_batch_dims(DimnameList names) {
 static std::vector<Dimname> compute_matmul_outnames(
     DimnameList self_names,
     DimnameList other_names) {
-  TORCH_CHECK(self_names.size() >= 1 && other_names.size() >= 1,
+  TORCH_CHECK(!self_names.empty() && !other_names.empty(),
       "both arguments to matmul need to be at least 1D, but they are ",
       self_names.size(), "D and ", other_names.size(), "D");
 
@@ -430,7 +430,7 @@ std::vector<Dimname> compute_cat_outnames(const MaterializedITensorListRef& tens
   std::vector<Dimname> result;
   for (const Tensor& tensor : tensors) {
     const auto tensor_names = tensor.names();
-    TORCH_CHECK(tensor_names.size() > 0, "zero-dimensional tensor cannot be concatenated");
+    TORCH_CHECK(!tensor_names.empty(), "zero-dimensional tensor cannot be concatenated");
     TORCH_CHECK(result.empty() || tensor_names.size() == result.size(),
         "Tensors must have same number of dimensions: got ", result.size(),
         " and ", tensor_names.size());

--- a/aten/src/ATen/PythonTorchFunctionTLS.cpp
+++ b/aten/src/ATen/PythonTorchFunctionTLS.cpp
@@ -11,7 +11,7 @@ void PythonTorchFunctionTLS::push_onto_stack(std::shared_ptr<SafePyObject> mode)
 }
 
 const std::shared_ptr<SafePyObject> PythonTorchFunctionTLS::pop_stack() {
-  TORCH_CHECK(pythonTorchFunctionState.stack_.size() > 0, "trying to pop from empty mode stack");
+  TORCH_CHECK(!pythonTorchFunctionState.stack_.empty(), "trying to pop from empty mode stack");
   auto out = pythonTorchFunctionState.stack_.back();
   pythonTorchFunctionState.stack_.pop_back();
   return out;

--- a/aten/src/ATen/SavedTensorHooks.cpp
+++ b/aten/src/ATen/SavedTensorHooks.cpp
@@ -26,7 +26,7 @@ bool SavedTensorDefaultHooks::is_enabled() {
 
 void SavedTensorDefaultHooks::disable(const std::string& message) {
   tls.disabled_error_message = message;
-  if (tls.stack.size() > 0) {
+  if (!tls.stack.empty()) {
     assertSavedTensorHooksNotDisabled();
   }
 }

--- a/aten/src/ATen/TensorIndexing.cpp
+++ b/aten/src/ATen/TensorIndexing.cpp
@@ -65,7 +65,7 @@ static inline void set_item(const Tensor& self, ArrayRef<TensorIndex> indices, c
 } // namespace indexing
 
 Tensor Tensor::index(ArrayRef<at::indexing::TensorIndex> indices) const {
-  TORCH_CHECK(indices.size() > 0, "Passing an empty index list to Tensor::index() is not valid syntax");
+  TORCH_CHECK(!indices.empty(), "Passing an empty index list to Tensor::index() is not valid syntax");
   OptionalDeviceGuard device_guard(device_of(*this));
   return at::indexing::get_item(*this, indices);
 }
@@ -74,13 +74,13 @@ Tensor Tensor::index(std::initializer_list<at::indexing::TensorIndex> indices) c
 }
 
 Tensor & Tensor::index_put_(ArrayRef<at::indexing::TensorIndex> indices, Tensor const & rhs) {
-  TORCH_CHECK(indices.size() > 0, "Passing an empty index list to Tensor::index_put_() is not valid syntax");
+  TORCH_CHECK(!indices.empty(), "Passing an empty index list to Tensor::index_put_() is not valid syntax");
   OptionalDeviceGuard device_guard(device_of(*this));
   at::indexing::set_item(*this, indices, rhs);
   return *this;
 }
 Tensor & Tensor::index_put_(ArrayRef<at::indexing::TensorIndex> indices, const Scalar& v) {
-  TORCH_CHECK(indices.size() > 0, "Passing an empty index list to Tensor::index_put_() is not valid syntax");
+  TORCH_CHECK(!indices.empty(), "Passing an empty index list to Tensor::index_put_() is not valid syntax");
   OptionalDeviceGuard device_guard(device_of(*this));
   at::indexing::set_item(*this, indices, v);
   return *this;

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -237,7 +237,7 @@ static inline Tensor applySelect(
   // See NOTE [nested tensor size for indexing]
   if (self_sizes.has_value()) {
     TORCH_CHECK_INDEX(
-        !(index == 0 && dim == 0 && self_sizes->size() == 0),
+        !(index == 0 && dim == 0 && self_sizes->empty()),
         "invalid index of a 0-dim tensor. ",
         "Use `tensor.item()` in Python or `tensor.item<T>()` in C++ to convert a 0-dim tensor to a number");
 

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -163,7 +163,7 @@ TensorIteratorConfig& TensorIteratorConfig::declare_static_shape(IntArrayRef sha
 
 TensorIteratorConfig& TensorIteratorConfig::declare_static_shape(IntArrayRef shape, IntArrayRef squash_dims) {
   declare_static_shape(shape);
-  if (!static_shape_->size()) return *this;
+  if (static_shape_->empty()) return *this;
   for (const auto& squash_dim : squash_dims) {
     TORCH_CHECK(squash_dim >= 0 && squash_dim < static_cast<int64_t>(static_shape_->size()),
                 "squash_dim ", squash_dim, " must be in [0, ", static_shape_->size(), ").");
@@ -715,7 +715,7 @@ void TensorIteratorBase::permute_dimensions(IntArrayRef perm) {
   // Update shape and strides
   shape_ = reorder(shape_);
   for (auto& op : operands_) {
-    if (op.stride_bytes.size() > 0) {
+    if (!op.stride_bytes.empty()) {
       op.stride_bytes = reorder(op.stride_bytes);
     }
   }
@@ -1225,7 +1225,7 @@ void TensorIteratorBase::compute_shape(const TensorIteratorConfig& config) {
       "TensorIterator does not support symbolic shapes; please implement this operator in torch/_refs "
       "using the elementwise or reduction helpers (look at backtrace to find out what operator this is)");
     auto shape = op.tensor_base().sizes();
-    if (shape.size() == 0) {
+    if (shape.empty()) {
       has_scalars = true;
     } else {
       has_tensors = true;
@@ -1724,7 +1724,7 @@ void DimCounter::increment(const std::array<int64_t, 2>& step) {
 std::array<int64_t, 2> DimCounter::max_2d_step() const {
   int64_t step0 = std::min(shape[0] - values[0], range.end - offset);
   int64_t step1 = 1;
-  if (step0 == shape[0] && shape.size() >= 1) {
+  if (step0 == shape[0] && !shape.empty()) {
     step1 = std::min(shape[1] - values[1], (range.end - offset) / shape[0]);
   }
   return {step0, step1};

--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -19,7 +19,7 @@ inline int64_t maybe_wrap_dim(int64_t dim, TensorImpl* tensor) {
 }
 
 inline int64_t maybe_wrap_dim(int64_t dim, TensorList tensors) {
-  if (tensors.size() == 0) {
+  if (tensors.empty()) {
     // can't wrap empty TensorList; rely on underlying implementation to throw
     // error if necessary.
     return dim;
@@ -30,7 +30,7 @@ inline int64_t maybe_wrap_dim(int64_t dim, TensorList tensors) {
 inline int64_t maybe_wrap_dim(
     int64_t dim,
     const std::vector<std::vector<int64_t>>& tensor_sizes) {
-  if (tensor_sizes.size() == 0) {
+  if (tensor_sizes.empty()) {
     // can't wrap empty list; rely on underlying implementation to throw error
     // if necessary
     return dim;

--- a/aten/src/ATen/code_template.h
+++ b/aten/src/ATen/code_template.h
@@ -192,14 +192,14 @@ struct CodeTemplate {
       const string_list& strings,
       bool comma_before,
       bool comma_after) const {
-    if (comma_before && strings.size() > 0)
+    if (comma_before && !strings.empty())
       out << ", ";
     for (const auto i : c10::irange(strings.size())) {
       if (i > 0)
         out << ", ";
       out << strings[i];
     }
-    if (comma_after && strings.size() > 0)
+    if (comma_after && !strings.empty())
       out << ", ";
   }
   // These indentation functions follow the convention that they never emit

--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -234,7 +234,7 @@ struct BoxedKernelWrapper<
       [&] {
         // op returns void, boxed kernel has pushed nothing onto stack.
         TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-          stack.size() == 0,
+          stack.empty(),
           "Boxed kernel was expected to return no values on the stack, ",
           "but instead returned ", stack.size(), " values."
         );

--- a/aten/src/ATen/core/class_type.cpp
+++ b/aten/src/ATen/core/class_type.cpp
@@ -152,7 +152,7 @@ void checkForwardHookInputArguments(
   if (forward_args.size() == 1) {
     // check for empty forward case
     TORCH_CHECK(
-        input_tuple_types.size() == 0,
+        input_tuple_types.empty(),
         hook_id,
         "was expecting Tuple[()] as the input type. Received type: '",
         input_arg.type()->annotation_str(),
@@ -213,7 +213,7 @@ void ClassType::checkForwardPreHookSchema(
   // or the contained single type if the input was a tuple containing a single
   // type.
   TORCH_CHECK(
-            pre_hook_schema.returns().size() != 0,
+            !pre_hook_schema.returns().empty(),
             hook_id,
             "is missing a return annotation. Return annotations are required, please add one.\n",
             pre_hook_err_msg
@@ -254,7 +254,7 @@ void ClassType::checkForwardPreHookSchema(
   // check for edge case of Tuple[()] for when forward has no arguments
   if (forward_args.size() == 1) {
     TORCH_CHECK(
-        return_tuple_types.size() == 0,
+        return_tuple_types.empty(),
         wrong_type_returned_err_msg,
         " Was expecting either 'None' or 'Tuple[()]' since forward had ",
         "no arguments.\n",

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -145,7 +145,7 @@ OperatorEntry::AnnotatedKernelContainerIterator OperatorEntry::registerKernel(
 #ifdef C10_DISPATCHER_ONE_KERNEL_PER_DISPATCH_KEY
   if (k[0].kernel.isValid()) {
 #else
-  if (k.size() > 0) {
+  if (!k.empty()) {
 #endif
     // Suppress the warning for Meta key as we are overriding C++ meta functions with python meta functions
     // for some ops
@@ -221,12 +221,12 @@ bool OperatorEntry::hasKernelForDispatchKey(DispatchKey k) const {
   TORCH_INTERNAL_ASSERT(kernels_.find(DispatchKey::Undefined) == kernels_.end());
   auto it = kernels_.find(k);
   if (it == kernels_.end()) return false;
-  return it->second.size() > 0;
+  return !it->second.empty();
 }
 
 const KernelFunction& OperatorEntry::kernelForDispatchKey(DispatchKey k) const {
   auto it = kernels_.find(k);
-  TORCH_CHECK(it != kernels_.end() && it->second.size(), "no kernel for ", k, " on ", name_);
+  TORCH_CHECK(it != kernels_.end() && !it->second.empty(), "no kernel for ", k, " on ", name_);
   auto jt = it->second.begin();
   TORCH_INTERNAL_ASSERT(jt->kernel.isValid())
   return jt->kernel;
@@ -462,7 +462,7 @@ void OperatorEntry::checkInvariants() const {
   }
   TORCH_INTERNAL_ASSERT(kernels_.find(DispatchKey::Undefined) == kernels_.end(), dumpState());
   for (const auto& kv : kernels_) {
-    TORCH_INTERNAL_ASSERT(kv.second.size() > 0, dumpState());
+    TORCH_INTERNAL_ASSERT(!kv.second.empty(), dumpState());
   }
   for (auto k : DispatchKeySet(DispatchKeySet::FULL)) {
     auto expected_k = computeDispatchTableEntry(c10::Dispatcher::singleton(), k);

--- a/aten/src/ATen/core/dynamic_type.cpp
+++ b/aten/src/ATen/core/dynamic_type.cpp
@@ -38,7 +38,7 @@ std::string DynamicType::str() const {
   std::string ret = "Dynamic<";
   ret += std::to_string(static_cast<DynamicTypeBits>(tag_));
   ret += ">";
-  if (tag_ != Tag::Class && arguments_.elems.size() > 0) {
+  if (tag_ != Tag::Class && !arguments_.elems.empty()) {
     ret += "[";
     for (const auto& arg : arguments_.elems) {
       if (arg.label) {

--- a/aten/src/ATen/core/function_schema.cpp
+++ b/aten/src/ATen/core/function_schema.cpp
@@ -109,7 +109,7 @@ c10::optional<AliasTypeSet> FunctionSchema::mapTypeToAliasTypeSet(const TypePtr&
               (*maybe_inner_types).end());
         }
       }
-      if (mutable_types.size() == 0) {
+      if (mutable_types.empty()) {
         return c10::nullopt;
       }
       return mutable_types;
@@ -130,7 +130,7 @@ c10::optional<AliasTypeSet> FunctionSchema::mapTypeToAliasTypeSet(const TypePtr&
               (*maybe_inner_types).end());
         }
       }
-      if (mutable_types.size() == 0) {
+      if (mutable_types.empty()) {
         return c10::nullopt;
       }
       return {AliasTypeSet{TupleType::create(std::move(mutable_types))}};

--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -11,7 +11,7 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
   // it is simpler for now to work directly on this schema
 
   out << schema.name();
-  if (schema.overload_name() != "") {
+  if (!schema.overload_name().empty()) {
     out << "." << schema.overload_name();
   }
   out << "(";
@@ -27,7 +27,7 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
   }
 
   if(schema.is_vararg()) {
-    if(schema.arguments().size() > 0)
+    if(!schema.arguments().empty())
       out << ", ";
     out << "...";
   }
@@ -51,7 +51,7 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
    */
   bool need_paren = !(
     (returns.size() == 1 && !schema.is_varret()) ||
-    (returns.size() == 0 && schema.is_varret()));
+    (returns.empty() && schema.is_varret()));
 
   if (returns.size() == 1 && !schema.is_varret()) {
     std::stringstream return_ss;
@@ -69,7 +69,7 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
     // PR (https://github.com/pytorch/pytorch/pull/23204) has more context about
     // this. test_serialize_and_deserialize (https://github.com/pytorch/pytorch/blob/master/test/test_function_schema.py#L15)
     // also covers this case.
-    if (return_str.size() > 0 && return_str.front() == '(') {
+    if (!return_str.empty() && return_str.front() == '(') {
       need_paren = true;
     }
   }
@@ -84,7 +84,7 @@ inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
     out << returns.at(i);
   }
   if (schema.is_varret()) {
-    if (returns.size() != 0) {
+    if (!returns.empty()) {
       out << ", ";
     }
     out << "...";

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -490,7 +490,7 @@ std::ostream& printMaybeAnnotatedList(
     const IValue& the_list,
     IValueFormatter formatter) {
   auto list_elem_type = the_list.type()->containedType(0);
-  if (the_list.toListRef().size() == 0 ||
+  if (the_list.toListRef().empty() ||
       !elementTypeCanBeInferredFromMembers(list_elem_type)) {
     out << "annotate(" << the_list.type<c10::Type>()->annotation_str() << ", ";
     printList(out, the_list.toListRef(), "[", "]", std::move(formatter));
@@ -531,7 +531,7 @@ std::ostream& printMaybeAnnotatedDict(
     const IValue& the_dict,
     IValueFormatter formatter) {
   auto value_type = the_dict.type()->castRaw<DictType>()->getValueType();
-  if (the_dict.toGenericDict().size() == 0 ||
+  if (the_dict.toGenericDict().empty() ||
       !elementTypeCanBeInferredFromMembers(value_type)) {
     out << "annotate(" << the_dict.type<c10::Type>()->annotation_str() << ",";
     printDict(out, the_dict.toGenericDict(), std::move(formatter)) << ")";
@@ -1098,7 +1098,7 @@ TORCH_API intrusive_ptr<ivalue::Future> collectAll(
   };
 
   auto ctx = std::make_shared<Ctx>(std::move(srcs));
-  if (ctx->srcFutures.size() == 0) {
+  if (ctx->srcFutures.empty()) {
     ctx->dstFuture->markCompleted(ctx->asIvalue);
   } else {
     auto typePtr = ctx->srcFutures.get(0)->elementType();

--- a/aten/src/ATen/core/op_registration/op_registration.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration.cpp
@@ -57,7 +57,7 @@ void RegisterOperators::checkSchemaAndRegisterOp_(Options&& options) {
 }
 
 c10::FunctionSchema RegisterOperators::inferSchemaFromKernels_(const OperatorName& opName, const RegisterOperators::Options& options) {
-  TORCH_CHECK(options.kernels.size() > 0, "Cannot infer operator schema in registration of operator ", opName, " because there is no kernel specified.");
+  TORCH_CHECK(!options.kernels.empty(), "Cannot infer operator schema in registration of operator ", opName, " because there is no kernel specified.");
 
   c10::optional<FunctionSchema> inferred_schema = c10::nullopt;
   for (const auto& kernel : options.kernels) {

--- a/aten/src/ATen/core/operator_name.cpp
+++ b/aten/src/ATen/core/operator_name.cpp
@@ -12,7 +12,7 @@ std::string toString(const OperatorName& opName) {
 
 std::ostream& operator<<(std::ostream& os, const OperatorName& opName) {
   os << opName.name;
-  if (opName.overload_name.size() != 0) {
+  if (!opName.overload_name.empty()) {
     os << "." << opName.overload_name;
   }
   return os;

--- a/aten/src/ATen/core/qualified_name.h
+++ b/aten/src/ATen/core/qualified_name.h
@@ -22,7 +22,7 @@ struct QualifiedName {
     while (pos != std::string::npos) {
       auto atom = name.substr(startSearchFrom, pos - startSearchFrom);
       TORCH_INTERNAL_ASSERT(
-          atom.size() > 0, "Invalid name for qualified name: '", name, "'");
+          !atom.empty(), "Invalid name for qualified name: '", name, "'");
       atoms_.push_back(std::move(atom));
       startSearchFrom = pos + 1;
       pos = name.find(delimiter_, startSearchFrom);
@@ -30,7 +30,7 @@ struct QualifiedName {
 
     auto finalAtom = name.substr(startSearchFrom, pos - startSearchFrom);
     TORCH_INTERNAL_ASSERT(
-        finalAtom.size() > 0, "Invalid name for qualified name: '", name, "'");
+        !finalAtom.empty(), "Invalid name for qualified name: '", name, "'");
     atoms_.emplace_back(std::move(finalAtom));
 
     cacheAccessors();
@@ -134,7 +134,7 @@ struct QualifiedName {
       prefix_ = join(delimiter_, prefixView);
     }
 
-    if (atoms_.size() >= 1) {
+    if (!atoms_.empty()) {
       name_ = atoms_.back();
     }
   }

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -431,7 +431,7 @@ c10::optional<TypePtr> unifyTypeList(
     std::ostream& why_not,
     bool default_to_union,
     TypePtr type_hint) {
-  if (elements.size() == 0) {
+  if (elements.empty()) {
     why_not << "Cannot get unified type from empty list";
     return c10::nullopt;
   }
@@ -879,7 +879,7 @@ std::string TupleType::annotation_str_impl(TypePrinter printer) const {
     ss << name()->qualifiedName();
   } else {
     ss << "Tuple[";
-    if (elements().size() == 0) {
+    if (elements().empty()) {
       // `typing.Tuple` special-cases the annotation syntax for empty tuple
       // with `typing.Tuple[()]`. See
       // https://docs.python.org/3/library/typing.html#typing.Tuple

--- a/aten/src/ATen/core/union_type.cpp
+++ b/aten/src/ATen/core/union_type.cpp
@@ -48,7 +48,7 @@ c10::optional<TypePtr> subtractTypeSetFrom(std::vector<TypePtr>& to_subtract, Ar
                 return !should_subtract(t);
               });
 
-  if (types.size() == 0) {
+  if (types.empty()) {
     return c10::nullopt;
   } else if (types.size() == 1) {
     return types[0];

--- a/aten/src/ATen/functorch/ADInterpreters.cpp
+++ b/aten/src/ATen/functorch/ADInterpreters.cpp
@@ -169,7 +169,7 @@ static void autogradBasedTransformSendToNext(
   }
 
   // Re-dispatch
-  if (getDynamicLayerStack().size() == 0) {
+  if (getDynamicLayerStack().empty()) {
     sanityCheckStack(op, stack);
   }
 

--- a/aten/src/ATen/functorch/BatchRulesHelper.h
+++ b/aten/src/ATen/functorch/BatchRulesHelper.h
@@ -154,7 +154,7 @@ void boxed_tensor_inputs_batch_rule(const c10::OperatorHandle& op, torch::jit::S
   Func(tensor_inputs);
 
   size_t tensor_idx = 0;
-  TORCH_INTERNAL_ASSERT(tensor_pos.size() > 0);
+  TORCH_INTERNAL_ASSERT(!tensor_pos.empty());
   for (const auto arg_idx : c10::irange(0, num_arguments)) {
     if (tensor_idx >= tensor_pos.size() || (int64_t)arg_idx != tensor_pos[tensor_idx]) {
       torch::jit::push(stack, arguments[arg_idx]);

--- a/aten/src/ATen/functorch/BatchRulesModules.cpp
+++ b/aten/src/ATen/functorch/BatchRulesModules.cpp
@@ -300,7 +300,7 @@ struct UpsampleBackwardBatchRuleHelper<F, Func, typelist<A, B, C, T...>> {
       c10::SymIntArrayRef output_size, c10::SymIntArrayRef input_size,
       T... extra_args) {
     auto grad_output_ = reshape_dim_into(*grad_output_bdim, 0, grad_output);
-    TORCH_INTERNAL_ASSERT(input_size.size() > 0);
+    TORCH_INTERNAL_ASSERT(!input_size.empty());
 
     // input_size is wrong so we correct it
     c10::SymDimVector physical_input_size(input_size.begin(), input_size.end());

--- a/aten/src/ATen/functorch/BatchRulesReduceOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesReduceOps.cpp
@@ -135,7 +135,7 @@ void boxed_reduction_batch_rule(const c10::OperatorHandle& op, torch::jit::Stack
   if (arguments[dim_arg_pos].isIntList()) {
     reduction_case = ReductionCase::DimArray;
     dims = arguments[dim_arg_pos].toIntList().vec();
-    if (dims.size() == 0) {
+    if (dims.empty()) {
       auto all_dims = range(0, std::max((int64_t)1, logical_dim));
       dims = std::vector<int64_t>(all_dims.begin(), all_dims.end());
     }

--- a/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
+++ b/aten/src/ATen/functorch/BatchRulesScatterOps.cpp
@@ -43,7 +43,7 @@ static int64_t get_max_index_logical_dim(
     ArrayRef<optional<int64_t>> indices_bdims) {
   int64_t max_logical_dim = -1;
   TORCH_INTERNAL_ASSERT(indices.size() == indices_bdims.size());
-  TORCH_INTERNAL_ASSERT(indices.size() > 0);
+  TORCH_INTERNAL_ASSERT(!indices.empty());
   for (const auto i : c10::irange(0, indices.size())) {
     const auto& maybe_tensor = indices[i];
     if (!maybe_tensor.has_value() || !maybe_tensor->defined()) {

--- a/aten/src/ATen/functorch/BatchRulesViews.cpp
+++ b/aten/src/ATen/functorch/BatchRulesViews.cpp
@@ -247,7 +247,7 @@ std::tuple<Tensor, optional<int64_t>> squeeze_dims_batch_rule(
   auto ndim = self.dim();
   if (ndim == 1) {
     TORCH_CHECK(
-        dims.size() == 0 || (dims.size() == 1 && dims[0] == 0),
+        dims.empty() || (dims.size() == 1 && dims[0] == 0),
         "Dimension is out of range (expected to be in range of [-1, 0], but got ", dims);
     return std::make_tuple(self.alias(), bdim);
   }

--- a/aten/src/ATen/functorch/BatchedFallback.cpp
+++ b/aten/src/ATen/functorch/BatchedFallback.cpp
@@ -161,7 +161,7 @@ void batchedTensorInplaceForLoopFallback(const c10::OperatorHandle& op, torch::j
     batched_tensor_inputs.push_back(tensor);
     batched_tensor_inputs_position.push_back(idx);
   }
-  TORCH_INTERNAL_ASSERT(batched_tensor_inputs.size() > 0);
+  TORCH_INTERNAL_ASSERT(!batched_tensor_inputs.empty());
 
   // MultiBatchVmapTransform the BatchedTensor arguments. This returns
   // VmapPhysicalViews that contain all of the batch dimensions.
@@ -306,7 +306,7 @@ void batchedTensorForLoopFallback(const c10::OperatorHandle& op, torch::jit::Sta
     batched_tensor_inputs.push_back(tensor);
     batched_tensor_inputs_position.push_back(idx);
   }
-  TORCH_INTERNAL_ASSERT(batched_tensor_inputs.size() > 0);
+  TORCH_INTERNAL_ASSERT(!batched_tensor_inputs.empty());
 
   // MultiBatchVmapTransform the BatchedTensor arguments. This returns
   // VmapPhysicalViews that contain all of the batch dimensions.

--- a/aten/src/ATen/functorch/FunctionalizeInterpreter.cpp
+++ b/aten/src/ATen/functorch/FunctionalizeInterpreter.cpp
@@ -57,7 +57,7 @@ void FunctionalizeInterpreterPtr::sendToNextInterpreterImpl(
   sanityCheckNotFunctional(op, stack, args_size);
 
   // Re-dispatch
-  if (getDynamicLayerStack().size() == 0) {
+  if (getDynamicLayerStack().empty()) {
     sanityCheckStack(op, stack);
   }
   op.callBoxed(stack);

--- a/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp
+++ b/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp
@@ -157,7 +157,7 @@ Tensor& squeeze_dims__batching_rule(Tensor& self, IntArrayRef dims) {
 
   if (logical_dim == 0) {
     TORCH_CHECK(
-        dims.size() == 0 || (dims.size() == 1 && dims[0] == 0),
+        dims.empty() || (dims.size() == 1 && dims[0] == 0),
         "Dimension is out of range (expected to be in range of [-1, 0], but got ", dims);
     return self;
   }
@@ -701,7 +701,7 @@ Tensor block_diag_batching_rule(TensorList tensors) {
   auto physical_tensors = fmap(
       physical_views, [](const VmapPhysicalView& view) -> Tensor { return view.tensor(); });
   TORCH_INTERNAL_ASSERT(
-      tensors.size() > 0, "The dispatcher should not have dispatched here otherwise.");
+      !tensors.empty(), "The dispatcher should not have dispatched here otherwise.");
   // Implementing this as a dummy for loop for now, since I'm not sure how to do it any better.
   // I'm probably not accounting for potentially multiple batched dimensions?
   auto bdim = physical_tensors[0].size(0);
@@ -729,7 +729,7 @@ Tensor stack_batching_rule(TensorList tensors, int64_t dim) {
   auto physical_tensors = fmap(
       physical_views, [](const VmapPhysicalView& view) -> Tensor { return view.tensor(); });
   TORCH_INTERNAL_ASSERT(
-      tensors.size() > 0, "The dispatcher should not have dispatched here otherwise.");
+      !tensors.empty(), "The dispatcher should not have dispatched here otherwise.");
   // NB: stack wraps the dimensionality to (logical dim + 1), so we have to
   // manually handle that here.
   auto dim_physical =

--- a/aten/src/ATen/functorch/VmapInterpreter.cpp
+++ b/aten/src/ATen/functorch/VmapInterpreter.cpp
@@ -16,7 +16,7 @@ void VmapInterpreterPtr::sendToNextInterpreterImpl(
     torch::jit::Stack* stack,
     bool grad_special_case) {
   // Re-dispatch
-  if (getDynamicLayerStack().size() == 0) {
+  if (getDynamicLayerStack().empty()) {
     sanityCheckStack(op, stack);
   }
   op.callBoxed(stack);

--- a/aten/src/ATen/native/CPUFallback.cpp
+++ b/aten/src/ATen/native/CPUFallback.cpp
@@ -50,7 +50,7 @@ c10::optional<c10::Device> compute_target_device(std::vector<at::Tensor>& t_args
   // Decide what device to move the output tensor(s) to.
   // The current convention is that we use the first tensor arg to pick the device
   // Barring that, we take the first tensor from a TensorList arg.
-  if (t_args.size() > 0) {
+  if (!t_args.empty()) {
     return t_args[0].device();
   } else {
     // We need to loop through all of the (potentially multiple) TensorList arguments

--- a/aten/src/ATen/native/ComplexHelper.h
+++ b/aten/src/ATen/native/ComplexHelper.h
@@ -81,7 +81,7 @@ Tensor view_as_complex(const Tensor& self) {
     "view_as_complex is only supported for half, float and double tensors, but got a tensor of scalar type: ", self.scalar_type());
 
   auto old_sizes = self.sym_sizes();
-  TORCH_CHECK(old_sizes.size() != 0, "Input tensor must have one or more dimensions");
+  TORCH_CHECK(!old_sizes.empty(), "Input tensor must have one or more dimensions");
   TORCH_CHECK(old_sizes[old_sizes.size()-1] == 2, "Tensor must have a last dimension of size 2");
   SymDimVector new_sizes(old_sizes.begin(), old_sizes.end() - 1);
 

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -207,7 +207,7 @@ static inline std::vector<T> _conv_output_size(
 ) {
   // ASSERT(input_size.size() > 2)
   // ASSERT(input_size.size() == weight_size.size())
-  bool has_dilation = dilation.size() > 0;
+  bool has_dilation = !dilation.empty();
   auto dim = input_size.size();
   std::vector<T> output_size(dim);
   output_size[0] = input_size[input_batch_size_dim];

--- a/aten/src/ATen/native/DilatedMaxPool2d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool2d.cpp
@@ -32,7 +32,7 @@ bool ceil_mode) {
 
   // NB: stride default is not expressible as an integer constant, so we accept
   // empty stride for this case
-  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 2,
+  TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 2,
     "max_pool2d: stride must either be omitted, a single int, or a tuple of two ints")
   const int dH = stride.empty() ? kH : safe_downcast<int, int64_t>(stride[0]);
   const int dW = stride.empty() ? kW :
@@ -105,7 +105,7 @@ const Tensor& indices) {
 
   // NB: stride default is not expressible as an integer constant, so we accept
   // empty stride for this case
-  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 2,
+  TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 2,
     "max_pool2d: stride must either be omitted, a single int, or a tuple of two ints")
   const int dH = stride.empty() ? kH : safe_downcast<int, int64_t>(stride[0]);
   const int dW = stride.empty() ? kW :

--- a/aten/src/ATen/native/DilatedMaxPool3d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool3d.cpp
@@ -164,7 +164,7 @@ void max_pool3d_with_indices_out_cpu_template(
   const int kH = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[1]);
   const int kW = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[2]);
 
-  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 3,
+  TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 3,
     "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
   const int dT = stride.empty() ? kT : safe_downcast<int, int64_t>(stride[0]);
   const int dH = stride.empty() ? kH :
@@ -372,7 +372,7 @@ Tensor& max_pool3d_with_indices_backward_out_cpu_template(
   const int kH = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[1]);
   const int kW = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[2]);
 
-  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 3,
+  TORCH_CHECK(stride.empty() || stride.size() == 1 || stride.size() == 3,
     "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
   const int dT = stride.empty() ? kT : safe_downcast<int, int64_t>(stride[0]);
   const int dH = stride.empty() ? kH :

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -29,7 +29,7 @@ bool has_bool_tensor(TensorList tensors) {
 // - All TensorLists and ScalarLists must have the same number of elements.
 // - Corresponding tensors must have the same size.
 void check_foreach_api_restrictions(TensorList tensors) {
-  TORCH_CHECK(tensors.size() > 0, "Tensor list must have at least one tensor.");
+  TORCH_CHECK(!tensors.empty(), "Tensor list must have at least one tensor.");
 }
 
 void check_foreach_api_restrictions(TensorList tensors, ArrayRef<Scalar> scalars) {
@@ -38,15 +38,15 @@ void check_foreach_api_restrictions(TensorList tensors, ArrayRef<Scalar> scalars
 }
 
 void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2) {
-  TORCH_CHECK(tensors1.size() > 0, "Tensor list must have at least one tensor.");
-  TORCH_CHECK(tensors2.size() > 0, "Tensor list must have at least one tensor.");
+  TORCH_CHECK(!tensors1.empty(), "Tensor list must have at least one tensor.");
+  TORCH_CHECK(!tensors2.empty(), "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors1.size() == tensors2.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors2.size());
 }
 
 void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3) {
-  TORCH_CHECK(tensors1.size() > 0, "Tensor list must have at least one tensor.");
-  TORCH_CHECK(tensors2.size() > 0, "Tensor list must have at least one tensor.");
-  TORCH_CHECK(tensors3.size() > 0, "Tensor list must have at least one tensor.");
+  TORCH_CHECK(!tensors1.empty(), "Tensor list must have at least one tensor.");
+  TORCH_CHECK(!tensors2.empty(), "Tensor list must have at least one tensor.");
+  TORCH_CHECK(!tensors3.empty(), "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors1.size() == tensors2.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors2.size());
   TORCH_CHECK(tensors1.size() == tensors3.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors3.size());
 }
@@ -110,7 +110,7 @@ bool check_fast_path_restrictions(
           return false;
         }
       }
-      if (scalarList.size() > 0) {
+      if (!scalarList.empty()) {
         const auto& scalar = scalarList.size() == 1 ? scalarList[0] : scalarList[i];
         const auto& tensor = tensorLists[0][i];
         // note(mkozuki): This check might be responsible for `_foreach_add(bool_tensors, bool_tensors)`

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -102,7 +102,7 @@ static Tensor sumproduct_pair(const Tensor& left_, const Tensor& right_, IntArra
   // assumes that tensors have been pre-unsqueezed (so that all dimensions match - after broadcasting)
   // but makes no other assumptions on the order of dimensions
   TORCH_CHECK(left_.dim()==right_.dim(), "number of dimensions must match");
-  if (sum_dims_.size() == 0)
+  if (sum_dims_.empty())
     return at::mul(left_, right_);
   int64_t dim = left_.dim();
   auto sum_dims = at::dim_list_to_bitset(sum_dims_, dim);

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -198,7 +198,7 @@ TORCH_META_FUNC(linalg_vector_norm)(const Tensor& self, const Scalar& scalar_ord
   //   - We cannot reduce over an empty dimension
   if (self.numel() == 0 && (ord < 0. || ord == INFINITY)) {
     // dim=None or dim=() reduces the whole tensor
-    TORCH_CHECK(opt_dim.has_value() && opt_dim->size() != 0,
+    TORCH_CHECK(opt_dim.has_value() && !opt_dim->empty(),
       "linalg.vector_norm cannot compute the ", scalar_ord, " norm on an empty ",
       "tensor because the operation does not have an identity");
     for (auto dim_num : dim) {
@@ -1078,7 +1078,7 @@ Tensor chain_matmul(TensorList matrices) {
   checkAllSameDim(matrices, 2);
 
   TORCH_CHECK(
-      matrices.size() > 0, "chain_matmul(): Expected one or more matrices");
+      !matrices.empty(), "chain_matmul(): Expected one or more matrices");
 
   if (matrices.size() == 1) {
     return matrices[0].clone();
@@ -1096,7 +1096,7 @@ Tensor& chain_matmul_out(TensorList matrices, Tensor& result) {
   checkAllSameDim(matrices, 2);
 
   TORCH_CHECK(
-      matrices.size() > 0, "chain_matmul(): Expected one or more matrices");
+      !matrices.empty(), "chain_matmul(): Expected one or more matrices");
 
   if (matrices.size() == 1) {
     at::native::resize_output(result, matrices[0].sizes());

--- a/aten/src/ATen/native/MaxPooling.cpp
+++ b/aten/src/ATen/native/MaxPooling.cpp
@@ -40,7 +40,7 @@ static void check_max_pool1d(
       "max_pool1d() kernel_size must be an int, list of ints or tuple of ints of size 1 but got size ",
       kernel_size.size());
   TORCH_CHECK(
-      stride.size() == 0 || stride.size() == 1,
+      stride.empty() || stride.size() == 1,
       "max_pool1d() stride must be None, an int, list of ints, or tuple of ints of size 1 but got size ",
       stride.size());
   TORCH_CHECK(

--- a/aten/src/ATen/native/NonEmptyUtils.h
+++ b/aten/src/ATen/native/NonEmptyUtils.h
@@ -18,7 +18,7 @@ inline int64_t ensure_nonempty_stride(const TensorBase &t, int64_t dim) {
 
 using IdxVec = std::vector<int64_t>;
 inline IdxVec ensure_nonempty_vec(IdxVec vec) {
-  if (vec.size() == 0) {
+  if (vec.empty()) {
     vec.push_back(1);
   }
   return vec;

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1321,7 +1321,7 @@ TORCH_IMPL_FUNC(mean_out)
   // in lieu of the sum + divide implementation below.
   if (self.device().is_cpu()) {
     int64_t dim_prod = 1;
-    if (!opt_dim.has_value() || opt_dim.value().size() == 0 || self.ndimension() == 0) {
+    if (!opt_dim.has_value() || opt_dim.value().empty() || self.ndimension() == 0) {
       dim_prod = self.numel();
     } else {
       auto dim = opt_dim.value();
@@ -2122,7 +2122,7 @@ Tensor value_selecting_reduction_backward_symint(const Tensor& grad, int64_t dim
         return grad_in.scatter_(dim, indices_, grad_out);
       };
 
-  if (!keepdim && sizes.size() > 0) {
+  if (!keepdim && !sizes.empty()) {
     auto grad_ = grad.unsqueeze(dim);
     auto indices_ = indices.unsqueeze(dim);
     return inplace_scatter_if_not_tensor_subclass(grad_, indices_);

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -64,7 +64,7 @@ TORCH_META_FUNC(topk)
   // Build the output size, which is the dim being selected set to
   // size k
   DimVector topKSize(self.sizes().vec());
-  if (topKSize.size() > 0) {
+  if (!topKSize.empty()) {
     topKSize[dim] = k;
   }
   set_output_raw_strided(0, topKSize, {}, self.options());

--- a/aten/src/ATen/native/SortingUtils.h
+++ b/aten/src/ATen/native/SortingUtils.h
@@ -23,7 +23,7 @@ inline void _reduction_with_indices_allocate_or_resize_output(
     bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
   auto result_sizes = self.sizes().vec();
-  if (result_sizes.size() > 0) {
+  if (!result_sizes.empty()) {
     result_sizes[dim] = 1;
   }
   if (values.defined()) {
@@ -63,7 +63,7 @@ inline void _allocate_or_resize_output_with_indices(
     int64_t k) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
   auto result_sizes = self.sizes().vec();
-  if (result_sizes.size() > 0) {
+  if (!result_sizes.empty()) {
     result_sizes[dim] = k;
   }
   if (values.defined()) {

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -479,7 +479,7 @@ static Tensor fft_rfftn_impl(Tensor out, const Tensor& self,
                              const c10::optional<c10::string_view>& norm_str) {
   TORCH_CHECK(!self.is_complex(), "rfftn expects a real-valued input tensor, but got ", self.scalar_type());
   auto desc = canonicalize_fft_shape_and_dim_args(self, s, dim);
-  TORCH_CHECK(desc.shape.size() > 0, "rfftn must transform at least one axis");
+  TORCH_CHECK(!desc.shape.empty(), "rfftn must transform at least one axis");
   Tensor input = promote_tensor_fft(self, /*require_complex=*/false);
   Tensor x = resize_fft_input(input, desc.dim, desc.shape);
   const auto norm = static_cast<int64_t>(norm_from_string(norm_str, /*forward=*/true));
@@ -507,7 +507,7 @@ ShapeAndDims canonicalize_fft_c2r_shape_and_dim_args(
     const at::OptionalIntArrayRef& dims,
     int64_t& last_dim_size) {
   auto desc = canonicalize_fft_shape_and_dim_args(self, s, dims);
-  TORCH_CHECK(desc.shape.size() > 0, fname, " must transform at least one axis");
+  TORCH_CHECK(!desc.shape.empty(), fname, " must transform at least one axis");
 
   // Expected output size of the hermitian-symmetric dimension
   last_dim_size = [&] {
@@ -607,7 +607,7 @@ static Tensor fft_ihfftn_impl(
     const Tensor& out) {
   constexpr c10::string_view fname = "ihfftn";
   auto desc = canonicalize_fft_shape_and_dim_args(self, s, dim);
-  TORCH_CHECK(desc.shape.size() > 0, "ihfftn must transform at least one axis");
+  TORCH_CHECK(!desc.shape.empty(), "ihfftn must transform at least one axis");
   auto input = promote_tensor_fft(self, /*require_complex=*/false);
   auto x = resize_fft_input(input, desc.dim, desc.shape);
   const auto norm = static_cast<int64_t>(
@@ -1186,7 +1186,7 @@ Tensor istft(const Tensor& self, const int64_t n_fft, const optional<int64_t> ho
 void _fft_fill_with_conjugate_symmetry_(const Tensor& input, IntArrayRef dim_) {
   const auto input_sizes = input.sizes();
   const auto input_strides = input.strides();
-  TORCH_CHECK(dim_.size() > 0);
+  TORCH_CHECK(!dim_.empty());
   DimVector dim(dim_.begin(), dim_.end());
   at::maybe_wrap_dims(dim, input_strides.size(), /*wrap_scalars=*/false);
 

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -286,11 +286,11 @@ TORCH_PRECOMPUTE_META_FUNC(index_copy)
 
   // Check that source and destination slices have the same size
   auto selfSlicedSizes = self.sizes().vec();
-  if (selfSlicedSizes.size() > 0) {
+  if (!selfSlicedSizes.empty()) {
     selfSlicedSizes.erase(selfSlicedSizes.begin() + dim);
   }
   auto sourceSlicedSizes = source.sizes().vec();
-  if (sourceSlicedSizes.size() > 0) {
+  if (!sourceSlicedSizes.empty()) {
     sourceSlicedSizes.erase(sourceSlicedSizes.begin() + dim);
   }
   if (selfSlicedSizes.size() != sourceSlicedSizes.size() ||
@@ -471,7 +471,7 @@ DEFINE_DISPATCH(scatter_reduce_expanded_index_stub);
 DEFINE_DISPATCH(gather_expanded_index_stub);
 
 static bool all_strides_match(TensorList tensors) {
-  TORCH_CHECK(tensors.size() >= 1);
+  TORCH_CHECK(!tensors.empty());
   auto strides = tensors[0].strides();
   for (auto& tensor : tensors.slice(1)) {
     if (!strides.equals(tensor.strides())) {
@@ -2084,7 +2084,7 @@ Tensor count_nonzero_cuda(const Tensor& self, IntArrayRef dims){
 }
 
 Tensor count_nonzero_cpu(const Tensor& self, IntArrayRef dims){
-  if (dims.size() > 0) {
+  if (!dims.empty()) {
     return (self != 0).sum(dims);
   }
 

--- a/aten/src/ATen/native/TensorTransformations.h
+++ b/aten/src/ATen/native/TensorTransformations.h
@@ -12,8 +12,8 @@ namespace at {
 namespace native {
 
 static inline Tensor roll_common(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
-  TORCH_CHECK(shifts.size() > 0, "`shifts` required");
-  if (dims.size() == 0 && shifts.size() == 1) {
+  TORCH_CHECK(!shifts.empty(), "`shifts` required");
+  if (dims.empty() && shifts.size() == 1) {
     auto flattened = self.contiguous().view(self.numel());
     return roll(flattened, shifts[0], 0).view(self.sizes());
   }

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -885,7 +885,7 @@ inline std::tuple<bool, Tensor, Tensor> NestedTensor_compute_size_stride(
 // we are designing a better semantics to include both inheritance and inference
 Tensor view_nested(const Tensor& self, IntArrayRef proposed_shape) {
   TORCH_CHECK(
-      proposed_shape.size() > 0,
+      !proposed_shape.empty(),
       "shape '[]' is invalid for a nested tensor");
   auto self_ptr = get_nested_tensor_impl(self);
   // basic information before reshaping
@@ -972,7 +972,7 @@ Tensor _nested_view_from_buffer(
 // See Note [Special size rule for nested tensor]
 Tensor reshape_nested(const Tensor& self, IntArrayRef proposed_shape) {
   TORCH_CHECK(
-      proposed_shape.size() > 0,
+      !proposed_shape.empty(),
       "shape '[]' is invalid for a nested tensor");
   auto self_ptr = get_nested_tensor_impl(self);
   // basic information before reshaping

--- a/aten/src/ATen/native/quantized/cpu/QuantUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/QuantUtils.h
@@ -188,7 +188,7 @@ inline TensorQuantizationParams ChooseQuantizationParams(
 constexpr int64_t kConv1dSqueezeDim = 0;
 static C10_UNUSED torch::List<int64_t> MakeArgForConv1d(const torch::List<int64_t>& arg,
                                              int64_t base_value) {
-  TORCH_CHECK(arg.size() > 0, "Argument must have elements.");
+  TORCH_CHECK(!arg.empty(), "Argument must have elements.");
   torch::List<int64_t> result({arg.get(0), base_value});
   if (arg.size() == 1) {
     result[1] = arg.get(0);

--- a/aten/src/ATen/native/quantized/cpu/TensorShape.cpp
+++ b/aten/src/ATen/native/quantized/cpu/TensorShape.cpp
@@ -34,7 +34,7 @@ DEFINE_DISPATCH(qcat_relu_nhwc_stub);
 namespace {
 
 bool is_cat_nhwc_fast_path(const MaterializedITensorListRef& qxs, int64_t dim) {
-  TORCH_CHECK(qxs.size() > 0);
+  TORCH_CHECK(!qxs.empty());
   bool is_fast_path = dim == 1;
   // NOLINTNEXTLINE(performance-implicit-conversion-in-loop)
   for (const at::Tensor& qx : qxs) {

--- a/aten/src/ATen/native/quantized/cpu/conv_serialization.h
+++ b/aten/src/ATen/native/quantized/cpu/conv_serialization.h
@@ -90,7 +90,7 @@ ConvParamsSerializationTypeV3 parse_conv_serialized_state(c10::IValue v) {
   int version = -1;
   if (v.isTuple()) {
     const auto& elements = v.toTupleRef().elements();
-    if (elements.size() > 0) {
+    if (!elements.empty()) {
       auto firstElement = elements[0];
       if (firstElement.isTensor()) {
         version = 1;

--- a/aten/src/ATen/native/sparse/SoftMax.cpp
+++ b/aten/src/ATen/native/sparse/SoftMax.cpp
@@ -337,7 +337,7 @@ void cpu_sparse_coo_softmax(Tensor output, const Tensor& input, const int64_t di
         auto pool_indices = pools[p];
 
         // Skip empty pools
-        if (pool_indices.size() == 0)
+        if (pool_indices.empty())
           continue;
 
         /* Prepare scratch space */
@@ -478,7 +478,7 @@ void cpu_sparse_coo_softmax_backward(const Tensor& grad_input, const Tensor& gra
         auto pool_indices = pools[p];
 
         // Skip empty pools
-        if (pool_indices.size() == 0)
+        if (pool_indices.empty())
           continue;
 
         std::vector<scalar_t> tmp_row(nvalues, 0);

--- a/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensorMath.cpp
@@ -1227,7 +1227,7 @@ Tensor reduce_sparse_csr_cpu_template(const Tensor& sparse, std::vector<int64_t>
     TORCH_INTERNAL_ASSERT(((dims[0] == 0 && dims[1] == 1) || (dims[0] == 1 && dims[1] == 0)));
     return reduce_sparse_csr_dim01_cpu_template<scalar_t>(sparse, rop);
   }
-  TORCH_INTERNAL_ASSERT(dims.size() == 0);
+  TORCH_INTERNAL_ASSERT(dims.empty());
   // effective after gh-29137 has been resolved
   return sparse.clone();
 }
@@ -1242,7 +1242,7 @@ Tensor reduce_sparse_csr_cpu_template(const Tensor& sparse, IntArrayRef dims_to_
   TORCH_INTERNAL_ASSERT(input_dim == 2);
   auto dims = dims_to_sum.vec();
   maybe_wrap_dims(dims, input_dim);
-  if (dims.size() == 0) {
+  if (dims.empty()) {
     // after gh-29137 is resolved, delete this if-block
     dims.emplace_back(0);
     dims.emplace_back(1);

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -375,7 +375,7 @@ Tensor norm_sparse(const SparseTensor& self, const Scalar& p) {
 
 Tensor norm_sparse(const SparseTensor& self, const optional<Scalar>& p, IntArrayRef dim, bool keepdim, optional<ScalarType> dtype) {
   AT_ASSERT(self.is_sparse());
-  if (dim.size() > 0) {
+  if (!dim.empty()) {
     // Only full reductions are supported, so check if that is the case
     int64_t ndim = self.dim();
     bool passed_full_reduction_check = static_cast<size_t>(ndim) == dim.size();
@@ -1658,7 +1658,7 @@ Tensor _sparse_sum(const SparseTensor& input, IntArrayRef dims_to_sum) {
   }
   const int64_t sparse_dims_to_sum_size = dims_to_sum_v.size() - dense_dims_to_sum_v.size();
   const bool sum_all_sparse_dim = (sparse_dim == sparse_dims_to_sum_size);
-  const bool sum_dense_dim = (dense_dims_to_sum_v.size() > 0);
+  const bool sum_dense_dim = (!dense_dims_to_sum_v.empty());
 
   // new values
   Tensor new_values;
@@ -1780,7 +1780,7 @@ Tensor _sparse_sum_backward_cpu(const Tensor& grad_, const SparseTensor& input_,
   }
 
   const bool sum_all_sparse_dim = (input_sparse_dim == sparse_dims_to_sum_size);
-  const bool sum_dense_dim = (dense_dims_to_sum_v.size() > 0);
+  const bool sum_dense_dim = (!dense_dims_to_sum_v.empty());
   const bool sum_sparse_dim = (sparse_dims_to_sum_size > 0);
 
   if (sum_all_sparse_dim) {

--- a/aten/src/ATen/nnapi/nnapi_bind.cpp
+++ b/aten/src/ATen/nnapi/nnapi_bind.cpp
@@ -73,7 +73,7 @@ void NnapiCompilation::init2(
     ser_model_ptr,
     serialized_model_tensor.nbytes()
   };
-  TORCH_CHECK(ser_model.size() > 0);
+  TORCH_CHECK(!ser_model.empty());
 
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   ANeuralNetworksModel* model;

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -97,7 +97,7 @@ int64_t get_sub_byte_tensor_size(IntArrayRef sizes, size_t dtype_itemsize, at::S
       element_per_byte = 1;
   }
   // zero dim tensor
-  if (sizes.size() == 0) {
+  if (sizes.empty()) {
     return c10::multiply_integers(sizes) * dtype_itemsize;
   }
   // Consider most inner dim as cols

--- a/c10/core/impl/TorchDispatchModeTLS.cpp
+++ b/c10/core/impl/TorchDispatchModeTLS.cpp
@@ -9,7 +9,7 @@ namespace impl {
 thread_local TorchDispatchModeTLS torchDispatchModeState;
 
 void TorchDispatchModeTLS::push_onto_stack(std::shared_ptr<SafePyObject> mode) {
-  if (torchDispatchModeState.stack_.size() == 0) {
+  if (torchDispatchModeState.stack_.empty()) {
     c10::impl::tls_set_dispatch_key_included(DispatchKey::Python, true);
     c10::impl::tls_set_dispatch_key_included(
         DispatchKey::PythonTLSSnapshot, true);
@@ -19,12 +19,12 @@ void TorchDispatchModeTLS::push_onto_stack(std::shared_ptr<SafePyObject> mode) {
 
 const std::shared_ptr<SafePyObject> TorchDispatchModeTLS::pop_stack() {
   TORCH_CHECK(
-      torchDispatchModeState.stack_.size() > 0,
+      !torchDispatchModeState.stack_.empty(),
       "trying to pop from empty mode stack");
   std::shared_ptr<SafePyObject> out = torchDispatchModeState.stack_.back();
   torchDispatchModeState.stack_.pop_back();
 
-  if (torchDispatchModeState.stack_.size() == 0) {
+  if (torchDispatchModeState.stack_.empty()) {
     c10::impl::tls_set_dispatch_key_included(DispatchKey::Python, false);
     c10::impl::tls_set_dispatch_key_included(
         DispatchKey::PythonTLSSnapshot, false);
@@ -50,7 +50,7 @@ const TorchDispatchModeTLS& TorchDispatchModeTLS::get_state() {
 
 void TorchDispatchModeTLS::set_state(const TorchDispatchModeTLS& state) {
   torchDispatchModeState = state;
-  if (torchDispatchModeState.stack_.size() == 0) {
+  if (torchDispatchModeState.stack_.empty()) {
     c10::impl::tls_set_dispatch_key_included(DispatchKey::Python, false);
     c10::impl::tls_set_dispatch_key_included(
         DispatchKey::PythonTLSSnapshot, false);

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -57,7 +57,7 @@ bool ThreadPool::inThreadPool() const {
 }
 
 void ThreadPool::run(std::function<void()> func) {
-  if (threads_.size() == 0) {
+  if (threads_.empty()) {
     throw std::runtime_error("No threads to run a task");
   }
   std::unique_lock<std::mutex> lock(mutex_);

--- a/functorch/csrc/dim/dim.cpp
+++ b/functorch/csrc/dim/dim.cpp
@@ -2874,7 +2874,7 @@ struct WrappedOperator : public py::base<WrappedOperator> {
         name = orig.attr("__name__");
         doc = orig.attr("__doc__");
         dim_name = std::move(dim_name_);
-        if (!py::is_none(doc) && dim_name.size() > 0) {
+        if (!py::is_none(doc) && !dim_name.empty()) {
             doc = py::unicode_from_format("%S\nArgument '%s' can be either an integer or a torchdim.Dim object.\n", doc.ptr(), dim_name.c_str());
         }
         method_def.ml_name = py::is_none(name) ? "" : PyUnicode_AsUTF8(name.ptr());

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -249,7 +249,7 @@ PyWarningHandler::~PyWarningHandler() noexcept(false) {
   c10::WarningUtils::set_warning_handler(prev_handler_);
   auto& warning_buffer = internal_handler_.warning_buffer_;
 
-  if (warning_buffer.size() > 0) {
+  if (!warning_buffer.empty()) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     PyObject *type, *value, *traceback;
     pybind11::gil_scoped_acquire gil;

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -242,7 +242,7 @@ py::handle getTorchApiFunction(const c10::OperatorHandle& op) {
 
     py::handle torch_api_function =
         py::module::import("torch").attr("ops").attr(ns).attr(func_name);
-    if (overload_name == "") {
+    if (overload_name.empty()) {
       return torch_api_function.attr("default").ptr();
     } else {
       return torch_api_function.attr(overload_name.c_str()).ptr();

--- a/torch/csrc/api/src/optim/schedulers/lr_scheduler.cpp
+++ b/torch/csrc/api/src/optim/schedulers/lr_scheduler.cpp
@@ -31,7 +31,7 @@ void LRScheduler::set_optimizer_lrs(const std::vector<double>& learning_rates) {
 
 std::vector<double> LRScheduler::get_current_lrs() const {
   std::vector<double> learnings_rates(optimizer_.param_groups().size());
-  if (learnings_rates.size() > 0) {
+  if (!learnings_rates.empty()) {
     for (const auto i : c10::irange(optimizer_.param_groups().size())) {
       learnings_rates[i] = optimizer_.param_groups()[i].options().get_lr();
     }

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -135,7 +135,7 @@ Tensor maybe_multiply(const Tensor& t, const Scalar& s) {
 
 int64_t _safe_size(IntArrayRef sizes, IntArrayRef dim) {
   int64_t size = 1;
-  if (sizes.size() == 0) {
+  if (sizes.empty()) {
     return 1;
   }
   for (auto d : dim) {
@@ -147,7 +147,7 @@ int64_t _safe_size(IntArrayRef sizes, IntArrayRef dim) {
 
 c10::SymInt _safe_size(c10::SymIntArrayRef sizes, c10::IntArrayRef dim) {
   c10::SymInt size = 1;
-  if (sizes.size() == 0) {
+  if (sizes.empty()) {
     return 1;
   }
   for (auto d : dim) {
@@ -613,8 +613,8 @@ Tensor sum_backward(
     c10::SymIntArrayRef sizes,
     OptionalIntArrayRef opt_dims,
     bool keepdim) {
-  if (!keepdim && sizes.size() > 0) {
-    if (opt_dims.has_value() && opt_dims.value().size() > 0) {
+  if (!keepdim && !sizes.empty()) {
+    if (opt_dims.has_value() && !opt_dims.value().empty()) {
       return unsqueeze_multiple(grad, opt_dims, sizes.size())
           .expand_symint(sizes);
     }
@@ -627,7 +627,7 @@ Tensor sum_backward(
     c10::SymIntArrayRef sizes,
     c10::IntArrayRef dims,
     bool keepdim) {
-  if (!keepdim && sizes.size() > 0 && dims.size() > 0) {
+  if (!keepdim && !sizes.empty() && !dims.empty()) {
     // we are only using `keepdim=true` path for SymInts for now
     TORCH_CHECK_NOT_IMPLEMENTED(
         false,
@@ -652,7 +652,7 @@ Tensor mean_backward(
     OptionalIntArrayRef opt_dim,
     c10::SymInt numel,
     bool keepdim) {
-  bool is_all_reduce = !opt_dim.has_value() || opt_dim.value().size() == 0;
+  bool is_all_reduce = !opt_dim.has_value() || opt_dim.value().empty();
   auto n =
       is_all_reduce ? std::move(numel) : _safe_size(shape, opt_dim.value());
   return sum_backward(grad, shape, opt_dim, keepdim) / std::move(n);
@@ -998,7 +998,7 @@ std::vector<Tensor> block_diag_backward(
                      .slice(1, cur_dim1, cur_dim1 + dim1);
     if (shape.size() == 1) {
       slice = slice.squeeze(-1);
-    } else if (shape.size() == 0) {
+    } else if (shape.empty()) {
       slice = slice.squeeze(-1).squeeze(-1);
     }
     grad_inputs[i] = slice;
@@ -2737,7 +2737,7 @@ Tensor softplus_double_backward(
 static inline bool _maybe_overlapping_memory(
     c10::SymIntArrayRef sizes,
     c10::SymIntArrayRef strides) {
-  if (sizes.size() > 0) {
+  if (!sizes.empty()) {
     std::vector<std::size_t> argsort(sizes.size());
     std::iota(argsort.begin(), argsort.end(), 0);
     std::sort(

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -115,7 +115,7 @@ void autogradNotImplementedFallbackImpl(
       stack_start,
       num_arguments);
 
-  const bool any_requires_grad = tensors_requiring_grad_on_stack.size() > 0;
+  const bool any_requires_grad = !tensors_requiring_grad_on_stack.empty();
 
   _foreach_tensor(
       [&](size_t _, size_t i, const at::Tensor& t) {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -676,7 +676,7 @@ void GraphTask::exec_post_processing() {
   // See Note [Streaming backwards].
   // Syncs caller_current_stream with leaf streams, so final_callbacks may use
   // any grad on its device's current stream.
-  if (leaf_streams.size() > 0) {
+  if (!leaf_streams.empty()) {
     for (const auto& leaf_stream : leaf_streams) {
       // stash_current_streams() stashed streams for all device IDs that already
       // had a CUDA context before the GraphTask executed. For inactive devices,

--- a/torch/csrc/autograd/forward_grad.cpp
+++ b/torch/csrc/autograd/forward_grad.cpp
@@ -29,7 +29,7 @@ void ForwardADLevel::release_idx(uint64_t idx) {
       "Exiting a forward AD level that is not the "
       "last that was created is not support. Ensure they are released in the reverse "
       "order they were created.");
-  TORCH_INTERNAL_ASSERT(all_forward_levels_.size() > 0);
+  TORCH_INTERNAL_ASSERT(!all_forward_levels_.empty());
   // Keep the level alive until we have released the lock
   auto lvl = all_forward_levels_.back();
   all_forward_levels_.pop_back();

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -577,7 +577,7 @@ void prepareProfiler(
   torch::profiler::impl::kineto::prepareTrace(
       /*cpuOnly=*/!at::hasCUDA(), activities, config.experimental_config);
 
-  if (config.experimental_config.performance_events.size()) {
+  if (!config.experimental_config.performance_events.empty()) {
     /* For now only CPU activity is supported */
     TORCH_CHECK(
         activities.count(torch::autograd::profiler::ActivityType::CPU),

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1100,7 +1100,7 @@ PyObject* THPVariable_get_name(THPVariable* self, void* unused) {
     END_HANDLE_TH_ERRORS
   }
   const auto& tensor = THPVariable_Unpack(self);
-  if (tensor.name() == "")
+  if (tensor.name().empty())
     Py_RETURN_NONE;
   return THPUtils_packString(tensor.name().c_str());
 }

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -351,7 +351,7 @@ void add_hook(
     const at::TensorBase& self,
     std::unique_ptr<FunctionPreHook> hook) {
   AutogradMeta* meta = materialize_autograd_meta(self);
-  TORCH_INTERNAL_ASSERT(meta->hooks_.size() == 0);
+  TORCH_INTERNAL_ASSERT(meta->hooks_.empty());
   meta->hooks_.push_back(std::move(hook));
 }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -154,7 +154,7 @@ void checkRemainingTime(
       " ms.");
   if (remainingTime.count() < 0) {
     std::string rankInfo;
-    if (processedRanks.size() > 0) {
+    if (!processedRanks.empty()) {
       rankInfo = c10::str(
           "Successfully processed ranks: ", c10::Join(", ", processedRanks));
     } else {
@@ -446,8 +446,8 @@ std::vector<at::Tensor> ProcessGroupGloo::AsyncWork::result() {
   TORCH_CHECK(
       outputTensors_.size() <= 1,
       "work result does not support list of lists, use .getFuture() and value()");
-  return outputTensors_.size() == 0 ? std::vector<at::Tensor>()
-                                    : outputTensors_.at(0);
+  return outputTensors_.empty() ? std::vector<at::Tensor>()
+                                : outputTensors_.at(0);
 }
 
 c10::intrusive_ptr<c10::ivalue::Future> ProcessGroupGloo::AsyncWork::
@@ -469,7 +469,7 @@ c10::intrusive_ptr<c10::ivalue::Future> createFutureAsOutput(
 void returnFutureWithOutput(
     c10::intrusive_ptr<c10::ivalue::Future>& future,
     const std::vector<std::vector<at::Tensor>>& outputTensors) {
-  if (outputTensors.size() == 0) {
+  if (outputTensors.empty()) {
     future->markCompleted(c10::IValue(std::vector<at::Tensor>()));
     return;
   }
@@ -1847,7 +1847,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::allgather(
     TORCH_CHECK(false, "ProcessGroupGloo::allgather: " + msg);
   };
 
-  if (inputs.size() == 0) {
+  if (inputs.empty()) {
     invalidArgument("requires non-empty input tensor list");
   }
 
@@ -2199,7 +2199,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::gather(
     const auto& sizes = inputs[0].sizes();
     assertTypeAndSizesMatch(invalidArgument, outputs[0], options, sizes);
   } else {
-    if (outputs.size() != 0) {
+    if (!outputs.empty()) {
       invalidArgument("requires empty output on non-root");
     }
   }
@@ -2245,9 +2245,8 @@ class AsyncScatterWork : public ProcessGroupGloo::AsyncWork {
       : ProcessGroupGloo::AsyncWork(
             {outputs},
             "gloo:scatter",
-            inputs.size() > 0
-                ? c10::optional<std::vector<at::Tensor>>(inputs[0])
-                : c10::nullopt),
+            !inputs.empty() ? c10::optional<std::vector<at::Tensor>>(inputs[0])
+                            : c10::nullopt),
         context(context),
         outputs(outputs),
         inputs(inputs),
@@ -2383,7 +2382,7 @@ c10::intrusive_ptr<Work> ProcessGroupGloo::scatter(
     const auto& sizes = outputs[0].sizes();
     assertTypeAndSizesMatch(invalidArgument, inputs[0], options, sizes);
   } else {
-    if (inputs.size() != 0) {
+    if (!inputs.empty()) {
       invalidArgument("requires empty input on non-root");
     }
   }
@@ -2454,7 +2453,7 @@ class AsyncAlltoallWork : public ProcessGroupGloo::AsyncWork {
 
   void alltoall(at::Tensor& outputTensor, at::Tensor& inputTensor) {
     const auto scalarType = outputTensor.scalar_type();
-    if (outputCounts.size() == 0 && inputCounts.size() == 0) {
+    if (outputCounts.empty() && inputCounts.empty()) {
       // Gloo alltoall
       gloo::AlltoallOptions opts(context);
       opts.setTag(tag);

--- a/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.cpp
@@ -10,7 +10,7 @@ ProcessGroupRoundRobin::ProcessGroupRoundRobin(
   TORCH_WARN(
       "ProcessGroupRoundRobin is deprecated and scheduled to be removed after this current release (1.13). ",
       "Please file an issue on https://github.com/pytorch/pytorch/issues if there are any concerns or issues with this deprecation.");
-  TORCH_CHECK(processGroups_.size() >= 1);
+  TORCH_CHECK(!processGroups_.empty());
   for (const auto& processGroup : processGroups_) {
     TORCH_CHECK(processGroup->getRank() == rank_);
     TORCH_CHECK(processGroup->getSize() == size_);

--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -242,7 +242,7 @@ void TCPStoreMasterDaemon::queryFds(std::vector<struct pollfd>& fds) {
             ++vecIt;
           }
         }
-        if (it->second.size() == 0) {
+        if (it->second.empty()) {
           it = waitingSockets_.erase(it);
         } else {
           ++it;

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -132,7 +132,7 @@ inline void assertSameSizes(
 
 inline void assertSameSizeAndType(const std::vector<at::Tensor>& tensors) {
   // Ensure we have at least one tensor
-  if (tensors.size() == 0) {
+  if (tensors.empty()) {
     throw std::invalid_argument("argument is empty");
   }
 
@@ -214,7 +214,7 @@ inline void assertLayoutMatch(
 inline void assertNonEmpty(
     std::function<void(const std::string&)> fn,
     const at::ArrayRef<at::Tensor> tensors) {
-  if (tensors.size() == 0) {
+  if (tensors.empty()) {
     fn("requires non-empty tensor list");
   }
 }
@@ -349,7 +349,7 @@ inline at::Tensor flattenDenseTensors(at::TensorList tensors) {
 inline at::Tensor newLikeFlat(
     std::vector<std::vector<at::Tensor>>& tensors,
     size_t deviceIdx) {
-  if (tensors.size() == 0 || tensors[0].size() == 0) {
+  if (tensors.empty() || tensors[0].empty()) {
     TORCH_CHECK(false, "Received an empty list");
   }
   if (deviceIdx >= tensors.size()) {
@@ -372,7 +372,7 @@ inline at::Tensor newLikeFlat(
 }
 
 inline at::Tensor newLikeFlat(std::vector<at::Tensor>& tensors) {
-  if (tensors.size() == 0) {
+  if (tensors.empty()) {
     TORCH_CHECK(false, "Received an empty list");
   }
   auto& t = tensors[0];
@@ -426,7 +426,7 @@ inline void checkSplitSizes(
     const std::vector<int64_t>& split_sizes,
     const at::Tensor& tensor,
     int group_size) {
-  if (split_sizes.size() == 0) {
+  if (split_sizes.empty()) {
     TORCH_CHECK(
         tensor.size(0) % group_size == 0,
         "Tensor's dim 0 does not divide equally across group size");
@@ -454,7 +454,7 @@ size_t computeLengthsAndOffsets(
   size_t split_size = 0;
   size_t offset = 0;
 
-  if (split_sizes.size() == 0) {
+  if (split_sizes.empty()) {
     equal_splits = true;
     split_size = tensor.size(0) / group_size;
   }

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1642,7 +1642,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
       "_round_robin_process_groups",
       [](std::vector<c10::intrusive_ptr<::c10d::ProcessGroup>> processGroups)
           -> c10::intrusive_ptr<::c10d::ProcessGroup> {
-        if (processGroups.size() == 0) {
+        if (processGroups.empty()) {
           throw std::invalid_argument("Specify at least 1 process group");
         }
         const auto& first = processGroups.front();

--- a/torch/csrc/distributed/c10d/logger.cpp
+++ b/torch/csrc/distributed/c10d/logger.cpp
@@ -37,7 +37,7 @@ std::ostream& operator<<(std::ostream& output, const Logger& logger) {
       ddp_logging_data.ints_map["avg_backward_comm_time"],
       ddp_logging_data.ints_map["avg_backward_compute_comm_overlap_time"]);
 
-  if (ddp_logging_data.strs_map["comm_hook"] != "") {
+  if (!ddp_logging_data.strs_map["comm_hook"].empty()) {
     loggerInfo += fmt::format(
         "\n Gradient comm. hook: {}", ddp_logging_data.strs_map["comm_hook"]);
   }
@@ -274,7 +274,7 @@ void Logger::set_runtime_stats_and_log() {
   // If unused_parameters_ is not empty, calculate its sizes.
   // unused_parameters_ is calculated in forward call of
   // each iteration.
-  if (reducer_->unused_parameters_.size() == 0 &&
+  if (reducer_->unused_parameters_.empty() &&
       reducer_->find_unused_parameters_) {
     // No unused params in this iteration
     ddp_logging_data_->ints_map["unused_parameter_size"] = 0;

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -119,8 +119,7 @@ Reducer::Reducer(
       param_names_(std::move(param_names)),
       first_bucket_bytes_cap_(first_bucket_bytes_cap) {
   C10_LOG_API_USAGE_ONCE("torch.distributed.ddp.reducer");
-  TORCH_INTERNAL_ASSERT(
-      params_.size() >= 1, "Expected at least one parameter.");
+  TORCH_INTERNAL_ASSERT(!params_.empty(), "Expected at least one parameter.");
 
   if (ddp_debug_level_ != c10d::DebugLevel::Off) {
     LOG(INFO) << "Reducer initialized with bucket_bytes_cap: "
@@ -515,7 +514,7 @@ void Reducer::set_divide_factor() {
       auto results = extractTensors(workHandle->getFuture()->value());
 
       // Guard against the results being empty
-      TORCH_INTERNAL_ASSERT(results.size() > 0);
+      TORCH_INTERNAL_ASSERT(!results.empty());
       at::Tensor& res = results.front();
       div_factor_ = res.item().to<int>();
     }
@@ -574,7 +573,7 @@ void Reducer::delay_all_reduce() {
     }
 
     // Each rank prints out all the unused parameters detected
-    if (unused_parameters_.size() > 0) {
+    if (!unused_parameters_.empty()) {
       LOG(INFO) << "[Rank " << process_group_->getRank() << "]: "
                 << "Parameter(s) (in the format of {param_name, index}): "
                 << unused_params_stream.str()
@@ -1016,7 +1015,7 @@ void Reducer::initialize_buckets(
     // TODO(@pietern): Validate indices.
     // Must be non-empty, unique, and unique across buckets.
     REDUCER_CHECK(
-        bucket_indices[bucket_index].size() > 0,
+        !bucket_indices[bucket_index].empty(),
         logger_,
         "Empty bucket specified.");
 
@@ -1804,7 +1803,7 @@ void Reducer::ensure_prior_reduction_finished() {
     auto unmarked_param_indices = getUnmarkedParamIndicesForIteration();
     // We should have some unmarked parameter indices, otherwise we would not
     // have run into this error branch.
-    TORCH_INTERNAL_ASSERT(unmarked_param_indices.size() > 0);
+    TORCH_INTERNAL_ASSERT(!unmarked_param_indices.empty());
 
     std::string kBaseErrorMsg =
         "Expected to have finished reduction in the prior iteration before "
@@ -1870,7 +1869,7 @@ void Reducer::ensure_prior_reduction_finished() {
     } else {
       // Retrieve set of parameter names that did not receive gradient.
       auto unmarkedParams = getUnmarkedParamsForIteration();
-      TORCH_INTERNAL_ASSERT(unmarkedParams.size() > 0);
+      TORCH_INTERNAL_ASSERT(!unmarkedParams.empty());
       for (const auto& s : unmarkedParams) {
         LOG(INFO) << "[Rank " << process_group_->getRank() << "] "
                   << "Parameter: " << s
@@ -1986,7 +1985,7 @@ compute_bucket_assignment_by_size(
   TORCH_INTERNAL_ASSERT(
       expect_sparse_gradient.empty() ||
       (tensors.size() == expect_sparse_gradient.size()));
-  TORCH_INTERNAL_ASSERT(tensors.size() > 0);
+  TORCH_INTERNAL_ASSERT(!tensors.empty());
   // Store bucket indices and their sizes together, because we later sort the
   // resulting indices by minimum tensor index and want to keep sizes
   // consistent.

--- a/torch/csrc/distributed/rpc/python_call.cpp
+++ b/torch/csrc/distributed/rpc/python_call.cpp
@@ -27,7 +27,7 @@ c10::intrusive_ptr<Message> PythonCall::toMessageImpl() && {
 
 std::unique_ptr<PythonCall> PythonCall::fromMessage(const Message& message) {
   TORCH_INTERNAL_ASSERT(
-      message.payload().size() >= 1,
+      !message.payload().empty(),
       "Failed to convert an RPC message to PythonCall, the payload should at "
       "least contain one byte indicating whether this is an async function, "
       "but got payload of size ",

--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -247,7 +247,7 @@ void RRefContext::delAllUsersAndUnforkedOwners(
   {
     std::unique_lock<std::mutex> lock(mutex_);
     bool noPending = deleteAllUsersCV_.wait_for(lock, timeoutMillis, [this]() {
-      return pendingUsers_.size() == 0 && pendingChildren_.size() == 0;
+      return pendingUsers_.empty() && pendingChildren_.empty();
     });
     if (!noPending) {
       LOG(ERROR)
@@ -297,7 +297,7 @@ void RRefContext::delAllUsersAndUnforkedOwners(
   {
     std::unique_lock<std::mutex> lock(mutex_);
     bool noOwner = deleteAllUsersCV_.wait_for(
-        lock, timeoutMillis, [this]() { return owners_.size() == 0; });
+        lock, timeoutMillis, [this]() { return owners_.empty(); });
     if (!noOwner) {
       LOG(ERROR) << "Timed out waiting for pending OwnerRRefs to be deleted.";
     }

--- a/torch/csrc/functorch/init.cpp
+++ b/torch/csrc/functorch/init.cpp
@@ -476,7 +476,7 @@ void initFuncTorchBindings(PyObject* module) {
   });
   m.def("peek_interpreter_stack", []() -> c10::optional<Interpreter> {
     const auto& stack = getDynamicLayerStack();
-    if (stack.size() == 0) {
+    if (stack.empty()) {
       return c10::nullopt;
     }
     auto result = stack.back().interpreter();

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -60,7 +60,7 @@ c10::IValue preprocess(
       }
     }
   }
-  if (error.size() != 0) {
+  if (!error.empty()) {
     throw std::runtime_error(
         error +
         "\nmethod_compile_spec should contain a Tensor or Tensor List which bundles input parameters:"

--- a/torch/csrc/jit/codegen/fuser/tensor_desc.h
+++ b/torch/csrc/jit/codegen/fuser/tensor_desc.h
@@ -26,7 +26,7 @@ struct TORCH_API TensorDesc {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   TensorDesc(const at::ScalarType& type, const std::vector<bool>& contiguity)
       : scalar_type{type}, contiguity{contiguity} {
-    if (contiguity.size() == 0) {
+    if (contiguity.empty()) {
       nDim_ = 0;
     } else {
       nDim_ = std::count(contiguity.begin(), contiguity.end(), false) +
@@ -59,7 +59,7 @@ struct TORCH_API TensorDesc {
 
   // True iff innermost stride is 1
   bool lastIsContiguous() const {
-    return (contiguity.size() == 0 || contiguity.back());
+    return (contiguity.empty() || contiguity.back());
   }
 
   static std::vector<bool> findContiguous(

--- a/torch/csrc/jit/frontend/error_report.cpp
+++ b/torch/csrc/jit/frontend/error_report.cpp
@@ -48,7 +48,7 @@ ErrorReport::CallStack::~CallStack() {}
 
 std::string get_stacked_errors(const std::vector<Call>& error_stack) {
   std::stringstream msg;
-  if (error_stack.size() > 0) {
+  if (!error_stack.empty()) {
     for (auto it = error_stack.rbegin(); it != error_stack.rend() - 1; ++it) {
       auto callee = it + 1;
 

--- a/torch/csrc/jit/frontend/exit_transforms.cpp
+++ b/torch/csrc/jit/frontend/exit_transforms.cpp
@@ -125,7 +125,7 @@ struct ExitTransformer {
   }
 
   static void removeOutputs(Block* b) {
-    while (b->outputs().size() > 0) {
+    while (!b->outputs().empty()) {
       b->eraseOutput(0);
     }
   }
@@ -347,7 +347,7 @@ struct ExitTransformer {
       new_if->addOutput()->setType(block->outputs().at(i)->type());
     }
 
-    while (block->outputs().size() > 0) {
+    while (!block->outputs().empty()) {
       block->eraseOutput(0);
     }
     for (auto out : new_if->outputs()) {
@@ -368,7 +368,7 @@ struct ExitTransformer {
   // never be used, it is safe to replace them with unitialized value
   void destroyNodeAfterExit(Node* n) {
     for (auto output : n->outputs()) {
-      if (output->uses().size() > 0) {
+      if (!output->uses().empty()) {
         output->replaceAllUsesWith(getUnitValue(output->type()));
       }
     }

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -655,7 +655,7 @@ struct to_ir {
     // Type annotations exclude explicitly typing the "self" parameter, so in
     // the case that this is a method with self we expect one fewer parameter
     // annotation than the number of parameters this Def takes.
-    if (self && def.decl().params().size() == 0) {
+    if (self && def.decl().params().empty()) {
       throw ErrorReport(def.decl().params().range())
           << "methods must have a self argument";
     }
@@ -2776,7 +2776,7 @@ struct to_ir {
 
       const auto slicedArg = NamedValue(stmt.lhs().range(), "self", sliced);
       const auto rhs = NamedValue(stmt.rhs().range(), emitExpr(stmt.rhs()));
-      if (tensorIndices.size() == 0) {
+      if (tensorIndices.empty()) {
         // Common case: we only tried to index with int and slices. Emit the
         // correct augmented assignment op to the sliced value
         emitBuiltinCall(
@@ -2869,7 +2869,7 @@ struct to_ir {
       // rhs must be a tensor, implicitly convert int/float/complex/bool
       const auto convertedRhs = emitValueToTensor(rhs, slicedArg);
 
-      if (tensorIndices.size() == 0) {
+      if (tensorIndices.empty()) {
         // Common case: we only tried to index with int and slices. Copy the
         // RHS into the resulting tensor.
         graph->insert(aten::copy_, {slicedArg, convertedRhs}, {}, stmtRange);
@@ -3284,7 +3284,7 @@ struct to_ir {
           << expected_inputs << " arguments but found "
           << apply.inputs().size();
     }
-    if (apply.attributes().size() > 0) {
+    if (!apply.attributes().empty()) {
       throw ErrorReport(loc)
           << Var(apply.callee()).name().name() << " takes no keyword arguments";
     }
@@ -3304,7 +3304,7 @@ struct to_ir {
           << min_expected_inputs << " and " << max_expected_inputs
           << " but found " << position_arg_size;
     }
-    if (apply.attributes().size() > 0) {
+    if (!apply.attributes().empty()) {
       throw ErrorReport(loc)
           << Var(apply.callee()).name().name() << " takes no keyword arguments";
     }
@@ -3337,7 +3337,7 @@ struct to_ir {
     switch (form) {
       case prim::fork: {
         auto& trees = apply.inputs().tree()->trees();
-        if (trees.size() < 1) {
+        if (trees.empty()) {
           throw ErrorReport(apply)
               << "Expected at least one argument to fork()";
         }
@@ -3474,7 +3474,7 @@ struct to_ir {
         bool all_ints = std::all_of(args.begin(), args.end(), [](Value* v) {
           return v->type()->cast<IntType>();
         });
-        if (args.size() == 0) {
+        if (args.empty()) {
           // empty inputs == torch.tensor([], dtype=....)
           auto inp_list =
               graph->insertNode(graph->createList(IntType::get(), {}))
@@ -3619,7 +3619,7 @@ struct to_ir {
         // zip(x, y) can be rewrite as subtrees:
         // IterableTree(IterableTree(x), IterableTree(y))
         auto inputs = apply.inputs();
-        if (inputs.size() == 0) {
+        if (inputs.empty()) {
           throw ErrorReport(apply)
               << "zip expected at least 1 arguments, got 0";
         }
@@ -3663,7 +3663,7 @@ struct to_ir {
   std::shared_ptr<SugaredValue> emitApplySpecialFormForList(
       Apply& apply,
       const TypePtr& type_hint = nullptr) {
-    if (apply.inputs().size() == 0) {
+    if (apply.inputs().empty()) {
       TypePtr type = type_hint ? type_hint : ListType::ofTensors();
       if (!type->cast<ListType>()) {
         throw ErrorReport(apply.range())
@@ -4140,7 +4140,7 @@ struct to_ir {
           << op_name << "(dst_worker_name, user_callable)\n"
           << "Now the number of arguments is " << apply.inputs().size();
     }
-    if (apply.attributes().size() != 0) {
+    if (!apply.attributes().empty()) {
       throw ErrorReport(apply)
           << op_name << "(dst_worker_name, user_callable, args, kwargs)"
           << "does not support kwargs yet";
@@ -4187,7 +4187,7 @@ struct to_ir {
     std::vector<NamedValue> kwargs;
     // Get args and kwargs as `NamedValue`s.
     // Similar to getNamedValues(..) and emitAttributes(..).
-    if (args_kwargs_timeout_trees.size() >= 1) {
+    if (!args_kwargs_timeout_trees.empty()) {
       // Unroll args from a Var that is known to be a Tuple.
       auto& args_tree = args_kwargs_timeout_trees[0];
       auto entry_sugared_values = emitSugaredExpr(Expr(args_tree), 1)
@@ -4298,7 +4298,7 @@ struct to_ir {
     // This is also the same behavior that C++ allows with {}
     // (cannot assign to a variable typed as auto)
     // These nodes will be removed in a later pass after initial compilation
-    if (values.size() == 0 && type_hint == nullptr) {
+    if (values.empty() && type_hint == nullptr) {
       auto node = graph->insertNode(graph->create(prim::EmptyListLiteral));
       node->output()->setType(ListType::ofTensors());
       return node->output();
@@ -5055,7 +5055,7 @@ struct to_ir {
     }
     auto idx = toIValue(idx_val);
     if (!idx) {
-      if (elems.size() == 0 ||
+      if (elems.empty() ||
           !convertibleToList(tuple_typ, ListType::create(elems[0]))) {
         throw ErrorReport(loc)
             << "Cannot index into a " << tuple_typ->repr_str()
@@ -5615,7 +5615,7 @@ void runCleanupPasses(std::shared_ptr<Graph>& to_clean) {
 // and do not record it as a unique name. This allows python printing to
 // be able to export and import more consistently named graphs
 bool meaningfulName(const std::string& name) {
-  if (name.size() == 0)
+  if (name.empty())
     return false;
   if (name[0] == '$')
     return false;

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -428,11 +428,11 @@ struct Lexer {
   }
   // Return the current token, and then move to the next one
   Token next() {
-    if (next_tokens.size() == 0)
+    if (next_tokens.empty())
       reportError("Lexer invariant violated: empty token queue");
     Token r = std::move(next_tokens.front());
     next_tokens.erase(next_tokens.begin());
-    if (next_tokens.size() == 0) {
+    if (next_tokens.empty()) {
       lex();
     }
     return r;
@@ -517,7 +517,7 @@ struct Lexer {
           while (indent_stack.back() != depth) {
             indent_stack.pop_back();
             next_tokens.emplace_back(TK_DEDENT, r.range);
-            if (indent_stack.size() == 0) {
+            if (indent_stack.empty()) {
               reportError(
                   "invalid indent level " + c10::guts::to_string(depth), r);
             }

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -578,7 +578,7 @@ std::pair<size_t, MatchedSchema> matchSchemas(
     at::ArrayRef<NamedValue> kwargs,
     const c10::optional<NamedValue>& self,
     bool render_errors) {
-  TORCH_INTERNAL_ASSERT(schemas.size() > 0);
+  TORCH_INTERNAL_ASSERT(!schemas.empty());
   // if there is only one schema, we do not need to try without conversions
   // first. this is faster and puts less dead code in the graph.
   if (schemas.size() == 1) {
@@ -667,7 +667,7 @@ static Value* emitBuiltinNode(
 }
 
 std::string getFullSchemaName(const ::c10::FunctionSchema& schema) {
-  if (schema.overload_name() != "") {
+  if (!schema.overload_name().empty()) {
     return schema.operator_name().name + "." + schema.overload_name();
   }
   return schema.operator_name().name;
@@ -743,12 +743,12 @@ Value* emitBuiltinCall(
   }
 
   // no operators found with the same name, print out similarly named operators
-  if (schemas.size() == 0) {
+  if (schemas.empty()) {
     const auto close_symbols = findSimilarOperators(name);
     auto error = ErrorReport(loc);
     const auto& user_function_name = name.toQualString();
     error << "Unknown builtin op: " << user_function_name << ".\n";
-    if (close_symbols.size() == 0) {
+    if (close_symbols.empty()) {
       error
           << "Could not find any similar ops to " << user_function_name
           << ". This op may not exist or may not be currently supported in TorchScript.\n";

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -81,7 +81,7 @@ TypePtr SchemaTypeParser::parseBaseType() {
 
   auto it = type_map.find(text);
   if (it == type_map.end()) {
-    if (text.size() > 0 && islower(text[0])) {
+    if (!text.empty() && islower(text[0])) {
       // lower case identifiers that are not otherwise valid types
       // are treated as type variables
       return c10::TypeFactory::createNamed<VarType>(text);

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -37,7 +37,7 @@ TypePtr ScriptTypeParser::subscriptToType(
       // i.e. `typing.Tuple[()]`. Allow for parsing an empty tuple literal
       // here. See https://docs.python.org/3/library/typing.html#typing.Tuple
       auto tup_literal = TupleLiteral(subscript.subscript_exprs()[0]);
-      if (tup_literal.inputs().size() > 0) {
+      if (!tup_literal.inputs().empty()) {
         throw ErrorReport(tup_literal.range())
             << "Tuple literal in Tuple type annotation must not "
             << "have any elements!";

--- a/torch/csrc/jit/frontend/source_range.cpp
+++ b/torch/csrc/jit/frontend/source_range.cpp
@@ -18,7 +18,7 @@ StringCordView::StringCordView(
   accumulated_sizes_.push_back(0);
   size_t running_sum = 0;
   for (auto& s : pieces_) {
-    if (s.size() > 0) {
+    if (!s.empty()) {
       running_sum += s.size();
       accumulated_sizes_.push_back(running_sum);
     }
@@ -26,7 +26,7 @@ StringCordView::StringCordView(
 }
 
 size_t StringCordView::find(const std::string& tok, size_t start) const {
-  if (tok.size() == 0) {
+  if (tok.empty()) {
     return 0;
   }
 
@@ -257,7 +257,7 @@ void SourceRange::print_with_context(
     size_t line, col;
     std::tie(filename, line, col) = *flc;
     out << "  File \"" << filename << "\", line " << line;
-    if (funcname != "") {
+    if (!funcname.empty()) {
       out << ", in " << funcname;
     }
     out << "\n";

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -503,7 +503,7 @@ RangeValue::RangeValue(
   }
 
   Graph& g = *m.graph();
-  if (inputs.size() == 0) {
+  if (inputs.empty()) {
     throw ErrorReport(loc) << "range expected at least 1 arguments, got 0";
   } else if (inputs.size() == 1) {
     end_ = inputs[0];
@@ -613,7 +613,7 @@ void IterableTree::addChild(
     GraphFunction& m,
     const SugaredValuePtr& iter_value) {
   c10::optional<int64_t> child_len = iter_value->staticLen();
-  if (children_.size() == 0) {
+  if (children_.empty()) {
     unroll_length_ = child_len;
   } else {
     if ((unroll_length_ && !child_len) || (child_len && !unroll_length_)) {
@@ -637,7 +637,7 @@ std::shared_ptr<SugaredValue> MagicMethod::call(
     at::ArrayRef<NamedValue> args,
     at::ArrayRef<NamedValue> kwargs,
     size_t n_binders) {
-  if (args.size() > 0) {
+  if (!args.empty()) {
     Value* self = args[0].value(*m.graph());
     if (auto class_ptr = self->type()->cast<ClassType>()) {
       return SimpleValue(self)

--- a/torch/csrc/jit/frontend/sugared_value.h
+++ b/torch/csrc/jit/frontend/sugared_value.h
@@ -512,7 +512,7 @@ struct TORCH_API CastValue : public BuiltinFunction {
       at::ArrayRef<NamedValue> args,
       at::ArrayRef<NamedValue> kwargs,
       size_t n_binders) override {
-    if (args.size() == 1 && kwargs.size() == 0) {
+    if (args.size() == 1 && kwargs.empty()) {
       auto len_op = std::make_shared<BuiltinFunction>(aten::len, at::nullopt);
       auto gt_op = std::make_shared<BuiltinFunction>(aten::gt, at::nullopt);
       auto zero = m.graph()->insertConstant(0);
@@ -550,7 +550,7 @@ struct TORCH_API TensorCastValue : public SugaredValue {
       at::ArrayRef<NamedValue> args,
       at::ArrayRef<NamedValue> kwargs,
       size_t n_binders) override {
-    TORCH_INTERNAL_ASSERT(args.size() == 0 && kwargs.size() == 0);
+    TORCH_INTERNAL_ASSERT(args.empty() && kwargs.empty());
     Value* dtype_const = m.graph()->insertConstant(dtype_, loc);
     std::vector<NamedValue> kwargs_{
         self_, NamedValue(loc, "dtype", dtype_const)};

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -104,7 +104,7 @@ class MutableTypePtrHelper {
                 (*maybe_inner_types).end());
           }
         }
-        if (mutable_types.size() == 0) {
+        if (mutable_types.empty()) {
           return c10::nullopt;
         }
         return mutable_types;
@@ -133,7 +133,7 @@ class MutableTypePtrHelper {
                 (*maybe_inner_types).end());
           }
         }
-        if (mutable_types.size() == 0) {
+        if (mutable_types.empty()) {
           return c10::nullopt;
         }
         return {AliasTypeSet{TupleType::create(mutable_types)}};
@@ -736,7 +736,7 @@ void AliasDb::analyzeImpl(Node* node) {
       // run into lifetime issues with the graph
       std::vector<std::shared_ptr<Graph>>& graphs =
           function_call_copies_[graph.get()];
-      if (graphs.size() == 0) {
+      if (graphs.empty()) {
         graphs.push_back(graph);
         analyzeSubgraph(node, graph);
       } else {
@@ -914,7 +914,7 @@ void AliasDb::analyzeImpl(Node* node) {
     // Otherwise it is the form of a|fresh, which we can ignore, taking the
     // conservative assumption that the output must alias `a`, e.g
     //   aten::cuda(Tensor(a) self) -> Tensor(a|fresh)
-    if (!inputs_has_alias && formal->beforeSets().size()) {
+    if (!inputs_has_alias && !formal->beforeSets().empty()) {
       giveFreshAlias(actual);
     }
 
@@ -1385,9 +1385,8 @@ bool AliasDb::mayContainAlias(
     const at::ArrayRef<Value*> a,
     const at::ArrayRef<Value*> b) const {
   auto a_elems = getElements(a);
-  return a_elems.size() == 0
-      ? false
-      : memoryDAG_->mayContainAlias(a_elems, getElements(b));
+  return a_elems.empty() ? false
+                         : memoryDAG_->mayContainAlias(a_elems, getElements(b));
 }
 
 bool AliasDb::mayContainAlias(Value* a, const at::ArrayRef<Value*> b) const {
@@ -1395,7 +1394,7 @@ bool AliasDb::mayContainAlias(Value* a, const at::ArrayRef<Value*> b) const {
     return false;
   }
   auto b_elems = getElements(b);
-  return b_elems.size() == 0
+  return b_elems.empty()
       ? false
       : memoryDAG_->mayContainAlias(elementMap_.at(a), b_elems);
 }

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -484,15 +484,15 @@ void Node::lint() const {
   // Node subclass invariants
   switch (kind()) {
     case prim::Constant:
-      AT_ASSERT(inputs_.size() == 0);
+      AT_ASSERT(inputs_.empty());
       break;
     case prim::Return:
       // Return uses is zero
-      AT_ASSERT(outputs().size() == 0);
+      AT_ASSERT(outputs().empty());
       break;
     case prim::Param:
       // Param inputs is zero
-      AT_ASSERT(inputs_.size() == 0);
+      AT_ASSERT(inputs_.empty());
       break;
     case prim::PythonOp: {
       // Python operator cconv is correct
@@ -835,7 +835,7 @@ std::string Value::debugNameBase() const {
 
 bool Value::isValidName(const std::string& name) {
   // Empty strings are legal
-  if (!name.size()) {
+  if (name.empty()) {
     return true;
   }
 
@@ -861,7 +861,7 @@ Value* Value::setDebugName(const std::string& name) {
   }
 
   // allow "" to clear the uniquename
-  if (name == "") {
+  if (name.empty()) {
     return this;
   }
 
@@ -1124,7 +1124,7 @@ const Operator& Node::getOperator() const {
     er << *inputs()[i]->type();
   }
   const auto& candidates = getAllOperatorsFor(kind());
-  if (candidates.size() > 0) {
+  if (!candidates.empty()) {
     er << "\ncandidates were:\n";
     for (auto& candidate : candidates) {
       er << "  " << candidate->schema() << "\n";
@@ -2109,7 +2109,7 @@ std::vector<Value*> inlineCallTo(
       module_instance_info = c10::make_optional(ModuleInstanceInfo(
           class_type_ptr, to_replace->input(0)->node()->s(attr::name)));
     } else if (
-        to_replace->owningGraph()->inputs().size() > 0 &&
+        !to_replace->owningGraph()->inputs().empty() &&
         to_replace->input(0) == to_replace->owningGraph()->inputs()[0]) {
       // This CallMethod must correspond to method of the same object
       // to which this graph belongs.

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -850,7 +850,7 @@ struct TORCH_API Node {
     return removeAttribute(Symbol::attr(name));
   }
   bool hasAttributes() const {
-    return values_.size() > 0;
+    return !values_.empty();
   }
   size_t numAttributes() const {
     return values_.size();

--- a/torch/csrc/jit/ir/ir_views.h
+++ b/torch/csrc/jit/ir/ir_views.h
@@ -126,8 +126,9 @@ struct LoopView {
         trip_count->toInt() !=
             std::numeric_limits<int64_t>::max() || // it is a constant but not
                                                    // the default one
-        currentTripCount()->uses().size() >
-            0; // it is actually being used in the body.
+        !currentTripCount()
+             ->uses()
+             .empty(); // it is actually being used in the body.
 
     if (condition_is_always_true) {
       // if the trip count was not specified this was a user-written while True:

--- a/torch/csrc/jit/jit_log.cpp
+++ b/torch/csrc/jit/jit_log.cpp
@@ -93,7 +93,7 @@ void JitLoggingConfig::parse() {
   files_to_levels.clear();
   std::string line;
   while (std::getline(in_ss, line, ':')) {
-    if (line.size() == 0) {
+    if (line.empty()) {
       continue;
     }
 

--- a/torch/csrc/jit/jit_opt_limit.cpp
+++ b/torch/csrc/jit/jit_opt_limit.cpp
@@ -37,7 +37,7 @@ static std::unordered_map<std::string, int64_t> parseJITOptLimitOption(
   std::unordered_map<std::string, int64_t> passes_to_opt_limits;
   std::string line;
   while (std::getline(in_ss, line, ':')) {
-    if (line.size() == 0) {
+    if (line.empty()) {
       continue;
     }
     auto index_at = line.find_last_of('=');

--- a/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
@@ -235,7 +235,7 @@ std::unordered_map<std::string, OperatorInfo> _get_model_ops_and_info(
       // grab name
       std::string op_name = op.at(0).toStringRef();
       std::string op_overload_name = op.at(1).toStringRef();
-      if (op_overload_name != "") {
+      if (!op_overload_name.empty()) {
         op_name.append(".");
         op_name.append(op_overload_name);
       }

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -310,7 +310,7 @@ void BytecodeDeserializer::parseMethods(
     c10::ivalue::TupleElements&& vals,
     c10::optional<c10::ivalue::TupleElements>&& debug_handles,
     mobile::CompilationUnit& mcu) {
-  TORCH_CHECK(vals.size() > 0, "Bytecode has no elements. ");
+  TORCH_CHECK(!vals.empty(), "Bytecode has no elements. ");
   // Initialized with the version number when kProducedBytecodeVersion was
   // introduced. The old models (some of them already in production) without
   // version number are seen as version 3 (deprecated).

--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -232,7 +232,7 @@ bool InterpreterState::run(Stack& stack) {
         } break;
         case RET:
           leaveFrame();
-          if (frames_.size() > 0) {
+          if (!frames_.empty()) {
             continue;
           }
           return false;

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -141,8 +141,7 @@ void slot_named_params_recurse(
   size_t nslots = slots.size();
   for (const auto i : c10::irange(nslots)) {
     auto slot = slots[i];
-    std::string name =
-        parent_name.size() == 0 ? parent_name : parent_name + ".";
+    std::string name = parent_name.empty() ? parent_name : parent_name + ".";
     name += obj->type()->getAttributeName(i);
     // TODO: Fix this filter. Requires_grad is not the appropriate
     // filter of a parameter, but is a temporary hack to help probable

--- a/torch/csrc/jit/mobile/type_parser.cpp
+++ b/torch/csrc/jit/mobile/type_parser.cpp
@@ -132,7 +132,7 @@ TypePtr TypeParser::parse() {
   const auto& baseTypes = DynamicTypeFactory::basePythonTypes();
   auto simpleTypeIt = baseTypes.find(token);
   if (simpleTypeIt != baseTypes.end()) {
-    if (cur() != "]" && cur() != "," && cur() != "") {
+    if (cur() != "]" && cur() != "," && !cur().empty()) {
       TORCH_CHECK(
           false, "Simple type ", token, " is followed by ", "invalid chars.");
     }

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -120,7 +120,7 @@ RegisterOperators mm_tree_reduction_reg({Operator(
       }
       drop(stack, num_inputs);
 
-      AT_ASSERT(inputs.size() > 0);
+      AT_ASSERT(!inputs.empty());
       AT_ASSERT(inputs.size() % 2 == 0);
       size_t side_num_elems = inputs.size() / 2;
       auto lhs_inputs = at::TensorList(inputs).slice(0, side_num_elems);
@@ -372,7 +372,7 @@ std::pair<std::vector<Node*>, std::vector<Node*>> gatherIndependentMMUses(
     Value* value,
     AliasDb& alias_db) {
   const auto postprocess = [&](std::vector<Node*> mms) {
-    if (mms.size() == 0) {
+    if (mms.empty()) {
       return mms;
     }
     std::sort(mms.begin(), mms.end(), [](Node* n, Node* m) {

--- a/torch/csrc/jit/passes/canonicalize.cpp
+++ b/torch/csrc/jit/passes/canonicalize.cpp
@@ -143,7 +143,7 @@ bool isBeforeOrAfter(const Use& a, const Use& b, bool checking_before) {
 }
 
 c10::optional<const Use> firstOrLastUse(Value* v, bool find_first) {
-  if (v->uses().size() == 0) {
+  if (v->uses().empty()) {
     return c10::nullopt;
   }
   Use extreme_use = v->uses()[0];

--- a/torch/csrc/jit/passes/check_strict_fusion.cpp
+++ b/torch/csrc/jit/passes/check_strict_fusion.cpp
@@ -98,7 +98,7 @@ void checkForUnfusedOps(Node* enter_node) {
       unfused_nodes_not_used_in_guard.push_back(unfused);
     }
   }
-  if (unfused_nodes_not_used_in_guard.size()) {
+  if (!unfused_nodes_not_used_in_guard.empty()) {
     std::stringstream ss;
     ss << "Found unfused operators: \n";
     for (Node* unfused : unfused_nodes_not_used_in_guard) {

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -358,7 +358,7 @@ struct ConstantPropagator {
     }
     return no_mutation && !n->kind().is_onnx() &&
         skip_list.count(n->kind()) == 0 && !n->isNondeterministic() &&
-        !n->hasSideEffects() && n->blocks().size() == 0;
+        !n->hasSideEffects() && n->blocks().empty();
   }
 
   void ConstantPropagation(at::ArrayRef<Block*> blocks) {

--- a/torch/csrc/jit/passes/create_functional_graphs.cpp
+++ b/torch/csrc/jit/passes/create_functional_graphs.cpp
@@ -37,7 +37,7 @@ struct FunctionalGraphSlicer {
  private:
   bool isEmptyFunctionalGraph(Node* n) {
     auto g = n->g(attr::Subgraph);
-    return g->inputs().size() == 0 && g->outputs().size() == 0;
+    return g->inputs().empty() && g->outputs().empty();
   }
 
   void nonConstNodes(Block* block, size_t* num) {

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -286,8 +286,8 @@ class DeadCodeEliminator {
             "Node ",
             it->kind().toQualString(),
             " which outputs ",
-            (node->outputs().size() > 0 ? node->outputs().at(0)->debugName()
-                                        : "n/a"),
+            (!node->outputs().empty() ? node->outputs().at(0)->debugName()
+                                      : "n/a"),
             " will be removed");
         it.destroyCurrent();
       }

--- a/torch/csrc/jit/passes/dtype_analysis.cpp
+++ b/torch/csrc/jit/passes/dtype_analysis.cpp
@@ -162,7 +162,7 @@ using DtypePropRule = std::function<bool(Node*)>;
 bool setIfAllDtypeMatch(Node* n) {
   // Sets all tensor outputs to the dtype of the first input
   // only if all inputs are the same dtype, otherwise do nothing
-  TORCH_INTERNAL_ASSERT(n->inputs().size() >= 1);
+  TORCH_INTERNAL_ASSERT(!n->inputs().empty());
   auto first_arg = n->inputs().at(0);
   auto tensor_type = first_arg->type()->cast<TensorType>();
   TORCH_INTERNAL_ASSERT(tensor_type, "Expecting a tensor type");
@@ -278,7 +278,7 @@ struct DtypePropagationPass {
       const at::ArrayRef<Value*>& list2) {
     // This is currently a placeholder for MobileNet
     // After Month1: implement the merge function
-    TORCH_INTERNAL_ASSERT(list1.size() == 0, "Not implemented yet");
+    TORCH_INTERNAL_ASSERT(list1.empty(), "Not implemented yet");
     return false;
   }
 

--- a/torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp
+++ b/torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp
@@ -155,7 +155,7 @@ struct ConvertTracedAttrReferences {
         for (Value* v : sub_unresolved) {
           n->addInput(v);
         }
-      } else if (n->blocks().size()) {
+      } else if (!n->blocks().empty()) {
         for (Block* sub_block : n->blocks()) {
           auto sub_unresolved =
               convertAttrReferencesToLocalGetAttrs(sub_block, prefix, self);
@@ -326,7 +326,7 @@ void convertReturnsToTuples(Block* b) {
           WithInsertPoint guard(sub_block->return_node());
           Node* return_tup =
               g->insertNode(g->createTuple(sub_block->outputs()));
-          while (sub_block->outputs().size()) {
+          while (!sub_block->outputs().empty()) {
             sub_block->eraseOutput(0);
           }
           sub_block->registerOutput(return_tup->output());
@@ -344,7 +344,7 @@ void convertReturnsToTuples(Block* b) {
           n->output(rev_idx)->replaceAllUsesWith(tup_unpack->output(rev_idx));
           n->eraseOutput(rev_idx);
         }
-      } else if (sub_block->outputs().size() == 0) {
+      } else if (sub_block->outputs().empty()) {
         WithInsertPoint guard(sub_block->return_node());
         sub_block->registerOutput(g->insertNode(g->createNone())->output());
         n->addOutput()->setType(NoneType::get());

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -199,7 +199,7 @@ struct GraphFuser {
   bool isFusableDefault(Node* node, bool strict_fuser_check) {
     bool fusableDevice = true;
     for (const auto& output : node->outputs()) {
-      if (output->uses().size() > 0) {
+      if (!output->uses().empty()) {
         fusableDevice &= isFusableDevice(output, strict_fuser_check);
       }
     }
@@ -307,7 +307,7 @@ struct GraphFuser {
       auto outputs = node->outputs();
       for (const auto i : c10::irange(outputs.size())) {
         auto output = outputs[i];
-        if (output->uses().size() == 0)
+        if (output->uses().empty())
           continue;
         consumer_subgraph->registerOutput(merged->outputs()[i]);
         auto new_output = consumer_group->addOutput();
@@ -455,7 +455,7 @@ struct GraphFuser {
     // fusion in cases where uses remain after the consumer
     // if these exist, re-route them to the version of producer
     // created in FusionGroup
-    if (producer->uses().size() != 0) {
+    if (!producer->uses().empty()) {
       getSubgraph(group).registerOutput(merged->output());
       Value* new_producer = group->addOutput();
       new_producer->copyMetadata(producer);
@@ -586,7 +586,7 @@ struct GraphFuser {
   }
 
   at::ArrayRef<Value*> broadcast_tensors(value_list inputs) {
-    AT_ASSERT(inputs.size() > 0);
+    AT_ASSERT(!inputs.empty());
     auto* g = inputs[0]->owningGraph();
     auto* input_list =
         g->insertNode(g->createList(TensorType::get(), inputs))->output();

--- a/torch/csrc/jit/passes/guard_elimination.cpp
+++ b/torch/csrc/jit/passes/guard_elimination.cpp
@@ -131,7 +131,7 @@ struct GuardElimination {
 
         // find all uses of the input that the guard node dominates
         std::vector<Use> uses = input->uses();
-        while (uses.size() > 0) {
+        while (!uses.empty()) {
           auto use = uses.at(uses.size() - 1);
           uses.pop_back();
 

--- a/torch/csrc/jit/passes/inliner.cpp
+++ b/torch/csrc/jit/passes/inliner.cpp
@@ -57,7 +57,7 @@ void inlineCalls(Block* block) {
           if (fallback && graphFunction->get_executor().isOptimized()) {
             auto exec_plans =
                 graphFunction->get_executor().getDebugState().execution_plans;
-            if (exec_plans.size() != 0) {
+            if (!exec_plans.empty()) {
               g = exec_plans.begin()->second.graph;
               // optimized_graph() calls Inline, so we only need to explicitly
               // invoke inlining on the jit optimized graph with recursive

--- a/torch/csrc/jit/passes/liveness.cpp
+++ b/torch/csrc/jit/passes/liveness.cpp
@@ -68,7 +68,7 @@ struct LivenessAnalyzer {
       const std::unordered_map<Node*, std::vector<Value*>>& liveness_sets) {
     std::cout << "Liveness info:\n";
     for (auto e : liveness_sets) {
-      if (e.first->outputs().size() > 0) {
+      if (!e.first->outputs().empty()) {
         std::cout << e.first->outputs()[0]->debugName();
       }
 

--- a/torch/csrc/jit/passes/loop_unrolling.cpp
+++ b/torch/csrc/jit/passes/loop_unrolling.cpp
@@ -172,7 +172,7 @@ void unroll(Node* loop) {
   // default one, because this will allow us to share it between the unrolled
   // loop and its epilogue. This is necessary only if the loop counter is
   // actually used in the body.
-  if (body->inputs()[0]->uses().size() > 0)
+  if (!body->inputs()[0]->uses().empty())
     replaceLoopCounter(loop);
 
   // Some optimization for constant-length loops. If we know they won't run too

--- a/torch/csrc/jit/passes/lower_graph.cpp
+++ b/torch/csrc/jit/passes/lower_graph.cpp
@@ -63,7 +63,7 @@ std::pair<std::shared_ptr<Graph>, std::vector<Slot>> lower_graph(
   for (Use use : self_value->uses()) {
     to_scan.emplace_back(ToScan{self, use.user, use.offset});
   }
-  while (to_scan.size() > 0) {
+  while (!to_scan.empty()) {
     auto e = to_scan.back();
     to_scan.pop_back();
 
@@ -104,7 +104,7 @@ std::pair<std::shared_ptr<Graph>, std::vector<Slot>> lower_graph(
     e.n->destroy();
   }
 
-  while (to_clean.size() > 0) {
+  while (!to_clean.empty()) {
     Node* n = to_clean.back();
     AT_ASSERT(!n->hasUses());
     n->destroy();

--- a/torch/csrc/jit/passes/onnx/eval_peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/eval_peephole.cpp
@@ -63,7 +63,7 @@ static void fuseConvBatchNorm(Block* b, ValueToParamPairMap& valsToParamsMap) {
 
       auto epsilon = bnNode->f(attr::epsilon);
       auto convInputVals = getValues(oldConv, valsToParamsMap);
-      if (convInputVals.size() < 1 ||
+      if (convInputVals.empty() ||
           (oldConv->inputs().size() == 3 && convInputVals.size() != 2)) {
         continue;
       }

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -74,7 +74,7 @@ bool IsErasableSequence(const Node* loop_node, size_t i) {
   const auto init_seq_node_kind = init_seq_node->kind();
   if ((init_seq_node_kind != ::c10::onnx::SequenceEmpty) &&
       (init_seq_node_kind != ::c10::prim::ListConstruct ||
-       init_seq_node->inputs().size() != 0)) {
+       !init_seq_node->inputs().empty())) {
     // Initial sequence must be empty.
     return false;
   }

--- a/torch/csrc/jit/passes/onnx/function_extraction.cpp
+++ b/torch/csrc/jit/passes/onnx/function_extraction.cpp
@@ -128,7 +128,7 @@ FunctionExtractor::FunctionContext::FunctionContext(
   GRAPH_UPDATE(
       "Process function context for scope ",
       scope_key_->name().toDisplayString());
-  TORCH_INTERNAL_ASSERT(scopes.size() > 0);
+  TORCH_INTERNAL_ASSERT(!scopes.empty());
   const auto& ref_ctx = scope_ctxs[scope_key_];
   // NOTE: Function scopes must have same number and order of nodes.
   GRAPH_DEBUG(
@@ -332,7 +332,7 @@ c10::optional<ScopePtr> FunctionExtractor::FindCommonAncestor(
 
 c10::optional<ScopePtr> FunctionExtractor::FindCommonAncestor(
     const scope_list& scopes) {
-  if (scopes.size() == 0) {
+  if (scopes.empty()) {
     return c10::nullopt;
   }
 
@@ -372,7 +372,7 @@ c10::optional<ScopePtr> FunctionExtractor::InferScope(Node* n) {
       output_scopes.emplace_back(use.user->scope());
     }
   }
-  if (output_scopes.size() > 0 &&
+  if (!output_scopes.empty() &&
       std::all_of(
           output_scopes.begin(),
           output_scopes.end(),
@@ -381,7 +381,7 @@ c10::optional<ScopePtr> FunctionExtractor::InferScope(Node* n) {
           })) {
     return output_scopes.at(0);
   } else if (
-      input_scopes.size() > 0 &&
+      !input_scopes.empty() &&
       std::all_of(
           input_scopes.begin(),
           input_scopes.end(),
@@ -401,7 +401,7 @@ c10::optional<ScopePtr> FunctionExtractor::InferScope(Node* n) {
         output_scopes.end(),
         std::back_inserter(scopes),
         IsValidScope);
-    if (scopes.size() > 0) {
+    if (!scopes.empty()) {
       auto common_ancestor = FindCommonAncestor(scopes);
       if (common_ancestor.has_value() &&
           IsValidScope(common_ancestor.value())) {
@@ -829,7 +829,7 @@ void FunctionExtractor::HandleNoScopeNodes(
         "ONNX function extraction cannot determine the scope for node: ", *n);
   }
   TORCH_INTERNAL_ASSERT(
-      no_scope_nlist.size() == 0,
+      no_scope_nlist.empty(),
       "ONNX function extraction cannot determine the scope for the above nodes.");
 }
 

--- a/torch/csrc/jit/passes/onnx/function_substitution.cpp
+++ b/torch/csrc/jit/passes/onnx/function_substitution.cpp
@@ -40,7 +40,7 @@ std::string GetCallNodeVariableName(const Node* call_node) {
     return "";
   }
   std::string module_name = module_node->s(attr::name);
-  if (module_node->inputs().size() == 0) {
+  if (module_node->inputs().empty()) {
     return module_name;
   }
   // If module is from container, attr::name in module node only carries
@@ -53,7 +53,7 @@ std::string GetCallNodeVariableName(const Node* call_node) {
             "__torch__.torch.nn.modules.container.ModuleList") {
       auto parent_module_node = parent_module_value->node();
       module_name = parent_module_node->s(attr::name) + "." + module_name;
-      parent_module_value = parent_module_node->inputs().size() > 0
+      parent_module_value = !parent_module_node->inputs().empty()
           ? parent_module_node->input(0)
           : nullptr;
     } else {
@@ -167,7 +167,7 @@ void functionCallSubstitution(Block* block) {
 }
 
 ScopePtr ONNXGraphTopLevelScope(Graph& graph) {
-  if (graph.inputs().size() == 0) {
+  if (graph.inputs().empty()) {
     return graph.current_scope();
   }
   if (auto top_module_type = graph.inputs().at(0)->type()->cast<ClassType>()) {

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -245,7 +245,7 @@ void ONNXLintGraph(
       GRAPH_DEBUG("Node does not set sourceRange:", *n);
       n_miss_source_range.emplace_back(n->kind());
     }
-    if (n->scopeName() == "") {
+    if (n->scopeName().empty()) {
       GRAPH_DEBUG("Node does not set scope:", *n);
       n_miss_scope.emplace_back(n->kind());
     }

--- a/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
+++ b/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
@@ -298,7 +298,7 @@ std::vector<Value*> ConvertIndexPutToONNX(
   // select operator(0).
   std::vector<Node*> slice_and_select_nodes =
       IndexingPatternFinder::FetchSliceAndSelect(index_put_node);
-  Node* last_node = slice_and_select_nodes.size() > 0
+  Node* last_node = !slice_and_select_nodes.empty()
       ? slice_and_select_nodes.back()
       : index_put_node;
   // Update inner block input originates from outside.

--- a/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_encapsulation.cpp
+++ b/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_encapsulation.cpp
@@ -33,7 +33,7 @@ Node* EncapsulateInplaceIndexPutForONNX(Node* index_put_node) {
   // select operator(0).
   std::vector<Node*> slice_and_select_nodes =
       IndexingPatternFinder::FetchSliceAndSelect(index_put_node);
-  Node* last_node = slice_and_select_nodes.size() > 0
+  Node* last_node = !slice_and_select_nodes.empty()
       ? slice_and_select_nodes.back()
       : index_put_node;
   Value* orig_data = last_node->input(0);

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -194,7 +194,7 @@ void fuseConsecutiveTransposes(Block* b) {
           composeTransposes(
               origInput->node()->is(attr::perm), n->is(attr::perm)));
       n->replaceInput(0, origInput->node()->input());
-      if (origInput->uses().size() == 0) {
+      if (origInput->uses().empty()) {
         origInput->node()->destroy();
       }
       continue;
@@ -233,7 +233,7 @@ void fuseTransposeIntoGemm(Block* b) {
             inp->node()->is(attr::perm) == simpleTransPerm) {
           n->replaceInput(i, inp->node()->input());
           n->i_(trans, n->hasAttribute(trans) ? !n->i(trans) : 1);
-          if (inp->uses().size() == 0) {
+          if (inp->uses().empty()) {
             inp->node()->destroy();
           }
         }
@@ -307,7 +307,7 @@ void pushPackingPastRnn(Block* b) {
     n->outputs().at(0)->replaceAllUsesWith(n->inputs().at(0));
 
     Value* batch_sizes = n->outputs().at(1);
-    while (batch_sizes->uses().size()) {
+    while (!batch_sizes->uses().empty()) {
       Use use_0 = batch_sizes->uses().at(0);
       Node* user = use_0.user;
       // Make calculation of max_batch_size not depend on batch_sizes.
@@ -526,7 +526,7 @@ void fixDefaultRNNState(
   fixed_init_state->addInput(concated_dims->outputs()[0]);
   n->replaceInput(input_index, fixed_init_state->outputs()[0]);
 
-  if (initial_state->uses().size() == 0) {
+  if (initial_state->uses().empty()) {
     initial_state->node()->destroy();
   }
 }
@@ -658,7 +658,7 @@ static void eraseListConstruct(Node* n, int opset_version) {
             i, std::vector<Value*>({concat_node->output()}));
       } else {
         if (opset_version >= OPSET_VERSION_11) {
-          c10::Symbol seq_node_kind = lc_node->inputs().size() > 0
+          c10::Symbol seq_node_kind = !lc_node->inputs().empty()
               ? onnx::SequenceConstruct
               : onnx::SequenceEmpty;
           Node* seq_node = block->owningGraph()->create(
@@ -855,7 +855,7 @@ static void fuseLogSoftmaxNllLoss(Block* b) {
         // (%10)
         origLogSoftmaxNode = prev->input(0)->node();
         auto transpose = origLogSoftmaxNode->input(0)->node();
-        if (transpose->inputs().size() > 0) {
+        if (!transpose->inputs().empty()) {
           origLogSoftmaxNode->replaceInput(0, transpose->inputs().at(0));
         }
       } else if (

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -294,7 +294,7 @@ static std::pair<Value*, Value*> PrepareListDeleteForONNX(Node* n) {
 
 static std::pair<Value*, Value*> PrepareListAppendAndInsertForONNX(Node* n) {
   TORCH_INTERNAL_ASSERT(n->kind() == aten::insert || n->kind() == aten::append);
-  if (n->outputs().size() == 0) {
+  if (n->outputs().empty()) {
     n->addOutput();
     n->output()->setType(n->inputs().at(0)->type());
   }
@@ -306,7 +306,7 @@ static std::pair<Value*, Value*> PrepareSetItemForONNX(Node* n) {
   // It seems the JIT does not always produce an output for _set_item.
   // In particular it seems to for list but not for dict.
   // So we add one if needed.
-  if (n->outputs().size() == 0) {
+  if (n->outputs().empty()) {
     n->addOutput();
     n->output()->setType(n->inputs().at(0)->type());
   }

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -198,7 +198,7 @@ bool IsValidONNXControlflowNode(const Node* n) {
   // nodes later, when the subgraph has already completed shape inferencing.
   auto node_kind = n->kind();
   if (node_kind == ::c10::onnx::Loop || node_kind == ::c10::onnx::If) {
-    if (n->blocks().size() == 0) {
+    if (n->blocks().empty()) {
       return false;
     }
   }
@@ -413,7 +413,7 @@ void ConvertGraphToONNXProto(
 }
 
 c10::optional<at::Tensor> ComputeConstantFolding(Node* n, int opset_version) {
-  if (n->inputs().size() == 0) {
+  if (n->inputs().empty()) {
     return c10::nullopt;
   }
   std::vector<at::Tensor> inputTensorValues;
@@ -958,7 +958,7 @@ void ProcessReshapeNode(Node* n, int opset_version) {
     auto static_shape_value =
         ConstantValueMap::GetValueInto1DInt64Vector(shape_name);
     auto symbolic_input_shape = ConstantValueMap::GetShape(input_name);
-    if (symbolic_input_shape && static_shape_value.size() > 0) {
+    if (symbolic_input_shape && !static_shape_value.empty()) {
       auto final_shape = ComputeShapeFromReshape(
           n,
           symbolic_input_shape.value(),

--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -211,7 +211,7 @@ std::vector<Node*> CreateQuantizedWeights(
   zero_point_node->t_(Symbol::attr("value"), zero_point_value.clone());
 
   Node* axis_node = graph->create(prim::Constant);
-  if (axis_data.size() > 0) {
+  if (!axis_data.empty()) {
     auto axis_value =
         at::from_blob(
             axis_data.data(), c10::IntArrayRef(axis_data.size()), at::kLong)

--- a/torch/csrc/jit/passes/peephole_alias_sensitive.cpp
+++ b/torch/csrc/jit/passes/peephole_alias_sensitive.cpp
@@ -52,7 +52,7 @@ struct PeepholeOptimizeAliasSensitiveImpl {
         auto dim_uses = c10::filter(node->output()->uses(), [](const Use& use) {
           return use.user->kind() == aten::dim;
         });
-        if (dim_uses.size() == 0) {
+        if (dim_uses.empty()) {
           continue;
         }
         auto kind = node->kind();

--- a/torch/csrc/jit/passes/peephole_dict_idioms.cpp
+++ b/torch/csrc/jit/passes/peephole_dict_idioms.cpp
@@ -235,7 +235,7 @@ class PeepholeOptimizeDictIdiomsImpl {
       }
 
       // only optimizing dict ops
-      if (node->inputs().size() == 0 || !isDict(node->input(0))) {
+      if (node->inputs().empty() || !isDict(node->input(0))) {
         continue;
       }
 

--- a/torch/csrc/jit/passes/peephole_list_idioms.cpp
+++ b/torch/csrc/jit/passes/peephole_list_idioms.cpp
@@ -37,7 +37,7 @@ struct ListLenRefiner {
   bool run() {
     std::unordered_set<Value*> li_with_len_use;
     collectListsToRefine(graph_->block(), li_with_len_use);
-    if (lists_to_refine_.size() == 0) {
+    if (lists_to_refine_.empty()) {
       return false;
     }
     ListRefinement refinements;
@@ -239,7 +239,7 @@ struct PeepholeOptimizeListIdiomsImpl {
       }
 
       // only optimizing list ops
-      if (node->inputs().size() == 0 ||
+      if (node->inputs().empty() ||
           !node->input(0)->type()->castRaw<ListType>()) {
         continue;
       }

--- a/torch/csrc/jit/passes/quantization/dedup_module_uses.cpp
+++ b/torch/csrc/jit/passes/quantization/dedup_module_uses.cpp
@@ -48,7 +48,7 @@ class ModuleUseDeduper {
 
         // path.size() == 0 means we're calling a method
         // on self, we don't need to dedup uses of self
-        if (path.size() == 0) {
+        if (path.empty()) {
           continue;
         }
         value_to_path_map_[instance] = path;
@@ -88,7 +88,7 @@ class ModuleUseDeduper {
       const Module& child_module,
       const std::vector<std::string>& path) {
     TORCH_INTERNAL_ASSERT(
-        path.size() > 0, "path must have at least one element.");
+        !path.empty(), "path must have at least one element.");
     // Parent module of the leaf child module corresponding to
     // the path
     auto parent_of_leaf = findChildModule(

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -63,7 +63,7 @@ void fillQConfigMap(
 
   for (const NameModule& s : module.named_children()) {
     std::string child_key;
-    if (key == "") {
+    if (key.empty()) {
       child_key = s.name;
     } else {
       child_key = key + "." + s.name;
@@ -1562,7 +1562,7 @@ InsertObserversHelper::insertObserversFor(
             subblock_output_observe_state.push_back(
                 isObserved(output, block_observed_values));
           }
-          if (aggregated_output_observe_state.size() > 0) {
+          if (!aggregated_output_observe_state.empty()) {
             TORCH_CHECK(
                 aggregated_output_observe_state ==
                     subblock_output_observe_state,

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -504,7 +504,7 @@ void ReplicateChooseQParamsQuantDequant(std::shared_ptr<Graph>& graph) {
   const Graph& dynamic_quant_graph = *dynamic_quant_pattern.pattern_graph;
 
   const auto& matches = findPatternMatches(dynamic_quant_graph, *graph);
-  if (matches.size() == 0) {
+  if (matches.empty()) {
     return;
   }
 
@@ -1250,7 +1250,7 @@ void removeDequantizeFromInputs(const std::unordered_set<Value*>& inputs) {
 // output
 c10::optional<std::vector<Value*>> getDequantizedInputs(Value* output) {
   auto inputs = getPassThroughInputs(output);
-  if (inputs.size() > 0) {
+  if (!inputs.empty()) {
     // note that we don't need to recursively check for prim::If
     // here because if all inputs of a prim::If is dequantized
     // the dequantize will be factored out before we get to this
@@ -1278,7 +1278,7 @@ void InsertQuantDeQuantHelper::propagateQuantizationOps(Block* block) {
       for (Block* subblock : n->blocks()) {
         propagateQuantizationOps(subblock);
       }
-      if (n->outputs().size() == 0) {
+      if (n->outputs().empty()) {
         continue;
       }
       if (n->outputs().size() > 1) {
@@ -1430,7 +1430,7 @@ void InsertQuantDeQuantHelper::run(
       auto qparam_map = std::get<1>(tp);
       // We check the size here because for some observers (like
       // PlaceholderObserver) the qparams might be empty.
-      if (qparam_map.size() > 0) {
+      if (!qparam_map.empty()) {
         TORCH_INTERNAL_ASSERT(
             qparam_name_map_for_node_.count(n),
             "Expected to have a qparam_name_map for node:",

--- a/torch/csrc/jit/passes/remove_mutation.cpp
+++ b/torch/csrc/jit/passes/remove_mutation.cpp
@@ -15,7 +15,7 @@ bool MutationRemover::removeTensorMutation() {
 bool MutationRemover::hasSideEffectOrAlias(Value* v, AliasDb* aliasDb) {
   // bail on nodes with side effects, blocks, or graph / graph inputs
   Node* n = v->node();
-  bool unhandled_node = n->blocks().size() != 0 ||
+  bool unhandled_node = !n->blocks().empty() ||
       n->hasAttribute(attr::Subgraph) || n->hasSideEffects() ||
       (v->node()->kind() == prim::Param);
 
@@ -210,7 +210,7 @@ bool MutationRemover::RemoveListMutation(Block* block) {
     }
 
     // process use-chain and aliasing of node output
-    bool has_output = (node->outputs().size() > 0);
+    bool has_output = (!node->outputs().empty());
     if (has_output) {
       node->output()->replaceAllUsesWith(mutated_value);
       getOrCreateAliasDb()->writeIndex_->erase(node);
@@ -339,7 +339,7 @@ bool MutationRemover::inplaceOpVariant(Node* n) {
   // all inplace ops at time of writing have a single input that is mutated
   // and returned. check that this is true, anything else could have strange
   // semantics,
-  if (n->outputs().size() != 1 || n->inputs().size() == 0) {
+  if (n->outputs().size() != 1 || n->inputs().empty()) {
     return false;
   }
   auto inputs = n->inputs();
@@ -350,7 +350,7 @@ bool MutationRemover::inplaceOpVariant(Node* n) {
   }
 
   auto new_schema = name.substr(0, name.size() - 1);
-  return getAllOperatorsFor(Symbol::fromQualString(new_schema)).size() != 0;
+  return !getAllOperatorsFor(Symbol::fromQualString(new_schema)).empty();
 }
 
 bool RemoveListMutation(const std::shared_ptr<Graph>& graph) {

--- a/torch/csrc/jit/passes/specialize_autogradzero.cpp
+++ b/torch/csrc/jit/passes/specialize_autogradzero.cpp
@@ -240,7 +240,7 @@ struct AutogradZeroSpecializer {
         continue;
       }
 
-      if (inp->uses().size() == 0 || !inp->type()->cast<TensorType>()) {
+      if (inp->uses().empty() || !inp->type()->cast<TensorType>()) {
         continue;
       }
 
@@ -265,7 +265,7 @@ struct AutogradZeroSpecializer {
     }
     GRAPH_DUMP("After for loop", graph_);
     // unable to specialize any of the inputs
-    if (nonzero_values.size() == 0 && zero_values.size() == 0) {
+    if (nonzero_values.empty() && zero_values.empty()) {
       GRAPH_DUMP("Unable to add any specialization guards", graph_);
       versioning_if->destroy();
       // the checks we inserted will be cleaned up
@@ -367,7 +367,7 @@ struct AutogradZeroSpecializer {
           // if we decided to specialize this graph
           // its input may have undefinedness info
           // otherwise it should be Unknown
-          if (n->inputs().size() > 0) {
+          if (!n->inputs().empty()) {
             state_[n->output()] = !state_.count(n->input())
                 ? State::Unknown
                 : state_[n->output()] = state_[n->input()];

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -317,7 +317,7 @@ struct SymbolicShapeOpAnalyzer {
 
   // We handle non-constant values in the shape propagation step
   void substituteConstantInputs() {
-    if (shape_compute_graph_->inputs().size() == 0) {
+    if (shape_compute_graph_->inputs().empty()) {
       return;
     }
 

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -322,7 +322,7 @@ void inlineFallbackGraphAndAddSRCopyOutOp(std::shared_ptr<Graph> graph) {
   auto false_block = if_v.elseBlock();
   std::vector<Value*> false_block_outputs(
       if_v.elseOutputs().begin(), if_v.elseOutputs().end());
-  TORCH_INTERNAL_ASSERT(false_block_outputs.size() != 0);
+  TORCH_INTERNAL_ASSERT(!false_block_outputs.empty());
 
   for (auto out : false_block_outputs) {
     TORCH_INTERNAL_ASSERT(out->type()->cast<TensorType>());
@@ -500,7 +500,7 @@ Operation StaticRuntimeCopyOuts(const Node* node) {
   return [num_ten_inputs](Stack& stack) {
     std::vector<IValue> inputs = pop(stack, num_ten_inputs);
     // uncommon case - first run
-    if (stack.size() == 0) {
+    if (stack.empty()) {
       for (IValue elem : inputs) {
         push(stack, std::move(elem));
       }
@@ -550,7 +550,7 @@ RegisterOperators reg_guard({
 
           // Map from symbolic dimension value to its set's index
           std::map<int64_t, size_t> sym_dim_flat_index;
-          TORCH_INTERNAL_ASSERT(types.size() >= 1);
+          TORCH_INTERNAL_ASSERT(!types.empty());
 
           // we should just be fusing fusion groups with a single device
           // and with tensors not requiring grad

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -325,7 +325,7 @@ void insertTypeGuard(
     guard_types.emplace_back(
         type_converter(input->type()->expect<TensorType>()));
   }
-  if (!inputs_to_check.size()) {
+  if (inputs_to_check.empty()) {
     return;
   }
 
@@ -693,7 +693,7 @@ class TensorExprFuser {
     }
 
     Node* prev_fusion_group =
-        initial_fusion_groups.size() ? initial_fusion_groups[0] : nullptr;
+        !initial_fusion_groups.empty() ? initial_fusion_groups[0] : nullptr;
 
     for (const auto i : c10::irange(1, initial_fusion_groups.size())) {
       // Try merging the just created fusion group into the previous one.
@@ -1315,7 +1315,7 @@ class TensorExprFuser {
 
     std::string line;
     while (std::getline(in_ss, line, ':')) {
-      if (line.size() == 0) {
+      if (line.empty()) {
         continue;
       }
       operators_not_to_fuse.insert(c10::Symbol::aten(line));

--- a/torch/csrc/jit/passes/utils/memory_dag.cpp
+++ b/torch/csrc/jit/passes/utils/memory_dag.cpp
@@ -102,7 +102,7 @@ void MemoryDAG::collectAllContainedMemoryLocationsImpl(
 bool MemoryDAG::mayContainAlias(
     const Element* a,
     const at::ArrayRef<Element*> b) const {
-  if (b.size() == 0) {
+  if (b.empty()) {
     return false;
   }
 
@@ -115,7 +115,7 @@ bool MemoryDAG::mayContainAlias(
 bool MemoryDAG::mayContainAlias(
     const at::ArrayRef<Element*> a,
     const at::ArrayRef<Element*> b) const {
-  if (a.size() == 0 || b.size() == 0) {
+  if (a.empty() || b.empty()) {
     return false;
   }
 

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -263,7 +263,7 @@ void collectNestedUses(
       collectNestedUses(
           closed_over_values, new_values, externalValuesMap, node);
     }
-  } else if (input_node->blocks().size() != 0) {
+  } else if (!input_node->blocks().empty()) {
     TORCH_INTERNAL_ASSERT(false, input_node, " kind not handled yet");
   }
   for (Value* output : input_node->outputs()) {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1886,7 +1886,7 @@ void initJITBindings(PyObject* module) {
     return self_value->overlaps(*other_value);
   });
   m.def("fork", [](const py::args& args, const py::kwargs& kwargs) {
-    AT_ASSERT(args.size() >= 1);
+    AT_ASSERT(!args.empty());
 
     py::function f = py::cast<py::function>(args[0]);
     py::tuple args_tup(args.size() - 1);

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -570,7 +570,7 @@ py::object toPyObject(IValue ivalue) {
 
     // If we have a NamedTuple
     if (tuple->type() && tuple->type()->schema() &&
-        tuple->type()->schema()->name() != "") {
+        !tuple->type()->schema()->name().empty()) {
       auto unqualName = tuple->type()->name()->name();
 
       const std::vector<Argument>& tuple_args =
@@ -758,7 +758,7 @@ py::object _get_operation_for_overload_or_packet(
         total_arg_num,
         false /* throw_error */);
   }
-  if (overloaded_args.size() > 0 || at::impl::torch_function_mode_enabled()) {
+  if (!overloaded_args.empty() || at::impl::torch_function_mode_enabled()) {
     py::object ret;
     std::string ns = symbol.ns().toUnqualString();
     std::string method_name = symbol.toUnqualString();
@@ -768,7 +768,7 @@ py::object _get_operation_for_overload_or_packet(
                          .attr(method_name.c_str());
     if (is_overload) {
       auto overload_name = operations[0]->schema().overload_name();
-      if (overload_name == "") {
+      if (overload_name.empty()) {
         self_func = self_func.attr("default");
       } else {
         self_func = self_func.attr(overload_name.c_str());

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -922,7 +922,7 @@ inline py::object runAndInsertCall(
   }
 
   TORCH_CHECK(
-      stack.size() > 0,
+      !stack.empty(),
       "Expected values in the stack after execution but found none");
   return toPyObject(std::move(stack.back()));
 }
@@ -963,7 +963,7 @@ inline c10::optional<py::object> maybeTorchFunctionDispatch(
         total_arg_num,
         false /* throw_error */);
   }
-  if (overloaded_args.size() > 0) {
+  if (!overloaded_args.empty()) {
     return pybind11::reinterpret_steal<py::object>(
         handle_torch_function_no_python_arg_parser(
             /*overloaded_args=*/overloaded_args,

--- a/torch/csrc/jit/python/python_dict.cpp
+++ b/torch/csrc/jit/python/python_dict.cpp
@@ -64,7 +64,7 @@ void initScriptDictBindings(PyObject* module) {
       .def(py::init([](py::dict dict) {
         TypePtr type = nullptr;
 
-        if (dict.size() > 0) {
+        if (!dict.empty()) {
           // If the source dictionary is nonempty, try to infer its type.
           auto inferred_type = tryToInferType(dict);
 

--- a/torch/csrc/jit/python/python_list.cpp
+++ b/torch/csrc/jit/python/python_list.cpp
@@ -63,7 +63,7 @@ void initScriptListBindings(PyObject* module) {
       .def(py::init([](py::list list) {
         TypePtr type = nullptr;
 
-        if (list.size() > 0) {
+        if (!list.empty()) {
           // If the source list is nonempty, try to infer its type.
           auto inferred_type = tryToInferType(list);
 
@@ -289,7 +289,7 @@ void initScriptListBindings(PyObject* module) {
           [](py::list list) { // __setstate__
             TypePtr type = nullptr;
 
-            if (list.size() > 0) {
+            if (!list.empty()) {
               // If the source list is nonempty, try to infer its type.
               auto inferred_type = tryToInferType(list);
 

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -50,7 +50,7 @@ FunctionSchema PythonValue::getSchema(
   auto param_names = py::cast<std::vector<std::string>>(py_param_names);
   auto names_it = param_names.begin();
   if (moduleSelf_) {
-    if (param_names.size() == 0) {
+    if (param_names.empty()) {
       throw ErrorReport(loc)
           << "Non-static method does not have a self argument";
     }
@@ -418,7 +418,7 @@ void recurseThroughNestedModules(
     auto keys_value = keys_iter->tup_.at(i);
     auto key_string = toIValue(keys_value->asValue(loc, m))->toStringRef();
     std::string submodule_prefix = prefix;
-    if (prefix != "") {
+    if (!prefix.empty()) {
       submodule_prefix = prefix + ".";
     }
     submodule_prefix += key_string;
@@ -746,9 +746,8 @@ std::shared_ptr<SugaredValue> ModuleValue::call(
     at::ArrayRef<NamedValue> kwargs,
     size_t n_binders) {
   c10::ClassTypePtr class_type = concreteType_->getJitType()->cast<ClassType>();
-  bool have_pre_hooks =
-      class_type && class_type->getForwardPreHooks().size() != 0;
-  bool have_hooks = class_type && class_type->getForwardHooks().size() != 0;
+  bool have_pre_hooks = class_type && !class_type->getForwardPreHooks().empty();
+  bool have_hooks = class_type && !class_type->getForwardHooks().empty();
 
   std::vector<Value*> arg_values;
   std::vector<NamedValue> pre_hook_result;
@@ -797,7 +796,7 @@ std::shared_ptr<SugaredValue> ModuleValue::call(
     for (auto& output_node : output_nodes) {
       pre_hook_result.emplace_back(output_node);
     }
-    if (args.size() != 0) { // only replace input if it existed
+    if (!args.empty()) { // only replace input if it existed
       args = pre_hook_result;
     }
   }
@@ -971,7 +970,7 @@ std::shared_ptr<SugaredValue> PythonExceptionValue::call(
     at::ArrayRef<NamedValue> kwargs,
     size_t /*n_binders*/) {
   Value* error_message = nullptr;
-  if (args.size() == 0) {
+  if (args.empty()) {
     error_message = insertConstant(*caller.graph(), "", loc);
   } else if (args.size() == 1) {
     error_message = args.at(0).value(*caller.graph());

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -139,7 +139,7 @@ struct VISIBILITY_HIDDEN ModuleDictMethod : public SugaredValue {
       at::ArrayRef<NamedValue> args,
       at::ArrayRef<NamedValue> kwargs,
       size_t n_binders) override {
-    if (args.size() || kwargs.size()) {
+    if (!args.empty() || !kwargs.empty()) {
       throw ErrorReport(loc)
           << name_ << " method does not accept any arguments";
     }

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1374,7 +1374,7 @@ void initJitScriptBindings(PyObject* module) {
       .def(
           py::init([](const std::string& lang, const uint32_t _frames_up) {
             auto cu = std::make_shared<CompilationUnit>();
-            if (lang.size() > 0) {
+            if (!lang.empty()) {
               pyCompilationUnitDefine(*cu, lang, nullptr, _frames_up);
             }
             return cu;

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -134,7 +134,7 @@ struct ArgumentSpec {
       return false;
     // NB: we need to break out early when there are no elements, because
     // passing a nullptr to memcmp is UB.
-    if (tensor_args.size() == 0)
+    if (tensor_args.empty())
       return true;
     return std::memcmp(
                tensor_args.data(),

--- a/torch/csrc/jit/runtime/calculate_necessary_args.h
+++ b/torch/csrc/jit/runtime/calculate_necessary_args.h
@@ -14,7 +14,7 @@ inline std::pair<int64_t, int64_t> CalculateNecessaryArgs(
     const std::vector<Argument>& schema_args,
     at::ArrayRef<Value*> actual_inputs,
     bool allow_trailing_out_args) {
-  if (schema_args.size() == 0) {
+  if (schema_args.empty()) {
     return std::make_pair(0, 0);
   }
 

--- a/torch/csrc/jit/runtime/decomposition_registry.cpp
+++ b/torch/csrc/jit/runtime/decomposition_registry.cpp
@@ -51,7 +51,7 @@ void loadModule(const CompilationUnit& module) {
 
 void loadDecompositionFunctions() {
   std::lock_guard<std::mutex> guard(lock);
-  if (schema_to_decomposition.size() != 0) {
+  if (!schema_to_decomposition.empty()) {
     return;
   }
 

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -895,7 +895,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
       // module hierarchy.
       const auto& g = frame.function->graph_;
       std::string g_self_type;
-      if (g && g->inputs().size() > 0) {
+      if (g && !g->inputs().empty()) {
         const auto& g_self_type_ptr =
             g->inputs()[0]->type()->cast<c10::ClassType>();
         if (g_self_type_ptr) {
@@ -945,7 +945,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
         if (node->input(0)->node()->kind() == prim::GetAttr) {
           class_instance_name = node->input(0)->node()->s(attr::name);
         } else if (
-            node->owningGraph()->inputs().size() > 0 &&
+            !node->owningGraph()->inputs().empty() &&
             node->input(0) == node->owningGraph()->inputs()[0]) {
           class_instance_name = "SELF";
         } else {

--- a/torch/csrc/jit/runtime/interpreter/code_impl.h
+++ b/torch/csrc/jit/runtime/interpreter/code_impl.h
@@ -903,7 +903,7 @@ struct MobileCodeImpl : CodeImpl {
 
           size_t numInclude = specifiedArgs.first +
               (support_default_args_before_out_ ? specifiedArgs.second : 0);
-          auto unique_name = op_schema.overload_name() != ""
+          auto unique_name = !op_schema.overload_name().empty()
               ? op_schema.name() + "." + op_schema.overload_name()
               : op_schema.name();
           auto it = op_to_num_specified_args_.insert(

--- a/torch/csrc/jit/runtime/interpreter/preprocess_graph.cpp
+++ b/torch/csrc/jit/runtime/interpreter/preprocess_graph.cpp
@@ -67,11 +67,11 @@ void dropUnused(Block* b) {
   auto createDropIfUnused = [&](ArrayRef<Value*> values) -> Node* {
     std::vector<Value*> to_drop;
     for (auto v : values) {
-      if (v->uses().size() == 0 && v->node()->kind() != prim::Constant) {
+      if (v->uses().empty() && v->node()->kind() != prim::Constant) {
         to_drop.push_back(v);
       }
     }
-    if (to_drop.size() == 0) {
+    if (to_drop.empty()) {
       return nullptr;
     }
     return b->owningGraph()->create(prim::Drop, to_drop, 0);

--- a/torch/csrc/jit/runtime/profiling_record.cpp
+++ b/torch/csrc/jit/runtime/profiling_record.cpp
@@ -266,7 +266,7 @@ bool needsProfiledOutput(Node* n) {
 void ProfilingRecord::removeProfileCounter(Block* b) {
   for (auto it = b->nodes().rbegin(); it != b->nodes().rend();) {
     auto n = *it;
-    if (n->kind() == prim::profile && n->inputs().size() == 0) {
+    if (n->kind() == prim::profile && n->inputs().empty()) {
       it.destroyCurrent();
       // there is only one counter node
       return;

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -108,7 +108,7 @@ void checkImplicitTensorToNum(const at::Tensor& t, bool toInt) {
     throw std::runtime_error(
         "Cannot input a tensor that requires grad as a scalar argument");
   }
-  if (t.sizes().size() != 0) {
+  if (!t.sizes().empty()) {
     throw std::runtime_error(
         "Cannot input a tensor of dimension other than 0 as a scalar argument");
   }

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -1379,7 +1379,7 @@ void dictDelete(Stack& stack) {
 
 void dictPopItem(Stack& stack) {
   auto dict = pop(stack).toGenericDict();
-  if (dict.size() == 0) {
+  if (dict.empty()) {
     AT_ERROR("popitem(): dictionary is empty");
   }
   auto head_item = dict.begin();
@@ -1993,7 +1993,7 @@ static const std::vector<OperatorGeneratorArgs> stringOpGenArgs{
           std::string string = pop(stack).toStringRef();
           LOG(WARNING)
               << "The isidentifier() implementation being used is from Python 2\n";
-          if (string.size() < 1) {
+          if (string.empty()) {
             push(stack, false);
             return;
           }
@@ -2416,7 +2416,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs1{
         [](Stack& stack) {
           at::Tensor a;
           pop(stack, a);
-          if (a.name() == "") {
+          if (a.name().empty()) {
             push(stack, IValue());
           } else {
             push(stack, a.name());

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -91,7 +91,7 @@ RegisterOperators reg({
           int64_t chunks = node->i(attr::chunks);
           int64_t dim = node->i(attr::dim);
           auto outputs_used = fmap(node->outputs(), [](const Value* v) {
-            return v->uses().size() > 0;
+            return !v->uses().empty();
           });
           return [=](Stack& stack) {
             RECORD_FUNCTION("chunk", last(stack, 1));

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -68,7 +68,7 @@ std::vector<int64_t> compute_sizes(const IValue& seq) {
   auto seq_recur = seq.toList();
   while (true) {
     sizes.push_back(seq_recur.size());
-    if (seq_recur.size() == 0 || !seq_recur.get(0).isList()) {
+    if (seq_recur.empty() || !seq_recur.get(0).isList()) {
       break;
     }
     seq_recur = seq_recur.get(0).toList();

--- a/torch/csrc/jit/runtime/static/fusion.cpp
+++ b/torch/csrc/jit/runtime/static/fusion.cpp
@@ -297,7 +297,7 @@ void createFusionGroups(Block* block, AliasDb* aliasDb, size_t min_size) {
   }
 
   Node* prev_fusion_group =
-      initial_fusion_groups.size() ? initial_fusion_groups[0] : nullptr;
+      !initial_fusion_groups.empty() ? initial_fusion_groups[0] : nullptr;
 
   for (const auto i : c10::irange(1, initial_fusion_groups.size())) {
     // Try merging the just created fusion group into the previous one.

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -955,7 +955,7 @@ void BlockRunner::set_inputs(
 
   const auto& schema_args = schema->arguments();
   size_t consumed_kwargs = 0;
-  DCHECK(schema_args.size() > 0);
+  DCHECK(!schema_args.empty());
   TORCH_CHECK(
       args.size() < schema_args.size(),
       "Static runtime got too many arguments");
@@ -1375,8 +1375,7 @@ void BlockRunner::benchmark(
     const int main_runs,
     bool print_per_node_time,
     bool generate_ai_pep_output) {
-  TORCH_CHECK(
-      kwargs_list.size() == 0 || args_list.size() == kwargs_list.size());
+  TORCH_CHECK(kwargs_list.empty() || args_list.size() == kwargs_list.size());
   std::cout << "Input size: " << args_list.size() << std::endl;
   float time_per_iter =
       benchmark_model(args_list, kwargs_list, warmup_runs, main_runs);
@@ -1397,7 +1396,7 @@ void BlockRunner::benchmark(
 
   std::vector<std::pair<std::string, double>> time_per_node_type_vec{
       results.time_per_node_type.begin(), results.time_per_node_type.end()};
-  if (args_list.size() == 0) {
+  if (args_list.empty()) {
     std::sort(
         time_per_node_type_vec.begin(),
         time_per_node_type_vec.end(),
@@ -1497,10 +1496,9 @@ float BlockRunner::benchmark_model(
     const int warmup_runs,
     const int main_runs) {
   TORCH_CHECK(warmup_runs >= 0 && main_runs >= 1);
-  TORCH_CHECK(
-      kwargs_list.size() == 0 || args_list.size() == kwargs_list.size());
+  TORCH_CHECK(kwargs_list.empty() || args_list.size() == kwargs_list.size());
 
-  const bool is_kwargs_empty = kwargs_list.size() == 0;
+  const bool is_kwargs_empty = kwargs_list.empty();
   const KeywordArgs empty_kwargs;
   for (const auto i : c10::irange(warmup_runs)) {
     (void)i; // Suppress unused variable warning
@@ -1599,13 +1597,12 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
     const std::vector<KeywordArgs>& kwargs_list,
     const int warmup_runs,
     const int main_runs) {
-  TORCH_CHECK(
-      kwargs_list.size() == 0 || args_list.size() == kwargs_list.size());
+  TORCH_CHECK(kwargs_list.empty() || args_list.size() == kwargs_list.size());
   TORCH_CHECK(warmup_runs >= 1 && main_runs >= 1);
 
   IndividualMetrics results;
   results.time_per_node.resize(nodes_.size(), 0);
-  if (args_list.size() == 0) {
+  if (args_list.empty()) {
     // When the given input is empty, compute the op statistics from the given
     // graph without executing it.
     for (const auto i : c10::irange(nodes_.size())) {
@@ -1634,7 +1631,7 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
     return results;
   }
 
-  const bool is_kwargs_empty = kwargs_list.size() == 0;
+  const bool is_kwargs_empty = kwargs_list.empty();
   const KeywordArgs empty_kwargs;
   bool manage_output_tensors = static_module_.opts().manage_output_tensors;
   // See comment on above use of InferenceMode for

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -1293,7 +1293,7 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
       if (!sr_schema_check(n, "aten::format(str self, ...) -> str")) {
         return nullptr;
       }
-      TORCH_CHECK(n->inputs().size() > 0);
+      TORCH_CHECK(!n->inputs().empty());
       return [](ProcessedNode* pnode) {
         const auto num_inputs = pnode->num_inputs();
         auto stack = boxInputs(*pnode);
@@ -1485,7 +1485,7 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         const auto& tensor = pnode->Input(0).toTensor();
         // JIT does a check for requires_grad, but we skip it here since SR is
         // inference only
-        if (tensor.sizes().size() != 0) {
+        if (!tensor.sizes().empty()) {
           throw std::runtime_error(
               "Cannot convert a tensor of dimension > 0 to scalar");
         }

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -885,7 +885,7 @@ SROperator aten_stack(Node* n) {
   }
   return [](ProcessedNode* p_node) {
     const auto inputs = p_node->Input(0).toTensorVector();
-    TORCH_CHECK(inputs.size() > 0, "stack expects non-empty tensor list");
+    TORCH_CHECK(!inputs.empty(), "stack expects non-empty tensor list");
     const auto dim = p_node->Input(1).toInt();
     if (p_node->Output(0).isNone()) {
       p_node->Output(0) = at::native::_stack_cpu(inputs, dim);
@@ -2617,7 +2617,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::cat, aten_cat, [](Node* n) -> SROperator {
   }
   return [](ProcessedNode* p_node) {
     const auto inputs = p_node->Input(0).toTensorVector();
-    TORCH_CHECK(inputs.size() > 0, "concat expects non-empty tensor list");
+    TORCH_CHECK(!inputs.empty(), "concat expects non-empty tensor list");
     const auto dim = p_node->Input(1).toInt();
     if (p_node->Output(0).isNone()) {
       p_node->Output(0) = at::cpu::cat(inputs, dim);

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -505,7 +505,7 @@ std::vector<TupleUnpackBlock> CollectVariadicTupleUnpackFusionCandidates(
 }
 
 void FuseTupleUnpackBlock(const TupleUnpackBlock& nodes) {
-  TORCH_CHECK(nodes.size() > 0);
+  TORCH_CHECK(!nodes.empty());
   auto graph = nodes[0]->owningGraph();
   auto var_unpack = graph->create(
       fromQualString("static_runtime::VarTupleUnpack"),
@@ -987,7 +987,7 @@ void RemoveImmutableInputDictLookups(
     }
     iter->second.push_back(getitem_node);
   }
-  if (keys.size() == 0) {
+  if (keys.empty()) {
     return;
   }
   // Move all keys to the beginning of the graph and insert new dict_unpack
@@ -996,7 +996,7 @@ void RemoveImmutableInputDictLookups(
   graph->prependNode(marker);
   graph->setInsertPoint(marker);
   for (Node* key : keys) {
-    DCHECK(key->inputs().size() == 0);
+    DCHECK(key->inputs().empty());
     key->moveBefore(marker);
   }
   const c10::Symbol static_runtime_dict_unpack_symbol =
@@ -1004,7 +1004,7 @@ void RemoveImmutableInputDictLookups(
   for (auto& it : dict_to_getitems) {
     Value* dict = it.first;
     std::vector<Node*>& getitems = it.second;
-    DCHECK(getitems.size() > 0);
+    DCHECK(!getitems.empty());
     auto* dict_unpack =
         graph->create(static_runtime_dict_unpack_symbol, getitems.size());
     graph->insertNode(dict_unpack);

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -1617,7 +1617,7 @@ void loadFunctions() {
 c10::optional<GradientPair> gradientInfoForSchema(
     const FunctionSchema& schema) {
   std::lock_guard<std::mutex> guard(lock);
-  if (schema_to_graphs.size() == 0) {
+  if (schema_to_graphs.empty()) {
     loadFunctions();
   }
   auto cache_it = cached_gradient_pairs.find(&schema);

--- a/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
+++ b/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
@@ -381,7 +381,7 @@ void loadFunctions() {
 c10::optional<std::shared_ptr<Graph>> shapeComputeGraphForSchema(
     const FunctionSchema& schema) {
   std::lock_guard<std::mutex> guard(lock);
-  if (cached_schema_to_graph.size() == 0) {
+  if (cached_schema_to_graph.empty()) {
     loadFunctions();
   }
 
@@ -398,7 +398,7 @@ c10::optional<std::shared_ptr<Graph>> shapeComputeGraphForSchema(
 TORCH_API c10::optional<BoundedShapeGraphs> boundedGraphsForSchema(
     const FunctionSchema& schema) {
   std::lock_guard<std::mutex> guard(lock);
-  if (cached_bounded_schema_to_graph.size() == 0) {
+  if (cached_bounded_schema_to_graph.empty()) {
     loadFunctions();
   }
   GRAPH_DEBUG("Trying to find schema in bounded graphs: ", schema);
@@ -414,7 +414,7 @@ void RegisterShapeComputeGraphForSchema(
     const FunctionSchema& schema,
     std::shared_ptr<Graph> g) {
   std::lock_guard<std::mutex> guard(lock);
-  if (cached_schema_to_graph.size() == 0) {
+  if (cached_schema_to_graph.empty()) {
     loadFunctions();
   }
   transformShapeFunction(&schema, g);
@@ -425,7 +425,7 @@ void RegisterShapeComputeGraphForSchema(
 
 std::vector<const FunctionSchema*> RegisteredShapeComputeSchemas() {
   std::lock_guard<std::mutex> guard(lock);
-  if (cached_schema_to_graph.size() == 0) {
+  if (cached_schema_to_graph.empty()) {
     loadFunctions();
   }
 

--- a/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
+++ b/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
@@ -115,7 +115,7 @@ std::vector<char> CallStackDebugInfoPickler::pickle(
   std::vector<at::Tensor> table;
   c10::IValue ivalue = c10::ivalue::Tuple::create(std::move(ivalues));
   auto result = jit::pickle(ivalue, &table);
-  TORCH_CHECK(table.size() == 0, "Expected 0 tensors to be written");
+  TORCH_CHECK(table.empty(), "Expected 0 tensors to be written");
   return result;
 }
 

--- a/torch/csrc/jit/serialization/import_read.cpp
+++ b/torch/csrc/jit/serialization/import_read.cpp
@@ -33,7 +33,7 @@ IValue readArchiveAndTensors(
   };
 
   std::string tensor_dir_path =
-      (tensor_prefix != "") ? tensor_prefix : archive_name + "/";
+      (!tensor_prefix.empty()) ? tensor_prefix : archive_name + "/";
 
   auto read_record = [&](const std::string& name) {
     std::string ss = tensor_dir_path + name;

--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -154,7 +154,7 @@ Function* SourceImporterImpl::findFunction(const QualifiedName& name) {
 
 void SourceImporterImpl::parseSourceIfNeeded(const std::string& qualifier) {
   // qualifier may be blank, for instance checking if __torch__ is a class.
-  if (qualifier == "" || loaded_sources_.count(qualifier)) {
+  if (qualifier.empty() || loaded_sources_.count(qualifier)) {
     return;
   }
   loaded_sources_.insert(qualifier);

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -125,7 +125,7 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
   } else if (ivalue.isCapsule()) {
     std::stringstream err;
     err << "Cannot serialize custom bound C++ class";
-    if (memoized_class_types_ && memoized_class_types_->size()) {
+    if (memoized_class_types_ && !memoized_class_types_->empty()) {
       if (auto qualname = memoized_class_types_->back()->name()) {
         err << " " << qualname->qualifiedName();
       }

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -29,7 +29,7 @@ static bool isValidIdentifierChar(char c, size_t pos) {
 }
 
 static bool isValidIdentifier(const std::string& name) {
-  if (name.size() == 0)
+  if (name.empty())
     return false;
   for (const auto i : c10::irange(name.size())) {
     if (!isValidIdentifierChar(name[i], i))
@@ -146,11 +146,11 @@ struct PythonPrintImpl {
       // This prevents having redundant entries at the same offset,
       // which can happen for example in printValueList when begin
       // and end are the empty string.
-      if (s.size() == 0) {
+      if (s.empty()) {
         return *this;
       }
 
-      if (!ranges_.size() || ranges_.back().range != srs_->back()) {
+      if (ranges_.empty() || ranges_.back().range != srs_->back()) {
         ranges_.emplace_back((size_t)oss_.tellp(), srs_->back());
       }
       oss_ << s;
@@ -159,7 +159,7 @@ struct PythonPrintImpl {
 
     TaggedStringStream& operator<<(const TaggedStringStream& rhs) {
       for (const auto& range : rhs.ranges_) {
-        if (!ranges_.size() || ranges_.back().range != range.range) {
+        if (ranges_.empty() || ranges_.back().range != range.range) {
           ranges_.emplace_back((size_t)oss_.tellp() + range.bytes, range.range);
         }
       }
@@ -178,7 +178,7 @@ struct PythonPrintImpl {
 
     template <typename T>
     TaggedStringStream& operator<<(const T& t) {
-      if (!ranges_.size() || ranges_.back().range != srs_->back()) {
+      if (ranges_.empty() || ranges_.back().range != srs_->back()) {
         ranges_.emplace_back((size_t)oss_.tellp(), srs_->back());
       }
       oss_ << t;
@@ -236,7 +236,7 @@ struct PythonPrintImpl {
     if (v->hasDebugName() && use.user->kind() != prim::Return)
       return false;
     // don't try to inline control blocks
-    if (n->blocks().size() != 0)
+    if (!n->blocks().empty())
       return false;
     // if it is a loop-carried input, we need a variable
     // otherwise the condition or trip count may be emitted in the wrong order
@@ -375,7 +375,7 @@ struct PythonPrintImpl {
   // force them to be by rewriting them
   static std::string makeValidIdentifier(const std::string& candidate) {
     std::stringstream ss;
-    if (candidate.size() == 0 || isdigit(candidate[0]))
+    if (candidate.empty() || isdigit(candidate[0]))
       ss << "_";
     for (char c : candidate) {
       if (isupper(c) || islower(c) || isdigit(c) || c == '_')
@@ -510,7 +510,7 @@ struct PythonPrintImpl {
   }
 
   void printAssignment(at::ArrayRef<Value*> lhs, at::ArrayRef<Value*> rhs) {
-    if (lhs.size() == 0) {
+    if (lhs.empty()) {
       return;
     }
     indent();
@@ -561,13 +561,13 @@ struct PythonPrintImpl {
     {
       auto guard = WithIndented();
       // Print node contents
-      printBlock(stmt.thenBlock(), stmt.outputs().size() > 0);
+      printBlock(stmt.thenBlock(), !stmt.outputs().empty());
       printAssignment(stmt.outputs(), stmt.thenOutputs());
     }
     indent() << "else:\n";
     {
       auto guard = WithIndented();
-      printBlock(stmt.elseBlock(), stmt.outputs().size() > 0);
+      printBlock(stmt.elseBlock(), !stmt.outputs().empty());
       printAssignment(stmt.outputs(), stmt.elseOutputs());
     }
   }
@@ -622,7 +622,7 @@ struct PythonPrintImpl {
       auto body_block = stmt.bodyBlock();
       ArrayRef<Value*> loop_carried_block_inputs =
           body_block->inputs().slice(offset);
-      printBlock(body_block, loop_carried_block_inputs.size() > 0);
+      printBlock(body_block, !loop_carried_block_inputs.empty());
       printAssignment(
           loop_carried_block_inputs, body_block->outputs().slice(offset));
     }
@@ -694,7 +694,7 @@ struct PythonPrintImpl {
     assignValuesToTheirUniqueNames(node->outputs());
     indent();
     // Print outputs
-    if (node->outputs().size() > 0) {
+    if (!node->outputs().empty()) {
       printValueList(body_, node->outputs());
       body_ << " = ";
     }
@@ -782,7 +782,7 @@ struct PythonPrintImpl {
               << "Exportable methods must have a single return value. "
               << "Normal use of ScriptMethods should enforce this";
         }
-        if (node->inputs().size() > 0) {
+        if (!node->inputs().empty()) {
           indent();
           body_ << "return ";
           printValueList(body_, node->inputs());
@@ -803,7 +803,7 @@ struct PythonPrintImpl {
         // the unpack to be inserted when parsed back in:
         // a, b, = unpacked
         // a, = unpacked # trailing comma forces an unpack to happen
-        if (node->outputs().size() > 0) {
+        if (!node->outputs().empty()) {
           printValueList(body_, node->outputs(), "", ", = ");
         }
         body_ << useOf(node->input()) << "\n";
@@ -836,7 +836,7 @@ struct PythonPrintImpl {
         const auto out = node->outputs().at(0);
         indent();
         body_ << "with " << useOf(in);
-        if (out->uses().size() > 0) {
+        if (!out->uses().empty()) {
           assignValue(out, genUniqueNameFor(out));
           body_ << " as " << useOf(out);
         }
@@ -1054,7 +1054,7 @@ struct PythonPrintImpl {
         TypePtr elem_type = list_type->getElementType();
         // Empty lists must be annotated with their type so the compiler knows
         // what type is supposed to be inside them
-        if (node->inputs().size() == 0) {
+        if (node->inputs().empty()) {
           stmt << "annotate("
                << node->output()->type()->annotation_str(type_printer_)
                << ", [])";
@@ -1078,7 +1078,7 @@ struct PythonPrintImpl {
         //   - the dict is empty
         //   - the dict has potentially ambiguous element types
         //       (e.g. Tensor vs. Optional[Tensor])
-        if (node->inputs().size() == 0 ||
+        if (node->inputs().empty() ||
             !elementTypeCanBeInferredFromMembers(dict_type->getKeyType()) ||
             !elementTypeCanBeInferredFromMembers(dict_type->getValueType())) {
           stmt << "annotate("
@@ -1320,7 +1320,7 @@ struct PythonPrintImpl {
         printNode(n, /*print_const=*/true);
       }
       // Print body
-      printBlock(body, body->return_node()->inputs().size() > 0);
+      printBlock(body, !body->return_node()->inputs().empty());
       printNode(body->return_node(), /*print_const=*/false);
     }
   }
@@ -1432,7 +1432,7 @@ struct PythonPrintImpl {
         }
         body_ << "]\n";
         auto forwardPreHooks = classType->getForwardPreHooks();
-        if (forwardPreHooks.size() > 0) {
+        if (!forwardPreHooks.empty()) {
           indent();
           body_ << "__forward_pre_hooks__ = [";
           for (const auto& pre_hook : forwardPreHooks) {
@@ -1442,7 +1442,7 @@ struct PythonPrintImpl {
         }
 
         auto forwardHooks = classType->getForwardHooks();
-        if (forwardHooks.size() > 0) {
+        if (!forwardHooks.empty()) {
           indent();
           body_ << "__forward_hooks__ = [";
           for (const auto& hook : forwardHooks) {
@@ -1543,7 +1543,7 @@ struct PythonPrintImpl {
           indent();
           body_ << "def " << method.name() << "(self";
           TORCH_INTERNAL_ASSERT(
-              method.arguments().size() > 0 &&
+              !method.arguments().empty() &&
               method.arguments().at(0).name() == "self");
           for (const Argument& arg :
                at::ArrayRef<Argument>(method.arguments()).slice(1)) {

--- a/torch/csrc/jit/serialization/source_range_serialization.cpp
+++ b/torch/csrc/jit/serialization/source_range_serialization.cpp
@@ -179,7 +179,7 @@ std::vector<char> SourceRangePickler::pickle(
   } else {
     result = jit::pickle(ivalue, &table);
   }
-  TORCH_CHECK(table.size() == 0, "Expected 0 tensors to be written");
+  TORCH_CHECK(table.empty(), "Expected 0 tensors to be written");
   return result;
 }
 

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -915,7 +915,7 @@ void Unpickler::rebuildTensorFromTypeV2() {
     const auto args_elems = args->elements();
     auto base_tensor_args = args_elems.at(tup_idx + 2).toTuple();
     auto py_state = args_elems.at(tup_idx + 3).toGenericDict();
-    if (py_state.size() > 0) {
+    if (!py_state.empty()) {
       TORCH_WARN(
           "Loading Tensor with Python attributes will return at::Tensor with Python attributes being discarded");
     }

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -309,7 +309,7 @@ void CodeGen::allocIntermediateBufs() {
       interm_bufs, interm_buf_ranges, bufs_external_allocs);
 
   // Insert memory allocation/mapping nodes.
-  if (buf_allocs.size() > 0) {
+  if (!buf_allocs.empty()) {
     auto stmt_new = insertAllocFree(buf_allocs, bufs_external_allocs, stmt_);
     set_stmt(stmt_new);
   }

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -689,7 +689,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
               "Number of dimensions did not match number of strides", buf);
         }
         size_t buf_size = 1;
-        if (dims.size() > 0) {
+        if (!dims.empty()) {
           ExprHandle buf_size_expr = ExprHandle(immLike(dims[0], 1));
           ExprHandle negative_one = ExprHandle(immLike(dims[0], -1));
           for (const auto& i : c10::irange(dims.size())) {
@@ -984,7 +984,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
       values[i] = this->value();
     }
     std::vector<TInput> v1;
-    if (values.size() >= 1ULL) {
+    if (!values.empty()) {
       v1 = values[0].as_vec<TInput>();
     }
     std::vector<TInput> v2;

--- a/torch/csrc/jit/tensorexpr/expr.cpp
+++ b/torch/csrc/jit/tensorexpr/expr.cpp
@@ -365,7 +365,7 @@ std::vector<ExprPtr> make_contiguous_strides(
     const std::vector<ExprHandle>& dims) {
   std::vector<ExprPtr> strides;
 
-  if (dims.size() > 0) {
+  if (!dims.empty()) {
     strides.resize(dims.size());
     auto si = immLike(dims[0], 1);
     // NOLINTNEXTLINE

--- a/torch/csrc/jit/tensorexpr/graph_opt.cpp
+++ b/torch/csrc/jit/tensorexpr/graph_opt.cpp
@@ -195,12 +195,11 @@ void annotateInputShapes(
 
 std::shared_ptr<Graph> removeUnusedSelfArgument(
     const std::shared_ptr<Graph>& graph) {
-  if (graph->inputs().size() == 0) {
+  if (graph->inputs().empty()) {
     return graph;
   }
   jit::Value* self_argument = graph->inputs().at(0);
-  if (self_argument->uses().size() != 0 ||
-      !self_argument->type()->is_module()) {
+  if (!self_argument->uses().empty() || !self_argument->type()->is_module()) {
     return graph;
   }
   graph->eraseInput(0);

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -13,7 +13,7 @@ static Dtype ChooseDtype(const Dtype& buffer_dtype, const Dtype& index_dtype) {
 }
 
 static Dtype dtypeOfIndices(const std::vector<ExprPtr>& indices) {
-  if (!indices.size()) {
+  if (indices.empty()) {
     // Return something so we can handle scalar buffers.
     return kInt;
   }
@@ -127,7 +127,7 @@ Dtype Intrinsics::IntrinsicsDtype(
     const std::vector<ExprPtr>& params) {
   // TODO: check the op_type and make a real decision
   // Doesnt this fail with kRand?
-  if (params.size() == 0) {
+  if (params.empty()) {
     throw malformed_input("invalid params in Intrinsics");
   } else if (params.size() == 1) {
     return IntrinsicsDtype(op_type, params[0]->dtype());

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -286,7 +286,7 @@ void IRPrinter::visit(RampPtr v) {
 
 void IRPrinter::visit(LoadPtr v) {
   // TODO: support the mask case
-  if (v->indices().size() == 0) {
+  if (v->indices().empty()) {
     os() << *v->base_handle();
   } else {
     os() << *v->base_handle() << "[";
@@ -414,7 +414,7 @@ void IRPrinter::visit(ReduceOpPtr v) {
 
 void IRPrinter::visit(StorePtr v) {
   // TODO: handle the mask
-  if (v->indices().size() == 0) {
+  if (v->indices().empty()) {
     os() << *v->base_handle() << " = " << *v->value() << ";";
     return;
   }

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -2336,7 +2336,7 @@ ExprPtr TermExpander::mutate(RoundOffPtr v) {
 
 ExprPtr buf_flat_size(BufPtr v) {
   std::vector<ExprPtr> dims = v->dims();
-  if (dims.size() == 0) {
+  if (dims.empty()) {
     return alloc<LongImm>(1);
   }
   ExprPtr flattened = immLike(dims[0], 1);

--- a/torch/csrc/jit/tensorexpr/ir_verifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_verifier.cpp
@@ -79,12 +79,12 @@ void IRVerifier::visit(RampPtr v) {
 
 void IRVerifier::visit(LoadPtr v) {
   auto indices = v->indices();
-  if (indices.size() > 0 && v->buf()->base_handle()->dtype() != kHandle) {
+  if (!indices.empty() && v->buf()->base_handle()->dtype() != kHandle) {
     throw malformed_ir(
         "Load base handle dtype must be Handle", v->buf()->base_handle());
   }
 
-  Dtype index_dtype = indices.size() ? indices.at(0)->dtype() : kInt;
+  Dtype index_dtype = !indices.empty() ? indices.at(0)->dtype() : kInt;
   if (indices.size() > 1) {
     for (size_t i = 1; i < indices.size(); ++i) {
       if (indices.at(i)->dtype() != index_dtype) {
@@ -135,12 +135,12 @@ void IRVerifier::visit(IntrinsicsPtr v) {
 
 void IRVerifier::visit(StorePtr v) {
   auto indices = v->indices();
-  if (indices.size() > 0 && v->buf()->base_handle()->dtype() != kHandle) {
+  if (!indices.empty() && v->buf()->base_handle()->dtype() != kHandle) {
     throw malformed_ir(
         "Store base handle dtype must be Handle", v->buf()->base_handle());
   }
 
-  Dtype index_dtype = indices.size() ? indices.at(0)->dtype() : kInt;
+  Dtype index_dtype = !indices.empty() ? indices.at(0)->dtype() : kInt;
   if (indices.size() > 1) {
     for (size_t i = 1; i < indices.size(); ++i) {
       if (indices.at(i)->dtype() != index_dtype) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -432,7 +432,7 @@ ArgValue TensorExprKernel::toArg(const torch::jit::Value* v) const {
     for (auto el : v->node()->inputs()) {
       vec.push_back(toArg(el));
     }
-    if (vec.size() == 0) {
+    if (vec.empty()) {
       return BufList(); // Return arbitrarily typed vector
     } else if (c10::get_if<BufHandle>(vec.data())) {
       return convertVecArgValue<BufHandle>(vec);
@@ -543,7 +543,7 @@ bool constZeroDimTensorAsScalarArg(
   }
 
   const auto t = toIValue(v)->toTensor();
-  if (t.sizes().size() != 0) {
+  if (!t.sizes().empty()) {
     return false;
   }
 
@@ -675,7 +675,7 @@ void fuseAllLoops(StmtPtr st) {
   std::vector<ForPtr> outer_loops;
   for (const auto& stmt : *block) {
     auto loop = to<For>(stmt);
-    auto hasReduction = NodeFinder<ReduceOp>::find(stmt).size() != 0;
+    auto hasReduction = !NodeFinder<ReduceOp>::find(stmt).empty();
     if (!loop || hasReduction) {
       all_outer_loops.push_back(outer_loops);
       outer_loops.clear();
@@ -797,7 +797,7 @@ StmtPtr TensorExprKernel::transformLoops(BackendType backendType, StmtPtr st) {
         "After random transform:\n", std::to_string(l.root_stmt()), "\n");
   }
 
-  bool hasReduction = NodeFinder<ReduceOp>::find(l.root_stmt()).size() != 0;
+  bool hasReduction = !NodeFinder<ReduceOp>::find(l.root_stmt()).empty();
 
   // For Block codegen we create a map of tensor dims before
   // inlining. Like GPU codegen we need to inline. But the order
@@ -1580,7 +1580,7 @@ void TensorExprKernel::deduceMemoryLayoutPolicy() {
   auto _prefer_symbolic_mem =
       [](const torch::jit::Value* val,
          const std::vector<torch::jit::StrideInput>& stride_desc_vec) {
-        TORCH_INTERNAL_ASSERT(stride_desc_vec.size() > 0);
+        TORCH_INTERNAL_ASSERT(!stride_desc_vec.empty());
         // Has symbolic stride information
         auto cur_stride_desc = stride_desc_vec[0];
         return (cur_stride_desc ==
@@ -1621,7 +1621,7 @@ void TensorExprKernel::deduceMemoryLayoutPolicy() {
   // std::all_of returns true if the range is empty. But we prefer to keep
   // the original memory layout propagation policy for this case. So we
   // check whether the range is empty.
-  auto prefer_channels_last = (graph_io_tensors.size() > 0);
+  auto prefer_channels_last = (!graph_io_tensors.empty());
   for (auto el : graph_io_tensors) {
     auto is_complete = el->isCompleteTensor();
     auto is_symbolic = symbolic_strides_.count(el);

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1354,7 +1354,7 @@ bool LoopNest::optimizeConditionals() {
       continue;
     }
     TORCH_INTERNAL_ASSERT(
-        comp_values.size() >= 1,
+        !comp_values.empty(),
         buildErrorMessage(
             "Expected at least one expression in optimizeConditional in the fuser."));
     comp_values.insert(comp_values.begin(), immLike(comp_values[0], 0));
@@ -1434,7 +1434,7 @@ void LoopNest::vectorizeInnerLoops() {
     worklist.push_back(rootF);
   } else if (BlockPtr body = to<Block>(root_stmt_)) {
     std::vector<BlockPtr> blocks = {body};
-    while (blocks.size()) {
+    while (!blocks.empty()) {
       BlockPtr b = blocks.back();
       blocks.pop_back();
 
@@ -1450,7 +1450,7 @@ void LoopNest::vectorizeInnerLoops() {
 
   // Traverse the For loop nest find inner-most loops, which are
   // vectorization candidates.
-  while (worklist.size()) {
+  while (!worklist.empty()) {
     ForPtr f = worklist.back();
     worklist.pop_back();
 

--- a/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
@@ -36,7 +36,7 @@ std::vector<std::vector<ForPtr>> GetAllPerfectlyNestedLoopNests(
   // Find the first set of loops that can be reordered
   std::vector<std::vector<ForPtr>> all_nested_loops;
   std::vector<ForPtr> nested_loops;
-  if (loops.size() == 0) {
+  if (loops.empty()) {
     return all_nested_loops;
   }
   nested_loops.push_back(loops[0]);
@@ -218,7 +218,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         case COMPUTE_INLINE: {
           if (can_inline) {
             auto bufs = NodeFinder<Buf>::find(l.root_stmt());
-            if (bufs.size() > 0) {
+            if (!bufs.empty()) {
               int buf_number = std::rand() % (int)bufs.size();
               message =
                   "computeInline(" + bufs[buf_number]->name_hint() + ");\n";
@@ -247,7 +247,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         }
         case SPLIT_TAIL: {
           auto loops = NodeFinder<For>::find(l.root_stmt());
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
@@ -261,7 +261,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         }
         case SPLIT_MASK: {
           auto loops = NodeFinder<For>::find(l.root_stmt());
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
@@ -275,14 +275,14 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         }
         case DIST1: {
           auto loops = NodeFinder<For>::find(l.root_stmt());
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
           auto loop = loops[loop_n];
           std::vector<StmtPtr> stmts(
               loop->body()->begin(), loop->body()->end());
-          if (stmts.size() == 0) {
+          if (stmts.empty()) {
             break;
           }
           int n_pivots = (std::rand() % (int)stmts.size()) + 1;
@@ -302,7 +302,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         case DIST2: {
           auto loops = NodeFinder<For>::find(l.root_stmt());
 
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
@@ -316,7 +316,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         case DIST3: {
           auto loops = NodeFinder<For>::find(l.root_stmt());
 
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
@@ -331,7 +331,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         case DIST4: {
           auto loops = NodeFinder<For>::find(l.root_stmt());
 
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
@@ -346,7 +346,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         case DIST5: {
           auto loops = NodeFinder<For>::find(l.root_stmt());
 
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
@@ -402,7 +402,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
           }
 
           // Choose a pair randomly
-          if (valid_pairs.size() == 0) {
+          if (valid_pairs.empty()) {
             break;
           }
           int valid_pair_n = std::rand() % (int)valid_pairs.size();
@@ -434,7 +434,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
           // Find all perfectly nested loop nests
           auto all_nested_loops =
               randomization_helper::GetAllPerfectlyNestedLoopNests(loops);
-          if (all_nested_loops.size() == 0) {
+          if (all_nested_loops.empty()) {
             break;
           }
 
@@ -475,7 +475,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
           // Find all perfectly nested loop nests
           auto all_nested_loops =
               randomization_helper::GetAllPerfectlyNestedLoopNests(loops);
-          if (all_nested_loops.size() == 0) {
+          if (all_nested_loops.empty()) {
             break;
           }
 
@@ -512,7 +512,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
 
         case FULL_UNROLL: {
           auto loops = NodeFinder<For>::find(l.root_stmt());
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
@@ -526,7 +526,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
 
         case NORMALIZE: {
           auto loops = NodeFinder<For>::find(l.root_stmt());
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
@@ -548,7 +548,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
           // Find all perfectly nested loop nests
           auto all_nested_loops =
               randomization_helper::GetAllPerfectlyNestedLoopNests(loops);
-          if (all_nested_loops.size() == 0) {
+          if (all_nested_loops.empty()) {
             break;
           }
 
@@ -594,7 +594,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         case SLICE_HEAD: {
           // Get all the loops
           auto loops = NodeFinder<For>::find(l.root_stmt());
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
@@ -613,7 +613,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
         case SLICE_TAIL: {
           // Get all the loops
           auto loops = NodeFinder<For>::find(l.root_stmt());
-          if (loops.size() == 0) {
+          if (loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)loops.size();
@@ -661,7 +661,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             }
           }
 
-          if (producer_consumer_pairs.size() == 0) {
+          if (producer_consumer_pairs.empty()) {
             break;
           }
 
@@ -702,7 +702,7 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
             }
           }
 
-          if (innermost_loops.size() == 0) {
+          if (innermost_loops.empty()) {
             break;
           }
           int loop_n = std::rand() % (int)innermost_loops.size();

--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -1732,7 +1732,7 @@ int nnc_lowerings_lazy_registration() {
             [&](const std::vector<VarHandle>& axes) {
               int64_t dim = c10::get<int64_t>(inputs[1]);
               if (dim < 0) {
-                if (axes.size() == 0) {
+                if (axes.empty()) {
                   throw malformed_input("axes are zero handling unsqueeze");
                 }
                 dim += axes.size();

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -150,7 +150,7 @@ bool AccessInfo::isWrite() const {
 
 void AccessInfo::print() const {
   std::cout << id_ << ". " << AccessToString(type_) << ": " << *var_ << "[";
-  if (bounds_.size() > 0) {
+  if (!bounds_.empty()) {
     for (size_t i = 0; i < bounds_.size() - 1; ++i) {
       bounds_[i].print();
       std::cout << ", ";
@@ -183,7 +183,7 @@ void AccessInfo::dumpDOT(std::ostream& os) const {
       type_ == AccessType::Alloc) {
     os << "n" << id_ << " [\n";
     os << "label = \"" << AccessToString(type_) << "\\n " << *var_ << "[";
-    if (bounds_.size() > 0) {
+    if (!bounds_.empty()) {
       for (size_t i = 0; i < bounds_.size() - 1; ++i) {
         os << *IRSimplifier::simplify(
                   alloc<Add>(bounds_[i].end, immLike(bounds_[i].end, 1)))
@@ -205,7 +205,7 @@ void AccessInfo::dumpDOT(std::ostream& os) const {
     os << "label = \"" << AccessToString(type_) << " (#" << id_ << ")\\n";
     os << "buf : " << *var_ << "\\n";
     os << "bounds : \[";
-    if (bounds_.size() > 0) {
+    if (!bounds_.empty()) {
       for (size_t i = 0; i < bounds_.size() - 1; ++i) {
         os << "(" << *bounds_[i].start << ", " << *bounds_[i].end << "), ";
       }

--- a/torch/csrc/jit/tensorexpr/operators/misc.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/misc.cpp
@@ -479,7 +479,7 @@ Tensor computeFlatten(
 
 static std::pair<ScalarType, std::vector<BufHandle>> processCatList(
     const std::vector<BufHandle>& bufList) {
-  if (bufList.size() == 0) {
+  if (bufList.empty()) {
     throw std::runtime_error("Empty input list is passed to aten::cat");
   }
   std::vector<BufHandle> bufInputs;
@@ -487,7 +487,7 @@ static std::pair<ScalarType, std::vector<BufHandle>> processCatList(
   for (auto buf : bufList) {
     bufInputs.push_back(buf);
     TORCH_INTERNAL_ASSERT(
-        buf.node()->dims().size() > 0, buildErrorMessage("Invalid buf rank"));
+        !buf.node()->dims().empty(), buildErrorMessage("Invalid buf rank"));
     // Ignore buffers that are 0-sized on any dimension.
     bool hasEmptyDims = false;
     for (const auto& dim : buf.dims()) {
@@ -542,7 +542,7 @@ Tensor computeCatWoConditionals(
       ToDtype(high_type),
       nullptr,
       output_strides_expr);
-  if (non_empty_inputs.size() == 0) {
+  if (non_empty_inputs.empty()) {
     return Tensor(
         output_buf, alloc<tensorexpr::Block>(std::vector<StmtPtr>({})));
   }
@@ -638,7 +638,7 @@ Tensor computeCat(
       outputShape,
       outputStrides,
       [&](const std::vector<VarHandle>& axes) {
-        if (nonEmptyInputs.size() == 0) {
+        if (nonEmptyInputs.empty()) {
           return ExprHandle(0);
         }
 

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -38,7 +38,7 @@ ArgValue convertPyToArgValue(py::handle inp) {
     return ArgNone();
   } else if (py::isinstance<py::list>(inp)) {
     auto l = py::cast<py::list>(inp);
-    if (l.size() == 0) {
+    if (l.empty()) {
       return std::vector<BufHandle>();
     } else if (py::isinstance<py::int_>(l[0])) {
       return py::cast<IntList>(inp);

--- a/torch/csrc/jit/tensorexpr/unique_name_manager.cpp
+++ b/torch/csrc/jit/tensorexpr/unique_name_manager.cpp
@@ -16,7 +16,7 @@ const std::string& UniqueNameManager::get_unique_name(VarPtr v) {
   // First use the name_hint as a prefix to check if there is another name
   // with the same prefix.
   std::string name_hint = v->name_hint();
-  if (name_hint == "") {
+  if (name_hint.empty()) {
     name_hint = "v";
   } else if (std::isdigit(name_hint[0])) {
     name_hint = "v" + name_hint;

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -153,7 +153,7 @@ struct FileCheckImpl {
   TORCH_API void run(const std::string& test_file) {
     has_run = true;
 
-    if (groups.size() == 0 || groups[0].size() == 0) {
+    if (groups.empty() || groups[0].empty()) {
       throw std::runtime_error(
           "No checks have been added to this instance of"
           "Filecheck! Check for bad input.");
@@ -172,7 +172,7 @@ struct FileCheckImpl {
 
   TORCH_API void addCheck(const Check& check) {
     // consecutive CHECK_DAGs & CHECK_NOTs need to be evaluated as a group
-    if (groups.size() == 0 ||
+    if (groups.empty() ||
         (check.type_ != CHECK_NOT && check.type_ != CHECK_DAG)) {
       groups.push_back({check});
     } else {
@@ -391,7 +391,7 @@ struct FileCheckImpl {
     size_t group_beg = std::string::npos;
     size_t group_end = 0;
 
-    AT_ASSERT(groups.size() != 0);
+    AT_ASSERT(!groups.empty());
     for (const auto& check : group) {
       AT_ASSERT(check.type_ == group[0].type_);
       auto pos = assertFind(source, check.search_str_, prev.end(), check);
@@ -406,7 +406,7 @@ struct FileCheckImpl {
       const std::vector<Check>& group,
       const std::shared_ptr<Source>& source,
       const SourceRange& prev) {
-    AT_ASSERT(group.size() != 0);
+    AT_ASSERT(!group.empty());
     CheckType type = group[0].type_;
 
     if (type == CHECK_DAG) {

--- a/torch/csrc/lazy/core/cache.h
+++ b/torch/csrc/lazy/core/cache.h
@@ -65,7 +65,7 @@ class Cache {
 
   TypePtr GetLatest() {
     std::lock_guard<std::mutex> g(lock_);
-    TORCH_CHECK(element_list_.size() > 0);
+    TORCH_CHECK(!element_list_.empty());
     return element_list_.front().second;
   }
 

--- a/torch/csrc/lazy/core/ir_metadata.cpp
+++ b/torch/csrc/lazy/core/ir_metadata.cpp
@@ -73,7 +73,7 @@ void PopScope() {
 }
 
 void ResetScopeContext() {
-  if (g_scope_context.scopes.size() != 0) {
+  if (!g_scope_context.scopes.empty()) {
     TORCH_CHECK(
         false, "Expecting scope to be empty but it is " + GetCurrentScope());
   }

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -1037,8 +1037,7 @@ void LazyGraphExecutor::TensorCollectionBarrier(SyncTensorCollection* coll) {
   if (coll) {
     static const std::string invalid_device(
         "Unknown0"); /* Temp solution to idetify unassigned devices */
-    if (coll->device.toString() == invalid_device ||
-        coll->unlocker.size() > 0) {
+    if (coll->device.toString() == invalid_device || !coll->unlocker.empty()) {
       return;
     }
     VLOG(4) << "Waiting on device barrier for device " << coll->device

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -488,7 +488,7 @@ std::vector<Shape> compute_shape_index_select(
 
   auto self_sizes = self.sizes();
   std::vector<int64_t> output_sizes(self_sizes.begin(), self_sizes.end());
-  TORCH_CHECK(output_sizes.size() > 0, "Empty output_sizes is not supported.");
+  TORCH_CHECK(!output_sizes.empty(), "Empty output_sizes is not supported.");
   output_sizes[dim] = index_size;
 
   return {Shape(self.scalar_type(), output_sizes)};
@@ -512,7 +512,7 @@ std::vector<Shape> compute_shape_cat(at::TensorList tensors, int64_t dim) {
   for (auto& tensor : tensors) {
     extended_dim_shape += tensor.sizes()[dim];
   }
-  TORCH_CHECK(out_shape.size() > 0, "Scalar tensors are not supported in cat.");
+  TORCH_CHECK(!out_shape.empty(), "Scalar tensors are not supported in cat.");
   TORCH_CHECK(
       extended_dim_shape <= std::numeric_limits<int64_t>::max(),
       "Size overflow");
@@ -1113,7 +1113,7 @@ TORCH_API std::vector<Shape> compute_shape_clone(
 }
 
 std::vector<Shape> compute_shape_stack(at::TensorList tensors, int64_t dim) {
-  TORCH_CHECK(tensors.size() > 0, "stack expects a non-empty TensorList");
+  TORCH_CHECK(!tensors.empty(), "stack expects a non-empty TensorList");
   auto wrapped_dim = at::maybe_wrap_dim(dim, tensors[0].ndimension() + 1);
 
   // Copied from 'check_stack_inputs' in TensorShape.cpp

--- a/torch/csrc/lazy/ts_backend/ts_eager_fallback.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_eager_fallback.cpp
@@ -119,7 +119,7 @@ c10::optional<c10::Device> compute_target_device(
   // Decide what device to move the output tensor(s) to.
   // The current convention is that we use the first tensor arg to pick the
   // device Barring that, we take the first tensor from a TensorList arg.
-  if (t_args.size() > 0) {
+  if (!t_args.empty()) {
     return t_args[0].device();
   } else {
     // We need to loop through all of the (potentially multiple) TensorList

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -519,7 +519,7 @@ ThreadLocalSubqueue::ThreadLocalSubqueue(
     const ProfilerConfig& config)
     : tid_{tid}, config_{config}, kineto_info_{kineto::kineto_ids()} {
   torch::profiler::impl::kineto::recordThreadInfo();
-  if (config_.experimental_config.performance_events.size()) {
+  if (!config_.experimental_config.performance_events.empty()) {
     perf_profiler_ =
         std::make_unique<torch::profiler::impl::linux_perf::PerfProfiler>();
     perf_profiler_->Configure(config_.experimental_config.performance_events);

--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -47,7 +47,7 @@ class LibKinetoClient : public libkineto::ClientInterface {
   }
 
   // NOLINTNEXTLINE(modernize-use-override)
-  void set_withstack(bool withStack) override {
+  void set_withstack(bool withStack) {
     withStack_ = withStack;
   }
 

--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -47,7 +47,7 @@ class LibKinetoClient : public libkineto::ClientInterface {
   }
 
   // NOLINTNEXTLINE(modernize-use-override)
-  void set_withstack(bool withStack) {
+  void set_withstack(bool withStack) override {
     withStack_ = withStack;
   }
 

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -151,7 +151,7 @@ class ExperimentalConfigWrapper {
     // Kineto supports reading performance events per kernel/iteration
     // using CUPTI Range based profiler API. In this mode however we
     // do not trace CPU or GPU events.
-    bool cupti_range_profiler = config_.profiler_metrics.size() > 0;
+    bool cupti_range_profiler = !config_.profiler_metrics.empty();
     if (cupti_range_profiler &&
         activities.count(torch::autograd::profiler::ActivityType::CPU)) {
       LOG(WARNING)

--- a/torch/csrc/profiler/perf.cpp
+++ b/torch/csrc/profiler/perf.cpp
@@ -158,7 +158,7 @@ void PerfProfiler::Configure(std::vector<std::string>& event_names) {
 }
 
 void PerfProfiler::Enable() {
-  if (start_values_.size()) {
+  if (!start_values_.empty()) {
     StopCounting();
   }
 
@@ -177,8 +177,7 @@ void PerfProfiler::Disable(perf_counters_t& vals) {
       vals.size() == events_.size(),
       "Can not fit all perf counters in the supplied container");
   TORCH_CHECK(
-      start_values_.size() > 0,
-      "PerfProfiler must be enabled before disabling");
+      !start_values_.empty(), "PerfProfiler must be enabled before disabling");
 
   /* Always connecting this disable event to the last enable event i.e. using
    * whatever is on the top of the start counter value stack. */
@@ -189,7 +188,7 @@ void PerfProfiler::Disable(perf_counters_t& vals) {
   start_values_.pop();
 
   // Restore it for a parent
-  if (start_values_.size()) {
+  if (!start_values_.empty()) {
     StartCounting();
   }
 }

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -106,7 +106,7 @@ std::string getNvtxStr(
     const std::vector<std::vector<int64_t>>& shapes,
     at::RecordFunctionHandle op_id,
     const std::list<std::pair<at::RecordFunctionHandle, int>>& input_op_ids) {
-  if (sequence_nr >= -1 || shapes.size() > 0) {
+  if (sequence_nr >= -1 || !shapes.empty()) {
     std::string str;
     if (sequence_nr >= 0) {
       str = fmt::format("{}, seq = {}", name, sequence_nr);
@@ -121,12 +121,12 @@ std::string getNvtxStr(
     if (op_id > 0) {
       str = fmt::format("{}, op_id = {}", str, op_id);
     }
-    if (shapes.size() > 0) {
+    if (!shapes.empty()) {
       str = fmt::format("{}, sizes = {}", str, shapesToStr(shapes));
     }
     // Include the op ids of the input edges so
     // you can build the network graph
-    if (input_op_ids.size() > 0) {
+    if (!input_op_ids.empty()) {
       str = fmt::format(
           "{}, input_op_ids = {}", str, inputOpIdsToStr(input_op_ids));
     }
@@ -557,7 +557,7 @@ uint64_t computeFlops(
 
     const auto mat1_size = mat1_sizes_ref.toDimVector();
     const auto mat2_size = mat2_sizes_ref.toDimVector();
-    if (mat1_size.size() == 0) {
+    if (mat1_size.empty()) {
       return 0;
     }
 
@@ -598,7 +598,7 @@ uint64_t computeFlops(
 
     const auto mat1_size = mat1_sizes_ref.toDimVector();
     const auto mat2_size = mat2_sizes_ref.toDimVector();
-    if (mat1_size.size() == 0) {
+    if (mat1_size.empty()) {
       return 0;
     }
 

--- a/torch/csrc/utils/invalid_arguments.cpp
+++ b/torch/csrc/utils/invalid_arguments.cpp
@@ -308,7 +308,7 @@ std::string _formattedArgDesc(
       result += reset_red;
     result += ", ";
   }
-  if (arguments.size() > 0)
+  if (!arguments.empty())
     result.erase(result.length() - 2);
   result += ")";
   return result;
@@ -322,7 +322,7 @@ std::string _argDesc(
     result += std::string(py_typename(arg)) + ", ";
   for (auto& kwarg : kwargs)
     result += kwarg.first + "=" + py_typename(kwarg.second) + ", ";
-  if (arguments.size() > 0)
+  if (!arguments.empty())
     result.erase(result.length() - 2);
   result += ")";
   return result;
@@ -390,7 +390,7 @@ std::string format_invalid_args(
     std::vector<std::string> unmatched_kwargs;
     if (has_kwargs)
       unmatched_kwargs = _tryMatchKwargs(option, kwargs);
-    if (unmatched_kwargs.size()) {
+    if (!unmatched_kwargs.empty()) {
       error_msg += "got unrecognized keyword arguments: ";
       for (auto& kwarg : unmatched_kwargs)
         error_msg += kwarg + ", ";
@@ -420,7 +420,7 @@ std::string format_invalid_args(
         std::vector<std::string> unmatched_kwargs;
         if (has_kwargs)
           unmatched_kwargs = _tryMatchKwargs(option, kwargs);
-        if (unmatched_kwargs.size() > 0) {
+        if (!unmatched_kwargs.empty()) {
           error_msg +=
               "      didn't match because some of the keywords were incorrect: ";
           for (auto& kwarg : unmatched_kwargs)

--- a/torch/csrc/utils/nested.cpp
+++ b/torch/csrc/utils/nested.cpp
@@ -74,11 +74,11 @@ at::Tensor nested_tensor_ctor(
   }
 
   at::ScalarType final_dtype = dtype_val;
-  if (r.isNone(1) && new_list.size() > 0) {
+  if (r.isNone(1) && !new_list.empty()) {
     final_dtype = c10::typeMetaToScalarType(new_list[0].dtype());
   }
   at::Device final_device = tensor_options.device();
-  if (r.isNone(2) && new_list.size() > 0) {
+  if (r.isNone(2) && !new_list.empty()) {
     final_device = new_list[0].device();
   }
   auto out = at::_nested_tensor_from_tensor_list(

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -702,7 +702,7 @@ static bool is_int_list(
     // in an intlist argument. Even float or complex scalar tensors.
     bool r =
         (jit::tracer::isTracing() && THPVariable_Check(item.ptr()) &&
-         THPVariable_Unpack(item.ptr()).sizes() == c10::IntArrayRef{});
+         THPVariable_Unpack(item.ptr()).sizes().empty());
     if (!r && failed_idx != nullptr) {
       *failed_idx = 0;
     }
@@ -738,7 +738,7 @@ static bool is_int_or_symint_list(
     // in an intlist argument. Even float or complex scalar tensors.
     bool r =
         (jit::tracer::isTracing() && THPVariable_Check(item.ptr()) &&
-         THPVariable_Unpack(item.ptr()).sizes() == c10::IntArrayRef{});
+         THPVariable_Unpack(item.ptr()).sizes().empty());
     if (!r && failed_idx != nullptr) {
       *failed_idx = 0;
     }
@@ -1454,7 +1454,7 @@ PythonArgParser::PythonArgParser(std::vector<std::string> fmts, bool traceable)
       max_args = signature.max_args;
     }
   }
-  if (signatures_.size() > 0) {
+  if (!signatures_.empty()) {
     function_name = signatures_[0].name;
   }
 

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -59,7 +59,7 @@ c10::AliasAnalysisKind parseAliasAnalysisKind(const std::string& k) {
 
 template <typename Func>
 inline torch::CppFunction dispatch_str(const char* key, Func&& raw_f) {
-  auto mb_key = std::string(key) == ""
+  auto mb_key = std::string(key).empty()
       ? c10::nullopt
       : c10::make_optional(c10::parseDispatchKey(key));
   if (mb_key) {
@@ -346,7 +346,7 @@ void initDispatchBindings(PyObject* module) {
         return std::make_unique<torch::Library>(
             parseKind(kind),
             std::move(name),
-            std::string(dispatch) == ""
+            std::string(dispatch).empty()
                 ? c10::nullopt
                 : c10::make_optional(c10::parseDispatchKey(dispatch)),
             "/dev/null", // temporary workaround
@@ -591,7 +591,7 @@ void initDispatchBindings(PyObject* module) {
   m.def(
       "_dispatch_print_registrations_for_dispatch_key",
       [](const char* dispatch_key = "") {
-        auto k = std::string(dispatch_key) == ""
+        auto k = std::string(dispatch_key).empty()
             ? c10::nullopt
             : c10::make_optional(c10::parseDispatchKey(dispatch_key));
         auto op_names =
@@ -605,7 +605,7 @@ void initDispatchBindings(PyObject* module) {
   m.def(
       "_dispatch_get_registrations_for_dispatch_key",
       [](const char* dispatch_key = "") {
-        auto k = std::string(dispatch_key) == ""
+        auto k = std::string(dispatch_key).empty()
             ? c10::nullopt
             : c10::make_optional(c10::parseDispatchKey(dispatch_key));
         auto op_names =
@@ -614,7 +614,8 @@ void initDispatchBindings(PyObject* module) {
         names.reserve(op_names.size());
         for (auto& op : op_names) {
           names.push_back(
-              op.name + (op.overload_name == "" ? "" : "." + op.overload_name));
+              op.name +
+              (op.overload_name.empty() ? "" : "." + op.overload_name));
         }
         return names;
       },

--- a/torch/csrc/utils/schema_info.cpp
+++ b/torch/csrc/utils/schema_info.cpp
@@ -341,7 +341,7 @@ void SchemaInfo::initSchemaInfo() {
       c10::optional<c10::AliasTypeSet> contained_types =
           schema_.getAliasTypeSetContainedTypes(
               schema_.mapTypeToAliasTypeSet(argument.type()));
-      if (contained_types && contained_types->size() > 0) {
+      if (contained_types && !contained_types->empty()) {
         container_set_.insert({type, i});
       }
     }

--- a/torch/csrc/utils/tensor_dtypes.cpp
+++ b/torch/csrc/utils/tensor_dtypes.cpp
@@ -78,7 +78,7 @@ void initializeDtypes() {
         0) {
       throw python_error();
     }
-    if (legacy_name != "") {
+    if (!legacy_name.empty()) {
       Py_INCREF(dtype);
       if (PyModule_AddObject(torch_module.get(), legacy_name.c_str(), dtype) !=
           0) {

--- a/torch/csrc/utils/tensor_flatten.cpp
+++ b/torch/csrc/utils/tensor_flatten.cpp
@@ -104,7 +104,7 @@ std::vector<at::Tensor> unflatten_sparse_tensors(
     const at::Tensor& flat_indices,
     const at::Tensor& flat_values,
     at::TensorList tensors) {
-  if (tensors.size() == 0)
+  if (tensors.empty())
     return {};
 
   auto indices =

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -102,7 +102,7 @@ THManagedMapAllocatorInit::THManagedMapAllocatorInit(
     if (!manager_handle_.empty()) {
       socket = &get_manager_socket(manager_handle_);
     } else {
-      if (managers.size() == 0) {
+      if (managers.empty()) {
         start_manager();
       }
       const auto& manager = managers.begin();

--- a/torch/lib/libshm/manager.cpp
+++ b/torch/lib/libshm/manager.cpp
@@ -113,12 +113,12 @@ int main(int argc, char* argv[]) {
   for (;;) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int nevents;
-    if (client_sessions.size() == 0)
+    if (client_sessions.empty())
       timeout = SHUTDOWN_TIMEOUT;
     SYSCHECK_ERR_RETURN_NEG1(
         nevents = poll(pollfds.data(), pollfds.size(), timeout));
     timeout = -1;
-    if (nevents == 0 && client_sessions.size() == 0)
+    if (nevents == 0 && client_sessions.empty())
       break;
 
     for (auto& pfd : pollfds) {


### PR DESCRIPTION
Not only is this change usually shorter and more readable, it also can yield better performance. size() is not always a constant time operation (such as on LinkedLists), but empty() always is.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @EikanWang