### PR TITLE
Remove pytest block list

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -159,7 +159,7 @@ pytest-flakefinder==1.1.0
 #Pinned versions: 1.1.0
 #test that import:
 
-pytest-rerunfailures
+pytest-rerunfailures>=10.3
 #Description: plugin for rerunning failure tests in pytest
 #Pinned versions:
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -144,11 +144,6 @@ pytest
 #Pinned versions:
 #test that import: test_typing.py, test_cpp_extensions_aot.py, run_test.py
 
-pytest-xdist
-#Description: plugin for running pytest in parallel
-#Pinned versions:
-#test that import:
-
 pytest-shard
 #Description: plugin spliting up tests in pytest
 #Pinned versions:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -144,6 +144,11 @@ pytest
 #Pinned versions:
 #test that import: test_typing.py, test_cpp_extensions_aot.py, run_test.py
 
+#pytest-xdist
+#Description: plugin for running pytest in parallel
+#Pinned versions:
+#test that import:
+
 pytest-shard
 #Description: plugin spliting up tests in pytest
 #Pinned versions:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -144,7 +144,7 @@ pytest
 #Pinned versions:
 #test that import: test_typing.py, test_cpp_extensions_aot.py, run_test.py
 
-#pytest-xdist
+pytest-xdist
 #Description: plugin for running pytest in parallel
 #Pinned versions:
 #test that import:

--- a/.ci/pytorch/win-test.sh
+++ b/.ci/pytorch/win-test.sh
@@ -42,6 +42,8 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   export PYTORCH_TESTING_DEVICE_ONLY_FOR="cuda"
 fi
 
+python -m pip uninstall -y pytest-xdist
+
 run_tests() {
     # Run nvidia-smi if available
     for path in '/c/Program Files/NVIDIA Corporation/NVSMI/nvidia-smi.exe' /c/Windows/System32/nvidia-smi.exe; do

--- a/.ci/pytorch/win-test.sh
+++ b/.ci/pytorch/win-test.sh
@@ -42,7 +42,7 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   export PYTORCH_TESTING_DEVICE_ONLY_FOR="cuda"
 fi
 
-python -m pip install pytest-rerunfailures==0.3
+python -m pip install pytest-rerunfailures==10.3
 
 run_tests() {
     # Run nvidia-smi if available

--- a/.ci/pytorch/win-test.sh
+++ b/.ci/pytorch/win-test.sh
@@ -42,7 +42,7 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   export PYTORCH_TESTING_DEVICE_ONLY_FOR="cuda"
 fi
 
-python -m pip uninstall -y pytest-xdist
+python -m pip install pytest-rerunfailures==0.3
 
 run_tests() {
     # Run nvidia-smi if available

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -12,7 +12,6 @@ psutil==5.9.1
 nvidia-ml-py==11.525.84
 pygments==2.12.0
 pytest==7.2.0
-pytest-xdist==3.0.2
 pytest-rerunfailures==10.2
 pytest-flakefinder==1.1.0
 pytest-shard==0.1.2

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -12,7 +12,7 @@ psutil==5.9.1
 nvidia-ml-py==11.525.84
 pygments==2.12.0
 pytest==7.2.0
-pytest-rerunfailures==10.2
+pytest-rerunfailures==10.3
 pytest-flakefinder==1.1.0
 pytest-shard==0.1.2
 scipy==1.9.0

--- a/.github/requirements/pip-requirements-macOS.txt
+++ b/.github/requirements/pip-requirements-macOS.txt
@@ -12,6 +12,7 @@ psutil==5.9.1
 nvidia-ml-py==11.525.84
 pygments==2.12.0
 pytest==7.2.0
+pytest-xdist==3.0.2
 pytest-rerunfailures==10.3
 pytest-flakefinder==1.1.0
 pytest-shard==0.1.2

--- a/test/dynamo/test_optimizers.py
+++ b/test/dynamo/test_optimizers.py
@@ -1,3 +1,7 @@
+"""
+PYTEST_DONT_REWRITE (prevents pytest from rewriting assertions, which interferes
+with test_adam in OptimizerTests)
+"""
 # Owner(s): ["module: dynamo"]
 
 import inspect
@@ -48,9 +52,7 @@ class OptimizerTests(torch._dynamo.test_case.TestCase):
     # furthermore, the break is inside a for loop, so we bail on the frame
     # entirely.  This is basically an xfail; if the frame count goes up
     # you done good
-    test_radam = torch._dynamo.testing.skip_if_pytest(
-        make_test(torch.optim.RAdam, exp_graph_count=0)
-    )
+    test_radam = make_test(torch.optim.RAdam, exp_graph_count=0)
 
 
 # exclude SparseAdam because other areas of the stack don't support it yet

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -1,3 +1,7 @@
+"""
+PYTEST_DONT_REWRITE (prevents pytest from rewriting assertions, which interferes
+with test_rewrite_assert_with_msg and test_rewrite_assert_without_msg)
+"""
 # Owner(s): ["module: dynamo"]
 import collections
 import contextlib
@@ -20,7 +24,6 @@ import torch._dynamo.testing
 import torch._dynamo.utils
 
 import torch._functorch.config
-from torch._dynamo.testing import skip_if_pytest
 
 try:
     from test_minifier import requires_cuda
@@ -2313,7 +2316,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
         self.assertNoUnraisable(f)
 
-    @skip_if_pytest
     @torch._dynamo.config.patch("rewrite_assert_with_torch_assert", True)
     def test_rewrite_assert_with_msg(self):
         def f(x):
@@ -2360,7 +2362,6 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "generic_jump"):
             exported, _ = torch._dynamo.export(f, torch.Tensor([3, 4, 5]))
 
-    @skip_if_pytest
     @torch._dynamo.config.patch("rewrite_assert_with_torch_assert", True)
     def test_rewrite_assert_without_msg(self):
         def f(x):

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -784,7 +784,8 @@ def get_pytest_args(options):
     pytest_args = [
         "--use-pytest",
         "-vv",
-        "-rfEX"
+        "-rfEX",
+        "-p", "no:xdist",
     ]
     pytest_args.extend(rerun_options)
     return pytest_args
@@ -864,14 +865,6 @@ CUSTOM_HANDLERS = {
     # not a test_ops file, but takes 2 hrs on some architectures and
     # run_test_ops is good at parallelizing things
     "test_decomp": run_test_ops,
-}
-
-
-PYTEST_BLOCKLIST = {
-    "profiler/test_profiler",
-    "dynamo/test_repros",  # skip_if_pytest
-    "dynamo/test_optimizers",  # skip_if_pytest
-    "dynamo/test_dynamic_shapes",  # needs change to check_if_enable for disabled test issues
 }
 
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -785,6 +785,7 @@ def get_pytest_args(options):
         "--use-pytest",
         "-vv",
         "-rfEX",
+        "-p", "no:xdist",
     ]
     pytest_args.extend(rerun_options)
     return pytest_args

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -785,7 +785,6 @@ def get_pytest_args(options):
         "--use-pytest",
         "-vv",
         "-rfEX",
-        "-p", "no:xdist",
     ]
     pytest_args.extend(rerun_options)
     return pytest_args
@@ -1122,7 +1121,7 @@ def must_serial(file: str) -> bool:
 
 
 def can_run_in_pytest(test):
-    return (test not in PYTEST_BLOCKLIST) and (os.getenv('PYTORCH_TEST_DO_NOT_USE_PYTEST', '0') == '0')
+    return os.getenv('PYTORCH_TEST_DO_NOT_USE_PYTEST', '0') == '0'
 
 
 def get_selected_tests(options):

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -35,7 +35,7 @@ def clone_me(x):
 def skip_if_pytest(fn):
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
-        if "PYTEST_CURRENT_TEST" in os.environ:
+        if "PYTEST_CURRENT_TEST" in os.environ or __name__ == "__main__":
             raise unittest.SkipTest("does not work under pytest")
         return fn(*args, **kwargs)
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -35,7 +35,7 @@ def clone_me(x):
 def skip_if_pytest(fn):
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
-        if "PYTEST_CURRENT_TEST" in os.environ or __name__ == "__main__":
+        if "PYTEST_CURRENT_TEST" in os.environ:
             raise unittest.SkipTest("does not work under pytest")
         return fn(*args, **kwargs)
 


### PR DESCRIPTION
Enables the last few files under pytest.

xdist was causing problems with `profiler/test_profiler` `test_source_multithreaded` due to creating extra threads.  Luckily we don't use it so we can disable it with `-p no:xdist`, but this is incompatible with pytest-rerunfailures==10.2, so upgrade to 10.3.  I'd update the windows ami but idk how.  

`dynamo/test_optimizers` and `dynamo/test_repros` both had tests that used skip_if_pytest.  https://github.com/pytorch/pytorch/pull/93251/files suggests that it is due to pytest assertion rewriting, so I added `PYTEST_DONT_REWRITE` to their module docstrings to prevent pytest from rewriting assertions. 

Disable test by issue in `dynamo/test_dynamic_shapes` seems sane.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire