### PR TITLE
Clean up install_triton and install_filelock in CI

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -149,32 +149,6 @@ function clone_pytorch_xla() {
   fi
 }
 
-function install_filelock() {
-  pip_install filelock
-}
-
-function install_triton() {
-  local commit
-  if [[ "${TEST_CONFIG}" == *rocm* ]]; then
-    echo "skipping triton due to rocm"
-  else
-    commit=$(get_pinned_commit triton)
-    if [[ "${BUILD_ENVIRONMENT}" == *gcc7* ]]; then
-      # Trition needs gcc-9 to build
-      sudo apt-get install -y g++-9
-      CXX=g++-9 pip_install --user "git+https://github.com/openai/triton@${commit}#subdirectory=python"
-    elif [[ "${BUILD_ENVIRONMENT}" == *clang* ]]; then
-      # Trition needs <filesystem> which surprisingly is not available with clang-9 toolchain
-      sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-      sudo apt-get install -y g++-9
-      CXX=g++-9 pip_install --user "git+https://github.com/openai/triton@${commit}#subdirectory=python"
-    else
-      pip_install --user "git+https://github.com/openai/triton@${commit}#subdirectory=python"
-    fi
-    pip_install --user jinja2
-  fi
-}
-
 function setup_torchdeploy_deps(){
   conda install -y -n "py_${ANACONDA_PYTHON_VERSION}" "libpython-static=${ANACONDA_PYTHON_VERSION}"
   local CC

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -884,7 +884,6 @@ elif [[ "${TEST_CONFIG}" == *dynamo* && "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHAR
 elif [[ "${TEST_CONFIG}" == *aot_eager_all* ]]; then
   install_torchtext
   install_torchvision
-  install_filelock
   checkout_install_torchbench
   install_huggingface
   install_timm
@@ -897,7 +896,6 @@ elif [[ "${TEST_CONFIG}" == *aot_eager_all* ]]; then
   fi
 elif [[ "${TEST_CONFIG}" == *aot_eager_huggingface* ]]; then
   install_torchvision
-  install_filelock
   install_huggingface
   if [[ "${TEST_CONFIG}" == *dynamic* ]]; then
     test_aot_eager_benchmark huggingface "" --dynamic-shapes
@@ -906,7 +904,6 @@ elif [[ "${TEST_CONFIG}" == *aot_eager_huggingface* ]]; then
   fi
 elif [[ "${TEST_CONFIG}" == *aot_eager_timm* && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
-  install_filelock
   install_timm
   id=$((SHARD_NUMBER-1))
   if [[ "${TEST_CONFIG}" == *dynamic* ]]; then
@@ -917,7 +914,6 @@ elif [[ "${TEST_CONFIG}" == *aot_eager_timm* && $NUM_TEST_SHARDS -gt 1 ]]; then
 elif [[ "${TEST_CONFIG}" == *aot_eager_torchbench* ]]; then
   install_torchtext
   install_torchvision
-  install_filelock
   checkout_install_torchbench
   if [[ "${TEST_CONFIG}" == *dynamic* ]]; then
     PYTHONPATH=$(pwd)/torchbench test_aot_eager_benchmark torchbench "" --dynamic-shapes

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -862,8 +862,6 @@ elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
   # TODO: run some C++ tests
   echo "no-op at the moment"
 elif [[ "$TEST_CONFIG" == distributed ]]; then
-  install_filelock
-  install_triton
   test_distributed
   # Only run RPC C++ tests on the first shard
   if [[ "${SHARD_NUMBER}" == 1 ]]; then
@@ -873,20 +871,15 @@ elif [[ "$TEST_CONFIG" == deploy ]]; then
   checkout_install_torchdeploy
   test_torch_deploy
 elif [[ "${TEST_CONFIG}" == *inductor_distributed* ]]; then
-  install_filelock
-  install_triton
   install_huggingface
   test_inductor_distributed
 elif [[ "${TEST_CONFIG}" == *dynamo* && "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
   test_without_numpy
   install_torchvision
-  install_triton
   test_dynamo_shard 1
   test_aten
 elif [[ "${TEST_CONFIG}" == *dynamo* && "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
-  install_filelock
-  install_triton
   test_dynamo_shard 2
 elif [[ "${TEST_CONFIG}" == *aot_eager_all* ]]; then
   install_torchtext
@@ -933,11 +926,6 @@ elif [[ "${TEST_CONFIG}" == *aot_eager_torchbench* ]]; then
   fi
 elif [[ "${TEST_CONFIG}" == *inductor_huggingface* ]]; then
   install_torchvision
-  install_filelock
-  if [[ "${TEST_CONFIG}" != *inductor_huggingface_cpu_accuracy* ]]; then
-    # Cpp backend does not depend on triton
-    install_triton
-  fi
   install_huggingface
   if [[ "${TEST_CONFIG}" == *inductor_huggingface_perf* ]]; then
     test_inductor_huggingface_perf
@@ -948,11 +936,6 @@ elif [[ "${TEST_CONFIG}" == *inductor_huggingface* ]]; then
   fi
 elif [[ "${TEST_CONFIG}" == *inductor_timm* && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
-  install_filelock
-  if [[ "${TEST_CONFIG}" != *inductor_timm_cpu_accuracy* ]]; then
-    # Cpp backend does not depend on triton
-    install_triton
-  fi
   install_timm
   id=$((SHARD_NUMBER-1))
   if [[ "${TEST_CONFIG}" == *inductor_timm_perf* && $NUM_TEST_SHARDS -gt 1 ]]; then
@@ -965,11 +948,6 @@ elif [[ "${TEST_CONFIG}" == *inductor_timm* && $NUM_TEST_SHARDS -gt 1 ]]; then
 elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
   install_torchtext
   install_torchvision
-  install_filelock
-  if [[ "${TEST_CONFIG}" != *inductor_torchbench_cpu_accuracy* ]]; then
-    # Cpp backend does not depend on triton
-    install_triton
-  fi
   if [[ "${TEST_CONFIG}" == *inductor_torchbench_perf* ]]; then
     checkout_install_torchbench
     test_inductor_torchbench_perf
@@ -985,19 +963,15 @@ elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
   fi
 elif [[ "${TEST_CONFIG}" == *inductor* && "${SHARD_NUMBER}" == 1 ]]; then
   install_torchvision
-  install_filelock
-  install_triton
   test_inductor
   test_inductor_distributed
 elif [[ "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
   test_without_numpy
   install_torchvision
-  install_triton
   test_python_shard 1
   test_aten
 elif [[ "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
-  install_triton
   test_python_shard 2
   test_libtorch
   test_aot_compilation
@@ -1007,7 +981,6 @@ elif [[ "${SHARD_NUMBER}" == 2 && $NUM_TEST_SHARDS -gt 1 ]]; then
 elif [[ "${SHARD_NUMBER}" -gt 2 ]]; then
   # Handle arbitrary number of shards
   install_torchvision
-  install_triton
   test_python_shard "$SHARD_NUMBER"
 elif [[ "${BUILD_ENVIRONMENT}" == *vulkan* ]]; then
   test_vulkan
@@ -1025,7 +998,6 @@ elif [[ "${TEST_CONFIG}" == *functorch* ]]; then
   test_functorch
 else
   install_torchvision
-  install_triton
   install_monkeytype
   test_python
   test_aten


### PR DESCRIPTION
After Dockerize triton in https://github.com/pytorch/pytorch/pull/95233, we can now clean up `install_triton` and `install_filelock` in the CI to improve its reliability.