### PR TITLE
[inductor][CI] also skip rexnet_100 on non-dynamic shapes

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -200,6 +200,7 @@ CI_SKIP[CI("inductor", training=True)] = [
     "fbnetv3_b",  # accuracy
     "levit_128",  # fp64_OOM
     # https://github.com/pytorch/pytorch/issues/94066
+    "rexnet_100",  # Accuracy failed for key name stem.bn.weight.grad
     "sebotnet33ts_256",  # Accuracy failed for key name stem.conv1.conv.weight.grad
     "xcit_large_24_p8_224",  # fp64_OOM
 ]

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -247,7 +247,6 @@ CI_SKIP[CI("inductor", training=True, dynamic=True)] = [
     "eca_botnext26ts_256",  # 'float' object has no attribute '_has_symbolic_sizes_strides'
     "dla102",  # Accuracy failed for key name base_layer.1.bias.grad
     "mixnet_l",  # 'float' object has no attribute '_has_symbolic_sizes_strides'
-    "rexnet_100",  # Accuracy failed for key name stem.bn.weight.grad
     "tf_efficientnet_b0",  # 'float' object has no attribute '_has_symbolic_sizes_strides'
     "tf_mixnet_l",  # 'float' object has no attribute '_has_symbolic_sizes_strides'
     "visformer_small",  # 'float' object has no attribute '_has_symbolic_sizes_strides'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #96691

Recent failures show rexnet_100 accuracy is flaky also on non-dynamic shapes (was already disabled for dynamic shapes in #96474). The failure occurs for the same reason (stem.bn.weight.grad).
e.g. https://github.com/pytorch/pytorch/actions/runs/4402868441/jobs/7710977874

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire