### PR TITLE
Report graph breaks separately from graph count

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1380,13 +1380,23 @@ class BenchmarkRunner:
         def get_stats():
             # TODO: consider deepcopy'ing the entire counters struct and
             # adding a helper to do subtraction on it
-            return collections.Counter({
-                'calls_captured': torch._dynamo.utils.counters["stats"]["calls_captured"],
-                'unique_graphs': torch._dynamo.utils.counters["stats"]["unique_graphs"],
-                'graph_breaks': sum(torch._dynamo.utils.counters["graph_break"].values()),
-                # NB: The plus removes zero counts
-                'unique_graph_breaks': len(+torch._dynamo.utils.counters["graph_break"]),
-            })
+            return collections.Counter(
+                {
+                    "calls_captured": torch._dynamo.utils.counters["stats"][
+                        "calls_captured"
+                    ],
+                    "unique_graphs": torch._dynamo.utils.counters["stats"][
+                        "unique_graphs"
+                    ],
+                    "graph_breaks": sum(
+                        torch._dynamo.utils.counters["graph_break"].values()
+                    ),
+                    # NB: The plus removes zero counts
+                    "unique_graph_breaks": len(
+                        +torch._dynamo.utils.counters["graph_break"]
+                    ),
+                }
+            )
 
         start_stats = get_stats()
 

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1378,6 +1378,7 @@ class BenchmarkRunner:
         print(msg, end=" ", flush=True)
         start_calls_captured = torch._dynamo.utils.counters["stats"]["calls_captured"]
         start_unique_graphs = torch._dynamo.utils.counters["stats"]["unique_graphs"]
+        start_graph_breaks = sum(torch._dynamo.utils.counters["graph_breaks"].values())
         if self.args.accuracy:
             status = self.check_accuracy(
                 name, model, example_inputs, optimize_ctx, experiment, tag
@@ -1404,10 +1405,12 @@ class BenchmarkRunner:
 
         end_calls_captured = torch._dynamo.utils.counters["stats"]["calls_captured"]
         end_unique_graphs = torch._dynamo.utils.counters["stats"]["unique_graphs"]
+        end_graph_breaks = sum(torch._dynamo.utils.counters["graph_breaks"].values())
         if explain:
             print(
                 f"Dynamo produced {end_unique_graphs-start_unique_graphs} graph(s) "
-                f"covering {end_calls_captured-start_calls_captured} ops"
+                f"covering {end_calls_captured-start_calls_captured} ops with "
+                f"{end_graph_breaks-start_graph_breaks} graph breaks"
             )
 
 

--- a/benchmarks/dynamo/parse_logs.py
+++ b/benchmarks/dynamo/parse_logs.py
@@ -59,6 +59,7 @@ out.writerow(
         "backend_time",
         "graph_count",
         "op_count",
+        "graph_breaks",
     ]
 )
 
@@ -153,9 +154,10 @@ for name, name2, log in chunker(entries, 3):
 
     graph_count = None
     op_count = None
-    if m := re.search(r"Dynamo produced (\d+) graph\(s\) covering (\d+) ops", log):
+    if m := re.search(r"Dynamo produced (\d+) graph\(s\) covering (\d+) ops with (\d+) graph breaks", log):
         graph_count = m.group(1)
         op_count = m.group(2)
+        graph_breaks = m.group(3)
 
     # If the context string is too long, don't put it in the CSV.
     # This is a hack to try to make it more likely that Google Sheets will
@@ -182,6 +184,7 @@ for name, name2, log in chunker(entries, 3):
             backend_time,
             graph_count,
             op_count,
+            graph_breaks,
         ]
     )
     i += 1

--- a/benchmarks/dynamo/parse_logs.py
+++ b/benchmarks/dynamo/parse_logs.py
@@ -157,7 +157,10 @@ for name, name2, log in chunker(entries, 3):
     op_count = None
     graph_breaks = None
     unique_graph_breaks = None
-    if m := re.search(r"Dynamo produced (\d+) graphs covering (\d+) ops with (\d+) graph breaks \((\d+) unique\)", log):
+    if m := re.search(
+        r"Dynamo produced (\d+) graphs covering (\d+) ops with (\d+) graph breaks \((\d+) unique\)",
+        log,
+    ):
         graph_count = m.group(1)
         op_count = m.group(2)
         graph_breaks = m.group(3)

--- a/benchmarks/dynamo/parse_logs.py
+++ b/benchmarks/dynamo/parse_logs.py
@@ -60,6 +60,7 @@ out.writerow(
         "graph_count",
         "op_count",
         "graph_breaks",
+        "unique_graph_breaks",
     ]
 )
 
@@ -154,10 +155,13 @@ for name, name2, log in chunker(entries, 3):
 
     graph_count = None
     op_count = None
-    if m := re.search(r"Dynamo produced (\d+) graph\(s\) covering (\d+) ops with (\d+) graph breaks", log):
+    graph_breaks = None
+    unique_graph_breaks = None
+    if m := re.search(r"Dynamo produced (\d+) graphs covering (\d+) ops with (\d+) graph breaks \((\d+) unique\)", log):
         graph_count = m.group(1)
         op_count = m.group(2)
         graph_breaks = m.group(3)
+        unique_graph_breaks = m.group(4)
 
     # If the context string is too long, don't put it in the CSV.
     # This is a hack to try to make it more likely that Google Sheets will
@@ -185,6 +189,7 @@ for name, name2, log in chunker(entries, 3):
             graph_count,
             op_count,
             graph_breaks,
+            unique_graph_breaks,
         ]
     )
     i += 1

--- a/benchmarks/dynamo/run_all.sh
+++ b/benchmarks/dynamo/run_all.sh
@@ -26,7 +26,7 @@ if getent hosts fwdproxy; then
 fi
 
 # Feel free to edit these, but we expect most users not to need to modify this
-BASE_FLAGS=( --accuracy --explain --timing )
+BASE_FLAGS=( --accuracy --explain --timing --print-graph-breaks )
 DATE="$(date)"
 WORK="$PWD"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94143
* #94138

graph break != graph count - 1.  Suppose you have a nested
inline function call f1 to f2 to f3.  A graph break in f3
results in six graphs: f1 before, f2 before, f3 before, f3 after,
f2 after, f1 after.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire