### PR TITLE
Run test_serialization serially (for 2xlarge runners)

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,4 +441,4 @@ Note: This project is unrelated to [hughperkins/pytorch](https://github.com/hugh
 
 ## License
 
-PyTorch has a BSD-style license, as found in the [LICENSE](LICENSE) file.
+PyTorch has a BSD-style license, as found in the [LICENSE](LICENSE) filename.

--- a/README.md
+++ b/README.md
@@ -441,4 +441,4 @@ Note: This project is unrelated to [hughperkins/pytorch](https://github.com/hugh
 
 ## License
 
-PyTorch has a BSD-style license, as found in the [LICENSE](LICENSE) filename.
+PyTorch has a BSD-style license, as found in the [LICENSE](LICENSE) file.

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -319,6 +319,7 @@ CI_SERIAL_LIST = [
     'functorch/test_vmap',  # OOM
     'test_fx',  # gets SIGKILL
     'test_dataloader',  # frequently hangs for ROCm
+    'test_serialization',   # test_serialization_2gb_file allocates a tensor of 2GB, and could cause OOM
 ]
 
 # A subset of our TEST list that validates PyTorch's ops, modules, and autograd function as expected

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -905,6 +905,8 @@ class TestSerialization(TestCase, SerializationMixin):
 
     # Ensure large zip64 serialization works properly
     def test_serialization_2gb_file(self):
+        # Run GC to clear up as much memory as possible before running this test
+        gc.collect()
         big_model = torch.nn.Conv2d(20000, 3200, kernel_size=3)
 
         with BytesIOContext() as f:

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -5,6 +5,7 @@ import unittest
 import io
 import tempfile
 import os
+import gc
 import sys
 import zipfile
 import warnings


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/92746