### PR TITLE
[dynamo] Control flow with torch.all

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -116,21 +116,6 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         resB = graph(*input)
         self.assertTrue(torch._dynamo.utils.same(resA, resB))
     
-    def test_export_control_flow_with_torch_any(self):
-        class MyModule(torch.nn.Module):
-            def forward(self, x):
-                if torch.any(x):
-                    return x * x 
-                else:
-                    return x - x
-
-        module = MyModule()
-        input = (torch.ones(4, 3),)
-        resA = module(*input)
-        graph, _ = torch._dynamo.export(module, *input)
-        resB = graph(*input)
-        self.assertTrue(torch._dynamo.utils.same(resA, resB))
-
     def test_export_graph_bypass(self):
         inp = [
             torch.tensor([0.1, 0.1]),

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -106,7 +106,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
             def forward(self, x):
                 if torch.all(x):
                     return x * x
-                else: 
+                else:
                     raise ValueError("bad")
 
         module = MyModule()
@@ -115,7 +115,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         graph, _ = torch._dynamo.export(module, *input)
         resB = graph(*input)
         self.assertTrue(torch._dynamo.utils.same(resA, resB))
-    
+
     def test_export_graph_bypass(self):
         inp = [
             torch.tensor([0.1, 0.1]),

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -314,6 +314,10 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
             if truth_fn(eval_result):
                 push and self.push(value)
                 self.jump(inst)
+        elif isinstance(value, TensorVariable) and value.dtype == torch.bool:
+            if truth_fn(value.get_real_value()):
+                push and self.push(value)
+                self.jump(inst)
         else:
             unimplemented(f"generic_jump {typestr(value)}")
 


### PR DESCRIPTION
A model does the following: `torch._assert(torch.all(x), "bad")`. However, running `torch._assert` results in `torch._dynamo.exc.Unsupported: data dependent operator: aten._local_scalar_dense.default`. So I converted the code to an if statement:
```
if not torch.all(x):
    raise ValueError("bad")
```
However, that runs into the issue `torch._dynamo.exc.Unsupported: generic_jump TensorVariable()`. However, x is a tensor with dtype torch.bool, so it seems ok to proceed with running the if statement.

Any advice is appreciated!

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire