### PR TITLE
[sympy] fix ValueRanges.pow error when b.lower is float

### DIFF
--- a/torch/utils/_sympy/value_ranges.py
+++ b/torch/utils/_sympy/value_ranges.py
@@ -367,7 +367,7 @@ class ValueRangeAnalysis:
             if r == sympy.zoo:
                 return ValueRanges.unknown()
             return ValueRanges.wrap(r)
-        elif b.is_singleton() and b.lower >= 0:
+        elif b.is_singleton() and b.lower >= 0 and isinstance(b.lower, int):
             i = ValueRanges.wrap(1)
             for _ in range(b.lower):
                 i = cls.mul(i, a)


### PR DESCRIPTION
Summary:
fix `TypeError: 'Float' object cannot be interpreted as an integer` for `ValueRanges.pow(a, b)` when `not a.is_singleton() and b.is_singleton() and not isinstance(b.lower, int)`

this is breaking  `cuda11.7-py3.10-gcc7-sm86 / test (inductor_timm, 1, 2, linux.g5.4xlarge.nvidia.gpu)`
{F878635541}

Test Plan: sandcastle + CI

Differential Revision: D43430385

