### PR TITLE
move caffe2/proto/ to its own Bazel package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@pytorch//third_party:substitution.bzl", "header_template_rule")
 load("@pytorch//:tools/bazel.bzl", "rules")
 load("@pytorch//tools/rules:cu.bzl", "cu_library")
@@ -444,19 +443,6 @@ CAFFE2_COPTS = COMMON_COPTS + [
     "-fno-math-errno",
     "-fno-trapping-math",
 ]
-
-proto_library(
-    name = "caffe2_proto_source",
-    srcs = glob([
-        "caffe2/proto/*.proto",
-    ]),
-    visibility = ["//visibility:public"],
-)
-
-cc_proto_library(
-    name = "caffe2_protos",
-    deps = [":caffe2_proto_source"],
-)
 
 header_template_rule(
     name = "caffe2_core_macros_h",
@@ -1287,13 +1273,13 @@ cc_library(
         "caffe2/utils/cpuid.h",
     ] + glob([
         "caffe2/utils/threadpool/*.h",
-        "caffe2/proto/*.h",
     ]),
     copts = CAFFE2_COPTS,
     visibility = ["//visibility:public"],
     deps = [
-        ":caffe2_protos",
         ":caffe2_core_macros_h",
+        "//caffe2/proto:caffe2_pb",
+        "//caffe2/proto:protos",
         "//c10:headers",
     ],
 )
@@ -1347,7 +1333,6 @@ cc_library(
         "caffe2/perfkernels/*.h",
         "caffe2/predictor/*.h",
         "caffe2/predictor/emulator/*.h",
-        "caffe2/proto/*.h",
         "caffe2/quantization/server/*.h",
         "caffe2/queue/*.h",
         "caffe2/serialize/*.h",
@@ -1370,7 +1355,8 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":caffe2_for_aten_headers",
-        ":caffe2_protos",
+        "//caffe2/proto:caffe2_pb",
+        "//caffe2/proto:protos",
     ],
 )
 
@@ -1431,7 +1417,8 @@ cc_library(
         ":caffe2_perfkernels_avx",
         ":caffe2_perfkernels_avx2",
         ":caffe2_perfkernels_avx512",
-        ":caffe2_protos",
+        "//caffe2/proto:caffe2_pb",
+        "//caffe2/proto:protos",
         "//third_party/miniz-2.1.0:miniz",
         "@com_google_protobuf//:protobuf",
         "@eigen",

--- a/caffe2/proto/BUILD.bazel
+++ b/caffe2/proto/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library")
+
+cc_library(
+    name = "caffe2_pb",
+    hdrs = ["caffe2_pb.h"],
+    deps = [
+	":protos",
+	"//c10/core:base",
+	"//c10/util:base",
+    ],
+    visibility = [
+	"//:__pkg__",
+    ],
+)
+
+proto_library(
+    name = "proto_source",
+    srcs = glob([
+        "*.proto",
+    ]),
+)
+
+cc_proto_library(
+    name = "protos",
+    deps = [":proto_source"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #97614
* #97613
* #97612
* #97601
* __->__ #97600
* #97599
* #97598
* #97611

This is just to break up build files and make the system easier to
reason about during the transition to the common build system.

Differential Revision: [D44395826](https://our.internmc.facebook.com/intern/diff/D44395826/)