### PR TITLE
Silence profiler error

### DIFF
--- a/torch/profiler/_pattern_matcher.py
+++ b/torch/profiler/_pattern_matcher.py
@@ -413,6 +413,14 @@ class SynchronizedDataLoaderPattern(Pattern):
                 os.path.join("torch", "utils", "data",
                              "dataloader.py")) and name.endswith(function_name)
 
+        # TODO: fixme! Due to lifetime issues of the function name, this field might
+        # actually point to an already freed string when the even is a PyCall.
+        # Just silently skip this to unblock testing.
+        try:
+            event.name
+        except UnicodeDecodeError:
+            return False
+
         if not is_dataloader_function(event.name, "__iter__"):
             return False
         if not event.children:


### PR DESCRIPTION
This is not 3.11 specific but a lot more likely in 3.11 I guess
You can find other reports at https://github.com/pytorch/pytorch/issues/64345 as well for it failing in 3.8