### PR TITLE
[SDPA] Add expanded autograd testing for fused kernels and disable head_dim128 sm86 mem-efficient

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -350,6 +350,21 @@ inline bool check_gpu_sm50_or_greater(sdp_params params, bool debug) {
   return true;
 }
 
+inline bool check_gpu_sm86_head_dim_128(sdp_params params, bool debug) {
+  // Memory Efficient Attention is throwing a cuda illegal memory error
+  // on sm86 when head_dim is 128.
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+  bool is_sm86 = (dprops->major == 8) && (dprops->minor == 6);
+  if (is_sm86 && (params.query.size(-1) == 128)) {
+    if (debug) {
+      TORCH_WARN(
+        "Memory Efficient Attention is throwing a cuda illegal memory error on sm86 when head_dim is 128.");
+    }
+    return false;
+  }
+  return true;
+}
+
 inline bool check_use_deterministic_algorithms(sdp_params params, bool debug) {
   auto& ctx = at::globalContext();
   if (ctx.deterministicAlgorithms()) {
@@ -411,13 +426,14 @@ inline bool use_mem_efficient_attention(sdp_params params, bool debug) {
       at::kHalf, at::kFloat, at::kBFloat16};
 
   //  Define gate functions that determine if a flash kernel can be ran
-  constexpr std::array<bool(*)(sdp_params, bool), 9> constraints{{
+  constexpr std::array<bool(*)(sdp_params, bool), 10> constraints{{
       check_gpu_sm50_or_greater,
       check_runtime_disabled_mem_efficient,
       check_requires_grad_and_nested,
       check_tensor_shapes,
       check_for_attn_mask,
       check_head_dim_size_mem_efficient,
+      check_gpu_sm86_head_dim_128,
       check_for_seq_len_1_nested_tensor,
       check_for_non_zero_dropout,
       check_use_deterministic_algorithms}};

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -358,7 +358,8 @@ inline bool check_gpu_sm86_head_dim_128(sdp_params params, bool debug) {
   if (is_sm86 && (params.query.size(-1) == 128)) {
     if (debug) {
       TORCH_WARN(
-        "Memory Efficient Attention is throwing a cuda illegal memory error on sm86 when head_dim is 128.");
+        "Memory Efficient Attention does not currently support head_dim == 128 on sm86",
+        "because it is throwing a cuda illegal memory error on sm86 when head_dim is 128.");
     }
     return false;
   }

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1473,6 +1473,13 @@ class TestSDPA(NNTestCase):
         device = 'cuda'
         dtype = torch.float16
         make_tensor = partial(self.rand_tensor, type="dense", device=device, dtype=dtype)
+        if isSM86Device:
+            # See check_gpu_sm86_head_dim_128 in pytorch/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+            size = (2, 2, 4, 128)
+            q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
+            with sdp_kernel(enable_mem_efficient=True, enable_flash=False, enable_math=False):
+                self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
+                    q, k, v, None, 0.0, False))
 
         with sdp_kernel(enable_flash=False, enable_math=False, enable_mem_efficient=False):
             size = (2, 3, 4)
@@ -1483,13 +1490,6 @@ class TestSDPA(NNTestCase):
                                    lambda: torch._fused_sdp_choice(q, k, v))
             self.assertRaisesRegex(RuntimeError, "No viable backend for scaled_dot_product_attention was found.",
                                    lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v))
-        if isSM86Device:
-            with sdp_kernel(enable_mem_efficient=True, enable_flash=False, enable_math=False):
-                # See check_gpu_sm86_head_dim_128 in pytorch/aten/src/ATen/native/transformers/cuda/sdp_utils.h
-                size = (2, 2, 4, 128)
-                q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
-                self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
-                    q, k, v, None, 0.0, False))
 
         if SM80OrLater:
             with sdp_kernel(enable_flash=True, enable_mem_efficient=False, enable_math=False):


### PR DESCRIPTION
# Summary
- Adds a large parameter sweep for testing the various configs a user can call sdpa with and compares the deviation of the fused kernels vs the eager math fallback to test for correctness.
- Sm86 + head_dim==128 is throwing an IMA  for memory efficient attention. We add a filter for use_mem_efficient_attention().  This has since been fixed in the upstream Xformers version but will likely not make it for branch cut.