### PR TITLE
[inductor] fix sympy.core.numbers.Expr

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -93,7 +93,7 @@ def validate_ir(node_or_nodes):
                 TensorBox,
                 RandSeedBuffer,
                 torch.fx.experimental.symbolic_shapes.Symbol,
-                sympy.core.numbers.Expr,
+                Expr,
             ),
         ), f"Found {type(node)}, which is not a supported top level IR node. See [Note: Inductor IR]"
 


### PR DESCRIPTION
Summary: Fix sympy.core.numbers.Expr, sympy.core has no module 'numbers'

Test Plan: sandcastle

Differential Revision: D43254644



cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire