### PR TITLE
Reserve the tensorrt backend name for torch-tensorrt

### DIFF
--- a/torch/_dynamo/backends/onnxrt.py
+++ b/torch/_dynamo/backends/onnxrt.py
@@ -116,8 +116,3 @@ def onnxrt(gm, example_inputs, *, filename=None, provider=None):
         return outputs
 
     return _call
-
-
-@register_backend
-def tensorrt(gm, example_inputs):
-    return onnxrt(gm, example_inputs, provider="TensorrtExecutionProvider")

--- a/torch/_dynamo/backends/tensorrt.py
+++ b/torch/_dynamo/backends/tensorrt.py
@@ -1,0 +1,12 @@
+# import torch  # type: ignore[import]
+# from .common import device_from_inputs, fake_tensor_unsupported  # type: ignore[import]
+# from .registry import register_backend  # type: ignore[import]
+
+"""
+Placeholder for TensorRT backend for dynamo via torch-tensorrt
+"""
+
+# @register_backend
+# def tensorrt(gm, example_inputs):
+#    import torch_tensorrt # type: ignore[import]
+#    pass


### PR DESCRIPTION
Cherry-pick #94632

In PR https://github.com/pytorch/pytorch/pull/93822 the fx2trt backend was removed which registered the tensorrt backend names to point to fx2trt / torch_tensorrt and move the name to onnxrt. We want to reserve the name tensorrt for torch_tensorrt to prevent any confusion but due to code-freeze we cannot complete the integration and set up testing for the next release. So we propose leaving out the tensorrt name until we can set up the backend and testing for it.


cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire