### PR TITLE
feat(quantization): Add warnings when `ObservedGraphModule` does not run a forward pass

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1401,7 +1401,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 self.conv = torch.nn.Conv2d(1, 1, 1)
 
             def forward(self, x):
-                return {"output": self.conv(x["input"])}
+                return self.conv(x["input"])
 
         example_inputs = ({"input": torch.randn(1, 1, 1, 1)},)
         m = M().eval()

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -899,6 +899,14 @@ def convert(
     if backend_config is None:
         backend_config = get_native_backend_config()
 
+    assert _is_observed_module(model)
+    if not model.forward.was_called:
+        warnings.warn(
+            "The model's forward pass has not been called. This means that any observers "
+            "in the model would not have recorded any data. Please check if you passed the "
+            "correct model into `convert`."
+        )
+
     node_name_to_scope, prepare_custom_config, observed_node_names = _restore_state(model)
     node_name_to_qconfig: Dict[str, QConfigAny] = model._node_name_to_qconfig  # type: ignore[assignment]
 

--- a/torch/ao/quantization/fx/graph_module.py
+++ b/torch/ao/quantization/fx/graph_module.py
@@ -68,11 +68,12 @@ class ObservedGraphModule(GraphModule):
         return python_code
 
 def was_called(func, init):
-  def wrapper(*args, **kwargs):
-    wrapper.was_called = True
-    return func(*args, **kwargs)
-  wrapper.was_called = init
-  return wrapper
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        wrapper.was_called = True
+        return func(*args, **kwargs)
+    wrapper.was_called = init
+    return wrapper
 
 def _is_observed_module(module: Any) -> bool:
     return isinstance(module, ObservedGraphModule)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/88609

Questions:
- do we need to extend this to e.g. `convert_standalone_module`? 
   - this PR seems good as a first pass, but we may be able to catch more cases where users try to convert an observed module that is not a `GraphModule` before running any forward passes through it. 
   - Also not sure about edge cases where the top-level model `forward` pass is not run, but forward passes of observed submodules are... - seems not worth considering

cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel @ezyang @SherlockNoMad @EikanWang @wenzhe-nrv