### PR TITLE
Dynamo: Remove unused size nodes from the output graph

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -655,7 +655,18 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
         # expect 1 more op (size call) for dynamic
         return torch._dynamo.testing.standard_test(
-            self, fn=fn, nargs=1, expected_ops=9, expected_ops_dynamic=10
+            self, fn=fn, nargs=1, expected_ops=9, expected_ops_dynamic=9
+        )
+
+    def test_range_with_shape_constant_folding(self):
+        def fn(a):
+            out = 1
+            for i in range(1, a.shape[0]):
+                out += 1
+            return a + out
+
+        return torch._dynamo.testing.standard_test(
+            self, fn=fn, nargs=1, expected_ops=1, expected_ops_dynamic=1
         )
 
     def test_no_grad(self):

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -700,6 +700,8 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
                     self.remove_node(node)
                 elif node.op == "call_function" and node.target is operator.getitem:
                     self.remove_node(node)
+                elif node.op == "call_method" and node.target == "size":
+                    self.remove_node(node)
 
         expanded_graphargs = []
         for arg in self.graphargs:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94224
* #94203
* #94202

Previously, extra `size` nodes could be left in the output graph if they took part in a `range`, for example. This update removes these unused extra nodes from the graph.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire