### PR TITLE
Fix typos under torch/nn directory

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4945,7 +4945,7 @@ Shape legend:
 
 Examples::
 
-    >>> # Optionally use the context manager to ensure one of the fused kerenels is run
+    >>> # Optionally use the context manager to ensure one of the fused kernels is run
     >>> query = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
     >>> key = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
     >>> value = torch.rand(32, 8, 128, 64, dtype=torch.float16, device="cuda")
@@ -5087,7 +5087,7 @@ def multi_head_attention_forward(
         need_weights: output attn_output_weights.
             Default: `True`
             Note: `needs_weight` defaults to `True`, but should be set to `False`
-            For best performance when attention weights are not nedeeded.
+            For best performance when attention weights are not needed.
             *Setting needs_weights to `True`
             leads to a significant performance degradation.*
         attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all

--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -165,7 +165,7 @@ class SyncBatchNorm(Function):
             # Although this process can directly set grad_input as an empty
             # tensor of zeros, it still needs to participate in the collective
             # communication to unblock its peers, as other peer processes might
-            # have recieved non-empty inputs.
+            # have received non-empty inputs.
             num_channels = saved_input.shape[1]
             if self.needs_input_grad[0]:
                 # launch all_reduce to unblock other peer processes

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1335,7 +1335,7 @@ class Module:
                           "is deprecated and will be removed in future versions. This hook will be missing "
                           "some grad_output. Please use register_full_backward_hook to get the documented behavior.")
         else:
-            # At this point the grad_ouput part of the hook will most likely be correct
+            # At this point the grad_output part of the hook will most likely be correct
             inputs_grad_fn = {i.grad_fn for i in inputs if i.grad_fn is not None}
 
             next_functions = {n[0] for n in grad_fn.next_functions}
@@ -1743,7 +1743,7 @@ class Module:
     def state_dict(self, *, prefix: str = ..., keep_vars: bool = ...) -> Dict[str, Any]:
         ...
 
-    # TODO: Change `*args` to `*` and remove the copprespinding warning in docs when BC allows.
+    # TODO: Change `*args` to `*` and remove the corresponding warning in docs when BC allows.
     # Also remove the logic for arg parsing together.
     def state_dict(self, *args, destination=None, prefix='', keep_vars=False):
         r"""Returns a dictionary containing references to the whole state of the module.

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -76,7 +76,7 @@ class _MixedPrecision:
     .. note:: If a ``reduce_dtype`` is not specified, then gradient reduction
         happens in ``param_dtype`` if specified or the original parameter dtype
         otherwise. For example, ``_MixedPrecision(param_dtype=torch.float16)``
-        would result in communication ocurring in fp16.
+        would result in communication occurring in fp16.
     """
 
     param_dtype: Optional[torch.dtype] = None
@@ -966,7 +966,7 @@ class DistributedDataParallel(Module, Joinable):
 
             # TODO (rohan-varma): this is a workaround that allows users to
             # disable the default behavior of DDP managed parameters with
-            # optimizer runing in backwards having their gradients all set to None.
+            # optimizer running in backwards having their gradients all set to None.
             # Currently, it is an "all or nothing behavior" where DDP will set
             # no grads to None or all of them, relaxing this behavior will be
             # done dependent on use cases.
@@ -1452,7 +1452,7 @@ class DistributedDataParallel(Module, Joinable):
                 work, self._divide_by_initial_world_size  # type: ignore[arg-type]
             )
 
-        # Calling _rebuild_buckets before forward compuation,
+        # Calling _rebuild_buckets before forward computation,
         # It may allocate new buckets before deallocating old buckets
         # inside _rebuild_buckets. To save peak memory usage,
         # call _rebuild_buckets before the peak memory usage increases
@@ -2193,9 +2193,9 @@ class DistributedDataParallel(Module, Joinable):
         r"""
         This interface can be called after DistributedDataParallel() is
         constructed. It returns a dictionary of logging data. It could help
-        for debugging and analysis. The loggind data includes DistributedDataParallel
+        for debugging and analysis. The logging data includes DistributedDataParallel
         constructor input parameters, some internal states of DistributedDataParallel
-        and performance metrics. Simply print the dictorinary and see what
+        and performance metrics. Simply print the dictionary and see what
         these metrics are.
         This is a prototype interface and subject to change in the future.
         """

--- a/torch/nn/utils/_deprecation_utils.py
+++ b/torch/nn/utils/_deprecation_utils.py
@@ -18,7 +18,7 @@ def lazy_deprecated_import(all: List[str], old_module: str, new_module: str) -> 
         new_module: New module location / Migrated location
 
     Returns:
-        Callable to asign to the `__getattr__`
+        Callable to assign to the `__getattr__`
 
     Usage:
 

--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -353,7 +353,7 @@ class _SpectralNorm(Module):
         #     Therefore, since the same power iteration is performed on all
         #     devices, simply updating the tensors in-place will make sure that
         #     the module replica on `device[0]` will update the _u vector on the
-        #     parallized module (by shared storage).
+        #     parallelized module (by shared storage).
         #
         #    However, after we update `u` and `v` in-place, we need to **clone**
         #    them before using them to normalize the weight. This is to support

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -115,7 +115,7 @@ class ParametrizationList(ModuleList):
         #    Y = param.right_inverse(X)
         #    assert isinstance(Y, Tensor) or
         #           (isinstance(Y, collections.abc.Sequence) and all(isinstance(t, Tensor) for t in Y))
-        #    Z = param(Y) if isisntance(Y, Tensor) else param(*Y)
+        #    Z = param(Y) if isinstance(Y, Tensor) else param(*Y)
         #    # Consistency checks
         #    assert X.dtype == Z.dtype and X.shape == Z.shape
         #    # If it has one input, this allows to be able to use set_ to be able to
@@ -725,7 +725,7 @@ def transfer_parametrizations_and_params(
         assert hasattr(parameters_to_transfer, "__iter__")  # for mypy
         for parameter_name in parameters_to_transfer:
 
-            # initialize the to-be-transfered param in to_module if it doesn't exist already
+            # initialize the to-be-transferred param in to_module if it doesn't exist already
             if not hasattr(to_module, parameter_name):
                 setattr(
                     to_module,

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -189,7 +189,7 @@ class BasePruningMethod(ABC):
         try:
             # get the final mask, computed according to the specific method
             mask = method.compute_mask(importance_scores, default_mask=default_mask)
-            # reparametrize by saving mask to `module[name + '_mask']`...
+            # reparameterize by saving mask to `module[name + '_mask']`...
             module.register_buffer(name + "_mask", mask)
             # ... and the new pruned tensor to `module[name]`
             setattr(module, name, method.apply_mask(module))

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -64,7 +64,7 @@ class SpectralNorm:
         #     Therefore, since the same power iteration is performed on all
         #     devices, simply updating the tensors in-place will make sure that
         #     the module replica on `device[0]` will update the _u vector on the
-        #     parallized module (by shared storage).
+        #     parallelized module (by shared storage).
         #
         #    However, after we update `u` and `v` in-place, we need to **clone**
         #    them before using them to normalize the weight. This is to support

--- a/torch/nn/utils/stateless.py
+++ b/torch/nn/utils/stateless.py
@@ -204,7 +204,7 @@ def functional_call(
         kwargs (dict): keyword arguments to be passed to the module call
         tie_weights (bool, optional): If True, then parameters and buffers tied in the original model will be treated as
             tied in the reparamaterized version. Therefore, if True and different values are passed for the tied
-            paramaters and buffers, it will error. If False, it will not respect the originally tied parameters and
+            parameters and buffers, it will error. If False, it will not respect the originally tied parameters and
             buffers unless the values passed for both weights are the same. Default: True.
         strict (bool, optional): If True, then the parameters and buffers passed in must match the parameters and
             buffers in the original module. Therefore, if True and there are any missing or unexpected keys, it will


### PR DESCRIPTION
This PR fixes typos in comments of `.py` files under `torch/nn` directory
