### PR TITLE
[ONNX] Reduce 'find_mismatch' memory footprint by promptly freeing past sessions.

### DIFF
--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -956,6 +956,7 @@ def verify_aten_graph(
 
         onnx_session = _onnx_backend_session(model_f, verification_options.backend)
         onnx_outs = _run_onnx(onnx_session, onnx_inputs)
+        del onnx_session  # To free device memory
 
         try:
             _compare_onnx_pytorch_outputs(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94648

