### PR TITLE
Allow Custom OpOverload passing into ONNX

### DIFF
--- a/test/onnx/test_fx_to_onnx_with_custom_op_overload.py
+++ b/test/onnx/test_fx_to_onnx_with_custom_op_overload.py
@@ -1,26 +1,56 @@
-import torch
-from torch.library import Library
-from torch.fx.experimental.proxy_tensor import make_fx
+# Owner(s): ["module: onnx"]
 import onnxscript
-
-from torch.onnx._internal import diagnostics, fx
+import pytorch_test_common
+import torch
 import torch.onnx._internal.fx.custom_operator
+from torch.onnx._internal import fx
+from torch.testing._internal import common_utils
 
-@fx.custom_operator.custom_op_overload("custom::op(Tensor x) -> Tensor")
-def custom_op(x):
-    return x * 2 + 1
 
-CUSTOM_OPSET = onnxscript.values.Opset(domain="com.custom", version=1)
-@onnxscript.script(opset=CUSTOM_OPSET)
-def custom_op_exporter(x):
-    return CUSTOM_OPSET.my_op(x)
+class TestFxToOnnx(pytorch_test_common.ExportTestCase):
+    def setUp(self):
+        super().setUp()
+        self.opset_version = torch.onnx._constants.ONNX_DEFAULT_OPSET
 
-fx.custom_operator._register_custom_op_overload(torch.ops.custom.op.default, "custom_op", custom_op_exporter)
+    def test_simple_function(self):
+        # Steps to put custom op into onnx model
+        #  1. Define a custom function and register it as torch._ops.OpOverload so that
+        #     this function can pass through PyTorch 2.0's FX-generation pipeline
+        #     (e.g., dynamo.export). Otherwise, the custom function will be traced
+        #     into (or decomposed) and exporter won't see any custom functions.
+        #  2. Write a custom exporter using ONNX Script for this custom function.
+        #  3. Register the custom exporter to the custom function (type: torch._ops.OpOverload).
 
-def f(x):
-    return custom_op(x) * 3
+        # Step 1
+        @fx.custom_operator._register_onnx_custom_op_overload(
+            "torch_custom_op(Tensor x) -> Tensor"
+        )
+        def custom_op(x):
+            return x * 2 + 1
 
-onnx_model = fx.export_after_normalizing_args_and_kwargs(
-    f, torch.randn(3), use_binary_format=False
-)
-print(onnx_model)
+        CUSTOM_OPSET = onnxscript.values.Opset(domain="com.custom", version=1)
+
+        # Step 2
+        @onnxscript.script(opset=CUSTOM_OPSET)
+        def custom_op_exporter(x):
+            return CUSTOM_OPSET.onnx_custom_op(x)
+
+        # Step 3
+        fx.custom_operator._register_exporter_for_op_overload(
+            torch.ops.onnx_custom.torch_custom_op.default,
+            "custom_op",
+            custom_op_exporter,
+        )
+
+        def f(x):
+            return 2 + custom_op(x) * 3
+
+        onnx_model = fx.export_after_normalizing_args_and_kwargs(
+            f, torch.randn(3), use_binary_format=False
+        )
+
+        self.assertIn("onnx_custom_op", str(onnx_model))
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/test/onnx/test_fx_to_onnx_with_custom_op_overload.py
+++ b/test/onnx/test_fx_to_onnx_with_custom_op_overload.py
@@ -1,0 +1,26 @@
+import torch
+from torch.library import Library
+from torch.fx.experimental.proxy_tensor import make_fx
+import onnxscript
+
+from torch.onnx._internal import diagnostics, fx
+import torch.onnx._internal.fx.custom_operator
+
+@fx.custom_operator.custom_op_overload("custom::op(Tensor x) -> Tensor")
+def custom_op(x):
+    return x * 2 + 1
+
+CUSTOM_OPSET = onnxscript.values.Opset(domain="com.custom", version=1)
+@onnxscript.script(opset=CUSTOM_OPSET)
+def custom_op_exporter(x):
+    return CUSTOM_OPSET.my_op(x)
+
+fx.custom_operator._register_custom_op_overload(torch.ops.custom.op.default, "custom_op", custom_op_exporter)
+
+def f(x):
+    return custom_op(x) * 3
+
+onnx_model = fx.export_after_normalizing_args_and_kwargs(
+    f, torch.randn(3), use_binary_format=False
+)
+print(onnx_model)

--- a/torch/onnx/_internal/fx/custom_operator.py
+++ b/torch/onnx/_internal/fx/custom_operator.py
@@ -1,0 +1,36 @@
+from typing import Callable
+
+import torch
+from .function_dispatcher import _ATENLIB_FUNCTIONS, _OP_OVERLOAD_TO_EXPORTER_KEY_TABLE
+
+CUSTOM_OP_OVERLOADS = []
+
+
+def custom_op_overload(schema: str):
+    def inner(f: Callable):
+        # TODO: Refactor the Library API so this is less rage inducing
+        # TODO: Perhaps the namespace should be directly based on Python
+        # module
+        if "::" in schema:
+            ns = schema.split("::", 2)[0]
+        else:
+            ns = "contrib"
+        # TODO: Library doesn't allow FRAGMENT, need to allow it
+        lib = torch.library.Library(ns, "DEF")
+        name = lib.define(schema)
+        if "::" in name:
+            name = name.split("::", 2)[1]
+        lib.impl(name, f, "CompositeExplicitAutograd")
+        CUSTOM_OP_OVERLOADS.append(lib)
+        return getattr(getattr(torch.ops, ns), name)
+
+    return inner
+
+
+def _register_custom_op_overload(
+    op_overload: torch._ops.OpOverload, exporter_key: str, exporter: Callable
+) -> None:
+    assert op_overload not in _OP_OVERLOAD_TO_EXPORTER_KEY_TABLE
+    assert exporter_key not in _ATENLIB_FUNCTIONS
+    _OP_OVERLOAD_TO_EXPORTER_KEY_TABLE[op_overload] = exporter_key
+    _ATENLIB_FUNCTIONS[exporter_key] = exporter

--- a/torch/onnx/_internal/fx/custom_operator.py
+++ b/torch/onnx/_internal/fx/custom_operator.py
@@ -7,12 +7,31 @@ ONNX_CUSTOM_OP_LIB = torch.library.Library("onnx_custom", "DEF")
 
 
 def _register_onnx_custom_op_overload(schema: str):
+    """This function decorator registers the wrapped function as a `torch._ops.OpOverload` with the provided `schema`.
+
+    Arguments:
+        schema (str): The schema of the wrapped function in PyTorch's type system; e.g., "my_op(Tensor a, Tensor b) -> Tensor c".
+
+    Example:
+    The following example register the `a_funny_op` function as `torch.ops.onnx_custom.my_op` (type: torch._ops.OpOverload).
+
+        import torch
+        import torch.onnx._internal.fx.custom_operator as fx_custom
+        @fx_custom._register_onnx_custom_op_overload("my_op(Tensor a, Tensor b) -> Tensor c")
+        def a_funny_op(a, b):
+            return a + b
+
+        x = torch.randn(3, 4)
+        y = torch.randn(3, 4)
+        # Now, use op_overload to invoke the custom function.
+        z = torch.ops.onnx_custom.my_op(x, y)
+    """
+
     def inner(f: Callable):
-        if "::" in schema:
-            domain = schema.split("::", 2)[0]
-            assert (
-                domain == "onnx_custom"
-            ), f"operator domain must be onnx_custom but found {schema}"
+        assert (
+            "::" not in schema
+        ), f"OpOverload created via this API is assumed to be in the `onnx_custom` namespace, so schema\
+              must not include the namespace. Received schema is {schema}"
         name = ONNX_CUSTOM_OP_LIB.define(schema)
         ONNX_CUSTOM_OP_LIB.impl(name, f, "CompositeExplicitAutograd")
         return getattr(torch.ops.onnx_custom, name)
@@ -23,6 +42,16 @@ def _register_onnx_custom_op_overload(schema: str):
 def _register_exporter_for_op_overload(
     op_overload: torch._ops.OpOverload, exporter_key: str, exporter: Callable
 ) -> None:
+    """Register the exporter for custom `op_overload`.
+
+    Pseudocode of the mapping process when processing one FX node:
+        # See a `torch._ops.OpOverload` node
+        op_overload = node.target
+        # Find its exporter key function_dispatcher._OP_OVERLOAD_TO_EXPORTER_KEY_TABLE table.
+        _OP_OVERLOAD_TO_EXPORTER_KEY_TABLE[op_overload]
+        # Retrieve the actual exporter and call it with proper inputs.
+        _ATENLIB_FUNCTIONS[exporter_key]
+    """
     assert op_overload not in _OP_OVERLOAD_TO_EXPORTER_KEY_TABLE
     assert exporter_key not in _ATENLIB_FUNCTIONS
     _OP_OVERLOAD_TO_EXPORTER_KEY_TABLE[op_overload] = exporter_key

--- a/torch/onnx/_internal/fx/passes/fx_to_onnxscript.py
+++ b/torch/onnx/_internal/fx/passes/fx_to_onnxscript.py
@@ -168,8 +168,11 @@ def _fill_tensor_meta(
     for i, (onnxscript_value, expected_value) in enumerate(
         zip(flat_onnxscript_values, flat_expected_values)
     ):
-        # Only set shape for now as we don't need type information.
+        # Set shape and type so that custom's output has
+        # the right output schema even if shape inference is
+        # not provided.
         onnxscript_value.shape = tuple(expected_value.size())
+        onnxscript_value.dtype = expected_value.dtype
         if i > 0:
             onnxscript_value.name = f"{name}_{i}"
         else:


### PR DESCRIPTION
As title. With this PR, we can generate a ONNX model with a custom node such as
```
...
  node {
    input: "torch_custom_op"
    input: "2"
    output: "mul"
    name: "aten_mul_2"
    op_type: "aten_mul"
    doc_string: ""
    domain: "onnxscript.atenlib"
  }
...
functions {
  name: "custom_op_exporter"
  input: "x"
  output: "return_val"
  node {
    input: "x"
    output: "return_val"
    name: "n0"
    op_type: "onnx_custom_op"
    domain: "com.custom"
  }
  opset_import {
    domain: "com.custom"
    version: 1
  }
  domain: "com.custom"
}
...
```

Example script:
```py
import torch
import onnxscript

from torch.onnx._internal import fx
import torch.onnx._internal.fx.custom_operator

@fx.custom_operator._register_onnx_custom_op_overload("torch_custom_op(Tensor x) -> Tensor")
def custom_op(x):
    return x * 2 + 1

CUSTOM_OPSET = onnxscript.values.Opset(domain="com.custom", version=1)
@onnxscript.script(opset=CUSTOM_OPSET)
def custom_op_exporter(x):
    return CUSTOM_OPSET.onnx_custom_op(x)

fx.custom_operator._register_exporter_for_op_overload(torch.ops.onnx_custom.torch_custom_op.default, "custom_op", custom_op_exporter)

def f(x):
    return custom_op(x) * 3

onnx_model = fx.export_after_normalizing_args_and_kwargs(
    f, torch.randn(3), use_binary_format=False
)
print(onnx_model)
```