### PR TITLE
[Dynamo] Fix number of inputs in onnxrt and tvm backend

### DIFF
--- a/torch/_dynamo/backends/onnxrt.py
+++ b/torch/_dynamo/backends/onnxrt.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import os
 import tempfile
 
@@ -23,6 +24,9 @@ try:
 
 except ImportError:
     _np_dtype = None
+
+
+log = logging.getLogger(__name__)
 
 
 def default_provider(device_type):
@@ -78,8 +82,12 @@ def onnxrt(gm, example_inputs, *, filename=None, provider=None):
 
     def _call(*initial_args):
         binding = session.io_binding()
+        active_inputs = set(inp.name for inp in session.get_inputs())
         args = [a.contiguous() for a in initial_args]
         for name, value in zip(input_names, args):
+            if name not in active_inputs:
+                log.warning(f"input {name} skipped as not found in onnx inference session")
+                continue
             dev = value.device
             binding.bind_input(
                 name,

--- a/torch/_dynamo/backends/onnxrt.py
+++ b/torch/_dynamo/backends/onnxrt.py
@@ -82,11 +82,13 @@ def onnxrt(gm, example_inputs, *, filename=None, provider=None):
 
     def _call(*initial_args):
         binding = session.io_binding()
-        active_inputs = set(inp.name for inp in session.get_inputs())
+        active_inputs = {inp.name for inp in session.get_inputs()}
         args = [a.contiguous() for a in initial_args]
         for name, value in zip(input_names, args):
             if name not in active_inputs:
-                log.warning(f"input {name} skipped as not found in onnx inference session")
+                log.warning(
+                    f"input {name} skipped as not found in onnx inference session"
+                )
                 continue
             dev = value.device
             binding.bind_input(

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -124,12 +124,18 @@ def tvm(gm, example_inputs, *, scheduler=None, trials=20000):
 
     def exec_tvm(*i_args):
         args = [a.contiguous() for a in i_args]
+        shape_info, _ = m.get_input_info()
+        active_inputs = set(name for name, _ in shape_info.items())
         for idx, arg in enumerate(args, 0):
             if arg.dim() != 0:
                 if arg.requires_grad:
                     arg = arg.detach()
+                inp_name = f"inp_{idx}"
+                if inp_name not in active_inputs:
+                    log.warning(f"input {inp_name} skipped as not found in tvm's runtime library")
+                    continue
                 m.set_input(
-                    f"inp_{idx}",
+                    inp_name,
                     to_tvm_tensor(arg),
                 )
         m.run()

--- a/torch/_dynamo/backends/tvm.py
+++ b/torch/_dynamo/backends/tvm.py
@@ -125,14 +125,16 @@ def tvm(gm, example_inputs, *, scheduler=None, trials=20000):
     def exec_tvm(*i_args):
         args = [a.contiguous() for a in i_args]
         shape_info, _ = m.get_input_info()
-        active_inputs = set(name for name, _ in shape_info.items())
+        active_inputs = {name for name, _ in shape_info.items()}
         for idx, arg in enumerate(args, 0):
             if arg.dim() != 0:
                 if arg.requires_grad:
                     arg = arg.detach()
                 inp_name = f"inp_{idx}"
                 if inp_name not in active_inputs:
-                    log.warning(f"input {inp_name} skipped as not found in tvm's runtime library")
+                    log.warning(
+                        f"input {inp_name} skipped as not found in tvm's runtime library"
+                    )
                     continue
                 m.set_input(
                     inp_name,


### PR DESCRIPTION
This PR intends to fix #95428 by only binding active inputs to onnxrt's inference session and tvm's runtime lib after model conversion. 

cc: @jansel 
 

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire