### PR TITLE
[cublas][cublasLt] Fall back to unfused addmm for 8-byte-aligned inputs on `sm90`.

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -292,6 +292,14 @@ bool CUDAHooks::supportsBFloat16ConvolutionWithCuDNNv8() const {
 #endif
 }
 
+bool CUDAHooks::supports8ByteAlignmentFloat32WithCublasLt() const {
+  cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
+  if (prop->major == 9 && prop->minor == 0) {
+    return false;
+  }
+  return true;
+}
+
 long CUDAHooks::versionCuDNN() const {
 #if AT_CUDNN_ENABLED()
   return CUDNN_VERSION;

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -38,6 +38,7 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   bool supportsDilatedConvolutionWithCuDNN() const override;
   bool supportsDepthwiseConvolutionWithCuDNN() const override;
   bool supportsBFloat16ConvolutionWithCuDNNv8() const override;
+  bool supports8ByteAlignmentFloat32WithCublasLt() const override;
   bool hasCUDART() const override;
   long versionCUDART() const override;
   long versionCuDNN() const override;

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -150,6 +150,10 @@ struct TORCH_API CUDAHooksInterface {
     return false;
   }
 
+  virtual bool supports8ByteAlignmentFloat32WithCublasLt() const {
+    return false;
+  }
+
   virtual long versionCuDNN() const {
     TORCH_CHECK(false, "Cannot query cuDNN version without ATen_cuda library. ", CUDA_HELP);
   }


### PR DESCRIPTION
Similar to #92201, but for 8-byte alignment for `float32` which is yielding `CUBLAS_STATUS_NOT_SUPPORTED`.

No test added as the failure is surfaced from an existing test; reproducible via
`python test/test_decomp.py -k test_rnn_decomp_module_nn_LSTM_eval_mode_cuda_float32` on `sm90`.

CC @ptrblck @ngimel


cc @csarofeen @ptrblck @xwang233