### PR TITLE
[quant][fx] Change prepare_fx and convert_fx to preserve the GraphModule type of input

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -12,6 +12,7 @@ import torch.ao.nn.intrinsic as nni
 import torch.ao.nn.intrinsic.quantized as nniq
 import torch.ao.nn.intrinsic.quantized.dynamic as nniqd
 import torch.multiprocessing as mp
+from torch.fx.graph_module import _USER_PRESERVED_ATTRIBUTES_KEY
 
 # graph mode quantization based on fx
 from torch.ao.quantization.quantize_fx import (
@@ -879,7 +880,7 @@ class TestFuseFx(QuantizationTestCase):
         m = fuse_fx(m, backend_config=backend_config)
         self.assertEqual(type(m.conv1), torch.nn.Conv2d)
         self.assertEqual(type(m.conv2), torch.nn.Conv2d)
-        # check relu are gone since we replaced the both patterns to conv
+        # check relu are gone since we replaced both patterns to conv
         self.assertFalse(hasattr(m, "relu1"))
         self.assertFalse(hasattr(m, "relu2"))
 
@@ -2761,11 +2762,11 @@ class TestQuantizeFx(QuantizationTestCase):
 
         # run it through input
         model(x)
+        # save state_dict of model
+        obs_dict = torch.ao.quantization.get_observer_state_dict(model)
 
         quant = convert_fx(model)
 
-        # save state_dict of model
-        obs_dict = torch.ao.quantization.get_observer_state_dict(model)
         b = io.BytesIO()
         torch.save(obs_dict, b)
         b.seek(0)
@@ -3412,7 +3413,6 @@ class TestQuantizeFx(QuantizationTestCase):
         # Expect each quantized linear op to have a scale and zero point
         self.assertTrue(scale_count == 3, "Expect each quantized linear op to have a scale in state_dict")
         self.assertTrue(zero_point_count == 3, "Expect each quantized linear op to have a zero_point in state_dict")
-        # ensure it runs
         m(*example_inputs)
         # ensure it is scriptable
         scripted = torch.jit.script(m)
@@ -4221,13 +4221,19 @@ class TestQuantizeFx(QuantizationTestCase):
             {"": default_qconfig},
             example_inputs=(torch.randn(1),),
             prepare_custom_config={"preserved_attributes": ["attr"]})
+        # preserved attributes are also stored in meta so that it doesn't get lost
+        # during deepcopy
         self.assertTrue(hasattr(m, "attr"))
+        self.assertTrue("attr" in m.meta[_USER_PRESERVED_ATTRIBUTES_KEY])
         m2 = copy.deepcopy(m)
         self.assertTrue(hasattr(m2, "attr"))
+        self.assertTrue("attr" in m2.meta[_USER_PRESERVED_ATTRIBUTES_KEY])
         m = convert_fx(m, convert_custom_config={"preserved_attributes": ["attr"]})
         self.assertTrue(hasattr(m, "attr"))
+        self.assertTrue("attr" in m.meta[_USER_PRESERVED_ATTRIBUTES_KEY])
         m2 = copy.deepcopy(m)
         self.assertTrue(hasattr(m2, "attr"))
+        self.assertTrue("attr" in m2.meta[_USER_PRESERVED_ATTRIBUTES_KEY])
 
     def test_output_lists_and_dicts(self):
         """Verify that specifying complicated output types does not crash.

--- a/torch/ao/ns/_numeric_suite_fx.py
+++ b/torch/ao/ns/_numeric_suite_fx.py
@@ -122,6 +122,7 @@ from .fx.ns_types import (
 from torch.ao.quantization.backend_config.utils import get_fusion_pattern_to_root_node_getter
 from torch.ao.quantization.backend_config import BackendConfig
 from torch.ao.quantization.fx.match_utils import _find_matches
+from torch.ao.quantization.fx.graph_module import _get_observed_graph_module_attr
 from torch.ao.quantization.fx.qconfig_mapping_utils import _generate_node_name_to_qconfig
 from torch.ao.quantization.fx.quantize_handler import _get_pattern_to_quantize_handlers
 from torch.ao.quantization.qconfig import QConfigAny
@@ -398,11 +399,13 @@ def extract_weights(
     tracer_a = NSTracer(skipped_module_names, skipped_module_classes)
     tracer_b = NSTracer(skipped_module_names, skipped_module_classes)
     gm_a = GraphModule(model_a, tracer_a.trace(model_a))
-    if hasattr(model_a, '_node_name_to_scope'):
-        gm_a._node_name_to_scope = model_a._node_name_to_scope
+    maybe_model_a_node_name_to_scope = _get_observed_graph_module_attr(model_a, 'node_name_to_scope')
+    if maybe_model_a_node_name_to_scope is not None:
+        gm_a._node_name_to_scope = maybe_model_a_node_name_to_scope
     gm_b = GraphModule(model_b, tracer_b.trace(model_b))
-    if hasattr(model_b, '_node_name_to_scope'):
-        gm_b._node_name_to_scope = model_b._node_name_to_scope
+    maybe_model_b_node_name_to_scope = _get_observed_graph_module_attr(model_b, 'node_name_to_scope')
+    if maybe_model_b_node_name_to_scope is not None:
+        gm_b._node_name_to_scope = maybe_model_b_node_name_to_scope
     return _extract_weights_impl(
         model_name_a, gm_a, model_name_b, gm_b, base_name_to_sets_of_related_ops,
         unmatchable_types_map, op_to_type_to_weight_extraction_fn)
@@ -509,11 +512,13 @@ def add_loggers(
     tracer_a = NSTracer(skipped_module_names, skipped_module_classes)
     tracer_b = NSTracer(skipped_module_names, skipped_module_classes)
     gm_a = GraphModule(model_a, tracer_a.trace(model_a))
-    if hasattr(model_a, '_node_name_to_scope'):
-        gm_a._node_name_to_scope = model_a._node_name_to_scope
+    maybe_model_a_node_name_to_scope = _get_observed_graph_module_attr(model_a, 'node_name_to_scope')
+    if maybe_model_a_node_name_to_scope is not None:
+        gm_a._node_name_to_scope = maybe_model_a_node_name_to_scope
     gm_b = GraphModule(model_b, tracer_b.trace(model_b))
-    if hasattr(model_b, '_node_name_to_scope'):
-        gm_b._node_name_to_scope = model_b._node_name_to_scope
+    maybe_model_b_node_name_to_scope = _get_observed_graph_module_attr(model_b, 'node_name_to_scope')
+    if maybe_model_b_node_name_to_scope is not None:
+        gm_b._node_name_to_scope = maybe_model_b_node_name_to_scope
     return _add_loggers_impl(
         name_a, gm_a, name_b, gm_b, logger_cls,
         should_log_inputs=should_log_inputs,
@@ -662,11 +667,13 @@ def add_shadow_loggers(
     tracer_a = NSTracer(skipped_module_names, skipped_module_classes)
     tracer_b = NSTracer(skipped_module_names, skipped_module_classes)
     gm_a = GraphModule(model_a, tracer_a.trace(model_a))
-    if hasattr(model_a, '_node_name_to_scope'):
-        gm_a._node_name_to_scope = model_a._node_name_to_scope
+    maybe_model_a_node_name_to_scope = _get_observed_graph_module_attr(model_a, 'node_name_to_scope')
+    if maybe_model_a_node_name_to_scope is not None:
+        gm_a._node_name_to_scope = maybe_model_a_node_name_to_scope
     gm_b = GraphModule(model_b, tracer_b.trace(model_b))
-    if hasattr(model_b, '_node_name_to_scope'):
-        gm_b._node_name_to_scope = model_b._node_name_to_scope
+    maybe_model_b_node_name_to_scope = _get_observed_graph_module_attr(model_b, 'node_name_to_scope')
+    if maybe_model_b_node_name_to_scope is not None:
+        gm_b._node_name_to_scope = maybe_model_b_node_name_to_scope
     return _add_shadow_loggers_impl(
         name_a, gm_a, name_b, gm_b, logger_cls,
         should_log_inputs=should_log_inputs,

--- a/torch/ao/quantization/fx/_equalize.py
+++ b/torch/ao/quantization/fx/_equalize.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 import torch.ao.nn.intrinsic as nni
 from torch.fx import GraphModule
 from torch.fx.graph import Node
+from torch.ao.quantization.fx.graph_module import _get_observed_graph_module_attr
 
 from torch.ao.quantization.backend_config import get_native_backend_config
 
@@ -296,7 +297,9 @@ def get_op_node_and_weight_eq_obs(
     if op_node.op == 'call_module':
         # If the op_node is a nn.Linear layer, then it must have a
         # WeightEqualizationObserver configuration
-        equalization_node_name_to_qconfig: Dict[str, Any] = model._equalization_node_name_to_qconfig  # type: ignore[assignment]
+        maybe_equalization_node_name_to_config = _get_observed_graph_module_attr(model, "equalization_node_name_to_qconfig")
+        assert maybe_equalization_node_name_to_config is not None
+        equalization_node_name_to_qconfig: Dict[str, Any] = maybe_equalization_node_name_to_config  # type: ignore[assignment]
         assert(equalization_node_name_to_qconfig.get(op_node.name, None) is not None)
         weight_eq_obs = equalization_node_name_to_qconfig.get(op_node.name, None).weight()
 

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -10,7 +10,7 @@ import torch.ao.nn.quantized as nnq
 import torch.ao.nn.quantized.dynamic as nnqd
 import torch.ao.nn.quantized.reference as nnqr
 from torch.ao.nn.quantized.modules.utils import WeightedQuantizedModule
-from .graph_module import QuantizedGraphModule
+from torch.fx import GraphModule
 from .utils import (
     collect_producer_nodes,
     get_linear_prepack_op_for_dtype,
@@ -346,10 +346,29 @@ QBIN_RELU_OP_MAPPING: Dict[Union[Callable, str], Callable] = {
     torch.mul: torch.ops.quantized.mul_relu,
 }
 
+def _save_packed_weight(self, destination, prefix, keep_vars):
+    for attr_name in dir(self):
+        if "_packed_weight" in attr_name and \
+           isinstance(getattr(self, attr_name), torch._C.ScriptObject):  # type: ignore[attr-defined]
+            packed_weight = getattr(self, attr_name)
+            destination[prefix + attr_name] = packed_weight
+
+def _load_packed_weight(self, state_dict, prefix, local_metadata, strict,
+                        missing_keys, unexpected_keys, error_msgs):
+    attrs_to_pop = []
+    for attr_name in state_dict:
+        if attr_name.startswith("_packed_weight") and isinstance(state_dict[attr_name], torch._C.ScriptObject):  # type: ignore[attr-defined] # noqa: B950
+            setattr(self, attr_name, state_dict[attr_name])
+            attrs_to_pop.append(attr_name)
+
+    # pop the packed param attributesn
+    for attr_name in attrs_to_pop:
+        state_dict.pop(attr_name)
+
 def fold_weight(
-    quantized: QuantizedGraphModule,
+    quantized_model: GraphModule,
     node_name_to_scope: Dict[str, Tuple[str, type]]
-) -> QuantizedGraphModule:
+) -> GraphModule:
     """
     Trace back from the weight node util we hit getattr, reconstruct the
     graph module with the traced nodes and run the graph module to pack the
