### PR TITLE
[BE]: pyupgrade Python to 3.8 - imports and object inheritance only

### DIFF
--- a/benchmarks/distributed/ddp/benchmark.py
+++ b/benchmarks/distributed/ddp/benchmark.py
@@ -151,7 +151,7 @@ def sweep(benchmark):
     return results
 
 
-class Benchmark(object):
+class Benchmark:
     def __init__(self, device, distributed_backend, bucket_size):
         self.device = device
         self.batch_size = 32

--- a/benchmarks/fastrnns/bench.py
+++ b/benchmarks/fastrnns/bench.py
@@ -44,7 +44,7 @@ def pretty_print(benchresult, colwidth=16, sep=' '):
     return sep.join(items)
 
 # shim for torch.cuda.Event when running on cpu
-class Event(object):
+class Event:
     def __init__(self, enable_timing):
         pass
 

--- a/benchmarks/framework_overhead_benchmark/C2Module.py
+++ b/benchmarks/framework_overhead_benchmark/C2Module.py
@@ -9,7 +9,7 @@ def add_blob(ws, blob_name, tensor_size):
     blob_tensor = np.random.randn(*tensor_size).astype(np.float32)
     ws.FeedBlob(blob_name, blob_tensor)
 
-class C2SimpleNet(object):
+class C2SimpleNet:
     """
     This module constructs a net with 'op_name' operator. The net consist
     a series of such operator.

--- a/benchmarks/framework_overhead_benchmark/pt_wrapper_module.py
+++ b/benchmarks/framework_overhead_benchmark/pt_wrapper_module.py
@@ -1,6 +1,6 @@
 import torch
 
-class WrapperModule(object):
+class WrapperModule:
     """ Wraps the instance of wrapped_type.
     For graph_mode traces the instance of wrapped_type.
     Randomaly initializes num_params tensors with single float element.

