### PR TITLE
Add experimental implementation of while_loop operator in eager mode.

### DIFF
--- a/functorch/experimental/_while_loop.py
+++ b/functorch/experimental/_while_loop.py
@@ -1,0 +1,37 @@
+import torch
+import torch.utils._pytree as pytree
+from torch._ops import PyOperator
+from torch._C import DispatchKey, DispatchKeySet, ExcludeDispatchKeyGuard
+from torch.utils._python_dispatch import (
+    _get_current_dispatch_mode,
+)
+
+"""
+Experimental implementation of JAX-like while_loop operator.
+"""
+while_loop = PyOperator("while_loop")
+
+@while_loop.py_impl(DispatchKey.AutogradCUDA)
+@while_loop.py_impl(DispatchKey.AutogradCPU)
+def while_loop_autograd(cond_fun, body_fun, init_val):
+    # TODO: support autograd
+    flat_operands, _ = pytree.tree_flatten([cond_fun, body_fun, init_val])
+    assert all([not f.requires_grad for f in flat_operands
+                if isinstance(f, torch.Tensor)])
+
+    _ = ExcludeDispatchKeyGuard(DispatchKeySet(DispatchKey.AutogradCPU))
+    return while_loop(cond_fun, body_fun, init_val)
+
+
+while_loop.fallthrough(DispatchKey.ADInplaceOrView)
+while_loop.fallthrough(DispatchKey.BackendSelect)
+
+@while_loop.py_impl(DispatchKey.CUDA)
+@while_loop.py_impl(DispatchKey.CPU)
+def while_loop_cpu(cond_fun, body_fun, init_val):
+    mode = _get_current_dispatch_mode()
+    assert (mode is None), "Mode should never be enabled for CPU/CUDA key"
+    val = init_val
+    while cond_fun(val):
+        val = body_fun(val)
+    return val

--- a/functorch/experimental/control_flow.py
+++ b/functorch/experimental/control_flow.py
@@ -1,2 +1,3 @@
 from ._map import map  # noqa: F401
 from ._cond import cond, UnsupportedAliasMutationException  # noqa: F401
+from ._while_loop import while_loop  # noqa: F401


### PR DESCRIPTION
We got requests from edge users that they would like to have a while_loop operator in the exported graph (similar as map and cond).

This pr implements the minimal necessary dispatch key to support CPU/GPU eager mode inference.

cc @zou3519 @Chillee @samdow @soumith @kshitij12345 @janeyx99