### PR TITLE
[optim] Set defaults to foreach, NOT fused (#95241)

### DIFF
--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -194,7 +194,7 @@ def adadelta(
     # We still respect when the user inputs False for foreach.
     if foreach is None:
         _, foreach = _default_to_fused_or_foreach([params, grads, square_avgs, acc_deltas],
-                                                  differentiable, has_fused=False)
+                                                  differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -211,7 +211,7 @@ def adagrad(
 
     if foreach is None:
         _, foreach = _default_to_fused_or_foreach([params, grads, state_sums, state_steps],
-                                                  differentiable, has_fused=False)
+                                                  differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -207,7 +207,7 @@ def adamax(
 
     if foreach is None:
         _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_infs, state_steps],
-                                                  differentiable, has_fused=False)
+                                                  differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -186,7 +186,7 @@ def asgd(
 
     if foreach is None:
         _, foreach = _default_to_fused_or_foreach([params, grads, axs, mus, etas, state_steps],
-                                                  differentiable, has_fused=False)
+                                                  differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -188,7 +188,7 @@ def nadam(params: List[Tensor],
 
     if foreach is None:
         _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, mu_products, state_steps],
-                                                  differentiable, has_fused=False)
+                                                  differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError('torch.jit.script not supported with foreach optimizers')

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -210,7 +210,7 @@ def radam(
 
     if foreach is None:
         _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, state_steps],
-                                                  differentiable, has_fused=False)
+                                                  differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -221,7 +221,7 @@ def rmsprop(
 
     if foreach is None:
         _, foreach = _default_to_fused_or_foreach([params, grads, square_avgs, grad_avgs, momentum_buffer_list],
-                                                  differentiable, has_fused=False)
+                                                  differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -193,7 +193,7 @@ def rprop(
 
     if foreach is None:
         _, foreach = _default_to_fused_or_foreach([params, grads, prevs, step_sizes],
-                                                  differentiable, has_fused=False)
+                                                  differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -208,7 +208,7 @@ def sgd(params: List[Tensor],
         # because JIT can't handle Optionals nor fancy conditionals when scripting
         if not torch.jit.is_scripting():
             _, foreach = _default_to_fused_or_foreach([params, d_p_list, momentum_buffer_list],
-                                                      differentiable=False, has_fused=False)
+                                                      differentiable=False, use_fused=False)
         else:
             foreach = False
 


### PR DESCRIPTION
Rolling back the default change for Adam and rectifying the docs to reflect that AdamW never defaulted to fused.

Since our fused implementations are relatively newer, let's give them a longer bake-in time before flipping the switch for every user.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/95241
Approved by: https://github.com/ngimel