### PR TITLE
Export supports Training

### DIFF
--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1689,6 +1689,14 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig):
                 fw_module, flat_args_with_views_handled
             )
 
+        with track_graph_compiling(aot_config, "backward"):
+            # !!! Trigger bw_compiler, args is WRONG
+            # Correct args should be [fw_outs_saved_for_bw, grad_outputs]
+            compiled_bw_func = aot_config.bw_compiler(
+                bw_module,
+                None   # this is a hack
+            )
+
     class CompiledFunction(torch.autograd.Function):
         compiled_fw = compiled_fw_func
         compiled_bw = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94158

Learnings from this prototype
- 

**Joint Graph or Split FW/BW Graphs?** 
- For joint graph to work, everything in the forward pass needs to passed to export(), including the loss function. 
- For a multi-task model, it's unlikely that we export the entire model in one shot. Instead, it's more likely that we export one Module(Arch) at a time. Consequently, the execution flow would be FW_Graph1 ->FW_Graph2 -> BW_Graph2 -> BW_Graph1. It's more feasible to export FW and BW in two separated graphs. 

**Should parameters/buffers be lifted as graph inputs?** 
- AOTAutograd currently lifts all parameters (TODO: not sure about buffers) as graph inputs. It's unclear that if this is right handling for export path: having all the parameters in graph input is confusing for user, and it's result in a different input signature from the original functions.

**Naming UX**
- It's hard to tell original semantics from these names `primals_1, primals_2, tangents_1...`. 
- We need some sort of traceback to link `primals_1` to `self.linear.weight` and `primals_3` to `val`. This is available in node.meta, and it should also be preserved in the serialized graph. 
- Ideally, `primals_1` should have a more meaningful name, e.g. `self_linear_weight`.  `tangents_1` should be `loss_grad`. 

**Implementation Notes**
- ATM, inference export is calling make_fx, this training export prototype is calling aot_module_simplified. We should unify them, so that they have the identical graph properties, e.g. handling of parameters. 
- There are merits for torch.compile() and torch.export() to share the aot_module_simplified path, but if their technical requirements diverges, we should consider adding an export-specific path for AOTAutograd. 

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire