### PR TITLE
[Dynamo] No graph break on namedtuple and potential other functions

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -733,6 +733,12 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         return a - b / c
 
     @make_test
+    def test_namedtuple(a, b):
+        mytuple = collections.namedtuple("mytuple", ["x", "y", "xy"])
+        tmp = mytuple(a, b, a + b)
+        return mytuple(tmp.x, tmp[1], tmp.xy + b)
+
+    @make_test
     def test_is_quantized(a, b):
         if not a.is_quantized:
             return a + b

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -770,11 +770,15 @@ class BuiltinVariable(VariableTracker):
         )
 
     @staticmethod
-    def call_dict_helper(tx, user_cls, arg):
+    def call_dict_helper(tx, user_cls, arg, **options):
         if arg is None:
-            return ConstDictVariable({}, user_cls, mutable_local=MutableLocal())
+            return ConstDictVariable(
+                {}, user_cls, mutable_local=MutableLocal()
+            ).add_options(options)
         elif isinstance(arg, variables.ConstDictVariable):
-            return arg.clone(user_cls=user_cls, mutable_local=MutableLocal())
+            return arg.clone(
+                user_cls=user_cls, mutable_local=MutableLocal()
+            ).add_options(options)
         elif isinstance(
             arg,
             (
@@ -788,7 +792,9 @@ class BuiltinVariable(VariableTracker):
                 k = x.unpack_var_sequence(tx)[0].as_python_constant()
                 v = x.unpack_var_sequence(tx)[1]
                 items.update({k: v})
-            return ConstDictVariable(items, user_cls, mutable_local=MutableLocal())
+            return ConstDictVariable(
+                items, user_cls, mutable_local=MutableLocal()
+            ).add_options(options)
         else:
             raise AssertionError("call_dict_helper with illegal arg")
 

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 import inspect
 import sys
 import types
@@ -12,8 +13,8 @@ from ..bytecode_transformation import create_call_function, create_instruction
 from ..exc import unimplemented
 from ..guards import GuardBuilder
 from ..source import AttrSource
-from ..utils import identity, proxy_args_kwargs
-from .base import VariableTracker
+from ..utils import check_constant_args, identity, proxy_args_kwargs
+from .base import MutableLocal, VariableTracker
 from .functions import (
     NestedUserFunctionVariable,
     UserFunctionVariable,
@@ -797,10 +798,19 @@ class SkipFilesVariable(VariableTracker):
     def as_python_constant(self):
         return self.value
 
+    @staticmethod
+    @functools.lru_cache(None)
+    def fold_through_function_to_wrapper():
+        return {
+            collections.namedtuple: variables.UserDefinedClassVariable,
+        }
+
     def call_function(
         self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
     ) -> "VariableTracker":
         from .builtin import BuiltinVariable
+
+        options = VariableTracker.propagate(self, args, kwargs.values())
 
         if inspect.getattr_static(self.value, "_torchdynamo_disable", False):
             unimplemented(f"call torch._dynamo.disable() wrapped function {self.value}")
@@ -811,7 +821,23 @@ class SkipFilesVariable(VariableTracker):
             and BuiltinVariable.is_supported_call_dict_arg(tx, args[0])
         ):
             return BuiltinVariable.call_dict_helper(
-                tx, collections.OrderedDict, None if len(args) == 0 else args[0]
+                tx,
+                collections.OrderedDict,
+                None if len(args) == 0 else args[0],
+                **options,
+            )
+        # Fold through the functions(e.g, collections.namedtuple)
+        # that inputs & outputs are all python constants
+        elif (
+            self.value in self.fold_through_function_to_wrapper().keys()
+            and check_constant_args(args, kwargs)
+        ):
+            value = self.value(
+                *[x.as_python_constant() for x in args],
+                **{k: v.as_python_constant() for k, v in kwargs.items()},
+            )
+            return self.fold_through_function_to_wrapper().get(self.value)(
+                value, mutable_local=MutableLocal(), **options
             )
         else:
             try:


### PR DESCRIPTION
```collections.namedtuple``` caused 40+ ```dynamo.export``` testing failing in 14k github models.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire