### PR TITLE
Run more tests through pytest

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -884,6 +884,30 @@ CUSTOM_HANDLERS = {
 }
 
 
+PYTEST_BLOCKLIST = [
+    "test_package",
+    "test_nccl",
+    "inductor/test_torchinductor",
+    "test_cuda",
+    "test_quantization",
+    "test_cuda_nvml_based_avail",
+    "test_cuda_primary_ctx",
+    "test_cuda_sanitizer",
+    "test_cuda_trace",
+    "test_fx",
+    "test_jiterator",
+    "test_mps",
+    "test_cuda_trace",
+    "profiler/test_profiler",
+    "test_jit",
+    "test_jit_legacy",
+    "dynamo/test_repros",  # skip_if_pytest
+    "dynamo/test_optimizers",  # skip_if_pytest
+    "dynamo/test_dynamic_shapes",  # needs change to check_if_enable for disabled test issues
+    "dynamo/test_unspec",  # imports repros
+] + list(CUSTOM_HANDLERS.keys())
+
+
 def parse_test_module(test):
     return test.split(".")[0]
 
@@ -1342,7 +1366,7 @@ def main():
         os.environ['PARALLEL_TESTING'] = '1'
         for test in selected_tests_parallel:
             options_clone = copy.deepcopy(options)
-            if test in USE_PYTEST_LIST:
+            if test not in PYTEST_BLOCKLIST:
                 options_clone.pytest = True
             pool.apply_async(run_test_module, args=(test, test_directory, options_clone), callback=success_callback)
         pool.close()
@@ -1360,7 +1384,7 @@ def main():
 
         for test in selected_tests_serial:
             options_clone = copy.deepcopy(options)
-            if test in USE_PYTEST_LIST:
+            if test not in PYTEST_BLOCKLIST:
                 options_clone.pytest = True
             err_message = run_test_module(test, test_directory, options_clone)
             if err_message is None:

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -748,11 +748,11 @@ def run_tests(argv=UNITTEST_ARGS):
             failed |= wait_for_process(p) != 0
         assert not failed, "Some test shards have failed"
     elif USE_PYTEST:
-        pytest_args = argv
+        pytest_args = argv + ["--use-main-module"]
         if TEST_SAVE_XML:
             test_report_path = get_report_path(pytest=True)
             print(f'Test results will be stored in {test_report_path}')
-            pytest_args = pytest_args + [f'--junit-xml-reruns={test_report_path}']
+            pytest_args.append(f'--junit-xml-reruns={test_report_path}')
 
         import pytest
         os.environ["NO_COLOR"] = "1"
@@ -804,7 +804,10 @@ def run_tests(argv=UNITTEST_ARGS):
         verbose = '--verbose' in argv or '-v' in argv
         if verbose:
             print(f'Test results will be stored in {test_report_path}')
-        unittest.main(argv=argv, testRunner=xmlrunner.XMLTestRunner(
+        unittest_args = argv.copy()
+        unittest_args.remove("-rfEX")
+        unittest_args.remove("--reruns=2")
+        unittest.main(argv=unittest_args, testRunner=xmlrunner.XMLTestRunner(
             output=test_report_path,
             verbosity=2 if verbose else 1,
             resultclass=XMLTestResultVerbose))

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -804,10 +804,7 @@ def run_tests(argv=UNITTEST_ARGS):
         verbose = '--verbose' in argv or '-v' in argv
         if verbose:
             print(f'Test results will be stored in {test_report_path}')
-        unittest_args = argv.copy()
-        unittest_args.remove("-rfEX")
-        unittest_args.remove("--reruns=2")
-        unittest.main(argv=unittest_args, testRunner=xmlrunner.XMLTestRunner(
+        unittest.main(argv=argv, testRunner=xmlrunner.XMLTestRunner(
             output=test_report_path,
             verbosity=2 if verbose else 1,
             resultclass=XMLTestResultVerbose))


### PR DESCRIPTION
Run more tests through pytest.

Use a block list for tests that shouldn't run through pytest.  As far as I can tell, the number of tests run, skipped, and xfailed for those not on the blocklist are the same.  


Regarding the main module:

Usually tests are run in CI, we call `python <test file>`, which causes the file to be imported under the module name `__main__`.  However, pytest searches for the module to be imported under the file name, so the file will be reimported.  This can cause issues for tests that run module level code and change global state, like test_nn, which modifies lists imported from another file, or tests in test/lazy, which initialize a backend that cannot coexist with a second copy of itself.  

My workaround for this is to run tests from the `__main__` module.  However, this results in pytest being unable to rewrite assertions (and possibly other things but I don't know what other things pytest does right now).  A better solution might be to call `pytest <test file>` directly and move all the code in run_tests(argv) to be module level code or put it in a hook in conftest.py.