### PR TITLE
[Dynamo] Add distributed_c10d collectives to disallowed list

### DIFF
--- a/test/distributed/test_dynamo_distributed.py
+++ b/test/distributed/test_dynamo_distributed.py
@@ -340,6 +340,7 @@ class TestMultiProc(DynamoDistributedMultiProcTestCase):
                 self.assertTrue(same(correct_results, opt_results))
 
     @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
     def test_c10d_collectives(self):
         class FakeModel(nn.Module):
 

--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -119,6 +119,37 @@ def _disallowed_function_ids():
         if isinstance(obj, type(torch.FloatStorage))
     ]
     remove += storage
+    c10d_collectives = [
+        torch.distributed.all_gather,
+        torch.distributed.all_gather_coalesced,
+        torch.distributed.all_gather_into_tensor,
+        torch.distributed.all_gather_multigpu,
+        torch.distributed.all_gather_object,
+        torch.distributed.all_reduce,
+        torch.distributed.all_reduce_coalesced,
+        torch.distributed.all_reduce_multigpu,
+        torch.distributed.all_to_all,
+        torch.distributed.all_to_all_single,
+        torch.distributed.barrier,
+        torch.distributed.batch_isend_irecv,
+        torch.distributed.broadcast,
+        torch.distributed.broadcast_multigpu,
+        torch.distributed.broadcast_object_list,
+        torch.distributed.gather,
+        torch.distributed.gather_object,
+        torch.distributed.irecv,
+        torch.distributed.isend,
+        torch.distributed.recv,
+        torch.distributed.reduce,
+        torch.distributed.reduce_multigpu,
+        torch.distributed.reduce_scatter,
+        torch.distributed.reduce_scatter_multigpu,
+        torch.distributed.reduce_scatter_tensor,
+        torch.distributed.scatter,
+        torch.distributed.scatter_object_list,
+        torch.distributed.send,
+    ]
+    remove += c10d_collectives
     return {id(x) for x in remove}
 
 

--- a/torch/_dynamo/allowed_functions.py
+++ b/torch/_dynamo/allowed_functions.py
@@ -119,37 +119,38 @@ def _disallowed_function_ids():
         if isinstance(obj, type(torch.FloatStorage))
     ]
     remove += storage
-    c10d_collectives = [
-        torch.distributed.all_gather,
-        torch.distributed.all_gather_coalesced,
-        torch.distributed.all_gather_into_tensor,
-        torch.distributed.all_gather_multigpu,
-        torch.distributed.all_gather_object,
-        torch.distributed.all_reduce,
-        torch.distributed.all_reduce_coalesced,
-        torch.distributed.all_reduce_multigpu,
-        torch.distributed.all_to_all,
-        torch.distributed.all_to_all_single,
-        torch.distributed.barrier,
-        torch.distributed.batch_isend_irecv,
-        torch.distributed.broadcast,
-        torch.distributed.broadcast_multigpu,
-        torch.distributed.broadcast_object_list,
-        torch.distributed.gather,
-        torch.distributed.gather_object,
-        torch.distributed.irecv,
-        torch.distributed.isend,
-        torch.distributed.recv,
-        torch.distributed.reduce,
-        torch.distributed.reduce_multigpu,
-        torch.distributed.reduce_scatter,
-        torch.distributed.reduce_scatter_multigpu,
-        torch.distributed.reduce_scatter_tensor,
-        torch.distributed.scatter,
-        torch.distributed.scatter_object_list,
-        torch.distributed.send,
-    ]
-    remove += c10d_collectives
+    if torch.distributed.is_available():
+        c10d_collectives = [
+            torch.distributed.all_gather,
+            torch.distributed.all_gather_coalesced,
+            torch.distributed.all_gather_into_tensor,
+            torch.distributed.all_gather_multigpu,
+            torch.distributed.all_gather_object,
+            torch.distributed.all_reduce,
+            torch.distributed.all_reduce_coalesced,
+            torch.distributed.all_reduce_multigpu,
+            torch.distributed.all_to_all,
+            torch.distributed.all_to_all_single,
+            torch.distributed.barrier,
+            torch.distributed.batch_isend_irecv,
+            torch.distributed.broadcast,
+            torch.distributed.broadcast_multigpu,
+            torch.distributed.broadcast_object_list,
+            torch.distributed.gather,
+            torch.distributed.gather_object,
+            torch.distributed.irecv,
+            torch.distributed.isend,
+            torch.distributed.recv,
+            torch.distributed.reduce,
+            torch.distributed.reduce_multigpu,
+            torch.distributed.reduce_scatter,
+            torch.distributed.reduce_scatter_multigpu,
+            torch.distributed.reduce_scatter_tensor,
+            torch.distributed.scatter,
+            torch.distributed.scatter_object_list,
+            torch.distributed.send,
+        ]
+        remove += c10d_collectives
     return {id(x) for x in remove}
 
 


### PR DESCRIPTION
Fixes #94599. Some models ([example](https://github.com/facebookresearch/detr/blob/main/models/detr.py#L231)) do use collectives like `torch.distributed.all_reduce` in the forward call.
cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire @wconstab
