### PR TITLE
Add warning when training is not set explicitly in base Module class

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -455,7 +455,7 @@ class Module:
         handling for parameters, submodules, and buffers but simply calls into
         super().__setattr__ for all other attributes.
         """
-        super().__setattr__('training', True)
+        super().__setattr__('training', None)
         super().__setattr__('_parameters', OrderedDict())
         super().__setattr__('_buffers', OrderedDict())
         super().__setattr__('_non_persistent_buffers_set', set())
@@ -476,6 +476,13 @@ class Module:
             super().__init__(*args, **kwargs)
 
     forward: Callable[..., Any] = _forward_unimplemented
+
+    def __getattribute__(self, name: str) -> Any:
+        if name == "forward":
+            if self.training is None:
+                warnings.warn(f"{self.__class__.__name__}.training is None. It must be set "
+                               "explicitly by calling either self.train() or self.eval().")
+        return object.__getattribute__(self, name)
 
     def register_buffer(self, name: str, tensor: Optional[Tensor], persistent: bool = True) -> None:
         r"""Adds a buffer to the module.


### PR DESCRIPTION
Currently, the training attribute of the `Module` base class is set to `True` by default. This can lead to unwanted and hard to catch side-effects.
For instance, when inferring using a `model` with `BatchNorm`, forgetting to call `model.eval()` could lead to undesired behavior (running stats being silently updated).
However, throwing an error seems too strict as it would break many existing code.
This PR instead proposes a very basic warning mechanism:
- the `training` attribute is set to `None` by default (instead of `True`)
- when the `forward` method is called, the base `Module` class checks if `self.training` is `None` and if so, raises a warning.
