### PR TITLE
inductor: fix complier error when trying to vectorize logit_and and logit_or

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5956,6 +5956,7 @@ if HAS_CPU:
                 "isnan",
                 "rand",
                 "logical_and",
+                "logical_or",
             ]
             union = {*cpp_vec_op_list, *diff}
             self.assertTrue(set(cpp_op_list).issubset(union))

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5642,6 +5642,15 @@ class CommonTemplate:
             eager_out = eager_mod(*eager_args)
             self.assertEqual(inductor_out, eager_out)
 
+    def test_logit_backward(self):
+        def fn(gy, x):
+            return aten.logit_backward(gy, x, eps=0.3)
+
+        self.common(
+            fn,
+            (torch.randn(2), torch.randn(2)),
+        )
+
 
 def copy_tests(my_cls, other_cls, suffix, test_skips=None):  # noqa: B902
     for name, value in my_cls.__dict__.items():

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5955,6 +5955,7 @@ if HAS_CPU:
                 "randn",
                 "isnan",
                 "rand",
+                "logical_and",
             ]
             union = {*cpp_vec_op_list, *diff}
             self.assertTrue(set(cpp_op_list).issubset(union))

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -5642,13 +5642,20 @@ class CommonTemplate:
             eager_out = eager_mod(*eager_args)
             self.assertEqual(inductor_out, eager_out)
 
-    def test_logit_backward(self):
-        def fn(gy, x):
-            return aten.logit_backward(gy, x, eps=0.3)
+    def test_where_with_logical_op(self):
+        def fn_and(x, y):
+            return torch.where(torch.logical_and(x, y), 1.0, 0.0)
+
+        def fn_or(x, y):
+            return torch.where(torch.logical_or(x, y), 1.0, 0.0)
 
         self.common(
-            fn,
-            (torch.randn(2), torch.randn(2)),
+            fn_and,
+            (torch.randn(32), torch.randn(32)),
+        )
+        self.common(
+            fn_or,
+            (torch.randn(32), torch.randn(32)),
         )
 
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -362,15 +362,15 @@ class CppVecOverrides(OpOverrides):
         return f"{x}.lgamma()"
 
     """
-    #TODO: support logical_and vectorization
+    #TODO: support logical_and and logical_or vectorization
     @staticmethod
     def logical_and(a, b):
         return f"{a} && {b}"
-    """
 
     @staticmethod
     def logical_or(a, b):
         return f"{a} || {b}"
+    """
 
     @staticmethod
     def tan(a):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -372,7 +372,6 @@ class CppVecOverrides(OpOverrides):
     def logical_or(a, b):
         return f"{a} || {b}"
 
-
     @staticmethod
     def tan(a):
         return f"{a}.tan()"

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -361,13 +361,17 @@ class CppVecOverrides(OpOverrides):
     def lgamma(x):
         return f"{x}.lgamma()"
 
+    """
+    #TODO: support logical_and and logical_or vectorization
     @staticmethod
     def logical_and(a, b):
         return f"{a} && {b}"
 
+
     @staticmethod
     def logical_or(a, b):
         return f"{a} || {b}"
+    """
 
     @staticmethod
     def tan(a):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -362,16 +362,16 @@ class CppVecOverrides(OpOverrides):
         return f"{x}.lgamma()"
 
     """
-    #TODO: support logical_and and logical_or vectorization
+    #TODO: support logical_and vectorization
     @staticmethod
     def logical_and(a, b):
         return f"{a} && {b}"
-
+    """
 
     @staticmethod
     def logical_or(a, b):
         return f"{a} || {b}"
-    """
+
 
     @staticmethod
     def tan(a):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95361

Currently, `operator&& `  and `operator|| ` don't have vectorization implementation, disable them now for a quick fix for 2.0 release.

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire