### PR TITLE
extract torch.proto to its own library

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1282,7 +1282,6 @@ cc_library(
     deps = [
         ":caffe2_core_macros_h",
         "//caffe2/proto:caffe2_pb",
-        "//caffe2/proto:caffe2_protos",
         "//c10:headers",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1639,6 +1639,7 @@ cc_library(
     deps = [
         ":caffe2",
         ":torch_headers",
+        "//caffe2/proto:torch_cc_proto",
         "@kineto",
     ] + if_cuda([
         ":torch_distributed_cuda",

--- a/caffe2/proto/BUILD.bazel
+++ b/caffe2/proto/BUILD.bazel
@@ -26,7 +26,13 @@ cc_proto_library(
 
 proto_library(
     name = "protos",
-    srcs = glob([
-        "*.proto",
-    ]),
+    srcs = [
+         "caffe2_legacy.proto",
+         "caffe2.proto",
+         "hsm.proto",
+         "metanet.proto",
+         "predictor_consts.proto",
+         "prof_dag.proto",
+         "torch.proto",
+    ],
 )

--- a/caffe2/proto/BUILD.bazel
+++ b/caffe2/proto/BUILD.bazel
@@ -5,7 +5,7 @@ cc_library(
     name = "caffe2_pb",
     hdrs = ["caffe2_pb.h"],
     deps = [
-        ":caffe2_protos",
+        ":caffe2_cc_proto",
         "//c10/core:base",
         "//c10/util:base",
     ],
@@ -14,6 +14,16 @@ cc_library(
         "//caffe2:__subpackages__",
         "//torch/csrc/jit/serialization:__pkg__",
     ],
+)
+
+cc_proto_library(
+    name = "caffe2_cc_proto",
+    deps = [":caffe2_proto"],
+)
+
+proto_library(
+    name = "caffe2_proto",
+    srcs = ["caffe2.proto"],
 )
 
 cc_proto_library(
@@ -28,11 +38,11 @@ proto_library(
     name = "protos",
     srcs = [
          "caffe2_legacy.proto",
-         "caffe2.proto",
          "hsm.proto",
          "metanet.proto",
          "predictor_consts.proto",
          "prof_dag.proto",
          "torch.proto",
     ],
+    deps = [":caffe2_proto"],
 )

--- a/caffe2/proto/BUILD.bazel
+++ b/caffe2/proto/BUILD.bazel
@@ -27,6 +27,18 @@ proto_library(
 )
 
 cc_proto_library(
+    name = "torch_cc_proto",
+    deps = [":torch_proto"],
+    visibility = ["//:__pkg__"],  # used in torch
+)
+
+proto_library(
+    name = "torch_proto",
+    srcs = ["torch.proto"],
+    deps = [":caffe2_proto"],
+)
+
+cc_proto_library(
     name = "caffe2_protos",
     deps = [":protos"],
     # Legacy, this should probably be restricted to the targets that
@@ -42,7 +54,6 @@ proto_library(
          "metanet.proto",
          "predictor_consts.proto",
          "prof_dag.proto",
-         "torch.proto",
     ],
     deps = [":caffe2_proto"],
 )


### PR DESCRIPTION
extract torch.proto to its own library

Summary: This is used in libtorch.

Test Plan: Rely on CI.

Reviewers: sahanp

Subscribers:

Tasks:

Tags:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/97336).
* #97337
* __->__ #97336
* #97335
* #97334