### PR TITLE
Make setup linux action be more friendly with gcp linux runners

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -18,7 +18,7 @@ runs:
           if [[ {{ runner.name}} != *"gcp"* ]]; then  
             curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
           else
-	    echo "Runner is from Google Cloud Platform, No OP on ec2 metadata" 
+            echo "Runner is from Google Cloud Platform, No OP on ec2 metadata" 
           fi
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -15,11 +15,10 @@ runs:
           category=$1
           # If it is GCP runner (runner name contains gcp), do not run this 
           runner_name_str=${{ runner.name }} 
-          echo $runner_name_str
           if [[ $runner_name_str != *"gcp"* ]]; then
             curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
           else 
-            echo "Runner is from Google Cloud Platform, No OP on ec2 metadata" 
+            echo "Runner is from Google Cloud Platform, No info on ec2 metadata" 
           fi
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -15,11 +15,9 @@ runs:
           category=$1
           # If it is GCP runner (runner name contains gcp), do not run this 
           echo {{ runner.name }}
-          if [[ {{ runner.name}} != *"gcp"* ]]; then  
-            curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-          else
-            echo "Runner is from Google Cloud Platform, No OP on ec2 metadata" 
-          fi
+          curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+          echo "Runner is from Google Cloud Platform, No OP on ec2 metadata" 
+          exit 1
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"
         echo "instance-id: $(get_ec2_metadata instance-id)"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -13,7 +13,10 @@ runs:
           # Pulled from instance metadata endpoint for EC2
           # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
           category=$1
-          curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+          # If it is GCP runner (runner name contains gcp), do not run this 
+          echo {{ runner.name }}
+          if [[ {{ runner.name}} != *"gcp"* ]]; then  
+            curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"
         echo "instance-id: $(get_ec2_metadata instance-id)"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -14,10 +14,12 @@ runs:
           # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
           category=$1
           # If it is GCP runner (runner name contains gcp), do not run this 
-          echo {{ runner.name }}
-          curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-          echo "Runner is from Google Cloud Platform, No OP on ec2 metadata" 
-          exit 1
+          runner_name_str={{ runner.name }}
+          if [[ "runner_name_str" != *"gcp"* ]]; then
+            curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+          else 
+            echo "Runner is from Google Cloud Platform, No OP on ec2 metadata" 
+          fi
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"
         echo "instance-id: $(get_ec2_metadata instance-id)"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -17,6 +17,7 @@ runs:
           echo {{ runner.name }}
           if [[ {{ runner.name}} != *"gcp"* ]]; then  
             curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+          fi
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"
         echo "instance-id: $(get_ec2_metadata instance-id)"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -14,7 +14,7 @@ runs:
           # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
           category=$1
           # If it is GCP runner (runner name contains gcp), do not run this 
-          runner_name_str= {{ runner.name }}
+          runner_name_str=${{ runner.name }} 
           echo $runner_name_str
           if [[ $runner_name_str != *"gcp"* ]]; then
             curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -13,12 +13,12 @@ runs:
           # Pulled from instance metadata endpoint for EC2
           # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
           category=$1
-          # If it is GCP runner (runner name contains gcp), do not run this 
-          runner_name_str=${{ runner.name }} 
+          # If it is GCP runner (runner name contains gcp), do not run this
+          runner_name_str=${{ runner.name }}
           if [[ $runner_name_str != *"gcp"* ]]; then
             curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
-          else 
-            echo "Runner is from Google Cloud Platform, No info on ec2 metadata" 
+          else
+            echo "Runner is from Google Cloud Platform, No info on ec2 metadata"
           fi
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -17,6 +17,8 @@ runs:
           echo {{ runner.name }}
           if [[ {{ runner.name}} != *"gcp"* ]]; then  
             curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+          else
+	    echo "Runner is from Google Cloud Platform, No OP on ec2 metadata" 
           fi
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -15,8 +15,8 @@ runs:
           category=$1
           # If it is GCP runner (runner name contains gcp), do not run this 
           runner_name_str= {{ runner.name }}
-          echo runner_name_str
-          if [[ "runner_name_str" != *"gcp"* ]]; then
+          echo $runner_name_str
+          if [[ $runner_name_str != *"gcp"* ]]; then
             curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
           else 
             echo "Runner is from Google Cloud Platform, No OP on ec2 metadata" 

--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -14,7 +14,8 @@ runs:
           # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
           category=$1
           # If it is GCP runner (runner name contains gcp), do not run this 
-          runner_name_str={{ runner.name }}
+          runner_name_str= {{ runner.name }}
+          echo runner_name_str
           if [[ "runner_name_str" != *"gcp"* ]]; then
             curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
           else 


### PR DESCRIPTION
Fixes issues like the following: 
https://github.com/pytorch/pytorch/actions/runs/4362155257/jobs/7627059487 has a more serious core dump failure but the log of curl failures (GCP linux trying to get EC2 specific metadata like EC2 AMI-ID, Instance ID, and Instance Type) confused the HUD. 
<img width="848" alt="image" src="https://user-images.githubusercontent.com/109318740/223670567-330521ba-050a-41c3-9efb-fae6ea3398c0.png">
This PR gets rid of those curl failures. 

This may have contributed to the impression of "flaky GCP" in #95416 

cc @desertfire  who first made the request to remove such annoying curl failures. 