### PR TITLE
[dynamo] avoid truncation of python pointers 

### DIFF
--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -321,8 +321,8 @@ static PyTypeObject TensorGuardsType = {
 static PyObject* check_type_id(PyObject* dummy, PyObject* args) {
   // faster `lambda obj, expected: id(type(obj)) == expected`
   PyObject* obj;
-  unsigned long expected;
-  if (!PyArg_ParseTuple(args, "Ok", &obj, &expected)) {
+  unsigned long long expected;
+  if (!PyArg_ParseTuple(args, "OK", &obj, &expected)) {
     return NULL;
   }
   if (Py_TYPE(obj) == (void*)expected) {
@@ -335,8 +335,8 @@ static PyObject* check_type_id(PyObject* dummy, PyObject* args) {
 static PyObject* check_obj_id(PyObject* dummy, PyObject* args) {
   // faster `lambda obj, expected: id(obj) == expected`
   PyObject* obj;
-  unsigned long expected;
-  if (!PyArg_ParseTuple(args, "Ok", &obj, &expected)) {
+  unsigned long long expected;
+  if (!PyArg_ParseTuple(args, "OK", &obj, &expected)) {
     return NULL;
   }
   if (obj == (void*)expected) {


### PR DESCRIPTION
This PR is separated from #94927 . It aims to fix to the MSVC warnings that passed python pointers are truncated to a smaller integer type.


cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire