### PR TITLE
[FSDP][3/N] Minor fixes (rename, assert message)

### DIFF
--- a/test/distributed/fsdp/test_fsdp_flatten_params.py
+++ b/test/distributed/fsdp/test_fsdp_flatten_params.py
@@ -340,7 +340,7 @@ class TestFlattenParams(FSDPTest):
             flat_param = flat_param_handle.flat_param
             (
                 flat_param._shard_param_offsets,
-                flat_param._shard_indices,
+                flat_param._shard_param_indices,
             ) = flat_param_handle._get_shard_metadata(kwargs["start"], kwargs["end"])
             self.assertEqual(
                 flat_param_handle.shard_metadata(),

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -123,7 +123,7 @@ def _module_handles(state: _FSDPState, module: nn.Module) -> List:
     if _is_composable(state):
         assert (
             module in state._fully_sharded_module_to_handles
-        ), f"Expects a `comm_module` but got {module} on rank {state.rank}"
+        ), f"Expects a fully sharded module but got {module} on rank {state.rank}"
         return state._fully_sharded_module_to_handles[module][:]
     else:
         # NOTE: This assumes `module` is a `FullyShardedDataParallel` instance.

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1727,7 +1727,7 @@ def _shard_orig_param_state(
     param_idx = fsdp_param_info.param_indices[fqn]
 
     optim_state = _gather_state_dict(optim_state, fsdp_state.process_group)
-    start, end = flat_param._shard_indices  # type: ignore[attr-defined]
+    start, end = flat_param._shard_param_indices  # type: ignore[attr-defined]
     if not (start <= param_idx <= end and flat_param._shard_param_offsets):  # type: ignore[attr-defined]
         return {}
     param_start, param_end = flat_param._shard_param_offsets[param_idx - start]  # type: ignore[attr-defined]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #97531
* #97530
* #97529
* #97528
* __->__ #97527
* #97526
* #97525

This is an easy PR.
- It renames `_shard_indices` to `_shard_param_indices` for consistency.
- It fixes an old mention of `comm_module` in an assert message.