### PR TITLE
Bump up pytorch-triton build string to 2.1.0

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -19,13 +19,13 @@ def check_and_replace(inp: str, src: str, dst: str) -> str:
     return inp.replace(src, dst)
 
 
-def patch_setup_py(path: Path, *, version: str = "2.0.0", name: str = "triton") -> None:
+def patch_setup_py(path: Path, *, version: str = "2.1.0", name: str = "triton") -> None:
     with open(path) as f:
         orig = f.read()
     # Replace name
     orig = check_and_replace(orig, "name=\"triton\",", f"name=\"{name}\",")
     # Replace version
-    orig = check_and_replace(orig, "version=\"2.0.0\",", f"version=\"{version}\",")
+    orig = check_and_replace(orig, "version=\"2.1.0\",", f"version=\"{version}\",")
     with open(path, "w") as f:
         f.write(orig)
 
@@ -38,7 +38,7 @@ def build_triton(commit_hash: str, build_conda: bool = False, py_version : Optio
         check_call(["git", "checkout", commit_hash], cwd=triton_basedir)
         if build_conda:
             with open(triton_basedir / "meta.yaml", "w") as meta:
-                print(f"package:\n  name: torchtriton\n  version: 2.0.0+{commit_hash[:10]}\n", file=meta)
+                print(f"package:\n  name: torchtriton\n  version: 2.1.0+{commit_hash[:10]}\n", file=meta)
                 print("source:\n  path: .\n", file=meta)
                 print("build:\n  string: py{{py}}\n  number: 1\n  script: cd python; "
                       "python setup.py install --single-version-externally-managed --record=record.txt\n", file=meta)
@@ -55,7 +55,7 @@ def build_triton(commit_hash: str, build_conda: bool = False, py_version : Optio
             shutil.copy(conda_path, Path.cwd())
             return Path.cwd() / conda_path.name
 
-        patch_setup_py(triton_pythondir / "setup.py", name="pytorch-triton", version=f"2.0.0+{commit_hash[:10]}")
+        patch_setup_py(triton_pythondir / "setup.py", name="pytorch-triton", version=f"2.1.0+{commit_hash[:10]}")
         check_call([sys.executable, "setup.py", "bdist_wheel"], cwd=triton_pythondir)
         whl_path = list((triton_pythondir / "dist").glob("*.whl"))[0]
         shutil.copy(whl_path, Path.cwd())

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -19,13 +19,13 @@ def check_and_replace(inp: str, src: str, dst: str) -> str:
     return inp.replace(src, dst)
 
 
-def patch_setup_py(path: Path, *, version: str = "2.1.0", name: str = "triton") -> None:
+def patch_setup_py(path: Path, *, version: str = "2.0.0", name: str = "triton") -> None:
     with open(path) as f:
         orig = f.read()
     # Replace name
     orig = check_and_replace(orig, "name=\"triton\",", f"name=\"{name}\",")
     # Replace version
-    orig = check_and_replace(orig, "version=\"2.1.0\",", f"version=\"{version}\",")
+    orig = check_and_replace(orig, "version=\"2.0.0\",", f"version=\"{version}\",")
     with open(path, "w") as f:
         f.write(orig)
 

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -19,13 +19,13 @@ def check_and_replace(inp: str, src: str, dst: str) -> str:
     return inp.replace(src, dst)
 
 
-def patch_setup_py(path: Path, *, version: str = "2.0.0", name: str = "triton") -> None:
+def patch_setup_py(path: Path, *, version: str = "2.1.0", name: str = "triton") -> None:
     with open(path) as f:
         orig = f.read()
     # Replace name
     orig = check_and_replace(orig, "name=\"triton\",", f"name=\"{name}\",")
     # Replace version
-    orig = check_and_replace(orig, "version=\"2.0.0\",", f"version=\"{version}\",")
+    orig = check_and_replace(orig, "version=\"2.1.0\",", f"version=\"{version}\",")
     with open(path, "w") as f:
         f.write(orig)
 

--- a/setup.py
+++ b/setup.py
@@ -1032,7 +1032,7 @@ def main():
         if os.path.exists(triton_pin_file):
             with open(triton_pin_file) as f:
                 triton_pin = f.read().strip()
-                extras_require['dynamo'] = ['pytorch-triton==2.0.0+' + triton_pin[:10], 'jinja2']
+                extras_require['dynamo'] = ['pytorch-triton==2.1.0+' + triton_pin[:10], 'jinja2']
 
     # Parse the command line and check the arguments before we proceed with
     # building deps and setup. We need to set values so `--help` works.


### PR DESCRIPTION
Fixes wild behaviour while installing nightly wheels: collecting torch 3 times! 

Collecting torch                    
  Using cached https://download.pytorch.org/whl/nightly/cu117/torch-2.1.0.dev20230303%2Bcu117-cp310-cp310-linux_x86_64.whl (1848.6 MB)           
Requirement already satisfied: torchvision in /fsx/users/weiwangmeta/conda/envs/test_nightly_wheel/lib/python3.10/site-packages (0.15.0.dev20230303+cu117)                                
Requirement already satisfied: TorchAudio in /fsx/users/weiwangmeta/conda/envs/test_nightly_wheel/lib/python3.10/site-packages (2.0.0.dev20230303+cu117)
Requirement already satisfied: filelock in /fsx/users/weiwangmeta/conda/envs/test_nightly_wheel/lib/python3.10/site-packages (from torch) (3.9.0)                                         
Requirement already satisfied: sympy in /fsx/users/weiwangmeta/conda/envs/test_nightly_wheel/lib/python3.10/site-packages (from torch) (1.11.1)                                           
Collecting pytorch-triton==2.0.0+b8b470bc59   
  Using cached https://download.pytorch.org/whl/nightly/pytorch_triton-2.0.0%2Bb8b470bc59-cp310-cp310-linux_x86_64.whl (66.5 MB)                                                          
Collecting torch                              
  Using cached https://download.pytorch.org/whl/nightly/cu117/torch-2.1.0.dev20230302%2Bcu117-cp310-cp310-linux_x86_64.whl (1850.4 MB)                                                    
  Using cached https://download.pytorch.org/whl/nightly/cu117/torch-2.0.0.dev20230301%2Bcu117-cp310-cp310-linux_x86_64.whl (1848.6 MB)
