### PR TITLE
[PyTorch] Add Borrowed<Tensor{,Base}>

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -10,6 +10,7 @@
 #include <c10/core/TensorOptions.h>
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/core/WrapDimMinimal.h>
+#include <c10/util/BorrowedTensorTraits.h>
 #include <c10/util/Exception.h>
 #include <c10/util/ExclusivelyOwnedTensorTraits.h>
 #include <c10/util/MaybeOwned.h>
@@ -86,6 +87,7 @@ class TORCH_API TensorBase {
   // time. Intended to support MaybeOwnedTraits<Tensor>.
   explicit TensorBase(unsafe_borrow_t, const TensorBase& rhs)
       : impl_(c10::intrusive_ptr<at::TensorImpl, UndefinedTensorImpl>::reclaim(rhs.impl_.get())) {}
+  friend BorrowedTraits<TensorBase>;
   friend MaybeOwnedTraits<TensorBase>;
 
  public:

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -93,6 +93,7 @@ class TORCH_API Tensor: public TensorBase {
   // taken to avoid decrementing this reference count at destruction
   // time. Intended to support MaybeOwnedTraits<Tensor>.
   explicit Tensor(unsafe_borrow_t, const TensorBase& rhs): TensorBase(unsafe_borrow_t{}, rhs) {}
+  friend BorrowedTraits<Tensor>;
   friend MaybeOwnedTraits<Tensor>;
   friend OptionalTensorRef;
 

--- a/aten/src/ATen/test/Borrowed_test.cpp
+++ b/aten/src/ATen/test/Borrowed_test.cpp
@@ -1,0 +1,138 @@
+#include <gtest/gtest.h>
+
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/Tensor.h>
+#include <c10/util/Borrowed.h>
+#include <c10/util/BorrowedTensorTraits.h>
+
+namespace {
+
+template <typename T>
+T getSampleValue();
+
+template <>
+at::Tensor getSampleValue() {
+  return at::zeros({2, 2}).to(at::kCPU);
+}
+
+template <>
+at::TensorBase getSampleValue() {
+  return getSampleValue<at::Tensor>();
+}
+
+template <typename T>
+class BorrowedTest : public ::testing::Test {
+ public:
+  c10::Borrowed<T> defaultConstructed;
+  c10::Borrowed<T> sample;
+  c10::Borrowed<T> sampleViaRawImplPointer;
+  ;
+  T ownedSample;
+
+ protected:
+  void SetUp() override; // defined below helpers
+  void TearDown() override {
+    defaultConstructed = c10::Borrowed<T>();
+    sample = c10::Borrowed<T>();
+    sampleViaRawImplPointer = c10::Borrowed<T>();
+    ownedSample = T();
+  }
+
+  void expectEmpty(const c10::Borrowed<T>& b) {
+    EXPECT_FALSE(static_cast<bool>(b));
+  }
+
+  void expectBorrowsFrom(const c10::Borrowed<T>& b, const T& from) {
+    EXPECT_TRUE(static_cast<bool>(b));
+    EXPECT_EQ(b->unsafeGetTensorImpl(), from.unsafeGetTensorImpl());
+    EXPECT_EQ((*b).unsafeGetTensorImpl(), from.unsafeGetTensorImpl());
+    EXPECT_EQ(b.get(), b.operator->());
+  }
+};
+
+template <typename T>
+void BorrowedTest<T>::SetUp() {
+  defaultConstructed = c10::Borrowed<T>();
+  ownedSample = getSampleValue<T>();
+  sample = c10::Borrowed<T>(ownedSample);
+  sampleViaRawImplPointer = c10::Borrowed<T>(ownedSample.unsafeGetTensorImpl());
+}
+
+using BorrowedTypes = ::testing::Types<at::Tensor, at::TensorBase>;
+
+TYPED_TEST_CASE(BorrowedTest, BorrowedTypes);
+
+TYPED_TEST(BorrowedTest, Basic) {
+  this->expectEmpty(this->defaultConstructed);
+  this->expectBorrowsFrom(this->sample, this->ownedSample);
+  this->expectBorrowsFrom(this->sampleViaRawImplPointer, this->ownedSample);
+}
+
+TYPED_TEST(BorrowedTest, CopyConstructor) {
+  auto copiedDefault = this->defaultConstructed;
+  auto copiedSample = this->sample;
+  auto copiedSampleViaRawImplPointer = this->sampleViaRawImplPointer;
+
+  this->expectEmpty(copiedDefault);
+  this->expectBorrowsFrom(copiedSample, this->ownedSample);
+  this->expectBorrowsFrom(copiedSampleViaRawImplPointer, this->ownedSample);
+}
+
+TYPED_TEST(BorrowedTest, MoveConstructor) {
+  auto movedDefault = std::move(this->defaultConstructed);
+  auto movedSample = std::move(this->sample);
+  auto movedSampleViaRawImplPointer = this->sampleViaRawImplPointer;
+
+  this->expectEmpty(movedDefault);
+  this->expectBorrowsFrom(movedSample, this->ownedSample);
+  this->expectBorrowsFrom(movedSampleViaRawImplPointer, this->ownedSample);
+}
+
+TYPED_TEST(BorrowedTest, CopyAssignment) {
+  c10::Borrowed<TypeParam> copiedDefault, copiedSample,
+      copiedSampleViaRawImplPointer;
+  copiedDefault = this->defaultConstructed;
+  copiedSample = this->sample;
+  copiedSampleViaRawImplPointer = this->sampleViaRawImplPointer;
+
+  this->expectEmpty(copiedDefault);
+  this->expectBorrowsFrom(copiedSample, this->ownedSample);
+  this->expectBorrowsFrom(copiedSampleViaRawImplPointer, this->ownedSample);
+}
+
+TYPED_TEST(BorrowedTest, MoveAssignment) {
+  c10::Borrowed<TypeParam> movedDefault, movedSample,
+      movedSampleViaRawImplPointer;
+  movedDefault = std::move(this->defaultConstructed);
+  movedSample = std::move(this->sample);
+  movedSampleViaRawImplPointer = this->sampleViaRawImplPointer;
+
+  this->expectEmpty(movedDefault);
+  this->expectBorrowsFrom(movedSample, this->ownedSample);
+  this->expectBorrowsFrom(movedSampleViaRawImplPointer, this->ownedSample);
+}
+
+TYPED_TEST(BorrowedTest, TensorAssignment) {
+  auto copiedDefault = this->defaultConstructed;
+  auto copiedSample = this->sample;
+  auto copiedSampleViaRawImplPointer = this->sampleViaRawImplPointer;
+  for (auto dest :
+       {this->defaultConstructed,
+        this->sample,
+        this->sampleViaRawImplPointer}) {
+    for (auto source :
+         {this->defaultConstructed,
+          this->sample,
+          this->sampleViaRawImplPointer}) {
+      dest = *source;
+      if (source) {
+        this->expectBorrowsFrom(dest, *source);
+      } else {
+        this->expectEmpty(dest);
+      }
+    }
+  }
+}
+
+} // namespace

--- a/c10/util/Borrowed.h
+++ b/c10/util/Borrowed.h
@@ -1,0 +1,82 @@
+#pragma once
+
+namespace c10 {
+
+/// Borrowed<T> is a smart-pointer-like wrapper around a borrowed
+/// instance of some type T that normally has mandatory reference
+/// counting (i.e., Tensor). It provides the following interesting
+/// properties:
+///
+/// - Can vend `const T&` and `const T*`
+/// - Does not require reference count operations to create/destroy/copy (hence
+/// "borrowed")
+/// - Must manually be guaranteed not to outlive the underlying T it was
+/// borrowed from.
+///
+/// You might reasonably ask at this point, "Why do I need this? I
+/// have `const T&` already, which does all these things." Unlike
+/// `const T&`, `Borrowed<T>` can be created without an instance of
+/// `T` handy (for example, from a TensorImpl*), and then it can be used
+/// to manufacture a `const T&` from there.
+///
+/// While it might make sense to unify Borrowed and/or BorrowedTraits
+/// with MaybeOwned and/or MaybeOwnedTraits in the future, I'm keeping
+/// them separate to start because MaybeOwned can work if the borrow
+/// type is something other than T whereas Borrowed is only
+/// interesting because it wraps a real T.
+
+template <typename T>
+struct BorrowedTraits;
+
+template <typename T>
+class Borrowed {
+  using BT = BorrowedTraits<T>;
+  union {
+    char dummy_;
+    typename BT::repr_type repr_;
+  };
+
+ public:
+  Borrowed() : repr_(BT::nullRepr()) {}
+
+  ~Borrowed() {
+    // Skip destruction! We could provide a hook such as
+    // BorrowedTraits::destroyRepr, but currently one is not needed.
+  }
+
+  explicit Borrowed(const T& t) : repr_(BT::copyToRepr(t)) {}
+
+  explicit Borrowed(typename BT::raw_impl_pointer_type p)
+      : repr_(BT::reprFromRawImplPointer(p)) {}
+
+  Borrowed(const Borrowed& rhs) : repr_(BT::copyRepr(rhs.repr_)) {}
+
+  Borrowed& operator=(const Borrowed& rhs) {
+    BT::assignRepr(
+        repr_,
+        rhs.repr_); // NOTE: handling self-assignment is delegated to assignRepr
+    return *this;
+  }
+
+  Borrowed& operator=(const T& rhs) {
+    *this = Borrowed(rhs);
+    return *this;
+  }
+
+  explicit operator bool() const noexcept {
+    return !BT::isNullRepr(repr_);
+  }
+
+  const T& operator*() const {
+    return BT::referenceFromRepr(repr_);
+  };
+
+  const T* operator->() const {
+    return get();
+  }
+
+  const T* get() const {
+    return BT::getImpl(repr_);
+  }
+};
+} // namespace c10

--- a/c10/util/BorrowedTensorTraits.h
+++ b/c10/util/BorrowedTensorTraits.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <c10/core/TensorImpl.h>
+#include <cstring>
+
+namespace c10 {
+// This traits class is very much logically part of the private
+// implementation of TensorBase. It pulls memcpy shenanigans that rely
+// on knowing how TensorBase (and intrusive_ptr) are represented and
+// work. However, the safety of this is guarded with tests that should
+// be running under ASAN.
+template <typename TensorType>
+struct BorrowedTraits {
+  using repr_type = TensorType;
+  using raw_impl_pointer_type = TensorImpl*;
+
+  static TensorType nullRepr() {
+    // intrusive_ptr(std::nullptr_t) sets the internal representation
+    // to NullType::singleton() instead. We want actual nullptr bit
+    // pattern. We will not dereference it or run the
+    // TensorImpl/intrusive_ptr destructor.
+    TensorType t;
+    std::nullptr_t nul = nullptr;
+    static_assert(sizeof(t) == sizeof(nul));
+    std::memcpy(&t, &nul, sizeof(nul));
+    return t;
+  }
+
+  static TensorType copyToRepr(const TensorType& t) {
+    static_assert(sizeof(TensorType) == sizeof(void*));
+    // Blind pointer copy. Cannot use the unsafe_borrow_t constructor
+    // because rhs might be nullptr, which intrusive_ptr::reclaim does
+    // not like.
+    TensorType result;
+    std::memcpy(&result, &t, sizeof(result));
+    return result;
+  }
+
+  static TensorType reprFromRawImplPointer(TensorImpl* p) {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(p != nullptr);
+    return TensorType(
+        c10::intrusive_ptr<TensorImpl, UndefinedTensorImpl>::reclaim(p));
+  }
+
+  static TensorType copyRepr(const TensorType& t) {
+    return copyToRepr(t);
+  }
+
+  static void assignRepr(TensorType& lhs, const TensorType& rhs) {
+    static_assert(sizeof(TensorType) == sizeof(void*));
+    // Blind pointer copy. Cannot use the unsafe_borrow_t constructor
+    // because rhs might be nullptr, which intrusive_ptr::reclaim does
+    // not like.
+    std::memcpy(&lhs, &rhs, sizeof(lhs));
+  }
+
+  static bool isNullRepr(const TensorType& t) {
+    return t.unsafeGetTensorImpl() == nullptr;
+  }
+
+  static const TensorType& referenceFromRepr(const TensorType& t) {
+    return t;
+  }
+
+  static const TensorType* getImpl(const TensorType& t) {
+    return &t;
+  }
+};
+} // namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95418

Yet another ownership-motivated smart pointer. This one is Tensor-specific, at least for now, and should allow us to manufacture `const Tensor&` from `at::TensorImpl*`.

Differential Revision: [D43544927](https://our.internmc.facebook.com/intern/diff/D43544927/)