### PR TITLE
remove std::iterator 

### DIFF
--- a/c10/util/reverse_iterator.h
+++ b/c10/util/reverse_iterator.h
@@ -61,13 +61,7 @@
 namespace c10 {
 
 template <typename _Iterator>
-class reverse_iterator
-    : public std::iterator<
-          typename std::iterator_traits<_Iterator>::iterator_category,
-          typename std::iterator_traits<_Iterator>::value_type,
-          typename std::iterator_traits<_Iterator>::difference_type,
-          typename std::iterator_traits<_Iterator>::pointer,
-          typename std::iterator_traits<_Iterator>::reference> {
+class reverse_iterator {
  protected:
   _Iterator current;
 
@@ -75,9 +69,11 @@ class reverse_iterator
 
  public:
   using iterator_type = _Iterator;
+  using value_type = typename __traits_type::value_type;
   using difference_type = typename __traits_type::difference_type;
   using pointer = typename __traits_type::pointer;
   using reference = typename __traits_type::reference;
+  using iterator_category = typename __traits_type::iterator_category;
 
   constexpr reverse_iterator() : current() {}
 


### PR DESCRIPTION
std::iterator is deprecated in C++17, and it is easy to remove it