### PR TITLE
[BE]: Apply pyupgrade yield from and unit test alias upgrades

### DIFF
--- a/caffe2/python/checkpoint_test.py
+++ b/caffe2/python/checkpoint_test.py
@@ -78,8 +78,8 @@ class TestCheckpoint(TestCase):
             session, checkpoint = builder()
             job.compile(LocalSession)
             num_epochs = JobRunner(job, checkpoint).train(session)
-            self.assertEquals(num_epochs, len(EXPECTED_TOTALS))
-            self.assertEquals(fetch_total(session), EXPECTED_TOTALS[-1])
+            self.assertEqual(num_epochs, len(EXPECTED_TOTALS))
+            self.assertEqual(fetch_total(session), EXPECTED_TOTALS[-1])
 
             for initial_epoch in range(1, num_epochs + 1):
                 session, checkpoint = builder()
@@ -87,11 +87,11 @@ class TestCheckpoint(TestCase):
                     job,
                     checkpoint, resume_from_epoch=initial_epoch
                 ).train(session)
-                self.assertEquals(fetch_total(session), EXPECTED_TOTALS[-1])
+                self.assertEqual(fetch_total(session), EXPECTED_TOTALS[-1])
 
             for epoch in range(1, num_epochs + 1):
                 session.run(checkpoint.load(epoch))
