### PR TITLE
[PyTorch][easy] Don't call IValue::type twice in Pickler::endTypeTag

### DIFF
--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -600,9 +600,9 @@ void Pickler::endTypeTag(const IValue& ivalue) {
   TORCH_INTERNAL_ASSERT(ivalue.isGenericDict() || ivalue.isList());
 
   // Push the dict type
-  TORCH_INTERNAL_ASSERT(ivalue.type());
-
   auto type = ivalue.type();
+  TORCH_INTERNAL_ASSERT(type);
+
   auto annot_str = type->annotation_str(type_printer);
   pushString(annot_str);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

The duplicate call is unlikely to be eliminated by the compiler (it can return a new heap-allocated object).

Differential Revision: [D43877846](https://our.internmc.facebook.com/intern/diff/D43877846/)