### PR TITLE
[MPS] Fix `cumsum` for negative indexes

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -244,7 +244,7 @@ TORCH_IMPL_FUNC(cumsum_out_mps)
  int64_t dim,
  c10::optional<ScalarType> dtype,
  const Tensor& result) {
-  TORCH_CHECK(dim >=0 && dim < std::max(1LL, self.ndimension()), "Expected dim to be between 0 and ", self.ndimension(), " but got ", dim);
+  dim = maybe_wrap_dim(dim, self.dim());
   if (!is_macos_13_or_newer()) {
     TORCH_WARN_ONCE("torch.cumsum supported by MPS on MacOS 13+, please upgrade");
     auto cpu_result = self.to(at::Device(kCPU)).cumsum(dim, dtype);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5858,6 +5858,13 @@ class TestNLLLoss(TestCase):
         helper(np.array([1, 1, 1, 1, 1]), (0 + 1 + 2 + 3 + 4) / 5, (6 - 2 * 2), 10000)
         helper(np.array([[1, 1, 1, 1, 1, 1, 1]]), 0, 0, 7, False)
 
+    def test_cumsum_dim_check(self):
+        x=torch.rand((3, 3), device="mps")
+        self.assertEqual(x.cumsum(1), x.cumsum(-1))
+        self.assertEqual(x.cumsum(0), x.cumsum(-2))
+        self.assertRaises(IndexError, lambda:x.cumsum(2))
+        self.assertRaises(IndexError, lambda:x.cumsum(-3))
+
 class TestNNMPS(NNTestCase):
 
     def _create_basic_net(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5859,11 +5859,11 @@ class TestNLLLoss(TestCase):
         helper(np.array([[1, 1, 1, 1, 1, 1, 1]]), 0, 0, 7, False)
 
     def test_cumsum_dim_check(self):
-        x=torch.rand((3, 3), device="mps")
+        x = torch.rand((3, 3), device="mps")
         self.assertEqual(x.cumsum(1), x.cumsum(-1))
         self.assertEqual(x.cumsum(0), x.cumsum(-2))
-        self.assertRaises(IndexError, lambda:x.cumsum(2))
-        self.assertRaises(IndexError, lambda:x.cumsum(-3))
+        self.assertRaises(IndexError, lambda: x.cumsum(2))
+        self.assertRaises(IndexError, lambda: x.cumsum(-3))
 
 class TestNNMPS(NNTestCase):
 


### PR DESCRIPTION
Use `wrap_dim` to get dim in range or range IndexError

Add test to test for that

Addresses feedback raised in https://github.com/pytorch/pytorch/pull/88319#issuecomment-1403541180

