### PR TITLE
[Docs] `VariableTracker.make_guards` -> `VariableBuilder.make_guards`

### DIFF
--- a/docs/source/dynamo/guards-overview.rst
+++ b/docs/source/dynamo/guards-overview.rst
@@ -374,7 +374,7 @@ knowing whether or not things have changed in between invocations, and
 whether we can safely read from the code cache or not.
 
 The most common code paths for getting an instance of a guard are
-through ``make_guards`` on ``VariableTracker``.
+through ``make_guards`` on ``VariableBuilder``.
 ``make_guards``-> ``source.make_guard``-> ``return Guard(self.name(), self.guard_source(), fn)``
 
 Or, in a concrete example:
@@ -387,7 +387,7 @@ Or, in a concrete example:
        return RangeVariable(value=value, guards=guards)
 
 Since ``source`` was set at the construction time of this
-``VariableTracker``, all that was needed here was to provide the ``fn``,
+``VariableBuilder``, all that was needed here was to provide the ``fn``,
 ``GuardBuilder.EQUALS_MATCH`` to the ``create_fn`` field.
 
 This ``create_fn`` must be a method on ``GuardBuilder``. The reason for


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#93932 [Docs] `VariableTracker.make_guards` -> `VariableBuilder.make_guards`**
* #93930 [Docs] Some more minor formatting fixes
* #93928 [Docs] `popn` returns `List[VariableTracker]`
* #93926 [Docs] Fix typo in guards overview

Perhaps, the tutorial was written before `VariableBuilder` existed. If so, we can defer this PR's change to a broader update to the tutorial, and I can close this PR.

https://github.com/pytorch/pytorch/blob/b11ec270bad96bf6078564ec4b2dc5dc69ea5bfa/torch/_dynamo/variables/builder.py#L260-L267

