### PR TITLE
Removed hip call hipDeviceSynchronize

### DIFF
--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -131,6 +131,9 @@ class ProfilerTree:
         if flat_nodes and flat_nodes[-1][1] == "cudaDeviceSynchronize":
             flat_nodes = flat_nodes[:-1]
 
+        if flat_nodes and flat_nodes[-1][1] == "hipDeviceSynchronize":
+            flat_nodes = flat_nodes[:-1]
+
         min_depth = min([d + 1 for d, name in flat_nodes if "begin_unit_test_marker" in name] or [0])
         return textwrap.indent(
             "\n".join([f"{'  ' * (d - min_depth)}{name.rstrip()}" for d, name in flat_nodes if d >= min_depth]),

--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -131,6 +131,7 @@ class ProfilerTree:
         if flat_nodes and flat_nodes[-1][1] == "cudaDeviceSynchronize":
             flat_nodes = flat_nodes[:-1]
 
+        # Profiler inserts a `hipDeviceSynchronize` at the end of profiling.
         if flat_nodes and flat_nodes[-1][1] == "hipDeviceSynchronize":
             flat_nodes = flat_nodes[:-1]
 


### PR DESCRIPTION
Similar to CUDA, fixed test_profiler_tree.py::TestProfilerTree unit test suites by DeviceSynchronize call removal.

@jithunnair-amd @pruthvistony 