### PR TITLE
[MPS] LogSoftmax numerical stability

### DIFF
--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -310,7 +310,7 @@ TORCH_IMPL_FUNC(log_softmax_mps_out) (
           newCachedGraph = new CachedGraph(mpsGraph);
 
           MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-            
+
           MPSGraphTensor* maximumsTensor = [mpsGraph reductionMaximumWithTensor:inputTensor
                                                                             axis:dim
                                                                             name:nil];
@@ -319,14 +319,14 @@ TORCH_IMPL_FUNC(log_softmax_mps_out) (
                                                                                 name:nil];
           MPSGraphTensor* exponentTensor = [mpsGraph exponentWithTensor:inputTensorSubMax
                                                                    name:nil];
-            
+
           MPSGraphTensor* exponentTensorReduced = [mpsGraph reductionSumWithTensor:exponentTensor
                                                                               axis:dim
                                                                               name:nil];
-            
+
           MPSGraphTensor* logSumExpTensor = [mpsGraph logarithmWithTensor:exponentTensorReduced
                                                                     name:nil];
-            
+
           MPSGraphTensor* outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensorSubMax
                                                                        secondaryTensor:logSumExpTensor
                                                                                   name:nil];

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -326,13 +326,8 @@ TORCH_IMPL_FUNC(log_softmax_mps_out) (
             
           MPSGraphTensor* logSumExpTensor = [mpsGraph logarithmWithTensor:exponentTensorReduced
                                                                     name:nil];
-
-
-          MPSGraphTensor* inputSubMaxTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                                secondaryTensor:maximumsTensor
-                                                                           name:nil];
             
-          MPSGraphTensor* outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputSubMaxTensor
+          MPSGraphTensor* outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensorSubMax
                                                                        secondaryTensor:logSumExpTensor
                                                                                   name:nil];
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3361,6 +3361,26 @@ class TestNLLLoss(TestCaseMPS):
 
         self.assertEqual(cpu_x.grad, mps_x.grad.to('cpu'))
 
+    def test_log_softmax_large_numbers(self):
+        values = [
+            [10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0],
+            [-10.0, -100.0, -1000.0, -10000.0, -100000.0, -1000000.0]
+        ]
+        cpu_x = torch.tensor(values, device='cpu', requires_grad=True)
+        mps_x = torch.tensor(values, device='mps', requires_grad=True)
+
+        cpu_log_softmax = F.log_softmax(cpu_x, dim=-1)
+        mps_log_softmax = F.log_softmax(mps_x, dim=-1)
+        self.assertEqual(cpu_log_softmax, mps_log_softmax.to('cpu'))
+
+        cpu_grad = torch.ones_like(cpu_log_softmax)
+        mps_grad = torch.ones_like(cpu_log_softmax).to('mps')
+
+        cpu_log_softmax.backward(gradient=cpu_grad)
+        mps_log_softmax.backward(gradient=mps_grad)
+
+        self.assertEqual(cpu_x.grad, mps_x.grad.to('cpu'))
+
     def test_eq(self):
         values1 = [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]]
         values2 = [[[1.0, 2.0, 15.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [0.0, 11.0, 12.0]]]


### PR DESCRIPTION
Fixes #94043

Calculations are now consistent with numericaly stable formula and CPU:

$LogSoftmax(X, \dim) = X - \max(X, \dim) - \log(sum(X - \max(X, \dim), \dim))$

@malfet

