### PR TITLE
Enable retry support for MPS tests

### DIFF
--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -74,12 +74,13 @@ jobs:
         id: test
         env:
           ENV_NAME: conda-test-env-${{ github.run_id }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PYTORCH_RETRY_TEST_CASES: 1
+          PYTORCH_OVERRIDE_FLAKY_SIGNAL: 1
         shell: arch -arch arm64 bash {0}
         run: |
           # shellcheck disable=SC1090
           set -ex
-          # TODO(https://github.com/pytorch/pytorch/issues/79293)
-
           ${CONDA_RUN} python3 test/run_test.py --mps --verbose
 
       - name: Print remaining test logs


### PR DESCRIPTION
Here is an example https://hud.pytorch.org/pytorch/pytorch/commit/d7c71a95b68dfd3b126acd021e05b18b5fa38f03 where the MPS test was flaky but not retried.  Thus it failed.  We probably would want to support retry on MPS tests like the rest of the CI