### PR TITLE
Stop using my channel for 3.11 builds

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -53,8 +53,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
   CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools"
   if [ "$ANACONDA_PYTHON_VERSION" = "3.11" ]; then
-    # TODO: Stop using `-c malfet`
-    conda_install numpy=1.23.5 ${CONDA_COMMON_DEPS} -c malfet
+    conda_install numpy=1.23.5 ${CONDA_COMMON_DEPS}
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.10" ]; then
     conda_install numpy=1.21.2 ${CONDA_COMMON_DEPS}
   elif [ "$ANACONDA_PYTHON_VERSION" = "3.9" ]; then

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -38,10 +38,6 @@ fi
 EXTRA_CONDA_FLAGS=""
 NUMPY_PIN=""
 PROTOBUF_PACKAGE="defaults::protobuf"
-if [[ "\$python_nodot" = *311* ]]; then
-  # Numpy is yet not avaiable on default conda channel
-  EXTRA_CONDA_FLAGS="-c=malfet"
-fi
 
 if [[ "\$python_nodot" = *310* ]]; then
   # There's an issue with conda channel priority where it'll randomly pick 1.19 over 1.20


### PR DESCRIPTION
As `numpy` for Python 3.11 is now available from the default anaconda channel
