### PR TITLE
[inductor] use triu ref instead of lowering

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -472,7 +472,7 @@ inductor_all_samples = {
     "mT",
     "mH",
     "rsub",
-    "triu"
+    "triu",
 }
 
 

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -472,6 +472,7 @@ inductor_all_samples = {
     "mT",
     "mH",
     "rsub",
+    "triu"
 }
 
 

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -309,6 +309,7 @@ def core_aten_decompositions() -> Dict[OpOverload, Callable]:
             aten.trace,
             aten.transpose.int,
             aten.tril.default,
+            aten.triu.default,
             aten.unfold,
             aten.unfold_backward,
             aten.upsample_bilinear2d,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1504,30 +1504,6 @@ def iota(
     )
 
 
-@register_lowering(aten.triu)
-def triu(x, diagonal=0):
-    x_loader = x.make_loader()
-    dtype = x.get_dtype()
-
-    def inner_fn(index):
-        *_, i, j = index
-        return ops.where(
-            ops.ge(
-                ops.index_expr(j - i - diagonal, torch.int32),
-                ops.constant(0, torch.int32),
-            ),
-            x_loader(index),
-            ops.constant(0, dtype),
-        )
-
-    return Pointwise.create(
-        device=x.get_device(),
-        dtype=dtype,
-        inner_fn=inner_fn,
-        ranges=list(x.get_size()),
-    )
-
-
 @register_lowering(aten.select_scatter, type_promotion_kind=None)
 def select_scatter(x, src, dim: int, index: int):
     assert x.get_dtype() == src.get_dtype()


### PR DESCRIPTION
Fixes #95958
Generated code is functionally identical with ref and lowering, only minor differences 


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire