### PR TITLE
Initial minifier smoke test + runbook

### DIFF
--- a/test/inductor/minifier_smoke.py
+++ b/test/inductor/minifier_smoke.py
@@ -1,12 +1,7 @@
 # Owner(s): ["module: inductor"]
-import logging
-import os
-import unittest
-
 os.environ["TORCHDYNAMO_REPRO_AFTER"] = "dynamo"
 import torch
 import torch._dynamo as torchdynamo
-import torch._inductor.config as torchinductor_config
 import torch._inductor.lowering
 import torch._ops
 

--- a/test/inductor/minifier_smoke.py
+++ b/test/inductor/minifier_smoke.py
@@ -1,0 +1,63 @@
+# Owner(s): ["module: inductor"]
+import logging
+import os
+import unittest
+
+os.environ["TORCHDYNAMO_REPRO_AFTER"] = "dynamo"
+import torch
+import torch._dynamo as torchdynamo
+import torch._inductor.config as torchinductor_config
+import torch._inductor.lowering
+import torch._ops
+
+
+def func(x):
+    x = torch.sigmoid(x)
+    x = torch.mul(x, torch.ones(2))
+    x = torch.add(x, torch.zeros(2))
+    x = torch.ops.aten.round(x)
+    return x
+
+
+error_injection_str = """
+import torch._inductor.lowering
+
+def inject_error():
+    def throw(x):
+        assert False
+    # inject an error in the lowerings
+    for x in list(torch._inductor.lowering.lowerings.keys()):
+        if 'round' in x.__name__:
+            torch._inductor.lowering.lowerings[x] = throw
+
+inject_error()
+"""
+
+exec(error_injection_str)
+
+
+def patch_launcher():
+    minifier_launcher_path = torchdynamo.debug_utils.get_minifier_repro_path()
+    with open(minifier_launcher_path, "r") as f:
+        code = f.read()
+        code = code.replace(
+            torchdynamo.debug_utils.TEST_REPLACEABLE_COMMENT, error_injection_str
+        )
+
+    with open(minifier_launcher_path, "w") as f:
+        f.write(code)
+
+    return code
+
+
+def run_internal_minifier():
+    torchdynamo.config.debug_dir_root = "."
+    try:
+        f_opt = torch.compile(func)
+        f_opt(torch.ones(2))
+    except Exception as e:
+        patch_launcher()
+        raise e
+
+
+run_internal_minifier()


### PR DESCRIPTION
Summary:
Adds a manual smoke test for the minifier in fb code to use as an example for the runbook. (We already have automatic tests which should be running)

See draft runbook:
https://docs.google.com/document/d/18I0KYhWiYo4taC4foR2UcijJXYyEcZV4McBJQIUSSJw/edit#

Test Plan:
buck2 run mode/dev-nosan //caffe2/test/inductor:minifier_smoke

Run displayed minifier launcher script, and it should reduce the graph from 5 to 3 nodes

Differential Revision: D43415890



cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire