### PR TITLE
[WIP][Draft][Discussion] AOT Autograd dedup by source, not pos, add support for param dedup

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -643,19 +643,9 @@ class CheckFunctionManager:
         )
         for guard in aotautograd_guards:
             if isinstance(guard, DuplicateInputs):
-                pos_a = self.output_graph.pos_to_arg[guard.input_pos_a]
-                pos_b = self.output_graph.pos_to_arg[guard.input_pos_b]
-                assert (
-                    pos_b >= 0 and pos_a >= 0
-                ), "Deduped args out of bounds, cannot be negative"
-
-                assert self.output_graph.graphargs[
-                    pos_a
-                ].is_tensor, "Deduped arg must be a tensor"
-                assert self.output_graph.graphargs[
-                    pos_b
-                ].is_tensor, "Deduped arg must be a tensor"
-                code_part = f"{self.output_graph.graphargs[pos_a].source.name()} is {self.output_graph.graphargs[pos_b].source.name()}"  # noqa: B950
+                source_a = guard.input_source_a
+                source_b = guard.input_source_b
+                code_part = f"{source_a.name()} is {source_b.name()}"
                 code_parts.append(code_part)
                 verbose_code_parts.append(code_part)
             else:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -15,6 +15,7 @@ from torch._guards import (
     Checkpointable,
     Guard,
     GuardsCheckpointState,
+    Source,
     tracing,
     TracingContext,
 )
@@ -68,6 +69,7 @@ class OutputGraphState(NamedTuple):
     tracked_fakes: List[TrackedFake]
     guard_state: GuardsCheckpointState
     nn_modules: Optional[Dict[str, torch.nn.Module]]
+    nn_modules_sources: Optional[Dict[str, Source]]
     side_effects: SideEffects
     timestamp: int
 
@@ -219,6 +221,7 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
         # should use original graphargs.
         self.orig_graphargs: List[GraphArg] = self.graphargs
         self.nn_modules: Optional[Dict[str, torch.nn.Module]] = dict()
+        self.nn_modules_sources: Optional[Dict[str, Source]] = dict()
         self.side_effects = SideEffects()
         self.code_options = dict(code_options)
         self.output_instructions: List[Instruction] = []
@@ -278,12 +281,14 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
     def copy_graphstate(self) -> OutputGraphState:
         """Create a checkpoint of the current state by copying everything"""
         assert self.nn_modules is not None
+        assert self.nn_modules_sources is not None
         guards_graph_state = self.tracing_context.guards_context.copy_graphstate()
         state = OutputGraphState(
             list(self.graphargs),
             list(self.tracked_fakes),
             guards_graph_state,
             dict(self.nn_modules),
+            dict(self.nn_modules_sources),
             self.side_effects.clone(),
             self.timestamp,
         )
@@ -297,6 +302,7 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
             self.tracked_fakes,
             guards_state,
             self.nn_modules,
+            self.nn_modules_sources,
             self.side_effects,
             self.timestamp,
         ) = state
@@ -469,6 +475,7 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
         for i in itertools.count():
             if name not in self.nn_modules:
                 self.nn_modules[name] = target
+                self.nn_modules_sources[name] = source
                 return wrap_name(name)
             name = f"{base}_{i}"
 
@@ -670,6 +677,14 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
             # WrapperBackend needs real inputs, for now, to verify correctness
             if config.verify_correctness:
                 compiler_fn = WrapperBackend(compiler_fn, self.example_inputs())
+
+            pos = 0
+            for node in gm.graph.nodes:
+                if node.op == "placeholder":
+                    node.meta["source"] = self.graphargs[pos].source
+                    pos += 1
+
+            gm._name_to_source_map = self.nn_modules_sources
 
             # NOTE: [Real Tensors in Accuracy Evaluation]
             #

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -477,6 +477,7 @@ class OutputGraph(fx.Tracer, Checkpointable[OutputGraphState]):
         for i in itertools.count():
             if name not in self.nn_modules:
                 self.nn_modules[name] = target
+                assert self.nn_modules_sources is not None
                 self.nn_modules_sources[name] = source
                 if isinstance(target, torch.nn.Module):
                     for n, p in target.named_parameters():

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -28,7 +28,6 @@ from ..source import (
     GlobalSource,
     GlobalWeakRefSource,
     is_constant_source,
-    LocalInputSource,
     LocalSource,
     RandomValueSource,
     Source,
@@ -125,11 +124,6 @@ class GraphArg:
             assert isinstance(
                 self.fake_tensor, torch._subclasses.fake_tensor.FakeTensor
             )
-            # Mapping for downstream systems to remap back into dynamo arg positions
-            if isinstance(self.source, LocalInputSource):
-                if "graph_arg_pos" not in self.fake_tensor.__dict__:
-                    self.fake_tensor.__dict__["graph_arg_pos"] = []
-                self.fake_tensor.__dict__["graph_arg_pos"].append(self.source.pos)
         if isinstance(self.example, torch._subclasses.fake_tensor.FakeTensor):
             raise AssertionError("Fake Tensor observed in TorchDynamo Fx graph inputs")
 

--- a/torch/_export/__init__.py
+++ b/torch/_export/__init__.py
@@ -145,6 +145,7 @@ def _aot_capture(mod, flat_args):
         create_aot_dispatcher_function(
             exported_call,
             full_args,
+            [],
             aot_config,
         )
 

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -2805,9 +2805,10 @@ def aot_module_simplified(
     if hasattr(mod, "_name_to_source_map"):
         for name, _ in params.items():
             arg_sources.append(mod._name_to_source_map[name])
-    for node in mod.graph.nodes:
-        if node.op == "placeholder":
-            arg_sources.append(node.meta['source'])
+    if hasattr(mod, "graph"):
+        for node in mod.graph.nodes:
+            if node.op == "placeholder" and 'source' in node.meta:
+                arg_sources.append(node.meta['source'])
 
     compiled_fn = create_aot_dispatcher_function(
         functional_call,

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -2811,7 +2811,6 @@ def aot_module_simplified(
             name = re.sub(r"\[(\d+)\]", r"_\g<1>", name)
             # e.g. replace abc.xyz_123.qkv with abc_xyz_123_qkv
             name = re.sub(r"[^a-zA-Z0-9]", "_", name)
-            breakpoint()
             arg_sources.append(mod._name_to_source_map[name])
     if hasattr(mod, "graph"):
         for node in mod.graph.nodes:

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -28,6 +28,7 @@ from torch.nn.utils import stateless
 from . import config
 from .partitioners import default_partition
 from torch._guards import TracingContext, DuplicateInputs
+import re
 
 log = logging.getLogger(__name__)
 
@@ -2804,6 +2805,12 @@ def aot_module_simplified(
     arg_sources = []
     if hasattr(mod, "_name_to_source_map"):
         for name, _ in params.items():
+            # TODO(voz): Util this!!!
+            # e.g. replace abc.xyz[123].qkv with abc.xyz_123.qkv
+            name = re.sub(r"\[(\d+)\]", r"_\g<1>", name)
+            # e.g. replace abc.xyz_123.qkv with abc_xyz_123_qkv
+            name = re.sub(r"[^a-zA-Z0-9]", "_", name)
+            breakpoint()
             arg_sources.append(mod._name_to_source_map[name])
     if hasattr(mod, "graph"):
         for node in mod.graph.nodes:

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1781,7 +1781,8 @@ def aot_wrapper_dedupe(
     deduped_flat_args = remove_dupe_args(flat_args)
 
     tracing_context = TracingContext.get()
-    if tracing_context:
+    # Arg sources can be len if we did not get dynamo input sources map
+    if tracing_context and len(arg_sources) > 0:
         # TODO(voz): This structure is 1:1, we could consider an alternate structure like
         # kept_pos:[dupe_arg_pos], however, add_dupe_map is 1:1 so we would need a new structure there,
         # which feels like needless complexity for a tiny bit of efficiency at this point.

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -203,21 +203,6 @@ class GuardEnvExpr:
 
 
 """
-A class representing a pair of duplicate inputs.
-input_pos_a and input_pos_b are input positions we have deduped.
-"""
-
-
-@dataclasses.dataclass
-class DuplicateInputs(GuardEnvExpr):
-    input_pos_a: int
-    input_pos_b: int
-
-    def __post_init__(self):
-        assert self.input_pos_a != self.input_pos_b
-
-
-"""
 Checkpointable is an interface for driving state snapshotting, left purposely vague for now.
 
 copy_graphstate() -> T, a somewhat legacy name, is expected to emit a snapshot of any type that
@@ -364,3 +349,18 @@ class Source:
 
     def is_nn_module(self) -> bool:
         return self.guard_source().is_nn_module()
+
+
+"""
+A class representing a pair of duplicate inputs.
+input_pos_a and input_pos_b are input positions we have deduped.
+"""
+
+
+@dataclasses.dataclass
+class DuplicateInputs(GuardEnvExpr):
+    input_source_a: Source
+    input_source_b: Source
+
+    def __post_init__(self):
+        assert self.input_source_a != self.input_source_b

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -295,7 +295,6 @@ class MetaConverter:
                         torch._C.DispatchKey.ADInplaceOrView, False
                     )
                     try:
-
                         if base.dtype == t.dtype:
                             pass
                         elif is_c_of_r(base.dtype, t.dtype):

--- a/torch/distributed/_spmd/aot_function_patch.py
+++ b/torch/distributed/_spmd/aot_function_patch.py
@@ -170,6 +170,7 @@ def patched_aot_function(
             compiled_fn = create_aot_dispatcher_function(
                 flat_fn,
                 compile_flat_args,
+                [],
                 aot_config,
             )
             cached_res = (compiled_fn, out_spec)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95737

This is an iteration on a prior implementation that used positions. This is more sound, and easier to follow, but does have an open question w/r/t flattening.

A few thoughts / discussion points / notes:

1) Writing source to a tensor is not good enough. Tensor identity is the very nature by which we dedup, so all duplicate tensors ARE the same tensor - writing a source to one means the last source wins. There is a potential alternative impl that instead replace writing source with writing a list of sources, but that kind of puts the notion of duplication into that list. 

2) Placeholders alone is not good enough. We need params and buffers too, and the param and buffer lifting happens downstream of dynamo. 

3) This feels a little bit brittle because it still relies on position matching, but with a much simpler contract since the positions are not used for keying or indexing, and instead just rely on a match between params+buffers+inputs and the gm.params+gm.buffers+example args, which feels like a much tighter contract.

4) I do not know enough about AOT calling conventions to understand the flattening gaps here - ostensibly, dynamo should never be sending inputs to aot_autograd where flattening matters, but I do not know. cc @ezyang 

`pytest test/dynamo/test_aot_autograd.py -k test_arg_dupe_via_dynamo_recompiles_many_args`

cc @soumith @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire