### PR TITLE
Fix typos under torch/fx directory 

### DIFF
--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -187,7 +187,7 @@ def get_attr_inference_rule(n: Node, traced):
 @register_inference_rule(torch.transpose)
 def transpose_inference_rule(n: Node):
     """
-    We check that dimentions for the transpose operations
+    We check that dimensions for the transpose operations
     are within range of the tensor type of the node
     """
     if n.target == torch.transpose:
@@ -502,7 +502,7 @@ def flatten_check(tensor_type, start_dim, end_dim):
         new_type_list = lhs + mid + rhs
         return TensorType(tuple(new_type_list))
     else:
-        raise TypeError(f'Incompatable dimensions {start_dim}, {end_dim - 1} in type {tensor_type}')
+        raise TypeError(f'Incompatible dimensions {start_dim}, {end_dim - 1} in type {tensor_type}')
 
 @register_inference_rule(torch.flatten)
 def flatten_inference_rule(n: Node):

--- a/torch/fx/experimental/migrate_gradual_types/constraint.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint.py
@@ -11,7 +11,7 @@ class Constraint:
 class Conj(Constraint):
     def __init__(self, conjuncts):
         """
-        :param conjuncts: Conjuction of constraints
+        :param conjuncts: Conjunction of constraints
         """
         self.conjucts = conjuncts
 
@@ -94,7 +94,7 @@ class BinaryConstraint(Constraint):
         """
         :param lhs: lhs of the constraint
         :param rhs: rhs of the constraint
-        :param op: string reprsenting the operation
+        :param op: string representing the operation
         """
         self.lhs = lhs
         self.rhs = rhs
@@ -221,7 +221,7 @@ class IndexSelect(Constraint):
             tensor_size: tensor size we are considering
             dim_replace: the dimension of the output at "index"
             index: location of the dimensions to replace in the input
-            outut: variable to store the result
+            output: variable to store the result
         """
         assert isinstance(input_var, TVar)
         assert isinstance(output, TVar)

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -254,7 +254,7 @@ def type_inference_rule(n: Node, symbols, constraints, counter):
 @register_inference_rule("masked_fill_")
 def masked_fill_inference_rule(n: Node, symbols, constraints, counter):
     """
-    Similar to addition. For now we implemenent the constraints when
+    Similar to addition. For now we implement the constraints when
     the argument is a boolean tensor. There is also a case for when
     it is a condition. We will leave this out for now.
     """
@@ -475,7 +475,7 @@ def getitem_inference_rule(n: Node, symbols, constraints, counter):
         get_item_output, counter = gen_dvar(counter)
         symbols[n] = get_item_output
 
-        # retreive arg variables
+        # retrieve arg variables
         get_item_arg = symbols[n.args[0]]
         assert isinstance(get_item_arg, TVar)
 
@@ -494,7 +494,7 @@ def getitem_inference_rule(n: Node, symbols, constraints, counter):
 
 
         # since the output is a dimension, we make sure it's a natural number
-        # added as a conjunction to the disjuction of c2
+        # added as a conjunction to the disjunction of c2
         c3 = BinConstraintD(0, get_item_output, op_leq)
         return [Disj([c1, Conj([Disj(c2), c3])])], counter
 
@@ -504,7 +504,7 @@ def getitem_inference_rule(n: Node, symbols, constraints, counter):
         get_item_output, counter = gen_tvar(counter)
         symbols[n] = get_item_output
 
-        # retreive arg variables
+        # retrieve arg variables
         if n.args[0] in symbols:
             get_item_arg = symbols[n.args[0]]
             assert isinstance(get_item_arg, TVar)

--- a/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
@@ -140,7 +140,7 @@ def transform_get_item_tensor(constraint, counter):
     When the index is a tuple, then the output will be a tensor
     TODO: we have to check if this is the case for all HF models
 
-    The cases we are covrering here are a tuple with one of:
+    The cases we are covering here are a tuple with one of:
      - slice with default argument
      - None
 
@@ -700,7 +700,7 @@ def gen_all_reshape_possibilities(list_of_dims, target):
         list_of_dims: The input list of dimensions
         target: The tensor we want to reshape to
 
-    Returns: A disjuncition of transformed reshape constraints
+    Returns: A disjunction of transformed reshape constraints
 
     """
     all_possibilities = generate_all_int_dyn_dim_possibilities(list_of_dims)
@@ -830,8 +830,8 @@ def no_broadcast_dim_with_index(d1: List[DVar],
                                 i: int):
     """
     Args:
-        d1: inpput 1
-        d2: inpput 2
+        d1: input 1
+        d2: input 2
         d3: simulated broadcasting for input 1
         d4: simulated broadcasting for input 2
         i: the rank of the resulting tensor addition
@@ -971,7 +971,7 @@ def gen_greatest_upper_bound(constraint: TGreatestUpperBound, counter: int):
 def generate_all_broadcasting_possibilities_no_padding(d1: List[DVar], d2: List[DVar], d11: List[DVar], d12: List[DVar]):
     """
     Generate broadcasting constraints assuming no padding. Broadcasting can happen at any dimension.
-    We look at all combinations for all dimendions in d1 and d2
+    We look at all combinations for all dimensions in d1 and d2
     Args:
         d1: input1 dimensions
         d2: input2 dimensions

--- a/torch/fx/experimental/migrate_gradual_types/transform_to_z3.py
+++ b/torch/fx/experimental/migrate_gradual_types/transform_to_z3.py
@@ -51,7 +51,7 @@ try:
                     return transformed_lhs == transformed_rhs, counter
 
                 elif is_dim(constraint.lhs) and is_dim(constraint.rhs):
-                    # with dimension tranformations we consider the encoding
+                    # with dimension transformations we consider the encoding
                     lhs, counter = transform_dimension(constraint.lhs, counter, dimension_dict)
                     rhs, counter = transform_dimension(constraint.rhs, counter, dimension_dict)
                     return lhs == rhs, counter

--- a/torch/fx/experimental/optimization.py
+++ b/torch/fx/experimental/optimization.py
@@ -246,7 +246,7 @@ def optimize_for_inference(
     3. MKL layout optimizations
 
     The third optimization takes a function `use_mkl_heuristic` that's used
-    to determine whether a subgraph should be explicity run in MKL layout.
+    to determine whether a subgraph should be explicitly run in MKL layout.
 
     Note: As FX does not currently handle aliasing, this pass currently
     assumes nothing aliases. If that isn't true, use at your own risk.

--- a/torch/fx/experimental/partitioner_utils.py
+++ b/torch/fx/experimental/partitioner_utils.py
@@ -128,7 +128,7 @@ def get_extra_size_of(node: Node, nodes: Set[Node]) -> int:
 def get_latency_of_one_partition(
     partition: Partition, node_to_latency_mapping: Dict[Node, NodeLatency]
 ) -> PartitionLatency:
-    """Given a partiton and its nodes' latency, return a PartitionLatency for this partition"""
+    """Given a partition and its nodes' latency, return a PartitionLatency for this partition"""
 
     def get_top_nodes(partition: Partition) -> List[Node]:
         """Given a partition, return a list of nodes on the top bfs level"""
@@ -273,7 +273,7 @@ def get_latency_of_partitioned_graph(
     partition_to_latency_mapping: Dict[Partition, PartitionLatency],
     transfer_rate_bytes_per_sec: float,
 ):
-    """Given all paritions in a graph, find the critical path among all partitions
+    """Given all partitions in a graph, find the critical path among all partitions
     and return its latency as the latency of the whole graph
     """
 

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -564,7 +564,7 @@ class ProxySymDispatchMode(SymDispatchMode):
         self.tracer = tracer
         # When false, we don't trace operations.  If you do this, you MUST
         # call track_tensor/track_tensor_tree on all results of the operation
-        # to ensure we can adeduately track the results
+        # to ensure we can adequately track the results
         self.enable_tracing = True
 
     @contextmanager

--- a/torch/fx/experimental/rewriter.py
+++ b/torch/fx/experimental/rewriter.py
@@ -33,7 +33,7 @@ class AST_Rewriter(ast.NodeTransformer):
         source_ast = ast.parse(normalized_str)
         dest_ast = ast.fix_missing_locations(self.visit(source_ast))
 
-        # Pull out the compiled fucntion from the newly-created Module
+        # Pull out the compiled function from the newly-created Module
         code = compile(dest_ast, "", "exec")
         globals_dict = copy.copy(fn.__globals__)
         keys_before = set(globals_dict.keys())

--- a/torch/fx/experimental/unification/core.py
+++ b/torch/fx/experimental/unification/core.py
@@ -8,9 +8,9 @@ from .dispatch import dispatch
 
 __all__ = ["reify", "unify"]
 
-################
-# Reificiation #
-################
+###############
+# Reification #
+###############
 
 @dispatch(Iterator, dict)
 def _reify(t, s):

--- a/torch/fx/experimental/unification/match.py
+++ b/torch/fx/experimental/unification/match.py
@@ -109,7 +109,7 @@ def edge(a, b, tie_breaker=hash):
 # Taken from multipledispatch
 def ordering(signatures):
     """ A sane ordering of signatures to check, first to last
-    Topoological sort of edges as given by ``edge`` and ``supercedes``
+    Topological sort of edges as given by ``edge`` and ``supercedes``
     """
     signatures = list(map(tuple, signatures))
     edges = [(a, b) for a in signatures for b in signatures if edge(a, b)]

--- a/torch/fx/experimental/unification/multipledispatch/conflict.py
+++ b/torch/fx/experimental/unification/multipledispatch/conflict.py
@@ -107,7 +107,7 @@ def edge(a, b, tie_breaker=hash):
 
 def ordering(signatures):
     """ A sane ordering of signatures to check, first to last
-    Topoological sort of edges as given by ``edge`` and ``supercedes``
+    Topological sort of edges as given by ``edge`` and ``supercedes``
     """
     signatures = list(map(tuple, signatures))
     edges = [(a, b) for a in signatures for b in signatures if edge(a, b)]

--- a/torch/fx/experimental/unification/multipledispatch/dispatcher.py
+++ b/torch/fx/experimental/unification/multipledispatch/dispatcher.py
@@ -282,7 +282,7 @@ class Dispatcher:
     __repr__ = __str__
 
     def dispatch(self, *types):
-        """Deterimine appropriate implementation for this type signature
+        """Determine appropriate implementation for this type signature
         This method is internal.  Users should call this object as a function.
         Implementation resolution occurs within the ``__call__`` method.
         >>> # xdoctest: +SKIP
@@ -320,7 +320,7 @@ class Dispatcher:
                     yield result
 
     def resolve(self, types):
-        """ Deterimine appropriate implementation for this type signature
+        """ Determine appropriate implementation for this type signature
         .. deprecated:: 0.4.4
             Use ``dispatch(*types)`` instead
         """

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -219,7 +219,7 @@ class PythonCode:
     """
     # Python source code for the forward function definition.
     src: str
-    # Values in global scope during exection of `src_def`.
+    # Values in global scope during execution of `src_def`.
     globals: Dict[str, Any]
 
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -584,7 +584,7 @@ class {module_name}(torch.nn.Module):
             if node.op == "call_module" or node.op == "get_attr":
 
                 # A list of strings representing the different parts
-                # of the path. For exmaple, `foo.bar.baz` gives us
+                # of the path. For example, `foo.bar.baz` gives us
                 # ["foo", "bar", "baz"]
                 fullpath = node.target.split(".")
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -405,7 +405,7 @@ class Node:
         Make target printouts more user-friendly.
         1) builtins will be printed as `builtins.xyz`
         2) operators will be printed as `operator.xyz`
-        3) other callables will be printed with qualfied name, e.g. torch.add
+        3) other callables will be printed with qualified name, e.g. torch.add
         """
         if isinstance(target, str):
             return target

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -80,7 +80,7 @@ def _torchscript_schema_to_signature(ts_schema : torch._C.FunctionSchema) -> ins
         if name == "from":
             assert kind == Parameter.POSITIONAL_OR_KEYWORD
             # ParameterKind type is internal implementation detail to inspec package
-            # which makes it hard to do type annoation
+            # which makes it hard to do type annotation
             kind = Parameter.POSITIONAL_ONLY  # type: ignore[assignment]
             # This renders all previous arguments to positional only
             for idx, p in enumerate(parameters):

--- a/torch/fx/passes/dialect/common/cse_pass.py
+++ b/torch/fx/passes/dialect/common/cse_pass.py
@@ -68,13 +68,13 @@ class CSEPass(PassBase):
         hash_env: Dict[Tuple[torch._ops.OpOverload, int], Node] = {}  # map from hash to a node in the new graph
         token_map: Dict[Tuple[torch._ops.OpOverload, int], Dict[str, Any]] = {}  # map from hash to token
         for n in graph_module.graph.nodes:
-            # The placeholder, output, and get_attr nodes are copied to the new grpah without change
+            # The placeholder, output, and get_attr nodes are copied to the new graph without change
             # do not CSE away random operations
             if n.op == 'placeholder' or n.op == 'output' or n.op == 'get_attr' or get_aten_target(n) in self.banned_ops:
                 new_node = new_graph.node_copy(n, lambda x: env[x])
                 env[n] = new_node
             else:  # n.op == 'call_function', should never see n.op == 'call_module' or 'call_method'
-                # substitute args and kwargs memebrs to their mapping in env if exists
+                # substitute args and kwargs members to their mapping in env if exists
                 # specs can be used to reconstruct nested list/dictionaries
                 def substitute(arg_list):
                     arg_list, spec = tree_flatten(arg_list)
@@ -98,7 +98,7 @@ class CSEPass(PassBase):
                 # check if a node has a substitute and can be eliminated
                 hash_val_in_hash_env = hash_val in hash_env
                 if hash_val_in_hash_env and token_map[hash_val] == token:
-                    modified = True  # substition happens and the graph is modified
+                    modified = True  # substitution happens and the graph is modified
                     env[n] = hash_env[hash_val]
                     continue
 

--- a/torch/fx/passes/infra/partitioner.py
+++ b/torch/fx/passes/infra/partitioner.py
@@ -57,7 +57,7 @@ class CapabilityBasedPartitioner:
 
     def propose_partitions(self) -> List[Partition]:
         # assumptions: nodes in candidate list is sorted in topological order
-        assignment: Dict[Node, int] = {}   # maping from node to partition_id
+        assignment: Dict[Node, int] = {}   # mapping from node to partition_id
         partitions_by_id: Dict[int, Partition] = {}  # mapping from partition_id to partition
         new_partition_id = itertools.count()
 
@@ -161,7 +161,7 @@ class CapabilityBasedPartitioner:
                 self_id = merge_candidates_list[0]
                 for other_id in merge_candidates_list[1:]:
                     # note: merge partition `other_id` into partition `self_id` if
-                    # it doesn't create cyclic depenency in the graph, otherwise,
+                    # it doesn't create cyclic dependency in the graph, otherwise,
                     # this is a no-op
                     maybe_merge_partition(self_id, other_id)
 

--- a/torch/fx/passes/net_min_base.py
+++ b/torch/fx/passes/net_min_base.py
@@ -615,4 +615,4 @@ class _MinimizerBase:
         if self.settings.traverse_method == "accumulate":
             return self._accumulate_traverse(nodes)
 
-        raise RuntimeError(f"Unknow traverse method {self.settings.traverse_method}!")
+        raise RuntimeError(f"Unknown traverse method {self.settings.traverse_method}!")

--- a/torch/fx/passes/reinplace.py
+++ b/torch/fx/passes/reinplace.py
@@ -153,7 +153,7 @@ def _maybe_get_inplace_op(op):
         for f in inplace_overloads
         if _schemas_match(op._schema, f._schema)
     ]
-    # Just becuase foo() and foo_() are both existing operators,
+    # Just because foo() and foo_() are both existing operators,
     # They aren't guaranteed to have compatible schemas.
     # For example, pow.Scalar(Scalar self, Tensor exponent) has no valid inplace variant,
     # Even though several overloads of pow_ exist.
@@ -280,7 +280,7 @@ def reinplace(gm, *sample_args):
            Because that would require resizing "a".
 
            Similarly, we can't convert torch.ge(a, b) into a.ge_(b),
-           beause that would require changing a's dtype (from e.g. float32 to bool).
+           because that would require changing a's dtype (from e.g. float32 to bool).
            Note that in this specific example, we could technically do better..
 
            If we see the pattern:

--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -182,7 +182,7 @@ def split_module(
                 if def_partition_name is not None:
                     use_partition.partitions_dependent_on.setdefault(def_partition_name)
 
-    # split nodes into parititons
+    # split nodes into partitions
     for node in m.graph.nodes:
         orig_nodes[node.name] = node
 
@@ -231,7 +231,7 @@ def split_module(
     if len(sorted_partitions) != len(partitions):
         raise RuntimeError("cycle exists between partitions!")
 
-    # add placeholders to parititons
+    # add placeholders to partitions
     for partition_name in sorted_partitions:
         partition = partitions[partition_name]
         for input in partition.inputs:

--- a/torch/fx/passes/split_utils.py
+++ b/torch/fx/passes/split_utils.py
@@ -181,7 +181,7 @@ def split_by_tags(gm: torch.fx.GraphModule, tags: List[str]) -> torch.fx.GraphMo
         # Max order of upperstream components.
         mx = max((c.order for c in upstream_components), default=0)
 
-        # Expect the componet for `node` has higher order then its upstream components.
+        # Expect the component for `node` has higher order then its upstream components.
         assert comp.order >= mx
 
         # Map a input of `node` to nodes in the component's graph.

--- a/torch/fx/passes/utils/common.py
+++ b/torch/fx/passes/utils/common.py
@@ -24,7 +24,7 @@ class HolderModule(Module):
 @compatibility(is_backward_compatible=False)
 def lift_subgraph_as_module(gm: GraphModule, subgraph: Graph, class_name: str = 'GraphModule') -> GraphModule:
     """
-    Create a GraphModule for subgraph, which copies the necessory attributes from the original parent graph_module.
+    Create a GraphModule for subgraph, which copies the necessary attributes from the original parent graph_module.
 
     Args:
         gm (GraphModule): parent graph module

--- a/torch/fx/passes/utils/fuser_utils.py
+++ b/torch/fx/passes/utils/fuser_utils.py
@@ -127,7 +127,7 @@ def fuse_as_graphmodule(gm: GraphModule,
     node_to_placeholder: Dict[Node, Node] = {}  # mapping of nodes from old graph to placeholder in new graph
     node_map: Dict[Node, Node] = {}       # mapping of nodes from old graph to new graph
 
-    # handles inputs throught graph.node_copy's arg_transform functions
+    # handles inputs through graph.node_copy's arg_transform functions
     def remap_inputs(x):
         if x.op == "get_attr":
             # TODO: do we really need copy the get_attr node into the graph?

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -97,7 +97,7 @@ class SubgraphMatcher:
             self.pattern_anchors = [n for n in output_node.all_input_nodes if len(n.users) == 1]
 
     def _match_attributes(self, pn: Node, gn: Node) -> bool:
-        # Attributes matching is compilcated. Right now we only support matching constant tensor
+        # Attributes matching is complicated. Right now we only support matching constant tensor
         assert isinstance(pn.target, str), f"pn.target {pn.target} must be a string."
         assert isinstance(gn.target, str), f"gn.target {gn.target} must be a string."
         pn_value = getattr(pn.graph.owning_module, pn.target)
@@ -191,7 +191,7 @@ class SubgraphMatcher:
         if pn in match.nodes_map:
             return match.nodes_map[pn] == gn
 
-        # TODO: use a more efficienty way to check if gn is matched before: two-way dict
+        # TODO: use a more efficient way to check if gn is matched before: two-way dict
         if gn in match.nodes_map.values():
             return False
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -120,7 +120,7 @@ class TracerBase:
             check_for_mutable_operation(target, args, kwargs)
 
         node = self.graph.create_node(kind, target, args, kwargs, name, type_expr)
-        # TODO node_name_to_scope will be depricated in favor of
+        # TODO node_name_to_scope will be depreciated in favor of
         # node.meta['nn_module_stack']
         self.node_name_to_scope[node.name] = (
             self.scope.module_path,

--- a/torch/fx/tensor_type.py
+++ b/torch/fx/tensor_type.py
@@ -56,7 +56,7 @@ Dyn = _DynType()
 def is_consistent(t1, t2):
     """
     A binary relation denoted by ~ that determines if t1 is consistent with t2.
-    The relation is reflexive, semmetric but not transitive.
+    The relation is reflexive, symmetric but not transitive.
     returns True if t1 and t2 are consistent and False otherwise.
     Example:
         Dyn ~ TensorType((1,2,3))


### PR DESCRIPTION
This PR fixes typos in comments and messages of `.py` files under `torch/fx` directory
