### PR TITLE
[MPS] Fix the failure with ReplicatePad3D

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -108,41 +108,43 @@ Tensor& pad_out_template(Tensor& output,
         outputSizes.emplace_back(new_dim);
       }
     } else {
-      // these checks aren't relevant for constant pad
-      TORCH_CHECK(pad_l < input_w && pad_r < input_w,
-                  "Argument #4: Padding size should be less than the corresponding "
-                  "input dimension, but got: padding (",
-                  pad_l,
-                  ", ",
-                  pad_r,
-                  ") at dimension ",
-                  dim_w,
-                  " of input ",
-                  ndims);
+      // these checks are only relevant for reflection padding (code taken from ReflectionPad.cpp)
+      if (mode == MPSGraphPaddingModeReflect) {
+        TORCH_CHECK(pad_l < input_w && pad_r < input_w,
+                    "Argument #4: Padding size should be less than the corresponding "
+                    "input dimension, but got: padding (",
+                    pad_l,
+                    ", ",
+                    pad_r,
+                    ") at dimension ",
+                    dim_w,
+                    " of input ",
+                    ndims);
 
-      if (padding_dim > 1) {
-        TORCH_CHECK(pad_t < input_h && pad_b < input_h,
-                    "Argument #6: Padding size should be less than the corresponding "
-                    "input dimension, but got: padding (",
-                    pad_t,
-                    ", ",
-                    pad_b,
-                    ") at dimension ",
-                    dim_h,
-                    " of input ",
-                    ndims);
-      }
-      if (padding_dim > 2) {
-        TORCH_CHECK(pad_front < input_d && pad_back < input_d,
-                    "Argument #8: Padding size should be less than the corresponding "
-                    "input dimension, but got: padding (",
-                    pad_front,
-                    ", ",
-                    pad_back,
-                    ") at dimension ",
-                    dim_d,
-                    " of input ",
-                    ndims);
+        if (padding_dim > 1) {
+          TORCH_CHECK(pad_t < input_h && pad_b < input_h,
+                      "Argument #6: Padding size should be less than the corresponding "
+                      "input dimension, but got: padding (",
+                      pad_t,
+                      ", ",
+                      pad_b,
+                      ") at dimension ",
+                      dim_h,
+                      " of input ",
+                      ndims);
+        }
+        if (padding_dim > 2) {
+          TORCH_CHECK(pad_front < input_d && pad_back < input_d,
+                      "Argument #8: Padding size should be less than the corresponding "
+                      "input dimension, but got: padding (",
+                      pad_front,
+                      ", ",
+                      pad_back,
+                      ") at dimension ",
+                      dim_d,
+                      " of input ",
+                      ndims);
+        }
       }
       outputSizes.insert(outputSizes.begin(), output_w);
       if (padding_dim >= 2)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5723,6 +5723,8 @@ class TestNLLLoss(TestCaseMPS):
         helper((2, 4, 6, 8, 4), (1, 3, 3, 5, 3, 4), nn.ReflectionPad3d)
         # verify if a change in shape of padding would cause problems with graph caching
         helper((2, 4, 6, 8, 4), (1, 3, 3, 5, 3, 4), nn.ReplicationPad3d)
+        # case where input_d == pad_front/back for ReplicationPad3d
+        helper((3, 4, 5, 6, 7), (1, 2, 3, 4, 5, 6), nn.ReplicationPad3d)
         # Constant Pad 3D
         helper((2, 4, 6, 8, 4), (1, 3, 3, 5, 3, 4), nn.ConstantPad3d)
         # input size < pad size


### PR DESCRIPTION
- Only ReflectPad needs the torch checks for input arguments and not the ReplicatePad
- Added a test case
- The failure was originally found in test_modules with test `test_forward_nn_ReplicationPad3d_mps_float32`


cc @kulinseth @albanD @malfet @DenisVieriu97 @abhudev