### PR TITLE
Add location information for assertions in `torch.jit.annotations.try_ann_to_type`

### DIFF
--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -347,8 +347,8 @@ def try_ann_to_type(ann, loc):
         else:
             contained = ann.__args__[1]
         valid_type = try_ann_to_type(contained, loc)
-        msg = "Unsupported annotation {} could not be resolved because {} could not be resolved."
-        assert valid_type, msg.format(repr(ann), repr(contained))
+        msg = "Unsupported annotation {} could not be resolved because {} could not be resolved. At\n{}"
+        assert valid_type, msg.format(repr(ann), repr(contained), repr(loc))
         return OptionalType(valid_type)
     if is_union(ann):
         # TODO: this is hack to recognize NumberType
@@ -362,8 +362,8 @@ def try_ann_to_type(ann, loc):
             if a is None:
                 inner.append(NoneType.get())
             maybe_type = try_ann_to_type(a, loc)
-            msg = "Unsupported annotation {} could not be resolved because {} could not be resolved."
-            assert maybe_type, msg.format(repr(ann), repr(maybe_type))
+            msg = "Unsupported annotation {} could not be resolved because {} could not be resolved. At\n{}"
+            assert maybe_type, msg.format(repr(ann), repr(maybe_type), repr(loc))
             inner.append(maybe_type)
         return UnionType(inner)    # type: ignore[arg-type]
     if torch.distributed.rpc.is_available() and is_rref(ann):


### PR DESCRIPTION
There are two assertions in `torch.jit.annotations.try_ann_to_type` that could benefit from adding source level location information. 

For example, the current assertion:
```
        msg = "Unsupported annotation {} could not be resolved because {} could not be resolved."
        assert valid_type, msg.format(repr(ann), repr(contained))
```
reports:
```
AssertionError: Unsupported annotation typing.Union[typing.Dict, NoneType] could not be resolved because typing.Dict could not be resolved at
```
I find it beneficial to know from which line of code this assertion was triggered. Adding the location information then reports:
```
AssertionError: Unsupported annotation typing.Union[typing.Dict, NoneType] could not be resolved because typing.Dict could not be resolved at
  File "/home/schuetze/Documents/work/github/prediction_net/multimodal/models/heads/retina_head.py", line 189
    def forward(self, fpn_features: t.Dict[str, torch.Tensor],
                inputs: t.Dict[str, torch.Tensor],
                gts: t.Optional[t.Dict] = None) -> t.Dict[str, t.Any]:
                     ~~~~~~~~~~~~~~~~~~ <--- HERE
        """
        """
```

Adding these location information are related to #96420  but these changes in this PR can be made without any API changes. 

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel