### PR TITLE
[inductor] Fix broadcast of random seed in mm epilogue

### DIFF
--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -196,6 +196,22 @@ class TestSelectAlgorithm(TestCase):
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
 
     @patches
+    def test_mm_dropout(self):
+        @torch.compile
+        def fn(x1, x2, seed):
+            mm_4 = torch.ops.aten.mm.default(x2, x1)
+            rnd = torch.ops.prims.philox_rand_like.default(mm_4, seed, 0)
+            return mm_4 * rnd
+
+        # sizes picked so triton autotuning wins
+        fn(
+            torch.randn(512, 1024, dtype=torch.float16, device="cuda"),
+            torch.randn(384, 512, dtype=torch.float16, device="cuda"),
+            torch.tensor(12345, device="cuda"),
+        )
+        self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
+
+    @patches
     @torch._inductor.config.patch(conv_1x1_as_mm=False)
     def test_convolution2(self):
         @torch.compile

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -619,6 +619,8 @@ class GraphLowering(torch.fx.Interpreter):
         from .codecache import PyCodeCache
 
         code, linemap = self.codegen()
+        if config.debug:
+            print(code)
 
         mod = PyCodeCache.load(code, linemap=linemap)
         for name, value in self.constants.items():

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -619,8 +619,6 @@ class GraphLowering(torch.fx.Interpreter):
         from .codecache import PyCodeCache
 
         code, linemap = self.codegen()
-        if config.debug:
-            print(code)
 
         mod = PyCodeCache.load(code, linemap=linemap)
         for name, value in self.constants.items():

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -269,10 +269,9 @@ class TritonTemplateKernel(TritonKernel):
         result, *mask = super().indexing(
             index,
             dense_indexing=False,
-            copy_shape=copy_shape,
+            copy_shape=self.template_mask,
             override_mask=self.template_mask,
         )
-        result += f" + tl.zeros({self.template_mask}.shape, tl.int32)"
         return (result, *mask)
 
     def initialize_range_tree(self, pid_cache):


### PR DESCRIPTION
Fixes #96468, #97553

In matmul codegen epilogue we use `mask` shape to infer the broadcasted shape in case we need to broadcast a scalar value.  

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire