### PR TITLE
[PyTorch] Optimize TupleType::annotation_str_impl

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -887,26 +887,28 @@ std::string TupleType::str() const {
   return ss.str();
 }
 std::string TupleType::annotation_str_impl(TypePrinter printer) const {
-  std::stringstream ss;
   if (schema_ && name()) {
-    ss << name()->qualifiedName();
-  } else {
-    ss << "Tuple[";
-    if (elements().empty()) {
-      // `typing.Tuple` special-cases the annotation syntax for empty tuple
-      // with `typing.Tuple[()]`. See
-      // https://docs.python.org/3/library/typing.html#typing.Tuple
-      ss << "()";
-    } else {
-      for (size_t i = 0; i < elements().size(); ++i) {
-        if (i > 0)
-          ss << ", ";
-        ss << elements()[i]->annotation_str(printer);
-      }
-    }
-    ss << "]";
+    return name()->qualifiedName();
   }
-  return ss.str();
+
+  if (elements().empty()) {
+    // `typing.Tuple` special-cases the annotation syntax for empty tuple
+    // with `typing.Tuple[()]`. See
+    // https://docs.python.org/3/library/typing.html#typing.Tuple
+    return "Tuple[()]";
+  }
+
+  std::ostringstream ss("Tuple[");
+  size_t i = 0;
+  for (const auto& element: elements()) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << element->annotation_str(printer);
+    i++;
+  }
+  ss << ']';
+  return std::move(ss).str();
 }
 
 InterfaceTypePtr InterfaceType::create(QualifiedName qualifiedName, bool is_module) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96215
* #96214

stringstream is expensive to create, we used stringstream instead of ostringstream, and we can easily specialize the empty tuple. Also, anybody compiling with C++20 support can move out of the stringstream and it shouldn't hurt people without C++20 support to do so. I would consider specializing the 1-element case as well but I don't have evidence that that's necessary right now.

Differential Revision: [D43882402](https://our.internmc.facebook.com/intern/diff/D43882402/)