### PR TITLE
Set C standard to C17 for CMake

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 build --cxxopt=--std=c++17
+build --copt=--std=c17
 build --copt=-I.
 # Bazel does not support including its cc_library targets as system
 # headers. We work around this for generated code

--- a/.buckconfig.oss
+++ b/.buckconfig.oss
@@ -13,6 +13,7 @@
   in_build = true
 
 [cxx]
+  cflags = -std=c17
   cxxflags = -std=c++17
   should_remap_host_platform = true
   cpp = /usr/bin/clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(env_cxx_standard GREATER -1)
       "PyTorch requires -std=c++17. Please remove -std=c++ settings in your environment.")
 endif()
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard whose features are requested to build this target.")
-set(CMAKE_C_STANDARD   11 CACHE STRING "The C standard whose features are requested to build this target.")
+set(CMAKE_C_STANDARD   17 CACHE STRING "The C standard whose features are requested to build this target.")
 
 # ---[ Utils
 include(cmake/public/utils.cmake)


### PR DESCRIPTION
Testing whether C17 breaks anything. I could find the CStandard being set anywhere for Bazel. Fixes #94739