### PR TITLE
remove dead torch_pb.h library

### DIFF
--- a/caffe2/proto/torch_pb.h
+++ b/caffe2/proto/torch_pb.h
@@ -1,8 +1,0 @@
-#ifndef CAFFE2_PROTO_TORCH_PB_H_
-#define CAFFE2_PROTO_TORCH_PB_H_
-
-#include <caffe2/core/common.h>
-#include <caffe2/proto/caffe2_pb.h>
-#include <caffe2/proto/torch.pb.h>
-
-#endif // CAFFE2_PROTO_TORCH_PB_H_

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -35,7 +35,7 @@
 #include "caffe2/predictor/emulator/data_filler.h"
 #include "caffe2/predictor/predictor.h"
 #include "caffe2/proto/caffe2_pb.h"
-#include "caffe2/proto/torch_pb.h"
+#include "caffe2/proto/torch.pb.h"
 #include "caffe2/python/pybind_state_registry.h"
 #include "caffe2/python/pybind_workspace.h"
 #include "caffe2/utils/cpuid.h"

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -12,7 +12,7 @@
 #include <caffe2/core/common.h>
 #include <caffe2/core/types.h>
 #include <caffe2/proto/caffe2_pb.h>
-#include <caffe2/proto/torch_pb.h>
+#include <caffe2/proto/torch.pb.h>
 #include <caffe2/serialize/inline_container.h>
 
 #include <ATen/ATen.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #97614
* #97613
* #97612
* #97601
* #97600
* __->__ #97599
* #97598
* #97611

This is only used in one place, ensure it still builds.

Differential Revision: [D44395699](https://our.internmc.facebook.com/intern/diff/D44395699/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D44395699/)!