-                self.assertEquals(fetch_total(session),
+                self.assertEqual(fetch_total(session),
                                   EXPECTED_TOTALS[epoch - 1])
 
     def test_single_checkpoint(self):
@@ -141,7 +141,7 @@ class TestCheckpoint(TestCase):
                     epoch = 5
                     node_name = 'trainer_%d' % node_id
                     expected_db_name = tmpdir + '/' + node_name + '.5'
-                    self.assertEquals(
+                    self.assertEqual(
                         checkpoint.get_ckpt_db_name(node_name, epoch),
                         expected_db_name)
             shutil.rmtree(tmpdir)
@@ -159,15 +159,15 @@ class TestCheckpoint(TestCase):
                     job.compile(LocalSession)
                     job_runner = JobRunner(job, checkpoint)
                     num_epochs = job_runner.train(session)
-                self.assertEquals(num_epochs, len(EXPECTED_TOTALS))
+                self.assertEqual(num_epochs, len(EXPECTED_TOTALS))
 
                 # There are 17 global blobs after finishing up the job runner.
                 # (only blobs on init_group are checkpointed)
-                self.assertEquals(len(ws.blobs), 17)
+                self.assertEqual(len(ws.blobs), 17)
 
             ws = workspace.C.Workspace()
             session = LocalSession(ws)
-            self.assertEquals(len(ws.blobs), 0)
+            self.assertEqual(len(ws.blobs), 0)
             model_blob_names = ['trainer_1/task_2/GivenTensorInt64Fill:0',
                                 'trainer_2/task_2/GivenTensorInt64Fill:0']
             checkpoint = MultiNodeCheckpointManager(tmpdir, 'minidb')
@@ -190,7 +190,7 @@ class TestCheckpoint(TestCase):
                     # Check that all the model blobs are loaded.
                     for blob_name in model_blob_names:
                         self.assertTrue(ws.has_blob(blob_name))
-                        self.assertEquals(
+                        self.assertEqual(
                             ws.fetch_blob(blob_name),
                             np.array([EXPECTED_TOTALS[epoch - 1]]))
                 self.assertFalse(
@@ -227,7 +227,7 @@ class TestCheckpoint(TestCase):
                         job, checkpoint,
                         upload_task_group_builder=local_upload_builder)
                     num_epochs = job_runner.train(session)
-                    self.assertEquals(num_epochs, len(EXPECTED_TOTALS))
+                    self.assertEqual(num_epochs, len(EXPECTED_TOTALS))
 
             # The uploaded files should exist now.
             for node_id in range(num_nodes):
@@ -260,7 +260,7 @@ class TestCheckpoint(TestCase):
                 num_epochs = job_runner.train(session)
             # make sure all epochs are executed even though saving the checkpoint failed
             # Saving checkpoint failure should not cause job failure
-            self.assertEquals(num_epochs, len(EXPECTED_TOTALS))
+            self.assertEqual(num_epochs, len(EXPECTED_TOTALS))
 
     def test_download_group_simple(self):
         """
@@ -332,7 +332,7 @@ class TestCheckpoint(TestCase):
                     checkpoint,
                     resume_from_epoch=initial_epoch
                 ).train(session)
-                self.assertEquals(fetch_total(session), EXPECTED_TOTALS[-1])
+                self.assertEqual(fetch_total(session), EXPECTED_TOTALS[-1])
 
         finally:
             shutil.rmtree(tmpdir)

--- a/caffe2/python/core_test.py
+++ b/caffe2/python/core_test.py
@@ -459,13 +459,13 @@ class TestExtractPredictorNet(test_util.TestCase):
             self.assertFalse("xx/data" in op.input)
 
         # Note: image input should not be included
-        self.assertEquals(ops[0].type, "Conv")
-        self.assertEquals(ops[1].type, "FC")
-        self.assertEquals(ops[2].type, "FC")
-        self.assertEquals(len(ops), 3)
+        self.assertEqual(ops[0].type, "Conv")
+        self.assertEqual(ops[1].type, "FC")
+        self.assertEqual(ops[2].type, "FC")
+        self.assertEqual(len(ops), 3)
 
         # test rename happened
-        self.assertEquals(ops[0].input[0], "image")
+        self.assertEqual(ops[0].input[0], "image")
 
         # Check export blobs
         self.assertTrue("image" not in export_blobs)
@@ -474,7 +474,7 @@ class TestExtractPredictorNet(test_util.TestCase):
 
         # Check external inputs/outputs
         self.assertTrue("image" in predict_net.Proto().external_input)
-        self.assertEquals(set(["pred"]), set(predict_net.Proto().external_output))
+        self.assertEqual(set(["pred"]), set(predict_net.Proto().external_output))
         self.assertEqual(
             set(predict_net.Proto().external_input) -
             set([str(p) for p in model.params]), set(["image"])

--- a/caffe2/python/layer_parameter_sharing_test.py
+++ b/caffe2/python/layer_parameter_sharing_test.py
@@ -20,26 +20,26 @@ class ParameterSharingTest(LayersTestCase):
                 self.model.input_feature_schema.float_features,
                 output_dims
             )
-            self.assertEquals(self.model.layers[-1].w, 'global_scope/fc/w')
-            self.assertEquals(fc1_output(), 'global_scope/fc/output')
+            self.assertEqual(self.model.layers[-1].w, 'global_scope/fc/w')
+            self.assertEqual(fc1_output(), 'global_scope/fc/output')
 
             with scope.NameScope('nested_scope'):
                 fc2_output = self.model.FC(
                     fc1_output,
                     output_dims
                 )
-                self.assertEquals(self.model.layers[-1].w,
+                self.assertEqual(self.model.layers[-1].w,
                                   'global_scope/nested_scope/fc/w')
-                self.assertEquals(fc2_output(),
+                self.assertEqual(fc2_output(),
                                   'global_scope/nested_scope/fc/output')
 
                 fc3_output = self.model.FC(
                     fc1_output,
                     output_dims
                 )
-                self.assertEquals(self.model.layers[-1].w,
+                self.assertEqual(self.model.layers[-1].w,
                                   'global_scope/nested_scope/fc_auto_0/w')
-                self.assertEquals(fc3_output(),
+                self.assertEqual(fc3_output(),
                                   'global_scope/nested_scope/fc_auto_0/output')
 
     def test_layer_shared_parameter_name_different_namescopes(self):
@@ -51,9 +51,9 @@ class ParameterSharingTest(LayersTestCase):
                         self.model.input_feature_schema.float_features,
                         output_dims
                     )
-                    self.assertEquals(self.model.layers[-1].w,
+                    self.assertEqual(self.model.layers[-1].w,
                                       'global_scope/scope_0/fc/w')
-                    self.assertEquals(fc1_output(),
+                    self.assertEqual(fc1_output(),
                                       'global_scope/scope_0/fc/output')
 
                 with scope.NameScope('scope_1'):
@@ -61,9 +61,9 @@ class ParameterSharingTest(LayersTestCase):
                         self.model.input_feature_schema.float_features,
                         output_dims
                     )
-                    self.assertEquals(self.model.layers[-1].w,
+                    self.assertEqual(self.model.layers[-1].w,
                                       'global_scope/scope_0/fc/w')
-                    self.assertEquals(fc2_output(),
+                    self.assertEqual(fc2_output(),
                                       'global_scope/scope_1/fc/output')
 
     def test_layer_shared_parameter_name_within_same_namescope(self):
@@ -74,14 +74,14 @@ class ParameterSharingTest(LayersTestCase):
                     self.model.input_feature_schema.float_features,
                     output_dims
                 )
-                self.assertEquals(self.model.layers[-1].w,
+                self.assertEqual(self.model.layers[-1].w,
                                   'global_scope/fc/w')
 
                 self.model.FC(
                     self.model.input_feature_schema.float_features,
                     output_dims
                 )
-                self.assertEquals(self.model.layers[-1].w,
+                self.assertEqual(self.model.layers[-1].w,
                                   'global_scope/fc/w')
 
     def test_layer_shared_parameter_name_within_same_namescope_customized_name(self):
@@ -93,7 +93,7 @@ class ParameterSharingTest(LayersTestCase):
                     output_dims,
                     name='shared_fc'
                 )
-                self.assertEquals(self.model.layers[-1].w,
+                self.assertEqual(self.model.layers[-1].w,
                                   'global_scope/shared_fc/w')
 
                 self.model.FC(
@@ -101,7 +101,7 @@ class ParameterSharingTest(LayersTestCase):
                     output_dims,
                     name='new_fc'
                 )
-                self.assertEquals(self.model.layers[-1].w,
+                self.assertEqual(self.model.layers[-1].w,
                                   'global_scope/shared_fc/w')
 
     def test_layer_shared_parameter_name_different_shapes(self):
@@ -112,7 +112,7 @@ class ParameterSharingTest(LayersTestCase):
                     self.model.input_feature_schema.float_features,
                     output_dims
                 )
-                self.assertEquals(self.model.layers[-1].w,
+                self.assertEqual(self.model.layers[-1].w,
                                   'global_scope/fc/w')
 
                 with self.assertRaisesRegex(ValueError, 'Got inconsistent shapes .*'):
@@ -145,7 +145,7 @@ class ParameterSharingTest(LayersTestCase):
             op_outputs.extend(op.output)
 
         # only fill these parameter blobs once
-        self.assertEquals(
+        self.assertEqual(
             sorted(op_outputs),
             ['global_scope/shared_fc/b', 'global_scope/shared_fc/w']
         )

--- a/caffe2/python/layers_test.py
+++ b/caffe2/python/layers_test.py
@@ -424,7 +424,7 @@ class TestLayers(LayersTestCase):
         workspace.RunNetOnce(train_net.Proto())
         embedding_after_training = workspace.FetchBlob("sparse_lookup/w")
         # Verify row 0's value does not change after reset
-        self.assertEquals(embedding_after_training.all(), embedding_after_init.all())
+        self.assertEqual(embedding_after_training.all(), embedding_after_init.all())
 
 
     def testSparseLookupSumPooling(self):

--- a/caffe2/python/memonger_test.py
+++ b/caffe2/python/memonger_test.py
@@ -263,7 +263,7 @@ class MemongerTest(hu.HypothesisTestCase):
         device_crossers = device_blobs[caffe2_pb2.CPU].intersection(
             device_blobs[workspace.GpuDeviceType]
         )
-        self.assertEquals(device_crossers, set())
+        self.assertEqual(device_crossers, set())
 
     @given(input_dim=st.integers(min_value=4, max_value=4),
            output_dim=st.integers(min_value=4, max_value=4),

--- a/caffe2/python/modeling/parameter_sharing_test.py
+++ b/caffe2/python/modeling/parameter_sharing_test.py
@@ -19,56 +19,56 @@ class ParameterSharingTest(unittest.TestCase):
     def test_parameter_sharing_default_scopes(self):
         # Test no sharing default scopes
         param_1 = parameter_sharing_context.get_parameter_name('w')
-        self.assertEquals(param_1, 'w')
+        self.assertEqual(param_1, 'w')
         with scope.NameScope('scope'):
             param_2 = parameter_sharing_context.get_parameter_name('w')
-            self.assertEquals(param_2, 'scope/w')
+            self.assertEqual(param_2, 'scope/w')
             with scope.NameScope('scope_2'):
                 param_3 = parameter_sharing_context.get_parameter_name('w')
-                self.assertEquals(param_3, 'scope/scope_2/w')
+                self.assertEqual(param_3, 'scope/scope_2/w')
 
     def test_parameter_sharing_nested_scopes(self):
         # Test parameter sharing
         with scope.NameScope('global_scope'):
             with ParameterSharing({'model_b': 'model_a'}):
                 param_global = parameter_sharing_context.get_parameter_name('w')
-                self.assertEquals(param_global, 'global_scope/w')
+                self.assertEqual(param_global, 'global_scope/w')
                 # This scope is overridden to match 'model_a'
                 with scope.NameScope('model_b'):
                     with ParameterSharing({'shared_scope': ''}):
                         param_4 = parameter_sharing_context.get_parameter_name(
                             'w')
-                        self.assertEquals(param_4, 'global_scope/model_a/w')
+                        self.assertEqual(param_4, 'global_scope/model_a/w')
                         with scope.NameScope('shared_scope'):
                             param_5 = parameter_sharing_context.\
                                 get_parameter_name('w')
-                            self.assertEquals(param_5, 'global_scope/model_a/w')
+                            self.assertEqual(param_5, 'global_scope/model_a/w')
                 # This scope is supposed to have not sharing
                 with scope.NameScope('model_c'):
                     with ParameterSharing({'shared_scope': ''}):
                         param_4 = parameter_sharing_context.get_parameter_name(
                             'w')
-                        self.assertEquals(param_4, 'global_scope/model_c/w')
+                        self.assertEqual(param_4, 'global_scope/model_c/w')
                         with scope.NameScope('shared_scope'):
                             param_5 = parameter_sharing_context.\
                                 get_parameter_name('w')
-                            self.assertEquals(param_5, 'global_scope/model_c/w')
+                            self.assertEqual(param_5, 'global_scope/model_c/w')
 
     def test_parameter_sharing_subscopes(self):
         # Sharing only one of the subscopes
         with ParameterSharing({'global_scope/b': 'global_scope/a'}):
             with scope.NameScope('global_scope'):
                 param_6 = parameter_sharing_context.get_parameter_name('w')
-                self.assertEquals(param_6, 'global_scope/w')
+                self.assertEqual(param_6, 'global_scope/w')
                 with scope.NameScope('a'):
                     param_7 = parameter_sharing_context.get_parameter_name('w')
-                    self.assertEquals(param_7, 'global_scope/a/w')
+                    self.assertEqual(param_7, 'global_scope/a/w')
                 with scope.NameScope('b'):
                     param_8 = parameter_sharing_context.get_parameter_name('w')
-                    self.assertEquals(param_8, 'global_scope/a/w')
+                    self.assertEqual(param_8, 'global_scope/a/w')
                 with scope.NameScope('c'):
                     param_9 = parameter_sharing_context.get_parameter_name('w')
-                    self.assertEquals(param_9, 'global_scope/c/w')
+                    self.assertEqual(param_9, 'global_scope/c/w')
 
     def test_create_param(self):
         model = model_helper.ModelHelper(name="test")

--- a/caffe2/python/net_builder_test.py
+++ b/caffe2/python/net_builder_test.py
@@ -101,7 +101,7 @@ class TestNetBuilder(unittest.TestCase):
         ]
         for b, expected in expected:
             actual = ws.blobs[str(b)].fetch()
-            self.assertEquals(actual, expected)
+            self.assertEqual(actual, expected)
 
     def _expected_loop(self):
         total = 0
@@ -152,7 +152,7 @@ class TestNetBuilder(unittest.TestCase):
             result = final_output(total)
         with LocalSession() as session:
             session.run(task)
-            self.assertEquals(2, result.fetch())
+            self.assertEqual(2, result.fetch())
 
     def test_loops(self):
         with Task() as task:
@@ -162,7 +162,7 @@ class TestNetBuilder(unittest.TestCase):
             expected = self._expected_loop()
             actual = [o.fetch() for o in out_actual]
             for e, a in zip(expected, actual):
-                self.assertEquals(e, a)
+                self.assertEqual(e, a)
 
     def test_setup(self):
         with Task() as task:
@@ -184,9 +184,9 @@ class TestNetBuilder(unittest.TestCase):
             o7_2 = final_output(seven_2)
         with LocalSession() as session:
             session.run(task)
-            self.assertEquals(o6.fetch(), 6)
-            self.assertEquals(o7_1.fetch(), 7)
-            self.assertEquals(o7_2.fetch(), 7)
+            self.assertEqual(o6.fetch(), 6)
+            self.assertEqual(o7_1.fetch(), 7)
+            self.assertEqual(o7_2.fetch(), 7)
 
     def test_multi_instance_python_op(self):
         """
@@ -203,8 +203,8 @@ class TestNetBuilder(unittest.TestCase):
             PythonOpStats.num_instances = 0
             PythonOpStats.num_calls = 0
             session.run(task)
-            self.assertEquals(PythonOpStats.num_instances, 64)
-            self.assertEquals(PythonOpStats.num_calls, 256)
+            self.assertEqual(PythonOpStats.num_instances, 64)
+            self.assertEqual(PythonOpStats.num_calls, 256)
 
     def test_multi_instance(self):
         NUM_INSTANCES = 10
@@ -242,9 +242,9 @@ class TestNetBuilder(unittest.TestCase):
 
         with LocalSession() as session:
             session.run(tg)
-            self.assertEquals(total1.fetch(), NUM_INSTANCES * NUM_ITERS)
-            self.assertEquals(total2.fetch(), NUM_INSTANCES * (NUM_ITERS ** 2))
-            self.assertEquals(total3.fetch(), NUM_INSTANCES * (NUM_ITERS ** 2))
+            self.assertEqual(total1.fetch(), NUM_INSTANCES * NUM_ITERS)
+            self.assertEqual(total2.fetch(), NUM_INSTANCES * (NUM_ITERS ** 2))
+            self.assertEqual(total3.fetch(), NUM_INSTANCES * (NUM_ITERS ** 2))
 
     def test_if_net(self):
         with NetBuilder() as nb:
@@ -303,11 +303,11 @@ class TestNetBuilder(unittest.TestCase):
         y1_value = ws.blobs[str(y1)].fetch()
         y2_value = ws.blobs[str(y2)].fetch()
 
-        self.assertEquals(first_res_value, 1)
-        self.assertEquals(second_res_value, 2)
-        self.assertEquals(y0_value, 1000)
-        self.assertEquals(y1_value, 101)
-        self.assertEquals(y2_value, 108)
+        self.assertEqual(first_res_value, 1)
+        self.assertEqual(second_res_value, 2)
+        self.assertEqual(y0_value, 1000)
+        self.assertEqual(y1_value, 101)
+        self.assertEqual(y2_value, 108)
         self.assertTrue(str(local_blob) not in ws.blobs)
 
     def test_while_net(self):

--- a/caffe2/python/normalizer_test.py
+++ b/caffe2/python/normalizer_test.py
@@ -12,4 +12,4 @@ class TestNormalizerContext(LayersTestCase):
         bn = BatchNormalizer(momentum=0.1)
         with UseNormalizer({'BATCH': bn}):
             normalizer = NormalizerContext.current().get_normalizer('BATCH')
-            self.assertEquals(bn, normalizer)
+            self.assertEqual(bn, normalizer)

--- a/caffe2/python/operator_fp_exceptions_test.py
+++ b/caffe2/python/operator_fp_exceptions_test.py
@@ -33,7 +33,7 @@ class OperatorFPExceptionsTest(TestCase):
                 workspace.RunNetOnce(net)
             except Exception as e:
                 exception_raised = True
-            self.assertEquals(exception_raised, throw_if_fp_exceptions)
+            self.assertEqual(exception_raised, throw_if_fp_exceptions)
 
 
 if __name__ == '__main__':

--- a/caffe2/python/operator_test/async_net_barrier_test.py
+++ b/caffe2/python/operator_test/async_net_barrier_test.py
@@ -25,7 +25,7 @@ class TestAsyncNetBarrierOp(hu.HypothesisTestCase):
         )
 
         def reference_func(*args):
-            self.assertEquals(len(args), n)
+            self.assertEqual(len(args), n)
             return args
 
         self.assertReferenceChecks(gc, barrier_op, test_inputs, reference_func)

--- a/caffe2/python/operator_test/atomic_ops_test.py
+++ b/caffe2/python/operator_test/atomic_ops_test.py
@@ -46,7 +46,7 @@ class TestAtomicOps(TestCase):
         plan.AddStep(super_step)
         workspace.RunPlan(plan)
         # checksum = sum[i=1..20000](i) = 20000 * 20001 / 2 = 200010000
-        self.assertEquals(workspace.FetchBlob(checksum), 200010000)
+        self.assertEqual(workspace.FetchBlob(checksum), 200010000)
 
     @unittest.skip("Test is flaky: https://github.com/pytorch/pytorch/issues/28179")
     def test_atomic64_ops(self):
@@ -85,7 +85,7 @@ class TestAtomicOps(TestCase):
         plan.AddStep(super_step)
         workspace.RunPlan(plan)
         # checksum = sum[i=1..20000](i) = 20000 * 20001 / 2 = 200010000
-        self.assertEquals(workspace.FetchBlob(checksum), 200010000)
+        self.assertEqual(workspace.FetchBlob(checksum), 200010000)
 
 if __name__ == "__main__":
     unittest.main()

--- a/caffe2/python/operator_test/dataset_ops_test.py
+++ b/caffe2/python/operator_test/dataset_ops_test.py
@@ -264,8 +264,8 @@ class TestDatasetOps(TestCase):
         ]
         zipped = zip(expected_fields, schema.field_names(), schema.field_types())
         for (ref_name, ref_type), name, dtype in zipped:
-            self.assertEquals(ref_name, name)
-            self.assertEquals(np.dtype(ref_type), dtype)
+            self.assertEqual(ref_name, name)
+            self.assertEqual(np.dtype(ref_type), dtype)
         """
         2. The contents of our dataset.
 
@@ -447,7 +447,7 @@ class TestDatasetOps(TestCase):
         """
         subschema = Struct(("top_level", schema.int_lists.values))
         int_list_contents = contents.int_lists.values.field_names()
-        self.assertEquals(len(subschema.field_names()), len(int_list_contents))
+        self.assertEqual(len(subschema.field_names()), len(int_list_contents))
         """
         7. Random Access a dataset
 
@@ -474,7 +474,7 @@ class TestDatasetOps(TestCase):
             actual = FetchRecord(batch)
             _assert_records_equal(actual, entry)
         workspace.RunNet(str(read_next_net))
-        self.assertEquals(True, workspace.FetchBlob(should_stop))
+        self.assertEqual(True, workspace.FetchBlob(should_stop))
         """
         8. Random Access a dataset with loop_over = true
 
@@ -496,7 +496,7 @@ class TestDatasetOps(TestCase):
 
         for _ in range(len(entries) * 3):
             workspace.RunNet(str(read_next_net))
-            self.assertEquals(False, workspace.FetchBlob(should_stop))
+            self.assertEqual(False, workspace.FetchBlob(should_stop))
         """
         9. Sort and shuffle a dataset
 
@@ -536,7 +536,7 @@ class TestDatasetOps(TestCase):
         trimmed = FetchRecord(ds.content())
         EXPECTED_SIZES = [2, 2, 3, 3, 2, 2, 2, 6, 2, 3, 3, 4, 4, 2, 2, 2]
         actual_sizes = [d.shape[0] for d in trimmed.field_blobs()]
-        self.assertEquals(EXPECTED_SIZES, actual_sizes)
+        self.assertEqual(EXPECTED_SIZES, actual_sizes)
 
     def test_last_n_window_ops(self):
         collect_net = core.Net("collect_net")

--- a/caffe2/python/operator_test/hsm_test.py
+++ b/caffe2/python/operator_test/hsm_test.py
@@ -119,7 +119,7 @@ class TestHsm(hu.HypothesisTestCase):
         for i in range(names.shape[0]):
             for j in range(names.shape[1]):
                 if names[i][j]:
-                    self.assertEquals(
+                    self.assertEqual(
                         names[i][j], p_names[i][j].item().encode('utf-8'))
                     self.assertAlmostEqual(
                         scores[i][j], p_scores[i][j], delta=0.001)

--- a/caffe2/python/operator_test/index_ops_test.py
+++ b/caffe2/python/operator_test/index_ops_test.py
@@ -56,7 +56,7 @@ class TestIndexOps(TestCase):
             ['index'],
             ['index_size']))
         size = workspace.FetchBlob('index_size')
-        self.assertEquals(size, 6)
+        self.assertEqual(size, 6)
 
         workspace.RunOperatorOnce(core.CreateOperator(
             'IndexStore',
@@ -89,7 +89,7 @@ class TestIndexOps(TestCase):
             ['index2'],
             ['index2_size']))
         index2_size = workspace.FetchBlob('index2_size')
-        self.assertEquals(index2_size, 5)
+        self.assertEqual(index2_size, 5)
 
         # test serde
         with tempfile.NamedTemporaryFile() as tmp:

--- a/caffe2/python/operator_test/pack_ops_test.py
+++ b/caffe2/python/operator_test/pack_ops_test.py
@@ -300,7 +300,7 @@ class TestTensorPackOps(serial.SerializedTestCase):
 
         output = workspace.FetchBlob('t')
         expected_output_shape = (3, 3, 2)
-        self.assertEquals(output.shape, expected_output_shape)
+        self.assertEqual(output.shape, expected_output_shape)
 
         presence_mask = workspace.FetchBlob('p')
         expected_presence_mask = np.array(
@@ -323,7 +323,7 @@ class TestTensorPackOps(serial.SerializedTestCase):
 
         output = workspace.FetchBlob('p')
         expected_output_shape = (0, 0)
-        self.assertEquals(output.shape, expected_output_shape)
+        self.assertEqual(output.shape, expected_output_shape)
 
     @given(**hu.gcs_cpu_only)
     @settings(deadline=10000)

--- a/caffe2/python/operator_test/rebatching_queue_test.py
+++ b/caffe2/python/operator_test/rebatching_queue_test.py
@@ -51,7 +51,7 @@ class TestReBatchingQueue(TestCase):
         workspace.RunNetOnce(net)
 
         for idx in range(3):
-            self.assertEquals(workspace.FetchBlob(results[idx]), [1.0])
+            self.assertEqual(workspace.FetchBlob(results[idx]), [1.0])
 
     def test_rebatching_queue_multi_enqueue_dequeue(self):
         net = core.Net('net')
@@ -280,7 +280,7 @@ class TestReBatchingQueue(TestCase):
         # We check that the outputs are a permutation of inputs
         inputs.sort()
         outputs.sort()
-        self.assertEquals(inputs, outputs)
+        self.assertEqual(inputs, outputs)
 
 
 if __name__ == "__main__":

--- a/caffe2/python/operator_test/shape_inference_test.py
+++ b/caffe2/python/operator_test/shape_inference_test.py
@@ -26,13 +26,13 @@ class TestShapeInference(test_util.TestCase):
                 {'data': [b, 96]}
             )
 
-            self.assertEquals(shapes['data'], [b, 96])
-            self.assertEquals(shapes['fc1_w'], [32, 96])
-            self.assertEquals(shapes['fc1_b'], [32])
-            self.assertEquals(shapes['fc1'], [b, 32])
-            self.assertEquals(shapes['fc2_w'], [55, 32])
-            self.assertEquals(shapes['fc2_b'], [55])
-            self.assertEquals(shapes['fc2'], [b, 55])
+            self.assertEqual(shapes['data'], [b, 96])
+            self.assertEqual(shapes['fc1_w'], [32, 96])
+            self.assertEqual(shapes['fc1_b'], [32])
+            self.assertEqual(shapes['fc1'], [b, 32])
+            self.assertEqual(shapes['fc2_w'], [55, 32])
+            self.assertEqual(shapes['fc2_b'], [55])
+            self.assertEqual(shapes['fc2'], [b, 55])
 
     def testFCAxis2(self):
         model = model_helper.ModelHelper(name="test_model")

--- a/caffe2/python/operator_test/stats_put_ops_test.py
+++ b/caffe2/python/operator_test/stats_put_ops_test.py
@@ -37,9 +37,9 @@ class TestPutOps(TestCase):
 
         self.assertIn(stat_name + sum_postfix, stat_dict)
         self.assertIn(stat_name + count_postfix, stat_dict)
-        self.assertEquals(stat_dict[stat_name + sum_postfix],
+        self.assertEqual(stat_dict[stat_name + sum_postfix],
          default_value * magnitude_expand)
-        self.assertEquals(stat_dict[stat_name + count_postfix], 1)
+        self.assertEqual(stat_dict[stat_name + count_postfix], 1)
 
     def test_clamp(self):
         put_value = 10
@@ -68,9 +68,9 @@ class TestPutOps(TestCase):
 
         self.assertIn(stat_name + sum_postfix, stat_dict)
         self.assertIn(stat_name + count_postfix, stat_dict)
-        self.assertEquals(stat_dict[stat_name + sum_postfix],
+        self.assertEqual(stat_dict[stat_name + sum_postfix],
             9223372036854775807)
-        self.assertEquals(stat_dict[stat_name + count_postfix], 1)
+        self.assertEqual(stat_dict[stat_name + count_postfix], 1)
 
     def test_clamp_with_out_of_bounds(self):
         put_value = float(1e20)
@@ -99,9 +99,9 @@ class TestPutOps(TestCase):
 
         self.assertIn(stat_name + sum_postfix, stat_dict)
         self.assertIn(stat_name + count_postfix, stat_dict)
-        self.assertEquals(stat_dict[stat_name + sum_postfix],
+        self.assertEqual(stat_dict[stat_name + sum_postfix],
             9223372036854775807)
-        self.assertEquals(stat_dict[stat_name + count_postfix], 1)
+        self.assertEqual(stat_dict[stat_name + count_postfix], 1)
 
     def test_avg_put_ops(self):
         put_value = 15.1111
@@ -129,9 +129,9 @@ class TestPutOps(TestCase):
 
         self.assertIn(stat_name + sum_postfix, stat_dict)
         self.assertIn(stat_name + count_postfix, stat_dict)
-        self.assertEquals(stat_dict[stat_name + sum_postfix],
+        self.assertEqual(stat_dict[stat_name + sum_postfix],
          put_value * magnitude_expand)
-        self.assertEquals(stat_dict[stat_name + count_postfix], 1)
+        self.assertEqual(stat_dict[stat_name + count_postfix], 1)
 
     def test_increment_put_ops(self):
         put_value = 15.1111
@@ -157,7 +157,7 @@ class TestPutOps(TestCase):
         stat_dict = dict(zip(k, v))
 
         self.assertIn(stat_name + member_postfix, stat_dict)
-        self.assertEquals(stat_dict[stat_name + member_postfix],
+        self.assertEqual(stat_dict[stat_name + member_postfix],
          put_value * magnitude_expand)
 
     def test_stddev_put_ops(self):
@@ -190,6 +190,6 @@ class TestPutOps(TestCase):
         self.assertIn(stat_name + count_postfix, stat_dict)
         self.assertIn(stat_name + sumoffset_postfix, stat_dict)
         self.assertIn(stat_name + sumsqoffset_postfix, stat_dict)
-        self.assertEquals(stat_dict[stat_name + sum_postfix],
+        self.assertEqual(stat_dict[stat_name + sum_postfix],
             put_value * magnitude_expand)
-        self.assertEquals(stat_dict[stat_name + count_postfix], 1)
+        self.assertEqual(stat_dict[stat_name + count_postfix], 1)

--- a/caffe2/python/operator_test/unsafe_coalesce_test.py
+++ b/caffe2/python/operator_test/unsafe_coalesce_test.py
@@ -27,7 +27,7 @@ class TestUnsafeCoalesceOp(hu.HypothesisTestCase):
         )
 
         def reference_func(*args):
-            self.assertEquals(len(args), n)
+            self.assertEqual(len(args), n)
             return list(args) + [np.concatenate([x.flatten() for x in args])]
 
         self.assertReferenceChecks(gc, coalesce_op, test_inputs, reference_func)

--- a/caffe2/python/pipeline_test.py
+++ b/caffe2/python/pipeline_test.py
@@ -70,7 +70,7 @@ class TestPipeline(TestCase):
         output = FetchRecord(dst_blobs, ws=ws)
         num_dequeues = ws.blobs[str(counter)].fetch()
 
-        self.assertEquals(
+        self.assertEqual(
             num_dequeues, int(math.ceil(float(N) / NUM_DEQUEUE_RECORDS)))
 
         for a, b in zip(output.field_blobs(), expected_dst.field_blobs()):

--- a/caffe2/python/schema_test.py
+++ b/caffe2/python/schema_test.py
@@ -82,7 +82,7 @@ class TestDB(unittest.TestCase):
 
     def testNormalizeField(self):
         s = schema.Struct(('field1', np.int32), ('field2', str))
-        self.assertEquals(
+        self.assertEqual(
             s,
             schema.Struct(
                 ('field1', schema.Scalar(dtype=np.int32)),
@@ -97,11 +97,11 @@ class TestDB(unittest.TestCase):
             ('field_1', schema.Scalar(dtype=np.str)),
             ('field_2', schema.Scalar(dtype=np.float32))
         )
-        self.assertEquals(s, s2)
-        self.assertEquals(s[0], schema.Scalar(dtype=np.int32))
-        self.assertEquals(s[1], schema.Scalar(dtype=np.str))
-        self.assertEquals(s[2], schema.Scalar(dtype=np.float32))
-        self.assertEquals(
+        self.assertEqual(s, s2)
+        self.assertEqual(s[0], schema.Scalar(dtype=np.int32))
+        self.assertEqual(s[1], schema.Scalar(dtype=np.str))
+        self.assertEqual(s[2], schema.Scalar(dtype=np.float32))
+        self.assertEqual(
             s[2, 0],
             schema.Struct(
                 ('field_2', schema.Scalar(dtype=np.float32)),
@@ -110,19 +110,19 @@ class TestDB(unittest.TestCase):
         )
         # test iterator behavior
         for i, (v1, v2) in enumerate(zip(s, s2)):
-            self.assertEquals(v1, v2)
-            self.assertEquals(s[i], v1)
-            self.assertEquals(s2[i], v1)
+            self.assertEqual(v1, v2)
+            self.assertEqual(s[i], v1)
+            self.assertEqual(s2[i], v1)
 
     def testRawTuple(self):
         s = schema.RawTuple(2)
-        self.assertEquals(
+        self.assertEqual(
             s, schema.Struct(
                 ('field_0', schema.Scalar()), ('field_1', schema.Scalar())
             )
         )
-        self.assertEquals(s[0], schema.Scalar())
-        self.assertEquals(s[1], schema.Scalar())
+        self.assertEqual(s[0], schema.Scalar())
+        self.assertEqual(s[1], schema.Scalar())
 
     def testStructIndexing(self):
         s = schema.Struct(
@@ -130,10 +130,10 @@ class TestDB(unittest.TestCase):
             ('field2', schema.List(schema.Scalar(dtype=str))),
             ('field3', schema.Struct()),
         )
-        self.assertEquals(s['field2'], s.field2)
-        self.assertEquals(s['field2'], schema.List(schema.Scalar(dtype=str)))
-        self.assertEquals(s['field3'], schema.Struct())
-        self.assertEquals(
+        self.assertEqual(s['field2'], s.field2)
+        self.assertEqual(s['field2'], schema.List(schema.Scalar(dtype=str)))
+        self.assertEqual(s['field3'], schema.Struct())
+        self.assertEqual(
             s['field2', 'field1'],
             schema.Struct(
                 ('field2', schema.List(schema.Scalar(dtype=str))),
@@ -147,8 +147,8 @@ class TestDB(unittest.TestCase):
             ('field1', schema.Scalar(dtype=np.int32)),
             ('field2', a)
         )
-        self.assertEquals(s['field2:lengths'], a.lengths)
-        self.assertEquals(s['field2:values'], a.items)
+        self.assertEqual(s['field2:lengths'], a.lengths)
+        self.assertEqual(s['field2:values'], a.items)
         with self.assertRaises(KeyError):
             s['fields2:items:non_existent']
         with self.assertRaises(KeyError):
@@ -160,9 +160,9 @@ class TestDB(unittest.TestCase):
             ('field1', schema.Scalar(dtype=np.int32)),
             ('field2', a)
         )
-        self.assertEquals(s['field2:lengths'], a.lengths)
-        self.assertEquals(s['field2:values'], a.items)
-        self.assertEquals(s['field2:_evicted_values'], a._evicted_values)
+        self.assertEqual(s['field2:lengths'], a.lengths)
+        self.assertEqual(s['field2:values'], a.items)
+        self.assertEqual(s['field2:_evicted_values'], a._evicted_values)
         with self.assertRaises(KeyError):
             s['fields2:items:non_existent']
         with self.assertRaises(KeyError):
@@ -177,8 +177,8 @@ class TestDB(unittest.TestCase):
             ('field1', schema.Scalar(dtype=np.int32)),
             ('field2', a)
         )
-        self.assertEquals(s['field2:values:keys'], a.keys)
-        self.assertEquals(s['field2:values:values'], a.values)
+        self.assertEqual(s['field2:values:keys'], a.keys)
+        self.assertEqual(s['field2:values:values'], a.values)
         with self.assertRaises(KeyError):
             s['fields2:keys:non_existent']
 

--- a/caffe2/python/scope_test.py
+++ b/caffe2/python/scope_test.py
@@ -35,69 +35,69 @@ def thread_runner(idx, testobj):
 class TestScope(unittest.TestCase):
 
     def testNamescopeBasic(self):
-        self.assertEquals(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentNameScope(), "")
 
         with scope.NameScope("test_scope"):
-            self.assertEquals(scope.CurrentNameScope(), "test_scope/")
+            self.assertEqual(scope.CurrentNameScope(), "test_scope/")
 
-        self.assertEquals(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentNameScope(), "")
 
     def testNamescopeAssertion(self):
-        self.assertEquals(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentNameScope(), "")
 
         try:
             with scope.NameScope("test_scope"):
-                self.assertEquals(scope.CurrentNameScope(), "test_scope/")
+                self.assertEqual(scope.CurrentNameScope(), "test_scope/")
                 raise Exception()
         except Exception:
             pass
 
-        self.assertEquals(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentNameScope(), "")
 
     def testEmptyNamescopeBasic(self):
-        self.assertEquals(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentNameScope(), "")
 
         with scope.NameScope("test_scope"):
             with scope.EmptyNameScope():
-                self.assertEquals(scope.CurrentNameScope(), "")
-            self.assertEquals(scope.CurrentNameScope(), "test_scope/")
+                self.assertEqual(scope.CurrentNameScope(), "")
+            self.assertEqual(scope.CurrentNameScope(), "test_scope/")
 
     def testDevicescopeBasic(self):
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
         dsc = core.DeviceOption(workspace.GpuDeviceType, 9)
         with scope.DeviceScope(dsc):
-            self.assertEquals(scope.CurrentDeviceScope(), dsc)
+            self.assertEqual(scope.CurrentDeviceScope(), dsc)
 
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
     def testEmptyDevicescopeBasic(self):
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
         dsc = core.DeviceOption(workspace.GpuDeviceType, 9)
         with scope.DeviceScope(dsc):
-            self.assertEquals(scope.CurrentDeviceScope(), dsc)
+            self.assertEqual(scope.CurrentDeviceScope(), dsc)
             with scope.EmptyDeviceScope():
-                self.assertEquals(scope.CurrentDeviceScope(), None)
-            self.assertEquals(scope.CurrentDeviceScope(), dsc)
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+                self.assertEqual(scope.CurrentDeviceScope(), None)
+            self.assertEqual(scope.CurrentDeviceScope(), dsc)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
     def testDevicescopeAssertion(self):
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
         dsc = core.DeviceOption(workspace.GpuDeviceType, 9)
 
         try:
             with scope.DeviceScope(dsc):
-                self.assertEquals(scope.CurrentDeviceScope(), dsc)
+                self.assertEqual(scope.CurrentDeviceScope(), dsc)
                 raise Exception()
         except Exception:
             pass
 
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
     def testTags(self):
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
         extra_info1 = ["key1:value1"]
         extra_info2 = ["key2:value2"]
@@ -107,19 +107,19 @@ class TestScope(unittest.TestCase):
         extra_info_1_2_3 = ["key1:value1", "key2:value2", "key3:value3"]
 
         with scope.DeviceScope(core.DeviceOption(0, extra_info=extra_info1)):
-            self.assertEquals(scope.CurrentDeviceScope().extra_info, extra_info1)
+            self.assertEqual(scope.CurrentDeviceScope().extra_info, extra_info1)
 
             with scope.DeviceScope(core.DeviceOption(0, extra_info=extra_info2)):
-                self.assertEquals(scope.CurrentDeviceScope().extra_info, extra_info_1_2)
+                self.assertEqual(scope.CurrentDeviceScope().extra_info, extra_info_1_2)
 
                 with scope.DeviceScope(core.DeviceOption(0, extra_info=extra_info3)):
-                    self.assertEquals(
+                    self.assertEqual(
                         scope.CurrentDeviceScope().extra_info, extra_info_1_2_3
                     )
 
-                self.assertEquals(scope.CurrentDeviceScope().extra_info, extra_info_1_2)
-            self.assertEquals(scope.CurrentDeviceScope().extra_info, extra_info1)
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+                self.assertEqual(scope.CurrentDeviceScope().extra_info, extra_info_1_2)
+            self.assertEqual(scope.CurrentDeviceScope().extra_info, extra_info1)
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
     def testMultiThreaded(self):
         """
@@ -127,8 +127,8 @@ class TestScope(unittest.TestCase):
         and don't interfere
         """
         global SUCCESS_COUNT
-        self.assertEquals(scope.CurrentNameScope(), "")
-        self.assertEquals(scope.CurrentDeviceScope(), None)
+        self.assertEqual(scope.CurrentNameScope(), "")
+        self.assertEqual(scope.CurrentDeviceScope(), None)
 
         threads = []
         for i in range(4):
@@ -140,13 +140,13 @@ class TestScope(unittest.TestCase):
             t.start()
 
         with scope.NameScope("master"):
-            self.assertEquals(scope.CurrentDeviceScope(), None)
-            self.assertEquals(scope.CurrentNameScope(), "master/")
+            self.assertEqual(scope.CurrentDeviceScope(), None)
+            self.assertEqual(scope.CurrentNameScope(), "master/")
             for t in threads:
                 t.join()
 
-            self.assertEquals(scope.CurrentNameScope(), "master/")
-            self.assertEquals(scope.CurrentDeviceScope(), None)
+            self.assertEqual(scope.CurrentNameScope(), "master/")
+            self.assertEqual(scope.CurrentDeviceScope(), None)
 
         # Ensure all threads succeeded
-        self.assertEquals(SUCCESS_COUNT, 4)
+        self.assertEqual(SUCCESS_COUNT, 4)

--- a/caffe2/python/transformations_test.py
+++ b/caffe2/python/transformations_test.py
@@ -44,7 +44,7 @@ class TestTransformations(tu.TestCase):
     expected_activation_arg=True):
         self._add_nnpack(net)
         transformer.FuseNNPACKConvRelu(net)
-        self.assertEquals(tu.numOps(net), expected_result_num_ops)
+        self.assertEqual(tu.numOps(net), expected_result_num_ops)
         has_activation_arg = False
         for arg in net.Proto().op[0].arg:
             if tu.str_compare(arg.name, "activation"):

--- a/caffe2/python/tt_core_test.py
+++ b/caffe2/python/tt_core_test.py
@@ -52,7 +52,7 @@ class TestTTSVD(hu.HypothesisTestCase):
         Y_full_tt = workspace.FetchBlob("Y").flatten()
 
         assert(len(Y_fc) == len(Y_full_tt))
-        self.assertAlmostEquals(np.linalg.norm(Y_fc - Y_full_tt), 0, delta=1e-3)
+        self.assertAlmostEqual(np.linalg.norm(Y_fc - Y_full_tt), 0, delta=1e-3)
 
         # Testing TT-decomposition with minimal ranks
         sparse_tt_ranks = [1, 1, 1, 1, 1]
@@ -74,7 +74,7 @@ class TestTTSVD(hu.HypothesisTestCase):
         Y_sparse_tt = workspace.FetchBlob("Y").flatten()
 
         assert(len(Y_fc) == len(Y_sparse_tt))
-        self.assertAlmostEquals(np.linalg.norm(Y_fc - Y_sparse_tt),
+        self.assertAlmostEqual(np.linalg.norm(Y_fc - Y_sparse_tt),
                                 39.974, delta=1e-3)
 
 

--- a/caffe2/python/workspace_test.py
+++ b/caffe2/python/workspace_test.py
@@ -134,13 +134,13 @@ class TestWorkspace(unittest.TestCase):
         """ feed (copy) data into tensor """
         val = np.array([[b"abc", b"def"], [b"ghi", b"jkl"]], dtype=np.object)
         tensor.feed(val)
-        self.assertEquals(tensor.data[0, 0], b"abc")
+        self.assertEqual(tensor.data[0, 0], b"abc")
         np.testing.assert_array_equal(ws.blobs["tensor"].fetch(), val)
 
         val = np.array([1.1, 10.2])
         tensor.feed(val)
         val[0] = 5.2
-        self.assertEquals(tensor.data[0], 1.1)
+        self.assertEqual(tensor.data[0], 1.1)
 
         """ fetch (copy) data from tensor """
         val = np.array([1.1, 1.2])
@@ -149,7 +149,7 @@ class TestWorkspace(unittest.TestCase):
         tensor.data[0] = 5.2
         val3 = tensor.fetch()
         np.testing.assert_array_equal(val, val2)
-        self.assertEquals(val3[0], 5.2)
+        self.assertEqual(val3[0], 5.2)
 
     def testFetchFeedBlob(self):
         self.assertEqual(
@@ -294,8 +294,8 @@ class TestWorkspace(unittest.TestCase):
         workspace.FeedBlob("s1", s1)
         workspace.FeedBlob("s2", s2)
         fetch1, fetch2 = workspace.FetchBlobs(["s1", "s2"])
-        self.assertEquals(s1, fetch1)
-        self.assertEquals(s2, fetch2)
+        self.assertEqual(s1, fetch1)
+        self.assertEqual(s2, fetch2)
 
     def testFetchFeedViaBlobDict(self):
         self.assertEqual(

--- a/test/distributed/_tensor/test_view_ops.py
+++ b/test/distributed/_tensor/test_view_ops.py
@@ -30,18 +30,18 @@ from torch.utils._pytree import tree_flatten
 
 class TestViewOps(DTensorTestBase):
     def test_view_groups(self):
-        self.assertEquals(
+        self.assertEqual(
             view_groups([2, 3], [3, 2]),
             (
                 Split(Flatten((InputDim(0), InputDim(1))), (3, 2), 0),
                 Split(Flatten((InputDim(0), InputDim(1))), (3, 2), 1),
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             view_groups([3, 4, 5], [12, 5]),
             (Flatten((InputDim(0), InputDim(1))), InputDim(2)),
         )
-        self.assertEquals(
+        self.assertEqual(
             view_groups([2, 3, 4, 5, 7], [12, 70]),
             (
                 Split(
@@ -72,7 +72,7 @@ class TestViewOps(DTensorTestBase):
                 ),
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             view_groups([2, 3, 4, 5, 7], [3, 8, 7, 5]),
             (
                 Split(Flatten((InputDim(0), InputDim(1), InputDim(2))), (3, 8), 0),
@@ -81,7 +81,7 @@ class TestViewOps(DTensorTestBase):
                 Split(Flatten((InputDim(3), InputDim(4))), (7, 5), 1),
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             view_groups([3, 4, 8, 3], [12, 4, 2, 3]),
             (
                 Flatten((InputDim(0), InputDim(1))),
@@ -90,7 +90,7 @@ class TestViewOps(DTensorTestBase):
                 InputDim(3),
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             view_groups([3, 24], [1, 3, 2, 4, 1, 3, 1]),
             (
                 Singleton(),
@@ -102,7 +102,7 @@ class TestViewOps(DTensorTestBase):
                 Singleton(),
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             view_groups([1, 1, 3, 2, 1, 1], [6, 1, 1, 1]),
             (
                 Flatten((InputDim(2), InputDim(3))),
@@ -111,7 +111,7 @@ class TestViewOps(DTensorTestBase):
                 Singleton(),
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             view_groups([1, 1, 12, 1, 1, 1, 2, 5, 1], [3, 4, 1, 10]),
             (
                 Split(InputDim(2), (3, 4), 0),
@@ -120,7 +120,7 @@ class TestViewOps(DTensorTestBase):
                 Flatten((InputDim(6), InputDim(7))),
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             view_groups([2, 3, 4], [2, -1, 4]),
             (InputDim(0), InputDim(1), InputDim(2)),
         )
@@ -180,7 +180,7 @@ class TestViewOps(DTensorTestBase):
 
     def dimmap_test(self, op, args, expected_rule_output):
         rules = ops[op].dim_map(*args)
-        self.assertEquals(rules, expected_rule_output)
+        self.assertEqual(rules, expected_rule_output)
         self.call_dt_test(op, args, {}, self.device_mesh)
 
     @with_comms

--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -189,8 +189,8 @@ class SimpleElasticAgentTest(unittest.TestCase):
         spec = self._get_worker_spec(max_restarts=1)
         agent = TestAgent(spec)
         worker_group = agent.get_worker_group()
-        self.assertEquals(WorkerState.INIT, worker_group.state)
-        self.assertEquals(spec.max_restarts, agent._remaining_restarts)
+        self.assertEqual(WorkerState.INIT, worker_group.state)
+        self.assertEqual(spec.max_restarts, agent._remaining_restarts)
 
     @patch("torch.distributed.elastic.agent.server.api.put_metric")
     def test_record_flakiness_metric(self, put_metric_mock):
@@ -398,7 +398,7 @@ class SimpleElasticAgentTest(unittest.TestCase):
         agent.run()
 
         # no failure, no membership changes -> no retries
-        self.assertEquals(max_restarts, agent._remaining_restarts)
+        self.assertEqual(max_restarts, agent._remaining_restarts)
         record_events_mock.assert_called_once()
 
     @patch.object(TestAgent, "_initialize_workers", side_effect=RuntimeError())
@@ -450,7 +450,7 @@ class SimpleElasticAgentTest(unittest.TestCase):
         worker_group = agent._worker_group
 
         agent.run()
-        self.assertEquals(WorkerState.SUCCEEDED, worker_group.state)
+        self.assertEqual(WorkerState.SUCCEEDED, worker_group.state)
         record_events_mock.assert_called_once()
 
     @patch.object(
@@ -482,8 +482,8 @@ class SimpleElasticAgentTest(unittest.TestCase):
         )
         agent = TestAgent(spec)
         total_sum, ranks = agent._get_ranks(role_infos, 0, 0, len(role_infos))
-        self.assertEquals(15, total_sum)
-        self.assertEquals([0, 1, 2, 3], list(ranks))
+        self.assertEqual(15, total_sum)
+        self.assertEqual([0, 1, 2, 3], list(ranks))
 
     def test_assign_worker_ranks(self):
         role_infos = [

--- a/test/distributed/fsdp/test_fsdp_traversal.py
+++ b/test/distributed/fsdp/test_fsdp_traversal.py
@@ -38,7 +38,7 @@ class TestTraversal(FSDPTest):
             CUDAInitMode.CUDA_BEFORE,
         )
         modules = FSDP.fsdp_modules(nested_wrapped_module)
-        self.assertEquals(
+        self.assertEqual(
             modules,
             [
                 nested_wrapped_module.module.get_submodule("1"),

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2959,7 +2959,7 @@ class TestComposability(TestCase):
             [sys.executable, "-W", "all", "-c", "import functorch"],
             stderr=subprocess.STDOUT,
             cwd=os.path.dirname(os.path.realpath(__file__)),).decode("utf-8")
-        self.assertEquals(out, "")
+        self.assertEqual(out, "")
 
     def test_requires_grad_inside_transform(self, device):
         def f(x):

--- a/test/fx/test_fx_const_fold.py
+++ b/test/fx/test_fx_const_fold.py
@@ -703,7 +703,7 @@ class TestConstFold(TestCase):
         for n in mod_folded.graph.nodes:
             if n.op == "get_attr":
                 attr = self._get_attr(n)
-                self.assertEquals(_extract_tensor_metadata(attr), n.meta["tensor_meta"])
+                self.assertEqual(_extract_tensor_metadata(attr), n.meta["tensor_meta"])
 
         # Now run both folded and non-folded to check results equal.
         base_result = mod(in_x, in_y)

--- a/test/fx/test_z3_gradual_types.py
+++ b/test/fx/test_z3_gradual_types.py
@@ -307,7 +307,7 @@ class HFOperations(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         expand_res = z3.Const(4, tensor_type)
         assert s.model()[expand_res].arg(0).arg(1) == b.shape[0]
         assert s.model()[expand_res].arg(1).arg(1) == b.shape[1]
@@ -322,7 +322,7 @@ class HFOperations(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         assert s.model()[expand_res].arg(1).arg(1) == b.shape[1]
 
@@ -343,7 +343,7 @@ class HFOperations(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         get_item_res = z3.Const(2, tensor_type)
         assert s.model()[get_item_res].arg(0).arg(1) == b.shape[0]
         assert s.model()[get_item_res].arg(1).arg(1) == b.shape[1]
@@ -380,7 +380,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(symbolic_traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         get_item_res = z3.Const(2, tensor_type)
         assert s.model()[get_item_res].arg(0).arg(1) == b.shape[0]
         assert s.model()[get_item_res].arg(1).arg(1) == b.shape[1]
@@ -403,7 +403,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(symbolic_traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         get_item_res = z3.Const(2, tensor_type)
         assert s.model()[get_item_res].arg(0).arg(1) == b.shape[0]
         assert s.model()[get_item_res].arg(1).arg(1) == b.shape[1]
@@ -429,7 +429,7 @@ class HFOperations(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         # make the output a size 1 tensor which should result
         # in the migration of the input
@@ -485,7 +485,7 @@ class HFOperations(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         # make the output a size 1 tensor which should result
         # in the migration of the input
@@ -515,7 +515,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(symbolic_traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         # migrate one of the parameters to a fully static shape so we can compare
 
@@ -527,7 +527,7 @@ class HFOperations(unittest.TestCase):
         s.add(input == tensor_type.tensor2(D(1, 2), D(1, 4)))
         s.add(input_2 == tensor_type.tensor2(D(1, s1), D(1, s2)))
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         actual_shape = BasicBlock().forward(torch.rand(2, 4), torch.rand(2, 4)).shape
         self.assertEqual(s.model()[output_long].arg(0).arg(1), actual_shape[0])
         self.assertEqual(s.model()[output_long].arg(1).arg(1), actual_shape[1])
@@ -552,7 +552,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         # change the annotations
         for n in graph.nodes:
@@ -565,7 +565,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         # force the second dimension to be Dyn
         # output should still be TensorType([2, 2])
@@ -786,7 +786,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         embedding_result = z3.Const(2, tensor_type)
 
         assert s.model()[embedding_result].arg(0).arg(1) == B[0]
@@ -801,7 +801,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         assert s.model()[embedding_result].arg(0).arg(0) == 0
         assert s.model()[embedding_result].arg(1).arg(0) == 0
         assert s.model()[embedding_result].arg(2).arg(1) == B[2]
@@ -815,7 +815,7 @@ class HFOperations(unittest.TestCase):
         s = z3.Solver()
         s.add(transformed)
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
 
     def test_embedding_2(self):
@@ -833,7 +833,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         embedding_result = z3.Const(5, tensor_type)
 
         assert s.model()[embedding_result].arg(0).arg(1) == B[0]
@@ -891,7 +891,7 @@ class HFOperations(unittest.TestCase):
         s = z3.Solver()
         s.add(transformed)
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         # force the input to be of size 4
 
@@ -903,12 +903,12 @@ class HFOperations(unittest.TestCase):
         s.add(input == tensor_type.tensor4(d1, d2, d3, d4))
 
         # check if the model is still SAT
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         s1, s2 = z3.Int(23), z3.Int(3)
 
         # check that the item is correct
-        self.assertEquals(s.model()[s1], s.model()[s2])
+        self.assertEqual(s.model()[s1], s.model()[s2])
 
         # invalid index but should still be SAT because input will be Dyn
         class BasicBlock(torch.nn.Module):
@@ -928,7 +928,7 @@ class HFOperations(unittest.TestCase):
         s = z3.Solver()
         s.add(transformed)
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         s.add(input != z3_dyn)
         self.assertEqual(s.check(), z3.unsat)
 
@@ -958,7 +958,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         # print(s.model())
 
         embedding_result = z3.Const(6, tensor_type)
@@ -990,7 +990,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         res = z3.Bool(4)
         self.assertEqual(s.model()[res], True)
 
@@ -1010,7 +1010,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
     def test_lt_tensor(self):
         class BasicBlock(torch.nn.Module):
@@ -1028,7 +1028,7 @@ class HFOperations(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
 
     def test_conditional_wrong_assumption(self):
@@ -1217,7 +1217,7 @@ class ComposeOperationsGradualTypes(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
     def test_add_reshape_2(self):
         class BasicBlock(torch.nn.Module):
@@ -1234,7 +1234,7 @@ class ComposeOperationsGradualTypes(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
     def test_conv_reshape_add_0(self):
         class BasicBlock(torch.nn.Module):
@@ -1254,7 +1254,7 @@ class ComposeOperationsGradualTypes(unittest.TestCase):
         new_transformed_c = transform_all_constraints(traced)
         solver = z3.Solver()
         solver.add(new_transformed_c)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
 
 
     def test_conv_reshape_add_0_2(self):
@@ -1279,7 +1279,7 @@ class ComposeOperationsGradualTypes(unittest.TestCase):
         new_transformed_c = transform_all_constraints(traced)
         solver = z3.Solver()
         solver.add(new_transformed_c)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
 
 
         conv_result = z3.Const(4, tensor_type)
@@ -1299,9 +1299,9 @@ class ComposeOperationsGradualTypes(unittest.TestCase):
         assert solver.model()[s4].as_long() == res[3]
 
         solver.add(input_2 == tensor_type.tensor2(D(1, 4), D(1, 1)))
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         solver.add(add_result == tensor_type.tensor4(d1, d2, d3, d4))
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
 
         # first dimension could be anything because we have broadcasting
         assert solver.model()[s1] == res[0]
@@ -1327,7 +1327,7 @@ class ComposeOperationsGradualTypes(unittest.TestCase):
         new_transformed_c = transform_all_constraints(traced)
         solver = z3.Solver()
         solver.add(new_transformed_c)
-        self.assertEquals(solver.check(), z3.unsat)
+        self.assertEqual(solver.check(), z3.unsat)
 
 
     def test_conv_reshape_add_1(self):
@@ -1348,7 +1348,7 @@ class ComposeOperationsGradualTypes(unittest.TestCase):
         new_transformed_c = transform_all_constraints(traced)
         solver = z3.Solver()
         solver.add(new_transformed_c)
-        self.assertEquals(solver.check(), z3.unsat)
+        self.assertEqual(solver.check(), z3.unsat)
 
 
 class GradualTypes(unittest.TestCase):
@@ -1371,7 +1371,7 @@ class GradualTypes(unittest.TestCase):
         new_transformed_c = transform_all_constraints(traced)
         solver = z3.Solver()
         solver.add(new_transformed_c)
-        self.assertEquals(solver.check(), z3.unsat)
+        self.assertEqual(solver.check(), z3.unsat)
 
     def test_conv_reshape0(self):
         class BasicBlock(torch.nn.Module):
@@ -1393,7 +1393,7 @@ class GradualTypes(unittest.TestCase):
 
         solver = z3.Solver()
         solver.add(new_transformed_c)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         conv_result = z3.Const(3, tensor_type)
 
         s1, s2, s3, s4 = z3.Ints('x1 x2 x3 x4')
@@ -1446,7 +1446,7 @@ class GradualTypes(unittest.TestCase):
 
         solver = z3.Solver()
         solver.add(new_transformed_c)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         conv_result = z3.Const(3, tensor_type)
 
         s1, s2, s3, s4 = z3.Ints('x1 x2 x3 x4')
@@ -1550,13 +1550,13 @@ class TestSingleOperation(unittest.TestCase):
         assert solver3.model()[s22].as_long() == 0
 
         solver3.add(s22 != 0)
-        self.assertEquals(solver3.check(), z3.unsat)
+        self.assertEqual(solver3.check(), z3.unsat)
 
         solver2 = z3.Solver()
         solver2.add(transformed)
         assert solver2.check() == z3.sat
         solver2.add(x == tensor_type.tensor3(d1, d2, d3))
-        self.assertEquals(solver2.check(), z3.unsat)
+        self.assertEqual(solver2.check(), z3.unsat)
 
 
     def test_add(self):
@@ -1579,20 +1579,20 @@ class TestSingleOperation(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         # make the tensor be of size 1
         x = z3.Const(1, tensor_type)
         s.add(x == tensor_type.tensor1(D(1, s11)))
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         y = z3.Const(2, tensor_type)
         s.add(y == tensor_type.tensor1(D(1, s22)))
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         s.add(s11 == 1)  # tensor[1]
         s.add(s22 == 2)  # tensor[2]
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         class BasicBlock2(torch.nn.Module):
             def __init__(self):
@@ -1608,17 +1608,17 @@ class TestSingleOperation(unittest.TestCase):
         transformed = transform_all_constraints(traced)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         # make the tensor be of size 1
         x = z3.Const(1, tensor_type)
         s.add(x == tensor_type.tensor1(D(1, s11)))
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         y = z3.Const(2, tensor_type)
         s.add(y == tensor_type.tensor1(D(1, s22)))
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         s.add(s11 == 4)  # tensor[4]
         s.add(s22 == 5)  # tensor[5]
-        self.assertEquals(s.check(), z3.unsat)
+        self.assertEqual(s.check(), z3.unsat)
 
         class BasicBlock3(torch.nn.Module):
             def __init__(self):
@@ -1636,7 +1636,7 @@ class TestSingleOperation(unittest.TestCase):
         s.add(transformed)
         x = z3.Const(1, tensor_type)
         s.add(x == tensor_type.tensor2(d1, d2))
-        self.assertEquals(s.check(), z3.unsat)
+        self.assertEqual(s.check(), z3.unsat)
 
     def test_add_padding(self):
         s1, s2, s3, s4 = z3.Ints('s1 s2 s3 s4')
@@ -1656,12 +1656,12 @@ class TestSingleOperation(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         x = z3.Const(1, tensor_type)
         s.add(x == tensor_type.tensor1(D(1, s1)))
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         # print(s.model())
 
@@ -1683,16 +1683,16 @@ class TestSingleOperation(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         # print(s.model())
 
         x = z3.Const(1, tensor_type)
         s.add(x == tensor_type.tensor2(D(1, s1), D(1, s2)))
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         y = z3.Const(2, tensor_type)
         s.add(y == tensor_type.tensor1(D(0, s3)))
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         add_result = z3.Const(3, tensor_type)
         broadcast_res1, broadcast_res2 = z3.Const(4, tensor_type), z3.Const(5, tensor_type)
@@ -1735,7 +1735,7 @@ class TestSingleOperation(unittest.TestCase):
         s = z3.Solver()
         s.add(transformed)
         # print(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         x = z3.Const(1, tensor_type)
         y = z3.Const(2, tensor_type)
@@ -1744,7 +1744,7 @@ class TestSingleOperation(unittest.TestCase):
         s.add(x == tensor_type.tensor2(D(0, s1), D(s2, 1)))
         s.add(y == tensor_type.tensor1(D(0, s3)))
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         # print(s.model())
 
@@ -1770,7 +1770,7 @@ class TestSingleOperation(unittest.TestCase):
         s = z3.Solver()
         s.add(transformed)
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         add_result = z3.Const(3, tensor_type)
         assert s.model()[add_result] == tensor_type.tensor2(D(1, 2), D(1, 3))
@@ -1791,7 +1791,7 @@ class TestSingleOperation(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.unsat)
+        self.assertEqual(s.check(), z3.unsat)
 
     def test_add_size_3(self):
 
@@ -1810,7 +1810,7 @@ class TestSingleOperation(unittest.TestCase):
 
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         x = z3.Const(1, tensor_type)
         y = z3.Const(2, tensor_type)
@@ -1820,11 +1820,11 @@ class TestSingleOperation(unittest.TestCase):
         s.add(x == tensor_type.tensor3(D(1, s1), D(1, 1), D(1, s2)))
         s.add(y == tensor_type.tensor3(D(1, s3), D(1, s4), D(1, s5)))
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         s.add(s2 == 5)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         s.add(s5 == 6)
-        self.assertEquals(s.check(), z3.unsat)
+        self.assertEqual(s.check(), z3.unsat)
 
     def test_add_padding_6(self):
 
@@ -1842,7 +1842,7 @@ class TestSingleOperation(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         x = z3.Const(1, tensor_type)
         y = z3.Const(2, tensor_type)
@@ -1852,12 +1852,12 @@ class TestSingleOperation(unittest.TestCase):
         s.add(x == tensor_type.tensor1(D(1, s1)))
         s.add(y == tensor_type.tensor3(D(1, s2), D(1, s3), D(1, s4)))
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         s.add(s1 == 4)
         s.add(s4 == 5)
 
-        self.assertEquals(s.check(), z3.unsat)
+        self.assertEqual(s.check(), z3.unsat)
 
     def test_add_padding_7(self):
 
@@ -1875,11 +1875,11 @@ class TestSingleOperation(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         x = z3.Const(1, tensor_type)
         s1, s2, s3, s4, s5 = z3.Ints('s1 s2 s3 s4 s5')
         s.add(x == tensor_type.tensor2(D(s1, s2), D(s2, s3)))
-        self.assertEquals(s.check(), z3.unsat)
+        self.assertEqual(s.check(), z3.unsat)
 
 
     def test_add_padding_8(self):
@@ -1898,7 +1898,7 @@ class TestSingleOperation(unittest.TestCase):
         transformed = transform_all_constraints(traced, counter=0)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         x = z3.Const(1, tensor_type)
         y = z3.Const(2, tensor_type)
 
@@ -1906,10 +1906,10 @@ class TestSingleOperation(unittest.TestCase):
         s.add(x == tensor_type.tensor1(D(s1, 1)))
         s.add(s1 >= 0)
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         s.add(y == tensor_type.tensor4(D(0, s2), D(0, s3), D(0, s4), D(0, s5)))
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
     def test_add_padding_9(self):
 
@@ -1928,21 +1928,21 @@ class TestSingleOperation(unittest.TestCase):
         s = z3.Solver()
         s.add(transformed)
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         x = z3.Const(1, tensor_type)
         y = z3.Const(2, tensor_type)
 
         s1, s2, s3, s4, s5, s6, s7 = z3.Ints('s1 s2 s3 s4 s5 s6 s7')
         s.add(x == tensor_type.tensor1(D(s1, s7)))
         s.add(s1 == 1)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         s.add(y == tensor_type.tensor4(D(0, s2), D(0, s3), D(0, s4), D(s6, s5)))
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
 
         s.add(s6 == 1)
 
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         s.add(s5 != 1, s7 != 1)
         assert s.check()
 
@@ -1976,14 +1976,14 @@ class TestSingleOperation(unittest.TestCase):
         new_transformed_c = transform_all_constraints(traced)
         solver = z3.Solver()
         solver.add(new_transformed_c)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
 
         x = z3.Const(1, tensor_type)
         y = z3.Const(2, tensor_type)
 
         solver.add(x == tensor_type.tensor4(d1, d2, d3, d4))
         solver.add(y == tensor_type.tensor4(b1, b2, b3, b4))
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         # print(solver.model())
         assert solver.model()[e3].as_long() == res[2]
         assert solver.model()[e4].as_long() == res[3]
@@ -2000,7 +2000,7 @@ class TestSingleOperation(unittest.TestCase):
         solver.add(x == tensor_type.tensor4(d1, d2, d3, d4))
         solver.add(y == tensor_type.tensor4(b1, b2, b3, b4))
 
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         assert solver.model()[e3].as_long() == res2[2]
         assert solver.model()[e4].as_long() == res2[3]
 
@@ -2021,14 +2021,14 @@ class TestSingleOperation(unittest.TestCase):
         transformed = transform_all_constraints(traced)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         x = z3.Const(1, tensor_type)
         s.add(x == tensor_type.tensor1(D(1, s11)))
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         s.add(z3.Or([s11 == 2, s11 == 4, s11 == 9]))
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         s.add(s11 == 9)
-        self.assertEquals(s.check(), z3.unsat)
+        self.assertEqual(s.check(), z3.unsat)
 
 
     def test_reshape_annotated(self):
@@ -2049,10 +2049,10 @@ class TestSingleOperation(unittest.TestCase):
         transformed = transform_all_constraints(traced)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         x = z3.Const(1, tensor_type)
         s.add(x == tensor_type.tensor2(d1, d2))
-        self.assertEquals(s.check(), z3.unsat)
+        self.assertEqual(s.check(), z3.unsat)
 
     def test_reshape_static_target(self):
         s11, s22, s33, s44 = z3.Ints('s11 s22 s33 s44')
@@ -2071,13 +2071,13 @@ class TestSingleOperation(unittest.TestCase):
         # print(transformed)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         x = z3.Const(1, tensor_type)
         s.add(x == tensor_type.tensor1(D(1, s11)))
         s.check()
         assert s.model()[s11].as_long() == 6
         s.add(s11 != 6)
-        self.assertEquals(s.check(), z3.unsat)
+        self.assertEqual(s.check(), z3.unsat)
 
     def test_reshape_static_target2(self):
         s11, s22, s33, s44 = z3.Ints('s11 s22 s33 s44')
@@ -2095,13 +2095,13 @@ class TestSingleOperation(unittest.TestCase):
         transformed = transform_all_constraints(traced)
         s = z3.Solver()
         s.add(transformed)
-        self.assertEquals(s.check(), z3.sat)
+        self.assertEqual(s.check(), z3.sat)
         x = z3.Const(1, tensor_type)
         s.add(x == tensor_type.tensor1(D(1, s11)))
         s.check()
         assert s.model()[s11].as_long() == 6
         s.add(s11 != 6)
-        self.assertEquals(s.check(), z3.unsat)
+        self.assertEqual(s.check(), z3.unsat)
 
 
     def test_conv2D_maxpool2d_flatten(self):
@@ -2172,7 +2172,7 @@ class TestSingleOperation(unittest.TestCase):
         solver.check()
         input = z3.Const(1, tensor_type)
         solver.add(input == tensor_type.tensor4(D(1, 4), D(1, 3), D(1, 32), D(1, 45)))
-        self.assertEquals(solver.check(), z3.unsat)
+        self.assertEqual(solver.check(), z3.unsat)
 
     def test_conv2D_maxpool2d_flatten_dyn(self):
         class BasicBlock(torch.nn.Module):
@@ -2202,7 +2202,7 @@ class TestSingleOperation(unittest.TestCase):
         constraints = transform_all_constraints(traced, counter=0)
         solver = z3.Solver()
         solver.add(constraints)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
 
     def test_type_check_flatten(self):
         s1, s2, s3, s4 = z3.Ints('s1 s2 s3 s4')
@@ -2216,7 +2216,7 @@ class TestSingleOperation(unittest.TestCase):
         constraints = transform_all_constraints(symbolic_traced, counter=0)
         solver = z3.Solver()
         solver.add(constraints)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         flatten = z3.Const(2, tensor_type)
 
         res = M().forward(torch.rand(2, 3, 4, 5)).size()
@@ -2232,12 +2232,12 @@ class TestSingleOperation(unittest.TestCase):
         constraints = transform_all_constraints(symbolic_traced, counter=0)
         solver = z3.Solver()
         solver.add(constraints)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         x = z3.Const(1, tensor_type)
         y = z3.Const(2, tensor_type)
 
         solver.add(x == tensor_type.tensor4(D(1, 2), D(1, 3), D(0, s1), D(1, 5)))
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         assert solver.model()[y].arg(1).arg(0) == 0
 
 
@@ -2251,7 +2251,7 @@ class TestSingleOperation(unittest.TestCase):
         constraints = transform_all_constraints(symbolic_traced, counter=0)
         solver = z3.Solver()
         solver.add(constraints)
-        self.assertEquals(solver.check(), z3.unsat)
+        self.assertEqual(solver.check(), z3.unsat)
 
 class ConstraintGeneration(unittest.TestCase):
 
@@ -2338,7 +2338,7 @@ class TestResNet(unittest.TestCase):
         input = z3.Const(1, tensor_type)
         # input with 3 dimensions
         solver.add(input == tensor_type.tensor3(D(1, 1), D(1, 3), D(1, 224)))
-        self.assertEquals(solver.check(), z3.unsat)
+        self.assertEqual(solver.check(), z3.unsat)
 
 
 
@@ -2352,12 +2352,12 @@ class TestResNet(unittest.TestCase):
         constraints = transform_all_constraints(traced, counter=0)
         solver = z3.Solver()
         solver.add(constraints)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         linear = z3.Const(650, tensor_type)
 
         input = z3.Const(1, tensor_type)
         solver.add(input == tensor_type.tensor4(D(1, 1), D(1, 3), D(1, 224), D(1, 224)))
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         assert solver.model()[linear] == tensor_type.tensor2(D(1, res[0]), D(1, res[1]))
 
     def test_resnet502(self):
@@ -2389,9 +2389,9 @@ class TestResNet(unittest.TestCase):
         batch, d1, d2 = z3.Ints('b d1 d2')
         solver.add(input == tensor_type.tensor4(D(1, batch), D(1, 3), D(1, 224), D(1, 224)))
         solver.add(linear == tensor_type.tensor2(D(1, d1), D(1, d2)))
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         solver.add(batch != d1)
-        self.assertEquals(solver.check(), z3.unsat)
+        self.assertEqual(solver.check(), z3.unsat)
 
 @skipIfNoTorchVision
 class TestAlexNet(unittest.TestCase):
@@ -2409,11 +2409,11 @@ class TestAlexNet(unittest.TestCase):
         constraints = transform_all_constraints(symbolic_traced, counter=0)
         solver = z3.Solver()
         solver.add(constraints)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         input = z3.Const(1, tensor_type)
         conv = z3.Const(2, tensor_type)
         solver.add(input == tensor_type.tensor4(D(1, 10), D(1, 3), D(1, 227), D(1, 227)))
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
         assert solver.model()[conv] == tensor_type.tensor4(D(1, 10), D(1, 64), D(1, 56), D(1, 56))
 
         relu = z3.Const(7, tensor_type)
@@ -2446,7 +2446,7 @@ class TestAlexNet(unittest.TestCase):
         constraints = transform_all_constraints(symbolic_traced, counter=0)
         solver = z3.Solver()
         solver.add(constraints)
-        self.assertEquals(solver.check(), z3.unsat)
+        self.assertEqual(solver.check(), z3.unsat)
 
     def test_alexnet3(self):
         alexnet = models.alexnet()
@@ -2459,7 +2459,7 @@ class TestAlexNet(unittest.TestCase):
         constraints = transform_all_constraints(symbolic_traced, counter=0)
         solver = z3.Solver()
         solver.add(constraints)
-        self.assertEquals(solver.check(), z3.sat)
+        self.assertEqual(solver.check(), z3.sat)
 
     def test_alexnet4(self):
         alexnet = models.alexnet()
@@ -2472,7 +2472,7 @@ class TestAlexNet(unittest.TestCase):
         constraints = transform_all_constraints(symbolic_traced, counter=0)
         solver = z3.Solver()
         solver.add(constraints)
-        self.assertEquals(solver.check(), z3.unsat)
+        self.assertEqual(solver.check(), z3.unsat)
 
 
 

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -628,8 +628,7 @@ class IDP_NoLen(IterDataPipe):
     # Prevent in-place modification
     def __iter__(self):
         input_dp = self.input_dp if isinstance(self.input_dp, IterDataPipe) else copy.deepcopy(self.input_dp)
-        for i in input_dp:
-            yield i
+        yield from input_dp
 
 
 def _fake_fn(data):
@@ -2202,8 +2201,7 @@ class TestTyping(TestCase):
 
         class DP2(IterDataPipe[T_co]):
             def __iter__(self) -> Iterator[T_co]:
-                for d in range(10):
-                    yield d  # type: ignore[misc]
+                yield from range(10)  # type: ignore[misc]
 
         self.assertTrue(issubclass(DP2, IterDataPipe))
         dp2 = DP2()  # type: ignore[var-annotated]
@@ -2307,8 +2305,7 @@ class TestTyping(TestCase):
 
             @runtime_validation
             def __iter__(self) -> Iterator[Tuple[int, T_co]]:
-                for d in self.ds:
-                    yield d
+                yield from self.ds
 
         dss = ([(1, '1'), (2, '2')],
                [(1, 1), (2, '2')])
@@ -2344,8 +2341,7 @@ class TestTyping(TestCase):
 
             @runtime_validation
             def __iter__(self) -> Iterator[T]:
-                for d in self.ds:
-                    yield d
+                yield from self.ds
 
         ds = list(range(10))
         # Valid type reinforcement
@@ -2376,8 +2372,7 @@ class NumbersDataset(IterDataPipe):
         self.size = size
 
     def __iter__(self):
-        for i in range(self.size):
-            yield i
+        yield from range(self.size)
 
     def __len__(self):
         return self.size

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -1033,8 +1033,7 @@ def get_strided_args(args):
             strided_arg_variants = [arg]
         strided_args.append(strided_arg_variants)
 
-    for result in itertools.product(*strided_args):
-        yield result
+    yield from itertools.product(*strided_args)
 
 class MetaCrossRefDispatchMode(torch.utils._python_dispatch.TorchDispatchMode):
     test_case: TestCase

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -444,7 +444,7 @@ $1 = torch._ops.my_lib.weird.default([None, LoggingTensor(tensor([[1., 1.],
         self.assertRaisesRegex(
             RuntimeError, "Unable to cast", lambda: A(torch.zeros(1)).neg(),
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             RuntimeError, "Unable to cast", lambda: A(torch.zeros(1)).detach(),
         )
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2032,7 +2032,7 @@ class TestImports(TestCase):
             # On Windows, opening the subprocess with the default CWD makes `import torch`
             # fail, so just set CWD to this script's directory
             cwd=os.path.dirname(os.path.realpath(__file__)),).decode("utf-8")
-        self.assertEquals(out, "")
+        self.assertEqual(out, "")
 
     @unittest.skipIf(IS_WINDOWS, "importing torch+CUDA on CPU results in warning")
     @parametrize('path', ['torch', 'functorch'])

--- a/tools/stats/check_disabled_tests.py
+++ b/tools/stats/check_disabled_tests.py
@@ -116,8 +116,7 @@ def get_test_reports(
         for path in artifact_paths:
             unzip(path)
 
-        for report in Path(".").glob("**/*.xml"):
-            yield report
+        yield from Path(".").glob("**/*.xml")
 
 
 def get_disabled_test_name(test_id: str) -> Tuple[str, str, str, str]:

--- a/torch/distributed/_composable/_ddp.py
+++ b/torch/distributed/_composable/_ddp.py
@@ -472,8 +472,7 @@ class DistributedDataParallel(Module):
                 if hasattr(m, "_former_parameters")
                 else m.parameters(recurse=False)
             )
-            for p in ps:
-                yield p
+            yield from ps
 
         for m in m.modules() if recurse else [m]:
             for p in model_parameters(m):

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -189,11 +189,9 @@ class _OverlappingCpuLoader(_TensorLoader):
         while not self._done:
             drained = self._drain()
             self._refill()
-            for obj in drained:
-                yield obj
+            yield from drained
 
-        for val in self._finish():
-            yield val
+        yield from self._finish()
 
 
 def _item_size(item: WriteItem) -> int:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2112,8 +2112,7 @@ class Module:
         gen = self._named_members(
             lambda module: module._parameters.items(),
             prefix=prefix, recurse=recurse, remove_duplicate=remove_duplicate)
-        for elem in gen:
-            yield elem
+        yield from gen
 
     def buffers(self, recurse: bool = True) -> Iterator[Tensor]:
         r"""Returns an iterator over module buffers.
@@ -2163,8 +2162,7 @@ class Module:
         gen = self._named_members(
             lambda module: module._buffers.items(),
             prefix=prefix, recurse=recurse, remove_duplicate=remove_duplicate)
-        for elem in gen:
-            yield elem
+        yield from gen
 
     def children(self) -> Iterator['Module']:
         r"""Returns an iterator over immediate children modules.

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1022,8 +1022,7 @@ class DistributedDataParallel(Module, Joinable):
                 if hasattr(m, "_former_parameters")
                 else m.parameters(recurse=False)
             )
-            for p in ps:
-                yield p
+            yield from ps
 
         for m in m.modules() if recurse else [m]:
             for p in model_parameters(m):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7349,8 +7349,7 @@ def sample_inputs_argwhere(op_info, device, dtype, requires_grad, **kwargs):
 def _generate_sample_shape_reduction():
     shapes = ((S,), (S, S), (S, S, S))
     reductions = ('none', 'mean', 'sum')
-    for s, r in product(shapes, reductions):
-        yield s, r
+    yield from product(shapes, reductions)
 
 def sample_inputs_gaussian_nll_loss(op_info, device, dtype, requires_grad, **kwargs):
     _make_tensor = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -52,8 +52,7 @@ class FunctionCounts(object):
     _linewidth: Optional[int] = None
 
     def __iter__(self) -> Generator[FunctionCount, None, None]:
-        for i in self._data:
-            yield i
+        yield from self._data
 
     def __len__(self) -> int:
         return len(self._data)

--- a/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
+++ b/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py
@@ -43,8 +43,7 @@ class PandasWrapper:
     def iterate(cls, data):
         if not _with_pandas():
             raise Exception("DataFrames prototype requires pandas to function")
-        for d in data.itertuples(index=False):
-            yield d
+        yield from data.itertuples(index=False)
 
     @classmethod
     def concat(cls, buffer):

--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -384,9 +384,7 @@ class DataChunk(list, Generic[T]):
         return res
 
     def __iter__(self) -> Iterator[T]:
-        for i in super().__iter__():
-            yield i
+        yield from super().__iter__()
 
     def raw_iterator(self) -> T:  # type: ignore[misc]
-        for i in self.items:
-            yield i
+        yield from self.items

--- a/torch/utils/data/datapipes/iter/combining.py
+++ b/torch/utils/data/datapipes/iter/combining.py
@@ -586,8 +586,7 @@ class ZipperIterDataPipe(IterDataPipe[Tuple[T_co]]):
 
     def __iter__(self) -> Iterator[Tuple[T_co]]:
         iterators = [iter(datapipe) for datapipe in self.datapipes]
-        for data in zip(*iterators):
-            yield data
+        yield from zip(*iterators)
 
     def __len__(self) -> int:
         if all(isinstance(dp, Sized) for dp in self.datapipes):

--- a/torch/utils/data/datapipes/iter/utils.py
+++ b/torch/utils/data/datapipes/iter/utils.py
@@ -44,8 +44,7 @@ class IterableWrapperIterDataPipe(IterDataPipe):
                     "The input iterable can not be deepcopied, "
                     "please be aware of in-place modification would affect source data."
                 )
-        for data in source_data:
-            yield data
+        yield from source_data
 
     def __len__(self):
         return len(self.iterable)

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -363,8 +363,7 @@ class StreamWrapper:
             self.close()
 
     def __iter__(self):
-        for line in self.file_obj:
-            yield line
+        yield from self.file_obj
 
     def __next__(self):
         return next(self.file_obj)


### PR DESCRIPTION
Applies some more harmless pyupgrades. This one gets rid of deprecated aliases in unit_tests and more upgrades yield for loops into yield from generators which are more performance and propagates more information / exceptions from original generator. This is the modern recommended way of forwarding generators.