### PR TITLE
Fix typo under torch/csrc/jit/tensorexpr directory 

### DIFF
--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -287,7 +287,7 @@ class BufLiveRange : public IRVisitor {
 
   static std::tuple<int32_t, int32_t> liveRange(StmtPtr s, BufPtr b) {
     BlockPtr block = to<Block>(std::move(s));
-    // We Only analze buffer live ranges for block stmts.
+    // We Only analyze buffer live ranges for block stmts.
     if (!block) {
       return std::make_tuple(0, 0);
     }
@@ -376,7 +376,7 @@ class BufLiveRange : public IRVisitor {
 };
 
 // A class that analyzes the given program relevant for Block backend
-// It creates a map of multi dim buffers and their flat verions
+// It creates a map of multi dim buffers and their flat versions
 class CreateBufferMap : public IRVisitor {
  public:
   const std::unordered_map<std::string, BufPtr>& getBufferMap() const {

--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -162,7 +162,7 @@ std::vector<ExprPtr> getBoundExtents(
   std::vector<ExprPtr> starts;
   std::vector<ExprPtr> stops;
 
-  // Find the safe size of the temprorary buffer by determining the outer
+  // Find the safe size of the temporary buffer by determining the outer
   // extents of a union of all bounds.
   for (const TensorAccessBoundsInfo& p : infos) {
     for (const auto i : c10::irange(p.start.size())) {

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.h
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.h
@@ -78,7 +78,7 @@ enum class CmpEvalResult { True, False, NotDetermined };
 OverlapKind TORCH_API boundOverlap(Bound A, Bound B);
 
 // The comparison is conservative and the compare result is deterministic.
-// It means that every element of the Bound to be compared needs to satisfiy
+// It means that every element of the Bound to be compared needs to satisfy
 // the given comparison operator.
 CmpEvalResult TORCH_API compareBound(
     const Bound& a,

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -150,7 +150,7 @@ std::vector<std::pair<BufPtr, BufPtr>> AllocBufsWithMemReuse(
 
     // Release memory for buffers whose liveness range ends before the creation
     // time of this buf.
-    // TODO: optimize in-place opererations and copy operations
+    // TODO: optimize in-place operations and copy operations
     std::vector<BufPtr> buf_to_release;
     for (auto& mapped : buf_mem_map) {
       auto buf_mapped = mapped.first;
@@ -294,7 +294,7 @@ void CodeGen::allocIntermediateBufs() {
     if (!bufs_allocated.count(buf) && !interm_bufs.count(buf)) {
       interm_bufs.insert(buf);
 
-      // Identify the access stmts to each unallocated intermeiate buffer.
+      // Identify the access stmts to each unallocated intermediate buffer.
       auto range = BufLiveRange::liveRange(stmt_, buf);
       interm_buf_ranges.emplace(buf, range);
     }

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -1319,7 +1319,7 @@ void CudaCodeGen::CompileToNVRTC(
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11010
       // CUDA 11.1 allows going directly to SASS (sm_) instead of PTX (compute_)
       // which gives better backwards compatibility to work on older driver,
-      // (since older driver doesn't necessrily recognize PTX emitted by new
+      // (since older driver doesn't necessarily recognize PTX emitted by new
       // toolkit);
       // Meanwhile, for forward compatibility (future device with
       // `compile_to_sass==false`), since SASS are not necessarily compatible,

--- a/torch/csrc/jit/tensorexpr/expr.cpp
+++ b/torch/csrc/jit/tensorexpr/expr.cpp
@@ -146,7 +146,7 @@ ExprHandle abs(const ExprHandle& v) {
 // The default tanh is quite slow, use the Eigen version from here:
 // https://bitbucket.org/eigen/eigen/src/94875feeeeb9abe5509b314197da1991ba2070f5/Eigen/src/Core/MathFunctionsImpl.h#lines-26
 ExprHandle fast_tanh(const ExprHandle& v) {
-  // TODO: use a dedicated bind-var to make sure v is not evalualted multiple
+  // TODO: use a dedicated bind-var to make sure v is not evaluated multiple
   // times. Clamp the input expression to [-9, 9]
   ExprHandle plus_9 = FloatImm::make(9.0f);
   ExprHandle minus_9 = FloatImm::make(-9.0f);
@@ -162,7 +162,7 @@ ExprHandle fast_tanh(const ExprHandle& v) {
   ExprHandle alpha_11 = FloatImm::make(2.00018790482477e-13f);
   ExprHandle alpha_13 = FloatImm::make(-2.76076847742355e-16f);
 
-  // The coeffecients for the denominator
+  // The coefficients for the denominator
   ExprHandle beta_0 = FloatImm::make(4.89352518554385e-03f);
   ExprHandle beta_2 = FloatImm::make(2.26843463243900e-03f);
   ExprHandle beta_4 = FloatImm::make(1.18534705686654e-04f);

--- a/torch/csrc/jit/tensorexpr/external_functions_registry.h
+++ b/torch/csrc/jit/tensorexpr/external_functions_registry.h
@@ -16,7 +16,7 @@ namespace tensorexpr {
 // It was picked for two reasons: 1) it should be generic enough to represent
 // most of the ops we might want to call, 2) it should be possible to generate a
 // code for this call in LLVM codegen.
-// The first 5 parameters allow to pass any number of contiguos CPU tensors in
+// The first 5 parameters allow to pass any number of contiguous CPU tensors in
 // case we need to run aten ops (TODO: support different devices). The first
 // buffer in the array is assumed to be the output buffer. We couldn't use
 // `at::Tensor` (or `c10::IValue`) type there directly as it would mean that

--- a/torch/csrc/jit/tensorexpr/half_support.h
+++ b/torch/csrc/jit/tensorexpr/half_support.h
@@ -9,7 +9,7 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
-// Walk the Statment looking for Half size loads/stores.
+// Walk the Statement looking for Half size loads/stores.
 class HalfChecker : public IRVisitor {
  public:
   HalfChecker(const std::vector<CodeGen::BufferArg>& args) {

--- a/torch/csrc/jit/tensorexpr/intrinsic_symbols.cpp
+++ b/torch/csrc/jit/tensorexpr/intrinsic_symbols.cpp
@@ -156,7 +156,7 @@ c10::ArrayRef<SymbolAddress> getIntrinsicSymbols() {
     {"fmodf", reinterpret_cast<void*>(&fmodf)},
     {"remainderf", reinterpret_cast<void*>(&remainderf)},
 
-    // float -> half & half -> float conversio)ns
+    // float -> half & half -> float conversions
     {"__gnu_h2f_ieee",
      reinterpret_cast<void*>(&c10::detail::fp16_ieee_to_fp32_value)},
     {"__gnu_f2h_ieee",

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1903,7 +1903,7 @@ c10::optional<class ModRound> isModRound(TermPtr e) {
         }
       }
 
-      // All non-mod vairables are considered as part of the multiplier.
+      // All non-mod variables are considered as part of the multiplier.
       multiplier = alloc<Mul>(multiplier, m);
     }
   }
@@ -2077,7 +2077,7 @@ ExprPtr simplifyRoundModPattern(PolynomialPtr poly) {
 
         // TODO: for now don't attempt partial factorization of this
         // optimization. E.g. it's possible to do: 2 * (x/y) * y + (x%y) => x +
-        // (x/y) * y but unsure thats actually much better, particulary with
+        // (x/y) * y but unsure thats actually much better, particularly with
         // CSE.
         if (!immediateEquals(
                 evaluateOp(alloc<Sub>(r->scalar(), m->scalar())), 0)) {
@@ -2144,7 +2144,7 @@ TermPtr PolynomialBase::factorizePolynomial(PolynomialPtr poly) {
     return nullptr;
   }
 
-  // Create new struture.
+  // Create new structure.
   std::vector<TermPtr> newPolyTerms;
   newPolyTerms.reserve(variables.size());
   for (const auto& t : variables) {
@@ -2386,7 +2386,7 @@ StmtPtr TermExpander::mutate(FreePtr v) {
   return v;
 }
 
-// Combines adjactent Cond nodes with identical conditions.
+// Combines adjacent Cond nodes with identical conditions.
 BlockPtr TermExpander::fuseConditions(BlockPtr v) {
   std::vector<StmtPtr> stmts;
   bool did_anything = false;
@@ -2641,7 +2641,7 @@ StmtPtr SimplifierUnderContext::mutate(ForPtr v) {
 //   TODO: remove d) from the requirements because the simplification formula
 //   still holds when x is a negative integer. In integer division, the result
 //   of the division is converted to an integer using `floor` function which
-//   returns the largest integer that is not greater than X. For exmaple, -1/6
+//   returns the largest integer that is not greater than X. For example, -1/6
 //   returns -1. But currently, both Pytorch and NNC are performing an incorrect
 //   integer division: (-1)/6 = 0. With the current implementation of integer
 //   division, x has to be not negative. d) x is not negative
@@ -2654,7 +2654,7 @@ StmtPtr SimplifierUnderContext::mutate(ForPtr v) {
 //   TODO: remove d) from the requirements because the simplification formula
 //   still holds when j is a negative integer. In integer division, the result
 //   of the division is converted to an integer using `floor` function which
-//   returns the largest integer that is not greater than X. For exmaple, -1/6
+//   returns the largest integer that is not greater than X. For example, -1/6
 //   returns -1. But currently, both Pytorch and NNC are performing an incorrect
 //   integer division: (-1)/6 = 0. With the current implementation of integer
 //   division, x has to be not negative. d) j is not negative
@@ -2759,7 +2759,7 @@ ExprPtr distributeDiv(ExprPtr lhs, ExprPtr rhs, VarBoundInfo var_bound_info) {
 //   TODO: remove d) from the requirements because the simplification formula
 //   still holds when x is a negative integer. In integer division, the result
 //   of the division is converted to an integer using `floor` function which
-//   returns the largest integer that is not greater than X. For exmaple, -1/6
+//   returns the largest integer that is not greater than X. For example, -1/6
 //   returns -1. But currently, both Pytorch and NNC are performing an incorrect
 //   integer division: (-1)/6 = 0. With the current implementation of integer
 //   division, x has to be not negative. d) x is not negative
@@ -2772,7 +2772,7 @@ ExprPtr distributeDiv(ExprPtr lhs, ExprPtr rhs, VarBoundInfo var_bound_info) {
 //   TODO: remove d) from the requirements because the simplification formula
 //   still holds when j is a negative integer. In integer division, the result
 //   of the division is converted to an integer using `floor` function which
-//   returns the largest integer that is not greater than X. For exmaple, -1/6
+//   returns the largest integer that is not greater than X. For example, -1/6
 //   returns -1. But currently, both Pytorch and NNC are performing an incorrect
 //   integer division: (-1)/6 = 0. With the current implementation of integer
 //   division, j has to be not negative. d) j is not negative

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -12,7 +12,7 @@
 
 /* IR Simplification
  *
- * Simplfies expressions in two stages:
+ * Simplifies expressions in two stages:
  *  1. Recursively traverse the map combining similar operations into Terms
  * (interacted via Multiplication) and Polynomials (interacted via Addition). We
  * reorder the components of each Term or Polynomial into a consistent order to

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1309,7 +1309,7 @@ Tensor TensorExprKernel::convertSymbolicOutputToCorrectStrides(
   TORCH_INTERNAL_ASSERT(
       bufs_.count(v),
       buildErrorMessage(
-          "Ouput tensor has no corresponding bufs in the fuser."));
+          "Output tensor has no corresponding bufs in the fuser."));
   BufPtr buf = bufs_.at(v);
   TORCH_INTERNAL_ASSERT(buf != nullptr);
   TORCH_INTERNAL_ASSERT(tt != nullptr);
@@ -1346,7 +1346,7 @@ Tensor TensorExprKernel::convertStaticShapeOutputToCorrectStrides(
   TORCH_INTERNAL_ASSERT(
       bufs_.count(v),
       buildErrorMessage(
-          "Ouput tensor has no corresponding bufs in the fuser."));
+          "Output tensor has no corresponding bufs in the fuser."));
   BufPtr buf = bufs_.at(v);
 
   // No shape info is present in the graph
@@ -1576,7 +1576,7 @@ BlockPtr TensorExprKernel::bindAllInputs() {
 
 void TensorExprKernel::deduceMemoryLayoutPolicy() {
   // If the tensor is channels-last contiguous, the preferred memory layout
-  // propagation policy is to use channes-last. Otherwise, the preferred policy
+  // propagation policy is to use channels-last. Otherwise, the preferred policy
   // is to use contiguous.
   auto _prefer_symbolic_mem =
       [](const torch::jit::Value* val,
@@ -1650,7 +1650,7 @@ void TensorExprKernel::optimizeOwningGraph() {
   GRAPH_DUMP("TensorExprKernel graph (Before graph optimization):", graph_);
 
   // We may manipulate output pointers in graph manipulation. So we store the
-  // orignal outputs for symbolic strides information synchronization
+  // original outputs for symbolic strides information synchronization
   auto _orignal_graph_outputs = graph_->outputs().vec();
 
   // Get the graph device information first. The graph optimization

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -26,7 +26,7 @@ struct SmallSizeTPairHash {
 bool conv2dIsSupportedJit(const Node* node);
 // Returns true if the TE fuser supports this conv2d with mkldnn prepacked conv.
 bool mkldnnPrepackedConvIsSupportedJit(const Node* node);
-// Returns true if the the _convolution node is Conv2d.
+// Returns true if the TE _convolution node is Conv2d.
 bool isConv2d(const Node* node);
 // Returns true if the TE fuser supports this matmul.
 bool matmulIsSupported(const Node* node);
@@ -103,7 +103,7 @@ class TORCH_API TensorExprKernel {
     BufPtr buf;
     // Only one of ptr and node is used at a time
     // 1) ptr for the constant tensors
-    // 2) node for the constant custom class ojects
+    // 2) node for the constant custom class objects
     void* ptr = nullptr;
     Node* node = nullptr;
   };

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -1120,7 +1120,7 @@ void LLVMCodeGenImpl::visit(CastPtr v) {
     value_ = irb_.CreateLShr(value_, toVec(shift_len, lans));
     value_ = irb_.CreateTrunc(value_, llvmTypeToVec(ShortTy_, lans));
     value_ = irb_.CreateBitOrPointerCast(value_, llvmTypeToVec(ShortTy_, lans));
-    // If the the value is NaN, return BF16 NaN.
+    // If the value is NaN, return BF16 NaN.
     value_ = irb_.CreateSelect(mask, value_, toVec(bf16_nan, lans));
     return;
   }

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -813,7 +813,7 @@ class FunctionInliner : public IRMutator {
     }
   }
 
-  // Any Random Instrinsics that were turned into vars must be inserted here.
+  // Any Random Intrinsics that were turned into vars must be inserted here.
   StmtPtr mutate(BlockPtr v) override {
     if (!success()) {
       return v;
@@ -2930,7 +2930,7 @@ LoopNest::AccessResult LoopNest::cacheAccesses(
     tmp_params.push_back(alloc<Add>(new_loop_vars[i], info.start[i]));
   }
 
-  // Replace acceses to the producer in the consumer with the cache.
+  // Replace accesses to the producer in the consumer with the cache.
   CacheReplacer replacer(producer, tmp_buf, info.start);
   consumer->accept_mutator(&replacer);
 

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -146,7 +146,7 @@ class TORCH_API LoopNest {
 
   // Splits the given loop into 2 nested loops with the given factor as the
   // inner loop bound. If the factor does not evenly divide the loop bound,
-  // then the remainining iterations are extracted into a tail loop that is
+  // then the remaining iterations are extracted into a tail loop that is
   // added after the given loop.
   //
   // For example, consider the following code:

--- a/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest_randomization.cpp
@@ -122,7 +122,7 @@ std::string indexOf(const std::vector<T>& objects, const T& object) {
 } // namespace randomization_helper
 
 void loopnestRandomization(int64_t seed, LoopNest& l) {
-  // This is to help with determinstic testing of randomized infrastructure.
+  // This is to help with deterministic testing of randomized infrastructure.
   // When seed value is 1, we perform preset loop transformations. This allows
   // testing of interface.
   if (seed == 1) {
@@ -132,8 +132,8 @@ void loopnestRandomization(int64_t seed, LoopNest& l) {
 
   std::default_random_engine random_engine(seed);
   std::srand(seed);
-  // Set the maximum allowed number of transformations beyong which it is hard
-  // to track and debug. Arbitratily choosing 20 as maximum number.
+  // Set the maximum allowed number of transformations beyond which it is hard
+  // to track and debug. Arbitrarily choosing 20 as maximum number.
   int max_allowed_transformations = 20;
   int n_transforms = randomization_helper::max_transformations(
       std::rand() % max_allowed_transformations);

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -686,7 +686,7 @@ void MemDependencyChecker::visit(ForPtr v) {
   // They exist in the enclosing scope, but accesses within the loop body may
   // depend on them via usage of the loop variable.
   // The way we handle this is to create a new scope so we have an easily
-  // accessible list of the acceses within the extents.
+  // accessible list of the accesses within the extents.
   auto extentsScope =
       std::make_shared<Scope>(currentScope_->block, currentScope_);
   currentScope_ = extentsScope;
@@ -940,7 +940,7 @@ void MemDependencyChecker::visit(CondPtr v) {
   // present in both the true and false branches then we can close overlapping
   // accesses in the enclosing scope. Without that analysis future accesses
   // may be dependent on a write of a common range in all three of the
-  // enclosing, true and false scope. This is a false positve so not too bad
+  // enclosing, true and false scope. This is a false positive so not too bad
   // in the short term, I think.
 
   // Merge both true and false branches into the parent, but don't close any
@@ -1212,7 +1212,7 @@ void MemDependencyChecker::updateWriteHistory(
       it = writeHistory.erase(it);
     } else {
       // The new write partially overlaps a previous write. We want to keep
-      // both, but only track the unconvered part of the earlier write.
+      // both, but only track the uncovered part of the earlier write.
 
       // Determine the slices of the earlier bound not covered by info.
       auto newBounds =

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
@@ -33,7 +33,7 @@ using DependencySet = std::unordered_set<std::shared_ptr<AccessInfo>>;
 /* AccessInfo
  *
  * Represents a single bounded memory access to a buffer, for instance a Load or
- * a Store. Holds infomation relating to the specific access and links to
+ * a Store. Holds information relating to the specific access and links to
  * connected accesses in the dependency graph.
  */
 class TORCH_API AccessInfo {
@@ -65,7 +65,8 @@ class TORCH_API AccessInfo {
         var_(std::move(var)),
         bounds_(std::move(bounds)) {}
 
-  // Id is a unique int representing the order this access occured in the graph.
+  // Id is a unique int representing the order this access occurred in the
+  // graph.
   size_t id() const {
     return id_;
   }
@@ -166,7 +167,7 @@ class TORCH_API AccessInfo {
 
 using VarBoundMap = std::unordered_map<VarPtr, Bound>;
 
-/* MemDepedencyChecker analyses a IR fragment and builds a dependency graph of
+/* MemDependencyChecker analyses a IR fragment and builds a dependency graph of
  * accesses contained within.
  *
  * It's possible to retrieve the entire graph in node-object form, or can be

--- a/torch/csrc/jit/tensorexpr/operators/misc.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/misc.cpp
@@ -444,7 +444,7 @@ Tensor computeReshape(
         for (size_t idx = 0; idx < A.ndim(); idx++) {
           size_t dim_idx = A.ndim() - idx - 1;
           // We don't need to generate mod-div for the first dimension -
-          // ideally IRSimlifier would get rid of that for us, but for now
+          // ideally IRSimplifier would get rid of that for us, but for now
           // let's just avoid generating it in the first place.
           if (dim_idx > 0) {
             orig_buf_indexes[dim_idx] = flat_idx / stride % A.dim(dim_idx);

--- a/torch/csrc/jit/tensorexpr/operators/quantization.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/quantization.cpp
@@ -707,7 +707,7 @@ Tensor computeUpsampleNearest2d(
   auto scale_h =
       promoteToDtype(input_height, ScalarType::Double) / output_height;
   auto scale_w = promoteToDtype(input_width, ScalarType::Double) / output_width;
-  // TODO: will repetetive if in idx calculation will be taken out of the loop?
+  // TODO: will repetitive if in idx calculation will be taken out of the loop?
   auto compute_nearest_idx =
       [](ExprHandle scale, ExprHandle dst_index, ExprHandle input_size) {
         return Min::make(

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -485,7 +485,7 @@ void RegisterizerAnalysis::visit(LoadPtr v) {
 }
 
 // Loop and Conditional scopes are different in that it may or may not be
-// possible to hoist the intializer of a scalar variable outside the block
+// possible to hoist the initializer of a scalar variable outside the block
 // depending on if we can tell that the Buffer access is valid outside. This is
 // tricky because the access that demonstrates this may be later in the tree and
 // we haven't encountered it yet.
@@ -523,7 +523,7 @@ void RegisterizerAnalysis::mergeHiddenScope(bool allowClosed) {
 void RegisterizerAnalysis::mergeCurrentScopeIntoParent() {
   auto parent = currentScope_->parent();
 
-  // copy across current closed accceses, merging / closing as necessary
+  // copy across current closed accesses, merging / closing as necessary
   for (auto& candidate : currentScope_->closedAccesses()) {
     auto& parentAccesses = parent->getAccessMapByBuf(candidate->buf());
 
@@ -662,7 +662,7 @@ ExprPtr RegisterizerReplacer::mutate(LoadPtr v) {
 
 StmtPtr RegisterizerReplacer::mutate(StorePtr v) {
   if (eliminatedIntializers_.count(v) != 0) {
-    // This store is the intializer for a scalar var that is already inserted.
+    // This store is the initializer for a scalar var that is already inserted.
     return nullptr;
   }
 

--- a/torch/csrc/jit/tensorexpr/registerizer.h
+++ b/torch/csrc/jit/tensorexpr/registerizer.h
@@ -314,7 +314,7 @@ class Scope {
  *
  * - IfThenElse: Same situation as Cond, except since IfThenElse is an Expr
  * rather than a Stmt we cannot insert the scalar definition or finalizer
- * within the conditional scope. Acccesses inside an IfThenElse can be safely
+ * within the conditional scope. Accesses inside an IfThenElse can be safely
  * combined with external accesses but cannot exist completely within.
  *
  * - Let: Accesses dependent on local variables via Let Stmts, or loop vars,

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -276,7 +276,7 @@ TORCH_API Tensor Reduce(
     const BufHandle& buffer,
     const std::vector<ExprHandle>& reduce_dims);
 
-// Overload for the common case of all dimensions of a prevously Computed
+// Overload for the common case of all dimensions of a previously Computed
 // Tensor.
 TORCH_API Tensor Reduce(
     const std::string& func_name,


### PR DESCRIPTION
This PR fixes typo in comments and messages under `torch/csrc/jit/tensorexpr` directory.


cc @EikanWang @jgong5