### PR TITLE
[jit][await] awaitable_arg

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -325,6 +325,15 @@ RegisterOperators reg({
         },
         aliasAnalysisSpecialCase()),
     Operator(
+        "aten::awaitable_arg(Await(t) self, int idx) -> Any",
+        [](Stack& stack) {
+          auto idx = pop(stack).toInt();
+          auto aw = stack.back().toAwait();
+          stack.pop_back();
+          stack.emplace_back(aw->args()[idx]);
+        },
+        aliasAnalysisFromSchema()),
+    Operator(
         "prim::awaitable_nowait(t self) -> Await(t)",
         [](Stack& stack) {
           auto aw =


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94623

```
 python3.8 test/test_jit.py TestAwait
```
```
======================================================================
ERROR: test_arg (jit.test_await.TestAwait)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ivankobzarev/github/pytorch/test/jit/test_await.py", line 406, in test_arg
    out = fn(inp)
  File "/home/ivankobzarev/github/pytorch/test/jit/test_await.py", line 395, in fn
    arg_any = torch.ops.aten.awaitable_arg(aw, 1)
  File "/home/ivankobzarev/github/pytorch/torch/_ops.py", line 499, in __call__
    return self._op(*args, **kwargs or {})
TypeError: no implementation found for 'torch.opsaten.awaitable_arg' on types that implement __torch_function__: [<class 'torch._C._Await'>]

----------------------------------------------------------------------
```
