### PR TITLE
[MPS] Remove mps specialized path in BCE backward

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1990,7 +1990,8 @@ Tensor binary_cross_entropy_target_backward(
     const Tensor& target,
     const c10::optional<Tensor>& weight,
     int64_t reduction) {
-  auto grad_target = [&] { return at::logit(self).neg_(); }();
+  auto grad_target = at::logit(self).neg_();
+
   if (!areAnyTensorSubclassLike({grad})) {
     grad_target.mul_(grad);
   } else {

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1990,12 +1990,7 @@ Tensor binary_cross_entropy_target_backward(
     const Tensor& target,
     const c10::optional<Tensor>& weight,
     int64_t reduction) {
-  auto grad_target = [&] {
-    if (self.is_mps()) {
-      return self.neg().log1p_().sub_(self.log());
-    }
-    return at::logit(self).neg_();
-  }();
+  auto grad_target = [&] { return at::logit(self).neg_(); }();
   if (!areAnyTensorSubclassLike({grad})) {
     grad_target.mul_(grad);
   } else {


### PR DESCRIPTION
Remove mps specialized path in BCE backward as `logit` op has been implemented for mps.
