### PR TITLE
Add GPU frequency lock option to inductor workflows running on A100

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -93,6 +93,13 @@ jobs:
         uses: pytorch/test-infra/.github/actions/setup-nvidia@main
         if: contains(inputs.build-environment, 'cuda') && !contains(matrix.config, 'nogpu')
 
+      - name: Lock NVIDIA A100 40GB Frequency
+        run: |
+          sudo nvidia-smi -pm 1
+          sudo nvidia-smi -ac 1215,1410
+          nvidia-smi
+        if: contains(matrix.runner, 'a100')
+
       - name: Start monitoring script
         id: monitor-script
         shell: bash


### PR DESCRIPTION
Fixes #97459 
