### PR TITLE
Add torch.utils._sympy.interp

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -854,6 +854,8 @@ include_patterns = [
     'test/distributed/_composable/**/*.py',
     'torch/testing/_internal/common_dist_composable.py',
     'test/test_value_ranges.py',
+    'torch/utils/_sympy/interp.py',
+    'torch/utils/_sympy/reference.py',
 ]
 command = [
     'python3',

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -26,7 +26,7 @@ UNARY_OPS = [
     "floor",
     "ceil",
 ]
-BINARY_OPS = ["truediv", "div", "add", "mul", "sub", "pow", "minimum", "maximum"]
+BINARY_OPS = ["truediv", "div", "add", "mul", "sub", "pow", "minimum", "maximum", "mod"]
 
 UNARY_BOOL_OPS = ["not_"]
 BINARY_BOOL_OPS = ["or_", "and_"]
@@ -58,9 +58,9 @@ LESS_CONSTANTS = [-1, 0, 1, 2, 100]
 def valid_unary(fn, v):
     if fn == "log" and v <= 0:
         return False
-    if fn == "reciprocal" and v == 0:
+    elif fn == "reciprocal" and v == 0:
         return False
-    if fn == "sqrt" and v < 0:
+    elif fn == "sqrt" and v < 0:
         return False
     return True
 
@@ -74,7 +74,9 @@ def valid_binary(fn, a, b):
         or (a == b == 0)  # no imaginary numbers  # 0**0 is undefined
     ):
         return False
-    if (fn == "div" or fn == "truediv") and b == 0:
+    elif fn == "mod" and b == 0:
+        return False
+    elif (fn == "div" or fn == "truediv") and b == 0:
         return False
     return True
 

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -2,7 +2,6 @@
 # Owner(s): ["oncall: pt2"]
 
 import itertools
-import math
 
 import sympy
 from torch.testing._internal.common_utils import (

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -1,0 +1,83 @@
+"""
+This is a simple interpreter for Sympy expressions that dispatches to
+classes following the torch._inductor.virtualized calling convention.
+For directness, the interpreter takes the handler directly rather than
+consulting the TLS.  It does not use most of the methods on the full
+handler; only those with corresponding Sympy expressions.  To see an example
+of a full handler, see torch.utils._sympy.value_ranges.ValueRangeAnalysis.
+"""
+
+import torch
+import sympy
+import functools
+from sympy.logic.boolalg import BooleanAtom
+from typing import Dict, Any, Union
+
+
+SympyBoolean = sympy.logic.boolalg.Boolean
+
+
+# TODO: Dedupe this with SYMPY_INTERP
+
+
+@functools.lru_cache(None)
+def handlers():
+    from torch.fx.experimental.symbolic_shapes import TrueDiv, FloorDiv, Pow
+    HANDLERS = dict([
+        (sympy.Or, 'or_'),
+        (sympy.And, 'and_'),
+        (sympy.Eq, 'eq'),
+        (sympy.Ne, 'ne'),
+        (sympy.Lt, 'lt'),
+        (sympy.Gt, 'gt'),
+        (sympy.Le, 'le'),
+        (sympy.Ge, 'ge'),
+        (sympy.Not, 'not_'),
+        (TrueDiv, 'truediv'),
+        (FloorDiv, 'div'),
+        (sympy.Add, 'add'),
+        (sympy.Mul, 'mul'),
+        (Pow, 'pow'),
+        (sympy.Pow, 'pow'),
+        (sympy.Mod, 'mod'),
+        (sympy.Abs, 'abs'),
+        (sympy.log, 'log'),
+        (sympy.exp, 'exp'),
+        (sympy.floor, 'floor'),
+        (sympy.ceiling, 'ceil'),
+        (sympy.Min, 'minimum'),
+        (sympy.Max, 'maximum'),
+    ])
+    return HANDLERS
+
+ASSOCIATIVE_OPS = {'minimum', 'maximum', 'mul', 'add', 'and_', 'or_'}
+
+def sympy_interp(analysis, bindings: Dict[sympy.Symbol, Any], expr: Union[sympy.Expr, SympyBoolean]):
+    # Handle base cases
+    # TODO: not really sure if I'm passing the right dtype here
+    # TODO: wouldn't it be better to pass the sympy expression through
+    # sometimes?
+    if isinstance(expr, sympy.Integer):
+        return analysis.constant(int(expr), torch.int64)
+    elif isinstance(expr, sympy.Float):
+        return analysis.constant(float(expr), torch.double)
+    elif isinstance(expr, BooleanAtom):
+        return analysis.constant(bool(expr), torch.bool)
+    elif isinstance(expr, sympy.Symbol):
+        return bindings[expr]
+
+    # Special cases
+    if isinstance(expr, sympy.Pow) and isinstance(expr.args[1], sympy.core.numbers.Half):
+        return analysis.sqrt(sympy_interp(analysis, bindings, expr.args[0]))
+
+    # Recursive case
+    args = [sympy_interp(analysis, bindings, arg) for arg in expr.args]
+    handler = getattr(analysis, handlers()[expr.func])
+    if handler in ASSOCIATIVE_OPS:
+        assert len(args) > 1
+        acc = handler(args[0], args[1])
+        for i in range(2, len(args)):
+            acc = handler(acc, args[i])
+        return acc
+    else:
+        return handler(*args)

--- a/torch/utils/_sympy/interp.py
+++ b/torch/utils/_sympy/interp.py
@@ -7,11 +7,13 @@ handler; only those with corresponding Sympy expressions.  To see an example
 of a full handler, see torch.utils._sympy.value_ranges.ValueRangeAnalysis.
 """
 
-import torch
-import sympy
 import functools
+from typing import Any, Dict, Union
+
+import sympy
 from sympy.logic.boolalg import BooleanAtom
-from typing import Dict, Any, Union
+
+import torch
 
 
 SympyBoolean = sympy.logic.boolalg.Boolean
@@ -22,37 +24,42 @@ SympyBoolean = sympy.logic.boolalg.Boolean
 
 @functools.lru_cache(None)
 def handlers():
-    from torch.fx.experimental.symbolic_shapes import TrueDiv, FloorDiv, Pow
-    HANDLERS = dict([
-        (sympy.Or, 'or_'),
-        (sympy.And, 'and_'),
-        (sympy.Eq, 'eq'),
-        (sympy.Ne, 'ne'),
-        (sympy.Lt, 'lt'),
-        (sympy.Gt, 'gt'),
-        (sympy.Le, 'le'),
-        (sympy.Ge, 'ge'),
-        (sympy.Not, 'not_'),
-        (TrueDiv, 'truediv'),
-        (FloorDiv, 'div'),
-        (sympy.Add, 'add'),
-        (sympy.Mul, 'mul'),
-        (Pow, 'pow'),
-        (sympy.Pow, 'pow'),
-        (sympy.Mod, 'mod'),
-        (sympy.Abs, 'abs'),
-        (sympy.log, 'log'),
-        (sympy.exp, 'exp'),
-        (sympy.floor, 'floor'),
-        (sympy.ceiling, 'ceil'),
-        (sympy.Min, 'minimum'),
-        (sympy.Max, 'maximum'),
-    ])
+    from torch.fx.experimental.symbolic_shapes import FloorDiv, Pow, TrueDiv
+
+    HANDLERS = {
+        sympy.Or: "or_",
+        sympy.And: "and_",
+        sympy.Eq: "eq",
+        sympy.Ne: "ne",
+        sympy.Lt: "lt",
+        sympy.Gt: "gt",
+        sympy.Le: "le",
+        sympy.Ge: "ge",
+        sympy.Not: "not_",
+        TrueDiv: "truediv",
+        FloorDiv: "div",
+        sympy.Add: "add",
+        sympy.Mul: "mul",
+        Pow: "pow",
+        sympy.Pow: "pow",
+        sympy.Mod: "mod",
+        sympy.Abs: "abs",
+        sympy.log: "log",
+        sympy.exp: "exp",
+        sympy.floor: "floor",
+        sympy.ceiling: "ceil",
+        sympy.Min: "minimum",
+        sympy.Max: "maximum",
+    }
     return HANDLERS
 
-ASSOCIATIVE_OPS = {'minimum', 'maximum', 'mul', 'add', 'and_', 'or_'}
 
-def sympy_interp(analysis, bindings: Dict[sympy.Symbol, Any], expr: Union[sympy.Expr, SympyBoolean]):
+ASSOCIATIVE_OPS = {"minimum", "maximum", "mul", "add", "and_", "or_"}
+
+
+def sympy_interp(
+    analysis, bindings: Dict[sympy.Symbol, Any], expr: Union[sympy.Expr, SympyBoolean]
+):
     # Handle base cases
     # TODO: not really sure if I'm passing the right dtype here
     # TODO: wouldn't it be better to pass the sympy expression through
@@ -67,7 +74,9 @@ def sympy_interp(analysis, bindings: Dict[sympy.Symbol, Any], expr: Union[sympy.
         return bindings[expr]
 
     # Special cases
-    if isinstance(expr, sympy.Pow) and isinstance(expr.args[1], sympy.core.numbers.Half):
+    if isinstance(expr, sympy.Pow) and isinstance(
+        expr.args[1], sympy.core.numbers.Half
+    ):
         return analysis.sqrt(sympy_interp(analysis, bindings, expr.args[0]))
 
     # Recursive case

--- a/torch/utils/_sympy/reference.py
+++ b/torch/utils/_sympy/reference.py
@@ -1,5 +1,4 @@
 import sympy
-import math
 
 # The normal Python interpretation of the operators
 # NB: For magic methods this needs to use normal magic methods

--- a/torch/utils/_sympy/reference.py
+++ b/torch/utils/_sympy/reference.py
@@ -1,0 +1,119 @@
+import sympy
+import math
+
+# The normal Python interpretation of the operators
+# NB: For magic methods this needs to use normal magic methods
+# so that test_magic_methods works
+class ReferenceAnalysis:
+    @staticmethod
+    def constant(c, dtype):
+        return sympy.sympify(c)
+
+    @staticmethod
+    def or_(a, b):
+        assert not isinstance(a, bool) and not isinstance(b, bool)
+        return a | b
+
+    @staticmethod
+    def and_(a, b):
+        assert not isinstance(a, bool) and not isinstance(b, bool)
+        return a & b
+
+    @staticmethod
+    def eq(a, b):
+        if isinstance(a, sympy.Expr) or isinstance(b, sympy.Expr):
+            return sympy.Eq(a, b)
+        return a == b
+
+    @classmethod
+    def ne(cls, a, b):
+        return cls.not_(cls.eq(a, b))
+
+    @staticmethod
+    def lt(a, b):
+        return a < b
+
+    @staticmethod
+    def gt(a, b):
+        return a > b
+
+    @staticmethod
+    def le(a, b):
+        return a <= b
+
+    @staticmethod
+    def ge(a, b):
+        return a >= b
+
+    @staticmethod
+    def not_(a):
+        assert not isinstance(a, bool)
+        return ~a
+
+    @staticmethod
+    def reciprocal(x):
+        return 1 / x
+
+    @staticmethod
+    def square(x):
+        return x * x
+
+    @staticmethod
+    def abs(x):
+        return abs(x)
+
+    @staticmethod
+    def neg(x):
+        return -x
+
+    @staticmethod
+    def truediv(a, b):
+        return a / b
+
+    @staticmethod
+    def div(a, b):
+        return a // b
+
+    @staticmethod
+    def add(a, b):
+        return a + b
+
+    @staticmethod
+    def mul(a, b):
+        return a * b
+
+    @staticmethod
+    def sub(a, b):
+        return a - b
+
+    @staticmethod
+    def exp(x):
+        return sympy.exp(x)
+
+    @staticmethod
+    def log(x):
+        return sympy.log(x)
+
+    @staticmethod
+    def sqrt(x):
+        return sympy.sqrt(x)
+
+    @staticmethod
+    def pow(a, b):
+        return a**b
+
+    @staticmethod
+    def minimum(a, b):
+        return sympy.Min(a, b)
+
+    @staticmethod
+    def maximum(a, b):
+        return sympy.Max(a, b)
+
+    @staticmethod
+    def floor(x):
+        return sympy.floor(x)
+
+    @staticmethod
+    def ceil(x):
+        return sympy.ceiling(x)

--- a/torch/utils/_sympy/reference.py
+++ b/torch/utils/_sympy/reference.py
@@ -58,6 +58,10 @@ class ReferenceAnalysis:
         return x * x
 
     @staticmethod
+    def mod(x, y):
+        return x % y
+
+    @staticmethod
     def abs(x):
         return abs(x)
 

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -341,6 +341,8 @@ class ValueRangeAnalysis:
 
     @staticmethod
     def mod(x, y):
+        if x.lower == x.upper and y.lower == y.upper and y.lower != 0:
+            return ValueRanges.wrap(x.lower % y.lower)
         if y.lower <= 0:
             return ValueRanges.unknown()
         return ValueRanges(0, y.upper)

--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -340,6 +340,12 @@ class ValueRangeAnalysis:
         return ValueRanges.increasing_map(x, sympy.log)
 
     @staticmethod
+    def mod(x, y):
+        if y.lower <= 0:
+            return ValueRanges.unknown()
+        return ValueRanges(0, y.upper)
+
+    @staticmethod
     def sqrt(x):
         if x.lower < 0:
             return ValueRanges.unknown()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #95063
* __->__ #94985
* #94944
* #94939
* #94906

This utility allows us to conveniently abstract interpret Sympy expressions with respect to some alternative domain. I am particularly interested in using ValueRanges to do range analysis on expressions (not this PR).

Some minor house-keeping:
* ReferenceAnalysis got moved to its own file, sprouted a constant() implementation, and some uses of math.* got converted to sympy.*
* ValueRangeAnalysis now understands mod
* Test file gets moved from `test_value_ranges.py` to `test_sympy_utils.py`

Signed-off-by: Edward Z. Yang <ezyang@meta.com>