### PR TITLE
Dynamo: Fix to unpack ConstantVariable in call_range()

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -631,6 +631,17 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             self, fn=fn1, nargs=1, expected_ops=3
         )
 
+    def test_range_with_shape(self):
+        def fn(a):
+            for i in range(1, a.shape[0]):
+                a += 1
+            return a
+
+        # expect 1 more op (size call) for dynamic
+        return torch._dynamo.testing.standard_test(
+            self, fn=fn, nargs=1, expected_ops=9, expected_ops_dynamic=10
+        )
+
     def test_no_grad(self):
         def fn1(a, b):
             x = a + 1

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -610,6 +610,8 @@ class BuiltinVariable(VariableTracker):
             def guard_if_dyn(arg):
                 if isinstance(arg, DynamicShapeVariable):
                     return arg.evaluate_expr(tx.output)
+                elif isinstance(arg, ConstantVariable):
+                    return arg.as_python_constant()
                 return arg
 
             args = [variables.ConstantVariable(guard_if_dyn(arg)) for arg in args]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #94224
* #94203
* __->__ #94202

Fixes the `pyhpc_turbulent_kinetic_energy` model in torchbench.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire