### PR TITLE
Don't constant fold torch._assert

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -56,7 +56,6 @@ REWRITE_OPS_TO_TENSOR_SIZE_METHOD = [
 ]
 
 constant_fold_functions = [
-    torch._assert,
     torch._utils._get_device_index,
     torch.cuda.is_available,
     torch.device,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94993

Otherwise, dynamo graph doesn't contain torch._assert. 

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire