### PR TITLE
[BE] Apply ufmt to run_test and GitHub Python util scripts

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-from subprocess import check_call
+import shutil
+import sys
 from pathlib import Path
+from subprocess import check_call
 from tempfile import TemporaryDirectory
 from typing import Optional
-import sys
-import shutil
+
 SCRIPT_DIR = Path(__file__).parent
 REPO_DIR = SCRIPT_DIR.parent.parent
+
 
 def read_triton_pin() -> str:
     with open(REPO_DIR / ".ci" / "docker" / "ci_commit_pins" / "triton.txt") as f:
@@ -19,7 +21,7 @@ def read_triton_version() -> str:
 
 
 def check_and_replace(inp: str, src: str, dst: str) -> str:
-    """ Checks that `src` can be found in `input` and replaces it with `dst` """
+    """Checks that `src` can be found in `input` and replaces it with `dst`"""
     if src not in inp:
         raise RuntimeError(f"Can't find ${src} in the input")
     return inp.replace(src, dst)
@@ -29,9 +31,11 @@ def patch_setup_py(path: Path, *, version: str, name: str = "triton") -> None:
     with open(path) as f:
         orig = f.read()
     # Replace name
-    orig = check_and_replace(orig, "name=\"triton\",", f"name=\"{name}\",")
+    orig = check_and_replace(orig, 'name="triton",', f'name="{name}",')
     # Replace version
-    orig = check_and_replace(orig, f"version=\"{read_triton_version()}\",", f"version=\"{version}\",")
+    orig = check_and_replace(
+        orig, f'version="{read_triton_version()}",', f'version="{version}",'
+    )
     with open(path, "w") as f:
         f.write(orig)
 
@@ -40,12 +44,20 @@ def patch_init_py(path: Path, *, version: str) -> None:
     with open(path) as f:
         orig = f.read()
     # Replace version
-    orig = check_and_replace(orig, f"__version__ = '{read_triton_version()}'", f"__version__ = \"{version}\"")
+    orig = check_and_replace(
+        orig, f"__version__ = '{read_triton_version()}'", f'__version__ = "{version}"'
+    )
     with open(path, "w") as f:
         f.write(orig)
 
 
-def build_triton(*, version: str, commit_hash: str, build_conda: bool = False, py_version : Optional[str] = None) -> Path:
+def build_triton(
+    *,
+    version: str,
+    commit_hash: str,
+    build_conda: bool = False,
+    py_version: Optional[str] = None,
+) -> Path:
     with TemporaryDirectory() as tmpdir:
         triton_basedir = Path(tmpdir) / "triton"
         triton_pythondir = triton_basedir / "python"
@@ -53,26 +65,60 @@ def build_triton(*, version: str, commit_hash: str, build_conda: bool = False, p
         check_call(["git", "checkout", commit_hash], cwd=triton_basedir)
         if build_conda:
             with open(triton_basedir / "meta.yaml", "w") as meta:
-                print(f"package:\n  name: torchtriton\n  version: {version}+{commit_hash[:10]}\n", file=meta)
+                print(
+                    f"package:\n  name: torchtriton\n  version: {version}+{commit_hash[:10]}\n",
+                    file=meta,
+                )
                 print("source:\n  path: .\n", file=meta)
-                print("build:\n  string: py{{py}}\n  number: 1\n  script: cd python; "
-                      "python setup.py install --single-version-externally-managed --record=record.txt\n", file=meta)
-                print("requirements:\n  host:\n    - python\n    - setuptools\n  run:\n    - python\n"
-                      "    - filelock\n    - pytorch\n", file=meta)
-                print("about:\n  home: https://github.com/openai/triton\n  license: MIT\n  summary:"
-                      " 'A language and compiler for custom Deep Learning operation'", file=meta)
+                print(
+                    "build:\n  string: py{{py}}\n  number: 1\n  script: cd python; "
+                    "python setup.py install --single-version-externally-managed --record=record.txt\n",
+                    file=meta,
+                )
+                print(
+                    "requirements:\n  host:\n    - python\n    - setuptools\n  run:\n    - python\n"
+                    "    - filelock\n    - pytorch\n",
+                    file=meta,
+                )
+                print(
+                    "about:\n  home: https://github.com/openai/triton\n  license: MIT\n  summary:"
+                    " 'A language and compiler for custom Deep Learning operation'",
+                    file=meta,
+                )
 
-            patch_init_py(triton_pythondir / "triton" / "__init__.py", version=f"{version}+{commit_hash[:10]}")
+            patch_init_py(
+                triton_pythondir / "triton" / "__init__.py",
+                version=f"{version}+{commit_hash[:10]}",
+            )
             if py_version is None:
                 py_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-            check_call(["conda", "build", "--python", py_version,
-                        "-c", "pytorch-nightly", "--output-folder", tmpdir, "."], cwd=triton_basedir)
+            check_call(
+                [
+                    "conda",
+                    "build",
+                    "--python",
+                    py_version,
+                    "-c",
+                    "pytorch-nightly",
+                    "--output-folder",
+                    tmpdir,
+                    ".",
+                ],
+                cwd=triton_basedir,
+            )
             conda_path = list(Path(tmpdir).glob("linux-64/torchtriton*.bz2"))[0]
             shutil.copy(conda_path, Path.cwd())
             return Path.cwd() / conda_path.name
 
-        patch_setup_py(triton_pythondir / "setup.py", name="pytorch-triton", version=f"{version}+{commit_hash[:10]}")
-        patch_init_py(triton_pythondir / "triton" / "__init__.py", version=f"{version}+{commit_hash[:10]}")
+        patch_setup_py(
+            triton_pythondir / "setup.py",
+            name="pytorch-triton",
+            version=f"{version}+{commit_hash[:10]}",
+        )
+        patch_init_py(
+            triton_pythondir / "triton" / "__init__.py",
+            version=f"{version}+{commit_hash[:10]}",
+        )
         check_call([sys.executable, "setup.py", "bdist_wheel"], cwd=triton_pythondir)
         whl_path = list((triton_pythondir / "dist").glob("*.whl"))[0]
         shutil.copy(whl_path, Path.cwd())
@@ -81,16 +127,19 @@ def build_triton(*, version: str, commit_hash: str, build_conda: bool = False, p
 
 def main() -> None:
     from argparse import ArgumentParser
+
     parser = ArgumentParser("Build Triton binaries")
     parser.add_argument("--build-conda", action="store_true")
     parser.add_argument("--py-version", type=str)
     parser.add_argument("--commit-hash", type=str, default=read_triton_pin())
     parser.add_argument("--triton-version", type=str, default=read_triton_version())
     args = parser.parse_args()
-    build_triton(commit_hash=args.commit_hash,
-                 version=args.triton_version,
-                 build_conda=args.build_conda,
-                 py_version=args.py_version)
+    build_triton(
+        commit_hash=args.commit_hash,
+        version=args.triton_version,
+        build_conda=args.build_conda,
+        py_version=args.py_version,
+    )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/check_labels.py
+++ b/.github/scripts/check_labels.py
@@ -3,21 +3,12 @@
 
 from typing import Any
 
-from gitutils import (
-    get_git_remote_name,
-    get_git_repo_dir,
-    GitRepo,
-)
+from github_utils import gh_delete_comment, gh_post_pr_comment
+
+from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
+from label_utils import has_required_labels, is_label_err_comment, LABEL_ERR_MSG
 from trymerge import GitHubPR
-from github_utils import (
-    gh_delete_comment,
-    gh_post_pr_comment,
-)
-from label_utils import (
-    LABEL_ERR_MSG,
-    is_label_err_comment,
-    has_required_labels,
-)
+
 
 def delete_all_label_err_comments(pr: "GitHubPR") -> None:
     for comment in pr.get_comments():
@@ -33,6 +24,7 @@ def add_label_err_comment(pr: "GitHubPR") -> None:
 
 def parse_args() -> Any:
     from argparse import ArgumentParser
+
     parser = ArgumentParser("Check PR labels")
     parser.add_argument("pr_num", type=int)
 

--- a/.github/scripts/collect_ciflow_labels.py
+++ b/.github/scripts/collect_ciflow_labels.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-from pathlib import Path
-from typing import Any, Dict, List, Set, cast
-import yaml
 import sys
+from pathlib import Path
+from typing import Any, cast, Dict, List, Set
+
+import yaml
 
 GITHUB_DIR = Path(__file__).parent.parent
+
 
 def get_workflows_push_tags() -> Set[str]:
     "Extract all known push tags from workflows"
@@ -22,8 +24,10 @@ def get_workflows_push_tags() -> Set[str]:
 
 
 def filter_ciflow_tags(tags: Set[str]) -> List[str]:
-    " Return sorted list of ciflow tags"
-    return sorted(tag[:-2] for tag in tags if tag.startswith("ciflow/") and tag.endswith("/*"))
+    "Return sorted list of ciflow tags"
+    return sorted(
+        tag[:-2] for tag in tags if tag.startswith("ciflow/") and tag.endswith("/*")
+    )
 
 
 def read_probot_config() -> Dict[str, Any]:
@@ -40,6 +44,7 @@ def update_probot_config(labels: Set[str]) -> None:
 
 if __name__ == "__main__":
     from argparse import ArgumentParser
+
     parser = ArgumentParser("Validate or update list of tags")
     parser.add_argument("--validate-tags", action="store_true")
     args = parser.parse_args()
@@ -51,9 +56,15 @@ if __name__ == "__main__":
         if config_tags != ciflow_tags:
             print("Tags mismatch!")
             if ciflow_tags.difference(config_tags):
-                print("Reference in workflows but not in config", ciflow_tags.difference(config_tags))
+                print(
+                    "Reference in workflows but not in config",
+                    ciflow_tags.difference(config_tags),
+                )
             if config_tags.difference(ciflow_tags):
-                print("Reference in config, but not in workflows", config_tags.difference(ciflow_tags))
+                print(
+                    "Reference in config, but not in workflows",
+                    config_tags.difference(ciflow_tags),
+                )
             print(f"Please run {__file__} to remediate the difference")
             sys.exit(-1)
         print("All tags are listed in pytorch-probot.yml")

--- a/.github/scripts/comment_on_pr.py
+++ b/.github/scripts/comment_on_pr.py
@@ -1,8 +1,9 @@
+import os
 from typing import Any
+
 from github_utils import gh_post_pr_comment
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from trymerge_explainer import BOT_COMMANDS_WIKI
-import os
 
 
 def parse_args() -> Any:

--- a/.github/scripts/convert_lintrunner_annotations_to_github.py
+++ b/.github/scripts/convert_lintrunner_annotations_to_github.py
@@ -24,7 +24,12 @@ class GitHubAnnotation(NamedTuple):
     title: Optional[str]
     raw_details: Optional[str]
 
-PYTORCH_ROOT = Path(subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('ascii').strip())
+
+PYTORCH_ROOT = Path(
+    subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+    .decode("ascii")
+    .strip()
+)
 
 annotations = []
 for line in sys.stdin:
@@ -32,7 +37,6 @@ for line in sys.stdin:
 
     path = lint_message.get("path")
     line = lint_message.get("line")
-
 
     code = lint_message["code"]
     severity = lint_message["severity"]
@@ -48,16 +52,18 @@ for line in sys.stdin:
     # normalize path relative to git root
     path = Path(path).relative_to(PYTORCH_ROOT)
 
-    annotations.append(GitHubAnnotation(
-        path=str(path),
-        start_line=int(line),
-        end_line=int(line),
-        start_column=None,
-        end_column=None,
-        annotation_level=GitHubAnnotationLevel.FAILURE,
-        message=description,
-        title=f"({code}) {name}",
-        raw_details=None,
-    )._asdict())
+    annotations.append(
+        GitHubAnnotation(
+            path=str(path),
+            start_line=int(line),
+            end_line=int(line),
+            start_column=None,
+            end_column=None,
+            annotation_level=GitHubAnnotationLevel.FAILURE,
+            message=description,
+            title=f"({code}) {name}",
+            raw_details=None,
+        )._asdict()
+    )
 
 print(json.dumps(annotations), flush=True)

--- a/.github/scripts/convert_lintrunner_annotations_to_github.py
+++ b/.github/scripts/convert_lintrunner_annotations_to_github.py
@@ -6,6 +6,7 @@ from enum import Enum
 from pathlib import Path
 from typing import NamedTuple, Optional
 
+
 # From: https://docs.github.com/en/rest/reference/checks
 class GitHubAnnotationLevel(str, Enum):
     NOTICE = "notice"

--- a/.github/scripts/ensure_actions_will_cancel.py
+++ b/.github/scripts/ensure_actions_will_cancel.py
@@ -2,15 +2,18 @@
 
 import argparse
 import sys
-import yaml
 
 from pathlib import Path
+
+import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
-EXPECTED_GROUP = "${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}" \
+EXPECTED_GROUP = (
+    "${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}"
     "-${{ github.event_name == 'workflow_dispatch' }}"
+)
 
 
 def should_check(filename: Path) -> bool:

--- a/.github/scripts/export_pytorch_labels.py
+++ b/.github/scripts/export_pytorch_labels.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-'''
+"""
 Test ownership was introduced in https://github.com/pytorch/pytorch/issues/66232.
 
 As a part of enforcing test ownership, we want to maintain a list of existing PyTorch labels
@@ -8,17 +8,19 @@ pytorch/pytorch labels so that the file could be uploaded to S3.
 
 This script assumes the correct env vars are set for AWS permissions.
 
-'''
+"""
+
+import json
+from typing import Any
 
 import boto3  # type: ignore[import]
-import json
 
 from label_utils import gh_get_labels
-from typing import Any
 
 
 def parse_args() -> Any:
     from argparse import ArgumentParser
+
     parser = ArgumentParser("Export PR labels")
     parser.add_argument("org", type=str)
     parser.add_argument("repo", type=str)
@@ -30,9 +32,9 @@ def main() -> None:
     args = parse_args()
     print(f"Exporting labels for {args.org}/{args.repo}")
     labels_file_name = "pytorch_labels.json"
-    obj = boto3.resource('s3').Object('ossci-metrics', labels_file_name)
+    obj = boto3.resource("s3").Object("ossci-metrics", labels_file_name)
     obj.put(Body=json.dumps(gh_get_labels(args.org, args.repo)).encode())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -123,7 +123,6 @@ def get_latest_green_commit(commits: List[str], results: List[Dict[str, Any]]) -
 
 
 def main() -> None:
-
     commits = get_latest_commits()
     results = query_commits(commits)
 

--- a/.github/scripts/fetch_latest_green_commit.py
+++ b/.github/scripts/fetch_latest_green_commit.py
@@ -1,19 +1,22 @@
-import sys
-from typing import Any, Dict, List, NamedTuple, Tuple, cast
-from gitutils import _check_output
-
-import rockset  # type: ignore[import]
 import os
 import re
+import sys
+from typing import Any, cast, Dict, List, NamedTuple, Tuple
+
+import rockset  # type: ignore[import]
+from gitutils import _check_output
+
 
 def eprint(msg: str) -> None:
     print(msg, file=sys.stderr)
+
 
 class WorkflowCheck(NamedTuple):
     workflowName: str
     name: str
     jobName: str
     conclusion: str
+
 
 def get_latest_commits() -> List[str]:
     latest_viable_commit = _check_output(
@@ -39,41 +42,45 @@ def get_latest_commits() -> List[str]:
 
     return commits
 
+
 def query_commits(commits: List[str]) -> List[Dict[str, Any]]:
     rs = rockset.RocksetClient(
         host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
     )
-    params = [{
-        "name": "shas",
-        "type": "string",
-        "value": ",".join(commits)
-    }]
+    params = [{"name": "shas", "type": "string", "value": ",".join(commits)}]
     res = rs.QueryLambdas.execute_query_lambda(
-        query_lambda='commit_jobs_batch_query',
-        version='8003fdfd18b64696',
-        workspace='commons',
-        parameters=params
+        query_lambda="commit_jobs_batch_query",
+        version="8003fdfd18b64696",
+        workspace="commons",
+        parameters=params,
     )
 
     return cast(List[Dict[str, Any]], res.results)
 
+
 def print_commit_status(commit: str, results: Dict[str, Any]) -> None:
     print(commit)
-    for check in results['results']:
-        if check['sha'] == commit:
+    for check in results["results"]:
+        if check["sha"] == commit:
             print(f"\t{check['conclusion']:>10}: {check['name']}")
 
-def get_commit_results(commit: str, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+
+def get_commit_results(
+    commit: str, results: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
     workflow_checks = []
     for check in results:
-        if check['sha'] == commit:
-            workflow_checks.append(WorkflowCheck(
-                workflowName=check['workflowName'],
-                name=check['name'],
-                jobName=check['jobName'],
-                conclusion=check['conclusion'],
-            )._asdict())
+        if check["sha"] == commit:
+            workflow_checks.append(
+                WorkflowCheck(
+                    workflowName=check["workflowName"],
+                    name=check["name"],
+                    jobName=check["jobName"],
+                    conclusion=check["conclusion"],
+                )._asdict()
+            )
     return workflow_checks
+
 
 def isGreen(commit: str, results: List[Dict[str, Any]]) -> Tuple[bool, str]:
     workflow_checks = get_commit_results(commit, results)
@@ -87,8 +94,8 @@ def isGreen(commit: str, results: List[Dict[str, Any]]) -> Tuple[bool, str]:
     }
 
     for check in workflow_checks:
-        workflowName = check['workflowName']
-        conclusion = check['conclusion']
+        workflowName = check["workflowName"]
+        conclusion = check["conclusion"]
         for required_check in regex:
             if re.match(required_check, workflowName, flags=re.IGNORECASE):
                 if conclusion not in ["success", "skipped"]:
@@ -102,6 +109,7 @@ def isGreen(commit: str, results: List[Dict[str, Any]]) -> Tuple[bool, str]:
 
     return (True, "")
 
+
 def get_latest_green_commit(commits: List[str], results: List[Dict[str, Any]]) -> Any:
     for commit in commits:
         eprint(f"Checking {commit}")
@@ -113,6 +121,7 @@ def get_latest_green_commit(commits: List[str], results: List[Dict[str, Any]]) -
             eprint("RED: " + msg)
     return None
 
+
 def main() -> None:
 
     commits = get_latest_commits()
@@ -120,6 +129,7 @@ def main() -> None:
 
     latest_viable_commit = get_latest_green_commit(commits, results)
     print(latest_viable_commit)
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -10,7 +10,7 @@ architectures:
     * Latest ROCM
 """
 
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
 
 
 CUDA_ARCHES = ["11.7", "11.8"]
@@ -19,7 +19,8 @@ CUDA_ARCHES = ["11.7", "11.8"]
 ROCM_ARCHES = ["5.3", "5.4.2"]
 
 
-CPU_CXX11_ABI_ARCH = ['cpu-cxx11-abi']
+CPU_CXX11_ABI_ARCH = ["cpu-cxx11-abi"]
+
 
 def arch_type(arch_version: str) -> str:
     if arch_version in CUDA_ARCHES:
@@ -121,9 +122,12 @@ def generate_conda_matrix(os: str) -> List[Dict[str, str]]:
     return ret
 
 
-def generate_libtorch_matrix(os: str, abi_version: str,
-                             arches: Optional[List[str]] = None,
-                             libtorch_variants: Optional[List[str]] = None) -> List[Dict[str, str]]:
+def generate_libtorch_matrix(
+    os: str,
+    abi_version: str,
+    arches: Optional[List[str]] = None,
+    libtorch_variants: Optional[List[str]] = None,
+) -> List[Dict[str, str]]:
     if arches is None:
         arches = ["cpu"]
         if os == "linux":
@@ -163,7 +167,9 @@ def generate_libtorch_matrix(os: str, abi_version: str,
                     "devtoolset": abi_version if os != "windows" else "",
                     "container_image": LIBTORCH_CONTAINER_IMAGES[
                         (arch_version, abi_version)
-                    ] if os != "windows" else "",
+                    ]
+                    if os != "windows"
+                    else "",
                     "package_type": "libtorch",
                     "build_name": f"libtorch-{gpu_arch_type}{gpu_arch_version}-{libtorch_variant}-{abi_version}".replace(
                         ".", "_"
@@ -173,9 +179,11 @@ def generate_libtorch_matrix(os: str, abi_version: str,
     return ret
 
 
-def generate_wheels_matrix(os: str,
-                           arches: Optional[List[str]] = None,
-                           python_versions: Optional[List[str]] = None) -> List[Dict[str, str]]:
+def generate_wheels_matrix(
+    os: str,
+    arches: Optional[List[str]] = None,
+    python_versions: Optional[List[str]] = None,
+) -> List[Dict[str, str]]:
     package_type = "wheel"
     if os == "linux":
         # NOTE: We only build manywheel packages for linux
@@ -196,7 +204,11 @@ def generate_wheels_matrix(os: str,
     for python_version in python_versions:
         for arch_version in arches:
             gpu_arch_type = arch_type(arch_version)
-            gpu_arch_version = "" if arch_version == "cpu" or arch_version == "cpu-cxx11-abi" else arch_version
+            gpu_arch_version = (
+                ""
+                if arch_version == "cpu" or arch_version == "cpu-cxx11-abi"
+                else arch_version
+            )
             # Skip rocm 3.11 binaries for now as the docker image are not correct
             if python_version == "3.11" and gpu_arch_type == "rocm":
                 continue
@@ -215,8 +227,7 @@ def generate_wheels_matrix(os: str,
                         "devtoolset": "",
                         "container_image": WHEEL_CONTAINER_IMAGES[arch_version],
                         "package_type": package_type,
-                        "pytorch_extra_install_requirements":
-                        "nvidia-cuda-nvrtc-cu11==11.7.99; platform_system == 'Linux' and platform_machine == 'x86_64' | "
+                        "pytorch_extra_install_requirements": "nvidia-cuda-nvrtc-cu11==11.7.99; platform_system == 'Linux' and platform_machine == 'x86_64' | "  # noqa: B950
                         "nvidia-cuda-runtime-cu11==11.7.99; platform_system == 'Linux' and platform_machine == 'x86_64' | "
                         "nvidia-cuda-cupti-cu11==11.7.101; platform_system == 'Linux' and platform_machine == 'x86_64' | "
                         "nvidia-cudnn-cu11==8.5.0.96; platform_system == 'Linux' and platform_machine == 'x86_64' | "
@@ -227,9 +238,7 @@ def generate_wheels_matrix(os: str,
                         "nvidia-cusparse-cu11==11.7.4.91; platform_system == 'Linux' and platform_machine == 'x86_64' | "
                         "nvidia-nccl-cu11==2.14.3; platform_system == 'Linux' and platform_machine == 'x86_64' | "
                         "nvidia-nvtx-cu11==11.7.91; platform_system == 'Linux' and platform_machine == 'x86_64'",
-                        "build_name":
-                        f"{package_type}-py{python_version}-{gpu_arch_type}{gpu_arch_version}-with-pypi-cudnn"
-                        .replace(
+                        "build_name": f"{package_type}-py{python_version}-{gpu_arch_type}{gpu_arch_version}-with-pypi-cudnn".replace(  # noqa: B950
                             ".", "_"
                         ),
                     }
@@ -243,7 +252,9 @@ def generate_wheels_matrix(os: str,
                     "desired_cuda": translate_desired_cuda(
                         gpu_arch_type, gpu_arch_version
                     ),
-                    "devtoolset": "cxx11-abi" if arch_version == "cpu-cxx11-abi" else "",
+                    "devtoolset": "cxx11-abi"
+                    if arch_version == "cpu-cxx11-abi"
+                    else "",
                     "container_image": WHEEL_CONTAINER_IMAGES[arch_version],
                     "package_type": package_type,
                     "build_name": f"{package_type}-py{python_version}-{gpu_arch_type}{gpu_arch_version}".replace(

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
 
-from dataclasses import asdict, dataclass, field
-from pathlib import Path
-from typing import Dict, Set, List, Literal, Iterable
-
-import jinja2
-
 import os
 import sys
-from typing_extensions import TypedDict  # Python 3.11+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Literal, Set
 
 import generate_binary_build_matrix  # type: ignore[import]
+
+import jinja2
+from typing_extensions import TypedDict  # Python 3.11+
 
 Arch = Literal["windows", "linux", "macos"]
 
@@ -22,6 +21,7 @@ LABEL_CIFLOW_PERIODIC = "ciflow/periodic"
 LABEL_CIFLOW_BINARIES_LIBTORCH = "ciflow/binaries_libtorch"
 LABEL_CIFLOW_BINARIES_CONDA = "ciflow/binaries_conda"
 LABEL_CIFLOW_BINARIES_WHEEL = "ciflow/binaries_wheel"
+
 
 @dataclass
 class CIFlowConfig:
@@ -36,9 +36,11 @@ class CIFlowConfig:
             if LABEL_CIFLOW_PERIODIC not in self.labels:
                 self.labels.add(LABEL_CIFLOW_TRUNK)
 
+
 class Config(TypedDict):
     num_shards: int
     runner: str
+
 
 @dataclass
 class BinaryBuildWorkflow:
@@ -47,23 +49,28 @@ class BinaryBuildWorkflow:
     package_type: str
 
     # Optional fields
-    build_environment: str = ''
-    abi_version: str = ''
+    build_environment: str = ""
+    abi_version: str = ""
     ciflow_config: CIFlowConfig = field(default_factory=CIFlowConfig)
-    is_scheduled: str = ''
-    branches: str = 'nightly'
+    is_scheduled: str = ""
+    branches: str = "nightly"
     # Mainly for macos
     cross_compile_arm64: bool = False
-    xcode_version: str = ''
+    xcode_version: str = ""
 
     def __post_init__(self) -> None:
         if self.abi_version:
-            self.build_environment = f"{self.os}-binary-{self.package_type}-{self.abi_version}"
+            self.build_environment = (
+                f"{self.os}-binary-{self.package_type}-{self.abi_version}"
+            )
         else:
             self.build_environment = f"{self.os}-binary-{self.package_type}"
 
     def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
-        output_file_path = GITHUB_DIR / f"workflows/generated-{self.build_environment}-{self.branches}.yml"
+        output_file_path = (
+            GITHUB_DIR
+            / f"workflows/generated-{self.build_environment}-{self.branches}.yml"
+        )
         with open(output_file_path, "w") as output_file:
             GENERATED = "generated"  # Note that please keep the variable GENERATED otherwise phabricator will hide the whole file
             output_file.writelines([f"# @{GENERATED} DO NOT EDIT MANUALLY\n"])
@@ -77,17 +84,21 @@ class BinaryBuildWorkflow:
                 output_file.write("\n")
         print(output_file_path)
 
+
 class OperatingSystem:
     LINUX = "linux"
     WINDOWS = "windows"
     MACOS = "macos"
     MACOS_ARM64 = "macos-arm64"
 
+
 LINUX_BINARY_BUILD_WORFKLOWS = [
     BinaryBuildWorkflow(
         os=OperatingSystem.LINUX,
         package_type="manywheel",
-        build_configs=generate_binary_build_matrix.generate_wheels_matrix(OperatingSystem.LINUX),
+        build_configs=generate_binary_build_matrix.generate_wheels_matrix(
+            OperatingSystem.LINUX
+        ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
             isolated_workflow=True,
@@ -96,7 +107,9 @@ LINUX_BINARY_BUILD_WORFKLOWS = [
     BinaryBuildWorkflow(
         os=OperatingSystem.LINUX,
         package_type="conda",
-        build_configs=generate_binary_build_matrix.generate_conda_matrix(OperatingSystem.LINUX),
+        build_configs=generate_binary_build_matrix.generate_conda_matrix(
+            OperatingSystem.LINUX
+        ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_CONDA},
             isolated_workflow=True,
@@ -133,18 +146,16 @@ LINUX_BINARY_SMOKE_WORKFLOWS = [
         os=OperatingSystem.LINUX,
         package_type="manywheel",
         build_configs=generate_binary_build_matrix.generate_wheels_matrix(
-            OperatingSystem.LINUX,
-            arches=["11.8"],
-            python_versions=["3.8"]),
+            OperatingSystem.LINUX, arches=["11.8"], python_versions=["3.8"]
+        ),
         branches="master",
     ),
     BinaryBuildWorkflow(
         os=OperatingSystem.LINUX,
         package_type="manywheel",
         build_configs=generate_binary_build_matrix.generate_wheels_matrix(
-            OperatingSystem.LINUX,
-            arches=["11.7"],
-            python_versions=["3.8"]),
+            OperatingSystem.LINUX, arches=["11.7"], python_versions=["3.8"]
+        ),
         branches="master",
     ),
     BinaryBuildWorkflow(
@@ -152,7 +163,8 @@ LINUX_BINARY_SMOKE_WORKFLOWS = [
         package_type="libtorch",
         abi_version=generate_binary_build_matrix.CXX11_ABI,
         build_configs=generate_binary_build_matrix.generate_libtorch_matrix(
-            OperatingSystem.LINUX, generate_binary_build_matrix.CXX11_ABI,
+            OperatingSystem.LINUX,
+            generate_binary_build_matrix.CXX11_ABI,
             arches=["cpu"],
             libtorch_variants=["shared-with-deps"],
         ),
@@ -163,7 +175,8 @@ LINUX_BINARY_SMOKE_WORKFLOWS = [
         package_type="libtorch",
         abi_version=generate_binary_build_matrix.PRE_CXX11_ABI,
         build_configs=generate_binary_build_matrix.generate_libtorch_matrix(
-            OperatingSystem.LINUX, generate_binary_build_matrix.PRE_CXX11_ABI,
+            OperatingSystem.LINUX,
+            generate_binary_build_matrix.PRE_CXX11_ABI,
             arches=["cpu"],
             libtorch_variants=["shared-with-deps"],
         ),
@@ -175,7 +188,9 @@ WINDOWS_BINARY_BUILD_WORKFLOWS = [
     BinaryBuildWorkflow(
         os=OperatingSystem.WINDOWS,
         package_type="wheel",
-        build_configs=generate_binary_build_matrix.generate_wheels_matrix(OperatingSystem.WINDOWS),
+        build_configs=generate_binary_build_matrix.generate_wheels_matrix(
+            OperatingSystem.WINDOWS
+        ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
             isolated_workflow=True,
@@ -184,7 +199,9 @@ WINDOWS_BINARY_BUILD_WORKFLOWS = [
     BinaryBuildWorkflow(
         os=OperatingSystem.WINDOWS,
         package_type="conda",
-        build_configs=generate_binary_build_matrix.generate_conda_matrix(OperatingSystem.WINDOWS),
+        build_configs=generate_binary_build_matrix.generate_conda_matrix(
+            OperatingSystem.WINDOWS
+        ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_CONDA},
             isolated_workflow=True,
@@ -221,7 +238,8 @@ WINDOWS_BINARY_SMOKE_WORKFLOWS = [
         package_type="libtorch",
         abi_version=generate_binary_build_matrix.RELEASE,
         build_configs=generate_binary_build_matrix.generate_libtorch_matrix(
-            OperatingSystem.WINDOWS, generate_binary_build_matrix.RELEASE,
+            OperatingSystem.WINDOWS,
+            generate_binary_build_matrix.RELEASE,
             arches=["cpu"],
             libtorch_variants=["shared-with-deps"],
         ),
@@ -232,7 +250,8 @@ WINDOWS_BINARY_SMOKE_WORKFLOWS = [
         package_type="libtorch",
         abi_version=generate_binary_build_matrix.DEBUG,
         build_configs=generate_binary_build_matrix.generate_libtorch_matrix(
-            OperatingSystem.WINDOWS, generate_binary_build_matrix.DEBUG,
+            OperatingSystem.WINDOWS,
+            generate_binary_build_matrix.DEBUG,
             arches=["cpu"],
             libtorch_variants=["shared-with-deps"],
         ),
@@ -244,7 +263,9 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
     BinaryBuildWorkflow(
         os=OperatingSystem.MACOS,
         package_type="wheel",
-        build_configs=generate_binary_build_matrix.generate_wheels_matrix(OperatingSystem.MACOS),
+        build_configs=generate_binary_build_matrix.generate_wheels_matrix(
+            OperatingSystem.MACOS
+        ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
             isolated_workflow=True,
@@ -253,7 +274,9 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
     BinaryBuildWorkflow(
         os=OperatingSystem.MACOS,
         package_type="conda",
-        build_configs=generate_binary_build_matrix.generate_conda_matrix(OperatingSystem.MACOS),
+        build_configs=generate_binary_build_matrix.generate_conda_matrix(
+            OperatingSystem.MACOS
+        ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_CONDA},
             isolated_workflow=True,
@@ -274,7 +297,9 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
     BinaryBuildWorkflow(
         os=OperatingSystem.MACOS_ARM64,
         package_type="wheel",
-        build_configs=generate_binary_build_matrix.generate_wheels_matrix(OperatingSystem.MACOS_ARM64),
+        build_configs=generate_binary_build_matrix.generate_wheels_matrix(
+            OperatingSystem.MACOS_ARM64
+        ),
         cross_compile_arm64=True,
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_WHEEL},
@@ -285,13 +310,16 @@ MACOS_BINARY_BUILD_WORKFLOWS = [
         os=OperatingSystem.MACOS_ARM64,
         package_type="conda",
         cross_compile_arm64=True,
-        build_configs=generate_binary_build_matrix.generate_conda_matrix(OperatingSystem.MACOS_ARM64),
+        build_configs=generate_binary_build_matrix.generate_conda_matrix(
+            OperatingSystem.MACOS_ARM64
+        ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_CONDA},
             isolated_workflow=True,
         ),
     ),
 ]
+
 
 def main() -> None:
     jinja_env = jinja2.Environment(
@@ -302,11 +330,26 @@ def main() -> None:
 
     # not ported yet
     template_and_workflows = [
-        (jinja_env.get_template("linux_binary_build_workflow.yml.j2"), LINUX_BINARY_BUILD_WORFKLOWS),
-        (jinja_env.get_template("linux_binary_build_workflow.yml.j2"), LINUX_BINARY_SMOKE_WORKFLOWS),
-        (jinja_env.get_template("windows_binary_build_workflow.yml.j2"), WINDOWS_BINARY_BUILD_WORKFLOWS),
-        (jinja_env.get_template("windows_binary_build_workflow.yml.j2"), WINDOWS_BINARY_SMOKE_WORKFLOWS),
-        (jinja_env.get_template("macos_binary_build_workflow.yml.j2"), MACOS_BINARY_BUILD_WORKFLOWS),
+        (
+            jinja_env.get_template("linux_binary_build_workflow.yml.j2"),
+            LINUX_BINARY_BUILD_WORFKLOWS,
+        ),
+        (
+            jinja_env.get_template("linux_binary_build_workflow.yml.j2"),
+            LINUX_BINARY_SMOKE_WORKFLOWS,
+        ),
+        (
+            jinja_env.get_template("windows_binary_build_workflow.yml.j2"),
+            WINDOWS_BINARY_BUILD_WORKFLOWS,
+        ),
+        (
+            jinja_env.get_template("windows_binary_build_workflow.yml.j2"),
+            WINDOWS_BINARY_SMOKE_WORKFLOWS,
+        ),
+        (
+            jinja_env.get_template("macos_binary_build_workflow.yml.j2"),
+            MACOS_BINARY_BUILD_WORKFLOWS,
+        ),
     ]
     # Delete the existing generated files first, this should align with .gitattributes file description.
     existing_workflows = GITHUB_DIR.glob("workflows/generated-*")
@@ -322,6 +365,7 @@ def main() -> None:
             raise Exception(f"How is workflows not iterable? {workflows}")
         for workflow in workflows:
             workflow.generate_workflow_file(workflow_template=template)
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -21,56 +21,69 @@ class GitHubComment:
 
 
 def gh_fetch_url(
-    url: str, *,
+    url: str,
+    *,
     headers: Optional[Dict[str, str]] = None,
     data: Optional[Dict[str, Any]] = None,
     method: Optional[str] = None,
-    reader: Callable[[Any], Any] = lambda x: x.read()
+    reader: Callable[[Any], Any] = lambda x: x.read(),
 ) -> Any:
     if headers is None:
         headers = {}
     token = os.environ.get("GITHUB_TOKEN")
-    if token is not None and url.startswith('https://api.github.com/'):
-        headers['Authorization'] = f'token {token}'
+    if token is not None and url.startswith("https://api.github.com/"):
+        headers["Authorization"] = f"token {token}"
     data_ = json.dumps(data).encode() if data is not None else None
     try:
         with urlopen(Request(url, headers=headers, data=data_, method=method)) as conn:
             return reader(conn)
     except HTTPError as err:
-        if err.code == 403 and all(key in err.headers for key in ['X-RateLimit-Limit', 'X-RateLimit-Used']):
-            print(f"""Rate limit exceeded:
+        if err.code == 403 and all(
+            key in err.headers for key in ["X-RateLimit-Limit", "X-RateLimit-Used"]
+        ):
+            print(
+                f"""Rate limit exceeded:
                 Used: {err.headers['X-RateLimit-Used']}
                 Limit: {err.headers['X-RateLimit-Limit']}
                 Remaining: {err.headers['X-RateLimit-Remaining']}
-                Resets at: {err.headers['x-RateLimit-Reset']}""")
+                Resets at: {err.headers['x-RateLimit-Reset']}"""
+            )
         raise
 
 
 def gh_fetch_json(
     url: str,
     params: Optional[Dict[str, Any]] = None,
-    data: Optional[Dict[str, Any]] = None
+    data: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
-    headers = {'Accept': 'application/vnd.github.v3+json'}
+    headers = {"Accept": "application/vnd.github.v3+json"}
     if params is not None and len(params) > 0:
-        url += '?' + '&'.join(f"{name}={quote(str(val))}" for name, val in params.items())
-    return cast(List[Dict[str, Any]], gh_fetch_url(url, headers=headers, data=data, reader=json.load))
+        url += "?" + "&".join(
+            f"{name}={quote(str(val))}" for name, val in params.items()
+        )
+    return cast(
+        List[Dict[str, Any]],
+        gh_fetch_url(url, headers=headers, data=data, reader=json.load),
+    )
+
 
 def _gh_fetch_json_any(
     url: str,
     params: Optional[Dict[str, Any]] = None,
-    data: Optional[Dict[str, Any]] = None
+    data: Optional[Dict[str, Any]] = None,
 ) -> Any:
-    headers = {'Accept': 'application/vnd.github.v3+json'}
+    headers = {"Accept": "application/vnd.github.v3+json"}
     if params is not None and len(params) > 0:
-        url += '?' + '&'.join(f"{name}={quote(str(val))}" for name, val in params.items())
+        url += "?" + "&".join(
+            f"{name}={quote(str(val))}" for name, val in params.items()
+        )
     return gh_fetch_url(url, headers=headers, data=data, reader=json.load)
 
 
 def gh_fetch_json_list(
     url: str,
     params: Optional[Dict[str, Any]] = None,
-    data: Optional[Dict[str, Any]] = None
+    data: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     return cast(List[Dict[str, Any]], _gh_fetch_json_any(url, params, data))
 
@@ -78,24 +91,38 @@ def gh_fetch_json_list(
 def gh_fetch_json_dict(
     url: str,
     params: Optional[Dict[str, Any]] = None,
-    data: Optional[Dict[str, Any]] = None
-) -> Dict[str, Any] :
+    data: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     return cast(Dict[str, Any], _gh_fetch_json_any(url, params, data))
 
 
-def _gh_post_comment(url: str, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
+def _gh_post_comment(
+    url: str, comment: str, dry_run: bool = False
+) -> List[Dict[str, Any]]:
     if dry_run:
         print(comment)
         return []
     return gh_fetch_json_list(url, data={"body": comment})
 
 
-def gh_post_pr_comment(org: str, repo: str, pr_num: int, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
-    return _gh_post_comment(f'https://api.github.com/repos/{org}/{repo}/issues/{pr_num}/comments', comment, dry_run)
+def gh_post_pr_comment(
+    org: str, repo: str, pr_num: int, comment: str, dry_run: bool = False
+) -> List[Dict[str, Any]]:
+    return _gh_post_comment(
+        f"https://api.github.com/repos/{org}/{repo}/issues/{pr_num}/comments",
+        comment,
+        dry_run,
+    )
 
 
-def gh_post_commit_comment(org: str, repo: str, sha: str, comment: str, dry_run: bool = False) -> List[Dict[str, Any]]:
-    return _gh_post_comment(f'https://api.github.com/repos/{org}/{repo}/commits/{sha}/comments', comment, dry_run)
+def gh_post_commit_comment(
+    org: str, repo: str, sha: str, comment: str, dry_run: bool = False
+) -> List[Dict[str, Any]]:
+    return _gh_post_comment(
+        f"https://api.github.com/repos/{org}/{repo}/commits/{sha}/comments",
+        comment,
+        dry_run,
+    )
 
 
 def gh_delete_comment(org: str, repo: str, comment_id: int) -> None:

--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -5,7 +5,7 @@ import re
 import tempfile
 from collections import defaultdict
 from datetime import datetime
-from typing import cast, Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, cast, Dict, Iterator, List, Optional, Tuple, Union
 
 
 RE_GITHUB_URL_MATCH = re.compile("^https://.*@?github.com/(.+)/(.+)$")
@@ -17,6 +17,7 @@ def get_git_remote_name() -> str:
 
 def get_git_repo_dir() -> str:
     from pathlib import Path
+
     return os.getenv("GIT_REPO_DIR", str(Path(__file__).resolve().parent.parent.parent))
 
 
@@ -31,7 +32,8 @@ def fuzzy_list_to_dict(items: List[Tuple[str, str]]) -> Dict[str, List[str]]:
 
 
 def _check_output(items: List[str], encoding: str = "utf-8") -> str:
-    from subprocess import check_output, CalledProcessError, STDOUT
+    from subprocess import CalledProcessError, check_output, STDOUT
+
     try:
         return check_output(items, stderr=STDOUT).decode(encoding)
     except CalledProcessError as e:
@@ -53,13 +55,15 @@ class GitCommit:
     author_date: datetime
     commit_date: Optional[datetime]
 
-    def __init__(self,
-                 commit_hash: str,
-                 author: str,
-                 author_date: datetime,
-                 title: str,
-                 body: str,
-                 commit_date: Optional[datetime] = None) -> None:
+    def __init__(
+        self,
+        commit_hash: str,
+        author: str,
+        author_date: datetime,
+        title: str,
+        body: str,
+        commit_date: Optional[datetime] = None,
+    ) -> None:
         self.commit_hash = commit_hash
         self.author = author
         self.author_date = author_date
@@ -100,13 +104,14 @@ def parse_fuller_format(lines: Union[str, List[str]]) -> GitCommit:
     assert lines[3].startswith("Commit: ")
     assert lines[4].startswith("CommitDate: ")
     assert len(lines[5]) == 0
-    return GitCommit(commit_hash=lines[0].split()[1].strip(),
-                     author=lines[1].split(":", 1)[1].strip(),
-                     author_date=datetime.fromtimestamp(int(lines[2].split(":", 1)[1].strip())),
-                     commit_date=datetime.fromtimestamp(int(lines[4].split(":", 1)[1].strip())),
-                     title=lines[6].strip(),
-                     body="\n".join(lines[7:]),
-                     )
+    return GitCommit(
+        commit_hash=lines[0].split()[1].strip(),
+        author=lines[1].split(":", 1)[1].strip(),
+        author_date=datetime.fromtimestamp(int(lines[2].split(":", 1)[1].strip())),
+        commit_date=datetime.fromtimestamp(int(lines[4].split(":", 1)[1].strip())),
+        title=lines[6].strip(),
+        body="\n".join(lines[7:]),
+    )
 
 
 class GitRepo:
@@ -139,16 +144,16 @@ class GitRepo:
             self._run_git("fetch", self.remote, f"{ref}:{branch}")
 
     def show_ref(self, name: str) -> str:
-        refs = self._run_git('show-ref', '-s', name).strip().split('\n')
+        refs = self._run_git("show-ref", "-s", name).strip().split("\n")
         if not all(refs[i] == refs[0] for i in range(1, len(refs))):
             raise RuntimeError(f"referce {name} is ambigous")
         return refs[0]
 
     def rev_parse(self, name: str) -> str:
-        return self._run_git('rev-parse', '--verify', name).strip()
+        return self._run_git("rev-parse", "--verify", name).strip()
 
     def get_merge_base(self, from_ref: str, to_ref: str) -> str:
-        return self._run_git('merge-base', from_ref, to_ref).strip()
+        return self._run_git("merge-base", from_ref, to_ref).strip()
 
     def patch_id(self, ref: Union[str, List[str]]) -> List[Tuple[str, str]]:
         is_list = isinstance(ref, list)
@@ -156,25 +161,31 @@ class GitRepo:
             if len(ref) == 0:
                 return []
             ref = " ".join(ref)
-        rc = _check_output(['sh', '-c', f'git -C {self.repo_dir} show {ref}|git patch-id --stable']).strip()
+        rc = _check_output(
+            ["sh", "-c", f"git -C {self.repo_dir} show {ref}|git patch-id --stable"]
+        ).strip()
         return [cast(Tuple[str, str], x.split(" ", 1)) for x in rc.split("\n")]
 
     def commits_resolving_gh_pr(self, pr_num: int) -> List[str]:
         owner, name = self.gh_owner_and_name()
         msg = f"Pull Request resolved: https://github.com/{owner}/{name}/pull/{pr_num}"
-        rc = self._run_git('log', '--format=%H', '--grep', msg).strip()
+        rc = self._run_git("log", "--format=%H", "--grep", msg).strip()
         return rc.split("\n") if len(rc) > 0 else []
 
     def get_commit(self, ref: str) -> GitCommit:
-        return parse_fuller_format(self._run_git('show', '--format=fuller', '--date=unix', '--shortstat', ref))
+        return parse_fuller_format(
+            self._run_git("show", "--format=fuller", "--date=unix", "--shortstat", ref)
+        )
 
     def cherry_pick(self, ref: str) -> None:
-        self._run_git('cherry-pick', '-x', ref)
+        self._run_git("cherry-pick", "-x", ref)
 
     def revert(self, ref: str) -> None:
         self._run_git("revert", "--no-edit", ref)
 
-    def compute_branch_diffs(self, from_branch: str, to_branch: str) -> Tuple[List[str], List[str]]:
+    def compute_branch_diffs(
+        self, from_branch: str, to_branch: str
+    ) -> Tuple[List[str], List[str]]:
         """
         Returns list of commmits that are missing in each other branch since their merge base
         Might be slow if merge base is between two branches is pretty far off
@@ -182,8 +193,8 @@ class GitRepo:
         from_ref = self.rev_parse(from_branch)
         to_ref = self.rev_parse(to_branch)
         merge_base = self.get_merge_base(from_ref, to_ref)
-        from_commits = self.revlist(f'{merge_base}..{from_ref}')
-        to_commits = self.revlist(f'{merge_base}..{to_ref}')
+        from_commits = self.revlist(f"{merge_base}..{from_ref}")
+        to_commits = self.revlist(f"{merge_base}..{to_ref}")
         from_ids = fuzzy_list_to_dict(self.patch_id(from_commits))
         to_ids = fuzzy_list_to_dict(self.patch_id(to_commits))
         for patch_id in set(from_ids).intersection(set(to_ids)):
@@ -199,14 +210,19 @@ class GitRepo:
                         # HACK: Same commit were merged, reverted and landed again
                         # which creates a tracking problem
                         if (
-                            "pytorch/pytorch" not in self.remote_url() or
-                            frc.commit_hash not in {"0a6a1b27a464ba5be5f587cce2ee12ab8c504dbf",
-                                                    "6d0f4a1d545a8f161df459e8d4ccafd4b9017dbe",
-                                                    "edf909e58f06150f7be41da2f98a3b9de3167bca",
-                                                    "a58c6aea5a0c9f8759a4154e46f544c8b03b8db1",
-                                                    "7106d216c29ca16a3504aa2bedad948ebcf4abc2"}
+                            "pytorch/pytorch" not in self.remote_url()
+                            or frc.commit_hash
+                            not in {
+                                "0a6a1b27a464ba5be5f587cce2ee12ab8c504dbf",
+                                "6d0f4a1d545a8f161df459e8d4ccafd4b9017dbe",
+                                "edf909e58f06150f7be41da2f98a3b9de3167bca",
+                                "a58c6aea5a0c9f8759a4154e46f544c8b03b8db1",
+                                "7106d216c29ca16a3504aa2bedad948ebcf4abc2",
+                            }
                         ):
-                            raise RuntimeError(f"Unexpected differences between {frc} and {toc}")
+                            raise RuntimeError(
+                                f"Unexpected differences between {frc} and {toc}"
+                            )
                     from_commits.remove(frc.commit_hash)
                     to_commits.remove(toc.commit_hash)
                 continue
@@ -217,11 +233,13 @@ class GitRepo:
         # Another HACK: Patch-id is not stable for commits with binary files or for big changes across commits
         # I.e. cherry-picking those from one branch into another will change patchid
         if "pytorch/pytorch" in self.remote_url():
-            for excluded_commit in {"8e09e20c1dafcdbdb45c2d1574da68a32e54a3a5",
-                                    "5f37e5c2a39c3acb776756a17730b865f0953432",
-                                    "b5222584e6d6990c6585981a936defd1af14c0ba",
-                                    "84d9a2e42d5ed30ec3b8b4140c38dd83abbce88d",
-                                    "f211ec90a6cdc8a2a5795478b5b5c8d7d7896f7e"}:
+            for excluded_commit in {
+                "8e09e20c1dafcdbdb45c2d1574da68a32e54a3a5",
+                "5f37e5c2a39c3acb776756a17730b865f0953432",
+                "b5222584e6d6990c6585981a936defd1af14c0ba",
+                "84d9a2e42d5ed30ec3b8b4140c38dd83abbce88d",
+                "f211ec90a6cdc8a2a5795478b5b5c8d7d7896f7e",
+            }:
                 if excluded_commit in from_commits:
                     from_commits.remove(excluded_commit)
 
@@ -281,7 +299,14 @@ class GitRepo:
 
 def clone_repo(username: str, password: str, org: str, project: str) -> GitRepo:
     path = tempfile.mkdtemp()
-    _check_output(['git', 'clone', f'https://{username}:{password}@github.com/{org}/{project}', path]).strip()
+    _check_output(
+        [
+            "git",
+            "clone",
+            f"https://{username}:{password}@github.com/{org}/{project}",
+            path,
+        ]
+    ).strip()
     return GitRepo(path=path)
 
 
@@ -337,17 +362,21 @@ def patterns_to_regex(allowed_patterns: List[str]) -> Any:
     rc += ")"
     return re.compile(rc)
 
+
 def _shasum(value: str) -> str:
     import hashlib
+
     m = hashlib.sha256()
     m.update(value.encode("utf-8"))
     return m.hexdigest()
 
 
 def are_ghstack_branches_in_sync(repo: GitRepo, head_ref: str) -> bool:
-    """ Checks that diff between base and head is the same as diff between orig and its parent """
-    orig_ref = re.sub(r'/head$', '/orig', head_ref)
-    base_ref = re.sub(r'/head$', '/base', head_ref)
+    """Checks that diff between base and head is the same as diff between orig and its parent"""
+    orig_ref = re.sub(r"/head$", "/orig", head_ref)
+    base_ref = re.sub(r"/head$", "/base", head_ref)
     orig_diff_sha = _shasum(repo.diff(f"{repo.remote}/{orig_ref}"))
-    head_diff_sha = _shasum(repo.diff(f"{repo.remote}/{base_ref}", f"{repo.remote}/{head_ref}"))
+    head_diff_sha = _shasum(
+        repo.diff(f"{repo.remote}/{base_ref}", f"{repo.remote}/{head_ref}")
+    )
     return orig_diff_sha == head_diff_sha

--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -26,7 +26,7 @@ def fuzzy_list_to_dict(items: List[Tuple[str, str]]) -> Dict[str, List[str]]:
     Converts list to dict preserving elements with duplicate keys
     """
     rc: Dict[str, List[str]] = defaultdict(lambda: [])
-    for (key, val) in items:
+    for key, val in items:
         rc[key].append(val)
     return dict(rc)
 

--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -28,6 +28,7 @@ For more information, see
 https://github.com/pytorch/pytorch/wiki/PyTorch-AutoLabel-Bot#why-categorize-for-release-notes-and-how-does-it-work.
 """
 
+
 # Modified from https://github.com/pytorch/pytorch/blob/b00206d4737d1f1e7a442c9f8a1cadccd272a386/torch/hub.py#L129
 def _read_url(url: Request) -> Tuple[Any, Any]:
     with urlopen(url) as r:

--- a/.github/scripts/label_utils.py
+++ b/.github/scripts/label_utils.py
@@ -3,13 +3,10 @@
 import json
 
 from functools import lru_cache
-from typing import List, Any, Tuple, TYPE_CHECKING, Union
-from urllib.request import urlopen, Request
+from typing import Any, List, Tuple, TYPE_CHECKING, Union
+from urllib.request import Request, urlopen
 
-from github_utils import (
-    GitHubComment,
-    gh_fetch_json,
-)
+from github_utils import gh_fetch_json, GitHubComment
 
 # TODO: this is a temp workaround to avoid circular dependencies,
 #       and should be removed once GitHubPR is refactored out of trymerge script.
@@ -34,11 +31,11 @@ https://github.com/pytorch/pytorch/wiki/PyTorch-AutoLabel-Bot#why-categorize-for
 # Modified from https://github.com/pytorch/pytorch/blob/b00206d4737d1f1e7a442c9f8a1cadccd272a386/torch/hub.py#L129
 def _read_url(url: Request) -> Tuple[Any, Any]:
     with urlopen(url) as r:
-        return r.headers, r.read().decode(r.headers.get_content_charset('utf-8'))
+        return r.headers, r.read().decode(r.headers.get_content_charset("utf-8"))
 
 
 def request_for_labels(url: str) -> Tuple[Any, Any]:
-    headers = {'Accept': 'application/vnd.github.v3+json'}
+    headers = {"Accept": "application/vnd.github.v3+json"}
     return _read_url(Request(url, headers=headers))
 
 
@@ -50,10 +47,12 @@ def update_labels(labels: List[str], info: str) -> None:
 def get_last_page_num_from_header(header: Any) -> int:
     # Link info looks like: <https://api.github.com/repositories/65600975/labels?per_page=100&page=2>;
     # rel="next", <https://api.github.com/repositories/65600975/labels?per_page=100&page=3>; rel="last"
-    link_info = header['link']
+    link_info = header["link"]
     prefix = "&page="
     suffix = ">;"
-    return int(link_info[link_info.rindex(prefix) + len(prefix):link_info.rindex(suffix)])
+    return int(
+        link_info[link_info.rindex(prefix) + len(prefix) : link_info.rindex(suffix)]
+    )
 
 
 @lru_cache()
@@ -64,7 +63,9 @@ def gh_get_labels(org: str, repo: str) -> List[str]:
     update_labels(labels, info)
 
     last_page = get_last_page_num_from_header(header)
-    assert last_page > 0, "Error reading header info to determine total number of pages of labels"
+    assert (
+        last_page > 0
+    ), "Error reading header info to determine total number of pages of labels"
     for page_number in range(2, last_page + 1):  # skip page 1
         _, info = request_for_labels(prefix + f"&page={page_number}")
         update_labels(labels, info)
@@ -72,26 +73,37 @@ def gh_get_labels(org: str, repo: str) -> List[str]:
     return labels
 
 
-def gh_add_labels(org: str, repo: str, pr_num: int, labels: Union[str, List[str]]) -> None:
+def gh_add_labels(
+    org: str, repo: str, pr_num: int, labels: Union[str, List[str]]
+) -> None:
     gh_fetch_json(
-        f'https://api.github.com/repos/{org}/{repo}/issues/{pr_num}/labels',
+        f"https://api.github.com/repos/{org}/{repo}/issues/{pr_num}/labels",
         data={"labels": labels},
     )
 
 
 def get_release_notes_labels(org: str, repo: str) -> List[str]:
-    return [label for label in gh_get_labels(org, repo) if label.lstrip().startswith("release notes:")]
+    return [
+        label
+        for label in gh_get_labels(org, repo)
+        if label.lstrip().startswith("release notes:")
+    ]
 
 
 def has_required_labels(pr: "GitHubPR") -> bool:
     pr_labels = pr.get_labels()
     # Check if PR is not user facing
-    is_not_user_facing_pr = any(label.strip() == "topic: not user facing" for label in pr_labels)
-    return (
-        is_not_user_facing_pr or
-        any(label.strip() in get_release_notes_labels(pr.org, pr.project) for label in pr_labels)
+    is_not_user_facing_pr = any(
+        label.strip() == "topic: not user facing" for label in pr_labels
+    )
+    return is_not_user_facing_pr or any(
+        label.strip() in get_release_notes_labels(pr.org, pr.project)
+        for label in pr_labels
     )
 
 
 def is_label_err_comment(comment: GitHubComment) -> bool:
-    return comment.body_text.lstrip(" #").startswith(LABEL_ERR_MSG_TITLE) and comment.author_login in BOT_AUTHORS
+    return (
+        comment.body_text.lstrip(" #").startswith(LABEL_ERR_MSG_TITLE)
+        and comment.author_login in BOT_AUTHORS
+    )

--- a/.github/scripts/lint_native_functions.py
+++ b/.github/scripts/lint_native_functions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-'''
+"""
 Verify that it is possible to round-trip native_functions.yaml via ruamel under some
 configuration.  Keeping native_functions.yaml consistent in this way allows us to
 run codemods on the file using ruamel without introducing line noise.  Note that we don't
@@ -12,24 +12,27 @@ you may find that you want to use some format that is not what ruamel prefers.  
 it is OK to modify this script (instead of reformatting native_functions.yaml)--the point
 is simply to make sure that there is *some* configuration of ruamel that can round trip
 the YAML, not to be prescriptive about it.
-'''
+"""
 
-import ruamel.yaml  # type: ignore[import]
 import difflib
 import sys
-from pathlib import Path
 from io import StringIO
+from pathlib import Path
+
+import ruamel.yaml  # type: ignore[import]
+
 
 def fn(base: str) -> str:
     return str(base / Path("aten/src/ATen/native/native_functions.yaml"))
 
-with open(Path(__file__).parent.parent.parent / fn('.'), "r") as f:
+
+with open(Path(__file__).parent.parent.parent / fn("."), "r") as f:
     contents = f.read()
 
 yaml = ruamel.yaml.YAML()  # type: ignore[attr-defined]
 yaml.preserve_quotes = True  # type: ignore[assignment]
 yaml.width = 1000  # type: ignore[assignment]
-yaml.boolean_representation = ['False', 'True']  # type: ignore[attr-defined]
+yaml.boolean_representation = ["False", "True"]  # type: ignore[attr-defined]
 r = yaml.load(contents)
 
 # Cuz ruamel's author intentionally didn't include conversion to string
@@ -40,12 +43,19 @@ new_contents = string_stream.getvalue()
 string_stream.close()
 
 if contents != new_contents:
-    print("""\
+    print(
+        """\
 
 ## LINT FAILURE: native_functions.yaml ##
 
 native_functions.yaml failed lint; please apply the diff below to fix lint.
 If you think this is in error, please see .github/scripts/lint_native_functions.py
-""", file=sys.stderr)
-    sys.stdout.writelines(difflib.unified_diff(contents.splitlines(True), new_contents.splitlines(True), fn('a'), fn('b')))
+""",
+        file=sys.stderr,
+    )
+    sys.stdout.writelines(
+        difflib.unified_diff(
+            contents.splitlines(True), new_contents.splitlines(True), fn("a"), fn("b")
+        )
+    )
     sys.exit(1)

--- a/.github/scripts/parse_ref.py
+++ b/.github/scripts/parse_ref.py
@@ -14,7 +14,7 @@ def set_output(name: str, val: str) -> None:
 
 def main() -> None:
     ref = os.environ["GITHUB_REF"]
-    m = re.match(r'^refs/(\w+)/(.*)$', ref)
+    m = re.match(r"^refs/(\w+)/(.*)$", ref)
     if m:
         category, stripped = m.groups()
         if category == "heads":

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -9,18 +9,20 @@ Testing environment:
 - Python 3.8
 - CUDA 11.3
 """
+import argparse
+
 # Known issues:
 # 1. Does not reuse the build artifact in other CI workflows
 # 2. CI jobs are serialized because there is only one worker
 import os
-import boto3  # type: ignore[import]
-import git  # type: ignore[import]
 import pathlib
-import argparse
 import subprocess
 from pathlib import Path
 
 from typing import List, Tuple
+
+import boto3  # type: ignore[import]
+import git  # type: ignore[import]
 
 TORCHBENCH_CONFIG_NAME = "config.yaml"
 TORCHBENCH_USERBENCHMARK_CONFIG_NAME = "ub-config.yaml"
@@ -37,21 +39,25 @@ S3_BUCKET = "ossci-metrics"
 S3_PREFIX = "torchbench-pr-test"
 S3_URL_BASE = f"https://{S3_BUCKET}.s3.amazonaws.com/"
 
+
 class S3Client:
     def __init__(self, bucket: str = S3_BUCKET, prefix: str = S3_PREFIX):
-        self.s3 = boto3.client('s3')
-        self.resource = boto3.resource('s3')
+        self.s3 = boto3.client("s3")
+        self.resource = boto3.resource("s3")
         self.bucket = bucket
         self.prefix = prefix
 
     def upload_file(self, file_path: Path, filekey_prefix: str) -> None:
-        assert file_path.is_file(), f"Specified file path {file_path} does not exist or not file."
+        assert (
+            file_path.is_file()
+        ), f"Specified file path {file_path} does not exist or not file."
         file_name = file_path.name
         s3_key = f"{self.prefix}/{filekey_prefix}/{file_name}"
         print(f"Uploading file {file_name} to S3 with key: {s3_key}")
         self.s3.upload_file(str(file_path), self.bucket, s3_key)
         # output the result URL
         print(f"Uploaded the result file {file_name} to {S3_URL_BASE}{s3_key}")
+
 
 def gen_abtest_config(control: str, treatment: str, models: List[str]) -> str:
     d = {}
@@ -65,18 +71,23 @@ def gen_abtest_config(control: str, treatment: str, models: List[str]) -> str:
     config = config + "\n"
     return config
 
+
 def setup_gha_env(name: str, val: str) -> None:
     fname = os.environ["GITHUB_ENV"]
     content = f"{name}={val}\n"
     with open(fname, "a") as fo:
         fo.write(content)
 
+
 def find_current_branch(repo_path: str) -> str:
     repo = git.Repo(repo_path)
     name: str = repo.active_branch.name
     return name
 
-def deploy_torchbench_config(output_dir: str, config: str, config_name: str = TORCHBENCH_CONFIG_NAME) -> None:
+
+def deploy_torchbench_config(
+    output_dir: str, config: str, config_name: str = TORCHBENCH_CONFIG_NAME
+) -> None:
     # Create test dir if needed
     pathlib.Path(output_dir).mkdir(exist_ok=True)
     # TorchBench config file name
@@ -84,20 +95,37 @@ def deploy_torchbench_config(output_dir: str, config: str, config_name: str = TO
     with open(config_path, "w") as fp:
         fp.write(config)
 
+
 def get_valid_models(torchbench_path: str) -> List[str]:
     benchmark_path = os.path.join(torchbench_path, "torchbenchmark", "models")
-    valid_models = [model for model in os.listdir(benchmark_path) if os.path.isdir(os.path.join(benchmark_path, model))]
+    valid_models = [
+        model
+        for model in os.listdir(benchmark_path)
+        if os.path.isdir(os.path.join(benchmark_path, model))
+    ]
     return valid_models
+
 
 def get_valid_userbenchmarks(torchbench_path: str) -> List[str]:
     def is_valid_ub_dir(ub_path: str) -> bool:
-        return os.path.isdir(ub_path) and os.path.exists(os.path.join(ub_path, "__init__.py"))
+        return os.path.isdir(ub_path) and os.path.exists(
+            os.path.join(ub_path, "__init__.py")
+        )
+
     ub_path = os.path.join(os.path.abspath(torchbench_path), "userbenchmark")
-    ubs = list(filter(is_valid_ub_dir, [os.path.join(ub_path, ubdir) for ubdir in os.listdir(ub_path)]))
+    ubs = list(
+        filter(
+            is_valid_ub_dir,
+            [os.path.join(ub_path, ubdir) for ubdir in os.listdir(ub_path)],
+        )
+    )
     valid_ubs = list(map(lambda x: os.path.basename(x), ubs))
     return valid_ubs
 
-def extract_models_from_pr(torchbench_path: str, prbody_file: str) -> Tuple[List[str], List[str]]:
+
+def extract_models_from_pr(
+    torchbench_path: str, prbody_file: str
+) -> Tuple[List[str], List[str]]:
     model_list = []
     userbenchmark_list = []
     pr_list = []
@@ -106,7 +134,9 @@ def extract_models_from_pr(torchbench_path: str, prbody_file: str) -> Tuple[List
         magic_lines = list(filter(lambda x: x.startswith(MAGIC_PREFIX), lines))
         if magic_lines:
             # Only the first magic line will be recognized.
-            pr_list = list(map(lambda x: x.strip(), magic_lines[0][len(MAGIC_PREFIX):].split(",")))
+            pr_list = list(
+                map(lambda x: x.strip(), magic_lines[0][len(MAGIC_PREFIX) :].split(","))
+            )
     valid_models = get_valid_models(torchbench_path)
     valid_ubs = get_valid_userbenchmarks(torchbench_path)
     for pr_bm in pr_list:
@@ -115,53 +145,87 @@ def extract_models_from_pr(torchbench_path: str, prbody_file: str) -> Tuple[List
         elif pr_bm in valid_ubs:
             userbenchmark_list.append(pr_bm)
         else:
-            print(f"The model or benchmark {pr_bm} you specified does not exist in TorchBench suite. Please double check.")
+            print(
+                f"The model or benchmark {pr_bm} you specified does not exist in TorchBench suite. Please double check."
+            )
             exit(-1)
     # Shortcut: if pr_list is ["ALL"], run all the model tests
     if "ALL" in model_list:
         model_list = ["ALL"]
     return model_list, userbenchmark_list
 
+
 def find_torchbench_branch(prbody_file: str) -> str:
     branch_name: str = ""
     with open(prbody_file, "r") as pf:
         lines = map(lambda x: x.strip(), pf.read().splitlines())
-        magic_lines = list(filter(lambda x: x.startswith(MAGIC_TORCHBENCH_PREFIX), lines))
+        magic_lines = list(
+            filter(lambda x: x.startswith(MAGIC_TORCHBENCH_PREFIX), lines)
+        )
         if magic_lines:
             # Only the first magic line will be recognized.
-            branch_name = magic_lines[0][len(MAGIC_TORCHBENCH_PREFIX):].strip()
+            branch_name = magic_lines[0][len(MAGIC_TORCHBENCH_PREFIX) :].strip()
     # If not specified, use main as the default branch
     if not branch_name:
         branch_name = "main"
     return branch_name
 
+
 def run_torchbench(pytorch_path: str, torchbench_path: str, output_dir: str) -> None:
     # Copy system environment so that we will not override
     env = dict(os.environ)
-    command = ["python", "bisection.py", "--work-dir", output_dir,
-               "--pytorch-src", pytorch_path, "--torchbench-src", torchbench_path,
-               "--config", os.path.join(output_dir, TORCHBENCH_CONFIG_NAME),
-               "--output", os.path.join(output_dir, "result.txt")]
+    command = [
+        "python",
+        "bisection.py",
+        "--work-dir",
+        output_dir,
+        "--pytorch-src",
+        pytorch_path,
+        "--torchbench-src",
+        torchbench_path,
+        "--config",
+        os.path.join(output_dir, TORCHBENCH_CONFIG_NAME),
+        "--output",
+        os.path.join(output_dir, "result.txt"),
+    ]
     print(f"Running torchbench command: {command}")
     subprocess.check_call(command, cwd=torchbench_path, env=env)
 
-def run_userbenchmarks(pytorch_path: str, torchbench_path: str, base_sha: str, head_sha: str,
-                       userbenchmark: str, output_dir: str) -> None:
+
+def run_userbenchmarks(
+    pytorch_path: str,
+    torchbench_path: str,
+    base_sha: str,
+    head_sha: str,
+    userbenchmark: str,
+    output_dir: str,
+) -> None:
     # Copy system environment so that we will not override
     env = dict(os.environ)
-    command = ["python", "./.github/scripts/abtest.py",
-               "--pytorch-repo", pytorch_path,
-               "--base", base_sha,
-               "--head", head_sha,
-               "--userbenchmark", userbenchmark,
-               "--output-dir", output_dir]
+    command = [
+        "python",
+        "./.github/scripts/abtest.py",
+        "--pytorch-repo",
+        pytorch_path,
+        "--base",
+        base_sha,
+        "--head",
+        head_sha,
+        "--userbenchmark",
+        userbenchmark,
+        "--output-dir",
+        output_dir,
+    ]
     print(f"Running torchbench userbenchmark command: {command}")
     subprocess.check_call(command, cwd=torchbench_path, env=env)
+
 
 def process_upload_s3(result_dir: str) -> None:
     # validate result directory
     result_dir_path = Path(result_dir)
-    assert result_dir_path.exists(), f"Specified result directory {result_dir} doesn't exist."
+    assert (
+        result_dir_path.exists()
+    ), f"Specified result directory {result_dir} doesn't exist."
     # upload all files to S3 bucket oss-ci-metrics
     files = [x for x in result_dir_path.iterdir() if x.is_file()]
     # upload file to S3 bucket
@@ -170,54 +234,92 @@ def process_upload_s3(result_dir: str) -> None:
     for f in files:
         s3_client.upload_file(f, filekey_prefix)
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Run TorchBench tests based on PR')
-    parser.add_argument('--pr-body', help="The file that contains body of a Pull Request")
 
-    subparsers = parser.add_subparsers(dest='command')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run TorchBench tests based on PR")
+    parser.add_argument(
+        "--pr-body", help="The file that contains body of a Pull Request"
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
     # parser for setup the torchbench branch name env
     branch_parser = subparsers.add_parser("set-torchbench-branch")
     # parser to run the torchbench branch
     run_parser = subparsers.add_parser("run")
-    run_parser.add_argument('--pr-num', required=True, type=str, help="The Pull Request number")
-    run_parser.add_argument('--pr-base-sha', required=True, type=str, help="The Pull Request base hash")
-    run_parser.add_argument('--pr-head-sha', required=True, type=str, help="The Pull Request head hash")
-    run_parser.add_argument('--pytorch-path', required=True, type=str, help="Path to pytorch repository")
-    run_parser.add_argument('--torchbench-path', required=True, type=str, help="Path to TorchBench repository")
+    run_parser.add_argument(
+        "--pr-num", required=True, type=str, help="The Pull Request number"
+    )
+    run_parser.add_argument(
+        "--pr-base-sha", required=True, type=str, help="The Pull Request base hash"
+    )
+    run_parser.add_argument(
+        "--pr-head-sha", required=True, type=str, help="The Pull Request head hash"
+    )
+    run_parser.add_argument(
+        "--pytorch-path", required=True, type=str, help="Path to pytorch repository"
+    )
+    run_parser.add_argument(
+        "--torchbench-path",
+        required=True,
+        type=str,
+        help="Path to TorchBench repository",
+    )
     # parser to upload results to S3
     upload_parser = subparsers.add_parser("upload-s3")
-    upload_parser.add_argument('--result-dir', required=True, type=str, help="Path to benchmark output")
+    upload_parser.add_argument(
+        "--result-dir", required=True, type=str, help="Path to benchmark output"
+    )
     args = parser.parse_args()
 
-    if args.command == 'set-torchbench-branch':
+    if args.command == "set-torchbench-branch":
         branch_name = find_torchbench_branch(args.pr_body)
         # env name: "TORCHBENCH_BRANCH"
         setup_gha_env(MAGIC_TORCHBENCH_PREFIX[:-1], branch_name)
-    elif args.command == 'run':
-        output_dir: str = os.path.join(os.environ["HOME"], ".torchbench", "bisection", f"pr{args.pr_num}")
+    elif args.command == "run":
+        output_dir: str = os.path.join(
+            os.environ["HOME"], ".torchbench", "bisection", f"pr{args.pr_num}"
+        )
         # Assert the current branch in args.torchbench_path is the same as the one specified in pr body
         branch_name = find_torchbench_branch(args.pr_body)
         current_branch = find_current_branch(args.torchbench_path)
-        assert branch_name == current_branch, f"Torchbench repo {args.torchbench_path} is on branch {current_branch}, \
+        assert (
+            branch_name == current_branch
+        ), f"Torchbench repo {args.torchbench_path} is on branch {current_branch}, \
                                                 but user specified to run on branch {branch_name}."
-        print(f"Ready to run TorchBench with benchmark. Result will be saved in the directory: {output_dir}.")
+        print(
+            f"Ready to run TorchBench with benchmark. Result will be saved in the directory: {output_dir}."
+        )
         # Identify the specified models and userbenchmarks
-        models, userbenchmarks = extract_models_from_pr(args.torchbench_path, args.pr_body)
+        models, userbenchmarks = extract_models_from_pr(
+            args.torchbench_path, args.pr_body
+        )
         if models:
-            torchbench_config = gen_abtest_config(args.pr_base_sha, args.pr_head_sha, models)
+            torchbench_config = gen_abtest_config(
+                args.pr_base_sha, args.pr_head_sha, models
+            )
             deploy_torchbench_config(output_dir, torchbench_config)
-            run_torchbench(pytorch_path=args.pytorch_path, torchbench_path=args.torchbench_path, output_dir=output_dir)
+            run_torchbench(
+                pytorch_path=args.pytorch_path,
+                torchbench_path=args.torchbench_path,
+                output_dir=output_dir,
+            )
         if userbenchmarks:
-            assert len(userbenchmarks) == 1, \
-                "We don't support running multiple userbenchmarks in single workflow yet." \
+            assert len(userbenchmarks) == 1, (
+                "We don't support running multiple userbenchmarks in single workflow yet."
                 "If you need, please submit a feature request."
-            run_userbenchmarks(pytorch_path=args.pytorch_path, torchbench_path=args.torchbench_path,
-                               base_sha=args.pr_base_sha, head_sha=args.pr_head_sha,
-                               userbenchmark=userbenchmarks[0], output_dir=output_dir)
+            )
+            run_userbenchmarks(
+                pytorch_path=args.pytorch_path,
+                torchbench_path=args.torchbench_path,
+                base_sha=args.pr_base_sha,
+                head_sha=args.pr_head_sha,
+                userbenchmark=userbenchmarks[0],
+                output_dir=output_dir,
+            )
         if not models and not userbenchmarks:
             print("Can't parse valid models or userbenchmarks from the pr body. Quit.")
             exit(-1)
-    elif args.command == 'upload-s3':
+    elif args.command == "upload-s3":
         process_upload_s3(args.result_dir)
     else:
         print(f"The command {args.command} is not supported.")

--- a/.github/scripts/test_check_labels.py
+++ b/.github/scripts/test_check_labels.py
@@ -1,29 +1,34 @@
 """test_check_labels.py"""
 
 from typing import Any, List
-from unittest import TestCase, mock, main
+from unittest import main, mock, TestCase
 
 from check_labels import (
-    main as check_labels_main,
     add_label_err_comment,
     delete_all_label_err_comments,
+    main as check_labels_main,
 )
 from github_utils import GitHubComment
 from label_utils import BOT_AUTHORS, LABEL_ERR_MSG_TITLE
-from test_trymerge import mocked_gh_graphql, mock_gh_get_info
+from test_trymerge import mock_gh_get_info, mocked_gh_graphql
 from trymerge import GitHubPR
+
 
 def mock_parse_args() -> object:
     class Object(object):
         def __init__(self) -> None:
             self.pr_num = 76123
+
     return Object()
+
 
 def mock_add_label_err_comment(pr: "GitHubPR") -> None:
     pass
 
+
 def mock_delete_all_label_err_comments(pr: "GitHubPR") -> None:
     pass
+
 
 def mock_get_comments() -> List[GitHubComment]:
     return [
@@ -49,9 +54,9 @@ def mock_get_comments() -> List[GitHubComment]:
 
 
 class TestCheckLabels(TestCase):
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('trymerge.GitHubPR.get_comments', return_value=[mock_get_comments()[0]])
-    @mock.patch('check_labels.gh_post_pr_comment')
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch("trymerge.GitHubPR.get_comments", return_value=[mock_get_comments()[0]])
+    @mock.patch("check_labels.gh_post_pr_comment")
     def test_correctly_add_label_err_comment(
         self, mock_gh_post_pr_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
     ) -> None:
@@ -60,9 +65,9 @@ class TestCheckLabels(TestCase):
         add_label_err_comment(pr)
         mock_gh_post_pr_comment.assert_called_once()
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('trymerge.GitHubPR.get_comments', return_value=[mock_get_comments()[1]])
-    @mock.patch('check_labels.gh_post_pr_comment')
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch("trymerge.GitHubPR.get_comments", return_value=[mock_get_comments()[1]])
+    @mock.patch("check_labels.gh_post_pr_comment")
     def test_not_add_label_err_comment(
         self, mock_gh_post_pr_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
     ) -> None:
@@ -71,9 +76,9 @@ class TestCheckLabels(TestCase):
         add_label_err_comment(pr)
         mock_gh_post_pr_comment.assert_not_called()
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('trymerge.GitHubPR.get_comments', return_value=mock_get_comments())
-    @mock.patch('check_labels.gh_delete_comment')
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch("trymerge.GitHubPR.get_comments", return_value=mock_get_comments())
+    @mock.patch("check_labels.gh_delete_comment")
     def test_correctly_delete_all_label_err_comments(
         self, mock_gh_delete_comment: Any, mock_get_comments: Any, mock_gh_grphql: Any
     ) -> None:
@@ -82,11 +87,16 @@ class TestCheckLabels(TestCase):
         delete_all_label_err_comments(pr)
         mock_gh_delete_comment.assert_called_once_with("pytorch", "pytorch", 2)
 
-    @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
-    @mock.patch('check_labels.parse_args', return_value=mock_parse_args())
-    @mock.patch('check_labels.has_required_labels', return_value=False)
-    @mock.patch('check_labels.delete_all_label_err_comments', side_effect=mock_delete_all_label_err_comments)
-    @mock.patch('check_labels.add_label_err_comment', side_effect=mock_add_label_err_comment)
+    @mock.patch("trymerge.gh_get_pr_info", return_value=mock_gh_get_info())
+    @mock.patch("check_labels.parse_args", return_value=mock_parse_args())
+    @mock.patch("check_labels.has_required_labels", return_value=False)
+    @mock.patch(
+        "check_labels.delete_all_label_err_comments",
+        side_effect=mock_delete_all_label_err_comments,
+    )
+    @mock.patch(
+        "check_labels.add_label_err_comment", side_effect=mock_add_label_err_comment
+    )
     def test_ci_comments_and_exit0_without_required_labels(
         self,
         mock_add_label_err_comment: Any,
@@ -101,11 +111,16 @@ class TestCheckLabels(TestCase):
         mock_add_label_err_comment.assert_called_once()
         mock_delete_all_label_err_comments.assert_not_called()
 
-    @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
-    @mock.patch('check_labels.parse_args', return_value=mock_parse_args())
-    @mock.patch('check_labels.has_required_labels', return_value=True)
-    @mock.patch('check_labels.delete_all_label_err_comments', side_effect=mock_delete_all_label_err_comments)
-    @mock.patch('check_labels.add_label_err_comment', side_effect=mock_add_label_err_comment)
+    @mock.patch("trymerge.gh_get_pr_info", return_value=mock_gh_get_info())
+    @mock.patch("check_labels.parse_args", return_value=mock_parse_args())
+    @mock.patch("check_labels.has_required_labels", return_value=True)
+    @mock.patch(
+        "check_labels.delete_all_label_err_comments",
+        side_effect=mock_delete_all_label_err_comments,
+    )
+    @mock.patch(
+        "check_labels.add_label_err_comment", side_effect=mock_add_label_err_comment
+    )
     def test_ci_exit0_with_required_labels(
         self,
         mock_add_label_err_comment: Any,
@@ -119,6 +134,7 @@ class TestCheckLabels(TestCase):
         self.assertEqual(str(sys_exit.exception), "0")
         mock_add_label_err_comment.assert_not_called()
         mock_delete_all_label_err_comments.assert_called_once()
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_fetch_latest_green_commit.py
+++ b/.github/scripts/test_fetch_latest_green_commit.py
@@ -1,5 +1,6 @@
-from unittest import TestCase, main, mock
-from typing import Any, List, Dict
+from typing import Any, Dict, List
+from unittest import main, mock, TestCase
+
 from fetch_latest_green_commit import isGreen, WorkflowCheck
 
 workflowNames = [
@@ -15,46 +16,72 @@ workflowNames = [
     "pr-labels",
     "Close stale pull requests",
     "Update S3 HTML indices for download.pytorch.org",
-    "Create Release"
+    "Create Release",
 ]
 
-def set_workflow_job_status(workflow: List[Dict[str, Any]], name: str, status: str) -> List[Dict[str, Any]]:
+
+def set_workflow_job_status(
+    workflow: List[Dict[str, Any]], name: str, status: str
+) -> List[Dict[str, Any]]:
     for check in workflow:
-        if check['workflowName'] == name:
-            check['conclusion'] = status
+        if check["workflowName"] == name:
+            check["conclusion"] = status
     return workflow
+
 
 class TestChecks:
     def make_test_checks(self) -> List[Dict[str, Any]]:
         workflow_checks = []
         for i in range(len(workflowNames)):
-            workflow_checks.append(WorkflowCheck(
-                workflowName=workflowNames[i],
-                name="test/job",
-                jobName="job",
-                conclusion="success",
-            )._asdict())
+            workflow_checks.append(
+                WorkflowCheck(
+                    workflowName=workflowNames[i],
+                    name="test/job",
+                    jobName="job",
+                    conclusion="success",
+                )._asdict()
+            )
         return workflow_checks
 
+
 class TestPrintCommits(TestCase):
-    @mock.patch('fetch_latest_green_commit.get_commit_results', return_value=TestChecks().make_test_checks())
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
     def test_all_successful(self, mock_get_commit_results: Any) -> None:
         "Test with workflows are successful"
         workflow_checks = mock_get_commit_results()
         self.assertTrue(isGreen("sha", workflow_checks)[0])
 
-    @mock.patch('fetch_latest_green_commit.get_commit_results', return_value=TestChecks().make_test_checks())
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
     def test_necessary_successful(self, mock_get_commit_results: Any) -> None:
         "Test with necessary workflows are successful"
         workflow_checks = mock_get_commit_results()
-        workflow_checks = set_workflow_job_status(workflow_checks, workflowNames[8], "failed")
-        workflow_checks = set_workflow_job_status(workflow_checks, workflowNames[9], "failed")
-        workflow_checks = set_workflow_job_status(workflow_checks, workflowNames[10], "failed")
-        workflow_checks = set_workflow_job_status(workflow_checks, workflowNames[11], "failed")
-        workflow_checks = set_workflow_job_status(workflow_checks, workflowNames[12], "failed")
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, workflowNames[8], "failed"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, workflowNames[9], "failed"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, workflowNames[10], "failed"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, workflowNames[11], "failed"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, workflowNames[12], "failed"
+        )
         self.assertTrue(isGreen("sha", workflow_checks)[0])
 
-    @mock.patch('fetch_latest_green_commit.get_commit_results', return_value=TestChecks().make_test_checks())
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
     def test_necessary_skipped(self, mock_get_commit_results: Any) -> None:
         "Test with necessary job (ex: pull) skipped"
         workflow_checks = mock_get_commit_results()
@@ -62,15 +89,25 @@ class TestPrintCommits(TestCase):
         result = isGreen("sha", workflow_checks)
         self.assertTrue(result[0])
 
-    @mock.patch('fetch_latest_green_commit.get_commit_results', return_value=TestChecks().make_test_checks())
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
     def test_skippable_skipped(self, mock_get_commit_results: Any) -> None:
         "Test with skippable jobs (periodic and docker-release-builds skipped"
         workflow_checks = mock_get_commit_results()
-        workflow_checks = set_workflow_job_status(workflow_checks, "periodic", "skipped")
-        workflow_checks = set_workflow_job_status(workflow_checks, "docker-release-builds", "skipped")
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, "periodic", "skipped"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, "docker-release-builds", "skipped"
+        )
         self.assertTrue(isGreen("sha", workflow_checks))
 
-    @mock.patch('fetch_latest_green_commit.get_commit_results', return_value=TestChecks().make_test_checks())
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
     def test_necessary_failed(self, mock_get_commit_results: Any) -> None:
         "Test with necessary job (ex: Lint) failed"
         workflow_checks = mock_get_commit_results()
@@ -79,22 +116,33 @@ class TestPrintCommits(TestCase):
         self.assertFalse(result[0])
         self.assertEqual(result[1], "Lint checks were not successful")
 
-    @mock.patch('fetch_latest_green_commit.get_commit_results', return_value=TestChecks().make_test_checks())
+    @mock.patch(
+        "fetch_latest_green_commit.get_commit_results",
+        return_value=TestChecks().make_test_checks(),
+    )
     def test_skippable_failed(self, mock_get_commit_results: Any) -> None:
         "Test with failing skippable jobs (ex: docker-release-builds) should pass"
         workflow_checks = mock_get_commit_results()
-        workflow_checks = set_workflow_job_status(workflow_checks, "periodic", "skipped")
-        workflow_checks = set_workflow_job_status(workflow_checks, "docker-release-builds", "failed")
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, "periodic", "skipped"
+        )
+        workflow_checks = set_workflow_job_status(
+            workflow_checks, "docker-release-builds", "failed"
+        )
         result = isGreen("sha", workflow_checks)
         self.assertTrue(result[0])
 
-    @mock.patch('fetch_latest_green_commit.get_commit_results', return_value={})
+    @mock.patch("fetch_latest_green_commit.get_commit_results", return_value={})
     def test_no_workflows(self, mock_get_commit_results: Any) -> None:
         "Test with missing workflows"
         workflow_checks = mock_get_commit_results()
         result = isGreen("sha", workflow_checks)
         self.assertFalse(result[0])
-        self.assertEqual(result[1], "missing required workflows: pull, trunk, lint, linux-binary, windows-binary")
+        self.assertEqual(
+            result[1],
+            "missing required workflows: pull, trunk, lint, linux-binary, windows-binary",
+        )
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_gitutils.py
+++ b/.github/scripts/test_gitutils.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python3
-from gitutils import PeekableIterator, patterns_to_regex, GitRepo, are_ghstack_branches_in_sync, _shasum
-from unittest import TestCase, main, SkipTest
 from pathlib import Path
+from unittest import main, SkipTest, TestCase
+
+from gitutils import (
+    _shasum,
+    are_ghstack_branches_in_sync,
+    GitRepo,
+    patterns_to_regex,
+    PeekableIterator,
+)
 
 
 BASE_DIR = Path(__file__).parent
@@ -15,6 +22,7 @@ class TestPeekableIterator(TestCase):
 
     def test_is_iterable(self) -> None:
         from collections.abc import Iterator
+
         iter_ = PeekableIterator("")
         self.assertTrue(isinstance(iter_, Iterator))
 
@@ -35,7 +43,8 @@ class TestPattern(TestCase):
         patterns_re = patterns_to_regex(allowed_patterns)
         fnames = [
             "aten/src/ATen/native/LinearAlgebra.cpp",
-            "aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp"]
+            "aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp",
+        ]
         for filename in fnames:
             self.assertTrue(patterns_re.match(filename))
 
@@ -44,11 +53,13 @@ class TestGitRepo(TestCase):
     def setUp(self) -> None:
         repo_dir = BASE_DIR.parent.parent.absolute()
         if not (repo_dir / ".git").is_dir():
-            raise SkipTest("Can't find git directory, make sure to run this test on real repo checkout")
+            raise SkipTest(
+                "Can't find git directory, make sure to run this test on real repo checkout"
+            )
         self.repo = GitRepo(str(repo_dir))
 
     def _skip_if_ref_does_not_exist(self, ref: str) -> None:
-        """ Skip test if ref is missing as stale branches are deleted with time """
+        """Skip test if ref is missing as stale branches are deleted with time"""
         try:
             self.repo.show_ref(ref)
         except RuntimeError as e:
@@ -69,5 +80,6 @@ class TestGitRepo(TestCase):
         self._skip_if_ref_does_not_exist(head_ref)
         self.assertFalse(are_ghstack_branches_in_sync(self.repo, head_ref))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/.github/scripts/test_label_utils.py
+++ b/.github/scripts/test_label_utils.py
@@ -1,29 +1,37 @@
 from typing import Any
-from unittest import TestCase, mock, main
+from unittest import main, mock, TestCase
 
 from label_utils import (
     get_last_page_num_from_header,
     gh_get_labels,
     has_required_labels,
 )
-from trymerge import GitHubPR
 from test_trymerge import mocked_gh_graphql
+from trymerge import GitHubPR
 
 
 release_notes_labels = [
     "release notes: nn",
 ]
 
+
 class TestLabelUtils(TestCase):
     MOCK_HEADER_LINKS_TO_PAGE_NUMS = {
-        1: {"link": "<https://api.github.com/dummy/labels?per_page=10&page=1>; rel='last'"},
+        1: {
+            "link": "<https://api.github.com/dummy/labels?per_page=10&page=1>; rel='last'"
+        },
         2: {"link": "<https://api.github.com/dummy/labels?per_page=1&page=2>;"},
         3: {"link": "<https://api.github.com/dummy/labels?per_page=1&page=2&page=3>;"},
     }
 
     def test_get_last_page_num_from_header(self) -> None:
-        for expected_page_num, mock_header in self.MOCK_HEADER_LINKS_TO_PAGE_NUMS.items():
-            self.assertEqual(get_last_page_num_from_header(mock_header), expected_page_num)
+        for (
+            expected_page_num,
+            mock_header,
+        ) in self.MOCK_HEADER_LINKS_TO_PAGE_NUMS.items():
+            self.assertEqual(
+                get_last_page_num_from_header(mock_header), expected_page_num
+            )
 
     MOCK_LABEL_INFO = '[{"name": "foo"}]'
 
@@ -49,23 +57,35 @@ class TestLabelUtils(TestCase):
             gh_get_labels("foo", "bar")
         self.assertIn("number of pages of labels", str(err.exception))
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('label_utils.get_release_notes_labels', return_value=release_notes_labels)
-    def test_pr_with_missing_labels(self, mocked_rn_labels: Any, mocked_gql: Any) -> None:
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch(
+        "label_utils.get_release_notes_labels", return_value=release_notes_labels
+    )
+    def test_pr_with_missing_labels(
+        self, mocked_rn_labels: Any, mocked_gql: Any
+    ) -> None:
         "Test PR with no 'release notes:' label or 'topic: not user facing' label"
         pr = GitHubPR("pytorch", "pytorch", 82169)
         self.assertFalse(has_required_labels(pr))
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('label_utils.get_release_notes_labels', return_value=release_notes_labels)
-    def test_pr_with_release_notes_label(self, mocked_rn_labels: Any, mocked_gql: Any) -> None:
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch(
+        "label_utils.get_release_notes_labels", return_value=release_notes_labels
+    )
+    def test_pr_with_release_notes_label(
+        self, mocked_rn_labels: Any, mocked_gql: Any
+    ) -> None:
         "Test PR with 'release notes: nn' label"
         pr = GitHubPR("pytorch", "pytorch", 71759)
         self.assertTrue(has_required_labels(pr))
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('label_utils.get_release_notes_labels', return_value=release_notes_labels)
-    def test_pr_with_not_user_facing_label(self, mocked_rn_labels: Any, mocked_gql: Any) -> None:
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch(
+        "label_utils.get_release_notes_labels", return_value=release_notes_labels
+    )
+    def test_pr_with_not_user_facing_label(
+        self, mocked_rn_labels: Any, mocked_gql: Any
+    ) -> None:
         "Test PR with 'topic: not user facing' label"
         pr = GitHubPR("pytorch", "pytorch", 75095)
         self.assertTrue(has_required_labels(pr))

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -10,30 +10,32 @@
 import json
 import os
 from hashlib import sha256
-
-from trymerge import (
-    find_matching_merge_rule,
-    gh_graphql,
-    gh_get_team_members,
-    read_merge_rules,
-    validate_revert,
-    GitHubPR,
-    MergeRule,
-    MandatoryChecksMissingError,
-    PostCommentError,
-    FlakyRule,
-    categorize_checks,
-    get_rockset_results,
-    main as trymerge_main,
-    get_classifications,
-)
-from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from typing import Any, Dict, List, Optional
-from unittest import TestCase, main, mock
+from unittest import main, mock, TestCase
 from urllib.error import HTTPError
 
-if 'GIT_REMOTE_URL' not in os.environ:
-    os.environ['GIT_REMOTE_URL'] = "https://github.com/pytorch/pytorch"
+from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
+
+from trymerge import (
+    categorize_checks,
+    find_matching_merge_rule,
+    FlakyRule,
+    get_classifications,
+    get_rockset_results,
+    gh_get_team_members,
+    gh_graphql,
+    GitHubPR,
+    main as trymerge_main,
+    MandatoryChecksMissingError,
+    MergeRule,
+    PostCommentError,
+    read_merge_rules,
+    validate_revert,
+)
+
+if "GIT_REMOTE_URL" not in os.environ:
+    os.environ["GIT_REMOTE_URL"] = "https://github.com/pytorch/pytorch"
+
 
 def mock_query(
     fallback_function: Any,
@@ -67,8 +69,13 @@ def mock_query(
             err_msg = f"If you are seeing this message during workflow run, please make sure to update {file_name}"
             err_msg += f" locally, by deleting it and running {os.path.basename(__file__)} with "
             err_msg += " GitHub Personal Access Token passed via GITHUB_TOKEN environment variable"
-            err_msg += " the rockset api key passed via ROCKSET_API_KEY environment variable"
-            if os.getenv("GITHUB_TOKEN") is None or os.getenv("ROCKSET_API_KEY") is None:
+            err_msg += (
+                " the rockset api key passed via ROCKSET_API_KEY environment variable"
+            )
+            if (
+                os.getenv("GITHUB_TOKEN") is None
+                or os.getenv("ROCKSET_API_KEY") is None
+            ):
                 err_msg = (
                     "Failed to update cached GraphQL queries as GITHUB_TOKEN or ROCKSET_API_KEY is not defined."
                     + err_msg
@@ -89,7 +96,9 @@ def mocked_gh_graphql(query: str, **kwargs: Any) -> Any:
 
     def gh_graphql_wrapper(query: str, kwargs: Any) -> Any:
         return gh_graphql(query, **kwargs)
+
     return mock_query(gh_graphql_wrapper, "gql_mocks.json", key_function, query, kwargs)
+
 
 def mocked_rockset_results(head_sha: str, merge_base: str, num_retries: int = 3) -> Any:
     return mock_query(
@@ -100,6 +109,7 @@ def mocked_rockset_results(head_sha: str, merge_base: str, num_retries: int = 3)
         merge_base,
     )
 
+
 def mock_parse_args(revert: bool = False, force: bool = False) -> Any:
     class Object(object):
         def __init__(self) -> None:
@@ -108,68 +118,86 @@ def mock_parse_args(revert: bool = False, force: bool = False) -> Any:
             self.pr_num = 76123
             self.dry_run = True
             self.comment_id = 0
-            self.reason = 'this is for testing'
+            self.reason = "this is for testing"
             self.ignore_current = False
 
     return Object()
 
-def mock_revert(repo: GitRepo, pr: GitHubPR, *,
-                dry_run: bool = False,
-                comment_id: Optional[int] = None,
-                reason: Optional[str] = None) -> None:
+
+def mock_revert(
+    repo: GitRepo,
+    pr: GitHubPR,
+    *,
+    dry_run: bool = False,
+    comment_id: Optional[int] = None,
+    reason: Optional[str] = None,
+) -> None:
     pass
 
-def mock_merge(pr_num: int, repo: GitRepo,
-               dry_run: bool = False,
-               skip_mandatory_checks: bool = False,
-               comment_id: Optional[int] = None,
-               timeout_minutes: int = 400,
-               stale_pr_days: int = 3,
-               ignore_current: bool = False) -> None:
+
+def mock_merge(
+    pr_num: int,
+    repo: GitRepo,
+    dry_run: bool = False,
+    skip_mandatory_checks: bool = False,
+    comment_id: Optional[int] = None,
+    timeout_minutes: int = 400,
+    stale_pr_days: int = 3,
+    ignore_current: bool = False,
+) -> None:
     pass
+
 
 def mock_gh_get_info() -> Any:
-    return {"closed": False,
-            "isCrossRepository": False,
-            "files": {"nodes": [], "pageInfo": {"hasNextPage": False}}, "changedFiles": 0}
+    return {
+        "closed": False,
+        "isCrossRepository": False,
+        "files": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+        "changedFiles": 0,
+    }
 
 
 def mocked_read_merge_rules_NE(repo: Any, org: str, project: str) -> List[MergeRule]:
     return [
-        MergeRule(name="mock with nonexistent check",
-                  patterns=["*"],
-                  approved_by=[],
-                  mandatory_checks_name=["Lint",
-                                         "Facebook CLA Check",
-                                         "nonexistent"],
-                  ),
+        MergeRule(
+            name="mock with nonexistent check",
+            patterns=["*"],
+            approved_by=[],
+            mandatory_checks_name=["Lint", "Facebook CLA Check", "nonexistent"],
+        ),
     ]
 
 
 def mocked_read_merge_rules(repo: Any, org: str, project: str) -> List[MergeRule]:
     return [
-        MergeRule(name="super",
-                  patterns=["*"],
-                  approved_by=["pytorch/metamates"],
-                  mandatory_checks_name=["Lint",
-                                         "Facebook CLA Check",
-                                         "pull / linux-xenial-cuda11.3-py3.7-gcc7 / build",
-                                         ],
-                  ),
+        MergeRule(
+            name="super",
+            patterns=["*"],
+            approved_by=["pytorch/metamates"],
+            mandatory_checks_name=[
+                "Lint",
+                "Facebook CLA Check",
+                "pull / linux-xenial-cuda11.3-py3.7-gcc7 / build",
+            ],
+        ),
     ]
 
 
 def mocked_read_merge_rules_raise(repo: Any, org: str, project: str) -> List[MergeRule]:
     raise RuntimeError("testing")
 
+
 def empty_flaky_rules() -> List[FlakyRule]:
     return []
+
 
 def empty_rockset_results(head_sha: str, merge_base: str) -> List[Dict[str, Any]]:
     return []
 
+
 def dummy_merge_base() -> str:
     return "dummy"
+
 
 class DummyGitRepo(GitRepo):
     def __init__(self) -> None:
@@ -185,7 +213,7 @@ class DummyGitRepo(GitRepo):
 @mock.patch("trymerge.read_flaky_rules", side_effect=empty_flaky_rules)
 @mock.patch("trymerge.get_rockset_results", side_effect=empty_rockset_results)
 @mock.patch("trymerge.GitHubPR.get_merge_base", side_effect=dummy_merge_base)
-@mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+@mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
 class TestTryMerge(TestCase):
     def test_merge_rules_valid(self, *args: Any) -> None:
         "Test that merge_rules.yaml can be parsed"
@@ -193,21 +221,23 @@ class TestTryMerge(TestCase):
         merge_rules = read_merge_rules(repo, "pytorch", "pytorch")
         self.assertGreater(len(merge_rules), 1)
 
-    @mock.patch('trymerge.read_merge_rules', side_effect=mocked_read_merge_rules)
+    @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)
     def test_match_rules(self, *args: Any) -> None:
         "Tests that PR passes merge rules"
         pr = GitHubPR("pytorch", "pytorch", 77700)
         repo = DummyGitRepo()
         self.assertTrue(find_matching_merge_rule(pr, repo) is not None)
 
-    @mock.patch('trymerge.read_merge_rules', side_effect=mocked_read_merge_rules_raise)
+    @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules_raise)
     def test_read_merge_rules_fails(self, *args: Any) -> None:
         "Tests that PR fails to read the merge rules"
         pr = GitHubPR("pytorch", "pytorch", 77700)
         repo = DummyGitRepo()
-        self.assertRaisesRegex(RuntimeError, "testing", lambda: find_matching_merge_rule(pr, repo))
+        self.assertRaisesRegex(
+            RuntimeError, "testing", lambda: find_matching_merge_rule(pr, repo)
+        )
 
-    @mock.patch('trymerge.read_merge_rules', side_effect=mocked_read_merge_rules)
+    @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)
     def test_lint_fails(self, *args: Any) -> None:
         "Tests that PR fails mandatory lint check"
         pr = GitHubPR("pytorch", "pytorch", 90791)
@@ -223,8 +253,8 @@ class TestTryMerge(TestCase):
         self.assertTrue("You've committed this PR" in comment.body_text)
 
     def test_get_author_null(self, *args: Any) -> None:
-        """ Tests that PR author can be computed
-            If reply contains NULL
+        """Tests that PR author can be computed
+        If reply contains NULL
         """
         pr = GitHubPR("pytorch", "pytorch", 71759)
         author = pr.get_author()
@@ -239,8 +269,7 @@ class TestTryMerge(TestCase):
         self.assertTrue(author is not None)
 
     def test_last_pushed_at(self, *args: Any) -> None:
-        """ Tests that last_pushed_at will return None on merge commits.
-        """
+        """Tests that last_pushed_at will return None on merge commits."""
         pr = GitHubPR("pytorch", "pytorch", 71759)
         self.assertIsNotNone(pr.last_pushed_at())
 
@@ -295,27 +324,26 @@ class TestTryMerge(TestCase):
             self.assertEqual(len(non_existing_team), 0)
 
     def test_get_author_many_commits(self, *args: Any) -> None:
-        """ Tests that authors for all commits can be fetched
-        """
+        """Tests that authors for all commits can be fetched"""
         pr = GitHubPR("pytorch", "pytorch", 76118)
         authors = pr.get_authors()
         self.assertGreater(pr.get_commit_count(), 100)
         self.assertGreater(len(authors), 50)
         self.assertTrue("@" in pr.get_author())
 
-    @mock.patch('trymerge.read_merge_rules', side_effect=mocked_read_merge_rules_NE)
+    @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules_NE)
     def test_pending_status_check(self, *args: Any) -> None:
-        """ Tests that PR with nonexistent/pending status checks fails with the right reason.
-        """
+        """Tests that PR with nonexistent/pending status checks fails with the right reason."""
         pr = GitHubPR("pytorch", "pytorch", 76118)
         repo = DummyGitRepo()
-        self.assertRaisesRegex(MandatoryChecksMissingError,
-                               ".*are pending/not yet run.*",
-                               lambda: find_matching_merge_rule(pr, repo))
+        self.assertRaisesRegex(
+            MandatoryChecksMissingError,
+            ".*are pending/not yet run.*",
+            lambda: find_matching_merge_rule(pr, repo),
+        )
 
     def test_get_author_many_reviews(self, *args: Any) -> None:
-        """ Tests that all reviews can be fetched
-        """
+        """Tests that all reviews can be fetched"""
         pr = GitHubPR("pytorch", "pytorch", 76123)
         approved_by = pr.get_approved_by()
         self.assertGreater(len(approved_by), 0)
@@ -323,56 +351,62 @@ class TestTryMerge(TestCase):
         self.assertGreater(len(pr._reviews), 100)
 
     def test_get_checkruns_many_runs(self, *args: Any) -> None:
-        """ Tests that all checkruns can be fetched
-        """
+        """Tests that all checkruns can be fetched"""
         pr = GitHubPR("pytorch", "pytorch", 77700)
         conclusions = pr.get_checkrun_conclusions()
         self.assertEqual(len(conclusions), 79)
         self.assertTrue("pull / linux-docs / build-docs (cpp)" in conclusions.keys())
 
     def test_cancelled_gets_ignored(self, *args: Any) -> None:
-        """ Tests that cancelled workflow does not override existing successfull status
-        """
+        """Tests that cancelled workflow does not override existing successfull status"""
         pr = GitHubPR("pytorch", "pytorch", 82169)
         conclusions = pr.get_checkrun_conclusions()
         lint_checks = [name for name in conclusions.keys() if "Lint" in name]
         self.assertTrue(len(lint_checks) > 0)
-        self.assertTrue(all([conclusions[name].status == "SUCCESS" for name in lint_checks]))
+        self.assertTrue(
+            all([conclusions[name].status == "SUCCESS" for name in lint_checks])
+        )
 
-    @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
-    @mock.patch('trymerge.parse_args', return_value=mock_parse_args(True, False))
-    @mock.patch('trymerge.try_revert', side_effect=mock_revert)
+    @mock.patch("trymerge.gh_get_pr_info", return_value=mock_gh_get_info())
+    @mock.patch("trymerge.parse_args", return_value=mock_parse_args(True, False))
+    @mock.patch("trymerge.try_revert", side_effect=mock_revert)
     def test_main_revert(self, mock_revert: Any, *args: Any) -> None:
         trymerge_main()
         mock_revert.assert_called_once()
 
-    @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
-    @mock.patch('trymerge.parse_args', return_value=mock_parse_args(False, True))
-    @mock.patch('trymerge.merge', side_effect=mock_merge)
-    def test_main_force(self, mock_merge: Any, mock_parse_args: Any, *args: Any) -> None:
+    @mock.patch("trymerge.gh_get_pr_info", return_value=mock_gh_get_info())
+    @mock.patch("trymerge.parse_args", return_value=mock_parse_args(False, True))
+    @mock.patch("trymerge.merge", side_effect=mock_merge)
+    def test_main_force(
+        self, mock_merge: Any, mock_parse_args: Any, *args: Any
+    ) -> None:
         trymerge_main()
-        mock_merge.assert_called_once_with(mock.ANY,
-                                           mock.ANY,
-                                           dry_run=mock.ANY,
-                                           skip_mandatory_checks=True,
-                                           comment_id=mock.ANY,
-                                           ignore_current=False)
+        mock_merge.assert_called_once_with(
+            mock.ANY,
+            mock.ANY,
+            dry_run=mock.ANY,
+            skip_mandatory_checks=True,
+            comment_id=mock.ANY,
+            ignore_current=False,
+        )
 
-    @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
-    @mock.patch('trymerge.parse_args', return_value=mock_parse_args(False, False))
-    @mock.patch('trymerge.merge', side_effect=mock_merge)
+    @mock.patch("trymerge.gh_get_pr_info", return_value=mock_gh_get_info())
+    @mock.patch("trymerge.parse_args", return_value=mock_parse_args(False, False))
+    @mock.patch("trymerge.merge", side_effect=mock_merge)
     def test_main_merge(self, mock_merge: Any, *args: Any) -> None:
         trymerge_main()
-        mock_merge.assert_called_once_with(mock.ANY,
-                                           mock.ANY,
-                                           dry_run=mock.ANY,
-                                           skip_mandatory_checks=False,
-                                           comment_id=mock.ANY,
-                                           ignore_current=False)
+        mock_merge.assert_called_once_with(
+            mock.ANY,
+            mock.ANY,
+            dry_run=mock.ANY,
+            skip_mandatory_checks=False,
+            comment_id=mock.ANY,
+            ignore_current=False,
+        )
 
-    @mock.patch('trymerge.read_merge_rules', side_effect=mocked_read_merge_rules)
+    @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)
     def test_revert_rules(self, *args: Any) -> None:
-        """ Tests that reverts from collaborators are allowed """
+        """Tests that reverts from collaborators are allowed"""
         pr = GitHubPR("pytorch", "pytorch", 79694)
         repo = DummyGitRepo()
         self.assertIsNotNone(validate_revert(repo, pr, comment_id=1189459845))
@@ -403,7 +437,11 @@ class TestTryMerge(TestCase):
                 return pr.get_body()
 
         repo = GitRepoCoDev()
-        self.assertRaisesRegex(PostCommentError, "landed via phabricator", lambda: validate_revert(repo, pr, comment_id=1372496233))
+        self.assertRaisesRegex(
+            PostCommentError,
+            "landed via phabricator",
+            lambda: validate_revert(repo, pr, comment_id=1372496233),
+        )
 
     def test_pr_changed_submodule_detection(self, *args: Any) -> None:
         # Updates submodule during dev-cycle but reverts it later
@@ -426,10 +464,14 @@ class TestTryMerge(TestCase):
 @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
 class TestBypassFailures(TestCase):
     def test_get_classifications(self, *args: Any) -> None:
-        flaky_rules = [FlakyRule("distributed", ["##[error]The operation was canceled."])]
+        flaky_rules = [
+            FlakyRule("distributed", ["##[error]The operation was canceled."])
+        ]
         pr = GitHubPR("pytorch", "pytorch", 92863)
         checks = pr.get_checkrun_conclusions()
-        checks = get_classifications(checks, pr.last_commit()['oid'], pr.get_merge_base(), flaky_rules, [])
+        checks = get_classifications(
+            checks, pr.last_commit()["oid"], pr.get_merge_base(), flaky_rules, []
+        )
         self.assertTrue(
             checks[
                 "pull / linux-bionic-py3_7-clang8-xla / test (xla, 1, 1, linux.4xlarge)"
@@ -442,10 +484,14 @@ class TestBypassFailures(TestCase):
             ].classification
             == "FLAKY"
         )
-        pending, failed = categorize_checks(checks, list(checks.keys()), ok_failed_checks_threshold=2)
+        pending, failed = categorize_checks(
+            checks, list(checks.keys()), ok_failed_checks_threshold=2
+        )
         self.assertTrue(len(pending) == 0)
         self.assertTrue(len(failed) == 0)
-        pending, failed = categorize_checks(checks, list(checks.keys()), ok_failed_checks_threshold=1)
+        pending, failed = categorize_checks(
+            checks, list(checks.keys()), ok_failed_checks_threshold=1
+        )
         self.assertTrue(len(pending) == 0)
         self.assertTrue(len(failed) == 2)
 
@@ -454,32 +500,52 @@ class TestBypassFailures(TestCase):
         # ignore current checks takes precedence over classifications for flaky
         # or broken trunk
 
-        flaky_rules = [FlakyRule("distributed", ["##[error]The operation was canceled."])]
-        flaky = "pull / linux-focal-py3.7-gcc7 / test (distributed, 1, 2, linux.2xlarge)"
-        broken_trunk = "pull / linux-bionic-py3_7-clang8-xla / test (xla, 1, 1, linux.4xlarge)"
+        flaky_rules = [
+            FlakyRule("distributed", ["##[error]The operation was canceled."])
+        ]
+        flaky = (
+            "pull / linux-focal-py3.7-gcc7 / test (distributed, 1, 2, linux.2xlarge)"
+        )
+        broken_trunk = (
+            "pull / linux-bionic-py3_7-clang8-xla / test (xla, 1, 1, linux.4xlarge)"
+        )
 
         pr = GitHubPR("pytorch", "pytorch", 92863)
         checks = pr.get_checkrun_conclusions()
 
         # No broken trunk or flaky rules
-        checks = get_classifications(checks, pr.last_commit()['oid'], None, [], [flaky])
+        checks = get_classifications(checks, pr.last_commit()["oid"], None, [], [flaky])
         self.assertTrue(checks[flaky].classification == "IGNORE_CURRENT_CHECK")
         self.assertTrue(checks[broken_trunk].classification is None)
-        _, failed = categorize_checks(checks, list(checks.keys()), ok_failed_checks_threshold=0)
+        _, failed = categorize_checks(
+            checks, list(checks.keys()), ok_failed_checks_threshold=0
+        )
         self.assertTrue(len(failed) == 1)
 
         # No flaky rules
-        checks = get_classifications(checks, pr.last_commit()['oid'], pr.get_merge_base(), [], [flaky])
+        checks = get_classifications(
+            checks, pr.last_commit()["oid"], pr.get_merge_base(), [], [flaky]
+        )
         self.assertTrue(checks[flaky].classification == "IGNORE_CURRENT_CHECK")
         self.assertTrue(checks[broken_trunk].classification == "BROKEN_TRUNK")
-        _, failed = categorize_checks(checks, list(checks.keys()), ok_failed_checks_threshold=1)
+        _, failed = categorize_checks(
+            checks, list(checks.keys()), ok_failed_checks_threshold=1
+        )
         self.assertTrue(len(failed) == 0)
 
         # No broken_trunk
-        checks = get_classifications(checks, pr.last_commit()['oid'], pr.get_merge_base(), flaky_rules, [broken_trunk])
+        checks = get_classifications(
+            checks,
+            pr.last_commit()["oid"],
+            pr.get_merge_base(),
+            flaky_rules,
+            [broken_trunk],
+        )
         self.assertTrue(checks[flaky].classification == "FLAKY")
         self.assertTrue(checks[broken_trunk].classification == "IGNORE_CURRENT_CHECK")
-        _, failed = categorize_checks(checks, list(checks.keys()), ok_failed_checks_threshold=1)
+        _, failed = categorize_checks(
+            checks, list(checks.keys()), ok_failed_checks_threshold=1
+        )
         self.assertTrue(len(failed) == 0)
 
 

--- a/.github/scripts/test_tryrebase.py
+++ b/.github/scripts/test_tryrebase.py
@@ -1,75 +1,129 @@
-from unittest import TestCase, mock, main
+from typing import Any
+from unittest import main, mock, TestCase
+
+from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from test_trymerge import mocked_gh_graphql
 from trymerge import GitHubPR
-from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
-from typing import Any
-from tryrebase import rebase_onto, rebase_ghstack_onto
+from tryrebase import rebase_ghstack_onto, rebase_onto
+
 
 def mocked_rev_parse(branch: str) -> str:
     return branch
 
-class TestRebase(TestCase):
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('gitutils.GitRepo._run_git')
-    @mock.patch('gitutils.GitRepo.rev_parse', side_effect=mocked_rev_parse)
-    @mock.patch('tryrebase.gh_post_comment')
-    def test_rebase(self, mocked_post_comment: Any, mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
+class TestRebase(TestCase):
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch("gitutils.GitRepo._run_git")
+    @mock.patch("gitutils.GitRepo.rev_parse", side_effect=mocked_rev_parse)
+    @mock.patch("tryrebase.gh_post_comment")
+    def test_rebase(
+        self,
+        mocked_post_comment: Any,
+        mocked_rp: Any,
+        mocked_run_git: Any,
+        mocked_gql: Any,
+    ) -> None:
         "Tests rebase successfully"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        rebase_onto(pr, repo, 'master')
-        calls = [mock.call('fetch', 'origin', 'pull/31093/head:pull/31093/head'),
-                 mock.call('rebase', 'refs/remotes/origin/master', 'pull/31093/head'),
-                 mock.call('push', '-f', 'https://github.com/mingxiaoh/pytorch.git', 'pull/31093/head:master')]
+        rebase_onto(pr, repo, "master")
+        calls = [
+            mock.call("fetch", "origin", "pull/31093/head:pull/31093/head"),
+            mock.call("rebase", "refs/remotes/origin/master", "pull/31093/head"),
+            mock.call(
+                "push",
+                "-f",
+                "https://github.com/mingxiaoh/pytorch.git",
+                "pull/31093/head:master",
+            ),
+        ]
         mocked_run_git.assert_has_calls(calls)
         self.assertTrue(
-            "Successfully rebased `master` onto `refs/remotes/origin/master`" in mocked_post_comment.call_args[0][3])
+            "Successfully rebased `master` onto `refs/remotes/origin/master`"
+            in mocked_post_comment.call_args[0][3]
+        )
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('gitutils.GitRepo._run_git')
-    @mock.patch('gitutils.GitRepo.rev_parse', side_effect=mocked_rev_parse)
-    @mock.patch('tryrebase.gh_post_comment')
-    def test_rebase_to_stable(self, mocked_post_comment: Any, mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch("gitutils.GitRepo._run_git")
+    @mock.patch("gitutils.GitRepo.rev_parse", side_effect=mocked_rev_parse)
+    @mock.patch("tryrebase.gh_post_comment")
+    def test_rebase_to_stable(
+        self,
+        mocked_post_comment: Any,
+        mocked_rp: Any,
+        mocked_run_git: Any,
+        mocked_gql: Any,
+    ) -> None:
         "Tests rebase to viable/strict successfully"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        rebase_onto(pr, repo, 'viable/strict', False)
-        calls = [mock.call('fetch', 'origin', 'pull/31093/head:pull/31093/head'),
-                 mock.call('rebase', 'refs/remotes/origin/viable/strict', 'pull/31093/head'),
-                 mock.call('push', '-f', 'https://github.com/mingxiaoh/pytorch.git', 'pull/31093/head:master')]
+        rebase_onto(pr, repo, "viable/strict", False)
+        calls = [
+            mock.call("fetch", "origin", "pull/31093/head:pull/31093/head"),
+            mock.call("rebase", "refs/remotes/origin/viable/strict", "pull/31093/head"),
+            mock.call(
+                "push",
+                "-f",
+                "https://github.com/mingxiaoh/pytorch.git",
+                "pull/31093/head:master",
+            ),
+        ]
         mocked_run_git.assert_has_calls(calls)
         self.assertTrue(
-            "Successfully rebased `master` onto `refs/remotes/origin/viable/strict`" in mocked_post_comment.call_args[0][3])
+            "Successfully rebased `master` onto `refs/remotes/origin/viable/strict`"
+            in mocked_post_comment.call_args[0][3]
+        )
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('gitutils.GitRepo._run_git', return_value="Everything up-to-date")
-    @mock.patch('gitutils.GitRepo.rev_parse', side_effect=mocked_rev_parse)
-    @mock.patch('tryrebase.gh_post_comment')
-    def test_no_need_to_rebase(self, mocked_post_comment: Any, mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch("gitutils.GitRepo._run_git", return_value="Everything up-to-date")
+    @mock.patch("gitutils.GitRepo.rev_parse", side_effect=mocked_rev_parse)
+    @mock.patch("tryrebase.gh_post_comment")
+    def test_no_need_to_rebase(
+        self,
+        mocked_post_comment: Any,
+        mocked_rp: Any,
+        mocked_run_git: Any,
+        mocked_gql: Any,
+    ) -> None:
         "Tests branch already up to date"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        rebase_onto(pr, repo, 'master')
-        calls = [mock.call('fetch', 'origin', 'pull/31093/head:pull/31093/head'),
-                 mock.call('rebase', 'refs/remotes/origin/master', 'pull/31093/head'),
-                 mock.call('push', '-f', 'https://github.com/mingxiaoh/pytorch.git', 'pull/31093/head:master')]
+        rebase_onto(pr, repo, "master")
+        calls = [
+            mock.call("fetch", "origin", "pull/31093/head:pull/31093/head"),
+            mock.call("rebase", "refs/remotes/origin/master", "pull/31093/head"),
+            mock.call(
+                "push",
+                "-f",
+                "https://github.com/mingxiaoh/pytorch.git",
+                "pull/31093/head:master",
+            ),
+        ]
         mocked_run_git.assert_has_calls(calls)
         self.assertTrue(
-            "Tried to rebase and push PR #31093, but it was already up to date" in mocked_post_comment.call_args[0][3])
+            "Tried to rebase and push PR #31093, but it was already up to date"
+            in mocked_post_comment.call_args[0][3]
+        )
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    @mock.patch('gitutils.GitRepo._run_git')
-    @mock.patch('gitutils.GitRepo.rev_parse', side_effect=lambda branch: "same sha")
-    @mock.patch('tryrebase.gh_post_comment')
-    def test_same_sha(self, mocked_post_comment: Any, mocked_rp: Any, mocked_run_git: Any, mocked_gql: Any) -> None:
+    @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+    @mock.patch("gitutils.GitRepo._run_git")
+    @mock.patch("gitutils.GitRepo.rev_parse", side_effect=lambda branch: "same sha")
+    @mock.patch("tryrebase.gh_post_comment")
+    def test_same_sha(
+        self,
+        mocked_post_comment: Any,
+        mocked_rp: Any,
+        mocked_run_git: Any,
+        mocked_gql: Any,
+    ) -> None:
         "Tests rebase results in same sha"
         pr = GitHubPR("pytorch", "pytorch", 31093)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        with self.assertRaisesRegex(Exception, 'same sha as the target branch'):
-            rebase_onto(pr, repo, 'master')
-        with self.assertRaisesRegex(Exception, 'same sha as the target branch'):
-            rebase_ghstack_onto(pr, repo, 'master')
+        with self.assertRaisesRegex(Exception, "same sha as the target branch"):
+            rebase_onto(pr, repo, "master")
+        with self.assertRaisesRegex(Exception, "same sha as the target branch"):
+            rebase_ghstack_onto(pr, repo, "master")
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -760,7 +760,7 @@ class GitHubPR:
                 )
                 info = rc["data"]["repository"]["pullRequest"]
         reviews = {}
-        for (author, state) in self._reviews:
+        for author, state in self._reviews:
             if state != "COMMENTED":
                 reviews[author] = state
         return list(reviews.items())

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -19,44 +19,29 @@ import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
-import yaml
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    NamedTuple,
-    Optional,
-    Pattern,
-    Tuple,
-    cast,
-)
-from warnings import warn
 from pathlib import Path
+from typing import Any, Callable, cast, Dict, List, NamedTuple, Optional, Pattern, Tuple
+from warnings import warn
 
-from gitutils import (
-    GitRepo,
-    are_ghstack_branches_in_sync,
-    get_git_remote_name,
-    get_git_repo_dir,
-    patterns_to_regex,
-)
+import yaml
 from github_utils import (
-    GitHubComment,
     gh_fetch_json_list,
     gh_fetch_url,
     gh_post_commit_comment,
     gh_post_pr_comment,
+    GitHubComment,
 )
-from label_utils import (
-    LABEL_ERR_MSG,
-    gh_add_labels,
-    has_required_labels,
+
+from gitutils import (
+    are_ghstack_branches_in_sync,
+    get_git_remote_name,
+    get_git_repo_dir,
+    GitRepo,
+    patterns_to_regex,
 )
-from trymerge_explainer import (
-    TryMergeExplainer,
-    get_revert_message,
-)
+from label_utils import gh_add_labels, has_required_labels, LABEL_ERR_MSG
+from trymerge_explainer import get_revert_message, TryMergeExplainer
+
 
 class JobCheckState(NamedTuple):
     name: str
@@ -64,7 +49,9 @@ class JobCheckState(NamedTuple):
     status: Optional[str]
     classification: Optional[str]
 
+
 JobNameToStateDict = Dict[str, JobCheckState]
+
 
 class WorkflowCheckState:
     def __init__(self, name: str, url: str, status: Optional[str]):
@@ -72,6 +59,7 @@ class WorkflowCheckState:
         self.url: str = url
         self.status: Optional[str] = status
         self.jobs: JobNameToStateDict = {}
+
 
 class FlakyRule:
     def __init__(self, name: str, captures: List[str]):
@@ -81,10 +69,16 @@ class FlakyRule:
     def matches(self, job: Optional[Dict[str, Any]]) -> bool:
         return (
             job is not None
-            and self.name in job.get('name', '')
+            and self.name in job.get("name", "")
             and job.get("failure_captures") is not None
-            and all([capture in job.get("failure_captures", []) for capture in self.captures])
+            and all(
+                [
+                    capture in job.get("failure_captures", [])
+                    for capture in self.captures
+                ]
+            )
         )
+
 
 GH_PR_REVIEWS_FRAGMENT = """
 fragment PRReviews on PullRequestReviewConnection {
@@ -157,7 +151,11 @@ fragment CommitAuthors on PullRequestCommitConnection {
 }
 """
 
-GH_GET_PR_INFO_QUERY = GH_PR_REVIEWS_FRAGMENT + GH_CHECKSUITES_FRAGMENT + GH_COMMIT_AUTHORS_FRAGMENT + """
+GH_GET_PR_INFO_QUERY = (
+    GH_PR_REVIEWS_FRAGMENT
+    + GH_CHECKSUITES_FRAGMENT
+    + GH_COMMIT_AUTHORS_FRAGMENT
+    + """
 query ($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
@@ -247,6 +245,7 @@ query ($owner: String!, $name: String!, $number: Int!) {
   }
 }
 """
+)
 
 GH_GET_PR_NEXT_FILES_QUERY = """
 query ($owner: String!, $name: String!, $number: Int!, $cursor: String!) {
@@ -266,7 +265,9 @@ query ($owner: String!, $name: String!, $number: Int!, $cursor: String!) {
 }
 """
 
-GH_GET_PR_NEXT_CHECKSUITES = GH_CHECKSUITES_FRAGMENT + """
+GH_GET_PR_NEXT_CHECKSUITES = (
+    GH_CHECKSUITES_FRAGMENT
+    + """
 query ($owner: String!, $name: String!, $number: Int!, $cursor: String!) {
   repository(name: $name, owner: $owner) {
     pullRequest(number: $number) {
@@ -284,6 +285,7 @@ query ($owner: String!, $name: String!, $number: Int!, $cursor: String!) {
   }
 }
 """
+)
 
 GH_GET_PR_NEXT_CHECK_RUNS = """
 query ($owner: String!, $name: String!, $number: Int!, $cs_cursor: String, $cr_cursor: String!) {
@@ -362,7 +364,9 @@ query($org: String!, $name: String!, $cursor: String) {
 }
 """
 
-GH_GET_PR_NEXT_AUTHORS_QUERY = GH_COMMIT_AUTHORS_FRAGMENT + """
+GH_GET_PR_NEXT_AUTHORS_QUERY = (
+    GH_COMMIT_AUTHORS_FRAGMENT
+    + """
 query ($owner: String!, $name: String!, $number: Int!, $cursor: String) {
   repository(name: $name, owner: $owner) {
     pullRequest(number: $number) {
@@ -373,8 +377,11 @@ query ($owner: String!, $name: String!, $number: Int!, $cursor: String) {
   }
 }
 """
+)
 
-GH_GET_PR_PREV_REVIEWS_QUERY = GH_PR_REVIEWS_FRAGMENT + """
+GH_GET_PR_PREV_REVIEWS_QUERY = (
+    GH_PR_REVIEWS_FRAGMENT
+    + """
 query ($owner: String!, $name: String!, $number: Int!, $cursor: String!) {
   repository(name: $name, owner: $owner) {
     pullRequest(number: $number) {
@@ -385,6 +392,7 @@ query ($owner: String!, $name: String!, $number: Int!, $cursor: String!) {
   }
 }
 """
+)
 
 GH_GET_REPO_SUBMODULES = """
 query ($owner: String!, $name: String!) {
@@ -403,23 +411,29 @@ query ($owner: String!, $name: String!) {
 """
 
 RE_GHSTACK_HEAD_REF = re.compile(r"^(gh/[^/]+/[0-9]+/)head$")
-RE_GHSTACK_DESC = re.compile(r'Stack.*:\r?\n(\* [^\r\n]+\r?\n)+', re.MULTILINE)
+RE_GHSTACK_DESC = re.compile(r"Stack.*:\r?\n(\* [^\r\n]+\r?\n)+", re.MULTILINE)
 RE_PULL_REQUEST_RESOLVED = re.compile(
-    r'Pull Request resolved: '
-    r'https://github.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>[0-9]+)',
-    re.MULTILINE
+    r"Pull Request resolved: "
+    r"https://github.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>[0-9]+)",
+    re.MULTILINE,
 )
-RE_PR_CC_LINE = re.compile(r'^cc:? @\w+.*\r?\n?$', re.MULTILINE)
-RE_DIFF_REV = re.compile(r'^Differential Revision:.+?(D[0-9]+)', re.MULTILINE)
+RE_PR_CC_LINE = re.compile(r"^cc:? @\w+.*\r?\n?$", re.MULTILINE)
+RE_DIFF_REV = re.compile(r"^Differential Revision:.+?(D[0-9]+)", re.MULTILINE)
 CIFLOW_LABEL = re.compile(r"^ciflow/.+")
 CIFLOW_TRUNK_LABEL = re.compile(r"^ciflow/trunk")
 MERGE_RULE_PATH = Path(".github") / "merge_rules.yaml"
 
 
 def gh_graphql(query: str, **kwargs: Any) -> Dict[str, Any]:
-    rc = gh_fetch_url("https://api.github.com/graphql", data={"query": query, "variables": kwargs}, reader=json.load)
+    rc = gh_fetch_url(
+        "https://api.github.com/graphql",
+        data={"query": query, "variables": kwargs},
+        reader=json.load,
+    )
     if "errors" in rc:
-        raise RuntimeError(f"GraphQL query {query}, args {kwargs} failed: {rc['errors']}")
+        raise RuntimeError(
+            f"GraphQL query {query}, args {kwargs} failed: {rc['errors']}"
+        )
     return cast(Dict[str, Any], rc)
 
 
@@ -427,12 +441,20 @@ def gh_get_pr_info(org: str, proj: str, pr_no: int) -> Any:
     rc = gh_graphql(GH_GET_PR_INFO_QUERY, name=proj, owner=org, number=pr_no)
     return rc["data"]["repository"]["pullRequest"]
 
+
 @lru_cache(maxsize=None)
 def gh_get_team_members(org: str, name: str) -> List[str]:
     rc: List[str] = []
-    team_members: Dict[str, Any] = {"pageInfo": {"hasNextPage": "true", "endCursor": None}}
+    team_members: Dict[str, Any] = {
+        "pageInfo": {"hasNextPage": "true", "endCursor": None}
+    }
     while bool(team_members["pageInfo"]["hasNextPage"]):
-        query = gh_graphql(GH_GET_TEAM_MEMBERS_QUERY, org=org, name=name, cursor=team_members["pageInfo"]["endCursor"])
+        query = gh_graphql(
+            GH_GET_TEAM_MEMBERS_QUERY,
+            org=org,
+            name=name,
+            cursor=team_members["pageInfo"]["endCursor"],
+        )
         team = query["data"]["organization"]["team"]
         if team is None:
             warn(f"Requested non-existing team {org}/{name}")
@@ -440,6 +462,7 @@ def gh_get_team_members(org: str, name: str) -> List[str]:
         team_members = team["members"]
         rc += [member["login"] for member in team_members["nodes"]]
     return rc
+
 
 def get_check_run_name_prefix(workflow_run: Any) -> str:
     if workflow_run is None:
@@ -451,10 +474,11 @@ def get_check_run_name_prefix(workflow_run: Any) -> str:
 def is_passing_status(status: Optional[str]) -> bool:
     return status is not None and status.upper() in ["SUCCESS", "SKIPPED", "NEUTRAL"]
 
+
 def add_workflow_conclusions(
     checksuites: Any,
     get_next_checkruns_page: Callable[[List[Dict[str, Dict[str, Any]]], int, Any], Any],
-    get_next_checksuites: Callable[[Any], Any]
+    get_next_checksuites: Callable[[Any], Any],
 ) -> JobNameToStateDict:
     # graphql seems to favor the most recent workflow run, so in theory we
     # shouldn't need to account for reruns, but do it just in case
@@ -487,7 +511,6 @@ def add_workflow_conclusions(
                     )
                 workflow_obj = workflows[workflow_name]
 
-
             while checkruns is not None:
                 for checkrun_node in checkruns["nodes"]:
                     if not isinstance(checkrun_node, dict):
@@ -495,12 +518,14 @@ def add_workflow_conclusions(
                         continue
                     checkrun_name = f'{get_check_run_name_prefix(workflow_run)}{checkrun_node["name"]}'
                     existing_checkrun = workflow_obj.jobs.get(checkrun_name)
-                    if existing_checkrun is None or not is_passing_status(existing_checkrun.status):
+                    if existing_checkrun is None or not is_passing_status(
+                        existing_checkrun.status
+                    ):
                         workflow_obj.jobs[checkrun_name] = JobCheckState(
                             checkrun_name,
                             checkrun_node["detailsUrl"],
                             checkrun_node["conclusion"],
-                            None
+                            None,
                         )
 
                 if bool(checkruns["pageInfo"]["hasNextPage"]):
@@ -525,10 +550,7 @@ def add_workflow_conclusions(
                 res[job_name] = job
         else:
             res[workflow_name] = JobCheckState(
-                workflow.name,
-                workflow.url,
-                workflow.status,
-                None
+                workflow.name, workflow.url, workflow.status, None
             )
     for job_name, job in no_workflow_obj.jobs.items():
         res[job_name] = job
@@ -537,6 +559,7 @@ def add_workflow_conclusions(
 
 def parse_args() -> Any:
     from argparse import ArgumentParser
+
     parser = ArgumentParser("Merge PR into default branch")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--revert", action="store_true")
@@ -546,6 +569,7 @@ def parse_args() -> Any:
     parser.add_argument("--reason", type=str)
     parser.add_argument("pr_num", type=int)
     return parser.parse_args()
+
 
 def can_skip_internal_checks(pr: "GitHubPR", comment_id: Optional[int] = None) -> bool:
     if comment_id is None:
@@ -557,9 +581,9 @@ def can_skip_internal_checks(pr: "GitHubPR", comment_id: Optional[int] = None) -
 
 
 def get_ghstack_prs(repo: GitRepo, pr: "GitHubPR") -> List[Tuple["GitHubPR", str]]:
-    '''
+    """
     Get the open PRs in the stack that are below this PR.  Throws error if any of the PRs are out of sync.
-    '''
+    """
     assert pr.is_ghstack_pr()
     entire_stack: List[Tuple["GitHubPR", str]] = []
     # For ghstack, cherry-pick commits based from origin
@@ -569,14 +593,20 @@ def get_ghstack_prs(repo: GitRepo, pr: "GitHubPR") -> List[Tuple["GitHubPR", str
         msg = repo.commit_message(rev)
         m = RE_PULL_REQUEST_RESOLVED.search(msg)
         if m is None:
-            raise RuntimeError(f"Could not find PR-resolved string in {msg} of ghstacked PR {pr.pr_num}")
-        if pr.org != m.group('owner') or pr.project != m.group('repo'):
-            raise RuntimeError(f"PR {m.group('number')} resolved to wrong owner/repo pair")
-        stacked_pr_num = int(m.group('number'))
+            raise RuntimeError(
+                f"Could not find PR-resolved string in {msg} of ghstacked PR {pr.pr_num}"
+            )
+        if pr.org != m.group("owner") or pr.project != m.group("repo"):
+            raise RuntimeError(
+                f"PR {m.group('number')} resolved to wrong owner/repo pair"
+            )
+        stacked_pr_num = int(m.group("number"))
         if stacked_pr_num != pr.pr_num:
             stacked_pr = GitHubPR(pr.org, pr.project, stacked_pr_num)
             if stacked_pr.is_closed():
-                print(f"Skipping {idx+1} of {len(rev_list)} PR (#{stacked_pr_num}) as its already been merged")
+                print(
+                    f"Skipping {idx+1} of {len(rev_list)} PR (#{stacked_pr_num}) as its already been merged"
+                )
                 continue
             entire_stack.append((stacked_pr, rev))
         else:
@@ -585,10 +615,10 @@ def get_ghstack_prs(repo: GitRepo, pr: "GitHubPR") -> List[Tuple["GitHubPR", str
     for stacked_pr, rev in entire_stack:
         if not are_ghstack_branches_in_sync(repo, stacked_pr.head_ref()):
             raise RuntimeError(
-                f"PR {stacked_pr.pr_num} is out of sync with the corresponding revision {rev} on " +
-                f"branch {orig_ref} that would be merged into master.  " +
-                "This usually happens because there is a non ghstack change in the PR.  " +
-                f"Please sync them and try again (ex. make the changes on {orig_ref} and run ghstack)."
+                f"PR {stacked_pr.pr_num} is out of sync with the corresponding revision {rev} on "
+                + f"branch {orig_ref} that would be merged into master.  "
+                + "This usually happens because there is a non ghstack change in the PR.  "
+                + f"Please sync them and try again (ex. make the changes on {orig_ref} and run ghstack)."
             )
     return entire_stack
 
@@ -648,7 +678,7 @@ class GitHubPR:
             branch_name = f"__pull-request-{self.pr_num}__init__"
         try:
             r = repo._run_git("rev-parse", branch_name)
-            if r.strip() == self.last_commit()['oid']:
+            if r.strip() == self.last_commit()["oid"]:
                 return
         except Exception:
             pass
@@ -659,7 +689,9 @@ class GitHubPR:
             return self.merge_base
         self.fetch()
         gitrepo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        self.merge_base = gitrepo.get_merge_base("origin/master", self.last_commit()['oid'])
+        self.merge_base = gitrepo.get_merge_base(
+            "origin/master", self.last_commit()["oid"]
+        )
         return self.merge_base
 
     def get_changed_files(self) -> List[str]:
@@ -671,11 +703,13 @@ class GitHubPR:
                 unique_changed_files.update([x["path"] for x in info["files"]["nodes"]])
                 if not info["files"]["pageInfo"]["hasNextPage"]:
                     break
-                rc = gh_graphql(GH_GET_PR_NEXT_FILES_QUERY,
-                                name=self.project,
-                                owner=self.org,
-                                number=self.pr_num,
-                                cursor=info["files"]["pageInfo"]["endCursor"])
+                rc = gh_graphql(
+                    GH_GET_PR_NEXT_FILES_QUERY,
+                    name=self.project,
+                    owner=self.org,
+                    number=self.pr_num,
+                    cursor=info["files"]["pageInfo"]["endCursor"],
+                )
                 info = rc["data"]["repository"]["pullRequest"]
             self.changed_files = list(unique_changed_files)
 
@@ -685,9 +719,7 @@ class GitHubPR:
 
     def get_submodules(self) -> List[str]:
         if self.submodules is None:
-            rc = gh_graphql(GH_GET_REPO_SUBMODULES,
-                            name=self.project,
-                            owner=self.org)
+            rc = gh_graphql(GH_GET_REPO_SUBMODULES, name=self.project, owner=self.org)
             info = rc["data"]["repository"]["submodules"]
             self.submodules = [s["path"] for s in info["nodes"]]
         return self.submodules
@@ -697,14 +729,16 @@ class GitHubPR:
         return [f for f in self.get_changed_files() if f in submodules]
 
     def has_invalid_submodule_updates(self) -> bool:
-        """ Submodule updates in PR are invalid if submodule keyword
+        """Submodule updates in PR are invalid if submodule keyword
         is not mentioned in neither the title nor body/description
         nor in any of the labels.
         """
-        return (len(self.get_changed_submodules()) > 0 and
-                "submodule" not in self.get_title().lower() and
-                "submodule" not in self.get_body().lower() and
-                all("submodule" not in label for label in self.get_labels()))
+        return (
+            len(self.get_changed_submodules()) > 0
+            and "submodule" not in self.get_title().lower()
+            and "submodule" not in self.get_body().lower()
+            and all("submodule" not in label for label in self.get_labels())
+        )
 
     def _get_reviews(self) -> List[Tuple[str, str]]:
         if self._reviews is None:
@@ -712,14 +746,18 @@ class GitHubPR:
             info = self.info
             for _ in range(100):
                 nodes = info["reviews"]["nodes"]
-                self._reviews = [(node["author"]["login"], node["state"]) for node in nodes] + self._reviews
+                self._reviews = [
+                    (node["author"]["login"], node["state"]) for node in nodes
+                ] + self._reviews
                 if not info["reviews"]["pageInfo"]["hasPreviousPage"]:
                     break
-                rc = gh_graphql(GH_GET_PR_PREV_REVIEWS_QUERY,
-                                name=self.project,
-                                owner=self.org,
-                                number=self.pr_num,
-                                cursor=info["reviews"]["pageInfo"]["startCursor"])
+                rc = gh_graphql(
+                    GH_GET_PR_PREV_REVIEWS_QUERY,
+                    name=self.project,
+                    owner=self.org,
+                    number=self.pr_num,
+                    cursor=info["reviews"]["pageInfo"]["startCursor"],
+                )
                 info = rc["data"]["repository"]["pullRequest"]
         reviews = {}
         for (author, state) in self._reviews:
@@ -757,11 +795,13 @@ class GitHubPR:
             add_authors(info)
             if not info["commits_with_authors"]["pageInfo"]["hasNextPage"]:
                 break
-            rc = gh_graphql(GH_GET_PR_NEXT_AUTHORS_QUERY,
-                            name=self.project,
-                            owner=self.org,
-                            number=self.pr_num,
-                            cursor=info["commits_with_authors"]["pageInfo"]["endCursor"])
+            rc = gh_graphql(
+                GH_GET_PR_NEXT_AUTHORS_QUERY,
+                name=self.project,
+                owner=self.org,
+                number=self.pr_num,
+                cursor=info["commits_with_authors"]["pageInfo"]["endCursor"],
+            )
             info = rc["data"]["repository"]["pullRequest"]
         self._authors = authors
         return authors
@@ -775,33 +815,45 @@ class GitHubPR:
     def get_labels(self) -> List[str]:
         if self.labels is not None:
             return self.labels
-        labels = [node['node']['name'] for node in self.info["labels"]["edges"]] if "labels" in self.info else []
+        labels = (
+            [node["node"]["name"] for node in self.info["labels"]["edges"]]
+            if "labels" in self.info
+            else []
+        )
         self.labels = labels
         return self.labels
 
     def get_checkrun_conclusions(self) -> JobNameToStateDict:
-        """ Returns dict of checkrun -> [conclusion, url] """
+        """Returns dict of checkrun -> [conclusion, url]"""
         if self.conclusions is not None:
             return self.conclusions
         orig_last_commit = self.last_commit()
 
-        def get_pr_next_check_runs(edges: List[Dict[str, Dict[str, Any]]], edge_idx: int, checkruns: Any) -> Any:
-            rc = gh_graphql(GH_GET_PR_NEXT_CHECK_RUNS,
-                            name=self.project,
-                            owner=self.org,
-                            number=self.pr_num,
-                            cs_cursor=edges[edge_idx - 1]["cursor"] if edge_idx > 0 else None,
-                            cr_cursor=checkruns["pageInfo"]["endCursor"])
-            last_commit = rc["data"]["repository"]["pullRequest"]["commits"]["nodes"][-1]["commit"]
+        def get_pr_next_check_runs(
+            edges: List[Dict[str, Dict[str, Any]]], edge_idx: int, checkruns: Any
+        ) -> Any:
+            rc = gh_graphql(
+                GH_GET_PR_NEXT_CHECK_RUNS,
+                name=self.project,
+                owner=self.org,
+                number=self.pr_num,
+                cs_cursor=edges[edge_idx - 1]["cursor"] if edge_idx > 0 else None,
+                cr_cursor=checkruns["pageInfo"]["endCursor"],
+            )
+            last_commit = rc["data"]["repository"]["pullRequest"]["commits"]["nodes"][
+                -1
+            ]["commit"]
             checkruns = last_commit["checkSuites"]["nodes"][-1]["checkRuns"]
             return checkruns
 
         def get_pr_next_checksuites(checksuites: Any) -> Any:
-            rc = gh_graphql(GH_GET_PR_NEXT_CHECKSUITES,
-                            name=self.project,
-                            owner=self.org,
-                            number=self.pr_num,
-                            cursor=checksuites["edges"][-1]["cursor"])
+            rc = gh_graphql(
+                GH_GET_PR_NEXT_CHECKSUITES,
+                name=self.project,
+                owner=self.org,
+                number=self.pr_num,
+                cursor=checksuites["edges"][-1]["cursor"],
+            )
             info = rc["data"]["repository"]["pullRequest"]
             last_commit = info["commits"]["nodes"][-1]["commit"]
             if last_commit["oid"] != orig_last_commit["oid"]:
@@ -810,13 +862,17 @@ class GitHubPR:
 
         checksuites = orig_last_commit["checkSuites"]
 
-        self.conclusions = add_workflow_conclusions(checksuites, get_pr_next_check_runs, get_pr_next_checksuites)
+        self.conclusions = add_workflow_conclusions(
+            checksuites, get_pr_next_check_runs, get_pr_next_checksuites
+        )
 
         # Append old style statuses(like ones populated by CircleCI or EasyCLA) to conclusions
         if orig_last_commit["status"] and orig_last_commit["status"]["contexts"]:
             for status in orig_last_commit["status"]["contexts"]:
                 name = status["context"]
-                self.conclusions[name] = JobCheckState(name, status["targetUrl"], status["state"], None)
+                self.conclusions[name] = JobCheckState(
+                    name, status["targetUrl"], status["state"], None
+                )
 
         return self.conclusions
 
@@ -859,13 +915,14 @@ class GitHubPR:
     @staticmethod
     def _comment_from_node(node: Any) -> GitHubComment:
         editor = node["editor"]
-        return GitHubComment(body_text=node["bodyText"],
-                             created_at=node["createdAt"] if "createdAt" in node else "",
-                             author_login=node["author"]["login"],
-                             author_association=node["authorAssociation"],
-                             editor_login=editor["login"] if editor else None,
-                             database_id=node["databaseId"]
-                             )
+        return GitHubComment(
+            body_text=node["bodyText"],
+            created_at=node["createdAt"] if "createdAt" in node else "",
+            author_login=node["author"]["login"],
+            author_association=node["authorAssociation"],
+            editor_login=editor["login"] if editor else None,
+            database_id=node["databaseId"],
+        )
 
     def get_comments(self) -> List[GitHubComment]:
         if self.comments is not None:
@@ -874,14 +931,18 @@ class GitHubPR:
         info = self.info["comments"]
         # Do not try to fetch more than 10K comments
         for _ in range(100):
-            self.comments = [self._comment_from_node(node) for node in info["nodes"]] + self.comments
+            self.comments = [
+                self._comment_from_node(node) for node in info["nodes"]
+            ] + self.comments
             if not info["pageInfo"]["hasPreviousPage"]:
                 break
-            rc = gh_graphql(GH_GET_PR_PREV_COMMENTS,
-                            name=self.project,
-                            owner=self.org,
-                            number=self.pr_num,
-                            cursor=info["pageInfo"]["startCursor"])
+            rc = gh_graphql(
+                GH_GET_PR_PREV_COMMENTS,
+                name=self.project,
+                owner=self.org,
+                number=self.pr_num,
+                cursor=info["pageInfo"]["startCursor"],
+            )
             info = rc["data"]["repository"]["pullRequest"]["comments"]
         return self.comments
 
@@ -937,11 +998,13 @@ class GitHubPR:
         return [x for x, _ in ghstack_prs]
 
     def gen_commit_message(self, filter_ghstack: bool = False) -> str:
-        """ Fetches title and body from PR description
-            adds reviewed by, pull request resolved and optionally
-            filters out ghstack info """
+        """Fetches title and body from PR description
+        adds reviewed by, pull request resolved and optionally
+        filters out ghstack info"""
         # Adding the url here makes it clickable within the Github UI
-        approved_by_urls = ', '.join(prefix_with_github_url(login) for login in self.get_approved_by())
+        approved_by_urls = ", ".join(
+            prefix_with_github_url(login) for login in self.get_approved_by()
+        )
         # Remove "cc: " line from the message body
         msg_body = re.sub(RE_PR_CC_LINE, "", self.get_body())
         if filter_ghstack:
@@ -960,11 +1023,15 @@ class GitHubPR:
                 label = f"{label_base}X{i+2}"
         gh_add_labels(self.org, self.project, self.pr_num, [label])
 
-    def merge_into(self, repo: GitRepo, *,
-                   skip_mandatory_checks: bool = False,
-                   dry_run: bool = False,
-                   comment_id: Optional[int] = None,
-                   ignore_current_checks: Optional[List[str]] = None) -> None:
+    def merge_into(
+        self,
+        repo: GitRepo,
+        *,
+        skip_mandatory_checks: bool = False,
+        dry_run: bool = False,
+        comment_id: Optional[int] = None,
+        ignore_current_checks: Optional[List[str]] = None,
+    ) -> None:
         # Raises exception if matching rule is not found
         find_matching_merge_rule(
             self,
@@ -973,7 +1040,9 @@ class GitHubPR:
             skip_internal_checks=can_skip_internal_checks(self, comment_id),
             ignore_current_checks=ignore_current_checks,
         )
-        additional_merged_prs = self.merge_changes(repo, skip_mandatory_checks, comment_id)
+        additional_merged_prs = self.merge_changes(
+            repo, skip_mandatory_checks, comment_id
+        )
 
         repo.push(self.default_branch(), dry_run)
         if not dry_run:
@@ -981,11 +1050,13 @@ class GitHubPR:
             for pr in additional_merged_prs:
                 pr.add_numbered_label("merged")
 
-    def merge_changes(self,
-                      repo: GitRepo,
-                      skip_mandatory_checks: bool = False,
-                      comment_id: Optional[int] = None,
-                      branch: Optional[str] = None) -> List["GitHubPR"]:
+    def merge_changes(
+        self,
+        repo: GitRepo,
+        skip_mandatory_checks: bool = False,
+        comment_id: Optional[int] = None,
+        branch: Optional[str] = None,
+    ) -> List["GitHubPR"]:
         branch_to_merge_into = self.default_branch() if branch is None else branch
         if repo.current_branch() != branch_to_merge_into:
             repo.checkout(branch_to_merge_into)
@@ -994,7 +1065,7 @@ class GitHubPR:
             pr_branch_name = f"__pull-request-{self.pr_num}__init__"
             self.fetch(pr_branch_name)
             repo._run_git("merge", "--squash", pr_branch_name)
-            repo._run_git("commit", f"--author=\"{self.get_author()}\"", "-m", msg)
+            repo._run_git("commit", f'--author="{self.get_author()}"', "-m", msg)
             return []
         else:
             return self.merge_ghstack_into(
@@ -1003,13 +1074,16 @@ class GitHubPR:
                 comment_id=comment_id,
             )
 
+
 class MergeRuleFailedError(RuntimeError):
-    def __init__(self, message: str, rule: Optional['MergeRule'] = None) -> None:
+    def __init__(self, message: str, rule: Optional["MergeRule"] = None) -> None:
         super().__init__(message)
         self.rule = rule
 
+
 class MandatoryChecksMissingError(MergeRuleFailedError):
     pass
+
 
 class PostCommentError(Exception):
     pass
@@ -1023,19 +1097,21 @@ class MergeRule:
     mandatory_checks_name: Optional[List[str]]
     ignore_flaky_failures: bool = True
 
+
 def gen_new_issue_link(
-    org: str,
-    project: str,
-    labels: List[str],
-    template: str = "bug-report.yml"
+    org: str, project: str, labels: List[str], template: str = "bug-report.yml"
 ) -> str:
-    labels_str = ",". join(labels)
-    return (f"https://github.com/{org}/{project}/issues/new?"
-            f"labels={urllib.parse.quote(labels_str)}&"
-            f"template={urllib.parse.quote(template)}")
+    labels_str = ",".join(labels)
+    return (
+        f"https://github.com/{org}/{project}/issues/new?"
+        f"labels={urllib.parse.quote(labels_str)}&"
+        f"template={urllib.parse.quote(template)}"
+    )
 
 
-def read_merge_rules(repo: Optional[GitRepo], org: str, project: str) -> List[MergeRule]:
+def read_merge_rules(
+    repo: Optional[GitRepo], org: str, project: str
+) -> List[MergeRule]:
     """Returns the list of all merge rules for the repo or project.
 
     NB: this function is used in Meta-internal workflows, see the comment
@@ -1045,7 +1121,7 @@ def read_merge_rules(repo: Optional[GitRepo], org: str, project: str) -> List[Me
     if repo is None:
         json_data = gh_fetch_url(
             f"https://api.github.com/repos/{org}/{project}/contents/{repo_relative_rules_path}",
-            headers={'Accept': 'application/vnd.github.v3+json'},
+            headers={"Accept": "application/vnd.github.v3+json"},
             reader=json.load,
         )
         content = base64.b64decode(json_data["content"])
@@ -1105,10 +1181,10 @@ def find_matching_merge_rule(
         )
     checks = get_classifications(
         checks,
-        pr.last_commit()['oid'],
+        pr.last_commit()["oid"],
         base_rev,
         flaky_rules,
-        ignore_current_checks=ignore_current_checks
+        ignore_current_checks=ignore_current_checks,
     )
 
     # PRs can fail multiple merge rules, but it only needs to pass one rule to be approved.
@@ -1137,11 +1213,13 @@ def find_matching_merge_rule(
             num_matching_files = len(changed_files) - len(non_matching_files)
             if num_matching_files > reject_reason_score:
                 reject_reason_score = num_matching_files
-                reject_reason = "\n".join((
-                    f"Not all files match rule `{rule_name}`."
-                    f"{num_matching_files} files matched, but there are still non-matching files:"
-                    f"{','.join(non_matching_files[:5])}{', ...' if len(non_matching_files) > 5 else ''}"
-                ))
+                reject_reason = "\n".join(
+                    (
+                        f"Not all files match rule `{rule_name}`."
+                        f"{num_matching_files} files matched, but there are still non-matching files:"
+                        f"{','.join(non_matching_files[:5])}{', ...' if len(non_matching_files) > 5 else ''}"
+                    )
+                )
             continue
 
         # If rule needs approvers but PR has not been reviewed, skip it
@@ -1164,45 +1242,59 @@ def find_matching_merge_rule(
         if len(approvers_intersection) == 0 and len(rule_approvers_set) > 0:
             if reject_reason_score < 10000:
                 reject_reason_score = 10000
-                reject_reason = "\n".join((
-                    "Approval needed from one of the following:",
-                    f"{', '.join(list(rule_approvers_set)[:5])}{', ...' if len(rule_approvers_set) > 5 else ''}"
-                ))
+                reject_reason = "\n".join(
+                    (
+                        "Approval needed from one of the following:",
+                        f"{', '.join(list(rule_approvers_set)[:5])}{', ...' if len(rule_approvers_set) > 5 else ''}",
+                    )
+                )
             continue
 
         # Does the PR pass the checks required by this rule?
-        mandatory_checks = rule.mandatory_checks_name if rule.mandatory_checks_name is not None else []
-        required_checks = list(filter(lambda x: "EasyCLA" in x or not skip_mandatory_checks, mandatory_checks))
+        mandatory_checks = (
+            rule.mandatory_checks_name if rule.mandatory_checks_name is not None else []
+        )
+        required_checks = list(
+            filter(
+                lambda x: "EasyCLA" in x or not skip_mandatory_checks, mandatory_checks
+            )
+        )
         [pending_checks, failed_checks] = categorize_checks(
             checks,
             required_checks,
-            ok_failed_checks_threshold=3 if rule.ignore_flaky_failures else 0
+            ok_failed_checks_threshold=3 if rule.ignore_flaky_failures else 0,
         )
 
         hud_link = f"https://hud.pytorch.org/{pr.org}/{pr.project}/commit/{pr.last_commit()['oid']}"
         if len(failed_checks) > 0:
             if reject_reason_score < 30000:
                 reject_reason_score = 30000
-                reject_reason = "\n".join((
-                    f"{len(failed_checks)} mandatory check(s) failed.  The first few are:",
-                    *checks_to_markdown_bullets(failed_checks),
-                    "",
-                    f"Dig deeper by [viewing the failures on hud]({hud_link})"
-                ))
+                reject_reason = "\n".join(
+                    (
+                        f"{len(failed_checks)} mandatory check(s) failed.  The first few are:",
+                        *checks_to_markdown_bullets(failed_checks),
+                        "",
+                        f"Dig deeper by [viewing the failures on hud]({hud_link})",
+                    )
+                )
             continue
         elif len(pending_checks) > 0:
             if reject_reason_score < 20000:
                 reject_reason_score = 20000
-                reject_reason = "\n".join((
-                    f"{len(pending_checks)} mandatory check(s) are pending/not yet run.  The first few are:",
-                    *checks_to_markdown_bullets(pending_checks),
-                    "",
-                    f"Dig deeper by [viewing the pending checks on hud]({hud_link})"
-                ))
+                reject_reason = "\n".join(
+                    (
+                        f"{len(pending_checks)} mandatory check(s) are pending/not yet run.  The first few are:",
+                        *checks_to_markdown_bullets(pending_checks),
+                        "",
+                        f"Dig deeper by [viewing the pending checks on hud]({hud_link})",
+                    )
+                )
             continue
 
         if not skip_internal_checks and pr.has_internal_changes():
-            raise RuntimeError("This PR has internal changes and must be landed via Phabricator")
+            raise RuntimeError(
+                "This PR has internal changes and must be landed via Phabricator"
+            )
 
         return rule
 
@@ -1216,7 +1308,9 @@ def checks_to_str(checks: List[Tuple[str, Optional[str]]]) -> str:
 
 
 def checks_to_markdown_bullets(checks: List[Tuple[str, Optional[str]]]) -> List[str]:
-    return [f"- [{c[0]}]({c[1]})" if c[1] is not None else f"- {c[0]}" for c in checks[:5]]
+    return [
+        f"- [{c[0]}]({c[1]})" if c[1] is not None else f"- {c[0]}" for c in checks[:5]
+    ]
 
 
 def _get_flaky_rules(url: str, num_retries: int = 3) -> List[FlakyRule]:
@@ -1229,7 +1323,9 @@ def _get_flaky_rules(url: str, num_retries: int = 3) -> List[FlakyRule]:
         return []
 
 
-def get_rockset_results(head_sha: str, merge_base: str, num_retries: int = 3) -> List[Dict[str, Any]]:
+def get_rockset_results(
+    head_sha: str, merge_base: str, num_retries: int = 3
+) -> List[Dict[str, Any]]:
     query = f"""
 SELECT
     w.name as workflow_name,
@@ -1248,6 +1344,7 @@ where
 """
     try:
         import rockset  # type: ignore[import]
+
         res = rockset.RocksetClient(
             host="api.usw2a1.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
         ).sql(query)
@@ -1258,7 +1355,9 @@ where
     except Exception as e:
         print(f"Could not download rockset data because: {e}.")
         if num_retries > 0:
-            return get_rockset_results(head_sha, merge_base, num_retries=num_retries - 1)
+            return get_rockset_results(
+                head_sha, merge_base, num_retries=num_retries - 1
+            )
         return []
 
 
@@ -1273,6 +1372,7 @@ def get_classifications(
     merge_base_jobs: Dict[str, Dict[str, Any]] = {}
 
     if merge_base is not None:
+
         def insert(d: Dict[str, Dict[str, Any]], key: str, val: Dict[str, Any]) -> None:
             if key not in d:
                 d[key] = val
@@ -1293,7 +1393,9 @@ def get_classifications(
         if check.status == "SUCCESS":
             continue
         if ignore_current_checks is not None and name in ignore_current_checks:
-            checks_with_classifications[name] = JobCheckState(check.name, check.url, check.status, "IGNORE_CURRENT_CHECK")
+            checks_with_classifications[name] = JobCheckState(
+                check.name, check.url, check.status, "IGNORE_CURRENT_CHECK"
+            )
             continue
         head_sha_job = head_sha_jobs.get(name)
         merge_base_job = merge_base_jobs.get(name)
@@ -1303,21 +1405,30 @@ def get_classifications(
             and head_sha_job["conclusion"] == merge_base_job["conclusion"]
             and head_sha_job["failure_captures"] == merge_base_job["failure_captures"]
         ):
-            checks_with_classifications[name] = JobCheckState(check.name, check.url, check.status, "BROKEN_TRUNK")
+            checks_with_classifications[name] = JobCheckState(
+                check.name, check.url, check.status, "BROKEN_TRUNK"
+            )
         elif any([rule.matches(head_sha_job) for rule in flaky_rules]):
-            checks_with_classifications[name] = JobCheckState(check.name, check.url, check.status, "FLAKY")
+            checks_with_classifications[name] = JobCheckState(
+                check.name, check.url, check.status, "FLAKY"
+            )
     return checks_with_classifications
 
 
 def filter_checks_with_lambda(
-    checks: JobNameToStateDict,
-    status_filter: Callable[[Optional[str]], bool]
+    checks: JobNameToStateDict, status_filter: Callable[[Optional[str]], bool]
 ) -> List[JobCheckState]:
     return [check for check in checks.values() if status_filter(check.status)]
 
-def validate_revert(repo: GitRepo, pr: GitHubPR, *,
-                    comment_id: Optional[int] = None) -> Tuple[str, str]:
-    comment = pr.get_last_comment() if comment_id is None else pr.get_comment_by_id(comment_id)
+
+def validate_revert(
+    repo: GitRepo, pr: GitHubPR, *, comment_id: Optional[int] = None
+) -> Tuple[str, str]:
+    comment = (
+        pr.get_last_comment()
+        if comment_id is None
+        else pr.get_comment_by_id(comment_id)
+    )
     if comment.editor_login is not None:
         raise PostCommentError("Don't want to revert based on edited command")
     author_association = comment.author_association
@@ -1327,14 +1438,18 @@ def validate_revert(repo: GitRepo, pr: GitHubPR, *,
     if pr.is_base_repo_private():
         allowed_reverters.append("CONTRIBUTOR")
     if author_association not in allowed_reverters:
-        raise PostCommentError((
-            f"Will not revert as @{author_login} is not one of "
-            f"[{', '.join(allowed_reverters)}], but instead is {author_association}."
-        ))
+        raise PostCommentError(
+            (
+                f"Will not revert as @{author_login} is not one of "
+                f"[{', '.join(allowed_reverters)}], but instead is {author_association}."
+            )
+        )
     skip_internal_checks = can_skip_internal_checks(pr, comment_id)
 
     # Raises exception if matching rule is not found, but ignores all status checks
-    find_matching_merge_rule(pr, repo, skip_mandatory_checks=True, skip_internal_checks=skip_internal_checks)
+    find_matching_merge_rule(
+        pr, repo, skip_mandatory_checks=True, skip_internal_checks=skip_internal_checks
+    )
     commit_sha = pr.get_merge_commit()
     if commit_sha is None:
         commits = repo.commits_resolving_gh_pr(pr.pr_num)
@@ -1345,18 +1460,23 @@ def validate_revert(repo: GitRepo, pr: GitHubPR, *,
     rc = RE_DIFF_REV.search(msg)
     if rc is not None and not skip_internal_checks:
         raise PostCommentError(
-            f"Can't revert PR that was landed via phabricator as {rc.group(1)}.  " +
-            "Please revert by going to the internal diff and clicking Unland."
+            f"Can't revert PR that was landed via phabricator as {rc.group(1)}.  "
+            + "Please revert by going to the internal diff and clicking Unland."
         )
     return (author_login, commit_sha)
 
 
-def try_revert(repo: GitRepo, pr: GitHubPR, *,
-               dry_run: bool = False,
-               comment_id: Optional[int] = None,
-               reason: Optional[str] = None) -> None:
+def try_revert(
+    repo: GitRepo,
+    pr: GitHubPR,
+    *,
+    dry_run: bool = False,
+    comment_id: Optional[int] = None,
+    reason: Optional[str] = None,
+) -> None:
     def post_comment(msg: str) -> None:
         gh_post_pr_comment(pr.org, pr.project, pr.pr_num, msg, dry_run=dry_run)
+
     try:
         author_login, commit_sha = validate_revert(repo, pr, comment_id=comment_id)
     except PostCommentError as e:
@@ -1370,7 +1490,9 @@ def try_revert(repo: GitRepo, pr: GitHubPR, *,
     msg += revert_msg
     repo.amend_commit_message(msg)
     repo.push(pr.default_branch(), dry_run)
-    post_comment(f"@{pr.get_pr_creator_login()} your PR has been successfully reverted.")
+    post_comment(
+        f"@{pr.get_pr_creator_login()} your PR has been successfully reverted."
+    )
     if not dry_run:
         pr.add_numbered_label("reverted")
         gh_post_commit_comment(pr.org, pr.project, commit_sha, revert_msg)
@@ -1378,6 +1500,7 @@ def try_revert(repo: GitRepo, pr: GitHubPR, *,
 
 def prefix_with_github_url(suffix_str: str) -> str:
     return f"https://github.com/{suffix_str}"
+
 
 def check_for_sev(org: str, project: str, skip_mandatory_checks: bool) -> None:
     if skip_mandatory_checks:
@@ -1403,16 +1526,19 @@ def check_for_sev(org: str, project: str, skip_mandatory_checks: bool) -> None:
 def has_label(labels: List[str], pattern: Pattern[str] = CIFLOW_LABEL) -> bool:
     return len(list(filter(pattern.match, labels))) > 0
 
+
 def categorize_checks(
     check_runs: JobNameToStateDict,
     required_checks: List[str],
-    ok_failed_checks_threshold: int = 3
+    ok_failed_checks_threshold: int = 3,
 ) -> Tuple[List[Tuple[str, Optional[str]]], List[Tuple[str, Optional[str]]]]:
     pending_checks: List[Tuple[str, Optional[str]]] = []
     failed_checks: List[Tuple[str, Optional[str]]] = []
     ok_failed_checks: List[Tuple[str, Optional[str]]] = []
 
-    relevant_checknames = [name for name in check_runs.keys() if any([x in name for x in required_checks])]
+    relevant_checknames = [
+        name for name in check_runs.keys() if any([x in name for x in required_checks])
+    ]
 
     for checkname in required_checks:
         if all([checkname not in x for x in check_runs.keys()]):
@@ -1423,18 +1549,20 @@ def categorize_checks(
         elif not is_passing_status(check_runs[checkname].status):
             if check_runs[checkname].classification == "IGNORE_CURRENT_CHECK":
                 pass
-            elif check_runs[checkname].classification in ('BROKEN_TRUNK', 'FLAKY'):
+            elif check_runs[checkname].classification in ("BROKEN_TRUNK", "FLAKY"):
                 ok_failed_checks.append((checkname, check_runs[checkname].url))
             else:
                 failed_checks.append((checkname, check_runs[checkname].url))
 
     if ok_failed_checks:
         print(
-            f"The following {len(ok_failed_checks)} checks failed but were likely due flakiness or broken trunk: " +
-            ", ".join([x[0] for x in ok_failed_checks]) +
-            (f" but this is greater than the threshold of {ok_failed_checks_threshold} so merge will fail"
-             if len(ok_failed_checks) > ok_failed_checks_threshold
-             else '')
+            f"The following {len(ok_failed_checks)} checks failed but were likely due flakiness or broken trunk: "
+            + ", ".join([x[0] for x in ok_failed_checks])
+            + (
+                f" but this is greater than the threshold of {ok_failed_checks_threshold} so merge will fail"
+                if len(ok_failed_checks) > ok_failed_checks_threshold
+                else ""
+            )
         )
 
     if len(ok_failed_checks) > ok_failed_checks_threshold:
@@ -1442,20 +1570,26 @@ def categorize_checks(
 
     return (pending_checks, failed_checks)
 
-def merge(pr_num: int, repo: GitRepo,
-          dry_run: bool = False,
-          skip_mandatory_checks: bool = False,
-          comment_id: Optional[int] = None,
-          timeout_minutes: int = 400,
-          stale_pr_days: int = 3,
-          ignore_current: bool = False) -> None:
+
+def merge(
+    pr_num: int,
+    repo: GitRepo,
+    dry_run: bool = False,
+    skip_mandatory_checks: bool = False,
+    comment_id: Optional[int] = None,
+    timeout_minutes: int = 400,
+    stale_pr_days: int = 3,
+    ignore_current: bool = False,
+) -> None:
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
     org, project = repo.gh_owner_and_name()
     pr = GitHubPR(org, project, pr_num)
-    initial_commit_sha = pr.last_commit()['oid']
+    initial_commit_sha = pr.last_commit()["oid"]
     print(f"Attempting merge of {initial_commit_sha}")
 
-    explainer = TryMergeExplainer(skip_mandatory_checks, pr.get_labels(), pr.pr_num, org, project, ignore_current)
+    explainer = TryMergeExplainer(
+        skip_mandatory_checks, pr.get_labels(), pr.pr_num, org, project, ignore_current
+    )
 
     # probably a bad name, but this is a list of current checks that should be
     # ignored and is toggled by the --ignore-current flag
@@ -1468,12 +1602,14 @@ def merge(pr_num: int, repo: GitRepo,
 
     if skip_mandatory_checks or can_skip_internal_checks(pr, comment_id):
         # do not wait for any pending signals if PR is closed as part of co-development process
-        gh_post_pr_comment(org, project, pr.pr_num, explainer.get_merge_message(), dry_run=dry_run)
+        gh_post_pr_comment(
+            org, project, pr.pr_num, explainer.get_merge_message(), dry_run=dry_run
+        )
         return pr.merge_into(
             repo,
             dry_run=dry_run,
             skip_mandatory_checks=skip_mandatory_checks,
-            comment_id=comment_id
+            comment_id=comment_id,
         )
 
     # Check for approvals
@@ -1488,42 +1624,56 @@ def merge(pr_num: int, repo: GitRepo,
         ignore_current_checks_info = failing
         if len(pending) == 0:
             raise RuntimeError(
-                "The --ignore-current flag was used but there are no pending checks on this PR.  Please use " +
-                "-f/--force instead."
+                "The --ignore-current flag was used but there are no pending checks on this PR.  Please use "
+                + "-f/--force instead."
             )
 
     gh_post_pr_comment(
-        org, project, pr.pr_num,
+        org,
+        project,
+        pr.pr_num,
         explainer.get_merge_message(ignore_current_checks_info),
-        dry_run=dry_run
+        dry_run=dry_run,
     )
 
     if pr.last_pushed_at() is None:
-        print(f"Can't get commit {pr.last_commit()['oid']} pushed date. Is it merge commit by chance?")
+        print(
+            f"Can't get commit {pr.last_commit()['oid']} pushed date. Is it merge commit by chance?"
+        )
     elif (datetime.utcnow() - cast(datetime, pr.last_pushed_at())).days > stale_pr_days:
-        raise RuntimeError(f"This PR is too stale; the last push date was more than {stale_pr_days} days ago. "
-                           "Please rebase and try again. You can rebase by leaving the following comment on this PR:\n"
-                           "`@pytorchbot rebase`")
+        raise RuntimeError(
+            f"This PR is too stale; the last push date was more than {stale_pr_days} days ago. "
+            "Please rebase and try again. You can rebase by leaving the following comment on this PR:\n"
+            "`@pytorchbot rebase`"
+        )
 
     start_time = time.time()
-    last_exception = ''
+    last_exception = ""
     elapsed_time = 0.0
     flaky_rules = read_flaky_rules()
-    ignore_current_checks = [x[0] for x in ignore_current_checks_info]  # convert to List[str] for convenience
+    ignore_current_checks = [
+        x[0] for x in ignore_current_checks_info
+    ]  # convert to List[str] for convenience
     while elapsed_time < timeout_minutes * 60:
         check_for_sev(org, project, skip_mandatory_checks)
         current_time = time.time()
         elapsed_time = current_time - start_time
-        print(f"Attempting merge of https://github.com/{org}/{project}/pull/{pr_num} ({elapsed_time / 60} minutes elapsed)")
+        print(
+            f"Attempting merge of https://github.com/{org}/{project}/pull/{pr_num} ({elapsed_time / 60} minutes elapsed)"
+        )
         pr = GitHubPR(org, project, pr_num)
-        if initial_commit_sha != pr.last_commit()['oid']:
-            raise RuntimeError("New commits were pushed while merging. Please rerun the merge command.")
+        if initial_commit_sha != pr.last_commit()["oid"]:
+            raise RuntimeError(
+                "New commits were pushed while merging. Please rerun the merge command."
+            )
         try:
             required_checks = []
             failed_rule_message = None
             ignore_flaky_failures = True
             try:
-                find_matching_merge_rule(pr, repo, ignore_current_checks=ignore_current_checks)
+                find_matching_merge_rule(
+                    pr, repo, ignore_current_checks=ignore_current_checks
+                )
             except MandatoryChecksMissingError as ex:
                 if ex.rule is not None:
                     ignore_flaky_failures = ex.rule.ignore_flaky_failures
@@ -1534,32 +1684,41 @@ def merge(pr_num: int, repo: GitRepo,
             checks = pr.get_checkrun_conclusions()
             checks = get_classifications(
                 checks,
-                pr.last_commit()['oid'],
+                pr.last_commit()["oid"],
                 pr.get_merge_base(),
                 flaky_rules,
-                ignore_current_checks=ignore_current_checks
+                ignore_current_checks=ignore_current_checks,
             )
             pending, failing = categorize_checks(
                 checks,
-                required_checks + [x for x in checks.keys() if x not in required_checks],
-                ok_failed_checks_threshold=3 if ignore_flaky_failures else 0
+                required_checks
+                + [x for x in checks.keys() if x not in required_checks],
+                ok_failed_checks_threshold=3 if ignore_flaky_failures else 0,
             )
             # HACK until GitHub will be better about surfacing those
-            startup_failures = filter_checks_with_lambda(checks, lambda status: status == "STARTUP_FAILURE")
+            startup_failures = filter_checks_with_lambda(
+                checks, lambda status: status == "STARTUP_FAILURE"
+            )
             if len(startup_failures) > 0:
-                raise RuntimeError(f"{len(startup_failures)} STARTUP failures reported, please check workflows syntax! " +
-                                   ', '.join(f"[{x.name}]({x.url})" for x in startup_failures[:5]))
+                raise RuntimeError(
+                    f"{len(startup_failures)} STARTUP failures reported, please check workflows syntax! "
+                    + ", ".join(f"[{x.name}]({x.url})" for x in startup_failures[:5])
+                )
             # END of HACK
 
             if len(failing) > 0:
-                raise RuntimeError(f"{len(failing)} jobs have failed, first few of them are: " +
-                                   ', '.join(f"[{x[0]}]({x[1]})" for x in failing[:5]))
+                raise RuntimeError(
+                    f"{len(failing)} jobs have failed, first few of them are: "
+                    + ", ".join(f"[{x[0]}]({x[1]})" for x in failing[:5])
+                )
             if len(pending) > 0:
                 if failed_rule_message is not None:
                     raise failed_rule_message
                 else:
-                    raise MandatoryChecksMissingError(f"Still waiting for {len(pending)} jobs to finish, " +
-                                                      f"first few of them are: {', '.join(x[0] for x in pending[:5])}")
+                    raise MandatoryChecksMissingError(
+                        f"Still waiting for {len(pending)} jobs to finish, "
+                        + f"first few of them are: {', '.join(x[0] for x in pending[:5])}"
+                    )
 
             return pr.merge_into(
                 repo,
@@ -1570,7 +1729,9 @@ def merge(pr_num: int, repo: GitRepo,
             )
         except MandatoryChecksMissingError as ex:
             last_exception = str(ex)
-            print(f"Merge of https://github.com/{org}/{project}/pull/{pr_num} failed due to: {ex}. Retrying in 5 min")
+            print(
+                f"Merge of https://github.com/{org}/{project}/pull/{pr_num} failed due to: {ex}. Retrying in 5 min"
+            )
             time.sleep(5 * 60)
     # Finally report timeout back
     msg = f"Merged timed out after {timeout_minutes} minutes. Please contact the pytorch_dev_infra team."
@@ -1578,6 +1739,7 @@ def merge(pr_num: int, repo: GitRepo,
     if not dry_run:
         gh_add_labels(org, project, pr_num, ["land-failed"])
     raise RuntimeError(msg)
+
 
 def main() -> None:
     args = parse_args()
@@ -1589,59 +1751,88 @@ def main() -> None:
         exception = f"**Reason**: {e}"
 
         failing_rule = None
-        if (isinstance(e, MergeRuleFailedError)):
+        if isinstance(e, MergeRuleFailedError):
             failing_rule = e.rule.name if e.rule else None
 
         internal_debugging = ""
         run_url = os.getenv("GH_RUN_URL")
         if run_url is not None:
             # Hide this behind a collapsed bullet since it's not helpful to most devs
-            internal_debugging = "\n".join(line for line in (
-                "<details><summary>Details for Dev Infra team</summary>",
-                f"Raised by <a href=\"{run_url}\">workflow job</a>\n",
-                f"Failing merge rule: {failing_rule}" if failing_rule else "",
-                "</details>"
-            ) if line)  # ignore empty lines during the join
+            internal_debugging = "\n".join(
+                line
+                for line in (
+                    "<details><summary>Details for Dev Infra team</summary>",
+                    f'Raised by <a href="{run_url}">workflow job</a>\n',
+                    f"Failing merge rule: {failing_rule}" if failing_rule else "",
+                    "</details>",
+                )
+                if line
+            )  # ignore empty lines during the join
 
-        msg = "\n".join((
-            f"## {title}",
-            f"{exception}",
-            "",
-            f"{internal_debugging}"
-        ))
+        msg = "\n".join((f"## {title}", f"{exception}", "", f"{internal_debugging}"))
 
         gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
         import traceback
+
         traceback.print_exc()
 
     if args.revert:
         try:
-            gh_post_pr_comment(org, project, args.pr_num, get_revert_message(org, project, pr.pr_num), args.dry_run)
-            try_revert(repo, pr, dry_run=args.dry_run, comment_id=args.comment_id, reason=args.reason)
+            gh_post_pr_comment(
+                org,
+                project,
+                args.pr_num,
+                get_revert_message(org, project, pr.pr_num),
+                args.dry_run,
+            )
+            try_revert(
+                repo,
+                pr,
+                dry_run=args.dry_run,
+                comment_id=args.comment_id,
+                reason=args.reason,
+            )
         except Exception as e:
             handle_exception(e, f"Reverting PR {args.pr_num} failed")
         return
 
     if pr.is_closed():
-        gh_post_pr_comment(org, project, args.pr_num, f"Can't merge closed PR #{args.pr_num}", dry_run=args.dry_run)
+        gh_post_pr_comment(
+            org,
+            project,
+            args.pr_num,
+            f"Can't merge closed PR #{args.pr_num}",
+            dry_run=args.dry_run,
+        )
         return
 
     if pr.is_cross_repo() and pr.is_ghstack_pr():
-        gh_post_pr_comment(org, project, args.pr_num, "Cross-repo ghstack merges are not supported", dry_run=args.dry_run)
+        gh_post_pr_comment(
+            org,
+            project,
+            args.pr_num,
+            "Cross-repo ghstack merges are not supported",
+            dry_run=args.dry_run,
+        )
         return
 
     if not args.force and pr.has_invalid_submodule_updates():
-        message = f"This PR updates submodules {', '.join(pr.get_changed_submodules())}\n"
-        message += "\nIf those updates are intentional, please add \"submodule\" keyword to PR title/description."
+        message = (
+            f"This PR updates submodules {', '.join(pr.get_changed_submodules())}\n"
+        )
+        message += '\nIf those updates are intentional, please add "submodule" keyword to PR title/description.'
         gh_post_pr_comment(org, project, args.pr_num, message, dry_run=args.dry_run)
         return
 
     try:
-        merge(args.pr_num, repo,
-              dry_run=args.dry_run,
-              skip_mandatory_checks=args.force,
-              comment_id=args.comment_id,
-              ignore_current=args.ignore_current)
+        merge(
+            args.pr_num,
+            repo,
+            dry_run=args.dry_run,
+            skip_mandatory_checks=args.force,
+            comment_id=args.comment_id,
+            ignore_current=args.ignore_current,
+        )
     except Exception as e:
         handle_exception(e)
 

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import List, Pattern, Optional, Tuple
+from typing import List, Optional, Pattern, Tuple
 
 
 BOT_COMMANDS_WIKI = "https://github.com/pytorch/pytorch/wiki/Bot-commands"
@@ -10,9 +10,7 @@ CIFLOW_TRUNK_LABEL = re.compile(r"^ciflow/trunk")
 
 OFFICE_HOURS_LINK = "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours"
 CONTACT_US = f"Questions? Feedback? Please reach out to the [PyTorch DevX Team]({OFFICE_HOURS_LINK})"
-ALTERNATIVES = (
-    f"Learn more about merging in the [wiki]({BOT_COMMANDS_WIKI})."
-)
+ALTERNATIVES = f"Learn more about merging in the [wiki]({BOT_COMMANDS_WIKI})."
 
 
 def has_label(labels: List[str], pattern: Pattern[str] = CIFLOW_LABEL) -> bool:
@@ -46,31 +44,35 @@ class TryMergeExplainer(object):
         self.project = project
         self.ignore_current = ignore_current
 
-    def _get_flag_msg(self, ignore_current_checks: Optional[List[Tuple[str, Optional[str]]]] = None) -> str:
+    def _get_flag_msg(
+        self, ignore_current_checks: Optional[List[Tuple[str, Optional[str]]]] = None
+    ) -> str:
         if self.force:
-            return "Your change will be merged immediately since you used the force (-f) flag, " + \
-                "**bypassing any CI checks** (ETA: 1-5 minutes)."
+            return (
+                "Your change will be merged immediately since you used the force (-f) flag, "
+                + "**bypassing any CI checks** (ETA: 1-5 minutes)."
+            )
         elif self.ignore_current and ignore_current_checks is not None:
             msg = f"Your change will be merged while ignoring the following {len(ignore_current_checks)} checks: "
-            msg += ', '.join(f"[{x[0]}]({x[1]})" for x in ignore_current_checks)
+            msg += ", ".join(f"[{x[0]}]({x[1]})" for x in ignore_current_checks)
             return msg
         else:
             return "Your change will be merged once all checks pass (ETA 0-4 Hours)."
 
-
     def get_merge_message(
-        self,
-        ignore_current_checks: Optional[List[Tuple[str, Optional[str]]]] = None
+        self, ignore_current_checks: Optional[List[Tuple[str, Optional[str]]]] = None
     ) -> str:
         title = "### Merge started"
         main_message = self._get_flag_msg(ignore_current_checks)
 
-        advanced_debugging = "\n".join((
-            "<details><summary>Advanced Debugging</summary>",
-            "Check the merge workflow status ",
-            f"<a href=\"{os.getenv('GH_RUN_URL')}\">here</a>",
-            "</details>"
-        ))
+        advanced_debugging = "\n".join(
+            (
+                "<details><summary>Advanced Debugging</summary>",
+                "Check the merge workflow status ",
+                f"<a href=\"{os.getenv('GH_RUN_URL')}\">here</a>",
+                "</details>",
+            )
+        )
 
         msg = title + "\n"
         msg += main_message + "\n\n"

--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -1,9 +1,10 @@
 import json
 import os
 import subprocess
-import requests
-from typing import Any, Dict
 from argparse import ArgumentParser
+from typing import Any, Dict
+
+import requests
 
 MERGEBOT_TOKEN = os.environ["MERGEBOT_TOKEN"]
 PYTORCHBOT_TOKEN = os.environ["PYTORCHBOT_TOKEN"]

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -826,7 +826,7 @@ init_command = [
 [[linter]]
 code = 'UFMT'
 include_patterns = [
-    '.github/scripts/**/.*.py',
+    '.github/**/*.py',
     'test/run_test.py',
     'test/onnx/**/*.py',
     'test/test_dynamo_cudagraphs.py',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -826,6 +826,8 @@ init_command = [
 [[linter]]
 code = 'UFMT'
 include_patterns = [
+    '.github/scripts/**/.*.py',
+    'test/run_test.py',
     'test/onnx/**/*.py',
     'test/test_dynamo_cudagraphs.py',
     'tools/**/*.py',

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -2,9 +2,9 @@
 
 import argparse
 import copy
-from datetime import datetime
-from distutils.version import LooseVersion
 import functools
+import glob
+import json
 import os
 import pathlib
 import shutil
@@ -12,23 +12,23 @@ import signal
 import subprocess
 import sys
 import tempfile
-import json
-import glob
-from typing import Dict, Optional, List, cast, Any
+from datetime import datetime
+from distutils.version import LooseVersion
+from typing import Any, cast, Dict, List, Optional
 
 import torch
-from torch.utils import cpp_extension
-from torch.testing._internal.common_utils import (
-    IS_CI,
-    FILE_SCHEMA,
-    TEST_WITH_ROCM,
-    shell,
-    set_cwd,
-    parser as common_parser,
-    is_slow_gradcheck_env,
-)
 import torch.distributed as dist
 from torch.multiprocessing import current_process, get_context
+from torch.testing._internal.common_utils import (
+    FILE_SCHEMA,
+    IS_CI,
+    is_slow_gradcheck_env,
+    parser as common_parser,
+    set_cwd,
+    shell,
+    TEST_WITH_ROCM,
+)
+from torch.utils import cpp_extension
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -37,11 +37,12 @@ try:
     sys.path.append(str(REPO_ROOT))
     from tools.stats.export_test_times import TEST_TIMES_FILE
     from tools.testing.test_selections import (
+        calculate_shards,
         get_reordered_tests,
         get_test_case_configs,
-        calculate_shards,
-        NUM_PROCS
+        NUM_PROCS,
     )
+
     HAVE_TEST_SELECTION_TOOLS = True
 except ImportError:
     HAVE_TEST_SELECTION_TOOLS = False
@@ -65,9 +66,9 @@ def maybe_set_hip_visible_devies():
     # Special handling of ROCm GHA runners for parallel (file granularity) tests.
     if torch.version.hip:
         p = current_process()
-        if p.name != 'MainProcess':
+        if p.name != "MainProcess":
             # this is a Process from a parallel Pool, not the MainProcess
-            os.environ['HIP_VISIBLE_DEVICES'] = str(p._identity[0] % NUM_PROCS)
+            os.environ["HIP_VISIBLE_DEVICES"] = str(p._identity[0] % NUM_PROCS)
 
 
 def strtobool(s):
@@ -77,13 +78,15 @@ def strtobool(s):
 
 
 def discover_tests(
-        base_dir: Optional[pathlib.Path] = None,
-        blocklisted_patterns: Optional[List[str]] = None,
-        blocklisted_tests: Optional[List[str]] = None,
-        extra_tests: Optional[List[str]] = None) -> List[str]:
+    base_dir: Optional[pathlib.Path] = None,
+    blocklisted_patterns: Optional[List[str]] = None,
+    blocklisted_tests: Optional[List[str]] = None,
+    extra_tests: Optional[List[str]] = None,
+) -> List[str]:
     """
     Searches for all python files starting with test_ excluding one specified by patterns
     """
+
     def skip_test_p(name: str) -> bool:
         rc = False
         if blocklisted_patterns is not None:
@@ -91,13 +94,16 @@ def discover_tests(
         if blocklisted_tests is not None:
             rc |= name in blocklisted_tests
         return rc
+
     cwd = pathlib.Path(__file__).resolve().parent if base_dir is None else base_dir
     # This supports symlinks, so we can link domain library tests to PyTorch test directory
-    all_py_files = [pathlib.Path(p) for p in glob.glob(f"{cwd}/**/test_*.py", recursive=True)]
+    all_py_files = [
+        pathlib.Path(p) for p in glob.glob(f"{cwd}/**/test_*.py", recursive=True)
+    ]
     rc = [str(fname.relative_to(cwd))[:-3] for fname in all_py_files]
     # Invert slashes on Windows
     if sys.platform == "win32":
-        rc = [name.replace('\\', '/') for name in rc]
+        rc = [name.replace("\\", "/") for name in rc]
     rc = [test for test in rc if not skip_test_p(test)]
     if extra_tests is not None:
         rc += extra_tests
@@ -106,31 +112,31 @@ def discover_tests(
 
 TESTS = discover_tests(
     blocklisted_patterns=[
-        'ao',
-        'bottleneck_test',
-        'custom_backend',
-        'custom_operator',
-        'fx',        # executed by test_fx.py
-        'jit',      # executed by test_jit.py
-        'mobile',
-        'onnx',
-        'package',  # executed by test_package.py
-        'quantization',  # executed by test_quantization.py
-        'autograd',  # executed by test_autograd.py
+        "ao",
+        "bottleneck_test",
+        "custom_backend",
+        "custom_operator",
+        "fx",  # executed by test_fx.py
+        "jit",  # executed by test_jit.py
+        "mobile",
+        "onnx",
+        "package",  # executed by test_package.py
+        "quantization",  # executed by test_quantization.py
+        "autograd",  # executed by test_autograd.py
     ],
     blocklisted_tests=[
-        'test_bundled_images',
-        'test_cpp_extensions_aot',
-        'test_determination',
-        'test_jit_fuser',
-        'test_jit_simple',
-        'test_jit_string',
-        'test_kernel_launch_checks',
-        'test_nnapi',
-        'test_segment_reductions',
-        'test_static_runtime',
-        'test_throughput_benchmark',
-        'test_typing',
+        "test_bundled_images",
+        "test_cpp_extensions_aot",
+        "test_determination",
+        "test_jit_fuser",
+        "test_jit_simple",
+        "test_jit_string",
+        "test_kernel_launch_checks",
+        "test_nnapi",
+        "test_segment_reductions",
+        "test_static_runtime",
+        "test_throughput_benchmark",
+        "test_typing",
         "distributed/bin/test_script",
         "distributed/elastic/multiprocessing/bin/test_script",
         "distributed/launcher/bin/test_script",
@@ -138,8 +144,8 @@ TESTS = discover_tests(
         "distributed/launcher/bin/test_script_is_torchelastic_launched",
         "distributed/launcher/bin/test_script_local_rank",
         "distributed/test_c10d_spawn",
-        'distributions/test_transforms',
-        'distributions/test_utils',
+        "distributions/test_transforms",
+        "distributions/test_utils",
     ],
     extra_tests=[
         "test_cpp_extensions_aot_ninja",
@@ -153,12 +159,12 @@ TESTS = discover_tests(
         "distributed/elastic/utils/util_test",
         "distributed/elastic/utils/distributed_test",
         "distributed/elastic/multiprocessing/api_test",
-    ]
+    ],
 )
 
 # The doctests are a special case that don't correspond to a file that discover
 # tests can enable.
-TESTS = TESTS + ['doctests']
+TESTS = TESTS + ["doctests"]
 
 FSDP_TEST = [test for test in TESTS if test.startswith("distributed/fsdp")]
 
@@ -243,34 +249,34 @@ RUN_PARALLEL_BLOCKLIST = [
 ] + FSDP_TEST
 
 CI_SERIAL_LIST = [
-    'test_nn',
-    'test_fake_tensor',
-    'test_cpp_api_parity',
-    'test_reductions',
-    'test_cuda',
-    'test_jit_cuda_fuser',  # OOM on test_issue_1785, also profiling?
-    'test_indexing',
-    'test_fx_backends',
-    'test_linalg',
-    'test_cpp_extensions_jit',
-    'test_torch',
-    'test_tensor_creation_ops',
-    'test_sparse_csr',
-    'test_dispatch',
-    'test_spectral_ops',    # Cause CUDA illegal memory access https://github.com/pytorch/pytorch/issues/88916
-    'nn/test_pooling',
-    'nn/test_convolution',  # Doesn't respect set_per_process_memory_fraction, results in OOM for other tests in slow gradcheck
-    'distributions/test_distributions',
-    'test_autograd',  # slow gradcheck runs a test that checks the cuda memory allocator
-    'test_prims',  # slow gradcheck runs a test that checks the cuda memory allocator
-    'test_modules',  # failed test due to mismatched elements
-    'functorch/test_vmap',  # OOM
-    'test_fx',  # gets SIGKILL
-    'test_dataloader',  # frequently hangs for ROCm
-    'test_serialization',   # test_serialization_2gb_file allocates a tensor of 2GB, and could cause OOM
-    '_nvfuser/test_torchscript',  # OOM on test_issue_1785
-    'test_schema_check',  # Cause CUDA illegal memory access https://github.com/pytorch/pytorch/issues/95749
-    'functorch/test_memory_efficient_fusion',   # Cause CUDA OOM on ROCm
+    "test_nn",
+    "test_fake_tensor",
+    "test_cpp_api_parity",
+    "test_reductions",
+    "test_cuda",
+    "test_jit_cuda_fuser",  # OOM on test_issue_1785, also profiling?
+    "test_indexing",
+    "test_fx_backends",
+    "test_linalg",
+    "test_cpp_extensions_jit",
+    "test_torch",
+    "test_tensor_creation_ops",
+    "test_sparse_csr",
+    "test_dispatch",
+    "test_spectral_ops",  # Cause CUDA illegal memory access https://github.com/pytorch/pytorch/issues/88916
+    "nn/test_pooling",
+    "nn/test_convolution",  # Doesn't respect set_per_process_memory_fraction, results in OOM for other tests in slow gradcheck
+    "distributions/test_distributions",
+    "test_autograd",  # slow gradcheck runs a test that checks the cuda memory allocator
+    "test_prims",  # slow gradcheck runs a test that checks the cuda memory allocator
+    "test_modules",  # failed test due to mismatched elements
+    "functorch/test_vmap",  # OOM
+    "test_fx",  # gets SIGKILL
+    "test_dataloader",  # frequently hangs for ROCm
+    "test_serialization",  # test_serialization_2gb_file allocates a tensor of 2GB, and could cause OOM
+    "_nvfuser/test_torchscript",  # OOM on test_issue_1785
+    "test_schema_check",  # Cause CUDA illegal memory access https://github.com/pytorch/pytorch/issues/95749
+    "functorch/test_memory_efficient_fusion",  # Cause CUDA OOM on ROCm
 ]
 
 # A subset of our TEST list that validates PyTorch's ops, modules, and autograd function as expected
@@ -282,7 +288,7 @@ CORE_TEST_LIST = [
     "test_ops_gradients",
     "test_ops_fwd_gradients",
     "test_ops_jit",
-    "test_torch"
+    "test_torch",
 ]
 
 # A list of distributed tests that run on multiple backends, i.e. gloo, nccl. These backends are spread out
@@ -377,6 +383,7 @@ TESTS_NOT_USING_GRADCHECK = [
     "test_quantization",
 ]
 
+
 def print_to_stderr(message):
     print(message, file=sys.stderr)
 
@@ -421,8 +428,10 @@ def run_test(
         unittest_args.extend(ci_args)
     if test_module in PYTEST_SKIP_RETRIES:
         if not options.pytest:
-            raise RuntimeError("A test running without pytest cannot skip retries using "
-                               "the PYTEST_SKIP_RETRIES set.")
+            raise RuntimeError(
+                "A test running without pytest cannot skip retries using "
+                "the PYTEST_SKIP_RETRIES set."
+            )
         unittest_args = [arg for arg in unittest_args if "--reruns" not in arg]
 
     # Extra arguments are not supported with pytest
@@ -433,9 +442,11 @@ def run_test(
     argv = [test_module + ".py"] + unittest_args
 
     os.makedirs(REPO_ROOT / "test" / "test-reports", exist_ok=True)
-    log_fd, log_path = tempfile.mkstemp(dir=REPO_ROOT / "test" / "test-reports",
-                                        prefix="{}_".format(test_module.replace("\\", "-").replace("/", "-")),
-                                        suffix=".log")
+    log_fd, log_path = tempfile.mkstemp(
+        dir=REPO_ROOT / "test" / "test-reports",
+        prefix="{}_".format(test_module.replace("\\", "-").replace("/", "-")),
+        suffix=".log",
+    )
     os.close(log_fd)
     command = (launcher_cmd or []) + executable + argv
     print_to_stderr("Executing {} ... [{}]".format(command, datetime.now()))
@@ -452,11 +463,15 @@ def test_cuda_primary_ctx(test_module, test_directory, options):
     )
 
 
-run_test_with_subprocess = functools.partial(run_test, extra_unittest_args=["--subprocess"])
+run_test_with_subprocess = functools.partial(
+    run_test, extra_unittest_args=["--subprocess"]
+)
 
 
 def get_run_test_with_subprocess_fn():
-    return lambda test_module, test_directory, options: run_test_with_subprocess(test_module, test_directory, options)
+    return lambda test_module, test_directory, options: run_test_with_subprocess(
+        test_module, test_directory, options
+    )
 
 
 def _test_cpp_extensions_aot(test_directory, options, use_ninja):
@@ -493,7 +508,7 @@ def _test_cpp_extensions_aot(test_directory, options, use_ninja):
     python_path = os.environ.get("PYTHONPATH", "")
     from shutil import copyfile
 
-    os.environ['USE_NINJA'] = shell_env['USE_NINJA']
+    os.environ["USE_NINJA"] = shell_env["USE_NINJA"]
     test_module = "test_cpp_extensions_aot" + ("_ninja" if use_ninja else "_no_ninja")
     copyfile(
         test_directory + "/test_cpp_extensions_aot.py",
@@ -515,7 +530,7 @@ def _test_cpp_extensions_aot(test_directory, options, use_ninja):
         os.environ["PYTHONPATH"] = python_path
         if os.path.exists(test_directory + "/" + test_module + ".py"):
             os.remove(test_directory + "/" + test_module + ".py")
-        os.environ.pop('USE_NINJA')
+        os.environ.pop("USE_NINJA")
 
 
 def test_cpp_extensions_aot_ninja(test_module, test_directory, options):
@@ -539,9 +554,15 @@ def test_distributed(test_module, test_directory, options):
     else:
         which_shard = num_shards = 1
     # Round-robin all backends to different shards
-    backend_to_shard = {backend: i % num_shards + 1
-                        for i, backend in enumerate(DISTRIBUTED_TESTS_WITH_MULTIPLE_BACKENDS[test_module])}
-    print_to_stderr(f"Map different backends to different shards for {test_module}: {backend_to_shard}")
+    backend_to_shard = {
+        backend: i % num_shards + 1
+        for i, backend in enumerate(
+            DISTRIBUTED_TESTS_WITH_MULTIPLE_BACKENDS[test_module]
+        )
+    }
+    print_to_stderr(
+        f"Map different backends to different shards for {test_module}: {backend_to_shard}"
+    )
 
     config = DISTRIBUTED_TESTS_CONFIG
     for backend, env_vars in config.items():
@@ -551,7 +572,9 @@ def test_distributed(test_module, test_directory, options):
             continue
         # Default to the first shard if seeing an unrecognized backend
         if which_shard != backend_to_shard.get(backend, 1):
-            print_to_stderr(f"Shard {which_shard}: {backend} should be run in {backend_to_shard.get(backend, 1)}")
+            print_to_stderr(
+                f"Shard {which_shard}: {backend} should be run in {backend_to_shard.get(backend, 1)}"
+            )
             continue
         for with_init_file in {True, False}:
             if sys.platform == "win32" and not with_init_file:
@@ -611,7 +634,12 @@ def test_distributed(test_module, test_directory, options):
                         test_module, test_directory, options, launcher_cmd=mpiexec
                     )
                 else:
-                    return_code = run_test(test_module, test_directory, options, extra_unittest_args=["--subprocess"])
+                    return_code = run_test(
+                        test_module,
+                        test_directory,
+                        options,
+                        extra_unittest_args=["--subprocess"],
+                    )
                 if return_code != 0:
                     return return_code
             finally:
@@ -626,8 +654,10 @@ def run_doctests(test_module, test_directory, options):
     Assumes the incoming test module is called doctest, and simply executes the
     xdoctest runner on the torch library itself.
     """
-    import xdoctest
     import pathlib
+
+    import xdoctest
+
     pkgpath = pathlib.Path(torch.__file__).parent
 
     exclude_module_list = []
@@ -638,42 +668,47 @@ def run_doctests(test_module, test_directory, options):
         # 'cuda': 'auto',
         # 'cuda1': 'auto',
         # 'qengine': 'auto',
-        'lapack': 0,
-        'cuda': 0,
-        'cuda1': 0,
-        'qengine': 0,
-        'autograd_profiler': 0,
-        'cpp_ext': 0,
-        'monitor': 0,
+        "lapack": 0,
+        "cuda": 0,
+        "cuda1": 0,
+        "qengine": 0,
+        "autograd_profiler": 0,
+        "cpp_ext": 0,
+        "monitor": 0,
         "onnx": "auto",
     }
 
     # Resolve "auto" based on a test to determine if the feature is available.
-    if enabled['cuda'] == 'auto' and torch.cuda.is_available():
-        enabled['cuda'] = True
+    if enabled["cuda"] == "auto" and torch.cuda.is_available():
+        enabled["cuda"] = True
 
-    if enabled['cuda1'] == 'auto' and torch.cuda.is_available() and torch.cuda.device_count() > 1:
-        enabled['cuda1'] = True
+    if (
+        enabled["cuda1"] == "auto"
+        and torch.cuda.is_available()
+        and torch.cuda.device_count() > 1
+    ):
+        enabled["cuda1"] = True
 
-    if enabled['lapack'] == 'auto' and torch._C.has_lapack:
-        enabled['lapack'] = True
+    if enabled["lapack"] == "auto" and torch._C.has_lapack:
+        enabled["lapack"] = True
 
-    if enabled['qengine'] == 'auto':
+    if enabled["qengine"] == "auto":
         try:
             # Is there a better check if quantization is enabled?
             import torch.ao.nn.quantized as nnq  # NOQA
-            torch.backends.quantized.engine = 'qnnpack'
-            torch.backends.quantized.engine = 'fbgemm'
+
+            torch.backends.quantized.engine = "qnnpack"
+            torch.backends.quantized.engine = "fbgemm"
         except (ImportError, RuntimeError):
             ...
         else:
-            enabled['qengine'] = True
+            enabled["qengine"] = True
 
     if enabled["onnx"] == "auto":
         try:
             import onnx  # NOQA
-            import onnxscript  # NOQA
             import onnxruntime  # NOQA
+            import onnxscript  # NOQA
         except ImportError:
             exclude_module_list.append("torch.onnx._internal.fx.*")
             enabled["onnx"] = False
@@ -681,69 +716,79 @@ def run_doctests(test_module, test_directory, options):
             enabled["onnx"] = True
 
     # Set doctest environment variables
-    if enabled['cuda']:
-        os.environ['TORCH_DOCTEST_CUDA'] = '1'
+    if enabled["cuda"]:
+        os.environ["TORCH_DOCTEST_CUDA"] = "1"
 
-    if enabled['cuda1']:
-        os.environ['TORCH_DOCTEST_CUDA1'] = '1'
+    if enabled["cuda1"]:
+        os.environ["TORCH_DOCTEST_CUDA1"] = "1"
 
-    if enabled['lapack']:
-        os.environ['TORCH_DOCTEST_LAPACK'] = '1'
+    if enabled["lapack"]:
+        os.environ["TORCH_DOCTEST_LAPACK"] = "1"
 
-    if enabled['qengine']:
-        os.environ['TORCH_DOCTEST_QENGINE'] = '1'
+    if enabled["qengine"]:
+        os.environ["TORCH_DOCTEST_QENGINE"] = "1"
 
-    if enabled['autograd_profiler']:
-        os.environ['TORCH_DOCTEST_AUTOGRAD_PROFILER'] = '1'
+    if enabled["autograd_profiler"]:
+        os.environ["TORCH_DOCTEST_AUTOGRAD_PROFILER"] = "1"
 
-    if enabled['cpp_ext']:
-        os.environ['TORCH_DOCTEST_CPP_EXT'] = '1'
+    if enabled["cpp_ext"]:
+        os.environ["TORCH_DOCTEST_CPP_EXT"] = "1"
 
-    if enabled['monitor']:
-        os.environ['TORCH_DOCTEST_MONITOR'] = '1'
+    if enabled["monitor"]:
+        os.environ["TORCH_DOCTEST_MONITOR"] = "1"
 
     if enabled["onnx"]:
-        os.environ['TORCH_DOCTEST_ONNX'] = '1'
+        os.environ["TORCH_DOCTEST_ONNX"] = "1"
 
     if 0:
         # TODO: could try to enable some of these
-        os.environ['TORCH_DOCTEST_QUANTIZED_DYNAMIC'] = '1'
-        os.environ['TORCH_DOCTEST_ANOMOLY'] = '1'
-        os.environ['TORCH_DOCTEST_AUTOGRAD'] = '1'
-        os.environ['TORCH_DOCTEST_HUB'] = '1'
-        os.environ['TORCH_DOCTEST_DATALOADER'] = '1'
-        os.environ['TORCH_DOCTEST_FUTURES'] = '1'
+        os.environ["TORCH_DOCTEST_QUANTIZED_DYNAMIC"] = "1"
+        os.environ["TORCH_DOCTEST_ANOMOLY"] = "1"
+        os.environ["TORCH_DOCTEST_AUTOGRAD"] = "1"
+        os.environ["TORCH_DOCTEST_HUB"] = "1"
+        os.environ["TORCH_DOCTEST_DATALOADER"] = "1"
+        os.environ["TORCH_DOCTEST_FUTURES"] = "1"
 
     pkgpath = os.path.dirname(torch.__file__)
 
     xdoctest_config = {
-        'global_exec': r'\n'.join([
-            'from torch import nn',
-            'import torch.nn.functional as F',
-            'import torch',
-        ]),
-        'analysis': 'static',  # set to "auto" to test doctests in compiled modules
-        'style': 'google',
-        'options': '+IGNORE_WHITESPACE',
+        "global_exec": r"\n".join(
+            [
+                "from torch import nn",
+                "import torch.nn.functional as F",
+                "import torch",
+            ]
+        ),
+        "analysis": "static",  # set to "auto" to test doctests in compiled modules
+        "style": "google",
+        "options": "+IGNORE_WHITESPACE",
     }
     xdoctest_verbose = max(1, options.verbose)
     run_summary = xdoctest.runner.doctest_module(
-        os.fspath(pkgpath), config=xdoctest_config, verbose=xdoctest_verbose,
-        command=options.xdoctest_command, argv=[],
-        exclude=exclude_module_list)
-    result = 1 if run_summary.get('n_failed', 0) else 0
+        os.fspath(pkgpath),
+        config=xdoctest_config,
+        verbose=xdoctest_verbose,
+        command=options.xdoctest_command,
+        argv=[],
+        exclude=exclude_module_list,
+    )
+    result = 1 if run_summary.get("n_failed", 0) else 0
     return result
 
 
 def print_log_file(test: str, file_path: str, failed: bool) -> None:
-    num_lines = sum(1 for _ in open(file_path, 'rb'))
+    num_lines = sum(1 for _ in open(file_path, "rb"))
     n = 100
     with open(file_path, "r") as f:
         print_to_stderr("")
         if failed:
             if n < num_lines:
-                print_to_stderr(f"Expand the folded group to see the beginning of the log file of {test}")
-                print_to_stderr(f"##[group]PRINTING BEGINNING OF LOG FILE of {test} ({file_path})")
+                print_to_stderr(
+                    f"Expand the folded group to see the beginning of the log file of {test}"
+                )
+                print_to_stderr(
+                    f"##[group]PRINTING BEGINNING OF LOG FILE of {test} ({file_path})"
+                )
                 for _ in range(num_lines - n):
                     print_to_stderr(next(f).rstrip())
                 print_to_stderr("##[endgroup]")
@@ -776,10 +821,12 @@ def get_pytest_args(options):
         "--use-pytest",
         "-vv",
         "-rfEX",
-        "-p", "no:xdist",
+        "-p",
+        "no:xdist",
     ]
     pytest_args.extend(rerun_options)
     return pytest_args
+
 
 def run_test_ops(test_module, test_directory, options):
     default_unittest_args = get_pytest_args(options)
@@ -789,11 +836,13 @@ def run_test_ops(test_module, test_directory, options):
     pool = get_context("spawn").Pool(NUM_PROCS)
     for i in range(NUM_PROCS):
         extra_unittest_args = default_unittest_args.copy()
-        extra_unittest_args.extend([
-            f"--shard-id={i}",
-            f"--num-shards={NUM_PROCS}",
-            "-k=not _linalg_cholesky_",
-        ])
+        extra_unittest_args.extend(
+            [
+                f"--shard-id={i}",
+                f"--num-shards={NUM_PROCS}",
+                "-k=not _linalg_cholesky_",
+            ]
+        )
 
         return_code = pool.apply_async(
             run_test,
@@ -813,9 +862,11 @@ def run_test_ops(test_module, test_directory, options):
             return return_code.get()
 
     extra_unittest_args = default_unittest_args.copy()
-    extra_unittest_args.extend([
-        "-k=_linalg_cholesky_",
-    ])
+    extra_unittest_args.extend(
+        [
+            "-k=_linalg_cholesky_",
+        ]
+    )
 
     return_code = run_test(
         test_module,
@@ -859,9 +910,7 @@ CUSTOM_HANDLERS = {
 }
 
 
-PYTEST_SKIP_RETRIES = {
-    'test_public_bindings'
-}
+PYTEST_SKIP_RETRIES = {"test_public_bindings"}
 
 
 def parse_test_module(test):
@@ -881,7 +930,7 @@ def parse_args():
         description="Run the PyTorch unit test suite",
         epilog="where TESTS is any of: {}".format(", ".join(TESTS)),
         formatter_class=argparse.RawTextHelpFormatter,
-        parents=[common_parser]
+        parents=[common_parser],
     )
     parser.add_argument(
         "-v",
@@ -905,22 +954,20 @@ def parse_args():
             "If this flag is present, we will only run functorch tests. "
             "If this flag is not present, we will run all tests "
             "(including functorch tests)."
-        )
+        ),
     )
     parser.add_argument(
         "--mps",
         "--mps",
         action="store_true",
-        help=(
-            "If this flag is present, we will only run test_mps and test_metal"
-        )
+        help=("If this flag is present, we will only run test_mps and test_metal"),
     )
     parser.add_argument(
         "-core",
         "--core",
         action="store_true",
         help="Only run core tests, or tests that validate PyTorch's ops, modules,"
-        "and autograd. They are defined by CORE_TEST_LIST."
+        "and autograd. They are defined by CORE_TEST_LIST.",
     )
     parser.add_argument(
         "-pt",
@@ -1028,12 +1075,13 @@ def parse_args():
     )
     parser.add_argument(
         "--xdoctest-command",
-        default='all',
+        default="all",
         help=(
             "Control the specific doctest action. "
             "Use 'list' to simply parse doctests and check syntax. "
             "Use 'all' to execute all doctests or specify a specific "
-            "doctest to run")
+            "doctest to run"
+        ),
     )
 
     group = parser.add_mutually_exclusive_group()
@@ -1088,11 +1136,15 @@ def find_test_index(test, selected_tests, find_last_index=False):
     return found_idx
 
 
-def exclude_tests(exclude_list, selected_tests, exclude_message=None, exact_match=False):
+def exclude_tests(
+    exclude_list, selected_tests, exclude_message=None, exact_match=False
+):
     for exclude_test in exclude_list:
         tests_copy = selected_tests[:]
         for test in tests_copy:
-            if (not exact_match and test.startswith(exclude_test)) or test == exclude_test:
+            if (
+                not exact_match and test.startswith(exclude_test)
+            ) or test == exclude_test:
                 if exclude_message is not None:
                     print_to_stderr("Excluding {} {}".format(test, exclude_message))
                 selected_tests.remove(test)
@@ -1101,19 +1153,19 @@ def exclude_tests(exclude_list, selected_tests, exclude_message=None, exact_matc
 
 def must_serial(file: str) -> bool:
     return (
-        os.getenv("PYTORCH_TEST_RUN_EVERYTHING_IN_SERIAL", "0") == "1" or
-        "distributed" in os.getenv("TEST_CONFIG", "") or
-        "dynamo" in os.getenv("TEST_CONFIG", "") or
-        "distributed" in file or
-        file in CUSTOM_HANDLERS or
-        file in RUN_PARALLEL_BLOCKLIST or
-        file in CI_SERIAL_LIST or
-        file in JIT_EXECUTOR_TESTS
+        os.getenv("PYTORCH_TEST_RUN_EVERYTHING_IN_SERIAL", "0") == "1"
+        or "distributed" in os.getenv("TEST_CONFIG", "")
+        or "dynamo" in os.getenv("TEST_CONFIG", "")
+        or "distributed" in file
+        or file in CUSTOM_HANDLERS
+        or file in RUN_PARALLEL_BLOCKLIST
+        or file in CI_SERIAL_LIST
+        or file in JIT_EXECUTOR_TESTS
     )
 
 
 def can_run_in_pytest(test):
-    return os.getenv('PYTORCH_TEST_DO_NOT_USE_PYTEST', '0') == '0'
+    return os.getenv("PYTORCH_TEST_DO_NOT_USE_PYTEST", "0") == "0"
 
 
 def get_selected_tests(options):
@@ -1127,9 +1179,13 @@ def get_selected_tests(options):
 
     if options.distributed_tests:
         selected_tests = list(
-            filter(lambda test_name: (test_name in DISTRIBUTED_TESTS and
-                                      test_name not in DISTRIBUTED_TESTS_WITH_MULTIPLE_BACKENDS),
-                   selected_tests)
+            filter(
+                lambda test_name: (
+                    test_name in DISTRIBUTED_TESTS
+                    and test_name not in DISTRIBUTED_TESTS_WITH_MULTIPLE_BACKENDS
+                ),
+                selected_tests,
+            )
         )
 
     # Filter to only run core tests when --core option is specified
@@ -1143,10 +1199,10 @@ def get_selected_tests(options):
         selected_tests = [tname for tname in selected_tests if tname in FUNCTORCH_TESTS]
 
     if options.mps:
-        selected_tests = ['test_mps', 'test_metal']
+        selected_tests = ["test_mps", "test_metal"]
     else:
         # Exclude all mps tests otherwise
-        options.exclude.extend(['test_mps', 'test_metal'])
+        options.exclude.extend(["test_mps", "test_metal"])
 
     # process reordering
     if options.bring_to_front:
@@ -1221,25 +1277,39 @@ def get_selected_tests(options):
         else:
             print("Found test time stats from artifacts")
             test_file_times_config = test_file_times[test_config]
-            shards = calculate_shards(num_shards, selected_tests, test_file_times_config,
-                                      must_serial=must_serial)
+            shards = calculate_shards(
+                num_shards,
+                selected_tests,
+                test_file_times_config,
+                must_serial=must_serial,
+            )
             _, tests_from_shard = shards[which_shard - 1]
             selected_tests = tests_from_shard
 
     # skip all distributed tests if distributed package is not available.
     if not dist.is_available():
-        selected_tests = exclude_tests(DISTRIBUTED_TESTS, selected_tests,
-                                       "PyTorch is built without distributed support.")
+        selected_tests = exclude_tests(
+            DISTRIBUTED_TESTS,
+            selected_tests,
+            "PyTorch is built without distributed support.",
+        )
 
     # skip tests that require LAPACK when it's not available
     if not torch._C.has_lapack:
-        selected_tests = exclude_tests(TESTS_REQUIRING_LAPACK, selected_tests,
-                                       "PyTorch is built without LAPACK support.")
+        selected_tests = exclude_tests(
+            TESTS_REQUIRING_LAPACK,
+            selected_tests,
+            "PyTorch is built without LAPACK support.",
+        )
 
     if is_slow_gradcheck_env():
-        selected_tests = exclude_tests(TESTS_NOT_USING_GRADCHECK, selected_tests,
-                                       "Running in slow gradcheck mode, skipping tests "
-                                       "that don't use gradcheck.", exact_match=True)
+        selected_tests = exclude_tests(
+            TESTS_NOT_USING_GRADCHECK,
+            selected_tests,
+            "Running in slow gradcheck mode, skipping tests "
+            "that don't use gradcheck.",
+            exact_match=True,
+        )
 
     if options.distributed_tests:
         # Run distributed tests with multiple backends across all shards, one per backend
@@ -1303,12 +1373,24 @@ def main():
     # parallel = in parallel with other files
     # serial = this file on it's own.  The file might still be run in parallel with itself (ex test_ops)
     selected_tests_parallel = [x for x in selected_tests if not must_serial(x)]
-    selected_tests_serial = [x for x in selected_tests if x not in selected_tests_parallel]
-    print_to_stderr("parallel (file granularity) tests:\n {}".format("\n ".join(selected_tests_parallel)))
-    print_to_stderr("serial (file granularity) tests:\n {}".format("\n ".join(selected_tests_serial)))
+    selected_tests_serial = [
+        x for x in selected_tests if x not in selected_tests_parallel
+    ]
+    print_to_stderr(
+        "parallel (file granularity) tests:\n {}".format(
+            "\n ".join(selected_tests_parallel)
+        )
+    )
+    print_to_stderr(
+        "serial (file granularity) tests:\n {}".format(
+            "\n ".join(selected_tests_serial)
+        )
+    )
 
     # See Note [ROCm parallel CI testing]
-    pool = get_context("spawn").Pool(NUM_PROCS, maxtasksperchild=None if torch.version.hip else 1)
+    pool = get_context("spawn").Pool(
+        NUM_PROCS, maxtasksperchild=None if torch.version.hip else 1
+    )
     os.makedirs(REPO_ROOT / "test" / "test-reports", exist_ok=True)
 
     def success_callback(err_message):
@@ -1321,20 +1403,24 @@ def main():
         return False
 
     try:
-        os.environ['PARALLEL_TESTING'] = '1'
+        os.environ["PARALLEL_TESTING"] = "1"
         for test in selected_tests_parallel:
             options_clone = copy.deepcopy(options)
             if can_run_in_pytest(test):
                 options_clone.pytest = True
-            pool.apply_async(run_test_module, args=(test, test_directory, options_clone), callback=success_callback)
+            pool.apply_async(
+                run_test_module,
+                args=(test, test_directory, options_clone),
+                callback=success_callback,
+            )
         pool.close()
         pool.join()
-        del os.environ['PARALLEL_TESTING']
+        del os.environ["PARALLEL_TESTING"]
 
         if not options.continue_through_error and len(failure_messages) != 0:
             raise RuntimeError(
-                "\n".join(failure_messages) +
-                "\n\nTip: You can keep running tests even on failure by "
+                "\n".join(failure_messages)
+                + "\n\nTip: You can keep running tests even on failure by "
                 "passing --keep-going to run_test.py.\n"
                 "If running on CI, add the 'keep-going' label to "
                 "your PR and rerun your jobs."


### PR DESCRIPTION
This has been bugging me for a while as I'm working on these Python scripts and they are not tracked by ufmt linter.  So I add these script into that linter.

```
[[linter]]
code = 'UFMT'
include_patterns = [
    '.github/**/*.py',
    'test/run_test.py',
```

This change should just work and not break anything as ufmt (black + usort) linter is very safe to use for standalone util scripts.