### PR TITLE
`FusedAdam(W)` should take `OptState` into account before unscaling grads

### DIFF
--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -353,7 +353,7 @@ class GradScaler(object):
                         t.to(scaler.device, non_blocking=True) for t in self._check_inf_per_device(optimizer).values()
                     ])
                 )
-                optimizer.grad_scale = scaler
+                optimizer.grad_scale = None if optimizer_state["stage"] == OptState.UNSCALED else scaler
                 optimizer.found_inf = found_inf
             retval = optimizer.step(*args, **kwargs_)
             optimizer_state["stage"] = OptState.STEPPED


### PR DESCRIPTION
the optimizers have to consult `OptState` before unscaling gradients because we could call `GradScaler.unscale_` explicitly to for e.g. `clip_grad_norm_` as mentioned in https://github.com/pytorch/pytorch/blob/e52786f3d177a7ca5d490a516cf52e236ef072cb/torch/cuda/amp/grad_scaler.py#L235-L266 and https://pytorch.org/docs/stable/notes/amp_examples.html#working-with-unscaled-gradients

Related #90752
