### PR TITLE
Fix c10d regression during cleanup.

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1161,6 +1161,16 @@ def destroy_process_group(group: Optional[ProcessGroup] = None):
         del _world.pg_group_ranks[pg]
         del _world.pg_backend_config[pg]
 
+        tag = _world.pg_to_tag.get(pg)
+        del _world.pg_to_tag[pg]
+        if tag is not None:
+            try:
+                _world.tags_to_pg[tag].remove(pg)
+                if tag.startswith("ptd:"):
+                    _world.tags_to_pg[""].remove(pg)
+            except Exception:
+                pass
+
 
 def get_rank(group: Optional[ProcessGroup] = None) -> int:
     """

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1143,6 +1143,8 @@ def destroy_process_group(group: Optional[ProcessGroup] = None):
         _world.pg_names.clear()
         _world.pg_group_ranks.clear()
         _world.pg_backend_config.clear()
+        _world.pg_to_tag.clear()
+        _world.tags_to_pg.clear()
 
         # when process group doesn't have an explicit name (only WORLD (default)
         # process group can have an explicit name), we use global _world.group_count


### PR DESCRIPTION
This fixes a regression introduced earlier today with a change to c10d global state.

It must be cleaned up in destroy_process_group or root PG and its Store will stay alive.

Fixes regression in test_c10d_nccl.py :: RendezvousEnvTest.test_common_errors