### PR TITLE
Clean up duplicated retry function in common.sh

### DIFF
--- a/.ci/pytorch/common.sh
+++ b/.ci/pytorch/common.sh
@@ -22,7 +22,3 @@ fi
 # TODO: Renable libtorch testing for MacOS, see https://github.com/pytorch/pytorch/issues/62598
 # shellcheck disable=SC2034
 BUILD_TEST_LIBTORCH=0
-
-retry () {
-  "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@")
-}


### PR DESCRIPTION
I just realize that this `retry` function is defined twice in:

* https://github.com/pytorch/pytorch/blob/master/.ci/pytorch/common_utils.sh#L12-L14
* and https://github.com/pytorch/pytorch/blob/master/.ci/pytorch/common.sh#L26-L28

Also they step on each other toes as `common.sh` load `common_utils.sh` in https://github.com/pytorch/pytorch/blob/master/.ci/pytorch/common.sh#L5

This will keep only the definition in `common_utils.sh` where it should be.
