### PR TITLE
[quant][bug fix] Fix qrange_len in `torch.ao.quantization.utils.py`

### DIFF
--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -355,7 +355,7 @@ def calculate_qmin_qmax(quant_min: int, quant_max: int, has_customized_qrange: b
             ), "quantization range should be positive and not exceed the maximum bit range (=256)."
         elif dtype == torch.qint32:
             assert (
-                0 < qrange_len <= 2**31
+                0 < qrange_len <= 2**32
             ), "quantization range should be positive and not exceed the maximum bit range (=4294967296)."
         if reduce_range:
             quant_min, quant_max = quant_min // 2, quant_max // 2

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -336,7 +336,7 @@ def calculate_qmin_qmax(quant_min: int, quant_max: int, has_customized_qrange: b
         # using of refinement to decouple initial_qmin and initial_qmax from quantization range.
         # The actual values of initial_qmin and initial_qmax will be reset below.
         if dtype == torch.qint32:
-            initial_quant_min, initial_quant_max = 0, 2**31 - 1
+            initial_quant_min, initial_quant_max = 0, 2**32 - 1
         else:
             initial_quant_min, initial_quant_max = 0, 255
         # The following assignment of self.qmin and self.qmax to the local variables and the if check refine the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95297

Summary:

It looks like there is a typo and qrange_len should be 2^32 instead of 2^31, as it is currently set.

Test Plan:
```
python test/test_quantization.py TestObserver.test_per_tensor_observers

```

Reviewers:

Subscribers:

Tasks: https://github.com/pytorch/pytorch/issues/95295

Tags: