### PR TITLE
[FSDP] Fix `clip_grad_norm_()` when rank has no local gradients

### DIFF
--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -1,5 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
+import contextlib
+import functools
 import itertools
 import sys
 from typing import Union
@@ -299,6 +301,59 @@ class TestClipGradNorm(FSDPTest):
                 self.assertTrue(
                     torch.linalg.vector_norm(param.grad, norm_type).item() <= max_norm,
                 )
+
+    @skip_if_lt_x_gpu(2)
+    def test_no_gradients(self):
+        mixed_precision_config = MixedPrecision(
+            param_dtype=torch.float16,
+            reduce_dtype=torch.float16,
+            buffer_dtype=torch.float32,
+        )
+        teacher_backbone = nn.Linear(24, 24)
+        student_backbone = nn.Linear(24, 24)
+        head = nn.Linear(24, 24)
+        x_half1 = torch.randn(32, 24, device="cuda", dtype=torch.float16)
+        x_half2 = torch.randn(32, 24, device="cuda", dtype=torch.float16)
+        fsdp_wrapper = functools.partial(
+            FSDP,
+            sharding_strategy=ShardingStrategy.SHARD_GRAD_OP,
+            mixed_precision=mixed_precision_config,
+            device_id=self.rank,
+            use_orig_params=True,
+        )
+        teacher_backbone = fsdp_wrapper(teacher_backbone)
+        student_backbone = fsdp_wrapper(student_backbone)
+        head = fsdp_wrapper(head)
+        t1 = teacher_backbone(x_half1)
+        # Calling `detach()` means `head`'s parameters receives no gradients
+        t2 = head(t1).detach()
+        s1 = student_backbone(x_half2)
+        s2 = head(s1)
+        loss = (s2 * t2).sum()
+        loss.backward()
+        # Check that there are no errors
+        for module in [student_backbone, head]:
+            # If an FSDP root on a rank has no gradients, then we must fall
+            # back to the default dtype for the total norm (in this case, FP32)
+            context = (
+                self.assertWarnsRegex(
+                    expected_warning=UserWarning,
+                    expected_regex="on rank "
+                    rf"{self.rank} with no gradients -- returning the total "
+                    "norm in the default dtype torch.float32",
+                )
+                if module is head
+                else contextlib.suppress()
+            )
+            with context:
+                total_norm = module.clip_grad_norm_(1)
+            # For both `student_backbone` (with gradients) and `head` (without
+            # gradients), the total norm should be in FP32 since the gradients
+            # are cast back to the full precision before the optimizer step
+            self.assertEqual(total_norm.dtype, torch.float32)
+            if module is head:
+                # Since `head` has no gradients, the total norm is 0
+                self.assertEqual(total_norm, torch.tensor(0.0, device="cuda"))
 
 
 instantiate_parametrized_tests(TestClipGradNorm)

--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -1,7 +1,5 @@
 # Owner(s): ["oncall: distributed"]
 
-import contextlib
-import functools
 import itertools
 import sys
 from typing import Union
@@ -304,56 +302,40 @@ class TestClipGradNorm(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     def test_no_gradients(self):
+        """
+        Tests that calling ``clip_grad_norm_()`` when the FDSP module has no
+        gradients simply returns a scalar zero tensor in FP32 without erroring.
+        """
+        self.run_subtests(
+            {"use_orig_params": [False, True]},
+            self._test_no_gradients,
+        )
+
+    def _test_no_gradients(self, use_orig_params: bool):
+        lin_module = nn.Linear(24, 24)
         mixed_precision_config = MixedPrecision(
             param_dtype=torch.float16,
-            reduce_dtype=torch.float16,
+            reduce_dtype=torch.float32,
             buffer_dtype=torch.float32,
         )
-        teacher_backbone = nn.Linear(24, 24)
-        student_backbone = nn.Linear(24, 24)
-        head = nn.Linear(24, 24)
-        x_half1 = torch.randn(32, 24, device="cuda", dtype=torch.float16)
-        x_half2 = torch.randn(32, 24, device="cuda", dtype=torch.float16)
-        fsdp_wrapper = functools.partial(
-            FSDP,
+        fsdp_module = FSDP(
+            lin_module,
             sharding_strategy=ShardingStrategy.SHARD_GRAD_OP,
             mixed_precision=mixed_precision_config,
             device_id=self.rank,
-            use_orig_params=True,
+            use_orig_params=use_orig_params,
         )
-        teacher_backbone = fsdp_wrapper(teacher_backbone)
-        student_backbone = fsdp_wrapper(student_backbone)
-        head = fsdp_wrapper(head)
-        t1 = teacher_backbone(x_half1)
-        # Calling `detach()` means `head`'s parameters receives no gradients
-        t2 = head(t1).detach()
-        s1 = student_backbone(x_half2)
-        s2 = head(s1)
-        loss = (s2 * t2).sum()
-        loss.backward()
-        # Check that there are no errors
-        for module in [student_backbone, head]:
-            # If an FSDP root on a rank has no gradients, then we must fall
-            # back to the default dtype for the total norm (in this case, FP32)
-            context = (
-                self.assertWarnsRegex(
-                    expected_warning=UserWarning,
-                    expected_regex="on rank "
-                    rf"{self.rank} with no gradients -- returning the total "
-                    "norm in the default dtype torch.float32",
-                )
-                if module is head
-                else contextlib.suppress()
-            )
-            with context:
-                total_norm = module.clip_grad_norm_(1)
-            # For both `student_backbone` (with gradients) and `head` (without
-            # gradients), the total norm should be in FP32 since the gradients
-            # are cast back to the full precision before the optimizer step
-            self.assertEqual(total_norm.dtype, torch.float32)
-            if module is head:
-                # Since `head` has no gradients, the total norm is 0
-                self.assertEqual(total_norm, torch.tensor(0.0, device="cuda"))
+        inp = torch.randn(32, 24, device="cuda")
+        fsdp_module(inp)
+        with self.assertWarnsRegex(
+            expected_warning=UserWarning,
+            expected_regex="on rank "
+            rf"{self.rank} with no gradients -- returning the total "
+            "norm in the default dtype torch.float32",
+        ):
+            total_norm = fsdp_module.clip_grad_norm_(1)
+        self.assertEqual(total_norm.dtype, torch.float32)
+        self.assertEqual(total_norm, torch.tensor(0.0, device="cuda"))
 
 
 instantiate_parametrized_tests(TestClipGradNorm)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1072,8 +1072,8 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         # dtype as if we did not force local norm computation to be in FP32
         if len(grads) == 0:
             # If this rank has no gradients, then we must default to FP32
-            # without additional communication, which we prefer to avoid since
-            # `clip_grad_norm_()` is called in the training loop
+            # unless we use additional communication, which we prefer to avoid
+            # since `clip_grad_norm_()` is called in the training loop
             warnings.warn(
                 f"Called FSDP.clip_grad_norm_() on rank {self.rank} with no "
                 "gradients -- returning the total norm in the default dtype "

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1078,7 +1078,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                 f"Called FSDP.clip_grad_norm_() on rank {self.rank} with no "
                 "gradients -- returning the total norm in the default dtype "
                 f"{total_norm.dtype}"
-            )
+            )  # warn since this is generally unexpected
             return total_norm
         total_norm_dtype = functools.reduce(
             lambda dtype1, dtype2: torch.promote_types(dtype1, dtype2),

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1070,6 +1070,16 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             grad.detach().mul_(clip_coef_clamped.to(grad.device, grad.dtype))
         # Use the "largest" dtype by type promotion semantics to use the same
         # dtype as if we did not force local norm computation to be in FP32
+        if len(grads) == 0:
+            # If this rank has no gradients, then we must default to FP32
+            # without additional communication, which we prefer to avoid since
+            # `clip_grad_norm_()` is called in the training loop
+            warnings.warn(
+                f"Called FSDP.clip_grad_norm_() on rank {self.rank} with no "
+                "gradients -- returning the total norm in the default dtype "
+                f"{total_norm.dtype}"
+            )
+            return total_norm
         total_norm_dtype = functools.reduce(
             lambda dtype1, dtype2: torch.promote_types(dtype1, dtype2),
             [grad.dtype for grad in grads],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#94835 [FSDP] Fix `clip_grad_norm_()` when rank has no local gradients**

`functools.reduce()` requires non-empty input. We need to add a case for `len(grads) == 0`. 
