### PR TITLE
Fix for verify_dynamo on ROCm

### DIFF
--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -81,7 +81,7 @@ def get_rocm_version():
 def check_cuda():
     import torch
 
-    if not torch.cuda.is_available():
+    if not torch.cuda.is_available() or torch.version.cuda is None:
         return None
 
     torch_cuda_ver = packaging.version.parse(torch.version.cuda)

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -81,7 +81,7 @@ def get_rocm_version():
 def check_cuda():
     import torch
 
-    if not torch.cuda.is_available() or torch.version.cuda is None:
+    if not torch.cuda.is_available() or torch.version.hip is not None:
         return None
 
     torch_cuda_ver = packaging.version.parse(torch.version.cuda)


### PR DESCRIPTION
Prior to this change ROCm was not exiting check_cuda, causing an exception at packaging.version.parse(torch.version.cuda), this change exits check_cuda if torch.version.cuda is None

```
python verify_dynamo.py 

Python version: 3.9.16
`torch` version: 2.1.0a0+git2b2f10c
CUDA version: None
ROCM version: 5.4

All required checks passed
```
cc: @dllehr-amd 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport