### PR TITLE
Back out "fix: make sure `sorter` indices are inbound in `searchsorted` (#94863)"

### DIFF
--- a/aten/src/ATen/native/BucketizationUtils.h
+++ b/aten/src/ATen/native/BucketizationUtils.h
@@ -134,12 +134,6 @@ inline void searchsorted_pre_check(
 
     TORCH_CHECK(sorter.scalar_type() == ScalarType::Long, "torch.searchsorted(): sorter must be a tensor of long ",
       "dtype but got dtype ", sorter.scalar_type());
-
-    if (sorter.numel() > 0) {
-      auto [vmin, vmax] = sorter.aminmax();
-      TORCH_CHECK(vmax.item().toLong() < sorter.sizes().back(), "torch.searchsorted(): sorter index out of range");
-      TORCH_CHECK(vmin.item().toLong() >= 0, "torch.searchsorted(): sorter index out of range");
-    }
   }
 
   TORCH_CHECK(input.dim() > 0 || (input.dim() == 0 && input.numel() == 1 && boundaries.dim() == 1),

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1563,14 +1563,6 @@ class TestReductions(TestCase):
             _, sorted_idx = torch.sort(sequence)
             torch.searchsorted(sequence, values_1d, sorter=sorted_idx.to(torch.float32))
 
-        # invalid sorter value, out of bound (>= innermost size)
-        with self.assertRaisesRegex(RuntimeError, "sorter index out of range"):
-            torch.searchsorted(torch.tensor([1, 2, 3]), 2.5, sorter=torch.tensor([0, 1, 3]))
-
-        # invalid sorter value, out of bound (< 0)
-        with self.assertRaisesRegex(RuntimeError, "sorter index out of range"):
-            torch.searchsorted(torch.tensor([1, 2, 3]), 2.5, sorter=torch.tensor([-1, 1, 2]))
-
         # scalar type bfloat16
         if self.device_type == 'cpu':
             def test_dtype_bfloat16(values_bf16=False, boundaries_bf16=False):


### PR DESCRIPTION
Summary:
Original commit changeset: 96a2200d1fd8

Original Phabricator Diff: D43342962

Test Plan: Sandcastle and land castle as well as buck2 build mode/opt //frl/et/projects/Masquerade/stable/datasets/masquerade/c6p7:post_processing

Reviewed By: seemethere, bigfootjon

Differential Revision: D43402398

@bypass-github-export-checks