### PR TITLE
MPS: MPSGraph created with wrong axes when dim=[] specified

### DIFF
--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include <vector>
+#include <iostream>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -17,7 +17,6 @@
 #endif
 
 #include <vector>
-#include <iostream>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -40,7 +40,7 @@ void set_apparent_shapes(NSMutableArray<NSNumber*>*& apparent_out_shape,
                          int64_t num_reduce_dims,
                          int64_t num_output_dims,
                          IntArrayRef& input_shape,
-                         NSMutableArray<NSNumber*>*& axes) {
+                         NSArray<NSNumber*>* axes) {
   if (num_reduce_dims == 0) {
     /* Output shape becomes a one
      * Input shape becomes flattened

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -416,13 +416,6 @@ void impl_func_norm_mps(const Tensor& input_tensor,
   int64_t num_reduce_dims = dim.size();
   int64_t num_output_dims;
 
-  std::cout << "impl_func_norm_mps" << "input_tensor: " << input_tensor << ", other_tensor: " << other_tensor
-            << ", p: " << p << ", dim: " << dim << ", keepdim: " << keepdim
-            << ", in_dtype: " << in_dtype
-            << ", output_t: " << output_t
-            << ", cdist: " << cdist
-            << ", input_shape: " << input_shape <<std::endl;
-
   // For output shape calculation, assume that keepdim is true
   num_output_dims = num_input_dims;
   NSMutableArray<NSNumber*>* apparent_output_shape = nil;
@@ -444,9 +437,6 @@ void impl_func_norm_mps(const Tensor& input_tensor,
     return;
   }
 
-  NSLog(@"apparent_input_shape = %@, apparent_output_shape = %@, axes = %@",
-    apparent_input_shape, apparent_output_shape, axes);
-
   auto stream = at::mps::getCurrentMPSStream();
   @autoreleasepool {
     NSString* ns_key = [[axes valueForKey:@"description"] componentsJoinedByString:@","];
@@ -455,7 +445,6 @@ void impl_func_norm_mps(const Tensor& input_tensor,
     string key =
         string("norm_out_mps:") + [ns_key UTF8String] + ":" + tensor_key + ":p" + to_string(p) + ":" + keepdim_info;
 
-    std::cout << "key: " << key << std::endl;
     auto cachedGraph = cache_->LookUpAs<MPSBinaryCachedGraph>(key);
 
     if (!cachedGraph) {
@@ -545,7 +534,6 @@ void impl_func_norm_mps(const Tensor& input_tensor,
 
 TORCH_IMPL_FUNC(norm_out_mps)
 (const Tensor& self, const OptionalScalarRef opt_p, IntArrayRef dim, bool keepdim, const Tensor& result) {
-  std::cout << "norm_out_mps" << ", dim: " << dim << ", keepdim: " << keepdim << std::endl;
   impl_func_norm_mps(self, self, opt_p, dim, keepdim, c10::nullopt, result, /*cdist=*/false);
 }
 
@@ -556,7 +544,6 @@ TORCH_IMPL_FUNC(norm_dtype_out_mps)
  bool keepdim,
  ScalarType dtype,
  const Tensor& result) {
-  std::cout << "norm_dtype_out_mps" << ", dim: " << dim << ", keepdim: " << keepdim << std::endl;
   impl_func_norm_mps(self, self, opt_p, dim, keepdim, dtype, result, /*cdist=*/false);
 }
 

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -78,9 +78,13 @@ void set_axes(NSMutableArray<NSNumber*>*& axes,
               int64_t num_reduce_dims,
               OptionalIntArrayRef opt_dim,
               int64_t num_input_dims) {
-  if (num_reduce_dims == 0) {
-    axes = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    axes[0] = @0;
+  if (!opt_dim.has_value() || num_reduce_dims == 0) {
+    // To match the CPU implementation, when dim={} or null,
+    // performs an all-reduce
+    axes = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
+    for (const auto i : c10::irange(num_input_dims)) {
+      axes[i] = @(i);
+    }
   } else {
     TORCH_INTERNAL_ASSERT(opt_dim.has_value());
     IntArrayRef dim = opt_dim.value();

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -412,6 +412,13 @@ void impl_func_norm_mps(const Tensor& input_tensor,
   int64_t num_reduce_dims = dim.size();
   int64_t num_output_dims;
 
+  std::cout << "impl_func_norm_mps" << "input_tensor: " << input_tensor << ", other_tensor: " << other_tensor
+            << ", p: " << p << ", dim: " << dim << ", keepdim: " << keepdim
+            << ", in_dtype: " << in_dtype
+            << ", output_t: " << output_t
+            << ", cdist: " << cdist
+            << ", input_shape: " << input_shape <<std::endl;
+
   // For output shape calculation, assume that keepdim is true
   num_output_dims = num_input_dims;
   NSMutableArray<NSNumber*>* apparent_output_shape = nil;
@@ -433,6 +440,9 @@ void impl_func_norm_mps(const Tensor& input_tensor,
     return;
   }
 
+  NSLog(@"apparent_input_shape = %@, apparent_output_shape = %@, axes = %@",
+    apparent_input_shape, apparent_output_shape, axes);
+
   auto stream = at::mps::getCurrentMPSStream();
   @autoreleasepool {
     NSString* ns_key = [[axes valueForKey:@"description"] componentsJoinedByString:@","];
@@ -441,6 +451,7 @@ void impl_func_norm_mps(const Tensor& input_tensor,
     string key =
         string("norm_out_mps:") + [ns_key UTF8String] + ":" + tensor_key + ":p" + to_string(p) + ":" + keepdim_info;
 
+    std::cout << "key: " << key << std::endl;
     auto cachedGraph = cache_->LookUpAs<MPSBinaryCachedGraph>(key);
 
     if (!cachedGraph) {
@@ -530,6 +541,7 @@ void impl_func_norm_mps(const Tensor& input_tensor,
 
 TORCH_IMPL_FUNC(norm_out_mps)
 (const Tensor& self, const OptionalScalarRef opt_p, IntArrayRef dim, bool keepdim, const Tensor& result) {
+  std::cout << "norm_out_mps" << ", dim: " << dim << ", keepdim: " << keepdim << std::endl;
   impl_func_norm_mps(self, self, opt_p, dim, keepdim, c10::nullopt, result, /*cdist=*/false);
 }
 
@@ -540,6 +552,7 @@ TORCH_IMPL_FUNC(norm_dtype_out_mps)
  bool keepdim,
  ScalarType dtype,
  const Tensor& result) {
+  std::cout << "norm_dtype_out_mps" << ", dim: " << dim << ", keepdim: " << keepdim << std::endl;
   impl_func_norm_mps(self, self, opt_p, dim, keepdim, dtype, result, /*cdist=*/false);
 }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1946,6 +1946,10 @@ class TestMPS(TestCaseMPS):
         c = torch.tensor([[1, 2, 3], [-1, 1, 4]], dtype=torch.float, device="mps")
         c_cpu = torch.tensor([[1, 2, 3], [-1, 1, 4]] , dtype=torch.float, device="cpu")
 
+        res = torch.norm(c, dim=[])
+        res_cpu = torch.norm(c_cpu, dim=[])
+        self.assertEqual(res, res_cpu)
+
         res = torch.norm(c, dim=0)
         res_cpu = torch.norm(c_cpu, dim=0)
         self.assertEqual(res, res_cpu)


### PR DESCRIPTION
This PR fixes https://github.com/pytorch/pytorch/issues/97231.

## Purpose

The implementation of the `set_axes` function in `aten/src/ATen/native/mps/operations/ReduceOps.mm` is different from the CPU implementation and does not perform an all-reduce when `dim=[]`. As a result, the MPSGraph is cached with incorrect axes.

This leads to the inconsistency and crashes described in https://github.com/pytorch/pytorch/issues/97231.

## Changes made

- Update `set_axes` function in `ReduceOps.mm` to match CPU implementation
- Replace the previous condition for `num_reduce_dims == 0` with a
  check for opt_dim having no value or `num_reduce_dims == 0`
- To perform an all-reduce, modify axes initialization to create an array with `num_input_dims` capacity and set each element to its index value.

