### PR TITLE
Fix typo under torch/testing directory 

### DIFF
--- a/torch/testing/_internal/codegen/random_topo_test.py
+++ b/torch/testing/_internal/codegen/random_topo_test.py
@@ -128,7 +128,7 @@ def random_topology_test(seed, *inp_tensor_list):
                     print("binary, op_2_index {0}, rh_index ?{1}".format(op_2_index, rh_index))
         else:
             # binary operation, we just randomly pick two candidates.
-            # this is not the most efficient way to close dependecy, as we could have
+            # this is not the most efficient way to close dependency, as we could have
             # two candidate that are actually connected
             cand_index = np.random.randint(0, len(candidate))
             if cand_index == index:

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -88,7 +88,7 @@ def tf32_on(self, tf32_precision=1e-5):
 
 # This is a wrapper that wraps a test to run this test twice, one with
 # allow_tf32=True, another with allow_tf32=False. When running with
-# allow_tf32=True, it will use reduced precision as pecified by the
+# allow_tf32=True, it will use reduced precision as specified by the
 # argument. For example:
 #    @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
 #    @tf32_on_and_off(0.005)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -288,9 +288,9 @@ def sample_inputs_as_strided_scatter(op_info, device, dtype, requires_grad, **kw
         ((3, 3), (2, 2), (1, 2), 0),
         ((3, 3), (2, 2), (1, 2), 1),
         ((3, 3), (2, 2), (2, 1), 0),
-        # Scatter to larger dimentions
+        # Scatter to larger dimensions
         ((16,), (2, 2, 2, 2), (8, 4, 2, 1), 0),
-        # Scatter to larger dimentions with strides inverted
+        # Scatter to larger dimensions with strides inverted
         ((16,), (2, 1, 1, 2), (1, 2, 4, 8), 0),
     ]
 
@@ -2202,7 +2202,7 @@ def error_inputs_hstack_dstack_vstack(op, device):
 def sample_inputs_unbind(op_info, device, dtype, requires_grad, **kwargs):
     # Note: we don't do any tests where we unbind along 0-length dims
     # because in that case unbind returns and empty tuple, and that breaks
-    # some asumptions in some backward tests in test_ops.py
+    # some assumptions in some backward tests in test_ops.py
     shape_dims = (((S,), 0),
                   ((S, S), 0),
                   ((S, S), 1),
@@ -2267,7 +2267,7 @@ def error_inputs_gather(op_info, device, **kwargs):
     #        [1, 0]
     idx = torch.tensor(((0, 0), (1, 0)), device=device, dtype=torch.long)
 
-    # Index should be smaller than self except on dimesion 1
+    # Index should be smaller than self except on dimension 1
     bad_src = make_tensor((1, 1), device=device, dtype=torch.float32)
     yield ErrorInput(SampleInput(bad_src, args=(1, idx,)),
                      error_regex="Size does not match at dimension 0")
@@ -4128,7 +4128,7 @@ def sample_inputs_gelu(self, device, dtype, requires_grad, **kwargs):
 
 
 def error_inputs_gelu(op, device, **kwargs):
-    # Tests thtat gelu errors out when passed an approximation we don't know.
+    # Tests that gelu errors out when passed an approximation we don't know.
     yield ErrorInput(SampleInput(make_tensor((), dtype=torch.float, device=device), kwargs={"approximate": "asdf"}),
                      error_regex="approximate argument must be either")
 
@@ -5778,7 +5778,7 @@ def sample_inputs_diagonal_scatter(op_info, device, dtype, requires_grad, **kwar
 
     for input_shape, arg in chain(product(shapes_2d, args_2d), product(shapes_3d, args_3d)):
         input_ = make_arg(input_shape)
-        # We can programatically figure out the right shape for src:
+        # We can programmatically figure out the right shape for src:
         # It should be the same size as input.diagonal(other_args...)
         if not isinstance(arg, tuple):
             arg_tuple = (arg,)
@@ -7983,13 +7983,13 @@ def sample_inputs_max_unpool_grad(op_info, device, dtype, requires_grad, **kwarg
         # It could be that a single element from the max_pool's
         # input is mapped to several locations in its output.
         # This situation leads to failed gradchecks because
-        # the finite difference algorithm perturbes the elements
+        # the finite difference algorithm perturbs the elements
         # of the output one by one, and not in classes of
         # equivalences determined by whether two elements
         # in the output are coming from the same location in the
         # input (simply put, they have the same corresponding index).
         # So, there are two ways to resolve this issue:
-        # 1. Extract a pertubation for one element and apply it all
+        # 1. Extract a perturbation for one element and apply it all
         #    the elements from the same equivalence class, or
         # 2. Make sure that the equivalence classes are all singletons,
         # i.e. the index tensor has to be comprised of only unique
@@ -9146,7 +9146,7 @@ op_db: List[OpInfo] = [
            skips=(
                # FX failed to normalize op - add the op to the op_skip list.
                DecorateInfo(unittest.expectedFailure, 'TestNormalizeOperators', 'test_normalize_operator_exhaustive'),
-               # Tests that assume input tensor has a meningful effect on output tensor
+               # Tests that assume input tensor has a meaningful effect on output tensor
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager'),
                DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_view'),
                DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_conj_view'),
@@ -13649,7 +13649,7 @@ op_db: List[OpInfo] = [
                     dtypes=all_types_and_complex_and(torch.half, torch.bfloat16),
                     dtypesIfCUDA=all_types_and_complex_and(torch.half, torch.bfloat16, torch.chalf),
                     ref=np.power,
-                    # Due to AVX2 curently not being fully supported for Float16, log_vml_cpu can't be enabled
+                    # Due to AVX2 currently not being fully supported for Float16, log_vml_cpu can't be enabled
                     # for Float16, causing this test to fail. pow's autograd for Float16 is thus currently
                     # unsupported on CPU.
                     backward_dtypes=floating_and_complex_types_and(torch.bfloat16),
@@ -16747,7 +16747,7 @@ op_db: List[OpInfo] = [
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_view'),
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_conj_view'),
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_conj_view'),
-            # Jiterator ops doesn't suport CompositeCompliantTensor
+            # Jiterator ops doesn't support CompositeCompliantTensor
             # Following test should expectedFailure, but it's causing cascading failures in CUDA, thus skipped
             DecorateInfo(unittest.skip("skip"), 'TestCompositeCompliance', 'test_operator'),
             # Skip reference_numerics tests for bool type, as the defined function doesn't work for bool
@@ -16783,7 +16783,7 @@ op_db: List[OpInfo] = [
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_view'),
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_conj_view'),
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_conj_view'),
-            # Jiterator ops doesn't suport CompositeCompliantTensor
+            # Jiterator ops doesn't support CompositeCompliantTensor
             # Following test should expectedFailure, but it's causing cascading failures in CUDA, thus skipped
             DecorateInfo(unittest.skip("skip"), 'TestCompositeCompliance', 'test_operator'),
             # Expected failure: torch.jiterator_binary is not a valid op
@@ -16808,7 +16808,7 @@ op_db: List[OpInfo] = [
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_view'),
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_conj_view'),
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_conj_view'),
-            # Jiterator ops doesn't suport CompositeCompliantTensor
+            # Jiterator ops doesn't support CompositeCompliantTensor
             # Following test should expectedFailure, but it's causing cascading failures in CUDA, thus skipped
             DecorateInfo(unittest.skip("skip"), 'TestCompositeCompliance', 'test_operator'),
             # Expected failure: torch.jiterator_4inputs_with_extra_args is not a valid op
@@ -16839,7 +16839,7 @@ op_db: List[OpInfo] = [
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_view'),
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_conj_view'),
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_conj_view'),
-            # Jiterator ops doesn't suport CompositeCompliantTensor
+            # Jiterator ops doesn't support CompositeCompliantTensor
             # Following test should expectedFailure, but it's causing cascading failures in CUDA, thus skipped
             DecorateInfo(unittest.skip("skip"), 'TestCompositeCompliance', 'test_operator'),
             # Expected failure: torch.jiterator_4inputs_with_extra_args is not a valid op
@@ -16870,7 +16870,7 @@ op_db: List[OpInfo] = [
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_view'),
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_conj_view'),
             DecorateInfo(unittest.expectedFailure, 'TestMathBits', 'test_neg_conj_view'),
-            # Jiterator ops doesn't suport CompositeCompliantTensor
+            # Jiterator ops doesn't support CompositeCompliantTensor
             # Following test should expectedFailure, but it's causing cascading failures in CUDA, thus skipped
             DecorateInfo(unittest.skip("skip"), 'TestCompositeCompliance', 'test_operator'),
             # Expected failure: torch.jiterator_4inputs_with_extra_args is not a valid op

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -408,7 +408,7 @@ class QuantizationTestCase(TestCase):
 
     def checkNoPrepModules(self, module):
         r"""Checks the module does not contain child
-            modules for quantization prepration, e.g.
+            modules for quantization preparation, e.g.
             quant, dequant and observer
         """
         self.assertFalse(hasattr(module, 'quant'))
@@ -424,7 +424,7 @@ class QuantizationTestCase(TestCase):
 
     def checkHasPrepModules(self, module):
         r"""Checks the module contains child
-            modules for quantization prepration, e.g.
+            modules for quantization preparation, e.g.
             quant, dequant and observer
         """
         self.assertTrue(hasattr(module, 'module'))
@@ -433,7 +433,7 @@ class QuantizationTestCase(TestCase):
 
     def checkObservers(self, module, propagate_qconfig_list=None, prepare_custom_config_dict=None):
         r"""Checks the module or module's leaf descendants
-            have observers in preperation for quantization
+            have observers in preparation for quantization
         """
         if propagate_qconfig_list is None:
             propagate_qconfig_list = get_default_qconfig_propagation_list()
@@ -861,7 +861,7 @@ class QuantizationTestCase(TestCase):
                     expected_node: NodeSpec
                         e.g. NodeSpec.call_function(torch.quantize_per_tensor)
                     expected_node_occurrence: a dict from NodeSpec to
-                        expected number of occurences (int)
+                        expected number of occurrences (int)
                         e.g. {NodeSpec.call_function(torch.quantize_per_tensor) : 1,
                                 NodeSpec.call_method('dequantize'): 1}
                     expected_node_list: a list of NodeSpec, used to check the order
@@ -887,7 +887,7 @@ class QuantizationTestCase(TestCase):
                        "quantized_reference": ...,  # the quantized reference model
                        "result": ...,  # the result for either quantized or
                                        # quantized_reference model depending on the
-                                       # is_reference arguemnt
+                                       # is_reference argument
                    }
             """
             # TODO: make img_data a single example instead of a list

--- a/torch/testing/_internal/common_subclass.py
+++ b/torch/testing/_internal/common_subclass.py
@@ -33,7 +33,7 @@ class WrapperTensor(torch.Tensor):
 
     @classmethod
     def get_wrapper_properties(cls, *args, **kwargs):
-        # Should return both an example Tensor and a dictionaly of kwargs
+        # Should return both an example Tensor and a dictionary of kwargs
         # to override any of that example Tensor's properly.
         # This is very similar to the `t.new_*(args)` API
         raise NotImplementedError("You need to implement get_wrapper_properties")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1595,7 +1595,7 @@ class CudaMemoryLeakCheck():
 
             discrepancy_detected = True
 
-            # Query memory multiple tiems to ensure leak was not transient
+            # Query memory multiple items to ensure leak was not transient
             for n in range(3):
                 caching_allocator_mem_allocated = torch.cuda.memory_allocated(i)
                 bytes_free, bytes_total = torch.cuda.mem_get_info(i)
@@ -1659,7 +1659,7 @@ def skip_exception_type(exc_type):
     except exc_type as e:
         raise unittest.SkipTest(f"not implemented: {e}") from e
 
-#  "min_satisfying_examples" setting has been deprecated in hypythesis
+#  "min_satisfying_examples" setting has been deprecated in hypothesis
 #  3.56.0 and removed in hypothesis 4.x
 try:
     import hypothesis
@@ -2343,7 +2343,7 @@ class TestCase(expecttest.TestCase):
         we'll find a maximal window in (n_rows + 1, n_cols + 1)-grid
         that is able to hold a sequence of sawteeth and so-called
         final correction, while the external part of the window is
-        filled with counts to meet the nnz contraint exactly.
+        filled with counts to meet the nnz constraint exactly.
         """
         assert 0 <= nnz <= n_rows * n_cols, (nnz, n_rows, n_cols)
 
@@ -4179,7 +4179,7 @@ def clone_input_helper(input):
 
 @contextmanager
 def custom_op(opname, symbolic_fn, opset_version):
-    """Context manager/decorator to test ONNX export with custom oeprator"""
+    """Context manager/decorator to test ONNX export with custom operator"""
     try:
         register_custom_op_symbolic(opname, symbolic_fn, opset_version)
         yield

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/_test_ops_common.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/_test_ops_common.py
@@ -86,7 +86,7 @@ def generate_local_weight_sharding_params_for_test(
         local_weight: weight matrix to be sharded.
         sharded_dim: The dimension which we shard on.
         gpu_num: number of ranks.
-        spec: shareding spec.
+        spec: sharding spec.
         rank: # of cuda process.
 
     Returns:

--- a/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py
@@ -469,7 +469,7 @@ class DdpUnderDistAutogradTest(RpcAgentTestFixture):
         elif self.rank in TRAINER_RANKS:
             self._trainer_process(self.rank)
         else:
-            raise RuntimeError(f"Unknow process rank: {self.rank}")
+            raise RuntimeError(f"Unknown process rank: {self.rank}")
 
     @requires_gloo()
     @dist_init

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -6279,7 +6279,7 @@ class DistributedTest:
                 self._model_step_with_zero_grad(model_DDP)
 
                 # Verify DDP logging data is sampled as expected
-                # If it has ran more than 10 iteratons and this is
+                # If it has ran more than 10 iterations and this is
                 # the sampled iteration for measuring run time stats,
                 # the run time stats for this idx-th iteration will not
                 # be zeros.
@@ -7128,7 +7128,7 @@ class DistributedTest:
             rank = self.rank
             sync_interval = test_case.sync_interval
             torch.cuda.set_device(rank)
-            # Ensure all outsanding GPU work is comlete so this test runs independently.
+            # Ensure all outstanding GPU work is completed so this test runs independently.
             dist.barrier()
             # Bucket_cap_mb is intentionally low to test allreduce scheduling when
             # there are many buckets.
@@ -8683,7 +8683,7 @@ class DistributedTest:
             # Kick off some allreduce work on all ranks
             for _ in range(10):
                 dist.all_reduce(torch.cat(tensors))
-            # Run monitored barrier and ensure it passees
+            # Run monitored barrier and ensure it passes
             timeout = timedelta(seconds=2)
             dist.monitored_barrier(timeout=timeout)
             # Check monitored_barrier success with wait_all_ranks=True

--- a/torch/testing/_internal/distributed/nn/api/remote_module_test.py
+++ b/torch/testing/_internal/distributed/nn/api/remote_module_test.py
@@ -482,7 +482,7 @@ class ThreeWorkersRemoteModuleTest(CommonRemoteModuleTest):
         dst_worker1_name = dist_utils.worker_name((self.rank + 1) % self.world_size)
         dst_worker2_name = dist_utils.worker_name((self.rank + 2) % self.world_size)
 
-        # Unpickled attribtes include both the inherent attributes of RemoteModule
+        # Unpickled attributes include both the inherent attributes of RemoteModule
         # (not inherited from the superclass) and two installed methods.
         expected_unpickled_attrs = list(_REMOTE_MODULE_PICKLED_ATTRIBUTES)
         expected_unpickled_attrs.append("forward_async")
@@ -520,7 +520,7 @@ class ThreeWorkersRemoteModuleTest(CommonRemoteModuleTest):
         dst_worker1_name = dist_utils.worker_name((self.rank + 1) % self.world_size)
         dst_worker2_name = dist_utils.worker_name((self.rank + 2) % self.world_size)
 
-        # Unpickled attribtes include both the inherent attributes of RemoteModule
+        # Unpickled attributes include both the inherent attributes of RemoteModule
         # (not inherited from the superclass) and two installed methods.
         expected_unpickled_attrs = list(_REMOTE_MODULE_PICKLED_ATTRIBUTES)
         expected_unpickled_attrs.append("forward_async")

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -159,7 +159,7 @@ def _all_contexts_cleaned_up(timeout_seconds=10):
     return success
 
 
-# This function creates a dis atugorad context, run rpc_sync on the given ps,
+# This function creates a dis autograd context, run rpc_sync on the given ps,
 # and then blocks until the ps has verified the grads are correctly accumulated.
 def _run_trainer(rref_t1, t2, ps, rank_diff, sparse):
     with dist_autograd.context() as context_id:
@@ -174,7 +174,7 @@ def _run_trainer(rref_t1, t2, ps, rank_diff, sparse):
         rpc.rpc_sync(ps, _check_rpc_done, args=(0,))
 
 # This function is the same as _run_trainer, except rpc calls torchscript
-# function "my_script_ref_add" instead of python funciton "my_rref_add"
+# function "my_script_ref_add" instead of python function "my_rref_add"
 def _run_trainer_torchscript(rref_t1, t2, ps, rank_diff, sparse):
     with dist_autograd.context() as context_id:
         ret = rpc.rpc_sync(ps, my_script_ref_add, args=(rref_t1, t2))
@@ -999,7 +999,7 @@ class CommonDistAutogradTest(RpcAgentTestFixture):
         )
         self.assertEqual(next_funcs[0][0], next_funcs[1][0])
 
-        # For send function when returning resonpose to previous call
+        # For send function when returning response to previous call
         # next function of the send function is the recv function
         # for received tensor result returned from nested call
         next_funcs = list(send_functions.values())[1].next_functions
@@ -2371,7 +2371,7 @@ class DistAutogradTest(CommonDistAutogradTest):
 
             @staticmethod
             def backward(ctx, grad):
-                # Create a sparse tensor with non-contigous indices and values
+                # Create a sparse tensor with non-contiguous indices and values
                 # and return as grad.
                 v = torch.rand(1, 3)
                 i = torch.ones(1, 1, dtype=torch.long)

--- a/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py
@@ -176,7 +176,7 @@ class Agent:
                 )
             )
 
-        # wait until all obervers have finished this episode
+        # wait until all observers have finished this episode
         for fut in futs:
             fut.wait()
 

--- a/torch/testing/_internal/distributed/rpc/jit/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/dist_autograd_test.py
@@ -97,7 +97,7 @@ class JitDistAutogradTest(RpcAgentTestFixture):
             res1 = res1_fut.wait()  # After this, the script runs in a new JIT thread.
             loss1 = res1.sum()
 
-            # SendRpcBackward is not attched, since DistAutogradContext is lost here.
+            # SendRpcBackward is not attached, since DistAutogradContext is lost here.
             res2_fut = rpc.rpc_async(dst_worker_name, local_add, (t2, t2))
             res2 = res2_fut.wait()
             loss2 = res2.sum()

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -767,7 +767,7 @@ class JitRpcOpTest:
 
         # Notice, TorchScript always translates(emits) Python `raise` statement,
         # as the exception message string, "Exception",
-        # no matter what exception type and excetpion message are in the statement,
+        # no matter what exception type and exception message are in the statement,
         @torch.jit.script
         def rpc_async_call_remote_raising_torchscript_in_torchscript(
             dst_worker_name: str,

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -1849,7 +1849,7 @@ class RpcTest(RpcAgentTestFixture, RpcTestCommon):
             return
 
         # Spawn multiple threads that send RPCs to ensure keys are correctly
-        # prefixied when there are multiple RPCs being created/in flight at the
+        # prefixed when there are multiple RPCs being created/in flight at the
         # same time.
         dst_ranks = [rank for rank in range(0, self.world_size) if rank != self.rank]
 
@@ -3074,7 +3074,7 @@ class RpcTest(RpcAgentTestFixture, RpcTestCommon):
     @dist_init(setup_rpc=True)
     def test_call_method_on_rref(self):
         """
-        Tests that it is possible to call an instance method on a remote objet
+        Tests that it is possible to call an instance method on a remote object
         by using rref.owner() as destination of the call.
         """
         vals = [10, 2, 5, 7]
@@ -6116,7 +6116,7 @@ class TensorPipeAgentCudaRpcTest(RpcAgentTestFixture, RpcTestCommon):
             options.set_device_map(input_src, {remote_device: local_device})
         elif self.rank == 2:
             # worker2 will get the out RRef and call to_here() and hence, needs
-            # to configure devcie map.
+            # to configure device map.
             options.set_device_map(model_dst, {local_device: remote_device})
 
         rpc.init_rpc(

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -149,7 +149,7 @@ class JitTestCase(JitCommonTestCase):
     def tearDown(self):
         super().tearDown()
         # needs to be cleared because python might be unloaded before
-        # the callback gets destucted
+        # the callback gets destructed
         self.clearHooks()
         clear_class_registry()
 
@@ -767,7 +767,7 @@ def _get_py3_code(code, fn_name):
         spec = importlib.util.spec_from_file_location(fn_name, script_path)
         module = importlib.util.module_from_spec(spec)
         loader = spec.loader
-        assert isinstance(loader, Loader)  # Assert type to meet MyPy requriement
+        assert isinstance(loader, Loader)  # Assert type to meet MyPy requirement
         loader.exec_module(module)
         fn = getattr(module, fn_name)
         return fn

--- a/torch/testing/_internal/opinfo/core.py
+++ b/torch/testing/_internal/opinfo/core.py
@@ -151,7 +151,7 @@ class SampleInput:
                 not var_args and not var_kwargs
             ), """
 A SampleInput can be constructed "naturally" with *args and **kwargs or by
-explicitly setting the "args" and "kwargs" paremeters, but the two
+explicitly setting the "args" and "kwargs" parameters, but the two
 methods of construction cannot be mixed!"""
         elif len(var_args) or len(var_kwargs):
             assert (
@@ -1829,7 +1829,7 @@ def generate_elementwise_binary_with_scalar_samples(
         yield SampleInput(lhs_scalar, args=(rhs_scalar,))
 
 
-# Returns a generator of pairs of contiguous tensors and 0d tensos and scalars and type promotion
+# Returns a generator of pairs of contiguous tensors and 0d tensors and scalars and type promotion
 def generate_elementwise_binary_with_scalar_and_type_promotion_samples(
     op, *, device, dtype, requires_grad=False
 ):


### PR DESCRIPTION
This PR fixes typo in comments and messages under `torch/testing` directory.
