### PR TITLE
Fix periodic job by excluding check_graph_breaks

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -320,8 +320,9 @@ test_single_dynamo_benchmark() {
       --output "$TEST_REPORTS_DIR/${name}_${suite}.csv"
     python benchmarks/dynamo/check_csv.py \
       -f "$TEST_REPORTS_DIR/${name}_${suite}.csv"
-    if [[ "${TEST_CONFIG}" != *cpu_accuracy* ]] && [[ "${TEST_CONFIG}" != *dynamic* ]]; then
-      # because I haven't tracked the cpu-side or dynamic expected artifacts yet, and need to differentiate filenames
+    if [[ "${TEST_CONFIG}" == *inductor* ]] && [[ "${TEST_CONFIG}" != *dynamic* ]]; then
+      # because I haven't dealt with dynamic expected artifacts yet,
+      # and non-inductor jobs (e.g. periodic) may have different set of expected models.
       python benchmarks/dynamo/check_graph_breaks.py \
         --actual "$TEST_REPORTS_DIR/${name}_$suite.csv" \
         --expected "benchmarks/dynamo/ci_expected_accuracy/${name}_${suite}${shard_id}.csv"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96780

It's going to be harder to properly support check_graph_breaks
across multiple baselines.

Periodic and Inductor workflows are different baselines since they include
different sets of models.

It's not as simple as checking in the csv for the superset (periodic),
becuase `update_expected.py` is designed to run given the sha of your
failing PR and reset the baseline to that PR's artifacts.  This is a
nice workflow, and would be harder to manage if it had to always point to
a periodic job.

For now just do the check on the inductor job and ignore the other models
covered only on periodic.