### PR TITLE
Remove unimported expecttest dependency to fix build

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -159,6 +159,7 @@ THIRD_PARTY_LIBS = {
     "XNNPACK": ["//xplat/third-party/XNNPACK:XNNPACK", "//third_party:XNNPACK"],
     "clog": ["//xplat/third-party/clog:clog", "//third_party:clog"],
     "cpuinfo": ["//third-party/cpuinfo:cpuinfo", "//third_party:cpuinfo"],
+    "expecttest": ["//third-party/pypi/expecttest:expecttest", "//third-party:expecttest"],
     "flatbuffers-api": ["//third-party/flatbuffers/fbsource_namespace:flatbuffers-api", "//third_party:flatbuffers-api"],
     "flatc": ["//third-party/flatbuffers/fbsource_namespace:flatc", "//third_party:flatc"],
     "fmt": ["//third-party/fmt:fmt", "//third_party:fmt"],

--- a/third_party/BUCK.oss
+++ b/third_party/BUCK.oss
@@ -227,6 +227,20 @@ prebuilt_python_library(
   deps = [":pyyaml-download"],
 )
 
+remote_file(
+  name = "expecttest-download",
+  url = "https://files.pythonhosted.org/packages/a6/26/1a287e44618c14659db0256bc1ee239c2134f9c863cb9a85813ecab73413/expecttest-0.1.4-py3-none-any.whl",
+  sha1 = "8cb529eefd897932f2d153f12b21e42be0fbd68e",
+  out = "expecttest.whl",
+)
+
+prebuilt_python_library(
+  name = "expecttest",
+  binary_src = ":expecttest-download",
+  visibility = ["PUBLIC"],
+  deps = [":expecttest-download"],
+)
+
 cxx_library(
     name = "ruy_lib",
     srcs = glob(

--- a/tools/BUCK.bzl
+++ b/tools/BUCK.bzl
@@ -292,7 +292,6 @@ def define_tools_targets(
     python_test(
         name = "test_torchgen_executorch",
         srcs = [
-            "test/test_executorch_custom_ops.py",
             "test/test_executorch_gen.py",
             "test/test_executorch_signatures.py",
             "test/test_executorch_types.py",
@@ -302,6 +301,5 @@ def define_tools_targets(
         visibility = ["PUBLIC"],
         deps = [
             torchgen_deps,
-            "fbsource//third-party/pypi/expecttest:expecttest",
         ],
     )

--- a/tools/BUCK.bzl
+++ b/tools/BUCK.bzl
@@ -292,6 +292,7 @@ def define_tools_targets(
     python_test(
         name = "test_torchgen_executorch",
         srcs = [
+	    "test/test_executorch_custom_ops.py",
             "test/test_executorch_gen.py",
             "test/test_executorch_signatures.py",
             "test/test_executorch_types.py",
@@ -300,6 +301,7 @@ def define_tools_targets(
         contacts = contacts,
         visibility = ["PUBLIC"],
         deps = [
+            third_party("expecttest"),
             torchgen_deps,
         ],
     )

--- a/tools/BUCK.bzl
+++ b/tools/BUCK.bzl
@@ -292,7 +292,7 @@ def define_tools_targets(
     python_test(
         name = "test_torchgen_executorch",
         srcs = [
-	    "test/test_executorch_custom_ops.py",
+            "test/test_executorch_custom_ops.py",
             "test/test_executorch_gen.py",
             "test/test_executorch_signatures.py",
             "test/test_executorch_types.py",


### PR DESCRIPTION
expecttest is not imported to OSS BUCK build yet. Using it in target test_torchgen_executorch breaks build.

Remove it first to fix the build, then bring in that lib.

