### PR TITLE
[c10d] Enhance broadcastUniqueNCCLID error reporting

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1124,7 +1124,10 @@ void ProcessGroupNCCL::broadcastUniqueNCCLID(
           "', but store->get('",
           storeKey,
           "') got error: ");
-      TORCH_CHECK(false, exceptionMsg + e.what());
+      TORCH_CHECK(
+          false,
+          exceptionMsg + e.what() +
+              ". This may indicate a possible application crash on rank 0 or a network set up issue.");
     } catch (...) {
       TORCH_CHECK(
           false,
@@ -1134,7 +1137,8 @@ void ProcessGroupNCCL::broadcastUniqueNCCLID(
               "] is setting up NCCL communicator and "
               "retrieving ncclUniqueId from [0] via c10d key-value store by key '",
               storeKey,
-              "'"));
+              "'",
+              ". This may indicate a possible application crash on rank 0 or a network set up issue."));
     }
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94752

When this error is hit, usually it is because rank 0 has hit an error
and crashed before setting the unique ID on rank 0. However, in many job
scheduling tools the rank 0 error is not clearly reported and user must look
for it, so add a small log reminding users to do so.

Differential Revision: [D43245190](https://our.internmc.facebook.com/intern/diff/D43245190/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D43245190/)!