### PR TITLE
Add count to FakeTensorMode.__torch_dispatch__

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -6,6 +6,7 @@ import csv
 import functools
 import importlib
 import io
+import itertools
 import logging
 import os
 import random
@@ -1510,9 +1511,12 @@ class BenchmarkRunner:
             from torch.utils._stats import simple_call_counter
 
             print_time_report()
-            stats = f"STATS: call_* op count: {op_count}"
+            stats = "STATS: "
             stats = stats + " | ".join(
-                f"{key}:{value}" for key, value in simple_call_counter.items()
+                itertools.chain(
+                    [f"call_* op count: {op_count}"],
+                    (f"{key}:{value}" for key, value in simple_call_counter.items()),
+                )
             )
             print(stats)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -770,6 +770,7 @@ class FakeTensorMode(TorchDispatchMode):
 
         self.shape_env = shape_env
 
+    @count
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         kwargs = kwargs if kwargs else {}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93936

Most calls to fake tensor never hit `FakeTensor.__torch_dispatch__`

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire