### PR TITLE
Update NestedTensor add to support non identical striding for NT+NT

### DIFF
--- a/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
@@ -79,7 +79,10 @@ Tensor NestedTensor_elementwise_Tensor(
     const Tensor& self,
     const Tensor& other,
     const std::string& op_name,
+    bool supports_striding,
     Func f) {
+  Tensor self_contiguous = self;
+  Tensor other_contiguous = other;
   // self is a scalar
   if (!self.is_nested() && self.dim() == 0 && self.numel() == 1) {
     auto other_impl = get_nested_tensor_impl(other);
@@ -125,9 +128,8 @@ Tensor NestedTensor_elementwise_Tensor(
     }
 
     if (is_broadcastable_3d) {
-      if (!nested_tensor_impl_is_contiguous(self_ptr)) {
-        self_ptr = get_nested_tensor_impl(self.contiguous());
-      }
+      self_contiguous = self.contiguous();
+      self_ptr = get_nested_tensor_impl(self_contiguous);
       const auto self_buffer = self_ptr->get_buffer();
       const auto self_sizes = self_ptr->get_nested_sizes();
       auto result_buffer = at::empty_like(self_buffer);
@@ -146,8 +148,12 @@ Tensor NestedTensor_elementwise_Tensor(
 
   NestedTensorImpl* self_impl = nullptr;
   NestedTensorImpl* other_impl = nullptr;
+
+  self_contiguous = supports_striding ? self.contiguous() : self;
+  other_contiguous = supports_striding ? other.contiguous() : other;
+
   std::tie(self_impl, other_impl) =
-      get_elementwise_nested_tensor_impl(self, other, op_name);
+      get_elementwise_nested_tensor_impl(self_contiguous, other_contiguous, op_name);
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(self_impl);
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(other_impl);
   return wrap_buffer(
@@ -163,14 +169,14 @@ Tensor NestedTensor_add_Tensor(
     const Tensor& other,
     const Scalar& alpha) {
   return NestedTensor_elementwise_Tensor(
-      self, other, "add", [alpha](const Tensor& b1, const Tensor& b2) {
+      self, other, "add", true /* supports_striding*/, [alpha](const Tensor& b1, const Tensor& b2) {
         return at::add(b1, b2, alpha);
       });
 }
 
 Tensor NestedTensor_mul_Tensor(const Tensor& self, const Tensor& other) {
   return NestedTensor_elementwise_Tensor(
-      self, other, "mul", [](const Tensor& b1, const Tensor& b2) {
+      self, other, "mul", false /* supports_striding*/, [](const Tensor& b1, const Tensor& b2) {
         return at::mul(b1, b2);
       });
 }
@@ -182,7 +188,7 @@ Tensor NestedTensor_mul_Scalar(const Tensor& self, const Scalar& other) {
 
 Tensor NestedTensor_div_Tensor(const Tensor& self, const Tensor& other) {
   return NestedTensor_elementwise_Tensor(
-      self, other, "div", [](const Tensor& b1, const Tensor& b2) {
+      self, other, "div", false /* supports_striding*/, [](const Tensor& b1, const Tensor& b2) {
         return at::div(b1, b2);
       });
 }

--- a/aten/src/ATen/native/nested/NestedTensorFactories.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorFactories.cpp
@@ -121,5 +121,69 @@ Tensor& copy_nested_(Tensor& self, const Tensor& src, bool non_blocking) {
   return self;
 }
 
+
+Tensor clone_nested(
+    const Tensor& self,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  auto memory_format = optional_memory_format.value_or(c10::MemoryFormat::Preserve);
+  auto self_ptr = get_nested_tensor_impl(self);
+  if (memory_format == c10::MemoryFormat::Preserve ||
+  (memory_format == c10::MemoryFormat::Contiguous && self.is_contiguous())) {
+    const Tensor& buffer = self_ptr->get_unsafe_storage_as_tensor(),
+        sizemat = self_ptr->get_nested_sizes(),
+        stridemat = self_ptr->get_nested_strides();
+    const auto& offsets = self_ptr->get_storage_offsets();
+    // TODO: The size and the stride do not necessarily need to be cloned,
+    //       but it is more conservative.
+    //       This is something we could revisit once we land a more
+    //       efficient implementation of nested_sizes_ and nested_strides.
+    return wrap_buffer(buffer.clone(), sizemat.clone(), stridemat.clone(), offsets.clone());
+  }
+  // actually, memory format is contiguous and self is noncontiguous
+  else if (memory_format == c10::MemoryFormat::Contiguous) {
+    const Tensor& self_buffer = self_ptr->get_unsafe_storage_as_tensor(),
+        sizemat = self_ptr->get_nested_sizes();
+    Tensor output_buffer = at::empty(self.numel(), self_buffer.options());
+    Tensor output = wrap_buffer(output_buffer, sizemat);
+    std::vector<Tensor> self_unbind = self.unbind(),
+        output_unbind = output.unbind();
+    for (const int64_t i: c10::irange(self_ptr->size(0))) {
+      output_unbind[i].copy_(self_unbind[i]);
+    }
+    return output;
+  } else {
+    TORCH_CHECK(
+        false,
+        "Nested tensor clone supports Preserve and Contiguous memory formats, called clone with memory format: ",
+        memory_format);
+  }
+}
+
+std::vector<at::Tensor> NestedTensor_unbind(
+    const at::Tensor& self,
+    int64_t dim) {
+  TORCH_CHECK(
+      dim == 0,
+      "NestedTensor can only be unbound along dimension 0 ",
+      "got dimension ",
+      dim,
+      " instead.");
+  auto self_ptr = get_nested_tensor_impl(self);
+  int64_t ntensors = self_ptr->size(0);
+  std::vector<at::Tensor> result_tensors(ntensors);
+  if (ntensors == 0) {
+    return result_tensors;
+  }
+  // This returns a differentiable view of self as a regular tensor
+  auto buffer = self.values();
+  std::vector<IntArrayRef> sizes = NestedTensor_get_sizes(self_ptr),
+      strides = NestedTensor_get_strides(self_ptr);
+  int64_t *offsets_ptr = self_ptr->get_storage_offsets().data_ptr<int64_t>();
+  for (const int64_t i: c10::irange(ntensors)){
+    result_tensors[i] = buffer.as_strided(sizes[i], strides[i], offsets_ptr[i]);
+  }
+  return result_tensors;
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -58,31 +58,6 @@ Tensor pad_tensor_to_shape(
 }
 } // namespace
 
-std::vector<at::Tensor> NestedTensor_unbind(
-    const at::Tensor& self,
-    int64_t dim) {
-  TORCH_CHECK(
-      dim == 0,
-      "NestedTensor can only be unbound along dimension 0 ",
-      "got dimension ",
-      dim,
-      " instead.");
-  auto self_ptr = get_nested_tensor_impl(self);
-  int64_t ntensors = self_ptr->size(0);
-  std::vector<at::Tensor> result_tensors(ntensors);
-  if (ntensors == 0) {
-    return result_tensors;
-  }
-  // This returns a differentiable view of self as a regular tensor
-  auto buffer = self.values();
-  std::vector<IntArrayRef> sizes = NestedTensor_get_sizes(self_ptr),
-      strides = NestedTensor_get_strides(self_ptr);
-  int64_t *offsets_ptr = self_ptr->get_storage_offsets().data_ptr<int64_t>();
-  for (const int64_t i: c10::irange(ntensors)){
-    result_tensors[i] = buffer.as_strided(sizes[i], strides[i], offsets_ptr[i]);
-  }
-  return result_tensors;
-}
 
 Tensor NestedTensor_nested_tensor_from_mask(const Tensor& t, const Tensor& mask, bool mask_check) {
     TORCH_CHECK(mask.scalar_type() == at::ScalarType::Bool, "Expected mask to be of ScalarType Bool, but got ", mask.scalar_type(), " instead.");
@@ -498,43 +473,6 @@ Tensor select_nested(const Tensor& self, int64_t dim, int64_t index) {
     return create_nested_view_tensor(self, new_sizes, new_strides, new_offsets);
   }
 
-}
-
-Tensor clone_nested(
-    const Tensor& self,
-    c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto memory_format = optional_memory_format.value_or(c10::MemoryFormat::Preserve);
-  auto self_ptr = get_nested_tensor_impl(self);
-  if (memory_format == c10::MemoryFormat::Preserve ||
-  (memory_format == c10::MemoryFormat::Contiguous && self.is_contiguous())) {
-    const Tensor& buffer = self_ptr->get_unsafe_storage_as_tensor(),
-        sizemat = self_ptr->get_nested_sizes(),
-        stridemat = self_ptr->get_nested_strides();
-    const auto& offsets = self_ptr->get_storage_offsets();
-    // TODO: The size and the stride do not necessarily need to be cloned,
-    //       but it is more conservative.
-    //       This is something we could revisit once we land a more
-    //       efficient implementation of nested_sizes_ and nested_strides.
-    return wrap_buffer(buffer.clone(), sizemat.clone(), stridemat.clone(), offsets.clone());
-  }
-  // actually, memory format is contiguous and self is noncontiguous
-  else if (memory_format == c10::MemoryFormat::Contiguous) {
-    const Tensor& self_buffer = self_ptr->get_unsafe_storage_as_tensor(),
-        sizemat = self_ptr->get_nested_sizes();
-    Tensor output_buffer = at::empty(self.numel(), self_buffer.options());
-    Tensor output = wrap_buffer(output_buffer, sizemat);
-    std::vector<Tensor> self_unbind = self.unbind(),
-        output_unbind = output.unbind();
-    for (const int64_t i: c10::irange(self_ptr->size(0))) {
-      output_unbind[i].copy_(self_unbind[i]);
-    }
-    return output;
-  } else {
-    TORCH_CHECK(
-        false,
-        "Nested tensor clone supports Preserve and Contiguous memory formats, called clone with memory format: ",
-        memory_format);
-  }
 }
 
 std::tuple<Tensor,Tensor> native_dropout_nested(const Tensor& input, double p, c10::optional<bool> train) {

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -550,6 +550,7 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     # _nested_tensor_size() should never actually be called with requires_grad=True tensor
     "_nested_tensor_size",
     "_nested_tensor_strides",
+    "_nested_tensor_storage_offsets",
     # Functional collectives keep an internal ref through the Work object
     "all_reduce",
     "all_gather_into_tensor",


### PR DESCRIPTION
# Summary
NestedTensors currenlty don't support non-identical strided addition. When accumulating grad it possible to try and accumulate a grad with different striding then the old var and there is no way to change this in user code. This is a solution.. probs should support strided addition for NT