### PR TITLE
Added a note to torch.round doc to indicate the return type 

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -9575,6 +9575,7 @@ Rounds elements of :attr:`input` to the nearest integer.
 
 For integer inputs, follows the array-api convention of returning a
 copy of the input tensor.
+The return type of output is same as that of input's dtype.
 
 .. note::
     This function implements the "round half to even" to


### PR DESCRIPTION
Added a note to torch.round doc to indicate the return type of output tensor

Fixes #89056 
