### PR TITLE
ao migration: fix broken import

### DIFF
--- a/test/quantization/ao_migration/test_ao_migration.py
+++ b/test/quantization/ao_migration/test_ao_migration.py
@@ -517,3 +517,9 @@ class TestAOMigrationNNIntrinsic(AOMigrationTestCase):
         ]
         self._test_function_import('linear_relu', function_list,
                                    base='nn.intrinsic.quantized.modules')
+
+    def test_modules_no_import_nn_intrinsic_quantized_dynamic(self):
+        # TODO(future PR): generalize this
+        import torch
+        _ = torch.ao.nn.intrinsic.quantized.dynamic
+        _ = torch.nn.intrinsic.quantized.dynamic

--- a/torch/nn/intrinsic/quantized/__init__.py
+++ b/torch/nn/intrinsic/quantized/__init__.py
@@ -1,4 +1,7 @@
 from .modules import *  # noqa: F403
+# to ensure customers can use the module below
+# without importing it directly
+import torch.nn.intrinsic.quantized.dynamic
 
 __all__ = [
     'BNReLU2d',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94453

Summary:

https://github.com/pytorch/pytorch/pull/94170 broke some Meta-only tests
because it broke the following syntax:

```
// file 1
import torch.nn.intrinsic

// file 2
_ = torch.nn.intrinsic.quantized.dynamic.*
```

This broke with the name change because the `ao` folder is currently
doing lazy import loading, but the original folders are not.

For now, just unbreak the folders needed for the tests to pass.
We will follow-up with ensuring this doesn't break for other folders
in a future PR.

Test plan:

```
python test/test_quantization.py -k AOMigrationNNIntrinsic.test_modules_no_import_nn_intrinsic_quantized_dynamic
```

Differential Revision: [D43141374](https://our.internmc.facebook.com/intern/diff/D43141374)