### PR TITLE
[dynamo] getattr for EnumVariables

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: dynamo"]
+from enum import Enum
 import operator
 from typing import Dict, List
 from unittest.mock import patch
@@ -100,6 +101,28 @@ class ExportTests(torch._dynamo.test_case.TestCase):
                 self.assertTrue("x.size()[0] <= 10" in guard.code_list[0])
 
         self.assertTrue(hit)
+    
+    def test_export_control_flow_with_getattr(self):
+        class Animal(Enum):
+            COW = "moo"
+
+        class MyModule(torch.nn.Module):
+            def __init__(self, a):
+                super().__init__()
+                self.a = a
+
+            def forward(self, x):
+                if self.a == Animal.COW.value:
+                    return x * x
+                else:
+                    raise ValueError("bad")
+
+        module = MyModule("moo")
+        input = (torch.ones(4, 3),)
+        resA = module(*input)
+        graph, _ = torch._dynamo.export(module, *input)
+        resB = graph(*input)
+        self.assertTrue(torch._dynamo.utils.same(resA, resB))
 
     def test_export_graph_bypass(self):
         inp = [

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1,6 +1,6 @@
 # Owner(s): ["module: dynamo"]
-from enum import Enum
 import operator
+from enum import Enum
 from typing import Dict, List
 from unittest.mock import patch
 
@@ -101,7 +101,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
                 self.assertTrue("x.size()[0] <= 10" in guard.code_list[0])
 
         self.assertTrue(hit)
-    
+
     def test_export_control_flow_with_getattr(self):
         class Animal(Enum):
             COW = "moo"

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -160,6 +160,9 @@ class EnumVariable(VariableTracker):
 
     def as_python_constant(self):
         return self.value
-    
+
     def const_getattr(self, tx, name):
-        return getattr(self.value, name)
+        member = getattr(self.value, name)
+        if callable(member):
+            raise NotImplementedError()
+        return member

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -160,3 +160,6 @@ class EnumVariable(VariableTracker):
 
     def as_python_constant(self):
         return self.value
+    
+    def const_getattr(self, tx, name):
+        return getattr(self.value, name)


### PR DESCRIPTION
I'm not sure if this is the correct fix, but it allowed me to enable the test case I added which I encountered in an internal model.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire