### PR TITLE
Update xnnpack to the latest commit

### DIFF
--- a/third_party/xnnpack.buck.bzl
+++ b/third_party/xnnpack.buck.bzl
@@ -1968,7 +1968,7 @@ def define_xnnpack(third_party, labels = [], XNNPACK_WINDOWS_AVX512F_ENABLED = F
             "XNNPACK/src/x8-lut-config.c",
             "XNNPACK/src/hardware-config.c",
             "XNNPACK/src/transpose-config.c",
-            "XNNPACK/src/amalgam/scalar.c",
+            "XNNPACK/src/amalgam/gen/scalar.c",
             "XNNPACK/src/operators/post-operation.c",
         ] + LOGGING_SRCS,
         visibility = ["PUBLIC"],

--- a/third_party/xnnpack_src_defs.bzl
+++ b/third_party/xnnpack_src_defs.bzl
@@ -7616,7 +7616,7 @@ PROD_SCALAR_AARCH32_MICROKERNEL_SRCS = [
 ]
 
 PROD_SCALAR_MICROKERNEL_SRCS = [
-    "XNNPACK/src/amalgam/scalar.c",
+    "XNNPACK/src/amalgam/gen/scalar.c",
 ]
 
 PROD_SCALAR_PORTABLE_MICROKERNEL_SRCS = [

--- a/third_party/xnnpack_wrapper_defs.bzl
+++ b/third_party/xnnpack_wrapper_defs.bzl
@@ -5898,7 +5898,7 @@ PROD_SCALAR_AARCH32_MICROKERNEL_SRCS = [
 ]
 
 PROD_SCALAR_MICROKERNEL_SRCS = [
-    "xnnpack_wrappers/amalgam/scalar.c",
+    "xnnpack_wrappers/amalgam/gen/scalar.c",
 ]
 
 PROD_SCALAR_PORTABLE_MICROKERNEL_SRCS = [


### PR DESCRIPTION
After trying to update cpuinfo submodule to the latest, I saw that an update on xnnpack is also necessary.

Fixes the 2 failing checks on [#95379](https://github.com/pytorch/pytorch/pull/95379)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @mcarilli @ptrblck @leslie-fang-intel