### PR TITLE
[BE] Replace some logger.error with logger.exception calls

### DIFF
--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -585,7 +585,7 @@ def wrap_compiler_debug(unconfigured_compiler_fn, compiler_name: str):
                             copy_tensor_attrs,
                             compiler_name,
                         )
-                    log.error("CompilerError")
+                    log.exception("CompilerError")
                     raise
 
         if config.repro_after == "aot":

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -695,7 +695,7 @@ def guard_fail_hook(
                 GuardFail(reason or "unknown reason", orig_code_map[code])
             )
     except Exception as e:
-        log.error(
+        log.exception(
             "Failure in guard_fail_fn callback - raising here will cause a NULL Error on guard eval",
             exc_info=True,
         )

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -288,7 +288,7 @@ def write_record_to_file(filename, exec_record):
             with open(filename, "wb") as f:
                 exec_record.dump(f)
     except Exception:
-        log.error(f"Unable to write execution record {filename}", exc_info=1)
+        log.exception(f"Unable to write execution record {filename}", exc_info=1)
 
 
 def count_calls(g: fx.Graph):

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -55,7 +55,7 @@ def _orthogonalize_gram_schmidt(matrices, epsilon=0):
             try:
                 col /= torch.norm(col, dim=1, keepdim=True)
             except ZeroDivisionError:
-                logger.error(
+                logger.exception(
                     "The matrices to be orthogonalized has at least a column of all 0s. Please set a small value such as 1e-8 "
                     "as `orthogonalization_epsilon` in PowerSGD state."
                 )

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -490,7 +490,7 @@ class MultiprocessContext(PContext):
             failed_proc = self._pc.processes[failed_local_rank]
             error_filepath = self.error_files[failed_local_rank]
 
-            log.error(
+            log.exception(
                 f"failed (exitcode: {failed_proc.exitcode})"
                 f" local_rank: {failed_local_rank} (pid: {e.pid})"
                 f" of fn: {fn_name} (start_method: {self.start_method})",

--- a/torch/distributed/elastic/multiprocessing/tail_log.py
+++ b/torch/distributed/elastic/multiprocessing/tail_log.py
@@ -131,7 +131,7 @@ class TailLog:
             try:
                 f.result()
             except Exception as e:
-                log.error(
+                log.exception(
                     f"error in log tailor for {self._name}{local_rank}."
                     f" {e.__class__.__qualname__}: {e}",
                 )

--- a/torch/distributed/elastic/timer/api.py
+++ b/torch/distributed/elastic/timer/api.py
@@ -170,7 +170,7 @@ class TimerServer(abc.ABC):
         try:
             return self._reap_worker(worker_id)
         except Exception as e:
-            log.error(
+            log.exception(
                 "Uncaught exception thrown from _reap_worker(), "
                 "check that the implementation correctly catches exceptions",
                 exc_info=e,
@@ -182,7 +182,7 @@ class TimerServer(abc.ABC):
             try:
                 self._run_watchdog()
             except Exception as e:
-                log.error("Error running watchdog", exc_info=e)
+                log.exception("Error running watchdog", exc_info=e)
 
     def _run_watchdog(self):
         batch_size = max(1, self._request_queue.size())

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -225,7 +225,7 @@ class FileTimerServer:
                     if run_once:
                         break
                 except Exception as e:
-                    log.error("Error running watchdog", exc_info=e)
+                    log.exception("Error running watchdog", exc_info=e)
 
     def _run_watchdog(self, fd: io.TextIOWrapper) -> None:
         timer_requests = self._get_requests(fd, self._max_interval)
@@ -328,5 +328,5 @@ class FileTimerServer:
             log.info(f"Process with pid={worker_pid} does not exist. Skipping")
             return True
         except Exception as e:
-            log.error(f"Error terminating pid={worker_pid}", exc_info=e)
+            log.exception(f"Error terminating pid={worker_pid}", exc_info=e)
         return False

--- a/torch/distributed/elastic/timer/local_timer.py
+++ b/torch/distributed/elastic/timer/local_timer.py
@@ -121,5 +121,5 @@ class LocalTimerServer(TimerServer):
             log.info(f"Process with pid={worker_id} does not exist. Skipping")
             return True
         except Exception as e:
-            log.error(f"Error terminating pid={worker_id}", exc_info=e)
+            log.exception(f"Error terminating pid={worker_id}", exc_info=e)
         return False

--- a/torch/distributed/rpc/_utils.py
+++ b/torch/distributed/rpc/_utils.py
@@ -28,7 +28,7 @@ def _group_membership_management(store, name, is_join):
             try:
                 store.wait([returned])
             except RuntimeError:
-                logger.error(f"Group membership token {my_token} timed out waiting for {returned} to be released.")
+                logger.exception(f"Group membership token {my_token} timed out waiting for {returned} to be released.")
                 raise
 
 def _update_group_membership(worker_info, my_devices, reverse_device_map, is_join):

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -282,7 +282,7 @@ def _barrier(worker_names):
     try:
         _all_gather(None, set(worker_names))
     except RuntimeError as ex:
-        logger.error(
+        logger.exception(
             f"Failed to complete barrier, got error {ex}"
         )
 
@@ -299,7 +299,7 @@ def _wait_all_workers(timeout=DEFAULT_SHUTDOWN_TIMEOUT):
     try:
         _all_gather(None, timeout=timeout)
     except RuntimeError as ex:
-        logger.error(
+        logger.exception(
             f"Failed to respond to 'Shutdown Proceed' in time, got error {ex}"
         )
         raise ex

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -281,10 +281,8 @@ def _barrier(worker_names):
     """
     try:
         _all_gather(None, set(worker_names))
-    except RuntimeError as ex:
-        logger.exception(
-            f"Failed to complete barrier, got error {ex}"
-        )
+    except RuntimeError:
+        logger.exception("Failed to complete barrier.")
 
 
 @_require_initialized
@@ -299,9 +297,7 @@ def _wait_all_workers(timeout=DEFAULT_SHUTDOWN_TIMEOUT):
     try:
         _all_gather(None, timeout=timeout)
     except RuntimeError as ex:
-        logger.exception(
-            f"Failed to respond to 'Shutdown Proceed' in time, got error {ex}"
-        )
+        logger.exception("Failed to respond to 'Shutdown Proceed' in time.")
         raise ex
 
 

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -669,7 +669,7 @@ class MultiProcessTestCase(TestCase):
             )
             sys.exit(TEST_SKIPS["generic"].exit_code)
         except Exception as e:
-            logger.error(
+            logger.exception(
                 f"Caught exception: \n{traceback.format_exc()} exiting "
                 f"process {self.rank} with exit code: {MultiProcessTestCase.TEST_ERROR_EXIT_CODE}"
             )
@@ -694,7 +694,7 @@ class MultiProcessTestCase(TestCase):
                     pipe.send(MultiProcessTestCase.Event.GET_TRACEBACK)
                     pipes.append((i, pipe))
                 except ConnectionError as e:
-                    logger.error(
+                    logger.exception(
                         f"Encountered error while trying to get traceback for process {i}: {e}"
                     )
 
@@ -718,7 +718,7 @@ class MultiProcessTestCase(TestCase):
                         f"Could not retrieve traceback for timed out process: {rank}"
                     )
             except ConnectionError as e:
-                logger.error(
+                logger.exception(
                     f"Encountered error while trying to get traceback for process {rank}: {e}"
                 )
 


### PR DESCRIPTION
Follows the python docs recommended behavior of using logger.exception when possible to pass exception data to the logger as well. This formats the logger more nicely to show where the exception causing the error message came from.


cc @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @ipiszy @chenyang78 @mlazos @soumith @yanboliang @desertfire