### PR TITLE
linemaps for inductor: python 3.9 and lower doesn't have bisect key argument

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -656,7 +656,8 @@ class PyCodeCache:
                 exec(code, mod.__dict__, mod.__dict__)
                 # another thread might set this first
                 cls.cache.setdefault(key, mod)
-                cls.linemaps[path] = linemap
+                # unzip into separate lines/nodes lists
+                cls.linemaps[path] = list(zip(*linemap))
 
         return cls.cache[key]
 
@@ -666,11 +667,11 @@ class PyCodeCache:
         if path not in cls.linemaps:
             return None
         # [(starting_line, <fx node>), ...]
-        linemap = cls.linemaps[path]
-        p = bisect_right(linemap, lineno, key=lambda x: x[0])
+        lines, nodes = cls.linemaps[path]
+        p = bisect_right(lines, lineno)
         if p == 0:
             return None
-        _, entry = linemap[p - 1]
+        entry = nodes[p - 1]
         if not entry:
             return None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97369
* #97363



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire