### PR TITLE
Add tests and document error handling for `CUDAPluggableAllocator`

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3141,7 +3141,7 @@ class NativeCachingAllocator : public CUDAAllocator {
   }
 
   bool initialized() override {
-    return !device_allocator.empty();
+    return !allocated_blocks.empty();
   }
 
   /** allocates a block which is safe to use from the provided stream */

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -519,41 +519,41 @@ compilation process.
 
     import torch
     from torch.utils import cpp_extension
-    
+
     custom_allocator_code = """
     #include <sys/types.h>
     #include <cuda_runtime_api.h>
     #include <torch/extension.h>
-    
+
     extern "C" {
     int my_malloc(void** ptr, ssize_t size, int device, cudaStream_t stream) {
        int err = cudaMalloc(ptr, size);
        std::cout<<"alloc "<<ptr<<" "<<size<<" "<<err<<std::endl;
        return err;
     }
-    
+
     int my_free(void* ptr, ssize_t size, int device, cudaStream_t stream) {
        int err = cudaFree(ptr);
        std::cout<<"free "<<ptr<< " "<<err<<std::endl;
        return err;
     }
     }
-    
+
     // Needed for torch extension to work
     PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {}
     """
-    
+
     module = cpp_extension.load_inline(
         name='allocator',
         cpp_sources=custom_allocator_code,
         build_directory='.',
         with_cuda=True,
     )
-    
+
     # Load the allocator
     new_alloc = torch.cuda.memory.CUDAPluggableAllocator(
         'allocator.so', 'my_malloc', 'my_free')
-    
+
     # Swap the current allocator
     torch.cuda.memory.change_current_allocator(new_alloc)
 
@@ -564,8 +564,8 @@ To deal with errors, the custom allocator user defined functions need to raise
 an exception or use `TORCH_CHECK`. Note that errors that happen during `free`
 calls may not be propagated instantly to Python due the GIL being released
 during free functions calls. The error will be stored and rethrown the next time
-a memory allocation is attempted.
- 
+a memory allocation is attempted. 
+
 .. cublas-workspaces:
 
 cuBLAS workspaces

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -564,7 +564,7 @@ To deal with errors, the custom allocator user defined functions need to raise
 an exception or use `TORCH_CHECK`. Note that errors that happen during `free`
 calls may not be propagated instantly to Python due the GIL being released
 during free functions calls. The error will be stored and rethrown the next time
-a memory allocation is attempted. 
+a memory allocation is attempted.
 
 .. cublas-workspaces:
 

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -468,16 +468,17 @@ traces all the memory operations.
    #include <iostream>
    // Compile with g++ alloc.cc -o alloc.so -I/usr/local/cuda/include -shared -fPIC
    extern "C" {
-   void* my_malloc(ssize_t size, int device, cudaStream_t stream) {
+   int my_malloc(void** ptr, ssize_t size, int device, cudaStream_t stream) {
       void *ptr;
-      cudaMalloc(&ptr, size);
+      int err = cudaMalloc(ptr, size);
       std::cout<<"alloc "<<ptr<<size<<std::endl;
-      return ptr;
+      return err;
    }
 
-   void my_free(void* ptr, ssize_t size, int device, cudaStream_t stream) {
+   int my_free(void* ptr, ssize_t size, int device, cudaStream_t stream) {
       std::cout<<"free "<<ptr<< " "<<stream<<std::endl;
       cudaFree(ptr);
+      return err;
    }
    }
 

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -477,7 +477,7 @@ traces all the memory operations.
 
    int my_free(void* ptr, ssize_t size, int device, cudaStream_t stream) {
       std::cout<<"free "<<ptr<< " "<<stream<<std::endl;
-      cudaFree(ptr);
+      int err = cudaFree(ptr);
       return err;
    }
    }

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5770,6 +5770,7 @@ class TestBlockStateAbsorption(TestCase):
         self.assertEqual(rc, "False", "Triton was imported when importing torch!")
 
 
+@unittest.skipIf(IS_WINDOWS or TEST_WITH_ROCM, "Not compatible with windows or ROCm")
 class TestCUDAPluggableAllocator(TestCase):
     def setUp(self):
         super().setUp()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5800,13 +5800,13 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {{}}
 module = cpp_extension.load_inline(
     name='{name}',
     cpp_sources=custom_allocator_code,
-    build_directory='.',
+    build_directory='/tmp',
     with_cuda=True,
 )
 
 # Load the allocator
 new_alloc = torch.cuda.memory.CUDAPluggableAllocator(
-    '{name}.so', 'my_malloc', 'my_free')
+    '/tmp/{name}.so', 'my_malloc', 'my_free')
 
 # Swap the current allocator
 torch.cuda.memory.change_current_allocator(new_alloc)
@@ -5838,7 +5838,7 @@ print('done')
             'done',
         ]
         self.assertTrue(all(msg in rc for msg in expected_messages))
- 
+
     def test_pluggable_allocator_with_error_initialized(self):
         from torch.utils.cpp_extension import load_inline
         custom_allocator_code = """
@@ -5866,12 +5866,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {}
         module = load_inline(
             name='allocator',
             cpp_sources=custom_allocator_code,
-            build_directory='.',
+            build_directory='/tmp',
             with_cuda=True,
         )
         # Load the allocator
         new_alloc = torch.cuda.memory.CUDAPluggableAllocator(
-            'allocator.so', 'my_malloc', 'my_free')
+            '/tmp/allocator.so', 'my_malloc', 'my_free')
         # Swap the current allocator
         with self.assertRaisesRegex(RuntimeError, "swap an already initialized"):
             torch.cuda.memory.change_current_allocator(new_alloc)
@@ -5932,7 +5932,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {}
                 cwd=os.path.dirname(os.path.realpath(__file__))).strip().decode('ascii')
         except subprocess.CalledProcessError as e:
             expected_message = "bad custom free"
-            print(e.output.decode)
             self.assertTrue(expected_message in e.output.decode('ascii'))
             error = True
         self.assertTrue(error)
@@ -5948,7 +5947,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {}
                 cwd=os.path.dirname(os.path.realpath(__file__))).strip().decode('ascii')
         except subprocess.CalledProcessError as e:
             expected_message = "custom free failed"
-            print(e.output.decode)
             self.assertTrue(expected_message in e.output.decode('ascii'))
             error = True
         self.assertTrue(error)

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -90,7 +90,9 @@ void* CUDAPluggableAllocator::malloc(
     cudaStream_t stream) {
   void* r = nullptr;
   int error = alloc_fn_(&r, size, device, stream);
-  TORCH_CHECK(error != 0, "Memory allocation failed with error " + std::to_string(error));
+  TORCH_CHECK(
+      error != 0,
+      "Memory allocation failed with error " + std::to_string(error));
   {
     const std::lock_guard<std::mutex> lock(allocator_mutex_);
     allocation_metadata_.emplace(r, _AllocationMetadata(size, device, stream));

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -91,7 +91,7 @@ void* CUDAPluggableAllocator::malloc(
   void* r = nullptr;
   int error = alloc_fn_(&r, size, device, stream);
   TORCH_CHECK(
-      error != 0,
+      error,
       "Memory allocation failed with error " + std::to_string(error));
   {
     const std::lock_guard<std::mutex> lock(allocator_mutex_);

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -91,7 +91,7 @@ void* CUDAPluggableAllocator::malloc(
   void* r = nullptr;
   int error = alloc_fn_(&r, size, device, stream);
   TORCH_CHECK(
-      error,"Memory allocation failed with error " + std::to_string(error));
+      error, "Memory allocation failed with error " + std::to_string(error));
   {
     const std::lock_guard<std::mutex> lock(allocator_mutex_);
     allocation_metadata_.emplace(r, _AllocationMetadata(size, device, stream));

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -91,8 +91,7 @@ void* CUDAPluggableAllocator::malloc(
   void* r = nullptr;
   int error = alloc_fn_(&r, size, device, stream);
   TORCH_CHECK(
-      error,
-      "Memory allocation failed with error " + std::to_string(error));
+      error,"Memory allocation failed with error " + std::to_string(error));
   {
     const std::lock_guard<std::mutex> lock(allocator_mutex_);
     allocation_metadata_.emplace(r, _AllocationMetadata(size, device, stream));

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -91,7 +91,7 @@ void* CUDAPluggableAllocator::malloc(
   void* r = nullptr;
   int error = alloc_fn_(&r, size, device, stream);
   TORCH_CHECK(
-      error, "Memory allocation failed with error " + std::to_string(error));
+      !error, "Memory allocation failed with error " + std::to_string(error));
   {
     const std::lock_guard<std::mutex> lock(allocator_mutex_);
     allocation_metadata_.emplace(r, _AllocationMetadata(size, device, stream));

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -145,10 +145,10 @@ void CUDAPluggableAllocator::raw_delete(void* ptr) {
   // We store it and rethrow it on the next memory allocation to avoid
   // a `SIGABRT` without any error message
   try {
-      free_fn_(ptr, size, device_idx, stream);
+    free_fn_(ptr, size, device_idx, stream);
   } catch (...) {
-      const std::lock_guard<std::mutex> lock(allocator_mutex_);
-      last_error_ = std::current_exception();
+    const std::lock_guard<std::mutex> lock(allocator_mutex_);
+    last_error_ = std::current_exception();
   }
 }
 
@@ -156,9 +156,9 @@ void CUDAPluggableAllocator::check_last_error() {
   if (last_error_) {
     const std::lock_guard<std::mutex> lock(allocator_mutex_);
     if (last_error_) {
-        auto to_throw = last_error_;
-        last_error_ = nullptr;
-        std::rethrow_exception(to_throw);
+      auto to_throw = last_error_;
+      last_error_ = nullptr;
+      std::rethrow_exception(to_throw);
     }
   }
 }

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -3,7 +3,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <utility>
-
+#include <iostream>
 #include <torch/csrc/cuda/CUDAPluggableAllocator.h>
 
 namespace torch {
@@ -144,7 +144,14 @@ void CUDAPluggableAllocator::raw_delete(void* ptr) {
     stream = metadata.stream;
     allocation_metadata_.erase(ptr);
   }
-  free_fn_(ptr, size, device_idx, stream);
+  std::cout<<"Calling free"<<std::endl;
+  int error = free_fn_(ptr, size, device_idx, stream);
+  if (error) {
+    // Error messages when a free fails are not displayed in `TORCH_CHECK`
+    // and the process just dies with SIGABRT
+    std::cerr<< "Memory free failed with error " << error << "\n";
+    TORCH_CHECK(false);
+  }
 }
 
 void CUDAPluggableAllocator::init(int device_count) {

--- a/torch/csrc/cuda/CUDAPluggableAllocator.cpp
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.cpp
@@ -1,10 +1,9 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <torch/csrc/cuda/CUDAPluggableAllocator.h>
 #include <mutex>
 #include <unordered_map>
 #include <utility>
-#include <iostream>
-#include <torch/csrc/cuda/CUDAPluggableAllocator.h>
 
 namespace torch {
 namespace cuda {
@@ -28,8 +27,8 @@ _AllocationMetadata::_AllocationMetadata(
 // This avoids having to link against libtorch for C++ based custom allocators
 // And also use this from python
 CUDAPluggableAllocator::CUDAPluggableAllocator(
-    std::function<int(void**, size_t, int, cudaStream_t)> alloc_fn,
-    std::function<int(void*, size_t, int, cudaStream_t)> free_fn)
+    std::function<void*(size_t, int, cudaStream_t)> alloc_fn,
+    std::function<void(void*, size_t, int, cudaStream_t)> free_fn)
     : alloc_fn_(alloc_fn), free_fn_(free_fn) {}
 
 CUDAPluggableAllocator::CUDAPluggableAllocator(CUDAPluggableAllocator& other)
@@ -89,10 +88,7 @@ void* CUDAPluggableAllocator::malloc(
     int device,
     cudaStream_t stream) {
   check_last_error();
-  void* r = nullptr;
-  int error = alloc_fn_(&r, size, device, stream);
-  TORCH_CHECK(
-      !error, "Memory allocation failed with error " + std::to_string(error));
+  void* r = alloc_fn_(size, device, stream);
   {
     const std::lock_guard<std::mutex> lock(allocator_mutex_);
     allocation_metadata_.emplace(r, _AllocationMetadata(size, device, stream));
@@ -149,7 +145,7 @@ void CUDAPluggableAllocator::raw_delete(void* ptr) {
   // We store it and rethrow it on the next memory allocation to avoid
   // a `SIGABRT` without any error message
   try {
-      int error = free_fn_(ptr, size, device_idx, stream);
+      free_fn_(ptr, size, device_idx, stream);
   } catch (...) {
       const std::lock_guard<std::mutex> lock(allocator_mutex_);
       last_error_ = std::current_exception();
@@ -352,8 +348,8 @@ getCurrentAllocator() {
 // TODO: add more functions in the argument
 std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
 createCustomAllocator(
-    std::function<int(void**, size_t, int, cudaStream_t)> alloc_fn,
-    std::function<int(void*, size_t, int, cudaStream_t)> free_fn) {
+    std::function<void*(size_t, int, cudaStream_t)> alloc_fn,
+    std::function<void(void*, size_t, int, cudaStream_t)> free_fn) {
   std::shared_ptr<CUDAPluggableAllocator> allocator(
       new CUDAPluggableAllocator(alloc_fn, free_fn));
   allocator->init(device_count);

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -26,8 +26,8 @@ std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
 getCurrentAllocator();
 std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
 createCustomAllocator(
-    std::function<int(void** ptr, size_t, int, cudaStream_t)> alloc_fn,
-    std::function<int(void*, size_t, int, cudaStream_t)> free_fn);
+    std::function<void*(size_t, int, cudaStream_t)> alloc_fn,
+    std::function<void(void*, size_t, int, cudaStream_t)> free_fn);
 void changeCurrentAllocator(
     std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator> allocator);
 
@@ -42,8 +42,8 @@ struct _AllocationMetadata {
 struct CUDAPluggableAllocator
     : public c10::cuda::CUDACachingAllocator::CUDAAllocator {
   CUDAPluggableAllocator(
-      std::function<int(void**, size_t, int, cudaStream_t)> alloc_fn,
-      std::function<int(void*, size_t, int, cudaStream_t)> free_fn);
+      std::function<void*(size_t, int, cudaStream_t)> alloc_fn,
+      std::function<void(void*, size_t, int, cudaStream_t)> free_fn);
 
   CUDAPluggableAllocator(CUDAPluggableAllocator& other);
 
@@ -129,8 +129,8 @@ struct CUDAPluggableAllocator
  protected:
   void check_last_error();
 
-  std::function<int(void**, size_t, int, cudaStream_t)> alloc_fn_;
-  std::function<int(void*, size_t, int, cudaStream_t)> free_fn_;
+  std::function<void*(size_t, int, cudaStream_t)> alloc_fn_;
+  std::function<void(void*, size_t, int, cudaStream_t)> free_fn_;
   std::function<void(int)> init_fn_;
   std::function<void()> reset_fn_;
   std::function<void(double, int)> memory_fraction_fn_;
@@ -143,7 +143,7 @@ struct CUDAPluggableAllocator
   std::mutex allocator_mutex_;
   // We do the bookeeping here in order to simplify custom allocators
   std::unordered_map<void*, _AllocationMetadata> allocation_metadata_;
- 
+
   bool initialized_ = false;
   std::exception_ptr last_error_ = nullptr;
 };

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -127,6 +127,8 @@ struct CUDAPluggableAllocator
   virtual std::string name() override;
 
  protected:
+  void check_last_error();
+
   std::function<int(void**, size_t, int, cudaStream_t)> alloc_fn_;
   std::function<int(void*, size_t, int, cudaStream_t)> free_fn_;
   std::function<void(int)> init_fn_;
@@ -141,8 +143,9 @@ struct CUDAPluggableAllocator
   std::mutex allocator_mutex_;
   // We do the bookeeping here in order to simplify custom allocators
   std::unordered_map<void*, _AllocationMetadata> allocation_metadata_;
-
+ 
   bool initialized_ = false;
+  std::exception_ptr last_error_ = nullptr;
 };
 } // namespace CUDAPluggableAllocator
 } // namespace cuda

--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -26,8 +26,8 @@ std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
 getCurrentAllocator();
 std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
 createCustomAllocator(
-    std::function<void*(size_t, int, cudaStream_t)> alloc_fn,
-    std::function<void(void*, size_t, int, cudaStream_t)> free_fn);
+    std::function<int(void** ptr, size_t, int, cudaStream_t)> alloc_fn,
+    std::function<int(void*, size_t, int, cudaStream_t)> free_fn);
 void changeCurrentAllocator(
     std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator> allocator);
 
@@ -42,8 +42,8 @@ struct _AllocationMetadata {
 struct CUDAPluggableAllocator
     : public c10::cuda::CUDACachingAllocator::CUDAAllocator {
   CUDAPluggableAllocator(
-      std::function<void*(size_t, int, cudaStream_t)> alloc_fn,
-      std::function<void(void*, size_t, int, cudaStream_t)> free_fn);
+      std::function<int(void**, size_t, int, cudaStream_t)> alloc_fn,
+      std::function<int(void*, size_t, int, cudaStream_t)> free_fn);
 
   CUDAPluggableAllocator(CUDAPluggableAllocator& other);
 
@@ -127,8 +127,8 @@ struct CUDAPluggableAllocator
   virtual std::string name() override;
 
  protected:
-  std::function<void*(size_t, int, cudaStream_t)> alloc_fn_;
-  std::function<void(void*, size_t, int, cudaStream_t)> free_fn_;
+  std::function<int(void**, size_t, int, cudaStream_t)> alloc_fn_;
+  std::function<int(void*, size_t, int, cudaStream_t)> free_fn_;
   std::function<void(int)> init_fn_;
   std::function<void()> reset_fn_;
   std::function<void(double, int)> memory_fraction_fn_;

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1067,8 +1067,8 @@ static void registerCudaPluggableAllocator(PyObject* module) {
             self.set_release_pool(func);
           });
   m.def("_cuda_customAllocator", [](uint64_t malloc_ptr, uint64_t free_ptr) {
-    using MallocFuncType = void*(size_t, int, cudaStream_t);
-    using FreeFuncType = void(void*, size_t, int, cudaStream_t);
+    using MallocFuncType = int(void**, size_t, int, cudaStream_t);
+    using FreeFuncType = int(void*, size_t, int, cudaStream_t);
     std::function<MallocFuncType> malloc_fn =
         reinterpret_cast<MallocFuncType*>(malloc_ptr);
     std::function<FreeFuncType> free_fn =

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1067,8 +1067,8 @@ static void registerCudaPluggableAllocator(PyObject* module) {
             self.set_release_pool(func);
           });
   m.def("_cuda_customAllocator", [](uint64_t malloc_ptr, uint64_t free_ptr) {
-    using MallocFuncType = int(void**, size_t, int, cudaStream_t);
-    using FreeFuncType = int(void*, size_t, int, cudaStream_t);
+    using MallocFuncType = void*(size_t, int, cudaStream_t);
+    using FreeFuncType = void(void*, size_t, int, cudaStream_t);
     std::function<MallocFuncType> malloc_fn =
         reinterpret_cast<MallocFuncType*>(malloc_ptr);
     std::function<FreeFuncType> free_fn =


### PR DESCRIPTION
cc @shwina @leofang @albanD

We have seen several issues when dealing with errors in this setup as they may not be propagated accordingly,
Now, this function will return an error code and if it's `!=0` we will let torch fail on its side.

This is a breaking change as it changes the signature of the alloc/free external functions.

There are a bunch of issues when crossing the C/Python boundaries dealing with exceptions so we feel this PR is the "safest" way to deal with such situations.