### PR TITLE
Fix XNNPACK missing symbol from post-operation.c

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -1969,6 +1969,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "XNNPACK/src/normalization.c",
             "XNNPACK/src/transpose-config.c",
             "XNNPACK/src/amalgam/scalar.c",
+            "XNNPACK/src/operators/post-operation.c",
         ] + LOGGING_SRCS,
         visibility = ["PUBLIC"],
         windows_clang_compiler_flags_override = (WINDOWS_FLAGS + WINDOWS_CLANG_COMPILER_FLAGS) if XNNPACK_WINDOWS_AVX512F_ENABLED else WINDOWS_FLAGS,


### PR DESCRIPTION
Summary: Fix RL team XNNPACK xnn_mutex.h issue.

Test Plan: buck2 test

Reviewed By: kirklandsign

Differential Revision: D43243129

