### PR TITLE
[DTensor] Fix DeviceMesh

### DIFF
--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -184,7 +184,7 @@ class DeviceMesh:
             self._dim_groups = dim_groups
             return
 
-        if self.mesh.ndim == 1 and unique_mesh_values[-1] == world_size - 1:
+        if self.mesh.ndim == 1 and len(unique_mesh_values) == world_size - 1:
             # if the mesh is the same as world_pg, we just append the default
             # pg to the first dim goups, as new_group cannot have the exact
             # same ranks as world


### PR DESCRIPTION
Summary: This Diff fixes some DeviceMesh issues, which blocks internal DTensor integration.  Specifically, when `self.mesh = [2, 3]` while `world_size = 4`, because `unique_mesh_values[-1] == 3`, it takes the first short-cut branch and uses `default_pg`. Let's check the length instead of the last value of `unique_mesh_values`.

Test Plan: CI

Reviewed By: wanchaol

Differential Revision: D44079872

