### PR TITLE
[POC] initial version of AOTDispatch

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1629,6 +1629,18 @@ import torch.fx.experimental.symbolic_shapes
 from torch import func as func
 from torch.func import vmap
 
+# This is a util for functionalization;
+# Given a functional tensor, syncs any pending updates on it
+def _sync(t):
+    from torch.utils._python_dispatch import supports_mode_tracing
+    if supports_mode_tracing(t):
+        tensors_to_sync, _ = t.__tensor_flatten__(t)
+    else:
+        tensors_to_sync = [t]
+    for t in tensors_to_sync:
+        torch._sync_functional_tensor(t)
+
+
 # The function _sparse_coo_tensor_unsafe is removed from PyTorch
 # Python API (v. 1.13), here we temporarily provide its replacement
 # with a deprecation warning.

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -7,6 +7,7 @@ import torch
 from torch._guards import Source
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.utils.weak import WeakIdRef
+from torch.utils._python_dispatch import supports_mode_tracing, transform_subclass
 
 
 def safe_is_leaf(t):
@@ -511,6 +512,9 @@ class MetaConverter:
             # tensors into their trace / some subclasses don't correctly
             # support meta.  Trying to YOLO this is more trouble than it's
             # worth.
+            if supports_mode_tracing(t):
+                out = transform_subclass(t, lambda t: self.meta_tensor(t, shape_env=shape_env, callback=callback, source=source))
+                return out
             self.miss += 1
             return NotImplemented
         else:

--- a/torch/csrc/DynamicTypes.cpp
+++ b/torch/csrc/DynamicTypes.cpp
@@ -82,9 +82,13 @@ PyObject* createPyObject(const at::Storage& storage) {
       // This is useful for checking aliasing info from python
       dynamic_cast<at::functionalization::FunctionalStorageImpl*>(
           storage.unsafeGetStorageImpl()) == nullptr) {
-    TORCH_CHECK_NOT_IMPLEMENTED(
-        false,
-        "python bindings to nullptr storage (e.g., from torch.Tensor._make_wrapper_subclass) are currently unsafe and thus disabled.  See https://github.com/pytorch/pytorch/issues/61669 for more details");
+    // TODO: allowing wrapper tensor subclasses to call .storage()
+    // is dangerous, but needed for AOTAutograd analysis.
+    // Some options:
+    // (1) remove the check
+    // (2) introduce ReadOnlyStorage
+    // (3) Add private TLS telling us when it is ok to return a null storage,
+    //     use it in AOTAutograd
   }
   PyTypeObject* type = reinterpret_cast<PyTypeObject*>(THPStorageClass);
   auto obj = THPObjectPtr(type->tp_alloc(type, 0));

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -525,7 +525,7 @@ static PyMethodDef torch_functions_manual[] = {
      castPyCFunctionWithKeywords(THPVariable__freeze_functional_tensor),
      METH_VARARGS | METH_KEYWORDS | METH_STATIC,
      nullptr},
-    {"_sync",
+    {"_sync_functional_tensor",
      castPyCFunctionWithKeywords(THPVariable__sync),
      METH_VARARGS | METH_KEYWORDS | METH_STATIC,
      nullptr},


### PR DESCRIPTION
This is an initial version of AOTDispatch support in aot_autograd.py. The idea is that you can pass (wrapper) tensor subclasses into `torch.compile()`, and have two things happen:

(1) (at compile time) we will trace *through* your subclass, and trace out a graph that takes in dense tensors and spits out dense tensors, that we send to the compiler

(2) (at runtime) AOTDispatch includes glue that knows how to "unwrap" your inputs before sending them to the compiled graph, and re-wrap the outputs into subclasses before sending them back to the user.

**Current Plan**

I have a simple `DoubleTensor` wrapper subclass that I used for testing, that seems to work. Before landing this PR, I want to do some E2E testing with protoquant, an out-of-tree repo that implements a form of quantization using a tensor subclass.

**Limitations of AOTDispatch**

As part of landing this PR, I think there should probably be some docs that clearly lay out what restrictions you are roped into, if you have a TorchDispatch tensor subclass (mode) and would like to compile through it. I'm going to write up that list and get agreement on it, after testing out the `protoquant` integration (starting to do that soon).

Right now, the PR requires the following:

(1) Your subclass must be a **wrapper** subclass. Aka it is a shell that holds a tensor, and calls `torch.Tensor._make_wrapper_subclass()`.

(2) Implement a `Subclass.__tensor_flatten__(x) -> List[torch.Tensor], ctx`, and `Subclass.__tensor_unflatten__(inner_tensors, ctx) -> Subclass` static method on your subclass. We should probably bikeshed on this API - I modeled it after pytrees

(3) You **must** create a TorchDispatchMode for your subclass, and enable it when you `torch.compile()` any function that takes in subclass inputs. We could remove this restriction with some effort. Some of the arguments in favor of this restriction are: (a) Creating a "dummy" mode for your subclass is pretty simple (we could also provide a basic util for it), and (b) the interactions between subclasses and modes are pretty subtle, so forcing everything to be a mode in torch.compile() world simplifies some logic.

(4) Your subclass should "logically" be a ATen op -> ATen op transform. More concretely, your __torch_dispatch__ logic cannot graph break or produce any guards. This is similar to the allow_in_graph restrictions: dynamo can't easily peak at __torch_dispatch__ code. This immediately eliminates doing things with global state, printing, etc. In theory, any behavior that you want to preserve that is not part of ATen can be converted into an opaque dispatcher operator, that you bake into the graph - so there's a bit of flexibility here, although the compiler (inductor) would need to know how to handle it in order for anything efficient to be generated.

**How to review this PR?**
Later today I'm going to try to outline the PR and call out important bits. I'd also be happy to go over the PR directly with anyone interested.

For a high level view of where TorchDispatch unwrapping slots into the other layers (autograd, functionalization, synthetic bases, deduping), see line 3071, where each of the passes is defined ([link](https://github.com/pytorch/pytorch/pull/97540/files#diff-df954bbf954d2dcb81f687876053267ffa4ddb36ed86b7d2bd76319ff2b94416R3071))

The two main new functions in aot_autograd.py are:
- `aot_dispatch_subclass()`. This function takes in a (potentially joint fw bw) function on subclass inputs, and translates it into a function on dense inputs. It hands that function the next layer (functionalization + tracing), and returns the result
- `aot_dispatch_subclass_runtime_wrapper()`. This function implements the runtime glue logic: when the user passes us a tensor subclass, we need to unwrap it into dense tensors before passing them to the compiled graph.

One layering issue that I don't love is the fact that AOTDispatch runs underneath the partitioning layer. This means that `aot_dispatch_subclass()` will only run once (on the joint graph), but `aot_dispatch_subclass_runtime_wrapper()` will run twice, once on the partitioned fw and again in the backward. This requires plumbing some metadata between the two functions. I think the way I'm doing it right now isn't too awful, but definitely open to suggestions.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97540
* #96784

