### PR TITLE
Remove cuda < 11.6 check in test_jiterator.py

### DIFF
--- a/test/test_jiterator.py
+++ b/test/test_jiterator.py
@@ -8,8 +8,7 @@ from itertools import product
 from torch.testing._internal.common_utils import TestCase, parametrize, run_tests, TEST_CUDA
 from torch.testing._internal.common_dtype import all_types_and_complex_and
 from torch.testing._internal.common_device_type import (
-    skipCUDAIfRocm, skipCUDAIf, instantiate_device_type_tests, dtypes, toleranceOverride, tol)
-from torch.testing._internal.common_cuda import _get_torch_cuda_version
+    skipCUDAIfRocm, instantiate_device_type_tests, dtypes, toleranceOverride, tol)
 
 if not TEST_CUDA:
     print('CUDA not available, skipping tests', file=sys.stderr)

--- a/test/test_jiterator.py
+++ b/test/test_jiterator.py
@@ -41,9 +41,6 @@ class TestPythonJiterator(TestCase):
         self.assertEqual(expected, result)
 
     @skipCUDAIfRocm
-    # See https://github.com/pytorch/pytorch/pull/76394#issuecomment-1118018287 for details
-    @skipCUDAIf(_get_torch_cuda_version() < (11, 6), "On cuda 11.3, nvrtcCompileProgram is taking too long to "
-                "compile jiterator generated kernels for non-contiguous input that requires dynamic-casting.")
     @parametrize("shape_strides", [
         (([3, 3], [1, 3]), ([3, 1], [1, 3])),  # non-contiguous
     ])


### PR DESCRIPTION
Remove cuda < 11.6 check in test_jiterator.py. CUDA 11.6 has been deprecated from CI and nightly

cc @mruberry @ngimel