### PR TITLE
[FSDP][Docs] Re-add why reg. post-bwd hook on 1st forward

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -1221,6 +1221,12 @@ def _register_post_backward_hooks(
     We register the post-backward hook only once in the *first* forward that a
     ``FlatParameter`` participates in. This relies on the ``AccumulateGrad``
     object being preserved through multiple forwards.
+
+    NOTE: We follow this heuristic to prefer the *first* forward to target the
+    parameter mixed precision case, where there are *separate*
+    ``AccumulateGrad`` objects across the different forwards. (Without
+    parameter mixed precision, the ``AccumulateGrad`` objects are the same.) If
+    we instead prefer the *last* forward, then the hook runs early.
     """
     # If there is no gradient computation, then there is no need for
     # post-backward logic


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#95326 [FSDP][Docs] Re-add why reg. post-bwd hook on 1st forward**
* #94835 [FSDP] Fix `clip_grad_norm_()` when rank has no local gradients

This PR adds back some explanation for why we have the heuristic to only register the post-backward hook on the first forward in the case of multiple forwards.