### PR TITLE
fix DeprecationWarning

### DIFF
--- a/torch/utils/tensorboard/__init__.py
+++ b/torch/utils/tensorboard/__init__.py
@@ -1,12 +1,12 @@
 import tensorboard
-from distutils.version import LooseVersion
+from packaging.version import Version
 
-if not hasattr(tensorboard, "__version__") or LooseVersion(
+if not hasattr(tensorboard, "__version__") or Version(
     tensorboard.__version__
-) < LooseVersion("1.15"):
+) < Version("1.15"):
     raise ImportError("TensorBoard logging requires TensorBoard version 1.15 or above")
 
-del LooseVersion
+del Version
 del tensorboard
 
 from .writer import FileWriter, SummaryWriter  # noqa: F401


### PR DESCRIPTION
This PR fixes 2 `DeprecationWarning` instances:

```
python3.8/site-packages/torch/utils/tensorboard/__init__.py:4
  /home/stas/anaconda3/envs/py38-pt113/lib/python3.8/site-packages/torch/utils/tensorboard/__init__.py:4: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if not hasattr(tensorboard, "__version__") or LooseVersion(

python3.8/site-packages/torch/utils/tensorboard/__init__.py:6
  /home/stas/anaconda3/envs/py38-pt113/lib/python3.8/site-packages/torch/utils/tensorboard/__init__.py:6: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    ) < LooseVersion("1.15"):
```