### PR TITLE
Fix kDefaultTimeout multiple definition build failure

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -125,7 +125,7 @@ class TORCH_API ProcessGroupGloo : public Backend {
     }
 
     void wait(const std::vector<std::string>& keys) override {
-      store_->wait(keys, Store::kDefaultTimeout);
+      store_->wait(keys, ::c10d::Store::kDefaultTimeout);
     }
 
     void wait(


### PR DESCRIPTION
Make the namespace explicit to avoid the constexpr conflict on GCC 11.

Fixes #90448

@ezyang 
