### PR TITLE
vmap support for linalg.lu_factor

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp
+++ b/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp
@@ -337,10 +337,18 @@ oneOutput cholesky_solve_batch_rule(
 
 threeOutputs linalg_lu_factor_ex_batch_rule(
     const Tensor& A, c10::optional<int64_t> A_bdim, bool pivot, bool check_errors) {
-  TORCH_CHECK(rankWithoutBatchDim(A, A_bdim) >= 2, "torch.lu_factor: Expected tensor with 2 or more dimensions. Got size: ", A.sizes(), " instead");
+  TORCH_CHECK(rankWithoutBatchDim(A, A_bdim) >= 2, "torch.lu_factor_ex: Expected tensor with 2 or more dimensions. Got size: ", A.sizes(), " instead");
   const auto A_ = moveBatchDimToFront(A, A_bdim);
   const auto res = at::linalg_lu_factor_ex(A_, pivot, check_errors);
   return std::make_tuple(std::get<0>(res), 0, std::get<1>(res), 0, std::get<2>(res), 0);
+}
+
+twoOutputs linalg_lu_factor_batch_rule(
+    const Tensor& A, c10::optional<int64_t> A_bdim, bool pivot) {
+  TORCH_CHECK(rankWithoutBatchDim(A, A_bdim) >= 2, "torch.lu_factor: Expected tensor with 2 or more dimensions. Got size: ", A.sizes(), " instead");
+  const auto A_ = moveBatchDimToFront(A, A_bdim);
+  const auto res = at::linalg_lu_factor(A_, pivot);
+  return std::make_tuple(std::get<0>(res), 0, std::get<1>(res), 0);
 }
 
 oneOutput matrix_exp_batch_rule(const Tensor& self, c10::optional<int64_t> self_bdim) {
@@ -600,6 +608,7 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   VMAP_SUPPORT(cholesky_solve, cholesky_solve_batch_rule);  // custom dim error
   VMAP_SUPPORT(linalg_lstsq, linalg_lstsq_batch_rule);  // custom errors and sometimes empty return
   VMAP_SUPPORT(linalg_lu_factor_ex, linalg_lu_factor_ex_batch_rule);
+  VMAP_SUPPORT(linalg_lu_factor, linalg_lu_factor_batch_rule);
   VMAP_SUPPORT(linalg_matrix_exp, matrix_exp_batch_rule);
   VMAP_SUPPORT(_linalg_solve_ex, solve_ex_batch_rule);
   VMAP_SUPPORT(linalg_cross, cross_batch_rule);

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -3664,7 +3664,6 @@ class TestVmapOperatorsOpInfo(TestCase):
         xfail('nn.functional.embedding_bag'),
         xfail('linalg.tensorsolve'),
         xfail('bernoulli', ''),
-        xfail('linalg.lu_factor', ''),
         xfail('nn.functional.feature_alpha_dropout', 'with_train'),
         xfail('native_dropout_backward'),
         xfail('nn.functional.kl_div', ''),

--- a/test/functorch/test_vmap_registrations.py
+++ b/test/functorch/test_vmap_registrations.py
@@ -24,6 +24,7 @@ xfail_functorch_batched = {
     "aten::linalg_pinv",
     "aten::linalg_pinv.atol_rtol_float",
     "aten::linalg_slogdet",
+    "aten::linalg_lu_factor",
     "aten::linear",
     "aten::log_sigmoid",
     "aten::log_softmax.int",


### PR DESCRIPTION
Differential Revision: D43093457

Fix #91415

### Expected behaviour

No use warning. 

```python
from functorch import vmap
x = torch.randn(4, 3, 2)
z = vmap(torch.linalg.lu_factor)(x)
```
Same behaviour as for-loop:

```python
x = torch.randn(4, 3, 2)
results = []
for xi in x:
  y = torch.linalg.lu_factor(xi)
  results.append(y)
```
