### PR TITLE
Disable USE_FAST_NVCC Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,7 +361,10 @@ endif()
 if(WIN32)
   set(USE_TENSORPIPE OFF)
   message(WARNING "TensorPipe cannot be used on Windows. Set it to OFF")
-
+  if(USE_FAST_NVCC)
+    set(USE_FAST_NVCC OFF)
+    message(WARNING "FAST_NVCC cannot be used on Windows. Set it to OFF")
+  endif()
   if(USE_DISTRIBUTED AND NOT DEFINED ENV{libuv_ROOT})
     find_library(
       libuv_tmp_LIBRARY


### PR DESCRIPTION
If USE_FAST_NVCC is ON, receive a warning message instead of an error that will continue the build without CUDA.

Fixes #67100
