### PR TITLE
dynamo export should be able to export identity function

### DIFF
--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -1842,6 +1842,7 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         def my_dyn_fn(a, b, c):
             if a.shape[0] == b.shape[1] == c.shape[2]:
                 return a.sin()
+
             return a.cos()
 
         torch._dynamo.export(my_dyn_fn, y, y, y)
@@ -1968,6 +1969,17 @@ class ExportTests(torch._dynamo.test_case.TestCase):
         dynamo_result = out_graph(*inps)
 
         self.assertTrue(torch._dynamo.utils.same(real_result, dynamo_result))
+
+    def test_export_identity(self):
+        inp = torch.tensor([0.1, 0.1])
+
+        def func(x):
+            return x
+
+        torch._dynamo.reset()
+        exported, _ = torch._dynamo.export(func, inp)
+        dynamo_result = exported(inp)
+        self.assertTrue(torch._dynamo.utils.same(inp, dynamo_result))
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1930,7 +1930,7 @@ class InstructionTranslator(InstructionTranslatorBase):
         return cg.get_instructions()
 
     def RETURN_VALUE(self, inst):
-        if self.output.count_calls() == 0:
+        if self.output.count_calls() == 0 and not self.export:
             raise exc.SkipFrame("because no content in function call")
         self.instruction_pointer = None
         _step_logger()(


### PR DESCRIPTION
Summary:
While working increasing coverage
(https://github.com/jansel/pytorch-jit-paritybench/pull/5) I found that identity function are not exportable because the generated graph has no call_function.

Test Plan:
Unit test

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes #ISSUE_NUMBER


cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire