### PR TITLE
update flatten.py docstring

### DIFF
--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -9,6 +9,12 @@ __all__ = ['Flatten', 'Unflatten']
 class Flatten(Module):
     r"""
     Flattens a contiguous range of dims into a tensor. For use with :class:`~nn.Sequential`.
+    
+    Unlike NumPy’s flatten, which always copies input’s data, this function may return the original object, a view, or copy. 
+    If no dimensions are flattened, then the original object input is returned. 
+    Otherwise, if input can be viewed as the flattened shape, then that view is returned. 
+    Finally, only if the input cannot be viewed as the flattened shape is input’s data copied. 
+    See torch.Tensor.view() for details on when a view will be returned.
 
     Shape:
         - Input: :math:`(*, S_{\text{start}},..., S_{i}, ..., S_{\text{end}}, *)`,'

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -9,7 +9,6 @@ __all__ = ['Flatten', 'Unflatten']
 class Flatten(Module):
     r"""
     Flattens a contiguous range of dims into a tensor. For use with :class:`~nn.Sequential`.
-    
     See :meth:`torch.flatten` for details.
 
     Shape:

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -10,11 +10,7 @@ class Flatten(Module):
     r"""
     Flattens a contiguous range of dims into a tensor. For use with :class:`~nn.Sequential`.
     
-    Unlike NumPy’s flatten, which always copies input’s data, this function may return the original object, a view, or copy. 
-    If no dimensions are flattened, then the original object input is returned. 
-    Otherwise, if input can be viewed as the flattened shape, then that view is returned. 
-    Finally, only if the input cannot be viewed as the flattened shape is input’s data copied. 
-    See torch.Tensor.view() for details on when a view will be returned.
+    Inherits from torch.flatten, see https://pytorch.org/docs/stable/generated/torch.flatten.html
 
     Shape:
         - Input: :math:`(*, S_{\text{start}},..., S_{i}, ..., S_{\text{end}}, *)`,'

--- a/torch/nn/modules/flatten.py
+++ b/torch/nn/modules/flatten.py
@@ -10,7 +10,7 @@ class Flatten(Module):
     r"""
     Flattens a contiguous range of dims into a tensor. For use with :class:`~nn.Sequential`.
     
-    Inherits from torch.flatten, see https://pytorch.org/docs/stable/generated/torch.flatten.html
+    See :meth:`torch.flatten` for details.
 
     Shape:
         - Input: :math:`(*, S_{\text{start}},..., S_{i}, ..., S_{\text{end}}, *)`,'


### PR DESCRIPTION
Carried over comment from tensor.flatten docstring to to clarify when a view vs copy is instantiated - this has been a [minor point of confusion in forums](https://discuss.pytorch.org/t/what-is-the-difference-of-flatten-and-view-1-in-pytorch/51790/5).  This comment is:

```
    Unlike NumPy’s flatten, which always copies input’s data, this function may return the original object, a view, or copy. 
    If no dimensions are flattened, then the original object input is returned. 
    Otherwise, if input can be viewed as the flattened shape, then that view is returned. 
    Finally, only if the input cannot be viewed as the flattened shape is input’s data copied. 
    See torch.Tensor.view() for details on when a view will be returned.
```