### PR TITLE
[Vulkan] Merge upsample_nearest2d and quantized_upsample_nearest2d

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Upsample.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Upsample.cpp
@@ -32,12 +32,17 @@ Tensor upsample_nearest2d(
           output_sizes[Layout::Parameter::height],
           output_sizes[Layout::Parameter::width],
       },
-      input_arg.scalar_type(),
-  };
+      input_arg.scalar_type()};
+
+  if (v_input.is_quantized()) {
+    v_output.set_is_quantized();
+    v_output.set_scale(v_input.get_scale());
+    v_output.set_zero_point(v_input.get_zero_point());
+  }
 
   const struct Block final {
     uvec3 extents;
-    uint32_t _;
+    uint32_t fill0;
     ivec2 iextents;
     vec2 scale;
   } block{
@@ -66,87 +71,8 @@ Tensor upsample_nearest2d(
 
   context->submit_compute_job(
       // shader descriptor
-      VK_KERNEL(upsample_nearest2d),
-      // pipeline barrier
-      pipeline_barrier,
-      // global work group size
-      v_output.extents(),
-      // local work group size
-      adaptive_work_group_size(v_output.extents()),
-      // fence handle
-      VK_NULL_HANDLE,
-      // shader arguments
-      v_output.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE,
-          api::MemoryAccessType::WRITE),
-      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
-      // params buffer
-      params.buffer());
-
-  return convert(v_output);
-}
-
-Tensor quantized_upsample_nearest2d(
-    const Tensor& input_arg,
-    const IntArrayRef output_sizes,
-    const c10::optional<double> scales_h,
-    const c10::optional<double> scales_w) {
-  api::Context* const context = api::context();
-
-  TORCH_CHECK(
-      (4 == input_arg.sizes().size()) && (2 == output_sizes.size()),
-      "Invalid input!");
-
-  const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
-  const vTensor& v_input = convert(input);
-  const auto v_input_sizes = v_input.sizes();
-
-  vTensor v_output{
-      context,
-      {
-          v_input_sizes[Layout::Activation4D::batch],
-          v_input_sizes[Layout::Activation4D::channels],
-          output_sizes[Layout::Parameter::height],
-          output_sizes[Layout::Parameter::width],
-      },
-      v_input.get_scale(),
-      v_input.get_zero_point(),
-      input_arg.scalar_type(),
-  };
-
-  const struct Block final {
-    uvec3 extents;
-    uint32_t _;
-    ivec2 iextents;
-    vec2 scale;
-  } block{
-      v_output.extents(),
-      0u,
-      {
-          safe_downcast<int32_t>(
-              input_arg.size(Layout::Activation4D::width) - 1),
-          safe_downcast<int32_t>(
-              input_arg.size(Layout::Activation4D::height) - 1),
-      },
-      {
-          compute_scales_value<float>(
-              scales_w,
-              v_input_sizes[Layout::Activation4D::width],
-              output_sizes[Layout::Parameter::width]),
-          compute_scales_value<float>(
-              scales_h,
-              v_input_sizes[Layout::Activation4D::height],
-              output_sizes[Layout::Parameter::height]),
-      },
-  };
-
-  api::UniformParamsBuffer params(context, block);
-  api::PipelineBarrier pipeline_barrier{};
-
-  context->submit_compute_job(
-      // shader descriptor
-      VK_KERNEL(quantized_upsample_nearest2d),
+      v_input.is_quantized() ? VK_KERNEL(quantized_upsample_nearest2d)
+                             : VK_KERNEL(upsample_nearest2d),
       // pipeline barrier
       pipeline_barrier,
       // global work group size

--- a/aten/src/ATen/test/vulkan_quantized_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_quantized_api_test.cpp
@@ -1749,9 +1749,7 @@ TEST_F(VulkanAPITest, quantized_upsample_nearest2d) {
   const auto in_vulkan = in_cpu.vulkan();
   const auto out_vulkan = at::native::vulkan::ops::quantize_per_tensor(
       in_vulkan, scale, zero_point, c10::ScalarType::QUInt8);
-  const auto upsample_vulkan =
-      at::native::vulkan::ops::quantized_upsample_nearest2d(
-          out_vulkan, {4, 6}, 1, 1);
+  const auto upsample_vulkan = at::upsample_nearest2d(out_vulkan, {4, 6}, 1, 1);
 
   const auto in_cpu2 =
       at::rand({2, 13, 4, 6}, at::TensorOptions(at::kCPU).dtype(at::kFloat));


### PR DESCRIPTION
Summary: Merging quantized_upsample_nearest2d into upsample_nearest2d. Therefore, at::upsample_nearest2d can handle quantized vulkan input tensors.

Test Plan:
On Mac
```
cd ~/fbsource
buck1 run -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64
```

On Android
```
cd ~/fbsource
buck1 build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_quantized_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_quantized_api_test
adb shell "/data/local/tmp/vulkan_quantized_api_test"
```

Reviewed By: SS-JIA

Differential Revision: D44118212

