### PR TITLE
Minor error in docs regarding execution time

### DIFF
--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -38,7 +38,7 @@ performance optimization.
 
 Like many other performance optimization sparse storage formats are not
 always advantageous. When trying sparse formats for your use case
-you might find your execution time to decrease rather than increase.
+you might find your execution time to increase rather than decrease.
 
 Please feel encouraged to open a GitHub issue if you analytically
 expected to see a stark increase in performance but measured a


### PR DESCRIPTION
The previous sentence seemed to imply that sparse may not always be helpful, ie, your execution time may increase when using sparse. But the docs mentioned otherwise.

A simple re-ordering of two words in the documentation to better align with the contextual sentiment.


cc @svekars @carljparker