### PR TITLE
eliminate typed data in Storage and StorageImpl

### DIFF
--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -60,16 +60,6 @@ struct C10_API Storage {
     set_data_ptr_noswap(allocator()->allocate(0));
   }
 
-  template <typename T>
-  T* data() const {
-    return storage_impl_->data<T>();
-  }
-
-  template <typename T>
-  T* unsafe_data() const {
-    return storage_impl_->unsafe_data<T>();
-  }
-
   // TODO: remove later
   void set_nbytes(size_t size_bytes) const {
     storage_impl_.get()->set_nbytes(size_bytes);

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -81,16 +81,6 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
     size_bytes_is_symbolic_ = false;
   }
 
-  template <typename T>
-  inline T* data() const {
-    return unsafe_data<T>();
-  }
-
-  template <typename T>
-  inline T* unsafe_data() const {
-    return static_cast<T*>(this->data_ptr_.get());
-  }
-
   // Destructor doesn't call release_resources because it's
   // unnecessary; don't forget to change that if needed!
   void release_resources() override {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1517,7 +1517,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         "Caffe2 uses a lazy allocation, so you will need to call "
         "mutable_data() or raw_mutable_data() to actually allocate memory.");
     // Caller does the type check.
-    return storage_.unsafe_data<T>() + storage_offset_;
+    return static_cast<T*>(storage_.data()) + storage_offset_;
   }
 
   /**
@@ -1555,7 +1555,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    */
   template <typename T>
   inline T* unsafe_data() const {
-    return storage_.unsafe_data<T>() + storage_offset_;
+    return static_cast<T*>(storage_.data()) + storage_offset_;
   }
 
   /**


### PR DESCRIPTION
eliminate typed data in Storage and StorageImpl

Summary:
Storage doesn't need to expose this, we can just move the cast up to
the tensor impl.

Test Plan: Rely on CI.

Reviewers: ezyang

Subscribers:

Tasks:

Tags:
