### PR TITLE
Suport tensor type for XPU

### DIFF
--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -46,6 +46,7 @@ using c10::optional;
 
 namespace VariableType {
   TORCH_API std::vector<at::DeprecatedTypeProperties*> allCUDATypes();
+  TORCH_API std::vector<at::DeprecatedTypeProperties*> allXPUTypes();
   TORCH_API std::vector<at::DeprecatedTypeProperties*> allCPUTypes();
 
   at::Tensor & unpack(Tensor & t, const char * name, int pos);

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -46,6 +46,10 @@ C10_EXPORT std::vector<at::DeprecatedTypeProperties*> allCUDATypes() {
   return allTypesForBackends({Backend::CUDA, Backend::SparseCUDA});
 }
 
+C10_EXPORT std::vector<at::DeprecatedTypeProperties*> allXPUTypes() {
+  return allTypesForBackends({Backend::XPU, Backend::SparseXPU});
+}
+
 namespace {
 const Variable& checked_cast_variable(
     const Tensor& t,


### PR DESCRIPTION
# Motivate
To support tensor type scenario for XPU.
like CUDA: 
```python
>>> import torch
>>> torch.rand(2,3).cuda(0).type(torch.cuda.IntTensor)
tensor([[0, 0, 0],
        [0, 0, 0]], device='cuda:0', dtype=torch.int32)
```
without this PR:
```python
>>> import torch
>>> import intel_extension_for_pytorch
>>> torch.rand(2,3).xpu('xpu:0').type(torch.xpu.IntTensor)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid type: 'torch.xpu.IntTensor'
```
with this PR:
```python
>>> import torch
>>> import intel_extension_for_pytorch
>>> torch.rand(2,3).xpu('xpu:0').type(torch.xpu.IntTensor)
tensor([[0, 0, 0],
        [0, 0, 0]], device='xpu:0', dtype=torch.int32)
```

# Solution
Add allXPUTypes in type method to parse all xpu tensor type

# Additional
UT pass.



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10