### PR TITLE
Make export use symbolic tracing_mode by default

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -563,7 +563,7 @@ def explain(f, *args, **kwargs):
 
 
 def export(
-    f, *args, aten_graph=False, decomposition_table=None, tracing_mode="real", **kwargs
+    f, *args, aten_graph=False, decomposition_table=None, tracing_mode="symbolic", **kwargs
 ):
     check_if_dynamo_supported()
     torch._C._log_api_usage_once("torch._dynamo.export")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95880

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @yanboliang @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire