### PR TITLE
Correctly use PythonPrinter for generating wrapper code referencing sympy

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -248,7 +248,6 @@ CI_SKIP[CI("inductor", training=True, dynamic=True)] = [
     "tf_efficientnet_b0",  # 'float' object has no attribute '_has_symbolic_sizes_strides'
     "tf_mixnet_l",  # 'float' object has no attribute '_has_symbolic_sizes_strides'
     "visformer_small",  # 'float' object has no attribute '_has_symbolic_sizes_strides'
-    "volo_d1_224",  # NameError: name 'ceiling' is not defined
 ]
 
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2073,7 +2073,9 @@ class ShapeAsConstantBuffer(IRNode):
         self.shape = shape
 
     def codegen_reference(self):
-        return str(V.graph.sizevars.simplify(self.shape))
+        from torch._inductor.codegen.wrapper import pexpr
+
+        return pexpr(V.graph.sizevars.simplify(self.shape))
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96710

Otherwise you get stuff like ceiling(s0) which is not valid Python code. Fixes volo_d1_224

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire