### PR TITLE
Add python type to NestedUserFunctionVariable

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -476,3 +476,6 @@ class NestedUserFunctionVariable(BaseUserFunctionVariable):
         codegen(self.code)
         codegen(self.fn_name)
         return [create_instruction("MAKE_FUNCTION", flags)]
+
+    def python_type(self):
+        return types.FunctionType


### PR DESCRIPTION
Summary:
Fixing NotImplementedError: NestedUserFunctionVariable() has no type
```
/torch/_dynamo/convert_frame.py(393)_compile()
-> raise InternalTorchDynamoError() from e
Traceback (most recent call last):
  /torch/_dynamo/convert_frame.py", line 323, in _compile
    out_code = transform_code_object(code, transform)
  /torch/_dynamo/bytecode_transformation.py", line 339, in transform_code_object
    transformations(instructions, code_options)
  /torch/_dynamo/convert_frame.py", line 310, in transform
    tracer.run()
  /torch/_dynamo/symbolic_convert.py", line 1715, in run
    super().run()
  /torch/_dynamo/symbolic_convert.py", line 564, in run
    and self.step()
  /torch/_dynamo/symbolic_convert.py", line 527, in step
    getattr(self, inst.opname)(inst)
  /torch/_dynamo/symbolic_convert.py", line 333, in wrapper
    return inner_fn(self, inst)
  /torch/_dynamo/symbolic_convert.py", line 1039, in CALL_FUNCTION_KW
    self.call_function(fn, args, kwargs)
  /torch/_dynamo/symbolic_convert.py", line 461, in call_function
    self.push(fn.call_function(self, args, kwargs))
  /torch/_dynamo/variables/functions.py", line 291, in call_function
    return super().call_function(tx, args, kwargs)
  /torch/_dynamo/variables/functions.py", line 259, in call_function
    return super(UserFunctionVariable, self).call_function(tx, args, kwargs)
  /torch/_dynamo/variables/functions.py", line 92, in call_function
    return tx.inline_user_function_return(
  /torch/_dynamo/symbolic_convert.py", line 497, in inline_user_function_return
    result = InliningInstructionTranslator.inline_call(self, fn, args, kwargs)
  /torch/_dynamo/symbolic_convert.py", line 1793, in inline_call
    return cls.inline_call_(parent, func, args, kwargs)
  /torch/_dynamo/symbolic_convert.py", line 1849, in inline_call_
    tracer.run()
  /torch/_dynamo/symbolic_convert.py", line 564, in run
    and self.step()
  /torch/_dynamo/symbolic_convert.py", line 527, in step
    getattr(self, inst.opname)(inst)
  /torch/_dynamo/symbolic_convert.py", line 333, in wrapper
    return inner_fn(self, inst)
  /torch/_dynamo/symbolic_convert.py", line 1039, in CALL_FUNCTION_KW
    self.call_function(fn, args, kwargs)
  /torch/_dynamo/symbolic_convert.py", line 461, in call_function
    self.push(fn.call_function(self, args, kwargs))
  /torch/_dynamo/variables/functions.py", line 291, in call_function
    return super().call_function(tx, args, kwargs)
  /torch/_dynamo/variables/functions.py", line 259, in call_function
    return super(UserFunctionVariable, self).call_function(tx, args, kwargs)
  /torch/_dynamo/variables/functions.py", line 92, in call_function
    return tx.inline_user_function_return(
  /torch/_dynamo/symbolic_convert.py", line 497, in inline_user_function_return
    result = InliningInstructionTranslator.inline_call(self, fn, args, kwargs)
  /torch/_dynamo/symbolic_convert.py", line 1793, in inline_call
    return cls.inline_call_(parent, func, args, kwargs)
  /torch/_dynamo/symbolic_convert.py", line 1849, in inline_call_
    tracer.run()
  /torch/_dynamo/symbolic_convert.py", line 564, in run
    and self.step()
  /torch/_dynamo/symbolic_convert.py", line 527, in step
    getattr(self, inst.opname)(inst)
  /torch/_dynamo/symbolic_convert.py", line 333, in wrapper
    return inner_fn(self, inst)
  /torch/_dynamo/symbolic_convert.py", line 990, in CALL_FUNCTION
    self.call_function(fn, args, {})
  /torch/_dynamo/symbolic_convert.py", line 461, in call_function
    self.push(fn.call_function(self, args, kwargs))
  /torch/_dynamo/variables/functions.py", line 291, in call_function
    return super().call_function(tx, args, kwargs)
  /torch/_dynamo/variables/functions.py", line 259, in call_function
    return super(UserFunctionVariable, self).call_function(tx, args, kwargs)
  /torch/_dynamo/variables/functions.py", line 92, in call_function
    return tx.inline_user_function_return(
  /torch/_dynamo/symbolic_convert.py", line 497, in inline_user_function_return
    result = InliningInstructionTranslator.inline_call(self, fn, args, kwargs)
  /torch/_dynamo/symbolic_convert.py", line 1793, in inline_call
    return cls.inline_call_(parent, func, args, kwargs)
  /torch/_dynamo/symbolic_convert.py", line 1849, in inline_call_
    tracer.run()
  /torch/_dynamo/symbolic_convert.py", line 564, in run
    and self.step()
  /torch/_dynamo/symbolic_convert.py", line 527, in step
    getattr(self, inst.opname)(inst)
  /torch/_dynamo/symbolic_convert.py", line 333, in wrapper
    return inner_fn(self, inst)
  /torch/_dynamo/symbolic_convert.py", line 990, in CALL_FUNCTION
    self.call_function(fn, args, {})
  /torch/_dynamo/symbolic_convert.py", line 461, in call_function
    self.push(fn.call_function(self, args, kwargs))
  /torch/_dynamo/variables/builtin.py", line 322, in call_function
    result = handler(tx, *args, **kwargs)
  /torch/_dynamo/variables/builtin.py", line 571, in call_isinstance
    arg_type = arg.python_type()
  /torch/_dynamo/variables/base.py", line 146, in python_type
    raise NotImplementedError(f"{self} has no type")
NotImplementedError: NestedUserFunctionVariable() has no type

```

Differential Revision: D43073446



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire