### PR TITLE
Adding tangent reorder to partition function

### DIFF
--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -31,6 +31,10 @@ debug_graphs = os.environ.get("AOT_FX_GRAPHS", False)
 # Prints out joint graph traced, before partitioning
 debug_joint = os.environ.get("AOT_FX_GRAPHS_JOINT", False)
 
+use_dynamic_shapes = os.getenv("AOT_DYNAMIC_SHAPES", False)
+
+reorder_backwards = os.getenv("AOT_REORDER_BACKWARDS", False)
+
 static_weight_shapes = True
 
 # Applies CSE to the graph before partitioning

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -274,8 +274,8 @@ def pointwise_ops():
 
 
 def min_cut_rematerialization_partition(
-    joint_module: fx.GraphModule, _joint_inputs, compiler="nvfuser", recomputable_ops=None, reorder_backwards=True,
-    *, num_fwd_outputs
+    joint_module: fx.GraphModule, _joint_inputs, compiler="nvfuser", recomputable_ops=None,
+    reorder_backwards=config.reorder_backwards, *, num_fwd_outputs
 ) -> Tuple[fx.GraphModule, fx.GraphModule]:
     """
     Partitions the joint graph such that the backward recomputes the forward.

--- a/torch/_functorch/reorder_tangents.py
+++ b/torch/_functorch/reorder_tangents.py
@@ -23,7 +23,7 @@ def collect_mul_ops(node, target_name="aten::mul.Tensor", seen=None):
     seen.add(node)
 
     def is_same_target(node):
-        if isinstance(node.target, torch._ops.PyOperatorABC):
+        if isinstance(node.target, torch._ops.OperatorBase):
             return node.target.name() == target_name
         return False
 

--- a/torch/_functorch/reorder_tangents.py
+++ b/torch/_functorch/reorder_tangents.py
@@ -13,9 +13,9 @@ def collect_mul_ops(node, target_name="aten::mul.Tensor"):
     """
 
     def is_same_target(node):
-        if isinstance(node.target, str):
-            return False
-        return node.target.name() == target_name
+        if isinstance(node.target, torch._ops.PyOperatorABC):
+            return node.target.name() == target_name
+        return False
 
     input_nodes = list(node.users)
     if is_same_target(node):

--- a/torch/_functorch/reorder_tangents.py
+++ b/torch/_functorch/reorder_tangents.py
@@ -42,7 +42,7 @@ def collect_mul_ops(node, target_name="aten::mul.Tensor", seen=None):
                 new_input_nodes.append(input_node)
 
         input_nodes = new_input_nodes
-        if len(group) > 1:
+        if len(group) > 2:
             yield group
 
     for input_node in input_nodes:
@@ -69,10 +69,9 @@ def reorder_tangents(graph):
 
     if AOT_PARTITIONER_DEBUG:
         print(f"Found {len(groups)} groups of pointwise multiplications to reorder")
-    # print(f"Found {[len(group) for group in groups]} groups")
     for group in groups:
         if AOT_PARTITIONER_DEBUG:
-            print(' + GROUP: ', group)
+            print(' + will reorder group: ', group)
         inputs = [group[0]._args[0]] + [node._args[1] for node in group]
         end = group[-1]
         while inputs:


### PR DESCRIPTION
With the graph:

```py
@torch.compile
def f(a, b, c, d):
   return a * b * c * d
```
## Without re-order
```
Ops banned from rematerialization:  set()

Theoretical Activations Stored:  9.6e-08
# remat/fw/bw: 0/3/3
Count of Ops Rematerialized:  []
====== Forward graph 0 ======
class GraphModule(torch.nn.Module):
    def forward(self, primals_1: f32[8], primals_2: f32[8], primals_3: f32[8], primals_4: f32[8]):
        # File: graph.py:11, code: return x * a * b * c
        mul: f32[8] = torch.ops.aten.mul.Tensor(primals_1, primals_2);  primals_1 = None
        mul_1: f32[8] = torch.ops.aten.mul.Tensor(mul, primals_3);  mul = None
        mul_2: f32[8] = torch.ops.aten.mul.Tensor(mul_1, primals_4);  mul_1 = None
        return [mul_2, primals_2, primals_3, primals_4]
        
====== Backward graph 0 ======
class GraphModule(torch.nn.Module):
    def forward(self, primals_2: f32[8], primals_3: f32[8], primals_4: f32[8], tangents_1: f32[8]):
        # File: graph.py:11, code: return x * a * b * c
        mul_3: f32[8] = torch.ops.aten.mul.Tensor(tangents_1, primals_4);  tangents_1 = primals_4 = None
        mul_4: f32[8] = torch.ops.aten.mul.Tensor(mul_3, primals_3);  mul_3 = primals_3 = None
        mul_5: f32[8] = torch.ops.aten.mul.Tensor(mul_4, primals_2);  mul_4 = primals_2 = None
        return [mul_5, None, None, None]
```

## With re-order
```
Theoretical Activations Stored:  3.2e-08
# remat/fw/bw: 0/5/1
Count of Ops Rematerialized:  []
====== Forward graph 0 ======
class GraphModule(torch.nn.Module):
    def forward(self, primals_1: f32[8], primals_2: f32[8], primals_3: f32[8], primals_4: f32[8]):
        # File: graph.py:11, code: return x * a * b * c
        mul: f32[8] = torch.ops.aten.mul.Tensor(primals_1, primals_2);  primals_1 = None
        mul_1: f32[8] = torch.ops.aten.mul.Tensor(mul, primals_3);  mul = None
        mul_2: f32[8] = torch.ops.aten.mul.Tensor(mul_1, primals_4);  mul_1 = None
        
        # No stacktrace found for following nodes
        mul_tensor: f32[8] = torch.ops.aten.mul.Tensor(primals_3, primals_2);  primals_3 = primals_2 = None
        mul_tensor_1: f32[8] = torch.ops.aten.mul.Tensor(primals_4, mul_tensor);  primals_4 = mul_tensor = None
        return [mul_2, mul_tensor_1]
        
====== Backward graph 0 ======
class GraphModule(torch.nn.Module):
    def forward(self, mul_tensor_1: f32[8], tangents_1: f32[8]):
        # No stacktrace found for following nodes
        mul_tensor_2: f32[8] = torch.ops.aten.mul.Tensor(tangents_1, mul_tensor_1);  tangents_1 = mul_tensor_1 = None
        return [mul_tensor_2, None, None, None]
        
tensor([ 0.0809, -0.0462, -0.0509,  0.0249,  0.0091, -0.0806, -0.2580, -0.8776],
       grad_fn=<CompiledFunctionBackward>)
```