### PR TITLE
Adding zeroing tensor for QuantizedCPU type in yaml

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6347,7 +6347,7 @@
   device_check: NoCheck   # TensorIterator
   variants: method, function
   dispatch:
-    CPU, CUDA: zero_
+    CPU, CUDA, QuantizedCPU: zero_
     MPS: zero_mps_
     Meta: zero_meta_
     SparseCPU, SparseCUDA, SparseMeta: zero_sparse_


### PR DESCRIPTION
Summary:
Gradient Checkpointing uses QUint8 type tensor quantizer which currently not supported in dispatch key.

By adding QuantizedCPU for zero_ operation, we enable gradient checkpointing compatible to custom backward function.

Since it is just filling zero element in a tensor, we can simply use same zero which uses CPU backend.

Test Plan: Signals

Differential Revision: D43144214



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10