### PR TITLE
[pytorch@arvr/windows] Fix pytorch build/import on Windows @ ovrsource

### DIFF
--- a/torch/csrc/stub.c
+++ b/torch/csrc/stub.c
@@ -1,8 +1,5 @@
 #include <Python.h>
 
-#ifdef _WIN32
-__declspec(dllimport)
-#endif
 extern PyObject* initModule(void);
 
 #ifndef _WIN32


### PR DESCRIPTION
Summary:

- Importing torch on Windows can cause a crash within python.
- The problem was introduced by the change in `Module.cpp` from https://github.com/pytorch/pytorch/pull/94927
- The cause is that a call to `PyObject* initModule(void)` declared with a `__declspec(dllimport)` specifier can lead to a crash if the definition doesn't include the `__declspec(dllexport)` counterpart.
- To mitigate the problem without introducing  customized macros and changing the build system (note, `#include <c10/macros/Export.h>` doesn't work in `stub.c`) is to simply remove the `__declspec(dllimport)` specifier.
- According to https://web.archive.org/web/20140808231508/http://blogs.msdn.com/b/russellk/archive/2005/03/20/399465.aspx and other sources, `__declspec(dllimport)` only leads to some code optimizations, and since `initModule()` is only called once at startup, this is marginal.
- Note: the `stub_with_flatbuffer.c` file counterpart wasn't affected, therefore, not touched.

Differential Revision: D44236183

