### PR TITLE
[POC] [Inductor] optimize loop collapse for cpp backend

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -169,7 +169,7 @@ class cpp:
     dynamic_threads = False
 
     simdlen = None
-    min_chunk_size = 4096
+    min_chunk_size = 8192
     cxx = (
         None,  # download gcc12 from conda-forge if conda is installed
         # "g++-12",


### PR DESCRIPTION
Fixes #93477

Current thread collapse implementation in Inductor is not optimal, e.x.: not consider the loop body workload but just loop times at each level. Need to re-design and tune it to be more comprehensive to maximize multi-threading performance.

This is a simple POC of weighted loop parallelization approach to demonstrate the whole path as to map each op of the kernel to a workload weight, then to control the collapse together with a threshold.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @ipiszy @ngimel @yf225 @chenyang78 @anijain2305 @soumith @desertfire