### PR TITLE
Fixes an ONNX export error with unflatten

### DIFF
--- a/test/onnx/test_op_consistency.py
+++ b/test/onnx/test_op_consistency.py
@@ -309,6 +309,7 @@ TESTED_OPS: frozenset[str] = frozenset(
         "sqrt",
         "stft",
         "t",
+        "unflatten",
     ]
 )
 

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -136,7 +136,11 @@ class Unflatten(Module):
         raise TypeError("unflattened_size must be a tuple of ints, but found type {}".format(type(input).__name__))
 
     def forward(self, input: Tensor) -> Tensor:
-        return input.unflatten(self.dim, self.unflattened_size)
+        return input.view([
+            *input.shape[:self.dim],
+            *self.unflattened_size,
+            *input.shape[self.dim + 1:]
+        ])
 
     def extra_repr(self) -> str:
         return 'dim={}, unflattened_size={}'.format(self.dim, self.unflattened_size)

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -136,11 +136,7 @@ class Unflatten(Module):
         raise TypeError("unflattened_size must be a tuple of ints, but found type {}".format(type(input).__name__))
 
     def forward(self, input: Tensor) -> Tensor:
-        return input.view([
-            *input.shape[:self.dim],
-            *self.unflattened_size,
-            *input.shape[self.dim + 1:]
-        ])
+        return input.unflatten(self.dim, self.unflattened_size)
 
     def extra_repr(self) -> str:
         return 'dim={}, unflattened_size={}'.format(self.dim, self.unflattened_size)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -5131,10 +5131,13 @@ def flatten(g: jit_utils.GraphContext, input, start_dim, end_dim):
 
 @_onnx_symbolic("aten::unflatten")
 @symbolic_helper.quantized_args(True, False, False)
-@symbolic_helper.parse_args("v", "i", "is")
 @_beartype.beartype
 def unflatten(g: jit_utils.GraphContext, input, dim, unflattened_size):
     input_rank = symbolic_helper._get_tensor_rank(input)
+    input_shape = symbolic_helper._get_tensor_sizes(input)
+    dim = symbolic_helper._maybe_get_const(dim, "i")
+    unflattened_size = symbolic_helper._parse_arg(unflattened_size, "is")
+    
     if input_rank is None:
         return symbolic_helper._unimplemented(
             "input_dim",
@@ -5146,7 +5149,6 @@ def unflatten(g: jit_utils.GraphContext, input, dim, unflattened_size):
     if dim < 0:
         dim = input_rank + dim
 
-    input_shape = symbolic_helper._get_tensor_sizes(input)
     shape = [*input_shape[:dim], *unflattened_size, *input_shape[dim + 1 :]]
     return reshape(g, input, shape)
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -264,6 +264,7 @@ __all__ = [
     "true_divide",
     "type_as",
     "unbind",
+    "unflatten",
     "unfold",
     "unsafe_chunk",
     "unsafe_split_with_sizes",
@@ -5127,6 +5128,30 @@ def flatten(g: jit_utils.GraphContext, input, start_dim, end_dim):
 
     return symbolic_helper._flatten_helper(g, input, start_dim, end_dim, dim)
 
+@_onnx_symbolic("aten::unflatten")
+@symbolic_helper.quantized_args(True, False, False)
+@symbolic_helper.parse_args("v", "i", "is")
+@_beartype.beartype
+def unflatten(g: jit_utils.GraphContext, input, dim, unflattened_size):
+    input_dim = symbolic_helper._get_tensor_rank(input)
+    if input_dim is None:
+        return symbolic_helper._unimplemented(
+            "input_dim",
+            "ONNX and PyTorch use different strategies to split the input. "
+            "Input rank must be known at export time.",
+            input,
+        )
+
+    if dim < 0:
+        dim = input_dim + dim
+
+    input_shape = symbolic_helper._get_tensor_sizes(input)
+    shape = [
+        *input_shape[:dim],
+        *unflattened_size,
+        *input_shape[dim + 1:]
+    ]
+    return reshape(g, input, shape)
 
 @_onnx_symbolic("aten::nonzero")
 @symbolic_helper.parse_args("v")

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -5133,8 +5133,8 @@ def flatten(g: jit_utils.GraphContext, input, start_dim, end_dim):
 @symbolic_helper.parse_args("v", "i", "is")
 @_beartype.beartype
 def unflatten(g: jit_utils.GraphContext, input, dim, unflattened_size):
-    input_dim = symbolic_helper._get_tensor_rank(input)
-    if input_dim is None:
+    input_rank = symbolic_helper._get_tensor_rank(input)
+    if input_rank is None:
         return symbolic_helper._unimplemented(
             "input_dim",
             "ONNX and PyTorch use different strategies to split the input. "
@@ -5143,7 +5143,7 @@ def unflatten(g: jit_utils.GraphContext, input, dim, unflattened_size):
         )
 
     if dim < 0:
-        dim = input_dim + dim
+        dim = input_rank + dim
 
     input_shape = symbolic_helper._get_tensor_sizes(input)
     shape = [

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -5128,6 +5128,7 @@ def flatten(g: jit_utils.GraphContext, input, start_dim, end_dim):
 
     return symbolic_helper._flatten_helper(g, input, start_dim, end_dim, dim)
 
+
 @_onnx_symbolic("aten::unflatten")
 @symbolic_helper.quantized_args(True, False, False)
 @symbolic_helper.parse_args("v", "i", "is")
@@ -5146,12 +5147,9 @@ def unflatten(g: jit_utils.GraphContext, input, dim, unflattened_size):
         dim = input_rank + dim
 
     input_shape = symbolic_helper._get_tensor_sizes(input)
-    shape = [
-        *input_shape[:dim],
-        *unflattened_size,
-        *input_shape[dim + 1:]
-    ]
+    shape = [*input_shape[:dim], *unflattened_size, *input_shape[dim + 1 :]]
     return reshape(g, input, shape)
+
 
 @_onnx_symbolic("aten::nonzero")
 @symbolic_helper.parse_args("v")


### PR DESCRIPTION
When trying to export to onnx a model, calling tensor.unflatten, the following error occurs:
```
torch.onnx.errors.UnsupportedOperatorError: Exporting the operator 'aten::unflatten' to ONNX opset version 11 is not supported. Please feel free to request support or submit a pull request on PyTorch GitHub: https://github.com/pytorch/pytorch/issues.
```

Converting ```input.unflatten``` to ```input.view``` fixes this issue.

Fixes #49538
