### PR TITLE
Fix typos in documents under torch

### DIFF
--- a/torch/ao/pruning/_experimental/pruner/README.md
+++ b/torch/ao/pruning/_experimental/pruner/README.md
@@ -4,7 +4,7 @@
 
 **Pruning** is the technique of removing parameters from a model to reduce the computational cost. The goal of pruning is to improve the performance of the model while maintaining it's accuracy.
 
-### Unstrictured vs. Structured Pruning
+### Unstructured vs. Structured Pruning
 One way to do this is to consider each parameter individually. This gives us the greatest granularity when pruning and is called **unstructured pruning**.
 
 For example, consider a simple linear regression model that is parametrized by a weight tensor W.
@@ -47,7 +47,7 @@ By removing a row from U and a column from W, we can avoid a shape mismatch.
 ![](./images/prune_6.png)
 
 
-One benefit of **structured pruning** is that it uses the same dense kernels that the original model uses, and does not rely on custom sparse kerenel like **unstructured pruning**.
+One benefit of **structured pruning** is that it uses the same dense kernels that the original model uses, and does not rely on custom sparse kernel like **unstructured pruning**.
 However, structured pruning degrades accuracy more than unstructured pruning because of the lack of granularity, so it is not always the right choice.
 
 Generally the structured pruning process looks something like this:
@@ -56,7 +56,7 @@ Generally the structured pruning process looks something like this:
 3. Remove rows by resizing the weight matrices of each layer
 4. Stop if target sparsity level is met.
 
-The accuracy degredation of pruning can be quite large initially. Once we are satisfied with our pruned tensor, we usually retrain the model after pruning in order to restore some of this accuracy loss.
+The accuracy degradation of pruning can be quite large initially. Once we are satisfied with our pruned tensor, we usually retrain the model after pruning in order to restore some of this accuracy loss.
 
 ## Quickstart Guide
 
@@ -76,7 +76,7 @@ Structured pruning works by traversing this graph and looking for specific **pat
 
 Each pattern is tied to a pruning function, which is responsible for structured pruning the graph nodes that match the pattern.
 
-The above [example](#weight-resizing) of two linear layers would match agains a `(nn.Linear, nn.Linear)` pattern. This is how we identify the rows to remove and the columns of the subsequent layer.
+The above [example](#weight-resizing) of two linear layers would match against a `(nn.Linear, nn.Linear)` pattern. This is how we identify the rows to remove and the columns of the subsequent layer.
 
 Structured pruning also works on other patterns other than two adjacent Linear layers,
 
@@ -146,7 +146,7 @@ pruner.step()
 # The output of pruner.prune() is a model with resized weights and the masks / parametrizations removed.
 pruned_model = pruner.prune()
 ```
-Afterwards, by printinting the name and size of each parameter in our model, we can see that it has been pruned.
+Afterwards, by printing the name and size of each parameter in our model, we can see that it has been pruned.
 
 ```
 # original model

--- a/torch/distributed/_tensor/README.md
+++ b/torch/distributed/_tensor/README.md
@@ -27,7 +27,7 @@ An ideal scenario is that users could build their distributed program just like 
 
 There're many recent works that working on tensor level parallelism to provide common abstractions, see the `Related Works` in the last section for more details. Inspired by [GSPMD](https://arxiv.org/pdf/2105.04663.pdf), [Oneflow](https://arxiv.org/pdf/2110.15032.pdf) and [TF’s DTensor](https://www.tensorflow.org/guide/dtensor_overview), we introduce PyTorch DTensor as the next generation of ShardedTensor to provide basic abstractions for distributing storage and computation. It serves as one of the basic building blocks for distributed program translations and describes the layout of a distributed training program. With the DTensor abstraction, we can seamlessly build parallelism strategies such as tensor parallelism, DDP and FSDP.
 
-## Value Propsition
+## Value Proposition
 
 PyTorch DTensor primarily:
 -   Offers a uniform way to save/load `state_dict` during checkpointing, even when there’re complex tensor storage distribution strategies such as combining tensor parallelism with parameter sharding in FSDP.
@@ -77,7 +77,7 @@ partial_replica = distribute_tensor(big_tensor, device_mesh=device_mesh, placeme
 local_tensor = torch.randn((8, 8), requires_grad=True)
 rowwise_tensor = DTensor.from_local(local_tensor, device_mesh, rowwise_placement)
 
-# reshard the current rowise tensor to a colwise tensor or replicate tensor
+# reshard the current row-wise tensor to a colwise tensor or replicate tensor
 colwise_tensor = rowwise_tensor.redistribute(device_mesh, colwise_placement)
 replica_tensor = colwise_tensor.redistribute(device_mesh, replica_placement)
 
@@ -168,4 +168,4 @@ There are also several cutting edge research fields that embeds tensor sharding 
 
 RFC: https://github.com/pytorch/pytorch/issues/88838
 
-We are gathering early feedbacks about this proposal. We have also posted this [RFC](https://dev-discuss.pytorch.org/t/rfc-pytorch-distributedtensor/740) to the dev-discuss forum, please feel free to comment directly in the above issue or in the forum post. To see a complete design doc with additional details about DTesnor, please refer to this [doc](https://docs.google.com/document/d/1nFeJ8NSFNhNlCkNgWK31ZGRqm1L9rd0i_XN_RprphaI/edit#heading=h.6sovjqv9jiqn)
+We are gathering early feedbacks about this proposal. We have also posted this [RFC](https://dev-discuss.pytorch.org/t/rfc-pytorch-distributedtensor/740) to the dev-discuss forum, please feel free to comment directly in the above issue or in the forum post. To see a complete design doc with additional details about DTensor, please refer to this [doc](https://docs.google.com/document/d/1nFeJ8NSFNhNlCkNgWK31ZGRqm1L9rd0i_XN_RprphaI/edit#heading=h.6sovjqv9jiqn)


### PR DESCRIPTION
This PR fixes typos of documents in `.md` files under `torch` directory.
