### PR TITLE
Logaddexp for complex in CPU

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -896,11 +896,7 @@ void logaddexp_kernel(TensorIteratorBase& iter) {
         });
   } else if (isComplexType(iter.dtype())) {
     AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "logaddexp_cpu", [&]() {
-      cpu_kernel(
-        iter,
-        [=](scalar_t a, scalar_t b) -> scalar_t {
-          return _log_add_exp_helper(a, b);
-        });
+      cpu_kernel(iter, _log_add_exp_helper<scalar_t>);
     });
   } else {
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "logaddexp_cpu", [&]() {

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -896,7 +896,11 @@ void logaddexp_kernel(TensorIteratorBase& iter) {
         });
   } else if (isComplexType(iter.dtype())) {
     AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "logaddexp_cpu", [&]() {
-      cpu_kernel(iter, _log_add_exp_helper<scalar_t>);
+      cpu_kernel(
+        iter,
+        [=](scalar_t a, scalar_t b) -> scalar_t {
+          return _log_add_exp_helper(a, b);
+        });
     });
   } else {
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "logaddexp_cpu", [&]() {

--- a/aten/src/ATen/native/cpu/LogAddExp.h
+++ b/aten/src/ATen/native/cpu/LogAddExp.h
@@ -34,9 +34,7 @@ scalar_t _log_add_exp_helper(scalar_t x, scalar_t y) {
 
 template <typename scalar_t>
 c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
-  auto minmax = _logcumsumexp_minmax<scalar_t>(x, y);
-  auto min = minmax.first;
-  auto max = minmax.second;
+  auto [min, max] = _logcumsumexp_minmax<scalar_t>(x, y);
   auto min_real = std::real(min);
   auto max_real = std::real(max);
 

--- a/aten/src/ATen/native/cpu/LogAddExp.h
+++ b/aten/src/ATen/native/cpu/LogAddExp.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <c10/util/complex.h>
+#include <ATen/NumericUtils.h>
+
+namespace at { namespace native {
+inline namespace CPU_CAPABILITY {
+
+// custom min and max to be used in logcumsumexp for complex arguments
+template <typename scalar_t, bool min>
+c10::complex<scalar_t> _logcumsumexp_minmax(c10::complex<scalar_t> x, c10::complex<scalar_t> y) {
+  if (at::_isnan(y)) {  // either real is nan or imag is nan
+    return y;
+  } else if (at::_isnan(x)) {  // either real is nan or imag is nan
+    return x;
+  } else {
+    return ((x.real() < y.real()) == min) ? x : y;  // logical xnor
+  }
+}
+
+template <typename scalar_t>
+scalar_t _log_add_exp_helper(scalar_t x, scalar_t y) {
+  // Reference : https://www.tensorflow.org/api_docs/python/tf/math/cumulative_logsumexp
+  scalar_t min = at::_isnan(y) ? y : std::min(x, y); // std::min returns first arg if one of the args is nan
+  scalar_t max = at::_isnan(y) ? y : std::max(x, y); // std::max returns first arg if one of the args is nan
+  if (min != max || std::isfinite(min)) {
+    // nan will be propagated here
+    return std::log1p(std::exp(min - max)) + max;
+  } else {
+    // special case to correctly handle infinite cases
+    return x;
+  }
+}
+
+template <typename scalar_t>
+c10::complex<scalar_t> _log_add_exp_helper(const c10::complex<scalar_t>& x, const c10::complex<scalar_t>& y) {
+  auto min = _logcumsumexp_minmax<scalar_t, true>(x, y);
+  auto max = _logcumsumexp_minmax<scalar_t, false>(x, y);
+  auto min_real = std::real(min);
+  auto max_real = std::real(max);
+
+  if (at::_isnan(min)) {  // either real is nan or imag is nan
+    // handling the "infectious" NaNs
+    return {std::numeric_limits<scalar_t>::quiet_NaN(), std::numeric_limits<scalar_t>::quiet_NaN()};
+  } else if ((!std::isfinite(min_real)) && (min_real == max_real)) {
+    if (min_real < 0) {
+      // handle the -inf case, the imaginary part here does not really matter as the exp(value)
+      // will be around 0.0 and the angle (i.e. the imaginary part) cannot be determined.
+      // It does not matter if we're taking the exp of this value
+      return min;
+    } else {
+      // handle the +inf case, we don't need the special precision for log1p for small values
+      // and to avoid producing nan in case of real(max) == real(min) == +inf
+      return std::log(std::exp(min) + std::exp(max));
+    }
+  } else {
+    return std::log1p(std::exp(min - max)) + max;
+  }
+}
+
+} // end namespace
+}} //end at::native

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3415,6 +3415,10 @@ class TestBinaryUfuncs(TestCase):
         if base2:
             ref_func = np.logaddexp2
             our_func = torch.logaddexp2
+        elif dtype in (torch.complex64, torch.complex128):
+            # numpy has not implemented logaddexp for complex
+            ref_func = lambda x, y: scipy.special.logsumexp(np.stack((x, y), axis=0), axis=0)
+            our_func = torch.logaddexp
         else:
             ref_func = np.logaddexp
             our_func = torch.logaddexp
@@ -3453,7 +3457,7 @@ class TestBinaryUfuncs(TestCase):
         )
         _test_helper(a, b)
 
-    @dtypes(torch.float32, torch.float64, torch.bfloat16)
+    @dtypes(torch.float32, torch.float64, torch.bfloat16, torch.complex64, torch.complex128)
     def test_logaddexp(self, device, dtype):
         self._test_logaddexp(device, dtype, base2=False)
 

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3457,6 +3457,7 @@ class TestBinaryUfuncs(TestCase):
         )
         _test_helper(a, b)
 
+    @dtypesIfCUDA(torch.float32, torch.float64, torch.bfloat16)
     @dtypes(torch.float32, torch.float64, torch.bfloat16, torch.complex64, torch.complex128)
     def test_logaddexp(self, device, dtype):
         self._test_logaddexp(device, dtype, base2=False)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3417,7 +3417,9 @@ class TestBinaryUfuncs(TestCase):
             our_func = torch.logaddexp2
         elif dtype in (torch.complex64, torch.complex128):
             # numpy has not implemented logaddexp for complex
-            ref_func = lambda x, y: scipy.special.logsumexp(np.stack((x, y), axis=0), axis=0)
+            def _ref_func(x, y):
+                return scipy.special.logsumexp(np.stack((x, y), axis=0), axis=0)
+            ref_func = _ref_func
             our_func = torch.logaddexp
         else:
             ref_func = np.logaddexp

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -903,8 +903,8 @@
   result: auto_element_wise
 
 - name: logaddexp(Tensor self, Tensor other) -> Tensor
-  self: grad / (1 + exp(other - self))
-  other: grad / (1 + exp(self - other))
+  self: grad / (1 + exp(other - self)).conj()
+  other: grad / (1 + exp(self - other)).conj()
   result: self_t / (1 + exp(other_p - self_p)) + other_t / (1 + exp(self_p - other_p))
 
 - name: logaddexp2(Tensor self, Tensor other) -> Tensor

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -249,6 +249,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     "log10",
     "log1p",
     "log2",
+    "logaddexp",
     "logcumsumexp",
     "reciprocal",
     "tan",

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1464,7 +1464,7 @@ def logaddexp(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
         )
         # the type for full_like does not include tensor yet
         nan_mask = torch.isnan(min_)
-        return torch.where(nan_mask, complex(float("nan"), float("nan")), non_nan_vals)
+        return torch.where(nan_mask, complex(float("nan"), float("nan")), non_nan_vals)  # type: ignore[call-overload]
     else:
         return torch.where(inf_mask, a, max_ + torch.log1p(torch.exp(min_ - max_)))
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1446,7 +1446,7 @@ def le(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     supports_rhs_python_scalar=False,
 )
 def logaddexp(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
-    # Nb. this implementation does nto distribute the gradients evenly when a == b
+    # Nb. this implementation does not distribute the gradients evenly when a == b
     mask = torch.real(a) >= torch.real(b)
     max_ = torch.where(mask, a, b)
     min_ = torch.where(mask, b, a)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1451,7 +1451,7 @@ def logaddexp(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     max_ = torch.where(mask, a, b)
     min_ = torch.where(mask, b, a)
     inf_mask = torch.logical_and(
-        torch.isinf(torch.real(a)), torch.real(a) == torch.real(b)
+        torch.logical_not(torch.isfinite(torch.real(a))), torch.real(a) == torch.real(b)
     )
     if utils.is_complex_dtype(a.dtype) or utils.is_complex_dtype(b.dtype):
         # are you wondering what this bunch of codes are for? edge cases!

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1457,7 +1457,8 @@ def logaddexp(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
         neg_min_mask = torch.real(min_) < 0
         inf_vals = torch.where(neg_min_mask, min_, torch.log(torch.exp(min_) + torch.exp(max_)))
         non_nan_vals = torch.where(inf_mask, inf_vals, max_ + torch.log1p(torch.exp(min_ - max_)))
-        nan_vals = torch.full_like(complex_tens, complex(float('nan'), float('nan')))
+        # the type for full_like does not include tensor yet
+        nan_vals = torch.full_like(complex_tens, complex(float('nan'), float('nan')))  # type: ignore
         nan_mask = torch.isnan(min_)
         return torch.where(nan_mask, nan_vals, non_nan_vals)
     else:

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1455,7 +1455,6 @@ def logaddexp(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     )
     if utils.is_complex_dtype(a.dtype) or utils.is_complex_dtype(b.dtype):
         # are you wondering what this bunch of codes are for? edge cases!
-        complex_tens = a if utils.is_complex_dtype(a.dtype) else b
         neg_min_mask = torch.real(min_) < 0
         inf_vals = torch.where(
             neg_min_mask, min_, torch.log(torch.exp(min_) + torch.exp(max_))
@@ -1465,7 +1464,7 @@ def logaddexp(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
         )
         # the type for full_like does not include tensor yet
         nan_mask = torch.isnan(min_)
-        return torch.where(nan_mask, nan_vals, complex(float("nan"), float("nan")))
+        return torch.where(nan_mask, complex(float("nan"), float("nan")), non_nan_vals)
     else:
         return torch.where(inf_mask, a, max_ + torch.log1p(torch.exp(min_ - max_)))
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1447,10 +1447,10 @@ def le(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
 )
 def logaddexp(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     # Nb. this implementation does nto distribute the gradients evenly when a == b
-    mask = a >= b
+    mask = a.real >= b.real
     max_ = torch.where(mask, a, b)
     min_ = torch.where(mask, b, a)
-    inf_mask = torch.logical_and(torch.isinf(a), a == b)
+    inf_mask = torch.logical_and(torch.isinf(a.real), a.real == b.real)
     return torch.where(inf_mask, a, max_ + torch.log1p(torch.exp(min_ - max_)))
 
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1464,9 +1464,8 @@ def logaddexp(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
             inf_mask, inf_vals, max_ + torch.log1p(torch.exp(min_ - max_))
         )
         # the type for full_like does not include tensor yet
-        nan_vals = torch.full_like(complex_tens, complex(float("nan"), float("nan")))  # type: ignore[arg-type]
         nan_mask = torch.isnan(min_)
-        return torch.where(nan_mask, nan_vals, non_nan_vals)
+        return torch.where(nan_mask, nan_vals, complex(float("nan"), float("nan")))
     else:
         return torch.where(inf_mask, a, max_ + torch.log1p(torch.exp(min_ - max_)))
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1450,15 +1450,21 @@ def logaddexp(a: TensorLikeType, b: TensorLikeType) -> TensorLikeType:
     mask = torch.real(a) >= torch.real(b)
     max_ = torch.where(mask, a, b)
     min_ = torch.where(mask, b, a)
-    inf_mask = torch.logical_and(torch.isinf(torch.real(a)), torch.real(a) == torch.real(b))
+    inf_mask = torch.logical_and(
+        torch.isinf(torch.real(a)), torch.real(a) == torch.real(b)
+    )
     if utils.is_complex_dtype(a.dtype) or utils.is_complex_dtype(b.dtype):
         # are you wondering what this bunch of codes are for? edge cases!
         complex_tens = a if utils.is_complex_dtype(a.dtype) else b
         neg_min_mask = torch.real(min_) < 0
-        inf_vals = torch.where(neg_min_mask, min_, torch.log(torch.exp(min_) + torch.exp(max_)))
-        non_nan_vals = torch.where(inf_mask, inf_vals, max_ + torch.log1p(torch.exp(min_ - max_)))
+        inf_vals = torch.where(
+            neg_min_mask, min_, torch.log(torch.exp(min_) + torch.exp(max_))
+        )
+        non_nan_vals = torch.where(
+            inf_mask, inf_vals, max_ + torch.log1p(torch.exp(min_ - max_))
+        )
         # the type for full_like does not include tensor yet
-        nan_vals = torch.full_like(complex_tens, complex(float('nan'), float('nan')))  # type: ignore
+        nan_vals = torch.full_like(complex_tens, complex(float("nan"), float("nan")))  # type: ignore[arg-type]
         nan_mask = torch.isnan(min_)
         return torch.where(nan_mask, nan_vals, non_nan_vals)
     else:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -10939,7 +10939,7 @@ op_db: List[OpInfo] = [
                         ),
                     ], ),
     BinaryUfuncInfo('logaddexp',
-                    dtypes=floating_types_and(torch.bfloat16),
+                    dtypes=floating_and_complex_types_and(torch.bfloat16),
                     dtypesIfCUDA=floating_types_and(torch.bfloat16, torch.float16),
                     dtypesIfROCM=floating_types_and(torch.bfloat16, torch.float16),
                     supports_forward_ad=True,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19017,6 +19017,11 @@ python_ref_db = [
         "_refs.logaddexp",
         torch_opinfo_name="logaddexp",
         supports_nvfuser=False,
+        skips=(
+            # failure due to mismatch in edge cases, which boils down to what torch.exp(inf + infj) should be
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='cpu',
+                         dtypes=(torch.complex64, torch.complex128)),
+        ),
     ),
     ElementwiseBinaryPythonRefInfo(
         "_refs.floor_divide",

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19021,6 +19021,8 @@ python_ref_db = [
             # failure due to mismatch in edge cases, which boils down to what torch.exp(inf + infj) should be
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='cpu',
                          dtypes=(torch.complex64, torch.complex128)),
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback', device_type='cpu',
+                         dtypes=(torch.complex64, torch.complex128)),
         ),
     ),
     ElementwiseBinaryPythonRefInfo(


### PR DESCRIPTION
Continuation of PR #93153 where I implemented logaddexp for complex, but didn't expose it to `torch.logaddexp`. So this PR is to expose the complex logaddexp to `torch.logaddexp`.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10