### PR TITLE
Fix typo under torch/csrc/jit/passes directory

### DIFF
--- a/torch/csrc/jit/passes/concat_opt.cpp
+++ b/torch/csrc/jit/passes/concat_opt.cpp
@@ -296,7 +296,7 @@ class ConcatExpander {
     auto cat_dim_value = maybe_cat_dim.value();
     auto cat_dim = node->input(1);
 
-    // Set the insertion point to the curent `cat` node.
+    // Set the insertion point to the current `cat` node.
     WithInsertPoint guard(node);
     auto none = graph_->insertConstant(IValue());
     auto one = graph_->insertConstant(1);

--- a/torch/csrc/jit/passes/dtype_analysis.cpp
+++ b/torch/csrc/jit/passes/dtype_analysis.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<Stack> MTensorArgumentCreator(Node* n) {
   auto stack = std::make_unique<std::vector<IValue>>();
   for (Value* inp : n->inputs()) {
     if (auto tp = inp->type()->cast<TensorType>()) {
-      // Zero-dim tensors have special type promotion behavoir, hence the need
+      // Zero-dim tensors have special type promotion behavior, hence the need
       // for rank.
       auto rank = tp->symbolic_sizes().rank(); // Validity checked earlier
       auto tensor_size = std::vector<int64_t>(rank.value(), 1);
@@ -56,7 +56,7 @@ std::unique_ptr<Stack> MTensorArgumentCreator(Node* n) {
       stack->emplace_back(false);
     } else {
       // Arrays of values are specifically not handled due
-      // to the fact that naive default vaules would likely be
+      // to the fact that naive default values would likely be
       // incorrect anyways.
       throw std::runtime_error("Unsupported input type for Tensor argument");
     }

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -62,7 +62,7 @@ class AttributePropagator {
         const auto& attr_name = resolved_name->second;
         if (parent_module.hasattr(attr_name)) {
           auto value = parent_module.attr(attr_name);
-          // Freezing client wants to presever this submodule. When cleaning
+          // Freezing client wants to preserve this submodule. When cleaning
           // the frozen module, make sure it will be preserved entirely.
           if (value.isModule()) {
             preservedSubModule_.insert(value.toModule()._ivalue());
@@ -813,7 +813,7 @@ class AttributePropagator {
     removeUnusedAttrs();
   }
 
-  // Prepraring for clean up phase. At this point, record all subModules that
+  // Preparing for clean up phase. At this point, record all subModules that
   // contains mutable attributes.
   void recordReferencedAttrs(std::shared_ptr<Graph>& graph) {
     std::stack<Block*> blocks({graph->block()});
@@ -883,7 +883,7 @@ class AttributePropagator {
     auto type = module.type();
     size_t N = type->numAttributes();
     if (moduleEscapes(module, graph)) {
-      // Perserve all its attributes and methods.
+      // Preserve all its attributes and methods.
       attrsToKeep_[type].insert(N);
       return;
     }
@@ -919,7 +919,7 @@ class AttributePropagator {
   }
 
   // Remove unused attributes and methods for each sub module of the frozen
-  // module. This function iterates over the Calsstypes of its submodule
+  // module. This function iterates over the Classtypes of its submodule
   // attributes including its own type.
   void removeUnusedAttrs() {
     std::vector<std::string> attrsToRemove;

--- a/torch/csrc/jit/passes/freeze_module.h
+++ b/torch/csrc/jit/passes/freeze_module.h
@@ -8,7 +8,7 @@
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/ir/ir.h>
 
-/** \brief Freeze Module, i.e., Assume all atrributes are constants.
+/** \brief Freeze Module, i.e., Assume all attributes are constants.
  *
  * Freezing module is a functionality that allows the JIT to internalize
  * immutable attributes. Combined with inlining, the module is aggressively

--- a/torch/csrc/jit/passes/frozen_concat_linear.cpp
+++ b/torch/csrc/jit/passes/frozen_concat_linear.cpp
@@ -174,7 +174,7 @@ class ConcatLinearLayers {
           constant_as<Tensor>(base_node->namedInput("bias")).value();
 
       // Now iterate over the rest of the users of the set to
-      // see if there is anything that we can coaleasce `base_node` with.
+      // see if there is anything that we can coalesce `base_node` with.
       for (size_t j = i + 1; j < linear_layer_group.size(); j++) {
         auto node = linear_layer_group[j];
         if (checked_nodes.count(node) != 0) {

--- a/torch/csrc/jit/passes/frozen_conv_folding.cpp
+++ b/torch/csrc/jit/passes/frozen_conv_folding.cpp
@@ -66,7 +66,7 @@ bool FoldFrozenConvBatchnorm(Block* b) {
       auto bn_rm_ivalue = bn->namedInput("running_mean");
       auto bn_rv_ivalue = bn->namedInput("running_var");
       // check running_mean and running_var has value, if they are
-      // None(track_running_stats=False), skiping the folding path.
+      // None(track_running_stats=False), skipping the folding path.
       if (bn_rm_ivalue->type() == NoneType::get() &&
           bn_rv_ivalue->type() == NoneType::get()) {
         continue;
@@ -191,7 +191,7 @@ bool checkConvAndBroadcastingOpPreConditions(Node* conv, Node* op) {
       constant_as<Tensor>(conv->namedInput("weight")).value();
 
   // avoid fusing op that causes type promotion
-  // resticting to float avoids int/float difficulties with scalar overload
+  // restricting to float avoids int/float difficulties with scalar overload
   if (!weight_tensor.is_floating_point()) {
     return false;
   }

--- a/torch/csrc/jit/passes/frozen_linear_folding.cpp
+++ b/torch/csrc/jit/passes/frozen_linear_folding.cpp
@@ -47,7 +47,7 @@ bool FoldFrozenLinearBatchnorm(Block* b) {
       auto bn_rv_ivalue = bn->namedInput("running_var");
 
       // check running_mean and running_var has value, if they are
-      // None(track_running_stats=False), skiping the folding path.
+      // None(track_running_stats=False), skipping the folding path.
       if (bn_rm_ivalue->type() == NoneType::get() &&
           bn_rv_ivalue->type() == NoneType::get()) {
         continue;

--- a/torch/csrc/jit/passes/fuse_relu.cpp
+++ b/torch/csrc/jit/passes/fuse_relu.cpp
@@ -54,8 +54,8 @@ void fuseAddReluImpl(std::shared_ptr<Graph>& graph) {
 
   rewriter.runOnGraph(graph);
   // NB: Patterns that are left out are add_ + relu and add_out + relu
-  // This is because inplace mutation of the testor done by add_ will be lost if
-  // inplace mutatation of the same tensor actually does add+relu
+  // This is because inplace mutation of the tensor done by add_ will be lost if
+  // inplace mutation of the same tensor actually does add+relu
 }
 } // namespace
 

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -402,7 +402,7 @@ struct GraphFuser {
   // to prepare for fusion and replace uses of n with the new group
   Node* createSingletonFusionGroup(Node* n) {
     auto group = block_->owningGraph()->createWithSubgraph(kind_);
-    // propogate position information for the new node so we can always
+    // propagate position information for the new node so we can always
     // have a valid mapping
     group->insertBefore(n);
     Node* mergedNode = mergeNodeIntoGroup(group, n);

--- a/torch/csrc/jit/passes/guard_elimination.cpp
+++ b/torch/csrc/jit/passes/guard_elimination.cpp
@@ -89,7 +89,7 @@ struct GuardElimination {
     // uses on *all* parameters are moved to the same anchor node
     // and they may come in different order after the anchor node
     // e.g. (anchor, guard_x, guard_y, guard_x, guard_y)
-    // this pass recognizes contigious streches of guards and
+    // this pass recognizes contiguous stretches of guards and
     // keeps track of the guards it's seen for each def. the next time
     // the guard on the same def, it simply removes it.
     std::unordered_map<Value*, Node*> inputs_to_guards;

--- a/torch/csrc/jit/passes/inliner.cpp
+++ b/torch/csrc/jit/passes/inliner.cpp
@@ -61,7 +61,7 @@ void inlineCalls(Block* block) {
               g = exec_plans.begin()->second.graph;
               // optimized_graph() calls Inline, so we only need to explicitly
               // invoke inlining on the jit optimized graph with recursive
-              // fallback funciton calls
+              // fallback function calls
               Inline(*g.get());
             }
           }

--- a/torch/csrc/jit/passes/loop_unrolling.cpp
+++ b/torch/csrc/jit/passes/loop_unrolling.cpp
@@ -339,7 +339,7 @@ Node* PeelLoop(Node* n, size_t times) {
   // only run until the peeled count
   new_lv.replaceMaxTripCount(min_trip_count);
 
-  // substract `maxTripCount` of the original loop by the number iterations
+  // subtract `maxTripCount` of the original loop by the number iterations
   // the peeled loop runs
   auto new_max_trip_count =
       graph->insert(aten::sub, {orig_loop.maxTripCount(), min_trip_count});

--- a/torch/csrc/jit/passes/onnx/preprocess_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/preprocess_for_onnx.cpp
@@ -53,7 +53,7 @@ at::optional<Node*> FindFusibleListUnpack(Node* n) {
 // graph(%input : Float(5, 4, 3, strides=[12, 3, 1])):
 //   %13 : int[] = prim::Constant[value=[2, 1, 2]]()
 //   %7 : int = prim::Constant[value=0]()
-//   %8 : int = prim::Constant[value=3]()  # Adding addtional input of value 3
+//   %8 : int = prim::Constant[value=3]()  # Adding additional input of value 3
 //      representing the number of outputs.
 //   %14 : Float(2, 4, 3, strides=[12, 3, 1]), %15 : Float(1, 4, 3, strides=[12,
 //      3, 1]), %16 : Float(2, 4, 3, strides=[12, 3, 1] =
@@ -165,7 +165,7 @@ static void ReplaceAddWithConcat(Block* b) {
 }
 
 // This pass also covers the case when the input to ListUnpack
-// is int[] comming from some other op than ListConstruct (like Slice or Shape)
+// is int[] coming from some other op than ListConstruct (like Slice or Shape)
 //
 // before the pass
 // graph(%x.1 : Float(2, 3, strides=[3, 1], requires_grad=0, device=cpu)):

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -70,7 +70,7 @@ struct InplaceConverter {
     // Map from aliases to root value.
     // A single value can have multiple aliases throughout the graph,
     // created by inplace operators, and preserved through loop carried
-    // input/output. For each such value, its first occurance will be set as
+    // input/output. For each such value, its first occurrence will be set as
     // root value.
     std::unordered_map<Value*, Value*> alias_to_value_;
 
@@ -515,7 +515,7 @@ void InplaceConverter::ValueTracker::recordSetValue(
   // then the update must be reflected back to outside.
   // Thus it needs to be registered as a subblock output.
   // This step can be skipped if other alias of this value has already been
-  // registered as sublock output.
+  // registered as subblock output.
   if (!registered && from_outer_alias) {
     if (owning_block_nkind == prim::Loop) {
       owning_block->registerOutput(new_v);

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -203,7 +203,7 @@ static c10::optional<c10::ScalarType> InferExpectedScalarType(const Node* n) {
           // seeing a scalar input, we convert its expected type to tensor.
           if (auto scalar_type = get_scalar_type(input)) {
             auto tensor_type = input->type()->castRaw<TensorType>();
-            // get_scalar_type returns non-null value already guranatees
+            // get_scalar_type returns non-null value already guarantees
             // that the input has a valid tensor_type.
             TORCH_INTERNAL_ASSERT(nullptr != tensor_type);
             auto rank = tensor_type->dim();

--- a/torch/csrc/jit/passes/peephole_alias_sensitive.cpp
+++ b/torch/csrc/jit/passes/peephole_alias_sensitive.cpp
@@ -13,7 +13,7 @@ namespace torch {
 namespace jit {
 
 // This pass only does optimizations which requires Alias Analysis
-// It is seprated out from Peephole Pass so that Peephole does not have
+// It is separated out from Peephole Pass so that Peephole does not have
 // maintain alias db correctness throughout the pass.
 struct PeepholeOptimizeAliasSensitiveImpl {
   PeepholeOptimizeAliasSensitiveImpl(

--- a/torch/csrc/jit/passes/quantization/finalize.cpp
+++ b/torch/csrc/jit/passes/quantization/finalize.cpp
@@ -233,7 +233,7 @@ Module FinalizeOnDevicePTQ(
   const std::string quantized_method_name = "quantized_" + orig_method_name;
   auto graph = module.get_method(method_name).graph();
   // Doing some AOT optimizations here
-  // Of all CSE seeems to be required otherwise in some experiments
+  // Of all CSE seems to be required otherwise in some experiments
   // serialized model is incorrect. As in it cannot be deserialized
   // Rest are included as canonical optimizations that are not for inference
   EliminateCommonSubexpression(graph);
@@ -257,7 +257,7 @@ Module FinalizeOnDevicePTQ(
   // 1. Replicate this method in quantize_forward
   // 2. Remove SetAttr for fp weights that are reset by quantize_forward
   // 3. Remove SetAttr node which will subsequently optimize away the nodes
-  //    producin packed_params
+  //    producing packed_params
   // 4. Modify quantized_forward to remove all the nodes except for SetAttrs
   cloneMethod(module, method_name, quantized_method_name);
   // removeWeightSetAttrs(module, quantized_method_name);
@@ -265,7 +265,7 @@ Module FinalizeOnDevicePTQ(
   removePackedParamInsertionAndFPWeightsSetAttr(
       quantized_graph, packed_param_attr_names);
   // Removing packed params is not sufficient since that does not do DCE
-  // for observer node's getatts and callmthods because callmethods have side
+  // for observer node's getatts and callmethods because callmethods have side
   // effects
   removeObserverCallMethods(quantized_graph);
   // This step removed the return output from the graph and subsequent

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -185,7 +185,7 @@ std::tuple<c10::QScheme, QParamVector> _per_tensor_asym_qparam =
              std::make_pair(".zero_point", IValue(_asym_zero_point)),
              std::make_pair(".scalar_type", IValue(c10::kQUInt8))}));
 
-// quantization parrameters for ops with range -1 to 1
+// quantization parameters for ops with range -1 to 1
 // for example: aten/src/ATen/native/quantized/cpu/qtanh.cpp
 std::tuple<c10::QScheme, QParamVector> _per_tensor_sym_qparam = std::make_tuple(
     c10::kPerTensorAffine,

--- a/torch/csrc/jit/passes/quantization/helper.h
+++ b/torch/csrc/jit/passes/quantization/helper.h
@@ -76,7 +76,7 @@ TORCH_API bool isClamp(Node* n);
 // the input tensor is quantized or not, example: aten::size
 TORCH_API bool isTensorInfoNode(Node* n);
 
-// Check if this the the propaagate op that has single input, e.g. aten::cat
+// Check if this the propagate op that has single input, e.g. aten::cat
 TORCH_API bool isPropagateQuantSingleInputOp(Node* n);
 
 // Check if this is the propagate op that has two inputs, e.g. aten::add

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -316,7 +316,7 @@ class InsertObserversHelper {
    * observe/quantize a value a not, we don't want to observe a value multiple
    * times.
    *
-   * arguemnt: is_entry_point means whether the current method is the forward
+   * argument: is_entry_point means whether the current method is the forward
    * method of the top level module.
    *
    * Since we want to insert observers in the call site instead of in the called
@@ -404,7 +404,7 @@ class InsertObserversHelper {
   // to return an observer configured for a value, if it is needed.
   c10::optional<Module> getObserverFor(Value* v);
 
-  // Uses the state created by fillPassThroughValueMap to propage observed
+  // Uses the state created by fillPassThroughValueMap to propagage observed
   // property which should pass through from inputs to outputs.
   void propagateObservedProperty(
       Value* output,
@@ -1409,7 +1409,7 @@ InsertObserversHelper::insertObserversFor(
     }
 
     for (auto* v : block->outputs()) {
-      // we need explictly skip the values that are already observed
+      // we need explicitly skip the values that are already observed
       // this might happen in subblocks for `if` since
       // these subblock has access to all values before the `if` node
       if (!isObserved(v, block_observed_values)) {
@@ -1706,7 +1706,7 @@ Module InsertObserversForOnDevicePTQ(
   // you will have multiple getattrs for the same attribute and thus potentially
   // multiple observers observing the same value. This will also lead to
   // increased size of the packed param struct. I dont expect this to be a
-  // commong pattern but something to be aware fo Note that current quant
+  // common pattern but something to be aware fo Note that current quant
   // workflow does not prevent this anyway since during inset quant dequant
   // things are inlined anyway
   helper.fillBoundaryValueMap(cloned_module, observer_method_name);

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -30,7 +30,7 @@ struct QuantOpParams {
   c10::QScheme qscheme{c10::kPerTensorAffine};
   std::vector<Value*> qparams;
   // This is only so that insertQuantizationOps can be templatized
-  // and subsequntly significant portion of that code can be reused.
+  // and subsequently significant portion of that code can be reused.
   std::string back() const {
     return "AttributeDoesNotExist";
   }
@@ -714,7 +714,7 @@ class InsertQuantDeQuantHelper {
 
   // In order to propagate quantization ops through the ops that doesn't
   // require observation, we'll first inline the graph, and call the
-  // PropgateQuantizationOps pass
+  // PropagateQuantizationOps pass
   void propagateQuantizationOps(Module& module);
 
   // Used for dynamic quantization to selectively run the weight observers.
@@ -1342,7 +1342,7 @@ void InsertQuantDeQuantHelper::propagateQuantizationOps(Block* block) {
       }
       // 2. remove the dequantize ops from inputs
       removeDequantizeFromInputs(dequantized_inputs);
-      // 3. insert dequantize op for outpus
+      // 3. insert dequantize op for outputs
       for (auto* output : outputs_to_dequantize) {
         insertDeQuantForAllUse(output->owningGraph(), output, output);
       }

--- a/torch/csrc/jit/passes/quantization/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization/quantization_patterns.h
@@ -789,7 +789,7 @@ graph(%a_quant, %alpha, %scale, %input_scale, %r_scale, %r_zero_point, %r_dtype)
          %r_quant = aten::quantize_per_tensor(%r, %r_scale, %r_zero_point, %r_dtype)
          return (%r_quant) )";
 
-  // ============= General Ops that inherit quantization paramters from input
+  // ============= General Ops that inherit quantization parameters from input
   // tensor =============
   auto avg_pool1d = getInputTensorQParamOpFusionInfo(
       "aten::avg_pool1d",

--- a/torch/csrc/jit/passes/remove_exceptions.h
+++ b/torch/csrc/jit/passes/remove_exceptions.h
@@ -15,7 +15,7 @@ namespace jit {
 // "Release" mode, while the original graph was in a "Debug" mode.
 // The pass should only be used when such transformation is guaranteed to be
 // safe by some other mechanisms. For instance, when we know exact shapes of
-// tensors flowing throuth the graph and tensors with such shapes never cause
+// tensors flowing through the graph and tensors with such shapes never cause
 // exceptions.
 TORCH_API void EliminateExceptions(std::shared_ptr<Graph>& graph);
 

--- a/torch/csrc/jit/passes/remove_mutation.cpp
+++ b/torch/csrc/jit/passes/remove_mutation.cpp
@@ -177,7 +177,7 @@ bool MutationRemover::RemoveListMutation(Block* block) {
     // x.append(v1) (or x.insert(0, v1))
     // to:
     // x = {v0, v1} (or x = {v1, v0})
-    // We can remove x.append from the the alias db list of writes.
+    // We can remove x.append from the alias db list of writes.
     // All other aliasing properties remain valid.
     Node* list_construct = mutated_value->node();
     switch (node->kind()) {

--- a/torch/csrc/jit/passes/restore_mutation.cpp
+++ b/torch/csrc/jit/passes/restore_mutation.cpp
@@ -45,7 +45,7 @@ bool FunctionalToInplaceRewriter::CanBeInplace(Node* node) {
     return false;
   }
 
-  // If x has more than one use, skip the converson.
+  // If x has more than one use, skip the conversion.
   // TODO: Use liveness analysis to catch more general scenario
   return (input->uses().size() == 1);
 }

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -208,7 +208,7 @@ c10::ScalarType unionScalarTypes(
 // Promotes result types for arithmetic operations on Tensor operands using
 // new type promotion logic. See tensor_attributes.rst for details.
 // This doesn't handle the case of arithmetic ops with Scalar arguments (when
-// `Tensor.getUnsafeTensorImpl()->is_wrapped_nubmer()` would return true)
+// `Tensor.getUnsafeTensorImpl()->is_wrapped_number()` would return true)
 c10::optional<c10::ScalarType> getPromotedTypeForArithmeticOp(Node* node) {
   c10::ScalarType dimmed = c10::ScalarType::Undefined;
   c10::ScalarType zerodim = c10::ScalarType::Undefined;
@@ -460,7 +460,7 @@ class ShapePropagator : public PropertyPropBase {
       // its most constrained form.
       auto tensor_type = node->outputs()[i]->type()->cast<TensorType>();
       if (stack[i].isTensor() && tensor_type) {
-        // gradient information isn't always available or part of represenative
+        // gradient information isn't always available or part of representative
         // inputs, maintain original grad property
         auto tensor_grad = tensor_type->requiresGrad();
         node->outputs()[i]->setType(TensorType::create(stack[i].toTensor())
@@ -1458,7 +1458,7 @@ class ShapePropagator : public PropertyPropBase {
     //   tensor inputs  : 1
     //   tensor outputs : 1
     // Additionally:
-    //   - has ScalarType dtype, Layeout layout and Device device arguments
+    //   - has ScalarType dtype, Layout layout and Device device arguments
     static const register_formula_for like_factories_with_options{
         {
             "aten::empty_like(Tensor self, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
@@ -1487,7 +1487,7 @@ class ShapePropagator : public PropertyPropBase {
     //   tensor inputs  : 1
     //   tensor outputs : 1
     // Additionally:
-    //   - has int[] size, ScalarType dtype, Layeout layout and Device device
+    //   - has int[] size, ScalarType dtype, Layout layout and Device device
     //   arguments
     static const register_formula_for size_factories_with_options{
         {

--- a/torch/csrc/jit/passes/specialize_autogradzero.cpp
+++ b/torch/csrc/jit/passes/specialize_autogradzero.cpp
@@ -302,8 +302,8 @@ struct AutogradZeroSpecializer {
     }
 
     // We've created:
-    // succesful_checks = Guards(...)
-    // if (succesful_checks)
+    // successful_checks = Guards(...)
+    // if (successful_checks)
     // -> optimized graph
     // else:
     // -> fallback graph

--- a/torch/csrc/jit/passes/subgraph_rewrite.cpp
+++ b/torch/csrc/jit/passes/subgraph_rewrite.cpp
@@ -94,7 +94,7 @@ void SubgraphRewriter::rewriteSinglePatternOnGraph(
 
   // First construct map of Node*-to-Node*
   // This maps Nodes in replacement graph to nodes in pattern graph
-  // given the value_name_map, which maps value names from repalcement
+  // given the value_name_map, which maps value names from replacement
   // pattern to value name in pattern
   std::unordered_map<Node*, Node*> pattern_node_map;
   std::set<const Node*> pattern_input_nodes;

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -268,17 +268,17 @@ c10::SymbolicShape extractListShape(
 }
 
 // Symbolic Shape Analysis works through iteratively partially evaluating
-// a TorchScript shape compute graph by inputing properties from input
+// a TorchScript shape compute graph by inputting properties from input
 // Tensors. We can substitute in properties like `len(x)` and `x[1]`
 // if they are statically on the input Tensors. We can also use
 // assertions like `assert len(x) == 4` in order to refine the input
 // length and unroll loops over its elements. We iteratively optimize and
 // substitute in properties until we are unable to make any further
 // optimizations. Finally, we try to extract Tensor properties from the output.
-// For instance `return [1, 2, inp[2] + 1, inp[3]]` we know that the ouptut
+// For instance `return [1, 2, inp[2] + 1, inp[3]]` we know that the output
 // will be length 4 with first two dimensions equal to 1 and 2. We can also
 // deduce that the 4th dimension has the same symbolic shape as inp[3], which
-// means that we do know its concrete value statically but we can asssign sets
+// means that we do know its concrete value statically but we can assign sets
 // of tensor dimensions which must be equal at runtime.
 
 struct SymbolicShapeOpAnalyzer {
@@ -287,7 +287,7 @@ struct SymbolicShapeOpAnalyzer {
   std::vector<SSArgument> inputs_;
 
   // For the case where we have a JIT graph,
-  // subsititute optional types for their component types
+  // substitute optional types for their component types
   // if the type is known. This doesn't need to be done
   // for known IValues.
   void refineInputUnionTypes(const Node* parent_graph_node) {
@@ -571,7 +571,7 @@ struct SymbolicShapeOpAnalyzer {
     TORCH_INTERNAL_ASSERT(
         shape_compute_graph_->outputs().size() == schema_->returns().size());
     // TODO: would be nice if there were easy facility to look at uses and see
-    // if they are all pure instead of instanting db.
+    // if they are all pure instead of instantiating db.
     auto res = std::vector<c10::SymbolicShape>();
     AliasDb db(shape_compute_graph_);
     for (size_t i = 0; i < shape_compute_graph_->outputs().size(); ++i) {

--- a/torch/csrc/jit/passes/symbolic_shape_cache.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_cache.cpp
@@ -4,7 +4,7 @@
 
 #include <utility>
 
-// SHAPE CACHINHG CODE
+// SHAPE CACHING CODE
 namespace torch {
 namespace jit {
 namespace {

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -115,7 +115,7 @@ StrideInput strideInputFromString(const std::string& si) {
 
 // in the runtime guard, strides are serialized as one flat
 // vector. stride_inputs_offset indexes into that vector
-// where the strides of this tensor beegin
+// where the strides of this tensor begin
 inline StrideInput summarizeStrideDim(
     const c10::IntArrayRef sizes,
     const c10::IntArrayRef strides,

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.h
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.h
@@ -14,7 +14,7 @@ namespace jit {
 // dimensions with the same value will be bucketed to the same symbolic shape.
 // E.g. Tensor(5, 3), Tensor(3, 1) -> Tensor(SS(-1), SS(-2)), Tensor(SS(-2), 1)
 // From there, runs symbolic shape inference on the graph, and creates a
-// versionining if in the graph with prim::TensorExprDynamicGuard checking if
+// versioning if in the graph with prim::TensorExprDynamicGuard checking if
 // the inputs at runtime match the Generalized Symbolic Shapes that are inputs
 // to the TE Kernel. The computate to calculate all symbolic dimensions is
 // inlined in to the if block with the TE Kernel. All Sym Dim Value* are

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -683,7 +683,7 @@ class TensorExprFuser {
 
     // Try to merge adjacent fusion groups together. Because we have only merged
     // by looking at graph inputs, without this we would not attempt to merge
-    // adjacent fusion groups that don't have a depdency on each other
+    // adjacent fusion groups that don't have a dependency on each other
 
     std::vector<Node*> initial_fusion_groups;
     for (Node* n : block->nodes()) {
@@ -699,7 +699,7 @@ class TensorExprFuser {
       // Try merging the just created fusion group into the previous one.
       // If it did not work, then put the previous fusion group into
       // fusion_groups vector - we will not touch it anymore in this loop.
-      // If merging suceeded, save the merged group as the "previous" fusion
+      // If merging succeeded, save the merged group as the "previous" fusion
       // group so that we can try to merge the next one into it.
 
       Node* fusion_group = initial_fusion_groups[i];
@@ -1151,7 +1151,7 @@ class TensorExprFuser {
     REQ(tensorexpr::isSupported(node));
     REQ(typesAreSupported(node));
 
-    // A hook to optimizations limitter to allow bisecting the pass
+    // A hook to optimizations limiter to allow bisecting the pass
     REQ(JIT_OPT_ALLOWED);
 
     if (fuse_to_dynamic_shapes_) {

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -610,7 +610,7 @@ std::string truncateStrWithHash(const std::string& s, size_t maxlen) {
   // If hash-string plus '_' can fit into maxlen, then truncate the original
   // string correspondingly so that the final string with the hash included fits
   // into maxlen. If that's not possible, at least truncate the original string
-  // to maxlen (and appen the hash to it).
+  // to maxlen (and append the hash to it).
   size_t trunc_len =
       (maxlen > hash_str.size() + 1) ? (maxlen - hash_str.size() - 1) : maxlen;
   std::stringstream truncated;

--- a/torch/csrc/jit/passes/utils/subgraph_utils.h
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.h
@@ -21,7 +21,7 @@ namespace SubgraphUtils {
 // Returns the new subgraph node.
 TORCH_API Node* createSingletonSubgraph(Node* n, Symbol subgraphKind);
 
-// Creates a new subgraph that only contains `n`, amd udpates the new outputs
+// Creates a new subgraph that only contains `n`, amd updates the new outputs
 // of the subgraph to have the aliasing properties of the original `n` outputs
 TORCH_API Node* createSingletonSubgraphAndUpdateAliasing(
     Node* to_merge,


### PR DESCRIPTION
This PR fixes typo in comments under `torch/csrc/jit/passes` directory.
