### PR TITLE
[Docs] Fix typo in guards overview

### DIFF
--- a/docs/source/dynamo/guards-overview.rst
+++ b/docs/source/dynamo/guards-overview.rst
@@ -238,7 +238,7 @@ bytecode instructions as possible.
 
 Across both the logic downstream of ``step`` and the logic from invoking
 ``VariableBuilder`` - we now have a lot of ``VariableTracker``\ s and of
-course, we’ve spoken about creating guards quiet a bit. Let’s dig into
+course, we’ve spoken about creating guards quite a bit. Let’s dig into
 what Variables are, and get a little closer to understanding guards.
 
 Variables


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #93932 [Docs] `VariableTracker.make_guards` -> `VariableBuilder.make_guards`
* #93930 [Docs] Some more minor formatting fixes
* #93928 [Docs] `popn` returns `List[VariableTracker]`
* **#93926 [Docs] Fix typo in guards overview**

