### PR TITLE
[test] Make environment variable name better

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -743,7 +743,7 @@ def run_doctests(test_module, test_directory, options):
     if 0:
         # TODO: could try to enable some of these
         os.environ["TORCH_DOCTEST_QUANTIZED_DYNAMIC"] = "1"
-        os.environ["TORCH_DOCTEST_ANOMOLY"] = "1"
+        os.environ["TORCH_DOCTEST_ANOMALY"] = "1"
         os.environ["TORCH_DOCTEST_AUTOGRAD"] = "1"
         os.environ["TORCH_DOCTEST_HUB"] = "1"
         os.environ["TORCH_DOCTEST_DATALOADER"] = "1"

--- a/torch/autograd/anomaly_mode.py
+++ b/torch/autograd/anomaly_mode.py
@@ -23,7 +23,7 @@ class detect_anomaly:
 
     Example:
 
-        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_ANOMOLY)
+        >>> # xdoctest: +REQUIRES(env:TORCH_DOCTEST_ANOMALY)
         >>> import torch
         >>> from torch import autograd
         >>> class MyFunc(autograd.Function):


### PR DESCRIPTION
This PR intends to use better (or correct?) environment variable name (`TORCH_DOCTEST_ANOMALY` instead of `TORCH_DOCTEST_ANOMOLY`) in test.
