### PR TITLE
explicitly list out caffe2 protos

### DIFF
--- a/caffe2/proto/BUILD.bazel
+++ b/caffe2/proto/BUILD.bazel
@@ -22,7 +22,13 @@ cc_proto_library(
 
 proto_library(
     name = "proto",
-    srcs = glob([
-        "*.proto",
-    ]),
+    srcs = [
+        "caffe2.proto",
+        "caffe2_legacy.proto",
+        "hsm.proto",
+        "metanet.proto",
+        "predictor_consts.proto",
+        "prof_dag.proto",
+        "torch.proto",
+    ],
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #97614
* #97613
* __->__ #97612
* #97601
* #97600
* #97599
* #97598
* #97611

This will make it easier to split up this library.

Differential Revision: [D44400049](https://our.internmc.facebook.com/intern/diff/D44400049/)