### PR TITLE
[caffe2] dont call cudnnDestroy on thread exit (crashes on windows with cuda 11/12)

### DIFF
--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -148,7 +148,15 @@ class CAFFE2_CUDA_API ThreadLocalCUDAObjects {
 #ifdef CAFFE2_USE_CUDNN
     for (auto element : cudnn_handles_) {
       if (element.second) {
+#ifdef _WIN32
+        // this is because of something dumb in the ordering of
+        // destruction. Sometimes at exit, the cuda context would already
+        // be destroyed by the time this gets destroyed. This happens on
+        // windows with cuda 11 and cuda 12.
+        cudnnDestroy(element.second);
+#else
         CUDNN_CHECK(cudnnDestroy(element.second));
+#endif // _WIN32
       }
     }
 #endif // CAFFE2_USE_CUDNN


### PR DESCRIPTION
Summary:
My team has been hitting a mysterious crash for a few months on a windows binary that uses Caffe2 inside a worker thread.

When this thread gets destroyed, there is an error at this line in context_gpu.h where the state of this operation gives CUDNN_STATUS_INTERNAL_ERROR instead of CUDNN_STATUS_SUCCESS.

When enabling cudnn debug logs (via the env variables nvidia specifies), I can see that the context is destroyed twice, even though this code only destroys it once, so something mysterious is causing a double free.

This seems very very similar to the issue/fix described here for pytorch:
https://github.com/pytorch/pytorch/issues/17658
https://github.com/apache/tvm/pull/8267

And pytorch handles this in the same way, by just not calling cudnnDestroy

This seems to have become an issue with cuda11, but I tested cuda12 as well and found that the issue persists so this needs to be somehow fixed.

Test Plan:
CI

I checked that the specific windows binary I am using is able to create and drestroy caffe2-invoking threads without causing the application to crash.

buck run arvr/mode/win/cuda11/opt //arvr/projects/nimble/prod/tools/MonoHandTrackingVis

Differential Revision: D43538017



cc @ngimel