### PR TITLE
inductor(cpu): fix issue of when load a scalar bfloat16

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6386,7 +6386,7 @@ if HAS_CPU:
             with config.patch({"cpp.simdlen": None}):
                 torch._dynamo.reset()
                 metrics.reset()
-                traced = make_fx(bn)(x, y)
+                traced = make_fx(bn)(x)
                 compiled = compile_fx_inner(traced, [x])
                 assert same(bn(x)[0], compiled([x])[0], equal_nan=True, tol=1e-2)
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6377,7 +6377,8 @@ if HAS_CPU:
                     )
 
                 def forward(self, x):
-                    return self.bn(x)
+                    x = self.bn(x)
+                    return (x,)
 
             bn = Model().to(dtype=torch.bfloat16).eval()
             x = torch.randn((2, 64, 16, 16), dtype=torch.bfloat16)
@@ -6387,7 +6388,7 @@ if HAS_CPU:
                 metrics.reset()
                 traced = make_fx(bn)(x, y)
                 compiled = compile_fx_inner(traced, [x])
-                assert same(fn(x, y)[0], compiled([x, y])[0], equal_nan=True, tol=1e-2)
+                assert same(bn(x)[0], compiled([x])[0], equal_nan=True, tol=1e-2)
 
         @unittest.skipIf(
             not codecache.valid_vec_isa_list(), "Does not support vectorization"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97221

For bn bfloat16, there has an issue when load a bfloat16 scalar:

```
/tmp/torchinductor_xiaobing/qu/cqunsk7ugwjsysikidole5rhzd27jsscfwyr7pqa7ktp43mhwa76.h:98:49: error: no matching function for call to ‘load_fp32_from_bf16(const int*&, at::vec::CPU_CAPABILITY::Vectorized<float>&)’
   at::vec::load_fp32_from_bf16(bf16_buf, res_vec);
                                                 ^
In file included from /home/xiaobing/Downloads/pytorch/torch/include/ATen/cpu/vec/vec256/vec256.h:12,
                 from /home/xiaobing/Downloads/pytorch/torch/include/ATen/cpu/vec/vec.h:6,
                 from /home/xiaobing/Downloads/pytorch/torch/include/ATen/cpu/vec/functional_base.h:6,
                 from /home/xiaobing/Downloads/pytorch/torch/include/ATen/cpu/vec/functional.h:3,
                 from /tmp/torchinductor_xiaobing/qu/cqunsk7ugwjsysikidole5rhzd27jsscfwyr7pqa7ktp43mhwa76.h:10,
                 from /tmp/torchinductor_xiaobing/4f/c4f7sn4hp5yb6xznpb6canqhxohiwuarfmngcbupkc3owfehe2ri.cpp:2:
/home/xiaobing/Downloads/pytorch/torch/include/ATen/cpu/vec/vec256/vec256_bfloat16.h:792:13: note: candidate: ‘void at::vec::CPU_CAPABILITY::load_fp32_from_bf16(const c10::BFloat16*, at::vec::CPU_CAPABILITY::Vectorized<float>&)’
 inline void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>& out) {
             ^~~~~~~~~~~~~~~~~~~
/home/xiaobing/Downloads/pytorch/torch/include/ATen/cpu/vec/vec256/vec256_bfloat16.h:792:13: note:   no known conversion for argument 1 from ‘const int*’ to ‘const c10::BFloat16*’
/home/xiaobing/Downloads/pytorch/torch/include/ATen/cpu/vec/vec256/vec256_bfloat16.h:799:13: note: candidate: ‘void at::vec::CPU_CAPABILITY::load_fp32_from_bf16(const c10::BFloat16*, at::vec::CPU_CAPABILITY::Vectorized<float>&, at::vec::CPU_CAPABILITY::Vectorized<float>&)’
 inline void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>& out1, Vectorized<float>& out2) {
             ^~~~~~~~~~~~~~~~~~~
/home/xiaobing/Downloads/pytorch/torch/include/ATen/cpu/vec/vec256/vec256_bfloat16.h:799:13: note:   candidate expects 3 arguments, 2 provided
/tmp/torchinductor_xiaobing/4f/c4f7sn4hp5yb6xznpb6canqhxohiwuarfmngcbupkc3owfehe2ri.cpp: In function ‘void kernel(const bfloat16*, const bfloat16*, const bfloat16*, const bfloat16*, const bfloat16*, bfloat16*)’:
/tmp/torchinductor_xiaobing/4f/c4f7sn4hp5yb6xznpb6canqhxohiwuarfmngcbupkc3owfehe2ri.cpp:19:92: error: no matching function for call to ‘load_bf16_as_float(const bfloat16*)’
                     auto tmp0 = load_bf16_as_float(in_ptr0 + (8*i2) + (256*i1) + (16384*i0));
                                                                                            ^
In file included from /tmp/torchinductor_xiaobing/4f/c4f7sn4hp5yb6xznpb6canqhxohiwuarfmngcbupkc3owfehe2ri.cpp:2:
/tmp/torchinductor_xiaobing/qu/cqunsk7ugwjsysikidole5rhzd27jsscfwyr7pqa7ktp43mhwa76.h:96:35: note: candidate: ‘at::vec::CPU_CAPABILITY::Vectorized<float> load_bf16_as_float(const int*)’
 inline at::vec::Vectorized<float> load_bf16_as_float(const T* bf16_buf) {
                                   ^~~~~~~~~~~~~~~~~~
/tmp/torchinductor_xiaobing/qu/cqunsk7ugwjsysikidole5rhzd27jsscfwyr7pqa7ktp43mhwa76.h:96:35: note:   no known conversion for argument 1 from ‘const bfloat16*’ {aka ‘const c10::BFloat16*’} to ‘const int*’
/tmp/torchinductor_xiaobing/qu/cqunsk7ugwjsysikidole5rhzd27jsscfwyr7pqa7ktp43mhwa76.h:114:35: note: candidate: ‘at::vec::CPU_CAPABILITY::Vectorized<float> load_bf16_as_float(const bfloat16&)’
 inline at::vec::Vectorized<float> load_bf16_as_float(const bfloat16& bf16_buf) {
                                   ^~~~~~~~~~~~~~~~~~
/tmp/torchinductor_xiaobing/qu/cqunsk7ugwjsysikidole5rhzd27jsscfwyr7pqa7ktp43mhwa76.h:114:35: note:   no known conversion for argument 1 from ‘const bfloat16*’ {aka ‘const c10::BFloat16*’} to ‘const bfloat16&’ {aka ‘const c10::BFloat16&’}
```
This PR will fix it.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire