### PR TITLE
[pt] add share_memory_ to aten TensorBase

### DIFF
--- a/aten/src/ATen/StorageUtils.cpp
+++ b/aten/src/ATen/StorageUtils.cpp
@@ -38,6 +38,11 @@ C10_EXPORT void share_memory_(TensorBase& t) {
   }
 
   const at::Storage& origStorage = t.storage();
+
+  if (MapAllocator::fromDataPtr(origStorage.data_ptr()) != nullptr) {
+    // already shared
+    return;
+  }
   at::Storage newStorage(new_shm_fd_storage(origStorage.nbytes()));
   storage_copy(newStorage, origStorage);
   std::swap(

--- a/aten/src/ATen/StorageUtils.h
+++ b/aten/src/ATen/StorageUtils.h
@@ -38,10 +38,9 @@ C10_EXPORT void storage_copy(
 /**
  * In place change the storage to shm based.
  *
- * This would later be invoked by at::TensorBase user facing API.
- * For now, to keep the change minimal,
- * intentionally separate the API changes from the core logic,
- * as the API changes may also need to handle device/OS specifics.
+ * This is only applicable to CPU tensors not already shared.
+ * Otherwise, it's a no op to mirror the THP tensor behavior:
+ * https://pytorch.org/docs/stable/generated/torch.Tensor.share_memory_.html
  *
  * @param t  a tensor
  */

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -6,6 +6,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/core/ScalarTypeToTypeMeta.h>
 #include <c10/core/Storage.h>
+#include <c10/core/SymIntArrayRef.h>
 #include <c10/core/TensorImpl.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/core/UndefinedTensorImpl.h>
@@ -18,8 +19,8 @@
 
 #include <ATen/core/NamedTensor.h>
 #include <ATen/core/QuantizerBase.h>
-#include <c10/core/SymIntArrayRef.h>
 #include <ATen/core/TensorAccessor.h>
+#include <ATen/StorageUtils.h>
 
 namespace c10 {
 class Scalar;
@@ -339,6 +340,25 @@ class TORCH_API TensorBase {
   }
   bool is_alias_of(const at::TensorBase& other) const{
     return impl_->storage().is_alias_of(other.storage());
+  }
+
+  // Move the storage backend to shm based
+  // to enable memory sharing across processes.
+  //
+  // NB1: the ideal behavior of this API still requires further discussion
+  // but for now we are inclined to keep it consistent with existing THP behavior
+  // https://github.com/pytorch/pytorch/blob/4dca9bde0552afc67b5b74f4a0696fe6055709c4/torch/storage.py#L196-L212
+  // so we don't assert on anything here and rely on caller knowing
+  // what it's doing.
+  //
+  // NB2: this currently provides Linux fd based shm support only
+  // to simplify the storage lifetime management logic in ATen
+  // and similarly for now we are not adding support for file system based
+  // shm support like in THP due to additional GC manager support needed
+  // to prevent leaks.
+  // As such, calling this from non supported systems (e.g. Windows) would fail.
+  void share_memory_() {
+    at::share_memory_(*this);
   }
 
   inline bool _is_zerotensor() const {


### PR DESCRIPTION
Summary:
This is the part 2 of adding `share_memory_()` support to C++ ATen lib.

See inline comments for API considerations and current behavior rationale.

Test Plan:
Since https://github.com/pytorch/pytorch/pull/95228 already adds the UT, this is not repeating it.

Github CI

Differential Revision: D43575383

