### PR TITLE
Fix regression on loading jit module from flatbuffer

### DIFF
--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -657,6 +657,7 @@ def script_module_to_buffer(script_module):
     return module_buffer
 
 
+# TODO(qihqi): This param is not setup correctly.
 @unittest.skipIf(
     not ENABLE_FLATBUFFER, "Need to enable flatbuffer to run the below tests"
 )

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -1745,7 +1745,9 @@ void jitModuleToPythonCodeAndConstants(
     class_deps.add(class_type);
   }
 
-  for (const auto i : c10::irange(class_deps.size())) {
+  for (size_t i = 0; i < class_deps.size(); ++i) {
+    // note: PythonPrint may extend class_deps, so re-checking .size() is
+    // necessary
     auto type = class_deps[i];
     auto qualname = uniquer.getUniqueName(type);
     std::string qualifier = qualname.prefix();


### PR DESCRIPTION
Summary:
https://fb.workplace.com/groups/pytorch.edge.users/permalink/1287477365455887

Root cause:
Introduced in D44106776. But this loop is wierd because class_dep can grow, so it cannot be replaced with c10::irange.

Test Plan:
Used model at `fbpkg fetch speech.tuna.milan.ondevice.en_us.transducer:6`
Then
`buck run xplat/caffe2/fb/lite_predictor:convert_model -- --model=$HOME/20230320debug/pytorchmodel.pt --output_name=/tmp/ffmodel.ff`

Differential Revision: D44234894

