### PR TITLE
Enables configuration of NCCL communicators

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1293,21 +1293,6 @@ class DistributedDataParallelTest(
         self._test_fp16()
 
     @requires_nccl()
-    @requires_nccl_version((2, 17), "Need NCCL 2.17+ for configuring NCCL communicators")
-    @skip_if_lt_x_gpu(2)
-    def test_ddp_default_cga(self):
-        nccl_debug_file = tempfile.NamedTemporaryFile()
-        os.environ["NCCL_DEBUG"] = "INFO"
-        os.environ["NCCL_DEBUG_FILE"] = nccl_debug_file.name
-
-        self._test_fp16()
-
-        # Tests if default CGA for DDP is 2
-        nccl_debug_file_content = nccl_debug_file.read()
-        cga_cluster_size = re.search(rb'CGA cluster.*(\d+)|$', nccl_debug_file_content).group(1)
-        self.assertEqual(int(cga_cluster_size), 2)
-
-    @requires_nccl()
     @skip_if_lt_x_gpu(2)
     def test_fp16_grad_is_view(self):
         self._test_fp16(gradient_as_bucket_view=True)

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1293,7 +1293,7 @@ class DistributedDataParallelTest(
         self._test_fp16()
 
     @requires_nccl()
-    @requires_nccl_version((2,17), "Need NCCL 2.17+ for configuring NCCL Communicators")
+    @requires_nccl_version((2, 17), "Need NCCL 2.17+ for configuring NCCL communicators")
     @skip_if_lt_x_gpu(2)
     def test_ddp_default_cga(self):
         nccl_debug_file = tempfile.NamedTemporaryFile()
@@ -2756,7 +2756,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         self._test_pass_nccl_options(pg_opts)
 
     @requires_nccl()
-    @requires_nccl_version((2,17), "Need NCCL 2.17+ for configuring NCCL Communicators")
+    @requires_nccl_version((2, 17), "Need NCCL 2.17+ for configuring NCCL communicators")
     @skip_if_lt_x_gpu(2)
     def test_pass_nccl_options_config(self):
         pg_opts = c10d.ProcessGroupNCCL.Options()

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4,6 +4,7 @@ import copy
 import math
 import os
 import random
+import re
 import signal
 import sys
 import tempfile
@@ -1290,6 +1291,21 @@ class DistributedDataParallelTest(
     @skip_if_lt_x_gpu(2)
     def test_fp16(self):
         self._test_fp16()
+
+    @requires_nccl()
+    @requires_nccl_version((2,17), "Need NCCL 2.17+ for configuring NCCL Communicators")
+    @skip_if_lt_x_gpu(2)
+    def test_ddp_default_cga(self):
+        nccl_debug_file = tempfile.NamedTemporaryFile()
+        os.environ["NCCL_DEBUG"] = "INFO"
+        os.environ["NCCL_DEBUG_FILE"] = nccl_debug_file.name
+
+        self._test_fp16()
+
+        # Tests if default CGA for DDP is 2
+        nccl_debug_file_content = nccl_debug_file.read()
+        cga_cluster_size = re.search(rb'CGA cluster.*(\d+)|$', nccl_debug_file_content).group(1)
+        self.assertEqual(int(cga_cluster_size), 2)
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
@@ -2713,12 +2729,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         torch.cuda.set_device(self.rank)
         self._test_sequence_num_set_new_group(backend="nccl")
 
-    @requires_nccl()
-    @skip_if_lt_x_gpu(2)
-    def test_pass_nccl_options_high_priority_stream(self):
-        pg_opts = c10d.ProcessGroupNCCL.Options()
-        pg_opts.is_high_priority_stream = True
-
+    def _test_pass_nccl_options(self, pg_opts):
         store = c10d.FileStore(self.file_name, self.world_size)
         # Test init_process_group accepts options
         dist.init_process_group(
@@ -2736,6 +2747,37 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         pg.allreduce(t).wait()
         expected_tensor = torch.tensor([3] * 10).cuda(self.rank)
         self.assertEqual(expected_tensor, t)
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_pass_nccl_options_high_priority_stream(self):
+        pg_opts = c10d.ProcessGroupNCCL.Options()
+        pg_opts.is_high_priority_stream = True
+        self._test_pass_nccl_options(pg_opts)
+
+    @requires_nccl()
+    @requires_nccl_version((2,17), "Need NCCL 2.17+ for configuring NCCL Communicators")
+    @skip_if_lt_x_gpu(2)
+    def test_pass_nccl_options_config(self):
+        pg_opts = c10d.ProcessGroupNCCL.Options()
+        pg_opts.config.max_ctas = 4
+        pg_opts.config.min_ctas = 2
+        pg_opts.config.cga_cluster_size = 2
+        nccl_debug_file = tempfile.NamedTemporaryFile()
+        os.environ["NCCL_DEBUG"] = "INFO"
+        os.environ["NCCL_DEBUG_FILE"] = nccl_debug_file.name
+
+        # Tests functionality when passing nccl config
+        self._test_pass_nccl_options(pg_opts)
+
+        # Tests if comms were configured
+        nccl_debug_file_content = nccl_debug_file.read()
+        max_ctas = re.search(rb'Max CTAs.*(\d+)|$', nccl_debug_file_content).group(1)
+        min_ctas = re.search(rb'Min CTAs.*(\d+)|$', nccl_debug_file_content).group(1)
+        cga_cluster_size = re.search(rb'CGA cluster.*(\d+)|$', nccl_debug_file_content).group(1)
+        self.assertEqual(pg_opts.config.max_ctas, int(max_ctas))
+        self.assertEqual(pg_opts.config.min_ctas, int(min_ctas))
+        self.assertEqual(pg_opts.config.cga_cluster_size, int(cga_cluster_size))
 
     @requires_nccl()
     @skip_if_lt_x_gpu(4)

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -203,7 +203,7 @@ class NCCLComm {
       config.blocking = 0;
       C10D_NCCL_CHECK_TIMEOUT(
         ncclCommInitRankConfig(&(comm->ncclComm_), numRanks, commId, rank, &config), comm->ncclComm_, c10::nullopt);
-    else {
+    } else {
       C10D_NCCL_CHECK(
         ncclCommInitRankConfig(&(comm->ncclComm_), numRanks, commId, rank, &config), c10::nullopt);
     }

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1156,7 +1156,7 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
     int deviceIndex = devices[i].index();
 
     gpuGuard.set_index(deviceIndex);
-#ifdef ENABLE_NCCL_RANK_CONFIG
+#ifdef NCCL_HAS_COMM_NONBLOCKING
     ncclComms[i] = NCCLComm::create(numRanks, rank, ncclID, options_->config);
 #else
     ncclComms[i] = NCCLComm::create(numRanks, rank, ncclID);

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1156,7 +1156,11 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
     int deviceIndex = devices[i].index();
 
     gpuGuard.set_index(deviceIndex);
+#ifdef ENABLE_NCCL_RANK_CONFIG
+    ncclComms[i] = NCCLComm::create(numRanks, rank, ncclID, options_->config);
+#else
     ncclComms[i] = NCCLComm::create(numRanks, rank, ncclID);
+#endif
 
     // Creates the NCCL streams
     streamVal.push_back(

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -280,7 +280,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
     // Schedule NCCL operations on high priority CUDA streams
     bool is_high_priority_stream;
 
-#ifdef ENABLE_NCCL_RANK_CONFIG
+#ifdef NCCL_HAS_COMM_NONBLOCKING
     // Configure ranks
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
 #endif

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -279,6 +279,11 @@ class TORCH_API ProcessGroupNCCL : public Backend {
 
     // Schedule NCCL operations on high priority CUDA streams
     bool is_high_priority_stream;
+
+#ifdef ENABLE_NCCL_RANK_CONFIG
+    // Configure ranks
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+#endif
   };
 
   // If you wish to create multiple process groups, each with a potentially

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2135,8 +2135,10 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
               "is_ucc_available", &::c10d::ProcessGroupNCCL::isUCCAvailable);
 
 #ifdef ENABLE_NCCL_RANK_CONFIG
-  py::class_<ncclConfig_t>(processGroupNCCL, "NCCLConfig",
-  R"(
+  py::class_<ncclConfig_t>(
+      processGroupNCCL,
+      "NCCLConfig",
+      R"(
 ncclConfig_t data type for configuring NCCL communicators.
 See https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/types.html#ncclconfig-t
 for details.
@@ -2186,9 +2188,7 @@ Example::
       .def_readwrite(
           "is_high_priority_stream",
           &::c10d::ProcessGroupNCCL::Options::is_high_priority_stream)
-      .def_readwrite(
-          "config",
-          &::c10d::ProcessGroupNCCL::Options::config);
+      .def_readwrite("config", &::c10d::ProcessGroupNCCL::Options::config);
 #else
       .def_readwrite(
           "is_high_priority_stream",

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2194,10 +2194,6 @@ Example::
           "is_high_priority_stream",
           &::c10d::ProcessGroupNCCL::Options::is_high_priority_stream);
 #endif
-  processGroupNCCL.def_static(
-      "_group_start", []() { ::c10d::ProcessGroupNCCL::groupStart(); });
-  processGroupNCCL.def_static(
-      "_group_end", []() { ::c10d::ProcessGroupNCCL::groupEnd(); });
 
 #ifdef USE_C10D_MPI
   auto processGroupMPI =

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2134,7 +2134,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
           .def_property_readonly(
               "is_ucc_available", &::c10d::ProcessGroupNCCL::isUCCAvailable);
 
-#ifdef ENABLE_NCCL_RANK_CONFIG
+#ifdef NCCL_HAS_COMM_CTA_CGA
   py::class_<ncclConfig_t>(
       processGroupNCCL,
       "NCCLConfig",
@@ -2184,7 +2184,7 @@ Example::
     >>> dist.init_process_group("nccl", pg_options=nccl_options)
       )")
       .def(py::init<bool>(), py::arg("is_high_priority_stream") = false)
-#ifdef ENABLE_NCCL_RANK_CONFIG
+#ifdef NCCL_HAS_COMM_CTA_CGA
       .def_readwrite(
           "is_high_priority_stream",
           &::c10d::ProcessGroupNCCL::Options::is_high_priority_stream)

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2195,6 +2195,8 @@ Example::
           &::c10d::ProcessGroupNCCL::Options::is_high_priority_stream);
 #endif
 
+#endif
+
 #ifdef USE_C10D_MPI
   auto processGroupMPI =
       intrusive_ptr_no_gil_destructor_class_<::c10d::ProcessGroupMPI>(

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2134,6 +2134,21 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
           .def_property_readonly(
               "is_ucc_available", &::c10d::ProcessGroupNCCL::isUCCAvailable);
 
+#ifdef ENABLE_NCCL_RANK_CONFIG
+  py::class_<ncclConfig_t>(processGroupNCCL, "NCCLConfig",
+  R"(
+ncclConfig_t data type for configuring NCCL communicators.
+See https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/types.html#ncclconfig-t
+for details.
+)")
+      .def(py::init<>())
+      .def_readwrite("blocking", &ncclConfig_t::blocking)
+      .def_readwrite("cga_cluster_size", &ncclConfig_t::cgaClusterSize)
+      .def_readwrite("min_ctas", &ncclConfig_t::minCTAs)
+      .def_readwrite("max_ctas", &ncclConfig_t::maxCTAs)
+      .def_readwrite("net_name", &ncclConfig_t::netName);
+#endif
+
   intrusive_ptr_class_<::c10d::ProcessGroupNCCL::Options>(
       processGroupNCCL,
       "Options",
@@ -2147,18 +2162,42 @@ Arguments:
             to prioritize NCCL kernels when there are compute kernels waiting.
             Default is False.
 
+Attributes:
+    config (NCCLConfig): configures NCCL communicators (only avaiable for
+            builds using NCCL 2.17+). This can be used to improve
+            communication-computation overlap for NCCL kernels by tuning
+            available parameters in the config. See
+            https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/types.html#ncclconfig-t
+            for details.
+
 Example::
     >>> import torch.distributed as dist
     >>>
     >>> nccl_options = dist.ProcessGroupNCCL.Options(is_high_priority_stream=True)
+    >>> # For builds using NCCL 2.17+, configure communicators
+    >>> nccl_options.config.cga_cluster_size = 2
+    >>> nccl_options.config.max_ctas = 4
+    >>> nccl_options.config.min_ctas = 2
     >>> # initialize a nccl process group with the options just created
     >>> dist.init_process_group("nccl", pg_options=nccl_options)
       )")
       .def(py::init<bool>(), py::arg("is_high_priority_stream") = false)
+#ifdef ENABLE_NCCL_RANK_CONFIG
+      .def_readwrite(
+          "is_high_priority_stream",
+          &::c10d::ProcessGroupNCCL::Options::is_high_priority_stream)
+      .def_readwrite(
+          "config",
+          &::c10d::ProcessGroupNCCL::Options::config);
+#else
       .def_readwrite(
           "is_high_priority_stream",
           &::c10d::ProcessGroupNCCL::Options::is_high_priority_stream);
 #endif
+  processGroupNCCL.def_static(
+      "_group_start", []() { ::c10d::ProcessGroupNCCL::groupStart(); });
+  processGroupNCCL.def_static(
+      "_group_end", []() { ::c10d::ProcessGroupNCCL::groupEnd(); });
 
 #ifdef USE_C10D_MPI
   auto processGroupMPI =

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -749,16 +749,6 @@ class DistributedDataParallel(Module, Joinable):
         else:
             self.process_group = process_group
 
-        if dist.get_backend(
-            self.process_group
-        ) == "nccl" and torch.cuda.nccl.version() >= (2, 17):
-            # Note: NVIDIA recommends using CGA Cluster Size of 2 when using DDP.
-            default_cga = dist.ProcessGroupNCCL.Options().config.cga_cluster_size  # type: ignore[attr-defined]
-            default_pg_nccl = self.process_group._get_backend(torch.device("cuda"))
-            current_cga = default_pg_nccl.options.config.cga_cluster_size
-            if current_cga == default_cga:
-                default_pg_nccl.options.config.cga_cluster_size = 2
-
         self.static_graph = False
         self.dim = dim
         self.module = module

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -749,9 +749,12 @@ class DistributedDataParallel(Module, Joinable):
         else:
             self.process_group = process_group
 
-        if self.process_group.options.backend == "nccl" and torch.cuda.nccl.version() >= (2, 17):
+        if (
+            dist.get_backend(self.process_group) == "nccl"
+            and torch.cuda.nccl.version() >= (2, 17)
+        ):
             # Note: NVIDIA recommends using CGA Cluster Size of 2 when using DDP.
-            default_cga = dist.ProcessGroupNCCL.Options().config.cga_cluster_size
+            default_cga = dist.ProcessGroupNCCL.Options().config.cga_cluster_size # type: ignore[attr-defined]
             default_pg_nccl = self.process_group._get_backend(torch.device("cuda"))
             current_cga = default_pg_nccl.options.config.cga_cluster_size
             if current_cga == default_cga:

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -749,12 +749,11 @@ class DistributedDataParallel(Module, Joinable):
         else:
             self.process_group = process_group
 
-        if (
-            dist.get_backend(self.process_group) == "nccl"
-            and torch.cuda.nccl.version() >= (2, 17)
-        ):
+        if dist.get_backend(
+            self.process_group
+        ) == "nccl" and torch.cuda.nccl.version() >= (2, 17):
             # Note: NVIDIA recommends using CGA Cluster Size of 2 when using DDP.
-            default_cga = dist.ProcessGroupNCCL.Options().config.cga_cluster_size # type: ignore[attr-defined]
+            default_cga = dist.ProcessGroupNCCL.Options().config.cga_cluster_size  # type: ignore[attr-defined]
             default_pg_nccl = self.process_group._get_backend(torch.device("cuda"))
             current_cga = default_pg_nccl.options.config.cga_cluster_size
             if current_cga == default_cga:


### PR DESCRIPTION
NCCL 2.17+ introduces some user configurable parameters for NCCL communicators using [ncclConfig_t](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/types.html#c.ncclConfig_t) datatype and [ncclCommInitRankConfig](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcomminitrankconfig). This PR enables that feature. 

A user can tune the parameters as follows:
```
import torch.distributed as dist
nccl_options = dist.ProcessGroupNCCL.Options()
nccl_options.config.max_ctas = 32
nccl_options.config.min_ctas = 8
nccl_options.config.cga_cluster_size = 2
dist.init_process_group(backend='nccl', init_method='env://', pg_options=nccl_options)
my_group = dist.new_group(pg_options=nccl_options)
```

The default values of these parameters are what is initialized by `NCCL_CONFIG_INITIALIZER`. Only for DistributedDataParallel, this PR sets the default value of cga_cluster_size to 2 (a heuristic that works well especially for DDP workloads). 

Tuning these parameters can lead to improvement in end-to-end performance, since it affects the communication-computation overlap for NCCL kernels. 

CC: @ptrblck @kwen2501 