### PR TITLE
Add shape function for squeeze.dims op

### DIFF
--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -155,6 +155,67 @@ def squeeze(li: List[int],
   return out
 
 )=====")
++ std::string(R"=====(def squeeze_dims(li: List[int],
+    dims: List[int]) -> List[int]:
+  wrapped_dims = annotate(List[int], [])
+  for _0 in range(torch.len(dims)):
+    i = dims[_0]
+    _1 = torch.len(li)
+    if torch.le(_1, 0):
+      dim_post_expr = 1
+    else:
+      dim_post_expr = _1
+    min = torch.neg(dim_post_expr)
+    max = torch.sub(dim_post_expr, 1)
+    if torch.lt(i, min):
+      _2 = True
+    else:
+      _2 = torch.gt(i, max)
+    if torch.__not__(_2):
+      pass
+    else:
+      ops.prim.RaiseException("AssertionError: ")
+    if torch.lt(i, 0):
+      dim = torch.add(i, dim_post_expr)
+    else:
+      dim = i
+    _3 = torch.append(wrapped_dims, dim)
+  torch.sort(wrapped_dims, True)
+  li0 = li
+  for _4 in range(torch.len(wrapped_dims)):
+    i0 = wrapped_dims[_4]
+    li1 = annotate(List[int], [])
+    _5 = torch.len(li0)
+    if torch.le(_5, 0):
+      dim_post_expr0 = 1
+    else:
+      dim_post_expr0 = _5
+    min0 = torch.neg(dim_post_expr0)
+    max0 = torch.sub(dim_post_expr0, 1)
+    if torch.lt(i0, min0):
+      _6 = True
+    else:
+      _6 = torch.gt(i0, max0)
+    if torch.__not__(_6):
+      pass
+    else:
+      ops.prim.RaiseException("AssertionError: ")
+    if torch.lt(i0, 0):
+      wrapped_dim = torch.add(i0, dim_post_expr0)
+    else:
+      wrapped_dim = i0
+    for i1 in range(torch.len(li0)):
+      if torch.eq(i1, wrapped_dim):
+        if torch.ne(li0[i1], 1):
+          _7 = torch.append(li1, li0[i1])
+        else:
+          pass
+      else:
+        _8 = torch.append(li1, li0[i1])
+    li0 = li1
+  return li0
+
+)=====")
 + std::string(R"=====(def unsqueeze(li: List[int],
     dim: int) -> List[int]:
   _0 = torch.add(torch.len(li), 1)
@@ -2627,49 +2688,57 @@ def conv_forwards(input: List[int],
 )=====")
 + std::string(R"=====(def upsample_nearest2d(input: List[int],
     output_size: Optional[List[int]],
-    scale_factors: Optional[List[float]]) -> Optional[List[int]]:
-  _0 = "AssertionError: Must specify exactly one of output_size and scale_factors"
-  _1 = "AssertionError: Either output_size or scale_factors must be presented"
+    scale_factors: Optional[List[float]]) -> List[int]:
+  _0 = "AssertionError: Either output_size or scale_factors must be presented"
+  _1 = "AssertionError: Must specify exactly one of output_size and scale_factors"
+  _2 = uninitialized(Optional[List[float]])
   out = annotate(List[int], [])
-  _2 = torch.append(out, input[0])
-  _3 = torch.append(out, input[1])
+  _3 = torch.append(out, input[0])
+  _4 = torch.append(out, input[1])
+  if torch.__is__(scale_factors, None):
+    _5, scale_factors0 = torch.__is__(output_size, None), scale_factors
+  else:
+    scale_factors1 = unchecked_cast(List[float], scale_factors)
+    _5, scale_factors0 = False, scale_factors1
+  if _5:
+    ops.prim.RaiseException(_0)
+  else:
+    pass
   if torch.__isnot__(output_size, None):
-    output_size0 = unchecked_cast(List[int], output_size)
-    if torch.__is__(scale_factors, None):
-      pass
+    output_size1 = unchecked_cast(List[int], output_size)
+    if torch.__is__(scale_factors0, None):
+      scale_factors3 : Optional[List[float]] = scale_factors0
     else:
-      ops.prim.RaiseException(_0)
-    _5 = torch.eq(torch.len(output_size0), 2)
-    if _5:
+      ops.prim.RaiseException(_1)
+      scale_factors3 = _2
+    _6 = torch.eq(torch.len(output_size1), 2)
+    if _6:
       pass
     else:
       ops.prim.RaiseException("AssertionError: ")
-    _6 = torch.append(out, output_size0[0])
-    _7 = torch.append(out, output_size0[1])
-    _4 : Optional[List[int]] = out
+    _7 = torch.append(out, output_size1[0])
+    _8 = torch.append(out, output_size1[1])
+    scale_factors2, output_size0 = scale_factors3, output_size1
   else:
-    _8 = torch.__isnot__(scale_factors, None)
-    if _8:
-      scale_factors0 = unchecked_cast(List[float], scale_factors)
-      if torch.__is__(output_size, None):
-        pass
-      else:
-        ops.prim.RaiseException(_0)
-      _10 = torch.eq(torch.len(scale_factors0), 2)
-      if _10:
-        pass
-      else:
-        ops.prim.RaiseException("AssertionError: ")
-      _11 = torch.mul(input[2], scale_factors0[0])
-      _12 = torch.append(out, int(_11))
-      _13 = torch.mul(input[3], scale_factors0[1])
-      _14 = torch.append(out, int(_13))
-      _9 : Optional[List[int]] = out
+    scale_factors2, output_size0 = scale_factors0, output_size
+  if torch.__isnot__(scale_factors2, None):
+    scale_factors4 = unchecked_cast(List[float], scale_factors2)
+    if torch.__is__(output_size0, None):
+      pass
     else:
       ops.prim.RaiseException(_1)
-      _9 = None
-    _4 = _9
-  return _4
+    _9 = torch.eq(torch.len(scale_factors4), 2)
+    if _9:
+      pass
+    else:
+      ops.prim.RaiseException("AssertionError: ")
+    _10 = torch.mul(input[2], scale_factors4[0])
+    _11 = torch.append(out, int(_10))
+    _12 = torch.mul(input[3], scale_factors4[1])
+    _13 = torch.append(out, int(_12))
+  else:
+    pass
+  return out
 
 )=====")
 + std::string(R"=====(def broadcast(a: List[int],
@@ -3076,6 +3145,7 @@ const OperatorMap<std::string>& GetShapeFunctionMappings() {
     {"aten::arange.start_step(Scalar start, Scalar end, Scalar step, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor", "arange_start_step"},
     {"aten::squeeze(Tensor(a) self) -> Tensor(a)", "squeeze_nodim"},
     {"aten::squeeze.dim(Tensor(a) self, int dim) -> Tensor(a)", "squeeze"},
+    {"aten::squeeze.dims(Tensor(a) self, int[] dim) -> Tensor(a)", "squeeze_dims"},
     {"aten::unsqueeze(Tensor(a) self, int dim) -> Tensor(a)", "unsqueeze"},
     {"aten::slice.Tensor(Tensor(a) self, int dim=0, int? start=None, int? end=None, int step=1) -> Tensor(a)", "slice"},
     {"aten::select.int(Tensor(a) self, int dim, int index) -> Tensor(a)", "select"},
@@ -3127,6 +3197,8 @@ const OperatorMap<std::string>& GetShapeFunctionMappings() {
     {"aten::nll_loss_forward(Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index) -> (Tensor output, Tensor total_weight)", "nll_loss_forward"},
     {"aten::native_layer_norm(Tensor input, int[] normalized_shape, Tensor? weight, Tensor? bias, float eps) -> (Tensor, Tensor, Tensor)", "native_layer_norm"},
     {"aten::native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)", "native_batch_norm"},
+    {"aten::_native_batch_norm_legit(Tensor input, Tensor? weight, Tensor? bias, Tensor running_mean, Tensor running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)", "native_batch_norm"},
+    {"aten::_native_batch_norm_legit.no_stats(Tensor input, Tensor? weight, Tensor? bias, Tensor running_mean, Tensor running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)", "native_batch_norm"},
     {"aten::lerp.Tensor(Tensor self, Tensor end, Tensor weight) -> Tensor", "broadcast_three"},
     {"aten::where.ScalarSelf(Tensor condition, Scalar self, Tensor other) -> Tensor", "broadcast_one_three"},
     {"aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)", "broadcast_inplace"},

--- a/torch/jit/_shape_functions.py
+++ b/torch/jit/_shape_functions.py
@@ -426,6 +426,14 @@ def squeeze(li: List[int], dim: int):
             out.append(li[i])
     return out
 
+def squeeze_dims(li: List[int], dims: List[int]):
+    wrapped_dims : List[int] = []
+    for i in dims:
+        wrapped_dims.append(maybe_wrap_dim(i, len(li)))
+    wrapped_dims.sort(reverse=True)
+    for i in wrapped_dims:
+        li = squeeze(li, i)
+    return li
 
 def index_select(self: List[int], dim: int, index: List[int]):
     dim = maybe_wrap_dim(dim, len(self))
@@ -1080,6 +1088,7 @@ add_shape_compute_mapping("aten::arange.start(Scalar start, Scalar end, *, Scala
 add_shape_compute_mapping("aten::arange.start_step(Scalar start, Scalar end, Scalar step, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor", arange_start_step)
 add_shape_compute_mapping("aten::squeeze(Tensor(a) self) -> Tensor(a)", squeeze_nodim)
 add_shape_compute_mapping("aten::squeeze.dim(Tensor(a) self, int dim) -> Tensor(a)", squeeze)
+add_shape_compute_mapping("aten::squeeze.dims(Tensor(a) self, int[] dim) -> Tensor(a)", squeeze_dims)
 add_shape_compute_mapping("aten::unsqueeze(Tensor(a) self, int dim) -> Tensor(a)", unsqueeze)
 add_shape_compute_mapping("aten::slice.Tensor(Tensor(a) self, int dim=0, int? start=None, int? end=None, int step=1) -> Tensor(a)", slice)
 add_shape_compute_mapping("aten::select.int(Tensor(a) self, int dim, int index) -> Tensor(a)", select)


### PR DESCRIPTION
Changes to `_native_batch_norm_legit` and `upsample_nearest2d` in `serialized_shape_function_registry.cpp` are made just because this file is auto-generated, and the file was not auto-generated after the changes in `_shape_functions.py` for those two ops.

Signed-Off By: Vivek Khandelwal <vivek@nod-labs.com>
