### PR TITLE
Support non-symbolic + symbolic addition for constants tracked by DynamicShapeVariables

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -548,6 +548,10 @@ class BuiltinVariable(VariableTracker):
         return args[0].call_method(tx, "__len__", args[1:], kwargs)
 
     def call_add(self, tx, *args, **kwargs):
+        # Commute add when the right-hand side is symbolic
+        # (since e.g. int.__add__(int, SymInt) is not implemented).
+        if len(args) == 2 and args[1].python_type() in (torch.SymInt, torch.SymFloat):
+            return args[1].call_method(tx, "__radd__", [args[0]], kwargs)
         return args[0].call_method(tx, "__add__", args[1:], kwargs)
 
     def call_sub(self, tx, *args, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93276
* #93271

Commuting for `__add__` was previously done for the ConstantVariable + DynamicShapeVariable case, but this is incomplete. DynamicShapeVariables can also track static shapes, such as the shape of a module parameter.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire