### PR TITLE
Turn on -Wsign-compare on builds

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -456,7 +456,6 @@ function(torch_compile_options libname)
       -Wno-type-limits
       -Wno-array-bounds
       -Wno-unknown-pragmas
-      -Wno-sign-compare
       -Wno-strict-overflow
       -Wno-strict-aliasing
       -Wno-error=deprecated-declarations


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95211

We appear to have it enabled internally in fbcode, so turn it on in OSS
too.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>