### PR TITLE
Move empty check to the start of _pack_padded_sequence

### DIFF
--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -32,13 +32,14 @@ void checkLongTensor(const Tensor& tensor) {
 // must be a CPU int64 tensor.
 // See NOTE [ device and dtype of a PackedSequence ]
 std::tuple<Tensor, Tensor> _pack_padded_sequence(const Tensor& _input, const Tensor& _lengths, bool batch_first) {
+  TORCH_CHECK(_input.numel() > 0, "Cannot pack empty tensors.");
   auto input = batch_first ? _input.transpose(0, 1) : _input;
   auto lengths_t = _lengths.contiguous();
   checkLongTensor(lengths_t);
 
   int64_t batch_size = input.size(1);
   int64_t * lengths = lengths_t.data_ptr<int64_t>();
-  TORCH_CHECK(input.numel() > 0, "Cannot pack empty tensors.");
+
   TORCH_CHECK(lengths_t.size(0) == batch_size,
            "Expected `len(lengths)` to be equal to batch_size, but got ", lengths_t.size(0),
            " (batch_size=", batch_size, ")");

--- a/test/nn/test_packed_sequence.py
+++ b/test/nn/test_packed_sequence.py
@@ -386,6 +386,9 @@ class PackedSequenceTest(TestCase):
             packed = rnn_utils.pack_padded_sequence(torch.randn(3, 3), [1, 3, 2])
         with self.assertRaisesRegex(RuntimeError, 'empty tensor'):
             packed = rnn_utils.pack_padded_sequence(torch.randn(0, 0), [])
+        with self.assertRaisesRegex(RuntimeError, 'empty tensor'):
+            packed = rnn_utils.pack_padded_sequence(torch.randn([0, 1, 10]),
+                                                    torch.randn([11, 14, 14, 2]), True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #94122.
Move empty check to the start of `_pack_padded_sequence`.
