### PR TITLE
Checkout torchbench with only needed models

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -205,6 +205,7 @@ function checkout_install_torchbench() {
     # Occasionally the installation may fail on one model but it is ok to continue
     # to install and test other models
     python install.py --continue_on_fail
+  fi
   popd
 }
 

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -198,9 +198,13 @@ function checkout_install_torchbench() {
   git clone https://github.com/pytorch/benchmark torchbench
   pushd torchbench
   git checkout no_torchaudio
-  # Occasionally the installation may fail on one model but it is ok to continue
-  # to install and test other models
-  python install.py --continue_on_fail
+
+  if [ "$1" ]; then
+    python install.py --continue_on_fail models=$1
+  else
+    # Occasionally the installation may fail on one model but it is ok to continue
+    # to install and test other models
+    python install.py --continue_on_fail
   popd
 }
 

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -200,7 +200,7 @@ function checkout_install_torchbench() {
   git checkout no_torchaudio
 
   if [ "$1" ]; then
-    python install.py --continue_on_fail models "$1"
+    python install.py --continue_on_fail models "$@"
   else
     # Occasionally the installation may fail on one model but it is ok to continue
     # to install and test other models

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -200,7 +200,7 @@ function checkout_install_torchbench() {
   git checkout no_torchaudio
 
   if [ "$1" ]; then
-    python install.py --continue_on_fail models=$1
+    python install.py --continue_on_fail models "$1"
   else
     # Occasionally the installation may fail on one model but it is ok to continue
     # to install and test other models

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -940,7 +940,6 @@ elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
   install_torchvision
   install_filelock
   install_triton
-  checkout_install_torchbench
   if [[ "${TEST_CONFIG}" == *inductor_torchbench_perf* ]]; then
     checkout_install_torchbench
     test_inductor_torchbench_perf

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -942,10 +942,13 @@ elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
   install_triton
   checkout_install_torchbench
   if [[ "${TEST_CONFIG}" == *inductor_torchbench_perf* ]]; then
+    checkout_install_torchbench
     test_inductor_torchbench_perf
   elif [[ "${TEST_CONFIG}" == *inductor_torchbench_smoketest_perf* ]]; then
+    checkout_install_torchbench hf_Bert
     test_inductor_torchbench_smoketest_perf
   else
+    checkout_install_torchbench
     test_inductor_torchbench
   fi
 elif [[ "${TEST_CONFIG}" == *inductor* && "${SHARD_NUMBER}" == 1 ]]; then

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -944,7 +944,7 @@ elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
     checkout_install_torchbench
     test_inductor_torchbench_perf
   elif [[ "${TEST_CONFIG}" == *inductor_torchbench_smoketest_perf* ]]; then
-    checkout_install_torchbench hf_Bert
+    checkout_install_torchbench hf_Bert hf_Albert timm_efficientdet timm_vision_transformer
     test_inductor_torchbench_smoketest_perf
   else
     checkout_install_torchbench


### PR DESCRIPTION
Addresses (https://github.com/pytorch/pytorch/pull/93395#issuecomment-1414231011) The perf smoke test is supposed to be around one minute. But the torchbench checkout process is taking more than 15 minutes. This PR explores a way to just checkout torchbench with only needed models that are later used to do perf smoke test and memory compression ratio check. 

Torchbench installation has "python install.py models model1 model 2 model3" support to just install model1 model2 and model3, not providing "models model1 model2 model3" would install all models by default. 

Before this PR, inductor job takes about 27 minutes (21 minutes spent in testing phase) https://github.com/pytorch/pytorch/actions/runs/4149154553/jobs/7178024253 
After this PR, inductor job takes about 19 minutes (12 minutes spent in testing phase), pytorch checkout and docker image pull takes about 5 - 6 minutes total.  https://github.com/pytorch/pytorch/actions/runs/4149155814/jobs/7178735494
