### PR TITLE
Remove proxy tensor's check for data dependent output

### DIFF
--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -275,13 +275,6 @@ def proxy_call(proxy_mode, func, args, kwargs):
             )
             with maybe_disable_fake_tensor_mode():
                 return func(*const_args, **const_kwargs)
-        # For symbolic tracing, we return a SymInt/SymFloat and try to
-        # get further in the trace
-        if proxy_mode.tracing_mode != "symbolic":
-            raise RuntimeError(
-                f"It appears that you're trying to get value out of a tracing tensor with {func} - erroring out! "
-                "It's likely that this is caused by data-dependent control flow or similar."
-            )
     proxy_args, proxy_kwargs = pytree.tree_map_only(
         (SymInt, SymFloat, SymBool),
         fetch_sym_proxy(proxy_mode.tracer),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93265

We'll rely on the underlying fake tensor to raise an error in these cases.  We only raise the error if there is an input to the data dependent operation that is a real tensor (and thus we are at risk of accidentally burning in real values)

Signed-off-by: Edward Z. Yang <ezyang@meta.com>