### PR TITLE
Support elementwise add / mul for [B, *] nested, [B, 1] dense (CUDA only)

### DIFF
--- a/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
@@ -99,19 +99,31 @@ Tensor NestedTensor_elementwise_Tensor(
       self_impl->get_storage_offsets()
     );
   }
-  // special case when other is dense
-  if (self.is_nested() && !other.is_nested()) {
+  // special case when other is dense (CUDA only for now)
+  if (self.is_nested() && !other.is_nested() && self.is_cuda() && other.is_cuda()) {
+    auto self_ptr = get_nested_tensor_impl(self);
+    auto other_ = other;
     // check for the [B, *, D], [B, 1, D] esuhm case
     // TODO: this if statement is ugly and hopefully we will remove this in the near future
-    auto self_ptr = get_nested_tensor_impl(self);
-    if (self_ptr->dim() == 3 &&
+    bool is_esuhm = (
+        self_ptr->dim() == 3 &&
         other.dim() == 3 &&
         self_ptr->size(0) == other.size(0) &&
         other.size(1) == 1 &&
         self_ptr->opt_size(2).has_value() &&
-        self_ptr->opt_size(2).value() == other.size(2) &&
-        self.is_cuda() &&
-        other.is_cuda()) {
+        self_ptr->opt_size(2).value() == other.size(2));
+    // check for the [B, *], [B, 1] case -> treat as esuhm with [B, *, 1], [B, 1, 1]
+    bool is_broadcastable_2d = (
+        self_ptr->dim() == 2 &&
+        other.dim() == 2 &&
+        self_ptr->size(0) == other.size(0) &&
+        other.size(1) == 1);
+    if(is_broadcastable_2d) {
+        other_ = other.unsqueeze(-1);
+        is_esuhm = true;
+    }
+
+    if (is_esuhm) {
       if (!nested_tensor_impl_is_contiguous(self_ptr)) {
         self_ptr = get_nested_tensor_impl(self.contiguous());
       }
@@ -120,9 +132,9 @@ Tensor NestedTensor_elementwise_Tensor(
       auto result_buffer = at::empty_like(self_buffer);
       auto result = wrap_buffer(result_buffer, self_sizes);
       if (op_name == "add") {
-        nested_dense_elementwise_stub(self.device().type(), result, self, other, NESTED_DENSE_OP::ADD);
+        nested_dense_elementwise_stub(self.device().type(), result, self, other_, NESTED_DENSE_OP::ADD);
       } else if (op_name == "mul") {
-        nested_dense_elementwise_stub(self.device().type(), result, self, other, NESTED_DENSE_OP::MUL);
+        nested_dense_elementwise_stub(self.device().type(), result, self, other_, NESTED_DENSE_OP::MUL);
       } else {
         TORCH_CHECK(false, "Unsupported nested dense elementwise op");
       }

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -917,15 +917,28 @@ class TestNestedTensorDeviceType(TestCase):
     @torch.inference_mode()
     @parametrize("embedding_dim", [8, 128, 256, 384])
     def test_nested_tensor_dense_elementwise(self, device, dtype, embedding_dim):
+        def _test_add_mul(nt, t):
+            ref_add = torch.nested.nested_tensor(
+                [t1 + t2 for (t1, t2) in zip(nt.unbind(), t.unbind())])
+            ref_mul = torch.nested.nested_tensor(
+                [t1 * t2 for (t1, t2) in zip(nt.unbind(), t.unbind())])
+            self.assertEqual(nt.add(t), ref_add)
+            self.assertEqual(nt.mul(t), ref_mul)
+
         batch_size = 32
         seq_lens = torch.randint(low=0, high=10, size=(batch_size,))
+
+        # [B, *, D], [B, 1, D] case
         ts = [torch.randn((seq_len, embedding_dim)) for seq_len in seq_lens]
         nt = torch.nested.nested_tensor(ts, device=device, dtype=dtype)
         t = torch.randn((batch_size, 1, embedding_dim), device=device, dtype=dtype)
-        ref_add = torch.nested.nested_tensor([t1 + t2 for (t1, t2) in zip(nt.unbind(), t.unbind())])
-        ref_mul = torch.nested.nested_tensor([t1 * t2 for (t1, t2) in zip(nt.unbind(), t.unbind())])
-        self.assertEqual(nt.add(t), ref_add)
-        self.assertEqual(nt.mul(t), ref_mul)
+        _test_add_mul(nt, t)
+
+        # [B, *], [B, 1] case
+        ts = [torch.randn(seq_len) for seq_len in seq_lens]
+        nt = torch.nested.nested_tensor(ts, device=device, dtype=dtype)
+        t = torch.randn((batch_size, 1), device=device, dtype=dtype)
+        _test_add_mul(nt, t)
 
     @dtypes(torch.float, torch.float16)
     @skipMeta


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95620

Small hack to reuse the 3D custom kernel from #88289 for [B, *] nested, [B, 1] dense elementwise add / mul. Simply treat the inputs as [B, *, 1], [B, 1, 1]. This is added to satisfy an internal ask.

Future work: full general broadcasting support between mixed nested / dense.

cc @cpuhrsch @bhosmer @drisspg @mikaylagawarecki