### PR TITLE
[rfc] warning for torch.ao deprecation

### DIFF
--- a/torch/quantization/__init__.py
+++ b/torch/quantization/__init__.py
@@ -10,6 +10,14 @@ from .quantize_jit import *  # noqa: F403
 from .quantization_mappings import *  # noqa: F403
 from .fuser_method_mappings import *  # noqa: F403
 
+import warnings
+warnings.warn(
+    "The `torch.quantization` folder has moved to "
+    "`torch.ao.quantization`, please move your callsite over to the new "
+    "location. `torch.quantization` will be deleted in a future release "
+    "of PyTorch. Please see https://github.com/pytorch/pytorch/issues/81667 "
+    "for more context.")
+
 def default_eval_fn(model, calib_data):
     r"""
     Default evaluation function takes a torch.utils.data.Dataset or a list of


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93963
* #93954

Summary:

Adds a warning when user tries to import `torch.quantization`, asking
them to move their callsite over to `torch.ao.quantization`.

RFC so we can align on the text quickly, once we align we can add the same
warning to all of the other files which were migrated.

Test plan:

```
>>> import torch
>>> import torch.ao.quantization as q1
>>> import torch.quantization as q2
/Users/vasiliy/pytorch/torch/quantization/__init__.py:14: UserWarning: The `torch.quantization` folder has moved to `torch.ao.quantization`, please move your callsite over to the new location. `torch.quantization` will be deleted in a future release of PyTorch. Please see https://github.com/pytorch/pytorch/issues/81667 for more context.
  warnings.warn(
```