### PR TITLE
Add `--recompiles` to print recompile stats in benchmarks

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -1396,7 +1396,7 @@ class BenchmarkRunner:
 
         start_stats = get_stats()
 
-        if self.args.recompiles:
+        if self.args.print_recompiles:
             prof = torch._dynamo.utils.CompileProfiler()
 
         if self.args.accuracy:
@@ -1423,7 +1423,7 @@ class BenchmarkRunner:
             )
             print(stats)
 
-        if self.args.recompiles:
+        if self.args.print_recompiles:
             gf = prof.get_metrics()["guard_failures"]
             recompile_stats = [[format_func_info(code), len(gf[code])] for code in gf]
             print(recompile_stats)
@@ -1711,7 +1711,7 @@ def parse_args(args=None):
     )
     parser.add_argument("--timing", action="store_true", help="Emits phase timing")
     parser.add_argument(
-        "--recompiles", action="store_true", help="Emits recompile stats"
+        "--print-recompiles", action="store_true", help="Emits recompile stats"
     )
 
     parser.add_argument(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94710

Ex, static:
```
python  benchmarks/dynamo/benchmarks.py --backend aot_eager --training  --accuracy --timing --only hf_Reformer --recompiles
```
```
[["'forward' (modeling_reformer.py:1467)", 1], ["'<graph break in _init_attention_seed>' (modeling_reformer.py:1443)", 11], ["'<graph break in forward>' (modeling_reformer.py:1484)", 5], ["'<graph break in _init_feed_forward_seed>' (modeling_reformer.py:1460)", 11], ["'<graph break in forward>' (modeling_reformer.py:1509)", 5]]
```

Ex, dynamic:
```
TORCHDYNAMO_DYNAMIC_SHAPES=1  AOT_DYNAMIC_SHAPES=1 python  benchmarks/dynamo/benchmarks.py --backend aot_eager --training  --accuracy --timing --only hf_Reformer --recompiles
```
```
[["'forward' (modeling_reformer.py:1467)", 1], ["'<graph break in _init_attention_seed>' (modeling_reformer.py:1443)", 11], ["'<graph break in forward>' (modeling_reformer.py:1484)", 5], ["'<graph break in _init_feed_forward_seed>' (modeling_reformer.py:1460)", 11], ["'<graph break in forward>' (modeling_reformer.py:1509)", 5]]
```
(same) 

cc @mlazos @soumith @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire