### PR TITLE
Modify all calls to checkpoint pass use_reentrant explicitly

### DIFF
--- a/test/distributed/fsdp/test_fsdp_checkpoint.py
+++ b/test/distributed/fsdp/test_fsdp_checkpoint.py
@@ -260,7 +260,7 @@ class TestFSDPCheckpoint(FSDPTest):
                             else contextlib.suppress()
                         )
                         with offload_ctx:
-                            out = checkpoint(m, inp)
+                            out = checkpoint(m, inp, use_reentrant=True)
                     else:
                         # _save_on_cpu should not be called yet
                         self.assertFalse(_save_on_cpu_called)

--- a/test/distributed/fsdp/test_fsdp_memory.py
+++ b/test/distributed/fsdp/test_fsdp_memory.py
@@ -84,7 +84,7 @@ class Model(nn.Module):
 
     def forward(self, x):
         if self.with_checkpoint:
-            return self.head(checkpoint(self.blocks, self.stem(x)))
+            return self.head(checkpoint(self.blocks, self.stem(x), use_reentrant=True))
         else:
             return self.head(self.blocks(self.stem(x)))
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5444,7 +5444,7 @@ for shape in [(1,), ()]:
             data_r = torch.empty(1, nz_inp)
             data_r.uniform_()
             data_r.requires_grad = True
-            feat_r = checkpoint(module, data_r)
+            feat_r = checkpoint(module, data_r, use_reentrant=True)
             feat_combined.append(feat_r)
 
         # compute mean as a proxy for some joint reasoning
@@ -5715,10 +5715,10 @@ for shape in [(1,), ()]:
         a = torch.randn(2, 2, requires_grad=True)
 
         with self.assertRaisesRegex(Exception, "Checkpointing is not compatible with .grad()"):
-            b = checkpoint(torch.exp, a).sum()
+            b = checkpoint(torch.exp, a, use_reentrant=True).sum()
             torch.autograd.grad(b, (a,))
 
-        c = checkpoint(torch.exp, a).sum()
+        c = checkpoint(torch.exp, a, use_reentrant=True).sum()
         c.backward()
 
     @parametrize("use_reentrant", [True, False])
@@ -9406,7 +9406,7 @@ class TestAutogradDeviceType(TestCase):
             # Perform checkpoint on cpu tensors. So the last op performed in the reentrant
             # autograd is an AccumulateGrad that runs on the cpu thread for the gpu thread.
             # So the cpu thread will notify the gpu thread with an empty NodeTask.
-            branch2 = checkpoint(fn_on_gpu, inp)
+            branch2 = checkpoint(fn_on_gpu, inp, use_reentrant=True)
             out = branch2 + branch1
             return out
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3350,7 +3350,7 @@ torch.cuda.synchronize()
                                     torch.nn.Linear(8, 8)).cuda()
         input = torch.rand((8, 8), device="cuda", dtype=torch.float16, requires_grad=True)
         with torch.autocast('cuda', ):
-            output = checkpoint_sequential(model, 2, input)
+            output = checkpoint_sequential(model, 2, input, use_reentrant=True)
         self.assertTrue(output.requires_grad)
         self.assertTrue(output.dtype is torch.float16)
         output.sum().backward()

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -172,7 +172,7 @@ def noop_context_fn():
 def checkpoint(
     function,
     *args,
-    use_reentrant: bool = True,
+    use_reentrant: bool = None,
     context_fn: Callable[[], Tuple[ContextManager, ContextManager]] = noop_context_fn,
     **kwargs
 ):
@@ -271,6 +271,7 @@ def checkpoint(
     Returns:
         Output of running :attr:`function` on :attr:`*args`
     """
+    assert use_reentrant is not None
     # Hack to mix *args with **kwargs in a python 2.7-compliant way
     preserve = kwargs.pop('preserve_rng_state', True)
     if kwargs and use_reentrant:
@@ -290,7 +291,7 @@ def checkpoint(
         )
 
 
-def checkpoint_sequential(functions, segments, input, use_reentrant=True, **kwargs):
+def checkpoint_sequential(functions, segments, input, use_reentrant=None, **kwargs):
     r"""A helper function for checkpointing sequential models.
 
     Sequential models execute a list of modules/functions in order
@@ -334,6 +335,7 @@ def checkpoint_sequential(functions, segments, input, use_reentrant=True, **kwar
         >>> model = nn.Sequential(...)
         >>> input_var = checkpoint_sequential(model, chunks, input_var)
     """
+    assert use_reentrant is not None
     # Hack for keyword-only parameter in a python 2.7-compliant way
     preserve = kwargs.pop('preserve_rng_state', True)
     if kwargs:

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -172,7 +172,7 @@ def noop_context_fn():
 def checkpoint(
     function,
     *args,
-    use_reentrant: bool = None,
+    use_reentrant: bool = True,
     context_fn: Callable[[], Tuple[ContextManager, ContextManager]] = noop_context_fn,
     **kwargs
 ):
@@ -271,7 +271,6 @@ def checkpoint(
     Returns:
         Output of running :attr:`function` on :attr:`*args`
     """
-    assert use_reentrant is not None
     # Hack to mix *args with **kwargs in a python 2.7-compliant way
     preserve = kwargs.pop('preserve_rng_state', True)
     if kwargs and use_reentrant:
@@ -291,7 +290,7 @@ def checkpoint(
         )
 
 
-def checkpoint_sequential(functions, segments, input, use_reentrant=None, **kwargs):
+def checkpoint_sequential(functions, segments, input, use_reentrant=True, **kwargs):
     r"""A helper function for checkpointing sequential models.
 
     Sequential models execute a list of modules/functions in order
@@ -335,7 +334,6 @@ def checkpoint_sequential(functions, segments, input, use_reentrant=None, **kwar
         >>> model = nn.Sequential(...)
         >>> input_var = checkpoint_sequential(model, chunks, input_var)
     """
-    assert use_reentrant is not None
     # Hack for keyword-only parameter in a python 2.7-compliant way
     preserve = kwargs.pop('preserve_rng_state', True)
     if kwargs:


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

This is the first step toward making use_reentrant=False the default. 