### PR TITLE
[NCCL] Cleanup NCCL-no-record streams, move to `TORCH_NCCL_AVOID_RECORD_STREAMS`

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -477,8 +477,6 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeStreams() {
   }
 
   if (avoidRecordStreams_) {
-    // TORCH_INTERNAL_ASSERT(outputs_->size() > 0);
-    // TORCH_INTERNAL_ASSERT(stashed_for_allocator_safety_->size() > 0);
     stashed_for_allocator_safety_->clear();
   }
 }
@@ -629,7 +627,7 @@ ProcessGroupNCCL::ProcessGroupNCCL(
       parseEnvVarIntDefault(NCCL_ASYNC_ERROR_HANDLING, 0));
   desyncDebug_ = parseEnvVarFlag(NCCL_DESYNC_DEBUG) ||
       (dist_debug_level_ >= DebugLevel::Detail);
-  avoidRecordStreams_ = parseEnvVarFlag(NCCL_AVOID_RECORD_STREAMS);
+  avoidRecordStreams_ = parseEnvVarFlag(TORCH_NCCL_AVOID_RECORD_STREAMS);
 
   if (blockingWait_) {
     if (asyncErrorHandling_ != NoHandling || desyncDebug_) {
@@ -1686,7 +1684,7 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::pointToPoint(
   // and the present call has no way to know it's not an isend.
   // Therefore, we warn and fall back to the typical recordStream logic:
   TORCH_WARN_ONCE(
-      !avoidRecordStreams_,
+      avoidRecordStreams_,
       "NCCL_AVOID_RECORD_STREAMS=1 has no effect for point-to-point "
       "collectives.");
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -54,7 +54,7 @@ enum ErrorHandlingMode { NoHandling = 0, TearDown = 1, CleanUpOnly = 2 };
 // Instead, it stashes live references to those tensors until after
 // user-facing streams are synced with comm streams.
 // See stashed_for_allocator_safety_ below.
-constexpr const char* NCCL_AVOID_RECORD_STREAMS = "NCCL_AVOID_RECORD_STREAMS";
+constexpr const char* TORCH_NCCL_AVOID_RECORD_STREAMS = "TORCH_NCCL_AVOID_RECORD_STREAMS";
 
 // ProcessGroupNCCL implements NCCL bindings for c10d.
 //
@@ -227,7 +227,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // give a more descriptive message when representing the Work as a string.
     std::shared_ptr<std::vector<at::Tensor>> outputs_;
 
-    // NCCL_AVOID_RECORD_STREAMS implementation helper.
+    // TORCH_NCCL_AVOID_RECORD_STREAMS implementation helper.
     // Stores references to participating non-output tensors (ie inputs,
     // flattened intermediates).
     // We'll clear this list in synchronizeStreams, just after user-facing
@@ -695,7 +695,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Whether or not to enable timeout root cause analysis.
   bool desyncDebug_;
 
-  // Whether or not NCCL_AVOID_RECORD_STREAMS was set
+  // Whether or not TORCH_NCCL_AVOID_RECORD_STREAMS was set
   bool avoidRecordStreams_ = false;
 
   // Set of communicators that this process group has aborted and their


### PR DESCRIPTION
Cleanup of #89880 including moving environment variable to `TORCH_*` prefix and a warning condition fix.

CC @ptrblck @kwen2501 