### PR TITLE
[Vulkan] fix build with gcc

### DIFF
--- a/aten/src/ATen/native/vulkan/impl/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/impl/Arithmetic.cpp
@@ -16,6 +16,8 @@ api::ShaderInfo get_shader(const OpType type) {
       return VK_KERNEL(mul);
     case OpType::DIV:
       return VK_KERNEL(div);
+    default:
+      TORCH_CHECK(false, "No kernel available!");
   }
 }
 

--- a/aten/src/ATen/native/vulkan/impl/Registry.cpp
+++ b/aten/src/ATen/native/vulkan/impl/Registry.cpp
@@ -33,7 +33,7 @@ const api::ShaderInfo& look_up_shader_info(const std::string& op_name) {
   const RegistryKeyMap& registry_key_map = registry_iterator->second;
 
   // Look for "override" and "catchall" keys
-  for (const std::string& key : {"override", "catchall"}) {
+  for (const char* const& key : {"override", "catchall"}) {
     const RegistryKeyMap::const_iterator registry_key_iterator =
         registry_key_map.find(key);
     if (registry_key_iterator != registry_key_map.end()) {


### PR DESCRIPTION
I had some errors making a Vulkan build on archlinux, but those small changes made the build work. 

Most likely reason those weren't caught until now because CI is using Clang and I'm using gcc.