### PR TITLE
Use `run_subtests` utility in FSDP `test_state_dict_save_load_flow` test

### DIFF
--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -770,15 +770,20 @@ class TestFSDPStateDict(FSDPTest):
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)
     def test_state_dict_save_load_flow(self, state_dict_type):
-        for move_to_cpu in [True, False]:
-            with self.subTest(move_to_cpu=move_to_cpu):
-                fsdp_params = self._dist_train(
-                    wrap_fsdp=True,
-                    state_dict_type=state_dict_type,
-                    move_to_cpu=move_to_cpu,
-                )
-                ddp_params = self._dist_train(wrap_fsdp=False)
-                self.assertEqual(ddp_params, fsdp_params)
+        self.run_subtests(
+            {"move_to_cpu": [True, False]},
+            self._test_state_dict_save_load_flow,
+            state_dict_type=state_dict_type,
+        )
+
+    def _test_state_dict_save_load_flow(self, state_dict_type, move_to_cpu):
+        fsdp_params = self._dist_train(
+            wrap_fsdp=True,
+            state_dict_type=state_dict_type,
+            move_to_cpu=move_to_cpu,
+        )
+        ddp_params = self._dist_train(wrap_fsdp=False)
+        self.assertEqual(ddp_params, fsdp_params)
 
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", _SUPPORTED_STATE_DICT_IMPLS)


### PR DESCRIPTION
Converts the single-instance of `self.subTest` in `test_fsdp_state_dict.py` to use the `run_subtests` utility.

Related: #84171
