### PR TITLE
[ROCm] Enable FSDP BF16 comm hooks unit tests

### DIFF
--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -29,11 +29,9 @@ if not dist.is_available():
     sys.exit(0)
 
 # bfloat16 is only supported by CUDA 11+
-BFLOAT16_AVAILABLE = (
-    torch.cuda.is_available()
-    and ((torch.version.cuda is not None
-    and int(torch.version.cuda.split(".")[0]) >= 11)
-    or torch.version.hip is not None)
+BFLOAT16_AVAILABLE = torch.cuda.is_available() and (
+    (torch.version.cuda is not None and int(torch.version.cuda.split(".")[0]) >= 11)
+    or torch.version.hip is not None
 )
 
 

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_ROCM,
 )
 
 if not dist.is_available():
@@ -34,7 +35,7 @@ BFLOAT16_AVAILABLE = (
     torch.cuda.is_available()
     and torch.version.cuda is not None
     and int(torch.version.cuda.split(".")[0]) >= 11
-)
+) or TEST_WITH_ROCM
 
 
 class Net(nn.Module):
@@ -435,7 +436,6 @@ class TestCommunicationHooks(FSDPTest):
         "BFloat16 is only supported by CUDA 11+",
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm
     @parametrize("has_wrapping", [True, False])
     @parametrize(
         "sharding_strategy",

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -16,7 +16,6 @@ from torch.testing._internal.common_distributed import (
     requires_nccl_version,
     skip_but_pass_in_sandcastle_if,
     skip_if_lt_x_gpu,
-    skip_if_rocm,
 )
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -22,7 +22,6 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    TEST_WITH_ROCM,
 )
 
 if not dist.is_available():
@@ -32,9 +31,10 @@ if not dist.is_available():
 # bfloat16 is only supported by CUDA 11+
 BFLOAT16_AVAILABLE = (
     torch.cuda.is_available()
-    and torch.version.cuda is not None
-    and int(torch.version.cuda.split(".")[0]) >= 11
-) or TEST_WITH_ROCM
+    and ((torch.version.cuda is not None
+    and int(torch.version.cuda.split(".")[0]) >= 11)
+    or torch.version.hip is not None)
+)
 
 
 class Net(nn.Module):


### PR DESCRIPTION
This PR enables the following unit tests in FSDP feature on ROCm. 
```
test_bf16_hook_has_wrapping_False_sharding_strategy_ShardingStrategy_FULL_SHARD
test_bf16_hook_has_wrapping_False_sharding_strategy_ShardingStrategy_NO_SHARD
test_bf16_hook_has_wrapping_False_sharding_strategy_ShardingStrategy_SHARD_GRAD_OP
test_bf16_hook_has_wrapping_True_sharding_strategy_ShardingStrategy_FULL_SHARD
test_bf16_hook_has_wrapping_True_sharding_strategy_ShardingStrategy_NO_SHARD
test_bf16_hook_has_wrapping_True_sharding_strategy_ShardingStrategy_SHARD_GRAD_OP
```


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport