### PR TITLE
[FSDP][optim_state_dict] Returns the initial states of the empty parameters for KeyedOptimizer/NamedOptimizer

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1202,6 +1202,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                     model=model,
                     shard_state=False,
                     use_orig_params=use_orig_params,
+                    optim=(optim if is_named_optimizer else None),
                 )
                 processed_osd = _process_pos_dim_tensor_state(flat_osd, world_size)
                 # Broadcast the optim state dict without positive-dimension tensor
@@ -1242,6 +1243,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                 model=model,
                 shard_state=True,
                 use_orig_params=use_orig_params,
+                optim=(optim if is_named_optimizer else None),
             )
             ret_state_dict = _rekey_sharded_optim_state_dict(
                 sharded_osd,

--- a/torch/distributed/optim/named_optimizer.py
+++ b/torch/distributed/optim/named_optimizer.py
@@ -193,7 +193,9 @@ class _NamedOptimizer(optim.Optimizer):
         for idx, param_key in enumerate(self.ordered_param_keys):
             # When the conditional training is performed, not all parameters are updated in the optim.
             if param_key not in state.keys():
-                continue
+                raise ValueError(
+                    f"Could not found {param_key} parameter in the state_dict."
+                )
             if len(state[param_key]) != len(new_state[idx]):
                 raise ValueError(
                     f"Expects equal length as {len(new_state[idx])} for parameter {param_key} but found: {len(state[param_key])}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94130
* #94129

KeyedOptimizer and NamedOptimizer expect the states exist in the state_dict when `load_state_dict` is called even if the corresponding parameters are empty (size == 0). This PR adds the support to make KeyedOptimizer work with `use_orig_params=True`.

Differential Revision: [D43019458](https://our.internmc.facebook.com/intern/diff/D43019458/)