### PR TITLE
[jit] Add c++ stacktraces for jit::ErrorReport

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -2105,6 +2105,7 @@ def define_buck_targets(
             "torch/csrc/jit/mobile/prim_ops_registery.cpp",
             "torch/csrc/jit/runtime/operator.cpp",
             "torch/csrc/jit/runtime/slice_indices_adjust.cpp",
+            "torch/csrc/utils/cpp_stacktraces.cpp",
         ],
         header_namespace = "",
         exported_headers = [

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -71,7 +71,6 @@ def libtorch_generated_sources(gencode_pattern):
 
 # copied from https://github.com/pytorch/pytorch/blob/f99a693cd9ff7a9b5fdc71357dac66b8192786d3/aten/src/ATen/core/CMakeLists.txt
 jit_core_headers = [
-    "torch/csrc/utils/memory.h",
     "torch/csrc/Export.h",
     "torch/csrc/jit/frontend/source_range.h",
     "torch/csrc/jit/serialization/callstack_debug_info_serialization.h",
@@ -84,7 +83,8 @@ jit_core_headers = [
     "torch/csrc/jit/frontend/schema_type_parser.h",
     "torch/csrc/jit/frontend/error_report.h",
     "torch/csrc/jit/frontend/tree.h",
-    "torch/csrc/jit/utils/cpp_stacktraces.h",
+    "torch/csrc/utils/cpp_stacktraces.h",
+    "torch/csrc/utils/memory.h",
     "torch/custom_class.h",
     "torch/custom_class_detail.h",
     "torch/library.h",
@@ -97,7 +97,7 @@ jit_core_sources = [
     "torch/csrc/jit/frontend/schema_type_parser.cpp",
     "torch/csrc/jit/frontend/strtod.cpp",
     "torch/csrc/jit/frontend/source_range.cpp",
-    "torch/csrc/jit/utils/cpp_stacktraces.cpp",
+    "torch/csrc/utils/cpp_stacktraces.cpp",
 ]
 
 # copied from https://github.com/pytorch/pytorch/blob/0bde610c14b92d351b968a0228df29e92442b1cc/torch/CMakeLists.txt

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -84,6 +84,7 @@ jit_core_headers = [
     "torch/csrc/jit/frontend/schema_type_parser.h",
     "torch/csrc/jit/frontend/error_report.h",
     "torch/csrc/jit/frontend/tree.h",
+    "torch/csrc/jit/utils/cpp_stacktraces.h",
     "torch/custom_class.h",
     "torch/custom_class_detail.h",
     "torch/library.h",
@@ -96,6 +97,7 @@ jit_core_sources = [
     "torch/csrc/jit/frontend/schema_type_parser.cpp",
     "torch/csrc/jit/frontend/strtod.cpp",
     "torch/csrc/jit/frontend/source_range.cpp",
+    "torch/csrc/jit/utils/cpp_stacktraces.cpp",
 ]
 
 # copied from https://github.com/pytorch/pytorch/blob/0bde610c14b92d351b968a0228df29e92442b1cc/torch/CMakeLists.txt
@@ -403,7 +405,6 @@ core_sources_full_mobile_no_backend_interface_xplat = [
     "torch/csrc/jit/tensorexpr/unique_name_manager.cpp",
     "torch/csrc/jit/testing/file_check.cpp",
     "torch/csrc/jit/testing/hooks_for_testing.cpp",
-    "torch/csrc/utils/cpp_stacktraces.cpp",
     "torch/csrc/utils/schema_info.cpp",
     "torch/csrc/utils/tensor_flatten.cpp",
     "torch/csrc/utils/variadic.cpp",

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -2,6 +2,7 @@
 #define C10_UTIL_LOGGING_H_
 
 #include <climits>
+#include <cstring>
 #include <exception>
 #include <functional>
 #include <limits>

--- a/torch/csrc/jit/frontend/error_report.cpp
+++ b/torch/csrc/jit/frontend/error_report.cpp
@@ -13,7 +13,7 @@ thread_local std::vector<Call> calls;
 #endif // C10_MOBILE
 
 namespace {
-std::string unwrap_backtrace(c10::optional<std::string>& backtrace) {
+std::string unwrap_backtrace(const c10::optional<std::string>& backtrace) {
   if (backtrace.has_value()) {
     return backtrace.value();
   }
@@ -29,7 +29,7 @@ ErrorReport::ErrorReport(const ErrorReport& e)
       backtrace_(e.backtrace_) {}
 
 #ifndef C10_MOBILE
-ErrorReport::ErrorReport(SourceRange r, c10::optional<std::string>& backtrace)
+ErrorReport::ErrorReport(SourceRange r, const c10::optional<std::string>& backtrace)
     : context(std::move(r)), error_stack(calls.begin(), calls.end()), backtrace_(unwrap_backtrace(backtrace)) {}
 
 void ErrorReport::CallStack::update_pending_range(const SourceRange& range) {

--- a/torch/csrc/jit/frontend/error_report.cpp
+++ b/torch/csrc/jit/frontend/error_report.cpp
@@ -3,6 +3,7 @@
 #include <c10/util/Logging.h>
 #include <c10/util/Optional.h>
 #include <torch/csrc/jit/frontend/tree.h>
+#include <torch/csrc/utils/cpp_stacktraces.h>
 #include <torch/csrc/utils/memory.h>
 
 namespace torch::jit {
@@ -91,6 +92,10 @@ const char* ErrorReport::what() const noexcept {
   context.highlight(msg);
 
   msg << get_stacked_errors(error_stack);
+
+  if (get_cpp_stacktraces_enabled()) {
+    msg << "\n" << backtrace_;
+  }
 
   the_message = msg.str();
   return the_message.c_str();

--- a/torch/csrc/jit/frontend/error_report.cpp
+++ b/torch/csrc/jit/frontend/error_report.cpp
@@ -1,7 +1,7 @@
 #include <torch/csrc/jit/frontend/error_report.h>
 
-#include <c10/util/Optional.h>
 #include <c10/util/Logging.h>
+#include <c10/util/Optional.h>
 #include <torch/csrc/jit/frontend/tree.h>
 #include <torch/csrc/utils/memory.h>
 
@@ -29,8 +29,12 @@ ErrorReport::ErrorReport(const ErrorReport& e)
       backtrace_(e.backtrace_) {}
 
 #ifndef C10_MOBILE
-ErrorReport::ErrorReport(SourceRange r, const c10::optional<std::string>& backtrace)
-    : context(std::move(r)), error_stack(calls.begin(), calls.end()), backtrace_(unwrap_backtrace(backtrace)) {}
+ErrorReport::ErrorReport(
+    SourceRange r,
+    const c10::optional<std::string>& backtrace)
+    : context(std::move(r)),
+      error_stack(calls.begin(), calls.end()),
+      backtrace_(unwrap_backtrace(backtrace)) {}
 
 void ErrorReport::CallStack::update_pending_range(const SourceRange& range) {
   calls.back().caller_range = range;

--- a/torch/csrc/jit/frontend/error_report.h
+++ b/torch/csrc/jit/frontend/error_report.h
@@ -15,9 +15,17 @@ struct Call {
 struct TORCH_API ErrorReport : public std::exception {
   ErrorReport(const ErrorReport& e);
 
-  explicit ErrorReport(SourceRange r, const c10::optional<std::string>& backtrace = c10::nullopt);
-  explicit ErrorReport(const TreeRef& tree, const c10::optional<std::string>& backtrace = c10::nullopt) : ErrorReport(tree->range(), backtrace) {}
-  explicit ErrorReport(const Token& tok, const c10::optional<std::string>& backtrace = c10::nullopt) : ErrorReport(tok.range, backtrace) {}
+  explicit ErrorReport(
+      SourceRange r,
+      const c10::optional<std::string>& backtrace = c10::nullopt);
+  explicit ErrorReport(
+      const TreeRef& tree,
+      const c10::optional<std::string>& backtrace = c10::nullopt)
+      : ErrorReport(tree->range(), backtrace) {}
+  explicit ErrorReport(
+      const Token& tok,
+      const c10::optional<std::string>& backtrace = c10::nullopt)
+      : ErrorReport(tok.range, backtrace) {}
 
   const char* what() const noexcept override;
 

--- a/torch/csrc/jit/frontend/error_report.h
+++ b/torch/csrc/jit/frontend/error_report.h
@@ -14,9 +14,9 @@ struct Call {
 struct TORCH_API ErrorReport : public std::exception {
   ErrorReport(const ErrorReport& e);
 
-  explicit ErrorReport(SourceRange r);
-  explicit ErrorReport(const TreeRef& tree) : ErrorReport(tree->range()) {}
-  explicit ErrorReport(const Token& tok) : ErrorReport(tok.range) {}
+  explicit ErrorReport(SourceRange r, c10::optional<std::string>& backtrace = c10::nullopt);
+  explicit ErrorReport(const TreeRef& tree, c10::optional<std::string>& backtrace = c10::nullopt) : ErrorReport(tree->range(), backtrace) {}
+  explicit ErrorReport(const Token& tok, c10::optional<std::string>& backtrace = c10::nullopt) : ErrorReport(tok.range, backtrace) {}
 
   const char* what() const noexcept override;
 
@@ -42,6 +42,7 @@ struct TORCH_API ErrorReport : public std::exception {
   OwnedSourceRange context;
   mutable std::string the_message;
   std::vector<Call> error_stack;
+  std::string backtrace_;
 };
 
 template <typename T>

--- a/torch/csrc/jit/frontend/error_report.h
+++ b/torch/csrc/jit/frontend/error_report.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/Backtrace.h>
 #include <c10/util/Optional.h>
 #include <torch/csrc/jit/frontend/tree.h>
 
@@ -14,9 +15,9 @@ struct Call {
 struct TORCH_API ErrorReport : public std::exception {
   ErrorReport(const ErrorReport& e);
 
-  explicit ErrorReport(SourceRange r, c10::optional<std::string>& backtrace = c10::nullopt);
-  explicit ErrorReport(const TreeRef& tree, c10::optional<std::string>& backtrace = c10::nullopt) : ErrorReport(tree->range(), backtrace) {}
-  explicit ErrorReport(const Token& tok, c10::optional<std::string>& backtrace = c10::nullopt) : ErrorReport(tok.range, backtrace) {}
+  explicit ErrorReport(SourceRange r, const c10::optional<std::string>& backtrace = c10::nullopt);
+  explicit ErrorReport(const TreeRef& tree, const c10::optional<std::string>& backtrace = c10::nullopt) : ErrorReport(tree->range(), backtrace) {}
+  explicit ErrorReport(const Token& tok, const c10::optional<std::string>& backtrace = c10::nullopt) : ErrorReport(tok.range, backtrace) {}
 
   const char* what() const noexcept override;
 


### PR DESCRIPTION
**Summary**: This PR adds C++ stacktraces to jit::ErrorReports. After this PR, if you run with `TORCH_SHOW_CPP_STACKTRACES=1` environment variable and a jit::ErrorReport is thrown, then the C++ stacktrace should be displayed.

**More background**: This behavior already occurs for c10::Error; but not for jit::ErrorReport. jit::ErrorReport _does_ usually have a python stacktrace for the python source, but it is sometimes still helpful to know where in the C++ codebase the error came from.