### PR TITLE
Error only if autocast actually enabled

### DIFF
--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -230,7 +230,7 @@ class autocast:
                 warnings.warn(error_message)
                 enabled = False
         elif self.device == 'cuda':
-            if self.fast_dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
+            if enabled and self.fast_dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
                 raise RuntimeError('Current CUDA Device does not support bfloat16. Please switch dtype to float16.')
         self._enabled = enabled
 


### PR DESCRIPTION
I am trying to use bfloat16 AMP on a range of devices, using the `enabled` argument to actually enable/disable AMP, like this:
```python
with torch.cuda.amp.autocast(enabled=use_amp, dtype=torch.bfloat16):
```

However, this raises a RuntimeError even if enabled=False.

```
  File "/venv/lib/python3.8/site-packages/torch/amp/autocast_mode.py", line 221, in __init__
    raise RuntimeError('Current CUDA Device does not support bfloat16. Please switch dtype to float16.')
RuntimeError: Current CUDA Device does not support bfloat16. Please switch dtype to float16.
```

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5