### PR TITLE
inductor: fix index check in reduction loader

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -3810,6 +3810,17 @@ class CommonTemplate:
         x = torch.rand([1, 2, 2, 1], dtype=torch.float64)
         self.common(fn, (x,))
 
+    def test_constant_pad_size_1(self):
+        # Repro for https://github.com/pytorch/pytorch/issues/93819
+        def fn(v1):
+            v1 = torch.nn.functional.log_softmax(v1, 2, _stacklevel=17, dtype=None)
+            v1 = torch.nn.functional.pad(v1, [0, 0, 1, 0], mode="constant", value=None)
+            return v1
+
+        x = torch.rand([4, 3, 1, 5])
+        for dtype in [torch.float]:
+            self.common(fn, (x.to(dtype=dtype),))
+
     def test_l1_loss(self):
         def fn(a, b):
             return torch.nn.functional.l1_loss(a, b), torch.nn.functional.mse_loss(a, b)

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -597,6 +597,7 @@ class SimplifyIndexing(V.WrapperHandler):  # type: ignore[name-defined]
     def __init__(self, inner, var_ranges: VarRanges):
         super().__init__(inner)
         self.name = "SimplifyIndexing"
+        self._var_ranges = var_ranges
         self._simplify: Callable[
             [Expr], Expr
         ] = lambda index: V.graph.sizevars.simplify_with_ranges(index, var_ranges)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94289

Fixes https://github.com/pytorch/pytorch/issues/93819.

The previous check in the reduction loader requires that `index == 0` for index of the reduced dim.
In the case of https://github.com/pytorch/pytorch/issues/93819, a reduction OP (the size of the reduced dim is 1 before the reduction) is followed by a constant pad OP.

The reduction OP has received `index = d2 - 1`, which is of a reduced dim.
The range of `d2` is `[0, 2)`.
- For `d2 == 0`, `index = d2 - 1 = -1`, it is in the area where the mask value will be `false`, so that `fill_value` will be used and the load won't actually happen:
https://github.com/pytorch/pytorch/blob/83275d8cdf7721285c4e1b921c28295dc215ba7c/torch/_inductor/lowering.py#L2452

- For `d2 == 1`,  `index = d2 - 1 = 0`, which has satisfied the check of `index == 0`.

We've improved the index check to be:
if the inferred index (based on the range of the free symbols) is possible to be 0, we consider that this is a legitimate load.

### Example:
```python
def test_constant_pad_size_1(self):
    def fn(v1):
        v1 = torch.nn.functional.log_softmax(v1, 2, _stacklevel=17, dtype=None)
        v1 = torch.nn.functional.pad(v1, [0, 0, 1, 0], mode="constant", value=None)
        return v1

    x = torch.rand([4, 3, 1, 5])
    for dtype in [torch.float]:
        self.common(fn, (x.to(dtype=dtype),))
```

Generated code (after fixing the index check):
```python

kernel_cpp_0 = async_compile.cpp('''
#include "/tmp/torchinductor_chunyuan/dm/cdmaihqxwe73zkb3he2zizktpq5uujetg2db26c3r4lgsmlx3b4c.h"
extern "C" void kernel(const float* __restrict__ in_ptr0,
                       float* __restrict__ out_ptr0)
{
    #pragma omp parallel num_threads(56)
    {
        {
            #pragma omp for 
            for(long i0=0; i0<12; i0+=1)
            {
                #pragma GCC ivdep
                for(long i1=0; i1<2; i1+=1)
                {
                    #pragma GCC ivdep
                    for(long i2=0; i2<5; i2+=1)
                    {
                        auto tmp0 = static_cast<long>((-1) + i1);
                        auto tmp1 = static_cast<long>(0);
                        auto tmp2 = tmp0 >= tmp1;
                        auto tmp3 = [&]
                        {
                            auto tmp4 = in_ptr0[i2 + (5*i0)];
                            auto tmp5 = tmp4 - tmp4;
                            auto tmp6 = std::exp(tmp5);
                            auto tmp7 = std::log(tmp6);
                            auto tmp8 = tmp5 - tmp7;
                            return tmp8;
                        }
                        ;
                        auto tmp9 = tmp2 ? tmp3() : static_cast<decltype(tmp3())>(0.0);
                        out_ptr0[i2 + (5*i1) + (10*i0)] = tmp9;
                    }
                }
            }
        }
    }
}
''')


async_compile.wait(globals())
del async_compile

def call(args):
    arg0_1, = args
    args.clear()
    buf0 = empty_strided((4, 3, 2, 5), (30, 10, 5, 1), device='cpu', dtype=torch.float32)
    kernel_cpp_0(c_void_p(arg0_1.data_ptr()), c_void_p(buf0.data_ptr()))
    del arg0_1
    return (buf0, )

```



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @kadeng @muchulee8 @aakhundov @mlazos @soumith @yanboliang @anijain2305 @desertfire