### PR TITLE
warn on future reshape alias mutation violations

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -332,6 +332,7 @@ intern_build_aten_ops(
     extra_impls = aten_ufunc_generated_cpu_kernel_sources("aten/src/ATen/{}"),
     deps = [
         ":aten_headers",
+        "//c10",
         "@fbgemm",
         "@mkl",
         "@sleef",
@@ -1629,6 +1630,8 @@ cc_library(
         ":caffe2",
         ":torch_headers",
         "//caffe2/proto:torch_cc_proto",
+        "//c10/core/impl/cow:enable_instrumentation",
+        "//c10/core/impl/cow:spy",
         "@kineto",
     ] + if_cuda([
         "@cuda//:nvToolsExt",

--- a/aten/src/ATen/core/copy_on_write.cpp
+++ b/aten/src/ATen/core/copy_on_write.cpp
@@ -1,0 +1,18 @@
+#include <ATen/core/copy_on_write.h>
+
+#include <ATen/core/TensorBase.h>
+#include <c10/util/Exception.h>
+
+namespace at {
+
+auto simulate_materialize_copy_on_write(TensorBase const& tensor) -> void {
+  if (!tensor.has_storage()) {
+    return;
+  }
+
+  c10::TensorImpl* tensor_impl = tensor.unsafeGetTensorImpl();
+  TORCH_INTERNAL_ASSERT(tensor_impl != nullptr);
+  tensor_impl->maybe_bump_copy_on_write_generation();
+}
+
+} // namespace at

--- a/aten/src/ATen/core/copy_on_write.h
+++ b/aten/src/ATen/core/copy_on_write.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace at {
+
+class TensorBase;
+
+// Materializes any copy on write tensors that are getting written to.
+auto simulate_materialize_copy_on_write(TensorBase const& tensor) -> void;
+
+} // namespace at

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1139,16 +1139,14 @@ Tensor make_qtensor(const Tensor& self, IntArrayRef size, IntArrayRef stride, Qu
 Tensor as_strided_tensorimpl(const Tensor& self, IntArrayRef size, IntArrayRef stride, optional<int64_t> storage_offset_) {
   TORCH_INTERNAL_ASSERT(!self.is_mps(), "as_strided_tensorimpl does not work with MPS; call self.as_strided(...) instead");
   auto storage_offset = storage_offset_.value_or(self.storage_offset());
-  auto result = at::detail::make_tensor<TensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
+  auto result = Tensor::wrap_tensor_impl(self.unsafeGetTensorImpl()->take_view());
   setStrided(result, size, stride, storage_offset);
   return result;
 }
 
 Tensor as_strided_tensorimpl_meta(const Tensor& self, IntArrayRef size, IntArrayRef stride, optional<int64_t> storage_offset_) {
   auto storage_offset = storage_offset_.value_or(self.storage_offset());
-  auto result = at::detail::make_tensor<TensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
+  auto result = Tensor::wrap_tensor_impl(self.unsafeGetTensorImpl()->take_view());
   setStrided(result, size, stride, storage_offset);
   return result;
 }
@@ -1165,8 +1163,7 @@ inline void setStridedUnchecked(
 
 Tensor as_strided_tensorimpl_meta_symint(const Tensor& self, SymIntArrayRef sym_size, SymIntArrayRef sym_stride, optional<c10::SymInt> sym_storage_offset_) {
   auto sym_storage_offset = sym_storage_offset_.value_or(self.sym_storage_offset());
-  auto result = at::detail::make_tensor<TensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
+  auto result = Tensor::wrap_tensor_impl(self.unsafeGetTensorImpl()->take_view());
   // NB: The reason this is unchecked is to ensure we don't generate
   // guards on the base storage itself when performing as_strided calls.
   // Although technically these guards are necessary, in practice they
@@ -1544,7 +1541,11 @@ template <typename Vec>
 Tensor alias_with_sizes_and_strides(
     const Tensor& self,
     const Vec& sizes,
-    const Vec& strides) {
+    const Vec& strides,
+    // If true, continue to return an alias, but instrument the
+    // TensorImpl such that it can detect if any future writes are
+    // subsequently read through this tensor.
+    bool simulate_copy_on_write) {
   //caller should make sure that sizes and strides are valid for self
   //(storage is sufficient, strides are non-negative, strides and sizes array size is the same)
   Tensor self_;
@@ -1555,8 +1556,10 @@ Tensor alias_with_sizes_and_strides(
     self_tmp_->set_storage_offset(self.storage_offset());
     self_tmp_->set_sizes_and_strides(sizes, strides);
   } else {
-    self_ = at::detail::make_tensor<TensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
+    const TensorImpl& tensor_impl = *self.unsafeGetTensorImpl();
+    intrusive_ptr<TensorImpl> new_tensor_impl = simulate_copy_on_write ? tensor_impl.simulate_copy_on_write()
+                                                                       : tensor_impl.take_view();
+    self_ = Tensor::wrap_tensor_impl(std::move(new_tensor_impl));
     auto* self_tmp_ = self_.unsafeGetTensorImpl();
     self_tmp_->set_storage_offset(self.storage_offset());
     self_tmp_->set_sizes_and_strides(sizes, strides);
@@ -1568,10 +1571,6 @@ Tensor alias_with_sizes_and_strides(
 Tensor reshape_symint(const Tensor& self, c10::SymIntArrayRef proposed_shape) {
   if (self.is_sparse()) {
     AT_ERROR("reshape is not implemented for sparse tensors");
-  }
-
-  if (self.is_contiguous() && !self.is_mkldnn()) {
-    return self.view_symint(proposed_shape);
   }
 
   c10::SymDimVector shape = infer_size_dv(proposed_shape, self.sym_numel());
@@ -1672,7 +1671,7 @@ Tensor _reshape_alias(const Tensor& self, IntArrayRef sizes, IntArrayRef strides
   // to `view`. This removes the overhead of calling `view` which duplicates some of
   // the work that's already been done (`infer_size_dv` and `computeStride`).
 
-  return alias_with_sizes_and_strides(self, sizes, strides);
+  return alias_with_sizes_and_strides(self, sizes, strides, /*simulate_copy_on_write=*/true);
 }
 
 Tensor reshape_as(const Tensor& self, const Tensor& other) {
@@ -3264,7 +3263,7 @@ inline Tensor view_impl(const Tensor& self, IntArrayRef size) {
   TORCH_CHECK(stride.has_value(), "view size is "
     "not compatible with input tensor's size and stride (at least one dimension"
     " spans across two contiguous subspaces). Use .reshape(...) instead.");
-  return alias_with_sizes_and_strides(self, inferred_size, *stride);
+  return alias_with_sizes_and_strides(self, inferred_size, *stride, /*simulate_copy_on_write=*/false);
 
 }
 
@@ -3650,7 +3649,7 @@ Tensor view(const Tensor& self,
 }
 
 Tensor alias(const Tensor& self) {
-  return alias_with_sizes_and_strides(self, self.sizes(), self.strides());
+  return alias_with_sizes_and_strides(self, self.sizes(), self.strides(), /*simulate_copy_on_write=*/false);
 }
 
 Tensor detach(const Tensor& self) {

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -940,8 +940,7 @@ Tensor as_strided_tensorimpl_mps(const Tensor& self,
                                  IntArrayRef stride,
                                  c10::optional<int64_t> storage_offset_) {
   auto storage_offset = storage_offset_.value_or(self.storage_offset());
-  auto result =
-      detail::make_tensor<TensorImpl>(c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
+  auto result = Tensor::wrap_tensor_impl(self.unsafeGetTensorImpl()->take_view());
   setStrided(result, size, stride, storage_offset);
 
   // creating the view graph will be deferred until gatherViewTensor() or scatterViewTensor() are called.

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -103,6 +103,7 @@ jit_core_sources = [
 # list for the shared files.
 
 core_sources_common = [
+    "torch/csrc/autograd/VariableTypeUtils.cpp",
     "torch/csrc/autograd/autograd_meta.cpp",
     "torch/csrc/autograd/forward_grad.cpp",
     "torch/csrc/jit/frontend/edit_distance.cpp",
@@ -1019,6 +1020,7 @@ aten_cpu_source_non_codegen_list = [
     "aten/src/ATen/core/VariableHooksInterface.cpp",
     "aten/src/ATen/core/Vitals.cpp",
     "aten/src/ATen/core/boxing/KernelFunction.cpp",
+    "aten/src/ATen/core/copy_on_write.cpp",
     "aten/src/ATen/core/custom_class.cpp",
     "aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp",
     "aten/src/ATen/core/dispatch/Dispatcher.cpp",

--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -29,6 +29,7 @@ file(GLOB C10_SRCS
         *.cpp
         core/*.cpp
         core/impl/*.cpp
+        core/impl/cow/*.cpp
         mobile/*.cpp
         macros/*.cpp
         util/*.cpp
@@ -37,6 +38,7 @@ file(GLOB C10_HEADERS
         *.h
         core/*.h
         core/impl/*.h
+        core/impl/cow/*.h
         mobile/*.h
         macros/*.h
         util/*.h

--- a/c10/core/StorageImpl.cpp
+++ b/c10/core/StorageImpl.cpp
@@ -1,1 +1,15 @@
 #include <c10/core/StorageImpl.h>
+
+namespace c10 {
+
+intrusive_ptr<impl::cow::ShadowStorage> StorageImpl::simulate_copy_on_write(
+    impl::cow::ShadowStorage* shadow_storage) {
+  return copy_on_write_state_.simulate_lazy_copy(shadow_storage);
+}
+
+void StorageImpl::maybe_bump_copy_on_write_generation(
+    impl::cow::ShadowStorage* shadow_storage) {
+  copy_on_write_state_.maybe_bump(shadow_storage);
+}
+
+} // namespace c10

--- a/c10/core/build.bzl
+++ b/c10/core/build.bzl
@@ -79,6 +79,8 @@ def define_targets(rules):
         visibility = ["//visibility:public"],
         deps = [
             ":ScalarType",
+            "//c10/core/impl/cow:shadow_storage",
+            "//c10/core/impl/cow:state_machine",
             "//c10/macros",
             "//c10/util:TypeCast",
             "//c10/util:base",

--- a/c10/core/impl/cow/BUILD.bazel
+++ b/c10/core/impl/cow/BUILD.bazel
@@ -1,0 +1,4 @@
+load("//:tools/bazel.bzl", "rules")
+load(":build.bzl", "define_targets")
+
+define_targets(rules = rules)

--- a/c10/core/impl/cow/README.md
+++ b/c10/core/impl/cow/README.md
@@ -1,0 +1,152 @@
+Copy-on-Write Storage
+=====================
+
+Motivation
+----------
+PyTorch inherited from NumPy an optimization on the reshape function
+that produces a view as an output if it can be represented as
+such. This complicates the work of the PyTorch compilation stack
+because it needs to understand the representation of the input in
+order to understand if the output will be a copy or an alias.
+
+The compilation stack would rather not be concerned with such details,
+motivating the Stride Agnostic PyTorch project.
+
+To address reshape specifically, we wish to simplify the
+implementation to *always* copy, but copy lazily upon modification if
+we can represent the output as a view.
+
+Implementation plan
+-------------------
+We have not implemented copy-on-write tensors yet, because this is a
+backward incompatible change (see Backward Incompatible section
+below). But this is the design.
+
+A copy-on-write tensor, also known as a lazily-copied tensor, is
+initially going to be created by an operation like reshape which would
+historically have created a view. We wish to maintain the performance
+of the view but drop the aliasing aspect. Note that there is desire
+for copy-on-write tensors outside of reshape, so we will likely also
+want to add a public operator that can do this. It could be named
+"lazy_clone" or something similar.
+
+The core tenet of the design is that we wish to maintain the invariant
+that Tensors alias if and only if they share a storage. Thus when we
+create a lazy-copy, we will need to create a new storage. We also will
+have to modify the source storage, since it also must now be lazily
+copied.
+
+The algorithm for creating a new copy-on-write tensor (and also
+converting the source to copy-on-write) is as follows:
+
+```
+def lazy_clone(src: Tensor) -> Tensor:
+    # First ensure that the source has a copy-on-write enabled storage.
+    # We implement this using a custom context on the DataPtr. The
+    # source tensor might already have this enabled, but if it doesn't,
+    # convert it.
+    if not has_copy_on_write_context(src.storage().storage_impl()):
+        if not(wrap_with_copy_on_write_context(src.storage().storage_impl())):
+            # For whatever reason, we weren't able to wrap the DataPtr.
+            # We have to do an eager copy.
+            return src.clone()
+
+    new_storage = fork_copy_on_write_storage(src.storage()) # can't fail
+    # Now just create a new tensor using the new storage.
+    return new Tensor(storage=new_storage, sizes_and_strides_like=src)
+```
+
+That's the high level algorithm. The copy-on-write context that we
+introduce is morally just a refcount on the underlying physical data
+pointer. Each unique storage represents a set of tensors that share a
+view and thus will hold a single refcount on the context.
+
+Now we just need to intercept writes to the storage and materialize
+them. We can use a few mechanisms to do this:
+
+1) autograd knows which operators write to which tensor inputs. We can
+   materialize at that point when autograd is enabled.
+2) if autograd is not enabled, we can introduce a new dispatch key
+   that does the same trick
+3) we can also materialize whenever there's mutable access to the data
+   pointer through any of `at::Tensor`, `c10::TensorImpl`,
+   `c10::Storage`, `c10::StorageImpl`, or `c10::DataPtr`. With the
+   current codebase, this will be too aggressive, but we will refactor
+   to have a minimal set of mutable accesses.
+
+Backwards incompatibiility
+--------------------------
+Changing reshape to produce a copy is a backwards incompatible change,
+because users could be relying on the aliasing behavior, intentionally
+or not.
+
+For one release, rather than returning copy-on-write tensors, we
+instead warn when users have triggered behavior in their program that
+relies on the aliasing of the output and input.
+
+To do this, we must simulate the behavior in a backward compatible
+way. To remain backward compatible, the aliases must preserve the
+invariant that they have the same storage. This is a big deviation
+from the design detailed above. To get closer to the real design and
+implementation, we introduce a new `c10::TensorImpl` level concept
+called "Shadow Storage". The shadow storage represents what the
+storage would have looked like the view actually been a lazy copy.
+
+In the instrumented world we thus maintain the formal invariant that
+tensors that alias share a storage. But we have a new invariant:
+tensors that are lazy-copies of each other will share a shadow
+storage.
+
+So what do we warn on? We warn if there is a write to a tensor in a
+set that shares a shadow storage followed by a read or a write to a
+different tensor that shares a physical storage but has a different
+shadow storage. In the real implementation, the first write would have
+triggered a copy, forever cleaving the two sets of tensors, but in the
+current world we instead had behavior that relied on the view-ness of
+the output of reshape.
+
+We can track these violations simply by adding a generation number to
+the shadow and physical storages, updating them both on writes and
+observing if a read or write ever encounters values that are out of
+sync.
+
+We have a few mechanisms for tracking reads and writes:
+ * reads can be tracked by const accesses to the data pointer
+ * writes can be tracked by mutable accesses to the data pointer
+ * writes may also be tracked via autograd, using the same mechanism
+   to bump version numbers
+
+Note that we presently are only checking via autograd, since we don't
+have const access to the data pointer, so we would be way too
+aggressive if we assumed every access was a real write.
+
+### Optimizations to the instrumentation
+Technically, every tensor will require a shadow storage, because if we
+were to create a view of a tensor and then create a lazy-copy, both
+the original tensor and the view would have to share the shadow
+storage, and thus it has to be created and shared before we ever even
+know we needed it.
+
+But we don't want to pay the memory cost of this since we don't expect
+it to be that common. We can get around this by saving the original
+shadow storage on the physical storage itself. We will have an
+asymmetrical rule that states that any tensor that has a null shadow
+storage will instead get its shadow storage from the physical
+storage. This allows us to avoid refcount bumps on the shadow storage
+as well as deferring any generation number bumps until we actually
+have an outstanding copy on write.
+
+The simulation instrumentation itself will be unnecessary to maintain
+once we can transition to enabling lazy copies. This may happen after
+the first that goes out which contains the instrumentation and the
+user warning.
+
+Future work
+-----------
+* enrich the warning by flagging reads/writes to data pointer after a
+  big refactoring
+* analyze violations of the warning and make a decision about whether
+  we require any coordination about the BC change or if we should just
+  let the warning run its course
+* implement the actual copy on write
+* simplify the compiler stack to no longer concern itself with this

--- a/c10/core/impl/cow/build.bzl
+++ b/c10/core/impl/cow/build.bzl
@@ -1,0 +1,47 @@
+def define_targets(rules):
+    rules.cc_library(
+        name = "enable_instrumentation",
+        hdrs = ["enable_instrumentation.h"],
+        visibility = ["//:__pkg__"],  # for module torch._C
+    )
+
+    rules.cc_library(
+        name = "shadow_storage",
+        srcs = ["shadow_storage.cpp"],
+        hdrs = ["shadow_storage.h"],
+        deps = [
+            "//c10/macros",
+            "//c10/util:base",
+        ],
+        visibility = [
+            "//c10/core:__pkg__",
+            "//c10/test/core/impl/cow:__pkg__",
+        ],
+    )
+
+    rules.cc_library(
+        name = "spy",
+        srcs = ["spy.cpp"],
+        hdrs = ["spy.h"],
+        deps = [
+            ":shadow_storage",
+            "//c10/core:base",
+            "//c10/macros",
+            "//c10/util:base",
+        ],
+        visibility = ["//:__pkg__"],
+    )
+
+    rules.cc_library(
+        name = "state_machine",
+        srcs = ["state_machine.cpp"],
+        hdrs = ["state_machine.h"],
+        deps = [
+            ":shadow_storage",
+            "//c10/util:base",
+        ],
+        visibility = [
+            "//c10/core:__pkg__",
+            "//c10/test/core/impl/cow:__pkg__",
+        ],
+    )

--- a/c10/core/impl/cow/enable_instrumentation.h
+++ b/c10/core/impl/cow/enable_instrumentation.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace c10::impl::cow {
+
+constexpr auto enable_instrumentation() -> bool {
+#if defined(PYTORCH_INSTRUMENT_COW_TENSOR)
+  return true;
+#else
+  return false;
+#endif
+}
+
+} // namespace c10::impl::cow

--- a/c10/core/impl/cow/shadow_storage.cpp
+++ b/c10/core/impl/cow/shadow_storage.cpp
@@ -1,0 +1,67 @@
+#include <c10/core/impl/cow/shadow_storage.h>
+
+#include <c10/util/Exception.h>
+
+#include <limits>
+
+namespace c10::impl {
+
+cow::ShadowStorage::ShadowStorage(Generation generation) noexcept
+    : generation_(generation) {}
+
+auto cow::ShadowStorage::generation() const noexcept -> Generation {
+  return generation_;
+}
+
+namespace {
+
+// Write the warning from a function because if we write it from a
+// template, it will warn once for every template instantiation.
+auto warn_on_write_after_write() -> void {
+  TORCH_WARN_ONCE(
+      "You have written through to both aliases created by calling reshape(). "
+      "In the future, reshape() will never create a view but will return a "
+      "lazily copied tensor. If you wish to preserve the aliasing properties, "
+      "you should rewrite your reshape() as a view().");
+}
+
+} // namespace
+
+auto cow::ShadowStorage::update_from_physical_generation(
+    Generation physical_generation) noexcept -> void {
+  TORCH_INTERNAL_ASSERT(physical_generation != 0);
+
+  Generation shadow_generation = generation_.exchange(physical_generation);
+  TORCH_INTERNAL_ASSERT(shadow_generation <= physical_generation);
+
+  if (shadow_generation + 1 != physical_generation) {
+    warn_on_write_after_write();
+  }
+}
+
+cow::ShadowStorageMixin::ShadowStorageMixin(
+    intrusive_ptr<cow::ShadowStorage> shadow_storage)
+#if defined(PYTORCH_INSTRUMENT_COW_TENSOR)
+    : shadow_storage_(std::move(shadow_storage))
+#endif
+{
+}
+
+auto cow::ShadowStorageMixin::shadow_storage() const -> cow::ShadowStorage* {
+#if defined(PYTORCH_INSTRUMENT_COW_TENSOR)
+  return shadow_storage_.get();
+#else
+  return nullptr;
+#endif
+}
+
+auto cow::ShadowStorageMixin::shadow_storage_ref() const
+    -> intrusive_ptr<cow::ShadowStorage> {
+#if defined(PYTORCH_INSTRUMENT_COW_TENSOR)
+  return shadow_storage_;
+#else
+  return nullptr;
+#endif
+}
+
+} // namespace c10::impl

--- a/c10/core/impl/cow/shadow_storage.h
+++ b/c10/core/impl/cow/shadow_storage.h
@@ -1,0 +1,100 @@
+#pragma once
+
+// This file provides two public types: ShadowStorage and
+// ShadowStorageNonIntrusive.
+//
+// See ShadowStorageImpl to understand the interface of these types.
+
+#include <c10/macros/Macros.h>
+#include <c10/util/intrusive_ptr.h>
+
+#include <atomic>
+#include <cstdint>
+#include <type_traits>
+
+namespace c10::impl::cow {
+
+// Represents the shadow storage for a tensor.
+//
+// For simulated lazy copies, the shadow storage represents the what
+// the storage would have been for a tensor that was lazily
+// copied. However, when simulating this, we can't actually replace
+// the storage because we would violate a core implementation
+// invariant that tensors which are views of each other share the same
+// storage.
+//
+// However, the fidelity of this check is limited by the extent to
+// which we have instrumented operations as reading or writing to
+// storage.
+//
+// We use a monotonically increasing generation number to track
+// modifications to storage.
+//
+// Note that we templatize on whether or not we are eligible to be
+// allocated into an intrusive_ptr. It *seems* as though ASan is
+// unhappy if we stack-allocate an object that inherits from
+// c10::intrusive_ptr_target.
+class C10_API ShadowStorage final : private intrusive_ptr_target {
+ public:
+  /** The type of the generation number. */
+  using Generation = std::int64_t;
+
+  // Creates an instance from an existing storage generation.
+  explicit ShadowStorage(Generation generation) noexcept;
+
+  // Gets the current generation.
+  auto generation() const noexcept -> Generation;
+
+  // Sets the generation from the physical generation, warning if they
+  // do not agree.
+  auto update_from_physical_generation(Generation physical_generation) noexcept
+      -> void;
+
+ private:
+  // From the user's perspective, copies are fully distinct and
+  // require no external synchronization, so we need to ensure this
+  // field's concurrency is properly managed.
+  std::atomic<Generation> generation_;
+
+  friend intrusive_ptr<ShadowStorage>;
+};
+
+// A mixin to be used on TensorImpl that gives it a shadow storage.
+//
+// We add this as a mixin because we desire the ability to toggle
+// shadow storage tracking at compilation time. If disabled, this
+// becomes an empty class and the empty base class optimization will
+// make this add no weight to TensorImpl.
+class C10_API ShadowStorageMixin {
+ protected:
+  // Initialize the field from a possibly null shadow_storage.
+  explicit ShadowStorageMixin(intrusive_ptr<cow::ShadowStorage> shadow_storage);
+
+  // Gets the possibly null shadow storage.
+  //
+  // Use this by default.
+  auto shadow_storage() const -> cow::ShadowStorage*;
+
+  // Gets a reference to the possibly null shadow storage.
+  //
+  // Only use this if you wish to have another reference to the same
+  // instance, for example, when taking a view.
+  auto shadow_storage_ref() const -> intrusive_ptr<cow::ShadowStorage>;
+
+ private:
+#if defined(PYTORCH_INSTRUMENT_COW_TENSOR)
+  // Invariant: this is always null if a copy on write was never
+  // requested.
+  //
+  // This *may* be null if a copy on write was requested and this
+  // tensor is part of the original view family. Subsequent view
+  // families will have this set, but the original one only gets its
+  // value from the storage.
+  //
+  // This is asymmetrical, but it allows us to avoid the allocation
+  // and any refcount bumps until we actually need them.
+  intrusive_ptr<impl::cow::ShadowStorage> shadow_storage_;
+#endif
+};
+
+} // namespace c10::impl::cow

--- a/c10/core/impl/cow/spy.cpp
+++ b/c10/core/impl/cow/spy.cpp
@@ -1,0 +1,22 @@
+#include <c10/core/impl/cow/spy.h>
+
+#include <c10/core/Storage.h>
+#include <c10/core/StorageImpl.h>
+#include <c10/core/TensorImpl.h>
+#include <c10/util/Exception.h>
+
+namespace c10::impl {
+
+/* static */ auto cow::Spy::get_generation(Storage const& storage)
+    -> std::uint64_t {
+  TORCH_INTERNAL_ASSERT(storage);
+  return storage.unsafeGetStorageImpl()
+      ->copy_on_write_state_.physical_generation();
+}
+
+/* static */ auto cow::Spy::get_shadow_storage(TensorImpl const& tensor)
+    -> ShadowStorage const* {
+  return tensor.shadow_storage();
+}
+
+} // namespace c10::impl

--- a/c10/core/impl/cow/spy.h
+++ b/c10/core/impl/cow/spy.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+
+#include <c10/core/impl/cow/shadow_storage.h>
+#include <c10/macros/Macros.h>
+
+namespace c10 {
+struct Storage;
+struct TensorImpl;
+} // namespace c10
+
+namespace c10::impl::cow {
+
+// Allows for introspection into TensorImpl and StorageImpl's
+// copy-on-write state.
+class Spy {
+ public:
+  // Gets the generation number from the storage.
+  static C10_API auto get_generation(Storage const& tensor) -> std::uint64_t;
+  // Gets the shadow storage instance from the tensor.
+  static C10_API auto get_shadow_storage(TensorImpl const& tensor)
+      -> ShadowStorage const*;
+};
+
+} // namespace c10::impl::cow

--- a/c10/core/impl/cow/state_machine.cpp
+++ b/c10/core/impl/cow/state_machine.cpp
@@ -1,0 +1,149 @@
+#include <c10/core/impl/cow/state_machine.h>
+
+#include <c10/util/Exception.h>
+#include <c10/util/Optional.h>
+
+#include <mutex>
+
+namespace c10::impl {
+
+class cow::StateMachine::Impl {
+ public:
+  // Bumps the physical and shadow generation numbers.
+  auto bump(cow::ShadowStorage* maybe_shadow_storage) -> void;
+
+  /** @see cow::StateMachine::simulate_lazy_copy */
+  auto simulate_lazy_copy(cow::ShadowStorage* maybe_shadow_storage)
+      -> intrusive_ptr<cow::ShadowStorage>;
+
+ private:
+  friend class cow::StateMachine;
+
+  // Guards all the state.
+  std::mutex mtx_;
+  // How many writes have been applied to the storage.
+  //
+  // How are physical and shadow generation numbes distinct?
+  //
+  // * the physical generation is how many writes have occured to a storage
+  // * the shadow generation is how many writes have occurred to a set
+  //   of tensors which share a view
+  //
+  // Since storage is 1:many with sets of tensors sharing a view, we
+  // expect physical_generation to always be greater than or equal to
+  // the shadow generation number.
+  cow::StateMachine::Generation physical_generation_ = 0;
+  // The shadow storage to use for any tensors that don't have
+  // one. This situation is common, and will be true for tensors and
+  // views thereof created before any copy on writes.
+  cow::ShadowStorage default_shadow_storage_{physical_generation_};
+};
+
+cow::StateMachine::StateMachine() : impl_(nullptr) {}
+
+cow::StateMachine::~StateMachine() {
+  // If we created an impl, we are responsible for cleaning this up
+  // here.
+  delete impl_.load();
+}
+
+auto cow::StateMachine::physical_generation() -> Generation {
+  Impl* impl = maybe_get_impl();
+  return impl != nullptr ? impl->physical_generation_ : 0;
+}
+
+auto cow::StateMachine::maybe_bump(cow::ShadowStorage* maybe_shadow_storage)
+    -> void {
+  Impl* impl = maybe_get_impl();
+  if (impl == nullptr) {
+    // Any created shadow storage should be bound to the physical
+    // storage that it was created from. Hence, there should only be a
+    // shadow storage on a tensor if its own storage created it. We
+    // don't check for the specific matching of the storage and shadow
+    // storage, but we do check that the presence relationship holds.
+    //
+    TORCH_INTERNAL_ASSERT(maybe_shadow_storage == nullptr);
+    return;
+  }
+
+  impl->bump(maybe_shadow_storage);
+}
+
+auto cow::StateMachine::simulate_lazy_copy(
+    cow::ShadowStorage* maybe_shadow_storage)
+    -> intrusive_ptr<cow::ShadowStorage> {
+  return ensure_initialized().simulate_lazy_copy(maybe_shadow_storage);
+}
+
+auto cow::StateMachine::maybe_get_impl() -> cow::StateMachine::Impl* {
+  // Use Release-Consume ordering to ensure that any creation of an
+  // impl will sequence before any read of that impl.
+  return impl_.load(std::memory_order_consume);
+}
+
+auto cow::StateMachine::ensure_initialized() -> cow::StateMachine::Impl& {
+  // We can get away with a relaxed load here because in the worst
+  // case we'll get the real value below instead.
+  if (Impl* impl = impl_.load(std::memory_order_relaxed); impl != nullptr) {
+    return *impl;
+  }
+
+  // We are not initialized. Speculatively create an implementation
+  // and see if we win.
+  auto new_impl = std::make_unique<cow::StateMachine::Impl>();
+
+  Impl* actual_impl = nullptr;
+  // Use Release-Acquire ordering to ensure that any creation of an
+  // impl will sequence before any read of that impl.
+  if (!impl_.compare_exchange_strong(
+          actual_impl, &*new_impl, std::memory_order_acq_rel)) {
+    // We raced with another initializer and lost. Return the
+    // current impl, which is asserted to be active inside
+    // as_state_machine_impl().
+    TORCH_INTERNAL_ASSERT(actual_impl != nullptr);
+    return *actual_impl;
+  }
+
+  return *new_impl.release(); // owned by impl_ now
+}
+
+namespace {
+
+// Applies a function to whichever shadow storage is active.
+//
+// Note that we templatize on the shadow storage types because they
+// may or may not be const. The bare types will always be
+// ShadowStorage and ShadowStorageNonIntrusive.
+auto active_shadow_storage(
+    cow::ShadowStorage* shadow_storage,
+    cow::ShadowStorage& default_shadow_storage) -> cow::ShadowStorage& {
+  if (shadow_storage != nullptr) {
+    return *shadow_storage;
+  }
+  return default_shadow_storage;
+}
+
+} // namespace
+
+auto cow::StateMachine::Impl::bump(cow::ShadowStorage* maybe_shadow_storage)
+    -> void {
+  std::lock_guard<std::mutex> lock(mtx_);
+  TORCH_INTERNAL_ASSERT(
+      physical_generation_ != std::numeric_limits<Generation>::max());
+  Generation physical_generation = ++physical_generation_;
+  active_shadow_storage(maybe_shadow_storage, default_shadow_storage_)
+      .update_from_physical_generation(physical_generation);
+}
+
+auto cow::StateMachine::Impl::simulate_lazy_copy(
+    cow::ShadowStorage* maybe_shadow_storage)
+    -> intrusive_ptr<cow::ShadowStorage> {
+  // We grab the lock here unconditionally. No need to check the
+  // current state first.
+  std::lock_guard<std::mutex> lock(mtx_);
+  return make_intrusive<cow::ShadowStorage>(
+      active_shadow_storage(maybe_shadow_storage, default_shadow_storage_)
+          .generation());
+}
+
+} // namespace c10::impl

--- a/c10/core/impl/cow/state_machine.h
+++ b/c10/core/impl/cow/state_machine.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <c10/core/impl/cow/shadow_storage.h>
+#include <c10/macros/Macros.h>
+#include <c10/util/intrusive_ptr.h>
+
+#include <cstdint>
+
+namespace c10::impl::cow {
+
+// Responsible for managing the copy-on-write simulation state
+// machine.
+//
+// This type manages the following transition:
+
+// 1) A tensor is created. It has a StateMachine instance that is in
+//    the StateId::initial state. There are no shadow storages. This tensor and
+//    any views created from it will have a null shadow storage.
+//
+// 2) A lazy copy is created, e.g. from Tensor::reshape(). This
+//    transitions from StateId::initializing and then finally to
+//    StateId::active. At this point a StateMachine::Impl has been
+//    allocated on the heap.
+//
+//    The Tensor that was the source of the lazy copy, and any views
+//    created from it, will still have a null shadow storage pointer,
+//    but its actual shadow storage will be in
+//    Impl::default_shadow_storage.
+class C10_API StateMachine {
+ public:
+  /** @see cow::ShadowStorage::Generation */
+  using Generation = cow::ShadowStorage::Generation;
+
+  // Constructs an instance in the "initial" state.
+  StateMachine();
+
+  // Responsible for cleaning up any implementation details.
+  ~StateMachine();
+
+  // Gets the current generation of the physical storage.
+  //
+  // Reminder: no tracking occurs until simulate_lazy_copy() is
+  // called.
+  auto physical_generation() -> Generation;
+
+  // Bumps the physical generation and updates the appropriate shadow
+  // storage to the new value, warning if there is an unexpected gap.
+  //
+  // This is called by a TensorImpl that is being written to. The
+  // shadow storage parameter to this function will be the shadow
+  // storage of the calling tensor.
+  //
+  // The very first tensor, and any views derived from it, have a null
+  // shadow storage member as a performance optimization: we try to
+  // make this "pay for what you use" as much as possible. A lazy copy
+  // may be performed on that tensor *only* after it is created. Thus
+  // if we wish to defer allocation of a shadow storage for a tensor,
+  // then there will be at least one and possibly many views that will
+  // not have a shadow storage.
+  //
+  // We get around this problem by storing the shadow storage for the
+  // initial tensor and its views on the storage object itself
+  // (i.e. here). We call this `default_shadow_storage_`.
+  auto maybe_bump(cow::ShadowStorage* maybe_shadow_storage) -> void;
+
+  // Simulates a lazy copy a tensor that owns the shadow storage.
+  //
+  // maybe_shadow_storage comes from the tensor that is being lazily
+  // copied. This may be null if this is the first lazy copy taking
+  // place, or if the lazy copy is being performed on a tensor that
+  // was part of the original tensors that share a view.
+  //
+  // The generation of the output will come from:
+  // 1) maybe_shadow_storage->generation(), if non-null.
+  // 2) this->default_shadow_storage_->generation(), if it is set.
+  // 3) physical_generation_, i.e. 0, if this is the first lazy copy.
+  auto simulate_lazy_copy(cow::ShadowStorage* maybe_shadow_storage)
+      -> intrusive_ptr<cow::ShadowStorage>;
+
+ private:
+  class Impl;
+
+  /** Gets the underlying Impl, returning null if uninitialized. */
+  auto maybe_get_impl() -> Impl*;
+  /** Gets the underlying Impl, initializing if uninitialized. */
+  auto ensure_initialized() -> Impl&;
+
+  // The current representation of the storage instance.
+  std::atomic<Impl*> impl_;
+};
+
+} // namespace c10::impl::cow

--- a/c10/test/build.bzl
+++ b/c10/test/build.bzl
@@ -5,6 +5,7 @@ def define_targets(rules):
             ":core_tests",
             ":typeid_test",
             ":util_base_tests",
+            "//c10/test/core/impl/cow:test",
         ],
         visibility = ["//:__pkg__"],
     )

--- a/c10/test/core/impl/cow/BUILD.bazel
+++ b/c10/test/core/impl/cow/BUILD.bazel
@@ -1,0 +1,4 @@
+load("//:tools/bazel.bzl", "rules")
+load(":build.bzl", "define_targets")
+
+define_targets(rules = rules)

--- a/c10/test/core/impl/cow/build.bzl
+++ b/c10/test/core/impl/cow/build.bzl
@@ -1,0 +1,11 @@
+def define_targets(rules):
+    rules.cc_test(
+        name = "test",
+        size = "small",
+        srcs = ["test.cpp"],
+        deps = [
+            "@com_google_googletest//:gtest_main",
+            "//c10/core/impl/cow:shadow_storage",
+            "//c10/core/impl/cow:state_machine",
+        ],
+    )

--- a/c10/test/core/impl/cow/test.cpp
+++ b/c10/test/core/impl/cow/test.cpp
@@ -1,0 +1,145 @@
+#include <c10/core/impl/cow/shadow_storage.h>
+#include <c10/core/impl/cow/state_machine.h>
+#include <c10/util/Exception.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+namespace c10 {
+
+// Provide a GoogleTest printer for the Warning type.
+void PrintTo(Warning const& warning, std::ostream* out) {
+  *out << warning.msg();
+}
+} // namespace c10
+
+namespace c10::impl::cow {
+namespace {
+
+// Implements WarningHandler and just stores seen warnings.
+//
+// Users are responsible for ensuring that all warnings are checked
+// for: any uninspected warnings will cause a test failure.
+class CapturingWarningHandler final : public WarningHandler {
+ public:
+  ~CapturingWarningHandler() final {
+    // Ensure that users do not leave uninspected warnings.
+    EXPECT_THAT(release_warnings(), testing::IsEmpty());
+  }
+
+  // See WarningHandler::process.
+  auto process(Warning const& warning) -> void final {
+    warnings_.push_back(warning);
+  }
+
+  // Releases any captured warnings to the user.
+  auto release_warnings() -> std::vector<Warning> {
+    return std::move(warnings_);
+  }
+
+ private:
+  // All captured warnings.
+  std::vector<Warning> warnings_;
+};
+
+// A test fixture that captures any warnings.
+class CaptureWarningsTest : public testing::Test {
+ protected:
+  // Releases any captured warnings to the caller.
+  auto release_warnings() -> std::vector<Warning> {
+    return warning_handler_.release_warnings();
+  }
+
+ private:
+  // We install our capturing warning handler for the scope of each
+  // test.
+  CapturingWarningHandler warning_handler_;
+  WarningUtils::WarningHandlerGuard override_warning_handler_{
+      &warning_handler_};
+};
+
+// We don't need any other test setup, just capture any warnings in
+// our test fixture.
+using CopyOnWriteTest = CaptureWarningsTest;
+
+TEST_F(CopyOnWriteTest, ShadowStorage) {
+  cow::ShadowStorage shadow_storage(/*generation=*/0);
+  ASSERT_THAT(shadow_storage.generation(), testing::Eq(0));
+  shadow_storage.update_from_physical_generation(1); // must not warn
+  ASSERT_THAT(shadow_storage.generation(), testing::Eq(1));
+}
+
+TEST_F(CopyOnWriteTest, StateMachineWithoutShadowStorage) {
+  cow::StateMachine state;
+  state.maybe_bump(nullptr);
+  ASSERT_THAT(state.physical_generation(), testing::Eq(0));
+}
+
+// Implement a matcher that verifies a warning has a message as a
+// substring.
+MATCHER_P(IsWarning, msg, "") {
+  return arg.msg().find(msg) != std::string::npos;
+}
+
+// Test our behavior with multiple view families.
+TEST_F(CopyOnWriteTest, MultipleViewFamilies) {
+  cow::StateMachine state;
+  intrusive_ptr<cow::ShadowStorage> family_2 =
+      state.simulate_lazy_copy(nullptr);
+
+  // Bump the second view family.
+  state.maybe_bump(&*family_2);
+
+  ASSERT_THAT(release_warnings(), testing::IsEmpty());
+
+  WarningUtils::WarnAlways enable_warn_always_mode;
+
+  // Bump the first view family. This will warn since we've bumped,
+  // i.e. written to, the second family.
+  state.maybe_bump(/*shadow_storage=*/nullptr);
+
+  ASSERT_THAT(
+      release_warnings(),
+      testing::ElementsAre(IsWarning(
+          "You have written through to both aliases created by calling reshape")));
+
+  // This will also warn, because we've just written the first view
+  // family.
+  state.maybe_bump(&*family_2);
+  ASSERT_THAT(
+      release_warnings(),
+      testing::ElementsAre(IsWarning(
+          "You have written through to both aliases created by calling reshape")));
+}
+
+// This test is mostly identical to the previous test, except it
+// doesn't run in WarnAlways mode. This verifies that the warn-once
+// setting is respected.
+TEST_F(CopyOnWriteTest, OnlyWarnsOnce) {
+  cow::StateMachine state;
+  intrusive_ptr<cow::ShadowStorage> family_2 =
+      state.simulate_lazy_copy(nullptr);
+
+  // Bump the second view family.
+  state.maybe_bump(&*family_2);
+
+  // Bump the first view family. This will warn since we've bumped,
+  // i.e. written to, the second family.
+  state.maybe_bump(/*shadow_storage=*/nullptr);
+
+  ASSERT_THAT(
+      release_warnings(),
+      testing::ElementsAre(IsWarning(
+          "You have written through to both aliases created by calling reshape")));
+
+  // This should also warn, because we've just written the first view
+  // family. However, the code is configured to only warn once, so it
+  // does not.
+  state.maybe_bump(&*family_2);
+  ASSERT_THAT(release_warnings(), testing::IsEmpty());
+}
+
+} // namespace
+} // namespace c10::impl::cow

--- a/setup.py
+++ b/setup.py
@@ -1112,6 +1112,7 @@ def main():
         'include/ATen/core/dispatch/*.h',
         'include/ATen/core/op_registration/*.h',
         'include/c10/core/impl/*.h',
+        'include/c10/core/impl/cow/*.h',
         'include/c10/util/*.h',
         'include/c10/cuda/*.h',
         'include/c10/cuda/impl/*.h',

--- a/test/test_copy_on_write.py
+++ b/test/test_copy_on_write.py
@@ -1,0 +1,56 @@
+# Owner(s): ["module: viewing and reshaping", "module: internals"]
+
+import warnings
+
+import pytest
+
+import torch
+
+@pytest.mark.skipif(not torch._C._enable_cow_instrumentation(), reason="requires lazy-copy instrumentation")
+def test_copy_on_write_warns():
+    t = torch.ones(4)
+    u = t.reshape(2, 2)
+
+    # Writing any number of times to just one of the "views" is fine.
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        # Writing once to t is fine.
+        t.add_(torch.arange(4))
+        # Even writing twice to t is fine.
+        t.add_(torch.ones(4))
+        # Taking a view from the lazy copy we haven't written is also fine.
+        v = u.view(4)
+
+    # But writing to (or reading from) u after we've written to t is a problem, because
+    # u is still sharing t's storage.
+    with pytest.warns(UserWarning, match='You have written through to both aliases created by calling reshape().'):
+        u.add_(torch.ones(4).view(2, 2))
+
+@pytest.mark.skipif(not torch._C._enable_cow_instrumentation(), reason="requires lazy-copy instrumentation")
+def test_copy_on_write():
+    t = torch.ones(4)
+    assert torch._C._get_shadow_storage_generation(t) is None
+    assert torch._C._get_storage_generation(t) == 0
+
+    u = t.reshape(2, 2)  # this will be a copy in the future
+    assert not torch._C._has_same_shadow_storage(t, u)
+    assert torch._C._get_shadow_storage_generation(u) == 0
+    assert torch._C._get_storage_generation(u) == 0
+
+    v = t.view(2, 2)
+    assert torch._C._has_same_shadow_storage(t, v)
+    assert not torch._C._has_same_shadow_storage(u, v)
+    assert torch._C._get_shadow_storage_generation(v) is None
+    assert torch._C._get_storage_generation(v) == 0
+
+    # Write to t: t and u alias, so they both see bumps.
+    t.add_(torch.ones(4))
+    assert torch._C._get_shadow_storage_generation(t) is None
+    assert torch._C._get_storage_generation(t) == 1
+    assert torch._C._get_shadow_storage_generation(v) is None
+    assert torch._C._get_storage_generation(v) == 1
+
+    # But u will not alias in the future, so its copy-on-write generation will not
+    # change.
+    assert torch._C._get_shadow_storage_generation(u) == 0
+    assert torch._C._get_storage_generation(u) == 1

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from importlib import import_module
 from torch.utils._pytree import tree_map
 from typing import Dict
-from torch.testing import make_tensor
+from torch.testing import assert_close, make_tensor
 from torch.testing._internal.common_dtype import (
     floating_and_complex_types_and,
     all_types_and_complex_and,
@@ -589,6 +589,97 @@ class TestCommon(TestCase):
             actual = op(n_inp, *n_args, **n_kwargs)
 
             self.assertEqual(actual, expected)
+
+            # Validate backward
+            # Short-circuits if the op doesn't support grad in this device x dtype
+            if not test_grad:
+                continue
+
+            expected = sample_input.output_process_fn_grad(expected)
+            actual = sample_input.output_process_fn_grad(actual)
+
+            if isinstance(expected, torch.Tensor):
+                grad_for_expected = torch.randn_like(expected)
+                grad_for_actual = noncontiguous_like(grad_for_expected)
+            elif isinstance(expected, Sequence):
+                # Filter output elements that do not require grad
+                expected = [
+                    t
+                    for t in expected
+                    if isinstance(t, torch.Tensor) and t.requires_grad
+                ]
+                actual = [
+                    n for n in actual if isinstance(n, torch.Tensor) and n.requires_grad
+                ]
+                grad_for_expected = [torch.randn_like(t) for t in expected]
+                grad_for_actual = [noncontiguous_like(n) for n in grad_for_expected]
+            else:
+                # Nothing to do if it returns a scalar or things like that
+                continue
+
+            # Concatenate inputs into a tuple
+            t_inputs = (
+                (t_inp,) + t_args
+                if isinstance(t_inp, torch.Tensor)
+                else tuple(t_inp) + t_args
+            )
+            n_inputs = (
+                (n_inp,) + n_args
+                if isinstance(n_inp, torch.Tensor)
+                else tuple(n_inp) + n_args
+            )
+
+            # Filter the elemnts that are tensors that require grad
+            t_input_tensors = [
+                t for t in t_inputs if isinstance(t, torch.Tensor) and t.requires_grad
+            ]
+            n_input_tensors = [
+                n for n in n_inputs if isinstance(n, torch.Tensor) and n.requires_grad
+            ]
+
+            self.assertEqual(len(t_input_tensors), len(n_input_tensors))
+
+            # Some functions may not use all the inputs to generate gradients. One of the
+            # few examples of this "odd" behaviour is F.hinge_embedding_loss
+            t_grads = torch.autograd.grad(
+                expected, t_input_tensors, grad_for_expected, allow_unused=True
+            )
+            n_grads = torch.autograd.grad(
+                actual, n_input_tensors, grad_for_actual, allow_unused=True
+            )
+
+            msg = "Got different gradients for contiguous / non-contiguous inputs wrt input {}."
+            for i, (t, n) in enumerate(zip(t_grads, n_grads)):
+                self.assertEqual(t, n, msg=msg.format(i))
+
+    @unittest.skipIf(not torch._C._enable_cow_instrumentation(), "copy on write not instrumented")
+    @onlyNativeDeviceTypes
+    @suppress_warnings
+    @ops(op_db, allowed_dtypes=(torch.float32, torch.long, torch.complex64))
+    def test_lazy_copy_samples(self, device, dtype, op):
+        """Test that operators succeed with a lazily copied tensor input."""
+
+        test_grad = dtype in op.supported_backward_dtypes(torch.device(device).type)
+        test_grad = False
+        sample_inputs = op.sample_inputs(device, dtype, requires_grad=test_grad)
+        for sample_input in sample_inputs:
+            t_inp, t_args, t_kwargs = (
+                sample_input.input,
+                sample_input.args,
+                sample_input.kwargs,
+            )
+            transformed_sample = sample_input.lazy_copy()
+            n_inp, n_args, n_kwargs = (
+                transformed_sample.input,
+                transformed_sample.args,
+                transformed_sample.kwargs,
+            )
+
+            # validates forward
+            expected = op(t_inp, *t_args, **t_kwargs)
+            actual = op(n_inp, *n_args, **n_kwargs)
+
+            assert_close(actual, expected, equal_nan=True)
 
             # Validate backward
             # Short-circuits if the op doesn't support grad in this device x dtype

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -17,6 +17,9 @@
 #include <ATen/dlpack.h>
 #include <ATen/native/ConvUtils.h>
 #include <c10/core/DispatchKeySet.h>
+#include <c10/core/impl/cow/enable_instrumentation.h>
+#include <c10/core/impl/cow/shadow_storage.h>
+#include <c10/core/impl/cow/spy.h>
 #include <c10/util/Logging.h>
 #include <c10/util/irange.h>
 #include <libshm.h>
@@ -1642,6 +1645,40 @@ Call this whenever a new thread is created in order to propagate values from
   ASSERT_TRUE(set_module_attr("_" C10_STRINGIZE(PYBIND11_BUILD_ABI), Py_None));
 #endif
 #undef SET_STR_DEFINE
+
+  py_module.def(
+      "_enable_cow_instrumentation",
+      [] { return c10::impl::cow::enable_instrumentation(); },
+      "Returns whether or not we are simulating copy-on-write tensors.");
+
+  py_module.def(
+      "_has_same_shadow_storage",
+      [](const at::Tensor& x, const at::Tensor& y) {
+        return c10::impl::cow::Spy::get_shadow_storage(
+                   *x.unsafeGetTensorImpl()) ==
+            c10::impl::cow::Spy::get_shadow_storage(*y.unsafeGetTensorImpl());
+      },
+      "Returns whether or not two tensors have the same shadow storages.");
+
+  py_module.def(
+      "_get_shadow_storage_generation",
+      [](const at::Tensor& x) -> std::optional<std::uint64_t> {
+        auto shadow_storage =
+            c10::impl::cow::Spy::get_shadow_storage(*x.unsafeGetTensorImpl());
+        return shadow_storage != nullptr
+            ? std::make_optional(
+                  const_cast<c10::impl::cow::ShadowStorage&>(*shadow_storage)
+                      .generation())
+            : std::nullopt;
+      },
+      "Gets the shadow storage generation.");
+
+  py_module.def(
+      "_get_storage_generation",
+      [](const at::Tensor& x) {
+        return c10::impl::cow::Spy::get_generation(x.storage());
+      },
+      "Gets the generation of the underlying storage.");
 
   py_module.def(
       "_set_conj", [](const at::Tensor& x, bool conj) { x._set_conj(conj); });

--- a/torch/csrc/autograd/VariableTypeUtils.cpp
+++ b/torch/csrc/autograd/VariableTypeUtils.cpp
@@ -1,0 +1,17 @@
+#include <torch/csrc/autograd/VariableTypeUtils.h>
+
+#include <ATen/core/TensorBase.h>
+#include <ATen/core/copy_on_write.h>
+
+#include <algorithm>
+#include <functional>
+
+namespace torch::autograd {
+
+void simulate_materialize_copies_on_write(
+    c10::ArrayRef<std::reference_wrapper<const at::TensorBase>> tensors) {
+  std::for_each(
+      tensors.begin(), tensors.end(), at::simulate_materialize_copy_on_write);
+}
+
+} // namespace torch::autograd

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/ArrayRef.h>
 #include <c10/util/irange.h>
 
 #include <ATen/core/boxing/KernelFunction.h>
@@ -128,6 +129,11 @@ inline void rebase_history(
     }
   }
 }
+
+// Simulates materializing any tensors that have copy on write
+// storage.
+void simulate_materialize_copies_on_write(
+    c10::ArrayRef<std::reference_wrapper<const at::TensorBase>> tensors);
 
 inline void increment_version(const at::Tensor& t) {
   impl::bump_version(t);

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -10093,6 +10093,7 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestBwdGradients', 'test_fn_grad'),
                # Jacobian mismatch
                DecorateInfo(unittest.expectedFailure, 'TestBwdGradients', 'test_fn_gradgrad'),
+               DecorateInfo(unittest.skip('output is non-deterministic'), 'TestCommon', 'test_lazy_copy_samples'),
                DecorateInfo(unittest.expectedFailure, 'TestFwdGradients', 'test_forward_mode_AD'),
                DecorateInfo(unittest.skip("Barely fails"), 'TestFwdGradients', 'test_fn_fwgrad_bwgrad'),
                # JIT test not working for tensor kwargs (https://github.com/pytorch/pytorch/issues/58507)
@@ -15441,6 +15442,7 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.skip("Expected: empty_like is not comparable"), 'TestCompositeCompliance',
                             'test_operator'),
                DecorateInfo(unittest.skip('output is non-deterministic'), 'TestCommon', 'test_compare_cpu'),
+               DecorateInfo(unittest.skip('output is non-deterministic'), 'TestCommon', 'test_lazy_copy_samples'),
            )),
     OpInfo('zeros_like',
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16, torch.chalf),
@@ -15676,6 +15678,7 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.skip("Expected: new_empty is not comparable"),
                             'TestCommon', 'test_complex_half_reference_testing'),
                DecorateInfo(unittest.skip('output is non-deterministic'), 'TestCommon', 'test_compare_cpu'),
+               DecorateInfo(unittest.skip('output is non-deterministic'), 'TestCommon', 'test_lazy_copy_samples'),
            ),
            supports_autograd=False),
     OpInfo('new_empty_strided',
@@ -15726,6 +15729,7 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.skip("Expected: new_empty_strided is not comparable"),
                             'TestCudaFuserOpInfo', 'test_nvfuser_correctness'),
                DecorateInfo(unittest.skip('output is non-deterministic'), 'TestCommon', 'test_compare_cpu'),
+               DecorateInfo(unittest.skip('output is non-deterministic'), 'TestCommon', 'test_lazy_copy_samples'),
            )),
     OpInfo('empty',
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16, torch.chalf),


### PR DESCRIPTION
warn on future reshape alias mutation violations

Summary:
Copy-on-Write Storage
=====================

Motivation
----------
PyTorch inherited from NumPy an optimization on the reshape function
that produces a view as an output if it can be represented as
such. This complicates the work of the PyTorch compilation stack
because it needs to understand the representation of the input in
order to understand if the output will be a copy or an alias.

The compilation stack would rather not be concerned with such details,
motivating the Stride Agnostic PyTorch project.

To address reshape specifically, we wish to simplify the
implementation to *always* copy, but copy lazily upon modification if
we can represent the output as a view.

Implementation plan
-------------------
We have not implemented copy-on-write tensors yet, because this is a
backward incompatible change (see Backward Incompatible section
below). But this is the design.

A copy-on-write tensor, also known as a lazily-copied tensor, is
initially going to be created by an operation like reshape which would
historically have created a view. We wish to maintain the performance
of the view but drop the aliasing aspect. Note that there is desire
for copy-on-write tensors outside of reshape, so we will likely also
want to add a public operator that can do this. It could be named
"lazy_clone" or something similar.

The core tenet of the design is that we wish to maintain the invariant
that Tensors alias if and only if they share a storage. Thus when we
create a lazy-copy, we will need to create a new storage. We also will
have to modify the source storage, since it also must now be lazily
copied.

The algorithm for creating a new copy-on-write tensor (and also
converting the source to copy-on-write) is as follows:

```
def lazy_clone(src: Tensor) -> Tensor:
    # First ensure that the source has a copy-on-write enabled storage.
    # We implement this using a custom context on the DataPtr. The
    # source tensor might already have this enabled, but if it doesn't,
    # convert it.
    if not has_copy_on_write_context(src.storage().storage_impl()):
        if not(wrap_with_copy_on_write_context(src.storage().storage_impl())):
            # For whatever reason, we weren't able to wrap the DataPtr.
            # We have to do an eager copy.
            return src.clone()

    new_storage = fork_copy_on_write_storage(src.storage()) # can't fail
    # Now just create a new tensor using the new storage.
    return new Tensor(storage=new_storage, sizes_and_strides_like=src)
```

That's the high level algorithm. The copy-on-write context that we
introduce is morally just a refcount on the underlying physical data
pointer. Each unique storage represents a set of tensors that share a
view and thus will hold a single refcount on the context.

Now we just need to intercept writes to the storage and materialize
them. We can use a few mechanisms to do this:

1) autograd knows which operators write to which tensor inputs. We can
   materialize at that point when autograd is enabled.
2) if autograd is not enabled, we can introduce a new dispatch key
   that does the same trick
3) we can also materialize whenever there's mutable access to the data
   pointer through any of `at::Tensor`, `c10::TensorImpl`,
   `c10::Storage`, `c10::StorageImpl`, or `c10::DataPtr`. With the
   current codebase, this will be too aggressive, but we will refactor
   to have a minimal set of mutable accesses.

Backwards incompatibiility
--------------------------
Changing reshape to produce a copy is a backwards incompatible change,
because users could be relying on the aliasing behavior, intentionally
or not.

For one release, rather than returning copy-on-write tensors, we
instead warn when users have triggered behavior in their program that
relies on the aliasing of the output and input.

To do this, we must simulate the behavior in a backward compatible
way. To remain backward compatible, the aliases must preserve the
invariant that they have the same storage. This is a big deviation
from the design detailed above. To get closer to the real design and
implementation, we introduce a new `c10::TensorImpl` level concept
called "Shadow Storage". The shadow storage represents what the
storage would have looked like the view actually been a lazy copy.

In the instrumented world we thus maintain the formal invariant that
tensors that alias share a storage. But we have a new invariant:
tensors that are lazy-copies of each other will share a shadow
storage.

So what do we warn on? We warn if there is a write to a tensor in a
set that shares a shadow storage followed by a read or a write to a
different tensor that shares a physical storage but has a different
shadow storage. In the real implementation, the first write would have
triggered a copy, forever cleaving the two sets of tensors, but in the
current world we instead had behavior that relied on the view-ness of
the output of reshape.

We can track these violations simply by adding a generation number to
the shadow and physical storages, updating them both on writes and
observing if a read or write ever encounters values that are out of
sync.

We have a few mechanisms for tracking reads and writes:
 * reads can be tracked by const accesses to the data pointer
 * writes can be tracked by mutable accesses to the data pointer
 * writes may also be tracked via autograd, using the same mechanism
   to bump version numbers

Note that we presently are only checking via autograd, since we don't
have const access to the data pointer, so we would be way too
aggressive if we assumed every access was a real write.

### Optimizations to the instrumentation
Technically, every tensor will require a shadow storage, because if we
were to create a view of a tensor and then create a lazy-copy, both
the original tensor and the view would have to share the shadow
storage, and thus it has to be created and shared before we ever even
know we needed it.

But we don't want to pay the memory cost of this since we don't expect
it to be that common. We can get around this by saving the original
shadow storage on the physical storage itself. We will have an
asymmetrical rule that states that any tensor that has a null shadow
storage will instead get its shadow storage from the physical
storage. This allows us to avoid refcount bumps on the shadow storage
as well as deferring any generation number bumps until we actually
have an outstanding copy on write.

The simulation instrumentation itself will be unnecessary to maintain
once we can transition to enabling lazy copies. This may happen after
the first that goes out which contains the instrumentation and the
user warning.

Future work
-----------
* enrich the warning by flagging reads/writes to data pointer after a
  big refactoring
* analyze violations of the warning and make a decision about whether
  we require any coordination about the BC change or if we should just
  let the warning run its course
* implement the actual copy on write
* simplify the compiler stack to no longer concern itself with this

Test Plan: Added new tests.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/97175).
* #98536
* __->__ #97175

cc @ezyang @bhosmer @smessmer @ljk53 @bdhirsh