### PR TITLE
[dynamo] enable export to preserve meaningful module attr name.

### DIFF
--- a/test/fx/test_makefx_preseve_attr_names.py
+++ b/test/fx/test_makefx_preseve_attr_names.py
@@ -1,0 +1,72 @@
+# Owner(s): ["module: fx"]
+
+import torch
+import itertools
+import inspect
+import functools
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing._internal.common_utils import (
+    TestCase, parametrize, instantiate_parametrized_tests, run_tests)
+
+class NestedModuleL2(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("running_mean", torch.zeros(3,))
+        self.register_buffer("running_var", torch.zeros(3,))
+        self.weight = torch.nn.Parameter(torch.zeros(3), requires_grad=True)
+        self.li = torch.nn.Linear(3, 3)
+
+    def forward(self, input):
+        a = self.li(self.weight)
+        return torch.batch_norm(input, a, None, self.running_mean,
+                                self.running_var, False, 0.1, 1e-5, False)[0].cos()
+
+class NestedModuleL1(torch.nn.Module):
+    def __init__(self, my_mod):
+        super().__init__()
+        self.mod = my_mod
+        self.weight = torch.nn.Parameter(torch.ones(1), requires_grad=True)
+
+    def forward(self, input):
+        return self.mod(input) + self.weight + 1
+
+
+mod = NestedModuleL1(NestedModuleL2())
+mod1 = NestedModuleL2()
+@functools.wraps(mod)
+def mod_wrapped_in_func(*args, **kwargs):
+    return mod(*args, **kwargs)
+
+callables = [mod, mod1, mod_wrapped_in_func]
+tracing_modes = ["real", "fake", "symbolic"]
+inputs = [torch.randn(2, 3, 1, 2), ]
+
+
+def name_fn(callable, tracing_mode, input):
+    """Names parameterized test cases"""
+    return f'{type(callable).__name__}_{tracing_mode}_mode'
+
+@instantiate_parametrized_tests
+class TestMakefxPreserveModAttrNames(TestCase):
+
+    @parametrize("callable,tracing_mode,input", itertools.product(callables, tracing_modes, inputs), name_fn)
+    def test_makefx_preserve_mod_attr_names(self, callable, tracing_mode, input):
+        def get_attr(m, fully_qualified_access_path):
+            obj = m
+            for key in fully_qualified_access_path.split("."):
+                obj = getattr(obj, key)
+            return obj
+
+        # Get the nn.Module wrapped in function
+        wrapped_m = inspect.unwrap(callable)
+        self.assertTrue(isinstance(wrapped_m, torch.nn.Module))
+
+        wrapped_m_params_and_buffers = {**dict(wrapped_m.named_parameters()), **dict(wrapped_m.named_buffers())}
+        gm = make_fx(callable, None, tracing_mode, _allow_non_fake_inputs=True)(input)
+
+        # Check attrs' access path in wrapped_m is valid for make_fx's output graph module
+        for access_path, value in wrapped_m_params_and_buffers.items():
+            self.assertTrue(value is get_attr(gm, access_path))
+
+if __name__ == '__main__':
+    run_tests()

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -637,6 +637,7 @@ def export(
 
     if aten_graph:
         # Running graph with interpreter is needed for propagating the stack_trace
+        @functools.wraps(graph)
         def graph_with_interpreter(*args):
             with torch.fx.traceback.preserve_node_meta():
                 return torch.fx.Interpreter(graph).run(*args)

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -459,6 +459,8 @@ def wrap_key(f, tensors, tracer):
     def wrapped(*proxies):
         flat_proxies, proxies_spec = pytree.tree_flatten(proxies)
         if len(flat_proxies) == len(flat_tensors) + 1:
+            # When f is a wrapper for a torch.nn.Module, the wrapped module will
+            # be passed as flat_proxies[0]. We discard it here and only wraps the inputs
             assert isinstance(flat_proxies[0], torch.nn.Module)
             flat_proxies = flat_proxies[1:]
         assert len(flat_proxies) == len(flat_tensors)


### PR DESCRIPTION
Fixes #94061 

For the code below:

```python
import torch
import torch.nn as nn
import torch._dynamo as torchdynamo
from torch.fx.experimental.proxy_tensor import make_fx

class MyMod(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.register_buffer("running_mean", torch.zeros(3,))
        self.register_buffer("running_var", torch.zeros(3,))
        self.weight = nn.Parameter(torch.zeros(3), requires_grad=True)
        self.li = nn.Linear(3, 3)


    def forward(self, input):
        return torch.batch_norm(input, self.li(self.weight), None, self.running_mean, self.running_var, False, 0.1, 1e-5, False)[0].cos()

class Wrapper(torch.nn.Module):
    def __init__(self, my_mod):
        super().__init__()
        self.mod = my_mod
        self.weight = nn.Parameter(torch.ones(1), requires_grad=True)
    
    def forward(self, input):
        return self.mod(input) + self.weight + 1

m = MyMod()
m = Wrapper(m)
m.eval()
input = torch.randn(2, 3, 1, 2)

print("before export\n", m)
em, _ = torchdynamo.export(m, input, aten_graph=True, tracing_mode="symbolic")
print("dynamo export graph module:\n", em)
gm = make_fx(m, None, "symbolic", True)(input)
print("make_fx graph_module\n", gm)
```

**make_fx before and after the pr:**
```python
# Previous:
make_fx graph_module
 <lambda>()

def forward(self, arg0_1):
    _param_constant0 = self._param_constant0
    t = torch.ops.aten.t.default(_param_constant0);  _param_constant0 = None
    _param_constant1 = self._param_constant1
    unsqueeze = torch.ops.aten.unsqueeze.default(_param_constant1, 0);  _param_constant1 = None
    mm = torch.ops.aten.mm.default(unsqueeze, t);  unsqueeze = t = None
    squeeze = torch.ops.aten.squeeze.dim(mm, 0);  mm = None
    _param_constant2 = self._param_constant2
    add = torch.ops.aten.add.Tensor(squeeze, _param_constant2);  squeeze = _param_constant2 = None
    empty = torch.ops.aten.empty.memory_format([0], dtype = torch.uint8, layout = torch.strided, device = device(type='cpu'))
    _tensor_constant0 = self._tensor_constant0
    _tensor_constant1 = self._tensor_constant1
    _native_batch_norm_legit = torch.ops.aten._native_batch_norm_legit.default(arg0_1, add, None, _tensor_constant0, _tensor_constant1, False, 0.1, 1e-05);  arg0_1 = add = _tensor_constant0 = _tensor_constant1 = None
    getitem = _native_batch_norm_legit[0]
    getitem_1 = _native_batch_norm_legit[1]
    getitem_2 = _native_batch_norm_legit[2];  _native_batch_norm_legit = None
    select = torch.ops.aten.select.int(getitem, 0, 0);  getitem = None
    cos = torch.ops.aten.cos.default(select);  select = None
    _param_constant3 = self._param_constant3
    add_1 = torch.ops.aten.add.Tensor(cos, _param_constant3);  cos = _param_constant3 = None
    add_2 = torch.ops.aten.add.Tensor(add_1, 1);  add_1 = None
    return add_2

# After:
make_fx graph_module
 wrapped(
  (mod): Module(
    (li): Module()
  )
)

def forward(self, input_1):
    mod_li_weight = self.mod.li.weight
    t = torch.ops.aten.t.default(mod_li_weight);  mod_li_weight = None
    mod_weight = self.mod.weight
    unsqueeze = torch.ops.aten.unsqueeze.default(mod_weight, 0);  mod_weight = None
    mm = torch.ops.aten.mm.default(unsqueeze, t);  unsqueeze = t = None
    squeeze = torch.ops.aten.squeeze.dim(mm, 0);  mm = None
    mod_li_bias = self.mod.li.bias
    add = torch.ops.aten.add.Tensor(squeeze, mod_li_bias);  squeeze = mod_li_bias = None
    empty = torch.ops.aten.empty.memory_format([0], dtype = torch.uint8, layout = torch.strided, device = device(type='cpu'))
    mod_running_mean = self.mod.running_mean
    mod_running_var = self.mod.running_var
    _native_batch_norm_legit = torch.ops.aten._native_batch_norm_legit.default(input_1, add, None, mod_running_mean, mod_running_var, False, 0.1, 1e-05);  input_1 = add = mod_running_mean = mod_running_var = None
    getitem = _native_batch_norm_legit[0]
    getitem_1 = _native_batch_norm_legit[1]
    getitem_2 = _native_batch_norm_legit[2];  _native_batch_norm_legit = None
    select = torch.ops.aten.select.int(getitem, 0, 0);  getitem = None
    cos = torch.ops.aten.cos.default(select);  select = None
    weight = self.weight
    add_1 = torch.ops.aten.add.Tensor(cos, weight);  cos = weight = None
    add_2 = torch.ops.aten.add.Tensor(add_1, 1);  add_1 = None
    return add_2
```

**Dynamo output  after the pr:**
```python
# Previous:
dynamo export graph module:
 GraphModule()

def forward(self, orig_arg_0):
    arg0, = fx_pytree.tree_flatten_spec(([orig_arg_0], {}), self._in_spec)
    _param_constant0 = self._param_constant0
    t_default = torch.ops.aten.t.default(_param_constant0);  _param_constant0 = None
    _param_constant1 = self._param_constant1
    unsqueeze_default = torch.ops.aten.unsqueeze.default(_param_constant1, 0);  _param_constant1 = None
    mm_default = torch.ops.aten.mm.default(unsqueeze_default, t_default);  unsqueeze_default = t_default = None
    squeeze_dim = torch.ops.aten.squeeze.dim(mm_default, 0);  mm_default = None
    _param_constant2 = self._param_constant2
    add_tensor = torch.ops.aten.add.Tensor(squeeze_dim, _param_constant2);  squeeze_dim = _param_constant2 = None
    empty_memory_format = torch.ops.aten.empty.memory_format([0], dtype = torch.uint8, layout = torch.strided, device = device(type='cpu'))
    _tensor_constant0 = self._tensor_constant0
    _tensor_constant1 = self._tensor_constant1
    _native_batch_norm_legit_default = torch.ops.aten._native_batch_norm_legit.default(arg0, add_tensor, None, _tensor_constant0, _tensor_constant1, False, 0.1, 1e-05);  arg0 = add_tensor = _tensor_constant0 = _tensor_constant1 = None
    getitem = _native_batch_norm_legit_default[0]
    getitem_1 = _native_batch_norm_legit_default[1]
    getitem_2 = _native_batch_norm_legit_default[2];  _native_batch_norm_legit_default = None
    select_int = torch.ops.aten.select.int(getitem, 0, 0);  getitem = None
    cos_default = torch.ops.aten.cos.default(select_int);  select_int = None
    _param_constant3 = self._param_constant3
    add_tensor_1 = torch.ops.aten.add.Tensor(cos_default, _param_constant3);  cos_default = _param_constant3 = None
    add_tensor_2 = torch.ops.aten.add.Tensor(add_tensor_1, 1);  add_tensor_1 = None
    return pytree.tree_unflatten([add_tensor_2], self._out_spec)


# After:
dynamo export graph module:
 GraphModule(
  (self_mod_li): Module()
)

def forward(self, orig_arg_0):
    arg0, = fx_pytree.tree_flatten_spec(([orig_arg_0], {}), self._in_spec)
    self_mod_li_weight = self.self_mod_li.weight
    t_default = torch.ops.aten.t.default(self_mod_li_weight);  self_mod_li_weight = None
    self_mod_weight = self.self_mod_weight
    unsqueeze_default = torch.ops.aten.unsqueeze.default(self_mod_weight, 0);  self_mod_weight = None
    mm_default = torch.ops.aten.mm.default(unsqueeze_default, t_default);  unsqueeze_default = t_default = None
    squeeze_dim = torch.ops.aten.squeeze.dim(mm_default, 0);  mm_default = None
    self_mod_li_bias = self.self_mod_li.bias
    add_tensor = torch.ops.aten.add.Tensor(squeeze_dim, self_mod_li_bias);  squeeze_dim = self_mod_li_bias = None
    empty_memory_format = torch.ops.aten.empty.memory_format([0], dtype = torch.uint8, layout = torch.strided, device = device(type='cpu'))
    self_mod_running_mean = self.self_mod_running_mean
    self_mod_running_var = self.self_mod_running_var
    _native_batch_norm_legit_default = torch.ops.aten._native_batch_norm_legit.default(arg0, add_tensor, None, self_mod_running_mean, self_mod_running_var, False, 0.1, 1e-05);  arg0 = add_tensor = self_mod_running_mean = self_mod_running_var = None
    getitem = _native_batch_norm_legit_default[0]
    getitem_1 = _native_batch_norm_legit_default[1]
    getitem_2 = _native_batch_norm_legit_default[2];  _native_batch_norm_legit_default = None
    select_int = torch.ops.aten.select.int(getitem, 0, 0);  getitem = None
    cos_default = torch.ops.aten.cos.default(select_int);  select_int = None
    self_weight = self.self_weight
    add_tensor_1 = torch.ops.aten.add.Tensor(cos_default, self_weight);  cos_default = self_weight = None
    add_tensor_2 = torch.ops.aten.add.Tensor(add_tensor_1, 1);  add_tensor_1 = None
    return pytree.tree_unflatten([add_tensor_2], self._out_spec)



```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire