### PR TITLE
Fix Win+CUDA builds using VS2017

### DIFF
--- a/aten/src/ATen/native/cuda/AbsKernel.cu
+++ b/aten/src/ATen/native/cuda/AbsKernel.cu
@@ -15,7 +15,7 @@ struct AbsFunctor {
   }
 };
 
-constexpr char abs_name[] = "abs_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char abs_name[] = "abs_kernel";
 void abs_kernel_cuda(TensorIteratorBase& iter) {
   auto dtype = iter.dtype();
   if (at::isComplexType(dtype)) {

--- a/aten/src/ATen/native/cuda/BinaryDivTrueKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryDivTrueKernel.cu
@@ -16,7 +16,7 @@
 namespace at::native {
 namespace binary_internal {
 
-constexpr char div_name[] = "div_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char div_name[] = "div_kernel";
 void div_true_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (iter.common_dtype() == kComplexHalf) {

--- a/aten/src/ATen/native/cuda/BinaryLogicalOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryLogicalOpsKernels.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char logical_and_name[] = "logical_and_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char logical_and_name[] = "logical_and_kernel";
 void logical_and_kernel_cuda(TensorIterator& iter) {
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {
@@ -48,7 +48,7 @@ void logical_and_kernel_cuda(TensorIterator& iter) {
   }
 }
 
-constexpr char logical_or_name[] = "logical_or_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char logical_or_name[] = "logical_or_kernel";
 void logical_or_kernel_cuda(TensorIterator& iter) {
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {
@@ -84,7 +84,7 @@ void logical_or_kernel_cuda(TensorIterator& iter) {
   }
 }
 
-constexpr char logical_xor_name[] = "logical_xor_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char logical_xor_name[] = "logical_xor_kernel";
 void logical_xor_kernel_cuda(TensorIterator& iter) {
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {

--- a/aten/src/ATen/native/cuda/BinaryMiscBackwardOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscBackwardOpsKernels.cu
@@ -15,7 +15,7 @@
 
 namespace at::native {
 
-constexpr char sigmoid_backward_name[] = "sigmoid_backward";
+CONSTEXPR_EXCEPT_WIN_CUDA char sigmoid_backward_name[] = "sigmoid_backward";
 void sigmoid_backward_kernel_cuda(TensorIteratorBase& iter) {
   auto dtype = iter.dtype();
   if(isComplexType(dtype)) {
@@ -86,7 +86,7 @@ void logit_backward_kernel_cuda(TensorIteratorBase& iter, const Scalar& eps_scal
       });
 }
 
-constexpr char tanh_backward_name[] = "tanh_backward";
+CONSTEXPR_EXCEPT_WIN_CUDA char tanh_backward_name[] = "tanh_backward";
 void tanh_backward_kernel_cuda(TensorIteratorBase& iter) {
   auto dtype = iter.dtype();
   if(isComplexType(dtype)) {

--- a/aten/src/ATen/native/cuda/BinaryMulKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulKernel.cu
@@ -18,7 +18,7 @@
 
 namespace at::native {
 
-constexpr char mul_name[] = "mul_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char mul_name[] = "mul_kernel";
 void mul_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (common_dtype == kComplexHalf) {

--- a/aten/src/ATen/native/cuda/GcdLcmKernel.cu
+++ b/aten/src/ATen/native/cuda/GcdLcmKernel.cu
@@ -14,7 +14,7 @@
 namespace at::native {
 
 // See note [Jiterator]
-constexpr char gcd_name[] = "gcd";
+CONSTEXPR_EXCEPT_WIN_CUDA char gcd_name[] = "gcd";
 void gcd_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "gcd_cuda", [&]() {
@@ -33,7 +33,7 @@ void gcd_kernel_cuda(TensorIteratorBase& iter) {
 }
 
 // See note [Jiterator]
-constexpr char lcm_name[] = "lcm";
+CONSTEXPR_EXCEPT_WIN_CUDA char lcm_name[] = "lcm";
 void lcm_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "lcm_cuda", [&]() {

--- a/aten/src/ATen/native/cuda/Lerp.cu
+++ b/aten/src/ATen/native/cuda/Lerp.cu
@@ -9,7 +9,7 @@
 namespace at::native {
 namespace {
 
-constexpr char lerp_tensor_name[] = "lerp_tensor";
+CONSTEXPR_EXCEPT_WIN_CUDA char lerp_tensor_name[] = "lerp_tensor";
 void lerp_tensor_kernel(at::TensorIteratorBase& iter) {
   auto dtype = iter.common_dtype();
   if(at::isComplexType(dtype)) {
@@ -63,7 +63,7 @@ void lerp_tensor_kernel(at::TensorIteratorBase& iter) {
   }
 }
 
-constexpr char lerp_scalar_name[] = "lerp_scalar";
+CONSTEXPR_EXCEPT_WIN_CUDA char lerp_scalar_name[] = "lerp_scalar";
 void lerp_scalar_kernel(at::TensorIteratorBase& iter, const c10::Scalar& weight) {
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {

--- a/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/PointwiseOpsKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char addcmul_name[] = "addcmul";
+CONSTEXPR_EXCEPT_WIN_CUDA char addcmul_name[] = "addcmul";
 void addcmul_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {
@@ -56,7 +56,7 @@ void addcmul_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
 }
 
 // return a + alpha * (b / static_cast<accscalar_t>(c));
-constexpr char addcdiv_name[] = "addcdiv";
+CONSTEXPR_EXCEPT_WIN_CUDA char addcdiv_name[] = "addcdiv";
 void addcdiv_cuda_kernel(TensorIteratorBase& iter, const Scalar& value) {
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {

--- a/aten/src/ATen/native/cuda/PowKernel.cu
+++ b/aten/src/ATen/native/cuda/PowKernel.cu
@@ -38,7 +38,7 @@ void pow_scalar_tensor_impl(TensorIteratorBase& iter, c10::complex<value_t> base
 }
 
 /* complex<Half> support impl */
-constexpr char pow_scalar_base_name[] = "pow_scalar_base_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char pow_scalar_base_name[] = "pow_scalar_base_kernel";
 template <>
 void pow_scalar_tensor_impl(TensorIteratorBase& iter, c10::complex<at::Half> base) {
   using scalar_t = c10::complex<at::Half>;
@@ -68,7 +68,7 @@ namespace {
 
 #if AT_USE_JITERATOR()
 /* complex<Half> support impl */
-constexpr char pow_name[] = "pow_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char pow_name[] = "pow_kernel";
 static const auto pow_kernel_string =
     jiterator_stringify(template <typename T> T pow_kernel(T base, T exp) {
       return std::pow(base, exp);

--- a/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceSumProdKernel.cu
@@ -21,7 +21,7 @@ struct sum_functor {
 };
 
 // jiterated specialization for `complex<Half>`
-constexpr char sum_name[] = "sum";
+CONSTEXPR_EXCEPT_WIN_CUDA char sum_name[] = "sum";
 template <>
 struct sum_functor<c10::complex<at::Half>> {
 // jiterator reduction fails on windows
@@ -57,7 +57,7 @@ struct nansum_functor {
   }
 };
 
-constexpr char prod_name[] = "prod";
+CONSTEXPR_EXCEPT_WIN_CUDA char prod_name[] = "prod";
 
 template <typename scalar_t, typename acc_t = scalar_t, typename out_t = scalar_t>
 struct prod_functor {

--- a/aten/src/ATen/native/cuda/UnaryComplexKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryComplexKernels.cu
@@ -25,7 +25,7 @@ __host__ __device__ static inline c10::complex<T> angle_wrapper(c10::complex<T> 
   return c10::complex<T>{std::arg(v), 0};
 }
 
-constexpr char angle_name[] = "angle_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char angle_name[] = "angle_kernel";
 void angle_kernel_cuda(TensorIteratorBase& iter) {
   auto dtype = iter.common_dtype();
   if (at::isComplexType(dtype)) {
@@ -60,7 +60,7 @@ void angle_kernel_cuda(TensorIteratorBase& iter) {
 }
 
 // NB: Ignores the negative bit on tensors
-constexpr char conj_name[] = "conj_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char conj_name[] = "conj_kernel";
 void conj_kernel_cuda(TensorIteratorBase& iter) {
   auto conj_chalf = [&] {
     using scalar_t = c10::complex<at::Half>;

--- a/aten/src/ATen/native/cuda/UnaryGammaKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryGammaKernels.cu
@@ -13,7 +13,7 @@
 namespace at::native {
 
 // See note [Jiterator]
-constexpr char digamma_name[] = "digamma";
+CONSTEXPR_EXCEPT_WIN_CUDA char digamma_name[] = "digamma";
 void digamma_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.common_dtype(), "digamma_cuda", [&]() {
@@ -32,7 +32,7 @@ void digamma_kernel_cuda(TensorIteratorBase& iter) {
 }
 
 // See note [Jiterator]
-constexpr char trigamma_name[] = "trigamma";
+CONSTEXPR_EXCEPT_WIN_CUDA char trigamma_name[] = "trigamma";
 void trigamma_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.common_dtype(), "trigamma_cuda", [&]() {
@@ -50,7 +50,7 @@ void trigamma_kernel_cuda(TensorIteratorBase& iter) {
   #endif // AT_USE_JITERATOR()
 }
 
-constexpr char polygamma_name[] = "polygamma";
+CONSTEXPR_EXCEPT_WIN_CUDA char polygamma_name[] = "polygamma";
 void polygamma_kernel_cuda(TensorIteratorBase& iter, int64_t n) {
   if (n == 0) {
     digamma_kernel_cuda(iter);
@@ -83,7 +83,7 @@ void polygamma_kernel_cuda(TensorIteratorBase& iter, int64_t n) {
   }
 }
 
-constexpr char lgamma_name[] = "lgamma_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char lgamma_name[] = "lgamma_kernel";
 void lgamma_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.common_dtype(), "lgamma_cuda", [&]() {

--- a/aten/src/ATen/native/cuda/UnaryGeometricAcosKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAcosKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char acos_name[] = "acos";
+CONSTEXPR_EXCEPT_WIN_CUDA char acos_name[] = "acos";
 void acos_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricAcoshKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAcoshKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char acosh_name[] = "acosh";
+CONSTEXPR_EXCEPT_WIN_CUDA char acosh_name[] = "acosh";
 void acosh_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if(at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricAsinKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAsinKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char asin_name[] = "asin";
+CONSTEXPR_EXCEPT_WIN_CUDA char asin_name[] = "asin";
 void asin_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricAsinhKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAsinhKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char asinh_name[] = "asinh";
+CONSTEXPR_EXCEPT_WIN_CUDA char asinh_name[] = "asinh";
 void asinh_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricAtanKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAtanKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char atan_name[] = "atan";
+CONSTEXPR_EXCEPT_WIN_CUDA char atan_name[] = "atan";
 void atan_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricAtanhKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricAtanhKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char atanh_name[] = "atanh";
+CONSTEXPR_EXCEPT_WIN_CUDA char atanh_name[] = "atanh";
 void atanh_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricCosKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricCosKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char cos_name[] = "cos";
+CONSTEXPR_EXCEPT_WIN_CUDA char cos_name[] = "cos";
 void cos_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricCoshKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricCoshKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char cosh_name[] = "cosh";
+CONSTEXPR_EXCEPT_WIN_CUDA char cosh_name[] = "cosh";
 void cosh_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricSinKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricSinKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char sin_name[] = "sin";
+CONSTEXPR_EXCEPT_WIN_CUDA char sin_name[] = "sin";
 void sin_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricSinhKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricSinhKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char sinh_name[] = "sinh";
+CONSTEXPR_EXCEPT_WIN_CUDA char sinh_name[] = "sinh";
 void sinh_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricTanKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricTanKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char tan_name[] = "tan";
+CONSTEXPR_EXCEPT_WIN_CUDA char tan_name[] = "tan";
 void tan_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryGeometricTanhKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryGeometricTanhKernel.cu
@@ -11,7 +11,7 @@
 
 namespace at::native {
 
-constexpr char tanh_name[] = "tanh";
+CONSTEXPR_EXCEPT_WIN_CUDA char tanh_name[] = "tanh";
 void tanh_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryLogKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryLogKernels.cu
@@ -12,7 +12,7 @@
 
 namespace at::native {
 
-constexpr char log_name[] = "log_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char log_name[] = "log_kernel";
 void log_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
@@ -44,7 +44,7 @@ void log_kernel_cuda(TensorIteratorBase& iter) {
   }
 }
 
-constexpr char log10_name[] = "log10_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char log10_name[] = "log10_kernel";
 void log10_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
@@ -81,7 +81,7 @@ void log1p_kernel_cuda(TensorIteratorBase& iter) {
   });
 }
 
-constexpr char log2_name[] = "log2_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char log2_name[] = "log2_kernel";
 void log2_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -34,7 +34,7 @@ void bitwise_not_kernel_cuda(TensorIteratorBase& iter) {
   }
 }
 
-constexpr char exp_name[] = "exp_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char exp_name[] = "exp_kernel";
 void exp_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
@@ -92,7 +92,7 @@ C10_HOST_DEVICE static inline c10::complex<T> rsqrt_wrapper(c10::complex<T> v) {
   return one / ::sqrt(v);
 }
 
-constexpr char rsqrt_name[] = "rsqrt_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char rsqrt_name[] = "rsqrt_kernel";
 void rsqrt_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
@@ -131,7 +131,7 @@ void rsqrt_kernel_cuda(TensorIteratorBase& iter) {
   }
 }
 
-constexpr char sqrt_name[] = "sqrt_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char sqrt_name[] = "sqrt_kernel";
 void sqrt_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {

--- a/aten/src/ATen/native/cuda/UnarySignKernels.cu
+++ b/aten/src/ATen/native/cuda/UnarySignKernels.cu
@@ -25,7 +25,7 @@ void logical_not_kernel_cuda(TensorIteratorBase& iter) {
 }
 
 // NB: Ignores the negative bit on tensors
-constexpr char neg_name[] = "neg_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char neg_name[] = "neg_kernel";
 void neg_kernel_cuda(TensorIteratorBase& iter) {
   auto dtype = iter.dtype();
   if (at::isComplexType(dtype)) {
@@ -96,7 +96,7 @@ C10_HOST_DEVICE static inline c10::complex<T> sgn_wrapper(c10::complex<T> z) {
   }
 }
 
-constexpr char sgn_name[] = "sgn_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char sgn_name[] = "sgn_kernel";
 void sgn_kernel_cuda(TensorIteratorBase& iter){
   auto dtype = iter.dtype();
   #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/UnarySpecialOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnarySpecialOpsKernel.cu
@@ -19,7 +19,7 @@
 
 namespace at::native {
 
-constexpr char exp2_name[] = "exp2_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char exp2_name[] = "exp2_kernel";
 void exp2_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
@@ -41,7 +41,7 @@ void exp2_kernel_cuda(TensorIteratorBase& iter) {
   #endif
 }
 
-constexpr char i0_name[] = "i0";
+CONSTEXPR_EXCEPT_WIN_CUDA char i0_name[] = "i0";
 void i0_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.common_dtype(), "i0_cuda", [&]() {
@@ -63,7 +63,7 @@ void i0_kernel_cuda(TensorIteratorBase& iter) {
 }
 
 // See note [Jiterator]
-constexpr char i0e_name[] = "calc_i0e";
+CONSTEXPR_EXCEPT_WIN_CUDA char i0e_name[] = "calc_i0e";
 void i0e_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.common_dtype(), "i0e_cuda", [&]() {
@@ -84,7 +84,7 @@ void i0e_kernel_cuda(TensorIteratorBase& iter) {
 
 // See note [Jiterator]
 
-constexpr char i1_name[] = "i1";
+CONSTEXPR_EXCEPT_WIN_CUDA char i1_name[] = "i1";
 void i1_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "i1_cuda", [&]() {
@@ -102,7 +102,7 @@ void i1_kernel_cuda(TensorIteratorBase& iter) {
   #endif // AT_USE_JITERATOR()
 }
 
-constexpr char i1e_name[] = "i1e";
+CONSTEXPR_EXCEPT_WIN_CUDA char i1e_name[] = "i1e";
 void i1e_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "i1e_cuda", [&]() {
@@ -120,7 +120,7 @@ void i1e_kernel_cuda(TensorIteratorBase& iter) {
   #endif
 }
 
-constexpr char sigmoid_name[] = "sigmoid";
+CONSTEXPR_EXCEPT_WIN_CUDA char sigmoid_name[] = "sigmoid";
 void sigmoid_kernel_cuda(TensorIteratorBase& iter) {
   auto common_dtype = iter.common_dtype();
   if (at::isComplexType(common_dtype)) {
@@ -159,7 +159,7 @@ void sigmoid_kernel_cuda(TensorIteratorBase& iter) {
   }
 }
 
-constexpr char sinc_name[] = "sinc";
+CONSTEXPR_EXCEPT_WIN_CUDA char sinc_name[] = "sinc";
 void sinc_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
@@ -217,7 +217,7 @@ void logit_kernel_cuda(TensorIteratorBase& iter, const Scalar& eps_scalar) {
       });
 }
 
-constexpr char ndtri_name[] = "ndtri";
+CONSTEXPR_EXCEPT_WIN_CUDA char ndtri_name[] = "ndtri";
 void ndtri_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "ndtri_cuda", [&]() {
@@ -234,7 +234,7 @@ void ndtri_kernel_cuda(TensorIteratorBase& iter) {
   #endif
 }
 
-constexpr char log_ndtr_name[] = "log_ndtr";
+CONSTEXPR_EXCEPT_WIN_CUDA char log_ndtr_name[] = "log_ndtr";
 void log_ndtr_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "log_ndtr_cuda", [&]() {
@@ -259,7 +259,7 @@ void erf_kernel_cuda(TensorIteratorBase& iter) {
   });
 }
 
-constexpr char erfc_name[] = "erfc_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char erfc_name[] = "erfc_kernel";
 void erfc_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.common_dtype(), "erfc_cuda", [&]() {
@@ -278,7 +278,7 @@ void erfc_kernel_cuda(TensorIteratorBase& iter) {
   #endif
 }
 
-constexpr char erfinv_name[] = "erfinv_kernel";
+CONSTEXPR_EXCEPT_WIN_CUDA char erfinv_name[] = "erfinv_kernel";
 void erfinv_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.common_dtype(), "erfinv_cuda", [&]() {
@@ -296,7 +296,7 @@ void erfinv_kernel_cuda(TensorIteratorBase& iter) {
   #endif
 }
 
-constexpr char erfcx_name[] = "erfcx";
+CONSTEXPR_EXCEPT_WIN_CUDA char erfcx_name[] = "erfcx";
 void erfcx_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "erfcx_cuda", [&]() {
@@ -313,7 +313,7 @@ void erfcx_kernel_cuda(TensorIteratorBase& iter) {
   #endif
 }
 
-constexpr char kaiser_window_name[] = "kaiser_window";
+CONSTEXPR_EXCEPT_WIN_CUDA char kaiser_window_name[] = "kaiser_window";
 void kaiser_window_kernel_cuda(TensorIteratorBase& iter, int64_t window_length, double beta_){
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.dtype(), "kaiser_window_cuda", [&](){
@@ -347,7 +347,7 @@ void kaiser_window_kernel_cuda(TensorIteratorBase& iter, int64_t window_length, 
   #endif
 }
 
-constexpr char entr_name[] = "entr";
+CONSTEXPR_EXCEPT_WIN_CUDA char entr_name[] = "entr";
 void entr_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::Half, ScalarType::BFloat16, iter.common_dtype(), "entr_cuda", [&]() {

--- a/aten/src/ATen/native/cuda/ZetaKernel.cu
+++ b/aten/src/ATen/native/cuda/ZetaKernel.cu
@@ -15,7 +15,7 @@ namespace {
  * See note [3-Clause BSD License for the Cephes Math Library].
  */
 // See note [Jiterator]
-constexpr char zeta_name[] = "zeta";
+CONSTEXPR_EXCEPT_WIN_CUDA char zeta_name[] = "zeta";
 void zeta_kernel_cuda(TensorIteratorBase& iter) {
   #if AT_USE_JITERATOR()
     AT_DISPATCH_FLOATING_TYPES(iter.common_dtype(), "zeta_cuda", [&]() {

--- a/aten/src/ATen/native/cuda/airy_ai.cu
+++ b/aten/src/ATen/native/cuda/airy_ai.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
 namespace {
-constexpr char airy_ai_name[] = "airy_ai_forward";
+CONSTEXPR_EXCEPT_WIN_CUDA char airy_ai_name[] = "airy_ai_forward";
 
 void airy_ai_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/bessel_j0.cu
+++ b/aten/src/ATen/native/cuda/bessel_j0.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
 namespace {
-constexpr char bessel_j0_name[] = "bessel_j0_forward";
+CONSTEXPR_EXCEPT_WIN_CUDA char bessel_j0_name[] = "bessel_j0_forward";
 
 void bessel_j0_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/bessel_j1.cu
+++ b/aten/src/ATen/native/cuda/bessel_j1.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
 namespace {
-constexpr char bessel_j1_name[] = "bessel_j1_forward";
+CONSTEXPR_EXCEPT_WIN_CUDA char bessel_j1_name[] = "bessel_j1_forward";
 
 void bessel_j1_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/bessel_y0.cu
+++ b/aten/src/ATen/native/cuda/bessel_y0.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char bessel_y0_name[] = "bessel_y0_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char bessel_y0_name[] = "bessel_y0_forward";
 
             void bessel_y0_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/bessel_y1.cu
+++ b/aten/src/ATen/native/cuda/bessel_y1.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char bessel_y1_name[] = "bessel_y1_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char bessel_y1_name[] = "bessel_y1_forward";
 
             void bessel_y1_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/chebyshev_polynomial_t.cu
+++ b/aten/src/ATen/native/cuda/chebyshev_polynomial_t.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char chebyshev_polynomial_t_name[] = "chebyshev_polynomial_t_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char chebyshev_polynomial_t_name[] = "chebyshev_polynomial_t_forward";
 
             void chebyshev_polynomial_t_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/chebyshev_polynomial_u.cu
+++ b/aten/src/ATen/native/cuda/chebyshev_polynomial_u.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char chebyshev_polynomial_u_name[] = "chebyshev_polynomial_u_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char chebyshev_polynomial_u_name[] = "chebyshev_polynomial_u_forward";
 
             void chebyshev_polynomial_u_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/chebyshev_polynomial_v.cu
+++ b/aten/src/ATen/native/cuda/chebyshev_polynomial_v.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char chebyshev_polynomial_v_name[] = "chebyshev_polynomial_v_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char chebyshev_polynomial_v_name[] = "chebyshev_polynomial_v_forward";
 
             void chebyshev_polynomial_v_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/chebyshev_polynomial_w.cu
+++ b/aten/src/ATen/native/cuda/chebyshev_polynomial_w.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char chebyshev_polynomial_w_name[] = "chebyshev_polynomial_w_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char chebyshev_polynomial_w_name[] = "chebyshev_polynomial_w_forward";
 
             void chebyshev_polynomial_w_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/hermite_polynomial_h.cu
+++ b/aten/src/ATen/native/cuda/hermite_polynomial_h.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char hermite_polynomial_h_name[] = "hermite_polynomial_h_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char hermite_polynomial_h_name[] = "hermite_polynomial_h_forward";
 
             void hermite_polynomial_h_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/hermite_polynomial_he.cu
+++ b/aten/src/ATen/native/cuda/hermite_polynomial_he.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char hermite_polynomial_he_name[] = "hermite_polynomial_he_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char hermite_polynomial_he_name[] = "hermite_polynomial_he_forward";
 
             void hermite_polynomial_he_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/laguerre_polynomial_l.cu
+++ b/aten/src/ATen/native/cuda/laguerre_polynomial_l.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char laguerre_polynomial_l_name[] = "laguerre_polynomial_l_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char laguerre_polynomial_l_name[] = "laguerre_polynomial_l_forward";
 
             void laguerre_polynomial_l_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/modified_bessel_i0.cu
+++ b/aten/src/ATen/native/cuda/modified_bessel_i0.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char modified_bessel_i0_name[] = "modified_bessel_i0_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char modified_bessel_i0_name[] = "modified_bessel_i0_forward";
 
             void modified_bessel_i0_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/modified_bessel_i1.cu
+++ b/aten/src/ATen/native/cuda/modified_bessel_i1.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char modified_bessel_i1_name[] = "modified_bessel_i1_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char modified_bessel_i1_name[] = "modified_bessel_i1_forward";
 
             void modified_bessel_i1_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/modified_bessel_k0.cu
+++ b/aten/src/ATen/native/cuda/modified_bessel_k0.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char modified_bessel_k0_name[] = "modified_bessel_k0_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char modified_bessel_k0_name[] = "modified_bessel_k0_forward";
 
             void modified_bessel_k0_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/modified_bessel_k1.cu
+++ b/aten/src/ATen/native/cuda/modified_bessel_k1.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char modified_bessel_k1_name[] = "modified_bessel_k1_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char modified_bessel_k1_name[] = "modified_bessel_k1_forward";
 
             void modified_bessel_k1_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/scaled_modified_bessel_k0.cu
+++ b/aten/src/ATen/native/cuda/scaled_modified_bessel_k0.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char scaled_modified_bessel_k0_name[] = "scaled_modified_bessel_k0_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char scaled_modified_bessel_k0_name[] = "scaled_modified_bessel_k0_forward";
 
             void scaled_modified_bessel_k0_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/scaled_modified_bessel_k1.cu
+++ b/aten/src/ATen/native/cuda/scaled_modified_bessel_k1.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char scaled_modified_bessel_k1_name[] = "scaled_modified_bessel_k1_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char scaled_modified_bessel_k1_name[] = "scaled_modified_bessel_k1_forward";
 
             void scaled_modified_bessel_k1_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_t.cu
+++ b/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_t.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char shifted_chebyshev_polynomial_t_name[] = "shifted_chebyshev_polynomial_t_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char shifted_chebyshev_polynomial_t_name[] = "shifted_chebyshev_polynomial_t_forward";
 
             void shifted_chebyshev_polynomial_t_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_u.cu
+++ b/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_u.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char shifted_chebyshev_polynomial_u_name[] = "shifted_chebyshev_polynomial_u_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char shifted_chebyshev_polynomial_u_name[] = "shifted_chebyshev_polynomial_u_forward";
 
             void shifted_chebyshev_polynomial_u_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_v.cu
+++ b/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_v.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
 namespace {
-constexpr char shifted_chebyshev_polynomial_v_name[] = "shifted_chebyshev_polynomial_v_forward";
+CONSTEXPR_EXCEPT_WIN_CUDA char shifted_chebyshev_polynomial_v_name[] = "shifted_chebyshev_polynomial_v_forward";
 
 void shifted_chebyshev_polynomial_v_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_w.cu
+++ b/aten/src/ATen/native/cuda/shifted_chebyshev_polynomial_w.cu
@@ -10,7 +10,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char shifted_chebyshev_polynomial_w_name[] = "shifted_chebyshev_polynomial_w_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char shifted_chebyshev_polynomial_w_name[] = "shifted_chebyshev_polynomial_w_forward";
 
             void shifted_chebyshev_polynomial_w_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()

--- a/aten/src/ATen/native/cuda/spherical_bessel_j0.cu
+++ b/aten/src/ATen/native/cuda/spherical_bessel_j0.cu
@@ -20,7 +20,7 @@
 
 namespace at::native {
         namespace {
-            constexpr char spherical_bessel_j0_name[] = "spherical_bessel_j0_forward";
+            CONSTEXPR_EXCEPT_WIN_CUDA char spherical_bessel_j0_name[] = "spherical_bessel_j0_forward";
 
             void spherical_bessel_j0_kernel_cuda(TensorIteratorBase& iterator) {
 #if AT_USE_JITERATOR()


### PR DESCRIPTION
Summary:
Followup after https://github.com/pytorch/pytorch/pull/93267
Generated by running:
```
for i in *.cu; do sed -i -e "s/constexpr char/CONSTEXPR_EXCEPT_WIN_CUDA char/" $i; done
```

Otherwise, attempts to compile using VS-15.9 results in:
```
D:\pytorch\aten\src\aten\native\cuda\laguerre_polynomial_l.cu(17): fatal error C1001: An internal error has occurred in the compiler.
(compiler file 'msc1.cpp', line 1518)
 To work around this problem, try simplifying or changing the program near the locations listed above.
Please choose the Technical Support command on the Visual C++
 Help menu, or open the Technical Support help file for more information
Internal Compiler Error in D:\VC\Tools\MSVC\14.16.27023\bin\Hostx64\x64\cl.exe.  You will be prompted to send an error report to Microsoft later.
INTERNAL COMPILER ERROR in 'D:\VC\Tools\MSVC\14.16.27023\bin\Hostx64\x64\cl.exe'
    Please choose the Technical Support command on the Visual C++
    Help menu, or open the Technical Support help file for more information

```

Test Plan: CI

Differential Revision: D43011140

