### PR TITLE
[FSDP][optim_state_dict] Fix `_is_named_optimizer` when the state is empty

### DIFF
--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -1503,6 +1503,26 @@ class TestFSDPOptimState(FSDPTest):
             state_dicts[0], state_dicts[1], check_same_param_keys=True
         )
 
+    @skip_if_lt_x_gpu(2)
+    def test_with_empty_optimizer_state(self):
+        class TestDummyModel(torch.nn.Module):
+            def __init__(self):
+                super(TestDummyModel, self).__init__()
+                torch.manual_seed(0)
+                self.net1 = nn.Sequential(nn.Linear(8, 16), nn.ReLU())
+                self.net2 = nn.Sequential(nn.Linear(16, 32), nn.ReLU())
+                self.net3 = nn.Linear(32, 64)
+                self.net4 = nn.Sequential(nn.ReLU(), nn.Linear(64, 8))
+
+            def forward(self, x):
+                return self.net4(self.net3(self.net2(self.net1(x))))
+
+        model = FSDP(TestDummyModel().cuda())
+        optim = torch.optim.Adam(model.parameters(), lr=1e-2)
+        state_dict = optim.state_dict()
+        gathered_state_dict = FSDP._optim_state_dict(model, optim)
+        self.assertEqual (gathered_state_dict["state"], state_dict["state"])
+
 
 instantiate_parametrized_tests(TestFSDPOptimState)
 

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -1521,7 +1521,7 @@ class TestFSDPOptimState(FSDPTest):
         optim = torch.optim.Adam(model.parameters(), lr=1e-2)
         state_dict = optim.state_dict()
         gathered_state_dict = FSDP._optim_state_dict(model, optim)
-        self.assertEqual (gathered_state_dict["state"], state_dict["state"])
+        self.assertEqual(gathered_state_dict["state"], state_dict["state"])
 
 
 instantiate_parametrized_tests(TestFSDPOptimState)

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1299,7 +1299,7 @@ def _is_named_optimizer(optim_state_dict: Dict[str, Any]) -> bool:
         # NamedOptimizer has eagerly initialization.
         return False
     try:
-        key = next(iter(state))
+        key = next(iter(state.keys()))
     except Exception as e:
         raise Exception(optim_state_dict) from e
     return isinstance(key, str)

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1299,7 +1299,7 @@ def _is_named_optimizer(optim_state_dict: Dict[str, Any]) -> bool:
         # NamedOptimizer has eagerly initialization.
         return False
     try:
-        key = next(iter(optim_state_dict["state"].keys()))
+        key = next(state.keys())
     except Exception as e:
         raise Exception(optim_state_dict) from e
     return isinstance(key, str)

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1299,7 +1299,7 @@ def _is_named_optimizer(optim_state_dict: Dict[str, Any]) -> bool:
         # NamedOptimizer has eagerly initialization.
         return False
     try:
-        key = next(state.keys())
+        key = next(iter(state))
     except Exception as e:
         raise Exception(optim_state_dict) from e
     return isinstance(key, str)

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1293,6 +1293,11 @@ def _unflatten_param_groups(
 
 
 def _is_named_optimizer(optim_state_dict: Dict[str, Any]) -> bool:
+    state = optim_state_dict("state", None)
+    if not state:
+        # If we cannot find a state, assume it is not NamedOptimizer as
+        # NamedOptimizer has eagerly initialization.
+        return False
     try:
         key = next(iter(optim_state_dict["state"].keys()))
     except Exception as e:

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1293,7 +1293,7 @@ def _unflatten_param_groups(
 
 
 def _is_named_optimizer(optim_state_dict: Dict[str, Any]) -> bool:
-    state = optim_state_dict("state", None)
+    state = optim_state_dict.get("state", None)
     if not state:
         # If we cannot find a state, assume it is not NamedOptimizer as
         # NamedOptimizer has eagerly initialization.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93303

Optimizer state is not eager initializaion -- only NamedOptimizer and KeyedOptimizer are. This PR makes it `_is_named_optimizer` work with regular optimizers.

Differential Revision: [D42858589](https://our.internmc.facebook.com/intern/diff/D42858589/)