### PR TITLE
Handle cuda driver shutown (cudaErrorCudartUnloading) in cuda check

### DIFF
--- a/c10/cuda/CUDAException.cpp
+++ b/c10/cuda/CUDAException.cpp
@@ -16,7 +16,8 @@ void c10_cuda_check_implementation(
     const int line_number,
     const bool include_device_assertions) {
   const auto cuda_error = static_cast<cudaError_t>(err);
-  const auto cuda_kernel_failure = include_device_assertions
+  const auto cuda_kernel_failure =
+      include_device_assertions && cuda_error != cudaErrorCudartUnloading
       ? c10::cuda::CUDAKernelLaunchRegistry::get_singleton_ref().has_failed()
       : false;
 


### PR DESCRIPTION
During exit, some dtors may attempt to run CUDA calls on already destroyed objects/after the cudart has been shutdown, `cudaErrorCudartUnloading` is returned (eg, cudaEventDestroy is called on an event after cudart shutdown).

This PR adds a check to correctly handle this case.

@puririshi98 @ptrblck 