### PR TITLE
Add fabi-version=11 to ensure compatibility between gcc7 and gcc9 binaries for _GLIBCXX_USE_CXX11_ABI=1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,10 @@ if(DEFINED GLIBCXX_USE_CXX11_ABI)
   if(${GLIBCXX_USE_CXX11_ABI} EQUAL 1)
     set(CXX_STANDARD_REQUIRED ON)
     string(APPEND CMAKE_CXX_FLAGS " -D_GLIBCXX_USE_CXX11_ABI=1")
-  else()
-    # Please note this is required in order to ensure compatibility between gcc 9 and gcc 7
-    # This could be removed when all Linux PyTorch binary builds are compiled by the same toolchain again
-    string(APPEND CMAKE_CXX_FLAGS " -fabi-version=11")
   endif()
+  # Please note this is required in order to ensure compatibility between gcc 9 and gcc 7
+  # This could be removed when all Linux PyTorch binary builds are compiled by the same toolchain again
+  string(APPEND CMAKE_CXX_FLAGS " -fabi-version=11")
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
Fixes #https://github.com/pytorch/pytorch/pull/92550
