### PR TITLE
[not for land] FX graph mode quantization with a user specified dtype

### DIFF
--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -228,12 +228,14 @@ class UniformQuantizationObserverBase(ObserverBase):
         ), "Default Observer only works for per_tensor_affine, \
                 per_tensor_symmetric, per_channel_affine, \
                 per_channel_symmetric and per_channel_float_qparams quantization scheme"
-        assert self.dtype in (
-            torch.qint8,
-            torch.quint8,
-            torch.quint4x2,
-            torch.qint32,
-        ), "Default Observer only works for qint8, quint8 and quint4x2 data type"
+        # TODO: make this work without hacks
+        if False:
+            assert self.dtype in (
+                torch.qint8,
+                torch.quint8,
+                torch.quint4x2,
+                torch.qint32,
+            ), "Default Observer only works for qint8, quint8 and quint4x2 data type"
         self.has_customized_qrange = (quant_min is not None) and (quant_max is not None)
         if self.has_customized_qrange:
             validate_qmin_qmax(quant_min, quant_max)

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -211,6 +211,10 @@ def activation_is_statically_quantized(qconfig):
     """ Given a qconfig, decide if the activation needs to be
     quantized or not, this includes quantizing to quint8, qint8 and qint32 and float16
     """
+    dtype = activation_dtype(qconfig)
+    if not isinstance(dtype, torch.dtype):
+        # TODO: make this work correctly, for now our example is only for static quant
+        return True
     return (
         activation_dtype(qconfig) in [torch.quint8, torch.qint8, torch.qint32, torch.float16]
         and (not activation_is_dynamically_quantized(qconfig))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95105

Summary:

This is a demo of making FX graph mode quant workflow work with
a dtype defined by the user (not existing in PyTorch repository at all).

The output of this can be lowered to a backend which supports the dtype,
even if PyTorch does not.

Test plan:

```
// Test script: https://www.internalfb.com/phabricator/paste/view/626294446
// Test script output (ref model): https://www.internalfb.com/phabricator/paste/view/P626294989
```