### PR TITLE
[BE] Don't use `six` in torch.utils.tensorboard

### DIFF
--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -6,8 +6,6 @@ from typing import Optional
 import numpy as np
 from google.protobuf import struct_pb2
 
-# pylint: disable=unused-import
-from six.moves import range
 from tensorboard.compat.proto.summary_pb2 import HistogramProto
 from tensorboard.compat.proto.summary_pb2 import Summary
 from tensorboard.compat.proto.summary_pb2 import SummaryMetadata
@@ -94,7 +92,6 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
         SessionEndInfo
     """
     import torch
-    from six import string_types
     from tensorboard.plugins.hparams.api_pb2 import (
         Experiment,
         HParamInfo,
@@ -179,7 +176,7 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
             )
             continue
 
-        if isinstance(v, string_types):
+        if isinstance(v, str):
             ssi.hparams[k].string_value = v
 
             if k in hparam_domain_discrete:


### PR DESCRIPTION
As PyTorch is Python-3.8+ project only

