### PR TITLE
[dtensor] set cuda device automatically, and refactor error handling

### DIFF
--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -4,22 +4,24 @@ from typing import List, Optional, Sequence, TypeVar, Union
 
 import torch
 from torch.distributed.distributed_c10d import (
+    Backend,
+    GroupMember,
+    ProcessGroup,
+    ReduceOp,
+    Work,
     _get_default_group,
     all_gather,
     all_to_all,
     broadcast,
+    get_backend,
     get_global_rank,
     get_rank,
     get_world_size,
-    GroupMember,
     init_process_group,
     is_initialized,
     new_group,
-    ProcessGroup,
     reduce_scatter,
-    ReduceOp,
     scatter,
-    Work,
 )
 
 import torch.distributed.distributed_c10d as c10d
@@ -121,32 +123,37 @@ class DeviceMesh:
             self._dim_groups = self._init_process_groups()
 
     def _get_or_create_default_group(self):
-        self._backend = "gloo" if self.device_type == "cpu" else "nccl"
-        if not is_initialized():
+        self._backend = Backend.GLOO if self.device_type == "cpu" else Backend.NCCL
+        default_initialized = is_initialized()
+        if not default_initialized:
             init_process_group(backend=self._backend)
-        else:
-            world_size = get_world_size()
-            if self.mesh.numel() > world_size:
-                raise RuntimeError(
-                    f"Mesh should not be bigger than default world size, but found {self.mesh.numel()} ranks!"
-                )
+
+        world_size = get_world_size()
+        if self.mesh.numel() > world_size:
+            raise RuntimeError(
+                f"Mesh should not be bigger than default world size, but found {self.mesh.numel()} ranks!"
+            )
 
         # TODO: we should do allgather the mesh tensor to ensure every rank have the same mesh value
         # TODO: if user want to pass pg_options, offer a way to do it
-        # check default pg backend, should support device_type
-        if self.device_type == "cpu":
-            assert (
-                self._backend == "gloo" or self._backend == "threaded"
-            ), f"ProcessGroup backend: {self._backend} not supporting CPU!"
+        world_backend = get_backend()
+        if self.device_type == "cpu"
+            cpu_backends = ["gloo", "threaded"]
+            assert world_backend in cpu_backends, f"Default PG backend: {world_backend} not supporting CPU!"
         elif self.device_type == "cuda":
-            if self._backend == "gloo":
+            cuda_backends = ["nccl", "gloo", "threaded"]
+            if world_backend == "gloo":
                 warnings.warn(
                     "We recommend using nccl backend for cuda device type, gloo backend might only have partial support!"
                 )
-            assert self._backend == "gloo" or self._backend == "nccl" or self._backend == "threaded"
+            assert world_backend in cuda_backends, f"Default PG backend: {world_backend} not supporting CUDA!"
+            if not default_initialized:
+                # automatically set the current cuda device base on num of gpu devices available in each host
+                # NOTE: This device selection would only work for homogenous hardware.
+                torch.cuda.set_device(get_rank() % torch.cuda.device_count())
         else:
             raise RuntimeError(
-                f"DeviceMesh only support cpu or cuda device type, but got {self.device_type}"
+                f"DeviceMesh only support cpu or cuda device type for now, but got {self.device_type}"
             )
 
         # calculate the coordinates of the current global rank on the mesh

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -54,7 +54,7 @@ MeshExprT = Union[
 ]
 
 
-class DeviceMesh:
+class DeviceMesh(object):
     """
     DeviceMesh represents a mesh of devices, where layout of devices could be
     represented as a n-d dimension array, and each value of the n-d dimensional
@@ -137,7 +137,7 @@ class DeviceMesh:
         # TODO: we should do allgather the mesh tensor to ensure every rank have the same mesh value
         # TODO: if user want to pass pg_options, offer a way to do it
         world_backend = get_backend()
-        if self.device_type == "cpu"
+        if self.device_type == "cpu":
             cpu_backends = ["gloo", "threaded"]
             assert world_backend in cpu_backends, f"Default PG backend: {world_backend} not supporting CPU!"
         elif self.device_type == "cuda":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97583
* #95629

This PR would detect if device_type is cuda, if cuda passed in,
we would set the current cuda device each process/thread automatically
(This assumption is based on homogenous devices).

Also refactored error handling code