### PR TITLE
dynamo: dispatch `var_getattr` for `@lazy_property`

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -111,9 +111,8 @@ class UserFunctionVariable(BaseUserFunctionVariable):
         else:
             self.is_constant = False
 
-        assert isinstance(
-            fn, types.FunctionType
-        ), f"expected FunctionType found {typestr(fn)} {fn}"
+        assert isinstance(fn, (types.FunctionType, types.MethodType)), \
+            f"expected FunctionType/MethodType found {typestr(fn)} {fn}"
         # unpack @torch._dynamo.optimize()(fn) wrapped function
         fn = inspect.getattr_static(fn, "_torchdynamo_inline", fn)
         # unpack torch.jit.script_if_tracing

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -326,7 +326,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             )
         elif isinstance(subobj, types.FunctionType):
             return variables.UserMethodVariable(subobj, self, source=source, **options)
-        elif hasattr(subobj, "__get__"):
+        elif isinstance(subobj, torch.distributions.utils.lazy_property):
             return variables.UserMethodVariable(
                 subobj.__get__, self, source=source, **options
             ).call_function(tx, [], {})

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -316,10 +316,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return variables.UserMethodVariable(
                 subobj.fget, self, source=source, **options
             ).call_function(tx, [], {})
-        if isinstance(subobj, torch.distributions.utils.lazy_property):
-            return variables.UserMethodVariable(
-                subobj.__get__, self, source=source, **options
-            ).call_function(tx, [], {})
         elif isinstance(subobj, staticmethod):
             return variables.UserFunctionVariable(
                 subobj.__get__(self.value), source=source, **options
@@ -330,6 +326,10 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             )
         elif isinstance(subobj, types.FunctionType):
             return variables.UserMethodVariable(subobj, self, source=source, **options)
+        elif hasattr(subobj, "__get__"):
+            return variables.UserMethodVariable(
+                subobj.__get__, self, source=source, **options
+            ).call_function(tx, [], {})
 
         if (
             name in getattr(value, "__dict__", {})

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -316,6 +316,10 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return variables.UserMethodVariable(
                 subobj.fget, self, source=source, **options
             ).call_function(tx, [], {})
+        if isinstance(subobj, torch.distributions.utils.lazy_property):
+            return variables.UserMethodVariable(
+                subobj.__get__, self, source=source, **options
+            ).call_function(tx, [], {})
         elif isinstance(subobj, staticmethod):
             return variables.UserFunctionVariable(
                 subobj.__get__(self.value), source=source, **options
@@ -375,7 +379,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
         if name == "__class__":
             return UserDefinedClassVariable(type(self.value), **options)
-
+        
         return variables.GetAttrVariable(self, name, **options)
 
     def call_hasattr(self, tx, name: str) -> "VariableTracker":

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -379,7 +379,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
         if name == "__class__":
             return UserDefinedClassVariable(type(self.value), **options)
-        
+
         return variables.GetAttrVariable(self, name, **options)
 
     def call_hasattr(self, tx, name: str) -> "VariableTracker":


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/93340

`lazy_property` is used in a lot of distributions, so I think it warrants special handling.

TODO:
- [ ] will add test 

cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @mlazos @soumith @yanboliang @desertfire