### PR TITLE
[inductor] Consolidate codegen functions in sizevars.py into wrapper.py

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -37,7 +37,7 @@ from .lowering import (
     make_fallback,
     needs_realized_inputs,
 )
-from .sizevars import CppSizeVarAllocator, SizeVarAllocator
+from .sizevars import SizeVarAllocator
 from .utils import (
     convert_shape_to_inductor,
     gather_origins,
@@ -555,7 +555,6 @@ class GraphLowering(torch.fx.Interpreter):
         if config.cpp_wrapper:
             self.check_cpp_wrapper()
             if self._can_use_cpp_wrapper:
-                self.sizevars = CppSizeVarAllocator(self._shape_env)
                 self.wrapper_code = (
                     CppAotWrapperCodeGen() if self.aot_mode else CppWrapperCodeGen()
                 )

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1521,10 +1521,10 @@ class ReinterpretView(BaseView):
         pass
 
     def codegen_reference(self):
-        size = V.graph.sizevars.codegen_shape_tuple(self.layout.size)
-        stride = V.graph.sizevars.codegen_shape_tuple(self.layout.stride)
-        offset = V.graph.sizevars.codegen_sizevar(self.layout.offset)
-        as_strided = V.graph.sizevars.as_strided
+        size = V.graph.wrapper_code.codegen_shape_tuple(self.layout.size)
+        stride = V.graph.wrapper_code.codegen_shape_tuple(self.layout.stride)
+        offset = V.graph.wrapper_code.codegen_sizevar(self.layout.offset)
+        as_strided = V.graph.wrapper_code.as_strided
         if offset != "0":
             return f"{as_strided}({self.get_name()}, {size}, {stride}, {offset})"
         return f"{as_strided}({self.get_name()}, {size}, {stride})"
@@ -2713,8 +2713,8 @@ class ExternKernel(InputsKernel):
 
     def codegen_size_asserts(self, wrapper):
         if config.size_asserts:
-            size = V.graph.sizevars.codegen_shape_tuple(self.get_size())
-            stride = V.graph.sizevars.codegen_shape_tuple(self.get_stride())
+            size = V.graph.wrapper_code.codegen_shape_tuple(self.get_size())
+            stride = V.graph.wrapper_code.codegen_shape_tuple(self.get_stride())
             wrapper.writeline(
                 f"assert_size_stride({self.get_name()}, {size}, {stride})"
             )

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -2,15 +2,13 @@ import dataclasses
 import functools
 import itertools
 import logging
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List
 
 import sympy
 from sympy import Expr
 
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
-from . import ir
-from .codegen.common import IndentedBuffer
 from .utils import sympy_subs, sympy_symbol, VarRanges
 from .virtualized import V
 
@@ -39,23 +37,9 @@ class SizeVarAllocator:
         # maps of dynamic sizes that have to be precomputed on the host to the kernel args
         self.precomputed_replacements: Dict[Expr, sympy.Symbol] = dict()
         self.inv_precomputed_replacements: Dict[sympy.Symbol, Expr] = dict()
-        self.need_seed = False
         self.stride_vars = self.make_stride_vars_cache()
         self.simplify_with_ranges = self.make_simplify_with_ranges_cache()
         self._simplify_loops = self.make_simplify_loops_cache()
-        self.declare = ""
-        self.ending = ""
-        self.as_strided = "as_strided"
-
-    def seed(self):
-        """
-        Seed is a special variable used to hold the rng seed for a graph.
-
-        Note this is only used by the CPU backend, we put seeds in a
-        1-element tensor for the CUDA backend.
-        """
-        self.need_seed = True
-        return sympy_symbol("seed")
 
     def simplify(self, expr: Expr):
         return sympy.expand(expr).xreplace(self.replacements)
@@ -428,84 +412,6 @@ class SizeVarAllocator:
             self.inv_precomputed_replacements[sym] = expr
         return self.precomputed_replacements[expr]
 
-    def codegen(self, code: IndentedBuffer, graph_inputs: Dict[str, ir.Buffer]):
-        """Assign all symbolic shapes to locals"""
-        if self.need_seed:
-            code.writeline(
-                "seed = torch.randint(2**31, size=(), dtype=torch.int32).item()"
-            )
-
-        @functools.lru_cache(None)
-        def sizeof(name):
-            code.writeline(f"{self.declare}{name}_size = {name}.size(){self.ending}")
-            return f"{name}_size"
-
-        @functools.lru_cache(None)
-        def strideof(name):
-            code.writeline(
-                f"{self.declare}{name}_stride = {name}.stride(){self.ending}"
-            )
-            return f"{name}_stride"
-
-        # Assign all symbolic shapes needed to local variables
-        needed = set(self.var_to_val.keys()) - set(self.replacements.keys())
-
-        def is_expr(x):
-            return isinstance(x[1], sympy.Expr)
-
-        graph_inputs_expr = list(filter(is_expr, graph_inputs.items()))
-        graph_inputs_tensors = list(
-            filter(lambda x: not is_expr(x), graph_inputs.items())
-        )
-
-        for name, shape in graph_inputs_expr:
-            shape = self.simplify(shape)
-            if shape in needed:
-                needed.remove(shape)
-                code.writeline(f"{self.declare}{shape} = {name}{self.ending}")
-
-        for name, value in graph_inputs_tensors:
-            shapes = value.get_size()
-            for dim, shape in enumerate(shapes):
-                shape = self.simplify(shape)
-                if shape in needed:
-                    needed.remove(shape)
-                    code.writeline(
-                        f"{self.declare}{shape} = {sizeof(name)}[{dim}]{self.ending}"
-                    )
-
-        for name, value in graph_inputs_tensors:
-            shapes = value.get_stride()
-            for dim, shape in enumerate(shapes):
-                shape = self.simplify(shape)
-                if shape in needed:
-                    needed.remove(shape)
-                    code.writeline(
-                        f"{self.declare}{shape} = {strideof(name)}[{dim}]{self.ending}"
-                    )
-
-    def codegen_precomputed_sizes(self, code: IndentedBuffer):
-        from .codegen.wrapper import pexpr
-
-        for sym, expr in self.inv_precomputed_replacements.items():
-            code.writeline(f"{self.declare}{sym} = {pexpr(expr)}")
-
-    def codegen_sizevar(self, x: Expr) -> str:
-        from .codegen.wrapper import pexpr
-
-        return pexpr(self.simplify(x))
-
-    def codegen_shape_tuple(self, shape: Tuple[Expr, ...]) -> str:
-        parts = list(map(self.codegen_sizevar, shape))
-        if len(parts) == 0:
-            return "()"
-        if len(parts) == 1:
-            return f"({parts[0]}, )"
-        return f"({', '.join(parts)})"
-
-    def codegen_benchmark_shape_tuple(self, shape: Tuple[Expr, ...]) -> str:
-        return self.codegen_shape_tuple(shape)
-
 
 def join_dimensions(expr: Expr) -> Expr:
     from .ir import ModularIndexing
@@ -570,25 +476,6 @@ def _join_dimensions_cached(expr: Expr) -> Expr:
                     )
                     return expr
     return expr
-
-
-class CppSizeVarAllocator(SizeVarAllocator):
-    def __init__(self, shape_env=None):
-        super().__init__(shape_env)
-        self.declare = "auto "
-        self.ending = ";"
-        self.as_strided = "at::as_strided"
-
-    def codegen_shape_tuple(self, shape: Tuple[Expr, ...]) -> str:
-        parts = list(map(self.codegen_sizevar, shape))
-        if len(parts) == 0:
-            return "{}"
-        if len(parts) == 1:
-            return f"{{{parts[0]}, }}"
-        return f"{{{', '.join(parts)}}}"
-
-    def codegen_benchmark_shape_tuple(self, shape: Tuple[Expr, ...]) -> str:
-        return super().codegen_shape_tuple(shape)
 
 
 class SimplifyIndexing(V.WrapperHandler):  # type: ignore[name-defined]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #96768
* __->__ #96654
* #96520

Summary: Refactor the code so that wrapper codegen doesn't mix Python and C++.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10