### PR TITLE
Look up `group["capturable"]`, not `defaults["capturable"]` in Adam(W)

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4312,7 +4312,7 @@ exit(2)
         param2.grad = grad2
         g = torch.cuda.CUDAGraph()
         if not second_param_group_capturable:
-            with self.assertRaises(RuntimeError):
+            with self.assertRaisesRegex(RuntimeError, "Attempting CUDA graph"):
                 with torch.cuda.graph(g):
                     opt.step()
             return

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4298,30 +4298,48 @@ exit(2)
         "CUDA >= 11.0 required for graphs",
     )
     def test_graph_adam_adamw_with_explicitly_capturable_param_groups(self):
+        # mimicking `_test_graphed_optimizer` maladroitly to pass two param_groups to optimizer.__init__
+        n_warmup, n_replay = 3, 2
         for optimizer, second_param_group_capturable in product((torch.optim.Adam, torch.optim.AdamW), (True, False)):
-            param1 = torch.nn.Parameter(torch.ones(1, device="cuda"))
-            param2 = torch.nn.Parameter(torch.ones(1, device="cuda"))
-            with torch.no_grad():
-                grad1 = torch.randn_like(param1)
-                grad2 = torch.randn_like(param2)
-            params = [{"params": [param1], "capturable": True}, {"params": [param2], "capturable": second_param_group_capturable}]
+            ref_p1, param1 = [torch.nn.Parameter(torch.ones(1, device="cuda")) for _ in range(2)]
+            ref_p2, param2 = [torch.nn.Parameter(torch.ones(1, device="cuda")) for _ in range(2)]
+            grads1, grads2 = [[torch.randn_like(param1) for _ in range(n_warmup + n_replay)] for _ in range(2)]
+            ref_grads1, ref_grads2 = [[t.clone() for t in tensors] for tensors in (grads1, grads2)]
+            params = [
+                {"params": [param1], "capturable": True},
+                {"params": [param2], "capturable": second_param_group_capturable},
+            ]
             opt = optimizer(params)
+            opt_ = optimizer([
+                {"params": [ref_p1], "capturable": False},
+                {"params": [ref_p2], "capturable": False},
+            ])
 
-            param1.grad = grad1
-            param2.grad = grad2
+            for i in range(n_warmup + n_replay):
+                ref_p1.grad = ref_grads1[i]
+                ref_p2.grad = ref_grads2[i]
+                opt_.step()
+
+            for i in range(n_warmup):
+                param1.grad = grads1[i]
+                param2.grad = grads2[i]
+                opt.step()
+
             g = torch.cuda.CUDAGraph()
             if not second_param_group_capturable:
                 with self.assertRaisesRegex(RuntimeError, "Attempting CUDA graph"):
                     with torch.cuda.graph(g):
                         opt.step()
-                return
-            with torch.cuda.graph(g):
-                opt.step()
+            else:
+                with torch.cuda.graph(g):
+                    opt.step()
 
-            for _ in range(3):
-                param1.grad.copy_(grad1)
-                param2.grad.copy_(grad2)
-                g.replay()
+                for i in range(n_replay):
+                    param1.grad.copy_(grads1[n_warmup + i])
+                    param2.grad.copy_(grads2[n_warmup + i])
+                    g.replay()
+                self.assertEqual(ref_p1, param1)
+                self.assertEqual(ref_p2, param2)
 
     @unittest.skipIf(
         (not TEST_CUDA) or TEST_WITH_ROCM or int(torch.version.cuda.split(".")[0]) < 11,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4294,6 +4294,37 @@ exit(2)
                 self._test_graphed_optimizer(3, 2, optimizer_ctor, kwargs)
 
     @unittest.skipIf(
+        not TEST_CUDA or TEST_WITH_ROCM or int(torch.version.cuda.split(".")[0]) < 11,
+        "CUDA >= 11.0 required for graphs",
+    )
+    @parametrize("optimizer", (torch.optim.Adam, torch.optim.AdamW))
+    @parametrize("second_param_group_capturable", (True, False))
+    def test_graph_adam_adamw_with_explicit_capturable(self, optimizer, second_param_group_capturable):
+        param1 = torch.nn.Parameter(torch.ones(1, device="cuda"))
+        param2 = torch.nn.Parameter(torch.ones(1, device="cuda"))
+        with torch.no_grad():
+            grad1 = torch.randn_like(param1)
+            grad2 = torch.randn_like(param2)
+        params = [{"params": [param1], "capturable": True}, {"params": [param2], "capturable": second_param_group_capturable}]
+        opt = optimizer(params)
+
+        param1.grad = grad1
+        param2.grad = grad2
+        g = torch.cuda.CUDAGraph()
+        if not second_param_group_capturable:
+            with self.assertRaises(RuntimeError):
+                with torch.cuda.graph(g):
+                    opt.step()
+            return
+        with torch.cuda.graph(g):
+            opt.step()
+
+        for _ in range(3):
+            param1.grad.copy_(grad1)
+            param2.grad.copy_(grad2)
+            g.replay()
+
+    @unittest.skipIf(
         (not TEST_CUDA) or TEST_WITH_ROCM or int(torch.version.cuda.split(".")[0]) < 11,
         "CUDA >= 11.0 required for graphs",
     )

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -884,12 +884,15 @@ class TestOptim(TestCase):
 
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_fused_optimizers_with_varying_tensors(self):
-        optimizer_pairs_with_flags = [
-            (optim.Adam, dict(weight_decay=1.0, amsgrad=False)),
-            (optim.Adam, dict(weight_decay=1.0, amsgrad=True)),
-            (optim.Adam, dict(weight_decay=0.0, amsgrad=False)),
-            (optim.Adam, dict(weight_decay=0.0, amsgrad=True)),
-        ]
+        optimizer_pairs_with_flags = tuple(itertools.product(
+            (optim.Adam, optim.AdamW),
+            (
+                dict(weight_decay=1., amsgrad=False),
+                dict(weight_decay=1., amsgrad=True),
+                dict(weight_decay=0., amsgrad=False),
+                dict(weight_decay=0., amsgrad=True),
+            ),
+        ))
         self._test_derived_optimizers_varying_tensors(optimizer_pairs_with_flags, "fused")
 
     def test_adam(self):

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -85,7 +85,7 @@ class Adam(Optimizer):
                 if len(state) == 0:
                     state['step'] = (
                         torch.zeros((1,), dtype=torch.float, device=p.device)
-                        if self.defaults['capturable'] or self.defaults['fused']
+                        if group['capturable'] or group['fused']
                         else torch.tensor(0.)
                     )
                     # Exponential moving average of gradient values
@@ -140,25 +140,27 @@ class Adam(Optimizer):
                 max_exp_avg_sqs,
                 state_steps)
 
-            adam(params_with_grad,
-                 grads,
-                 exp_avgs,
-                 exp_avg_sqs,
-                 max_exp_avg_sqs,
-                 state_steps,
-                 amsgrad=group['amsgrad'],
-                 beta1=beta1,
-                 beta2=beta2,
-                 lr=group['lr'],
-                 weight_decay=group['weight_decay'],
-                 eps=group['eps'],
-                 maximize=group['maximize'],
-                 foreach=group['foreach'],
-                 capturable=group['capturable'],
-                 differentiable=group['differentiable'],
-                 fused=group['fused'],
-                 grad_scale=getattr(self, "grad_scale", None),
-                 found_inf=getattr(self, "found_inf", None))
+            adam(
+                params_with_grad,
+                grads,
+                exp_avgs,
+                exp_avg_sqs,
+                max_exp_avg_sqs,
+                state_steps,
+                amsgrad=group['amsgrad'],
+                beta1=beta1,
+                beta2=beta2,
+                lr=group['lr'],
+                weight_decay=group['weight_decay'],
+                eps=group['eps'],
+                maximize=group['maximize'],
+                foreach=group['foreach'],
+                capturable=group['capturable'],
+                differentiable=group['differentiable'],
+                fused=group['fused'],
+                grad_scale=getattr(self, "grad_scale", None),
+                found_inf=getattr(self, "found_inf", None),
+            )
 
         return loss
 

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -112,8 +112,6 @@ class Adam(Optimizer):
         Args:
             closure (Callable, optional): A closure that reevaluates the model
                 and returns the loss.
