### PR TITLE
Convert operator.not_ to torch.logical_not

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -103,6 +103,23 @@ class ExportTests(torch._dynamo.test_case.TestCase):
 
         self.assertTrue(hit)
 
+    @config.patch(dynamic_shapes=True)
+    def test_export_tensor_bool_not(self):
+        def true_fn(x, y):
+            return x + y
+
+        def false_fn(x, y):
+            return x - y
+
+        def f(x, y):
+            return cond(not torch.any(x), true_fn, false_fn, [x, y])
+
+        input = (torch.zeros(1), torch.ones(1))
+        resA = f(*input)
+        graph, _ = torch._dynamo.export(f, *input)
+        resB = graph(*input)
+        self.assertTrue(torch._dynamo.utils.same(resA, resB))
+
     def test_export_control_flow_with_getattr(self):
         class Animal(Enum):
             COW = "moo"

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -104,7 +104,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(hit)
 
     @config.patch(dynamic_shapes=True)
-    def test_export_tensor_bool_not(self):
+    def test_export_not_tensor(self):
         def true_fn(x, y):
             return x + y
 

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -8,6 +8,7 @@ import torch
 
 import torch._dynamo.test_case
 import torch._dynamo.testing
+from functorch.experimental.control_flow import cond
 from torch._dynamo.testing import same
 
 try:
@@ -238,6 +239,26 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
             ref = fn(x, y)
             res = opt_fn(x, y)
             self.assertTrue(same(ref, res))
+
+    def test_unspec_control_flow(self):
+        def true_fn(x, y):
+            return x + y
+
+        def false_fn(x, y):
+            return x - y
+
+        def fn(x, y, z):
+            z, x = z + 1, max(x, y)
+            return cond(torch.tensor(not x), true_fn, false_fn, [x, z])
+
+        x = np.int64(12)
+        y = 10
+        z = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float64)
+        res1 = fn(x, y, z)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts)(fn)
+        res2 = opt_fn(x, y, z)
+        self.assertTrue(same(res1, res2, relax_numpy_equality=True))
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -473,6 +473,9 @@ class BuiltinVariable(VariableTracker):
                     # Work around weird bug in hf_T5
                     fn, args = operator.add, [args[1], args[0]]
 
+                if self.fn is operator.not_:
+                    fn = torch.logical_not
+
                 proxy = tx.output.create_proxy(
                     "call_function",
                     fn,


### PR DESCRIPTION
If the input to operator.not_ is a tensor, I want to convert the operator to a torch.logical_not. This allows the following test case to pass. Beforehand it resulted in the error `NotImplementedError("local_scalar_dense/item NYI for torch.bool")`

```
    def test_export_tensor_bool_not(self):
        def true_fn(x, y):
            return x + y

        def false_fn(x, y):
            return x - y

        def f(x, y):
            return cond(not torch.any(x), true_fn, false_fn, [x, y])
```

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire