### PR TITLE
enable taskset core pinning in addition to numactl

### DIFF
--- a/test/backends/xeon/test_launch.py
+++ b/test/backends/xeon/test_launch.py
@@ -53,7 +53,7 @@ class TestTorchrun(TestCase):
     def test_multi_threads(self):
         num = 0
         with subprocess.Popen(f"python -m torch.backends.xeon.run_cpu --ninstances 4 --use-default-allocator \
-            --disable-iomp --disable-numactl --log-path {self._test_dir} --no-python pwd",
+            --disable-iomp --disable-numactl --disable-taskset --log-path {self._test_dir} --no-python pwd",
                               shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as p:
             for line in p.stdout.readlines():
                 segs = str(line, "utf-8").strip().split("-")

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -286,7 +286,7 @@ or /.local/lib/ or /usr/local/lib/ or /usr/local/lib64/ or /usr/lib or /usr/lib6
         numactl_available = False
         try:
             cmd = ["numactl", "-C", "0", "-m", "0", "hostname"]
-            r = subprocess.run(cmd, env=os.environ, stdout=subprocess.DEVNULL)
+            r = subprocess.run(cmd, env=os.environ, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             if r.returncode == 0:
                 numactl_available = True
         except:

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -281,7 +281,19 @@ or /.local/lib/ or /usr/local/lib/ or /usr/local/lib64/ or /usr/lib or /usr/lib6
                     break
         return lib_set or lib_find
 
-
+    
+    def is_numactl_available(self):
+        numactl_available = False
+        try:
+            cmd = ["numactl", "-C", "0", "-m", "0", "hostname"]
+            r = subprocess.run(cmd, env=os.environ)
+            if r.returncode == 0:
+                numactl_available = True
+        except:
+            pass
+        return numactl_available
+        
+        
     def set_memory_allocator(self, enable_tcmalloc=True, enable_jemalloc=False, use_default_allocator=False):
         """
         Enable TCMalloc/JeMalloc with LD_PRELOAD and set configuration for JeMalloc.
@@ -373,6 +385,7 @@ Value applied: {os.environ[env_name]}. Value ignored: {env_value}")
     def launch(self, args):
         cores = []
         set_kmp_affinity = True
+        enable_taskset = False
         if args.core_list:  # user specify what cores will be used by params
             cores = [int(x) for x in args.core_list.split(",")]
             if args.ncores_per_instance == -1:
@@ -457,7 +470,21 @@ won\'t take effect even if it is set explicitly.')
 
         if args.ninstances > 1 and args.rank != -1:
             logger.info(f"assigning {args.ncores_per_instance} cores for instance {args.rank}")
-
+        
+        if not args.disable_numactl:
+            numactl_available = self.is_numactl_available()
+            if not numactl_available:
+                if not args.disable_taskset:
+                    logger.warning("Core binding with numactl is not available. Disabling numactl and using taskset instead. This may affect performance in multi-socket system; please use numactl if memory binding is needed.")
+                    args.disable_numactl = True 
+                    enable_taskset = True 
+                else:
+                    logger.warning("Core binding with numactl is not available, and --disable_taskset is set. Please unset --disable_taskset to use taskset insetad of numactl.")
+                    exit(-1)
+        
+        if not args.disable_taskset:
+            enable_taskset = True 
+            
         self.set_multi_thread_and_allocator(args.ncores_per_instance,
                                             args.disable_iomp,
                                             set_kmp_affinity,
@@ -471,8 +498,11 @@ won\'t take effect even if it is set explicitly.')
         for i in range(args.ninstances):
             cmd = []
             cur_process_cores = ""
-            if not args.disable_numactl:
-                cmd = ["numactl"]
+            if not args.disable_numactl or enable_taskset:
+                if not args.disable_numactl:
+                    cmd = ["numactl"]
+                elif enable_taskset:
+                    cmd = ["taskset"]
                 cores = sorted(cores)
                 if args.rank == -1:  # sequentially assign ncores_per_instance to ninstances
                     core_list = cores[i * args.ncores_per_instance : (i + 1) * args.ncores_per_instance]
@@ -494,10 +524,14 @@ won\'t take effect even if it is set explicitly.')
                 for r in core_ranges:
                     cur_process_cores = f"{cur_process_cores}{r['start']}-{r['end']},"
                 cur_process_cores = cur_process_cores[:-1]
-                numa_params = f"-C {cur_process_cores} "
-                numa_ids = ",".join([str(numa_id) for numa_id in self.cpuinfo.numa_aware_check(core_list)])
-                numa_params += f"-m {numa_ids}"
-                cmd.extend(numa_params.split())
+                if not args.disable_numactl:
+                    numa_params = f"-C {cur_process_cores} "
+                    numa_ids = ",".join([str(numa_id) for numa_id in self.cpuinfo.numa_aware_check(core_list)])
+                    numa_params += f"-m {numa_ids}"
+                    cmd.extend(numa_params.split())
+                elif enable_taskset:
+                    taskset_params = f"-c {cur_process_cores} "
+                    cmd.extend(taskset_params.split())
             with_python = not args.no_python
             if with_python:
                 cmd.append(sys.executable)
@@ -562,6 +596,8 @@ https://github.com/intel/intel-extension-for-pytorch/blob/master/docs/tutorials/
                        help="Whether only use physical cores")
     group.add_argument("--disable-numactl", "--disable_numactl", action="store_true", default=False,
                        help="Disable numactl")
+    group.add_argument("--disable-taskset", "--disable_taskset", action="store_true", default=False,
+                       help="Disable taskset")
     group.add_argument("--core-list", "--core_list", metavar="\b", default=None, type=str,
                        help="Specify the core list as \"core_id, core_id, ....\", otherwise, all the cores will be used.")
     group.add_argument("--log-path", "--log_path", metavar="\b", default="", type=str,

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -286,7 +286,7 @@ or /.local/lib/ or /usr/local/lib/ or /usr/local/lib64/ or /usr/lib or /usr/lib6
         numactl_available = False
         try:
             cmd = ["numactl", "-C", "0", "-m", "0", "hostname"]
-            r = subprocess.run(cmd, env=os.environ)
+            r = subprocess.run(cmd, env=os.environ, stdout=subprocess.DEVNULL)
             if r.returncode == 0:
                 numactl_available = True
         except:

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -281,7 +281,7 @@ or /.local/lib/ or /usr/local/lib/ or /usr/local/lib64/ or /usr/lib or /usr/lib6
                     break
         return lib_set or lib_find
 
-    
+
     def is_numactl_available(self):
         numactl_available = False
         try:
@@ -289,11 +289,11 @@ or /.local/lib/ or /usr/local/lib/ or /usr/local/lib64/ or /usr/lib or /usr/lib6
             r = subprocess.run(cmd, env=os.environ, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             if r.returncode == 0:
                 numactl_available = True
-        except:
+        except Exception:
             pass
         return numactl_available
-        
-        
+
+
     def set_memory_allocator(self, enable_tcmalloc=True, enable_jemalloc=False, use_default_allocator=False):
         """
         Enable TCMalloc/JeMalloc with LD_PRELOAD and set configuration for JeMalloc.
@@ -470,21 +470,23 @@ won\'t take effect even if it is set explicitly.')
 
         if args.ninstances > 1 and args.rank != -1:
             logger.info(f"assigning {args.ncores_per_instance} cores for instance {args.rank}")
-        
+
         if not args.disable_numactl:
             numactl_available = self.is_numactl_available()
             if not numactl_available:
                 if not args.disable_taskset:
-                    logger.warning("Core binding with numactl is not available. Disabling numactl and using taskset instead. This may affect performance in multi-socket system; please use numactl if memory binding is needed.")
-                    args.disable_numactl = True 
-                    enable_taskset = True 
+                    logger.warning("Core binding with numactl is not available. Disabling numactl and using taskset instead. \
+                    This may affect performance in multi-socket system; please use numactl if memory binding is needed.")
+                    args.disable_numactl = True
+                    enable_taskset = True
                 else:
-                    logger.warning("Core binding with numactl is not available, and --disable_taskset is set. Please unset --disable_taskset to use taskset insetad of numactl.")
+                    logger.warning("Core binding with numactl is not available, and --disable_taskset is set. \
+                    Please unset --disable_taskset to use taskset insetad of numactl.")
                     exit(-1)
-        
+
         if not args.disable_taskset:
-            enable_taskset = True 
-            
+            enable_taskset = True
+
         self.set_multi_thread_and_allocator(args.ncores_per_instance,
                                             args.disable_iomp,
                                             set_kmp_affinity,


### PR DESCRIPTION
- port https://github.com/intel-innersource/frameworks.ai.pytorch.ipex-cpu/pull/740 to `run_cpu`
- use-case by https://github.com/pytorch/serve/pull/2166 where `numactl` is unavailable (e.g., requires `privileged` mode) 

This PR automatically tries taskset if numactl core binding doesn't work.

Reference: 
`taskset` is added to adapt to launcher use-cases such as in docker where `numactl` requires to be ran in  `privileged` mode, where the  `privileged` mode "wont work for deployments like sagemaker for example" as raised by TorchServe. Please see [torchserve ipex docker discussion](https://github.com/pytorch/serve/pull/1401#issuecomment-1090817704) for reference. To address such use-cases, `taskset` can be used in place of `numactl` to set core affinity. Note that, unlike `numactl`, `taskset` does not provide memory binding to local memories; however, memory binding may not be needed in these use-cases  that typically do not span multi sockets. Hence we can automatically try taskset if numactl doesn't work. 
