### PR TITLE
Restore ROCm trunk jobs

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -247,6 +247,31 @@ jobs:
       cuda-version: "11.7"
       test-matrix: ${{ needs.win-vs2019-cuda11_7-py3-build.outputs.test-matrix }}
 
+  linux-focal-rocm5_4_2-py3_8-build:
+    name: linux-focal-rocm5.4.2-py3.8
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-focal-rocm5.4.2-py3.8
+      docker-image-name: pytorch-linux-focal-rocm-n-py3
+      sync-tag: rocm-build
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
+        ]}
+  linux-focal-rocm5_4_2-py3_8-test:
+    name: linux-focal-rocm5.4.2-py3.8
+    uses: ./.github/workflows/_rocm-test.yml
+    needs: linux-focal-rocm5_4_2-py3_8-build
+    with:
+      build-environment: linux-focal-rocm5.4.2-py3.8
+      docker-image: ${{ needs.linux-focal-rocm5_4_2-py3_8-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-focal-rocm5_4_2-py3_8-build.outputs.test-matrix }}
+    secrets:
+      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
+      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
+
   android-emulator-build-test:
     name: android-emulator-build-test
     uses: ./.github/workflows/_run_android_tests.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -260,6 +260,7 @@ jobs:
           { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
           { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
         ]}
+
   linux-focal-rocm5_4_2-py3_8-test:
     name: linux-focal-rocm5.4.2-py3.8
     uses: ./.github/workflows/_rocm-test.yml

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -52,29 +52,3 @@ jobs:
       build-environment: linux-focal-py3.8-gcc7
       docker-image: ${{ needs.linux-focal-py3_8-gcc7-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-focal-py3_8-gcc7-build.outputs.test-matrix }}
-
-  linux-focal-rocm5_4_2-py3_8-build:
-    name: linux-focal-rocm5.4.2-py3.8
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: linux-focal-rocm5.4.2-py3.8
-      docker-image-name: pytorch-linux-focal-rocm-n-py3
-      sync-tag: rocm-build
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
-        ]}
-
-  linux-focal-rocm5_4_2-py3_8-test:
-    name: linux-focal-rocm5.4.2-py3.8
-    uses: ./.github/workflows/_rocm-test.yml
-    needs: linux-focal-rocm5_4_2-py3_8-build
-    with:
-      build-environment: linux-focal-rocm5.4.2-py3.8
-      docker-image: ${{ needs.linux-focal-rocm5_4_2-py3_8-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-focal-rocm5_4_2-py3_8-build.outputs.test-matrix }}
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1555,6 +1555,7 @@ class TestOperators(TestCase):
         xfail("_native_batch_norm_legit"),
         xfail('native_dropout_backward'),
         decorate('linalg.svd', decorator=skipIfRocm),  # https://github.com/pytorch/pytorch/issues/97256
+        decorate('svd', decorator=skipIfRocm),  # Flaky tensor-likes are not close error on ROCm, adjust tolerance?
     }))
     @ops(op_db + additional_op_db + autograd_function_db, allowed_dtypes=(torch.float,))
     @toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1e-04)})


### PR DESCRIPTION
Move it back from unstable as the job looks stable now.  The one remaining flaky test I have seen is `functorch/test_ops.py::TestOperatorsCUDA::test_vmapjvpvjp_svd_cuda_float32` https://hud.pytorch.org/pytorch/pytorch/commit/b04363ead4b97ad46d819ad7c5643292df8f4fa4.  So I just try to skip that one on ROCm?

I will monitor the job a bit longer, and have this PR at the ready.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport