### PR TITLE
Use working pre-built sccache binary

### DIFF
--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -36,6 +36,10 @@ if [ -n "$ROCM_VERSION" ]; then
   curl --retry 3 http://repo.radeon.com/misc/.sccache_amd/sccache -o /opt/cache/bin/sccache
 else
   ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+  # TODO: Install the pre-built binary from S3 as building from source
+  # https://github.com/pytorch/sccache has started failing mysteriously
+  # in which sccache server couldn't start with the following error:
+  #   sccache: error: Invalid argument (os error 22)
   install_binary
 fi
 chmod a+x /opt/cache/bin/sccache

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -36,14 +36,7 @@ if [ -n "$ROCM_VERSION" ]; then
   curl --retry 3 http://repo.radeon.com/misc/.sccache_amd/sccache -o /opt/cache/bin/sccache
 else
   ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
-  case "$ID" in
-    ubuntu)
-      install_ubuntu
-      ;;
-    *)
-      install_binary
-      ;;
-  esac
+  install_binary
 fi
 chmod a+x /opt/cache/bin/sccache
 


### PR DESCRIPTION
From https://github.com/pytorch/pytorch/pull/95938 where a new Docker image build fails to start sccache. This issue starts to happen today (Mar 3rd).   The server fails to start with a cryptic `sccache: error: Invalid argument (os error 22)`

```
=================== sccache compilation log ===================
ERROR 2023-03-03T20:31:14Z: sccache::server: failed to start server: Invalid argument (os error 22)

sccache: error: Invalid argument (os error 22)

=========== If your build fails, please take a look at the log above for possible reasons ===========

+ sccache --show-stats
sccache: error: Connection to server timed out
```

I don't have a good explanation for this yet.  The version of sccache we build from https://github.com/pytorch/sccache is ancient.  If I start to build the exact same version on Ubuntu Docker image now, the issue will manifest.  But the older binary built only few days ago https://hud.pytorch.org/pytorch/pytorch/commit/e50ff3fcdb3890ce3bbab99e60b1c27ff49be2af works without any issue.  So I fix sccache binary to that version instead of rebuilding it every time in the image as a temporary mitigation while trying to root cause this further.

