### PR TITLE
[PyTorch] Use c10::FastMap for memoizing in Pickler

### DIFF
--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -9,6 +9,7 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/core/jit_type.h>
 #include <c10/util/ArrayRef.h>
+#include <c10/util/FbcodeMaps.h>
 #include <torch/csrc/Export.h>
 
 namespace torch {
@@ -251,7 +252,7 @@ class TORCH_API Pickler {
 
   // Memoization of IValues that have been written (index in table is used for
   // BINPUT opcodes) to enable shared references
-  std::unordered_map<const void*, uint32_t> memoized_ivalue_map_;
+  c10::FastMap<const void*, uint32_t> memoized_ivalue_map_;
 
   // because we de-dup ivalues based on their raw pointer address in the above
   // map we need to keep all the memoized values alive during the pickle.
@@ -271,11 +272,11 @@ class TORCH_API Pickler {
   // List of tensor storages to serialize in the same binary as the pickle data
   // similar to ivalues, they are memoized using BINPUT
   std::vector<at::Tensor> tensor_data_;
-  std::unordered_map<const void*, uint32_t> memoized_storage_map_;
+  c10::FastMap<const void*, uint32_t> memoized_storage_map_;
 
-  std::unordered_map<std::string, uint32_t> memoized_globals_map_;
-  std::unordered_map<std::string, uint32_t> memoized_strings_map_;
-  std::unordered_map<std::string, uint32_t> memoized_devices_map_;
+  c10::FastMap<std::string, uint32_t> memoized_globals_map_;
+  c10::FastMap<std::string, uint32_t> memoized_strings_map_;
+  c10::FastMap<std::string, uint32_t> memoized_devices_map_;
   // when true, List and Dict objects will be wrapped in a
   // torch.jit._pickle.restore_type_tag call to correctly set the dynamic
   // TorchScript type for the object. When true the thing unpickling must have


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

These maps don't rely on reference stability, so FastMap should be fine.

Differential Revision: [D43926671](https://our.internmc.facebook.com/intern/diff/D43926671/)