### PR TITLE
Switch reduce_scatter and all_gather in DeviceMesh to use functional collectives

### DIFF
--- a/test/distributed/_spmd/test_tracing.py
+++ b/test/distributed/_spmd/test_tracing.py
@@ -141,20 +141,14 @@ class TraceDeviceMeshTestBase:
                 get_global_rank(dim_group, i) for i in range(dim_group_size)
             ]
 
-            gathered_list = [
-                torch.empty_like(local_tensor) for _ in range(dim_group_size)
-            ]
-
-            def fn(gathered_list: List[torch.Tensor], tensor: torch.Tensor):
-                gathered_list = [CommTensor(t) for t in gathered_list]
-                tensor = CommTensor(tensor)
-                mesh.all_gather(gathered_list, tensor, mesh_dim=dim)
-                return [t * 1 for t in gathered_list]
+            def fn(tensor: torch.Tensor):
+                big_tensor = mesh.all_gather(tensor, mesh_dim=dim)
+                return list(torch.chunk(big_tensor, dim_group_size))
 
             # use a local_tensor + 1 for tracing to make sure that we are not
             # simply replaying recorded tensor value
-            traced_fn = make_fx(fn)(gathered_list, local_tensor + 1)
-            gathered_list = traced_fn(gathered_list, local_tensor)
+            traced_fn = make_fx(fn)(local_tensor + 1)
+            gathered_list = traced_fn(local_tensor)
 
             self.assertEqual(len(gathered_list), dim_group_size)
             for idx, gathered_tensor in enumerate(gathered_list):

--- a/test/distributed/_tensor/test_device_mesh.py
+++ b/test/distributed/_tensor/test_device_mesh.py
@@ -240,9 +240,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
             )
             local_tensor = tensor_padded_list[my_rank]
             big_tensor = device_mesh.all_gather(
-                local_tensor,
-                mesh_dim=0,
-                gather_dim=shard_dim
+                local_tensor, mesh_dim=0, gather_dim=shard_dim
             )
             if pad_idx != 0:
                 big_tensor = shard_placement._unpad_concat_tensor(
@@ -261,7 +259,9 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
             input_size[dim] *= self.world_size
             input_tensor = torch.ones(input_size, device=self.device_type) * self.rank
             res_num = ((0 + self.world_size - 1) * self.world_size) / 2
-            scattered_tensor = mesh.reduce_scatter(input_tensor, mesh_dim=0, scatter_dim=dim)
+            scattered_tensor = mesh.reduce_scatter(
+                input_tensor, mesh_dim=0, scatter_dim=dim
+            )
             self.assertEqual(scattered_tensor, torch.ones(3, 3) * res_num)
 
     @with_comms
@@ -290,11 +290,12 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
 
             res_num = ((0 + self.world_size - 1) * self.world_size) / 2
 
-            scattered_tensor = device_mesh.reduce_scatter(tensor_to_reduce, mesh_dim=0, scatter_dim=shard_dim)
+            scattered_tensor = device_mesh.reduce_scatter(
+                tensor_to_reduce, mesh_dim=0, scatter_dim=shard_dim
+            )
 
             if pad_idx <= device_mesh.get_coordinate()[0]:
                 scattered_tensor = shard_placement._unpad_tensor(scattered_tensor)
-
 
             self.assertEqual(
                 scattered_tensor.size(), tensor_splitted_list[my_rank].size()
@@ -335,7 +336,9 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
             input_tensor = torch.ones(input_size, device=self.device_type) * self.rank
             global_ranks = get_process_group_ranks(dim_group)
 
-            scattered_tensor = mesh.reduce_scatter(input_tensor, mesh_dim=dim, scatter_dim=dim)
+            scattered_tensor = mesh.reduce_scatter(
+                input_tensor, mesh_dim=dim, scatter_dim=dim
+            )
 
             res_num = torch.sum(torch.tensor(global_ranks))
             self.assertEqual(scattered_tensor, torch.ones(3, 3, 3) * res_num)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3010,5 +3010,8 @@
 - name: all_gather_into_tensor(Tensor shard, str tag, int[] ranks, int group_size) -> Tensor
   shard: non_differentiable
 
+- name: reduce_scatter_tensor(Tensor input, str reduceOp, int scatter_dim, str tag, int[] ranks, int group_size) -> Tensor
+  input: non_differentiable
+
 - name: wait_tensor(Tensor self) -> Tensor
   self: non_differentiable

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -555,6 +555,7 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     # Functional collectives keep an internal ref through the Work object
     "all_reduce",
     "all_gather_into_tensor",
+    "reduce_scatter_tensor",
     "wait_tensor",
 }
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -363,7 +363,7 @@ def reduce_scatter_tensor(
         tensor_list = torch.chunk(self, group_size, dim=scatter_dim)
         self = torch.cat(tensor_list)
 
-    tensor = torch._C._nn.reduce_scatter_tensor(self, reduceOp, tag, rankset, group_size)  # type: ignore[attr-defined]
+    tensor = torch._C._nn.reduce_scatter_tensor(self, reduceOp, 0, tag, rankset, group_size)  # type: ignore[attr-defined]
     res =_maybe_wrap_tensor(tensor)
     return res
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -329,7 +329,7 @@ def all_gather_tensor(
     res: torch.Tensor = AsyncCollectiveTensor(tensor)
     _register_wrapper_tensor(res, tensor)
     # TODO this should be done inside AsyncCollectiveTensor to delay the wait() call
-    if gather_dim > 0:
+    if gather_dim != 0:
         res = torch.cat(torch.chunk(res, group_size, dim=0), dim=gather_dim)
     return res
 
@@ -359,7 +359,7 @@ def reduce_scatter_tensor(
     assert (
         self.size(scatter_dim) % group_size == 0
     ), f"input dimension 0 ({self.size(0)} must be a multiple of group_size {group_size}"
-    if scatter_dim > 0:
+    if scatter_dim != 0:
         tensor_list = torch.chunk(self, group_size, dim=scatter_dim)
         self = torch.cat(tensor_list)
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -364,7 +364,7 @@ def reduce_scatter_tensor(
         self = torch.cat(tensor_list)
 
     tensor = torch._C._nn.reduce_scatter_tensor(self, reduceOp, 0, tag, rankset, group_size)  # type: ignore[attr-defined]
-    res =_maybe_wrap_tensor(tensor)
+    res = _maybe_wrap_tensor(tensor)
     return res
 
 

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -5,7 +5,6 @@ from typing import List, Optional, TYPE_CHECKING, Union
 import torch
 import torch.distributed._functional_collectives as funcol
 
-import torch.distributed.distributed_c10d as c10d
 from torch.distributed.distributed_c10d import (
     _get_default_group,
     all_to_all,
@@ -428,7 +427,9 @@ class DeviceMesh(object):
         op_name: str = op.name  # type: ignore[attr-defined]
         if self._backend == "nccl" or self._backend == "threaded":
             dim_group = self._dim_groups[mesh_dim]
-            scatter_tensor = funcol.reduce_scatter_tensor(input, reduceOp=op_name, scatter_dim=scatter_dim, group=dim_group)
+            scatter_tensor = funcol.reduce_scatter_tensor(
+                input, reduceOp=op_name, scatter_dim=scatter_dim, group=dim_group
+            )
 
         elif self._backend == "gloo":
             # it's gloo, which does not have reduce_scatter

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -49,19 +49,7 @@ def set_global_device_mesh(mesh: Optional["DeviceMesh"]) -> None:
     _global_device_mesh = mesh
 
 
-# We want a type for "can be passed to torch.as_tensor()";
-# this is a recursive sequence type, which isn't fully supported
-# yet in python. This construct simulates that up to depth 7.
-T = TypeVar("T")
-_L = Union[T, Sequence[T]]
-NDIntList = _L[_L[_L[_L[_L[_L[_L[int]]]]]]]
-
-MeshExprT = Union[
-    torch.Tensor,
-    NDIntList,
-]
-
-class DeviceMesh:
+class DeviceMesh(object):
     """
     DeviceMesh represents a mesh of devices, where layout of devices could be
     represented as a n-d dimension array, and each value of the n-d dimensional

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -71,7 +71,7 @@ MeshExprT = Union[
     NDIntList,
 ]
 
-class DeviceMesh(object):
+class DeviceMesh:
     """
     DeviceMesh represents a mesh of devices, where layout of devices could be
     represented as a n-d dimension array, and each value of the n-d dimensional

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -375,7 +375,6 @@ class DeviceMesh:
                 to scatter on, we by default choose the first rank on the
                 mesh dimension as source of truth.
             gather_dim (int, optional): Dimension to concatenate the resulting tensor.
-            gather_size (torch.Size, optional): Desired shape of the gathered tensor.
 
             This suppport up to 1 elem of padding on gather_dim.
         Returns:
@@ -457,10 +456,6 @@ class DeviceMesh:
             raise RuntimeError(
                 f"backend {self._backend} does not support reduce_scatter!"
             )
-
-        # if needs_padding:
-        #     if pad_idx != 0 and my_coordinate[mesh_dim] >= pad_idx:
-        #         scatter_tensor = shard._unpad_tensor(scatter_tensor)
 
         return scatter_tensor
 

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -20,21 +20,11 @@ from torch.distributed.distributed_c10d import (
     is_initialized,
     new_group,
     ProcessGroup,
-    reduce_scatter,
-<<<<<<< HEAD
-=======
-    ProcessGroup,
->>>>>>> Switch DeviceMesh all_gather and reduce_scatter to funcol.
     ReduceOp,
     scatter,
     Work,
 )
 
-<<<<<<< HEAD
-=======
-import torch.distributed._functional_collectives as funcol
-
->>>>>>> Switch DeviceMesh all_gather and reduce_scatter to funcol.
 # only import numpy typing when type checking
 if TYPE_CHECKING:
     try:

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -180,7 +180,7 @@ class Shard(Placement):
         is replicated on the previously sharded mesh dimension
         """
         my_coordinate = mesh.get_coordinate()
-        num_chunks = mesh.size(dim=self.dim)
+        num_chunks = mesh.size(mesh_dim)
         # TODO: what should happen if rank is not in the mesh?
         # see issue https://github.com/pytorch/tau/pull/492
         assert (

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -79,16 +79,15 @@ class Shard(Placement):
         # unpad tensor by 1 on the shard dim
         return tensor.narrow(self.dim, start=0, length=tensor.size(self.dim) - 1)
 
-    def _unpad_concat_tensor(self, tensor: torch.Tensor, padding_idx: int, shard_count: int) -> torch.Tensor:
+    def _unpad_concat_tensor(
+        self, tensor: torch.Tensor, padding_idx: int, shard_count: int
+    ) -> torch.Tensor:
         gathered_list = torch.chunk(tensor, shard_count, dim=self.dim)
         gathered_list = [
-            self._unpad_tensor(gathered_tensor)
-            if i >= padding_idx
-            else gathered_tensor
+            self._unpad_tensor(gathered_tensor) if i >= padding_idx else gathered_tensor
             for i, gathered_tensor in enumerate(gathered_list)
         ]
         return torch.cat(gathered_list, dim=self.dim)
-
 
     def _local_shard_size_on_dim(
         self,
@@ -162,7 +161,9 @@ class Shard(Placement):
             )
             tensor = torch.cat(scattered_list, dim=self.dim)
 
-        output = mesh.reduce_scatter(tensor, op=reduce_op, mesh_dim=mesh_dim, scatter_dim=self.dim)
+        output = mesh.reduce_scatter(
+            tensor, op=reduce_op, mesh_dim=mesh_dim, scatter_dim=self.dim
+        )
 
         if pad_idx != 0 and my_coordinate[mesh_dim] >= pad_idx:
             output = self._unpad_tensor(output)
@@ -200,9 +201,7 @@ class Shard(Placement):
         if pad_idx != 0:
             gathered_list = torch.chunk(result, num_chunks, dim=self.dim)
             gathered_list = [
-                self._unpad_tensor(gathered_tensor)
-                if i >= pad_idx
-                else gathered_tensor
+                self._unpad_tensor(gathered_tensor) if i >= pad_idx else gathered_tensor
                 for i, gathered_tensor in enumerate(gathered_list)
             ]
 

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -5,7 +5,6 @@ from typing import cast, List, Optional, Sequence, Tuple
 
 import torch
 import torch.distributed.distributed_c10d as c10d
-from torch.distributed._spmd.comm_tensor import CommTensor
 
 from torch.distributed._tensor.device_mesh import DeviceMesh
 from torch.fx.passes.shape_prop import TensorMetadata
@@ -80,6 +79,17 @@ class Shard(Placement):
         # unpad tensor by 1 on the shard dim
         return tensor.narrow(self.dim, start=0, length=tensor.size(self.dim) - 1)
 
+    def _unpad_concat_tensor(self, tensor: torch.Tensor, padding_idx: int, shard_count: int) -> torch.Tensor:
+        gathered_list = torch.chunk(tensor, shard_count, dim=self.dim)
+        gathered_list = [
+            self._unpad_tensor(gathered_tensor)
+            if i >= padding_idx
+            else gathered_tensor
+            for i, gathered_tensor in enumerate(gathered_list)
+        ]
+        return torch.cat(gathered_list, dim=self.dim)
+
+
     def _local_shard_size_on_dim(
         self,
         size_on_dim: int,
@@ -144,18 +154,16 @@ class Shard(Placement):
         assert (
             my_coordinate is not None
         ), "Rank if not part of mesh"  # TODO: figure out behavior here
-        scattered_list, pad_idx = self._split_tensor(
-            tensor, num_chunks, with_padding=True, contiguous=True
-        )
-        # wrap with comm tensor
-        scattered_list = [CommTensor(t) for t in scattered_list]
-        output = torch.empty_like(scattered_list[my_coordinate[mesh_dim]])
-        mesh.reduce_scatter(
-            CommTensor(output),
-            scattered_list,  # pyre-ignore[6]
-            op=reduce_op,
-            mesh_dim=mesh_dim,
-        )
+
+        pad_idx = 0
+        if tensor.size(self.dim) % num_chunks != 0:
+            scattered_list, pad_idx = self._split_tensor(
+                tensor, num_chunks, with_padding=True, contiguous=False
+            )
+            tensor = torch.cat(scattered_list, dim=self.dim)
+
+        output = mesh.reduce_scatter(tensor, op=reduce_op, mesh_dim=mesh_dim, scatter_dim=self.dim)
+
         if pad_idx != 0 and my_coordinate[mesh_dim] >= pad_idx:
             output = self._unpad_tensor(output)
         return output
@@ -172,41 +180,34 @@ class Shard(Placement):
         is replicated on the previously sharded mesh dimension
         """
         my_coordinate = mesh.get_coordinate()
-        num_chunks = mesh.size(dim=mesh_dim)
+        num_chunks = mesh.size(dim=self.dim)
         # TODO: what should happen if rank is not in the mesh?
         # see issue https://github.com/pytorch/tau/pull/492
         assert (
             my_coordinate is not None
         ), "Rank if not part of mesh"  # TODO: figure out behavior here
-        # check if it needs to pad input tensor before all_gather
-        pad_idx = size[self.dim] % num_chunks
+
+        gather_dim_len = size[self.dim]
+        pad_idx = gather_dim_len % num_chunks
         if pad_idx != 0 and my_coordinate[mesh_dim] >= pad_idx:
-            local_tensor = self._pad_tensor(local_tensor).contiguous()
+            local_tensor = self._pad_tensor(local_tensor)
 
-        gathered_list = []
-        # N.B. CommTensor does not change eager mode behavior. During tracing, it
-        # makes sure communication result is properly waited before subsequent
-        # read operations.
-        for _ in range(num_chunks):
-            gathered_list.append(
-                CommTensor(
-                    torch.empty_like(
-                        local_tensor,
-                        memory_format=torch.contiguous_format,
-                    )
-                )
-            )
-
-        mesh.all_gather(gathered_list, CommTensor(local_tensor.contiguous()), mesh_dim=mesh_dim)  # type: ignore[arg-type]
-        # unpad the tensor if the input tensor was padded
+        result = mesh.all_gather(
+            tensor=local_tensor,
+            mesh_dim=mesh_dim,
+            gather_dim=self.dim,
+        )
         if pad_idx != 0:
+            gathered_list = torch.chunk(result, num_chunks, dim=self.dim)
             gathered_list = [
-                self._unpad_tensor(gathered_tensor)  # type: ignore[misc]
+                self._unpad_tensor(gathered_tensor)
                 if i >= pad_idx
                 else gathered_tensor
                 for i, gathered_tensor in enumerate(gathered_list)
             ]
-        return torch.cat(gathered_list, dim=self.dim)  # type: ignore[arg-type]
+
+            result = torch.cat(gathered_list, dim=self.dim)
+        return result
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Shard):

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -279,6 +279,10 @@ class ProcessLocalGroup(dist.ProcessGroup):
         ProcessLocalGroup._end_coll(coll, self)
         return res
 
+    def _allgather_base(self, output_tensor, input_tensor, opts=AllgatherOptions()):
+        tensor_list = list(torch.chunk(output_tensor, self._world_size))
+        return self.allgather([tensor_list], [input_tensor], opts)
+
     def broadcast(self, tensor_list, opts=BroadcastOptions()):
         coll = ProcessLocalGroup._start_coll(Broadcast(opts.rootRank), self)
         res = coll.join(self._rank, tensor_list)


### PR DESCRIPTION
Among the changes is the introduction of gather_dim and scatter_dim in DeviceMesh collectives to simplify user code.

The current plan is to keep padding and gather/scatter dim support in DeviceMesh while we explore  optimization opportunities in Inductor.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @desertfire