### PR TITLE
Add support of dltensor for ORT

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -42,7 +42,7 @@ class TORCH_API Context {
     } else if (device_type == at::kMPS) {
       return at::detail::getMPSHooks().getDefaultMPSGenerator();
     } else {
-      AT_ERROR(DeviceTypeName(device_type), " device type not enabled.");
+      AT_ERROR(DeviceTypeName(device_type), " device type not enabled for defaultGenerator");
     }
   }
   Device getDeviceFromPtr(void* data, DeviceType device_type) {
@@ -52,8 +52,10 @@ class TORCH_API Context {
       return DeviceType::CPU;
     } else if (device_type == at::kCUDA) {
       return at::detail::getCUDAHooks().getDeviceFromPtr(data);
+    } else if (device_type == at::kORT) {
+      return {DeviceType::ORT, static_cast<DeviceIndex>(0)};
     } else {
-      AT_ERROR(DeviceTypeName(device_type), " device type not enabled.");
+      AT_ERROR(DeviceTypeName(device_type), " device type not enabled for getDeviceFromPtr");
     }
   }
   static bool isPinnedPtr(void* data) {

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -90,6 +90,9 @@ DLDevice getDLDevice(const Tensor& tensor, const int64_t& device_id) {
     case DeviceType::HIP:
       ctx.device_type = DLDeviceType::kDLROCM;
       break;
+    case DeviceType::ORT:
+      ctx.device_type = DLDeviceType::kDLExtDev;
+      break;
     default:
       TORCH_CHECK(false, "Cannot pack tensors on " + tensor.device().str());
   }
@@ -114,6 +117,8 @@ static Device getATenDevice(const DLDevice& ctx) {
 #else
       return at::Device(DeviceType::HIP, ctx.device_id);
 #endif
+    case DLDeviceType::kDLExtDev:
+      return at::Device(DeviceType::ORT, ctx.device_id);
     default:
       TORCH_CHECK(
           false, "Unsupported device_type: " + c10::to_string(ctx.device_type));

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1362,6 +1362,8 @@ class Tensor(torch._C._TensorBase):
             device_type = DLDeviceType.kDLGPU
         elif torch_device_type == "cpu":
             device_type = DLDeviceType.kDLCPU
+        elif torch_device_type == "ort":
+            device_type = DLDeviceType.kDLExtDev
         else:
             raise ValueError(
                 "Unknown device type {} for Dlpack".format(torch_device_type)


### PR DESCRIPTION
This PR extends the support of dltensor for `ORT` device. Currently in the PR, tensor conversion through `DLPack` borrows `DLExtDevice`, which is planned to use `DLOrt` once a [PR](https://github.com/dmlc/dlpack/pull/121) that supports DLOrt is merged.