### PR TITLE
Basic Validation for FSDP `state_dict` transformations of modules with persistent buffers

### DIFF
--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -484,7 +484,7 @@ class TestFSDPStateDict(FSDPTest):
     @parametrize("use_orig_params", [True, False])
     def test_basic_save_and_load_state_dict(
         self,
-        state_dict_type: StateDictType,
+        state_dict_type: str,
         cpu_offload: bool,
         fp16: bool,
         state_dict_rank0_and_offload: bool,
@@ -570,7 +570,7 @@ class TestFSDPStateDict(FSDPTest):
     @parametrize("use_orig_params", [True, False])
     def test_buffers_save_and_load_state_dict(
         self,
-        state_dict_type: StateDictType,
+        state_dict_type: str,
         cpu_offload: bool,
         mixed_precision: bool,
         state_dict_rank0_and_offload: bool,

--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -116,16 +116,20 @@ class TestFSDPStateDict(FSDPTest):
         # TODO (rohan-varma): remove model
         return _broadcast_state_dict(self.rank, state_dict)
 
-    def _compare_models(self, model, model_new, assert_fn, check_fp16=False):
+    def _state_compare(self, model, model_new, assert_fn, state_generator='parameters'):
+        state_base = list(getattr(model, state_generator)())
+        state_new = list(getattr(model_new, state_generator)())
+        # Regardless of `assert_fn`, the number of parameters should be the same
+        self.assertEqual(len(state_base), len(state_new))
+        assert_fn(state_base, state_new)
+        
+    def _compare_models(self, model, model_new, assert_fn, check_fp16=False, check_buffers=False):
         assert assert_fn in (self.assertEqual, self.assertNotEqual)
         with FSDP.summon_full_params(model):
             with FSDP.summon_full_params(model_new):
-                params = list(model.parameters())
-                params_new = list(model_new.parameters())
-                # Regardless of `assert_fn`, the number of parameters should be
-                # the same
-                self.assertEqual(len(params), len(params_new))
-                assert_fn(params, params_new)
+                self._state_compare(model, model_new, assert_fn)
+                if check_buffers:
+                    self._state_compare(model, model_new, assert_fn, state_generator='buffers')
                 if check_fp16:
                     for tensor in model_new.parameters():
                         self.assertEqual(tensor.dtype, torch.float16)
@@ -155,6 +159,32 @@ class TestFSDPStateDict(FSDPTest):
         if checkpoint_wrap:
             lin = checkpoint_wrapper(lin)
         model = FSDP(lin, *fsdp_args, **fsdp_kwargs)
+        return model
+    
+    def _get_multibuffer_nested_model(self, *fsdp_args, wrap=True, checkpoint_wrap=False, **fsdp_kwargs):
+        full_p = torch.float32
+        lin_mp = fsdp_kwargs.pop('mixed_precision', None)
+        bn_mp = MixedPrecision(param_dtype=full_p, reduce_dtype=full_p, buffer_dtype=full_p) if lin_mp else None
+        if wrap:
+            lin1 = nn.Linear(10, 10, bias=False).cuda()
+            bn1 = nn.BatchNorm1d(10).cuda()
+            lin2 = nn.Linear(10, 10, bias=False).cuda()
+            if checkpoint_wrap:
+                lin1 = checkpoint_wrapper(lin1)
+                bn1 = checkpoint_wrapper(bn1)
+                lin2 = checkpoint_wrapper(lin2)
+            seq = nn.Sequential(FSDP(lin1, mixed_precision=lin_mp, *fsdp_args, **fsdp_kwargs), 
+                                FSDP(bn1, mixed_precision=bn_mp, *fsdp_args, **fsdp_kwargs), 
+                                lin2)
+            if checkpoint_wrap:
+                seq = checkpoint_wrapper(seq)
+            model = FSDP(seq, *fsdp_args, **fsdp_kwargs)
+        else:
+            model = nn.Sequential(
+                nn.Linear(10, 10, bias=False).cuda(),
+                nn.BatchNorm1d(10).cuda(),
+                nn.Linear(10, 10, bias=False).cuda(),
+            )
         return model
 
     def _get_non_fsdp_root_module(self, *fsdp_args, wrap=True, **fsdp_kwargs):
@@ -512,6 +542,63 @@ class TestFSDPStateDict(FSDPTest):
                 model_new.load_state_dict(fsdp_state_dict, strict=True)
 
             self._compare_models(model, model_new, self.assertEqual, check_fp16=fp16)
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)
+    @parametrize(
+        "cpu_offload",
+        [CPUOffload(offload_params=True), CPUOffload(offload_params=False)],
+    )
+    @parametrize("mixed_precision", [True, False])
+    @parametrize("state_dict_rank0_and_offload", [True, False])
+    def test_buffers_save_and_load_state_dict(
+        self,
+        state_dict_type: StateDictType,
+        cpu_offload: bool,
+        mixed_precision: bool,
+        state_dict_rank0_and_offload: bool,
+    ):
+        """
+        Tests that we can save a state_dict and load it for modules with persistent buffers, including
+        in the context of non-default mixed precision, different ``state_dict_type`` s and CPU offloading.
+        """
+        if (state_dict_rank0_and_offload and state_dict_type != "state_dict"):
+            return  # not supported
+        mixed_precision = (
+            MixedPrecision(
+                param_dtype=torch.float16,
+                reduce_dtype=torch.float16,
+                buffer_dtype=torch.float16,
+            )
+            if mixed_precision
+            else None
+        )
+        model_call = partial(self._get_multibuffer_nested_model,
+                             cpu_offload=cpu_offload,
+                             use_orig_params=False,
+                             mixed_precision=mixed_precision)
+        model = model_call()
+        ctx = self._get_state_dict_mgr(model, state_dict_type, state_dict_rank0_and_offload)
+        with ctx:
+            fsdp_state_dict = _get_state_dict(model, cpu_offload.offload_params, False)
+
+        self._validate_state_dict_contents(model, fsdp_state_dict, state_dict_rank0_and_offload)
+
+        model_new = model_call()
+        if not cpu_offload.offload_params:
+            model_new = model_new.cuda()
+
+        # zero the model to ensure parameters are different.
+        _zero_model(model_new, zero_buffers=True)
+        self._compare_models(model, model_new, self.assertNotEqual)
+
+        # Verify parameters are the same in the new model.
+        if state_dict_rank0_and_offload:
+            fsdp_state_dict = self._broadcast_state_dict(model, fsdp_state_dict)
+        with FSDP.state_dict_type(model_new, STATE_DICT_MAPPING[state_dict_type]):
+            model_new.load_state_dict(fsdp_state_dict, strict=True)
+
+        self._compare_models(model, model_new, self.assertEqual, check_buffers=True)
 
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -248,7 +248,7 @@ def _common_unshard_post_state_dict_hook(
             _cast_buffers_to_dtype_and_device(
                 buffers, buffer_dtypes, fsdp_state.compute_device
             )
-            for buffers, clean_fqn in zip(buffers, buffer_clean_fqns):
+            for buffer, clean_fqn in zip(buffers, buffer_clean_fqns):
                 fqn = f"{prefix}{clean_fqn}"
                 state_dict[fqn] = buffer.clone()
     return state_dict


### PR DESCRIPTION
Fixes #93391

Thank you to the PyTorch Distributed team for your invaluable contributions to the PyTorch ecosystem, your work is immensely impressive and inspiring!

As mentioned in  #93391, in preparing the downstream package I maintain ([finetuning-scheduler](https://github.com/speediedan/finetuning-scheduler)) to support PyTorch 2.0's version of FSDP, I noticed modules that include multiple persistent buffers were not having their state properly transformed during saving of `state_dict`s.

The issue was that the post-state_dict hook codepath shared by the `FULL_STATE_DICT` and `SHARDED_STATE_DICT` `_state_dict_type`s ([`_common_unshard_post_state_dict_hook`](https://github.com/pytorch/pytorch/blob/332d55d3df5ef22e47d3df73fa785f7ca4802169/torch/distributed/fsdp/_state_dict_utils.py#L158)) was inadvertently referencing a local variable (`buffer`) that was used in a [prior transformation](https://github.com/pytorch/pytorch/blob/332d55d3df5ef22e47d3df73fa785f7ca4802169/torch/distributed/fsdp/_state_dict_utils.py#L231), instead of the `buffers` variable that should have been referenced in the iteration context:

https://github.com/pytorch/pytorch/blob/332d55d3df5ef22e47d3df73fa785f7ca4802169/torch/distributed/fsdp/_state_dict_utils.py#L251-L253

In this case, modules with a single persistent buffer or without mixed precision enabled would be unaffected. With multiple buffers and mixed precision enabled however, the issue may appear stochastically in proportion to the ratio of persistent buffers that have compatible dimensions (since the value of the last buffer visited in the ``buffer_names`` ``Set`` is copied to all buffers and the ``Set`` iteration order will of course vary)

```bash
File ".../pytorch/torch/nn/modules/module.py", line 2028, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for FullyShardedDataParallel:
    size mismatch for _fsdp_wrapped_module.1._fsdp_wrapped_module.running_mean: copying a param with shape torch.Size([]) from checkpoint, the shape in current model is torch.Size([10]).
```
To both address this issue and enhance coverage to avoid similar issues, this PR fixes the aforementioned typo and adds an additional set of basic tests that validate `state_dict` saving and loading for modules with persistent buffers in various contexts. 

I found that adding another model along with additional buffer-specific logic to adapt [`test_basic_save_and_load_state_dict`](https://github.com/pytorch/pytorch/blob/76b683b0087cf90bb201e9acabec05a85e683ab2/test/distributed/fsdp/test_fsdp_state_dict.py#L439) for the purposes of this coverage seemed to increase complexity of that test to an undesirable degree. 

Instead of adding additional complexity to that existing test, I've added a new test ``test_buffers_save_and_load_state_dict`` that does basic validation of ``state_dict`` saving and loading with mixed precision, ``state_dict_type`` and CPU offloading parameterization. Certainly let me know if you prefer I extend the logic of/add the persistent buffers model into the existing basic ``state_dict`` test, I'm happy to do so, just thought it was cleaner this way. Also, I thought doubling the number of tests with a ``use_orig_params`` parameterization or by testing additional different non-default buffer mixed precision data types was computationally imprudent but let me know if you'd like me to add those tests as well. 

The only other notable test change is that I've refactored ``TestFSDPStateDict._compare_models`` to accommodate both ``buffers`` and ``parameters`` comparisons without code duplication.

Thanks again to the PyTorch Distributed team for your exceptional contributions. I've got some more to do adapting my package for 2.0's FSDP but it's been a delight so far thanks to your superlative work!


