### PR TITLE
Upload coredump from ROCm and print the stacktrace

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -138,6 +138,8 @@ jobs:
         run: |
           set -x
 
+          which gdb
+
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
             TEST_COMMAND=.ci/pytorch/multigpu-test.sh
           elif [[ $BUILD_ENVIRONMENT == *onnx* ]]; then
@@ -237,6 +239,21 @@ jobs:
         with:
           use-gha: true
           file-suffix: ${{ github.job }}-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}_${{ steps.get-job-id.outputs.job-id }}
+
+      - name: Collect backtraces from coredumps (if any)
+        if: always()
+        run: |
+          # shellcheck disable=SC2156
+          find . -iname "core.[1-9]*" -exec docker exec "${DOCKER_CONTAINER_ID}" sh -c "gdb python {} -ex 'bt' -ex 'q'" \;
+
+      - name: Store Core dumps on GitHub
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: coredumps-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}
+          retention-days: 14
+          if-no-files-found: ignore
+          path: ./**/core.[1-9]*
 
       - name: Teardown ROCm
         uses: ./.github/actions/teardown-rocm

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -244,7 +244,7 @@ jobs:
         if: always()
         run: |
           # shellcheck disable=SC2156
-          find . -iname "core.[1-9]*" -exec docker exec "${DOCKER_CONTAINER_ID}" sh -c "gdb python {} -ex 'bt' -ex 'q'" \;
+          find . -iname "core.[1-9]*" -exec docker exec "${CONTAINER_NAME}" sh -c "gdb python {} -ex 'bt' -ex 'q'" \;
 
       - name: Store Core dumps on GitHub
         uses: actions/upload-artifact@v3

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -138,8 +138,6 @@ jobs:
         run: |
           set -x
 
-          which gdb
-
           if [[ $TEST_CONFIG == 'multigpu' ]]; then
             TEST_COMMAND=.ci/pytorch/multigpu-test.sh
           elif [[ $BUILD_ENVIRONMENT == *onnx* ]]; then


### PR DESCRIPTION
There was a burst of `test_cuda` SIGSEGV or SIGIOT from ROCm today, for example https://hud.pytorch.org/pytorch/pytorch/commit/5705199fb10ae96f16a8444b0a7cb59e5629f81c.  So, I'm trying to apply the same logic from Linux [test workflows](https://github.com/pytorch/pytorch/blob/master/.github/workflows/_linux-test.yml#L248-L261) here to uploading the core dump to GitHub and print the stack trace.  This would help debug similar issues in the future.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport