### PR TITLE
dynamo.export uses core_aten_decomp by default in aten mode

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1382,21 +1382,13 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         graph, _ = torch._dynamo.export(
             f,
-            (torch.randn(5)),
+            (torch.randn(5, 5)),
             aten_graph=True,
             decomposition_table={torch.ops.aten.t.default: nop},
         )
         self.assertEqual(
             len([n for n in graph.graph.nodes if n.target == torch.ops.aten.t.default]),
             0,
-        )
-
-        graph, _ = torch._dynamo.export(
-            f, (torch.randn(5)), aten_graph=True, decomposition_table=None
-        )
-        self.assertEqual(
-            len([n for n in graph.graph.nodes if n.target == torch.ops.aten.t.default]),
-            2,
         )
 
     def test_export_decomp_asserts_bad_args(self):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import torch
 import torch.utils._pytree as pytree
+from torch._decomp import core_aten_decompositions
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.graph import _PyTreeCodeGen, _PyTreeInfo
 from torch.nn.parallel.distributed import DistributedDataParallel
@@ -522,14 +523,23 @@ def explain(f, *args, **kwargs):
     )
 
 
+CORE_ATEN_DECOMPS = core_aten_decompositions()
+
+
 def export(
-    f, *args, aten_graph=False, decomposition_table=None, tracing_mode="real", **kwargs
+    f,
+    *args,
+    aten_graph=False,
+    decomposition_table=CORE_ATEN_DECOMPS,
+    tracing_mode="real",
+    **kwargs,
 ):
     torch._C._log_api_usage_once("torch._dynamo.export")
-    if decomposition_table is not None or tracing_mode != "real":
+    if decomposition_table is not CORE_ATEN_DECOMPS or tracing_mode != "real":
         assert (
             aten_graph
         ), "Specifying a decomposition_table table or tracing mode is illegal without setting aten_graph=True"
+
     f = innermost_fn(f)
 
     graph = None


### PR DESCRIPTION
Moved from https://github.com/pytorch/pytorch/pull/93133


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire