### PR TITLE
Point to scatter_reduce for reduce argument in scatter_ docs

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4274,6 +4274,8 @@ is updated as::
 Reducing with the addition operation is the same as using
 :meth:`~torch.Tensor.scatter_add_`.
 
+For more reduction options, one might prefer :meth:`~torch.Tensor.scatter_reduce_`.
+
 Args:
     dim (int): the axis along which to index
     index (LongTensor): the indices of elements to scatter, can be either empty


### PR DESCRIPTION
Fix in response to https://github.com/pytorch/pytorch/issues/22378#issuecomment-1411636451
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #94081

