### PR TITLE
[Dynamo] Backend registration with ``entry_points``

### DIFF
--- a/docs/source/dynamo/custom-backends.rst
+++ b/docs/source/dynamo/custom-backends.rst
@@ -51,6 +51,35 @@ You can register your backend using the ``register_backend`` decorator, for exam
     def my_compiler(gm, example_inputs):
         ...
 
+Besides the ``register_backend`` decorator, if your backend is in another python package, you could also register your
+backend through entry points of python package, which provides a way for a package to register a plugin for another one.
+
+.. hint::
+
+    You can learn more about ``entry_points`` in the
+    `python packaging documentation <https://setuptools.pypa.io/en/latest/userguide/entry_point.html>`__.
+
+To register your backend through ``entry_points``, you could add your backend function to the ``torch_dynamo_backends`` entry point group in the
+``setup.py`` file of your package like:
+
+.. code-block:: python
+
+    ...
+    setup(
+        ...
+        'torch_dynamo_backends': [
+            'my_compiler = your_module.submodule:my_compiler',
+        ]
+        ...
+    )
+
+Please replace the ``my_compiler`` before ``=`` to the name of your backend's name and replace the part after ``=`` to
+the module and function name of your backend function.
+The entry point will be added to your python environment after the installation of the package.
+When you call ``torch.compile(model, backend="my_compiler")``, PyTorch would first search the backend named ``my_compiler``
+that has been registered with ``register_backend``. If not found, it will continue to search in all backends registered
+via ``entry_points``.
+
 Registration serves two purposes:
 
 * You can pass a string containing your backend function's name to ``torch.compile`` instead of the function itself,

--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -1,4 +1,5 @@
 import functools
+import sys
 from typing import Callable, Dict, List, Optional, Protocol, Sequence, Tuple
 
 import torch
@@ -53,6 +54,8 @@ def lookup_backend(compiler_fn):
     if isinstance(compiler_fn, str):
         if compiler_fn not in _BACKENDS:
             _lazy_import()
+        if compiler_fn not in _BACKENDS:
+            _lazy_import_entry_point(compiler_fn)
         compiler_fn = _BACKENDS[compiler_fn]
     return compiler_fn
 
@@ -84,3 +87,22 @@ def _lazy_import():
     from ..debug_utils import dynamo_minifier_backend
 
     assert dynamo_minifier_backend is not None
+
+
+@functools.lru_cache(None)
+def _lazy_import_entry_point(backend_name: str):
+    from importlib.metadata import entry_points
+    compiler_fn = None
+    group_name = "torch_dynamo_backends"
+    if sys.version_info < (3, 10):
+        backend_eps = entry_points()
+        eps = [ep for ep in backend_eps[group_name] if ep.name == backend_name]
+        if len(eps) > 0:
+            compiler_fn = eps[0].load()
+    else:
+        backend_eps = entry_points(group=group_name)
+        if backend_name in backend_eps.names:
+            compiler_fn = backend_eps[backend_name].load()
+
+    if compiler_fn is not None:
+        register_backend(compiler_fn=compiler_fn, name=backend_name)

--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -104,5 +104,5 @@ def _lazy_import_entry_point(backend_name: str):
         if backend_name in backend_eps.names:
             compiler_fn = backend_eps[backend_name].load()
 
-    if compiler_fn is not None:
+    if compiler_fn is not None and backend_name not in list_backends(tuple()):
         register_backend(compiler_fn=compiler_fn, name=backend_name)

--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -92,6 +92,7 @@ def _lazy_import():
 @functools.lru_cache(None)
 def _lazy_import_entry_point(backend_name: str):
     from importlib.metadata import entry_points
+
     compiler_fn = None
     group_name = "torch_dynamo_backends"
     if sys.version_info < (3, 10):


### PR DESCRIPTION
Fixes #91824

This PR add a new dynamo backend registration mechanism through ``entry_points``. The ``entry_points`` of a package is provides a way for the package to reigster a plugin for another one. 

The docs of the new mechanism:
![image](https://user-images.githubusercontent.com/23381083/216133221-18cf18e2-6ad6-4cf7-8da2-9b9b883389c8.png)
(the typo '...named "my_backend" that has been..." has been fixed to '...named "my_compiler" that has been...')

# Discussion

## About the test
I did not add a test for this PR as it is hard either to install a fack package during a test or manually hack the entry points function by replacing it with a fake one. I have tested this PR offline with the hidet compiler and it works fine. Please let me know if you have any good idea to test this PR.

## About the dependency of ``importlib_metadata``
This PR will add a dependency ``importlib_metadata`` for the python < 3.10 because the modern usage of ``importlib`` gets stable at this python version (see the documentation of the importlib package [here](https://docs.python.org/3/library/importlib.html)).  For python < 3.10, the package ``importlib_metadata`` implements the feature of ``importlib``. The current PR will hint the user to install this ``importlib_metata`` if their python version < 3.10. 

## About the name and docs
Please let me know how do you think the name ``torch_dynamo_backend`` as the entry point group name and the documentation of this registration mechanism.


cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire