### PR TITLE
Test the impact of 4 to 1 checks in each module

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1495,7 +1495,7 @@ class Module:
         forward_call = (self._slow_forward if torch._C._get_tracing_state() else self.forward)
         # If we don't have any hooks, we want to skip the rest of the logic in
         # this function, and just call forward.
-        if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
+        if not (self._forward_hooks
                 or _global_backward_pre_hooks or _global_backward_hooks
                 or _global_forward_hooks or _global_forward_pre_hooks):
             return forward_call(*args, **kwargs)


### PR DESCRIPTION
This is a simple ablation
* first i revert my 'unsound _has_hools' PR, below in stack
* then I do some useless optimization on the global hooks (next pr in stack, no effect on perf)
* finally in this PR, i just cut 3 of the 4 module hook dicts from the fast path check, and get all my perf back

`python benchmarks/dynamo/huggingface.py --only MobileBertForQuestionAnswering --inductor --train --performance`
This PR: 1.269x
This the PR below 1.186x
The baseline from master (before the unsound revert): 1.266x

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96361
* #96246
* #96242

