### PR TITLE
[ONNX] Fix assert in cat

### DIFF
--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -538,7 +538,7 @@ def cat(g: jit_utils.GraphContext, tensor_list, dim):
     assert len(nonempty_tensors) > 0
     assert all(
         [
-            symbolic_helper._get_tensor_rank(nonempty_tensors[0]) is None
+            symbolic_helper._get_tensor_rank(t) is None
             or symbolic_helper._get_tensor_rank(t)
             == symbolic_helper._get_tensor_rank(nonempty_tensors[0])
             for t in nonempty_tensors

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -538,7 +538,8 @@ def cat(g: jit_utils.GraphContext, tensor_list, dim):
     assert len(nonempty_tensors) > 0
     assert all(
         [
-            symbolic_helper._get_tensor_rank(t) is None
+            symbolic_helper._get_tensor_rank(nonempty_tensors[0]) is None
+            or symbolic_helper._get_tensor_rank(t) is None
             or symbolic_helper._get_tensor_rank(t)
             == symbolic_helper._get_tensor_rank(nonempty_tensors[0])
             for t in nonempty_tensors


### PR DESCRIPTION
The assert statement blocks tensors with unknown ranks. This change unblocks those cases. Needed for https://github.com/pytorch/vision/pull/7056

Verified against https://github.com/pytorch/vision/pull/7056