### PR TITLE
Add merge_rule for "functorch" module

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -351,6 +351,29 @@
   - Lint
   - pull
 
+- name: functorch
+  patterns:
+  - functorch/**
+  - test/functorch/**
+  - torch/_C/__init__.pyi.in
+  - torch/__init__.py
+  - torch/csrc/functorch/**
+  - torch/_functorch/**
+  - torch/func/**
+  - aten/src/ATen/functorch/**
+  - docs/source/func**
+  - '**vmap**'
+  - '**functorch**'
+  approved_by:
+  - kshiteej12345
+  - srossross
+  - chillee
+  - zou3519
+  mandatory_checks_name:
+  - EasyCLA
+  - Lint
+  - pull
+
 - name: ROCm
   patterns:
   - '**rocm**'

--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -364,6 +364,7 @@
   - docs/source/func**
   - '**vmap**'
   - '**functorch**'
+  - '**pytree**'
   approved_by:
   - kshiteej12345
   - srossross


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #96657

This PR enables our non-meta contributors to be able to approve
"functorch" PRs without intervention from meta contributors.

A PR is deemed a "functorch" PR if it matches one of the patterns in
merge_rules.yaml. These patterns are definitely not exhaustive
(we modify core pytorch pieces quite often), but should be a good starting
point.