### PR TITLE
[inductor] Fix a conv stride assertion

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6684,6 +6684,40 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             )
             self.assertTrue(same(fn(*inputs), inputs[0] + inputs[1]))
 
+        @config.patch(tune_layout=True)
+        def test_tune_layout(self):
+            class Repro(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+
+                def forward(self, arg1_1, unsqueeze, unsqueeze_1):
+                    convolution_1 = torch.ops.aten.convolution.default(
+                        unsqueeze,
+                        unsqueeze_1,
+                        arg1_1,
+                        [1, 1],
+                        [1, 0],
+                        [1, 1],
+                        False,
+                        [0, 0],
+                        1,
+                    )
+                    unsqueeze = unsqueeze_1 = arg1_1 = None
+                    return (convolution_1,)
+
+            args = [
+                ((512,), (1,), torch.float16, "cuda"),
+                ((4096, 512, 16, 1), (8192, 16, 1, 1), torch.float16, "cuda"),
+                ((512, 512, 3, 1), (1536, 3, 1, 1), torch.float16, "cuda"),
+            ]
+            args = [rand_strided(sh, st, dt, dev) for (sh, st, dt, dev) in args]
+
+            mod = Repro()
+            opt_mod = torch._dynamo.optimize("inductor")(mod)
+            ref = mod(*args)
+            res = opt_mod(*args)
+            self.assertTrue(same(ref, res))
+
         @config.patch({"triton.cudagraphs": True})
         def test_inplace_updates_cudagraphs(self):
             class Repro(torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94405

Summary: The issue appears when _inductor.config.tune_layout is set. If
we pick a different aten convolution memory format, we need to transform
its input layout.

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10