### PR TITLE
[inductor] improve bandwidth computation

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: inductor"]
+import contextlib
 import subprocess
 import sys
 from unittest.mock import patch
@@ -12,15 +13,19 @@ from torch.testing._internal.inductor_utils import HAS_CUDA
 
 
 class TestKernelBenchmark(TestCase):
-    @patch.object(config, "benchmark_kernel", True)
-    def test_kernel_benchmark(self):
-        @torch.compile
-        def f(x):
-            return torch.sin(x) + torch.cos(x)
+    @classmethod
+    def setUpClass(cls):
+        cls.exit_stack = contextlib.ExitStack()
+        cls.exit_stack.enter_context(patch.object(config, "benchmark_kernel", True))
 
-        inp = torch.rand(2, 3).cuda()
-        out = f(inp)
+    @classmethod
+    def tearDownClass(cls):
+        cls.exit_stack.close()
 
+    def setUp(self):
+        PyCodeCache.cache.clear()
+
+    def get_compiled_module(self):
         compiled_module = None
         for k, v in PyCodeCache.cache.items():
             if hasattr(v, "benchmark_compiled_module"):
@@ -30,25 +35,72 @@ class TestKernelBenchmark(TestCase):
                 compiled_module = v
 
         self.assertTrue(compiled_module is not None)
+        return compiled_module
 
-        try:
-            # now run the compiled module in subprocess and check its output
-            bench_out = subprocess.check_output(
-                f"{sys.executable} {compiled_module.__file__} -kc".split(),
-                stderr=subprocess.STDOUT,
-            ).decode()
+    def test_kernel_benchmark(self):
+        @torch.compile
+        def f(x):
+            return torch.sin(x) + torch.cos(x)
 
-            # make sure we have the bandwidth information in the output
-            FileCheck().check_count(
-                "GB/s",
-                1,
-                exactly=1,
-            ).run(bench_out)
-        except subprocess.CalledProcessError:
-            # calling python in a subprocess somehow fail in CI. Ignore it for now.
-            # Even we ignore it, we've already done basic checks like the compiled
-            # module should have benchmark_compiled_module function defined.
-            pass
+        inp = torch.rand(2, 3).cuda()
+        out = f(inp)
+
+        compiled_module = self.get_compiled_module()
+
+        # now run the compiled module in subprocess and check its output
+        bench_out = subprocess.check_output(
+            f"{sys.executable} {compiled_module.__file__} -kc".split(),
+            stderr=subprocess.STDOUT,
+        ).decode()
+
+        # make sure we have the bandwidth information in the output
+        FileCheck().check_count(
+            "GB/s",
+            1,
+            exactly=1,
+        ).run(bench_out)
+
+    def test_bandwidth_computation(self):
+        """
+        The test does a matmul and then mul. Without max-autotune, we use
+        the matmul in aten. So there is a single triton kernel for mul.
+        The kernel we generated is like:
+
+            @triton.jit
+            def triton_(in_out_ptr0, xnumel, XBLOCK : tl.constexpr):
+
+        Note the in_out_ptr0 argument. It's for a 1000x1000 tensor, but it's
+        inplace udpated, so when computing the bandwidth, we should count
+        the total memory access as 2 * 1000 * 1000 * 4 = 8MB. This amount is
+        what this test asserts.
+        """
+        torch.set_float32_matmul_precision("high")  # suggested by a warning
+
+        @torch.compile
+        def f(x, y):
+            z = x @ y
+            w = z * z
+            return w
+
+        M, N, K = 1000, 1000, 10
+        x = torch.rand(M, K).to("cuda")
+        y = torch.rand(K, N).to("cuda")
+        out = torch.compile(f)(x, y)
+
+        compiled_module = self.get_compiled_module()
+
+        # now run the compiled module in subprocess and check its output
+        bench_out = subprocess.check_output(
+            f"{sys.executable} {compiled_module.__file__} -k".split(),
+            stderr=subprocess.STDOUT,
+        ).decode()
+
+        # make sure we have the bandwidth information in the output
+        FileCheck().check_count(
+            "0.008 GB ",
+            1,
+            exactly=1,
+        ).run(bench_out)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -25,6 +25,7 @@ from ..utils import (
     sympy_product,
     sympy_subs,
     sympy_symbol,
+    unique,
 )
 from ..virtualized import ops, V
 
@@ -1244,6 +1245,7 @@ class TritonKernel(Kernel):
                     f"return triton_.benchmark_all_configs(*args, {extra_args_str}grid=grid({', '.join(grid)}))"
                 )
 
+        ninplace_args = len(unique(self.args.inplace_buffers.values()))
         result.writelines(["\n", "\n", "if __name__ == '__main__':"])
         with result.indent():
             result.writeline("from torch._inductor.utils import get_num_bytes")
@@ -1254,7 +1256,9 @@ class TritonKernel(Kernel):
             result.writeline(
                 "ms = do_bench(lambda: call(args), rep=40, fast_flush=True)[0]"
             )
-            result.writeline("num_gb = get_num_bytes(*args) / 1e9")
+            result.writeline(
+                f"num_gb = get_num_bytes(*args, num_in_out_args={ninplace_args}) / 1e9"
+            )
             result.writeline("gb_per_s = num_gb / (ms / 1e3)")
             result.writeline(
                 'print(f"{ms:.3f}ms    {num_gb:.3f}GB    {gb_per_s:.2f}GB/s")'

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -411,9 +411,6 @@ class TritonTemplate:
         # TODO(nmacchioni) fix bug here in CI tests
         # assert list(call_args) == expected_args, (call_args, expected_args)
         if list(call_args) != expected_args:
-            import pdb
-
-            pdb.set_trace()  # TODO
             return None
         extra_args = V.graph.sizevars.size_hints(
             map(sympy.expand, call_args[len(expected_args) :])

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -411,6 +411,9 @@ class TritonTemplate:
         # TODO(nmacchioni) fix bug here in CI tests
         # assert list(call_args) == expected_args, (call_args, expected_args)
         if list(call_args) != expected_args:
+            import pdb
+
+            pdb.set_trace()  # TODO
             return None
         extra_args = V.graph.sizevars.size_hints(
             map(sympy.expand, call_args[len(expected_args) :])

--- a/torch/_inductor/triton_ops/autotune.py
+++ b/torch/_inductor/triton_ops/autotune.py
@@ -257,7 +257,14 @@ class DebugAutotuner(CachingAutotuner):
         (launcher,) = self.launchers
 
         ms = self.bench(launcher, *args, grid=grid)[0]
-        num_gb = get_num_bytes(*args) / 1e9
+        num_in_out_ptrs = len(
+            [
+                arg_name
+                for arg_name in self.fn.arg_names
+                if arg_name.startswith("in_out_ptr")
+            ]
+        )
+        num_gb = get_num_bytes(*args, num_in_out_args=num_in_out_ptrs) / 1e9
         gb_per_s = num_gb / (ms / 1e3)
 
         collected_calls.append((ms, num_gb, gb_per_s, kernel_name)),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97057
* #96991

When we compute bandwidth for an kernel, we should double the memory usage for inplace arguments since we need read them once and write them once.


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire