### PR TITLE
Improvements to roundup_power2_divisions knob in CUDA Caching Allocator

### DIFF
--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -418,10 +418,16 @@ Available options:
   will be rounded to 1280 as the nearest ceiling of power-2 division.
   Specify a single value to apply for all allocation sizes or specify an
   array of key value pairs to set power-2 division individually for each
-  power of two interval. For example to set 1 division for all allocations
-  under 256MB, 2 division for allocations between 256MB and 512MB, 4 divisions
-  for allocations between 512MB and 1GB and 8 divisions for any larger allocations,
-  set the knob value to: [256:1,512:2,1024:4,>:8].
+  power of two interval. The intervals start with the 1MB-2MB interval
+  and end with the 64GB-128GB interval. The first value of the array is applied
+  to all previous intervals. If a interval is skipped, it will use
+  the same value as the previous specified interval. Values for intervals after
+  the last specified interval can be set using the ">" character.
+  The values of 0 or 1 can be use to specify no rouding for the given interval.
+  For example to set 2 divisions for all allocations
+  under 4MB and between 4MB and 64MB, 4 division for allocations between 64MB and 1GB,
+  8 divisions for allocations between 1GB and 2GB and no divisions
+  for allocations bigger than 2GB, set the knob value to: [4:2,64:4,1024:8:2048:1, >:1].
   ``roundup_power2_divisions`` is only meaningful with ``backend:native``.
   With ``backend:cudaMallocAsync``, ``roundup_power2_divisions`` is ignored.
 * ``roundup_bypass_threshold_mb`` bypass rounding the requested allocation size,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5014,7 +5014,7 @@ class TestCudaComm(TestCase):
         # roundup_power2_divisions knob array syntax
         torch.cuda.memory.empty_cache()
         torch.cuda.memory._set_allocator_settings(
-            "garbage_collection_threshold:0.5,roundup_power2_divisions:[64:8,128:2,256:2,512:2,1024:1,>:1]")
+            "garbage_collection_threshold:0.5,roundup_power2_divisions:[64:8,128:2,1024:1,>:1]")
         start_mem = torch.cuda.memory_stats()[key]
         w = torch.rand(nelems, device='cuda')
 


### PR DESCRIPTION
Summary:
Changed the behaviour of the roundup_power2_divisions, so that if a interval is skipped, it will use the same value as the previous specified interval (e.g. for [1:1, 4:2, 16:4], the intervals 2-4 and 8-16 will use the values of the previous intervals: 1 and 2 respectively)

Also improved and updated documentation for this knob

Misc:
Currently when divisions is set to 1 we enter roundup_power2_next_division just to immediately exit returning the original size, thus not aligning the memory allocation to kMinBlockSize
I took this oportunity to remove the if statement inside roundup_power2_next_division, becasue:
size <= 4 -> this is allready previously satisfied by if (... && size > (kMinBlockSize * divisions))
divisions <= 1 -> moved this check outside of the function and combined it with the other check on divisions, thus we check fordivisions > 1 before calling roundup_power2_next_division

Test Plan: Modified test in test_cuda.py

Differential Revision: D42966057

