### PR TITLE
[FSDP] Full precision in eval mode

### DIFF
--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -710,6 +710,10 @@ def _post_backward_hook(
             if (
                 not _low_precision_hook_enabled(state)
                 and flat_param.grad.dtype != handle._reduce_dtype
+                # TODO (rohan-varma) add test when in eval mode, but only
+                # reduction is in reduced dtype, comm should still be in fp32
+                # due to this check.
+                and not handle._force_full_precision
             ):
                 flat_param.grad.data = flat_param.grad.to(handle._reduce_dtype)
 
@@ -1376,4 +1380,5 @@ def _cast_buffers_to_dtype_and_device(
         if not torch.is_floating_point(buffer) or buffer_dtype is None:
             buffer.data = buffer.to(device=device)
         else:
+            print(f" -- casting buffer {buffer.shape} to {buffer_dtype}")
             buffer.data = buffer.to(device=device, dtype=buffer_dtype)

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -233,10 +233,12 @@ class TransformerWithSharedParams(FSDPTestModel):
         self.register_buffer(
             "vocab_bias", self.embed_tokens.weight.new_ones((d_model,))
         )
+        print(f"vocab_bias dtype {self.vocab_bias.dtype}")
         self.register_buffer(
             "long_buffer",
             torch.zeros_like(self.vocab_bias, dtype=torch.long),
         )  # type: ignore[arg-type]
+        print(f"long_buffer dtype {self.long_buffer.dtype}")
 
         self.bs = 2
         self.bn = torch.nn.BatchNorm1d(self.bs) if add_bn else torch.nn.Identity()
@@ -253,6 +255,7 @@ class TransformerWithSharedParams(FSDPTestModel):
 
     def forward(self, src_ids, tgt_ids):
         src = self.embed_tokens(src_ids)
+        print(f"in fwd: {self.vocab_bias.dtype}")
         src = src + self.vocab_bias + self.long_buffer.type_as(src)  # type: ignore[operator]
         tgt = self.embed_tokens(tgt_ids)
         tgt = self.bn(tgt)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Run in full precision during eval

Differential Revision: [D43933690](https://our.internmc.facebook.com/intern/diff/D43933690/)