### PR TITLE
Enable bitwise shift operations tests

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryShiftOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryShiftOpsKernels.cu
@@ -15,6 +15,10 @@ void lshift_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "lshift_cuda", [&]() {
     gpu_kernel_with_scalars(iter,
       []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+        constexpr scalar_t max_shift = sizeof(scalar_t) * CHAR_BIT;
+        if ((static_cast<std::make_signed_t<scalar_t>>(b) < 0) || (b >= max_shift)) {
+          return 0;
+        }
         return static_cast<std::make_unsigned_t<scalar_t>>(a) << b;
     });
   });
@@ -24,6 +28,11 @@ void rshift_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "rshift_cuda", [&]() {
     gpu_kernel_with_scalars(iter,
       []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+        // right shift value to retain sign bit for signed and no bits for unsigned
+        constexpr scalar_t max_shift = sizeof(scalar_t) * CHAR_BIT - std::is_signed_v<scalar_t>;
+        if ((static_cast<std::make_signed_t<scalar_t>>(b) < 0) || (b >= max_shift)) {
+          return a >> max_shift;
+        }
         return a >> b;
     });
   });

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -3134,10 +3134,10 @@ class TestBinaryUfuncs(TestCase):
         self.assertEqual(a >> 1, expected_r)
         self.compare_with_numpy(lambda x: x >> 1, lambda x: np.right_shift(x, 1), a)
 
-    @onlyCPU
+    @onlyNativeDeviceTypes
     @dtypes(*get_all_int_dtypes())
     def test_shift_limits(self, device, dtype):
-        "Ensure that CPU integer bit shifting works as expected with out-of-limits shift values."
+        "Ensure that integer bit shifting works as expected with out-of-limits shift values."
         # Issue #70904
         iinfo = torch.iinfo(dtype)
         bits = iinfo.bits


### PR DESCRIPTION
With #70904 fixed, we can remove the skips for the bitwise shift tests.

