### PR TITLE
fix for debug crash build

### DIFF
--- a/c10/core/impl/PyInterpreter.cpp
+++ b/c10/core/impl/PyInterpreter.cpp
@@ -99,10 +99,9 @@ struct NoopPyInterpreterVTable final : public PyInterpreterVTable {
 
 // Construct this in Global scope instead of within `disarm`
 // where it will be only initialized first time `disarm` is called.
-// This decreases the likelihood that other object which holds
-// reference to `noop_vtable` (and tries to do something with `noop_vtable`)
-// goes out of scope first.
-//
+// This increases the likelihood `noop_vtable` lives longer than
+// any object that refers to it.
+
 // If `noop_vtable` goes out of scope first, other objects will have dangling
 // reference to it.
 static NoopPyInterpreterVTable noop_vtable;

--- a/c10/core/impl/PyInterpreter.cpp
+++ b/c10/core/impl/PyInterpreter.cpp
@@ -97,9 +97,17 @@ struct NoopPyInterpreterVTable final : public PyInterpreterVTable {
   };
 };
 
+// Construct this in Global scope instead of within `disarm`
+// where it will be only initialized first time `disarm` is called.
+// This decreases the likelihood that other object which holds
+// reference to `noop_vtable` (and tries to do something with `noop_vtable`)
+// goes out of scope first.
+//
+// If `noop_vtable` goes out of scope first, other objects will have dangling
+// reference to it.
+static NoopPyInterpreterVTable noop_vtable;
+
 void PyInterpreter::disarm() noexcept {
-  // Intentionally leaked
-  static NoopPyInterpreterVTable noop_vtable;
   vtable_ = &noop_vtable;
 }
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/94376

⚠️ Hacky fix 

Details about use of `noop_vtable`:
https://github.com/pytorch/pytorch/blob/d677432b706904f84b08bfee5d8bec7c4e220894/c10/core/impl/PyInterpreter.h#L92-L102


Currently, at destruction, `noop_vtable` goes out of scope first while there are dangling references to the object still present with other objects like `PythonKernelHolder` which is held by the singleton `Dispatcher`.
