### PR TITLE
Specify file encoding in test_torch.py

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6845,7 +6845,7 @@ class TestTorch(TestCase):
                 '^TypedStorage is deprecated',
                 str(warning)))
             # Check the line of code from the warning's stack
-            with open(w[0].filename) as f:
+            with open(w[0].filename, encoding="utf-8") as f:
                 code_line = f.readlines()[w[0].lineno - 1]
             self.assertTrue(re.search(re.escape('torch.FloatStorage()'), code_line))
 


### PR DESCRIPTION
Attempt to fix 
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 5260: ordinal not in range(128)
```
in https://github.com/pytorch/pytorch/actions/runs/4522628359/jobs/7965372405

In general, it's a good practice to explicitly specify encoding, as otherwise it depends on environment variable and makes tests failures unpredicatble

