### PR TITLE
[cpu][inductor] improve cpu vec implementations of cos & sin

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -219,13 +219,13 @@ public:
   }
   Vectorized<float> frac() const;
   Vectorized<float> sin() const {
-    return Vectorized<float>(Sleef_sinf8_u10(values));
+    return Vectorized<float>(Sleef_sinf8_u35(values));
   }
   Vectorized<float> sinh() const {
     return Vectorized<float>(Sleef_sinhf8_u10(values));
   }
   Vectorized<float> cos() const {
-    return Vectorized<float>(Sleef_cosf8_u10(values));
+    return Vectorized<float>(Sleef_cosf8_u35(values));
   }
   Vectorized<float> cosh() const {
     return Vectorized<float>(Sleef_coshf8_u10(values));

--- a/aten/src/ATen/cpu/vec/vec512/vec512_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_float.h
@@ -248,13 +248,13 @@ public:
   }
   Vectorized<float> frac() const;
   Vectorized<float> sin() const {
-    return Vectorized<float>(Sleef_sinf16_u10(values));
+    return Vectorized<float>(Sleef_sinf16_u35(values));
   }
   Vectorized<float> sinh() const {
     return Vectorized<float>(Sleef_sinhf16_u10(values));
   }
   Vectorized<float> cos() const {
-    return Vectorized<float>(Sleef_cosf16_u10(values));
+    return Vectorized<float>(Sleef_cosf16_u35(values));
   }
   Vectorized<float> cosh() const {
     return Vectorized<float>(Sleef_coshf16_u10(values));

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5905,7 +5905,7 @@ if HAS_CPU:
         @patch("torch.cuda.is_available", lambda: False)
         def test_vec_cpu_only_for_all_available_isa(self):
             def fn(x):
-                return (torch.erf(x),)
+                return (torch.sin(torch.cos(torch.erf(x))),)
 
             x = torch.randn((2, 9))
             x[0, 0] = torch.nan


### PR DESCRIPTION
The current Torchinductor's `cos` & `sin` implementations will call `sleef` functions in `aten::Vec` which show worse performance than Aten's `cos` & `sin` implementations that invoke `MKL` functions. The reason is that the `sleef` algorithms sacrifice performance in order to have a higher precision. This PR changes Torchinductor's `cos` & `sin` implementations from the `sleef` functions with `1.0` ULP error bound to the ones with `3.5` ULP error bound.

**Performance data for eager v.s. inductor:**
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/xuanliao/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/xuanliao/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

</head>

<body link=blue vlink=purple>



suite=huggingface |   |   |   |   |  
-- | -- | -- | -- | -- | --
op | improved_ratio | speedup_old | RSD(3) | speedup_new | RSD(3)
cos | 62.12% | 0.653826147 | 4.48% | 1.059999006 | 3.38%
sin | 38.12% | 0.745482927 | 0.72% | 1.029642026 | 5.33%



</body>

</html>

**Accuracy data for eager v.s. inductor:**
Each tol has been tested for 1000 times.
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/xuanliao/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/xuanliao/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

</head>

<body link=blue vlink=purple>



error_bound | tol=1e-7 | tol=1e-8
-- | -- | --
1.0 ULP | PASS | FAIL
3.5 ULP | PASS | FAIL



</body>

</html>


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire