### PR TITLE
Add missing reference for the const parameter in GetBackendDevice

### DIFF
--- a/torch/csrc/lazy/backend/backend_device.h
+++ b/torch/csrc/lazy/backend/backend_device.h
@@ -80,7 +80,7 @@ TORCH_API c10::optional<BackendDevice> GetBackendDevice(
 TORCH_API c10::optional<BackendDevice> GetBackendDevice(
     const at::Tensor& tensor);
 TORCH_API c10::optional<BackendDevice> GetBackendDevice(
-    const c10::optional<c10::Device> device);
+    const c10::optional<c10::Device>& device);
 
 // For variadic template.
 TORCH_API c10::optional<BackendDevice> GetBackendDevice();


### PR DESCRIPTION
Fixes #96676

PR #95942 introduced some changes in function implementations to replace const parameters by const referenced ones. However, GetBackendDevice was missed and  remains the old signature. This quick fix solves the type mismatch.
