### PR TITLE
Change linux.gcp.a100 to linux.gcp.a100.large 

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -22,10 +22,10 @@ jobs:
       cuda-arch-list: '8.0'
       test-matrix: |
         { include: [
-          { config: "inductor_huggingface_perf", shard: 1, num_shards: 1, runner: "linux.gcp.a100" },
-          { config: "inductor_timm_perf", shard: 1, num_shards: 2, runner: "linux.gcp.a100" },
-          { config: "inductor_timm_perf", shard: 2, num_shards: 2, runner: "linux.gcp.a100" },
-          { config: "inductor_torchbench_perf", shard: 1, num_shards: 1, runner: "linux.gcp.a100" },
+          { config: "inductor_huggingface_perf", shard: 1, num_shards: 1, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 1, num_shards: 2, runner: "linux.gcp.a100.large" },
+          { config: "inductor_timm_perf", shard: 2, num_shards: 2, runner: "linux.gcp.a100.large" },
+          { config: "inductor_torchbench_perf", shard: 1, num_shards: 1, runner: "linux.gcp.a100.large" },
         ]}
 
   linux-bionic-cuda11_7-py3_10-gcc7-inductor-test:


### PR DESCRIPTION
To avoid making workloads like https://github.com/pytorch/pytorch/blob/master/.github/workflows/inductor.yml#L52 queue for a long time.

For example, in the past the runners were all used to run https://github.com/pytorch/pytorch/actions/workflows/inductor-perf-test-nightly.yml and perf smoke test jobs in https://github.com/pytorch/pytorch/actions/workflows/inductor.yml did not get runners. 

<img width="614" alt="image" src="https://user-images.githubusercontent.com/109318740/222570066-7aec611d-0feb-42cb-8b1b-d93bd36f4d17.png">

This PR makes sure the queue only happens to long-running workloads and we have a plan to address it with more runners with basic auto-scaling feature enabled.  
