### PR TITLE
[POC] Use slots to speed up Module hooks checks

### DIFF
--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -82,6 +82,8 @@ class Linear(Module):
         >>> print(output.size())
         torch.Size([128, 30])
     """
+    __slots__ = ("_forward_hooks", "_forward_pre_hooks", "_backward_hooks", "_backward_pre_hooks")
+
     __constants__ = ['in_features', 'out_features']
     in_features: int
     out_features: int


### PR DESCRIPTION
This is a POC on how to quickly check if a Module has hooks.
This is done by storing the hooks dictionaries as slots and using the C API to quickly access these.

I added slots to nn.Linear here as an example but we can instrument all core modules this way as needed.

Tested via
```python
import torch
import timeit

print("Modules:")
lin = torch.nn.Linear(2,2)
print(f"{lin=}")
mod = torch.nn.Module()
print(f"{mod=}")
print("")

for m, name in ((lin, "lin"), (mod, "mod")):
    print(f"Testing {name}")
    print(f"bool(x._has_hooks) | x = {name}")
    print(timeit.timeit("bool(x._has_hooks)", number=10000000, globals={'x': m}))

    print(f"x._has_hooks is False | x = {name}")
    print(timeit.timeit("x._has_hooks is False", number=10000000, globals={'x': m}))

    print(f"fn(x) | x = {name}, fn = torch._C._try_check_module_has_hooks")
    print(timeit.timeit("fn(x)", number=10000000, globals={'x': m, 'fn': torch._C._try_check_module_has_hooks}))

    print("Try check:", torch._C._try_check_module_has_hooks(m))

    print("Adding hook")
    m.register_forward_hook(lambda x: x)
    print("Try check:", torch._C._try_check_module_has_hooks(m))
    print("")

```

Which gives
```
Modules:
lin=Linear(in_features=2, out_features=2, bias=True)
mod=Module()

Testing lin
bool(x._has_hooks) | x = lin
0.4736098180001136
x._has_hooks is False | x = lin
0.38799949098029174
fn(x) | x = lin, fn = torch._C._try_check_module_has_hooks
0.2757353439810686
Try check: True
Adding hook
Try check: False

Testing mod
bool(x._has_hooks) | x = mod
0.33703727400279604
x._has_hooks is False | x = mod
0.31324804000905715
fn(x) | x = mod, fn = torch._C._try_check_module_has_hooks
0.16570157199748792
Try check: None
Adding hook
Try check: None


```