### PR TITLE
Improved perfs for vectorized interpolate cpu uint8 RGB-case

### DIFF
--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -742,7 +742,7 @@ struct HelperInterpBase {
   }
 
   template <typename scalar_t, typename aa_filter_fn_t>
-  static inline void _compute_weights_aa(
+  static inline scalar_t _compute_weights_aa(
     const int64_t i, const int64_t input_size, const scalar_t scale, const scalar_t support,
     scalar_t* wt_ptr, const int64_t max_interp_size, aa_filter_fn_t filter_fn,
     int64_t& xmin, int64_t& xsize, bool antialias, double align_corners_delta
@@ -764,14 +764,19 @@ struct HelperInterpBase {
       wt_ptr[j] = w;
       total_w += w;
     }
-    for (j = 0; j < xsize; j++) {
-      if (total_w != 0.0) {
+
+    scalar_t wt_max = 0.0;
+    if (total_w != 0.0) {
+      for (j = 0; j < xsize; j++) {
         wt_ptr[j] /= total_w;
+        wt_max = (wt_max < wt_ptr[j]) ? wt_ptr[j] : wt_max;
       }
     }
+
     for (; j < max_interp_size; j++) {
       wt_ptr[j] = static_cast<scalar_t>(0.0);
     }
+    return wt_max;
   }
 
   // Note [ Support for antialias=False as a subcase of antilias=True ]
@@ -785,7 +790,7 @@ struct HelperInterpBase {
   // indices, but this can be optimized further when aa=False since we know
   // their actual dimensions.
   template <typename scalar_t, typename aa_filter_fn_t, int weight_index_stride=sizeof(scalar_t)>
-  static inline std::tuple<std::vector<Tensor>, int> _compute_indices_weights_aa(
+  static inline std::tuple<std::vector<Tensor>, int, scalar_t> _compute_indices_weights_aa(
     int64_t input_size, int64_t output_size, int64_t stride, int64_t ndims,
     int64_t reshape_dim, scalar_t scale,
     int interp_size, aa_filter_fn_t aa_filter_fn, bool antialias, double align_corners_delta
@@ -834,10 +839,11 @@ struct HelperInterpBase {
     scalar_t* wt_ptr = output[3].data_ptr<scalar_t>();
     int64_t* wt_idx_ptr = output[4].data_ptr<int64_t>();
 
-    int64_t xmin, xmax;
+    scalar_t wt_max = 0.0;
 
     for (const auto i : c10::irange(output_size)) {
-      HelperInterpBase::_compute_weights_aa(
+      int64_t xmin, xmax;
+      auto wt_max_i = HelperInterpBase::_compute_weights_aa(
           i,
           input_size,
           scale,
@@ -850,12 +856,14 @@ struct HelperInterpBase {
           antialias,
           align_corners_delta);
 
+      wt_max = (wt_max < wt_max_i) ? wt_max_i : wt_max;
+
       idx_ptr_xmin[i] = xmin * stride;
       idx_ptr_size[i] = xmax;
       idx_ptr_stride[i] = stride;
       wt_idx_ptr[i] = i * max_interp_size * weight_index_stride;
     }
-    return {output, max_interp_size};
+    return {output, max_interp_size, wt_max};
   }
 
   /*
@@ -911,33 +919,25 @@ struct HelperInterpBase {
 
     std::vector<Tensor> indices_weights;
     auto align_corners_delta = (align_corners && !antialias) ? 0.5 : 0.0;
-    std::tie(indices_weights, interp_size) = HelperInterpBase::_compute_indices_weights_aa<double, aa_filter_fn_t, sizeof(int16_t)>(
+    double wt_max;
+    std::tie(indices_weights, interp_size, wt_max) = HelperInterpBase::_compute_indices_weights_aa<double, aa_filter_fn_t, sizeof(int16_t)>(
         input_size, output_size, stride, ndims, reshape_dim, scale, interp_size, aa_filter_fn, antialias, align_corners_delta);
 
     // Rescale float weights to int16 and compute weights precision
     auto weights_f64 = indices_weights[3];
     double * data_f64 = weights_f64.data_ptr<double>();
-    int64_t weights_f64_size = output_size * interp_size;
-    // can't use weights_f64.max() here as tensor is restrided
-    double w_max = data_f64[0];
-    for (const auto i : c10::irange(weights_f64_size)) {
-        double v = data_f64[i];
-        if (w_max < v) {
-            w_max = v;
-        }
-    }
+
+    int16_t * data_i16 = (int16_t *) data_f64;
+    auto aligned_interp_size = interp_size;
 
     unsigned int weights_precision = 0;
-    for (weights_precision = 0; weights_precision < 22; weights_precision += 1) {
-        int next_value = (int) (0.5 + w_max * (1 << (weights_precision + 1)));
+    for (weights_precision = 0; weights_precision < 22; ++weights_precision) {
+        int next_value = (int) (0.5 + wt_max * (1 << (weights_precision + 1)));
         if (next_value >= (1 << 15))
             break;
     }
 
     // Rescale float values to int16
-    int16_t * data_i16 = (int16_t *) data_f64;
-    auto aligned_interp_size = interp_size;
-
     if (align_i32) {
       // We should respect int32 alignment as we will load int16 data as int32
       // See ImagingResampleHorizontalConvolution8u4x, mmk0 = _mm256_set1_epi32(*(int32_t*)&k[x]);
@@ -951,12 +951,8 @@ struct HelperInterpBase {
 
     for (const auto j : c10::irange(output_size)) {
       for (const auto k : c10::irange(interp_size)) {
-        double v = data_f64[j * interp_size + k];
-        if (v < 0) {
-            data_i16[j * aligned_interp_size + k] = (int) (-0.5 + v * (1 << weights_precision));
-        } else {
-            data_i16[j * aligned_interp_size + k] = (int) (0.5 + v * (1 << weights_precision));
-        }
+        double v = data_f64[j * interp_size + k] * (1 << weights_precision);
+        data_i16[j * aligned_interp_size + k] = (v < 0) ? (int) (-0.5 + v) : (int) (0.5 + v);
       }
     }
 
@@ -1171,8 +1167,9 @@ struct HelperInterpLinear : public HelperInterpBase {
 
         auto interp_size = HelperInterpLinear::interp_size;
         int unused;
+        scalar_t unused_2;
 
-        std::tie(indices_weights, unused) = HelperInterpLinear::_compute_indices_weights_aa<scalar_t>(
+        std::tie(indices_weights, unused, unused_2) = HelperInterpLinear::_compute_indices_weights_aa<scalar_t>(
             input_size,
             output_size,
             stride,
@@ -1303,8 +1300,9 @@ struct HelperInterpCubic : public HelperInterpBase {
 
         auto interp_size = HelperInterpCubic::interp_size;
         int unused;
+        scalar_t unused_2;
 
-        std::tie(indices_weights, unused) = HelperInterpCubic::_compute_indices_weights_aa<scalar_t>(
+        std::tie(indices_weights, unused, unused_2) = HelperInterpCubic::_compute_indices_weights_aa<scalar_t>(
             input_size,
             output_size,
             stride,
@@ -1760,18 +1758,15 @@ void upsample_bilinear2d_aa_kernel_impl(
     c10::optional<double> scales_w) {
 #ifdef CPU_CAPABILITY_AVX2
   if (input.dtype() == at::kByte && input.size(1) <= 4) {
-    // std::cout << "- Call upsample_avx_bilinear_uint8" << std::endl;
     upsample_avx_bilinear_uint8<scale_t, HelperInterpLinear>(
       input, output, align_corners, {scales_h, scales_w},
       /*antialias=*/true);
   } else {
-    // std::cout << "- 1 Call separable_upsample_generic_Nd_kernel_impl" << std::endl;
     separable_upsample_generic_Nd_kernel_impl<2, scale_t, HelperInterpLinear>(
         output, input, align_corners, {scales_h, scales_w},
         /*antialias=*/true);
   }
 #else // CPU_CAPABILITY_AVX2
-  // std::cout << "- 2 Call separable_upsample_generic_Nd_kernel_impl" << std::endl;
   separable_upsample_generic_Nd_kernel_impl<2, scale_t, HelperInterpLinear>(
       output, input, align_corners, {scales_h, scales_w},
       /*antialias=*/true);

--- a/aten/src/ATen/native/cpu/UpSampleKernelAVXAntialias.h
+++ b/aten/src/ATen/native/cpu/UpSampleKernelAVXAntialias.h
@@ -35,7 +35,7 @@ Like PIL, Pillow is licensed under the open source HPND License
 
 namespace {
 
-static __m128i inline mm_cvtepu8_epi32(const uint32_t* C10_RESTRICT ptr) {
+static __m128i inline mm_cvtepu8_epi32(const uint8_t* C10_RESTRICT ptr) {
   return _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(int32_t*)ptr));
 }
 
@@ -90,38 +90,44 @@ void pack_rgb(
 }
 
 void ImagingResampleHorizontalConvolution8u4x(
-    uint32_t* C10_RESTRICT lineOut0,
-    uint32_t* C10_RESTRICT lineOut1,
-    uint32_t* C10_RESTRICT lineOut2,
-    uint32_t* C10_RESTRICT lineOut3,
-    const uint32_t* C10_RESTRICT lineIn0,
-    const uint32_t* C10_RESTRICT lineIn1,
-    const uint32_t* C10_RESTRICT lineIn2,
-    const uint32_t* C10_RESTRICT lineIn3,
-    int xsize,
-    int* xbounds,
-    int16_t* kk,
+    uint8_t* C10_RESTRICT lineOut0,
+    uint8_t* C10_RESTRICT lineOut1,
+    uint8_t* C10_RESTRICT lineOut2,
+    uint8_t* C10_RESTRICT lineOut3,
+    const uint8_t* C10_RESTRICT lineIn0,
+    const uint8_t* C10_RESTRICT lineIn1,
+    const uint8_t* C10_RESTRICT lineIn2,
+    const uint8_t* C10_RESTRICT lineIn3,
+    int64_t xsize,
+    const int64_t* idx_ptr_xmin,
+    const int64_t* idx_ptr_size,
+    const int16_t* kk,
     int kmax,
-    int coefs_precision);
+    unsigned int coefs_precision,
+    int64_t num_channels);
 
 void ImagingResampleHorizontalConvolution8u(
-    uint32_t* C10_RESTRICT lineOut,
-    const uint32_t* C10_RESTRICT lineIn,
-    int xsize,
-    int* xbounds,
-    int16_t* kk,
+    uint8_t* C10_RESTRICT lineOut,
+    const uint8_t* C10_RESTRICT lineIn,
+    int64_t xsize,
+    const int64_t* idx_ptr_xmin,
+    const int64_t* idx_ptr_size,
+    const int16_t* kk,
     int kmax,
-    int coefs_precision);
+    unsigned int coefs_precision,
+    int64_t num_channels);
 
 void ImagingResampleVerticalConvolution8u(
-    uint32_t* C10_RESTRICT lineOut,
-    const uint32_t* C10_RESTRICT imIn,
-    int xmin,
-    int xmax,
-    int16_t* k,
-    int coefs_precision,
-    int xin);
+    uint8_t* C10_RESTRICT lineOut,
+    const uint8_t* C10_RESTRICT lineIn,
+    int64_t xsize,
+    int64_t ymin,
+    int64_t ymax,
+    const int16_t* k,
+    unsigned int coefs_precision,
+    int64_t num_channels);
 
+template<int num_channels>
 void ImagingResampleHorizontal(
     const at::Tensor & unpacked_output,
     const at::Tensor & unpacked_input,
@@ -132,56 +138,58 @@ void ImagingResampleHorizontal(
   // basic_loop_aa_horizontal<uint8_t>)
   // Although this may not be needed if / when we port all this code to use
   // Vec.h since this would potentially give us another fall-back implem
-  int yy;
 
-  int16_t* kk = (int16_t*)(horiz_indices_weights[3].data_ptr<double>());
+  const int16_t* kk = (int16_t*)(horiz_indices_weights[3].data_ptr<double>());
 
   auto xout = unpacked_output.size(2);
   auto yout = unpacked_output.size(1);
   auto xin = unpacked_input.size(2);
+  // const auto num_channels = unpacked_input.size(0);
+  // TORCH_INTERNAL_ASSERT(num_channels == 3 || num_channels == 4);
+  TORCH_INTERNAL_ASSERT(num_channels == unpacked_input.size(0));
 
-  std::vector<int> bounds_vec(2 * xout, 0);
-  int* bounds = bounds_vec.data();
+  const int64_t* idx_ptr_xmin = horiz_indices_weights[0].data_ptr<int64_t>();
+  const int64_t* idx_ptr_size = horiz_indices_weights[1].data_ptr<int64_t>();
 
-  int64_t* idx_ptr_xmin = horiz_indices_weights[0].data_ptr<int64_t>();
-  int64_t* idx_ptr_size = horiz_indices_weights[1].data_ptr<int64_t>();
-  for (int i = 0; i < xout; i++) {
-    bounds[2 * i + 0] = idx_ptr_xmin[i];
-    bounds[2 * i + 1] = idx_ptr_size[i];
-  }
+  uint8_t* unpacked_output_p = unpacked_output.data_ptr<uint8_t>();
+  const uint8_t* unpacked_input_p = unpacked_input.data_ptr<uint8_t>();
 
-  uint32_t* unpacked_input_p = (uint32_t*) unpacked_input.data_ptr<uint8_t>();
-  uint32_t* unpacked_output_p = (uint32_t*) unpacked_output.data_ptr<uint8_t>();
-
-  yy = 0;
+  int64_t yy = 0;
+  auto xout_stride = xout * num_channels;
+  auto xin_stride = xin * num_channels;
   for (; yy < yout - 3; yy += 4) {
     ImagingResampleHorizontalConvolution8u4x(
-        unpacked_output_p + yy * xout,
-        unpacked_output_p + (yy + 1) * xout,
-        unpacked_output_p + (yy + 2) * xout,
-        unpacked_output_p + (yy + 3) * xout,
-        unpacked_input_p + yy * xin,
-        unpacked_input_p + (yy + 1) * xin,
-        unpacked_input_p + (yy + 2) * xin,
-        unpacked_input_p + (yy + 3) * xin,
+        unpacked_output_p + yy * xout_stride,
+        unpacked_output_p + (yy + 1) * xout_stride,
+        unpacked_output_p + (yy + 2) * xout_stride,
+        unpacked_output_p + (yy + 3) * xout_stride,
+        unpacked_input_p + yy * xin_stride,
+        unpacked_input_p + (yy + 1) * xin_stride,
+        unpacked_input_p + (yy + 2) * xin_stride,
+        unpacked_input_p + (yy + 3) * xin_stride,
         xout,
-        bounds,
+        idx_ptr_xmin,
+        idx_ptr_size,
         kk,
         ksize,
-        (int)horiz_weights_precision);
+        horiz_weights_precision,
+        num_channels);
   }
   for (; yy < yout; yy++) {
     ImagingResampleHorizontalConvolution8u(
-        unpacked_output_p + yy * xout,
-        unpacked_input_p + yy * xin,
+        unpacked_output_p + yy * xout_stride,
+        unpacked_input_p + yy * xin_stride,
         xout,
-        bounds,
+        idx_ptr_xmin,
+        idx_ptr_size,
         kk,
         ksize,
-        (int)horiz_weights_precision);
+        horiz_weights_precision,
+        num_channels);
   }
 }
 
+template<int num_channels>
 void ImagingResampleVertical(
     const at::Tensor & unpacked_output,
     const at::Tensor & unpacked_input,
@@ -192,32 +200,35 @@ void ImagingResampleVertical(
   // basic_loop_aa_vertical<uint8_t>)
   // Although this may not be needed if / when we port all this code to use
   // Vec.h since this would potentially give us another fall-back implem
-  int ymin, ymax;
-  int16_t* k = nullptr;
-  int16_t* kk = (int16_t*)(vert_indices_weights[3].data_ptr<double>());
+  const int16_t* kk = (int16_t*)(vert_indices_weights[3].data_ptr<double>());
 
-  int64_t* idx_ptr_xmin = vert_indices_weights[0].data_ptr<int64_t>();
-  int64_t* idx_ptr_size = vert_indices_weights[1].data_ptr<int64_t>();
+  const int64_t* idx_ptr_xmin = vert_indices_weights[0].data_ptr<int64_t>();
+  const int64_t* idx_ptr_size = vert_indices_weights[1].data_ptr<int64_t>();
 
-  uint32_t* unpacked_output_p = (uint32_t*) unpacked_output.data_ptr<uint8_t>();
-  uint32_t* unpacked_input_p = (uint32_t*) unpacked_input.data_ptr<uint8_t>();
+  uint8_t* unpacked_output_p = unpacked_output.data_ptr<uint8_t>();
+  const uint8_t* unpacked_input_p = unpacked_input.data_ptr<uint8_t>();
 
   auto xout = unpacked_output.size(2);
   auto yout = unpacked_output.size(1);
+  // const auto num_channels = unpacked_input.size(0);
+  // TORCH_INTERNAL_ASSERT(num_channels == 3 || num_channels == 4);
+  TORCH_INTERNAL_ASSERT(num_channels == unpacked_input.size(0));
 
+  auto xout_stride = xout * num_channels;
   for (const auto yy : c10::irange(yout)) {
-    k = &kk[yy * ksize];
+    const auto* k = &kk[yy * ksize];
 
-    ymin = idx_ptr_xmin[yy];
-    ymax = idx_ptr_size[yy];
+    auto ymin = idx_ptr_xmin[yy];
+    auto ymax = idx_ptr_size[yy];
     ImagingResampleVerticalConvolution8u(
-        unpacked_output_p + yy * xout,
+        unpacked_output_p + yy * xout_stride,
         unpacked_input_p,
+        xout,
         ymin,
         ymax,
         k,
-        (int)vert_weights_precision,
-        xout);
+        vert_weights_precision,
+        num_channels);
   }
 }
 
@@ -292,14 +303,16 @@ void upsample_avx_bilinear_uint8(
             /*align_i32=*/true);
   }
 
-  bool is_rgba = num_channels == 4 && input.is_contiguous(at::MemoryFormat::ChannelsLast);
+  bool is_rgb_or_rgba = (num_channels == 3 || num_channels == 4) && input.is_contiguous(at::MemoryFormat::ChannelsLast);
 
   at::Tensor buffer_horiz, buffer_vert;
-  if (need_horizontal && !(is_rgba && !need_vertical)) {
-    buffer_horiz = at::empty({4, yin, xout}, input.options());
+  if (need_horizontal && !(is_rgb_or_rgba && !need_vertical)) {
+    auto c = (is_rgb_or_rgba) ? num_channels : 4;
+    buffer_horiz = at::empty({c, yin, xout}, input.options());
   }
-  if (need_vertical && !is_rgba) {
-    buffer_vert = at::empty({4, yout, xout}, input.options());
+  if (need_vertical && !is_rgb_or_rgba) {
+    auto c = (is_rgb_or_rgba) ? num_channels : 4;
+    buffer_vert = at::empty({c, yout, xout}, input.options());
   }
 
   // TODO: The unpack / pack operations create a copy of the original input and
@@ -308,146 +321,217 @@ void upsample_avx_bilinear_uint8(
   // tensors and just copy part of them (line by line).
   for (const auto i : c10::irange(batch_size)) {
 
-    at::Tensor unpacked_input = (is_rgba) ? input[i] : unpack_rgb(input[i]);
+    at::Tensor unpacked_input = (is_rgb_or_rgba) ? input[i] : unpack_rgb(input[i]);
     at::Tensor unpacked_output;
 
     if (need_horizontal) {
+      at::Tensor unpacked_output_temp = (is_rgb_or_rgba && !need_vertical) ? output[i] : buffer_horiz;
 
-      at::Tensor unpacked_output_temp = (is_rgba && !need_vertical) ? output[i] : buffer_horiz;
-
-      ImagingResampleHorizontal(
-          unpacked_output_temp,
-          unpacked_input,
-          ksize_horiz,
-          horiz_indices_weights,
-          horiz_weights_precision);
+      if (is_rgb_or_rgba && num_channels == 3) {
+        ImagingResampleHorizontal<3>(
+            unpacked_output_temp,
+            unpacked_input,
+            ksize_horiz,
+            horiz_indices_weights,
+            horiz_weights_precision);
+      } else {
+        ImagingResampleHorizontal<4>(
+            unpacked_output_temp,
+            unpacked_input,
+            ksize_horiz,
+            horiz_indices_weights,
+            horiz_weights_precision);
+      }
       unpacked_output = unpacked_input = unpacked_output_temp;
     }
     if (need_vertical) {
-      unpacked_output = (is_rgba) ? output[i] : buffer_vert;
+      unpacked_output = (is_rgb_or_rgba) ? output[i] : buffer_vert;
 
-      ImagingResampleVertical(
-          unpacked_output,
-          unpacked_input,
-          ksize_vert,
-          vert_indices_weights,
-          vert_weights_precision);
+      if (is_rgb_or_rgba && num_channels == 3) {
+        ImagingResampleVertical<3>(
+            unpacked_output,
+            unpacked_input,
+            ksize_vert,
+            vert_indices_weights,
+            vert_weights_precision);
+      } else {
+        ImagingResampleVertical<4>(
+            unpacked_output,
+            unpacked_input,
+            ksize_vert,
+            vert_indices_weights,
+            vert_weights_precision);
+      }
     }
 
     TORCH_INTERNAL_ASSERT(unpacked_output.defined());
 
-    if (!is_rgba) {
+    if (!is_rgb_or_rgba) {
       pack_rgb(unpacked_output, output[i]);
     }
   }
 }
 
-// https://gist.github.com/NicolasHug/47c97d731f05eaad5694c173849b86f5
 void ImagingResampleHorizontalConvolution8u4x(
-    uint32_t* C10_RESTRICT lineOut0,
-    uint32_t* C10_RESTRICT lineOut1,
-    uint32_t* C10_RESTRICT lineOut2,
-    uint32_t* C10_RESTRICT lineOut3,
-    const uint32_t* C10_RESTRICT lineIn0,
-    const uint32_t* C10_RESTRICT lineIn1,
-    const uint32_t* C10_RESTRICT lineIn2,
-    const uint32_t* C10_RESTRICT lineIn3,
-    int xsize,
-    int* xbounds,
-    int16_t* kk,
+    uint8_t* C10_RESTRICT lineOut0,
+    uint8_t* C10_RESTRICT lineOut1,
+    uint8_t* C10_RESTRICT lineOut2,
+    uint8_t* C10_RESTRICT lineOut3,
+    const uint8_t* C10_RESTRICT lineIn0,
+    const uint8_t* C10_RESTRICT lineIn1,
+    const uint8_t* C10_RESTRICT lineIn2,
+    const uint8_t* C10_RESTRICT lineIn3,
+    int64_t xsize,
+    const int64_t* idx_ptr_xmin,
+    const int64_t* idx_ptr_size,
+    const int16_t* kk,
     int kmax,
-    int coefs_precision) {
-  int xmin, xmax, x;
-  int16_t* k;
+    unsigned int coefs_precision,
+    int64_t num_channels) {
+
+  // Define shuffling masks (low/high) for num_channels 4 and 3
+  const __m256i masks_low_high_c4[2] = {
+    _mm256_set_epi8(
+      -1, 7, -1, 3, -1, 6, -1, 2, -1, 5, -1, 1, -1, 4, -1, 0,
+      -1, 7, -1, 3, -1, 6, -1, 2, -1, 5, -1, 1, -1, 4, -1, 0
+    ),
+    _mm256_set_epi8(
+      -1, 15, -1, 11, -1, 14, -1, 10, -1, 13, -1, 9, -1, 12, -1, 8,
+      -1, 15, -1, 11, -1, 14, -1, 10, -1, 13, -1, 9, -1, 12, -1, 8
+    )
+  };
+  const __m256i masks_low_high_c3[2] = {
+    _mm256_set_epi8(
+      -1, -1, -1, -1, -1, 5, -1, 2, -1, 4, -1, 1, -1, 3, -1, 0,
+      -1, -1, -1, -1, -1, 5, -1, 2, -1, 4, -1, 1, -1, 3, -1, 0
+    ),
+    _mm256_set_epi8(
+      -1, -1, -1, -1, -1, 11, -1, 8, -1, 10, -1, 7, -1, 9, -1, 6,
+      -1, -1, -1, -1, -1, 11, -1, 8, -1, 10, -1, 7, -1, 9, -1, 6
+    )
+  };
+
+  const auto mask_low = (num_channels == 3) ? masks_low_high_c3[0] : masks_low_high_c4[0];
+  const auto mask_high = (num_channels == 3) ? masks_low_high_c3[1] : masks_low_high_c4[1];
+
+  const auto mask_ch = _mm256_set_epi8(
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 2, 1, 0,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 2, 1, 0
+  );
+
+  const auto stride = num_channels * 1;  // num channels * sizeof(uint8)
+
+  TORCH_INTERNAL_ASSERT(stride == 3 || stride == 4);
+
+  // Precompute xmax limits for block 4 and block 2
+  // lineIn0 + stride * (x + xmin) + 16 <= lineIn0 + stride * (xmax + xmin)
+  // --> x <= xmax - 16.0 / stride
+  // --> x < xmax + 1 - int(16.0 / stride)
+  const auto b4_delta = int(16.0 / stride) - 1;
+
+  // lineIn0 + stride * (x + xmin) + 8 <= lineIn0 + stride * (xmax + xmin)
+  // --> x <= xmax - 8.0 / stride
+  // --> x < xmax + 1 - int(8.0 / stride)
+  const auto b2_delta = int(8.0 / stride) - 1;
+
+  // xsize = output width, xx = output x index
+  // xmax = interpolation size, x = interpolation index (horizontal <-> x dimension)
+  // xmin = input x start index corresponding to output x index (xx)
+
+  const auto zero = _mm256_setzero_si256();
+  const auto initial = _mm256_set1_epi32(1 << (coefs_precision - 1));
 
   for (const auto xx : c10::irange(xsize)) {
-    xmin = xbounds[xx * 2 + 0];
-    xmax = xbounds[xx * 2 + 1];
-    k = &kk[xx * kmax];
-    x = 0;
+    const auto xmin = idx_ptr_xmin[xx];
+    const auto xmax = idx_ptr_size[xx];
+    const auto * k = &kk[xx * kmax];
+    int64_t x = 0;
 
-    __m256i sss0, sss1;
-    __m256i zero = _mm256_setzero_si256();
-    __m256i initial = _mm256_set1_epi32(1 << (coefs_precision - 1));
-    sss0 = initial;
-    sss1 = initial;
+    auto sss0 = initial;
+    auto sss1 = initial;
 
-    for (; x < xmax - 3; x += 4) {
-      __m256i pix, mmk0, mmk1, source;
+    for (; x < xmax - b4_delta; x += 4) {
+      auto mmk0 = _mm256_set1_epi32(*(int32_t*)&k[x]);
+      auto mmk1 = _mm256_set1_epi32(*(int32_t*)&k[x + 2]);
 
-      mmk0 = _mm256_set1_epi32(*(int32_t*)&k[x]);
-      mmk1 = _mm256_set1_epi32(*(int32_t*)&k[x + 2]);
+      auto source = _mm256_inserti128_si256(_mm256_castsi128_si256(
+          _mm_loadu_si128((__m128i *) (lineIn0 + stride * (x + xmin)))),
+          _mm_loadu_si128((__m128i *) (lineIn1 + stride * (x + xmin))), 1);
 
-      source = _mm256_inserti128_si256(
-          _mm256_castsi128_si256(_mm_loadu_si128((__m128i*)&lineIn0[x + xmin])),
-          _mm_loadu_si128((__m128i*)&lineIn1[x + xmin]),
-          1);
-      // clang-format off
-      pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
-        -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0,
-        -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+      auto pix = _mm256_shuffle_epi8(source, mask_low);
       sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk0));
-      pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
-        -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8,
-        -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8));
+      pix = _mm256_shuffle_epi8(source, mask_high);
       sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk1));
 
-      source = _mm256_inserti128_si256(
-          _mm256_castsi128_si256(_mm_loadu_si128((__m128i*)&lineIn2[x + xmin])),
-          _mm_loadu_si128((__m128i*)&lineIn3[x + xmin]),
-          1);
-      pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
-        -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0,
-        -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+      source = _mm256_inserti128_si256(_mm256_castsi128_si256(
+          _mm_loadu_si128((__m128i *) (lineIn2 + stride * (x + xmin)))),
+          _mm_loadu_si128((__m128i *) (lineIn3 + stride * (x + xmin))), 1);
+      pix = _mm256_shuffle_epi8(source, mask_low);
       sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk0));
