### PR TITLE
[pt2][inductor] switch dinfo representation

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -79,9 +79,9 @@ class PersistentCache:
         self.global_cache_path = config.global_cache_path
 
         if torch.cuda.is_available():
-            self.dinfo = repr(
-                torch.cuda.get_device_properties(torch.cuda.current_device())
-            )
+            self.dinfo = torch.cuda.get_device_properties(
+                torch.cuda.current_device()
+            ).name
             self.vinfo = torch.version.cuda
 
     def get_local_cache(self):


### PR DESCRIPTION
Summary:
bypass-github-export-checks

use `dinfo.name` instead of `repr(dinfo)`, as initial results have shown that `dinfo.total_memory` may unexpectedly fluctuate

Test Plan: sandcastle + CI

Differential Revision: D43503558



cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire