### PR TITLE
[MPS] Fixes in backward functions of the MPS ops

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -265,7 +265,7 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& src, MPSS
   id<MTLBuffer> srcBuf = getMTLBufferStorage(src);
   bool sliceViewTensor = canSliceViewTensor(src, mpsShape);
   // a view tensor could be contiguous (e.g., slice ops) or non-contiguous (e.g., transpose())
-  if ((!src.is_contiguous() || (src.is_view() && src.storage_offset() && !sliceViewTensor)) && gatherTensorData) {
+  if ((!src.is_contiguous() || (src.storage_offset() && !sliceViewTensor)) && gatherTensorData) {
      Tensor emptyShell = Tensor();
     // use "_tensor" from Placeholder to retain view's output during its usage in other ops
     _tensor = gatherViewTensor(src, emptyShell);

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -1819,7 +1819,7 @@ std::tuple<Tensor, Tensor> prelu_backward_mps(const Tensor& grad_output, const T
     using namespace mps;
 
     Tensor grad_input = at::empty_like(self, self.suggest_memory_format());
-    Tensor weight_grad = at::empty_like(weight_, at::MemoryFormat::Contiguous);
+    Tensor weight_grad = at::empty_like(self, at::MemoryFormat::Contiguous);
     if (grad_output.numel() == 0) {
       return std::tuple<Tensor, Tensor>{grad_input, weight_grad};
     }

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -163,6 +163,9 @@ void reduction_out_mps(
     if (reduction_type == MPSReductionType::PROD) {
       output_t.fill_(1);
     }
+    else if (reduction_type == MPSReductionType::SUM) {
+      output_t.zero_();
+    }
     return;
   }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9511,6 +9511,7 @@ class TestConsistency(TestCaseMPS):
         'native_batch_norm': ['f32'],
         'native_layer_norm': ['f32'],
         'nn.functional.gelu': ['f32'],
+        'nn.functional.bilinear': ['f32'],
     }
 
     # These ops that are problematic. So never run them even when

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9512,6 +9512,7 @@ class TestConsistency(TestCaseMPS):
         'native_layer_norm': ['f32'],
         'nn.functional.gelu': ['f32'],
         'nn.functional.bilinear': ['f32'],
+        'nn.functional.prelu': ['f32'],
     }
 
     # These ops that are problematic. So never run them even when


### PR DESCRIPTION
Combination PR: #94892, #94923, #94933, #94950

-  Fix bilinear backward pass
-  Fix the crash in elu_backward()
- Fix prelu backward pass
- Fix embedding_backward() issue with Float16

