### PR TITLE
unwrap sizevars passed as args

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -93,7 +93,7 @@ class TestInductorDynamic(TestCase):
         # HAS_CUDA also checks compute capability to skip tests
         # on older devices
         if self.device_type == "cuda" and not HAS_CUDA:
-            self.skipTest()
+            self.skipTest("Triton not available")
         torch._dynamo.reset()
         super(TestCase, self).setUp()
         # this should be in setUpClass, but device-generic tests

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -1,11 +1,15 @@
 # Owner(s): ["module: inductor"]
+import contextlib
 import importlib
 import os
 import sys
 import unittest
+from functools import partial
+from unittest.mock import patch
 
 import torch
 from torch._dynamo.testing import make_test_cls_with_patches
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     IS_CI,
     IS_WINDOWS,
@@ -80,6 +84,55 @@ if HAS_CUDA and not TEST_WITH_ASAN:
 
     copy_tests(DynamicShapesCommonTemplate, DynamicShapesCudaTests, "cuda", test_skips)
 
+
+class TestInductorDynamic(TestCase):
+
+    compile_fn = partial(torch.compile, dynamic=True)
+
+    def setUp(self):
+        torch._dynamo.reset()
+        super(TestCase, self).setUp()
+        # this should be in setUpClass, but device-generic tests
+        # don't work with setUpClass well (non-deterministically the wrong setUpClass is resolved),
+        # so put it in test setUp, it's cheap
+        self._stack = contextlib.ExitStack()
+        self._stack.enter_context(
+            torch._inductor.config.patch(
+                {
+                    "debug": False,
+                    "cpp.min_chunk_size": 1,
+                    "triton.autotune_pointwise": False,  # too slow
+                    "implicit_fallbacks": False,
+                }
+            )
+        )
+
+    def tearDown(self):
+        self._stack.close()
+        super(TestCase, self).tearDown()
+        torch._dynamo.reset()
+
+    @patch.object(torch._dynamo.config, "specialize_int", False)
+    def test_arange_dynamic(self, device):
+        def fn(a):
+            batch_size = a.numel()
+            max_len = a.max()
+            return ~(
+                torch.arange(0, max_len, device=a.device)
+                .type_as(a)
+                .repeat(batch_size, 1)
+                .lt(a.unsqueeze(1))
+            )
+
+        a = torch.randint(10, 30, (10,), device=device)
+        a[0] = 29  # fix max_len
+        opt = self.compile_fn(fn)
+        res = opt(a)
+        ref = fn(a)
+        self.assertEqual(res, ref)
+
+
+instantiate_device_type_tests(TestInductorDynamic, globals())
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -90,6 +90,10 @@ class TestInductorDynamic(TestCase):
     compile_fn = partial(torch.compile, dynamic=True)
 
     def setUp(self):
+        # HAS_CUDA also checks compute capability to skip tests
+        # on older devices
+        if self.device_type == "cuda" and not HAS_CUDA:
+            self.skipTest()
         torch._dynamo.reset()
         super(TestCase, self).setUp()
         # this should be in setUpClass, but device-generic tests

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -462,7 +462,9 @@ class SizeVarAllocator:
             shape = self.simplify(shape)
             if shape in needed:
                 needed.remove(shape)
-                code.writeline(f"{self.declare}{shape} = {name}{self.ending}")
+                code.writeline(
+                    f"{self.declare}{shape} = {name}.item() if isinstance({name}, torch.Tensor) else {name}{self.ending}"
+                )
 
         for name, value in graph_inputs_tensors:
             shapes = value.get_size()


### PR DESCRIPTION
Undoes int arg wrapping that dynamo does
Generated line:
```
s1 = arg2_1.item() if isinstance(arg2_1, torch.Tensor) else arg2_1
```
Fixes #ISSUE_NUMBER


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire