### PR TITLE
Functionalization of torch.rand/rand_like ops

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -1,4 +1,4 @@
-# Owner(s): ["module: functorch"]
+# Owner(s): ["oncall: pt2"]
 
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.

--- a/test/test_functionalization_of_rng_ops.py
+++ b/test/test_functionalization_of_rng_ops.py
@@ -1,0 +1,282 @@
+# Owner(s): ["oncall: pt2"]
+
+import torch
+from torch.testing._internal.common_utils import (
+    TestCase,
+    run_tests,
+)
+
+from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes
+from functorch.compile import aot_function, nop, min_cut_rematerialization_partition
+from unittest import skip
+from unittest.mock import patch
+import functools
+import torch.utils.checkpoint
+
+
+def count_philox_rand(gm, args, freq):
+    assert [node.target for node in gm.graph.nodes].count(torch.ops.rngprims.philox_rand.default) == freq
+    return gm
+
+class TestFunctionalizationRngOps(TestCase):
+    @dtypes(torch.float32)
+    @patch.object(torch._functorch.config, "functionalize_rng_ops", True)
+    def test_rand_like(self, dtype, device):
+        def fn(x):
+            a = torch.rand_like(x) * x
+            a = torch.rand_like(x) * a
+            return a
+
+        x = torch.rand(10, device=device, dtype=dtype)
+
+        for seed in range(10):
+            torch.cuda.manual_seed(seed)
+            ref = fn(x)
+
+            torch.cuda.manual_seed(seed)
+            aot_fn = aot_function(fn, functools.partial(count_philox_rand, freq=2))
+            res = aot_fn(x)
+
+            self.assertEqual(ref, res)
+
+    @dtypes(torch.float32)
+    @patch.object(torch._functorch.config, "functionalize_rng_ops", True)
+    def test_rand(self, dtype, device):
+        shape = (10,)
+
+        def fn(x):
+            a = torch.rand(*shape, device=device, dtype=dtype) * x
+            a = torch.rand(*shape, device=device, dtype=dtype) * a
+            return a
+
+        x = torch.rand(*shape, device=device, dtype=dtype)
+
+        for seed in range(10):
+            torch.cuda.manual_seed(seed)
+            ref = fn(x)
+
+            torch.cuda.manual_seed(seed)
+            aot_fn = aot_function(fn, functools.partial(count_philox_rand, freq=2))
+            res = aot_fn(x)
+
+            self.assertEqual(ref, res)
+
+    @dtypes(torch.float32)
+    @patch.object(torch._functorch.config, "functionalize_rng_ops", True)
+    def test_autograd_function(self, dtype, device):
+        shape = (16, 16)
+
+        class Custom(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.save_for_backward(x)
+                a = torch.rand_like(x) * x
+                a = torch.rand_like(x) * a
+                return a
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                x, = ctx.saved_tensors
+                return grad_out * torch.rand_like(grad_out) * torch.cos(x)
+
+        custom = Custom.apply
+
+        x = torch.rand(*shape, device=device, dtype=dtype, requires_grad=True)
+
+        x_clone = x.clone().detach().requires_grad_(True)
+
+        torch.cuda.manual_seed(123)
+        ref = custom(x)
+        ref.sum().backward()
+
+        torch.cuda.manual_seed(123)
+        fwd_compiler = functools.partial(count_philox_rand, freq=2)
+        bwd_compiler = functools.partial(count_philox_rand, freq=1)
+        aot_custom = aot_function(custom, fwd_compiler, bwd_compiler)
+        res = aot_custom(x_clone)
+        res.sum().backward()
+
+        self.assertEqual(ref, res)
+        self.assertEqual(x.grad, x_clone.grad)
+
+    @dtypes(torch.float32)
+    @patch.object(torch._functorch.config, "functionalize_rng_ops", True)
+    def test_multiple_subgraphs(self, dtype, device):
+        # Checks that rng state is maintained when there are multiple aot traced
+        # graphs.
+        shape = (16, 16)
+
+        class CustomOp1(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.save_for_backward(x)
+                a = torch.rand_like(x) * x
+                a = torch.rand_like(x) * a
+                return a
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                x, = ctx.saved_tensors
+                return grad_out * torch.rand_like(grad_out) * torch.cos(x)
+
+        class CustomOp2(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.save_for_backward(x)
+                a = torch.rand_like(x) * x
+                return a
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                x, = ctx.saved_tensors
+                return grad_out * torch.rand_like(grad_out) * torch.rand_like(x)
+
+
+        custom_op1 = CustomOp1.apply
+        custom_op2 = CustomOp2.apply
+
+        def fn(x):
+            a = custom_op1(x)
+            b = a.sin()
+            return custom_op2(b)
+
+        fwd_compiler = functools.partial(count_philox_rand, freq=2)
+        bwd_compiler = functools.partial(count_philox_rand, freq=1)
+        aot_custom_op1 = aot_function(custom_op1, fwd_compiler, bwd_compiler)
+        fwd_compiler = functools.partial(count_philox_rand, freq=1)
+        bwd_compiler = functools.partial(count_philox_rand, freq=2)
+        aot_custom_op2 = aot_function(custom_op2, fwd_compiler, bwd_compiler)
+
+        def aot_fn(x):
+            a = aot_custom_op1(x)
+            b = a.sin()
+            return aot_custom_op2(b)
+
+
+        for seed in range(10):
+            torch.cuda.manual_seed(seed)
+            x = torch.rand(*shape, device=device, dtype=dtype, requires_grad=True)
+            x_clone = x.clone().detach().requires_grad_(True)
+
+            torch.cuda.manual_seed(seed)
+            ref = fn(x)
+            ref.sum().backward()
+
+            torch.cuda.manual_seed(seed)
+            res = aot_fn(x_clone)
+            res.sum().backward()
+
+            self.assertEqual(ref, res)
+            self.assertEqual(x.grad, x_clone.grad)
+
+    @dtypes(torch.float32)
+    @patch.object(torch._functorch.config, "functionalize_rng_ops", True)
+    def test_set_get_rng_state(self, dtype, device):
+        def fn(x):
+            a = torch.rand_like(x) * x
+            state = torch.cuda.get_rng_state()
+            a = torch.rand_like(x) * a
+            torch.cuda.set_rng_state(state)
+            a = torch.rand_like(x) * a
+            return a
+
+        x = torch.rand(10, device=device, dtype=dtype)
+
+        for seed in range(10):
+            torch.cuda.manual_seed(seed)
+            ref = fn(x)
+
+            torch.cuda.manual_seed(seed)
+            fwd_compiler = functools.partial(count_philox_rand, freq=3)
+            aot_fn = aot_function(fn, fwd_compiler)
+            res = aot_fn(x)
+
+            self.assertEqual(ref, res)
+
+    @dtypes(torch.float32)
+    @patch.object(torch._functorch.config, "functionalize_rng_ops", True)
+    def test_min_cut_partitioner(self, dtype, device):
+        # Checks that the calling convention is maintained
+        shape = (16, 16)
+
+        def fn(x):
+            a = torch.rand_like(x) * x
+            a = torch.rand_like(x) * a
+            a = torch.sin(a)
+            a = torch.sin(a)
+            a = torch.sin(a)
+            return a
+
+
+        x = torch.rand(*shape, device=device, dtype=dtype, requires_grad=True)
+
+        x_clone = x.clone().detach().requires_grad_(True)
+
+        torch.cuda.manual_seed(123)
+        ref = fn(x)
+        ref.sum().backward()
+
+        torch.cuda.manual_seed(123)
+        fwd_compiler = functools.partial(count_philox_rand, freq=2)
+        bwd_compiler = functools.partial(count_philox_rand, freq=0)
+        aot_custom = aot_function(fn, fwd_compiler, bwd_compiler, partition_fn=min_cut_rematerialization_partition)
+        # aot_custom = aot_function(fn, fwd_compiler, bwd_compiler)
+        res = aot_custom(x_clone)
+        res.sum().backward()
+
+        self.assertEqual(ref, res)
+        self.assertEqual(x.grad, x_clone.grad)
+
+    # TODO - Dropout needs more work because of offset calculation
+    @skip("Dropout needs more work because of offset calculation")
+    @patch.object(torch._functorch.config, "functionalize_rng_ops", True)
+    @dtypes(torch.float32)
+    def test_checkpoint(self, dtype, device):
+        def g(x, y):
+            return torch.nn.functional.dropout(x, 0.6)
+
+        def fn(x, y):
+            return torch.utils.checkpoint.checkpoint(g, x, y, use_reentrant=False)
+
+        # x = torch.rand(2, 2, device="cuda", requires_grad=True)
+        x = torch.ones(2, 2, device="cuda", requires_grad=True)
+        y = torch.rand(2, 2, device="cuda", requires_grad=True)
+        torch.cuda.manual_seed(123)
+        ref = fn(x, y)
+
+        # With checkpointing we should recompute dropout in bwd, and should see philox_rand
+        fwd_compiler = functools.partial(count_philox_rand, freq=1)
+        bwd_compiler = functools.partial(count_philox_rand, freq=1)
+        aot_fn = aot_function(fn, fwd_compiler, bwd_compiler)
+        torch.cuda.manual_seed(123)
+        res = aot_fn(x, y)
+        # res.sum().backward()
+        # TODO - This is not same. Debug this further.
+        self.assertEqual(ref, res)
+
+
+only_for = ("cuda",)
+instantiate_device_type_tests(TestFunctionalizationRngOps, globals(), only_for=only_for)
+
+
+class NegativeTest(TestCase):
+    @dtypes(torch.float32)
+    @patch.object(torch._functorch.config, "functionalize_rng_ops", True)
+    def test_on_cpu(self, dtype, device):
+        def fn(x):
+            a = torch.rand_like(x) * x
+            a = torch.rand_like(x) * a
+            return a
+
+        x = torch.rand(10, device=device, dtype=dtype)
+
+        aot_fn = aot_function(fn, nop)
+        with self.assertRaises(RuntimeError):
+            aot_fn(x)
+
+
+only_for = ("cpu",)
+instantiate_device_type_tests(NegativeTest, globals(), only_for=only_for)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_device_type import (
 
 from torch.testing._internal.logging_tensor import LoggingTensor, capture_logs, log_input
 import torch._prims as prims
+from torch._prims_common import CUDARngStateHelper
 from torch._prims.executor import make_traced
 import torch._refs as refs
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -1094,6 +1095,34 @@ class TestPrims(TestCase):
         result_refs = refs.view(a, *new_shape)
         self.assertEqual(result_eager, result_refs)
 
+
+    @onlyCUDA
+    @dtypes(torch.float32)
+    def test_philox_rand(self, device, dtype):
+        sizes = (1000, 1000000)  # offsets of 4 and 8
+        repeats = 2  # Checks multiple rand calls results with multiple philox_rand calls
+        for size in sizes:
+            torch.cuda.manual_seed(123)
+            references = []
+            results = []
+            rng_states = []
+            for _ in range(repeats):
+                rng_states.append(CUDARngStateHelper.get_torch_state_as_tuple())
+                references.append(torch.rand(size, device=device, dtype=dtype))
+
+            torch.cuda.manual_seed(123)
+            for idx in range(repeats):
+                seed, offset = rng_states[idx]
+                result = torch.ops.rngprims.philox_rand((size,),
+                                                        seed=seed,
+                                                        offset=offset,
+                                                        stride=None,
+                                                        device=device,
+                                                        dtype=dtype)
+                results.append(result)
+
+            for a, b in zip(references, results):
+                self.assertEqual(a, b)
 
 class TestPrimsBasic(TestCase):
     def test_torch_ops(self):

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1103,6 +1103,8 @@ class _LinalgBackend:
 
 class ConvBackend(Enum): ...
 
+class Tag(Enum): ...
+
 # Defined in `valgrind.h` and `callgrind.h` respectively.
 def _valgrind_supported_platform() -> _bool: ...  # NVALGRIND
 def _valgrind_toggle() -> None: ...  # CALLGRIND_TOGGLE_COLLECT
@@ -1544,6 +1546,7 @@ class _CudaDeviceProperties:
     total_memory: _int
     is_integrated: _int
     is_multi_gpu_board: _int
+    max_threads_per_multi_processor: _int
 
 # Defined in torch/csrc/cuda/python_comm.cpp
 def _broadcast(tensor: Tensor, devices: List[_int]) -> List[Tensor]: ...

--- a/torch/_decomp/decompositions_for_rng.py
+++ b/torch/_decomp/decompositions_for_rng.py
@@ -1,0 +1,222 @@
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+import torch
+import torch._decomp as decomp
+from torch._ops import OpOverload
+from torch._prims_common import make_contiguous_strides_for
+
+aten = torch.ops.aten
+
+rng_decompositions: Dict[str, Dict[OpOverload, Callable]] = defaultdict(dict)
+
+
+def register_rng_decomposition(aten_op):
+    return decomp.register_decomposition(aten_op, rng_decompositions)
+
+
+def throw_on_non_cuda(device):
+    raise RuntimeError(
+        f"You are trying to functionalize a {device.type} RNG operator but {device.type} does not "
+        f"use Philox/counter-based RNG. Therefore, functionalizing a {device.type} RNG operator is "
+        "not supported. We are discussing the possibility of a Philox-based RNG implementation for CPU."
+    )
+
+
+def rand_offset_calculator(shape):
+    # For impl, look at the function calc_execution_policy in the file
+    # aten/src/ATen/native/cuda/DistributionTemplates.h. The impl was copied at
+    # commit hash 72aa0667bd16707d50eb8fa337092a1f5d11dfb6
+    numel = 1
+    for dim_size in shape:
+        numel *= dim_size
+
+    block_size = 256
+    unroll = 4
+    curand4_engine_calls = 4
+    device_property = torch.cuda.get_device_properties(torch.cuda.current_device())
+    blocks_per_sm = device_property.max_threads_per_multi_processor // block_size
+    grid_size = (numel + block_size - 1) // block_size
+    grid_size = min(grid_size, device_property.multi_processor_count * blocks_per_sm)
+    offset = (
+        (numel - 1) // (block_size * grid_size * unroll) + 1
+    ) * curand4_engine_calls
+    return offset
+
+
+# TODO - We have to register many more distributions here, and also higher level
+# ops like dropout which have fused implementation and can hide the rand inside.
+@register_rng_decomposition(aten.rand)
+def rand(shape, dtype=None, layout=torch.strided, device=None, pin_memory=False):
+    if device and device.type != "cuda":
+        throw_on_non_cuda(device)
+    seed, offset = PhiloxStateTracker.get_state_as_tuple()
+    dtype = dtype or torch.float32
+    stride = make_contiguous_strides_for(shape)
+    r = torch.ops.rngprims.philox_rand(shape, seed, offset, None, device, dtype)
+    PhiloxStateTracker.advance_offset(rand_offset_calculator(shape))
+    return r
+
+
+@register_rng_decomposition(aten.rand_like)
+def rand_like(
+    x: torch.Tensor,
+    dtype=None,
+    layout=None,
+    device=None,
+    pin_memory=False,
+    memory_format=torch.preserve_format,
+):
+    device = device or x.device
+    if device.type != "cuda":
+        throw_on_non_cuda(device)
+    dtype = dtype or x.dtype
+    seed, offset = PhiloxStateTracker.get_state_as_tuple()
+    r = torch.ops.rngprims.philox_rand(x.shape, seed, offset, None, device, dtype)
+    PhiloxStateTracker.advance_offset(rand_offset_calculator(x.shape))
+    return r
+
+
+class PhiloxState:
+    """
+    Represents a PhiloxRngState - (seed, offset) where offset = base_offset +
+    relative_offset. seed and base_offset basically point to the rng state just
+    before tracing starts. relative offset tracks the totaly consumed offset at
+    trace time.
+    """
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.seed = torch.tensor(())
+        self.base_offset = torch.tensor(())
+        self.relative_offset = 0
+
+    def validate_state(self):
+        assert self.seed.numel() != 0 and self.base_offset.numel() != 0
+
+    def advance_offset(self, consumed_offset):
+        self.relative_offset += consumed_offset
+
+    def set_state(self, seed, base_offset, relative_offset=0):
+        self.seed = seed
+        self.base_offset = base_offset
+        self.relative_offset = relative_offset
+
+    def get_state_as_tuple(self):
+        self.validate_state()
+        return (self.seed, self.base_offset + self.relative_offset)
+
+    def get_state_as_tensor(self):
+        # Only needed because we override get_rng_state.
+        self.validate_state()
+        return torch.stack([self.seed, self.base_offset + self.relative_offset])
+
+    def set_state_from_tensor(self, state):
+        # Only needed because we override set_rng_state.
+        self.seed, self.base_offset = torch.split(state, 1)
+        self.relative_offset = 0
+
+
+@dataclass
+class PhiloxTotalOffsets:
+    """
+    PhiloxStateTracker computes the total fwd and bwd offsets for an AOT
+    Autograd traced graph. However, PhiloxStateTracker is a singleton class, but
+    the total offsets are specific to each traced graph. These offsets are
+    stored as part of AOT graph. This class just encapsulates the fwd and bwd
+    offsets to be used at runtime.
+    """
+
+    total_fwd_offset: int
+    total_bwd_offset: int
+
+
+class PhiloxStateTracker:
+    """
+    Singleton class to track the philox rng state during AOT Autograd tracing.
+    For each aot tracing instance, AOT Autograd resets this tracker and keeps
+    track of both forward and backward offsets. At runtime, we only care about
+    the total consumed forward and backward offsets. There are stored as part of
+    aot_config (PhiloxTotalOffsets), which is a config object per aot-tracing.
+    """
+
+    running_state: PhiloxState
+    fwd_state: PhiloxState
+    bwd_state: PhiloxState
+
+    def __enter__(self):
+        PhiloxStateTracker.reset()
+        return self
+
+    def __exit__(self, exc_type, exc_cal, exc_tb):
+        PhiloxStateTracker.reset()
+
+    @classmethod
+    def reset(cls):
+        cls.running_state = PhiloxState()
+        cls.fwd_state = PhiloxState()
+        cls.bwd_state = PhiloxState()
+
+    @classmethod
+    def mark_beginning_of_forward(cls):
+        # Tells the tracker to use fwd_state as the running state
+        cls.running_state = cls.fwd_state
+
+    @classmethod
+    def mark_beginning_of_backward(cls):
+        # Tells the tracker to use bwd_state as the running state
+        cls.running_state = cls.bwd_state
+
+    @classmethod
+    def record_state(cls, seed, offset, mode):
+        # Records the seed and offset tensors. These tensors are used to invoke
+        # the philox_rand functional primitives.
+        if mode == "forward":
+            cls.fwd_state.set_state(seed, offset)
+            cls.mark_beginning_of_forward()
+        else:
+            assert mode == "backward"
+            cls.bwd_state.set_state(seed, offset)
+
+    @classmethod
+    def get_state_as_tensor(cls):
+        # The only reason this exists is because we override get_rng_state and
+        # set_rng_state during tracing. get_rng_state expects a tensor output,
+        # so return (seed, offset) tuple upset other parts of the program like
+        # ctx.saved_tensors.
+
+        # A bad consequence is that if user saves and restores rng state, we
+        # have little bit of ugliness in the generated code, where we first
+        # concat the (seed, offset) to create a tensor for get_rng_state, and
+        # then split it back to get (seed, offset) tuple in set_rng_state.
+
+        # TODO: Investigate if there is be a better way to wrap the tuple in a
+        # false Tensor object, and then desugar it later on.
+        return cls.running_state.get_state_as_tensor()
+
+    @classmethod
+    def get_state_as_tuple(cls):
+        return cls.running_state.get_state_as_tuple()
+
+    @classmethod
+    def set_state_from_tensor(cls, x):
+        # This is only needed because we override set_rng_state. Look at the
+        # comment in get_state_from_tensor method.
+        cls.running_state.set_state_from_tensor(x)
+
+    @classmethod
+    def advance_offset(cls, consumed_offset):
+        cls.running_state.advance_offset(consumed_offset)
+
+    @classmethod
+    def get_current_relative_offset(cls):
+        return cls.running_state.relative_offset
+
+    @classmethod
+    def get_accumulated_offsets(cls):
+        fwd_offset = cls.fwd_state.relative_offset
+        bwd_offset = cls.bwd_state.relative_offset
+        return PhiloxTotalOffsets(fwd_offset, bwd_offset)

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import partial, wraps
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, NewType
+from unittest.mock import patch
 
 from functorch import make_fx
 
@@ -19,6 +20,8 @@ import torch.utils.dlpack
 from torch import Tensor
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.utils import dynamo_timed, lazy_format_graph_code
+from torch._guards import detect_fake_mode
+from torch._prims_common import CUDARngStateHelper
 from torch._logging import getArtifactLogger
 from torch._subclasses import CrossRefFakeMode, FakeTensor, FakeTensorMode
 from torch.fx import immutable_collections, Interpreter
@@ -26,6 +29,7 @@ from torch.fx.experimental.proxy_tensor import is_sym_node, py_sym_types
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.nn.utils import stateless
+from torch._decomp.decompositions_for_rng import PhiloxStateTracker, rng_decompositions, PhiloxTotalOffsets
 from . import config
 from .partitioners import default_partition
 from torch._guards import TracingContext, DuplicateInputs, Source
@@ -109,6 +113,7 @@ def preserve_rng_state():
             torch.random.set_rng_state(rng_state)
             if torch.cuda.is_available():
                 torch.cuda.set_rng_state(cuda_rng_state)
+
 
 
 # Set up hooks so that during backward the fx's stack_trace is properly set
@@ -541,6 +546,17 @@ class ViewAndMutationMeta:
                 len(self.traced_tangents) == len(other.traced_tangents) and
                 all(x.shape == y.shape and x.dtype == y.dtype for x, y, in zip(self.traced_tangents, other.traced_tangents)))
 
+
+# This side data structures stores the functionalization of RNG related metadata
+# to be used at runtime. In future, we can repurpose this class to RuntimeMeta
+# if more metadata usecases popup
+@dataclass
+class RNGMeta:
+    # Stores if the config.functionalize_rng_ops was True at compile time
+    is_compiled_with_functional_rng_ops: bool
+
+    # Stores PhiloxTotalOffsets to be used at runtime
+    philox_total_offsets: PhiloxTotalOffsets
 
 # This class exists because:
 # - the autograd.Function.forward() in aot autograd returns outputs that might alias inputs
@@ -1056,6 +1072,8 @@ def create_joint(
 
         setup_stacktrace_preservation_hooks([out.grad_fn for out in needed_outs])
 
+        if config.functionalize_rng_ops:
+            PhiloxStateTracker.mark_beginning_of_backward()
         backward_out = []
         # Call the backwards pass
         if grad_primals:
@@ -1149,8 +1167,16 @@ def create_functionalized_graph(
     def fwd_helper(*args):
         return functionalized_f_helper(*args)
 
+    helper = joint_helper if trace_joint else fwd_helper
+    if config.functionalize_rng_ops:
+        # Setup the wrapper for functionalization of rng ops
+        helper, args = create_functionalized_rng_ops_wrapper(helper, args, trace_joint)
+
     with enable_python_dispatcher():
-        return make_fx(joint_helper if trace_joint else fwd_helper, decomposition_table=aot_config.decompositions)(*args)
+        fx_g = make_fx(helper, decomposition_table=aot_config.decompositions)(*args)
+
+
+    return fx_g
 
 
 def normalize_as_list(x):
@@ -1291,7 +1317,18 @@ def aot_dispatch_base(flat_fn, flat_args: List[Tensor], aot_config: AOTConfig, *
 
     with context(), track_graph_compiling(aot_config, "inference"):
         compiler = aot_config.inference_compiler if aot_config.inference_compiler is not None else aot_config.fw_compiler
+        if config.functionalize_rng_ops:
+            # Add the seed and offset as example inputs to pass to the compiler
+            fake_mode = detect_fake_mode()
+            seed, offset = CUDARngStateHelper.get_torch_state_as_tuple(fake_mode)
+            flat_args = (seed, offset, *flat_args)
         compiled_fw = compiler(fw_module, flat_args)
+
+    # Get the RNG functionalization related metadata to be used at runtime.
+    rng_metadata = RNGMeta(False, PhiloxTotalOffsets(0, 0))
+    if config.functionalize_rng_ops:
+        rng_metadata = RNGMeta(config.functionalize_rng_ops, PhiloxStateTracker.get_accumulated_offsets())
+
 
     compiled_fn = create_runtime_wrapper(
         compiled_fw,
@@ -1302,7 +1339,19 @@ def aot_dispatch_base(flat_fn, flat_args: List[Tensor], aot_config: AOTConfig, *
         disable_amp=disable_amp
     )
 
-    return compiled_fn
+    @wraps(compiled_fn)
+    def wrapper(*args):
+        if rng_metadata.is_compiled_with_functional_rng_ops:
+            # Add the seed and offset to args
+            seed, offset = CUDARngStateHelper.get_torch_state_as_tuple()
+            out = compiled_fn(seed, offset, *args)
+            # Advance the rng state offset
+            CUDARngStateHelper.advance_torch_state(rng_metadata.philox_total_offsets.total_fwd_offset)
+            return out
+        else:
+            return compiled_fn(*args)
+
+    return wrapper
 
 
 # Returns the number of detected copy_
@@ -2268,6 +2317,41 @@ def create_runtime_wrapper(
             return fw_outs
     return runtime_wrapper
 
+def create_functionalized_rng_ops_wrapper(func, args, trace_joint=True):
+    # Functionalization of rng ops changes the calling convention of the joint graph.
+    # It goes from (primals, tangents) to (seed, offset, primals, tangents)
+    # At runtime, we pass on the current seed and offset. This is hidden from
+    # the user.
+    fake_mode = detect_fake_mode()
+
+    def override_get_rng_state(device: Union[int, str, torch.device] = 'cuda'):
+        out = PhiloxStateTracker.get_state_as_tensor()
+        return out
+
+    def override_set_rng_state(x, device: Union[int, str, torch.device] = 'cuda'):
+        PhiloxStateTracker.set_state_from_tensor(x)
+
+    def traced_joint(fwd_seed, fwd_base_offset, bwd_seed, bwd_base_offset, primals, tangents):
+        with patch("torch.cuda.get_rng_state", override_get_rng_state), patch("torch.cuda.set_rng_state", override_set_rng_state):
+            return func(primals, tangents)
+
+    def traced_forward(fwd_seed, fwd_base_offset, *primals):
+        with patch("torch.cuda.get_rng_state", override_get_rng_state), patch("torch.cuda.set_rng_state", override_set_rng_state):
+            return func(*primals)
+
+    if trace_joint:
+        # Get the current seed and offset to setup tracing.
+        fwd_seed, fwd_base_offset = CUDARngStateHelper.get_torch_state_as_tuple(fake_mode)
+        bwd_seed, bwd_base_offset = CUDARngStateHelper.get_torch_state_as_tuple(fake_mode)
+        PhiloxStateTracker.record_state(fwd_seed, fwd_base_offset, "forward")
+        PhiloxStateTracker.record_state(bwd_seed, bwd_base_offset, "backward")
+        return traced_joint, (fwd_seed, fwd_base_offset, bwd_seed, bwd_base_offset, *args)
+    else:
+        # Get the current seed and offset to setup tracing.
+        fwd_seed, fwd_base_offset = CUDARngStateHelper.get_torch_state_as_tuple(fake_mode)
+        PhiloxStateTracker.record_state(fwd_seed, fwd_base_offset, "forward")
+        return traced_forward, (fwd_seed, fwd_base_offset, *args)
+
 # Has the precondition that there
 # are no duplicate arguments in flat_args (e.g., the same Tensor
 # object never shows up twice.  However, two tensor inputs MAY alias
@@ -2302,6 +2386,7 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
 
         # There should be *NO* mutating ops in the graph at this point.
         assert_functional_graph(fx_g.graph)
+
         # Redudant with the check above, but worth having in case tracing introduced
         # a fake tensor. Unlikely.
         # See Note: [Fake Modules and AOTAutograd]
@@ -2399,9 +2484,25 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
             aot_graphs_log.info("%s", lazy_format_graph_code("Backward graph", bw_module, aot_config.aot_id))
 
         with track_graph_compiling(aot_config, "forward"):
+            if config.functionalize_rng_ops:
+                # Update example inputs for the fw_compiler
+                fake_mode = detect_fake_mode()
+                seed, offset = CUDARngStateHelper.get_torch_state_as_tuple(fake_mode)
+                flat_args = (seed, offset, *flat_args)
             compiled_fw_func = aot_config.fw_compiler(
                 fw_module, flat_args
             )
+
+
+    # Get the rng_metadata so that it can be used at runtime
+    rng_metadata = RNGMeta(False, PhiloxTotalOffsets(0, 0))
+    if config.functionalize_rng_ops:
+        rng_metadata = RNGMeta(config.functionalize_rng_ops, PhiloxStateTracker.get_accumulated_offsets())
+        # Total offsets differ for each AOT traced graph, so they can't be saved
+        # in the PhiloxStateTracker singleton object. Therefore, we save them
+        # into rng_meta side datastructure.
+
+
 
     class CompiledFunction(torch.autograd.Function):
         compiled_fw = compiled_fw_func
@@ -2411,7 +2512,11 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
 
         @staticmethod
         def forward(ctx, *deduped_flat_tensor_args):
-
+            args = deduped_flat_tensor_args
+            if rng_metadata.is_compiled_with_functional_rng_ops:
+                # Add the seed and offset to args
+                seed, offset = CUDARngStateHelper.get_torch_state_as_tuple()
+                args = (seed, offset, *args)
             # There is a pretty complicated calling convention around what the compiled fw returns.
             # The full list of outputs and their relative order is:
             # (*mutated_inputs, *fw_outs, *fw_intermediate_bases, *saved_tensors, *saved_symints)
@@ -2419,7 +2524,7 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
             #   of the original view, and not the synthetic base
             fw_outs = call_func_with_args(
                 CompiledFunction.compiled_fw,
-                deduped_flat_tensor_args,
+                args,
                 disable_amp=disable_amp,
             )
 
@@ -2509,6 +2614,10 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
             ]
             ctx.mark_non_differentiable(*fw_outs_not_requiring_grad)
 
+
+            if rng_metadata.is_compiled_with_functional_rng_ops:
+                # Advance total fwd offset
+                CUDARngStateHelper.advance_torch_state(rng_metadata.philox_total_offsets.total_fwd_offset)
             return tuple(raw_returns)
 
         @staticmethod
@@ -2582,9 +2691,15 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
                 t.contiguous() if torch.is_tensor(t) else t for t in flat_bw_args
             ]
 
+            rng_args = []
+            if rng_metadata.is_compiled_with_functional_rng_ops:
+                # Add the seed and offset to args
+                rng_args = CUDARngStateHelper.get_torch_state_as_tuple()
+
             all_args = (
-                list(ctx.symints) + list(ctx.saved_tensors) + list(contiguous_args)
+                list(rng_args) + list(ctx.symints) + list(ctx.saved_tensors) + list(contiguous_args)
             )
+
             del contiguous_args
 
             def call_compiled_backward():
@@ -2617,6 +2732,9 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
                     disable_amp=disable_amp,
                 )
 
+                if rng_metadata.is_compiled_with_functional_rng_ops:
+                    # Advance total bwd rng offset
+                    CUDARngStateHelper.advance_torch_state(rng_metadata.philox_total_offsets.total_bwd_offset)
                 return tuple(out)
 
             if torch.is_grad_enabled() and any(t.requires_grad for t in all_args if isinstance(t, torch.Tensor)):
@@ -2708,10 +2826,18 @@ def create_aot_dispatcher_function(
     if aot_config.decompositions is None:
         aot_config.decompositions = {}
 
+
     aot_config.decompositions = {
         **aot_autograd_decompositions,
         **aot_config.decompositions,
     }
+
+    if config.functionalize_rng_ops:
+        # Update the decompositions with functionalized random decompositions
+        aot_config.decompositions = {
+            **rng_decompositions,
+            **aot_config.decompositions,
+        }
 
     # NB: don't bother setting allow_fallback_kernels; this should not actually
     # be configurable in fake tensor, we should automatically do the right
@@ -2746,7 +2872,7 @@ def create_aot_dispatcher_function(
 
     with torch.autograd.set_multithreading_enabled(
         False
-    ), preserve_rng_state(), cross_ref, fake_mode, python_dispatcher_mode:
+    ), preserve_rng_state(), cross_ref, fake_mode, python_dispatcher_mode, PhiloxStateTracker():
 
         def process_inputs(flat_args):
             if config.use_fake_tensor or isinstance(fake_mode, FakeTensorMode):
@@ -2783,10 +2909,13 @@ def create_aot_dispatcher_function(
             and torch.is_grad_enabled()
         )
         with enable_python_dispatcher():
-            fw_metadata = run_functionalized_fw_and_collect_metadata(
-                flat_fn,
-                keep_input_mutations=aot_config.keep_inference_input_mutations and not needs_autograd,
-            )(*fake_flat_args)
+            # Patch set_rng_state as set_rng_state with fake tensors is
+            # nonsensical. This does not affect the collection of metadata.
+            with patch("torch.cuda.set_rng_state", lambda *args: None):
+                fw_metadata = run_functionalized_fw_and_collect_metadata(
+                    flat_fn,
+                    keep_input_mutations=aot_config.keep_inference_input_mutations and not needs_autograd,
+                )(*fake_flat_args)
 
         # crappy version of dispatcher
         # TODO: Do this properly

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -14,6 +14,10 @@ use_functionalize = True
 
 use_fake_tensor = True
 
+# Converts torch rng ops to their functional philox rng equivalents. Note that
+# we functionalize only CUDA rng ops today.
+functionalize_rng_ops = False
+
 # can be useful for debugging if we are incorrectly creating meta fake tensors
 fake_tensor_allow_meta = os.environ.get("FAKE_ALLOW_META", True)
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -84,11 +84,15 @@ def _extract_graph_with_inputs_outputs(joint_graph, inputs, outputs):
 
 
 def _is_primal(node):
-    return node.op == "placeholder" and "tangents" not in node.target
+    return node.op == "placeholder" and "tangents" not in node.target and not _is_bwd_seed_offset(node)
 
 
 def _is_tangent(node):
     return node.op == "placeholder" and "tangents" in node.target
+
+
+def _is_bwd_seed_offset(node):
+    return node.op == "placeholder" and ("bwd_seed" in node.target or "bwd_base_offset" in node.target)
 
 
 def _extract_fwd_bwd_outputs(joint_module: fx.GraphModule, *, num_fwd_outputs):
@@ -102,10 +106,15 @@ def _extract_fwd_bwd_modules(joint_module: fx.GraphModule, saved_values, saved_s
     fwd_outputs, bwd_outputs = _extract_fwd_bwd_outputs(joint_module, num_fwd_outputs=num_fwd_outputs)
     primal_inputs = list(filter(_is_primal, joint_module.graph.nodes))
     tangent_inputs = list(filter(_is_tangent, joint_module.graph.nodes))
+    bwd_seed_offset_inputs = list(filter(_is_bwd_seed_offset, joint_module.graph.nodes))
+
     # Construct the forward module
     # Keep symints separate from tensors, passed between fwd/bwd graphs, and in the right order.
     fwd_graph = _extract_graph_with_inputs_outputs(joint_module.graph, primal_inputs, fwd_outputs + saved_values + saved_sym_nodes)
-    bwd_graph = _extract_graph_with_inputs_outputs(joint_module.graph, saved_sym_nodes + saved_values + tangent_inputs, bwd_outputs)
+    bwd_graph = _extract_graph_with_inputs_outputs(
+        joint_module.graph,
+        bwd_seed_offset_inputs + saved_sym_nodes + saved_values + tangent_inputs, bwd_outputs
+    )
 
     # This is to filter out saved values that don't actually end up being used by the backwards pass
     for node in bwd_graph.nodes:
@@ -123,7 +132,10 @@ def _extract_fwd_bwd_modules(joint_module: fx.GraphModule, saved_values, saved_s
     # Now, we re-generate the fwd/bwd graphs.
     # NB: This might increase compilation time, but I doubt it matters
     fwd_graph = _extract_graph_with_inputs_outputs(joint_module.graph, primal_inputs, fwd_outputs + saved_values + saved_sym_nodes)
-    bwd_graph = _extract_graph_with_inputs_outputs(joint_module.graph, saved_sym_nodes + saved_values + tangent_inputs, bwd_outputs)
+    bwd_graph = _extract_graph_with_inputs_outputs(
+        joint_module.graph,
+        bwd_seed_offset_inputs + saved_sym_nodes + saved_values + tangent_inputs, bwd_outputs
+    )
 
     fwd_module = fx.GraphModule(joint_module, fwd_graph)
     bwd_module = fx.GraphModule(joint_module, bwd_graph)

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -13,6 +13,7 @@ import torch.library
 from torch import sym_float, Tensor, TypedStorage
 from torch._C import _get_default_device
 from torch._prims.nvfuser_prims import register_nvprims
+from torch._prims.rng_prims import register_rng_prims
 from torch._prims_common import (
     check,
     Dim,
@@ -2963,3 +2964,4 @@ fft_c2r = _make_prim(
 )
 
 register_nvprims()
+register_rng_prims()

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -1,0 +1,89 @@
+from typing import Optional, Tuple
+
+import torch
+from torch import _prims
+
+from torch._prims_common import CUDARngStateHelper, make_contiguous_strides_for
+from torch._prims_common.wrappers import backwards_not_supported
+from torch.types import _device, _dtype
+
+rngprim_namespace = "rngprims"
+rngprim = torch.library.Library(rngprim_namespace, "DEF")
+rngprim_impl = torch.library.Library(
+    rngprim_namespace, "IMPL", "CompositeExplicitAutograd"
+)
+rngprim_autograd_impl = torch.library.Library(rngprim_namespace, "IMPL", "Autograd")
+rngprim_meta_impl = torch.library.Library(rngprim_namespace, "IMPL", "Meta")
+
+
+def throw_on_non_cuda(device):
+    raise RuntimeError(
+        f"You are trying to functionalize a {device.type} RNG operator but {device.type} does not "
+        f"use Philox/counter-based RNG. Therefore, functionalizing a {device.type} RNG operator is "
+        "not supported. We are discussing the possibility of a Philox-based RNG implementation for CPU."
+    )
+
+
+def register_philox_rand():
+    name = "philox_rand"
+    schema = "philox_rand(int[] size, Tensor seed, Tensor offset, int[]? stride, Device? device=None, ScalarType? dtype=None) -> Tensor"  # noqa: B950
+
+    rngprim.define(schema)
+
+    def _philox_rand_meta(
+        shape: torch.Size,
+        seed: torch.Tensor,
+        offset: torch.Tensor,
+        stride: Optional[Tuple[int, ...]],
+        device: _device,
+        dtype: _dtype,
+    ):
+        # stride arg will be useful for distributed usecase. Currently, its unused.
+        assert stride is None
+        stride = make_contiguous_strides_for(shape)
+        return _prims.TensorMeta(
+            shape=shape, strides=stride, dtype=dtype, device=device
+        )
+
+    def _philox_rand(
+        shape: torch.Size,
+        seed: torch.Tensor,
+        offset: torch.Tensor,
+        stride: Optional[Tuple[int, ...]],
+        device: _device,
+        dtype: _dtype,
+    ):
+        # stride arg will be useful for distributed usecase. Currently, its unused.
+        assert stride is None
+        if device.type == "cpu":
+            devices = []
+        else:
+            devices = [device]
+
+        if device.type != "cuda":
+            raise throw_on_non_cuda(device)
+
+        with torch.random.fork_rng(devices):
+            CUDARngStateHelper.set_torch_state_tensor(seed, offset)
+            return torch.rand(shape, device=device, dtype=dtype)
+
+    rngprim_impl.impl(name, _philox_rand)
+    rngprim_meta_impl.impl(name, _philox_rand_meta)
+
+    prim_packet = getattr(torch._ops.ops.rngprims, name)
+    prim = prim_packet.default
+    prim._tags = (torch.Tag.nondeterministic_seeded,)  # type: ignore[attr-defined]
+
+    rngprim_autograd_impl.impl(name, backwards_not_supported(prim))
+
+    for p in (prim_packet, prim):
+        p.__doc__ = "Philox based stateless rand operator"
+        p.return_type = torch._prims_common.RETURN_TYPE.NEW  # type: ignore[attr-defined]
+
+        p.schema = schema
+        p.prim_meta_impl = _philox_rand_meta
+        p.impl_aten = _philox_rand
+
+
+def register_rng_prims():
+    register_philox_rand()

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -1762,3 +1762,39 @@ def clone_preserve_strides(x):
         return torch.as_strided(buffer, x.size(), x.stride(), x.storage_offset())
     finally:
         torch._C._dispatch_tls_set_dispatch_key_excluded(torch._C.DispatchKey.ADInplaceOrView, old)
+
+class CUDARngStateHelper:
+    @staticmethod
+    def get_torch_state_as_tuple(fake_mode=None):
+        if not torch.cuda.is_available():
+            seed = torch.tensor(0)
+            offset = torch.tensor(0)
+            if fake_mode:
+                seed = fake_mode.from_tensor(seed)
+                offset = fake_mode.from_tensor(offset)
+            return seed, offset
+
+        rng_state = torch.cuda.get_rng_state()
+        if fake_mode:
+            rng_state = fake_mode.from_tensor(rng_state)
+        # Rng state is [64-bit seed, 64-bit offset]
+        seed = rng_state[0:8].view(dtype=torch.int64)[0]
+        offset = rng_state[8:].view(dtype=torch.int64)[0]
+        return seed, offset
+
+    @staticmethod
+    def set_torch_state_tensor(seed, offset):
+        # Rng state is [64-bit seed, 64-bit offset]
+        seed_portion = seed.reshape([1]).view(torch.uint8)
+        offset_portion = offset.reshape([1]).view(torch.uint8)
+        new_state = torch.cat([seed_portion, offset_portion])
+        torch.cuda.set_rng_state(new_state)
+
+    @staticmethod
+    def advance_torch_state(relative_offset):
+        rng_state = torch.cuda.get_rng_state()
+        # Rng state is [64-bit seed, 64-bit offset]
+        seed = rng_state[0:8].view(dtype=torch.int64)[0]
+        offset = rng_state[8:].view(dtype=torch.int64)[0]
+        new_offset = offset + relative_offset
+        CUDARngStateHelper.set_torch_state_tensor(seed, new_offset)

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -873,6 +873,9 @@ static void registerCudaDeviceProperties(PyObject* module) {
       .def_readonly(
           "multi_processor_count", &cudaDeviceProp::multiProcessorCount)
       .def_readonly("total_memory", &cudaDeviceProp::totalGlobalMem)
+      .def_readonly(
+          "max_threads_per_multi_processor",
+          &cudaDeviceProp::maxThreadsPerMultiProcessor)
       .def("__repr__", [](const cudaDeviceProp& prop) {
         std::ostringstream stream;
         stream << "_CudaDeviceProperties(name='" << prop.name


### PR DESCRIPTION
This PR introduces the functionalization of RNG ops. Key points are

* Introduces a new `philox_rand` prim operator that accepts seed, offset.
* Adds decompositions for random operators that use these philox_rand prims
* Adds a PhiloxStateTracker to track the offset for each occurence of rand ops
* Changes calling convention of AOT Autograd and adds <fwd_seed, fwd_base_offset> and <bwd_seed, bwd_base_offset>
* Monkeypatches set_rng_state and get_rng_state while AOT Autograd tracing to record the rng state behavior
* Raises assertion for CPU because CPU does not Philox RNG.


Not dealt in this PR
* dropout op - offset calculation is different
* other distributions like normal, poisson etc
* Inductor support 
* Cudagraph support
* Dynamic shape support


An example
~~~

class Custom(torch.autograd.Function):
    @staticmethod
    def forward(ctx, x):
        ctx.save_for_backward(x)
        a = torch.rand_like(x) * x
        a = torch.rand_like(x) * a
        return a

    @staticmethod
    def backward(ctx, grad_out):
        x, = ctx.saved_tensors
        return grad_out * torch.rand_like(grad_out) * torch.cos(x)



====== Forward graph 0 ======
def forward(self, fwd_seed_1: i64[], fwd_base_offset_1: i64[], primals_1: f32[16, 16]):
    # No stacktrace found for following nodes
    add: i64[] = torch.ops.aten.add.Tensor(fwd_base_offset_1, 0)
    philox_rand: f32[16, 16] = torch.ops.prims.philox_rand.default([16, 16], fwd_seed_1, add, [16, 1], device(type='cuda', index=0), torch.float32);  add = None
    mul: f32[16, 16] = torch.ops.aten.mul.Tensor(philox_rand, primals_1);  philox_rand = None
    add_1: i64[] = torch.ops.aten.add.Tensor(fwd_base_offset_1, 4);  fwd_base_offset_1 = None
    philox_rand_1: f32[16, 16] = torch.ops.prims.philox_rand.default([16, 16], fwd_seed_1, add_1, [16, 1], device(type='cuda', index=0), torch.float32);  fwd_seed_1 = add_1 = None
    mul_1: f32[16, 16] = torch.ops.aten.mul.Tensor(philox_rand_1, mul);  philox_rand_1 = mul = None
    return [mul_1, primals_1]


====== Backward graph 0 ======
def forward(self, bwd_seed_1: i64[], bwd_base_offset_1: i64[], primals_1: f32[16, 16], tangents_1: f32[16, 16]):
    # No stacktrace found for following nodes
    add_2: i64[] = torch.ops.aten.add.Tensor(bwd_base_offset_1, 0);  bwd_base_offset_1 = None
    philox_rand_2: f32[16, 16] = torch.ops.prims.philox_rand.default([16, 16], bwd_seed_1, add_2, [16, 1], device(type='cuda', index=0), torch.float32);  bwd_seed_1 = add_2 = None
    mul_2: f32[16, 16] = torch.ops.aten.mul.Tensor(tangents_1, philox_rand_2);  tangents_1 = philox_rand_2 = None
    cos: f32[16, 16] = torch.ops.aten.cos.default(primals_1);  primals_1 = None
    mul_3: f32[16, 16] = torch.ops.aten.mul.Tensor(mul_2, cos);  mul_2 = cos = None
    return [mul_3]

~~~


cc @soumith @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire