### PR TITLE
Add sympy to binary linux test - fix conda nightly

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -77,6 +77,7 @@ if [[ "$PACKAGE_TYPE" == conda ]]; then
       "numpy\${NUMPY_PIN}" \
       mkl>=2018 \
       ninja \
+      sympy \
       typing-extensions \
       ${PROTOBUF_PACKAGE}
     if [[ "$DESIRED_CUDA" == 'cpu' ]]; then


### PR DESCRIPTION
Try to fix following nightly conda linux failure:
https://github.com/pytorch/pytorch/actions/runs/4476375944/jobs/7868006749

We will have to revert builder sympy install:
https://github.com/pytorch/builder/commit/ce427de8a88675c584f63008f4bb9164ab9eef79

cc @malfet 
