### PR TITLE
Use GH cache for sccache on GH mac runners

### DIFF
--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -133,7 +133,7 @@ jobs:
               echo "SCCACHE_GHA_CACHE_TO=${BUILD_ENVIRONMENT}-sccache-${GITHUB_SHA}" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_CACHE_FROM=${BUILD_ENVIRONMENT}-sccache-" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_CACHE_URL=${ACTIONS_CACHE_URL}" >> "${GITHUB_ENV}"
-              echo "SCCACHE_ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "${GITHUB_ENV}"
+              echo "SCCACHE_GHA_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "${GITHUB_ENV}"
             else
               sudo curl --retry 3 --retry-all-errors https://s3.amazonaws.com/ossci-macos/sccache_v2.15 --output /usr/local/bin/sccache
               echo "SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2" >> "${GITHUB_ENV}"

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -132,8 +132,8 @@ jobs:
               rm -rf sccache-v0.4.0-pre.7-x86_64-apple-darwin*
               echo "SCCACHE_GHA_CACHE_TO=${BUILD_ENVIRONMENT}-sccache-${GITHUB_SHA}" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_CACHE_FROM=${BUILD_ENVIRONMENT}-sccache-" >> "${GITHUB_ENV}"
-              echo "SCCACHE_GHA_CACHE_URL=${ACTIONS_CACHE_URL}" >> "${GITHUB_ENV}"
-              echo "SCCACHE_GHA_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "${GITHUB_ENV}"
+              echo "ACTIONS_CACHE_URL=${ACTIONS_CACHE_URL}" >> "${GITHUB_ENV}"
+              echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_ENABLED=on" >> "${GITHUB_ENV}"
             else
               sudo curl --retry 3 --retry-all-errors https://s3.amazonaws.com/ossci-macos/sccache_v2.15 --output /usr/local/bin/sccache

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -44,6 +44,11 @@ on:
           An option JSON description of what test configs to run later on. This
           is moved here from the Linux test workflow so that we can apply filter
           logic using test-config labels earlier and skip unnecessary builds
+      sccache-use-gha:
+        required: false
+        type: boolean
+        default: false
+        description: If true, use the Github cache as the storage option for sccache instead of S3.
 
     outputs:
       test-matrix:
@@ -71,6 +76,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
       BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
+      SCCACHE_USE_GHA: ${{ inputs.sccache-use-gha }}  # this is placed here instead of the sccache step to appease actionlint
     outputs:
       build-outcome: ${{ steps.build.outcome }}
     steps:
@@ -119,10 +125,21 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 90
           command: |
-            sudo curl --retry 3 --retry-all-errors https://s3.amazonaws.com/ossci-macos/sccache_v2.15 --output /usr/local/bin/sccache
+            if [[ "${SCCACHE_USE_GHA}" == "true" ]]; then
+              sudo curl --retry 3 --retry-all-errors -OL https://github.com/mozilla/sccache/releases/download/v0.3.3/sccache-v0.3.3-x86_64-apple-darwin.tar.gz
+              tar -xvf sccache-v0.3.3-x86_64-apple-darwin.tar.gz
+              cp sccache-v0.3.3-x86_64-apple-darwin/sccache /usr/local/bin/
+              rm -rf sccache-v0.3.3-x86_64-apple-darwin*
+              echo "SCCACHE_GHA_CACHE_TO=${BUILD_ENVIRONMENT}-sccache-${GITHUB_SHA}" >> "${GITHUB_ENV}"
+              echo "SCCACHE_GHA_CACHE_FROM=${BUILD_ENVIRONMENT}-sccache-" >> "${GITHUB_ENV}"
+              echo "SCCACHE_GHA_CACHE_URL=${ACTIONS_CACHE_URL}" >> "${GITHUB_ENV}"
+              echo "SCCACHE_ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "${GITHUB_ENV}"
+            else
+              sudo curl --retry 3 --retry-all-errors https://s3.amazonaws.com/ossci-macos/sccache_v2.15 --output /usr/local/bin/sccache
+              echo "SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2" >> "${GITHUB_ENV}"
+              echo "SCCACHE_S3_KEY_PREFIX=${GITHUB_WORKFLOW}" >> "${GITHUB_ENV}"
+            fi
             sudo chmod +x /usr/local/bin/sccache
-            echo "SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2" >> "${GITHUB_ENV}"
-            echo "SCCACHE_S3_KEY_PREFIX=${GITHUB_WORKFLOW}" >> "${GITHUB_ENV}"
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -126,10 +126,7 @@ jobs:
           retry_wait_seconds: 90
           command: |
             if [[ "${SCCACHE_USE_GHA}" == "true" ]]; then
-              sudo curl --retry 3 --retry-all-errors -OL https://github.com/mozilla/sccache/releases/download/v0.4.0-pre.7/sccache-v0.4.0-pre.7-x86_64-apple-darwin.tar.gz
-              tar -xvf sccache-v0.4.0-pre.7-x86_64-apple-darwin.tar.gz
-              cp sccache-v0.4.0-pre.7-x86_64-apple-darwin/sccache /usr/local/bin/
-              rm -rf sccache-v0.4.0-pre.7-x86_64-apple-darwin*
+              sudo curl --retry 3 --retry-all-errors https://s3.amazonaws.com/ossci-macos/sccache_v0.4.0-pre.7 --output /usr/local/bin/sccache
               echo "ACTIONS_CACHE_URL=${ACTIONS_CACHE_URL}" >> "${GITHUB_ENV}"
               echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_ENABLED=on" >> "${GITHUB_ENV}"

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -126,7 +126,7 @@ jobs:
           retry_wait_seconds: 90
           command: |
             if [[ "${SCCACHE_USE_GHA}" == "true" ]]; then
-              sudo curl --retry 3 --retry-all-errors -OL https://github.com/mozilla/sccache/releases/download/v0.3.3/sccache-v0.3.3-x86_64-apple-darwin.tar.gz
+              sudo curl --retry 3 --retry-all-errors -OL https://github.com/mozilla/sccache/releases/download/v0.4.0-pre.7/sccache-v0.4.0-pre.7-x86_64-apple-darwin.tar.gz
               tar -xvf sccache-v0.3.3-x86_64-apple-darwin.tar.gz
               cp sccache-v0.3.3-x86_64-apple-darwin/sccache /usr/local/bin/
               rm -rf sccache-v0.3.3-x86_64-apple-darwin*

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -130,8 +130,6 @@ jobs:
               tar -xvf sccache-v0.4.0-pre.7-x86_64-apple-darwin.tar.gz
               cp sccache-v0.4.0-pre.7-x86_64-apple-darwin/sccache /usr/local/bin/
               rm -rf sccache-v0.4.0-pre.7-x86_64-apple-darwin*
-              echo "SCCACHE_GHA_CACHE_TO=${BUILD_ENVIRONMENT}-sccache-${GITHUB_SHA}" >> "${GITHUB_ENV}"
-              echo "SCCACHE_GHA_CACHE_FROM=${BUILD_ENVIRONMENT}-sccache-" >> "${GITHUB_ENV}"
               echo "ACTIONS_CACHE_URL=${ACTIONS_CACHE_URL}" >> "${GITHUB_ENV}"
               echo "ACTIONS_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_ENABLED=on" >> "${GITHUB_ENV}"

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -127,13 +127,14 @@ jobs:
           command: |
             if [[ "${SCCACHE_USE_GHA}" == "true" ]]; then
               sudo curl --retry 3 --retry-all-errors -OL https://github.com/mozilla/sccache/releases/download/v0.4.0-pre.7/sccache-v0.4.0-pre.7-x86_64-apple-darwin.tar.gz
-              tar -xvf sccache-v0.3.3-x86_64-apple-darwin.tar.gz
-              cp sccache-v0.3.3-x86_64-apple-darwin/sccache /usr/local/bin/
-              rm -rf sccache-v0.3.3-x86_64-apple-darwin*
+              tar -xvf sccache-v0.4.0-pre.7-x86_64-apple-darwin.tar.gz
+              cp sccache-v0.4.0-pre.7-x86_64-apple-darwin/sccache /usr/local/bin/
+              rm -rf sccache-v0.4.0-pre.7-x86_64-apple-darwin*
               echo "SCCACHE_GHA_CACHE_TO=${BUILD_ENVIRONMENT}-sccache-${GITHUB_SHA}" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_CACHE_FROM=${BUILD_ENVIRONMENT}-sccache-" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_CACHE_URL=${ACTIONS_CACHE_URL}" >> "${GITHUB_ENV}"
               echo "SCCACHE_GHA_RUNTIME_TOKEN=${ACTIONS_RUNTIME_TOKEN}" >> "${GITHUB_ENV}"
+              echo "SCCACHE_GHA_ENABLED=on" >> "${GITHUB_ENV}"
             else
               sudo curl --retry 3 --retry-all-errors https://s3.amazonaws.com/ossci-macos/sccache_v2.15 --output /usr/local/bin/sccache
               echo "SCCACHE_BUCKET=ossci-compiler-cache-circleci-v2" >> "${GITHUB_ENV}"

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -179,6 +179,7 @@ jobs:
       xcode-version: "13.3.1"
       runner-type: macos-12-xl
       build-generates-artifacts: true
+      sccache-use-gha: true
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 3, runner: "macos-12" },
@@ -210,6 +211,7 @@ jobs:
       xcode-version: "13.3.1"
       runner-type: macos-12-xl
       build-generates-artifacts: false
+      sccache-use-gha: true
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 1, runner: "macos-12" },

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -191,17 +191,17 @@ jobs:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
-  macos-12-py3-x86-64-test:
-    name: macos-12-py3-x86-64
-    uses: ./.github/workflows/_mac-test.yml
-    needs: macos-12-py3-x86-64-build
-    with:
-      build-environment: macos-12-py3-x86-64
-      test-matrix: ${{ needs.macos-12-py3-x86-64-build.outputs.test-matrix }}
-      arch: x86_64
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
+  # macos-12-py3-x86-64-test:
+  #   name: macos-12-py3-x86-64
+  #   uses: ./.github/workflows/_mac-test.yml
+  #   needs: macos-12-py3-x86-64-build
+  #   with:
+  #     build-environment: macos-12-py3-x86-64
+  #     test-matrix: ${{ needs.macos-12-py3-x86-64-build.outputs.test-matrix }}
+  #     arch: x86_64
+  #   secrets:
+  #     AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
+  #     AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
   macos-12-py3-x86-64-lite-interpreter-build-test:
     name: macos-12-py3-x86-64-lite-interpreter

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -191,17 +191,17 @@ jobs:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
-  # macos-12-py3-x86-64-test:
-  #   name: macos-12-py3-x86-64
-  #   uses: ./.github/workflows/_mac-test.yml
-  #   needs: macos-12-py3-x86-64-build
-  #   with:
-  #     build-environment: macos-12-py3-x86-64
-  #     test-matrix: ${{ needs.macos-12-py3-x86-64-build.outputs.test-matrix }}
-  #     arch: x86_64
-  #   secrets:
-  #     AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-  #     AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
+  macos-12-py3-x86-64-test:
+    name: macos-12-py3-x86-64
+    uses: ./.github/workflows/_mac-test.yml
+    needs: macos-12-py3-x86-64-build
+    with:
+      build-environment: macos-12-py3-x86-64
+      test-matrix: ${{ needs.macos-12-py3-x86-64-build.outputs.test-matrix }}
+      arch: x86_64
+    secrets:
+      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
+      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
   macos-12-py3-x86-64-lite-interpreter-build-test:
     name: macos-12-py3-x86-64-lite-interpreter


### PR DESCRIPTION
sccache added GH cache as a storage option, so try to use it for the GH provided mac runners.

My experiments with this are varied.  I tried a couple of different releases and the first run with a cold cache took 1hr (v0.3.3), 1hr (v0.4.0 pre7), 2hr (v0.3.3).  

Afterwards it usually takes 30 minutes but sometimes longer, but no longer than 1hr.

I am using v0.4.0 pre7 because they reduced the amount of configuration/env vars you need to set and the GH cache keys get managed by sccache.