### PR TITLE
[pt] move csrc shm logic to aten storage utils

### DIFF
--- a/aten/src/ATen/StorageUtils.cpp
+++ b/aten/src/ATen/StorageUtils.cpp
@@ -1,0 +1,47 @@
+#include <ATen/Functions.h>
+#include <ATen/MapAllocator.h>
+#include <ATen/StorageUtils.h>
+#include <c10/core/TensorOptions.h>
+
+namespace at {
+
+C10_EXPORT c10::intrusive_ptr<c10::StorageImpl> new_shm_fd_storage(
+    size_t size) {
+  int flags = ALLOCATOR_MAPPED_SHAREDMEM | ALLOCATOR_MAPPED_EXCLUSIVE |
+      ALLOCATOR_MAPPED_KEEPFD | ALLOCATOR_MAPPED_UNLINK;
+  std::string handle = NewProcessWideShmHandle();
+  auto sptr = MapAllocator::makeDataPtr(
+      handle.c_str(), flags, size * sizeof(uint8_t), nullptr);
+  return c10::make_intrusive<StorageImpl>(
+      c10::StorageImpl::use_byte_size_t(),
+      size,
+      std::move(sptr),
+      /*allocator=*/nullptr,
+      /*resizable=*/false);
+}
+
+C10_EXPORT void storage_copy(
+    c10::Storage& dst,
+    const c10::Storage& src,
+    bool non_blocking) {
+  auto dst_options = c10::TensorOptions().device(dst.device()).dtype(at::kByte);
+  auto dst_t = at::empty({0}, {}, dst_options).set_(dst);
+
+  auto src_options = c10::TensorOptions().device(src.device()).dtype(at::kByte);
+  auto src_t = at::empty({0}, {}, src_options).set_(src);
+  dst_t.copy_(src_t, non_blocking);
+}
+
+C10_EXPORT void share_memory_(TensorBase& t) {
+  if (t.device() != at::kCPU) {
+    return;
+  }
+
+  const at::Storage& origStorage = t.storage();
+  at::Storage newStorage(new_shm_fd_storage(origStorage.nbytes()));
+  storage_copy(newStorage, origStorage);
+  std::swap(
+      *origStorage.unsafeGetStorageImpl(), *newStorage.unsafeGetStorageImpl());
+}
+
+} // namespace at

--- a/aten/src/ATen/StorageUtils.h
+++ b/aten/src/ATen/StorageUtils.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <c10/core/Storage.h>
+#include <c10/core/StorageImpl.h>
+#include <c10/util/intrusive_ptr.h>
+
+namespace at {
+
+class TensorBase;
+
+// Here we define a series of utils to create/manipulate ATen backed
+// c10 storage implementations.
+
+/**
+ * Create a new shared memory storage impl managed by file descriptor
+ *
+ * @param size  size in bytes
+ */
+C10_EXPORT c10::intrusive_ptr<c10::StorageImpl> new_shm_fd_storage(size_t size);
+
+/**
+ * Copy src to dst
+ * Caller must guarantee the validness of the storage objects
+ * during the entire copy process, esp. when it's async.
+ *
+ * This can probably live in c10 namespace later if needed,
+ * but for now keep it in at to keep implementation simple.
+ *
+ * @param dst  dst tensor
+ * @param src  src tensor
+ * @param non_blocking  (default false) whether this operation blocks caller
+ */
+C10_EXPORT void storage_copy(
+    c10::Storage& dst,
+    const c10::Storage& src,
+    bool non_blocking = false);
+
+/**
+ * In place change the storage to shm based.
+ *
+ * This would later be invoked by at::TensorBase user facing API.
+ * For now, to keep the change minimal,
+ * intentionally separate the API changes from the core logic,
+ * as the API changes may also need to handle device/OS specifics.
+ *
+ * @param t  a tensor
+ */
+C10_EXPORT void share_memory_(TensorBase& t);
+
+} // namespace at

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/reportMemoryUsage_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/scalar_tensor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/scalar_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/StorageUtils_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/stride_properties_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/tensor_iterator_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_parallel.cpp

--- a/aten/src/ATen/test/StorageUtils_test.cpp
+++ b/aten/src/ATen/test/StorageUtils_test.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+
+#include <ATen/Functions.h>
+#include <ATen/Tensor.h>
+#include <ATen/StorageUtils.h>
+
+using namespace ::testing;
+
+TEST(StorageUtilsTest, shm_storage_refcount) {
+  auto t1 = std::make_unique<at::Tensor>(
+      at::full({5, 5}, 7, at::dtype(at::kLong).device(at::kCPU)));
+  auto t2 = std::make_unique<at::Tensor>(t1->slice(0, 0, 3));
+
+  auto verificationTensor = t1->clone();
+  ASSERT_EQ(t1->storage().use_count(), 2);
+  ASSERT_EQ(t2->storage().use_count(), 2);
+  ASSERT_EQ(verificationTensor.storage().use_count(), 1);
+
+  at::share_memory_(*t1);
+  ASSERT_EQ(t1->storage().allocator(), nullptr)
+      << "Expect original storage allocator to be detached";
+  ASSERT_NE(verificationTensor.storage().allocator(), nullptr);
+  ASSERT_EQ(t1->storage().use_count(), 2) << "Expect refcount to be the same";
+  ASSERT_EQ(t2->storage().use_count(), 2);
+
+  ASSERT_TRUE(t1->equal(verificationTensor));
+  auto weakStoragePtr = t1->storage().getWeakStorageImpl();
+  // weak + 1 (if any strong ref exists due to how intrusive_ptr refcount works)
+  ASSERT_EQ(weakStoragePtr.weak_use_count(), 2);
+  t1.reset();
+  t2.reset();
+  ASSERT_TRUE(weakStoragePtr.expired());
+}

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -21,6 +21,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/MapAllocator.h>
+#include <ATen/StorageUtils.h>
 #include <torch/csrc/utils/pycfunction_helpers.h>
 #include <torch/csrc/utils/python_arg_parser.h>
 #include <torch/csrc/utils/python_numbers.h>
@@ -71,7 +72,7 @@ static PyObject* THPStorage_copy_(
 
   TORCH_CHECK(self_.nbytes() == src.nbytes(), "size does not match");
 
-  storage_copy(self_, src, non_blocking);
+  at::storage_copy(self_, src, non_blocking);
 
   Py_INCREF(self);
   return self;

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -195,15 +195,6 @@ void THPPointer<THPStorage>::free() {
     Py_DECREF(ptr);
 }
 
-void storage_copy(at::Storage dst, at::Storage src, bool non_blocking) {
-  auto dst_options = c10::TensorOptions().device(dst.device()).dtype(at::kByte);
-  auto dst_t = at::empty({0}, {}, dst_options).set_(dst);
-
-  auto src_options = c10::TensorOptions().device(src.device()).dtype(at::kByte);
-  auto src_t = at::empty({0}, {}, src_options).set_(src);
-  dst_t.copy_(src_t, non_blocking);
-}
-
 void storage_fill(at::Storage self, uint8_t value) {
   auto options = c10::TensorOptions().device(self.device()).dtype(at::kByte);
   auto self_t = at::empty({0}, {}, options).set_(self);

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -219,7 +219,6 @@ std::vector<c10::optional<at::cuda::CUDAStream>>
 THPUtils_PySequence_to_CUDAStreamList(PyObject* obj);
 #endif
 
-void storage_copy(at::Storage dst, at::Storage src, bool non_blocking = false);
 void storage_fill(at::Storage self, uint8_t value);
 void storage_set(at::Storage self, ptrdiff_t idx, uint8_t value);
 uint8_t storage_get(at::Storage self, ptrdiff_t idx);


### PR DESCRIPTION
Summary:
This is part 1 of the effort to support `share_memory_()` in C++ aten library.

This allows C++ code to in place replace the tensor storage to shm based.
For now fd based shm is the only implementation supported to simplify memory management in general.

This first part intentionally avoids public api changes (to `TensorBase`, see comments in `StorageUtil.h`) such that we can get the core features usable outside pt/csrc first. The API addition to `Tensor` or `TensorBase` would involve more distracting changes and make the change harder to review.

Test Plan:
```
buck test caffe2:StorageUtils_test
```

Differential Revision: D43467616

