### PR TITLE
[pytorch][2/3] Pytorch profiler permits CPU events with CUPTI Range profiler mode

### DIFF
--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -17,7 +17,7 @@ namespace kineto {
 
 #ifdef USE_KINETO
 namespace {
-const std::set<libkineto::ActivityType> cpuTypes{
+const std::set<libkineto::ActivityType> kCpuTypes{
     libkineto::ActivityType::CPU_OP,
     libkineto::ActivityType::CPU_INSTANT_EVENT,
     libkineto::ActivityType::USER_ANNOTATION,
@@ -27,18 +27,18 @@ const std::set<libkineto::ActivityType> cpuTypes{
     libkineto::ActivityType::PYTHON_FUNCTION,
 };
 
-const std::set<libkineto::ActivityType> cudaTypes = {
+const std::set<libkineto::ActivityType> kCudaTypes = {
     libkineto::ActivityType::GPU_MEMCPY,
     libkineto::ActivityType::GPU_MEMSET,
     libkineto::ActivityType::CONCURRENT_KERNEL,
-    // CUDA_RUNTIME appears in both cpuTypes and cudaTypes.
+    // CUDA_RUNTIME appears in both kCpuTypes and kCudaTypes.
     libkineto::ActivityType::CUDA_RUNTIME,
 };
-const std::set<libkineto::ActivityType> xpuTypes = {
+const std::set<libkineto::ActivityType> kXpuTypes = {
     libkineto::ActivityType::GPU_MEMCPY,
     libkineto::ActivityType::GPU_MEMSET,
     libkineto::ActivityType::CONCURRENT_KERNEL,
-    // XPU_RUNTIME appears in both cpuTypes and xpuTypes.
+    // XPU_RUNTIME appears in both kCpuTypes and kXpuTypes.
     libkineto::ActivityType::XPU_RUNTIME,
 };
 } // namespace
@@ -65,6 +65,7 @@ void addMetadata(
 #ifdef USE_KINETO
   // ActivityTraceInterface returns const pointers, so we have to cast away the
   // constness to add metadata.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<activity_t*>(activity)->addMetadata(key, value);
 #endif // USE_KINETO
 }
@@ -96,6 +97,7 @@ activity_t* TraceWrapper::addCPUActivity(
   auto& act = libkineto::CpuTraceBuffer::toRef(cpu_trace_->activities.back());
   act.device = device_and_resource.device;
   act.resource = device_and_resource.resource;
+  // NOLINTNEXTLINE
   act.id = correlation_id;
   act.startTime = start_time;
   if (type != libkineto::ActivityType::CPU_INSTANT_EVENT) {
@@ -155,25 +157,19 @@ class ExperimentalConfigWrapper {
       const torch::profiler::impl::ExperimentalConfig& config)
       : config_(config) {}
 
-  bool assertValid(const ActivitySet& activities) {
-    // Kineto supports reading performance events per kernel/iteration
-    // using CUPTI Range based profiler API. In this mode however we
-    // do not trace CPU or GPU events.
-    bool cupti_range_profiler = !config_.profiler_metrics.empty();
-    if (cupti_range_profiler &&
-        activities.count(torch::autograd::profiler::ActivityType::CPU)) {
-      LOG(WARNING)
-          << "Cannot run range profiler with CPU activities, please only"
-          << " use CUDA activity type";
-      return false;
-    }
-    return cupti_range_profiler;
+  bool assertValid() {
+    return !config_.profiler_metrics.empty();
   }
 
-  void prepareTraceWithExperimentalOptions() {
+  void prepareTraceWithExperimentalOptions(bool add_cpu_activity) {
 #ifdef USE_KINETO
     std::set<libkineto::ActivityType> k_activities{
         libkineto::ActivityType::CUDA_PROFILER_RANGE};
+
+    // Only add CPU activities if we are measuring per kernel ranges
+    if (add_cpu_activity && config_.profiler_measure_per_kernel) {
+      k_activities.insert(kCpuTypes.begin(), kCpuTypes.end());
+    }
 
     const size_t num_metrics = config_.profiler_metrics.size();
     std::stringstream configss;
@@ -219,21 +215,24 @@ void prepareTrace(
   }
 
   std::set<libkineto::ActivityType> k_activities;
-  if (activities.count(torch::autograd::profiler::ActivityType::CPU)) {
-    k_activities.insert(cpuTypes.begin(), cpuTypes.end());
+  bool has_cpu_activity =
+      activities.count(torch::autograd::profiler::ActivityType::CPU);
+
+  if (has_cpu_activity) {
+    k_activities.insert(kCpuTypes.begin(), kCpuTypes.end());
   }
   if (activities.count(torch::autograd::profiler::ActivityType::XPU)) {
-    k_activities.insert(xpuTypes.begin(), xpuTypes.end());
+    k_activities.insert(kXpuTypes.begin(), kXpuTypes.end());
   }
   if (activities.count(torch::autograd::profiler::ActivityType::CUDA)) {
-    k_activities.insert(cudaTypes.begin(), cudaTypes.end());
+    k_activities.insert(kCudaTypes.begin(), kCudaTypes.end());
   }
 
   ExperimentalConfigWrapper configWrap(config);
 
   // Experimental Configuration options are present
-  if (config && configWrap.assertValid(activities)) {
-    configWrap.prepareTraceWithExperimentalOptions();
+  if (config && configWrap.assertValid()) {
+    configWrap.prepareTraceWithExperimentalOptions(has_cpu_activity);
     return;
   }
 


### PR DESCRIPTION
Summary:
## Motivation
Initial version of CUPTI Range profile was conservative in turning of all other event types in kineto/pytorch profiler.
However, there is value in enabling CPU side activity logging. This let's us correlate the CPU operator -> GPU kernel statistics, helps us analyze flops/other performance metrics at the operator level.

## Details
1. Update pytorch profiler experimental configs parsing to allow setting CPU activities along with range profiler. Only enable on per kernel measurement mode.
1. Fixed Clang tidy issues (added nolint for 2 of them)

Test Plan: Testplan see bottom diff

Differential Revision: D44165079

