### PR TITLE
Add a private API banner

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -31,6 +31,16 @@
     {% include "searchbox.html" %}
 {% endblock %}
 
+{%- block content %}
+{{ super() }}
+<script>
+if((window.location.href.indexOf("/_([0-9]+)$/")!= -1))
+  {
+    var div = '<div class="admonition note"><p class="admonition-title">Note</p><p><i class="fa fa-flask" aria-hidden="true">&nbsp</i> This page describes a private API. No support is provided for private APIs.</p></div>'
+    document.getElementById("pytorch-article").insertAdjacentHTML('afterBegin', div)
+  }
+</script>
+{%- endblock %}
 
 {% block footer %}
 {{ super() }}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -35,11 +35,8 @@
 {{ super() }}
 <script>
 
-//const re = new RegExp("/_[a-zA-Z0-9_]*.html")
-//const match = window.location.href.match(re)
-
-var match      = window.location.href.match(/\/_[a-zA-Z0-9_]*.html|_dynamo/gi);
-var url  = window.location.href.lastIndexOf(match[match.length-1]);
+var match = window.location.href.match(/\/_[a-zA-Z0-9_]*.html|_dynamo/gi);
+var url = window.location.href.lastIndexOf(match[match.length-1]);
 
 if (url)
   {

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -34,9 +34,16 @@
 {%- block content %}
 {{ super() }}
 <script>
-if((window.location.href.indexOf("/_([0-9]+)$/")!= -1))
+
+//const re = new RegExp("/_[a-zA-Z0-9_]*.html")
+//const match = window.location.href.match(re)
+
+var match      = window.location.href.match(/\/_[a-zA-Z0-9_]*.html|_dynamo/gi);
+var url  = window.location.href.lastIndexOf(match[match.length-1]);
+
+if (url)
   {
-    var div = '<div class="admonition note"><p class="admonition-title">Note</p><p><i class="fa fa-flask" aria-hidden="true">&nbsp</i> This page describes a private API. No support is provided for private APIs.</p></div>'
+    var div = '<div class="admonition note"><p class="admonition-title">Note</p><p><i class="fa fa-exclamation-circle" aria-hidden="true">&nbsp</i> This page describes a private API. No support is provided for private APIs.</p></div>'
     document.getElementById("pytorch-article").insertAdjacentHTML('afterBegin', div)
   }
 </script>

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -43,7 +43,7 @@ var url  = window.location.href.lastIndexOf(match[match.length-1]);
 
 if (url)
   {
-    var div = '<div class="admonition note"><p class="admonition-title">Note</p><p><i class="fa fa-exclamation-circle" aria-hidden="true">&nbsp</i> This page describes a private API. No support is provided for private APIs.</p></div>'
+    var div = '<div class="admonition note"><p class="admonition-title">Note</p><p><i class="fa fa-exclamation-circle" aria-hidden="true">&nbsp</i> This page describes an internal API which is not intended to be used outside of the PyTorch codebase and can be modified or removed without notice.</p></div>'
     document.getElementById("pytorch-article").insertAdjacentHTML('afterBegin', div)
   }
 </script>


### PR DESCRIPTION
Add a banner that will appear on all pages where the last segment of the URL starts with an underscore "_". 
Example pages: 
* https://pytorch.org/docs/master/_dynamo.html
* https://pytorch.org/docs/master/_modules/torch/_jit_internal.html
Sample screenshots:
<img width="885" alt="Screenshot 2023-02-03 at 1 13 47 PM" src="https://user-images.githubusercontent.com/5317992/216711948-6ba35d38-da8f-4145-9580-bafc921a1df5.png">
<img width="871" alt="Screenshot 2023-02-03 at 1 12 51 PM" src="https://user-images.githubusercontent.com/5317992/216711951-877a760e-3449-4593-b81c-14bf3b9943da.png">



cc @carljparker