### PR TITLE
Issue-88098: extract utils from check labels

### DIFF
--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -9,13 +9,26 @@ from gitutils import (
     GitRepo,
 )
 from trymerge import GitHubPR
+from github_utils import (
+    gh_post_delete_comment,
+    gh_post_pr_comment,
+)
 from label_utils import (
     LABEL_ERR_MSG,
-    add_label_err_comment,
-    delete_all_label_err_comments,
+    is_label_err_comment,
     has_required_labels,
 )
 
+def delete_all_label_err_comments(pr: "GitHubPR") -> None:
+    for comment in pr.get_comments():
+        if is_label_err_comment(comment):
+            gh_post_delete_comment(pr.org, pr.project, comment.database_id)
+
+
+def add_label_err_comment(pr: "GitHubPR") -> None:
+    # Only make a comment if one doesn't exist already
+    if not any(is_label_err_comment(comment) for comment in pr.get_comments()):
+        gh_post_pr_comment(pr.org, pr.project, pr.pr_num, LABEL_ERR_MSG)
 
 def parse_args() -> Any:
     from argparse import ArgumentParser

--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -30,6 +30,7 @@ def add_label_err_comment(pr: "GitHubPR") -> None:
     if not any(is_label_err_comment(comment) for comment in pr.get_comments()):
         gh_post_pr_comment(pr.org, pr.project, pr.pr_num, LABEL_ERR_MSG)
 
+
 def parse_args() -> Any:
     from argparse import ArgumentParser
     parser = ArgumentParser("Check PR labels")

--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check a PR has required labels."""
+"""Check whether a PR has required labels."""
 
 from typing import Any
 

--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -1,64 +1,20 @@
 #!/usr/bin/env python3
-"""check_labels.py"""
+"""Check a PR has required labels."""
 
-from typing import Any, List
+from typing import Any
 
-from label_utils import gh_get_labels
 from gitutils import (
     get_git_remote_name,
     get_git_repo_dir,
     GitRepo,
 )
-from trymerge import (
-    _fetch_url,
-    gh_post_pr_comment,
-    GitHubPR,
+from trymerge import GitHubPR
+from label_utils import (
+    LABEL_ERR_MSG,
+    add_label_err_comment,
+    delete_all_label_err_comments,
+    has_required_labels,
 )
-
-
-BOT_AUTHORS = ["github-actions", "pytorchmergebot", "pytorch-bot"]
-
-ERR_MSG_TITLE = "This PR needs a label"
-ERR_MSG = (
-    f"# {ERR_MSG_TITLE}\n"
-    "If your changes are user facing and intended to be a part of release notes, please use a label starting with `release notes:`.\n\n"  # noqa: E501  pylint: disable=line-too-long
-    "If not, please add the `topic: not user facing` label.\n\n"
-    "For more information, see https://github.com/pytorch/pytorch/wiki/PyTorch-AutoLabel-Bot#why-categorize-for-release-notes-and-how-does-it-work."  # noqa: E501  pylint: disable=line-too-long
-)
-
-
-def get_release_notes_labels(org: str, repo: str) -> List[str]:
-    return [label for label in gh_get_labels(org, repo) if label.lstrip().startswith("release notes:")]
-
-
-def delete_comment(comment_id: int) -> None:
-    url = f"https://api.github.com/repos/pytorch/pytorch/issues/comments/{comment_id}"
-    _fetch_url(url, method="DELETE")
-
-
-def has_required_labels(pr: GitHubPR) -> bool:
-    pr_labels = pr.get_labels()
-    # Check if PR is not user facing
-    is_not_user_facing_pr = any(label.strip() == "topic: not user facing" for label in pr_labels)
-    return (
-        is_not_user_facing_pr or
-        any(label.strip() in get_release_notes_labels(pr.org, pr.project) for label in pr_labels)
-    )
-
-
-def delete_comments(pr: GitHubPR) -> None:
-    # Delete all previous comments
-    for comment in pr.get_comments():
-        if comment.body_text.lstrip(" #").startswith(ERR_MSG_TITLE) and comment.author_login in BOT_AUTHORS:
-            delete_comment(comment.database_id)
-
-
-def add_comment(pr: GitHubPR) -> None:
-    # Only make a comment if one doesn't exist already
-    for comment in pr.get_comments():
-        if comment.body_text.lstrip(" #").startswith(ERR_MSG_TITLE) and comment.author_login in BOT_AUTHORS:
-            return
-    gh_post_pr_comment(pr.org, pr.project, pr.pr_num, ERR_MSG)
 
 
 def parse_args() -> Any:
@@ -77,11 +33,11 @@ def main() -> None:
 
     try:
         if not has_required_labels(pr):
-            print(ERR_MSG)
-            add_comment(pr)
+            print(LABEL_ERR_MSG)
+            add_label_err_comment(pr)
             exit(1)
         else:
-            delete_comments(pr)
+            delete_all_label_err_comments(pr)
     except Exception as e:
         pass
 

--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -10,7 +10,7 @@ from gitutils import (
 )
 from trymerge import GitHubPR
 from github_utils import (
-    gh_post_delete_comment,
+    gh_delete_comment,
     gh_post_pr_comment,
 )
 from label_utils import (
@@ -22,7 +22,7 @@ from label_utils import (
 def delete_all_label_err_comments(pr: "GitHubPR") -> None:
     for comment in pr.get_comments():
         if is_label_err_comment(comment):
-            gh_post_delete_comment(pr.org, pr.project, comment.database_id)
+            gh_delete_comment(pr.org, pr.project, comment.database_id)
 
 
 def add_label_err_comment(pr: "GitHubPR") -> None:

--- a/.github/scripts/comment_on_pr.py
+++ b/.github/scripts/comment_on_pr.py
@@ -1,5 +1,5 @@
 from typing import Any
-from trymerge import gh_post_pr_comment
+from github_utils import gh_post_pr_comment
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from trymerge_explainer import BOT_COMMANDS_WIKI
 import os

--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -63,15 +63,19 @@ def gh_fetch_json_any(
     return gh_fetch_url(url, headers=headers, data=data, reader=json.load)
 
 
-def gh_fetch_json_list(url: str,
-                    params: Optional[Dict[str, Any]] = None,
-                    data: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+def gh_fetch_json_list(
+    url: str,
+    params: Optional[Dict[str, Any]] = None,
+    data: Optional[Dict[str, Any]] = None
+) -> List[Dict[str, Any]]:
     return cast(List[Dict[str, Any]], gh_fetch_json_any(url, params, data))
 
 
-def gh_fetch_json_dict(url: str,
-                    params: Optional[Dict[str, Any]] = None,
-                    data: Optional[Dict[str, Any]] = None) -> Dict[str, Any] :
+def gh_fetch_json_dict(
+    url: str,
+    params: Optional[Dict[str, Any]] = None,
+    data: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any] :
     return cast(Dict[str, Any], gh_fetch_json_any(url, params, data))
 
 
@@ -82,14 +86,14 @@ def _gh_post_comment(url: str, comment: str, dry_run: bool = False) -> List[Dict
     return gh_fetch_json_list(url, data={"body": comment})
 
 
-def gh_post_pr_comment(org: str, project: str, pr_num: int, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
-    return _gh_post_comment(f'https://api.github.com/repos/{org}/{project}/issues/{pr_num}/comments', comment, dry_run)
+def gh_post_pr_comment(org: str, repo: str, pr_num: int, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
+    return _gh_post_comment(f'https://api.github.com/repos/{org}/{repo}/issues/{pr_num}/comments', comment, dry_run)
 
 
-def gh_post_commit_comment(org: str, project: str, sha: str, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
-    return _gh_post_comment(f'https://api.github.com/repos/{org}/{project}/commits/{sha}/comments', comment, dry_run)
+def gh_post_commit_comment(org: str, repo: str, sha: str, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
+    return _gh_post_comment(f'https://api.github.com/repos/{org}/{repo}/commits/{sha}/comments', comment, dry_run)
 
 
-def gh_post_delete_comment(org: str, project: str, comment_id: int) -> None:
-    url = f"https://api.github.com/repos/{org}/{project}/issues/comments/{comment_id}"
+def gh_post_delete_comment(org: str, repo: str, comment_id: int) -> None:
+    url = f"https://api.github.com/repos/{org}/{repo}/issues/comments/{comment_id}"
     gh_fetch_url(url, method="DELETE")

--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -1,0 +1,95 @@
+"""GitHub Utilities"""
+
+import json
+import os
+
+from dataclasses import dataclass
+from typing import Any, Callable, cast, Dict, List, Optional
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+@dataclass
+class GitHubComment:
+    body_text: str
+    created_at: str
+    author_login: str
+    author_association: str
+    editor_login: Optional[str]
+    database_id: int
+
+
+def gh_fetch_url(
+    url: str, *,
+    headers: Optional[Dict[str, str]] = None,
+    data: Optional[Dict[str, Any]] = None,
+    method: Optional[str] = None,
+    reader: Callable[[Any], Any] = lambda x: x.read()
+) -> Any:
+    if headers is None:
+        headers = {}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token is not None and url.startswith('https://api.github.com/'):
+        headers['Authorization'] = f'token {token}'
+    data_ = json.dumps(data).encode() if data is not None else None
+    try:
+        with urlopen(Request(url, headers=headers, data=data_, method=method)) as conn:
+            return reader(conn)
+    except HTTPError as err:
+        if err.code == 403 and all(key in err.headers for key in ['X-RateLimit-Limit', 'X-RateLimit-Used']):
+            print(f"Rate limit exceeded: {err.headers['X-RateLimit-Used']}/{err.headers['X-RateLimit-Limit']}")
+        raise
+
+
+def gh_fetch_json(
+    url: str,
+    params: Optional[Dict[str, Any]] = None,
+    data: Optional[Dict[str, Any]] = None
+) -> List[Dict[str, Any]]:
+    headers = {'Accept': 'application/vnd.github.v3+json'}
+    if params is not None and len(params) > 0:
+        url += '?' + '&'.join(f"{name}={quote(str(val))}" for name, val in params.items())
+    return cast(List[Dict[str, Any]], gh_fetch_url(url, headers=headers, data=data, reader=json.load))
+
+def gh_fetch_json_any(
+    url: str,
+    params: Optional[Dict[str, Any]] = None,
+    data: Optional[Dict[str, Any]] = None
+) -> Any:
+    headers = {'Accept': 'application/vnd.github.v3+json'}
+    if params is not None and len(params) > 0:
+        url += '?' + '&'.join(f"{name}={quote(str(val))}" for name, val in params.items())
+    return gh_fetch_url(url, headers=headers, data=data, reader=json.load)
+
+
+def gh_fetch_json_list(url: str,
+                    params: Optional[Dict[str, Any]] = None,
+                    data: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    return cast(List[Dict[str, Any]], gh_fetch_json_any(url, params, data))
+
+
+def gh_fetch_json_dict(url: str,
+                    params: Optional[Dict[str, Any]] = None,
+                    data: Optional[Dict[str, Any]] = None) -> Dict[str, Any] :
+    return cast(Dict[str, Any], gh_fetch_json_any(url, params, data))
+
+
+def _gh_post_comment(url: str, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
+    if dry_run:
+        print(comment)
+        return []
+    return gh_fetch_json_list(url, data={"body": comment})
+
+
+def gh_post_pr_comment(org: str, project: str, pr_num: int, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
+    return _gh_post_comment(f'https://api.github.com/repos/{org}/{project}/issues/{pr_num}/comments', comment, dry_run)
+
+
+def gh_post_commit_comment(org: str, project: str, sha: str, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
+    return _gh_post_comment(f'https://api.github.com/repos/{org}/{project}/commits/{sha}/comments', comment, dry_run)
+
+
+def gh_post_delete_comment(org: str, project: str, comment_id: int) -> None:
+    url = f"https://api.github.com/repos/{org}/{project}/issues/comments/{comment_id}"
+    gh_fetch_url(url, method="DELETE")

--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -52,7 +52,7 @@ def gh_fetch_json(
         url += '?' + '&'.join(f"{name}={quote(str(val))}" for name, val in params.items())
     return cast(List[Dict[str, Any]], gh_fetch_url(url, headers=headers, data=data, reader=json.load))
 
-def gh_fetch_json_any(
+def _gh_fetch_json_any(
     url: str,
     params: Optional[Dict[str, Any]] = None,
     data: Optional[Dict[str, Any]] = None
@@ -68,7 +68,7 @@ def gh_fetch_json_list(
     params: Optional[Dict[str, Any]] = None,
     data: Optional[Dict[str, Any]] = None
 ) -> List[Dict[str, Any]]:
-    return cast(List[Dict[str, Any]], gh_fetch_json_any(url, params, data))
+    return cast(List[Dict[str, Any]], _gh_fetch_json_any(url, params, data))
 
 
 def gh_fetch_json_dict(
@@ -76,7 +76,7 @@ def gh_fetch_json_dict(
     params: Optional[Dict[str, Any]] = None,
     data: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Any] :
-    return cast(Dict[str, Any], gh_fetch_json_any(url, params, data))
+    return cast(Dict[str, Any], _gh_fetch_json_any(url, params, data))
 
 
 def _gh_post_comment(url: str, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
@@ -94,6 +94,6 @@ def gh_post_commit_comment(org: str, repo: str, sha: str, comment: str, dry_run:
     return _gh_post_comment(f'https://api.github.com/repos/{org}/{repo}/commits/{sha}/comments', comment, dry_run)
 
 
-def gh_post_delete_comment(org: str, repo: str, comment_id: int) -> None:
+def gh_delete_comment(org: str, repo: str, comment_id: int) -> None:
     url = f"https://api.github.com/repos/{org}/{repo}/issues/comments/{comment_id}"
     gh_fetch_url(url, method="DELETE")

--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -69,9 +69,9 @@ def gh_get_labels(org: str, repo: str) -> List[str]:
     return labels
 
 
-def gh_add_labels(org: str, project: str, pr_num: int, labels: Union[str, List[str]]) -> None:
+def gh_add_labels(org: str, repo: str, pr_num: int, labels: Union[str, List[str]]) -> None:
     gh_fetch_json(
-        f'https://api.github.com/repos/{org}/{project}/issues/{pr_num}/labels',
+        f'https://api.github.com/repos/{org}/{repo}/issues/{pr_num}/labels',
         data={"labels": labels},
     )
 

--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -9,8 +9,6 @@ from urllib.request import urlopen, Request
 from github_utils import (
     GitHubComment,
     gh_fetch_json,
-    gh_post_delete_comment,
-    gh_post_pr_comment,
 )
 
 # TODO: this is a temp workaround to avoid circular dependencies,
@@ -94,15 +92,3 @@ def has_required_labels(pr: "GitHubPR") -> bool:
 
 def is_label_err_comment(comment: GitHubComment) -> bool:
     return comment.body_text.lstrip(" #").startswith(LABEL_ERR_MSG_TITLE) and comment.author_login in BOT_AUTHORS
-
-
-def delete_all_label_err_comments(pr: "GitHubPR") -> None:
-    for comment in pr.get_comments():
-        if is_label_err_comment(comment):
-            gh_post_delete_comment(pr.org, pr.project, comment.database_id)
-
-
-def add_label_err_comment(pr: "GitHubPR") -> None:
-    # Only make a comment if one doesn't exist already
-    if not any(is_label_err_comment(comment) for comment in pr.get_comments()):
-        gh_post_pr_comment(pr.org, pr.project, pr.pr_num, LABEL_ERR_MSG)

--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -19,9 +19,8 @@ if TYPE_CHECKING:
 BOT_AUTHORS = ["github-actions", "pytorchmergebot", "pytorch-bot"]
 
 LABEL_ERR_MSG_TITLE = "This PR needs a label"
-LABEL_ERR_MSG = f"""# {LABEL_ERR_MSG_TITLE}\n
+LABEL_ERR_MSG = f"""# {LABEL_ERR_MSG_TITLE}
     If your changes are user facing and intended to be a part of release notes, please use a label starting with `release notes:`.
-
 
     If not, please add the `topic: not user facing` label.
     For more information, see

--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -3,8 +3,32 @@
 import json
 
 from functools import lru_cache
-from typing import List, Any, Tuple
+from typing import List, Any, Tuple, TYPE_CHECKING, Union
 from urllib.request import urlopen, Request
+
+from github_utils import (
+    GitHubComment,
+    gh_fetch_json,
+    gh_post_delete_comment,
+    gh_post_pr_comment,
+)
+
+# TODO: this is a temp workaround to avoid circular dependencies,
+#       and should be removed once GitHubPR is refactored out of trymerge script.
+if TYPE_CHECKING:
+    from trymerge import GitHubPR
+
+BOT_AUTHORS = ["github-actions", "pytorchmergebot", "pytorch-bot"]
+
+LABEL_ERR_MSG_TITLE = "This PR needs a label"
+LABEL_ERR_MSG = f"""# {LABEL_ERR_MSG_TITLE}\n
+    If your changes are user facing and intended to be a part of release notes, please use a label starting with `release notes:`.
+
+
+    If not, please add the `topic: not user facing` label.
+    For more information, see
+    https://github.com/pytorch/pytorch/wiki/PyTorch-AutoLabel-Bot#why-categorize-for-release-notes-and-how-does-it-work.
+"""
 
 # Modified from https://github.com/pytorch/pytorch/blob/b00206d4737d1f1e7a442c9f8a1cadccd272a386/torch/hub.py#L129
 def _read_url(url: Request) -> Tuple[Any, Any]:
@@ -45,3 +69,40 @@ def gh_get_labels(org: str, repo: str) -> List[str]:
         update_labels(labels, info)
 
     return labels
+
+
+def gh_add_labels(org: str, project: str, pr_num: int, labels: Union[str, List[str]]) -> None:
+    gh_fetch_json(
+        f'https://api.github.com/repos/{org}/{project}/issues/{pr_num}/labels',
+        data={"labels": labels},
+    )
+
+
+def get_release_notes_labels(org: str, repo: str) -> List[str]:
+    return [label for label in gh_get_labels(org, repo) if label.lstrip().startswith("release notes:")]
+
+
+def has_required_labels(pr: "GitHubPR") -> bool:
+    pr_labels = pr.get_labels()
+    # Check if PR is not user facing
+    is_not_user_facing_pr = any(label.strip() == "topic: not user facing" for label in pr_labels)
+    return (
+        is_not_user_facing_pr or
+        any(label.strip() in get_release_notes_labels(pr.org, pr.project) for label in pr_labels)
+    )
+
+
+def is_label_err_comment(comment: GitHubComment) -> bool:
+    return comment.body_text.lstrip(" #").startswith(LABEL_ERR_MSG_TITLE) and comment.author_login in BOT_AUTHORS
+
+
+def delete_all_label_err_comments(pr: "GitHubPR") -> None:
+    for comment in pr.get_comments():
+        if is_label_err_comment(comment):
+            gh_post_delete_comment(pr.org, pr.project, comment.database_id)
+
+
+def add_label_err_comment(pr: "GitHubPR") -> None:
+    # Only make a comment if one doesn't exist already
+    if not any(is_label_err_comment(comment) for comment in pr.get_comments()):
+        gh_post_pr_comment(pr.org, pr.project, pr.pr_num, LABEL_ERR_MSG)

--- a/.github/scripts/test_check_labels.py
+++ b/.github/scripts/test_check_labels.py
@@ -1,16 +1,17 @@
 """test_check_labels.py"""
 
-from typing import Any, TYPE_CHECKING
+from typing import Any, List
 from unittest import TestCase, mock, main
 
-from check_labels import main as check_labels_main
-from label_utils import LABEL_ERR_MSG
-from test_trymerge import mock_gh_get_info
-
-# TODO: this is a temp workaround to avoid circular dependencies,
-#       and should be removed once GitHubPR is refactored out of trymerge script.
-if TYPE_CHECKING:
-    from trymerge import GitHubPR
+from check_labels import (
+    main as check_labels_main,
+    add_label_err_comment,
+    delete_all_label_err_comments,
+)
+from github_utils import GitHubComment
+from label_utils import BOT_AUTHORS, LABEL_ERR_MSG, LABEL_ERR_MSG_TITLE
+from test_trymerge import mocked_gh_graphql, mock_gh_get_info
+from trymerge import GitHubPR
 
 def mock_parse_args() -> object:
     class Object(object):
@@ -24,8 +25,63 @@ def mock_add_label_err_comment(pr: "GitHubPR") -> None:
 def mock_delete_all_label_err_comments(pr: "GitHubPR") -> None:
     pass
 
+def mock_get_comments() -> List[GitHubComment]:
+    return [
+        # Case 1 - a non label err comment
+        GitHubComment(
+            body_text="mock_body_text",
+            created_at="",
+            author_login="",
+            author_association="",
+            editor_login=None,
+            database_id=1,
+        ),
+        # Case 2 - a label err comment
+        GitHubComment(
+            body_text=" #" + LABEL_ERR_MSG_TITLE,
+            created_at="",
+            author_login=BOT_AUTHORS[1],
+            author_association="",
+            editor_login=None,
+            database_id=2,
+        ),
+    ]
+
 
 class TestCheckLabels(TestCase):
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    @mock.patch('trymerge.GitHubPR.get_comments', return_value=[mock_get_comments()[0]])
+    @mock.patch('check_labels.gh_post_pr_comment')
+    def test_correctly_add_label_err_comment(
+        self, mock_gh_post_pr_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
+    ) -> None:
+        "Test add label err comment when similar comments don't exist."
+        pr = GitHubPR("pytorch", "pytorch", 75095)
+        add_label_err_comment(pr)
+        mock_gh_post_pr_comment.assert_called_once()
+
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    @mock.patch('trymerge.GitHubPR.get_comments', return_value=[mock_get_comments()[1]])
+    @mock.patch('check_labels.gh_post_pr_comment')
+    def test_not_add_label_err_comment(
+        self, mock_gh_post_pr_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
+    ) -> None:
+        "Test not add label err comment when similar comments exist."
+        pr = GitHubPR("pytorch", "pytorch", 75095)
+        add_label_err_comment(pr)
+        mock_gh_post_pr_comment.assert_not_called()
+
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    @mock.patch('trymerge.GitHubPR.get_comments', return_value=mock_get_comments())
+    @mock.patch('check_labels.gh_post_delete_comment')
+    def test_correctly_delete_all_label_err_comments(
+        self, mock_gh_post_delete_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
+    ) -> None:
+        "Test only delete label err comment."
+        pr = GitHubPR("pytorch", "pytorch", 75095)
+        delete_all_label_err_comments(pr)
+        mock_gh_post_delete_comment.assert_called_once_with("pytorch", "pytorch", 2)
+
     @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
     @mock.patch('check_labels.parse_args', return_value=mock_parse_args())
     @mock.patch('check_labels.has_required_labels', return_value=False)

--- a/.github/scripts/test_check_labels.py
+++ b/.github/scripts/test_check_labels.py
@@ -73,14 +73,14 @@ class TestCheckLabels(TestCase):
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
     @mock.patch('trymerge.GitHubPR.get_comments', return_value=mock_get_comments())
-    @mock.patch('check_labels.gh_post_delete_comment')
+    @mock.patch('check_labels.gh_delete_comment')
     def test_correctly_delete_all_label_err_comments(
-        self, mock_gh_post_delete_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
+        self, mock_gh_delete_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
     ) -> None:
         "Test only delete label err comment."
         pr = GitHubPR("pytorch", "pytorch", 75095)
         delete_all_label_err_comments(pr)
-        mock_gh_post_delete_comment.assert_called_once_with("pytorch", "pytorch", 2)
+        mock_gh_delete_comment.assert_called_once_with("pytorch", "pytorch", 2)
 
     @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
     @mock.patch('check_labels.parse_args', return_value=mock_parse_args())

--- a/.github/scripts/test_check_labels.py
+++ b/.github/scripts/test_check_labels.py
@@ -1,77 +1,66 @@
 """test_check_labels.py"""
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from unittest import TestCase, mock, main
 
-from trymerge import GitHubPR
-from test_trymerge import mocked_gh_graphql
-from check_labels import has_required_labels
+from check_labels import main as check_labels_main
+from label_utils import LABEL_ERR_MSG
+from test_trymerge import mock_gh_get_info
 
-release_notes_labels = [
-    "release notes: AO frontend",
-    "release notes: autograd",
-    "release notes: benchmark",
-    "release notes: build",
-    "release notes: complex",
-    "release notes: composability",
-    "release notes: cpp",
-    "release notes: cuda",
-    "release notes: cudnn",
-    "release notes: dataloader",
-    "release notes: distributed (c10d)",
-    "release notes: distributed (ddp)",
-    "release notes: distributed (fsdp)",
-    "release notes: distributed (pipeline)",
-    "release notes: distributed (rpc)",
-    "release notes: distributed (sharded)",
-    "release notes: foreach_frontend",
-    "release notes: functorch",
-    "release notes: fx",
-    "release notes: hub",
-    "release notes: jit",
-    "release notes: lazy",
-    "release notes: linalg_frontend",
-    "release notes: memory format",
-    "release notes: Meta API",
-    "release notes: mobile",
-    "release notes: mps",
-    "release notes: nested tensor",
-    "release notes: nn",
-    "release notes: onnx",
-    "release notes: package/deploy",
-    "release notes: performance_as_product",
-    "release notes: profiler",
-    "release notes: python_frontend",
-    "release notes: quantization",
-    "release notes: releng",
-    "release notes: rocm",
-    "release notes: sparse",
-    "release notes: visualization",
-    "release notes: vulkan",
-]
+# TODO: this is a temp workaround to avoid circular dependencies,
+#       and should be removed once GitHubPR is refactored out of trymerge script.
+if TYPE_CHECKING:
+    from trymerge import GitHubPR
+
+def mock_parse_args() -> object:
+    class Object(object):
+        def __init__(self) -> None:
+            self.pr_num = 76123
+    return Object()
+
+def mock_add_label_err_comment(pr: "GitHubPR") -> None:
+    pass
+
+def mock_delete_all_label_err_comments(pr: "GitHubPR") -> None:
+    pass
 
 
 class TestCheckLabels(TestCase):
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('check_labels.get_release_notes_labels', return_value=release_notes_labels)
-    def test_pr_with_missing_labels(self, mocked_rn_labels: Any, mocked_gql: Any) -> None:
-        "Test PR with no 'release notes:' label or 'topic: not user facing' label"
-        pr = GitHubPR("pytorch", "pytorch", 82169)
-        self.assertFalse(has_required_labels(pr))
+    @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
+    @mock.patch('check_labels.parse_args', return_value=mock_parse_args())
+    @mock.patch('check_labels.has_required_labels', return_value=False)
+    @mock.patch('check_labels.delete_all_label_err_comments', side_effect=mock_delete_all_label_err_comments)
+    @mock.patch('check_labels.add_label_err_comment', side_effect=mock_add_label_err_comment)
+    def test_ci_fails_without_required_labels(
+        self,
+        mock_add_label_err_comment: Any,
+        mock_delete_all_label_err_comments: Any,
+        mock_has_required_labels: Any,
+        mock_parse_args: Any,
+        mock_gh_get_info: Any,
+    ) -> None:
+        with self.assertRaises(SystemExit) as err:
+            check_labels_main()
+            self.assertEqual(err.exception, LABEL_ERR_MSG)
+            mock_add_label_err_comment.assert_called_once()
+            mock_delete_all_label_err_comments.assert_not_called()
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('check_labels.get_release_notes_labels', return_value=release_notes_labels)
-    def test_pr_with_release_notes_label(self, mocked_rn_labels: Any, mocked_gql: Any) -> None:
-        "Test PR with 'release notes: nn' label"
-        pr = GitHubPR("pytorch", "pytorch", 71759)
-        self.assertTrue(has_required_labels(pr))
-
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('check_labels.get_release_notes_labels', return_value=release_notes_labels)
-    def test_pr_with_not_user_facing_label(self, mocked_rn_labels: Any, mocked_gql: Any) -> None:
-        "Test PR with 'topic: not user facing' label"
-        pr = GitHubPR("pytorch", "pytorch", 75095)
-        self.assertTrue(has_required_labels(pr))
+    @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
+    @mock.patch('check_labels.parse_args', return_value=mock_parse_args())
+    @mock.patch('check_labels.has_required_labels', return_value=True)
+    @mock.patch('check_labels.delete_all_label_err_comments', side_effect=mock_delete_all_label_err_comments)
+    @mock.patch('check_labels.add_label_err_comment', side_effect=mock_add_label_err_comment)
+    def test_ci_success_with_required_labels(
+        self,
+        mock_add_label_err_comment: Any,
+        mock_delete_all_label_err_comments: Any,
+        mock_has_required_labels: Any,
+        mock_parse_args: Any,
+        mock_gh_get_info: Any,
+    ) -> None:
+        check_labels_main()
+        mock_add_label_err_comment.assert_not_called()
+        mock_delete_all_label_err_comments.assert_called_once()
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_label_utils.py
+++ b/.github/scripts/test_label_utils.py
@@ -1,12 +1,7 @@
-from typing import Any, List
+from typing import Any
 from unittest import TestCase, mock, main
 
-from github_utils import GitHubComment
 from label_utils import (
-    BOT_AUTHORS,
-    LABEL_ERR_MSG_TITLE,
-    add_label_err_comment,
-    delete_all_label_err_comments,
     get_last_page_num_from_header,
     gh_get_labels,
     has_required_labels,
@@ -18,28 +13,6 @@ from test_trymerge import mocked_gh_graphql
 release_notes_labels = [
     "release notes: nn",
 ]
-
-def mock_get_comments() -> List[GitHubComment]:
-    return [
-        # Case 1 - a non label err comment
-        GitHubComment(
-            body_text="mock_body_text",
-            created_at="",
-            author_login="",
-            author_association="",
-            editor_login=None,
-            database_id=1,
-        ),
-        # Case 2 - a label err comment
-        GitHubComment(
-            body_text=" #" + LABEL_ERR_MSG_TITLE,
-            created_at="",
-            author_login=BOT_AUTHORS[1],
-            author_association="",
-            editor_login=None,
-            database_id=2,
-        ),
-    ]
 
 class TestLabelUtils(TestCase):
     MOCK_HEADER_LINKS_TO_PAGE_NUMS = {
@@ -96,39 +69,6 @@ class TestLabelUtils(TestCase):
         "Test PR with 'topic: not user facing' label"
         pr = GitHubPR("pytorch", "pytorch", 75095)
         self.assertTrue(has_required_labels(pr))
-
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('trymerge.GitHubPR.get_comments', return_value=[mock_get_comments()[0]])
-    @mock.patch('label_utils.gh_post_pr_comment')
-    def test_correctly_add_label_err_comment(
-        self, mock_gh_post_pr_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
-    ) -> None:
-        "Test add label err comment when similar comments don't exist."
-        pr = GitHubPR("pytorch", "pytorch", 75095)
-        add_label_err_comment(pr)
-        mock_gh_post_pr_comment.assert_called_once()
-
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('trymerge.GitHubPR.get_comments', return_value=[mock_get_comments()[1]])
-    @mock.patch('label_utils.gh_post_pr_comment')
-    def test_not_add_label_err_comment(
-        self, mock_gh_post_pr_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
-    ) -> None:
-        "Test not add label err comment when similar comments exist."
-        pr = GitHubPR("pytorch", "pytorch", 75095)
-        add_label_err_comment(pr)
-        mock_gh_post_pr_comment.assert_not_called()
-
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('trymerge.GitHubPR.get_comments', return_value=mock_get_comments())
-    @mock.patch('label_utils.gh_post_delete_comment')
-    def test_correctly_delete_all_label_err_comments(
-        self, mock_gh_post_delete_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
-    ) -> None:
-        "Test only delete label err comment."
-        pr = GitHubPR("pytorch", "pytorch", 75095)
-        delete_all_label_err_comments(pr)
-        mock_gh_post_delete_comment.assert_called_once_with("pytorch", "pytorch", 2)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -18,11 +18,8 @@ from typing import (
     Optional,
     Pattern,
     Tuple,
-    Union,
     cast,
 )
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
 from warnings import warn
 from pathlib import Path
 
@@ -33,6 +30,14 @@ from gitutils import (
     get_git_repo_dir,
     patterns_to_regex,
 )
+from github_utils import (
+    GitHubComment,
+    gh_fetch_json_list,
+    gh_fetch_url,
+    gh_post_commit_comment,
+    gh_post_pr_comment,
+)
+from label_utils import gh_add_labels
 from trymerge_explainer import (
     TryMergeExplainer,
     get_revert_message,
@@ -440,67 +445,8 @@ CIFLOW_TRUNK_LABEL = re.compile(r"^ciflow/trunk")
 MERGE_RULE_PATH = Path(".github") / "merge_rules.yaml"
 
 
-def _fetch_url(url: str, *,
-               headers: Optional[Dict[str, str]] = None,
-               data: Optional[Dict[str, Any]] = None,
-               method: Optional[str] = None,
-               reader: Callable[[Any], Any] = lambda x: x.read()) -> Any:
-    if headers is None:
-        headers = {}
-    token = os.environ.get("GITHUB_TOKEN")
-    if token is not None and url.startswith('https://api.github.com/'):
-        headers['Authorization'] = f'token {token}'
-    data_ = json.dumps(data).encode() if data is not None else None
-    try:
-        with urlopen(Request(url, headers=headers, data=data_, method=method)) as conn:
-            return reader(conn)
-    except HTTPError as err:
-        if err.code == 403 and all(key in err.headers for key in ['X-RateLimit-Limit', 'X-RateLimit-Used']):
-            print(f"Rate limit exceeded: {err.headers['X-RateLimit-Used']}/{err.headers['X-RateLimit-Limit']}")
-        raise
-
-def _fetch_json_any(
-    url: str,
-    params: Optional[Dict[str, Any]] = None,
-    data: Optional[Dict[str, Any]] = None
-) -> Any:
-    headers = {'Accept': 'application/vnd.github.v3+json'}
-    if params is not None and len(params) > 0:
-        url += '?' + '&'.join(f"{name}={urllib.parse.quote(str(val))}" for name, val in params.items())
-    return _fetch_url(url, headers=headers, data=data, reader=json.load)
-
-def fetch_json_list(url: str,
-                    params: Optional[Dict[str, Any]] = None,
-                    data: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
-    return cast(List[Dict[str, Any]], _fetch_json_any(url, params, data))
-
-def fetch_json_dict(url: str,
-                    params: Optional[Dict[str, Any]] = None,
-                    data: Optional[Dict[str, Any]] = None) -> Dict[str, Any] :
-    return cast(Dict[str, Any], _fetch_json_any(url, params, data))
-
-def _gh_post_comment(url: str, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
-    if dry_run:
-        print(comment)
-        return []
-    return fetch_json_list(url, data={"body": comment})
-
-
-def gh_post_pr_comment(org: str, project: str, pr_num: int, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
-    return _gh_post_comment(f'https://api.github.com/repos/{org}/{project}/issues/{pr_num}/comments', comment, dry_run)
-
-
-def gh_post_commit_comment(org: str, project: str, sha: str, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
-    return _gh_post_comment(f'https://api.github.com/repos/{org}/{project}/commits/{sha}/comments', comment, dry_run)
-
-
-def gh_add_labels(org: str, project: str, pr_num: int, labels: Union[str, List[str]]) -> None:
-    fetch_json_list(f'https://api.github.com/repos/{org}/{project}/issues/{pr_num}/labels',
-                    data={"labels": labels})
-
-
 def gh_graphql(query: str, **kwargs: Any) -> Dict[str, Any]:
-    rc = _fetch_url("https://api.github.com/graphql", data={"query": query, "variables": kwargs}, reader=json.load)
+    rc = gh_fetch_url("https://api.github.com/graphql", data={"query": query, "variables": kwargs}, reader=json.load)
     if "errors" in rc:
         raise RuntimeError(f"GraphQL query {query}, args {kwargs} failed: {rc['errors']}")
     return cast(Dict[str, Any], rc)
@@ -676,15 +622,6 @@ def get_ghstack_prs(repo: GitRepo, pr: "GitHubPR") -> List[Tuple["GitHubPR", str
                 f"Please sync them and try again (ex. make the changes on {orig_ref} and run ghstack)."
             )
     return entire_stack
-
-@dataclass
-class GitHubComment:
-    body_text: str
-    created_at: str
-    author_login: str
-    author_association: str
-    editor_login: Optional[str]
-    database_id: int
 
 
 class GitHubPR:
@@ -1139,7 +1076,7 @@ def gen_new_issue_link(
 def read_merge_rules(repo: Optional[GitRepo], org: str, project: str) -> List[MergeRule]:
     repo_relative_rules_path = MERGE_RULE_PATH
     if repo is None:
-        json_data = _fetch_url(
+        json_data = gh_fetch_url(
             f"https://api.github.com/repos/{org}/{project}/contents/{repo_relative_rules_path}",
             headers={'Accept': 'application/vnd.github.v3+json'},
             reader=json.load,
@@ -1324,7 +1261,7 @@ def checks_to_markdown_bullets(checks: List[Tuple[str, Optional[str]]]) -> List[
 
 def _get_flaky_rules(url: str, num_retries: int = 3) -> List[FlakyRule]:
     try:
-        return [FlakyRule(**rule) for rule in fetch_json_list(url)]
+        return [FlakyRule(**rule) for rule in gh_fetch_json_list(url)]
     except Exception as e:
         print(f"Could not download {url} because: {e}.")
         if num_retries > 0:
@@ -1509,7 +1446,7 @@ def check_for_sev(org: str, project: str, skip_mandatory_checks: bool) -> None:
         return
     response = cast(
         Dict[str, Any],
-        fetch_json_list(
+        gh_fetch_json_list(
             "https://api.github.com/search/issues",
             params={"q": f'repo:{org}/{project} is:open is:issue label:"ci: sev"'},
         ),

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -6,7 +6,8 @@ import sys
 import re
 from typing import Any
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
-from trymerge import gh_post_pr_comment as gh_post_comment, GitHubPR
+from github_utils import gh_post_pr_comment as gh_post_comment
+from trymerge import GitHubPR
 
 SAME_SHA_ERROR = (
     "\n```\nAborting rebase because rebasing the branch resulted in the same sha as the target branch.\n" +


### PR DESCRIPTION
Fixes #88098 

This is a mirror of the same PR (https://github.com/Goldspear/pytorch/pull/2) that has been reviewed in my fork (due to it's a stacked PR).

======================
## Context

This is the 2nd of the 3 PRs to address issue-88098.

## What Changed
1. Extract comment related utils from trymerge.py to github_utils.py
2. Extract label related utils from trymerge.py and check_labels.py to label_utils.py

## Tests
* pytorch-dummy repo [trymerge run ](https://github.com/Goldspear/pytorch-dummy/actions/runs/4118944174)merged the test PR [OK](https://github.com/Goldspear/pytorch-dummy/pull/2).

## Note to Reviewers
Due to higher degree of complexity involved to extract GitHubPR class, it's worth having a separate issue to handle that part of refactoring. This issue only focusing on refactoring where necessary to ship the functional diff.

* 1st PR: https://github.com/pytorch/pytorch/pull/94179
* 2nd PR: this one
* 3rd PR: https://github.com/Goldspear/pytorch/pull/3
