### PR TITLE
[Quant][PT2.0] fix issues for rearranging weight observer for decomposed linear

### DIFF
--- a/test/quantization/fx/test_quantize_pt2e.py
+++ b/test/quantization/fx/test_quantize_pt2e.py
@@ -15,6 +15,7 @@ from torch.testing._internal.common_quantized import (
 from torch.ao.quantization import (
     get_default_qconfig,
     QConfigMapping,
+    observer,
 )
 from torch.ao.quantization.backend_config import (
     get_qnnpack_backend_config,
@@ -26,6 +27,7 @@ from torch.ao.ns.fx.utils import (
     compute_sqnr,
 )
 import copy
+import itertools
 
 @skipIfNoQNNPACK
 class TestQuantizePT2E(QuantizationTestCase):
@@ -125,6 +127,68 @@ class TestQuantizePT2E(QuantizationTestCase):
                 ns.call_function(torch.ops.aten.addmm.default),
             ]
             self.checkGraphModuleNodes(m, expected_node_list=node_list)
+
+    @xfailIfPython311
+    def test_rearrange_weight_observer_for_decomposed_linear(self):
+        """
+        Check whether weight observer is correctly rearranged for decomposed linear.
+        before:
+            weight - t - observer \
+              input - observer - addmm/mm
+        after:
+            weight - observer - t \
+              input - observer - addmm/mm
+        """
+        class M(torch.nn.Module):
+            def __init__(self, with_bias, use_relu):
+                super().__init__()
+                self.linear = nn.Linear(4, 4, bias=with_bias)
+                self.relu = nn.ReLU()
+                self.use_relu = use_relu
+
+            def forward(self, x):
+                x = self.linear(x)
+                return self.relu(x) if self.use_relu else x
+
+        with_bias_list = [True, False]
+        use_relu_list = [True, False]
+        cases = itertools.product(with_bias_list, use_relu_list)
+        for with_bias, use_relu in cases:
+            m = M(with_bias, use_relu).eval()
+            example_inputs = (torch.randn(1, 4),)
+
+            # program capture
+            m, guards = torchdynamo.export(
+                m,
+                *copy.deepcopy(example_inputs),
+                aten_graph=True,
+                tracing_mode="real",
+            )
+
+            qconfig = get_default_qconfig('qnnpack')
+            qconfig_mapping = QConfigMapping().set_global(qconfig)
+            backend_config = get_qnnpack_pt2e_backend_config()
+            m = prepare_pt2e(m, qconfig_mapping, example_inputs, backend_config)
+
+            # 1. Check graph nodes:
+            # - args[0] of t should be the weight observer
+            # - args[-1] of addmm/mm should be t
+            error_msg = 'Weight observer is not correctly rearranged for decomposed linear'
+            for node in m.graph.nodes:
+                if node.target == torch.ops.aten.t.default:
+                    target = node.args[0].target
+                    self.assertTrue(isinstance(getattr(m, target), observer.ObserverBase), error_msg)
+                elif node.target in (torch.ops.aten.addmm.default, torch.ops.aten.mm.default):
+                    target = node.args[-1].target
+                    self.assertTrue(target == torch.ops.aten.t.default, error_msg)
+
+            # 2. Check m.code to ensure `m.recompile()` is called.
+            # If weight observer is rearranged in graph but `m.recompile()` is not called,
+            # m.code would be wrong.
+            code_before_recompile = m.code
+            m.recompile()
+            code_after_recompile = m.code
+            self.assertTrue(code_before_recompile == code_after_recompile, error_msg)
 
 class TestQuantizePT2EModels(QuantizationTestCase):
     @skip_if_no_torchvision

--- a/torch/ao/quantization/_quantize_pt2e.py
+++ b/torch/ao/quantization/_quantize_pt2e.py
@@ -6,7 +6,7 @@ from .fx import prepare
 from .quantize_fx import _convert_to_reference_decomposed_fx
 from ._pt2e.utils import (
     _fuse_conv_bn_,
-    _rearrange_weight_observer_for_addmm,
+    _rearrange_weight_observer_for_decomposed_linear,
 )
 
 from typing import Tuple, Any, Dict
@@ -42,7 +42,7 @@ def prepare_pt2e(
 
     # TODO: remove hack when we have better support for pattern matching
     # move around the observer for addmm
-    _rearrange_weight_observer_for_addmm(model)
+    _rearrange_weight_observer_for_decomposed_linear(model)
     return model
 
 def convert_pt2e(

--- a/torch/ao/quantization/backend_config/_qnnpack_pt2e.py
+++ b/torch/ao/quantization/backend_config/_qnnpack_pt2e.py
@@ -60,6 +60,13 @@ def get_linear_configs():
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 2, "bias": 0})
     )
+    # linear is decomposed to `t - mm` if bias is not present
+    linear_configs.append(
+        BackendPatternConfig(torch.ops.aten.mm.default)
+        .set_observation_type(observation_type)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
+        ._set_input_type_to_index({"weight": 1})
+    )
     return linear_configs
 
 def get_conv_configs():


### PR DESCRIPTION
**Summary**
Linear is decomposed to `t - addmm/mm` after `dynamo.export`. And weight's observer is inserted between `t` and `addmm/mm` in the first place. `_rearrange_weight_observer_for_addmm()` is then called to move the observer between weight and `t`.
```
    before:
         weight - t - observer \
           input - observer - addmm/mm
    after:
         weight - observer - t \
           input - observer - addmm/mm
```
We found two issues of `_rearrange_weight_observer_for_addmm()`:
- It does not call `m.recompile()` in the end, so it does not function correctly.
- It does not support `aten.mm.default` which is from decomposed linear without bias.

This PR fixes the two issues and renames the function to `_rearrange_weight_observer_for_decomposed_linear`.

**Test plan**
python test/test_quantization.py -k test_rearrange_weight_observer_for_decomposed_linear


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10