### PR TITLE
Sanity check the minifier accuracy test

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -567,6 +567,8 @@ def wrap_compiler_debug(unconfigured_compiler_fn, compiler_name: str):
                     # agree
                     assert len(out) == 1
                     tested_output = out[0]
+                    from .utils import same
+
                     if not same(real_output, tested_output, tol=config.repro_tolerance):
                         log.error(
                             "Accuracy didn't fail, but when we reran the optimized module "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93861

We actually generate the results of the compiled module twice:
once in test backend accuracy, and once to actually return the
result.  If these don't agree, there's something gone horribly
wrong in our framework.  This would have flagged that there
was a problem at https://github.com/pytorch/pytorch/pull/93308

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire