### PR TITLE
[DTensor] Fix the default PG condition for DeviceMesh

### DIFF
--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -169,7 +169,7 @@ class DeviceMesh:
         # one valid process group per rank
         dim_groups: List[ProcessGroup] = []
 
-        if self.mesh.ndim == 1 and len(unique_mesh_values) == get_world_size() - 1:
+        if self.mesh.ndim == 1 and len(unique_mesh_values) == get_world_size():
             # if the mesh is the same as world_pg, we just append the default
             # pg to the first dim goups, as new_group cannot have the exact
             # same ranks as world


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97384

The current conditin to use the default PG is `len(unique_mesh_values) == WORLD_SIZE - 1`. The `- 1` is not correct and seems to be an incorrect fix from https://github.com/pytorch/pytorch/pull/96861.

Differential Revision: [D44314317](https://our.internmc.facebook.com/intern/diff/D44314317/)