### PR TITLE
Checking for nullptr in get_model_bytecode_version

### DIFF
--- a/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
@@ -108,6 +108,7 @@ uint64_t _get_model_bytecode_version_zip(
 }
 
 uint64_t _get_model_bytecode_version_from_bytes(char* data, size_t size) {
+  TORCH_CHECK(data != nullptr, "Pointer to bytes is null.");
   TORCH_CHECK(size >= kFileFormatHeaderSize, "Unrecognized data format");
   auto format = getFileFormat(data);
   switch (format) {


### PR DESCRIPTION
One-liner commit to check that the ptr is not null. Just had `test_jit` that had a segfault there. 