### PR TITLE
aten: size_t -> int64_t

### DIFF
--- a/aten/src/ATen/native/sparse/ValidateCompressedIndicesCommon.h
+++ b/aten/src/ATen/native/sparse/ValidateCompressedIndicesCommon.h
@@ -343,7 +343,7 @@ void validate_compressed_sparse_indices_kernel(
     const int64_t cdim,
     const int64_t dim,
     const int64_t nnz) {
-  constexpr size_t idx_max_ndims = 8; // up to 7-dim batch.
+  constexpr int64_t idx_max_ndims = 8; // up to 7-dim batch.
   const int64_t idx_ndims = idx.dim();
 
   if (is_crow) {


### PR DESCRIPTION
Forward fixes sign comparison compilation issues that were introduced in https://github.com/pytorch/pytorch/pull/94048
