### PR TITLE
Call MPSAllocator callbacks when allocation fails.

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -293,7 +293,7 @@ private:
   constexpr static double default_low_watermark_ratio_discrete = 1.0;
 
   const id<MTLDevice> m_device;
-  std::mutex m_mutex;
+  std::recursive_mutex m_mutex;
   // allocated buffers by device pointer
   ska::flat_hash_map<void*, BufferBlock*> m_allocated_buffers;
   // unallocated cached buffers larger than 1 MB

--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -358,10 +358,11 @@ private:
   // total allocated size instead of manually tracking in MPSAllocator
   size_t current_allocated_size() const { return [m_device currentAllocatedSize]; }
 
-  void trigger_memory_callbacks(BufferBlock* buffer_block, IMpsAllocatorCallback::EventType event) const {
+  bool trigger_memory_callbacks(BufferBlock* buffer_block, IMpsAllocatorCallback::EventType event) const {
     for (const auto& name : MPSAllocatorCallbacksRegistry()->Keys()) {
-      MPSAllocatorCallbacksRegistry()->Create(name)->executeMPSAllocatorCallback(buffer_block->buffer, event);
+      MPSAllocatorCallbacksRegistry()->Create(name)->executeMPSAllocatorCallback(buffer_block ? buffer_block->buffer : nullptr, event);
     }
+    return true;
   }
 
   // TODO: make a common function to do size unit conversions in PyTorch.

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -210,6 +210,9 @@ BufferBlock* MPSHeapAllocatorImpl::alloc_buffer_block(size_t size, uint32_t usag
     block_found =
         // Attempt allocate
         alloc_buffer(params) ||
+        // Callbacks might release more memory (eg. by forcing a GC in the host language) thus
+        // we can retry getting a free buffer in the pool, before trying to alloc again.
+        (trigger_memory_callbacks(nullptr, IMpsAllocatorCallback::EventType::ALLOCATION_FAILED) && get_free_buffer(params)) ||
         // Free enough available cached blocks to satisfy alloc and retry alloc.
         (release_available_cached_buffers(params) && alloc_buffer(params)) ||
         // Free all cached buffers and retry alloc.

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -308,7 +308,7 @@ bool MPSHeapAllocatorImpl::release_buffer(BufferBlock* buffer_block, bool remove
       pool.heaps_pending_update.insert(heap_block);
       m_mutex.unlock();
       m_stream->addCompletedHandler(^(id <MTLCommandBuffer>) {
-        std::lock_guard<std::mutex> lock(m_mutex);
+        std::lock_guard<std::recursive_mutex> lock(m_mutex);
         // check if the heap block still exists
         if (pool.heaps_pending_update.find(heap_block) != pool.heaps_pending_update.end()) {
           pool.heaps_pending_update.erase(heap_block);
@@ -448,7 +448,7 @@ void MPSHeapAllocatorImpl::garbage_collect_cached_buffers(AllocParams& params)
 // public interface to MPSAllocator
 id<MTLBuffer> MPSHeapAllocatorImpl::malloc(size_t size, uint32_t usage)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   BufferBlock* buffer_block = alloc_buffer_block(size, usage);
   return buffer_block ? buffer_block->buffer : nullptr;
@@ -456,7 +456,7 @@ id<MTLBuffer> MPSHeapAllocatorImpl::malloc(size_t size, uint32_t usage)
 
 bool MPSHeapAllocatorImpl::isSharedBuffer(void* ptr)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   BufferBlock *buffer_block = get_allocated_buffer_block(ptr);
   // it's OK for the buffer_block to not exist yet
@@ -467,7 +467,7 @@ id<MTLBuffer> MPSHeapAllocatorImpl::allocScalarBufferWithValue(void* value, size
 {
   BufferBlock* buffer_block = nullptr;
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     buffer_block = alloc_buffer_block(size, UsageFlags::SCALAR);
     if (!buffer_block)
@@ -480,7 +480,7 @@ id<MTLBuffer> MPSHeapAllocatorImpl::allocScalarBufferWithValue(void* value, size
 
 ssize_t MPSHeapAllocatorImpl::getUnalignedBufferSize(void* ptr)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   BufferBlock *buffer_block = get_allocated_buffer_block(ptr);
   if (buffer_block)
@@ -491,7 +491,7 @@ ssize_t MPSHeapAllocatorImpl::getUnalignedBufferSize(void* ptr)
 
 void MPSHeapAllocatorImpl::setBufferShape(void* ptr, const IntArrayRef& shape)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   BufferBlock *buffer_block = get_allocated_buffer_block(ptr);
   TORCH_INTERNAL_ASSERT(buffer_block, "failed to find the buffer ", ptr);
@@ -503,7 +503,7 @@ void MPSHeapAllocatorImpl::setBufferShape(void* ptr, const IntArrayRef& shape)
 
 IntArrayRef MPSHeapAllocatorImpl::getBufferShape(void* ptr)
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   BufferBlock *buffer_block = get_allocated_buffer_block(ptr);
   if (buffer_block && buffer_block->shape.size() > 0)
@@ -516,7 +516,7 @@ void MPSHeapAllocatorImpl::free(void* ptr)
 {
   BufferBlock *buffer_block = nullptr;
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
     buffer_block = get_allocated_buffer_block(ptr);
     TORCH_INTERNAL_ASSERT(buffer_block);
@@ -529,14 +529,14 @@ void MPSHeapAllocatorImpl::free(void* ptr)
   // we sync the scalar pool manually with completion handler at the time buffer is
   // freed when the MPSScalar instance goes our of scope
   m_stream->addCompletedHandler(^(id <MTLCommandBuffer>) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     free_buffer(buffer_block);
   });
 }
 
 void MPSHeapAllocatorImpl::emptyCache()
 {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   release_cached_buffers();
 }
 

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -36,6 +36,7 @@ class IMpsAllocatorCallback {
     RECYCLED,  // buffer pulled from free list to be reused
     FREED,     // buffer put to free list for future recycling
     RELEASED,  // buffer memory released
+    ALLOCATION_FAILED // buffer allocation failed
   };
   virtual ~IMpsAllocatorCallback() = default;
   virtual void executeMPSAllocatorCallback(void* ptr, EventType event) = 0;

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -107,6 +107,7 @@ list(APPEND ATen_VEC_TEST_SRCS
 
 list(APPEND ATen_MPS_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_print.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/mps_test_allocator.cpp
   )
 
 # Caffe2 specific tests

--- a/aten/src/ATen/test/mps_test_allocator.cpp
+++ b/aten/src/ATen/test/mps_test_allocator.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+#include <ATen/mps/MPSAllocatorInterface.h>
+
+namespace replay {
+std::function<void()> callback_action;
+
+class ReplayBufferCleaner : virtual public at::mps::IMpsAllocatorCallback {
+    public:
+    void executeMPSAllocatorCallback(void* ptr, EventType event) override {
+     if (event == EventType::ALLOCATION_FAILED) {
+        callback_action();
+     }
+    }
+};
+}
+
+namespace at::mps {
+REGISTER_MPS_ALLOCATOR_CALLBACK("ReplayBufferCleaner", replay::ReplayBufferCleaner);
+}
+
+TEST(MPSAllocator, MPSAllocatorCallbacks) {
+    std::vector<torch::Tensor> replay_buffer;
+    replay::callback_action = [&]() {
+        if (!replay_buffer.empty()) {
+            replay_buffer.erase(replay_buffer.begin(), replay_buffer.begin() + (replay_buffer.size()/10));
+        }
+    };
+    size_t max_iter = 100000;
+    for (size_t i = 0; i < max_iter; i++) {
+        torch::Tensor new_value = torch::randn({10000, 10000}, at::device(at::kMPS));
+        // early stop the first time the callback is called
+        if (replay_buffer.size() != i) {
+            break;
+        }
+        replay_buffer.push_back(new_value);
+    }
+    ASSERT_TRUE(replay_buffer.size() < max_iter);
+}


### PR DESCRIPTION
Fixes #87374

@kulinseth and @albanD This makes the MPSAllocator call the MPSAllocatorCallbacks when getting a free buffer and a first try on allocating fails. User can register callbacks that might free a few buffers and an allocation will be retried.

The reason why we need the `recursive_mutex` is that since callbacks are supposed to free memory, they will eventually call free_buffer() that will lock the same `mutex` that's used for allocation. This approach is similar what's used with the `FreeMemoryCallback` in the `CUDACachingAllocator`.

This PR tries to be as minimal as possible, but there could be some additional improvements cleanups, like:

- In current main, there's no way callbacks can be called, so we could probably rename the callback registry to something reflect the same naming in the CudaAllocator:

https://github.com/pytorch/pytorch/blob/996cc1c0d09a7bc6ad33441c08961226005c69bf/c10/cuda/CUDACachingAllocator.h#L14-L24

- Review the EventTypes here:

https://github.com/pytorch/pytorch/blob/996cc1c0d09a7bc6ad33441c08961226005c69bf/aten/src/ATen/mps/MPSAllocator.h#L18-L23

- And IMHO a nice improvement would be if callbacks could be aware of AllocParams, so they can decide to be more agressive or not depending on how much memory is requested. So I'd pass AllocParams in the signature of the executeCallback instance:

https://github.com/pytorch/pytorch/blob/996cc1c0d09a7bc6ad33441c08961226005c69bf/aten/src/ATen/mps/MPSAllocator.h#L25

Let me know if you think we could sneak those changes into this PR or if it's better to propose them in other smaller PR's.