### PR TITLE
[CI][ez] Rename some jobs

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -133,11 +133,11 @@ jobs:
       docker-image: ${{ needs.linux-bionic-cuda11_6-py3_9-gcc7-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_6-py3_9-gcc7-build.outputs.test-matrix }}
 
-  linux-bionic-cuda11_6-py3_7-gcc7-debug-build:
-    name: linux-bionic-cuda11.6-py3.7-gcc7-debug
+  linux-bionic-cuda11_6-py3_10-gcc7-debug-build:
+    name: linux-bionic-cuda11.6-py3.10-gcc7-debug
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-bionic-cuda11.6-py3.7-gcc7-debug
+      build-environment: linux-bionic-cuda11.6-py3.10-gcc7-debug
       docker-image-name: pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7
       build-with-debug: true
       test-matrix: |
@@ -148,14 +148,14 @@ jobs:
           { config: "default", shard: 4, num_shards: 4, runner: "linux.4xlarge.nvidia.gpu" },
         ]}
 
-  linux-bionic-cuda11_6-py3_7-gcc7-debug-test:
-    name: linux-bionic-cuda11.6-py3.7-gcc7-debug
+  linux-bionic-cuda11_6-py3_10-gcc7-debug-test:
+    name: linux-bionic-cuda11.6-py3.10-gcc7-debug
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-bionic-cuda11_6-py3_7-gcc7-debug-build
+    needs: linux-bionic-cuda11_6-py3_10-gcc7-debug-build
     with:
-      build-environment: linux-bionic-cuda11.6-py3.7-gcc7-debug
-      docker-image: ${{ needs.linux-bionic-cuda11_6-py3_7-gcc7-debug-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-bionic-cuda11_6-py3_7-gcc7-debug-build.outputs.test-matrix }}
+      build-environment: linux-bionic-cuda11.6-py3.10-gcc7-debug
+      docker-image: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-debug-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-bionic-cuda11_6-py3_10-gcc7-debug-build.outputs.test-matrix }}
 
   linux-bionic-cuda11_8-py3_8-gcc7-debug-build:
     name: linux-bionic-cuda11.8-py3.8-gcc7-debug
@@ -181,11 +181,11 @@ jobs:
       docker-image: ${{ needs.linux-bionic-cuda11_8-py3_8-gcc7-debug-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-bionic-cuda11_8-py3_8-gcc7-debug-build.outputs.test-matrix }}
 
-  libtorch-linux-bionic-cuda11_8-py3_8-gcc7-build:
-    name: libtorch-linux-bionic-cuda11.8-py3.8-gcc7
+  libtorch-linux-bionic-cuda11_8-gcc7-build:
+    name: libtorch-linux-bionic-cuda11.8-gcc7
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: libtorch-linux-bionic-cuda11.8-py3.8-gcc7
+      build-environment: libtorch-linux-bionic-cuda11.8-gcc7
       docker-image-name: pytorch-linux-bionic-cuda11.8-cudnn8-py3-gcc7
       build-generates-artifacts: false
 
@@ -212,11 +212,11 @@ jobs:
       cuda-version: "11.8"
       test-matrix: ${{ needs.win-vs2019-cuda11_8-py3-build.outputs.test-matrix }}
 
-  linux-bionic-cuda11_7-py3_7-gcc7-debug-build:
-    name: linux-bionic-cuda11.7-py3.7-gcc7-debug
+  linux-bionic-cuda11_7-py3_10-gcc7-debug-build:
+    name: linux-bionic-cuda11.7-py3.10-gcc7-debug
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-bionic-cuda11.7-py3.7-gcc7-debug
+      build-environment: linux-bionic-cuda11.7-py3.10-gcc7-debug
       docker-image-name: pytorch-linux-bionic-cuda11.7-cudnn8-py3-gcc7
       build-with-debug: true
       test-matrix: |
@@ -227,20 +227,20 @@ jobs:
           { config: "default", shard: 4, num_shards: 4, runner: "linux.4xlarge.nvidia.gpu" },
         ]}
 
-  linux-bionic-cuda11_7-py3_7-gcc7-debug-test:
-    name: linux-bionic-cuda11.7-py3.7-gcc7-debug
+  linux-bionic-cuda11_7-py3_10-gcc7-debug-test:
+    name: linux-bionic-cuda11.7-py3.10-gcc7-debug
     uses: ./.github/workflows/_linux-test.yml
-    needs: linux-bionic-cuda11_7-py3_7-gcc7-debug-build
+    needs: linux-bionic-cuda11_7-py3_10-gcc7-debug-build
     with:
-      build-environment: linux-bionic-cuda11.7-py3.7-gcc7-debug
-      docker-image: ${{ needs.linux-bionic-cuda11_7-py3_7-gcc7-debug-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-bionic-cuda11_7-py3_7-gcc7-debug-build.outputs.test-matrix }}
+      build-environment: linux-bionic-cuda11.7-py3.10-gcc7-debug
+      docker-image: ${{ needs.linux-bionic-cuda11_7-py3_10-gcc7-debug-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-bionic-cuda11_7-py3_10-gcc7-debug-build.outputs.test-matrix }}
 
-  libtorch-linux-bionic-cuda11_7-py3_7-gcc7-build:
-    name: libtorch-linux-bionic-cuda11.7-py3.7-gcc7
+  libtorch-linux-bionic-cuda11_7-gcc7-build:
+    name: libtorch-linux-bionic-cuda11.7-gcc7
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: libtorch-linux-bionic-cuda11.7-py3.7-gcc7
+      build-environment: libtorch-linux-bionic-cuda11.7-gcc7
       docker-image-name: pytorch-linux-bionic-cuda11.7-cudnn8-py3-gcc7
       build-generates-artifacts: false
 


### PR DESCRIPTION
periodic debug builds are actually running against Python-3.10

Remove Python version specifier from libtorch builds, as it kind of
irrelevant (libtorch is C++ only build, so Python version should not
matter)
