### PR TITLE
Fix test_module_patch

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -501,7 +501,9 @@ class VariableBuilder:
             # which doesn't support'CALL_FUNCTION'
             return UserMethodVariable(
                 value.__func__,
-                VariableBuilder(self.tx, source=AttrSource(self.source, "__self__"))(value.__self__),
+                VariableBuilder(self.tx, source=AttrSource(self.source, "__self__"))(
+                    value.__self__
+                ),
                 source=self.source,
                 guards=make_guards(GuardBuilder.FUNCTION_MATCH),
             )

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -63,7 +63,7 @@ from .dicts import (
     DefaultDictVariable,
     HFPretrainedConfigVariable,
 )
-from .functions import UserFunctionVariable
+from .functions import UserFunctionVariable, UserMethodVariable
 from .lists import (
     ListIteratorVariable,
     ListVariable,
@@ -495,6 +495,15 @@ class VariableBuilder:
                     guards=make_guards(GuardBuilder.FUNCTION_MATCH),
                 ),
                 "apply",
+            )
+        elif isinstance(value, types.MethodType):
+            # don't let methodtypes fall through to UserDefinedObject,
+            # which doesn't support'CALL_FUNCTION'
+            return UserMethodVariable(
+                value.__func__,
+                VariableBuilder(self.tx, source=AttrSource(self.source, "__self__"))(value.__self__),
+                source=self.source,
+                guards=make_guards(GuardBuilder.FUNCTION_MATCH),
             )
         elif isinstance(value, (int, float)) or (
             HAS_NUMPY and (isinstance(value, np.number))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94833
* #94832
* #94644
* #92125

- previously, patched module.forward was being directly wrapped in a UserFunctionVariable and then called.
- after my change to handle hooks,  module.__call__ was being inlined and then module.forward was being treated
  as a UserDefinedObjectVariable by _wrap
- a new special case in _wrap treats module.forward as a UserDefinedMethod instead of UserDefinedObjectVariable,
  which fixes "can't call UserDefinedObject"

cc @mlazos @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire