### PR TITLE
Rename PyOperator to HigherOrderOperator

### DIFF
--- a/functorch/experimental/_cond.py
+++ b/functorch/experimental/_cond.py
@@ -7,7 +7,7 @@ import torch.utils._pytree as pytree
 
 from torch._C import DispatchKey, DispatchKeySet, ExcludeDispatchKeyGuard
 from torch._functorch.eager_transforms import _unwrap_all_tensors_from_functional, _wrap_all_tensors_to_functional, functionalize
-from torch._ops import PyOperator
+from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
@@ -33,7 +33,7 @@ class UnsupportedAliasMutationException(RuntimeError):
 We're going to define a `cond` operation.
 In order to do this, we need implementations for each of the dispatch keys.
 """
-cond = PyOperator("cond")
+cond = HigherOrderOperator("cond")
 
 
 def trace_cond(proxy_mode, func_overload, pred, true_fn, false_fn, operands):

--- a/functorch/experimental/_map.py
+++ b/functorch/experimental/_map.py
@@ -4,7 +4,7 @@ import torch
 import torch.utils._pytree as pytree
 from torch._C import DispatchKey, DispatchKeySet, ExcludeDispatchKeyGuard
 from torch._functorch.eager_transforms import _unwrap_all_tensors_from_functional, _wrap_all_tensors_to_functional, functionalize
-from torch._ops import PyOperator
+from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import (
     disable_proxy_modes_tracing,
@@ -21,7 +21,7 @@ from torch.utils._pytree import tree_flatten
 from ._cond import _has_potential_branch_input_alias, _has_potential_branch_input_mutation, UnsupportedAliasMutationException
 
 
-map = PyOperator("map")
+map = HigherOrderOperator("map")
 
 
 def trace_map(proxy_mode, func_overload, f, xs, *args):

--- a/functorch/experimental/ops.py
+++ b/functorch/experimental/ops.py
@@ -1,1 +1,1 @@
-from torch._ops import PyOperator  # noqa: F401
+from torch._ops import HigherOrderOperator  # noqa: F401

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -39,7 +39,7 @@ from torch._functorch.make_functional import (
 )
 from torch._functorch.eager_transforms import _slice_argnums
 from functorch.experimental import functionalize
-from torch._ops import PyOperator
+from torch._ops import HigherOrderOperator
 from torch._functorch.utils import enable_single_level_autograd_function
 import torch.autograd.forward_ad as fwAD
 from torch.func import functional_call, stack_module_state, linearize
@@ -4439,7 +4439,7 @@ def forward(self, x_1):
 
 
 def construct_sum_pyop():
-    mysum = PyOperator("mysum")
+    mysum = HigherOrderOperator("mysum")
 
     @mysum.py_impl(torch._C._functorch.TransformType.Vmap)
     def mysum_batch_rule(interpreter, x, dim):
@@ -4493,7 +4493,7 @@ def construct_sum_pyop():
 
 sum_pyop = construct_sum_pyop()
 
-class TestPyOperatorInteraction(TestCase):
+class TestHigherOrderOperatorInteraction(TestCase):
 
     def test_basic_sum(self, device):
         x = torch.randn(2, 3, 4, device=device)
@@ -4609,7 +4609,7 @@ instantiate_device_type_tests(
     only_for=only_for,
 )
 instantiate_device_type_tests(
-    TestPyOperatorInteraction,
+    TestHigherOrderOperatorInteraction,
     globals(),
     only_for=only_for,
 )

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1948,7 +1948,7 @@ class TestOperators(TestCase):
     # Usually testing the composition of two transforms is sufficient to convince
     # ourselves that an operator is correctly implemented. For the following cases,
     # we want to be extra sure, so we send those through some three-transform tests:
-    # - autograd.Function. The mechanism is via PyDispatcher/PyOperator, not the
+    # - autograd.Function. The mechanism is via PyDispatcher/HigherOrderOperator, not the
     #   regular PyTorch dispatcher, so it's good to exercise more caution.
     @ops(autograd_function_db, allowed_dtypes=(torch.float32,))
     @skipOps('TestOperators', 'test_vmapvjpvmap', {

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -322,7 +322,7 @@ class TestFX(JitTestCase):
         def f(x, y):
             x = control_flow.cond(x[0] == 0, true, false, [x, y])
 
-        with self.assertRaisesRegex(RuntimeError, "Unable to symbolically trace PyOperators"):
+        with self.assertRaisesRegex(RuntimeError, "Unable to symbolically trace HigherOrderOperators"):
             _ = symbolic_trace(f)
 
     def test_disallow_override(self):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -12,7 +12,7 @@ import torch
 
 from torch import SymInt
 from torch._guards import GuardSource
-from torch._ops import PyOperator
+from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.immutable_collections import immutable_list
 
@@ -95,7 +95,7 @@ from .tensor import (
 from .torch import (
     tensor_dunder_fns,
     torch_special_class_types,
-    TorchPyOperator,
+    TorchHigherOrderOperator,
     TorchVariable,
 )
 from .user_defined import UserDefinedClassVariable, UserDefinedObjectVariable
@@ -462,8 +462,8 @@ class VariableBuilder:
             return HFPretrainedConfigVariable(
                 value, guards=make_guards(GuardBuilder.TYPE_MATCH)
             )
-        elif isinstance(value, PyOperator):
-            return TorchPyOperator(
+        elif isinstance(value, HigherOrderOperator):
+            return TorchHigherOrderOperator(
                 value,
                 guards=self.make_guards(
                     GuardBuilder.TYPE_MATCH, GuardBuilder.NAME_MATCH

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -773,7 +773,7 @@ For now, dynamo will explicitly graph break when it encounters user code with th
             return handle_ntuple(args[0])
 
 
-class TorchPyOperator(VariableTracker):
+class TorchHigherOrderOperator(VariableTracker):
     def __init__(self, value, **kwargs):
         super().__init__(**kwargs)
         self.value = value
@@ -1022,7 +1022,7 @@ class TorchPyOperator(VariableTracker):
                 [get_fake_value(args[1].as_proxy().node, tx).shape[0], *r.shape]
             )
         else:
-            unimplemented(f"PyOperator {self.value.__name__}")
+            unimplemented(f"HigherOrderOperator {self.value.__name__}")
 
         # Store the invocation as a call
         return wrap_fx_proxy(

--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -1,5 +1,5 @@
 import torch
-from torch._ops import PyOperator
+from torch._ops import HigherOrderOperator
 from torch._C._functorch import TransformType
 from torch._functorch.utils import enable_single_level_autograd_function
 import torch.utils._pytree as pytree
@@ -24,9 +24,9 @@ from typing import Any, NamedTuple, Tuple
 # work with it. One day we might decide to change this, but until then,
 # we need to give the illusion that autograd.Function runs before those things.
 #
-# We do this by using creating a custom PyOperator that only functorch
+# We do this by using creating a custom HigherOrderOperator that only functorch
 # dispatches specially.
-class CustomFunctionPyOperator(PyOperator):
+class CustomFunctionHigherOrderOperator(HigherOrderOperator):
     def __init__(self):
         super().__init__('custom_function_call')
 
@@ -50,9 +50,9 @@ class CustomFunctionPyOperator(PyOperator):
 # "custom_function_call"
 # This is the mechanism for an autograd.Function that works with functorch transforms.
 # It wraps an autograd.Function; interactions with functorch transforms are defined
-# via PyDispatcher and PyOperator rather than through the traditional PyTorch
+# via PyDispatcher and HigherOrderOperator rather than through the traditional PyTorch
 # dispatcher.
-custom_function_call = CustomFunctionPyOperator()
+custom_function_call = CustomFunctionHigherOrderOperator()
 
 
 # The grad rule for custom_function_call is to construct a new _SingleLevelFunction

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -34,7 +34,7 @@ def dl_open_guard():
 
 class OperatorBase:
     """
-    Base class for OpOverload (which represents C++ ATen operators) and PyOperator
+    Base class for OpOverload (which represents C++ ATen operators) and HigherOrderOperator
     (which represents Python-only operators that are unrepresentable in TorchScript).
     """
 
@@ -53,7 +53,7 @@ class OperatorBase:
         # NB: This name is hard-coded in torch/csrc/autograd/python_variable.cpp
         # for use with OpOverload; cache lookup is done entirely from C++
         # for speed.
-        # TODO: The cache is NOT currently used by PyOperator, but it should!
+        # TODO: The cache is NOT currently used by HigherOrderOperator, but it should!
         self._dispatch_cache: Dict[
             torch._C.DispatchKey, Union[torch._C.DispatchKey, Callable[..., Any]]
         ] = {}
@@ -81,7 +81,7 @@ class OperatorBase:
 
         # This table allows you to override the behavior of functorch
         # transformations.  NB: this currently only does something for
-        # PyOperator
+        # HigherOrderOperator
         self.functorch_table = {}
 
     def __call__(self, *args, **kwargs):
@@ -189,7 +189,7 @@ def resolve_key(op: OperatorBase, k: DispatchKey):  # type: ignore[valid-type]
 pyop_namespace = {}
 
 
-class PyOperator(OperatorBase):
+class HigherOrderOperator(OperatorBase):
     def __init__(self, name):
         super().__init__()
         self._name = name
@@ -228,7 +228,7 @@ class PyOperator(OperatorBase):
         final_key = resolve_key(self, dispatch_key)
 
         # This can current fail due to backend fallbacks.  You just have to
-        # register them by hand for PyOperator.
+        # register them by hand for HigherOrderOperator.
         assert final_key in self.py_kernels, f"{dispatch_key} -> {final_key}"
         self._dispatch_cache[dispatch_key] = self.py_kernels[final_key]
         kernel = self.py_kernels[final_key]

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -440,9 +440,9 @@ class Proxy:
         if torch.overrides.is_tensor_method_or_property(orig_method):
             return tracer.create_proxy('call_method', orig_method.__name__, args, kwargs)
         else:
-            if isinstance(orig_method, torch._ops.PyOperator):
-                # TODO: Define how to symbolically trace PyOperators
-                raise RuntimeError("Unable to symbolically trace PyOperators")
+            if isinstance(orig_method, torch._ops.HigherOrderOperator):
+                # TODO: Define how to symbolically trace HigherOrderOperators
+                raise RuntimeError("Unable to symbolically trace HigherOrderOperators")
             return tracer.create_proxy('call_function', orig_method, args, kwargs,
                                        name=tracer.graph._target_to_str(orig_method.__name__))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97493

Twice this week I have had people confuse "operator defined with Python
operator registration aka torch.library" and "PyOperator which is used
to define control flow operators and other operators that cannot be
represented in JIT schema."  Renaming PyOperator for clarity.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire