### PR TITLE
address variable size unique_ptr in TensorImpl size checks

### DIFF
--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -1256,4 +1256,9 @@ AutogradMetaFactory* GetAutogradMetaFactory() {
 
 } // namespace impl
 
+// We use a class to encapsulate size-checking logic with
+// templates to capture sizes and flags. We call this within
+// a static assert to prove there is no run-time behaviour.
+static_assert(C10_TensorImpl_Size_Check_Dummy_Class<>::check_sizes());
+
 } // namespace c10

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -3132,13 +3132,10 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
 
     // clang-format off
     are_equal<sizeof(storage_),            8,  FieldNameEnum::storage_>();
-    // On some systems involving NVCC the size of unique_ptr is 16 bytes. We haven't
-    // figured out how to detect those via macro preprocessors yet, so we use <=
-    // comparisons for the relevant fields.
-    is_le<sizeof(autograd_meta_),         16,  FieldNameEnum::autograd_meta_>();
-    is_le<sizeof(extra_meta_),            16,  FieldNameEnum::extra_meta_>();
+    are_equal<sizeof(autograd_meta_),      8,  FieldNameEnum::autograd_meta_>();
+    are_equal<sizeof(extra_meta_),         8,  FieldNameEnum::extra_meta_>();
     are_equal<sizeof(version_counter_),    8,  FieldNameEnum::version_counter_>();
-    are_equal<sizeof(pyobj_slot_),   16,  FieldNameEnum::pyobj_slot_>();
+    are_equal<sizeof(pyobj_slot_),        16,  FieldNameEnum::pyobj_slot_>();
     are_equal<sizeof(sizes_and_strides_), 88,  FieldNameEnum::sizes_and_strides_>();
     are_equal<sizeof(storage_offset_),     8,  FieldNameEnum::storage_offset_>();
     are_equal<sizeof(numel_),              8,  FieldNameEnum::numel_>();
@@ -3152,16 +3149,6 @@ class C10_TensorImpl_Size_Check_Dummy_Class : private TensorImpl {
   }
 #endif
 };
-
-// We use a class to encapsulate size-checking logic with
-// templates to capture sizes and flags. We call this within
-// a static assert to prove there is no run-time behaviour.
-// Since the methods we call return either true or fail their
-// own static_asserts, we should never see the error messages
-// below. We have to provide it though for c++ <17.
-static_assert(
-    C10_TensorImpl_Size_Check_Dummy_Class<>::check_sizes(),
-    "You should not see this message.");
 
 // Clean up after ourselves
 #undef C10_NVCC


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #96117
* __->__ #96116

We move the size checks into the TensorImpl implementation file so
that they are only executed when compiling the TensorImpl class,
rather than anywhere the header is included. This neatly avoids the
problem when compiling it in a .cu file while also improving the
compile-time of the many compilation units that include TensorImpl.h.

Differential Revision: [D43834329](https://our.internmc.facebook.com/intern/diff/D43834329/)