### PR TITLE
Sample custom guards [Do not land, for answering question]

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -661,6 +661,11 @@ class CheckFunctionManager:
             else:
                 raise RuntimeError(f"Unknown GuardEnvExpr: {guard}")
 
+        custom_guards = self.output_graph.tracing_context.guards_context.custom_guards
+        for guard in custom_guards:
+            code_parts.append(guard.code)
+            verbose_code_parts.append(guard.code)
+
         code_parts.extend(local_builder.shape_env_code)
         verbose_code_parts.extend(local_builder.shape_env_code)
         assert not global_builder.shape_env_code

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -216,6 +216,9 @@ class DuplicateInputs(GuardEnvExpr):
     def __post_init__(self):
         assert self.input_pos_a != self.input_pos_b
 
+@dataclasses.dataclass
+class ArbitraryStringGuard(GuardEnvExpr):
+    code: str
 
 """
 Checkpointable is an interface for driving state snapshotting, left purposely vague for now.
@@ -279,6 +282,8 @@ prefer to extract them with copy_graphstate to produce a GuardsCheckpointState.
 class GuardsContext(Checkpointable[GuardsCheckpointState]):
     def __init__(self):
         self.dynamo_guards: Set[Guard] = set()
+        # TODO(CRITICAL) - add to graphstate
+        self.custom_guards: List[ArbitraryStringGuard] = []
         self.aotautograd_guards: List[GuardEnvExpr] = []
 
     def copy_graphstate(self):


### PR DESCRIPTION
Context: 
https://dev-discuss.pytorch.org/t/can-backend-compilers-modify-guards-for-torch-dynamo-frame/1074

Invoked with:

```
def my_backend(gm, args):
    print("Compile!")
    TracingContext.get().guards_context.custom_guards.append(ArbitraryStringGuard("x.tag == 'foo'"))
    return gm
    
x = torch.randn([2, 2])
y = torch.randn([2, 2])

def simple_fn(x, y):
    return x * y    

torch._dynamo.optimize(my_backend)(simple_fn)(x, y)
x.tag = 'bar'
torch._dynamo.optimize(my_backend)(simple_fn)(x, y)
x.tag = 'foo'
torch._dynamo.optimize(my_backend)(simple_fn)(x, y)
torch._dynamo.optimize(my_backend)(simple_fn)(x, y)
```

Run with `TORCHDYNAMO_PRINT_GUARDS=1`

To see:

```
GUARDS ___guarded_code.valid and ___check_tensors(x, y) and x.tag == 'foo' and x.size()[1] == x.size()[0] and x.stride()[0] == x.size()[0] and x.stride()[1] == 1 and x.storage_offset() == 0 and y.size()[0] == x.size()[0] and y.size()[1] == x.size()[0] and y.stride()[0] == x.size()[0] and y.stride()[1] == 1 and y.storage_offset() == 0 and Eq(x.size()[0], 2) and 2 <= x.size()[0]
```

cc @soumith @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire