### PR TITLE
Fix typos in documents under torch directory

### DIFF
--- a/torch/ao/pruning/_experimental/pruner/README.md
+++ b/torch/ao/pruning/_experimental/pruner/README.md
@@ -228,7 +228,7 @@ If you're working with linear/conv2d layers, it's very probable that you just ne
 This is because there are many modules, for example **pooling** that behave the same way and do not need to be modified by the pruning code.
 
 ```python
-from torch.ao.pruning._experimental.pruner.prune_functions improt prune_conv2d_activation_conv2d
+from torch.ao.pruning._experimental.pruner.prune_functions import prune_conv2d_activation_conv2d
 
 def prune_conv2d_pool_activation_conv2d(
     c1: nn.Conv2d,

--- a/torch/distributed/_tensor/README.md
+++ b/torch/distributed/_tensor/README.md
@@ -150,7 +150,7 @@ GSPMD:
 -   GSPMD is now the fundamental component of JAX/TensorFlow distributed training and enables various optimizations with the XLA compiler to allow users to train their models efficiently in a large scale setting.
 -   Fundamentally, GSPMD have three types of sharding strategies within a tensor: “tiled”, “replicated”, “partially tiled” to represent sharding and replication.
 -   At the core of GSPMD Partitioner, it utilizes the XLA compiler to do advanced optimizations, i.e. sharding propagation and compiler based fusion.
--   XLA mark_sharding API: PyTorch XLA’s [mark_sharding](https://github.com/pytorch/xla/pull/3476) API uses [XLAShardedTensor](https://github.com/pytorch/xla/issues/3871) abstraction (i.e. sharding specs) in PyTorch/XLA. Under the hood XLAShardedTensor is utilizing the GPSMD partitioner to enable SPMD style training on TPU.
+-   XLA mark_sharding API: PyTorch XLA’s [mark_sharding](https://github.com/pytorch/xla/pull/3476) API uses [XLAShardedTensor](https://github.com/pytorch/xla/issues/3871) abstraction (i.e. sharding specs) in PyTorch/XLA. Under the hood XLAShardedTensor is utilizing the GSPMD partitioner to enable SPMD style training on TPU.
 
 OneFlow GlobalTensor:
 


### PR DESCRIPTION
This PR fixes typo in `.md` files under `torch` directory
