### PR TITLE
[Vulkan] Fix quantized cpu to vulkan broken by padding

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/image_to_nchw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/image_to_nchw.glsl
@@ -20,9 +20,11 @@ uBuffer;
  * Params Buffer
  */
 layout(set = 0, binding = 2) uniform PRECISION restrict Block {
-  // Extents of the output texture
+  // xyz contain the extents of the input texture, w contains HxW to help
+  // calculate buffer offsets
   ivec4 in_extents;
-  // Number of texels spanned by one channel
+  // x: number of texels spanned by one channel
+  // y: number of channels
   ivec2 c_info;
 }
 uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/nchw_to_image_int32.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/nchw_to_image_int32.glsl
@@ -23,9 +23,12 @@ uBuffer;
  * Params Buffer
  */
 layout(set = 0, binding = 2) uniform PRECISION restrict Block {
-  // xyz contain the extents of the input texture, w contains HxW to help
+  // xyz contain the extents of the output texture, w contains HxW to help
   // calculate buffer offsets
   ivec4 out_extents;
+  // x: number of texels spanned by one channel
+  // y: number of channels
+  ivec2 c_info;
 }
 uBlock;
 
@@ -41,8 +44,12 @@ void main() {
     return;
   }
 
+  const int n_index = int(pos.z / uBlock.c_info.x);
+  const int c_index = (pos.z % uBlock.c_info.x) * 4;
+  int d_offset = (n_index * uBlock.c_info.y) + c_index;
+
   const int base_index =
-      pos.x + uBlock.out_extents.x * pos.y + (4 * uBlock.out_extents.w) * pos.z;
+      pos.x + uBlock.out_extents.x * pos.y + uBlock.out_extents.w * d_offset;
   const ivec4 buf_indices =
       base_index + ivec4(0, 1, 2, 3) * uBlock.out_extents.w;
 
@@ -51,5 +58,13 @@ void main() {
   int val_z = uBuffer.data[buf_indices.z];
   int val_w = uBuffer.data[buf_indices.w];
 
-  imageStore(uImage, pos, ivec4(val_x, val_y, val_z, val_w));
+  ivec4 texel = ivec4(val_x, val_y, val_z, val_w);
+
+  if (c_index + 3 >= uBlock.c_info.y) {
+    ivec4 c_ind = ivec4(c_index) + ivec4(0, 1, 2, 3);
+    ivec4 valid_c = ivec4(lessThan(c_ind, ivec4(uBlock.c_info.y)));
+    texel = texel * valid_c;
+  }
+
+  imageStore(uImage, pos, texel);
 }

--- a/aten/src/ATen/native/vulkan/glsl/nchw_to_image_int8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/nchw_to_image_int8.glsl
@@ -23,9 +23,12 @@ uBuffer;
  * Params Buffer
  */
 layout(set = 0, binding = 2) uniform PRECISION restrict Block {
-  // xyz contain the extents of the input texture, w contains HxW to help
+  // xyz contain the extents of the output texture, w contains HxW to help
   // calculate buffer offsets
   ivec4 out_extents;
+  // x: number of texels spanned by one channel
+  // y: number of channels
+  ivec2 c_info;
 }
 uBlock;
 
@@ -51,8 +54,12 @@ void main() {
     return;
   }
 
+  const int n_index = int(pos.z / uBlock.c_info.x);
+  const int c_index = (pos.z % uBlock.c_info.x) * 4;
+  int d_offset = (n_index * uBlock.c_info.y) + c_index;
+
   const int base_index =
-      pos.x + uBlock.out_extents.x * pos.y + (4 * uBlock.out_extents.w) * pos.z;
+      pos.x + uBlock.out_extents.x * pos.y + uBlock.out_extents.w * d_offset;
   const ivec4 buf_indices =
       base_index + ivec4(0, 1, 2, 3) * uBlock.out_extents.w;
 
@@ -80,6 +87,12 @@ void main() {
   r_v = extend_sign(r_v);
 
   ivec4 texel = ivec4(a_v, b_v, g_v, r_v);
+
+  if (c_index + 3 >= uBlock.c_info.y) {
+    ivec4 c_ind = ivec4(c_index) + ivec4(0, 1, 2, 3);
+    ivec4 valid_c = ivec4(lessThan(c_ind, ivec4(uBlock.c_info.y)));
+    texel = texel * valid_c;
+  }
 
   imageStore(uImage, pos, texel);
 }

--- a/aten/src/ATen/native/vulkan/glsl/nchw_to_image_uint8.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/nchw_to_image_uint8.glsl
@@ -23,9 +23,12 @@ uBuffer;
  * Params Buffer
  */
 layout(set = 0, binding = 2) uniform PRECISION restrict Block {
-  // xyz contain the extents of the input texture, w contains HxW to help
+  // xyz contain the extents of the output texture, w contains HxW to help
   // calculate buffer offsets
   ivec4 out_extents;
+  // x: number of texels spanned by one channel
+  // y: number of channels
+  ivec2 c_info;
 }
 uBlock;
 
@@ -41,8 +44,12 @@ void main() {
     return;
   }
 
+  const int n_index = int(pos.z / uBlock.c_info.x);
+  const int c_index = (pos.z % uBlock.c_info.x) * 4;
+  int d_offset = (n_index * uBlock.c_info.y) + c_index;
+
   const int base_index =
-      pos.x + uBlock.out_extents.x * pos.y + (4 * uBlock.out_extents.w) * pos.z;
+      pos.x + uBlock.out_extents.x * pos.y + uBlock.out_extents.w * d_offset;
   const ivec4 buf_indices =
       base_index + ivec4(0, 1, 2, 3) * uBlock.out_extents.w;
 
@@ -66,6 +73,12 @@ void main() {
   uint r_v = (buf_in_4 & masks.w) >> 8 * (buf_indices.w % 4);
 
   uvec4 texel = uvec4(a_v, b_v, g_v, r_v);
+
+  if (c_index + 3 >= uBlock.c_info.y) {
+    ivec4 c_ind = ivec4(c_index) + ivec4(0, 1, 2, 3);
+    uvec4 valid_c = uvec4(lessThan(c_ind, ivec4(uBlock.c_info.y)));
+    texel = texel * valid_c;
+  }
 
   imageStore(uImage, pos, texel);
 }


### PR DESCRIPTION
Summary:
Previous diff D43068669 introduced channel padding, and in doing so, it broke the quantized copy of cpu to vulkan tensors.
This diff updates the quantized nchw to image shaders, in order to work with padded channels.

Test Plan:
```
buck run --target-platforms ovr_config//platform/macos:arm64-fbsource -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64
```

Differential Revision: D44309956

