### PR TITLE
Use the right run_test for inductor opinfo tests

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import torch
 
 import torch._dynamo
+from torch._dynamo.test_case import run_tests
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyNativeDeviceTypes,
@@ -24,7 +25,6 @@ from torch.testing._internal.common_utils import (
     dtype_abbrs,
     IS_MACOS,
     IS_X86,
-    run_tests,
     skipCUDAMemoryLeakCheckIf,
     skipIfCrossRef,
     skipIfTorchDynamo,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #94056
* __->__ #94312


One of the side effect of this is that this is not properly skipped on 3.11
As a side note, it was very surprising to find testing-specific code in `torch._dynamo` and not `torch.testing`...

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire