### PR TITLE
Fixing a bug where allocating a 4GB block results in using 8GB of memory

### DIFF
--- a/aten/src/ATen/cuda/CachingHostAllocator.cpp
+++ b/aten/src/ATen/cuda/CachingHostAllocator.cpp
@@ -19,6 +19,12 @@ namespace at {
 namespace cuda {
 namespace {
 
+// allocations above this size will not be rounded up to the next power of two
+const size_t kMaxRoundThreshold = 32 * 1024 * 1024;
+
+// allocations above this size will not be cached
+const size_t kMaxCachedSize = kMaxRoundThreshold;
+
 struct BlockSize {
   size_t size_{0};
   void* ptr_{nullptr};
@@ -174,12 +180,17 @@ class CUDAHostAllocator {
           at::Device(at::DeviceType::CUDA, *primary_ctx_device_index));
     }
 
+    size_t rounded_size = size;
+    if (size < kMaxRoundThreshold) {
+        rounded_size = c10::llvm::PowerOf2Ceil(size);
+    }
+
     // Round up the allocation to the nearest power of two to improve reuse.
     void* ptr = nullptr;
     C10_CUDA_CHECK(cudaHostAlloc(
-        &ptr, c10::llvm::PowerOf2Ceil(size), cudaHostAllocDefault));
+        &ptr, rounded_size, cudaHostAllocDefault));
     auto block = new Block();
-    block->size_ = c10::llvm::PowerOf2Ceil(size);
+    block->size_ = rounded_size;
     block->ptr_ = ptr;
     block->allocated_ = true;
 
@@ -220,8 +231,13 @@ class CUDAHostAllocator {
     }
 
     if (!events) {
-      std::lock_guard<std::mutex> g(free_list_mutex_);
-      free_list_.insert(block);
+      if (block->size_ <= kMaxCachedSize) {
+        std::lock_guard<std::mutex> g(free_list_mutex_);
+        free_list_.insert(block);
+      } else {
+        std::lock_guard<std::mutex> g(blocks_mutex_);
+        delete_block(block);
+      }
     } else {
       std::lock_guard<std::mutex> g(cuda_events_mutex_);
       for (auto&& event : *events) {
@@ -278,14 +294,18 @@ class CUDAHostAllocator {
     std::vector<Block*> blocks_to_remove(free_list_.begin(), free_list_.end());
     free_list_.clear();
     for (auto* block : blocks_to_remove) {
-      blocks_.erase(block);
-      ptr_to_block_.erase(block->ptr_);
-      AT_CUDA_CHECK(cudaFreeHost(block->ptr_));
-      delete block;
+      delete_block(block);
     }
   }
 
  private:
+  void delete_block(Block* block) {
+    blocks_.erase(block);
+    ptr_to_block_.erase(block->ptr_);
+    AT_CUDA_CHECK(cudaFreeHost(block->ptr_));
+    delete block;
+  }
+
   void process_events() {
     while (true) {
       // Avoid calling cudaEventDestroy while holding a mutex, so move
@@ -338,8 +358,13 @@ class CUDAHostAllocator {
       }
 
       if (available) {
-        std::lock_guard<std::mutex> g(free_list_mutex_);
-        free_list_.insert(block);
+        if (block->size_ <= kMaxCachedSize) {
+          std::lock_guard<std::mutex> g(free_list_mutex_);
+          free_list_.insert(block);
+        } else {
+          std::lock_guard<std::mutex> g(blocks_mutex_);
+          delete_block(block);
+        }
       }
     }
   }


### PR DESCRIPTION
I added two constants. First helps with avoiding rounding while we hit a certain threshold, and second, to control what blocks can be cached.

Allocations larger than `kMaxRoundThreshold` will not be rounded to the next power of two anymore. Generally it is expected that larger allocations happen less frequently, and this more or less matches what happens in `CudaCachingAllocator`.

Blocks larger than `kMaxCachedSize` will not be cached. This is a separate problem than the above but I noticed this caching is poorly implemented here and doesn't do anything to avoid fragmentation or to help with good resource utilization. For example, the following allocations:
```
t1 = alloc(4GB)
del t1
t2 = alloc(10k)
t3 = alloc(4GB)
```
this results in allocating 8GB, because the first 4GB block that is cached gets assigned to the 10k allocation wasting the rest of the block.

Lastly, ideally I would make this constants configurable, but looking around the code I didn't see any existing mechanisms in ATen to configure things at runtime.

Fixes #95823
