### PR TITLE
fix: Add an extra handling for `NotADirectoryError` from ROCm-related task(`hipconfig`)

### DIFF
--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -34,7 +34,7 @@ try:
     rocm_path = subprocess.check_output(["hipconfig", "--rocmpath"]).decode("utf-8")
 except subprocess.CalledProcessError:
     print(f"Warning: hipconfig --rocmpath failed, assuming {rocm_path}")
-except (FileNotFoundError, PermissionError):
+except (FileNotFoundError, NotADirectoryError, PermissionError):
     # Do not print warning. This is okay. This file can also be imported for non-ROCm builds.
     pass
 


### PR DESCRIPTION
Hi, PyTorch Team! While I was installing [microsoft/DeepSpeed](https://github.com/microsoft/DeepSpeed) from inside an `amd64` container running on Docker, I faced an error below:
```sh
root@34507066ebe5:/home/work# pip install deepspeed
Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com
Collecting deepspeed
  Downloading deepspeed-0.8.2.tar.gz (763 kB)
     |████████████████████████████████| 763 kB 4.7 MB/s 
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-2lanthkm/deepspeed_24d89203ea74453fb64f28a0ff002a38/setup.py'"'"'; __file__='"'"'/tmp/pip-install-2lanthkm/deepspeed_24d89203ea74453fb64f28a0ff002a38/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-jbhh78ok
         cwd: /tmp/pip-install-2lanthkm/deepspeed_24d89203ea74453fb64f28a0ff002a38/
    Complete output (21 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-2lanthkm/deepspeed_24d89203ea74453fb64f28a0ff002a38/setup.py", line 95, in <module>
        cmdclass['build_ext'] = get_accelerator().build_extension().with_options(
      File "/tmp/pip-install-2lanthkm/deepspeed_24d89203ea74453fb64f28a0ff002a38/accelerator/cuda_accelerator.py", line 253, in build_extension
        from torch.utils.cpp_extension import BuildExtension
      File "/usr/local/lib/python3.8/dist-packages/torch/utils/cpp_extension.py", line 19, in <module>
        from .hipify import hipify_python
      File "/usr/local/lib/python3.8/dist-packages/torch/utils/hipify/hipify_python.py", line 34, in <module>
        from .cuda_to_hip_mappings import CUDA_TO_HIP_MAPPINGS
      File "/usr/local/lib/python3.8/dist-packages/torch/utils/hipify/cuda_to_hip_mappings.py", line 34, in <module>
        rocm_path = subprocess.check_output(["hipconfig", "--rocmpath"]).decode("utf-8")
      File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
        return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
      File "/usr/lib/python3.8/subprocess.py", line 493, in run
        with Popen(*popenargs, **kwargs) as process:
      File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
        self._execute_child(args, executable, preexec_fn, close_fds,
      File "/usr/lib/python3.8/subprocess.py", line 1704, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
    NotADirectoryError: [Errno 20] Not a directory: 'hipconfig'
    ----------------------------------------
```

I searched for the related-issues and this one looks similar to mine.

Reference
- https://github.com/pytorch/pytorch/pull/83009

FYI: The machine I used has no ROCm device. I'm not sure what actually `hipconfig` does, but I think this error has to be handled.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport