### PR TITLE
Apply filter logic to disabled jobs dynamically

### DIFF
--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -28,6 +28,19 @@ outputs:
 runs:
   using: composite
   steps:
+    - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
+      name: Setup dependencies
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      with:
+        shell: bash
+        timeout_minutes: 10
+        max_attempts: 5
+        retry_wait_seconds: 30
+        command: |
+          set -eux
+          python3 -m pip install requests==2.26.0 pyyaml==6.0
+
     - name: Parse ref
       shell: bash
       id: parse-ref

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -54,7 +54,7 @@ runs:
       run: |
         echo "${{ github.workflow }}"
         echo "${{ github.job }}"
-        echo "${{ jobs.*.name }}"
+        echo "${{ jobs.build.name }}"
         echo "${{ github.action }}"
         echo "${{ github.event_name }}"
 

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -77,14 +77,12 @@ runs:
         JOB_NAME: ${{ steps.get-job-name.outputs.job-name }}
       id: filter
       run: |
-        echo "${{ github.workflow }}"
-        echo "${{ github.job }}"
-        echo "${JOB_NAME}"
-        echo "${{ github.action }}"
-        echo "${{ github.run_id }}"
-        echo "${{ github.event_name }}"
+        echo "Workflow: ${GITHUB_WORKFLOW}"
+        echo "Job name: ${JOB_NAME}"
 
         .github/scripts/filter_test_configs.py \
+          --workflow "${GITHUB_WORKFLOW}" \
+          --job-name "${JOB_NAME}" \
           --test-matrix "${{ inputs.test-matrix }}" \
           --pr-number "${{ github.event.pull_request.number }}" \
           --tag "${{ steps.parse-ref.outputs.tag }}" \

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -29,30 +29,37 @@ runs:
   using: composite
   steps:
     - name: Dump GitHub context
+      shell: bash
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
     - name: Dump job context
+      shell: bash
       env:
         JOB_CONTEXT: ${{ toJson(job) }}
       run: echo "$JOB_CONTEXT"
     - name: Dump steps context
+      shell: bash
       env:
         STEPS_CONTEXT: ${{ toJson(steps) }}
       run: echo "$STEPS_CONTEXT"
     - name: Dump runner context
+      shell: bash
       env:
         RUNNER_CONTEXT: ${{ toJson(runner) }}
       run: echo "$RUNNER_CONTEXT"
     - name: Dump strategy context
+      shell: bash
       env:
         STRATEGY_CONTEXT: ${{ toJson(strategy) }}
       run: echo "$STRATEGY_CONTEXT"
     - name: Dump matrix context
+      shell: bash
       env:
         MATRIX_CONTEXT: ${{ toJson(matrix) }}
       run: echo "$MATRIX_CONTEXT"
     - name: Dump env context
+      shell: bash
       env:
         ENV_CONTEXT: ${{ toJson(env) }}
       run: echo "$ENV_CONTEXT"

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -28,6 +28,35 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Dump job context
+      env:
+        JOB_CONTEXT: ${{ toJson(job) }}
+      run: echo "$JOB_CONTEXT"
+    - name: Dump steps context
+      env:
+        STEPS_CONTEXT: ${{ toJson(steps) }}
+      run: echo "$STEPS_CONTEXT"
+    - name: Dump runner context
+      env:
+        RUNNER_CONTEXT: ${{ toJson(runner) }}
+      run: echo "$RUNNER_CONTEXT"
+    - name: Dump strategy context
+      env:
+        STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+      run: echo "$STRATEGY_CONTEXT"
+    - name: Dump matrix context
+      env:
+        MATRIX_CONTEXT: ${{ toJson(matrix) }}
+      run: echo "$MATRIX_CONTEXT"
+    - name: Dump env context
+      env:
+        ENV_CONTEXT: ${{ toJson(env) }}
+      run: echo "$ENV_CONTEXT"
+
     - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
       name: Setup dependencies
       env:
@@ -55,6 +84,7 @@ runs:
         echo "${{ github.workflow }}"
         echo "${{ github.job }}"
         echo "${{ github.action }}"
+        echo "${{ github.run_id }}"
         echo "${{ github.event_name }}"
 
         .github/scripts/filter_test_configs.py \

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -60,7 +60,6 @@ runs:
         ls -la "${{ runner.workspace }}/../_temp/"
         ls -la "${{ runner.workspace }}/../../"
         ls -la "${{ runner.workspace }}/../../../"
-        ls -la "${{ runner.workspace }}/../../../runners/"
         ls -la "${{ runner.workspace }}/../../../work/"
         ls -la "${{ runner.workspace }}/../../../project/"
 

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -53,6 +53,17 @@ runs:
       run: |
         set -x
 
+        # DEBUG: MacOS
+        ls -la "${{ runner.workspace }}/"
+        ls -la "${{ runner.workspace }}/../"
+        ls -la "${{ runner.workspace }}/../_actions/"
+        ls -la "${{ runner.workspace }}/../_temp/"
+        ls -la "${{ runner.workspace }}/../../"
+        ls -la "${{ runner.workspace }}/../../../"
+        ls -la "${{ runner.workspace }}/../../../runners/"
+        ls -la "${{ runner.workspace }}/../../../work/"
+        ls -la "${{ runner.workspace }}/../../../project/"
+
         # TODO: This is a very hacky way to get the job name. GitHub runner has the info
         # but doesn't expose it in anyway. The job name is part of the job message the
         # runner receives, so it's there and printed out to the diag log. Below is the

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -64,6 +64,26 @@ runs:
         ENV_CONTEXT: ${{ toJson(env) }}
       run: echo "$ENV_CONTEXT"
 
+    - name: DEBUG
+      shell: bash
+      run: |
+        set -e
+
+        echo "${{ github.path }}"
+        cat "${{ github.path }}"
+
+        echo "${{ github.env }}"
+        cat "${{ github.env }}"
+
+        echo "${{ github.step_summary }}"
+        cat "${{ github.step_summary }}"
+
+        echo "${{ github.state }}"
+        cat "${{ github.state }}"
+
+        echo "${{ github.output }}"
+        cat "${{ github.output }}"
+
     - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
       name: Setup dependencies
       env:

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -59,9 +59,10 @@ runs:
         ls -la "${{ runner.workspace }}/../_actions/"
         ls -la "${{ runner.workspace }}/../_temp/"
         ls -la "${{ runner.workspace }}/../../"
-        ls -la "${{ runner.workspace }}/../../../"
-        ls -la "${{ runner.workspace }}/../../../work/"
-        ls -la "${{ runner.workspace }}/../../../project/"
+        ls -la "${{ runner.workspace }}/../../runners"
+        ls -la "${{ runner.workspace }}/../../work/"
+        ls -la "${{ runner.workspace }}/../../project/"
+        ls -la "${{ runner.workspace }}/../../target/"
 
         # TODO: This is a very hacky way to get the job name. GitHub runner has the info
         # but doesn't expose it in anyway. The job name is part of the job message the

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -54,15 +54,15 @@ runs:
         set -x
 
         # TODO: This is a very hacky way to get the job name. GitHub runner has the info
-        # but doesn't expose it in any way. The job name is part of the job message the
-        # runner receives though, so it's there and printed out to the diag log. Below
-        # is the code responsible for printing it. Need to check with GitHub to see if
-        # they can expose this variable as part of GitHub context.
+        # but doesn't expose it in anyway. The job name is part of the job message the
+        # runner receives, so it's there and printed out to the diag log. Below is the
+        # code responsible for printing it. Need to check with GitHub to see if they can
+        # expose this variable as part of GitHub context.
         # https://github.com/actions/runner/blob/main/src/Runner.Worker/JobExtension.cs#L345
         pushd "${{ runner.workspace }}/../../_diag"
         pwd
 
-        LOG_FILE=$(grep -l -r "${{ github.sha }}" *.log)
+        LOG_FILE=$(grep -l -r "${{ github.sha }}" *.log | tail -n 1)
         if [ -n "${LOG_FILE}" ]; then
           JOB_NAME=$(grep -r "\"jobDisplayName\"" "${LOG_FILE}" | awk -F '[:,]' '{print $2}' | sed 's/"//g' | xargs)
           echo "job-name=${JOB_NAME}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -54,7 +54,6 @@ runs:
       run: |
         echo "${{ github.workflow }}"
         echo "${{ github.job }}"
-        echo "${{ jobs.build.name }}"
         echo "${{ github.action }}"
         echo "${{ github.event_name }}"
 

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -28,62 +28,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Dump GitHub context
-      shell: bash
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - name: Dump job context
-      shell: bash
-      env:
-        JOB_CONTEXT: ${{ toJson(job) }}
-      run: echo "$JOB_CONTEXT"
-    - name: Dump steps context
-      shell: bash
-      env:
-        STEPS_CONTEXT: ${{ toJson(steps) }}
-      run: echo "$STEPS_CONTEXT"
-    - name: Dump runner context
-      shell: bash
-      env:
-        RUNNER_CONTEXT: ${{ toJson(runner) }}
-      run: echo "$RUNNER_CONTEXT"
-    - name: Dump strategy context
-      shell: bash
-      env:
-        STRATEGY_CONTEXT: ${{ toJson(strategy) }}
-      run: echo "$STRATEGY_CONTEXT"
-    - name: Dump matrix context
-      shell: bash
-      env:
-        MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      run: echo "$MATRIX_CONTEXT"
-    - name: Dump env context
-      shell: bash
-      env:
-        ENV_CONTEXT: ${{ toJson(env) }}
-      run: echo "$ENV_CONTEXT"
-
-    - name: DEBUG
-      shell: bash
-      run: |
-        set -e
-
-        echo "${{ github.path }}"
-        cat "${{ github.path }}"
-
-        echo "${{ github.env }}"
-        cat "${{ github.env }}"
-
-        echo "${{ github.step_summary }}"
-        cat "${{ github.step_summary }}"
-
-        echo "${{ github.state }}"
-        cat "${{ github.state }}"
-
-        echo "${{ github.output }}"
-        cat "${{ github.output }}"
-
     - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
       name: Setup dependencies
       env:
@@ -102,14 +46,40 @@ runs:
       id: parse-ref
       run: .github/scripts/parse_ref.py
 
+    - name: Get the job name
+      id: get-job-name
+      continue-on-error: true
+      shell: bash
+      run: |
+        set -x
+
+        # TODO: This is a very hacky way to get the job name. GitHub runner has the info
+        # but doesn't expose it in any way. The job name is part of the job message the
+        # runner receives though, so it's there and printed out to the diag log. Below
+        # is the code responsible for printing it. Need to check with GitHub to see if
+        # they can expose this variable as part of GitHub context.
+        # https://github.com/actions/runner/blob/main/src/Runner.Worker/JobExtension.cs#L345
+        pushd "${{ runner.workspace }}/../../_diag"
+        pwd
+
+        LOG_FILE=$(grep -l -r "${{ github.sha }}" *.log)
+        if [ -n "${LOG_FILE}" ]; then
+          JOB_NAME=$(grep -r "\"jobDisplayName\"" "${LOG_FILE}" | awk -F '[:,]' '{print $2}' | sed 's/"//g' | xargs)
+          echo "job-name=${JOB_NAME}" >> "${GITHUB_OUTPUT}"
+        fi
+
+        popd
+
     - name: Select all requested test configurations
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        JOB_NAME: ${{ steps.get-job-name.outputs.job-name }}
       id: filter
       run: |
         echo "${{ github.workflow }}"
         echo "${{ github.job }}"
+        echo "${JOB_NAME}"
         echo "${{ github.action }}"
         echo "${{ github.run_id }}"
         echo "${{ github.event_name }}"

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -53,12 +53,6 @@ runs:
       run: |
         set -x
 
-        # DEBUG: MacOS
-        ls "${{ runner.workspace }}/"
-        ls "${{ runner.workspace }}/../"
-        ls "${{ runner.workspace }}/../../"
-        ls "${{ runner.workspace }}/../../../"
-
         # TODO: This is a very hacky way to get the job name. GitHub runner has the info
         # but doesn't expose it in anyway. The job name is part of the job message the
         # runner receives, so it's there and printed out to the diag log. Below is the

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -53,17 +53,6 @@ runs:
       run: |
         set -x
 
-        # DEBUG: MacOS
-        ls -la "${{ runner.workspace }}/"
-        ls -la "${{ runner.workspace }}/../"
-        ls -la "${{ runner.workspace }}/../_actions/"
-        ls -la "${{ runner.workspace }}/../_temp/"
-        ls -la "${{ runner.workspace }}/../../"
-        ls -la "${{ runner.workspace }}/../../runners"
-        ls -la "${{ runner.workspace }}/../../work/"
-        ls -la "${{ runner.workspace }}/../../project/"
-        ls -la "${{ runner.workspace }}/../../target/"
-
         # TODO: This is a very hacky way to get the job name. GitHub runner has the info
         # but doesn't expose it in anyway. The job name is part of the job message the
         # runner receives, so it's there and printed out to the diag log. Below is the

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -28,19 +28,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
-      name: Setup dependencies
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      with:
-        shell: bash
-        timeout_minutes: 10
-        max_attempts: 5
-        retry_wait_seconds: 30
-        command: |
-          set -eux
-          python3 -m pip install requests==2.26.0 pyyaml==6.0
-
     - name: Parse ref
       shell: bash
       id: parse-ref
@@ -52,6 +39,12 @@ runs:
       shell: bash
       run: |
         set -x
+
+        # DEBUG: MacOS
+        ls "${{ runner.workspace }}/"
+        ls "${{ runner.workspace }}/../"
+        ls "${{ runner.workspace }}/../../"
+        ls "${{ runner.workspace }}/../../../"
 
         # TODO: This is a very hacky way to get the job name. GitHub runner has the info
         # but doesn't expose it in anyway. The job name is part of the job message the

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -54,8 +54,9 @@ runs:
       run: |
         echo "${{ github.workflow }}"
         echo "${{ github.job }}"
+        echo "${{ jobs.*.name }}"
+        echo "${{ github.action }}"
         echo "${{ github.event_name }}"
-        echo "${{ github.event.workflow }}"
 
         .github/scripts/filter_test_configs.py \
           --test-matrix "${{ inputs.test-matrix }}" \

--- a/.github/actions/filter-test-configs/action.yml
+++ b/.github/actions/filter-test-configs/action.yml
@@ -52,6 +52,11 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       id: filter
       run: |
+        echo "${{ github.workflow }}"
+        echo "${{ github.job }}"
+        echo "${{ github.event_name }}"
+        echo "${{ github.event.workflow }}"
+
         .github/scripts/filter_test_configs.py \
           --test-matrix "${{ inputs.test-matrix }}" \
           --pr-number "${{ github.event.pull_request.number }}" \

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -1,40 +1,45 @@
 #!/usr/bin/env python3
 
-import sys
-import re
 import json
 import os
-import requests
-from typing import Any, Dict, Set, List
-import yaml
+import re
+import sys
 import warnings
+from typing import Any, Dict, List, Set
+from urllib.request import urlopen
+
+import requests
+import yaml
 
 PREFIX = "test-config/"
 
 # Same as shard names
-VALID_TEST_CONFIG_LABELS = {f"{PREFIX}{label}" for label in {
-    "backwards_compat",
-    "crossref",
-    "default",
-    "deploy",
-    "distributed",
-    "docs_tests",
-    "dynamo",
-    "force_on_cpu",
-    "functorch",
-    "inductor",
-    "inductor_distributed",
-    "inductor_huggingface",
-    "inductor_timm",
-    "inductor_torchbench",
-    "jit_legacy",
-    "multigpu",
-    "nogpu_AVX512",
-    "nogpu_NO_AVX2",
-    "slow",
-    "tsan",
-    "xla",
-}}
+VALID_TEST_CONFIG_LABELS = {
+    f"{PREFIX}{label}"
+    for label in {
+        "backwards_compat",
+        "crossref",
+        "default",
+        "deploy",
+        "distributed",
+        "docs_tests",
+        "dynamo",
+        "force_on_cpu",
+        "functorch",
+        "inductor",
+        "inductor_distributed",
+        "inductor_huggingface",
+        "inductor_timm",
+        "inductor_torchbench",
+        "jit_legacy",
+        "multigpu",
+        "nogpu_AVX512",
+        "nogpu_NO_AVX2",
+        "slow",
+        "tsan",
+        "xla",
+    }
+}
 
 # Supported modes when running periodically
 SUPPORTED_PERIODICAL_MODES = {
@@ -42,15 +47,43 @@ SUPPORTED_PERIODICAL_MODES = {
     "rerun_disabled_tests",
 }
 
+# The link to the published list of disabled jobs
+DISABLED_JOBS_URL = "https://ossci-metrics.s3.amazonaws.com/disabled-jobs.json"
+# Some constants used to remove disabled jobs
+JOB_NAME_SEP = "/"
+BUILD_JOB_NAME = "build"
+TEST_JOB_NAME = "test"
+BUILD_AND_TEST_JOB_NAME = "build-and-test"
+JOB_NAME_CFG_REGEX = re.compile(r"(?P<job>[\w-]+)\s+\((?P<cfg>[\w-]+)\)")
+
 
 def parse_args() -> Any:
     from argparse import ArgumentParser
-    parser = ArgumentParser("Filter all test configurations and keep only requested ones")
-    parser.add_argument("--test-matrix", type=str, required=True, help="the original test matrix")
+
+    parser = ArgumentParser(
+        "Filter all test configurations and keep only requested ones"
+    )
+    parser.add_argument(
+        "--test-matrix", type=str, required=True, help="the original test matrix"
+    )
+    parser.add_argument(
+        "--workflow", type=str, help="the name of the current workflow, i.e. pull"
+    )
+    parser.add_argument(
+        "--job-name",
+        type=str,
+        help="the name of the current job, i.e. linux-focal-py3.8-gcc7 / build",
+    )
     parser.add_argument("--pr-number", type=str, help="the pull request number")
     parser.add_argument("--tag", type=str, help="the associated tag if it exists")
-    parser.add_argument("--event-name", type=str, help="name of the event that triggered the job (pull, schedule, etc)")
-    parser.add_argument("--schedule", type=str, help="cron schedule that triggered the job")
+    parser.add_argument(
+        "--event-name",
+        type=str,
+        help="name of the event that triggered the job (pull, schedule, etc)",
+    )
+    parser.add_argument(
+        "--schedule", type=str, help="cron schedule that triggered the job"
+    )
     return parser.parse_args()
 
 
@@ -74,7 +107,9 @@ def get_labels(pr_number: int) -> Set[str]:
     )
 
     if response.status_code != requests.codes.ok:
-        warnings.warn(f"Failed to get the labels for #{pr_number} (status code {response.status_code})")
+        warnings.warn(
+            f"Failed to get the labels for #{pr_number} (status code {response.status_code})"
+        )
         return set()
 
     return {label.get("name") for label in response.json() if label.get("name")}
@@ -93,9 +128,7 @@ def filter(test_matrix: Dict[str, List[Any]], labels: Set[str]) -> Dict[str, Lis
     If the PR has none of the test-config label, all tests are run as usual.
     """
 
-    filtered_test_matrix: Dict[str, List[Any]] = {
-        "include": []
-    }
+    filtered_test_matrix: Dict[str, List[Any]] = {"include": []}
 
     for entry in test_matrix.get("include", []):
         config_name = entry.get("config", "")
@@ -104,7 +137,9 @@ def filter(test_matrix: Dict[str, List[Any]], labels: Set[str]) -> Dict[str, Lis
 
         label = f"{PREFIX}{config_name.strip()}"
         if label in labels:
-            print(f"Select {config_name} because label {label} is presented in the pull request by the time the test starts")
+            print(
+                f"Select {config_name} because label {label} is presented in the pull request by the time the test starts"
+            )
             filtered_test_matrix["include"].append(entry)
 
     valid_test_config_labels = labels.intersection(VALID_TEST_CONFIG_LABELS)
@@ -134,6 +169,133 @@ def set_periodic_modes(test_matrix: Dict[str, List[Any]]) -> Dict[str, List[Any]
             scheduled_test_matrix["include"].append(cfg)
 
     return scheduled_test_matrix
+
+
+def remove_disabled_jobs(
+    workflow: str, job_name: str, test_matrix: Dict[str, List[Any]]
+) -> Dict[str, List[Any]]:
+    """
+    Check the list of disabled jobs, remove the current job and all its dependents
+    if it exists in the list. The list of disabled jobs is as follows:
+
+    {
+        "WORKFLOW / PLATFORM / JOB (CONFIG)": [
+            AUTHOR,
+            ISSUE_NUMBER,
+            ISSUE_URL,
+            WORKFLOW,
+            PLATFORM,
+            JOB (CONFIG),
+        ],
+        "pull / linux-bionic-py3.8-clang9 / test (dynamo)": [
+            "pytorchbot",
+            "94861",
+            "https://github.com/pytorch/pytorch/issues/94861",
+            "pull",
+            "linux-bionic-py3.8-clang9",
+            "test (dynamo)",
+        ],
+    }
+    """
+    try:
+        # The job name from github is in the PLATFORM / JOB (CONFIG) format, so breaking
+        # it into its two components first
+        current_platform, _ = [n.strip() for n in job_name.split(JOB_NAME_SEP, 1) if n]
+    except ValueError as error:
+        warnings.warn(f"Invalid job name {job_name}, returning")
+        return test_matrix
+
+    # The result will be stored here
+    filtered_test_matrix: Dict[str, List[Any]] = {"include": []}
+
+    for _, record in download_json(DISABLED_JOBS_URL).items():
+        (
+            author,
+            _,
+            disabled_url,
+            disabled_workflow,
+            disabled_platform,
+            disabled_job_cfg,
+        ) = record
+
+        if disabled_workflow != workflow or disabled_platform != current_platform:
+            # The current workflow or platform is not disabled by this record
+            continue
+
+        # The logic after this is fairly complicated:
+        #
+        # - If the disabled record doesn't have the optional job (config) name,
+        #   i.e. pull / linux-bionic-py3.8-clang9, all build and test jobs will
+        #   be skipped
+        #
+        # - If the disabled record has the job name and it's a build job, i.e.
+        #   pull / linux-bionic-py3.8-clang9 / build, all build and test jobs
+        #   will be skipped, because the latter requires the former
+        #
+        # - If the disabled record has the job name and it's a test job without
+        #   the config part, i.e. pull / linux-bionic-py3.8-clang9 / test, all
+        #   test jobs will be skipped. TODO: At the moment, the script uses the
+        #   short-circuiting logic to skip the build job automatically when there
+        #   is no test job assuming that it would be a waste of effort building
+        #   for nothing. This might not be the desirable behavior, and could be
+        #   fixed later if needed
+        #
+        # - If the disabled record has the job (config) name, only that test config
+        #   will be skipped, i.e. pull / linux-bionic-py3.8-clang9 / test (dynamo)
+        if not disabled_job_cfg:
+            print(
+                f"Issue {disabled_url} created by {author} has disabled all CI jobs for {workflow} / {job_name}"
+            )
+            return filtered_test_matrix
+
+        if disabled_job_cfg == BUILD_JOB_NAME:
+            print(
+                f"Issue {disabled_url} created by {author} has disabled the build job for {workflow} / {job_name}"
+            )
+            return filtered_test_matrix
+
+        if (
+            disabled_job_cfg == TEST_JOB_NAME
+            or disabled_job_cfg == BUILD_AND_TEST_JOB_NAME
+        ):
+            print(
+                f"Issue {disabled_url} created by {author} has disabled all the test jobs for {workflow} / {job_name}"
+            )
+            return filtered_test_matrix
+
+        m = JOB_NAME_CFG_REGEX.match(disabled_job_cfg)
+        if m:
+            disabled_job = m.group("job")
+            # Make sure that the job name is a valid test job name first before checking the config
+            if disabled_job == TEST_JOB_NAME or disabled_job == BUILD_AND_TEST_JOB_NAME:
+                disabled_cfg = m.group("cfg")
+                # Remove the disabled config from the test matrix
+                filtered_test_matrix["include"] = [
+                    r
+                    for r in test_matrix["include"]
+                    if r.get("config", "") != disabled_cfg
+                ]
+                return filtered_test_matrix
+
+        warnings.warn(
+            f"Found a matching disabled issue {disabled_url} for {workflow} / {job_name}, "
+            f"but the name {disabled_job_cfg} is invalid"
+        )
+
+    # Found no matching disabled issue, return the same input test matrix
+    return test_matrix
+
+
+def download_json(url: str, num_retries: int = 3) -> Any:
+    for _ in range(num_retries):
+        try:
+            content = urlopen(url, timeout=5).read().decode("utf-8")
+            return json.loads(content)
+        except Exception as e:
+            warnings.warn(f"Could not download {url}: {e}")
+
+    warnings.warn(f"All {num_retries} retries exhausted, downloading {url} failed")
+    return {}
 
 
 def set_output(name: str, val: Any) -> None:
@@ -190,10 +352,17 @@ def main() -> None:
         # No PR number, no tag, we can just return the test matrix as it is
         filtered_test_matrix = test_matrix
 
-    if args.event_name == "schedule" and args.schedule == '29 8 * * *':
+    if args.event_name == "schedule" and args.schedule == "29 8 * * *":
         # we don't want to run the mem leack check or disabled tests on normal
         # periodically scheduled jobs, only the ones at this time
         filtered_test_matrix = set_periodic_modes(filtered_test_matrix)
+
+    if args.workflow and args.job_name:
+        # If both workflow and job name are available, we will check if the current job
+        # is disabled and remove it and all its dependants from the test matrix
+        filtered_test_matrix = remove_disabled_jobs(
+            args.workflow, args.job_name, filtered_test_matrix
+        )
 
     # Set the filtered test matrix as the output
     set_output("test-matrix", json.dumps(filtered_test_matrix))

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -1,20 +1,90 @@
 #!/usr/bin/env python3
 
-import os
-import yaml
 import json
-from unittest import TestCase, main, mock
-from filter_test_configs import (
-    get_labels,
-    filter,
-    set_periodic_modes,
-    PREFIX,
-    VALID_TEST_CONFIG_LABELS,
-    SUPPORTED_PERIODICAL_MODES
-)
-import requests
-from requests.models import Response
+import os
 from typing import Any, Dict
+from unittest import main, mock, TestCase
+
+import requests
+import yaml
+from filter_test_configs import (
+    filter,
+    get_labels,
+    PREFIX,
+    remove_disabled_jobs,
+    set_periodic_modes,
+    SUPPORTED_PERIODICAL_MODES,
+    VALID_TEST_CONFIG_LABELS,
+)
+from requests.models import Response
+
+
+MOCKED_DISABLED_JOBS = {
+    "pull / mock-platform-1": [
+        "pytorchbot",
+        "1",
+        "https://github.com/pytorch/pytorch/issues/1",
+        "pull",
+        "mock-platform-1",
+        "",
+    ],
+    "trunk / mock-platform-2 / build": [
+        "pytorchbot",
+        "2",
+        "https://github.com/pytorch/pytorch/issues/2",
+        "trunk",
+        "mock-platform-2",
+        "build",
+    ],
+    "periodic / mock-platform-3 / test": [
+        "pytorchbot",
+        "3",
+        "https://github.com/pytorch/pytorch/issues/3",
+        "periodic",
+        "mock-platform-3",
+        "test",
+    ],
+    "pull / mock-platform-4 / build-and-test": [
+        "pytorchbot",
+        "4",
+        "https://github.com/pytorch/pytorch/issues/4",
+        "pull",
+        "mock-platform-4",
+        "build-and-test",
+    ],
+    "trunk / mock-platform-5 / test (backward_compat)": [
+        "pytorchbot",
+        "5",
+        "https://github.com/pytorch/pytorch/issues/5",
+        "trunk",
+        "mock-platform-5",
+        "test (backward_compat)",
+    ],
+    "periodic / mock-platform-6 / build-and-test (default)": [
+        "pytorchbot",
+        "6",
+        "https://github.com/pytorch/pytorch/issues/6",
+        "periodic",
+        "mock-platform-6",
+        "build-and-test (default)",
+    ],
+    "pull / mock-platform-7 / test [invalid syntax]": [
+        "pytorchbot",
+        "7",
+        "https://github.com/pytorch/pytorch/issues/7",
+        "pull",
+        "mock-platform-7",
+        "test [invalid syntax]",
+    ],
+    "trunk / mock-platform-8 / build (dynamo)": [
+        "pytorchbot",
+        "8",
+        "https://github.com/pytorch/pytorch/issues/8",
+        "trunk",
+        "mock-platform-8",
+        "build (dynamo)",
+    ],
+}
 
 
 def mocked_gh_get_labels_failed(url: str, headers: Dict[str, str]) -> Response:
@@ -31,7 +101,6 @@ def mocked_gh_get_labels(url: str, headers: Dict[str, str]) -> Response:
 
 
 class TestConfigFilter(TestCase):
-
     def setUp(self) -> None:
         os.environ["GITHUB_TOKEN"] = "GITHUB_TOKEN"
         if os.getenv("GITHUB_OUTPUT"):
@@ -42,7 +111,9 @@ class TestConfigFilter(TestCase):
         labels = get_labels(pr_number=12345)
         self.assertSetEqual({"foo", "bar"}, labels)
 
-    @mock.patch("filter_test_configs.requests.get", side_effect=mocked_gh_get_labels_failed)
+    @mock.patch(
+        "filter_test_configs.requests.get", side_effect=mocked_gh_get_labels_failed
+    )
     def test_get_labels_failed(self, mocked_gh: Any) -> None:
         labels = get_labels(pr_number=54321)
         self.assertFalse(labels)
@@ -68,7 +139,9 @@ class TestConfigFilter(TestCase):
         ]
 
         for case in testcases:
-            filtered_test_matrix = filter(yaml.safe_load(case["test_matrix"]), mocked_labels)
+            filtered_test_matrix = filter(
+                yaml.safe_load(case["test_matrix"]), mocked_labels
+            )
             self.assertEqual(case["expected"], json.dumps(filtered_test_matrix))
 
     def test_filter_with_valid_label(self) -> None:
@@ -89,9 +162,10 @@ class TestConfigFilter(TestCase):
         ]
 
         for case in testcases:
-            filtered_test_matrix = filter(yaml.safe_load(case["test_matrix"]), mocked_labels)
+            filtered_test_matrix = filter(
+                yaml.safe_load(case["test_matrix"]), mocked_labels
+            )
             self.assertEqual(case["expected"], json.dumps(filtered_test_matrix))
-
 
     def test_set_periodic_modes(self) -> None:
         testcases = [
@@ -110,9 +184,101 @@ class TestConfigFilter(TestCase):
             scheduled_test_matrix = set_periodic_modes(test_matrix)
             self.assertEqual(
                 len(test_matrix["include"]) * len(SUPPORTED_PERIODICAL_MODES),
-                len(scheduled_test_matrix["include"])
+                len(scheduled_test_matrix["include"]),
             )
 
+    @mock.patch("filter_test_configs.download_json")
+    def test_remove_disabled_jobs(self, mock_download_json: Any) -> None:
+        mock_download_json.return_value = MOCKED_DISABLED_JOBS
 
-if __name__ == '__main__':
+        testcases = [
+            {
+                "workflow": "pull",
+                "job_name": "invalid job name",
+                "test_matrix": '{include: [{config: "default"}]}',
+                "expected": '{"include": [{"config": "default"}]}',
+                "description": "invalid job name",
+            },
+            {
+                "workflow": "pull",
+                "job_name": "mock-platform-1 / build",
+                "test_matrix": '{include: [{config: "default"}]}',
+                "expected": '{"include": []}',
+                "description": "disable build and test jobs",
+            },
+            {
+                "workflow": "trunk",
+                "job_name": "mock-platform-2 / build",
+                "test_matrix": '{include: [{config: "default"}]}',
+                "expected": '{"include": []}',
+                "description": "disable build job",
+            },
+            {
+                "workflow": "periodic",
+                "job_name": "mock-platform-3 / test",
+                "test_matrix": '{include: [{config: "default"}]}',
+                "expected": '{"include": []}',
+                "description": "disable test job",
+            },
+            {
+                "workflow": "pull",
+                "job_name": "mock-platform-4 / build-and-test",
+                "test_matrix": '{include: [{config: "default"}]}',
+                "expected": '{"include": []}',
+                "description": "disable build-and-test job",
+            },
+            {
+                "workflow": "trunk",
+                "job_name": "mock-platform-5 / test",
+                "test_matrix": '{include: [{config: "default", runner: "linux"}, {config: "backward_compat"}]}',
+                "expected": '{"include": [{"config": "default", "runner": "linux"}]}',
+                "description": "disable a test config",
+            },
+            {
+                "workflow": "periodic",
+                "job_name": "mock-platform-6 / build-and-test",
+                "test_matrix": '{include: [{config: "default", runner: "linux"}, {config: "backward_compat"}]}',
+                "expected": '{"include": [{"config": "backward_compat"}]}',
+                "description": "disable a build-and-test config",
+            },
+            {
+                "workflow": "pull",
+                "job_name": "mock-platform-7 / test",
+                "test_matrix": '{include: [{config: "default"}, {config: "backward_compat"}]}',
+                "expected": '{"include": [{"config": "default"}, {"config": "backward_compat"}]}',
+                "description": "include an invalid job name in the disabled issue",
+            },
+            {
+                "workflow": "trunk",
+                "job_name": "mock-platform-8 / build",
+                "test_matrix": '{include: [{config: "default"}, {config: "backward_compat"}]}',
+                "expected": '{"include": [{"config": "default"}, {"config": "backward_compat"}]}',
+                "description": "include an invalid combination of build and test config",
+            },
+            {
+                "workflow": "inductor",
+                "job_name": "mock-platform-8 / build",
+                "test_matrix": '{include: [{config: "default"}, {config: "backward_compat"}]}',
+                "expected": '{"include": [{"config": "default"}, {"config": "backward_compat"}]}',
+                "description": "not disabled on this workflow",
+            },
+            {
+                "workflow": "pull",
+                "job_name": "mock-platform-9 / build",
+                "test_matrix": '{include: [{config: "default"}, {config: "backward_compat"}]}',
+                "expected": '{"include": [{"config": "default"}, {"config": "backward_compat"}]}',
+                "description": "not disabled on this platform",
+            },
+        ]
+
+        for case in testcases:
+            workflow = case["workflow"]
+            job_name = case["job_name"]
+            test_matrix = yaml.safe_load(case["test_matrix"])
+
+            filtered_test_matrix = remove_disabled_jobs(workflow, job_name, test_matrix)
+            self.assertEqual(case["expected"], json.dumps(filtered_test_matrix))
+
+
+if __name__ == "__main__":
     main()

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -66,6 +66,11 @@ jobs:
     outputs:
       docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
     steps:
+      - name: DEBUG
+        run: |
+          echo "${{ jobs.build.name }}"
+          echo "${{ jobs.*.name }}"
+
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
         with:

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -66,11 +66,6 @@ jobs:
     outputs:
       docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
     steps:
-      - name: DEBUG
-        run: |
-          echo "${{ jobs.build.name }}"
-          echo "${{ jobs.*.name }}"
-
       - name: Setup SSH (Click me for login details)
         uses: pytorch/test-infra/.github/actions/setup-ssh@main
         with:


### PR DESCRIPTION
Apply filter logic to disabled jobs dynamically.  The list of disabled jobs is published at https://ossci-metrics.s3.amazonaws.com/disabled-jobs.json.  When the workflow (i.e. `pull`) and the platform (i.e. `linux-bionic-py3.8-clang9`) names match, job will be disabled (skipped) if they are in the list.

Note that getting the current job name within the GitHub action is fairly hacky.  This is a TODO item.

### Testing

* Unit testing
* This PR. https://github.com/pytorch/pytorch/issues/94861 disables `pull / linux-bionic-py3.8-clang9 / test (dynamo)` in the CI.  We have:
   * No dynamo tests running in `pull / linux-bionic-py3.8-clang9` https://github.com/pytorch/pytorch/actions/runs/4272505289/jobs/7437706181
   * Other dynamo tests, i.e. `pull / linux-bionic-py3.11-clang9`, are run normally https://github.com/pytorch/pytorch/actions/runs/4272505289/jobs/7437706054
 * This PR. https://github.com/pytorch/pytorch/issues/95642 disables `pull / linux-bionic-cuda11.7-py3.10-gcc7-sm86 / test`.  All test jobs for `pull / linux-bionic-cuda11.7-py3.10-gcc7-sm86` are skipped https://github.com/pytorch/pytorch/actions/runs/4287330986/jobs/7468179694
 * This PR. https://github.com/pytorch/pytorch/issues/95656 disables `pull / linux-bionic-py3_8-clang8-xla / build`.  All build and test jobs for `pull / linux-bionic-py3_8-clang8-xla` are skipped https://github.com/pytorch/pytorch/actions/runs/4287330986/jobs/7470478905