### PR TITLE
[Dynamo] modify dynamo ipex backend

### DIFF
--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -84,9 +84,15 @@ def fake_tensor_unsupported(fn):
     def defake(x):
         if not isinstance(x, FakeTensor):
             return x
+        if x._has_symbolic_sizes_strides:
+            size = [s.node.shape_env.size_hint(s.node.expr) for s in x.size()]
+            stride = [s.node.shape_env.size_hint(s.node.expr) for s in x.stride()]
+        else:
+            size = x.size()
+            stride = x.stride()
         y = torch.empty_strided(
-            x.size(),
-            x.stride(),
+            size,
+            stride,
             dtype=x.dtype,
             device=x.device,
             requires_grad=x.requires_grad,

--- a/torch/_dynamo/backends/ipex.py
+++ b/torch/_dynamo/backends/ipex.py
@@ -2,8 +2,8 @@ import importlib
 import logging
 
 import torch
-from .common import fake_tensor_unsupported
 from torch._dynamo import register_backend
+from .common import fake_tensor_unsupported
 
 log = logging.getLogger(__name__)
 

--- a/torch/_dynamo/backends/ipex.py
+++ b/torch/_dynamo/backends/ipex.py
@@ -2,13 +2,14 @@ import importlib
 import logging
 
 import torch
-
+from .common import fake_tensor_unsupported
 from torch._dynamo import register_backend
 
 log = logging.getLogger(__name__)
 
 
 @register_backend
+@fake_tensor_unsupported
 def ipex(model, inputs):
     try:
         import intel_extension_for_pytorch  # type: ignore[import]  # noqa: F401
@@ -20,24 +21,9 @@ def ipex(model, inputs):
         )
         raise
 
-    from torch.utils._mode_utils import no_dispatch
-
-    with no_dispatch():
-        static_inputs = []
-        for x in inputs:
-            if x._has_symbolic_sizes_strides:
-                size = [s.node.shape_env.size_hint(s.node.expr) for s in x.size()]
-                stride = [s.node.shape_env.size_hint(s.node.expr) for s in x.stride()]
-                static_inputs.append(
-                    torch.as_strided(
-                        torch.zeros(size, dtype=x.dtype, device=x.device), size, stride
-                    )
-                )
-            else:
-                static_inputs.append(torch.zeros_like(x))
     try:
         with torch.no_grad():
-            traced_model = torch.jit.trace(model.eval(), static_inputs)
+            traced_model = torch.jit.trace(model.eval(), inputs)
             traced_model = torch.jit.freeze(traced_model)
         return traced_model
     except Exception:


### PR DESCRIPTION
1. Extend fake_tensor_unsupported to support dynamic shapes mode.
2. Use fake_tensor_unsupported  in dynamo ipex backend.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @desertfire