### PR TITLE
[PyTorch][XNNPACK] Update wrappers for internal only x86 SSE2 kernels

### DIFF
--- a/third_party/xnnpack_src_defs.bzl
+++ b/third_party/xnnpack_src_defs.bzl
@@ -348,8 +348,8 @@ AARCH64_ASM_MICROKERNEL_SRCS = [
     "XNNPACK/src/qu8-igemm/gen/qu8-igemm-4x16c4-minmax-rndnu-asm-aarch64-neondot-cortex-a55.S",
     "XNNPACK/src/qu8-igemm/gen/qu8-igemm-4x16c4-minmax-rndnu-asm-aarch64-neondot-ld128.S",
 ] + [
-    "xnnpack_wrappers/qc8-gemm/gen/qc8-gemm-4x16c4-minmax-none-asm-aarch64-neondot-cortex-a55.S",
-    "xnnpack_wrappers/qs8-gemm/gen/qs8-gemm-4x16c4-minmax-none-asm-aarch64-neondot-cortex-a55.S",
+    "XNNPACK/src/qc8-gemm/gen/qc8-gemm-4x16c4-minmax-none-asm-aarch64-neondot-cortex-a55.S",
+    "XNNPACK/src/qs8-gemm/gen/qs8-gemm-4x16c4-minmax-none-asm-aarch64-neondot-cortex-a55.S",
 ] if native.read_config("pt", "is_oss", "0") == "0" else []
 
 ALL_ARMSIMD32_MICROKERNEL_SRCS = [
@@ -5094,7 +5094,14 @@ ALL_SSE2_MICROKERNEL_SRCS = [
     "XNNPACK/src/x64-transposec/gen/x64-transposec-2x2-reuse-switch-sse2.c",
     "XNNPACK/src/xx-fill/xx-fill-sse2-x64.c",
     "XNNPACK/src/xx-pad/xx-pad-sse2.c",
-]
+] + [
+    "XNNPACK/src/qc8-gemm/gen/qc8-gemm-1x4c8-minmax-none-sse2-ld64.c",
+    "XNNPACK/src/qc8-gemm/gen/qc8-gemm-2x4c8-minmax-none-sse2-ld64.c",
+    "XNNPACK/src/qc8-gemm/gen/qc8-gemm-3x4c8-minmax-none-sse2-ld64.c",
+    "XNNPACK/src/qs8-gemm/gen/qs8-gemm-1x4c8-minmax-none-sse2-ld64.c",
+    "XNNPACK/src/qs8-gemm/gen/qs8-gemm-2x4c8-minmax-none-sse2-ld64.c",
+    "XNNPACK/src/qs8-gemm/gen/qs8-gemm-3x4c8-minmax-none-sse2-ld64.c",
+] if native.read_config("pt", "is_oss", "0") == "0" else []
 
 ALL_SSE41_MICROKERNEL_SRCS = [
     "XNNPACK/src/f16-f32-vcvt/gen/f16-f32-vcvt-sse41-int16-x8.c",

--- a/third_party/xnnpack_wrapper_defs.bzl
+++ b/third_party/xnnpack_wrapper_defs.bzl
@@ -5082,7 +5082,14 @@ ALL_SSE2_MICROKERNEL_SRCS = [
     "xnnpack_wrappers/x64-transposec/gen/x64-transposec-2x2-reuse-switch-sse2.c",
     "xnnpack_wrappers/xx-fill/xx-fill-sse2-x64.c",
     "xnnpack_wrappers/xx-pad/xx-pad-sse2.c",
-]
+] + [
+    "xnnpack_wrappers/qc8-gemm/gen/qc8-gemm-1x4c8-minmax-none-sse2-ld64.c",
+    "xnnpack_wrappers/qc8-gemm/gen/qc8-gemm-2x4c8-minmax-none-sse2-ld64.c",
+    "xnnpack_wrappers/qc8-gemm/gen/qc8-gemm-3x4c8-minmax-none-sse2-ld64.c",
+    "xnnpack_wrappers/qs8-gemm/gen/qs8-gemm-1x4c8-minmax-none-sse2-ld64.c",
+    "xnnpack_wrappers/qs8-gemm/gen/qs8-gemm-2x4c8-minmax-none-sse2-ld64.c",
+    "xnnpack_wrappers/qs8-gemm/gen/qs8-gemm-3x4c8-minmax-none-sse2-ld64.c",
+] if native.read_config("pt", "is_oss", "0") == "0" else []
 
 ALL_SSE41_MICROKERNEL_SRCS = [
     "xnnpack_wrappers/f16-f32-vcvt/gen/f16-f32-vcvt-sse41-int16-x8.c",


### PR DESCRIPTION
Summary:
Same as D43747173 (https://github.com/pytorch/pytorch/pull/95911) except for the newly added x86 SSE2 kernels.

For future reference, wrappers can be generated by

```
cd ~/fbsource/xplat/third-party/XNNPACK
# Update the list of internal only kernels in generate-wrappers.py
python3 generate-wrappers.py
```

Test Plan: CI

Reviewed By: digantdesai

Differential Revision: D44072764

