### PR TITLE
[pt2][inductor] layout as part of cache key

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -609,6 +609,7 @@ class AlgorithmSelectorCache(PersistentCache):
             choices,
             choices[0].name,
             repr([self.key_of(x) for x in input_nodes]),
+            repr(layout),
             autotune,
         )
         if timings == {} or choices[0] not in timings:


### PR DESCRIPTION
Summary: include layout as part of the key, otherwise we don't have enough information to autotune offline (i.e. batch size for bmm is only in layout, not inputs)

Test Plan: sandcastle + CI

Differential Revision: D43525122



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @soumith @yanboliang @anijain2305 @desertfire