### PR TITLE
Use L1 loss for Smooth L1 loss with beta=0

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5397,6 +5397,26 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             F.smooth_l1_loss(torch.randn(2, 2), torch.randn(2, 2), beta=-1.0)
 
+    def test_smoothl1loss_backward_zero_beta_cpu(self):
+        input = torch.randn(300, 256, requires_grad=True, device='cpu')
+        target = input.detach()
+
+        loss = F.smooth_l1_loss(input, target, beta=0.0, reduction='sum')
+        loss.backward()
+
+        grad_max_abs = input.grad.abs().max().item()
+        self.assertLessEqual(grad_max_abs, 1.0)
+
+    def test_smoothl1loss_backward_zero_beta_cuda(self):
+        input = torch.randn(300, 256, requires_grad=True, device='cuda')
+        target = input.detach()
+
+        loss = F.smooth_l1_loss(input, target, beta=0.0, reduction='sum')
+        loss.backward()
+
+        grad_max_abs = input.grad.abs().max().item()
+        self.assertLessEqual(grad_max_abs, 1.0)
+
     def test_huber_loss_invalid_delta(self):
         def _test_huber_loss_delta_error_helper(delta):
             input, target = torch.randn(2, 2), torch.randn(2, 2)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5397,19 +5397,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             F.smooth_l1_loss(torch.randn(2, 2), torch.randn(2, 2), beta=-1.0)
 
-    def test_smoothl1loss_backward_zero_beta_cpu(self):
-        input = torch.randn(300, 256, requires_grad=True, device='cpu')
-        target = input.detach()
-
-        loss = F.smooth_l1_loss(input, target, beta=0.0, reduction='sum')
-        loss.backward()
-
-        grad_max_abs = input.grad.abs().max().item()
-        self.assertLessEqual(grad_max_abs, 1.0)
-
-    @onlyCUDA
-    def test_smoothl1loss_backward_zero_beta_cuda(self):
-        input = torch.randn(300, 256, requires_grad=True, device='cuda')
+    def test_smoothl1loss_backward_zero_beta(self, device):
+        input = torch.randn(300, 256, requires_grad=True, device=device)
         target = input.detach()
 
         loss = F.smooth_l1_loss(input, target, beta=0.0, reduction='sum')

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5407,6 +5407,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         grad_max_abs = input.grad.abs().max().item()
         self.assertLessEqual(grad_max_abs, 1.0)
 
+    @onlyCUDA
     def test_smoothl1loss_backward_zero_beta_cuda(self):
         input = torch.randn(300, 256, requires_grad=True, device='cuda')
         target = input.detach()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5397,16 +5397,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(RuntimeError):
             F.smooth_l1_loss(torch.randn(2, 2), torch.randn(2, 2), beta=-1.0)
 
-    def test_smoothl1loss_backward_zero_beta(self, device):
-        input = torch.randn(300, 256, requires_grad=True, device=device)
-        target = input.detach()
-
-        loss = F.smooth_l1_loss(input, target, beta=0.0, reduction='sum')
-        loss.backward()
-
-        grad_max_abs = input.grad.abs().max().item()
-        self.assertLessEqual(grad_max_abs, 1.0)
-
     def test_huber_loss_invalid_delta(self):
         def _test_huber_loss_delta_error_helper(delta):
             input, target = torch.randn(2, 2), torch.randn(2, 2)
@@ -11407,6 +11397,16 @@ class TestNNDeviceType(NNTestCase):
         self.assertTrue(torch.allclose(loss.cpu(), loss_cpu, rtol=rtol, atol=atol))
         if reduction != "none":
             self.assertTrue(torch.allclose(logits.grad.cpu(), logits_cpu.grad, rtol=rtol, atol=atol))
+
+    def test_smoothl1loss_backward_zero_beta(self, device):
+        input = torch.randn(300, 256, requires_grad=True, device=device)
+        target = input.detach()
+
+        loss = F.smooth_l1_loss(input, target, beta=0.0, reduction='sum')
+        loss.backward()
+
+        grad_max_abs = input.grad.abs().max().item()
+        self.assertLessEqual(grad_max_abs, 1.0)
 
     def test_softshrink_negative(self, device):
         input = torch.randn(5, device=device, requires_grad=True)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3205,7 +3205,11 @@ def smooth_l1_loss(
         reduction = _Reduction.legacy_get_string(size_average, reduce)
 
     expanded_input, expanded_target = torch.broadcast_tensors(input, target)
-    return torch._C._nn.smooth_l1_loss(expanded_input, expanded_target, _Reduction.get_enum(reduction), beta)
+
+    if beta == 0.0:
+        return torch._C._nn.l1_loss(expanded_input, expanded_target, _Reduction.get_enum(reduction))
+    else:
+        return torch._C._nn.smooth_l1_loss(expanded_input, expanded_target, _Reduction.get_enum(reduction), beta)
 
 
 def huber_loss(


### PR DESCRIPTION
Fixes #96813.

Comments:

1. Wasn't able to test since tools/nightly.py does not allow for GPU build (and I don't want to build from scratch).
2. In theory, the bug (i.e. NaNs) can still occur when beta is very small (e.g. `beta=1e-50`), but not sure whether anybody cares.
3. Some checks within the smooth_l1_loss C++ code could be changed to check for `beta > 0` instead of `beta >= 0`.