### PR TITLE
Fix missing dynamo cache lookup registration in profiler.profiler

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2033,41 +2033,46 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             z = y**3
             return z
 
-        x = torch.randn((2, 2), requires_grad=True)
-        ref = fn(x)
-        opt_fn = torch.compile(fn, backend="aot_eager")
+        for profiler in (
+            torch.autograd.profiler.profile,
+            torch.profiler.profiler.profile,
+        ):
+            x = torch.randn((2, 2), requires_grad=True)
+            ref = fn(x)
+            opt_fn = torch.compile(fn, backend="aot_eager")
 
-        # warmup
-        opt_fn(x)
+            # warmup
+            opt_fn(x)
 
-        # whenver we enter the profiler context, hooks are automatically registered
-        with torch.autograd.profiler.profile() as prof:
-            res = opt_fn(x)
-        events = list(
-            filter(
-                lambda event: event.name == "TorchDynamo Cache Lookup",
-                prof.function_events,
+            # whenver we enter the profiler context, hooks are automatically registered
+            with profiler() as prof:
+                res = opt_fn(x)
+            events = list(
+                filter(
+                    lambda event: event.name == "TorchDynamo Cache Lookup",
+                    prof.function_events,
+                )
             )
-        )
 
-        self.assertTrue(same(ref, res))
-        self.assertTrue(
-            len(events) == 1, "Expected one lookup profiler event for one opt_fn run"
-        )
-
-        with torch.autograd.profiler.profile() as prof:
-            # just make sure the disable functionality works
-            _enable_dynamo_cache_lookup_profiler(False)
-            res = opt_fn(x)
-        events = list(
-            filter(
-                lambda event: event.name == "TorchDynamo Cache Lookup",
-                prof.function_events,
+            self.assertTrue(same(ref, res))
+            self.assertTrue(
+                len(events) == 1,
+                "Expected one lookup profiler event for one opt_fn run",
             )
-        )
 
-        self.assertTrue(same(ref, res))
-        self.assertTrue(len(events) == 0, "Expected disabled profiling")
+            with profiler() as prof:
+                # just make sure the disable functionality works
+                _enable_dynamo_cache_lookup_profiler(False)
+                res = opt_fn(x)
+            events = list(
+                filter(
+                    lambda event: event.name == "TorchDynamo Cache Lookup",
+                    prof.function_events,
+                )
+            )
+
+            self.assertTrue(same(ref, res))
+            self.assertTrue(len(events) == 0, "Expected disabled profiling")
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_cuda_stream_context_manager1(self):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -2033,9 +2033,9 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             z = y**3
             return z
 
-        for profiler in (
-            torch.autograd.profiler.profile,
-            torch.profiler.profiler.profile,
+        for profiler, get_events in (
+            (torch.autograd.profiler.profile, lambda prof: prof.function_events),
+            (torch.profiler.profiler.profile, lambda prof: prof.events()),
         ):
             x = torch.randn((2, 2), requires_grad=True)
             ref = fn(x)
@@ -2050,7 +2050,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             events = list(
                 filter(
                     lambda event: event.name == "TorchDynamo Cache Lookup",
-                    prof.function_events,
+                    get_events(prof),
                 )
             )
 
@@ -2067,7 +2067,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             events = list(
                 filter(
                     lambda event: event.name == "TorchDynamo Cache Lookup",
-                    prof.function_events,
+                    get_events(prof),
                 )
             )
 

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -532,11 +532,13 @@ class profile(_KinetoProfile):
         prof.KinetoStepTracker.init_step_count(PROFILER_STEP_NAME)
 
     def __enter__(self):
+        prof._enable_dynamo_cache_lookup_profiler(True)
         self.start()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
+        prof._enable_dynamo_cache_lookup_profiler(False)
         prof.KinetoStepTracker.erase_step_count(PROFILER_STEP_NAME)
 
     def start(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97305

This follows https://github.com/pytorch/pytorch/pull/96199 and supports the 'other' profiler.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire