### PR TITLE
[fix] legacybatching: getPhysicalDims

### DIFF
--- a/aten/src/ATen/LegacyVmapTransforms.cpp
+++ b/aten/src/ATen/LegacyVmapTransforms.cpp
@@ -61,7 +61,7 @@ VmapDimVector VmapPhysicalView::getPhysicalDims(OptionalIntArrayRef opt_logical_
   // NB: fmap doesn't have a SmallVector variant, so we don't use it here.
   VmapDimVector result;
   result.reserve(logical_ndim);
-  if (opt_logical_dims.has_value() && opt_logical_dims.value().size() > 0) {
+  if (opt_logical_dims.has_value() && !opt_logical_dims.value().empty()) {
     auto logical_dims = opt_logical_dims.value();
     for (auto dim : logical_dims) {
       result.push_back(maybe_wrap_dim(dim, logical_ndim) + numBatchDims());

--- a/aten/src/ATen/LegacyVmapTransforms.cpp
+++ b/aten/src/ATen/LegacyVmapTransforms.cpp
@@ -61,7 +61,7 @@ VmapDimVector VmapPhysicalView::getPhysicalDims(OptionalIntArrayRef opt_logical_
   // NB: fmap doesn't have a SmallVector variant, so we don't use it here.
   VmapDimVector result;
   result.reserve(logical_ndim);
-  if (opt_logical_dims.has_value()) {
+  if (opt_logical_dims.has_value() && opt_logical_dims.value().size() > 0) {
     auto logical_dims = opt_logical_dims.value();
     for (auto dim : logical_dims) {
       result.push_back(maybe_wrap_dim(dim, logical_ndim) + numBatchDims());

--- a/test/test_legacy_vmap.py
+++ b/test/test_legacy_vmap.py
@@ -1871,6 +1871,7 @@ class TestVmapOperators(Namespace.TestVmapBase):
 
         # Single vmap, various in_dims / out_dims
         test(lambda x: x.sum(()), [torch.randn([B0])])
+        test(lambda x: x.sum(()), [torch.randn([B0, 2])])
         test(lambda x: x.sum(0), [torch.randn([B0])])
         test(lambda x: x.sum(-1), [torch.randn([B0])])
         test(lambda x: x.sum(0), [torch.randn([B0, 3])])


### PR DESCRIPTION
Fixes #92985

Minimum Repro:
```python
import torch
from torch._vmap_internals import vmap

input = torch.randn(2, 2)

def fn(x):
    return x.sum(())

o = vmap(fn)(input)
```
