### PR TITLE
Fix bug where a github api failure would prevent the label check from failing

### DIFF
--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -80,7 +80,6 @@ def main() -> None:
     try:
         needs_labels = not has_required_labels(pr)
         if needs_labels:
-            exit_code = 1
             print(ERR_MSG)
             add_comment(pr)
         else:

--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -2,7 +2,6 @@
 """check_labels.py"""
 
 from typing import Any, List
-from urllib.error import HTTPError
 
 from label_utils import gh_get_labels
 from gitutils import (

--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -76,10 +76,10 @@ def main() -> None:
     org, project = repo.gh_owner_and_name()
     pr = GitHubPR(org, project, args.pr_num)
 
-    needs_labels = False
+    exit_code = 0
     try:
-        needs_labels = not has_required_labels(pr)
-        if needs_labels:
+        if not has_required_labels(pr):
+            exit_code = 1
             print(ERR_MSG)
             add_comment(pr)
         else:
@@ -87,7 +87,7 @@ def main() -> None:
     except Exception as e:
         pass
 
-    exit(needs_labels)
+    exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -2,6 +2,7 @@
 """check_labels.py"""
 
 from typing import Any, List
+from urllib.error import HTTPError
 
 from label_utils import gh_get_labels
 from gitutils import (
@@ -75,15 +76,19 @@ def main() -> None:
     org, project = repo.gh_owner_and_name()
     pr = GitHubPR(org, project, args.pr_num)
 
+    needs_labels = False
     try:
-        if not has_required_labels(pr):
+        needs_labels = not has_required_labels(pr)
+        if needs_labels:
+            exit_code = 1
             print(ERR_MSG)
             add_comment(pr)
-            exit(1)
         else:
             delete_comments(pr)
     except Exception as e:
         pass
+
+    exit(needs_labels)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -456,7 +456,12 @@ def _fetch_url(url: str, *,
             return reader(conn)
     except HTTPError as err:
         if err.code == 403 and all(key in err.headers for key in ['X-RateLimit-Limit', 'X-RateLimit-Used']):
-            print(f"Rate limit exceeded: {err.headers['X-RateLimit-Used']}/{err.headers['X-RateLimit-Limit']}")
+            print(f"""Rate limit exceeded:
+                Used: {err.headers['X-RateLimit-Used']}
+                Limit: {err.headers['X-RateLimit-Limit']}
+                Remaining: {err.headers['X-RateLimit-Remaining']}
+                Resets at: {err.headers['x-ratelimit-reset']}"""
+            )
         raise
 
 def _fetch_json_any(

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -460,7 +460,7 @@ def _fetch_url(url: str, *,
                 Used: {err.headers['X-RateLimit-Used']}
                 Limit: {err.headers['X-RateLimit-Limit']}
                 Remaining: {err.headers['X-RateLimit-Remaining']}
-                Resets at: {err.headers['x-ratelimit-reset']}"""
+                Resets at: {err.headers['x-RateLimit-Reset']}"""
             )
         raise
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -460,8 +460,7 @@ def _fetch_url(url: str, *,
                 Used: {err.headers['X-RateLimit-Used']}
                 Limit: {err.headers['X-RateLimit-Limit']}
                 Remaining: {err.headers['X-RateLimit-Remaining']}
-                Resets at: {err.headers['x-RateLimit-Reset']}"""
-            )
+                Resets at: {err.headers['x-RateLimit-Reset']}""")
         raise
 
 def _fetch_json_any(


### PR DESCRIPTION
Fix bug where a github api failure would prevent the check from failing even if we already saw that labels were needed.

Also adds more debugging info to the rate limit exceeded error since it's weird to see an error claiming the rate limit has exceeded when the "Used" amount is way below the limit.  I suspect these happen when the request arrived just before the rate reset time, but the response was generated right after the reset time, hence the apparently tiny "used" amounts

Example run where the check should have failed, but passed instead:
https://github.com/pytorch/pytorch/actions/runs/4200205209/jobs/7285979824