### PR TITLE
Add option to pass dynamo config to make_fx

### DIFF
--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -736,6 +736,7 @@ def export(
             decomposition_table=decomposition_table,
             tracing_mode=tracing_mode,
             _allow_non_fake_inputs=True,
+            _is_dynamo_frontend=True,
         )(*graph_captured_input)
 
     new_graph = ChangeInputOutputSignature(


### PR DESCRIPTION
Differential Revision: D43853035

We currently have no way to pass dynamo specific flags to make_fx. This PR attempts to do that by providing extra flag in make_fx. 


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire