### PR TITLE
enable Half for cat serial kernel

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -566,7 +566,9 @@ TORCH_IMPL_FUNC(cat_out_cpu)
   // fast path for single thread when both inputs and result are contiguous and not empty
   bool use_serial_kernel = result.numel() < at::internal::GRAIN_SIZE || at::get_num_threads() == 1;
   ScalarType dtype = materialized[valid].get().scalar_type();
-  bool serial_dtype = (dtype == ScalarType::Double || dtype == ScalarType::Float || dtype == ScalarType::BFloat16);
+  bool serial_dtype =
+      (dtype == ScalarType::Double || dtype == ScalarType::Float ||
+       dtype == ScalarType::BFloat16 || dtype == ScalarType::Half);
   if (use_serial_kernel && all_contiguous && all_same_dtype && serial_dtype) {
     cat_serial_stub(kCPU, result, materialized, dim);
     return;

--- a/aten/src/ATen/native/cpu/CatKernel.cpp
+++ b/aten/src/ATen/native/cpu/CatKernel.cpp
@@ -56,9 +56,12 @@ void cat_serial_kernel_impl(const Tensor& result, const MaterializedITensorListR
 }
 
 void cat_serial_kernel(const Tensor& result, const MaterializedITensorListRef& tensors, int64_t dim) {
-  AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, result.scalar_type(), "cat_serial_kernel", [&]() {
-    cat_serial_kernel_impl<scalar_t>(result, tensors, dim);
-  });
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      ScalarType::BFloat16,
+      ScalarType::Half,
+      result.scalar_type(),
+      "cat_serial_kernel",
+      [&]() { cat_serial_kernel_impl<scalar_t>(result, tensors, dim); });
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Summary:
1.31 x speedup.

|                     | shape                    | before | after |
| ------------ | ------------- | ------------ | ------------- |
| half          | 1024 * (100 + i)  |    235.75 us      | 179.11 us      |

Benchmark with
```
import torch
import torch.utils.benchmark as benchmark

def cat(*args, dim=0):
    return torch.cat(args, dim)

tensors = []
for i in range(10):
    tensors.append(torch.rand(1024, 100 + i).half())

t0 = benchmark.Timer(
    stmt="cat(*tensors, dim=1)",
    setup="from __main__ import cat",
    globals={"tensors": tensors},
    num_threads=1,
)

```

Test Plan: CI

Differential Revision: D43810514



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10