### PR TITLE
[Inductor] aten.{avg_pool2d/max_pool2d_with_indices} arguments can be 1 element tuple

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2675,7 +2675,21 @@ class CommonTemplate:
     def test_max_pool2d3(self):
         def fn(x):
             # with padding
-            return aten.max_pool2d_with_indices(x, [3, 3], [2, 2], [1, 1])
+            return (
+                aten.max_pool2d_with_indices(x, [3, 3], [2, 2], [1, 1]),
+                aten.max_pool2d_with_indices(
+                    x,
+                    [
+                        3,
+                    ],
+                    [
+                        2,
+                    ],
+                    [
+                        1,
+                    ],
+                ),
+            )
 
         self.common(
             fn,
@@ -2746,7 +2760,21 @@ class CommonTemplate:
 
     def test_avg_pool2d3(self):
         def fn(x):
-            return aten.avg_pool2d(x, [3, 3], [2, 2], [1, 1])
+            return (
+                aten.avg_pool2d(x, [3, 3], [2, 2], [1, 1]),
+                aten.avg_pool2d(
+                    x,
+                    [
+                        3,
+                    ],
+                    [
+                        2,
+                    ],
+                    [
+                        1,
+                    ],
+                ),
+            )
 
         self.common(
             fn,

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -37,7 +37,7 @@ from .ir import (
     validate_ir,
     View,
 )
-from .utils import ceildiv, developer_warning, sympy_product
+from .utils import ceildiv, developer_warning, pad_list, sympy_product
 from .virtualized import ops, V
 
 log = logging.getLogger(__name__)
@@ -2707,6 +2707,9 @@ def max_pool2d_with_indices(
         padding = [0, 0]
     if not stride:
         stride = kernel_size
+    kernel_size = pad_list(kernel_size)
+    stride = pad_list(stride)
+    padding = pad_list(padding)
 
     assert dilation == 1 or all(d == 1 for d in dilation)
     assert isinstance(x, TensorBox)
@@ -3117,6 +3120,9 @@ def avg_pool2d(
         stride = kernel_size
     if not padding:
         padding = [0, 0]
+    kernel_size = pad_list(kernel_size)
+    stride = pad_list(stride)
+    padding = pad_list(padding)
 
     assert isinstance(x, TensorBox)
     assert len(kernel_size) == 2

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -221,6 +221,13 @@ def cmp(a, b):
     return int(a > b) - int(a < b)
 
 
+def pad_list(x):
+    if len(x) == 1:
+        return [x[0], x[0]]
+    else:
+        return x
+
+
 def cache_on_self(fn):
     key = f"__{fn.__name__}_cache"
 


### PR DESCRIPTION
Fixes failure from 14k github models: ```pytest ./generated/test_ProGamerGov_neural_dream.py -k test_000```
Error:
```
......
  File "/scratch/ybliang/work/repos/pytorch/torch/_inductor/graph.py", line 357, in call_function
    raise LoweringException(e, target, args, kwargs).with_traceback(
  File "/scratch/ybliang/work/repos/pytorch/torch/_inductor/graph.py", line 354, in call_function
    out = lowerings[target](*args, **kwargs)
  File "/scratch/ybliang/work/repos/pytorch/torch/_inductor/lowering.py", line 228, in wrapped
    out = decomp_fn(*args, **kwargs)
  File "/scratch/ybliang/work/repos/pytorch/torch/_inductor/lowering.py", line 3124, in avg_pool2d
    assert len(padding) == 2
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
LoweringException: AssertionError: 
  target: aten.avg_pool2d.default
  args[0]: TensorBox(StorageBox(
    InputBuffer(name='arg0_1', layout=FixedLayout('cuda', torch.float32, size=[4, 4, 64, 64], stride=[16384, 4096, 64, 1]))
  ))
  args[1]: [7, 7]
  args[2]: [1, 1]
  args[3]: [0]
  args[4]: False
  args[5]: False

```


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire