### PR TITLE
Reorder the Fx execution order to in-time get_attr rather than putting all get_attr ahead

### DIFF
--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -136,6 +136,31 @@ def split_module(
             > self.assertEqual(orig_out, submodules_out)
             True
     """
+
+    def construct_graph(
+        node: torch.fx.node.Node,
+        base_mod_env: Dict[str, torch.fx.node.Node],
+        base_mod_attrs: Dict[str, torch.fx.graph_module.GraphModule],
+    ):
+        if node.op == "placeholder":
+            default_value = (
+                node.args[0] if len(node.args) > 0 else inspect.Signature.empty
+            )
+            base_mod_env[node.name] = base_mod_graph.placeholder(
+                node.target, type_expr=node.type, default_value=default_value
+            )
+            base_mod_env[node.name].meta = node.meta.copy()
+        elif node.op == "get_attr":
+            base_mod_env[node.name] = base_mod_graph.get_attr(node.target)
+            base_mod_env[node.name].meta = node.meta.copy()
+            attr_val = m
+            for atom in node.target.split("."):  # type: ignore[union-attr]
+                if not hasattr(attr_val, atom):
+                    raise AttributeError(f"Node target {node.target} not found!")
+                attr_val = getattr(attr_val, atom)
+            base_mod_attrs[node.target] = attr_val  # type: ignore[index]
+        return base_mod_env, base_mod_attrs
+
     partitions: Dict[str, Partition] = {}
     orig_nodes: Dict[str, torch.fx.node.Node] = {}
 
@@ -236,7 +261,7 @@ def split_module(
                 target_attr = m
                 for atom in target_atoms:
                     if not hasattr(target_attr, atom):
-                        raise RuntimeError(f"Operator target {node.target} not found!")
+                        raise AttributeError(f"Operator target {node.target} not found!")
                     target_attr = getattr(target_attr, atom)
                 # target = target_atoms[-1]
                 target = "_".join(target_atoms)
@@ -260,39 +285,35 @@ def split_module(
             new_node.meta = node.meta.copy()
             partition.environment[node] = new_node
 
+    # original module environment dict mapping node names to nodes
+    org_mod_env: Dict[str, torch.fx.node.Node] = {}
     # Set up values to construct base module
     base_mod_env: Dict[str, torch.fx.node.Node] = {}
     base_mod_graph: torch.fx.graph.Graph = torch.fx.graph.Graph()
     base_mod_attrs: Dict[str, torch.fx.graph_module.GraphModule] = {}
-    for node in m.graph.nodes:
-        if node.op == "placeholder":
-            default_value = (
-                node.args[0] if len(node.args) > 0 else inspect.Signature.empty
+    if not keep_original_order:
+        for node in m.graph.nodes:
+            base_mod_env, base_mod_attrs = construct_graph(
+                node, base_mod_env, base_mod_attrs
             )
-            base_mod_env[node.name] = base_mod_graph.placeholder(
-                node.target, type_expr=node.type, default_value=default_value
-            )
-            base_mod_env[node.name].meta = node.meta.copy()
-        elif node.op == "get_attr":
-            base_mod_env[node.name] = base_mod_graph.get_attr(node.target)
-            base_mod_env[node.name].meta = node.meta.copy()
-            attr_val = m
-            for atom in node.target.split("."):
-                if not hasattr(attr_val, atom):
-                    raise RuntimeError(f"Node target {node.target} not found!")
-                attr_val = getattr(attr_val, atom)
-            base_mod_attrs[node.target] = attr_val
+
+    else:
+        # Go through the graph to construct the mapping dict
+        for node in m.graph.nodes:
+            if node.op == "placeholder" or "get_attr":
+                org_mod_env[node.name] = node
 
     # Do some things iterating over the partitions in topological order again:
     # 1) Finish off submodule Graphs by setting corresponding outputs
     # 2) Construct GraphModules for each submodule
     # 3) Construct the base graph by emitting calls to those submodules in
-    #    topological order
+    #    topological order or original order specified by keep_original_order
 
     construct_order_partitions = (
         sorted_partitions if not keep_original_order else original_partition_order
     )
 
+    already_constructed_attr_nodes = set()
     for partition_name in construct_order_partitions:
         partition = partitions[partition_name]
 
@@ -303,7 +324,20 @@ def split_module(
         output_vals = output_vals[0] if len(output_vals) == 1 else output_vals  # type: ignore[assignment]
         partition.graph.output(output_vals)
 
-        # Construct GraphModule for this partition
+        if keep_original_order:
+            # first get the attr nodes required by this partition
+            org_mod_attr_nodes: List[torch.fx.node.Node] = [
+                org_mod_env[key] for key in partition.inputs
+            ]
+            # Construct GraphModule for this partition
+            for node in org_mod_attr_nodes:  # type: ignore[attr-defined]
+                if node in already_constructed_attr_nodes:
+                    continue
+                base_mod_env, base_mod_attrs = construct_graph(
+                    node, base_mod_env, base_mod_attrs
+                )
+                already_constructed_attr_nodes.add(node)
+
         base_mod_attrs[partition.submod_name] = torch.fx.graph_module.GraphModule(
             partition.targets, partition.graph
         )  # noqa: B950


### PR DESCRIPTION
Summary:
Basically today we:
[getattr....getattr, call partition1, call parition2]
this makes getattr just in time:
so [getattr, call partition1, getattr, call partition 2 ..]

Test Plan:
CMF and MAI test result:
https://fb.quip.com/K5J9A7G246Ox

Differential Revision: D43376080

