### PR TITLE
[ROCm]Fixed ut test_memory_timeline

### DIFF
--- a/test/profiler/test_memory_profiler.py
+++ b/test/profiler/test_memory_profiler.py
@@ -1480,7 +1480,7 @@ class TestMemoryProfilerE2E(TestCase):
 
             # We generally don't care about tiny allocations during memory
             # profiling and they add a lot of noise to the unit test.
-            if size >= 256
+            if size >= 512
         ]
 
         self.assertExpectedInline(


### PR DESCRIPTION
Fixed test_memory_profiler::TestMemoryProfilerE2E::test_memory_timeline by changing the (arbitrary) threshold for logging. We observe differently-sized allocations on different AMD GPUs, so chose a higher threshold of 512 to account for those differences and yet satisfy the test requirements.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport