### PR TITLE
change stacksize_analysis to worklist algorithm for better result

### DIFF
--- a/torch/_dynamo/bytecode_analysis.py
+++ b/torch/_dynamo/bytecode_analysis.py
@@ -212,7 +212,9 @@ def stacksize_analysis(instructions):
             changed = stack_sizes[inst.target].offset_of(
                 stack_size, stack_effect(inst.opcode, inst.arg, jump=True)
             )
-            if changed:
+            if changed and (
+                sys.version_info >= (3, 9) or inst.opcode != dis.opmap["CALL_FINALLY"]
+            ):
                 worklist.append(indexof[id(inst.target)])
 
     if False:


### PR DESCRIPTION
The current algorithm for stacksize_analysis is round-robin algorithm with 100 as iteration upper limit, which is not an optimal choice. This PR implements the worklist version for better complexity and precision.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @chenyang78 @aakhundov @kadeng @soumith @yanboliang @anijain2305 @desertfire