### PR TITLE
[PyTorch] Accept string_view in Pickler::pushGlobal

### DIFF
--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -328,12 +328,16 @@ void Pickler::pushBytes(const std::string& string) {
 }
 
 void Pickler::pushGlobal(
-    const std::string& module_name,
-    const std::string& class_name) {
+    c10::string_view module_name,
+    c10::string_view class_name) {
   std::string key;
   key.reserve(module_name.size() + class_name.size() + 2);
-  key.append(module_name).append("\n").append(class_name).append("\n");
-  auto memo_entry = memoized_globals_map_.find(key);
+  key.append(module_name.data(), module_name.size());
+  key.push_back('\n');
+  key.append(class_name.data(), class_name.size());
+  key.push_back('\n');
+
+  const auto memo_entry = memoized_globals_map_.find(key);
   if (memo_entry == memoized_globals_map_.end()) {
     push<PickleOpCode>(PickleOpCode::GLOBAL);
     pushBytes(key);

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -9,6 +9,7 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/core/jit_type.h>
 #include <c10/util/ArrayRef.h>
+#include <c10/util/string_view.h>
 #include <torch/csrc/Export.h>
 
 namespace torch {
@@ -191,8 +192,8 @@ class TORCH_API Pickler {
       const char* list_name,
       const std::function<void(const IValue&)>& item_pusher);
   void pushGlobal(
-      const std::string& module_name,
-      const std::string& class_name);
+      c10::string_view module_name,
+      c10::string_view class_name);
   // raw string data is appended directly to the byte stream
   void pushBytes(const std::string& string);
   void pushTensorData(const at::Tensor& tensor);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This should make a difference for users building with libstdc++: we pass string literals to pushGlobal with length longer than 15 bytes, and 15 bytes is the maximum inline size of libstdc++'s std::string before it will heap allocate.

Differential Revision: [D43930698](https://our.internmc.facebook.com/intern/diff/D43930698/)