### PR TITLE
[Profiler] Add export_memory_timeline to save memory timeline plot to file

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -17,7 +17,7 @@ from torch._C._profiler import (
     _remove_execution_graph_observer,
 )
 from torch.autograd import kineto_available, ProfilerActivity
-from torch.profiler import _memory_profiler
+from torch.profiler._memory_profiler import MemoryProfile, MemoryProfileTimeline
 
 
 __all__ = [
@@ -92,6 +92,7 @@ class _KinetoProfile:
         self.with_modules = with_modules
         self.experimental_config = experimental_config
         self.profiler: Optional[prof.profile] = None
+        self.mem_tl: Optional[MemoryProfileTimeline] = None
 
     def start(self):
         self.prepare_trace()
@@ -217,14 +218,43 @@ class _KinetoProfile:
             "world_size": dist.get_world_size()
         }
 
-    def _memory_profile(self) -> _memory_profiler.MemoryProfile:
+    def _memory_profile(self) -> MemoryProfile:
         required = ("record_shapes", "profile_memory", "with_stack")
         missing = [f"{i}=True" for i in required if not getattr(self, i)]
         if missing:
             raise ValueError(f"{', '.join(missing)} required for memory profiling.")
 
         assert self.profiler is not None and self.profiler.kineto_results is not None
-        return _memory_profiler.MemoryProfile(self.profiler.kineto_results)
+        return MemoryProfile(self.profiler.kineto_results)
+
+    def export_memory_timeline(self, path: str, device: str = None) -> None:
+        """Extract the memory information from the memory profile collected
+        tree for a given device, and export a timeline plot consisting of
+        [times, [sizes by category]], where times are timestamps and sizes
+        are memory usage for each category. The memory timeline plot will
+        be saved a JSON (by default) or gzipped JSON.
+
+        Input: (path of file, device)
+        Output: File written as JSON or gzipped JSON
+        """
+        # Default to device 0, if unset. Fallback on cpu.
+        if device is None:
+            device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+        # Construct the memory timeline plot data
+        self.mem_tl = MemoryProfileTimeline(self._memory_profile())
+
+        # Depending on the file suffix, save the data as json.gz or json.
+        if path.endswith('.gz'):
+            fp = tempfile.NamedTemporaryFile('w+t', suffix='.json', delete=False)
+            fp.close()
+            self.mem_tl.export_memory_timeline(fp.name, device)
+            with open(fp.name) as fin:
+                with gzip.open(path, 'wt') as fout:
+                    fout.writelines(fin)
+            os.remove(fp.name)
+        else:
+            self.mem_tl.export_memory_timeline(path, device)
 
 
 class ProfilerAction(Enum):


### PR DESCRIPTION
Summary: Added the functionality to export the memory timeline plot as a list of times and sizes, which the post processing visualization can parse and plot.

Test Plan: CI Tests

Reviewed By: leitian, fengxizhou

Differential Revision: D43680760

Pulled By: aaronenyeshi

