### PR TITLE
inductor: fix convert_shape_to_symint

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1719,7 +1719,7 @@ class CommonTemplate:
                 (v,),
             )
 
-    def test_conv_sym_shape(self):
+    def test_upsample_conv(self):
         class M(torch.nn.Module):
             def __init__(
                 self,
@@ -5270,7 +5270,7 @@ class CommonTemplate:
 test_skips = {
     "test_alexnet_prefix_dynamic_shapes": ("cuda",),
     "test_baddbmm_dynamic_shapes": ("cpu", "cuda"),
-    "test_conv_sym_shape_dynamic_shapes": ("cpu"),  # TODO： fix me
+    "test_upsample_conv_dynamic_shapes": ("cpu", "cuda"),  # upsample does not support dynamic shapes yet (#92667)
     "test_cpp_wrapper_dynamic_shapes": ("cpu",),
     "test_cudnn_rnn_dynamic_shapes": ("cuda",),
     "test_grid_sampler_2d_dynamic_shapes": ("cpu", "cuda"),

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1719,6 +1719,39 @@ class CommonTemplate:
                 (v,),
             )
 
+    def test_conv_sym_shape(self):
+        class M(torch.nn.Module):
+            def __init__(
+                self,
+                **kwargs,
+            ):
+                super(M, self).__init__()
+                self.upsample = torch.nn.UpsamplingNearest2d(scale_factor=2)
+                self.conv = torch.nn.Conv2d(
+                    768,
+                    256,
+                    kernel_size=1,
+                    padding=0,
+                    stride=1,
+                    dilation=1,
+                    **kwargs,
+                )
+
+            def forward(self, x, y):
+                x = self.upsample(x)
+                z = torch.cat([x, y], dim=1)
+                z = self.conv(z)
+                return z
+
+        v1 = torch.randn([8, 256, 12, 26])
+        v2 = torch.randn([8, 512, 24, 52])
+
+        with torch.no_grad():
+            self.common(
+                M().eval(),
+                (v1, v2),
+            )
+
     def test_conv2d_packed(self):
         if self.device == "cuda":
             raise unittest.SkipTest("only support cpu conv2d packed test")
@@ -5237,6 +5270,7 @@ class CommonTemplate:
 test_skips = {
     "test_alexnet_prefix_dynamic_shapes": ("cuda",),
     "test_baddbmm_dynamic_shapes": ("cpu", "cuda"),
+    "test_conv_sym_shape_dynamic_shapes": ("cpu"),  # TODO： fix me
     "test_cpp_wrapper_dynamic_shapes": ("cpu",),
     "test_cudnn_rnn_dynamic_shapes": ("cuda",),
     "test_grid_sampler_2d_dynamic_shapes": ("cpu", "cuda"),

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5270,7 +5270,6 @@ class CommonTemplate:
 test_skips = {
     "test_alexnet_prefix_dynamic_shapes": ("cuda",),
     "test_baddbmm_dynamic_shapes": ("cpu", "cuda"),
-    "test_upsample_conv_dynamic_shapes": ("cpu", "cuda"),  # upsample does not support dynamic shapes yet (#92667)
     "test_cpp_wrapper_dynamic_shapes": ("cpu",),
     "test_cudnn_rnn_dynamic_shapes": ("cuda",),
     "test_grid_sampler_2d_dynamic_shapes": ("cpu", "cuda"),
@@ -5288,6 +5287,10 @@ test_skips = {
     "test_unroll_small_reduction_dynamic_shapes": ("cpu", "cuda"),
     "test_upsample_bilinear2d_a_dynamic_shapes": ("cpu", "cuda"),
     "test_upsample_bilinear2d_b_dynamic_shapes": ("cpu", "cuda"),
+    "test_upsample_conv_dynamic_shapes": (
+        "cpu",
+        "cuda",
+    ),  # upsample does not support dynamic shapes yet (#92667)
     "test_upsample_nearest1d_dynamic_shapes": ("cpu", "cuda"),
     "test_upsample_nearest2d_backward_dynamic_shapes": ("cpu", "cuda"),
     "test_upsample_nearest2d_dynamic_shapes": ("cpu", "cuda"),

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1719,7 +1719,7 @@ class CommonTemplate:
                 (v,),
             )
 
-    def test_upsample_conv(self):
+    def test_upsample_cat_conv(self):
         class M(torch.nn.Module):
             def __init__(
                 self,
@@ -1728,8 +1728,8 @@ class CommonTemplate:
                 super(M, self).__init__()
                 self.upsample = torch.nn.UpsamplingNearest2d(scale_factor=2)
                 self.conv = torch.nn.Conv2d(
-                    768,
-                    256,
+                    8,
+                    5,
                     kernel_size=1,
                     padding=0,
                     stride=1,
@@ -1743,8 +1743,8 @@ class CommonTemplate:
                 z = self.conv(z)
                 return z
 
-        v1 = torch.randn([8, 256, 12, 26])
-        v2 = torch.randn([8, 512, 24, 52])
+        v1 = torch.randn([8, 2, 12, 26])
+        v2 = torch.randn([8, 6, 24, 52])
 
         with torch.no_grad():
             self.common(
@@ -5287,7 +5287,7 @@ test_skips = {
     "test_unroll_small_reduction_dynamic_shapes": ("cpu", "cuda"),
     "test_upsample_bilinear2d_a_dynamic_shapes": ("cpu", "cuda"),
     "test_upsample_bilinear2d_b_dynamic_shapes": ("cpu", "cuda"),
-    "test_upsample_conv_dynamic_shapes": (
+    "test_upsample_cat_conv_dynamic_shapes": (
         "cpu",
         "cuda",
     ),  # upsample does not support dynamic shapes yet (#92667)

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1720,6 +1720,9 @@ class CommonTemplate:
             )
 
     def test_upsample_cat_conv(self):
+        if self.device == "cuda":
+            raise unittest.SkipTest("only support cpu upsample_cat_conv test")
+
         class M(torch.nn.Module):
             def __init__(
                 self,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -99,11 +99,14 @@ def convert_shape_to_symint(
     """
     from .virtualized import V
 
-    if all(isinstance(i, int) for i in lst):
-        return lst
-    if all(isinstance(i, sympy.Integer) for i in lst):
-        return [int(i) for i in lst]
-    return [V.graph.sizevars.shape_env.create_symintnode(i) for i in lst]
+    return [
+        i
+        if isinstance(i, int)
+        else int(i)
+        if isinstance(i, sympy.Integer)
+        else V.graph.sizevars.shape_env.create_symintnode(i)
+        for i in lst
+    ]
 
 
 def gen_gm_and_inputs(target, args, kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93349

Fixes https://github.com/pytorch/pytorch/issues/93833.

When `lst` is composed of a mix of static shapes and `sympy.Expr`, convert static shapes to ints and `sympy.Expr` to `symints`.
The old logic required that all of the elements of `lst` be static and it can then convert them to ints.


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire