### PR TITLE
pt2e short term quant: respect qmin/qmax for linear weight

### DIFF
--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -31,6 +31,7 @@ from torch.testing._internal.common_quantized import (
     qengine_is_qnnpack,
     qengine_is_onednn,
 )
+import torch.fx
 from hypothesis import assume, given
 from hypothesis import strategies as st
 import torch.testing._internal.hypothesis_utils as hu
@@ -202,7 +203,7 @@ class TestStaticQuantizedModule(QuantizationTestCase):
 
         for name, module in loaded_from_package.named_modules():
             # noop, just make sure attribute "_modules" is restored correctly during torch.package import
-            assert(name is not None)
+            assert(name is not None)  # noqa: E275
 
         # Test copy and deepcopy
         copied_linear = copy.copy(qlinear)
@@ -2053,3 +2054,33 @@ class TestReferenceQuantizedModule(QuantizationTestCase):
             fp32_res = fp32_embedding(*args)
             ref_res = ref_embedding(*args)
             self.assertEqual(fp32_res, ref_res)
+
+    def test_linear_decomposed_weight_custom_qmin_qmax(self):
+        """Verify that reference Linear respects custom qmin/qmax for weight
+        """
+        linear_fp32 = torch.nn.Linear(2, 2)
+        qconfig = torch.ao.quantization.default_symmetric_qnnpack_qconfig
+        w_obs = qconfig.weight()
+        self.assertTrue(w_obs.quant_min == -127)
+        self.assertTrue(w_obs.quant_max == 127)
+        w_obs(linear_fp32.weight)
+        weight_qparams = torch.ao.quantization.utils.get_qparam_dict(w_obs)
+        weight_qparams["is_decomposed"] = True
+        linear_ref = nnqr.Linear.from_float(linear_fp32, weight_qparams)
+        linear_ref_traced = torch.fx.symbolic_trace(linear_ref)
+
+        # verify that the qmin/qmax arguments for weight q/dq are correctly
+        # taken from the observer
+        found = 0
+        for n in linear_ref_traced.graph.nodes:
+            if n.op != 'call_function':
+                continue
+            if n.target in (
+                torch.ops.quantized_decomposed.quantize_per_tensor,
+                torch.ops.quantized_decomposed.dequantize_per_tensor,
+            ):
+                _0, _1, _2, qmin, qmax, _5 = n.args
+                self.assertTrue(qmin == -127)
+                self.assertTrue(qmax == 127)
+                found += 1
+        self.assertTrue(found == 2)

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -179,6 +179,11 @@ def get_qparam_dict(observer_or_fake_quant):
     qparams["scale"] = scale
     qparams["zero_point"] = zero_point
 
+    if hasattr(observer_or_fake_quant, "quant_min"):
+        qparams["quant_min"] = observer_or_fake_quant.quant_min
+    if hasattr(observer_or_fake_quant, "quant_max"):
+        qparams["quant_max"] = observer_or_fake_quant.quant_max
+
     return qparams
 
 


### PR DESCRIPTION
Summary:

Makes the `nnqr.Linear` module respect the qmin/qmax attributes of weight observer.  This is to unblock some customer teams who are depending on non-default values of these attributes.

Test plan:

```
python test/test_quantization.py -k TestReferenceQuantizedModule.test_linear_decomposed
```

Fixes #ISSUE_NUMBER
