### PR TITLE
[BE] Add regression test for aten shared build

### DIFF
--- a/.buckconfig.oss
+++ b/.buckconfig.oss
@@ -14,6 +14,7 @@
 
 [cxx]
   cxxflags = -std=c++17
+  ldflags = -Wl,--no-undefined
   should_remap_host_platform = true
   cpp = /usr/bin/clang
   cc = /usr/bin/clang

--- a/.github/workflows/_buck-build-test.yml
+++ b/.github/workflows/_buck-build-test.yml
@@ -73,7 +73,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           command: |
-            sh scripts/buck_setup.sh
+            bash scripts/buck_setup.sh
 
       - name: Build tools
         run: |

--- a/.github/workflows/_buck-build-test.yml
+++ b/.github/workflows/_buck-build-test.yml
@@ -103,10 +103,6 @@ jobs:
         run: |
           buck build :aten_cpu
 
-      - name: Build aten_cpu@shared
-        run: |
-          buck build :aten_cpu#linux-x86_64,shared
-
       - name: Build torch_mobile_core
         run: |
           buck build :torch_mobile_core
@@ -126,3 +122,7 @@ jobs:
       - name: Build everything
         run: |
           buck build //... --keep-going
+
+      - name: Build aten_cpu@shared
+        run: |
+          buck build :aten_cpu#linux-x86_64,shared

--- a/.github/workflows/_buck-build-test.yml
+++ b/.github/workflows/_buck-build-test.yml
@@ -103,6 +103,10 @@ jobs:
         run: |
           buck build :aten_cpu
 
+      - name: Build aten_cpu@shared
+        run: |
+          buck build :aten_cpu#linux-x86_64,shared
+
       - name: Build torch_mobile_core
         run: |
           buck build :torch_mobile_core


### PR DESCRIPTION
To expose errors similar to https://github.com/pytorch/pytorch/pull/94401#issuecomment-1466654593 in OSS CI

Building `aten_cpu` as a shared library with `-Wl,--no-undefined` simulates behavior of Android NDK toolchain.

Test plan: It should fail, see https://github.com/pytorch/pytorch/actions/runs/4410571970/jobs/7728232916#step:14:1386
