### PR TITLE
Fix focus builds of macOS apps on apple silicon.

### DIFF
--- a/c2_defs.bzl
+++ b/c2_defs.bzl
@@ -324,43 +324,28 @@ def get_c2_default_cxx_args():
     )
 
 def get_c2_aten_cpu_fbobjc_macosx_deps():
-    if is_focus_enabled():
-        # focus2 is broken when using platform deps (T80070498) so in the case
-        # where it's focus2 we just add fbgemm as a standard dep. Otherwise we
-        # use platform deps to select correctly for arm64.
-        return [
-            "fbsource//xplat/deeplearning/fbgemm:fbgemm",
-            "fbsource//xplat/caffe2:cpukernel_avx2",
-        ]
-    else:
-        return select({
-            "DEFAULT": [],
-            "ovr_config//os:macos-x86_64": ["fbsource//xplat/deeplearning/fbgemm:fbgemm"],
-        }) if is_arvr_mode() else []
+    return select({
+        "DEFAULT": [],
+        "ovr_config//os:macos-x86_64": ["fbsource//xplat/deeplearning/fbgemm:fbgemm"],
+    }) if is_arvr_mode() else []
 
 def get_c2_aten_cpu_fbobjc_macosx_platform_deps():
-    if is_focus_enabled():
-        # focus2 is broken when using platform deps (T80070498) so in the case
-        # where it's focus2 we just add fbgemm as a standard dep. Otherwise we
-        # use platform deps to select correctly for arm64.
-        return []
-    else:
-        return compose_platform_setting_list([
-            {
-                "cpu": "x86_64",
-                "flags": [
-                    "fbsource//xplat/deeplearning/fbgemm:fbgemmAppleMac",
-                ] + ([
-                    "fbsource//xplat/caffe2:cpukernel_avx2AppleMac",
-                ] if not is_arvr_mode() else []),
-                "os": "macosx",
-            },
-            {
-                "cpu": "arm64",
-                "flags": ["fbsource//xplat/third-party/XNNPACK:XNNPACKAppleMac"],
-                "os": "macosx",
-            },
-        ])
+    return compose_platform_setting_list([
+        {
+            "cpu": "x86_64",
+            "flags": [
+                "fbsource//xplat/deeplearning/fbgemm:fbgemmAppleMac",
+            ] + ([
+                "fbsource//xplat/caffe2:cpukernel_avx2AppleMac",
+            ] if not is_arvr_mode() else []),
+            "os": "macosx",
+        },
+        {
+            "cpu": "arm64",
+            "flags": ["fbsource//xplat/third-party/XNNPACK:XNNPACKAppleMac"],
+            "os": "macosx",
+        },
+    ])
 
 def using_protobuf_v3():
     # Consider migrating this to `read_config("protobuf", "use_v3")`


### PR DESCRIPTION
Summary: Focus2 builds of some apps on apple silicon Macs are failing. We've determined that removing the `user.focus_enabled=true` config option allows the build to succeed.

Reviewed By: milend

Differential Revision: D44076509

