### PR TITLE
[pytorch] [hygiene] remove legacy buck rules

### DIFF
--- a/c10/BUILD.bazel
+++ b/c10/BUILD.bazel
@@ -40,7 +40,7 @@ cc_library(
     deps = [
         "//c10/core:alignment",
         "//c10/cuda:Macros",
-        "//c10/macros",
+        "//c10/macros:macros",
     ] + select({
         ":using_gflags": ["@com_github_gflags_gflags//:gflags"],
         "//conditions:default": [],

--- a/c10/build.bzl
+++ b/c10/build.bzl
@@ -7,7 +7,7 @@ def define_targets(rules):
             "//c10/core:alignment",
             "//c10/core:alloc_cpu",
             "//c10/core:base",
-            "//c10/macros",
+            "//c10/macros:macros",
             "//c10/mobile:CPUCachingAllocator",
             "//c10/mobile:CPUProfilingAllocator",
             "//c10/util:TypeCast",
@@ -15,7 +15,7 @@ def define_targets(rules):
             "//c10/util:typeid",
         ] + rules.if_cuda(
             [
-                "//c10/cuda",
+                "//c10/cuda:cuda",
                 "//c10/cuda:Macros",
             ],
             [],

--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -47,7 +47,7 @@ def define_targets(rules):
         visibility = ["//visibility:public"],
         deps = [
             ":alignment",
-            "//c10/macros",
+            "//c10/macros:macros",
             "//c10/util:base",
         ],
     )
@@ -82,7 +82,7 @@ def define_targets(rules):
         visibility = ["//visibility:public"],
         deps = [
             ":ScalarType",
-            "//c10/macros",
+            "//c10/macros:macros",
             "//c10/util:TypeCast",
             "//c10/util:base",
             "//c10/util:typeid",

--- a/c10/cuda/build.bzl
+++ b/c10/cuda/build.bzl
@@ -30,7 +30,7 @@ def define_targets(rules):
             ":Macros",
             "@cuda",
             "//c10/core:base",
-            "//c10/macros",
+            "//c10/macros:macros",
             "//c10/util:base",
         ],
         target_compatible_with = rules.requires_cuda_enabled(),

--- a/c10/cuda/test/build.bzl
+++ b/c10/cuda/test/build.bzl
@@ -16,7 +16,7 @@ def define_targets(rules):
         ],
         deps = [
             "@com_google_googletest//:gtest_main",
-            "//c10/cuda",
+            "//c10/cuda:cuda",
         ],
         target_compatible_with = rules.requires_cuda_enabled(),
     )
@@ -30,7 +30,7 @@ def define_targets(rules):
             ],
             deps = [
                 "@com_google_googletest//:gtest_main",
-                "//c10/cuda",
+                "//c10/cuda:cuda",
             ],
             target_compatible_with = rules.requires_cuda_enabled(),
         )

--- a/c10/test/build.bzl
+++ b/c10/test/build.bzl
@@ -47,7 +47,7 @@ def define_targets(rules):
             ":complex_math_test_common",
             ":complex_test_common",
             "@com_google_googletest//:gtest_main",
-            "//c10/macros",
+            "//c10/macros:macros",
             "//c10/util:base",
         ],
     )
@@ -74,7 +74,7 @@ def define_targets(rules):
         hdrs = ["util/complex_test_common.h"],
         deps = [
             "@com_google_googletest//:gtest",
-            "//c10/macros",
+            "//c10/macros:macros",
             "//c10/util:base",
         ],
         testonly = True,

--- a/c10/util/build.bzl
+++ b/c10/util/build.bzl
@@ -9,7 +9,7 @@ def define_targets(rules):
         deps = [
             ":base",
             "//c10/core:ScalarType",
-            "//c10/macros",
+            "//c10/macros:macros",
         ],
     )
 
@@ -37,7 +37,7 @@ def define_targets(rules):
         visibility = ["//visibility:public"],
         deps = [
             "@fmt",
-            "//c10/macros",
+            "//c10/macros:macros",
         ] + rules.select({
             "//c10:using_gflags": ["@com_github_gflags_gflags//:gflags"],
             "//conditions:default": [],
@@ -57,7 +57,7 @@ def define_targets(rules):
         deps = [
             ":base",
             "//c10/core:ScalarType",
-            "//c10/macros",
+            "//c10/macros:macros",
         ],
     )
 


### PR DESCRIPTION
Summary:
Removes legacy buck rules specifically we do the following conversions
- ["xxx:=yyy"] -> ["xxx[yyy]"]
- "//xxx/yyy" - "//xxx/yyy:yyy"

Test Plan: CI should pass

Differential Revision: D42999413

