### PR TITLE
Set `_fields` for return types for namedtuple check

### DIFF
--- a/test/test_return_types.py
+++ b/test/test_return_types.py
@@ -1,0 +1,31 @@
+# Owner(s): ["module: autograd"]
+
+import inspect
+
+import torch
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import instantiate_parametrized_tests
+
+
+def is_namedtuple_class(cls):
+    bases = cls.__bases__
+    if len(bases) != 1 or bases[0] != tuple:
+        return False
+    fields = getattr(cls, '_fields', None)
+    if not isinstance(fields, tuple):
+        return False
+    return all(type(entry) is str for entry in fields)
+
+
+class TestReturnTypes(TestCase):
+    def test_hasattr_fields(self):
+        for name in torch.return_types.__all__:
+            attr = getattr(torch.return_types, name)
+            if inspect.isclass(attr) and issubclass(attr, tuple):
+                self.assertTrue(is_namedtuple_class(attr))
+
+
+instantiate_parametrized_tests(TestReturnTypes)
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
In PyTree utilities, we use `obj._fields` attribute to determine whether the object is a namedtuple:

https://github.com/pytorch/pytorch/blob/04082fc042d85ed934ccba4b74eb2fc1c2442aeb/torch/utils/_pytree.py#L89-L97

All members of `torch.return_types` are `PyStructSequence` types. As the CPython documented:

> Struct sequence objects are the C equivalent of `collections.namedtuple` objects.

However, the Python C API does not set the `_fields` attribute. This makes our namedtuple checker fail to test the `torch.return_types.*` as namedtuple. They need manually register as node type in PyTree utilities.

## BC-breaking notes

Everything in `torch.return_types` is a `PyStructSequence` type at the moment. Usually, an instance of that type would be considered a `namedtuple`, which is a common container type in the concept of pytrees. All `torch.return_types.*` types are implemented with the Python C API `PyStructSequence_InitType`, which is differ from the Python `collections.namedtuple`. Most of the PyTorch code detects the `namedtuple` by checking the `_fields` attribute. In this PR, we set the `_fields` attribute in the auto-generated type definition.

This changes the auto-generated C definition for the `return_types` types. That means C extensions built for previous versions of PyTorch need to be rebuilt to add the new class attribute `_fields`.

cc @ezyang @gchanan