### PR TITLE
[CUDA 12] Autograd engine follow up

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -653,6 +653,7 @@ if(USE_CUDA)
   )
   set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp PROPERTIES COMPILE_FLAGS "-DUSE_CUDA=1")
   set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/codegen/cuda/interface.cpp PROPERTIES COMPILE_FLAGS "-DUSE_CUDA=1")
+  set_source_files_properties(${TORCH_SRC_DIR}/csrc/autograd/engine.cpp PROPERTIES COMPILE_FLAGS "-DUSE_CUDA=1")
 endif()
 
 if(BUILD_ONEDNN_GRAPH)

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -348,7 +348,7 @@ void Engine::thread_init(
   // arbitrarily picked to colocate devices.  Maybe the other approach is
   // better.
 
-#if defined(USE_CUDA)
+#ifdef USE_CUDA
   if (at::detail::getCUDAHooks().hasPrimaryContext(device)) {
     set_device(device);
   }


### PR DESCRIPTION
This PR is follow up to #91191.
In my latest local builds `USE_CUDA` not being defined by default, therefore the following piece of code never enters the guards:
https://github.com/pytorch/pytorch/blob/fa1ea9f9bcaa77c1370468059be95ad9b421f500/torch/csrc/autograd/engine.cpp#L351-L357
In this PR `USE_CUDA` is redefined by applying the compile flag.