### PR TITLE
MHA torch.jit.script fix for in_proj_weight = None

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1899,6 +1899,14 @@ class TestSDPA(NNTestCase):
             value = torch.randn(shape, dtype=torch.float16, device=device)
             self.assertRaises(RuntimeError, lambda: F.scaled_dot_product_attention(query, key, value))
 
+
+    def script_mha_in_proj_weight_none(self):
+        mha = torch.nn.MultiheadAttention(
+            embed_dim=128, num_heads=8, kdim=256, vdim=256
+        ).eval()
+
+        torch.jit.script(mha)
+
 # TODO: Replace this with instantiate_device_type_tests() to take advantage of test framework support for
 # cross device / dtype testing.
 instantiate_parametrized_tests(TestTransformers)


### PR DESCRIPTION
Summary: MHA fix to support in_proj_weight being None

Test Plan: sandcastle

Differential Revision: D43628206

