### PR TITLE
Fix typos under torch/_dynamo directory

### DIFF
--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -262,7 +262,7 @@ def is_allowed(obj):
 
 
 def torch_get_name(obj, default):
-    """Convert a torch.* funcion to a string"""
+    """Convert a torch.* function to a string"""
     return _allowed_function_ids.get_name(id(obj), default)
 
 

--- a/torch/_dynamo/backends/distributed.py
+++ b/torch/_dynamo/backends/distributed.py
@@ -65,7 +65,7 @@ class DDPOptimizer:
      - DDP uses allreduce collectives to synchronize partial gradients computed on different workers
      - DDP groups gradient allreduces into 'buckets' to optimize communication efficiency of all-reduce
      - Parameters grouped into buckets are assumed to be adjacent in time, so they become ready
-       at around the same time during backward and thus can share the same allreduce efficently
+       at around the same time during backward and thus can share the same allreduce efficiently
      - Allreduces must overlap with backward compute for optimal training performance
      - DDP schedules allreduces using 'hooks' fired from the c++ autograd engine in pytorch, which
        operates when individual grads become 'ready'
@@ -277,7 +277,7 @@ class DDPOptimizer:
 
             # Note:
             #
-            # The way distributed works today around fake tensors can be somehwat confusing.
+            # The way distributed works today around fake tensors can be somewhat confusing.
             # Some of these codepaths are shared in both runtime, and compile time. The presence
             # of a fake_mode, read off of fake tensor inputs, dictates how we will operate.
             #
@@ -294,7 +294,7 @@ class DDPOptimizer:
             # 4) Fake tensors should never be around at runtime.
             #
             # 5) We end up with a compilation mode that takes a real submodule and fake tensors,
-            # to match what aot_autograd exepcts. See Note: [Fake Modules and AOTAutograd]
+            # to match what aot_autograd expects. See Note: [Fake Modules and AOTAutograd]
             def run_node(self, n: Node) -> Any:
                 with self._set_current_node(n):
                     args, kwargs = self.fetch_args_kwargs_from_env(n)

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -328,7 +328,7 @@ def remove_load_call_method(instructions: List[Instruction]):
 
 
 def explicit_super(code: types.CodeType, instructions: List[Instruction]):
-    """convert super() with no args into explict arg form"""
+    """convert super() with no args into explicit arg form"""
     cell_and_free = (code.co_cellvars or tuple()) + (code.co_freevars or tuple())
     output = []
     for idx, inst in enumerate(instructions):

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -138,7 +138,7 @@ repro_after = os.environ.get("TORCHDYNAMO_REPRO_AFTER", None)
 # Compiler compilation debug info
 # 1: Dumps the original graph out to repro.py if compilation fails
 # 2: Dumps a minifier_launcher.py if compilation fails.
-# 3: Always dumps a minifier_laucher.py. Good for segfaults.
+# 3: Always dumps a minifier_launcher.py. Good for segfaults.
 # 4: Dumps a minifier_launcher.py if the accuracy fails.
 repro_level = int(os.environ.get("TORCHDYNAMO_REPRO_LEVEL", 2))
 

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -504,7 +504,7 @@ def wrap_compiler_debug(unconfigured_compiler_fn, compiler_name: str):
     Minifier for Fx Graph modules after Aot Autograd has finished. We wrap both
     forward and backward call separately with the backend compiler_fn - like
     inductor or nvfuser. Intercepting after Aot Autograd presents neat
-    abstration, where all the params are lifted as graph inputs, making it easy
+    abstraction, where all the params are lifted as graph inputs, making it easy
     to save the graph as a string.
     """
 
@@ -522,9 +522,9 @@ def wrap_compiler_debug(unconfigured_compiler_fn, compiler_name: str):
             """
             Aot Autograd fw_compiler and bw_compiler can have fake tensors. So,
             example_inputs can be fake tensors. We can call compiler_fn (which is
-            inductor or nvfuser) with fake tensors but the actualy compiled_fn
+            inductor or nvfuser) with fake tensors but the actually compiled_fn
             should be called with real tensors. Therefore, the actual invocation
-            is deffered.
+            is deferred.
             """
             # Avoid re-compiling when we call the compiled function twice. This happens
             # when we run the model inference or training in a for loop like here
@@ -1014,7 +1014,7 @@ def wrap_backend_debug(unconfigured_compiler_fn, compiler_name: str):
                 compiled_gm = compiler_fn(copy.deepcopy(gm), example_inputs)
                 if backend_accuracy_fails(gm, example_inputs, compiler_fn):
                     log.warning(
-                        "Accuracy failed for the TorchDyanmo produced graph. Creating script to minify the error."
+                        "Accuracy failed for the TorchDynamo produced graph. Creating script to minify the error."
                     )
                     dump_to_minify_after_dynamo(
                         fx.GraphModule(gm, copy.deepcopy(gm.graph)),

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -84,7 +84,7 @@ class OptimizedModule(torch.nn.Module):
     def forward(self, *args, **kwargs):
         # TODO: should this actually be a warning? Should we omit this? (There was a test that literally calls .forward)
         # Warning: usually you don't want to call this.  You probably want to go through
-        # __call__ intstead.  If you go through __call__, you'll get hooks support.
+        # __call__ instead.  If you go through __call__, you'll get hooks support.
         return self.dynamo_ctx(self._orig_mod.forward)(*args, **kwargs)
 
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -175,7 +175,7 @@ class GuardBuilder(GuardBuilderBase):
         #
         # WARNING: this guard is not safe to use generally.  It only works if the runtime
         # value is of a type that supports bool(), and some types e.g. Tensor do not.
-        # Only use this guard in cases you can gaurantee the runtime type will be friendly.
+        # Only use this guard in cases you can guarantee the runtime type will be friendly.
         # (e.g. Specialized NNModule with mutation protection via setattr)
         #
         # Why not simply check the runtime type inside this guard?  It's slow enough to defeat
@@ -521,7 +521,7 @@ class GuardBuilder(GuardBuilderBase):
 
 
 # NB: Naively, you'd expect this to only be a function that produces
-# the callable that consistutes the guard.  However, there is some
+# the callable that constitutes the guard.  However, there is some
 # delicate handling for invalidating this check function when the
 # locals/globals get invalidated, so there's some extra state
 # we have to hold in this manager class.

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -458,7 +458,7 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
 
         # create a new unique name
         name = "_".join(map(str, names))
-        # e.g. repalce abc.xyz[123].qkv with abc.xyz_123.qkv
+        # e.g. replace abc.xyz[123].qkv with abc.xyz_123.qkv
         name = re.sub(r"\[(\d+)\]", r"_\g<1>", name)
         # e.g. replace abc.xyz_123.qkv with abc_xyz_123_qkv
         name = re.sub(r"[^a-zA-Z0-9]", "_", name)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -291,7 +291,7 @@ def generic_jump(truth_fn: typing.Callable[[object], bool], push: bool):
                 + if_jump
             )
         elif isinstance(value, NNModuleVariable):
-            # Equivant of "self.nn_module is not None"
+            # Equivalent of "self.nn_module is not None"
             if truth_fn(value):
                 push and self.push(value)
                 self.jump(inst)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -933,7 +933,7 @@ def same(
                 ):
                     # In the presence of noise, noise might dominate our error
                     # metric for smaller tensors.
-                    # Similary, for 1x1 kenerls, there seems to be high noise with amp.
+                    # Similary, for 1x1 kernels, there seems to be high noise with amp.
                     multiplier = 3.0
 
                 passes_test = res_error <= (multiplier * ref_error + tol / 10.0)


### PR DESCRIPTION
This PR fixes typos in comments and messages of `.py` files under `torch/_dynamo` directory


cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire