### PR TITLE
[EASY] Do hook sizes check with SymInt

### DIFF
--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -474,7 +474,7 @@ void check_variable_result(
     throw std::runtime_error(ss.str());
   }
 
-  if (original.sizes().vec() != result.sizes().vec()) {
+  if (original.sym_sizes().vec() != result.sym_sizes().vec()) {
     std::stringstream ss;
     ss << "hook '" << hook_name << "' has changed the size of value";
     throw std::runtime_error(ss.str());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97362

I don't think this matters for any uses right now, but I found
it during an audit; might as well fix it.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>