### PR TITLE
Float support for `masked_fill`

### DIFF
--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -305,12 +305,18 @@ void index_copy_kernel(
 template <typename scalar_t, typename mask_t>
 void cpu_masked_fill_kernel(TensorIterator& iter, scalar_t value) {
   auto is_mask_bool = std::is_same<mask_t, bool>::value;
+  auto is_mask_float = std::is_same<mask_t, float>::value || 
+    std::is_same<mask_t, double>::value || std::is_same<mask_t, at::Half>::value;
+
   auto loop = [&](char** data, const int64_t* strides, int64_t n) {
     char* dst = data[0];
     char* mask = data[1];
     for (const auto i : c10::irange(n)) {
       mask_t mask_value = *(mask_t*)(mask + strides[1] * i);
-      if (!is_mask_bool) {
+
+      // TODO: current python tests assume non-zero masked float values equate to true
+      // Would have to change tests (if needed), then remove `is_mask_float`
+      if (!is_mask_bool && !is_mask_float) {
         TORCH_CHECK(mask_value == 0 || mask_value == 1, "Mask tensor can take 0 and 1 values only");
       }
       if (mask_value) {
@@ -328,6 +334,12 @@ void masked_fill_kernel(TensorIterator& iter, const Scalar& value) {
       auto mask_dtype = iter.input_dtype(0);
       if (mask_dtype == ScalarType::Bool) {
         cpu_masked_fill_kernel<scalar_t, bool>(iter, scalar_val);
+      } else if (mask_dtype == ScalarType::Float || mask_dtype == ScalarType::BFloat16) {
+        cpu_masked_fill_kernel<scalar_t, float>(iter, scalar_val);
+      } else if (mask_dtype == ScalarType::Double) {
+        cpu_masked_fill_kernel<scalar_t, double>(iter, scalar_val);
+      } else if (mask_dtype == ScalarType::Half) {
+        cpu_masked_fill_kernel<scalar_t, at::Half>(iter, scalar_val);
       } else {
         cpu_masked_fill_kernel<scalar_t, unsigned char>(iter, scalar_val);
       }

--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -305,7 +305,7 @@ void index_copy_kernel(
 template <typename scalar_t, typename mask_t>
 void cpu_masked_fill_kernel(TensorIterator& iter, scalar_t value) {
   auto is_mask_bool = std::is_same<mask_t, bool>::value;
-  auto is_mask_float = std::is_same<mask_t, float>::value || 
+  auto is_mask_float = std::is_same<mask_t, float>::value ||
     std::is_same<mask_t, double>::value || std::is_same<mask_t, at::Half>::value;
 
   auto loop = [&](char** data, const int64_t* strides, int64_t n) {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3750,7 +3750,7 @@ else:
                 self.assertEqual(out_dc, expected, atol=0, rtol=0)
 
     # FIXME: find a test suite for the masked fill operator
-    @dtypes(*product(all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16), (torch.uint8, torch.bool)))
+    @dtypes(*product(all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16), (torch.uint8, torch.bool, torch.float)))
     def test_masked_fill(self, device, dtypes):
         dtype = dtypes[0]
         mask_dtype = dtypes[1]
@@ -3759,7 +3759,12 @@ else:
 
             num_dest = 10
             dst = torch.zeros(num_dest, dtype=dtype)
-            mask = torch.randint(2, (num_dest,), dtype=mask_dtype)
+            if mask_dtype == torch.float:
+                mask = torch.rand((num_dest,), dtype=mask_dtype)
+                # test false conditions with some 0 values
+                mask[mask > 0.5] = 0
+            else:
+                mask = torch.randint(2, (num_dest,), dtype=mask_dtype)
             val = random.random()
             dst2 = dst.clone()
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -62,7 +62,7 @@ except ImportError:
 # class TestClassFoo(TestCase):
 #
 #   # A template test that can be specialized with a device
-#   # NOTE: this test case is not runnably by unittest or pytest because it
+#   # NOTE: this test case is not runnable by unittest or pytest because it
 #   #   accepts an extra positional argument, "device", they do not understand
 #   def test_bar(self, device):
 #     pass


### PR DESCRIPTION
__What?__
Fixes #85063 and #89320 and when mask values are `ScalarType::Half` (to be precise, `float16` didn't mask on my local machine)

Further changes:
1. Minor typo in `torch/testing/_internal/common_device_type.py`

__Why?__
1. Restricting floating-point mask values to 0 or 1 threw errors on existing tests, so non-zero values are `True`. We could also `TORCH_CHECK` to prevent the use of floating-point, as opposed to Dispatch switch macros (tests failed when I didn't put `kBool` under the `ALL_TYPES` Dispatch macro).

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 