### PR TITLE
Fix CPU vectorized eq and ne operations for complex types

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -446,11 +446,15 @@ Vectorized<c10::complex<double>> inline operator^(const Vectorized<c10::complex<
 }
 
 inline Vectorized<c10::complex<double>> Vectorized<c10::complex<double>>::eq(const Vectorized<c10::complex<double>>& other) const {
-  return (*this == other) & Vectorized<c10::complex<double>>(_mm256_set1_pd(1.0));
+  auto eq = (*this == other);  // compares real and imag individually
+  // If both real numbers and imag numbers are equal, then the complex numbers are equal
+  return (eq.real() & eq.imag()) & Vectorized<c10::complex<double>>(_mm256_set1_pd(1.0));
 }
 
 inline Vectorized<c10::complex<double>> Vectorized<c10::complex<double>>::ne(const Vectorized<c10::complex<double>>& other) const {
-  return (*this != other) & Vectorized<c10::complex<double>>(_mm256_set1_pd(1.0));
+  auto ne = (*this != other);  // compares real and imag individually
+  // If either real numbers or imag numbers are not equal, then the complex numbers are not equal
+  return (ne.real() | ne.imag()) & Vectorized<c10::complex<double>>(_mm256_set1_pd(1.0));
 }
 
 #endif

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -483,12 +483,16 @@ Vectorized<c10::complex<float>> inline operator^(const Vectorized<c10::complex<f
 
 inline Vectorized<c10::complex<float>> Vectorized<c10::complex<float>>::eq(
     const Vectorized<c10::complex<float>>& other) const {
-  return (*this == other) & Vectorized<c10::complex<float>>(_mm256_set1_ps(1.0f));
+  auto eq = (*this == other);  // compares real and imag individually
+  // If both real numbers and imag numbers are equal, then the complex numbers are equal
+  return (eq.real() & eq.imag()) & Vectorized<c10::complex<float>>(_mm256_set1_ps(1.0f));
 }
 
 inline Vectorized<c10::complex<float>> Vectorized<c10::complex<float>>::ne(
     const Vectorized<c10::complex<float>>& other) const {
-  return (*this != other) & Vectorized<c10::complex<float>>(_mm256_set1_ps(1.0f));
+  auto ne = (*this != other);  // compares real and imag individually
+  // If either real numbers or imag numbers are not equal, then the complex numbers are not equal
+  return (ne.real() | ne.imag()) & Vectorized<c10::complex<float>>(_mm256_set1_ps(1.0f));
 }
 
 #endif

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_double_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_double_vsx.h
@@ -515,12 +515,14 @@ class Vectorized<ComplexDbl> {
   }
 
   Vectorized<ComplexDbl> eq(const Vectorized<ComplexDbl>& other) const {
-    auto ret = (*this == other);
-    return ret & vd_one;
+    auto eq = (*this == other);  // compares real and imag individually
+    // If both real numbers and imag numbers are equal, then the complex numbers are equal
+    return (eq.real() & eq.imag()) & vd_one;
   }
   Vectorized<ComplexDbl> ne(const Vectorized<ComplexDbl>& other) const {
-    auto ret = (*this != other);
-    return ret & vd_one;
+    auto ne = (*this != other);  // compares real and imag individually
+    // If either real numbers or imag numbers are not equal, then the complex numbers are not equal
+    return (ne.real() | ne.imag()) & vd_one;
   }
 
   Vectorized<ComplexDbl> lt(const Vectorized<ComplexDbl>& other) const {

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_float_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_complex_float_vsx.h
@@ -540,12 +540,14 @@ class Vectorized<ComplexFlt> {
   }
 
   Vectorized<ComplexFlt> eq(const Vectorized<ComplexFlt>& other) const {
-    auto ret = (*this == other);
-    return ret & one;
+    auto eq = (*this == other);  // compares real and imag individually
+    // If both real numbers and imag numbers are equal, then the complex numbers are equal
+    return (eq.real() & eq.imag()) & one;
   }
   Vectorized<ComplexFlt> ne(const Vectorized<ComplexFlt>& other) const {
-    auto ret = (*this != other);
-    return ret & one;
+    auto ne = (*this != other);  // compares real and imag individually
+    // If either real numbers or imag numbers are not equal, then the complex numbers are not equal
+    return (ne.real() | ne.imag()) & one;
   }
 
   Vectorized<ComplexFlt> sgn() const {

--- a/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
+++ b/aten/src/ATen/cpu/vec/vec256/zarch/vec256_zarch.h
@@ -2212,10 +2212,18 @@ struct Vectorized<T, std::enable_if_t<is_zarch_implemented_complex<T>()>> {
   }
 
   Vectorized<T> C10_ALWAYS_INLINE eq(const Vectorized<T>& other) const {
-    return Vectorized<T>{_vec.eq(other._vec)};
+    auto eq = _vec.eq(other._vec);  // compares real and imag individually
+    // If both real numbers and imag numbers are equal, then the complex numbers are equal
+    auto real = eq & vinner_type(real_mask<underline_type>());
+    auto imag = (eq & vinner_type(image_mask<underline_type>())).swapped();
+    return Vectorized<T>{real & imag};
   }
   Vectorized<T> C10_ALWAYS_INLINE ne(const Vectorized<T>& other) const {
-    return Vectorized<T>{_vec.ne(other._vec)};
+    auto ne = _vec.ne(other._vec);  // compares real and imag individually
+    // If either real numbers or imag numbers are not equal, then the complex numbers are not equal
+    auto real = ne & vinner_type(real_mask<underline_type>());
+    auto imag = (ne & vinner_type(image_mask<underline_type>())).swapped();
+    return Vectorized<T>{real | imag};
   }
 
   Vectorized<T> real() const {

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
@@ -528,11 +528,15 @@ Vectorized<c10::complex<double>> inline operator^(const Vectorized<c10::complex<
 }
 
 inline Vectorized<c10::complex<double>> Vectorized<c10::complex<double>>::eq(const Vectorized<c10::complex<double>>& other) const {
-  return (*this == other) & Vectorized<c10::complex<double>>(_mm512_set1_pd(1.0));
+  auto eq = (*this == other);  // compares real and imag individually
+  // If both real numbers and imag numbers are equal, then the complex numbers are equal
+  return (eq.real() & eq.imag()) & Vectorized<c10::complex<double>>(_mm512_set1_pd(1.0));
 }
 
 inline Vectorized<c10::complex<double>> Vectorized<c10::complex<double>>::ne(const Vectorized<c10::complex<double>>& other) const {
-  return (*this != other) & Vectorized<c10::complex<double>>(_mm512_set1_pd(1.0));
+  auto ne = (*this != other);  // compares real and imag individually
+  // If either real numbers or imag numbers are not equal, then the complex numbers are not equal
+  return (ne.real() | ne.imag()) & Vectorized<c10::complex<double>>(_mm512_set1_pd(1.0));
 }
 
 #endif

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
@@ -1032,12 +1032,16 @@ Vectorized<c10::complex<float>> inline operator^(const Vectorized<c10::complex<f
 
 inline Vectorized<c10::complex<float>> Vectorized<c10::complex<float>>::eq(
     const Vectorized<c10::complex<float>>& other) const {
-  return (*this == other) & Vectorized<c10::complex<float>>(_mm512_set1_ps(1.0f));
+  auto eq = (*this == other);  // compares real and imag individually
+  // If both real numbers and imag numbers are equal, then the complex numbers are equal
+  return (eq.real() & eq.imag()) & Vectorized<c10::complex<float>>(_mm512_set1_ps(1.0f));
 }
 
 inline Vectorized<c10::complex<float>> Vectorized<c10::complex<float>>::ne(
     const Vectorized<c10::complex<float>>& other) const {
-  return (*this != other) & Vectorized<c10::complex<float>>(_mm512_set1_ps(1.0f));
+  auto ne = (*this != other);  // compares real and imag individually
+  // If either real numbers or imag numbers are not equal, then the complex numbers are not equal
+  return (ne.real() | ne.imag()) & Vectorized<c10::complex<float>>(_mm512_set1_ps(1.0f));
 }
 
 #endif

--- a/test/test_complex.py
+++ b/test/test_complex.py
@@ -1,7 +1,11 @@
 # Owner(s): ["module: complex"]
 
 import torch
-from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    dtypes,
+    onlyCPU,
+)
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch.testing._internal.common_dtype import complex_types
 
@@ -22,6 +26,144 @@ class TestComplexTensor(TestCase):
         x = torch.tensor([3., 3. + 5.j], device=device)
         torch.set_default_dtype(default_dtype)
         self.assertEqual(x.dtype, torch.cdouble if dtype == torch.float64 else torch.cfloat)
+
+    @onlyCPU
+    @dtypes(*complex_types())
+    def test_eq(self, device, dtype):
+        "Test eq on complex types"
+        nan = float("nan")
+        # Non-vectorized operations
+        for a, b in (
+            (torch.tensor([-0.0610 - 2.1172j], device=device, dtype=dtype),
+             torch.tensor([-6.1278 - 8.5019j], device=device, dtype=dtype)),
+            (torch.tensor([-0.0610 - 2.1172j], device=device, dtype=dtype),
+             torch.tensor([-6.1278 - 2.1172j], device=device, dtype=dtype)),
+            (torch.tensor([-0.0610 - 2.1172j], device=device, dtype=dtype),
+             torch.tensor([-0.0610 - 8.5019j], device=device, dtype=dtype)),
+        ):
+            actual = torch.eq(a, b)
+            expected = torch.tensor([False], device=device, dtype=torch.bool)
+            self.assertEqual(actual, expected, msg=f"\neq\nactual {actual}\nexpected {expected}")
+
+            actual = torch.eq(a, a)
+            expected = torch.tensor([True], device=device, dtype=torch.bool)
+            self.assertEqual(actual, expected, msg=f"\neq\nactual {actual}\nexpected {expected}")
+
+            actual = torch.full_like(b, complex(2, 2))
+            torch.eq(a, b, out=actual)
+            expected = torch.tensor([complex(0)], device=device, dtype=dtype)
+            self.assertEqual(actual, expected, msg=f"\neq(out)\nactual {actual}\nexpected {expected}")
+
+            actual = torch.full_like(b, complex(2, 2))
+            torch.eq(a, a, out=actual)
+            expected = torch.tensor([complex(1)], device=device, dtype=dtype)
+            self.assertEqual(actual, expected, msg=f"\neq(out)\nactual {actual}\nexpected {expected}")
+
+        # Vectorized operations
+        for a, b in (
+            (torch.tensor([
+                -0.0610 - 2.1172j, 5.1576 + 5.4775j, complex(2.8871, nan), -6.6545 - 3.7655j, -2.7036 - 1.4470j, 0.3712 + 7.989j,
+                -0.0610 - 2.1172j, 5.1576 + 5.4775j, complex(nan, -3.2650), -6.6545 - 3.7655j, -2.7036 - 1.4470j, 0.3712 + 7.989j],
+                device=device, dtype=dtype),
+             torch.tensor([
+                -6.1278 - 8.5019j, 0.5886 + 8.8816j, complex(2.8871, nan), 6.3505 + 2.2683j, 0.3712 + 7.9659j, 0.3712 + 7.989j,
+                -6.1278 - 2.1172j, 5.1576 + 8.8816j, complex(nan, -3.2650), 6.3505 + 2.2683j, 0.3712 + 7.9659j, 0.3712 + 7.989j],
+                device=device, dtype=dtype)),
+        ):
+            actual = torch.eq(a, b)
+            expected = torch.tensor([False, False, False, False, False, True,
+                                    False, False, False, False, False, True],
+                                    device=device, dtype=torch.bool)
+            self.assertEqual(actual, expected, msg=f"\neq\nactual {actual}\nexpected {expected}")
+
+            actual = torch.eq(a, a)
+            expected = torch.tensor([True, True, False, True, True, True,
+                                    True, True, False, True, True, True],
+                                    device=device, dtype=torch.bool)
+            self.assertEqual(actual, expected, msg=f"\neq\nactual {actual}\nexpected {expected}")
+
+            actual = torch.full_like(b, complex(2, 2))
+            torch.eq(a, b, out=actual)
+            expected = torch.tensor([complex(0), complex(0), complex(0), complex(0), complex(0), complex(1),
+                                    complex(0), complex(0), complex(0), complex(0), complex(0), complex(1)],
+                                    device=device, dtype=dtype)
+            self.assertEqual(actual, expected, msg=f"\neq(out)\nactual {actual}\nexpected {expected}")
+
+            actual = torch.full_like(b, complex(2, 2))
+            torch.eq(a, a, out=actual)
+            expected = torch.tensor([complex(1), complex(1), complex(0), complex(1), complex(1), complex(1),
+                                    complex(1), complex(1), complex(0), complex(1), complex(1), complex(1)],
+                                    device=device, dtype=dtype)
+            self.assertEqual(actual, expected, msg=f"\neq(out)\nactual {actual}\nexpected {expected}")
+
+    @onlyCPU
+    @dtypes(*complex_types())
+    def test_ne(self, device, dtype):
+        "Test ne on complex types"
+        nan = float("nan")
+        # Non-vectorized operations
+        for a, b in (
+            (torch.tensor([-0.0610 - 2.1172j], device=device, dtype=dtype),
+             torch.tensor([-6.1278 - 8.5019j], device=device, dtype=dtype)),
+            (torch.tensor([-0.0610 - 2.1172j], device=device, dtype=dtype),
+             torch.tensor([-6.1278 - 2.1172j], device=device, dtype=dtype)),
+            (torch.tensor([-0.0610 - 2.1172j], device=device, dtype=dtype),
+             torch.tensor([-0.0610 - 8.5019j], device=device, dtype=dtype)),
+        ):
+            actual = torch.ne(a, b)
+            expected = torch.tensor([True], device=device, dtype=torch.bool)
+            self.assertEqual(actual, expected, msg=f"\nne\nactual {actual}\nexpected {expected}")
+
+            actual = torch.ne(a, a)
+            expected = torch.tensor([False], device=device, dtype=torch.bool)
+            self.assertEqual(actual, expected, msg=f"\nne\nactual {actual}\nexpected {expected}")
+
+            actual = torch.full_like(b, complex(2, 2))
+            torch.ne(a, b, out=actual)
+            expected = torch.tensor([complex(1)], device=device, dtype=dtype)
+            self.assertEqual(actual, expected, msg=f"\nne(out)\nactual {actual}\nexpected {expected}")
+
+            actual = torch.full_like(b, complex(2, 2))
+            torch.ne(a, a, out=actual)
+            expected = torch.tensor([complex(0)], device=device, dtype=dtype)
+            self.assertEqual(actual, expected, msg=f"\nne(out)\nactual {actual}\nexpected {expected}")
+
+        # Vectorized operations
+        for a, b in (
+            (torch.tensor([
+                -0.0610 - 2.1172j, 5.1576 + 5.4775j, complex(2.8871, nan), -6.6545 - 3.7655j, -2.7036 - 1.4470j, 0.3712 + 7.989j,
+                -0.0610 - 2.1172j, 5.1576 + 5.4775j, complex(nan, -3.2650), -6.6545 - 3.7655j, -2.7036 - 1.4470j, 0.3712 + 7.989j],
+                device=device, dtype=dtype),
+             torch.tensor([
+                -6.1278 - 8.5019j, 0.5886 + 8.8816j, complex(2.8871, nan), 6.3505 + 2.2683j, 0.3712 + 7.9659j, 0.3712 + 7.989j,
+                -6.1278 - 2.1172j, 5.1576 + 8.8816j, complex(nan, -3.2650), 6.3505 + 2.2683j, 0.3712 + 7.9659j, 0.3712 + 7.989j],
+                device=device, dtype=dtype)),
+        ):
+            actual = torch.ne(a, b)
+            expected = torch.tensor([True, True, True, True, True, False,
+                                    True, True, True, True, True, False],
+                                    device=device, dtype=torch.bool)
+            self.assertEqual(actual, expected, msg=f"\nne\nactual {actual}\nexpected {expected}")
+
+            actual = torch.ne(a, a)
+            expected = torch.tensor([False, False, True, False, False, False,
+                                    False, False, True, False, False, False],
+                                    device=device, dtype=torch.bool)
+            self.assertEqual(actual, expected, msg=f"\nne\nactual {actual}\nexpected {expected}")
+
+            actual = torch.full_like(b, complex(2, 2))
+            torch.ne(a, b, out=actual)
+            expected = torch.tensor([complex(1), complex(1), complex(1), complex(1), complex(1), complex(0),
+                                    complex(1), complex(1), complex(1), complex(1), complex(1), complex(0)],
+                                    device=device, dtype=dtype)
+            self.assertEqual(actual, expected, msg=f"\nne(out)\nactual {actual}\nexpected {expected}")
+
+            actual = torch.full_like(b, complex(2, 2))
+            torch.ne(a, a, out=actual)
+            expected = torch.tensor([complex(0), complex(0), complex(1), complex(0), complex(0), complex(0),
+                                    complex(0), complex(0), complex(1), complex(0), complex(0), complex(0)],
+                                    device=device, dtype=dtype)
+            self.assertEqual(actual, expected, msg=f"\nne(out)\nactual {actual}\nexpected {expected}")
 
 instantiate_device_type_tests(TestComplexTensor, globals())
 


### PR DESCRIPTION
The comparison of both the real and imag parts need to be combined and then the result must have the real number be 1 for true and 0 for false while the imag number must always be 0.

Fixes https://github.com/pytorch/pytorch/issues/75950


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10