### PR TITLE
[quant] Add QConfig v2 keys

### DIFF
--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -81,7 +81,7 @@ class QConfig(
             "QConfig",
             # using list literal instead of variable to silent the complaint from pyre
             ["activation", "weight", "input_args", "module_attrs", "output", "version"],
-            # please update this number when the fields list is updated
+            # please update this tuple when the fields list is updated
             defaults=(None, None, None, None, None, None))):
     """
     Describes how to quantize a layer or a part of the network by providing

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -119,7 +119,7 @@ class QConfig(namedtuple('QConfig', _qconfig_fields, defaults=(None,) * len(_qco
     it should have the same structure as the positional arguments e.g. for an operator with
     the following signature: `op(arg0, arg1, arg2)`, "input_args" should look like the following:
     ```
-    qconfig.input_args = (obs0, obs1, obs3)
+    qconfig.input_args = (obs0, obs1, obs2)
     ```
     this can be expanded to more general structures like nested dictionary with a tuple as a value etc.
 

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -76,10 +76,13 @@ __all__ = [
     "qconfig_equals",
 ]
 
-_qconfig_fields = [
-    "activation", "weight", "input_args", "module_attrs", "output", "version"
-]
-class QConfig(namedtuple('QConfig', _qconfig_fields, defaults=(None,) * len(_qconfig_fields))):
+class QConfig(
+        namedtuple(
+            "QConfig",
+            # using list literal instead of variable to silent the complaint from pyre
+            ["activation", "weight", "input_args", "module_attrs", "output", "version"],
+            # please update this number when the fields list is updated
+            defaults=(None, None, None, None, None, None))):
     """
     Describes how to quantize a layer or a part of the network by providing
     settings (observer classes) for activations and weights respectively.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94251

Summary:
This PR adds keys for the second version of QConfig that allows users have more fine grained quantization
settings. version 1 and version 2 keys can't be set at the same time.

QConfig is an object for users to set the observer or fake quantize classes for input/output/weight of an operator/module.

**QConfig v1**
QConfig v1 (current QConfig) was introduced when eager mode quantization is designed,
it has two keys: "activation" and "weight", here
activation means the output activation, and weight means weight attributes for weighted modules

Later we developed torchscript graph mode quantization (quantize_jit) and fx graph
mode quantization (quantize_fx), and now quantization in pytorch 2.0 export path
(quantize_pt2e), but we did not redesign QConfig, and "activation" is redefined as a
setting for both input and output, "weight" also expanded it's definition serving both setting for module\
weigt and the weight input of torch functional or torch ops (with the aid of extra
configurations to specify which input is weight) and we do not have a way to configure
the observer/fake_quant constructor for bias.

**QConfig v2**
This PR adds keys for the second version of QConfig, it has the following keys:
["input_args", "module_attrs", "output", "version"]

"input_args": is used to configure the observer/fakequant constructors for input arguments,
it should have the same structure as the positional arguments e.g. for an operator with
the following signature: `op(arg0, arg1, arg2)`, "input_args" should look like the following:
```
qconfig.input_args = (obs0, obs1, obs2)
```
this can be expanded to more general structures like nested dictionary with a tuple as a value etc.

"module_attrs": is used to configure the observer/fakequant constructors for module attributes,
 e.g. weight, it should be a dictionary from module attribute name to the observer/fake_quant class, e.g.:

qconfig.module_attrs = {"weight": obs0}

"output": is used to configure the observer/fakequant constructors for output,
it should match the structure of output, e.g. if output has the following structure:
{"key0": out0, "key1": (out1, out2)}, we will have the following output config:
qconfig.output = {"key0": obs0, "key1": (obs1, obs2)}

"version": should be None (meaning v1), 1 or 2

**Examples**::

  # v1
  my_qconfig = QConfig(
      activation=MinMaxObserver.with_args(dtype=torch.qint8),
      weight=default_observer.with_args(dtype=torch.qint8))
  # v2
  my_qconfig = QConfig(
      input_args=(MinMaxObserver.with_args(dtype=torch.qint8),),
      module_attrs={"weight": default_observer.with_args(dtype=torch.qint8)},
      output=(MinMaxObserver.with_args(dtype=torch.qint8),)
  )

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: