### PR TITLE
[cudnn] Support v8 API in fbcode

### DIFF
--- a/aten/src/ATen/native/cudnn/Macros.h
+++ b/aten/src/ATen/native/cudnn/Macros.h
@@ -5,7 +5,7 @@
 // Note: The version below should not actually be 8000. Instead, it should
 // be whatever version of cuDNN that v8 API work with PyTorch correctly.
 // The version is set to 8000 today for convenience of debugging.
-#if defined(USE_EXPERIMENTAL_CUDNN_V8_API) && defined(CUDNN_VERSION) && CUDNN_VERSION >= 8000
+#if defined(USE_EXPERIMENTAL_CUDNN_V8_API) && defined(CUDNN_VERSION) && CUDNN_VERSION >= 8300
 #define HAS_CUDNN_V8() true
 #else
 #define HAS_CUDNN_V8() false

--- a/defs.bzl
+++ b/defs.bzl
@@ -34,6 +34,7 @@ default_compiler_flags = [
     "-DTH_INDEX_BASE=0",
     "-DMAGMA_V2",
     "-DNO_CUDNN_DESTROY_HANDLE",
+    "-DUSE_EXPERIMENTAL_CUDNN_V8_API",  # enable cudnn v8 api
     "-DUSE_FBGEMM",
     "-DUSE_QNNPACK",
     "-DUSE_PYTORCH_QNNPACK",


### PR DESCRIPTION
Summary: It turns out we never turn on cudnn v8 API which blocks bf16 conv. Enable the new v8 API

Test Plan: buck run mode/dev-nosan scripts/xdwang/example:fc_pytorch

Reviewed By: ngimel

Differential Revision: D43784279

