### PR TITLE
Fix saved tensor hooks to propogate errors back to python as-is

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7562,6 +7562,36 @@ for shape in [(1,), ()]:
 
         self.assertTrue(torch._C._autograd._saved_tensors_hooks_is_enabled())
 
+    def test_saved_tensor_hooks_custom_error_propagaation(self):
+        class CustomError(Exception):
+            pass
+
+        class error_on_pack_hook(torch.autograd.graph.saved_tensors_hooks):
+            def __init__(self):
+                def pack_hook(x):
+                    raise CustomError("pack")
+
+                super().__init__(pack_hook, lambda x: x)
+
+        class error_on_unpack_hook(torch.autograd.graph.saved_tensors_hooks):
+            def __init__(self):
+                def unpack_hook(x):
+                    raise CustomError("unpack")
+
+                super().__init__(lambda x: x, unpack_hook)
+
+        a = torch.tensor(1., requires_grad=True)
+
+        with error_on_pack_hook():
+            with self.assertRaisesRegex(CustomError, "pack"):
+                out = torch.sin(a)
+
+        with error_on_unpack_hook():
+            out = torch.sin(a)
+            with self.assertRaisesRegex(CustomError, "unpack"):
+                out.backward()
+
+
     def test_save_on_cpu_and_checkpoint(self):
         a = torch.randn(2, 2, requires_grad=True)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9688,7 +9688,7 @@ class TestAllowMutationOnSaved(TestCase):
             out = (a**2).sum()
 
         msg = "Trying to backward outside of the 'allow_mutation_on_saved_tensors' context"
-        with self.assertRaisesRegex(RuntimeError, msg):
+        with self.assertRaisesRegex(AssertionError, msg):
             out.backward()
 
         # Different context
@@ -9697,13 +9697,13 @@ class TestAllowMutationOnSaved(TestCase):
             out = (a**2).sum()
 
         with torch.autograd.graph.allow_mutation_on_saved_tensors() as ctx:
-            with self.assertRaisesRegex(RuntimeError, msg):
+            with self.assertRaisesRegex(AssertionError, msg):
                 out.backward()
 
     def test_disallow_nesting(self):
         with torch.autograd.graph.allow_mutation_on_saved_tensors() as ctx:
             msg = "allow_mutation_on_saved_tensors contexts cannot be nested"
-            with self.assertRaisesRegex(RuntimeError, msg):
+            with self.assertRaisesRegex(AssertionError, msg):
                 with torch.autograd.graph.allow_mutation_on_saved_tensors() as ctx:
                     pass
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9703,7 +9703,7 @@ class TestAllowMutationOnSaved(TestCase):
     def test_disallow_nesting(self):
         with torch.autograd.graph.allow_mutation_on_saved_tensors() as ctx:
             msg = "allow_mutation_on_saved_tensors contexts cannot be nested"
-            with self.assertRaisesRegex(AssertionError, msg):
+            with self.assertRaisesRegex(RuntimeError, msg):
                 with torch.autograd.graph.allow_mutation_on_saved_tensors() as ctx:
                     pass
 

--- a/torch/csrc/autograd/python_saved_variable_hooks.cpp
+++ b/torch/csrc/autograd/python_saved_variable_hooks.cpp
@@ -14,32 +14,33 @@ PySavedVariableHooks::PySavedVariableHooks(
       pack_hook_(pack_hook.release().ptr()),
       unpack_hook_(unpack_hook.release().ptr()) {}
 
+// We don't use pybind for call_pack_hook and call_unpack_hook to avoid
+// https://github.com/pytorch/pytorch/issues/34172
 void PySavedVariableHooks::call_pack_hook(const at::Tensor& tensor) {
   py::gil_scoped_acquire acquire;
-  auto pack_hook = py::reinterpret_borrow<py::function>(pack_hook_);
-  auto wrapped = THPVariable_Wrap(tensor);
-  py::object obj = py::reinterpret_steal<py::object>(wrapped);
-  py::object packed = pack_hook(obj);
-  data_ = packed.release().ptr();
-  // pack_hook, obj are decrefed on exit
-  // wrapped and packed had their references stolen
+  THPObjectPtr obj(THPVariable_Wrap(tensor));
+  THPObjectPtr packed(PyObject_CallFunctionObjArgs(pack_hook_, obj.get(), nullptr));
+  if (!packed) {
+    throw python_error();
+  }
+  data_ = packed.release();
+  // obj is decrefed on exit, packed has their references stolen
   // pack_hook_ and data_ will be manually decrefed when the saved variable is
   // released
 }
 
 at::Tensor PySavedVariableHooks::call_unpack_hook() {
   py::gil_scoped_acquire acquire;
-  auto unpack_hook = py::reinterpret_borrow<py::function>(unpack_hook_);
-  py::object obj = py::cast<py::object>(data_);
-  py::object res = unpack_hook(obj);
-  PyObject* ptr = res.ptr();
+  THPObjectPtr res(PyObject_CallFunctionObjArgs(unpack_hook_, data_, nullptr));
+  if (!res) {
+    throw python_error();
+  }
   TORCH_CHECK_TYPE(
-      THPVariable_Check(ptr),
+      THPVariable_Check(res),
       "Output of saved tensor unpack_hook expected to be a Tensor but got result of type ",
-      THPUtils_typename(ptr));
-  return THPVariable_Unpack(ptr);
-  // unpack_hook, obj and res are decrefed on exit
-  // ptr is only alive as long as res is
+      THPUtils_typename(res));
+  return THPVariable_Unpack(res);
+  // res is decrefed on exit
   // unpack_hook_ will be manually decrefed when the saved variable is released
 }
 

--- a/torch/csrc/autograd/python_saved_variable_hooks.cpp
+++ b/torch/csrc/autograd/python_saved_variable_hooks.cpp
@@ -19,7 +19,8 @@ PySavedVariableHooks::PySavedVariableHooks(
 void PySavedVariableHooks::call_pack_hook(const at::Tensor& tensor) {
   py::gil_scoped_acquire acquire;
   THPObjectPtr obj(THPVariable_Wrap(tensor));
-  THPObjectPtr packed(PyObject_CallFunctionObjArgs(pack_hook_, obj.get(), nullptr));
+  THPObjectPtr packed(
+      PyObject_CallFunctionObjArgs(pack_hook_, obj.get(), nullptr));
   if (!packed) {
     throw python_error();
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #90105
* #93912
* __->__ #94456

Mitigates the effect of https://github.com/pytorch/pytorch/issues/34172 for saved tensor hooks

BC Breaking message:
- Exceptions raised inside the pack and unpack hooks are no longer erroneously converted to RuntimeErrors. You should update your code to handle the original type of exception raised.

cc @ezyang @gchanan