### PR TITLE
[BE] [2/3] Rewrite `super()` calls in functorch and torch

### DIFF
--- a/functorch/examples/compilation/fuse_module.py
+++ b/functorch/examples/compilation/fuse_module.py
@@ -23,7 +23,7 @@ def run(mod, input):
 
 class Foo(nn.Module):
     def __init__(self):
-        super(Foo, self).__init__()
+        super().__init__()
         self.param = nn.Parameter(torch.randn(1))
         self.register_buffer("buf", torch.randn(1))
 

--- a/functorch/examples/maml_regression/evjang_transforms_module.py
+++ b/functorch/examples/maml_regression/evjang_transforms_module.py
@@ -15,7 +15,7 @@ mpl.use('Agg')
 
 class ThreeLayerNet(nn.Module):
     def __init__(self):
-        super(ThreeLayerNet, self).__init__()
+        super().__init__()
         self.fc1 = nn.Linear(1, 40)
         self.relu1 = nn.ReLU()
         self.fc2 = nn.Linear(40, 40)

--- a/functorch/notebooks/_src/plot_ensembling.py
+++ b/functorch/notebooks/_src/plot_ensembling.py
@@ -24,7 +24,7 @@ torch.manual_seed(0)
 # Here's a simple CNN
 class SimpleCNN(nn.Module):
     def __init__(self):
-        super(SimpleCNN, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 32, 3, 1)
         self.conv2 = nn.Conv2d(32, 64, 3, 1)
         self.fc1 = nn.Linear(9216, 128)

--- a/functorch/notebooks/_src/plot_per_sample_gradients.py
+++ b/functorch/notebooks/_src/plot_per_sample_gradients.py
@@ -17,7 +17,7 @@ torch.manual_seed(0)
 # Here's a simple CNN
 class SimpleCNN(nn.Module):
     def __init__(self):
-        super(SimpleCNN, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 32, 3, 1)
         self.conv2 = nn.Conv2d(32, 64, 3, 1)
         self.fc1 = nn.Linear(9216, 128)

--- a/functorch/notebooks/ensembling.ipynb
+++ b/functorch/notebooks/ensembling.ipynb
@@ -49,7 +49,7 @@
         "# Here's a simple MLP\n",
         "class SimpleMLP(nn.Module):\n",
         "    def __init__(self):\n",
-        "        super(SimpleMLP, self).__init__()\n",
+        "        super().__init__()\n",
         "        self.fc1 = nn.Linear(784, 128)\n",
         "        self.fc2 = nn.Linear(128, 128)\n",
         "        self.fc3 = nn.Linear(128, 10)\n",

--- a/functorch/notebooks/neural_tangent_kernels.ipynb
+++ b/functorch/notebooks/neural_tangent_kernels.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "class CNN(nn.Module):\n",
     "    def __init__(self):\n",
-    "        super(CNN, self).__init__()\n",
+    "        super().__init__()\n",
     "        self.conv1 = nn.Conv2d(3, 32, (3, 3))\n",
     "        self.conv2 = nn.Conv2d(32, 32, (3, 3))\n",
     "        self.conv3 = nn.Conv2d(32, 32, (3, 3))\n",

--- a/functorch/notebooks/per_sample_grads.ipynb
+++ b/functorch/notebooks/per_sample_grads.ipynb
@@ -44,7 +44,7 @@
         "\n",
         "class SimpleCNN(nn.Module):\n",
         "    def __init__(self):\n",
-        "        super(SimpleCNN, self).__init__()\n",
+        "        super().__init__()\n",
         "        self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
         "        self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
         "        self.fc1 = nn.Linear(9216, 128)\n",

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -112,9 +112,6 @@ def check_dynamo(backend, device, err_msg):
             return x + x
 
         class Module(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
             def forward(self, x):
                 return x + x
 

--- a/torch/_VF.py
+++ b/torch/_VF.py
@@ -20,7 +20,7 @@ class VFModule(types.ModuleType):
     vf: types.ModuleType
 
     def __init__(self, name):
-        super(VFModule, self).__init__(name)
+        super().__init__(name)
         self.vf = torch._C._VariableFunctions
 
     def __getattr__(self, attr):

--- a/torch/_classes.py
+++ b/torch/_classes.py
@@ -5,7 +5,7 @@ import torch._C
 
 class _ClassNamespace(types.ModuleType):
     def __init__(self, name):
-        super(_ClassNamespace, self).__init__("torch.classes" + name)
+        super().__init__("torch.classes" + name)
         self.name = name
 
     def __getattr__(self, attr):
@@ -19,7 +19,7 @@ class _Classes(types.ModuleType):
     __file__ = "_classes.py"
 
     def __init__(self):
-        super(_Classes, self).__init__("torch.classes")
+        super().__init__("torch.classes")
 
     def __getattr__(self, name):
         namespace = _ClassNamespace(name)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -615,8 +615,7 @@ def export(
             super().__init__(m)
             arg_len = len(flat_args)
             self.new_args = [
-                super(ChangeInputOutputSignature, self).placeholder(f"arg{i}", (), {})
-                for i in range(0, arg_len)
+                super().placeholder(f"arg{i}", (), {}) for i in range(0, arg_len)
             ]
             self.old_args_gen = (
                 self.new_args[i] for i in matched_input_elements_positions

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -615,7 +615,8 @@ def export(
             super().__init__(m)
             arg_len = len(flat_args)
             self.new_args = [
-                super().placeholder(f"arg{i}", (), {}) for i in range(0, arg_len)
+                super(ChangeInputOutputSignature, self).placeholder(f"arg{i}", (), {})
+                for i in range(0, arg_len)
             ]
             self.old_args_gen = (
                 self.new_args[i] for i in matched_input_elements_positions

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -30,7 +30,7 @@ class TorchRuntimeError(TorchDynamoException):
 
 class ResetRequired(TorchDynamoException):
     def __init__(self):
-        super(ResetRequired, self).__init__(
+        super().__init__(
             textwrap.dedent(
                 """
                 Must call `torch._dynamo.reset()` before changing backends.  Detected two calls to
@@ -50,7 +50,7 @@ class BackendCompilerFailed(TorchDynamoException):
 
 class Unsupported(TorchDynamoException):
     def __init__(self, msg):
-        super(Unsupported, self).__init__(msg)
+        super().__init__(msg)
         self.real_stack = []
         self.msg = msg
         self.category = None

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -115,7 +115,7 @@ class FakeRootModule(torch.nn.Module):
     """Trick the constructor of fx.GraphModule"""
 
     def __init__(self, nn_modules: Dict[str, torch.nn.Module]):
-        super(FakeRootModule, self).__init__()
+        super().__init__()
         for k, v in nn_modules.items():
             setattr(self, k, v)
 
@@ -177,7 +177,7 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
         compiler_fn: CompilerFn,
         root_tx,
     ):
-        super(OutputGraph, self).__init__()
+        super().__init__()
         self.graph = torch.fx.Graph()
         self.graphargs: List[GraphArg] = []
         fake_mode = torch._subclasses.FakeTensorMode(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1598,7 +1598,7 @@ class InstructionTranslator(InstructionTranslatorBase):
         export,
         mutated_closure_cell_contents: Set[str],
     ):
-        super(InstructionTranslator, self).__init__(
+        super().__init__(
             output=OutputGraph(f_globals, code_options, compiler_fn, self),
             instructions=instructions,
             f_locals=f_locals,
@@ -1853,7 +1853,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         f_builtins = f_globals["__builtins__"]
         if not isinstance(f_builtins, dict):
             f_builtins = f_builtins.__dict__
-        super(InliningInstructionTranslator, self).__init__(
+        super().__init__(
             output=parent.output,
             f_locals={},
             f_globals=f_globals,
@@ -1951,7 +1951,7 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
     generated_items: List[VariableTracker]
 
     def __init__(self, *args, **kwargs):
-        super(InliningGeneratorInstructionTranslator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.generated_items = []
 
     def YIELD_VALUE(self, inst: Instruction):

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -259,7 +259,7 @@ class VariableTracker(metaclass=HasPostInit):
         mutable_local: MutableLocal = None,
         recursively_contains: Optional[Set] = None,
     ):
-        super(VariableTracker, self).__init__()
+        super().__init__()
         self.guards = guards or set()
         self.source = source
         self.mutable_local = mutable_local

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -160,7 +160,7 @@ class VariableBuilder:
         source: Source,
     ):
         assert source is not None
-        super(VariableBuilder, self).__init__()
+        super().__init__()
         self.tx = tx
         self.source = source
         self.name = source.name()

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -365,7 +365,7 @@ class BuiltinVariable(VariableTracker):
         return self.fn in self._fx_graph_functions()
 
     def __init__(self, fn, **kwargs):
-        super(BuiltinVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.fn = fn
 
     def __str__(self):

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -11,7 +11,7 @@ from .base import typestr, VariableTracker
 
 class ConstantVariable(VariableTracker):
     def __init__(self, value, **kwargs):
-        super(ConstantVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         assert not isinstance(value, torch.Tensor)
         assert not isinstance(value, torch.SymInt)
         assert not isinstance(value, torch.SymFloat)
@@ -96,7 +96,7 @@ class ConstantVariable(VariableTracker):
             const_args = [a.as_python_constant() for a in args]
             const_kwargs = {k: v.as_python_constant() for k, v in kwargs.items()}
         except NotImplementedError:
-            return super(ConstantVariable, self).call_method(tx, name, args, kwargs)
+            return super().call_method(tx, name, args, kwargs)
 
         def has_arith_binop(num_ty):
             return (
@@ -138,7 +138,7 @@ class ConstantVariable(VariableTracker):
 
 class EnumVariable(VariableTracker):
     def __init__(self, value, **kwargs):
-        super(EnumVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.value = value
 
     def as_proxy(self):

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -17,9 +17,7 @@ from .tensor import TensorVariable
 
 class ConstDictVariable(VariableTracker):
     def __init__(self, items, user_cls, recursively_contains=None, **kwargs):
-        super(ConstDictVariable, self).__init__(
-            recursively_contains=recursively_contains, **kwargs
-        )
+        super().__init__(recursively_contains=recursively_contains, **kwargs)
 
         self.guards.update(VariableTracker.propagate(items.values())["guards"])
         self.items = items
@@ -221,7 +219,7 @@ class ConstDictVariable(VariableTracker):
 
 class DefaultDictVariable(ConstDictVariable):
     def __init__(self, items, user_cls, default_factory=None, **kwargs):
-        super(DefaultDictVariable, self).__init__(items, user_cls, **kwargs)
+        super().__init__(items, user_cls, **kwargs)
         assert user_cls is collections.defaultdict
         self.default_factory = default_factory
 
@@ -358,7 +356,7 @@ class DataClassVariable(ConstDictVariable):
         )
 
     def __init__(self, items, user_cls, **options):
-        super(DataClassVariable, self).__init__(items, user_cls, **options)
+        super().__init__(items, user_cls, **options)
         assert self.is_matching_cls(user_cls)
 
     def as_proxy(self):
@@ -398,7 +396,7 @@ class DataClassVariable(ConstDictVariable):
             return variables.TupleVariable(list(self.items.values()), **options)
         elif name == "__setattr__":
             name = "__setitem__"
-        return super(DataClassVariable, self).call_method(tx, name, args, kwargs)
+        return super().call_method(tx, name, args, kwargs)
 
     def var_getattr(self, tx, name: str) -> "VariableTracker":
         if name in self.items:
@@ -410,7 +408,7 @@ class DataClassVariable(ConstDictVariable):
             if name in defaults:
                 assert variables.ConstantVariable.is_literal(defaults[name])
                 return variables.ConstantVariable(defaults[name]).add_options(self)
-        super(DataClassVariable, self).var_getattr(tx, name)
+        super().var_getattr(tx, name)
 
 
 class HFPretrainedConfigVariable(VariableTracker):
@@ -432,7 +430,7 @@ class HFPretrainedConfigVariable(VariableTracker):
         return cls.is_matching_cls(type(obj))
 
     def __init__(self, obj, **kwargs):
-        super(HFPretrainedConfigVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.obj = obj
         assert self.is_matching_cls(type(obj))
 

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -104,7 +104,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
     """Some unsupported user-defined global function"""
 
     def __init__(self, fn, is_constant=False, **kwargs):
-        super(UserFunctionVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if getattr(fn, "_dynamo_marked_constant", False):
             # This method should be treated as a constant for the purposes of compilation
             self.is_constant = True
@@ -256,14 +256,14 @@ class UserFunctionVariable(BaseUserFunctionVariable):
                 tx, self.fn, self.get_name(), options, args, kwargs
             )
 
-        return super(UserFunctionVariable, self).call_function(tx, args, kwargs)
+        return super().call_function(tx, args, kwargs)
 
 
 class UserMethodVariable(UserFunctionVariable):
     """Some unsupported user-defined method"""
 
     def __init__(self, fn, obj, **kwargs):
-        super(UserMethodVariable, self).__init__(fn=fn, **kwargs)
+        super().__init__(fn=fn, **kwargs)
         self.obj = obj
 
     def __str__(self):
@@ -291,16 +291,14 @@ class UserMethodVariable(UserFunctionVariable):
         return super().call_function(tx, args, kwargs)
 
     def num_parameters(self):
-        return super(UserMethodVariable, self).num_parameters() - 1
+        return super().num_parameters() - 1
 
 
 class WrappedUserMethodVariable(UserMethodVariable):
     def __init__(self, wrapped, context, **kwargs):
         kwargs.pop("fn", None)
         kwargs.pop("obj", None)
-        super(WrappedUserMethodVariable, self).__init__(
-            wrapped.fn, wrapped.obj, **kwargs
-        )
+        super().__init__(wrapped.fn, wrapped.obj, **kwargs)
         self.wrapped = wrapped
         self.context = context
 
@@ -317,7 +315,7 @@ class WrappedUserFunctionVariable(UserFunctionVariable):
     def __init__(self, wrapped, context, **kwargs):
         kwargs.pop("fn", None)
         kwargs.pop("obj", None)
-        super(WrappedUserFunctionVariable, self).__init__(wrapped.fn, **kwargs)
+        super().__init__(wrapped.fn, **kwargs)
         self.wrapped = wrapped
         self.context = context
 
@@ -360,7 +358,7 @@ class NestedUserFunctionVariable(BaseUserFunctionVariable):
         closure_scope,
         **kwargs,
     ):
-        super(NestedUserFunctionVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         assert isinstance(fn_name.as_python_constant(), str)
         assert isinstance(code.as_python_constant(), types.CodeType)
         assert isinstance(f_globals, dict)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -32,9 +32,7 @@ class BaseListVariable(VariableTracker):
         regen_guards=True,
         **kwargs,
     ):
-        super(BaseListVariable, self).__init__(
-            recursively_contains=recursively_contains, **kwargs
-        )
+        super().__init__(recursively_contains=recursively_contains, **kwargs)
         assert isinstance(items, list)
         assert all(isinstance(x, VariableTracker) for x in items)
 
@@ -97,7 +95,7 @@ class BaseListVariable(VariableTracker):
             result = any(x.as_python_constant() == search for x in self.items)
             return variables.ConstantVariable(result, **options)
 
-        return super(BaseListVariable, self).call_method(tx, name, args, kwargs)
+        return super().call_method(tx, name, args, kwargs)
 
     @staticmethod
     def list_compare(tx, op, left, right):
@@ -382,7 +380,7 @@ class SizeVariable(TupleVariable):
             else:
                 out = self.getitem_const(args[0])
             return out
-        return super(SizeVariable, self).call_method(tx, name, args, kwargs)
+        return super().call_method(tx, name, args, kwargs)
 
     def get_item_dyn(self, tx, arg: VariableTracker):
         from .tensor import SymNodeVariable
@@ -500,9 +498,7 @@ class SliceVariable(BaseListVariable):
 
 class ListIteratorVariable(VariableTracker):
     def __init__(self, items, index: int = 0, recursively_contains=None, **kwargs):
-        super(ListIteratorVariable, self).__init__(
-            recursively_contains=recursively_contains, **kwargs
-        )
+        super().__init__(recursively_contains=recursively_contains, **kwargs)
         assert isinstance(items, list)
         # Removing this check as it slows things down too much
         # https://github.com/pytorch/pytorch/pull/87533#issuecomment-1287574492

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -24,7 +24,7 @@ from .functions import (
 
 class SuperVariable(VariableTracker):
     def __init__(self, typevar, objvar=None, specialized=False, **kwargs):
-        super(SuperVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.typevar = typevar
         self.objvar = objvar
         self.specialized = specialized  # directly get attr from self.typevar if true
@@ -148,7 +148,7 @@ class ComptimeVariable(VariableTracker):
 
 class ClosureVariable(UnknownVariable):
     def __init__(self, name, **kwargs):
-        super(ClosureVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.name = name
 
     def reconstruct(self, codegen):
@@ -157,17 +157,17 @@ class ClosureVariable(UnknownVariable):
 
 class NewCellVariable(VariableTracker):
     def __init__(self, **kwargs):
-        super(NewCellVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
 
 class NewGlobalVariable(VariableTracker):
     def __init__(self, **kwargs):
-        super(NewGlobalVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
 
 class ContextWrappingVariable(VariableTracker):
     def __init__(self, target_values, initial_values=None, **kwargs):
-        super(ContextWrappingVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.target_values = target_values
         self.initial_values = initial_values
         self.recursively_contains = (
@@ -335,7 +335,7 @@ class GradModeVariable(ContextWrappingVariable):
         return var
 
     def __init__(self, target_values, initial_values=None, **kwargs):
-        super(GradModeVariable, self).__init__(
+        super().__init__(
             target_values=target_values, initial_values=initial_values, **kwargs
         )
         self.guards = self.guards | self._guards_singleton
@@ -385,7 +385,7 @@ class AutocastModeVariable(ContextWrappingVariable):
         return var
 
     def __init__(self, target_values, initial_values=None, **kwargs):
-        super(AutocastModeVariable, self).__init__(
+        super().__init__(
             target_values=target_values, initial_values=initial_values, **kwargs
         )
         self.target_values = [val.as_python_constant() for val in target_values]
@@ -426,7 +426,7 @@ class NullContextVariable(ContextWrappingVariable):
     """
 
     def __init__(self, target_values=None, **kwargs):
-        super(NullContextVariable, self).__init__(target_values=target_values, **kwargs)
+        super().__init__(target_values=target_values, **kwargs)
 
     def enter(self, tx):
         return variables.ConstantVariable(None, **VariableTracker.propagate(self))
@@ -463,7 +463,7 @@ class CUDAStreamContextVariable(ContextWrappingVariable):
         )
 
     def __init__(self, target_values, initial_values=None, **kwargs):
-        super(CUDAStreamContextVariable, self).__init__(
+        super().__init__(
             target_values=target_values, initial_values=initial_values, **kwargs
         )
 
@@ -512,7 +512,7 @@ class CUDAStreamVariable(VariableTracker):
 
 class WithExitFunctionVariable(VariableTracker):
     def __init__(self, ctx: VariableTracker, target, **kwargs):
-        super(WithExitFunctionVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.ctx = ctx
         self.target = target
 
@@ -551,7 +551,7 @@ class InspectSignatureVariable(VariableTracker):
         return InspectSignatureVariable(callable)
 
     def __init__(self, inspected, **kwargs):
-        super(InspectSignatureVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.inspected = inspected
 
 
@@ -631,7 +631,7 @@ class AutogradFunctionContextVariable(VariableTracker):
 
 class LambdaVariable(VariableTracker):
     def __init__(self, fn, **kwargs):
-        super(LambdaVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.fn = fn
 
     def call_function(
@@ -642,7 +642,7 @@ class LambdaVariable(VariableTracker):
 
 class GetAttrVariable(VariableTracker):
     def __init__(self, obj, name, **kwargs):
-        super(GetAttrVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         assert isinstance(obj, VariableTracker)
         assert isinstance(name, str)
         self.obj = obj
@@ -758,12 +758,12 @@ class GetAttrVariable(VariableTracker):
                 self.obj.inspected.num_parameters(),
                 **VariableTracker.propagate(self, self.obj, self.obj.inspected),
             )
-        return super(GetAttrVariable, self).call_method(tx, name, args, kwargs)
+        return super().call_method(tx, name, args, kwargs)
 
 
 class PythonModuleVariable(VariableTracker):
     def __init__(self, value: types.ModuleType, **kwargs):
-        super(PythonModuleVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.value = value
 
     def python_type(self):

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -30,7 +30,7 @@ class NNModuleVariable(VariableTracker):
     _nonvar_fields = ["module_type", "module_key"]
 
     def __init__(self, module_type: type, module_key: str, **kwargs):
-        super(NNModuleVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.module_type = module_type
         self.module_key = module_key
         assert self.source
@@ -516,7 +516,7 @@ class UnspecializedNNModuleVariable(UserDefinedObjectVariable):
     """
 
     def __init__(self, value, **kwargs):
-        super(UnspecializedNNModuleVariable, self).__init__(value=value, **kwargs)
+        super().__init__(value=value, **kwargs)
         if self.source and self.source.is_nn_module():
             # force guard checks even when `not config.guard_nn_modules``
             self.source = NotNNModuleSource(self.source)

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -85,7 +85,7 @@ class TensorVariable(VariableTracker):
         specialized_value=None,
         **kwargs,
     ):
-        super(TensorVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.proxy = proxy
         self.dtype = dtype
         self.device = device
@@ -447,7 +447,7 @@ class SymNodeVariable(VariableTracker):
         return SymNodeVariable(proxy, sym_num, **options)
 
     def __init__(self, proxy, sym_num, **kwargs):
-        super(SymNodeVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.proxy = proxy
         self.sym_num = sym_num
 
@@ -455,7 +455,7 @@ class SymNodeVariable(VariableTracker):
         return type(self.sym_num)
 
     def unpack_var_sequence(self, tx):
-        super(SymNodeVariable, self).unpack_var_sequence(tx)
+        super().unpack_var_sequence(tx)
 
     def as_proxy(self):
         return self.proxy
@@ -498,7 +498,7 @@ class TensorWithTFOverrideVariable(VariableTracker):
         subclass_type,
         **kwargs,
     ):
-        super(TensorWithTFOverrideVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.tensor_variable = tensor_variable
         self.orig_tensor_variable_source = orig_tensor_variable_source
         self.subclass_torch_function__func = subclass_torch_function__func
@@ -614,7 +614,7 @@ class UnspecializedPythonVariable(TensorVariable):
         if HAS_NUMPY and isinstance(raw_value, np.number):
             raw_values = raw_value.item()
         need_unwrap = kwargs.pop("need_unwrap", True)
-        super(UnspecializedPythonVariable, self).__init__(proxy, **kwargs)
+        super().__init__(proxy, **kwargs)
         self.raw_value = raw_value
         self.need_unwrap = need_unwrap
 
@@ -645,7 +645,7 @@ class FakeItemVariable(TensorVariable):
 
     def __init__(self, proxy: torch.fx.Proxy, **kwargs):
         need_unwrap = kwargs.pop("need_unwrap", False)
-        super(FakeItemVariable, self).__init__(proxy, **kwargs)
+        super().__init__(proxy, **kwargs)
         self.need_unwrap = need_unwrap
 
     @classmethod

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -121,7 +121,7 @@ class TorchVariable(VariableTracker):
     """Points to a module or method in torch.*"""
 
     def __init__(self, value, **kwargs):
-        super(TorchVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if value in tensor_dunder_fns_remap:
             value = tensor_dunder_fns_remap[value]
@@ -719,7 +719,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
 
 class TorchPyOperator(VariableTracker):
     def __init__(self, value, **kwargs):
-        super(TorchPyOperator, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.value = value
 
     def call_function(

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -60,7 +60,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             elif ConstantVariable.is_literal(obj):
                 return ConstantVariable(obj, **options)
 
-        return super(UserDefinedClassVariable, self).var_getattr(tx, name)
+        return super().var_getattr(tx, name)
 
     def call_method(
         self,
@@ -138,7 +138,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
     """
 
     def __init__(self, value, value_type=None, **kwargs):
-        super(UserDefinedObjectVariable, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.value = value
         self.value_type = value_type or type(value)
         assert type(value) is self.value_type

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -2377,7 +2377,7 @@ def aot_module(mod: nn.Module, *args, **kwargs) -> nn.Module:
 
     class AOTModule(nn.Module):
         def __init__(self):
-            super(AOTModule, self).__init__()
+            super().__init__()
             self.orig_module = mod
 
         def forward(self, *args, **kwargs):

--- a/torch/_functorch/make_functional.py
+++ b/torch/_functorch/make_functional.py
@@ -264,7 +264,7 @@ class FunctionalModuleWithBuffers(nn.Module):
         param_names_map: Dict[str, List[str]],
         buffer_names_map: Dict[str, List[str]],
     ) -> None:
-        super(FunctionalModuleWithBuffers, self).__init__()
+        super().__init__()
         self.stateless_model = stateless_model
         self.param_names = param_names
         self.buffer_names = buffer_names
@@ -318,7 +318,7 @@ class FunctionalModule(nn.Module):
         param_names: Tuple[str, ...],
         names_map: Dict[str, List[str]],
     ) -> None:
-        super(FunctionalModule, self).__init__()
+        super().__init__()
         self.stateless_model = stateless_model
         self.param_names = param_names
         self.names_map = names_map

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -150,7 +150,7 @@ class DeferredLine(DeferredLineBase):
 
 class DeferredIndentedBuffer(IndentedBuffer):
     def __init__(self, initial_indent=0):
-        super(DeferredIndentedBuffer, self).__init__(initial_indent)
+        super().__init__(initial_indent)
 
     def writeline(self, name, line):
         if name is None:

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -740,7 +740,7 @@ class CppKernel(Kernel):
     suffix = ";"
 
     def __init__(self, args, num_threads):
-        super(CppKernel, self).__init__(args)
+        super().__init__(args)
         self.call_ranges = None
         self.ranges = None
         self.itervars = None
@@ -962,7 +962,7 @@ class CppVecKernel(CppKernel):
     overrides = CppVecOverrides
 
     def __init__(self, args, num_threads, tiling_factor=0):
-        super(CppVecKernel, self).__init__(args, num_threads)
+        super().__init__(args, num_threads)
         assert codecache.pick_vec_isa()
         if tiling_factor == 0:
             tiling_factor = codecache.pick_vec_isa().nelements()
@@ -1267,7 +1267,7 @@ class CppTile2DTailKernel(CppKernel):
 
 class CppVecKernelChecker(CppVecKernel):
     def __init__(self, args, num_threads, tiling_factor):
-        super(CppVecKernelChecker, self).__init__(args, num_threads, tiling_factor)
+        super().__init__(args, num_threads, tiling_factor)
 
         # Since this kernel is only for checker but does not genreate any
         # code, so we need to decrease the kernel count.
@@ -1709,9 +1709,7 @@ class CppTile2DKernelChecker(CppVecKernelChecker):
 
 class CppKernelProxy(CppKernel):
     def __init__(self, kernel_group):
-        super(CppKernelProxy, self).__init__(
-            kernel_group.args, kernel_group.ws.num_threads
-        )
+        super().__init__(kernel_group.args, kernel_group.ws.num_threads)
         self.kernel_group = kernel_group
         self.loop_nest = None
         self.call_ranges = None

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -355,7 +355,7 @@ class IterationRanges:
         divisor=sympy.Integer(1),
         length=sympy.Integer(1),
     ):
-        super(IterationRanges, self).__init__()
+        super().__init__()
         self.name = name
         self.var_list = var_list
         self.var_ranges = var_ranges
@@ -380,7 +380,7 @@ class IterationRangesRoot(IterationRanges):
     ):
         if pid_cache is None:
             pid_cache = {}
-        super(IterationRangesRoot, self).__init__(
+        super().__init__(
             name=name,
             var_list=[],
             var_ranges={},
@@ -495,7 +495,7 @@ class IterationRangesEntry(IterationRanges):
         expr: sympy.Expr,
         parent: IterationRanges,
     ):
-        super(IterationRangesEntry, self).__init__(
+        super().__init__(
             name=name,
             numel=parent.numel / length,
             var_list=parent.var_list,
@@ -563,7 +563,7 @@ class TritonKernel(Kernel):
     ):
         if pid_cache is None:
             pid_cache = {}
-        super(TritonKernel, self).__init__()
+        super().__init__()
         self.numels = [V.graph.sizevars.simplify(s) for s in groups]
         self.mutations = mutations
         self.range_trees = []

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1859,7 +1859,7 @@ class FlexibleLayout(Layout):
             strides = FlexibleLayout.fill_ordered(size, stride_order)
         else:
             strides = FlexibleLayout.contiguous_strides(size)
-        super(FlexibleLayout, self).__init__(device, dtype, size, strides)
+        super().__init__(device, dtype, size, strides)
 
 
 class AliasedLayout(Layout):
@@ -2965,7 +2965,7 @@ class FallbackKernel(ExternKernelAlloc):
         unflatten_args,
         kwargs=None,
     ):
-        super(FallbackKernel, self).__init__(
+        super().__init__(
             layout,
             tuple(tensor_args),
             tuple(nontensor_args),

--- a/torch/_inductor/mkldnn.py
+++ b/torch/_inductor/mkldnn.py
@@ -26,7 +26,7 @@ class UnaryAttr:
         self.op_name = op_name
         self.scalars_attr = scalars_attr if scalars_attr else []
         self.algorithm_attr = algorithm_attr if algorithm_attr else ""
-        super(UnaryAttr, self).__init__()
+        super().__init__()
 
     def __call__(self, unary_module: nn.Module):
         if type(unary_module) is nn.ReLU6:
@@ -106,7 +106,7 @@ class ConvUnary2d(nn.Conv2d):
         unary: Optional[nn.Module],
         input_size: list,
     ):
-        super(ConvUnary2d, self).__init__(
+        super().__init__(
             conv.in_channels,
             conv.out_channels,
             conv.kernel_size,
@@ -182,7 +182,7 @@ class ConvBinary2d(nn.Conv2d):
         binary_op_name: str,
         input_size: list,
     ):
-        super(ConvBinary2d, self).__init__(
+        super().__init__(
             conv.in_channels,
             conv.out_channels,
             conv.kernel_size,
@@ -267,7 +267,7 @@ class ConvBinaryInplace2d(nn.Conv2d):
         binary_op_name: str,
         input_size: list,
     ):
-        super(ConvBinaryInplace2d, self).__init__(
+        super().__init__(
             conv.in_channels,
             conv.out_channels,
             conv.kernel_size,
@@ -347,7 +347,7 @@ class ConvBinaryInplace2d(nn.Conv2d):
 
 class PackedLinear(nn.Linear):
     def __init__(self, linear: nn.Module, input_size: list):
-        super(PackedLinear, self).__init__(
+        super().__init__(
             linear.in_features,
             linear.out_features,
             linear.bias is not None,
@@ -379,7 +379,7 @@ class LinearUnary(nn.Linear):
         linear: nn.Module,
         unary: nn.Module,
     ):
-        super(LinearUnary, self).__init__(
+        super().__init__(
             linear.in_features,
             linear.out_features,
             linear.bias is not None,
@@ -403,7 +403,7 @@ class LinearUnary(nn.Linear):
 
 class LinearBinary(nn.Linear):
     def __init__(self, linear: nn.Module, binary_op_name: str):
-        super(LinearBinary, self).__init__(
+        super().__init__(
             linear.in_features,
             linear.out_features,
             linear.bias is not None,
@@ -431,7 +431,7 @@ class ConvTransposeUnary2d(nn.ConvTranspose2d):
         unary: Optional[nn.Module],
         input_size: list,
     ):
-        super(ConvTransposeUnary2d, self).__init__(
+        super().__init__(
             conv_transpose.in_channels,
             conv_transpose.out_channels,
             conv_transpose.kernel_size,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -555,7 +555,7 @@ class NodeUser:
 class Scheduler:
     @dynamo_timed
     def __init__(self, nodes):
-        super(Scheduler, self).__init__()
+        super().__init__()
         self.backends = {}
 
         self.nodes = []

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -587,7 +587,7 @@ def unused(fn):
 
             class MyModule(nn.Module):
                 def __init__(self, use_memory_efficient):
-                    super(MyModule, self).__init__()
+                    super().__init__()
                     self.use_memory_efficient = use_memory_efficient
 
                 @torch.jit.unused

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -540,7 +540,7 @@ class _OpNamespace(types.ModuleType):
     """
 
     def __init__(self, name):
-        super(_OpNamespace, self).__init__("torch.ops." + name)
+        super().__init__("torch.ops." + name)
         self.name = name
         self._dir = []
 
@@ -584,7 +584,7 @@ class _OpNamespace(types.ModuleType):
 
 class _PyOpNamespace(_OpNamespace):
     def __init__(self):
-        super(_PyOpNamespace, self).__init__("torch.ops")
+        super().__init__("torch.ops")
         self.pyop_namespace = pyop_namespace
 
 
@@ -592,7 +592,7 @@ class _Ops(types.ModuleType):
     __file__ = "_ops.py"
 
     def __init__(self):
-        super(_Ops, self).__init__("torch.ops")
+        super().__init__("torch.ops")
         self.loaded_libraries = set()
         self.pyops = _PyOpNamespace()
         self._dir = []

--- a/torch/_sources.py
+++ b/torch/_sources.py
@@ -93,9 +93,7 @@ class SourceContext(SourceRangeFactory):
         uses_true_division=True,
         funcname=None,
     ):
-        super(SourceContext, self).__init__(
-            source, filename, file_lineno, leading_whitespace_len
-        )
+        super().__init__(source, filename, file_lineno, leading_whitespace_len)
         self.uses_true_division = uses_true_division
         self.filename = filename
         self.funcname = funcname

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1120,7 +1120,7 @@ class Tensor(torch._C._TensorBase):
         if has_torch_function_unary(self):
             return handle_torch_function(Tensor.refine_names, (self,), self, *names)
         names = resolve_ellipsis(names, self.names, "refine_names")
-        return super(Tensor, self).refine_names(names)
+        return super().refine_names(names)
 
     def align_to(self, *names):
         r"""Permutes the dimensions of the :attr:`self` tensor to match the order
@@ -1162,8 +1162,8 @@ class Tensor(torch._C._TensorBase):
             return handle_torch_function(Tensor.align_to, (self,), self, *names)
         ellipsis_idx = single_ellipsis_index(names, "align_to")
         if ellipsis_idx is None:
-            return super(Tensor, self).align_to(names)
-        return super(Tensor, self).align_to(
+            return super().align_to(names)
+        return super().align_to(
             [name for name in names if not is_ellipsis(name)], ellipsis_idx
         )
 
@@ -1185,9 +1185,9 @@ class Tensor(torch._C._TensorBase):
             isinstance(sizes, (tuple, list)) and isinstance(sizes[0], (tuple, list))
         ):
             names, sizes = unzip_namedshape(sizes)
-            return super(Tensor, self).unflatten(dim, sizes, names)
+            return super().unflatten(dim, sizes, names)
         else:
-            return super(Tensor, self).unflatten(dim, sizes)
+            return super().unflatten(dim, sizes)
 
     def rename_(self, *names, **rename_map):
         """In-place version of :meth:`~Tensor.rename`."""
@@ -1267,9 +1267,9 @@ class Tensor(torch._C._TensorBase):
 
         # See Note [rename_ / rename API]
         if inplace:
-            return super(Tensor, self).rename_(names)
+            return super().rename_(names)
         else:
-            return super(Tensor, self).rename(names)
+            return super().rename(names)
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -118,7 +118,7 @@ class autocast:
 
         class TestModel(nn.Module):
             def __init__(self, input_size, num_classes):
-                super(TestModel, self).__init__()
+                super().__init__()
                 self.fc1 = nn.Linear(input_size, num_classes)
             def forward(self, x):
                 return self.fc1(x)

--- a/torch/ao/nn/intrinsic/modules/fused.py
+++ b/torch/ao/nn/intrinsic/modules/fused.py
@@ -62,7 +62,7 @@ class ConvBn2d(_FusedModule):
         assert type_before_parametrizations(conv) == Conv2d and type_before_parametrizations(bn) == BatchNorm2d, \
             'Incorrect types for input modules{}{}'.format(
                 type_before_parametrizations(conv), type_before_parametrizations(bn))
-        super(ConvBn2d, self).__init__(conv, bn)
+        super().__init__(conv, bn)
 
 class ConvBnReLU1d(_FusedModule):
     r"""This is a sequential container which calls the Conv 1d, Batch Norm 1d, and ReLU modules.

--- a/torch/ao/nn/intrinsic/qat/modules/conv_fused.py
+++ b/torch/ao/nn/intrinsic/qat/modules/conv_fused.py
@@ -83,7 +83,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd, nni._FusedModule):
             init.uniform_(self.bias, -bound, bound)
 
     def reset_parameters(self):
-        super(_ConvBnNd, self).reset_parameters()
+        super().reset_parameters()
 
     def update_bn_stats(self):
         self.freeze_bn = False
@@ -218,7 +218,7 @@ class _ConvBnNd(nn.modules.conv._ConvNd, nni._FusedModule):
 
     def extra_repr(self):
         # TODO(jerryzh): extend
-        return super(_ConvBnNd, self).extra_repr()
+        return super().extra_repr()
 
     def forward(self, input):
         return self._forward(input)
@@ -285,8 +285,8 @@ class _ConvBnNd(nn.modules.conv._ConvNd, nni._FusedModule):
                 elif strict:
                     missing_keys.append(prefix + v2_name)
 
-        super(_ConvBnNd, self)._load_from_state_dict(
-            state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, strict,
+                                      missing_keys, unexpected_keys, error_msgs)
 
     @classmethod
     def from_float(cls, mod):
@@ -476,10 +476,10 @@ class ConvReLU1d(nnqat.Conv1d, nni._FusedModule):
                  padding=0, dilation=1, groups=1,
                  bias=True, padding_mode='zeros',
                  qconfig=None):
-        super(ConvReLU1d, self).__init__(in_channels, out_channels, kernel_size,
-                                         stride=stride, padding=padding, dilation=dilation,
-                                         groups=groups, bias=bias, padding_mode=padding_mode,
-                                         qconfig=qconfig)
+        super().__init__(in_channels, out_channels, kernel_size,
+                         stride=stride, padding=padding, dilation=dilation,
+                         groups=groups, bias=bias, padding_mode=padding_mode,
+                         qconfig=qconfig)
         assert qconfig, 'qconfig must be provided for QAT module'
         self.qconfig = qconfig
         self.weight_fake_quant = self.qconfig.weight()
@@ -574,11 +574,11 @@ class ConvBnReLU2d(ConvBn2d):
                  # Args for this module
                  freeze_bn=False,
                  qconfig=None):
-        super(ConvBnReLU2d, self).__init__(in_channels, out_channels, kernel_size, stride,
-                                           padding, dilation, groups, bias,
-                                           padding_mode, eps, momentum,
-                                           freeze_bn,
-                                           qconfig)
+        super().__init__(in_channels, out_channels, kernel_size, stride,
+                         padding, dilation, groups, bias,
+                         padding_mode, eps, momentum,
+                         freeze_bn,
+                         qconfig)
 
     def forward(self, input):
         return F.relu(ConvBn2d._forward(self, input))
@@ -608,10 +608,10 @@ class ConvReLU2d(nnqat.Conv2d, nni._FusedModule):
                  padding=0, dilation=1, groups=1,
                  bias=True, padding_mode='zeros',
                  qconfig=None):
-        super(ConvReLU2d, self).__init__(in_channels, out_channels, kernel_size,
-                                         stride=stride, padding=padding, dilation=dilation,
-                                         groups=groups, bias=bias, padding_mode=padding_mode,
-                                         qconfig=qconfig)
+        super().__init__(in_channels, out_channels, kernel_size,
+                         stride=stride, padding=padding, dilation=dilation,
+                         groups=groups, bias=bias, padding_mode=padding_mode,
+                         qconfig=qconfig)
         assert qconfig, 'qconfig must be provided for QAT module'
         self.qconfig = qconfig
         self.weight_fake_quant = self.qconfig.weight()
@@ -737,7 +737,7 @@ class ConvBnReLU3d(ConvBn3d):
         freeze_bn=False,
         qconfig=None,
     ):
-        super(ConvBnReLU3d, self).__init__(
+        super().__init__(
             in_channels,
             out_channels,
             kernel_size,
@@ -790,7 +790,7 @@ class ConvReLU3d(nnqat.Conv3d, nni._FusedModule):
         padding_mode="zeros",
         qconfig=None,
     ):
-        super(ConvReLU3d, self).__init__(
+        super().__init__(
             in_channels,
             out_channels,
             kernel_size,

--- a/torch/ao/nn/intrinsic/qat/modules/linear_fused.py
+++ b/torch/ao/nn/intrinsic/qat/modules/linear_fused.py
@@ -68,7 +68,7 @@ class LinearBn1d(nn.modules.linear.Linear, nni._FusedModule):
         init.zeros_(self.bn.bias)
 
     def reset_parameters(self):
-        super(LinearBn1d, self).reset_parameters()
+        super().reset_parameters()
 
     def update_bn_stats(self):
         self.freeze_bn = False

--- a/torch/ao/nn/intrinsic/qat/modules/linear_relu.py
+++ b/torch/ao/nn/intrinsic/qat/modules/linear_relu.py
@@ -30,7 +30,7 @@ class LinearReLU(nnqat.Linear, nni._FusedModule):
 
     def __init__(self, in_features, out_features, bias=True,
                  qconfig=None):
-        super(LinearReLU, self).__init__(in_features, out_features, bias, qconfig)
+        super().__init__(in_features, out_features, bias, qconfig)
 
     def forward(self, input):
         return F.relu(F.linear(input, self.weight_fake_quant(self.weight), self.bias))

--- a/torch/ao/nn/intrinsic/quantized/modules/bn_relu.py
+++ b/torch/ao/nn/intrinsic/quantized/modules/bn_relu.py
@@ -22,7 +22,7 @@ class BNReLU2d(nnq.BatchNorm2d):
     _FLOAT_MODULE = torch.ao.nn.intrinsic.BNReLU2d
 
     def __init__(self, num_features, eps=1e-5, momentum=0.1, device=None, dtype=None):
-        super(BNReLU2d, self).__init__(num_features, eps=eps, momentum=momentum, device=device, dtype=dtype)
+        super().__init__(num_features, eps=eps, momentum=momentum, device=device, dtype=dtype)
 
     def forward(self, input):
         # Temporarily using len(shape) instead of ndim due to JIT issue
@@ -58,7 +58,7 @@ class BNReLU3d(nnq.BatchNorm3d):
     _FLOAT_MODULE = torch.ao.nn.intrinsic.BNReLU3d
 
     def __init__(self, num_features, eps=1e-5, momentum=0.1, device=None, dtype=None):
-        super(BNReLU3d, self).__init__(num_features, eps=eps, momentum=momentum, device=device, dtype=dtype)
+        super().__init__(num_features, eps=eps, momentum=momentum, device=device, dtype=dtype)
 
     def forward(self, input):
         # Temporarily using len(shape) instead of ndim due to JIT issue

--- a/torch/ao/nn/intrinsic/quantized/modules/conv_relu.py
+++ b/torch/ao/nn/intrinsic/quantized/modules/conv_relu.py
@@ -31,7 +31,7 @@ class ConvReLU1d(nnq.Conv1d):
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
                  padding=0, dilation=1, groups=1, bias=True,
                  padding_mode='zeros', device=None, dtype=None):
-        super(ConvReLU1d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride=stride,
             padding=padding, dilation=dilation, groups=groups, bias=bias,
             padding_mode=padding_mode, device=device, dtype=dtype)
@@ -81,7 +81,7 @@ class ConvReLU2d(nnq.Conv2d):
     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
                  padding=0, dilation=1, groups=1, bias=True,
                  padding_mode='zeros', device=None, dtype=None):
-        super(ConvReLU2d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride=stride,
             padding=padding, dilation=dilation, groups=groups, bias=bias,
             padding_mode=padding_mode, device=device, dtype=dtype)
@@ -131,7 +131,7 @@ class ConvReLU3d(nnq.Conv3d):
                  padding=0, dilation=1, groups=1, bias=True,
                  padding_mode='zeros', device=None, dtype=None):
         assert padding_mode != 'reflect', "Conv3d does not support reflection padding"
-        super(ConvReLU3d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride=stride,
             padding=padding, dilation=dilation, groups=groups, bias=bias,
             padding_mode=padding_mode, device=device, dtype=dtype)

--- a/torch/ao/nn/quantizable/modules/activation.py
+++ b/torch/ao/nn/quantizable/modules/activation.py
@@ -66,10 +66,10 @@ class MultiheadAttention(nn.MultiheadAttention):
                  kdim: int = None, vdim: int = None, batch_first: bool = False,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(MultiheadAttention, self).__init__(embed_dim, num_heads, dropout,
-                                                 bias, add_bias_kv,
-                                                 add_zero_attn, kdim, vdim, batch_first,
-                                                 **factory_kwargs)
+        super().__init__(embed_dim, num_heads, dropout,
+                         bias, add_bias_kv,
+                         add_zero_attn, kdim, vdim, batch_first,
+                         **factory_kwargs)
         self.linear_Q = nn.Linear(self.embed_dim, self.embed_dim, bias=bias, **factory_kwargs)
         self.linear_K = nn.Linear(self.kdim, self.embed_dim, bias=bias, **factory_kwargs)
         self.linear_V = nn.Linear(self.vdim, self.embed_dim, bias=bias, **factory_kwargs)

--- a/torch/ao/nn/quantized/dynamic/modules/conv.py
+++ b/torch/ao/nn/quantized/dynamic/modules/conv.py
@@ -67,7 +67,7 @@ class Conv1d(nnq.Conv1d):
         padding = padding if isinstance(padding, str) else _single(padding)
         dilation = _single(dilation)
 
-        super(Conv1d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             groups, bias, padding_mode, **factory_kwargs)
 
@@ -132,7 +132,7 @@ class Conv2d(nnq.Conv2d):
         padding = _pair(padding)
         dilation = _pair(dilation)
 
-        super(Conv2d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             groups, bias, padding_mode, **factory_kwargs)
 
@@ -197,7 +197,7 @@ class Conv3d(nnq.Conv3d):
         stride = _triple(stride)
         padding = _triple(padding)
         dilation = _triple(dilation)
-        super(Conv3d, self)._init(
+        super()._init(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             False, _triple(0), groups, bias, padding_mode, **factory_kwargs)
 
@@ -262,7 +262,7 @@ class ConvTranspose1d(nnq.ConvTranspose1d):
             )
         )
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(ConvTranspose1d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, output_padding,
             groups, bias, dilation, padding_mode, **factory_kwargs)
 
@@ -323,7 +323,7 @@ class ConvTranspose2d(nnq.ConvTranspose2d):
             )
         )
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(ConvTranspose2d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, output_padding,
             groups, bias, dilation, padding_mode, **factory_kwargs)
 
@@ -384,7 +384,7 @@ class ConvTranspose3d(nnq.ConvTranspose3d):
             )
         )
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(ConvTranspose3d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, output_padding,
             groups, bias, dilation, padding_mode, **factory_kwargs)
 

--- a/torch/ao/nn/quantized/dynamic/modules/linear.py
+++ b/torch/ao/nn/quantized/dynamic/modules/linear.py
@@ -37,7 +37,7 @@ class Linear(nnq.Linear):
     _version = 4
 
     def __init__(self, in_features, out_features, bias_=True, dtype=torch.qint8):
-        super(Linear, self).__init__(in_features, out_features, bias_, dtype=dtype)
+        super().__init__(in_features, out_features, bias_, dtype=dtype)
         # We don't muck around with buffers or attributes or anything here
         # to keep the module simple. *everything* is simply a Python attribute.
         # Serialization logic is explicitly handled in the below serialization and
@@ -75,8 +75,8 @@ class Linear(nnq.Linear):
                               missing_keys, unexpected_keys, error_msgs):
         version = local_metadata.get('version', None)
         self.version = version
-        super(Linear, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                  missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
+                                      missing_keys, unexpected_keys, error_msgs)
 
     @classmethod
     def from_float(cls, mod):

--- a/torch/ao/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/ao/nn/quantized/dynamic/modules/rnn.py
@@ -45,18 +45,18 @@ def pack_weight_bias(qweight, bias, dtype):
 
 class PackedParameter(torch.nn.Module):
     def __init__(self, param):
-        super(PackedParameter, self).__init__()
+        super().__init__()
         self.param = param
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(PackedParameter, self)._save_to_state_dict(destination, prefix, keep_vars)
+        super()._save_to_state_dict(destination, prefix, keep_vars)
         destination[prefix + 'param'] = self.param
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
         self.param = state_dict[prefix + 'param']
-        super(PackedParameter, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                           missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
+                                      missing_keys, unexpected_keys, error_msgs)
 
 
 class RNNBase(torch.nn.Module):
@@ -68,7 +68,7 @@ class RNNBase(torch.nn.Module):
     def __init__(self, mode, input_size, hidden_size,
                  num_layers=1, bias=True, batch_first=False,
                  dropout=0., bidirectional=False, dtype=torch.qint8):
-        super(RNNBase, self).__init__()
+        super().__init__()
 
         self.mode = mode
         self.input_size = input_size
@@ -225,8 +225,8 @@ class RNNBase(torch.nn.Module):
                               missing_keys, unexpected_keys, error_msgs):
         version = local_metadata.get('version', None)
         self.version = version
-        super(RNNBase, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                   missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
+                                      missing_keys, unexpected_keys, error_msgs)
 
     def set_weight_bias(self, weight_bias_dict):
 
@@ -401,7 +401,7 @@ class LSTM(RNNBase):
     __overloads__ = {'forward': ['forward_packed', 'forward_tensor']}
 
     def __init__(self, *args, **kwargs):
-        super(LSTM, self).__init__('LSTM', *args, **kwargs)
+        super().__init__('LSTM', *args, **kwargs)
 
     def _get_name(self):
         return 'DynamicQuantizedLSTM'
@@ -627,7 +627,7 @@ class GRU(RNNBase):
     __overloads__ = {'forward': ['forward_packed', 'forward_tensor']}
 
     def __init__(self, *args, **kwargs):
-        super(GRU, self).__init__('GRU', *args, **kwargs)
+        super().__init__('GRU', *args, **kwargs)
 
     def _get_name(self):
         return 'DynamicQuantizedGRU'
@@ -753,7 +753,7 @@ class RNNCellBase(torch.nn.Module):
     __constants__ = ['input_size', 'hidden_size', 'bias']
 
     def __init__(self, input_size, hidden_size, bias=True, num_chunks=4, dtype=torch.qint8):
-        super(RNNCellBase, self).__init__()
+        super().__init__()
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.bias = bias
@@ -935,7 +935,7 @@ class RNNCellBase(torch.nn.Module):
             self.weight_dtype)
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(RNNCellBase, self)._save_to_state_dict(destination, prefix, keep_vars)
+        super()._save_to_state_dict(destination, prefix, keep_vars)
         destination[prefix + '_packed_weight_ih'] = self._packed_weight_ih
         destination[prefix + '_packed_weight_hh'] = self._packed_weight_hh
 
@@ -943,8 +943,8 @@ class RNNCellBase(torch.nn.Module):
                               missing_keys, unexpected_keys, error_msgs):
         self._packed_weight_ih = state_dict.pop(prefix + '_packed_weight_ih')
         self._packed_weight_hh = state_dict.pop(prefix + '_packed_weight_hh')
-        super(RNNCellBase, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                       missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
+                                      missing_keys, unexpected_keys, error_msgs)
 
 
 class RNNCell(RNNCellBase):
@@ -967,7 +967,7 @@ class RNNCell(RNNCellBase):
     __constants__ = ['input_size', 'hidden_size', 'bias', 'nonlinearity']
 
     def __init__(self, input_size, hidden_size, bias=True, nonlinearity="tanh", dtype=torch.qint8):
-        super(RNNCell, self).__init__(input_size, hidden_size, bias, num_chunks=1, dtype=dtype)
+        super().__init__(input_size, hidden_size, bias, num_chunks=1, dtype=dtype)
         self.nonlinearity = nonlinearity
 
     def _get_name(self):
@@ -1020,7 +1020,7 @@ class LSTMCell(RNNCellBase):
     """
 
     def __init__(self, *args, **kwargs):
-        super(LSTMCell, self).__init__(*args, num_chunks=4, **kwargs)  # type: ignore[misc]
+        super().__init__(*args, num_chunks=4, **kwargs)  # type: ignore[misc]
 
     def _get_name(self):
         return 'DynamicQuantizedLSTMCell'
@@ -1062,7 +1062,7 @@ class GRUCell(RNNCellBase):
     """
 
     def __init__(self, input_size, hidden_size, bias=True, dtype=torch.qint8):
-        super(GRUCell, self).__init__(input_size, hidden_size, bias, num_chunks=3, dtype=dtype)
+        super().__init__(input_size, hidden_size, bias, num_chunks=3, dtype=dtype)
 
     def _get_name(self):
         return 'DynamicQuantizedGRUCell'

--- a/torch/ao/nn/quantized/modules/__init__.py
+++ b/torch/ao/nn/quantized/modules/__init__.py
@@ -86,7 +86,7 @@ class Quantize(torch.nn.Module):
 
     def __init__(self, scale, zero_point, dtype, factory_kwargs=None):
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
-        super(Quantize, self).__init__()
+        super().__init__()
         self.register_buffer('scale', torch.tensor([scale], **factory_kwargs))
         self.register_buffer('zero_point',
                              torch.tensor([zero_point], dtype=torch.long,
@@ -122,9 +122,6 @@ class DeQuantize(torch.nn.Module):
         tensor([[ 1., -1.],
                 [ 1., -1.]], dtype=torch.float32)
     """
-
-    def __init__(self):
-        super(DeQuantize, self).__init__()
 
     def forward(self, Xq):
         return Xq.dequantize()

--- a/torch/ao/nn/quantized/modules/activation.py
+++ b/torch/ao/nn/quantized/modules/activation.py
@@ -36,7 +36,7 @@ class ReLU6(torch.nn.ReLU):
         >>> output = m(input)
     """
     def __init__(self, inplace=False):
-        super(ReLU6, self).__init__(inplace)
+        super().__init__(inplace)
         self.inplace = inplace
 
     def forward(self, input):
@@ -57,7 +57,7 @@ class Hardswish(torch.nn.Hardswish):
         zero_point: quantization zero point of the output tensor
     """
     def __init__(self, scale, zero_point):
-        super(Hardswish, self).__init__()
+        super().__init__()
         self.scale = scale
         self.zero_point = zero_point
 
@@ -86,7 +86,7 @@ class ELU(torch.nn.ELU):
         alpha: the alpha constant
     """
     def __init__(self, scale, zero_point, alpha=1.):
-        super(ELU, self).__init__(alpha)
+        super().__init__(alpha)
         self.scale = scale
         self.zero_point = zero_point
 

--- a/torch/ao/nn/quantized/modules/conv.py
+++ b/torch/ao/nn/quantized/modules/conv.py
@@ -48,7 +48,7 @@ class _ConvNd(WeightedQuantizedModule):
               device=None,
               dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(_ConvNd, self).__init__()
+        super().__init__()
 
         if in_channels % groups != 0:
             raise ValueError('in_channels must be divisible by groups')
@@ -120,7 +120,7 @@ class _ConvNd(WeightedQuantizedModule):
     #   self
     #   |--- _packed_params : Conv2dPackedParamsBase or Conv3dPackedParamsBase
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(_ConvNd, self)._save_to_state_dict(destination, prefix, keep_vars)
+        super()._save_to_state_dict(destination, prefix, keep_vars)
         (w, b) = self._weight_bias()
         destination[prefix + 'weight'] = w
         destination[prefix + 'bias'] = b
@@ -161,7 +161,7 @@ class _ConvNd(WeightedQuantizedModule):
         state_dict.pop(prefix + 'scale')
         self.zero_point = int(state_dict[prefix + 'zero_point'])
         state_dict.pop(prefix + 'zero_point')
-        super(_ConvNd, self)._load_from_state_dict(
+        super()._load_from_state_dict(
             state_dict, prefix, local_metadata, False, missing_keys,
             unexpected_keys, error_msgs)
 
@@ -330,7 +330,7 @@ class Conv1d(_ConvNd):
 
         # Subclasses of _ConvNd needs to call _init rather than __init__. See
         # discussion on PR #49702
-        super(Conv1d, self)._init(
+        super()._init(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             False, _single(0), groups, bias, padding_mode, **factory_kwargs)
 
@@ -433,7 +433,7 @@ class Conv2d(_ConvNd):
         dilation = _pair(dilation)
         # Subclasses of _ConvNd need to call _init rather than __init__. See
         # discussion on PR #49702
-        super(Conv2d, self)._init(
+        super()._init(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             False, _pair(0), groups, bias, padding_mode, **factory_kwargs)
 
@@ -535,7 +535,7 @@ class Conv3d(_ConvNd):
         dilation = _triple(dilation)
         # Subclasses of _ConvNd need to call _init rather than __init__. See
         # discussion on PR #49702
-        super(Conv3d, self)._init(
+        super()._init(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             False, _triple(0), groups, bias, padding_mode, **factory_kwargs)
 
@@ -597,7 +597,7 @@ class _ConvTransposeNd(_ConvNd):
         factory_kwargs = {'device': device, 'dtype': dtype}
         # Subclasses of _ConvNd need to call _init rather than __init__. See
         # discussion on PR #49702
-        super(_ConvTransposeNd, self)._init(
+        super()._init(
             in_channels, out_channels, kernel_size, stride,
             padding, dilation, transposed, output_padding,
             groups, bias, padding_mode, **factory_kwargs)
@@ -725,7 +725,7 @@ class ConvTranspose1d(_ConvTransposeNd):
         dilation = _single(dilation)
         output_padding = _single(output_padding)
 
-        super(ConvTranspose1d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             True, output_padding, groups, bias, padding_mode, **factory_kwargs)
 
@@ -816,7 +816,7 @@ class ConvTranspose2d(_ConvTransposeNd):
         dilation = _pair(dilation)
         output_padding = _pair(output_padding)
 
-        super(ConvTranspose2d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             True, output_padding, groups, bias, padding_mode, **factory_kwargs)
 
@@ -909,7 +909,7 @@ class ConvTranspose3d(_ConvTransposeNd):
         dilation = _triple(dilation)
         output_padding = _triple(output_padding)
 
-        super(ConvTranspose3d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             True, output_padding, groups, bias, padding_mode, **factory_kwargs)
 

--- a/torch/ao/nn/quantized/modules/embedding_ops.py
+++ b/torch/ao/nn/quantized/modules/embedding_ops.py
@@ -12,7 +12,7 @@ class EmbeddingPackedParams(torch.nn.Module):
     _version = 1
 
     def __init__(self, num_embeddings, embedding_dim, dtype=torch.quint8):
-        super(EmbeddingPackedParams, self).__init__()
+        super().__init__()
         self.dtype = dtype
         if self.dtype in [torch.quint8, torch.quint4x2]:
             scales = torch.ones(num_embeddings, dtype=torch.float)
@@ -48,7 +48,7 @@ class EmbeddingPackedParams(torch.nn.Module):
     #   |--- dtype : torch.dtype
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(EmbeddingPackedParams, self)._save_to_state_dict(destination, prefix, keep_vars)
+        super()._save_to_state_dict(destination, prefix, keep_vars)
         destination[prefix + 'dtype'] = self.dtype
         destination[prefix + '_packed_weight'] = self._weight()
 
@@ -61,8 +61,8 @@ class EmbeddingPackedParams(torch.nn.Module):
         state_dict.pop(prefix + '_packed_weight')
         self.set_weight(weight)
 
-        super(EmbeddingPackedParams, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                                 missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
+                                      missing_keys, unexpected_keys, error_msgs)
 
     def __repr__(self):
         return self._weight().__repr__()
@@ -93,7 +93,7 @@ class Embedding(torch.nn.Module):
     def __init__(self, num_embeddings: int, embedding_dim: int, padding_idx: Optional[int] = None,
                  max_norm: Optional[float] = None, norm_type: float = 2., scale_grad_by_freq: bool = False,
                  sparse: bool = False, _weight: Optional[Tensor] = None, dtype=torch.quint8) -> None:
-        super(Embedding, self).__init__()
+        super().__init__()
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
         self.dtype = dtype
@@ -220,7 +220,7 @@ class EmbeddingBag(Embedding):
                  max_norm: Optional[float] = None, norm_type: float = 2., scale_grad_by_freq: bool = False,
                  mode: str = 'sum', sparse: bool = False, _weight: Optional[Tensor] = None,
                  include_last_offset: bool = False, dtype=torch.quint8) -> None:
-        super(EmbeddingBag, self).__init__(num_embeddings, embedding_dim, _weight=_weight, dtype=dtype)
+        super().__init__(num_embeddings, embedding_dim, _weight=_weight, dtype=dtype)
 
         self.mode = mode
         self.pruned_weights = False

--- a/torch/ao/nn/quantized/modules/functional_modules.py
+++ b/torch/ao/nn/quantized/modules/functional_modules.py
@@ -33,7 +33,7 @@ class FloatFunctional(torch.nn.Module):
         - mul_scalar
     """
     def __init__(self):
-        super(FloatFunctional, self).__init__()
+        super().__init__()
         self.activation_post_process = torch.nn.Identity()
 
     def forward(self, x):
@@ -154,13 +154,13 @@ class QFunctional(torch.nn.Module):
         - mul_scalar
     """
     def __init__(self):
-        super(QFunctional, self).__init__()
+        super().__init__()
         self.scale = 1.0
         self.zero_point = 0
         self.activation_post_process = torch.nn.Identity()
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(QFunctional, self)._save_to_state_dict(destination, prefix, keep_vars)
+        super()._save_to_state_dict(destination, prefix, keep_vars)
         destination[prefix + 'scale'] = torch.tensor(self.scale)
         destination[prefix + 'zero_point'] = torch.tensor(self.zero_point)
 
@@ -169,8 +169,8 @@ class QFunctional(torch.nn.Module):
 
         self.scale = float(state_dict.pop(prefix + 'scale'))
         self.zero_point = int(state_dict.pop(prefix + 'zero_point'))
-        super(QFunctional, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                       missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
+                                      missing_keys, unexpected_keys, error_msgs)
 
     def _get_name(self):
         return 'QFunctional'

--- a/torch/ao/nn/quantized/modules/linear.py
+++ b/torch/ao/nn/quantized/modules/linear.py
@@ -65,7 +65,7 @@ class LinearPackedParams(torch.nn.Module):
     #                         of LinearPackedParams
     #   |--- dtype : torch.dtype
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(LinearPackedParams, self)._save_to_state_dict(destination, prefix, keep_vars)
+        super()._save_to_state_dict(destination, prefix, keep_vars)
         destination[prefix + 'dtype'] = self.dtype
         destination[prefix + '_packed_params'] = self._weight_bias()
 
@@ -88,8 +88,8 @@ class LinearPackedParams(torch.nn.Module):
             state_dict.pop(prefix + '_packed_params')
             self.set_weight_bias(weight, bias)
 
-        super(LinearPackedParams, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                                              missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
+                                      missing_keys, unexpected_keys, error_msgs)
 
 
     def __repr__(self):

--- a/torch/ao/nn/quantized/modules/normalization.py
+++ b/torch/ao/nn/quantized/modules/normalization.py
@@ -14,9 +14,8 @@ class LayerNorm(torch.nn.LayerNorm):
     def __init__(self, normalized_shape, weight, bias, scale, zero_point, eps=1e-5,
                  elementwise_affine=True, device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(LayerNorm, self).__init__(
-            normalized_shape, eps=eps, elementwise_affine=elementwise_affine,
-            **factory_kwargs)
+        super().__init__(normalized_shape, eps=eps, elementwise_affine=elementwise_affine,
+                         **factory_kwargs)
         self.weight = weight
         self.bias = bias
         self.register_buffer('scale', torch.tensor(scale, **factory_kwargs))
@@ -57,8 +56,7 @@ class GroupNorm(torch.nn.GroupNorm):
     def __init__(self, num_groups, num_channels, weight, bias, scale, zero_point, eps=1e-5,
                  affine=True, device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(GroupNorm, self).__init__(num_groups, num_channels, eps, affine,
-                                        **factory_kwargs)
+        super().__init__(num_groups, num_channels, eps, affine, **factory_kwargs)
         self.weight = weight
         self.bias = bias
         self.register_buffer('scale', torch.tensor(scale, **factory_kwargs))
@@ -92,8 +90,7 @@ class InstanceNorm1d(torch.nn.InstanceNorm1d):
                  eps=1e-5, momentum=0.1, affine=False,
                  track_running_stats=False, device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(InstanceNorm1d, self).__init__(
-            num_features, eps, momentum, affine, track_running_stats, **factory_kwargs)
+        super().__init__(num_features, eps, momentum, affine, track_running_stats, **factory_kwargs)
         self.weight = weight
         self.bias = bias
         self.register_buffer('scale', torch.tensor(scale, **factory_kwargs))
@@ -133,8 +130,7 @@ class InstanceNorm2d(torch.nn.InstanceNorm2d):
                  eps=1e-5, momentum=0.1, affine=False,
                  track_running_stats=False, device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(InstanceNorm2d, self).__init__(
-            num_features, eps, momentum, affine, track_running_stats, **factory_kwargs)
+        super().__init__(num_features, eps, momentum, affine, track_running_stats, **factory_kwargs)
         self.weight = weight
         self.bias = bias
         self.register_buffer('scale', torch.tensor(scale, **factory_kwargs))
@@ -174,8 +170,7 @@ class InstanceNorm3d(torch.nn.InstanceNorm3d):
                  eps=1e-5, momentum=0.1, affine=False,
                  track_running_stats=False, device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(InstanceNorm3d, self).__init__(
-            num_features, eps, momentum, affine, track_running_stats, **factory_kwargs)
+        super().__init__(num_features, eps, momentum, affine, track_running_stats, **factory_kwargs)
         self.weight = weight
         self.bias = bias
         self.register_buffer('scale', torch.tensor(scale, **factory_kwargs))

--- a/torch/ao/ns/_numeric_suite.py
+++ b/torch/ao/ns/_numeric_suite.py
@@ -171,7 +171,7 @@ class Logger(nn.Module):
     """
 
     def __init__(self):
-        super(Logger, self).__init__()
+        super().__init__()
         self.stats = {}
         # We only insert observer if the op is quantized with static quantization,
         # which is identified by activation_observer.dtype == quint8.  This is needed
@@ -190,7 +190,7 @@ class ShadowLogger(Logger):
     """
 
     def __init__(self):
-        super(ShadowLogger, self).__init__()
+        super().__init__()
         self.stats["float"] = []
         self.stats["quantized"] = []
 
@@ -210,7 +210,7 @@ class OutputLogger(Logger):
     """
 
     def __init__(self):
-        super(OutputLogger, self).__init__()
+        super().__init__()
         self.stats["tensor_val"] = []
 
 
@@ -248,7 +248,7 @@ class Shadow(nn.Module):
     """
 
     def __init__(self, q_module, float_module, logger_cls):
-        super(Shadow, self).__init__()
+        super().__init__()
         self.orig_module = q_module
         self.shadow_module = float_module
         self.dequant = nnq.DeQuantize()

--- a/torch/ao/pruning/scheduler/lambda_scheduler.py
+++ b/torch/ao/pruning/scheduler/lambda_scheduler.py
@@ -37,7 +37,7 @@ class LambdaSL(BaseScheduler):
                 raise ValueError("Expected {} lr_lambdas, but got {}".format(
                     len(sparsifier.groups), len(sl_lambda)))
             self.sl_lambdas = list(sl_lambda)
-        super(LambdaSL, self).__init__(sparsifier, last_epoch, verbose)
+        super().__init__(sparsifier, last_epoch, verbose)
 
     def get_sl(self):
         if not self._get_sl_called_within_step:

--- a/torch/ao/quantization/_correct_bias.py
+++ b/torch/ao/quantization/_correct_bias.py
@@ -45,7 +45,7 @@ class MeanShadowLogger(ns.Logger):
     of the data passed to the floating point and quantized models
     """
     def __init__(self):
-        super(MeanShadowLogger, self).__init__()
+        super().__init__()
         self.stats["float"] = None
         self.stats["quantized"] = None
         self.count = 0

--- a/torch/ao/quantization/_learnable_fake_quantize.py
+++ b/torch/ao/quantization/_learnable_fake_quantize.py
@@ -30,7 +30,7 @@ class _LearnableFakeQuantize(torch.ao.quantization.FakeQuantizeBase):
     """
     def __init__(self, observer, quant_min=0, quant_max=255, scale=1., zero_point=0., channel_len=-1,
                  use_grad_scaling=False, **observer_kwargs):
-        super(_LearnableFakeQuantize, self).__init__()
+        super().__init__()
         assert quant_min < quant_max, 'quant_min must be strictly less than quant_max.'
         self.quant_min = quant_min
         self.quant_max = quant_max

--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -222,7 +222,7 @@ class FakeQuantize(FakeQuantizeBase):
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         # We cannot currently register scalar values as buffers, so need to manually
         # specify serialization here.
-        super(FakeQuantize, self)._save_to_state_dict(destination, prefix, keep_vars)
+        super()._save_to_state_dict(destination, prefix, keep_vars)
         destination[prefix + 'scale'] = self.scale
         destination[prefix + 'zero_point'] = self.zero_point
 
@@ -254,8 +254,8 @@ class FakeQuantize(FakeQuantizeBase):
                         self.zero_point.copy_(val)
             elif strict:
                 missing_keys.append(key)
-        super(FakeQuantize, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
-                                                        missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, strict,
+                                      missing_keys, unexpected_keys, error_msgs)
 
 
 class FixedQParamsFakeQuantize(FakeQuantize):

--- a/torch/ao/quantization/fx/_equalize.py
+++ b/torch/ao/quantization/fx/_equalize.py
@@ -58,7 +58,7 @@ class _InputEqualizationObserver(nn.Module):
 
     def __init__(self, dtype=torch.quint8, qscheme=torch.per_tensor_affine,
                  quant_min=None, quant_max=None, factory_kwargs=None) -> None:
-        super(_InputEqualizationObserver, self).__init__()
+        super().__init__()
 
         if qscheme not in {torch.per_tensor_affine, torch.per_tensor_symmetric}:
             raise TypeError("Input qscheme must be per-tensor")
@@ -142,7 +142,7 @@ class _WeightEqualizationObserver(nn.Module):
 
     def __init__(self, dtype=torch.qint8, qscheme=torch.per_tensor_affine, quant_min=None,
                  quant_max=None, factory_kwargs=None) -> None:
-        super(_WeightEqualizationObserver, self).__init__()
+        super().__init__()
 
         self.dtype = dtype
         self.qscheme = qscheme

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -136,7 +136,7 @@ class ObserverBase(ABC, nn.Module):
     """
 
     def __init__(self, dtype):
-        super(ObserverBase, self).__init__()
+        super().__init__()
         self.dtype = dtype
 
     @abstractmethod
@@ -258,7 +258,7 @@ class UniformQuantizationObserverBase(ObserverBase):
             eps = torch.tensor([torch.finfo(torch.float32).eps])
             state_dict[prefix + "eps"] = eps
 
-        super(ObserverBase, self)._load_from_state_dict(
+        super()._load_from_state_dict(
             state_dict,
             prefix,
             local_metadata,
@@ -467,7 +467,7 @@ class MinMaxObserver(UniformQuantizationObserverBase):
         # For more details see aten/src/ATen/native/quantized/cpu/qconv.cpp
         # This is not an optimal choice for non x86 backends as it loses a bit
         # of precision for activations.
-        super(MinMaxObserver, self).__init__(
+        super().__init__(
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,
@@ -580,7 +580,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
                     torch.per_tensor_symmetric and torch.per_tensor_affine."
             )
         self.averaging_constant = averaging_constant
-        super(MovingAverageMinMaxObserver, self).__init__(
+        super().__init__(
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,
@@ -654,7 +654,7 @@ class PerChannelMinMaxObserver(UniformQuantizationObserverBase):
                 "PerChannelMinMaxObserver's qscheme only support \
                     torch.per_channel_symmetric, torch.per_channel_affine and torch.per_channel_affine_float_qparams."
             )
-        super(PerChannelMinMaxObserver, self).__init__(
+        super().__init__(
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,
@@ -760,7 +760,7 @@ class PerChannelMinMaxObserver(UniformQuantizationObserverBase):
                 missing_keys.append(key)
 
         if not torch.jit.is_scripting():
-            super(PerChannelMinMaxObserver, self)._load_from_state_dict(
+            super()._load_from_state_dict(
                 state_dict,
                 prefix,
                 local_metadata,
@@ -846,7 +846,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
                 "MovingAveragePerChannelMinMaxObserver's qscheme only support \
                     torch.per_channel_symmetric, torch.per_channel_affine and torch.per_channel_affine_float_qparams."
             )
-        super(MovingAveragePerChannelMinMaxObserver, self).__init__(
+        super().__init__(
             ch_axis=ch_axis,
             dtype=dtype,
             qscheme=qscheme,
@@ -933,7 +933,7 @@ class HistogramObserver(UniformQuantizationObserverBase):
                     and torch.per_tensor_affine."
             )
         # bins: The number of bins used for histogram calculation.
-        super(HistogramObserver, self).__init__(
+        super().__init__(
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,
@@ -1221,9 +1221,7 @@ class HistogramObserver(UniformQuantizationObserverBase):
         return self._calculate_qparams(new_min, new_max)
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(HistogramObserver, self)._save_to_state_dict(
-            destination, prefix, keep_vars
-        )
+        super()._save_to_state_dict(destination, prefix, keep_vars)
         destination[prefix + "min_val"] = self.min_val
         destination[prefix + "max_val"] = self.max_val
 
@@ -1258,7 +1256,7 @@ class HistogramObserver(UniformQuantizationObserverBase):
                 setattr(self, name, val)
             elif strict:
                 missing_keys.append(key)
-        super(HistogramObserver, self)._load_from_state_dict(
+        super()._load_from_state_dict(
             state_dict,
             prefix,
             local_metadata,
@@ -1294,7 +1292,7 @@ class FixedQParamsObserver(ObserverBase):
                  qscheme=torch.per_tensor_affine,
                  quant_min=0,
                  quant_max=255):
-        super(FixedQParamsObserver, self).__init__(dtype=dtype)
+        super().__init__(dtype=dtype)
         self.quant_min = quant_min
         self.quant_max = quant_max
         self.register_buffer('scale', torch.tensor([scale], dtype=torch.float))
@@ -1376,7 +1374,7 @@ class RecordingObserver(ObserverBase):
     __annotations__ = {"tensor_val": List[Optional[torch.Tensor]]}
 
     def __init__(self, dtype=torch.quint8, **kwargs):
-        super(RecordingObserver, self).__init__(dtype=dtype, **kwargs)  # type: ignore[call-arg]
+        super().__init__(dtype=dtype, **kwargs)  # type: ignore[call-arg]
         self.tensor_val = []
 
     def forward(self, x):
@@ -1407,7 +1405,7 @@ class NoopObserver(ObserverBase):
     """
 
     def __init__(self, dtype=torch.float16, custom_op_name="") -> None:
-        super(NoopObserver, self).__init__(dtype=dtype)
+        super().__init__(dtype=dtype)
         self.dtype = dtype
         self.custom_op = custom_op_name
 

--- a/torch/ao/quantization/stubs.py
+++ b/torch/ao/quantization/stubs.py
@@ -10,7 +10,7 @@ class QuantStub(nn.Module):
             if qconfig is not provided, we will get qconfig from parent modules
     """
     def __init__(self, qconfig=None):
-        super(QuantStub, self).__init__()
+        super().__init__()
         if qconfig:
             self.qconfig = qconfig
 
@@ -27,7 +27,7 @@ class DeQuantStub(nn.Module):
             if qconfig is not provided, we will get qconfig from parent modules
     """
     def __init__(self, qconfig=None):
-        super(DeQuantStub, self).__init__()
+        super().__init__()
         if qconfig:
             self.qconfig = qconfig
 
@@ -51,7 +51,7 @@ class QuantWrapper(nn.Module):
     module: nn.Module
 
     def __init__(self, module):
-        super(QuantWrapper, self).__init__()
+        super().__init__()
         qconfig = module.qconfig if hasattr(module, 'qconfig') else None
         self.add_module('quant', QuantStub(qconfig))
         self.add_module('dequant', DeQuantStub(qconfig))

--- a/torch/autograd/forward_ad.py
+++ b/torch/autograd/forward_ad.py
@@ -176,9 +176,6 @@ class dual_level(_DecoratorContextManager):
     Please see the `forward-mode AD tutorial <https://pytorch.org/tutorials/intermediate/forward_ad_usage.html>`__
     for detailed steps on how to use this API.
     """
-    def __init__(self):
-        super().__init__()
-
     def __enter__(self):
         return enter_dual_level()
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -578,7 +578,7 @@ def traceable(fn_cls):
 class InplaceFunction(Function):
 
     def __init__(self, inplace=False):
-        super(InplaceFunction, self).__init__()
+        super().__init__()
         self.inplace = inplace
 
 
@@ -680,14 +680,14 @@ class NestedIOFunction(Function):
     def _do_forward(self, *input):
         self._nested_input = input
         flat_input = tuple(_iter_tensors(input))
-        flat_output = super(NestedIOFunction, self)._do_forward(*flat_input)
+        flat_output = super()._do_forward(*flat_input)
         nested_output = self._nested_output
         nested_tensors = _unflatten(flat_output, self._nested_output)
         return nested_tensors
 
     def _do_backward(self, gradients, retain_variables):
         self.retain_variables = retain_variables
-        result = super(NestedIOFunction, self)._do_backward(gradients, retain_variables)
+        result = super()._do_backward(gradients, retain_variables)
         if not retain_variables:
             del self._nested_output
             del self._to_save_nested
@@ -713,7 +713,7 @@ class NestedIOFunction(Function):
 
     @property
     def saved_tensors(self):
-        flat_tensors = super(NestedIOFunction, self).saved_tensors
+        flat_tensors = super().saved_tensors
         return _unflatten(flat_tensors, self._to_save_nested)
 
     def mark_dirty(self, *args: Any, **kwargs: Any) -> None:

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -19,7 +19,7 @@ class EventList(list):
         use_cuda = kwargs.pop('use_cuda', True)
         profile_memory = kwargs.pop('profile_memory', False)
         with_flops = kwargs.pop('with_flops', False)
-        super(EventList, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._use_cuda = use_cuda
         self._profile_memory = profile_memory
         self._tree_built = False

--- a/torch/backends/__init__.py
+++ b/torch/backends/__init__.py
@@ -40,7 +40,7 @@ class ContextProp:
 
 class PropModule(types.ModuleType):
     def __init__(self, m, name):
-        super(PropModule, self).__init__(name)
+        super().__init__(name)
         self.m = m
 
     def __getattr__(self, attr):

--- a/torch/backends/cuda/__init__.py
+++ b/torch/backends/cuda/__init__.py
@@ -88,7 +88,7 @@ class cuFFTPlanCacheManager:
         if self.__initialized:
             return setattr(self[torch.cuda.current_device()], name, value)
         else:
-            return super(cuFFTPlanCacheManager, self).__setattr__(name, value)
+            return super().__setattr__(name, value)
 
 
 class cuBLASModule:

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -141,7 +141,7 @@ def flags(enabled=False, benchmark=False, benchmark_limit=10, deterministic=Fals
 
 class CudnnModule(PropModule):
     def __init__(self, m, name):
-        super(CudnnModule, self).__init__(m, name)
+        super().__init__(m, name)
 
     enabled = ContextProp(torch._C._get_cudnn_enabled, torch._C._set_cudnn_enabled)
     deterministic = ContextProp(torch._C._get_cudnn_deterministic, torch._C._set_cudnn_deterministic)

--- a/torch/backends/mkldnn/__init__.py
+++ b/torch/backends/mkldnn/__init__.py
@@ -70,7 +70,7 @@ def flags(enabled=False):
 
 class MkldnnModule(PropModule):
     def __init__(self, m, name):
-        super(MkldnnModule, self).__init__(m, name)
+        super().__init__(m, name)
 
     enabled = ContextProp(torch._C._get_mkldnn_enabled, torch._C._set_mkldnn_enabled)
 

--- a/torch/backends/opt_einsum/__init__.py
+++ b/torch/backends/opt_einsum/__init__.py
@@ -82,7 +82,7 @@ def flags(enabled=None, strategy=None):
 
 class OptEinsumModule(PropModule):
     def __init__(self, m, name):
-        super(OptEinsumModule, self).__init__(m, name)
+        super().__init__(m, name)
 
     global enabled
     enabled = ContextProp(_get_enabled, _set_enabled)

--- a/torch/backends/quantized/__init__.py
+++ b/torch/backends/quantized/__init__.py
@@ -42,7 +42,7 @@ class _SupportedQEnginesProp:
 
 class QuantizedEngine(types.ModuleType):
     def __init__(self, m, name):
-        super(QuantizedEngine, self).__init__(name)
+        super().__init__(name)
         self.m = m
 
     def __getattr__(self, attr):

--- a/torch/backends/xnnpack/__init__.py
+++ b/torch/backends/xnnpack/__init__.py
@@ -11,7 +11,7 @@ class _XNNPACKEnabled:
 
 class XNNPACKEngine(types.ModuleType):
     def __init__(self, m, name):
-        super(XNNPACKEngine, self).__init__(name)
+        super().__init__(name)
         self.m = m
 
     def __getattr__(self, attr):

--- a/torch/csrc/jit/operator_upgraders/README.md
+++ b/torch/csrc/jit/operator_upgraders/README.md
@@ -38,7 +38,7 @@ When making changes to the operators, the first thing to identify is if it's BC/
   ```
   class TestVersionedLinspaceV7(torch.nn.Module):
       def __init__(self):
-          super(TestVersionedLinspaceV7, self).__init__()
+          super().__init__()
 
       def forward(self, a: Union[int, float, complex], b: Union[int, float, complex]):
           c = torch.linspace(a, b, steps=5)
@@ -164,7 +164,7 @@ When making changes to the operators, the first thing to identify is if it's BC/
             # Step 2. Write down how current module should look like
             class MyModuleFloat(torch.nn.Module):
                 def __init__(self):
-                    super(MyModuleFloat, self).__init__()
+                    super().__init__()
 
                 def forward(self, a, b: float):
                     return a / b

--- a/torch/csrc/lazy/test_mnist.py
+++ b/torch/csrc/lazy/test_mnist.py
@@ -13,7 +13,7 @@ torch._lazy.ts_backend.init()
 
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 32, 3, 1)
         self.conv2 = nn.Conv2d(32, 64, 3, 1)
         self.dropout1 = nn.Dropout(0.25)

--- a/torch/csrc/lazy/tutorial.md
+++ b/torch/csrc/lazy/tutorial.md
@@ -136,7 +136,7 @@ Here's our model definition:
 ```python
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 32, 3, 1)
         self.conv2 = nn.Conv2d(32, 64, 3, 1)
         self.dropout1 = nn.Dropout(0.25)

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -279,7 +279,7 @@ class cudaStatus:
 class CudaError(RuntimeError):
     def __init__(self, code: int) -> None:
         msg = _cudart.cudaGetErrorString(_cudart.cudaError(code))
-        super(CudaError, self).__init__('{0} ({1})'.format(msg, code))
+        super().__init__('{0} ({1})'.format(msg, code))
 
 
 def check_error(res: int) -> None:
@@ -332,7 +332,7 @@ class device_of(device):
 
     def __init__(self, obj):
         idx = obj.get_device() if obj.is_cuda else -1
-        super(device_of, self).__init__(idx)
+        super().__init__(idx)
 
 
 def set_device(device: _device_t) -> None:
@@ -748,7 +748,7 @@ class _CudaBase:
         # but it is only available in the typing module on Python >= 3.8
         # or on typing_extensions module on Python >= 3.6
         with device(self.get_device()):  # type: ignore[attr-defined]
-            return super(_CudaBase, self).type(*args, **kwargs)  # type: ignore[misc]
+            return super().type(*args, **kwargs)  # type: ignore[misc]
 
     __new__ = _lazy_new
 

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -47,9 +47,6 @@ class CUDAGraph(torch._C._CUDAGraph):
     def __new__(cls):
         return super(CUDAGraph, cls).__new__(cls)
 
-    def __init__(self):
-        super(CUDAGraph, self).__init__()
-
     def capture_begin(self, pool=None):
         r"""
         Begins capturing CUDA work on the current stream.
@@ -66,9 +63,9 @@ class CUDAGraph(torch._C._CUDAGraph):
         # I'm not sure if pybind11 converts a None arg to the default defined on the C++ side,
         # so I'm not taking any chances.
         if pool is None:
-            super(CUDAGraph, self).capture_begin()
+            super().capture_begin()
         else:
-            super(CUDAGraph, self).capture_begin(pool)
+            super().capture_begin(pool)
 
     def capture_end(self):
         r"""
@@ -79,19 +76,19 @@ class CUDAGraph(torch._C._CUDAGraph):
         Use :class:`~torch.cuda.graph` or :func:`~torch.cuda.make_graphed_callables`,
         which call ``capture_end`` internally.
         """
-        super(CUDAGraph, self).capture_end()
+        super().capture_end()
 
     def replay(self):
         r"""
         Replays the CUDA work captured by this graph.
         """
-        super(CUDAGraph, self).replay()
+        super().replay()
 
     def reset(self):
         r"""
         Deletes the graph currently held by this instance.
         """
-        super(CUDAGraph, self).reset()
+        super().reset()
 
     def pool(self):
         r"""
@@ -99,13 +96,13 @@ class CUDAGraph(torch._C._CUDAGraph):
         This id can optionally be passed to another graph's ``capture_begin``,
         which hints the other graph may share the same memory pool.
         """
-        return super(CUDAGraph, self).pool()
+        return super().pool()
 
     def enable_debug_mode(self):
         r"""
         Enables debugging mode for CUDAGraph.debug_dump.
         """
-        return super(CUDAGraph, self).enable_debug_mode()
+        return super().enable_debug_mode()
 
     def debug_dump(self, debug_path):
         r"""
@@ -115,7 +112,7 @@ class CUDAGraph(torch._C._CUDAGraph):
         Calls a debugging function to dump the graph if the debugging is
         enabled via CUDAGraph.enable_debug_mode()
         """
-        return super(CUDAGraph, self).debug_dump(debug_path)
+        return super().debug_dump(debug_path)
 
 
 class graph:

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -87,7 +87,7 @@ class Stream(torch._C._CudaStreamBase):
 
         Returns:
             A boolean indicating if all kernels in this stream are completed."""
-        return super(Stream, self).query()
+        return super().query()
 
     def synchronize(self):
         r"""Wait for all the kernels in this stream to complete.
@@ -95,7 +95,7 @@ class Stream(torch._C._CudaStreamBase):
         .. note:: This is a wrapper around ``cudaStreamSynchronize()``: see
            `CUDA Stream documentation`_ for more info.
         """
-        super(Stream, self).synchronize()
+        super().synchronize()
 
     @property
     def _as_parameter_(self):
@@ -103,7 +103,7 @@ class Stream(torch._C._CudaStreamBase):
 
     def __eq__(self, o):
         if isinstance(o, Stream):
-            return super(Stream, self).__eq__(o)
+            return super().__eq__(o)
         return False
 
     def __hash__(self):
@@ -177,7 +177,7 @@ class Event(torch._C._CudaEventBase):
         stream's device must match the event's device."""
         if stream is None:
             stream = torch.cuda.current_stream()
-        super(Event, self).record(stream)
+        super().record(stream)
 
     def wait(self, stream=None):
         r"""Makes all future work submitted to the given stream wait for this
@@ -190,7 +190,7 @@ class Event(torch._C._CudaEventBase):
         """
         if stream is None:
             stream = torch.cuda.current_stream()
-        super(Event, self).wait(stream)
+        super().wait(stream)
 
     def query(self):
         r"""Checks if all work currently captured by event has completed.
@@ -199,13 +199,13 @@ class Event(torch._C._CudaEventBase):
             A boolean indicating if all work currently captured by event has
             completed.
         """
-        return super(Event, self).query()
+        return super().query()
 
     def elapsed_time(self, end_event):
         r"""Returns the time elapsed in milliseconds after the event was
         recorded and before the end_event was recorded.
         """
-        return super(Event, self).elapsed_time(end_event)
+        return super().elapsed_time(end_event)
 
     def synchronize(self):
         r"""Waits for the event to complete.
@@ -216,12 +216,12 @@ class Event(torch._C._CudaEventBase):
          .. note:: This is a wrapper around ``cudaEventSynchronize()``: see
             `CUDA Event documentation`_ for more info.
         """
-        super(Event, self).synchronize()
+        super().synchronize()
 
     def ipc_handle(self):
         r"""Returns an IPC handle of this event. If not recorded yet, the event
         will use the current device. """
-        return super(Event, self).ipc_handle()
+        return super().ipc_handle()
 
     @property
     def _as_parameter_(self):

--- a/torch/distributed/_composable/_ddp.py
+++ b/torch/distributed/_composable/_ddp.py
@@ -104,7 +104,7 @@ class DistributedDataParallel(Module):
         static_graph=False,
     ):
 
-        super(DistributedDataParallel, self).__init__()
+        super().__init__()
         self.logger: Optional[dist.Logger] = None
         if not any((p.requires_grad for p in module.parameters())):
             self._log_and_throw(
@@ -337,7 +337,7 @@ class DistributedDataParallel(Module):
     def __setstate__(self, state):
         # If serializable, then the process group should be the default one
         self.process_group = _get_default_group()
-        super(DistributedDataParallel, self).__setstate__(state)
+        super().__setstate__(state)
         self.__dict__.setdefault("require_forward_param_sync", True)
         self.__dict__.setdefault("require_backward_grad_sync", True)
         parameters, expect_sparse_gradient = self._build_params_for_reducer()
@@ -655,7 +655,7 @@ class DistributedDataParallel(Module):
         return gather(outputs, output_device, dim=self.dim)
 
     def train(self, mode=True):
-        super(DistributedDataParallel, self).train(mode)
+        super().train(mode)
         return self
 
     # When running in join mode, schedules an allreduce to notify joined ranks

--- a/torch/distributed/_shard/partial_tensor.py
+++ b/torch/distributed/_shard/partial_tensor.py
@@ -252,7 +252,7 @@ class _PartialTensor(torch.Tensor):
         )
 
     def __repr__(self):
-        return f"PartialTensor({super(_PartialTensor, self).__repr__()})"
+        return f"PartialTensor({super().__repr__()})"
 
 def _transpose_impl(types, args=(), kwargs=None, process_group=None):
     partial_tensor = args[0]

--- a/torch/distributed/_shard/replicated_tensor.py
+++ b/torch/distributed/_shard/replicated_tensor.py
@@ -57,7 +57,7 @@ class ReplicatedTensor(torch.Tensor):
             return result
 
     def __repr__(self):
-        return f"ReplicatedTensor({super(ReplicatedTensor, self).__repr__()})"
+        return f"ReplicatedTensor({super().__repr__()})"
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):

--- a/torch/distributed/algorithms/join.py
+++ b/torch/distributed/algorithms/join.py
@@ -50,7 +50,7 @@ class Joinable(ABC):
     """
     @abstractmethod
     def __init__(self):
-        super(Joinable, self).__init__()
+        super().__init__()
         self._join_config = _JoinConfig.construct_disabled_join_config()
 
     @abstractmethod

--- a/torch/distributed/benchmarks/benchmark_ddp_rpc.py
+++ b/torch/distributed/benchmarks/benchmark_ddp_rpc.py
@@ -42,7 +42,7 @@ class HybridModel(torch.nn.Module):
    """
 
     def __init__(self, emb_rref_list, device):
-        super(HybridModel, self).__init__()
+        super().__init__()
         self.emb_rref_list = emb_rref_list
         fc1 = torch.nn.Linear(512, 256)
         fc2 = torch.nn.Linear(256, 128)

--- a/torch/distributed/pipeline/sync/pipe.py
+++ b/torch/distributed/pipeline/sync/pipe.py
@@ -162,7 +162,7 @@ class WithDevice(nn.Module):
         >>> model = Pipe(model, chunks=8)
     """
     def __init__(self, module: nn.Module, device: torch.device):
-        super(WithDevice, self).__init__()
+        super().__init__()
         self._module = module
         self._device = torch.device(device)
 

--- a/torch/distributed/tensor/parallel/multihead_attention_tp.py
+++ b/torch/distributed/tensor/parallel/multihead_attention_tp.py
@@ -64,7 +64,7 @@ class TensorParallelMultiheadAttention(torch.nn.Module):
         tp_size: int = 1,
         self_attention: bool = True,
     ) -> None:
-        super(TensorParallelMultiheadAttention, self).__init__()
+        super().__init__()
         self.device: torch.device = (
             torch.device("cuda" if torch.cuda.is_available() else "cpu")
             if device is None

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -48,7 +48,7 @@ class Bernoulli(ExponentialFamily):
             batch_shape = torch.Size()
         else:
             batch_shape = self._param.size()
-        super(Bernoulli, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Bernoulli, _instance)

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -36,7 +36,7 @@ class Beta(ExponentialFamily):
             concentration1, concentration0 = broadcast_all(concentration1, concentration0)
             concentration1_concentration0 = torch.stack([concentration1, concentration0], -1)
         self._dirichlet = Dirichlet(concentration1_concentration0, validate_args=validate_args)
-        super(Beta, self).__init__(self._dirichlet._batch_shape, validate_args=validate_args)
+        super().__init__(self._dirichlet._batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Beta, _instance)

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -50,7 +50,7 @@ class Binomial(Distribution):
 
         self._param = self.probs if probs is not None else self.logits
         batch_shape = self._param.size()
-        super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Binomial, _instance)

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -63,7 +63,7 @@ class Categorical(Distribution):
         self._param = self.probs if probs is not None else self.logits
         self._num_events = self._param.size()[-1]
         batch_shape = self._param.size()[:-1] if self._param.ndimension() > 1 else torch.Size()
-        super(Categorical, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Categorical, _instance)

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -36,7 +36,7 @@ class Cauchy(Distribution):
             batch_shape = torch.Size()
         else:
             batch_shape = self.loc.size()
-        super(Cauchy, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Cauchy, _instance)

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -21,11 +21,11 @@ class Chi2(Gamma):
     arg_constraints = {'df': constraints.positive}
 
     def __init__(self, df, validate_args=None):
-        super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
+        super().__init__(0.5 * df, 0.5, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Chi2, _instance)
-        return super(Chi2, self).expand(batch_shape, new)
+        return super().expand(batch_shape, new)
 
     @property
     def df(self):

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -82,7 +82,7 @@ class ConstraintRegistry:
     """
     def __init__(self):
         self._registry = {}
-        super(ConstraintRegistry, self).__init__()
+        super().__init__()
 
     def register(self, constraint, factory=None):
         """

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -62,7 +62,7 @@ class ContinuousBernoulli(ExponentialFamily):
         else:
             batch_shape = self._param.size()
         self._lims = lims
-        super(ContinuousBernoulli, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(ContinuousBernoulli, _instance)

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -51,7 +51,7 @@ class Dirichlet(ExponentialFamily):
             raise ValueError("`concentration` parameter must be at least one-dimensional.")
         self.concentration = concentration
         batch_shape, event_shape = concentration.shape[:-1], concentration.shape[-1:]
-        super(Dirichlet, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Dirichlet, _instance)

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -66,7 +66,7 @@ class Distribution:
                         f"to satisfy the constraint {repr(constraint)}, "
                         f"but found invalid values:\n{value}"
                     )
-        super(Distribution, self).__init__()
+        super().__init__()
 
     def expand(self, batch_shape: torch.Size, _instance=None):
         """

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -45,7 +45,7 @@ class Exponential(ExponentialFamily):
     def __init__(self, rate, validate_args=None):
         self.rate, = broadcast_all(rate)
         batch_shape = torch.Size() if isinstance(rate, Number) else self.rate.size()
-        super(Exponential, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Exponential, _instance)

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -36,7 +36,7 @@ class FisherSnedecor(Distribution):
             batch_shape = torch.Size()
         else:
             batch_shape = self.df1.size()
-        super(FisherSnedecor, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(FisherSnedecor, _instance)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -51,7 +51,7 @@ class Gamma(ExponentialFamily):
             batch_shape = torch.Size()
         else:
             batch_shape = self.concentration.size()
-        super(Gamma, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Gamma, _instance)

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -44,7 +44,7 @@ class Geometric(Distribution):
             batch_shape = torch.Size()
         else:
             batch_shape = probs_or_logits.size()
-        super(Geometric, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
         if self._validate_args and probs is not None:
             # Add an extra check beyond unit_interval
             value = self.probs

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -37,13 +37,13 @@ class Gumbel(TransformedDistribution):
                                 torch.full_like(self.loc, 1 - finfo.eps))
         transforms = [ExpTransform().inv, AffineTransform(loc=0, scale=-torch.ones_like(self.scale)),
                       ExpTransform().inv, AffineTransform(loc=loc, scale=-self.scale)]
-        super(Gumbel, self).__init__(base_dist, transforms, validate_args=validate_args)
+        super().__init__(base_dist, transforms, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Gumbel, _instance)
         new.loc = self.loc.expand(batch_shape)
         new.scale = self.scale.expand(batch_shape)
-        return super(Gumbel, self).expand(batch_shape, _instance=new)
+        return super().expand(batch_shape, _instance=new)
 
     # Explicitly defining the log probability function for Gumbel due to precision issues
     def log_prob(self, value):

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -32,12 +32,11 @@ class HalfCauchy(TransformedDistribution):
 
     def __init__(self, scale, validate_args=None):
         base_dist = Cauchy(0, scale, validate_args=False)
-        super(HalfCauchy, self).__init__(base_dist, AbsTransform(),
-                                         validate_args=validate_args)
+        super().__init__(base_dist, AbsTransform(), validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(HalfCauchy, _instance)
-        return super(HalfCauchy, self).expand(batch_shape, _instance=new)
+        return super().expand(batch_shape, _instance=new)
 
     @property
     def scale(self):

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -32,12 +32,11 @@ class HalfNormal(TransformedDistribution):
 
     def __init__(self, scale, validate_args=None):
         base_dist = Normal(0, scale, validate_args=False)
-        super(HalfNormal, self).__init__(base_dist, AbsTransform(),
-                                         validate_args=validate_args)
+        super().__init__(base_dist, AbsTransform(), validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(HalfNormal, _instance)
-        return super(HalfNormal, self).expand(batch_shape, _instance=new)
+        return super().expand(batch_shape, _instance=new)
 
     @property
     def scale(self):

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -48,7 +48,7 @@ class Independent(Distribution):
         event_shape = shape[len(shape) - event_dim:]
         self.base_dist = base_distribution
         self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
-        super(Independent, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Independent, _instance)

--- a/torch/distributions/kumaraswamy.py
+++ b/torch/distributions/kumaraswamy.py
@@ -47,13 +47,13 @@ class Kumaraswamy(TransformedDistribution):
         transforms = [PowerTransform(exponent=self.concentration0.reciprocal()),
                       AffineTransform(loc=1., scale=-1.),
                       PowerTransform(exponent=self.concentration1.reciprocal())]
-        super(Kumaraswamy, self).__init__(base_dist, transforms, validate_args=validate_args)
+        super().__init__(base_dist, transforms, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Kumaraswamy, _instance)
         new.concentration1 = self.concentration1.expand(batch_shape)
         new.concentration0 = self.concentration0.expand(batch_shape)
-        return super(Kumaraswamy, self).expand(batch_shape, _instance=new)
+        return super().expand(batch_shape, _instance=new)
 
     @property
     def mean(self):

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -47,7 +47,7 @@ class Laplace(Distribution):
             batch_shape = torch.Size()
         else:
             batch_shape = self.loc.size()
-        super(Laplace, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Laplace, _instance)

--- a/torch/distributions/lkj_cholesky.py
+++ b/torch/distributions/lkj_cholesky.py
@@ -71,7 +71,7 @@ class LKJCholesky(Distribution):
         beta_conc1 = offset + 0.5
         beta_conc0 = marginal_conc.unsqueeze(-1) - 0.5 * offset
         self._beta = Beta(beta_conc1, beta_conc0)
-        super(LKJCholesky, self).__init__(batch_shape, event_shape, validate_args)
+        super().__init__(batch_shape, event_shape, validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LKJCholesky, _instance)

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -30,11 +30,11 @@ class LogNormal(TransformedDistribution):
 
     def __init__(self, loc, scale, validate_args=None):
         base_dist = Normal(loc, scale, validate_args=validate_args)
-        super(LogNormal, self).__init__(base_dist, ExpTransform(), validate_args=validate_args)
+        super().__init__(base_dist, ExpTransform(), validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LogNormal, _instance)
-        return super(LogNormal, self).expand(batch_shape, _instance=new)
+        return super().expand(batch_shape, _instance=new)
 
     @property
     def loc(self):

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -36,13 +36,11 @@ class LogisticNormal(TransformedDistribution):
         base_dist = Normal(loc, scale, validate_args=validate_args)
         if not base_dist.batch_shape:
             base_dist = base_dist.expand([1])
-        super(LogisticNormal, self).__init__(base_dist,
-                                             StickBreakingTransform(),
-                                             validate_args=validate_args)
+        super().__init__(base_dist, StickBreakingTransform(), validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LogisticNormal, _instance)
-        return super(LogisticNormal, self).expand(batch_shape, _instance=new)
+        return super().expand(batch_shape, _instance=new)
 
     @property
     def loc(self):

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -109,8 +109,7 @@ class LowRankMultivariateNormal(Distribution):
         self._unbroadcasted_cov_factor = cov_factor
         self._unbroadcasted_cov_diag = cov_diag
         self._capacitance_tril = _batch_capacitance_tril(cov_factor, cov_diag)
-        super(LowRankMultivariateNormal, self).__init__(batch_shape, event_shape,
-                                                        validate_args=validate_args)
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LowRankMultivariateNormal, _instance)

--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -86,9 +86,7 @@ class MixtureSameFamily(Distribution):
 
         event_shape = self._component_distribution.event_shape
         self._event_ndims = len(event_shape)
-        super(MixtureSameFamily, self).__init__(batch_shape=cdbs,
-                                                event_shape=event_shape,
-                                                validate_args=validate_args)
+        super().__init__(batch_shape=cdbs, event_shape=event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         batch_shape = torch.Size(batch_shape)

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -65,7 +65,7 @@ class Multinomial(Distribution):
         self._binomial = Binomial(total_count=total_count, probs=self.probs)
         batch_shape = self._categorical.batch_shape
         event_shape = self._categorical.param_shape[-1:]
-        super(Multinomial, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Multinomial, _instance)

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -147,7 +147,7 @@ class MultivariateNormal(Distribution):
         self.loc = loc.expand(batch_shape + (-1,))
 
         event_shape = self.loc.shape[-1:]
-        super(MultivariateNormal, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
         if scale_tril is not None:
             self._unbroadcasted_scale_tril = scale_tril

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -37,7 +37,7 @@ class NegativeBinomial(Distribution):
 
         self._param = self.probs if probs is not None else self.logits
         batch_shape = self._param.size()
-        super(NegativeBinomial, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(NegativeBinomial, _instance)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -53,7 +53,7 @@ class Normal(ExponentialFamily):
             batch_shape = torch.Size()
         else:
             batch_shape = self.loc.size()
-        super(Normal, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Normal, _instance)

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -43,7 +43,7 @@ class OneHotCategorical(Distribution):
         self._categorical = Categorical(probs, logits)
         batch_shape = self._categorical.batch_shape
         event_shape = self._categorical.param_shape[-1:]
-        super(OneHotCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(OneHotCategorical, _instance)

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -27,13 +27,13 @@ class Pareto(TransformedDistribution):
         self.scale, self.alpha = broadcast_all(scale, alpha)
         base_dist = Exponential(self.alpha, validate_args=validate_args)
         transforms = [ExpTransform(), AffineTransform(loc=0, scale=self.scale)]
-        super(Pareto, self).__init__(base_dist, transforms, validate_args=validate_args)
+        super().__init__(base_dist, transforms, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Pareto, _instance)
         new.scale = self.scale.expand(batch_shape)
         new.alpha = self.alpha.expand(batch_shape)
-        return super(Pareto, self).expand(batch_shape, _instance=new)
+        return super().expand(batch_shape, _instance=new)
 
     @property
     def mean(self):

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -47,7 +47,7 @@ class Poisson(ExponentialFamily):
             batch_shape = torch.Size()
         else:
             batch_shape = self.rate.size()
-        super(Poisson, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Poisson, _instance)

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -46,7 +46,7 @@ class LogitRelaxedBernoulli(Distribution):
             batch_shape = torch.Size()
         else:
             batch_shape = self._param.size()
-        super(LogitRelaxedBernoulli, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LogitRelaxedBernoulli, _instance)
@@ -118,13 +118,11 @@ class RelaxedBernoulli(TransformedDistribution):
 
     def __init__(self, temperature, probs=None, logits=None, validate_args=None):
         base_dist = LogitRelaxedBernoulli(temperature, probs, logits)
-        super(RelaxedBernoulli, self).__init__(base_dist,
-                                               SigmoidTransform(),
-                                               validate_args=validate_args)
+        super().__init__(base_dist, SigmoidTransform(), validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(RelaxedBernoulli, _instance)
-        return super(RelaxedBernoulli, self).expand(batch_shape, _instance=new)
+        return super().expand(batch_shape, _instance=new)
 
     @property
     def temperature(self):

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -40,7 +40,7 @@ class ExpRelaxedCategorical(Distribution):
         self.temperature = temperature
         batch_shape = self._categorical.batch_shape
         event_shape = self._categorical.param_shape[-1:]
-        super(ExpRelaxedCategorical, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(ExpRelaxedCategorical, _instance)
@@ -112,13 +112,11 @@ class RelaxedOneHotCategorical(TransformedDistribution):
 
     def __init__(self, temperature, probs=None, logits=None, validate_args=None):
         base_dist = ExpRelaxedCategorical(temperature, probs, logits, validate_args=validate_args)
-        super(RelaxedOneHotCategorical, self).__init__(base_dist,
-                                                       ExpTransform(),
-                                                       validate_args=validate_args)
+        super().__init__(base_dist, ExpTransform(), validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(RelaxedOneHotCategorical, _instance)
-        return super(RelaxedOneHotCategorical, self).expand(batch_shape, _instance=new)
+        return super().expand(batch_shape, _instance=new)
 
     @property
     def temperature(self):

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -51,7 +51,7 @@ class StudentT(Distribution):
         self.df, self.loc, self.scale = broadcast_all(df, loc, scale)
         self._chi2 = Chi2(self.df)
         batch_shape = self.df.size()
-        super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(StudentT, _instance)

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -80,7 +80,7 @@ class TransformedDistribution(Distribution):
         cut = len(forward_shape) - event_dim
         batch_shape = forward_shape[:cut]
         event_shape = forward_shape[cut:]
-        super(TransformedDistribution, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(TransformedDistribution, _instance)

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -95,7 +95,7 @@ class Transform:
             self._cached_x_y = None, None
         else:
             raise ValueError('cache_size must be 0 or 1')
-        super(Transform, self).__init__()
+        super().__init__()
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -212,7 +212,7 @@ class _InverseTransform(Transform):
     This class is private; please instead use the ``Transform.inv`` property.
     """
     def __init__(self, transform: Transform):
-        super(_InverseTransform, self).__init__(cache_size=transform._cache_size)
+        super().__init__(cache_size=transform._cache_size)
         self._inv: Transform = transform
 
     @constraints.dependent_property(is_discrete=False)
@@ -280,7 +280,7 @@ class ComposeTransform(Transform):
     def __init__(self, parts: List[Transform], cache_size=0):
         if cache_size:
             parts = [part.with_cache(cache_size) for part in parts]
-        super(ComposeTransform, self).__init__(cache_size=cache_size)
+        super().__init__(cache_size=cache_size)
         self.parts = parts
 
     def __eq__(self, other):
@@ -550,7 +550,7 @@ class PowerTransform(Transform):
     sign = +1
 
     def __init__(self, exponent, cache_size=0):
-        super(PowerTransform, self).__init__(cache_size=cache_size)
+        super().__init__(cache_size=cache_size)
         self.exponent, = broadcast_all(exponent)
 
     def with_cache(self, cache_size=1):
@@ -698,7 +698,7 @@ class AffineTransform(Transform):
     bijective = True
 
     def __init__(self, loc, scale, event_dim=0, cache_size=0):
-        super(AffineTransform, self).__init__(cache_size=cache_size)
+        super().__init__(cache_size=cache_size)
         self.loc = loc
         self.scale = scale
         self._event_dim = event_dim
@@ -1012,7 +1012,7 @@ class CatTransform(Transform):
         assert all(isinstance(t, Transform) for t in tseq)
         if cache_size:
             tseq = [t.with_cache(cache_size) for t in tseq]
-        super(CatTransform, self).__init__(cache_size=cache_size)
+        super().__init__(cache_size=cache_size)
         self.transforms = list(tseq)
         if lengths is None:
             lengths = [1] * len(self.transforms)
@@ -1113,7 +1113,7 @@ class StackTransform(Transform):
         assert all(isinstance(t, Transform) for t in tseq)
         if cache_size:
             tseq = [t.with_cache(cache_size) for t in tseq]
-        super(StackTransform, self).__init__(cache_size=cache_size)
+        super().__init__(cache_size=cache_size)
         self.transforms = list(tseq)
         self.dim = dim
 
@@ -1189,7 +1189,7 @@ class CumulativeDistributionTransform(Transform):
     sign = +1
 
     def __init__(self, distribution, cache_size=0):
-        super(CumulativeDistributionTransform, self).__init__(cache_size=cache_size)
+        super().__init__(cache_size=cache_size)
         self.distribution = distribution
 
     @property

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -52,7 +52,7 @@ class Uniform(Distribution):
             batch_shape = torch.Size()
         else:
             batch_shape = self.low.size()
-        super(Uniform, self).__init__(batch_shape, validate_args=validate_args)
+        super().__init__(batch_shape, validate_args=validate_args)
 
         if self._validate_args and not torch.lt(self.low, self.high).all():
             raise ValueError("Uniform is not defined when low>= high")

--- a/torch/distributions/von_mises.py
+++ b/torch/distributions/von_mises.py
@@ -98,7 +98,7 @@ class VonMises(Distribution):
         rho = (tau - (2 * tau).sqrt()) / (2 * self.concentration)
         self._proposal_r = (1 + rho ** 2) / (2 * rho)
 
-        super(VonMises, self).__init__(batch_shape, event_shape, validate_args)
+        super().__init__(batch_shape, event_shape, validate_args)
 
     def log_prob(self, value):
         if self._validate_args:
@@ -120,7 +120,7 @@ class VonMises(Distribution):
 
     def expand(self, batch_shape):
         try:
-            return super(VonMises, self).expand(batch_shape)
+            return super().expand(batch_shape)
         except NotImplementedError:
             validate_args = self.__dict__.get('_validate_args')
             loc = self.loc.expand(batch_shape)

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -32,9 +32,7 @@ class Weibull(TransformedDistribution):
         base_dist = Exponential(torch.ones_like(self.scale), validate_args=validate_args)
         transforms = [PowerTransform(exponent=self.concentration_reciprocal),
                       AffineTransform(loc=0, scale=self.scale)]
-        super(Weibull, self).__init__(base_dist,
-                                      transforms,
-                                      validate_args=validate_args)
+        super().__init__(base_dist, transforms, validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Weibull, _instance)

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -106,7 +106,7 @@ class Wishart(ExponentialFamily):
         if self.df.lt(event_shape[-1]).any():
             warnings.warn("Low df values detected. Singular samples are highly likely to occur for ndim - 1 < df < ndim.")
 
-        super(Wishart, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
         self._batch_dims = [-(x + 1) for x in range(len(self._batch_shape))]
 
         if scale_tril is not None:

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -899,7 +899,7 @@ class _PatchedFnSetAttr(_PatchedFn):
 
 class _Patcher:
     def __init__(self):
-        super(_Patcher, self).__init__()
+        super().__init__()
         self.patches_made: List[_PatchedFn] = []
         self.visited: Set[int] = set()
 

--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -80,7 +80,7 @@ class ShapeProp(torch.fx.Interpreter):
 
         class TwoLayerNet(torch.nn.Module):
             def __init__(self, D_in, H, D_out):
-                super(TwoLayerNet, self).__init__()
+                super().__init__()
                 self.linear1 = torch.nn.Linear(D_in, H)
                 self.linear2 = torch.nn.Linear(H, D_out)
             def forward(self, x):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -178,7 +178,7 @@ def isinstance(obj, target_type):
 
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
 
             def forward(self, input: Any): # note the Any type
                 if torch.jit.isinstance(input, List[torch.Tensor]):

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -40,7 +40,7 @@ def freeze(mod, preserved_attrs: Optional[List[str]] = None, optimize_numerics: 
         import torch
         class MyModule(torch.nn.Module):
             def __init__(self, N, M):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.weight = torch.nn.Parameter(torch.rand(N, M))
                 self.linear = torch.nn.Linear(N, M)
 
@@ -62,7 +62,7 @@ def freeze(mod, preserved_attrs: Optional[List[str]] = None, optimize_numerics: 
         import torch
         class MyModule2(torch.nn.Module):
             def __init__(self):
-                super(MyModule2, self).__init__()
+                super().__init__()
                 self.modified_tensor = torch.tensor(10.)
                 self.version = 1
 

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -122,7 +122,7 @@ def _get_valid_constant(attr, v, owner_type):
 
 class SourceContext(torch._C._jit_tree_views.SourceRangeFactory):
     def __init__(self, source, filename, file_lineno, leading_whitespace_len):
-        super(SourceContext, self).__init__(source, filename, file_lineno, leading_whitespace_len)
+        super().__init__(source, filename, file_lineno, leading_whitespace_len)
 
 
 def infer_concrete_type_builder(nn_module, share_types=True):

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -97,7 +97,7 @@ Attribute.__doc__ = """
 
         class AttributeModule(torch.jit.ScriptModule):
             def __init__(self):
-                super(AttributeModule, self).__init__()
+                super().__init__()
                 self.foo = torch.jit.Attribute(0.1, float)
 
                 # we should be able to use self.foo as a float here
@@ -128,7 +128,7 @@ Attribute.__doc__ = """
             names: Dict[str, int]
 
             def __init__(self):
-                super(AttributeModule, self).__init__()
+                super().__init__()
                 self.names = {}
 
         m = AttributeModule()
@@ -215,7 +215,7 @@ class OrderedDictWrapper:
 
 class OrderedModuleDict(OrderedDictWrapper):
     def __init__(self, module, python_dict):
-        super(OrderedModuleDict, self).__init__(torch._C.ModuleDict(module))
+        super().__init__(torch._C.ModuleDict(module))
         # contains _both_ script modules and non-script python-only modules
 
         # because script modules are subclassed in python and the
@@ -424,7 +424,7 @@ if _enabled:
                 exposed on this wrppaer.
         """
         def __init__(self, cpp_class):
-            super(RecursiveScriptClass, self).__init__()
+            super().__init__()
             self.__dict__["_initializing"] = True
             self._c = cpp_class
 
@@ -435,7 +435,7 @@ if _enabled:
 
         def __getattr__(self, attr):
             if "_initializing" in self.__dict__ and self.__dict__["_initializing"]:
-                return super(RecursiveScriptClass, self).__getattr__(attr)  # type: ignore[misc]
+                return super().__getattr__(attr)  # type: ignore[misc]
 
             if attr in self._props:
                 return self._props[attr].fget()  # type: ignore[call-arg, misc]
@@ -444,7 +444,7 @@ if _enabled:
 
         def __setattr__(self, attr, value):
             if "_initializing" in self.__dict__ and self.__dict__["_initializing"]:
-                return super(RecursiveScriptClass, self).__setattr__(attr, value)
+                return super().__setattr__(attr, value)
 
             if attr in self._props:
                 return self._props[attr].fset(value)  # type: ignore[call-arg, misc]
@@ -493,13 +493,13 @@ if _enabled:
         __jit_unused_properties__ = ['code', 'code_with_constants', 'graph', 'inlined_graph', 'original_name']
 
         def __init__(self):
-            super(ScriptModule, self).__init__()
+            super().__init__()
 
         forward = _CachedForward()
 
         def __getattr__(self, attr):
             if "_actual_script_module" not in self.__dict__:
-                return super(ScriptModule, self).__getattr__(attr)
+                return super().__getattr__(attr)
             return getattr(self._actual_script_module, attr)
 
         def __setattr__(self, attr, value):
@@ -518,7 +518,7 @@ if _enabled:
                         self.__class__.__annotations__ = {}
                     self.__annotations__[attr] = value.type
                     value = value.value
-                return super(ScriptModule, self).__setattr__(attr, value)
+                return super().__setattr__(attr, value)
 
             setattr(self._actual_script_module, attr, value)
 
@@ -591,7 +591,7 @@ if _enabled:
         def __init__(self, cpp_module):
             self.__dict__["_initializing"] = True
             self._c = cpp_module
-            super(RecursiveScriptModule, self).__init__()
+            super().__init__()
             # Delete the 'training' attribute set up by `Module.__init__`. It
             # will get set on the underlying cpp module, so we delete it here
             # to avoid this version shadowing the cpp module version.
@@ -767,7 +767,7 @@ if _enabled:
                 )
 
             if self._initializing:
-                return super(RecursiveScriptModule, self).__getattr__(attr)
+                return super().__getattr__(attr)
 
             # _modules check is before hasattr since modules are included as attributes in _c,
             # but we want to get the python wrapper from _modules instead of the raw _c object.
@@ -782,11 +782,11 @@ if _enabled:
                 self.__dict__[attr] = script_method
                 return script_method
 
-            return super(RecursiveScriptModule, self).__getattr__(attr)
+            return super().__getattr__(attr)
 
         def __setattr__(self, attr, value):
             if self._initializing:
-                return super(RecursiveScriptModule, self).__setattr__(attr, value)
+                return super().__setattr__(attr, value)
 
             if attr in self._modules:
                 self._modules[attr] = value
@@ -811,7 +811,7 @@ if _enabled:
                 #   s.python_attr = ...
                 #   s.save()   <--- this doesn't have `python_attr`
                 # It's fairly trivial to save enough info to warn in this case.
-                return super(RecursiveScriptModule, self).__setattr__(attr, value)
+                return super().__setattr__(attr, value)
 
         def __copy__(self):
             return torch.jit._recursive.wrap_cpp_module(copy.copy(self._c))
@@ -850,7 +850,7 @@ if _enabled:
             if self_method.__func__ == _get_function_from_type(  # type: ignore[attr-defined]
                 RecursiveScriptModule, "__dir__"
             ):
-                return super(RecursiveScriptModule, self).__dir__()
+                return super().__dir__()
             return self_method()
 
         # to resolve bool(value), Python looks if __bool__ is defined then __iter__
@@ -877,7 +877,7 @@ if _enabled:
 
     # Need to copy all RecursiveScriptModule methods to ScriptModule.
     #
-    # This is because `super(MyScriptModule, self).foo()` does not use
+    # This is because `super().foo()` does not use
     # `__getattr__` to look up `foo`. So we need to make each method available on
     # the ScriptModule manually.
     for name, item in RecursiveScriptModule.__dict__.items():
@@ -1141,7 +1141,7 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None,
 
             class MyModule(torch.nn.Module):
                 def __init__(self, N, M):
-                    super(MyModule, self).__init__()
+                    super().__init__()
                     # This parameter will be copied to the new ScriptModule
                     self.weight = torch.nn.Parameter(torch.rand(N, M))
 
@@ -1168,7 +1168,7 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None,
 
             class MyModule(nn.Module):
                 def __init__(self):
-                    super(MyModule, self).__init__()
+                    super().__init__()
                     # torch.jit.trace produces a ScriptModule's conv1 and conv2
                     self.conv1 = torch.jit.trace(nn.Conv2d(1, 20, 5), torch.rand(1, 1, 16, 16))
                     self.conv2 = torch.jit.trace(nn.Conv2d(20, 20, 5), torch.rand(1, 20, 16, 16))
@@ -1191,7 +1191,7 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None,
 
             class MyModule(nn.Module):
                 def __init__(self):
-                    super(MyModule, self).__init__()
+                    super().__init__()
 
                 @torch.jit.export
                 def some_entry_point(self, input):

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -81,7 +81,7 @@ class ONNXTracedModule(torch.nn.Module):
         return_inputs=False,
         return_inputs_states=False,
     ):
-        super(ONNXTracedModule, self).__init__()
+        super().__init__()
         # inner may be a Module, or it may be an arbitrary callable
         # If it's a Module, we get its parameters automatically, which lets
         # us avoid a special casing functions versus modules.
@@ -302,7 +302,7 @@ class TracingCheckError(Exception):
                 " encountered untraceable code.\n"
             )
             self.message += indent(tensor_compare_error) + "\n"
-        super(TracingCheckError, self).__init__(self.message)
+        super().__init__(self.message)
 
 
 # Check the traced module against a set of user-provided validation inputs
@@ -748,7 +748,7 @@ def trace(
 
         class Net(nn.Module):
             def __init__(self):
-                super(Net, self).__init__()
+                super().__init__()
                 self.conv = nn.Conv2d(1, 1, 3)
 
             def forward(self, x):
@@ -957,7 +957,7 @@ def trace_module(
 
         class Net(nn.Module):
             def __init__(self):
-                super(Net, self).__init__()
+                super().__init__()
                 self.conv = nn.Conv2d(1, 1, 3)
 
             def forward(self, x):
@@ -1105,7 +1105,7 @@ class TracedModule(ScriptModule):
 
     def __init__(self, orig, id_set=None, _compilation_unit=None):
         # XXX: orig can be a nn.Module or a function!
-        super(TracedModule, self).__init__()
+        super().__init__()
         assert isinstance(orig, torch.nn.Module)
 
         # Copy a subset of `orig` to a temporary nn.Module.
@@ -1176,12 +1176,12 @@ class TracedModule(ScriptModule):
 
     def __getattr__(self, attr):
         if "_actual_script_module" not in self.__dict__:
-            return super(TracedModule, self).__getattr__(attr)
+            return super().__getattr__(attr)
         return getattr(self._actual_script_module, attr)
 
     def __setattr__(self, attr, value):
         if "_actual_script_module" not in self.__dict__:
-            return super(TracedModule, self).__setattr__(attr, value)
+            return super().__setattr__(attr, value)
         setattr(self._actual_script_module, attr, value)
 
     def _get_name(self):

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -126,7 +126,7 @@ class UnsupportedNodeError(NotSupportedError):
                                       offending_node.col_offset + range_len)
         feature_name = pretty_node_names.get(node_type, node_type.__name__)
         msg = "{} {}aren't supported".format(feature_name, reason + ' ' if reason else '')
-        super(UnsupportedNodeError, self).__init__(source_range, msg)
+        super().__init__(source_range, msg)
 
 
 class FrontendTypeError(FrontendError):

--- a/torch/jit/mobile/__init__.py
+++ b/torch/jit/mobile/__init__.py
@@ -54,7 +54,7 @@ def _load_for_lite_interpreter(f, map_location=None):
 class LiteScriptModule:
     def __init__(self, cpp_module):
         self._c = cpp_module
-        super(LiteScriptModule, self).__init__()
+        super().__init__()
 
     def __call__(self, *input):
         return self._c.forward(input)

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -11,7 +11,7 @@ class QuantizedLinear(torch.jit.ScriptModule):
     __constants__ = ['scale', 'zero_point']
 
     def __init__(self, other):
-        super(QuantizedLinear, self).__init__()
+        super().__init__()
         warnings.warn(
             "torch.jit.QuantizedLinear is deprecated and will be removed in an upcoming "
             "PyTorch release. Please use the torch.ao.nn.quantized.dynamic.Linear instead.")
@@ -56,7 +56,7 @@ class QuantizedLinear(torch.jit.ScriptModule):
 class QuantizedLinearFP16(torch.jit.ScriptModule):
 
     def __init__(self, other):
-        super(QuantizedLinearFP16, self).__init__()
+        super().__init__()
         warnings.warn(
             "torch.jit.QuantizedLinearFP16 is deprecated and will be removed in an upcoming "
             "PyTorch release. Please use the torch.ao.nn.quantized.dynamic.Linear instead.")
@@ -96,7 +96,7 @@ class QuantizedRNNCellBase(torch.jit.ScriptModule):
                      'zero_point_ih', 'zero_point_hh']
 
     def __init__(self, other):
-        super(QuantizedRNNCellBase, self).__init__()
+        super().__init__()
         warnings.warn(
             "torch.jit.QuantizedRNNCellBase is deprecated and will be removed in an upcoming "
             "PyTorch release. Please use the torch.ao.nn.quantized.dynamic.RNNCell instead.")
@@ -174,7 +174,7 @@ class QuantizedRNNCell(QuantizedRNNCellBase):
                      'zero_point_ih', 'zero_point_hh', 'nonlinearity']
 
     def __init__(self, other):
-        super(QuantizedRNNCell, self).__init__(other)
+        super().__init__(other)
         warnings.warn(
             "torch.jit.QuantizedRNNCell is deprecated and will be removed in an upcoming "
             "PyTorch release. Please use the torch.ao.nn.quantized.dynamic.RNNCell instead.")
@@ -209,7 +209,7 @@ class QuantizedRNNCell(QuantizedRNNCellBase):
 
 class QuantizedLSTMCell(QuantizedRNNCellBase):
     def __init__(self, other):
-        super(QuantizedLSTMCell, self).__init__(other)
+        super().__init__(other)
         warnings.warn(
             "torch.jit.QuantizedLSTMCell is deprecated and will be removed in an upcoming "
             "PyTorch release. Please use the torch.ao.nn.quantized.dynamic.LSTMCell instead.")
@@ -232,7 +232,7 @@ class QuantizedLSTMCell(QuantizedRNNCellBase):
 
 class QuantizedGRUCell(QuantizedRNNCellBase):
     def __init__(self, other):
-        super(QuantizedGRUCell, self).__init__(other)
+        super().__init__(other)
         warnings.warn(
             "torch.jit.QuantizedGRUCell is deprecated and will be removed in an upcoming "
             "PyTorch release. Please use the torch.ao.nn.quantized.dynamic.GRUCell instead.")
@@ -260,7 +260,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
                      'batch_first', 'dropout', 'bidirectional', 'dtype']
 
     def __init__(self, other, dtype=torch.int8):
-        super(QuantizedRNNBase, self).__init__()
+        super().__init__()
         warnings.warn(
             "torch.jit.QuantizedRNNBase is deprecated and will be removed in an upcoming "
             "PyTorch release. Please use the torch.ao.nn.quantized.dynamic instead.")
@@ -365,7 +365,7 @@ class QuantizedLSTM(QuantizedRNNBase):
     __overloads__ = {'forward': ['forward_packed', 'forward_tensor']}
 
     def __init__(self, other, dtype):
-        super(QuantizedLSTM, self).__init__(other, dtype)
+        super().__init__(other, dtype)
         warnings.warn(
             "torch.jit.QuantizedLSTM is deprecated and will be removed in an upcoming "
             "PyTorch release. Please use the torch.ao.nn.quantized.dynamic.LSTM instead.")

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -30,7 +30,7 @@ class ConnectionWrapper:
 class Queue(multiprocessing.queues.Queue):
 
     def __init__(self, *args, **kwargs):
-        super(Queue, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._reader: ConnectionWrapper = ConnectionWrapper(self._reader)
         self._writer: ConnectionWrapper = ConnectionWrapper(self._writer)
         self._send = self._writer.send
@@ -43,4 +43,4 @@ class SimpleQueue(multiprocessing.queues.SimpleQueue):
         if not isinstance(self._reader, ConnectionWrapper):
             self._reader: ConnectionWrapper = ConnectionWrapper(self._reader)
             self._writer: ConnectionWrapper = ConnectionWrapper(self._writer)
-        super(SimpleQueue, self)._make_methods()  # type: ignore[misc]
+        super()._make_methods()  # type: ignore[misc]

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -163,8 +163,7 @@ class ProcessContext:
 class SpawnContext(ProcessContext):
     def __init__(self, processes, error_queues):
         warnings.warn('SpawnContext is renamed to ProcessContext since 1.4 release.')
-        super(SpawnContext, self).__init__(processes, error_queues)
-    pass
+        super().__init__(processes, error_queues)
 
 
 # Note: [start_processes]

--- a/torch/nn/cpp.py
+++ b/torch/nn/cpp.py
@@ -56,7 +56,7 @@ class ModuleWrapper(nn.Module):
         # Assign before the super class constructor so ``self.training`` can be
         # assigned to in the super class constructor.
         self.cpp_module = cpp_module
-        super(ModuleWrapper, self).__init__()
+        super().__init__()
         self._parameters = OrderedDictWrapper(cpp_module, "_parameters")  # type: ignore[assignment]
         self._buffers: OrderedDictWrapper = OrderedDictWrapper(cpp_module, "_buffers")  # type: ignore[assignment]
         self._modules: OrderedDictWrapper = OrderedDictWrapper(cpp_module, "_modules")  # type: ignore[assignment]

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -49,7 +49,7 @@ class Threshold(Module):
     inplace: bool
 
     def __init__(self, threshold: float, value: float, inplace: bool = False) -> None:
-        super(Threshold, self).__init__()
+        super().__init__()
         self.threshold = threshold
         self.value = value
         self.inplace = inplace
@@ -96,7 +96,7 @@ class ReLU(Module):
     inplace: bool
 
     def __init__(self, inplace: bool = False):
-        super(ReLU, self).__init__()
+        super().__init__()
         self.inplace = inplace
 
     def forward(self, input: Tensor) -> Tensor:
@@ -159,7 +159,7 @@ class RReLU(Module):
         upper: float = 1. / 3,
         inplace: bool = False
     ):
-        super(RReLU, self).__init__()
+        super().__init__()
         self.lower = lower
         self.upper = upper
         self.inplace = inplace
@@ -218,7 +218,7 @@ class Hardtanh(Module):
         min_value: Optional[float] = None,
         max_value: Optional[float] = None
     ) -> None:
-        super(Hardtanh, self).__init__()
+        super().__init__()
         if min_value is not None:
             warnings.warn("keyword argument min_value is deprecated and rename to min_val")
             min_val = min_value
@@ -264,7 +264,7 @@ class ReLU6(Hardtanh):
     """
 
     def __init__(self, inplace: bool = False):
-        super(ReLU6, self).__init__(0., 6., inplace)
+        super().__init__(0., 6., inplace)
 
     def extra_repr(self) -> str:
         inplace_str = 'inplace=True' if self.inplace else ''
@@ -327,7 +327,7 @@ class Hardsigmoid(Module):
     inplace: bool
 
     def __init__(self, inplace : bool = False) -> None:
-        super(Hardsigmoid, self).__init__()
+        super().__init__()
         self.inplace = inplace
 
     def forward(self, input: Tensor) -> Tensor:
@@ -389,7 +389,7 @@ class SiLU(Module):
     inplace: bool
 
     def __init__(self, inplace: bool = False):
-        super(SiLU, self).__init__()
+        super().__init__()
         self.inplace = inplace
 
     def forward(self, input: Tensor) -> Tensor:
@@ -425,7 +425,7 @@ class Mish(Module):
     inplace: bool
 
     def __init__(self, inplace: bool = False):
-        super(Mish, self).__init__()
+        super().__init__()
         self.inplace = inplace
 
     def forward(self, input: Tensor) -> Tensor:
@@ -468,7 +468,7 @@ class Hardswish(Module):
     inplace: bool
 
     def __init__(self, inplace : bool = False) -> None:
-        super(Hardswish, self).__init__()
+        super().__init__()
         self.inplace = inplace
 
     def forward(self, input: Tensor) -> Tensor:
@@ -509,7 +509,7 @@ class ELU(Module):
     inplace: bool
 
     def __init__(self, alpha: float = 1., inplace: bool = False) -> None:
-        super(ELU, self).__init__()
+        super().__init__()
         self.alpha = alpha
         self.inplace = inplace
 
@@ -553,7 +553,7 @@ class CELU(Module):
     inplace: bool
 
     def __init__(self, alpha: float = 1., inplace: bool = False) -> None:
-        super(CELU, self).__init__()
+        super().__init__()
         self.alpha = alpha
         self.inplace = inplace
 
@@ -603,7 +603,7 @@ class SELU(Module):
     inplace: bool
 
     def __init__(self, inplace: bool = False) -> None:
-        super(SELU, self).__init__()
+        super().__init__()
         self.inplace = inplace
 
     def forward(self, input: Tensor) -> Tensor:
@@ -637,7 +637,7 @@ class GLU(Module):
     dim: int
 
     def __init__(self, dim: int = -1) -> None:
-        super(GLU, self).__init__()
+        super().__init__()
         self.dim = dim
 
     def forward(self, input: Tensor) -> Tensor:
@@ -678,7 +678,7 @@ class GELU(Module):
     approximate: str
 
     def __init__(self, approximate: str = 'none') -> None:
-        super(GELU, self).__init__()
+        super().__init__()
         self.approximate = approximate
 
     def forward(self, input: Tensor) -> Tensor:
@@ -720,7 +720,7 @@ class Hardshrink(Module):
     lambd: float
 
     def __init__(self, lambd: float = 0.5) -> None:
-        super(Hardshrink, self).__init__()
+        super().__init__()
         self.lambd = lambd
 
     def forward(self, input: Tensor) -> Tensor:
@@ -768,7 +768,7 @@ class LeakyReLU(Module):
     negative_slope: float
 
     def __init__(self, negative_slope: float = 1e-2, inplace: bool = False) -> None:
-        super(LeakyReLU, self).__init__()
+        super().__init__()
         self.negative_slope = negative_slope
         self.inplace = inplace
 
@@ -834,7 +834,7 @@ class Softplus(Module):
     threshold: int
 
     def __init__(self, beta: int = 1, threshold: int = 20) -> None:
-        super(Softplus, self).__init__()
+        super().__init__()
         self.beta = beta
         self.threshold = threshold
 
@@ -875,7 +875,7 @@ class Softshrink(Module):
     lambd: float
 
     def __init__(self, lambd: float = 0.5) -> None:
-        super(Softshrink, self).__init__()
+        super().__init__()
         self.lambd = lambd
 
     def forward(self, input: Tensor) -> Tensor:
@@ -952,7 +952,7 @@ class MultiheadAttention(Module):
     def __init__(self, embed_dim, num_heads, dropout=0., bias=True, add_bias_kv=False, add_zero_attn=False,
                  kdim=None, vdim=None, batch_first=False, device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(MultiheadAttention, self).__init__()
+        super().__init__()
         self.embed_dim = embed_dim
         self.kdim = kdim if kdim is not None else embed_dim
         self.vdim = vdim if vdim is not None else embed_dim
@@ -1012,7 +1012,7 @@ class MultiheadAttention(Module):
         if '_qkv_same_embed_dim' not in state:
             state['_qkv_same_embed_dim'] = True
 
-        super(MultiheadAttention, self).__setstate__(state)
+        super().__setstate__(state)
 
     def forward(
             self,
@@ -1301,7 +1301,7 @@ class PReLU(Module):
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
         self.num_parameters = num_parameters
-        super(PReLU, self).__init__()
+        super().__init__()
         self.weight = Parameter(torch.empty(num_parameters, **factory_kwargs).fill_(init))
 
     def forward(self, input: Tensor) -> Tensor:
@@ -1390,7 +1390,7 @@ class Softmin(Module):
     dim: Optional[int]
 
     def __init__(self, dim: Optional[int] = None) -> None:
-        super(Softmin, self).__init__()
+        super().__init__()
         self.dim = dim
 
     def __setstate__(self, state):
@@ -1446,7 +1446,7 @@ class Softmax(Module):
     dim: Optional[int]
 
     def __init__(self, dim: Optional[int] = None) -> None:
-        super(Softmax, self).__init__()
+        super().__init__()
         self.dim = dim
 
     def __setstate__(self, state):
@@ -1517,7 +1517,7 @@ class LogSoftmax(Module):
     dim: Optional[int]
 
     def __init__(self, dim: Optional[int] = None) -> None:
-        super(LogSoftmax, self).__init__()
+        super().__init__()
         self.dim = dim
 
     def __setstate__(self, state):

--- a/torch/nn/modules/adaptive.py
+++ b/torch/nn/modules/adaptive.py
@@ -121,7 +121,7 @@ class AdaptiveLogSoftmaxWithLoss(Module):
         dtype=None
     ) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(AdaptiveLogSoftmaxWithLoss, self).__init__()
+        super().__init__()
 
         cutoffs = list(cutoffs)
 

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -38,7 +38,7 @@ class _NormBase(Module):
         dtype=None
     ) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(_NormBase, self).__init__()
+        super().__init__()
         self.num_features = num_features
         self.eps = eps
         self.momentum = momentum
@@ -107,7 +107,7 @@ class _NormBase(Module):
             if num_batches_tracked_key not in state_dict:
                 state_dict[num_batches_tracked_key] = torch.tensor(0, dtype=torch.long)
 
-        super(_NormBase, self)._load_from_state_dict(
+        super()._load_from_state_dict(
             state_dict,
             prefix,
             local_metadata,
@@ -130,7 +130,7 @@ class _BatchNorm(_NormBase):
         dtype=None
     ) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(_BatchNorm, self).__init__(
+        super().__init__(
             num_features, eps, momentum, affine, track_running_stats, **factory_kwargs
         )
 
@@ -191,7 +191,7 @@ class _LazyNormBase(LazyModuleMixin, _NormBase):
     def __init__(self, eps=1e-5, momentum=0.1, affine=True, track_running_stats=True,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(_LazyNormBase, self).__init__(
+        super().__init__(
             # affine and track_running_stats are hardcoded to False to
             # avoid creating tensors that will soon be overwritten.
             0,
@@ -663,7 +663,7 @@ class SyncBatchNorm(_BatchNorm):
         dtype=None
     ) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(SyncBatchNorm, self).__init__(
+        super().__init__(
             num_features, eps, momentum, affine, track_running_stats, **factory_kwargs
         )
         self.process_group = process_group

--- a/torch/nn/modules/channelshuffle.py
+++ b/torch/nn/modules/channelshuffle.py
@@ -44,7 +44,7 @@ class ChannelShuffle(Module):
     groups: int
 
     def __init__(self, groups: int) -> None:
-        super(ChannelShuffle, self).__init__()
+        super().__init__()
         self.groups = groups
 
     def forward(self, input: Tensor) -> Tensor:

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -31,7 +31,7 @@ def _addindent(s_, numSpaces):
 class Container(Module):
 
     def __init__(self, **kwargs: Any) -> None:
-        super(Container, self).__init__()
+        super().__init__()
         # DeprecationWarning is ignored by default <sigh>
         warnings.warn("nn.Container is deprecated. All of it's functionality "
                       "is now implemented in nn.Module. Subclass that instead.")
@@ -95,7 +95,7 @@ class Sequential(Module):
         ...
 
     def __init__(self, *args):
-        super(Sequential, self).__init__()
+        super().__init__()
         if len(args) == 1 and isinstance(args[0], OrderedDict):
             for key, module in args[0].items():
                 self.add_module(key, module)
@@ -200,7 +200,7 @@ class Sequential(Module):
 
     @_copy_to_script_wrapper
     def __dir__(self):
-        keys = super(Sequential, self).__dir__()
+        keys = super().__dir__()
         keys = [key for key in keys if not key.isdigit()]
         return keys
 
@@ -261,7 +261,7 @@ class ModuleList(Module):
 
         class MyModule(nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.linears = nn.ModuleList([nn.Linear(10, 10) for i in range(10)])
 
             def forward(self, x):
@@ -274,7 +274,7 @@ class ModuleList(Module):
     _modules: Dict[str, Module]  # type: ignore[assignment]
 
     def __init__(self, modules: Optional[Iterable[Module]] = None) -> None:
-        super(ModuleList, self).__init__()
+        super().__init__()
         if modules is not None:
             self += modules
 
@@ -359,7 +359,7 @@ class ModuleList(Module):
 
     @_copy_to_script_wrapper
     def __dir__(self):
-        keys = super(ModuleList, self).__dir__()
+        keys = super().__dir__()
         keys = [key for key in keys if not key.isdigit()]
         return keys
 
@@ -433,7 +433,7 @@ class ModuleDict(Module):
 
         class MyModule(nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.choices = nn.ModuleDict({
                         'conv': nn.Conv2d(10, 10, 3),
                         'pool': nn.MaxPool2d(3)
@@ -452,7 +452,7 @@ class ModuleDict(Module):
     _modules: Dict[str, Module]  # type: ignore[assignment]
 
     def __init__(self, modules: Optional[Mapping[str, Module]] = None) -> None:
-        super(ModuleDict, self).__init__()
+        super().__init__()
         if modules is not None:
             self.update(modules)
 
@@ -567,7 +567,7 @@ class ParameterList(Module):
 
         class MyModule(nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.params = nn.ParameterList([nn.Parameter(torch.randn(10, 10)) for i in range(10)])
 
             def forward(self, x):
@@ -578,7 +578,7 @@ class ParameterList(Module):
     """
 
     def __init__(self, values: Optional[Iterable[Any]] = None) -> None:
-        super(ParameterList, self).__init__()
+        super().__init__()
         self._size = 0
         if values is not None:
             self += values
@@ -632,7 +632,7 @@ class ParameterList(Module):
         return self.extend(parameters)
 
     def __dir__(self):
-        keys = super(ParameterList, self).__dir__()
+        keys = super().__dir__()
         keys = [key for key in keys if not key.isdigit()]
         return keys
 
@@ -707,7 +707,7 @@ class ParameterDict(Module):
 
         class MyModule(nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.params = nn.ParameterDict({
                         'left': nn.Parameter(torch.randn(5, 10)),
                         'right': nn.Parameter(torch.randn(5, 10))
@@ -719,7 +719,7 @@ class ParameterDict(Module):
     """
 
     def __init__(self, parameters: Any = None) -> None:
-        super(ParameterDict, self).__init__()
+        super().__init__()
         self._keys: Dict[str, None] = {}
         if parameters is not None:
             self.update(parameters)

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -83,7 +83,7 @@ class _ConvNd(Module):
                  device=None,
                  dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(_ConvNd, self).__init__()
+        super().__init__()
         if groups <= 0:
             raise ValueError('groups must be a positive integer')
         if in_channels % groups != 0:
@@ -172,7 +172,7 @@ class _ConvNd(Module):
         return s.format(**self.__dict__)
 
     def __setstate__(self, state):
-        super(_ConvNd, self).__setstate__(state)
+        super().__setstate__(state)
         if not hasattr(self, 'padding_mode'):
             self.padding_mode = 'zeros'
 
@@ -297,7 +297,7 @@ class Conv1d(_ConvNd):
         stride_ = _single(stride)
         padding_ = padding if isinstance(padding, str) else _single(padding)
         dilation_ = _single(dilation)
-        super(Conv1d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size_, stride_, padding_, dilation_,
             False, _single(0), groups, bias, padding_mode, **factory_kwargs)
 
@@ -447,7 +447,7 @@ class Conv2d(_ConvNd):
         stride_ = _pair(stride)
         padding_ = padding if isinstance(padding, str) else _pair(padding)
         dilation_ = _pair(dilation)
-        super(Conv2d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size_, stride_, padding_, dilation_,
             False, _pair(0), groups, bias, padding_mode, **factory_kwargs)
 
@@ -588,7 +588,7 @@ class Conv3d(_ConvNd):
         stride_ = _triple(stride)
         padding_ = padding if isinstance(padding, str) else _triple(padding)
         dilation_ = _triple(dilation)
-        super(Conv3d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size_, stride_, padding_, dilation_,
             False, _triple(0), groups, bias, padding_mode, **factory_kwargs)
 
@@ -622,7 +622,7 @@ class _ConvTransposeNd(_ConvNd):
             raise ValueError('Only "zeros" padding mode is supported for {}'.format(self.__class__.__name__))
 
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(_ConvTransposeNd, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride,
             padding, dilation, transposed, output_padding,
             groups, bias, padding_mode, **factory_kwargs)
@@ -783,7 +783,7 @@ class ConvTranspose1d(_ConvTransposeNd):
         padding = _single(padding)
         dilation = _single(dilation)
         output_padding = _single(output_padding)
-        super(ConvTranspose1d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             True, output_padding, groups, bias, padding_mode, **factory_kwargs)
 
@@ -937,7 +937,7 @@ class ConvTranspose2d(_ConvTransposeNd):
         padding = _pair(padding)
         dilation = _pair(dilation)
         output_padding = _pair(output_padding)
-        super(ConvTranspose2d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             True, output_padding, groups, bias, padding_mode, **factory_kwargs)
 
@@ -1089,7 +1089,7 @@ class ConvTranspose3d(_ConvTransposeNd):
         padding = _triple(padding)
         dilation = _triple(dilation)
         output_padding = _triple(output_padding)
-        super(ConvTranspose3d, self).__init__(
+        super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             True, output_padding, groups, bias, padding_mode, **factory_kwargs)
 
@@ -1130,7 +1130,7 @@ class _ConvTransposeMixin(_ConvTransposeNd):
         warnings.warn(
             "_ConvTransposeMixin is a deprecated internal class. "
             "Please consider using public APIs.")
-        super(_ConvTransposeMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 # TODO: Conv2dLocal

--- a/torch/nn/modules/distance.py
+++ b/torch/nn/modules/distance.py
@@ -44,7 +44,7 @@ class PairwiseDistance(Module):
     keepdim: bool
 
     def __init__(self, p: float = 2., eps: float = 1e-6, keepdim: bool = False) -> None:
-        super(PairwiseDistance, self).__init__()
+        super().__init__()
         self.norm = p
         self.eps = eps
         self.keepdim = keepdim
@@ -79,7 +79,7 @@ class CosineSimilarity(Module):
     eps: float
 
     def __init__(self, dim: int = 1, eps: float = 1e-8) -> None:
-        super(CosineSimilarity, self).__init__()
+        super().__init__()
         self.dim = dim
         self.eps = eps
 

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -11,7 +11,7 @@ class _DropoutNd(Module):
     inplace: bool
 
     def __init__(self, p: float = 0.5, inplace: bool = False) -> None:
-        super(_DropoutNd, self).__init__()
+        super().__init__()
         if p < 0 or p > 1:
             raise ValueError("dropout probability has to be between 0 and 1, "
                              "but got {}".format(p))

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -38,7 +38,7 @@ class Flatten(Module):
     end_dim: int
 
     def __init__(self, start_dim: int = 1, end_dim: int = -1) -> None:
-        super(Flatten, self).__init__()
+        super().__init__()
         self.start_dim = start_dim
         self.end_dim = end_dim
 
@@ -104,7 +104,7 @@ class Unflatten(Module):
     unflattened_size: Union[_size, NamedShape]
 
     def __init__(self, dim: Union[int, str], unflattened_size: Union[_size, NamedShape]) -> None:
-        super(Unflatten, self).__init__()
+        super().__init__()
 
         if isinstance(dim, int):
             self._require_tuple_int(unflattened_size)

--- a/torch/nn/modules/fold.py
+++ b/torch/nn/modules/fold.py
@@ -135,7 +135,7 @@ class Fold(Module):
         padding: _size_any_t = 0,
         stride: _size_any_t = 1
     ) -> None:
-        super(Fold, self).__init__()
+        super().__init__()
         self.output_size = output_size
         self.kernel_size = kernel_size
         self.dilation = dilation
@@ -288,7 +288,7 @@ class Unfold(Module):
         padding: _size_any_t = 0,
         stride: _size_any_t = 1
     ) -> None:
-        super(Unfold, self).__init__()
+        super().__init__()
         self.kernel_size = kernel_size
         self.dilation = dilation
         self.padding = padding

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -18,7 +18,7 @@ class _InstanceNorm(_NormBase):
         dtype=None
     ) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(_InstanceNorm, self).__init__(
+        super().__init__(
             num_features, eps, momentum, affine, track_running_stats, **factory_kwargs)
 
     def _check_input_dim(self, input):
@@ -61,7 +61,7 @@ class _InstanceNorm(_NormBase):
                 for key in running_stats_keys:
                     state_dict.pop(key)
 
-        super(_InstanceNorm, self)._load_from_state_dict(
+        super()._load_from_state_dict(
             state_dict, prefix, local_metadata, strict,
             missing_keys, unexpected_keys, error_msgs)
 

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -39,7 +39,7 @@ class Identity(Module):
 
     """
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super(Identity, self).__init__()
+        super().__init__()
 
     def forward(self, input: Tensor) -> Tensor:
         return input
@@ -90,7 +90,7 @@ class Linear(Module):
     def __init__(self, in_features: int, out_features: int, bias: bool = True,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(Linear, self).__init__()
+        super().__init__()
         self.in_features = in_features
         self.out_features = out_features
         self.weight = Parameter(torch.empty((out_features, in_features), **factory_kwargs))
@@ -178,7 +178,7 @@ class Bilinear(Module):
     def __init__(self, in1_features: int, in2_features: int, out_features: int, bias: bool = True,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(Bilinear, self).__init__()
+        super().__init__()
         self.in1_features = in1_features
         self.in2_features = in2_features
         self.out_features = out_features

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -18,7 +18,7 @@ class _Loss(Module):
     reduction: str
 
     def __init__(self, size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(_Loss, self).__init__()
+        super().__init__()
         if size_average is not None or reduce is not None:
             self.reduction: str = _Reduction.legacy_get_string(size_average, reduce)
         else:
@@ -27,7 +27,7 @@ class _Loss(Module):
 
 class _WeightedLoss(_Loss):
     def __init__(self, weight: Optional[Tensor] = None, size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(_WeightedLoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
         self.register_buffer('weight', weight)
         self.weight: Optional[Tensor]
 
@@ -95,7 +95,7 @@ class L1Loss(_Loss):
     __constants__ = ['reduction']
 
     def __init__(self, size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(L1Loss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
         return F.l1_loss(input, target, reduction=self.reduction)
@@ -209,7 +209,7 @@ class NLLLoss(_WeightedLoss):
 
     def __init__(self, weight: Optional[Tensor] = None, size_average=None, ignore_index: int = -100,
                  reduce=None, reduction: str = 'mean') -> None:
-        super(NLLLoss, self).__init__(weight, size_average, reduce, reduction)
+        super().__init__(weight, size_average, reduce, reduction)
         self.ignore_index = ignore_index
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
@@ -222,7 +222,7 @@ class NLLLoss2d(NLLLoss):
         warnings.warn("NLLLoss2d has been deprecated. "
                       "Please use NLLLoss instead as a drop-in replacement and see "
                       "https://pytorch.org/docs/master/nn.html#torch.nn.NLLLoss for more details.")
-        super(NLLLoss2d, self).__init__(weight, size_average, ignore_index, reduce, reduction)
+        super().__init__(weight, size_average, ignore_index, reduce, reduction)
 
 
 class PoissonNLLLoss(_Loss):
@@ -288,7 +288,7 @@ class PoissonNLLLoss(_Loss):
 
     def __init__(self, log_input: bool = True, full: bool = False, size_average=None,
                  eps: float = 1e-8, reduce=None, reduction: str = 'mean') -> None:
-        super(PoissonNLLLoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
         self.log_input = log_input
         self.full = full
         self.eps = eps
@@ -369,7 +369,7 @@ class GaussianNLLLoss(_Loss):
     eps: float
 
     def __init__(self, *, full: bool = False, eps: float = 1e-6, reduction: str = 'mean') -> None:
-        super(GaussianNLLLoss, self).__init__(None, None, reduction)
+        super().__init__(None, None, reduction)
         self.full = full
         self.eps = eps
 
@@ -464,7 +464,7 @@ class KLDivLoss(_Loss):
     __constants__ = ['reduction']
 
     def __init__(self, size_average=None, reduce=None, reduction: str = 'mean', log_target: bool = False) -> None:
-        super(KLDivLoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
         self.log_target = log_target
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
@@ -530,7 +530,7 @@ class MSELoss(_Loss):
     __constants__ = ['reduction']
 
     def __init__(self, size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(MSELoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
         return F.mse_loss(input, target, reduction=self.reduction)
@@ -613,7 +613,7 @@ class BCELoss(_WeightedLoss):
     __constants__ = ['reduction']
 
     def __init__(self, weight: Optional[Tensor] = None, size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(BCELoss, self).__init__(weight, size_average, reduce, reduction)
+        super().__init__(weight, size_average, reduce, reduction)
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
         return F.binary_cross_entropy(input, target, weight=self.weight, reduction=self.reduction)
@@ -710,7 +710,7 @@ class BCEWithLogitsLoss(_Loss):
     """
     def __init__(self, weight: Optional[Tensor] = None, size_average=None, reduce=None, reduction: str = 'mean',
                  pos_weight: Optional[Tensor] = None) -> None:
-        super(BCEWithLogitsLoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
         self.register_buffer('weight', weight)
         self.register_buffer('pos_weight', pos_weight)
         self.weight: Optional[Tensor]
@@ -776,7 +776,7 @@ class HingeEmbeddingLoss(_Loss):
     margin: float
 
     def __init__(self, margin: float = 1.0, size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(HingeEmbeddingLoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
         self.margin = margin
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
@@ -841,7 +841,7 @@ class MultiLabelMarginLoss(_Loss):
     __constants__ = ['reduction']
 
     def __init__(self, size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(MultiLabelMarginLoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
         return F.multilabel_margin_loss(input, target, reduction=self.reduction)
@@ -921,7 +921,7 @@ class SmoothL1Loss(_Loss):
     __constants__ = ['reduction']
 
     def __init__(self, size_average=None, reduce=None, reduction: str = 'mean', beta: float = 1.0) -> None:
-        super(SmoothL1Loss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
         self.beta = beta
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
@@ -1023,7 +1023,7 @@ class SoftMarginLoss(_Loss):
     __constants__ = ['reduction']
 
     def __init__(self, size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(SoftMarginLoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
         return F.soft_margin_loss(input, target, reduction=self.reduction)
@@ -1166,7 +1166,7 @@ class CrossEntropyLoss(_WeightedLoss):
 
     def __init__(self, weight: Optional[Tensor] = None, size_average=None, ignore_index: int = -100,
                  reduce=None, reduction: str = 'mean', label_smoothing: float = 0.0) -> None:
-        super(CrossEntropyLoss, self).__init__(weight, size_average, reduce, reduction)
+        super().__init__(weight, size_average, reduce, reduction)
         self.ignore_index = ignore_index
         self.label_smoothing = label_smoothing
 
@@ -1217,7 +1217,7 @@ class MultiLabelSoftMarginLoss(_WeightedLoss):
     __constants__ = ['reduction']
 
     def __init__(self, weight: Optional[Tensor] = None, size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(MultiLabelSoftMarginLoss, self).__init__(weight, size_average, reduce, reduction)
+        super().__init__(weight, size_average, reduce, reduction)
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
         return F.multilabel_soft_margin_loss(input, target, weight=self.weight, reduction=self.reduction)
@@ -1269,7 +1269,7 @@ class CosineEmbeddingLoss(_Loss):
     margin: float
 
     def __init__(self, margin: float = 0., size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(CosineEmbeddingLoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
         self.margin = margin
 
     def forward(self, input1: Tensor, input2: Tensor, target: Tensor) -> Tensor:
@@ -1326,7 +1326,7 @@ class MarginRankingLoss(_Loss):
     margin: float
 
     def __init__(self, margin: float = 0., size_average=None, reduce=None, reduction: str = 'mean') -> None:
-        super(MarginRankingLoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
         self.margin = margin
 
     def forward(self, input1: Tensor, input2: Tensor, target: Tensor) -> Tensor:
@@ -1399,7 +1399,7 @@ class MultiMarginLoss(_WeightedLoss):
 
     def __init__(self, p: int = 1, margin: float = 1., weight: Optional[Tensor] = None, size_average=None,
                  reduce=None, reduction: str = 'mean') -> None:
-        super(MultiMarginLoss, self).__init__(weight, size_average, reduce, reduction)
+        super().__init__(weight, size_average, reduce, reduction)
         if p != 1 and p != 2:
             raise ValueError("only p == 1 and p == 2 supported")
         assert weight is None or weight.dim() == 1
@@ -1484,7 +1484,7 @@ class TripletMarginLoss(_Loss):
 
     def __init__(self, margin: float = 1.0, p: float = 2., eps: float = 1e-6, swap: bool = False, size_average=None,
                  reduce=None, reduction: str = 'mean'):
-        super(TripletMarginLoss, self).__init__(size_average, reduce, reduction)
+        super().__init__(size_average, reduce, reduction)
         self.margin = margin
         self.p = p
         self.eps = eps
@@ -1599,7 +1599,7 @@ class TripletMarginWithDistanceLoss(_Loss):
 
     def __init__(self, *, distance_function: Optional[Callable[[Tensor, Tensor], Tensor]] = None,
                  margin: float = 1.0, swap: bool = False, reduction: str = 'mean'):
-        super(TripletMarginWithDistanceLoss, self).__init__(size_average=None, reduce=None, reduction=reduction)
+        super().__init__(size_average=None, reduce=None, reduction=reduction)
         self.distance_function: Optional[Callable[[Tensor, Tensor], Tensor]] = \
             distance_function if distance_function is not None else PairwiseDistance()
         self.margin = margin
@@ -1748,7 +1748,7 @@ class CTCLoss(_Loss):
     zero_infinity: bool
 
     def __init__(self, blank: int = 0, reduction: str = 'mean', zero_infinity: bool = False):
-        super(CTCLoss, self).__init__(reduction=reduction)
+        super().__init__(reduction=reduction)
         self.blank = blank
         self.zero_infinity = zero_infinity
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -28,7 +28,7 @@ class _IncompatibleKeys(namedtuple('IncompatibleKeys', ['missing_keys', 'unexpec
     def __repr__(self):
         if not self.missing_keys and not self.unexpected_keys:
             return '<All keys matched successfully>'
-        return super(_IncompatibleKeys, self).__repr__()
+        return super().__repr__()
 
     __str__ = __repr__
 
@@ -473,7 +473,7 @@ class Module:
         super().__setattr__('_modules', OrderedDict())
 
         if self.call_super_init:
-            super(Module, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
     forward: Callable[..., Any] = _forward_unimplemented
 

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -46,7 +46,7 @@ class LocalResponseNorm(Module):
     k: float
 
     def __init__(self, size: int, alpha: float = 1e-4, beta: float = 0.75, k: float = 1.) -> None:
-        super(LocalResponseNorm, self).__init__()
+        super().__init__()
         self.size = size
         self.alpha = alpha
         self.beta = beta
@@ -67,7 +67,7 @@ class CrossMapLRN2d(Module):
     k: float
 
     def __init__(self, size: int, alpha: float = 1e-4, beta: float = 0.75, k: float = 1) -> None:
-        super(CrossMapLRN2d, self).__init__()
+        super().__init__()
         self.size = size
         self.alpha = alpha
         self.beta = beta
@@ -165,7 +165,7 @@ class LayerNorm(Module):
     def __init__(self, normalized_shape: _shape_t, eps: float = 1e-5, elementwise_affine: bool = True,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(LayerNorm, self).__init__()
+        super().__init__()
         if isinstance(normalized_shape, numbers.Integral):
             # mypy error: incompatible types in assignment
             normalized_shape = (normalized_shape,)  # type: ignore[assignment]
@@ -247,7 +247,7 @@ class GroupNorm(Module):
     def __init__(self, num_groups: int, num_channels: int, eps: float = 1e-5, affine: bool = True,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(GroupNorm, self).__init__()
+        super().__init__()
         if num_channels % num_groups != 0:
             raise ValueError('num_channels must be divisible by num_groups')
 

--- a/torch/nn/modules/padding.py
+++ b/torch/nn/modules/padding.py
@@ -18,7 +18,7 @@ class _ConstantPadNd(Module):
     padding: Sequence[int]
 
     def __init__(self, value: float) -> None:
-        super(_ConstantPadNd, self).__init__()
+        super().__init__()
         self.value = value
 
     def forward(self, input: Tensor) -> Tensor:
@@ -75,7 +75,7 @@ class ConstantPad1d(_ConstantPadNd):
     padding: Tuple[int, int]
 
     def __init__(self, padding: _size_2_t, value: float):
-        super(ConstantPad1d, self).__init__(value)
+        super().__init__(value)
         self.padding = _pair(padding)
 
 
@@ -126,7 +126,7 @@ class ConstantPad2d(_ConstantPadNd):
     padding: Tuple[int, int, int, int]
 
     def __init__(self, padding: _size_4_t, value: float) -> None:
-        super(ConstantPad2d, self).__init__(value)
+        super().__init__(value)
         self.padding = _quadruple(padding)
 
 
@@ -166,7 +166,7 @@ class ConstantPad3d(_ConstantPadNd):
     padding: Tuple[int, int, int, int, int, int]
 
     def __init__(self, padding: _size_6_t, value: float) -> None:
-        super(ConstantPad3d, self).__init__(value)
+        super().__init__(value)
         self.padding = _ntuple(6)(padding)
 
 
@@ -218,7 +218,7 @@ class ReflectionPad1d(_ReflectionPadNd):
     padding: Tuple[int, int]
 
     def __init__(self, padding: _size_2_t) -> None:
-        super(ReflectionPad1d, self).__init__()
+        super().__init__()
         self.padding = _pair(padding)
 
 
@@ -270,7 +270,7 @@ class ReflectionPad2d(_ReflectionPadNd):
     padding: Tuple[int, int, int, int]
 
     def __init__(self, padding: _size_4_t) -> None:
-        super(ReflectionPad2d, self).__init__()
+        super().__init__()
         self.padding = _quadruple(padding)
 
 
@@ -323,7 +323,7 @@ class ReflectionPad3d(_ReflectionPadNd):
     padding: Tuple[int, int, int, int, int, int]
 
     def __init__(self, padding: _size_6_t) -> None:
-        super(ReflectionPad3d, self).__init__()
+        super().__init__()
         self.padding = _ntuple(6)(padding)
 
 
@@ -375,7 +375,7 @@ class ReplicationPad1d(_ReplicationPadNd):
     padding: Tuple[int, int]
 
     def __init__(self, padding: _size_2_t) -> None:
-        super(ReplicationPad1d, self).__init__()
+        super().__init__()
         self.padding = _pair(padding)
 
 
@@ -427,7 +427,7 @@ class ReplicationPad2d(_ReplicationPadNd):
     padding: Tuple[int, int, int, int]
 
     def __init__(self, padding: _size_4_t) -> None:
-        super(ReplicationPad2d, self).__init__()
+        super().__init__()
         self.padding = _quadruple(padding)
 
 
@@ -468,7 +468,7 @@ class ReplicationPad3d(_ReplicationPadNd):
     padding: Tuple[int, int, int, int, int, int]
 
     def __init__(self, padding: _size_6_t) -> None:
-        super(ReplicationPad3d, self).__init__()
+        super().__init__()
         self.padding = _ntuple(6)(padding)
 
 
@@ -520,7 +520,7 @@ class ZeroPad2d(ConstantPad2d):
     padding: Tuple[int, int, int, int]
 
     def __init__(self, padding: _size_4_t) -> None:
-        super(ZeroPad2d, self).__init__(padding, 0.)
+        super().__init__(padding, 0.)
 
     def extra_repr(self) -> str:
         return '{}'.format(self.padding)

--- a/torch/nn/modules/pixelshuffle.py
+++ b/torch/nn/modules/pixelshuffle.py
@@ -47,7 +47,7 @@ class PixelShuffle(Module):
     upscale_factor: int
 
     def __init__(self, upscale_factor: int) -> None:
-        super(PixelShuffle, self).__init__()
+        super().__init__()
         self.upscale_factor = upscale_factor
 
     def forward(self, input: Tensor) -> Tensor:
@@ -97,7 +97,7 @@ class PixelUnshuffle(Module):
     downscale_factor: int
 
     def __init__(self, downscale_factor: int) -> None:
-        super(PixelUnshuffle, self).__init__()
+        super().__init__()
         self.downscale_factor = downscale_factor
 
     def forward(self, input: Tensor) -> Tensor:

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -22,7 +22,7 @@ class _MaxPoolNd(Module):
     def __init__(self, kernel_size: _size_any_t, stride: Optional[_size_any_t] = None,
                  padding: _size_any_t = 0, dilation: _size_any_t = 1,
                  return_indices: bool = False, ceil_mode: bool = False) -> None:
-        super(_MaxPoolNd, self).__init__()
+        super().__init__()
         self.kernel_size = kernel_size
         self.stride = stride if (stride is not None) else kernel_size
         self.padding = padding
@@ -314,7 +314,7 @@ class MaxUnpool1d(_MaxUnpoolNd):
     padding: _size_1_t
 
     def __init__(self, kernel_size: _size_1_t, stride: Optional[_size_1_t] = None, padding: _size_1_t = 0) -> None:
-        super(MaxUnpool1d, self).__init__()
+        super().__init__()
         self.kernel_size = _single(kernel_size)
         self.stride = _single(stride if (stride is not None) else kernel_size)
         self.padding = _single(padding)
@@ -397,7 +397,7 @@ class MaxUnpool2d(_MaxUnpoolNd):
     padding: _size_2_t
 
     def __init__(self, kernel_size: _size_2_t, stride: Optional[_size_2_t] = None, padding: _size_2_t = 0) -> None:
-        super(MaxUnpool2d, self).__init__()
+        super().__init__()
         self.kernel_size = _pair(kernel_size)
         self.stride = _pair(stride if (stride is not None) else kernel_size)
         self.padding = _pair(padding)
@@ -463,7 +463,7 @@ class MaxUnpool3d(_MaxUnpoolNd):
     padding: _size_3_t
 
     def __init__(self, kernel_size: _size_3_t, stride: Optional[_size_3_t] = None, padding: _size_3_t = 0) -> None:
-        super(MaxUnpool3d, self).__init__()
+        super().__init__()
         self.kernel_size = _triple(kernel_size)
         self.stride = _triple(stride if (stride is not None) else kernel_size)
         self.padding = _triple(padding)
@@ -536,7 +536,7 @@ class AvgPool1d(_AvgPoolNd):
 
     def __init__(self, kernel_size: _size_1_t, stride: _size_1_t = None, padding: _size_1_t = 0, ceil_mode: bool = False,
                  count_include_pad: bool = True) -> None:
-        super(AvgPool1d, self).__init__()
+        super().__init__()
         self.kernel_size = _single(kernel_size)
         self.stride = _single(stride if stride is not None else kernel_size)
         self.padding = _single(padding)
@@ -615,7 +615,7 @@ class AvgPool2d(_AvgPoolNd):
 
     def __init__(self, kernel_size: _size_2_t, stride: Optional[_size_2_t] = None, padding: _size_2_t = 0,
                  ceil_mode: bool = False, count_include_pad: bool = True, divisor_override: Optional[int] = None) -> None:
-        super(AvgPool2d, self).__init__()
+        super().__init__()
         self.kernel_size = kernel_size
         self.stride = stride if (stride is not None) else kernel_size
         self.padding = padding
@@ -701,7 +701,7 @@ class AvgPool3d(_AvgPoolNd):
 
     def __init__(self, kernel_size: _size_3_t, stride: Optional[_size_3_t] = None, padding: _size_3_t = 0,
                  ceil_mode: bool = False, count_include_pad: bool = True, divisor_override: Optional[int] = None) -> None:
-        super(AvgPool3d, self).__init__()
+        super().__init__()
         self.kernel_size = kernel_size
         self.stride = stride if (stride is not None) else kernel_size
         self.padding = padding
@@ -714,7 +714,7 @@ class AvgPool3d(_AvgPoolNd):
                             self.padding, self.ceil_mode, self.count_include_pad, self.divisor_override)
 
     def __setstate__(self, d):
-        super(AvgPool3d, self).__setstate__(d)
+        super().__setstate__(d)
         self.__dict__.setdefault('padding', 0)
         self.__dict__.setdefault('ceil_mode', False)
         self.__dict__.setdefault('count_include_pad', True)
@@ -767,7 +767,7 @@ class FractionalMaxPool2d(Module):
     def __init__(self, kernel_size: _size_2_t, output_size: Optional[_size_2_t] = None,
                  output_ratio: Optional[_ratio_2_t] = None,
                  return_indices: bool = False, _random_samples=None) -> None:
-        super(FractionalMaxPool2d, self).__init__()
+        super().__init__()
         self.kernel_size = _pair(kernel_size)
         self.return_indices = return_indices
         self.register_buffer('_random_samples', _random_samples)
@@ -836,7 +836,7 @@ class FractionalMaxPool3d(Module):
     def __init__(self, kernel_size: _size_3_t, output_size: Optional[_size_3_t] = None,
                  output_ratio: Optional[_ratio_3_t] = None,
                  return_indices: bool = False, _random_samples=None) -> None:
-        super(FractionalMaxPool3d, self).__init__()
+        super().__init__()
         self.kernel_size = _triple(kernel_size)
         self.return_indices = return_indices
         self.register_buffer('_random_samples', _random_samples)
@@ -867,7 +867,7 @@ class _LPPoolNd(Module):
 
     def __init__(self, norm_type: float, kernel_size: _size_any_t, stride: Optional[_size_any_t] = None,
                  ceil_mode: bool = False) -> None:
-        super(_LPPoolNd, self).__init__()
+        super().__init__()
         self.norm_type = norm_type
         self.kernel_size = kernel_size
         self.stride = stride
@@ -980,7 +980,7 @@ class _AdaptiveMaxPoolNd(Module):
     return_indices: bool
 
     def __init__(self, output_size: _size_any_opt_t, return_indices: bool = False) -> None:
-        super(_AdaptiveMaxPoolNd, self).__init__()
+        super().__init__()
         self.output_size = output_size
         self.return_indices = return_indices
 
@@ -1110,7 +1110,7 @@ class _AdaptiveAvgPoolNd(Module):
     __constants__ = ['output_size']
 
     def __init__(self, output_size: _size_any_opt_t) -> None:
-        super(_AdaptiveAvgPoolNd, self).__init__()
+        super().__init__()
         self.output_size = output_size
 
     def extra_repr(self) -> str:

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -49,7 +49,7 @@ class RNNBase(Module):
                  dropout: float = 0., bidirectional: bool = False, proj_size: int = 0,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(RNNBase, self).__init__()
+        super().__init__()
         self.mode = mode
         self.input_size = input_size
         self.hidden_size = hidden_size
@@ -143,7 +143,7 @@ class RNNBase(Module):
             # keep self._flat_weights up to date if you do self.weight = ...
             idx = self._flat_weights_names.index(attr)
             self._flat_weights[idx] = value
-        super(RNNBase, self).__setattr__(attr, value)
+        super().__setattr__(attr, value)
 
     def flatten_parameters(self) -> None:
         """Resets parameter data pointer so that they can use faster code paths.
@@ -194,7 +194,7 @@ class RNNBase(Module):
                         self.batch_first, bool(self.bidirectional))
 
     def _apply(self, fn):
-        ret = super(RNNBase, self)._apply(fn)
+        ret = super()._apply(fn)
 
         # Resets _flat_weights
         # Note: be v. careful before removing this, as 3rd party device types
@@ -284,7 +284,7 @@ class RNNBase(Module):
         return state
 
     def __setstate__(self, d):
-        super(RNNBase, self).__setstate__(d)
+        super().__setstate__(d)
         if 'all_weights' in d:
             self._all_weights = d['all_weights']
         # In PyTorch 1.8 we added a proj_size member variable to LSTM.
@@ -329,7 +329,7 @@ class RNNBase(Module):
         return [[getattr(self, weight) for weight in weights] for weights in self._all_weights]
 
     def _replicate_for_data_parallel(self):
-        replica = super(RNNBase, self)._replicate_for_data_parallel()
+        replica = super()._replicate_for_data_parallel()
         # Need to copy these caches, otherwise the replica will share the same
         # flat weights list.
         replica._flat_weights = replica._flat_weights[:]
@@ -450,7 +450,7 @@ class RNN(RNNBase):
             mode = 'RNN_RELU'
         else:
             raise ValueError("Unknown nonlinearity '{}'".format(self.nonlinearity))
-        super(RNN, self).__init__(mode, *args, **kwargs)
+        super().__init__(mode, *args, **kwargs)
 
     @overload
     @torch._jit_internal._overload_method  # noqa: F811
@@ -708,7 +708,7 @@ class LSTM(RNNBase):
     """
 
     def __init__(self, *args, **kwargs):
-        super(LSTM, self).__init__('LSTM', *args, **kwargs)
+        super().__init__('LSTM', *args, **kwargs)
 
     def get_expected_cell_size(self, input: Tensor, batch_sizes: Optional[Tensor]) -> Tuple[int, int, int]:
         if batch_sizes is not None:
@@ -940,7 +940,7 @@ class GRU(RNNBase):
     def __init__(self, *args, **kwargs):
         if 'proj_size' in kwargs:
             raise ValueError("proj_size argument is only supported for LSTM, not RNN or GRU")
-        super(GRU, self).__init__('GRU', *args, **kwargs)
+        super().__init__('GRU', *args, **kwargs)
 
     @overload  # type: ignore[override]
     @torch._jit_internal._overload_method  # noqa: F811
@@ -1029,7 +1029,7 @@ class RNNCellBase(Module):
     def __init__(self, input_size: int, hidden_size: int, bias: bool, num_chunks: int,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(RNNCellBase, self).__init__()
+        super().__init__()
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.bias = bias
@@ -1118,7 +1118,7 @@ class RNNCell(RNNCellBase):
     def __init__(self, input_size: int, hidden_size: int, bias: bool = True, nonlinearity: str = "tanh",
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(RNNCell, self).__init__(input_size, hidden_size, bias, num_chunks=1, **factory_kwargs)
+        super().__init__(input_size, hidden_size, bias, num_chunks=1, **factory_kwargs)
         self.nonlinearity = nonlinearity
 
     def forward(self, input: Tensor, hx: Optional[Tensor] = None) -> Tensor:
@@ -1219,7 +1219,7 @@ class LSTMCell(RNNCellBase):
     def __init__(self, input_size: int, hidden_size: int, bias: bool = True,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(LSTMCell, self).__init__(input_size, hidden_size, bias, num_chunks=4, **factory_kwargs)
+        super().__init__(input_size, hidden_size, bias, num_chunks=4, **factory_kwargs)
 
     def forward(self, input: Tensor, hx: Optional[Tuple[Tensor, Tensor]] = None) -> Tuple[Tensor, Tensor]:
         assert input.dim() in (1, 2), \
@@ -1310,7 +1310,7 @@ class GRUCell(RNNCellBase):
     def __init__(self, input_size: int, hidden_size: int, bias: bool = True,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(GRUCell, self).__init__(input_size, hidden_size, bias, num_chunks=3, **factory_kwargs)
+        super().__init__(input_size, hidden_size, bias, num_chunks=3, **factory_kwargs)
 
     def forward(self, input: Tensor, hx: Optional[Tensor] = None) -> Tensor:
         assert input.dim() in (1, 2), \

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -125,7 +125,7 @@ class Embedding(Module):
                  sparse: bool = False, _weight: Optional[Tensor] = None, _freeze: bool = False,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(Embedding, self).__init__()
+        super().__init__()
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
         if padding_idx is not None:
@@ -322,7 +322,7 @@ class EmbeddingBag(Module):
                  include_last_offset: bool = False, padding_idx: Optional[int] = None,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(EmbeddingBag, self).__init__()
+        super().__init__()
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
         self.max_norm = max_norm

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -55,7 +55,7 @@ class Transformer(Module):
                  layer_norm_eps: float = 1e-5, batch_first: bool = False, norm_first: bool = False,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(Transformer, self).__init__()
+        super().__init__()
         torch._C._log_api_usage_once(f"torch.nn.modules.{self.__class__.__name__}")
 
         if custom_encoder is not None:
@@ -184,7 +184,7 @@ class TransformerEncoder(Module):
     __constants__ = ['norm']
 
     def __init__(self, encoder_layer, num_layers, norm=None, enable_nested_tensor=True, mask_check=True):
-        super(TransformerEncoder, self).__init__()
+        super().__init__()
         torch._C._log_api_usage_once(f"torch.nn.modules.{self.__class__.__name__}")
         self.layers = _get_clones(encoder_layer, num_layers)
         self.num_layers = num_layers
@@ -332,7 +332,7 @@ class TransformerDecoder(Module):
     __constants__ = ['norm']
 
     def __init__(self, decoder_layer, num_layers, norm=None):
-        super(TransformerDecoder, self).__init__()
+        super().__init__()
         torch._C._log_api_usage_once(f"torch.nn.modules.{self.__class__.__name__}")
         self.layers = _get_clones(decoder_layer, num_layers)
         self.num_layers = num_layers
@@ -432,7 +432,7 @@ class TransformerEncoderLayer(Module):
                  layer_norm_eps: float = 1e-5, batch_first: bool = False, norm_first: bool = False,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(TransformerEncoderLayer, self).__init__()
+        super().__init__()
         self.self_attn = MultiheadAttention(d_model, nhead, dropout=dropout, batch_first=batch_first,
                                             **factory_kwargs)
         # Implementation of Feedforward model
@@ -461,7 +461,7 @@ class TransformerEncoderLayer(Module):
         self.activation = activation
 
     def __setstate__(self, state):
-        super(TransformerEncoderLayer, self).__setstate__(state)
+        super().__setstate__(state)
         if not hasattr(self, 'activation'):
             self.activation = F.relu
 
@@ -631,7 +631,7 @@ class TransformerDecoderLayer(Module):
                  layer_norm_eps: float = 1e-5, batch_first: bool = False, norm_first: bool = False,
                  device=None, dtype=None) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
-        super(TransformerDecoderLayer, self).__init__()
+        super().__init__()
         self.self_attn = MultiheadAttention(d_model, nhead, dropout=dropout, batch_first=batch_first,
                                             **factory_kwargs)
         self.multihead_attn = MultiheadAttention(d_model, nhead, dropout=dropout, batch_first=batch_first,
@@ -658,7 +658,7 @@ class TransformerDecoderLayer(Module):
     def __setstate__(self, state):
         if 'activation' not in state:
             state['activation'] = F.relu
-        super(TransformerDecoderLayer, self).__setstate__(state)
+        super().__setstate__(state)
 
     def forward(
         self,

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -141,7 +141,7 @@ class Upsample(Module):
     def __init__(self, size: Optional[_size_any_t] = None, scale_factor: Optional[_ratio_any_t] = None,
                  mode: str = 'nearest', align_corners: Optional[bool] = None,
                  recompute_scale_factor: Optional[bool] = None) -> None:
-        super(Upsample, self).__init__()
+        super().__init__()
         self.name = type(self).__name__
         self.size = size
         if isinstance(scale_factor, tuple):
@@ -207,7 +207,7 @@ class UpsamplingNearest2d(Upsample):
                   [3., 3., 4., 4.]]]])
     """
     def __init__(self, size: Optional[_size_2_t] = None, scale_factor: Optional[_ratio_2_t] = None) -> None:
-        super(UpsamplingNearest2d, self).__init__(size, scale_factor, mode='nearest')
+        super().__init__(size, scale_factor, mode='nearest')
 
 
 class UpsamplingBilinear2d(Upsample):
@@ -254,4 +254,4 @@ class UpsamplingBilinear2d(Upsample):
                   [3.0000, 3.3333, 3.6667, 4.0000]]]])
     """
     def __init__(self, size: Optional[_size_2_t] = None, scale_factor: Optional[_ratio_2_t] = None) -> None:
-        super(UpsamplingBilinear2d, self).__init__(size, scale_factor, mode='bilinear', align_corners=True)
+        super().__init__(size, scale_factor, mode='bilinear', align_corners=True)

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -122,7 +122,7 @@ class DataParallel(Module):
     # TODO: update notes/cuda.rst when this class handles 8+ GPUs well
 
     def __init__(self, module, device_ids=None, output_device=None, dim=0):
-        super(DataParallel, self).__init__()
+        super().__init__()
         torch._C._log_api_usage_once("torch.nn.parallel.DataParallel")
         device_type = _get_available_device_type()
         if device_type is None:

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -559,7 +559,7 @@ class DistributedDataParallel(Module, Joinable):
         gradient_as_bucket_view=False,
         static_graph=False,
     ):
-        super(DistributedDataParallel, self).__init__()
+        super().__init__()
         Joinable.__init__(self)
         self.logger = None
         if hasattr(module, "_ddp_params_and_buffers_to_ignore"):
@@ -879,7 +879,7 @@ class DistributedDataParallel(Module, Joinable):
     def __setstate__(self, state):
         # If serializable, then the process group should be the default one
         self.process_group = _get_default_group()
-        super(DistributedDataParallel, self).__setstate__(state)
+        super().__setstate__(state)
         self._build_replicated_tensor_module()
         self.__dict__.setdefault("require_forward_param_sync", True)
         self.__dict__.setdefault("require_backward_grad_sync", True)
@@ -1232,7 +1232,7 @@ class DistributedDataParallel(Module, Joinable):
         return gather(outputs, output_device, dim=self.dim)
 
     def train(self, mode=True):
-        super(DistributedDataParallel, self).train(mode)
+        super().train(mode)
         if self._use_replicated_tensor_module:
             self._replicated_tensor_module.train(mode)  # type: ignore[union-attr]
         return self

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -57,7 +57,7 @@ class Parameter(torch.Tensor, metaclass=_ParameterMeta):
             return result
 
     def __repr__(self):
-        return 'Parameter containing:\n' + super(Parameter, self).__repr__()
+        return 'Parameter containing:\n' + super().__repr__()
 
     def __reduce_ex__(self, proto):
         state = torch._utils._get_obj_state(self)

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -40,7 +40,7 @@ class Adadelta(Optimizer):
             foreach=foreach,
             differentiable=differentiable,
         )
-        super(Adadelta, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     def __setstate__(self, state):
         super().__setstate__(state)

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -48,7 +48,7 @@ class Adagrad(Optimizer):
             maximize=maximize,
             differentiable=differentiable,
         )
-        super(Adagrad, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
         for group in self.param_groups:
             for p in group["params"]:

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -30,7 +30,7 @@ class Adam(Optimizer):
                         weight_decay=weight_decay, amsgrad=amsgrad,
                         maximize=maximize, foreach=foreach, capturable=capturable,
                         differentiable=differentiable, fused=fused)
-        super(Adam, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
         if fused:
             if differentiable:

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -42,7 +42,7 @@ class Adamax(Optimizer):
             maximize=maximize,
             differentiable=differentiable,
         )
-        super(Adamax, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     def __setstate__(self, state):
         super().__setstate__(state)

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -47,7 +47,7 @@ class AdamW(Optimizer):
             differentiable=differentiable,
             fused=fused,
         )
-        super(AdamW, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
         if fused:
             if differentiable:

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -43,7 +43,7 @@ class ASGD(Optimizer):
             maximize=maximize,
             differentiable=differentiable,
         )
-        super(ASGD, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     def __setstate__(self, state):
         super().__setstate__(state)

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -231,7 +231,7 @@ class LBFGS(Optimizer):
             tolerance_change=tolerance_change,
             history_size=history_size,
             line_search_fn=line_search_fn)
-        super(LBFGS, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
         if len(self.param_groups) != 1:
             raise ValueError("LBFGS doesn't support per-parameter options "

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -218,7 +218,7 @@ class LambdaLR(LRScheduler):
                 raise ValueError("Expected {} lr_lambdas, but got {}".format(
                     len(optimizer.param_groups), len(lr_lambda)))
             self.lr_lambdas = list(lr_lambda)
-        super(LambdaLR, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
 
     def state_dict(self):
         """Returns the state of the scheduler as a :class:`dict`.
@@ -302,7 +302,7 @@ class MultiplicativeLR(LRScheduler):
                 raise ValueError("Expected {} lr_lambdas, but got {}".format(
                     len(optimizer.param_groups), len(lr_lambda)))
             self.lr_lambdas = list(lr_lambda)
-        super(MultiplicativeLR, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
 
     def state_dict(self):
         """Returns the state of the scheduler as a :class:`dict`.
@@ -382,7 +382,7 @@ class StepLR(LRScheduler):
     def __init__(self, optimizer, step_size, gamma=0.1, last_epoch=-1, verbose=False):
         self.step_size = step_size
         self.gamma = gamma
-        super(StepLR, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:
@@ -430,7 +430,7 @@ class MultiStepLR(LRScheduler):
     def __init__(self, optimizer, milestones, gamma=0.1, last_epoch=-1, verbose=False):
         self.milestones = Counter(milestones)
         self.gamma = gamma
-        super(MultiStepLR, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:
@@ -484,7 +484,7 @@ class ConstantLR(LRScheduler):
 
         self.factor = factor
         self.total_iters = total_iters
-        super(ConstantLR, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:
@@ -551,7 +551,7 @@ class LinearLR(LRScheduler):
         self.start_factor = start_factor
         self.end_factor = end_factor
         self.total_iters = total_iters
-        super(LinearLR, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:
@@ -588,7 +588,7 @@ class ExponentialLR(LRScheduler):
 
     def __init__(self, optimizer, gamma, last_epoch=-1, verbose=False):
         self.gamma = gamma
-        super(ExponentialLR, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:
@@ -807,7 +807,7 @@ class CosineAnnealingLR(LRScheduler):
     def __init__(self, optimizer, T_max, eta_min=0, last_epoch=-1, verbose=False):
         self.T_max = T_max
         self.eta_min = eta_min
-        super(CosineAnnealingLR, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:
@@ -1237,7 +1237,7 @@ class CyclicLR(LRScheduler):
             self.base_momentums = [group['momentum'] for group in optimizer.param_groups]
             self.max_momentums = self._format_param('max_momentum', optimizer, max_momentum)
 
-        super(CyclicLR, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
         self.base_lrs = base_lrs
 
     def _init_scale_fn(self):
@@ -1372,7 +1372,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         self.T_mult = T_mult
         self.eta_min = eta_min
         self.T_cur = last_epoch
-        super(CosineAnnealingWarmRestarts, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:
@@ -1673,7 +1673,7 @@ class OneCycleLR(LRScheduler):
                     group['max_momentum'] = m_momentum
                     group['base_momentum'] = b_momentum
 
-        super(OneCycleLR, self).__init__(optimizer, last_epoch, verbose)
+        super().__init__(optimizer, last_epoch, verbose)
 
     def _format_param(self, name, optimizer, param):
         """Return correctly formatted lr/momentum for each param group."""

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -26,7 +26,7 @@ class NAdam(Optimizer):
         defaults = dict(lr=lr, betas=betas, eps=eps,
                         weight_decay=weight_decay, momentum_decay=momentum_decay,
                         foreach=foreach, differentiable=differentiable)
-        super(NAdam, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     def __setstate__(self, state):
         super().__setstate__(state)

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -40,7 +40,7 @@ class RAdam(Optimizer):
             foreach=foreach,
             differentiable=differentiable,
         )
-        super(RAdam, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     def __setstate__(self, state):
         super().__setstate__(state)

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -44,7 +44,7 @@ class RMSprop(Optimizer):
             maximize=maximize,
             differentiable=differentiable,
         )
-        super(RMSprop, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     def __setstate__(self, state):
         super().__setstate__(state)

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -33,7 +33,7 @@ class Rprop(Optimizer):
             maximize=maximize,
             differentiable=differentiable,
         )
-        super(Rprop, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     def __setstate__(self, state):
         super().__setstate__(state)

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -24,7 +24,7 @@ class SGD(Optimizer):
                         differentiable=differentiable)
         if nesterov and (momentum <= 0 or dampening != 0):
             raise ValueError("Nesterov momentum requires a momentum and zero dampening")
-        super(SGD, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     def __setstate__(self, state):
         super().__setstate__(state)

--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -33,7 +33,7 @@ class SparseAdam(Optimizer):
             )
 
         defaults = dict(lr=lr, betas=betas, eps=eps, maximize=maximize)
-        super(SparseAdam, self).__init__(params, defaults)
+        super().__init__(params, defaults)
 
     @torch.no_grad()
     def step(self, closure=None):

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -100,7 +100,7 @@ class AveragedModel(Module):
         https://arxiv.org/abs/2001.02312
     """
     def __init__(self, model, device=None, avg_fn=None, use_buffers=False):
-        super(AveragedModel, self).__init__()
+        super().__init__()
         self.module = deepcopy(model)
         if device is not None:
             self.module = self.module.to(device)
@@ -254,7 +254,7 @@ class SWALR(LRScheduler):
         if not isinstance(anneal_epochs, int) or anneal_epochs < 0:
             raise ValueError(f"anneal_epochs must be equal or greater than 0, got {anneal_epochs}")
         self.anneal_epochs = anneal_epochs
-        super(SWALR, self).__init__(optimizer, last_epoch)
+        super().__init__(optimizer, last_epoch)
 
     @staticmethod
     def _format_param(optimizer, swa_lrs):

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -105,7 +105,7 @@ class _StorageBase:
         return (_load_from_bytes, (b.getvalue(),))
 
     def __sizeof__(self):
-        return super(_StorageBase, self).__sizeof__() + self.size()
+        return super().__sizeof__() + self.size()
 
     def clone(self):
         """Returns a copy of this storage"""
@@ -662,7 +662,7 @@ class TypedStorage:
 
     def __sizeof__(self):
         _warn_typed_storage_removal()
-        return super(TypedStorage, self).__sizeof__() + self.nbytes()
+        return super().__sizeof__() + self.nbytes()
 
     def clone(self):
         """Returns a copy of this storage"""

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -239,7 +239,7 @@ except ImportError:
 #         # Intention is to override
 #         def assertEqual(self, x, y):
 #             # This DOESN'T WORK!
-#             super(TestFooDeviceType, self).assertEqual(x, y)
+#             super().assertEqual(x, y)
 #
 # If you try to run this code, you'll get an error saying that TestFooDeviceType
 # is not in scope.  This is because after instantiating our classes, we delete

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -715,7 +715,7 @@ class MixtureOfExperts(NestedWrappedModule):
 
 class FSDPTest(MultiProcessTestCase):
     def setUp(self):
-        super(FSDPTest, self).setUp()
+        super().setUp()
         self._spawn_processes()
 
     @property

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -6477,13 +6477,13 @@ def _test_module_empty_input(test_case, module, inp, check_size=True, inference=
 def _create_basic_net():
     class Layer(nn.Module):
         def __init__(self):
-            super(Layer, self).__init__()
+            super().__init__()
             self.layer_dummy_param = nn.Parameter(torch.empty(3, 5))
             self.register_buffer('layer_dummy_buf', torch.zeros(1, 3, 3, 7))
 
     class Net(nn.Module):
         def __init__(self):
-            super(Net, self).__init__()
+            super().__init__()
             self.l1 = Layer()
             self.dummy_param = nn.Parameter(torch.empty(3, 5))
             self.register_buffer('dummy_buf', torch.zeros(7, 3, 3, 1))

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -1272,7 +1272,7 @@ class ConvBnReLUModel(torch.nn.Module):
 
 class AnnotatedConvBnReLUModel(torch.nn.Module):
     def __init__(self, qengine='fbgemm'):
-        super(AnnotatedConvBnReLUModel, self).__init__()
+        super().__init__()
         self.qconfig = torch.ao.quantization.get_default_qconfig(qengine)
         self.conv = torch.nn.Conv2d(3, 5, 3, bias=False).to(dtype=torch.float)
         self.bn = torch.nn.BatchNorm2d(5).to(dtype=torch.float)
@@ -1328,7 +1328,7 @@ class TwoLayerLinearModel(torch.nn.Module):
 
 class LinearModelWithSubmodule(nn.Module):
     def __init__(self):
-        super(LinearModelWithSubmodule, self).__init__()
+        super().__init__()
         self.subm = TwoLayerLinearModel()
         self.fc = nn.Linear(5, 5)
 
@@ -1976,7 +1976,7 @@ class ManualConvLinearSymmQATModel(ManualConvLinearQATModel):
 
 class ManualEmbeddingBagLinear(nn.Module):
     def __init__(self):
-        super(ManualEmbeddingBagLinear, self).__init__()
+        super().__init__()
         self.emb = nn.EmbeddingBag(num_embeddings=10, embedding_dim=12, mode='sum')
         self.emb.qconfig = default_embedding_qat_qconfig
         self.quant = QuantStub()
@@ -2335,7 +2335,7 @@ class EmbeddingWithStaticLinear(torch.nn.Module):
 class DenseTopMLP(nn.Module):
 
     def __init__(self, dense_dim, dense_out, embedding_dim, top_out_in, top_out_out) -> None:
-        super(DenseTopMLP, self).__init__()
+        super().__init__()
 
         self.dense_mlp = nn.Sequential(
             nn.Linear(dense_dim, dense_out),
@@ -2376,7 +2376,7 @@ class SparseNNModel(nn.Module):
     _TOP_MLP_DIM = 1
 
     def __init__(self) -> None:
-        super(SparseNNModel, self).__init__()
+        super().__init__()
 
         self.model_sparse = EmbBagWrapper(self._NUM_EMBEDDINGS, self._EMBEDDING_DIM)
         self.dense_top = DenseTopMLP(

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/_test_st_common.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/_test_st_common.py
@@ -36,7 +36,7 @@ class MyShardedModel2(torch.nn.Module):
         group=None,
         init_rrefs=True
     ) -> None:
-        super(MyShardedModel2, self).__init__()
+        super().__init__()
         if spec is not None:
             self.sharded_tensor2 = sharded_tensor.rand(
                 spec, 10, 20, process_group=group, init_rrefs=init_rrefs
@@ -53,7 +53,7 @@ class MyShardedModel1(torch.nn.Module):
         group=None,
         init_rrefs=True
     ) -> None:
-        super(MyShardedModel1, self).__init__()
+        super().__init__()
         if spec is not None:
             self.sharded_tensor1 = sharded_tensor.rand(
                 spec, 10, 20, process_group=group, init_rrefs=init_rrefs

--- a/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
@@ -92,7 +92,7 @@ def _remote_method_async(method, rref, *args, **kwargs):
 class RemoteEM(nn.Module):
     def __init__(self, num_embeddings: int, embedding_dim: int):
         gLogger.info(f"Initing RemoteEM with {num_embeddings} {embedding_dim}")
-        super(RemoteEM, self).__init__()
+        super().__init__()
         init_em = [0.5] * embedding_dim
         self.em = nn.EmbeddingBag(
             num_embeddings,
@@ -118,7 +118,7 @@ def getLinear(d_in, d_out):
 class RemoteNet(nn.Module):
     def __init__(self, d_in: int, d_out: int):
         gLogger.info(f"Initing RemoteNet with {d_in} {d_out}")
-        super(RemoteNet, self).__init__()
+        super().__init__()
         self.fc = getLinear(d_in, d_out)
         self.relu = nn.ReLU()
 
@@ -134,7 +134,7 @@ class HybridModel(nn.Module):
         remote_net_rref: rpc.RRef,
         process_group_for_ddp: dist.ProcessGroup = None,
     ):
-        super(HybridModel, self).__init__()
+        super().__init__()
         self.remote_em_rref = remote_em_rref
         self.remote_net_rref = remote_net_rref
         self.fc1 = getLinear(D_DENSE, D_DENSE)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -224,7 +224,7 @@ class DDPUnevenTestInput(NamedTuple):
 
 class _FC2(nn.Module):
     def __init__(self):
-        super(_FC2, self).__init__()
+        super().__init__()
         self.fc = nn.Linear(10, 50, bias=True)
         self.fc.bias.requires_grad = False
 
@@ -235,7 +235,7 @@ class _FC2(nn.Module):
 
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.fc1 = nn.Linear(2, 10, bias=False)
         self.fc2 = _FC2()
         self.fc3 = nn.Linear(50, 4, bias=False)
@@ -253,7 +253,7 @@ class Net(nn.Module):
 
 class LargeNet(nn.Module):
     def __init__(self):
-        super(LargeNet, self).__init__()
+        super().__init__()
         self.fc1 = nn.Linear(1000, 2000, bias=False)
         self.fc2 = nn.Linear(2000, 500, bias=False)
 
@@ -274,7 +274,7 @@ class Task(nn.Module):
 
 class BatchNormNet(nn.Module):
     def __init__(self, affine=True):
-        super(BatchNormNet, self).__init__()
+        super().__init__()
         self.fc1 = nn.Linear(2, 40, bias=False)
         self.bn = nn.BatchNorm1d(4, affine=affine)
         self.fc2 = nn.Linear(40, 4, bias=False)
@@ -346,7 +346,7 @@ class EmbeddingNetDifferentParams(nn.Module):
 
 class ControlFlowToyModel(nn.Module):
     def __init__(self):
-        super(ControlFlowToyModel, self).__init__()
+        super().__init__()
         self.lin1 = nn.Linear(10, 10, bias=False)
         self.lin2 = nn.Linear(10, 10, bias=False)
 
@@ -4225,7 +4225,7 @@ class DistributedTest:
         def test_ddp_zero_output_features(self):
             class ToyModel(nn.Module):
                 def __init__(self):
-                    super(ToyModel, self).__init__()
+                    super().__init__()
                     self.net1 = nn.Linear(10, 10)
                     self.relu = nn.ReLU()
                     self.net2 = nn.Linear(10, 0)
@@ -7094,7 +7094,7 @@ class DistributedTest:
             class TestModel(nn.Module):
                 def __init__(self, rank):
                     self.rank = rank
-                    super(TestModel, self).__init__()
+                    super().__init__()
                     self.fc1 = nn.Linear(1, 1, bias=False)
                     # Proxy that will be materialized to another architecture later.
                     # (after wrapping model with DDP)
@@ -7195,7 +7195,7 @@ class DistributedTest:
         def test_ddp_unused_params_rebuild_buckets_exception(self):
             class ToyModel(nn.Module):
                 def __init__(self):
-                    super(ToyModel, self).__init__()
+                    super().__init__()
                     self.net1 = nn.Linear(10, 10, bias=False)
                     self.net2 = nn.Linear(10, 10, bias=False)
 
@@ -7250,7 +7250,7 @@ class DistributedTest:
             # even if they share gradient accumulators.
             class ToyModel(nn.Module):
                 def __init__(self):
-                    super(ToyModel, self).__init__()
+                    super().__init__()
                     # net1, bias, and net1.bias are all unused params.
                     self.net1 = nn.Linear(10, 5, bias=False)
                     self.bias = nn.Parameter(torch.zeros(5))
@@ -7564,7 +7564,7 @@ class DistributedTest:
 
             class ToyModel(nn.Module):
                 def __init__(self, rank):
-                    super(ToyModel, self).__init__()
+                    super().__init__()
                     self.lin1 = nn.Linear(10, 10, bias=False)
                     self.lin2 = nn.Linear(10, 10, bias=False)
                     self.rank = rank
@@ -8070,7 +8070,7 @@ class DistributedTest:
         ):
             class ToyModel(nn.Module):
                 def __init__(self, rank):
-                    super(ToyModel, self).__init__()
+                    super().__init__()
                     self.lin1 = nn.Linear(10, 10, bias=False)
                     self.lin2 = nn.Linear(10, 10, bias=False)
                     self.rank = rank
@@ -8778,7 +8778,7 @@ class DistributedTest:
         def test_detect_ddp_is_actually_static(self):
             class ToyModel(nn.Module):
                 def __init__(self):
-                    super(ToyModel, self).__init__()
+                    super().__init__()
                     self.net1 = nn.Linear(10, 10, bias=False)
                     self.net2 = nn.Linear(10, 10)
 
@@ -9151,7 +9151,7 @@ class DistributedTest:
         def test_ddp_forward_backward_hook(self):
             class DummyTestModel(nn.Module):
                 def __init__(self):
-                    super(DummyTestModel, self).__init__()
+                    super().__init__()
                     torch.manual_seed(0)
                     self.fc = nn.Linear(2, 2)
 

--- a/torch/testing/_internal/distributed/distributed_utils.py
+++ b/torch/testing/_internal/distributed/distributed_utils.py
@@ -11,7 +11,7 @@ import torch.distributed.distributed_c10d as c10d
 class MockProcessGroup(dist.ProcessGroup):
 
     def __init__(self, rank, world):
-        super(MockProcessGroup, self).__init__(rank, world)
+        super().__init__(rank, world)
 
     def getBackendName(self):
         return "mock_process_group"

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -260,7 +260,7 @@ class ProcessLocalGroup(dist.ProcessGroup):
         return res
 
     def __init__(self, rank, world_size):
-        super(ProcessLocalGroup, self).__init__(rank, world_size)
+        super().__init__(rank, world_size)
         self._rank = rank
         self._world_size = world_size
         ProcessLocalGroup._register(self)

--- a/torch/testing/_internal/distributed/pipe_with_ddp_test.py
+++ b/torch/testing/_internal/distributed/pipe_with_ddp_test.py
@@ -90,7 +90,7 @@ class PipeWithDDPTest(RpcAgentTestFixture):
 
         class MyModule(nn.Module):
             def __init__(self, device):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.fc2 = nn.Linear(8, 4, bias=False).cuda(device)
                 self.fc3 = nn.Linear(4, 2, bias=False).cuda(device)
 

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -2680,9 +2680,6 @@ class TensorPipeCudaDistAutogradTest(RpcAgentTestFixture):
         rpc.shutdown()
 
     class MyRemoteCompute(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-
         def forward(self, input):
             input = input * 2.0
             return input

--- a/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py
@@ -43,7 +43,7 @@ class Policy(nn.Module):
     See https://github.com/pytorch/examples/tree/master/reinforcement_learning
     """
     def __init__(self):
-        super(Policy, self).__init__()
+        super().__init__()
         self.affine1 = nn.Linear(4, 128)
         self.dropout = nn.Dropout(p=0.6)
         self.affine2 = nn.Linear(128, 2)

--- a/torch/testing/_internal/jit_metaprogramming_utils.py
+++ b/torch/testing/_internal/jit_metaprogramming_utils.py
@@ -605,7 +605,7 @@ def create_script_module(self, nn_module, constructor_args, *args, **kwargs):
             __constants__ = submodule_constants
 
             def __init__(self):
-                super(TheModule, self).__init__()
+                super().__init__()
                 self.submodule = nn_module(*constructor_args)
 
         def make_module(script):

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -2011,7 +2011,7 @@ class BinaryUfuncInfo(OpInfo):
             ),
         )
         kwargs["skips"] = kwargs.get("skips", tuple()) + common_skips
-        super(BinaryUfuncInfo, self).__init__(
+        super().__init__(
             name,
             sample_inputs_func=sample_inputs_func,
             reference_inputs_func=reference_inputs_func,
@@ -2530,7 +2530,7 @@ class ShapeFuncInfo(OpInfo):
         sample_inputs_func=None,
         **kwargs,
     ):
-        super(ShapeFuncInfo, self).__init__(
+        super().__init__(
             name,
             dtypes=dtypes,
             dtypesIfCUDA=dtypesIfCUDA,

--- a/torch/testing/_internal/opinfo/refs.py
+++ b/torch/testing/_internal/opinfo/refs.py
@@ -115,7 +115,7 @@ class PythonRefInfo(OpInfo):
 
         inherited = self.torch_opinfo._original_opinfo_args
         ukwargs = _inherit_constructor_args(name, op, inherited, kwargs)
-        super(PythonRefInfo, self).__init__(**ukwargs)
+        super().__init__(**ukwargs)
 
 
 class ReductionPythonRefInfo(ReductionOpInfo):
@@ -182,7 +182,7 @@ class ElementwiseUnaryPythonRefInfo(UnaryUfuncInfo):
         inherited = self.torch_opinfo._original_unary_ufunc_args
         ukwargs = _inherit_constructor_args(name, op, inherited, kwargs)
 
-        super(ElementwiseUnaryPythonRefInfo, self).__init__(**ukwargs)
+        super().__init__(**ukwargs)
 
 
 class ElementwiseBinaryPythonRefInfo(BinaryUfuncInfo):
@@ -213,4 +213,4 @@ class ElementwiseBinaryPythonRefInfo(BinaryUfuncInfo):
         inherited = self.torch_opinfo._original_binary_ufunc_args
         ukwargs = _inherit_constructor_args(name, op, inherited, kwargs)
 
-        super(ElementwiseBinaryPythonRefInfo, self).__init__(**ukwargs)
+        super().__init__(**ukwargs)

--- a/torch/utils/benchmark/utils/compare.py
+++ b/torch/utils/benchmark/utils/compare.py
@@ -78,7 +78,7 @@ def optional_min(seq):
 class _Row:
     def __init__(self, results, row_group, render_env, env_str_len,
                  row_name_str_len, time_scale, colorize, num_threads=None):
-        super(_Row, self).__init__()
+        super().__init__()
         self._results = results
         self._row_group = row_group
         self._render_env = render_env

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -464,7 +464,7 @@ class BuildExtension(build_ext):
         return cls_with_options
 
     def __init__(self, *args, **kwargs) -> None:
-        super(BuildExtension, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.no_python_abi_suffix = kwargs.get("no_python_abi_suffix", False)
 
         self.use_ninja = kwargs.get('use_ninja', True)
@@ -846,7 +846,7 @@ class BuildExtension(build_ext):
         # Get the original shared library name. For Python 3, this name will be
         # suffixed with "<SOABI>.so", where <SOABI> will be something like
         # cpython-37m-x86_64-linux-gnu.
-        ext_filename = super(BuildExtension, self).get_ext_filename(ext_name)
+        ext_filename = super().get_ext_filename(ext_name)
         # If `no_python_abi_suffix` is `True`, we omit the Python 3 ABI
         # component. This makes building shared libraries with setuptools that
         # aren't Python modules nicer.

--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -17,9 +17,7 @@ class _BaseDatasetFetcher:
 
 class _IterableDatasetFetcher(_BaseDatasetFetcher):
     def __init__(self, dataset, auto_collation, collate_fn, drop_last):
-        super(_IterableDatasetFetcher, self).__init__(
-            dataset, auto_collation, collate_fn, drop_last
-        )
+        super().__init__(dataset, auto_collation, collate_fn, drop_last)
         self.dataset_iter = iter(dataset)
         self.ended = False
 
@@ -45,11 +43,6 @@ class _IterableDatasetFetcher(_BaseDatasetFetcher):
 
 
 class _MapDatasetFetcher(_BaseDatasetFetcher):
-    def __init__(self, dataset, auto_collation, collate_fn, drop_last):
-        super(_MapDatasetFetcher, self).__init__(
-            dataset, auto_collation, collate_fn, drop_last
-        )
-
     def fetch(self, possibly_batched_index):
         if self.auto_collation:
             if hasattr(self.dataset, "__getitems__") and self.dataset.__getitems__:

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -77,7 +77,7 @@ class WorkerInfo:
     def __setattr__(self, key, val):
         if self.__initialized:
             raise RuntimeError("Cannot assign attributes to {} objects".format(self.__class__.__name__))
-        return super(WorkerInfo, self).__setattr__(key, val)
+        return super().__setattr__(key, val)
 
     def __repr__(self):
         items = []

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -90,7 +90,7 @@ class _InfiniteConstantSampler(Sampler):
     """
 
     def __init__(self):
-        super(_InfiniteConstantSampler, self).__init__(None)
+        super().__init__(None)
 
     def __iter__(self):
         while True:
@@ -423,7 +423,7 @@ class DataLoader(Generic[T_co]):
             raise ValueError('{} attribute should not be set after {} is '
                              'initialized'.format(attr, self.__class__.__name__))
 
-        super(DataLoader, self).__setattr__(attr, val)
+        super().__setattr__(attr, val)
 
     # We quote '_BaseDataLoaderIter' since it isn't defined yet and the definition can't be moved up
     # since '_BaseDataLoaderIter' references 'DataLoader'.
@@ -661,7 +661,7 @@ class _BaseDataLoaderIter:
 
 class _SingleProcessDataLoaderIter(_BaseDataLoaderIter):
     def __init__(self, loader):
-        super(_SingleProcessDataLoaderIter, self).__init__(loader)
+        super().__init__(loader)
         assert self._timeout == 0
         assert self._num_workers == 0
 
@@ -993,7 +993,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
     #     down.
 
     def __init__(self, loader):
-        super(_MultiProcessingDataLoaderIter, self).__init__(loader)
+        super().__init__(loader)
 
         self._prefetch_factor = loader.prefetch_factor
 

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -220,7 +220,7 @@ class ConcatDataset(Dataset[T_co]):
         return r
 
     def __init__(self, datasets: Iterable[Dataset]) -> None:
-        super(ConcatDataset, self).__init__()
+        super().__init__()
         self.datasets = list(datasets)
         assert len(self.datasets) > 0, 'datasets should not be an empty iterable'  # type: ignore[arg-type]
         for d in self.datasets:
@@ -260,7 +260,7 @@ class ChainDataset(IterableDataset):
         datasets (iterable of IterableDataset): datasets to be chained together
     """
     def __init__(self, datasets: Iterable[Dataset]) -> None:
-        super(ChainDataset, self).__init__()
+        super().__init__()
         self.datasets = datasets
 
     def __iter__(self):

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -58,7 +58,7 @@ class InputError(Exception):
     # Exception raised for errors in the input.
 
     def __init__(self, message):
-        super(InputError, self).__init__(message)
+        super().__init__(message)
         self.message = message
 
     def __str__(self):

--- a/torch/utils/mkldnn.py
+++ b/torch/utils/mkldnn.py
@@ -3,7 +3,7 @@ import torch
 
 class MkldnnLinear(torch.jit.ScriptModule):
     def __init__(self, dense_module, dtype):
-        super(MkldnnLinear, self).__init__()
+        super().__init__()
         self.register_buffer('weight', dense_module.weight.to_mkldnn(dtype))
         if dense_module.bias is not None:
             # Bias can be fp32 or bf16 for OneDNN bf16 path, but for good accuracy,
@@ -38,7 +38,7 @@ class _MkldnnConvNd(torch.jit.ScriptModule):
     __constants__ = ['stride', 'padding', 'dilation', 'groups']
 
     def __init__(self, dense_module):
-        super(_MkldnnConvNd, self).__init__()
+        super().__init__()
 
         self.stride = dense_module.stride
         self.padding = dense_module.padding
@@ -73,7 +73,7 @@ class _MkldnnConvNd(torch.jit.ScriptModule):
 
 class MkldnnConv1d(_MkldnnConvNd):
     def __init__(self, dense_module, dtype):
-        super(MkldnnConv1d, self).__init__(dense_module)
+        super().__init__(dense_module)
 
         self.register_buffer('weight', dense_module.weight.to_mkldnn(dtype))
 
@@ -86,7 +86,7 @@ class MkldnnConv1d(_MkldnnConvNd):
 
 class MkldnnConv2d(_MkldnnConvNd):
     def __init__(self, dense_module, dtype):
-        super(MkldnnConv2d, self).__init__(dense_module)
+        super().__init__(dense_module)
 
         self.register_buffer('weight', torch._C._nn.mkldnn_reorder_conv2d_weight(
             dense_module.weight.to_mkldnn(dtype),
@@ -108,7 +108,7 @@ class MkldnnConv2d(_MkldnnConvNd):
 
 class MkldnnConv3d(_MkldnnConvNd):
     def __init__(self, dense_module, dtype):
-        super(MkldnnConv3d, self).__init__(dense_module)
+        super().__init__(dense_module)
 
         self.register_buffer('weight', torch._C._nn.mkldnn_reorder_conv3d_weight(
             dense_module.weight.to_mkldnn(dtype),
@@ -133,7 +133,7 @@ class MkldnnBatchNorm(torch.jit.ScriptModule):
     __constants__ = ['exponential_average_factor', 'eps']
 
     def __init__(self, dense_module):
-        super(MkldnnBatchNorm, self).__init__()
+        super().__init__()
 
         assert(not dense_module.training)
         assert(dense_module.track_running_stats)
@@ -182,7 +182,7 @@ class MkldnnBatchNorm(torch.jit.ScriptModule):
 
 class MkldnnPrelu(torch.jit.ScriptModule):
     def __init__(self, dense_module, dtype):
-        super(MkldnnPrelu, self).__init__()
+        super().__init__()
         self.register_buffer('weight', dense_module.weight.to_mkldnn(dtype))
 
     @torch.jit.script_method

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -64,7 +64,7 @@ class NodeBase:
 
 class NodePy(NodeBase):
     def __init__(self, node_cpp, valid_methods):
-        super(NodePy, self).__init__(node_cpp)
+        super().__init__(node_cpp)
         valid_methods = valid_methods[:]
         self.inputs = []
 
@@ -89,7 +89,7 @@ class NodePy(NodeBase):
 
 class NodePyIO(NodePy):
     def __init__(self, node_cpp, input_or_output=None):
-        super(NodePyIO, self).__init__(node_cpp, methods_IO)
+        super().__init__(node_cpp, methods_IO)
         try:
             tensor_size = node_cpp.type().sizes()
         except RuntimeError:
@@ -109,7 +109,7 @@ class NodePyIO(NodePy):
 
 class NodePyOP(NodePy):
     def __init__(self, node_cpp):
-        super(NodePyOP, self).__init__(node_cpp, methods_OP)
+        super().__init__(node_cpp, methods_OP)
         # Replace single quote which causes strange behavior in TensorBoard
         # TODO: See if we can remove this in the future
         self.attributes = str(


### PR DESCRIPTION
Rewrite Python built-in class `super()` calls. Only non-semantic changes should be applied.

- #94587
- #94588
- #94592

Also, methods with only a `super()` call are removed:

```diff
class MyModule(nn.Module):
-   def __init__(self):
-       super().__init__()
-
    def forward(self, ...):
        ...
```

Some cases that change the semantics should be kept unchanged. E.g.:

https://github.com/pytorch/pytorch/blob/f152a79be9612b824e1672b8f8cb88a414ce4c12/caffe2/python/net_printer.py#L184-L190

https://github.com/pytorch/pytorch/blob/f152a79be9612b824e1672b8f8cb88a414ce4c12/test/test_jit_fuser_te.py#L2628-L2635

cc @ezyang @gchanan @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @mcarilli @ptrblck @leslie-fang-intel @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire @mlazos @yanboliang