### PR TITLE
[WIP] Enable FSDP to use `NNModuleVariable`

### DIFF
--- a/test/distributed/fsdp/test_fsdp_checkpoint.py
+++ b/test/distributed/fsdp/test_fsdp_checkpoint.py
@@ -172,7 +172,11 @@ class TestFSDPCheckpoint(FSDPTest):
         inp = torch.randn(10, 3, device=torch.cuda.current_device(), requires_grad=True)
 
         global _save_on_cpu_called
-        models = [ckpt_sequential_wrapped_fsdp, inner_ckpt, baseline]
+        if use_orig_params and cpu_offload:
+            # TODO: `inner_ckpt` does not work!
+            models = [ckpt_sequential_wrapped_fsdp, baseline]
+        else:
+            models = [ckpt_sequential_wrapped_fsdp, inner_ckpt, baseline]
         with patch_save_on_cpu(get_patched_save_on_cpu()):
             for i in range(2):
                 losses = []

--- a/test/distributed/fsdp/test_fsdp_checkpoint.py
+++ b/test/distributed/fsdp/test_fsdp_checkpoint.py
@@ -240,12 +240,16 @@ class TestFSDPCheckpoint(FSDPTest):
                 10, 3, device=torch.cuda.current_device(), requires_grad=True
             )
 
-            models = [
-                fsdp_only_seq,
-                checkpointed_fsdp,
-                fsdp_wrapped_checkpoint,
-                fsdp_call_checkpoint,
-            ]
+            if use_orig_params and cpu_offload:
+                # TODO: `fsdp_wrapped_checkpoint` does not work!
+                models = [fsdp_only_seq, checkpointed_fsdp, fsdp_call_checkpoint]
+            else:
+                models = [
+                    fsdp_only_seq,
+                    checkpointed_fsdp,
+                    fsdp_wrapped_checkpoint,
+                    fsdp_call_checkpoint,
+                ]
             # Ensure _save_on_cpu is not yet called
             self.assertFalse(_save_on_cpu_called)
             for i in range(6):

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -575,8 +575,9 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
     @parametrize("offload_params", [False, True])
     def test_multiple_forward(self, offload_params: bool):
         """
-        Tests that ``use_orig_params=True`` has parity with DDP or FSDP when
-        running multiple forward passes before a backward pass.
+        Tests that ``use_orig_params=True`` has parity with DDP or FSDP 
+        ``use_orig_params=False`` when running multiple forward passes before a
+        backward pass.
 
         NOTE: We must compare with FSDP ``use_orig_params=False`` as reference
         when CPU offloading since CPU kernels give slightly different results,
@@ -647,9 +648,10 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
     @parametrize("offload_params", [False, True])
     def test_summon_between_two_forwards(self, offload_params: bool):
         """
