### PR TITLE
Add `torch_compile_debug/` to .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ torch/nn/functional.pyi
 torch/utils/data/datapipes/datapipe.pyi
 torch/csrc/autograd/generated/*
 torch/csrc/lazy/generated/*.[!m]*
+torch_compile_debug/
 # Listed manually because some files in this directory are not generated
 torch/testing/_internal/generated/annotated_fn_args.py
 torch/testing/_internal/data/*.pt


### PR DESCRIPTION
# Summary
I have almost checked this in multiple times. Add to gitignore.