### PR TITLE
Fix typo under torch/csrc/jit/runtime directory

### DIFF
--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -132,7 +132,7 @@ bool isDifferentiable(Graph& g) {
 //
 // The output of compiled forward graph is [real_outputs, ctx]
 // The input of compiled backward graph is [ctx, grad_values]
-// We run LowerSimpleTuples afterwards to elmininate all tuples generated in
+// We run LowerSimpleTuples afterwards to eliminate all tuples generated in
 // this process. The original node and TupleConstruct nodes in forward graph
 // will be cleaned up later using EliminateDeadCode(block). TupleUnPack node in
 // backward graph will be removed in eliminateDeadcode(ReverseDetails) defined
@@ -304,7 +304,7 @@ class GradientHelper {
 // If we have a function y = f(x) with jacobian J, the backwards of f is dx =
 // J^t dy. Note that because the backwards always implements this matrix
 // multiply, we know that it maps an input vector of zeros to an output vector
-// of zero regardless of what operations it choses to do inside to actually
+// of zero regardless of what operations it chooses to do inside to actually
 // implement the matrix multiply (most use some optimized form and never
 // generate J^t). More generally, we know that all of the backward computations
 // are linear and can use this property to do more aggressive optimizations
@@ -752,7 +752,7 @@ static void lambdaLiftReverse(Gradient& grad_desc, ReverseDetails& rev_info) {
       // an output
     } else {
       // we need to create a new temporary output for this capture because it
-      // wasn't availiable.
+      // wasn't available.
 
       auto out_index = graph.registerOutput(capture_val);
       GRAPH_DEBUG(

--- a/torch/csrc/jit/runtime/calculate_necessary_args.h
+++ b/torch/csrc/jit/runtime/calculate_necessary_args.h
@@ -57,7 +57,7 @@ inline std::pair<int64_t, int64_t> CalculateNecessaryArgs(
         return std::make_pair(schema_idx + 1, num_out);
       }
       // if the IR has same value as default value of the schema,
-      // it is not neccessary argument.
+      // it is not necessary argument.
       if (schema_value != actual_value.value()) {
         return std::make_pair(schema_idx + 1, num_out);
       }

--- a/torch/csrc/jit/runtime/decomposition_registry.cpp
+++ b/torch/csrc/jit/runtime/decomposition_registry.cpp
@@ -133,7 +133,7 @@ c10::optional<GraphFunction*> GetDecompositionFunction(
   auto& func = toGraphFunction(*cache_it->second);
   // Simple Executor:
   // To allow decomposition to run on tensor subclasses such as batched tensors,
-  // we set decompostion execution to use the simple executor so that
+  // we set decomposition execution to use the simple executor so that
   // optimizations that do not compose with arbitrary subclasses (such as
   // fusion) do not run
   func._set_initial_executor_execution_mode(ExecutorExecutionMode::SIMPLE);

--- a/torch/csrc/jit/runtime/instruction.h
+++ b/torch/csrc/jit/runtime/instruction.h
@@ -58,7 +58,7 @@ namespace jit {
   _(UNCHECKED_CAST, "") /* perform an unchecked cast operation */              \
   _(__IS__, "") /* performs `is` operator from Python */                       \
   _(UN_INITIALIZED,                                                            \
-    "") /* sets default values to varaibles that are  un initialized */        \
+    "") /* sets default values to variables that are uninitialized */          \
   _(__ISNOT__, "") /* performs `is not` operator from Python  */               \
   _(FORMAT, "I") /* performs string format function `f strings` or `{}.format` \
                      the number of inputs in stored in X */                    \

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -145,12 +145,12 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
   // this holds all the tensors for this interpreter run
   // we don't bother minimizing the size of this vector, since the extra
   // memory used by the pointers in this will be small
-  // instead we are very aggressive about releasing tensors when they become dead
-  // to make sure memory management happens efficiently.
-  // We optimize for the case where derivatives are run with retain_graph=False
-  // in the case where it is true, then the interpreter and this array get
-  // copied if this every becomes a bottleneck then we _should_ consider
-  // minimizing the total number or register
+  // instead we are very aggressive about releasing tensors when they become
+  // dead to make sure memory management happens efficiently. We optimize for
+  // the case where derivatives are run with retain_graph=False in the case
+  // where it is true, then the interpreter and this array get copied if this
+  // every becomes a bottleneck then we _should_ consider minimizing the total
+  // number or register
   std::vector<IValue> registers;
 
   // A stack of objects that have been __enter__'d.

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -55,7 +55,7 @@ namespace jit {
 
 using CodeImpl = interpreter::CodeImpl;
 
-// Before we translate to intepreter instructions, we do
+// Before we translate to interpreter instructions, we do
 // some preprocessing of the graph to turn it into a form that is closer
 // to what the instructions will look like.
 // In particular we:
@@ -145,7 +145,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
   // this holds all the tensors for this interpreter run
   // we don't bother minimizing the size of this vector, since the extra
   // memory used by the pointers in this will be small
-  // instead we are very aggresive about releasing tensors when they become dead
+  // instead we are very aggressive about releasing tensors when they become dead
   // to make sure memory management happens efficiently.
   // We optimize for the case where derivatives are run with retain_graph=False
   // in the case where it is true, then the interpreter and this array get
@@ -188,7 +188,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
   }
 
   // relative to the end of the register list so that when we call
-  // functions we are referring to the registers of the currenly executing
+  // functions we are referring to the registers of the currently executing
   // function.
   IValue& reg(size_t reg) {
     return *(registers.end() - reg);
@@ -207,7 +207,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
 #endif
 // Primitives for making interpreter internal state transitions.
 // We maintain two local variables as the internal interpreter state:
-// `frame` will be the current frame that the interpreter operatos on.
+// `frame` will be the current frame that the interpreter operators on.
 // `inst` will the current instruction pointed to by program counter.
 //
 // Instruction blocks should be always declared through `INST` macro and

--- a/torch/csrc/jit/runtime/interpreter/can_emit_inline.h
+++ b/torch/csrc/jit/runtime/interpreter/can_emit_inline.h
@@ -67,7 +67,7 @@ struct CanEmitInline {
   Node* scanValue(Node* block_point, Value* v) {
     // this node is a candidate for inline, if our reverse scan of the
     // node list lines up with the use of v, we know it will be emitted in
-    // tree order, and we can inlining. Scan continutes for further nodes.
+    // tree order, and we can inlining. Scan continues for further nodes.
     if (v->node() == block_point && canInline(v)) {
       // since we inlined this node, we may be able to recursively inline
       // its inputs, so we continue scanning it

--- a/torch/csrc/jit/runtime/jit_trace.cpp
+++ b/torch/csrc/jit/runtime/jit_trace.cpp
@@ -23,7 +23,7 @@ namespace jit {
 
 namespace {
 
-// A helper structure to mantain the mappings
+// A helper structure to maintain the mappings
 // between values from a scripted graph and
 // a traced graph
 struct TracingData {

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -395,7 +395,7 @@ FusionBehavior ProfilingGraphExecutorImpl::getCurrentBehavior(
     }
   }
   // should never get here
-  TORCH_WARN("Stratgy changed mid-invocation, NYI");
+  TORCH_WARN("Strategy changed mid-invocation, NYI");
   return FusionBehavior::STATIC;
 }
 

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -260,7 +260,7 @@ RegisterOperators reg({
         },
         aliasAnalysisFromSchema()),
     // NB: backward op might write to every input tensors in the graph and it's
-    // much more expensive to analayze the leaves and sometimes it might retain
+    // much more expensive to analyze the leaves and sometimes it might retain
     // the whole gradients in every tensor of the Autograd graph with
     // create_graph=True so we use aliasAnalysisConservative for these two OPs
     Operator(

--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -959,8 +959,8 @@ def mv(self: List[int],
   _1 = "AssertionError: max_pool2d: stride must either be omitted, a single int, or a tuple of two ints"
   _2 = "AssertionError: max_pool2d: padding must be either be a single int, or a tuple of two ints"
   _3 = "AssertionError: max_pool2d: dilation must be either a single int, or a tuple of two ints"
-  _4 = "AssertionError: stride should not be zeero"
-  _5 = "AssertionError: stride should not be zeero"
+  _4 = "AssertionError: stride should not be zero"
+  _5 = "AssertionError: stride should not be zero"
   if torch.eq(torch.len(kernel_size), 1):
     _6 = True
   else:
@@ -1172,7 +1172,7 @@ def mv(self: List[int],
   _1 = "AssertionError: max_pool2d: stride must either be omitted, a single int, or a tuple of two ints"
   _2 = "AssertionError: max_pool2d: padding must be either be a single int, or a tuple of two ints"
   _3 = "AssertionError: max_pool2d: dilation must be either a single int, or a tuple of two ints"
-  _4 = "AssertionError: stride should not be zeero"
+  _4 = "AssertionError: stride should not be zero"
   if torch.eq(torch.len(kernel_size), 1):
     _5 = True
   else:

--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -959,8 +959,8 @@ def mv(self: List[int],
   _1 = "AssertionError: max_pool2d: stride must either be omitted, a single int, or a tuple of two ints"
   _2 = "AssertionError: max_pool2d: padding must be either be a single int, or a tuple of two ints"
   _3 = "AssertionError: max_pool2d: dilation must be either a single int, or a tuple of two ints"
-  _4 = "AssertionError: stride should not be zero"
-  _5 = "AssertionError: stride should not be zero"
+  _4 = "AssertionError: stride should not be zeero"
+  _5 = "AssertionError: stride should not be zeero"
   if torch.eq(torch.len(kernel_size), 1):
     _6 = True
   else:
@@ -1172,7 +1172,7 @@ def mv(self: List[int],
   _1 = "AssertionError: max_pool2d: stride must either be omitted, a single int, or a tuple of two ints"
   _2 = "AssertionError: max_pool2d: padding must be either be a single int, or a tuple of two ints"
   _3 = "AssertionError: max_pool2d: dilation must be either a single int, or a tuple of two ints"
-  _4 = "AssertionError: stride should not be zero"
+  _4 = "AssertionError: stride should not be zeero"
   if torch.eq(torch.len(kernel_size), 1):
     _5 = True
   else:

--- a/torch/csrc/jit/runtime/static/fusion.cpp
+++ b/torch/csrc/jit/runtime/static/fusion.cpp
@@ -287,7 +287,7 @@ void createFusionGroups(Block* block, AliasDb* aliasDb, size_t min_size) {
 
   // Try to merge adjacent fusion groups together. Because we have only merged
   // by looking at graph inputs, without this we would not attempt to merge
-  // adjacent fusion groups that don't have a depdency on each other
+  // adjacent fusion groups that don't have a dependency on each other
 
   std::vector<Node*> initial_fusion_groups;
   for (Node* n : block->nodes()) {
@@ -303,7 +303,7 @@ void createFusionGroups(Block* block, AliasDb* aliasDb, size_t min_size) {
     // Try merging the just created fusion group into the previous one.
     // If it did not work, then put the previous fusion group into
     // fusion_groups vector - we will not touch it anymore in this loop.
-    // If merging suceeded, save the merged group as the "previous" fusion
+    // If merging succeeded, save the merged group as the "previous" fusion
     // group so that we can try to merge the next one into it.
 
     Node* fusion_group = initial_fusion_groups[i];

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1251,7 +1251,7 @@ void BlockRunner::Deallocator::cleanupImpl() {
     block_runner_.planner_->deallocate();
   } else {
     // This is the first run, and it didn't finish, so we can't use a
-    // `MemoryPlanner` to deallocate stuff. Just reset everything mannually.
+    // `MemoryPlanner` to deallocate stuff. Just reset everything manually.
     block_runner_.resetMemory();
   }
   // clean up owning refs of input tensors
@@ -1712,7 +1712,7 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
   results.setup_time = timer.MilliSeconds();
 
   // The first iteration profiles each node's output Tensors' sizes and
-  // initializes the memory planner with the profile information. Folllowing
+  // initializes the memory planner with the profile information. Following
   // iterations just use the already established memory planning.
   timer.Start();
   operator()(args_list[0], is_kwargs_empty ? empty_kwargs : kwargs_list[0]);

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -855,7 +855,7 @@ class TORCH_API ProcessedNodeMetadata {
 
   ProcessedNodeMetadata() : launcher_(nullptr) {}
 
-  // deleted copy ctor/assigment as standard containers (vector) always
+  // deleted copy ctor/assignment as standard containers (vector) always
   // have copy constructors, but their instantiation is not well-formed
   // if the contained type (BlockRunner) is not copyable
   ProcessedNodeMetadata(const ProcessedNodeMetadata&) = delete;

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -1089,7 +1089,7 @@ class TORCH_API ForkedSubgraphSRLauncher {
 /*
   helper function to create a future on return type
   of the graph outputs. This function is utilized by
-  prim::fork and aten::wait oprations for async
+  prim::fork and aten::wait operations for async
   execution of subgraphs
 */
 c10::intrusive_ptr<Future> createFutureTypeFromGraphOutput(

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -403,7 +403,7 @@ const std::vector<std::string> functions = {
 
         # In matmul backward case of [b, m, n] * [b, n, p] => [m, p],
         # instead of doing [b, m, p] and then reduce to [m, p]
-        # whice potentially uses large intermediate of size b*m*p,
+        # which potentially uses large intermediate of size b*m*p,
         # we do [m, bn] * [bn, p] to avoid having the large
         # intermediate, thus reduces max memory usage.
         def AD_matmul_bw_special_fold(mat1, mat2):

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -18,7 +18,7 @@ void addFormattedArg(
     const IValue& ival,
     std::stringstream& ss,
     int precision = defaultPrecision) {
-  // TODO: Implement precison-based formatting
+  // TODO: Implement precision-based formatting
   std::stringstream tmp;
   switch (key) {
     case 'd':


### PR DESCRIPTION
This PR fixes typo in comments and messages under `torch/csrc/jit/runtime` directory.