### PR TITLE
[MPS] Fix LSTM backward and forward pass

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1423,7 +1423,7 @@ std::tuple<Tensor, Tensor, Tensor> lstm(
   }
 #ifdef USE_MPS
   if (_input.is_mps() && !bidirectional) {
-    std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> output = at::_lstm_mps(_input, hx, _params, has_biases,
+    std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> output = at::_lstm_mps(_input, hx, _params, has_biases,
             num_layers, dropout_p, train, bidirectional, batch_first);
     std::tuple<Tensor, Tensor, Tensor> return_values = std::make_tuple(std::get<0>(output), std::get<1>(output), std::get<2>(output));
     return return_values;

--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -532,10 +532,7 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
             Tensor grad_cell_state = at::empty_like(hx[1]);
             weights.push_back(grad_weights);
             weights.push_back(grad_rec_weights);
-            if(has_biases) {
-                weights.push_back(grad_bias);
-                weights.push_back(grad_bias);
-            }
+
             if (i == 0) {
                 outputPlaceholder = Placeholder([gradOutputArray objectAtIndex:num_layers - i - 1], output_out);
                 gradStatePlaceholder = Placeholder([gradStateArray objectAtIndex:num_layers - i - 1], grad_state_out);
@@ -548,12 +545,15 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
 
             gradRecWeightsPlaceholder = Placeholder([gradRecWeightsArray objectAtIndex:num_layers - i - 1], grad_rec_weights);
             gradWeightsPlaceholder = Placeholder([gradWeightsArray objectAtIndex:num_layers - i - 1], grad_weights);
-            gradBiasPlaceholder = Placeholder([gradBiasArray objectAtIndex:num_layers - i - 1], grad_bias);
 
+            if(has_biases) {
+                weights.push_back(grad_bias);
+                gradBiasPlaceholder = Placeholder([gradBiasArray objectAtIndex:num_layers - i - 1], grad_bias);
+                [results setObject:gradBiasPlaceholder.getMPSGraphTensorData() forKey:gradBiasPlaceholder.getMPSGraphTensor()];
+            }
 
             [results setObject:outputPlaceholder.getMPSGraphTensorData() forKey:outputPlaceholder.getMPSGraphTensor()];
             [results setObject:gradRecWeightsPlaceholder.getMPSGraphTensorData() forKey:gradRecWeightsPlaceholder.getMPSGraphTensor()];
-            [results setObject:gradBiasPlaceholder.getMPSGraphTensorData() forKey:gradBiasPlaceholder.getMPSGraphTensor()];
             [results setObject:gradStatePlaceholder.getMPSGraphTensorData() forKey:gradStatePlaceholder.getMPSGraphTensor()];
             [results setObject:gradCellStatePlaceholder.getMPSGraphTensorData() forKey:gradCellStatePlaceholder.getMPSGraphTensor()];
             [results setObject:gradWeightsPlaceholder.getMPSGraphTensorData() forKey:gradWeightsPlaceholder.getMPSGraphTensor()];

--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -533,6 +533,11 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
             weights.push_back(grad_weights);
             weights.push_back(grad_rec_weights);
 
+            if(has_biases) {
+                weights.push_back(grad_bias);
+                weights.push_back(grad_bias);
+            }
+
             if (i == 0) {
                 outputPlaceholder = Placeholder([gradOutputArray objectAtIndex:num_layers - i - 1], output_out);
                 gradStatePlaceholder = Placeholder([gradStateArray objectAtIndex:num_layers - i - 1], grad_state_out);
@@ -545,13 +550,8 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
 
             gradRecWeightsPlaceholder = Placeholder([gradRecWeightsArray objectAtIndex:num_layers - i - 1], grad_rec_weights);
             gradWeightsPlaceholder = Placeholder([gradWeightsArray objectAtIndex:num_layers - i - 1], grad_weights);
-
-            if(has_biases) {
-                weights.push_back(grad_bias);
-                gradBiasPlaceholder = Placeholder([gradBiasArray objectAtIndex:num_layers - i - 1], grad_bias);
-                [results setObject:gradBiasPlaceholder.getMPSGraphTensorData() forKey:gradBiasPlaceholder.getMPSGraphTensor()];
-            }
-
+            gradBiasPlaceholder = Placeholder([gradBiasArray objectAtIndex:num_layers - i - 1], grad_bias);
+            [results setObject:gradBiasPlaceholder.getMPSGraphTensorData() forKey:gradBiasPlaceholder.getMPSGraphTensor()];
             [results setObject:outputPlaceholder.getMPSGraphTensorData() forKey:outputPlaceholder.getMPSGraphTensor()];
             [results setObject:gradRecWeightsPlaceholder.getMPSGraphTensorData() forKey:gradRecWeightsPlaceholder.getMPSGraphTensor()];
             [results setObject:gradStatePlaceholder.getMPSGraphTensorData() forKey:gradStatePlaceholder.getMPSGraphTensor()];

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7192,12 +7192,12 @@
 
 # MPS LSTM implementation
 
-- func: _lstm_mps(Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
+- func: _lstm_mps(Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)
   dispatch:
     MPS: _lstm_mps
   autogen: _lstm_mps.out
 
-- func: lstm_mps_backward(Tensor grad_y, Tensor? grad_hy, Tensor? grad_cy, Tensor z_state, Tensor cell_state_fwd, Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor[], Tensor[])
+- func: lstm_mps_backward(Tensor grad_y, Tensor? grad_hy, Tensor? grad_cy, Tensor z_state, Tensor cell_state_fwd, Tensor input, Tensor layersOutputs, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor[], Tensor[])
   dispatch:
     MPS: lstm_mps_backward
   autogen: lstm_mps_backward.out

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8912,7 +8912,7 @@ class TestRNNMPS(TestCaseMPS):
             self.assertEqual(cpu_hn, hn)
             self.assertEqual(cpu_cn, cn)
 
-    def test_lstm_backward_one_layer(self, device="mps", dtype=torch.float32):
+    def test_lstm_backward(self, device="mps", dtype=torch.float32):
         for layers in [1, 2, 5]:
             inp_data = np.random.random((5, 3, 2))
             cell_data = np.random.random((layers, 3, 4))

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8876,7 +8876,7 @@ class TestAdvancedIndexing(TestCaseMPS):
 
 class TestRNNMPS(TestCaseMPS):
     def test_lstm_1(self, device="mps", dtype=torch.float32):
-        for layers in [1, 2, 5]:
+        for layers in [1] if product_version < 13.0 else [1, 2, 5]:
             torch.random.manual_seed(42)
             rnn = nn.LSTM(7, 4, layers, device="cpu")
             input = torch.randn(2, 3, 7, device="cpu")
@@ -8913,7 +8913,7 @@ class TestRNNMPS(TestCaseMPS):
             self.assertEqual(cpu_cn, cn)
 
     def test_lstm_backward(self, device="mps", dtype=torch.float32):
-        for layers in [1, 2, 5]:
+        for layers in [1] if product_version < 13.0 else [1, 2, 5]:
             inp_data = np.random.random((5, 3, 2))
             hx_data = np.random.random((layers, 3, 4))
             cx_data = np.random.random((layers, 3, 4))
@@ -8964,6 +8964,7 @@ class TestRNNMPS(TestCaseMPS):
             self.assertEqual(cpu_input_grad, mps_input_grad)
             for (cpu_name, cpu_weight_grad), (mps_name, mps_weight_grad) in zip(cpu_weights_grad, mps_weights_grad):
                 self.assertEqual(cpu_weight_grad, mps_weight_grad, f"mismatch in cpu:{cpu_name} vs mps:{mps_name}")
+
 
     def test_RNN_cell_no_broadcasting(self):
         def test(cell_module, input, hx, input_size, hidden_size):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8924,13 +8924,11 @@ class TestRNNMPS(TestCaseMPS):
                 output, _ = rnn(inp, (hx, cx))
                 f = output.sum()
 
-                weight_grads = sorted(
-                    [(param[0], torch.autograd.grad(f, [param[1]], retain_graph=True)[0]) for param in rnn.named_parameters()],
-                    key=lambda x: x[0]
-                )
+                param_names, params = zip(*rnn.named_parameters())
+                param_grads = zip(param_names, torch.autograd.grad(f, params, retain_graph=True))
 
                 input_grad, hx_grad, cx_grad = torch.autograd.grad(f, [inp, hx, cx])
-                return output, weight_grads, input_grad, hx_grad, cx_grad
+                return output, param_grads, input_grad, hx_grad, cx_grad
 
             inp = torch.randn((5, 3, 2), requires_grad=True, dtype=dtype, device=device)
             hx = torch.randn((layers, 3, 4), requires_grad=True, dtype=dtype, device=device)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8876,11 +8876,12 @@ class TestAdvancedIndexing(TestCaseMPS):
 
 class TestRNNMPS(TestCaseMPS):
     def test_lstm_1(self, device="mps", dtype=torch.float32):
-
-        rnn = nn.LSTM(7, 4, 2, device="cpu")
+        layers = 2
+        torch.random.manual_seed(42)
+        rnn = nn.LSTM(7, 4, layers, device="cpu")
         input = torch.randn(2, 3, 7, device="cpu")
-        hx = torch.randn(2, 3, 4, device="cpu")
-        cx = torch.randn(2, 3, 4, device="cpu")
+        hx = torch.randn(layers, 3, 4, device="cpu")
+        cx = torch.randn(layers, 3, 4, device="cpu")
 
         cpu_output, (cpu_hn, cpu_cn) = rnn(input, (hx, cx))
 
@@ -8895,10 +8896,10 @@ class TestRNNMPS(TestCaseMPS):
         self.assertEqual(cpu_cn, cn)
 
         # test batch_first
-        rnn = nn.LSTM(7, 4, 2, device="cpu", batch_first=True)
+        rnn = nn.LSTM(7, 4, layers, device="cpu", batch_first=True)
         input = torch.randn(3, 2, 7, device="cpu")
-        hx = torch.randn(2, 3, 4, device="cpu")
-        cx = torch.randn(2, 3, 4, device="cpu")
+        hx = torch.randn(layers, 3, 4, device="cpu")
+        cx = torch.randn(layers, 3, 4, device="cpu")
         cpu_output, (cpu_hn, cpu_cn) = rnn(input, (hx, cx))
 
         rnn = rnn.to(device)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8879,8 +8879,8 @@ class TestRNNMPS(TestCaseMPS):
 
         rnn = nn.LSTM(7, 4, 2, device="cpu")
         input = torch.randn(2, 3, 7, device="cpu")
-        hx = torch.zeros(2, 3, 4, device="cpu")
-        cx = torch.zeros(2, 3, 4, device="cpu")
+        hx = torch.randn(2, 3, 4, device="cpu")
+        cx = torch.randn(2, 3, 4, device="cpu")
 
         cpu_output, (cpu_hn, cpu_cn) = rnn(input, (hx, cx))
 
@@ -8897,8 +8897,8 @@ class TestRNNMPS(TestCaseMPS):
         # test batch_first
         rnn = nn.LSTM(7, 4, 2, device="cpu", batch_first=True)
         input = torch.randn(3, 2, 7, device="cpu")
-        hx = torch.zeros(2, 3, 4, device="cpu")
-        cx = torch.zeros(2, 3, 4, device="cpu")
+        hx = torch.randn(2, 3, 4, device="cpu")
+        cx = torch.randn(2, 3, 4, device="cpu")
         cpu_output, (cpu_hn, cpu_cn) = rnn(input, (hx, cx))
 
         rnn = rnn.to(device)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8913,7 +8913,7 @@ class TestRNNMPS(TestCaseMPS):
         self.assertEqual(cpu_cn, cn)
 
     def test_lstm_backward_one_layer(self, device="mps", dtype=torch.float32):
-        layers = 2
+        layers = 1
         inp_data = np.random.random((5, 3, 2))
         cell_data = np.random.random((layers, 3, 4))
 
@@ -8940,12 +8940,13 @@ class TestRNNMPS(TestCaseMPS):
             return output, weight_grads, input_grad, hx.grad.clone(), cx.grad.clone()
 
         cpu_output, cpu_weights_grad, cpu_input_grad, cpu_hx_grad, cpu_cx_grad = get_results("cpu")
-        mps_output, mps_weights_grad, mps_input_grad, mps_hx_grad, mps_cx_grad  = get_results(device)
+        mps_output, mps_weights_grad, mps_input_grad, mps_hx_grad, mps_cx_grad = get_results(device)
 
         self.assertEqual(cpu_hx_grad, mps_hx_grad)
         self.assertEqual(cpu_cx_grad, mps_cx_grad)
         self.assertEqual(cpu_output, mps_output)
         for cpu_weight_grad, mps_weight_grad in zip(cpu_weights_grad, mps_weights_grad):
+            print(cpu_weight_grad, mps_weight_grad)
             self.assertEqual(cpu_weight_grad, mps_weight_grad)
         self.assertEqual(cpu_input_grad, mps_input_grad)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8913,7 +8913,7 @@ class TestRNNMPS(TestCaseMPS):
         self.assertEqual(cpu_cn, cn)
 
     def test_lstm_backward_one_layer(self, device="mps", dtype=torch.float32):
-        layers = 1
+        layers = 2
         inp_data = np.random.random((5, 3, 2))
         cell_data = np.random.random((layers, 3, 4))
 
@@ -8937,11 +8937,13 @@ class TestRNNMPS(TestCaseMPS):
             if layers == 2:
                 weight_grads = weight_grads + (rnn.weight_ih_l1.grad.clone(), rnn.weight_hh_l1.grad.clone())
             input_grad = inp.grad.clone()
-            return output, weight_grads, input_grad
+            return output, weight_grads, input_grad, hx.grad.clone(), cx.grad.clone()
 
-        cpu_output, cpu_weights_grad, cpu_input_grad = get_results("cpu")
-        mps_output, mps_weights_grad, mps_input_grad = get_results(device)
+        cpu_output, cpu_weights_grad, cpu_input_grad, cpu_hx_grad, cpu_cx_grad = get_results("cpu")
+        mps_output, mps_weights_grad, mps_input_grad, mps_hx_grad, mps_cx_grad  = get_results(device)
 
+        self.assertEqual(cpu_hx_grad, mps_hx_grad)
+        self.assertEqual(cpu_cx_grad, mps_cx_grad)
         self.assertEqual(cpu_output, mps_output)
         for cpu_weight_grad, mps_weight_grad in zip(cpu_weights_grad, mps_weights_grad):
             self.assertEqual(cpu_weight_grad, mps_weight_grad)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8948,6 +8948,23 @@ class TestRNNMPS(TestCaseMPS):
             for (cpu_name, cpu_weight_grad), (mps_name, mps_weight_grad) in zip(cpu_weights_grad, mps_weights_grad):
                 self.assertEqual(cpu_weight_grad, mps_weight_grad, f"mismatch in cpu:{cpu_name} vs mps:{mps_name}")
 
+            # test batch_first backward
+            lstm = nn.LSTM(2, 4, layers, batch_first=True)
+            lstm.train()
+
+            hx_data = np.random.random((layers, 5, 4))
+            cx_data = np.random.random((layers, 5, 4))
+
+            cpu_output, cpu_weights_grad, cpu_input_grad, cpu_hx_grad, cpu_cx_grad = get_results("cpu")
+            mps_output, mps_weights_grad, mps_input_grad, mps_hx_grad, mps_cx_grad = get_results(device)
+
+            self.assertEqual(cpu_hx_grad, mps_hx_grad)
+            self.assertEqual(cpu_cx_grad, mps_cx_grad)
+            self.assertEqual(cpu_output, mps_output)
+            self.assertEqual(cpu_input_grad, mps_input_grad)
+            for (cpu_name, cpu_weight_grad), (mps_name, mps_weight_grad) in zip(cpu_weights_grad, mps_weights_grad):
+                self.assertEqual(cpu_weight_grad, mps_weight_grad, f"mismatch in cpu:{cpu_name} vs mps:{mps_name}")
+
     def test_RNN_cell_no_broadcasting(self):
         def test(cell_module, input, hx, input_size, hidden_size):
             cell = cell_module(input_size, hidden_size, device='mps')

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8877,8 +8877,8 @@ class TestAdvancedIndexing(TestCaseMPS):
 class TestRNNMPS(TestCaseMPS):
     def test_lstm_1(self, device="mps", dtype=torch.float32):
 
-        rnn = nn.LSTM(1, 4, 2, device="cpu")
-        input = torch.randn(2, 3, 1, device="cpu")
+        rnn = nn.LSTM(7, 4, 2, device="cpu")
+        input = torch.randn(2, 3, 7, device="cpu")
         hx = torch.zeros(2, 3, 4, device="cpu")
         cx = torch.zeros(2, 3, 4, device="cpu")
 
@@ -8895,8 +8895,8 @@ class TestRNNMPS(TestCaseMPS):
         self.assertEqual(cpu_cn, cn)
 
         # test batch_first
-        rnn = nn.LSTM(1, 4, 2, device="cpu", batch_first=True)
-        input = torch.randn(3, 2, 1, device="cpu")
+        rnn = nn.LSTM(7, 4, 2, device="cpu", batch_first=True)
+        input = torch.randn(3, 2, 7, device="cpu")
         hx = torch.zeros(2, 3, 4, device="cpu")
         cx = torch.zeros(2, 3, 4, device="cpu")
         cpu_output, (cpu_hn, cpu_cn) = rnn(input, (hx, cx))

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2568,11 +2568,11 @@
   input, weight, bias: "grad.defined() ? convolution_backward_symint(grad, input, weight, bias->sym_sizes(), stride, padding, std::vector<int64_t>(padding.size(), 1), false, std::vector<c10::SymInt>(padding.size(), 0), 1, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>()"
 
 #LSTM MPS
-- name: _lstm_mps(Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
-  output_differentiability: [True, True, True, False, False]
-  input, hx, params: "lstm_mps_backward(grads[0], grads[1], grads[2], result3, result4, input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first)"
+- name: _lstm_mps(Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)
+  output_differentiability: [True, True, True, False, False, False]
+  input, hx, params: "lstm_mps_backward(grads[0], grads[1], grads[2], result3, result4, input, result5, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first)"
 
-- name: lstm_mps_backward(Tensor grad_y, Tensor? grad_hy, Tensor? grad_cy, Tensor z_state, Tensor cell_state_fwd, Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor[], Tensor[])
+- name: lstm_mps_backward(Tensor grad_y, Tensor? grad_hy, Tensor? grad_cy, Tensor z_state, Tensor cell_state_fwd, Tensor input, Tensor layersOutputs, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor[], Tensor[])
 
 
 

--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -1109,6 +1109,7 @@ SUPPORTED_RETURN_TYPES = {
     "::std::tuple<at::Tensor,at::Tensor,at::Tensor>",
     "::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>",
     "::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor,at::Tensor>",
+    "::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor,at::Tensor,at::Tensor>",
     "::std::tuple<at::Tensor,at::Tensor,at::Tensor,int64_t>",
     "::std::tuple<at::Tensor,at::Tensor,double,int64_t>",
     "::std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor,int64_t>",


### PR DESCRIPTION
Fixes #91694 
Fixes #92615

Several transpositions were missing for backward graph in case of `batch_first=True`. The #91694 is not reproduced with `batch_first=False`.

After fixing transpose issue, I finally thought that now I can use LSTM freely in my project. And then I got horrific results on train. Seems related to #92615. 

After that I decided to fix LSTM's backward step completely. I collected all my findings in this thread — seems like I succeeded

Funny enough, backward tests were completely disabled before and were not passing:
```python
    @unittest.skipIf(True, "Backward of lstm returns wrong result")
    def test_lstm_2(self, device="mps", dtype=torch.float32):
```

UPD: forward pass of multi-layer version also was wrong due to the incorrect `initState, initCell` slices. Tests were passing because states were inited with zeros. *Accidentally* fixed this too
