### PR TITLE
for SymInt nodes in fx graph, get result from node meta in inductor GraphLowering

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -400,6 +400,7 @@ class GraphLowering(torch.fx.Interpreter):
     def run_node(self, n: torch.fx.Node):
         with ir.IRNode.current_origins({n}):
             import math
+
             if n.op == "call_function" and n.target in layout_constraints:
                 args, kwargs = self.fetch_args_kwargs_from_env(n)
                 args, kwargs = layout_constraints[n.target](n, *args, **kwargs)

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -12,7 +12,7 @@ import torch
 import torch.fx
 from torch._decomp import get_decompositions
 from torch._dynamo.utils import dynamo_timed
-from torch.fx.experimental.symbolic_shapes import ShapeEnv
+from torch.fx.experimental.symbolic_shapes import magic_methods, method_to_operator, ShapeEnv
 from torch.utils._mode_utils import no_dispatch
 
 from .._dynamo import config as dynamo_config
@@ -58,6 +58,10 @@ def supported_dtype_of_cpp_wrapper(dtype):
         # torch.bfloat16, # TODO: implement this
     }
     return dtype in supported_dtype
+
+def is_magic_method(op):
+    magic_ops = {method_to_operator(m) for m in magic_methods}
+    return op in magic_ops
 
 
 class GraphLowering(torch.fx.Interpreter):
@@ -405,7 +409,7 @@ class GraphLowering(torch.fx.Interpreter):
                 args, kwargs = self.fetch_args_kwargs_from_env(n)
                 args, kwargs = layout_constraints[n.target](n, *args, **kwargs)
                 result = self.call_function(n.target, args, kwargs)
-            elif n.target == math.floor or n.target == math.ceil:
+            elif is_magic_method(n.target):
                 if isinstance(n.meta["val"], torch.SymInt):
                     result = n.meta["val"].node.expr
                 else:

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -12,7 +12,11 @@ import torch
 import torch.fx
 from torch._decomp import get_decompositions
 from torch._dynamo.utils import dynamo_timed
-from torch.fx.experimental.symbolic_shapes import magic_methods, method_to_operator, ShapeEnv
+from torch.fx.experimental.symbolic_shapes import (
+    magic_methods,
+    method_to_operator,
+    ShapeEnv,
+)
 from torch.utils._mode_utils import no_dispatch
 
 from .._dynamo import config as dynamo_config
@@ -58,6 +62,7 @@ def supported_dtype_of_cpp_wrapper(dtype):
         # torch.bfloat16, # TODO: implement this
     }
     return dtype in supported_dtype
+
 
 def is_magic_method(op):
     magic_ops = {method_to_operator(m) for m in magic_methods}
@@ -403,8 +408,6 @@ class GraphLowering(torch.fx.Interpreter):
 
     def run_node(self, n: torch.fx.Node):
         with ir.IRNode.current_origins({n}):
-            import math
-
             if n.op == "call_function" and n.target in layout_constraints:
                 args, kwargs = self.fetch_args_kwargs_from_env(n)
                 args, kwargs = layout_constraints[n.target](n, *args, **kwargs)


### PR DESCRIPTION
Finally, swin is passing, with no floors in the generated code. 
I don't know how to write a test for it though, and swin patterns triggering this are pretty complicated (even prior to this PR we were already good at pulling `floors` out of device code). 


cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire