### PR TITLE
[experiment, do not land] per-stream allocation cache

### DIFF
--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -16,6 +16,9 @@ namespace c10 {
 class C10_CUDA_API FreeMemoryCallback {
  public:
   virtual ~FreeMemoryCallback() = default;
+  virtual bool FreeMemory(int device) {
+    return Execute();
+  }
   virtual bool Execute() = 0;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96383

Quick and hacky way to avoid contention on the same device when multiple
threads are issuing commands to different streams. Each stream maintains
a list of exact match tensors, and will hand them out before going to the allocator.