### PR TITLE
Remove stack trace captures from import

### DIFF
--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -36,7 +36,7 @@ __all__ = ['WorkerSpec', 'Worker', 'WorkerState', 'WorkerGroup', 'RunResult', 'E
 _TERMINAL_STATE_SYNC_ID = "torchelastic/agent/terminal_state"
 
 DEFAULT_ROLE = "default"
-log = get_logger()
+log = get_logger(__name__)
 
 
 @dataclass

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -32,7 +32,7 @@ from torch.distributed.elastic.multiprocessing import PContext, start_processes
 from torch.distributed.elastic.utils import macros
 from torch.distributed.elastic.utils.logging import get_logger
 
-log = get_logger()
+log = get_logger(__name__)
 
 __all__ = [
     "LocalElasticAgent",

--- a/torch/distributed/elastic/multiprocessing/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/__init__.py
@@ -79,7 +79,7 @@ from torch.distributed.elastic.multiprocessing.api import (  # noqa: F401
 )
 from torch.distributed.elastic.utils.logging import get_logger
 
-log = get_logger()
+log = get_logger(__name__)
 
 
 def start_processes(

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -67,7 +67,7 @@ from .handlers import get_error_handler  # noqa: F401
 
 __all__ = ["ProcessFailure", "ChildFailedError", "record", "ErrorHandler", "get_error_handler"]
 
-log = get_logger()
+log = get_logger(__name__)
 
 
 JSON = Dict

--- a/torch/distributed/elastic/utils/distributed.py
+++ b/torch/distributed/elastic/utils/distributed.py
@@ -13,7 +13,7 @@ import torch.distributed as dist
 from torch.distributed.elastic.utils.logging import get_logger
 
 
-log = get_logger()
+log = get_logger(__name__)
 
 _ADDRESS_IN_USE = "Address already in use"
 _SOCKET_TIMEOUT = "Socket Timeout"

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -22,7 +22,7 @@ from torch.distributed.elastic.utils.logging import get_logger
 
 __all__ = ['LaunchConfig', 'elastic_launch', 'launch_agent']
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -386,7 +386,7 @@ from torch.distributed.elastic.utils.logging import get_logger
 from torch.distributed.launcher.api import LaunchConfig, elastic_launch
 
 
-log = get_logger()
+log = get_logger(__name__)
 
 
 def get_args_parser() -> ArgumentParser:


### PR DESCRIPTION
Summary:
Calls to this function without an argument will get a stack trace at
import time. This is expensive, we can just skip it by passing in a value.

Test Plan: Wait for tests

Differential Revision: D44244345

