### PR TITLE
Revert "Implement sparse semantics support in gradcheck (#94714)"

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4651,7 +4651,7 @@ Done""")
                       check_batched_grad=False, fast_mode=fast_mode)
             with self.assertRaisesRegex(RuntimeError, 'gradcheck expects all tensor inputs are dense'):
                 gradcheck(fn, torch.rand(10, dtype=torch.double).to_sparse().requires_grad_(True), check_sparse_nnz=False,
-                          check_batched_grad=False, fast_mode=fast_mode, masked=True)
+                          check_batched_grad=False, fast_mode=fast_mode)
         check(fast_mode=True)
         check(fast_mode=False)
 
@@ -4665,8 +4665,8 @@ Done""")
 
             with self.assertRaisesRegex(RuntimeError, 'gradcheck expects all tensor inputs are dense'):
                 gradcheck(fn, torch.rand(2, 2, dtype=torch.double).to_sparse_csr().requires_grad_(True), check_sparse_nnz=False,
-                          check_batched_grad=False, fast_mode=fast_mode, masked=True)
-        check(fast_mode=True)
+                          check_batched_grad=False, fast_mode=fast_mode)
+        # check(fast_mode=True) # RuntimeError: sparse_mask_sparse_csr expects self to be 2D
         check(fast_mode=False)
 
     def test_gradcheck_sparse_csc_input(self):
@@ -4679,8 +4679,8 @@ Done""")
 
             with self.assertRaisesRegex(RuntimeError, 'gradcheck expects all tensor inputs are dense'):
                 gradcheck(fn, torch.rand(2, 2, dtype=torch.double).to_sparse_csc().requires_grad_(True), check_sparse_nnz=False,
-                          check_batched_grad=False, fast_mode=fast_mode, masked=True)
-        check(fast_mode=True)
+                          check_batched_grad=False, fast_mode=fast_mode)
+        # check(fast_mode=True) # RuntimeError: Expected result Tensor to be of format CSR
         check(fast_mode=False)
 
     def test_gradcheck_sparse_bsr_input(self):
@@ -4693,8 +4693,9 @@ Done""")
 
             with self.assertRaisesRegex(RuntimeError, 'gradcheck expects all tensor inputs are dense'):
                 gradcheck(fn, torch.rand(2, 2, dtype=torch.double).to_sparse_bsr((2, 2)).requires_grad_(True),
-                          check_sparse_nnz=False, check_batched_grad=False, fast_mode=fast_mode, masked=True)
-        check(fast_mode=True)
+                          check_sparse_nnz=False, check_batched_grad=False, fast_mode=fast_mode)
+        # RuntimeError: "empty_sparse_compressed" expected sparse compressed (non-block) tensor layout but got SparseBsr
+        # check(fast_mode=True)
         check(fast_mode=False)
 
     def test_gradcheck_sparse_bsc_input(self):
@@ -4707,8 +4708,9 @@ Done""")
 
             with self.assertRaisesRegex(RuntimeError, 'gradcheck expects all tensor inputs are dense'):
                 gradcheck(fn, torch.rand(2, 2, dtype=torch.double).to_sparse_bsc((2, 2)).requires_grad_(True),
-                          check_sparse_nnz=False, check_batched_grad=False, fast_mode=fast_mode, masked=True)
-        check(fast_mode=True)
+                          check_sparse_nnz=False, check_batched_grad=False, fast_mode=fast_mode)
+        # RuntimeError: "empty_sparse_compressed" expected sparse compressed (non-block) tensor layout but got SparseBsc
+        # check(fast_mode=True)
         check(fast_mode=False)
 
     def test_gradcheck_nondeterministic(self):
@@ -4744,7 +4746,7 @@ Done""")
             x = torch.rand(10, requires_grad=True).to_sparse()
             with self.assertRaisesRegex(RuntimeError, 'dense when check_sparse_nnz is set to False.'):
                 gradcheck(lambda x: x.to_dense(), (x,), check_sparse_nnz=False, check_batched_grad=False,
-                          fast_mode=fast_mode, masked=True)
+                          fast_mode=fast_mode)
             self.assertFalse(gradcheck(lambda x: x.to_dense(), (x,), check_sparse_nnz=False,
                                        check_batched_grad=False, raise_exception=False, fast_mode=fast_mode))
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -58,15 +58,6 @@ def all_sparse_layouts(test_name='layout', include_strided=False):
         subtest(torch.sparse_bsc, name='SparseBSC'),
     ][(0 if include_strided else 1):])
 
-def gradcheck_semantics(test_name='gradcheck'):
-    gradcheck_sparse = functools.partial(gradcheck, masked=False)
-    gradcheck_masked = functools.partial(gradcheck, masked=True, check_sparse_nnz=True)
-    gradcheck_sparse.masked = False
-    gradcheck_masked.masked = True
-    return parametrize(test_name, [
-        subtest(gradcheck_sparse, name='sparse'),
-        subtest(gradcheck_masked, name='masked')])
-
 
 class CrossRefSparseFakeMode(torch._subclasses.CrossRefFakeMode):
     def __init__(self):
@@ -411,8 +402,7 @@ class TestSparse(TestSparseBase):
 
     @dtypes(*floating_and_complex_types_and(torch.float16, torch.bfloat16))
     @unittest.skipIf(TEST_WITH_CROSSREF, "generator unsupport triggers assertion error")
-    @gradcheck_semantics()
-    def test_to_dense_with_gradcheck(self, device, dtype, gradcheck):
+    def test_to_dense(self, device, dtype):
         def test_tensor(x, res):
             x.to_dense()  # Tests triple to_dense for memory corruption
             x.to_dense()
@@ -545,8 +535,7 @@ class TestSparse(TestSparseBase):
 
     @dtypes(torch.double, torch.cdouble)
     @unittest.skipIf(TEST_WITH_CROSSREF, "generator unsupport triggers assertion error")
-    @gradcheck_semantics()
-    def test_to_dense_hybrid(self, device, dtype, gradcheck):
+    def test_to_dense_hybrid(self, device, dtype):
         def test_tensor(x, res):
             x.to_dense()  # Tests double to_dense for memory corruption
             x.to_dense()
@@ -900,8 +889,7 @@ class TestSparse(TestSparseBase):
     @coalescedonoff
     @dtypes(torch.double, torch.cdouble)
     @unittest.skipIf(TEST_WITH_CROSSREF, "generator unsupport triggers assertion error")
-    @gradcheck_semantics()
-    def test_permute(self, device, dtype, coalesced, gradcheck):
+    def test_permute(self, device, dtype, coalesced):
         # trivial checks
         s = torch.rand(3, 3, 3, device=device, dtype=dtype).to_sparse()
         with self.assertRaisesRegex(RuntimeError, "does not match the length"):
@@ -1525,8 +1513,7 @@ class TestSparse(TestSparseBase):
     @coalescedonoff
     @unittest.skip("See https://github.com/pytorch/pytorch/issues/73145")
     @dtypes(torch.double, torch.cdouble, torch.bfloat16)
-    @gradcheck_semantics()
-    def test_sparse_addmm(self, device, dtype, coalesced, gradcheck):
+    def test_sparse_addmm(self, device, dtype, coalesced):
         def test_shape(m, n, p, nnz, broadcast, alpha_beta=None):
             if alpha_beta is None:
                 alpha = random.random()
@@ -1573,7 +1560,7 @@ class TestSparse(TestSparseBase):
 
             def fn(S, D):
                 return torch.sparse.mm(S, D)
-            gradcheck(fn, (S, D), check_sparse_nnz=True, masked=True)
+            gradcheck(fn, (S, D), check_sparse_nnz=True)
 
         test_shape(7, 8, 9, 20, False)
         test_shape(7, 8, 9, 20, True)
