### PR TITLE
Fixed issue with --diff-branch arg in dynamo benchmarks

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -13,7 +13,6 @@ import signal
 import subprocess
 import sys
 import time
-import warnings
 from contextlib import contextmanager
 from typing import NamedTuple
 
@@ -313,6 +312,8 @@ def print_summary(filename):
     data = pd.read_csv(filename)
     if "tag" in data.columns:
         for tag in data.tag.unique():
+            if tag == "0.0000":
+                continue  # This happens for failed runs
             print(f"\nSummary for tag={tag}:")
             print_summary_table(data[data.tag == tag])
     else:
@@ -326,21 +327,21 @@ def print_summary_table(data):
             if col in ("dev", "name", "batch_size", "tag"):
                 continue
             elif col in ("pct_ops", "pct_time"):
-                print(col.ljust(width), f"{data[col].mean():.1%}")
+                print(col.ljust(width), f"{data[col].mean():.3%}")
             elif col in ("graphs", "graph_calls", "captured_ops", "total_ops"):
-                print(col.ljust(width), f"{data[col].mean():.1f}")
+                print(col.ljust(width), f"{data[col].mean():.3f}")
             elif col in ("compilation_latency"):
-                print(col.ljust(width), f"mean={data[col].mean():.1f} seconds")
+                print(col.ljust(width), f"mean={data[col].mean():.3f} seconds")
             elif col in ("compression_ratio"):
-                print(col.ljust(width), f"mean={data[col].mean():.1f}x")
+                print(col.ljust(width), f"mean={data[col].mean():.3f}x")
             elif col in ("accuracy"):
                 pass_rate = (data[col] == "pass").mean()
-                print(col.ljust(width), f"pass_rate={100*pass_rate:.1f}%")
+                print(col.ljust(width), f"pass_rate={100*pass_rate:.2f}%")
             else:
                 cdata = data[col].clip(1)
                 print(
                     col.ljust(width),
-                    f"gmean={gmean(cdata):.2f}x mean={cdata.mean():.2f}x",
+                    f"gmean={gmean(cdata):.2f}x mean={cdata.mean():.3f}x",
                 )
         except Exception as e:
             pass
@@ -1415,56 +1416,6 @@ class BenchmarkRunner:
             results.append(experiment(model, example_inputs, **experiment_kwargs))
             return " ".join(map(str, results))
 
-    def compare_branches(
-        self,
-        name,
-        model,
-        example_inputs,
-        optimize_ctx,
-        experiment,
-        explain,
-        comparison_branch=None,
-        branch=None,
-    ):
-        assert branch is None, "Branch set during top level flow."
-        import git
-
-        repo = git.Repo()
-        curr_branch = repo.active_branch.name
-        if curr_branch != comparison_branch:
-            # Run current
-            try:
-                self.run_one_model(
-                    name,
-                    model,
-                    example_inputs,
-                    optimize_ctx,
-                    experiment,
-                    explain=explain,
-                    branch=curr_branch,
-                    tag=curr_branch,
-                )
-                # Run comparison branch
-                repo.git.checkout(comparison_branch)
-                self.run_one_model(
-                    name,
-                    model,
-                    example_inputs,
-                    optimize_ctx,
-                    experiment,
-                    explain=explain,
-                    branch=comparison_branch,
-                    tag=comparison_branch,
-                )
-            finally:
-                # Swap back
-                repo.git.checkout(curr_branch)
-            return
-        else:
-            raise RuntimeError(
-                f"--diff-branch: current branch is same as {comparison_branch} branch, what are you diffing?"
-            )
-
     def run_one_model(
         self,
         name,
@@ -1472,26 +1423,13 @@ class BenchmarkRunner:
         example_inputs,
         optimize_ctx,
         experiment,
-        comparison_branch=None,
-        branch=None,
         explain=False,
         tag=None,
     ):
-        if comparison_branch is not None:
-            self.compare_branches(
-                name,
-                model,
-                example_inputs,
-                optimize_ctx,
-                experiment,
-                comparison_branch=comparison_branch,
-                explain=explain,
-            )
-            return
         mode = "train" if self.args.training else "eval"
         msg = f"{current_device:4} {mode:5} {current_name:34} "
