### PR TITLE
Update version of Python to 3.8 in the prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ They require JetPack 4.2 and above, and [@dusty-nv](https://github.com/dusty-nv)
 
 #### Prerequisites
 If you are installing from source, you will need:
-- Python 3.7 or later (for Linux, Python 3.7.6+ or 3.8.1+ is needed)
+- Python 3.8 or later (for Linux, Python 3.8.1+ is needed)
 - A C++17 compatible compiler, such as clang
 
 We highly recommend installing an [Anaconda](https://www.anaconda.com/distribution/#download-section) environment. You will get a high-quality BLAS library (MKL) and you get controlled dependency versions regardless of your Linux distro.


### PR DESCRIPTION
With support of Python 3.7 being deprecated, updating the prerequisites to list Python 3.8 or later.

Fixes #93256


cc @carljparker