### PR TITLE
[Pytorch][coreml]Pass backend and modelid by value

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.h
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.h
@@ -12,8 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)compileModel:(const std::string&)modelSpecs modelID:(const std::string&)modelID;
 
-+ (nullable MLModel*)loadModel:(const std::string&)modelID
-                       backend:(const std::string&)backend
++ (nullable MLModel*)loadModel:(const std::string)modelID
+                       backend:(const std::string)backend
              allowLowPrecision:(BOOL)allowLowPrecision;
 
 @end

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
@@ -55,7 +55,7 @@ static NSString *gVersionExtension = @"version";
   return [PTMCoreMLCompiler _compileModel:modelName atPath:modelPath];
 }
 
-+ (nullable MLModel*)loadModel:(const std::string&)modelID backend:(const std::string&)backend allowLowPrecision:(BOOL)allowLowPrecision {
++ (nullable MLModel*)loadModel:(const std::string)modelID backend:(const std::string)backend allowLowPrecision:(BOOL)allowLowPrecision {
   NSString *modelName = [NSString stringWithCString:modelID.c_str() encoding:NSUTF8StringEncoding];
   NSURL *modelURL = [PTMCoreMLCompiler _cacheURLForModel:modelName extension:gCompiledModelExtension];
 


### PR DESCRIPTION
Summary:
Due to async dispatch passing by reference may cause crash.

Test Plan: CI

Reviewed By: mcr229

Differential Revision: D44386623

