### PR TITLE
Clarify the instructions for setting up dev environment [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Other potentially useful environment variables may be found in `setup.py`.
 
 ```bash
 conda install cmake ninja
+# Run this command from the PyTorch directory after cloning the source code using the “Get the PyTorch Source“ section below
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
The `requirement.txt` file is in the PyTorch directory. The instructions to `clone` and `cd` to the PyTorch directory are in the later section under Get the PyTorch Source. So, the instructions as such gives an error that requirement.txt is not found.
```ERROR: Could not open requirements file: .. No such file or directory: 'requirements.txt' ```

This PR clarifies the usage of the command.

