### PR TITLE
[Docs] `popn` returns `List[VariableTracker]`

### DIFF
--- a/docs/source/dynamo/guards-overview.rst
+++ b/docs/source/dynamo/guards-overview.rst
@@ -310,9 +310,9 @@ Here is what this code does:
    analogous to ``counts`` in the pydoc for the equivalent instruction.
 
 2. The function ``popn`` the items, in this case, the signature is
-   ``def  popn(self, n: int) -> List[TensorVariable]:`` this hints at an
-   underlying contract - we are returning ``TensorVariables``. If we
-   take a closer look at ``sybmolic_convert.py`` and
+   ``def  popn(self, n: int) -> List[VariableTracker]:`` this hints at an
+   underlying contract - we are returning ``VariableTracker``\ s. If we
+   take a closer look at ``symbolic_convert.py`` and
    ``InstructionTranslatorBase``/``InstructionTranslator``\ we see that
    the only thing pushed onto and popped from our stack are
    ``VariableTracker``\ s.

--- a/docs/source/dynamo/guards-overview.rst
+++ b/docs/source/dynamo/guards-overview.rst
@@ -312,7 +312,7 @@ Here is what this code does:
 2. The function ``popn`` the items, in this case, the signature is
    ``def  popn(self, n: int) -> List[VariableTracker]:`` this hints at an
    underlying contract - we are returning ``VariableTracker``\ s. If we
-   take a closer look at ``symbolic_convert.py`` and
+   take a closer look at ``sybmolic_convert.py`` and
    ``InstructionTranslatorBase``/``InstructionTranslator``\ we see that
    the only thing pushed onto and popped from our stack are
    ``VariableTracker``\ s.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #93932 [Docs] `VariableTracker.make_guards` -> `VariableBuilder.make_guards`
* #93930 [Docs] Some more minor formatting fixes
* **#93928 [Docs] `popn` returns `List[VariableTracker]`**
* #93926 [Docs] Fix typo in guards overview

https://github.com/pytorch/pytorch/blob/59ccc786dff9657ac85aae2b333d521728608cd6/torch/_dynamo/symbolic_convert.py#L596

Saying the return value is of `VariableTracker`s, not `TensorVariable`s specifically, seems to be more in line with the subsequent sentence that the only things pushed/popped from the stack are `VariableTracker`s. Let me know if I am misunderstanding.