### PR TITLE
Correctly pass $@ to the runner benchmark script

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -305,7 +305,7 @@ test_single_dynamo_benchmark() {
     # MKL_THREADING_LAYER=GNU to mitigate https://github.com/pytorch/pytorch/issues/37377
     MKL_THREADING_LAYER=GNU python benchmarks/dynamo/runner.py --suites="$suite" \
       --base-sha="$BASE_SHA" --output-dir="$TEST_REPORTS_DIR" "${partition_flags[@]}" \
-      --no-graphs --no-update-archive --no-gh-comment
+      --no-graphs --no-update-archive --no-gh-comment "$@"
   else
     python "benchmarks/dynamo/$suite.py" \
       --ci --accuracy --timing --explain \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96190

Alternative to https://github.com/pytorch/pytorch/pull/96168

Signed-off-by: Edward Z. Yang <ezyang@meta.com>