### PR TITLE
[ONNX] Enable skipped gpt2 test

### DIFF
--- a/test/onnx/test_fx_to_onnx_with_onnxruntime.py
+++ b/test/onnx/test_fx_to_onnx_with_onnxruntime.py
@@ -307,7 +307,6 @@ class TestFxToOnnxWithOnnxRuntime(onnx_test_common._TestONNXRuntime):
             "toy_mlp1", create_model, create_args, create_pytorch_only_extra_kwargs
         )
 
-    @unittest.skip("To pass this test, if-else conditions in GPT2 should be removed.")
     def test_large_scale_exporter_with_tiny_gpt2(self):
         model_name = "sshleifer/tiny-gpt2"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94930

I think the skip is outdated. Test passed in CI.
