### PR TITLE
Plumb dynamic_spec to meta converter

### DIFF
--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -63,8 +63,6 @@ class LocalSource(Source):
 class LocalInputSource(LocalSource):
     pos: int
 
-    dynamic_spec: Optional[Tuple[Optional[str], ...]]  # e.g. ['batch', 'seq', None]
-
 
 @dataclasses.dataclass
 class RandomValueSource(Source):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1664,9 +1664,10 @@ class InstructionTranslator(InstructionTranslatorBase):
                 k,
                 VariableBuilder(
                     self,
-                    LocalInputSource(k, code_options["co_varnames"].index(k), self.dynamic_args.get(k, None))
+                    LocalInputSource(k, code_options["co_varnames"].index(k))
                     if k in code_options["co_varnames"]
                     else LocalSource((k)),
+                    dynamic_spec=self.dynamic_args.get(k, None),
                 )(f_locals[k]),
             )
             for k in vars

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -256,6 +256,7 @@ class VariableTracker(object, metaclass=HasPostInit):
         self,
         guards: Optional[Set] = None,
         source: Source = None,
+        dynamic_spec = None,
         mutable_local: MutableLocal = None,
         recursively_contains: Optional[Set] = None,
     ):

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -218,6 +218,7 @@ class FakeTensorConverter(object):
         ignore_subclass=False,
         *,
         source=None,
+        dynamic_spec=None,
     ):
         maybe_memo = self._get_memo(t)
         if maybe_memo is not None:
@@ -251,6 +252,7 @@ class FakeTensorConverter(object):
             callback=mk_fake_tensor,
             ignore_subclass=ignore_subclass,
             source=source,
+            dynamic_spec=dynamic_spec,
         )
         if out is NotImplemented:
             raise UnsupportedFakeTensorException("meta converter nyi")
@@ -287,6 +289,7 @@ class FakeTensorConverter(object):
         shape_env=None,
         ignore_subclass=False,
         source=None,
+        dynamic_spec=None,
     ):
         # breakpoint()
         return self.from_real_tensor(
@@ -296,6 +299,7 @@ class FakeTensorConverter(object):
             shape_env=shape_env,
             ignore_subclass=ignore_subclass,
             source=source,
+            dynamic_spec=dynamic_spec,
         )
 
 
@@ -1082,6 +1086,7 @@ class FakeTensorMode(TorchDispatchMode):
         static_shapes=False,
         ignore_subclass=False,
         source: Optional[Source] = None,
+        dynamic_spec=None,
     ):
         # breakpoint()
         if static_shapes:
@@ -1094,6 +1099,7 @@ class FakeTensorMode(TorchDispatchMode):
             shape_env=self.shape_env,
             ignore_subclass=ignore_subclass,
             source=source,
+            dynamic_spec=dynamic_spec,
         )
 
 

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -160,7 +160,10 @@ class MetaConverter:
     # as part of this process, we will maintain this invariant!  (Even though
     # other users of this may not need it this property to be upheld.)
     def meta_tensor(
-        self, t, shape_env=None, callback=lambda t: t(), source: Optional[Source] = None
+        self, t, shape_env=None,
+        callback=lambda t: t(),
+        source: Optional[Source]=None,
+        dynamic_spec=None,
     ):
         if source is None:
             from torch._dynamo.source import ConstantSource
@@ -212,7 +215,7 @@ class MetaConverter:
         def sym_sizes_strides_storage_offset(t):
             if make_symbolic:
                 # breakpoint()
-                return shape_env.create_symbolic_sizes_strides_storage_offset(t, source)
+                return shape_env.create_symbolic_sizes_strides_storage_offset(t, source, dynamic_spec=dynamic_spec)
             return (t.size(), t.stride(), t.storage_offset())
 
         # see expired-storages
@@ -454,6 +457,7 @@ class MetaConverter:
         callback=lambda t: t(),
         ignore_subclass=False,
         source=None,
+        dynamic_spec=None,
     ):
         # TODO: zero tensors?  We appear to have eliminated them by
         # excluding complex for now
@@ -502,7 +506,7 @@ class MetaConverter:
                     ctx = torch._C.DisableTorchFunctionSubclass()
                 with ctx:
                     r = self.meta_tensor(
-                        t, shape_env=shape_env, callback=callback, source=source
+                        t, shape_env=shape_env, callback=callback, source=source, dynamic_spec=dynamic_spec
                     )
                 # TODO: this is suspicious, now that we have callback argument
                 if type(t) is torch.nn.Parameter:

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -671,24 +671,25 @@ class ShapeEnv(object):
         """
         return (len(self.replacements), len(self.divisible))
 
-    def create_symbolic_sizes_strides_storage_offset(self, ex: torch.Tensor, source: Source):
+    def create_symbolic_sizes_strides_storage_offset(self, ex: torch.Tensor, source: Source, dynamic_spec=None):
         """
         Returns a list of symbolic sizes and strides for the given tensor.
         We try our best to express stride in terms of the sizes, so as to not
         introduce new symbolic variables.
         """
-        from torch._dynamo.source import TensorPropertySource, TensorProperty, LocalInputSource
+        from torch._dynamo.source import TensorPropertySource, TensorProperty
 
         rank = len(ex.size())
 
-        if isinstance(source, LocalInputSource) and source.dynamic_spec:
-            assert len(source.dynamic_spec) == rank, "dynamic_spec must be same rank as tensor"
+        # breakpoint()
+        if dynamic_spec:
+            assert len(dynamic_spec) == rank, "dynamic_spec must be same rank as tensor"
 
             size = [None] * rank
             for i, val in enumerate(ex.size()):
-                if source.dynamic_spec[i]:
+                if dynamic_spec[i]:
                     size[i] = self.create_symbol(
-                        val, TensorPropertySource(source, TensorProperty.SIZE, i), name=source.dynamic_spec[i]
+                        val, TensorPropertySource(source, TensorProperty.SIZE, i), name=dynamic_spec[i]
                     )
                 else:
                     size[i] = sympy.Integer(val)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93820
* #93813

If we don't reuse LocalInputSource, then I have to plumb it through 7 files as shown in this PR. 

Also, only input tensor could have dynamic_spec, adding dynamic_spec to VariableBuilder and VariableTracker doesn't looks correct.

Maybe we should extend the meaning of LocalInputSource?

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @chunyuan-w @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire