### PR TITLE
[Kineto] Improve Config Options for Input Shapes, Memory, Stack, Flops, and Modules - Part 1

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -1679,6 +1679,7 @@ def define_buck_targets(
             # Need this otherwise USE_KINETO is undefed
             # for mobile
             "-DEDGE_PROFILER_USE_KINETO",
+            "-DKINETO_NEW_CLIENT_CONF",
         ],
         # @lint-ignore BUCKLINT link_whole
         link_whole = True,
@@ -1703,6 +1704,7 @@ def define_buck_targets(
         exported_preprocessor_flags = get_pt_preprocessor_flags() + [
             "-DUSE_KINETO",
             "-DEDGE_PROFILER_USE_KINETO",
+            "-DKINETO_NEW_CLIENT_CONF",
         ],
         # @lint-ignore BUCKLINT link_whole
         link_whole = True,
@@ -1791,6 +1793,7 @@ def define_buck_targets(
             # Need this otherwise USE_KINETO is undefed
             # for mobile
             "-DEDGE_PROFILER_USE_KINETO",
+            "-DKINETO_NEW_CLIENT_CONF",
         ] + (["-DFB_XPLAT_BUILD"] if not IS_OSS else []),
         extra_flags = {
             "fbandroid_compiler_flags": ["-frtti"],

--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -22,6 +22,35 @@ class LibKinetoClient : public libkineto::ClientInterface {
  public:
   void init() override {}
 
+#ifdef KINETO_NEW_CLIENT_CONF
+  void prepare(
+      bool report_input_shapes = true,
+      bool profile_memory = false,
+      bool with_stack = false,
+      bool with_flops = false,
+      bool with_modules = false) override {
+    cfg_ = std::make_unique<ProfilerConfig>(
+        ProfilerState::KINETO_ONDEMAND,
+        /*report_input_shapes=*/report_input_shapes,
+        /*profile_memory=*/profile_memory,
+        /*with_stack=*/with_stack,
+        /*with_flops=*/with_flops,
+        /*with_modules=*/with_modules);
+  }
+
+  void start() override {
+    if (!cfg_) {
+      prepare();
+    }
+    std::set<ActivityType> activities{ActivityType::CPU};
+    std::unordered_set<at::RecordScope> scopes;
+    scopes.insert(at::RecordScope::FUNCTION);
+    scopes.insert(at::RecordScope::USER_SCOPE);
+    scopes.insert(at::RecordScope::BACKWARD_FUNCTION);
+    enableProfiler(*cfg_, activities, scopes);
+    cfg_.reset();
+  }
+#else
   void warmup(bool setupOpInputsCollection) override {
     reportInputShapes_ = setupOpInputsCollection;
   }
@@ -42,18 +71,23 @@ class LibKinetoClient : public libkineto::ClientInterface {
     enableProfiler(cfg, activities, scopes);
   }
 
-  void stop() override {
-    (void)disableProfiler();
-  }
-
   // NOLINTNEXTLINE(modernize-use-override)
   void set_withstack(bool withStack) override {
     withStack_ = withStack;
   }
+#endif
+
+  void stop() override {
+    (void)disableProfiler();
+  }
 
  private:
+#ifdef KINETO_NEW_CLIENT_CONF
+  std::unique_ptr<ProfilerConfig> cfg_;
+#else
   bool reportInputShapes_{true};
   bool withStack_{false};
+#endif
 };
 
 } // namespace


### PR DESCRIPTION
Summary:
Improve On-Demand Kineto config to enable toggling of [profiler options](https://pytorch.org/docs/stable/profiler.html) via the config file. New config strings:
- PROFILE_REPORT_INPUT_SHAPES
- PROFILE_PROFILE_MEMORY
- PROFILE_WITH_STACK
- PROFILE_WITH_FLOPS
- PROFILE_WITH_MODULES

Also marked for deprecation, but still valid, old config options:
- CLIENT_INTERFACE_ENABLE_OP_INPUTS_COLLECTION
- PYTHON_STACK_TRACE

Test Plan: CI Tests (internal testing)

Reviewed By: leitian

Differential Revision: D44275220

Pulled By: aaronenyeshi

