### PR TITLE
Upload failed and rerun tests

### DIFF
--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -354,6 +354,19 @@ if __name__ == "__main__":
         invoking_file_times,
     )
 
+    # Separate out the failed test cases. Uploading everying is too data intensive most of the time
+    failed_tests_cases = []
+    for test_case in test_cases:
+        if "rerun" in test_case or "failure" in test_case:
+            failed_tests_cases.append(test_case)
+
+    upload_workflow_stats_to_s3(
+        args.workflow_run_id,
+        args.workflow_run_attempt,
+        "failed_test_runs",
+        failed_tests_cases,
+    )
+
     if args.head_branch == "master":
         # For master jobs, upload everytihng.
         upload_workflow_stats_to_s3(

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -354,7 +354,9 @@ if __name__ == "__main__":
         invoking_file_times,
     )
 
-    # Separate out the failed test cases. Uploading everying is too data intensive most of the time
+    # Separate out the failed test cases. 
+    # Uploading everying is too data intensive most of the time, 
+    # but these will be just a tiny fraction.
     failed_tests_cases = []
     for test_case in test_cases:
         if "rerun" in test_case or "failure" in test_case or "error" in test_case:

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -357,7 +357,7 @@ if __name__ == "__main__":
     # Separate out the failed test cases. Uploading everying is too data intensive most of the time
     failed_tests_cases = []
     for test_case in test_cases:
-        if "rerun" in test_case or "failure" in test_case:
+        if "rerun" in test_case or "failure" in test_case or "error" in test_case:
             failed_tests_cases.append(test_case)
 
     upload_workflow_stats_to_s3(

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -354,8 +354,8 @@ if __name__ == "__main__":
         invoking_file_times,
     )
 
-    # Separate out the failed test cases. 
-    # Uploading everying is too data intensive most of the time, 
+    # Separate out the failed test cases.
+    # Uploading everying is too data intensive most of the time,
     # but these will be just a tiny fraction.
     failed_tests_cases = []
     for test_case in test_cases:


### PR DESCRIPTION
Upload data for any test that didn't cleanly succeed to S3 for injestion by rockset.

About 0.001% of tests fall under this category, keeping the data usage low.