### PR TITLE
Add rnn.unpad_sequence and rnn.unpack_sequence to documentation

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -442,6 +442,8 @@ Utility functions in other modules
     nn.utils.rnn.pad_packed_sequence
     nn.utils.rnn.pad_sequence
     nn.utils.rnn.pack_sequence
+    nn.utils.rnn.unpack_sequence
+    nn.utils.rnn.unpad_sequence
 
 .. autosummary::
     :toctree: generated


### PR DESCRIPTION
Fix #76064

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #94316

