### PR TITLE
Implement last dim split_with_sizes for NT (forward only, non-SymInt-ified)

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5197,6 +5197,7 @@
   device_guard: False
   dispatch:
     CompositeExplicitAutograd: split_with_sizes
+    NestedTensorCPU, NestedTensorCUDA: split_with_sizes_nested
 
 - func: hsplit.int(Tensor(a -> *) self, int sections) -> Tensor(a)[]
   variants: function, method

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -75,25 +75,45 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
   dim = maybe_wrap_dim(dim, ndim);
   TORCH_CHECK(self.dim() - 1 == dim,
            "Chunk for nested tensors is currently only supported for the last dimension.");
-  TORCH_CHECK(chunks > 0, "chunk expects `chunks` to be greater than 0, got: ", chunks);
+  TORCH_CHECK(chunks > 0,"chunk expects `chunks` to be greater than 0, got: ", chunks);
   TORCH_CHECK(self.is_contiguous(), "chunk expects `self` to be contiguous.");
   auto self_impl = get_nested_tensor_impl(self);
   const int64_t last_dim_size = get_consistent_last_dim_of_nested_tensor(*self_impl);
     TORCH_CHECK(last_dim_size % chunks == 0,
            "Chunk for nested tensors is only supported for nested tensors with trailing dimension divisible by chunks, got: ",
            last_dim_size, " % ", chunks, " != 0");
-
-  // logic handled by split_with_sizes
+  int64_t n_tensors = self.size(0);
   int64_t split_size = last_dim_size / chunks;
-  std::vector<int64_t> split_sizes(chunks, split_size);
-  return split_with_sizes_nested(self, split_sizes, dim);
+  std::vector<Tensor> splits(chunks);
+  const auto& sizes = self_impl->get_nested_sizes();
+  const auto& strides = self_impl->get_nested_strides();
+  const auto offsets = self_impl->get_storage_offsets();
+  int64_t *offsets_ptr = offsets.data_ptr<int64_t>();
+  // Account for the implicit batch dim
+  --dim;
+  int64_t tensor_dim = sizes.size(1);
+  for (const auto split_idx : c10::irange(chunks)) {
+      auto new_sizes = sizes.clone() ;
+      auto new_strides = strides.clone();
+      // This copys offsets so we are safe to move
+      auto new_offsets = offsets.clone();
+      int64_t *size_ptr = new_sizes.data_ptr<int64_t>();
+      // Get start val for each split
+      int64_t start_val = split_idx * split_size;
+      for (int64_t i : c10::irange(n_tensors)) {
+        const int64_t index = i * tensor_dim + dim;
+        new_offsets[i] = offsets_ptr[i] + start_val;
+        size_ptr[index] = split_size;
+    }
+    splits[split_idx] = create_nested_view_tensor(self, new_sizes, new_strides, new_offsets);
+  }
+  return splits;
 }
 
 std::vector<Tensor> split_with_sizes_nested(
     const Tensor& self,
     c10::IntArrayRef split_sizes,
     int64_t dim) {
-  std::vector<Tensor> blah;
   int64_t ndim = self.dim();
   if (ndim == 0) {
     TORCH_CHECK_INDEX(false, "split_with_sizes() cannot be applied to a 0-dim tensor.");

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -940,6 +940,8 @@ class TestNestedTensorDeviceType(TestCase):
         self.assertRaisesRegex(
             RuntimeError, "split_with_sizes for nested tensors is currently only supported for the last dimension.",
             lambda: torch.split_with_sizes(nt, split_sizes, dim=1))
+
+        # Failure calling on non-last dimension
         self.assertRaisesRegex(
             RuntimeError, "split_with_sizes for nested tensors is currently only supported for the last dimension.",
             lambda: torch.split_with_sizes(nt, split_sizes, dim=0))

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1493,8 +1493,12 @@
   result: auto_linear
 
 - name: split_with_sizes(Tensor(a -> *) self, SymInt[] split_sizes, int dim=0) -> Tensor(a)[]
-  self: split_with_sizes_backward(grads, split_sizes, dim, self.sym_sizes(), self.options())
-  result: auto_linear
+  dispatch:
+    Default:
+      self: split_with_sizes_backward(grads, split_sizes, dim, self.sym_sizes(), self.options())
+      result: auto_linear
+    AutogradNestedTensor:
+      self: _nested_split_with_sizes_backward(grads, split_sizes, dim, self)
 
 - name: unsafe_split_with_sizes(Tensor self, SymInt[] split_sizes, int dim=0) -> Tensor[]
   self: split_with_sizes_backward(grads, split_sizes, dim, self.sym_sizes(), self.options())

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1873,6 +1873,14 @@ Tensor split_with_sizes_backward(
   return ret;
 }
 
+Tensor _nested_split_with_sizes_backward(
+    const std::vector<torch::autograd::Variable>& grads,
+    c10::SymIntArrayRef split_sizes,
+    int64_t dim,
+    const Tensor& self) {
+  return not_implemented("aten::split_with_sizes");
+}
+
 Tensor split_backward(
     const std::vector<torch::autograd::Variable>& grads,
     c10::SymInt split_size,

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -387,6 +387,11 @@ at::Tensor split_with_sizes_backward(
     int64_t dim,
     c10::SymIntArrayRef sizes,
     const at::TensorOptions& options);
+at::Tensor _nested_split_with_sizes_backward(
+    const std::vector<torch::autograd::Variable>& grads,
+    c10::SymIntArrayRef split_sizes,
+    int64_t dim,
+    const Tensor& self);
 at::Tensor split_backward(
     const std::vector<torch::autograd::Variable>& grads,
     c10::SymInt split_size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97446

This is needed for the HSTU model.

Details:
* ~~NT `chunk` now calls into NT `split_with_sizes` since the latter is more general~~ (removed; they're totally separate)
* Throws for backward
* Only operates over the last dim (`dim=-1`)

cc @cpuhrsch @bhosmer @drisspg