### PR TITLE
backport std::ssize to c10

### DIFF
--- a/c10/test/build.bzl
+++ b/c10/test/build.bzl
@@ -39,7 +39,10 @@ def define_targets(rules):
         name = "util_base_tests",
         srcs = rules.glob(
             ["util/*.cpp"],
-            exclude = ["util/typeid_test.cpp"],
+            exclude = [
+                "util/ssize_test.cpp",
+                "util/typeid_test.cpp",
+            ],
         ),
         copts = ["-Wno-deprecated-declarations"],
         deps = [
@@ -49,6 +52,15 @@ def define_targets(rules):
             "@com_google_googletest//:gtest_main",
             "//c10/macros:macros",
             "//c10/util:base",
+        ],
+    )
+
+    rules.cc_test(
+        name = "util/ssize_test",
+        srcs = ["util/ssize_test.cpp"],
+        deps = [
+            "@com_google_googletest//:gtest_main",
+            "//c10/util:ssize",
         ],
     )
 

--- a/c10/test/util/ssize_test.cpp
+++ b/c10/test/util/ssize_test.cpp
@@ -1,0 +1,59 @@
+#include <c10/util/ssize.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+
+namespace c10 {
+namespace {
+
+template <typename size_type_>
+class Container {
+ public:
+  using size_type = size_type_;
+
+  constexpr explicit Container(size_type size) : size_(size) {}
+
+  constexpr auto size() const noexcept -> size_type {
+    return size_;
+  }
+
+ private:
+  size_type size_;
+};
+
+TEST(ssize_test, size_t) {
+  ASSERT_THAT(ssize(Container(std::size_t{3})), testing::Eq(std::ptrdiff_t{3}));
+}
+
+TEST(ssize_test, size_t_overflow) {
+#if defined(NDEBUG)
+  GTEST_SKIP() << "Only valid if assert is enabled." << std::endl;
+#endif
+
+  constexpr auto ptrdiff_t_max =
+      std::size_t{std::numeric_limits<std::ptrdiff_t>::max()};
+  static_assert(ptrdiff_t_max < std::numeric_limits<std::size_t>::max());
+  EXPECT_THROW(ssize(Container(ptrdiff_t_max + 1)), c10::Error);
+}
+
+TEST(ssize_test, small_container_promotes_to_ptrdiff_t) {
+  auto signed_size = ssize(Container(std::uint16_t{3}));
+  static_assert(std::is_same_v<decltype(signed_size), std::ptrdiff_t>);
+  ASSERT_THAT(signed_size, testing::Eq(3));
+}
+
+TEST(ssize_test, promotes_to_64_bit_on_32_bit_platform) {
+  if (sizeof(std::intptr_t) != 4) {
+    GTEST_SKIP() << "Only valid in 64-bits." << std::endl;
+  }
+
+  auto signed_size = ssize(Container(std::uint64_t{3}));
+  static_assert(std::is_same_v<decltype(signed_size), std::int64_t>);
+  ASSERT_THAT(signed_size, testing::Eq(3));
+}
+
+} // namespace
+} // namespace c10

--- a/c10/util/build.bzl
+++ b/c10/util/build.bzl
@@ -48,6 +48,14 @@ def define_targets(rules):
     )
 
     rules.cc_library(
+        name = "ssize",
+        hdrs = ["ssize.h"],
+        linkstatic = True,
+        visibility = ["//:__subpackages__"],
+        deps = [":base"],
+    )
+
+    rules.cc_library(
         name = "typeid",
         srcs = ["typeid.cpp"],
         hdrs = ["typeid.h"],
@@ -66,6 +74,7 @@ def define_targets(rules):
         srcs = rules.glob(
             ["*.h"],
             exclude = [
+                "ssize.h",
             ],
         ),
         visibility = ["//c10:__pkg__", "//:__pkg__"],

--- a/c10/util/ssize.h
+++ b/c10/util/ssize.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <c10/util/Exception.h>
+#include <c10/util/TypeSafeSignMath.h>
+
+#include <cstddef>
+#include <type_traits>
+
+namespace c10 {
+
+// Implementations of std::ssize() from C++ 20.
+//
+// This is useful in particular for avoiding -Werror=sign-compare
+// issues.
+//
+// Use this with argument-dependent lookup, e.g.:
+// use c10::ssize;
+// auto size = ssize(container);
+//
+// As with the standard library version, containers are permitted to
+// specialize this with a free function defined in the same namespace.
+//
+// See https://en.cppreference.com/w/cpp/iterator/size for more
+// information as well as the source of our implementations.
+//
+// We augment the implementation by adding an assert() if an overflow
+// would occur.
+
+template <typename C>
+constexpr auto ssize(const C& c) -> std::
+    common_type_t<std::ptrdiff_t, std::make_signed_t<decltype(c.size())>> {
+  using R = std::
+      common_type_t<std::ptrdiff_t, std::make_signed_t<decltype(c.size())>>;
+  // We expect this to be exceedingly rare to fire and don't wish to
+  // pay a performance hit in release mode.
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!greater_than_max<R>(c.size()));
+  return static_cast<R>(c.size());
+}
+
+template <typename T, std::ptrdiff_t N>
+constexpr auto ssize(const T (&array)[N]) noexcept -> std::ptrdiff_t {
+  return N;
+}
+
+} // namespace c10


### PR DESCRIPTION
backport std::ssize to c10

Summary:
Now that we have -Werror=sign-compare enabled, we encounter a lot of
friction comparing standard containers and our tensors which are
signed.

std::ssize will make it easier and safer to succinctly convert
container sizes to a signed type.

Test Plan: Added a unit test.

Reviewers: ezyang

Subscribers:

Tasks:

Tags:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/97442).
* #97443
* __->__ #97442