### PR TITLE
[Inductor Perf Test Workflow] Remove pull request trigger and rely on ciflow/ label only

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -3,9 +3,6 @@ name: inductor-A100-perf
 on:
   schedule:
     - cron: 45 1,9,17 * * *
-  pull_request:
-    paths:
-      - .github/workflows/inductor-perf-test-nightly.yml
   push:
     tags:
       - ciflow/inductor-perf-test-nightly/*


### PR DESCRIPTION
Mitigates A100 queue issue. 
Workflow seems to run twice upon pull request changes. 