### PR TITLE
Fix aot/dynamo handling of *args input to forward

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -624,6 +624,59 @@ class AotAutogradFallbackTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cc.frame_count, 2)
         self.assertEqual(failure_reason, "c is d")
 
+
+    @patch("torch._functorch.config.debug_assert", True)
+    def test_arg_dupe_via_dynamo_recompiles_star_args(self):
+        class F(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mean = torch.nn.Parameter(torch.randn(3, 3))
+
+            def forward(self, *args):
+                a, b, c, d = args
+                a.t_()
+                b.t_()
+                c.t_()
+                d.t_()
+                return a + b + c + d + self.mean
+
+        a = torch.randn(3, 3, requires_grad=True)
+        b = torch.randn(3, 3, requires_grad=True)
+        a1, a2, a3, a4 = a.clone(), a.clone(), a.clone(), a.clone()
+        b1, b2, b3, b4 = b.clone(), b.clone(), b.clone(), b.clone()
+
+        failure_reason = None
+
+        def guard_fail_fn(failure):
+            nonlocal failure_reason
+            failure_reason = failure[0]
+
+        self.assertTrue(failure_reason is None)
+
+        cc = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
+
+        f = torch._dynamo.optimize(cc, guard_fail_fn=guard_fail_fn)(F())
+        f(a1, a1, a1, a1)
+        f(a2, b2, b2, b2)
+        self.assertEqual(cc.frame_count, 2)
+        self.assertEqual(failure_reason, "args[0] is args[1]")
+
+        torch._dynamo.reset()
+
+        cc = torch._dynamo.testing.CompileCounterWithBackend("aot_eager")
+
+        c = torch.randn(3, 3, requires_grad=True)
+        d = torch.randn(3, 3, requires_grad=True)
+        c3, c4 = c.clone(), c.clone()
+        d3, d4 = d.clone(), d.clone()
+
+        f = torch._dynamo.optimize(cc, guard_fail_fn=guard_fail_fn)(F())
+        f(a3, b3, c3, c3)
+        f(a4, b4, c4, d4)
+        self.assertEqual(cc.frame_count, 2)
+        self.assertEqual(failure_reason, "args[2] is args[3]")
+
+
     @patch("torch._functorch.config.debug_assert", True)
     def test_arg_dupe_via_dynamo_recompiles_many_args(self):
         class F(torch.nn.Module):

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -121,7 +121,7 @@ def augment_exc_message(exc, msg="\n"):
             "    torch._dynamo.config.suppress_errors = True\n"
         )
 
-    old_msg = "" if len(exc.args) == 0 else exc.args[0]
+    old_msg = "" if len(exc.args) == 0 else str(exc.args[0])
 
     if isinstance(exc, KeyError):
         exc.args = (KeyErrorMsg(old_msg + msg),) + exc.args[1:]

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -14,6 +14,7 @@ import torch
 
 from torch._guards import (
     DuplicateInputs,
+    DuplicateStarArgsInputs,
     Guard,
     GuardBuilderBase,
     GuardEnvExpr,
@@ -633,6 +634,25 @@ class CheckFunctionManager:
                     pos_b
                 ].is_tensor, "Deduped arg must be a tensor"
                 code_part = f"{self.output_graph.graphargs[pos_a].source.name()} is {self.output_graph.graphargs[pos_b].source.name()}"  # noqa: B950
+                code_parts.append(code_part)
+                verbose_code_parts.append(code_part)
+            elif isinstance(guard, DuplicateStarArgsInputs):
+                breakpoint()
+                args_a = self.output_graph.pos_to_arg[guard.input_args_a]
+                args_b = self.output_graph.pos_to_arg[guard.input_args_b]
+                pos_a = guard.input_pos_a
+                pos_b = guard.input_pos_b
+                assert (
+                    pos_b >= 0 and pos_a >= 0 and args_a >= 0 and args_b >= 0
+                ), "Deduped args out of bounds, cannot be negative"
+
+                assert self.output_graph.graphargs[
+                    args_a
+                ][pos_a].is_tensor, "Deduped arg must be a tensor"
+                assert self.output_graph.graphargs[
+                    args_b
+                ][pos_b].is_tensor, "Deduped arg must be a tensor"
+                code_part = f"{self.output_graph.graphargs[args_a].source.name()}[{pos_a}] is {self.output_graph.graphargs[args_b].source.name()}[{pos_b}]"  # noqa: B950
                 code_parts.append(code_part)
                 verbose_code_parts.append(code_part)
             else:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -316,6 +316,9 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
     def add_grapharg(self, arg: GraphArg):
         curr_pos = len(self.graphargs)
         self.graphargs.append(arg)
+        # ok what do we want to do here... 
+        # are GraphArgs always tensors? should 'args' be a grapharg?
+        # should args[0](a tensor) also be a grapharg when args is a grapharg?
         if isinstance(arg.source, LocalInputSource):
             self.pos_to_arg[arg.source.pos] = curr_pos
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -128,6 +128,10 @@ class GraphArg:
                 if "graph_arg_pos" not in self.fake_tensor.__dict__:
                     self.fake_tensor.__dict__["graph_arg_pos"] = []
                 self.fake_tensor.__dict__["graph_arg_pos"].append(self.source.pos)
+            elif isinstance(self.source, GetItemSource) and isinstance(self.source.base, LocalInputSource):
+                if "graph_stararg_pos" not in self.fake_tensor.__dict__:
+                    self.fake_tensor.__dict__["graph_stararg_pos"] = []
+                self.fake_tensor.__dict__["graph_stararg_pos"].append((self.source.base.pos, self.source.index))
         if isinstance(self.example, torch._subclasses.fake_tensor.FakeTensor):
             raise AssertionError("Fake Tensor observed in TorchDynamo Fx graph inputs")
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -216,6 +216,16 @@ class DuplicateInputs(GuardEnvExpr):
     def __post_init__(self):
         assert self.input_pos_a != self.input_pos_b
 
+@dataclasses.dataclass
+class DuplicateStarArgsInputs(GuardEnvExpr):
+    input_args_a: int
+    input_pos_a: int
+    input_args_b: int
+    input_pos_b: int
+
+    def __post_init__(self):
+        if self.input_args_a == self.input_args_b:
+            assert self.input_pos_a != self.input_pos_b
 
 """
 Checkpointable is an interface for driving state snapshotting, left purposely vague for now.


### PR DESCRIPTION
(this is not a fix yet, it's me hacking towards one and getting stuck)

Question: how do we deal with input args that are tuples of tensors when considering dupes/graphargs?

Context: we had a gap previously with module.forward(*args), but it got worse when I tried to support hooks and we trace __call__(*args,...).  (yes, there are also kwargs which i'm conveniently ignoring for the moment)


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95520

fixes #95501
