### PR TITLE
correct calculation of sum_self_cuda_time_total

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -821,15 +821,7 @@ def _build_table(
         result.append('\n')  # Yes, newline after the end as well
 
     sum_self_cpu_time_total = sum([event.self_cpu_time_total for event in events])
-    sum_self_cuda_time_total = 0
-    for evt in events:
-        if evt.device_type == DeviceType.CPU:
-            # in legacy profiler, kernel info is stored in cpu events
-            if evt.is_legacy:
-                sum_self_cuda_time_total += evt.self_cuda_time_total
-        elif evt.device_type == DeviceType.CUDA:
-            # in kineto profiler, there're events with the correct device type (e.g. CUDA)
-            sum_self_cuda_time_total += evt.self_cuda_time_total
+    sum_self_cuda_time_total = sum([event.self_cuda_time_total for event in events])
 
     # Actual printing
     if header is not None:


### PR DESCRIPTION
it seems the calculation of `sum_self_cuda_time_total` is wrong and misses much time.

Following the tutorial in https://pytorch.org/tutorials/recipes/recipes/profiler_recipe.html , I found that percentages of "Self CUDA %" sum up to over 100%, which means there must be some missing cuda time.

The profiler code assumes no cuda time if `evt.is_legacy == False`. However, it is not the case. I print some message here, showing that `evt.self_cuda_time_total` can be non-zero even if `evt.is_legacy == False`:

```
debug: evt.key:aten::convolution_backward evt.self_cuda_time_total:1082941, evt.is_legacy:False
debug: evt.key:aten::cudnn_convolution evt.self_cuda_time_total:380612, evt.is_legacy:False
debug: evt.key:aten::cudnn_batch_norm_backward evt.self_cuda_time_total:274686, evt.is_legacy:False
debug: evt.key:aten::cudnn_batch_norm evt.self_cuda_time_total:177172, evt.is_legacy:False
debug: evt.key:cudaLaunchKernel evt.self_cuda_time_total:140516, evt.is_legacy:False
debug: evt.key:aten::threshold_backward evt.self_cuda_time_total:135466, evt.is_legacy:False
debug: evt.key:aten::clamp_min_ evt.self_cuda_time_total:92828, evt.is_legacy:False
debug: evt.key:aten::add_ evt.self_cuda_time_total:86217, evt.is_legacy:False
debug: evt.key:aten::add evt.self_cuda_time_total:78447, evt.is_legacy:False
debug: evt.key:cudaDeviceGetStreamPriorityRange evt.self_cuda_time_total:60155, evt.is_legacy:False
debug: evt.key:cudaStreamGetPriority evt.self_cuda_time_total:55187, evt.is_legacy:False
debug: evt.key:cudaStreamIsCapturing evt.self_cuda_time_total:50766, evt.is_legacy:False
debug: evt.key:cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags evt.self_cuda_time_total:41838, evt.is_legacy:False
debug: evt.key:cudaMemsetAsync evt.self_cuda_time_total:20459, evt.is_legacy:False
debug: evt.key:aten::max_pool2d_with_indices_backward evt.self_cuda_time_total:20100, evt.is_legacy:False
debug: evt.key:cudaFree evt.self_cuda_time_total:7470, evt.is_legacy:False
debug: evt.key:aten::max_pool2d_with_indices evt.self_cuda_time_total:6777, evt.is_legacy:False
......
```

Therefore, the correct sum of self_cuda_time_total should be calculated regardless of `evt.is_legacy`. After the correction, the percentages of "Self CUDA %" sum up to about 100%.

cc @robieta @chaekit @aaronenyeshi @ngimel @nbcsm @guotuofeng @guyang3532 @gaoteng-git @tiffzhaofb @dzhulgakov