### PR TITLE
enable bf16 atomic add

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -906,7 +906,11 @@ class CppKernel(Kernel):
             if not config.cpp.dynamic_threads and self.num_threads == 1:
                 line = f"{var}[{cexpr(index)}] += {value};"
             else:
-                line = f"atomic_add(&{var}[{cexpr(index)}], {value});"
+                 dtype = V.graph.get_dtype(name)
+                 if dtype in (torch.float16, torch.bfloat16):
+                     line = f"atomic_add(&{var}[{cexpr(index)}], static_cast<{DTYPE_TO_CPP[dtype]}>({value}));"
+                 else:
+                    line = f"atomic_add(&{var}[{cexpr(index)}], {value});"
         else:
             raise NotImplementedError(f"store mode={mode}")
         self.stores.writeline(name, line)

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -38,24 +38,44 @@ float randn_cpu(uint32_t seed, uint32_t offset) {
 template <typename T> struct AsIntegerType { typedef T type; };
 template <> struct AsIntegerType<float> { typedef uint32_t type; };
 template <> struct AsIntegerType<double> { typedef uint64_t type; };
+template <>
+struct AsIntegerType<bfloat16> {
+  typedef uint16_t type;
+};
+template <>
+struct AsIntegerType<half> {
+  typedef uint16_t type;
+};
 
-template <typename T> void atomic_add(volatile T *addr, T offset) {
+template <typename T>
+void atomic_add(T* addr, T offset) {
   typedef typename AsIntegerType<T>::type alt_type;
 
   static_assert(sizeof(std::atomic<alt_type>) == sizeof(T),
                 "std::atomic issue");
 
-  alt_type expected;
+  typedef union {
+    alt_type intV;
+    T fV;
+  } uf_int;
 
-  alt_type desired;
+  uf_int expected, desired;
+  std::atomic<alt_type>* atomic_addr = (std::atomic<alt_type>*)addr;
 
-  std::atomic<alt_type> *atomic_addr = (std::atomic<alt_type> *)addr;
-  do {
-    T val = *addr;
-    reinterpret_cast<T *>(&expected)[0] = val;
-    reinterpret_cast<T *>(&desired)[0] = val + offset;
-  } while (!atomic_addr->compare_exchange_weak(expected, desired,
-                                               std::memory_order_relaxed));
+  expected.fV = *addr;
+  desired.fV = expected.fV + offset;
+
+  alt_type* expected_intV = (alt_type*)(&expected.intV);
+  while (!std::atomic_compare_exchange_strong(
+      atomic_addr, expected_intV, desired.intV)) {
+#ifdef __aarch64__
+    __asm__ __volatile__("yield;" : : : "memory");
+#else
+    _mm_pause();
+#endif
+    expected.fV = *addr;
+    desired.fV = expected.fV + offset;
+  }
 }
 
 // This function is used to convert bool or uint8 to float mask for
@@ -85,16 +105,11 @@ inline at::vec::Vectorized<float> to_float_mask(at::vec::Vectorized<SRC>& src) {
   assert(
       at::vec::Vectorized<float>::size() == at::vec::Vectorized<SRC>::size());
   at::vec::Vectorized<float> res_vec(0);
-  __at_align__ float dst_tmp[at::vec::Vectorized<float>::size()];
-  __at_align__ SRC src_tmp[at::vec::Vectorized<SRC>::size()];
-  src.store(src_tmp);
-
 #pragma unroll
   for (int i = 0; i < at::vec::Vectorized<float>::size(); i++) {
-    dst_tmp[i] = src_tmp[i] ? 0xFFFFFFFF : 0;
+    res_vec[i] = src[i] ? 0xFFFFFFFF : 0;
   }
-
-  return res_vec.loadu(dst_tmp);
+  return res_vec;
 }
 
 template <>

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -107,7 +107,7 @@ inline at::vec::Vectorized<float> to_float_mask(at::vec::Vectorized<SRC>& src) {
   at::vec::Vectorized<float> res_vec(0);
   __at_align__ float dst_tmp[at::vec::Vectorized<float>::size()];
   __at_align__ SRC src_tmp[at::vec::Vectorized<SRC>::size()];
-  src.store(src_tmp);  
+  src.store(src_tmp);
 
 #pragma unroll
   for (int i = 0; i < at::vec::Vectorized<float>::size(); i++) {

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -13,6 +13,12 @@
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
 
+#if (defined(__x86_64__) || defined(__i386__) || defined(__aarch64__))
+#include <ATen/native/cpu/Intrinsics.h>
+#else
+#define _mm_pause()
+#endif
+
 typedef at::Half half;
 typedef at::BFloat16 bfloat16;
 

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -105,11 +105,14 @@ inline at::vec::Vectorized<float> to_float_mask(at::vec::Vectorized<SRC>& src) {
   assert(
       at::vec::Vectorized<float>::size() == at::vec::Vectorized<SRC>::size());
   at::vec::Vectorized<float> res_vec(0);
+  __at_align__ float dst_tmp[at::vec::Vectorized<float>::size()];
+  __at_align__ SRC src_tmp[at::vec::Vectorized<SRC>::size()];
+  src.store(src_tmp);  
 #pragma unroll
   for (int i = 0; i < at::vec::Vectorized<float>::size(); i++) {
-    res_vec[i] = src[i] ? 0xFFFFFFFF : 0;
+    dst_tmp[i] = src_tmp[i] ? 0xFFFFFFFF : 0;
   }
-  return res_vec;
+  return res_vec.loadu(dst_tmp);
 }
 
 template <>

--- a/torch/_inductor/codegen/cpp_prefix.h
+++ b/torch/_inductor/codegen/cpp_prefix.h
@@ -108,10 +108,12 @@ inline at::vec::Vectorized<float> to_float_mask(at::vec::Vectorized<SRC>& src) {
   __at_align__ float dst_tmp[at::vec::Vectorized<float>::size()];
   __at_align__ SRC src_tmp[at::vec::Vectorized<SRC>::size()];
   src.store(src_tmp);  
+
 #pragma unroll
   for (int i = 0; i < at::vec::Vectorized<float>::size(); i++) {
     dst_tmp[i] = src_tmp[i] ? 0xFFFFFFFF : 0;
   }
+
   return res_vec.loadu(dst_tmp);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96472

This PR just enabled BF16 atomic add to solve functionality issue for https://github.com/pytorch/pytorch/issues/95197 and https://github.com/pytorch/pytorch/issues/95189. `atomic add`are following https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/AtomicAddFloat.h. The old one with `volatile` keyword and`weak exchange` is hard to support BF16 since BF16 is not a dtype and do not support `bfloat16 val = *addr` while `addr` is `volatile bfloat16 *`


But I do not know whether we should use BF16 atomic add since it accuracy is low. It suffered from:
 - non deterministic parallel reduction (FP32 also suffered but low precision suffered more. https://github.com/pytorch/pytorch/issues/93582
 -  Do no using accumulation type.

From my understanding, it is hard to have high accuracy if we perform add to a `bfloat16 ptr` in `store`
```
extern "C" void kernel(const bfloat16* __restrict__ in_ptr0,
                       const long* __restrict__ in_ptr1,
                       const bfloat16* __restrict__ in_ptr2,
                       bfloat16* __restrict__ out_ptr0)
{
    #pragma omp parallel num_threads(64)
    {
        {
            #pragma omp for 
            for(long i0=0; i0<1254400; i0+=1)
            {
                auto tmp0 = static_cast<float>(in_ptr0[i0]);
                out_ptr0[i0] = tmp0;
            }
        }
        {
            #pragma omp for 
            for(long i0=0; i0<600; i0+=1)
            {
                #pragma GCC ivdep
                for(long i1=0; i1<12544; i1+=1)
                {
                    auto tmp0 = in_ptr1[i0];
                    auto tmp1 = static_cast<float>(in_ptr2[i1 + (12544*i0)]);
                    atomic_add(&out_ptr0[i1 + (12544*tmp0)], static_cast<bfloat16>(tmp1));
                }
            }
        }
    }
}
''')
```
Using local buffer for accumulation and using single thread to add local buffer together might be a better solution for both two issues, but may have impact on performance. Do you have some suggestions are this? CC @EikanWang, @jgong5.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @soumith @anijain2305 @desertfire