### PR TITLE
[Inductor] index_put - unsqueeze indices[0] if self and indices[0] are not broadcastable

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4455,6 +4455,21 @@ class CommonTemplate:
             ],
         )
 
+    def test_index_put4(self):
+        # a, b[0] are not broadcastable
+        # https://github.com/pytorch/pytorch/issues/97104
+        def fn(a, b, c):
+            return torch.index_put(a, [b], c)
+
+        self.common(
+            fn,
+            [
+                torch.rand([8, 2]),
+                torch.rand([8]) > 0.5,
+                torch.rand([]),
+            ],
+        )
+
     def test_index_put_as_masked_fill(self):
         def fn(a, b, c, d):
             a = a.clone()

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2050,7 +2050,11 @@ def index_put_(self, indices, values, accumulate=False):
         and len(indices) == 1
         and indices[0].get_dtype() in {torch.bool, torch.uint8}
     ):
-        return index_put_as_masked_fill(self, indices, values, accumulate)
+        try:
+            return index_put_as_masked_fill(self, indices, values, accumulate)
+        except AssertionError:
+            # Fallback if self and indices[0] are not broadcastable
+            return index_put_fallback(self, indices, values, accumulate)
 
     # Fallback if there is a boolean index
     for index in indices:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2050,11 +2050,10 @@ def index_put_(self, indices, values, accumulate=False):
         and len(indices) == 1
         and indices[0].get_dtype() in {torch.bool, torch.uint8}
     ):
-        try:
-            return index_put_as_masked_fill(self, indices, values, accumulate)
-        except AssertionError:
-            # Fallback if self and indices[0] are not broadcastable
-            return index_put_fallback(self, indices, values, accumulate)
+        mask = indices[0]
+        for _ in range(len(mask.get_size()), len(self.get_size())):
+            mask = unsqueeze(mask, -1)
+        return index_put_as_masked_fill(self, [mask], values, accumulate)
 
     # Fallback if there is a boolean index
     for index in indices:


### PR DESCRIPTION
Fixes #97104


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire