### PR TITLE
Fix `update_pytorch_labels` workflow

### DIFF
--- a/.github/scripts/export_pytorch_labels.py
+++ b/.github/scripts/export_pytorch_labels.py
@@ -14,12 +14,25 @@ import boto3  # type: ignore[import]
 import json
 
 from label_utils import gh_get_labels
+from argparse import ArgumentParser
+from typing import Any
+
+
+def parse_args() -> Any:
+    from argparse import ArgumentParser
+    parser = ArgumentParser("Export PR labels")
+    parser.add_argument("org", type=str)
+    parser.add_argument("repo", type=str)
+
+    return parser.parse_args()
 
 
 def main() -> None:
+    args = parse_args()
+    print(f"Exporting labels for {args.org}/{args.repo}")
     labels_file_name = "pytorch_labels.json"
     obj = boto3.resource('s3').Object('ossci-metrics', labels_file_name)
-    obj.put(Body=json.dumps(gh_get_labels()).encode())
+    obj.put(Body=json.dumps(gh_get_labels(args.org, args.repo)).encode())
 
 
 if __name__ == '__main__':

--- a/.github/scripts/export_pytorch_labels.py
+++ b/.github/scripts/export_pytorch_labels.py
@@ -14,7 +14,6 @@ import boto3  # type: ignore[import]
 import json
 
 from label_utils import gh_get_labels
-from argparse import ArgumentParser
 from typing import Any
 
 

--- a/.github/workflows/update_pytorch_labels.yml
+++ b/.github/workflows/update_pytorch_labels.yml
@@ -24,4 +24,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
         run: |
           python3 -m pip install boto3==1.19.12
-          .github/scripts/export_pytorch_labels.py
+          .github/scripts/export_pytorch_labels.py pytorch pytorch


### PR DESCRIPTION
Pass in repo args now that they're required (after a recent refactor). Also changes the script to pass in the repo name instead of being hardcoded to pytorch/pytorch.

I'm guessing this wasn't noticed earlier since the workflow is only triggered when a label is created/edited/deleted