### PR TITLE
[fully_shard] Add `limit_all_gathers=True` fn arg

### DIFF
--- a/torch/distributed/_composable/fully_shard.py
+++ b/torch/distributed/_composable/fully_shard.py
@@ -45,6 +45,7 @@ def fully_shard(
     device_id: Optional[Union[int, torch.device]] = None,
     param_init_fn: Optional[Callable[[nn.Module], None]] = None,
     sync_module_states: bool = False,
+    limit_all_gathers: bool = True,
 ) -> nn.Module:
     """
     Applies ``FullyShardedDataParallel` (FSDP) semantics to ``module``.
@@ -58,7 +59,6 @@ def fully_shard(
     state = _init_process_group_state(
         state, process_group, ShardingStrategy.FULL_SHARD, policy
     )
-    limit_all_gathers = True
     use_orig_params = True
     backward_prefetch_limit = 1
     forward_prefetch_limit = 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#95400 [fully_shard] Add `limit_all_gathers=True` fn arg**

This PR adds the `limit_all_gathers: bool` argument to `fully_shard` since some users may still want to set it to `False`. We default to `True` still.