### PR TITLE
Avoid recursion in graph traverse

### DIFF
--- a/torch/fx/passes/utils/fuser_utils.py
+++ b/torch/fx/passes/utils/fuser_utils.py
@@ -50,13 +50,19 @@ def validate_partition(partition: NodeList) -> bool:
                 # external user node, need to expose as an output
                 outputs.append(user_node)
 
-    # Perform DFS on the partition outputs.
+    # Perform BFS on the partition outputs.
     # If it reaches a node within the partition, then it found a cycle.
-    def dfs_find_cycle(node, visited):
-        # Start with `node` and traverse through (toward child nodes)
-        # its connected sub-graph. Nodes in `visited` won't be added
+    # This function takes the ownership of `root_nodes` and may modify it.
+    def bfs_find_cycle(root_nodes: NodeList) -> bool:
+        # Set used to exclude nodes that have already been visited.
+        # If a node has been visited, that node and all its children have
+        # been checked for cycles.
+        visited: NodeSet = set()
+
+        # Start with `root_nodes` and traverse through (toward child nodes)
+        # their connected sub-graph. Nodes in `visited` won't be added
         # to `queue` again.
-        queue: NodeList = [node]
+        queue: NodeList = root_nodes
         while queue:
             current = queue.pop()
             visited.add(current)
@@ -68,19 +74,13 @@ def validate_partition(partition: NodeList) -> bool:
                 if user_node in visited:
                     continue
                 queue.append(user_node)
-        # `node` doesn't cause cycle.
+        # `root_nodes` don't cause cycle.
         return False
 
-    # Set used to exclude nodes that have already been visited.
-    # If a node has been visited, that node and all its children have
-    # been checked for cycles.
-    visited: NodeSet = set()
-    for output_node in outputs:
-        # Use the same `visited` for all outputs so that
-        # if a node has been visited, it is not visited again
-        # when traversing from another output.
-        if dfs_find_cycle(output_node, visited):
-            return False
+    # Use all output nodes as roots to traverse
+    # the graph to check cycles.
+    if bfs_find_cycle(outputs):
+        return False
 
     return True
 

--- a/torch/fx/passes/utils/fuser_utils.py
+++ b/torch/fx/passes/utils/fuser_utils.py
@@ -50,18 +50,26 @@ def validate_partition(partition: NodeList) -> bool:
                 # external user node, need to expose as an output
                 outputs.append(user_node)
 
+    # Set used to execlude nodes that have already been visited. 
+    # If a node has been visited, that node and all its children have
+    # been checked for cycles.
+    visited: NodeSet = set()
+
     # perform DFS on the parition outputs
     # if it reaches a node within the partition, then it found a cycle
     def dfs_find_cycle(node):
         # Start with `node` and traverse
         # through (toward child nodes)
         # its connected sub-graph.
-        queue = [node]
+        queue: NodeList = [node]
         while queue:
             current = queue.pop()
+            visited.add(current)
             if current in partition_set:
                 return True
             for user_node in current.users:
+                if user_node in visited:
+                    continue
                 queue.append(user_node)
         return False
 

--- a/torch/fx/passes/utils/fuser_utils.py
+++ b/torch/fx/passes/utils/fuser_utils.py
@@ -52,17 +52,17 @@ def validate_partition(partition: NodeList) -> bool:
 
     # perform DFS on the parition outputs
     # if it reaches a node within the partition, then it found a cycle
-    visited: NodeSet = set()
-
     def dfs_find_cycle(node):
-        if node in partition_set:
-            return True  # found cycle, return
-
-        visited.add(node)
-        for user_node in node.users:
-            if user_node not in visited:
-                if dfs_find_cycle(user_node):
-                    return True
+        # Start with `node` and traverse
+        # through (toward child nodes)
+        # its connected sub-graph.
+        queue = [node]
+        while queue:
+            current = queue.pop()
+            if current in partition_set:
+                return True
+            for user_node in current.users:
+                queue.append(user_node)
         return False
 
     for output_node in outputs:

--- a/torch/fx/passes/utils/fuser_utils.py
+++ b/torch/fx/passes/utils/fuser_utils.py
@@ -50,31 +50,36 @@ def validate_partition(partition: NodeList) -> bool:
                 # external user node, need to expose as an output
                 outputs.append(user_node)
 
-    # Set used to execlude nodes that have already been visited. 
-    # If a node has been visited, that node and all its children have
-    # been checked for cycles.
-    visited: NodeSet = set()
-
-    # perform DFS on the parition outputs
-    # if it reaches a node within the partition, then it found a cycle
-    def dfs_find_cycle(node):
-        # Start with `node` and traverse
-        # through (toward child nodes)
-        # its connected sub-graph.
+    # Perform DFS on the partition outputs.
+    # If it reaches a node within the partition, then it found a cycle.
+    def dfs_find_cycle(node, visited):
+        # Start with `node` and traverse through (toward child nodes)
+        # its connected sub-graph. Nodes in `visited` won't be added
+        # to `queue` again.
         queue: NodeList = [node]
         while queue:
             current = queue.pop()
             visited.add(current)
             if current in partition_set:
+                # Started from partition's `output` nodes, and reached
+                # another node in partition. Cycle!
                 return True
             for user_node in current.users:
                 if user_node in visited:
                     continue
                 queue.append(user_node)
+        # `node` doesn't cause cycle.
         return False
 
+    # Set used to exclude nodes that have already been visited.
+    # If a node has been visited, that node and all its children have
+    # been checked for cycles.
+    visited: NodeSet = set()
     for output_node in outputs:
-        if dfs_find_cycle(output_node):
+        # Use the same `visited` for all outputs so that
+        # if a node has been visited, it is not visited again
+        # when traversing from another output.
+        if dfs_find_cycle(output_node, visited):
             return False
 
     return True


### PR DESCRIPTION
It's easy to reach recursion limit in Python when calling `dfs_find_cycle` in big graphs (e.g., searching for attention heads in GPT-2 via SubgraphMatcher). Let's switch to queue-based graph tarversing.