### PR TITLE
explicitly list out caffe2 protos

### DIFF
--- a/caffe2/proto/BUILD.bazel
+++ b/caffe2/proto/BUILD.bazel
@@ -26,7 +26,13 @@ cc_proto_library(
 
 proto_library(
     name = "protos",
-    srcs = glob([
-        "*.proto",
-    ]),
+    srcs = [
+         "caffe2_legacy.proto",
+         "caffe2.proto",
+         "hsm.proto",
+         "metanet.proto",
+         "predictor_consts.proto",
+         "prof_dag.proto",
+         "torch.proto",
+    ],
 )


### PR DESCRIPTION
explicitly list out caffe2 protos

Summary: This will make it easier to split up this library.

Test Plan: Rely on CI.

Reviewers: sahanp

Subscribers:

Tasks:

Tags:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/97334).
* #97337
* #97336
* #97335
* __->__ #97334