### PR TITLE
Transformers: fix src and key padding mask bool regression

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -510,6 +510,36 @@ class TestTransformers(NNTestCase):
             with cm:
                 _test(batch_first, training, enable_nested_tensor)
 
+
+    def test_padding_and_src_mask_bool(self):
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=16,
+            nhead=2,
+            dim_feedforward=32,
+            dropout=0.1,
+            activation='relu',
+            batch_first=True,
+        )
+        encoder_norm = nn.LayerNorm(16)
+        encoder = nn.TransformerEncoder(
+            encoder_layer, 2, encoder_norm
+        )
+
+        inputs = torch.randn(2, 3, 16)
+
+        src_mask = torch.ones(3, 3, dtype=torch.bool).triu_(diagonal=1)
+        input_seq_len = torch.tensor([3, 2])
+        padding_mask = (
+            torch.arange(3)[None, :].cpu() >= input_seq_len[:, None]
+        )
+
+        encoder(
+            inputs,
+            mask=src_mask,
+            src_key_padding_mask=padding_mask,
+        )
+
+
     @unittest.skipIf(not TEST_FAIRSEQ, "Fairseq not found")
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_decoder_only_layer(self):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5206,8 +5206,8 @@ def multi_head_attention_forward(
     attn_mask = _canonical_mask(
         mask=attn_mask,
         mask_name="attn_mask",
-        other_type=_none_or_dtype(key_padding_mask),
-        other_name="key_padding_mask",
+        other_type=None,
+        other_name="",
         target_type=q.dtype,
         check_other=False,
     )

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1244,8 +1244,8 @@ class MultiheadAttention(Module):
         attn_mask = F._canonical_mask(
             mask=attn_mask,
             mask_name="attn_mask",
-            other_type=F._none_or_dtype(key_padding_mask),
-            other_name="key_padding_mask",
+            other_type=None,
+            other_name="",
             target_type=query.dtype,
             check_other=False,
         )

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -219,6 +219,15 @@ class TransformerEncoder(Module):
             target_type=src.dtype
         )
 
+        mask = F._canonical_mask(
+            mask=mask,
+            mask_name="mask",
+            other_type=None,
+            other_name="",
+            target_type=src.dtype,
+            check_other=False,
+        )
+
         output = src
         convert_to_nested = False
         first_layer = self.layers[0]
@@ -490,6 +499,15 @@ class TransformerEncoderLayer(Module):
             other_type=F._none_or_dtype(src_mask),
             other_name="src_mask",
             target_type=src.dtype
+        )
+
+        src_mask = F._canonical_mask(
+            mask=src_mask,
+            mask_name="src_mask",
+            other_type=None,
+            other_name="",
+            target_type=src.dtype,
+            check_other=False,
         )
 
         # see Fig. 1 of https://arxiv.org/pdf/2002.04745v1.pdf


### PR DESCRIPTION
Summary: fix src and pad mask bool regression

This fixes a regression introduced previously with #92733. That PR unified testing of masks to remove Byte Tensors as permissible mask, introduced mask compatibility check, and mask conversion to FP mask.  The problem addressed in this PR was that after the first mask had been converted, a check for mask compatibility would fail.  

Test Plan: sandcastle & github

Differential Revision: D43782858

Fixes  https://github.com/pytorch/pytorch/issues/95702
