### PR TITLE
[Vulkan] Fix static analysis errors in vulkan_quantized_api_test.cpp

### DIFF
--- a/aten/src/ATen/test/vulkan_quantized_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_quantized_api_test.cpp
@@ -2,17 +2,18 @@
 
 #include <ATen/ATen.h>
 #include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <ATen/native/vulkan/api/api.h>
-#include <gtest/gtest.h>
-
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/Copy.h>
 #include <ATen/native/vulkan/ops/Factory.h>
 #include <ATen/native/vulkan/ops/QuantizedFunctions.h>
-#include <ATen/native/quantized/cpu/QuantUtils.h>
-#include <string.h>
-
 #include <c10/util/irange.h>
+#include <gtest/gtest.h>
+#include <cstring>
+#include <random>
+
+using namespace at::native::vulkan::api::utils;
 
 /*
  * TODO: rename this file to something like vulkan_experimental_test and move
@@ -27,10 +28,10 @@ bool checkRtol(
     const at::Tensor& diff,
     const std::vector<at::Tensor>& inputs,
     const float tolerated_error = 0) {
-  float maxValue = 0.0f;
+  double maxValue = 0.0;
 
   for (const auto& tensor : inputs) {
-    maxValue = fmax(tensor.abs().max().item<float>(), maxValue);
+    maxValue = fmax(tensor.abs().max().item<double>(), maxValue);
   }
 
 #ifdef USE_VULKAN_FP16_INFERENCE
@@ -39,10 +40,14 @@ bool checkRtol(
   constexpr float tolerance = 1e-5;
 #endif
 
-  return diff.abs().max().item<float>() <= (tolerance * maxValue + tolerated_error);
+  return diff.abs().max().item<double>() <=
+      (tolerance * maxValue + tolerated_error);
 }
 
-bool almostEqual(const at::Tensor& a, const at::Tensor& b, const float tolerated_error = 0) {
+bool almostEqual(
+    const at::Tensor& a,
+    const at::Tensor& b,
+    const float tolerated_error = 0) {
   return checkRtol(a - b, {a, b}, tolerated_error);
 }
 
@@ -55,8 +60,8 @@ bool exactlyEqual(const at::Tensor& a, const at::Tensor& b) {
 void showRtol(const at::Tensor& a, const at::Tensor& b) {
   const auto diff = (a - b).abs();
 
-  float maxValue = a.abs().max().item<float>();
-  maxValue = fmax(b.abs().max().item<float>(), maxValue);
+  double maxValue = a.abs().max().item<double>();
+  maxValue = fmax(b.abs().max().item<double>(), maxValue);
 
 #ifdef USE_VULKAN_FP16_INFERENCE
   constexpr float tolerance = 1e-2;
@@ -64,13 +69,13 @@ void showRtol(const at::Tensor& a, const at::Tensor& b) {
   constexpr float tolerance = 1e-5;
 #endif
 
-  const float maxDiff = maxValue * tolerance;
+  const double maxDiff = maxValue * tolerance;
   std::cout << "Max Diff allowed: " << maxDiff << std::endl;
   if (diff.sizes().size() == 2) {
     for (const auto y : c10::irange(diff.sizes()[0])) {
       std::cout << y << ":";
       for (const auto x : c10::irange(diff.sizes()[1])) {
-        float diff_xy = diff[y][x].item<float>();
+        double diff_xy = diff[y][x].item<double>();
         if (diff_xy > maxDiff) {
           std::cout << std::setw(5) << x;
         } else {
@@ -111,20 +116,31 @@ inline std::vector<c10::IValue> callOpByName(
 
 namespace {
 
-double rand01() {
-  return (double)rand() / (double)RAND_MAX;
+double rand_double(const double min, const double max) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  if (std::fabs(max - min) < std::numeric_limits<double>::epsilon()) {
+    return min;
+  }
+  return std::uniform_real_distribution<double>(min, max)(gen);
 }
 
-int64_t rand_pos_int(const int max_val) {
+int rand_int(const int min, const int max) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  return std::uniform_int_distribution<int>(min, max)(gen);
+}
+
+int rand_pos_int(const int max_val) {
   TORCH_CHECK(max_val > 0, "max value must be positive");
-  return 1 + rand() % max_val;
+  return 1 + rand_int(0, max_val);
 }
 
 at::Tensor produce_random_tensor(
     const at::IntArrayRef tensor_shape,
-    const float s_min = 1.0,
-    const float s_max = 100.0,
-    const float shift = 0.45) {
+    const double s_min = 1.0,
+    const double s_max = 100.0,
+    const double shift = 0.45) {
   // tensor is randomly generated with values in the range
   // [-shift * s, (1-shift) * s), where s is randomly generated in the range
   // [s_min, s_max]
@@ -133,9 +149,9 @@ at::Tensor produce_random_tensor(
   // [-0.45, 0.55) or as wide as [-45.0, 55.0)
   TORCH_CHECK(s_min > 0, "scalar lower bound must be positive");
   TORCH_CHECK(s_min <= s_max, "scalar lower bound must be <= upper bound");
-  const auto scalar = s_min + (s_max - s_min) * (float)rand()/(float)RAND_MAX;
+  const auto scalar = rand_double(s_min, s_max);
   return scalar *
-    (at::rand(tensor_shape, at::device(at::kCPU).dtype(at::kFloat)) - shift);
+      (at::rand(tensor_shape, at::device(at::kCPU).dtype(at::kFloat)) - shift);
 }
 
 double produce_random_scale(
@@ -143,34 +159,36 @@ double produce_random_scale(
     const double scale_max = 2.0) {
   TORCH_CHECK(scale_min <= scale_max, "scale min must be <= scale max");
   // scale is randomly generated in the range [scale_min, scale_max)
-  return rand01() * (scale_max - scale_min) + scale_min;
+  return rand_double(scale_min, scale_max);
+  ;
 }
 
-int64_t produce_random_zero_point(const c10::ScalarType dtype) {
-  int64_t zero_point;
+int produce_random_zero_point(const c10::ScalarType dtype) {
+  int zero_point = 0;
   switch (dtype) {
     case c10::ScalarType::QUInt8:
-      zero_point = rand() % 256;
+      zero_point = rand_int(0, 255);
       break;
     case c10::ScalarType::QInt8:
-      zero_point = rand() % 256 - 128;
+      zero_point = rand_int(-128, 127);
       break;
     case c10::ScalarType::QInt32:
-      zero_point = rand() % 100000 - 200000;
+      zero_point = rand_int(-100000, 100000);
       break;
     default:
       TORCH_CHECK(
-        false, "Vulkan quantization currently not supported for dtype ", dtype
-      );
+          false,
+          "Vulkan quantization currently not supported for dtype ",
+          dtype);
   }
   return zero_point;
 }
 
-std::tuple<double, int64_t> compute_quant_params(
-    const at::Tensor tensor,
+std::tuple<double, int> compute_quant_params(
+    const at::Tensor& tensor,
     const c10::ScalarType dtype = c10::ScalarType::QUInt8) {
-  int zero_point_min;
-  int zero_point_max;
+  int zero_point_min = 0;
+  int zero_point_max = 255;
   if (dtype == c10::ScalarType::QUInt8) {
     zero_point_min = 0;
     zero_point_max = 255;
@@ -178,20 +196,22 @@ std::tuple<double, int64_t> compute_quant_params(
     zero_point_min = -128;
     zero_point_max = 127;
   } else {
-    TORCH_CHECK(false, "Computation of quant params only available for dtypes",
-                       "QUInt8 and QInt8");
+    TORCH_CHECK(
+        false,
+        "Computation of quant params only available for dtypes",
+        "QUInt8 and QInt8");
   }
   const auto tensor_max = tensor.max().item<double>();
   const auto tensor_min = tensor.min().item<double>();
   auto q_params = quant_utils::ChooseQuantizationParams(
-      /*min=*/tensor_min,
-      /*max=*/tensor_max,
+      /*min=*/safe_downcast<float>(tensor_min),
+      /*max=*/safe_downcast<float>(tensor_max),
       /*qmin=*/zero_point_min,
       /*qmax=*/zero_point_max,
       /*preserve_sparsity=*/false,
       /*force_scale_power_of_two=*/false,
       /*reduce_range=*/false);
-  return std::tuple<double, int64_t>(q_params.scale, q_params.zero_point);
+  return std::tuple<double, int>(q_params.scale, q_params.zero_point);
 }
 
 } // namespace
@@ -200,7 +220,7 @@ namespace {
 
 class VulkanAPITest : public ::testing::Test {
  public:
-  void SetUp() {
+  void SetUp() override {
     if (!at::is_vulkan_available()) {
       GTEST_SKIP() << "Vulkan is not available";
     }
@@ -209,7 +229,7 @@ class VulkanAPITest : public ::testing::Test {
 #endif
   }
 
-  void TearDown() {
+  void TearDown() override {
 #if defined(USE_VULKAN_GPU_DIAGNOSTICS) && defined(__ANDROID__)
     try {
       at::native::vulkan::api::context()->querypool().extract_results();
@@ -270,7 +290,7 @@ at::Tensor vulkan_to_cpu(at::Tensor vulkan, at::Tensor in_cpu) {
 TEST_F(VulkanAPITest, uniform_buffer_copy) {
   using namespace at::native::vulkan;
 
-  struct TestStruct{
+  struct TestStruct {
     int a;
     int b;
     int c;
@@ -294,15 +314,16 @@ TEST_F(VulkanAPITest, uniform_buffer_copy) {
 TEST_F(VulkanAPITest, copy_to_buffer) {
   using namespace at::native::vulkan;
 
-  at::Tensor test_tensors[] = {
-    // 4D
-    at::rand({7, 17, 134, 213}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
-    // 3D
-    at::rand({67, 134, 213}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
-    // 2D
-    at::rand({229, 213}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
-    // 1D
-    at::rand({1902}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+  std::array<at::Tensor, 4> test_tensors = {
+      // 4D
+      at::rand(
+          {7, 17, 134, 213}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+      // 3D
+      at::rand({67, 134, 213}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+      // 2D
+      at::rand({229, 213}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+      // 1D
+      at::rand({1902}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
   };
 
   for (auto in_cpu : test_tensors) {
@@ -311,9 +332,9 @@ TEST_F(VulkanAPITest, copy_to_buffer) {
 
     const auto check_copy = almostEqual(out_copied, in_cpu);
 
-    if(!check_copy) {
-      std::cout << "Copy failed on size " << in_cpu.sizes()
-                << "with dtype" << in_cpu.dtype() << std::endl;
+    if (!check_copy) {
+      std::cout << "Copy failed on size " << in_cpu.sizes() << "with dtype"
+                << in_cpu.dtype() << std::endl;
     }
 
     ASSERT_TRUE(check_copy);
@@ -326,9 +347,9 @@ TEST_F(VulkanAPITest, copy_to_buffer_channels_last) {
   at::TensorOptions options(at::kCPU);
   options = options.dtype(at::kFloat);
 
-  at::Tensor test_tensors[] = {
-    // 4D
-    at::rand({7, 17, 134, 213}, options).to(at::MemoryFormat::ChannelsLast),
+  std::array<at::Tensor, 1> test_tensors = {
+      // 4D
+      at::rand({7, 17, 134, 213}, options).to(at::MemoryFormat::ChannelsLast),
   };
 
   for (auto in_cpu : test_tensors) {
@@ -337,9 +358,9 @@ TEST_F(VulkanAPITest, copy_to_buffer_channels_last) {
 
     const auto check_copy = almostEqual(out_copied, in_cpu);
 
-    if(!check_copy) {
-      std::cout << "Copy failed on size " << in_cpu.sizes()
-                << "with dtype" << in_cpu.dtype() << std::endl;
+    if (!check_copy) {
+      std::cout << "Copy failed on size " << in_cpu.sizes() << "with dtype"
+                << in_cpu.dtype() << std::endl;
     }
 
     ASSERT_TRUE(check_copy);
@@ -349,7 +370,7 @@ TEST_F(VulkanAPITest, copy_to_buffer_channels_last) {
 // TODO: Fix vulkan to cpu on Android
 TEST_F(VulkanAPITest, DISABLED_support_vulkan) {
   const double scale = 0.1;
-  const int64_t zero_point = 10;
+  const int zero_point = 10;
 
   auto in_cpu =
       at::rand({2, 13, 32, 27}, at::device(at::kCPU).dtype(at::kFloat)) * 12 -
@@ -390,11 +411,9 @@ void test_cpu_to_vulkan_and_vulkan_to_cpu(
     const double scale,
     const int zero_point,
     const c10::ScalarType dtype = c10::ScalarType::QUInt8) {
-
   // produce random quantized cpu tensor
   auto in_cpu = produce_random_tensor(input_shape);
-  auto in_q_cpu = at::quantize_per_tensor(
-      in_cpu, scale, zero_point, dtype);
+  auto in_q_cpu = at::quantize_per_tensor(in_cpu, scale, zero_point, dtype);
 
   // copy quantized cpu tensor to vulkan
   auto in_q_cpu_vk = cpu_to_vulkan(in_q_cpu);
@@ -403,32 +422,29 @@ void test_cpu_to_vulkan_and_vulkan_to_cpu(
   auto out_q_cpu = vulkan_to_cpu(in_q_cpu_vk, in_q_cpu);
 
   // check that the copy equals the original
-  const auto diff = at::native::int_repr_quantized_cpu(in_q_cpu)
-                    - at::native::int_repr_quantized_cpu(out_q_cpu);
+  const auto diff = at::native::int_repr_quantized_cpu(in_q_cpu) -
+      at::native::int_repr_quantized_cpu(out_q_cpu);
 
   const int error = diff.abs().max().item<int>();
 
   const auto check = (error == 0);
 
   if (!check) {
-    std::cout
-      << "Copy to vulkan and back to cpu failed with input shape: "
-      << input_shape << " scale: " << scale << " and zero point: "
-      << zero_point << std::endl;
+    std::cout << "Copy to vulkan and back to cpu failed with input shape: "
+              << input_shape << " scale: " << scale
+              << " and zero point: " << zero_point << std::endl;
     std::cout << "Error: " << error << std::endl;
   }
 
   ASSERT_TRUE(check);
 }
 
-void test_cpu_to_vulkan_and_vulkan_to_cpu_random(
-    const c10::ScalarType dtype) {
+void test_cpu_to_vulkan_and_vulkan_to_cpu_random(const c10::ScalarType dtype) {
   const double scale = produce_random_scale();
-  const int64_t zero_point = produce_random_zero_point(dtype);
-  const at::IntArrayRef tensor_shape =
-    {rand_pos_int(30), rand_pos_int(30), rand_pos_int(100), rand_pos_int(100)};
-  test_cpu_to_vulkan_and_vulkan_to_cpu(
-    tensor_shape, scale, zero_point, dtype);
+  const int zero_point = produce_random_zero_point(dtype);
+  const at::IntArrayRef tensor_shape = {
+      rand_pos_int(30), rand_pos_int(30), rand_pos_int(100), rand_pos_int(100)};
+  test_cpu_to_vulkan_and_vulkan_to_cpu(tensor_shape, scale, zero_point, dtype);
 }
 
 // TODO: Fix vulkan to cpu on Android
@@ -517,11 +533,9 @@ void test_cpu_to_vulkan_and_dequantize(
     const double scale,
     const int zero_point,
     const c10::ScalarType dtype = c10::ScalarType::QUInt8) {
-
   // produce random quantized cpu tensor
   auto in_cpu = produce_random_tensor(input_shape);
-  auto in_q_cpu = at::quantize_per_tensor(
-      in_cpu, scale, zero_point, dtype);
+  auto in_q_cpu = at::quantize_per_tensor(in_cpu, scale, zero_point, dtype);
 
   // copy quantized cpu tensor to vulkan
   auto in_q_cpu_vk = cpu_to_vulkan(in_q_cpu);
@@ -535,24 +549,22 @@ void test_cpu_to_vulkan_and_dequantize(
   const auto check = almostEqual(out_cpu_deq, out_vk_deq_cpu);
 
   if (!check) {
-    const auto error = at::abs(out_vk_deq_cpu - out_cpu_deq).max().item<float>();
-    std::cout
-      << "Copy cpu to vulkan and dequantize failed with input shape: "
-      << input_shape << " scale: " << scale << " and zero point: "
-      << zero_point << std::endl;
+    const auto error =
+        at::abs(out_vk_deq_cpu - out_cpu_deq).max().item<float>();
+    std::cout << "Copy cpu to vulkan and dequantize failed with input shape: "
+              << input_shape << " scale: " << scale
+              << " and zero point: " << zero_point << std::endl;
     std::cout << "Error: " << error << std::endl;
   }
   ASSERT_TRUE(check);
 }
 
-void test_cpu_to_vulkan_and_dequantize_random(
-    const c10::ScalarType dtype) {
+void test_cpu_to_vulkan_and_dequantize_random(const c10::ScalarType dtype) {
   const double scale = produce_random_scale();
-  const int64_t zero_point = produce_random_zero_point(dtype);
-  const at::IntArrayRef tensor_shape =
-    {rand_pos_int(30), rand_pos_int(30), rand_pos_int(100), rand_pos_int(100)};
-  test_cpu_to_vulkan_and_dequantize(
-    tensor_shape, scale, zero_point, dtype);
+  const int zero_point = produce_random_zero_point(dtype);
+  const at::IntArrayRef tensor_shape = {
+      rand_pos_int(30), rand_pos_int(30), rand_pos_int(100), rand_pos_int(100)};
+  test_cpu_to_vulkan_and_dequantize(tensor_shape, scale, zero_point, dtype);
 }
 
 TEST_F(VulkanAPITest, cpu_to_vulkan_and_dequantize_quint8) {
@@ -674,27 +686,26 @@ void test_quantize_per_tensor_and_vulkan_to_cpu(
   at::Tensor input = produce_random_tensor(input_shape);
 
   // quantize tensor
-  at::Tensor out_q_cpu = at::quantize_per_tensor(
-    input, input_scale, input_zero_point, dtype);
+  at::Tensor out_q_cpu =
+      at::quantize_per_tensor(input, input_scale, input_zero_point, dtype);
 
   at::Tensor out_q_vk = at::quantize_per_tensor(
-    input.vulkan(), input_scale, input_zero_point, dtype);
+      input.vulkan(), input_scale, input_zero_point, dtype);
 
   // copy vulkan tensor to cpu
   at::Tensor out_q_vk_cpu = vulkan_to_cpu(out_q_vk, out_q_cpu);
 
-  const auto diff = at::native::int_repr_quantized_cpu(out_q_vk_cpu)
-                    - at::native::int_repr_quantized_cpu(out_q_cpu);
+  const auto diff = at::native::int_repr_quantized_cpu(out_q_vk_cpu) -
+      at::native::int_repr_quantized_cpu(out_q_cpu);
 
   const int error = diff.abs().max().item<int>();
 
   const auto check = (error <= tolerance);
 
   if (!check) {
-    std::cout
-      << "Quantize and copy to cpu failed with input shape: " << input_shape
-      << " scale: " << input_scale << " and zero point: " << input_zero_point
-    << std::endl;
+    std::cout << "Quantize and copy to cpu failed with input shape: "
+              << input_shape << " scale: " << input_scale
+              << " and zero point: " << input_zero_point << std::endl;
     std::cout << "Error: " << error << std::endl;
   }
 
@@ -704,11 +715,11 @@ void test_quantize_per_tensor_and_vulkan_to_cpu(
 void test_quantize_per_tensor_and_vulkan_to_cpu_random(
     const c10::ScalarType dtype) {
   const double scale = produce_random_scale();
-  const int64_t zero_point = produce_random_zero_point(dtype);
-  const at::IntArrayRef tensor_shape =
-    {rand_pos_int(30), rand_pos_int(30), rand_pos_int(100), rand_pos_int(100)};
+  const int zero_point = produce_random_zero_point(dtype);
+  const at::IntArrayRef tensor_shape = {
+      rand_pos_int(30), rand_pos_int(30), rand_pos_int(100), rand_pos_int(100)};
   test_quantize_per_tensor_and_vulkan_to_cpu(
-    tensor_shape, scale, zero_point, dtype);
+      tensor_shape, scale, zero_point, dtype);
 }
 
 // TODO: Fix vulkan to cpu on Android
@@ -725,14 +736,17 @@ TEST_F(VulkanAPITest, DISABLED_quantize_per_tensor_and_vulkan_to_cpu_quint8) {
   test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 12, 17}, 0.1, 10, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 17, 12}, 0.1, 10, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({2, 4, 17, 12}, 0.1, 10, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 10, 14}, 0.0001, 101, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {1, 1, 10, 14}, 0.0001, 101, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 10, 14}, 0.009, 43, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 10, 15}, 0.1, 19, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({4, 4, 9, 17}, 0.1, 19, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 25, 29}, 0.1, 19, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({4, 4, 25, 29}, 0.1, 19, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({11, 17, 25, 29}, 0.027, 89, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({3, 16, 77, 54}, 0.204173, 229, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {11, 17, 25, 29}, 0.027, 89, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {3, 16, 77, 54}, 0.204173, 229, dtype);
 
   for (int i = 0; i < 20; i += 1) {
     test_quantize_per_tensor_and_vulkan_to_cpu_random(dtype);
@@ -753,14 +767,17 @@ TEST_F(VulkanAPITest, DISABLED_quantize_per_tensor_and_vulkan_to_cpu_qint8) {
   test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 12, 17}, 0.1, -10, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 17, 12}, 0.1, 10, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({2, 4, 17, 12}, 0.1, -10, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 10, 14}, 0.0001, 101, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {1, 1, 10, 14}, 0.0001, 101, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 10, 14}, 0.009, -43, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 10, 15}, 0.1, 19, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({4, 4, 9, 17}, 0.1, -19, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 25, 29}, 0.1, 19, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({4, 4, 25, 29}, 0.1, -19, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({11, 17, 25, 29}, 0.027, 89, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({3, 16, 77, 54}, 0.204173, 229, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {11, 17, 25, 29}, 0.027, 89, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {3, 16, 77, 54}, 0.204173, 229, dtype);
 
   for (int i = 0; i < 20; i += 1) {
     test_quantize_per_tensor_and_vulkan_to_cpu_random(dtype);
@@ -772,23 +789,34 @@ TEST_F(VulkanAPITest, DISABLED_quantize_per_tensor_and_vulkan_to_cpu_qint32) {
   const c10::ScalarType dtype = c10::ScalarType::QInt32;
   test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 1, 1}, 0.13, -21123, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 1, 4}, 0.339, 8734, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 4, 1}, 0.228, -12023, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {1, 1, 4, 1}, 0.228, -12023, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 7, 7}, 0.338, 8723, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 8, 8}, 0.193, -1023, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 8, 8}, 0.0449, 972, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 11, 17}, 0.073, -15, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 12, 17}, 0.1572, 102, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 12, 17}, 0.147, -156, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 17, 12}, 0.129, 10448, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {1, 1, 12, 17}, 0.1572, 102, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {3, 5, 12, 17}, 0.147, -156, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {1, 1, 17, 12}, 0.129, 10448, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({2, 4, 17, 12}, 0.137, -10, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({1, 1, 10, 14}, 0.0001, 101, dtype, 1);
-  test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 10, 14}, 0.009, -43267, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {1, 1, 10, 14}, 0.0001, 101, dtype, 1);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {3, 5, 10, 14}, 0.009, -43267, dtype);
   test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 10, 15}, 0.1243, 19, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({4, 4, 9, 17}, 0.1889, -19784, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({3, 5, 25, 29}, 0.1345, 196, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({4, 4, 25, 29}, 0.129, -19489, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({11, 17, 25, 29}, 0.027, 89, dtype);
-  test_quantize_per_tensor_and_vulkan_to_cpu({3, 16, 77, 54}, 0.204173, 229, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {4, 4, 9, 17}, 0.1889, -19784, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {3, 5, 25, 29}, 0.1345, 196, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {4, 4, 25, 29}, 0.129, -19489, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {11, 17, 25, 29}, 0.027, 89, dtype);
+  test_quantize_per_tensor_and_vulkan_to_cpu(
+      {3, 16, 77, 54}, 0.204173, 229, dtype);
 
   for (int i = 0; i < 20; i += 1) {
     test_quantize_per_tensor_and_vulkan_to_cpu_random(dtype);
@@ -841,10 +869,10 @@ void test_quantize_per_tensor_and_dequantize(
   at::Tensor input = produce_random_tensor(input_shape);
 
   // quantize tensors
-  at::Tensor out_q_cpu = at::quantize_per_tensor(
-    input, input_scale, input_zero_point, dtype);
+  at::Tensor out_q_cpu =
+      at::quantize_per_tensor(input, input_scale, input_zero_point, dtype);
   at::Tensor out_q_vk = at::quantize_per_tensor(
-    input.vulkan(), input_scale, input_zero_point, dtype);
+      input.vulkan(), input_scale, input_zero_point, dtype);
 
   // dequantize tensors
   const auto out_cpu_deq = at::dequantize(out_q_cpu);
@@ -852,18 +880,18 @@ void test_quantize_per_tensor_and_dequantize(
   const auto out_vk_deq_cpu = out_vk_deq.cpu();
 
   // check dequantized tensor are equal
-  const float tolerance = input_scale;
+  const float tolerance = safe_downcast<float>(input_scale);
   // tolerated error = scale, to allow for precision differences after dividing
   // by random scale, which could result on a difference of 1 unit in the
   // quantized result.
   const auto check = almostEqual(out_cpu_deq, out_vk_deq_cpu, tolerance);
 
   if (!check) {
-    const auto error = at::abs(out_vk_deq_cpu - out_cpu_deq).max().item<float>();
-    std::cout
-      << "Quantize and Dequantize failed with input shape: " << input_shape
-      << " scale: " << input_scale << " and zero point: " << input_zero_point
-    << std::endl;
+    const auto error =
+        at::abs(out_vk_deq_cpu - out_cpu_deq).max().item<float>();
+    std::cout << "Quantize and Dequantize failed with input shape: "
+              << input_shape << " scale: " << input_scale
+              << " and zero point: " << input_zero_point << std::endl;
     std::cout << "Error: " << error << std::endl;
   }
   ASSERT_TRUE(check);
@@ -872,11 +900,11 @@ void test_quantize_per_tensor_and_dequantize(
 void test_quantize_per_tensor_and_dequantize_random(
     const c10::ScalarType dtype) {
   const double scale = produce_random_scale();
-  const int64_t zero_point = produce_random_zero_point(dtype);
-  const at::IntArrayRef tensor_shape =
-    {rand_pos_int(30), rand_pos_int(30), rand_pos_int(100), rand_pos_int(100)};
+  const int zero_point = produce_random_zero_point(dtype);
+  const at::IntArrayRef tensor_shape = {
+      rand_pos_int(30), rand_pos_int(30), rand_pos_int(100), rand_pos_int(100)};
   test_quantize_per_tensor_and_dequantize(
-    tensor_shape, scale, zero_point, dtype);
+      tensor_shape, scale, zero_point, dtype);
 }
 
 TEST_F(VulkanAPITest, quantize_per_tensor_and_dequantize_quint8) {
@@ -980,9 +1008,7 @@ TEST_F(VulkanAPITest, quantized_add) {
   const double scale3 = 0.15;
   const int zero_point3 = 15;
   const auto reg_added_tensors = callOpByName(
-      "quantized::add",
-      "",
-      out_cpu, out_cpu2, scale3, zero_point3);
+      "quantized::add", "", out_cpu, out_cpu2, scale3, zero_point3);
   const auto vulk_added_tensors = at::native::vulkan::ops::quantized_add(
       out_vulkan, out_vulkan2, scale3, zero_point3);
 
@@ -993,7 +1019,10 @@ TEST_F(VulkanAPITest, quantized_add) {
   float rtol = 0;
   float atol = 0.5;
   const auto check = at::allclose(
-      at::dequantize(reg_added_tensors[0].toTensor()), output_for_dequantized_vulkan, rtol, atol);
+      at::dequantize(reg_added_tensors[0].toTensor()),
+      output_for_dequantized_vulkan,
+      rtol,
+      atol);
 
   if (!check) {
     std::cout << "Max Diff allowed: " << rtol << std::endl;
@@ -1025,9 +1054,7 @@ TEST_F(VulkanAPITest, quantized_add_broadcast) {
   const double scale3 = 0.15;
   const int zero_point3 = 15;
   const auto reg_added_tensors = callOpByName(
-      "quantized::add",
-      "",
-      out_cpu, out_cpu2, scale3, zero_point3);
+      "quantized::add", "", out_cpu, out_cpu2, scale3, zero_point3);
   const auto vulk_added_tensors = at::native::vulkan::ops::quantized_add(
       out_vulkan, out_vulkan2, scale3, zero_point3);
 
@@ -1039,8 +1066,11 @@ TEST_F(VulkanAPITest, quantized_add_broadcast) {
 
   float rtol = 0;
   float atol = 0.5;
-   const auto check = at::allclose(
-      at::dequantize(reg_added_tensors[0].toTensor()), output_for_dequantized_vulkan, rtol, atol);
+  const auto check = at::allclose(
+      at::dequantize(reg_added_tensors[0].toTensor()),
+      output_for_dequantized_vulkan,
+      rtol,
+      atol);
 
   if (!check) {
     std::cout << "Max Diff allowed: " << rtol << std::endl;
@@ -1076,9 +1106,7 @@ TEST_F(VulkanAPITest, quantized_add_broadcast1) {
   const double scale3 = 0.15;
   const int zero_point3 = 15;
   const auto reg_added_tensors = callOpByName(
-      "quantized::add",
-      "",
-      out_cpu, out_cpu2, scale3, zero_point3);
+      "quantized::add", "", out_cpu, out_cpu2, scale3, zero_point3);
   const auto vulk_added_tensors = at::native::vulkan::ops::quantized_add(
       out_vulkan, out_vulkan2, scale3, zero_point3);
 
@@ -1091,7 +1119,10 @@ TEST_F(VulkanAPITest, quantized_add_broadcast1) {
   float rtol = 0;
   float atol = 0.5;
   const auto check = at::allclose(
-      at::dequantize(reg_added_tensors[0].toTensor()), output_for_dequantized_vulkan, rtol, atol);
+      at::dequantize(reg_added_tensors[0].toTensor()),
+      output_for_dequantized_vulkan,
+      rtol,
+      atol);
 
   if (!check) {
     std::cout << "Max Diff allowed: " << rtol << std::endl;
@@ -1127,9 +1158,7 @@ TEST_F(VulkanAPITest, quantized_add_broadcast2) {
   const double scale3 = 0.15;
   const int zero_point3 = 15;
   const auto reg_added_tensors = callOpByName(
-      "quantized::add",
-      "",
-      out_cpu, out_cpu2, scale3, zero_point3);
+      "quantized::add", "", out_cpu, out_cpu2, scale3, zero_point3);
   const auto vulk_added_tensors = at::native::vulkan::ops::quantized_add(
       out_vulkan, out_vulkan2, scale3, zero_point3);
 
@@ -1142,7 +1171,10 @@ TEST_F(VulkanAPITest, quantized_add_broadcast2) {
   float rtol = 0;
   float atol = 0.5;
   const auto check = at::allclose(
-      at::dequantize(reg_added_tensors[0].toTensor()), output_for_dequantized_vulkan, rtol, atol);
+      at::dequantize(reg_added_tensors[0].toTensor()),
+      output_for_dequantized_vulkan,
+      rtol,
+      atol);
 
   if (!check) {
     std::cout << "Max Diff allowed: " << rtol << std::endl;
@@ -1178,9 +1210,7 @@ TEST_F(VulkanAPITest, quantized_add_broadcast3) {
   const double scale3 = 0.15;
   const int zero_point3 = 15;
   const auto reg_added_tensors = callOpByName(
-      "quantized::add",
-      "",
-      out_cpu, out_cpu2, scale3, zero_point3);
+      "quantized::add", "", out_cpu, out_cpu2, scale3, zero_point3);
   const auto vulk_added_tensors = at::native::vulkan::ops::quantized_add(
       out_vulkan, out_vulkan2, scale3, zero_point3);
 
@@ -1193,7 +1223,10 @@ TEST_F(VulkanAPITest, quantized_add_broadcast3) {
   float rtol = 0;
   float atol = 0.5;
   const auto check = at::allclose(
-      at::dequantize(reg_added_tensors[0].toTensor()), output_for_dequantized_vulkan, rtol, atol);
+      at::dequantize(reg_added_tensors[0].toTensor()),
+      output_for_dequantized_vulkan,
+      rtol,
+      atol);
 
   if (!check) {
     std::cout << "Max Diff allowed: " << rtol << std::endl;
@@ -1226,9 +1259,7 @@ TEST_F(VulkanAPITest, quantized_add_dif_params) {
   const double scale3 = 0.15;
   const int zero_point3 = 15;
   const auto reg_added_tensors = callOpByName(
-      "quantized::add",
-      "",
-      out_cpu, out_cpu2, scale3, zero_point3);
+      "quantized::add", "", out_cpu, out_cpu2, scale3, zero_point3);
   const auto vulk_added_tensors = at::native::vulkan::ops::quantized_add(
       out_vulkan, out_vulkan2, scale3, zero_point3);
 
@@ -1239,7 +1270,10 @@ TEST_F(VulkanAPITest, quantized_add_dif_params) {
   float rtol = 0;
   float atol = 0.5;
   const auto check = at::allclose(
-      at::dequantize(reg_added_tensors[0].toTensor()), output_for_dequantized_vulkan, rtol, atol);
+      at::dequantize(reg_added_tensors[0].toTensor()),
+      output_for_dequantized_vulkan,
+      rtol,
+      atol);
 
   if (!check) {
     std::cout << "Max Diff allowed: " << rtol << std::endl;
@@ -1737,33 +1771,40 @@ TEST_F(VulkanAPITest, quantized_upsample_nearest2d) {
   ASSERT_TRUE(check);
 }
 
-std::tuple<double, double, int64_t, int64_t> produce_inputs_for_binary_op(
+std::tuple<double, double, int, int> produce_inputs_for_binary_op(
     const bool compute_quantization_params,
     const bool random_quantization_params,
     const char* op_name,
     const at::IntArrayRef input1_shape,
     const at::IntArrayRef input2_shape,
-    double in1_scale, double in2_scale,
-    int in1_zero_point, int in2_zero_point,
-    at::Tensor& input1_cpu, at::Tensor& input1_cpu_q,
+    double in1_scale,
+    double in2_scale,
+    int in1_zero_point,
+    int in2_zero_point,
+    at::Tensor& input1_cpu,
+    at::Tensor& input1_cpu_q,
     at::Tensor& input1_cpu_deq,
-    at::Tensor& input1_vk, at::Tensor& input1_vk_q,
-    at::Tensor& input1_vk_deq, at::Tensor& input1_vk_deq_cpu,
-    at::Tensor& input2_cpu, at::Tensor& input2_cpu_q,
+    at::Tensor& input1_vk,
+    at::Tensor& input1_vk_q,
+    at::Tensor& input1_vk_deq,
+    at::Tensor& input1_vk_deq_cpu,
+    at::Tensor& input2_cpu,
+    at::Tensor& input2_cpu_q,
     at::Tensor& input2_cpu_deq,
-    at::Tensor& input2_vk, at::Tensor& input2_vk_q,
-    at::Tensor& input2_vk_deq, at::Tensor& input2_vk_deq_cpu) {
-
+    at::Tensor& input2_vk,
+    at::Tensor& input2_vk_q,
+    at::Tensor& input2_vk_deq,
+    at::Tensor& input2_vk_deq_cpu) {
   int num_attempts = 5;
-    // in order to make sure we start with input tensors that are numerically
-    // the same (cpu vs vulkan), we allow multiple attempts when randomly
-    // generating the inputs. If the cpu quantized tensor and the vk quantized
-    // tensors are not the same (maybe off by 1 due to differences in rounding
-    // and precision), we try again.
+  // in order to make sure we start with input tensors that are numerically
+  // the same (cpu vs vulkan), we allow multiple attempts when randomly
+  // generating the inputs. If the cpu quantized tensor and the vk quantized
+  // tensors are not the same (maybe off by 1 due to differences in rounding
+  // and precision), we try again.
   for (int i = 0; i < num_attempts; i += 1) {
     // produce random inputs
     input1_cpu = produce_random_tensor(input1_shape);
-    input2_cpu = produce_random_tensor(input1_shape);
+    input2_cpu = produce_random_tensor(input2_shape);
 
     if (compute_quantization_params) {
       // compute appropiate scale and zero point for inputs
@@ -1793,11 +1834,14 @@ std::tuple<double, double, int64_t, int64_t> produce_inputs_for_binary_op(
         in2_zero_point = std::get<1>(in2_quant_params);
       }
 
-      const auto non_zero_sign = input2_cpu.sign() - input2_cpu.sign().abs() + 1;
-        // non_zero_sign = 1 if the value is non negative, and -1 if it is negative
+      const auto non_zero_sign =
+          input2_cpu.sign() - input2_cpu.sign().abs() + 1;
+      // non_zero_sign = 1 if the value is non negative, and -1 if it is
+      // negative
       input2_cpu = input2_cpu + in2_scale * non_zero_sign;
-        // this will force abs(input2_cpu) >= in2_scale, which means that none of
-        // the quantized values of the second input will be equal to the zero point.
+      // this will force abs(input2_cpu) >= in2_scale, which means that none of
+      // the quantized values of the second input will be equal to the zero
+      // point.
     }
 
     // quantize cpu inputs
@@ -1825,9 +1869,12 @@ std::tuple<double, double, int64_t, int64_t> produce_inputs_for_binary_op(
     input1_vk_deq_cpu = input1_vk_deq.cpu();
     input2_vk_deq_cpu = input2_vk_deq.cpu();
 
-    const float input1_dif = at::abs(input1_cpu_deq - input1_vk_deq_cpu).max().item<float>();
-    const float input2_dif = at::abs(input2_cpu_deq - input2_vk_deq_cpu).max().item<float>();
-    if (input1_dif < 1e-5 && input2_dif < 1e-5 && input1_dif < in1_scale/2 && input2_dif < in2_scale/2) {
+    const float input1_dif =
+        at::abs(input1_cpu_deq - input1_vk_deq_cpu).max().item<float>();
+    const float input2_dif =
+        at::abs(input2_cpu_deq - input2_vk_deq_cpu).max().item<float>();
+    if (input1_dif < 1e-5 && input2_dif < 1e-5 && input1_dif < in1_scale / 2 &&
+        input2_dif < in2_scale / 2) {
       break;
     }
   }
@@ -1857,19 +1904,19 @@ at::Tensor apply_vulkan_quantized_binary_op(
     at::Tensor input1_vk_q,
     at::Tensor input2_vk_q,
     double out_scale,
-    int64_t out_zero_point) {
+    int out_zero_point) {
   if (strcmp(op_name, "quantized::add") == 0) {
     return at::native::vulkan::ops::quantized_add(
-      input1_vk_q, input2_vk_q, out_scale, out_zero_point);
+        input1_vk_q, input2_vk_q, out_scale, out_zero_point);
   } else if (strcmp(op_name, "quantized::sub") == 0) {
     return at::native::vulkan::ops::quantized_sub(
-      input1_vk_q, input2_vk_q, out_scale, out_zero_point);
+        input1_vk_q, input2_vk_q, out_scale, out_zero_point);
   } else if (strcmp(op_name, "quantized::mul") == 0) {
     return at::native::vulkan::ops::quantized_mul(
-      input1_vk_q, input2_vk_q, out_scale, out_zero_point);
+        input1_vk_q, input2_vk_q, out_scale, out_zero_point);
   } else if (strcmp(op_name, "quantized::div") == 0) {
     return at::native::vulkan::ops::quantized_div(
-      input1_vk_q, input2_vk_q, out_scale, out_zero_point);
+        input1_vk_q, input2_vk_q, out_scale, out_zero_point);
   } else {
     TORCH_CHECK(false, "Invalid op");
   }
@@ -1884,10 +1931,9 @@ void test_quantized_binary_op(
     double in1_scale_default = 0.103,
     double in2_scale_default = 0.171,
     double out_scale_default = 0.139,
-    int64_t in1_zero_point_default = 11,
-    int64_t in2_zero_point_default = 9,
-    int64_t out_zero_point_default = 17) {
-
+    int in1_zero_point_default = 11,
+    int in2_zero_point_default = 9,
+    int out_zero_point_default = 17) {
   // produce inputs
   at::Tensor input1_cpu, input1_cpu_q, input1_cpu_deq;
   at::Tensor input1_vk, input1_vk_q, input1_vk_deq, input1_vk_deq_cpu;
@@ -1895,26 +1941,41 @@ void test_quantized_binary_op(
   at::Tensor input2_vk, input2_vk_q, input2_vk_deq, input2_vk_deq_cpu;
 
   auto input_params = produce_inputs_for_binary_op(
-    compute_quantization_params, random_quantization_params, op_name,
-    input1_shape, input2_shape,
-    in1_scale_default, in2_scale_default,
-    in1_zero_point_default, in2_zero_point_default,
-    input1_cpu, input1_cpu_q, input1_cpu_deq,
-    input1_vk, input1_vk_q, input1_vk_deq, input1_vk_deq_cpu,
-    input2_cpu, input2_cpu_q, input2_cpu_deq,
-    input2_vk, input2_vk_q, input2_vk_deq, input2_vk_deq_cpu);
+      compute_quantization_params,
+      random_quantization_params,
+      op_name,
+      input1_shape,
+      input2_shape,
+      in1_scale_default,
+      in2_scale_default,
+      in1_zero_point_default,
+      in2_zero_point_default,
+      input1_cpu,
+      input1_cpu_q,
+      input1_cpu_deq,
+      input1_vk,
+      input1_vk_q,
+      input1_vk_deq,
+      input1_vk_deq_cpu,
+      input2_cpu,
+      input2_cpu_q,
+      input2_cpu_deq,
+      input2_vk,
+      input2_vk_q,
+      input2_vk_deq,
+      input2_vk_deq_cpu);
 
   double in1_scale = std::get<0>(input_params);
   double in2_scale = std::get<1>(input_params);
-  int64_t in1_zero_point = std::get<2>(input_params);
-  int64_t in2_zero_point = std::get<3>(input_params);
+  int in1_zero_point = std::get<2>(input_params);
+  int in2_zero_point = std::get<3>(input_params);
 
   double out_scale = out_scale_default;
-  int64_t out_zero_point = out_zero_point_default;
+  int out_zero_point = out_zero_point_default;
 
   // apply op on dequantized cpu tensors
-  at::Tensor output_cpu = apply_cpu_quantized_binary_op(
-    op_name, input1_cpu_deq, input2_cpu_deq);
+  at::Tensor output_cpu =
+      apply_cpu_quantized_binary_op(op_name, input1_cpu_deq, input2_cpu_deq);
 
   if (compute_quantization_params || random_quantization_params) {
     // compute appropiate scale and zero point for output
@@ -1930,65 +1991,78 @@ void test_quantized_binary_op(
 
   // vulkan quantized output
   at::Tensor output_vk_q = apply_vulkan_quantized_binary_op(
-    op_name, input1_vk_q, input2_vk_q, out_scale, out_zero_point);
+      op_name, input1_vk_q, input2_vk_q, out_scale, out_zero_point);
 
   const auto output_vk_deq = at::dequantize(output_vk_q);
   const auto output_vk_deq_cpu = output_vk_deq.cpu();
 
   // check
   const float tolerance =
-    (compute_quantization_params || random_quantization_params) ? out_scale : 0;
+      (compute_quantization_params || random_quantization_params)
+      ? safe_downcast<float>(out_scale)
+      : 0;
   const auto check = almostEqual(output_cpu_deq, output_vk_deq_cpu, tolerance);
 
   if (!check) {
-    const auto vk_q_error = at::abs(output_vk_deq_cpu - output_cpu_deq).max().item<float>();
-    std::cout << "Binary op " << op_name << " failed with inputs: " << std::endl;
+    const auto vk_q_error =
+        at::abs(output_vk_deq_cpu - output_cpu_deq).max().item<float>();
+    std::cout << "Binary op " << op_name
+              << " failed with inputs: " << std::endl;
     std::cout << "input1: shape " << input1_shape << " scale " << in1_scale
               << " and zero point " << in1_zero_point << std::endl;
     std::cout << "input2: shape " << input2_shape << " scale " << in2_scale
               << " and zero point " << in2_zero_point << std::endl;
-    std::cout << "output scale " << out_scale
-              << " and zero point " << out_zero_point << std::endl;
+    std::cout << "output scale " << out_scale << " and zero point "
+              << out_zero_point << std::endl;
     std::cout << "error: " << vk_q_error << std::endl;
   }
   ASSERT_TRUE(check);
 }
 
-void quantized_binary_op_test_set(
-    const char* op_name) {
+void quantized_binary_op_test_set(const char* op_name) {
   // fixed params
   test_quantized_binary_op(false, false, op_name, {1, 1, 1, 1}, {1, 1, 1, 1});
   test_quantized_binary_op(false, false, op_name, {1, 1, 8, 8}, {1, 1, 8, 8});
-  test_quantized_binary_op(false, false, op_name, {1, 1, 12, 17}, {1, 1, 12, 17});
-  test_quantized_binary_op(false, false, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
-  test_quantized_binary_op(false, false, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
-  test_quantized_binary_op(false, false, op_name, {7, 1, 6, 17}, {7, 5, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, false, op_name, {1, 1, 12, 17}, {1, 1, 12, 17});
+  test_quantized_binary_op(
+      false, false, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
+  test_quantized_binary_op(
+      false, false, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, false, op_name, {7, 5, 6, 1}, {7, 5, 6, 17}); // broadcasting
 
   // compute params
   test_quantized_binary_op(true, false, op_name, {1, 1, 1, 1}, {1, 1, 1, 1});
   test_quantized_binary_op(true, false, op_name, {1, 1, 8, 8}, {1, 1, 8, 8});
-  test_quantized_binary_op(true, false, op_name, {1, 1, 12, 17}, {1, 1, 12, 17});
-  test_quantized_binary_op(true, false, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
-  test_quantized_binary_op(true, false, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
-  test_quantized_binary_op(true, false, op_name, {7, 1, 6, 17}, {7, 5, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      true, false, op_name, {1, 1, 12, 17}, {1, 1, 12, 17});
+  test_quantized_binary_op(
+      true, false, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
+  test_quantized_binary_op(
+      true, false, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
+  test_quantized_binary_op(
+      true, false, op_name, {7, 5, 6, 1}, {7, 5, 6, 17}); // broadcasting
 
   // random params
   test_quantized_binary_op(false, true, op_name, {1, 1, 1, 1}, {1, 1, 1, 1});
   test_quantized_binary_op(false, true, op_name, {1, 1, 8, 8}, {1, 1, 8, 8});
-  test_quantized_binary_op(false, true, op_name, {1, 1, 12, 17}, {1, 1, 12, 17});
-  test_quantized_binary_op(false, true, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
-  test_quantized_binary_op(false, true, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
-  test_quantized_binary_op(false, true, op_name, {7, 1, 6, 17}, {7, 5, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, true, op_name, {1, 1, 12, 17}, {1, 1, 12, 17});
+  test_quantized_binary_op(
+      false, true, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
+  test_quantized_binary_op(
+      false, true, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, true, op_name, {7, 5, 6, 1}, {7, 5, 6, 17}); // broadcasting
 
   // random shape and params
   for (int i = 0; i < 10; i += 1) {
-    const at::IntArrayRef tensor_shape =
-      {
+    const at::IntArrayRef tensor_shape = {
         rand_pos_int(30),
         rand_pos_int(30),
         rand_pos_int(100),
-        rand_pos_int(100)
-      };
+        rand_pos_int(100)};
     test_quantized_binary_op(false, true, op_name, tensor_shape, tensor_shape);
   }
 }
@@ -2026,35 +2100,37 @@ void test_quantized_conv2d(
     double w_scale = 0.29,
     double b_scale = 0.19,
     double out_scale = 0.15,
-    int64_t in_zero_point = 11,
-    int64_t w_zero_point = 19,
-    int64_t b_zero_point = 27,
-    int64_t out_zero_point = 10) {
+    int in_zero_point = 11,
+    int w_zero_point = 19,
+    int b_zero_point = 27,
+    int out_zero_point = 10) {
   c10::InferenceMode mode;
 
   const c10::ScalarType in_dtype = c10::ScalarType::QUInt8;
   const c10::ScalarType out_dtype = c10::ScalarType::QUInt8;
 
   // input cpu
-  at::Tensor input_cpu;         // input cpu tensor
-  at::Tensor input_cpu_q;       // input cpu tensor -> quantized
-  at::Tensor input_cpu_deq;     // input cpu tensor -> quantized -> dequantized
+  at::Tensor input_cpu; // input cpu tensor
+  at::Tensor input_cpu_q; // input cpu tensor -> quantized
+  at::Tensor input_cpu_deq; // input cpu tensor -> quantized -> dequantized
 
   // input vulkan
-  at::Tensor input_vk;          // input cpu tensor -> to vulkan
-  at::Tensor input_vk_q;        // input cpu tensor -> to vulkan -> quantized
-  at::Tensor input_vk_deq;      // input cpu tensor -> to vulkan -> quantized -> dequantized
-  at::Tensor input_vk_deq_cpu;  // input cpu tensor -> to vulkan -> quantized -> dequantized -> to cpu
+  at::Tensor input_vk; // input cpu tensor -> to vulkan
+  at::Tensor input_vk_q; // input cpu tensor -> to vulkan -> quantized
+  at::Tensor
+      input_vk_deq; // input cpu tensor -> to vulkan -> quantized -> dequantized
+  at::Tensor input_vk_deq_cpu; // input cpu tensor -> to vulkan -> quantized ->
+                               // dequantized -> to cpu
 
   // weight cpu
-  at::Tensor weight_cpu;        // weight cpu tensor
-  at::Tensor weight_cpu_q;      // weight cpu tensor -> quantized
-  at::Tensor weight_cpu_deq;    // weight cpu tensor -> quantized -> dequantized
+  at::Tensor weight_cpu; // weight cpu tensor
+  at::Tensor weight_cpu_q; // weight cpu tensor -> quantized
+  at::Tensor weight_cpu_deq; // weight cpu tensor -> quantized -> dequantized
 
   // bias cpu
-  at::Tensor bias_cpu;          // bias cpu tensor
-  at::Tensor bias_cpu_q;        // bias cpu tensor -> quantized
-  at::Tensor bias_cpu_deq;      // bias cpu tensor -> quantized -> dequantized
+  at::Tensor bias_cpu; // bias cpu tensor
+  at::Tensor bias_cpu_q; // bias cpu tensor -> quantized
+  at::Tensor bias_cpu_deq; // bias cpu tensor -> quantized -> dequantized
 
   // When we randomly generate the input tensor, we might get unlucky
   // and one of the entries might be generated such that when it is divided
@@ -2063,7 +2139,8 @@ void test_quantized_conv2d(
   // Because of that possibility, we generate the input and check the
   // difference between input_cpu_deq and input_vk_deq_cpu
   // If they are different we regenerated them again (up to 3 times)
-  // The goal is to start with input tensors that remain equal after quantization.
+  // The goal is to start with input tensors that remain equal after
+  // quantization.
   int num_attempts = 5;
   for (int i = 0; i < num_attempts; i += 1) {
     // produce random input, weight and bias
@@ -2085,15 +2162,16 @@ void test_quantized_conv2d(
       const auto input_min = input_cpu.min().item<float>();
       const auto input_range = input_max - input_min;
 
-      bias_cpu = input_range * at::rand(bias_shape, at::device(at::kCPU).dtype(at::kFloat)) + input_min;
+      bias_cpu = input_range *
+              at::rand(bias_shape, at::device(at::kCPU).dtype(at::kFloat)) +
+          input_min;
       b_scale = in_scale;
       b_zero_point = in_zero_point;
       if (b_dtype == c10::ScalarType::QInt32) {
         b_scale = in_scale * w_scale;
         b_zero_point = 0;
       }
-    }
-    else if (random_quantization_params) {
+    } else if (random_quantization_params) {
       // produce random scale and zero point for inputs
       in_scale = produce_random_scale();
       in_zero_point = produce_random_zero_point(in_dtype);
@@ -2106,12 +2184,12 @@ void test_quantized_conv2d(
     }
 
     // quantize cpu input, weight and bias
-    input_cpu_q = at::quantize_per_tensor(
-        input_cpu, in_scale, in_zero_point, in_dtype);
-    weight_cpu_q = at::quantize_per_tensor(
-        weight_cpu, w_scale, w_zero_point, w_dtype);
-    bias_cpu_q = at::quantize_per_tensor(
-        bias_cpu, b_scale, b_zero_point, b_dtype);
+    input_cpu_q =
+        at::quantize_per_tensor(input_cpu, in_scale, in_zero_point, in_dtype);
+    weight_cpu_q =
+        at::quantize_per_tensor(weight_cpu, w_scale, w_zero_point, w_dtype);
+    bias_cpu_q =
+        at::quantize_per_tensor(bias_cpu, b_scale, b_zero_point, b_dtype);
 
     // dequantize quantized cpu input, weight and bias
     input_cpu_deq = at::dequantize(input_cpu_q);
@@ -2120,16 +2198,17 @@ void test_quantized_conv2d(
 
     // vulkan quantized input
     input_vk = input_cpu.vulkan();
-    input_vk_q = at::quantize_per_tensor(
-        input_vk, in_scale, in_zero_point, in_dtype);
+    input_vk_q =
+        at::quantize_per_tensor(input_vk, in_scale, in_zero_point, in_dtype);
 
     // dequantize quantized vulkan input
     input_vk_deq = at::dequantize(input_vk_q);
     input_vk_deq_cpu = input_vk_deq.cpu();
 
-    const float input_dif = at::abs(input_cpu_deq - input_vk_deq_cpu).max().item<float>();
+    const float input_dif =
+        at::abs(input_cpu_deq - input_vk_deq_cpu).max().item<float>();
 
-    if (input_dif < 1e-5 && input_dif < in_scale/2) {
+    if (input_dif < 1e-5 && input_dif < in_scale / 2) {
       break;
     } else {
       std::cout << "input_dif too big: " << input_dif;
@@ -2142,10 +2221,16 @@ void test_quantized_conv2d(
   }
 
   // conv2d on dequantized cpu tensors
-  // Note: we apply the convolution to the dequantized quantized tensors, that way
-  // we are performing the operations on the same numeric values.
+  // Note: we apply the convolution to the dequantized quantized tensors, that
+  // way we are performing the operations on the same numeric values.
   const auto output_cpu = at::conv2d(
-      input_cpu_deq, weight_cpu_deq, bias_cpu_deq, stride, padding, dilation, groups);
+      input_cpu_deq,
+      weight_cpu_deq,
+      bias_cpu_deq,
+      stride,
+      padding,
+      dilation,
+      groups);
 
   if (compute_quantization_params || random_quantization_params) {
     // compute appropiate scale and zero point for output
@@ -2155,8 +2240,8 @@ void test_quantized_conv2d(
   }
 
   // quantize and dequantize cpu output
-  at::Tensor output_cpu_q = at::quantize_per_tensor(
-      output_cpu, out_scale, out_zero_point, out_dtype);
+  at::Tensor output_cpu_q =
+      at::quantize_per_tensor(output_cpu, out_scale, out_zero_point, out_dtype);
   at::Tensor output_cpu_deq = at::dequantize(output_cpu_q);
 
   // vulkan quantized output
@@ -2165,19 +2250,35 @@ void test_quantized_conv2d(
   if (!prepacking) {
     // vulkan quantized conv2d
     output_vk_q = at::native::vulkan::ops::quantized_conv2d(
-        input_vk_q, weight_cpu_q, bias_cpu_q,
-        stride, padding, dilation, groups,
-        out_scale, out_zero_point);
+        input_vk_q,
+        weight_cpu_q,
+        bias_cpu_q,
+        stride,
+        padding,
+        dilation,
+        groups,
+        out_scale,
+        out_zero_point);
   } else {
     // vulkan quantized conv2d call by name
     const auto prepack_vulkan_call_by_name = callOpByName(
         "vulkan_prepack::create_qconv2d_context",
         "",
-        weight_cpu_q, bias_cpu_q, stride, padding, dilation, groups, c10::nullopt, c10::nullopt);
+        weight_cpu_q,
+        bias_cpu_q,
+        stride,
+        padding,
+        dilation,
+        groups,
+        c10::nullopt,
+        c10::nullopt);
     const auto vulkan_output = callOpByName(
         "vulkan_prepack::run_qconv2d_context",
         "",
-        input_vk_q, out_scale, out_zero_point, prepack_vulkan_call_by_name[0]);
+        input_vk_q,
+        out_scale,
+        out_zero_point,
+        prepack_vulkan_call_by_name[0]);
     output_vk_q = vulkan_output[0].toTensor();
   }
 
@@ -2186,11 +2287,12 @@ void test_quantized_conv2d(
   const auto output_vk_deq_cpu = output_vk_deq.cpu();
 
   // check
-  const float tolerance = out_scale;
+  const float tolerance = safe_downcast<float>(out_scale);
   const auto check = almostEqual(output_cpu_deq, output_vk_deq_cpu, tolerance);
 
   if (!check) {
-    const auto vk_q_error = at::abs(output_vk_deq_cpu - output_cpu_deq).max().item<float>();
+    const auto vk_q_error =
+        at::abs(output_vk_deq_cpu - output_cpu_deq).max().item<float>();
     std::cout << "Quantized Conv2d failed with: " << std::endl;
     std::cout << "input: shape " << input_shape << " scale " << in_scale
               << " and zero point " << in_zero_point << std::endl;
@@ -2198,8 +2300,8 @@ void test_quantized_conv2d(
               << " and zero point " << w_zero_point << std::endl;
     std::cout << "bias: shape " << bias_shape << " scale " << b_scale
               << " and zero point " << b_zero_point << std::endl;
-    std::cout << "output scale " << out_scale
-              << " and zero point " << out_zero_point << std::endl;
+    std::cout << "output scale " << out_scale << " and zero point "
+              << out_zero_point << std::endl;
     std::cout << "error: " << vk_q_error << std::endl;
   }
   ASSERT_TRUE(check);
@@ -2207,614 +2309,578 @@ void test_quantized_conv2d(
 
 TEST_F(VulkanAPITest, conv2d_quantized_fixed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_computed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_random_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_prepack_fixed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_prepack_computed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_prepack_random_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_fixed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_computed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ false,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_random_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_prepack_fixed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_prepack_computed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ true,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_prepack_random_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_fixed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_computed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_random_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_prepack_fixed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_prepack_computed_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_prepack_random_params_uint8) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QUInt8,
-    /* bias_dtype */    c10::ScalarType::QUInt8,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QUInt8,
+      /* bias_dtype */ c10::ScalarType::QUInt8,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_fixed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_computed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_random_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_prepack_fixed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_prepack_computed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_quantized_prepack_random_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 3, 8, 8},
-    /* weight_shape */  {1, 3, 3, 3},
-    /* bias_shape */    {1},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 2},
-    /* padding */       {1, 1},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 3, 8, 8},
+      /* weight_shape */ {1, 3, 3, 3},
+      /* bias_shape */ {1},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 2},
+      /* padding */ {1, 1},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_fixed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_computed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ false,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_random_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_prepack_fixed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_prepack_computed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ true,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_dw_quantized_prepack_random_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 7, 137, 199},
-    /* weight_shape */  {7, 1, 17, 7},
-    /* bias_shape */    {7},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {2, 3},
-    /* padding */       {0, 4},
-    /* dilation */      {3, 1},
-    /* groups */        7
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 7, 137, 199},
+      /* weight_shape */ {7, 1, 17, 7},
+      /* bias_shape */ {7},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {2, 3},
+      /* padding */ {0, 4},
+      /* dilation */ {3, 1},
+      /* groups */ 7);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_fixed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_computed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_random_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   false,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ false,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_prepack_fixed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ false,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ false,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_prepack_computed_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */true,
-    /* random params */ false,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ true,
+      /* random params */ false,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 TEST_F(VulkanAPITest, conv2d_pw_quantized_prepack_random_params_int8_int32) {
   test_quantized_conv2d(
-    /* prepacking? */   true,
-    /* compute params */false,
-    /* random params */ true,
-    /* input_shape */   {1, 17, 127, 397},
-    /* weight_shape */  {29, 17, 1, 1},
-    /* bias_shape */    {29},
-    /* weight_dtype */  c10::ScalarType::QInt8,
-    /* bias_dtype */    c10::ScalarType::QInt32,
-    /* stride */        {1, 1},
-    /* padding */       {0, 0},
-    /* dilation */      {1, 1},
-    /* groups */        1
-  );
+      /* prepacking? */ true,
+      /* compute params */ false,
+      /* random params */ true,
+      /* input_shape */ {1, 17, 127, 397},
+      /* weight_shape */ {29, 17, 1, 1},
+      /* bias_shape */ {29},
+      /* weight_dtype */ c10::ScalarType::QInt8,
+      /* bias_dtype */ c10::ScalarType::QInt32,
+      /* stride */ {1, 1},
+      /* padding */ {0, 0},
+      /* dilation */ {1, 1},
+      /* groups */ 1);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Fixes many static analysis and linter issues present in vulkan_quantized_api_test.cpp.
Replaces C-style rand function by Cpp rand functions.

Test Plan:
```
buck run --target-platforms ovr_config//platform/macos:arm64-fbsource -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64
```

Differential Revision: D44315235

