### PR TITLE
Mark linux-focal-py3.8-gcc7 / test (distributed) as unstable temporarily

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -27,8 +27,6 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
           { config: "default", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
-          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
-          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
           { config: "functorch", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
           { config: "docs_test", shard: 1, num_shards: 1,  runner: "linux.2xlarge" },
           { config: "jit_legacy", shard: 1, num_shards: 1, runner: "linux.2xlarge" },

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -31,3 +31,24 @@ jobs:
           echo
           echo "Once the jobs are deemed stable enough (% red signal < 20% and TTS < 3h),"
           echo " they can graduate and move back to pull or trunk."
+
+  linux-focal-py3_8-gcc7-build:
+    name: linux-focal-py3.8-gcc7
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-focal-py3.8-gcc7
+      docker-image-name: pytorch-linux-focal-py3.8-gcc7
+      test-matrix: |
+        { include: [
+          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
+          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
+        ]}
+
+  linux-focal-py3_8-gcc7-test:
+    name: linux-focal-py3.8-gcc7
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-focal-py3_8-gcc7-build
+    with:
+      build-environment: linux-focal-py3.8-gcc7
+      docker-image: ${{ needs.linux-focal-py3_8-gcc7-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-py3_8-gcc7-build.outputs.test-matrix }}

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -29,7 +29,7 @@ jobs:
           echo " PR to trigger this workflow. That can be done either manually or"
           echo " automatically using PyTorch auto-label bot."
           echo
-          echo "Once the jobs are deemed stable enough (% red signal < 20% and TTS < 3h),"
+          echo "Once the jobs are deemed stable enough (% red signal < 5% and TTS < 3h),"
           echo " they can graduate and move back to pull or trunk."
 
   linux-focal-py3_8-gcc7-build:


### PR DESCRIPTION
This has become flaky recently (5.11% > 5% threshold) https://hud.pytorch.org/reliability/pytorch/pytorch?jobName=pull%20%2F%20linux-focal-py3.8-gcc7%20%2F%20test%20(distributed), moving it to unstable makes sense because the more important CUDA distributed jobs are still run in trunk.  The issue is being investigated in https://github.com/pytorch/pytorch/issues/94954