### PR TITLE
[Docs] Document of RReLU about its different behavior between training and evaluation

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -123,7 +123,8 @@ class RReLU(Module):
         \end{cases}
 
     where :math:`a` is randomly sampled from uniform distribution
-    :math:`\mathcal{U}(\text{lower}, \text{upper})`.
+    :math:`\mathcal{U}(\text{lower}, \text{upper})` during training while during 
+    evaluation :math:`a` is fixed with :math:`a = \frac{\text{lower} + \text{upper}}{2}`.
 
      See: https://arxiv.org/pdf/1505.00853.pdf
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -123,7 +123,7 @@ class RReLU(Module):
         \end{cases}
 
     where :math:`a` is randomly sampled from uniform distribution
-    :math:`\mathcal{U}(\text{lower}, \text{upper})` during training while during 
+    :math:`\mathcal{U}(\text{lower}, \text{upper})` during training while during
     evaluation :math:`a` is fixed with :math:`a = \frac{\text{lower} + \text{upper}}{2}`.
 
      See: https://arxiv.org/pdf/1505.00853.pdf


### PR DESCRIPTION
Current document of [Randomized Leaky ReLU (RReLU)](https://pytorch.org/docs/stable/generated/torch.nn.RReLU.html#torch.nn.RReLU) does not demonstrate its different behavior between training and evaluation. This PR adds illustrations about this.

Fixes #95605.
