### PR TITLE
Clean up mentions of removed torch/csrc/generic/*.cpp

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -222,7 +222,6 @@ exclude_patterns = [
     # caffe2_pb.h, otherwise we'd have to build protos as part of this CI job.
     # FunctionsManual.cpp is excluded to keep this diff clean. It will be fixed
     # in a follow up PR.
-    # /torch/csrc/generic/*.cpp is excluded because those files aren't actually built.
     # that are not easily converted to accepted c++
     'c10/test/**/*.cpp',
     'torch/csrc/jit/passes/onnx/helper.cpp',
@@ -235,7 +234,6 @@ exclude_patterns = [
     'torch/csrc/cuda/nccl.*',
     'torch/csrc/cuda/python_nccl.cpp',
     'torch/csrc/autograd/FunctionsManual.cpp',
-    'torch/csrc/generic/*.cpp',
     'torch/csrc/jit/codegen/cuda/runtime/*',
     'torch/csrc/utils/disable_torch_function.cpp',
 ]

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1585,7 +1585,6 @@ cc_library(
             "torch/csrc/**/*.h",
             "torch/csrc/distributed/c10d/*.hpp",
             "torch/lib/libshm/*.h",
-            "torch/csrc/generic/*.cpp",
         ],
         exclude = [
             "torch/csrc/autograd/generated/VariableType.h",

--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -909,7 +909,6 @@ def define_buck_targets(
             [
                 ("torch/csrc/api/include", "torch/**/*.h"),
                 ("", "torch/csrc/**/*.h"),
-                ("", "torch/csrc/generic/*.cpp"),
                 ("", "torch/script.h"),
                 ("", "torch/library.h"),
                 ("", "torch/custom_class.h"),


### PR DESCRIPTION
Summary: The dir was removed in https://github.com/pytorch/pytorch/pull/82373.

Test Plan: Sandcastlle + GitHub CI.

Differential Revision: D43016100

