### PR TITLE
Improved message to suppress errors in _dynamo/exc.py

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -187,6 +187,7 @@ def augment_exc_message(exc, msg="\n"):
         msg += (
             "\n\n"
             "You can suppress this exception and fall back to eager by setting:\n"
+            "    import torch._dynamo\n"
             "    torch._dynamo.config.suppress_errors = True\n"
         )
 


### PR DESCRIPTION
If user adds simply to their code:
```python
import torch

torch._dynamo.config.suppress_errors = True
```
they will get:
```
AttributeError: module 'torch' has no attribute '_dynamo'
```






cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire