### PR TITLE
Remove fetch-depth from _calc_docker_img

### DIFF
--- a/.github/workflows/_calculate-docker-image.yml
+++ b/.github/workflows/_calculate-docker-image.yml
@@ -25,7 +25,6 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
-          fetch-depth: 1
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux


### PR DESCRIPTION
As in current form it will only work for PRs with one commit. 
Checkout full PyTorch repo (but skip submodules)

Example of failure in PR with multiple commits, see https://github.com/pytorch/pytorch/actions/runs/4389777316/jobs/7687694067#step:4:68
