### PR TITLE
[ROCM] Restrict pytorch rocm to only use triton 2.0.x (#95793)

### DIFF
--- a/.github/requirements/triton-requirements-rocm.txt
+++ b/.github/requirements/triton-requirements-rocm.txt
@@ -1,1 +1,1 @@
-pytorch-triton-rocm>=2.0.0.dev
+pytorch-triton-rocm>=2.0.0,<2.1


### PR DESCRIPTION
To align with upstream, we are requiring triton dependency to be between 2.0.0 and 2.1.  This will allow PyTorch 2.0 on ROCM to stay flexible enough to pick up any performance/stability improvements from Triton, without needing to cut a separate PyTorch version.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/95793
Approved by: https://github.com/huydhn

Fixes #ISSUE_NUMBER


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport