### PR TITLE
Retry brew and gem installation in trunk ios workflow

### DIFF
--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -92,9 +92,14 @@ jobs:
           esac
 
       - name: Install brew dependencies
-        run: |
-          # Install dependencies
-          brew install libtool
+        uses: nick-fields/retry@v2.8.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 90
+          command: |
+            # Install dependencies
+            brew install libtool
 
       - name: Setup miniconda for iOS
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
@@ -104,12 +109,17 @@ jobs:
           pip-requirements-file: .github/requirements/pip-requirements-iOS.txt
 
       - name: Setup Fastlane
-        run: |
-          set -x
-          cd ios/TestApp
-          # install fastlane
-          sudo gem install bundler && bundle install
-          bundle update fastlane
+        uses: nick-fields/retry@v2.8.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 90
+          command: |
+            set -x
+            cd ios/TestApp
+            # install fastlane
+            sudo gem install bundler && bundle install
+            bundle update fastlane
 
       - name: Build PyTorch Mobile Runtime
         run: |

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -112,10 +112,15 @@ jobs:
           environment-file: ${{ inputs.environment-file }}
 
       - name: Install macOS homebrew dependencies
-        run: |
-          # Install dependencies
-          brew install libomp
-          brew link --force libomp
+        uses: nick-fields/retry@v2.8.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 90
+          command: |
+            # Install dependencies
+            brew install libomp
+            brew link --force libomp
 
       - name: Install sccache (only for non-forked PRs, and pushes to trunk)
         uses: nick-fields/retry@v2.8.2

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -81,10 +81,15 @@ jobs:
       # runners are shared and not ephemeral, so the issue wasn't manifested if the runners with the fix were
       # used
       - name: Install macOS homebrew dependencies
-        run: |
-          # Install dependencies
-          brew install libomp
-          brew link --force libomp
+        uses: nick-fields/retry@v2.8.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 90
+          command: |
+            # Install dependencies
+            brew install libomp
+            brew link --force libomp
 
       - name: Setup miniconda
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -128,10 +128,15 @@ jobs:
           echo "monitor-script-pid=${!}" >> "${GITHUB_OUTPUT}"
 
       - name: Install macOS homebrew dependencies
-        run: |
-          # Install dependencies
-          brew install libomp
-          brew link --force libomp
+        uses: nick-fields/retry@v2.8.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 90
+          command: |
+            # Install dependencies
+            brew install libomp
+            brew link --force libomp
 
       - name: Parse ref
         id: parse-ref


### PR DESCRIPTION
Per title, I don't want to see network flakiness like this https://github.com/pytorch/pytorch/actions/runs/4439991996/jobs/7793213476 ever again :P