### PR TITLE
Fix prototype of torch::lazy::OperandHashes

### DIFF
--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -69,6 +69,7 @@ using OpList = c10::ArrayRef<Value>;
 
 hash_t OperandHashes(
     const OpList& operands,
+    const c10::ArrayRef<Shape>& shapes,
     const hash_t& seed,
     bool bakeInSizes);
 // A node in the graph. Nodes for operations which require extra data to be


### PR DESCRIPTION
Seems there is missing argument compraed to its implementation https://github.com/pytorch/pytorch/blob/a6d8c70933785067b40f2be54a876357294a9871/torch/csrc/lazy/ts_backend/ts_node.cpp#L21

Fixes #ISSUE_NUMBER

`copilot:all`