### PR TITLE
[MTPG] Improve all_reduce and handle bwd thread support

### DIFF
--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -144,10 +144,6 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
         res_num = ((0 + self.world_size - 1) * self.world_size) / 2
         self.assertEqual(output, torch.ones(3, 3) * res_num)
 
-        # Test unimplemented error
-        with self.assertRaisesRegex(NotImplementedError, "only supports SUM on threaded pg for now"):
-            dist.all_reduce(output, op=ReduceOp.MAX)
-
     def test_all_reduce_ops(self):
         tensor = torch.tensor([dist.get_rank() + 1])
         dist.all_reduce(tensor, op=ReduceOp.PRODUCT)

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -283,7 +283,10 @@ class ProcessLocalGroup(dist.ProcessGroup):
         super().__init__(rank, world_size)
         self._rank = rank
         self._world_size = world_size
-        self._world = weakref.ref(dist.distributed_c10d._world._get_world())
+        world = dist.distributed_c10d._world
+        if isinstance(world, ThreadLocalWorld):
+            world = world._get_world()
+        self._world = weakref.ref(world)
         ProcessLocalGroup._register(self)
 
     def size(self):

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -6,6 +6,7 @@ from functools import partial, reduce
 
 import torch
 import torch.distributed as dist
+import weakref
 from torch._C._distributed_c10d import (
     _create_work_from_future,
     AllgatherOptions,
@@ -282,6 +283,7 @@ class ProcessLocalGroup(dist.ProcessGroup):
         super().__init__(rank, world_size)
         self._rank = rank
         self._world_size = world_size
+        self._world = weakref.ref(dist.distributed_c10d._world._get_world())
         ProcessLocalGroup._register(self)
 
     def size(self):
@@ -292,7 +294,7 @@ class ProcessLocalGroup(dist.ProcessGroup):
         """
         return the global registered name of the current pg in the world
         """
-        return dist.distributed_c10d._world.pg_names[self]
+        return self._world().pg_names[self]
 
     def getBackendName(self):
         return "threaded"


### PR DESCRIPTION
This implements all reduce ops in all_reduce and a PG being used from a thread different than the one that created it.

We should be this >< close to getting complex training tests working.

