### PR TITLE
[CI] Switch inductor integration tests to run on linux.gcp.a100

### DIFF
--- a/.github/workflows/inductor.yml
+++ b/.github/workflows/inductor.yml
@@ -24,10 +24,10 @@ jobs:
       test-matrix: |
         { include: [
           { config: "inductor", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_timm", shard: 1, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_timm", shard: 2, num_shards: 2, runner: "linux.g5.4xlarge.nvidia.gpu" },
-          { config: "inductor_torchbench", shard: 1, num_shards: 1, runner: "linux.g5.4xlarge.nvidia.gpu" },
+          { config: "inductor_huggingface", shard: 1, num_shards: 1, runner: "linux.gcp.a100" },
+          { config: "inductor_timm", shard: 1, num_shards: 2, runner: "linux.gcp.a100" },
+          { config: "inductor_timm", shard: 2, num_shards: 2, runner: "linux.gcp.a100" },
+          { config: "inductor_torchbench", shard: 1, num_shards: 1, runner: "linux.gcp.a100" },
           { config: "inductor_distributed", shard: 1, num_shards: 1, runner: "linux.g5.12xlarge.nvidia.gpu" },
         ]}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96107

Summary: Inductor integration tests have shown annoying flaky failures
that are not reproducible on our A100 dev environment. Switch tests to
run on GCP A100 instance.