### PR TITLE
Use internal symbolizer for FBCODE

### DIFF
--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -1,3 +1,4 @@
+#include <ATen/Context.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <torch/csrc/cuda/memory_snapshot.h>
 #include <torch/csrc/jit/runtime/interpreter.h>
@@ -113,6 +114,7 @@ void _record_memory_history(
       recorder = gather;
     }
   }
+  at::globalContext().lazyInitCUDA();
   c10::cuda::CUDACachingAllocator::recordHistory(
       enabled, recorder, trace_alloc_max_entries, trace_alloc_record_context);
 }

--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -294,7 +294,13 @@ std::vector<void*> unwind() {
   return frames;
 }
 
-std::vector<Frame> symbolize(const std::vector<void*>& frames) {
+#ifdef FBCODE_CAFFE2
+// in CUDA binaries, we have to use the internal symbolizer because
+// addr2line seems to hang.
+__attribute__((weak))
+#endif
+std::vector<Frame>
+symbolize(const std::vector<void*>& frames) {
   // we need to make sure we don't write more than 64k bytes to
   // a pipe before reading the results. Otherwise the buffer may
   // get filled and block before we read the results.


### PR DESCRIPTION
Summary:
addr2line does not work fast on fbcode binaries, so use the
internally symbolize pathway.

Test Plan: sandcastle

Differential Revision: D44227690

