### PR TITLE
[FSDP][optim_state_dict] Makes FSDP optim_state_dict be aware of DDP prefix

### DIFF
--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -299,6 +299,17 @@ def _apply_to_modules(
                             f"submodule_name = {submodule_name}"
                         )
                         new_prefix = prefix
+                    elif (
+                        submodule_name == "module"
+                    ):
+                        warnings.warn(
+                            "An unexpected prefix is detected. This case "
+                            " should only happen when DDP wraps the outer "
+                            " modules while FSDP wraps the inner ones."
+                            f"prefix = {prefix}, "
+                            f"submodule_name = {submodule_name}"
+                        )
+                        new_prefix = prefix
             f(submodule, new_prefix, *args, **kwargs)
 
     f(root_module, "", *args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

When wrapping FSDP within DDP, optimizer state_dict may be broken due to the prefix of DDP. This PR fixes the issue.

Differential Revision: [D43893609](https://our.internmc.facebook.com/intern/diff/D43893609/)