-            grad_scaler (:class:`torch.cuda.amp.GradScaler`, optional): A GradScaler which is
-                supplied from ``grad_scaler.step(optimizer)``.
         """
         self._cuda_graph_capture_health_check()
 

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -107,7 +107,7 @@ class AdamW(Optimizer):
             if len(state) == 0:
                 state["step"] = (
                     torch.zeros((1,), dtype=torch.float, device=p.device)
-                    if self.defaults["capturable"] or self.defaults["fused"]
+                    if group["capturable"] or group["fused"]
                     else torch.tensor(0.0)
                 )
                 # Exponential moving average of gradient values

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -221,7 +221,7 @@ class Optimizer(object):
 
             if (
                 (not getattr(self, "_warned_capturable_if_run_uncaptured", False))
-                and (self.defaults["capturable"] or all(group['capturable'] for group in self.param_groups))
+                and all(group['capturable'] for group in self.param_groups)
                 and (not capturing)
             ):
                 warnings.warn(

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -214,19 +214,22 @@ class Optimizer(object):
         if torch.has_cuda and torch.cuda.is_available():
             capturing = torch.cuda.is_current_stream_capturing()
 
-            if capturing and not self.defaults['capturable']:
+            # if capturing and not self.defaults['capturable']:
+            if capturing and not all(group['capturable'] for group in self.param_groups):
                 raise RuntimeError("Attempting CUDA graph capture of step() for an instance of " +
                                    self.__class__.__name__ +
                                    " but this instance was constructed with capturable=False.")
 
             if (
                 (not getattr(self, "_warned_capturable_if_run_uncaptured", False))
-                and self.defaults["capturable"]
+                and (self.defaults["capturable"] or all(group['capturable'] for group in self.param_groups))
                 and (not capturing)
             ):
-                print("Warning: This instance was constructed with capturable=True, but step() " +
-                      "is running without CUDA graph capture. If you never intend to graph-capture this " +
-                      "instance, capturable=True can impair performance, and you should set capturable=False.")
+                warnings.warn(
+                    "This instance was constructed with capturable=True or some of all the param_groups came with capturable=True, "
+                    "but step() is running without CUDA graph capture. If you never intend to graph-capture this "
+                    "instance, capturable=True can impair performance, and you should set capturable=False."
+                )
                 self._warned_capturable_if_run_uncaptured = True
 
     def _optimizer_step_code(self):

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -214,11 +214,10 @@ class Optimizer(object):
         if torch.has_cuda and torch.cuda.is_available():
             capturing = torch.cuda.is_current_stream_capturing()
 
-            # if capturing and not self.defaults['capturable']:
             if capturing and not all(group['capturable'] for group in self.param_groups):
                 raise RuntimeError("Attempting CUDA graph capture of step() for an instance of " +
                                    self.__class__.__name__ +
-                                   " but this instance was constructed with capturable=False.")
+                                   " but param_groups' capturable is False.")
 
             if (
                 (not getattr(self, "_warned_capturable_if_run_uncaptured", False))


### PR DESCRIPTION
We could set different values in each `param_group` when calling dunder init of `torch.optim` optimizers as in e.g.  https://github.com/pytorch/pytorch/issues/89987.

So check whether or not `capturable` is `True` among all the `param_group`s.