### PR TITLE
Multiple fixes for functional collectives.

### DIFF
--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -344,7 +344,7 @@ class TestCollectivesInductor(DynamoDistributedSingleProcTestCase):
 
         input = torch.ones(4, 4, device="cuda", requires_grad=True)
         # TODO implement backwards
-        with self.assertRaisesRegex(RuntimeError, "derivative for aten::all_reduce is not implemented"):
+        with self.assertRaisesRegex(RuntimeError, "element 0 of tensors does not require grad and does not have a grad_fn"):
             compiled = torch.compile(func, backend="aot_eager")  # inductor bug with single-op allreduce graph
             out = compiled(input, **self.get_world_trs())
             out.sum().backward()

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3033,3 +3033,9 @@
 
 - name: all_reduce(Tensor self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor
   self: non_differentiable
+
+- name: all_gather_into_tensor(Tensor shard, str tag, int[] ranks, int group_size) -> Tensor
+  shard: non_differentiable
+
+- name: wait_tensor(Tensor self) -> Tensor
+  self: non_differentiable

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3030,3 +3030,6 @@
 
 - name: _foreach_maximum.ScalarList(Tensor[] self, Scalar[] scalars) -> Tensor[]
   self: at::where(self[i] == scalars[i], grads[i] / 2, grads[i]).masked_fill_(self[i] < scalars[i], 0)
+
+- name: all_reduce(Tensor self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor
+  self: non_differentiable

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -550,6 +550,8 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     # _nested_tensor_size() should never actually be called with requires_grad=True tensor
     "_nested_tensor_size",
     "_nested_tensor_strides",
+    # Functional collectives keep an internal ref through the Work object
+    "all_reduce",
 }
 
 DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -552,6 +552,8 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     "_nested_tensor_strides",
     # Functional collectives keep an internal ref through the Work object
     "all_reduce",
+    "all_gather_into_tensor",
+    "wait_tensor",
 }
 
 DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -120,7 +120,8 @@ class DTensorTestBase(MultiProcessTestCase):
 
     def destroy_pg(self) -> None:
         # Wait for all ranks to reach here before starting shutdown.
-        dist.barrier()
+        # FIXME dist.barrier deadlocks with multiple threads and NCCL: https://github.com/pytorch/pytorch/issues/95895
+        dist.all_reduce(torch.zeros((1,), device="cuda" if torch.cuda.is_available() else "cpu"))
         dist.destroy_process_group()
 
     def setUp(self) -> None:


### PR DESCRIPTION
_functional_collectives.py: Ensure we always wait all collectives.
derivatives.yaml: mark all_reduce as non differentiable
gen_variable_type.py: Add all_reduce to DONT_ENFORCE_TENSOR_IMPL_USE_COUNT
common_dtensor.py: replace dist.barrier with all_reduce

