### PR TITLE
[DTensor][fix] MultiThreadedTestCase misses _tls object and it won't reflect in CI

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1025,6 +1025,7 @@ class MultiThreadedTestCase(TestCase):
         # every thread have the same value. This would be relevant when we use op db tests, where it
         # needs those states to be set i.e. using instantiate_device_type_tests()
         # TODO: figure out a better way to do this
+        self._tls = threading.local()
         self._tls.precision = TestCase._precision
         self._tls.rel_tol = TestCase._rel_tol
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #93306
* __->__ #93832
* #93160