-        if branch:
-            msg += f" {branch:26}"
+        if tag:
+            msg += f" {tag:26}"
         print(msg, end=" ", flush=True)
         start_calls_captured = torch._dynamo.utils.counters["stats"]["calls_captured"]
         start_unique_graphs = torch._dynamo.utils.counters["stats"]["unique_graphs"]
@@ -1527,6 +1465,13 @@ class BenchmarkRunner:
 
 def help(fn):
     return fn.__doc__
+
+
+diff_branch_default = "DIFF-BRANCH-DEFAULT"
+
+
+def should_diff_branch(args):
+    return args.diff_branch != diff_branch_default
 
 
 def parse_args(args=None):
@@ -1738,7 +1683,13 @@ def parse_args(args=None):
     parser.add_argument("--profiler_trace_name", help="Overwrites exported trace name")
 
     parser.add_argument(
-        "--diff-branch", default=None, help="Delta current branch against given branch."
+        "--diff-branch",
+        default=diff_branch_default,
+        help="delta current branch against given branch.",
+    )
+
+    parser.add_argument(
+        "--tag", default=None, help="Specify a tag to be included in csv files."
     )
 
     parser.add_argument(
@@ -1886,7 +1837,7 @@ def main(runner, original_dir=None):
         os.chdir(original_dir)
     args = parse_args()
 
-    if args.diff_branch:
+    if should_diff_branch(args):
         import git
 
         # We do this here so we error out earlier if there's an issue
@@ -1894,6 +1845,11 @@ def main(runner, original_dir=None):
         if repo.is_dirty():
             raise RuntimeError(
                 "--diff-branch called on dirty branch. Commit, stash, or reset."
+            )
+        main_branch = repo.active_branch.name
+        if main_branch == args.diff_branch:
+            raise RuntimeError(
+                f"--diff-branch: current branch is same as {args.diff_branch} branch, what are you diffing?"
             )
 
     with maybe_init_distributed(
@@ -2223,7 +2179,25 @@ def run(runner, args, original_dir=None):
 
     experiment = functools.partial(experiment, args, runner.model_iter_fn)
 
-    if args.only:
+    if args.only and should_diff_branch(args):
+        import git
+
+        repo = git.Repo()
+        main_branch = repo.active_branch.name
+        try:
+            # Adding diff-branch again to the args will override previous value
+            call_args = (
+                [sys.executable] + sys.argv + [f"--diff-branch={diff_branch_default}"]
+            )
+            # Run for main branch
+            subprocess.check_call(call_args + [f"--tag={main_branch}"])
+            # Run for comparison branch
+            repo.git.checkout(args.diff_branch)
+            subprocess.check_call(call_args + [f"--tag={args.diff_branch}"])
+        finally:
+            # Go back to main branch
+            repo.git.checkout(main_branch)
+    elif args.only:
         model_name = args.only
         for device in args.devices:
             batch_size = args.batch_size
@@ -2295,8 +2269,8 @@ def run(runner, args, original_dir=None):
                 example_inputs,
                 optimize_ctx,
                 experiment,
-                comparison_branch=args.diff_branch,
                 explain=args.explain,
+                tag=args.tag,
             )
         if args.generate_aot_autograd_stats:
             stats_file = output_filename.split(".csv")[0] + "_stats.csv"
@@ -2330,8 +2304,11 @@ def run(runner, args, original_dir=None):
                     )
 
             try:
+                timeout = 60 * 20
+                if should_diff_branch(args):
+                    timeout *= 2
                 subprocess.check_call(
-                    [sys.executable] + sys.argv + [f"--only={name}"], timeout=60 * 20
+                    [sys.executable] + sys.argv + [f"--only={name}"], timeout=timeout
                 )
             except subprocess.TimeoutExpired:
                 print("TIMEOUT", file=sys.stderr)
@@ -2377,6 +2354,6 @@ def log_operator_inputs(model, example_inputs, model_iter_fn, name, args):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.WARNING)
-    warnings.filterwarnings("ignore")
-    main()
+    raise RuntimeError(
+        f"You shouldn't run {sys.argv[0]} directly, instead try timm_model.py, torchbench.py or hugginface.py"
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93989

As @peterbell10 pointed out, it was giving incorrect results for `compression_ratio`
and `compression_latency` when you used `--diff-branch`. 

This fixes this by running a separate subprocess for each branch to make sure you are not being affected by run for other branch.

Also added a couple of more significant figures
to numbers in summary table.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire