### PR TITLE
[doc] fix `torch.cuda.mem_get_info` doc

### DIFF
--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -600,7 +600,7 @@ def list_gpu_processes(device: Union[Device, int] = None) -> str:
     return "\n".join(lines)
 
 def mem_get_info(device: Union[Device, int] = None) -> Tuple[int, int]:
-    r"""Returns the global free and total GPU memory occupied for a given
+    r"""Returns the global free and total GPU memory for a given
     device using cudaMemGetInfo.
 
     Args:


### PR DESCRIPTION
the current `torch.cuda.mem_get_info` doc is incorrect. This util returns `free, total` and not `free, used`

```
__host__ ​cudaError_t cudaMemGetInfo ( size_t* free, size_t* total )
    Gets free and total device memory.
```

Also this util isn't mentioned in https://pytorch.org/docs/stable/notes/cuda.html#cuda-memory-management - should it be included there as well?