### PR TITLE
[AIT & TRT] const fold should skip non-tensor values

### DIFF
--- a/torch/fx/experimental/const_fold.py
+++ b/torch/fx/experimental/const_fold.py
@@ -179,6 +179,15 @@ def split_const_subgraphs(
         if node.is_impure():
             continue
 
+        # Skip folding non-tensor values
+        node_type = node.meta.get('type', None)
+        if (
+            node_type
+            and isinstance(node_type, type)
+            and not issubclass(node_type, torch.Tensor)
+        ):
+            continue
+
         # Must be a constant foldable node at this point.
         const_nodes.add(node)
         if node.op != "get_attr":


### PR DESCRIPTION
Summary: const fold can't handle non-tensor values.

Differential Revision: D43060919

