### PR TITLE
Fix signed-unsigned compare in  FlattenIndicesCommon.h

### DIFF
--- a/aten/src/ATen/native/sparse/FlattenIndicesCommon.h
+++ b/aten/src/ATen/native/sparse/FlattenIndicesCommon.h
@@ -86,7 +86,7 @@ Tensor _flatten_indices_impl(const Tensor& indices, IntArrayRef size) {
 
 template <template <typename func_t> class kernel_t>
 Tensor _flatten_indices(const Tensor& indices, IntArrayRef size) {
-  TORCH_CHECK(indices.dim() > 1 && indices.size(0) == size.size(),
+  TORCH_CHECK(indices.dim() > 1 && static_cast<size_t>(indices.size(0)) == size.size(),
       NAME, "(): the dimensionality of sparse `indices` and the lenght of `size` must match. ",
             "Got `indices.size(0) == ", indices.size(0), "` != `size.size() == ", size.size(), "`.");
   Tensor flattened_indices;


### PR DESCRIPTION
One more regression from https://github.com/pytorch/pytorch/pull/94401