@@ -359,7 +378,7 @@ def fold_weight(
     # map from folded node name to the prepacked weight name
     folded_nodes = {}
     # get packed weights
-    for node in quantized.graph.nodes:
+    for node in quantized_model.graph.nodes:
         if node.op == 'call_function' and node.target in WEIGHT_PREPACK_OPS:
             nodes_to_fold = collect_producer_nodes(node)
             if nodes_to_fold is not None:
@@ -367,7 +386,7 @@ def fold_weight(
                     folded_nodes[node_to_fold.name] = node
 
                 prepacking_module = graph_module_from_producer_nodes(
-                    quantized, nodes_to_fold)
+                    quantized_model, nodes_to_fold)
                 packed_weight = prepacking_module()
                 packed_weights[node.name] = packed_weight
 
@@ -377,10 +396,8 @@ def fold_weight(
 
     def load_arg(a):
         return map_arg(a, lambda node: env[node.name])
-    quantized_root = quantized
-    quantized_graph = quantized.graph
 
-    for node in quantized_graph.nodes:
+    for node in quantized_model.graph.nodes:
         prepack_node = folded_nodes.get(node.name, None)
         if prepack_node is node:
             packed_weight = packed_weights[node.name]
@@ -389,8 +406,8 @@ def fold_weight(
             module_path, _ = node_name_to_scope[op_node.name]
             get_new_packed_weight_name = \
                 get_new_attr_name_with_prefix(module_path + '_packed_weight_')
-            packed_weight_name = get_new_packed_weight_name(quantized_root)
-            setattr(quantized_root, packed_weight_name, packed_weight)
+            packed_weight_name = get_new_packed_weight_name(quantized_model)
+            setattr(quantized_model, packed_weight_name, packed_weight)
             # replace prepack node with a getattr node
             env[node.name] = folded_graph.create_node(
                 'get_attr', packed_weight_name, (), {})
@@ -400,7 +417,11 @@ def fold_weight(
         else:
             # copy other nodes
             env[node.name] = folded_graph.node_copy(node, load_arg)
-    return QuantizedGraphModule(quantized_root, folded_graph, quantized_root.preserved_attr_names)
+
+    quantized_model = GraphModule(quantized_model, folded_graph)
+    quantized_model._register_state_dict_hook(_save_packed_weight)
+    quantized_model._register_load_state_dict_pre_hook(_load_packed_weight, with_module=True)
+    return quantized_model
 
 def _get_module(node: Node, modules: Dict[str, nn.Module]) -> Optional[nn.Module]:
     """
@@ -542,7 +563,7 @@ def _match_static_pattern_with_two_inputs(
     return (q_node, ref_node)
 
 def _lower_static_weighted_ref_module(
-        model: QuantizedGraphModule,
+        model: GraphModule,
         qconfig_map: Dict[str, QConfigAny]):
     """
     Traverse the graph and find dequantize - ref module - quantize patterns
@@ -592,7 +613,7 @@ def _lower_static_weighted_ref_module(
         model.graph.erase_node(zero_point_node)
 
 def _lower_static_weighted_ref_module_with_two_inputs(
-        model: QuantizedGraphModule,
+        model: GraphModule,
         qconfig_map: Dict[str, QConfigAny]):
     """
     Traverse the graph and find patterns
@@ -651,7 +672,7 @@ def _lower_static_weighted_ref_module_with_two_inputs(
         model.graph.erase_node(scale_node)
         model.graph.erase_node(zero_point_node)
 
-def _lower_dynamic_weighted_ref_module(model: QuantizedGraphModule):
+def _lower_dynamic_weighted_ref_module(model: GraphModule):
     """
     Traverse the graph and find quantize_per_tensor_dynamic - dequantize - ref_module patterns
     and replace them with the dynamically quantized version of the ref module.
@@ -696,7 +717,7 @@ def _lower_dynamic_weighted_ref_module(model: QuantizedGraphModule):
         setattr(named_modules[parent_name], module_name, q_module)
         ref_node.replace_input_with(dq_node, input_dynamic_q_node.args[0])
 
-def _lower_weight_only_weighted_ref_module(model: QuantizedGraphModule):
+def _lower_weight_only_weighted_ref_module(model: GraphModule):
     """
     Traverse the graph and find ref_module patterns
     and replace them with the weight only quantized version of the ref module.
@@ -722,7 +743,7 @@ def _lower_weight_only_weighted_ref_module(model: QuantizedGraphModule):
         setattr(named_modules[parent_name], module_name, q_module)
 
 def _lower_static_weighted_ref_functional(
-        model: QuantizedGraphModule,
+        model: GraphModule,
         qconfig_map: Dict[str, QConfigAny]):
     """
     Traverse the graph and replace functional reference patterns with their quantized versions.
@@ -783,7 +804,7 @@ def _lower_static_weighted_ref_functional(
             model.graph.erase_node(relu_node)
 
 def _lower_dynamic_weighted_ref_functional(
-        model: QuantizedGraphModule,
+        model: GraphModule,
         qconfig_map: Dict[str, QConfigAny]):
     """
     Traverse the graph and replace functional reference patterns with their dynamically
@@ -886,7 +907,7 @@ def _lower_dynamic_weighted_ref_functional(
             model.graph.erase_node(relu_node)
 
 def _lower_quantized_binary_op(
-        model: QuantizedGraphModule,
+        model: GraphModule,
         qconfig_map: Dict[str, QConfigAny]):
     binary_ops_to_lower: List[Callable] = [operator.add, torch.add, operator.mul, torch.mul, torch.matmul]
     modules = dict(model.named_modules(remove_duplicate=False))
@@ -936,7 +957,7 @@ def _lower_quantized_binary_op(
             model.graph.erase_node(relu_node)
         model.graph.erase_node(bop_node)
 
-def special_pattern_replacement(model: QuantizedGraphModule):
+def special_pattern_replacement(model: GraphModule):
     modules = dict(model.named_modules(remove_duplicate=False))
     for n in model.graph.nodes:
         q_node = n
@@ -1044,7 +1065,7 @@ def special_pattern_replacement(model: QuantizedGraphModule):
 
     return model
 
-def _lower_getattr_tensor_metadta_op(model: QuantizedGraphModule):
+def _lower_getattr_tensor_metadta_op(model: GraphModule):
     """ Modified the graph of the model inplace, to skip extra dequantize op before
     the general tensor shape ops when possible
     """
@@ -1058,7 +1079,7 @@ def _lower_getattr_tensor_metadta_op(model: QuantizedGraphModule):
             args[0] = n.args[0].args[0]
             n.args = tuple(args)
 
-def _lower_get_tensor_info_op(model: QuantizedGraphModule):
+def _lower_get_tensor_info_op(model: GraphModule):
     """ Modified the graph of the model inplace, to skip extra dequantize op before
     the general tensor shape ops when possible
     """
@@ -1074,10 +1095,10 @@ def _lower_get_tensor_info_op(model: QuantizedGraphModule):
         n.args = tuple(args)
 
 def _lower_to_native_backend(
-    model: QuantizedGraphModule,
+    model: GraphModule,
     qconfig_map: Dict[str, QConfigAny],
     node_name_to_scope: Dict[str, Tuple[str, type]]
-) -> QuantizedGraphModule:
+) -> GraphModule:
     """ Lower a quantized reference model (with reference quantized operator patterns)
     to the native backend in PyTorch (fbgemm/qnnpack), both backends shares the same
     operator signature so they can be lowered with the same function

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -42,7 +42,6 @@ from torch.ao.quantization.backend_config import (
 )
 from torch.ao.quantization.observer import _is_activation_post_process
 from .graph_module import (
-    QuantizedGraphModule,
     _is_observed_module,
     _is_observed_standalone_module,
 )
@@ -445,18 +444,6 @@ def _is_conversion_supported(activation_post_process: torch.nn.Module) -> bool:
         dtype == torch.float16
     )
 
-def _restore_state(
-        observed: torch.nn.Module
-) -> Tuple[Dict[str, Tuple[str, type]],
-           PrepareCustomConfig,
-           Set[str]]:
-    assert _is_observed_module(observed), \
-        'incoming model must be produced by prepare_fx'
-    prepare_custom_config: PrepareCustomConfig = observed._prepare_custom_config  # type: ignore[assignment]
-    node_name_to_scope: Dict[str, Tuple[str, type]] = observed._node_name_to_scope  # type: ignore[assignment]
-    observed_node_names: Set[str] = observed._observed_node_names  # type: ignore[assignment]
-    return node_name_to_scope, prepare_custom_config, observed_node_names
-
 def _has_none_qconfig(node: Argument, node_name_to_qconfig: Dict[str, QConfigAny]) -> bool:
     """ Check if a node has a qconfig of None, i.e. user requested to not quantize
     the node
@@ -607,8 +594,7 @@ def convert_standalone_module(
     observed_standalone_module : GraphModule = modules[str(node.target)]  # type: ignore[assignment]
     sm_input_quantized_idxs = \
         observed_standalone_module \
-        ._standalone_module_input_quantized_idxs\
-        .tolist()  # type: ignore[operator]
+        .meta["_observed_graph_module_attrs"].standalone_module_input_quantized_idxs
     # remove the dequantize nodes for inputs
     args = list(node.args)
     for idx in range(len(args)):
@@ -622,8 +608,7 @@ def convert_standalone_module(
     # add dequantize node for output
     sm_output_quantized_idxs = \
         observed_standalone_module \
-        ._standalone_module_output_quantized_idxs \
-        .tolist()  # type: ignore[operator]
+        .meta["_observed_graph_module_attrs"].standalone_module_output_quantized_idxs
     if len(sm_output_quantized_idxs) > 0:
         assert sm_output_quantized_idxs[0] == 0, "Currently only quantized"
         "output idxs = [0] is supported"
@@ -899,8 +884,13 @@ def convert(
     if backend_config is None:
         backend_config = get_native_backend_config()
 
-    node_name_to_scope, prepare_custom_config, observed_node_names = _restore_state(model)
-    node_name_to_qconfig: Dict[str, QConfigAny] = model._node_name_to_qconfig  # type: ignore[assignment]
+    assert _is_observed_module(model), \
+        'incoming model must be produced by prepare_fx'
+    observed_graph_module_attrs = model.meta["_observed_graph_module_attrs"]
+    node_name_to_scope: Dict[str, Tuple[str, type]] = observed_graph_module_attrs.node_name_to_scope
+    prepare_custom_config: PrepareCustomConfig = observed_graph_module_attrs.prepare_custom_config
+    observed_node_names: Set[str] = observed_graph_module_attrs.observed_node_names
+    node_name_to_qconfig: Dict[str, QConfigAny] = observed_graph_module_attrs.node_name_to_qconfig  # type: ignore[assignment]
 
     # mapping from fully qualified module name to module instance
     # for example,
@@ -916,10 +906,10 @@ def convert(
     # TODO refactor this code once we update the prepare logic to have additional information on
     # which graph nodes have been observed and share that with convert to decide which observers to ignore.
     if qconfig_mapping:
-        prepare_qconfig_mapping: QConfigMapping = model._qconfig_mapping  # type: ignore[assignment]
+        prepare_qconfig_mapping: QConfigMapping = observed_graph_module_attrs.qconfig_mapping  # type: ignore[assignment]
         modules_copy = copy.deepcopy(modules)
 
-        if model._is_qat:
+        if observed_graph_module_attrs.is_qat:
             _update_qconfig_for_qat(qconfig_mapping, backend_config)
         _update_qconfig_for_fusion(model, qconfig_mapping)
 
@@ -940,7 +930,7 @@ def convert(
     custom_module_classes = get_custom_module_class_keys(convert_custom_config.observed_to_quantized_mapping)
     custom_module_class_mapping = convert_custom_config.observed_to_quantized_mapping
 
-    if model._equalization_node_name_to_qconfig is not None:
+    if observed_graph_module_attrs.equalization_node_name_to_qconfig is not None:
         # If we want to do equalization then do the following:
         # Calculate the equalization scale, update the observers with the scaled
         # inputs, and scale the weight
@@ -1037,19 +1027,19 @@ def convert(
                     node, model.graph, modules, custom_module_class_mapping,
                     statically_quantized_custom_module_nodes)
 
-    preserved_attributes = set(convert_custom_config.preserved_attributes)
-    model = QuantizedGraphModule(model, copy.deepcopy(model.graph), preserved_attributes)
-
     # remove deadcode after converting observers to quant/dequant ops
     model.graph.eliminate_dead_code()
-    model.recompile()
+    model = GraphModule(model, model.graph)
 
     # TODO: maybe move this to quantize_fx.py
     if not is_reference:
         model = lower_to_fbgemm(model, node_name_to_qconfig, node_name_to_scope)
+
     # TODO: this looks hacky, we want to check why we need this and see if we can
     # remove this
     # removes qconfig and activation_post_process modules
     if _remove_qconfig_flag:
         _remove_qconfig(model)
+    model.delete_all_unused_submodules()
+    model.meta.pop("_observed_graph_module_attrs", None)
     return model

--- a/torch/ao/quantization/fx/lower_to_fbgemm.py
+++ b/torch/ao/quantization/fx/lower_to_fbgemm.py
@@ -1,15 +1,15 @@
 from ._lower_to_native_backend import _lower_to_native_backend
-from .graph_module import QuantizedGraphModule
 from ..qconfig import QConfigAny
+from torch.fx import GraphModule
 from typing import Dict, Tuple
 
 __all__ = ['lower_to_fbgemm']
 
 def lower_to_fbgemm(
-    model: QuantizedGraphModule,
+    model: GraphModule,
     qconfig_map: Dict[str, QConfigAny],
     node_name_to_scope: Dict[str, Tuple[str, type]]
-) -> QuantizedGraphModule:
+) -> GraphModule:
     """ Lower a quantized reference model (with reference quantized operator patterns)
     to fbgemm
     """

--- a/torch/ao/quantization/fx/lower_to_qnnpack.py
+++ b/torch/ao/quantization/fx/lower_to_qnnpack.py
@@ -1,6 +1,6 @@
 from ._lower_to_native_backend import _lower_to_native_backend
-from .graph_module import QuantizedGraphModule
 from ..qconfig import QConfigAny
+from torch.fx import GraphModule
 from typing import Dict, Tuple
 
 __all__ = [
@@ -8,10 +8,10 @@ __all__ = [
 ]
 
 def lower_to_qnnpack(
-    model: QuantizedGraphModule,
+    model: GraphModule,
     qconfig_map: Dict[str, QConfigAny],
     node_name_to_scope: Dict[str, Tuple[str, type]]
-) -> QuantizedGraphModule:
+) -> GraphModule:
     """ Lower a quantized reference model (with reference quantized operator patterns)
     to qnnpack
     """

--- a/torch/ao/quantization/fx/utils.py
+++ b/torch/ao/quantization/fx/utils.py
@@ -27,6 +27,7 @@ from torch.ao.quantization.utils import (
     activation_is_statically_quantized,
 )
 from torch.ao.quantization.observer import _is_activation_post_process
+from torch.ao.quantization.qconfig_mapping import QConfigMapping
 
 from torch.fx import GraphModule, map_arg
 
@@ -39,6 +40,7 @@ from .custom_config import PrepareCustomConfig
 from ._decomposed import quantized_decomposed_lib  # noqa: F401
 
 from typing import Callable, Optional, List, Dict, Any, Set, Tuple, Union, Type
+from dataclasses import dataclass
 from collections import namedtuple
 import operator
 import warnings
@@ -66,9 +68,23 @@ __all__ = [
     "NON_OBSERVABLE_ARG_DICT",
     "NON_QUANTIZABLE_WEIGHT_OPS",
     "return_arg_list",
+    "ObservedGraphModuleAttrs",
 ]
 
 NON_QUANTIZABLE_WEIGHT_OPS = {torch.nn.functional.layer_norm, torch.nn.functional.group_norm, torch.nn.functional.instance_norm}
+
+@dataclass
+class ObservedGraphModuleAttrs:
+    node_name_to_qconfig: Dict[str, QConfigAny]
+    node_name_to_scope: Dict[str, Tuple[str, type]]
+    prepare_custom_config: PrepareCustomConfig
+    equalization_node_name_to_qconfig: Dict[str, Any]
+    qconfig_mapping: QConfigMapping
+    is_qat: bool
+    observed_node_names: Set[str]
+    is_observed_standalone_module: bool = False
+    standalone_module_input_quantized_idxs: Optional[List[int]] = None
+    standalone_module_output_quantized_idxs: Optional[List[int]] = None
 
 def node_arg_is_weight(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
     """Returns if node arg is weight"""

--- a/torch/ao/quantization/quantize_fx.py
+++ b/torch/ao/quantization/quantize_fx.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, Optional, Set, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 import warnings
 
 import torch
+import copy
 from torch.fx import GraphModule
+from torch.fx.graph_module import _USER_PRESERVED_ATTRIBUTES_KEY
 from .fx.tracer import QuantizationTracer
 from .fx.tracer import (  # noqa: F401
     Scope,
@@ -15,7 +17,7 @@ from .backend_config import (  # noqa: F401
     BackendConfig,
     get_tensorrt_backend_config,
 )
-from .fx.graph_module import ObservedGraphModule
+from .fx.graph_module import ObservedGraphModule  # noqa: F401
 from .fx.custom_config import (
     ConvertCustomConfig,
     FuseCustomConfig,
@@ -24,6 +26,16 @@ from .fx.custom_config import (
 from .fx.utils import get_custom_module_class_keys  # noqa: F401
 from .fx.utils import get_skipped_module_name_and_classes
 from .qconfig_mapping import QConfigMapping
+
+def attach_preserved_attrs_to_model(
+        model: Union[GraphModule, torch.nn.Module], preserved_attrs: Dict[str, Any]):
+    """ Store preserved attributes to the model.meta so that it can be preserved during deepcopy
+    """
+    model.meta[_USER_PRESERVED_ATTRIBUTES_KEY] = copy.copy(preserved_attrs)  # type: ignore[operator, index, assignment]
+    # set the preserved attributes in the model so that user can call
+    # model.attr as they do before calling fx graph mode quantization
+    for attr_name, attr in model.meta[_USER_PRESERVED_ATTRIBUTES_KEY].items():  # type: ignore[index, union-attr]
+        setattr(model, attr_name, attr)
 
 def _check_is_graph_module(model: torch.nn.Module) -> None:
     if not isinstance(model, GraphModule):
@@ -77,7 +89,6 @@ def _fuse_fx(
     return fuse(
         model, is_qat, fuse_custom_config, backend_config)  # type: ignore[operator]
 
-
 def _prepare_fx(
     model: torch.nn.Module,
     qconfig_mapping: Union[QConfigMapping, Dict[str, Any]],
@@ -87,7 +98,7 @@ def _prepare_fx(
     _equalization_config: Optional[Union[QConfigMapping, Dict[str, Any]]] = None,
     backend_config: Union[BackendConfig, Dict[str, Any], None] = None,
     is_standalone_module: bool = False,
-) -> ObservedGraphModule:
+) -> GraphModule:
     r""" Internal helper function for prepare_fx
     Args:
       `model`, `qconfig_mapping`, `prepare_custom_config`, `_equalization_config`:
@@ -115,14 +126,13 @@ forward graph of the parent module,
 
     skipped_module_names, skipped_module_classes = \
         get_skipped_module_name_and_classes(prepare_custom_config, is_standalone_module)
-    preserved_attributes = prepare_custom_config.preserved_attributes
+    preserved_attr_names = prepare_custom_config.preserved_attributes
+    preserved_attrs = {attr: getattr(model, attr) for attr in preserved_attr_names if hasattr(model, attr)}
     # symbolically trace the model
     tracer = QuantizationTracer(skipped_module_names, skipped_module_classes)  # type: ignore[arg-type]
     graph_module = GraphModule(model, tracer.trace(model))
     _attach_meta_to_node_if_not_exist(graph_module)
 
-    for attr_name in preserved_attributes:
-        setattr(graph_module, attr_name, getattr(model, attr_name))
     fuse_custom_config = FuseCustomConfig().set_preserved_attributes(prepare_custom_config.preserved_attributes)
     graph_module = _fuse_fx(
         graph_module,
@@ -141,8 +151,7 @@ forward graph of the parent module,
         is_standalone_module=is_standalone_module,
     )  # type: ignore[operator]
 
-    for attr_name in preserved_attributes:
-        setattr(prepared, attr_name, getattr(model, attr_name))
+    attach_preserved_attrs_to_model(prepared, preserved_attrs)
     return prepared
 
 
@@ -164,13 +173,14 @@ def _prepare_standalone_module_fx(
 
     Returns:
 
-        * model(GraphModule): prepared standalone module. It has these attributes:
+        * model(GraphModule): prepared standalone module. It has these attributes in
+          model.meta:
 
-            * `_standalone_module_input_quantized_idxs(List[Int])`: a list of
+            * `standalone_module_input_quantized_idxs(List[Int])`: a list of
               indexes for the graph input that is expected to be quantized,
               same as input_quantized_idxs configuration provided
               for the standalone module
-            * `_standalone_module_output_quantized_idxs(List[Int])`: a list of
+            * `standalone_module_output_quantized_idxs(List[Int])`: a list of
               indexs for the graph output that is quantized
               same as input_quantized_idxs configuration provided
               for the standalone module
@@ -217,15 +227,15 @@ def fuse_fx(
         fuse_custom_config = FuseCustomConfig.from_dict(fuse_custom_config)
 
     torch._C._log_api_usage_once("quantization_api.quantize_fx.fuse_fx")
+    preserved_attr_names = fuse_custom_config.preserved_attributes
+    preserved_attrs = {attr: getattr(model, attr) for attr in preserved_attr_names if hasattr(model, attr)}
+
     graph_module = torch.fx.symbolic_trace(model)
     _attach_meta_to_node_if_not_exist(graph_module)
-    preserved_attributes: Set[str] = set()
-    if fuse_custom_config:
-        preserved_attributes = set(fuse_custom_config.preserved_attributes)
-    for attr_name in preserved_attributes:
-        setattr(graph_module, attr_name, getattr(model, attr_name))
-    return _fuse_fx(graph_module, False, fuse_custom_config, backend_config)
+    graph_module = _fuse_fx(graph_module, False, fuse_custom_config, backend_config)
 
+    attach_preserved_attrs_to_model(graph_module, preserved_attrs)
+    return graph_module
 
 def prepare_fx(
     model: torch.nn.Module,
@@ -234,7 +244,7 @@ def prepare_fx(
     prepare_custom_config: Union[PrepareCustomConfig, Dict[str, Any], None] = None,
     _equalization_config: Optional[Union[QConfigMapping, Dict[str, Any]]] = None,
     backend_config: Union[BackendConfig, Dict[str, Any], None] = None,
-) -> ObservedGraphModule:
+) -> GraphModule:
     r""" Prepare a model for post training static quantization
 
     Args:
@@ -384,7 +394,7 @@ def prepare_qat_fx(
     example_inputs: Tuple[Any, ...],
     prepare_custom_config: Union[PrepareCustomConfig, Dict[str, Any], None] = None,
     backend_config: Union[BackendConfig, Dict[str, Any], None] = None,
-) -> ObservedGraphModule:
+) -> GraphModule:
     r""" Prepare a model for quantization aware training
 
     Args:
@@ -506,6 +516,8 @@ def _convert_fx(
         convert_custom_config = ConvertCustomConfig.from_dict(convert_custom_config)
 
     _check_is_graph_module(graph_module)
+    preserved_attr_names = convert_custom_config.preserved_attributes
+    preserved_attrs = {attr: getattr(graph_module, attr) for attr in preserved_attr_names if hasattr(graph_module, attr)}
 
     quantized = convert(
         graph_module,
@@ -518,9 +530,7 @@ def _convert_fx(
         is_decomposed=is_decomposed,
     )
 
-    preserved_attributes = convert_custom_config.preserved_attributes
-    for attr_name in preserved_attributes:
-        setattr(quantized, attr_name, getattr(graph_module, attr_name))
+    attach_preserved_attrs_to_model(quantized, preserved_attrs)
     return quantized
 
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -18,6 +18,8 @@ import warnings
 
 __all__ = ["reduce_graph_module", "reduce_package_graph_module", "reduce_deploy_graph_module", "GraphModule"]
 
+_USER_PRESERVED_ATTRIBUTES_KEY = "_user_preserved_attributes"
+
 # Normal exec loses the source code, however we can work with
 # the linecache module to recover it.
 # Using _exec_with_source will add it to our local cache
@@ -709,9 +711,23 @@ class {module_name}(torch.nn.Module):
         fake_mod = torch.nn.Module()
         fake_mod.__dict__ = copy.deepcopy(self.__dict__, memo)
         GraphModule.__init__(res, fake_mod, fake_mod.__dict__['_graph'])
+        # hooks are lost during `GraphModule.__init__`, so we need to copy over
+        # them explicitly, note right now we are only copying state_dict related
+        # hooks, to reduce bc-related issues, we can copy forward/backward related
+        # hooks in the future as well if needed
+        extra_preserved_attrs = [
+            "_state_dict_hooks",
+            "_load_state_dict_pre_hooks",
+            "_load_state_dict_post_hooks"
+        ]
+        for attr in extra_preserved_attrs:
+            if attr in self.__dict__:
+                setattr(res, attr, copy.deepcopy(self.__dict__[attr], memo))
         res.meta = copy.deepcopy(getattr(self, 'meta', {}), memo)
+        if _USER_PRESERVED_ATTRIBUTES_KEY in res.meta:
+            for attr_name, attr in res.meta[_USER_PRESERVED_ATTRIBUTES_KEY].items():
+                setattr(res, attr_name, attr)
         return res
-
 
     def __copy__(self):
         res = GraphModule(self, self.graph)


### PR DESCRIPTION
Summary:
Previously prepare_fx returns an ObservedGraphModule and convert_fx returns a QuantizedGraphModule,
this is to preserve the attributes since torch.fx.GraphModule did not preserve them, after https://github.com/pytorch/pytorch/pull/92062
we are preserving `model.meta`, so we can store the attributes in model.meta now to preserve them.

With this, we don't need to create a new type of GraphModule in these functions and can use GraphModule directly, this
is useful for quantization in pytorch 2.0 flow, if other transformations are using GraphModule as well, the quantization passes will be composable with them

Test Plan:
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps
python test/test_quantization.py TestQuantizeFxModels
python test/test_quantization.py TestQuantizePT2E

Imported from OSS

Differential Revision: D42979722

