### PR TITLE
_mm_prefetch is for Intel, changed to __prefetch for Arm64

### DIFF
--- a/caffe2/serialize/crc_alt.h
+++ b/caffe2/serialize/crc_alt.h
@@ -101,15 +101,21 @@ uint32_t crc32_16bytes_prefetch(const void* data, size_t length, uint32_t previo
   // Windows always little endian
   #define __BYTE_ORDER __LITTLE_ENDIAN
 
-  #if !defined(_M_ARM64)
   // intrinsics / prefetching
-  #include <xmmintrin.h>
+  #if defined(_M_ARM64)
+    #include <intrin.h>
+  #else
+    #include <xmmintrin.h>
   #endif
 
   #ifdef __MINGW32__
     #define PREFETCH(location) __builtin_prefetch(location)
   #else
-    #define PREFETCH(location) _mm_prefetch(location, _MM_HINT_T0)
+    #if defined(_M_ARM64)
+      #define PREFETCH(location) __prefetch(location)
+    #else
+      #define PREFETCH(location) _mm_prefetch(location, _MM_HINT_T0)
+    #endif
   #endif
 #elif defined(__APPLE__)
   #include <TargetConditionals.h>


### PR DESCRIPTION
The current master build on Windows Arm64 is broken on this.

cc @peterjc123 @mszhanyi @skyline75489 @nbcsm @vladimir-aubrecht @malfet