### PR TITLE
move quantization imports in torch/__init__.py to new location

### DIFF
--- a/test/test_module_init.py
+++ b/test/test_module_init.py
@@ -185,9 +185,9 @@ def build_constructor_arg_db():
         torch.ao.nn.qat.EmbeddingBag: ((10, 12), {
             'qconfig': torch.ao.quantization.float_qparams_weight_only_qconfig,
         }),
-        torch.nn.quantizable.LSTM: ((5, 6), {}),
-        torch.nn.quantizable.LSTMCell: ((5, 6), {}),
-        torch.nn.quantizable.MultiheadAttention: ((10, 2), {}),
+        torch.ao.nn.quantizable.LSTM: ((5, 6), {}),
+        torch.ao.nn.quantizable.LSTMCell: ((5, 6), {}),
+        torch.ao.nn.quantizable.MultiheadAttention: ((10, 2), {}),
         torch.ao.nn.quantized.BatchNorm2d: ((2,), {}),
         torch.ao.nn.quantized.BatchNorm3d: ((2,), {}),
         torch.ao.nn.quantized.Dropout: ((), {}),
@@ -237,73 +237,73 @@ def build_constructor_arg_db():
         torch.ao.nn.quantized.FXFloatFunctional: ((), {}),
         torch.ao.nn.quantized.QFunctional: ((), {}),
         # Remove torch.nn.quantized after the migration completes:
-        torch.nn.qat.Conv1d: ((3, 3, 3), {
+        torch.ao.nn.qat.Conv1d: ((3, 3, 3), {
             'qconfig': torch.ao.quantization.default_qconfig,
         }),
-        torch.nn.qat.Conv2d: ((3, 3, 3), {
+        torch.ao.nn.qat.Conv2d: ((3, 3, 3), {
             'qconfig': torch.ao.quantization.default_qconfig,
         }),
-        torch.nn.qat.Conv3d: ((3, 3, 3), {
+        torch.ao.nn.qat.Conv3d: ((3, 3, 3), {
             'qconfig': torch.ao.quantization.default_qconfig,
         }),
-        torch.nn.qat.Linear: ((5, 2), {
+        torch.ao.nn.qat.Linear: ((5, 2), {
             'qconfig': torch.ao.quantization.default_qconfig,
         }),
-        torch.nn.qat.Embedding: ((10, 12), {
+        torch.ao.nn.qat.Embedding: ((10, 12), {
             'qconfig': torch.ao.quantization.float_qparams_weight_only_qconfig,
         }),
-        torch.nn.qat.EmbeddingBag: ((10, 12), {
+        torch.ao.nn.qat.EmbeddingBag: ((10, 12), {
             'qconfig': torch.ao.quantization.float_qparams_weight_only_qconfig,
         }),
-        torch.nn.quantized.BatchNorm2d: ((2,), {}),
-        torch.nn.quantized.BatchNorm3d: ((2,), {}),
-        torch.nn.quantized.Dropout: ((), {}),
-        torch.nn.quantized.Conv1d: ((3, 3, 3), {}),
-        torch.nn.quantized.Conv2d: ((3, 3, 3), {}),
-        torch.nn.quantized.Conv3d: ((3, 3, 3), {}),
-        torch.nn.quantized.ConvTranspose1d: ((3, 3, 3), {}),
-        torch.nn.quantized.ConvTranspose2d: ((3, 3, 3), {}),
-        torch.nn.quantized.ConvTranspose3d: ((16, 33, (3, 3, 5)), {
+        torch.ao.nn.quantized.BatchNorm2d: ((2,), {}),
+        torch.ao.nn.quantized.BatchNorm3d: ((2,), {}),
+        torch.ao.nn.quantized.Dropout: ((), {}),
+        torch.ao.nn.quantized.Conv1d: ((3, 3, 3), {}),
+        torch.ao.nn.quantized.Conv2d: ((3, 3, 3), {}),
+        torch.ao.nn.quantized.Conv3d: ((3, 3, 3), {}),
+        torch.ao.nn.quantized.ConvTranspose1d: ((3, 3, 3), {}),
+        torch.ao.nn.quantized.ConvTranspose2d: ((3, 3, 3), {}),
+        torch.ao.nn.quantized.ConvTranspose3d: ((16, 33, (3, 3, 5)), {
             'stride': (2, 1, 1),
             'padding': (4, 2, 2),
             'output_padding': (2, 2, 2),
             'dilation': (1, 1, 1),
         }),
-        torch.nn.quantized.DeQuantize: ((), {}),
-        torch.nn.quantized.ELU: ((0.01, 0), {}),
-        torch.nn.quantized.Embedding: ((10, 3), {
+        torch.ao.nn.quantized.DeQuantize: ((), {}),
+        torch.ao.nn.quantized.ELU: ((0.01, 0), {}),
+        torch.ao.nn.quantized.Embedding: ((10, 3), {
             'factory_kwargs': {},
         }),
-        torch.nn.quantized.EmbeddingBag: ((10, 3), {
+        torch.ao.nn.quantized.EmbeddingBag: ((10, 3), {
             'factory_kwargs': {},
         }),
-        torch.nn.quantized.GroupNorm: ((2, 4, torch.nn.Parameter(torch.tensor(2.)),
+        torch.ao.nn.quantized.GroupNorm: ((2, 4, torch.nn.Parameter(torch.tensor(2.)),
                                         torch.nn.Parameter(torch.tensor(2.)), 0.1, 0), {}),
-        torch.nn.quantized.Hardswish: ((0.1, 0,), {}),
-        torch.nn.quantized.InstanceNorm1d: ((2, torch.nn.Parameter(torch.tensor(2.)),
+        torch.ao.nn.quantized.Hardswish: ((0.1, 0,), {}),
+        torch.ao.nn.quantized.InstanceNorm1d: ((2, torch.nn.Parameter(torch.tensor(2.)),
                                              torch.nn.Parameter(torch.tensor(2.)), 0.1, 0), {}),
-        torch.nn.quantized.InstanceNorm2d: ((2, torch.nn.Parameter(torch.tensor(2.)),
+        torch.ao.nn.quantized.InstanceNorm2d: ((2, torch.nn.Parameter(torch.tensor(2.)),
                                              torch.nn.Parameter(torch.tensor(2.)), 0.1, 0), {}),
-        torch.nn.quantized.InstanceNorm3d: ((2, torch.nn.Parameter(torch.tensor(2.)),
+        torch.ao.nn.quantized.InstanceNorm3d: ((2, torch.nn.Parameter(torch.tensor(2.)),
                                              torch.nn.Parameter(torch.tensor(2.)), 0.1, 0), {}),
-        torch.nn.quantized.LayerNorm: ((2, torch.nn.Parameter(torch.tensor(2.)),
+        torch.ao.nn.quantized.LayerNorm: ((2, torch.nn.Parameter(torch.tensor(2.)),
                                         torch.nn.Parameter(torch.tensor(2.)), 0.1, 0), {}),
-        torch.nn.quantized.LeakyReLU: ((0.01, 0), {}),
-        torch.nn.quantized.Linear: ((5, 2), {
+        torch.ao.nn.quantized.LeakyReLU: ((0.01, 0), {}),
+        torch.ao.nn.quantized.Linear: ((5, 2), {
             'factory_kwargs': {},
         }),
-        torch.nn.quantized.MaxPool2d: ((3,), {}),
-        torch.nn.quantized.PReLU: ((0.01, 0), {}),
-        torch.nn.quantized.Quantize: ((0.1, 0), {
+        torch.ao.nn.quantized.MaxPool2d: ((3,), {}),
+        torch.ao.nn.quantized.PReLU: ((0.01, 0), {}),
+        torch.ao.nn.quantized.Quantize: ((0.1, 0), {
             'dtype': torch.int16,
             'factory_kwargs': {},
         }),
-        torch.nn.quantized.ReLU6: ((), {}),
-        torch.nn.quantized.Sigmoid: ((0.1, 0), {}),
-        torch.nn.quantized.Softmax: ((), {}),
-        torch.nn.quantized.FloatFunctional: ((), {}),
-        torch.nn.quantized.FXFloatFunctional: ((), {}),
-        torch.nn.quantized.QFunctional: ((), {}),
+        torch.ao.nn.quantized.ReLU6: ((), {}),
+        torch.ao.nn.quantized.Sigmoid: ((0.1, 0), {}),
+        torch.ao.nn.quantized.Softmax: ((), {}),
+        torch.ao.nn.quantized.FloatFunctional: ((), {}),
+        torch.ao.nn.quantized.FXFloatFunctional: ((), {}),
+        torch.ao.nn.quantized.QFunctional: ((), {}),
     }
 
 
@@ -427,9 +427,9 @@ def generate_tests(test_cls, constructor_arg_db):
         torch.nn,
         torch.ao.nn.qat,
         torch.ao.nn.quantized,
-        torch.nn.qat,
-        torch.nn.quantizable,
-        torch.nn.quantized,
+        torch.ao.nn.qat,
+        torch.ao.nn.quantizable,
+        torch.ao.nn.quantized,
     ]
     # ...except these
     MODULES_TO_SKIP = {
@@ -440,10 +440,10 @@ def generate_tests(test_cls, constructor_arg_db):
         # See https://github.com/pytorch/pytorch/issues/55396
         torch.ao.nn.quantized.Embedding,
         torch.ao.nn.quantized.EmbeddingBag,
-        torch.nn.quantized.Embedding,
-        torch.nn.quantized.EmbeddingBag,
-        torch.nn.quantized.LSTM,
-        torch.nn.quantized.MultiheadAttention,
+        torch.ao.nn.quantized.Embedding,
+        torch.ao.nn.quantized.EmbeddingBag,
+        torch.ao.nn.quantized.LSTM,
+        torch.ao.nn.quantized.MultiheadAttention,
     }
     # no need to support kwargs for these modules even though
     # they have parameters / buffers because they are passed in
@@ -490,14 +490,6 @@ def generate_tests(test_cls, constructor_arg_db):
         torch.ao.nn.quantized.ConvTranspose2d,
         torch.ao.nn.quantized.ConvTranspose3d,
         torch.ao.nn.quantized.Linear,
-        # Remove the lines below after AO migration is complete
-        torch.nn.quantized.Conv1d,
-        torch.nn.quantized.Conv2d,
-        torch.nn.quantized.Conv3d,
-        torch.nn.quantized.ConvTranspose1d,
-        torch.nn.quantized.ConvTranspose2d,
-        torch.nn.quantized.ConvTranspose3d,
-        torch.nn.quantized.Linear,
     }
 
     for namespace in NAMESPACES:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1245,10 +1245,10 @@ from torch import profiler as profiler
 # is expected to depend on them.
 from torch import ao as ao
 # nn.quant* depends on ao -- so should be after those.
-import torch.nn.quantizable
-import torch.nn.quantized
-import torch.nn.qat
-import torch.nn.intrinsic
+import torch.ao.nn.quantizable
+import torch.ao.nn.quantized
+import torch.ao.nn.qat
+import torch.ao.nn.intrinsic
 
 _C._init_names(list(torch._storage_classes))
 
@@ -1268,7 +1268,7 @@ from torch._classes import classes
 
 # quantization depends on torch.fx
 # Import quantization
-from torch import quantization as quantization
+from torch.ao import quantization as quantization
 
 # Import the quasi random sampler
 from torch import quasirandom as quasirandom

--- a/torch/ao/nn/quantizable/modules/activation.py
+++ b/torch/ao/nn/quantizable/modules/activation.py
@@ -51,7 +51,7 @@ class MultiheadAttention(nn.MultiheadAttention):
 
     Examples::
 
-        >>> import torch.nn.quantizable as nnqa
+        >>> import torch.ao.nn.quantizable as nnqa
         >>> multihead_attn = nnqa.MultiheadAttention(embed_dim, num_heads)
         >>> attn_output, attn_output_weights = multihead_attn(query, key, value)
 
@@ -77,7 +77,7 @@ class MultiheadAttention(nn.MultiheadAttention):
         self.out_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=bias, **factory_kwargs)  # type: ignore[assignment]
 
         # Functionals
-        self.q_scaling_product = torch.nn.quantized.FloatFunctional()
+        self.q_scaling_product = torch.ao.nn.quantized.FloatFunctional()
         # note: importing torch.nn.quantized at top creates a circular import
 
         # Quant/Dequant

--- a/torch/ao/nn/quantized/modules/rnn.py
+++ b/torch/ao/nn/quantized/modules/rnn.py
@@ -29,7 +29,7 @@ class LSTM(torch.ao.nn.quantizable.LSTM):
         >>> tq.prepare(model, prepare_custom_module_class=custom_module_config)
         >>> tq.convert(model, convert_custom_module_class=custom_module_config)
     """
-    _FLOAT_MODULE = torch.nn.quantizable.LSTM  # type: ignore[assignment]
+    _FLOAT_MODULE = torch.ao.nn.quantizable.LSTM  # type: ignore[assignment]
 
     def _get_name(self):
         return 'QuantizedLSTM'

--- a/torch/ao/quantization/quantization_mappings.py
+++ b/torch/ao/quantization/quantization_mappings.py
@@ -2,7 +2,6 @@ import copy
 
 import torch
 from torch import nn
-from torch.ao import nn as ao_nn
 
 import torch.nn.functional as F
 import torch.ao.nn.intrinsic as nni

--- a/torch/ao/quantization/quantization_mappings.py
+++ b/torch/ao/quantization/quantization_mappings.py
@@ -2,6 +2,7 @@ import copy
 
 import torch
 from torch import nn
+from torch.ao import nn as ao_nn
 
 import torch.nn.functional as F
 import torch.ao.nn.intrinsic as nni
@@ -209,8 +210,8 @@ DEFAULT_DYNAMIC_SPARSE_QUANT_MODULE_MAPPINGS : Dict[Callable, Any] = {
 def no_observer_set() -> Set[Any]:
     r"""These modules cannot have observers inserted by default."""
     no_observers = set([
-        nn.quantizable.LSTM,
-        nn.quantizable.MultiheadAttention
+        ao_nn.quantizable.LSTM,
+        ao_nn.quantizable.MultiheadAttention
     ])
     return no_observers
 

--- a/torch/ao/quantization/quantize.py
+++ b/torch/ao/quantization/quantize.py
@@ -4,6 +4,7 @@ import warnings
 
 import torch
 import torch.nn as nn
+import torch.ao.nn as ao_nn
 import torch.ao.nn.quantized as nnq
 from torch.nn.intrinsic import _FusedModule
 
@@ -49,12 +50,12 @@ __all__ = [
 
 _DEFAULT_CUSTOM_CONFIG_DICT = {
     'float_to_observed_custom_module_class': {
-        nn.LSTM: nn.quantizable.LSTM,
-        nn.MultiheadAttention: nn.quantizable.MultiheadAttention,
+        nn.LSTM: ao_nn.quantizable.LSTM,
+        nn.MultiheadAttention: ao_nn.quantizable.MultiheadAttention,
     },
     'observed_to_quantized_custom_module_class': {
-        nn.quantizable.LSTM: nn.quantized.LSTM,
-        nn.quantizable.MultiheadAttention: nn.quantized.MultiheadAttention,
+        ao_nn.quantizable.LSTM: ao_nn.quantized.LSTM,
+        ao_nn.quantizable.MultiheadAttention: ao_nn.quantized.MultiheadAttention,
     }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #93963
* __->__ #93954

Summary:

We are moving quantization code into `torch/ao` to reduce namespace
pollution.  This PR moves over the `torch/__init__.py` callsites
to the new location.

We want to finish the cleanup and surface the user warnings by PT2.0
branch cut, so we can delete the old code in PT2.0+x.

Test plan:

```
// no errors
import torch
```