### PR TITLE
Remove fast_nvcc entry in README.md

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -25,11 +25,6 @@ Build system pieces:
 * [build_libtorch.py](build_libtorch.py) - Script for building
   libtorch, a standalone C++ library without Python support.  This
   build script is tested in CI.
-* [fast_nvcc](fast_nvcc) - Mostly-transparent wrapper over nvcc that
-  parallelizes compilation when used to build CUDA files for multiple
-  architectures at once.
-  * [fast_nvcc.py](fast_nvcc/fast_nvcc.py) - Python script, entrypoint to the
-    fast nvcc wrapper.
 
 Developer tools which you might find useful:
 


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/96665 landed, fast_nvcc tool is no longer available.
This commit removes the documentation for it so as not to confuse users.