### PR TITLE
Re-enable TestJit.test_profiler

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -367,7 +367,6 @@ class TestJitProfiler(JitTestCase):
             self.graph_executor_optimize_opt
         )
 
-    @unittest.skipIf(IS_WINDOWS, 'TODO: fix occasional windows failure')
     def test_profiler(self):
         torch._C._set_graph_executor_optimize(False)
 


### PR DESCRIPTION
Test to see if TestJit.test_profiler still fails on Windows on CI. 
I was not able to reproduce the crash locally. Also I tested 3 times on CI and the test passed.
Even with this change the test will still be disabled due to https://github.com/pytorch/pytorch/issues/81626
Fixes #62820


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel