### PR TITLE
[CUDA] Abate spurious resize warnings in MultiMarginLoss backward

### DIFF
--- a/aten/src/ATen/native/cuda/MultiMarginLoss.cu
+++ b/aten/src/ATen/native/cuda/MultiMarginLoss.cu
@@ -385,7 +385,7 @@ Tensor multi_margin_loss_cuda_backward(
     const Tensor &grad_output, const Tensor &input, const Tensor &target,
     const Scalar &p, const Scalar &margin, const c10::optional<Tensor> &weights,
     int64_t reduction) {
-  auto grad_input = at::empty({}, input.options());
+  auto grad_input = at::empty({0}, input.options());
   multi_margin_loss_cuda_backward_out(
       grad_output, input, target, p, margin, weights, reduction, grad_input);
   return grad_input;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8686,10 +8686,10 @@ class TestNNDeviceType(NNTestCase):
         loss = torch.nn.MultiMarginLoss()
         x = torch.rand((56, 128), device=device)
         targets = torch.randint(22, (56,), device=device)
-        out = model(x)
-        l = loss(out, targets)
         f = io.StringIO()
         with contextlib.redirect_stderr(f):
+            out = model(x)
+            l = loss(out, targets)
             l.backward()
         self.assertTrue(len(f.getvalue()) == 0)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8680,6 +8680,19 @@ class TestNNDeviceType(NNTestCase):
                 y = torch.ones(10, 0, device=device).type(torch.long)
                 mod(x, y)
 
+    @onlyCUDA
+    def test_MarginLoss_warnings(self, device):
+        model = torch.nn.Linear(128, 22, device=device)
+        loss = torch.nn.MultiMarginLoss()
+        x = torch.rand((56, 128), device=device)
+        targets = torch.randint(22, (56,), device=device)
+        out = model(x)
+        l = loss(out, targets)
+        f = io.StringIO()
+        with contextlib.redirect_stderr(f):
+            l.backward()
+        self.assertTrue(len(f.getvalue()) == 0)
+
     @onlyNativeDeviceTypes
     def test_Unfold_empty(self, device):
         inp = torch.randn(0, 3, 3, 4, device=device)


### PR DESCRIPTION
Follow-up of #75000 for backward.

CC @ngimel @ptrblck 