### PR TITLE
[BE] Get rid of `six` in caffe2 code

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -75,7 +75,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   }
 
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
-  CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools six"
+  CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools"
   if [ "$ANACONDA_PYTHON_VERSION" = "3.11" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
     # TODO: Stop using `-c malfet`

--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -8,7 +8,6 @@
 from collections import namedtuple, OrderedDict, defaultdict
 from past.builtins import basestring
 from itertools import chain
-from six import binary_type, string_types, text_type
 
 from caffe2.proto import caffe2_pb2
 from caffe2.python import scope, utils, workspace
@@ -215,9 +214,9 @@ class BlobReference(object):
         Note that this does not prepends the namescope. If needed, use
         ScopedBlobReference() to prepend the existing namespace.
         """
-        if isinstance(name, string_types):
+        if isinstance(name, str):
             self._name = name
-        elif isinstance(name, binary_type):
+        elif isinstance(name, bytes):
             self._name = name.decode('utf-8')
         else:
             self._name = str(name)
@@ -230,9 +229,9 @@ class BlobReference(object):
         return hash(self._name)
 
     def __eq__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, str):
             return self._name == other
-        elif isinstance(other, binary_type):
+        elif isinstance(other, bytes):
             return self._name == other.decode('utf-8')
         elif isinstance(other, BlobReference):
             return self._name == other._name
@@ -249,12 +248,12 @@ class BlobReference(object):
         return 'BlobReference("{}")'.format(self._name)
 
     def __add__(self, other):
-        if not isinstance(other, string_types):
+        if not isinstance(other, str):
             raise RuntimeError('Cannot add BlobReference to a non-string.')
         return BlobReference(self._name + other, self._from_net)
 
     def __radd__(self, other):
-        if not isinstance(other, string_types):
+        if not isinstance(other, str):
             raise RuntimeError('Cannot add a non-string to BlobReference.')
         return BlobReference(other + self._name, self._from_net)
 
@@ -272,7 +271,7 @@ class BlobReference(object):
         network's __getattr__ function.
         """
         inputs = [] if inputs is None else inputs
-        if isinstance(inputs, BlobReference) or isinstance(inputs, string_types):
+        if isinstance(inputs, BlobReference) or isinstance(inputs, str):
             inputs = [inputs]
         # add self to the input list.
         inputs.insert(0, self)
@@ -317,7 +316,7 @@ class BlobReference(object):
 
 def ScopedName(name):
     """prefix the name with the current scope."""
-    if isinstance(name, binary_type):
+    if isinstance(name, bytes):
         name = name.decode('ascii')
     return scope.CurrentNameScope() + name
 
@@ -331,7 +330,7 @@ def _RectifyInputOutput(blobs, net=None):
     """A helper function to rectify the input or output of the CreateOperator
     interface.
     """
-    if isinstance(blobs, string_types) or isinstance(blobs, binary_type):
+    if isinstance(blobs, (bytes, str)):
         # If blobs is a single string, prepend scope.CurrentNameScope()
         # and put it as a list.
         # TODO(jiayq): enforce using BlobReference instead of raw strings.
@@ -343,7 +342,7 @@ def _RectifyInputOutput(blobs, net=None):
         # If blob is a list, we go through it and type check.
         rectified = []
         for blob in blobs:
-            if isinstance(blob, string_types) or isinstance(blob, binary_type):
+            if isinstance(blob, (bytes, str)):
                 rectified.append(ScopedBlobReference(blob, net=net))
             elif type(blob) is BlobReference:
                 rectified.append(blob)
@@ -385,11 +384,11 @@ def CreateOperator(
     # Add rectified inputs and outputs
     inputs = _RectifyInputOutput(inputs)
     outputs = _RectifyInputOutput(outputs)
-    operator.input.extend([text_type(i) for i in inputs])
-    operator.output.extend([text_type(o) for o in outputs])
+    operator.input.extend([str(i) for i in inputs])
+    operator.output.extend([str(o) for o in outputs])
     if control_input:
         control_input = _RectifyInputOutput(control_input)
-        operator.control_input.extend([text_type(i) for i in control_input])
+        operator.control_input.extend([str(i) for i in control_input])
     # Set device option:
     # (1) If device_option is explicitly set, use device_option.
     # (2) If not, but scope.CurrentDeviceScope() is set,
@@ -1095,8 +1094,7 @@ StopGradient. Op:\n\n{}""".format(op.output[0], str(op)))
         all_input_to_grad_out = {}
         for key, val in all_input_to_grad.items():
             if val is not None:
-                if (isinstance(val, string_types) or
-                        isinstance(val, binary_type)):
+                if isinstance(val, (bytes, str)):
                     grad_out = BlobReference(val)
                 else:
                     grad_out = GradientSlice(BlobReference(val[0]),
@@ -1310,7 +1308,7 @@ def recurrent_network_op_remap(op, prefix, blob_remap):
     """
 
     def get_remapped_str(blob_str):
-        if isinstance(blob_str, binary_type):
+        if isinstance(blob_str, bytes):
             blob_str = blob_str.decode('utf-8')
         return blob_remap.get(blob_str, blob_str).encode('utf-8')
 
@@ -1983,7 +1981,7 @@ class Net(object):
     def _ExtendOps(self, new_ops):
         self._net.op.extend(new_ops)
         for op in new_ops:
-            self._op_outputs.update([text_type(o) for o in op.output])
+            self._op_outputs.update([str(o) for o in op.output])
 
     def _CheckLookupTables(self):
         '''

--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -384,11 +384,11 @@ def CreateOperator(
     # Add rectified inputs and outputs
     inputs = _RectifyInputOutput(inputs)
     outputs = _RectifyInputOutput(outputs)
-    operator.input.extend([str(i) for i in inputs])
-    operator.output.extend([str(o) for o in outputs])
+    operator.input.extend(map(str, inputs))
+    operator.output.extend(map(str, outputs))
     if control_input:
         control_input = _RectifyInputOutput(control_input)
-        operator.control_input.extend([str(i) for i in control_input])
+        operator.control_input.extend(map(str, control_input))
     # Set device option:
     # (1) If device_option is explicitly set, use device_option.
     # (2) If not, but scope.CurrentDeviceScope() is set,
@@ -666,7 +666,7 @@ StopGradient. Op:\n\n{}""".format(op.output[0], str(op)))
             # (2) add outputs to the locally generated blobs
             # If an output corresponds to the gradient of an input, we also
             # record it to gradient_generators
-            locally_generated_blobs.extend([str(s) for s in grad_op.output])
+            locally_generated_blobs.extend(map(str, grad_op.output))
             for i, output in enumerate(grad_op.output):
                 input_index = GetIndexFromGradientList(g_input, output)
                 if input_index is not None:

--- a/caffe2/python/functional.py
+++ b/caffe2/python/functional.py
@@ -7,7 +7,6 @@ from caffe2.python import core, workspace
 from caffe2.proto import caffe2_pb2
 from caffe2.python.onnx.workspace import Workspace
 from collections import namedtuple
-from six import string_types
 
 OpSchema = workspace.C.OpSchema
 
@@ -19,7 +18,7 @@ def namedtupledict(typename, field_names, *args, **kwargs):
     data = namedtuple(typename, field_names, *args, **kwargs)
 
     def getitem(self, key):
-        if isinstance(key, string_types):
+        if isinstance(key, str):
             key = field_names_map[key]
         return super(type(self), self).__getitem__(key)
 

--- a/caffe2/python/net_printer.py
+++ b/caffe2/python/net_printer.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from contextlib import contextmanager
 from copy import copy
 from itertools import chain
-from six import binary_type, text_type
 
 
 class Visitor(object):
@@ -192,9 +191,9 @@ class Printer(Visitor, Text):
 
 
 def _sanitize_str(s):
-    if isinstance(s, text_type):
+    if isinstance(s, str):
         sanitized = s
-    elif isinstance(s, binary_type):
+    elif isinstance(s, bytes):
         sanitized = s.decode('ascii', errors='ignore')
     else:
         sanitized = str(s)

--- a/caffe2/python/schema.py
+++ b/caffe2/python/schema.py
@@ -26,7 +26,7 @@ from caffe2.python.core import BlobReference
 from collections import OrderedDict, namedtuple
 from past.builtins import basestring
 from itertools import islice
-from six import StringIO
+from io import StringIO
 from typing import Sequence
 
 logger = logging.getLogger(__name__)

--- a/caffe2/python/trt/test_trt.py
+++ b/caffe2/python/trt/test_trt.py
@@ -21,7 +21,7 @@ import unittest
 import tarfile
 import tempfile
 import shutil
-from six.moves.urllib.request import urlretrieve
+from urllib.request import urlretrieve
 
 def _print_net(net):
     for i in net.external_input:

--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -14,7 +14,6 @@ import collections
 import copy
 import functools
 import numpy as np
-from six import integer_types, binary_type, text_type, string_types
 
 OPTIMIZER_ITERATION_NAME = "optimizer_iteration"
 OPTIMIZER_ITERATION_LR_NAME = "optimizer_iteration_lr"
@@ -30,7 +29,7 @@ def OpAlmostEqual(op_a, op_b, ignore_fields=None):
     if not isinstance(ignore_fields, list):
         ignore_fields = [ignore_fields]
 
-    assert all(isinstance(f, text_type) for f in ignore_fields), (
+    assert all(isinstance(f, str) for f in ignore_fields), (
         'Expect each field is text type, but got {}'.format(ignore_fields))
 
     def clean_op(op):
@@ -145,13 +144,13 @@ def MakeArgument(key, value):
 
     if type(value) is float:
         argument.f = value
-    elif type(value) in integer_types or type(value) is bool:
+    elif type(value) in [bool, int]:
         # We make a relaxation that a boolean variable will also be stored as
         # int.
         argument.i = value
-    elif isinstance(value, binary_type):
+    elif isinstance(value, bytes):
         argument.s = value
-    elif isinstance(value, text_type):
+    elif isinstance(value, str):
         argument.s = value.encode('utf-8')
     elif isinstance(value, caffe2_pb2.NetDef):
         argument.n.CopyFrom(value)
@@ -162,16 +161,16 @@ def MakeArgument(key, value):
             v.item() if type(v) is np.float_ else v for v in value
         )
     elif iterable and all(
-        type(v) in integer_types or type(v) in [bool, np.int_] for v in value
+        type(v) in [bool, int, np.int_] for v in value
     ):
         argument.ints.extend(
             v.item() if type(v) is np.int_ else v for v in value
         )
     elif iterable and all(
-        isinstance(v, binary_type) or isinstance(v, text_type) for v in value
+        isinstance(v, bytes) or isinstance(v, str) for v in value
     ):
         argument.strings.extend(
-            v.encode('utf-8') if isinstance(v, text_type) else v
+            v.encode('utf-8') if isinstance(v, str) else v
             for v in value
         )
     elif iterable and all(isinstance(v, caffe2_pb2.NetDef) for v in value):
@@ -384,7 +383,7 @@ def EnumClassKeyVals(cls):
     for k in dir(cls):
         if k == k.upper():
             v = getattr(cls, k)
-            if isinstance(v, string_types):
+            if isinstance(v, str):
                 assert v not in enum.values(), (
                     "Failed to resolve {} as Enum: "
                     "duplicate entries {}={}, {}={}".format(

--- a/functorch/examples/maml_omniglot/support/omniglot_loaders.py
+++ b/functorch/examples/maml_omniglot/support/omniglot_loaders.py
@@ -82,7 +82,7 @@ class Omniglot(data.Dataset):
             os.path.exists(os.path.join(self.root, self.processed_folder, "images_background"))
 
     def download(self):
-        from six.moves import urllib
+        import urllib
         import zipfile
 
         if self._check_exists():

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ psutil
 pyyaml
 requests
 setuptools
-six
 types-dataclasses
 typing_extensions
 sympy


### PR DESCRIPTION
Mostly `s/string_types/str/` `s/binary_types/bytes/` and `s/text_types/str/`
Also `y.extend([str(x) for x in foo])`->`y.extend(map(str, foo))`
As Python-2 is long dead
