### PR TITLE
Flag guard unbacked SymInt/SymFloat support

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -60,6 +60,16 @@ constant_functions = {
 # don't specialize on shapes and strides and put shape ops in graph
 dynamic_shapes = os.environ.get("TORCHDYNAMO_DYNAMIC_SHAPES") == "1"
 
+# If True, we will attempt to capture data-dependent operations (like item()
+# and nonzero()) and pass them directly to backends.  Our fallback behavior
+# for these situations is currently incomplete, so this may cause models
+# that previously compiled (with graph breaks) to stop compiling.  Furthermore,
+# most backends cannot usefully take advantage of graphs with data-dependent
+# operations.  You may find this useful for export, and once we fix fallback
+# behavior we plan to default this to True and remove this configuration
+# option.
+capture_data_dependent_ops = False
+
 # Set this to False to assume nn.Modules() contents are immutable (similar assumption as freezing)
 guard_nn_modules = False
 

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -60,16 +60,6 @@ constant_functions = {
 # don't specialize on shapes and strides and put shape ops in graph
 dynamic_shapes = os.environ.get("TORCHDYNAMO_DYNAMIC_SHAPES") == "1"
 
-# If True, we will attempt to capture data-dependent operations (like item()
-# and nonzero()) and pass them directly to backends.  Our fallback behavior
-# for these situations is currently incomplete, so this may cause models
-# that previously compiled (with graph breaks) to stop compiling.  Furthermore,
-# most backends cannot usefully take advantage of graphs with data-dependent
-# operations.  You may find this useful for export, and once we fix fallback
-# behavior we plan to default this to True and remove this configuration
-# option.
-capture_data_dependent_ops = False
-
 # Set this to False to assume nn.Modules() contents are immutable (similar assumption as freezing)
 guard_nn_modules = False
 

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -182,7 +182,7 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
         self.graphargs: List[GraphArg] = []
         shape_env = None
         if config.dynamic_shapes:
-            shape_env = ShapeEnv(allow_unbacked=config.capture_data_dependent_ops)
+            shape_env = ShapeEnv(allow_scalar_outputs=config.capture_scalar_outputs)
         fake_mode = torch._subclasses.FakeTensorMode(
             shape_env=shape_env,
         )

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -180,8 +180,11 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
         super().__init__()
         self.graph = torch.fx.Graph()
         self.graphargs: List[GraphArg] = []
+        shape_env = None
+        if config.dynamic_shapes:
+            shape_env = ShapeEnv(allow_unbacked=config.capture_data_dependent_ops)
         fake_mode = torch._subclasses.FakeTensorMode(
-            shape_env=ShapeEnv() if config.dynamic_shapes else None,
+            shape_env=shape_env,
         )
         self.tracing_context: TracingContext = TracingContext(fake_mode)
         if config.dynamic_shapes:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -408,6 +408,8 @@ def local_scalar_dense(fake_mode, func, arg):
     if fake_mode.shape_env is None:
         # Without symints/symfloats, cannot handle this
         raise DataDependentOutputException(func)
+    if not fake_mode.shape_env.allow_scalar_outputs:
+        raise DataDependentOutputException(func)
     if is_float_dtype(arg.dtype):
         return fake_mode.shape_env.create_unbacked_symfloat()
     elif is_integer_dtype(arg.dtype):

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1063,8 +1063,9 @@ TLS = threading.local()
 
 
 class ShapeEnv:
-    def __init__(self, allow_unbacked=True):
-        self.allow_unbacked = allow_unbacked
+    def __init__(self, allow_scalar_outputs=True):
+        # Not directly used by ShapeEnv; indirectly used by FakeTensor
+        self.allow_scalar_outputs = allow_scalar_outputs
         self.guards: List[ShapeGuard] = []
         # Maps symbolic ints to their original concrete values
         # Currently populated from tensors
@@ -1175,17 +1176,11 @@ class ShapeEnv:
         return SymInt(SymNode(sym, self, int, hint))
 
     def create_unbacked_symfloat(self):
-        from torch._subclasses.fake_tensor import DataDependentOutputException
-        if not allow_unbacked:
-            raise DataDependentOutputException()
         symbol = Symbol(f"f{next(self.unbacked_symfloat_counter)}")
         symbol.stack = ''.join(traceback.format_list(traceback.extract_stack()[:-1]))
         return SymFloat(SymNode(symbol, self, float, None))
 
     def create_unbacked_symint(self):
-        from torch._subclasses.fake_tensor import DataDependentOutputException
-        if not allow_unbacked:
-            raise DataDependentOutputException()
         symbol = Symbol(f"i{next(self.unbacked_symint_counter)}", integer=True)
         symbol.stack = ''.join(traceback.format_list(traceback.extract_stack()[:-1]))
         return SymInt(SymNode(symbol, self, int, None))

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1063,7 +1063,8 @@ TLS = threading.local()
 
 
 class ShapeEnv:
-    def __init__(self):
+    def __init__(self, allow_unbacked=True):
+        self.allow_unbacked = allow_unbacked
         self.guards: List[ShapeGuard] = []
         # Maps symbolic ints to their original concrete values
         # Currently populated from tensors
@@ -1174,11 +1175,17 @@ class ShapeEnv:
         return SymInt(SymNode(sym, self, int, hint))
 
     def create_unbacked_symfloat(self):
+        from torch._subclasses.fake_tensor import DataDependentOutputException
+        if not allow_unbacked:
+            raise DataDependentOutputException()
         symbol = Symbol(f"f{next(self.unbacked_symfloat_counter)}")
         symbol.stack = ''.join(traceback.format_list(traceback.extract_stack()[:-1]))
         return SymFloat(SymNode(symbol, self, float, None))
 
     def create_unbacked_symint(self):
+        from torch._subclasses.fake_tensor import DataDependentOutputException
+        if not allow_unbacked:
+            raise DataDependentOutputException()
         symbol = Symbol(f"i{next(self.unbacked_symint_counter)}", integer=True)
         symbol.stack = ''.join(traceback.format_list(traceback.extract_stack()[:-1]))
         return SymInt(SymNode(symbol, self, int, None))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94987

I believe this fixes the AllenaiLongformerBase problem in periodic.

The longer version of the problem is here is we are currently optimistically converting all item() calls into unbacked SymInt/SymFloat, but sometimes this results in a downstream error due to a data-dependent guard. Fallbacks for this case are non-existent; this will just crash the model. This is bad. So we flag guard until we get working fallbacks.

What could these fallbacks look like? One idea I have is to optimistically make data-dependent calls unbacked, but then if it results in a crash, restart Dynamo analysis with the plan of graph breaking when the item() call immediately happened.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire