### PR TITLE
Fix: `validate_input_col` for partial functions

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1254,6 +1254,7 @@ class TestFunctionalIterDataPipe(TestCase):
 
         p_fn_n1 = partial(fn_n1, d1=1)
         p_fn_cmplx = partial(fn_cmplx, d2=2)
+        p_fn_cmplx_large_arg = partial(fn_cmplx, d2={i: list(range(i)) for i in range(10_000)})
 
         def _helper(ref_fn, fn, input_col=None, output_col=None, error=None):
             for constr in (list, tuple):
@@ -1272,6 +1273,7 @@ class TestFunctionalIterDataPipe(TestCase):
         _helper(lambda data: (data[0], data[1], data[0] + data[1]), fn_n1_def, [0, 1], 2)
         _helper(lambda data: data, p_fn_n1, 0, 1)
         _helper(lambda data: data, p_fn_cmplx, 0, 1)
+        _helper(lambda data: data, p_fn_cmplx_large_arg, 0, 1)
         _helper(lambda data: (data[0], data[1], data[0] + data[1]), p_fn_cmplx, [0, 1], 2)
         _helper(lambda data: (data[0] + data[1], ), fn_n1_pos, [0, 1, 2])
 
@@ -1359,6 +1361,7 @@ class TestFunctionalIterDataPipe(TestCase):
             return d0 + d1
 
         p_fn_cmplx = partial(fn_cmplx, d2=2)
+        p_fn_cmplx_large_arg = partial(fn_cmplx, d2={i: list(range(i)) for i in range(10_000)})
 
         # Prevent modification in-place to support resetting
         def _dict_update(data, newdata, remove_idx=None):
@@ -1389,6 +1392,7 @@ class TestFunctionalIterDataPipe(TestCase):
         _helper(lambda data: data, fn_n1_def, 'x', 'y')
         _helper(lambda data: data, p_fn_n1, 'x', 'y')
         _helper(lambda data: data, p_fn_cmplx, 'x', 'y')
+        _helper(lambda data: data, p_fn_cmplx_large_arg, 'x', 'y')
         _helper(lambda data: _dict_update(data, {"z": data["x"] + data["y"]}),
                 p_fn_cmplx, ["x", "y", "z"], "z")
 

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -1,4 +1,5 @@
 import fnmatch
+import functools
 import inspect
 import os
 import warnings
@@ -61,8 +62,6 @@ def validate_input_col(fn: Callable, input_col: Optional[Union[int, tuple, list]
     else:
         input_col_size = 1
 
-    fn_name = str(fn)
-
     pos = []
     var_positional = False
     non_default_kw_only = []
@@ -77,6 +76,11 @@ def validate_input_col(fn: Callable, input_col: Optional[Union[int, tuple, list]
                 non_default_kw_only.append(p)
         else:
             continue
+
+    if isinstance(fn, functools.partial):
+        fn_name = fn.func.__name__
+    else:
+        fn_name = fn.__name__
 
     if len(non_default_kw_only) > 0:
         raise ValueError(


### PR DESCRIPTION
Fixes #95066

#### Proposed change:
do not call `str()` on a `Callable` to determine its name

#### Reasoning:
Please see https://github.com/pytorch/pytorch/issues/95066 for reasoning and examples

#### Effect:
* The code example given in https://github.com/pytorch/pytorch/issues/95066 now executes instantly.
* If invalid input is provided, the stacktrace now prints nicely as
  ```
  ValueError: The function foo takes 1 parameters, but 2 are required.
  ```
