### PR TITLE
Require DOCTEST_SHOW environ to run plt.show

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -473,6 +473,7 @@ else:
             `torch.meshgrid` is commonly used to produce a grid for
             plotting.
             >>> # xdoctest: +REQUIRES(module:matplotlib)
+            >>> # xdoctest: +REQUIRES(env:DOCTEST_SHOW)
             >>> import matplotlib.pyplot as plt
             >>> xs = torch.linspace(-5, 5, steps=100)
             >>> ys = torch.linspace(-5, 5, steps=100)


### PR DESCRIPTION
@ezyang This is a minor change.

I was using the doctests to check that my install wasn't broken via: 

```bash
xdoctest -m torch --style=google --global-exec "from torch import nn\nimport torch.nn.functional as F\nimport torch" --options="+IGNORE_WHITESPACE"
```

And noticed that it stops in the middle to show this matplotlib figure. I added a condition so it only does the pyplot show if a DOCTEST_SHOW environment variable exists. With this fix the above command runs to completion and is an easy way for users to put torch through its paces given just a fresh install.