### PR TITLE
Update lr_scheduler.py to check the type of eta_min

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1367,6 +1367,8 @@ class CosineAnnealingWarmRestarts(LRScheduler):
             raise ValueError("Expected positive integer T_0, but got {}".format(T_0))
         if T_mult < 1 or not isinstance(T_mult, int):
             raise ValueError("Expected integer T_mult >= 1, but got {}".format(T_mult))
+        if not isinstance(eta_min, float):
+            raise ValueError("Exprected float, but got {}".format(eta_min))
         self.T_0 = T_0
         self.T_i = T_0
         self.T_mult = T_mult

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1367,8 +1367,8 @@ class CosineAnnealingWarmRestarts(LRScheduler):
             raise ValueError("Expected positive integer T_0, but got {}".format(T_0))
         if T_mult < 1 or not isinstance(T_mult, int):
             raise ValueError("Expected integer T_mult >= 1, but got {}".format(T_mult))
-        if not isinstance(eta_min, float):
-            raise ValueError("Expected float eta_min, but got {} of type {}".format(eta_min, type(eta_min)))
+        if not isinstance(eta_min, (float, int)):
+            raise ValueError("Expected float or int eta_min, but got {} of type {}".format(eta_min, type(eta_min)))
         self.T_0 = T_0
         self.T_i = T_0
         self.T_mult = T_mult

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1368,7 +1368,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         if T_mult < 1 or not isinstance(T_mult, int):
             raise ValueError("Expected integer T_mult >= 1, but got {}".format(T_mult))
         if not isinstance(eta_min, float):
-            raise ValueError("Expected float eta_min, but got {} of type {}".format(eta_min, type(eta_min))
+            raise ValueError("Expected float eta_min, but got {} of type {}".format(eta_min, type(eta_min)))
         self.T_0 = T_0
         self.T_i = T_0
         self.T_mult = T_mult

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1368,7 +1368,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         if T_mult < 1 or not isinstance(T_mult, int):
             raise ValueError("Expected integer T_mult >= 1, but got {}".format(T_mult))
         if not isinstance(eta_min, float):
-            raise ValueError("Exprected float, but got {}".format(eta_min))
+            raise ValueError("Expected float eta_min, but got {} of type {}".format(eta_min, type(eta_min))
         self.T_0 = T_0
         self.T_i = T_0
         self.T_mult = T_mult


### PR DESCRIPTION
Add float assertion to `eta_min` parameter in `CosineAnnealingWarmRestarts`.

Fixes #87757
