### PR TITLE
distinguish mutability of typed StorageImpl::data() member

### DIFF
--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -97,7 +97,7 @@ void resize_bytes_cpu(StorageImpl* storage, size_t size_bytes) {
   storage->set_nbytes(size_bytes);
   const auto copy_capacity = std::min(size_bytes, old_capacity);
   if (old_data != nullptr && copy_capacity > 0) {
-    memcpy(storage->data(), old_data.get(), copy_capacity);
+    memcpy(storage->mutable_data(), old_data.get(), copy_capacity);
   }
 }
 

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -67,7 +67,7 @@ struct C10_API Storage {
 
   template <typename T>
   T* unsafe_data() const {
-    return storage_impl_->unsafe_data<T>();
+    return storage_impl_->mutable_unsafe_data<T>();
   }
 
   // TODO: remove later

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -93,7 +93,7 @@ struct C10_API Storage {
   // get() use here is to get const-correctness
 
   void* data() const {
-    return storage_impl_.get()->data();
+    return storage_impl_.get()->mutable_data();
   }
 
   at::DataPtr& data_ptr() {

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -62,7 +62,7 @@ struct C10_API Storage {
 
   template <typename T>
   T* data() const {
-    return storage_impl_->data<T>();
+    return storage_impl_->mutable_data<T>();
   }
 
   template <typename T>

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -82,8 +82,13 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   }
 
   template <typename T>
-  inline T* data() const {
-    return static_cast<T*>(data_ptr_.get());
+  inline T* mutable_data() {
+    return mutable_unsafe_data<T>();
+  }
+
+  template <typename T>
+  inline const T* data() const {
+    return unsafe_data<T>();
   }
 
   template <typename T>

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -139,12 +139,11 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
     data_ptr_ = std::move(data_ptr);
   }
 
-  // TODO: Return const ptr eventually if possible
-  void* data() {
+  void* mutable_data() {
     return data_ptr_.get();
   }
 
-  void* data() const {
+  const void* data() const {
     return data_ptr_.get();
   }
 

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -83,12 +83,17 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
 
   template <typename T>
   inline T* data() const {
-    return unsafe_data<T>();
+    return static_cast<T*>(data_ptr_.get());
   }
 
   template <typename T>
-  inline T* unsafe_data() const {
+  inline T* mutable_unsafe_data() {
     return static_cast<T*>(this->data_ptr_.get());
+  }
+
+  template <typename T>
+  inline const T* unsafe_data() const {
+    return static_cast<const T*>(this->data_ptr_.get());
   }
 
   // Destructor doesn't call release_resources because it's

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -272,7 +272,7 @@ static PyObject* THPStorage_fromBuffer(
       /*resizable=*/true);
 
   if (scalar_type == at::kByte || scalar_type == at::kChar) {
-    memcpy(storage->data(), src + offset, count);
+    memcpy(storage->mutable_data(), src + offset, count);
   } else if (scalar_type == at::kBool) {
     // Because of ASAN checks, that are failing whenever
     // we are trying to get a value which is not 0 or 1, we have to manually

--- a/torch/csrc/StorageMethods.cpp
+++ b/torch/csrc/StorageMethods.cpp
@@ -278,37 +278,40 @@ static PyObject* THPStorage_fromBuffer(
     // we are trying to get a value which is not 0 or 1, we have to manually
     // convert original values to boolean ones.
     torch::utils::THP_decodeBoolBuffer(
-        storage->data<bool>(), src + offset, do_byte_swap, count);
+        storage->mutable_data<bool>(), src + offset, do_byte_swap, count);
   } else if (scalar_type == at::kShort) {
     torch::utils::THP_decodeInt16Buffer(
-        storage->data<int16_t>(), src + offset, do_byte_swap, count);
+        storage->mutable_data<int16_t>(), src + offset, do_byte_swap, count);
   } else if (scalar_type == at::kInt) {
     torch::utils::THP_decodeInt32Buffer(
-        storage->data<int32_t>(), src + offset, do_byte_swap, count);
+        storage->mutable_data<int32_t>(), src + offset, do_byte_swap, count);
   } else if (scalar_type == at::kLong) {
     torch::utils::THP_decodeInt64Buffer(
-        storage->data<int64_t>(), src + offset, do_byte_swap, count);
+        storage->mutable_data<int64_t>(), src + offset, do_byte_swap, count);
   } else if (scalar_type == at::kHalf) {
     torch::utils::THP_decodeHalfBuffer(
-        storage->data<c10::Half>(), src + offset, do_byte_swap, count);
+        storage->mutable_data<c10::Half>(), src + offset, do_byte_swap, count);
   } else if (scalar_type == at::kBFloat16) {
     torch::utils::THP_decodeBFloat16Buffer(
-        storage->data<c10::BFloat16>(), src + offset, do_byte_swap, count);
+        storage->mutable_data<c10::BFloat16>(),
+        src + offset,
+        do_byte_swap,
+        count);
   } else if (scalar_type == at::kFloat) {
     torch::utils::THP_decodeFloatBuffer(
-        storage->data<float>(), src + offset, do_byte_swap, count);
+        storage->mutable_data<float>(), src + offset, do_byte_swap, count);
   } else if (scalar_type == at::kDouble) {
     torch::utils::THP_decodeDoubleBuffer(
-        storage->data<double>(), src + offset, do_byte_swap, count);
+        storage->mutable_data<double>(), src + offset, do_byte_swap, count);
   } else if (scalar_type == at::kComplexFloat) {
     torch::utils::THP_decodeComplexFloatBuffer(
-        storage->data<c10::complex<float>>(),
+        storage->mutable_data<c10::complex<float>>(),
         src + offset,
         do_byte_swap,
         count);
   } else if (scalar_type == at::kComplexDouble) {
     torch::utils::THP_decodeComplexDoubleBuffer(
-        storage->data<c10::complex<double>>(),
+        storage->mutable_data<c10::complex<double>>(),
         src + offset,
         do_byte_swap,
         count);

--- a/torch/csrc/serialization.h
+++ b/torch/csrc/serialization.h
@@ -5,7 +5,7 @@ template <class io>
 void doRead(io fildes, void* buf, size_t nbytes);
 
 template <class io>
-void doWrite(io fildes, void* buf, size_t nbytes);
+void doWrite(io fildes, const void* buf, size_t nbytes);
 
 template <class io>
 void THPStorage_writeFileRaw(


### PR DESCRIPTION
distinguish mutability of typed StorageImpl::data() member

Summary: See #97461.

Test Plan: Rely on CI.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/97489).
* #97492
* __->__ #97489
* #97477
* #97461