### PR TITLE
Involve single data inputs to parallel apply

### DIFF
--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -40,7 +40,6 @@ def parallel_apply(modules, inputs, kwargs_tup=None, devices=None):
         inputs = [inputs] * len(modules)
     else:
         assert len(modules) == len(inputs), f'modules length {len(modules)} is not equal to the inputs length {len(inputs)}'
-    
     if kwargs_tup is not None:
         assert len(modules) == len(kwargs_tup)
     else:

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -26,8 +26,9 @@ def parallel_apply(modules, inputs, kwargs_tup=None, devices=None):
     on each of :attr:`devices`.
 
     Args:
-        modules (Module): modules to be parallelized
-        inputs (tensor): inputs to the modules
+        modules (list of Module): modules to be parallelized
+        inputs (list of tensor or tensor): inputs to the modules
+        kwargs_tup (tuple of dict, optional): keyword arguments for the modules
         devices (list of int or torch.device): CUDA devices
 
     :attr:`modules`, :attr:`inputs`, :attr:`kwargs_tup` (if given), and
@@ -35,7 +36,11 @@ def parallel_apply(modules, inputs, kwargs_tup=None, devices=None):
     element of :attr:`inputs` can either be a single object as the only argument
     to a module, or a collection of positional arguments.
     """
-    assert len(modules) == len(inputs), f'The number of modules {len(modules)} is not equal to the number of inputs {len(inputs)}'
+    if isinstance(inputs, torch.Tensor):
+        inputs = [inputs] * len(modules)
+    else:
+        assert len(modules) == len(inputs), f'The number of modules {len(modules)} is not equal to the number of inputs {len(inputs)}'
+    
     if kwargs_tup is not None:
         assert len(modules) == len(kwargs_tup)
     else:

--- a/torch/nn/parallel/parallel_apply.py
+++ b/torch/nn/parallel/parallel_apply.py
@@ -39,7 +39,7 @@ def parallel_apply(modules, inputs, kwargs_tup=None, devices=None):
     if isinstance(inputs, torch.Tensor):
         inputs = [inputs] * len(modules)
     else:
-        assert len(modules) == len(inputs), f'The number of modules {len(modules)} is not equal to the number of inputs {len(inputs)}'
+        assert len(modules) == len(inputs), f'modules length {len(modules)} is not equal to the inputs length {len(inputs)}'
     
     if kwargs_tup is not None:
         assert len(modules) == len(kwargs_tup)


### PR DESCRIPTION
According to my experience, there are many cases when using parallel_apply that 'inputs' consist of multiple of the same data. Considering that this function is usually called once when the calculation begins, I think adding another ability to use only single input is efficient.

    if isinstance(inputs, torch.Tensor):

will find out inputs is torch.Tensor whether not tuple or list. If it turns out to be a single Tensor, It will do 

        inputs = [inputs] * len(modules)

to make a length of modules and inputs as same.

I did not add this ability to kwargs_tup or devices since they are optional.

Fixes #ISSUE_NUMBER
