### PR TITLE
Fix typos in torch/fx/_compatibility.py

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -36,7 +36,7 @@ from copy import deepcopy
 from collections import namedtuple
 
 from torch.fx.proxy import TraceError
-from torch.fx._compatibility import _BACK_COMPAT_OBJECTS, _MARKED_WITH_COMATIBLITY
+from torch.fx._compatibility import _BACK_COMPAT_OBJECTS, _MARKED_WITH_COMPATIBILITY
 
 from fx.test_subgraph_rewriter import TestSubgraphRewriter  # noqa: F401
 from fx.test_dce_pass import TestDCE  # noqa: F401
@@ -3883,7 +3883,7 @@ class TestFXAPIBackwardCompatibility(JitTestCase):
                 if isinstance(v, types.ModuleType):
                     check_symbols_have_bc_designation(v, prefix + [k])
                 elif isinstance(v, (type, types.FunctionType)):
-                    if v not in _MARKED_WITH_COMATIBLITY:
+                    if v not in _MARKED_WITH_COMPATIBILITY:
                         non_back_compat_objects.setdefault(v)
 
         check_symbols_have_bc_designation(torch.fx, ['torch', 'fx'])

--- a/torch/fx/_compatibility.py
+++ b/torch/fx/_compatibility.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 import textwrap
 
 _BACK_COMPAT_OBJECTS : Dict[Any, None] = {}
-_MARKED_WITH_COMATIBLITY : Dict[Any, None] = {}
+_MARKED_WITH_COMPATIBILITY : Dict[Any, None] = {}
 
 def compatibility(is_backward_compatible : bool):
     if is_backward_compatible:
@@ -15,7 +15,7 @@ def compatibility(is_backward_compatible : bool):
 """
             fn.__doc__ = docstring
             _BACK_COMPAT_OBJECTS.setdefault(fn)
-            _MARKED_WITH_COMATIBLITY.setdefault(fn)
+            _MARKED_WITH_COMPATIBILITY.setdefault(fn)
             return fn
 
         return mark_back_compat
@@ -28,7 +28,7 @@ def compatibility(is_backward_compatible : bool):
     This API is experimental and is *NOT* backward-compatible.
 """
             fn.__doc__ = docstring
-            _MARKED_WITH_COMATIBLITY.setdefault(fn)
+            _MARKED_WITH_COMPATIBILITY.setdefault(fn)
             return fn
 
         return mark_not_back_compat


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
Modify the _compatibility.py file global variable name and modify its test file simultaneously.

cc @ezyang @SherlockNoMad @soumith @EikanWang @jgong5 @wenzhe-nrv