-      pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
-        -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8,
-        -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8));
+      pix = _mm256_shuffle_epi8(source, mask_high);
       sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk1));
     }
 
-    for (; x < xmax - 1; x += 2) {
-      __m256i pix, mmk;
+    for (; x < xmax - b2_delta; x += 2) {
+      auto mmk = _mm256_set1_epi32(*(int32_t*)&k[x]);
 
-      mmk = _mm256_set1_epi32(*(int32_t*)&k[x]);
-
-      pix = _mm256_inserti128_si256(
-          _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)&lineIn0[x + xmin])),
-          _mm_loadl_epi64((__m128i*)&lineIn1[x + xmin]),
-          1);
-      pix = _mm256_shuffle_epi8(pix, _mm256_set_epi8(
-        -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0,
-        -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+      auto pix = _mm256_inserti128_si256(_mm256_castsi128_si256(
+          _mm_loadu_si64(lineIn0 + stride * (x + xmin))),
+          _mm_loadu_si64(lineIn1 + stride * (x + xmin)), 1);
+      pix = _mm256_shuffle_epi8(pix, mask_low);
       sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk));
 
-      pix = _mm256_inserti128_si256(
-          _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)&lineIn2[x + xmin])),
-          _mm_loadl_epi64((__m128i*)&lineIn3[x + xmin]),
-          1);
-      pix = _mm256_shuffle_epi8(pix, _mm256_set_epi8(
-        -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0,
-        -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
+      pix = _mm256_inserti128_si256(_mm256_castsi128_si256(
+          _mm_loadu_si64(lineIn2 + stride * (x + xmin))),
+          _mm_loadu_si64(lineIn3 + stride * (x + xmin)), 1);
+      pix = _mm256_shuffle_epi8(pix, mask_low);
       sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk));
-      // clang-format on
     }
 
-    for (; x < xmax; x++) {
-      __m256i pix, mmk;
-
-      // [16] xx k0 xx k0 xx k0 xx k0 xx k0 xx k0 xx k0 xx k0
-      mmk = _mm256_set1_epi32(k[x]);
-
-      // [16] xx a0 xx b0 xx g0 xx r0 xx a0 xx b0 xx g0 xx r0
-      pix = _mm256_inserti128_si256(
-          _mm256_castsi128_si256(mm_cvtepu8_epi32(&lineIn0[x + xmin])),
-          mm_cvtepu8_epi32(&lineIn1[x + xmin]),
-          1);
+    for (; x < xmax - 1; x++) {
+      auto mmk = _mm256_set1_epi32(k[x]);
+      auto pix = _mm256_inserti128_si256(_mm256_castsi128_si256(
+          mm_cvtepu8_epi32(lineIn0 + stride * (x + xmin))),
+          mm_cvtepu8_epi32(lineIn1 + stride * (x + xmin)), 1);
       sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk));
 
-      pix = _mm256_inserti128_si256(
-          _mm256_castsi128_si256(mm_cvtepu8_epi32(&lineIn2[x + xmin])),
-          mm_cvtepu8_epi32(&lineIn3[x + xmin]),
-          1);
+      pix = _mm256_inserti128_si256(_mm256_castsi128_si256(
+          mm_cvtepu8_epi32(lineIn2 + stride * (x + xmin))),
+          mm_cvtepu8_epi32(lineIn3 + stride * (x + xmin)), 1);
+      sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk));
+    }
+
+    if (x == xmax - 1) {
+      // last element x = xmax - 1
+      auto mmk = _mm256_set1_epi32(k[x]);
+      __m256i pix;
+      __m128i p0, p1;
+      if (num_channels == 3) {
+        uint8_t output0[4];
+        uint8_t output1[4];
+        std::memcpy(output0, lineIn0 + stride * (x + xmin), 3);
+        std::memcpy(output1, lineIn1 + stride * (x + xmin), 3);
+        p0 = mm_cvtepu8_epi32(output0);
+        p1 = mm_cvtepu8_epi32(output1);
+      } else {
+        p0 = mm_cvtepu8_epi32(lineIn0 + stride * (x + xmin));
+        p1 = mm_cvtepu8_epi32(lineIn1 + stride * (x + xmin));
+      }
+      pix = _mm256_inserti128_si256(_mm256_castsi128_si256(p0), p1, 1);
+      sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk));
+
+      if (num_channels == 3) {
+        uint8_t output0[4];
+        uint8_t output1[4];
+        std::memcpy(output0, lineIn2 + stride * (x + xmin), 3);
+        std::memcpy(output1, lineIn3 + stride * (x + xmin), 3);
+        p0 = mm_cvtepu8_epi32(output0);
+        p1 = mm_cvtepu8_epi32(output1);
+      } else {
+        p0 = mm_cvtepu8_epi32(lineIn2 + stride * (x + xmin));
+        p1 = mm_cvtepu8_epi32(lineIn3 + stride * (x + xmin));
+      }
+      pix = _mm256_inserti128_si256(_mm256_castsi128_si256(p0), p1, 1);
       sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk));
     }
 
@@ -457,82 +541,164 @@ void ImagingResampleHorizontalConvolution8u4x(
     sss1 = _mm256_packs_epi32(sss1, zero);
     sss0 = _mm256_packus_epi16(sss0, zero);
     sss1 = _mm256_packus_epi16(sss1, zero);
-    lineOut0[xx] = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss0, 0));
-    lineOut1[xx] = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss0, 1));
-    lineOut2[xx] = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss1, 0));
-    lineOut3[xx] = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss1, 1));
+    if (num_channels == 3) {
+        sss0 = _mm256_shuffle_epi8(sss0, mask_ch);
+        sss1 = _mm256_shuffle_epi8(sss1, mask_ch);
+    }
+
+    auto o0 = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss0, 0));
+    auto o1 = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss0, 1));
+    auto o2 = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss1, 0));
+    auto o3 = _mm_cvtsi128_si32(_mm256_extracti128_si256(sss1, 1));
+    if (num_channels == 3 && C10_UNLIKELY(stride * xx + 4 >= xsize * stride)) {
+        std::memcpy(lineOut0 + stride * xx, (unsigned char *) &o0, num_channels);
+        std::memcpy(lineOut1 + stride * xx, (unsigned char *) &o1, num_channels);
+        std::memcpy(lineOut2 + stride * xx, (unsigned char *) &o2, num_channels);
+        std::memcpy(lineOut3 + stride * xx, (unsigned char *) &o3, num_channels);
+    } else {
+      *(uint32_t *)(lineOut0 + stride * xx) = o0;
+      *(uint32_t *)(lineOut1 + stride * xx) = o1;
+      *(uint32_t *)(lineOut2 + stride * xx) = o2;
+      *(uint32_t *)(lineOut3 + stride * xx) = o3;
+    }
   }
 }
 
-// https://gist.github.com/NicolasHug/47c97d731f05eaad5694c173849b86f5
 void ImagingResampleHorizontalConvolution8u(
-    uint32_t* C10_RESTRICT lineOut,
-    const uint32_t* C10_RESTRICT lineIn,
-    int xsize,
-    int* xbounds,
-    int16_t* kk,
+    uint8_t* C10_RESTRICT lineOut,
+    const uint8_t* C10_RESTRICT lineIn,
+    int64_t xsize,
+    const int64_t* idx_ptr_xmin,
+    const int64_t* idx_ptr_size,
+    const int16_t* kk,
     int kmax,
-    int coefs_precision) {
-  int xmin, xmax, x;
-  int16_t* k;
+    unsigned int coefs_precision,
+    int64_t num_channels) {
+
+  // Define various shuffling masks
+  const auto kmask_low = _mm256_set_epi8(
+      11, 10, 9, 8, 11, 10, 9, 8, 11, 10, 9, 8, 11, 10, 9, 8,
+      3, 2, 1, 0, 3, 2, 1, 0, 3, 2, 1, 0, 3, 2, 1, 0);
+  const auto kmask_high = _mm256_set_epi8(
+      15, 14, 13, 12, 15, 14, 13, 12, 15, 14, 13, 12, 15, 14, 13, 12,
+      7, 6, 5, 4, 7, 6, 5, 4, 7, 6, 5, 4, 7, 6, 5, 4);
+  const auto kmask_hl = _mm256_set_epi8(
+      7, 6, 5, 4, 7, 6, 5, 4, 7, 6, 5, 4, 7, 6, 5, 4,
+      3, 2, 1, 0, 3, 2, 1, 0, 3, 2, 1, 0, 3, 2, 1, 0);
+
+  const auto mask_ch = _mm_set_epi8(
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 2, 1, 0);
+
+  const __m256i masks_low_high_c4[2] = {
+    _mm256_set_epi8(
+      -1, 7, -1, 3, -1, 6, -1, 2, -1, 5, -1, 1, -1, 4, -1, 0,
+      -1, 7, -1, 3, -1, 6, -1, 2, -1, 5, -1, 1, -1, 4, -1, 0
+    ),
+    _mm256_set_epi8(
+      -1, 15, -1, 11, -1, 14, -1, 10, -1, 13, -1, 9, -1, 12, -1, 8,
+      -1, 15, -1, 11, -1, 14, -1, 10, -1, 13, -1, 9, -1, 12, -1, 8
+    )
+  };
+  const __m256i masks_low_high_c3[2] = {
+    _mm256_set_epi8(
+      -1, -1, -1, -1, -1, 5, -1, 2, -1, 4, -1, 1, -1, 3, -1, 0,
+      -1, -1, -1, -1, -1, 5, -1, 2, -1, 4, -1, 1, -1, 3, -1, 0
+    ),
+    _mm256_set_epi8(
+      -1, -1, -1, -1, -1, 11, -1, 8, -1, 10, -1, 7, -1, 9, -1, 6,
+      -1, -1, -1, -1, -1, 11, -1, 8, -1, 10, -1, 7, -1, 9, -1, 6
+    )
+  };
+  const __m256i masks_lh_c3_c4[2] = {
+    _mm256_set_epi8(
+      -1, -1, -1, -1, -1, 11, -1, 8, -1, 10, -1, 7, -1, 9, -1, 6,
+      -1, -1, -1, -1, -1, 5, -1, 2, -1, 4, -1, 1, -1, 3, -1, 0
+    ),
+    _mm256_set_epi8(
+      -1, 15, -1, 11, -1, 14, -1, 10, -1, 13, -1, 9, -1, 12, -1, 8,
+      -1, 7, -1, 3, -1, 6, -1, 2, -1, 5, -1, 1, -1, 4, -1, 0
+    )
+  };
+
+  const __m128i masks_low128_c3_c4[2] = {
+    _mm_set_epi8(
+      -1, -1, -1, -1, -1, 5, -1, 2, -1, 4, -1, 1, -1, 3, -1, 0
+    ),
+    _mm_set_epi8(
+      -1, 7, -1, 3, -1, 6, -1, 2, -1, 5, -1, 1, -1, 4, -1, 0
+    )
+  };
+
+  const auto mask_low = (num_channels == 3) ? masks_low_high_c3[0] : masks_low_high_c4[0];
+  const auto mask_high = (num_channels == 3) ? masks_low_high_c3[1] : masks_low_high_c4[1];
+  const auto mask_hl = (num_channels == 3) ? masks_lh_c3_c4[0] : masks_lh_c3_c4[1];
+  const auto mask_low128 = (num_channels == 3) ? masks_low128_c3_c4[0] : masks_low128_c3_c4[1];
+
+  // xsize = output width, xx = output x index
+  // xmax = interpolation size, x = interpolation index (horizontal <-> x dimension)
+  // xmin = input x start index corresponding to output x index (xx)
+
+  const auto stride = num_channels * 1;  // num channels * sizeof(uint8)
+  const auto zero = _mm_setzero_si128();
+
+  TORCH_INTERNAL_ASSERT(stride == 3 || stride == 4);
+
+  // Precompute xmax limits for block 8, block 4 and block 2
+  // lineIn + stride * (x + xmin) + 32 <= lineIn + stride * (xmax + xmin)
+  // --> x <= xmax - 32.0 / stride
+  // --> x < xmax + 1 - int(32.0 / stride)
+  const auto b8_delta = int(32.0 / stride) - 1;
+
+  // lineIn + stride * (x + xmin) + 16 <= lineIn0 + stride * (xmax + xmin)
+  // --> x <= xmax - 16.0 / stride
+  // --> x < xmax + 1 - int(16.0 / stride)
+  const auto b4_delta = int(16.0 / stride) - 1;
+
+  // lineIn0 + stride * (x + xmin) + 8 <= lineIn0 + stride * (xmax + xmin)
+  // --> x <= xmax - 8.0 / stride
+  // --> x < xmax + 1 - int(8.0 / stride)
+  const auto b2_delta = int(8.0 / stride) - 1;
 
   for (const auto xx : c10::irange(xsize)) {
     __m128i sss;
-    xmin = xbounds[xx * 2 + 0];
-    xmax = xbounds[xx * 2 + 1];
-    k = &kk[xx * kmax];
-    x = 0;
+    const auto xmin = idx_ptr_xmin[xx];
+    const auto xmax = idx_ptr_size[xx];
+    const auto * k = &kk[xx * kmax];
+    int64_t x = 0;
 
     if (xmax < 8) {
       sss = _mm_set1_epi32(1 << (coefs_precision - 1));
     } else {
       // Lower part will be added to higher, use only half of the error
-      __m256i sss256 = _mm256_set1_epi32(1 << (coefs_precision - 2));
+      auto sss256 = _mm256_set1_epi32(1 << (coefs_precision - 2));
 
-      for (; x < xmax - 7; x += 8) {
-        __m256i pix, mmk, source;
-        __m128i tmp = _mm_loadu_si128((__m128i*)&k[x]);
-        __m256i ksource =
-            _mm256_insertf128_si256(_mm256_castsi128_si256(tmp), tmp, 1);
+      for (; x < xmax - b8_delta; x += 8) {
+        auto tmp = _mm_loadu_si128((__m128i*)&k[x]);
+        auto ksource = _mm256_insertf128_si256(_mm256_castsi128_si256(tmp), tmp, 1);
 
-        // clang-format off
-        source = _mm256_loadu_si256((__m256i*)&lineIn[x + xmin]);
-        pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
-          -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0,
-          -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
-        mmk = _mm256_shuffle_epi8(ksource, _mm256_set_epi8(
-          11,10, 9,8, 11,10, 9,8, 11,10, 9,8, 11,10, 9,8,
-          3,2, 1,0, 3,2, 1,0, 3,2, 1,0, 3,2, 1,0));
+        auto source = _mm256_inserti128_si256(_mm256_castsi128_si256(
+            _mm_loadu_si128((__m128i *) (lineIn + stride * (x + 0 + xmin)))),
+            _mm_loadu_si128((__m128i *) (lineIn + stride * (x + 4 + xmin))), 1);
+
+        auto pix = _mm256_shuffle_epi8(source, mask_low);
+        auto mmk = _mm256_shuffle_epi8(ksource, kmask_low);
         sss256 = _mm256_add_epi32(sss256, _mm256_madd_epi16(pix, mmk));
 
-        pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
-          -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8,
-          -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8));
-        mmk = _mm256_shuffle_epi8(ksource, _mm256_set_epi8(
-          15,14, 13,12, 15,14, 13,12, 15,14, 13,12, 15,14, 13,12,
-          7,6, 5,4, 7,6, 5,4, 7,6, 5,4, 7,6, 5,4));
+        pix = _mm256_shuffle_epi8(source, mask_high);
+        mmk = _mm256_shuffle_epi8(ksource, kmask_high);
         sss256 = _mm256_add_epi32(sss256, _mm256_madd_epi16(pix, mmk));
-        // clang-format on
       }
 
-      for (; x < xmax - 3; x += 4) {
-        __m256i pix, mmk, source;
-        __m128i tmp = _mm_loadl_epi64((__m128i*)&k[x]);
-        __m256i ksource =
-            _mm256_insertf128_si256(_mm256_castsi128_si256(tmp), tmp, 1);
+      for (; x < xmax - b4_delta; x += 4) {
+        auto tmp = _mm_loadu_si64(&k[x]);
+        auto ksource = _mm256_insertf128_si256(_mm256_castsi128_si256(tmp), tmp, 1);
 
-        tmp = _mm_loadu_si128((__m128i*)&lineIn[x + xmin]);
-        source = _mm256_insertf128_si256(_mm256_castsi128_si256(tmp), tmp, 1);
+        tmp = _mm_loadu_si128((__m128i *) (lineIn + stride * (x + xmin)));
+        auto source = _mm256_insertf128_si256(_mm256_castsi128_si256(tmp), tmp, 1);
 
-        // clang-format off
-        pix = _mm256_shuffle_epi8(source, _mm256_set_epi8(
-          -1,15, -1,11, -1,14, -1,10, -1,13, -1,9, -1,12, -1,8,
-          -1,7, -1,3, -1,6, -1,2, -1,5, -1,1, -1,4, -1,0));
-        mmk = _mm256_shuffle_epi8(ksource, _mm256_set_epi8(
-          7,6, 5,4, 7,6, 5,4, 7,6, 5,4, 7,6, 5,4,
-          3,2, 1,0, 3,2, 1,0, 3,2, 1,0, 3,2, 1,0));
+        auto pix = _mm256_shuffle_epi8(source, mask_hl);
+        auto mmk = _mm256_shuffle_epi8(ksource, kmask_hl);
         sss256 = _mm256_add_epi32(sss256, _mm256_madd_epi16(pix, mmk));
-        // clang-format on
       }
 
       sss = _mm_add_epi32(
@@ -540,91 +706,124 @@ void ImagingResampleHorizontalConvolution8u(
           _mm256_extracti128_si256(sss256, 1));
     }
 
-    for (; x < xmax - 1; x += 2) {
-      __m128i mmk = _mm_set1_epi32(*(int32_t*)&k[x]);
-      __m128i source = _mm_loadl_epi64((__m128i*)&lineIn[x + xmin]);
-      __m128i pix = _mm_shuffle_epi8(
-          source,
-          _mm_set_epi8(-1, 7, -1, 3, -1, 6, -1, 2, -1, 5, -1, 1, -1, 4, -1, 0));
+    for (; x < xmax - b2_delta; x += 2) {
+      auto mmk = _mm_set1_epi32(*(int32_t*)&k[x]);
+      auto source = _mm_loadu_si64(lineIn + stride * (x + xmin));
+      auto pix = _mm_shuffle_epi8(source, mask_low128);
       sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
     }
 
-    for (; x < xmax; x++) {
-      __m128i pix = mm_cvtepu8_epi32(&lineIn[x + xmin]);
-      __m128i mmk = _mm_set1_epi32(k[x]);
+    for (; x < xmax - 1; x++) {
+      auto mmk = _mm_set1_epi32(k[x]);
+      auto pix = mm_cvtepu8_epi32(lineIn + stride * (x + xmin));
+      sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
+    }
+
+    if (x == xmax - 1) {
+      // last element x = xmax - 1
+      auto mmk = _mm_set1_epi32(k[x]);
+      __m128i pix;
+      auto p = lineIn + stride * (x + xmin);
+      if (num_channels == 3) {
+        unsigned char output[4];
+        std::memcpy(output, p, 3);
+        pix = mm_cvtepu8_epi32(output);
+      } else {
+        pix = mm_cvtepu8_epi32(p);
+      }
       sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
     }
     sss = _mm_srai_epi32(sss, coefs_precision);
-    sss = _mm_packs_epi32(sss, sss);
-    lineOut[xx] = _mm_cvtsi128_si32(_mm_packus_epi16(sss, sss));
+    sss = _mm_packs_epi32(sss, zero);
+    sss = _mm_packus_epi16(sss, zero);
+    if (num_channels == 3) {
+      sss = _mm_shuffle_epi8(sss, mask_ch);
+    }
+
+    auto o = _mm_cvtsi128_si32(sss);
+    if (num_channels == 3 && C10_UNLIKELY(stride * xx + 4 >= xsize * stride)) {
+      std::memcpy(lineOut + stride * xx, (unsigned char *) &o, num_channels);
+    } else {
+      *(uint32_t *)(lineOut + stride * xx) = o;
+    }
   }
 }
 
-// https://gist.github.com/NicolasHug/47c97d731f05eaad5694c173849b86f5
 void ImagingResampleVerticalConvolution8u(
-    uint32_t* C10_RESTRICT lineOut,
-    const uint32_t* C10_RESTRICT imIn,
-    int xmin,
-    int xmax,
-    int16_t* k,
-    int coefs_precision,
-    int xin) {
-  int x;
-  int xx = 0;
-  int xsize = xin;
+    uint8_t* C10_RESTRICT lineOut,
+    const uint8_t* C10_RESTRICT lineIn,
+    int64_t xsize,
+    int64_t ymin,
+    int64_t ymax,
+    const int16_t* k,
+    unsigned int coefs_precision,
+    int64_t num_channels) {
 
-  __m128i initial = _mm_set1_epi32(1 << (coefs_precision - 1));
-  __m256i initial_256 = _mm256_set1_epi32(1 << (coefs_precision - 1));
+  // xsize = output width and input width, xx = output x index
+  // ymax = interpolation size, y = interpolation index (vertical <-> y dimension)
+  // ymin = input y start index
 
-  for (; xx < xsize - 7; xx += 8) {
-    __m256i sss0 = initial_256;
-    __m256i sss1 = initial_256;
-    __m256i sss2 = initial_256;
-    __m256i sss3 = initial_256;
-    x = 0;
-    for (; x < xmax - 1; x += 2) {
-      __m256i source, source1, source2;
-      __m256i pix, mmk;
+  const auto stride = num_channels * 1;  // num channels * sizeof(uint8)
 
+  TORCH_INTERNAL_ASSERT(stride == 3 || stride == 4);
+
+  const int64_t data_size = xsize * stride;
+  const int64_t data_stride = stride;
+  constexpr auto vec_size = 256 / 8;
+
+  const auto initial = _mm_set1_epi32(1 << (coefs_precision - 1));
+  const auto initial_256 = _mm256_set1_epi32(1 << (coefs_precision - 1));
+  const auto zero = _mm_setzero_si128();
+  const auto zero_256 = _mm256_setzero_si256();
+
+  const auto mask_ch = _mm_set_epi8(
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 2, 1, 0);
+
+  int64_t i = 0;
+  const auto b8_usable_vec_stride = (vec_size / data_stride) * data_stride;
+  for (; i < data_size - vec_size; i += b8_usable_vec_stride) {
+    auto sss0 = initial_256;
+    auto sss1 = initial_256;
+    auto sss2 = initial_256;
+    auto sss3 = initial_256;
+    int64_t y = 0;
+    for (; y < ymax - 1; y += 2) {
       // Load two coefficients at once
-      mmk = _mm256_set1_epi32(*(int32_t*)&k[x]);
+      auto mmk = _mm256_set1_epi32(*(int32_t*)&k[y]);
 
       // Load 2 lines
-      //                           (__m256i *) &imIn->image32[x + xmin][xx]
-      source1 = _mm256_loadu_si256((__m256i*)(imIn + (x + xmin) * xin + xx));
-      //                           (__m256i *) &imIn->image32[x + 1 + xmin][xx]
-      source2 =
-          _mm256_loadu_si256((__m256i*)(imIn + (x + 1 + xmin) * xin + xx));
+      auto source1 =
+          _mm256_loadu_si256((__m256i*)(lineIn + i + data_size * (y + ymin)));
+      auto source2 =
+          _mm256_loadu_si256((__m256i*)(lineIn + i + data_size * (y + 1 + ymin)));
 
-      source = _mm256_unpacklo_epi8(source1, source2);
-      pix = _mm256_unpacklo_epi8(source, _mm256_setzero_si256());
+      auto source = _mm256_unpacklo_epi8(source1, source2);
+      auto pix = _mm256_unpacklo_epi8(source, zero_256);
       sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk));
-      pix = _mm256_unpackhi_epi8(source, _mm256_setzero_si256());
+      pix = _mm256_unpackhi_epi8(source, zero_256);
       sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk));
 
       source = _mm256_unpackhi_epi8(source1, source2);
-      pix = _mm256_unpacklo_epi8(source, _mm256_setzero_si256());
+      pix = _mm256_unpacklo_epi8(source, zero_256);
       sss2 = _mm256_add_epi32(sss2, _mm256_madd_epi16(pix, mmk));
-      pix = _mm256_unpackhi_epi8(source, _mm256_setzero_si256());
+      pix = _mm256_unpackhi_epi8(source, zero_256);
       sss3 = _mm256_add_epi32(sss3, _mm256_madd_epi16(pix, mmk));
     }
-    for (; x < xmax; x += 1) {
-      __m256i source, source1, pix, mmk;
-      mmk = _mm256_set1_epi32(k[x]);
+    for (; y < ymax; y += 1) {
+      auto mmk = _mm256_set1_epi32(k[y]);
 
-      //                           (__m256i *) &imIn->image32[x + xmin][xx])
-      source1 = _mm256_loadu_si256((__m256i*)(imIn + (x + xmin) * xin + xx));
+      auto source1 = _mm256_loadu_si256((__m256i*)(lineIn + i + data_size * (y + ymin)));
 
-      source = _mm256_unpacklo_epi8(source1, _mm256_setzero_si256());
-      pix = _mm256_unpacklo_epi8(source, _mm256_setzero_si256());
+      auto source = _mm256_unpacklo_epi8(source1, zero_256);
+      auto pix = _mm256_unpacklo_epi8(source, zero_256);
       sss0 = _mm256_add_epi32(sss0, _mm256_madd_epi16(pix, mmk));
-      pix = _mm256_unpackhi_epi8(source, _mm256_setzero_si256());
+      pix = _mm256_unpackhi_epi8(source, zero_256);
       sss1 = _mm256_add_epi32(sss1, _mm256_madd_epi16(pix, mmk));
 
-      source = _mm256_unpackhi_epi8(source1, _mm256_setzero_si256());
-      pix = _mm256_unpacklo_epi8(source, _mm256_setzero_si256());
+      source = _mm256_unpackhi_epi8(source1, zero_256);
+      pix = _mm256_unpacklo_epi8(source, zero_256);
       sss2 = _mm256_add_epi32(sss2, _mm256_madd_epi16(pix, mmk));
-      pix = _mm256_unpackhi_epi8(source, _mm256_setzero_si256());
+      pix = _mm256_unpackhi_epi8(source, zero_256);
       sss3 = _mm256_add_epi32(sss3, _mm256_madd_epi16(pix, mmk));
     }
     sss0 = _mm256_srai_epi32(sss0, coefs_precision);
@@ -635,43 +834,39 @@ void ImagingResampleVerticalConvolution8u(
     sss0 = _mm256_packs_epi32(sss0, sss1);
     sss2 = _mm256_packs_epi32(sss2, sss3);
     sss0 = _mm256_packus_epi16(sss0, sss2);
-    _mm256_storeu_si256((__m256i*)&lineOut[xx], sss0);
+
+    // Stores 32 bytes
+    _mm256_storeu_si256((__m256i*)(lineOut + i), sss0);
   }
 
-  for (; xx < xsize - 1; xx += 2) {
-    __m128i sss0 = initial; // left row
-    __m128i sss1 = initial; // right row
-    x = 0;
-    for (; x < xmax - 1; x += 2) {
-      __m128i source, source1, source2;
-      __m128i pix, mmk;
-
+  const auto b2_usable_vec_stride = (8 / data_stride) * data_stride;
+  // TODO: can we make b2_usable_vec_stride as (16 / data_stride) * data_stride ?
+  for (; i < data_size - vec_size / 4; i += b2_usable_vec_stride) {
+    auto sss0 = initial; // left row
+    auto sss1 = initial; // right row
+    int64_t y = 0;
+    for (; y < ymax - 1; y += 2) {
       // Load two coefficients at once
-      mmk = _mm_set1_epi32(*(int32_t*)&k[x]);
+      auto mmk = _mm_set1_epi32(*(int32_t*)&k[y]);
 
       // Load 2 lines
-      //                        (__m128i *) &imIn->image32[x + xmin][xx])
-      source1 = _mm_loadl_epi64((__m128i*)(imIn + (x + xmin) * xin + xx));
-      //                        (__m128i *) &imIn->image32[x + 1 + xmin][xx]
-      source2 = _mm_loadl_epi64((__m128i*)(imIn + (x + 1 + xmin) * xin + xx));
+      auto source1 = _mm_loadu_si64(lineIn + i + data_size * (y + ymin));
+      auto source2 = _mm_loadu_si64(lineIn + i + data_size * (y + 1 + ymin));
 
-      source = _mm_unpacklo_epi8(source1, source2);
-      pix = _mm_unpacklo_epi8(source, _mm_setzero_si128());
+      auto source = _mm_unpacklo_epi8(source1, source2);
+      auto pix = _mm_unpacklo_epi8(source, zero);
       sss0 = _mm_add_epi32(sss0, _mm_madd_epi16(pix, mmk));
-      pix = _mm_unpackhi_epi8(source, _mm_setzero_si128());
+      pix = _mm_unpackhi_epi8(source, zero);
       sss1 = _mm_add_epi32(sss1, _mm_madd_epi16(pix, mmk));
     }
-    for (; x < xmax; x += 1) {
-      __m128i source, source1, pix, mmk;
-      mmk = _mm_set1_epi32(k[x]);
+    for (; y < ymax; y += 1) {
+      auto mmk = _mm_set1_epi32(k[y]);
 
-      //                        (__m128i *) &imIn->image32[x + xmin][xx]);
-      source1 = _mm_loadl_epi64((__m128i*)(imIn + (x + xmin) * xin + xx));
-
-      source = _mm_unpacklo_epi8(source1, _mm_setzero_si128());
-      pix = _mm_unpacklo_epi8(source, _mm_setzero_si128());
+      auto source1 = _mm_loadu_si64(lineIn + i + data_size * (y + ymin));
+      auto source = _mm_unpacklo_epi8(source1, zero);
+      auto pix = _mm_unpacklo_epi8(source, zero);
       sss0 = _mm_add_epi32(sss0, _mm_madd_epi16(pix, mmk));
-      pix = _mm_unpackhi_epi8(source, _mm_setzero_si128());
+      pix = _mm_unpackhi_epi8(source, zero);
       sss1 = _mm_add_epi32(sss1, _mm_madd_epi16(pix, mmk));
     }
     sss0 = _mm_srai_epi32(sss0, coefs_precision);
@@ -679,40 +874,95 @@ void ImagingResampleVerticalConvolution8u(
 
     sss0 = _mm_packs_epi32(sss0, sss1);
     sss0 = _mm_packus_epi16(sss0, sss0);
-    _mm_storel_epi64((__m128i*)&lineOut[xx], sss0);
+
+    _mm_storel_epi64((__m128i*)(lineOut + i), sss0);
   }
 
-  for (; xx < xsize; xx++) {
-    __m128i sss = initial;
-    x = 0;
-    for (; x < xmax - 1; x += 2) {
-      __m128i source, source1, source2;
-      __m128i pix, mmk;
-
+  const auto b1_usable_vec_stride = (4 / data_stride) * data_stride;
+  for (; i < data_size - 4; i += b1_usable_vec_stride) {
+    auto sss = initial;
+    int64_t y = 0;
+    for (; y < ymax - 1; y += 2) {
       // Load two coefficients at once
-      mmk = _mm_set1_epi32(*(int32_t*)&k[x]);
+      auto mmk = _mm_set1_epi32(*(int32_t*)&k[y]);
 
       // Load 2 lines
-      //                           *(int *) &imIn->image32[x + xmin][xx]
-      source1 = _mm_cvtsi32_si128(*(int*)(imIn + (x + xmin) * xin + xx));
-      //                          *(int *) &imIn->image32[x + 1 + xmin][xx]
-      source2 = _mm_cvtsi32_si128(*(int*)(imIn + (x + 1 + xmin) * xin + xx));
+      auto source1 = _mm_cvtsi32_si128(*(int32_t*)(lineIn + i + data_size * (y + ymin)));
+      auto source2 = _mm_cvtsi32_si128(*(int32_t*)(lineIn + i + data_size * (y + 1 + ymin)));
 
-      source = _mm_unpacklo_epi8(source1, source2);
-      pix = _mm_unpacklo_epi8(source, _mm_setzero_si128());
+      auto source = _mm_unpacklo_epi8(source1, source2);
+      auto pix = _mm_unpacklo_epi8(source, zero);
       sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
     }
 
-    for (; x < xmax; x++) {
-      //                             &imIn->image32[x + xmin][xx]
-      __m128i pix = mm_cvtepu8_epi32(imIn + (x + xmin) * xin + xx);
-      __m128i mmk = _mm_set1_epi32(k[x]);
+    for (; y < ymax; y++) {
+      auto mmk = _mm_set1_epi32(k[y]);
+      auto pix = mm_cvtepu8_epi32(lineIn + i + data_size * (y + ymin));
       sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
     }
     sss = _mm_srai_epi32(sss, coefs_precision);
-    sss = _mm_packs_epi32(sss, sss);
-    lineOut[xx] = _mm_cvtsi128_si32(_mm_packus_epi16(sss, sss));
+    sss = _mm_packs_epi32(sss, zero);
+    sss = _mm_packus_epi16(sss, zero);
+
+    if (num_channels == 3) {
+      sss = _mm_shuffle_epi8(sss, mask_ch);
+    }
+
+    auto o = _mm_cvtsi128_si32(sss);
+
+    // Here we write 4 bytes to the output even if num_channels < 4, e.g o = {r,g,b,0} for num_channels=3
+    // It is OK to write 4th byte (e.g. 0) as on the next step we will overwrite it with new data.
+    // We also wont go out of bounds of lineOut memory allocation
+    *(uint32_t *)(lineOut + i) = o;
   }
+
+  for (; i < data_size; i += data_stride) {
+    auto sss = initial;
+    int64_t y = 0;
+    for (; y < ymax - 1; y += 2) {
+      // Load two coefficients at once
+      auto mmk = _mm_set1_epi32(*(int32_t*)&k[y]);
+
+      // Load 2 lines
+      auto source1 = _mm_cvtsi32_si128(*(int32_t*)(lineIn + i + data_size * (y + ymin)));
+      auto source2 = _mm_cvtsi32_si128(*(int32_t*)(lineIn + i + data_size * (y + 1 + ymin)));
+
+      auto source = _mm_unpacklo_epi8(source1, source2);
+      auto pix = _mm_unpacklo_epi8(source, zero);
+      sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
+    }
+
+    for (; y < ymax; y++) {
+      auto mmk = _mm_set1_epi32(k[y]);
+
+      const uint8_t * p = lineIn + i + data_size * (y + ymin);
+      __m128i pix;
+      // TODO: Update condition to apply on the last pixel only
+      if (num_channels == 3) {
+        unsigned char output[4];
+        std::memcpy(output, p, 3);
+        pix = mm_cvtepu8_epi32(output);
+      } else {
+        pix = mm_cvtepu8_epi32(p);
+      }
+      sss = _mm_add_epi32(sss, _mm_madd_epi16(pix, mmk));
+    }
+
+    sss = _mm_srai_epi32(sss, coefs_precision);
+    sss = _mm_packs_epi32(sss, zero);
+    sss = _mm_packus_epi16(sss, zero);
+    if (num_channels == 3) {
+      sss = _mm_shuffle_epi8(sss, mask_ch);
+    }
+
+    auto o = _mm_cvtsi128_si32(sss);
+    if (num_channels == 3 && C10_UNLIKELY(i + 4 >= data_size)) {
+      std::memcpy(lineOut + i, (unsigned char *) &o, num_channels);
+    } else {
+      *(uint32_t *)(lineOut + i) = o;
+    }
+  }
+
 }
 
 } // anonymous namespace


### PR DESCRIPTION

Closed in favor of this stack: https://github.com/pytorch/pytorch/pull/96848

--- 

## Description

- Improved perfs for vectorized interpolate uint8 RGB-case
  - unified RGB and RGBA processing code such that RGB input is not copied into RGBA
- Performances are more close to Pillow-SIMD
- RGBA case perfs are the same after refactoring (see Source link below) 

## Results

```
[------------------------------------------------------------------------------------------ Resize -----------------------------------------------------------------------------------------]
                                                                 |  Pillow (9.0.0.post1)  |  torch (2.1.0a0+git1d3a939) PR  |  torch (2.1.0a0+git5309c44) nightly  |  Speed-up: PR vs nightly
1 threads: ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      3 torch.uint8 channels_last bilinear 256 -> 32 aa=True     |          38.5          |                56.3             |                 132.5                |            2.4
      3 torch.uint8 channels_last bilinear 256 -> 32 aa=False    |                        |                36.2             |                 110.6                |            3.1
      3 torch.uint8 channels_last bilinear 256 -> 224 aa=True    |         127.0          |               149.9             |                 292.2                |            1.9
      3 torch.uint8 channels_last bilinear 256 -> 224 aa=False   |                        |               134.2             |                 276.8                |            2.1
      3 torch.uint8 channels_last bilinear 256 -> 320 aa=True    |         178.1          |               200.3             |                 416.4                |            2.1
      3 torch.uint8 channels_last bilinear 256 -> 320 aa=False   |                        |               198.0             |                 414.4                |            2.1
      3 torch.uint8 channels_last bilinear 520 -> 32 aa=True     |         112.9          |               129.3             |                 441.3                |            3.4
      3 torch.uint8 channels_last bilinear 520 -> 32 aa=False    |                        |                54.9             |                 364.2                |            6.6
      3 torch.uint8 channels_last bilinear 520 -> 224 aa=True    |         282.7          |               324.8             |                 691.6                |            2.1
      3 torch.uint8 channels_last bilinear 520 -> 224 aa=False   |                        |               211.9             |                 583.1                |            2.8
      3 torch.uint8 channels_last bilinear 712 -> 32 aa=True     |         185.9          |               201.1             |                 783.1                |            3.9
      3 torch.uint8 channels_last bilinear 712 -> 32 aa=False    |                        |                72.1             |                 649.8                |            9.0
      3 torch.uint8 channels_last bilinear 712 -> 224 aa=True    |         408.7          |               436.7             |                1100.5                |            2.5
      3 torch.uint8 channels_last bilinear 712 -> 224 aa=False   |                        |               268.8             |                 906.6                |            3.4
```

[Source](https://gist.github.com/vfdev-5/1c0778904a07ce40401306548b9525e8#file-20230313-135759-pr_vs_nightly_speedup-md)


## Context

- https://github.com/pytorch/pytorch/pull/90771


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10