### PR TITLE
If the input is contiguous, short-circuit infer_size_dv in reshape

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1568,7 +1568,7 @@ Tensor reshape_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
     AT_ERROR("reshape is not implemented for sparse tensors");
   }
 
-  if (self.is_contiguous()) {
+  if (self.is_contiguous() && !self.is_mkldnn()) {
     return self.view_symint(proposed_shape);
   }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1567,6 +1567,11 @@ Tensor reshape_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
   if (self.is_sparse()) {
     AT_ERROR("reshape is not implemented for sparse tensors");
   }
+
+  if (self.is_contiguous()) {
+    return self.view_symint(proposed_shape);
+  }
+
   c10::SymDimVector shape = infer_size_dv(proposed_shape, self.sym_numel());
 
   if (self.is_mkldnn()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95216

The main improvement is that this avoids guards from infer_size_dv,
although this also counts as a minor perf improvement too.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>