### PR TITLE
Add dimension check in tensordot

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9164,6 +9164,15 @@ dedent """
         dims = 2
         self.checkScript(tensordot_dims_int, (a, b, dims))
 
+        for dims in [-1, 5]:
+            try:
+                tensordot_dims_int(a, b, dims)
+            except RuntimeError as error:
+                if dims < 0:
+                    self.assertEqual(str(error), "tensordot expects dims >= 0, but got dims=" + str(dims))
+                if dims > min(a.dim(), b.dim()):
+                    self.assertEqual(str(error), "tensordot expects dims < ndim_a or ndim_b, but got dims=" + str(dims))
+
     def test_torch_functional_tensordot_tensor(self):
         def tensordot_dims_tensor(a: torch.Tensor, b: torch.Tensor, dims: torch.Tensor):
             return torch.tensordot(a, b, dims=dims)

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1093,6 +1093,11 @@ def tensordot(a, b, dims=2, out: Optional[torch.Tensor] = None):  # noqa: F811
     if isinstance(dims, int):
         if dims < 0:
             raise RuntimeError(f"tensordot expects dims >= 0, but got dims={dims}")
+        ndim_a = a.dim()
+        ndim_b = b.dim()
+        expected_ndim = ndim_a if ndim_a <= ndim_b else ndim_b
+        if dims > expected_ndim:
+            raise RuntimeError(f"tensordot expects dims < ndim_a or ndim_b, but got dims={dims}")
         dims_a = list(range(-dims, 0))
         dims_b = list(range(dims))
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1093,10 +1093,7 @@ def tensordot(a, b, dims=2, out: Optional[torch.Tensor] = None):  # noqa: F811
     if isinstance(dims, int):
         if dims < 0:
             raise RuntimeError(f"tensordot expects dims >= 0, but got dims={dims}")
-        ndim_a = a.dim()
-        ndim_b = b.dim()
-        expected_ndim = ndim_a if ndim_a <= ndim_b else ndim_b
-        if dims > expected_ndim:
+        if dims > min(a.dim(), b.dim()):
             raise RuntimeError(f"tensordot expects dims < ndim_a or ndim_b, but got dims={dims}")
         dims_a = list(range(-dims, 0))
         dims_b = list(range(dims))


### PR DESCRIPTION
This PR is to add dimension check in tensordot. The expected dimension should be smaller than `dim_a` or `dim_b`.
Fix #91589

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10