### PR TITLE
[fx] Fix matching args

### DIFF
--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -46,3 +46,16 @@ class TestMatcher(JitTestCase):
         subgraph_matcher = SubgraphMatcher(pattern_graph)
         match_result = subgraph_matcher.match(large_model_graph)
         self.assertEqual(len(match_result), 1)
+
+    def test_subgraph_matcher_with_list(self):
+        def original(x, y):
+            return torch.ops.aten.view(x, [5, y.shape[0]])
+        original_graph = torch.fx.symbolic_trace(original).graph
+
+        def pattern(x, y, z):
+            return torch.ops.aten.view(x, [z, y.shape[0]])
+        pattern_graph = torch.fx.symbolic_trace(pattern).graph
+
+        subgraph_matcher = SubgraphMatcher(pattern_graph)
+        match_result = subgraph_matcher.match(original_graph)
+        self.assertEqual(len(match_result), 1)

--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -59,3 +59,16 @@ class TestMatcher(JitTestCase):
         subgraph_matcher = SubgraphMatcher(pattern_graph)
         match_result = subgraph_matcher.match(original_graph)
         self.assertEqual(len(match_result), 1)
+
+    def test_subgraph_matcher_with_list_bad(self):
+        def original(x, y):
+            return torch.ops.aten._reshape_alias_copy.default(x, [1, y.shape[0]], [y.shape[1], y.shape[1]])
+        original_graph = torch.fx.symbolic_trace(original).graph
+
+        def pattern(x, y, b):
+            return torch.ops.aten._reshape_alias_copy.default(x, [b, y.shape[0], y.shape[1]], [y.shape[1]])
+        pattern_graph = torch.fx.symbolic_trace(pattern).graph
+
+        subgraph_matcher = SubgraphMatcher(pattern_graph)
+        match_result = subgraph_matcher.match(original_graph)
+        self.assertEqual(len(match_result), 0)

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -45,6 +45,7 @@ from fx.test_fx_param_shape_control_flow import TestConstParamShapeInControlFlow
 from fx.test_pass_infra import TestPassManager  # noqa: F401
 from fx.test_common_passes import TestCommonPass  # noqa: F401
 from fx.test_cse_pass import TestCSEPass  # noqa: F401
+from fx.test_matcher_utils import TestMatcher  # noqa: F401
 
 if sys.version_info >= (3, 7):
     from fx.test_gradual_type import AnnotationsTest  # noqa: F401

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 from collections import defaultdict
-from functools import reduce
 import copy
 import torch
 from torch.fx.graph import Graph
@@ -199,16 +198,18 @@ class SubgraphMatcher:
         saved_match = copy.copy(match)
         match.nodes_map[pn] = gn
 
+        # Placeholder is a wildcard and can be matched with any python object
+        # (including list/tuple)
         if pn.op == "placeholder":
             return True
 
         # Recursively traverse upwards to check if `pn` is a true
         # match for `gn`
         match_found = True
-        
+
         def _match_args(args1: Union[List, Tuple], args2: Union[List, Tuple]) -> bool:
             if len(args1) != len(args2):
-                return False 
+                return False
 
             for a1, a2 in zip(args1, args2):
                 if isinstance(a1, Node) and isinstance(a2, Node):
@@ -220,7 +221,7 @@ class SubgraphMatcher:
 
                 if not matched:
                     return False
-            
+
             return True
 
         match_found = match_found and _match_args(pn.args, gn.args)

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -177,7 +177,7 @@ class SubgraphMatcher:
             return False
         else:
             return type(gn) == type(pn) and gn == pn
-    
+
     def _match_nodes(self, pn: Node, gn: Node, match: InternalMatch) -> bool:
         logger.info(f"  matching {pn} to {gn}")
 

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from collections import defaultdict
+from functools import reduce
 import copy
 import torch
 from torch.fx.graph import Graph
@@ -210,7 +211,11 @@ class SubgraphMatcher:
             result : List[Any] = []
             for arg in args:
                 if isinstance(arg, (list, tuple)):
-                    result.extend(flatten_args(arg))
+                    # Do not flatten the list if it's a list of literals
+                    if reduce(lambda a, b: a and (not isinstance(b, torch.fx.Node)), arg):
+                        result.append(arg)
+                    else:
+                        result.extend(flatten_args(arg))
                 else:
                     result.append(arg)
 

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -209,8 +209,7 @@ class SubgraphMatcher:
             # Recursively flatten args
             result : List[Any] = []
             for arg in args:
-                # flatten the list, if only it's a list/tuple of nodes
-                if isinstance(arg, (list, tuple)) and len(arg) > 0 and isinstance(arg[0], Node):
+                if isinstance(arg, (list, tuple)):
                     result.extend(flatten_args(arg))
                 else:
                     result.append(arg)


### PR DESCRIPTION
To match nodes within the graph, the matcher currently flattens the arguments and compares each argument against each other. However, if it believes that a list input contains all literals, it will not flatten the list and will instead compare the list directly against each other. It determines if a list is a literal by checking if the first element is a node. However this doesn't work in some cases (like the test cases I added).

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @mcarilli @ptrblck @leslie-fang-intel @EikanWang @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire