### PR TITLE
Move label check failure to mergebot

### DIFF
--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -45,10 +45,8 @@ def main() -> None:
     org, project = repo.gh_owner_and_name()
     pr = GitHubPR(org, project, args.pr_num)
 
-    exit_code = 0
     try:
         if not has_required_labels(pr):
-            exit_code = 1
             print(LABEL_ERR_MSG)
             add_label_err_comment(pr)
         else:
@@ -56,7 +54,7 @@ def main() -> None:
     except Exception as e:
         pass
 
-    exit(exit_code)
+    exit(0)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -20,11 +20,12 @@ BOT_AUTHORS = ["github-actions", "pytorchmergebot", "pytorch-bot"]
 
 LABEL_ERR_MSG_TITLE = "This PR needs a label"
 LABEL_ERR_MSG = f"""# {LABEL_ERR_MSG_TITLE}
-    If your changes are user facing and intended to be a part of release notes, please use a label starting with `release notes:`.
+If your changes are user facing and intended to be a part of release notes, please use a label starting with `release notes:`.
 
-    If not, please add the `topic: not user facing` label.
-    For more information, see
-    https://github.com/pytorch/pytorch/wiki/PyTorch-AutoLabel-Bot#why-categorize-for-release-notes-and-how-does-it-work.
+If not, please add the `topic: not user facing` label.
+
+For more information, see
+https://github.com/pytorch/pytorch/wiki/PyTorch-AutoLabel-Bot#why-categorize-for-release-notes-and-how-does-it-work.
 """
 
 # Modified from https://github.com/pytorch/pytorch/blob/b00206d4737d1f1e7a442c9f8a1cadccd272a386/torch/hub.py#L129

--- a/.github/scripts/test_check_labels.py
+++ b/.github/scripts/test_check_labels.py
@@ -87,7 +87,7 @@ class TestCheckLabels(TestCase):
     @mock.patch('check_labels.has_required_labels', return_value=False)
     @mock.patch('check_labels.delete_all_label_err_comments', side_effect=mock_delete_all_label_err_comments)
     @mock.patch('check_labels.add_label_err_comment', side_effect=mock_add_label_err_comment)
-    def test_ci_fails_without_required_labels(
+    def test_ci_comments_and_exit1_without_required_labels(
         self,
         mock_add_label_err_comment: Any,
         mock_delete_all_label_err_comments: Any,
@@ -106,7 +106,7 @@ class TestCheckLabels(TestCase):
     @mock.patch('check_labels.has_required_labels', return_value=True)
     @mock.patch('check_labels.delete_all_label_err_comments', side_effect=mock_delete_all_label_err_comments)
     @mock.patch('check_labels.add_label_err_comment', side_effect=mock_add_label_err_comment)
-    def test_ci_success_with_required_labels(
+    def test_ci_exit0_with_required_labels(
         self,
         mock_add_label_err_comment: Any,
         mock_delete_all_label_err_comments: Any,

--- a/.github/scripts/test_check_labels.py
+++ b/.github/scripts/test_check_labels.py
@@ -87,7 +87,7 @@ class TestCheckLabels(TestCase):
     @mock.patch('check_labels.has_required_labels', return_value=False)
     @mock.patch('check_labels.delete_all_label_err_comments', side_effect=mock_delete_all_label_err_comments)
     @mock.patch('check_labels.add_label_err_comment', side_effect=mock_add_label_err_comment)
-    def test_ci_comments_and_exit1_without_required_labels(
+    def test_ci_comments_and_exit0_without_required_labels(
         self,
         mock_add_label_err_comment: Any,
         mock_delete_all_label_err_comments: Any,
@@ -97,7 +97,7 @@ class TestCheckLabels(TestCase):
     ) -> None:
         with self.assertRaises(SystemExit) as sys_exit:
             check_labels_main()
-        self.assertEqual(str(sys_exit.exception), "1")
+        self.assertEqual(str(sys_exit.exception), "0")
         mock_add_label_err_comment.assert_called_once()
         mock_delete_all_label_err_comments.assert_not_called()
 

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -193,7 +193,7 @@ class DummyGitRepo(GitRepo):
 @mock.patch("trymerge.get_rockset_results", side_effect=empty_rockset_results)
 @mock.patch("trymerge.GitHubPR.get_merge_base", side_effect=dummy_merge_base)
 @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-class TestGitHubPR(TestCase):
+class TestTryMerge(TestCase):
     def test_merge_rules_valid(self, *args: Any) -> None:
         "Test that merge_rules.yaml can be parsed"
         repo = DummyGitRepo()

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -47,7 +47,11 @@ from github_utils import (
     gh_post_commit_comment,
     gh_post_pr_comment,
 )
-from label_utils import gh_add_labels
+from label_utils import (
+    LABEL_ERR_MSG,
+    gh_add_labels,
+    has_required_labels,
+)
 from trymerge_explainer import (
     TryMergeExplainer,
     get_revert_message,
@@ -1627,6 +1631,9 @@ def merge(pr_num: int, repo: GitRepo,
     # jobs. If there's missing approval, a RuntimeError will be raised
     # here to stop the merge process right away
     find_matching_merge_rule(pr, repo, skip_mandatory_checks=True)
+
+    if not has_required_labels(pr):
+        raise RuntimeError(LABEL_ERR_MSG.lstrip(" #"))
 
     if land_checks and not dry_run:
         land_check_commit = pr.create_land_time_check_branch(


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/88098

This is a mirror of the same PR (https://github.com/Goldspear/pytorch/pull/3) that has been reviewed in my fork (due to it's a stacked PR).

==============
## Context
This the 3rd of the 3 PRs to address the issue 88098.

## What Changed
1. check_labels.py no longer fails, but only leaving a comment
2. trymerge.py now would fail if no required labels provided

## Tests
* dummy-repo trymerge run [fails without required label](https://github.com/Goldspear/pytorch-dummy/actions/runs/4162819216) and resulted in [a label error comment](https://github.com/Goldspear/pytorch-dummy/pull/3#issuecomment-1427756769)
* the above pr was [correctly merged](https://github.com/Goldspear/pytorch-dummy/pull/3) after label is added. 

## Note to Reviewers
1st PR: https://github.com/pytorch/pytorch/pull/94179
2nd PR: https://github.com/pytorch/pytorch/pull/94899
3rd PR: this one