### PR TITLE
Add back in registration

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13788,6 +13788,12 @@
   variants: function
   autogen: scaled_dot_product_attention.out
 
+# TODO: THIS NEEDS TO BE REMOVED BUT PEOPLE HAVE TRAINED THEIR MODELS WITH THIS OP BUILTIN
+- func: _scaled_dot_product_attention(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool need_attn_weights=False, bool is_causal=False) -> (Tensor, Tensor)
+  python_module: nn
+  variants: function
+  autogen: _scaled_dot_product_attention.out
+
 # This aten function is kept so that we can test the choice function from Python
 - func: _fused_sdp_choice(Tensor query, Tensor key, Tensor value, Tensor? attn_mask=None, float dropout_p=0.0, bool is_causal=False) -> int
   dispatch:


### PR DESCRIPTION
Summary: Need to re-register the underscored function in order to have the op present in predictor. This is because older models have been exported with the underscored version.

Test Plan: See if predictor tests pass?

Reviewed By: cpuhrsch

Differential Revision: D43138338

