### PR TITLE
record caller frame instead of function frame

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5008,7 +5008,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
         model.training_step()
 
-    def test_torch_guards_stack_frame_register(self):
+    def test_torch_guards_stack_frame_register_inlining_disable(self):
         y = torch.nn.Parameter(torch.tensor([0.25, 0.25]))
         x = torch.tensor([0.5, 0.5])
 
@@ -5041,8 +5041,50 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         ):
             torch._dynamo.optimize("eager")(e)(x)
 
+        self.assertEqual(len(seen_frames), 0)
+
+    def test_torch_guards_stack_frame_register_inlining_partially_disable(self):
+        y = torch.nn.Parameter(torch.tensor([0.25, 0.25]))
+        x = torch.tensor([0.5, 0.5])
+
+        class encoder(torch.nn.Module):
+            def __init__(self, y):
+                super().__init__()
+                self.register_parameter("param", y)
+
+            @torch._dynamo.disable
+            def helper_disabled(self, x, y):
+                return x * y
+
+            def helper(self, x, y):
+                return x * y
+
+            def forward(self, a, *args):
+                x = a + a
+                return self.helper(x, self.param) + self.helper_disabled(x, self.param)
+
+        e = encoder(y)
+
+        seen_frames = []
+        import contextlib
+
+        @contextlib.contextmanager
+        def global_context_capture_fn(frame_summary):
+            seen_frames.append(frame_summary)
+            yield
+
+        with mock.patch(
+            "torch._guards.TracingContext.current_frame",
+            side_effect=global_context_capture_fn,
+        ):
+            torch._dynamo.optimize("eager")(e)(x)
+
         self.assertEqual(len(seen_frames), 1)
-        self.assertEqual(seen_frames[0].line, "def forward(self, a, *args):")
+        self.assertEqual(seen_frames[0].name, "forward")
+        self.assertEqual(
+            seen_frames[0].line,
+            "return self.helper(x, self.param) + self.helper_disabled(x, self.param)",
+        )
 
     def test_torch_guards_stack_frame_register_inlining(self):
         x = torch.tensor([0.5, 0.5])
@@ -5072,9 +5114,45 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         ):
             torch._dynamo.optimize("eager")(fn)(x, y, z)
 
-        self.assertEqual(len(seen_frames), 2)
+        self.assertEqual(len(seen_frames), 1)
         self.assertEqual(seen_frames[0].name, "fn")
-        self.assertEqual(seen_frames[1].line, "def uwu_inline_me(x, y, z):")
+        self.assertEqual(seen_frames[0].line, "r, r2 = uwu_inline_me(x, y, z)")
+
+    def test_torch_guards_stack_frame_register_inlining_deep(self):
+        x = torch.tensor([0.5, 0.5])
+        y = torch.tensor([0.75, 0.75, 0.75, 0.75])
+        z = torch.tensor([0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25])
+
+        def uwu_inline_me_deep(x, y):
+            return torch.cat((x, x)) + y
+
+        def uwu_inline_me(x, y, z):
+            r = uwu_inline_me_deep(x, y)
+            r2 = uwu_inline_me_deep(y, z)
+            return r, r2
+
+        def fn(x, y, z):
+            r, r2 = uwu_inline_me(x, y, z)
+            return torch.mul(r, r), torch.mul(r2, r2)
+
+        seen_frames = []
+        import contextlib
+
+        @contextlib.contextmanager
+        def global_context_capture_fn(frame_summary):
+            seen_frames.append(frame_summary)
+            yield
+
+        with mock.patch(
+            "torch._guards.TracingContext.current_frame",
+            side_effect=global_context_capture_fn,
+        ):
+            torch._dynamo.optimize("eager")(fn)(x, y, z)
+
+        self.assertEqual(len(seen_frames), 3)
+        self.assertEqual(seen_frames[0].name, "fn")
+        self.assertEqual(seen_frames[1].name, "uwu_inline_me")
+        self.assertEqual(seen_frames[2].line, "r2 = uwu_inline_me_deep(y, z)")
 
 
 class CustomFunc1(torch.autograd.Function):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 import dataclasses
 import dis
 import functools
@@ -557,7 +558,7 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
         try:
             if not hasattr(self, inst.opname):
                 unimplemented(f"missing: {inst.opname}")
-            with TracingContext.current_loc(self.f_code.co_filename, self.lineno):
+            with TracingContext.current_loc(self.f_code.co_filename, self.lineno, self.f_code.co_name):
                 getattr(self, inst.opname)(inst)
 
             return inst.opname != "RETURN_VALUE"
@@ -588,8 +589,11 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
             [create_jump_absolute(continue_inst)] + self.instructions
         )
 
+    def run_ctx_mgr(self):
+        return contextlib.nullcontext()
+
     def run(self):
-        with TracingContext.current_frame(self.frame_summary()):
+        with self.run_ctx_mgr():
             try:
                 self.output.push_tx(self)
                 while (
@@ -2057,6 +2061,9 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
     @property
     def fake_mode(self):
         return self.parent.fake_mode
+
+    def run_ctx_mgr(self):
+        return TracingContext.current_frame(self.parent.frame_summary())
 
     def STORE_DEREF(self, inst):
         if inst.argval in self.closure_cells:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -558,7 +558,9 @@ class InstructionTranslatorBase(Checkpointable[InstructionTranslatorGraphState])
         try:
             if not hasattr(self, inst.opname):
                 unimplemented(f"missing: {inst.opname}")
-            with TracingContext.current_loc(self.f_code.co_filename, self.lineno, self.f_code.co_name):
+            with TracingContext.current_loc(
+                self.f_code.co_filename, self.lineno, self.f_code.co_name
+            ):
                 getattr(self, inst.opname)(inst)
 
             return inst.opname != "RETURN_VALUE"

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -346,16 +346,12 @@ class TracingContext:
 
     @staticmethod
     @contextlib.contextmanager
-    def current_loc(filename, lineno):
+    def current_loc(filename, lineno, frame_name):
         tc = TracingContext.get()
         assert (
             tc is not None
         ), "Loc context manager must be called within an ongoing trace."
-        if len(tc.frame_summary_stack) > 0:
-            current_frame_name = tc.frame_summary_stack[-1].name
-        else:
-            current_frame_name = "<unknown>"
-        tc.loc_in_frame = traceback.FrameSummary(filename, lineno, current_frame_name)
+        tc.loc_in_frame = traceback.FrameSummary(filename, lineno, frame_name)
         try:
             yield
         finally:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96882

Previously, when starting to trace a function, we would record a frame summary recording the definition loc. This would lead to an unconventional-looking stack trace when used for debugging, e.g., shape guards.

```
  File ".../scripts/avik/pt2/example.py", line 407, in forward
    def forward(self, x):
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 912, in forward
    @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 562, in forward
    def forward(
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 484, in forward
    def forward(
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 416, in forward
    def forward(
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 275, in forward
    def forward(
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 351, in forward
    attention_scores = attention_scores + attention_mask
```

As noted in https://github.com/pytorch/pytorch/pull/95848#discussion_r1134397096, we would like to change this to record function calls instead, like conventional stack traces do. This diff makes this change. The above stack now looks like the following, which is way more helpful at a glance to understand what's going on.

```
  File ".../scripts/avik/pt2/example.py", line 408, in forward
    bert_out = self.bert(**x)
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 1021, in forward
    encoder_outputs = self.encoder(
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 610, in forward
    layer_outputs = layer_module(
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 496, in forward
    self_attention_outputs = self.attention(
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 426, in forward
    self_outputs = self.self(
  ...
  File ".../transformers/models/bert/modeling_bert.py", line 351, in forward
    attention_scores = attention_scores + attention_mask
```

Differential Revision: [D44101882](https://our.internmc.facebook.com/intern/diff/D44101882/)

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire