### PR TITLE
Prevent duplicate symbol for dsa_add_new_assertion_failure

### DIFF
--- a/c10/cuda/CUDADeviceAssertion.h
+++ b/c10/cuda/CUDADeviceAssertion.h
@@ -18,7 +18,7 @@ static __device__ void dstrcpy(char* dst, const char* src) {
   *dst = '\0';
 }
 
-__device__ void dsa_add_new_assertion_failure(
+static __device__ void dsa_add_new_assertion_failure(
     DeviceAssertionsData* assertions_data,
     const char* assertion_msg,
     const char* filename,


### PR DESCRIPTION
`dsa_add_new_assertion_failure` is currently causing duplicate definition issues. Possible solutions:
1. Put the device code in a .cu file - requires device linking, which would be very painful to get setup.
2. inline the code - could cause bloat, especially since a function might include many DSAs.
3. Anonymous namespace - balances the above two. Putting the code in a .cu file would ensure that there's a single copy of the function, but it's hard to setup. Inlining the code would cause bloat. An anonymous namespace is easy to setup and produces a single copy of the function per translation unit, which allows the function to be called many times without bloat.

Differential Revision: D42998295

