### PR TITLE
[inductor] support SymPy exprs in `reflection_pad2d_backward` lowering

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -49,11 +49,6 @@ test_failures = {
     "test_kwargs_dynamic_shapes": TestFailure(("cpu",)),
     # test_roi_align uses torchvision, which doesn't work with dynamic shapes
     "test_roi_align_dynamic_shapes": TestFailure(("cpu", "cuda")),
-    #
-    # These are from switching to specialize_int=False
-    #
-    # NotImplementedError: argument of type: <class 'sympy.core.add.Add'>
-    "test_reflection_pad2d_backward_dynamic_shapes": TestFailure(("cpu", "cuda")),
 }
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2467,6 +2467,8 @@ def reflection_pad2d_backward(grad_output, x, padding):
         def index_range_condition(index_range):
             i, lb, ub = index_range
             i = ops.index_expr(i, torch.int32)
+            lb = ops.index_expr(lb, torch.int64)
+            ub = ops.index_expr(ub, torch.int64)
             return ops.and_(ops.ge(i, lb), ops.le(i, ub))
 
         def accumulate(out_x, out_y, index_range1, index_range2=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #97604
* #97519



cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10 @desertfire