### PR TITLE
Proof of concept / feedback - allow_in_graph on module

### DIFF
--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -72,6 +72,9 @@ def allow_in_graph(fn):
 
     Will capture a single graph containing `my_custom_function()`.
     """
+    import torch
+    if isinstance(fn, torch.nn.Module):
+        fn._dynamo_marked_allow = True
     if isinstance(fn, (list, tuple)):
         return [allow_in_graph(x) for x in fn]
     assert callable(fn), "allow_in_graph expects a callable"


### PR DESCRIPTION
```
import torch
import torch.nn as nn
import torch.nn.functional as F

import torch._dynamo.config
import torch._inductor.config

from torch._dynamo import allow_in_graph

class Net(nn.Module):
    def __init__(self):
      super(Net, self).__init__()
      self.conv1 = nn.Conv2d(1, 32, 3, 1)
      self.conv2 = nn.Conv2d(32, 64, 3, 1)
      self.dropout1 = nn.Dropout2d(0.25)
      self.dropout2 = nn.Dropout2d(0.5)
      self.fc1 = nn.Linear(9216, 128)
      self.fc2 = nn.Linear(128, 10)

    def forward(self, x):
      x = self.conv1(x)
      x = F.relu(x)
      x = self.conv2(x)
      x = F.relu(x)
      x = F.max_pool2d(x, 2)
      x = self.dropout1(x)
      x = torch.flatten(x, 1)
      x = self.fc1(x)
      x = F.relu(x)
      x = self.dropout2(x)
      x = self.fc2(x)
      output = F.log_softmax(x, dim=1)
      return output

m = Net()

def foo(x):    
    return m(x)


exported = torch._dynamo.export(foo, torch.rand((1, 1, 28, 28)))
out_graph = exported[0]
out_graph.graph.print_tabular()
# opcode         name         target                                                      args              kwargs
# -------------  -----------  ----------------------------------------------------------  ----------------  ----------
# placeholder    arg0         arg0                                                        ()                {}
# call_module    m_conv1      m_conv1                                                     (arg0,)           {}
# call_function  relu         <function relu at 0x7f95c7ef71c0>                           (m_conv1,)        {}
# call_module    m_conv2      m_conv2                                                     (relu,)           {}
# call_function  relu_1       <function relu at 0x7f95c7ef71c0>                           (m_conv2,)        {}
# call_function  max_pool2d   <function boolean_dispatch.<locals>.fn at 0x7f95c7ef60e0>   (relu_1, 2)       {}
# call_module    m_dropout1   m_dropout1                                                  (max_pool2d,)     {}
# call_function  flatten      <built-in method flatten of type object at 0x7f97d8ac4d00>  (m_dropout1, 1)   {}
# call_module    m_fc1        m_fc1                                                       (flatten,)        {}
# call_function  relu_2       <function relu at 0x7f95c7ef71c0>                           (m_fc1,)          {}
# call_module    m_dropout2   m_dropout2                                                  (relu_2,)         {}
# call_module    m_fc2        m_fc2                                                       (m_dropout2,)     {}
# call_function  log_softmax  <function log_softmax at 0x7f95c7ef7b50>                    (m_fc2,)          {'dim': 1}
# output         output       output                                                      ([log_softmax],)  {}


# After allow in graph...
allow_in_graph(m)

exported = torch._dynamo.export(foo, torch.rand((1, 1, 28, 28)))
out_graph = exported[0]
out_graph.graph.print_tabular()
# opcode       name    target    args     kwargs
# -----------  ------  --------  -------  --------
# placeholder  arg0    arg0      ()       {}
# call_module  m       m         (arg0,)  {}
# output       output  output    ([m],)   {}
```

cc @mlazos @soumith @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire