### PR TITLE
Add environment variable to force flattening of 3D input tensor

### DIFF
--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -38,6 +38,28 @@
 
 namespace at { namespace native {
 
+static inline bool parseLinearFlatten3d() {
+  // Uninitialized value
+  static int value = -1;
+  if (value == -1) {
+    const char* env_str = std::getenv("LINEAR_FLATTEN_3D");
+    if (env_str != nullptr && strcmp(env_str, "1") == 0) {
+      value = 1;
+    } else {
+      value = 0;
+    }
+  }
+  return value;
+}
+
+// `_flatten_3d_linear` flattens the first two dimensions of the input tensor
+// before passing it to linear operation if it is 3D
+static inline Tensor _flatten_3d_linear(const Tensor& input, const Tensor& weight, const Tensor& bias) {
+    const auto input_sizes = input.sym_sizes();
+    const auto result = at::addmm(bias, input.view_symint({input_sizes[0] * input_sizes[1], input_sizes[2]}), weight.t());
+    return result.view_symint({input_sizes[0], input_sizes[1], result.sym_size(1)});
+}
+
 Tensor linear(const Tensor& input, const Tensor& weight, const c10::optional<Tensor>& bias_opt) {
   // See [Note: hacky wrapper removal for optional tensor]
   auto bias = bias_opt.has_value()
@@ -56,13 +78,16 @@ Tensor linear(const Tensor& input, const Tensor& weight, const c10::optional<Ten
     // Fused op is marginally faster.
     return at::addmm(*bias, input, weight.t());
   }
-  if (input.dim() == 3 && bias->defined() && input.is_contiguous() &&
-      !input.is_xla()) {
+  if (input.dim() == 3 && bias->defined() && !input.is_xla()) {
     // Also hit the fused path for contiguous 3D input, if not using xla
     // backend. Reshaping/flattening has some performance implications on xla.
-    const auto input_sizes = input.sym_sizes();
-    const auto result = at::addmm(*bias, input.view_symint({input_sizes[0] * input_sizes[1], input_sizes[2]}), weight.t());
-    return result.view_symint({input_sizes[0], input_sizes[1], result.sym_size(1)});
+    if (input.is_contiguous()) {
+      return _flatten_3d_linear(input, weight, *bias);
+    } else if (parseLinearFlatten3d()) {
+      // If user forces flattening via env var
+      const Tensor input_cont = input.contiguous();
+      return _flatten_3d_linear(input_cont, weight, *bias);
+    }
   }
   auto output = at::matmul(input, weight.t());
   if (bias->defined()) {

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -38,22 +38,23 @@
 
 namespace at { namespace native {
 
+// Parse environment variable "TORCH_LINEAR_FLATTEN_3D"
 static inline bool parseLinearFlatten3d() {
   // Uninitialized value
   static int value = -1;
   if (value == -1) {
-    const char* env_str = std::getenv("LINEAR_FLATTEN_3D");
+    const char* env_str = std::getenv("TORCH_LINEAR_FLATTEN_3D");
     if (env_str != nullptr && strcmp(env_str, "1") == 0) {
       value = 1;
     } else {
       value = 0;
     }
   }
-  return value;
+  return bool(value);
 }
 
 // `_flatten_3d_linear` flattens the first two dimensions of the input tensor
-// before passing it to linear operation if it is 3D
+// before passing it to linear operation, if the input tensor is 3D
 static inline Tensor _flatten_3d_linear(const Tensor& input, const Tensor& weight, const Tensor& bias) {
     const auto input_sizes = input.sym_sizes();
     const auto result = at::addmm(bias, input.view_symint({input_sizes[0] * input_sizes[1], input_sizes[2]}), weight.t());


### PR DESCRIPTION
Adding an environment variable `TORCH_LINEAR_FLATTEN_3D` to force flattening of 3D input tensor even when it is non-contiguous.

Today, the `Linear` op would flatten a 3D input sensor if it is contiguous.

It was found that even for some non-contiguous inputs (esp. with BF16 data type), flattening would also yield higher performance.
For example:
```
x_size = (3072, 1196, 128)
x = torch.rand(x_size, device="cuda", dtype=torch.bfloat16)
x = torch.transpose(x, 1, 2)
torch._C._nn.linear(x, weight, bias)
```

Since the detailed auto-tuning is unknown, this PR adds an environment variable for users to make a choice.
(Default value is still 0.)