### PR TITLE
Update mkl_verbose return value check due to API change in mkl

### DIFF
--- a/aten/src/ATen/native/verbose_wrapper.cpp
+++ b/aten/src/ATen/native/verbose_wrapper.cpp
@@ -14,7 +14,8 @@ namespace verbose {
 
 TORCH_API int _mkl_set_verbose(int enable) {
 #if AT_MKL_ENABLED()
-  return mkl_verbose(enable);
+  int ret = mkl_verbose(enable);
+  return ret != -1;
 #else
   return 0;
 #endif

--- a/aten/src/ATen/native/verbose_wrapper.cpp
+++ b/aten/src/ATen/native/verbose_wrapper.cpp
@@ -15,8 +15,12 @@ namespace verbose {
 TORCH_API int _mkl_set_verbose(int enable) {
 #if AT_MKL_ENABLED()
   int ret = mkl_verbose(enable);
+
+  // Return 0 when the mkl_verbose function fails to set verbose level.
+  // Return 1 on success.
   return ret != -1;
 #else
+  // Return 0 since oneMKL is not enabled.
   return 0;
 #endif
 }


### PR DESCRIPTION
As title.
Originally `mkl_verbose()` function returned `0` and `1`, indicating failure and success respectively. However, the version that PyTorch uses now changed the output of `mkl_verbose()` to reflect its input level. Thus, the check logic needs to be changed to compare output of the `mkl_verbose()` function with -1.
https://www.intel.com/content/www/us/en/develop/documentation/onemkl-developer-reference-c/top/support-functions/miscellaneous/mkl-verbose.html

cc @frank-wei @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei