### PR TITLE
[MPS] Add type promotion to `torch.addcmul`

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -404,6 +404,9 @@ MPSGraphTensor* mpsGraphScalarPlaceHolder(MPSGraph *mpsGraph, const Scalar& scal
 // this is meant to suppress the availability warning on castTensor
 // we pass ScalarType instead of MPSDataType to handle MPSDataTypeBoolean's availability too
 MPSGraphTensor* castMPSTensor(MPSGraph *mpsGraph, MPSGraphTensor* tensor, MPSDataType toType) {
+  if ([tensor dataType] == toType) {
+    return tensor;
+  }
   return [mpsGraph castTensor:tensor toType:toType name:@"castTensor"];
 }
 

--- a/aten/src/ATen/native/mps/operations/PointwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/PointwiseOps.mm
@@ -1,26 +1,27 @@
 //  Copyright © 2022 Apple Inc.
 
 #include <ATen/native/mps/OperationUtils.h>
+#include "c10/core/ScalarType.h"
 
 namespace at::native {
 // scope the MPS's internal methods to not expose them to at::native
 namespace mps {
 
-Tensor& addc_mul_div_out_mps(const Tensor& self,
+void addc_mul_div_out_mps(const Tensor& self,
                              const Tensor& tensor1,
                              const Tensor& tensor2,
                              const Scalar& value_opt, // default value = 1.0
-                             Tensor& output,
+                             const Tensor& output,
                              const bool is_div,
                              const string op_name)
 {
   if (value_opt.toDouble() == 0.0) {
     output.copy_(self);
-    return output;
+    return;
   }
 
   if(output.numel() == 0) {
-    return output;
+    return;
   }
 
   MPSStream* mpsStream = getCurrentMPSStream();
@@ -38,10 +39,11 @@ Tensor& addc_mul_div_out_mps(const Tensor& self,
 
     CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
-    if(!cachedGraph) {
+    if (!cachedGraph) {
         cachedGraph = cache_->CreateCachedGraphAs<CachedGraph>(key, ^ MPSCachedGraph * () {
 
           CachedGraph* newCachedGraph = nil;
+          ScalarType common_dtype = c10::promoteTypes(self.scalar_type(), c10::promoteTypes(tensor1.scalar_type(), tensor2.scalar_type()));
           @autoreleasepool {
             MPSGraph* mpsGraph = make_mps_graph();
             newCachedGraph = new CachedGraph(mpsGraph);
@@ -53,22 +55,25 @@ Tensor& addc_mul_div_out_mps(const Tensor& self,
 
             // the tensor to be optionally multiplied by value_scalar
             MPSGraphTensor *multiplicandTensor = nil;
+            auto firstTensor = castMPSTensor(mpsGraph, newCachedGraph->firstTensor, common_dtype);
+            auto secondTensor = castMPSTensor(mpsGraph, newCachedGraph->secondTensor, common_dtype);
             if (is_div) {
-              multiplicandTensor = [mpsGraph divisionWithPrimaryTensor:newCachedGraph->firstTensor
-                                                       secondaryTensor:newCachedGraph->secondTensor
+              multiplicandTensor = [mpsGraph divisionWithPrimaryTensor:firstTensor
+                                                       secondaryTensor:secondTensor
                                                                   name:nil];
             } else {
-              multiplicandTensor = [mpsGraph multiplicationWithPrimaryTensor:newCachedGraph->firstTensor
-                                                             secondaryTensor:newCachedGraph->secondTensor
+              multiplicandTensor = [mpsGraph multiplicationWithPrimaryTensor:firstTensor
+                                                             secondaryTensor:secondTensor
                                                                         name:nil];
             }
             // the tensor to be added to input_tensor
             MPSGraphTensor *addendTensor = [mpsGraph multiplicationWithPrimaryTensor:multiplicandTensor
-                                                      secondaryTensor:newCachedGraph->valueTensor
+                                                      secondaryTensor:castMPSTensor(mpsGraph, newCachedGraph->valueTensor, common_dtype)
                                                                 name:nil];
-            newCachedGraph->outputTensor = [mpsGraph additionWithPrimaryTensor:newCachedGraph->inputTensor
-                                                               secondaryTensor:addendTensor
-                                                                          name:nil];
+            auto outputTensor = [mpsGraph additionWithPrimaryTensor:castMPSTensor(mpsGraph, newCachedGraph->inputTensor, common_dtype)
+                                                    secondaryTensor:addendTensor
+                                                               name:nil];
+            newCachedGraph->outputTensor = castMPSTensor(mpsGraph, outputTensor, output.scalar_type());
           }
           return newCachedGraph;
       });
@@ -95,8 +100,6 @@ Tensor& addc_mul_div_out_mps(const Tensor& self,
 
     runMPSGraph(mpsStream, cachedGraph->graph(), feeds, results);
   }
-
-  return output;
 }
 
 } // namespace mps
@@ -105,13 +108,13 @@ Tensor& addc_mul_div_out_mps(const Tensor& self,
 TORCH_IMPL_FUNC(addcmul_out_mps)
 (const Tensor& self, const Tensor& tensor1, const Tensor& tensor2, const Scalar& value, const Tensor& output)
 {
-  mps::addc_mul_div_out_mps(self, tensor1, tensor2, value, const_cast<Tensor&>(output), false, "addcmul_out_mps");
+  mps::addc_mul_div_out_mps(self, tensor1, tensor2, value, output, false, "addcmul_out_mps");
 }
 
 TORCH_IMPL_FUNC(addcdiv_out_mps)
 (const Tensor& self, const Tensor& tensor1, const Tensor& tensor2, const Scalar& value, const Tensor& output)
 {
-  mps::addc_mul_div_out_mps(self, tensor1, tensor2, value, const_cast<Tensor&>(output), true, "addcdiv_out_mps");
+  mps::addc_mul_div_out_mps(self, tensor1, tensor2, value, output, true, "addcdiv_out_mps");
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/PointwiseOps.mm
+++ b/aten/src/ATen/native/mps/operations/PointwiseOps.mm
@@ -1,7 +1,6 @@
 //  Copyright © 2022 Apple Inc.
 
 #include <ATen/native/mps/OperationUtils.h>
-#include "c10/core/ScalarType.h"
 
 namespace at::native {
 // scope the MPS's internal methods to not expose them to at::native

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1846,15 +1846,15 @@ class TestMPS(TestCaseMPS):
 
     # Test addcmul
     def test_addcmul(self):
-        def helper(shape, value):
+        def helper(shape, value, xtype=torch.float32, ytype=torch.float32, ztype=torch.float32):
 
-            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
+            cpu_x = torch.randn(shape, device='cpu', dtype=xtype, requires_grad=False)
             x = cpu_x.detach().clone().to('mps')
 
-            cpu_y = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
+            cpu_y = torch.randn(shape, device='cpu', dtype=ytype, requires_grad=False)
             y = cpu_y.detach().clone().to('mps')
 
-            cpu_z = torch.randn(shape, device='cpu', dtype=torch.float, requires_grad=False)
+            cpu_z = torch.randn(shape, device='cpu', dtype=ztype, requires_grad=False)
             z = cpu_z.detach().clone().to('mps')
 
             y = torch.addcmul(x, y, z, value=value)
@@ -1866,6 +1866,10 @@ class TestMPS(TestCaseMPS):
         helper((2, 8, 4, 5), 0.1)
         helper((2, 3, 4, 5), 0.2)
         helper((2, 8, 4, 5), 0.2)
+        # Mixed types
+        helper((2, 2), 1.0, xtype=torch.float16)
+        helper((3, 2), 1.0, ytype=torch.float16)
+        helper((2, 3), 1.0, ztype=torch.float16)
 
     # Test addcdiv
     def test_addcdiv(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1846,15 +1846,19 @@ class TestMPS(TestCaseMPS):
 
     # Test addcmul
     def test_addcmul(self):
-        def helper(shape, value, xtype=torch.float32, ytype=torch.float32, ztype=torch.float32):
+        def helper(shape, value, xtype=torch.float32, ytype=None, ztype=None):
+            def rand_helper(dtype):
+                if dtype.is_floating_point:
+                    return torch.randn(shape, device='cpu', dtype=dtype, requires_grad=False)
+                return torch.randint(10, shape, dtype=dtype, device='cpu', requires_grad=False)
 
-            cpu_x = torch.randn(shape, device='cpu', dtype=xtype, requires_grad=False)
+            cpu_x = rand_helper(xtype)
             x = cpu_x.detach().clone().to('mps')
 
-            cpu_y = torch.randn(shape, device='cpu', dtype=ytype, requires_grad=False)
+            cpu_y = rand_helper(ytype if ytype is not None else xtype)
             y = cpu_y.detach().clone().to('mps')
 
-            cpu_z = torch.randn(shape, device='cpu', dtype=ztype, requires_grad=False)
+            cpu_z = rand_helper(ztype if ztype is not None else xtype)
             z = cpu_z.detach().clone().to('mps')
 
             y = torch.addcmul(x, y, z, value=value)
@@ -1866,10 +1870,16 @@ class TestMPS(TestCaseMPS):
         helper((2, 8, 4, 5), 0.1)
         helper((2, 3, 4, 5), 0.2)
         helper((2, 8, 4, 5), 0.2)
+        # Integral types
+        helper((2, 2), 1.0, xtype=torch.int32)
+        helper((2, 2), 2.0, xtype=torch.int16)
+
         # Mixed types
-        helper((2, 2), 1.0, xtype=torch.float16)
+        helper((2, 2), 1.0, xtype=torch.float16, ytype=torch.float32)
         helper((3, 2), 1.0, ytype=torch.float16)
         helper((2, 3), 1.0, ztype=torch.float16)
+        helper((2, 2), 1.0, xtype=torch.int32, ytype=torch.int16, ztype=torch.uint8)
+        helper((2, 2), 1.0, ytype=torch.int16, ztype=torch.uint8)
 
     # Test addcdiv
     def test_addcdiv(self):


### PR DESCRIPTION
Fixes crash while running something like `python -c "import torch;x=torch.rand(3, 3, dtype=torch.float16, device='mps');y=x.addcmul(torch.ones(3, device='mps'), torch.ones(3, device='mps'));print(y)"`

Modify `castMPSTensor` to become a no-op if cast is not needed

Define `common_dtype` as `c10::promoType` between self, tensor1 and
tensor2. Cast to any output type.

Add mixed-types test to `TestMPS.test_addcmul`, though it does not cover
all the permutations

Discovered while looking at https://github.com/pytorch/pytorch/issues/96113


cc @nairbv @mruberry