### PR TITLE
Run ASAN in 4xlarge in all shards

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -74,9 +74,9 @@ jobs:
       docker-image-name: pytorch-linux-focal-py3-clang7-asan
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 5, runner: "linux.2xlarge" },
-          { config: "default", shard: 2, num_shards: 5, runner: "linux.2xlarge" },
-          { config: "default", shard: 3, num_shards: 5, runner: "linux.2xlarge" },
+          { config: "default", shard: 1, num_shards: 5, runner: "linux.4xlarge" },
+          { config: "default", shard: 2, num_shards: 5, runner: "linux.4xlarge" },
+          { config: "default", shard: 3, num_shards: 5, runner: "linux.4xlarge" },
           { config: "default", shard: 4, num_shards: 5, runner: "linux.4xlarge" },
           { config: "default", shard: 5, num_shards: 5, runner: "linux.4xlarge" },
           { config: "functorch", shard: 1, num_shards: 1, runner: "linux.2xlarge" },


### PR DESCRIPTION
We used to have ASAN shard 4 and 5 running in 4xlarge because they timed out.  With the current issue with test time collecting, I guess the shard allocation has been changed, and there are now timeout from shard 1 to 3.  It's better to just have all shards using the same runner for consistency