### PR TITLE
[Vulkan] Fix broadcasting in quantized elementwise ops

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/quantized_add.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_add.glsl
@@ -27,11 +27,15 @@ void main() {
     const ivec3 input0_pos = pos % uBlock.isize0.xyz;
     const ivec3 input1_pos = pos % uBlock.isize1.xyz;
 
-    vec4 texel0 = texelFetch(uInput0, input0_pos, 0);
-    vec4 texel1 = texelFetch(uInput1, input1_pos, 0);
+    const vec4 v0 = uBlock.isize0.w == 1
+                      ? texelFetch(uInput0, input0_pos, 0).xxxx
+                      : texelFetch(uInput0, input0_pos, 0);
+    const vec4 v1 = uBlock.isize1.w == 1
+                      ? texelFetch(uInput1, input1_pos, 0).xxxx
+                      : texelFetch(uInput1, input1_pos, 0);
 
-    vec4 deq_in_0 = uBlock.in_scale.x * (texel0 - uBlock.in_zero_point.x);
-    vec4 deq_in_1 = uBlock.in_scale.y * (texel1 - uBlock.in_zero_point.y);
+    vec4 deq_in_0 = uBlock.in_scale.x * (v0 - uBlock.in_zero_point.x);
+    vec4 deq_in_1 = uBlock.in_scale.y * (v1 - uBlock.in_zero_point.y);
 
     vec4 res = deq_in_0 + deq_in_1;
     vec4 q_res = roundEven(res / uBlock.out_scale.x) + uBlock.out_zero_point.x;

--- a/aten/src/ATen/native/vulkan/glsl/quantized_div.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_div.glsl
@@ -27,11 +27,15 @@ void main() {
     const ivec3 input0_pos = pos % uBlock.isize0.xyz;
     const ivec3 input1_pos = pos % uBlock.isize1.xyz;
 
-    vec4 texel0 = texelFetch(uInput0, input0_pos, 0);
-    vec4 texel1 = texelFetch(uInput1, input1_pos, 0);
+    const vec4 v0 = uBlock.isize0.w == 1
+                      ? texelFetch(uInput0, input0_pos, 0).xxxx
+                      : texelFetch(uInput0, input0_pos, 0);
+    const vec4 v1 = uBlock.isize1.w == 1
+                      ? texelFetch(uInput1, input1_pos, 0).xxxx
+                      : texelFetch(uInput1, input1_pos, 0);
 
-    vec4 deq_in_0 = uBlock.in_scale.x * (texel0 - uBlock.in_zero_point.x);
-    vec4 deq_in_1 = uBlock.in_scale.y * (texel1 - uBlock.in_zero_point.y);
+    vec4 deq_in_0 = uBlock.in_scale.x * (v0 - uBlock.in_zero_point.x);
+    vec4 deq_in_1 = uBlock.in_scale.y * (v1 - uBlock.in_zero_point.y);
 
     vec4 res = deq_in_0 / deq_in_1;
     vec4 q_res = roundEven(res / uBlock.out_scale.x) + uBlock.out_zero_point.x;

--- a/aten/src/ATen/native/vulkan/glsl/quantized_mul.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_mul.glsl
@@ -27,11 +27,15 @@ void main() {
     const ivec3 input0_pos = pos % uBlock.isize0.xyz;
     const ivec3 input1_pos = pos % uBlock.isize1.xyz;
 
-    vec4 texel0 = texelFetch(uInput0, input0_pos, 0);
-    vec4 texel1 = texelFetch(uInput1, input1_pos, 0);
+    const vec4 v0 = uBlock.isize0.w == 1
+                      ? texelFetch(uInput0, input0_pos, 0).xxxx
+                      : texelFetch(uInput0, input0_pos, 0);
+    const vec4 v1 = uBlock.isize1.w == 1
+                      ? texelFetch(uInput1, input1_pos, 0).xxxx
+                      : texelFetch(uInput1, input1_pos, 0);
 
-    vec4 deq_in_0 = uBlock.in_scale.x * (texel0 - uBlock.in_zero_point.x);
-    vec4 deq_in_1 = uBlock.in_scale.y * (texel1 - uBlock.in_zero_point.y);
+    vec4 deq_in_0 = uBlock.in_scale.x * (v0 - uBlock.in_zero_point.x);
+    vec4 deq_in_1 = uBlock.in_scale.y * (v1 - uBlock.in_zero_point.y);
 
     vec4 res = deq_in_0 * deq_in_1;
     vec4 q_res = roundEven(res / uBlock.out_scale.x) + uBlock.out_zero_point.x;

--- a/aten/src/ATen/native/vulkan/glsl/quantized_sub.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_sub.glsl
@@ -27,11 +27,15 @@ void main() {
     const ivec3 input0_pos = pos % uBlock.isize0.xyz;
     const ivec3 input1_pos = pos % uBlock.isize1.xyz;
 
-    vec4 texel0 = texelFetch(uInput0, input0_pos, 0);
-    vec4 texel1 = texelFetch(uInput1, input1_pos, 0);
+    const vec4 v0 = uBlock.isize0.w == 1
+                      ? texelFetch(uInput0, input0_pos, 0).xxxx
+                      : texelFetch(uInput0, input0_pos, 0);
+    const vec4 v1 = uBlock.isize1.w == 1
+                      ? texelFetch(uInput1, input1_pos, 0).xxxx
+                      : texelFetch(uInput1, input1_pos, 0);
 
-    vec4 deq_in_0 = uBlock.in_scale.x * (texel0 - uBlock.in_zero_point.x);
-    vec4 deq_in_1 = uBlock.in_scale.y * (texel1 - uBlock.in_zero_point.y);
+    vec4 deq_in_0 = uBlock.in_scale.x * (v0 - uBlock.in_zero_point.x);
+    vec4 deq_in_1 = uBlock.in_scale.y * (v1 - uBlock.in_zero_point.y);
 
     vec4 res = deq_in_0 - deq_in_1;
     vec4 q_res = roundEven(res / uBlock.out_scale.x) + uBlock.out_zero_point.x;

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -15,23 +15,24 @@ void check_inputs(const Tensor& input1, const Tensor& input2) {
       "Incompatible dimensions for broadcasting for binary elementwise op!";
   if (get_dim<Dim4D::Batch>(input1) != get_dim<Dim4D::Batch>(input2)) {
     TORCH_CHECK(
-        get_dim<Dim4D::Batch>(input1) == 1 || get_dim<Dim4D::Batch>(input2),
+        get_dim<Dim4D::Batch>(input1) == 1 ||
+            get_dim<Dim4D::Batch>(input2) == 1,
         broadcast_error_msg);
     TORCH_CHECK(
-        (get_dim<Dim4D::Channel>(input1) == get_dim<Dim4D::Channel>(input2) &&
-         get_dim<Dim4D::Channel>(input1) % 4 == 0) ||
+        get_dim<Dim4D::Channel>(input1) == get_dim<Dim4D::Channel>(input2) ||
             get_dim<Dim4D::Channel>(input1) * get_dim<Dim4D::Batch>(input1) ==
                 1 ||
             get_dim<Dim4D::Channel>(input2) * get_dim<Dim4D::Batch>(input2) ==
                 1,
         "Invalid broadcasting for Vulkan binary elementwise op! "
         "If batch dimensions aren't equal, then channel dimensions must be "
-        "equal and multiple of 4 or one of the inputs must have "
-        "channel and batch dimensions both equal to 1!");
+        "equal or one of the inputs must have channel and batch dimensions "
+        "both equal to 1!");
   }
   if (get_dim<Dim4D::Channel>(input1) != get_dim<Dim4D::Channel>(input2)) {
     TORCH_CHECK(
-        get_dim<Dim4D::Channel>(input1) == 1 || get_dim<Dim4D::Channel>(input2),
+        get_dim<Dim4D::Channel>(input1) == 1 ||
+            get_dim<Dim4D::Channel>(input2) == 1,
         broadcast_error_msg);
     TORCH_CHECK(
         get_dim<Dim4D::Channel>(input1) * get_dim<Dim4D::Batch>(input1) == 1 ||
@@ -43,12 +44,14 @@ void check_inputs(const Tensor& input1, const Tensor& input2) {
   }
   if (get_dim<Dim4D::Height>(input1) != get_dim<Dim4D::Height>(input2)) {
     TORCH_CHECK(
-        get_dim<Dim4D::Height>(input1) == 1 || get_dim<Dim4D::Height>(input2),
+        get_dim<Dim4D::Height>(input1) == 1 ||
+            get_dim<Dim4D::Height>(input2) == 1,
         broadcast_error_msg);
   }
   if (get_dim<Dim4D::Width>(input1) != get_dim<Dim4D::Width>(input2)) {
     TORCH_CHECK(
-        get_dim<Dim4D::Width>(input1) == 1 || get_dim<Dim4D::Width>(input2),
+        get_dim<Dim4D::Width>(input1) == 1 ||
+            get_dim<Dim4D::Width>(input2) == 1,
         broadcast_error_msg);
   }
 }
@@ -68,7 +71,7 @@ std::vector<int64_t> broadcast_size(const Tensor& t1, const Tensor& t2) {
     }
   }
 
-  if (out.size() > 0) {
+  if (!out.empty()) {
     out[out.size() - 1] =
         std::max(get_dim<Dim4D::Width>(t1), get_dim<Dim4D::Width>(t2));
   }
@@ -211,14 +214,14 @@ Tensor arithmetic_tensor(
       self_arg.scalar_type(),
   };
 
-  const float alpha = alpha_arg ? alpha_arg->to<float>() : 1.0;
+  const double alpha = alpha_arg ? alpha_arg->to<double>() : 1.0;
   const struct Block final {
     uvec3 extents;
-    uint32_t fill_0;
-    uvec3 input1_extents;
-    uint32_t channel_batch_size_1;
-    uvec3 input2_extents;
-    uint32_t channel_batch_size_2;
+    uint32_t fill0;
+    uvec3 input1Extents;
+    uint32_t channelBatchSize1;
+    uvec3 input2Extents;
+    uint32_t channelBatchSize2;
     float alpha;
   } block{
       v_output.extents(),
@@ -227,7 +230,7 @@ Tensor arithmetic_tensor(
       get_dim<Dim4D::Channel>(self) * get_dim<Dim4D::Batch>(self),
       v_other.extents(),
       get_dim<Dim4D::Channel>(other) * get_dim<Dim4D::Batch>(other),
-      alpha,
+      safe_downcast<float>(alpha),
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -288,26 +291,26 @@ Tensor quantized_arithmetic_tensor(
   const int64_t zero_point2 = v_other.get_zero_point();
   const struct Block final {
     uvec3 extents;
-    uint32_t fill_0;
-    uvec3 input1_extents;
-    uint32_t fill_1;
-    uvec3 input2_extents;
-    uint32_t fill_2;
+    uint32_t fill0;
+    uvec3 input1Extents;
+    uint32_t channelBatchSize1;
+    uvec3 input2Extents;
+    uint32_t channelBatchSize2;
     float scale1;
     float scale2;
-    int32_t zero_point1;
-    int32_t zero_point2;
+    int32_t zeroPoint1;
+    int32_t zeroPoint2;
     float scale;
-    float _1;
-    int32_t zero_point;
-    int32_t _2;
+    float fill1;
+    int32_t zeroPoint;
+    int32_t fill2;
   } block{
       v_output.extents(),
       0u,
       v_self.extents(),
-      0u,
+      get_dim<Dim4D::Channel>(self) * get_dim<Dim4D::Batch>(self),
       v_other.extents(),
-      0u,
+      get_dim<Dim4D::Channel>(other) * get_dim<Dim4D::Batch>(other),
       safe_downcast<float>(scale1),
       safe_downcast<float>(scale2),
       safe_downcast<int32_t>(zero_point1),
@@ -373,19 +376,19 @@ Tensor& arithmetic_tensor_(
   const Tensor other = other_arg.is_vulkan() ? other_arg : other_arg.vulkan();
   const vTensor& v_other = convert(other);
 
-  const float alpha = alpha_arg ? alpha_arg->to<float>() : 1.0;
+  const double alpha = alpha_arg ? alpha_arg->to<double>() : 1.0;
   const struct Block final {
     uvec3 extents;
-    uint32_t fill_0;
-    uvec3 input_extents;
-    uint32_t channel_batch_size_other;
+    uint32_t fill0;
+    uvec3 inputExtents;
+    uint32_t channelBatchSizeOther;
     float alpha;
   } block{
       v_self.extents(),
       0u,
       v_other.extents(),
       get_dim<Dim4D::Channel>(other) * get_dim<Dim4D::Batch>(other),
-      alpha,
+      safe_downcast<float>(alpha),
   };
 
   api::UniformParamsBuffer params(context, block);

--- a/aten/src/ATen/test/vulkan_quantized_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_quantized_api_test.cpp
@@ -2028,9 +2028,21 @@ void quantized_binary_op_test_set(const char* op_name) {
   test_quantized_binary_op(
       false, false, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
   test_quantized_binary_op(
+      false, false, op_name, {7, 15, 6, 1}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, false, op_name, {7, 15, 6, 17}, {7, 15, 6, 1}); // broadcasting
+  test_quantized_binary_op(
+      false, false, op_name, {7, 15, 1, 17}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
       false, false, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
   test_quantized_binary_op(
-      false, false, op_name, {7, 5, 6, 1}, {7, 5, 6, 17}); // broadcasting
+      false, false, op_name, {1, 1, 6, 17}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, false, op_name, {7, 15, 6, 17}, {1, 1, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, false, op_name, {1, 15, 6, 17}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, false, op_name, {7, 15, 6, 17}, {1, 15, 6, 17}); // broadcasting
 
   // compute params
   test_quantized_binary_op(true, false, op_name, {1, 1, 1, 1}, {1, 1, 1, 1});
@@ -2040,9 +2052,21 @@ void quantized_binary_op_test_set(const char* op_name) {
   test_quantized_binary_op(
       true, false, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
   test_quantized_binary_op(
+      true, false, op_name, {7, 15, 6, 1}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      true, false, op_name, {7, 15, 6, 17}, {7, 15, 6, 1}); // broadcasting
+  test_quantized_binary_op(
+      true, false, op_name, {7, 15, 1, 17}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
       true, false, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
   test_quantized_binary_op(
-      true, false, op_name, {7, 5, 6, 1}, {7, 5, 6, 17}); // broadcasting
+      true, false, op_name, {1, 1, 6, 17}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      true, false, op_name, {7, 15, 6, 17}, {1, 1, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      true, false, op_name, {1, 15, 6, 17}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      true, false, op_name, {7, 15, 6, 17}, {1, 15, 6, 17}); // broadcasting
 
   // random params
   test_quantized_binary_op(false, true, op_name, {1, 1, 1, 1}, {1, 1, 1, 1});
@@ -2052,9 +2076,21 @@ void quantized_binary_op_test_set(const char* op_name) {
   test_quantized_binary_op(
       false, true, op_name, {2, 13, 32, 27}, {2, 13, 32, 27});
   test_quantized_binary_op(
+      false, true, op_name, {7, 15, 6, 1}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, true, op_name, {7, 15, 6, 17}, {7, 15, 6, 1}); // broadcasting
+  test_quantized_binary_op(
+      false, true, op_name, {7, 15, 1, 17}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
       false, true, op_name, {7, 15, 6, 17}, {7, 15, 1, 17}); // broadcasting
   test_quantized_binary_op(
-      false, true, op_name, {7, 5, 6, 1}, {7, 5, 6, 17}); // broadcasting
+      false, true, op_name, {1, 1, 6, 17}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, true, op_name, {7, 15, 6, 17}, {1, 1, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, true, op_name, {1, 15, 6, 17}, {7, 15, 6, 17}); // broadcasting
+  test_quantized_binary_op(
+      false, true, op_name, {7, 15, 6, 17}, {1, 15, 6, 17}); // broadcasting
 
   // random shape and params
   for (int i = 0; i < 10; i += 1) {


### PR DESCRIPTION
Summary: Fixes broadcasting along the channel and batch dimensions in quantized add, sub, mul and div

Test Plan:
```
buck run --target-platforms ovr_config//platform/macos:arm64-fbsource -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64
```

Reviewed By: SS-JIA

Differential Revision: D44359706

