### PR TITLE
inductor: fix bf16 load

### DIFF
--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -1148,7 +1148,7 @@ class CppVecKernel(CppKernel):
             )
             line = f"at::vec::Vectorized<float>::loadu({self.var_vec_buf_map[var]})"
         elif V.graph.get_dtype(name) in [torch.bfloat16]:
-            line = f"load_bf16_as_float({var_expr})"
+            line = f"load_bf16_as_float({var})"
         elif is_broadcast:
             line = f"at::vec::Vectorized<float>({var_expr})"
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97011

Fix c++ compile error when running bfloat16:
```log
error: cannot convert ‘const bfloat16’ {aka ‘const c10::BFloat16’} to ‘const bfloat16*’ {aka ‘const c10::BFloat16*’}
   27 |                     auto tmp2 = load_bf16_as_float(in_ptr1[i0]);
      |                                                    ~~~~~~~~~~^
      |                                                              |
      |                                                              const bfloat16 {aka const c10::BFloat16}
```


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire