### PR TITLE
[CI] Use p4d24xlarge for inductor integration test

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -335,7 +335,7 @@ test_inductor_benchmark_perf() {
   TEST_REPORTS_DIR=$(pwd)/test/test-reports
   PARTITION_FLAGS=""
   if [[ -n "$NUM_TEST_SHARDS" && -n "$2" ]]; then
-    PARTITION_FLAGS="--total-partitions 2 --partition-id $2"
+    PARTITION_FLAGS="--total-partitions $NUM_TEST_SHARDS --partition-id $2"
   fi
   mkdir -p "$TEST_REPORTS_DIR"
   # Check training with --amp
@@ -967,9 +967,9 @@ elif [[ "${TEST_CONFIG}" == *inductor_timm* && $NUM_TEST_SHARDS -gt 1 ]]; then
   if [[ "${TEST_CONFIG}" == *inductor_timm_perf* && $NUM_TEST_SHARDS -gt 1 ]]; then
     test_inductor_timm_perf_shard $id
   elif [[ "${TEST_CONFIG}" == *inductor_timm_cpu_accuracy* && $NUM_TEST_SHARDS -gt 1 ]]; then
-    test_inductor_timm_shard cpu $id
+    test_inductor_timm_shard cpu $NUM_TEST_SHARDS $id
   else
-    test_inductor_timm_shard cuda $id
+    test_inductor_timm_shard cuda $NUM_TEST_SHARDS $id
   fi
 elif [[ "${TEST_CONFIG}" == *inductor_torchbench* ]]; then
   install_torchtext

--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -23,12 +23,9 @@ jobs:
       cuda-arch-list: '8.6'
       test-matrix: |
         { include: [
-          { config: "inductor", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_timm", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_timm", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_torchbench", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
+          { config: "inductor_unit_test", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "inductor_distributed", shard: 1, num_shards: 1, runner: "linux.g5.12xlarge.nvidia.gpu" },
+          { config: "inductor_integration", shard: 1, num_shards: 1, runner: "linux.p4d24xlarge.nvidia.gpu" },
         ]}
 
   linux-bionic-cuda11_7-py3_10-gcc7-inductor-test:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -67,7 +67,6 @@ jobs:
       cuda-arch-list: '8.6'
       test-matrix: |
         { include: [
-          { config: "aot_eager_all", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
           # These jobs run too slowly so they must be sharded, unfortunately
           { config: "dynamic_aot_eager_torchbench", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "dynamic_aot_eager_huggingface", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96071

Summary: Inductor integration tests have shown annoying flaky failures
that are not reproducible on our A100 dev environment. Switch the tests
to run on p4d24xlarge which contains 8 A100, and we shard the tests at
the bash script level to utilize all the cards there. More advanced
sharding can be applied if needed.