### PR TITLE
Add xpu device type to torch dispatch overload

### DIFF
--- a/torch/library.h
+++ b/torch/library.h
@@ -362,6 +362,8 @@ inline CppFunction dispatch(c10::DeviceType type, Func&& raw_f) {
         return c10::DispatchKey::XLA;
       case c10::DeviceType::Lazy:
         return c10::DispatchKey::Lazy;
+      case c10::DeviceType::XPU:
+        return c10::DispatchKey::XPU;
       case c10::DeviceType::MPS:
         return c10::DispatchKey::MPS;
       case c10::DeviceType::Meta:


### PR DESCRIPTION
# Motivate
Add XPU device type to CppFunction dispatch overload function.
We previously omitted it.

# Solution
Add XPU device type.

# Additional
This list is synchronized with the k-constants in c10/core/DeviceType.h