### PR TITLE
Support per channel tensor with unpacking in QNNPACK

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/LinearUnpackImpl.cpp
+++ b/aten/src/ATen/native/quantized/cpu/LinearUnpackImpl.cpp
@@ -15,7 +15,6 @@
 #else
 #include <ATen/ops/_empty_affine_quantized.h>
 #include <ATen/ops/_empty_per_channel_affine_quantized.h>
-#include <ATen/ops/_make_per_tensor_quantized_tensor.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/from_blob.h>
 #endif
@@ -62,25 +61,58 @@ std::tuple<at::Tensor, c10::optional<at::Tensor>> PackedLinearWeight::unpack() {
 #ifdef USE_PYTORCH_QNNPACK
 std::tuple<at::Tensor, c10::optional<at::Tensor>> PackedLinearWeightsQnnp::
     unpack() {
-    if (orig_weight.defined()){
-        return std::tuple<at::Tensor, c10::optional<at::Tensor>>(orig_weight, bias_);
+  if (orig_weight.defined()) {
+    return std::tuple<at::Tensor, c10::optional<at::Tensor>>(
+        orig_weight, bias_);
+  } else {
+    // Unpacking requires reverting *make_zero_points_and_scales_tensor*
+    // function in QnnpackUtils.h Please refer for a detail mechanism.
+    // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/quantized/cpu/QnnpackUtils.h#L469
+    // w_scales and w_zero_points are different from original scales & zero
+    // points with padding & casting etc
+    at::Tensor weight_origin;
+
+    float* weight_scales_data = w_scales.data_ptr<float>();
+    if (q_scheme == c10::kPerTensorAffine) {
+      weight_origin = at::_empty_affine_quantized(
+          weight_sizes,
+          at::device(c10::kCPU).dtype(c10::kQInt8),
+          static_cast<double>(weight_scales_data[0]),
+          (int64_t)w_zero_points[0] - 128);
+    } else if (q_scheme == c10::kPerChannelAffine) {
+      auto scales = at::from_blob(
+          weight_scales_data,
+          w_scales.sizes()[0] - kPaddingChannels,
+          device(c10::kCPU).dtype(c10::kFloat));
+
+      at::Tensor zero_points = at::empty(
+          w_zero_points.size() - kPaddingChannels, at::device(c10::kCPU).dtype(c10::kLong));
+      for (const auto i : c10::irange(zero_points.numel())) {
+        zero_points[i] = ((int64_t)w_zero_points[i] - 128);
+      }
+      weight_origin = at::_empty_per_channel_affine_quantized(
+                          weight_sizes,
+                          scales,
+                          zero_points.toType(c10::kLong),
+                          0, // The output channel axis is 0
+                          device(c10::kCPU).dtype(c10::kQInt8))
+                          .contiguous();
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "Unsupported quantization scheme.");
     }
-    else{
-        float* weight_scales_data = w_scales.data_ptr<float>();
-        at::Tensor weight_origin;
-        weight_origin = at::empty(weight_sizes, at::device(c10::kCPU).dtype(at::kChar));
-        int8_t* weight_ptr_int8 =
-            reinterpret_cast<int8_t*>(weight_origin.data_ptr<int8_t>());
-        w->unpackWeights(w_zero_points.data(), weight_ptr_int8);
-        // See for the subtraction 128
-        // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp#L319
-        weight_origin.sub_(128);
-        // As of now, we are supporting only per tensor quantizer
-        // TO-DO : Support a per channel as well.
-        at::Tensor original_quantized_tensor = at::_make_per_tensor_quantized_tensor(weight_origin, weight_scales_data[0], w_zero_points[0]);
-        TORCH_CHECK(original_quantized_tensor.qscheme() == c10::kPerTensorAffine);
-        return std::tuple<at::Tensor, c10::optional<at::Tensor>>(original_quantized_tensor, bias_);
+    int8_t* weight_ptr_int8 =
+        reinterpret_cast<int8_t*>(weight_origin.data_ptr<c10::qint8>());
+    w->unpackWeights(w_zero_points.data(), weight_ptr_int8);
+    // See for the subtraction 128
+    // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp#L319
+    auto wt_numel = weight_origin.numel();
+    for (const auto i : c10::irange(wt_numel)) {
+      weight_ptr_int8[i] = (int8_t)(weight_ptr_int8[i] - 128);
     }
+
+    return std::tuple<at::Tensor, c10::optional<at::Tensor>>(
+        weight_origin, bias_);
+  }
 }
 #endif // USE_PYTORCH_QNNPACK
 


### PR DESCRIPTION
Summary: Supporting Per Channel quantizer with unpacking for QNNPACK.

Test Plan: buck2 test //caffe2/test/quantization:quantization --  test_qlinear_per_channel_qnnpack_free_memory_and_unpack

Differential Revision: D43865268



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10