### PR TITLE
[optim] Add general documentation on our algorithm defaults

### DIFF
--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -141,7 +141,7 @@ implementations, which combine parameters into a multi-tensor and run the big ch
 of computation all at once, thereby saving many sequential kernel calls. A few of our
 optimizers have even faster fused implementations, which fuse the big chunks of
 computation into one kernel. We can think of foreach implementations as fusing
-horizontally and fused implementations as fusing vertically.
+horizontally and fused implementations as fusing vertically on top of that.
 
 In general, the performance ordering of the 3 implementations is fused > foreach > for-loop.
 So when applicable, we default to foreach over for-loop. Applicable means the foreach

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -144,16 +144,12 @@ computation into one kernel. We can think of foreach implementations as fusing
 horizontally and fused implementations as fusing vertically.
 
 In general, the performance ordering of the 3 implementations is fused > foreach > for-loop.
-So when applicable, we default to foreach over for-loop. Applicable means:
-* the foreach implementation is available
-* the user has not specified any implementation-specific kwargs (e.g., fused, foreach, 
-differentiable) 
-* all tensors are native and on CUDA because the foreach implementation is reliably faster
-under these conditions
-
-Note that while fused should be even faster than foreach, the implementations are newer
-and we would like to give them more bake-in time before flipping the switch everywhere.
-You are welcome to try them out though!
+So when applicable, we default to foreach over for-loop. Applicable means the foreach
+implementation is available, the user has not specified any implementation-specific kwargs
+(e.g., fused, foreach, differentiable), and all tensors are native and on CUDA. Note that
+while fused should be even faster than foreach, the implementations are newer and we would
+like to give them more bake-in time before flipping the switch everywhere. You are welcome
+to try them out though!
 
 Below is a table showing the available and default implementations of each algorithm:
 

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -129,11 +129,13 @@ Algorithms
     Rprop
     SGD
 
-Many of our algorithms have various implementations optimized for performance, so
-we attempt to default to the faster foreach implementation if no particular
-implementation has been specified by the user.
+Many of our algorithms have various implementations optimized for performance,
+readability and/or generality, so we attempt to default to the generally fastest
+implementation for the current device if no particular implementation has been
+specified by the user.
 
-The most straightforward implementations are for-loops over the parameters with
+We have 3 major categories of implementations: for-loop, foreach (multi-tensor), and
+fused. The most straightforward implementations are for-loops over the parameters with
 big chunks of computation. For-looping is usually slower than our foreach
 implementations, which combine parameters into a multi-tensor and run the big chunks
 of computation all at once, thereby saving many sequential kernel calls. A few of our
@@ -141,16 +143,17 @@ optimizers have even faster fused implementations, which fuse the big chunks of
 computation into one kernel. We can think of foreach implementations as fusing
 horizontally and fused implementations as fusing vertically.
 
-Since these implementations are faster under certain configurations, we attempt
-to switch to the foreach implementation if applicable. Here, applicable means the
-foreach implementation is available, the differentiable kwarg is the default (False),
-and the user has not specified any kwargs referring to particular implementations
-such as fused and foreach. The configuration for when we flip the switch is when all
-tensors are native and on CUDA because the foreach implementation is reliably faster
-under these conditions. Note that while the fused implementations should be even more
-performant than the foreach implementations, they are relatively new and we would like
-to give them more bake-in time before flipping the switch on every use case. You are
-welcome to try them out though!
+In general, the performance ordering of the 3 implementations is fused > foreach > for-loop.
+So when applicable, we default to foreach over for-loop. Applicable means:
+* the foreach implementation is available
+* the user has not specified any implementation-specific kwargs (e.g., fused, foreach, 
+differentiable) 
+* all tensors are native and on CUDA because the foreach implementation is reliably faster
+under these conditions
+
+Note that while fused should be even faster than foreach, the implementations are newer
+and we would like to give them more bake-in time before flipping the switch everywhere.
+You are welcome to try them out though!
 
 Below is a table showing the available and default implementations of each algorithm:
 

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -153,24 +153,25 @@ to give them more bake-in time before flipping the switch on every use case. You
 welcome to try them out though!
 
 Below is a table showing the available and default implementations of each algorithm:
-.. csv-table::
-   :header: "Algorithm", "Default", "Has foreach?", "Has fused?"
-   :widths: 25, 25, 25, 25
-   :delim: ;
 
-   :class:`Adadelta`;foreach;yes;no
-   :class:`Adagrad`;foreach;yes;no
-   :class:`Adam`;foreach;yes;yes
-   :class:`AdamW`;foreach;yes;yes
-   :class:`SparseAdam`;for-loop;no;no
-   :class:`Adamax`;foreach;yes;no
-   :class:`ASGD`;foreach;yes;no
-   :class:`LBFGS`;for-loop;no;no
-   :class:`NAdam`;foreach;yes;no
-   :class:`RAdam`;foreach;yes;no
-   :class:`RMSprop`;foreach;yes;no
-   :class:`Rprop`;foreach;yes;no
-   :class:`SGD`;foreach;yes;no
+.. csv-table::
+    :header: "Algorithm", "Default", "Has foreach?", "Has fused?"
+    :widths: 25, 25, 25, 25
+    :delim: ;
+
+    :class:`Adadelta`;foreach;yes;no
+    :class:`Adagrad`;foreach;yes;no
+    :class:`Adam`;foreach;yes;yes
+    :class:`AdamW`;foreach;yes;yes
+    :class:`SparseAdam`;for-loop;no;no
+    :class:`Adamax`;foreach;yes;no
+    :class:`ASGD`;foreach;yes;no
+    :class:`LBFGS`;for-loop;no;no
+    :class:`NAdam`;foreach;yes;no
+    :class:`RAdam`;foreach;yes;no
+    :class:`RMSprop`;foreach;yes;no
+    :class:`Rprop`;foreach;yes;no
+    :class:`SGD`;foreach;yes;no
 
 How to adjust learning rate
 ---------------------------

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -154,23 +154,23 @@ welcome to try them out though!
 
 Below is a table showing the available and default implementations of each algorithm:
 .. csv-table::
-    :header: "Algorithm", "Default", "Has foreach?", "Has fused?"
-    :widths: 25, 25, 25, 25
-    :delim: ;
+   :header: "Algorithm", "Default", "Has foreach?", "Has fused?"
+   :widths: 25, 25, 25, 25
+   :delim: ;
 
-    :class:`Adadelta`;foreach;yes;no
-    :class:`Adagrad`;foreach;yes;no
-    :class:`Adam`;foreach;yes;yes
-    :class:`AdamW`;foreach;yes;yes
-    :class:`SparseAdam`;for-loop;no;no
-    :class:`Adamax`;foreach;yes;no
-    :class:`ASGD`;foreach;yes;no
-    :class:`LBFGS`;for-loop;no;no
-    :class:`NAdam`;foreach;yes;no
-    :class:`RAdam`;foreach;yes;no
-    :class:`RMSprop`;foreach;yes;no
-    :class:`Rprop`;foreach;yes;no
-    :class:`SGD`;foreach;yes;no
+   :class:`Adadelta`;foreach;yes;no
+   :class:`Adagrad`;foreach;yes;no
+   :class:`Adam`;foreach;yes;yes
+   :class:`AdamW`;foreach;yes;yes
+   :class:`SparseAdam`;for-loop;no;no
+   :class:`Adamax`;foreach;yes;no
+   :class:`ASGD`;foreach;yes;no
+   :class:`LBFGS`;for-loop;no;no
+   :class:`NAdam`;foreach;yes;no
+   :class:`RAdam`;foreach;yes;no
+   :class:`RMSprop`;foreach;yes;no
+   :class:`Rprop`;foreach;yes;no
+   :class:`SGD`;foreach;yes;no
 
 How to adjust learning rate
 ---------------------------

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -129,6 +129,49 @@ Algorithms
     Rprop
     SGD
 
+Many of our algorithms have various implementations optimized for performance, so
+we attempt to default to the faster foreach implementation if no particular
+implementation has been specified by the user.
+
+The most straightforward implementations are for-loops over the parameters with
+big chunks of computation. For-looping is usually slower than our foreach
+implementations, which combine parameters into a multi-tensor and run the big chunks
+of computation all at once, thereby saving many sequential kernel calls. A few of our
+optimizers have even faster fused implementations, which fuse the big chunks of
+computation into one kernel. We can think of foreach implementations as fusing
+horizontally and fused implementations as fusing vertically.
+
+Since these implementations are faster under certain configurations, we attempt
+to switch to the foreach implementation if applicable. Here, applicable means the
+foreach implementation is available, the differentiable kwarg is the default (False),
+and the user has not specified any kwargs referring to particular implementations
+such as fused and foreach. The configuration for when we flip the switch is when all
+tensors are native and on CUDA because the foreach implementation is reliably faster
+under these conditions. Note that while the fused implementations should be even more
+performant than the foreach implementations, they are relatively new and we would like
+to give them more bake-in time before flipping the switch on every use case. You are
+welcome to try them out though!
+
+Below is a table showing the available and default implementations of each algorithm:
+.. csv-table::
+    :header: "Algorithm", "Default", "Has foreach?", "Has fused?"
+    :widths: 25, 25, 25, 25
+    :delim: ;
+
+    :class:`Adadelta`;foreach;yes;no
+    :class:`Adagrad`;foreach;yes;no
+    :class:`Adam`;foreach;yes;yes
+    :class:`AdamW`;foreach;yes;yes
+    :class:`SparseAdam`;for-loop;no;no
+    :class:`Adamax`;foreach;yes;no
+    :class:`ASGD`;foreach;yes;no
+    :class:`LBFGS`;for-loop;no;no
+    :class:`NAdam`;foreach;yes;no
+    :class:`RAdam`;foreach;yes;no
+    :class:`RMSprop`;foreach;yes;no
+    :class:`Rprop`;foreach;yes;no
+    :class:`SGD`;foreach;yes;no
+
 How to adjust learning rate
 ---------------------------
 


### PR DESCRIPTION
I added a section + table under Algorithms
https://docs-preview.pytorch.org/95391/optim.html?highlight=optim#module-torch.optim
<img width="725" alt="image" src="https://user-images.githubusercontent.com/31798555/221246256-99325a27-9016-407b-a9fe-404d61e41a82.png">


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95391

