### PR TITLE
Per Channel in brack-propagation function

### DIFF
--- a/torch/csrc/quantized/quantized_backward.cpp
+++ b/torch/csrc/quantized/quantized_backward.cpp
@@ -1,4 +1,5 @@
 #include <ATen/native/quantized/PackedParams.h>
+#include <ATen/native/quantized/cpu/QuantUtils.h>
 #include <torch/library.h>
 #include <torch/torch.h>
 
@@ -31,24 +32,107 @@ class PackedLinearWeightDynamicBackward
                 bool)>();
     auto output = op.redispatch(
         DispatchKeySet({DispatchKey::CPU}), input, packed_weight, reduce_range);
+    auto input_contig = input.contiguous();
+    // Calculate statistics for quantization of input Tensor
+    float x_min = 0;
+    float x_max = 0;
+    if (input.numel() > 0) {
+      x_min = input_contig.min().item<float>();
+      x_max = input_contig.max().item<float>();
+    }
+    auto q_params = quant_utils::ChooseQuantizationParams(
+        /*min=*/x_min,
+        /*max=*/x_max,
+        /*qmin=*/0,
+        /*qmax=*/255);
     ctx->saved_data["weight"] = packed_weight;
+    // q_params.scale : shape [1] (per-tensor)
+    ctx->saved_data["input_scale"] = q_params.scale;
     return output;
   }
 
   static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+    if (grad_outputs.empty()) {
+      return {torch::Tensor(), torch::Tensor(), torch::Tensor()};
+    }
     auto packed_weight =
         ctx->saved_data["weight"].toCustomClass<LinearPackedParamsBase>();
     auto unpacked_parameters = packed_weight->unpack();
     auto original_weight = std::get<0>(unpacked_parameters);
-    original_weight = at::permute(original_weight, {1, 0});
-    auto grad_output = grad_outputs[0];
+    auto input_scale = ctx->saved_data["input_scale"].toDouble();
+
+    // Gradient for post-scaling
+    // Let us rewrite this layer by separating the matmul from the output
+    // scaling: y = (x * s1) @ w * s2 + b So you now back-propagate through four
+    // operations: + b, * s2, @ W, and * s1. The steps are: start with the
+    // gradient from the top, aka the adjoint, which is grad_outputs[0].
+    // gradient for  + b: this is a no-op.
+    // gradient for * s2: scale by s2. That's the affine/per-channel scale baked
+    // into W. gradient for @ W: matmul with W.t. gradient for * s1: scale by
+    // s1.
+    auto grad_output0 = grad_outputs[0];
+    const auto qtype = original_weight.qscheme();
+    if (qtype == at::kPerTensorAffine) {
+      grad_output0 *= original_weight.q_scale();
+      original_weight = at::permute(original_weight, {1, 0});
+    } else if (qtype == at::kPerChannelAffine) {
+      // Per Channel quantizer does not support transpose.
+      // Manual transpose is necessary
+      original_weight = original_weight.dequantize();
+#if 1
+      // Enable Kernel backend for quantized backpropagaiton matrix
+      // multiplication
+      original_weight = at::permute(original_weight, {1, 0});
+      // Take advantage of QNNPACK for matrix multiplication
+      // Per channel scales & zero point computation
+      // Sources :
+      // https://github.com/pytorch/pytorch/blob/master/torch/ao/quantization/observer.py#L350-L353
+      auto [amin, amax] = at::aminmax(original_weight, /*dim* = */ 1);
+      // QInt8 type signed quantization
+      auto qmax = 127;
+      auto qmin = -128;
+      // Clamp with some epsilon number, so that value does not go below zero
+      auto epsilon = 1e-9;
+      auto new_scales = (amax - amin) / float(qmax - qmin);
+      new_scales = at::clamp(new_scales, epsilon);
+      auto new_zero_point =
+          qmin - at::round(amin / new_scales).toType(c10::kInt);
+      new_zero_point = at::clamp(new_zero_point, qmin, qmax);
+      // TO-DO (BUGBUG)
+      // Backend kernel is designed for inference, tightly coded for output
+      // channel. For mathematical correctness, we should enable to run kernel
+      // with input channel axis after transpose. As workaround, we are simply
+      // either exploring per tensor quantization or per channel quantization
+      // with axis = 0
+      original_weight = at::quantize_per_channel(
+          original_weight,
+          new_scales,
+          new_zero_point,
+          /*axis = 1 for transpose, but we are forcing it to non-transposed case
+             due to above issue*/
+          0,
+          c10::kQInt8);
+#endif
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "Unsupported quantization scheme.");
+    }
+#if 0
+    // Pure FP32 computation, useful for debugging purpose
+    auto dLdX1 = torch::matmul(grad_output0, original_weight);
+#else
+    // Take advantage of QNNPACK for matrix multiplication
     static auto op = at::Dispatcher::singleton()
                          .findSchemaOrThrow("quantized::linear_prepack", "")
                          .typed<c10::intrusive_ptr<LinearPackedParamsBase>(
                              at::Tensor, c10::optional<at::Tensor>)>();
     auto prepacked_weight = op.call(original_weight, nullopt);
-    auto grad_input = prepacked_weight->apply_dynamic(grad_output);
-    return {grad_input, torch::Tensor(), torch::Tensor()};
+
+    auto dLdX1 =
+        prepacked_weight->apply_dynamic(grad_output0.toType(c10::kFloat));
+#endif
+
+    auto input_grad0 = dLdX1 * input_scale;
+    return {input_grad0, torch::Tensor(), torch::Tensor()};
   }
 };
 


### PR DESCRIPTION
Summary:
Supporting Per Channel quantization in the gradient computation function.

One workaround that I have added here is
Current QNNPACK is not designed to process [transposed weight](https://fb.workplace.com/groups/pytorch.edge.users/permalink/1283737025829921/)
Here we are simply replacing Per Channel to Per Tensor to compute a gradient (Some slow learning curve or WER degradation might be expected - We don't know, nothing is guaranteed)

Test Plan:
You can create your own synthetic model,
FP32 layer -> INT8 layer with Per Channel and see if loss is decreasing

Differential Revision: D43898794



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10