### PR TITLE
pass `None` instead of `False` inside `Adam.__setstate__`

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -92,7 +92,7 @@ class Adam(Optimizer):
             group.setdefault('foreach', None)
             group.setdefault('capturable', False)
             group.setdefault('differentiable', False)
-            group.setdefault('fused', False)
+            group.setdefault('fused', None)
         state_values = list(self.state.values())
         step_is_tensor = (len(state_values) != 0) and torch.is_tensor(state_values[0]['step'])
         if not step_is_tensor:


### PR DESCRIPTION
with https://github.com/pytorch/pytorch/commit/a061f139dccb5f56c9d14e25ef54ff821b4dd3c8, `fused`'s type hint is `Optional[bool]` and its default value is `None`.

cc @janeyx99 @albanD 