### PR TITLE
Ignore 7z locked usage log error on Windows non-ephemeral runners

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -74,6 +74,7 @@ runs:
 
     - name: Zip usage log for upload
       if: runner.os == 'Windows' && !inputs.use-gha
+      continue-on-error: true
       shell: powershell
       env:
         FILE_SUFFIX: ${{ inputs.file-suffix }}


### PR DESCRIPTION
This is the second times I spot this error on the new Windows non-ephemeral runners, so let's get it fixed. 

The error https://github.com/pytorch/pytorch/actions/runs/4130018165/jobs/7136942722 was during 7z-ing the usage log artifact on the runners:

```
WARNING: The process cannot access the file because it is being used by another process.
usage_log.txt
```

The locking process is probably the monitoring script.  This looks very similar to the issue on MacOS pet runners in which the monitoring script is not killed sometime.

I could try to kill the process to unlock the file.  But then not being able to upload the usage log here is arguably ok too.  So I think it would be easier to just ignore the locked file and move on.