### PR TITLE
Segmentation fault in flatbuffers when parsing malformed modules

### DIFF
--- a/test/cpp/jit/test_flatbuffer.cpp
+++ b/test/cpp/jit/test_flatbuffer.cpp
@@ -53,6 +53,23 @@ mobile::Module parse_mobile_module(
 }
 } // namespace
 
+TEST(FlatbufferTest, LoadMalformedModule) {
+  // Manually create some data with Flatbuffer header.
+  std::stringstream bad_data;
+  bad_data << "PK\x03\x04PTMF\x00\x00"
+           << "*}NV\xb3\xfa\xdf\x00pa";
+
+  // Loading module from it should throw an exception.
+  // Check guard at parse_and_initialize_mobile_module_for_jit.
+  ASSERT_THROWS_WITH_MESSAGE(
+      torch::jit::load(bad_data), "Malformed Flatbuffer module");
+
+  // Check guard at parse_and_initialize_mobile_module.
+  ASSERT_THROWS_WITH_MESSAGE(
+      parse_mobile_module(bad_data.str().data(), bad_data.str().size()),
+      "Malformed Flatbuffer module");
+}
+
 TEST(FlatbufferTest, UpsampleNearest2d) {
   Module m("m");
   m.define(R"(

--- a/test/cpp/jit/test_lite_trainer.cpp
+++ b/test/cpp/jit/test_lite_trainer.cpp
@@ -1,3 +1,5 @@
+#include <test/cpp/jit/test_utils.h>
+
 #include <gtest/gtest.h>
 
 #include <c10/core/TensorOptions.h>
@@ -236,6 +238,17 @@ TEST(MobileTest, LoadParametersEmptyDataShouldThrow) {
   // Loading parameters from an empty data stream should throw an exception.
   std::stringstream empty;
   EXPECT_ANY_THROW(_load_parameters(empty));
+}
+
+TEST(MobileTest, LoadParametersMalformedFlatbuffer) {
+  // Manually create some data with Flatbuffer header.
+  std::stringstream bad_data;
+  bad_data << "PK\x03\x04PTMF\x00\x00"
+           << "*}NV\xb3\xfa\xdf\x00pa";
+
+  // Loading parameters from it should throw an exception.
+  ASSERT_THROWS_WITH_MESSAGE(
+      _load_parameters(bad_data), "Malformed Flatbuffer module");
 }
 
 TEST(LiteTrainerTest, SGD) {


### PR DESCRIPTION
Fixes #95061, #95062

Add Flatbuffer verification before parsing to avoid crashing on malformed modules. Flatbuffers doesn't perform boundary checks at runtime for the sake of performance, so when parsing untrusted modules it is highly recommended to verify overall buffer integrity.

This bug can be triggered both by C++ (`torch::jit::load`, `torch::jitload_jit_module_from_file`) and Python  API (`torch.jit.load`, `torch.jit.jit_module_from_flatbuffer`).

Crash files to reproduce: 
[crash-1feb368861083e3d242e5c3fcb1090869f4819c4.txt](https://github.com/pytorch/pytorch/files/10795267/crash-1feb368861083e3d242e5c3fcb1090869f4819c4.txt)
[crash-7e8ffd314223be96b43ca246d3d3481702869455.txt](https://github.com/pytorch/pytorch/files/10795268/crash-7e8ffd314223be96b43ca246d3d3481702869455.txt)
[crash-ad4d7c6183af8f34fe1cb5c8133315c6389c409f.txt](https://github.com/pytorch/pytorch/files/10795279/crash-ad4d7c6183af8f34fe1cb5c8133315c6389c409f.txt)

