### PR TITLE
[ROCm] MIOpen supports bias with bfloat16

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -497,7 +497,6 @@ struct ConvParams {
            && input.is_cuda()
            && input.dim() <= MIOPEN_DIM_MAX
            && !(groups > 1 && is_dilated()) // MIOpen currently does not support dilation with groups of size > 1
-           && !(input.scalar_type() == at::kBFloat16 && bias_defined) // MIOpen currently doesn't support bias with bfloat16
            && cudnn_enabled
            ;
   }


### PR DESCRIPTION
Removes the condition in ConvParams::use_miopen restricting bfloat16 with bias defined.


cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10