### PR TITLE
distinguish mutability of StorageImpl::unsafe_data

### DIFF
--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -97,7 +97,7 @@ void resize_bytes_cpu(StorageImpl* storage, size_t size_bytes) {
   storage->set_nbytes(size_bytes);
   const auto copy_capacity = std::min(size_bytes, old_capacity);
   if (old_data != nullptr && copy_capacity > 0) {
-    memcpy(storage->data(), old_data.get(), copy_capacity);
+    memcpy(storage->mutable_data(), old_data.get(), copy_capacity);
   }
 }
 

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -67,7 +67,7 @@ struct C10_API Storage {
 
   template <typename T>
   T* unsafe_data() const {
-    return storage_impl_->unsafe_data<T>();
+    return storage_impl_->mutable_unsafe_data<T>();
   }
 
   // TODO: remove later

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -93,7 +93,7 @@ struct C10_API Storage {
   // get() use here is to get const-correctness
 
   void* data() const {
-    return storage_impl_.get()->data();
+    return storage_impl_.get()->mutable_data();
   }
 
   at::DataPtr& data_ptr() {

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -139,12 +139,11 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
     data_ptr_ = std::move(data_ptr);
   }
 
-  // TODO: Return const ptr eventually if possible
-  void* data() {
+  void* mutable_data() {
     return data_ptr_.get();
   }
 
-  void* data() const {
+  const void* data() const {
     return data_ptr_.get();
   }
 

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -83,12 +83,17 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
 
   template <typename T>
   inline T* data() const {
-    return unsafe_data<T>();
+    return static_cast<T*>(data_ptr_.get());
   }
 
   template <typename T>
-  inline T* unsafe_data() const {
+  inline T* mutable_unsafe_data() {
     return static_cast<T*>(this->data_ptr_.get());
+  }
+
+  template <typename T>
+  inline const T* unsafe_data() const {
+    return static_cast<const T*>(this->data_ptr_.get());
   }
 
   // Destructor doesn't call release_resources because it's

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -272,7 +272,7 @@ static PyObject* THPStorage_fromBuffer(
       /*resizable=*/true);
 
   if (scalar_type == at::kByte || scalar_type == at::kChar) {
-    memcpy(storage->data(), src + offset, count);
+    memcpy(storage->mutable_data(), src + offset, count);
   } else if (scalar_type == at::kBool) {
     // Because of ASAN checks, that are failing whenever
     // we are trying to get a value which is not 0 or 1, we have to manually


### PR DESCRIPTION
distinguish mutability of StorageImpl::unsafe_data

Summary:
See #97461.

Test Plan: Rely on CI.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/97477).
* #97492
* #97489
* __->__ #97477
* #97461