### PR TITLE
Fix typos under torch/_inductor directory

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -453,7 +453,7 @@ def pick_vec_isa():
     if not _valid_vec_isa_list:
         return invalid_vec_isa
 
-    # If the simdlen is None, it indicates determin the vectroization length automatically
+    # If the simdlen is None, it indicates determin the vectorization length automatically
     if config.cpp.simdlen is None:
         assert _valid_vec_isa_list
         return _valid_vec_isa_list[0]

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2020,11 +2020,11 @@ class CppKernelProxy(CppKernel):
 
             def eliminate_to_dtype(sub_graph: torch.fx.Graph):
                 def _eliminate_duplicate_to_node(sub_graph: torch.fx.Graph):
-                    # Eliminate the redudant to_dtype node. Let's consider a pattern as follows:
+                    # Eliminate the redundant to_dtype node. Let's consider a pattern as follows:
                     #   graph():
                     #     %to_dtype1 = call_method[target=to_dtype](args = (%ops, %input, torch.float), kwargs = {})
                     #     %to_dtype2 = call_method[target=to_dtype](args = (%ops, %to_dtype1, torch.float), kwargs = {})
-                    # Regarding the first to_dtype, it is redudant because the second to_type also converts to the
+                    # Regarding the first to_dtype, it is redundant because the second to_type also converts to the
                     # torch.float. Hence, we remove the first to_type
                     def _used_by_to(to_node: torch.fx.Node):
                         return all(usr.target == "to_dtype" for usr in to_node.users)
@@ -2083,7 +2083,7 @@ class CppKernelProxy(CppKernel):
             with kernel_group.new_kernel(cls, *args) as kernel:
                 run(kernel)
 
-                # Ugly hack to maitain the metrics kernel count since
+                # Ugly hack to maintain the metrics kernel count since
                 # we only count in CppKernelProxy, not those contained in it
                 metrics.generated_kernel_count -= 1
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -825,7 +825,7 @@ def flatten_graph_inputs(gm: torch.fx.GraphModule, inputs, compile_gm):
 
 def handle_dynamo_export_graph(gm, inputs, compile_gm):
     """
-    `torch._dynamo.export` embeds pytrees in the FX graph codgen object,
+    `torch._dynamo.export` embeds pytrees in the FX graph codegen object,
     convert that to a normal FX graph so inductor can compile it.
     """
     codegen = gm.graph._codegen

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -61,7 +61,7 @@ search_autotune_cache = os.environ.get("TORCHINDUCTOR_SEARCH_AUTOTUNE_CACHE") ==
 autotune_in_subproc = os.environ.get("TORCHINDUCTOR_AUTOTUNE_IN_SUBPROC") == "1"
 
 # control store vs recompute heuristic
-# For fanouts, rematearialization can lead to exponential blowup. So, have
+# For fanouts, rematerialization can lead to exponential blowup. So, have
 # smaller threshold
 realize_reads_threshold = 4
 realize_bytes_threshold = 2000

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -121,7 +121,7 @@ def clear_cublass_cache():
     A tensor in the cublas workspace would continue to be in use the workspace but would also get allocated
     in the next run. The memory would be in use in two places.
 
-    To solve this, we clear cublass caches before and after warming up or recording. If a workspace is required
+    To solve this, we clear cublas caches before and after warming up or recording. If a workspace is required
     it will be allocated to the cudagraph private pool and accounted for in the allocator for the duration of the
     program. There is no overhead to this on replay since cudagraphs removes allocation overhead.
     """
@@ -130,7 +130,7 @@ def clear_cublass_cache():
 
 @contextlib.contextmanager
 def clear_cublas_manager():
-    "Context manager around clearing cublass caches that will clear on enter and exit"
+    "Context manager around clearing cublas caches that will clear on enter and exit"
     clear_cublass_cache()
     try:
         yield
@@ -1433,7 +1433,7 @@ class CUDAGraphTreeManager:
 
         # the most recently invoked cudagraph wrapping of a function. Will be None
         # when there is no output from a previous recording or execution whose memory
-        # we need to respect in the cuda caching allocaton. If you incremented generation,
+        # we need to respect in the cuda caching allocation. If you incremented generation,
         # this will also be none, as ignore those allocations.
         self.current_node: Optional[CUDAGraphNode] = None
 

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -209,7 +209,7 @@ class _RecordLoadStoreInner(V.MockHandler):
             return index, tuple([x for x in sizes if x != 1])
 
         # Try to further simplify the indexes even if simplify_loops didn't
-        # convert it to the simpliest form because of the interference from
+        # convert it to the simplest form because of the interference from
         # different indexing formulas.
         index_vars = list(self._var_ranges.keys())
         new_sizes, reindex, prune = V.graph.sizevars._simplify_loops(

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -2718,7 +2718,7 @@ class ExternKernel(InputsKernel):
 
     def canonicalize(self):
         """
-        Manually get cononicalization of the output index
+        Manually get canonicalization of the output index
         """
         # manually generate index formula for conv
         sizevars = V.graph.sizevars

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2575,7 +2575,7 @@ def reflection_pad2d_backward(grad_output, x, padding):
 
 @register_lowering(prims.rev.default)
 def rev(x, dims):
-    # note - dims pre-canoncalized
+    # note - dims pre-canonicalized
     x_loader = x.make_loader()
     sizes = x.get_size()
 

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -189,7 +189,7 @@ class KeywordArg(PatternExpr):
 
 class CallFunction(PatternExpr):
     """
-    Matches a call_function node in the FX graps: `fns[i](*args, **kwargs)`
+    Matches a call_function node in the FX graphs: `fns[i](*args, **kwargs)`
     """
 
     def __init__(self, fns, *args, _users=1, **kwargs):
@@ -787,7 +787,7 @@ def cat_addmm(match, inputs, dim):
 def cat_tuned_op(match, inputs, dim, *, op, shape_of):
     """
     Memory planning to remove cat.  We can't use the stock memory
-    planner since autotuning matmauls needs to know the output layout.
+    planner since autotuning matmuls needs to know the output layout.
     """
     if len(inputs) == 1:
         return op(*inputs[0])

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -734,7 +734,7 @@ def get_kernel_category(kernel_mod):
     - reduction
     - persistent_reduction
 
-    Currently we simply decide the cateory depending on what decorator is imported
+    Currently we simply decide the category depending on what decorator is imported
     by the kernel.
     """
     choices = [ch for ch in _kernel_category_choices if ch in kernel_mod.__dict__]


### PR DESCRIPTION
This PR fixes typos in comments and messages of `.py` files under `torch/_inductor` directory

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire