### PR TITLE
Remove in-place operations in NegativeBinomial

### DIFF
--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -98,7 +98,7 @@ class NegativeBinomial(Distribution):
 
         log_unnormalized_prob = (self.total_count * F.logsigmoid(-self.logits) +
                                  value * F.logsigmoid(self.logits))
-        
+
         log_normalization = (-torch.lgamma(self.total_count + value) + torch.lgamma(1. + value) +
                              torch.lgamma(self.total_count))
         # The case self.total_count == 0 and value == 0 has probability 1 but

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -99,8 +99,7 @@ class NegativeBinomial(Distribution):
         log_unnormalized_prob = (self.total_count * F.logsigmoid(-self.logits) +
                                  value * F.logsigmoid(self.logits))
 
-        log_normalization = (-torch.lgamma(self.total_count + value) + torch.lgamma(1. + value) +
-                             torch.lgamma(self.total_count))
-        log_normalization[self.total_count + value == 0.] = 0.
+        log_normalization = (-torch.lgamma(self.total_count + value).nan_to_num(nan=float("nan"), posinf=0, neginf=-float("inf")) +
+                             torch.lgamma(1. + value) + torch.lgamma(self.total_count))
 
         return log_unnormalized_prob - log_normalization


### PR DESCRIPTION
This is a suggestion for a minor modification.

The line `log_normalization[self.total_count + value == 0.] = 0.` prevents Jit compilation when the condition occurs, with the error message

`RuntimeError: a view of a leaf Variable that requires grad is being used in an in-place operation.`

I propose an alternative that does not involve in-place operations. It uses the function `nan_to_num()` to replace infinite values by 0 where `self.total_count + value == 0.` while leaving `nan` and `-inf` as they are. Readability is suboptimal because the code does not replace nan with numbers, but I could not find a function that only replaces infinite values.
