### PR TITLE
[test / POC, needs discussion] get python gc to find ref cycle

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -1030,10 +1030,13 @@ def forward(self, primals_1, primals_2):
             torch.ones(8, 8, device='cuda', requires_grad=True),
             torch.ones(1, 4, 1, device='cuda', requires_grad=True),
         ]
+        import gc
+        gc.collect()
         mem_before = torch.cuda.memory_allocated()
         f_compiled(*inps)
+        gc.collect()
         mem_after = torch.cuda.memory_allocated()
-        self.assertTrue(mem_after == mem_before)
+        self.assertEqual(mem_after, mem_before)
 
     @patch("functorch.compile.config.use_fake_tensor", True)
     def test_output_aliases_multiple_inputs_get_correct_one(self):

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -2186,7 +2186,7 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig):
                     [isinstance(x, torch.Tensor) for x in tensors_saved_for_backwards]
                 )
                 # See Note [Detaching saved tensors in AOTAutograd]
-                ctx.save_for_backward(*map(lambda x: x.detach() if x._is_view() else x, tensors_saved_for_backwards))
+                ctx.save_for_backward(*tensors_saved_for_backwards)
                 symint_outs = fw_outs[-num_symints_saved_for_bw:]
                 assert all(
                     [
@@ -2198,7 +2198,7 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig):
             else:
                 tensors_saved_for_backwards = fw_outs[num_forward_returns:]
                 # See Note [Detaching saved tensors in AOTAutograd]
-                ctx.save_for_backward(*map(lambda x: x.detach() if x._is_view() else x, tensors_saved_for_backwards))
+                ctx.save_for_backward(*tensors_saved_for_backwards)
                 ctx.symints = []
 
             raw_returns = fw_outs[0:num_forward_returns]

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -274,7 +274,14 @@ static int THPFunction_clear(THPFunction* self) {
 
   self->output_info.clear();
   self->input_info.clear();
-  self->saved_variables.clear();
+  {
+    // If this is part of a gc cycle, clearing this field might
+    // end up calling release_variables() on this. So we must make
+    // sure that self->saved_variables is in a good state when we
+    // start de-allocating the SavedVariables
+    auto tmp  = std::move(self->saved_variables);
+    self->saved_variables.clear();
+  }
   self->is_variable_input.clear();
 
   return 0;

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1984,46 +1984,69 @@ static int THPVariable_subclass_traverse(
 
   // Finally traverse THPVariable special stuff
   Py_VISIT(var->backward_hooks);
+  // Ordinarly, we would only traverse the "special stuff" if our pyobject owned
+  // the C++ tensor. In some cases though, we need to perform this traversal
+  // even if we don't own the C++ tensor.
   if (!var->cdata.unsafeIsBorrowed()) {
-    const auto& tensor = THPVariable_Unpack(var);
-    if (tensor.defined()) {
-      // WARNING: The grad_fn traversal logic is very subtle, if you change
-      // this, be very careful not to re-introduce this bug:
-      // https://gist.github.com/zou3519/7ac92b84dd7d206dcc6eae55fee8372c
+    THPVariable_cpp_tensor_visit(*(var->cdata), visit, arg);
+  }
 
-      // We ensure that we follow NOTE [ PyObject Traversal ] he by checking
-      // that this python object is the sole owner of the underlying Tensor and
-      // that this Tensor is the sole owner of its grad_fn. In this case, the
-      // only way to get a new reference to the grad_fn is by using this python
-      // object, which requires the GIL to be accessed. Note that this is only
-      // valid as long as user don't share non-owning references across
-      // different threads (which is crazy and should never be done).
-      auto autograd_meta = torch::autograd::impl::get_autograd_meta(tensor);
-      if (tensor.use_count() == 1) {
-        if (autograd_meta) {
-          // Do NOT call grad_fn() here as that might trigger a recompute
-          const auto& grad_fn = autograd_meta->grad_fn_;
-          if (grad_fn && grad_fn.use_count() == 1) {
-            // All Node can have a pyobj (stored in "pyobj_")
-            Py_VISIT(grad_fn->pyobj());
-            // PyNode are special as they also have an "obj" field
-            if (auto py_node_fn = dynamic_cast<PyNode*>(grad_fn.get())) {
-              Py_VISIT(py_node_fn->obj);
-            }
-          }
-        }
-      }
-      if (autograd_meta) {
-        for (const auto& hook : torch::autograd::impl::hooks(tensor)) {
-          if (auto pyhook =
-                  dynamic_cast<PyFunctionTensorPreHook*>(hook.get())) {
-            Py_VISIT(pyhook->dict);
-          }
-        }
+  return 0;
+}
+
+int THPVariable_cpp_tensor_visit(
+    const at::Tensor& tensor,
+    visitproc visit,
+    void* arg) {
+  // pre-conditions
+  TORCH_INTERNAL_ASSERT(tensor.defined());
+  TORCH_INTERNAL_ASSERT(tensor.use_count() == 1);
+  // WARNING: The grad_fn traversal logic is very subtle, if you change
+  // this, be very careful not to re-introduce this bug:
+  // https://gist.github.com/zou3519/7ac92b84dd7d206dcc6eae55fee8372c
+
+  // We ensure that we follow NOTE [ PyObject Traversal ] he by checking
+  // that this python object is the sole owner of the underlying Tensor and
+  // that this Tensor is the sole owner of its grad_fn. In this case, the
+  // only way to get a new reference to the grad_fn is by using this python
+  // object, which requires the GIL to be accessed. Note that this is only
+  // valid as long as user don't share non-owning references across
+  // different threads (which is crazy and should never be done).
+  auto autograd_meta = torch::autograd::impl::get_autograd_meta(tensor);
+  auto view_autograd_meta =
+      torch::autograd::impl::get_view_autograd_meta(tensor);
+  if (autograd_meta) {
+    // Do NOT call grad_fn() here as that might trigger a recompute
+    const auto& grad_fn = autograd_meta->grad_fn_;
+
+    if (grad_fn && grad_fn.use_count() == 1) {
+      // All Node can have a pyobj (stored in "pyobj_")
+      Py_VISIT(grad_fn->pyobj());
+      // PyNode are special as they also have an "obj" field
+      if (auto py_node_fn = dynamic_cast<PyNode*>(grad_fn.get())) {
+        Py_VISIT(py_node_fn->obj);
       }
     }
   }
-
+  if (view_autograd_meta && view_autograd_meta->has_bw_view()) {
+    const auto& bw_info = view_autograd_meta->get_backward_view();
+    if (bw_info.base_.use_count() == 1) {
+      THPVariable_cpp_tensor_visit(bw_info.base_, visit, arg);
+    }
+  }
+  if (autograd_meta) {
+    for (const auto& hook : torch::autograd::impl::hooks(tensor)) {
+      if (auto pyhook = dynamic_cast<PyFunctionTensorPreHook*>(hook.get())) {
+        Py_VISIT(pyhook->dict);
+      }
+    }
+  }
+  // Only if we own the python tensor, should we Py_VISIT it.
+  if (tensor.unsafeGetTensorImpl()->pyobj_slot()->owns_pyobj()) {
+    Py_VISIT(tensor.unsafeGetTensorImpl()
+                 ->pyobj_slot()
+                 ->_unchecked_untagged_pyobj());
+  }
   return 0;
 }
 

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -76,3 +76,8 @@ void pushPyOutToStack(
     torch::jit::Stack* stack,
     py::object out,
     const char* msg);
+
+int THPVariable_cpp_tensor_visit(
+    const at::Tensor& self,
+    visitproc visit,
+    void* arg);

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -44,6 +44,13 @@ class TORCH_API SavedVariable {
   /// circular reference.
   Variable unpack(std::shared_ptr<Node> saved_for = nullptr) const;
 
+  const at::Tensor& _unsafe_data() const {
+    return data_;
+  }
+  bool _unsafe_saved_original() const {
+    return saved_original_;
+  }
+
   void register_hooks(std::unique_ptr<SavedVariableHooks>&& hooks);
 
   void reset_data();


### PR DESCRIPTION
This PR attempts to update the way to perform `tp_traverse()` on `THPTensor` and `THPFunction` to fix the existing reference cycle mentioned at https://github.com/pytorch/pytorch/issues/94990#issuecomment-1435181804. I put the example repro and the reference cycle that it creates below.

```
import torch

class TestFn(torch.autograd.Function):
    @staticmethod
    def forward(ctx, a):
        b = a + 1
        c = b.view(-1)
        ctx.save_for_backward(c)
        return b

    @staticmethod
    def backward(ctx, *flat_args):
        raise RuntimeError("")

a = torch.ones(64656, 640, device='cuda', requires_grad=True)
import gc
gc.collect()
mem_before = torch.cuda.memory_allocated()
TestFn.apply(a)
gc.collect()
mem_after = torch.cuda.memory_allocated()
```

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/16311747/222545657-82147b2f-dcbc-4810-a1e8-0174a74e1c24.png">

First: this PR appears to fix the reference cycle as described, but it segfaults on more complicated examples - after some attempts at debugging, I've put up my current state here to save my current progress.

There are two main changes to our tp_traverse code that this PR makes:

**Change (1): update how we traverse python tensors that are owned by their C++ tensors**

Ed updated our C++ tensor to perform pyobject preservation a while ago - it is possible for the C++ tensor to "own" its python tensor, when the python tensor goes dead.

However, both the C++ tensor and the python tensor can potentially own their own separate python state that might need to be traversed. After talking to Alban, I updated `THPVariable_subclass_traverse()`, and added a new function, `THPVariable_cpp_tensor_visit()`. The idea is that:

(a) `THPVariable_subclass_traverse()` is now only in charge of visiting the python state it owns, like hooks. If it also owns the C++ tensor, it will call `THPVariable_cpp_tensor_visit()`.

(b) `THPVariable_cpp_tensor_visit()` is only in charge of visiting the python state it owns, like autograd state. If it also owns the python tensor, it will call `THPVariable_subclass_traverse()`.

Quick picture:

<img width="862" alt="image" src="https://user-images.githubusercontent.com/16311747/222556719-9718930c-1b8b-4a56-a42e-73d9ad44c9b4.png">


**Change (2): update `THPFunction`'s tp_traverse to visit saved variables**

You can see in the ref cycle drawn above that the part of the cycle includes following the custom autograd.Function object through the tensor that it saves for backward. So inside of our custom autograd.Function's tp_traverse, we need to try to visit any saved variables, if there are any.

Specifically, those saved variables will be `at::Tensor`'s, so I call the new `THPVariable_cpp_tensor_visit()` on them. If those C++ tensors happen to own their python tensor (as is this case in this cycle), that will indirectly end up calling `THPVariable_subclass_traverse()` on the python object for the saved tensor.


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #95904
* #95748