-        Tests that ``use_orig_params=True`` has parity with DDP or FSDP when
-        running a forward pass, :meth:`summon_full_params()`, and another
-        forward pass before a backward pass.
+        Tests that ``use_orig_params=True`` has parity with DDP or FSDP
+        ``use_orig_params=False`` when running a forward pass,
+        :meth:`summon_full_params`, and another forward pass before a backward
+        pass.
 
         NOTE: We must compare with FSDP ``use_orig_params=False`` as reference
         when CPU offloading since CPU kernels give slightly different results,

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -575,7 +575,7 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
     @parametrize("offload_params", [False, True])
     def test_multiple_forward(self, offload_params: bool):
         """
-        Tests that ``use_orig_params=True`` has parity with DDP or FSDP 
+        Tests that ``use_orig_params=True`` has parity with DDP or FSDP
         ``use_orig_params=False`` when running multiple forward passes before a
         backward pass.
 

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -486,43 +486,6 @@ class TestFSDPUseOrigParamsUnshardReshard(FSDPTest):
     def world_size(self) -> int:
         return 2
 
-    def _get_fsdp_models_and_optims(
-        self,
-        sharding_strategy: ShardingStrategy,
-        cpu_offload: CPUOffload,
-    ) -> Tuple[FSDP, torch.optim.Optimizer, FSDP, torch.optim.Optimizer]:
-        """
-        Returns a pair of (FSDP model, optimizer) for ``use_orig_params=False``
-        and ``True``, respectively.
-        """
-        LR = 1e-2  # larger learning rate to amplify gradient differences
-        fsdp_kwargs = {
-            "sharding_strategy": sharding_strategy,
-            "cpu_offload": cpu_offload,
-            "use_orig_params": False,
-        }
-        fsdp_model = TransformerWithSharedParams.init(
-            self.process_group,
-            FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
-            fsdp_kwargs=fsdp_kwargs,
-            deterministic=True,
-            add_bn=False,
-        )
-        optim = torch.optim.Adam(fsdp_model.parameters(), foreach=False, lr=LR)
-        fsdp_kwargs["use_orig_params"] = True
-        fsdp_model_orig_params = TransformerWithSharedParams.init(
-            self.process_group,
-            FSDPInitMode.RECURSIVE,
-            CUDAInitMode.CUDA_BEFORE,
-            fsdp_kwargs=fsdp_kwargs,
-            deterministic=True,
-        )
-        optim_orig_params = torch.optim.Adam(
-            fsdp_model_orig_params.parameters(), foreach=False, lr=LR
-        )
-        return fsdp_model, optim, fsdp_model_orig_params, optim_orig_params
-
     def _get_dist_models_and_optims(
         self,
         local_model: nn.Module,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -649,22 +649,19 @@ class VariableBuilder:
             return self.tx.output.side_effects.track_object_existing(
                 self.source, value, result
             )
-        elif getattr(value, "_is_fsdp_managed_module", False) or issubclass(
+        elif issubclass(
             value.__class__, torch.nn.parallel.distributed.DistributedDataParallel
         ):
+            return UnspecializedNNModuleVariable(
+                value, guards=self.make_guards(GuardBuilder.TYPE_MATCH)
+            )
+        else:
             if getattr(value, "_is_fsdp_managed_module", False):
                 # Note: we can't do this assert inside FSDP constructor,
                 # since we don't know yet whether dynamo will be used
                 assert getattr(
                     value, "_fsdp_use_orig_params", False
                 ), "Dynamo only supports FSDP with use_orig_params=True"
-
-            # See note [Dynamo treats FSDP wrapped modules as UnspecializedNNModule]
-            # in fully_sharded_data_parallel.py for more information
-            return UnspecializedNNModuleVariable(
-                value, guards=self.make_guards(GuardBuilder.TYPE_MATCH)
-            )
-        else:
             return self.tx.output.register_attr_or_module(
                 value,
                 self.name,

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -1032,11 +1032,7 @@ def _grad_alloc_hook(
     ``param`` should be one of ``handle`` 's original parameters.
     """
     if handle._ran_grad_alloc_hook:
-        # if state.rank == 0:
-        #     print(f"already ran grad alloc hook {handle}")
         return
-    # if state.rank == 0:
-    #     print(f"running grad alloc hook {handle}")
     # Track that this is the first invocation of the hook among the handle's
     # parameters in the current backward pass -- the flat gradient should only
     # need to be pre-allocated once per backward

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -28,6 +28,7 @@ from torch.distributed.fsdp._common_utils import (
     HandleTrainingState,
 )
 from torch.distributed.utils import _alloc_storage, _free_storage, _p_assert
+from torch.utils.hooks import RemovableHandle
 
 from ._fsdp_extensions import _ext_post_unflatten_transform, _ext_pre_flatten_transform
 from ._utils import _no_dispatch_record_stream, _same_storage
@@ -215,13 +216,6 @@ class FlatParameter(nn.Parameter):
         _shared_params (Optional[List[nn.Parameter]]): The original shared
             parameter variables if ``use_orig_params=True`` and ``None``
             otherwise.
-        _tensors (Optional[List[Optional[Tensor]]]): This saves the ``Tensor``
-            views created in the forward and tracked by autograd when
-            ``use_orig_params=True`` and is ``None`` otherwise. This is to
-            preserve those ``Tensor`` variables for the backward to ensure that
-            the ``FlatParameter`` 's ``AccumulateGrad`` object does not change
-            in which case the post-backward hook does not run. This is relevant
-            for cases like reentrant activation checkpointing.
         _is_grad_none (Optional[List[bool]]): A mask over the original
             parameters' gradients indicating if it is logically ``None`` or not
             if ``use_orig_params=True`` and ``None`` otherwise. This is needed
@@ -286,14 +280,10 @@ class FlatParameter(nn.Parameter):
             self._is_grad_none: Optional[List[bool]] = [
                 False for _ in range(len(params))
             ]
-            self._tensors: Optional[List[Optional[Tensor]]] = [
-                None for _ in range(len(self._params))
-            ]
         else:
             self._params = None
             self._shared_params = None
             self._is_grad_none = None
-            self._tensors = None
         self._unpadded_unsharded_size = self.size()
         _set_fsdp_flattened(self)
         # Tracks whether the `FlatParameter`'s post-backward hook has been
@@ -360,8 +350,14 @@ class FlatParamHandle:
         self._fully_sharded_module = fully_sharded_module
         self._init_flat_param(params, fully_sharded_module, use_orig_params)
         self._orig_param_dtype = self.flat_param.dtype
-        self._use_unsharded_views(as_params=False)
+        self._use_unsharded_views(as_params=self._use_orig_params)
         self._init_param_reduce_dtypes(mp_param_dtype, mp_reduce_dtype)
+
+        self._ran_grad_alloc_hook = False
+        self._grad_alloc_hook_handles: List[Optional[RemovableHandle]] = [
+            None for _ in range(self.flat_param._num_params)
+        ]
+        self._multi_post_grad_hook = None
 
     def _init_flat_param(
         self,
@@ -1001,15 +997,8 @@ class FlatParamHandle:
             unsharded_size
         )  # this `.view()` is not autograd visible
         in_forward = self._training_state == HandleTrainingState.FORWARD
-        in_pre_backward = self._training_state == HandleTrainingState.BACKWARD_PRE
         if self._use_orig_params:
-            # We use `Tensor` views in the forward so that they are tracked by
-            # autograd. We use them in the pre-backward as well to support
-            # reentrant activation checkpointing, which needs the views to be
-            # tracked by autograd in the backward pass's recomputed forward.
-            self._use_unsharded_views(
-                as_params=(not in_forward and not in_pre_backward)
-            )
+            self._use_unsharded_views(as_params=True)
         elif in_forward:
             self._use_unsharded_views(as_params=False)
 
@@ -1401,23 +1390,7 @@ class FlatParamHandle:
             else:  # `as_params=False`
                 param_var: Tensor = view
                 if self._use_orig_params:
-                    if self._training_state == HandleTrainingState.FORWARD:
-                        assert self.flat_param._tensors is not None
-                        # Save the `Tensor` for the pre-backward
-                        self.flat_param._tensors[i] = view  # save for pre-backward
-                    elif self._training_state == HandleTrainingState.BACKWARD_PRE:
-                        # Use the saved `Tensor` variable from the forward to
-                        # preserve the autograd graph so that the post-backward
-                        # hook fires (e.g. for reentrant AC)
-                        assert self.flat_param._tensors is not None  # mypy
-                        tensor = self.flat_param._tensors[i]
-                        _p_assert(
-                            tensor is not None,
-                            "Expects `Tensor` to have been saved in forward",
-                        )
-                        tensor.data = view  # type: ignore[union-attr]
-                        assert tensor is not None  # mypy
-                        param_var = tensor
+                    raise AssertionError("This branch should be unreachable")
                 setattr(module, param_name, param_var)
                 if (
                     self._use_orig_params
@@ -1536,7 +1509,7 @@ class FlatParamHandle:
         try:
             yield
         finally:
-            self._use_unsharded_views(as_params=False)
+            self._use_unsharded_views(as_params=self._use_orig_params)
 
     @torch.no_grad()
     def _use_sharded_views(self) -> None:
@@ -1592,11 +1565,6 @@ class FlatParamHandle:
             setattr(module, param_name, param)
             prim_param = getattr(prim_module, prim_param_name)
             param.data = prim_param  # could be both empty and non-empty
-        if self._training_state == HandleTrainingState.BACKWARD_POST:
-            assert self.flat_param._tensors is not None  # mypy
-            # Clear the saved `Tensor`s since they are unneeded now
-            for i in range(len(self.flat_param._tensors)):
-                self.flat_param._tensors[i] = None  # type: ignore[index]
 
     @torch.no_grad()
     def _use_sharded_grad_views(self) -> None:

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1072,6 +1072,12 @@ class FlatParamHandle:
             self._check_sharded(flat_param.grad)
             flat_param._saved_grad_shard = flat_param.grad  # type: ignore[attr-defined]
             sharded_grad = flat_param._saved_grad_shard  # type: ignore[attr-defined]
+            if sharded_grad.device != self.device:
+                _p_assert(
+                    sharded_grad.device == torch.device("cpu") and self._offload_params,
+                    f"`flat_param.grad` on unexpected device {sharded_grad.device}",
+                )
+                sharded_grad = sharded_grad.to(self.device)
         dist.all_gather_into_tensor(
             padded_unsharded_grad, sharded_grad, self.process_group
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96483
* #96482
* #96356

**Overview**
`torch/_dynamo/variables/builder.py`
- TorchDynamo now tracks FSDP-wrapped modules using `NNModuleVariable` instead of `UnspecializedNNModuleVariable`. It still requires `use_orig_params=True`.

To-do: explain two hooks

**Known Limitations**
`test/distributed/fsdp/test_fsdp_checkpoint.py`
- For activation checkpointing + CPU offload, the multi-post-grad hook is not running. The existing unit tests only test reentrant, but for non-reentrant, the hook does not run either.

**Other Notes**
`test/distributed/fsdp/test_fsdp_use_orig_params.py`
- For multiple forwards + no CPU offload, there were slight numerical differences with FSDP `use_orig_params=False`, so I changed the reference to be DDP.
- For multiple forwards + CPU offload, there were slight numerical differences with DDP (since it does not support CPU offloading, which means its optimizer step runs on GPU), so I kept the reference to be FSDP `use_orig_params=False`.

