### PR TITLE
Prevent segfault when `_neg_view` is invoked on a quantized tensor

### DIFF
--- a/aten/src/ATen/native/MathBitFallThroughLists.h
+++ b/aten/src/ATen/native/MathBitFallThroughLists.h
@@ -63,7 +63,13 @@ namespace at {
   m.impl("size.Dimname", torch::CppFunction::makeFallthrough()); \
   m.impl("is_complex", torch::CppFunction::makeFallthrough()); \
   m.impl("is_floating_point", torch::CppFunction::makeFallthrough()); \
-  m.impl("requires_grad_", torch::CppFunction::makeFallthrough());
+  m.impl("requires_grad_", torch::CppFunction::makeFallthrough()); \
+  m.impl("qscheme", torch::CppFunction::makeFallthrough()); \
+  m.impl("q_scale", torch::CppFunction::makeFallthrough()); \
+  m.impl("q_zero_point", torch::CppFunction::makeFallthrough()); \
+  m.impl("q_per_channel_scales", torch::CppFunction::makeFallthrough()); \
+  m.impl("q_per_channel_zero_points", torch::CppFunction::makeFallthrough()); \
+  m.impl("q_per_channel_axis", torch::CppFunction::makeFallthrough());
 }
 
 #define TORCH_VIEW_FNS_NATIVE_FN_REGISTRATION(m) \


### PR DESCRIPTION
Fixes #88484 

Two options -

- [ ] Display a runtime error instead:
```
RuntimeError: "neg_cpu" not implemented for 'QUInt8'
```
In this case, would also add an `expected failure` UT based on the example in #88484 
 
 OR
 
 - [ ] Add `qneg_kernel` for quantized tensors in `QuantizedOpKernels.cpp` to fully support `_neg_view` for quantized tensors
   OR add the corresponding code in `neg_kernel` (as in `copy_kernel`, use `isQIntType`, and add corresponding code).
   `neg` seems intuitive for symmetrically quantized tensors. Need to think a bit about asymmetric quantization
   Tests: ?