### PR TITLE
Disable flaky linalg.det.singular tests on ROCm

### DIFF
--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -31,6 +31,7 @@ from torch.testing._internal.common_dtype import (
     all_types_and_complex_and,
     floating_and_complex_types,
     floating_and_complex_types_and,
+    get_all_complex_dtypes,
 )
 from torch.testing._internal.common_utils import (
     GRADCHECK_NONDET_TOL,
@@ -38,6 +39,7 @@ from torch.testing._internal.common_utils import (
     make_fullrank_matrices_with_distinct_singular_values,
     skipIfSlowGradcheckEnv,
     slowTest,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.opinfo.core import (
     clone_sample,
@@ -1255,6 +1257,20 @@ op_db: List[OpInfo] = [
                 "TestFwdGradients",
                 "test_fn_fwgrad_bwgrad",
                 device_type="cuda",
+            ),
+            DecorateInfo(
+                unittest.skip("Flaky on ROCm https://github.com/pytorch/pytorch/issues/93044"),
+                'TestBwdGradients',
+                'test_fn_grad',
+                device_type='cuda',
+                active_if=TEST_WITH_ROCM,
+            ),
+            DecorateInfo(
+                unittest.skip("Flaky on ROCm https://github.com/pytorch/pytorch/issues/93045"),
+                'TestFwdGradients',
+                'test_forward_mode_AD',
+                device_type='cuda',
+                active_if=TEST_WITH_ROCM,
             ),
         ),
     ),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1263,6 +1263,7 @@ op_db: List[OpInfo] = [
                 'TestBwdGradients',
                 'test_fn_grad',
                 device_type='cuda',
+                dtypes=get_all_complex_dtypes(),
                 active_if=TEST_WITH_ROCM,
             ),
             DecorateInfo(
@@ -1270,6 +1271,7 @@ op_db: List[OpInfo] = [
                 'TestFwdGradients',
                 'test_forward_mode_AD',
                 device_type='cuda',
+                dtypes=get_all_complex_dtypes(),
                 active_if=TEST_WITH_ROCM,
             ),
         ),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1259,18 +1259,22 @@ op_db: List[OpInfo] = [
                 device_type="cuda",
             ),
             DecorateInfo(
-                unittest.skip("Flaky on ROCm https://github.com/pytorch/pytorch/issues/93044"),
-                'TestBwdGradients',
-                'test_fn_grad',
-                device_type='cuda',
+                unittest.skip(
+                    "Flaky on ROCm https://github.com/pytorch/pytorch/issues/93044"
+                ),
+                "TestBwdGradients",
+                "test_fn_grad",
+                device_type="cuda",
                 dtypes=get_all_complex_dtypes(),
                 active_if=TEST_WITH_ROCM,
             ),
             DecorateInfo(
-                unittest.skip("Flaky on ROCm https://github.com/pytorch/pytorch/issues/93045"),
-                'TestFwdGradients',
-                'test_forward_mode_AD',
-                device_type='cuda',
+                unittest.skip(
+                    "Flaky on ROCm https://github.com/pytorch/pytorch/issues/93045"
+                ),
+                "TestFwdGradients",
+                "test_forward_mode_AD",
+                device_type="cuda",
                 dtypes=get_all_complex_dtypes(),
                 active_if=TEST_WITH_ROCM,
             ),


### PR DESCRIPTION
Related issues: https://github.com/pytorch/pytorch/issues/93044 and https://github.com/pytorch/pytorch/issues/93045.

* No access to runner to debug ROCm flakiness
* Haven't seen any update on the two issues above
* Tests are still flaky whenever they are closed

### Testing

The tests are skipped https://ossci-raw-job-status.s3.amazonaws.com/log/11976899251

```
2023-03-14T03:39:02.1336514Z test_ops_gradients.py::TestBwdGradientsCUDA::test_fn_grad_linalg_det_singular_cuda_complex128 SKIPPED (Flaky on ROCm https://github.com/pytorch/pytorch/issues/93044) [ 27%]
...
2023-03-14T03:41:46.4234072Z test_ops_fwd_gradients.py::TestFwdGradientsCUDA::test_forward_mode_AD_linalg_det_singular_cuda_complex128 SKIPPED (Flaky on ROCm https://github.com/pytorch/pytorch/issues/93045) [ 44%]
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport