### PR TITLE
Improve retries when ECR login is flaky

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -30,16 +30,21 @@ runs:
         fi
 
     - name: Log in to ECR
-      shell: bash
+      uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
       env:
         AWS_RETRY_MODE: standard
         AWS_MAX_ATTEMPTS: "5"
         AWS_DEFAULT_REGION: us-east-1
-      run: |
-        AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
-        retry () { "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@") }
-        retry aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS \
-            --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"
+      with:
+        shell: bash
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 30
+        command: |
+          retry () { "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@") }
+          AWS_ACCOUNT_ID=$(retry aws sts get-caller-identity|grep Account|cut -f4 -d\")
+          retry aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS \
+              --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"
 
     - name: Preserve github env variables for use in docker
       shell: bash

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -41,9 +41,8 @@ runs:
         max_attempts: 3
         retry_wait_seconds: 30
         command: |
-          retry () { "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@") }
-          AWS_ACCOUNT_ID=$(retry aws sts get-caller-identity|grep Account|cut -f4 -d\")
-          retry aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS \
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
+          aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS \
               --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"
 
     - name: Preserve github env variables for use in docker


### PR DESCRIPTION
We had a few failures on master where the AWS ECR login was flaky
- [example 1](https://github.com/pytorch/pytorch/actions/runs/4255994694/jobs/7404316780)
- [example 2](https://github.com/pytorch/pytorch/actions/runs/4255390043/jobs/7402936370)
- [example 3](https://github.com/pytorch/pytorch/actions/runs/4255390040/jobs/7403356275)

Most likely the failure happened when getting the AWS_ACCOUNT_ID (which wasn't protected by a retry).

Retrying getting the account id, and also moving the whole step into a retry action to retry on slightly longer lasting ECR outages