### PR TITLE
Add jinja2 as mandatory dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1022,6 +1022,7 @@ def main():
         'typing-extensions',
         'sympy',
         'networkx',
+        'jinja2',
     ]
 
     extras_require = {


### PR DESCRIPTION
Should fix #95671  for nightly wheels issue. v2.0.0 RC does not need this. 