### PR TITLE
[c10d] Update get_backend() in exception_handler

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1426,7 +1426,7 @@ def exception_handler(func):
                     "func_name": f"{func.__name__}",
                     "args": f"{args}, {kwargs}",
                     "backend": f"{get_backend(kwargs.get('group'))}",
-                    "world_size": f"{get_world_size()}",
+                    "world_size": f"{get_world_size(kwargs.get('group'))}",
                     "global_rank": f"{get_rank()}",
                     "local_rank": f"{get_rank(kwargs.get('group'))}",
                     "error": f"{error}",

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1425,7 +1425,7 @@ def exception_handler(func):
                 error_msg_dict = {
                     "func_name": f"{func.__name__}",
                     "args": f"{args}, {kwargs}",
-                    "backend": f"{get_backend()}",
+                    "backend": f"{get_backend(kwargs.get('group'))}",
                     "world_size": f"{get_world_size()}",
                     "global_rank": f"{get_rank()}",
                     "local_rank": f"{get_rank(kwargs.get('group'))}",


### PR DESCRIPTION
Currently, get_backend() and get_world_size() would always return the default value if no pg group argument is passed. This fixes the issue. 
 