### PR TITLE
Remove inductor-perf-test-nightly label

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -7,7 +7,6 @@ ciflow_push_tags:
 - ciflow/binaries_wheel
 - ciflow/inductor
 - ciflow/inductor-perf-compare
-- ciflow/inductor-perf-test-nightly
 - ciflow/mps
 - ciflow/nightly
 - ciflow/periodic

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -1,9 +1,6 @@
 name: inductor-A100-perf-compare
 
 on:
-  push:
-    tags:
-      - ciflow/inductor-perf-compare/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -1,6 +1,9 @@
 name: inductor-A100-perf-compare
 
 on:
+  push:
+    tags:
+      - ciflow/inductor-perf-compare/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -3,9 +3,6 @@ name: inductor-A100-perf-nightly
 on:
   schedule:
     - cron: 45 1,7,13,19 * * *
-  push:
-    tags:
-      - ciflow/inductor-perf-test-nightly/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Remove labels according to Ed's suggestion 
"I do NOT think performance dashboard should be label triggered. It easy to put a label on the PR, and then forget about it and keep spamming our limited A100 capacity when you push updates to your PR." Instead, one can use the "Run workflow" option and specify their feature branch in https://github.com/pytorch/pytorch/actions/workflows/inductor-perf-compare.yml
