### PR TITLE
lower cmake version requirement in FindSanitizer.cmake

### DIFF
--- a/cmake/Modules/FindSanitizer.cmake
+++ b/cmake/Modules/FindSanitizer.cmake
@@ -53,10 +53,18 @@ foreach(sanitizer_name IN ITEMS address thread undefined leak memory)
 
   set(CMAKE_REQUIRED_QUIET ON)
   set(_run_res 0)
-  include(CheckSourceRuns)
+  include(CheckCSourceRuns)
+  include(CheckCXXSourceRuns)
   foreach(lang IN LISTS languages)
-    if(lang STREQUAL CXX OR lang STREQUAL C)
-      check_source_runs(${lang} "${_source_code}"
+    if(lang STREQUAL C)
+      check_c_source_runs("${_source_code}"
+                        __${lang}_${sanitizer_name}_res)
+      if(__${lang}_${sanitizer_name}_res)
+        set(_run_res 1)
+      endif()
+    endif()
+    if(lang STREQUAL CXX)
+      check_cxx_source_runs("${_source_code}"
                         __${lang}_${sanitizer_name}_res)
       if(__${lang}_${sanitizer_name}_res)
         set(_run_res 1)


### PR DESCRIPTION
As indicated by the last comment from PR #93147, we should replace CheckSourceRuns in **cmake/Modules/FindSanitizer.cmake**  with older versions to avoid dependency on CMake 3.19+