### PR TITLE
[optim] _actually_ default to foreach

### DIFF
--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -504,7 +504,7 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
             fsdp_kwargs=fsdp_kwargs,
             deterministic=True,
         )
-        optim = torch.optim.Adam(fsdp_model.parameters(), lr=LR)
+        optim = torch.optim.Adam(fsdp_model.parameters(), foreach=False, lr=LR)
         fsdp_kwargs["use_orig_params"] = True
         fsdp_model_orig_params = TransformerWithSharedParams.init(
             self.process_group,
@@ -513,7 +513,9 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
             fsdp_kwargs=fsdp_kwargs,
             deterministic=True,
         )
-        optim_orig_params = torch.optim.Adam(fsdp_model_orig_params.parameters(), lr=LR)
+        optim_orig_params = torch.optim.Adam(
+            fsdp_model_orig_params.parameters(), foreach=False, lr=LR
+        )
         return fsdp_model, optim, fsdp_model_orig_params, optim_orig_params
 
     def _check_fsdp_parameter_parity(self, fsdp1: FSDP, fsdp2: FSDP) -> None:

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -46,9 +46,10 @@ from torch.testing._internal.common_utils import (
     skipIfRocm,
     skipIfTorchDynamo
 )
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
+from torch.testing._internal.common_cuda import TEST_MULTIGPU, TEST_CUDA
 from typing import Dict, Any, Tuple
 from torch.optim.optimizer import register_optimizer_step_pre_hook, register_optimizer_step_post_hook
+from unittest.mock import patch
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -252,21 +253,26 @@ class TestOptim(TestCase):
         )
 
         # Make sure that optimizers that support maximize can load older models
-        state_dict = optimizer.state_dict()
-        if "maximize" in state_dict["param_groups"][0]:
-            for group in state_dict["param_groups"]:
+        old_state_dict = deepcopy(optimizer.state_dict())
+        state_dict_no_maximize = deepcopy(optimizer.state_dict())
+        if "maximize" in state_dict_no_maximize["param_groups"][0]:
+            for group in state_dict_no_maximize["param_groups"]:
                 del group["maximize"]
-            optimizer.load_state_dict(state_dict)
+            optimizer.load_state_dict(state_dict_no_maximize)
             # Make sure we can still step
             optimizer.step()
+            # Undo these changes before proceeding!
+            optimizer.load_state_dict(old_state_dict)
         # Make sure that optimizers that support foreach can load older models
-        state_dict = optimizer.state_dict()
-        if "foreach" in state_dict["param_groups"][0]:
-            for group in state_dict["param_groups"]:
+        state_dict_no_foreach = deepcopy(optimizer.state_dict())
+        if "foreach" in state_dict_no_foreach["param_groups"][0]:
+            for group in state_dict_no_foreach["param_groups"]:
                 del group["foreach"]
-            optimizer.load_state_dict(state_dict)
+            optimizer.load_state_dict(state_dict_no_foreach)
             # Make sure we can still step
             optimizer.step()
+            # Undo these changes before proceeding!
+            optimizer.load_state_dict(old_state_dict)
 
         # Make sure that loading optimizers with step not wrapped in tensor can work
         state_dict = optimizer.state_dict()
@@ -4533,6 +4539,40 @@ class TestDifferentiableOptimizer(TestCase):
                 *state.values(),
             ),
         )
+
+
+    @unittest.skipIf(not TEST_CUDA, "test requires CUDA")
+    def test_defaults_changed_to_foreach(self):
+        from torch.optim import (adam, adamw, nadam, sgd, radam, rmsprop, rprop,
+                                 asgd, adamax, adadelta, adagrad)
+        multi_optims = ((optim.Adam, adam, "_multi_tensor_adam"),
+                        (optim.AdamW, adamw, "_multi_tensor_adamw"),
+                        (optim.NAdam, nadam, "_multi_tensor_nadam"),
+                        (optim.SGD, sgd, "_multi_tensor_sgd"),
+                        (optim.RAdam, radam, "_multi_tensor_radam"),
+                        (optim.RMSprop, rmsprop, "_multi_tensor_rmsprop"),
+                        (optim.Rprop, rprop, "_multi_tensor_rprop"),
+                        (optim.ASGD, asgd, "_multi_tensor_asgd"),
+                        (optim.Adamax, adamax, "_multi_tensor_adamax"),
+                        (optim.Adadelta, adadelta, "_multi_tensor_adadelta"),
+                        (optim.Adagrad, adagrad, "_multi_tensor_adagrad"),)
+
+        model = torch.nn.Linear(5, 5)
+        model.to(dtype=torch.float64, device="cuda")
+        input = torch.rand(2, 5, dtype=torch.float64, device="cuda")
+
+        for opt, mod, func in multi_optims:
+            defaults = {}
+            if opt == optim.SGD:
+                defaults["lr"] = 1e-2
+            optimizer = opt(model.parameters(), **defaults)
+            optimizer.zero_grad()
+            output = model(input)
+            loss = output.sum()
+            loss.backward()
+            with patch.object(mod, func) as mocked_foreach_impl:
+                optimizer.step()
+                self.assertTrue(mocked_foreach_impl.called)
 
 
 if __name__ == "__main__":

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -193,8 +193,7 @@ def adadelta(
 
     # We still respect when the user inputs False for foreach.
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, square_avgs, acc_deltas],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -210,8 +210,7 @@ def adagrad(
         )
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, state_sums, state_steps],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -259,9 +259,7 @@ def adam(params: List[Tensor],
     # and pass False to use_fused. This is not a mistake--we want to give the fused impl
     # bake-in time before making it the default, even if it is typically faster.
     if fused is None and foreach is None:
-        _, foreach = _default_to_fused_or_foreach(
-            [params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, state_steps],
-            differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
     if fused is None:
         fused = False
     if foreach is None:

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -206,8 +206,7 @@ def adamax(
         )
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_infs, state_steps],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -300,9 +300,7 @@ def adamw(
     # and pass False to use_fused. This is not a mistake--we want to give the fused impl
     # bake-in time before making it the default, even if it is typically faster.
     if fused is None and foreach is None:
-        _, foreach = _default_to_fused_or_foreach(
-            [params, grads, exp_avgs, exp_avg_sqs, max_exp_avg_sqs, state_steps],
-            differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
     if fused is None:
         fused = False
     if foreach is None:

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -185,8 +185,7 @@ def asgd(
     """
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, axs, mus, etas, state_steps],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -187,8 +187,7 @@ def nadam(params: List[Tensor],
         raise RuntimeError("API has changed, `mu_products` argument must contain a list of singleton tensors")
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, mu_products, state_steps],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError('torch.jit.script not supported with foreach optimizers')

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -15,6 +15,7 @@ from torch._utils import is_compiling
 __all__ = ['Optimizer', 'register_optimizer_step_pre_hook', 'register_optimizer_step_post_hook']
 _global_optimizer_pre_hooks: Dict[int, Callable] = OrderedDict()
 _global_optimizer_post_hooks: Dict[int, Callable] = OrderedDict()
+_foreach_supported_types = [torch.Tensor, torch.nn.parameter.Parameter]
 
 class _RequiredParameter:
     """Singleton class representing a required parameter for an Optimizer."""
@@ -69,10 +70,10 @@ def _default_to_fused_or_foreach(tensorlists: List[List[torch.Tensor]],
     for tensorlist in tensorlists:
         all_tensors.extend(tensorlist)
     fused = use_fused and all(
-        p is None or (type(p) == torch.Tensor and p.is_cuda and torch.is_floating_point(p)) for p in all_tensors
+        p is None or (type(p) in _foreach_supported_types and p.is_cuda and torch.is_floating_point(p)) for p in all_tensors
     )
     foreach = not fused and all(
-        p is None or (type(p) == torch.Tensor and p.is_cuda) for p in all_tensors
+        p is None or (type(p) in _foreach_supported_types and p.is_cuda) for p in all_tensors
     )
     return fused, foreach
 

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -57,23 +57,20 @@ def _dispatch_sqrt(x: float):  # float annotation is needed because of torchscri
 
 # For any optimizer with a faster implementation, we attempt to default to the
 # fastest + stablest whenever possible. For foreach, the requirements are to have
-# native tensors all on CUDA. For fused, there's currently the additional requirement
+# native params all on CUDA. For fused, there's currently the additional requirement
 # that the tensors' dtypes must be floating point. Neither alternative supports
 # torch.jit.script nor differentiable, so we fall back to the single tensor
 # implementation in those cases.
-def _default_to_fused_or_foreach(tensorlists: List[List[torch.Tensor]],
+def _default_to_fused_or_foreach(params: List[torch.Tensor],
                                  differentiable: bool,
                                  use_fused: bool = False) -> Tuple[bool, bool]:
     if torch.jit.is_scripting() or differentiable:
         return False, False
-    all_tensors = []
-    for tensorlist in tensorlists:
-        all_tensors.extend(tensorlist)
     fused = use_fused and all(
-        p is None or (type(p) in _foreach_supported_types and p.is_cuda and torch.is_floating_point(p)) for p in all_tensors
+        p is None or (type(p) in _foreach_supported_types and p.is_cuda and torch.is_floating_point(p)) for p in params
     )
     foreach = not fused and all(
-        p is None or (type(p) in _foreach_supported_types and p.is_cuda) for p in all_tensors
+        p is None or (type(p) in _foreach_supported_types and p.is_cuda) for p in params
     )
     return fused, foreach
 

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -209,8 +209,7 @@ def radam(
         )
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, exp_avgs, exp_avg_sqs, state_steps],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -220,8 +220,7 @@ def rmsprop(
     """
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, square_avgs, grad_avgs, momentum_buffer_list],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -192,8 +192,7 @@ def rprop(
     """
 
     if foreach is None:
-        _, foreach = _default_to_fused_or_foreach([params, grads, prevs, step_sizes],
-                                                  differentiable, use_fused=False)
+        _, foreach = _default_to_fused_or_foreach(params, differentiable, use_fused=False)
 
     if foreach and torch.jit.is_scripting():
         raise RuntimeError("torch.jit.script not supported with foreach optimizers")

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -207,8 +207,7 @@ def sgd(params: List[Tensor],
         # why must we be explicit about an if statement for torch.jit.is_scripting here?
         # because JIT can't handle Optionals nor fancy conditionals when scripting
         if not torch.jit.is_scripting():
-            _, foreach = _default_to_fused_or_foreach([params, d_p_list, momentum_buffer_list],
-                                                      differentiable=False, use_fused=False)
+            _, foreach = _default_to_fused_or_foreach(params, differentiable=False, use_fused=False)
         else:
             foreach = False
 


### PR DESCRIPTION
Big OOP correction. Also added a test this time to verify the defaulting was as expected. 

We've claimed + intended to default to foreach as much as we can, but today we realize we missed two critical (the biggest, essentially all real use cases) groups:
1. models. we forgot to check for nn.Parameters as native tensors, so foreach was only defaulting on test cases/people who didn't use models.
2. we were previously checking that ALL relevant tensors were on CUDA to flip the switch. almost all of the state_steps, however, are on CPU the whole time, so a great majority of these did not flip correctly.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95820
* #95811