### PR TITLE
fix cache_on_self when there are kwargs present

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -225,7 +225,9 @@ def cache_on_self(fn):
     key = f"__{fn.__name__}_cache"
 
     @functools.wraps(fn)
-    def wrapper(self):
+    def wrapper(self, *args, **kwargs):
+        if len(args) > 0 or len(kwargs) > 0:
+            return fn(self, args, kwargs)
         if not hasattr(self, key):
             setattr(self, key, fn(self))
         return getattr(self, key)


### PR DESCRIPTION
Fixes #95939
```
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
TypeError: wrapper() got an unexpected keyword argument 'max_lines'
```


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire