### PR TITLE
Retry CI Android emulator test

### DIFF
--- a/android/common.sh
+++ b/android/common.sh
@@ -10,6 +10,10 @@ if [ -z "$PYTORCH_DIR" ]; then
   exit 1
 fi
 
+retry () {
+    "$@" || (sleep 10 && "$@") || (sleep 20 && "$@") || (sleep 40 && "$@")
+}
+
 check_android_sdk() {
   if [ -z "$ANDROID_HOME" ]; then
     echo "ANDROID_HOME not set; please set it to Android sdk directory"

--- a/android/run_tests.sh
+++ b/android/run_tests.sh
@@ -49,7 +49,8 @@ echo "Waiting for emulator boot completed"
 $ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;'
 
 {
-  $GRADLE_PATH -PABI_FILTERS=x86 -p $PYTORCH_ANDROID_DIR connectedAndroidTest
+  # The test currently takes about 10 minutes
+  retry $GRADLE_PATH -PABI_FILTERS=x86 -p $PYTORCH_ANDROID_DIR connectedAndroidTest
 } || {
   echo "::error::Check https://github.com/pytorch/pytorch/tree/master/test/mobile/model_test to see how to fix the failed mobile test"
   exit 1


### PR DESCRIPTION
This is not the first time I spot Android test flakiness such as
https://hud.pytorch.org/pytorch/pytorch/commit/893aa5df3f2a475c91ea8eadb1353812e52fb227.  From some StackOverflow results, it looks like the failure `Unknown failure: Error: Could not access the Package Manager.  Is the system running?` could be fixed by waiting a bit for the emulator to start fully https://stackoverflow.com/questions/15524185/could-not-access-the-package-manager-is-the-system-running-while-installing-and

So, I'm adding retry capability here to give the test another chance.