### PR TITLE
Add float to list of allowed ops (#94910)

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -736,6 +736,15 @@ class SerializationMixin:
             with self.assertRaisesRegex(RuntimeError, error_msg):
                 torch.save([a.storage(), s_bytes], f)
 
+    def test_safe_load_basic_types(self):
+        with tempfile.NamedTemporaryFile() as f:
+            data = {"int": 123, "str": "world", "float": 3.14, "bool": False}
+            torch.save(data, f)
+            f.seek(0)
+            loaded_data = torch.load(f, weights_only=True)
+            self.assertEqual(data, loaded_data)
+
+
 class serialization_method:
     def __init__(self, use_zip):
         self.use_zip = use_zip

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 from pickle import (
     APPEND,
     APPENDS,
+    BINFLOAT,
     BINGET,
     BININT,
     BININT1,
@@ -226,6 +227,8 @@ class Unpickler:
                 self.append(self.read(1)[0])
             elif key[0] == BININT2[0]:
                 self.append(unpack("<H", read(2))[0])
+            elif key[0] == BINFLOAT[0]:
+                self.append(unpack(">d", self.read(8))[0])
             elif key[0] == BINUNICODE[0]:
                 strlen = unpack("<I", read(4))[0]
                 if strlen > maxsize:


### PR DESCRIPTION
By adding `BINFLOAT` op support

Fixes https://github.com/pytorch/pytorch/issues/94670 
Pull Request resolved: https://github.com/pytorch/pytorch/pull/94910
Approved by: https://github.com/albanD
