### PR TITLE
[BE] Migrate Anaconda Prune jobs from CircleCI to GHA

### DIFF
--- a/.github/workflows/_prune-anaconda-packages.yml
+++ b/.github/workflows/_prune-anaconda-packages.yml
@@ -1,0 +1,30 @@
+name: upload
+
+on:
+  workflow_call:
+    inputs:
+      build_name:
+        required: true
+        type: string
+        description: The build's name
+    secrets:
+      conda-pytorchbot-token:
+        required: true
+        description: Conda PyTorchBot token
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    container:
+      image: continuumio/miniconda3:4.12.0
+    steps:
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+        with:
+          no-sudo: true
+
+      - name: Prune binaries
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.conda-pytorchbot-token }}
+        run: |
+            set -ex
+            bash ./scripts/release/anaconda-prune/run.sh

--- a/.github/workflows/_prune-anaconda-packages.yml
+++ b/.github/workflows/_prune-anaconda-packages.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Prune binaries
         env:
+          CHANNEl: ${{ inputs.channel }}
+          PACKAGES: ${{ inputs.packages }}
           ANACONDA_API_TOKEN: ${{ secrets.conda-pytorchbot-token }}
         run: |
             set -ex

--- a/.github/workflows/_prune-anaconda-packages.yml
+++ b/.github/workflows/_prune-anaconda-packages.yml
@@ -1,4 +1,4 @@
-name: upload
+name: Prune Anaconda Binaries
 
 on:
   workflow_call:

--- a/.github/workflows/_prune-anaconda-packages.yml
+++ b/.github/workflows/_prune-anaconda-packages.yml
@@ -28,5 +28,6 @@ jobs:
           PACKAGES: ${{ inputs.packages }}
           ANACONDA_API_TOKEN: ${{ secrets.conda-pytorchbot-token }}
         run: |
-            set -ex
+            set -euxo pipefail
+            conda install -yq anaconda-client
             bash ./scripts/release/anaconda-prune/run.sh

--- a/.github/workflows/_prune-anaconda-packages.yml
+++ b/.github/workflows/_prune-anaconda-packages.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
         description: The channel to prune packages
+    secrets:
+      conda-pytorchbot-token:
+        required: true
+        description: Conda PyTorchBot token
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/_prune-anaconda-packages.yml
+++ b/.github/workflows/_prune-anaconda-packages.yml
@@ -3,10 +3,14 @@ name: upload
 on:
   workflow_call:
     inputs:
-      build_name:
+      packages:
         required: true
         type: string
-        description: The build's name
+        description: The packages to prune
+      channel:
+        required: true
+        type: string
+        description: The channel to prune packages
     secrets:
       conda-pytorchbot-token:
         required: true

--- a/.github/workflows/_prune-anaconda-packages.yml
+++ b/.github/workflows/_prune-anaconda-packages.yml
@@ -11,10 +11,6 @@ on:
         required: true
         type: string
         description: The channel to prune packages
-    secrets:
-      conda-pytorchbot-token:
-        required: true
-        description: Conda PyTorchBot token
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/_prune-anaconda-packages.yml
+++ b/.github/workflows/_prune-anaconda-packages.yml
@@ -28,6 +28,6 @@ jobs:
           PACKAGES: ${{ inputs.packages }}
           ANACONDA_API_TOKEN: ${{ secrets.conda-pytorchbot-token }}
         run: |
-            set -euxo pipefail
+            set -ex
             conda install -yq anaconda-client
             bash ./scripts/release/anaconda-prune/run.sh

--- a/.github/workflows/anaconda-prune.yml
+++ b/.github/workflows/anaconda-prune.yml
@@ -25,8 +25,6 @@ jobs:
     #packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
       packages: "pytorch torchvision torchaudio torchtext"
       channel: pytorch-nightly
-    secrets:
-      CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
       
   anaconda-prune-pytorch-test:
     name: anaconda-prune-pytorch-test
@@ -35,5 +33,3 @@ jobs:
     #packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
       packages: "pytorch torchvision torchaudio torchtext"
       channel: pytorch-test
-    secrets:
-      CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/anaconda-prune.yml
+++ b/.github/workflows/anaconda-prune.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - .github/workflows/anaconda-prune.yml
       - .github/workflows/_prune-anaconda-packages.yml
+      - scripts/release/anaconda-prune/run.sh
+      - scripts/release/anaconda-prune/prune.sh
   workflow_dispatch:
 
 concurrency:
@@ -22,18 +24,16 @@ jobs:
     name: anaconda-prune-pytorch-nightly
     uses: ./.github/workflows/_prune-anaconda-packages.yml
     with:
-    #packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
-      packages: "pytorch torchvision torchaudio torchtext"
+      packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
       channel: pytorch-nightly
-    secrets: 
+    secrets:
      conda-pytorchbot-token: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
 
   anaconda-prune-pytorch-test:
     name: anaconda-prune-pytorch-test
     uses: ./.github/workflows/_prune-anaconda-packages.yml
     with:
-    #packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
-      packages: "pytorch torchvision torchaudio torchtext"
+      packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
       channel: pytorch-test
-    secrets: 
+    secrets:
      conda-pytorchbot-token: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/anaconda-prune.yml
+++ b/.github/workflows/anaconda-prune.yml
@@ -21,11 +21,11 @@ jobs:
   anaconda-prune-pytorch-nightly:
     name: anaconda-prune-pytorch-nightly
     uses: ./.github/workflows/_prune-anaconda-packages.yml
-    with: 
+    with:
     #packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
       packages: "pytorch torchvision torchaudio torchtext"
       channel: pytorch-nightly
-      
+
   anaconda-prune-pytorch-test:
     name: anaconda-prune-pytorch-test
     uses: ./.github/workflows/_prune-anaconda-packages.yml

--- a/.github/workflows/anaconda-prune.yml
+++ b/.github/workflows/anaconda-prune.yml
@@ -25,6 +25,8 @@ jobs:
     #packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
       packages: "pytorch torchvision torchaudio torchtext"
       channel: pytorch-nightly
+    secrets: 
+     conda-pytorchbot-token: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
 
   anaconda-prune-pytorch-test:
     name: anaconda-prune-pytorch-test
@@ -33,3 +35,5 @@ jobs:
     #packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
       packages: "pytorch torchvision torchaudio torchtext"
       channel: pytorch-test
+    secrets: 
+     conda-pytorchbot-token: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/anaconda-prune.yml
+++ b/.github/workflows/anaconda-prune.yml
@@ -1,6 +1,8 @@
 name: anaconda-prune
 
 on:
+  schedule:
+    - cron: 45 1,7,13,19 * * *
   push:
     branches:
       - postnightly

--- a/.github/workflows/anaconda-prune.yml
+++ b/.github/workflows/anaconda-prune.yml
@@ -1,0 +1,37 @@
+name: anaconda-prune
+
+on:
+  push:
+    branches:
+      - postnightly
+  pull_request:
+    paths:
+      - .github/workflows/prune-nightly-anaconda-packages.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+
+jobs:
+  anaconda-prune-pytorch-nightly:
+    name: anaconda-prune-pytorch-nightly
+    uses: ./.github/workflows/_prune-anaconda-packages.yml
+    with: 
+    #packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
+      packages: "pytorch torchvision torchaudio torchtext"
+      channel: pytorch-nightly
+    secrets:
+      CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
+      
+  anaconda-prune-pytorch-test:
+    name: anaconda-prune-pytorch-test
+    uses: ./.github/workflows/_prune-anaconda-packages.yml
+    with: 
+    #packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
+      packages: "pytorch torchvision torchaudio torchtext"
+      channel: pytorch-test
+    secrets:
+      CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/anaconda-prune.yml
+++ b/.github/workflows/anaconda-prune.yml
@@ -29,7 +29,7 @@ jobs:
   anaconda-prune-pytorch-test:
     name: anaconda-prune-pytorch-test
     uses: ./.github/workflows/_prune-anaconda-packages.yml
-    with: 
+    with:
     #packages: "pytorch torchvision torchaudio torchtext ignite torchcsprng"
       packages: "pytorch torchvision torchaudio torchtext"
       channel: pytorch-test

--- a/.github/workflows/anaconda-prune.yml
+++ b/.github/workflows/anaconda-prune.yml
@@ -4,16 +4,16 @@ on:
   push:
     branches:
       - postnightly
+      - weiwangmeta/migrate_anaconda_prune_to_gha
   pull_request:
     paths:
-      - .github/workflows/prune-nightly-anaconda-packages.yml
+      - .github/workflows/anaconda-prune.yml
+      - .github/workflows/_prune-anaconda-packages.yml
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
-
-jobs:
 
 jobs:
   anaconda-prune-pytorch-nightly:

--- a/scripts/release/anaconda-prune/prune.sh
+++ b/scripts/release/anaconda-prune/prune.sh
@@ -47,7 +47,7 @@ for platform in ${PLATFORMS}; do
                 set -x
                 echo "Removing ${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
                 #anaconda remove --force "${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
-		anaconda remove --force "pytorch-nightly/torchauido/win-64/torchaudio-0.11.0.dev20211229-py36_cu115.tar.bz2"
+		anaconda remove --force "pytorch-nightly/torchaudio/win-64/torchaudio-0.11.0.dev20211229-py36_cu115.tar.bz2"
             )
         fi
         done

--- a/scripts/release/anaconda-prune/prune.sh
+++ b/scripts/release/anaconda-prune/prune.sh
@@ -33,6 +33,7 @@ CHANNEL=${CHANNEL:-pytorch-nightly}
 PKG=${PKG:-pytorch}
 PLATFORMS=${PLATFORMS:-noarch osx-64 osx-arm64 linux-64 win-64}
 
+#anaconda remove --force "pytorch-nightly/pytorch/}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
 for platform in ${PLATFORMS}; do
     latest_version="$(grab_latest_version || true)"
     specs_in_latest_version="$(grab_specs_for_version "${latest_version}" || true)"
@@ -44,7 +45,8 @@ for platform in ${PLATFORMS}; do
         if [[ "${specs_in_latest_version}" =~ ${spec} ]];then
             (
                 set -x
-                anaconda remove --force "${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
+                echo "Removing ${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
+                #anaconda remove --force "${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
             )
         fi
         done

--- a/scripts/release/anaconda-prune/prune.sh
+++ b/scripts/release/anaconda-prune/prune.sh
@@ -33,7 +33,6 @@ CHANNEL=${CHANNEL:-pytorch-nightly}
 PKG=${PKG:-pytorch}
 PLATFORMS=${PLATFORMS:-noarch osx-64 osx-arm64 linux-64 win-64}
 
-#anaconda remove --force "pytorch-nightly/pytorch/}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
 for platform in ${PLATFORMS}; do
     latest_version="$(grab_latest_version || true)"
     specs_in_latest_version="$(grab_specs_for_version "${latest_version}" || true)"

--- a/scripts/release/anaconda-prune/prune.sh
+++ b/scripts/release/anaconda-prune/prune.sh
@@ -47,6 +47,7 @@ for platform in ${PLATFORMS}; do
                 set -x
                 echo "Removing ${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
                 #anaconda remove --force "${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
+		anaconda remove --force "pytorch-nightly/torchauido/win-64/torchaudio-0.11.0.dev20211229-py36_cu115.tar.bz2"
             )
         fi
         done

--- a/scripts/release/anaconda-prune/prune.sh
+++ b/scripts/release/anaconda-prune/prune.sh
@@ -47,7 +47,7 @@ for platform in ${PLATFORMS}; do
                 set -x
                 echo "Removing ${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
                 #anaconda remove --force "${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
-		anaconda remove --force "pytorch-nightly/torchaudio/win-64/torchaudio-0.11.0.dev20211229-py36_cu115.tar.bz2"
+		anaconda remove --force "pytorch-nightly/torchaudio/0.11.0.dev20211229/win-64/torchaudio-0.11.0.dev20211229-py36_cu115.tar.bz2"
             )
         fi
         done

--- a/scripts/release/anaconda-prune/prune.sh
+++ b/scripts/release/anaconda-prune/prune.sh
@@ -45,9 +45,7 @@ for platform in ${PLATFORMS}; do
         if [[ "${specs_in_latest_version}" =~ ${spec} ]];then
             (
                 set -x
-                echo "Removing ${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
-                #anaconda remove --force "${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
-		anaconda remove --force "pytorch-nightly/torchaudio/0.11.0.dev20211229/win-64/torchaudio-0.11.0.dev20211229-py36_cu115.tar.bz2"
+                anaconda remove --force "${CHANNEL}/${PKG}/${version}/${platform}/${PKG}-${version}-${spec}.tar.bz2"
             )
         fi
         done


### PR DESCRIPTION
We need periodical anaconda prune jobs to remove older packages (e.g. pytorch, torchvision, torchaudio, torchtext etc) from channels like pytorch-nightly and pytorch-test. 
Currently it is done in circleci (e.g. https://app.circleci.com/pipelines/github/pytorch/pytorch/647201/workflows/72e5af30-0d54-44c1-8d9b-4c5502d27c9d/jobs/17260775) and triggered by postnightly update (https://github.com/pytorch/pytorch/tree/postnightly)

However, this postnightly branch triggers so many useless jobs (dozens of them failed due to docker command too long. Why? Because change history was part of docker command and it exceeds max INT). 

<img width="756" alt="image" src="https://user-images.githubusercontent.com/109318740/216139179-3c913094-82cb-4605-99b7-23a21b4cbb36.png">

Therefore, we should stop the postnightly jobs (waste of resources) but save anaconda prune jobs. 
This PR attempts to achieve this. 