### PR TITLE
Add support for allowing PyOperators to implement fx tracing override behavior

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -322,8 +322,7 @@ class TestFX(JitTestCase):
         def f(x, y):
             x = control_flow.cond(x[0] == 0, true, false, [x, y])
 
-        with self.assertRaisesRegex(RuntimeError, "Unable to symbolically trace PyOperators"):
-            _ = symbolic_trace(f)
+        mod = symbolic_trace(f)
 
     def test_disallow_override(self):
         # Custom delegate to disallow in-place tensor operations

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -446,9 +446,8 @@ class Proxy:
             if isinstance(orig_method, torch._ops.PyOperator):
                 try:
                     return orig_method.create_proxy(tracer, args, kwargs)
-                    # tracer.create_proxy('call_function', orig_method, args, kwargs)
                 except Exception as e:
-                    raise RuntimeError("Unable to symbolically trace PyOperators")
+                    raise RuntimeError(f"Unable to symbolically trace PyOperator {orig_method.name()}")
             return tracer.create_proxy('call_function', orig_method, args, kwargs,
                                        name=tracer.graph._target_to_str(orig_method.__name__))
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -260,8 +260,6 @@ class TracerBase:
             return a.node
         elif isinstance(a, base_types) or a is None or a is ...:
             return a
-        elif isinstance(a, types.FunctionType):
-            breakpoint()
         raise NotImplementedError(f"argument of type: {type(a)}")
 
     @compatibility(is_backward_compatible=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #96886

Today, we have no ability to do symbolic tracing on PyOperators - kind of. While technically a PyOperators is a function that should *just work* in tracing, the reality is that the reason behind a PyOperator is often because it is doing something special that other operators cannot. In the case of cond, map, etc - we take functions as inputs! In the case of cond, make_fx actually chokes on the *function args* not on the cond impl itself, so to speak. Thus, if we let the actual operator impl (which has a firm schema, in the cond case again, of always having a pos1 and pos2 arg of functions), write its own tracing outline, we can avoid having to centralize the logic for how to trace all the PyOperators, letting the op define this itself, which feels more in line with the whole raison d'etre of these ops anyway. 

```
def true(x, y):
    return x + y

def false(x, y):
    return x - y

def f(x, y):
    x = control_flow.cond(x[0] == 0, true, false, [x, y])

mod = symbolic_trace(f)
```

Now produces:

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/4755252/225444986-1baac397-4dc7-4db5-b501-329518ab2944.png">

Which seems right?

Differential Revision: [D44143208](https://our.internmc.facebook.com/intern/diff/D44143208)