### PR TITLE
Improve Padding Heuristic for A100

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -103,7 +103,7 @@ kernel_name_max_ops = 10
 inductor_import = __name__.replace(".config", "")
 
 # Pad input tensors of matmul/bmm/addmm to leverage Tensor Cores in NVIDIA GPUs
-shape_padding = os.environ.get("TORCHINDUCTOR_SHAPE_PADDING", "0") == "1"
+shape_padding = os.environ.get("TORCHINDUCTOR_SHAPE_PADDING", "1") == "1"
 
 # Fx-based linear/matmul/bmm + permute/transpose vertical fusion
 permute_fusion = os.environ.get("TORCHINDUCTOR_PERMUTE_FUSION", "0") == "1"

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -154,7 +154,11 @@ def floordiv(a, b):
 
 
 def get_alignment_size(x):
-    if "A100" in torch.cuda.get_device_name():
+    try:
+        gpu_name = torch.cuda.get_device_name()
+    except:
+        gpu_name = ""
+    if "A100" in gpu_name:
         has_a100 = True
     if x.dtype == torch.int8:
         return 128 if has_a100 else 16

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -154,10 +154,16 @@ def floordiv(a, b):
 
 
 def get_alignment_size(x):
-    if x.dtype == torch.float16 or x.dtype == torch.half or x.dtype == torch.bfloat16:
-        return 8
-    elif x.dtype == torch.float32 or x.dtype == torch.float:
-        return 4
+    if torch.cuda.get_device_name().contains("A100"):
+        has_a100 = True
+    if x.dtype == torch.int8:
+        return 128 if has_a100 else 16
+    elif x.dtype == torch.float16 or x.dtype == torch.half or x.dtype == torch.bfloat16:
+        return 64 if has_a100 else 8
+    elif x.dtype == torch.float32:
+        return 32 if has_a100 else 4
+    elif x.dtype == torch.float64:
+        return 16 if has_a100 else 2
     else:
         return 0
 

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -154,7 +154,7 @@ def floordiv(a, b):
 
 
 def get_alignment_size(x):
-    if torch.cuda.get_device_name().contains("A100"):
+    if "A100" in torch.cuda.get_device_name():
         has_a100 = True
     if x.dtype == torch.int8:
         return 128 if has_a100 else 16


### PR DESCRIPTION
This just fixes the alignment sizes for A100 based on https://docs.nvidia.com/deeplearning/performance/dl-performance-matrix-multiplication/index.html#requirements-tc

cc @Chillee 

Next steps
* Tagging this PR with ciflow/inductor-perf-test-nightly to get benchmarks
* Checking how many times a repadding happens and whether we can do it just once instead
* Alignment sizes for A100 are quite big so we can quantify distance to next best alignment in the heuristic and then make the tradeoff. Also if the matrices are already massive then padding should in the limit padding overhead isn't a big deal