### PR TITLE
link cpp inductor backend code to torchdeploy when inside deploy/multipy interpreter

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -392,6 +392,14 @@ def get_include_and_linking_paths(
         ipaths = cpp_extension.include_paths() + [sysconfig.get_path("include")]
         lpaths = cpp_extension.library_paths() + [sysconfig.get_config_var("LIBDIR")]
         libs = ["c10", "torch", "torch_cpu", "torch_python", "gomp"]
+
+       try:
+            if sys.using_multipy_interpreter:
+                log.info("Using torchdeploy/multipy")
+                libs.append("torch_deploy")
+        except:
+            pass
+
         macros = vec_isa.build_macro()
         if macros:
             macros = f"-D{macros}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #94324
* __->__ #94007



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire