### PR TITLE
Add retries for get_workflow_job_id and try catch in upload_test_stats

### DIFF
--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -37,16 +37,19 @@ def fetch_url(url: str, *,
               reader: Callable[[Any], Any] = lambda x: x.read()) -> Any:
     if headers is None:
         headers = {}
-    try:
-        with urlopen(Request(url, headers=headers)) as conn:
-            return reader(conn)
-    except urllib.error.HTTPError as err:
-        exception_message = (
-            "Is github alright?",
-            f"Recieved status code '{err.code}' when attempting to retrieve {url}:\n",
-            f"{err.reason}\n\nheaders={err.headers}"
-        )
-        raise RuntimeError(exception_message) from err
+    retries = 3
+    for i in range(retries + 1):
+        try:
+            with urlopen(Request(url, headers=headers)) as conn:
+                return reader(conn)
+        except urllib.error.HTTPError as err:
+            exception_message = (
+                "Is github alright?",
+                f"Recieved status code '{err.code}' when attempting to retrieve {url}:\n",
+                f"{err.reason}\n\nheaders={err.headers}"
+            )
+            if i == retries:
+                raise RuntimeError(exception_message) from err
 
 def parse_args() -> Any:
     parser = argparse.ArgumentParser()

--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sys
+import time
 import urllib
 import urllib.parse
 
@@ -50,6 +51,7 @@ def fetch_url(url: str, *,
             )
             if i == retries:
                 raise RuntimeError(exception_message) from err
+        time.sleep(0.5)
 
 def parse_args() -> Any:
     parser = argparse.ArgumentParser()

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -33,8 +33,12 @@ def parse_xml_report(
     """Convert a test report xml file into a JSON-serializable list of test cases."""
     print(f"Parsing {tag}s for test report: {report}")
 
-    job_id = get_job_id(report)
-    print(f"Found job id: {job_id}")
+    try:
+        job_id = get_job_id(report)
+        print(f"Found job id: {job_id}")
+    except Exception:
+        job_id = None
+        print("Failed to find job id")
 
     test_cases: List[Dict[str, Any]] = []
 


### PR DESCRIPTION
upload_test_stats keeps failing b/c it can't handle when the id is workflow-<workflow_id> so add a try catch for this.

Add retries to get_workflow_job_id to try and reduce the number of times the id can't be found

Failure to upload test stats and inability to get the job id cause our sharding infra and slow test infra (probably also flaky test detection) to be less effective.  This does not completely resolve the issue since we do rely on the job id

Failure to get the workflow job id happens tragically often, hopefully retries will help