### PR TITLE
[optim] Widen the cases for defaulting to foreach

### DIFF
--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -516,7 +516,9 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
             fsdp_kwargs=fsdp_kwargs,
             deterministic=True,
         )
-        optim_orig_params = torch.optim.Adam(fsdp_model_orig_params.parameters(), foreach=False, lr=LR)
+        optim_orig_params = torch.optim.Adam(
+            fsdp_model_orig_params.parameters(), foreach=False, lr=LR
+        )
         return fsdp_model, optim, fsdp_model_orig_params, optim_orig_params
 
     def _check_fsdp_parameter_parity(self, fsdp1: FSDP, fsdp2: FSDP) -> None:

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -507,7 +507,7 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
             fsdp_kwargs=fsdp_kwargs,
             deterministic=True,
         )
-        optim = torch.optim.Adam(fsdp_model.parameters(), lr=LR)
+        optim = torch.optim.Adam(fsdp_model.parameters(), foreach=False, lr=LR)
         fsdp_kwargs["use_orig_params"] = True
         fsdp_model_orig_params = TransformerWithSharedParams.init(
             self.process_group,
@@ -516,7 +516,7 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
             fsdp_kwargs=fsdp_kwargs,
             deterministic=True,
         )
-        optim_orig_params = torch.optim.Adam(fsdp_model_orig_params.parameters(), lr=LR)
+        optim_orig_params = torch.optim.Adam(fsdp_model_orig_params.parameters(), foreach=False, lr=LR)
         return fsdp_model, optim, fsdp_model_orig_params, optim_orig_params
 
     def _check_fsdp_parameter_parity(self, fsdp1: FSDP, fsdp2: FSDP) -> None:

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -193,8 +193,7 @@ def adadelta(
 
     # We still respect when the user inputs False for foreach.
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, square_avgs, acc_deltas],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -210,8 +210,7 @@ def adagrad(
         )
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, state_sums, state_steps],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -259,9 +259,7 @@ def adam(params: List[Tensor],
     # and pass False to use_fused. This is not a mistake--we want to give the fused impl
     # bake-in time before making it the default, even if it is typically faster.
     if fused is None and foreach is None:
-        _, foreach = _default_to_fused_or_foreach(
-            [params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, state_steps],
-            differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
     if fused is None:
         fused = False
     if foreach is None:

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -206,8 +206,7 @@ def adamax(
         )
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_infs, state_steps],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -300,9 +300,7 @@ def adamw(
     # and pass False to use_fused. This is not a mistake--we want to give the fused impl
     # bake-in time before making it the default, even if it is typically faster.
     if fused is None and foreach is None:
-        _, foreach = _default_to_fused_or_foreach(
-            [params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, state_steps],
-            differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
     if fused is None:
         fused = False
     if foreach is None:

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -185,8 +185,7 @@ def asgd(
     """
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, axs, mus, etas, state_steps],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -187,8 +187,7 @@ def nadam(params: List[Tensor],
         raise RuntimeError("API has changed, `mu_products` argument must contain a list of singleton tensors")
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, mu_products, state_steps],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError('torch.jit.script not supported with foreach optimizers')

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -57,23 +57,20 @@ def _dispatch_sqrt(x: float):  # float annotation is needed because of torchscri
 
 # For any optimizer with a faster implementation, we attempt to default to the
 # fastest + stablest whenever possible. For foreach, the requirements are to have
-# native tensors all on CUDA. For fused, there's currently the additional requirement
+# native params all on CUDA. For fused, there's currently the additional requirement
 # that the tensors' dtypes must be floating point. Neither alternative supports
 # torch.jit.script nor differentiable, so we fall back to the single tensor
 # implementation in those cases.
-def _default_to_fused_or_foreach(tensorlists: List[List[torch.Tensor]],
+def _default_to_fused_or_foreach(params: List[torch.Tensor],
                                  differentiable: bool,
                                  use_fused: bool = False) -> Tuple[bool, bool]:
     if torch.jit.is_scripting() or differentiable:
         return False, False
-    all_tensors = []
-    for tensorlist in tensorlists:
-        all_tensors.extend(tensorlist)
     fused = use_fused and all(
-        p is None or (type(p) in _foreach_supported_types and p.is_cuda and torch.is_floating_point(p)) for p in all_tensors
+        p is None or (type(p) in _foreach_supported_types and p.is_cuda and torch.is_floating_point(p)) for p in params
     )
     foreach = not fused and all(
-        p is None or (type(p) in _foreach_supported_types and p.is_cuda) for p in all_tensors
+        p is None or (type(p) in _foreach_supported_types and p.is_cuda) for p in params
     )
     return fused, foreach
 

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -209,8 +209,7 @@ def radam(
         )
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, state_steps],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -220,8 +220,7 @@ def rmsprop(
     """
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, square_avgs, grad_avgs, momentum_buffer_list],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -192,8 +192,7 @@ def rprop(
     """
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, prevs, step_sizes],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -207,8 +207,7 @@ def sgd(params: List[Tensor],
         # why must we be explicit about an if statement for torch.jit.is_scripting here?
         # because JIT can't handle Optionals nor fancy conditionals when scripting
         if not torch.jit.is_scripting():
-            _, foreach = _default_to_fused_or_foreach([params, d_p_list, momentum_buffer_list],
-                                                      differentiable=False, use_fused=False)
+            _, foreach = _default_to_fused_or_foreach(params, differentiable=False, use_fused=False)
         else:
             foreach = False
 


### PR DESCRIPTION
Big OOP correction continued. Also added a test this time to verify the defaulting was as expected. 

The key here is realizing that the grouping for foreach already assumes that the non-param tensorlists follow suit in dtype and device, so it is too narrow to check that _all_ tensors were on CUDA. The main leeway this allowed was state_steps, which are sometimes cpu tensors. Since foreach _can_ handle cpu tensors, this should not introduce breakage.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95820
* #95811

