### PR TITLE
[executorch] Add context argument to Functions.h declarations

### DIFF
--- a/tools/test/test_executorch_gen.py
+++ b/tools/test/test_executorch_gen.py
@@ -203,3 +203,27 @@ TORCH_API inline bool op_2(torch::executor::RuntimeContext & context) {
         """
             in declarations
         )
+
+    def test_operators_in_aten_mode_call_native_function_without_context(self) -> None:
+        declarations = gen_functions_declarations(
+                native_functions=[
+                    self.custom_1_native_function,
+                ],
+                static_dispatch_idx=self.static_dispatch_idx,
+                selector=SelectiveBuilder.get_nop_selector(),
+                use_aten_lib=True,
+            )
+        self.assertEqual(
+            """
+namespace custom_1 {
+
+// custom_1::op_1() -> bool
+TORCH_API inline bool op_1(torch::executor::RuntimeContext & context) {
+    (void)context;
+    return at::op_1();
+}
+
+} // namespace custom_1
+        """
+            , declarations
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95235

Previously we don't add context argument to generated `Functions.h` declarations in ATen mode.

Old `Functions.h`:

```
// aten::add.out(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
TORCH_API inline at::Tensor & add_outf(const at::Tensor & self, const at::Tensor & other, const at::Scalar & alpha, at::Tensor & out) {
    return ::at::add_outf(self, other, alpha, out);
}
```

This causes discrepancy on