### PR TITLE
[Inductor CI] Fix concurrency cancellation rule of inductor-perf-compare job

### DIFF
--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Currently old commits' jobs are not cancelled: https://github.com/pytorch/pytorch/actions/workflows/inductor-perf-compare.yml
This PR tries to fix the concurrency rule so that when new commit is pushed, old job gets cancelled immediately. 