### PR TITLE
Rewrite NCCL watchdog to more reliably throw timeout

### DIFF
--- a/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
+++ b/test/cpp/c10d/ProcessGroupNCCLErrorsTest.cpp
@@ -224,7 +224,7 @@ TEST_F(ProcessGroupNCCLErrorsTest, testNCCLTimedoutErrorsBlocking) {
   // Now run all reduce with errors.
   pg.set_timedout_error();
   work = pg.allreduce(tensors_);
-  EXPECT_THROW(work->wait(), c10::Error);
+  EXPECT_THROW(work->wait(), std::runtime_error);
 
   // Communicators might be aborted here, further operations would fail.
 }

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1119,8 +1119,7 @@ class DistributedDataParallelTest(
             try:
                 pg.allreduce([torch.ones(2).cuda(self.rank)]).wait()
             except RuntimeError as e:
-                self.assertTrue("timed out in call to wait()" in str(e))
-                self.assertTrue("TensorShape=[1]" in str(e))
+                self.assertTrue("aborted" in str(e))
             else:
                 self.fail("Expected error to be raised!")
 

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -8,7 +8,6 @@ import signal
 import sys
 import tempfile
 import threading
-import time
 from contextlib import contextmanager
 from datetime import timedelta
 from itertools import product

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -875,8 +875,9 @@ void ProcessGroupNCCL::workCleanupLoop() {
       if (work.exception()) {
         // Abort work and corresponding communicators
         work.abort();
-        // Abort all other communicators on this rank
-        abortAllComms();
+        // PG level abort, which would abort all other communicators on this
+        // rank
+        abort();
         // Report desync state in case of timeout
         if (desyncDebug_ && timedOut) {
           auto desyncMsg = retrieveDesyncReport(store_, "NCCL", rank_, size_);

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -523,6 +523,9 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeInternal(
           (*this),
           " timed out in blocking wait (NCCL_BLOCKING_WAIT=1).");
       LOG(ERROR) << exceptionMsg;
+    }
+    // exception() includes timeout and error during blocking wait
+    if (exception()) {
       // Abort NCCL communicators
       abort();
       // Throw exception (from main thread here)

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -44,7 +44,7 @@ constexpr const char* NCCL_DESYNC_DEBUG = "NCCL_DESYNC_DEBUG";
 
 constexpr const char* NCCL_BACKEND_NAME = "nccl";
 
-// TearDown mode: tear down process upon error, see `WorkNCCL::handleNCCLGuard`
+// TearDown mode: tear down process upon error, see `WorkNCCL::handleException`
 // Soft mode: just clean up collectives and abort communicators without tearing down process
 enum ErrorHandlingMode { NoHandling = 0, TearDown = 1, CleanUpOnly = 2 };
 
@@ -135,9 +135,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // Synchronize streams by blocking each on the NCCL stream
     void synchronizeStreams();
 
-    // Helper function used in CUDA Stream callbacks to complete WorkNCCL
-    // objects and throw exceptions when needed.
-    void handleNCCLGuard(ErrorHandlingMode asyncErrorHandling);
+    // Helper function to handle exception (throw if needed).
+    void handleException(ErrorHandlingMode asyncErrorHandling);
 
     // Helper function that checks if the NCCL kernels have finished
     // execution on the GPUs
@@ -151,10 +150,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
     // Helper function that returns True if the WorkNCCL object has timed out
     // and False otherwise.
-    bool timedOut();
-
-    // Helper function that checks timeout and set exception
-    void checkTimeout();
+    // In case of timeout, set exception on the WorkNCCL object.
+    bool checkTimeout();
 
     std::vector<at::Tensor> result() override;
 
@@ -208,11 +205,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
    private:
     // Helper function for synchronize
     void synchronizeInternal(std::chrono::milliseconds timeout);
+
     // Checks for NCCL errors and sets an appropriate exception_ptr.
     void checkAndSetException();
-
-    // Checks for NCCL errors and throws an appropriate exception.
-    void checkAndThrowException();
 
     // Just checks whether GPU execution has started, without modifying
     // exception_ptr.
@@ -542,14 +537,6 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // object might get destroyed before the WorkNCCL object.
   void ncclCommWatchdog();
 
-  void ncclCommWatchdogInternal();
-
-  // This function iterates through the list of WorkNCCL objects in the
-  // workList_ corresponding to incomplete collectives and then aborts NCCL
-  // communicators associated with timed out collectives.
-  void abortTimedOutCollectives(
-      std::unordered_set<std::string>& abortedCommIds);
-
   // Performs a health check by initializing dummy NCCL communicators and then
   // destroying them. This will help indicate and signal any NCCL-related issues
   // prior to the first collective. The actual initialization and subsequent
@@ -635,19 +622,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // Whether or not we should terminate the watchdog and workCleanup threads.
   std::atomic<bool> terminateProcessGroup_;
 
-  // Condition variable to control how long the watchdog thread waits.
-  std::condition_variable watchdogCV_;
-
-  // Mutex for watchdog.
-  std::mutex watchdogCVMutex_;
-
-  // Thread that removes NCCL Work upon timeout
-  std::thread workCleanupThread_;
-
   // Mutex to Guard workMetaList_
   std::mutex workMetaListMutex_;
 
-  // Condition Variable for timeout thread sleep
+  // Condition Variable for watchdog thread sleep
   std::condition_variable workMetaListCV_;
 
   // Vector to Store WorkNCCL pointers

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -555,8 +555,6 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   void logWorkEnd(WorkNCCL& work);
 
-  void abortAllComms();
-
  protected:
   static const int64_t kWorkCleanupThreadSleepMillis;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -560,7 +560,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   void logWorkEnd(WorkNCCL& work);
 
  protected:
-  static const int64_t kWorkCleanupThreadSleepMillis;
+  static const int64_t kWatchdogThreadSleepMillis;
 
   // The store is used to broadcast the NCCL unique ID of rank 0.
   c10::intrusive_ptr<Store> store_;

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -153,6 +153,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // and False otherwise.
     bool timedOut();
 
+    // Helper function that checks timeout and set exception
+    void checkTimeout();
+
     std::vector<at::Tensor> result() override;
 
    protected:
@@ -561,6 +564,10 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   void workCleanupLoop();
 
+  void logWorkStart(WorkNCCL& work);
+
+  void logWorkEnd(WorkNCCL& work);
+
  protected:
   static const int64_t kWatchdogThreadSleepMillis;
   static const int64_t kWorkCleanupThreadSleepMillis;
@@ -711,6 +718,8 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   // Counting for the sequential number of NCCL collective call.
   uint64_t seq_{0};
+
+  std::exception_ptr watchDogException_ = nullptr;
 
 #ifdef USE_NCCL_WITH_UCC
   // ProcessGroupUCC shared library handle and ProcessGroup pointer

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -549,10 +549,14 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   // communicators from the cache and clears used device indices.
   void destroyNCCLComms(const std::string& devNCCLCommMapKey);
 
+  // Watchdog's inside loop.
+  // Takes care of cleaning up completed work, and aborting upon failure or timeout.
   void workCleanupLoop();
 
+  // Desync debug helper
   void logWorkStart(WorkNCCL& work);
 
+  // Desync debug helper
   void logWorkEnd(WorkNCCL& work);
 
  protected:

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -568,8 +568,9 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
   void logWorkEnd(WorkNCCL& work);
 
+  void abortAllComms();
+
  protected:
-  static const int64_t kWatchdogThreadSleepMillis;
   static const int64_t kWorkCleanupThreadSleepMillis;
 
   // The store is used to broadcast the NCCL unique ID of rank 0.

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -8314,7 +8314,7 @@ class DistributedTest:
                     dist.get_backend(group_to_use) == dist.Backend.NCCL
                     and not is_detail_dbg_mode
                 ):
-                    expected_err = "Caught collective operation timeout"
+                    expected_err = "caught collective operation timeout"
                     ctx = self.assertRaisesRegex(RuntimeError, expected_err)
                 else:
                     expected_err = None
@@ -8767,7 +8767,7 @@ class DistributedTest:
                 if dist.get_debug_level() == dist.DebugLevel.DETAIL:
                     err_regex = "Timed out waiting"
                 else:
-                    err_regex = "Caught collective operation timeout"
+                    err_regex = "caught collective operation timeout"
                 with self.assertRaisesRegex(RuntimeError, err_regex):
                     nccl_pg.allreduce(tensors).wait(timedelta(seconds=0.1))
             else:


### PR DESCRIPTION
Fixes #97191

This PR aims to propagate collective exceptions (async error or timeout) up to the program, so as to avoid silent stuck job.

### Previous output in #97191
```
Rank 0 is the problematic rank
Rank 4 completed
Rank 5 completed
Rank 3 completed
Rank 6 completed
Rank 2 completed
Rank 7 completed
Rank 1 completed
[E ProcessGroupNCCL.cpp:464] [Rank 0] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=1, OpType=ALLREDUCE, Timeout(ms)=10000) ran for 10917 milliseconds before timing out.
Rank 0 completed
[E ProcessGroupNCCL.cpp:478] Some NCCL operations have failed or timed out. Due to the asynchronous nature of CUDA kernels, subsequent GPU operations might run on corrupted/incomplete data.
[E ProcessGroupNCCL.cpp:483] To avoid data inconsistency, we are taking the entire process down.
```
Although it says that it is taking the process down, it sometimes fails to do so.

### New output after this PR:
```
...
[E ProcessGroupNCCL.cpp:459] [Rank 0] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=1, OpType=ALLREDUCE, Timeout(ms)=10000) ran for 10599 milliseconds before timing out.
[E ProcessGroupNCCL.cpp:473] Some NCCL operations have failed or timed out. Due to the asynchronous nature of CUDA kernels, subsequent GPU operations might run on corrupted/incomplete data.
[E ProcessGroupNCCL.cpp:479] To avoid data inconsistency, we are taking the entire process down.
[E ProcessGroupNCCL.cpp:818] [Rank 0] NCCL watchdog thread terminated with exception: [Rank 0] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=1, OpType=ALLREDUCE, Timeout(ms)=10000) ran for 10599 milliseconds before timing out.
ERROR:torch.distributed.elastic.multiprocessing.api:failed (exitcode: -6) local_rank: 0 (pid: 194470) of binary: /data/home/kw2501/repos/pytorch-dev-env/bin/python
Traceback (most recent call last):
  File "/pytorch-dev-env/bin/torchrun", line 33, in <module>
    sys.exit(load_entry_point('torch', 'console_scripts', 'torchrun')())
  File "/pytorch-dev/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
    return f(*args, **kwargs)
  File "/pytorch-dev/torch/distributed/run.py", line 794, in main
    run(args)
  File "/pytorch-dev/torch/distributed/run.py", line 785, in run
    elastic_launch(
  File "/pytorch-dev/torch/distributed/launcher/api.py", line 134, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
  File "/pytorch-dev/torch/distributed/launcher/api.py", line 250, in launch_agent
    raise ChildFailedError(
torch.distributed.elastic.multiprocessing.errors.ChildFailedError: 
============================================================
hang.py FAILED
------------------------------------------------------------
Failures:
  <NO_OTHER_FAILURES>
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2023-03-20_22:00:42
  host      : node0
  rank      : 0 (local_rank: 0)
  exitcode  : -6 (pid: 194470)
  error_file: <N/A>
  traceback : Signal 6 (SIGABRT) received by PID 194470
============================================================
```

The log suggests that TorchX monitor is triggered, and job is torn down.

### Major changes in this PR:
1. Merge ncclWatchDog thread and workCleanupLoop thread into one so that the watch action and the throw action are streamlined.
Previously, ncclWatchDog is responsible for watching comm error and timeout, and workCleanupLoop is responsible for watching Work item error and throwing exception. This two-thread design is not streamlined, raising the chance of missing the throw. Also, it is duplicated to watch at multiple level. 
2. Rethrow exception at watchdog thread.
3. Clean up a bunch of duplicated functions, e.g. `checkAndThrowException` and `handleNcclException`.
4. Turn on ASYNC_ERROR_HANDLING by default 