### PR TITLE
[pt2][inductor]global autotuning cache

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -16,8 +16,8 @@ torch.backends.cuda.matmul.allow_tf32 = False
 
 
 def patches(fn):
-    def skip_cache(self, key, generate):
-        return generate()
+    def skip_cache(self, choices, name, key, generate):
+        return {choice: generate(choice) for choice in choices}
 
     for patcher in [
         dynamo_config.patch(verbose=True),
@@ -52,7 +52,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(16, device="cuda"),
         )
         # Autotuning checks correctness of each version
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+        self.assertEqual(counters["inductor"]["choice_caller_benchmarked"], 14)
         # It would be nice to assert this got fused into a single kernel, but that
         # only happens if we select a triton template (and not aten).
 
@@ -68,7 +68,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(20, 16, device="cuda"),
         )
         # Autotuning checks correctness of each version
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+        self.assertEqual(counters["inductor"]["choice_caller_benchmarked"], 13)
 
     @patches
     def test_mm(self):
@@ -80,7 +80,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(8, 32, device="cuda"),
             torch.randn(32, 8, device="cuda"),
         )
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+        self.assertEqual(counters["inductor"]["choice_caller_benchmarked"], 13)
 
     @patches
     def test_mm_skip(self):
@@ -93,7 +93,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(32, 8, device="cuda", dtype=torch.float64),
         )
         # float64 not supported by tl.dot()
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 0)
+        self.assertEqual(counters["inductor"]["choice_caller_benchmarked"], 0)
 
     @patches
     def test_bmm(self):
@@ -106,7 +106,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(2, 32, 8, device="cuda"),
         )
         # Autotuning checks correctness of each version
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+        self.assertEqual(counters["inductor"]["choice_caller_benchmarked"], 13)
 
     @patches
     def test_mm_not_even_k(self):
@@ -118,7 +118,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(11, 22, device="cuda"),
             torch.randn(22, 33, device="cuda"),
         )
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+        self.assertEqual(counters["inductor"]["choice_caller_benchmarked"], 13)
 
     @patches
     def test_baddbmm(self):
@@ -132,7 +132,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(2, 1, 8, device="cuda"),
         )
         # Autotuning checks correctness of each version
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+        self.assertEqual(counters["inductor"]["choice_caller_benchmarked"], 13)
 
     @patches
     def test_mm_plus_mm(self):
@@ -147,7 +147,7 @@ class TestSelectAlgorithm(TestCase):
             torch.randn(32, 32, device="cuda"),
         )
         # Autotuning checks correctness of each version
-        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+        self.assertEqual(counters["inductor"]["choice_caller_benchmarked"], 11)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -17,16 +17,25 @@ import tempfile
 import types
 from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from ctypes import cdll
+from functools import partial
 from threading import Thread
 from time import sleep, time
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Tuple
 
 import torch
 
+from torch._inductor import config, cuda_properties, exc
+from torch._inductor.utils import developer_warning
 from torch.hub import _Faketqdm, tqdm
 from torch.utils import cpp_extension
-from . import config, cuda_properties, exc
-from .utils import developer_warning
+
+if config.is_fbcode():
+    from torch._inductor.fb.logging import global_cache_log
+else:
+
+    def global_cache_log(*args, **kwargs):
+        pass
+
 
 LOCK_TIMEOUT = 600
 
@@ -56,51 +65,112 @@ logging.getLogger("filelock").setLevel(logging.DEBUG if config.debug else loggin
 
 @functools.lru_cache(None)
 def cache_dir():
-    return os.environ.get(
+    cache_dir = os.environ.get(
         "TORCHINDUCTOR_CACHE_DIR",
         f"{tempfile.gettempdir()}/torchinductor_{getpass.getuser()}",
     )
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir
 
 
-def remove_cache_dir():
-    """
-    Removes the directory added automatically by inductor during compilation.
-    Uses the cache_dir function above.
+class PersistentCache:
+    def __init__(self):
+        self.local_cache_path = os.path.join(cache_dir(), "local_cache")
+        self.global_cache_path = config.global_cache_path
 
-    No op if the directory does not exist.
-    """
-    if os.path.isdir(cache_dir()):
-        shutil.rmtree(cache_dir())
+        if torch.cuda.is_available():
+            self.dinfo = repr(
+                torch.cuda.get_device_properties(torch.cuda.current_device())
+            )
+            self.vinfo = torch.version.cuda
 
+    def get_local_cache(self):
+        if not os.path.isfile(self.local_cache_path):
+            return {}
+        with open(self.local_cache_path, "r") as local_cache_file:
+            local_cache = json.load(local_cache_file)
+        return local_cache
 
-class DiskCache:
-    @staticmethod
+    def update_local_cache(self, local_cache):
+        write_atomic(self.local_cache_path, json.dumps(local_cache, indent=4))
+
     @functools.lru_cache(None)
-    def _subdir():
-        subdir = os.path.join(cache_dir(), "cached_tunings")
-        os.makedirs(subdir, exist_ok=True)
-        return subdir
+    def get_global_cache(self):
+        if self.global_cache_path is None or not os.path.isfile(self.global_cache_path):
+            return {}
+        with open(self.global_cache_path, "r") as global_cache_file:
+            global_cache = json.load(global_cache_file)
+        if self.dinfo not in global_cache:
+            global_cache[self.dinfo] = {}
+        if self.vinfo not in global_cache[self.dinfo]:
+            global_cache[self.dinfo][self.vinfo] = {}
+        return global_cache[self.dinfo][self.vinfo]
 
-    @staticmethod
-    @functools.lru_cache(4096)
-    def _read_file(path):
-        with open(path, "r") as fd:
-            return json.loads(fd.read())
-
-    def __init__(self, unique_name):
-        super().__init__()
-        self.unique_name = unique_name
-
-    def lookup(self, key: Any, generate: Callable[[], Any]):
+    def lookup(
+        self,
+        choices,
+        name: str,
+        inputs: str,
+        benchmark: Callable[[Any], Tuple[Dict, bool]],
+    ):
         """
-        Check if we have already generated key, if not call generate()
-        to populate the cache.
+        Check to see if we have benchmarked the given choice callers. For each
+        choice caller:
+
+            1. Check global_cache[name][inputs][choice], return benchmark if cached.
+            2. Check local_cache[name][inputs][choice], return benchmark if cached.
+            3.
+                a. `max_autotune=True`: benchmark the choice, update
+                    local_cache[name][inputs][choice], and return the benchmark.
+                b. `max_autotune=False`: don't benchmark the choice, return nothing.
         """
-        path = os.path.join(self._subdir(), code_hash(self.unique_name + repr(key)))
-        if not os.path.exists(path):
-            value = generate()
-            write_atomic(path, json.dumps(value))
-        return self._read_file(path)
+        local_cache, benchmarked = self.get_local_cache(), False
+        global_cache, gc_log = self.get_global_cache(), partial(
+            global_cache_log, self.dinfo, self.vinfo, name, inputs
+        )
+
+        timings = {}
+        for choice in choices:
+            choice_hash = choice.hash_key()
+
+            if (
+                name in global_cache
+                and inputs in global_cache[name]
+                and choice_hash in global_cache[name][inputs]
+            ):
+                # global cache hit
+                timings[choice] = global_cache[name][inputs][choice_hash]
+                gc_log(choice_hash, cached=True)
+                continue
+            # global cache miss
+            gc_log(choice_hash, cached=False)
+
+            if (
+                name in local_cache
+                and inputs in local_cache[name]
+                and choice_hash in local_cache[name][inputs]
+            ):
+                # local cache hit
+                timings[choice] = local_cache[name][inputs][choice_hash]
+                continue
+            # local cache miss
+            if not config.max_autotune:
+                continue
+
+            # benchmark the choice
+            if name not in local_cache:
+                local_cache[name] = {}
+            if inputs not in local_cache[name]:
+                local_cache[name][inputs] = {}
+            local_cache[name][inputs][choice_hash], benchmarked = (
+                benchmark(choice),
+                True,
+            )
+
+        if benchmarked:
+            self.update_local_cache(local_cache)
+
+        return timings
 
 
 def get_lock_dir():

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -48,6 +48,9 @@ reordering = False
 # enable slow autotuning passes to select algorithms
 max_autotune = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE") == "1"
 
+# enable searching global and local cache regardless of `max_autotune`
+search_autotune_cache = os.environ.get("TORCHINDUCTOR_SEARCH_AUTOTUNE_CACHE") == "1"
+
 # control store vs recompute heuristic
 # For fanouts, rematearialization can lead to exponential blowup. So, have
 # smaller threshold
@@ -95,6 +98,14 @@ compile_threads = (
         else os.cpu_count(),
     )
 )
+
+# autotuning global cache path
+if is_fbcode():
+    from libfb.py import parutil
+
+    global_cache_path = parutil.get_file_path("fb/global_cache", pkg=__package__)
+else:
+    global_cache_path = None
 
 # If kernel is fused, the name is generated from the origin node op names
 # for larger kernels limit this

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -483,7 +483,7 @@ def is_big_gpu(index):
 
 def use_triton_template(layout):
     return (
-        inductor_config.max_autotune
+        (inductor_config.max_autotune or inductor_config.search_autotune_cache)
         and layout.device.type == "cuda"
         and layout.dtype in (torch.float16, torch.bfloat16, torch.float32)
         and is_big_gpu(layout.device.index or 0)


### PR DESCRIPTION
Summary:
this diff adds logic to handle a global autotuning cache, stored in json format at config.global_cache_path.

what is changing from `DiskCache`:
* `DiskCache` is renamed to `PersistentCache`
* the local cache is now stored as a single file in json format, located at `/tmp/torchinductor_{$USER}/local_cache`. the file contains a dictionary structure like `local_cache[name][inputs][choice]` where `name` is the type of operation, like `addmm`, `inputs` is the repr of the inputs, and `choice` is the hash of a `ChoiceCaller`. the stored value is the benchmark time for that `ChoiceCaller`.
* a global cache is added, initially stored at `fbcode/caffe2/torch/_inductor/global_cache`, with almost identical format as the local cache. since the global cache exists over different machines, there is an additional `dinfo` field, such that `global_cache[dinfo] = local_cache` (at least structure wise, there is no guarantee that the global cache and local cache share the same values). `dinfo` is just a repr of the cuda device properties.
* the autotuner will prioritize the global cache, and return values from there first, before looking in the local cache
* the autotuner will look in both the global cache and the local cache even when `max_autotune=False`, but will still only generate values if `max_autotune=True`.
* the autotuner will log global cache hits and misses to a scuba table (inductor_autotuning_cache) which will be used to update the global cache at regular intervals

Test Plan: D43285472

Differential Revision: D42785435



cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire