### PR TITLE
Set number of threads to be 1 for ARM

### DIFF
--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -41,6 +41,8 @@ class C10_API TaskThreadPoolBase {
     auto num_threads = std::thread::hardware_concurrency();
 #if defined(_M_X64) || defined(__x86_64__)
     num_threads /= 2;
+#elif defined(FBCODE_CAFFE2) && defined(__aarch64__) && !defined(C10_MOBILE)
+    num_threads = 1;
 #endif
     return num_threads;
   }


### PR DESCRIPTION
Summary:
In highly multi-threaded environment, using # of threads to be matching hardware_concurrency leads to high contention.
x86 path actually ends up using different path (MKL path), which results in using 1 thread for x86 as well.

Differential Revision: D44353111

