### PR TITLE
Switch DTensor to use funcol::all_reduce.

### DIFF
--- a/test/distributed/_spmd/test_tracing.py
+++ b/test/distributed/_spmd/test_tracing.py
@@ -47,10 +47,9 @@ class TraceDeviceMeshTestBase:
             ]
 
             def fn(tensor: torch.Tensor):
-                tensor_to_reduce = CommTensor(tensor.clone())
-                mesh.all_reduce(tensor_to_reduce, mesh_dim=dim)
+                tensor = mesh.all_reduce(tensor, mesh_dim=dim)
                 # multiply with 1 to trigger wait on read during tracing.
-                return tensor_to_reduce * 1
+                return tensor * 1
 
             # use a local_tensor + 1 for tracing to make sure that we are not
             # simply replaying recorded tensor value

--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -13,6 +13,7 @@ from torch.distributed.distributed_c10d import (
     is_initialized,
     new_group,
     ProcessGroup,
+    get_process_group_ranks,
 )
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -239,7 +240,8 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
     def test_all_reduce_1d(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
         local_tensor = torch.ones(3, 3, device=self.device_type) * self.rank
-        mesh.all_reduce(local_tensor, mesh_dim=0)
+        # multiply with 1 to trigger wait
+        local_tensor = mesh.all_reduce(local_tensor, mesh_dim=0) * 1
         res_num = ((0 + self.world_size - 1) * self.world_size) / 2
         self.assertEqual(local_tensor, torch.ones(3, 3) * res_num)
 
@@ -479,12 +481,9 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
         # check all dim groups
         dim_to_subgroups = mesh.get_dim_groups()
         for dim, dim_group in enumerate(dim_to_subgroups):
-            dim_group_size = get_world_size(dim_group)
-            global_ranks = [
-                get_global_rank(dim_group, i) for i in range(dim_group_size)
-            ]
+            global_ranks = get_process_group_ranks(dim_group)
             cloned_local_tensor = local_tensor.clone()
-            mesh.all_reduce(cloned_local_tensor, mesh_dim=dim)
+            cloned_local_tensor = mesh.all_reduce(cloned_local_tensor, mesh_dim=dim) * 1
             res_num = sum(global_ranks)
             self.assertEqual(cloned_local_tensor, torch.ones(3, 3) * res_num)
 

--- a/torch/distributed/_spmd/distribute.py
+++ b/torch/distributed/_spmd/distribute.py
@@ -251,7 +251,7 @@ def _convert_output(
 
         traced_dispatch, result_obj = _build_dummy_add_graph(dt, node_to_obj)
 
-        wait = [n for n in traced_dispatch.graph.nodes if n.name == "wait_comm"]
+        wait = [n for n in traced_dispatch.graph.nodes if n.name == "wait_comm" or n.name == "wait_tensor"]
         add = [n for n in traced_dispatch.graph.nodes if n.name == "add"]
         assert len(wait) == 1 and len(add) == 1
 

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -7,7 +7,6 @@ import torch
 from torch.distributed.distributed_c10d import (
     _get_default_group,
     all_gather,
-    all_reduce,
     all_to_all,
     broadcast,
     get_global_rank,
@@ -23,6 +22,9 @@ from torch.distributed.distributed_c10d import (
     scatter,
     Work,
 )
+
+import torch.distributed.distributed_c10d as c10d
+import torch.distributed._functional_collectives as funcol
 
 _global_device_mesh: Optional["DeviceMesh"] = None
 
@@ -419,7 +421,7 @@ class DeviceMesh:
         op: ReduceOp = ReduceOp.SUM,  # type: ignore[assignment]
         mesh_dim: int = 0,
         async_op: bool = False,
-    ) -> Optional[Work]:
+    ) -> torch.Tensor:
         """
         all_reduce the tensor on each rank on a device mesh dimension, and
         return an output tensor on each rank after all_reduce.
@@ -432,10 +434,11 @@ class DeviceMesh:
                 to reduce on.
 
         Returns:
-            A :class:`Work` object
+            A :class:`torch.Tensor` object
         """
         dim_group = self._dim_groups[mesh_dim]
-        return all_reduce(tensor, op=op, group=dim_group, async_op=async_op)
+        op_name: str = op.name  # type: ignore[attr-defined]
+        return funcol.all_reduce(tensor, reduceOp=op_name, group=(self, mesh_dim,))
 
     def reduce_scatter(
         self,
@@ -493,9 +496,9 @@ class DeviceMesh:
             flat_tensor = torch.cat(flattened_list).clone(
                 memory_format=torch.contiguous_format
             )
-            fut = self.all_reduce(
-                flat_tensor, op=op, mesh_dim=mesh_dim, async_op=async_op
-            )
+            dim_group = self._dim_groups[mesh_dim]
+            fut = c10d.all_reduce(flat_tensor, op=op, group=dim_group, async_op=async_op)
+
             # scatter the tensor
             output_offset = offset_list[my_coordinate[mesh_dim]]
             output.copy_(

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -269,13 +269,9 @@ class _Partial(Placement):
     def _to_replicate(
         self, tensor: torch.Tensor, mesh: DeviceMesh, mesh_dim: int
     ) -> torch.Tensor:
-        # out-of-place all_reduce to replicate, since the current partial DTensor
-        # might get used by other ops as well, so we can't inplace modify it
-        cloned_local = CommTensor(tensor.clone(memory_format=torch.contiguous_format))
-        mesh.all_reduce(
-            cloned_local, self.reduce_op, mesh_dim=mesh_dim  # type: ignore[call-arg]
+        return mesh.all_reduce(
+            tensor, self.reduce_op, mesh_dim=mesh_dim  # type: ignore[call-arg]
         )
-        return cloned_local
 
     def _to_shard(
         self,


### PR DESCRIPTION
This is relanding the troubling part of #95009 that caused a regression.

BC: This changes the signature and semantics of DeviceMesh::all_reduce.

DeviceMesh::all_reduce now uses a functional collective under the hood which makes it more easily traceable.
You no longer need to use CommTensor to get a trace.

all_reduce now is async only and uses AsyncCollectiveTensor to ensure proper stream synchronization.

Signature changed: removed async_op param and changes return type from Optional[Work] to torch.Tensor.