### PR TITLE
[FSDP][6/N] Rename param/module name helpers for clarity

### DIFF
--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -347,11 +347,11 @@ def _flatten_optim_state_dict(
             clean_fqn = clean_tensor_name(fqn)
             local_state_clean_fqns[clean_fqn] = fqn
 
-    for param, unflat_param_names in param_to_fqns.items():
-        fqn = unflat_param_names[0]
+    for fqns in param_to_fqns.values():
+        fqn = fqns[0]
         if fqn not in unflat_osd_state:
             continue
-        all_state_keys.difference_update(unflat_param_names)
+        all_state_keys.difference_update(fqns)
         if fqn in fqn_to_fsdp_param_info:
             fsdp_param_info = fqn_to_fsdp_param_info[fqn]
             if use_orig_params:
@@ -367,25 +367,25 @@ def _flatten_optim_state_dict(
                 flat_state = _flatten_optim_state(
                     fsdp_param_info,
                     unflat_osd_state,
-                    unflat_param_names,
+                    fqns,
                     shard_state,
                 )
-            key = _OptimStateKey(tuple(unflat_param_names), True)
+            key = _OptimStateKey(tuple(fqns), True)
             # Only include non-empty states since as expected by
             # `torch.optim.Optimizer` s unless the optimizer is KeyedOptimizer
             # or NamedOptimizer.
             if flat_state:
                 flat_osd_state[key] = flat_state
             elif optim is not None:  # NamedOptimizer or KeyedOptimizer case.
-                assert len(unflat_param_names) == 1
+                assert len(fqns) == 1
                 local_wrapped_fqn = local_state_clean_fqns.get(fqn, "")
                 if local_wrapped_fqn:
                     flat_osd_state[key] = copy.deepcopy(
                         local_state_dict[local_wrapped_fqn]
                     )
         else:  # do not flatten non-FSDP parameters' states
-            assert len(unflat_param_names) == 1
-            key = _OptimStateKey(tuple(unflat_param_names), False)
+            assert len(fqns) == 1
+            key = _OptimStateKey(tuple(fqns), False)
             flat_osd_state[key] = copy.copy(unflat_osd_state[fqn])
 
     # Handle user-defined state, states that are not accosiated with parameters.

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1894,7 +1894,7 @@ class FlatParamHandle:
         sharded_size = self.flat_param._sharded_size  # type: ignore[attr-defined]
         return tensor.size() == sharded_size
 
-    def parameter_module_names(self) -> Iterator[Tuple[str, str]]:
+    def param_module_names(self) -> Iterator[Tuple[str, str]]:
         shared_param_infos = [
             ParamInfo(param_name, module, module_name)
             for (
@@ -1911,7 +1911,7 @@ class FlatParamHandle:
         ):
             yield (param_name, module_name)
 
-    def shared_parameter_module_names(self) -> Iterator[Tuple[str, str]]:
+    def shared_param_module_names(self) -> Iterator[Tuple[str, str]]:
         for param_name, _, module_name in [
             ParamInfo(param_name, module, module_name)
             for (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #97667
* __->__ #97666
* #97665
* #97664
* #97663
* #97662
* #97661

This is an easy PR. It has some remaining local changes that I had that I felt clarified naming.
- `_param_fqns` -> `_param_name_infos` since it returns a tuple of `fqn, param_name, module_name`, not only `fqn`. (similarly for `_shared_param_fqns` -> `_shared_param_name_infos`)
- nit: `parameter_module_names` -> `param_module_names` for consistency since we almost never fully spell out `parameter`. (similarly for `shared_parameter_module_names` -> `shared_param_module_names`)
- nit: `full_fqn` -> `fqn_from_global_root`