### PR TITLE
Add all_reduce_coalesced functional collective

### DIFF
--- a/aten/src/ATen/native/Collectives.cpp
+++ b/aten/src/ATen/native/Collectives.cpp
@@ -20,6 +20,10 @@ at::Tensor all_reduce(at::Tensor const& self, const c10::string_view reduceOp, c
     TORCH_INTERNAL_ASSERT(false);
 }
 
+std::vector<at::Tensor> all_reduce_coalesced(TensorList self, const c10::string_view reduceOp, const c10::string_view tag, c10::ArrayRef<int64_t> ranks, int64_t group_size) {
+    TORCH_INTERNAL_ASSERT(false);
+}
+
 at::Tensor all_gather_into_tensor(at::Tensor const& shard, const c10::string_view tag, c10::ArrayRef<int64_t> ranks, int64_t group_size) {
     TORCH_INTERNAL_ASSERT(false);
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14744,6 +14744,13 @@
   dispatch:
     CompositeExplicitAutograd: wait_tensor
 
+- func: all_reduce_coalesced(Tensor[] self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor[]
+  # This should be changed to distributed but it requires changes all over the place to work
+  python_module: nn
+  dispatch:
+    CompositeExplicitAutograd: all_reduce_coalesced
+  variants: function
+
 # This op is ONLY used by pytorch/XLA in functionalization, and should never show up in vanilla eager mode or in any pytorch tracing contexts.
 - func: _propagate_xla_data(Tensor input, Tensor output) -> ()
   variants: function

--- a/test/expect/HasDecompTest.test_has_decomposition.expect
+++ b/test/expect/HasDecompTest.test_has_decomposition.expect
@@ -576,6 +576,7 @@ aten::alias_copy
 aten::alias_copy.out
 aten::all_gather_into_tensor
 aten::all_reduce
+aten::all_reduce_coalesced
 aten::allclose
 aten::angle
 aten::angle.out

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3007,6 +3007,9 @@
 - name: all_reduce(Tensor self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor
   self: non_differentiable
 
+- name: all_reduce_coalesced(Tensor[] self, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor[]
+  self: non_differentiable
+
 - name: all_gather_into_tensor(Tensor shard, str tag, int[] ranks, int group_size) -> Tensor
   shard: non_differentiable
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -554,6 +554,7 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     "_nested_tensor_storage_offsets",
     # Functional collectives keep an internal ref through the Work object
     "all_reduce",
+    "all_reduce_coalesced",
     "all_gather_into_tensor",
     "reduce_scatter_tensor",
     "wait_tensor",

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4053,6 +4053,123 @@ class CollectiveKernel(ExternKernel):
         wrapper.writeline(f"_register_tensor_work({output_name}, {output_name}_work)")
 
 
+class MultiOutputNoSizeAssert(MultiOutput):
+    """
+    Extract partial output from a multi-output OP.
+        Works like MultiOutput but doesn't assert size. This must be a property guaranteed by the op emiting this.
+    """
+
+    def codegen(self, wrapper):
+        wrapper.writeline(
+            f"{self.get_name()} = {self.inputs[0].get_name()}{self.index}"
+        )
+
+
+class ForceInPlace(ExternKernel):
+    """
+    Helper OP to encode an in/out argument that tries to make it inplace whenever possible.
+    Wrap the input of your inplace op to enable this behavior.
+
+    TODO: We should test whether wait_tensor can be a victim of reordering and lead to data races.
+    """
+
+    def codegen(self, wrapper):
+        input_name = self.inputs[0].codegen_reference()
+        output_name = self.get_name()
+        if not wrapper.did_reuse(self, self.inputs[0]):
+            wrapper.writeline(f"{output_name}.copy_({input_name}) #no reuse")
+
+    def __init__(self, layout, input):
+        input = self.realize_input(input)
+        super().__init__(None, layout, self.unwrap_storage([input]), ())
+        self.name = V.graph.register_buffer(self)
+
+    def should_allocate(self):
+        return True
+
+
+class AllReduceCoalesced(ExternKernel):
+    def __init__(self, layout, inputs, constant_args, reduce_op):
+        super().__init__(None, layout, inputs, constant_args)
+        self.reduce_op = reduce_op
+        self.name = V.graph.register_buffer(self)
+
+    def should_allocate(self):
+        return False
+
+    @classmethod
+    def create(
+        cls,
+        inputs: List["TensorBox"],
+        reduce_op: str,
+        tag: str,
+        ranks: List[int],
+        group_size: int,
+    ):
+        res = []
+
+        def wrap_input(var):
+            nonlocal res
+            op = ForceInPlace(
+                FlexibleLayout(var.get_device(), var.get_dtype(), var.get_size()), var
+            )
+            res.append(op)
+            return TensorBox.create(op)
+
+        inputs = list(map(wrap_input, inputs))
+
+        layout = MultiOutputLayout(inputs[0].get_device())
+
+        packed = AllReduceCoalesced(
+            layout=layout,
+            inputs=inputs,
+            constant_args=[tag, ranks, group_size],
+            reduce_op=reduce_op,
+        )
+        for i, in_t in enumerate(inputs):
+            res.append(
+                MultiOutputNoSizeAssert(
+                    FlexibleLayout(
+                        in_t.get_device(), in_t.get_dtype(), in_t.get_size()
+                    ),
+                    packed,
+                    f"[{i}]",
+                )
+            )
+        return res
+
+    def codegen(self, wrapper):
+        wrapper.add_import_once("import torch.distributed as dist")
+        wrapper.add_import_once(
+            "from torch.distributed._functional_collectives import _str_to_reduce_op, _register_tensor_work"
+        )
+        wrapper.add_import_once(
+            "from torch.distributed.distributed_c10d import _find_or_create_pg_by_ranks_and_tag"
+        )
+
+        output_name = self.get_name()
+        tag, ranks, group_size = self.constant_args
+
+        wrapper.writeline(
+            f"{output_name}_pg = _find_or_create_pg_by_ranks_and_tag('{tag}', {ranks}, {group_size})"
+        )
+
+        inputs = []
+        for inp in self.inputs:
+            inputs.append(inp.codegen_reference())
+
+        wrapper.writeline(f"{output_name} = [{','.join(inputs)}] ")
+
+        wrapper.writeline(
+            f"{output_name}_work = dist.all_reduce_coalesced("
+            f"{output_name}, "
+            f"op=_str_to_reduce_op('{str(self.reduce_op)}'), "
+            f"group={output_name}_pg, "
+            "async_op=True)"
+        )
+        wrapper.writeline(f"_register_tensor_work({inputs[0]}, {output_name}_work)")
+
+
 class AllReduce(CollectiveKernel):
     def __init__(self, layout, inputs, constant_args, reduce_op):
         super().__init__(layout, inputs, constant_args)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3893,6 +3893,11 @@ try:
             ir.AllReduce.create(input, reduce_op, tag, ranks, group_size)
         )
 
+    @register_lowering(aten.all_reduce_coalesced)
+    def all_reduce_coalesced(input, reduce_op, tag, ranks, group_size):
+        result = ir.AllReduceCoalesced.create(input, reduce_op, tag, ranks, group_size)
+        return list(map(TensorBox.create, result))
+
     @register_lowering(aten.all_gather_into_tensor)
     def all_gather_into_tensor(shard, tag, ranks, group_size):
         return TensorBox.create(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -213,7 +213,7 @@ class BaseSchedulerNode:
                 # o what have i done.  lets make this an api
                 or (
                     isinstance(self, ExternKernelSchedulerNode)
-                    and isinstance(self.node, ir.AllReduce)
+                    and isinstance(self.node, (ir.AllReduce, ir.ForceInPlace))
                 )
             )
             and config.inplace_buffers
@@ -333,7 +333,9 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
             # (would this have been fixed if I tracked mutations properly above?)
             return False
 
-        if not isinstance(self.node, torch._inductor.ir.AllReduce):
+        if not isinstance(
+            self.node, (torch._inductor.ir.AllReduce, torch._inductor.ir.ForceInPlace)
+        ):
             # TODO make this a property of the IR
             return False
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3093,6 +3093,11 @@ def all_reduce_meta(self, reduceOp, tag, rankset, group_size):
     return torch.empty_like(self)
 
 
+@register_meta(aten.all_reduce_coalesced)
+def all_reduce_coalesced_meta(self, reduceOp, tag, rankset, group_size):
+    return [torch.empty_like(t) for t in self]
+
+
 @register_meta(aten.all_gather_into_tensor)
 def all_gather_into_tensor_meta(shard, tag, rankset, group_size):
     out_size = list(shard.size())

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1,7 +1,7 @@
 import warnings
 
 import weakref
-from typing import Any, cast, List, Tuple, Union
+from typing import cast, List, Tuple, Union
 
 import sys
 import torch
@@ -102,6 +102,19 @@ def _wait_tensor(tensor: torch.Tensor) -> torch.Tensor:
         _wait_and_clear_tensor(data_ptr, version_and_work[0])
     return tensor
 
+class WaitHolder:
+    def __init__(self, lookup_tensor):
+        self.lookup_tensor = lookup_tensor
+
+    def lazy_init(self, tensor):
+        if self.lookup_tensor is None:
+            self.lookup_tensor = tensor
+
+    def wait_tensor(self):
+        if self.lookup_tensor is not None:
+            wait_tensor(self.lookup_tensor)
+            self.lookup_tensor = None
+
 class AsyncCollectiveTensor(torch.Tensor):
     r"""
     A Tensor wrapper subclass that is used to trigger a call to wait
@@ -115,13 +128,14 @@ class AsyncCollectiveTensor(torch.Tensor):
         return res
     """
     elem: torch.Tensor
+    _holder: WaitHolder
 
-    __slots__ = ['elem']
+    __slots__ = ['elem', '_holder']
 
     __torch_function__ = torch._C._disabled_torch_function_impl
 
     @staticmethod
-    def __new__(cls, elem: torch.Tensor):
+    def __new__(cls, elem: torch.Tensor, holder: WaitHolder):
 
         r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
             cls, elem.size(),
@@ -130,15 +144,23 @@ class AsyncCollectiveTensor(torch.Tensor):
             device=elem.device, requires_grad=False
         )
         r.elem = elem
+        r._holder = holder
         return r
 
     def __repr__(self):
         return f"AsyncCollectiveTensor({self.elem})"
 
+    def trigger_wait(self):
+        self._holder.wait_tensor()
+        return self
+
     @classmethod
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
-        def unwrap(e: Any):
-            return wait_tensor(e.elem)
+        def unwrap(e: AsyncCollectiveTensor):
+            # TODO do we need to insert a wait_tensor op for all tensors or just the first one?
+            # Given only first usage of any of the output tensors needs to wait, for now we emit only one wait
+            e._holder.wait_tensor()
+            return e.elem
 
         unwrapped_args = tree_map_only(AsyncCollectiveTensor, unwrap, args)
         unwrapped_kwargs = tree_map_only(AsyncCollectiveTensor, unwrap, kwargs)
@@ -166,6 +188,17 @@ def _all_reduce(self, reduceOp, tag, ranks, group_size):
     _register_tensor_work(inplace_tensor, work)
 
     return inplace_tensor
+
+def _all_reduce_coalesced(self, reduceOp, tag, ranks, group_size):
+    op = _str_to_reduce_op(reduceOp)
+    group = c10d._find_or_create_pg_by_ranks_and_tag(tag, ranks, group_size)
+    assert group is not None
+
+    inplace_tensor_list = [t.clone(memory_format=torch.contiguous_format) for t in self]
+    work = dist.all_reduce_coalesced(inplace_tensor_list, op=op, group=group, async_op=True)
+    _register_tensor_work(inplace_tensor_list[0], work)
+
+    return inplace_tensor_list
 
 def _all_gather_into_tensor(shard, tag, ranks, group_size):
     # TODO add dim support?
@@ -265,7 +298,7 @@ def _are_we_tracing() -> bool:
 def _maybe_wrap_tensor(self):
     if _are_we_tracing():
         return wait_tensor(self)
-    res = AsyncCollectiveTensor(self)
+    res = AsyncCollectiveTensor(self, WaitHolder(self))
     _register_wrapper_tensor(res, self)
     return res
 
@@ -368,12 +401,33 @@ def reduce_scatter_tensor(
     return res
 
 
+def all_reduce_coalesced(self: List[torch.Tensor], reduceOp: str, group: RANK_TYPES, tag: str = "") -> List[torch.Tensor]:
+    tag, rankset, group_size = _expand_group(group, tag)
+    tensor_list = torch._C._nn.all_reduce_coalesced(self, reduceOp, tag, rankset, group_size)  # type: ignore[attr-defined]
+
+    if _are_we_tracing():
+        return list(map(wait_tensor, tensor_list))
+
+    res = []
+    lookup_tensor = tensor_list[0]
+    wh = WaitHolder(lookup_tensor)
+    for tensor in tensor_list:
+        act = AsyncCollectiveTensor(tensor, wh)
+        res.append(cast(torch.Tensor, act))
+
+    # FIXME we should register all tensors and ref count when to emit the wait
+    _register_wrapper_tensor(res[0], lookup_tensor)
+    return res
+
 c10_lib_cpu = torch.library.Library("aten", "IMPL", "CPU")
 c10_lib_cuda = torch.library.Library("aten", "IMPL", "CUDA")
 
 def _register_ops():
     c10_lib_cpu.impl("all_reduce", _all_reduce)
     c10_lib_cuda.impl("all_reduce", _all_reduce)
+
+    c10_lib_cpu.impl("all_reduce_coalesced", _all_reduce_coalesced)
+    c10_lib_cuda.impl("all_reduce_coalesced", _all_reduce_coalesced)
 
     c10_lib_cpu.impl("wait_tensor", _wait_tensor)
     c10_lib_cuda.impl("wait_tensor", _wait_tensor)

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -70,13 +70,14 @@ class AllReduce:
         self.op = op.op
 
     def work(self, data):
-        tensors = []
-        for src_rank in range(0, len(data)):
-            tensors.append(data[src_rank][0])
-        res = _reduce_ops[self.op](tensors)
-        with torch.no_grad():
-            for src_rank in range(len(data)):
-                data[src_rank][0].copy_(res)
+        for i in range(len(data[0])):
+            tensors = []
+            for src_rank in range(0, len(data)):
+                tensors.append(data[src_rank][i])
+            res = _reduce_ops[self.op](tensors)
+            with torch.no_grad():
+                for src_rank in range(len(data)):
+                    data[src_rank][i].copy_(res)
 
 
 class AllGather:
@@ -268,6 +269,12 @@ class ProcessLocalGroup(dist.ProcessGroup):
             cls._terminate.clear()
 
     def allreduce(self, tensor_list, opts=AllreduceOptions()):
+        coll = ProcessLocalGroup._start_coll(AllReduce(opts.reduceOp), self)
+        res = coll.join(self._rank, tensor_list)
+        ProcessLocalGroup._end_coll(coll, self)
+        return res
+
+    def allreduce_coalesced(self, tensor_list, opts=AllreduceOptions()):
         coll = ProcessLocalGroup._start_coll(AllReduce(opts.reduceOp), self)
         res = coll.join(self._rank, tensor_list)
         ProcessLocalGroup._end_coll(coll, self)


### PR DESCRIPTION
Inductor codegen is suboptimal when calling all_reduce_coalesced with input args. We need to fix inductor's calling convention for that, or something else.

Might not work if any outputs is unused.

Test code:

```python
import torch
import torch.distributed as dist
import torch.nn.functional as F
from functorch import make_fx
import os

import torch.distributed._functional_collectives as ft_c
from torch.testing._internal.common_distributed import (
    spawn_threads_and_init_comms,
)
from torch._inductor.compile_fx import compile_fx_inner

def my_fun(a, b):
    c = a * 3
    tensors = ft_c.all_reduce_coalesced([a, c, b], "sum", [0])
    return ((tensors[1] + tensors[0] + tensors[2]).sum(), )

@spawn_threads_and_init_comms(world_size=1)
def inductor_main(self):

    x = torch.arange(4).cuda() * (dist.get_rank() + 1)
    y = torch.arange(4).cuda() * (dist.get_rank() + 1)
    x = x.to(torch.float)
    y = y.to(torch.float) * 0.5
    res = make_fx(my_fun)(x, y)
    print(f"fx graph:\n{res.graph}")
    ind = compile_fx_inner(res, [x, y])
    print(f"inductor done:\n{ind}")

os.environ["PROXY_TENSOR_TRACING"] = "1"
os.environ["TORCH_COMPILE_DEBUG"] = "1"
torch._dynamo.config.output_code = True

if __name__ == "__main__":
    inductor_main(None)
```



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire