### PR TITLE
Fix formatting for merge failed message

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1733,7 +1733,7 @@ def main() -> None:
             # Hide this behind a collapsed bullet since it's not helpful to most devs
             internal_debugging = "\n".join(line for line in (
                 "<details><summary>Details for Dev Infra team</summary>",
-                f"Raised by <a href=\"{run_url}\">workflow job</a>",
+                f"<Raised by <a href=\"{run_url}\">workflow job</a>\n",
                 f"Failing merge rule: {failing_rule}" if failing_rule else "",
                 "</details>"
             ) if line)  # ignore empty lines during the join

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1733,7 +1733,7 @@ def main() -> None:
             # Hide this behind a collapsed bullet since it's not helpful to most devs
             internal_debugging = "\n".join(line for line in (
                 "<details><summary>Details for Dev Infra team</summary>",
-                f"<Raised by <a href=\"{run_url}\">workflow job</a>\n",
+                f"Raised by <a href=\"{run_url}\">workflow job</a>\n",
                 f"Failing merge rule: {failing_rule}" if failing_rule else "",
                 "</details>"
             ) if line)  # ignore empty lines during the join


### PR DESCRIPTION
Fixes formatting so that the merge rule shows up on a different line than the "Raised by" text

Follow up to https://github.com/pytorch/pytorch/pull/94932

New version
<img width="433" alt="image" src="https://user-images.githubusercontent.com/4468967/220441349-ac99096d-590a-42c1-b995-4a23b2d9b810.png">