### PR TITLE
FakeTensor should constant propagate through ops that allow numbers as scalars

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -584,6 +584,11 @@ class FakeTensorConstHandling(TestCase):
             y[0] = 1
             self.assertNotConst(x)
 
+    def test_constant_propagate_through_functions(self):
+        with FakeTensorMode():
+            y = torch.div(4, 4, rounding_mode='trunc')
+            self.assertConst(y)
+
 def contains_type(type: torch._C.Type, maybe_contained_type: torch._C.Type):
     return maybe_contained_type.isSubtypeOf(type) or any(
         contains_type(e, maybe_contained_type) for e in type.containedTypes()

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -527,6 +527,13 @@ def in_kernel_invocation_manager(fake_mode):
         del guard
 
 
+# Return if the function allows Python numbers to bind to Tensors
+def should_allow_numbers_as_tensors(func: OpOverload):
+    return torch._C._should_allow_numbers_as_tensors(
+        func.name().split("::")[-1].split(".")[0]
+    )
+
+
 class FakeTensorConfig:
     debug = os.environ.get("TORCH_FAKE_TENSOR_DEBUG", False)
 
@@ -713,12 +720,7 @@ class FakeTensor(torch.Tensor):
         # some functions that allow Python numbers to bind to Tensors
         # if we have failed to find a device, and we're running one of these operators,
         # we must have scalar only inputs
-        if (
-            torch._C._should_allow_numbers_as_tensors(
-                func.name().split("::")[-1].split(".")[0]
-            )
-            and common_device is None
-        ):
+        if should_allow_numbers_as_tensors(func) and common_device is None:
             # ops with scalar only inputs always have result on cpu
             has_scalar_only_inputs = True
             common_device = torch.device("cpu")
@@ -809,9 +811,7 @@ class FakeTensorMode(TorchDispatchMode):
         #    we can query it if we're asked to item() it at some later point
         # 2, Some functions that allow Python numbers to bind to Tensors, e.g, torch.div
         if func in self.lift_fns or (
-            torch._C._should_allow_numbers_as_tensors(
-                func.name().split("::")[-1].split(".")[0]
-            )
+            should_allow_numbers_as_tensors(func)
             and not has_symbolic_sizes
             and not flat_arg_fake_tensors
         ):


### PR DESCRIPTION
Fixes #92655

Thanks @eellison for the code change suggestion.
