### PR TITLE
Update perf smoke test threshold in check_hf_bert_perf_csv.py

### DIFF
--- a/benchmarks/dynamo/check_hf_bert_perf_csv.py
+++ b/benchmarks/dynamo/check_hf_bert_perf_csv.py
@@ -17,8 +17,8 @@ def check_hf_bert_perf_csv(filename):
         model_name = row["name"]
         speedup = row["speedup"]
         # Reduce from 1.165 to 1.160, see https://github.com/pytorch/pytorch/issues/96530
-        # Reduce from 1.160 to 1.145 after a transformer version upgrade, see https://github.com/pytorch/benchmark/pull/1406
-        if speedup < 1.145:
+        # Reduce from 1.160 to 1.140 after a transformer version upgrade, see https://github.com/pytorch/benchmark/pull/1406
+        if speedup < 1.140:
             failed.append(model_name)
 
         print(f"{model_name:34} {speedup}")


### PR DESCRIPTION
Reduce the threshold a little further due to runner to runner performance variations.  e.g. https://github.com/pytorch/pytorch/actions/runs/4419276220/jobs/7747985757  https://github.com/pytorch/pytorch/actions/runs/4419548525/jobs/7748553775  failed to meet 1.145 but were above 1.140.


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire