### PR TITLE
Change evict_last heuristic to only apply on broadcasted elements [WIP]

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -901,7 +901,7 @@ class TritonKernel(Kernel):
         original_index = index
         index, mask_vars, mask = self.indexing(index)
 
-        if "rmask" in mask and not self.persistent_reduction:
+        if "rmask" in mask and "xmask" not in mask and not self.persistent_reduction:
             # This eviction policy heuristic is untested.
             # ptillet suggested we should try only doing this for
             # the first N-1 loops and not for the final loop.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #95355
* __->__ #95044



cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire

I was benchmarking `torch.mv` performance, since there's no reason that Inductor shouldn't be hitting peak on it. To my surprise, though we weren't! We were getting outperformed by PyTorch's `torch.mv`.

```
import torch
from triton.testing import do_bench

def f_mv(inp, weight):
    return torch.mv(weight, inp)


D = 16384
N = 1
inp = torch.randn(D, device='cuda', dtype=torch.float16)
weight_fp16 = torch.zeros(D, D, dtype=torch.float16, device='cuda')

opt_f_mv = torch.compile(f_mv)
print(do_bench(lambda : f_mv(inp, weight_fp16))[0]) # 0.413
print(do_bench(lambda : opt_f_mv(inp, weight_fp16))[0]) # 0.584
```

~~Huh? What could be going wrong in a pointwise + reduction? Looking at the code, I had an idea~~

![image](https://user-images.githubusercontent.com/6355099/219558485-4591580e-a134-4f3d-a80e-e7dbf9f8cfd7.png)

~~For a [N x N] x [N, 1] multiply, the memory bandwidth in principle should be N^2 + N for the inputs and N for the outputs. This is a bit tricky to actually realize, since in order for each block to compute a row it needs to load N values from A *and* N values from B. Ideally, however, the B values are stored in the L2 cache. However, we're just setting `evict_last` on all of the loads! So I thought that perhaps B was getting evicted from the L2 cache every time.~~

~~I tried removing evict_last from A's load, and voila, the performance improved from 0.584 => 0.403.~~

~~I'm not sure this is actually the right heuristic, but this seems more reasonable to me than the current one? I suspect we could be doing much smarter things here.~~

Ignore me - it seems to be that for some reason, Triton is generating vectorized loads in one case but not the other.