### PR TITLE
[Bootcamp] [AI Accelerators] Convert attention equation to attention call in torch.compile()

### DIFF
--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -8,7 +8,10 @@ from torch.fx import symbolic_trace
 
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
-from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
+from torch.fx.passes.utils.matcher_utils import (
+    SubgraphMatcher,
+    SubgraphMultiPatternMatcher,
+)
 from torch.testing._internal.jit_utils import JitTestCase
 
 class TestMatcher(JitTestCase):
@@ -70,5 +73,67 @@ class TestMatcher(JitTestCase):
         pattern_graph = torch.fx.symbolic_trace(pattern).graph
 
         subgraph_matcher = SubgraphMatcher(pattern_graph)
+        match_result = subgraph_matcher.match(original_graph)
+        self.assertEqual(len(match_result), 0)
+
+
+    def test_subgraph_multi_matcher_with_attributes(self):
+        class LargeModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._weight = torch.nn.Parameter(torch.ones(3, 3))
+                self._bias = torch.nn.Parameter(torch.ones(3, 3))
+
+            def forward(self, x):
+                return torch.ops.aten.addmm.default(self._bias, x, self._weight)
+
+        # Large Model graph:
+        # opcode         name           target              args                 kwargs
+        # -------------  -------------  ------------------  -------------------  --------
+        # placeholder    x              x                   ()                   {}
+        # get_attr       _bias          _bias               ()                   {}
+        # get_attr       _weight        _weight             ()                   {}
+        # call_function  addmm_default  aten.addmm.default  (_bias, x, _weight)  {}
+        # output         output         output              (addmm_default,)     {}
+        large_model_graph = symbolic_trace(LargeModel()).graph
+
+        class PatternModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._weight_1 = torch.nn.Parameter(torch.ones(5, 5))
+                self._bias_1 = torch.nn.Parameter(torch.ones(5, 5))
+
+            def forward(self, x):
+                return torch.ops.aten.addmm.default(self._bias_1, x, self._weight_1)
+
+        pattern_graph = torch.fx.symbolic_trace(PatternModel()).graph
+
+        subgraph_matcher = SubgraphMultiPatternMatcher([pattern_graph])
+        match_result = subgraph_matcher.match(large_model_graph)
+        self.assertEqual(len(match_result), 1)
+
+    def test_subgraph_multi_matcher_with_list(self):
+        def original(x, y):
+            return torch.ops.aten.view(x, [5, y.shape[0]])
+        original_graph = torch.fx.symbolic_trace(original).graph
+
+        def pattern(x, y, z):
+            return torch.ops.aten.view(x, [z, y.shape[0]])
+        pattern_graph = torch.fx.symbolic_trace(pattern).graph
+
+        subgraph_matcher = SubgraphMultiPatternMatcher([pattern_graph])
+        match_result = subgraph_matcher.match(original_graph)
+        self.assertEqual(len(match_result), 1)
+
+    def test_subgraph_multi_matcher_with_list_bad(self):
+        def original(x, y):
+            return torch.ops.aten._reshape_alias_copy.default(x, [1, y.shape[0]], [y.shape[1], y.shape[1]])
+        original_graph = torch.fx.symbolic_trace(original).graph
+
+        def pattern(x, y, b):
+            return torch.ops.aten._reshape_alias_copy.default(x, [b, y.shape[0], y.shape[1]], [y.shape[1]])
+        pattern_graph = torch.fx.symbolic_trace(pattern).graph
+
+        subgraph_matcher = SubgraphMultiPatternMatcher([pattern_graph])
         match_result = subgraph_matcher.match(original_graph)
         self.assertEqual(len(match_result), 0)

--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -4,19 +4,28 @@ import os
 import sys
 
 import torch
-from torch.fx import symbolic_trace, subgraph_rewriter
+from parameterized import parameterized_class
+from torch.fx import Graph, GraphModule, subgraph_rewriter, symbolic_trace
 from torch.fx.annotate import annotate
+
 # Make the helper files in test/ importable
 from torch.fx.experimental.rewriter import RewritingTracer
 
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
+from typing import Callable, List, Union
+
+from torch.fx.subgraph_rewriter import Match
+
 from torch.testing._internal.jit_utils import JitTestCase
 
-if __name__ == '__main__':
-    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
-                       "\tpython test/test_fx.py TESTNAME\n\n"
-                       "instead.")
+if __name__ == "__main__":
+    raise RuntimeError(
+        "This test file is not meant to be run directly, use:\n\n"
+        "\tpython test/test_fx.py TESTNAME\n\n"
+        "instead."
+    )
+
 
 @torch.fx.wrap
 def wrapped_gemm_bias_mul(a, b, bias):
@@ -24,14 +33,76 @@ def wrapped_gemm_bias_mul(a, b, bias):
     mul_res = lin_res * a
     return lin_res, mul_res
 
+
 @torch.fx.wrap
 def wrapped_gemm_bias_mul_with_c(a, b, bias, c):
     lin_res = torch.nn.functional.linear(a, b, bias=bias)
     mul_res = lin_res * c
     return lin_res, mul_res
 
-class TestSubgraphRewriter(JitTestCase):
 
+# nuisance pattern and corresponding replacement for multi replacer
+def nuisance_pattern(a, b):
+    return torch.sqrt(a.sqrt() * 0.144395 + b.pow(2.52113))
+
+
+def nuisance_replacement(a, b):
+    return a + b
+
+
+def replace_multi_pattern_impl(
+    gm: GraphModule,
+    pattern: Union[Callable, GraphModule],
+    replacement: Union[Callable, GraphModule],
+) -> List[Match]:
+    # Wrapping subgraph_rewriter.replace_multiple_patterns_with_filters with a function
+    # that has same call signature as subgraph_rewriter.replace_pattern
+    if not isinstance(pattern, GraphModule):
+        pattern = symbolic_trace(pattern)
+    if not isinstance(replacement, GraphModule):
+        replacement = symbolic_trace(replacement)
+    return subgraph_rewriter.replace_multiple_patterns_with_filters(
+        gm,
+        {pattern: replacement, nuisance_pattern: nuisance_replacement},
+        match_filters=None,
+    )
+
+
+def replace_multi_pattern_with_filters_impl(
+    gm: GraphModule,
+    pattern: Union[Callable, GraphModule],
+    replacement: Union[Callable, GraphModule],
+    match_filters: List[Callable[["InternalMatch", Graph, Graph], bool]],  # type: ignore[name-defined]
+) -> List[Match]:
+    # Wrapping subgraph_rewriter.replace_multiple_patterns_with_filters with a function
+    # that has same call signature as subgraph_rewriter.replace_pattern_with_filters
+    return subgraph_rewriter.replace_multiple_patterns_with_filters(
+        gm, {pattern: replacement}, match_filters=match_filters
+    )
+
+
+@parameterized_class(
+    [
+        # Parameterize unit test with
+        # Alternative implementation of subgraph_rewriter.replace_pattern,
+        # backed by subgraph_rewriter.replace_multiple_patterns_with_filters
+        # So that all tests in this unit test can be applied to both implementations
+        # without duplicating the code
+        {
+            "replace_pattern_impl": subgraph_rewriter.replace_pattern,
+            "replace_pattern_with_filters_impl": subgraph_rewriter.replace_pattern_with_filters,
+        },
+        {
+            "replace_pattern_impl": replace_multi_pattern_impl,
+            "replace_pattern_with_filters_impl": replace_multi_pattern_with_filters_impl,
+        },
+    ],
+    class_name_func=lambda cls, idx, input: [
+        "TestSubgraphRewriter",
+        "TestSubgraphMultiRewriter",
+    ][idx],
+)
+class TestSubgraphRewriterParameterized(JitTestCase):
     def test_subgraph_rewriter_preserves_logic(self):
         class M(torch.nn.Module):
             def forward(self, x):
@@ -52,7 +123,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         # Replace `pattern` with the same pattern (shouldn't change
         # the underlying logic)
-        subgraph_rewriter.replace_pattern(traced, pattern, pattern)
+        type(self).replace_pattern_impl(traced, pattern, pattern)
 
         traced.graph.lint()
 
@@ -81,7 +152,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.rand(1, 3)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -110,7 +181,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.rand(1, 3)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -143,7 +214,7 @@ class TestSubgraphRewriter(JitTestCase):
         w1 = torch.rand(1, 3)
         w2 = torch.rand(1, 3)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -168,7 +239,7 @@ class TestSubgraphRewriter(JitTestCase):
         x = torch.randn(3, 4)
         y = torch.randn(4, 5)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, pattern)
+        type(self).replace_pattern_impl(traced, pattern, pattern)
 
         traced.graph.lint()
 
@@ -198,7 +269,7 @@ class TestSubgraphRewriter(JitTestCase):
         x = torch.randn(4, 4)
         y = torch.randn(4, 4)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -231,7 +302,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, traced_pattern, traced_replacement)
+        type(self).replace_pattern_impl(traced, traced_pattern, traced_replacement)
 
         traced.graph.lint()
 
@@ -258,7 +329,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -266,7 +337,9 @@ class TestSubgraphRewriter(JitTestCase):
         test_outs = traced.forward(x)
         self.assertEqual(ref_outs, test_outs)
 
-    def test_subgraph_rewriter_pattern_output_pattern_node_can_have_users_that_are_not_matched(self):
+    def test_subgraph_rewriter_pattern_output_pattern_node_can_have_users_that_are_not_matched(
+        self,
+    ):
         class M(torch.nn.Module):
             def forward(self, x):
                 y = torch.relu(x)
@@ -287,7 +360,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -295,7 +368,9 @@ class TestSubgraphRewriter(JitTestCase):
         test_outs = traced.forward(x)
         self.assertEqual(ref_outs, test_outs)
 
-    def test_subgraph_rewriter_internal_pattern_nodes_cannot_have_users_that_are_not_matched(self):
+    def test_subgraph_rewriter_internal_pattern_nodes_cannot_have_users_that_are_not_matched(
+        self,
+    ):
         class M(torch.nn.Module):
             def forward(self, x, w1, w2, b1, b2):
                 m0 = torch.cat([w1, w2])
@@ -354,6 +429,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         Credit to Jerry Zhang (GitHub: jerryzh168) for this test case
         """
+
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -384,7 +460,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -436,7 +512,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, Pattern(), Replacement())
+        type(self).replace_pattern_impl(traced, Pattern(), Replacement())
 
         traced.graph.lint()
 
@@ -452,7 +528,6 @@ class TestSubgraphRewriter(JitTestCase):
         self.assertEqual(type(submod), torch.nn.ReLU)
 
     def test_subgraph_rewriter_annotations_int(self):
-
         class M1(torch.nn.Module):
             def forward(self, x):
                 y: int = x
@@ -469,12 +544,11 @@ class TestSubgraphRewriter(JitTestCase):
         module = M2()
         symbolic_traced: torch.fx.GraphModule = symbolic_trace(module)
         for n, m in zip(symbolic_traced.graph.nodes, graph.nodes):
-            if n.op == 'placeholder':
+            if n.op == "placeholder":
                 assert n.type == int
                 assert m.type == int
 
     def test_subgraph_rewriter_replace_consecutive_submodules(self):
-
         def f(x):
             x = torch.sigmoid(x)
             x = torch.sigmoid(x)
@@ -496,7 +570,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -505,7 +579,6 @@ class TestSubgraphRewriter(JitTestCase):
         self.assertEqual(ref_outs, test_outs)
 
     def test_subgraph_rewriter_with_overlapping_matches(self):
-
         def f(x):
             x = torch.sigmoid(x)
             x = torch.sigmoid(x)
@@ -529,7 +602,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -538,6 +611,9 @@ class TestSubgraphRewriter(JitTestCase):
         self.assertEqual(ref_outs, test_outs)
 
     def test_subgraph_rewriter_replace_with_multiple_outputs(self):
+        if type(self).__name__ == "TestSubgraphMultiRewriter":
+            # This test does not work with multi pattern rewriter, as the example has multiple anchors
+            self.skipTest("Multiple anchors not supported for subgraph multi replace")
 
         def f(x):
             y = torch.sigmoid(x)
@@ -562,7 +638,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -571,6 +647,9 @@ class TestSubgraphRewriter(JitTestCase):
         self.assertEqual(ref_outs, test_outs)
 
     def test_subgraph_rewriter_replace_with_duplicated_outputs(self):
+        if type(self).__name__ == "TestSubgraphMultiRewriter":
+            # This test does not work with multi pattern rewriter, as the example has multiple anchors
+            self.skipTest("Multiple anchors not supported for subgraph multi replace")
 
         def f(x1, x2):
             x = x1 - x2
@@ -599,7 +678,7 @@ class TestSubgraphRewriter(JitTestCase):
         x1 = torch.randn(3, 4)
         x2 = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -627,8 +706,7 @@ class TestSubgraphRewriter(JitTestCase):
         x1 = torch.randn(3, 4)
         x2 = torch.randn(3, 4)
         x3 = torch.randn(3, 4)
-
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
         placeholder_nodes = [n for n in traced.graph.nodes if n.op == "placeholder"]
@@ -639,7 +717,6 @@ class TestSubgraphRewriter(JitTestCase):
         self.assertEqual(ref_outs, test_outs)
 
     def test_subgraph_rewriter_call_method(self):
-
         class M(torch.nn.Module):
             def forward(self, x):
                 x = x.dequantize()
@@ -661,7 +738,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         x1 = torch.randn(3, 4)
 
-        subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        type(self).replace_pattern_impl(traced, pattern, replacement)
 
         traced.graph.lint()
 
@@ -670,6 +747,9 @@ class TestSubgraphRewriter(JitTestCase):
         self.assertEqual(ref_outs, test_outs)
 
     def test_subgraph_rewriter_nodes_with_kwargs(self):
+        if type(self).__name__ == "TestSubgraphMultiRewriter":
+            # This test does not work with multi pattern rewriter, as the example has multiple anchors
+            self.skipTest("Multiple anchors not supported for subgraph multi replace")
 
         class M(torch.nn.Module):
             def __init__(self) -> None:
@@ -693,7 +773,7 @@ class TestSubgraphRewriter(JitTestCase):
             return lin_res, mul_res
 
         traced = symbolic_trace(M())
-        matches = subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        matches = type(self).replace_pattern_impl(traced, pattern, replacement)
 
         self.assertEqual(len(matches), 1)
 
@@ -706,11 +786,13 @@ class TestSubgraphRewriter(JitTestCase):
         self.assertTrue(found_repalcement_node)
 
     def test_subgraph_rewriter_local_revert(self):
-
         # Following model will have 3 anchors as the matching candidate with the given pattern
         # Anchor 1 and 3 is a real match, but anchor 2 is not.
         # The subgraph rewriter should be able to revert the changes made while matching anchor 2.
         # Final match with anchor 3 should be successful.
+        if type(self).__name__ == "TestSubgraphMultiRewriter":
+            # This test does not work with multi pattern rewriter, as the example has multiple anchors
+            self.skipTest("Multiple anchors not supported for subgraph multi replace")
 
         class M(torch.nn.Module):
             def __init__(self) -> None:
@@ -732,9 +814,7 @@ class TestSubgraphRewriter(JitTestCase):
                 # potential match at anchor 1
                 mul_res_1 = in1 * lin_res_2
                 sum_res_1 = mul_res_1 + in1
-                lin_res_3 = torch.nn.functional.linear(
-                    sum_res_1, self.w2, bias=self.b2
-                )
+                lin_res_3 = torch.nn.functional.linear(sum_res_1, self.w2, bias=self.b2)
                 sigmoid_res_1 = torch.sigmoid(lin_res_3)
                 # potential match at anchor 2
                 mul_res_2 = lin_res_3 * sigmoid_res_1
@@ -759,10 +839,10 @@ class TestSubgraphRewriter(JitTestCase):
             return lin_res, mul_res
 
         traced = symbolic_trace(M())
+
         matches = subgraph_rewriter.replace_pattern(
-            traced,
-            gemm_bias_mul_pattern_with_c,
-            gemm_bias_mul_replacement_with_c)
+            traced, gemm_bias_mul_pattern_with_c, gemm_bias_mul_replacement_with_c
+        )
 
         self.assertEqual(len(matches), 2)
 
@@ -803,7 +883,7 @@ class TestSubgraphRewriter(JitTestCase):
             return x
 
         def second_input_is_scalar(match, original_graph, pattern_graph):
-            """ check the node that's matched to the second input of the pattern graph
+            """check the node that's matched to the second input of the pattern graph
             is a scalar number
             """
             input_idx = 0
@@ -817,29 +897,32 @@ class TestSubgraphRewriter(JitTestCase):
             return True
 
         def check_replacement_nodes(self, traced, matches):
-            replacement_nodes_in_graph = [node for node in traced.graph.nodes if node.target == torch.mul]
+            replacement_nodes_in_graph = [
+                node for node in traced.graph.nodes if node.target == torch.mul
+            ]
             replacement_nodes_in_res = [r for m in matches for r in m.replacements]
-            self.assertEqual(len(replacement_nodes_in_graph), len(replacement_nodes_in_res))
+            self.assertEqual(
+                len(replacement_nodes_in_graph), len(replacement_nodes_in_res)
+            )
             self.assertEqual(replacement_nodes_in_graph, replacement_nodes_in_res)
             return len(replacement_nodes_in_graph)
 
         # match without filter, should find 2 match
         traced = symbolic_trace(M())
-        matches = subgraph_rewriter.replace_pattern_with_filters(
-            traced,
-            BinaryOpScalarReLUPattern,
-            BinaryOpScalarReLUReplacement,
-            None)
+        matches = type(self).replace_pattern_with_filters_impl(
+            traced, BinaryOpScalarReLUPattern, BinaryOpScalarReLUReplacement, None
+        )
         self.assertEqual(len(matches), 2)
         self.assertEqual(check_replacement_nodes(self, traced, matches), 2)
 
         # match with filter, should find 1 match
         traced = symbolic_trace(M())
-        matches = subgraph_rewriter.replace_pattern_with_filters(
+        matches = type(self).replace_pattern_with_filters_impl(
             traced,
             BinaryOpScalarReLUPattern,
             BinaryOpScalarReLUReplacement,
-            [second_input_is_scalar])
+            [second_input_is_scalar],
+        )
         self.assertEqual(len(matches), 1)
         self.assertEqual(check_replacement_nodes(self, traced, matches), 1)
 
@@ -855,11 +938,14 @@ class TestSubgraphRewriter(JitTestCase):
             return torch.ops.aten._reshape_alias_copy.default(x, arg1, arg0)
 
         traced = symbolic_trace(M())
-        matches = subgraph_rewriter.replace_pattern(traced, pattern, replacement)
+        matches = type(self).replace_pattern_impl(traced, pattern, replacement)
 
         self.assertEqual(len(matches), 1)
 
-        self.assertExpectedInline(traced.code.strip(), """\
+        self.assertExpectedInline(
+            traced.code.strip(),
+            """\
 def forward(self, x):
     _reshape_alias_copy_default_1 = torch.ops.aten._reshape_alias_copy.default(x, [3, 4], [1, 2]);  x = None
-    return _reshape_alias_copy_default_1""")  # noqa: B950
+    return _reshape_alias_copy_default_1""",
+        )  # noqa: B950

--- a/test/inductor/test_sdpa_pattern_rewriter.py
+++ b/test/inductor/test_sdpa_pattern_rewriter.py
@@ -1,0 +1,568 @@
+# Owner(s): ["module: inductor"]
+import math
+import re
+import unittest
+from types import FunctionType
+
+import torch
+import torch._inductor.config
+import torch._inductor.sdpa_pattern_rewriter as sdpa_pattern_rewriter
+import torch.functional as F
+import torch.nn as nn
+from torch._dynamo.test_case import run_tests, TestCase
+from torch.backends.cuda import sdp_kernel
+from torch.fx import GraphModule
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FUSED_SDPA, TEST_CUDA
+from torch.testing._internal.common_utils import freeze_rng_state, IS_LINUX
+from torch.testing._internal.inductor_utils import HAS_CUDA
+
+
+class CfgNode:
+    n_embd: int = 128
+    n_head: int = 4
+    resid_pdrop: float = 0.2
+    attn_pdrop: float = 0.1
+    block_size: int = 12
+    vocab_size: int = 1000
+    n_layer = 12
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+# CausalSelfAttention block from Karpathy's MinGPT
+# copied from https://github.com/karpathy/minGPT/blob/90420ee978fed95e6eb7c9add728d33bb890fe39/mingpt/model.py
+# under MIT License ( https://github.com/karpathy/minGPT/blob/90420ee978fed95e6eb7c9add728d33bb890fe39/LICENSE )
+# In this test, we are showing that we can replace this module..
+class CausalSelfAttention(nn.Module):
+    """
+    A vanilla multi-head masked self-attention layer with a projection at the end.
+    It is possible to use torch.nn.MultiheadAttention here but I am including an
+    explicit implementation here to show that there is nothing too scary here.
+    """
+
+    def __init__(self, config: CfgNode):
+        super().__init__()
+        assert config.n_embd % config.n_head == 0
+        # key, query, value projections for all heads, but in a batch
+        self.c_attn = nn.Linear(config.n_embd, 3 * config.n_embd)
+        # output projection
+        self.c_proj = nn.Linear(config.n_embd, config.n_embd)
+        # regularization
+        self.attn_dropout = nn.Dropout(config.attn_pdrop)
+        self.resid_dropout = nn.Dropout(config.resid_pdrop)
+        # causal mask to ensure that attention is only applied to the left in the input sequence
+        self.register_buffer(
+            "bias",
+            torch.tril(torch.ones(config.block_size, config.block_size)).view(
+                1, 1, config.block_size, config.block_size
+            ),
+        )
+        self.n_head = config.n_head
+        self.n_embd = config.n_embd
+
+    def forward(self, x):
+        (
+            B,
+            T,
+            C,
+        ) = x.size()  # batch size, sequence length, embedding dimensionality (n_embd)
+
+        # calculate query, key, values for all heads in batch and move head forward to be the batch dim
+        q, k, v = self.c_attn(x).split(self.n_embd, dim=2)
+        k = k.view(B, T, self.n_head, C // self.n_head).transpose(
+            1, 2
+        )  # (B, nh, T, hs)
+        q = q.view(B, T, self.n_head, C // self.n_head).transpose(
+            1, 2
+        )  # (B, nh, T, hs)
+        v = v.view(B, T, self.n_head, C // self.n_head).transpose(
+            1, 2
+        )  # (B, nh, T, hs)
+
+        # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
+        att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
+        att = att.masked_fill(self.bias[:, :, :T, :T] == 0, float("-inf"))
+        att = F.softmax(att, dim=-1)
+        att = self.attn_dropout(att)
+        y = att @ v  # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+        y = (
+            y.transpose(1, 2).contiguous().view(B, T, C)
+        )  # re-assemble all head outputs side by side
+
+        # output projection
+        y = self.resid_dropout(self.c_proj(y))
+        return y
+
+
+def _safe_str(target):
+    if isinstance(target, FunctionType):
+        return target.__name__
+    else:
+        return re.sub(r"at 0x[a-f0-9]+", "at [address]", str(target))
+
+
+def create_graph_desc(gm: GraphModule):
+    return "\n".join(
+        [
+            "    ".join(
+                [
+                    _safe_str(n.op),
+                    _safe_str(n.name),
+                    _safe_str(n.target),
+                    _safe_str(n.args),
+                    _safe_str(n.kwargs),
+                ]
+            )
+            for n in gm.graph.nodes
+        ]
+    )
+
+
+class TestSDPAPatternRewriter(TestCase):
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FUSED_SDPA, "Fused SDPA was not built for this system"
+    )
+    def test_sdpa_rewriter_1(self):
+        with sdp_kernel(enable_flash=False, enable_math=True):
+
+            def dot_prod_attention(
+                query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
+            ) -> torch.Tensor:
+                """Input tensors assumed to have shape (batch_size, n_head, seq_len, embed_dim)"""
+                assert query.dim() == 4
+                assert key.dim() == 4
+                assert value.dim() == 4
+                return (
+                    torch.matmul(query, key.transpose(-2, -1))
+                    .div(math.sqrt(key.shape[-1]))
+                    .softmax(dim=-1)
+                    .matmul(value)
+                )
+
+            tensor_shape = (2, 4, 8, 16)
+            batch_size, n_head, seq_len, embed_dim = tensor_shape
+            args = [
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+            ]
+            # See whether the optimization matches our test pattern and is replaced
+            gm: torch.fx.GraphModule = torch._dynamo.export(dot_prod_attention, *args)[
+                0
+            ]
+            gm = sdpa_pattern_rewriter.fuse_scaled_dot_product_attention(gm)
+            graph_desc = create_graph_desc(gm)
+            self.assertExpectedInline(
+                graph_desc,
+                """\
+placeholder    arg0    arg0    ()    {}
+placeholder    arg1    arg1    ()    {}
+placeholder    arg2    arg2    ()    {}
+call_method    contiguous    contiguous    (arg0,)    {}
+call_method    contiguous_1    contiguous    (arg1,)    {}
+call_method    contiguous_2    contiguous    (arg2,)    {}
+call_function    truediv    <built-in function truediv>    (1.0, 4.0)    {}
+call_function    _scale_factor_dot_product_attention    _scale_factor_dot_product_attention    (contiguous, contiguous_1, contiguous_2)    {'attn_mask': None, 'dropout_p': 0.0, 'is_causal': False, 'scale_factor': truediv}
+output    output    output    ([_scale_factor_dot_product_attention],)    {}""",
+            )
+            expected = dot_prod_attention(*args)
+            saved_flag = torch._inductor.config.scaled_dot_product_attention_fusion
+            torch._inductor.config.scaled_dot_product_attention_fusion = True
+            try:
+                efficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                actual = efficient_dot_prod_attention(*args)
+
+                torch.testing.assert_close(actual, expected)
+            finally:
+                torch._inductor.config.scaled_dot_product_attention_fusion = saved_flag
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FUSED_SDPA, "Fused SDPA was not built for this system"
+    )
+    def test_sdpa_rewriter_attn_weights_not_dead(self):
+        """
+        This test checks that the replacement is not done
+        when an intermediate result is being used / returned downstream
+        """
+        with sdp_kernel(enable_flash=False, enable_math=True):
+
+            def dot_prod_attention(
+                query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
+            ) -> torch.Tensor:
+                """Input tensors assumed to have shape (batch_size, n_head, seq_len, embed_dim)"""
+                assert query.dim() == 4
+                assert key.dim() == 4
+                assert value.dim() == 4
+                attn_weights = (
+                    torch.matmul(query, key.transpose(-2, -1))
+                    .div(math.sqrt(key.shape[-1]))
+                    .softmax(dim=-1)
+                )
+                return attn_weights.matmul(value), attn_weights
+
+            tensor_shape = (2, 4, 8, 16)
+            batch_size, n_head, seq_len, embed_dim = tensor_shape
+            args = [
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+            ]
+            # See whether the optimization matches our test pattern and is replaced
+            gm: torch.fx.GraphModule = torch._dynamo.export(dot_prod_attention, *args)[
+                0
+            ]
+            gm = sdpa_pattern_rewriter.fuse_scaled_dot_product_attention(gm)
+            graph_desc = create_graph_desc(gm)
+            self.assertExpectedInline(
+                graph_desc,
+                """\
+placeholder    arg0    arg0    ()    {}
+placeholder    arg1    arg1    ()    {}
+placeholder    arg2    arg2    ()    {}
+call_method    transpose    transpose    (arg1, -2, -1)    {}
+call_function    matmul    <built-in method matmul of type object at [address]>    (arg0, transpose)    {}
+call_method    div    div    (matmul, 4.0)    {}
+call_method    softmax    softmax    (div,)    {'dim': -1}
+call_method    matmul_1    matmul    (softmax, arg2)    {}
+output    output    output    ([matmul_1, softmax],)    {}""",
+            )
+            expected = dot_prod_attention(*args)
+            saved_flag = torch._inductor.config.scaled_dot_product_attention_fusion
+            torch._inductor.config.scaled_dot_product_attention_fusion = True
+            try:
+                efficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                actual = efficient_dot_prod_attention(*args)
+
+                torch.testing.assert_close(actual, expected)
+            finally:
+                torch._inductor.config.scaled_dot_product_attention_fusion = saved_flag
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FUSED_SDPA, "Fused SDPA was not built for this system"
+    )
+    def test_sdpa_rewriter_2(self):
+        with sdp_kernel(enable_flash=False, enable_math=True):
+
+            def dot_prod_attention(
+                query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
+            ) -> torch.Tensor:
+                """Input tensors assumed to have shape (batch_size, n_head, seq_len, embed_dim)"""
+                assert query.dim() == 4
+                assert key.dim() == 4
+                assert value.dim() == 4
+                return (
+                    torch.matmul(query, key.transpose(-2, -1))
+                    .mul(1.0 / math.sqrt(key.shape[-1]))
+                    .softmax(dim=-1)
+                    .matmul(value)
+                )
+
+            tensor_shape = (2, 4, 8, 16)
+            batch_size, n_head, seq_len, embed_dim = tensor_shape
+            args = [
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+            ]
+            # See whether the optimization matches our test pattern and is replaced
+            gm: torch.fx.GraphModule = torch._dynamo.export(dot_prod_attention, *args)[
+                0
+            ]
+            gm = sdpa_pattern_rewriter.fuse_scaled_dot_product_attention(gm)
+            graph_desc = create_graph_desc(gm)
+            self.assertExpectedInline(
+                graph_desc,
+                """\
+placeholder    arg0    arg0    ()    {}
+placeholder    arg1    arg1    ()    {}
+placeholder    arg2    arg2    ()    {}
+call_method    contiguous    contiguous    (arg0,)    {}
+call_method    contiguous_1    contiguous    (arg1,)    {}
+call_method    contiguous_2    contiguous    (arg2,)    {}
+call_function    _scale_factor_dot_product_attention    _scale_factor_dot_product_attention    (contiguous, contiguous_1, contiguous_2)    {'attn_mask': None, 'dropout_p': 0.0, 'is_causal': False, 'scale_factor': 0.25}
+output    output    output    ([_scale_factor_dot_product_attention],)    {}""",
+            )
+
+            expected = dot_prod_attention(*args)
+            saved_flag = torch._inductor.config.scaled_dot_product_attention_fusion
+            torch._inductor.config.scaled_dot_product_attention_fusion = True
+            try:
+                efficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                actual = efficient_dot_prod_attention(*args)
+
+                torch.testing.assert_close(actual, expected)
+            finally:
+                torch._inductor.config.scaled_dot_product_attention_fusion = saved_flag
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FUSED_SDPA, "Fused SDPA was not built for this system"
+    )
+    def test_sdpa_rewriter_3(self):
+        with sdp_kernel(enable_flash=False, enable_math=True):
+
+            def dot_prod_attention(
+                query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
+            ) -> torch.Tensor:
+                """Input tensors assumed to have shape (batch_size, n_head, seq_len, embed_dim)"""
+                assert query.dim() == 4
+                assert key.dim() == 4
+                assert value.dim() == 4
+                return torch.nn.functional.dropout(
+                    torch.matmul(query, key.transpose(-2, -1)).div(3.0).softmax(dim=-1),
+                    p=0.4,
+                    training=True,
+                    inplace=False,
+                ).matmul(value)
+
+            tensor_shape = (2, 4, 8, 16)
+            batch_size, n_head, seq_len, embed_dim = tensor_shape
+            args = [
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+            ]
+            # See whether the optimization matches our test pattern and is replaced
+            gm: torch.fx.GraphModule = torch._dynamo.export(dot_prod_attention, *args)[
+                0
+            ]
+            gm = sdpa_pattern_rewriter.fuse_scaled_dot_product_attention(gm)
+            graph_desc = create_graph_desc(gm)
+            self.assertExpectedInline(
+                graph_desc,
+                """\
+placeholder    arg0    arg0    ()    {}
+placeholder    arg1    arg1    ()    {}
+placeholder    arg2    arg2    ()    {}
+call_method    contiguous    contiguous    (arg0,)    {}
+call_method    contiguous_1    contiguous    (arg1,)    {}
+call_method    contiguous_2    contiguous    (arg2,)    {}
+call_function    truediv    <built-in function truediv>    (1.0, 3.0)    {}
+call_function    _scale_factor_dot_product_attention    _scale_factor_dot_product_attention    (contiguous, contiguous_1, contiguous_2)    {'attn_mask': None, 'dropout_p': 0.4, 'is_causal': False, 'scale_factor': truediv}
+output    output    output    ([_scale_factor_dot_product_attention],)    {}""",
+            )
+
+            saved_flag = torch._inductor.config.scaled_dot_product_attention_fusion
+            torch._inductor.config.scaled_dot_product_attention_fusion = True
+            try:
+                with freeze_rng_state():
+                    efficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                    actual = efficient_dot_prod_attention(*args)
+                torch._inductor.config.scaled_dot_product_attention_fusion = False
+                with freeze_rng_state():
+                    inefficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                    expected = inefficient_dot_prod_attention(*args)
+            finally:
+                torch._inductor.config.scaled_dot_product_attention_fusion = saved_flag
+            torch.testing.assert_close(actual, expected)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FUSED_SDPA, "Fused SDPA was not built for this system"
+    )
+    def test_sdpa_rewriter_4(self):
+        with sdp_kernel(enable_flash=False, enable_math=True):
+
+            def dot_prod_attention(
+                query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
+            ) -> torch.Tensor:
+                """Input tensors assumed to have shape (batch_size, n_head, seq_len, embed_dim)"""
+                assert query.dim() == 4
+                assert key.dim() == 4
+                assert value.dim() == 4
+                return torch.nn.functional.dropout(
+                    torch.matmul(query, key.transpose(-2, -1)).mul(0.4).softmax(dim=-1),
+                    p=0.2,
+                    training=True,
+                    inplace=False,
+                ).matmul(value)
+
+            tensor_shape = (2, 4, 8, 16)
+            batch_size, n_head, seq_len, embed_dim = tensor_shape
+            args = [
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+            ]
+            # See whether the optimization matches our test pattern and is replaced
+            gm: torch.fx.GraphModule = torch._dynamo.export(dot_prod_attention, *args)[
+                0
+            ]
+            gm = sdpa_pattern_rewriter.fuse_scaled_dot_product_attention(gm)
+            graph_desc = create_graph_desc(gm)
+            self.assertExpectedInline(
+                graph_desc,
+                """\
+placeholder    arg0    arg0    ()    {}
+placeholder    arg1    arg1    ()    {}
+placeholder    arg2    arg2    ()    {}
+call_method    contiguous    contiguous    (arg0,)    {}
+call_method    contiguous_1    contiguous    (arg1,)    {}
+call_method    contiguous_2    contiguous    (arg2,)    {}
+call_function    _scale_factor_dot_product_attention    _scale_factor_dot_product_attention    (contiguous, contiguous_1, contiguous_2)    {'attn_mask': None, 'dropout_p': 0.2, 'is_causal': False, 'scale_factor': 0.4}
+output    output    output    ([_scale_factor_dot_product_attention],)    {}""",
+            )
+
+            # Now check that the result is identical
+            saved_flag = torch._inductor.config.scaled_dot_product_attention_fusion
+            torch._inductor.config.scaled_dot_product_attention_fusion = True
+            try:
+                with freeze_rng_state():
+                    efficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                    actual = efficient_dot_prod_attention(*args)
+                torch._inductor.config.scaled_dot_product_attention_fusion = False
+                with freeze_rng_state():
+                    inefficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                    expected = inefficient_dot_prod_attention(*args)
+            finally:
+                torch._inductor.config.scaled_dot_product_attention_fusion = saved_flag
+            torch.testing.assert_close(actual, expected)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FUSED_SDPA, "Fused SDPA was not built for this system"
+    )
+    def test_sdpa_rewriter_5(self):
+        with sdp_kernel(enable_flash=False, enable_math=True):
+
+            def dot_prod_attention(
+                query: torch.Tensor,
+                key: torch.Tensor,
+                value: torch.Tensor,
+                attn_mask: torch.Tensor,
+            ) -> torch.Tensor:
+                """Input tensors assumed to have shape (batch_size, n_head, seq_len, embed_dim)"""
+                assert query.dim() == 4
+                assert key.dim() == 4
+                assert value.dim() == 4
+                return (
+                    torch.matmul(query, key.transpose(-2, -1))
+                    .div(0.1)
+                    .masked_fill(attn_mask, float("-inf"))
+                    .softmax(dim=-1)
+                    .matmul(value)
+                )
+
+            tensor_shape = (2, 4, 8, 16)
+            batch_size, n_head, seq_len, embed_dim = tensor_shape
+            args = [
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn((1, 1, 8, 8), device="cuda")
+                > 0,  # Note the >0 to turn this into a binary mask
+            ]
+            # See whether the optimization matches our test pattern and is replaced
+            gm: torch.fx.GraphModule = torch._dynamo.export(dot_prod_attention, *args)[
+                0
+            ]
+            gm = sdpa_pattern_rewriter.fuse_scaled_dot_product_attention(gm)
+            graph_desc = create_graph_desc(gm)
+            self.assertExpectedInline(
+                graph_desc,
+                """\
+placeholder    arg0    arg0    ()    {}
+placeholder    arg1    arg1    ()    {}
+placeholder    arg2    arg2    ()    {}
+placeholder    arg3    arg3    ()    {}
+call_method    contiguous    contiguous    (arg0,)    {}
+call_method    contiguous_1    contiguous    (arg1,)    {}
+call_method    contiguous_2    contiguous    (arg2,)    {}
+call_function    truediv    <built-in function truediv>    (1.0, 0.1)    {}
+call_function    _scale_factor_dot_product_attention    _scale_factor_dot_product_attention    (contiguous, contiguous_1, contiguous_2)    {'attn_mask': arg3, 'dropout_p': 0.0, 'is_causal': False, 'scale_factor': truediv}
+output    output    output    ([_scale_factor_dot_product_attention],)    {}""",
+            )
+
+            saved_flag = torch._inductor.config.scaled_dot_product_attention_fusion
+            torch._inductor.config.scaled_dot_product_attention_fusion = True
+            try:
+                with freeze_rng_state():
+                    efficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                    actual = efficient_dot_prod_attention(*args)
+                torch._inductor.config.scaled_dot_product_attention_fusion = False
+                with freeze_rng_state():
+                    inefficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                    expected = inefficient_dot_prod_attention(*args)
+            finally:
+                torch._inductor.config.scaled_dot_product_attention_fusion = saved_flag
+            torch.testing.assert_close(actual, expected)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FUSED_SDPA, "Fused SDPA was not built for this system"
+    )
+    def test_sdpa_rewriter_6(self):
+        with sdp_kernel(enable_flash=False, enable_math=True):
+
+            def dot_prod_attention(
+                query: torch.Tensor,
+                key: torch.Tensor,
+                value: torch.Tensor,
+                attn_mask: torch.Tensor,
+            ) -> torch.Tensor:
+                """Input tensors assumed to have shape (batch_size, n_head, seq_len, embed_dim)"""
+                assert query.dim() == 4
+                assert key.dim() == 4
+                assert value.dim() == 4
+                return torch.nn.functional.dropout(
+                    torch.matmul(query, key.transpose(-2, -1))
+                    .div(0.1)
+                    .masked_fill(attn_mask, float("-inf"))
+                    .softmax(dim=-1),
+                    p=0.3,
+                    training=True,
+                    inplace=False,
+                ).matmul(value)
+
+            tensor_shape = (2, 4, 8, 16)
+            batch_size, n_head, seq_len, embed_dim = tensor_shape
+            args = [
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn(tensor_shape, device="cuda"),
+                torch.randn((1, 1, 8, 8), device="cuda")
+                > 0,  # Note the >0 to turn this into a binary mask
+            ]
+            # See whether the optimization matches our test pattern and is replaced
+            gm: torch.fx.GraphModule = torch._dynamo.export(dot_prod_attention, *args)[
+                0
+            ]
+            gm = sdpa_pattern_rewriter.fuse_scaled_dot_product_attention(gm)
+            graph_desc = create_graph_desc(gm)
+            self.assertExpectedInline(
+                graph_desc,
+                """\
+placeholder    arg0    arg0    ()    {}
+placeholder    arg1    arg1    ()    {}
+placeholder    arg2    arg2    ()    {}
+placeholder    arg3    arg3    ()    {}
+call_method    contiguous    contiguous    (arg0,)    {}
+call_method    contiguous_1    contiguous    (arg1,)    {}
+call_method    contiguous_2    contiguous    (arg2,)    {}
+call_function    truediv    <built-in function truediv>    (1.0, 0.1)    {}
+call_function    _scale_factor_dot_product_attention    _scale_factor_dot_product_attention    (contiguous, contiguous_1, contiguous_2)    {'attn_mask': arg3, 'dropout_p': 0.3, 'is_causal': False, 'scale_factor': truediv}
+output    output    output    ([_scale_factor_dot_product_attention],)    {}""",
+            )
+
+            saved_flag = torch._inductor.config.scaled_dot_product_attention_fusion
+            torch._inductor.config.scaled_dot_product_attention_fusion = True
+            try:
+                with freeze_rng_state():
+                    efficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                    actual = efficient_dot_prod_attention(*args)
+                torch._inductor.config.scaled_dot_product_attention_fusion = False
+                with freeze_rng_state():
+                    inefficient_dot_prod_attention = torch.compile(dot_prod_attention)
+                    expected = inefficient_dot_prod_attention(*args)
+            finally:
+                torch._inductor.config.scaled_dot_product_attention_fusion = saved_flag
+            torch.testing.assert_close(actual, expected)
+
+
+if __name__ == "__main__":
+    if IS_LINUX and HAS_CUDA:
+        run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -45,6 +45,10 @@ epilogue_fusion_first = False
 # enable pattern match+replace optimizations
 pattern_matcher = True
 
