### PR TITLE
allow privateuse1 key to be used with legacy constructor

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -487,6 +487,7 @@ void check_base_legacy_new(
         c10::DispatchKey::HPU,
         c10::DispatchKey::MPS,
         c10::DispatchKey::Meta,
+        c10::DispatchKey::PrivateUse1,
     });
     TORCH_CHECK(
         expected_key_set.has(dispatch_key),


### PR DESCRIPTION
fixes https://github.com/pytorch/pytorch/issues/95734

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95748

