### PR TITLE
torch.inference_mode: add type hints

### DIFF
--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -205,7 +205,7 @@ class inference_mode(_DecoratorContextManager):
         False
 
     """
-    def __init__(self, mode=True):
+    def __init__(self, mode: bool = True) -> None:
         if not torch._jit_internal.is_scripting():
             super().__init__()
         # Holds a python binding to a RAII guard that can enable or disable
@@ -213,7 +213,7 @@ class inference_mode(_DecoratorContextManager):
         self._inference_mode_raii_guard = None
         self.mode = mode
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self._inference_mode_raii_guard = torch._C._InferenceMode(self.mode)
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -1,5 +1,5 @@
 import torch
-from typing import Any
+from typing import Any, Optional
 
 from torch.utils._contextlib import _DecoratorContextManager
 
@@ -157,7 +157,7 @@ class set_grad_enabled(_DecoratorContextManager):
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         torch._C._set_grad_enabled(self.prev)
 
-    def clone(self):
+    def clone(self) -> "set_grad_enabled":
         return self.__class__(self.mode)
 
 
@@ -210,7 +210,7 @@ class inference_mode(_DecoratorContextManager):
             super().__init__()
         # Holds a python binding to a RAII guard that can enable or disable
         # inference mode
-        self._inference_mode_raii_guard = None
+        self._inference_mode_raii_guard: Optional[torch._C._InferenceMode] = None
         self.mode = mode
 
     def __enter__(self) -> None:
@@ -219,7 +219,7 @@ class inference_mode(_DecoratorContextManager):
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         del self._inference_mode_raii_guard
 
-    def clone(self):
+    def clone(self) -> "inference_mode":
         return self.__class__(self.mode)
 
 
@@ -251,5 +251,5 @@ class set_multithreading_enabled(_DecoratorContextManager):
     def __exit__(self, *args) -> None:
         del self.multithreadeding_enabled_guard
 
-    def clone(self):
+    def clone(self) -> "set_multithreading_enabled":
         return self.__class__(self.mode)


### PR DESCRIPTION
Copied the type hints from the other context managers. 

Not sure how to add type hints for `clone` since it returns the same class. The `Self` type isn't introduced until Python 3.11 and mypy just recently added support for it. Could also use `"inference_mode"` with quotes to avoid using it before it's declared, or `from __future__ import annotations` to allow its use without quotes. Or we could just skip it.