### PR TITLE
Run _calculate-docker-image on 2xlarge with a larger disk space

### DIFF
--- a/.github/workflows/_calculate-docker-image.yml
+++ b/.github/workflows/_calculate-docker-image.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   calculate-docker-image:
     if: github.repository_owner == 'pytorch'
-    runs-on: [self-hosted, linux.large]
+    runs-on: [self-hosted, linux.2xlarge]
     timeout-minutes: 30
     outputs:
       docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}


### PR DESCRIPTION
Not quite sure why I chose `linux.large` here, probably a copy paste mistake.  `linux.large` is a small runner with too small disk space (15GB), so there is a chance that it could run out of space as in https://github.com/pytorch/pytorch/actions/runs/4513709983/jobs/7948892825