### PR TITLE
PyTorchFileWriter: drop the GIL while writing to disk

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1297,8 +1297,7 @@ void initJITBindings(PyObject* module) {
           "fallback", [](GraphExecutorState& s) { return s.fallback; });
 
   py::class_<PyTorchStreamWriter>(m, "PyTorchFileWriter")
-      .def(py::init<std::string>(),
-           py::call_guard<py::gil_scoped_release>())
+      .def(py::init<std::string>(), py::call_guard<py::gil_scoped_release>())
       .def(py::init([](const py::object& buffer) {
         auto writer_func = [=](const void* data, size_t size) {
           // Writing an empty file is a noop
@@ -1321,9 +1320,10 @@ void initJITBindings(PyObject* module) {
              const char* data,
              size_t size) { return self.writeRecord(name, data, size); },
           py::call_guard<py::gil_scoped_release>())
-      .def("write_end_of_file",
-           &PyTorchStreamWriter::writeEndOfFile,
-           py::call_guard<py::gil_scoped_release>())
+      .def(
+          "write_end_of_file",
+          &PyTorchStreamWriter::writeEndOfFile,
+          py::call_guard<py::gil_scoped_release>())
       .def("set_min_version", &PyTorchStreamWriter::setMinVersion)
       .def(
           "write_record",


### PR DESCRIPTION
`PyTorchStreamWriter` is pure C++ code that does not touch any Python data structures, so it's safe to drop the GIL while calling into it. We make sure to grab it again in the case where the `PyTorchFileWriter` is backed by a Python object.

This enables one thread to `torch.save` a large tensor without incurring large hangs by any other concurrently-running threads.

Fixes #94238

Running the test case from that issue, I see no "Unexpected latency!" lines using either the `torch` or the `open+torch` codepaths.