### PR TITLE
[DCP] Expose create_read_items_for_chunk_list helper.

### DIFF
--- a/torch/distributed/checkpoint/optimizer.py
+++ b/torch/distributed/checkpoint/optimizer.py
@@ -1,6 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 
-import copy
 import dataclasses
 from typing import Dict, List, Optional, Sequence, Tuple, Union, cast
 from torch.distributed.checkpoint.planner import LoadPlan
@@ -21,9 +20,10 @@ from torch.distributed.checkpoint.metadata import (
     MetadataIndex,
     STATE_DICT_TYPE,
     TensorStorageMetadata,
+    ChunkStorageMetadata
 )
 from torch.distributed.checkpoint.planner_helpers import (
-    _create_sharded_read_items,
+    create_read_items_for_chunk_list,
     _create_read_items,
 )
 from torch.distributed.remote_device import _remote_device
@@ -168,14 +168,15 @@ class _ReaderWithOffset(DefaultLoadPlanner):
 
             assert len(obj.local_shards()) == 1
             original_shard = obj.local_shards()[0]
-            shard_md = copy.deepcopy(original_shard.metadata)
-            shard_md.shard_offsets = _element_wise_add(
-                shard_md.shard_offsets, offset
-            )
-            local_shards = [Shard(original_shard.tensor, shard_md)]
+            local_chunks = [
+                ChunkStorageMetadata(
+                    offsets=torch.Size(_element_wise_add(original_shard.metadata.shard_offsets, offset)),
+                    sizes=torch.Size(original_shard.metadata.shard_sizes)
+                )
+            ]
 
-            reqs = _create_sharded_read_items(
-                fqn, cast(TensorStorageMetadata, md), local_shards
+            reqs = create_read_items_for_chunk_list(
+                fqn, cast(TensorStorageMetadata, md), local_chunks
             )
             # TODO: The ReadItems will have a displaced MetadataIndex, fix it.
             # TODO: we should change _create_sharded_read_items to have more ergonomic API

--- a/torch/distributed/checkpoint/planner_helpers.py
+++ b/torch/distributed/checkpoint/planner_helpers.py
@@ -31,7 +31,7 @@ from .resharding import (
     _check_shard_metadata_pair_overlap
 )
 
-__all__: List[str] = [ "create_read_items_for_chunk_list" ]
+__all__: List[str] = ["create_read_items_for_chunk_list"]
 
 
 def _create_chunk_from_tensor(tensor: torch.Tensor) -> ChunkStorageMetadata:

--- a/torch/distributed/checkpoint/planner_helpers.py
+++ b/torch/distributed/checkpoint/planner_helpers.py
@@ -31,7 +31,7 @@ from .resharding import (
     _check_shard_metadata_pair_overlap
 )
 
-__all__: List[str] = []
+__all__: List[str] = [ "create_read_items_for_chunk_list" ]
 
 
 def _create_chunk_from_tensor(tensor: torch.Tensor) -> ChunkStorageMetadata:

--- a/torch/distributed/checkpoint/planner_helpers.py
+++ b/torch/distributed/checkpoint/planner_helpers.py
@@ -2,17 +2,11 @@ from typing import Any, List
 
 import torch
 
-import torch.distributed as dist
 from torch.distributed._shard.metadata import ShardMetadata
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
-from torch.distributed._shard.sharded_tensor.shard import Shard
 from torch.distributed._tensor import DTensor
 from torch.distributed._tensor._utils import compute_local_shape, compute_local_offset
-
-from torch.distributed._shard.sharding_spec._internals import (
-    _check_shard_metadata_pair_overlap,
-)
 
 from .planner import (
     LoadItemType,
@@ -32,20 +26,19 @@ from .metadata import (
     STORAGE_TYPES,
 )
 
-from .resharding import _shards_get_overlap_region_wrt_saved_tensor
+from .resharding import (
+    _shards_get_overlap_region_wrt_saved_tensor,
+    _check_shard_metadata_pair_overlap
+)
 
 __all__: List[str] = []
 
 
-def _create_shard_metadata(size: torch.Size) -> ShardMetadata:
-    return ShardMetadata(
-        shard_offsets=[0] * len(size),
-        shard_sizes=list(size),
+def _create_chunk_from_tensor(tensor: torch.Tensor) -> ChunkStorageMetadata:
+    return ChunkStorageMetadata(
+        offsets=torch.Size([0] * len(tensor.size())),
+        sizes=tensor.size()
     )
-
-
-def _create_shard_from_tensor(tensor: torch.Tensor) -> Shard:
-    return Shard(tensor=tensor, metadata=_create_shard_metadata(tensor.size()))
 
 
 def _chunk_for_shard(shard_md: ShardMetadata) -> ChunkStorageMetadata:
@@ -145,24 +138,33 @@ def _create_read_item_for_tensor(
         lengths=torch.Size(lengths),
     )
 
-
-def _create_sharded_read_items(
+def create_read_items_for_chunk_list(
     fqn: str,
     checkpoint_md: TensorStorageMetadata,
-    local_shards: List[Shard],
+    local_chunks: List[ChunkStorageMetadata],
 ) -> List[ReadItem]:
+    """
+    Creates a list of ``ReadItem`` based on the checkpoint and local chunks.
 
+    This applies the resharding algorithm and computes the reads needed
+    to satisfy ``local_chunks`` with a checkpoint described by ``checkpoint_md``.
+
+    Args:
+        fqn (str) : The state_dict FQN to pass to ``ReadItem``.
+        checkpoint_md (TensorStorageMetadata): metadata for a given tensor
+            from a checkpoint.
+        local_chunks (List[ChunkStorageMetadata]): Local chunks that needs to be
+            loaded.
+
+    Returns:
+        A list of ``ReadItem`` that will satisfy all input chunks.
+    """
     read_items = []
     # this is a naive quadratic algo that can be optimized later
-    for idx, shard in enumerate(local_shards):
+    for idx, shard in enumerate(local_chunks):
         for storage_idx, storage_md in enumerate(checkpoint_md.chunks):
-            shard_md_from_storage = ShardMetadata(
-                shard_sizes=list(storage_md.sizes),
-                shard_offsets=list(storage_md.offsets),
-            )
-
             if not _check_shard_metadata_pair_overlap(
-                shard.metadata, shard_md_from_storage
+                shard, storage_md
             ):
                 continue
 
@@ -175,7 +177,7 @@ def _create_sharded_read_items(
                 offset_for_current_tensor,
                 length,
             ) in _shards_get_overlap_region_wrt_saved_tensor(
-                saved_shard=shard_md_from_storage, current_shard=shard.metadata
+                saved_shard=storage_md, current_shard=shard
             ):
                 storage_offsets.append(offset_for_saved_tensor)
                 dest_offsets.append(offset_for_current_tensor)
@@ -184,7 +186,7 @@ def _create_sharded_read_items(
             read_items.append(
                 _create_read_item_for_tensor(
                     dest_index=MetadataIndex(
-                        fqn, shard.metadata.shard_offsets, idx
+                        fqn, shard.offsets, idx
                     ),
                     dest_offsets=dest_offsets,
                     storage_index=MetadataIndex(
@@ -228,7 +230,7 @@ def _create_write_items(fqn: str, object: Any) -> List[WriteItem]:
         return [_create_write_item_for_bytesio(fqn, object)]
 
 
-def _create_shard_from_dtensor(tensor: DTensor) -> Shard:
+def _create_chunk_from_dtensor(tensor: DTensor) -> ChunkStorageMetadata:
     device_mesh = tensor.device_mesh
     assert (
         device_mesh.ndim == 1
@@ -236,30 +238,26 @@ def _create_shard_from_dtensor(tensor: DTensor) -> Shard:
 
     sizes = torch.Size(compute_local_shape(tensor.shape, device_mesh, tensor.placements))
     offsets = torch.Size(compute_local_offset(tensor.shape, device_mesh, tensor.placements))
-    return Shard(
-        tensor=tensor.to_local(),
-        metadata=ShardMetadata(
-            shard_offsets=list(offsets),
-            shard_sizes=list(sizes),
-            placement=f"rank:{dist.get_rank()}/{tensor.to_local().device}",
-        ),
+    return ChunkStorageMetadata(
+        offsets=offsets,
+        sizes=sizes,
     )
 
 
 def _create_read_items(fqn: str, md: STORAGE_TYPES, obj: Any) -> List[ReadItem]:
     if not isinstance(md, BytesStorageMetadata):
         if isinstance(obj, DTensor):
-            local_shards = [_create_shard_from_dtensor(obj)]
+            local_chunks = [_create_chunk_from_dtensor(obj)]
         elif isinstance(obj, ShardedTensor):
-            local_shards = obj.local_shards()
+            local_chunks = [_chunk_for_shard(shard.metadata) for shard in obj.local_shards()]
         elif isinstance(obj, torch.Tensor):
-            local_shards = [_create_shard_from_tensor(obj)]
+            local_chunks = [_create_chunk_from_tensor(obj)]
         else:
             raise ValueError(
                 f"Invalid checkpoint metadata for {fqn}, "
                 + f"expected BytesStorageMetadata but found {type(md)}"
             )
-        return _create_sharded_read_items(fqn, md, local_shards)
+        return create_read_items_for_chunk_list(fqn, md, local_chunks)
     else:
         return [
             _create_read_item_for_byteio(


### PR DESCRIPTION
This function is needed by all ReadPlanner subclasses that are trying to implement support for a custom distributed tensor.

Better expose it than have users reimplement this.
