### PR TITLE
[pt2][inductor] Ignore trace.upload_tar when pickling config

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -255,6 +255,12 @@ class trace:
     upload_tar = None
 
 
+_save_config_ignore = {
+    # workaround: "Can't pickle <function ...>"
+    "trace.upload_tar",
+}
+
+
 from .._dynamo.config_utils import install_config_module
 
 # adds patch, save_config, etc


### PR DESCRIPTION
Summary: if trace.upload_tar is set, it's a function, and it can't be pickled.

Test Plan:
Used on a Meta-internal workload; also, hacked up
test/inductor/test_smoke.py to set trace.upload_tar and ran with
TORCH_COMPILE_DEBUG=1

Reviewed By: mlazos

Differential Revision: D43915178



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire