### PR TITLE
[FSDP] Relax `sharded_grad` assert to allow IDLE

### DIFF
--- a/test/distributed/fsdp/test_fsdp_state_dict.py
+++ b/test/distributed/fsdp/test_fsdp_state_dict.py
@@ -507,7 +507,6 @@ class TestFSDPStateDict(FSDPTest):
                 self._get_non_fsdp_root_module,
                 cpu_offload=cpu_offload,
                 use_orig_params=use_orig_params,
-                # sharding_strategy=ShardingStrategy.SHARD_GRAD_OP,
             ),
             partial(
                 self._get_simple_nested_model,

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1926,16 +1926,21 @@ class FlatParamHandle:
         if hasattr(flat_param, "_cpu_grad"):
             grad = flat_param._cpu_grad  # type: ignore[attr-defined]
         elif hasattr(flat_param, "_saved_grad_shard"):
+            # In the post-backward hook, the sharded gradient is still in
+            # `_saved_grad_shard`.
             grad = flat_param._saved_grad_shard  # type: ignore[attr-defined]
         else:
-            # If in the forward, then there may be an accumulated gradient,
-            # which will be in `.grad`
+            # If in IDLE or in FORWARD states, then there may be an
+            # (accumulated) gradient. If accessed in IDLE, then should should
+            # be due re-registering the original parameters (e.g. in state dict
+            # load).
             _p_assert(
                 flat_param.grad is None
                 or not self.uses_sharded_strategy
-                or self._training_state == HandleTrainingState.FORWARD,
+                or self._training_state
+                in (HandleTrainingState.FORWARD, HandleTrainingState.IDLE),
                 "Sharded strategies should use `_cpu_grad` or `_saved_grad_shard` "
-                "unless in FORWARD (for the post-forward reshard)",
+                "unless in IDLE or FORWARD"
             )
             grad = flat_param.grad
         return grad

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1940,7 +1940,7 @@ class FlatParamHandle:
                 or self._training_state
                 in (HandleTrainingState.FORWARD, HandleTrainingState.IDLE),
                 "Sharded strategies should use `_cpu_grad` or `_saved_grad_shard` "
-                "unless in IDLE or FORWARD"
+                "unless in IDLE or FORWARD",
             )
             grad = flat_param.grad
         return grad

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1931,9 +1931,9 @@ class FlatParamHandle:
             grad = flat_param._saved_grad_shard  # type: ignore[attr-defined]
         else:
             # If in IDLE or in FORWARD states, then there may be an
-            # (accumulated) gradient. If accessed in IDLE, then should should
-            # be due re-registering the original parameters (e.g. in state dict
-            # load).
+            # (accumulated) gradient. If accessed in IDLE, then this should
+            # be due to re-registering the original parameters (e.g. in state
+            # dict load).
             _p_assert(
                 flat_param.grad is None
                 or not self.uses_sharded_strategy


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96584

`_use_sharded_grad_views()` can be called when re-registering the original parameters in `load_state_dict()`, in which case the training state is `IDLE`. Previously, I only expected `_use_sharded_grad_views()` to be called in `FORWARD` when the sharded gradient is not in `_saved_grad_shard` or `_cpu_grad`.