### PR TITLE
Clean up leftover processes on non-ephemeral Windows runner

### DIFF
--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -65,10 +65,16 @@ jobs:
 
       - name: Clean up leftover processes on non-ephemeral Windows runner
         shell: powershell
+        continue-on-error: true
         run: |
           # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-process
           # This needs to be run before checking out PyTorch to avoid locking the working directory
-          Get-Process -Name "python" | Stop-Process -Force
+          try {
+              Get-Process -Name "python" | Stop-Process -Force
+          }
+          catch [NoProcessFoundForGivenName,Microsoft.PowerShell.Commands.GetProcessCommand] {
+              Write-Output "No leftover process, continuing"
+          }
 
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -63,6 +63,13 @@ jobs:
         run: |
           git config --global core.symlinks true
 
+      - name: Clean up leftover processes on non-ephemeral Windows runner
+        shell: powershell
+        run: |
+          # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-process
+          # This needs to be run before checking out PyTorch to avoid locking the working directory
+          Get-Process -Name "python" | Stop-Process -Force
+
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
         with:

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -72,7 +72,7 @@ jobs:
           try {
               Get-Process -Name "python" | Stop-Process -Force
           }
-          catch [NoProcessFoundForGivenName,Microsoft.PowerShell.Commands.GetProcessCommand] {
+          catch [Microsoft.PowerShell.Commands.GetProcessCommand] {
               Write-Output "No leftover process, continuing"
           }
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -70,9 +70,9 @@ jobs:
           # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-process
           # This needs to be run before checking out PyTorch to avoid locking the working directory
           try {
-              Get-Process -Name "python" | Stop-Process -Force
+              Get-Process -Name "python" -ErrorAction Stop | Stop-Process -Force
           }
-          catch [Microsoft.PowerShell.Commands.GetProcessCommand] {
+          catch {
               Write-Output "No leftover process, continuing"
           }
 


### PR DESCRIPTION
In some rare cases, checking out PyTorch on non-ephemeral Windows G5 runner could fail because of leftover processes from the previous workflow.  For example, https://github.com/pytorch/pytorch/actions/runs/4058503816/jobs/6986773162