### PR TITLE
[FSDP] Move `_post_backward_callback_queued` to `_RootFSDPState`

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -79,6 +79,7 @@ class _RootFSDPState(_FSDPState):
         # Save these static lists to avoid the repeated tree traversals
         self._all_fsdp_states: List[_FSDPState] = []
         self._all_handles: List[flat_param_file.FlatParamHandle] = []
+        self._post_backward_callback_queued = False
         raise AssertionError(f"{self.__class__} is not meant to be instantiated")
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#95466 [FSDP] Move `_post_backward_callback_queued` to `_RootFSDPState`**
* #95465 [FSDP] Save `_all_handles`; `_all_fsdp_states` to root
* #95343 [FSDP] Save `_fsdp_states` on root

This is a follow-up to move `_post_backward_callback_queued` to `_RootFSDPState`. The attribute does not exist for non-root states.