### PR TITLE
Get matrix multiply with unbacked SymInt working

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1842,6 +1842,7 @@ class TestRefsOpsInfo(TestCase):
         # other
         '_refs.empty',  # intentional; direct empty is faster and has less guards
         '_refs.empty_permuted',  # intentional; direct empty is faster and has less guards
+        '_refs.expand',  # intentional; expand meta has less guards
         '_refs.expand_as',
         '_refs.as_strided',  # _prims._as_strided_meta: "reduce() of empty sequence with no initial value"
         '_refs.copy_to',  # torch._C._jit_get_operation: No such operator aten::copy_to

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -953,20 +953,20 @@ def forward(self, crop_camera_1, mask_1):
     copy_ = torch.ops.aten.copy_.default(select_1, lift_fresh_copy);  select_1 = lift_fresh_copy = None
     sym_size = torch.ops.aten.sym_size(index, 0)
     expand = torch.ops.aten.expand.default(eye, [sym_size, 3, 3])
-    view_of = torch.ops.prims.view_of.default(expand);  expand = None
+    view = torch.ops.aten.view.default(expand, [sym_size, 3, 3]);  expand = None
     sym_size_1 = torch.ops.aten.sym_size(crop_camera_1, 1)
     sym_size_2 = torch.ops.aten.sym_size(crop_camera_1, 2)
-    expand_1 = torch.ops.aten.expand.default(index, [sym_size, sym_size_1, sym_size_2]);  index = sym_size_1 = None
-    view_of_1 = torch.ops.prims.view_of.default(expand_1);  expand_1 = None
-    bmm = torch.ops.aten.bmm.default(view_of, view_of_1);  view_of = view_of_1 = None
-    view = torch.ops.aten.view.default(bmm, [sym_size, 3, sym_size_2]);  bmm = None
-    expand_2 = torch.ops.aten.expand.default(view, [sym_size, 3, sym_size_2]);  view = sym_size_2 = None
-    view_of_2 = torch.ops.prims.view_of.default(expand_2);  expand_2 = None
+    expand_1 = torch.ops.aten.expand.default(index, [sym_size, sym_size_1, sym_size_2]);  index = None
+    view_1 = torch.ops.aten.view.default(expand_1, [sym_size, sym_size_1, sym_size_2]);  expand_1 = sym_size_1 = None
+    bmm = torch.ops.aten.bmm.default(view, view_1);  view = view_1 = None
+    view_2 = torch.ops.aten.view.default(bmm, [sym_size, 3, sym_size_2]);  bmm = None
+    expand_2 = torch.ops.aten.expand.default(view_2, [sym_size, 3, sym_size_2]);  view_2 = None
+    view_3 = torch.ops.aten.view.default(expand_2, [sym_size, 3, sym_size_2]);  expand_2 = sym_size_2 = None
     expand_3 = torch.ops.aten.expand.default(eye, [sym_size, 3, 3]);  eye = None
-    view_of_3 = torch.ops.prims.view_of.default(expand_3);  expand_3 = None
-    bmm_1 = torch.ops.aten.bmm.default(view_of_2, view_of_3);  view_of_2 = view_of_3 = None
-    view_1 = torch.ops.aten.view.default(bmm_1, [sym_size, 3, 3]);  bmm_1 = sym_size = None
-    index_put_ = torch.ops.aten.index_put_.default(crop_camera_1, [mask_1], view_1);  crop_camera_1 = mask_1 = view_1 = None
+    view_4 = torch.ops.aten.view.default(expand_3, [sym_size, 3, 3]);  expand_3 = None
+    bmm_1 = torch.ops.aten.bmm.default(view_3, view_4);  view_3 = view_4 = None
+    view_5 = torch.ops.aten.view.default(bmm_1, [sym_size, 3, 3]);  bmm_1 = sym_size = None
+    index_put_ = torch.ops.aten.index_put_.default(crop_camera_1, [mask_1], view_5);  crop_camera_1 = mask_1 = view_5 = None
     return None""")
 
     def test_boolean_index(self):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3254,6 +3254,84 @@ def matmul(tensor1, tensor2):
         utils.check(False, lambda: "both arguments to matmul need to be at least 1D")
 
 
+def computeStride(oldshape, oldstride, newshape):
+    if len(oldshape) == 0:
+        return [1] * len(newshape)
+
+    numel = 1
+    for s in oldshape:
+        numel *= s
+
+    if numel == 0 and oldshape == newshape:
+        return list(oldstride)
+
+    newstride = [1] * len(newshape)
+    if numel == 0:
+        for view_d in range(len(newshape) - 1, -1, -1):
+            if view_d == len(newshape) - 1:
+                newstride[view_d] = 1
+            else:
+                newstride[view_d] = max(newshape[view_d + 1], 1) * newstride[view_d + 1]
+
+        return newstride
+
+    view_d = len(newshape) - 1;
+    chunk_base_stride = oldstride[-1]
+    tensor_numel = 1
+    view_numel = 1
+    for tensor_d in range(len(oldshape) - 1,  -1, -1):
+        tensor_numel *= oldshape[tensor_d]
+
+        if (tensor_d == 0) or (oldshape[tensor_d - 1] != 1 and
+            oldstride[tensor_d - 1] != tensor_numel * chunk_base_stride):
+            while view_d >= 0 and (view_numel < tensor_numel or newshape[view_d] == 1):
+                newstride[view_d] = view_numel * chunk_base_stride
+                view_numel *= newshape[view_d]
+                view_d -= 1
+
+            if view_numel != tensor_numel:
+                return None
+
+            if tensor_d > 0:
+                chunk_base_stride = oldstride[tensor_d - 1]
+                tensor_numel = 1
+                view_numel = 1
+
+
+    if view_d != -1:
+        return None
+
+    return newstride
+
+
+@aten.reshape.default.py_impl(DispatchKey.CompositeImplicitAutograd)
+def reshape(self, proposed_shape):
+    if self.is_sparse:
+        raise RuntimeError("reshape is not implemented for sparse tensors")
+
+    # TODO: fix this hack properly
+    if definitely_true(self.numel() != 0) and self.is_contiguous() and not self.is_mkldnn:
+        return self.view(proposed_shape)
+
+    # This is pretty dumb, but sometimes we ask to reshape... to our same
+    # shape lol
+    if len(self.size()) == len(proposed_shape) and all(definitely_true(s1 == s2) for s1, s2 in zip(self.size(), proposed_shape)):
+        return self.view(proposed_shape)
+
+    shape = utils.infer_size(proposed_shape, self.numel())
+
+    if self.is_mkldnn:
+        return torch.ops.aten._mkldnn_reshape(self, shape)
+
+    stride = computeStride(self.size(), self.stride(), shape)
+
+    if stride is not None:
+        # NB: omitted _reshape_alias optimization
+        return self.view(shape)
+
+    return torch.ops.aten._unsafe_view(self.clone(memory_format=torch.contiguous_format), shape)
+
+
 @register_decomposition(aten.expand.default)
 def expand_meta(self, sizes):
     utils.check(

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3275,15 +3275,17 @@ def computeStride(oldshape, oldstride, newshape):
 
         return newstride
 
-    view_d = len(newshape) - 1;
+    view_d = len(newshape) - 1
     chunk_base_stride = oldstride[-1]
     tensor_numel = 1
     view_numel = 1
-    for tensor_d in range(len(oldshape) - 1,  -1, -1):
+    for tensor_d in range(len(oldshape) - 1, -1, -1):
         tensor_numel *= oldshape[tensor_d]
 
-        if (tensor_d == 0) or (oldshape[tensor_d - 1] != 1 and
-            oldstride[tensor_d - 1] != tensor_numel * chunk_base_stride):
+        if (tensor_d == 0) or (
+            oldshape[tensor_d - 1] != 1
+            and oldstride[tensor_d - 1] != tensor_numel * chunk_base_stride
+        ):
             while view_d >= 0 and (view_numel < tensor_numel or newshape[view_d] == 1):
                 newstride[view_d] = view_numel * chunk_base_stride
                 view_numel *= newshape[view_d]
@@ -3297,7 +3299,6 @@ def computeStride(oldshape, oldstride, newshape):
                 tensor_numel = 1
                 view_numel = 1
 
-
     if view_d != -1:
         return None
 
@@ -3310,12 +3311,18 @@ def reshape(self, proposed_shape):
         raise RuntimeError("reshape is not implemented for sparse tensors")
 
     # TODO: fix this hack properly
-    if definitely_true(self.numel() != 0) and self.is_contiguous() and not self.is_mkldnn:
+    if (
+        definitely_true(self.numel() != 0)
+        and self.is_contiguous()
+        and not self.is_mkldnn
+    ):
         return self.view(proposed_shape)
 
     # This is pretty dumb, but sometimes we ask to reshape... to our same
     # shape lol
-    if len(self.size()) == len(proposed_shape) and all(definitely_true(s1 == s2) for s1, s2 in zip(self.size(), proposed_shape)):
+    if len(self.size()) == len(proposed_shape) and all(
+        definitely_true(s1 == s2) for s1, s2 in zip(self.size(), proposed_shape)
+    ):
         return self.view(proposed_shape)
 
     shape = utils.infer_size(proposed_shape, self.numel())
@@ -3329,7 +3336,9 @@ def reshape(self, proposed_shape):
         # NB: omitted _reshape_alias optimization
         return self.view(shape)
 
-    return torch.ops.aten._unsafe_view(self.clone(memory_format=torch.contiguous_format), shape)
+    return torch.ops.aten._unsafe_view(
+        self.clone(memory_format=torch.contiguous_format), shape
+    )
 
 
 @register_decomposition(aten.expand.default)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -19,7 +19,11 @@ from torch._prims_common.wrappers import (
     _safe_copy_out,
     out_wrapper,
 )
-from torch.fx.experimental.symbolic_shapes import guard_int, tensor_has_hints, definitely_true
+from torch.fx.experimental.symbolic_shapes import (
+    definitely_true,
+    guard_int,
+    tensor_has_hints,
+)
 from torch.utils._pytree import tree_flatten, tree_map
 
 DispatchKey = torch._C.DispatchKey  # type: ignore[attr-defined]
@@ -3166,8 +3170,10 @@ def matmul(tensor1, tensor2):
     # understand way.  Suppress folding if you have unbacked SymInts.  It's
     # possible you can get the folding code to work with unbacked SymInts
     # but I couldn't figure out how to do it.
-    elif tensor_has_hints(tensor1) and tensor_has_hints(tensor2) and (
-        should_fold(tensor1, dim_tensor2) or should_fold(tensor2, dim_tensor1)
+    elif (
+        tensor_has_hints(tensor1)
+        and tensor_has_hints(tensor2)
+        and (should_fold(tensor1, dim_tensor2) or should_fold(tensor2, dim_tensor1))
     ):
         # NB: Much of this was written with Copilot! (although still had to fix a bunch of issues)
 
@@ -3250,10 +3256,11 @@ def matmul(tensor1, tensor2):
 
 @register_decomposition(aten.expand.default)
 def expand_meta(self, sizes):
-    utils.check(len(sizes) >= self.dim(), lambda:
-        f"expand({tuple(self.size())}, size={sizes}): the number of sizes "
+    utils.check(
+        len(sizes) >= self.dim(),
+        lambda: f"expand({tuple(self.size())}, size={sizes}): the number of sizes "
         "the number of sizes provided ({len(sizes)}) must be greater or "
-        "equal to the number of dimensions in the tensor ({self.dim()})"
+        "equal to the number of dimensions in the tensor ({self.dim()})",
     )
     tensor_sizes = self.size()
     tensor_strides = self.stride()
@@ -3271,13 +3278,18 @@ def expand_meta(self, sizes):
         offset = ndim - 1 - i
         dim = tensor_dim - 1 - offset
         size = tensor_sizes[dim] if dim >= 0 else 1
-        stride = tensor_strides[dim] if dim >= 0 else expandedSizes[i + 1] * expandedStrides[i + 1]
+        stride = (
+            tensor_strides[dim]
+            if dim >= 0
+            else expandedSizes[i + 1] * expandedStrides[i + 1]
+        )
         targetSize = sizes[i]
 
         if targetSize == -1:
-            utils.check(dim >= 0, lambda:
-                f"The expanded size of the tensor ({targetSize}) isn't allowed "
-                f"in a leading, non-existing dimension {i}"
+            utils.check(
+                dim >= 0,
+                lambda: f"The expanded size of the tensor ({targetSize}) isn't allowed "
+                f"in a leading, non-existing dimension {i}",
             )
             targetSize = size
 
@@ -3285,15 +3297,20 @@ def expand_meta(self, sizes):
         # one, we're supposed to provide the predicted stride (not zero).
         # Cannot easily tell when this has occurred.  So this change is only
         # valid under "stride agnostic PyTorch"
-        if definitely_true(size == 1) and isinstance(targetSize, torch.SymInt) and not targetSize.node.has_hint():
+        if (
+            definitely_true(size == 1)
+            and isinstance(targetSize, torch.SymInt)
+            and not targetSize.node.has_hint()
+        ):
             size = targetSize
             stride = 0
 
         elif size != targetSize:
-            utils.check(size == 1, lambda:
-                f"The expanded size of the tensor ({targetSize}) must match the "
+            utils.check(
+                size == 1,
+                lambda: f"The expanded size of the tensor ({targetSize}) must match the "
                 f"existing size ({size}) at non-singleton dimension {i}.  "
-                f"Target sizes: {sizes}. Tensor sizes: {tensor_sizes}"
+                f"Target sizes: {sizes}. Tensor sizes: {tensor_sizes}",
             )
             size = targetSize
             stride = 0

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2754,7 +2754,6 @@ def dstack(tensors: TensorSequenceType) -> TensorLikeType:
     return cat(aligned_tensors, 2)
 
 
-@register_decomposition(aten.expand)
 def expand(a: Tensor, *shape) -> Tensor:
     # NOTE: cannot use utils.extract_shape_from_varargs here
     # because that also validates the shape, but the shape
@@ -3262,6 +3261,7 @@ def _reshape_view_helper(a: TensorLikeType, *shape, allow_copy: bool) -> TensorL
 # NOTE: shape is a vararg because Tensor.reshape can be called with as
 # Tensor.reshape(a, b, c) or Tensor.reshape((a, b, c)) Function call
 # torch.reshape doesn't support unpacked shapes
+@aten.reshape.default.py_impl(DispatchKey.CompositeImplicitAutograd)
 def reshape(a: TensorLikeType, *shape: ShapeType) -> TensorLikeType:
     return _reshape_view_helper(a, *shape, allow_copy=True)
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3261,7 +3261,6 @@ def _reshape_view_helper(a: TensorLikeType, *shape, allow_copy: bool) -> TensorL
 # NOTE: shape is a vararg because Tensor.reshape can be called with as
 # Tensor.reshape(a, b, c) or Tensor.reshape((a, b, c)) Function call
 # torch.reshape doesn't support unpacked shapes
-@aten.reshape.default.py_impl(DispatchKey.CompositeImplicitAutograd)
 def reshape(a: TensorLikeType, *shape: ShapeType) -> TensorLikeType:
     return _reshape_view_helper(a, *shape, allow_copy=True)
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -152,7 +152,7 @@ def broadcast_shapes(*shapes):
                         raise RuntimeError("Shape mismatch: objects cannot be broadcast to a single shape")
             else:
                 raise RuntimeError("Input shapes should be of type ints, a tuple of ints, or a list of ints, got ", shape)
-        return torch.Size(result)
+        return torch.Size(result)  # type: ignore[arg-type]
     else:
         # with implementation above, torch.jit.trace hardcodes the sizes which makes subsequent replays fail
         with torch.no_grad():

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -108,6 +108,17 @@ def hint_int(a):
     assert type(a) is int, a
     return a
 
+def has_hint(a):
+    if isinstance(a, torch.SymInt):
+        return a.node.has_hint()
+    return True
+
+# Returns True if every size dim on the tensor has a hint
+# TODO: Should this include strides too?  For now it doesn't matter,
+# that's quite an obscure case
+def tensor_has_hints(t):
+    return all(has_hint(s) for s in t.size())
+
 def definitely_true(a):
     """
     Returns True only if we can tell that a is True, possibly introducing


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #95222
* __->__ #95218
* #94790
* #94523
* #95209
* #95208

This PR gets `reflect @ R @ reflect` working, where R has unbacked batch size. This pattern occurred in CrystalDPR. The billing of changes:

* torch.broadcast_shapes avoids guarding on unbacked SymInts when testing for broadcastable dims. I extracted this to https://github.com/pytorch/pytorch/pull/95217 for separate review; it's repeated in this PR as it is necessary for the E2E test
* I disable matrix multiply folding when there is an unbacked SymInt on any input. Folding is strictly a performance optimization and can be omitted. Also, I believe export would prefer to get matmul (rather than bmm/etc), so we should eventually actually get https://github.com/pytorch/pytorch/pull/91081/ going
* I add a direct Python transcription of the reshape composite adapted from https://github.com/pytorch/pytorch/pull/84584 . I cannot use the PrimTorch composite as it has problems when I register it pre-autograd. It has the same implementation as regular reshape, but at the beginning there is one more test for trivial reshapes, which is sufficient for the matmul example.
* I hand-write a meta function for expand, rather than using the PrimTorch decomposition. I couldn't really figure out how to make the PrimTorch decomposition guard free, but with the hand-written meta it is clear where the divergence lies: we cannot easily choose the correct stride for the unbacked dim, as we need to know whether or not the size is one (in which case we give the predicted stride) versus non-one (in which case we MUST give zero.) In composability sync, we agreed that changes to striding behavior are fair game with unbacked SymInts, so I just unconditionally give these zero stride.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>