### PR TITLE
inductor: pre-convert a TensorBox's layout to FixedLayout at FX side if one user of it is a CPU external customer kernel

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -478,19 +478,24 @@ class GraphLowering(torch.fx.Interpreter):
                         #
                         # When we do a better job selecting layout, we should
                         # revisit this.
-                        if user.target in (
+                        need_fixed_layout = [
                             torch.ops.aten.convolution.default,
                             torch.ops.aten.convolution_backward.default,
                             torch.ops.aten.mm.default,
                             torch.ops.aten._int_mm.default,
-                            torch.ops.mkldnn._convolution_pointwise.default,
-                            torch.ops.mkldnn._convolution_pointwise.binary,
-                            torch.ops.mkldnn._convolution_pointwise_.binary,
-                            torch.ops.mkldnn._convolution_transpose_pointwise.default,
-                            torch.ops.mkldnn._linear_pointwise.default,
-                            torch.ops.mkldnn._linear_pointwise.binary,
-                            torch.ops.mkl._mkl_linear.default,
-                        ):
+                        ]
+                        if torch._C.has_mkldnn:
+                            need_fixed_layout += [
+                                torch.ops.mkldnn._convolution_pointwise.default,
+                                torch.ops.mkldnn._convolution_pointwise.binary,
+                                torch.ops.mkldnn._convolution_pointwise_.binary,
+                                torch.ops.mkldnn._convolution_transpose_pointwise.default,
+                                torch.ops.mkldnn._linear_pointwise.default,
+                                torch.ops.mkldnn._linear_pointwise.binary,
+                            ]
+                            if torch._C.hastorch._C.has_mkl:
+                                need_fixed_layout += [torch.ops.mkl._mkl_linear.default]
+                        if user.target in need_fixed_layout:
                             result = ir.ExternKernel.require_stride_order(
                                 result, ir.get_stride_order(n.meta["val"].stride())
                             )

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -483,6 +483,13 @@ class GraphLowering(torch.fx.Interpreter):
                             torch.ops.aten.convolution_backward.default,
                             torch.ops.aten.mm.default,
                             torch.ops.aten._int_mm.default,
+                            torch.ops.mkldnn._convolution_pointwise.default,
+                            torch.ops.mkldnn._convolution_pointwise.binary,
+                            torch.ops.mkldnn._convolution_pointwise_.binary,
+                            torch.ops.mkldnn._convolution_transpose_pointwise.default,
+                            torch.ops.mkldnn._linear_pointwise.default,
+                            torch.ops.mkldnn._linear_pointwise.binary,
+                            torch.ops.mkl._mkl_linear.default,
                         ):
                             result = ir.ExternKernel.require_stride_order(
                                 result, ir.get_stride_order(n.meta["val"].stride())

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -493,7 +493,7 @@ class GraphLowering(torch.fx.Interpreter):
                                 torch.ops.mkldnn._linear_pointwise.default,
                                 torch.ops.mkldnn._linear_pointwise.binary,
                             ]
-                            if torch._C.hastorch._C.has_mkl:
+                            if torch._C.has_mkl:
                                 need_fixed_layout += [torch.ops.mkl._mkl_linear.default]
                         if user.target in need_fixed_layout:
                             result = ir.ExternKernel.require_stride_order(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -847,6 +847,12 @@ def glu(x, dim=-1):
 
 def register_onednn_fusion_ops():
     if torch._C.has_mkldnn:
+        cpu_needs_realized_inputs = [
+            torch.ops.mkldnn._convolution_pointwise,
+            torch.ops.mkldnn._convolution_pointwise_,
+            torch.ops.mkldnn._convolution_transpose_pointwise,
+            torch.ops.mkldnn._linear_pointwise,
+        ]
 
         @register_lowering(torch.ops.mkldnn._convolution_pointwise)
         def convolution_unary(
@@ -987,6 +993,7 @@ def register_onednn_fusion_ops():
             )
 
         if torch._C.has_mkl:
+            cpu_needs_realized_inputs.append(torch.ops.mkl._mkl_linear)
 
             @register_lowering(torch.ops.mkl._mkl_linear)
             def mkl_packed_linear(
@@ -1003,6 +1010,7 @@ def register_onednn_fusion_ops():
                     result = add(result, b)
                 return result
 
+        add_needs_realized_inputs(cpu_needs_realized_inputs)
     else:
         pass
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -82,11 +82,6 @@ add_needs_realized_inputs(
         aten.upsample_nearest2d,
         aten.upsample_bicubic2d,
         aten._int_mm,
-        torch.ops.mkldnn._convolution_pointwise,
-        torch.ops.mkldnn._convolution_pointwise_,
-        torch.ops.mkldnn._convolution_transpose_pointwise,
-        torch.ops.mkldnn._linear_pointwise,
-        torch.ops.mkl._mkl_linear,
     ]
 )
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -82,6 +82,11 @@ add_needs_realized_inputs(
         aten.upsample_nearest2d,
         aten.upsample_bicubic2d,
         aten._int_mm,
+        torch.ops.mkldnn._convolution_pointwise,
+        torch.ops.mkldnn._convolution_pointwise_,
+        torch.ops.mkldnn._convolution_transpose_pointwise,
+        torch.ops.mkldnn._linear_pointwise,
+        torch.ops.mkl._mkl_linear,
     ]
 )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95873


Given the following case:

```
import torch
import torch._dynamo

class Model(torch.nn.Module):
    def __init__(self):
        super(Model, self).__init__()
        self.conv1 =  torch.nn.Conv2d(64, 64, kernel_size=(1, 1), stride=(1, 1))
        self.conv2 =  torch.nn.Conv2d(64, 64, kernel_size=(1, 1), stride=(1, 1))
        self.silu = torch.nn.SiLU(inplace=False)

    def forward(self, x,):
        x = self.silu(x)
        y1 = self.conv1(x)
        y2 = self.conv2(x)
        return y1, y2

model = Model().eval()
model = model.to(memory_format=torch.channels_last).eval()
opt_model = torch._dynamo.optimize('inductor')(model)

x = torch.randn(128, 64, 112, 112).to(memory_format=torch.channels_last)
with torch.no_grad():
    for i in range(3):
        out = opt_model(x)
```

the silu is used by two external kernels, and there always have redundant memory copy:

```
kernel_cpp_0 = async_compile.cpp('''
#include "/tmp/torchinductor_xiaobing/dl/cdljpywww2h2ag4o35mwbvm45hhasxnxkhqgbupxnk3y7olula65.h"
extern "C" void kernel(const float* __restrict__ in_ptr0,
                       float* __restrict__ out_ptr0,
                       float* __restrict__ out_ptr1)
{
    #pragma omp parallel num_threads(40)
    {
        {
            #pragma omp for
            for(long i0=0; i0<6422528; i0+=1)
            {
                auto tmp0 = at::vec::Vectorized<float>::loadu(in_ptr0 + 16*i0);
                auto tmp1 = decltype(tmp0)(1)/(decltype(tmp0)(1) + tmp0.neg().exp());
                auto tmp2 = tmp0 * tmp1;
                tmp2.store(out_ptr0 + 16*i0);
                tmp2.store(out_ptr1 + 16*i0);
            }
            #pragma omp for simd simdlen(8)
            for(long i0=102760448; i0<102760448; i0+=1)
            {
                auto tmp0 = in_ptr0[i0];
                auto tmp1 = decltype(tmp0)(1) / (decltype(tmp0)(1) + std::exp(-tmp0));
                auto tmp2 = tmp0 * tmp1;
                out_ptr0[i0] = tmp2;
                out_ptr1[i0] = tmp2;
            }
        }
    }
}
''')
```
This PR will pre-convert the `silu`'s layout to FixedLayout at FX side(will be realized to avoid multi-realize at external kernel) if one user of it is a CPU external customer kernel, after this PR, the output code is: 

```
kernel_cpp_0 = async_compile.cpp('''
#include "/tmp/torchinductor_xiaobing/dl/cdljpywww2h2ag4o35mwbvm45hhasxnxkhqgbupxnk3y7olula65.h"
extern "C" void kernel(const float* __restrict__ in_ptr0,
                       float* __restrict__ out_ptr0)
{
    #pragma omp parallel num_threads(40)
    {
        {
            #pragma omp for
            for(long i0=0; i0<6422528; i0+=1)
            {
                auto tmp0 = at::vec::Vectorized<float>::loadu(in_ptr0 + 16*i0);
                auto tmp1 = decltype(tmp0)(1)/(decltype(tmp0)(1) + tmp0.neg().exp());
                auto tmp2 = tmp0 * tmp1;
                tmp2.store(out_ptr0 + 16*i0);
            }
            #pragma omp for simd simdlen(8)
            for(long i0=102760448; i0<102760448; i0+=1)
            {
                auto tmp0 = in_ptr0[i0];
                auto tmp1 = decltype(tmp0)(1) / (decltype(tmp0)(1) + std::exp(-tmp0));
                auto tmp2 = tmp0 * tmp1;
                out_ptr0[i0] = tmp2;
            }
        }
    }
}
''')
```

Currently, this PR only considers the CPU external customer kernel, but for other external kernels, there may have the same issue.

For Timm **eca_halonext26ts** , this PR will give about **8%** performance improvement(BS=128, 20 cores on SKX).

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire