### PR TITLE
Make linter quick-checks setup steps retryable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,10 +92,15 @@ jobs:
           cache-dependency-path: |
             **/requirements.txt
       - name: Install dependencies
+        uses: nick-fields/retry@v2.8.2
         id: requirements
-        run: |
-          pip install -r requirements.txt --user
-          sudo apt-get install -y doxygen
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 90
+          command: |
+            pip install -r requirements.txt --user
+            sudo apt-get install -y doxygen
       - name: Ensure no non-breaking spaces (nonretryable)
         if: always()
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,10 +91,12 @@ jobs:
           cache: pip
           cache-dependency-path: |
             **/requirements.txt
-      - name: Install requirements
+      - name: Install dependencies
         id: requirements
-        run: pip install -r requirements.txt --user
-      - name: Ensure no non-breaking spaces
+        run: |
+          pip install -r requirements.txt --user
+          sudo apt-get install -y doxygen
+      - name: Ensure no non-breaking spaces (nonretryable)
         if: always()
         run: |
           # NB: We use 'printf' below rather than '\u000a' since bash pre-4.2
@@ -111,7 +113,6 @@ jobs:
       - name: C++ docs check (nonretryable)
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
-          sudo apt-get install -y doxygen
           cd docs/cpp/source && ./check-doxygen.sh
       - name: CUDA kernel launch check (nonretryable)
         if: ${{ always() && steps.requirements.outcome == 'success' }}


### PR DESCRIPTION
We've been seeing linter failures when the `apt-get install doxygen` command fails to install due to network errors, and the workflow doesn't get retried since it's in a non-retryable step

This PR moves it to a retryable step

It also marks a deterministic step as nonretryable, since retrying that one will never change the output
