### PR TITLE
[SDPA] Adds basic correctness checks

### DIFF
--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -719,8 +719,7 @@ inline void validate_sdpa_input(
     bool is_causal){
     TORCH_CHECK(query_.dtype() == key.dtype() && query_.dtype() == value.dtype(), "Query, key, and value must have the same dtype");
     TORCH_CHECK(query_.device() == key.device() && query_.device() == value.device(), "Query, key, and value must be on the same device");
-    TORCH_CHECK(query_.dim() == key.dim() && query_.dim() == value.dim(), "Query, key, and value must all have the same number of dimensions");
-    TORCH_CHECK(query_.dim() >= 2, "Query, key, and value must have at least 2 dimensions");
+    TORCH_CHECK(query_.dim() >= 2 && key.dim() >= 2 && value.dim() >=2, "Query, key, and value must have at least 2 dimensions");
     return;
   }
 // Computes scaled dot product attention on query, key and value tensors, using

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -719,16 +719,21 @@ inline void validate_sdpa_input(
     bool is_causal) {
   TORCH_CHECK(
       query_.dtype() == key.dtype() && query_.dtype() == value.dtype(),
-      "Query, key, and value must have the same dtype");
+      "Expected query, key, and value to have the same dtype, but got query.dtype: ",
+      query_.dtype(), " key.dtype: ", key.dtype(), " and value.dtype: ", value.dtype(), " instead.");
   TORCH_CHECK(
       query_.device() == key.device() && query_.device() == value.device(),
-      "Query, key, and value must be on the same device");
+      "Expected query, key, and value to have the same device type, but got query.device: ",
+      query_.device(), " key.device: ", key.device(), " and value.device: ", value.device(), " instead.");
   TORCH_CHECK(
       query_.dim() >= 2 && key.dim() >= 2 && value.dim() >= 2,
-      "Query, key, and value must have at least 2 dimensions");
+      "Expected query, key, and value to all be  at least 2 dimensional, but got query.dim: ",
+      query_.dim(), " key.dim: ", key.dim(), " and value.dim: ", value.dim(), " instead.");
   if (attn_mask_.has_value()){
     auto mask_dtype = attn_mask_->dtype();
-    TORCH_CHECK(mask_dtype == at::kBool || mask_dtype == query_.dtype(),"attn_mask dtype must either match query dtype or be dtype bool.")
+    TORCH_CHECK(mask_dtype == at::kBool || mask_dtype == query_.dtype(),
+      "Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: ",
+      mask_dtype, " and  query.dtype: ", query_.dtype(), " instead.");
   }
   return;
 }

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -716,12 +716,18 @@ inline void validate_sdpa_input(
     const Tensor& value,
     const c10::optional<Tensor>& attn_mask_,
     double dropout_p,
-    bool is_causal){
-    TORCH_CHECK(query_.dtype() == key.dtype() && query_.dtype() == value.dtype(), "Query, key, and value must have the same dtype");
-    TORCH_CHECK(query_.device() == key.device() && query_.device() == value.device(), "Query, key, and value must be on the same device");
-    TORCH_CHECK(query_.dim() >= 2 && key.dim() >= 2 && value.dim() >=2, "Query, key, and value must have at least 2 dimensions");
-    return;
-  }
+    bool is_causal) {
+  TORCH_CHECK(
+      query_.dtype() == key.dtype() && query_.dtype() == value.dtype(),
+      "Query, key, and value must have the same dtype");
+  TORCH_CHECK(
+      query_.device() == key.device() && query_.device() == value.device(),
+      "Query, key, and value must be on the same device");
+  TORCH_CHECK(
+      query_.dim() >= 2 && key.dim() >= 2 && value.dim() >= 2,
+      "Query, key, and value must have at least 2 dimensions");
+  return;
+}
 // Computes scaled dot product attention on query, key and value tensors, using
 // an optional attention mask if passed, and applying dropout if a probability
 // greater than 0.0 is specified.

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -719,7 +719,7 @@ inline void validate_sdpa_input(
     bool is_causal){
     TORCH_CHECK(query_.dtype() == key.dtype() && query_.dtype() == value.dtype(), "Query, key, and value must have the same dtype");
     TORCH_CHECK(query_.device() == key.device() && query_.device() == value.device(), "Query, key, and value must be on the same device");
-    TORCH_CHECK(query_.dim() == key.dim() && query_.dim() == value.dim(), "Query, key, and value must have at least 2 dimensions");
+    TORCH_CHECK(query_.dim() == key.dim() && query_.dim() == value.dim(), "Query, key, and value must all have the same number of dimensions");
     TORCH_CHECK(query_.dim() >= 2, "Query, key, and value must have at least 2 dimensions");
     return;
   }

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -721,7 +721,6 @@ inline void validate_sdpa_input(
     TORCH_CHECK(query_.device() == key.device() && query_.device() == value.device(), "Query, key, and value must be on the same device");
     TORCH_CHECK(query_.dim() == key.dim() && query_.dim() == value.dim(), "Query, key, and value must have at least 2 dimensions");
     TORCH_CHECK(query_.dim() >= 2, "Query, key, and value must have at least 2 dimensions");
-    TORCH_CHECK(query_.layout() == key.layout() && query_.layout() == value.layout(), "Query, key, and value must have the same layout");
     return;
   }
 // Computes scaled dot product attention on query, key and value tensors, using

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -214,6 +214,27 @@ inline bool check_tensor_shapes(sdp_params params, bool debug) {
   return true;
 }
 
+inline bool check_equal_batch_size_and_num_heads(sdp_params params, bool debug) {
+  // This is expected to be called after check_tensor_shapes ensuring that the size()
+  // calls won't error since the inputs are all 4 dimensional
+  bool same_batch_size = params.query.size(0) == params.key.size(0) && params.query.size(0) == params.value.size(0);
+  bool same_num_heads = params.query.size(1) == params.key.size(1) && params.query.size(1) == params.value.size(1);
+  if (!(same_batch_size && same_num_heads)) {
+    if (debug) {
+      TORCH_WARN(
+        "Both fused kernels requires query, key and value to have the same batch_size and num_heads. Query.sizes(): ",
+        params.query.sizes(),
+        ", Key sizes(): ",
+        params.key.sizes(),
+        ", Value sizes(): ",
+        params.value.sizes(),
+        " instead.");
+    }
+    return false;
+  }
+  return true;
+}
+
 inline bool check_head_dim_size(sdp_params params, bool debug) {
   const int64_t query_size_last = params.query.size(-1);
   const int64_t key_size_last = params.key.size(-1);
@@ -395,9 +416,10 @@ inline bool use_flash_attention(sdp_params params, bool debug) {
   return false;
 #endif
   //  Define gate functions that determine if a flash kernel can be ran
-  constexpr std::array<bool(*)(sdp_params, bool), 7> constraints {{
+  constexpr std::array<bool(*)(sdp_params, bool), 8> constraints {{
       check_runtime_disabled_flash,
       check_tensor_shapes,
+      check_equal_batch_size_and_num_heads,
       check_for_attn_mask,
       check_head_dim_size,
       check_gpu_sm75_or_greater,
@@ -429,11 +451,12 @@ inline bool use_mem_efficient_attention(sdp_params params, bool debug) {
       at::kHalf, at::kFloat, at::kBFloat16};
 
   //  Define gate functions that determine if a flash kernel can be ran
-  constexpr std::array<bool(*)(sdp_params, bool), 10> constraints{{
+  constexpr std::array<bool(*)(sdp_params, bool), 11> constraints{{
       check_gpu_sm50_or_greater,
       check_runtime_disabled_mem_efficient,
       check_requires_grad_and_nested,
       check_tensor_shapes,
+      check_equal_batch_size_and_num_heads,
       check_for_attn_mask,
       check_head_dim_size_mem_efficient,
       check_gpu_sm86_head_dim_128,

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -217,8 +217,14 @@ inline bool check_tensor_shapes(sdp_params params, bool debug) {
 inline bool check_equal_batch_size_and_num_heads(sdp_params params, bool debug) {
   // This is expected to be called after check_tensor_shapes ensuring that the size()
   // calls won't error since the inputs are all 4 dimensional
-  bool same_batch_size = params.query.size(0) == params.key.size(0) && params.query.size(0) == params.value.size(0);
-  bool same_num_heads = params.query.size(1) == params.key.size(1) && params.query.size(1) == params.value.size(1);
+  bool same_batch_size = params.query.size(0) == params.key.size(0) &&
+      params.query.size(0) == params.value.size(0);
+  // We pass through for NestedTensors since this is checked in a later filter
+  bool same_num_heads = params.query.is_nested()
+      ? true
+      : params.query.size(1) == params.key.size(1) &&
+          params.query.size(1) == params.value.size(1);
+
   if (!(same_batch_size && same_num_heads)) {
     if (debug) {
       TORCH_WARN(

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -216,20 +216,22 @@ inline bool check_tensor_shapes(sdp_params params, bool debug) {
 
 inline bool check_head_dim_size(sdp_params params, bool debug) {
   const int64_t query_size_last = params.query.size(-1);
+  const int64_t key_size_last = params.key.size(-1);
   const int64_t value_size_last = params.value.size(-1);
-  if (!(query_size_last == params.key.size(-1) && query_size_last % 8 == 0 &&
+  if (!(query_size_last == key_size_last &&
+        query_size_last == value_size_last && query_size_last % 8 == 0 &&
         query_size_last <= 128 && value_size_last % 8 == 0 &&
         value_size_last <= 128)) {
     if (debug) {
       TORCH_WARN(
-        "Flash attention requires last dimension of inputs to be a multiple of 8 and less than or equal to 128.",
-        "Got Query.size(-1): ",
-        query_size_last,
-        ", Key.size(-1): ",
-        params.key.size(-1),
-        ", Value.size(-1): ",
-        params.value.size(-1),
-        " instead.");
+          "Flash attention requires q,k,v to have the same last dimension and to be a multiple of 8 and less than or equal to 128.",
+          " Got Query.size(-1): ",
+          query_size_last,
+          ", Key.size(-1): ",
+          params.key.size(-1),
+          ", Value.size(-1): ",
+          params.value.size(-1),
+          " instead.");
     }
     return false;
   }

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1810,14 +1810,6 @@ class TestSDPA(NNTestCase):
                 value = torch.randn(shape, dtype=torch.float16, device='cpu')
                 self.assertRaises(RuntimeError, lambda: F.scaled_dot_product_attention(query, key, value))
 
-            # Different dims
-            shape_q = (1, 4, 8, 16)
-            shape_kv = (1, 4, 8, 8, 32)
-            query = torch.randn(shape_q, dtype=torch.float16, device=device)
-            key = torch.randn(shape_kv, dtype=torch.float16, device=device)
-            value = torch.randn(shape_kv, dtype=torch.float16, device=device)
-            self.assertRaises(RuntimeError, lambda: F.scaled_dot_product_attention(query, key, value))
-
             # 1 dim
             shape = (1, 4)
             query = torch.randn(4, dtype=torch.float16, device=device)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1784,6 +1784,10 @@ class TestSDPA(NNTestCase):
         self.assertEqual(value.grad, value_ref.grad.to(value.grad.dtype),
                          atol=grad_v_ref_atol, rtol=grad_v_ref_rtol)
 
+    @parametrize("kernel", [SDPBackend.MATH, SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION])
+    def test_invalid_inputs(self, kernel: SDPBackend):
+        pass
+
 # TODO: Replace this with instantiate_device_type_tests() to take advantage of test framework support for
 # cross device / dtype testing.
 instantiate_parametrized_tests(TestTransformers)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1509,7 +1509,8 @@ class TestSDPA(NNTestCase):
                                    lambda: torch._fused_sdp_choice(q, k, v))
             self.assertRaisesRegex(RuntimeError, "No viable backend for scaled_dot_product_attention was found.",
                                    lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v))
-        fused_kernels = [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if SM80OrLater else [SDPBackend.EFFICIENT_ATTENTION]
+        fused_kernels = [SDPBackend.FLASH_ATTENTION,
+                         SDPBackend.EFFICIENT_ATTENTION] if SM80OrLater else [SDPBackend.EFFICIENT_ATTENTION]
         for kernel in fused_kernels:
             with sdp_kernel(**self.backend_map[kernel]):
                 # Dim is not 4

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1552,13 +1552,8 @@ class TestSDPA(NNTestCase):
             self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
                 q, k, v, None, 0.0, False))
 
-    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Does not support fused scaled dot product attention")
-    @parametrize(
-        "kernel",
-        [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]
-        if SM80OrLater
-        else [SDPBackend.EFFICIENT_ATTENTION],
-    )
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA or not SM80OrLater, "Does not support fused scaled dot product attention")
+    @parametrize("kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION])
     def test_invalid_fused_inputs_head_dim(self, kernel: SDPBackend):
         with sdp_kernel(**self.backend_map[kernel]):
             # The embed dim per head is not divisible by 8 for flash attention

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1527,7 +1527,12 @@ class TestSDPA(NNTestCase):
                                    lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v))
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Does not support fused scaled dot product attention")
-    @parametrize("kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if SM80OrLater else [SDPBackend.EFFICIENT_ATTENTION])
+    @parametrize(
+        "kernel",
+        [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]
+        if SM80OrLater
+        else [SDPBackend.EFFICIENT_ATTENTION],
+    )
     def test_invalid_fused_inputs_dim_3(self, kernel: SDPBackend):
         with sdp_kernel(**self.backend_map[kernel]):
             # Dim is not 4
@@ -1541,7 +1546,12 @@ class TestSDPA(NNTestCase):
                 q, k, v, None, 0.0, False))
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Does not support fused scaled dot product attention")
-    @parametrize("kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if SM80OrLater else [SDPBackend.EFFICIENT_ATTENTION])
+    @parametrize(
+        "kernel",
+        [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]
+        if SM80OrLater
+        else [SDPBackend.EFFICIENT_ATTENTION],
+    )
     def test_invalid_fused_inputs_broadcast(self, kernel: SDPBackend):
         with sdp_kernel(**self.backend_map[kernel]):
             #  Fused Kernels don't support broadcasting
@@ -1556,7 +1566,12 @@ class TestSDPA(NNTestCase):
                 q, k, v, None, 0.0, False))
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Does not support fused scaled dot product attention")
-    @parametrize("kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if SM80OrLater else [SDPBackend.EFFICIENT_ATTENTION])
+    @parametrize(
+        "kernel",
+        [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]
+        if SM80OrLater
+        else [SDPBackend.EFFICIENT_ATTENTION],
+    )
     def test_invalid_fused_inputs_head_dim(self, kernel: SDPBackend):
         with sdp_kernel(**self.backend_map[kernel]):
             # The embed dim per head is not divisible by 8 for flash attention
@@ -1569,7 +1584,12 @@ class TestSDPA(NNTestCase):
                 q, k, v, None, 0.0, False))
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Does not support fused scaled dot product attention")
-    @parametrize("kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if SM80OrLater else [SDPBackend.EFFICIENT_ATTENTION])
+    @parametrize(
+        "kernel",
+        [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]
+        if SM80OrLater
+        else [SDPBackend.EFFICIENT_ATTENTION],
+    )
     def test_invalid_fused_inputs_invalid_dtype(self, kernel: SDPBackend):
         with sdp_kernel(**self.backend_map[kernel]):
             # Invalid dtype for both Flash Attention and Mem Efficient Attention
@@ -1581,7 +1601,12 @@ class TestSDPA(NNTestCase):
                 q, k, v, None, 0.0, False))
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Does not support fused scaled dot product attention")
-    @parametrize("kernel", [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION] if SM80OrLater else [SDPBackend.EFFICIENT_ATTENTION])
+    @parametrize(
+        "kernel",
+        [SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]
+        if SM80OrLater
+        else [SDPBackend.EFFICIENT_ATTENTION],
+    )
     def test_invalid_fused_inputs_attn_mask_present(self, kernel: SDPBackend):
         with sdp_kernel(**self.backend_map[kernel]):
             # Failures for unsupported SDP args
@@ -1858,7 +1883,7 @@ class TestSDPA(NNTestCase):
 
     @parametrize("kernel", [SDPBackend.MATH, SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION])
     @parametrize("device", ["cpu", "cuda"] if TEST_CUDA else ["cpu"])
-    def test_invalid_inputs_different_datatypes(self, kernel: SDPBackend, device: str):
+    def test_invalid_inputs_1_dimensional_inputs(self, kernel: SDPBackend, device: str):
         with sdp_kernel(**self.backend_map[kernel]):
             # 1 dimensional input
             shape = (1, 4)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7652,7 +7652,7 @@ def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_
     )
     samples.append(diff_v_head_dim)
 
-    yield from (samples)
+    yield from samples
 
 def sample_inputs_pairwise_distance(op_info, device, dtype, requires_grad, **kwargs):
     make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7627,17 +7627,32 @@ def sample_inputs_scaled_dot_product_attention(op_info, device, dtype, requires_
     dim_4_q_shape = (batch, num_heads, seq_q, head_dim)
     dim_4_kv_shape = (batch, num_heads, seq_kv, head_dim)
 
-    qkv_shapes = [(dim_3_q_shape, dim_3_kv_shape), (dim_4_q_shape, dim_4_kv_shape)]
+    broadcast_tuple = ((num_heads, seq_q, head_dim), (batch, num_heads, seq_kv, head_dim))
+
+    qkv_shapes = [(dim_3_q_shape, dim_3_kv_shape), (dim_4_q_shape, dim_4_kv_shape), broadcast_tuple]
+    samples = []
     for qkv_shapes, is_causal, dropout_p in product(
             qkv_shapes, [True, False], [0.0, 0.5]):
         shape_q, shape_kv = qkv_shapes
-        yield SampleInput(
+        samples.append(SampleInput(
             make(shape_q),
             make(shape_kv),
             make(shape_kv),
             is_causal=is_causal,
             dropout_p=dropout_p
-        )
+        ))
+
+    # Add non standard shapes
+    diff_v_head_dim = SampleInput(
+        make((batch, num_heads, seq_q, head_dim)),
+        make((batch, num_heads, seq_kv, head_dim)),
+        make((batch, num_heads, seq_kv, head_dim + 8)),
+        is_causal=is_causal,
+        dropout_p=dropout_p
+    )
+    samples.append(diff_v_head_dim)
+
+    yield from (samples)
 
 def sample_inputs_pairwise_distance(op_info, device, dtype, requires_grad, **kwargs):
     make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)


### PR DESCRIPTION
# Summary
Add more checks around shape constraints as well as update the sdp_utils to properly catch different head_dims between qk and v for flash_attention which is not supported.