### PR TITLE
Cleanup hung Windows processes

### DIFF
--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -78,6 +78,18 @@ jobs:
             }
             Catch {
               Write-Output "No leftover $process process, continuing"
+              Write-Output $_
+            }
+          }
+
+          # Try it again https://stackoverflow.com/questions/40585754/powershell-wont-terminate-hung-process
+          # for hung processes
+          Foreach ($process In $processes) {
+            Try {
+              (Get-WmiObject -Class Win32_Process -Filter "Name LIKE '${process}%'").terminate()
+            }
+            Catch {
+              Write-Output $_
             }
           }
 


### PR DESCRIPTION
Follow https://stackoverflow.com/questions/40585754/powershell-wont-terminate-hung-process to see if the hung python process can be killed completely

```
C:\Jenkins\Miniconda3\python.exe -bb test_ops.py -v --use-pytest -vv -rfEX -x --reruns=2 --shard-id=0 --num-shards=2 "-k=not linalg_cholesky" --import-slow-tests --import-disabled-tests
```

The command `Get-Process -Name $process -ErrorAction Stop | Stop-Process -Force` doesn't stop this process as expect

### Testing

1. Spinning up a local python process on Windows runner `C:\Jenkins\Miniconda3\python.exe debug.py`
2. See that the process is runnning

```
Get-WmiObject -Class Win32_Process -Filter "Name LIKE 'python%' AND CommandLine LIKE '%debug%'"


__GENUS                    : 2
__CLASS                    : Win32_Process
__SUPERCLASS               : CIM_Process
__DYNASTY                  : CIM_ManagedSystemElement
__RELPATH                  : Win32_Process.Handle="8812"
__PROPERTY_COUNT           : 45
__DERIVATION               : {CIM_Process, CIM_LogicalElement, CIM_ManagedSystemElement}
__SERVER                   : EC2AMAZ-S19AQ2Q
__NAMESPACE                : root\cimv2
__PATH                     : \\EC2AMAZ-S19AQ2Q\root\cimv2:Win32_Process.Handle="8812"
Caption                    : python.exe
CommandLine                : "C:\Jenkins\Miniconda3\python.exe" debug.py
CreationClassName          : Win32_Process
CreationDate               : 20230208002358.569943+000
CSCreationClassName        : Win32_ComputerSystem
CSName                     : EC2AMAZ-S19AQ2Q
Description                : python.exe
ExecutablePath             : C:\Jenkins\Miniconda3\python.exe
ExecutionState             :
Handle                     : 8812
HandleCount                : 82
InstallDate                :
KernelModeTime             : 312500
MaximumWorkingSetSize      : 1380
MinimumWorkingSetSize      : 200
Name                       : python.exe
OSCreationClassName        : Win32_OperatingSystem
OSName                     : Microsoft Windows Server 2019 Datacenter|C:\Windows|\Device\Harddisk0\Partition1
OtherOperationCount        : 1135
OtherTransferCount         : 150908
PageFaults                 : 2442
PageFileUsage              : 5020
ParentProcessId            : 5396
PeakPageFileUsage          : 5120
PeakVirtualSize            : 4368465920
PeakWorkingSetSize         : 9424
Priority                   : 8
PrivatePageCount           : 5140480
ProcessId                  : 8812
QuotaNonPagedPoolUsage     : 8
QuotaPagedPoolUsage        : 63
QuotaPeakNonPagedPoolUsage : 8
QuotaPeakPagedPoolUsage    : 63
ReadOperationCount         : 88
ReadTransferCount          : 519894
SessionId                  : 0
Status                     :
TerminationDate            :
ThreadCount                : 1
UserModeTime               : 156250
VirtualSize                : 4362371072
WindowsVersion             : 10.0.17763
WorkingSetSize             : 9592832
WriteOperationCount        : 0
WriteTransferCount         : 0
PSComputerName             : EC2AMAZ-S19AQ2Q
ProcessName                : python.exe
Handles                    : 82
VM                         : 4362371072
WS                         : 9592832
Path                       : C:\Jenkins\Miniconda3\python.exe
```

3. Kill it
```
(Get-WmiObject -Class Win32_Process -Filter "Name LIKE 'python%' AND CommandLine LIKE '%debug%'").terminate()

__GENUS          : 2
__CLASS          : __PARAMETERS
__SUPERCLASS     :
__DYNASTY        : __PARAMETERS
__RELPATH        :
__PROPERTY_COUNT : 1
__DERIVATION     : {}
__SERVER         :
__NAMESPACE      :
__PATH           :
ReturnValue      : 0
PSComputerName   :
```

4. Confirm that the process is killed