### PR TITLE
Reduce pytest blocklist part 2

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6648,6 +6648,7 @@ if HAS_CPU:
                 )
                 return clone_3
 
+            metrics.reset()
             x = torch.randn(1, 384, 20, 20).to(memory_format=torch.channels_last)
             opt_fn = torch._dynamo.optimize("inductor")(fn)
             same(fn(x), opt_fn(x))

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -5106,6 +5106,17 @@ class TestQuantizeFx(QuantizationTestCase):
         self.assertEqual(fq1()._observer_ctr, fq2()._observer_ctr)
 
     def test_register_patterns(self):
+        def cleanUp():
+            del _DEFAULT_FUSION_PATTERNS["dummy_fusion"]
+            del _DEFAULT_QUANTIZATION_PATTERNS["dummy_quant"]
+            del _DEFAULT_QUANTIZATION_PATTERNS["dummy_quant2"]
+            del _DEFAULT_QUANTIZATION_PATTERNS["dummy_quant3"]
+            del _DEFAULT_OUTPUT_OBSERVER_MAP["dummy_quant2"]
+            del _DEFAULT_OUTPUT_OBSERVER_MAP["dummy_quant3"]
+            del _DEFAULT_OUTPUT_FAKE_QUANTIZE_MAP["dummy_quant2"]
+            del _DEFAULT_OUTPUT_FAKE_QUANTIZE_MAP["dummy_quant3"]
+        self.addCleanup(cleanUp)
+
         @_register_fusion_pattern("dummy_fusion")
         class DummyFusion():
             pass

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -902,15 +902,10 @@ CUSTOM_HANDLERS = {
 
 
 PYTEST_BLOCKLIST = [
-    "test_package",
-    "inductor/test_torchinductor",
-    "test_quantization",
-    "test_fx",
     "profiler/test_profiler",
     "dynamo/test_repros",  # skip_if_pytest
     "dynamo/test_optimizers",  # skip_if_pytest
     "dynamo/test_dynamic_shapes",  # needs change to check_if_enable for disabled test issues
-    "dynamo/test_unspec",  # imports repros
 ]
 
 

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -1,14 +1,23 @@
 # Owner(s): ["oncall: package/deploy"]
 
-def load_tests(loader, standard_tests, pattern):
-    """Load all tests from `test/pacakge/`
-    """
-    if pattern is None:
-        # Use the default pattern if none is specified by the test loader.
-        pattern = "test*.py"
-    package_tests = loader.discover("package", pattern=pattern)
-    standard_tests.addTests(package_tests)
-    return standard_tests
+from package.test_resources import TestResources  # noqa: F401
+from package.test_model import ModelTest  # noqa: F401
+from package.test_dependency_api import TestDependencyAPI  # noqa: F401
+from package.test_mangling import TestMangling  # noqa: F401
+from package.test_misc import TestMisc  # noqa: F401
+from package.test_directory_reader import DirectoryReaderTest  # noqa: F401
+from package.test_importer import TestImporter  # noqa: F401
+from package.test_glob_group import TestGlobGroup  # noqa: F401
+from package.test_package_script import TestPackageScript  # noqa: F401
+from package.test_save_load import TestSaveLoad  # noqa: F401
+from package.test_repackage import TestRepackage  # noqa: F401
+from package.test_package_fx import TestPackageFX  # noqa: F401
+from package.test_dependency_hooks import TestDependencyHooks  # noqa: F401
+from package.test_load_bc_packages import TestLoadBCPackages  # noqa: F401
+from package.test_analyze import TestAnalyze  # noqa: F401
+from package.test_digraph import TestDiGraph  # noqa: F401
+from package.package_a.test_all_leaf_modules_tracer import TestAllLeafModulesTracer  # noqa: F401
+from package.package_a.test_nn_module import TestNnModule  # noqa: F401
 
 
 if __name__ == "__main__":

--- a/torch/fx/passes/utils/fuser_utils.py
+++ b/torch/fx/passes/utils/fuser_utils.py
@@ -207,6 +207,7 @@ def insert_subgm(gm: GraphModule, sub_gm: GraphModule, orig_inputs: Tuple[Node, 
             orig_output.replace_all_uses_with(proxy_out, propagate_meta=True)
     return gm
 
+@compatibility(is_backward_compatible=False)
 def erase_nodes(gm: GraphModule, nodes: NodeList):
 
     # erase original nodes in inversed topological order
@@ -214,6 +215,7 @@ def erase_nodes(gm: GraphModule, nodes: NodeList):
         gm.graph.erase_node(node)
 
 
+@compatibility(is_backward_compatible=False)
 def fuse_by_partitions(gm: GraphModule, partitions: List[NodeList]) -> GraphModule:
     for partition_id, nodes in enumerate(partitions):
         sorted_nodes = topo_sort(nodes)

--- a/torch/fx/passes/utils/fuser_utils.py
+++ b/torch/fx/passes/utils/fuser_utils.py
@@ -8,7 +8,9 @@ from torch.fx.graph import Graph
 from torch.fx.node import Node
 from torch.fx.passes.tools_common import NodeList, NodeSet, legalize_graph
 from torch.fx.passes.utils import lift_subgraph_as_module
+from torch.fx._compatibility import compatibility
 
+@compatibility(is_backward_compatible=False)
 def topo_sort(nodes: NodeList) -> NodeList:
     # sort nodes according to the topological order
     indegree_map = {node : 0 for node in nodes}
@@ -37,6 +39,7 @@ def topo_sort(nodes: NodeList) -> NodeList:
     return sorted_nodes
 
 
+@compatibility(is_backward_compatible=False)
 def validate_partition(partition: NodeList) -> bool:
     # verify the partition does't form a dependency cycle in the original graph
     # returns True for valid partition, False for invalid
@@ -85,6 +88,7 @@ def validate_partition(partition: NodeList) -> bool:
     return True
 
 
+@compatibility(is_backward_compatible=False)
 def fuse_as_graphmodule(gm: GraphModule,
                         nodes: NodeList,
                         module_name: str) -> Tuple[GraphModule, Tuple[Node, ...], Tuple[Node, ...]]:
@@ -181,6 +185,7 @@ def fuse_as_graphmodule(gm: GraphModule,
     return fused_gm, original_inputs, original_outputs
 
 
+@compatibility(is_backward_compatible=False)
 def insert_subgm(gm: GraphModule, sub_gm: GraphModule, orig_inputs: Tuple[Node, ...], orig_outputs: Tuple[Node, ...]):
     # add sub_gm into gm
     submodule_name = sub_gm.__class__.__name__


### PR DESCRIPTION
Enable pytest for a few unique files.  pytest runs tests in a different order than unittest (but still a consistent ordering with respect to itself) and some tests change global state, causing other tests to fail.

`test_transpose_non_contiguous` in `test_torchinductor.py` gets impacted from some other test but I'm not sure which one, so my solution is to reset the metrics before the rest of the test is run.

`test_register_patterns` in `test_quantize_fx.py` adds extra keys to global variables, so remove them when the test is done via unittest's `addCleanUp` which also works on pytest.  

pytest doesn't really have an equivalent for `load_tests` so change it to be like `test_jit` that imports all the classes.  I also attempted to dynamically import them, but I failed.

`test_public_api_surface` in `test_fx.py` checks for a backwards compatibility classification.  There is a different test in test_fx that results in `fuser_utils` being imported.  pytest runs this test before `test_public_api_surface` while unittest runs it after, so pytest sees `fuser_utils` when crawling through the modules.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire