### PR TITLE
Fix SIGFPE in slow_conv3d_forward_out_cpu

### DIFF
--- a/aten/src/ATen/native/ConvolutionMM3d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM3d.cpp
@@ -574,7 +574,7 @@ Tensor& slow_conv3d_forward_out_cpu(const Tensor& self,
 
   // TODO: hacky way of deciding the groups
   // Assuming the group size is checked in upstream functions
-  const int64_t groups = self.size(1) / weight.size(1);
+  const int64_t groups = weights.size(1) > 0 ? self.size(1) / weight.size(1) : 0;
 
   slow_conv3d_shape_check(
       self,

--- a/aten/src/ATen/native/ConvolutionMM3d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM3d.cpp
@@ -574,7 +574,7 @@ Tensor& slow_conv3d_forward_out_cpu(const Tensor& self,
 
   // TODO: hacky way of deciding the groups
   // Assuming the group size is checked in upstream functions
-  const int64_t groups = weights.size(1) > 0 ? self.size(1) / weight.size(1) : 0;
+  const int64_t groups = weight.size(1) > 0 ? self.size(1) / weight.size(1) : 0;
 
   slow_conv3d_shape_check(
       self,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8062,6 +8062,11 @@ class TestNNDeviceType(NNTestCase):
         weight = weight.contiguous()
         out_ref = F.conv2d(input2d, weight, bias, (1, 1), 0, (1, 1), 1)
         self.assertEqual(out_ref, out)
+        # sigfpe reported in https://github.com/pytorch/pytorch/issues/94125
+        with self.assertRaises(RuntimeError):
+            inp = torch.empty([1, 1, 1, 0], dtype=dtype, device=device)
+            weight = torch.empty([1, 0, 1], dtype=dtype, device=device)
+            torch._C._nn.slow_conv3d(inp, weight, 1)
 
     def test_InstanceNorm1d_general(self, device):
         b = random.randint(3, 5)


### PR DESCRIPTION
Set number of groups to 0 if weights second dimension is zero.

`slow_conv_shape_check` will raise an exception if groups are zero anyway.

Fixes SIGFPE reported in https://github.com/pytorch/pytorch/issues/94125


cc @albanD @mruberry @jbschlosser @walterddr @saketh-are @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10