### PR TITLE
make index_put to support assign from other type value

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -982,6 +982,7 @@ class TestIndexing(TestCase):
         src[[0, 2, 1], :, :] = res
         self.assertEqual(res.shape, src.shape)
 
+    @skipXLA
     @dtypes(torch.float, torch.bfloat16, torch.long, torch.bool)
     @dtypesIfCPU(torch.float, torch.long, torch.bfloat16, torch.bool)
     @dtypesIfCUDA(torch.half, torch.long, torch.bfloat16, torch.bool)

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -10,7 +10,7 @@ from torch.testing._internal.common_utils import (TestCase, run_tests, load_test
                                                   TEST_NUMPY, set_default_dtype, torch_to_numpy_dtype_dict,
                                                   numpy_to_torch_dtype_dict, skipIfTorchDynamo)
 from torch.testing._internal.common_device_type import (instantiate_device_type_tests, onlyNativeDeviceTypes,
-                                                        dtypes, onlyCPU, expectedFailureMeta, skipMeta)
+                                                        dtypes, onlyCPU, skipMeta)
 from torch.testing._internal.common_dtype import (
     all_types_and_complex_and, get_all_math_dtypes, floating_types, get_all_dtypes
 )
@@ -685,15 +685,6 @@ class TestTypePromotion(TestCase):
     def test_promote_self(self, device):
         for dtype in all_types_and_complex_and(torch.half, torch.bfloat16, torch.chalf, torch.bool):
             self.assertEqual(torch.promote_types(dtype, dtype), dtype)
-
-    @expectedFailureMeta
-    @float_double_default_dtype
-    def test_indexing_fail(self, device):
-        # https://github.com/pytorch/pytorch/issues/28010
-        a = torch.ones(5, 2, dtype=torch.double, device=device)
-        b = torch.zeros(5, dtype=torch.int, device=device)
-        with self.assertRaises(RuntimeError):
-            a[:, [1]] = b.unsqueeze(-1)
 
     @float_double_default_dtype
     def test_indexing(self, device):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96177

numpy index_put can asign any type value to src, but pytorch always asser a error if the value's dype is not same with src: **RuntimeError: Index put requires the source and destination dtypes match, got Float for the destination and Double for the source.**

see the following case, numpy works fine.
```
>>> import torch
>>> x = torch.zeros((3,3,3), dtype=torch.float32)
>>> y = torch.tensor(5, dtype=torch.float64)
>>> x_numpy = x.numpy()
>>> x_numpy[[0,1,2],:,1]=y.numpy()
>>> x_numpy[[0,1,2],:,1]=y.int().numpy()
```
but pytorch reports error. I think Pytorch should also support such behavior. Thanks!
