### PR TITLE
Support registering op returning symint in python

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -3,7 +3,10 @@
 import tempfile
 import torch
 from copy import deepcopy
-from torch.library import Library
+from torch.library import Library, impl
+from torch.fx.experimental.proxy_tensor import ShapeEnv
+from torch import SymInt
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.cuda.jiterator import _create_jit_fn
 import unittest
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_ROCM, IS_WINDOWS
@@ -283,6 +286,25 @@ class TestPythonRegistration(TestCase):
 
         with self.assertRaisesRegex(ValueError, "reserved namespace"):
             my_lib1 = Library("prim", "DEF")
+
+    def test_returning_symint(self) -> None:
+        shape_env = ShapeEnv()
+        fake_tensor_mode = FakeTensorMode(shape_env=shape_env)
+
+        ft = fake_tensor_mode.from_tensor(torch.rand(2, 3))
+
+        s0, s1 = ft.shape
+
+        tlib = Library("tlib", "DEF")
+        tlib.define("sqsum(SymInt a, SymInt b) -> SymInt")
+
+        @impl(tlib, "sqsum", "CompositeExplicitAutograd")
+        def sqsum(a: SymInt, b: SymInt):
+            return a * a + b * b
+
+        out = torch.ops.tlib.sqsum.default(s0, s1)
+        out_val = shape_env.evaluate_expr(out.node.expr)
+        self.assertEquals(out_val, 13)
 
 class TestPythonDispatch(TestCase):
     def test_basic(self) -> None:

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -169,13 +169,14 @@ void pushPyOutToStack(
         " to return None but it returned something else instead.");
   } else if (num_returns == 1) {
     torch::jit::push(
-        stack, torch::jit::toIValue(out.ptr(), schema_returns[0].type()));
+        stack, torch::jit::toIValue(out.ptr(), schema_returns[0].real_type()));
   } else {
     auto outs = py::cast<py::sequence>(out);
     for (const auto idx : c10::irange(outs.size())) {
       torch::jit::push(
           stack,
-          torch::jit::toIValue(outs[idx].ptr(), schema_returns[idx].type()));
+          torch::jit::toIValue(
+              outs[idx].ptr(), schema_returns[idx].real_type()));
     }
   }
 }


### PR DESCRIPTION
Running an operator registered in python returning a symint will result in the following error:
```
RuntimeError: Unable to cast Python instance of type <class 'torch.SymInt'> to C++ type 'long'
```

The interaction of 2 things make the issue being triggered:
- We use boxed kernel here. For boxed kernel, we need convert py::object to IValue in torch/csrc/autograd/python_variable.cpp pushPyOutToStack .
- In the schema parsing code in torch/csrc/jit/frontend/schema_type_parser.cpp SchemaTypeParser::parseFakeAndRealType , if a SymInt is found, we register a Int type instead (not sure why we do this), and register SymInt as the real type.

The result is we would convert an SymInt to int in pushPyOutToStack and cause the issue.

The fix is to use real type when we convert py::object to IValue.

BTW, registering the same op using C++ API does not trigger the issue.
```
TORCH_LIBRARY(clib, m) {
  m.def("sqsum(SymInt a, SymInt b) -> SymInt", [](SymInt a, SymInt b) -> SymInt {
    return a * a + b * b;
  });
}
```
The reason is, the kernel registered in C++ is unboxed kernel and it does not trigger the code path above that converts an py::object to IValue.

