### PR TITLE
Include missing header

### DIFF
--- a/torch/csrc/lazy/core/multi_wait.h
+++ b/torch/csrc/lazy/core/multi_wait.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <condition_variable>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
`std::exception_ptr` is defined in `<exception>`. This works in the past because the header is transitively included by other headers. The situation has changed in most recent llvm (https://github.com/llvm/llvm-project/commit/c9d36bd80760db14f14b33789e6cbc6cb8c64830)
