### PR TITLE
[FSDP] Add unsafe setattr gated by env var

### DIFF
--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -682,7 +682,6 @@ class TestFSDPMiscWorldSize1(FSDPTest):
         os.environ[_FSDP_USE_UNSAFE_SETATTR] = "1"
         module = SetattrLinear(5, 5, torch.device("cuda"))
         fsdp_module = FSDP(module, use_orig_params=use_orig_params)
-        inp = torch.randn((8, 5), device=torch.device("cuda"))
         called_setattr_override = False
         fsdp_module(inp)
         self.assertFalse(called_setattr_override)
@@ -691,7 +690,6 @@ class TestFSDPMiscWorldSize1(FSDPTest):
         os.environ[_FSDP_USE_UNSAFE_SETATTR] = "0"
         module = SetattrLinear(5, 5, torch.device("cuda"))
         fsdp_module = FSDP(module, use_orig_params=use_orig_params)
-        inp = torch.randn((8, 5), device=torch.device("cuda"))
         called_setattr_override = False
         fsdp_module(inp)
         self.assertTrue(called_setattr_override)

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -20,7 +20,7 @@ from torch.distributed.fsdp import (
     ShardingStrategy,
 )
 from torch.distributed.fsdp._runtime_utils import HOMOGENEOUS_ATTR_NAMES
-from torch.distributed.fsdp.flat_param import _FSDP_USE_SAFE_SETATTR
+from torch.distributed.fsdp.flat_param import _FSDP_USE_UNSAFE_SETATTR
 from torch.distributed.fsdp.wrap import (
     always_wrap_policy,
     ModuleWrapPolicy,
@@ -668,8 +668,8 @@ class TestFSDPMiscWorldSize1(FSDPTest):
         fsdp_module(inp)
         self.assertTrue(called_setattr_override)
 
-        # Repeat with safe setattr explicitly disabled
-        os.environ[_FSDP_USE_SAFE_SETATTR] = "0"
+        # Repeat with unsafe setattr explicitly enabled
+        os.environ[_FSDP_USE_UNSAFE_SETATTR] = "1"
         module = SetattrLinear(5, 5, torch.device("cuda"))
         fsdp_module = FSDP(module, use_orig_params=True)
         inp = torch.randn((8, 5), device=torch.device("cuda"))
@@ -677,8 +677,8 @@ class TestFSDPMiscWorldSize1(FSDPTest):
         fsdp_module(inp)
         self.assertFalse(called_setattr_override)
 
-        # Repeat with safe setattr explicitly enabled
-        os.environ[_FSDP_USE_SAFE_SETATTR] = "1"
+        # Repeat with unsafe setattr explicitly disabled
+        os.environ[_FSDP_USE_UNSAFE_SETATTR] = "0"
         module = SetattrLinear(5, 5, torch.device("cuda"))
         fsdp_module = FSDP(module, use_orig_params=True)
         inp = torch.randn((8, 5), device=torch.device("cuda"))

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -642,6 +642,17 @@ class TestFSDPMiscWorldSize1(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     def test_unsafe_setattr(self):
+        """
+        Tests that the environment variable for using unsafe setattr gates as
+        expected.
+        """
+        self.run_subtests(
+            {"use_orig_params": [False, True]},
+            self._test_unsafe_setattr,
+        )
+
+
+    def _test_unsafe_setattr(self, use_orig_params: bool):
         called_setattr_override = False
 
         class SetattrLinear(nn.Module):
@@ -662,7 +673,7 @@ class TestFSDPMiscWorldSize1(FSDPTest):
         # Construct FSDP module without changing any environment variables and
         # run forward, which triggers both unsharded and sharded view setting
         module = SetattrLinear(5, 5, torch.device("cuda"))
-        fsdp_module = FSDP(module, use_orig_params=True)
+        fsdp_module = FSDP(module, use_orig_params=use_orig_params)
         inp = torch.randn((8, 5), device=torch.device("cuda"))
         called_setattr_override = False
         fsdp_module(inp)
@@ -671,7 +682,7 @@ class TestFSDPMiscWorldSize1(FSDPTest):
         # Repeat with unsafe setattr explicitly enabled
         os.environ[_FSDP_USE_UNSAFE_SETATTR] = "1"
         module = SetattrLinear(5, 5, torch.device("cuda"))
-        fsdp_module = FSDP(module, use_orig_params=True)
+        fsdp_module = FSDP(module, use_orig_params=use_orig_params)
         inp = torch.randn((8, 5), device=torch.device("cuda"))
         called_setattr_override = False
         fsdp_module(inp)
@@ -680,7 +691,7 @@ class TestFSDPMiscWorldSize1(FSDPTest):
         # Repeat with unsafe setattr explicitly disabled
         os.environ[_FSDP_USE_UNSAFE_SETATTR] = "0"
         module = SetattrLinear(5, 5, torch.device("cuda"))
-        fsdp_module = FSDP(module, use_orig_params=True)
+        fsdp_module = FSDP(module, use_orig_params=use_orig_params)
         inp = torch.randn((8, 5), device=torch.device("cuda"))
         called_setattr_override = False
         fsdp_module(inp)

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import functools
+import os
 import sys
 import warnings
 from collections import namedtuple
@@ -19,6 +20,7 @@ from torch.distributed.fsdp import (
     ShardingStrategy,
 )
 from torch.distributed.fsdp._runtime_utils import HOMOGENEOUS_ATTR_NAMES
+from torch.distributed.fsdp.flat_param import _FSDP_USE_SAFE_SETATTR
 from torch.distributed.fsdp.wrap import (
     always_wrap_policy,
     ModuleWrapPolicy,
@@ -637,6 +639,52 @@ class TestFSDPMiscWorldSize1(FSDPTest):
             "when offloading parameters.",
         ):
             fsdp_model(inp)
+
+    @skip_if_lt_x_gpu(2)
+    def test_unsafe_setattr(self):
+        called_setattr_override = False
+
+        class SetattrLinear(nn.Module):
+            def __init__(self, in_dim: int, out_dim: int, device: torch.device) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(
+                    torch.randn((in_dim, out_dim), device=device)
+                )
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x @ self.weight
+
+            def __setattr__(self, name: str, value: Any) -> None:
+                nonlocal called_setattr_override
+                called_setattr_override = True
+                return super().__setattr__(name, value)
+
+        # Construct FSDP module without changing any environment variables and
+        # run forward, which triggers both unsharded and sharded view setting
+        module = SetattrLinear(5, 5, torch.device("cuda"))
+        fsdp_module = FSDP(module, use_orig_params=True)
+        inp = torch.randn((8, 5), device=torch.device("cuda"))
+        called_setattr_override = False
+        fsdp_module(inp)
+        self.assertTrue(called_setattr_override)
+
+        # Repeat with safe setattr explicitly disabled
+        os.environ[_FSDP_USE_SAFE_SETATTR] = "0"
+        module = SetattrLinear(5, 5, torch.device("cuda"))
+        fsdp_module = FSDP(module, use_orig_params=True)
+        inp = torch.randn((8, 5), device=torch.device("cuda"))
+        called_setattr_override = False
+        fsdp_module(inp)
+        self.assertFalse(called_setattr_override)
+
+        # Repeat with safe setattr explicitly enabled
+        os.environ[_FSDP_USE_SAFE_SETATTR] = "1"
+        module = SetattrLinear(5, 5, torch.device("cuda"))
+        fsdp_module = FSDP(module, use_orig_params=True)
+        inp = torch.randn((8, 5), device=torch.device("cuda"))
+        called_setattr_override = False
+        fsdp_module(inp)
+        self.assertTrue(called_setattr_override)
 
 
 instantiate_parametrized_tests(TestFSDPMisc)

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -651,7 +651,6 @@ class TestFSDPMiscWorldSize1(FSDPTest):
             self._test_unsafe_setattr,
         )
 
-
     def _test_unsafe_setattr(self, use_orig_params: bool):
         called_setattr_override = False
 

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -65,7 +65,7 @@ For the non-wrapper code path:
 or a submodule chosen by the provided wrapping policy.
 """
 
-# Environment variable to toggling whether to use unsafe `setattr()` for view
+# Environment variable toggling whether to use unsafe `setattr()` for view
 # setting in `_use_sharded_views()` and `_use_unsharded_views()`
 # We should use 'safe' by default since it respects method overrides, but for
 # special cases such as for high CPU overhead or for intentionally bypassing

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1,9 +1,11 @@
 import contextlib
+import os
 import warnings
 from enum import auto, Enum
 from itertools import accumulate, chain
 from typing import (
     Any,
+    Callable,
     Dict,
     Generator,
     Iterator,
@@ -62,6 +64,9 @@ For the non-wrapper code path:
 - The fully sharded module may either be the direct argument to ``fully_shard``
 or a submodule chosen by the provided wrapping policy.
 """
+
+
+_FSDP_USE_SAFE_SETATTR = "FSDP_USE_SAFE_SETATTR"
 
 
 class ParamInfo(NamedTuple):
@@ -347,6 +352,17 @@ class FlatParamHandle:
         use_orig_params: bool,
     ):
         super().__init__()
+        # For special cases (e.g. high CPU overhead), we may want to bypass the
+        # `nn.Module.setattr()` checks, where we gate this with an env var.
+        use_safe_setattr = os.environ.get(_FSDP_USE_SAFE_SETATTR, "1") == "1"
+        self._setattr_tensor: Callable[[nn.Module, str, Tensor], None]
+        self._setattr_param: Callable[[nn.Module, str, nn.Parameter], None]
+        if use_safe_setattr:
+            self._setattr_tensor = _safe_setattr_tensor_or_param
+            self._setattr_param = _safe_setattr_tensor_or_param
+        else:
+            self._setattr_tensor = _unsafe_setattr_tensor
+            self._setattr_param = _unsafe_setattr_param
         self.device = device
         self.process_group = process_group
         self.rank = process_group.rank()
@@ -1384,20 +1400,18 @@ class FlatParamHandle:
         for i, (view, (param_name, module, _)) in enumerate(
             zip(views, self.flat_param._param_infos)
         ):
-            if hasattr(module, param_name):
-                delattr(module, param_name)
             if self._use_orig_params and as_params:
                 if type(view) is DTensor:
                     # A `DTensor` `view` is not compatible with assigning
                     # `param.data = view`, so we cannot preserve the parameter
                     # variable.
-                    setattr(module, param_name, nn.Parameter(view))
+                    self._setattr_param(module, param_name, nn.Parameter(view))
                     continue
                 param = self.flat_param._params[i]  # type: ignore[index]
-                setattr(module, param_name, param)
+                self._setattr_param(module, param_name, param)
                 param.data = view
             elif as_params:
-                module.register_parameter(param_name, nn.Parameter(view))
+                self._setattr_param(module, param_name, nn.Parameter(view))
             else:  # `as_params=False`
                 param_var: Tensor = view
                 if self._use_orig_params:
@@ -1418,7 +1432,7 @@ class FlatParamHandle:
                         tensor.data = view  # type: ignore[union-attr]
                         assert tensor is not None  # mypy
                         param_var = tensor
-                setattr(module, param_name, param_var)
+                self._setattr_tensor(module, param_name, param_var)
                 if (
                     self._use_orig_params
                     and self._training_state == HandleTrainingState.FORWARD
@@ -1447,13 +1461,13 @@ class FlatParamHandle:
             )
             if self._use_orig_params and as_params:
                 shared_param = self.flat_param._shared_params[i]  # type: ignore[index]
-                setattr(module, param_name, shared_param)
+                self._setattr_param(module, param_name, shared_param)
                 shared_param.data = prim_param
             elif as_params:
                 assert isinstance(prim_param, nn.Parameter)
-                module.register_parameter(param_name, prim_param)
+                self._setattr_param(module, param_name, prim_param)
             else:
-                setattr(module, param_name, prim_param)
+                self._setattr_tensor(module, param_name, prim_param)
                 if (
                     self._use_orig_params
                     and self._training_state == HandleTrainingState.FORWARD
@@ -1563,7 +1577,7 @@ class FlatParamHandle:
         for i, (param, (param_name, module, _)) in enumerate(
             zip(self.flat_param._params, self.flat_param._param_infos)
         ):
-            setattr(module, param_name, param)
+            self._setattr_param(module, param_name, param)
             in_sharded_flat_param = (
                 i >= start
                 and i <= end
@@ -1589,7 +1603,7 @@ class FlatParamHandle:
         ) in enumerate(
             zip(self.flat_param._shared_params, self.flat_param._shared_param_infos)
         ):
-            setattr(module, param_name, param)
+            self._setattr_param(module, param_name, param)
             prim_param = getattr(prim_module, prim_param_name)
             param.data = prim_param  # could be both empty and non-empty
         if self._training_state == HandleTrainingState.BACKWARD_POST:
@@ -2047,6 +2061,32 @@ class FlatParamHandle:
             self._training_state == HandleTrainingState.SUMMON_FULL_PARAMS
             and self._uses_param_mixed_precision
         )
+
+
+# NOTE: These are hacks to bypass `nn.Module.__setattr__` checks.
+def _unsafe_setattr_param(
+    module: nn.Module, param_name: str, param: nn.Parameter
+) -> None:
+    module._parameters[param_name] = param
+    # This bypasses any overrides in case `module` is an instance of an
+    # `nn.Module` subclass
+    super(nn.Module, module).__setattr__(param_name, param)
+
+
+def _unsafe_setattr_tensor(module: nn.Module, param_name: str, tensor: Tensor) -> None:
+    module._parameters.pop(param_name, None)
+    # This bypasses any overrides in case `module` is an instance of an
+    # `nn.Module` subclass
+    super(nn.Module, module).__setattr__(param_name, tensor)
+
+
+def _safe_setattr_tensor_or_param(
+    module: nn.Module, param_name: str, tensor_or_param: Union[Tensor, nn.Parameter]
+):
+    # Call `delattr()` and `setattr()` to go through `nn.Module` checks
+    if hasattr(module, param_name):
+        delattr(module, param_name)
+    setattr(module, param_name, tensor_or_param)
 
 
 # A handles key represents the group of `FlatParamHandle`s involved in a given

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -65,7 +65,11 @@ For the non-wrapper code path:
 or a submodule chosen by the provided wrapping policy.
 """
 
-# Environment variable to use unsafe `setattr()` for view setting
+# Environment variable to toggling whether to use unsafe `setattr()` for view
+# setting in `_use_sharded_views()` and `_use_unsharded_views()`
+# We should use 'safe' by default since it respects method overrides, but for
+# special cases such as for high CPU overhead or for intentionally bypassing
+# checks in the overrides, we may use 'unsafe'.
 _FSDP_USE_UNSAFE_SETATTR = "FSDP_USE_UNSAFE_SETATTR"
 
 
@@ -352,8 +356,6 @@ class FlatParamHandle:
         use_orig_params: bool,
     ):
         super().__init__()
-        # For special cases (e.g. high CPU overhead), we may want to bypass the
-        # `nn.Module.setattr()` checks, where we gate this with an env var.
         use_unsafe_setattr = os.environ.get(_FSDP_USE_UNSAFE_SETATTR, "") == "1"
         self._setattr_tensor: Callable[[nn.Module, str, Tensor], None]
         self._setattr_param: Callable[[nn.Module, str, nn.Parameter], None]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96326

This adds the option to use an unsafe `setattr` for `_use_sharded_views()` and `_use_unsharded_views()` gated by the environment variable `FSDP_USE_UNSAFE_SETATTR`, where a value of `1` means to use the unsafe `setattr`. The unsafe option is disabled by default.

The unsafe `setattr` may be able to save CPU overhead and may be used to intentionally bypass `setattr` checks. Both `_use_sharded_views()` and `_use_unsharded_views()` must use the unsafe version or use the safe versions atomically.