### PR TITLE
Allow fused optimizers to call _foreach_zero_ in zero_grad

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -446,7 +446,7 @@ class Optimizer:
                 (in one case it does the step with a gradient of 0 and in the other it skips
                 the step altogether).
         """
-        foreach = self.defaults.get('foreach', False)
+        foreach = self.defaults.get('foreach', False) or self.defaults.get('fused', False)
 
         if not hasattr(self, "_zero_grad_profile_name"):
             self._patch_step_function()


### PR DESCRIPTION
Fixes #97032
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97159

