### PR TITLE
enable some cuda warnings

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -329,14 +329,11 @@ list(APPEND CUDA_NVCC_FLAGS ${NVCC_FLAGS_EXTRA})
 message(STATUS "Added CUDA NVCC flags for: ${NVCC_FLAGS_EXTRA}")
 
 # disable some nvcc diagnostic that appears in boost, glog, glags, opencv, etc.
-foreach(diag cc_clobber_ignored integer_sign_change useless_using_declaration
+foreach(diag cc_clobber_ignored
              set_but_not_used field_without_dll_interface
              base_class_has_different_dll_interface
              dll_interface_conflict_none_assumed
              dll_interface_conflict_dllexport_assumed
-             implicit_return_from_non_void_function
-             unsigned_compare_with_zero
-             declared_but_not_referenced
              bad_friend_decl)
   list(APPEND SUPPRESS_WARNING_FLAGS --diag_suppress=${diag})
 endforeach()


### PR DESCRIPTION
Currently some CUDA warnings are disabled due to  some old issues of code quality that are fixed now. So it is time to remove the suppression. 