### PR TITLE
Upload torch dynamo performance stats to S3 before Rockset

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -2,7 +2,7 @@ name: Upload test stats
 
 on:
   workflow_run:
-    workflows: [pull, trunk, periodic, inductor, inductor-A100-perf]
+    workflows: [pull, trunk, periodic, inductor]
     types:
       - completed
 

--- a/.github/workflows/upload-torch-dynamo-perf-stats.yml
+++ b/.github/workflows/upload-torch-dynamo-perf-stats.yml
@@ -39,7 +39,21 @@ jobs:
       - run: |
           pip3 install requests==2.26 rockset==1.0.3 boto3==1.19.12
 
+      - name: Upload torch dynamo performance stats to S3
+        id: upload-s3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_ARTIFACTS_URL: ${{ github.event.workflow_run.artifacts_url }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          REPO_FULLNAME: ${{ github.event.workflow_run.repository.full_name }}
+        run: |
+          # Upload perf test reports from GHA to S3, which can now be downloaded
+          # on HUD
+          python3 -m tools.stats.upload_artifacts --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --repo "${REPO_FULLNAME}"
+
       - name: Upload torch dynamo performance stats to Rockset
+        if: steps.upload-s3.outcome && steps.upload-s3.outcome == 'success'
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
I have a minor tweak on the uploading workflow to upload to S3 first before Rockset as `upload-test-stats` and  `upload-torch-dynamo-perf-stats` both run when inductor-A100-perf finished.  There is a potential race condition where the test reports are not yet no S3 when `upload-torch-dynamo-perf-stats` runs (it gets the data from S3).  `inductor-A100-perf` is now handled exclusively by `upload-torch-dynamo-perf-stats` to avoid this.  It will upload test reports to S3 first before getting them to Rockset.

The uploading script works fine with the test reports from https://hud.pytorch.org/pr/95685.