### PR TITLE
cleanup caffe2/proto package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1279,7 +1279,7 @@ cc_library(
     deps = [
         ":caffe2_core_macros_h",
         "//caffe2/proto:caffe2_pb",
-        "//caffe2/proto:protos",
+        "//caffe2/proto:cc_proto",
         "//c10:headers",
     ],
 )
@@ -1356,7 +1356,7 @@ cc_library(
     deps = [
         ":caffe2_for_aten_headers",
         "//caffe2/proto:caffe2_pb",
-        "//caffe2/proto:protos",
+        "//caffe2/proto:cc_proto",
     ],
 )
 
@@ -1418,7 +1418,7 @@ cc_library(
         ":caffe2_perfkernels_avx2",
         ":caffe2_perfkernels_avx512",
         "//caffe2/proto:caffe2_pb",
-        "//caffe2/proto:protos",
+        "//caffe2/proto:cc_proto",
         "//third_party/miniz-2.1.0:miniz",
         "@com_google_protobuf//:protobuf",
         "@eigen",

--- a/caffe2/proto/BUILD.bazel
+++ b/caffe2/proto/BUILD.bazel
@@ -5,7 +5,7 @@ cc_library(
     name = "caffe2_pb",
     hdrs = ["caffe2_pb.h"],
     deps = [
-        ":protos",
+        ":cc_proto",
         "//c10/core:base",
         "//c10/util:base",
     ],
@@ -14,15 +14,15 @@ cc_library(
     ],
 )
 
+cc_proto_library(
+    name = "cc_proto",
+    deps = [":proto_source"],
+    visibility = ["//:__pkg__"],
+)
+
 proto_library(
-    name = "proto_source",
+    name = "proto",
     srcs = glob([
         "*.proto",
     ]),
-)
-
-cc_proto_library(
-    name = "protos",
-    deps = [":proto_source"],
-    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #97614
* #97613
* #97612
* __->__ #97601
* #97600
* #97599
* #97598
* #97611

Name according to Bazel recommendations, adjust order from public to
private, and restrict visibility.

Differential Revision: [D44396068](https://our.internmc.facebook.com/intern/diff/D44396068/)