### PR TITLE
Rollback fx.symbolic traced getitem

### DIFF
--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -886,7 +886,7 @@ def _create_wrapped_method(cls, name):
 
         # If there is no input with proxy, see if we are tracing with proxy tensors
         proxy_mode = get_innermost_proxy_mode()
-        if proxy_mode is not None:
+        if proxy_mode is not None and name != "__getitem__":
             # Disable tracing of the interior of the wrapped method while evaluating
             with disable_proxy_modes_tracing():
                 out = proxy_call(proxy_mode, orig_fn, args, kwargs)


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/93273 changes the `__getitem__` op traced by `fx.symbolic_trace` and causes a regression (?). A test is included in this PR for reproducing the error:
```
  File "/pytorch/torch/fx/node.py", line 42, in _find_module_of_method
    module = orig_method.__module__
AttributeError: 'wrapper_descriptor' object has no attribute '__module__'
```

A simple condition is added to `fx.symbolic_trace` to recovery the previous behaviour.

Another fix for this problem is #94461. Maybe the test here can be moved to #94461.