### PR TITLE
[kineto] init kineto_activity for each event

### DIFF
--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -583,7 +583,8 @@ static constexpr const char* indexKey = "Ev Idx";
 void passEventsToKineto(
     const std::vector<std::shared_ptr<Result>>& results,
     uint64_t start_time_us,
-    uint64_t end_time_us) {
+    uint64_t end_time_us,
+    const ProfilerConfig& config) {
   using namespace torch::profiler::impl::kineto;
   TraceWrapper cpu_trace(start_time_us, "PyTorch Profiler");
 
@@ -601,6 +602,16 @@ void passEventsToKineto(
     TORCH_INTERNAL_ASSERT(activity || !kKinetoAvailable);
     if (activity) {
       addMetadata(activity, indexKey, std::to_string(i));
+
+      // There is a longstanding regression for initializing
+      // on-demand Kineto activity handling. Enabling this path
+      // for Profiler API could cause side effects as much has changed since.
+      // Make a surgical fix here until we holistically assess the on-demand
+      // vs API path framentation, which has been snowballing in complexity
+      // and thus flakiness.
+      if (config.global()) {
+        e->kineto_activity_ = activity;
+      }
     }
   }
 
@@ -865,7 +876,7 @@ trace_ptr_t addKinetoEvents(
     uint64_t end_time_us,
     const ProfilerConfig& config) {
   using namespace torch::profiler::impl::kineto;
-  passEventsToKineto(results, start_time_us, end_time_us);
+  passEventsToKineto(results, start_time_us, end_time_us, config);
 
   // In on demand mode kineto is directly controlled by other machinery.
   if (config.global()) {


### PR DESCRIPTION
Summary:
There was a refactoring while back to address Kineto <--> PyTorch Profiler buffer management issues. This made the Profiler API path safer but it regressed the OnDemand path.

The proper long term solution is to merge those paths which would significantly improve the maintainability of the codebase.

Test Plan:
# Test on Resnet integration test
```
buck2 run mode/opt  kineto/libkineto/fb/integration_tests:pytorch_resnet_integration_test
dyno gputrace
```

# Trace
https://fburl.com/perfdoctor/t8nkda9z

Differential Revision: D44362040

