### PR TITLE
[MPS] Fix the regression with test_index_select_scalar()

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5276,7 +5276,6 @@ class TestNLLLoss(TestCase):
 
             self.assertEqual(idx_result, idx_result_cpu)
 
-        helper(0.5, 0, [0, 0])
         helper(22, 0, [])
 
     def test_embedding_dense_backward(self):


### PR DESCRIPTION
The PR #94347 caused a regression in test_mps which this patch fixes it.