### PR TITLE
Move multi-line wrap functions to helper

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -6,7 +6,7 @@ import inspect
 import operator
 import re
 import types
-from typing import Any, Optional, Union
+from typing import Any, NamedTuple, Optional, Union
 
 import torch
 
@@ -237,50 +237,11 @@ class VariableBuilder:
         if istensor(value):
             return self.wrap_tensor(value)
         elif istype(value, (tuple, list, odict_values)) or is_namedtuple(value):
-            # One can index a tensor with a list/tuple. Therefore, we need to
-            # have a stricter match.
-            if istype(value, (tuple, list)) and all(
-                [isinstance(x, int) or is_numpy_int_type(x) or x is None for x in value]
-            ):
-                guards = self.make_guards(GuardBuilder.EQUALS_MATCH)
-            else:
-                guards = self.make_guards(GuardBuilder.LIST_LENGTH)
-            output = [
-                VariableBuilder(self.tx, GetItemSource(self.get_source(), i))(
-                    item
-                ).add_guards(guards)
-                for i, item in enumerate(value)
-            ]
-            result = self.list_type(value)(output, guards=guards)
-            if istype(value, list):
-                return self.tx.output.side_effects.track_list(
-                    self.source, value, result
-                )
-            return result
+            return self.wrap_listlike(value)
         elif istype(value, tuple_iterator):
-            guards = self.make_guards(GuardBuilder.TUPLE_ITERATOR_LEN)
-            output = [
-                VariableBuilder(
-                    self.tx, TupleIteratorGetItemSource(self.get_source(), i)
-                )(tuple_iterator_getitem(value, i)).add_guards(guards)
-                for i in range(tuple_iterator_len(value))
-            ]
-            return ListIteratorVariable(
-                output, mutable_local=MutableLocal(), guards=guards
-            )
+            return self.wrap_tuple_iterator(value)
         elif istype(value, (slice, range)):
-            items = [
-                VariableBuilder(self.tx, AttrSource(self.get_source(), k))(
-                    getattr(value, k)
-                )
-                for k in ("start", "stop", "step")
-            ]
-            if isinstance(value, slice):
-                return SliceVariable(items, guards=make_guards(GuardBuilder.TYPE_MATCH))
-            else:
-                return RangeVariable(
-                    items, guards=make_guards(GuardBuilder.EQUALS_MATCH)
-                )
+            return self.wrap_slice_range(value)
         elif istype(
             value, (dict, collections.defaultdict, collections.OrderedDict)
         ) and all(
@@ -320,44 +281,7 @@ class VariableBuilder:
 
             return self.tx.output.side_effects.track_dict(self.source, value, result)
         elif isinstance(value, torch.nn.Module):
-            if (
-                isinstance(value, (torch.nn.RNN, torch.nn.GRU, torch.nn.LSTM))
-                and not config.allow_rnn
-            ):
-                unimplemented("TorchDynamo purposely graph breaks on RNN, GRU, LSTMs")
-            if mutation_guard.is_dynamic_nn_module(value):
-                # created dynamically, don't specialize on it
-                result = UnspecializedNNModuleVariable(
-                    value, guards=make_guards(GuardBuilder.TYPE_MATCH)
-                )
-                if not SideEffects.cls_supports_mutation_side_effects(type(value)):
-                    # don't allow STORE_ATTR mutation with custom __setattr__
-                    return result
-                return self.tx.output.side_effects.track_object_existing(
-                    self.source, value, result
-                )
-            elif getattr(value, "_is_fsdp_managed_module", False) or issubclass(
-                value.__class__, torch.nn.parallel.distributed.DistributedDataParallel
-            ):
-                if getattr(value, "_is_fsdp_managed_module", False):
-                    # Note: we can't do this assert inside FSDP constructor,
-                    # since we don't know yet whether dynamo will be used
-                    assert getattr(
-                        value, "_fsdp_use_orig_params", False
-                    ), "Dynamo only supports FSDP with use_orig_params=True"
-
-                # See note [Dynamo treats FSDP wrapped modules as UnspecializedNNModule]
-                # in fully_sharded_data_parallel.py for more information
-                return UnspecializedNNModuleVariable(
-                    value, guards=make_guards(GuardBuilder.TYPE_MATCH)
-                )
-            else:
-                return self.tx.output.register_attr_or_module(
-                    value,
-                    self.name,
-                    source=self.get_source(),
-                    # Guards are added inside register_attr_or_module
-                )
+            return self.wrap_module(value)
         elif ConstantVariable.is_literal(value) or istype(
             value, (torch.Size, torch.device, torch.dtype)
         ):
@@ -590,6 +514,88 @@ class VariableBuilder:
             sym_num=value
             # shape Guards live their own rich life via shape_env
         )
+
+    def wrap_listlike(self, value: Union[tuple, list, odict_values, NamedTuple]):
+        # One can index a tensor with a list/tuple. Therefore, we need to
+        # have a stricter match.
+        if istype(value, (tuple, list)) and all(
+            [isinstance(x, int) or is_numpy_int_type(x) or x is None for x in value]
+        ):
+            guards = self.make_guards(GuardBuilder.EQUALS_MATCH)
+        else:
+            guards = self.make_guards(GuardBuilder.LIST_LENGTH)
+        output = [
+            VariableBuilder(self.tx, GetItemSource(self.get_source(), i))(
+                item
+            ).add_guards(guards)
+            for i, item in enumerate(value)
+        ]
+        result = self.list_type(value)(output, guards=guards)
+        if istype(value, list):
+            return self.tx.output.side_effects.track_list(self.source, value, result)
+        return result
+
+    def wrap_tuple_iterator(self, value: tuple_iterator):
+        guards = self.make_guards(GuardBuilder.TUPLE_ITERATOR_LEN)
+        output = [
+            VariableBuilder(self.tx, TupleIteratorGetItemSource(self.get_source(), i))(
+                tuple_iterator_getitem(value, i)
+            ).add_guards(guards)
+            for i in range(tuple_iterator_len(value))
+        ]
+        return ListIteratorVariable(output, mutable_local=MutableLocal(), guards=guards)
+
+    def wrap_slice_range(self, value: Union[slice, range]):
+        items = [
+            VariableBuilder(self.tx, AttrSource(self.get_source(), k))(
+                getattr(value, k)
+            )
+            for k in ("start", "stop", "step")
+        ]
+        if isinstance(value, slice):
+            return SliceVariable(items, guards=make_guards(GuardBuilder.TYPE_MATCH))
+        else:
+            return RangeVariable(items, guards=make_guards(GuardBuilder.EQUALS_MATCH))
+
+    def wrap_module(self, value: torch.nn.Module):
+        if (
+            isinstance(value, (torch.nn.RNN, torch.nn.GRU, torch.nn.LSTM))
+            and not config.allow_rnn
+        ):
+            unimplemented("TorchDynamo purposely graph breaks on RNN, GRU, LSTMs")
+        if mutation_guard.is_dynamic_nn_module(value):
+            # created dynamically, don't specialize on it
+            result = UnspecializedNNModuleVariable(
+                value, guards=make_guards(GuardBuilder.TYPE_MATCH)
+            )
+            if not SideEffects.cls_supports_mutation_side_effects(type(value)):
+                # don't allow STORE_ATTR mutation with custom __setattr__
+                return result
+            return self.tx.output.side_effects.track_object_existing(
+                self.source, value, result
+            )
+        elif getattr(value, "_is_fsdp_managed_module", False) or issubclass(
+            value.__class__, torch.nn.parallel.distributed.DistributedDataParallel
+        ):
+            if getattr(value, "_is_fsdp_managed_module", False):
+                # Note: we can't do this assert inside FSDP constructor,
+                # since we don't know yet whether dynamo will be used
+                assert getattr(
+                    value, "_fsdp_use_orig_params", False
+                ), "Dynamo only supports FSDP with use_orig_params=True"
+
+            # See note [Dynamo treats FSDP wrapped modules as UnspecializedNNModule]
+            # in fully_sharded_data_parallel.py for more information
+            return UnspecializedNNModuleVariable(
+                value, guards=make_guards(GuardBuilder.TYPE_MATCH)
+            )
+        else:
+            return self.tx.output.register_attr_or_module(
+                value,
+                self.name,
+                source=self.get_source(),
+                # Guards are added inside register_attr_or_module
+            )
 
     def wrap_tensor(self, value: torch.Tensor):
         if self.get_source().guard_source().is_nn_module():

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -553,9 +553,9 @@ class VariableBuilder:
             for k in ("start", "stop", "step")
         ]
         if isinstance(value, slice):
-            return SliceVariable(items, guards=make_guards(GuardBuilder.TYPE_MATCH))
+            return SliceVariable(items, guards=self.make_guards(GuardBuilder.TYPE_MATCH))
         else:
-            return RangeVariable(items, guards=make_guards(GuardBuilder.EQUALS_MATCH))
+            return RangeVariable(items, guards=self.make_guards(GuardBuilder.EQUALS_MATCH))
 
     def wrap_module(self, value: torch.nn.Module):
         if (
@@ -566,7 +566,7 @@ class VariableBuilder:
         if mutation_guard.is_dynamic_nn_module(value):
             # created dynamically, don't specialize on it
             result = UnspecializedNNModuleVariable(
-                value, guards=make_guards(GuardBuilder.TYPE_MATCH)
+                value, guards=self.make_guards(GuardBuilder.TYPE_MATCH)
             )
             if not SideEffects.cls_supports_mutation_side_effects(type(value)):
                 # don't allow STORE_ATTR mutation with custom __setattr__
@@ -587,7 +587,7 @@ class VariableBuilder:
             # See note [Dynamo treats FSDP wrapped modules as UnspecializedNNModule]
             # in fully_sharded_data_parallel.py for more information
             return UnspecializedNNModuleVariable(
-                value, guards=make_guards(GuardBuilder.TYPE_MATCH)
+                value, guards=self.make_guards(GuardBuilder.TYPE_MATCH)
             )
         else:
             return self.tx.output.register_attr_or_module(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #95476
* __->__ #95472
* #95471

My intention is to collapse all of the istype() and isinstance() and object identity tests into a more structured form involving a dict lookup. To do this conveniently, I need every continuation to be expressible in a single expression. Thus, all multi-line wrap methods are moved. This is code motion only, no logic changes.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire