### PR TITLE
Add jinja2 as mandatory dependency (#95691)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1024,6 +1024,7 @@ def main():
         'typing-extensions',
         'sympy',
         'networkx',
+        'jinja2',
     ]
 
     extras_require = {


### PR DESCRIPTION
Should fix #95671  for nightly wheels issue. 
Pull Request resolved: https://github.com/pytorch/pytorch/pull/95691 
Approved by: https://github.com/malfet

[Edit] Remove `v2.0.0 RC does not need this.`