### PR TITLE
Add meta kernels for dequantize_per_tensor and quantize_per_tensor

### DIFF
--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -165,6 +165,20 @@ def dequantize_per_tensor_tensor(
     assert scale.numel() == 1, f"Exepecting scale tensor to be one element, but received : {scale.numel()}"
     return dequantize_per_tensor(input, scale.item(), zero_point.item(), quant_min, quant_max, dtype)
 
+@impl(quantized_decomposed_lib, "dequantize_per_tensor", "Meta")
+def dequantize_per_tensor_meta(input, scale, zero_point, quant_min, quant_max, dtype):
+    assert input.dtype == dtype, f"Expecting input to have dtype: {dtype}"
+    if dtype in [torch.uint8, torch.int8, torch.int32]:
+        return torch.empty_like(input, dtype=torch.float32)
+    else:
+        raise ValueError(f"Unsupported dtype in dequantize_per_tensor: {dtype}")
+
+@impl(quantized_decomposed_lib, "quantize_per_tensor", "Meta")
+def quantize_per_tensor_meta(input, scale, zero_point, quant_min, quant_max, dtype):
+    assert input.dtype == torch.float32, f"Expecting input to have dtype torch.float32, but got dtype: {input.dtype}"
+    _quant_min_max_bounds_check(quant_min, quant_max, dtype)
+    return torch.empty_like(input, dtype=dtype)
+
 @impl(quantized_decomposed_lib, "dequantize_per_tensor.tensor", "Meta")
 def dequantize_per_tensor_tensor_meta(input, scale, zero_point, quant_min, quant_max, dtype):
     assert zero_point.numel() == 1, f"Exepecting zero_point tensor to be one element, but received : {zero_point.numel()}"


### PR DESCRIPTION
Summary:
We're currently missing meta kernels for quantize_per_tensor and dequantize_per_tensor. When tracing models with dynamo i was running into failures due to these missing meta kernels if the integers passed into these function calls are SymInt's:

```
RuntimeError: buck-out/v2/gen/fbcode/346db10ce50cfaa6/caffe2/__gen_aten__/out/RegisterCompositeExplicitAutograd.cpp:1164: SymIntArrayRef expected to contain only concrete integers
```

Test Plan:
Test repro used:
```
def test_fn(x,b,c):
    a = torch.ops.quantized_decomposed.quantize_per_tensor.default(x, 0.1, 0, b, c, torch.int8)
    return a
```

Tracing this with the edge export flow causes failures as described above. Adding these missing meta kernels fixes the issue.

Differential Revision: D44046306

