### PR TITLE
[FSDP] Expose private prefetch limit setters

### DIFF
--- a/test/distributed/fsdp/test_fsdp_core.py
+++ b/test/distributed/fsdp/test_fsdp_core.py
@@ -169,6 +169,23 @@ class TestParityWithDDP(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
+    def test_transformer_with_increased_prefetch_limit(self):
+        cpu_offload = CPUOffload(False)
+        config = self._get_subtest_config(cpu_offload)
+        config["forward_prefetch_limit"] = [3, None]
+        config["backward_prefetch_limit"] = [3, None]
+        config["sharding_strategy"] = [
+            ShardingStrategy.FULL_SHARD,
+            ShardingStrategy.SHARD_GRAD_OP,
+        ]
+        self.run_subtests(
+            config,
+            self._test_fsdp_parity,
+            TransformerWithSharedParams,
+            FSDPInitMode.RECURSIVE,
+        )
+
+    @skip_if_lt_x_gpu(2)
     @parametrize(params, configs, subtest_name)
     def test_delayed_optim_step(
         self,

--- a/test/distributed/fsdp/test_fsdp_core.py
+++ b/test/distributed/fsdp/test_fsdp_core.py
@@ -170,6 +170,10 @@ class TestParityWithDDP(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     def test_transformer_with_increased_prefetch_limit(self):
+        """
+        NOTE: This only tests for correctness, not that the prefetching works
+        as expected.
+        """
         cpu_offload = CPUOffload(False)
         config = self._get_subtest_config(cpu_offload)
         config["forward_prefetch_limit"] = [3, None]

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1962,6 +1962,28 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             submodule._communication_hook_state = state
             submodule._communication_hook = hook
 
+    def _set_forward_prefetch_limit(self, limit: int) -> None:
+        """
+        Sets the forward prefetch limit that defines the number of all-gathers
+        that are prefetched during forward. The default limit is 1.
+
+        This should be called on the root FSDP instance.
+        """
+        if limit < 0:
+            raise ValueError(f"Invalid forward prefetch limit: {limit}")
+        self._exec_order_data._forward_prefetch_limit = limit
+
+    def _set_backward_prefetch_limit(self, limit: int) -> None:
+        """
+        Sets the backward prefetch limit that defines the number of all-gathers
+        that are prefetched during backward. The default limit is 1.
+
+        This should be called on the root FSDP instance.
+        """
+        if limit < 0:
+            raise ValueError(f"Invalid backward prefetch limit: {limit}")
+        self._exec_order_data._backward_prefetch_limit = limit
+
 
 def _get_grad_norm(
     params: Iterable[nn.Parameter],

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -905,6 +905,8 @@ class FSDPTest(MultiProcessTestCase):
         enable_sharded_grad_scaler: bool = False,
         use_pure_fp16: bool = False,
         init_kwargs: Optional[Dict[str, Any]] = None,
+        forward_prefetch_limit: Optional[bool] = None,
+        backward_prefetch_limit: Optional[bool] = None,
         **fsdp_kwargs,
     ):
         """
@@ -985,6 +987,10 @@ class FSDPTest(MultiProcessTestCase):
             fsdp_model = fsdp_model.half()
         if cuda_init_mode == CUDAInitMode.CUDA_AFTER:
             fsdp_model = fsdp_model.cuda()
+        if forward_prefetch_limit is not None:
+            fsdp_model._set_forward_prefetch_limit(forward_prefetch_limit)
+        if backward_prefetch_limit is not None:
+            fsdp_model._set_backward_prefetch_limit(backward_prefetch_limit)
         offload_params = cpu_offload is not None and cpu_offload.offload_params
         # Offloading parameters with `CUDA_AFTER` should raise an error during
         # lazy initialization due to the parameter devices not being CPU;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#95507 [FSDP] Expose private prefetch limit setters**
* #95465 [FSDP] Save `_all_handles`; `_all_fsdp_states` to root
* #95343 [FSDP] Save `_fsdp_states` on root

