### PR TITLE
Fix typos under torch/distributed directory

### DIFF
--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -186,7 +186,7 @@ class TensorParallelStyleTest(DTensorTestBase):
         )
         with self.assertRaisesRegex(
             AssertionError,
-            "device_mesh has dims 2 but expcted to be 1 for output.",
+            "device_mesh has dims 2 but expected to be 1 for output.",
         ):
             func(dtensor, device_mesh)
 

--- a/test/distributed/tensor/parallel/test_tp_style.py
+++ b/test/distributed/tensor/parallel/test_tp_style.py
@@ -41,7 +41,7 @@ class TensorParallelStyleTest(DTensorTestBase):
         )
         with self.assertRaisesRegex(
             RuntimeError,
-            "device_mesh has dims [0-9]+ but expcted to be 1 for input.",
+            "device_mesh has dims [0-9]+ but expected to be 1 for input.",
         ):
             dtensor = func(input_local_tensor, device_mesh)
 

--- a/torch/distributed/_composable/contract.py
+++ b/torch/distributed/_composable/contract.py
@@ -11,7 +11,7 @@ from torch.distributed._composable_state import _State
 # properties.
 # TODO: since all composable distributed features can share the same slot.
 class _StateKey(str):
-    # Make _StateKey as str to satify the assumption that object.__dict__.keys()
+    # Make _StateKey as str to satisfy the assumption that object.__dict__.keys()
     # are strings.
     def __new__(cls, string="__composable_api_state_key"):
         return super().__new__(cls, f"{string}_{str(uuid.uuid4())}")

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -56,7 +56,7 @@ We use this dictionary when AsyncCollectiveTensor is used to invoke Work::wait()
 Finally, we setup a finalizer against the tensor wrapper to observe it getting collected so we
 can clean up stale entries in the dictionary.
 
-To eliminate the possiblity of races we have a global version counter that is used by the finalizer.
+To eliminate the possibility of races we have a global version counter that is used by the finalizer.
 
 As a wise man said once: Don't cross the streams (https://www.youtube.com/watch?v=wyKQe_i9yyo)
 

--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -421,7 +421,7 @@ class ShardedTensor(ShardedTensorBase):
 
     def _get_preferred_device(self) -> torch.device:
         """
-        Return the prefered device to be used when creating tensors for collectives.
+        Return the preferred device to be used when creating tensors for collectives.
         This method takes into account the associated process group
         """
         if dist.get_backend(self._process_group) == dist.Backend.NCCL:

--- a/torch/distributed/_shard/sharding_plan/api.py
+++ b/torch/distributed/_shard/sharding_plan/api.py
@@ -29,7 +29,7 @@ class ShardingPlan:
             Default: `None`
         return_local_tensor (List[str], optional): a list of string, each element enables
             a module's sharded output to be returned as a Tensor from its local shards to
-            ensure further processsing in a data parallel fashion. ("" in list means the
+            ensure further processing in a data parallel fashion. ("" in list means the
             root module).
             Default: None
     Example:

--- a/torch/distributed/_spmd/comm_tensor.py
+++ b/torch/distributed/_spmd/comm_tensor.py
@@ -65,7 +65,7 @@ class CommTensor(torch.Tensor):
 
     In eager mode, it will record whether the inplace collective communication
     has been launched using this Tensor and remember the corresponding work
-    handle. If yes, it will expliclty call wait() in the ``__torch_dispatch__``
+    handle. If yes, it will explicitly call wait() in the ``__torch_dispatch__``
     function before subsequent operations consuming the value of the Tensor.
 
     In tracing mode, ``CommTensor`` inserts two node into the graph using the

--- a/torch/distributed/_spmd/graph_utils.py
+++ b/torch/distributed/_spmd/graph_utils.py
@@ -39,7 +39,7 @@ def get_comm_block_nodes(
     wait_node: fx.Node, comm_type: CommType
 ) -> Tuple[int, List[fx.Node]]:
     """
-    Given a wait_comm node, find out all the nodes belong to this communcation.
+    Given a wait_comm node, find out all the nodes belong to this communication.
 
     Args:
         wait_node(fx.Node): The target wait_comm node.

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -36,7 +36,7 @@ __all__ = ["DTensor", "distribute_tensor", "distribute_module"]
 #  input(torch.Tensor) -> Module A -> Module B -> Module C -> output (torch.Tensor)
 #
 # Suppose I only want to make Module B be a sharded module with
-# DistributedTensor params, we would need to make the folloing
+# DistributedTensor params, we would need to make the following
 # flow to work:
 #
 #  input(torch.Tensor) -> Module A
@@ -411,7 +411,7 @@ def distribute_tensor(
     """
     # get default device mesh if there's nothing specified
     device_mesh = get_global_device_mesh() if device_mesh is None else device_mesh
-    # convert tensor to the correponding device type if it's not in that device type
+    # convert tensor to the corresponding device type if it's not in that device type
     if not tensor.is_meta:
         tensor = tensor.to(device_mesh.device_type)
     # set default placements to replicated if not specified

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -171,7 +171,7 @@ class DeviceMesh:
 
         if self.mesh.ndim == 1 and len(unique_mesh_values) == get_world_size():
             # if the mesh is the same as world_pg, we just append the default
-            # pg to the first dim goups, as new_group cannot have the exact
+            # pg to the first dim groups, as new_group cannot have the exact
             # same ranks as world
             dim_groups.append(default_pg)
         else:

--- a/torch/distributed/_tensor/op_schema.py
+++ b/torch/distributed/_tensor/op_schema.py
@@ -10,7 +10,7 @@ from torch.distributed._tensor.placement_types import DTensorSpec
 ArgsType = Tuple[object, ...]
 KwargsType = Dict[str, object]
 # ATen op schemas could have Tensor, Tuple[Tensor] and List[Tensor], so output type sould
-# be the same set of possiblities.
+# be the same set of possibilities.
 OutputSpecType = Optional[Union[DTensorSpec, Sequence[Optional[DTensorSpec]]]]
 
 

--- a/torch/distributed/_tensor/ops/view_ops.py
+++ b/torch/distributed/_tensor/ops/view_ops.py
@@ -382,7 +382,7 @@ def dim_squeeze(shape: Shape, dim: Optional[int] = None) -> DimMap:
     # FIXME: this is wrong when dim=None and one of the dimensions
     # equals size of the mesh. For example squeeze(DTensor(tensor(4), Shard[0])) could
     # end up as squeeze(tensor(1)) if we have 4 devices; this would lead to
-    # removal of a dimension that is not acutally a singleton.
+    # removal of a dimension that is not actually a singleton.
     return tuple(
         InputDim(i)
         for i, s in enumerate(shape)

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -47,7 +47,7 @@ class Shard(Placement):
         # it might be slow compared to even size collective, we need to pad tensor
         # before really calling the collective, and unpad/narrow it afterwards
         # TODO: consider if we should remove this logic once ProcessGroupGloo
-        # support uneven list, and collective perfomance on par
+        # support uneven list, and collective performance on par
         assert (
             self.dim <= tensor.ndim
         ), f"Sharding dim {self.dim} greater than tensor ndim {tensor.ndim}"
@@ -63,7 +63,7 @@ class Shard(Placement):
             for i, shard in enumerate(tensor_list):
                 if with_padding and idx_start_to_pad != 0 and i >= idx_start_to_pad:
                     shard = self._pad_tensor(shard)
-                # input tensors are expected to be congtiguous by the collective backend
+                # input tensors are expected to be contiguous by the collective backend
                 shard = shard.contiguous() if contiguous else shard
                 shard_list.append(shard)
             return shard_list, idx_start_to_pad

--- a/torch/distributed/_tensor/redistribute.py
+++ b/torch/distributed/_tensor/redistribute.py
@@ -38,7 +38,7 @@ def _decompose_reshard(val: List[_PlacementItem]) -> List[_PlacementItem]:
           (Shard(0), Shard(0)) -> (Replicate(), Shard(0))
           Here the Shard(0) -> Shard(0) for mesh dimension 2 is actually
           a reshard, because in the first case it's a sub-sharding of an already tensor dimension 0,
-          and in the second case, it's the first sharding on tensor dimesnion 0.
+          and in the second case, it's the first sharding on tensor dimension 0.
     """
     # detect mis-aligned repeated shardings
     from collections import defaultdict
@@ -219,7 +219,7 @@ class Redistribute(torch.autograd.Function):
         # In this case we keep the grad as replicate, this is because we don't
         # want to convert the replicated gradients back to partial, although
         # that's logically conform with the same layout, converting the gradients
-        # back to partial is acutally useless as you would have to do reduce later
+        # back to partial is actually useless as you would have to do reduce later
         # which would be more expensive than keeping it replicate! For this reason,
         # we keep the replicate grad here.
         # TODO: see if this make sense for all cases.

--- a/torch/distributed/_tensor/sharding_prop.py
+++ b/torch/distributed/_tensor/sharding_prop.py
@@ -109,7 +109,7 @@ class ShardingPropagator:
                     output_sharding.schema_suggestions = [op_schema]
             else:
                 # we do auto redistribute on inputs if necessary
-                # to get an eligble input, which we will pick a
+                # to get an eligible input, which we will pick a
                 # schema suggestion base on the redistribute cost.
                 # For now we simply pick the first suggestion.
                 # TODO: implement full auto distribute with a

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -235,7 +235,7 @@ class MemoryTracker:
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """
-        The pre_foward_hook is to insert current module name with forward prefix for the operator
+        The pre_forward_hook is to insert current module name with forward prefix for the operator
         name, also it inserts the marker "fw_start" when the forward pass begins.
         """
 

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -81,7 +81,7 @@ def _should_compress(
 
     The result of this function is a tuple of the form (compression_recommendation, uncompressed_el_count, compressed_el_count), where:
 
-    compresion_recommendation is true if the tensor is worth compressing, and false otherwise (see above);
+    compression_recommendation is true if the tensor is worth compressing, and false otherwise (see above);
 
     uncompressed_el_count is the uncompressed element count, i.e. ``num_rows`` * ``num_cols``; and,
 
@@ -258,7 +258,7 @@ class PowerSGDState:
             1, compression_stats_logging_frequency
         )
         self.next_stats_report = 0
-        # Batching tensors with same shape can increase parallelism in compressiom / decompression computation.
+        # Batching tensors with same shape can increase parallelism in compression / decompression computation.
         # This requires a larger bucket size to make more same-shaped tensor to appear in one bucket, however
         # this may reduce the overlap between computation and communication, and increase the memory footprint
         # due to stacking tensors.
@@ -827,7 +827,7 @@ def batched_powerSGD_hook(
         if state.use_error_feedback:
             # Memorize the local errors.
             state.error_dict[bucket_index] = input_tensor_cp - input_tensor
-        # Removing this seemingly unnecessary sync somehow may cause faliures.
+        # Removing this seemingly unnecessary sync somehow may cause failures.
         # See: https://github.com/pytorch/pytorch/pull/54838
         if torch.cuda.is_available():
             torch.cuda.synchronize(device)

--- a/torch/distributed/algorithms/ddp_comm_hooks/quantization_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/quantization_hooks.py
@@ -50,7 +50,7 @@ def quantization_pertensor_hook(
     protocol. Workers first allgather the scale and zero point of their own
     ``GradBucket`` prior to the quantization. After all workers have that information,
     the first ``then`` callback called ``quantize_and_allgather`` quantizes worker's
-    own gradient tensor, and uses ``allgather`` to communicate these accross all workers.
+    own gradient tensor, and uses ``allgather`` to communicate these across all workers.
     The final ``then`` callback called ``dequantize_and_aggregate``, dequantizes and
     aggregates each quantized gradient tensor locally and returns the mean.
 
@@ -82,7 +82,7 @@ def quantization_pertensor_hook(
     ).get_future()
 
     def quantize_and_allgather(fut):
-        # Store scale and zeros accross all workers.
+        # Store scale and zeros across all workers.
         all_ranks_s_and_z = fut.wait()[0]
         # All workers quantize their own ``GradBucket`` tensors.
         quantized_tensor = _quantize_per_tensor_cuda(
@@ -130,7 +130,7 @@ def quantization_perchannel_hook(
     elements. Then, workers allgather the scales and zero points of their own
     ``GradBucket`` prior to the quantization. After all workers have that information,
     the first ``then`` callback called ``quantize_and_allgather`` quantizes worker's
-    own gradient tensor, and uses ``allgather`` to communicate these accross all workers.
+    own gradient tensor, and uses ``allgather`` to communicate these across all workers.
     The final ``then`` callback called ``dequantize_and_aggregate``, dequantizes, flattens, and
     aggregates each quantized gradient tensor locally and returns the mean.
 
@@ -174,7 +174,7 @@ def quantization_perchannel_hook(
     ).get_future()
 
     def quantize_and_allgather(fut):
-        # Store scale and zeros accross all workers.
+        # Store scale and zeros across all workers.
         all_ranks_s_and_z = fut.wait()[0]
         # All workers quantize their corresponding ``GradBucket`` tensors.
         quantized_tensor = _quantize_per_channel_cuda(

--- a/torch/distributed/algorithms/model_averaging/hierarchical_model_averager.py
+++ b/torch/distributed/algorithms/model_averaging/hierarchical_model_averager.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class HierarchicalModelAverager(averagers.ModelAverager):
     r"""
     Runs hierarchical model averaging (`hierarchical SGD <https://arxiv.org/pdf/2010.12998.pdf>`_).
-    Process groups of different sizes are organized in a hierarhicy, and they average parameters
+    Process groups of different sizes are organized in a hierarchy, and they average parameters
     by using different periods concurrently after the warm-up stage.
     This is an extension of :class:`~torch.distributed.algorithms.model_averaging.averagers.PeriodicModelAverager`
     that supports `post-local SGD <https://arxiv.org/abs/1808.07217>`_, which essentially only supports

--- a/torch/distributed/checkpoint/_traverse.py
+++ b/torch/distributed/checkpoint/_traverse.py
@@ -163,7 +163,7 @@ def print_tensor(
     print_fun: Callable[[str], None] = print,
 ) -> None:
     """
-    Callback that can be used with travese_state_dict to print its content.
+    Callback that can be used with traverse_state_dict to print its content.
     By default the content is printed using the builtin ``print`` but this can
     be change by passing a different ``print_fun` callable.
     """

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -328,7 +328,7 @@ class FileSystemWriter(StorageWriter):
         Initialize the writer pointing to `path`
 
         Args:
-            path: diretory where the checkpoint will be writen to.
+            path: directory where the checkpoint will be written to.
             single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
             sync_files : force files to be synced to permanent storage. Default to True.
             thread_count: Number of IO threads to use to write. Default to 1.
@@ -506,7 +506,7 @@ class FileSystemReader(StorageReader):
         fut.set_result(None)
         return fut
 
-    # Implementating the abstract function in StorageReader
+    # Implementing the abstract function in StorageReader
     def read_metadata(self) -> Metadata:
         with (self.path / ".metadata").open("rb") as metadata_file:
             return pickle.load(metadata_file)

--- a/torch/distributed/checkpoint/optimizer.py
+++ b/torch/distributed/checkpoint/optimizer.py
@@ -202,7 +202,7 @@ def load_sharded_optimizer_state_dict(
     storage_reader: dist_cp.StorageReader,
 ) -> STATE_DICT_TYPE:
     """
-    Loads a state_dict in conjuntion with FSDP sharded optimizer state.
+    Loads a state_dict in conjunction with FSDP sharded optimizer state.
     This is the current recommended way to checkpoint FSDP.
     >>> # xdoctest: +SKIP
     >>> import torch.distributed.checkpoint as dist_cp

--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -95,7 +95,7 @@ class SavePlanner(abc.ABC):
 
     SavePlanners are stateful objects that can be used to customize the whole save process.
 
-    SavePlanner acts as an access proxy to the state_dict, so any transfomation done to it
+    SavePlanner acts as an access proxy to the state_dict, so any transformation done to it
     will be visible to the whole process.
 
     A planner subclass can expect the following sequence of calls during save_state_dict:
@@ -115,7 +115,7 @@ class SavePlanner(abc.ABC):
     5) resolve_data - called multiple times on each rank
         Lookups a value on the `state_dict` for the storage layer to write.
 
-    Users are recomended to extend DefaultSavePlanner instead of this interface directly as
+    Users are recommended to extend DefaultSavePlanner instead of this interface directly as
     most changes can be expressed by changes in a single method.
 
     There are 3 usual patterns of extension:
@@ -248,7 +248,7 @@ class LoadPlanner:
 
     LoadPlanner are stateful objects that can be used to customize the whole load process.
 
-    LoadPlanner acts as an access proxy to the state_dict, so any transfomation done to it
+    LoadPlanner acts as an access proxy to the state_dict, so any transformation done to it
     will be visible to the whole process.
 
     A planner subclass can expect the following sequence of calls during load_state_dict:
@@ -268,7 +268,7 @@ class LoadPlanner:
     5) resolve_tensor and commit_tensor - called multiple times on each rank
         They are called in pair for each Tensor value in state_dict.
 
-    Users are recomended to extend DefaultLoadPlanner instead of this interface directly as
+    Users are recommended to extend DefaultLoadPlanner instead of this interface directly as
     most changes can be expressed by changes in a single method.
 
     There are two usual patterns of extension:

--- a/torch/distributed/checkpoint/state_dict_saver.py
+++ b/torch/distributed/checkpoint/state_dict_saver.py
@@ -65,7 +65,7 @@ def save_state_dict(
         >>> fs_storage_writer = torch.distributed.checkpoint.FileSystemWriter("/checkpoint/1")
         >>> torch.distributed.checkpoint.save_state_dict(
         >>>     state_dict=model_state_dict,
-        >>>     storage_writer=fs_stroage_writer,
+        >>>     storage_writer=fs_storage_writer,
         >>> )
 
     .. note::

--- a/torch/distributed/checkpoint/storage.py
+++ b/torch/distributed/checkpoint/storage.py
@@ -50,7 +50,7 @@ class StorageWriter(abc.ABC):
         Initialize this instance.
 
         Args:
-            is_coordinator (bool): Whether this instance is reponsible for coordinating
+            is_coordinator (bool): Whether this instance is responsible for coordinating
               the checkpoint.
         """
         pass
@@ -60,7 +60,7 @@ class StorageWriter(abc.ABC):
         """
         Perform storage-specific local planning.
 
-        While this method can produce a completely different plan, the recomended
+        While this method can produce a completely different plan, the recommended
         way is to store storage specific data in SavePlan::storage_data.
 
         Args:
@@ -78,7 +78,7 @@ class StorageWriter(abc.ABC):
 
         This method is only called on the coordinator instance.
 
-        While this method can produce a completely different plan, the prefered
+        While this method can produce a completely different plan, the preferred
         way is to store storage specific data in SavePlan::storage_data.
 
         Args:
@@ -100,7 +100,7 @@ class StorageWriter(abc.ABC):
         from the plan to get access to the underlying object to write.
 
         Subclasses should lazily call `resolve_data` as it can allocate memory.
-        In case of tensors, make following assuptions:
+        In case of tensors, make following assumptions:
 
         - They might be on any device, including not matching the one on ``WriteItem::tensor_data``
         - They might be views or not contiguous. Only the projection needs to be saved.
@@ -119,7 +119,7 @@ class StorageWriter(abc.ABC):
         self, metadata: Metadata, results: List[List[WriteResult]]
     ) -> None:
         """
-        Writes the metadata and marks the current checkpoint as sucessful.
+        Writes the metadata and marks the current checkpoint as successful.
 
         The actual format/schema used for serializing `metadata` is an
         implemetation detail. The only requirement is that it's recoverable
@@ -158,7 +158,7 @@ class StorageReader(abc.ABC):
         Reads the checkpoint metadata.
 
         Returns:
-            The metatada object associated with the checkpoint being loaded.
+            The metadata object associated with the checkpoint being loaded.
 
         """
         pass
@@ -170,7 +170,7 @@ class StorageReader(abc.ABC):
 
         Args:
             metadata (Metadata): The metadata schema to use.
-            is_coordinator (bool): Whether this instance is reponsible for coordinating
+            is_coordinator (bool): Whether this instance is responsible for coordinating
               the checkpoint.
         """
         pass
@@ -180,7 +180,7 @@ class StorageReader(abc.ABC):
         """
         Perform storage-specific local planning.
 
-        While this method can produce a completely different plan, the recomended
+        While this method can produce a completely different plan, the recommended
         way is to store storage specific data in LoadPlan::storage_data.
 
         Args:
@@ -198,7 +198,7 @@ class StorageReader(abc.ABC):
 
         This method is only called on the coordinator instance.
 
-        While this method can produce a completely different plan, the prefered
+        While this method can produce a completely different plan, the preferred
         way is to store storage specific data in LoadPlan::storage_data.
 
         Args:

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -288,7 +288,7 @@ class BackendConfig:
                 self.device_backend_map[device] = Backend(backend)
 
     def __repr__(self):
-        # string with all the device:backend pairs separared by commas
+        # string with all the device:backend pairs separated by commas
         return ",".join(f"{device}:{backend}" for device, backend in self.device_backend_map.items())
 
     def get_device_backend_map(self):
@@ -482,7 +482,7 @@ def _store_based_barrier(rank, store, timeout):
     world_size = get_world_size()
     # Use 'add' instead of 'get' since for some store implementations 'add'
     # doesn't work well with 'get'. Ideally the store implementations should
-    # be fixed, but for backward compatiblity reasons it is risky to change
+    # be fixed, but for backward compatibility reasons it is risky to change
     # the store implementations. Once, we completely migrate away from these
     # legacy stores, we can use 'get' here instead.
     worker_count = store.add(store_key, 0)
@@ -826,7 +826,7 @@ def init_process_group(
     Args:
         backend (str or Backend, optional): The backend to use. Depending on
             build-time configurations, valid values include ``mpi``, ``gloo``,
-            ``nccl``, and ``ucc``. If the backend is not provied, then both a ``gloo``
+            ``nccl``, and ``ucc``. If the backend is not provided, then both a ``gloo``
             and ``nccl`` backend will be created, see notes below for how multiple
             backends are managed. This field can be given as a lowercase string
             (e.g., ``"gloo"``), which can also be accessed via
@@ -2170,7 +2170,7 @@ def gather_object(obj, object_gather_list=None, dst=0, group=None):
         _warn_not_in_group("gather_object")
         return
 
-    # Ensure object_gather_list is specified appopriately.
+    # Ensure object_gather_list is specified appropriately.
     my_rank = get_rank()
     _validate_output_list_for_rank(my_rank, dst, object_gather_list)
     current_device = _get_pg_device(group)
@@ -3092,7 +3092,7 @@ def all_to_all_single(
     Complex tensors are supported.
 
     Args:
-        output (Tensor): Gathered cancatenated output tensor.
+        output (Tensor): Gathered concatenated output tensor.
         input (Tensor): Input tensor to scatter.
         output_split_sizes: (list[Int], optional): Output split sizes for dim 0
             if specified None or empty, dim 0 of ``output`` tensor must divide

--- a/torch/distributed/elastic/events/api.py
+++ b/torch/distributed/elastic/events/api.py
@@ -34,7 +34,7 @@ class Event:
     Args:
         name: event name.
         source: the event producer, e.g. agent or worker
-        timestamp: timestamp in milliseconds when event occured.
+        timestamp: timestamp in milliseconds when event occurred.
         metadata: additional data that is associated with the event.
     """
 

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -266,7 +266,7 @@ class PContext(abc.ABC):
         A timeout value of zero simply queries the status of the processes (e.g. equivalent
         to a poll).
 
-        ..note: Multiprocesing library registers SIGTERM and SIGINT signal handlers that raise
+        ..note: Multiprocessing library registers SIGTERM and SIGINT signal handlers that raise
                 ``SignalException`` when the signals received. It is up to the consumer of the code
                 to properly handle the exception. It is important not to swallow the exception otherwise
                 the process would not terminate. Example of the typical workflow can be:
@@ -322,7 +322,7 @@ class PContext(abc.ABC):
         meta resources (e.g. redirect, error_file files).
 
         Args:
-            death_sig: Death signal to terminate porcesses.
+            death_sig: Death signal to terminate processes.
             timeout: Time to wait for processes to finish, if process is
                 still alive after this time, it will be terminated via SIGKILL.
         """
@@ -525,7 +525,7 @@ class MultiprocessContext(PContext):
                     os.kill(proc.pid, death_sig)
                 except ProcessLookupError:
                     # If the process exited because of some reason,
-                    # `ProcessLookupError` will be rasied, it is safe to ignore it.
+                    # `ProcessLookupError` will be raised, it is safe to ignore it.
                     pass
         end = time.monotonic() + timeout
         for proc in self._pc.processes:
@@ -542,7 +542,7 @@ class MultiprocessContext(PContext):
                     os.kill(proc.pid, _get_kill_signal())
                 except ProcessLookupError:
                     # If the process exited because of some reason,
-                    # `ProcessLookupError` will be rasied, it is safe to ignore it.
+                    # `ProcessLookupError` will be raised, it is safe to ignore it.
                     pass
             proc.join()
 

--- a/torch/distributed/elastic/multiprocessing/redirects.py
+++ b/torch/distributed/elastic/multiprocessing/redirects.py
@@ -51,7 +51,7 @@ def redirect(std: str, to_file: str):
     """
     Redirects ``std`` (one of ``"stdout"`` or ``"stderr"``) to a file
     in the path specified by ``to_file``. This method redirects the
-    underlying std file descriptor (not just pyton's ``sys.stdout|stderr``).
+    underlying std file descriptor (not just python's ``sys.stdout|stderr``).
     See usage for details.
 
     Directory of ``dst_filename`` is assumed to exist and the destination file

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -915,7 +915,7 @@ class DynamicRendezvousHandler(RendezvousHandler):
             max_nodes:
                 The maximum number of nodes to admit to the rendezvous.
             local_addr:
-                The local node adress.
+                The local node address.
             timeout:
                 The timeout configuration of the rendezvous.
         """

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -69,7 +69,7 @@ CONST_WORKER_KEEPALIVE_TTL = 10
 # TTL for the ephemeral run_id-specific directory. All rendezvous state data
 # for a specific run_id (job instance) is contained within directory.
 # Its only role is to clean-up rendezvous data from old runs (for the case when
-# etcd server is persistent), and has no affect on correctnes, but should be
+# etcd server is persistent), and has no affect on correctness, but should be
 # larger than any timeouts that a worker process is expected to survive:
 CONST_RUNID_SUBROOT_TTL = 7200  # 2 hours
 
@@ -372,7 +372,7 @@ class EtcdRendezvous:
 
         # If this worker was first to reach num_min_workers requirement,
         # and rendezvous is still joinable (therefore it is elastic),
-        # then this worker will be repsonsible for waiting out the "last call"
+        # then this worker will be responsible for waiting out the "last call"
         # timeout and closing (i.e. transitioning to 'frozen') the rendezvous
         # afterwards.
         # As a safety against a potential failure of this worker (during the
@@ -398,7 +398,7 @@ class EtcdRendezvous:
 
     def confirm_phase(self, expected_version, this_rank):
         """
-        Once the rendezvous state trainsitions from 'joinable' to 'frozen',
+        Once the rendezvous state transitions from 'joinable' to 'frozen',
         we have every participant confirm their membership and setup per-member
         keep-alive TTL keys, and then wait for all other participants to confirm,
         which would then successfully conclude this rendezvous.
@@ -628,7 +628,7 @@ class EtcdRendezvous:
         active_version, state = self.get_rdzv_state()
         while True:
             if state["status"] == "final" and state["version"] == expected_version:
-                # Succcess. This rendezvous is final, and we accept it.
+                # Success. This rendezvous is final, and we accept it.
                 return active_version
 
             elif state["status"] == "frozen" and state["version"] == expected_version:
@@ -752,7 +752,7 @@ class EtcdRendezvous:
 
         1. state becomes <frozen, expected_version>
         2. timeout happens (reaching deadline), in which case
-           we try the tranisiton to <frozen, expected_version>
+           we try the transition to <frozen, expected_version>
 
         Exit with exception otherwise.
         """
@@ -761,7 +761,7 @@ class EtcdRendezvous:
         while True:
             if state["status"] == "frozen" and state["version"] == expected_version:
                 # Worker set became frozen before last-call timeout. This is possible
-                # when num_max_workers is reached before the tiemout.
+                # when num_max_workers is reached before the timeout.
                 return
 
             if state["status"] != "joinable" or state["version"] != expected_version:

--- a/torch/distributed/elastic/timer/api.py
+++ b/torch/distributed/elastic/timer/api.py
@@ -265,7 +265,7 @@ def expires(
     """
     if client is None:
         if _timer_client is None:
-            raise RuntimeError("Configure timer client before using coundown timers.")
+            raise RuntimeError("Configure timer client before using countdown timers.")
         client = _timer_client
     if scope is None:
         # grab the caller file + lineno

--- a/torch/distributed/examples/memory_tracker_example.py
+++ b/torch/distributed/examples/memory_tracker_example.py
@@ -13,7 +13,7 @@ def run_one_model(net: torch.nn.Module, input: torch.Tensor):
     # start_monitor before the training iteration starts
     mem_tracker.start_monitor(net)
 
-    # run one traing iteration
+    # run one training iteration
     net.zero_grad(True)
     loss = net(input)
     if isinstance(loss, dict):

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -225,8 +225,8 @@ def _get_param_to_fqns(
                     # calls `named_child` to traverse the module recursively and
                     # calls `named_parameters` with `recurse=False`, parameters
                     # will be traversed more than once.
-                    # This hack is specificed designed for DMP + FSDP. We
-                    # overwite the flat_parameters traversal result to only obtain
+                    # This hack is specified designed for DMP + FSDP. We
+                    # overwrite the flat_parameters traversal result to only obtain
                     # the last one, which happens to be the correct one.
                     #
                     # TODO: Remove this hack once DMP + FSDP is not supported.
@@ -286,7 +286,7 @@ def _apply_to_modules(
                 else:
                     # DMP's named_parameter() will mess up the traversal with
                     # ``named_children`` + `named_parameter(recurse=False)``.
-                    # This hack is a must to make the travsersal work.
+                    # This hack is a must to make the traversal work.
                     # TODO: Remove this hack once DMP + FSDP is not supported.
                     if (
                         submodule_name == "_fsdp_wrapped_module"

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -96,7 +96,7 @@ class _OptimStateKey(NamedTuple):
     """
     This represents an optimizer state key that may be used commonly across
     ranks. It is based on the unflattened parameter names rather than parameter
-    IDs to make it indepenendent of each rank's own optimizer construction.
+    IDs to make it independent of each rank's own optimizer construction.
     """
 
     unflat_param_names: Tuple[str, ...]
@@ -388,7 +388,7 @@ def _flatten_optim_state_dict(
             key = _OptimStateKey(tuple(unflat_param_names), False)
             flat_osd_state[key] = copy.copy(unflat_osd_state[fqn])
 
-    # Handle user-defined state, states that are not accosiated with parameters.
+    # Handle user-defined state, states that are not associated with parameters.
     for key in all_state_keys:
         flat_osd_state[key] = copy.copy(unflat_osd_state[key])
 
@@ -1579,7 +1579,7 @@ def _all_gather_optim_state(
     """
     All-gathering state from all the ranks. This API is slow as it uses
     ``all_gather_object``. However, optim state_dict is not in the critical path.
-    We can fuse the communication across differnt state if the performance
+    We can fuse the communication across different state if the performance
     becomes a problem.
     """
     # Allgather the scalar tensor state, non-tensor states and tensors metadata.
@@ -1600,7 +1600,7 @@ def _all_gather_optim_state(
     ]
     dist.all_gather_object(object_list, processed_state)
 
-    # Convert the gathered, pre-proccessed state of each rank to the original one.
+    # Convert the gathered, pre-processed state of each rank to the original one.
     gathered_state: Dict[str, Any] = {}
 
     all_tensor_states = sorted(

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -130,7 +130,7 @@ def _validate_and_get_hybrid_shard_state(
         return None
     error_prefix = "At least one instance uses a hybrid sharding strategy but has no "
     if len(intra_node_pgs) > 0 and len(inter_node_pgs) == 0:
-        raise AssertionError(error_prefix + "inter-node proces group set")
+        raise AssertionError(error_prefix + "inter-node process group set")
     if len(intra_node_pgs) == 0 and len(inter_node_pgs) > 0:
         raise AssertionError(error_prefix + "intra-node process group set")
     error_prefix = "Some instances use a hybrid sharding strategy, but "
@@ -459,7 +459,7 @@ def _post_forward(
         module (nn.Module): Module whose forward just ran, which should be a
             fully sharded module (see [Note: Fully Sharded Module]); expected
             by the hook signature.
-        input (Any): Unused; exepcted by the hook signature.
+        input (Any): Unused; expected by the hook signature.
         output (Any): Forward pass output; pre-backward hooks are registered on
             the tensors that require gradients in this output.
 

--- a/torch/distributed/fsdp/_shard_utils.py
+++ b/torch/distributed/fsdp/_shard_utils.py
@@ -107,7 +107,7 @@ def _reshard_flatten_tensor(
 ) -> torch.Tensor:
     """
     Resharded a sharded flatten tensor, this is used by FSDP to do sharded
-    state_dict. But the functionaility is not supported by ShardedTensor.
+    state_dict. But the functionality is not supported by ShardedTensor.
     This API is designed to be used for FSDP; therefore this API supports only
     1-D ShardedTensor (hence the naming, reshard_flatten_tensor).
 

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1492,7 +1492,7 @@ class FlatParamHandle:
                 # NOTE: This is a hack using `.data` to side step the
                 # check that parameter/gradient sizes and dtypes match. Here,
                 # `param` can have the sharded size, and `grad` can have the
-                # unsharded size. Orthgonally, `param` can have the full
+                # unsharded size. Orthogonally, `param` can have the full
                 # precision dtype from `reshard()`, and `grad` can have the
                 # parameter low precision dtype. Both of these mismatches
                 # happen when running in `no_sync()`.

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -535,7 +535,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
 
     def _low_precision_hook_enabled(self) -> bool:
         """
-        Wether a low precision hook is registered or not.
+        Whether a low precision hook is registered or not.
         """
         return (
             self._communication_hook is not None
@@ -827,7 +827,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
         """
         This deregisters the original parameters and exposes the
         :class:`FlatParameter` s. If a :class:`FlatParameter` is sharded, then
-        this refreshes the sharded views before exiting. This method shouuld
+        this refreshes the sharded views before exiting. This method should
         only be called when using the original parameters.
         """
         _p_assert(
@@ -1732,7 +1732,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             >>> save_a_checkpoint(state_dict, optim_state_dict)
             >>> # Load a checkpoint
             >>> model, optim = ...
-            >>> state_dict, optim_state_dict = load_a_checkponit()
+            >>> state_dict, optim_state_dict = load_a_checkpoint()
             >>> FSDP.set_state_dict_type(
             >>>     model,
             >>>     StateDictType.FULL_STATE_DICT,
@@ -1786,7 +1786,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
     ) -> Dict[str, Any]:
         """
         This hook is intended be used by ``torch.distributed.NamedOptimizer``.
-        The functionaility is identical to ``:meth:optim_state_dict`` except
+        The functionality is identical to ``:meth:optim_state_dict`` except
         for the different arguments.
 
         Args:
@@ -1795,7 +1795,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
                 were passed into the optimizer ``optim``.
             optim (torch.optim.Optimizer): Optimizer for ``model`` 's
                 parameters.
-            optim (Dict[str, Any]: the optim_state_dict to be coverted. The value
+            optim (Dict[str, Any]: the optim_state_dict to be converted. The value
                is typically returned by ``NamedOptimizer.state_dict()``.
             group (dist.ProcessGroup): Model's process group across which parameters
                 are sharded or ``None`` if using the default process group. (
@@ -1856,7 +1856,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             >>> save_a_checkpoint(state_dict, optim_state_dict)
             >>> # Load a checkpoint
             >>> model, optim = ...
-            >>> state_dict, optim_state_dict = load_a_checkponit()
+            >>> state_dict, optim_state_dict = load_a_checkpoint()
             >>> FSDP.set_state_dict_type(
             >>>     model,
             >>>     StateDictType.FULL_STATE_DICT,
@@ -1913,7 +1913,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
     ) -> Dict[str, Any]:
         """
         This hook is intended be used by ``torch.distributed.NamedOptimizer``.
-        The functionaility is identical to ``:meth:optim_state_dict_to_load``
+        The functionality is identical to ``:meth:optim_state_dict_to_load``
         except for the different arguments.
 
         Args:

--- a/torch/distributed/fsdp/sharded_grad_scaler.py
+++ b/torch/distributed/fsdp/sharded_grad_scaler.py
@@ -36,7 +36,7 @@ class ShardedGradScaler(GradScaler):
     """
     ShardedGradScaler helps perform gradient scaling in a shard aware manner. It extends
     functionality from GradScaler:
-    * Suports Pytorch DDP and FSDP implementations
+    * Supports Pytorch DDP and FSDP implementations
     * Support CPU offloaded tensors (as used in fully sharded data parallel[FSDP])
     * Supports the custom Mixed Precision loss dtype (fp16, bf16) that FSDP returns
     * Sync inf/nan for scaled gradient tensors on any torch.device (where tensors are placed) across
@@ -208,7 +208,7 @@ class ShardedGradScaler(GradScaler):
                         # For scaled fp16 values, there's a good chance coalescing will cause overflow,
                         # so we should check the coalesced _values().
                         if param.grad.dtype is torch.float16:
-                            # coalesce is not suported in torch.float16
+                            # coalesce is not supported in torch.float16
                             param_grad_fp32 = param.grad.type(torch.float32).coalesce()
                             param.grad = param_grad_fp32.type(torch.float16)
                         to_unscale = param.grad._values()

--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -13,7 +13,7 @@ each distributed process will be operating on a single GPU. This can achieve
 well-improved single-node training performance. It can also be used in
 multi-node distributed training, by spawning up multiple processes on each node
 for well-improved multi-node distributed training performance as well.
-This will especially be benefitial for systems with multiple Infiniband
+This will especially be beneficial for systems with multiple Infiniband
 interfaces that have direct-GPU support, since all of them can be utilized for
 aggregated communication bandwidth.
 

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -137,7 +137,7 @@ class elastic_launch:
 def _get_entrypoint_name(
     entrypoint: Union[Callable, str, None], args: List[Any]
 ) -> str:
-    """Retrive entrypoint name with the rule:
+    """Retrieve entrypoint name with the rule:
     1. If entrypoint is a function, use ``entrypont.__qualname__``.
     2. If entrypoint is a string, check its value:
         2.1 if entrypoint equals to ``sys.executable`` (like "python"), use the first element from ``args``

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -227,7 +227,7 @@ class _RemoteModule(nn.Module):
 
         enable_moving_cpu_tensors_to_cuda = self._prepare_init(remote_device)
 
-        # Default arguments preperation.
+        # Default arguments preparation.
         args = args if args is not None else ()
         kwargs = kwargs if kwargs is not None else {}
 
@@ -282,7 +282,7 @@ class _RemoteModule(nn.Module):
     def remote_parameters(self, recurse: bool = True) -> List[rpc.RRef[Parameter]]:
         """
         Returns a list of :class:`~torch.distributed.rpc.RRef` pointing to the
-        remote module's parameters. This can typically be used in conjuction
+        remote module's parameters. This can typically be used in conjunction
         with :class:`~torch.distributed.optim.DistributedOptimizer`.
 
         Args:
@@ -458,7 +458,7 @@ class _RemoteModule(nn.Module):
 
     def _prepare_init(self, remote_device_str: str) -> bool:
         """
-        Prepares the initializaiton and returns whether to enable automatically moving CPU tensors to CUDA devices.
+        Prepares the initialization and returns whether to enable automatically moving CPU tensors to CUDA devices.
         """
         # Sanity check.
         assert rpc._is_current_rpc_agent_set(), "RemoteModule only works in RPC."
@@ -516,7 +516,7 @@ class _RemoteModule(nn.Module):
     ):
         """
         Besides the constructor, a RemoteModule instance can also be initialized given a module RRef.
-        This alternate initiailization method can be particularly useful if we want to create multiple
+        This alternate initialization method can be particularly useful if we want to create multiple
         RemoteModule instances that share the same underlying module and reduce memory consumption.
 
         Moreover, this also provides a workaround for passing script RemoteModule over RPC,

--- a/torch/distributed/optim/named_optimizer.py
+++ b/torch/distributed/optim/named_optimizer.py
@@ -20,7 +20,7 @@ class _NamedOptimizer(optim.Optimizer):
     """
     ``_NamedOptimizer`` takes a dict of parameters and exposes ``state_dict`` by
     parameter key. We replace the original key (number) in an optim to the
-    fully qualifed name (FQN) string. User can initialize the optim as they
+    fully qualified name (FQN) string. User can initialize the optim as they
     initialize a PyTorch optim, the only difference is that they also need to
     pass in the FQN of each parameters.
 
@@ -120,8 +120,8 @@ class _NamedOptimizer(optim.Optimizer):
 
     def state_dict(self) -> Dict[str, Any]:
         """
-        Return the ``state_dict`` of the optimzer. Instead of using number to index
-        parameters, we will use module fully qualifed name (FQN) as the key.
+        Return the ``state_dict`` of the optimizer. Instead of using number to index
+        parameters, we will use module fully qualified name (FQN) as the key.
         """
         state_dict = self._optimizer.state_dict()
         param_groups = state_dict["param_groups"]

--- a/torch/distributed/pipeline/sync/microbatch.py
+++ b/torch/distributed/pipeline/sync/microbatch.py
@@ -60,7 +60,7 @@ class Batch:
 
     @property
     def values(self):
-        """Retreives the underlying values for the batch"""
+        """Retrieves the underlying values for the batch"""
         return self._values
 
     def find_tensor_idx(self):

--- a/torch/distributed/pipeline/sync/pipe.py
+++ b/torch/distributed/pipeline/sync/pipe.py
@@ -297,7 +297,7 @@ class Pipe(Module):
         will be expanded to support inter-node pipelining in the future.
         The forward function returns an :class:`~torch.distributed.rpc.RRef`
         to allow for inter-node pipelining in the future, where the output
-        might be on a remote host. For intra-node pipelinining you can use
+        might be on a remote host. For intra-node pipelining you can use
         :meth:`~torch.distributed.rpc.RRef.local_value` to retrieve the
         output locally.
 

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -102,7 +102,7 @@ class AllGatherStates:
 
 
 # States used by `def _all_gather()`.
-# `_ALL_WORKER_NAMES` is initialized on initiaizing RPC layer.
+# `_ALL_WORKER_NAMES` is initialized on initializing RPC layer.
 _ALL_WORKER_NAMES: Set[Any] = set()
 _all_gather_dict_lock = threading.RLock()
 _all_gather_sequence_id: Dict[str, int] = {}

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -103,8 +103,8 @@ class _InternalRPCPickler:
         # user picklers could have different initialization function from _InternalRPCPickler,
         # but all the user picklers should call serialize() and use _rref_reducer to pickle rref
         # in python. also, when _internal_rpc_pickler is imported to rpc/api.py, rpc.RRef is not
-        # compiled yet, it is not good place to acces rpc.RRef inside _InternalRPCPickler constructor,
-        # so puting rref's dispatch table here
+        # compiled yet, it is not good place to access rpc.RRef inside _InternalRPCPickler constructor,
+        # so putting rref's dispatch table here
         #
         # The return value of a `rpc.remote(..)` call is type of `rpc.PyRRef`.
         # The deserialized RRef object on an RPC receiver side is type of `rpc.PyRRef`.

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -97,7 +97,7 @@ setup on different ports to avoid port conflicts (or worse, two jobs being merge
 as a single job). To do this you have to run with ``--rdzv-backend=c10d``
 and specify a different port by setting ``--rdzv-endpoint=localhost:$PORT_k``.
 For ``--nodes=1``, its often convenient to let ``torchrun`` pick a free random
-port automatically instead of manually assgining different ports for each run.
+port automatically instead of manually assigning different ports for each run.
 
 ::
 
@@ -325,7 +325,7 @@ utility
 5. This module only supports homogeneous ``LOCAL_WORLD_SIZE``. That is, it is assumed that all
    nodes run the same number of local workers (per role).
 
-6. ``RANK`` is NOT stable. Between restarts, the local workers on a node can be assgined a
+6. ``RANK`` is NOT stable. Between restarts, the local workers on a node can be assigned a
    different range of ranks than before. NEVER hard code any assumptions about the stable-ness of
    ranks or some correlation between ``RANK`` and ``LOCAL_RANK``.
 

--- a/torch/distributed/tensor/parallel/_utils.py
+++ b/torch/distributed/tensor/parallel/_utils.py
@@ -58,7 +58,7 @@ def _prepare_input_validate(
                 raise RuntimeError("device_mesh is not passed nor can be inferred")
         if device_mesh.ndim != 1:
             raise RuntimeError(
-                f"device_mesh has dims {device_mesh.ndim} but expcted to be 1"
+                f"device_mesh has dims {device_mesh.ndim} but expected to be 1"
                 " for input."
             )
         return _prepare_input_func(*args, **kwargs)
@@ -107,7 +107,7 @@ def _prepare_output_validate(
             device_mesh = args[1]
 
         assert device_mesh.ndim == 1, (
-            f"device_mesh has dims {device_mesh.ndim} but expcted to be 1 for"
+            f"device_mesh has dims {device_mesh.ndim} but expected to be 1 for"
             " output."
         )
         return _prepare_output_func(*args, **kwargs)

--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -44,7 +44,7 @@ def parallelize_module(  # type: ignore[return]
     :class:`ParallelStyle`, which indicates how user wants the module or sub_module
     to be parallelized.
 
-    User can also specify different parallel style per module fully qualifed name (FQN).
+    User can also specify different parallel style per module fully qualified name (FQN).
     The API supports 2D parallelism natively by accepting an n-dimension device_mesh
     and users just need to specify the dimension where we perform tensor parallelism on.
 

--- a/torch/distributed/tensor/parallel/multihead_attention_tp.py
+++ b/torch/distributed/tensor/parallel/multihead_attention_tp.py
@@ -192,7 +192,7 @@ class TensorParallelMultiheadAttention(torch.nn.Module):
         # ===================================
 
         factor = self.tp_size if isinstance(query_layer, DT) else 1
-        # preallocting result tensor: [b * nh, sq, sk]
+        # preallocating result tensor: [b * nh, sq, sk]
         matmul_result = torch.empty(
             b * nh // factor,
             sq,


### PR DESCRIPTION
This PR fixes typos in comments and messages of `.py` files under torch/distributed directory
