### PR TITLE
Remove import cycle from torch._refs.nn.functional

### DIFF
--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -7,7 +7,6 @@ import torch._prims as prims
 import torch._prims_common as utils
 import torch._refs as refs
 from torch._decomp import register_decomposition
-from torch._decomp.decompositions import Reduction
 from torch._prims_common import (
     check,
     ELEMENTWISE_TYPE_PROMOTION_KIND,
@@ -22,8 +21,6 @@ from torch._prims_common.wrappers import (
     out_wrapper,
 )
 from torch._refs import _make_inplace
-
-from torch._subclasses.fake_tensor import FakeTensor
 
 __all__ = [
     "alpha_dropout",
@@ -478,6 +475,8 @@ def softshrink(a: TensorLikeType, lambd: float = 0.5):
 
 # Losses
 def _reduction_int_to_str(reduction: int) -> str:
+    from torch._decomp.decompositions import Reduction
+
     if reduction == Reduction.NONE.value:
         return "none"
     elif reduction == Reduction.MEAN.value:
@@ -650,6 +649,7 @@ def _nll_loss_nd(
     # TODO: This check does not work with FakeTensor inputs; See Issue #85834
     # Explicit cast for class_check to bool; See Issue #78071
     """
+    from torch._subclasses.fake_tensor import FakeTensor
     num_classes = input.shape[1] if input.ndim > 1 else input.shape[0]
     valid_classes_mask = torch.logical_and(
         (flat_target >= 0), (flat_target < num_classes)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93948

This makes it possible to import torch._refs from
torch._subclasses.fake_tensor

Signed-off-by: Edward Z. Yang <ezyang@meta.com>