### PR TITLE
Dockerize torch deploy setup

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -94,5 +94,8 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     pip_install scikit-learn==0.20.3
   fi
 
+  # Required to test torch deploy
+  conda_install "libpython-static=${ANACONDA_PYTHON_VERSION}"
+
   popd
 fi

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -7,6 +7,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   BASE_URL="https://repo.anaconda.com/miniconda"
 
   MAJOR_PYTHON_VERSION=$(echo "$ANACONDA_PYTHON_VERSION" | cut -d . -f 1)
+  MINOR_PYTHON_VERSION=$(echo "$ANACONDA_PYTHON_VERSION" | cut -d . -f 2)
 
   case "$MAJOR_PYTHON_VERSION" in
     2)
@@ -52,25 +53,30 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
   CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools"
   if [ "$ANACONDA_PYTHON_VERSION" = "3.11" ]; then
-    # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
-    # and libpython-static for torch deploy
     # TODO: Stop using `-c malfet`
-    conda_install numpy=1.23.5 ${CONDA_COMMON_DEPS} llvmdev=8.0.0 "libpython-static=${ANACONDA_PYTHON_VERSION}" -c malfet
+    conda_install numpy=1.23.5 ${CONDA_COMMON_DEPS} -c malfet
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.10" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
     # and libpython-static for torch deploy
-    conda_install numpy=1.21.2 ${CONDA_COMMON_DEPS} llvmdev=8.0.0 "libpython-static=${ANACONDA_PYTHON_VERSION}"
+    conda_install numpy=1.21.2 ${CONDA_COMMON_DEPS}
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.9" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
     # and libpython-static for torch deploy
-    conda_install numpy=1.19.2 ${CONDA_COMMON_DEPS} llvmdev=8.0.0 "libpython-static=${ANACONDA_PYTHON_VERSION}"
+    conda_install numpy=1.19.2 ${CONDA_COMMON_DEPS}
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.8" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
     # and libpython-static for torch deploy
-    conda_install numpy=1.18.5 ${CONDA_COMMON_DEPS} llvmdev=8.0.0 "libpython-static=${ANACONDA_PYTHON_VERSION}"
+    conda_install numpy=1.18.5 ${CONDA_COMMON_DEPS}
   else
     # Install `typing-extensions` for 3.7
     conda_install numpy=1.18.5 ${CONDA_COMMON_DEPS} typing-extensions
+  fi
+
+  # This is only supported in 3.8 upward
+  if [ "$MINOR_PYTHON_VERSION" -gt "7" ]; then
+    # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
+    # and libpython-static for torch deploy
+    conda_install llvmdev=8.0.0 "libpython-static=${ANACONDA_PYTHON_VERSION}"
   fi
 
   # Use conda cmake in some cases. Conda cmake will be newer than our supported

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -53,17 +53,21 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools"
   if [ "$ANACONDA_PYTHON_VERSION" = "3.11" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
+    # and libpython-static for torch deploy
     # TODO: Stop using `-c malfet`
-    conda_install numpy=1.23.5 ${CONDA_COMMON_DEPS} llvmdev=8.0.0 -c malfet
+    conda_install numpy=1.23.5 ${CONDA_COMMON_DEPS} llvmdev=8.0.0 "libpython-static=${ANACONDA_PYTHON_VERSION}" -c malfet
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.10" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
-    conda_install numpy=1.21.2 ${CONDA_COMMON_DEPS} llvmdev=8.0.0
+    # and libpython-static for torch deploy
+    conda_install numpy=1.21.2 ${CONDA_COMMON_DEPS} llvmdev=8.0.0 "libpython-static=${ANACONDA_PYTHON_VERSION}"
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.9" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
-    conda_install numpy=1.19.2 ${CONDA_COMMON_DEPS} llvmdev=8.0.0
+    # and libpython-static for torch deploy
+    conda_install numpy=1.19.2 ${CONDA_COMMON_DEPS} llvmdev=8.0.0 "libpython-static=${ANACONDA_PYTHON_VERSION}"
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.8" ]; then
     # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
-    conda_install numpy=1.18.5 ${CONDA_COMMON_DEPS} llvmdev=8.0.0
+    # and libpython-static for torch deploy
+    conda_install numpy=1.18.5 ${CONDA_COMMON_DEPS} llvmdev=8.0.0 "libpython-static=${ANACONDA_PYTHON_VERSION}"
   else
     # Install `typing-extensions` for 3.7
     conda_install numpy=1.18.5 ${CONDA_COMMON_DEPS} typing-extensions
@@ -93,9 +97,6 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     # Pinned scikit-learn due to https://github.com/scikit-learn/scikit-learn/issues/14485 (affects gcc 5.5 only)
     pip_install scikit-learn==0.20.3
   fi
-
-  # Required to test torch deploy
-  conda_install "libpython-static=${ANACONDA_PYTHON_VERSION}"
 
   popd
 fi

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -56,16 +56,10 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     # TODO: Stop using `-c malfet`
     conda_install numpy=1.23.5 ${CONDA_COMMON_DEPS} -c malfet
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.10" ]; then
-    # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
-    # and libpython-static for torch deploy
     conda_install numpy=1.21.2 ${CONDA_COMMON_DEPS}
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.9" ]; then
-    # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
-    # and libpython-static for torch deploy
     conda_install numpy=1.19.2 ${CONDA_COMMON_DEPS}
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.8" ]; then
-    # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source
-    # and libpython-static for torch deploy
     conda_install numpy=1.18.5 ${CONDA_COMMON_DEPS}
   else
     # Install `typing-extensions` for 3.7

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -157,21 +157,9 @@ function install_tabulate() {
   pip_install tabulate
 }
 
-function setup_torchdeploy_deps(){
-  conda install -y -n "py_${ANACONDA_PYTHON_VERSION}" "libpython-static=${ANACONDA_PYTHON_VERSION}"
-  local CC
-  local CXX
-  CC="$(which gcc)"
-  CXX="$(which g++)"
-  export CC
-  export CXX
-  pip install --upgrade pip
-}
-
 function checkout_install_torchdeploy() {
   local commit
   commit=$(get_pinned_commit multipy)
-  setup_torchdeploy_deps
   pushd ..
   git clone --recurse-submodules https://github.com/pytorch/multipy.git
   pushd multipy


### PR DESCRIPTION
The step `conda_install "libpython-static=${ANACONDA_PYTHON_VERSION}"` could fail flakily, for example https://hud.pytorch.org/pytorch/pytorch/commit/5f89d147a100064ae8a9743fa0e297bdedfa1b61, so let's put that into Docker.