### PR TITLE
[BE][MPS] Use convenience functions

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -42,9 +42,18 @@ void runMPSGraph(
     NSDictionary* results);
 
 MPSDataType getMPSDataType(ScalarType scalar_type);
+static inline MPSDataType getMPSDataType(const Tensor& t) {
+  return getMPSDataType(t.scalar_type());
+}
 MPSDataType getMPSScalarType(ScalarType scalar_type);
+static inline MPSDataType getMPSScalarType(const Tensor& t) {
+  return getMPSScalarType(t.scalar_type());
+}
 MPSScalar   getMPSScalar(const Scalar& scalar, ScalarType type);
 std::string getMPSTypeString(ScalarType scalar_type, bool short_name = false);
+static inline std::string getMPSTypeString(const Tensor& t, bool short_name = false) {
+  return getMPSTypeString(t.scalar_type(), short_name);
+}
 std::string scalarToMetalTypeString(const c10::ScalarType& scalar_type);
 NSArray<NSNumber*>* getTensorAxes(const Tensor& t);
 NSArray<NSNumber*>* getTensorAxes(const Tensor& t, at::OptionalIntArrayRef dim);

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -162,7 +162,7 @@ TORCH_IMPL_FUNC(leaky_relu_out_mps) (
 
           MPSGraphTensor* negSlopeTensor = [mpsGraph constantWithScalar:negative_slope.to<double>()
                                                                   shape:@[@1]
-                                                               dataType:getMPSDataType(self.scalar_type())];
+                                                               dataType:getMPSDataType(self)];
           MPSGraphTensor* negSlopeMulXTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
                                                                          secondaryTensor:negSlopeTensor
                                                                                     name:nil];
@@ -237,10 +237,10 @@ TORCH_IMPL_FUNC(leaky_relu_backward_out_mps) (
 
           MPSGraphTensor* negSlopeTensor = [mpsGraph constantWithScalar:negative_slope.to<double>()
                                                                   shape:@[@1]
-                                                               dataType:getMPSScalarType(self.scalar_type())];
+                                                               dataType:getMPSScalarType(self)];
           MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
                                                               shape:@[@1]
-                                                           dataType:getMPSScalarType(self.scalar_type())];
+                                                           dataType:getMPSScalarType(self)];
           MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
                                                                    secondaryTensor:zeroTensor
                                                                               name:nil];
@@ -380,7 +380,7 @@ TORCH_IMPL_FUNC(log_softmax_backward_mps_out) (
   MPSStream* stream = at::mps::getCurrentMPSStream();
 
   @autoreleasepool {
-    string key = "log_softmax_backward_mps_out:" + getMPSTypeString(grad_output.scalar_type()) + ":" + to_string(dim);
+    string key = "log_softmax_backward_mps_out:" + getMPSTypeString(grad_output) + ":" + to_string(dim);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
 
     if(!cachedGraph) {
@@ -392,8 +392,8 @@ TORCH_IMPL_FUNC(log_softmax_backward_mps_out) (
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output.scalar_type()));
-          MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output.scalar_type()));
+          MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
+          MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
 
           MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:outputTensor
                                                               name:nil];
@@ -672,7 +672,7 @@ TORCH_IMPL_FUNC(sigmoid_backward_out_mps)(
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
-    string key = "sigmoid_backward_out_mps:" + getMPSTypeString(grad_output.scalar_type());
+    string key = "sigmoid_backward_out_mps:" + getMPSTypeString(grad_output);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
     if(!cachedGraph) {
       MPSCachedGraph *tmpCachedGraph = cache_->CreateCachedGraph(key, ^ MPSCachedGraph * () {
@@ -683,12 +683,12 @@ TORCH_IMPL_FUNC(sigmoid_backward_out_mps)(
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output.scalar_type()));
-          MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output.scalar_type()));
+          MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
+          MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
 
           MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(grad_output.scalar_type())];
+                                                           dataType:getMPSDataType(grad_output)];
           MPSGraphTensor* oneMinusSigmoidTensor = [mpsGraph subtractionWithPrimaryTensor:unitTensor
                                                                          secondaryTensor:outputTensor
                                                                                     name:nil];
@@ -751,7 +751,7 @@ TORCH_IMPL_FUNC(tanh_backward_out_mps)(
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
-    string key = "tanh_backward_out_mps:" + getMPSTypeString(grad_output.scalar_type());
+    string key = "tanh_backward_out_mps:" + getMPSTypeString(grad_output);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
     if(!cachedGraph) {
       MPSCachedGraph *tmpCachedGraph = cache_->CreateCachedGraph(key, ^ MPSCachedGraph * () {
@@ -762,12 +762,12 @@ TORCH_IMPL_FUNC(tanh_backward_out_mps)(
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output.scalar_type()));
-          MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output.scalar_type()));
+          MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
+          MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
 
           MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(grad_output.scalar_type())];
+                                                           dataType:getMPSDataType(grad_output)];
           MPSGraphTensor* tanh2Tensor = [mpsGraph squareWithTensor:outputTensor
                                                               name:nil];
           MPSGraphTensor* oneMinusTanh2Tensor = [mpsGraph subtractionWithPrimaryTensor:unitTensor
@@ -837,11 +837,11 @@ TORCH_IMPL_FUNC(threshold_out_mps)(
 
           MPSGraphTensor *thresholdTensor = [mpsGraph constantWithScalar: threshold.to<double>()
                                                                    shape: @[@1]
-                                                                dataType: getMPSDataType(self.scalar_type())];
+                                                                dataType: getMPSDataType(self)];
 
           MPSGraphTensor *valueTensor = [mpsGraph constantWithScalar: value.to<double>()
                                                                shape: @[@1]
-                                                            dataType: getMPSDataType(self.scalar_type())];
+                                                            dataType: getMPSDataType(self)];
 
           // x > threshold
           MPSGraphTensor *predicateTensor = [mpsGraph greaterThanWithPrimaryTensor: inputTensor
@@ -918,7 +918,7 @@ TORCH_IMPL_FUNC(threshold_backward_out_mps)(
 
           MPSGraphTensor *thresholdTensor = [mpsGraph constantWithScalar: threshold.to<double>()
                                                                    shape: @[@1]
-                                                                dataType: getMPSDataType(self.scalar_type())];
+                                                                dataType: getMPSDataType(self)];
 
           MPSGraphTensor *zeroTensor = [mpsGraph constantWithScalar: 0.0
                                                            dataType: inputTensor.dataType];
@@ -1068,7 +1068,7 @@ TORCH_IMPL_FUNC(gelu_out_mps) (
           newCachedGraph = new CachedGraph(mpsGraph);
 
           MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph,
-                                                                  getMPSDataType(self.scalar_type()),
+                                                                  getMPSDataType(self),
                                                                   getMPSShape(self));
 
           MPSGraphTensor* outputTensor = nil;
@@ -1135,12 +1135,12 @@ TORCH_IMPL_FUNC(gelu_backward_out_mps) (
         CachedGraph *newCachedGraph = nil;
 
         @autoreleasepool {
-          auto dataType = getMPSDataType(self.scalar_type());
+          auto dataType = getMPSDataType(self);
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
           MPSGraphTensor* gradTensor = mpsGraphRankedPlaceHolder(mpsGraph,
-                                                                  getMPSDataType(grad.scalar_type()),
+                                                                  getMPSDataType(grad),
                                                                   getMPSShape(grad));
           MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph,
                                                                   dataType,
@@ -1333,21 +1333,21 @@ void elu_variants_out_mps (
 
           MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.to<double>()
                                                                shape:@[@1]
-                                                            dataType:getMPSDataType(self.scalar_type())];
+                                                            dataType:getMPSDataType(self)];
 
           MPSGraphTensor* inputScaleTensor = [mpsGraph constantWithScalar:input_scale.to<double>()
                                                                     shape:@[@1]
-                                                                 dataType:getMPSDataType(self.scalar_type())];
+                                                                 dataType:getMPSDataType(self)];
 
           MPSGraphTensor* scaleTensor = [mpsGraph constantWithScalar:scale.to<double>()
                                                                shape:@[@1]
-                                                            dataType:getMPSDataType(self.scalar_type())];
+                                                            dataType:getMPSDataType(self)];
           MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0f
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(self.scalar_type())];
+                                                           dataType:getMPSDataType(self)];
           MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(self.scalar_type())];
+                                                           dataType:getMPSDataType(self)];
 
           MPSGraphTensor* scaledInputTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
                                                                         secondaryTensor:inputScaleTensor
@@ -1467,14 +1467,14 @@ TORCH_IMPL_FUNC(elu_backward_out_mps) (
           if(is_result) {
             MPSGraphTensor* alphaTensor = [mpsGraph constantWithScalar:alpha.to<double>()
                                                                shape:@[@1]
-                                                            dataType:getMPSDataType(grad_output.scalar_type())];
+                                                            dataType:getMPSDataType(grad_output)];
             MPSGraphTensor* resultPlusAlphaTensor = [mpsGraph additionWithPrimaryTensor:selfOrResultTensor
                                                                         secondaryTensor:alphaTensor
                                                                                    name:nil];
             auto constMul = scale.to<double>() * input_scale.to<double>();
             MPSGraphTensor* constMulTensor = [mpsGraph constantWithScalar:constMul
                                                                     shape:@[@1]
-                                                                 dataType:getMPSDataType(grad_output.scalar_type())];
+                                                                 dataType:getMPSDataType(grad_output)];
             lessThanZeroGradTensor = [mpsGraph multiplicationWithPrimaryTensor:resultPlusAlphaTensor
                                                                secondaryTensor:constMulTensor
                                                                           name:nil];
@@ -1482,7 +1482,7 @@ TORCH_IMPL_FUNC(elu_backward_out_mps) (
           else {
             MPSGraphTensor* inputScaleTensor = [mpsGraph constantWithScalar:input_scale.to<double>()
                                                                     shape:@[@1]
-                                                                 dataType:getMPSDataType(grad_output.scalar_type())];
+                                                                 dataType:getMPSDataType(grad_output)];
             MPSGraphTensor* scaledInputTensor = [mpsGraph multiplicationWithPrimaryTensor:selfOrResultTensor
                                                                           secondaryTensor:inputScaleTensor
                                                                                      name:nil];
@@ -1491,7 +1491,7 @@ TORCH_IMPL_FUNC(elu_backward_out_mps) (
             auto constMul = scale.to<double>() * input_scale.to<double>() * alpha.to<double>();
             MPSGraphTensor* constMulTensor = [mpsGraph constantWithScalar:constMul
                                                                     shape:@[@1]
-                                                                 dataType:getMPSDataType(grad_output.scalar_type())];
+                                                                 dataType:getMPSDataType(grad_output)];
             lessThanZeroGradTensor = [mpsGraph multiplicationWithPrimaryTensor:expTensor
                                                                secondaryTensor:constMulTensor
                                                                           name:nil];
@@ -1499,10 +1499,10 @@ TORCH_IMPL_FUNC(elu_backward_out_mps) (
 
           MPSGraphTensor* scaleTensor = [mpsGraph constantWithScalar:scale.to<double>()
                                                                shape:@[@1]
-                                                            dataType:getMPSDataType(grad_output.scalar_type())];
+                                                            dataType:getMPSDataType(grad_output)];
           MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(grad_output.scalar_type())];
+                                                           dataType:getMPSDataType(grad_output)];
           MPSGraphTensor* predicateTensor = [mpsGraph greaterThanWithPrimaryTensor:selfOrResultTensor
                                                                    secondaryTensor:zeroTensor
                                                                               name:nil];
@@ -1585,7 +1585,7 @@ TORCH_IMPL_FUNC(glu_out_mps) (
           newCachedGraph = new CachedGraph(mpsGraph);
 
           MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph,
-                                                                  getMPSDataType(self.scalar_type()),
+                                                                  getMPSDataType(self),
                                                                   getMPSShape(self));
           NSArray<MPSGraphTensor *> * outputTensorsArray = [mpsGraph splitTensor:inputTensor
                                                                        numSplits:2
@@ -1664,10 +1664,10 @@ Tensor& glu_backward_mps_out (
           newCachedGraph = new CachedGraph(mpsGraph);
 
           MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph,
-                                                                  getMPSDataType(self.scalar_type()),
+                                                                  getMPSDataType(self),
                                                                   getMPSShape(self));
           MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph,
-                                                                  getMPSDataType(grad_output.scalar_type()),
+                                                                  getMPSDataType(grad_output),
                                                                   getMPSShape(grad_output));
           NSArray<MPSGraphTensor *> * inputTensorsArray = [mpsGraph splitTensor:inputTensor
                                                                       numSplits:2
@@ -1684,7 +1684,7 @@ Tensor& glu_backward_mps_out (
           // second half
           MPSGraphTensor* one_val = [mpsGraph constantWithScalar:1.0
                                                            shape:@[@1]
-                                                        dataType:getMPSDataType(self.scalar_type())];
+                                                        dataType:getMPSDataType(self)];
 
           MPSGraphTensor* secondHalfOutputTensor = [mpsGraph subtractionWithPrimaryTensor : one_val
                                                                 secondaryTensor : sigmoidOutputTensor
@@ -1899,7 +1899,7 @@ TORCH_IMPL_FUNC(softplus_backward_out_mps) (
 
               MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0
                                                                   shape:@[@1]
-                                                               dataType:getMPSDataType(self.scalar_type())];
+                                                               dataType:getMPSDataType(self)];
               MPSGraphTensor* bxTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
                                                                   secondaryTensor:betaTensor
                                                                   name:nil];
@@ -1991,7 +1991,7 @@ Tensor prelu_mps(const Tensor& self, const Tensor& weight_) {
 
           MPSGraphTensor *zeroTensor = [mpsGraph constantWithScalar:0.0
                                                               shape:@[@1]
-                                                            dataType:getMPSDataType(self.scalar_type())];
+                                                            dataType:getMPSDataType(self)];
           MPSGraphTensor *reluTensor = [mpsGraph reLUWithTensor:inputTensor
                                                             name:nil];
           MPSGraphTensor *predicateTensor = [mpsGraph lessThanWithPrimaryTensor: inputTensor
@@ -2165,7 +2165,7 @@ TORCH_IMPL_FUNC(silu_out_mps) (
 
           MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(self.scalar_type())];
+                                                           dataType:getMPSDataType(self)];
           MPSGraphTensor* negativeInput = [mpsGraph negativeWithTensor:inputTensor
                                                                   name:nil];
           MPSGraphTensor* expNegativeTensor = [mpsGraph exponentWithTensor:negativeInput
@@ -2244,7 +2244,7 @@ TORCH_IMPL_FUNC(silu_backward_out_mps) (
 
           MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(grad_output.scalar_type())];
+                                                           dataType:getMPSDataType(grad_output)];
           MPSGraphTensor* negativeInput = [mpsGraph negativeWithTensor:inputTensor
                                                                   name:nil];
           MPSGraphTensor* expNegativeTensor = [mpsGraph exponentWithTensor:negativeInput
@@ -2334,13 +2334,13 @@ TORCH_IMPL_FUNC(hardsigmoid_out_mps) (const Tensor& self, const Tensor& result) 
           MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
           MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(self.scalar_type())];
+                                                           dataType:getMPSDataType(self)];
           MPSGraphTensor* threeTensor = [mpsGraph constantWithScalar:3.0
                                                                shape:@[@1]
-                                                            dataType:getMPSDataType(self.scalar_type())];
+                                                            dataType:getMPSDataType(self)];
           MPSGraphTensor* sixTensor = [mpsGraph constantWithScalar:6.0
                                                              shape:@[@1]
-                                                          dataType:getMPSDataType(self.scalar_type())];
+                                                          dataType:getMPSDataType(self)];
           MPSGraphTensor* inputPlusThreeTensor = [mpsGraph additionWithPrimaryTensor:inputTensor
                                                                      secondaryTensor:threeTensor
                                                                                 name:nil];
@@ -2415,16 +2415,16 @@ TORCH_IMPL_FUNC(hardsigmoid_backward_out_mps) (
           MPSGraphTensor *gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
           MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(self.scalar_type())];
+                                                           dataType:getMPSDataType(self)];
           MPSGraphTensor* highTensor = [mpsGraph constantWithScalar:3.0
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(self.scalar_type())];
+                                                           dataType:getMPSDataType(self)];
           MPSGraphTensor* lowTensor = [mpsGraph constantWithScalar:-3.0
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(self.scalar_type())];
+                                                           dataType:getMPSDataType(self)];
           MPSGraphTensor* oneSixTensor = [mpsGraph constantWithScalar:1.0/6.0
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(self.scalar_type())];
+                                                           dataType:getMPSDataType(self)];
           MPSGraphTensor *inputLessThanHighPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
                                                                                  secondaryTensor:highTensor
                                                                                             name:nil];
@@ -2537,16 +2537,16 @@ Tensor& hardtanh_backward_out_mps
           // TODO: Compute gradient
           MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0f
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(grad_output.scalar_type())];
+                                                           dataType:getMPSDataType(grad_output)];
           MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0f
                                                               shape:@[@1]
-                                                           dataType:getMPSDataType(grad_output.scalar_type())];
+                                                           dataType:getMPSDataType(grad_output)];
           MPSGraphTensor* minTensor = [mpsGraph constantWithScalar:min.to<double>()
                                                              shape:@[@1]
-                                                          dataType:getMPSDataType(grad_output.scalar_type())];
+                                                          dataType:getMPSDataType(grad_output)];
           MPSGraphTensor* maxTensor = [mpsGraph constantWithScalar:max.to<double>()
                                                              shape:@[@1]
-                                                          dataType:getMPSDataType(grad_output.scalar_type())];
+                                                          dataType:getMPSDataType(grad_output)];
           MPSGraphTensor* greaterThanMaxPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
                                                                                  secondaryTensor:maxTensor
                                                                                             name:nil];
@@ -2632,22 +2632,22 @@ Tensor& hardswish_out_mps(const Tensor& self, Tensor& output) {
               MPSGraphTensor* zeroTensor = [mpsGraph
                   constantWithScalar:0.0f
                                shape:@[ @1 ]
-                            dataType:getMPSDataType(self.scalar_type())];
+                            dataType:getMPSDataType(self)];
 
               MPSGraphTensor* threeTensor = [mpsGraph
                   constantWithScalar:3.0f
                                shape:@[ @1 ]
-                            dataType:getMPSDataType(self.scalar_type())];
+                            dataType:getMPSDataType(self)];
 
               MPSGraphTensor* negativeThreeTensor = [mpsGraph
                   constantWithScalar:-3.0f
                                shape:@[ @1 ]
-                            dataType:getMPSDataType(self.scalar_type())];
+                            dataType:getMPSDataType(self)];
 
               MPSGraphTensor* sixTensor = [mpsGraph
                   constantWithScalar:6.0f
                                shape:@[ @1 ]
-                            dataType:getMPSDataType(self.scalar_type())];
+                            dataType:getMPSDataType(self)];
 
               MPSGraphTensor* lessThanMinPredicateTensor = [mpsGraph
                   lessThanOrEqualToWithPrimaryTensor:inputTensor
@@ -2761,27 +2761,27 @@ Tensor hardswish_backward_mps(const Tensor& grad_output, const Tensor& self) {
           MPSGraphTensor* zeroTensor = [mpsGraph
               constantWithScalar:0.0f
                            shape:@[ @1 ]
-                        dataType:getMPSDataType(grad_output.scalar_type())];
+                        dataType:getMPSDataType(grad_output)];
 
           MPSGraphTensor* unitTensor = [mpsGraph
               constantWithScalar:1.0f
                            shape:@[ @1 ]
-                        dataType:getMPSDataType(grad_output.scalar_type())];
+                        dataType:getMPSDataType(grad_output)];
 
           MPSGraphTensor* threeTensor = [mpsGraph
               constantWithScalar:3.0f
                            shape:@[ @1 ]
-                        dataType:getMPSDataType(grad_output.scalar_type())];
+                        dataType:getMPSDataType(grad_output)];
 
           MPSGraphTensor* negativeThreeTensor = [mpsGraph
               constantWithScalar:-3.0f
                            shape:@[ @1 ]
-                        dataType:getMPSDataType(grad_output.scalar_type())];
+                        dataType:getMPSDataType(grad_output)];
 
           MPSGraphTensor* halfTensor = [mpsGraph
               constantWithScalar:0.5f
                            shape:@[ @1 ]
-                        dataType:getMPSDataType(grad_output.scalar_type())];
+                        dataType:getMPSDataType(grad_output)];
 
           MPSGraphTensor* tempTensor =
               [mpsGraph divisionWithPrimaryTensor:inputTensor

--- a/aten/src/ATen/native/mps/operations/Blas.mm
+++ b/aten/src/ATen/native/mps/operations/Blas.mm
@@ -80,7 +80,7 @@ Tensor dot_mps(
           if(self.scalar_type() == ScalarType::Short || self.scalar_type() == ScalarType::Byte
                                                      || self.scalar_type() == ScalarType::Char)
             dotProductTensor = [mpsGraph castTensor:dotProductTensor
-                                             toType:getMPSDataType(self.scalar_type())
+                                             toType:getMPSDataType(self)
                                                name:@"castDotProductTensor"];
 
           newCachedGraph->selfTensor_ = selfTensor;

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -180,7 +180,7 @@ Tensor _mps_convolution_impl(
 
           MPSGraphTensor* biasTensor = nil;
           if(bias_defined) {
-            biasTensor = native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType((bias_opt.value()).scalar_type()));
+            biasTensor = native_mps::mpsGraphUnrankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(bias_opt.value()));
           }
 
           MPSGraphTensor* outputTensor;

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -57,8 +57,8 @@ void copy_cast_mps(at::Tensor& dst, const at::Tensor& src,
   MPSStream* stream = getCurrentMPSStream();
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
 
-  MPSDataType dstDType = getMPSDataType(dst.scalar_type());
-  MPSDataType srcDType = getMPSDataType(src.scalar_type());
+  MPSDataType dstDType = getMPSDataType(dst);
+  MPSDataType srcDType = getMPSDataType(src);
   MPSShape* dstShape = getMPSShape(dst);
   MPSShape* srcShape = getMPSShape(src);
 

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -87,7 +87,7 @@ Tensor& random_mps_impl(Tensor& self, scalar_t val1, scalar_t val2,
                                                                                name: nil];
           newCachedGraph->resultTensor = randomBlock ? randomBlock(newCachedGraph, resultTensors[0]) : resultTensors[0];
           // results will be cast if self's scalar type isn't directly supported by MPS backend.
-          if (getMPSDataType(self.scalar_type()) != outputDataType)
+          if (getMPSDataType(self) != outputDataType)
             newCachedGraph->resultTensor = castMPSTensor(mpsGraph, newCachedGraph->resultTensor, self.scalar_type());
         }
         return newCachedGraph;
@@ -371,7 +371,7 @@ Tensor& randperm_out_mps(int64_t n, c10::optional<Generator> generator, Tensor& 
                                                            name:nil];
     if (result.scalar_type() != kInt) {
       argsortTensor = [mpsGraph castTensor:argsortTensor
-                                    toType:mps::getMPSDataType(result.scalar_type())
+                                    toType:mps::getMPSDataType(result)
                                       name:@"castOutput"];
     }
     return argsortTensor;
@@ -416,10 +416,10 @@ Tensor& multinomial_with_replacement_mps_kernel(
           newCachedGraph = new RandomCachedGraph(mpsGraph);
           newCachedGraph->stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[@7]);
 
-          auto prob_dtype = getMPSDataType(self_v.scalar_type());
+          auto prob_dtype = getMPSDataType(self_v);
 
           // This is probability weights
-          newCachedGraph->probTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self_v.scalar_type()), prob_shape);
+          newCachedGraph->probTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self_v), prob_shape);
 
           MPSGraphTensor *sumProbs = [mpsGraph reductionSumWithTensor:newCachedGraph->probTensor
                                                                  axis:-1
@@ -502,7 +502,7 @@ Tensor& multinomial_with_replacement_mps_kernel(
                                                        withShape:@[ns_numDist ,ns_n_sample]
                                                             name:nil];
           newCachedGraph->resultTensor = [mpsGraph castTensor:reshapeTensor
-                                                       toType:getMPSDataType(result.scalar_type())
+                                                       toType:getMPSDataType(result)
                                                          name:@"resultTensor"];
         }
         return newCachedGraph;

--- a/aten/src/ATen/native/mps/operations/Eye.mm
+++ b/aten/src/ATen/native/mps/operations/Eye.mm
@@ -81,7 +81,7 @@ Tensor& eye_out_mps(int64_t n, int64_t m, Tensor& result) {
           newCachedGraph = new CachedGraph(mpsGraph);
           MPSGraphTensor* onesTensor = [mpsGraph constantWithScalar:1.0f
                                                               shape:getMPSShape(result)
-                                                           dataType:getMPSDataType(result.scalar_type())];
+                                                           dataType:getMPSDataType(result)];
 
           // Here we can call the MPSGraph API needed to execute the operation.
           // The API details can be found here: https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraph

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -139,7 +139,7 @@ Tensor& mm_out_mps_impl(
 
             outputTensor = [mpsGraph constantWithScalar:0.
                                                   shape:getMPSShape(output_sizes)
-                                                   dataType:getMPSDataType(output.scalar_type())];
+                                                   dataType:getMPSDataType(output)];
 
           }
           else {
@@ -267,8 +267,8 @@ Tensor& addr_out_mps(const Tensor& self,
           MPSGraph *mpsGraph = mps::make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor *t1 = mps::mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(vec1.scalar_type()), inputShape);
-          MPSGraphTensor *t2 =  mps::mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(vec2.scalar_type()), otherShape);
+          MPSGraphTensor *t1 = mps::mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(vec1), inputShape);
+          MPSGraphTensor *t2 =  mps::mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(vec2), otherShape);
           MPSGraphTensor *selfTensor =  mps::mpsGraphRankedPlaceHolder(mpsGraph, *self_);
 
           // Intermediate as placeholder
@@ -793,13 +793,13 @@ Tensor& linalg_solve_triangular_mps_impl( const Tensor& A, const Tensor& B, bool
                                                                                    matrices:batchSize
                                                                                    rowBytes:aCols * aElemSize
                                                                                 matrixBytes:aRows * aCols * aElemSize
-                                                                                   dataType:getMPSDataType(A_.scalar_type())];
+                                                                                   dataType:getMPSDataType(A_)];
       MPSMatrixDescriptor* rightHandSideMatrixDesc = [MPSMatrixDescriptor matrixDescriptorWithRows:bRows
                                                                                            columns:bCols
                                                                                           matrices:batchSize
                                                                                           rowBytes:bCols * bElemSize
                                                                                        matrixBytes:bRows * bCols * bElemSize
-                                                                                          dataType:getMPSDataType(B_.scalar_type())];
+                                                                                          dataType:getMPSDataType(B_)];
       for (const auto i: c10::irange(batchSize)) {
         const uint64_t aBatchOffset = i * aRows * aCols;
         const uint64_t bBatchOffset = i * bRows * bCols;

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -137,7 +137,7 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out
                       + [ns_shape_key UTF8String] + ":"
                       + native_mps::getTensorsStringKey({
                         self, weight_opt.value_or(Tensor()), bias_opt.value_or(Tensor()), running_mean_opt.value_or(Tensor()), running_var_opt.value_or(Tensor())});
-    auto input_mps_dtype = native_mps::getMPSDataType(self.scalar_type());
+    auto input_mps_dtype = native_mps::getMPSDataType(self);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
 
     // Dim where channels are located
@@ -166,15 +166,15 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out
             MPSGraphTensor* weightTensor = nil;
             // Should have shape of mean
             if(has_weight)
-              weightTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(weight_opt.value().scalar_type()), new_mean_shape);
+              weightTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(weight_opt.value()), new_mean_shape);
             MPSGraphTensor* biasTensor = nil;
             if(has_bias)
-              biasTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(bias_opt.value().scalar_type()), new_mean_shape);
+              biasTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(bias_opt.value()), new_mean_shape);
             MPSGraphTensor* runningMeanTensor = nil;
             MPSGraphTensor* runningVarTensor = nil;
             if(has_running_mean) {
-              runningMeanTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(running_mean_opt.value().scalar_type()), new_mean_shape);
-              runningVarTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(running_var_opt.value().scalar_type()), new_mean_shape);
+              runningMeanTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(running_mean_opt.value()), new_mean_shape);
+              runningVarTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(running_var_opt.value()), new_mean_shape);
             }
 
             // Mean and inv std tensors to be saved and returned
@@ -609,8 +609,8 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps
                       + std::to_string(train) + ":"
                       + std::to_string(has_running_mean) + ":"
                       + std::to_string(has_weight) + ":"
-                      + [ns_shape_key UTF8String] + ":" + native_mps::getMPSTypeString(input.scalar_type());
-    auto input_mps_dtype = native_mps::getMPSDataType(input.scalar_type());
+                      + [ns_shape_key UTF8String] + ":" + native_mps::getMPSTypeString(input);
+    auto input_mps_dtype = native_mps::getMPSDataType(input);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
 
     if(!cachedGraph) {
@@ -627,23 +627,23 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps
 
           MPSGraphTensor* inputTensorOriginal = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, input_mps_dtype, input_shape);
           // Shape is the ORIGINAL NCHW shape
-          MPSGraphTensor* gradOutputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(grad_out.scalar_type()), input_shape_readonly);
+          MPSGraphTensor* gradOutputTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(grad_out), input_shape_readonly);
           MPSGraphTensor* weightTensor = nil;
           if(has_weight)
-            weightTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(weight_opt.value().scalar_type()), new_mean_shape);
+            weightTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(weight_opt.value()), new_mean_shape);
           MPSGraphTensor* runningMeanTensor = nil;
           MPSGraphTensor* runningVarTensor = nil;
           if(has_running_mean) {
-            runningMeanTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(running_mean_opt.value().scalar_type()), new_mean_shape);
-            runningVarTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(running_var_opt.value().scalar_type()), new_mean_shape);
+            runningMeanTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(running_mean_opt.value()), new_mean_shape);
+            runningVarTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(running_var_opt.value()), new_mean_shape);
           }
 
           // Mean and inv std tensors to be saved and returned
           MPSGraphTensor* saveMeanTensor = nil;
           MPSGraphTensor* saveVarTensor = nil;
           if(has_save_mean) {
-            saveMeanTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(save_mean_opt.value().scalar_type()), new_mean_shape);
-            saveVarTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(save_var_opt.value().scalar_type()), new_mean_shape);
+            saveMeanTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(save_mean_opt.value()), new_mean_shape);
+            saveVarTensor = native_mps::mpsGraphRankedPlaceHolder(mpsGraph, native_mps::getMPSDataType(save_var_opt.value()), new_mean_shape);
           }
 
           MPSGraphTensor* gradInputTensor = nil;
@@ -1084,7 +1084,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(
                         + std::to_string(has_weight) + ":"
                         + native_mps::getArrayRefString(normalized_shape) + ":"
                         + native_mps::getArrayRefString((*X).sizes()) + ":"
-                        + native_mps::getMPSTypeString((*X).scalar_type());
+                        + native_mps::getMPSTypeString(*X);
 
       CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
 

--- a/aten/src/ATen/native/mps/operations/RangeFactories.mm
+++ b/aten/src/ATen/native/mps/operations/RangeFactories.mm
@@ -97,7 +97,7 @@ Tensor& arange_mps_out(const Scalar& start, const Scalar& end, const Scalar& ste
     using namespace mps;
     auto cache_ = MPSGraphCache::getInstance();
     auto stream = getCurrentMPSStream();
-    auto mpsDataType = getMPSDataType(result.scalar_type());
+    auto mpsDataType = getMPSDataType(result);
     @autoreleasepool {
       string key = "arange_mps_out" + getTensorsStringKey({result}) + ":" + to_string(size);
       auto cachedGraph = static_cast<RangeCachedGraph *>(cache_->LookUp(key));
@@ -168,7 +168,7 @@ Tensor& range_mps_out(const Scalar& start, const Scalar& end, const Scalar& step
     using namespace mps;
     auto cache_ = MPSGraphCache::getInstance();
     auto stream = getCurrentMPSStream();
-    auto mpsDataType = getMPSDataType(result.scalar_type());
+    auto mpsDataType = getMPSDataType(result);
     @autoreleasepool {
       string key = "arange_mps_out" + getTensorsStringKey({result}) + ":" + to_string(size);
       auto cachedGraph = static_cast<RangeCachedGraph *>(cache_->LookUp(key));
@@ -234,8 +234,8 @@ Tensor& linspace_out_mps(const Scalar& start, const Scalar& end, int64_t steps, 
             MPSGraph* mpsGraph = make_mps_graph();
             newCachedGraph = new RangeCachedGraph(mpsGraph, MPSDataTypeFloat32, steps, true, start_less_end);
 
-            if(getMPSDataType(result.scalar_type()) != MPSDataTypeFloat32) {
-              newCachedGraph->outputTensor = [mpsGraph castTensor:newCachedGraph->outputTensor toType:getMPSDataType(result.scalar_type()) name:@"output"];
+            if(getMPSDataType(result) != MPSDataTypeFloat32) {
+              newCachedGraph->outputTensor = [mpsGraph castTensor:newCachedGraph->outputTensor toType:getMPSDataType(result) name:@"output"];
             }
           }
           return newCachedGraph;

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -271,7 +271,7 @@ void reduction_out_mps(
           }
 
           MPSGraphTensor* outputTensor = castOutputTensor;
-          if (getMPSDataType(output_t.scalar_type()) != [castOutputTensor dataType]) {
+          if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
             outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
           }
 
@@ -885,7 +885,7 @@ Tensor std_var_common_impl_mps(
 
           if (use_correction && correction_value) {
               MPSGraphTensor *besselTensor= [mpsGraph constantWithScalar:bessel_correction
-                                                                dataType:getMPSDataType(input_t.scalar_type())];
+                                                                dataType:getMPSDataType(input_t)];
               MPSGraphTensor *correctedTensor = [mpsGraph multiplicationWithPrimaryTensor:outputVarTensor
                                                                           secondaryTensor:besselTensor
                                                                                      name:nil];
@@ -969,7 +969,7 @@ TORCH_IMPL_FUNC(any_out_mps)
 
   @autoreleasepool {
     MPSShape* input_t_shape = getMPSShape(input_t);
-    string key = string("any_out_mps:") + getMPSShapeString(input_t_shape) + ":" + to_string(dim_) + ":" + getMPSTypeString(input_t.scalar_type());
+    string key = string("any_out_mps:") + getMPSShapeString(input_t_shape) + ":" + to_string(dim_) + ":" + getMPSTypeString(input_t);
     CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
     if (!cachedGraph) {
@@ -979,7 +979,7 @@ TORCH_IMPL_FUNC(any_out_mps)
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSDataType input_type = getMPSDataType(input_t.scalar_type());
+          MPSDataType input_type = getMPSDataType(input_t);
           MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
 
           MPSGraphTensor* castInputTensor = castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
@@ -1033,7 +1033,7 @@ TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
 
   @autoreleasepool {
     MPSShape* input_t_shape = getMPSShape(input_t);
-    string key = string("any_all_out_mps:") + getMPSShapeString(input_t_shape) +":" + getMPSTypeString(input_t.scalar_type());
+    string key = string("any_all_out_mps:") + getMPSShapeString(input_t_shape) +":" + getMPSTypeString(input_t);
     CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
     if (!cachedGraph) {
@@ -1045,7 +1045,7 @@ TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSDataType input_type = getMPSDataType(input_t.scalar_type());
+          MPSDataType input_type = getMPSDataType(input_t);
           MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
           MPSGraphTensor* castInputTensor = castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
           MPSGraphTensor* castOutputTensor = [mpsGraph reductionOrWithTensor:castInputTensor
@@ -1053,7 +1053,7 @@ TORCH_IMPL_FUNC(any_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
                                                                             name:nil];
 
           MPSGraphTensor* outputTensor = castOutputTensor;
-          if (getMPSDataType(output_t.scalar_type()) != [castOutputTensor dataType]) {
+          if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
             outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
           }
           newCachedGraph->inputTensor_ = inputTensor;
@@ -1111,7 +1111,7 @@ TORCH_IMPL_FUNC(all_out_mps)
 
   @autoreleasepool {
     MPSShape* input_t_shape = getMPSShape(input_t);
-    string key = string("all_out_mps:") + getMPSShapeString(input_t_shape) + ":" + to_string(dim_) + ":" + getMPSTypeString(input_t.scalar_type());
+    string key = string("all_out_mps:") + getMPSShapeString(input_t_shape) + ":" + to_string(dim_) + ":" + getMPSTypeString(input_t);
     CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
     if (!cachedGraph) {
@@ -1121,7 +1121,7 @@ TORCH_IMPL_FUNC(all_out_mps)
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSDataType input_type = getMPSDataType(input_t.scalar_type());
+          MPSDataType input_type = getMPSDataType(input_t);
           MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
           MPSGraphTensor* castInputTensor = castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
           MPSGraphTensor* castOutputTensor = [mpsGraph reductionAndWithTensor:castInputTensor
@@ -1167,7 +1167,7 @@ TORCH_IMPL_FUNC(all_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
 
   @autoreleasepool {
     MPSShape* input_t_shape = getMPSShape(input_t);
-    string key = string("all_all_out_mps:") + getMPSShapeString(input_t_shape) +":" + getMPSTypeString(input_t.scalar_type());
+    string key = string("all_all_out_mps:") + getMPSShapeString(input_t_shape) +":" + getMPSTypeString(input_t);
     CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
 
     if (!cachedGraph) {
@@ -1177,7 +1177,7 @@ TORCH_IMPL_FUNC(all_all_out_mps)(const Tensor& input_t, const Tensor& output_t) 
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSDataType input_type = getMPSDataType(input_t.scalar_type());
+          MPSDataType input_type = getMPSDataType(input_t);
           MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_type, input_t_shape);
           MPSGraphTensor* castInputTensor = castToIHFTypes(mpsGraph, inputTensor, input_t, /*includesInt64=*/macOS13_3_plus);
           MPSGraphTensor* castOutputTensor = [mpsGraph reductionAndWithTensor:castInputTensor
@@ -1260,7 +1260,7 @@ Tensor min_max_mps
           }
 
           MPSGraphTensor* outputTensor = castOutputTensor;
-          if (getMPSDataType(output_t.scalar_type()) != [castOutputTensor dataType]) {
+          if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
             outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
           }
 
@@ -1388,7 +1388,7 @@ void min_max_out_mps
                                             name:@"cast_out"];
           }
 
-          if ([outputTensor dataType] != getMPSDataType(output_t.scalar_type())) {
+          if ([outputTensor dataType] != getMPSDataType(output_t)) {
             outputTensor = castMPSTensor(mpsGraph, outputTensor, output_t.scalar_type());
           }
           newCachedGraph->inputTensor_ = inputTensor;
@@ -1535,7 +1535,7 @@ void argmax_argmin_out_mps
           }
 
           MPSGraphTensor* outputTensor = argreduceOutTensor;
-          if (getMPSDataType(output_t.scalar_type()) != [argreduceOutTensor dataType]) {
+          if (getMPSDataType(output_t) != [argreduceOutTensor dataType]) {
             outputTensor = castMPSTensor(mpsGraph, argreduceOutTensor, output_t.scalar_type());
           }
 
@@ -1703,7 +1703,7 @@ Tensor median_mps(const Tensor& input_t) {
   }
 
   @autoreleasepool {
-    string key = "median_mps:"+ mps::getMPSTypeString(input_t.scalar_type())  + mps::getTensorsStringKey(input_t);
+    string key = "median_mps:"+ mps::getMPSTypeString(input_t)  + mps::getTensorsStringKey(input_t);
     CachedGraph* cachedGraph = cache_->LookUpAs<CachedGraph>(key);
     // Initialize once if configuration not found in cache
     if (!cachedGraph) {

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -73,8 +73,8 @@ Tensor repeat_mps(const Tensor& self, IntArrayRef repeats) {
   }
 
   auto stream = at::mps::getCurrentMPSStream();
-  auto inputDataType = getMPSDataType(expanded_tensor.scalar_type());
-  auto outputDataType = getMPSDataType(result.scalar_type());
+  auto inputDataType = getMPSDataType(expanded_tensor);
+  auto outputDataType = getMPSDataType(result);
   if (!is_macos_13_or_newer()) {
      if (expanded_tensor.scalar_type() == kBool) {
       inputDataType = MPSDataTypeInt8;

--- a/aten/src/ATen/native/mps/operations/RnnOps.mm
+++ b/aten/src/ATen/native/mps/operations/RnnOps.mm
@@ -144,7 +144,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> _lstm_mps(const Tenso
     MPSStream* stream = getCurrentMPSStream();
 
     @autoreleasepool {
-      string key = "lstm_" + getTensorsStringKey({input, hx[0], hx[1]}) + getMPSTypeString(input.scalar_type()) + "_num_layers_" + std::to_string(num_layers) + "_bidirectional_" + std::to_string(bidirectional) + "_has_biases_" + std::to_string(has_biases) + "_dropout_" + std::to_string(dropout_p) + "_batch_first_" + std::to_string(batch_first);
+      string key = "lstm_" + getTensorsStringKey({input, hx[0], hx[1]}) + getMPSTypeString(input) + "_num_layers_" + std::to_string(num_layers) + "_bidirectional_" + std::to_string(bidirectional) + "_has_biases_" + std::to_string(has_biases) + "_dropout_" + std::to_string(dropout_p) + "_batch_first_" + std::to_string(batch_first);
       CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
       if(!cachedGraph) {
         MPSCachedGraph *tmpCachedGraph = cache_->CreateCachedGraph(key, ^ MPSCachedGraph * () {
@@ -161,11 +161,11 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> _lstm_mps(const Tenso
             NSMutableArray<MPSGraphTensor*> *layersOutputsList = [[NSMutableArray alloc] initWithCapacity:num_layers];
 
             for (const auto i : c10::irange(total_layers)) {
-                [kernelWeightsList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()), getMPSShape(kernel_weights[i]))];
-                [recurrentKernelWeightsList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()),getMPSShape(recurrent_kernel_weights[i]))];
+                [kernelWeightsList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(kernel_weights[i]))];
+                [recurrentKernelWeightsList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(recurrent_kernel_weights[i]))];
                 if(has_biases) {
-                    [kernelBiasList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()),getMPSShape(biases[i]))];
-                    [recurrentBiasList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()),getMPSShape(recurrent_biases[i]))];
+                    [kernelBiasList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(biases[i]))];
+                    [recurrentBiasList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(recurrent_biases[i]))];
                 }
             }
 
@@ -174,9 +174,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> _lstm_mps(const Tenso
             opDesc.bidirectional = bidirectional;
             opDesc.produceCell = true;
 
-            MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()), getMPSShape(input));
-            MPSGraphTensor* stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()), getMPSShape(hx[0]));
-            MPSGraphTensor* cellStateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()), getMPSShape(hx[1]));
+            MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(input));
+            MPSGraphTensor* stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[0]));
+            MPSGraphTensor* cellStateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[1]));
             std::vector<MPSGraphTensor*> inputTensors = {inputTensor, stateTensor, cellStateTensor,};
 
             if (batch_first) {
@@ -396,7 +396,7 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
     MPSStream* stream = getCurrentMPSStream();
     @autoreleasepool {
 
-        string key = "lstm_backward_" + getTensorsStringKey({input, z_state, cell_state_fwd, grad_y, grad_cy, grad_hy})+ getMPSTypeString(input.scalar_type()) + "_num_layers_" + std::to_string(num_layers) + "_bidirectional_" + std::to_string(bidirectional) + "_has_biases_" + std::to_string(has_biases) + "_batch_first_" + std::to_string(batch_first);
+        string key = "lstm_backward_" + getTensorsStringKey({input, z_state, cell_state_fwd, grad_y, grad_cy, grad_hy})+ getMPSTypeString(input) + "_num_layers_" + std::to_string(num_layers) + "_bidirectional_" + std::to_string(bidirectional) + "_has_biases_" + std::to_string(has_biases) + "_batch_first_" + std::to_string(batch_first);
         CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
         if (!cachedGraph) {
             MPSCachedGraph *tmpCachedGraph = cache_->CreateCachedGraph(key, ^ MPSCachedGraph * () {
@@ -412,23 +412,23 @@ std::tuple<Tensor, std::vector<Tensor>, std::vector<Tensor>> lstm_mps_backward(c
                     NSMutableArray<MPSGraphTensor*> *recurrentBiasList = [[NSMutableArray alloc] initWithCapacity:params.size()];
 
                     for (const auto i : c10::irange(total_layers)) {
-                        [kernelWeightsList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()), getMPSShape(kernel_weights[i]))];
-                        [recurrentKernelWeightsList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()),getMPSShape(recurrent_kernel_weights[i]))];
+                        [kernelWeightsList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(kernel_weights[i]))];
+                        [recurrentKernelWeightsList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(recurrent_kernel_weights[i]))];
                         if (has_biases) {
-                            [kernelBiasList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()),getMPSShape(biases[i]))];
-                            [recurrentBiasList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()),getMPSShape(recurrent_biases[i]))];
+                            [kernelBiasList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(biases[i]))];
+                            [recurrentBiasList addObject:mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(recurrent_biases[i]))];
                         }
                     }
 
-                    MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()), getMPSShape(input));
-                    MPSGraphTensor* stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()), getMPSShape(hx[0]));
-                    MPSGraphTensor* cellStateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()), getMPSShape(hx[1]));
-                    MPSGraphTensor* zStateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()), getMPSShape(z_state));
-                    MPSGraphTensor* gradientTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_y.scalar_type()), getMPSShape(grad_y));
-                    MPSGraphTensor* gradientCyTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_cy.scalar_type()), getMPSShape(grad_cy));
-                    MPSGraphTensor* gradientHyTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_hy.scalar_type()), getMPSShape(grad_hy));
-                    MPSGraphTensor* cellStateFwdTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(cell_state_fwd.scalar_type()), getMPSShape(cell_state_fwd));
-                    MPSGraphTensor* layersOutputsTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(layersOutputs.scalar_type()), getMPSShape(layersOutputs));
+                    MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(input));
+                    MPSGraphTensor* stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[0]));
+                    MPSGraphTensor* cellStateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(hx[1]));
+                    MPSGraphTensor* zStateTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), getMPSShape(z_state));
+                    MPSGraphTensor* gradientTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_y), getMPSShape(grad_y));
+                    MPSGraphTensor* gradientCyTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_cy), getMPSShape(grad_cy));
+                    MPSGraphTensor* gradientHyTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_hy), getMPSShape(grad_hy));
+                    MPSGraphTensor* cellStateFwdTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(cell_state_fwd), getMPSShape(cell_state_fwd));
+                    MPSGraphTensor* layersOutputsTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(layersOutputs), getMPSShape(layersOutputs));
 
                     std::vector<MPSGraphTensor*> inputs = {inputTensor, stateTensor, cellStateTensor, gradientTensor, zStateTensor, cellStateFwdTensor, gradientHyTensor, gradientCyTensor, layersOutputsTensor};
 

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -51,8 +51,8 @@ TORCH_IMPL_FUNC(gather_out_mps)
       if(i != dim && [index_shape[i] intValue] < [input_shape[i] intValue])
         needSlice = true;
     }
-    auto input_type = getMPSDataType(self.scalar_type());
-    auto output_type = getMPSDataType(output.scalar_type());
+    auto input_type = getMPSDataType(self);
+    auto output_type = getMPSDataType(output);
     if (input_type == MPSDataTypeUInt8 || ((input_type ==  MPSDataTypeBool && !is_macos_13_or_newer()))) {
       input_type = MPSDataTypeInt8;
     }
@@ -191,7 +191,7 @@ void scatter_mps_general
     }
     TORCH_CHECK(reduce != "mean", "Scatter reduce mean mode not yet supported in MPS")
 
-    MPSDataType src_type = getMPSDataType(src.scalar_type());
+    MPSDataType src_type = getMPSDataType(src);
     if (reduce != "set" || src_type == MPSDataTypeUInt8 || src_type == MPSDataTypeBool) {
       src_type = isFloatingType(src.scalar_type()) ? MPSDataTypeFloat32 : MPSDataTypeInt32;
       needsCast = true;

--- a/aten/src/ATen/native/mps/operations/Shape.mm
+++ b/aten/src/ATen/native/mps/operations/Shape.mm
@@ -86,7 +86,7 @@ TORCH_IMPL_FUNC(topk_out_mps)
     MPSShape* input_shape = getMPSShape(self);
     NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
     string key = string("topk:") + [ns_shape_key UTF8String] + ":" +
-                           getMPSTypeString(self.scalar_type()) +
+                           getMPSTypeString(self) +
                            ":k" + to_string(k) + ":dim" + to_string(dim_) +
                            ":largest" + to_string(largest);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
@@ -96,11 +96,11 @@ TORCH_IMPL_FUNC(topk_out_mps)
         @autoreleasepool {
             MPSGraph* mpsGraph = make_mps_graph();
             newCachedGraph = new CachedGraph(mpsGraph);
-            newCachedGraph->selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self.scalar_type()), input_shape);
+            newCachedGraph->selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), input_shape);
 
             if (is_macos_13_or_newer()) {
               MPSGraphTensor* castInputTensor = newCachedGraph->selfTensor;
-              MPSDataType dataType = getMPSDataType(self.scalar_type());
+              MPSDataType dataType = getMPSDataType(self);
               // #issue 104398441 sortWithTensor and argsortWithTensor
               if (dataType != MPSDataTypeInt32 &&
                   dataType != MPSDataTypeFloat32 &&

--- a/aten/src/ATen/native/mps/operations/SoftMax.mm
+++ b/aten/src/ATen/native/mps/operations/SoftMax.mm
@@ -105,7 +105,7 @@ TORCH_IMPL_FUNC(softmax_mps_out)
 
     NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
 
-    string key = "softmax_mps_out:" + mem_format_key + ":" + getMPSTypeString(input.scalar_type()) + ":"
+    string key = "softmax_mps_out:" + mem_format_key + ":" + getMPSTypeString(input) + ":"
                                     + [ns_shape_key UTF8String] + ":" + std::to_string(dim_);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
 
@@ -117,7 +117,7 @@ TORCH_IMPL_FUNC(softmax_mps_out)
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()), input_shape);
+          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), input_shape);
 
           // passing selector of softMaxWithTensor on the mpsGraph object
           MPSGraphTensor* outputTensor = [mpsGraph softMaxWithTensor:inputTensor
@@ -217,7 +217,7 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
     MPSShape* grad_shape = mps::getMPSShape(grad);
     NSString* ns_shape_key = [[grad_shape valueForKey:@"description"] componentsJoinedByString:@","];
 
-    string key = "softmax_backward_mps_out:" + getMPSTypeString(output.scalar_type()) + ":"
+    string key = "softmax_backward_mps_out:" + getMPSTypeString(output) + ":"
                                              + [ns_shape_key UTF8String] + ":" + std::to_string(dim_);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
 
@@ -229,8 +229,8 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
           MPSGraph* mpsGraph = make_mps_graph();
           newCachedGraph = new CachedGraph(mpsGraph);
 
-          MPSGraphTensor* softmaxTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(output.scalar_type()), grad_shape);
-          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad.scalar_type()), grad_shape);
+          MPSGraphTensor* softmaxTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(output), grad_shape);
+          MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad), grad_shape);
 
           MPSGraphTensor* mulTensor = [mpsGraph multiplicationWithPrimaryTensor:softmaxTensor
                                                                 secondaryTensor:gradOutputTensor

--- a/aten/src/ATen/native/mps/operations/Sort.mm
+++ b/aten/src/ATen/native/mps/operations/Sort.mm
@@ -50,7 +50,7 @@ TORCH_IMPL_FUNC(sort_stable_out_mps)
     // Input as placeholders
     MPSShape* input_shape = getMPSShape(self);
     NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
-    string key = string("sort:") + [ns_shape_key UTF8String] + ":" + getMPSTypeString(self.scalar_type()) +
+    string key = string("sort:") + [ns_shape_key UTF8String] + ":" + getMPSTypeString(self) +
                            ":dim" + to_string(dim) + ":descending" + to_string(descending);
     CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
     if(!cachedGraph) {
@@ -59,21 +59,21 @@ TORCH_IMPL_FUNC(sort_stable_out_mps)
         @autoreleasepool {
             MPSGraph* mpsGraph = make_mps_graph();
             newCachedGraph = new CachedGraph(mpsGraph);
-            newCachedGraph->selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self.scalar_type()), input_shape);
+            newCachedGraph->selfTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), input_shape);
 
             MPSGraphTensor* castInputTensor = castToIHFTypes(mpsGraph, newCachedGraph->selfTensor, self, /*includesInt64=*/macOS13_3_plus);
             MPSGraphTensor * sortedTensor = [mpsGraph sortWithTensor:castInputTensor
                                                                 axis:(NSInteger)dim
                                                                 descending:(BOOL)descending
                                                                 name:@"sort_out"];
-            if ([sortedTensor dataType] != getMPSDataType(values.scalar_type())) {
+            if ([sortedTensor dataType] != getMPSDataType(values)) {
               sortedTensor = castMPSTensor(mpsGraph, sortedTensor, values.scalar_type());
             }
             MPSGraphTensor* argSortedTensor = [mpsGraph argSortWithTensor:castInputTensor
                                                                      axis:(NSInteger)dim
                                                                      descending:(BOOL)descending
                                                                      name:@"argsort_out"];
-            if ([argSortedTensor dataType] != getMPSDataType(indices.scalar_type())) {
+            if ([argSortedTensor dataType] != getMPSDataType(indices)) {
               argSortedTensor = castMPSTensor(mpsGraph, argSortedTensor, indices.scalar_type());
             }
             newCachedGraph->valuesTensor = sortedTensor;

--- a/aten/src/ATen/native/mps/operations/SummaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/SummaryOps.mm
@@ -44,7 +44,7 @@ Tensor& bincount_mps_impl(const Tensor& self,
           else {
             updatesTensor = [mpsGraph constantWithScalar:1.0f
                                                    shape:getMPSShape(self)
-                                                dataType:getMPSDataType(output.scalar_type())];
+                                                dataType:getMPSDataType(output)];
           }
 
           MPSGraphTensor *castedInputTensor = inputTensor;

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -448,7 +448,7 @@ TORCH_IMPL_FUNC(cumsum_out_mps)
        auto rc = [mpsGraph cumulativeSumWithTensor: inputTensor
                                               axis: dim
                                               name: nil];
-       if ((mps::getMPSDataType(result.scalar_type()) != [rc dataType]) || castInputData) {
+       if ((mps::getMPSDataType(result) != [rc dataType]) || castInputData) {
          return mps::castMPSTensor(mpsGraph, rc, result.scalar_type());
        }
        return rc;

--- a/aten/src/ATen/native/mps/operations/UpSample.mm
+++ b/aten/src/ATen/native/mps/operations/UpSample.mm
@@ -103,7 +103,7 @@ void upsample_out_template(const Tensor& input,
             inputSizeVec[3] = @(input_dim.size() > 3 ? input_size[3] : 1);
             inputSizeTensor = [mpsGraph constantWithScalar: 0
                                                      shape: [NSArray arrayWithObjects:inputSizeVec.data() count:input_dim.size()]
-                                                  dataType: getMPSDataType(input.scalar_type())];
+                                                  dataType: getMPSDataType(input)];
           }
           if (is_macOS_13_0_or_newer) {
             if (!is_backward_pass) {


### PR DESCRIPTION
Introduce `getMPSScalarType(const Tensor&)` that calls `getMPSScalarType(t.scalar_type())`
And replace `getMPSScalarType(t.scalar_type)` with `getMPSScalarType(t)` throughout the codebase

Fixes #ISSUE_NUMBER
