### PR TITLE
Update `fx.pass.graph_drawer` usage doc to draw fx graph

### DIFF
--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -56,8 +56,7 @@ if HAS_PYDOT:
         Visualize a torch.fx.Graph with graphviz
         Basic usage:
             g = FxGraphDrawer(symbolic_traced, "resnet18")
-            with open("a.svg", "w") as f:
-                f.write(g.get_dot_graph().create_svg())
+            g.get_dot_graph().write_svg("a.svg")
         """
 
         def __init__(


### PR DESCRIPTION
Previous usage gave this error:
```
f.write(g.get_dot_graph().create_svg())
TypeError: write() argument must be str, not bytes
```

pydot has function to save to different types, e.g. `save_svg()`. I updated the usage doc working code.
