### PR TITLE
Combining logic in some distribution init's to help readability

### DIFF
--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -37,13 +37,15 @@ class Bernoulli(ExponentialFamily):
     def __init__(self, probs=None, logits=None, validate_args=None):
         if (probs is None) == (logits is None):
             raise ValueError("Either `probs` or `logits` must be specified, but not both.")
-        if probs is not None:
-            is_scalar = isinstance(probs, Number)
-            self.probs, = broadcast_all(probs)
-        else:
+        if probs is None:
             is_scalar = isinstance(logits, Number)
             self.logits, = broadcast_all(logits)
-        self._param = self.probs if probs is not None else self.logits
+            self._param = self.logits
+        else:
+            is_scalar = isinstance(probs, Number)
+            self.probs, = broadcast_all(probs)
+            self._param = self.probs
+
         if is_scalar:
             batch_shape = torch.Size()
         else:

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -41,14 +41,15 @@ class Binomial(Distribution):
     def __init__(self, total_count=1, probs=None, logits=None, validate_args=None):
         if (probs is None) == (logits is None):
             raise ValueError("Either `probs` or `logits` must be specified, but not both.")
-        if probs is not None:
-            self.total_count, self.probs, = broadcast_all(total_count, probs)
-            self.total_count = self.total_count.type_as(self.probs)
-        else:
+        if probs is None:
             self.total_count, self.logits, = broadcast_all(total_count, logits)
             self.total_count = self.total_count.type_as(self.logits)
+            self._param = self.logits
+        else:
+            self.total_count, self.probs, = broadcast_all(total_count, probs)
+            self.total_count = self.total_count.type_as(self.probs)
+            self._param = self.probs
 
-        self._param = self.probs if probs is not None else self.logits
         batch_shape = self._param.size()
         super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
 

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -51,16 +51,18 @@ class Categorical(Distribution):
     def __init__(self, probs=None, logits=None, validate_args=None):
         if (probs is None) == (logits is None):
             raise ValueError("Either `probs` or `logits` must be specified, but not both.")
-        if probs is not None:
-            if probs.dim() < 1:
-                raise ValueError("`probs` parameter must be at least one-dimensional.")
-            self.probs = probs / probs.sum(-1, keepdim=True)
-        else:
+        if probs is None:
             if logits.dim() < 1:
                 raise ValueError("`logits` parameter must be at least one-dimensional.")
             # Normalize
             self.logits = logits - logits.logsumexp(dim=-1, keepdim=True)
-        self._param = self.probs if probs is not None else self.logits
+            self._param = self.logits
+        else:
+            if probs.dim() < 1:
+                raise ValueError("`probs` parameter must be at least one-dimensional.")
+            self.probs = probs / probs.sum(-1, keepdim=True)
+            self._param = self.probs
+
         self._num_events = self._param.size()[-1]
         batch_shape = self._param.size()[:-1] if self._param.ndimension() > 1 else torch.Size()
         super(Categorical, self).__init__(batch_shape, validate_args=validate_args)

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -44,7 +44,11 @@ class ContinuousBernoulli(ExponentialFamily):
     def __init__(self, probs=None, logits=None, lims=(0.499, 0.501), validate_args=None):
         if (probs is None) == (logits is None):
             raise ValueError("Either `probs` or `logits` must be specified, but not both.")
-        if probs is not None:
+        if probs is None:
+            is_scalar = isinstance(logits, Number)
+            self.logits, = broadcast_all(logits)
+            self._param = self.logits
+        else:
             is_scalar = isinstance(probs, Number)
             self.probs, = broadcast_all(probs)
             # validate 'probs' here if necessary as it is later clamped for numerical stability
@@ -53,10 +57,8 @@ class ContinuousBernoulli(ExponentialFamily):
                 if not self.arg_constraints['probs'].check(getattr(self, 'probs')).all():
                     raise ValueError("The parameter {} has invalid values".format('probs'))
             self.probs = clamp_probs(self.probs)
-        else:
-            is_scalar = isinstance(logits, Number)
-            self.logits, = broadcast_all(logits)
-        self._param = self.probs if probs is not None else self.logits
+            self._param = self.probs
+
         if is_scalar:
             batch_shape = torch.Size()
         else:

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -35,11 +35,13 @@ class Geometric(Distribution):
     def __init__(self, probs=None, logits=None, validate_args=None):
         if (probs is None) == (logits is None):
             raise ValueError("Either `probs` or `logits` must be specified, but not both.")
-        if probs is not None:
-            self.probs, = broadcast_all(probs)
-        else:
+        if probs is None:
             self.logits, = broadcast_all(logits)
-        probs_or_logits = probs if probs is not None else logits
+            probs_or_logits = logits
+        else:
+            self.probs, = broadcast_all(probs)
+            probs_or_logits = probs
+
         if isinstance(probs_or_logits, Number):
             batch_shape = torch.Size()
         else:

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -28,14 +28,15 @@ class NegativeBinomial(Distribution):
     def __init__(self, total_count, probs=None, logits=None, validate_args=None):
         if (probs is None) == (logits is None):
             raise ValueError("Either `probs` or `logits` must be specified, but not both.")
-        if probs is not None:
-            self.total_count, self.probs, = broadcast_all(total_count, probs)
-            self.total_count = self.total_count.type_as(self.probs)
-        else:
+        if probs is None:
             self.total_count, self.logits, = broadcast_all(total_count, logits)
             self.total_count = self.total_count.type_as(self.logits)
+            self._param = self.logits
+        else:
+            self.total_count, self.probs, = broadcast_all(total_count, probs)
+            self.total_count = self.total_count.type_as(self.probs)
+            self._param = self.probs
 
-        self._param = self.probs if probs is not None else self.logits
         batch_shape = self._param.size()
         super(NegativeBinomial, self).__init__(batch_shape, validate_args=validate_args)
 

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -35,13 +35,15 @@ class LogitRelaxedBernoulli(Distribution):
         self.temperature = temperature
         if (probs is None) == (logits is None):
             raise ValueError("Either `probs` or `logits` must be specified, but not both.")
-        if probs is not None:
-            is_scalar = isinstance(probs, Number)
-            self.probs, = broadcast_all(probs)
-        else:
+        if probs is None:
             is_scalar = isinstance(logits, Number)
             self.logits, = broadcast_all(logits)
-        self._param = self.probs if probs is not None else self.logits
+            self._param = self.logits
+        else:
+            is_scalar = isinstance(probs, Number)
+            self.probs, = broadcast_all(probs)
+            self._param = self.probs
+
         if is_scalar:
             batch_shape = torch.Size()
         else:


### PR DESCRIPTION
Reading through the distributions, the same logic was used in preceding lines in some of the __init__'s. I removed the redundancy.

Also, wanted to make the if statements there a little more readable as `if None` instead of the double negative of `if not None` since there is an `else` statement. Not sold if this is an improvement, but it makes it better for me at this moment!