### PR TITLE
Prevent c10d/Store from direct initialization

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -364,6 +364,14 @@ class PythonStoreTest(TestCase):
         # of this test function.
         dist._test_python_store(MyPythonStore())
 
+    def test_abstract_store_initialization_error(self):
+        with self.assertRaisesRegex(RuntimeError, "^Cannot instantiate abstract base class 'Store'"):
+            torch.distributed.Store()
+
+    def test_custom_store_initialization(self):
+        store = MyPythonStore()
+        self.assertIsInstance(store, MyPythonStore)
+
 
 class RendezvousTest(TestCase):
     def test_unknown_handler(self):

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -783,8 +783,13 @@ Base class for all store implementations, such as the 3 provided by PyTorch
 distributed: (:class:`~torch.distributed.TCPStore`, :class:`~torch.distributed.FileStore`,
 and :class:`~torch.distributed.HashStore`).
 )")
-          // Default constructor.
-          .def(py::init<>())
+          .def(
+              py::init([]() -> ::c10d::Store* {
+                throw std::runtime_error(
+                    "Cannot instantiate abstract base class 'Store'");
+                return nullptr;
+              }),
+              "Protected constructor to prevent direct instantiation.")
           // Convert from std::string to std::vector<uint8>.
           .def(
               "set",


### PR DESCRIPTION
Summary:
Potential fix to prevent issue in https://github.com/pytorch/pytorch/issues/95309

We still want users to be able to derive from the trampoline class, but do not allow for direct instantiations
- Add runtime error in constructor.

Differential Revision: D43537212