+# enable scaled dot-product attention replacements/fusions
+# based on pattern matching. (requires pattern_matcher==True)
+scaled_dot_product_attention_fusion = False
+
 # enable reordering pass
 reordering = False
 

--- a/torch/_inductor/sdpa_pattern_rewriter.py
+++ b/torch/_inductor/sdpa_pattern_rewriter.py
@@ -1,0 +1,239 @@
+import logging
+from typing import Callable, List, Optional, Tuple
+
+import torch
+import torch.nn
+from torch.fx import GraphModule
+from torch.fx.subgraph_rewriter import replace_multiple_patterns_with_filters
+
+log = logging.getLogger(__name__)
+
+# expected function signature: (query, key, value, attn_mask, dropout_p, is_causal, scale_factor) -> Tensor
+_scaled_dot_product_attention_impl = torch.nn.functional.scaled_dot_product_attention
+
+
+def set_scaled_dot_product_attention_impl(
+    scaled_dot_product_attention_impl: Callable,
+) -> None:
+    """
+    Sets the scaled_dot_product_attention function to be used to replace inefficient patterns.
+
+    Call this first, before calling fuse_scaled_dot_product_attention(...)
+
+    The passed function has to match the function signature of torch.nn.functional.scaled_dot_product with an additional
+    scale factor parameter which is commonly set to sqrt(EMBED_DIM) where EMBED_DIM equals query.size(-1)
+
+    IMPORTANT: Tested only for native functions (i.e. similar to torch.nn.functional.scaled_dot_product_attention, not custom Python functions which might be broken down further by torch dynamo )
+    This function is called once per graph module be
+
+    Arguments:
+        scaled_dot_product_attention_impl : (see above) sdpa implementation callable with signature (query, key, value, attn_mask, dropout_p, is_causal, scale_factor) -> Tensor
+    """
+    global _scaled_dot_product_attention_impl
+    _scaled_dot_product_attention_impl = scaled_dot_product_attention_impl
+
+
+def fuse_scaled_dot_product_attention(gm: torch.fx.GraphModule):
+    """
+    Fuses Convolution/BN layers for inference purposes. Modifies passed graph module in-place and returns it.
+
+    Arguments:
+        gm : torch.fx.GraphModule to apply sdpa graph optimizations to ( in-place)
+    Returns:
+        Same graph module after (inplace) optimizations have been applied.
+    """
+    global _scale_factor_dot_product_attention_replacement_graph_modules, _scaled_dot_product_attention_impl
+    if _scaled_dot_product_attention_impl is None:
+        log.warning(
+            "fuse_scaled_dot_product_attention(gm) called, without calling set_scaled_dot_product_attention_impl() first. Graph replacements will be dysfunctional."
+        )
+    _ensure_scale_factor_dot_product_attention_replacement_graph_modules()  # Compiles patterns and replacements on first call
+    # for (
+    #    pattern,
+    #    replacement,
+    # ) in _scale_factor_dot_product_attention_replacement_graph_modules:
+    #    replace_multiple_patterns_with_filters(gm, { pattern : replacement}, filters=None)
+    pmap = {
+        pattern: replacement
+        for pattern, replacement in _scale_factor_dot_product_attention_replacement_graph_modules
+    }
+    replace_multiple_patterns_with_filters(gm, pmap, match_filters=None)
+    # for pattern, replacement in _scale_factor_dot_product_attention_replacement_graph_modules:
+    #    replace_multiple_patterns_with_filters(gm, { pattern : replacement }, match_filters=None)
+    # replace_pattern(gm, pattern, replacement)
+
+    gm.graph.lint()
+    gm.recompile()
+    return gm
+
+
+@torch.fx.wrap
+def _scale_factor_dot_product_attention(
+    query, key, value, attn_mask, dropout_p, is_causal, scale_factor
+):
+    """
+    Wrapper for the configured scaled_dot_product_attention_impl, which ensures
+    the function is not broken down further by torch fx when compiling the replacement Graph
+    """
+    # If we do not torch.fx.wrap the call, dynamo compilation step could fail
+    # with TypeError: scaled_dot_product_attention(): argument 'scale_factor' (position 7) must be Number, not Proxy
+    # error thrown in python_arg_parser.cpp
+    return _scaled_dot_product_attention_impl(
+        query, key, value, attn_mask, dropout_p, is_causal, scale=scale_factor
+    )
+
+
+def _sfdp_pattern_1(query, key, value, inv_scale_factor):
+    return (
+        torch.matmul(query, key.transpose(-2, -1))
+        .div(inv_scale_factor)
+        .softmax(dim=-1)
+        .matmul(value)
+    )
+
+
+def _sfdp_replacement_1(query, key, value, inv_scale_factor):
+    return _scale_factor_dot_product_attention(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=False,
+        scale_factor=1.0 / inv_scale_factor,
+    )
+
+
+def _sfdp_pattern_2(query, key, value, scale_factor):
+    return (
+        torch.matmul(query, key.transpose(-2, -1))
+        .mul(scale_factor)
+        .softmax(dim=-1)
+        .matmul(value)
+    )
+
+
+def _sfdp_replacement_2(query, key, value, scale_factor):
+    return _scale_factor_dot_product_attention(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=False,
+        scale_factor=scale_factor,
+    )
+
+
+def _sfdp_pattern_3(query, key, value, inv_scale_factor, dropout_p):
+    return torch.nn.functional.dropout(
+        torch.matmul(query, key.transpose(-2, -1))
+        .div(inv_scale_factor)
+        .softmax(dim=-1),
+        p=dropout_p,
+    ).matmul(value)
+
+
+def _sfdp_replacement_3(query, key, value, inv_scale_factor, dropout_p):
+    return _scale_factor_dot_product_attention(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        attn_mask=None,
+        dropout_p=dropout_p,
+        is_causal=False,
+        scale_factor=1.0 / inv_scale_factor,
+    )
+
+
+def _sfdp_pattern_4(query, key, value, scale_factor, dropout_p):
+    return torch.nn.functional.dropout(
+        torch.matmul(query, key.transpose(-2, -1)).mul(scale_factor).softmax(dim=-1),
+        p=dropout_p,
+    ).matmul(value)
+
+
+def _sfdp_replacement_4(query, key, value, scale_factor, dropout_p):
+    return _scale_factor_dot_product_attention(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        attn_mask=None,
+        dropout_p=dropout_p,
+        is_causal=False,
+        scale_factor=scale_factor,
+    )
+
+
+def _sfdp_pattern_5(query, key, value, inv_scale_factor, attn_mask):
+    return (
+        torch.matmul(query, key.transpose(-2, -1))
+        .div(inv_scale_factor)
+        .masked_fill(attn_mask, float("-inf"))
+        .softmax(dim=-1)
+        .matmul(value)
+    )
+
+
+def _sfdp_replacement_5(query, key, value, inv_scale_factor, attn_mask):
+    return _scale_factor_dot_product_attention(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        attn_mask=attn_mask,
+        dropout_p=0.0,
+        is_causal=False,
+        scale_factor=1.0 / inv_scale_factor,
+    )
+
+
+def _sfdp_pattern_6(query, key, value, inv_scale_factor, attn_mask, dropout_p):
+    return torch.nn.functional.dropout(
+        torch.matmul(query, key.transpose(-2, -1))
+        .div(inv_scale_factor)
+        .masked_fill(attn_mask, float("-inf"))
+        .softmax(dim=-1),
+        p=dropout_p,
+    ).matmul(value)
+
+
+def _sfdp_replacement_6(query, key, value, inv_scale_factor, attn_mask, dropout_p):
+    return _scale_factor_dot_product_attention(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        attn_mask=attn_mask,
+        dropout_p=dropout_p,
+        is_causal=False,
+        scale_factor=1.0 / inv_scale_factor,
+    )
+
+
+# TODO: Add more patterns
+_scale_factor_dot_product_attention_replacements: List[Tuple[Callable, Callable]] = [
+    (_sfdp_pattern_1, _sfdp_replacement_1),
+    (_sfdp_pattern_2, _sfdp_replacement_2),
+    (_sfdp_pattern_3, _sfdp_replacement_3),
+    (_sfdp_pattern_4, _sfdp_replacement_4),
+    (_sfdp_pattern_5, _sfdp_replacement_5),
+    (_sfdp_pattern_6, _sfdp_replacement_6),
+]
+
+_scale_factor_dot_product_attention_replacement_graph_modules: Optional[
+    List[Tuple[GraphModule, GraphModule]]
+] = None
+
+
+def _ensure_scale_factor_dot_product_attention_replacement_graph_modules():
+    """
+    Builds the list of (scaled_dot_product_attention, replacement) tuples, if they haven't been built yet.
+    this operation is a bit expensive and should be done only once, since it requires torch.fx.symbolic_trace
+    for every pattern and replacement.
+    """
+    global _scale_factor_dot_product_attention_replacement_graph_modules
+    if _scale_factor_dot_product_attention_replacement_graph_modules is not None:
+        return
+    _scale_factor_dot_product_attention_replacement_graph_modules = [
+        (torch.fx.symbolic_trace(pattern), torch.fx.symbolic_trace(replacement))
+        for pattern, replacement in _scale_factor_dot_product_attention_replacements
+    ]


### PR DESCRIPTION
Summary:
### Goals

Many attention-based models directly implement scaled dot product attention used by transformer models using component pytorch operators.  Recognize these with FX rewrites and convert them to calls to sdpa(), such that
the optimized implementation is chosen where applicable.

Implementation

Given that the usual scaled dot product attention equation references a shape variable ( because everything gets normalized by a dividing by sqrt(embedding_dim_size), the graph rewrite is not entirely trivial.

It requires a new scale_factor parameter in torch.nn.functional.scaled_dot_product_attention ( not part of this PR, see  discussion https://github.com/pytorch/pytorch/pull/94729#discussion_r1107490896 about earlier version of this PR )

This in turn will allow to rewrite any pattern like

  torch.matmul(query, key.transpose(-2, -1))
        .div(scale_factor)
        .softmax(dim=-1)
        .matmul(value)

into a corresponding (potentially optimized) API call like

  scaled_dot_product_attention(
        query.contiguous(),
        key.contiguous(),
        value.contiguous(),
        attn_mask=None,
        dropout_p=0.0,
        is_causal=False,
        scale_factor=scale_factor,
    )

without knowing the scale factor or query and key shapes at compile time.

### Reviewer Notes:

As discussed with drisspg, this code would be ready for integration into torch._inductor.overrides once the scale_factor parameter is available on torch.nn.functional.scaled_dot_product_attention. Once that is done, the corresponding sections in the unit tests
may be activated again to verify not just the graph rewrite, but also numerical equivalence.

### Followup Tasks:

Once torch.nn.functional.scaled_dot_product_attention has a scale_factor parameter, this rewrite could be activated by configuring it as the sdpa implementation, and the inactive code sections in the unit tests could be made active again.

Test Plan:
Added several new unit tests. These can be executed selectively by running ( Meta Internal Tooling )

  buck2 test @//mode/dev-nosan caffe2/test/inductor:pattern_matcher -- test_sdpa_rewriter

Differential Revision: D43234635



cc @mcarilli @ptrblck @leslie-fang-intel @jgong5 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @soumith @yanboliang @anijain2305 @desertfire @mlazos