### PR TITLE
Example of running  Decomposition in eager mode

### DIFF
--- a/export_workspace/eager_decomp.py
+++ b/export_workspace/eager_decomp.py
@@ -1,0 +1,34 @@
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch._decomp import core_aten_decompositions
+
+class TestModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bn = torch.nn.BatchNorm2d(3)
+
+    def forward(self, x):
+        return self.bn(x)
+
+x = torch.rand(2, 3, 244, 244)
+model = TestModule()
+
+class TorchEagerDecomposeMode(TorchDispatchMode):
+    def __init__(self, decomposition_table):
+        super().__init__()
+        self.decomposition_table = decomposition_table
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if func in self.decomposition_table:
+            print(f"Decomposing {func}")
+            with self:
+                return self.decomposition_table[func](*args, **kwargs)
+        else:
+            print(f"Running {func}")
+            return func(*args, **kwargs)
+
+enable_eager_decomp = False
+decomposition_table = core_aten_decompositions() if enable_eager_decomp else {}
+
+with TorchEagerDecomposeMode(decomposition_table):
+    y = model(x)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #96661
* __->__ #96466

enable_eager_decom=False
```
Running aten.add_.Tensor
Running aten.empty.memory_format
Running aten.native_batch_norm.default
```

enable_eager_decom=True
```
Running aten.add_.Tensor
Running aten.empty.memory_format
Decomposing aten.native_batch_norm.default
Running aten.to.dtype
Running aten.var_mean.correction
Running aten.add.Tensor
Running aten.rsqrt.default
Running aten.sub.Tensor
Running aten.mul.Tensor
Running aten.squeeze.dims
Running aten.squeeze.dims
Running aten.mul.Tensor
Running aten.mul.Tensor
Running aten.add.Tensor
Running aten.copy_.default
Running aten.squeeze.dims
Running aten.mul.Tensor
Running aten.mul.Tensor
Running aten.mul.Tensor
Running aten.add.Tensor
Running aten.copy_.default
Running aten.unsqueeze.default
Running aten.unsqueeze.default
Running aten.unsqueeze.default
Running aten.unsqueeze.default
Running aten.mul.Tensor
Running aten.add.Tensor
Running aten.to.dtype
Running aten.to.dtype
Running aten.to.dtype
```