### PR TITLE
[Sparse] Add reference implementation for addmv

### DIFF
--- a/aten/src/ATen/mkl/Sparse.h
+++ b/aten/src/ATen/mkl/Sparse.h
@@ -3,7 +3,7 @@
 #include <ATen/Config.h>
 
 // MKL Sparse is not currently supported on Windows
-// See https://github.com/pytorch/pytorch/pull/50937#issuecomment-779272492
+// See https://github.com/pytorch/pytorch/issues/97352
 #if AT_MKL_ENABLED() && (!defined(_WIN32))
 #define AT_USE_MKL_SPARSE() 1
 #else

--- a/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
@@ -218,6 +218,7 @@ Tensor& _compressed_row_strided_addmm_out(
 }
 
 namespace cpu {
+#if !AT_USE_MKL_SPARSE()
 template<typename scalar_t>
 void addmv_sparse_csr(
         const scalar_t* mat_values,
@@ -266,6 +267,8 @@ void addmv_sparse_bsr(
           }
         });
 }
+#endif // !AT_USE_MKL_SPARSE()
+
 /*
   Computes a sparse matrix-dense vector product defined as
   y <- alpha*op(A)*x + beta*y

--- a/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlasImpl.cpp
@@ -290,25 +290,49 @@ void addmv_out_sparse_csr(
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
       result.scalar_type(), "addmv_out_sparse_csr_impl_reference", [&] {
         if (mat.layout() == kSparseBsr) {
-          addmv_sparse_bsr(mat.values().data<scalar_t>(),
-              mat.crow_indices().toType(kLong).data<int64_t>(),
-              mat.col_indices().toType(kLong).data_ptr<int64_t>(),
-              mat.size(0),
-              mat.values().size(1),
-              mat.values().size(2),
-              vec.data<scalar_t>(),
-              alpha.to<scalar_t>(),
-              beta.to<scalar_t>(),
-              result.data<scalar_t>());
+          if (mat.crow_indices().scalar_type() == kLong) {
+            addmv_sparse_bsr(mat.values().data<scalar_t>(),
+                mat.crow_indices().data<int64_t>(),
+                mat.col_indices().data_ptr<int64_t>(),
+                mat.size(0),
+                mat.values().size(1),
+                mat.values().size(2),
+                vec.data<scalar_t>(),
+                alpha.to<scalar_t>(),
+                beta.to<scalar_t>(),
+                result.data<scalar_t>());
+          } else {
+            addmv_sparse_bsr(mat.values().data<scalar_t>(),
+                mat.crow_indices().data<int32_t>(),
+                mat.col_indices().data_ptr<int32_t>(),
+                mat.size(0),
+                mat.values().size(1),
+                mat.values().size(2),
+                vec.data<scalar_t>(),
+                alpha.to<scalar_t>(),
+                beta.to<scalar_t>(),
+                result.data<scalar_t>());
+          }
         } else if (mat.layout() == kSparseCsr) {
-          addmv_sparse_csr(mat.values().data<scalar_t>(),
-              mat.crow_indices().data<int64_t>(),
-              mat.col_indices().data_ptr<int64_t>(),
-              mat.size(0),
-              vec.data<scalar_t>(),
-              alpha.to<scalar_t>(),
-              beta.to<scalar_t>(),
-              result.data<scalar_t>());
+          if (mat.crow_indices().scalar_type() == kLong) {
+            addmv_sparse_csr(mat.values().data<scalar_t>(),
+                mat.crow_indices().data<int64_t>(),
+                mat.col_indices().data_ptr<int64_t>(),
+                mat.size(0),
+                vec.data<scalar_t>(),
+                alpha.to<scalar_t>(),
+                beta.to<scalar_t>(),
+                result.data<scalar_t>());
+          } else {
+            addmv_sparse_csr(mat.values().data<scalar_t>(),
+                mat.crow_indices().data<int32_t>(),
+                mat.col_indices().data_ptr<int32_t>(),
+                mat.size(0),
+                vec.data<scalar_t>(),
+                alpha.to<scalar_t>(),
+                beta.to<scalar_t>(),
+                result.data<scalar_t>());
+          }
         } else {
           TORCH_CHECK(false, "Unexpected layout ", mat.layout());
         }


### PR DESCRIPTION
Partially addresses the problem raised in https://github.com/pytorch/pytorch/issues/96972

Add `test_addmv` and enable `test_block_addmv` on all platforms (so the test could be run on M1)

TODO: Make sure that test_block_addmv non-contiguous mode actually
generate non-contiguous as rigth now it probably does not, as test
passes assuming values are contiguous.

