### PR TITLE
Node.stack_trace should have innermost frame last

### DIFF
--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -818,10 +818,12 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
         while tx:
             frame_summaries.append(tx.frame_summary())
             tx = getattr(tx, "parent", None)
+        # Reverse the frame_summaries, such that the innermost frame is at the last
+        frame_summaries.reverse()
 
         # official from_list stub doesn't have new-style type
         msgs = traceback.StackSummary.from_list(frame_summaries).format()  # type: ignore[arg-type]
-        rv.node.stack_trace = " | ".join(msgs)
+        rv.node.stack_trace = "".join(msgs)
 
         return rv
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -454,27 +454,17 @@ class CodeGen:
                         # stacktrace should have innermost frame last, so we
                         # iterate backwards to find the first line that starts
                         # with 'File '
-                        idx = len(lines) - 1
-                        while idx >= 0:
+                        summary_str = ""
+                        for idx in range(len(lines) - 2, -1, -1):
                             line = lines[idx].strip()
-                            if line.startswith('File '):
-                                break
-                            idx -= 1
-
-                        summary_lines = []
-                        if idx >= 0 and idx + 1 < len(lines):
-                            matches = pattern.match(lines[idx].strip())
+                            matches = pattern.match(line)
                             if matches:
                                 file = matches.group(1)
                                 lineno = matches.group(2)
-                                lineage = f'File: {file}:{lineno}'
-                                summary_lines.append(lineage)
-
                                 # next line should be the code
-                                code = f"code: {lines[idx + 1].strip()}"
-                                summary_lines.append(code)
-
-                        summary_str = ', '.join(summary_lines)
+                                code = lines[idx + 1].strip()
+                                summary_str = f'File: {file}:{lineno}, code: {code}'
+                                break
                         body.append(f'\n# {summary_str}\n')
                 elif prev_stacktrace != "":
                     prev_stacktrace = ""

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -451,15 +451,18 @@ class CodeGen:
                         prev_stacktrace = node.stack_trace
 
                         lines = node.stack_trace.strip().split('\n')
-                        idx = 0
-                        while idx < len(lines):
+                        # stacktrace should have innermost frame last, so we
+                        # iterate backwards to find the first line that starts
+                        # with 'File '
+                        idx = len(lines) - 1
+                        while idx >= 0:
                             line = lines[idx].strip()
                             if line.startswith('File '):
                                 break
-                            idx += 1
+                            idx -= 1
 
                         summary_lines = []
-                        if idx + 1 < len(lines):
+                        if idx >= 0 and idx + 1 < len(lines):
                             matches = pattern.match(lines[idx].strip())
                             if matches:
                                 file = matches.group(1)
@@ -467,8 +470,9 @@ class CodeGen:
                                 lineage = f'File: {file}:{lineno}'
                                 summary_lines.append(lineage)
 
-                            code = f"code: {lines[idx + 1].strip()}"
-                            summary_lines.append(code)
+                                # next line should be the code
+                                code = f"code: {lines[idx + 1].strip()}"
+                                summary_lines.append(code)
 
                         summary_str = ', '.join(summary_lines)
                         body.append(f'\n# {summary_str}\n')

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -363,9 +363,13 @@ class Node:
     def stack_trace(self) -> Optional[str]:
         """
         Return the Python stack trace that was recorded during tracing, if any.
-        This property is usually populated by `Tracer.create_proxy`. To record
-        stack traces during tracing for debug purposes, set
-        `record_stack_traces = True` on the `Tracer` instance.
+        When traced with fx.Tracer, this property is usually populated by
+        `Tracer.create_proxy`. To record stack traces during tracing for debug purposes,
+        set `record_stack_traces = True` on the `Tracer` instance.
+        When traced with dynamo, this property will be populated by default by
+        `OutputGraph.create_proxy`.
+
+        stack_trace would have the innermost frame at the bottom.
         """
         return self.meta.get("stack_trace", None)
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -369,7 +369,7 @@ class Node:
         When traced with dynamo, this property will be populated by default by
         `OutputGraph.create_proxy`.
 
-        stack_trace would have the innermost frame at the bottom.
+        stack_trace would have the innermost frame at the end of the string.
         """
         return self.meta.get("stack_trace", None)
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -180,9 +180,9 @@ class TracerBase:
         if self.record_stack_traces and not proxy.node.stack_trace:
             user_frame = self._find_user_frame()
             if user_frame:
-                walk_stack_gen = traceback.walk_stack(user_frame)
-                summary = traceback.StackSummary.extract(walk_stack_gen)  # type: ignore[arg-type]
+                summary = traceback.extract_stack(user_frame)
                 tb_lines = summary.format()
+                # stack_trace would have innermost frame at the bottom
                 proxy.node.stack_trace = ''.join(tb_lines)
 
         return proxy


### PR DESCRIPTION
Both fx.Tracer and Dynamo should store node.stack_trace in the "innermost frame last" order. 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95592



cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire