### PR TITLE
[ONNX] Skip import test for experimental files

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1987,6 +1987,7 @@ class TestImports(TestCase):
                            "torch.contrib.",  # something weird
                            "torch.testing._internal.distributed.",  # just fails
                            "torch.ao.pruning._experimental.",  # depends on pytorch_lightning, not user-facing
+                           "torch.onnx._internal.fx",  # depends on onnx-script
                            ]
         # See https://github.com/pytorch/pytorch/issues/77801
         if not sys.version_info >= (3, 9):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94552

`torch.onnx._internal.fx` is experimental and is not imported when `import torch`/`import torch.onnx`.
Need to skip it in this test as it depends on `onnx-script`.