### PR TITLE
Add source for user defined objects

### DIFF
--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -216,6 +216,7 @@ class SideEffects:
         obj = object_new(user_cls)
         variable = variable_cls(
             obj,
+            source=cls_source,
             mutable_local=AttributeMutationNew(None, cls_source),
             **options,
         )


### PR DESCRIPTION
I ran into an issue where a user is trying to do `type(m)` where `m` is UserDefinedObjectVariable declared while tracing. This runs into an issue with `type(m)` because there is no source defined, and so we run into an unimplemented error.

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire