### PR TITLE
fix(fx): make all `make_fx` invocations isolated (opaque to higher `make_fx` invocations) by default

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -234,7 +234,7 @@ class TestGenericProxyTensor(TestCase):
             gm = make_fx(f1)(x)
             self.assertFalse(is_any_sum(gm))
             self.assertTrue(is_any_sigmoid(gm))
-            return torch.digamma(x)
+            return torch.digamma(f1(x))
 
         traced = make_fx(f2)(torch.randn(3))
         self.assertFalse(is_any_sum(traced))

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -241,7 +241,7 @@ class TestGenericProxyTensor(TestCase):
         self.assertFalse(is_any_sigmoid(traced))
         self.assertTrue(is_any_digamma(traced))
 
-        # Verify that the `forward`` function of a graph module produced as a 
+        # Verify that the `forward`` function of a graph module produced as a
         # side effect of an interior `make_fx` is still traced
         def f3(x):
             gm = make_fx(f1)(x)

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -241,12 +241,13 @@ class TestGenericProxyTensor(TestCase):
         self.assertFalse(is_any_sigmoid(traced))
         self.assertTrue(is_any_digamma(traced))
 
-        # Verify that the forward function of a graph module produced as a 
-        # side effect of an inner `make_fx` is still traced
+        # Verify that the `forward`` function of a graph module produced as a 
+        # side effect of an interior `make_fx` is still traced
         def f3(x):
             gm = make_fx(f1)(x)
             self.assertFalse(is_any_sum(gm))
             self.assertTrue(is_any_sigmoid(gm))
+            # `gm.forward`` is still traced
             return torch.digamma(gm(x))
 
         traced = make_fx(f3)(torch.randn(3))

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -736,8 +736,8 @@ def disable_proxy_modes_tracing():
         for proxy_mode, old in zip(proxy_tensor_modes, olds):
             proxy_mode.enable_tracing = old
 
-# Disables all proxy modes except the current, most recently instantiated one. This makes `make_fx`
-# opaque to all higher invocations of `make_fx`
+# Disables all proxy modes except the current, most recently instantiated one. This makes the containing
+# code opaque to all higher invocations of `make_fx`
 @contextlib.contextmanager
 def enable_current_proxy_mode_exclusive():
     # TODO: This probably doesn't correctly also disable ProxySymDispatchMode

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -697,7 +697,8 @@ def make_fx(f, decomposition_table=None, tracing_mode="real", _allow_non_fake_in
 
         # We disable the autocast cache as the autocast cache causes type conversions on parameters to
         # check a cache, which introduces untracked tensors into the graph
-        # We also disable other proxy tracers except the outermost one. This means that 
+        # We also disable other proxy tracers except the current one. This means that a trace from the resultant
+        # function will not be contaminated by nested proxy traces.
         with decompose(decomposition_table), fake_tensor_mode, python_dispatcher_mode, \
              sym_mode, proxy_mode, disable_autocast_cache(), disable_proxy_modes_tracing_except_current():  # type: ignore[attr-defined]
             t = dispatch_trace(wrap_key(func, args, fx_tracer), tracer=fx_tracer, concrete_args=tuple(phs))

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -506,7 +506,8 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
         if func in [prim.device.default]:
             return func(*args, **kwargs)
 
-        out = proxy_call(self, func, args, kwargs)
+        with disable_proxy_modes_tracing():
+            out = proxy_call(self, func, args, kwargs)
         return out
 
 

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -696,13 +696,13 @@ def make_fx(f, decomposition_table=None, tracing_mode="real", _allow_non_fake_in
             func = f
 
         # We disable the autocast cache as the autocast cache causes type conversions on parameters to
-        # check a cache, which introduces untracked tensors into the graph   
-        #      
-        # We also disable tracing by any other tensor proxy-based tracers except the current. The  
+        # check a cache, which introduces untracked tensors into the graph
+        #
+        # We also disable tracing by any other tensor proxy-based tracers except the current. The
         # purpose of `make_fx` is to produce graphmodules as a side effect; its internal execution is
         # thus irrelevant to any external functional trace.
         with decompose(decomposition_table), fake_tensor_mode, python_dispatcher_mode, \
-             sym_mode, proxy_mode, disable_autocast_cache(), disable_proxy_modes_tracing(enable_current=True):  # type: ignore[attr-defined]
+             sym_mode, proxy_mode, disable_autocast_cache(), disable_proxy_modes_tracing(enable_current=True):
             t = dispatch_trace(wrap_key(func, args, fx_tracer), tracer=fx_tracer, concrete_args=tuple(phs))
 
         # TODO: kind of a bad way to do it, should maybe figure out a better way


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/88996#issuecomment-1409174554

Example code:
```python
import torch
from torch.fx.experimental.proxy_tensor import make_fx, wrapper_and_args_for_make_fx

@torch.fx.wrap
def func(a, b):
    return b.expand([1, a.shape[0], b.shape[-1]])

a = torch.randn(3, 4)
b = torch.randn(4)

class TestMode(torch.overrides.TorchFunctionMode):
    def __torch_function__(self, func, types, args=(), kwargs={}):
        if torch.overrides.resolve_name(func) in ["torch.Tensor.expand"]:
            print(f"TestMode: {func} {args} {kwargs}")
            wrapped, all_args = wrapper_and_args_for_make_fx(func, args, kwargs)
            gm = make_fx(wrapped, tracing_mode="real")(all_args)

        return func(*args, **kwargs)

with TestMode():
    gm = make_fx(func, tracing_mode="symbolic")(a, b)

gm.graph.print_tabular()
```
Before:
```
opcode         name        target               args                              kwargs
-------------  ----------  -------------------  --------------------------------  --------
placeholder    a_1         a_1                  ()                                {}
placeholder    b_1         b_1                  ()                                {}
call_function  detach      aten.detach.default  (b_1,)                            {}
call_function  detach_1    aten.detach.default  (detach,)                         {}
call_function  sym_size    aten.sym_size        (a_1, 0)                          {}
call_function  sym_size_1  aten.sym_size        (b_1, 0)                          {}
call_function  expand      aten.expand.default  (b_1, [1, sym_size, sym_size_1])  {}
call_function  detach_2    aten.detach.default  (expand,)                         {}
call_function  expand_1    aten.expand.default  (b_1, [1, sym_size, sym_size_1])  {}
output         output      output               (expand_1,)                       {}
```

After:
```
opcode         name        target               args                              kwargs
-------------  ----------  -------------------  --------------------------------  --------
placeholder    a_1         a_1                  ()                                {}
placeholder    b_1         b_1                  ()                                {}
call_function  sym_size    aten.sym_size        (a_1, 0)                          {}
call_function  sym_size_1  aten.sym_size        (b_1, 0)                          {}
call_function  expand      aten.expand.default  (b_1, [1, sym_size, sym_size_1])  {}
output         output      output               (expand_1,)                       {}
```