### PR TITLE
Context manager to ignore disable_saved_tensor_hooks for testing

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7562,6 +7562,18 @@ for shape in [(1,), ()]:
 
         self.assertTrue(torch._C._autograd._saved_tensors_hooks_is_enabled())
 
+    def test_ignore_disable_saved_tensor_hooks(self):
+        with torch.autograd.graph._ignore_disable_saved_tensor_hooks():
+            with torch.autograd.graph.disable_saved_tensors_hooks("error message"):
+                self.assertTrue(torch._C._autograd._saved_tensors_hooks_is_enabled())
+                with torch.autograd.graph.saved_tensors_hooks(lambda x: x, lambda x: x):
+                    pass
+
+        with torch.autograd.graph._ignore_disable_saved_tensor_hooks():
+            with self.assertRaisesRegex(RuntimeError, "cannot be nested"):
+                with torch.autograd.graph._ignore_disable_saved_tensor_hooks():
+                    pass
+
     def test_save_on_cpu_and_checkpoint(self):
         a = torch.randn(2, 2, requires_grad=True)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #93912
* __->__ #93911
* #93910

When this context manager is enabled, the disable_saved_tensor_hooks API is a noop. This is used for testing only. See the next PR in the stack, for an example of its usage.