### PR TITLE
[FSDP][optim_state_dict] Let optim_state_dict ignore the non-FSDP managed parameters that do not reside on the rank

### DIFF
--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -1610,7 +1610,7 @@ class TestFSDPOptimState(FSDPTest):
         state_dicts = []
 
         # Train one batch and see if optim_state_dict are the same.
-        batch = torch.rand(5, 8).cuda()
+        batch = torch.rand(5, 8, device=torch.device("cuda"))
         for model, optim in zip(models, optims):
             # Eagerly initialize the states
             for param in model.parameters():

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -2,6 +2,7 @@
 
 import bisect
 import sys
+from copy import deepcopy
 from enum import auto, Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
@@ -433,7 +434,10 @@ class TestFSDPOptimState(FSDPTest):
             # Check parameter keys are the same first for earlier erroring
             ref_osd_param_ids = set(ref_osd_state.keys())
             fsdp_osd_param_ids = set(fsdp_osd_state.keys())
-            self.assertTrue(ref_osd_param_ids == fsdp_osd_param_ids)
+            self.assertTrue(
+                ref_osd_param_ids == fsdp_osd_param_ids,
+                (ref_osd_param_ids, fsdp_osd_param_ids),
+            )
             # Check state values are the same
             for param_id, param_state in fsdp_osd_state.items():
                 for state_name, value in param_state.items():
@@ -1562,11 +1566,10 @@ class TestFSDPOptimState(FSDPTest):
         optim.step()
 
     @skip_if_lt_x_gpu(2)
-    def test_compatible_with_named_optimizer(self):
-        class TestDummyModel(torch.nn.Module):
+    def test_compatible_with_trec(self):
+        class DenseModel(torch.nn.Module):
             def __init__(self):
-                super(TestDummyModel, self).__init__()
-                torch.manual_seed(0)
+                super().__init__()
                 self.net1 = nn.Sequential(nn.Linear(8, 16), nn.ReLU())
                 self.net2 = nn.Sequential(nn.Linear(16, 32), nn.ReLU())
                 self.net3 = nn.Linear(32, 64)
@@ -1575,24 +1578,39 @@ class TestFSDPOptimState(FSDPTest):
             def forward(self, x):
                 return self.net4(self.net3(self.net2(self.net1(x))))
 
-        models = []
-        optims = []
-        state_dicts = []
-        models.append(FSDP(TestDummyModel().cuda(), use_orig_params=True))
-        optims.append(torch.optim.Adam(models[-1].parameters(), lr=1e-2))
-        models.append(FSDP(TestDummyModel().cuda(), use_orig_params=True))
-        optims.append(
+        class FakeMPModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                torch.manual_seed(0)
+                self.dense = FSDP(DenseModel().cuda(), use_orig_params=True)
+                if dist.get_rank() == 0:
+                    self.sparse0 = nn.Sequential(nn.Linear(8, 8), nn.ReLU())
+                else:
+                    self.sparse1 = nn.Sequential(nn.Linear(8, 8), nn.ReLU())
+
+            def forward(self, x):
+                if dist.get_rank() == 0:
+                    sparse = self.sparse0(x)
+                else:
+                    sparse = self.sparse1(x)
+                dist.all_reduce(sparse)
+                return self.dense(sparse)
+
+        models = [FakeMPModel().cuda(), FakeMPModel().cuda()]
+        optims = [
+            torch.optim.Adam(models[0].parameters(), lr=1e-2),
             _NamedOptimizer(
-                models[-1].named_parameters(),
+                models[1].named_parameters(),
                 torch.optim.Adam,
-                [{"params": models[-1].parameters()}],
-                models[-1],
+                [{"params": models[1].parameters()}],
+                models[1],
                 lr=1e-2,
-            )
-        )
+            ),
+        ]
+        state_dicts = []
 
         # Train one batch and see if optim_state_dict are the same.
-        batch = torch.rand(5, 8)
+        batch = torch.rand(5, 8).cuda()
         for model, optim in zip(models, optims):
             # Eagerly initialize the states
             for param in model.parameters():
@@ -1603,7 +1621,7 @@ class TestFSDPOptimState(FSDPTest):
             loss = model(batch).sum()
             loss.backward()
             optim.step()
-            state_dicts.append(FSDP.optim_state_dict(model, optim))
+            state_dicts.append(deepcopy(FSDP.optim_state_dict(model, optim)))
 
         self._check_same_param_groups(
             state_dicts[0], state_dicts[1], check_same_param_keys=False
@@ -1614,13 +1632,16 @@ class TestFSDPOptimState(FSDPTest):
 
         # Make optim1 has a different state.
         for i in range(5):
-            batch = torch.rand(5, 8)
+            batch = torch.rand(5, 8).cuda()
             loss = models[1](batch).sum()
             loss.backward()
             optims[1].step()
 
         # Load the state back to see if load_optim_state_dict works.
-        optims[1].load_state_dict(state_dicts[1])
+        state_dict_to_load = FSDP.optim_state_dict_to_load(
+            state_dicts[1], models[1], optims[1], is_named_optimizer=True
+        )
+        optims[1].load_state_dict(state_dict_to_load)
         state_dicts[1] = FSDP.optim_state_dict(models[1], optims[1])
 
         self._check_same_param_groups(

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1407,7 +1407,8 @@ def _optim_state_dict(
                 "If use_orig_params is False, we must be able to find the "
                 f"corresponding param id. {optim_state_key} {param_key}"
             )
-            continue
+            if not optim_state_key.is_fsdp_managed:
+                continue
 
         if optim_state_key.is_fsdp_managed:
             # If there are multiple unflat_param_names (not use_orig_params),

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1401,16 +1401,14 @@ def _optim_state_dict(
         param_key: Union[str, int, None] = optim_state_key_to_param_key.get(
             optim_state_key, None
         )
-        assert param_key is not None or (
-            optim_state_key.is_fsdp_managed and use_orig_params
-        ), (
-            "If use_orig_params is False, we must be able to find the "
-            "corresponding param id. If use_orig_params is True, some FSDP "
-            "managedparameters may not exist in the local shard, so the lookup "
-            "can return -1. Both assert conditions failed, some unexpected "
-            "corner case happens."
-            f"{param_key}  {optim_state_key.is_fsdp_managed} {use_orig_params}"
-        )
+
+        if param_key is None:
+            assert use_orig_params, (
+                "If use_orig_params is False, we must be able to find the "
+                f"corresponding param id. {optim_state_key} {param_key}"
+            )
+            continue
+
         if optim_state_key.is_fsdp_managed:
             # If there are multiple unflat_param_names (not use_orig_params),
             # they share the same FSDPParamInfo. So the first unflat_param_name


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #94130
* __->__ #94129

When FSDP is used with other parallelism (e.g., TorchRec), some parameters that are not managed by FSDP may not reside on all the ranks (TorchRec is model parallelism). When `use_orig_params=True` , FSDP will synchronize the FQNs among ranks. As a result, a rank may get the FQNs that the rank does not actually own. If the FQN belongs to a TorchRec managed parameter, FSDP has to ignore the parameter state. Otherwise FSDP does not know how to store the state.

This PR add the logic to ignore the parameters that are not managed by FSDP and are not on the rank.

Differential Revision: [D42982778](https://our.internmc.facebook.com/intern/diff/D42982778/)