### PR TITLE
Disable inductor developer warnings in official releases

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -102,7 +102,8 @@ def is_fbcode():
 
 
 # warnings intended for PyTorch developers, disable for point releases
-developer_warnings = is_fbcode() or "dev" in torch.__version__
+is_nightly_or_source = "dev" in torch.__version__ or "git" in torch.__version__
+developer_warnings = is_fbcode() or is_nightly_or_source
 
 
 def decide_compile_threads():

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -102,7 +102,7 @@ def is_fbcode():
 
 
 # warnings intended for PyTorch developers, disable for point releases
-developer_warnings = is_fbcode() or "+" in torch.__version__
+developer_warnings = is_fbcode() or "dev" in torch.__version__
 
 
 def decide_compile_threads():


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/97449

We shouldn't match on: torch             2.0.0+cu118
We should match on: torch             2.1.0.dev20230323+cu118
We should match on: torch              2.1.0a0+git63e1f12


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire