### PR TITLE
[SDPA] Update dispatch logic to check for sm86 and head_size == 128 for flash attention 

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -29,6 +29,15 @@ To bit_cast(From f) {
   return t;
 }
 
+// This helper function creates a constexpr std::array
+// From a compile time list of values
+template <typename V, typename... T>
+constexpr auto array_of(T&&... t)
+    -> std::array < V, sizeof...(T) >
+{
+    return {{ std::forward<T>(t)... }};
+}
+
 struct sdp_params {
   const at::Tensor& query;
   const at::Tensor& key;
@@ -395,6 +404,18 @@ inline bool check_gpu_sm86_head_dim_128(sdp_params params, bool debug) {
   return true;
 }
 
+inline bool check_requires_grad_and_head_dim_128_and_sm86(sdp_params params, bool debug){
+  // Flash Attention will raise an error in the backward pass if the head_dim size is 128
+  // And the device is not sm80, the other head_dim check catches everything but sm86
+  if (!check_requires_grad(params, false) && !check_gpu_sm86_head_dim_128(params, false)){
+    if (debug){
+      TORCH_WARN("Flash attention currently doesn't support training with head_dim == 128 on sm86.");
+    }
+    return false;
+  }
+  return true;
+}
+
 inline bool check_use_deterministic_algorithms(sdp_params params, bool debug) {
   auto& ctx = at::globalContext();
   if (ctx.deterministicAlgorithms()) {
@@ -421,8 +442,10 @@ inline bool use_flash_attention(sdp_params params, bool debug) {
   TORCH_CHECK(!debug, "Torch was not compiled with flash attention.");
   return false;
 #endif
-  //  Define gate functions that determine if a flash kernel can be ran
-  constexpr std::array<bool(*)(sdp_params, bool), 8> constraints {{
+
+  // Define gate functions that determine if a flash kernel can be ran
+  // Replace with std::to_array when we migrate to c++20
+  constexpr auto constraints = array_of<bool (*)(sdp_params, bool)>(
       check_runtime_disabled_flash,
       check_tensor_shapes,
       check_equal_batch_size_and_num_heads,
@@ -430,7 +453,8 @@ inline bool use_flash_attention(sdp_params params, bool debug) {
       check_head_dim_size,
       check_gpu_sm75_or_greater,
       check_for_nested_inputs,
-      check_for_seq_len_1_nested_tensor}};
+      check_requires_grad_and_head_dim_128_and_sm86,
+      check_for_seq_len_1_nested_tensor);
   for (auto& constraint : constraints) {
     if (!constraint(params, debug)) {
       return false;
@@ -439,10 +463,10 @@ inline bool use_flash_attention(sdp_params params, bool debug) {
 
   auto dprop = at::cuda::getCurrentDeviceProperties();
   if (dprop->major >= 8) {
-    static const std::array<at::ScalarType, 2> sm80_flash_dtypes{at::kHalf, at::kBFloat16};
+    constexpr auto sm80_flash_dtypes = array_of<at::ScalarType> (at::kHalf, at::kBFloat16);
     return check_tensor_dtype(params, sm80_flash_dtypes, debug);
   } else {
-    static const std::array<at::ScalarType, 1> default_flash_dtypes{at::kHalf};
+    constexpr auto default_flash_dtypes = array_of<at::ScalarType> (at::kHalf);
     return check_tensor_dtype(params, default_flash_dtypes, debug);
   }
 }
@@ -452,12 +476,12 @@ inline bool use_mem_efficient_attention(sdp_params params, bool debug) {
   TORCH_CHECK(!debug, "Torch was not compiled with flash attention.");
   return false;
 #endif
-  // Constraints specific to flash attention
-  static const std::vector<caffe2::ScalarType> flash_dtypes{
-      at::kHalf, at::kFloat, at::kBFloat16};
+  // Constraints specific to mem efficient attention
+  constexpr auto mem_efficient_dtypes =
+      array_of<at::ScalarType>(at::kHalf, at::kFloat, at::kBFloat16);
 
   //  Define gate functions that determine if a flash kernel can be ran
-  constexpr std::array<bool(*)(sdp_params, bool), 11> constraints{{
+  constexpr auto constraints = array_of<bool (*)(sdp_params, bool)>(
       check_gpu_sm50_or_greater,
       check_runtime_disabled_mem_efficient,
       check_requires_grad_and_nested,
@@ -468,13 +492,13 @@ inline bool use_mem_efficient_attention(sdp_params params, bool debug) {
       check_gpu_sm86_head_dim_128,
       check_for_seq_len_1_nested_tensor,
       check_for_non_zero_dropout,
-      check_use_deterministic_algorithms}};
+      check_use_deterministic_algorithms);
   for (auto& constraint : constraints) {
     if (!constraint(params, debug)) {
       return false;
     }
   }
-  if (!check_tensor_dtype(params, flash_dtypes, debug)) {
+  if (!check_tensor_dtype(params, mem_efficient_dtypes, debug)) {
     return false;
   }
   return true;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -169,12 +169,10 @@ inline bool check_for_nested_inputs(sdp_params params, bool debug){
 }
 
 inline bool check_requires_grad(sdp_params params, bool debug) {
-  bool any_tensors_are_subclass =
-      at::areAnyTensorSubclassLike({params.query, params.key, params.value});
   const bool any_inputs_require_grad = params.query.requires_grad() ||
       params.key.requires_grad() || params.value.requires_grad();
   const bool gradmode_enabled = at::GradMode::is_enabled();
-  if ((any_inputs_require_grad && gradmode_enabled) || any_tensors_are_subclass) {
+  if ((any_inputs_require_grad && gradmode_enabled)) {
     if (debug) {
       TORCH_WARN("Flash Attention does not currently support training.");
     }

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1512,7 +1512,9 @@ class TestSDPA(NNTestCase):
             torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, False)
 
             # Should fail because inputs require grad
-            q, k, v = make_tensor(size, requires_grad=True), make_tensor(size, requires_grad=True), make_tensor(size, requires_grad=True)
+            q = make_tensor(size, requires_grad=True)
+            k = make_tensor(size, requires_grad=True)
+            v = make_tensor(size, requires_grad=True)
             self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
                 q, k, v, None, 0.0, False))
 

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1499,6 +1499,23 @@ class TestSDPA(NNTestCase):
             self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
                 q, k, v, None, 0.0, False))
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA or not isSM86Device, "CUDA unavailable")
+    def test_flash_backward_sm86_headdim128(self):
+        device = 'cuda'
+        dtype = torch.float16
+        make_tensor = partial(self.rand_tensor, type="dense", device=device, dtype=dtype)
+        # See check_gpu_sm86_head_dim_128 in pytorch/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+        size = (2, 2, 4, 128)
+        q, k, v = make_tensor(size), make_tensor(size), make_tensor(size)
+        with sdp_kernel(enable_mem_efficient=False, enable_flash=True, enable_math=False):
+            # Should not fail because inputs don't require grad
+            torch.nn.functional.scaled_dot_product_attention(q, k, v, None, 0.0, False)
+
+            # Should fail because inputs require grad
+            q, k, v = make_tensor(size, requires_grad=True), make_tensor(size, requires_grad=True), make_tensor(size, requires_grad=True)
+            self.assertRaises(RuntimeError, lambda: torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, None, 0.0, False))
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_SDPA, "Does not support fused scaled dot product attention")
     def test_dispatch_fails_no_backend(self):
         dtype = torch.float16


### PR DESCRIPTION
Fixes #94883

Where backward for flash_attention on sm86 hardware with head_size == 128 is not supported.
