### PR TITLE
Enable thp(transparent huge pages) for buffer sizes >=2MB

### DIFF
--- a/c10/core/alignment.h
+++ b/c10/core/alignment.h
@@ -14,4 +14,8 @@ constexpr size_t gAlignment = 16;
 constexpr size_t gAlignment = 64;
 #endif
 
+constexpr size_t gPagesize = 4096;
+// since the default thp pagesize is 2MB, enable thp only
+// for buffers of size 2MB or larger to avoid memory bloating
+constexpr size_t gAlloc_threshold_thp = 2 * 1024 * 1024;
 } // namespace c10

--- a/c10/core/impl/alloc_cpu.cpp
+++ b/c10/core/impl/alloc_cpu.cpp
@@ -54,7 +54,7 @@ static inline bool is_thp_alloc_enabled() {
 
 #ifdef __linux__
 inline size_t c10_compute_alignment(size_t nbytes) {
-  static int pagesize = sysconf(_SC_PAGESIZE);
+  static const auto pagesize = sysconf(_SC_PAGESIZE);
   // for kernels that don't provide page size, default it to 4K
   const size_t thp_alignment = (gPagesize < 0 ? gPagesize : pagesize);
   return (is_thp_alloc_enabled() ? thp_alignment : gAlignment);

--- a/c10/core/impl/alloc_cpu.cpp
+++ b/c10/core/impl/alloc_cpu.cpp
@@ -41,6 +41,38 @@ void memset_junk(void* data, size_t num) {
   }
 }
 
+static inline bool is_thp_alloc_enabled() {
+  static bool value = [&](const char* pt) {
+    if (pt != nullptr) {
+      return std::atoi(pt);
+    } else {
+      return 0;
+    }
+  }(std::getenv("THP_MEM_ALLOC_ENABLE"));
+  return value;
+}
+
+#ifdef __linux__
+inline size_t c10_compute_alignment(size_t nbytes) {
+  static int pagesize = sysconf(_SC_PAGESIZE);
+  // for kernels that don't provide page size, default it to 4K
+  const size_t thp_alignment = (gPagesize < 0 ? gPagesize : pagesize);
+  return (is_thp_alloc_enabled() ? thp_alignment : gAlignment);
+}
+
+inline bool is_thp_alloc(size_t nbytes) {
+  // enable thp (transparent huge pages) for larger buffers
+  return (is_thp_alloc_enabled() && (nbytes >= gAlloc_threshold_thp));
+}
+#else
+constexpr size_t c10_compute_alignment(C10_UNUSED size_t nbytes) {
+  return gAlignment;
+}
+
+constexpr bool is_thp_alloc(C10_UNUSED size_t nbytes) {
+  return false;
+}
+#endif
 } // namespace
 
 void* alloc_cpu(size_t nbytes) {
@@ -71,7 +103,7 @@ void* alloc_cpu(size_t nbytes) {
       nbytes,
       " bytes.");
 #else
-  int err = posix_memalign(&data, gAlignment, nbytes);
+  int err = posix_memalign(&data, c10_compute_alignment(nbytes), nbytes);
   CAFFE_ENFORCE(
       err == 0,
       "DefaultCPUAllocator: can't allocate memory: you tried to allocate ",
@@ -81,6 +113,16 @@ void* alloc_cpu(size_t nbytes) {
       " (",
       strerror(err),
       ")");
+#ifdef __linux__
+  // MADV_HUGEPAGE advise is available only for linux.
+  // general posix compliant systems can check POSIX_MADV_SEQUENTIAL advise.
+  if (is_thp_alloc(nbytes)) {
+    int ret = madvise(data, nbytes, MADV_HUGEPAGE);
+    if (ret != 0) {
+      TORCH_WARN_ONCE("thp madvise for HUGEPAGE failed with ", strerror(errno));
+    }
+  }
+#endif
 #endif
 
   // move data to a thread's NUMA node

--- a/c10/core/impl/alloc_cpu.h
+++ b/c10/core/impl/alloc_cpu.h
@@ -4,6 +4,11 @@
 
 #include <cstddef>
 
+#ifdef __linux__
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
 namespace c10 {
 
 C10_API void* alloc_cpu(size_t nbytes);


### PR DESCRIPTION
The 2MB thp pages provide better allocation latencies compared to the standard 4KB pages. This change has shown significant improvement for batch mode usecases where the tensor sizes are larger than 100MB.

Only enabled if `THP_MEM_ALLOC_ENABLE` environment variable is set.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10