### PR TITLE
Fix kernel name bug

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1571,7 +1571,12 @@ class TritonScheduling:
             )
             kernel_name = "_".join(["triton", fused_name, wrapper.next_kernel_suffix()])
             wrapper.kernels[src_code] = kernel_name
-            subs_name = kernel_name if config.triton.ordered_kernel_names else "triton_"
+            subs_name = (
+                kernel_name
+                if config.triton.ordered_kernel_names
+                or config.triton.descriptive_kernel_names
+                else "triton_"
+            )
             src_code = src_code.replace("KERNEL_NAME", subs_name)
 
             # TODO(voz): Ostensibly, we should not need this. But there are cases where C++ codegen does


### PR DESCRIPTION
[T146374491](https://www.internalfb.com/intern/tasks/?t=146374491): [Inductor] Descriptive kernel names not displaying in trace

Use the descriptive kernel name for the triton function name if indicated in the config

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire