### PR TITLE
[BE] Simplify `Source.is_nn_module`; add some types

### DIFF
--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -356,19 +356,16 @@ class Source:
     def reconstruct(self, codegen):
         raise NotImplementedError()
 
-    def guard_source(self):
+    def guard_source(self) -> GuardSource:
         raise NotImplementedError()
 
-    def name(self):
+    def name(self) -> str:
         raise NotImplementedError()
 
-    def make_guard(self, fn, is_volatile=False):
+    def make_guard(self, fn, is_volatile=False) -> Guard:
         if self.guard_source() is GuardSource.CONSTANT:
             raise NotImplementedError()
         return Guard(self.name(), self.guard_source(), fn, is_volatile)
 
-    def is_nn_module(self):
-        return self.guard_source() in (
-            GuardSource.LOCAL_NN_MODULE,
-            GuardSource.GLOBAL_NN_MODULE,
-        )
+    def is_nn_module(self) -> bool:
+        return self.guard_source().is_nn_module()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#95292 [BE] Simplify `Source.is_nn_module`; add some types**

I am still reading Dynamo source code...

This is an easy PR to simplify `Source.is_nn_module()` to reuse `GuardSource.is_nn_module()` instead of having the `in (...)` check implemented twice. While simplifying that, I thought I might as well add some type annotations for `Source` methods.