### PR TITLE
[functorch][experimental] Support while_loop in eager_mode

### DIFF
--- a/functorch/experimental/_while_loop.py
+++ b/functorch/experimental/_while_loop.py
@@ -1,0 +1,35 @@
+import torch
+import torch.utils._pytree as pytree
+from torch._ops import PyOperator
+from torch._C import DispatchKey, DispatchKeySet, ExcludeDispatchKeyGuard
+from torch.utils._python_dispatch import (
+    _get_current_dispatch_mode,
+)
+
+"""
+Experimental implementation of JAX-like while_loop operator.
+"""
+while_loop = PyOperator("while_loop")
+
+@while_loop.py_impl(DispatchKey.Autograd)
+def while_loop_autograd(cond_fun, body_fun, init_val):
+    # TODO: support autograd
+    flat_operands, _ = pytree.tree_flatten([cond_fun, body_fun, init_val])
+    assert all([not f.requires_grad for f in flat_operands
+                if isinstance(f, torch.Tensor)])
+
+    _ = ExcludeDispatchKeyGuard(DispatchKeySet(DispatchKey.AutogradCPU))
+    return while_loop(cond_fun, body_fun, init_val)
+
+
+@while_loop.py_impl(DispatchKey.CompositeExplicitAutograd)
+def while_loop_cpu(cond_fun, body_fun, init_val):
+    mode = _get_current_dispatch_mode()
+    assert (mode is None), "Mode should never be enabled for CPU/CUDA key"
+    val = init_val
+    while cond_fun(*val):
+        val = body_fun(*val)
+    return val
+
+while_loop.fallthrough(DispatchKey.ADInplaceOrView)
+while_loop.fallthrough(DispatchKey.BackendSelect)

--- a/functorch/experimental/control_flow.py
+++ b/functorch/experimental/control_flow.py
@@ -1,2 +1,3 @@
 from ._map import map  # noqa: F401
 from ._cond import cond, UnsupportedAliasMutationException  # noqa: F401
+from ._while_loop import while_loop  # noqa: F401

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -45,6 +45,59 @@ class TestControlFlow(TestCase):
 
         self.assertEqual(res, control_flow.map(f, torch.ones(3, 2, 2), torch.ones(2)))
 
+    @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA.")
+    def test_while_loop_no_trace_gpu(self):
+        def cond_fun(iter, val):
+            return iter > 0
+
+        def body_fun(iter, val):
+            return (iter - 1, val.sin())
+
+        iter = torch.tensor(5)
+        val = torch.randn(2, 3, device="cuda")
+        res_scalar = control_flow.while_loop(cond_fun, body_fun, (iter, val))
+        while iter > 0:
+            val = val.sin()
+            iter -= 1
+        self.assertEqual(res_scalar, (0, val))
+
+    def test_while_loop_no_trace(self):
+        def cond_fun(iter, val):
+            return iter > 0
+
+        def body_fun(iter, val):
+            return (iter - 1, val.sin())
+
+        iter = torch.tensor(5)
+        val = torch.randn(2, 3)
+        res_scalar = control_flow.while_loop(cond_fun, body_fun, (iter, val))
+        while iter > 0:
+            val = val.sin()
+            iter -= 1
+        self.assertEqual(res_scalar, (0, val))
+
+    def test_while_loop_no_trace_nested(self):
+
+        def fun(iter, val):
+            return (iter - 1, val + 1)
+
+        def cond_fun(iter, val):
+            return iter > 0
+
+        def body_fun(iter, val):
+            _, val = control_flow.while_loop(cond_fun, fun, (inner_iter, val))
+            return (iter - 1, val)
+
+        iter = torch.tensor(5)
+        inner_iter = torch.tensor(2)
+        total_iter = iter * inner_iter
+        val = torch.randn(2, 3)
+        res_scalar = control_flow.while_loop(cond_fun, body_fun, (iter, val))
+        while total_iter > 0:
+            val = val + 1
+            total_iter -= 1
+        self.assertEqual(res_scalar, (0, val))
+
 
 class TestControlFlowTraced(TestCase):
     def test_cond_traced_not_nested(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #96902
* #96901
* #96900
* __->__ #96899

## Motivation
Recently, we (export team) got a feature request from edge team: it's preferred to have a while\_loop operator in the exported graph. One specific example model belongs to the MaskRCNN family. The pseudo code is as follows:
```python
# Stage 1: Find all boxes
boxes: List[Tensor] = []
search_offset = 0
box_found = True
no_boxes = 0
while box_found:
  box_found, box, search_offset = find_next_box(image, search_offset)
  if box_found:
    boxes.append(box)
    no_boxes += 1

# Stage 2: Conditional computation on variable number of boxes
boxes_predicted = 0
box_predictions: List[Tensor] = []
while boxes_predicted < no_boxes:
  box_predictions.append(expensive_box_prediction(boxes[boxes_predicted])
  boxes_predicted += 1
return box_predictions, no_boxes
```
The requirements that motivate the need of a data-dependent loop operator are:
- Minimize calls to **expensive_box_prediction** and **find_next_box**, which is critical for edge devices. This requires the while loop in stage 1 to exit the while loop early in a input data dependent manner.
- The models were written for eager mode evaluation on GPU and are now being re-targeted for edge devices. A while_loop would be ideal for easier migration. Rewriting stage 1 with combinations of index_select/split/concat might be feasible but it hurts readability.

Besides, @vadimkantorov would also like to see an implementation of while_loop in https://github.com/pytorch/pytorch/issues/50688.

## Design
We learn from the designs of while_loop operators in existing systems such as JAX. The mental model and eager execution semantic of while_loop is:
```python
'''
cond_fun takes returns a Scalar boolean Tensor
body_fun takes a tuple/list of tensors (nesting not supported for now).
return val has the same structure as input.
'''
def while_loop(cond_fun, body_fun, init_val):
  val = init_val
  while cond_fun(val):
    val = body_fun(val)
  return val
```
Some restrictions we would like to have in order to make things easier to be correct:
1. The elements of init_val must be tensor.
2. val and init_val has the same length and elements must have the same meta data e.g. shape, dtype.
3. cond_fun and body_fun are not allowed to have side\_effects outside the function such as mutating input/global/module variable. Users should pass in the variables they intend to mutate as arguments, return the new values as part of val and apply the side\_effects afterwards.
4. cond_fun and body_fun's outputs' tensors are no not allowed to aliase input.

## Plan
We need to support while_loop across the stack: eager_mode, make_fx, functionalization, vmap, autograd, dynamo. This pr is the first step.