### PR TITLE
Make ShapeEnv deepcopy'able

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -15,6 +15,7 @@ import contextlib
 import math
 import atexit
 import os
+import copy
 from torch.utils._pytree import tree_map
 from torch.fx.experimental import symbolic_shapes
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -425,6 +426,14 @@ class TestPySymInt(TestCase):
             y = torch.add(x, x, alpha=a0)
 
         self.assertTrue(sym_int_encountered)
+
+    @skipIfNoSympy
+    def test_deepcopy(self):
+        shape_env = ShapeEnv()
+        a0 = create_symint(shape_env, 2)
+        assert a0 < 4
+        new_shape_env = copy.deepcopy(shape_env)
+        self.assertEqual(len(new_shape_env.guards), 1)
 
     @skipIfNoSympy
     def test_print_readable_with_symints(self):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -634,6 +634,8 @@ if HAS_SYMPY:
             return self.source_ref(self.symbol_to_source[expr][0])
 
 
+TLS = threading.local()
+
 
 class ShapeEnv(object):
     def __init__(self):
@@ -649,20 +651,19 @@ class ShapeEnv(object):
         # Duck-shaping says that if two input tensors have the same size,
         # they get assigned the same symbolic variable
         self.val_to_var: Dict[int, "sympy.Expr"] = {0: sympy.Integer(0), 1: sympy.Integer(1)}
-        self.tls = threading.local()
         self.unbacked_symfloat_counter = itertools.count()
         self.unbacked_symint_counter = itertools.count()
 
     def _suppress_guards_tls(self):
-        return getattr(self.tls, "suppress_guards", False)
+        return getattr(TLS, "suppress_guards", False)
 
     @contextmanager
     def suppress_guards(self):
-        self.tls.suppress_guards = True
+        TLS.suppress_guards = True
         try:
             yield
         finally:
-            self.tls.suppress_guards = False
+            TLS.suppress_guards = False
 
     def _get_key(self):
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93403

We sometimes put ShapeEnv on GraphModule, and code in our testing
utils assume that you can deepcopy a GraphModule, so it's good
for ShapeEnv to be deepcopy'able too.  This is done by making the
TLS module-wide rather than per-ShapeEnv.  We never really have
multiple ShapeEnv so this is a good trade.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>