### PR TITLE
Print the actual values with scalar mismatch.

### DIFF
--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -1385,6 +1385,7 @@ def assert_close(
         ...
         AssertionError: Scalars are not equal!
         <BLANKLINE>
+        Expected 1e-10 but got 1e-09.
         Absolute difference: 9.000000000000001e-10
         Relative difference: 9.0
 
@@ -1456,6 +1457,7 @@ def assert_close(
         ...
         AssertionError: Scalars are not close!
         <BLANKLINE>
+        Expected nan but got nan.
         Absolute difference: nan (up to 1e-05 allowed)
         Relative difference: nan (up to 1.3e-06 allowed)
         >>> torch.testing.assert_close(actual, expected, equal_nan=True)

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -228,6 +228,7 @@ def make_scalar_mismatch_msg(
     return _make_mismatch_msg(
         default_identifier="Scalars",
         identifier=identifier,
+        extra=f"Expected {expected} but got {actual}.",
         abs_diff=abs_diff,
         atol=atol,
         rel_diff=rel_diff,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95879

When you do assertEqual between two ints, previously it would only print

```
Absolute difference: 1
Relative difference: 0.3333333333333333
```

Now it prints:

```
Expected 3 but got 2.
Absolute difference: 1
Relative difference: 0.3333333333333333
```

Signed-off-by: Edward Z. Yang <ezyang@meta.com>