### PR TITLE
Retry XLA dependencies installation step

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -647,7 +647,7 @@ build_xla() {
   apply_patches
   SITE_PACKAGES="$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
   # These functions are defined in .circleci/common.sh in pytorch/xla repo
-  install_deps_pytorch_xla $XLA_DIR $USE_CACHE
+  retry install_deps_pytorch_xla $XLA_DIR $USE_CACHE
   CMAKE_PREFIX_PATH="${SITE_PACKAGES}/torch:${CMAKE_PREFIX_PATH}" XLA_SANDBOX_BUILD=1 build_torch_xla $XLA_DIR
   assert_git_not_dirty
 }


### PR DESCRIPTION
XLA install some dependencies as part of the CI job and the step could fail sometime due to network flakiness, i.e. https://hud.pytorch.org/pytorch/pytorch/commit/3f840cc627b8e0002cdf6593e9d1d83a46255f31 where it failed to get some nodejs packages.  A quick fix would be to retry the step.