### PR TITLE
Enable fake_crossref unit tests on rocm

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -32,7 +32,6 @@ from torch.testing._internal.common_utils import (
     noncontiguous_like,
     TEST_WITH_ASAN,
     TEST_WITH_UBSAN,
-    skipIfRocm,
     IS_WINDOWS,
     IS_FBCODE,
     first_sample,

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2158,14 +2158,12 @@ class TestFakeTensor(TestCase):
                         sample.output_process_fn_grad,
                         op.gradcheck_wrapper)
 
-    @skipIfRocm
     @onlyCUDA
     @ops([op for op in op_db if op.supports_autograd], allowed_dtypes=(torch.float,))
     @skipOps('TestFakeTensor', 'test_fake_crossref_backward_no_amp', fake_backward_xfails)
     def test_fake_crossref_backward_no_amp(self, device, dtype, op):
         self._test_fake_crossref_helper(device, dtype, op, contextlib.nullcontext)
 
-    @skipIfRocm
     @onlyCUDA
     @ops([op for op in op_db if op.supports_autograd], allowed_dtypes=(torch.float,))
     @skipOps('TestFakeTensor', 'test_fake_crossref_backward_amp', fake_backward_xfails | fake_autocast_backward_xfails)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14757,6 +14757,10 @@ op_db: List[OpInfo] = [
                             device_type='mps', dtypes=[torch.float32]),
                DecorateInfo(unittest.skip("Skipped!"), 'TestJit', 'test_variant_consistency_jit',
                             device_type='mps', dtypes=[torch.float32]),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestFakeTensor', 'test_fake_crossref_backward_amp',
+                            device_type='cuda', dtypes=[torch.float32], active_if=TEST_WITH_ROCM),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestFakeTensor', 'test_fake_crossref_backward_no_amp',
+                            device_type='cuda', dtypes=[torch.float32], active_if=TEST_WITH_ROCM),
            )),
     OpInfo('svd_lowrank',
            op=lambda *args, **kwargs: wrapper_set_seed(
@@ -17020,7 +17024,11 @@ op_db: List[OpInfo] = [
            skips=(
                # Dispatches in Python to matrix_norm. Not sure how to make this test happy
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit',
-                            dtypes=(torch.complex64, torch.float32,)),)
+                            dtypes=(torch.complex64, torch.float32,)),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestFakeTensor', 'test_fake_crossref_backward_amp',
+                            device_type='cuda', dtypes=[torch.float32], active_if=TEST_WITH_ROCM),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestFakeTensor', 'test_fake_crossref_backward_no_amp',
+                            device_type='cuda', dtypes=[torch.float32], active_if=TEST_WITH_ROCM),)
            ),
     OpInfo('norm',
            variant_test_name='fro',

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1354,19 +1354,19 @@ op_db: List[OpInfo] = [
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_amp',
-                device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_no_amp',
-				device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_no_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
         ),
     ),
@@ -1722,19 +1722,19 @@ op_db: List[OpInfo] = [
             ),
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_amp',
-                device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_no_amp',
-				device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_no_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
         ),
     ),
@@ -1768,19 +1768,19 @@ op_db: List[OpInfo] = [
             DecorateInfo(unittest.expectedFailure, "TestBwdGradients", "test_fn_grad"),
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_amp',
-                device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_no_amp',
-				device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_no_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
         ),
     ),
@@ -1797,19 +1797,19 @@ op_db: List[OpInfo] = [
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_amp',
-                device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_no_amp',
-				device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_no_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
         ),
     ),
@@ -2304,19 +2304,19 @@ op_db: List[OpInfo] = [
             ),
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_amp',
-                device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_no_amp',
-				device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_no_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
         ),
     ),
@@ -2336,19 +2336,19 @@ op_db: List[OpInfo] = [
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_amp',
-                device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                'TestFakeTensor',
-                'test_fake_crossref_backward_no_amp',
-				device_type='cuda',
+                "TestFakeTensor",
+                "test_fake_crossref_backward_no_amp",
+                device_type="cuda",
                 dtypes=[torch.float32],
-                active_if=TEST_WITH_ROCM
+                active_if=TEST_WITH_ROCM,
             ),
         ),
     ),

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1350,7 +1350,7 @@ op_db: List[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
     ),
     OpInfo(
         "linalg.eig",
@@ -1693,7 +1693,7 @@ op_db: List[OpInfo] = [
         aten_name="linalg_norm",
         op=torch.linalg.norm,
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
         sample_inputs_func=sample_inputs_linalg_norm,
         supports_forward_ad=True,
         check_batched_forward_grad=False,
@@ -1709,7 +1709,7 @@ op_db: List[OpInfo] = [
         op=torch.linalg.norm,
         variant_test_name="subgradients_at_zero",
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
         sample_inputs_func=partial(
             sample_inputs_linalg_norm, variant="subgradient_at_zero"
         ),
@@ -1742,7 +1742,7 @@ op_db: List[OpInfo] = [
         check_batched_forward_grad=False,
         check_batched_gradgrad=False,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
         sample_inputs_func=sample_inputs_linalg_matrix_norm,
     ),
     OpInfo(
@@ -2211,7 +2211,7 @@ op_db: List[OpInfo] = [
         check_batched_grad=False,
         check_batched_gradgrad=False,
         sample_inputs_func=sample_inputs_svd,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -2248,7 +2248,7 @@ op_db: List[OpInfo] = [
         # We're using at::allclose, which does not have a batching rule
         check_batched_gradgrad=False,
         sample_inputs_func=sample_inputs_linalg_svdvals,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
     ),
     OpInfo(
         "linalg.tensorinv",

--- a/torch/testing/_internal/opinfo/definitions/linalg.py
+++ b/torch/testing/_internal/opinfo/definitions/linalg.py
@@ -1350,7 +1350,25 @@ op_db: List[OpInfo] = [
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
         gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        skips=(
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_amp',
+                device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_no_amp',
+				device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
+        ),
     ),
     OpInfo(
         "linalg.eig",
@@ -1693,7 +1711,7 @@ op_db: List[OpInfo] = [
         aten_name="linalg_norm",
         op=torch.linalg.norm,
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
         sample_inputs_func=sample_inputs_linalg_norm,
         supports_forward_ad=True,
         check_batched_forward_grad=False,
@@ -1702,6 +1720,22 @@ op_db: List[OpInfo] = [
             DecorateInfo(
                 unittest.expectedFailure, "TestBwdGradients", "test_fn_gradgrad"
             ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_amp',
+                device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_no_amp',
+				device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
         ),
     ),
     OpInfo(
@@ -1709,7 +1743,7 @@ op_db: List[OpInfo] = [
         op=torch.linalg.norm,
         variant_test_name="subgradients_at_zero",
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
         sample_inputs_func=partial(
             sample_inputs_linalg_norm, variant="subgradient_at_zero"
         ),
@@ -1732,6 +1766,22 @@ op_db: List[OpInfo] = [
                 unittest.expectedFailure, "TestFwdGradients", "test_forward_mode_AD"
             ),
             DecorateInfo(unittest.expectedFailure, "TestBwdGradients", "test_fn_grad"),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_amp',
+                device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_no_amp',
+				device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
         ),
     ),
     OpInfo(
@@ -1742,8 +1792,26 @@ op_db: List[OpInfo] = [
         check_batched_forward_grad=False,
         check_batched_gradgrad=False,
         supports_fwgrad_bwgrad=True,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
         sample_inputs_func=sample_inputs_linalg_matrix_norm,
+        skips=(
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_amp',
+                device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_no_amp',
+				device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
+        ),
     ),
     OpInfo(
         "linalg.qr",
@@ -2211,7 +2279,7 @@ op_db: List[OpInfo] = [
         check_batched_grad=False,
         check_batched_gradgrad=False,
         sample_inputs_func=sample_inputs_svd,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -2234,6 +2302,22 @@ op_db: List[OpInfo] = [
                 device_type="mps",
                 dtypes=[torch.float32],
             ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_amp',
+                device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_no_amp',
+				device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
         ),
     ),
     OpInfo(
@@ -2248,7 +2332,25 @@ op_db: List[OpInfo] = [
         # We're using at::allclose, which does not have a batching rule
         check_batched_gradgrad=False,
         sample_inputs_func=sample_inputs_linalg_svdvals,
-        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack, with_tf32_off],
+        decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCPUIfNoLapack, with_tf32_off],
+        skips=(
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_amp',
+                device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                'TestFakeTensor',
+                'test_fake_crossref_backward_no_amp',
+				device_type='cuda',
+                dtypes=[torch.float32],
+                active_if=TEST_WITH_ROCM
+            ),
+        ),
     ),
     OpInfo(
         "linalg.tensorinv",


### PR DESCRIPTION
This PR should enable 900+ fake_crossref unit tests for ROCm.
cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport