### PR TITLE
Refactor sharding data pipe into a seperate file

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -54,7 +54,7 @@ from torch.utils.data.datapipes.utils.snapshot import (
 )
 from torch.utils.data.datapipes.dataframe import CaptureDataFrame
 from torch.utils.data.datapipes.dataframe import dataframe_wrapper as df_wrapper
-from torch.utils.data.datapipes.iter.grouping import SHARDING_PRIORITIES
+from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 
 try:
     import dill

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -35,7 +35,7 @@ from . import (
     Dataset,)
 
 from torch.utils.data.datapipes.datapipe import _IterDataPipeSerializationWrapper, _MapDataPipeSerializationWrapper
-from torch.utils.data.datapipes.iter.grouping import SHARDING_PRIORITIES
+from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 
 from . import _utils
 

--- a/torch/utils/data/datapipes/iter/__init__.py
+++ b/torch/utils/data/datapipes/iter/__init__.py
@@ -25,8 +25,10 @@ from torch.utils.data.datapipes.iter.fileopener import (
 from torch.utils.data.datapipes.iter.grouping import (
     BatcherIterDataPipe as Batcher,
     GrouperIterDataPipe as Grouper,
-    ShardingFilterIterDataPipe as ShardingFilter,
     UnBatcherIterDataPipe as UnBatcher,
+)
+from torch.utils.data.datapipes.iter.sharding import (
+    ShardingFilterIterDataPipe as ShardingFilter,
 )
 from torch.utils.data.datapipes.iter.routeddecoder import (
     RoutedDecoderIterDataPipe as RoutedDecoder,

--- a/torch/utils/data/datapipes/iter/grouping.py
+++ b/torch/utils/data/datapipes/iter/grouping.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
-from enum import IntEnum
-from typing import Any, Callable, DefaultDict, Dict, Iterator, List, Optional, Sized, Tuple, TypeVar
+from typing import Any, Callable, DefaultDict, Iterator, List, Optional, Sized, TypeVar
 
 from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data.datapipes.datapipe import IterDataPipe, DataChunk
@@ -9,80 +8,10 @@ from torch.utils.data.datapipes.utils.common import _check_unpickable_fn
 __all__ = [
     "BatcherIterDataPipe",
     "GrouperIterDataPipe",
-    "ShardingFilterIterDataPipe",
-    "SHARDING_PRIORITIES",
     "UnBatcherIterDataPipe",
 ]
 
 T_co = TypeVar('T_co', covariant=True)
-
-
-class SHARDING_PRIORITIES(IntEnum):
-    DEFAULT = 1
-    DISTRIBUTED = 2
-    MULTIPROCESSING = 3
-
-
-@functional_datapipe('sharding_filter')
-class ShardingFilterIterDataPipe(IterDataPipe):
-    r"""
-    Wrapper that allows DataPipe to be sharded (functional name: ``sharding_filter``). After ``apply_sharding`` is
-    called, each instance of the DataPipe (on different workers) will have every `n`-th element of the
-    original DataPipe, where `n` equals to the number of instances.
-
-    Args:
-        source_datapipe: Iterable DataPipe that will be sharded
-    """
-
-    def __init__(self, source_datapipe: IterDataPipe, sharding_group_filter=None):
-        self.source_datapipe = source_datapipe
-        self.sharding_group_filter = sharding_group_filter
-        self.groups: Dict[int, Tuple[int, int]] = {}
-        self.num_of_instances = 1
-        self.instance_id = 0
-        self._update_num_of_instances()
-
-    def is_shardable(self):
-        return True
-
-    def apply_sharding(self, num_of_instances, instance_id, sharding_group=SHARDING_PRIORITIES.DEFAULT):
-        if instance_id >= num_of_instances:
-            raise ValueError(f"instance_id({instance_id}) should be smaller than num_of_instances({num_of_instances})")
-        if sharding_group == SHARDING_PRIORITIES.DEFAULT:
-            if len(self.groups) and SHARDING_PRIORITIES.DEFAULT not in self.groups:
-                raise Exception('ShardingFilter cannot mix DEFAULT and non DEFAULT groups')
-        else:
-            if SHARDING_PRIORITIES.DEFAULT in self.groups:
-                raise Exception('ShardingFilter cannot mix DEFAULT and non DEFAULT groups')
-        self.groups[sharding_group] = (num_of_instances, instance_id)
-        self._update_num_of_instances()
-
-    def _update_num_of_instances(self):
-        sorted_sharding_groups = []
-        for key in sorted(self.groups.keys()):
-            if self.sharding_group_filter is None or key == self.sharding_group_filter:
-                sorted_sharding_groups.append(self.groups[key])
-
-        sorted_sharding_groups.reverse()
-
-        self.num_of_instances = 1
-        self.instance_id = 0
-
-        for group_num_of_instances, group_instance_id in sorted_sharding_groups:
-            self.instance_id += self.num_of_instances * group_instance_id
-            self.num_of_instances *= group_num_of_instances
-
-    def __iter__(self):
-        for i, item in enumerate(self.source_datapipe):
-            if i % self.num_of_instances == self.instance_id:
-                yield item
-
-    def __len__(self):
-        if isinstance(self.source_datapipe, Sized):
-            return len(self.source_datapipe) // self.num_of_instances +\
-                (1 if (self.instance_id < len(self.source_datapipe) % self.num_of_instances) else 0)
-        raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))
-
 
 @functional_datapipe('batch')
 class BatcherIterDataPipe(IterDataPipe[DataChunk]):

--- a/torch/utils/data/datapipes/iter/sharding.py
+++ b/torch/utils/data/datapipes/iter/sharding.py
@@ -1,0 +1,80 @@
+from typing import (
+    Dict,
+    Sized,
+    Tuple,
+)
+
+from torch.utils.data.datapipes._decorator import functional_datapipe
+from torch.utils.data.datapipes.datapipe import IterDataPipe
+from enum import IntEnum
+
+__all__ = [
+    "SHARDING_PRIORITIES",
+    "ShardingFilterIterDataPipe",
+]
+
+class SHARDING_PRIORITIES(IntEnum):
+    DEFAULT = 1
+    DISTRIBUTED = 2
+    MULTIPROCESSING = 3
+
+class _ShardingIterDataPipe(IterDataPipe):
+    def apply_sharding(self, num_of_instances, instance_id, sharding_group):
+        raise NotImplementedError
+
+@functional_datapipe('sharding_filter')
+class ShardingFilterIterDataPipe(_ShardingIterDataPipe):
+    r"""
+    Wrapper that allows DataPipe to be sharded (functional name: ``sharding_filter``). After ``apply_sharding`` is
+    called, each instance of the DataPipe (on different workers) will have every `n`-th element of the
+    original DataPipe, where `n` equals to the number of instances.
+
+    Args:
+        source_datapipe: Iterable DataPipe that will be sharded
+    """
+
+    def __init__(self, source_datapipe: IterDataPipe, sharding_group_filter=None):
+        self.source_datapipe = source_datapipe
+        self.sharding_group_filter = sharding_group_filter
+        self.groups: Dict[int, Tuple[int, int]] = {}
+        self.num_of_instances = 1
+        self.instance_id = 0
+        self._update_num_of_instances()
+
+    def apply_sharding(self, num_of_instances, instance_id, sharding_group=SHARDING_PRIORITIES.DEFAULT):
+        if instance_id >= num_of_instances:
+            raise ValueError(f"instance_id({instance_id}) should be smaller than num_of_instances({num_of_instances})")
+        if sharding_group == SHARDING_PRIORITIES.DEFAULT:
+            if len(self.groups) and SHARDING_PRIORITIES.DEFAULT not in self.groups:
+                raise Exception('ShardingFilter cannot mix DEFAULT and non DEFAULT groups')
+        else:
+            if SHARDING_PRIORITIES.DEFAULT in self.groups:
+                raise Exception('ShardingFilter cannot mix DEFAULT and non DEFAULT groups')
+        self.groups[sharding_group] = (num_of_instances, instance_id)
+        self._update_num_of_instances()
+
+    def _update_num_of_instances(self):
+        sorted_sharding_groups = []
+        for key in sorted(self.groups.keys()):
+            if self.sharding_group_filter is None or key == self.sharding_group_filter:
+                sorted_sharding_groups.append(self.groups[key])
+
+        sorted_sharding_groups.reverse()
+
+        self.num_of_instances = 1
+        self.instance_id = 0
+
+        for group_num_of_instances, group_instance_id in sorted_sharding_groups:
+            self.instance_id += self.num_of_instances * group_instance_id
+            self.num_of_instances *= group_num_of_instances
+
+    def __iter__(self):
+        for i, item in enumerate(self.source_datapipe):
+            if i % self.num_of_instances == self.instance_id:
+                yield item
+
+    def __len__(self):
+        if isinstance(self.source_datapipe, Sized):
+            return len(self.source_datapipe) // self.num_of_instances +\
+                (1 if (self.instance_id < len(self.source_datapipe) % self.num_of_instances) else 0)
+        raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -5,8 +5,11 @@ from typing import Any, List, Optional, Set
 
 import torch
 
+from torch.utils.data.datapipes.iter.sharding import (
+    _ShardingIterDataPipe,
+    SHARDING_PRIORITIES,
+)
 from torch.utils.data.graph import DataPipe, DataPipeGraph, traverse_dps
-from torch.utils.data.datapipes.iter.grouping import SHARDING_PRIORITIES
 
 __all__ = [
     "apply_random_seed",
@@ -45,13 +48,12 @@ def apply_sharding(datapipe: DataPipe,
     def _helper(graph, prev_applied=None):
         for _, (dp, sub_graph) in graph.items():
             applied = None
-            if hasattr(dp, 'is_shardable') and dp.is_shardable():
-                if hasattr(dp, 'apply_sharding'):
-                    if prev_applied is not None:
-                        raise RuntimeError("Sharding twice on a single pipeline is likely unintended and will cause data loss. "
-                                           f"Sharding already applied to {prev_applied} while trying to apply to {dp}")
-                    dp.apply_sharding(num_of_instances, instance_id, sharding_group=sharding_group)
-                    applied = dp
+            if isinstance(dp, _ShardingIterDataPipe):
+                if prev_applied is not None:
+                    raise RuntimeError("Sharding twice on a single pipeline is likely unintended and will cause data loss. "
+                                       f"Sharding already applied to {prev_applied} while trying to apply to {dp}")
+                dp.apply_sharding(num_of_instances, instance_id, sharding_group=sharding_group)
+                applied = dp
             if applied is None:
                 applied = prev_applied
             _helper(sub_graph, applied)


### PR DESCRIPTION
Move `ShardingFilterIterDataPipe` into a dedicated file. 

Also, propose to have a dedicated parent class (`_ShardingIterDataPipe`) for sharding data pipe, as this seems more like a "system/engine-level" datapipe that gives strong hints to RS on how to execute, and needs first-class citizen treatment in RS (compared with other "user-level" datapipe that are mostly composable `Callable[[Iterable], Iterable]`.  So we don't need to based on whether `is_shardable` and `apply_sharding` are presented in DataPipe in `graph_settings.py`. But open to other discussions. 



Open question: Should 
[ShardingRoundRobinDispatcherIterDataPipe](https://github.com/pytorch/data/blob/01fc76200354501b057bb439b43a1f05f609dd0a/torchdata/datapipes/iter/util/sharding.py#L16-L17) also be considered as a `_ShardingIterDataPipe`? (e.g. this sharding is executed by replicating (the metadata), while `ShardingRoundRobinDispatcherIterDataPipe` hints too expensive to replicate so requires round robin data exchange/dispatch). 

Differential Revision: D43014692

