### PR TITLE
Update lintrunner to version that uses  as default mergebase

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -244,9 +244,9 @@ unittest-xml-reporting<=3.2.0,>=2.0.0
 #Pinned versions:
 #test that import:
 
-lintrunner==0.9.2
+lintrunner==0.10.7
 #Description: all about linters
-#Pinned versions: 0.9.2
+#Pinned versions: 0.10.7
 #test that import:
 
 rockset==1.0.3

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -244,9 +244,9 @@ unittest-xml-reporting<=3.2.0,>=2.0.0
 #Pinned versions:
 #test that import:
 
-lintrunner==0.10.7
+lintrunner==0.9.2
 #Description: all about linters
-#Pinned versions: 0.10.7
+#Pinned versions: 0.9.2
 #test that import:
 
 rockset==1.0.3

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -245,7 +245,7 @@ unittest-xml-reporting<=3.2.0,>=2.0.0
 #test that import:
 
 lintrunner==0.10.7
-#Description: all about linters
+#Description: all about linters!
 #Pinned versions: 0.10.7
 #test that import:
 

--- a/.github/requirements-gha-cache.txt
+++ b/.github/requirements-gha-cache.txt
@@ -7,7 +7,7 @@
 #   .ci/docker/requirements-ci.txt
 boto3==1.19.12
 jinja2==3.0.1
-lintrunner==0.9.2
+lintrunner==0.10.7
 ninja==1.10.0.post1
 nvidia-ml-py==11.525.84
 pyyaml==6.0

--- a/.github/requirements-gha-cache.txt
+++ b/.github/requirements-gha-cache.txt
@@ -7,7 +7,7 @@
 #   .ci/docker/requirements-ci.txt
 boto3==1.19.12
 jinja2==3.0.1
-lintrunner==0.10.7
+lintrunner==0.9.2
 ninja==1.10.0.post1
 nvidia-ml-py==11.525.84
 pyyaml==6.0

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1,3 +1,5 @@
+merge_base_with = "master"
+
 [[linter]]
 code = 'FLAKE8'
 include_patterns = ['**/*.py']


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/93156

Upgrades lintrunner to the latest version which can use the `master` branch as the merge base by default (provided it's specified in `.lintrunner.toml` and update `.lintrunner.toml` accordingly
