### PR TITLE
Remove unnecessary TensorMeta rewrap

### DIFF
--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -1932,8 +1932,7 @@ reshape = _make_prim(
 
 def _rev_meta(a: TensorLikeType, dims: DimsSequenceType) -> TensorLikeType:
     utils.validate_dimension_indices(a.ndim, dims)
-    out = torch.empty_like(a, memory_format=torch.preserve_format)
-    return TensorMeta(out)
+    return torch.empty_like(a, memory_format=torch.preserve_format)
 
 
 _rev_doc = """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95004

Extracted from https://github.com/pytorch/pytorch/pull/94523

Signed-off-by: Edward Z. Yang <ezyang@meta.com>