### PR TITLE
[inductor] Get compiler from environment variable if exists

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -131,7 +131,7 @@ class cpp:
         # "g++-11",
         # "g++-10",
         # "clang++",
-        "g++",
+        os.environ.get("CXX", "g++"),
         # "g++.par",
     )
     # Allow kernel performance profiling via PyTorch profiler


### PR DESCRIPTION
Fixes an issue where the default `g++` compiler does not specify the right compiler to use (or does not exist).

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire