### PR TITLE
Remove unimported expecttest deps and usage

### DIFF
--- a/tools/BUCK.bzl
+++ b/tools/BUCK.bzl
@@ -292,7 +292,6 @@ def define_tools_targets(
     python_test(
         name = "test_torchgen_executorch",
         srcs = [
-            "test/test_executorch_custom_ops.py",
             "test/test_executorch_gen.py",
             "test/test_executorch_signatures.py",
             "test/test_executorch_types.py",
@@ -302,6 +301,5 @@ def define_tools_targets(
         visibility = ["PUBLIC"],
         deps = [
             torchgen_deps,
-            "fbsource//third-party/pypi/expecttest:expecttest",
         ],
     )


### PR DESCRIPTION
expecttest is not imported to OSS BUCK build yet. Using it in target test_torchgen_executorch breaks build.

Remove it first to fix the build. Will import and fix in a follow-up PR.
