### PR TITLE
Revert "[BE] Use data() method when possible as it's safer and more r…

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -253,7 +253,7 @@ at::Tensor& embedding_bag_nbit_impl(
     } else {
       shape_arr[0] = output_size;
       shape_arr[1] = D;
-      shape = c10::IntArrayRef(shape_arr.data(), 2);
+      shape = c10::IntArrayRef(&shape_arr[0], 2);
     }
     at::native::resize_(output, shape, c10::nullopt);
   }
@@ -423,7 +423,7 @@ at::Tensor& embedding_bag_byte_impl(
     } else {
       shape_arr[0] = output_size;
       shape_arr[1] = D;
-      shape = c10::IntArrayRef(shape_arr.data(), 2);
+      shape = c10::IntArrayRef(&shape_arr[0], 2);
     }
     at::native::resize_(output, shape, c10::nullopt);
   }

--- a/c10/util/StringUtil.cpp
+++ b/c10/util/StringUtil.cpp
@@ -46,7 +46,7 @@ size_t ReplaceAll(std::string& s, c10::string_view from, c10::string_view to) {
   if (from.size() >= to.size()) {
     // If the replacement string is not larger than the original, we
     // can do the replacement in-place without allocating new storage.
-    char* s_data = s.data();
+    char* s_data = &s[0];
 
     while ((cur_pos = s.find(from.data(), last_pos, from.size())) !=
            std::string::npos) {

--- a/torch/csrc/init_flatbuffer_module.cpp
+++ b/torch/csrc/init_flatbuffer_module.cpp
@@ -117,8 +117,8 @@ extern "C"
       "_get_module_info_from_flatbuffer", [](std::string flatbuffer_content) {
         py::gil_scoped_acquire acquire;
         py::dict result;
-        mobile::ModuleInfo minfo = torch::jit::get_module_info_from_flatbuffer(
-            flatbuffer_content.data());
+        mobile::ModuleInfo minfo =
+            torch::jit::get_module_info_from_flatbuffer(&flatbuffer_content[0]);
         result["bytecode_version"] = minfo.bytecode_version;
         result["operator_version"] = minfo.operator_version;
         result["function_names"] = minfo.function_names;

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -1012,7 +1012,7 @@ std::string Unpickler::readBytes(size_t length) {
     // If the string is smallish, do a full buffer read,
     // and read out of that buffer.
     data.resize(length);
-    readSlowWithBuffer(data.data(), length);
+    readSlowWithBuffer(&data[0], length);
   } else {
     // Otherwise, for larger strings, read what we can from
     // the buffer, and then read directly to the destination.

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -434,9 +434,9 @@ ArgValue TensorExprKernel::toArg(const torch::jit::Value* v) const {
     }
     if (vec.empty()) {
       return BufList(); // Return arbitrarily typed vector
-    } else if (c10::get_if<BufHandle>(vec.data())) {
+    } else if (c10::get_if<BufHandle>(&vec[0])) {
       return convertVecArgValue<BufHandle>(vec);
-    } else if (c10::get_if<int64_t>(vec.data())) {
+    } else if (c10::get_if<int64_t>(&vec[0])) {
       return convertVecArgValue<int64_t>(vec);
     }
     throw unsupported_dtype();


### PR DESCRIPTION
This reverts commit 582485bf0f880de75c7eb36a466562f77e6c64db  (PR #92755) as it causes compilation errors on macOS.

Fixes #94723

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @EikanWang @ezyang 