@@ -1581,8 +1568,7 @@ class TestSparse(TestSparseBase):
     @coalescedonoff
     @dtypes(torch.double)
     @unittest.skipIf(TEST_WITH_CROSSREF, "generator unsupport triggers assertion error")
-    @gradcheck_semantics()
-    def test_sparse_mul(self, device, dtype, coalesced, gradcheck):
+    def test_sparse_mul(self, device, dtype, coalesced):
         # https://github.com/pytorch/pytorch/issues/79914
         a = torch.tensor([[0., 1]], dtype=dtype, device=device).to_sparse().requires_grad_(True)
         b = torch.tensor([[0., 1]], dtype=dtype, device=device).to_sparse().requires_grad_(True)
@@ -1774,7 +1760,7 @@ class TestSparse(TestSparseBase):
                     if res.is_sparse:
                         res = res.to_dense()
                     return res
-                gradcheck(fn, (S,), check_sparse_nnz=True, masked=True)
+                gradcheck(fn, (S,), check_sparse_nnz=True)
             else:
                 S_sum = torch.sparse.sum(S, td)
                 D_sum = D.sum(td)
@@ -1785,7 +1771,7 @@ class TestSparse(TestSparseBase):
                     if res.is_sparse:
                         res = res.to_dense()
                     return res
-                gradcheck(fn, (S,), check_sparse_nnz=True, masked=True)
+                gradcheck(fn, (S,), check_sparse_nnz=True)
 
         nnz = 10
         sparse_dims = 2
@@ -3571,9 +3557,9 @@ class TestSparse(TestSparseBase):
                     # This is because cuSparse sometimes returns approximate zero values like `~e-323`
                     # TODO: Check this cuSparse issue.
                     # This happens when you do chain multiplication `torch.sparse.mm` operations
-                    gradcheck(fn, (a, b), check_sparse_nnz=True, nondet_tol=1e-5, masked=True)
+                    gradcheck(fn, (a, b), check_sparse_nnz=True, nondet_tol=1e-5)
                 else:
-                    gradcheck(fn, (a, b), check_sparse_nnz=True, masked=True)
+                    gradcheck(fn, (a, b), check_sparse_nnz=True)
                 grad_with_custom_sparsity_pattern_test_helper(sparse_dims, nnz, shape_a, shape_b)
 
         def test_error_cases():
@@ -4074,8 +4060,7 @@ class TestSparseUnaryUfuncs(TestCase):
                 check_grad_dtypes=True,
                 check_sparse_nnz=True,
                 nondet_tol=op.gradcheck_nondet_tol,
-                fast_mode=op.gradcheck_fast_mode,
-                masked=True))
+                fast_mode=op.gradcheck_fast_mode))
 
 
 class TestSparseMaskedReductions(TestCase):
@@ -4342,42 +4327,13 @@ class TestSparseAny(TestCase):
     @parametrize("index_dtype", [torch.int32, torch.int64])
     def test_to_dense(self, from_layout, device, dtype, index_dtype):
         """
-        This test tests conversion from any layout to strided layout.
+        This test tests conversion from any layout to any sparse layout.
         """
         for t in self.generate_simple_inputs(
                 from_layout, device=device, dtype=dtype, index_dtype=index_dtype):
             r = t.to_dense()
             self.assertEqual(r.layout, torch.strided)
             self.assertEqual(r, t)
-
-    @all_sparse_layouts('from_layout', include_strided=False)
-    @dtypes(torch.float64, torch.complex128)
-    @parametrize("index_dtype", [torch.int64])
-    @gradcheck_semantics()
-    @parametrize("fast_mode", [subtest(False, name='slow'), subtest(True, name='fast')])
-    def test_gradcheck_to_dense(self, from_layout, device, dtype, index_dtype, gradcheck, fast_mode):
-        for t in self.generate_simple_inputs(
-                from_layout, device=device, dtype=dtype, index_dtype=index_dtype):
-            batch_dim = t.dim() - t.dense_dim() - t.sparse_dim()
-            if batch_dim > 0:
-                # TODO: implement batch support in _convert_indices_from_csr_to_coo
-                continue
-            t = t.clone().detach().requires_grad_(True)
-            if not fast_mode and not gradcheck.masked:
-                # TODO: remove this if-block when TODO items below are resolved
-                try:
-                    gradcheck(torch.Tensor.to_dense, t, fast_mode=fast_mode)
-                except RuntimeError as msg:
-                    # TODO: implement non-masked semantics support in to_dense_backward
-                    with self.assertRaisesRegex(RuntimeError, "Jacobian mismatch"):
-                        gradcheck(torch.Tensor.to_dense, t, fast_mode=fast_mode)
-                    self.skipTest('non-masked semantics not supported')
-            r = gradcheck(torch.Tensor.to_dense, t, fast_mode=fast_mode)
-            self.assertTrue(r)
-
-        # when the following assert fails, it means that the if-block
-        # above and the assertFalse test below can be safely removed
-        self.assertFalse(not fast_mode and not gradcheck.masked)
 
     @all_sparse_layouts('from_layout', include_strided=True)
     @all_sparse_layouts('to_layout', include_strided=False)
@@ -4646,57 +4602,6 @@ class TestSparseAny(TestCase):
             with self.assertRaisesRegex(RuntimeError, expected_behaviour[1]):
                 mth(inp)
 
-    @onlyNativeDeviceTypes
-    @all_sparse_layouts('layout', include_strided=not True)
-    @dtypes(torch.float64, torch.cdouble)
-    @parametrize("masked", [subtest(False, name='sparse'), subtest(True, name='masked')])
-    @parametrize("fast_mode", [subtest(False, name='slow'), subtest(True, name='fast')])
-    def test_gradcheck_mm(self, layout, dtype, device, masked, fast_mode):
-        # This function does not check the following cases:
-        # - batch or hybrid tensors because addmm does not support
-        #   such inputs yet
-        # - check_forward_ad=True because of the lack of sparse tensor
-        #   support in aten::view_as_real, torch._VF._make_dual, etc.
-
-        ref_x = torch.tensor([[1, 2, 0, 0],
-                              [0, 6, 0, 0],
-                              [0, 0, 0, 0],
-                              [13, 14, 0, 15]], dtype=dtype, device=device)
-        ref_y = torch.tensor([[11, 12, 13, 14],
-                              [21, 22, 23, 24],
-                              [31, 32, 33, 34],
-                              [41, 42, 43, 44]],
-                             dtype=dtype, device=device)
-
-        mm = torch.sparse.mm if masked else torch.mm
-
-        blocksize = (2, 2) if layout in {torch.sparse_bsr, torch.sparse_bsc} else None
-        x = ref_x.to_sparse(layout=layout, blocksize=blocksize).requires_grad_(True)
-        y = ref_y.requires_grad_(True)
-
-        if layout is torch.sparse_bsr and not masked or layout is torch.sparse_bsc:
-            with self.assertRaisesRegex(
-                    RuntimeError,
-                    r"addmm: computation on (CPU|CUDA) is not implemented for Strided \+ Sparse(Bsr|Bsc) @ Strided"):
-                torch.autograd.gradcheck(mm, (x, y), check_sparse_nnz=True, fast_mode=fast_mode, masked=masked)
-            self.skipTest('NOT IMPL')
-        elif layout in {torch.sparse_csc, torch.sparse_bsr, torch.sparse_bsc} and masked:
-            with self.assertRaisesRegex(
-                    RuntimeError,
-                    r"(sparse_addmm_sparse_backward: unsupported combination of layouts,"
-                    r" grad: Strided, mat1: Sparse(Csc|Bsr|Bsc), mat2: Strided"
-                    r"|addmm: computation on (CPU|CUDA) is not implemented for "
-                    r"Strided \+ Sparse(Csc|Bsr|Bsc) @ Strided without MKL)"):
-                torch.autograd.gradcheck(mm, (x, y), check_sparse_nnz=True, fast_mode=fast_mode, masked=masked)
-            self.skipTest('NOT IMPL')
-        else:
-            if masked:
-                r = torch.autograd.gradcheck(mm, (x, y), check_sparse_nnz=True, fast_mode=fast_mode, masked=masked)
-            else:
-                # Specifying check_sparse_nnz is unnecessary in
-                # non-masked/sparse semantics
-                r = torch.autograd.gradcheck(mm, (x, y), fast_mode=fast_mode, masked=masked)
-            self.assertTrue(r)
 
 # e.g., TestSparseUnaryUfuncsCPU and TestSparseUnaryUfuncsCUDA
 instantiate_device_type_tests(TestSparseUnaryUfuncs, globals(), except_for='meta')

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -72,43 +72,6 @@ def _iter_tensors(x: Union[torch.Tensor, Iterable[torch.Tensor]],
                 yield result
 
 
-def _densify(x):
-    # return a copy of sparse x with all unspecified elements
-    # "replaced" with zero-valued elements
-    if isinstance(x, (list, tuple)):
-        return type(x)(map(_densify, x))
-    elif not is_tensor_like(x) or x.layout in {torch.strided, torch._mkldnn}:  # type: ignore[attr-defined] # no attr _mkldnn
-        return x
-    elif x.layout is torch.sparse_coo:
-        device = x.device
-        indices_dtype = x._indices().dtype
-        tmp = torch.ones(x.shape[:x.sparse_dim()], dtype=torch.int8, device=device)
-        indices = tmp.nonzero().t().to(dtype=indices_dtype)
-        values = torch.zeros((tmp.numel(), *x.shape[x.sparse_dim():]), dtype=x.dtype, device=device)
-        x_coalesced = x.detach().coalesce()
-        if x_coalesced.numel() > 0:
-            stride = tmp.stride()
-            flat_indices = x_coalesced.indices().mul(
-                torch.tensor(stride, dtype=indices_dtype, device=device).unsqueeze(1)).sum(0)
-            values[flat_indices] = x_coalesced.values()
-        return torch.sparse_coo_tensor(indices, values, x.shape)._coalesced_(True).requires_grad_(x.requires_grad)
-    elif _is_sparse_compressed_tensor(x):
-        blocksize = x.values().shape[1:3] if x.layout in {torch.sparse_bsr, torch.sparse_bsc} else None
-        compressed_indices = x.crow_indices() if x.layout in {torch.sparse_csr, torch.sparse_bsr} else x.ccol_indices()
-        # We'll use intermediate sparse COO for simplicity
-        r = _densify(x.detach().to_sparse(layout=torch.sparse_coo)).to_sparse(layout=x.layout, blocksize=blocksize)
-        # Check that all elements are specified also after `to_sparse` op:
-        dense_numel = r.values().numel() // max(1, r.values().shape[0])
-        batch_numel = compressed_indices.numel() // compressed_indices.shape[-1]
-        sparse_numel = r.numel() // max(1, dense_numel * batch_numel)
-        if sparse_numel != r._nnz():
-            raise AssertionError(f'{x.layout} densify failed: expected nnz={sparse_numel} but got {r._nnz()}')
-        return r.requires_grad_(x.requires_grad)
-    elif _is_sparse_any_tensor(x):
-        raise NotImplementedError(x.layout)
-    return x
-
-
 def _iter_tensor(x_tensor):
     # (Only used for slow gradcheck) Returns a generator that yields the following
     # elements at each iteration:
@@ -151,8 +114,8 @@ def _iter_tensor(x_tensor):
             x_blocksize = x_block_values.size()[1:3]
             x_indices = torch._convert_indices_from_csr_to_coo(x_tensor.crow_indices(), x_tensor.col_indices()) \
                              .repeat_interleave(x_blocksize[0] * x_blocksize[1], 1) \
-                             .mul_(torch.tensor(x_blocksize, device=x_tensor.device).reshape(2, 1)) \
-                             .add_(torch.stack(torch.where(torch.ones(x_blocksize, device=x_tensor.device))).repeat(1, x_nnz)).t()
+                             .mul_(torch.tensor(x_blocksize).reshape(2, 1)) \
+                             .add_(torch.stack(torch.where(torch.ones(x_blocksize))).repeat(1, x_nnz)).t()
             x_values = x_block_values.flatten(0, 2)
             x_nnz = x_values.size(0)
         elif x_tensor.layout is torch.sparse_bsc:
@@ -160,8 +123,8 @@ def _iter_tensor(x_tensor):
             x_blocksize = x_block_values.size()[1:3]
             x_indices = torch._convert_indices_from_csr_to_coo(x_tensor.ccol_indices(), x_tensor.row_indices(), transpose=True) \
                              .repeat_interleave(x_blocksize[0] * x_blocksize[1], 1) \
-                             .mul_(torch.tensor(x_blocksize, device=x_tensor.device).reshape(2, 1)) \
-                             .add_(torch.stack(torch.where(torch.ones(x_blocksize, device=x_tensor.device))).repeat(1, x_nnz)).t()
+                             .mul_(torch.tensor(x_blocksize).reshape(2, 1)) \
+                             .add_(torch.stack(torch.where(torch.ones(x_blocksize))).repeat(1, x_nnz)).t()
             x_values = x_block_values.flatten(0, 2)
             x_nnz = x_values.size(0)
         else:
@@ -262,19 +225,6 @@ def get_numerical_jacobian(fn, inputs, target=None, eps=1e-3, grad_out=1.0):
 def _compute_numerical_gradient(fn, entry, v, norm_v, nbhd_checks_fn):
     # Performs finite differencing by perturbing `entry` in-place by `v` and
     # returns the gradient of each of the outputs wrt to x at idx.
-    if _is_sparse_compressed_tensor(entry):
-        # sparse compressed tensors don't implement sub/add/copy_
-        # yet. However, in non-masked semantics context entry and v
-        # have the same sparse indices ...
-        assert entry.layout == v.layout, (entry.layout, v.layout)
-        assert entry._nnz() == v._nnz(), (entry._nnz(), v._nnz(), entry.shape)
-        # ... the finite differencing can be performed on values only:
-        entry = entry.values()
-        v = v.values()
-        # we'll detach to avoid backward computations that sparse
-        # tensors have limited support for.
-        entry = entry.detach()
-
     orig = entry.clone()
     entry.copy_(orig - v)
     outa = fn()
@@ -727,10 +677,9 @@ def _get_analytical_vjps_wrt_specific_output(vjp_fn, sample_output, v) -> List[L
     return vjps
 
 
-def _check_inputs(tupled_inputs, check_sparse_nnz, masked) -> bool:
-    if masked and not check_sparse_nnz and any(_is_sparse_any_tensor(t) for t in tupled_inputs if isinstance(t, torch.Tensor)):
-        raise GradcheckError('gradcheck expects all tensor inputs are dense'
-                             ' when check_sparse_nnz is set to False and masked is set to True.')
+def _check_inputs(tupled_inputs, check_sparse_nnz) -> bool:
+    if not check_sparse_nnz and any(_is_sparse_any_tensor(t) for t in tupled_inputs if isinstance(t, torch.Tensor)):
+        raise GradcheckError('gradcheck expects all tensor inputs are dense when check_sparse_nnz is set to False.')
     # Make sure that gradients are saved for at least one input
     any_input_requiring_grad = False
     for idx, inp in enumerate(tupled_inputs):
@@ -968,10 +917,8 @@ def _test_backward_mul_by_grad_output(outputs, inputs, check_sparse_nnz) -> bool
                 raise GradcheckError('backward not multiplied by grad_output')
         elif not gi.eq(0).all():
             raise GradcheckError('backward not multiplied by grad_output')
-        if gi.dtype != di.dtype:
+        if gi.dtype != di.dtype or gi.device != di.device or gi.is_sparse != di.is_sparse:
             raise GradcheckError("grad is incorrect type")
-        if gi.device != di.device:
-            raise GradcheckError("grad is incorrect device")
         if gi.size() != di.size():
             raise GradcheckError('grad is incorrect size')
     return True
@@ -1194,16 +1141,13 @@ def _gradcheck_real_imag(gradcheck_fn, func, func_out, tupled_inputs, outputs, e
                 _test_undefined_forward_mode(func, outputs, tupled_inputs)
 
 def _slow_gradcheck(func, func_out, tupled_inputs, outputs, eps, rtol, atol, check_grad_dtypes,
-                    nondet_tol, *, use_forward_ad=False, complex_indices=None, test_imag=False, masked=False):
+                    nondet_tol, *, use_forward_ad=False, complex_indices=None, test_imag=False):
     func_out = _as_tuple(func_out)
     if not outputs:
         return _check_no_differentiable_outputs(func, tupled_inputs, func_out,
                                                 eps=eps, is_forward_ad=use_forward_ad)
 
-    tupled_inputs_numerical = tupled_inputs if masked else _densify(tupled_inputs)
-
-    numerical = _transpose(_get_numerical_jacobian(func, tupled_inputs_numerical, func_out,
-                                                   eps=eps, is_forward_ad=use_forward_ad))
+    numerical = _transpose(_get_numerical_jacobian(func, tupled_inputs, func_out, eps=eps, is_forward_ad=use_forward_ad))
     # Note: [numerical vs analytical output length]
     # The numerical path returns jacobian quantity for all outputs, even if requires_grad of that
     # output is False. This behavior is necessary for _check_no_differentiable_outputs to work.
@@ -1296,8 +1240,9 @@ def _adjusted_atol(atol, u, v):
     # matrix): v^T M u = \sum_{i} \sum_{j} u_i * v_j = (\sum_{i} u_i)(\sum_{i} v_i)
     # TODO: properly handle case when u is tuple instead of only taking first element
     u = u[0] if isinstance(u, tuple) else u
-    sum_u = u.sum()
-    sum_v = 1. if v is None else v.sum()
+    # TODO: replace torch.sparse.sum(u) with u.sum()
+    sum_u = torch.sparse.sum(u) if u.layout == torch.sparse_coo else u.sum()
+    sum_v = 1. if v is None else torch.sparse.sum(v) if v.layout == torch.sparse_coo else v.sum()
     return atol * float(sum_u) * float(sum_v)
 
 
@@ -1391,8 +1336,7 @@ def _check_analytical_numerical_equal(all_analytical, all_numerical, complex_ind
 
 
 def _fast_gradcheck(func, func_out, inputs, outputs, eps, rtol,
-                    atol, check_grad_dtypes, nondet_tol, *, use_forward_ad=False, complex_indices=None, test_imag=False,
-                    masked=False):
+                    atol, check_grad_dtypes, nondet_tol, *, use_forward_ad=False, complex_indices=None, test_imag=False):
     # See https://github.com/pytorch/pytorch/issues/53876 for details
     inp_tensors_idx, inp_tensors = _get_inp_tensors(inputs)
     # Backward mode computes v^T * J (VJP)
@@ -1404,10 +1348,7 @@ def _fast_gradcheck(func, func_out, inputs, outputs, eps, rtol,
     # we don't need v for correctness check here as asserted below
     all_v, all_u, all_u_dense = _make_vectors(inp_tensors, outputs, use_forward_ad=use_forward_ad)
 
-    inputs_numerical, all_u_numerical, all_v_numerical = (inputs, all_u, all_v) if masked else _densify((inputs, all_u, all_v))
-
-    numerical_vJu = _get_numerical_vJu(func, inputs_numerical, inp_tensors_idx, func_out,
-                                       all_u_numerical, all_v_numerical, eps, is_forward_ad=use_forward_ad)
+    numerical_vJu = _get_numerical_vJu(func, inputs, inp_tensors_idx, func_out, all_u, all_v, eps, is_forward_ad=use_forward_ad)
     # TODO: replicate https://github.com/pytorch/pytorch/pull/77743 for fast gradcheck as well
     if use_forward_ad:
         assert all_v is None
@@ -1450,7 +1391,6 @@ def gradcheck(
     check_forward_ad: bool = False,
     check_backward_ad: bool = True,
     fast_mode: bool = False,
-    masked: bool = False,
 ) -> bool:
     r"""Check gradients computed via small finite differences against analytical
     gradients w.r.t. tensors in :attr:`inputs` that are of floating point or complex type
@@ -1515,8 +1455,7 @@ def gradcheck(
             implemented for R to R functions. If none of the inputs and outputs are complex
             a faster implementation of gradcheck that no longer computes the entire jacobian
             is run; otherwise, we fall back to the slow implementation.
-        masked (bool, optional): if True, the gradients of unspecified elements of
-            sparse tensors are ignored (default, False).
+
     Returns:
         True if all differences satisfy allclose condition
     """
@@ -1539,15 +1478,15 @@ def gradcheck(
 
 def _gradcheck_helper(func, inputs, eps, atol, rtol, check_sparse_nnz, nondet_tol, check_undefined_grad,
                       check_grad_dtypes, check_batched_grad, check_batched_forward_grad, check_forward_ad,
-                      check_backward_ad, fast_mode, masked):
+                      check_backward_ad, fast_mode):
     tupled_inputs = _as_tuple(inputs)
-    _check_inputs(tupled_inputs, check_sparse_nnz, masked)
+    _check_inputs(tupled_inputs, check_sparse_nnz)
 
     func_out = func(*tupled_inputs)
     outputs = _differentiable_outputs(func_out)
     _check_outputs(outputs)
 
-    gradcheck_fn = functools.partial(_fast_gradcheck if fast_mode else _slow_gradcheck, masked=masked)
+    gradcheck_fn = _fast_gradcheck if fast_mode else _slow_gradcheck
     _gradcheck_real_imag(gradcheck_fn, func, func_out, tupled_inputs, outputs, eps,
                          rtol, atol, check_grad_dtypes, check_forward_ad=check_forward_ad,
                          check_backward_ad=check_backward_ad, nondet_tol=nondet_tol,
@@ -1588,7 +1527,6 @@ def gradgradcheck(
     check_fwd_over_rev: bool = False,
     check_rev_over_rev: bool = True,
     fast_mode: bool = False,
-    masked: bool = False,
 ) -> bool:
     r"""Check gradients of gradients computed via small finite differences
     against analytical gradients w.r.t. tensors in :attr:`inputs` and
@@ -1639,8 +1577,7 @@ def gradgradcheck(
             batched gradients using prototype vmap support. Defaults to False.
         fast_mode (bool, optional): if True, run a faster implementation of gradgradcheck that
             no longer computes the entire jacobian.
-        masked (bool, optional): if True, the gradients of unspecified elements of
-            sparse tensors are ignored (default, False).
+
     Returns:
         True if all differences satisfy allclose condition
     """
@@ -1696,4 +1633,4 @@ def gradgradcheck(
         new_func, tupled_inputs + tupled_grad_outputs, eps=eps, atol=atol, rtol=rtol, raise_exception=raise_exception,
         nondet_tol=nondet_tol, check_undefined_grad=check_undefined_grad,
         check_grad_dtypes=check_grad_dtypes, check_batched_grad=check_batched_grad, fast_mode=fast_mode,
-        check_forward_ad=check_fwd_over_rev, check_backward_ad=check_rev_over_rev, masked=masked)
+        check_forward_ad=check_fwd_over_rev, check_backward_ad=check_rev_over_rev)


### PR DESCRIPTION
This reverts commit 7ac511c29ad365f6dc078b8353d9c189720970a2 from https://github.com/pytorch/pytorch/pull/94714 since it breaks periodic.

Git thinks there's a merge conflict due to an unfortunately located newline deletion, so reverting this one manually

Details behind the failure in https://github.com/pytorch/pytorch/pull/94714#issuecomment-1442160593