### PR TITLE
[inductor] use real data for cudagraphify

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -329,7 +329,7 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
 
     assert isinstance(inputs, (list, tuple))
     static_inputs = [
-        static_input(x).zero_() if idx not in static_input_idxs else x.detach()
+        static_input(x).copy_(x.detach()) if idx not in static_input_idxs else x.detach()
         for idx, x in enumerate(inputs)
     ]
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -329,7 +329,9 @@ def cudagraphify_impl(model, inputs, static_input_idxs=()):
 
     assert isinstance(inputs, (list, tuple))
     static_inputs = [
-        static_input(x).copy_(x.detach()) if idx not in static_input_idxs else x.detach()
+        static_input(x).copy_(x.detach())
+        if idx not in static_input_idxs
+        else x.detach()
         for idx, x in enumerate(inputs)
     ]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #97369
* __->__ #97363

Using zeros is unsafe and results in a bad memory
access in GPT2SequenceClassification that only occurs
when a tensor gets put at the beginning of segment.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire