### PR TITLE
Inductor: fix compile error of Tensor.select + add_

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6501,6 +6501,15 @@ if HAS_CPU:
             same(fn(x), opt_fn(x))
             assert metrics.generated_cpp_vec_kernel_count == 0
 
+        def test_select_add_(self):
+            def fn(input):
+                v = input.select(2, 0)
+                return v.add_(1)
+
+            x = torch.rand([1, 2, 1, 2, 1, 2])
+            opt_fn = torch._dynamo.optimize("inductor")(fn)
+            same(fn(x), opt_fn(x))
+
 
 if HAS_CUDA and not TEST_WITH_ASAN:
     import triton

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1541,8 +1541,8 @@ def select_scatter(x, src, dim: int, index: int):
     def inner_fn(idx):
         return ops.where(
             ops.eq(
-                ops.index_expr(idx[dim], torch.int32),
-                ops.index_expr(index, torch.int32),
+                ops.index_expr(idx[dim] - index, x.get_dtype()),
+                ops.constant(0, x.get_dtype()),
             ),
             src_loader(idx),
             x_loader(idx),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1541,8 +1541,8 @@ def select_scatter(x, src, dim: int, index: int):
     def inner_fn(idx):
         return ops.where(
             ops.eq(
-                ops.index_expr(idx[dim] - index, x.get_dtype()),
-                ops.constant(0, x.get_dtype()),
+                ops.index_expr(idx[dim] - index, torch.float),
+                ops.constant(0, torch.float),
             ),
             src_loader(idx),
             x_loader(idx),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95354

Fix https://github.com/pytorch/pytorch/issues/94960

Before this pr, `auto tmp5 = decltype(tmp4)::blendv(tmp2, tmp4, tmp1);` triggered compile error because tmp1's type is  `at::vec::CPU_CAPABILITY::Vectorized<int>`, which cannot be converted to `const at::vec::CPU_CAPABILITY::Vectorized<float>&`.

```
for(long i0=0; i0<0; i0+=1)
{
    auto tmp2 = at::vec::Vectorized<float>::loadu(out_ptr2 + 16*i0);
    auto tmp0 = at::vec::Vectorized<int>(static_cast<int>(0));
    auto tmp1 = tmp0 == tmp0;
    auto tmp3 = at::vec::Vectorized<float>(static_cast<float>(1));
    auto tmp4 = tmp2 + tmp3;
    auto tmp5 = decltype(tmp4)::blendv(tmp2, tmp4, tmp1);
    tmp5.store(out_ptr0 + 16*i0);
    tmp5.store(out_ptr2 + 16*i0);
}
```
After this pr:

```
for(long i0=0; i0<0; i0+=1)
{
    auto tmp2 = at::vec::Vectorized<float>::loadu(out_ptr2 + 16*i0);
    auto tmp0 = at::vec::Vectorized<float>(static_cast<float>(0));
    auto tmp1 = tmp0 == tmp0;
    auto tmp3 = at::vec::Vectorized<float>(static_cast<float>(1));
    auto tmp4 = tmp2 + tmp3;
    auto tmp5 = decltype(tmp4)::blendv(tmp2, tmp4, tmp1);
    tmp5.store(out_ptr0 + 16*i0);
    tmp5.store(out_ptr2 + 16*i0);
}
```

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire