### PR TITLE
Pin setup-buildx-action version. Fix Docker build

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -72,6 +72,8 @@ jobs:
           QEMU_BINARY_PATH: ${{ runner.temp }}/bin
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.10.0
       - name: Setup job specific variables
         run: |
           set -eou pipefail

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,8 @@ RUN if test -n "${TRITON_VERSION}" -a "${TARGETPLATFORM}" != "linux/arm64"; then
         CU_VER=$(echo $CUDA_VERSION | cut -d'.' -f 1-2) && \
         mkdir -p /usr/local/triton-min-cuda-${CU_VER} && \
         ln -s /usr/local/triton-min-cuda-${CU_VER} /usr/local/cuda; \
-        mkdir -p /usr/local/cuda/bin; cp /opt/conda/bin/ptxas /usr/local/cuda/bin; \
-        mkdir -p /usr/local/cuda/include; cp /opt/conda/include/cuda.h /usr/local/cuda/include; \
+        # mkdir -p /usr/local/cuda/bin; cp /opt/conda/bin/ptxas /usr/local/cuda/bin; \
+        # mkdir -p /usr/local/cuda/include; cp /opt/conda/include/cuda.h /usr/local/cuda/include; \
     fi
 RUN rm -rf /var/lib/apt/lists/*
 ENV PATH /opt/conda/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,8 @@ RUN if test -n "${TRITON_VERSION}" -a "${TARGETPLATFORM}" != "linux/arm64"; then
         CU_VER=$(echo $CUDA_VERSION | cut -d'.' -f 1-2) && \
         mkdir -p /usr/local/triton-min-cuda-${CU_VER} && \
         ln -s /usr/local/triton-min-cuda-${CU_VER} /usr/local/cuda; \
-        # mkdir -p /usr/local/cuda/bin; cp /opt/conda/bin/ptxas /usr/local/cuda/bin; \
-        # mkdir -p /usr/local/cuda/include; cp /opt/conda/include/cuda.h /usr/local/cuda/include; \
+        mkdir -p /usr/local/cuda/bin; cp /opt/conda/bin/ptxas /usr/local/cuda/bin; \
+        mkdir -p /usr/local/cuda/include; cp /opt/conda/include/cuda.h /usr/local/cuda/include; \
     fi
 RUN rm -rf /var/lib/apt/lists/*
 ENV PATH /opt/conda/bin:$PATH


### PR DESCRIPTION
This pins setup-buildx-action version.
Our Docker builds where fixed by: https://github.com/pytorch/pytorch/pull/92702 on Jan 25,26
However setup-builder-action update on Jan 27 broke these builds again.
This PR pins version of setup-buildx-action and fixes Docker builds for nightly.
