### PR TITLE
ci: Add workflow to build windows on VS2017

### DIFF
--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -6,6 +6,10 @@ inputs:
   cuda-version:
     description: which cuda version to install, 'cpu' for none
     required: true
+  enable-vs2017:
+    description: Enables VS2017 builds
+    default: false
+    type: boolean
 
 runs:
   using: composite
@@ -82,3 +86,23 @@ runs:
             echo "Found no Python using ${CONDA_RUN}"
           fi
         fi
+
+    # You might be asking yourself why VS2017 still?
+    # Let's work on removing this together at https://fburl.com/gdoc/qk2a7rlh
+    - name: Clone test-infra to get VS2017 installer
+      if: ${{ inputs.enable-vs2017 }}
+      uses: malfet/checkout@silent-checkout
+      with:
+        ref: main
+        repository: pytorch/test-infra
+        # Checkout to hidden directory
+        path: .test-infra/
+
+    - name: Run vs2017 installer
+      if: ${{ inputs.enable-vs2017 }}
+      env:
+        VS_VERSION: "15.9.51"
+        INSTALL_WINDOWS_SDK: "1"
+      shell: powershell
+      run: |
+        .\.test-infra\aws\ami\windows\scripts\Installers\Install-VS.ps1

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -103,6 +103,10 @@ runs:
       env:
         VS_VERSION: "15.9.51"
         INSTALL_WINDOWS_SDK: "1"
+        # Weird code artifact from a while ago, but we can use CIRCLECI=1 here to tell
+        # the script to delete the existing VS tools installation without having to make
+        # an extra change so for this bandaid we use an old technical debt loop hole
+        CIRCLECI: "1"
       shell: powershell
       run: |
         .\.test-infra\aws\ami\windows\scripts\Installers\Install-VS.ps1

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -6,10 +6,6 @@ inputs:
   cuda-version:
     description: which cuda version to install, 'cpu' for none
     required: true
-  enable-vs2017:
-    description: Enables VS2017 builds
-    default: false
-    type: boolean
 
 runs:
   using: composite
@@ -86,36 +82,3 @@ runs:
             echo "Found no Python using ${CONDA_RUN}"
           fi
         fi
-
-    # ======================================================================================
-    # TODO: DELETE ME AFTER WE MIGRATE OFF VS2017 (windows-vs2017)
-    # You might be asking yourself why VS2017 still?
-    # Let's work on removing this together at https://fburl.com/gdoc/qk2a7rlh
-    - name: Clone test-infra to get VS2017 installer
-      if: ${{ inputs.enable-vs2017 }}
-      uses: malfet/checkout@silent-checkout
-      with:
-        ref: main
-        repository: pytorch/test-infra
-        # Checkout to hidden directory
-        path: .test-infra/
-
-    - name: Run vs2017 installer
-      if: ${{ inputs.enable-vs2017 }}
-      env:
-        VS_VERSION: "15.9.51"
-        INSTALL_WINDOWS_SDK: "1"
-        # Weird code artifact from a while ago, but we can use CIRCLECI=1 here to tell
-        # the script to delete the existing VS tools installation without having to make
-        # an extra change so for this bandaid we use an old technical debt loop hole
-        CIRCLECI: "1"
-      shell: powershell
-      run: |
-        .\.test-infra\aws\ami\windows\scripts\Installers\Install-VS.ps1
-
-    - name: Remove test-infra directory (to satisfy git porcelain)
-      if: ${{ inputs.enable-vs2017 }}
-      shell: bash
-      run: |
-        rm -rf .test-infra
-    # ======================================================================================

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -87,6 +87,8 @@ runs:
           fi
         fi
 
+    # ======================================================================================
+    # TODO: DELETE ME AFTER WE MIGRATE OFF VS2017 (windows-vs2017)
     # You might be asking yourself why VS2017 still?
     # Let's work on removing this together at https://fburl.com/gdoc/qk2a7rlh
     - name: Clone test-infra to get VS2017 installer
@@ -110,3 +112,10 @@ runs:
       shell: powershell
       run: |
         .\.test-infra\aws\ami\windows\scripts\Installers\Install-VS.ps1
+
+    - name: Remove test-infra directory (to satisfy git porcelain)
+      if: ${{ inputs.enable-vs2017 }}
+      shell: bash
+      run: |
+        rm -rf .test-infra
+    # ======================================================================================

--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -12,3 +12,4 @@ ciflow_push_tags:
 - ciflow/periodic
 - ciflow/trunk
 - ciflow/unstable
+- ciflow/windows-vs2017

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/actions/setup-win
         with:
           cuda-version: ${{ inputs.cuda-version }}
-          enable-vs2017: ${{ contains(inputs.build-environment, "vs2017") }}
+          enable-vs2017: ${{ contains(inputs.build-environment, 'vs2017') }}
 
       - name: Parse ref
         id: parse-ref

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -83,7 +83,7 @@ jobs:
           cuda-version: ${{ inputs.cuda-version }}
           # =================================================================
           # TODO: DELETE ME AFTER WE MIGRATE OFF VS2017 (windows-vs2017)
-          enable-vs2017: ${{ contains(inputs.build-environment, 'vs2017') }}
+          enable-vs2017: ${{ inputs.vc-year == '2017' }}
           # =================================================================
 
       - name: Parse ref

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -11,6 +11,11 @@ on:
         required: true
         type: string
         description: What CUDA version to build with, "cpu" for none.
+      vc-year:
+        required: false
+        type: string
+        description: What VC year version to build with, "2019" by default
+        default: "2019"
       build-with-debug:
         required: false
         type: boolean
@@ -58,7 +63,7 @@ jobs:
             To start build locally, change working folder to \actions-runner\_work\pytorch\pytorch,
             Activate miniconda and Visual Studio environment, by running:
               call C:\Jenkins\Miniconda3\Scripts\activate.bat C:\Jenkins\Miniconda3
-              call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
+              call "C:\Program Files (x86)\Microsoft Visual Studio\${{ inputs.vc-year }}\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
 
       # Duplicated in win-test because this MUST go before a checkout
       - name: Enable git symlinks on Windows
@@ -116,7 +121,7 @@ jobs:
           SCCACHE_S3_KEY_PREFIX: ${{ github.workflow }}
           VC_PRODUCT: "BuildTools"
           VC_VERSION: ""
-          VC_YEAR: "2019"
+          VC_YEAR: ${{ inputs.vc-year }}
           ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
           AWS_DEFAULT_REGION: us-east-1
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -76,6 +76,7 @@ jobs:
         uses: ./.github/actions/setup-win
         with:
           cuda-version: ${{ inputs.cuda-version }}
+          enable-vs2017: ${{ contains(inputs.build-environment, "vs2017") }}
 
       - name: Parse ref
         id: parse-ref

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -76,7 +76,10 @@ jobs:
         uses: ./.github/actions/setup-win
         with:
           cuda-version: ${{ inputs.cuda-version }}
+          # =================================================================
+          # TODO: DELETE ME AFTER WE MIGRATE OFF VS2017 (windows-vs2017)
           enable-vs2017: ${{ contains(inputs.build-environment, 'vs2017') }}
+          # =================================================================
 
       - name: Parse ref
         id: parse-ref

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -81,10 +81,45 @@ jobs:
         uses: ./.github/actions/setup-win
         with:
           cuda-version: ${{ inputs.cuda-version }}
-          # =================================================================
-          # TODO: DELETE ME AFTER WE MIGRATE OFF VS2017 (windows-vs2017)
-          enable-vs2017: ${{ inputs.vc-year == '2017' }}
-          # =================================================================
+
+      # ====================================================================================
+      # TODO: DELETE ME AFTER WE MIGRATE OFF VS2017 (windows-vs2017)
+      # You might be asking yourself why VS2017 still?
+      # Let's work on removing this together at https://fburl.com/gdoc/qk2a7rlh
+      - name: Clone test-infra to get VS2017 installer
+        if: inputs.vc-year == '2017'
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: main
+          repository: pytorch/test-infra
+          # Checkout to hidden directory
+          path: .test-infra/
+
+      - name: Run vs2017 installer
+        if: inputs.vc-year == '2017'
+        env:
+          VS_VERSION: "15.9.51"
+          INSTALL_WINDOWS_SDK: "1"
+          # Weird code artifact from a while ago, but we can use CIRCLECI=1 here to tell
+          # the script to delete the existing VS tools installation without having to make
+          # an extra change so for this bandaid we use an old technical debt loop hole
+          CIRCLECI: "1"
+        shell: powershell
+        run: |
+          .\.test-infra\aws\ami\windows\scripts\Installers\Install-VS.ps1
+
+      - name: Remove test-infra directory (to satisfy git porcelain)
+        if: inputs.vc-year == '2017'
+        shell: bash
+        run: |
+          rm -rf .test-infra
+
+      - name: Setup VS2017 specific environment variables
+        shell: bash
+        if: inputs.vc-year == '2017'
+        run:
+          echo "USE_MKLDNN=0" >> "${GITHUB_ENV}"
+      # ====================================================================================
 
       - name: Parse ref
         id: parse-ref

--- a/.github/workflows/windows-vs2017.yml
+++ b/.github/workflows/windows-vs2017.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows-vs2017.yml
+++ b/.github/workflows/windows-vs2017.yml
@@ -1,0 +1,26 @@
+name: Windows VS2017
+
+on:
+  # Add explicit ciflow job here so you can run with ciflow
+  push:
+    tags:
+      - ciflow/windows-vs2017/*
+  # Set up pathing here to make it so that this auto-runs on the most problematic types of PRs
+  pull_request:
+    paths:
+      - aten/src/ATen/cuda/*
+      - aten/src/ATen/native/cuda/*
+      - .github/workflows/windows-vs2017.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  win-vs2017-cuda11_7-py3-build:
+    name: win-vs2017-cuda11_7-py3
+    uses: ./.github/workflows/_win-build.yml
+    with:
+      build-environment: win-vs2017-cuda11_7-py3
+      cuda-version: "11.7"

--- a/.github/workflows/windows-vs2017.yml
+++ b/.github/workflows/windows-vs2017.yml
@@ -1,3 +1,7 @@
+# ==============================================================
+# TODO: DELETE ME AFTER WE MIGRATE OFF VS2017 (windows-vs2017)
+# You might be asking yourself why VS2017 still?
+# Let's work on removing this together at https://fburl.com/gdoc/qk2a7rlh
 name: Windows VS2017
 
 on:
@@ -24,3 +28,4 @@ jobs:
     with:
       build-environment: win-vs2017-cuda11_7-py3
       cuda-version: "11.7"
+# ==============================================================

--- a/.github/workflows/windows-vs2017.yml
+++ b/.github/workflows/windows-vs2017.yml
@@ -28,4 +28,5 @@ jobs:
     with:
       build-environment: win-vs2017-cuda11_7-py3
       cuda-version: "11.7"
+      vc-year: "2017"
 # ==============================================================


### PR DESCRIPTION
Adds a workflow to build windows on VS2017 due to constraints with moving internal projects off of VS2017.

NOTE: This is not meant to be a permanent workflow and should only live until we finish the migration for internal projects
