### PR TITLE
set/get cuda rng, unblock Xiaodong, probably not sound to land cause of autograd concerns downtream...

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -811,6 +811,7 @@ def wrap_fx_proxy_cls(
                 "ignore_subclass": ignore_subclass,
                 "is_tensor": target_cls is TensorVariable,
             }
+            breakpoint()
             assert "source" in options and options["source"] is not None
             kwargs["source"] = options["source"]
             example_value = wrap_to_fake_tensor_and_record(

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -811,7 +811,6 @@ def wrap_fx_proxy_cls(
                 "ignore_subclass": ignore_subclass,
                 "is_tensor": target_cls is TensorVariable,
             }
-            breakpoint()
             assert "source" in options and options["source"] is not None
             kwargs["source"] = options["source"]
             example_value = wrap_to_fake_tensor_and_record(


### PR DESCRIPTION
```
import torch
import torch.nn as nn

import torch._dynamo.config
import torch._inductor.config

def pre_attention_state_ops(input, mems, state):
    cuda_rng = torch.cuda.get_rng_state()
    torch.cuda.set_rng_state(cuda_rng)
    lc_key = state[0]
    lc_val = state[1]
    bar = []
    for i in range(0, 4):
        bar2 = []
        for j in range(0, 3):
            bar2.append(
                lc_key + lc_val + torch.tensor([0.1, 0.25, 0.4, 0.5, 0.1], device="cuda")
            )
        bar.append(bar2)

    return bar

mems = torch.tensor([[[1.8364, 0.2724, -1.4917, -0.4367, 0.8640]]], device="cuda")
state = [
    torch.tensor([[[1.0517, 0.3848, -0.6472, 0.0823, 0.9116]]], device="cuda"),
    torch.tensor([[[1.0517, 0.3848, -0.6472, 0.0823, 0.9116]]], device="cuda"),
]
i = torch.tensor(
    [
        [0.0313, -0.1487, -0.3846, -0.5321],
        [-1.7073, 1.3331, -0.0890, -1.4935],
        [-0.8314, -0.1862, -0.5935, 1.5232],
    ],
    device="cuda"
)


exported = torch._dynamo.export(pre_attention_state_ops, i, mems, state)
out_graph = exported[0]

dynamo_result = out_graph(i, mems, state)
```