### PR TITLE
Split rnn primitive for inference and training

### DIFF
--- a/aten/src/ATen/native/mkldnn/RNN.cpp
+++ b/aten/src/ATen/native/mkldnn/RNN.cpp
@@ -288,7 +288,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> mkldnn_rnn_layer(const Tensor& input,
   auto w1_ = get_mkldnn_tensor(weight_ih, rnn.weights_layer_desc(input_size, get_mkldnn_dtype(weight_ih)));
   auto w2_ = get_mkldnn_tensor(weight_hh, rnn.weights_iter_desc(get_mkldnn_dtype(weight_hh)));
 
-  if (train) {
+  if (at::GradMode::is_enabled()) {
     Tensor workspace = Tensor();
     auto pd = ideep::lstm_forward_training::prepare(
         x, hx, cx, w1_, w2_, b, y, hy, cy, reverse);

--- a/aten/src/ATen/native/mkldnn/RNN.cpp
+++ b/aten/src/ATen/native/mkldnn/RNN.cpp
@@ -288,15 +288,22 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> mkldnn_rnn_layer(const Tensor& input,
   auto w1_ = get_mkldnn_tensor(weight_ih, rnn.weights_layer_desc(input_size, get_mkldnn_dtype(weight_ih)));
   auto w2_ = get_mkldnn_tensor(weight_hh, rnn.weights_iter_desc(get_mkldnn_dtype(weight_hh)));
 
-  auto pd = ideep::lstm_forward_training::prepare(
-      x, hx, cx, w1_, w2_, b, y, hy, cy, reverse);
-  auto workspace = at::empty(pd.workspace_desc().get_size() / sizeof(uint8_t), input.options().dtype(at::kByte));
-  ideep::tensor mkldnn_workspace;
-  mkldnn_workspace.init(
-      pd.workspace_desc(), workspace.data_ptr<uint8_t>());
-  ideep::lstm_forward_training::compute(
-      pd, x, hx, cx, w1_, w2_, b, mkldnn_workspace, y, hy, cy, reverse, ideep::prop_kind::forward_training);
-  return std::make_tuple(output, hy_, cy_, workspace);
+  if (train) {
+    Tensor workspace = Tensor();
+    auto pd = ideep::lstm_forward_training::prepare(
+        x, hx, cx, w1_, w2_, b, y, hy, cy, reverse);
+    workspace = at::empty(pd.workspace_desc().get_size() / sizeof(uint8_t), input.options().dtype(at::kByte));
+    ideep::tensor mkldnn_workspace;
+    mkldnn_workspace.init(
+        pd.workspace_desc(), workspace.template data_ptr<uint8_t>());
+    ideep::lstm_forward_training::compute(
+        pd, x, hx, cx, w1_, w2_, b, mkldnn_workspace, y, hy, cy, reverse, ideep::prop_kind::forward_training);
+    return std::make_tuple(output, hy_, cy_, workspace);
+  } else {
+    ideep::lstm_forward_inference::compute(
+        x, hx, cx, w1_, w2_, b, y, hy, cy, reverse, ideep::prop_kind::forward_inference);
+    return std::make_tuple(output, hy_, cy_, Tensor());
+  }
 }
 
 std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor> mkldnn_rnn_layer_backward(

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -4,6 +4,7 @@ import copy
 import itertools
 import functools
 import unittest
+from contextlib import nullcontext
 
 try:
     import torchvision
@@ -1391,7 +1392,7 @@ class TestMkldnn(TestCase):
 
                 model1 = copy.deepcopy(model)
                 model2 = copy.deepcopy(model)
-                with torch.cpu.amp.autocast(enabled=bf16, dtype=torch.bfloat16):
+                with torch.cpu.amp.autocast(enabled=bf16, dtype=torch.bfloat16), torch.no_grad() if not training else nullcontext():
                     with torch.backends.mkldnn.flags(enabled=False):
                         torch.manual_seed(seed)
                         output1, (hn1, cn1) = self._cast_dtype(model1, bf16)(self._cast_dtype(input1, bf16),


### PR DESCRIPTION
## Description
Currently, both inference and training will use `forward_training` in rnn primitive, which will bring performance downgrade for inference (The performance drop is from rnn primitive and unnecessary creation of `pd` and `workspace`). This PR is to split them into `forward_inference` and `forward_training` seperately.

## Performance
With this fix PR, in RNN-T inference, the throughput reduction is 167 ms, which increases `3.7%` of E2E time.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10