### PR TITLE
Make barrier sync against current stream instead of whole device

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -539,8 +539,8 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeInternal(
     // If we use the work to do barrier, we should block here
     at::cuda::OptionalCUDAGuard gpuGuard;
     for (auto& device : devices_) {
-      gpuGuard.set_index(device.index());
-      AT_CUDA_CHECK(cudaDeviceSynchronize());
+      auto currentStream = at::cuda::getCurrentCUDAStream(device.index());
+      AT_CUDA_CHECK(cudaStreamSynchronize(currentStream));
     }
   }
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -537,8 +537,18 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeInternal(
   // Device synchronize only after we've completed timeout checks.
   if (!barrierTensors_.empty()) {
     // If we use the work to do barrier, we should block here
-    at::cuda::OptionalCUDAGuard gpuGuard;
     for (auto& device : devices_) {
+      // `dist.barrier()` only requires all CPU processes to enter this
+      // function, hence we only need to make sure the dummy all-reduce has
+      // completed. So we would only need to sync the **current stream** back to
+      // host, and do not need to synchronize the entire device (which may have
+      // kernels running on other streams).
+      // Using `cudaStreamSynchronize` instead of `cudaDeviceSynchronize` can:
+      // - lower chance of hang;
+      // - CurrentCUDAStream is usually the context of the next operation in
+      // Python, thus blocking current stream would already block the next
+      // compute kernel;
+      // - achieve better barrier performance.
       auto currentStream = at::cuda::getCurrentCUDAStream(device.index());
       AT_CUDA_CHECK(cudaStreamSynchronize(currentStream));
     }


### PR DESCRIPTION
The document says:

>```torch.distributed.barrier(group=None, async_op=False, device_ids=None)```
>
>Synchronizes all processes.
>This collective blocks processes until the whole group enters this function...

Both `cudaStreamSynchronize` and `cudaDeviceSynchronize` would sync the host-side process to the completion of the barrier kernel in the GPU, hence achieving the above functionality.

This PR chooses a smaller set `cudaStreamSynchronize` instead of `cudaDeviceSynchronize`, for three reasons:
1. lower chance of hang;
2. `CurrentCUDAStream` is usually the context for next operation in Python script;
3. better barrier performance.