### PR TITLE
Enhance error message for dependency check

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1069,6 +1069,11 @@ if(BUILD_PYTHON)
   find_package(PythonInterp 3.0)
   find_package(PythonLibs 3.0)
 
+  if(NOT PYTHONLIBS_VERSION_STRING)
+    message(FATAL_ERROR
+      "Python development libraries could not be found.")
+  endif()
+
   if(${PYTHONLIBS_VERSION_STRING} VERSION_LESS 3)
     message(FATAL_ERROR
       "Found Python libraries version ${PYTHONLIBS_VERSION_STRING}. Python 2 has reached end-of-life and is no longer supported by PyTorch.")


### PR DESCRIPTION
If python development library is missing when building pytorch from source, cmake will raise the error like:
```
CMake Error at cmake/Dependencies.cmake:1079 (if):
  if given arguments:

    "VERSION_LESS" "3"

  Unknown arguments specified
```

it's quite a misleading information that user would consider it's a syntax error or cmake version problem.

This PR add a check to ensure `PYTHONLIBS_VERSION_STRING` exist before using.

Related  #87993
