### PR TITLE
Saved tensor hooks no longer detach even if registered directly

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5999,7 +5999,7 @@ for shape in [(1,), ()]:
 
     def test_saved_tensor_hook_calls_pack_with_non_detached_tensors(self):
         def pack(x):
-            self.assertTrue(x.grad_fn, torch._C._functions.CloneBackward0)
+            self.assertIsInstance(x.grad_fn, torch._C._functions.CloneBackward0)
             return x
 
         a = torch.ones(2, 2, requires_grad=True).clone()

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -247,7 +247,7 @@ void SavedVariable::set_hooks_and_pack_data(
   hooks_ = std::move(hooks);
   at::NoGradGuard guard;
   const auto version = impl::version_counter(data).current_version();
-  hooks_->call_pack_hook(saved_original_ ? data.detach() : data);
+  hooks_->call_pack_hook(data);
   TORCH_CHECK(
       version == impl::version_counter(data).current_version(),
       "A saved tensor pack hook is modifying its input in place. "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #94948
* __->__ #94947
* #93912

Previously, since saved_original_ was set AFTER hooks are called, the set_hooks_and_pack_data never detached when saved tensor hooks are registered using the context manager. Inputs to pack were, however, detached if we registered saved_tensor_hooks directly to the raw SavedVariable object. 

I think we prefer the behavior where they aren't detached. This makes that behavior consistent across how saved tensor hooks are registered.