### PR TITLE
Fix MSVC compiler error in basic_ops.h

### DIFF
--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -40,7 +40,9 @@ struct TORCH_API NotImplemented : public Error {
 // @once_differentiable
 struct TORCH_API DelayedError : public Node {
   DelayedError(std::string msg, int num_inputs) : msg(std::move(msg)) {
-    for ([[maybe_unused]] const auto _ : c10::irange(num_inputs)) {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+    for (const auto i : c10::irange(num_inputs)) {
+      (void)i; // Suppress unused variable warning
       add_input_metadata(Node::undefined_input());
     }
   }


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/93069 introduces a compiler error in some internal Windows builds using MSVC:

```
stderr: d:\full-fbsource\xplat\caffe2\torch\csrc\autograd\functions\basic_ops.h(43): fatal error C1001: An internal error has occurred in the compiler.
```
This may be related to older versions of MSVC not recognizing the `[[maybe-unused]]` attribute: https://developercommunity.visualstudio.com/t/compiler-bug-on-parsing-maybe-unused-in-range-base/209488. This PR reverts the changes in `basic_ops.h` that resolves those errors.

Verified this fixes the internal jobs, and landed as [D42854205](https://www.internalfb.com/diff/D42854205).