### PR TITLE
[reland][inductor] do benchmark in sub processes for max autotuning

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1,0 +1,158 @@
+# Owner(s): ["module: inductor"]
+
+import torch
+from torch import multiprocessing as mp
+from torch._dynamo.test_case import run_tests, TestCase
+from torch._inductor import config
+from torch._inductor.graph import GraphLowering
+from torch._inductor.ir import Buffer, FixedLayout
+from torch._inductor.kernel.mm_plus_mm import aten_mm_plus_mm
+from torch._inductor.select_algorithm import AlgorithmSelectorCache, ChoiceCaller
+from torch._inductor.virtualized import V
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing._internal.inductor_utils import HAS_CUDA
+
+torch.set_float32_matmul_precision("high")
+
+
+def benchmark_choice(choice, args, out, expected_out, timings):
+    result = choice.benchmark(*args, out=out)
+    if expected_out is not None:
+        torch.testing.assert_close(out, expected_out)
+
+    timings.copy_(torch.tensor(result))
+
+
+class FailChoiceCaller(ChoiceCaller):
+    def benchmark(self, *args, out):
+        raise RuntimeError("This choice caller will always throw")
+
+
+class TestDoBench(TestCase):
+    def _create_buffer(self, name, shape):
+        return Buffer(name, FixedLayout(torch.device("cuda:0"), torch.float32, shape))
+
+    def test_benchmark_choice_in_subproc(self):
+        gm = make_fx(
+            lambda: torch.zeros(2, 3)
+        )()  # a dummy graph to construct the GraphLowering
+        graph = GraphLowering(gm)
+
+        # the graph handler is neede to create benchmark example value below
+        with V.set_graph_handler(graph):
+            buf1 = self._create_buffer("mat1", (2, 3))
+            buf2 = self._create_buffer("mat2", (3, 2))
+            buf3 = self._create_buffer("mat3", (2, 3))
+            buf4 = self._create_buffer("mat4", (3, 2))
+
+            layout = FixedLayout(torch.device("cuda:0"), torch.float32, (2, 2))
+
+            mat1 = AlgorithmSelectorCache.benchmark_example_value(buf1)
+            mat2 = AlgorithmSelectorCache.benchmark_example_value(buf2)
+            mat3 = AlgorithmSelectorCache.benchmark_example_value(buf3)
+            mat4 = AlgorithmSelectorCache.benchmark_example_value(buf4)
+
+            out = AlgorithmSelectorCache.benchmark_example_value(layout)
+            # expected_out = (mat1 @ mat2) + (mat3 @ mat4)
+            expected_out = None
+
+            choice = aten_mm_plus_mm.bind((buf1, buf2, buf3, buf4), layout)
+            # use a tensor since the mutation to a python list in a sub process
+            # is not synced back to the parent process
+            timings = torch.zeros(3, dtype=torch.float32)
+            ctx = mp.get_context("spawn")
+            child = ctx.Process(
+                target=benchmark_choice,
+                args=(choice, (mat1, mat2, mat3, mat4), out, expected_out, timings),
+            )
+            child.start()
+            child.join()
+            self.assertEqual(0, child.exitcode)
+            print(f"timings is {timings}, out {out}, expected_out {expected_out}")
+
+    def test_benchmark_choice_fail_in_subproc(self):
+        gm = make_fx(
+            lambda: torch.zeros(2, 3)
+        )()  # a dummy graph to construct the GraphLowering
+        graph = GraphLowering(gm)
+
+        # the graph handler is neede to create benchmark example value below
+        with V.set_graph_handler(graph):
+            buf1 = self._create_buffer("mat1", (2, 3))
+            buf2 = self._create_buffer("mat2", (3, 2))
+            buf3 = self._create_buffer("mat3", (2, 3))
+            buf4 = self._create_buffer("mat4", (3, 2))
+
+            layout = FixedLayout(torch.device("cuda:0"), torch.float32, (2, 2))
+
+            mat1 = AlgorithmSelectorCache.benchmark_example_value(buf1)
+            mat2 = AlgorithmSelectorCache.benchmark_example_value(buf2)
+            mat3 = AlgorithmSelectorCache.benchmark_example_value(buf3)
+            mat4 = AlgorithmSelectorCache.benchmark_example_value(buf4)
+
+            out = AlgorithmSelectorCache.benchmark_example_value(layout)
+            expected_out = (mat1 @ mat2) + (mat3 @ mat4)
+
+            choice = FailChoiceCaller("fail_choice_caller", [], None)
+
+            # use a tensor since python list is not synced back
+            timings = torch.zeros(3, dtype=torch.float32)
+            ctx = mp.get_context("spawn")
+            child = ctx.Process(
+                target=benchmark_choice,
+                args=(choice, (mat1, mat2, mat3, mat4), out, expected_out, timings),
+            )
+            child.start()
+            child.join()
+            self.assertNotEqual(0, child.exitcode)
+
+    def test_max_autotune_mm_plus_mm(self):
+        """
+        This crash previously due to a triton issue: https://github.com/openai/triton/issues/1298 .
+        With autotuning in subprocess, we don't crash anymore.
+        """
+        m, n, k = 2048, 1536, 64
+
+        def mm_plus_mm(a, b, c, d):
+            return a @ b + c @ d
+
+        a = torch.randn(m, k).cuda()
+        b = torch.randn(k, n).cuda()
+        c = torch.randn(m, k).cuda()
+        d = torch.randn(k, n).cuda()
+
+        with config.patch({"max_autotune": True, "autotune_in_subproc": True}):
+            torch.compile(mm_plus_mm)(a, b, c, d)
+
+    def test_max_autotune_regular_mm(self):
+        """
+        Make sure autotuning mm in sub processes work without crashes.
+        """
+
+        def mm(a, b):
+            a = torch.sin(a)
+            return a @ b
+
+        a = torch.randn(100, 10).cuda()
+        b = torch.randn(10, 100).cuda()
+        with config.patch({"max_autotune": True, "autotune_in_subproc": True}):
+            torch.compile(mm)(a, b)
+
+    def test_max_autotune_addmm(self):
+        """
+        Make sure autotuning addmm in sub processes work without crashes.
+        """
+
+        def addmm(x, a, b):
+            return torch.addmm(x, a, b)
+
+        x = torch.randn(100).cuda()
+        a = torch.randn(100, 10).cuda()
+        b = torch.randn(10, 100).cuda()
+        with config.patch({"max_autotune": True, "autotune_in_subproc": True}):
+            torch.compile(addmm)(x, a, b)
+
+
+if __name__ == "__main__":
+    if HAS_CUDA:
+        run_tests()

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -1,0 +1,150 @@
+import dataclasses
+import warnings
+from typing import Any, Dict, List
+
+import torch
+from torch import multiprocessing
+from torch._dynamo.testing import rand_strided
+from torch._inductor import ir
+from torch._inductor.codecache import PyCodeCache
+
+from .utils import do_bench
+from .virtualized import V
+
+DEBUG = False
+
+
+@dataclasses.dataclass
+class TensorMeta:
+    device: torch.device
+    dtype: torch.dtype
+    sizes: List[int]
+    strides: List[int]
+    offset: int
+
+    @classmethod
+    def from_irnodes(cls, irnodes):
+        if isinstance(irnodes, (tuple, list)):
+            return [cls.from_irnodes(x) for x in irnodes]
+
+        node = irnodes
+        if isinstance(node, ir.Layout):
+            node = ir.Buffer("fake", node)
+
+        return TensorMeta(
+            device=node.get_device(),
+            dtype=node.get_dtype(),
+            sizes=V.graph.sizevars.size_hints(node.get_size()),
+            strides=V.graph.sizevars.size_hints(node.get_stride()),
+            offset=V.graph.sizevars.size_hint(node.get_layout().offset),
+        )
+
+    def to_tensor(self) -> torch.Tensor:
+        return rand_strided(
+            self.sizes,
+            self.strides,
+            device=self.device,
+            dtype=self.dtype,
+            extra_size=self.offset,
+        )
+
+
+@dataclasses.dataclass
+class BenchmarkRequest:
+    """
+    Only handle triton template benchmark for now. The extern kernel benchmark
+    can be done inside the same process since they usually don't cause crash.
+    """
+
+    module_path: str  # the path of the module defining the triton kernel
+    module_cache_key: str
+    kernel_name: str  # the kernel name defined in the module
+    grid: List[int]
+    extra_args: Dict[str, Any]
+    num_stages: int
+    num_warps: int
+
+    input_tensors: List[TensorMeta]
+    output_tensor: TensorMeta
+
+    def benchmark(self, *input_tensors, output_tensor=None) -> float:
+        if DEBUG:
+            start_ts = time.time()
+
+        mod = PyCodeCache.load_by_key_path(self.module_cache_key, self.module_path)
+        run = getattr(mod, self.kernel_name).run
+
+        if DEBUG:
+            load_elapse = time.time() - start_ts
+            start_ts = time.time()
+
+        # create args and out tensor
+        if output_tensor is None:
+            assert len(input_tensors) == 0
+            input_tensors = [x.to_tensor() for x in self.input_tensors]
+            output_tensor = self.output_tensor.to_tensor()
+
+        if DEBUG:
+            create_tensor_elapse = time.time() - start_ts
+            start_ts = time.time()
+
+        def worker():
+            return run(
+                *input_tensors,
+                output_tensor,
+                *self.extra_args,
+                grid=self.grid,
+                num_stages=self.num_stages,
+                num_warps=self.num_warps,
+            )
+
+        out = do_bench(worker)[0]
+        torch.cuda.synchronize()  # shake out any CUDA errors
+
+        if DEBUG:
+            bench_elapse = time.time() - start_ts
+            print(
+                f"InChidProcess {self.module_cache_key}: load {load_elapse}, "
+                + f"create tensor {create_tensor_elapse}, bench {bench_elapse}"
+            )
+        return out
+
+
+def process_main(bmreq: BenchmarkRequest, timings: torch.Tensor):
+    """
+    The main function for the child process.
+    """
+    timings[0] = bmreq.benchmark()
+
+
+def benchmark_in_sub_process(
+    choice: "ChoiceCaller",
+) -> float:
+    assert choice.bmreq is not None
+
+    # use a tensor since the mutation to a python list in a sub process
+    # is not synced back to the parent process. While a tensor works well since
+    # they are moved to shared memory.
+    # TODO: can ue a Queue instead.
+    timings = torch.zeros(1, dtype=torch.float32)
+
+    ctx = multiprocessing.get_context("spawn")
+    child = ctx.Process(
+        target=process_main,
+        args=(
+            choice.bmreq,
+            timings,
+        ),
+    )
+    child.start()
+    child.join()
+
+    # child process fail
+    if child.exitcode != 0:
+        warnings.warn(
+            f"Fail to benchmark choice '{choice}'. It will be ignored. Please debug the root cause in case the choice can bring perf gains."  # noqa: B950 line too long
+        )
+        # return a large value to this choice will be ignored
+        return float("inf")
+
+    return timings[0].item()

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -642,6 +642,10 @@ class PyCodeCache:
     @classmethod
     def load(cls, source_code, extra="", linemap=()):
         key, path = write(source_code, "py", extra)
+        return cls.load_by_key_path(key, path, linemap)
+
+    @classmethod
+    def load_by_key_path(cls, key, path, linemap=()):
         if key not in cls.cache:
             with open(path) as f:
                 try:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -60,6 +60,9 @@ max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 # enable searching global and local cache regardless of `max_autotune`
 search_autotune_cache = os.environ.get("TORCHINDUCTOR_SEARCH_AUTOTUNE_CACHE") == "1"
 
+# We will disable creating subprocess for autotuning if this is False
+autotune_in_subproc = os.environ.get("TORCHINDUCTOR_AUTOTUNE_IN_SUBPROC") == "1"
+
 # control store vs recompute heuristic
 # For fanouts, rematearialization can lead to exponential blowup. So, have
 # smaller threshold

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 import sys
 import textwrap
+import time
 from io import StringIO
 
 from typing import Any, List
@@ -17,6 +18,7 @@ from torch._dynamo.testing import rand_strided
 from torch._dynamo.utils import counters, identity
 
 from . import config, ir
+from .autotune_process import BenchmarkRequest, TensorMeta
 from .codecache import code_hash, PersistentCache, PyCodeCache
 
 from .codegen.common import IndentedBuffer
@@ -37,7 +39,6 @@ class KernelNamespace:
 
 
 # these objects are imported from the generated wrapper code
-template_kernels = KernelNamespace()
 extern_kernels = KernelNamespace()
 
 
@@ -404,7 +405,6 @@ class TritonTemplate:
                 + "-"
             )
             mod = PyCodeCache.load(code, extra)
-            run = getattr(mod, kernel_name).run
             _, call_args, _ = kernel.args.python_argdefs()
 
         expected_args = [x.get_name() for x in input_nodes] + [fake_out.get_name()]
@@ -417,21 +417,7 @@ class TritonTemplate:
         )
         assert not extra_args, "TODO: dynamic shapes"
 
-        def call(*args, out):
-            return run(
-                *args,
-                out,
-                *extra_args,
-                grid=self.grid(*out.size(), kwargs),
-                num_stages=num_stages,
-                num_warps=num_warps,
-            )
-
-        call.key = mod.key
-        call.__file__ = mod.__file__
-
         kernel_hash_name = f"triton_{self.name}_{next(self.index_counter)}"
-        setattr(template_kernels, kernel_hash_name, call)
 
         def make_kernel_render(out_node):
             kernel = TritonTemplateKernel(
@@ -447,12 +433,27 @@ class TritonTemplate:
             )
             return kernel, render
 
+        # create the BenchmarkRequest
+        grid = self.grid(*V.graph.sizevars.size_hints(layout.size), kwargs)
+        bmreq = BenchmarkRequest(
+            module_path=mod.__file__,
+            module_cache_key=mod.key,
+            kernel_name=kernel_name,
+            grid=grid,
+            extra_args=extra_args,
+            num_stages=num_stages,
+            num_warps=num_warps,
+            input_tensors=TensorMeta.from_irnodes(input_nodes),
+            output_tensor=TensorMeta.from_irnodes(layout),
+        )
+
         return TritonTemplateCaller(
             kernel_hash_name,
             input_nodes,
             layout,
             make_kernel_render,
             extra.strip("-").replace("-", ", "),
+            bmreq,
         )
 
     @staticmethod
@@ -538,10 +539,17 @@ class ChoiceCaller:
 
 
 class TritonTemplateCaller(ChoiceCaller):
-    def __init__(self, name, input_nodes, layout, make_kernel_render, debug_extra):
+    def __init__(
+        self, name, input_nodes, layout, make_kernel_render, debug_extra, bmreq
+    ):
         super().__init__(name, input_nodes, layout)
         self.make_kernel_render = make_kernel_render
         self.debug_extra = debug_extra
+        self.bmreq = bmreq
+
+    def benchmark(self, *args, out):
+        assert self.bmreq is not None
+        return self.bmreq.benchmark(*args, output_tensor=out)
 
     def __str__(self):
         return (
@@ -551,14 +559,11 @@ class TritonTemplateCaller(ChoiceCaller):
     def call_name(self):
         return f"template_kernels.{self.name}"
 
-    def to_callable(self):
-        return getattr(template_kernels, self.name)
-
     def hash_key(self):
         return "-".join(
             [
                 self.name.rsplit("_", 1)[0],
-                self.to_callable().key,
+                self.bmreq.module_cache_key,
             ]
         )
 
@@ -677,18 +682,20 @@ class AlgorithmSelectorCache(PersistentCache):
                 raise AssertionError(f"Incorrect result from choice {choice}\n\n{e}")
             return timing
 
+        autotune_start_ts = time.time()
         timings = self.lookup(
             choices,
             choices[0].name,
             repr([self.key_of(x) for x in input_nodes]),
             autotune,
         )
+        autotune_elapse = time.time() - autotune_start_ts
         if timings == {} or choices[0] not in timings:
             return choices[0].output_node()
 
         if make_benchmark_fn.cache_info().currsize:
             counters["inductor"]["select_algorithm_autotune"] += 1
-            self.log_results(choices[0].name, input_nodes, timings)
+            self.log_results(choices[0].name, input_nodes, timings, autotune_elapse)
         return builtins.min(timings, key=timings.__getitem__).output_node()
 
     @classmethod
@@ -716,18 +723,36 @@ class AlgorithmSelectorCache(PersistentCache):
             choices[0].benchmark(*example_inputs_extern, out=out_extern)
             expected = out_extern.clone()
 
-        def benchmark(choice):
+        def benchmark_in_current_process(choice):
             out.zero_()
             if isinstance(choice, ExternKernelCaller):
                 # aten kernels want the offset baked in for sliced tensors
-                result = choice.benchmark(*example_inputs_extern, out=out_extern)
+                result = choice.benchmark(*example_inputs_extern, out=out_extern)[0]
             else:
                 # triton templates want the base pointer for sliced tensors
                 result = choice.benchmark(*example_inputs, out=out)
             if VERIFY:
                 torch.testing.assert_close(out_extern, expected, **VERIFY)
             torch.cuda.synchronize()  # shake out any CUDA errors
-            return min(result)
+            return result
+
+        def benchmark_in_sub_process(choice):
+            # only benchmark triton kernel in sub process for now.
+            # ATen/Extern kernel are still benchmarked in the current process.
+            if isinstance(choice, ExternKernelCaller):
+                return benchmark_in_current_process(choice)
+
+            from . import autotune_process
+
+            return autotune_process.benchmark_in_sub_process(
+                choice,
+            )
+
+        benchmark = (
+            benchmark_in_sub_process
+            if config.autotune_in_subproc
+            else benchmark_in_current_process
+        )
 
         def debug_str():
             def tensor_repr(x):
@@ -748,7 +773,7 @@ class AlgorithmSelectorCache(PersistentCache):
         return benchmark
 
     @staticmethod
-    def log_results(name, input_nodes, timings):
+    def log_results(name, input_nodes, timings, elapse):
         if not (config.max_autotune or config.max_autotune_gemm) or not PRINT_AUTOTUNE:
             return
         sizes = ", ".join(
@@ -764,6 +789,11 @@ class AlgorithmSelectorCache(PersistentCache):
         for choice in top_k:
             result = timings[choice]
             sys.stderr.write(f"  {choice.name} {result:.4f}s {best_time/result:.1%}\n")
+
+        autotune_type_str = (
+            "SubProcess" if config.autotune_in_subproc else "SingleProcess"
+        )
+        sys.stderr.write(f"{autotune_type_str} AUTOTUNE takes {elapse} seconds\n")
 
     @staticmethod
     def benchmark_example_value(node):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #97203
* #97219
* __->__ #97215

Previous attempt of landing this PR is reverted due to a landrace: https://github.com/pytorch/pytorch/pull/96410 .

The reason is `PyCodeCache.load` has a new linemap argument being added but my previous PR does not handle it (due to a stale checkout). Fix is trivial.


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire