### PR TITLE
Implement the joint_fw_bw export path in AOTAutograd

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -519,7 +519,7 @@ def explain(f, *args, **kwargs):
 
 
 def export(
-    f, *args, aten_graph=False, decomposition_table=None, tracing_mode="real", **kwargs
+    f, *args, aten_graph=False, decomposition_table=None, tracing_mode="real", training_mode=False, **kwargs
 ):
     check_if_dynamo_supported()
     torch._C._log_api_usage_once("torch._dynamo.export")
@@ -645,7 +645,19 @@ def export(
             self.current_node = n
             return super().run_node(n)
 
-    if aten_graph:
+    if training_mode:
+        assert aten_graph is True, "training mode only works with aten_graph=True"
+
+        from torch._functorch.aot_autograd import aot_module_export
+
+        joint_gm = aot_module_export(
+            graph,
+            graph_captured_input,
+            decompositions=decomposition_table,
+        )
+        return (joint_gm, out_guards)
+
+    elif aten_graph:
         # Running graph with interpreter is needed for propagating the stack_trace
         def graph_with_interpreter(*args):
             with torch.fx.traceback.preserve_node_meta():

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -372,7 +372,7 @@ static PyObject* THPVariable__to_functional_tensor(
     auto inner_autograd_meta = impl::get_autograd_meta(self_);
     if (inner_autograd_meta) {
       wrapped.set_requires_grad(self_.requires_grad());
-      if (wrapped.requires_grad()) {
+      if (wrapped.requires_grad() && !self_.is_leaf()) {
         auto new_grad_fn = std::shared_ptr<torch::autograd::Error>(
             new torch::autograd::Error(
                 "Cannot backprop through mirrored meta, file a bug in PyTorch"),


### PR DESCRIPTION
Summary:
This PR introduces an experimental training mode for dynamo.export().
It implements a export path for joint_fw_bw inside AOTAutograd. 

We also introduces a set of constrains to the exported program, such that the resulting joint graph would have the following signature.

        class JointGraphSignature:
            # joint graph inputs
            num_lifted_parameters: int
            num_lifted_buffers: int
            num_user_inputs: int

            # joint graph outputs
            num_input_mutations: int
            num_users_outputs: int
            num_gradient_parameters: int
            num_gradient_buffers: int
            num_gradient_user_inputs: int

A sample of the joint graph: https://www.internalfb.com/phabricator/paste/view/P629981166


Differential Revision: D43215635



cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire