### PR TITLE
Drop OneCycleLR pickling of bound methods

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -3435,6 +3435,32 @@ class TestLRScheduler(TestCase):
         )
         self._test_cycle_lr(scheduler, lr_targets, momentum_targets, 10, use_beta1=True)
         self.opt = old_opt  # set optimizer back to SGD
+        
+    def test_onecycle_lr_pickleable(self):
+        adam_opt = optim.Adam(self.net.parameters())
+        scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200)
+        state = scheduler.state_dict()
+        self.assertNotIn("anneal_func", state)
+        pickle.dumps(state)
+        
+    def test_onecycle_lr_restore_from_state_dict(self):
+        adam_opt = optim.Adam(self.net.parameters())
+        
+        #case 1: cosine annealing
+        scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200, anneal_strategy='cos')
+        restored_scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200)
+        restored_scheduler.load_state_dict(scheduler.state_dict())
+        self.assertTrue(restored_scheduler.anneal_strategy == scheduler.anneal_strategy == 'cos')
+        self.assertIsNotNone(restored_scheduler.anneal_func)
+        self.assertIsNotNone(scheduler.anneal_func)
+        
+        #case 2: linear annealing
+        scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200, anneal_strategy='linear')
+        restored_scheduler = OneCycleLR(adam_opt, max_lr=5, total_steps=200)
+        restored_scheduler.load_state_dict(scheduler.state_dict())
+        self.assertTrue(restored_scheduler.anneal_strategy == scheduler.anneal_strategy == 'linear')
+        self.assertIsNotNone(restored_scheduler.anneal_func)
+        self.assertIsNotNone(scheduler.anneal_func)
 
     def test_lambda_lr(self):
         epochs = 10

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1642,7 +1642,7 @@ class OneCycleLR(LRScheduler):
 
         # Set and Validate anneal_strategy
         self.anneal_strategy = anneal_strategy
-        self._init_annealing_func()       
+        self._init_anneal_func()       
 
         # Initialize learning rate variables
         max_lrs = self._format_param('max_lr', self.optimizer, max_lr)
@@ -1681,7 +1681,7 @@ class OneCycleLR(LRScheduler):
         else:
             return [param] * len(optimizer.param_groups)
     
-    def _init_annealing_func(self):
+    def _init_anneal_func(self):
         if self.anneal_strategy not in ['cos', 'linear']:
             raise ValueError("anneal_strategy must by one of 'cos' or 'linear', instead got {}".format(self.anneal_strategy))
         elif self.anneal_strategy == 'cos':
@@ -1733,10 +1733,10 @@ class OneCycleLR(LRScheduler):
         
     def state_dict(self):
         state = super().state_dict()
-        # We are dropping the `_anneal_func` attribute because it can't be pickled
+        # We are dropping the `anneal_func` attribute because it can't be pickled
         state.pop("anneal_func")
         return state
 
     def load_state_dict(self, state_dict):
         super().load_state_dict(state_dict)
-        self._init_annealing_func()
+        self._init_anneal_func()


### PR DESCRIPTION
This PR drops pickling of bound methods in OneCycleLR scheduler. Adds a new attribute 'anneal_strategy' and re-inits whichever method is specified by this attribute. 

This fixes an issue where creating a subclass of OneCycleLR makes that subclass unpickleable.

Added tests for `state_dict()` and `load_state_dict()`