### PR TITLE
Set push_null to False to fix periodic

### DIFF
--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -37,7 +37,7 @@ class ConstDictVariable(VariableTracker):
         if self.user_cls is collections.OrderedDict:
             codegen.extend_output(
                 [
-                    codegen.create_load_python_module(collections),
+                    codegen.create_load_python_module(collections, False),
                     create_instruction("LOAD_METHOD", "OrderedDict"),
                 ]
             )


### PR DESCRIPTION
periodic / cuda11.7-py3.10-gcc7-sm86-periodic-dynamo-benchmarks / test (aot_eager_all is failing due to a landrace between https://github.com/pytorch/pytorch/pull/95250 and https://github.com/pytorch/pytorch/pull/94098.


cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire