### PR TITLE
[dynamo][dashboard] Clear local changes before pulling git repos

### DIFF
--- a/benchmarks/dynamo/Makefile
+++ b/benchmarks/dynamo/Makefile
@@ -15,13 +15,13 @@ clone-deps:
 
 pull-deps: clone-deps
 	echo $(TRITON_VERSION)
-	(cd ../../../torchvision    && git pull && git submodule update --init --recursive)
-	(cd ../../../torchdata      && git pull && git submodule update --init --recursive)
-	(cd ../../../torchtext      && git pull && git submodule update --init --recursive)
-	(cd ../../../torchaudio     && git pull && git submodule update --init --recursive)
-	(cd ../../../detectron2     && git pull && git submodule update --init --recursive)
-	(cd ../../../torchbenchmark && git pull && git submodule update --init --recursive)
-	(cd ../../../triton         && git fetch && git checkout $(TRITON_VERSION) && git submodule update --init --recursive)
+	(cd ../../../torchvision    && git reset --hard HEAD && git pull && git submodule update --init --recursive)
+	(cd ../../../torchdata      && git reset --hard HEAD && git pull && git submodule update --init --recursive)
+	(cd ../../../torchtext      && git reset --hard HEAD && git pull && git submodule update --init --recursive)
+	(cd ../../../torchaudio     && git reset --hard HEAD && git pull && git submodule update --init --recursive)
+	(cd ../../../detectron2     && git reset --hard HEAD && git pull && git submodule update --init --recursive)
+	(cd ../../../torchbenchmark && git reset --hard HEAD && git pull && git submodule update --init --recursive)
+	(cd ../../../triton         && git reset --hard HEAD && git fetch && git checkout $(TRITON_VERSION) && git submodule update --init --recursive)
 
 build-deps: clone-deps
 	# conda env remove --name torchdynamo


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96667

Current dashboard issue is due to a .pt file in torchbench that has beeen modified for some reason. This clears any local changes before pulling.

Tested in a duplicate dashboard environment with the same .pt file modified:
* Before the change to this makefile, `make pull-deps` fails
* After the change to this makefile, `make pull-deps` succeeds.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire