### PR TITLE
[CUDA][cuFFT] Minor fix for cuFFT plan cache docs

### DIFF
--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -38,21 +38,22 @@ torch.backends.cuda
 
     A :class:`bool` that controls whether reduced precision reductions are allowed with bf16 GEMMs.
 
-.. attribute::  torch.backends.cuda.cufft_plan_cache
+.. attribute::  torch.backends.cuda.cufft_plan_cache[i]
 
-    ``cufft_plan_cache`` caches the cuFFT plans
+    ``cufft_plan_cache`` contains the cuFFT plan caches for each CUDA device.
+    Query a specific device `i`'s cache via `torch.backends.cuda.cufft_plan_cache[i]`.
 
     .. attribute::  size
 
-        A readonly :class:`int` that shows the number of plans currently in the cuFFT plan cache.
+        A readonly :class:`int` that shows the number of plans currently in a cuFFT plan cache.
 
     .. attribute::  max_size
 
-        A :class:`int` that controls cache capacity of cuFFT plan.
+        A :class:`int` that controls the capacity of a cuFFT plan cache.
 
     .. method::  clear()
 
-        Clears the cuFFT plan cache.
+        Clears a cuFFT plan cache.
 
 .. autofunction:: torch.backends.cuda.preferred_linalg_library
 

--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -38,7 +38,7 @@ torch.backends.cuda
 
     A :class:`bool` that controls whether reduced precision reductions are allowed with bf16 GEMMs.
 
-.. attribute::  torch.backends.cuda.cufft_plan_cache[i]
+.. attribute::  torch.backends.cuda.cufft_plan_cache
 
     ``cufft_plan_cache`` contains the cuFFT plan caches for each CUDA device.
     Query a specific device `i`'s cache via `torch.backends.cuda.cufft_plan_cache[i]`.


### PR DESCRIPTION
The attributes described in the docs require indexing in to the plan cache manager, as there is a separate plan cache per device.

CC @ptrblck @ngimel 