### PR TITLE
Add super().setUp() in test_symbolic_shape_analysis

### DIFF
--- a/test/jit/test_symbolic_shape_analysis.py
+++ b/test/jit/test_symbolic_shape_analysis.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
 # XXX: still in prototype
 class TestSymbolicShapeAnalysis(JitTestCase):
     def setUp(self):
-        super(JitTestCase).setUp()
+        super(JitTestCase, self).setUp()
         self.prev_symbolic_shapes_test_enabled = torch._C._jit_symbolic_shapes_test_mode_enabled()
         torch._C._jit_set_symbolic_shapes_test_mode(True)
 

--- a/test/jit/test_symbolic_shape_analysis.py
+++ b/test/jit/test_symbolic_shape_analysis.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
 # XXX: still in prototype
 class TestSymbolicShapeAnalysis(JitTestCase):
     def setUp(self):
-        super().setUp()
+        super(JitTestCase).setUp()
         self.prev_symbolic_shapes_test_enabled = torch._C._jit_symbolic_shapes_test_mode_enabled()
         torch._C._jit_set_symbolic_shapes_test_mode(True)
 

--- a/test/jit/test_symbolic_shape_analysis.py
+++ b/test/jit/test_symbolic_shape_analysis.py
@@ -20,6 +20,7 @@ if __name__ == '__main__':
 # XXX: still in prototype
 class TestSymbolicShapeAnalysis(JitTestCase):
     def setUp(self):
+        super().setUp()
         self.prev_symbolic_shapes_test_enabled = torch._C._jit_symbolic_shapes_test_mode_enabled()
         torch._C._jit_set_symbolic_shapes_test_mode(True)
 


### PR DESCRIPTION
Instead of the usual `super().setUp()`, use `super(JitTestCase, self).setUp()` since JitTestCase.setUp() seems to interfere with the test (see the results on the first commit of this PR).  `super(JitTestCase, self).setUp()` skips the setUp method of JitTestCase

Fixes https://github.com/pytorch/pytorch/issues/95341