--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -12,7 +12,7 @@ microbenchmarks.
 """
 
 
-class Caffe2BenchmarkBase(object):
+class Caffe2BenchmarkBase:
     """ This is a base class used to create Caffe2 operator benchmark
     """
     tensor_index = 0
@@ -103,7 +103,7 @@ class Caffe2BenchmarkBase(object):
         pass
 
 
-class Caffe2OperatorTestCase(object):
+class Caffe2OperatorTestCase:
     """ This class includes all the information needed to benchmark an operator.
         op_bench: it's a user-defined class (child of Caffe2BenchmarkBase)
         which includes input and operator, .etc

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -150,7 +150,7 @@ def _build_test(configs, bench_op, OperatorTestCase, run_backward, op_name_funct
             yield _create_test(new_op, test_attrs, tags, OperatorTestCase, run_backward, input_name)
 
 
-class BenchmarkRunner(object):
+class BenchmarkRunner:
     """BenchmarkRunner is responsible for benchmarking all the registered
     benchmark test groups.
 

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -100,7 +100,7 @@ class TorchBenchmarkBase(torch.nn.Module):
         return name
 
 
-class PyTorchOperatorTestCase(object):
+class PyTorchOperatorTestCase:
     """ This class includes all the information needed to benchmark an operator.
         op_bench: it's a user-defined class (child of TorchBenchmarkBase)
         which includes input and operator, .etc

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -185,7 +185,7 @@ def attr_probs(**probs):
     return probs
 
 
-class RandomSample(object):
+class RandomSample:
 
     def __init__(self, configs):
         self.saved_cum_distribution = {}

--- a/benchmarks/sparse/utils.py
+++ b/benchmarks/sparse/utils.py
@@ -6,7 +6,7 @@ import numpy as np
 import time
 
 # shim for torch.cuda.Event when running on cpu
-class Event(object):
+class Event:
     def __init__(self, enable_timing):
         pass
 

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -7,7 +7,7 @@ import torch
 import json
 
 
-class Benchmark(object):
+class Benchmark:
     def __init__(self, mode, device, dtype):
         self.mode = mode
         self.deterministic = False
@@ -238,7 +238,7 @@ def cuda_pointwise_context(loop_levels, block_count, block_size):
         torch._C._jit_set_te_cuda_pointwise_block_size(old_block_size)
 
 # Auxiliary class to facilitate dynamic input shape
-class DynamicShape(object):
+class DynamicShape:
     r'''
     An Auxiliary class for dynamic shape benchmarks
 

--- a/benchmarks/tensorexpr/microbenchmarks.py
+++ b/benchmarks/tensorexpr/microbenchmarks.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 import argparse
 
-class kernel_arena_scope(object):
+class kernel_arena_scope:
     def __enter__(self):
         self.scope = te.KernelScope()
 

--- a/benchmarks/tensorexpr/pt_engine.py
+++ b/benchmarks/tensorexpr/pt_engine.py
@@ -1,7 +1,7 @@
 import torch
 
 
-class TorchTensorEngine(object):
+class TorchTensorEngine:
     def rand(self, shape, device=None, dtype=None, requires_grad=False):
         return torch.rand(shape, device=device, dtype=dtype, requires_grad=requires_grad)
 

--- a/caffe2/contrib/playground/AnyExp.py
+++ b/caffe2/contrib/playground/AnyExp.py
@@ -76,7 +76,7 @@ def initialize_params_from_file(*args, **kwargs):
     return checkpoint.initialize_params_from_file(*args, **kwargs)
 
 
-class AnyExpTrainer(object):
+class AnyExpTrainer:
 
     def __init__(self, opts):
         import logging

--- a/caffe2/contrib/playground/meter.py
+++ b/caffe2/contrib/playground/meter.py
@@ -6,7 +6,7 @@
 from abc import abstractmethod
 
 
-class Meter(object):
+class Meter:
 
     @abstractmethod
     def __init__(self, **kwargs):

--- a/caffe2/contrib/tensorboard/tensorboard.py
+++ b/caffe2/contrib/tensorboard/tensorboard.py
@@ -28,7 +28,7 @@ except ImportError:
         # tensorflow<=0.12.1
         from tensorflow.train import SummaryWriter as FileWriter
 
-class Config(object):
+class Config:
     HEIGHT = 600
     ASPECT_RATIO = 1.6
 

--- a/caffe2/distributed/store_ops_test_util.py
+++ b/caffe2/distributed/store_ops_test_util.py
@@ -12,7 +12,7 @@ import numpy as np
 from caffe2.python import core, workspace
 
 
-class StoreOpsTests(object):
+class StoreOpsTests:
     @classmethod
     def _test_set_get(cls, queue, create_store_handler_fn, index, num_procs):
         store_handler = create_store_handler_fn()

--- a/caffe2/experiments/python/device_reduce_sum_bench.py
+++ b/caffe2/experiments/python/device_reduce_sum_bench.py
@@ -47,7 +47,7 @@ class BenchmarkMeta(type):
 
 
 @add_metaclass(BenchmarkMeta)
-class Benchmark(object):
+class Benchmark:
 
     def __init__(self):
         self.results = []

--- a/caffe2/python/binarysize.py
+++ b/caffe2/python/binarysize.py
@@ -24,7 +24,7 @@ import subprocess
 import sys
 
 
-class Trie(object):
+class Trie:
     """A simple class that represents a Trie."""
 
     def __init__(self, name):

--- a/caffe2/python/caffe_translator.py
+++ b/caffe2/python/caffe_translator.py
@@ -192,7 +192,7 @@ def _GetInputDims(caffe_net):
     return input_dims
 
 
-class TranslatorRegistry(object):
+class TranslatorRegistry:
     registry_ = {}
 
     @classmethod

--- a/caffe2/python/checkpoint.py
+++ b/caffe2/python/checkpoint.py
@@ -146,7 +146,7 @@ def db_name(epoch, node_name, db_prefix, path_prefix=None):
     return db_name
 
 
-class CheckpointManager(object):
+class CheckpointManager:
     """
     Controls saving and loading of workspaces on every epoch boundary of a job.
     If a CheckpointManager instance is passed to JobRunner, then JobRunner will
@@ -429,7 +429,7 @@ class CheckpointManager(object):
             return True
 
 
-class MultiNodeCheckpointManager(object):
+class MultiNodeCheckpointManager:
     """
     Coordinates checkpointing and checkpointing across multiple nodes.
     Each of `init`, `load` and `save` will build TaskGroups which will
@@ -634,7 +634,7 @@ class MultiNodeCheckpointManager(object):
             return True
 
 
-class UploadTaskGroupBuilder(object):
+class UploadTaskGroupBuilder:
     """A simple class to upload checkpoints."""
     def build(self, epoch, checkpoint_manager):
         """Builds the task group to upload checkpoints.
@@ -652,7 +652,7 @@ class UploadTaskGroupBuilder(object):
         raise NotImplementedError()
 
 
-class JobRunner(object):
+class JobRunner:
     """
     Implement the runtime logic for jobs with checkpointing at the level of
     epoch. Can be used to run either single-host or distributed jobs. Job

--- a/caffe2/python/context.py
+++ b/caffe2/python/context.py
@@ -6,7 +6,7 @@ import threading
 import functools
 
 
-class _ContextInfo(object):
+class _ContextInfo:
     def __init__(self, cls, allow_default):
         self.cls = cls
         self.allow_default = allow_default
@@ -35,7 +35,7 @@ class _ContextInfo(object):
         return self._stack[-1]
 
 
-class _ContextRegistry(object):
+class _ContextRegistry:
     def __init__(self):
         self._ctxs = {}
 
@@ -62,7 +62,7 @@ def _get_managed_classes(obj):
 
 
 
-class Managed(object):
+class Managed:
     """
     Managed makes the inheritted class a context managed class.
 

--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -200,7 +200,7 @@ def InferOpDeviceAsBlobDevices(op):
 GradientSlice = namedtuple('GradientSlice', ['indices', 'values'])
 
 
-class BlobReference(object):
+class BlobReference:
     """A wrapper around a blob in a net.
 
     BlobReference gives us a way to refer to the network that the blob is
@@ -485,7 +485,7 @@ SparseGradGenMeta = namedtuple('SparseGradGenMeta', [
 ])
 
 
-class IR(object):
+class IR:
     """A simple IR class to keep track of all intermediate representations used
     in the gradient computation.
     """
@@ -1103,7 +1103,7 @@ StopGradient. Op:\n\n{}""".format(op.output[0], str(op)))
         return all_gradient_ops, all_input_to_grad_out
 
 
-class GradientRegistry(object):
+class GradientRegistry:
     """GradientRegistry holds the mapping from operators to their gradients."""
     gradient_registry_ = {}
 
@@ -1444,7 +1444,7 @@ def _recover_record_by_prefix(names, prefix=''):
         col_blobs=[_get_blob_ref(prefix + name) for name in column_names])
 
 
-class Net(object):
+class Net:
     _net_names_used = set()
     operator_registry_ = {}
 
@@ -2666,7 +2666,7 @@ def _add_net_to_dict(net_dict, net):
         return True
 
 
-class ExecutionStep(object):
+class ExecutionStep:
     _step_names_used = set()
 
     @staticmethod
@@ -2872,7 +2872,7 @@ def add_nets_in_order(step, net_list):
         net_list.append(proto.report_net)
 
 
-class Plan(object):
+class Plan:
 
     def __init__(self, name_or_step):
         self._plan = caffe2_pb2.PlanDef()

--- a/caffe2/python/crf.py
+++ b/caffe2/python/crf.py
@@ -13,7 +13,7 @@ and its gradient in C++ and handle the different batches there.
 """
 
 
-class CRFWithLoss(object):
+class CRFWithLoss:
     def __init__(self, model, num_classes, transitions_blob=None):
         self.model = model
         self.num_classes = num_classes

--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -1304,7 +1304,7 @@ def _RemapParameterBlobsForSharedModel(model, all_params):
     modify_ops(model.net)
 
 
-class CollectivesConcurrencyControl(object):
+class CollectivesConcurrencyControl:
     """
     Creates common worlds (up to max_concurrent_context) and manage the
     sequential execution of collectives that shares the same context with

--- a/caffe2/python/dataio.py
+++ b/caffe2/python/dataio.py
@@ -26,7 +26,7 @@ import numpy as np
 import time
 
 
-class Reader(object):
+class Reader:
     """
     Reader is an abstract class to be implemented in order to provide
     operations capable of iterating through a dataset or stream of data.
@@ -143,7 +143,7 @@ class Reader(object):
         return (read_step, fields)
 
 
-class Writer(object):
+class Writer:
     """
     Writer is an abstract class to be implemented in order to provide
     operations capable of feeding a data stream or a dataset.
@@ -207,7 +207,7 @@ class Writer(object):
         pass
 
 
-class ReaderBuilder(object):
+class ReaderBuilder:
     """ Allow usage of a reader in distributed fashion. """
     def schema(self):
         raise NotImplementedError()
@@ -256,7 +256,7 @@ class PipedReaderBuilder(ReaderBuilder):
         return output if isinstance(output, Reader) else output.reader()
 
 
-class Pipe(object):
+class Pipe:
     def __init__(self, schema=None, obj_key=None):
         self._num_writers = 0
         self._num_readers = 0

--- a/caffe2/python/dataset.py
+++ b/caffe2/python/dataset.py
@@ -182,7 +182,7 @@ def execution_step_with_progress(name, init_net, substeps, rows_read):
         report_interval=5)
 
 
-class Dataset(object):
+class Dataset:
     """Represents an in-memory dataset with fixed schema.
 
     Use this to store and iterate through datasets with complex schema that

--- a/caffe2/python/device_checker.py
+++ b/caffe2/python/device_checker.py
@@ -6,7 +6,7 @@ from caffe2.python import workspace
 from caffe2.python.core import InferOpBlobDevicesAsDict
 
 
-class DeviceChecker(object):
+class DeviceChecker:
     """A device checker in Python to check consistency across multiple devices.
 
     This is not the most efficient way to check devices, as the Python interface

--- a/caffe2/python/docs/formatter.py
+++ b/caffe2/python/docs/formatter.py
@@ -7,7 +7,7 @@
 from caffe2.python.docs.parser import Parser
 
 
-class Formatter(object):
+class Formatter:
     def __init__(self):
         self.content = ""
 

--- a/caffe2/python/docs/generator.py
+++ b/caffe2/python/docs/generator.py
@@ -12,7 +12,7 @@ from caffe2.python.docs.formatter import Markdown
 OpSchema = workspace.C.OpSchema
 
 
-class DocUploader(object):
+class DocUploader:
     def __init__(self):
         pass
 
@@ -20,7 +20,7 @@ class DocUploader(object):
         pass
 
 
-class DocGenerator(object):
+class DocGenerator:
     def __init__(self, formatter, uploader):
         self.formatter = formatter
         self.uploader = uploader
@@ -94,7 +94,7 @@ class OpDocGenerator(DocGenerator):
         self.content_body += self.formatter.dump()
 
 
-class OperatorEngine(object):
+class OperatorEngine:
     def __init__(self, name):
         self.op_name = name
         self.base_op_name, self.engine = name.split("_ENGINE_", 1)
@@ -116,7 +116,7 @@ class OperatorEngine(object):
                                                       impl=impl))
 
 
-class OperatorDoc(object):
+class OperatorDoc:
     def __init__(self, name, schema, priority):
         self.name = name
         self.schema = schema

--- a/caffe2/python/docs/parser.py
+++ b/caffe2/python/docs/parser.py
@@ -7,7 +7,7 @@
 import re
 
 
-class Parser(object):
+class Parser:
     # List of tuples (regex_str, lambda(regex_match, formatter))
     # If a lambda returns True it will be called repeatedly with replacement
     # otherwise it will only be called on text that hasn't been parsed yet.

--- a/caffe2/python/examples/char_rnn.py
+++ b/caffe2/python/examples/char_rnn.py
@@ -35,7 +35,7 @@ def CreateNetOnce(net, created_names=set()): # noqa
         workspace.CreateNet(net)
 
 
-class CharRNN(object):
+class CharRNN:
     def __init__(self, args):
         self.seq_length = args.seq_length
         self.batch_size = args.batch_size

--- a/caffe2/python/experiment_util.py
+++ b/caffe2/python/experiment_util.py
@@ -23,7 +23,7 @@ an external log destination.
 '''
 
 
-class ExternalLogger(object):
+class ExternalLogger:
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod

--- a/caffe2/python/functional.py
+++ b/caffe2/python/functional.py
@@ -26,7 +26,7 @@ def namedtupledict(typename, field_names, *args, **kwargs):
     return data
 
 
-class _Functional(object):
+class _Functional:
     def __getattribute__(self, op_type):
         def op_func(*inputs, **args):
             ws = Workspace()

--- a/caffe2/python/gradient_checker.py
+++ b/caffe2/python/gradient_checker.py
@@ -69,7 +69,7 @@ def _assert_close(value1, value2, threshold, err_msg=''):
     return np.mean(delta), max(delta)
 
 
-class NetGradientChecker(object):
+class NetGradientChecker:
     @staticmethod
     def CompareNets(nets, outputs, outputs_with_grad_ids,
                     inputs_with_grads, input_values=None,

--- a/caffe2/python/layers/layers.py
+++ b/caffe2/python/layers/layers.py
@@ -119,7 +119,7 @@ def set_request_only(field):
         )
 
 
-class InstantiationContext(object):
+class InstantiationContext:
     """
     List of contexts where layer could be instantitated
     """
@@ -157,7 +157,7 @@ def create_layer(layer_name, *args, **kwargs):
 LayerPsParam = namedtuple("LayerPsParam", ["sparse_key", "average_length"])
 
 
-class LayerParameter(object):
+class LayerParameter:
     def __init__(
         self,
         parameter=None,
@@ -248,7 +248,7 @@ def is_request_only_scalar(scalar):
 # `ids`: A set of feature IDs that are accessed in the model layer
 AccessedFeatures = namedtuple("AccessedFeatures", ["type", "ids"])
 
-class ModelLayer(object):
+class ModelLayer:
     def __init__(
         self,
         model,

--- a/caffe2/python/layers/tags.py
+++ b/caffe2/python/layers/tags.py
@@ -27,7 +27,7 @@ class TagContext(context.DefaultManaged):
         self.tags = self.tags[:-len(tags)]
 
 
-class Tags(object):
+class Tags:
     # TODO(amalevich): Tags might need to live in their own contexts, add this
     # split later
     EXCLUDE_FROM_TRAIN = 'exclude_from_train'

--- a/caffe2/python/model_helper.py
+++ b/caffe2/python/model_helper.py
@@ -72,7 +72,7 @@ _known_working_ops = [
 ]
 
 
-class ModelHelper(object):
+class ModelHelper:
     """A helper model so we can manange models more easily. It contains net def
     and parameter storages. You can add an Operator yourself, e.g.
 

--- a/caffe2/python/modeling/initializers.py
+++ b/caffe2/python/modeling/initializers.py
@@ -7,7 +7,7 @@ from caffe2.python.core import DataType, BlobReference, ScopedBlobReference
 from caffe2.python.modeling.parameter_info import ParameterInfo
 
 
-class Initializer(object):
+class Initializer:
     '''
     This class abstracts out parameter creation. One can come up with a new
     Initializer in order to implement more complex parameter initialization logic
@@ -33,7 +33,7 @@ class Initializer(object):
         )
 
 
-class ExternalInitializer(object):
+class ExternalInitializer:
     '''
     This class is used in cases when the parameter should not be initialized by
     the initializer, but rather provided in the workspace when param_init_net is

--- a/caffe2/python/modeling/parameter_info.py
+++ b/caffe2/python/modeling/parameter_info.py
@@ -8,13 +8,13 @@ from caffe2.python import core
 import numpy as np
 
 
-class ParameterTags(object):
+class ParameterTags:
     BIAS = 'BIAS'
     WEIGHT = 'WEIGHT'
     COMPUTED_PARAM = 'COMPUTED_PARAM'
 
 
-class ParameterInfo(object):
+class ParameterInfo:
 
     def __init__(
             self, param_id, param, key=None, shape=None, length=None,

--- a/caffe2/python/modeling/parameter_sharing.py
+++ b/caffe2/python/modeling/parameter_sharing.py
@@ -11,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class ParameterSharingContext(object):
+class ParameterSharingContext:
     """
     This class manages scope driven way of parameter sharing across different
     NameScopes.

--- a/caffe2/python/models/seq2seq/beam_search.py
+++ b/caffe2/python/models/seq2seq/beam_search.py
@@ -11,7 +11,7 @@ import caffe2.python.models.seq2seq.seq2seq_util as seq2seq_util
 from caffe2.python.models.seq2seq.seq2seq_model_helper import Seq2SeqModelHelper
 
 
-class BeamSearchForwardOnly(object):
+class BeamSearchForwardOnly:
     """
     Class generalizing forward beam search for seq2seq models.
 

--- a/caffe2/python/models/seq2seq/seq2seq_util.py
+++ b/caffe2/python/models/seq2seq/seq2seq_util.py
@@ -316,7 +316,7 @@ def build_embedding_encoder(
     )
 
 
-class LSTMWithAttentionDecoder(object):
+class LSTMWithAttentionDecoder:
 
     def scope(self, name):
         return self.name + '/' + name if self.name is not None else name

--- a/caffe2/python/models/seq2seq/train.py
+++ b/caffe2/python/models/seq2seq/train.py
@@ -96,7 +96,7 @@ def prepare_batch(batch):
     )
 
 
-class Seq2SeqModelCaffe2(object):
+class Seq2SeqModelCaffe2:
 
     def _build_model(
         self,

--- a/caffe2/python/modifier_context.py
+++ b/caffe2/python/modifier_context.py
@@ -9,7 +9,7 @@
 DEFAULT_MODIFIER = 'DEFAULT'
 
 
-class ModifierContext(object):
+class ModifierContext:
     """
     provide context to allow param_info to have different modifiers
     """
@@ -40,7 +40,7 @@ class ModifierContext(object):
         self._rebuild_modifiers()
 
 
-class UseModifierBase(object):
+class UseModifierBase:
     '''
     context class to allow setting the current context.
     Example usage with layer:

--- a/caffe2/python/net_builder.py
+++ b/caffe2/python/net_builder.py
@@ -203,7 +203,7 @@ class NetBuilder(context.Managed):
         return self.name or 'Un-named NetBuilder'
 
 
-class Operations(object):
+class Operations:
     """
     Operations to be used in the context of a NetBuilder.
     """

--- a/caffe2/python/net_builder_test.py
+++ b/caffe2/python/net_builder_test.py
@@ -12,7 +12,7 @@ import unittest
 import threading
 
 
-class PythonOpStats(object):
+class PythonOpStats:
     lock = threading.Lock()
     num_instances = 0
     num_calls = 0

--- a/caffe2/python/net_printer.py
+++ b/caffe2/python/net_printer.py
@@ -15,7 +15,7 @@ from copy import copy
 from itertools import chain
 
 
-class Visitor(object):
+class Visitor:
     @classmethod
     def register(cls, Type):
         if not(hasattr(cls, 'visitors')):
@@ -154,7 +154,7 @@ def analyze(obj):
     Analyzer()(obj)
 
 
-class Text(object):
+class Text:
     def __init__(self):
         self._indent = 0
         self._lines_in_context = [0]

--- a/caffe2/python/nomnigraph.py
+++ b/caffe2/python/nomnigraph.py
@@ -9,7 +9,7 @@ from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 
 
-class NNModule(object):
+class NNModule:
     def __init__(self, net=None, device_map=None):
         if net is not None:
             serialized_proto = None

--- a/caffe2/python/normalizer.py
+++ b/caffe2/python/normalizer.py
@@ -3,7 +3,7 @@
 
 
 
-class Normalizer(object):
+class Normalizer:
     def __init__(self):
         pass
     """

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -100,7 +100,7 @@ def convertAttributeProto(onnx_arg):
 
 
 # TODO: Move this into ONNX main library
-class OnnxNode(object):
+class OnnxNode:
     """
     Reimplementation of NodeProto from ONNX, but in a form
     more convenient to work with from Python.

--- a/caffe2/python/onnx/frontend.py
+++ b/caffe2/python/onnx/frontend.py
@@ -29,7 +29,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-class Caffe2Frontend(object):
+class Caffe2Frontend:
     # This number controls the semantics of the operators we target.  Whenever
     # ONNX makes a BC breaking change to semantics of operators, having this set
     # to an accurate number will prevent our models form exporting.  However,

--- a/caffe2/python/onnx/workspace.py
+++ b/caffe2/python/onnx/workspace.py
@@ -12,7 +12,7 @@ from caffe2.python import workspace
 
 # Separating out the context manager part so that users won't
 # (mis-)use Workspace instances as context managers
-class _WorkspaceCtx(object):
+class _WorkspaceCtx:
     def __init__(self, workspace_id):
         self.workspace_id = workspace_id
         # A stack, so that the context manager is reentrant.
@@ -34,7 +34,7 @@ class _WorkspaceCtx(object):
         workspace.SwitchWorkspace(w, create_if_missing=True)
 
 
-class Workspace(object):
+class Workspace:
     """
     An object representing a Caffe2 workspace.  It is a context manager,
     so you can say 'with workspace:' to use the represented workspace

--- a/caffe2/python/operator_test/self_binning_histogram_test.py
+++ b/caffe2/python/operator_test/self_binning_histogram_test.py
@@ -7,7 +7,7 @@ from caffe2.python import core, workspace
 from hypothesis import given, settings
 
 
-class TestSelfBinningHistogramBase(object):
+class TestSelfBinningHistogramBase:
     def __init__(self, bin_spacing, dtype, abs=False):
         self.bin_spacing = bin_spacing
         self.dtype = dtype

--- a/caffe2/python/optimizer.py
+++ b/caffe2/python/optimizer.py
@@ -32,7 +32,7 @@ def reset_optimizer_instance_count():
     _optimizer_instance_count.clear()
 
 
-class Optimizer(object):
+class Optimizer:
     def __init__(self):
         self._aux_params = AuxOptimizerParams(local=[], shared=[])
         self._instance_num = _optimizer_instance_count[self.__class__.__name__]

--- a/caffe2/python/optimizer_test_util.py
+++ b/caffe2/python/optimizer_test_util.py
@@ -14,7 +14,7 @@ from caffe2.python.modeling.initializers import (
 from caffe2.python.model_helper import ModelHelper
 
 
-class OptimizerTestBase(object):
+class OptimizerTestBase:
     """
     This is an abstract base class.
     Don't inherit from unittest.TestCase, and don't name it 'Test*'.
@@ -148,7 +148,7 @@ class OptimizerTestBase(object):
         self.check_optimizer(optimizer)
 
 
-class LRModificationTestBase(object):
+class LRModificationTestBase:
     """
     This is an abstract base class.
     Don't inherit from unittest.TestCase, and don't name it 'Test*'.

--- a/caffe2/python/parallel_workers.py
+++ b/caffe2/python/parallel_workers.py
@@ -84,7 +84,7 @@ def init_workers(
     return global_coordinator
 
 
-class Metrics(object):
+class Metrics:
     def __init__(self, external_loggers):
         self._metrics = collections.defaultdict(lambda: 0)
         self._external_loggers = external_loggers
@@ -124,7 +124,7 @@ class State():
         pass
 
 
-class WorkerCoordinator(object):
+class WorkerCoordinator:
     def __init__(
         self, worker_name, worker_ids, init_fun,
         state=None, shutdown_fun=None
@@ -191,7 +191,7 @@ class WorkerCoordinator(object):
         return self._worker_ids
 
 
-class GlobalWorkerCoordinator(object):
+class GlobalWorkerCoordinator:
     def __init__(self):
         self._coordinators = []
         self._fetcher_id_seq = 0
@@ -248,7 +248,7 @@ class GlobalWorkerCoordinator(object):
         atexit.register(cleanup)
 
 
-class Worker(object):
+class Worker:
     def __init__(
         self,
         coordinator,

--- a/caffe2/python/pipeline.py
+++ b/caffe2/python/pipeline.py
@@ -12,7 +12,7 @@ from caffe2.python.schema import as_record, Field
 from caffe2.python.task import Node, Task, TaskGroup
 
 
-class Output(object):
+class Output:
     """
     Represents the result of a processor function. A processor can either
     return an Output, or it can return a record, in which case an Output will be
@@ -394,7 +394,7 @@ class ProcessingReader(Reader):
         return read_nets, status, fields
 
 
-class NetProcessor(object):
+class NetProcessor:
     """
     Processor that clones a core.Net each time it's called, executing
     the cloned net as the processor. It requires the Net to have input

--- a/caffe2/python/record_queue.py
+++ b/caffe2/python/record_queue.py
@@ -45,7 +45,7 @@ class _QueueWriter(Writer):
         return status
 
 
-class RecordQueue(object):
+class RecordQueue:
     """ The class is used to feed data with some process from a reader into a
         queue and provider a reader interface for data fetching from the queue.
     """

--- a/caffe2/python/regularizer.py
+++ b/caffe2/python/regularizer.py
@@ -6,12 +6,12 @@ from caffe2.python import core, utils
 import numpy as np
 
 
-class RegularizationBy(object):
+class RegularizationBy:
     AFTER_OPTIMIZER = "after_optimizer"
     ON_LOSS = "on_loss"
 
 
-class Regularizer(object):
+class Regularizer:
     def __init__(self):
         self.kEpsilon = 1e-9
 

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -42,7 +42,7 @@ def _RectifyNames(blob_references_or_names):
     return [_RectifyName(i) for i in blob_references_or_names]
 
 
-class RNNCell(object):
+class RNNCell:
     '''
     Base class for writing recurrent / stateful operations.
 
@@ -268,7 +268,7 @@ class RNNCell(object):
         return state_outputs[output_sequence_index]
 
 
-class LSTMInitializer(object):
+class LSTMInitializer:
     def __init__(self, hidden_size):
         self.hidden_size = hidden_size
 
@@ -888,7 +888,7 @@ class DropoutCell(RNNCell):
         return output
 
 
-class MultiRNNCellInitializer(object):
+class MultiRNNCellInitializer:
     def __init__(self, cells):
         self.cells = cells
 

--- a/caffe2/python/schema.py
+++ b/caffe2/python/schema.py
@@ -95,7 +95,7 @@ class Metadata(
 Metadata.__new__.__defaults__ = (None, None, None)
 
 
-class Field(object):
+class Field:
     """Represents an abstract field type in a dataset.
     """
 
@@ -979,7 +979,7 @@ def from_dtype(dtype, _outer_shape=()):
     return Struct(*struct_fields)
 
 
-class _SchemaNode(object):
+class _SchemaNode:
     """This is a private class used to represent a Schema Node"""
 
     __slots__: Sequence[str] = ("name", "children", "type_str", "field")

--- a/caffe2/python/session.py
+++ b/caffe2/python/session.py
@@ -10,14 +10,14 @@ from caffe2.python import core, workspace
 from caffe2.python.task import Cluster, Task, TaskGroup, WorkspaceType
 
 
-class CompiledRunnable(object):
+class CompiledRunnable:
     """ Wrapper for compiled runnable returned from session.compile() """
     def __init__(self, obj, session_class):
         self.obj = obj
         self.session_class = session_class
 
 
-class Session(object):
+class Session:
     """
     Allows to run Nets, ExecutionSteps, Plans, Tasks and TaskGroups.
     A session can potentially run in multiple nodes concurrently.

--- a/caffe2/python/task.py
+++ b/caffe2/python/task.py
@@ -89,7 +89,7 @@ class Node(context.DefaultManaged):
         return self._kwargs
 
 
-class WorkspaceType(object):
+class WorkspaceType:
     """
     Determines whether tasks of a TaskGroup will run directly at the global
     workspace, which is kept alive across runs, or whether a new child
@@ -351,7 +351,7 @@ class TaskGroup(context.Managed):
             self.remote_nets())
 
 
-class TaskOutput(object):
+class TaskOutput:
     """
     Represents the output of a task. An output can be a blob,
     a list of blob, or a record.
@@ -409,7 +409,7 @@ def final_output(blob_or_record):
     return cur_task.add_output(blob_or_record)
 
 
-class TaskOutputList(object):
+class TaskOutputList:
     """ Keeps a list of outputs for a task """
     def __init__(self, outputs=None):
         self.outputs = outputs or []
@@ -644,7 +644,7 @@ class Task(context.Managed):
             self.name, self.node, self.outputs())
 
 
-class SetupNets(object):
+class SetupNets:
     """
     Allow to register a list of nets to be run at initialization
     and finalization of Tasks or TaskGroups.

--- a/caffe2/python/transformations.py
+++ b/caffe2/python/transformations.py
@@ -21,7 +21,7 @@
 import caffe2.python._import_c_extension as C
 
 
-class Transformer(object):
+class Transformer:
     def __init__(self):
         pass
 

--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -276,7 +276,7 @@ def ResetBlobs(blobs):
     )
 
 
-class DebugMode(object):
+class DebugMode:
     '''
     This class allows to drop you into an interactive debugger
     if there is an unhandled exception in your python script

--- a/caffe2/python/visualize.py
+++ b/caffe2/python/visualize.py
@@ -25,7 +25,7 @@ def ChannelLast(arr):
     return arr.swapaxes(ndim - 3, ndim - 2).swapaxes(ndim - 2, ndim - 1)
 
 
-class PatchVisualizer(object):
+class PatchVisualizer:
     """PatchVisualizer visualizes patches.
   """
 
@@ -139,7 +139,7 @@ explicitly instantiate a patch visualizer, and call those functions.
 """
 
 
-class NHWC(object):
+class NHWC:
     @staticmethod
     def ShowSingle(*args, **kwargs):
         _default_visualizer.ShowSingle(*args, **kwargs)
@@ -157,7 +157,7 @@ class NHWC(object):
         _default_visualizer.ShowChannels(*args, **kwargs)
 
 
-class NCHW(object):
+class NCHW:
     @staticmethod
     def ShowSingle(patch, *args, **kwargs):
         _default_visualizer.ShowSingle(ChannelLast(patch), *args, **kwargs)

--- a/caffe2/python/workspace.py
+++ b/caffe2/python/workspace.py
@@ -526,7 +526,7 @@ def GetNameScope():
     return scope.CurrentNameScope()
 
 
-class _BlobDict(object):
+class _BlobDict:
     """Provides python dict compatible way to do fetching and feeding"""
 
     def __getitem__(self, key):

--- a/test/cpp/jit/tests_setup.py
+++ b/test/cpp/jit/tests_setup.py
@@ -3,7 +3,7 @@ import os
 import torch
 
 
-class Setup(object):
+class Setup:
     def setup(self):
         raise NotImplementedError()
 
@@ -11,7 +11,7 @@ class Setup(object):
         raise NotImplementedError()
 
 
-class FileSetup(object):
+class FileSetup:
     path = None
 
     def shutdown(self):

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -69,7 +69,7 @@ class Net(nn.Module):
         return self.out(F.relu(self.net(x)))
 
 
-class DummyState(object):
+class DummyState:
 
     __slots__ = ["process_group", "noise"]
 
@@ -78,7 +78,7 @@ class DummyState(object):
         self.noise = noise
 
 
-class DummyHook(object):
+class DummyHook:
     def dummy_hook_for_no_shard_fsdp(self, state: DummyState, grad: torch.Tensor):
         """
         This communication hook is for illustration and testing purpose only.

--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -76,7 +76,7 @@ def gpus_for_rank(world_size):
     return gpus_for_rank
 
 
-class AbstractTimeoutTest(object):
+class AbstractTimeoutTest:
     def _test_store_timeout(self, backend, init_method, c2p):
         try:
             dist.init_process_group(
@@ -249,7 +249,7 @@ class SparseGradientModule(nn.Module):
         return F.softmax(self.embedding(x), dim=1)
 
 
-class CommonDistributedDataParallelTest(object):
+class CommonDistributedDataParallelTest:
     def tearDown(self):
         # DistributedDataParallel test doesn't seem to call FileStore destructor
         # TODO: investigate this test and the test is known to have issues
@@ -1037,7 +1037,7 @@ class ComputeBucketAssignmentTest(TestCase):
         self.assertEqual(per_bucket_size_limits, [200, 200, 400, 400])
 
 
-class AbstractCommTest(object):
+class AbstractCommTest:
     @property
     def op_timeout_sec(self):
         return 1

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -82,7 +82,7 @@ class RendezvousEnvTest(TestCase):
             "MASTER_PORT": str(common.find_free_port()),
         }
 
-        class Env(object):
+        class Env:
             def __init__(self, vars):
                 self.env_patcher = mock.patch.dict(os.environ, vars, clear=True)
 

--- a/test/distributed/test_c10d_spawn.py
+++ b/test/distributed/test_c10d_spawn.py
@@ -33,7 +33,7 @@ if NO_MULTIPROCESSING_SPAWN:
     sys.exit(0)
 
 
-class AbstractProcessGroupShareTensorTest(object):
+class AbstractProcessGroupShareTensorTest:
     world_size = 2
 
     def _test_multiprocess(self, f, shared_tensors, init_pg, n_output):

--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -60,7 +60,7 @@ def gpus_for_rank(world_size):
     return gpus_for_rank
 
 
-class StoreTestBase(object):
+class StoreTestBase:
     def _create_store(self, i):
         raise RuntimeError("not implemented")
 

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -943,7 +943,7 @@ class TestDistributions(DistributionsTestCase):
     def test_lazy_property_grad(self):
         x = torch.randn(1, requires_grad=True)
 
-        class Dummy(object):
+        class Dummy:
             @lazy_property
             def y(self):
                 return x + 1
@@ -1466,7 +1466,7 @@ class TestDistributions(DistributionsTestCase):
     def test_rounded_relaxed_bernoulli(self):
         set_rng_seed(0)  # see Note [Randomized statistical tests]
 
-        class Rounded(object):
+        class Rounded:
             def __init__(self, dist):
                 self.dist = dist
 
@@ -1513,7 +1513,7 @@ class TestDistributions(DistributionsTestCase):
     def test_argmax_relaxed_categorical(self):
         set_rng_seed(0)  # see Note [Randomized statistical tests]
 
-        class ArgMax(object):
+        class ArgMax:
             def __init__(self, dist):
                 self.dist = dist
 
@@ -1522,7 +1522,7 @@ class TestDistributions(DistributionsTestCase):
                 _, idx = torch.max(s, -1)
                 return idx
 
-        class ScipyCategorical(object):
+        class ScipyCategorical:
             def __init__(self, dist):
                 self.dist = dist
 
@@ -1882,7 +1882,7 @@ class TestDistributions(DistributionsTestCase):
         loc = torch.randn(5)
         scale = torch.rand(5)
 
-        class ScipyMixtureNormal(object):
+        class ScipyMixtureNormal:
             def __init__(self, probs, mu, std):
                 self.probs = probs
                 self.mu = mu

--- a/test/dynamo/test_global.py
+++ b/test/dynamo/test_global.py
@@ -11,7 +11,7 @@ except ImportError:
     import test_global_declaration
 
 
-class Pair(object):  # noqa: B903
+class Pair:  # noqa: B903
     def __init__(self, x, y):
         self.x = x
         self.y = y

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1515,7 +1515,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(ref1, res1))
 
     def test_is_tensor_like2(self):
-        class MyTensor(object):
+        class MyTensor:
             @classmethod
             def __torch_function__(cls, func, types, args=(), kwargs=None):
                 if kwargs is None:
@@ -3341,12 +3341,12 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
     def test_if_cond_user_defined_object(self):
         # obj.__bool__ is not existed
-        class A(object):  # noqa: B903
+        class A:  # noqa: B903
             def __init__(self, x):
                 self.x = x
 
         # obj.__bool__ is function and returns bool type
-        class B(object):
+        class B:
             def __init__(self, x):
                 self.x = x
 
@@ -3354,7 +3354,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
                 return self.x > 0
 
         # obj.__bool__ is non-function
-        class C(object):
+        class C:
             def __init__(self, x):
                 self.x = x
                 self.__bool__ = False
@@ -3380,7 +3380,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
     def test_if_cond_user_defined_object2(self):
         # obj.__bool__ is function and returns non-bool type
-        class MyObj(object):
+        class MyObj:
             def __init__(self, x):
                 self.x = x
 
@@ -3404,14 +3404,14 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             self.assertIn("__bool__ should return bool, returned int", str(e))
 
     def test_class_has_instancecheck_method(self):
-        class A(object):
+        class A:
             pass
 
         class ExampleMeta(type):
             def __instancecheck__(cls, instance):
                 return True
 
-        class B(object, metaclass=ExampleMeta):
+        class B(metaclass=ExampleMeta):
             pass
 
         def fn(x, obj):
@@ -3702,7 +3702,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(graph.tracing_context.guards_context.dynamo_guards, guards)
 
     def test_call_parent_non_class_methods_from_child(self):
-        class A(object):
+        class A:
             def add(self, x):
                 return x + 10
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6946,7 +6946,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
     class TritonCodeGenTests(TestCase):
         counter = itertools.count(0)
 
-        class DebugDirManager(object):
+        class DebugDirManager:
             def __init__(self):
                 self.id = next(TritonCodeGenTests.counter)
                 self.prev_debug_name = None

--- a/test/jit/_imported_class_test/bar.py
+++ b/test/jit/_imported_class_test/bar.py
@@ -4,6 +4,6 @@ import torch
 
 
 @torch.jit.script  # noqa: B903
-class FooSameName(object):  # noqa: B903
+class FooSameName:  # noqa: B903
     def __init__(self, y):
         self.y = y

--- a/test/jit/_imported_class_test/foo.py
+++ b/test/jit/_imported_class_test/foo.py
@@ -5,7 +5,7 @@ from . import bar
 
 
 @torch.jit.script  # noqa: B903
-class FooSameName(object):
+class FooSameName:
     def __init__(self, x):
         self.x = x
         self.nested = bar.FooSameName(x)

--- a/test/jit/_imported_class_test/very/very/nested.py
+++ b/test/jit/_imported_class_test/very/very/nested.py
@@ -4,6 +4,6 @@ import torch
 
 
 @torch.jit.script  # noqa: B903
-class FooUniqueName(object):  # noqa: B903
+class FooUniqueName:  # noqa: B903
     def __init__(self, y):
         self.y = y

--- a/test/jit/test_await.py
+++ b/test/jit/test_await.py
@@ -59,7 +59,7 @@ class TestAwait(JitTestCase):
         self.assertTrue(torch.allclose(script_out, out))
 
     def test_nowait_class(self):
-        class C(object):
+        class C:
             def __init__(self, a: Tensor, b: Tensor):
                 self._a = a
                 self._b = b
@@ -85,7 +85,7 @@ class TestAwait(JitTestCase):
 
     def test_await_class_arg(self):
 
-        class C(object):
+        class C:
             def __init__(self, a: Tensor, b: Tensor):
                 self.__a = a
                 self.__b = b
@@ -113,7 +113,7 @@ class TestAwait(JitTestCase):
         self.assertTrue(torch.allclose(script_out, out))
 
     def test_awaitable_to_await(self):
-        class C(object):
+        class C:
             __slots__ = ["_a", "_b"]
 
             def __init__(self, a: Tensor, b: Tensor):
@@ -144,7 +144,7 @@ class TestAwait(JitTestCase):
 
     def test_await_class_return(self):
 
-        class C(object):
+        class C:
             __slots__ = ["a", "b"]
 
             def __init__(self, a: Tensor, b: Tensor):
@@ -178,7 +178,7 @@ class TestAwait(JitTestCase):
         self.assertGraphContainsExactly(sm.graph, kind='prim::awaitable_wait', num_kind_nodes=1)
 
     def test_await_getattr_implicit_convertion(self):
-        class C(object):
+        class C:
             def __init__(self, a: Tensor, b: Tensor):
                 self._a = a
                 self._b = b
@@ -216,7 +216,7 @@ class TestAwait(JitTestCase):
 
     def test_await_nested(self):
 
-        class C(object):
+        class C:
             def __init__(self, a: Tensor, b: Tensor):
                 self.__a = a
                 self.__b = b
@@ -246,7 +246,7 @@ class TestAwait(JitTestCase):
 
     def test_eager_await_non_scriptable(self):
         # Tree type can not be compiled (Recursive type)
-        class Tree(object):
+        class Tree:
             def __init__(self, v):
                 self.parent = torch.jit.annotate(Optional[Tree], None)
                 self.v = v

--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -29,7 +29,7 @@ class TestClassType(JitTestCase):
         Test that modifications made to a class instance in TorchScript
         are visible in eager.
         """
-        class Foo(object):
+        class Foo:
             def __init__(self, a: int):
                 self.a = a
 
@@ -59,7 +59,7 @@ class TestClassType(JitTestCase):
         self.assertEqual(obj.attr, 2)
 
     def test_get_with_method(self):
-        class FooTest(object):
+        class FooTest:
             def __init__(self, x):
                 self.foo = x
 
@@ -74,7 +74,7 @@ class TestClassType(JitTestCase):
         self.assertEqual(fn(input), input)
 
     def test_get_attr(self):
-        class FooTest(object):  # noqa: B903
+        class FooTest:  # noqa: B903
             def __init__(self, x):
                 self.foo = x
 
@@ -87,7 +87,7 @@ class TestClassType(JitTestCase):
         self.assertEqual(fn(input), input)
 
     def test_in(self):
-        class FooTest(object):  # noqa: B903
+        class FooTest:  # noqa: B903
             def __init__(self):
                 pass
 
@@ -102,7 +102,7 @@ class TestClassType(JitTestCase):
         self.assertEqual(fn(), (True, False))
 
     def test_set_attr_in_method(self):
-        class FooTest(object):
+        class FooTest:
             def __init__(self, x: int) -> None:
                 self.foo = x
 
@@ -120,7 +120,7 @@ class TestClassType(JitTestCase):
     def test_set_attr_type_mismatch(self):
         with self.assertRaisesRegexWithHighlight(RuntimeError, "Wrong type for attribute assignment", "self.foo = 10"):
             @torch.jit.script
-            class FooTest(object):
+            class FooTest:
                 def __init__(self, x):
                     self.foo = x
                     self.foo = 10  # should error since int != Tensor
@@ -128,7 +128,7 @@ class TestClassType(JitTestCase):
     def test_get_attr_not_initialized(self):
         with self.assertRaisesRegexWithHighlight(RuntimeError, "object has no attribute or method", "self.asdf"):
             @torch.jit.script
-            class FooTest(object):
+            class FooTest:
                 def __init__(self, x):
                     self.foo = x
 
@@ -138,7 +138,7 @@ class TestClassType(JitTestCase):
     def test_set_attr_non_initialized(self):
         with self.assertRaisesRegexWithHighlight(RuntimeError, "Tried to set nonexistent attribute", "self.bar = y"):
             @torch.jit.script
-            class FooTest(object):
+            class FooTest:
                 def __init__(self, x):
                     self.foo = x
 
@@ -160,7 +160,7 @@ class TestClassType(JitTestCase):
     def test_type_annotations(self):
         with self.assertRaisesRegexWithHighlight(RuntimeError, "Expected a value of type \'bool", ""):
             @torch.jit.script  # noqa: B903
-            class FooTest(object):  # noqa: B903
+            class FooTest:  # noqa: B903
                 def __init__(self, x: bool) -> None:
                     self.foo = x
 
@@ -173,13 +173,13 @@ class TestClassType(JitTestCase):
     def test_conditional_set_attr(self):
         with self.assertRaisesRegexWithHighlight(RuntimeError, "assignment cannot be in a control-flow block", ""):
             @torch.jit.script
-            class FooTest(object):
+            class FooTest:
                 def __init__(self, x):
                     if 1 == 1:
                         self.attr = x
 
     def test_class_type_as_param(self):
-        class FooTest(object):  # noqa: B903
+        class FooTest:  # noqa: B903
             def __init__(self, x):
                 self.attr = x
 
@@ -198,7 +198,7 @@ class TestClassType(JitTestCase):
         self.assertEqual(fn2(input), input)
 
     def test_out_of_order_methods(self):
-        class FooTest(object):
+        class FooTest:
             def __init__(self, x):
                 self.x = x
                 self.x = self.get_stuff(x)
@@ -215,7 +215,7 @@ class TestClassType(JitTestCase):
         self.assertEqual(fn(input), input + input)
 
     def test_save_load_with_classes(self):
-        class FooTest(object):
+        class FooTest:
             def __init__(self, x):
                 self.x = x
 
@@ -245,7 +245,7 @@ class TestClassType(JitTestCase):
         self.assertEqual(input, output)
 
     def test_save_load_with_classes_returned(self):
-        class FooTest(object):
+        class FooTest:
             def __init__(self, x):
                 self.x = x
 
@@ -277,16 +277,16 @@ class TestClassType(JitTestCase):
         self.assertEqual(input, output)
 
     def test_save_load_with_classes_nested(self):
-        class FooNestedTest(object):  # noqa: B903
+        class FooNestedTest:  # noqa: B903
             def __init__(self, y):
                 self.y = y
 
-        class FooNestedTest2(object):
+        class FooNestedTest2:
             def __init__(self, y):
                 self.y = y
                 self.nested = FooNestedTest(y)
 
-        class FooTest(object):
+        class FooTest:
             def __init__(self, x):
                 self.class_attr = FooNestedTest(x)
                 self.class_attr2 = FooNestedTest2(x)
@@ -315,7 +315,7 @@ class TestClassType(JitTestCase):
         self.assertEqual(2 * input, output)
 
     def test_python_interop(self):
-        class Foo(object):  # noqa: B903
+        class Foo:  # noqa: B903
             def __init__(self, x, y):
                 self.x = x
                 self.y = y
@@ -341,7 +341,7 @@ class TestClassType(JitTestCase):
         self.assertEqual(y, f2.y)
 
     def test_class_specialization(self):
-        class Foo(object):  # noqa: B903
+        class Foo:  # noqa: B903
             def __init__(self, x, y):
                 self.x = x
                 self.y = y
@@ -365,7 +365,7 @@ class TestClassType(JitTestCase):
         FileCheck().check_count("prim::GetAttr", 4).run(graphstr)
 
     def test_class_sorting(self):
-        class Foo(object):  # noqa: B903
+        class Foo:  # noqa: B903
             def __init__(self, x: int) -> None:
                 self.x = x
 
@@ -429,7 +429,7 @@ class TestClassType(JitTestCase):
 
         with self.assertRaisesRegexWithHighlight(RuntimeError, "must define a __lt__", ""):
             @torch.jit.script
-            class NoMethod(object):
+            class NoMethod:
                 def __init__(self):
                     pass
 
@@ -441,7 +441,7 @@ class TestClassType(JitTestCase):
             test()
 
         @torch.jit.script
-        class WrongLt(object):
+        class WrongLt:
             def __init__(self):
                 pass
 
@@ -459,7 +459,7 @@ class TestClassType(JitTestCase):
 
     def test_class_inheritance(self):
         @torch.jit.script
-        class Base(object):
+        class Base:
             def __init__(self):
                 self.b = 2
 
@@ -538,7 +538,7 @@ class TestClassType(JitTestCase):
 
     def test_interface(self):
         @torch.jit.script
-        class Foo(object):
+        class Foo:
             def __init__(self):
                 pass
 
@@ -549,7 +549,7 @@ class TestClassType(JitTestCase):
                 return 2 * x
 
         @torch.jit.script
-        class Bar(object):
+        class Bar:
             def __init__(self):
                 pass
 
@@ -560,7 +560,7 @@ class TestClassType(JitTestCase):
                 return 2 / x
 
         @torch.jit.interface
-        class OneTwo(object):
+        class OneTwo:
             def one(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
                 pass
 
@@ -568,7 +568,7 @@ class TestClassType(JitTestCase):
                 pass
 
         @torch.jit.interface
-        class OneTwoThree(object):
+        class OneTwoThree:
             def one(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
                 pass
 
@@ -579,7 +579,7 @@ class TestClassType(JitTestCase):
                 pass
 
         @torch.jit.interface
-        class OneTwoWrong(object):
+        class OneTwoWrong:
             def one(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
                 pass
 
@@ -587,7 +587,7 @@ class TestClassType(JitTestCase):
                 pass
 
         @torch.jit.script
-        class NotMember(object):
+        class NotMember:
             def __init__(self):
                 pass
 
@@ -596,7 +596,7 @@ class TestClassType(JitTestCase):
             # missing two
 
         @torch.jit.script
-        class NotMember2(object):
+        class NotMember2:
             def __init__(self):
                 pass
 
@@ -678,7 +678,7 @@ class TestClassType(JitTestCase):
             torch.jit.script(TestPyAssignError(Foo()))
 
         # test pure python object assignment to interface fails
-        class PyClass(object):
+        class PyClass:
             def __init__(self):
                 pass
 
@@ -690,7 +690,7 @@ class TestClassType(JitTestCase):
 
     def test_overloaded_fn(self):
         @torch.jit.script
-        class Foo(object):
+        class Foo:
             def __init__(self, x):
                 self.x = x
 
@@ -715,7 +715,7 @@ class TestClassType(JitTestCase):
 
         # TODO - support compiling classes from strings in jit.CompilationUnit
         @torch.jit.script
-        class MyClass(object):
+        class MyClass:
             def __init__(self, x: int) -> None:
                 self.x = x
 
@@ -827,7 +827,7 @@ class TestClassType(JitTestCase):
 
     def test_cast_overloads(self):
         @torch.jit.script
-        class Foo(object):
+        class Foo:
             def __init__(self, val: float) -> None:
                 self.val = val
 
@@ -858,7 +858,7 @@ class TestClassType(JitTestCase):
         self.assertTrue("0." in (str(Foo(0.0))))
 
         @torch.jit.script
-        class BadBool(object):
+        class BadBool:
             def __init__(self):
                 pass
 
@@ -874,7 +874,7 @@ class TestClassType(JitTestCase):
 
     def test_init_compiled_first(self):
         @torch.jit.script  # noqa: B903
-        class Foo(object):  # noqa: B903
+        class Foo:  # noqa: B903
             def __before_init__(self):
                 # accessing this field should not throw, since __init__ should be compiled
                 return self.x
@@ -885,7 +885,7 @@ class TestClassType(JitTestCase):
 
     def test_class_constructs_itself(self):
         @torch.jit.script  # noqa: B903
-        class LSTMStateStack(object):  # noqa: B903
+        class LSTMStateStack:  # noqa: B903
             def __init__(self, num_layers: int, hidden_size: int) -> None:
                 self.num_layers = num_layers
                 self.hidden_size = hidden_size
@@ -903,13 +903,13 @@ class TestClassType(JitTestCase):
 
     def test_optional_type_promotion(self):
         @torch.jit.script
-        class Leaf(object):
+        class Leaf:
             def __init__(self):
                 self.x = 1
 
         # should not throw
         @torch.jit.script  # noqa: B903
-        class Tree(object):  # noqa: B903
+        class Tree:  # noqa: B903
             def __init__(self):
                 self.child = torch.jit.annotate(Optional[Leaf], None)
 
@@ -922,7 +922,7 @@ class TestClassType(JitTestCase):
         """
         with self.assertRaises(RuntimeError):
             @torch.jit.script  # noqa: B903
-            class Tree(object):  # noqa: B903
+            class Tree:  # noqa: B903
                 def __init__(self):
                     self.parent = torch.jit.annotate(Optional[Tree], None)
 
@@ -953,7 +953,7 @@ class TestClassType(JitTestCase):
             self.assertEqual(m.w, m_loaded.w)
 
     def test_py_class_to_ivalue_missing_attribute(self):
-        class Foo(object):
+        class Foo:
             i : int
             f : float
 
@@ -977,7 +977,7 @@ class TestClassType(JitTestCase):
         Test unused methods on scripted classes.
         """
         @torch.jit.script
-        class Unused(object):
+        class Unused:
             def __init__(self):
                 self.count: int = 0
                 self.items: List[int] = []
@@ -1029,7 +1029,7 @@ class TestClassType(JitTestCase):
         in its type annotations.
         """
         @torch.jit.script
-        class Meta(object):
+        class Meta:
             def __init__(self, a: int):
                 self.a = a
 
@@ -1240,7 +1240,7 @@ class TestClassType(JitTestCase):
             return x + 1
 
         @torch.jit.script
-        class Properties(object):
+        class Properties:
             __jit_unused_properties__ = ["unsupported"]
 
             def __init__(self, a: int):
@@ -1268,7 +1268,7 @@ class TestClassType(JitTestCase):
                 self.a = value + 3
 
         @torch.jit.script
-        class NoSetter(object):
+        class NoSetter:
             def __init__(self, a: int):
                 self.a = a
 
@@ -1277,7 +1277,7 @@ class TestClassType(JitTestCase):
                 return free_function(self.a)
 
         @torch.jit.script
-        class MethodThatUsesProperty(object):
+        class MethodThatUsesProperty:
             def __init__(self, a: int):
                 self.a = a
 
@@ -1315,7 +1315,7 @@ class TestClassType(JitTestCase):
         Test that del can be called on an instance of a class that
         overrides __delitem__.
         """
-        class Example(object):
+        class Example:
             def __init__(self):
                 self._data: Dict[str, torch.Tensor] = {"1": torch.tensor(1.0)}
 
@@ -1333,7 +1333,7 @@ class TestClassType(JitTestCase):
         self.checkScript(fn, ())
 
         # Test the case in which the class does not have __delitem__ defined.
-        class NoDelItem(object):
+        class NoDelItem:
             def __init__(self):
                 self._data: Dict[str, torch.Tensor] = {"1": torch.tensor(1.0)}
 
@@ -1359,7 +1359,7 @@ class TestClassType(JitTestCase):
         device_t = torch.device
         device_ty = torch.device
 
-        class A(object):
+        class A:
             def __init__(self):
                 pass
 
@@ -1425,7 +1425,7 @@ class TestClassType(JitTestCase):
         to an IValue that has an attribute of the wrong type.
         """
         @torch.jit.script  # noqa: B903
-        class ValHolder(object):  # noqa: B903
+        class ValHolder:  # noqa: B903
             def __init__(self, val):
                 self.val = val
 
@@ -1450,7 +1450,7 @@ class TestClassType(JitTestCase):
         Test that class types are recursively scripted when an Python instance of one
         is encountered as a module attribute.
         """
-        class Class(object):
+        class Class:
             def __init__(self, a: int):
                 self.a = a
 
@@ -1473,7 +1473,7 @@ class TestClassType(JitTestCase):
         are added as failed attributes and do not cause compilation itself
         to fail unless they are used in scripted code.
         """
-        class UnscriptableClass(object):
+        class UnscriptableClass:
             def __init__(self, a: int):
                 self.a = a
 
@@ -1511,7 +1511,7 @@ class TestClassType(JitTestCase):
 
 
     def test_unresolved_class_attributes(self):
-        class UnresolvedAttrClass(object):
+        class UnresolvedAttrClass:
             def __init__(self):
                 pass
 

--- a/test/jit/test_dce.py
+++ b/test/jit/test_dce.py
@@ -22,7 +22,7 @@ class TestDCE(JitTestCase):
 
     def test_setattr_removed(self):
         @torch.jit.script
-        class Thing1(object):
+        class Thing1:
             def __init__(self):
                 self.x = torch.zeros([2, 2])
 

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1016,7 +1016,7 @@ class TestFreezing(JitTestCase):
 
     def test_freeze_module_inlining(self):
         @torch.jit.script  # noqa: B903
-        class Obj(object):  # noqa: B903
+        class Obj:  # noqa: B903
             def __init__(self, x: int, y: int):
                 self.x = x
                 self.y = y
@@ -1459,7 +1459,7 @@ class TestFreezing(JitTestCase):
 
     def test_module_getattr_indirection(self):
         @torch.jit.script
-        class ValHolder(object):
+        class ValHolder:
             def __init__(self, val: int):
                 self.val: int = val
 
@@ -1914,7 +1914,7 @@ class TestFreezing(JitTestCase):
         self.expectEqual(expected, actual)
 
     def test_freeze_non_module_class_getattr(self):
-        class BoxCoder(object):
+        class BoxCoder:
             def __init__(self, bbox_xform_clip):
                 # type: (float) -> None
                 self.bbox_xform_clip = bbox_xform_clip

--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -2564,7 +2564,7 @@ class TestScriptList(JitTestCase):
         """
         Test extend.
         """
-        class Iterable(object):
+        class Iterable:
             def __init__(self, limit: int):
                 self.limit = limit
                 self.value = 0

--- a/test/jit/test_module_interface.py
+++ b/test/jit/test_module_interface.py
@@ -73,7 +73,7 @@ class TestModuleInterface(JitTestCase):
                 pass
 
         @torch.jit.interface
-        class OneTwoClass(object):
+        class OneTwoClass:
             def one(self, x: Tensor, y: Tensor) -> Tensor:
                 pass
 
@@ -173,7 +173,7 @@ class TestModuleInterface(JitTestCase):
             return x
 
         @torch.jit.script
-        class Foo(object):
+        class Foo:
             def one(self, x: Tensor, y: Tensor) -> Tensor:
                 return x + y
 

--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -200,7 +200,7 @@ class TestRecursiveScript(JitTestCase):
 
     def test_ignore_class(self):
         @torch.jit.ignore
-        class MyScriptClass(object):
+        class MyScriptClass:
             def unscriptable(self):
                 return "a" + 200
 
@@ -290,7 +290,7 @@ class TestRecursiveScript(JitTestCase):
         def other_fn(a: int, b: Tensor) -> Tensor:
             return a * b
 
-        class B(object):
+        class B:
             def __init__(self, x):
                 self.x = 2
 
@@ -384,7 +384,7 @@ class TestRecursiveScript(JitTestCase):
         self.assertEqual(a_script_fn(t, t, t), t + t + t)
 
     def test_error_stack_class(self):
-        class X(object):
+        class X:
             def bad_fn(self):
                 import pdb  # noqa: F401
 
@@ -400,7 +400,7 @@ class TestRecursiveScript(JitTestCase):
             checker.run(str(e))
 
     def test_error_stack_annotation(self):
-        class X(object):
+        class X:
             def bad_fn(self):
                 import pdb  # noqa: F401
 
@@ -549,18 +549,18 @@ class TestRecursiveScript(JitTestCase):
 
     def test_attributes(self):
         @torch.jit.script
-        class Inner2(object):
+        class Inner2:
             def __init__(self):
                 self.b = "a string"
 
         @torch.jit.script
-        class Foo(object):
+        class Foo:
             def __init__(self):
                 self.a = 4
                 self.inner = Inner2()
 
         @torch.jit.script
-        class SFoo(object):
+        class SFoo:
             def __init__(self):
                 self.a = 4
                 self.inner = Inner2()

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -152,12 +152,12 @@ class TestSaveLoad(JitTestCase):
         """
 
         @torch.jit.interface
-        class MyInterface(object):
+        class MyInterface:
             def bar(self, x: Tensor) -> Tensor:
                 pass
 
         @torch.jit.script
-        class ImplementInterface(object):
+        class ImplementInterface:
             def __init__(self):
                 pass
 
@@ -182,12 +182,12 @@ class TestSaveLoad(JitTestCase):
         clear_class_registry()
 
         @torch.jit.interface
-        class MyInterface(object):
+        class MyInterface:
             def not_bar(self, x: Tensor) -> Tensor:
                 pass
 
         @torch.jit.script  # noqa: F811
-        class ImplementInterface(object):  # noqa: F811
+        class ImplementInterface:  # noqa: F811
             def __init__(self):
                 pass
 
@@ -238,12 +238,12 @@ class TestSaveLoad(JitTestCase):
             a: int
 
         @torch.jit.interface
-        class MyInterface(object):
+        class MyInterface:
             def bar(self, x: Tensor) -> Tensor:
                 pass
 
         @torch.jit.script
-        class ImplementInterface(object):
+        class ImplementInterface:
             def __init__(self):
                 pass
 
@@ -278,12 +278,12 @@ class TestSaveLoad(JitTestCase):
         clear_class_registry()
 
         @torch.jit.interface
-        class MyInterface(object):
+        class MyInterface:
             def not_bar(self, x: Tensor) -> Tensor:
                 pass
 
         @torch.jit.script  # noqa: F811
-        class ImplementInterface(object):  # noqa: F811
+        class ImplementInterface:  # noqa: F811
             def __init__(self):
                 pass
 
@@ -683,12 +683,12 @@ class TestSaveLoadFlatbuffer(JitTestCase):
         """
 
         @torch.jit.interface
-        class MyInterface(object):
+        class MyInterface:
             def bar(self, x: Tensor) -> Tensor:
                 pass
 
         @torch.jit.script
-        class ImplementInterface(object):
+        class ImplementInterface:
             def __init__(self):
                 pass
 
@@ -710,12 +710,12 @@ class TestSaveLoadFlatbuffer(JitTestCase):
         clear_class_registry()
 
         @torch.jit.interface
-        class MyInterface(object):
+        class MyInterface:
             def not_bar(self, x: Tensor) -> Tensor:
                 pass
 
         @torch.jit.script  # noqa: F811
-        class ImplementInterface(object):  # noqa: F811
+        class ImplementInterface:  # noqa: F811
             def __init__(self):
                 pass
 
@@ -766,12 +766,12 @@ class TestSaveLoadFlatbuffer(JitTestCase):
             a: int
 
         @torch.jit.interface
-        class MyInterface(object):
+        class MyInterface:
             def bar(self, x: Tensor) -> Tensor:
                 pass
 
         @torch.jit.script
-        class ImplementInterface(object):
+        class ImplementInterface:
             def __init__(self):
                 pass
 
@@ -804,12 +804,12 @@ class TestSaveLoadFlatbuffer(JitTestCase):
         clear_class_registry()
 
         @torch.jit.interface
-        class MyInterface(object):
+        class MyInterface:
             def not_bar(self, x: Tensor) -> Tensor:
                 pass
 
         @torch.jit.script  # noqa: F811
-        class ImplementInterface(object):  # noqa: F811
+        class ImplementInterface:  # noqa: F811
             def __init__(self):
                 pass
 

--- a/test/jit/test_torchbind.py
+++ b/test/jit/test_torchbind.py
@@ -65,7 +65,7 @@ class TestTorchbind(JitTestCase):
         test_equality(f, lambda x: x)
 
         # test nn module with prepare_scriptable function
-        class NonJitableClass(object):
+        class NonJitableClass:
             def __init__(self, int1, int2):
                 self.int1 = int1
                 self.int2 = int2

--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -99,7 +99,7 @@ class TestTypesAndAnnotation(JitTestCase):
         FileCheck().check("dropout_modality").check("in_batch").run(str(sm.graph))
 
     def test_python_callable(self):
-        class MyPythonClass(object):
+        class MyPythonClass:
             @torch.jit.ignore
             def __call__(self, *args) -> str:
                 return str(type(args[0]))
@@ -246,7 +246,7 @@ class TestTypesAndAnnotation(JitTestCase):
 
 
     def test_ignoring_fn_with_nonscriptable_types(self):
-        class CFX(object):
+        class CFX:
             def __init__(self, a: List[torch.Tensor]) -> None:
                 self.a = a
 
@@ -306,7 +306,7 @@ class TestTypesAndAnnotation(JitTestCase):
         # Simple case
         with self.assertRaisesRegexWithHighlight(ValueError, msg, highlight):
             @torch.jit.script
-            class BadModule(object):
+            class BadModule:
                 def __init__(self, x: int):
                     self.x = x
 
@@ -316,7 +316,7 @@ class TestTypesAndAnnotation(JitTestCase):
         # Type annotation in a loop
         with self.assertRaisesRegexWithHighlight(ValueError, msg, highlight):
             @torch.jit.script
-            class BadModuleLoop(object):
+            class BadModuleLoop:
                 def __init__(self, x: int):
                     self.x = x
 
@@ -326,7 +326,7 @@ class TestTypesAndAnnotation(JitTestCase):
 
         # Type annotation in __init__, should not fail
         @torch.jit.script
-        class GoodModule(object):
+        class GoodModule:
             def __init__(self, x: int):
                 self.x: int = x
 

--- a/test/jit/test_union.py
+++ b/test/jit/test_union.py
@@ -113,7 +113,7 @@ class TestUnion(JitTestCase):
     def test_union_in_class_constructor(self):
 
         @torch.jit.script  # noqa: B903
-        class A(object):    # noqa: B903
+        class A:    # noqa: B903
             def __init__(self, x: Union[int, str]) -> None:
                 self.x = x
 

--- a/test/jit/test_with.py
+++ b/test/jit/test_with.py
@@ -33,7 +33,7 @@ class TestWith(JitTestCase):
         to targets work as expected.
         """
         @torch.jit.script
-        class Context(object):
+        class Context:
             """
             This class implements a basic context manager interface for use in
             the unit tests. Unlike Context, the stateful part of this class
@@ -190,7 +190,7 @@ class TestWith(JitTestCase):
         to targets work as expected.
         """
         @torch.jit.script
-        class Context(object):
+        class Context:
             """
             This class implements a basic context manager interface for use in
             the unit tests. Unlike Context, the stateful part of this class
@@ -346,7 +346,7 @@ class TestWith(JitTestCase):
         handled correctly.
         """
         @torch.jit.script
-        class Context(object):
+        class Context:
             """
             This class implements a basic context manager interface for use in
             the unit tests. Unlike Context, the stateful part of this class
@@ -434,7 +434,7 @@ class TestWith(JitTestCase):
         """
 
         @torch.jit.script
-        class NoEnterNoExit(object):
+        class NoEnterNoExit:
             """
             This class is missing __enter__ and __exit__ methods.
             """
@@ -443,7 +443,7 @@ class TestWith(JitTestCase):
                 self.count = 1
 
         @torch.jit.script
-        class BadEnter(object):
+        class BadEnter:
             """
             This class has an __enter__ method with an incorrect signature.
             """
@@ -458,7 +458,7 @@ class TestWith(JitTestCase):
                 pass
 
         @torch.jit.script
-        class BadExit(object):
+        class BadExit:
             """
             This class has an __exit__ method with an incorrect signature.
             """
@@ -473,7 +473,7 @@ class TestWith(JitTestCase):
                 pass
 
         @torch.jit.script
-        class ExitIncorrectTypes(object):
+        class ExitIncorrectTypes:
             """
             This class has an __exit__ method with unsupported argument types.
             """

--- a/test/quantization/core/experimental/quantization_util.py
+++ b/test/quantization/core/experimental/quantization_util.py
@@ -28,7 +28,7 @@ _ = torch.manual_seed(191009)
 train_batch_size = 30
 eval_batch_size = 50
 
-class AverageMeter(object):
+class AverageMeter:
     """Computes and stores the average and current value"""
     def __init__(self, name, fmt=':f'):
         self.name = name

--- a/test/quantization/jit/test_ondevice_quantization.py
+++ b/test/quantization/jit/test_ondevice_quantization.py
@@ -60,7 +60,7 @@ class MyConvLinearModule(torch.nn.Module):
         return (torch.rand(1, 3, 12, 7),)
 
 
-class OnDevicePTQUtils(object):
+class OnDevicePTQUtils:
     observer_module_name = ['MinMaxObserver', 'PerChannelMinMaxObserver']
 
     @staticmethod

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4096,7 +4096,7 @@ Done""")
         # its output. Previously, this created a reference cycle.
         dealloc = [0]
 
-        class IncrementOnDelete(object):
+        class IncrementOnDelete:
             def __del__(self):
                 dealloc[0] += 1
 
@@ -4386,7 +4386,7 @@ Done""")
             #
             # We want to test that when grad goes out of scope at the end of this function that PyObject is destroyed
             # We can test this by seeing whether Foo is not kept alive once t is destroyed
-            class Foo(object):
+            class Foo:
                 pass
             my_obj = Foo()
             meta_dict = t.grad_fn.metadata
@@ -4443,7 +4443,7 @@ Done""")
                     with detect_anomaly():
                         ginp.backward()
 
-            class Foo(object):
+            class Foo:
                 pass
             my_obj = Foo()
             meta_dict = out.grad_fn.metadata

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -2533,7 +2533,7 @@ class TestNamedTupleDataLoader(TestCase):
             self.assertIsInstance(batch.data, NamedTupleDataset.Data)
             self.assertNotIsInstance(batch.data.positive, torch.Tensor)
 
-class SimpleCustomBatch(object):
+class SimpleCustomBatch:
     def __init__(self, data):
         transposed_data = list(zip(*data))
         self.inp = torch.stack(transposed_data[0], 0)

--- a/test/test_determination.py
+++ b/test/test_determination.py
@@ -6,7 +6,7 @@ import run_test
 from torch.testing._internal.common_utils import TestCase, run_tests
 
 
-class DummyOptions(object):
+class DummyOptions:
     verbose = False
 
 

--- a/test/test_functional_optim.py
+++ b/test/test_functional_optim.py
@@ -22,7 +22,7 @@ class MyModule(torch.nn.Module):
         return self.lin2(F.relu(self.lin1(t1)))
 
 # dummy class to showcase custom optimizer registration with functional wrapper
-class MyDummyFnOptimizer(object):
+class MyDummyFnOptimizer:
     def __init__(
         self,
         params: List[Tensor],

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -149,7 +149,7 @@ class Pair(NamedTuple):
         return f"Pair(x={_format_arg(self.x)}, y={_format_arg(self.y)})"
 
 # for testing pytrees
-class Foo(object):  # noqa: B209
+class Foo:  # noqa: B209
     def __init__(self, a, b):
         self.a = a
         self.b = b

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3007,7 +3007,7 @@ class TestFrontend(JitTestCase):
 
     def test_instancing_error(self):
         @torch.jit.ignore
-        class MyScriptClass(object):
+        class MyScriptClass:
             def unscriptable(self):
                 return "a" + 200
 
@@ -3837,7 +3837,7 @@ def foo(x):
     @_tmp_donotuse_dont_inline_everything
     def test_first_class_calls(self):
         @torch.jit.script
-        class Foo(object):
+        class Foo:
             def __init__(self, x):
                 self.bar = x
 
@@ -4157,7 +4157,7 @@ def foo(x):
 
     def test_class_as_attribute(self):
         @torch.jit.script
-        class Foo321(object):
+        class Foo321:
             def __init__(self):
                 self.x = 3
 
@@ -4279,7 +4279,7 @@ def foo(x):
 
     def test_nested_aug_assign(self):
         @torch.jit.script
-        class SomeClass(object):
+        class SomeClass:
             def __init__(self):
                 self.num = 99
 
@@ -4293,7 +4293,7 @@ def foo(x):
                 return self.num == other.num
 
         @torch.jit.script
-        class SomeOutOfPlaceClass(object):
+        class SomeOutOfPlaceClass:
             def __init__(self):
                 self.num = 99
 
@@ -4338,7 +4338,7 @@ def foo(x):
         self.assertEqual(a.child.list, sa.child.list)
 
         @torch.jit.script
-        class SomeNonAddableClass(object):
+        class SomeNonAddableClass:
             def __init__(self):
                 self.num = 99
 
@@ -4361,7 +4361,7 @@ def foo(x):
 
     def test_var_aug_assign(self):
         @torch.jit.script
-        class SomeNonAddableClass(object):
+        class SomeNonAddableClass:
             def __init__(self):
                 self.num = 99
 
@@ -4377,7 +4377,7 @@ def foo(x):
                 return a
 
         @torch.jit.script
-        class SomeClass(object):
+        class SomeClass:
             def __init__(self):
                 self.num = 99
 
@@ -4391,7 +4391,7 @@ def foo(x):
                 return self.num == other.num
 
         @torch.jit.script
-        class SomeOutOfPlaceClass(object):
+        class SomeOutOfPlaceClass:
             def __init__(self):
                 self.num = 99
 
@@ -4440,7 +4440,7 @@ def foo(x):
             scripted = torch.jit.script(foobar)
 
     def test_file_line_error_class_defn(self):
-        class FooBar(object):
+        class FooBar:
             def baz(self, xyz):
                 return torch.blargh(xyz)
 
@@ -6958,12 +6958,12 @@ a")
             return foo(c, b)
 
         @torch.jit.script
-        class Bar(object):
+        class Bar:
             def one(self, x, y):
                 return bar(x, y)
 
         @torch.jit.interface
-        class IFace(object):
+        class IFace:
             def one(self, x, y):
                 # type: (Tensor, Tensor) -> Tensor
                 pass
@@ -13499,7 +13499,7 @@ dedent """
                 return id(2) == id(None)
 
         @torch.jit.script
-        class FooTest(object):
+        class FooTest:
             def __init__(self, x):
                 self.foo = x
 
@@ -15565,7 +15565,7 @@ dedent """
         def foo():
             print('foo')
 
-        class Redirect(object):
+        class Redirect:
             def __init__(self):
                 self.s = ''
 
@@ -15703,7 +15703,7 @@ dedent """
         self.checkModule(HasAttrMod(), ())
 
         @torch.jit.script
-        class FooTest(object):
+        class FooTest:
             def __init__(self):
                 self.x = 1
 

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -184,7 +184,7 @@ def fs_sharing():
         mp.set_sharing_strategy(prev_strategy)
 
 
-class leak_checker(object):
+class leak_checker:
 
     def __init__(self, test_case):
         self.checked_pids = [os.getpid()]

--- a/test/test_multiprocessing_spawn.py
+++ b/test/test_multiprocessing_spawn.py
@@ -87,7 +87,7 @@ def _test_nested(i, pids_queue, nested_child_sleep, start_method):
     # Kill self. This should take down the child processes as well.
     os.kill(os.getpid(), signal.SIGTERM)
 
-class _TestMultiProcessing(object):
+class _TestMultiProcessing:
     start_method = None
 
     def test_success(self):

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -84,7 +84,7 @@ def implements_diagonal(torch_function):
         return func
     return decorator
 
-class DiagonalTensor(object):
+class DiagonalTensor:
     """A class with __torch_function__ and a specific diagonal representation
 
     This class has limited utility and is mostly useful for verifying that the
@@ -358,7 +358,7 @@ def generate_tensor_like_torch_implementations():
 
 generate_tensor_like_torch_implementations()
 
-class TensorLike(object):
+class TensorLike:
     """A class that overrides the full torch API
 
     This class is used to explicitly test that the full torch.tensor API

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -45,7 +45,7 @@ with warnings.catch_warnings(record=True) as warns:
                 break
 
 
-class FilelikeMock(object):
+class FilelikeMock:
     def __init__(self, data, has_fileno=True, has_readinto=False):
         if has_readinto:
             self.readinto = self.readinto_opt
@@ -78,7 +78,7 @@ class FilelikeMock(object):
         return name in self.calls
 
 
-class SerializationMixin(object):
+class SerializationMixin:
     def _test_serialization_data(self):
         a = [torch.randn(5, 5).float() for i in range(2)]
         b = [a[i % 2] for i in range(4)]  # 0-3
@@ -312,7 +312,7 @@ class SerializationMixin(object):
         x[1][1] = 1
         x = x.to_sparse()
 
-        class TensorSerializationSpoofer(object):
+        class TensorSerializationSpoofer:
             def __init__(self, tensor):
                 self.tensor = tensor
 
@@ -344,7 +344,7 @@ class SerializationMixin(object):
         x[1][1] = 1
         x = conversion(x)
 
-        class TensorSerializationSpoofer(object):
+        class TensorSerializationSpoofer:
             def __init__(self, tensor):
                 self.tensor = tensor
 
@@ -418,7 +418,7 @@ class SerializationMixin(object):
         self.assertEqual(c[1], c[3], atol=0, rtol=0)
 
         # test some old tensor serialization mechanism
-        class OldTensorBase(object):
+        class OldTensorBase:
             def __init__(self, new_tensor):
                 self.new_tensor = new_tensor
 
@@ -735,7 +735,7 @@ class SerializationMixin(object):
             with self.assertRaisesRegex(RuntimeError, error_msg):
                 torch.save([a.storage(), s_bytes], f)
 
-class serialization_method(object):
+class serialization_method:
     def __init__(self, use_zip):
         self.use_zip = use_zip
         self.torch_save = torch.save

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1155,7 +1155,7 @@ class TestTensorCreation(TestCase):
     # TODO: update to work on CUDA, too?
     @onlyCPU
     def test_tensor_from_sequence(self, device):
-        class MockSequence(object):
+        class MockSequence:
             def __init__(self, lst):
                 self.lst = lst
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -779,7 +779,7 @@ class TestStandaloneCPPJIT(TestCase):
             shutil.rmtree(build_dir)
 
 
-class DummyXPUModule(object):
+class DummyXPUModule:
     @staticmethod
     def is_available():
         return True

--- a/test/test_weak.py
+++ b/test/test_weak.py
@@ -512,7 +512,7 @@ class WeakKeyDictionaryTestCase(TestCase):
 
         d = self._empty_mapping()
 
-        class badseq(object):
+        class badseq:
             def __iter__(self):
                 return self
 

--- a/tools/gen_vulkan_spv.py
+++ b/tools/gen_vulkan_spv.py
@@ -61,7 +61,7 @@ class UniqueKeyLoader(Loader):
         return mapping
 
 
-class VulkanShaderGenerator(object):
+class VulkanShaderGenerator:
     standard_header = """
 #version 450 core
 #define PRECISION $precision

--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -43,7 +43,7 @@ if "CFLAGS" in os.environ and "CXXFLAGS" not in os.environ:
     os.environ["CXXFLAGS"] = os.environ["CFLAGS"]
 
 
-class BuildType(object):
+class BuildType:
     """Checks build type. The build type will be given in :attr:`cmake_build_type_env`. If :attr:`cmake_build_type_env`
     is ``None``, then the build type will be inferred from ``CMakeCache.txt``. If ``CMakeCache.txt`` does not exist,
     os.environ['CMAKE_BUILD_TYPE'] will be used.

--- a/tools/shared/cwrap_common.py
+++ b/tools/shared/cwrap_common.py
@@ -149,7 +149,7 @@ def sort_by_number_of_args(declaration: Declaration, reverse: bool = True) -> No
     declaration["options"].sort(key=num_args, reverse=reverse)
 
 
-class Function(object):
+class Function:
     def __init__(self, name: str) -> None:
         self.name = name
         self.arguments: List["Argument"] = []
@@ -162,7 +162,7 @@ class Function(object):
         return self.name + "(" + ", ".join(a.__repr__() for a in self.arguments) + ")"
 
 
-class Argument(object):
+class Argument:
     def __init__(self, _type: str, name: str, is_optional: bool):
         self.type = _type
         self.name = name

--- a/tools/test/test_selective_build.py
+++ b/tools/test/test_selective_build.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 import unittest
 

--- a/tools/test/test_selective_build.py
+++ b/tools/test/test_selective_build.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 from torchgen.selective_build.operator import *

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -31,7 +31,7 @@ class GraphOutputEntry:
         self.variable = self.variable.add_options(other)
 
 
-class PyCodegen(object):
+class PyCodegen:
     """
     Helper class uses for constructing Python bytecode
     """

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -232,7 +232,7 @@ tensortype_to_dtype = {
 }
 
 
-class DuplicateWarningChecker(object):
+class DuplicateWarningChecker:
     def __init__(self, maxsize=4096):
         self.maxsize = maxsize
         self.reset()

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -29,7 +29,7 @@ class HasPostInit(type):
         return obj
 
 
-class VariableTracker(object, metaclass=HasPostInit):
+class VariableTracker(metaclass=HasPostInit):
     """
     Base class for tracked locals and stack values
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -17,7 +17,7 @@ AOT_PARTITIONER_DEBUG = config.debug_partitioner
 
 
 
-class InvalidNodeBase(object):
+class InvalidNodeBase:
     def __repr__(self):
         return "Invalid Node"
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -196,7 +196,7 @@ def is_gcc():
     return re.search(r"(gcc|g\+\+)", cpp_compiler())
 
 
-class VecISA(object):
+class VecISA:
     _bit_width: int
     _macro: str
     _arch_flags: str

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -261,7 +261,7 @@ def is_cpu(x):
 
 
 @dataclasses.dataclass
-class IRNode(object):
+class IRNode:
     _current_origins: ClassVar[Set[Any]] = set()
 
     @staticmethod

--- a/torch/_inductor/mkldnn.py
+++ b/torch/_inductor/mkldnn.py
@@ -21,7 +21,7 @@ from . import config
 from .fx_utils import matches_module_function_pattern
 
 
-class UnaryAttr(object):
+class UnaryAttr:
     def __init__(self, op_name: str, scalars_attr=None, algorithm_attr=None):
         self.op_name = op_name
         self.scalars_attr = scalars_attr if scalars_attr else []

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass(frozen=True)
-class ValueRanges(object):
+class ValueRanges:
     lower: Union[sympy.Expr, sympy.Number, int, float, bool]
     upper: Union[sympy.Expr, sympy.Number, int, float, bool]
 
@@ -82,7 +82,7 @@ class ValueRanges(object):
         return ValueRanges(min(products), max(products))
 
 
-class ValueRangeAnalysis(object):
+class ValueRangeAnalysis:
     def __init__(self):
         self.name = "ValueRangeAnalysis"
         boolean_operators = (
@@ -329,7 +329,7 @@ def range_expressable_in_32_bits(range):
     )
 
 
-class OptimizeIndexing(object):
+class OptimizeIndexing:
     """
     Performs Value Range Analysis on LoopBody's fx graph to reduce precision of
     intermediaries from int64 to int32. This is an important optimization for indexing

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -37,7 +37,7 @@ class PositiveGuard:
     expr: Expr
 
 
-class SizeVarAllocator(object):
+class SizeVarAllocator:
     def __init__(self, shape_env=None):
         super().__init__()
         if shape_env is None:

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -183,7 +183,7 @@ def createResolutionCallbackFromFrame(frames_up: int = 0):
     f_locals = frame.f_locals
     f_globals = frame.f_globals
 
-    class env(object):
+    class env:
         def __getattr__(self, key):
             if key in f_locals:
                 return f_locals[key]
@@ -260,7 +260,7 @@ def createResolutionCallbackFromClosure(fn):
     """
     closure = get_closure(fn)
 
-    class closure_lookup(object):
+    class closure_lookup:
         # This is a class since `closure` is a dict and it's easier in
         # `env_helper` if everything just works with `getattr` calls
         def __getattr__(self, key):
@@ -513,7 +513,7 @@ def boolean_dispatch(
     return fn
 
 
-class FunctionModifiers(object):
+class FunctionModifiers:
     """
     Used to denote the behavior of a function in TorchScript. See export() and
     ignore() for details.
@@ -1089,7 +1089,7 @@ def is_final(ann) -> bool:
 
 
 # allows BroadcastingList instance to be subscriptable
-class BroadcastingListCls(object):
+class BroadcastingListCls:
     def __getitem__(self, types):
         return
 

--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -692,7 +692,7 @@ def _lobpcg(
     return worker.E[:k], worker.X[:, :k]
 
 
-class LOBPCG(object):
+class LOBPCG:
     """Worker class of LOBPCG methods."""
 
     def __init__(

--- a/torch/_prims_common/wrappers.py
+++ b/torch/_prims_common/wrappers.py
@@ -75,7 +75,7 @@ def _annotation_has_type(*, typ, annotation):
     return typ is annotation
 
 
-class elementwise_type_promotion_wrapper(object):
+class elementwise_type_promotion_wrapper:
     """
     Adds elementwise type promotion to a Python reference implementation.
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -142,7 +142,7 @@ def tree_flatten_only(ty: Type[T], pytree: PyTree):
 # multiple tensors into fake tensors which share the same view/storage
 # structure. Like `MetaConverter`, it uses `WeakIdRef` to
 # hold a weak reference for all memoized tensors.
-class FakeTensorConverter(object):
+class FakeTensorConverter:
     @property
     def tensor_memo(self):
         return self.meta_converter.tensor_memo

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -6,7 +6,7 @@ import torch
 from torch._six import inf
 
 
-class __PrinterOptions(object):
+class __PrinterOptions:
     precision: int = 4
     threshold: float = 1000
     edgeitems: int = 3
@@ -96,7 +96,7 @@ def tensor_totype(t):
     return t.to(dtype=dtype)
 
 
-class _Formatter(object):
+class _Formatter:
     def __init__(self, tensor):
         self.floating_dtype = tensor.dtype.is_floating_point
         self.int_mode = True

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -607,7 +607,7 @@ class KeyErrorMessage(str):
         return self
 
 
-class ExceptionWrapper(object):
+class ExceptionWrapper:
     r"""Wraps an exception plus traceback to communicate across threads"""
 
     def __init__(self, exc_info=None, where="in background"):

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -15,7 +15,7 @@ def autocast_decorator(autocast_instance, func):
     decorate_autocast.__script_unsupported = '@autocast() decorator is not supported in script mode'  # type: ignore[attr-defined]
     return decorate_autocast
 
-class autocast(object):
+class autocast:
     r"""
     Instances of :class:`autocast` serve as context managers or decorators that
     allow regions of your script to run in mixed precision.

--- a/torch/ao/pruning/_experimental/data_scheduler/base_data_scheduler.py
+++ b/torch/ao/pruning/_experimental/data_scheduler/base_data_scheduler.py
@@ -8,7 +8,7 @@ from ..data_sparsifier import BaseDataSparsifier
 __all__ = ['BaseDataScheduler']
 
 
-class BaseDataScheduler(object):
+class BaseDataScheduler:
     r"""
     The BaseDataScheduler is the abstract scheduler class specifically for the
     BaseDataSparsifier class. This class controls a specific hyperparameter of

--- a/torch/ao/pruning/scheduler/base_scheduler.py
+++ b/torch/ao/pruning/scheduler/base_scheduler.py
@@ -7,7 +7,7 @@ import weakref
 
 __all__ = ["BaseScheduler"]
 
-class BaseScheduler(object):
+class BaseScheduler:
 
     def __init__(self, sparsifier, last_epoch=-1, verbose=False):
 

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -49,7 +49,7 @@ __all__ = [
 ]
 
 
-class _PartialWrapper(object):
+class _PartialWrapper:
     def __init__(self, p):
         self.p = p
         self.callable_args = {}

--- a/torch/autograd/anomaly_mode.py
+++ b/torch/autograd/anomaly_mode.py
@@ -6,7 +6,7 @@ from typing import Any
 __all__ = ["detect_anomaly", "set_detect_anomaly"]
 
 
-class detect_anomaly(object):
+class detect_anomaly:
     r"""Context-manager that enable anomaly detection for the autograd engine.
 
     This does two things:
@@ -88,7 +88,7 @@ class detect_anomaly(object):
         torch.set_anomaly_enabled(self.prev, self.prev_check_nan)
 
 
-class set_detect_anomaly(object):
+class set_detect_anomaly:
     r"""Context-manager that sets the anomaly detection for the autograd engine on or off.
 
     ``set_detect_anomaly`` will enable or disable the autograd anomaly detection

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -14,7 +14,7 @@ __all__ = ["FunctionCtx", "BackwardCFunction", "FunctionMeta", "Function", "once
            "InplaceFunction", "NestedIOFunction"]
 
 # Formerly known as: _ContextMethodMixin
-class FunctionCtx(object):
+class FunctionCtx:
 
     def save_for_backward(self, *tensors: torch.Tensor):
         r"""Saves given tensors for a future call to :func:`~Function.backward`.
@@ -250,7 +250,7 @@ class FunctionCtx(object):
 # DO NOT USE: This is only defined to be able to load old serialized models
 _ContextMethodMixin = FunctionCtx
 
-class _HookMixin(object):
+class _HookMixin:
 
     @staticmethod
     def _register_hook(backward_hooks, hook):

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -40,7 +40,7 @@ try:
 except ImportError:
     import functools
 
-    class _ContextDecorator(object):  # type: ignore[no-redef]
+    class _ContextDecorator:  # type: ignore[no-redef]
 
         def __enter__(self):
             raise NotImplementedError
@@ -56,7 +56,7 @@ except ImportError:
 
             return wrapped
 
-class profile(object):
+class profile:
     """Context manager that manages autograd profiler state and holds a summary of results.
     Under the hood it just records events of functions being executed in C++ and
     exposes those events to Python. You can wrap any code into it and it will
@@ -549,7 +549,7 @@ class record_function(_ContextDecorator):
         return profiled_future
 
 
-class emit_itt(object):
+class emit_itt:
     """Context manager that makes every autograd operation emit an ITT range.
 
     It is useful when running the program under Intel(R) VTune Profiler::
@@ -616,7 +616,7 @@ class emit_itt(object):
         return False
 
 
-class emit_nvtx(object):
+class emit_nvtx:
     """Context manager that makes every autograd operation emit an NVTX range.
 
     It is useful when running the program under nvprof::
@@ -742,7 +742,7 @@ def load_nvprof(path):
     return EventList(parse_nvprof_trace(path))
 
 
-class EnforceUnique(object):
+class EnforceUnique:
     """Raises an error if a key is seen more than once."""
     def __init__(self):
         self.seen = set()

--- a/torch/autograd/profiler_legacy.py
+++ b/torch/autograd/profiler_legacy.py
@@ -15,7 +15,7 @@ from warnings import warn
 
 __all__ = ["profile"]
 
-class profile(object):
+class profile:
     """DEPRECATED: use torch.profiler instead"""
     def __init__(
             self,

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -349,7 +349,7 @@ def _attr_formatter(name):
     return property(lambda self: _format_time(getattr(self, name)))
 
 
-class FormattedTimesMixin(object):
+class FormattedTimesMixin:
     """Helpers for FunctionEvent and FunctionEventAvg.
 
     The subclass should define `*_time_total` and `count` attributes.
@@ -370,7 +370,7 @@ class FormattedTimesMixin(object):
         return 0.0 if self.count == 0 else 1.0 * self.cuda_time_total / self.count  # type: ignore[attr-defined]
 
 
-class Interval(object):
+class Interval:
     def __init__(self, start, end):
         self.start = start
         self.end = end

--- a/torch/backends/__init__.py
+++ b/torch/backends/__init__.py
@@ -23,7 +23,7 @@ def __allow_nonbracketed_mutation():
     finally:
         __allow_nonbracketed_mutation_flag = old
 
-class ContextProp(object):
+class ContextProp:
     def __init__(self, getter, setter):
         self.getter = getter
         self.setter = setter

--- a/torch/backends/_nnapi/serializer.py
+++ b/torch/backends/_nnapi/serializer.py
@@ -21,7 +21,7 @@ import torch
 LOG = logging.getLogger("nnapi_serialize")
 
 
-class NNAPI_OperandCode(object):
+class NNAPI_OperandCode:
     FLOAT32 = 0
     INT32 = 1
     UINT32 = 2
@@ -37,7 +37,7 @@ class NNAPI_OperandCode(object):
     TENSOR_QUANT16_ASYMM = 12
 
 
-class NNAPI_OperationCode(object):
+class NNAPI_OperationCode:
     ADD = 0
     AVERAGE_POOL_2D = 1
     CONCATENATION = 2
@@ -135,14 +135,14 @@ class NNAPI_OperationCode(object):
     RESIZE_NEAREST_NEIGHBOR = 94
 
 
-class NNAPI_FuseCode(object):
+class NNAPI_FuseCode:
     FUSED_NONE = 0
     FUSED_RELU = 1
     FUSED_RELU1 = 2
     FUSED_RELU6 = 3
 
 
-class OperandValueSourceType(object):
+class OperandValueSourceType:
     IMMEDIATE = 0
     NUMBERED_BUFFER = 2
     NUMBERED_MEMORY = 3
@@ -319,7 +319,7 @@ def flex_name(op_id, dim):
     return f"s_{op_id}_{dim}"
 
 
-class _NnapiSerializer(object):
+class _NnapiSerializer:
     def __init__(self, config, use_int16_for_qint16=False):
         self.operands = []
         self.values = []

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -18,7 +18,7 @@ def is_built():
     return torch._C.has_cuda
 
 
-class cuFFTPlanCacheAttrContextProp(object):
+class cuFFTPlanCacheAttrContextProp:
     # Like regular ContextProp, but uses the `.device_index` attribute from the
     # calling object as the first argument to the getter and setter.
     def __init__(self, getter, setter):
@@ -34,7 +34,7 @@ class cuFFTPlanCacheAttrContextProp(object):
         self.setter(obj.device_index, val)
 
 
-class cuFFTPlanCache(object):
+class cuFFTPlanCache:
     r"""
     Represents a specific plan cache for a specific `device_index`. The
     attributes `size` and `max_size`, and method `clear`, can fetch and/ or
@@ -55,7 +55,7 @@ class cuFFTPlanCache(object):
         return torch._cufft_clear_plan_cache(self.device_index)
 
 
-class cuFFTPlanCacheManager(object):
+class cuFFTPlanCacheManager:
     r"""
     Represents all cuFFT plan caches. When indexed with a device object/index,
     this object returns the `cuFFTPlanCache` corresponding to that device.

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -24,7 +24,7 @@ def get_cudnn_mode(mode):
 # NB: We don't actually need this class anymore (in fact, we could serialize the
 # dropout state for even better reproducibility), but it is kept for backwards
 # compatibility for old models.
-class Unserializable(object):
+class Unserializable:
 
     def __init__(self, inner):
         self.inner = inner

--- a/torch/backends/mkl/__init__.py
+++ b/torch/backends/mkl/__init__.py
@@ -6,7 +6,7 @@ def is_available():
 
 VERBOSE_OFF = 0
 VERBOSE_ON = 1
-class verbose(object):
+class verbose:
     """
     On-demand oneMKL verbosing functionality
     To make it easier to debug performance issues, oneMKL can dump verbose

--- a/torch/backends/mkldnn/__init__.py
+++ b/torch/backends/mkldnn/__init__.py
@@ -10,7 +10,7 @@ def is_available():
 VERBOSE_OFF = 0
 VERBOSE_ON = 1
 VERBOSE_ON_CREATION = 2
-class verbose(object):
+class verbose:
     """
     On-demand oneDNN (former MKL-DNN) verbosing functionality
     To make it easier to debug performance issues, oneDNN can dump verbose

--- a/torch/backends/quantized/__init__.py
+++ b/torch/backends/quantized/__init__.py
@@ -25,14 +25,14 @@ def _get_qengine_str(qengine: int) -> str:
     all_engines = {0 : 'none', 1 : 'fbgemm', 2 : 'qnnpack', 3 : 'onednn', 4 : 'x86'}
     return all_engines.get(qengine, '*undefined')
 
-class _QEngineProp(object):
+class _QEngineProp:
     def __get__(self, obj, objtype) -> str:
         return _get_qengine_str(torch._C._get_qengine())
 
     def __set__(self, obj, val: str) -> None:
         torch._C._set_qengine(_get_qengine_id(val))
 
-class _SupportedQEnginesProp(object):
+class _SupportedQEnginesProp:
     def __get__(self, obj, objtype) -> List[str]:
         qengines = torch._C._supported_qengines()
         return [_get_qengine_str(qe) for qe in qengines]

--- a/torch/backends/xnnpack/__init__.py
+++ b/torch/backends/xnnpack/__init__.py
@@ -2,7 +2,7 @@ import sys
 import torch
 import types
 
-class _XNNPACKEnabled(object):
+class _XNNPACKEnabled:
     def __get__(self, obj, objtype):
         return torch._C._is_xnnpack_enabled()
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -272,7 +272,7 @@ def cudart():
     return _cudart
 
 
-class cudaStatus(object):
+class cudaStatus:
     SUCCESS: int = 0
     ERROR_NOT_READY: int = 34
 
@@ -411,7 +411,7 @@ def can_device_access_peer(device: _device_t, peer_device: _device_t) -> bool:
     return torch._C._cuda_canDeviceAccessPeer(device, peer_device)
 
 
-class StreamContext(object):
+class StreamContext:
     r"""Context-manager that selects a given stream.
 
     All CUDA kernels queued within its context will be enqueued on a selected
@@ -739,7 +739,7 @@ def _lazy_new(cls, *args, **kwargs):
     return super(_CudaBase, cls).__new__(cls, *args, **kwargs)
 
 
-class _CudaBase(object):
+class _CudaBase:
     is_cuda = True
     is_sparse = False
 

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -10,7 +10,7 @@ from .common import amp_definitely_not_available
 
 __all__ = ["OptState", "GradScaler"]
 
-class _MultiDeviceReplicator(object):
+class _MultiDeviceReplicator:
     """
     Lazily serves copies of a tensor to requested devices.  Copies are cached per-device.
     """
@@ -42,7 +42,7 @@ def _refresh_per_optimizer_state():
     return {"stage": OptState.READY, "found_inf_per_device": {}}
 
 
-class GradScaler(object):
+class GradScaler:
     _scale: Optional[torch.Tensor]
     _grows_tracker: Optional[torch.Tensor]
     _per_optimizer_states: Dict[int, Dict[str, Any]]

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -118,7 +118,7 @@ class CUDAGraph(torch._C._CUDAGraph):
         return super(CUDAGraph, self).debug_dump(debug_path)
 
 
-class graph(object):
+class graph:
     r"""
     Context-manager that captures CUDA work into a :class:`torch.cuda.CUDAGraph`
     object for later replay.

--- a/torch/cuda/nvtx.py
+++ b/torch/cuda/nvtx.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 try:
     from torch._C import _nvtx
 except ImportError:
-    class _NVTXStub(object):
+    class _NVTXStub:
         @staticmethod
         def _fail(*args, **kwargs):
             raise RuntimeError("NVTX functions not installed. Are you sure you have a CUDA build?")

--- a/torch/distributed/_shard/metadata.py
+++ b/torch/distributed/_shard/metadata.py
@@ -5,7 +5,7 @@ from functools import reduce
 from torch.distributed.remote_device import _remote_device
 
 @dataclass
-class ShardMetadata(object):
+class ShardMetadata:
     """
     Represents a shard of the overall Tensor including its
     offsets, lengths and device placement.

--- a/torch/distributed/_shard/sharded_tensor/metadata.py
+++ b/torch/distributed/_shard/sharded_tensor/metadata.py
@@ -11,7 +11,7 @@ class MEM_FORMAT_ENCODING(Enum):
     TORCH_PRESERVE_FORMAT = 2
 
 @dataclass
-class TensorProperties(object):
+class TensorProperties:
     """ Properties used to create :class:`Tensor` """
 
     # Regular tensor fields
@@ -68,7 +68,7 @@ class TensorProperties(object):
             pin_memory=tensor.is_pinned()
         )
 @dataclass
-class ShardedTensorMetadata(object):
+class ShardedTensorMetadata:
     """
     Represents metadata for :class:`ShardedTensor`
     """

--- a/torch/distributed/_shard/sharded_tensor/shard.py
+++ b/torch/distributed/_shard/sharded_tensor/shard.py
@@ -7,7 +7,7 @@ from torch.distributed.remote_device import _remote_device
 
 
 @dataclass
-class Shard(object):
+class Shard:
     """
     Container which holds the data for a shard as a Tensor and also
     the associated metadata for that shard.

--- a/torch/distributed/_shard/sharding_plan/api.py
+++ b/torch/distributed/_shard/sharding_plan/api.py
@@ -8,7 +8,7 @@ from torch.distributed._shard.sharder import Sharder
 from torch.distributed._shard.sharding_spec import ShardingSpec
 
 @dataclass
-class ShardingPlan(object):
+class ShardingPlan:
     """
     Representation of a sharding plan, describes how to shard a module
     across hosts. `plan` is used to shard module parameters according to the spec provided,

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -51,7 +51,7 @@ MeshExprT = Union[
 ]
 
 
-class DeviceMesh(object):
+class DeviceMesh:
     """
     DeviceMesh represents a mesh of devices, where layout of devices could be
     represented as a n-d dimension array, and each value of the n-d dimensional

--- a/torch/distributed/_tensor/op_schema.py
+++ b/torch/distributed/_tensor/op_schema.py
@@ -14,7 +14,7 @@ OutputSpecType = Optional[Union[DTensorSpec, Sequence[Optional[DTensorSpec]]]]
 
 
 @dataclass
-class OpSchema(object):
+class OpSchema:
     """
     OpSchema is a data class that describes an operator input schemas, it
     includes DTensor DTensorSpecs and non-tensor args/kwargs (positional order

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -10,7 +10,7 @@ from torch.distributed._spmd.comm_tensor import CommTensor
 from torch.distributed._tensor.device_mesh import DeviceMesh
 
 
-class Placement(object):
+class Placement:
     # base class Placement type
 
     # convenient utils to check for placement types
@@ -285,7 +285,7 @@ class _Partial(Placement):
 
 # used internally to propagate the placements
 @dataclass
-class DTensorSpec(object):
+class DTensorSpec:
     mesh: DeviceMesh
     placements: Sequence[Placement]
     # shape of the current dist tensor, this will be set upon

--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -16,7 +16,7 @@ def unwrap_schema(e: object) -> object:
     return e._spec if isinstance(e, dtensor.DTensor) else e
 
 
-class ShardingPropagator(object):
+class ShardingPropagator:
     def __init__(self) -> None:
         self.op_to_rules: Dict[OpOverload, Callable[[OpSchema], OutputSharding]] = {}
 

--- a/torch/distributed/algorithms/_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/_comm_hooks/default_hooks.py
@@ -3,7 +3,7 @@ import torch
 import torch.distributed as dist
 
 
-class DefaultState(object):
+class DefaultState:
     r"""
     Stores state needed to perform the default communication algorithm
     within a communication hook.

--- a/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py
@@ -10,7 +10,7 @@ __all__: List[str] = []
 
 _FUNCTIONAL_OPTIM_STEP_METHOD_NAME = "step_param"
 
-class _OptimizerHookState(object):
+class _OptimizerHookState:
     """
     Holds state for running optimizer in-line after DDP communication hook.
     Currently contains only optimizer class which must have a method `step_param`.

--- a/torch/distributed/algorithms/ddp_comm_hooks/post_localSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/post_localSGD_hook.py
@@ -8,7 +8,7 @@ from . import default_hooks as default
 logger = logging.getLogger(__name__)
 
 
-class PostLocalSGDState(object):
+class PostLocalSGDState:
     r"""
     Stores the state for all-reducing gradients globally using ``process_group`` until step ``start_localSGD_iter``,
     and all-reducing gradients locally using ``subgroup`` afterwards.

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -112,7 +112,7 @@ def _report_compression_stats(bucket, state):
         state.next_stats_report = state.iter + state.compression_stats_logging_frequency
 
 
-class PowerSGDState(object):
+class PowerSGDState:
     r"""
     Stores both the algorithm's hyperparameters and the internal state for all the gradients during the training.
     Particularly, ``matrix_approximation_rank`` and ``start_powerSGD_iter`` are the main hyperparameters that should be tuned by the user.

--- a/torch/distributed/autograd/__init__.py
+++ b/torch/distributed/autograd/__init__.py
@@ -26,7 +26,7 @@ if is_available():
     )
 
 
-class context(object):
+class context:
     '''
     Context object to wrap forward and backward passes when using
     distributed autograd. The ``context_id`` generated in the ``with``

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -147,7 +147,7 @@ def supports_complex(reduceOp: ReduceOp) -> bool:
     return reduceOp not in denyList
 
 
-class Backend(object):
+class Backend:
     """
     An enum-like class of available backends: GLOO, NCCL, UCC, MPI, and other registered
     backends.
@@ -223,7 +223,7 @@ class Backend(object):
         Backend.backend_list.append(name.lower())
         Backend._plugins[name.upper()] = Backend._BackendPlugin(func, extended_api)
 
-class BackendConfig(object):
+class BackendConfig:
 
     def __init__(self, backend: Union[str, Backend]):
         self.device_backend_map: Dict[torch.device, Backend] = {}
@@ -266,7 +266,7 @@ _backend: str = Backend.UNDEFINED
 dist_backend = Backend
 
 
-class _reduce_op(object):
+class _reduce_op:
     r"""
     Deprecated enum-like class for reduction operations: ``SUM``, ``PRODUCT``,
     ``MIN``, and ``MAX``.
@@ -390,10 +390,10 @@ class _WorldMeta(type):
     def WORLD(cls, pg: Optional[ProcessGroup]):
         _world.default_pg = pg
 
-class group(object, metaclass=_WorldMeta):
+class group(metaclass=_WorldMeta):
     pass
 
-class GroupMember(object, metaclass=_WorldMeta):
+class GroupMember(metaclass=_WorldMeta):
     NON_GROUP_MEMBER = object()
 
 
@@ -1313,7 +1313,7 @@ def recv(tensor: torch.Tensor, src: Optional[int] = None, group: Optional[Proces
         return src
 
 
-class P2POp(object):
+class P2POp:
     """
     A class to build point-to-point operations for ``batch_isend_irecv``.
 

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -194,7 +194,7 @@ class EtcdRendezvousHandler(RendezvousHandler):
 # but is verbose to add everywhere. Consider wrapping the client calls
 # into auto-retry for these errors?
 #
-class EtcdRendezvous(object):
+class EtcdRendezvous:
     """
     A rendezvous implementation that uses `etcd <https://etcd.io/>`__ as
     the backend store.

--- a/torch/distributed/optim/functional_adadelta.py
+++ b/torch/distributed/optim/functional_adadelta.py
@@ -17,7 +17,7 @@ __all__: List[str] = []
 # NOTE: This should be only used by distributed optimizer internals
 # and not meant to expose to the user.
 @torch.jit.script
-class _FunctionalAdadelta(object):
+class _FunctionalAdadelta:
     def __init__(
         self,
         params: List[Tensor],

--- a/torch/distributed/optim/functional_adagrad.py
+++ b/torch/distributed/optim/functional_adagrad.py
@@ -17,7 +17,7 @@ __all__: List[str] = []
 # NOTE: This should be only used by distributed optimizer internals
 # and not meant to expose to the user.
 @torch.jit.script
-class _FunctionalAdagrad(object):
+class _FunctionalAdagrad:
     def __init__(
         self,
         params: List[Tensor],

--- a/torch/distributed/optim/functional_adam.py
+++ b/torch/distributed/optim/functional_adam.py
@@ -17,7 +17,7 @@ __all__: List[str] = []
 # NOTE: This should be only used by distributed optimizer internals
 # and not meant to expose to the user.
 @torch.jit.script
-class _FunctionalAdam(object):
+class _FunctionalAdam:
     def __init__(
         self,
         params: List[Tensor],

--- a/torch/distributed/optim/functional_adamax.py
+++ b/torch/distributed/optim/functional_adamax.py
@@ -17,7 +17,7 @@ __all__: List[str] = []
 # NOTE: This should be only used by distributed optimizer internals
 # and not meant to expose to the user.
 @torch.jit.script
-class _FunctionalAdamax(object):
+class _FunctionalAdamax:
     def __init__(
         self,
         params: List[Tensor],

--- a/torch/distributed/optim/functional_adamw.py
+++ b/torch/distributed/optim/functional_adamw.py
@@ -17,7 +17,7 @@ __all__: List[str] = []
 # NOTE: This should be only used by distributed optimizer internals
 # and not meant to expose to the user.
 @torch.jit.script
-class _FunctionalAdamW(object):
+class _FunctionalAdamW:
     def __init__(
         self,
         params: List[Tensor],

--- a/torch/distributed/optim/functional_rmsprop.py
+++ b/torch/distributed/optim/functional_rmsprop.py
@@ -17,7 +17,7 @@ __all__: List[str] = []
 # NOTE: This should be only used by distributed optimizer internals
 # and not meant to expose to the user.
 @torch.jit.script
-class _FunctionalRMSprop(object):
+class _FunctionalRMSprop:
     def __init__(
         self,
         params: List[Tensor],

--- a/torch/distributed/optim/functional_rprop.py
+++ b/torch/distributed/optim/functional_rprop.py
@@ -17,7 +17,7 @@ __all__: List[str] = []
 # NOTE: This should be only used by distributed optimizer internals
 # and not meant to expose to the user.
 @torch.jit.script
-class _FunctionalRprop(object):
+class _FunctionalRprop:
     def __init__(
         self,
         params: List[Tensor],

--- a/torch/distributed/optim/functional_sgd.py
+++ b/torch/distributed/optim/functional_sgd.py
@@ -17,7 +17,7 @@ __all__: List[str] = []
 # NOTE: This should be only used by distributed optimizer internals
 # and not meant to expose to the user.
 @torch.jit.script
-class _FunctionalSGD(object):
+class _FunctionalSGD:
     def __init__(
         self,
         params: List[Tensor],

--- a/torch/distributed/optim/optimizer.py
+++ b/torch/distributed/optim/optimizer.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 # TODO (wanchaol): remove this once we added TorchScript
 # class reference semantics
 @jit.interface
-class _ScriptLocalOptimizerInterface(object):
+class _ScriptLocalOptimizerInterface:
     def step(self, autograd_ctx_id: int) -> None:
         pass
 
@@ -59,7 +59,7 @@ class _ScriptLocalOptimizer(nn.Module):
 
 # TODO (wanchaol): remove/merge this with ScriptLocalOptimizer once
 # we have converted all to functional optimizer in distributed.optim
-class _LocalOptimizer(object):
+class _LocalOptimizer:
     # Ideally we would only need to share a lock for instances of
     # _LocalOptimizer that deal with the same parameters. We are
     # making a simplifying assumption here that if there is more

--- a/torch/distributed/pipeline/sync/microbatch.py
+++ b/torch/distributed/pipeline/sync/microbatch.py
@@ -20,7 +20,7 @@ TensorOrTensors = Union[Tensor, Tensors]
 Function = Callable[[TensorOrTensors], Union[List[Any], Tensor]]
 
 
-class NoChunk(object):
+class NoChunk:
     """
     Wrapper for a Tensor in :meth:`Pipe.forward` indicating that the tensor
     should not be chunked on the batch dimension and instead be replicated

--- a/torch/distributed/remote_device.py
+++ b/torch/distributed/remote_device.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 import torch
 
 
-class _remote_device(object):
+class _remote_device:
     """
     Represents a device on a remote worker.
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -84,7 +84,7 @@ def _require_initialized(func):
     return wrapper
 
 
-class AllGatherStates(object):
+class AllGatherStates:
     def __init__(self):
         # Each `gathered_objects` is an empty dict at beginning.
         # The leader worker is elected as the first worker in a sorted worker

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -76,7 +76,7 @@ __all__ = [
 ]
 
 
-class ConstraintRegistry(object):
+class ConstraintRegistry:
     """
     Registry to link constraints to transforms.
     """

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -65,7 +65,7 @@ __all__ = [
 ]
 
 
-class Constraint(object):
+class Constraint:
     """
     Abstract base class for constraints.
 

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional, Any, Tuple
 
 __all__ = ['Distribution']
 
-class Distribution(object):
+class Distribution:
     r"""
     Distribution is the abstract base class for probability distributions.
     """

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -78,7 +78,7 @@ def register_kl(type_p, type_q):
 
 
 @total_ordering
-class _Match(object):
+class _Match:
     __slots__ = ['types']
 
     def __init__(self, *types):

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -38,7 +38,7 @@ __all__ = [
 ]
 
 
-class Transform(object):
+class Transform:
     """
     Abstract class for invertable transformations with computable log
     det jacobians. They are primarily used in

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -189,7 +189,7 @@ def _patch_function(fn: FunctionType, nargs: int) -> FunctionType:
 
 
 @compatibility(is_backward_compatible=False)
-class PHBase(object):
+class PHBase:
     """
     Object representing an input placeholder to `concrete_args`
     """
@@ -921,7 +921,7 @@ class _PatchedFnSetAttr(_PatchedFn):
         setattr(self.frame_dict, self.fn_name, self.orig_fn)
 
 
-class _Patcher(object):
+class _Patcher:
     def __init__(self):
         super(_Patcher, self).__init__()
         self.patches_made: List[_PatchedFn] = []

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -728,7 +728,7 @@ if HAS_SYMPY:
 TLS = threading.local()
 
 
-class ShapeEnv(object):
+class ShapeEnv:
     def __init__(self):
         self.guards: List[ShapeGuard] = []
         # Maps symbolic ints to their original concrete values

--- a/torch/fx/experimental/unification/match.py
+++ b/torch/fx/experimental/unification/match.py
@@ -4,7 +4,7 @@ from .utils import _toposort, freeze
 from .unification_tools import groupby, first  # type: ignore[import]
 
 
-class Dispatcher(object):
+class Dispatcher:
     def __init__(self, name):
         self.name = name
         self.funcs = {}

--- a/torch/fx/experimental/unification/multipledispatch/dispatcher.py
+++ b/torch/fx/experimental/unification/multipledispatch/dispatcher.py
@@ -92,7 +92,7 @@ def variadic_signature_matches(types, full_signature):
     return all(variadic_signature_matches_iter(types, full_signature))
 
 
-class Dispatcher(object):
+class Dispatcher:
     """ Dispatch methods based on type signature
     Use ``dispatch`` to add implementations
     Examples

--- a/torch/fx/experimental/unification/variable.py
+++ b/torch/fx/experimental/unification/variable.py
@@ -6,7 +6,7 @@ _global_logic_variables = set()  # type: ignore[var-annotated]
 _glv = _global_logic_variables
 
 
-class Var(object):
+class Var:
     """ Logic Variable """
 
     _id = 1

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -273,7 +273,7 @@ class _PyTreeInfo(NamedTuple):
     out_spec: Optional[pytree.TreeSpec]
 
 @compatibility(is_backward_compatible=False)
-class CodeGen(object):
+class CodeGen:
     def __init__(self):
         self._body_transformer: Optional[TransformCodeFunc] = None
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -22,7 +22,7 @@ __all__ = ["reduce_graph_module", "reduce_package_graph_module", "reduce_deploy_
 # the linecache module to recover it.
 # Using _exec_with_source will add it to our local cache
 # and then tools like TorchScript will be able to get source info.
-class _EvalCacheLoader(object):
+class _EvalCacheLoader:
     def __init__(self):
         self.eval_cache = {}
         self.next_id = 0

--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 import hashlib
 import torch

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -20,7 +20,7 @@ __all__ = ['TracerBase', 'GraphAppendingTracer', 'TraceError',
 
 
 @compatibility(is_backward_compatible=False)
-class Scope(object):
+class Scope:
     """ Scope object that records the module path and the module type
     of a module. Scope is used to track the information of the module
     that contains a Node in a Graph of GraphModule. For example::
@@ -51,7 +51,7 @@ class Scope(object):
 
 
 @compatibility(is_backward_compatible=False)
-class ScopeContextManager(object):
+class ScopeContextManager:
     """ A context manager to track the Scope of Node during symbolic tracing.
     When entering a forward function of a Module, we'll update the scope information of
     the current module, and when we exit, we'll restore the previous scope information.

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -17,7 +17,7 @@ from urllib.request import urlopen, Request
 from urllib.parse import urlparse  # noqa: F401
 from torch.serialization import MAP_LOCATION
 
-class _Faketqdm(object):  # type: ignore[no-redef]
+class _Faketqdm:  # type: ignore[no-redef]
 
     def __init__(self, total=None, disable=False,
                  unit=None, *args, **kwargs):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -196,7 +196,7 @@ def isinstance(obj, target_type):
     """
     return _isinstance(obj, target_type)
 
-class strict_fusion(object):
+class strict_fusion:
     """
     This class errors if not all nodes have been fused in
     inference, or symbolically differentiated in training.

--- a/torch/jit/_ir_utils.py
+++ b/torch/jit/_ir_utils.py
@@ -1,7 +1,7 @@
 import torch
 from typing import Union
 
-class _InsertPoint(object):
+class _InsertPoint:
     def __init__(self, insert_point_graph: torch._C.Graph, insert_point: Union[torch._C.Node, torch._C.Block]):
         self.insert_point = insert_point
         self.g = insert_point_graph

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -351,7 +351,7 @@ def infer_concrete_type_builder(nn_module, share_types=True):
 
     return concrete_type_builder
 
-class ConcreteTypeStore(object):
+class ConcreteTypeStore:
     type_store: Dict[Type[Module], List[torch._C.ConcreteModuleType]]
     methods_compiled: Set[torch._C.ConcreteModuleType]
 

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -177,7 +177,7 @@ def _is_new_style_class(cls):
 #  len(view)
 
 
-class OrderedDictWrapper(object):
+class OrderedDictWrapper:
     def __init__(self, _c):
         self._c = _c
 
@@ -321,7 +321,7 @@ class ScriptMeta(type):
         super(ScriptMeta, cls).__init__(name, bases, attrs)
 
 
-class _CachedForward(object):
+class _CachedForward:
     def __get__(self, obj, cls):
         return self.__getattr__("forward")  # type: ignore[attr-defined]
 
@@ -411,7 +411,7 @@ if _enabled:
         "__exit__",
     ]
 
-    class RecursiveScriptClass(object):
+    class RecursiveScriptClass:
         """
         An analogue of RecursiveScriptModule for regular objects that are not modules.
         This class is a wrapper around a torch._C.ScriptObject that represents an instance
@@ -956,7 +956,7 @@ if _enabled:
 
 else:
     # TODO MAKE SURE THAT DISABLING WORKS
-    class RecursiveScriptClass(object):  # type: ignore[no-redef]
+    class RecursiveScriptClass:  # type: ignore[no-redef]
         def __init__(self):
             super().__init__()
 

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -26,7 +26,7 @@ if torch.distributed.rpc.is_available():
 
 from torch._ops import OpOverloadPacket
 
-class Module(object):
+class Module:
     def __init__(self, name, members):
         self.name = name
         self.members = members
@@ -38,7 +38,7 @@ class Module(object):
             raise RuntimeError(f"Module {self.name} has no member called {name}") from None
 
 
-class EvalEnv(object):
+class EvalEnv:
     env = {
         'torch': Module('torch', {'Tensor': torch.Tensor}),
         'Tensor': torch.Tensor,

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -313,7 +313,7 @@ def is_torch_jit_ignore_context_manager(stmt):
                         return True
     return False
 
-class Builder(object):
+class Builder:
     def __call__(self, ctx, node):
         method = getattr(self, 'build_' + node.__class__.__name__, None)
         if method is None:

--- a/torch/jit/mobile/__init__.py
+++ b/torch/jit/mobile/__init__.py
@@ -51,7 +51,7 @@ def _load_for_lite_interpreter(f, map_location=None):
 
     return LiteScriptModule(cpp_module)
 
-class LiteScriptModule(object):
+class LiteScriptModule:
     def __init__(self, cpp_module):
         self._c = cpp_module
         super(LiteScriptModule, self).__init__()

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -4,7 +4,7 @@ from multiprocessing.reduction import ForkingPickler
 import pickle
 
 
-class ConnectionWrapper(object):
+class ConnectionWrapper:
     """Proxy class for _multiprocessing.Connection which uses ForkingPickler to
     serialize objects"""
 

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -19,7 +19,7 @@ except ImportError:
     pass
 
 
-class StorageWeakRef(object):
+class StorageWeakRef:
     r"""A weak reference to a Storage.
 
     The cdata member is a Python number containing the integer representation of

--- a/torch/nn/cpp.py
+++ b/torch/nn/cpp.py
@@ -3,7 +3,7 @@
 from torch import nn
 
 
-class OrderedDictWrapper(object):
+class OrderedDictWrapper:
     """
     A wrapper around a C++ OrderedDict that dynamically evaluates the
     OrderedDict getter on a bound C++ module, such that new changes on the C++

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -8,7 +8,7 @@ from ..modules import Module
 
 __all__ = ['WeightNorm', 'weight_norm', 'remove_weight_norm']
 
-class WeightNorm(object):
+class WeightNorm:
     name: str
     dim: int
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -23,7 +23,7 @@ EPOCH_DEPRECATION_WARNING = (
 )
 
 
-class LRScheduler(object):
+class LRScheduler:
 
     def __init__(self, optimizer, last_epoch=-1, verbose=False):
 
@@ -910,7 +910,7 @@ class ChainedScheduler(LRScheduler):
             self._schedulers[idx].load_state_dict(s)
 
 
-class ReduceLROnPlateau(object):
+class ReduceLROnPlateau:
     """Reduce learning rate when a metric has stopped improving.
     Models often benefit from reducing the learning rate by a factor
     of 2-10 once learning stagnates. This scheduler reads a metrics

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -16,7 +16,7 @@ __all__ = ['Optimizer', 'register_optimizer_step_pre_hook', 'register_optimizer_
 _global_optimizer_pre_hooks: Dict[int, Callable] = OrderedDict()
 _global_optimizer_post_hooks: Dict[int, Callable] = OrderedDict()
 
-class _RequiredParameter(object):
+class _RequiredParameter:
     """Singleton class representing a required parameter for an Optimizer."""
     def __repr__(self):
         return "<required parameter>"
@@ -136,7 +136,7 @@ def register_optimizer_step_post_hook(hook: Callable[..., None]) -> RemovableHan
     return handle
 
 
-class Optimizer(object):
+class Optimizer:
     r"""Base class for all optimizers.
 
     .. warning::

--- a/torch/package/_directory_reader.py
+++ b/torch/package/_directory_reader.py
@@ -6,7 +6,7 @@ import torch
 from torch.types import Storage
 
 # because get_storage_from_record returns a tensor!?
-class _HasStorage(object):
+class _HasStorage:
     def __init__(self, storage):
         self._storage = storage
 
@@ -14,7 +14,7 @@ class _HasStorage(object):
         return self._storage
 
 
-class DirectoryReader(object):
+class DirectoryReader:
     """
     Class to allow PackageImporter to operate on unzipped packages. Methods
     copy the behavior of the internal PyTorchFileReader class (which is used for

--- a/torch/profiler/itt.py
+++ b/torch/profiler/itt.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 try:
     from torch._C import _itt
 except ImportError:
-    class _ITTStub(object):
+    class _ITTStub:
         @staticmethod
         def _fail(*args, **kwargs):
             raise RuntimeError("ITT functions not installed. Are you sure you have a ITT build?")

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -44,7 +44,7 @@ def supported_activities():
     return torch.autograd._supported_activities()
 
 
-class _KinetoProfile(object):
+class _KinetoProfile:
     """Low-level profiler wrap the autograd profile
 
     Args:

--- a/torch/quasirandom.py
+++ b/torch/quasirandom.py
@@ -2,7 +2,7 @@ import torch
 from typing import Optional
 
 
-class SobolEngine(object):
+class SobolEngine:
     r"""
     The :class:`torch.quasirandom.SobolEngine` is an engine for generating
     (scrambled) Sobol sequences. Sobol sequences are an example of low

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -238,7 +238,7 @@ def _is_path(name_or_buffer):
         isinstance(name_or_buffer, pathlib.Path)
 
 
-class _opener(object):
+class _opener:
     def __init__(self, file_like):
         self.file_like = file_like
 

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -359,7 +359,7 @@ Specifying a positive offset::
 """)
 
 
-class check_sparse_tensor_invariants(object):
+class check_sparse_tensor_invariants:
     """A tool to control checking sparse tensor invariants.
 
 The following options exists to manage sparsr tensor invariants

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -15,7 +15,7 @@ except ModuleNotFoundError:
     np = None  # type: ignore[assignment]
 
 T = TypeVar('T', bound='Union[_StorageBase, TypedStorage]')
-class _StorageBase(object):
+class _StorageBase:
     _cdata: Any
     is_sparse: bool = False
     is_sparse_csr: bool = False

--- a/torch/testing/_internal/autocast_test_lists.py
+++ b/torch/testing/_internal/autocast_test_lists.py
@@ -2,7 +2,7 @@ import torch
 from torch.testing._internal.common_utils import TEST_WITH_ROCM
 
 
-class AutocastTestLists(object):
+class AutocastTestLists:
     def _rnn_cell_args(self, n, num_chunks, is_lstm, dev, dtype):
         input = (torch.randn((n, n), device=dev, dtype=torch.float32),)
 
@@ -230,7 +230,7 @@ class AutocastTestLists(object):
                                       torch.rand((n, n), device=dev, dtype=torch.float32)), torch._C._nn),
         ]
 
-class AutocastCPUTestLists(object):
+class AutocastCPUTestLists:
     # Supplies ops and arguments for test_autocast_* in test/test_cpu.py
     def __init__(self, dev):
         super().__init__()

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -870,7 +870,7 @@ class ops(_TestParametrizer):
 #       for the test to run. If you want to use a string argument you should
 #       probably define a new decorator instead (see below).
 #   (3) Prefer the existing decorators to defining the 'device_type' kwarg.
-class skipIf(object):
+class skipIf:
 
     def __init__(self, dep, reason, device_type=None):
         self.dep = dep
@@ -973,7 +973,7 @@ def largeTensorTest(size, device=None):
     return inner
 
 
-class expectedFailure(object):
+class expectedFailure:
 
     def __init__(self, device_type):
         self.device_type = device_type
@@ -994,7 +994,7 @@ class expectedFailure(object):
         return efail_fn
 
 
-class onlyOn(object):
+class onlyOn:
 
     def __init__(self, device_type):
         self.device_type = device_type
@@ -1016,7 +1016,7 @@ class onlyOn(object):
 # as a list of strings instead of providing a single device string.
 # Skips the test if the number of available devices of the variant's device
 # type is less than the 'num_required_devices' arg.
-class deviceCountAtLeast(object):
+class deviceCountAtLeast:
 
     def __init__(self, num_required_devices):
         self.num_required_devices = num_required_devices
@@ -1064,7 +1064,7 @@ def onlyNativeDeviceTypes(fn):
 # precisions (or are working with multiple dtypes) they should be specified
 # explicitly and computed using self.precision (e.g.
 # self.precision *2, max(1, self.precision)).
-class precisionOverride(object):
+class precisionOverride:
 
     def __init__(self, d):
         assert isinstance(d, dict), "precisionOverride not given a dtype : precision dict!"
@@ -1096,7 +1096,7 @@ class precisionOverride(object):
 # atol = 1e-4 and rtol = 0 for torch.double.
 tol = namedtuple('tol', ['atol', 'rtol'])
 
-class toleranceOverride(object):
+class toleranceOverride:
     def __init__(self, d):
         assert isinstance(d, dict), "toleranceOverride not given a dtype : tol dict!"
         for dtype, prec in d.items():
@@ -1119,7 +1119,7 @@ class toleranceOverride(object):
 # Examples:
 # @dtypes(torch.float32, torch.float64)
 # @dtypes((torch.long, torch.float32), (torch.int, torch.float64))
-class dtypes(object):
+class dtypes:
 
     def __init__(self, *args, device_type="all"):
         if len(args) > 0 and isinstance(args[0], (list, tuple)):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3056,7 +3056,7 @@ def sample_inputs_reduction_sparse(op_info, device, dtype, requires_grad, layout
                 kwargs=sample_input.kwargs)
 
 
-class _TestParamsMaxPoolBase(object):
+class _TestParamsMaxPoolBase:
 
     def __init__(self):
         self.kwargs = {

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -132,7 +132,7 @@ def get_module_common_name(module_cls):
         return module_cls.__name__
 
 
-class FunctionInput(object):
+class FunctionInput:
     """ Contains args and kwargs to pass as input to a function. """
     __slots__ = ['args', 'kwargs']
 
@@ -141,7 +141,7 @@ class FunctionInput(object):
         self.kwargs = kwargs
 
 
-class ModuleInput(object):
+class ModuleInput:
     """ Contains args / kwargs for module instantiation + forward pass. """
     __slots__ = ['constructor_input', 'forward_input', 'desc', 'reference_fn']
 
@@ -164,7 +164,7 @@ class ModuleInput(object):
             self.reference_fn = copy_reference_fn
 
 
-class ModuleInfo(object):
+class ModuleInfo:
     """ Module information to be used in testing. """
 
     def __init__(self,

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5848,7 +5848,7 @@ class NNTestCase(TestCase):
             self.assertLessEqual(max(differences), PRECISION)  # type: ignore[type-var]
 
 
-class TestBase(object):
+class TestBase:
 
     _required_arg_names = {'constructor_args', 'input', 'extra_args'}
 
@@ -6108,7 +6108,7 @@ class ModuleTest(TestBase):
         self.test_noncontig(test_case, gpu_module, gpu_input_tuple)
 
 
-class InputVariableMixin(object):
+class InputVariableMixin:
     def _get_input(self):
         input = TestBase._get_input(self, False)  # type: ignore[arg-type]
 

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -129,7 +129,7 @@ def test_only_train_fn(model, train_data, loss_fn=_default_loss_fn):
             correct += (predicted == target).sum().item()
     return train_loss, correct, total
 
-class AverageMeter(object):
+class AverageMeter:
     """Computes and stores the average and current value"""
     def __init__(self, name, fmt=':f'):
         self.name = name

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -128,7 +128,7 @@ if os.getenv("DISABLED_TESTS_FILE", ""):
 NATIVE_DEVICES = ('cpu', 'cuda', 'meta')
 
 
-class _TestParametrizer(object):
+class _TestParametrizer:
     """
     Decorator class for parametrizing a test function, yielding a set of new tests spawned
     from the original generic test, each specialized for a specific set of test inputs. For
@@ -266,7 +266,7 @@ def instantiate_parametrized_tests(generic_cls):
     return generic_cls
 
 
-class subtest(object):
+class subtest:
     """
     Explicit subtest case for use with test parametrization.
     Allows for explicit naming of individual subtest cases as well as applying

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -191,7 +191,7 @@ class DTensorOpTestBase(MultiThreadedTestCase):
 
 
 # This is a class for converting args/kwargs of an op into distributed args/kwargs
-class DTensorConverter(object):
+class DTensorConverter:
     def __init__(
         self,
         mesh: DeviceMesh,

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -481,7 +481,7 @@ def _create_torch_profiler():
 
 
 
-class Barrier(object):
+class Barrier:
     barrier_id = 0
 
     @classmethod

--- a/torch/testing/_internal/distributed/rpc/examples/parameter_server_test.py
+++ b/torch/testing/_internal/distributed/rpc/examples/parameter_server_test.py
@@ -27,7 +27,7 @@ def timed_log(text):
     print(f"{datetime.now().strftime('%H:%M:%S')} {text}")
 
 
-class BatchUpdateParameterServer(object):
+class BatchUpdateParameterServer:
 
     def __init__(self, batch_update_size):
         self.model = nn.Linear(in_features, out_features)
@@ -69,7 +69,7 @@ class BatchUpdateParameterServer(object):
         return fut
 
 
-class Trainer(object):
+class Trainer:
 
     def __init__(self, ps_rref):
         self.ps_rref = ps_rref

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -69,7 +69,7 @@ def get_execution_plan(graph_executor_state):
                            'only have one execution plan, got: {}'.format(num_plans))
     return execution_plans[0]
 
-class _AssertRaisesRegexWithHighlightContext(object):
+class _AssertRaisesRegexWithHighlightContext:
     """
     A context manager that is useful for checking that error messages highlight
     the correct part of the source code.
@@ -645,7 +645,7 @@ class JitTestCase(JitCommonTestCase):
 
         return sm
 
-class NoTracerWarnContextManager(object):
+class NoTracerWarnContextManager:
     def __enter__(self):
         self.prev = torch._C._jit_get_tracer_state_warn()
         torch._C._jit_set_tracer_state_warn(False)

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -56,7 +56,7 @@ def _getattr_qual(obj, name, default=_NOTHING):
             raise
 
 
-class DecorateInfo(object):
+class DecorateInfo:
     """Describes which test, or type of tests, should be wrapped in the given
     decorators when testing an operator. Any test that matches all provided
     arguments will be decorated. The decorators will only be applied if the
@@ -117,7 +117,7 @@ class DecorateInfo(object):
 # Note: historically the 'input' kwarg had to be a Tensor or TensorList, but we are trying
 #   to support scalar inputs, too. Some tests still depend on 'input' being a Tensor
 #   or TensorList, however.
-class SampleInput(object):
+class SampleInput:
     """Represents sample inputs to a function."""
 
     __slots__ = [
@@ -309,7 +309,7 @@ cannot specify additional metadata in keyword arguments"""
 NumericsFilter = collections.namedtuple("NumericsFilter", ["condition", "safe_val"])
 
 
-class ErrorInput(object):
+class ErrorInput:
     """
     A SampleInput that will cause the operation to throw an error plus information
     about the resulting error.
@@ -323,7 +323,7 @@ class ErrorInput(object):
         self.error_regex = error_regex
 
 
-class AliasInfo(object):
+class AliasInfo:
     """Class holds alias information. For example, torch.abs ->
     torch.absolute, torch.Tensor.absolute, torch.Tensor.absolute_
     """
@@ -617,7 +617,7 @@ class AliasInfo(object):
 
 # Classes and methods for the operator database
 @dataclass
-class OpInfo(object):
+class OpInfo:
     """Operator information and helper functions for acquiring it."""
 
     # the string name of the function

--- a/torch/testing/_internal/test_module/future_div.py
+++ b/torch/testing/_internal/test_module/future_div.py
@@ -1,4 +1,3 @@
-from __future__ import division
 
 
 def div_int_future():

--- a/torch/types.py
+++ b/torch/types.py
@@ -36,7 +36,7 @@ Device = Union[_device, str, _int, None]
 
 # Storage protocol implemented by ${Type}StorageBase classes
 
-class Storage(object):
+class Storage:
     _cdata: int
     device: torch.device
     dtype: torch.dtype

--- a/torch/utils/_cpp_extension_versioner.py
+++ b/torch/utils/_cpp_extension_versioner.py
@@ -25,7 +25,7 @@ def hash_build_arguments(hash_value, build_arguments):
     return hash_value
 
 
-class ExtensionVersioner(object):
+class ExtensionVersioner:
     def __init__(self):
         self.entries = {}
 

--- a/torch/utils/backcompat/__init__.py
+++ b/torch/utils/backcompat/__init__.py
@@ -4,7 +4,7 @@ from torch._C import _set_backcompat_keepdim_warn
 from torch._C import _get_backcompat_keepdim_warn
 
 
-class Warning(object):
+class Warning:
     def __init__(self, setter, getter):
         self.setter = setter
         self.getter = getter

--- a/torch/utils/benchmark/examples/compare.py
+++ b/torch/utils/benchmark/examples/compare.py
@@ -12,7 +12,7 @@ import torch
 import torch.utils.benchmark as benchmark_utils
 
 
-class FauxTorch(object):
+class FauxTorch:
     """Emulate different versions of pytorch.
 
     In normal circumstances this would be done with multiple processes

--- a/torch/utils/benchmark/examples/sparse/compare.py
+++ b/torch/utils/benchmark/examples/sparse/compare.py
@@ -11,7 +11,7 @@ import torch
 import torch.utils.benchmark as benchmark_utils
 
 
-class FauxTorch(object):
+class FauxTorch:
     """Emulate different versions of pytorch.
 
     In normal circumstances this would be done with multiple processes

--- a/torch/utils/benchmark/utils/compare.py
+++ b/torch/utils/benchmark/utils/compare.py
@@ -24,7 +24,7 @@ class Colorize(enum.Enum):
 
 
 # Classes to separate internal bookkeeping from what is rendered.
-class _Column(object):
+class _Column:
     def __init__(
         self,
         grouped_results: List[Tuple[Optional[common.Measurement], ...]],
@@ -75,7 +75,7 @@ def optional_min(seq):
     return None if len(l) == 0 else min(l)
 
 
-class _Row(object):
+class _Row:
     def __init__(self, results, row_group, render_env, env_str_len,
                  row_name_str_len, time_scale, colorize, num_threads=None):
         super(_Row, self).__init__()
@@ -147,7 +147,7 @@ class _Row(object):
         return row_contents
 
 
-class Table(object):
+class Table:
     def __init__(
             self,
             results: List[common.Measurement],
@@ -265,7 +265,7 @@ Times are in {common.unit_to_english(self.time_unit)}s ({self.time_unit}).
 {'(! XX%) Measurement has high variance, where XX is the IQR / median * 100.' + newline if has_warnings else ""}"""[1:]
 
 
-class Compare(object):
+class Compare:
     def __init__(self, results: List[common.Measurement]):
         self._results: List[common.Measurement] = []
         self.extend_results(results)

--- a/torch/utils/benchmark/utils/fuzzer.py
+++ b/torch/utils/benchmark/utils/fuzzer.py
@@ -19,7 +19,7 @@ _DISTRIBUTIONS = (
 )
 
 
-class FuzzedParameter(object):
+class FuzzedParameter:
     """Specification for a parameter to be generated during fuzzing."""
     def __init__(
         self,
@@ -126,7 +126,7 @@ class FuzzedParameter(object):
         return list(self._distribution.keys())[index]
 
 
-class ParameterAlias(object):
+class ParameterAlias:
     """Indicates that a parameter should alias the value of another parameter.
 
     When used in conjunction with a custom distribution, this allows fuzzed
@@ -176,7 +176,7 @@ def prod(values, base=1):
     return functools.reduce(lambda x, y: int(x) * int(y), values, base)
 
 
-class FuzzedTensor(object):
+class FuzzedTensor:
     def __init__(
         self,
         name: str,
@@ -340,7 +340,7 @@ class FuzzedTensor(object):
         ))
 
 
-class Fuzzer(object):
+class Fuzzer:
     def __init__(
         self,
         parameters: List[Union[FuzzedParameter, List[FuzzedParameter]]],

--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -64,7 +64,7 @@ class CPPTimer:
         return self._timeit_module.timeit(number)
 
 
-class Timer(object):
+class Timer:
     """Helper class for measuring execution time of PyTorch statements.
 
     For a full tutorial on how to use this class, see:

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -32,7 +32,7 @@ FunctionCount = NamedTuple("FunctionCount", [("count", int), ("function", str)])
 
 
 @dataclasses.dataclass(repr=False, eq=False, frozen=True)
-class FunctionCounts(object):
+class FunctionCounts:
     """Container for manipulating Callgrind results.
 
     It supports:
@@ -157,7 +157,7 @@ class FunctionCounts(object):
 
 
 @dataclasses.dataclass(repr=False, eq=False, frozen=True)
-class CallgrindStats(object):
+class CallgrindStats:
     """Top level container for Callgrind results collected by Timer.
 
     Manipulation is generally done using the FunctionCounts class, which is
@@ -471,7 +471,7 @@ class GlobalsBridge:
         return "\n".join(load_lines)
 
 
-class _ValgrindWrapper(object):
+class _ValgrindWrapper:
     def __init__(self) -> None:
         self._bindings_module: Optional[CallgrindModuleType] = None
         valgrind_symbols = (

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 # Unlike the rest of the PyTorch this file must be python2 compliant.
 # This script outputs relevant system environment info

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -424,7 +424,7 @@ def _check_cuda_version(compiler_name: str, compiler_version: TorchVersion) -> N
 # https://stackoverflow.com/questions/1713038/super-fails-with-error-typeerror-argument-1-must-be-type-not-classobj-when
 
 
-class BuildExtension(build_ext, object):
+class BuildExtension(build_ext):
     r'''
     A custom :mod:`setuptools` build extension .
 

--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -4,7 +4,7 @@ single- and multi-processing data loading.
 """
 
 
-class _BaseDatasetFetcher(object):
+class _BaseDatasetFetcher:
     def __init__(self, dataset, auto_collation, collate_fn, drop_last):
         self.dataset = dataset
         self.auto_collation = auto_collation

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -22,7 +22,7 @@ if IS_WINDOWS:
     # On Windows, the parent ID of the worker process remains unchanged when the manager process
     # is gone, and the only way to check it through OS is to let the worker have a process handle
     # of the manager and ask if the process status has changed.
-    class ManagerWatchdog(object):
+    class ManagerWatchdog:
         def __init__(self):
             self.manager_pid = os.getppid()
 
@@ -48,7 +48,7 @@ if IS_WINDOWS:
                 self.manager_dead = self.kernel32.WaitForSingleObject(self.manager_handle, 0) == 0
             return not self.manager_dead
 else:
-    class ManagerWatchdog(object):  # type: ignore[no-redef]
+    class ManagerWatchdog:  # type: ignore[no-redef]
         def __init__(self):
             self.manager_pid = os.getppid()
             self.manager_dead = False
@@ -61,7 +61,7 @@ else:
 _worker_info = None
 
 
-class WorkerInfo(object):
+class WorkerInfo:
     id: int
     num_workers: int
     seed: int
@@ -117,12 +117,12 @@ def get_worker_info() -> Optional[WorkerInfo]:
 
 r"""Dummy class used to signal the end of an IterableDataset"""
 @dataclass(frozen=True)
-class _IterableDatasetStopIteration(object):
+class _IterableDatasetStopIteration:
     worker_id: int
 
 r"""Dummy class used to resume the fetching when worker reuse is enabled"""
 @dataclass(frozen=True)
-class _ResumeIteration(object):
+class _ResumeIteration:
     seed: Optional[int] = None
 
 # The function `_generate_state` is adapted from `numpy.random.SeedSequence`

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -69,7 +69,7 @@ get_worker_info = _utils.worker.get_worker_info
 logger = logging.getLogger(__name__)
 
 
-class _DatasetKind(object):
+class _DatasetKind:
     Map = 0
     Iterable = 1
 
@@ -565,7 +565,7 @@ class DataLoader(Generic[T_co]):
                 cpuset_checked))
 
 
-class _BaseDataLoaderIter(object):
+class _BaseDataLoaderIter:
     def __init__(self, loader: DataLoader) -> None:
         self._dataset = loader.dataset
         self._shared_seed = None

--- a/torch/utils/data/datapipes/_decorator.py
+++ b/torch/utils/data/datapipes/_decorator.py
@@ -8,7 +8,7 @@ from torch.utils.data.datapipes._typing import _DataPipeMeta
 ######################################################
 # Functional API
 ######################################################
-class functional_datapipe(object):
+class functional_datapipe:
     name: str
 
     def __init__(self, name: str, enable_df_api_tracing=False) -> None:
@@ -44,7 +44,7 @@ class functional_datapipe(object):
 _determinism: bool = False
 
 
-class guaranteed_datapipes_determinism(object):
+class guaranteed_datapipes_determinism:
     prev: bool
 
     def __init__(self) -> None:
@@ -60,7 +60,7 @@ class guaranteed_datapipes_determinism(object):
         _determinism = self.prev
 
 
-class non_deterministic(object):
+class non_deterministic:
     cls: Optional[Type[IterDataPipe]] = None
     # TODO: Lambda for picking
     deterministic_fn: Callable[[], bool]
@@ -145,7 +145,7 @@ def argument_validation(f):
 _runtime_validation_enabled: bool = True
 
 
-class runtime_validation_disabled(object):
+class runtime_validation_disabled:
     prev: bool
 
     def __init__(self) -> None:

--- a/torch/utils/data/datapipes/dataframe/dataframes.py
+++ b/torch/utils/data/datapipes/dataframe/dataframes.py
@@ -57,7 +57,7 @@ DATAPIPES_OPS = ['_dataframes_as_tuples', 'groupby', '_dataframes_filter', 'map'
 UNIMPLEMENTED_ATTR = ['__deepcopy__', '__setstate__', 'is_shardable', 'apply_sharding']
 
 
-class Capture(object):
+class Capture:
     # TODO: All operations are shared across entire InitialCapture, need to figure out what if we join two captures
 
     def __init__(self, schema_df=None):

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -6,7 +6,7 @@ from typing import Any
 
 __all__ = ["RemovableHandle", "unserializable_hook", "warn_if_has_hooks", "BackwardHook"]
 
-class RemovableHandle(object):
+class RemovableHandle:
     r"""
     A handle which provides the capability to remove a hook.
 
@@ -89,7 +89,7 @@ def warn_if_has_hooks(tensor):
                               "decorate the function with @torch.utils.hooks.unserializable_hook "
                               "to suppress this warning".format(repr(hook)))
 
-class BackwardHook(object):
+class BackwardHook:
     """
     A wrapper class to implement nn.Module backward hooks.
     It handles:

--- a/torch/utils/show_pickle.py
+++ b/torch/utils/show_pickle.py
@@ -9,7 +9,7 @@ from typing import Any, IO, BinaryIO, Union
 
 __all__ = ["FakeObject", "FakeClass", "DumpUnpickler", "main"]
 
-class FakeObject(object):
+class FakeObject:
     def __init__(self, module, name, args):
         self.module = module
         self.name = name
@@ -43,7 +43,7 @@ class FakeObject(object):
         raise Exception("Need to implement")
 
 
-class FakeClass(object):
+class FakeClass:
     def __init__(self, module, name):
         self.module = module
         self.name = name

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -32,7 +32,7 @@ GETATTR_KIND = "prim::GetAttr"
 CLASSTYPE_KIND = "ClassType"
 
 
-class NodeBase(object):
+class NodeBase:
     def __init__(
         self,
         debugName=None,
@@ -118,7 +118,7 @@ class NodePyOP(NodePy):
         self.kind = node_cpp.kind()
 
 
-class GraphPy(object):
+class GraphPy:
     """Helper class to convert torch.nn.Module to GraphDef proto and visualization
     with TensorBoard.
 

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -41,7 +41,7 @@ from .summary import (
 
 __all__ = ['FileWriter', 'SummaryWriter']
 
-class FileWriter(object):
+class FileWriter:
     """Writes protocol buffers to event files to be consumed by TensorBoard.
 
     The `FileWriter` class provides a mechanism to create an event file in a
@@ -164,7 +164,7 @@ class FileWriter(object):
         self.event_writer.reopen()
 
 
-class SummaryWriter(object):
+class SummaryWriter:
     """Writes entries directly to event files in the log_dir to be
     consumed by TensorBoard.
 

--- a/torch/utils/throughput_benchmark.py
+++ b/torch/utils/throughput_benchmark.py
@@ -24,7 +24,7 @@ def format_time(time_us=None, time_ms=None, time_s=None):
     return '{:.3f}us'.format(time_us)
 
 
-class ExecutionStats(object):
+class ExecutionStats:
     def __init__(self, c_stats, benchmark_config):
         self._c_stats = c_stats
         self.benchmark_config = benchmark_config
@@ -58,7 +58,7 @@ class ExecutionStats(object):
         ])
 
 
-class ThroughputBenchmark(object):
+class ThroughputBenchmark:
     '''
     This class is a wrapper around a c++ component throughput_benchmark::ThroughputBenchmark
     responsible for executing a PyTorch module (nn.Module or ScriptModule)


### PR DESCRIPTION
Apply parts of pyupgrade to torch (starting with the safest changes). 
This PR only does two things: removes the need to inherit from object and removes unused future imports.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5 @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire