### PR TITLE
[FSDP] Save `_all_handles`; `_all_fsdp_states` to root

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -61,25 +61,10 @@ class _FSDPState(_State):
             nn.Module, flat_param_file.FlatParamHandle
         ] = {}
         self.compute_device = torch.device("cuda", torch.cuda.current_device())
-
-
-class _RootFSDPState(_FSDPState):
-    """
-    This class shows the attributes defined only for the root FSDP state (i.e.
-    ones with ``_is_root=True``.) We do not instantiate this class. Instead, we
-    may use the idiom ``state = cast(_RootFSDPState, state)``, where ``state``
-    is an ``_FSDPState`` instance, for improved type checking.
-
-    TODO: Since most FSDP functions have the ``@no_type_check`` decorator, this
-    separation may not have much effect until we remove those.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
+        # All following attributes should only be used for root states:
         # Save these static lists to avoid the repeated tree traversals
         self._all_fsdp_states: List[_FSDPState] = []
         self._all_handles: List[flat_param_file.FlatParamHandle] = []
-        raise AssertionError(f"{self.__class__} is not meant to be instantiated")
 
 
 def _get_module_fsdp_state(module: nn.Module) -> Optional[_FSDPState]:

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -57,12 +57,29 @@ class _FSDPState(_State):
         self._optim_state_dict_config: OptimStateDictConfig = FullOptimStateDictConfig()
         self._is_root: Optional[bool] = None
         self._handles: List[flat_param_file.FlatParamHandle] = []
-        # All FSDP states in the root's tree for the root; `None` for non-root
-        self._fsdp_states: Optional[_FSDPState] = None
         self._fully_sharded_module_to_handles: Dict[
             nn.Module, flat_param_file.FlatParamHandle
         ] = {}
         self.compute_device = torch.device("cuda", torch.cuda.current_device())
+
+
+class _RootFSDPState(_FSDPState):
+    """
+    This class shows the attributes defined only for the root FSDP state (i.e.
+    ones with ``_is_root=True``.) We do not instantiate this class. Instead, we
+    may use the idiom ``root_state = cast(_RootFSDPState, state)``, where
+    ``state`` is an ``_FSDPState`` instance, for improved type checking.
+
+    TODO: Since most FSDP functions have the ``@no_type_check`` decorator, this
+    separation may not have much effect until we remove those.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Save these static lists to avoid the repeated tree traversals
+        self._all_fsdp_states: List[_FSDPState] = []
+        self._all_handles: List[flat_param_file.FlatParamHandle] = []
+        raise AssertionError(f"{self.__class__} is not meant to be instantiated")
 
 
 def _get_module_fsdp_state(module: nn.Module) -> Optional[_FSDPState]:

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -67,8 +67,8 @@ class _RootFSDPState(_FSDPState):
     """
     This class shows the attributes defined only for the root FSDP state (i.e.
     ones with ``_is_root=True``.) We do not instantiate this class. Instead, we
-    may use the idiom ``root_state = cast(_RootFSDPState, state)``, where
-    ``state`` is an ``_FSDPState`` instance, for improved type checking.
+    may use the idiom ``state = cast(_RootFSDPState, state)``, where ``state``
+    is an ``_FSDPState`` instance, for improved type checking.
 
     TODO: Since most FSDP functions have the ``@no_type_check`` decorator, this
     separation may not have much effect until we remove those.

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -218,7 +218,7 @@ def _share_state_and_init_handle_attrs(
     for attr_name in HOMOGENEOUS_ATTR_NAMES:
         attr_name_to_values[attr_name] = set()
     root_state._all_fsdp_states = traversal_utils._get_fsdp_states(root_module)
-    root_state._all_handles = root_state._exec_order_data.all_handles
+    root_state._all_handles = root_state._exec_order_data.all_handles  # share reference
     for fsdp_state in root_state._all_fsdp_states:
         for attr_name in HOMOGENEOUS_ATTR_NAMES:
             _p_assert(

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -2,7 +2,6 @@ import functools
 from typing import (
     Any,
     Callable,
-    cast,
     Dict,
     Iterable,
     List,
@@ -24,7 +23,6 @@ from torch.distributed.fsdp._common_utils import (
     _get_module_fsdp_state,
     _get_sharding_strategy,
     _is_composable,
-    _RootFSDPState,
     TrainingState,
 )
 from torch.distributed.fsdp._init_utils import HYBRID_SHARDING_STRATEGIES
@@ -203,7 +201,7 @@ def _check_flat_params_on_expected_device(state: _FSDPState, module: nn.Module):
 
 @no_type_check
 def _share_state_and_init_handle_attrs(
-    root_state: _RootFSDPState,
+    root_state: _FSDPState,
     root_module: nn.Module,
 ) -> None:
     """
@@ -521,7 +519,6 @@ def _root_pre_forward(
     _p_assert(state._is_root is not None, "Expects a root FSDP to have been set")
     if not state._is_root:
         return args, kwargs
-    state = cast(_RootFSDPState, state)
     if state.forward_prefetch:
         handles_keys = []
         for fsdp_state in state._all_fsdp_states:
@@ -614,7 +611,6 @@ def _pre_backward_hook(
         # after all backward calls complete
         if state._is_root and not state._post_backward_callback_queued:
             _register_post_backward_final_callback(state, module)
-            state = cast(_RootFSDPState, state)
             _clear_grads_if_needed(state._all_handles)
         elif _handles_key:
             allowed_states = [TrainingState.IDLE]

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, cast, Dict, Iterator, no_type_check, Tuple
 import torch
 import torch.distributed as dist
 import torch.distributed.algorithms._checkpoint.checkpoint_wrapper as checkpoint_wrapper
-import torch.distributed.fsdp._traversal_utils as traversal_utils
 
 import torch.nn as nn
 import torch.nn.functional as F
@@ -21,6 +20,7 @@ from torch.distributed.fsdp._common_utils import (
     _has_fsdp_params,
     _is_composable,
     _module_handles,
+    _RootFSDPState,
     clean_tensor_name,
     FSDP_PREFIX,
     FSDP_WRAPPED_MODULE,
@@ -127,7 +127,8 @@ def _common_pre_state_dict_hook(
     _lazy_init(fsdp_state, module)
     # TODO: change to this call after pre_state_dict_hook is in `nn.Module`.
     if fsdp_state._is_root:
-        _clear_grads_if_needed(traversal_utils._get_fsdp_handles(module))
+        fsdp_state = cast(_RootFSDPState, fsdp_state)
+        _clear_grads_if_needed(fsdp_state._all_handles)
 
 
 def _common_unshard_pre_state_dict_hook(

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -20,7 +20,6 @@ from torch.distributed.fsdp._common_utils import (
     _has_fsdp_params,
     _is_composable,
     _module_handles,
-    _RootFSDPState,
     clean_tensor_name,
     FSDP_PREFIX,
     FSDP_WRAPPED_MODULE,
@@ -127,7 +126,6 @@ def _common_pre_state_dict_hook(
     _lazy_init(fsdp_state, module)
     # TODO: change to this call after pre_state_dict_hook is in `nn.Module`.
     if fsdp_state._is_root:
-        fsdp_state = cast(_RootFSDPState, fsdp_state)
         _clear_grads_if_needed(fsdp_state._all_handles)
 
 

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1003,8 +1003,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         # If every FSDP instance uses `NO_SHARD`, then we can directly use
         # the normal `nn.utils` one targeting local gradients
         all_no_shard = all(
-            not handle.uses_sharded_strategy
-            for handle in traversal_utils._get_fsdp_handles(self)
+            not handle.uses_sharded_strategy for handle in self._all_handles
         )
         if all_no_shard:
             return torch.nn.utils.clip_grad_norm_(
@@ -1017,7 +1016,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         sharded_params = set()
         nonsharded_params = set()  # `NO_SHARD` or not FSDP-managed
         grads: List[torch.Tensor] = []
-        for handle in traversal_utils._get_fsdp_handles(self):
+        for handle in self._all_handles:
             target_set = (
                 sharded_params if handle.uses_sharded_strategy else nonsharded_params
             )

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -9,7 +9,6 @@ from enum import auto, Enum
 from typing import (
     Any,
     Callable,
-    cast,
     Dict,
     Generator,
     Iterable,
@@ -32,7 +31,6 @@ from torch.distributed.algorithms._comm_hooks import LOW_PRECISION_HOOKS
 from torch.distributed.fsdp._common_utils import (
     _FSDPState,
     _get_param_to_fqns,
-    _RootFSDPState,
     FSDP_PREFIX,
     FSDP_WRAPPED_MODULE,
     TrainingState,
@@ -1001,7 +999,6 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             raise RuntimeError(
                 "`clip_grad_norm_()` should only be called on the root FSDP instance"
             )
-        self = cast(_RootFSDPState, self)
         self._assert_state(TrainingState.IDLE)
         # If every FSDP instance uses `NO_SHARD`, then we can directly use
         # the normal `nn.utils` one targeting local gradients

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -9,6 +9,7 @@ from enum import auto, Enum
 from typing import (
     Any,
     Callable,
+    cast,
     Dict,
     Generator,
     Iterable,
@@ -31,6 +32,7 @@ from torch.distributed.algorithms._comm_hooks import LOW_PRECISION_HOOKS
 from torch.distributed.fsdp._common_utils import (
     _FSDPState,
     _get_param_to_fqns,
+    _RootFSDPState,
     FSDP_PREFIX,
     FSDP_WRAPPED_MODULE,
     TrainingState,
@@ -999,6 +1001,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             raise RuntimeError(
                 "`clip_grad_norm_()` should only be called on the root FSDP instance"
             )
+        self = cast(_RootFSDPState, self)
         self._assert_state(TrainingState.IDLE)
         # If every FSDP instance uses `NO_SHARD`, then we can directly use
         # the normal `nn.utils` one targeting local gradients


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #95507 [FSDP] Expose private prefetch limit setters
* **#95465 [FSDP] Save `_all_handles`; `_all_fsdp_states` to root**
* #95343 [FSDP] Save `_fsdp_states` on root

- The previous PR addressed one tree traversal in `_root_pre_forward()` but not the main one from `_get_fsdp_handles()` that runs for all settings.
- This PR saves `_all_handles` to cache `_get_fsdp_handles()` and `_all_fsdp_states` to cache `_get_fsdp_states()` (renamed from `_fsdp_states` compared to last PR) on the root state.
- This PR introduces a dummy `_RootFSDPState` class that inherits from `_FSDPState` to be used only for type checking since some attributes are only defined for root states.
    - I found this approach to be better than adding `_p_assert(state.root_only_attr is not None, ...)` upon each usage of `root_only_attr`.
    - This hopefully also helps readers to quickly see which attributes are defined only on root states.