### PR TITLE
[vulkan] Add core graph components

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Command.cpp
+++ b/aten/src/ATen/native/vulkan/api/Command.cpp
@@ -341,7 +341,7 @@ void CommandBuffer::reset_querypool(
   vkCmdResetQueryPool(handle_, querypool, first_idx, count);
 }
 
-VkCommandBuffer CommandBuffer::get_submit_handle() {
+VkCommandBuffer CommandBuffer::get_submit_handle(const bool final_use) {
   TORCH_CHECK(
       state_ == CommandBuffer::State::READY,
       "Vulkan CommandBuffer: called begin() on a command buffer whose state "
@@ -349,7 +349,7 @@ VkCommandBuffer CommandBuffer::get_submit_handle() {
 
   const VkCommandBuffer handle = handle_;
 
-  if (!is_reusable()) {
+  if (!is_reusable() || final_use) {
     invalidate();
   }
   state_ = CommandBuffer::State::SUBMITTED;

--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -120,7 +120,7 @@ class CommandBuffer final {
   void write_timestamp(const VkQueryPool, const uint32_t) const;
   void reset_querypool(const VkQueryPool, const uint32_t, const uint32_t) const;
 
-  VkCommandBuffer get_submit_handle();
+  VkCommandBuffer get_submit_handle(const bool final_use = false);
 
   inline operator bool() const {
     return VK_NULL_HANDLE != handle_;

--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -70,10 +70,13 @@ void Context::submit_compute_epilogue(
   command_buffer.dispatch(global_workgroup_size);
 }
 
-void Context::submit_cmd_to_gpu(const VkFence fence_handle) {
+void Context::submit_cmd_to_gpu(
+    const VkFence fence_handle,
+    const bool final_use) {
   if (cmd_) {
     cmd_.end();
-    adapter_p_->submit_cmd(queue_, cmd_.get_submit_handle(), fence_handle);
+    adapter_p_->submit_cmd(
+        queue_, cmd_.get_submit_handle(final_use), fence_handle);
 
     submit_count_ = 0u;
   }

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -196,7 +196,9 @@ class Context final {
       const VkFence fence_handle,
       Arguments&&...);
 
-  void submit_cmd_to_gpu(const VkFence fence_handle = VK_NULL_HANDLE);
+  void submit_cmd_to_gpu(
+      const VkFence fence_handle = VK_NULL_HANDLE,
+      const bool final_use = false);
 
   void flush();
 };
@@ -255,14 +257,18 @@ class StorageBuffer final {
   StorageBuffer(const StorageBuffer&) = delete;
   StorageBuffer& operator=(const StorageBuffer&) = delete;
 
-  StorageBuffer(StorageBuffer&&) = delete;
-  StorageBuffer& operator=(StorageBuffer&&) = delete;
+  StorageBuffer(StorageBuffer&&) = default;
+  StorageBuffer& operator=(StorageBuffer&&) = default;
 
   ~StorageBuffer() {
     context_p_->register_buffer_cleanup(vulkan_buffer_);
   }
 
-  VulkanBuffer& buffer() {
+  inline c10::ScalarType dtype() {
+    return dtype_;
+  }
+
+  inline VulkanBuffer& buffer() {
     return vulkan_buffer_;
   }
 };

--- a/aten/src/ATen/native/vulkan/api/Tensor.h
+++ b/aten/src/ATen/native/vulkan/api/Tensor.h
@@ -101,6 +101,16 @@ class vTensor final {
       const api::StorageType storage_type = api::StorageType::TEXTURE_3D,
       const c10::MemoryFormat memory_format = c10::MemoryFormat::Contiguous);
 
+  // Copy Constructor and Assignment; Ideally copying  would be disabled
+  // (see the reasoning for move assignment below) but it is required for
+  // compatibility with OpaqueTensorImpl
+  vTensor(const vTensor& other) = default;
+  vTensor& operator=(const vTensor& other) = default;
+
+  // Move Constructor and assignment
+  vTensor(vTensor&& other) = default;
+  vTensor& operator=(vTensor&& other) = default;
+
   // Used for passing buffer sizes and strides data to shaders
   struct BufferMetadata {
     api::utils::uvec4 sizes;
@@ -269,15 +279,15 @@ class vTensor final {
     return c10::multiply_integers(sizes());
   }
 
+  inline size_t nbytes() const {
+    return c10::elementSize(dtype()) * numel();
+  }
+
   /*
    * Returns numel but based on gpu_sizes_ instead of sizes_
    */
   inline size_t gpu_numel() const {
     return view_->buffer_length_;
-  }
-
-  inline size_t nbytes() const {
-    return c10::elementSize(dtype()) * numel();
   }
 
   /*

--- a/aten/src/ATen/native/vulkan/graph/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Arithmetic.cpp
@@ -1,0 +1,101 @@
+#include <ATen/native/vulkan/impl/Common.h>
+
+#include <ATen/native/vulkan/graph/Arithmetic.h>
+#include <ATen/native/vulkan/graph/Staging.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void add_arithmetic_node(
+    ComputeGraph& graph,
+    const ValueRef t1,
+    const ValueRef t2,
+    const ValueRef out,
+    const float alpha,
+    const arithmetic::OpType optype) {
+  // Prepacking first arg (if needed)
+  ValueRef arg1 = t1;
+  if (graph.get_val(t1).isTensorRef()) {
+    TensorRef& t1_asref = graph.get_val(t1).toTensorRef();
+    ValueRef t1_vten = graph.add_tensor(t1_asref.sizes, t1_asref.dtype);
+    graph.prepack_nodes().emplace_back(new ArithmeticPrepack(t1, t1_vten));
+    arg1 = t1_vten;
+  }
+  VKGRAPH_CHECK(graph.get_val(arg1).isTensor());
+  // Prepacking second arg (if needed)
+  ValueRef arg2 = t2;
+  if (graph.get_val(t2).isTensorRef()) {
+    TensorRef& t2_asref = graph.get_val(t2).toTensorRef();
+    ValueRef t2_vten = graph.add_tensor(t2_asref.sizes, t2_asref.dtype);
+    graph.prepack_nodes().emplace_back(new ArithmeticPrepack(t2, t2_vten));
+    arg2 = t2_vten;
+  }
+  VKGRAPH_CHECK(graph.get_val(arg2).isTensor());
+
+  graph.execute_nodes().emplace_back(
+      new ArithmeticNode(arg1, arg2, out, alpha, optype));
+}
+
+ValueRef add_arithmetic_node(
+    ComputeGraph& graph,
+    const ValueRef t1,
+    const ValueRef t2,
+    const float alpha,
+    const arithmetic::OpType optype) {
+  IntArrayRef t1_sizes = graph.get_val_sizes(t1);
+  c10::ScalarType t1_dtype = graph.get_val_dtype(t1);
+
+  IntArrayRef t2_sizes = graph.get_val_sizes(t2);
+  c10::ScalarType t2_dtype = graph.get_val_dtype(t2);
+
+  ValueRef out = graph.add_tensor(t1_sizes, t1_dtype);
+  add_arithmetic_node(graph, t1, t2, out, alpha, optype);
+  return out;
+}
+
+ArithmeticPrepack::ArithmeticPrepack(
+    const ValueRef tref,
+    const ValueRef packed) {
+  inputs_.emplace_back(tref);
+  outputs_.emplace_back(packed);
+}
+
+void ArithmeticPrepack::encode_prepack(ComputeGraph* graph) const {
+  TensorRef tref = graph->get_val(inputs_[0]).toTensorRef();
+  vTensor packed = graph->get_val(outputs_[0]).toTensor();
+
+  api::StorageBuffer staging(
+      graph->context(), packed.dtype(), packed.gpu_nbytes());
+
+  size_t numel = c10::multiply_integers(tref.sizes);
+  size_t nbytes = numel * c10::elementSize(tref.dtype);
+  copy_ptr_to_staging(tref.data, staging, nbytes);
+
+  encode_copy_to_vtensor(graph->context(), staging, packed);
+}
+
+ArithmeticNode::ArithmeticNode(
+    const ValueRef t1,
+    const ValueRef t2,
+    const ValueRef out,
+    const float alpha,
+    const arithmetic::OpType optype)
+    : alpha_(alpha), optype_(optype) {
+  inputs_.emplace_back(t1);
+  inputs_.emplace_back(t2);
+  outputs_.emplace_back(out);
+}
+
+void ArithmeticNode::encode_execute(ComputeGraph* graph) const {
+  vTensor& in1 = graph->get_val(inputs_[0]).toTensor();
+  vTensor& in2 = graph->get_val(inputs_[1]).toTensor();
+  vTensor& out = graph->get_val(outputs_[0]).toTensor();
+
+  api::ShaderInfo kernel = arithmetic::get_shader(optype_);
+  arithmetic::record_op(graph->context(), kernel, in1, in2, out, alpha_);
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/graph/Arithmetic.h
+++ b/aten/src/ATen/native/vulkan/graph/Arithmetic.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/impl/Arithmetic.h>
+
+#include <ATen/native/vulkan/graph/Graph.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void add_arithmetic_node(
+    ComputeGraph& graph,
+    const ValueRef t1,
+    const ValueRef t2,
+    const ValueRef out,
+    const float alpha,
+    const arithmetic::OpType optype);
+
+ValueRef add_arithmetic_node(
+    ComputeGraph& graph,
+    const ValueRef t1,
+    const ValueRef t2,
+    const float alpha,
+    const arithmetic::OpType optype);
+
+class ArithmeticPrepack : public virtual OpNode {
+ public:
+  explicit ArithmeticPrepack(const ValueRef tref, const ValueRef packed);
+
+  void encode_prepack(ComputeGraph* graph) const override;
+};
+
+class ArithmeticNode : public virtual OpNode {
+ public:
+  explicit ArithmeticNode(
+      const ValueRef t1,
+      const ValueRef t2,
+      const ValueRef out,
+      const float alpha,
+      const arithmetic::OpType optype);
+
+  void encode_execute(ComputeGraph* graph) const override;
+
+ private:
+  float alpha_;
+  arithmetic::OpType optype_;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/graph/Config.h
+++ b/aten/src/ATen/native/vulkan/graph/Config.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Context.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+struct GraphConfig final {
+  api::ContextConfig context_config;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/graph/Constant.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Constant.cpp
@@ -1,0 +1,21 @@
+#include <ATen/native/vulkan/graph/Constant.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+TensorRef::TensorRef(
+    const IntArrayRef t_sizes,
+    c10::ScalarType t_dtype,
+    const void* const t_data)
+    : sizes{}, dtype{t_dtype}, data{t_data} {
+  size_t ndim = t_sizes.size();
+  sizes.resize(ndim);
+  for (int i = 0; i < ndim; ++i) {
+    sizes[i] = t_sizes[i];
+  }
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/graph/Constant.h
+++ b/aten/src/ATen/native/vulkan/graph/Constant.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Context.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+/*
+ * Represents a reference to a tensor that has been serialized with the model,
+ * such as a serialized weight tensor. It contains some metadata as well as a
+ * raw pointer to the data of the tensor, which is assumed to be contiguous.
+ */
+struct TensorRef final {
+  std::vector<int64_t> sizes;
+  c10::ScalarType dtype;
+  const void* data;
+
+  explicit TensorRef(
+      const IntArrayRef t_sizes,
+      c10::ScalarType t_dtype,
+      const void* const t_data);
+
+  TensorRef(const TensorRef&) = default;
+  TensorRef& operator=(const TensorRef&) = default;
+
+  TensorRef(TensorRef&&) = default;
+  TensorRef& operator=(TensorRef&&) = default;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/graph/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Copy.cpp
@@ -1,0 +1,55 @@
+#include <ATen/native/vulkan/graph/Copy.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void add_copy_node(
+    ComputeGraph& graph,
+    const ValueRef from,
+    const ValueRef to) {
+  graph.execute_nodes().emplace_back(new CopyNode(from, to));
+}
+
+ValueRef add_copy_node(ComputeGraph& graph, const ValueRef from) {
+  IntArrayRef out_sizes = graph.get_val_sizes(from);
+  c10::ScalarType out_dtype = graph.get_val_dtype(from);
+  ValueRef to = graph.add_tensor(out_sizes, out_dtype);
+  add_copy_node(graph, from, to);
+  return to;
+}
+
+CopyNode::CopyNode(const ValueRef from, const ValueRef to) {
+  inputs_.emplace_back(from);
+  outputs_.emplace_back(to);
+}
+
+void CopyNode::encode_execute(ComputeGraph* graph) const {
+  api::PipelineBarrier pipeline_barrier{};
+
+  vTensor& from_tensor = graph->get_val(inputs_[0]).toTensor();
+  vTensor& to_tensor = graph->get_val(outputs_[0]).toTensor();
+
+  graph->context()->submit_copy<api::VulkanImage, api::VulkanImage>(
+      // pipeline barrier
+      pipeline_barrier,
+      // resources
+      from_tensor.image(
+          pipeline_barrier,
+          api::PipelineStage::TRANSFER,
+          api::MemoryAccessType::READ),
+      to_tensor.image(
+          pipeline_barrier,
+          api::PipelineStage::TRANSFER,
+          api::MemoryAccessType::WRITE),
+      // copy details
+      from_tensor.extents(),
+      {0u, 0u, 0u},
+      {0u, 0u, 0u},
+      // fence handle
+      VK_NULL_HANDLE);
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/graph/Copy.h
+++ b/aten/src/ATen/native/vulkan/graph/Copy.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/graph/Graph.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void add_copy_node(ComputeGraph& graph, const ValueRef from, const ValueRef to);
+ValueRef add_copy_node(ComputeGraph& graph, const ValueRef from);
+
+class CopyNode : public virtual OpNode {
+ public:
+  explicit CopyNode(const ValueRef from, const ValueRef to);
+
+  void encode_execute(ComputeGraph* graph) const override;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/graph/Exception.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Exception.cpp
@@ -1,0 +1,37 @@
+#include <ATen/native/vulkan/graph/Exception.h>
+
+#include <sstream>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+std::ostream& operator<<(std::ostream& out, const SourceLocation& loc) {
+  out << loc.func << " at " << loc.file << ": " << loc.line;
+  return out;
+}
+
+Error::Error(SourceLocation location, std::string msg)
+    : location_{location}, msg_(std::move(msg)) {
+  refresh_what();
+}
+
+void Error::refresh_what() {
+  what_ = compute_what(/*include_backtrace =*/true);
+}
+
+std::string Error::compute_what(bool include_source) const {
+  std::ostringstream oss;
+  oss << msg_;
+
+  if (include_source) {
+    oss << "\n"
+        << "Raised from: " << location_;
+  }
+
+  return oss.str();
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/graph/Exception.h
+++ b/aten/src/ATen/native/vulkan/graph/Exception.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <exception>
+#include <ostream>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+/*
+ * Same as c10::SourceLocation, represents a location in source code
+ */
+struct SourceLocation {
+  const char* func;
+  const char* file;
+  uint32_t line;
+};
+
+std::ostream& operator<<(std::ostream& out, const SourceLocation& loc);
+
+/*
+ * Simple error class modeled after c10::Error
+ */
+class Error : public std::exception {
+ public:
+  // Constructors
+  Error(SourceLocation location, std::string msg);
+
+ private:
+  // The source location of the exception
+  SourceLocation location_;
+  // The actual error message
+  std::string msg_;
+
+  std::string what_;
+
+ public:
+  const char* what() const noexcept override {
+    return what_.c_str();
+  }
+
+  const std::string& msg() const {
+    return msg_;
+  }
+
+ private:
+  void refresh_what();
+  std::string compute_what(bool include_source) const;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#define VKGRAPH_THROW(...)                                   \
+  throw ::at::native::vulkan::Error(                         \
+      {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
+      c10::str(__VA_ARGS__));
+
+#define VKGRAPH_CHECK(cond, ...)                               \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {                        \
+    throw ::at::native::vulkan::Error(                         \
+        {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
+        c10::str(__VA_ARGS__));                                \
+  }
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/graph/Graph.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Graph.cpp
@@ -1,0 +1,134 @@
+#include <ATen/native/vulkan/graph/Graph.h>
+#include <ATen/native/vulkan/graph/Staging.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+ComputeGraph::ComputeGraph(GraphConfig config)
+    : config_{config},
+      context_{new api::Context(
+          api::runtime()->default_adapter_i(),
+          config_.context_config)},
+      values_{},
+      prepack_nodes_{},
+      execute_nodes_{},
+      inputs_{},
+      outputs_{} {
+  context_->set_cmd(/*reusable = */ true);
+}
+
+ComputeGraph::~ComputeGraph() {
+  values_.clear();
+
+  prepack_nodes_.clear();
+  execute_nodes_.clear();
+
+  context_->flush();
+}
+
+ValueRef ComputeGraph::add_tensor(
+    const IntArrayRef sizes,
+    const c10::ScalarType dtype) {
+  ValueRef idx(values_.size());
+  values_.emplace_back(vTensor(context(), sizes, dtype));
+  return idx;
+}
+
+ValueRef ComputeGraph::add_tensorref(
+    const IntArrayRef sizes,
+    const c10::ScalarType dtype,
+    const void* const data) {
+  ValueRef idx(values_.size());
+  values_.emplace_back(TensorRef(sizes, dtype, data));
+  return idx;
+}
+
+ValueRef ComputeGraph::add_staging(
+    const c10::ScalarType dtype,
+    const size_t numel) {
+  ValueRef idx(values_.size());
+  values_.emplace_back(api::StorageBuffer(context(), dtype, numel));
+  return idx;
+}
+
+ValueRef ComputeGraph::set_input_tensor(
+    const ValueRef idx,
+    const bool use_staging) {
+  if (use_staging) {
+    vTensor& tensor = get_val(idx).toTensor();
+    ValueRef staging_idx = add_staging(tensor.dtype(), tensor.gpu_numel());
+    execute_nodes_.emplace_back(new StagingNode(staging_idx, idx));
+    inputs_.push_back(staging_idx);
+    return staging_idx;
+  }
+  inputs_.push_back(idx);
+  return idx;
+}
+
+ValueRef ComputeGraph::set_output_tensor(
+    const ValueRef idx,
+    const bool use_staging) {
+  if (use_staging) {
+    vTensor& tensor = get_val(idx).toTensor();
+    ValueRef staging_idx = add_staging(tensor.dtype(), tensor.gpu_numel());
+    execute_nodes_.emplace_back(new StagingNode(idx, staging_idx));
+    outputs_.push_back(staging_idx);
+    return staging_idx;
+  }
+  outputs_.push_back(idx);
+  return idx;
+}
+
+void ComputeGraph::copy_into_staging(
+    const ValueRef idx,
+    const void* data,
+    const size_t numel) {
+  Value& in_val = get_val(idx);
+  api::StorageBuffer& staging = in_val.toStaging();
+  size_t nbytes = numel * c10::elementSize(staging.dtype());
+  copy_ptr_to_staging(data, staging, nbytes);
+}
+
+void ComputeGraph::copy_from_staging(
+    const ValueRef idx,
+    void* data,
+    const size_t numel) {
+  Value& out_val = get_val(idx);
+  api::StorageBuffer& staging = out_val.toStaging();
+  size_t nbytes = numel * c10::elementSize(staging.dtype());
+  copy_staging_to_ptr(staging, data, nbytes);
+}
+
+void ComputeGraph::encode_prepack() {
+  for (std::unique_ptr<OpNode>& node : prepack_nodes_) {
+    node->encode_prepack(this);
+  }
+}
+
+void ComputeGraph::prepack() const {
+  // Submit and execute the command buffer
+  api::VulkanFence fence = context_->fences().get_fence();
+  context_->submit_cmd_to_gpu(fence.get_submit_handle(), /*final_use = */ true);
+  fence.wait();
+
+  // Flush the context and obtain a new command buffer
+  context_->flush();
+  context_->set_cmd(/*reusable = */ true);
+}
+
+void ComputeGraph::encode_execute() {
+  for (std::unique_ptr<OpNode>& node : execute_nodes_) {
+    node->encode_execute(this);
+  }
+}
+
+void ComputeGraph::execute() const {
+  api::VulkanFence fence = context_->fences().get_fence();
+  context_->submit_cmd_to_gpu(fence.get_submit_handle());
+  fence.wait();
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/graph/Graph.h
+++ b/aten/src/ATen/native/vulkan/graph/Graph.h
@@ -1,0 +1,165 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Context.h>
+#include <ATen/native/vulkan/api/Tensor.h>
+
+#include <ATen/native/vulkan/graph/Config.h>
+#include <ATen/native/vulkan/graph/Exception.h>
+#include <ATen/native/vulkan/graph/Value.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+typedef int32_t ValueRef;
+class ComputeGraph;
+
+/*
+ * Represents a single op in a ML model. In graph mode, ops will be implemented
+ * introducing a derived class that implements encode_execute, which will
+ * implement encoding of the shader corresponding to the op into the command
+ * buffer of a ComputeGraph, as well as encode_prepack, which will implement
+ * encoding of shaders transferring necessary data (such as weights and biases)
+ * to the GPU, wherever prepacking is necessary.
+ */
+class OpNode {
+  friend class ComputeGraph;
+
+ public:
+  virtual ~OpNode() {}
+
+ protected:
+  std::vector<ValueRef> inputs_;
+  std::vector<ValueRef> outputs_;
+
+ public:
+  virtual void encode_prepack(ComputeGraph* graph) const {}
+  virtual void encode_execute(ComputeGraph* graph) const {}
+};
+
+/*
+ * This is the core data structure used to execute Vulkan models in graph mode.
+ * As opposed to ATen/eager mode where a command buffer is encoded every
+ * inference (since ops are executed with the model), in graph mode the ops that
+ * compose the model are intended to be parsed only once, upon which a command
+ * buffer will be encoded. Model inference will then execute the cached command
+ * buffer without needing to encode a new one.
+ */
+class ComputeGraph final {
+ public:
+  explicit ComputeGraph(GraphConfig config);
+
+  ComputeGraph(ComputeGraph&&) = default;
+  ComputeGraph& operator=(ComputeGraph&&) = default;
+
+  ~ComputeGraph();
+
+ private:
+  GraphConfig config_;
+  std::unique_ptr<api::Context> context_;
+  std::vector<Value> values_;
+
+  std::vector<std::unique_ptr<OpNode>> prepack_nodes_;
+  std::vector<std::unique_ptr<OpNode>> execute_nodes_;
+
+  std::vector<ValueRef> inputs_;
+  std::vector<ValueRef> outputs_;
+
+ public:
+  //
+  // Accessors
+  //
+
+  inline api::Context* context() {
+    return context_.get();
+  }
+
+  inline std::vector<ValueRef>& inputs() {
+    return inputs_;
+  }
+
+  inline std::vector<ValueRef>& outputs() {
+    return outputs_;
+  }
+
+  /*
+   * Returns the value at a particular reference
+   */
+  inline Value& get_val(ValueRef idx) {
+    return values_[idx];
+  }
+
+  inline IntArrayRef get_val_sizes(ValueRef idx) {
+    Value& val = get_val(idx);
+    if (val.isTensor()) {
+      return val.toTensor().sizes();
+    } else if (val.isTensorRef()) {
+      return val.toTensorRef().sizes;
+    }
+    VKGRAPH_THROW("Could not get sizes of value with type ", val.type());
+  }
+
+  inline c10::ScalarType get_val_dtype(ValueRef idx) {
+    Value& val = get_val(idx);
+    if (val.isTensor()) {
+      return val.toTensor().dtype();
+    } else if (val.isTensorRef()) {
+      return val.toTensorRef().dtype;
+    }
+    VKGRAPH_THROW("Could not get dtype of value with type ", val.type());
+  }
+
+  inline std::vector<std::unique_ptr<OpNode>>& prepack_nodes() {
+    return prepack_nodes_;
+  }
+
+  inline std::vector<std::unique_ptr<OpNode>>& execute_nodes() {
+    return execute_nodes_;
+  }
+
+  //
+  // Graph Building
+  //
+
+  ValueRef add_tensor(const IntArrayRef sizes, const c10::ScalarType dtype);
+  ValueRef add_tensorref(
+      const IntArrayRef sizes,
+      const c10::ScalarType dtype,
+      const void* const data);
+  ValueRef add_staging(const c10::ScalarType dtype, const size_t numel);
+
+  ValueRef set_input_tensor(const ValueRef idx, const bool use_staging = true);
+  ValueRef set_output_tensor(const ValueRef idx, const bool use_staging = true);
+
+  //
+  // Input/Output
+  //
+
+  void copy_into_staging(
+      const ValueRef idx,
+      const void* data,
+      const size_t numel);
+  void copy_from_staging(const ValueRef idx, void* data, const size_t numel);
+
+  //
+  // Graph Prepacking
+  //
+
+  void encode_prepack();
+  void prepack() const;
+
+  //
+  // Graph Execution
+  //
+
+  void encode_execute();
+  void execute() const;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/graph/Staging.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Staging.cpp
@@ -1,0 +1,126 @@
+#include <ATen/native/vulkan/impl/Packing.h>
+
+#include <ATen/native/vulkan/graph/Exception.h>
+#include <ATen/native/vulkan/graph/Staging.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+void memcpy_to_mapping(
+    const void* src,
+    api::MemoryMap& dst_mapping,
+    const size_t nbytes,
+    const c10::ScalarType dtype) {
+  if (dtype == at::kFloat) {
+    memcpy_to_mapping_impl<float>(src, dst_mapping, nbytes);
+  } else if (dtype == at::kHalf) {
+    memcpy_to_mapping_impl<c10::Half>(src, dst_mapping, nbytes);
+  } else if (dtype == c10::kQUInt8) {
+    memcpy_to_mapping_impl<c10::quint8>(src, dst_mapping, nbytes);
+  } else if (dtype == c10::kQInt8) {
+    memcpy_to_mapping_impl<c10::qint8>(src, dst_mapping, nbytes);
+  } else if (dtype == c10::kQInt32) {
+    memcpy_to_mapping_impl<c10::qint32>(src, dst_mapping, nbytes);
+  } else {
+    VKGRAPH_THROW("Unrecognized dtype!");
+  }
+}
+
+void memcpy_from_mapping(
+    api::MemoryMap& src_mapping,
+    void* dst,
+    const size_t nbytes,
+    const c10::ScalarType dtype) {
+  if (dtype == at::kFloat) {
+    memcpy_from_mapping_impl<float>(src_mapping, dst, nbytes);
+  } else if (dtype == at::kHalf) {
+    memcpy_from_mapping_impl<c10::Half>(src_mapping, dst, nbytes);
+  } else if (dtype == c10::kQUInt8) {
+    memcpy_from_mapping_impl<c10::quint8>(src_mapping, dst, nbytes);
+  } else if (dtype == c10::kQInt8) {
+    memcpy_from_mapping_impl<c10::qint8>(src_mapping, dst, nbytes);
+  } else if (dtype == c10::kQInt32) {
+    memcpy_from_mapping_impl<c10::qint32>(src_mapping, dst, nbytes);
+  } else {
+    VKGRAPH_THROW("Unrecognized dtype!");
+  }
+}
+
+void copy_ptr_to_staging(
+    const void* src,
+    api::StorageBuffer& staging,
+    const size_t nbytes) {
+  api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
+  mapping.invalidate();
+  memcpy_to_mapping(src, mapping, nbytes, staging.dtype());
+}
+
+void copy_staging_to_ptr(
+    api::StorageBuffer& staging,
+    void* dst,
+    const size_t nbytes) {
+  api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::READ);
+  mapping.invalidate();
+  memcpy_from_mapping(mapping, dst, nbytes, staging.dtype());
+}
+
+void encode_copy_to_vtensor(
+    api::Context* context,
+    api::StorageBuffer& staging,
+    vTensor& tensor) {
+  api::ShaderInfo shader = packing::get_nchw_to_image_shader(tensor);
+  api::PipelineBarrier pipeline_barrier{};
+  packing::record_nchw_to_image_op(
+      context,
+      shader,
+      staging.buffer(),
+      tensor,
+      pipeline_barrier,
+      VK_NULL_HANDLE);
+}
+
+void encode_copy_from_vtensor(
+    api::Context* context,
+    vTensor& tensor,
+    api::StorageBuffer& staging) {
+  api::ShaderInfo shader = packing::get_image_to_nchw_shader(tensor);
+  api::PipelineBarrier pipeline_barrier{};
+  packing::record_image_to_nchw_op(
+      context,
+      shader,
+      tensor,
+      staging.buffer(),
+      pipeline_barrier,
+      VK_NULL_HANDLE);
+}
+
+StagingNode::StagingNode(ValueRef from, ValueRef to) {
+  inputs_.emplace_back(from);
+  outputs_.emplace_back(to);
+}
+
+void StagingNode::encode_execute(ComputeGraph* graph) const {
+  Value& in_val = graph->get_val(inputs_[0]);
+  Value& out_val = graph->get_val(outputs_[0]);
+
+  if (in_val.isStaging() && out_val.isTensor()) {
+    api::StorageBuffer& from_staging = graph->get_val(inputs_[0]).toStaging();
+    vTensor& to_tensor = graph->get_val(outputs_[0]).toTensor();
+    encode_copy_to_vtensor(graph->context(), from_staging, to_tensor);
+  } else if (in_val.isTensor() && out_val.isStaging()) {
+    vTensor& from_tensor = graph->get_val(inputs_[0]).toTensor();
+    api::StorageBuffer& to_staging = graph->get_val(outputs_[0]).toStaging();
+    encode_copy_from_vtensor(graph->context(), from_tensor, to_staging);
+  } else {
+    VKGRAPH_THROW(
+        "Unexpected input value type ",
+        in_val.type(),
+        " and output value type ",
+        out_val.type());
+  }
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/graph/Staging.h
+++ b/aten/src/ATen/native/vulkan/graph/Staging.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/graph/Graph.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+//
+// Functions to memcpy data into staging buffer
+//
+
+void memcpy_to_mapping(
+    const void* src,
+    api::MemoryMap& dst_mapping,
+    const size_t nbytes,
+    const c10::ScalarType dtype);
+void memcpy_from_mapping(
+    const api::MemoryMap& src_mapping,
+    void* dst,
+    const size_t nbytes,
+    const c10::ScalarType dtype);
+
+//
+// Utility functions for memcpy
+//
+
+template <typename T>
+void memcpy_to_mapping_impl(
+    const void* src,
+    api::MemoryMap& dst_mapping,
+    const size_t nbytes) {
+  T* data_ptr = dst_mapping.template data<T>();
+  memcpy(data_ptr, reinterpret_cast<const T*>(src), nbytes);
+}
+
+template <typename T>
+void memcpy_from_mapping_impl(
+    api::MemoryMap& src_mapping,
+    void* dst,
+    const size_t nbytes) {
+  T* data_ptr = src_mapping.template data<T>();
+  memcpy(reinterpret_cast<T*>(dst), data_ptr, nbytes);
+}
+
+//
+// Functions to copy data into and out of a staging buffer
+//
+
+void copy_ptr_to_staging(
+    const void* src,
+    api::StorageBuffer& staging,
+    const size_t nbytes);
+void copy_staging_to_ptr(
+    api::StorageBuffer& staging,
+    void* dst,
+    const size_t nbytes);
+
+//
+// Functions to record copying data between a staging buffer and a vTensor
+//
+
+void encode_copy_to_vtensor(
+    api::Context* context,
+    api::StorageBuffer& staging,
+    vTensor& tensor);
+void encode_copy_from_vtensor(
+    api::Context* context,
+    vTensor& tensor,
+    api::StorageBuffer& staging);
+
+/*
+ * OpNode that allows copying data into and out of a staging buffer.
+ */
+class StagingNode : public virtual OpNode {
+ public:
+  explicit StagingNode(ValueRef from, ValueRef to);
+
+  void encode_execute(ComputeGraph* graph) const override;
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/graph/Types.cpp
+++ b/aten/src/ATen/native/vulkan/graph/Types.cpp
@@ -1,0 +1,27 @@
+#include <ATen/native/vulkan/graph/Types.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+std::ostream& operator<<(std::ostream& out, const TypeTag& tag) {
+  switch (tag) {
+    case TypeTag::NONE:
+      out << "NONE";
+      break;
+    case TypeTag::TENSOR:
+      out << "TENSOR";
+      break;
+    case TypeTag::STAGING:
+      out << "STAGING";
+      break;
+    default:
+      out << "UNKNOWN";
+      break;
+  }
+  return out;
+}
+
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/graph/Types.h
+++ b/aten/src/ATen/native/vulkan/graph/Types.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ostream>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+/*
+ * This class is modelled after c10::IValue; however, it is simplified and does
+ * not support as many types. However, the core design is the same; it is a
+ * tagged union over the types supported by the Vulkan Graph type.
+ */
+enum class TypeTag : uint32_t {
+  NONE,
+  TENSOR,
+  STAGING,
+  TENSORREF,
+  INT,
+  DOUBLE,
+  BOOL,
+};
+
+std::ostream& operator<<(std::ostream& out, const TypeTag& tag);
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/graph/Value.h
+++ b/aten/src/ATen/native/vulkan/graph/Value.h
@@ -1,0 +1,178 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Context.h>
+#include <ATen/native/vulkan/api/Tensor.h>
+
+#include <ATen/native/vulkan/graph/Constant.h>
+#include <ATen/native/vulkan/graph/Types.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+
+/*
+ * This class is modelled after c10::IValue; however, it is simplified and does
+ * not support as many types. However, the core design is the same; it is a
+ * tagged union over the types supported by the Vulkan Graph type.
+ */
+struct Value final {
+ private:
+  /*
+   * The union type which is used to store the value of the Value.
+   */
+  union Payload {
+    /*
+     * Similar to IValue::Payload, trivially copyable types are nested in their
+     * own union.
+     */
+    union TriviallyCopyablePayload {
+      TriviallyCopyablePayload() : as_int(0) {}
+      int64_t as_int;
+      double as_double;
+      bool as_bool;
+    } u;
+
+    vTensor as_tensor;
+    api::StorageBuffer as_staging;
+    TensorRef as_tensorref;
+
+    Payload() : u() {}
+    ~Payload() {}
+  };
+
+ public:
+  //
+  // Copy constructor and assignment (disabled)
+  //
+
+  Value(const Value& rhs) = delete;
+  Value& operator=(const Value&) = delete;
+
+  //
+  // Move constructor and assignment; Move assignment is disabled but
+  // construction is implemented to allow for use in container types.
+  //
+
+  Value& operator=(Value&&) = delete;
+
+  Value(Value&& rhs) noexcept : tag(rhs.tag) {
+    if (rhs.isTensor()) {
+      new (&payload.as_tensor) vTensor(std::move(rhs.payload.as_tensor));
+    } else if (rhs.isStaging()) {
+      new (&payload.as_staging)
+          api::StorageBuffer(std::move(rhs.payload.as_staging));
+    } else if (rhs.isTensorRef()) {
+      payload.as_tensorref = std::move(rhs.payload.as_tensorref);
+    } else {
+      payload.u = rhs.payload.u;
+    }
+    tag = rhs.tag;
+    rhs.clearToNone();
+  }
+
+  //
+  // Accessors
+  //
+
+  inline TypeTag type() const {
+    return tag;
+  }
+
+  //
+  // Destructor
+  //
+
+  ~Value() {
+    if (this->isTensor()) {
+      payload.as_tensor.~vTensor();
+    } else if (this->isStaging()) {
+      payload.as_staging.~StorageBuffer();
+    } else if (this->isTensorRef()) {
+      payload.as_tensorref.~TensorRef();
+    }
+  }
+
+  //
+  // Tensor
+  //
+
+  Value(vTensor&& t) : tag(TypeTag::TENSOR) {
+    new (&payload.as_tensor) vTensor(std::move(t));
+  }
+
+  inline bool isTensor() const {
+    return TypeTag::TENSOR == tag;
+  }
+
+  inline vTensor& toTensor() {
+    VKGRAPH_CHECK(
+        isTensor(),
+        "Expected value to have type TENSOR, got ",
+        tag,
+        " instead.");
+    return payload.as_tensor;
+  }
+
+  //
+  // Staging
+  //
+
+  Value(api::StorageBuffer&& t) : tag(TypeTag::STAGING) {
+    new (&payload.as_staging) api::StorageBuffer(std::move(t));
+  }
+
+  inline bool isStaging() const {
+    return TypeTag::STAGING == tag;
+  }
+
+  inline api::StorageBuffer& toStaging() {
+    VKGRAPH_CHECK(
+        isStaging(),
+        "Expected value to have type STAGING, got ",
+        tag,
+        " instead.");
+    return payload.as_staging;
+  }
+
+  //
+  // TensorRef
+  //
+
+  Value(TensorRef&& t) : tag(TypeTag::TENSORREF) {
+    payload.as_tensorref = std::move(t);
+  }
+
+  inline bool isTensorRef() const {
+    return TypeTag::TENSORREF == tag;
+  }
+
+  inline TensorRef& toTensorRef() {
+    VKGRAPH_CHECK(
+        isTensorRef(),
+        "Expected value to have type TENSORREF, got ",
+        tag,
+        " instead.");
+    return payload.as_tensorref;
+  }
+
+ private:
+  Payload payload;
+  TypeTag tag;
+
+  //
+  // Utility Functions
+  //
+
+  inline void clearToNone() noexcept {
+    payload.u.as_int = 0;
+    tag = TypeTag::NONE;
+  }
+};
+
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/impl/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/impl/Arithmetic.cpp
@@ -1,0 +1,83 @@
+#include <ATen/native/vulkan/impl/Arithmetic.h>
+#include <ATen/native/vulkan/impl/Common.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace arithmetic {
+
+api::ShaderInfo get_shader(const OpType type) {
+  switch (type) {
+    case OpType::ADD:
+      return VK_KERNEL(add);
+    case OpType::SUB:
+      return VK_KERNEL(sub);
+    case OpType::MUL:
+      return VK_KERNEL(mul);
+    case OpType::DIV:
+      return VK_KERNEL(div);
+  }
+}
+
+struct Params final {
+  api::utils::ivec3 out_extents;
+  int32_t fill_0;
+  api::utils::ivec3 input1_extents;
+  int32_t nc_size_1;
+  api::utils::ivec3 input2_extents;
+  int32_t nc_size_2;
+  float alpha;
+};
+
+void record_op(
+    api::Context* const context,
+    const api::ShaderInfo& compute_shader,
+    vTensor& v_in1,
+    vTensor& v_in2,
+    vTensor& v_dst,
+    const float alpha) {
+  api::utils::uvec3 global_size = v_dst.extents();
+  api::utils::uvec3 local_size = adaptive_work_group_size(global_size);
+
+  uint32_t nc_1 = dim_at<Dim4D::Channel>(v_in1) * dim_at<Dim4D::Batch>(v_in1);
+  uint32_t nc_2 = dim_at<Dim4D::Channel>(v_in2) * dim_at<Dim4D::Batch>(v_in2);
+
+  Params block{
+      api::utils::make_ivec3(v_dst.extents()),
+      0u,
+      api::utils::make_ivec3(v_in1.extents()),
+      api::utils::safe_downcast<int32_t>(nc_1),
+      api::utils::make_ivec3(v_in2.extents()),
+      api::utils::safe_downcast<int32_t>(nc_2),
+      alpha,
+  };
+
+  api::UniformParamsBuffer params(context, block);
+  api::PipelineBarrier pipeline_barrier{};
+
+  context->submit_compute_job(
+      // shader descriptor
+      compute_shader,
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      global_size,
+      // local work group size
+      local_size,
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_dst.image(
+          pipeline_barrier,
+          api::PipelineStage::COMPUTE,
+          api::MemoryAccessType::WRITE),
+      v_in1.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_in2.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      // params buffer
+      params.buffer());
+}
+
+} // namespace arithmetic
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/impl/Arithmetic.h
+++ b/aten/src/ATen/native/vulkan/impl/Arithmetic.h
@@ -1,0 +1,28 @@
+#include <ATen/native/vulkan/api/api.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace arithmetic {
+
+enum class OpType : uint32_t {
+  ADD,
+  SUB,
+  MUL,
+  DIV,
+};
+
+api::ShaderInfo get_shader(const OpType type);
+
+void record_op(
+    api::Context* const context,
+    const api::ShaderInfo& compute_shader,
+    vTensor& v_in1,
+    vTensor& v_in2,
+    vTensor& v_dst,
+    const float alpha);
+
+} // namespace arithmetic
+} // namespace vulkan
+} // namespace native
+} // namespace at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94221

This diff introduced the core components needed for the Vulkan Graph runtime.

* ComputeGraph data structure
* Value data structure
* Copy node
* Add node with option for prepacked weights

Differential Revision: [D42614155](https://our.internmc.facebook.com/intern/diff/D42614155/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D42614155/)!