### PR TITLE
[Dynamo] No graph break on calling dict & collections.OrderedDict()

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -567,6 +567,24 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         test(self)
 
     @make_test
+    def test_call_dict1(x):
+        d1 = dict()
+        d1["x"] = x + 1
+        d2 = collections.OrderedDict()
+        d2["x"] = x + 2
+        return d1["x"] + d2["x"] + 1
+
+    @make_test
+    def test_call_dict2(x):
+        d1 = dict()
+        d1["x"] = x
+        d2 = collections.OrderedDict(d1)
+        if isinstance(d2, collections.OrderedDict):
+            return x + 1
+        else:
+            return x - 1
+
+    @make_test
     def test_min_max(a, b):
         c = a + b
         a = a.sum()

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2070,18 +2070,6 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             collections.OrderedDict,
         )
 
-    def test_const_dict_reconstruct(self):
-        def fn(x):
-            od = collections.OrderedDict({"a": x + 1, "b": 20})
-            torch._dynamo.graph_break()
-            return od
-
-        x = torch.rand(3)
-        opt_fn = torch._dynamo.optimize("eager")(fn)
-        ref = fn(x)
-        res = opt_fn(x)
-        self.assertTrue(same(ref, res))
-
     def test_builtin_subclasses_as_method_on_class_type(self):
         class Foo:
             def __init__(self, name):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2070,6 +2070,18 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             collections.OrderedDict,
         )
 
+    def test_const_dict_reconstruct(self):
+        def fn(x):
+            od = collections.OrderedDict({"a": x + 1, "b": 20})
+            torch._dynamo.graph_break()
+            return od
+
+        x = torch.rand(3)
+        opt_fn = torch._dynamo.optimize("eager")(fn)
+        ref = fn(x)
+        res = opt_fn(x)
+        self.assertTrue(same(ref, res))
+
     def test_builtin_subclasses_as_method_on_class_type(self):
         class Foo:
             def __init__(self, name):

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -750,9 +750,18 @@ class BuiltinVariable(VariableTracker):
     call_tuple = _call_iter_tuple_list
     call_list = _call_iter_tuple_list
 
-    def call_dict(self, tx, arg):
-        if isinstance(arg, variables.ConstDictVariable):
-            return arg.clone(mutable_local=MutableLocal())
+    @staticmethod
+    def call_dict_helper(user_cls, arg):
+        if arg is None:
+            return variables.ConstDictVariable(
+                {}, user_cls, mutable_local=MutableLocal()
+            )
+        elif isinstance(arg, variables.ConstDictVariable):
+            return arg.clone(user_cls=user_cls, mutable_local=MutableLocal())
+
+    def call_dict(self, tx, obj=None):
+        if obj is None or isinstance(obj, variables.ConstDictVariable):
+            return self.call_dict_helper(dict, obj)
 
     def call_zip(self, tx, *args):
         options = VariableTracker.propagate(self, args)

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -758,6 +758,8 @@ class BuiltinVariable(VariableTracker):
             )
         elif isinstance(arg, variables.ConstDictVariable):
             return arg.clone(user_cls=user_cls, mutable_local=MutableLocal())
+        else:
+            raise AssertionError("call_dict_helper with illegal arg")
 
     def call_dict(self, tx, obj=None):
         if obj is None or isinstance(obj, variables.ConstDictVariable):

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -791,6 +791,7 @@ class SkipFilesVariable(VariableTracker):
 
         if inspect.getattr_static(self.value, "_torchdynamo_disable", False):
             unimplemented(f"call torch._dynamo.disable() wrapped function {self.value}")
+        # Allowlist a few popular classes(e.g, collections.OrderedDict) calls in skip files.
         elif self.value is collections.OrderedDict and (
             len(args) == 0 or len(args) == 1 and isinstance(args[0], ConstDictVariable)
         ):


### PR DESCRIPTION
It's common to call ```dict()``` or ```collections.OrderedDict()``` inside of ```forward``` function, so we should not graph break. 

This pattern has been used in many places including:
* The use case in [torchvision](
https://github.com/pytorch/vision/blob/928b05cad36eadb13e169f03028767c8bcd1f21d/torchvision/models/_utils.py#L66-L73).
* It causes ~100 model failures(nopython=True) in the 14k github models.
* Also it hits several Meta internal use cases.


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire