### PR TITLE
[ONNX][Diagnostics] Speed up 'python_call_stack' by 'traceback'

### DIFF
--- a/torch/onnx/_internal/diagnostics/infra/_infra.py
+++ b/torch/onnx/_internal/diagnostics/infra/_infra.py
@@ -179,7 +179,7 @@ class StackFrame:
 
 @dataclasses.dataclass
 class Stack:
-    """Records a stack trace. The top of the stack is the first element in the list."""
+    """Records a stack trace. The frames are in order from newest to oldest stack frame."""
 
     frames: List[StackFrame] = dataclasses.field(default_factory=list)
     message: Optional[str] = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96348

`inspect.stack()` retrieves all stacktraces, and is not performant. `inspect.stack(0)`
speeds up the call greatly, but loses line snippet.
Rewrite with `traceback.extract_stack` which is better in both regards.
Speeds up `export` call in `test_gpt2_tiny` from ~30s to ~4s under profiling.

Before
```log
│...├─ 30.794 export_after_normalizing_args_and_kwargs  <@beartype(torch.onnx._internal.fx.exporter.export_after_normalizing_args_and_kwargs) at 0x7f815cba0700>:1
│...│  └─ 30.794 export_after_normalizing_args_and_kwargs  torch/onnx/_internal/fx/exporter.py:580
```

After
```log
│...├─ 4.427 export_after_normalizing_args_and_kwargs  <@beartype(torch.onnx._internal.fx.exporter.export_after_normalizing_args_and_kwargs) at 0x7fd8281b3700>:1
│...│  └─ 4.427 export_after_normalizing_args_and_kwargs  torch/onnx/_internal/fx/exporter.py:580
```
