### PR TITLE
Update smoke test threshold

### DIFF
--- a/benchmarks/dynamo/check_hf_bert_perf_csv.py
+++ b/benchmarks/dynamo/check_hf_bert_perf_csv.py
@@ -17,7 +17,8 @@ def check_hf_bert_perf_csv(filename):
         model_name = row["name"]
         speedup = row["speedup"]
         # Reduced from 1.19 to 1.17, see https://github.com/pytorch/pytorch/issues/94687
-        if speedup < 1.17:
+        # Reduce further to 1.165 due to runner and run to run variances
+        if speedup < 1.165:
             failed.append(model_name)
 
         print(f"{model_name:34} {speedup}")


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/94249 touched upon what values we should set. It turns out 1.17 is too high, as seemingly innocent commits are failing to yield 1.17x. They yielded ~1.168x. 
https://github.com/pytorch/pytorch/actions/runs/4180998255/jobs/7242758816 
<img width="881" alt="image" src="https://user-images.githubusercontent.com/109318740/218951536-476d3764-1aa6-481b-bd92-f55d1c50e385.png">

Setting it to 1.165x. 




cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire