### PR TITLE
[pytorch] fix typo in named optimzer

### DIFF
--- a/torch/distributed/optim/named_optimizer.py
+++ b/torch/distributed/optim/named_optimizer.py
@@ -120,7 +120,7 @@ class _NamedOptimizer(optim.Optimizer):
 
     def state_dict(self) -> Dict[str, Any]:
         """
-        Return the ``state_dict`` of the optimzer. Instead of using number to index
+        Return the ``state_dict`` of the optimizer. Instead of using number to index
         parameters, we will use module fully qualifed name (FQN) as the key.
         """
         state_dict = self._optimizer.state_dict()


### PR DESCRIPTION
When I wound to find something with `optimizer`, I just typed `optimzer`.
And I found this typo.