### PR TITLE
Fix typos under torch/_inductor directory 

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1374,12 +1374,12 @@ class CppVecKernelChecker(CppVecKernel):
     def __init__(self, args, num_threads, tiling_factor):
         super().__init__(args, num_threads, tiling_factor)
 
-        # Since this kernel is only for checker but does not genreate any
+        # Since this kernel is only for checker but does not generate any
         # code, so we need to decrease the kernel count.
         metrics.generated_kernel_count -= 1
         metrics.generated_cpp_vec_kernel_count -= 1
 
-        # Used to recorde the graph wrapper code as the wrapper_code status could be
+        # Used to record the graph wrapper code as the wrapper_code status could be
         # changed during graph run.
         self._orig_wrapper_code = None
 
@@ -1564,11 +1564,11 @@ class CppVecKernelChecker(CppVecKernel):
         self.exit_stack.__exit__(exc_type, exc_val, exc_tb)
 
     def __enter__(self):
-        # Recorde the graph wrapper code. The wrapper_code status could be
+        # Record the graph wrapper code. The wrapper_code status could be
         # changed during graph run. Regarding this checker, we also need to
         # run the graph but we don't expect to change any status that would
-        # impact the code generation. Hence, we record the graph wapper code
-        # and replace it with a dummy warpper_code and then restore to the
+        # impact the code generation. Hence, we record the graph wrapper code
+        # and replace it with a dummy wrapper_code and then restore to the
         # original one as long as the checker is finished.
         self._orig_wrapper_code = V.graph.wrapper_code
         V.graph.wrapper_code = WrapperCodeGen()

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -225,8 +225,8 @@ def should_pad_bench(mat1, mat2, op, input=None):
                 fast_flush=True,
             )[0]
 
-        # Shape padding introduces addtional memory ops. Based on microbenchmarks, 1.1x represents a reasonable
-        # tradeoff between performance improvement from shape padding and overhead from addtional memory ops
+        # Shape padding introduces additional memory ops. Based on microbenchmarks, 1.1x represents a reasonable
+        # tradeoff between performance improvement from shape padding and overhead from additional memory ops
         # TODO: Build a learned model which would be better than this heuristic
         return ori_time > pad_time * 1.1
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2312,7 +2312,7 @@ class ComputedBuffer(Buffer):
 
 class TemplateBuffer(Buffer):
     """
-    Represents a Triton (in the futurue other type) of template operator
+    Represents a Triton (in the future other type) of template operator
     that we can fuse an epilogue onto.
     """
 
@@ -2581,7 +2581,7 @@ class ExternKernel(InputsKernel):
         """
         In order to pass this to an extern kernel we need a
         ReinterpretView not a View.  This allows us to avoid some
-        uneeded copies.
+        unneeded copies.
         """
         assert isinstance(x, BaseView)
         if isinstance(x, ReinterpretView):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2555,7 +2555,7 @@ def reflection_pad2d_backward(grad_output, x, padding):
         # -----------------------------------------
         #   bottom-left |   bottom  |   bottom-right
         #
-        # The center area is the orignial matrix. Other areas are reflections.
+        # The center area is the original matrix. Other areas are reflections.
 
         center_x, center_y = x + top, y + left
         top_reflect_x, left_reflect_y = top - x, left - y

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -203,7 +203,7 @@ class CallFunction(PatternExpr):
         node_items, node_spec = self.flatten(node.args, node.kwargs)
         self_items, self_spec = self.flat_args_kwargs
         if node_spec != self_spec:
-            return FailedMatch(f"args_stucture {node_spec} {self_spec}")
+            return FailedMatch(f"args_structure {node_spec} {self_spec}")
         assert len(node_items) == len(self_items)
 
         m = Match(self)

--- a/torch/_inductor/triton_ops/conv.py
+++ b/torch/_inductor/triton_ops/conv.py
@@ -61,7 +61,7 @@ if has_triton():
         BLOCK_N: tl.constexpr,
         # reduction tiling parameter for matmul
         BLOCK_K: tl.constexpr,
-        # Super-blocking for better L2 peformance
+        # Super-blocking for better L2 performance
         GROUP_H: tl.constexpr,
     ):
         """
@@ -248,7 +248,7 @@ if has_triton():
         BLOCK_N: tl.constexpr,
         # reduction tiling parameter for matmul
         BLOCK_K: tl.constexpr,
-        # Super-blocking for better L2 peformance
+        # Super-blocking for better L2 performance
         GROUP_H: tl.constexpr,
     ):
         """
@@ -373,7 +373,7 @@ if has_triton():
     class _conv:
         kernel = _kernel_delta_x_hwc
 
-        # for the contigous order of w ptr, what"s the corresponding
+        # for the contiguous order of w ptr, what"s the corresponding
         # ptr changes for x in a sliding window
         @staticmethod
         def _delta_x_ptr_hwc(
@@ -465,7 +465,7 @@ if has_triton():
             shape_w = w.shape
             shape_bias = bias.shape if bias is not None else None
 
-            # indicies for the layout
+            # indices for the layout
             xn, xc, xh, xw = 0, 1, 2, 3
             yn, yc, yh, yw = 0, 1, 2, 3
             wn, wc, wh, ww = 0, 1, 2, 3

--- a/torch/_inductor/triton_ops/conv1x1.py
+++ b/torch/_inductor/triton_ops/conv1x1.py
@@ -26,7 +26,7 @@ if has_triton():
             shape_w = w.shape
             shape_bias = bias.shape if bias is not None else None
 
-            # indicies for the layout
+            # indices for the layout
             xn, xc, xh, xw = 0, 1, 2, 3
             yn, yc, yh, yw = 0, 1, 2, 3
             wn, wc, wh, ww = 0, 1, 2, 3


### PR DESCRIPTION
This PR fixes typos in comments and messages of `.py` files under `torch/_inductor` directory


cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire