### PR TITLE
cleanup caffe2 cc_proto_library

### DIFF
--- a/caffe2/proto/BUILD.bazel
+++ b/caffe2/proto/BUILD.bazel
@@ -16,18 +16,17 @@ cc_library(
     ],
 )
 
-proto_library(
-    name = "caffe2_proto_source",
-    srcs = glob([
-        "*.proto",
-    ]),
-    visibility = ["//visibility:public"],
-)
-
 cc_proto_library(
     name = "caffe2_protos",
-    deps = [":caffe2_proto_source"],
+    deps = [":protos"],
     # Legacy, this should probably be restricted to the targets that
     # actually need this.
     visibility = ["//:__pkg__"],
+)
+
+proto_library(
+    name = "protos",
+    srcs = glob([
+        "*.proto",
+    ]),
 )


### PR DESCRIPTION
cleanup caffe2 cc_proto_library

Summary:
This doesn't need to be public, nor does it need a long name. Since
this is the most private library, we move it to the bottom of the
file.

Test Plan: Should be a no-op, verify in CI.

Reviewers: sahanp

Subscribers:

Tasks:

Tags:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/97325).
* #97337
* #97336
* #97335
* #97334
* __->__ #97325