### PR TITLE
Disable python dispatcher in fallthrough for PyOperators

### DIFF
--- a/functorch/experimental/_cond.py
+++ b/functorch/experimental/_cond.py
@@ -8,7 +8,7 @@ import torch.utils._pytree as pytree
 from torch._C import DispatchKey, DispatchKeySet, ExcludeDispatchKeyGuard
 from torch._functorch.eager_transforms import _unwrap_all_tensors_from_functional, _wrap_all_tensors_to_functional, functionalize
 from torch._ops import PyOperator
-from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
     ProxyTorchDispatchMode,

--- a/functorch/experimental/_map.py
+++ b/functorch/experimental/_map.py
@@ -93,11 +93,6 @@ def map_fake_tensor_mode(f, xs, *args):
     outs = [f(x, *args) for x in xs]
     return outs[0].new_empty([xs.shape[0], *outs[0].shape])
 
-# We cannot directly call fallthrough here due to issue #89037.
-@map.py_impl(DispatchKey.PythonDispatcher)
-def map_python_dispatcher(*args):
-    _ = ExcludeDispatchKeyGuard(DispatchKeySet(DispatchKey.PythonDispatcher))
-    return map(*args)
 
 @map.py_impl(torch._C._functorch.TransformType.Functionalize)
 def map_functionalize(interpreter, f, xs, *args):
@@ -130,6 +125,7 @@ def map_functionalize(interpreter, f, xs, *args):
         return _wrap_all_tensors_to_functional(map_return, level=interpreter.level())
 
 # TODO(voz) Make this automatic for keys, this is very ugly atm
+map.fallthrough(DispatchKey.PythonDispatcher)
 map.fallthrough(DispatchKey.PythonTLSSnapshot)
 map.fallthrough(DispatchKey.ADInplaceOrView)
 map.fallthrough(DispatchKey.BackendSelect)

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -132,6 +132,9 @@ class TestControlFlowTraced(TestCase):
                 all_ops_in_true_branch.append(node.target)
 
         self.assertFalse(any([op._schema.is_mutable for op in all_ops_in_true_branch]))
+        
+        graph_module = make_fx(torch.func.functionalize(f), tracing_mode="symbolic")(*example_inputs)
+        self.assertEqual(graph_module(*example_inputs), f(*example_inputs))
 
         graph_module = make_fx(torch.func.functionalize(f), tracing_mode="symbolic")(*example_inputs)
         self.assertEqual(graph_module(*example_inputs), f(*example_inputs))
@@ -177,6 +180,9 @@ class TestControlFlowTraced(TestCase):
 
         graph_module = make_fx(torch.func.functionalize(f))(*example_inputs)
         self.assertEqual(graph_module(*example_inputs), f(*example_inputs))
+        
+        graph_module1 = make_fx(torch.func.functionalize(f), tracing_mode="symbolic")(*example_inputs)
+        self.assertEqual(graph_module1(*example_inputs), f(*example_inputs))
 
         gm_true_true_branch = graph_module.true_graph_0.true_graph_0
 

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -132,7 +132,7 @@ class TestControlFlowTraced(TestCase):
                 all_ops_in_true_branch.append(node.target)
 
         self.assertFalse(any([op._schema.is_mutable for op in all_ops_in_true_branch]))
-        
+
         graph_module = make_fx(torch.func.functionalize(f), tracing_mode="symbolic")(*example_inputs)
         self.assertEqual(graph_module(*example_inputs), f(*example_inputs))
 
@@ -180,7 +180,7 @@ class TestControlFlowTraced(TestCase):
 
         graph_module = make_fx(torch.func.functionalize(f))(*example_inputs)
         self.assertEqual(graph_module(*example_inputs), f(*example_inputs))
-        
+
         graph_module1 = make_fx(torch.func.functionalize(f), tracing_mode="symbolic")(*example_inputs)
         self.assertEqual(graph_module1(*example_inputs), f(*example_inputs))
 

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -150,7 +150,7 @@ class PyOperator(PyOperatorABC):
 
             dispatch_key = dispatch_key_or_mode_or_transform
             assert (
-                dispatch_key != DispatchKey.Python
+                dispatch_key != torch._C.DispatchKey.Python
             ), "Please register a mode for the torch._C.DispatchKey.Python key instead."
             assert isinstance(dispatch_key, torch._C.DispatchKey)
             assert dispatch_key not in self.table
@@ -162,10 +162,10 @@ class PyOperator(PyOperatorABC):
     def dispatch(self, dispatch_key, *args, **kwargs):
         from torch.utils._python_dispatch import _get_current_dispatch_mode
 
-        if dispatch_key == DispatchKey.FuncTorchDynamicLayerFrontMode:
+        if dispatch_key == torch._C.DispatchKey.FuncTorchDynamicLayerFrontMode:
             return dispatch_functorch(self, args, kwargs)
 
-        if dispatch_key == DispatchKey.Python:
+        if dispatch_key == torch._C.DispatchKey.Python:
             # TODO(voz): We should walk all the nodes here / turn it into a list, topmode is ok for now.
             curr_mode = _get_current_dispatch_mode()
             assert (
@@ -205,8 +205,9 @@ class PyOperator(PyOperatorABC):
                 - self.fallthrough_keys
                 - DispatchKeySet(dispatch_key)
             )
-            highest_key = all_keys_after_current_masked.highestPriorityTypeId()
-            return self.dispatch(highest_key, *args, **kwargs)
+            return self.dispatch(
+                all_keys_after_current_masked.highestPriorityTypeId(), *args, **kwargs
+            )
 
         return inner
 
@@ -225,9 +226,9 @@ class PyOperator(PyOperatorABC):
             all_keys_after_current_masked = all_keys_after_current & _compute_keyset(
                 args, kwargs
             )
-            highest_key = all_keys_after_current_masked.highestPriorityTypeId()
-
-            return self.dispatch(highest_key, *args, **kwargs)
+            return self.dispatch(
+                all_keys_after_current_masked.highestPriorityTypeId(), *args, **kwargs
+            )
 
         return inner
 

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -9,8 +9,8 @@ from typing import Any, Dict
 import torch._C
 
 from torch import _utils_internal
+from torch._dispatch.python import enable_python_dispatcher, no_python_dispatcher
 from torch._functorch.pyfunctorch import dispatch_functorch
-from torch._dispatch.python import no_python_dispatcher, enable_python_dispatcher
 
 # Query `hasattr` only once.
 
@@ -194,12 +194,14 @@ class PyOperator(PyOperatorABC):
     def _fallthrough_fn(self, operator, dispatch_key):
         def inner(*args, **kwargs):
             with no_python_dispatcher():
-                all_keys_after_current = torch._C._dispatch_keyset_full_after(dispatch_key)
-                all_keys_after_current_masked = all_keys_after_current & _compute_keyset(
-                    args, kwargs
+                all_keys_after_current = torch._C._dispatch_keyset_full_after(
+                    dispatch_key
+                )
+                all_keys_after_current_masked = (
+                    all_keys_after_current & _compute_keyset(args, kwargs)
                 )
                 highest_key = all_keys_after_current_masked.highestPriorityTypeId()
-                
+
             return self.dispatch(highest_key, *args, **kwargs)
 
         return inner


### PR DESCRIPTION
Possible fix for https://github.com/pytorch/pytorch/issues/89037

Context: The existing fallthrough implementation for PyOperators will cause the PythonDispatcher to infinitely redispatch to the PythonDispatcher due to this [line](https://github.com/pytorch/pytorch/blob/61fa43a1f2bd36b7f79333d83d989edb2a0353aa/c10/core/DispatchKeySet.h#L176) which permanently adds the PythonDispatcher to the dispatch key set which we get on this [line](https://github.com/pytorch/pytorch/blob/61fa43a1f2bd36b7f79333d83d989edb2a0353aa/torch/_ops.py#L195). We temporarily fixed this by excluding the PythonDispatcher key from the global keyset ([here](https://github.com/pytorch/pytorch/blob/61fa43a1f2bd36b7f79333d83d989edb2a0353aa/functorch/experimental/_cond.py#L156)), but this runs into an issue during the implementation for the functionalization key where we want to call [functionalize](https://github.com/pytorch/pytorch/blob/61fa43a1f2bd36b7f79333d83d989edb2a0353aa/functorch/experimental/_cond.py#L230-L231) for the true/false subgraphs, and [make_fx](https://github.com/pytorch/pytorch/blob/61fa43a1f2bd36b7f79333d83d989edb2a0353aa/functorch/experimental/_cond.py#L195) to check for aliasing/mutations, which requires having the PythonDispatcher key.

Our attempt at fixing this is to modify the fallthrough function to ignore the PythonDispatcher key when generating keys to redispatch to. This should prevent the infinite recursion, but won't modify the global state of having the PythonDispatcher key.