### PR TITLE
Add DLPack support for XPU backend by mapping to kDLOneAPI in DLPack …

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -97,13 +97,17 @@ DLDevice getDLDevice(const Tensor& tensor, const int64_t& device_id) {
     case DeviceType::HIP:
       ctx.device_type = DLDeviceType::kDLROCM;
       break;
+    case DeviceType::XPU:
+      ctx = at::detail::getXPUHooks().getDLPackDeviceFromATenDevice(
+          ctx, tensor.device(), tensor.data_ptr());
+      break;
     default:
       TORCH_CHECK(false, "Cannot pack tensors on " + tensor.device().str());
   }
   return ctx;
 }
 
-static Device getATenDevice(const DLDevice& ctx) {
+static Device getATenDevice(const DLDevice& ctx, void* data) {
   switch (ctx.device_type) {
     case DLDeviceType::kDLCPU:
       return at::Device(DeviceType::CPU);
@@ -121,6 +125,8 @@ static Device getATenDevice(const DLDevice& ctx) {
 #else
       return at::Device(DeviceType::HIP, ctx.device_id);
 #endif
+    case DLDeviceType::kDLOneAPI:
+      return at::detail::getXPUHooks().getATenDeviceFromDLPackDevice(ctx, data);
     default:
       TORCH_CHECK(
           false, "Unsupported device_type: " + c10::to_string(ctx.device_type));
@@ -268,13 +274,15 @@ Tensor fromDLPack(const DLManagedTensor* src) {
 Tensor fromDLPack(
     const DLManagedTensor* src,
     std::function<void(void*)> deleter) {
-  Device device = getATenDevice(src->dl_tensor.device);
+  Device device = getATenDevice(src->dl_tensor.device, src->dl_tensor.data);
   ScalarType stype = toScalarType(src->dl_tensor.dtype);
   if (!src->dl_tensor.strides) {
-    return at::from_blob(src->dl_tensor.data,
+    return at::from_blob(
+        src->dl_tensor.data,
         IntArrayRef(src->dl_tensor.shape, src->dl_tensor.ndim),
         deleter,
-        at::device(device).dtype(stype));
+        at::device(device).dtype(stype),
+        {device});
   }
   return at::from_blob(
       src->dl_tensor.data,

--- a/aten/src/ATen/detail/XPUHooksInterface.h
+++ b/aten/src/ATen/detail/XPUHooksInterface.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ATen/dlpack.h>
 #include <c10/core/Device.h>
 #include <c10/util/Exception.h>
 
@@ -13,6 +12,11 @@
 namespace at {
 class Context;
 }
+
+// We use forward declaration here instead of #include <ATen/dlpack.h> to avoid
+// leaking DLPack implementation detail to every project that includes `ATen/Context.h`, which in turn
+// would lead to a conflict when linked with another project using DLPack (for example TVM)
+struct DLDevice_;
 
 namespace at {
 
@@ -45,7 +49,7 @@ struct TORCH_API XPUHooksInterface {
   }
 
   virtual Device getATenDeviceFromDLPackDevice(
-      const DLDevice& dl_device,
+      const DLDevice_& dl_device,
       void* data) const {
     TORCH_CHECK(
         false,
@@ -53,7 +57,8 @@ struct TORCH_API XPUHooksInterface {
         XPU_HELP);
   }
 
-  virtual DLDevice getDLPackDeviceFromATenDevice(
+  virtual DLDevice_& getDLPackDeviceFromATenDevice(
+      DLDevice_& dl_device,
       const Device& aten_device,
       void* data) const {
     TORCH_CHECK(

--- a/aten/src/ATen/dlpack.h
+++ b/aten/src/ATen/dlpack.h
@@ -6,6 +6,9 @@
 #ifndef DLPACK_DLPACK_H_
 #define DLPACK_DLPACK_H_
 
+/**
+ * \brief Compatibility with C++
+ */
 #ifdef __cplusplus
 #define DLPACK_EXTERN_C extern "C"
 #else
@@ -13,7 +16,10 @@
 #endif
 
 /*! \brief The current version of dlpack */
-#define DLPACK_VERSION 60
+#define DLPACK_VERSION 70
+
+/*! \brief The current ABI version of dlpack */
+#define DLPACK_ABI_VERSION 1
 
 /*! \brief DLPACK_DLL prefix for windows */
 #ifdef _WIN32
@@ -35,7 +41,11 @@ extern "C" {
 /*!
  * \brief The device type in DLDevice.
  */
+#ifdef __cplusplus
+typedef enum : int32_t {
+#else
 typedef enum {
+#endif
   /*! \brief CPU device */
   kDLCPU = 1,
   /*! \brief CUDA GPU device */
@@ -68,19 +78,33 @@ typedef enum {
    * \brief CUDA managed/unified memory allocated by cudaMallocManaged
    */
   kDLCUDAManaged = 13,
+  /*!
+   * \brief Unified shared memory allocated on a oneAPI non-partititioned
+   * device. Call to oneAPI runtime is required to determine the device
+   * type, the USM allocation type and the sycl context it is bound to.
+   *
+   */
+  kDLOneAPI = 14,
+  /*! \brief GPU support for next generation WebGPU standard. */
+  kDLWebGPU = 15,
+  /*! \brief Qualcomm Hexagon DSP */
+  kDLHexagon = 16,
 } DLDeviceType;
 
 /*!
  * \brief A Device for Tensor and operator.
  */
-typedef struct {
+// NB: This is the only difference from
+// https://github.com/dmlc/dlpack/blob/v0.7/include/dlpack/dlpack.h Required to
+// allow forward declaration of DLDevice.
+typedef struct DLDevice_ {
   /*! \brief The device type used in the device. */
   DLDeviceType device_type;
   /*!
    * \brief The device index.
    * For vanilla CPU memory, pinned memory, or managed memory, this is set to 0.
    */
-  int device_id;
+  int32_t device_id;
 } DLDevice;
 
 /*!
@@ -109,7 +133,9 @@ typedef enum {
 } DLDataTypeCode;
 
 /*!
- * \brief The data type the tensor can hold.
+ * \brief The data type the tensor can hold. The data type is assumed to follow
+ * the native endian-ness. An explicit error message should be raised when
+ * attempting to export an array with non-native endianness
  *
  *  Examples
  *   - float: type_code = 2, bits = 32, lanes=1
@@ -137,9 +163,16 @@ typedef struct {
  */
 typedef struct {
   /*!
-   * \brief The opaque data pointer points to the allocated data. This will be
-   * CUDA device pointer or cl_mem handle in OpenCL. This pointer is always
-   * aligned to 256 bytes as in CUDA.
+   * \brief The data pointer points to the allocated data. This will be CUDA
+   * device pointer or cl_mem handle in OpenCL. It may be opaque on some device
+   * types. This pointer is always aligned to 256 bytes as in CUDA. The
+   * `byte_offset` field should be used to point to the beginning of the data.
+   *
+   * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
+   * TVM, perhaps others) do not adhere to this 256 byte aligment requirement
+   * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
+   * (after which this note will be updated); at the moment it is recommended
+   * to not rely on the data pointer being correctly aligned.
    *
    * For given DLTensor, the size of memory required to store the contents of
    * data is calculated as follows:
@@ -159,7 +192,7 @@ typedef struct {
   /*! \brief The device of the tensor */
   DLDevice device;
   /*! \brief Number of dimensions */
-  int ndim;
+  int32_t ndim;
   /*! \brief The data type of the pointer*/
   DLDataType dtype;
   /*! \brief The shape of the tensor */

--- a/aten/src/ATen/ops/from_blob.h
+++ b/aten/src/ATen/ops/from_blob.h
@@ -127,10 +127,12 @@ inline Tensor from_blob(
     void* data,
     IntArrayRef sizes,
     const std::function<void(void*)>& deleter,
-    const TensorOptions& options = {}) {
+    const TensorOptions& options = {},
+    const c10::optional<Device> target_device = c10::nullopt) {
   return for_blob(data, sizes)
       .deleter(deleter)
       .options(options)
+      .target_device(target_device)
       .make_tensor();
 }
 

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1363,6 +1363,8 @@ class Tensor(torch._C._TensorBase):
             device_type = DLDeviceType.kDLGPU
         elif torch_device_type == "cpu":
             device_type = DLDeviceType.kDLCPU
+        elif self.device.type == "xpu":
+            device_type = DLDeviceType.kDLOneAPI
         else:
             raise ValueError(
                 "Unknown device type {} for Dlpack".format(torch_device_type)

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -18,6 +18,7 @@ class DLDeviceType(enum.IntEnum):
     kDLVPI = 9,
     kDLROCM = 10,
     kDLExtDev = 12,
+    kDLOneAPI = 14,
 
 
 torch._C._add_docstr(to_dlpack, r"""to_dlpack(tensor) -> PyCapsule


### PR DESCRIPTION
# Motivation
The DLPack device type kDLOneAPI stands for the Unified Shared Memory allocated on a oneAPI device. The corresponding Pytorch backend type is XPU.
Support to export/import the Pytorch XPU tensor as a DLPack tensor of kDLOneAPI device.

# Solution
1. Update the DLPack protocol to v0.7.
2. Add the XPU hooks to map the Aten device and DLPack device with the address value and device information.

# Additional Context
Reopen (#82867)


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire