### PR TITLE
Properly avoid wrapping numbers as tensors before backend

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -835,7 +835,7 @@ class VariableBuilder:
                     GraphArg(
                         self.get_source(),
                         wrapped_value,
-                        True,
+                        isinstance(wrapped_value, torch.Tensor),
                         fake_tensor_value,
                         is_tensor=False,
                     )

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -462,9 +462,7 @@ class SizeVarAllocator:
             shape = self.simplify(shape)
             if shape in needed:
                 needed.remove(shape)
-                code.writeline(
-                    f"{self.declare}{shape} = {name}.item() if isinstance({name}, torch.Tensor) else {name}{self.ending}"
-                )
+                code.writeline(f"{self.declare}{shape} = {name}{self.ending}")
 
         for name, value in graph_inputs_tensors:
             shapes = value.get_size()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96193

This partially reverts https://github.com/pytorch/pytorch/pull/96051 with a proper fix.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire