### PR TITLE
suppress nvfuser loading warning when we disable nvfuser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1164,6 +1164,7 @@ if(BUILD_NVFUSER)
   else()
     add_subdirectory(third_party/nvfuser nvfuser)
   endif()
+  add_compile_definitions(BUILD_NVFUSER)
 endif()
 
 include(cmake/Summary.cmake)

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -44,7 +44,9 @@ class LoadingNvfuserLibrary {
     try {
       nvfuserLib_ = std::make_shared<at::DynamicLibrary>(library_name.c_str());
     } catch (const c10::DynamicLibraryError& e) {
+#if defined(BUILD_NVFUSER) || !defined(NODEBUG)
       TORCH_WARN("Loading nvfuser library failed with: ", e.msg());
+#endif
     }
   }
 


### PR DESCRIPTION
To avoid annoying warnings such as "[W interface.cpp:47] Warning: Loading nvfuser library failed" 
