### PR TITLE
[fx.GraphModule] Populate memo in deepcopy BEFORE copying children.

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -3606,6 +3606,7 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
         m = symbolic_trace(SimpleTest())
         m.meta['hello'] = m  # circular reference
         copy_m = copy.deepcopy(m)  # finishes
+        self.assertEqual(id(copy_m), id(copy_m.meta['hello']))
 
 
 def run_getitem_target():

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -704,9 +704,11 @@ class {module_name}(torch.nn.Module):
     # we need to define deepcopy otherwise it will call __reduce__
     # and cause symbolic tracing to occur every time we try to copy the object
     def __deepcopy__(self, memo):
+        res = type(self).__new__(type(self))
+        memo[id(self)] = res
         fake_mod = torch.nn.Module()
         fake_mod.__dict__ = copy.deepcopy(self.__dict__, memo)
-        res = GraphModule(fake_mod, fake_mod.__dict__['_graph'])
+        GraphModule.__init__(res, fake_mod, fake_mod.__dict__['_graph'])
         res.meta = copy.deepcopy(getattr(self, 'meta', {}), memo)
         return res
 


### PR DESCRIPTION
Summary:
Apparently if not then at somepoint, we might lose fields if the submodules have circular reference

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER
