### PR TITLE
inductor: align baddbmm behavior with eager mode for beta=0 and input has nan value

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4269,7 +4269,8 @@ class CommonTemplate:
         b = torch.randn(6, 128, 64)
         c = torch.randn(6, 64, 100)
         options = itertools.product(
-            [torch.randn(6, 1, 100), torch.randn(6, 1, 100).fill_(torch.nan)], [0.0]
+            [torch.randn(6, 1, 100), torch.randn(6, 1, 100).fill_(torch.nan)],
+            [0.0, 1.0],
         )
         for a, beta in options:
             self.common(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4266,19 +4266,18 @@ class CommonTemplate:
         def fn(a, b, c):
             return aten.baddbmm(a, b, c)
 
-        self.common(
-            fn,
-            [
-                torch.randn(6, 1, 100),
-                torch.randn(6, 128, 64),
-                torch.randn(6, 64, 100),
-            ],
-            # Mismatched elements: 1212 / 76800 (1.6%)
-            # Greatest absolute difference: 0.001953125 at index (0, 0, 93) (up to 1e-05 allowed)
-            # Greatest relative difference: 1.0 at index (3, 19, 4) (up to 0.001 allowed)
-            atol=0.002,
-            rtol=0.001,
-        )
+        b = torch.randn(6, 128, 64)
+        c = torch.randn(6, 64, 100)
+        for a in [torch.randn(6, 1, 100), torch.randn(6, 1, 100).fill_(torch.nan)]:
+            self.common(
+                fn,
+                [a, b, c],
+                # Mismatched elements: 1212 / 76800 (1.6%)
+                # Greatest absolute difference: 0.001953125 at index (0, 0, 93) (up to 1e-05 allowed)
+                # Greatest relative difference: 1.0 at index (3, 19, 4) (up to 0.001 allowed)
+                atol=0.002,
+                rtol=0.001,
+            )
 
     @config.patch({"triton.max_tiles": 2})
     def test_fuse_tiled(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4263,15 +4263,18 @@ class CommonTemplate:
         self.common(fn, [torch.randn(64) * 10])
 
     def test_baddbmm(self):
-        def fn(a, b, c):
-            return aten.baddbmm(a, b, c)
+        def fn(a, b, c, beta):
+            return aten.baddbmm(a, b, c, beta=beta)
 
         b = torch.randn(6, 128, 64)
         c = torch.randn(6, 64, 100)
-        for a in [torch.randn(6, 1, 100), torch.randn(6, 1, 100).fill_(torch.nan)]:
+        options = itertools.product(
+            [torch.randn(6, 1, 100), torch.randn(6, 1, 100).fill_(torch.nan)], [0.0]
+        )
+        for a, beta in options:
             self.common(
                 fn,
-                [a, b, c],
+                [a, b, c, beta],
                 # Mismatched elements: 1212 / 76800 (1.6%)
                 # Greatest absolute difference: 0.001953125 at index (0, 0, 93) (up to 1e-05 allowed)
                 # Greatest relative difference: 1.0 at index (3, 19, 4) (up to 0.001 allowed)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -363,6 +363,8 @@ def baddbmm(self, batch1, batch2, beta=1, alpha=1):
     result = torch.bmm(batch1, batch2)
     if not isinstance(alpha, numbers.Number) or alpha != 1:
         result = result * alpha
+    if beta == 0:
+        return result
     if not isinstance(beta, numbers.Number) or beta != 1:
         self = self * beta
     return self + result


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96087
* #96086


For ```torch.baddbmm(input, mat1,mat2, beta=0)```, if ```beta``` is zero, the multiplication of value ```input*beta``` will be ignored for the eager mode(always gets zero number, see https://pytorch.org/docs/stable/generated/torch.baddbmm.html?highlight=torch+baddbmm#torch.baddbmm), but the inductor is not, the inductor will get a different value if the input has a ```nan``` of ```inf``` value:

```
def fn_test(input, mat1, mat2):
    return torch.baddbmm(input, mat1, mat2, beta=0.0)

opt_fn = torch._dynamo.optimize("inductor")(fn_test)
a, b, c = [torch.rand((3,2,2)) for _ in range(3)]

real_out = fn_test(a, b, c)
a[:] = torch.nan
compiled_out = opt_fn(a, b,c)

print(compiled_out)
print(real_out)

```
before this PR, the output will be like this:

```
tensor([[[0.4272, 0.6037],
         [0.4279, 0.4219]],

        [[0.0838, 0.4873],
         [0.1210, 0.5516]],

        [[   nan,    nan],
         [   nan,    nan]]])
tensor([[[0.4272, 0.6037],
         [0.4279, 0.4219]],

        [[0.0838, 0.4873],
         [0.1210, 0.5516]],

        [[0.4985, 0.1072],
         [0.0857, 0.0186]]])

```

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire