### PR TITLE
Added current buck target as minifier dep

### DIFF
--- a/test/inductor/minifier_smoke.py
+++ b/test/inductor/minifier_smoke.py
@@ -1,4 +1,6 @@
 # Owner(s): ["module: inductor"]
+import os
+
 os.environ["TORCHDYNAMO_REPRO_AFTER"] = "dynamo"
 import torch
 import torch._dynamo as torchdynamo

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -25,6 +25,9 @@ log = logging.getLogger(__name__)
 inductor_config = import_module("torch._inductor.config")
 use_buck = inductor_config.is_fbcode()
 
+if use_buck:
+    import libfb.py.build_info
+
 
 extra_deps = []
 extra_imports = ""
@@ -36,6 +39,7 @@ if use_buck:
         "//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu",
         "//deeplearning/fbgemm/fbgemm_gpu:sparse_ops",
     ]
+    cur_target = libfb.py.build_info.BuildInfo.get_build_rule().replace("fbcode:", "//")
     extra_imports = "\n".join([f'torch.ops.load_library("{x}")' for x in extra_deps])
 
 
@@ -71,6 +75,7 @@ python_binary(
         "//caffe2:torch",
         "//caffe2/functorch:functorch",
         "//triton:triton",
+        "{cur_target}",
     ],
     cpp_deps = [
 {extra_cpp_deps}


### PR DESCRIPTION
Summary: Have minifier include the current buck target as a dependency to make sure all deps are included.

Test Plan: TORCH_COMPILE_DEBUG_DIR=”.” buck2 run mode/dev-nosan //caffe2/test/inductor:minifier_smoke

Differential Revision: D44231209



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire