### PR TITLE
Increase the timeout value for linter calculate-docker-image

### DIFF
--- a/.github/workflows/_calculate-docker-image.yml
+++ b/.github/workflows/_calculate-docker-image.yml
@@ -17,7 +17,7 @@ jobs:
   calculate-docker-image:
     if: github.repository_owner == 'pytorch'
     runs-on: [self-hosted, linux.large]
-    timeout-minutes: 15
+    timeout-minutes: 30
     outputs:
       docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
     steps:


### PR DESCRIPTION
I should have known that this step rebuilds the linter Docker image if it doesn't exists.  When it does so, it takes close to 15 minutes to finish, i.e. https://github.com/pytorch/pytorch/actions/runs/4443046530/attempts/1, instead of the regular 2-minute run, i.e. https://github.com/pytorch/pytorch/actions/runs/4442455480/jobs/7798700609.

This x2 the timeout value of this step to 30 minutes to avoid getting timeout flakily.
