### PR TITLE
[CI] Reduce the frequency of running inductor-perf-test-nightly

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -2,7 +2,7 @@ name: inductor-A100-perf
 
 on:
   schedule:
-    - cron: 45 1,9,17 * * *
+    - cron: 45 1 * * *
   push:
     tags:
       - ciflow/inductor-perf-test-nightly/*


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #95685
* __->__ #95778

Summary: This to prepare for extending inductor-perf-test-nightly to
collect dashboard numbers.