### PR TITLE
[BE][docs]Improve and update checkpoint documentation

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -193,23 +193,28 @@ def checkpoint(
 
     The non-reentrant variant improves upon the reentrant variant in several
     ways:
+
     * Unlike the reentrant variant, the non-reentrant variant properly records
       the autograd graph during forward, e.g. allowing you to perform backward
       on that graph inside checkpointed regions, and allowing you to attach
       hooks to the graph in a more fine-grained way. The reentrant variant
       runs the forward in :func:`torch.no_grad`.
+
     * Unlike the reentrant variant, the non-reentrant variant supports all
       ways of performing backward. Reentrant checkpoint only supports the
       :func:`torch.autograd.backward` API and only if its `inputs` argument is
       not passed. :func:`torch.autograd.grad` is not supported.
+
     * Unlike the reentrant variant, the non-reentrant variant  does not have
       the restriction that at least one of the inputs and at least one of the
       outputs needs to have ``requires_grad=True``. If this condition is
       not met for reentrant checkpoint, the checkpointed part of the model
       won't have gradients.
+
     * Unlike the reentrant variant, the non-reentrant variant considers
       Tensors passed as inputs or returned as outputs in nested structures
       (e.g., custom objects, lists, dicts, etc) as participating in autograd.
+
     * Unlike the reentrant variant, the non-reentrant variant supports the
       checkpointed region containing tensors detached from the computational
       graph. For the reentrant variant, if the checkpointed segment
@@ -470,6 +475,7 @@ def checkpoint_sequential(functions, segments, input, use_reentrant=True, **kwar
 # out = checkpoint(fn)(inp)
 #
 # In the code above fn is computed (potentially partially) 4 times in total.
+<<<<<<< HEAD
 #   1. Don't save x and y since we are inside a checkpoint.
 #   2. Trigger a recompute of fn as we reach (3) since x and y weren't saved.
 #   3. If early stop is enabled, stop at (2)
@@ -480,6 +486,18 @@ def checkpoint_sequential(functions, segments, input, use_reentrant=True, **kwar
 #      We save x and w, however.
 #   7. Continue with returning
 #
+=======
+#
+# 1. Don't save x and y since we are inside a checkpoint.
+# 2. Trigger a recompute of fn as we reach (3) since x and y weren't saved.
+# 3. If early stop is enabled, stop at (2)
+# 4. Continue original forward at (4), not saving x and w.
+# 5. (5) triggers a recompute of fn
+# 6. During recompute, we see that in the original graph, gx has already
+#    cleared x and y since backward is run at (3) without retain_graph=True
+#    We save x and w, however.
+# 7. Continue with returning
+>>>>>>> eef5549ccea (fixup)
 
 # NB: This is temporary and should be removed in a follow up PR. Early stopping
 #     is currently disabled by default. Since some nested test cases require

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -178,58 +178,52 @@ def checkpoint(
 ):
     r"""Checkpoint a model or part of the model
 
-    Checkpointing works by trading compute for memory. Rather than storing all
-    intermediate activations of the entire computation graph for computing
-    backward, the checkpointed part does **not** save intermediate activations,
-    and instead recomputes them in backward pass. It can be applied on any part
-    of a model.
+    Checkpointing is a technique that trades compute for memory. Instead of
+    storing all intermediate activations of the entire computation graph for
+    the backward pass, the checkpointed part omits saving intermediate
+    activations and recomputes them during the backward pass. This can be
+    applied to any part of a model.
 
-    Currently there are two implementations of checkpointing that you can choose
-    between by specifying the :attr:`use_reentrant` parameter. In the future
-    however, we plan to deprecate ``use_reentrant=True`` (reentrant variant). It
-    is recommended that you use ``use_reentrant=False`` (non-reentrant variant).
-    Please file an issue if you have a use case that requires the reentrant
-    variant.
+    There are currently two checkpointing implementations available, determined
+    by the :attr:`use_reentrant` parameter. In the future, we plan to deprecate
+    ``use_reentrant=True`` (reentrant variant). so it is recommended that you
+    use ``use_reentrant=False`` (non-reentrant variant). If you have a use case
+    that requires the reentrant variant, please file an issue.
 
-    The non-reentrant variant improves upon the reentrant variant in several
-    ways:
+    The non-reentrant variant offers several improvements over the reentrant
+    variant:
 
-    * Unlike the reentrant variant, the non-reentrant variant properly records
-      the autograd graph during forward, e.g. allowing you to perform backward
-      on that graph inside checkpointed regions, and allowing you to attach
-      hooks to the graph in a more fine-grained way. The reentrant variant
-      runs the forward in :func:`torch.no_grad`.
+    * Properly records the autograd graph during the forward pass, allowing for
+      more fine-grained control, such as performing backward on the graph within
+      checkpointed regions and attaching hooks. The reentrant variant runs the
+      forward in :func:`torch.no_grad`.
 
-    * Unlike the reentrant variant, the non-reentrant variant supports all
-      ways of performing backward. Reentrant checkpoint only supports the
-      :func:`torch.autograd.backward` API and only if its `inputs` argument is
-      not passed. :func:`torch.autograd.grad` is not supported.
+    * Supports all ways of performing the backward pass, whereas reentrant
+      checkpoint only supports the :func:`torch.autograd.backward` API and only
+      if its `inputs` argument is not passed. Reentrant checkpoint does not
+      support :func:`torch.autograd.grad`.
 
-    * Unlike the reentrant variant, the non-reentrant variant  does not have
-      the restriction that at least one of the inputs and at least one of the
-      outputs needs to have ``requires_grad=True``. If this condition is
-      not met for reentrant checkpoint, the checkpointed part of the model
-      won't have gradients.
+    * No requirement for at least one input and output to have
+      ``requires_grad=True``. If this condition is unmet in the reentrant
+      checkpoint, the checkpointed part of the model will not have gradients.
 
-    * Unlike the reentrant variant, the non-reentrant variant considers
-      Tensors passed as inputs or returned as outputs in nested structures
-      (e.g., custom objects, lists, dicts, etc) as participating in autograd.
+    * Considers tensors passed as inputs or returned as outputs in nested
+      structures (e.g., custom objects, lists, dicts, etc) as participating in
+      autograd.
 
-    * Unlike the reentrant variant, the non-reentrant variant supports the
-      checkpointed region containing tensors detached from the computational
-      graph. For the reentrant variant, if the checkpointed segment
-      contains tensors detached from the computational graph by `detach()` or
+    * Supports checkpointed regions containing tensors detached from the
+      computational graph. For the reentrant variant, if the checkpointed
+      segment contains tensors detached using ``detach()`` or with
       :func:`torch.no_grad`, the backward pass will raise an error. This is
-      because ``checkpoint`` makes all the outputs require gradients which
+      because ``checkpoint`` makes all the outputs require gradients and this
       causes issues when a tensor is defined to have no gradient in the model.
-      To circumvent this, detach the tensors outside of the `checkpoint`
-      function.
+      To avoid this, detach the tensors outside of the ``checkpoint`` function.
 
     .. warning::
-        If :attr:`function` invocation during backward does anything different
-        than the one during forward, e.g., due to some global variable, the
-        checkpointed version won't be equivalent, this may result in an error
-        being raised or result in silently incorrect gradients.
+        If the :attr:`function` invocation during the backward pass differs
+        from the forward pass, e.g., due to a global variable, the checkpointed
+        checkpointed version may not be equivalent, potentially causing an
+        error being raised or leading to silently incorrect gradients.
 
     Args:
         function: describes what to run in the forward pass of the model or

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -475,18 +475,6 @@ def checkpoint_sequential(functions, segments, input, use_reentrant=True, **kwar
 # out = checkpoint(fn)(inp)
 #
 # In the code above fn is computed (potentially partially) 4 times in total.
-<<<<<<< HEAD
-#   1. Don't save x and y since we are inside a checkpoint.
-#   2. Trigger a recompute of fn as we reach (3) since x and y weren't saved.
-#   3. If early stop is enabled, stop at (2)
-#   4. Continue original forward at (4), not saving x and w.
-#   5. (5) triggers a recompute of fn
-#   6. During recompute, we see that in the original graph, gx has already
-#      cleared x and y since backward is run at (3) without retain_graph=True
-#      We save x and w, however.
-#   7. Continue with returning
-#
-=======
 #
 # 1. Don't save x and y since we are inside a checkpoint.
 # 2. Trigger a recompute of fn as we reach (3) since x and y weren't saved.
@@ -497,7 +485,6 @@ def checkpoint_sequential(functions, segments, input, use_reentrant=True, **kwar
 #    cleared x and y since backward is run at (3) without retain_graph=True
 #    We save x and w, however.
 # 7. Continue with returning
->>>>>>> eef5549ccea (fixup)
 
 # NB: This is temporary and should be removed in a follow up PR. Early stopping
 #     is currently disabled by default. Since some nested test cases require

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -294,11 +294,10 @@ def checkpoint_sequential(functions, segments, input, use_reentrant=True, **kwar
     be saved for re-running the segment in the backward pass.
 
     .. warning::
-        If you are using the ``use_reentrant=True` implementation (this is the
-        default), please see :func:`~torch.utils.checkpoint.checkpoint` to see
-        the restrictions of this variant. It is recommended that you pass
-        ``use_reentrant=False``. We plan to deprecate ``use_reentrant=True`` in
-        a future version of PyTorch.
+        If you are using the ``use_reentrant=True` variant (this is the
+        default), please see :func:`~torch.utils.checkpoint.checkpoint` for
+        the important considerations and limitations of this variant. It is
+        recommended that you use ``use_reentrant=False``.
 
     .. warning:
         Since PyTorch 1.4, it allows only one Tensor as the input and

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -185,45 +185,58 @@ def checkpoint(
     applied to any part of a model.
 
     There are currently two checkpointing implementations available, determined
-    by the :attr:`use_reentrant` parameter. In the future, we plan to deprecate
-    ``use_reentrant=True`` (reentrant variant). so it is recommended that you
-    use ``use_reentrant=False`` (non-reentrant variant). If you have a use case
-    that requires the reentrant variant, please file an issue.
-
-    The non-reentrant variant offers several improvements over the reentrant
-    variant:
-
-    * Properly records the autograd graph during the forward pass, allowing for
-      more fine-grained control, such as performing backward on the graph within
-      checkpointed regions and attaching hooks. The reentrant variant runs the
-      forward in :func:`torch.no_grad`.
-
-    * Supports all ways of performing the backward pass, whereas reentrant
-      checkpoint only supports the :func:`torch.autograd.backward` API and only
-      if its `inputs` argument is not passed. Reentrant checkpoint does not
-      support :func:`torch.autograd.grad`.
-
-    * No requirement for at least one input and output to have
-      ``requires_grad=True``. If this condition is unmet in the reentrant
-      checkpoint, the checkpointed part of the model will not have gradients.
-
-    * Considers tensors passed as inputs or returned as outputs in nested
-      structures (e.g., custom objects, lists, dicts, etc) as participating in
-      autograd.
-
-    * Supports checkpointed regions containing tensors detached from the
-      computational graph. For the reentrant variant, if the checkpointed
-      segment contains tensors detached using ``detach()`` or with
-      :func:`torch.no_grad`, the backward pass will raise an error. This is
-      because ``checkpoint`` makes all the outputs require gradients and this
-      causes issues when a tensor is defined to have no gradient in the model.
-      To avoid this, detach the tensors outside of the ``checkpoint`` function.
+    by the :attr:`use_reentrant` parameter. It is recommended that you use
+    ``use_reentrant=False``. Please refer the note below for a discussion of
+    their differences.
 
     .. warning::
+
         If the :attr:`function` invocation during the backward pass differs
         from the forward pass, e.g., due to a global variable, the checkpointed
         checkpointed version may not be equivalent, potentially causing an
         error being raised or leading to silently incorrect gradients.
+
+    .. warning::
+
+        If you are using the ``use_reentrant=True`` variant (this is currently
+        the default), please refer to the note below for important
+        considerations and potential limitations.
+
+    .. note::
+
+        The reentrant variant of checkpoint (``use_reentrant=True``) and
+        the non-reentrant variant of checkpoint (``use_reentrant=False``)
+        differ in the following ways:
+
+        * The reentrant variant does not record the autograd graph during the
+          forward pass, as it runs with the forward pass under
+          :func:`torch.no_grad`. The non-reentrant version does record the
+          autograd graph, allowing one to perform backward on the graph within
+          checkpointed regions.
+
+        * The reentrant checkpoint only supports the
+          :func:`torch.autograd.backward` API for the backward pass without its
+          `inputs` argument, while the non-reentrant version supports all ways
+          of performing the backward pass.
+
+        * At least one input and output must have ``requires_grad=True`` for the
+          reentrant variant. If this condition is unmet, the checkpointed part
+          of the model will not have gradients. The non-reentrant version does
+          not have this requirement.
+
+        * The reentrant version does not consider tensors in nested structures
+          (e.g., custom objects, lists, dicts, etc) as participating in
+          autograd, while the non-reentrant version does.
+
+        * The reentrant checkpoint does not support checkpointed regions with
+          detached tensors from the computational graph, whereas the
+          non-reentrant version does. For the reentrant variant, if the
+          checkpointed segment contains tensors detached using ``detach()`` or
+          with :func:`torch.no_grad`, the backward pass will raise an error.
+          This is because ``checkpoint`` makes all the outputs require gradients
+          and this causes issues when a tensor is defined to have no gradient in
+          the model. To avoid this, detach the tensors outside of the
+          ``checkpoint`` function.
 
     Args:
         function: describes what to run in the forward pass of the model or


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #96923
* #96866
* __->__ #96862
* #96783
* #90105

Updates:
- ~recommend user to use non-reentrant, mention that reentrant will be deprecated in the future~
- merges all the warnings into a single list of non-reentrant improvements over reentrant
- adds an additional entry to the list about allowing backward inside checkpointed region

