### PR TITLE
[FSDP] Fix bug in determining whether parameters need to be materialized

### DIFF
--- a/torch/distributed/fsdp/_init_utils.py
+++ b/torch/distributed/fsdp/_init_utils.py
@@ -734,7 +734,7 @@ def _need_to_materialize_module(
     be ``True``. If either is ``True``, then ``module`` needs to be
     materialized.
     """
-    managed_params = _get_orig_params(module, ignored_params)
+    managed_params = list(_get_orig_params(module, ignored_params))
     is_meta_module = any(param.is_meta for param in managed_params)
     is_torchdistX_deferred_init = (
         not is_meta_module


### PR DESCRIPTION
Previously, `_need_to_materialize_module` would return false because:

* `managed_params =_get_orig_params(module, ignored_params)` returns a generator
* `is_meta_module = any(param.is_meta for param in managed_params)` exhausts the generator in its check
* `any(fake.is_fake(param) for param in managed_params)` would try to iterate over the empty generator and get an empty sequence, thus returning `False`