### PR TITLE
fix torch.var backward when n==correction

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1569,7 +1569,10 @@ Tensor var_backward(
     // To apease ASAN
     auto n = self.numel();
     if (n == correction) {
-      return INFINITY * grad;
+      for (const auto i : c10::irange(self.dim())) {
+        grad = grad.unsqueeze(-1);
+      }
+      return std::numeric_limits<double>::quiet_NaN() * grad;
     } else {
       return (c10::SymFloat(2.0) /
               c10::SymFloat(self.sym_numel() - correction)) *

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1569,10 +1569,15 @@ Tensor var_backward(
     // To apease ASAN
     auto n = self.numel();
     if (n == correction) {
-      for (const auto i : c10::irange(self.dim())) {
-        grad = grad.unsqueeze(-1);
-      }
-      return std::numeric_limits<double>::quiet_NaN() * grad;
+      // when n == correction, 2 / (n - correction) is infinity
+      // when self == self.mean(), we return NaN because infinity * 0 = NaN
+      // otherwise, we return infinity because infinity * c = infinity, for all
+      // c > 0
+      return grad *
+          at::where(
+                 self == self.mean(),
+                 std::numeric_limits<double>::quiet_NaN(),
+                 std::numeric_limits<double>::infinity());
     } else {
       return (c10::SymFloat(2.0) /
               c10::SymFloat(self.sym_numel() - correction)) *


### PR DESCRIPTION
Fixes #94184

This PR, as discussed in [comment ](https://github.com/pytorch/pytorch/issues/94184#issuecomment-1422128166),  returns `x.grad` of same shape as `x`, and filled with `NaN` when the gradient of `torch.var(unbiased=True)` is `NaN`. The gradient of unbiased variance is `NaN` (undefined, divide by zero in the denom `N-1`, where `N` is the number of samples) when `N` is 1 (i.e., there's one sample only -- product of dim is 1 such as `[1]`, `[1,...,1]`). 