### PR TITLE
[FSDP] Set `param.grad` even if `requires_grad=False`

### DIFF
--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1635,7 +1635,7 @@ class FlatParamHandle:
                 param_start, param_end = flat_param._shard_param_offsets[i - start]  # type: ignore[attr-defined]
                 numel_in_shard = param_end - param_start + 1
                 assert flat_param._is_grad_none is not None  # mypy
-                if param.requires_grad and not flat_param._is_grad_none[i]:
+                if not flat_param._is_grad_none[i]:
                     if self._keep_low_precision_grads or param.dtype != grad.dtype:
                         # NOTE: This is a hack using `.data` to side step the
                         # check that parameter/gradient dtypes match. Here,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#95315 [FSDP] Set `param.grad` even if `requires_grad=False`**
* #94835 [FSDP] Fix `clip_grad_norm_()` when rank has no local gradients

Fixes https://github.com/pytorch/pytorch/issues/94857.