### PR TITLE
[FSDP][7/N] Add alignment padding for `use_orig_params=True`

### DIFF
--- a/test/distributed/fsdp/test_fsdp_flatten_params.py
+++ b/test/distributed/fsdp/test_fsdp_flatten_params.py
@@ -38,7 +38,16 @@ class TestFlattenParams(FSDPTest):
         return 1
 
     def _get_default_config(self):
-        return (HandleShardingStrategy.FULL_SHARD, False, None, None, False)
+        return {
+            "device": torch.device("cuda"),
+            "sharding_strategy": HandleShardingStrategy.FULL_SHARD,
+            "offload_params": False,
+            "mp_param_dtype": None,
+            "mp_reduce_dtype": None,
+            "keep_low_precision_grads": False,
+            "process_group": self.process_group,
+            "use_orig_params": False,
+        }
 
     def _get_transformer(self, seed=0):
         torch.manual_seed(seed)  # keep everything deterministic
@@ -141,15 +150,12 @@ class TestFlattenParams(FSDPTest):
             module = module.half()
         with self.assertRaisesRegex(
             ValueError,
-            "Cannot initialize a `FlatParameter` from an empty parameter list",
+            "Cannot construct a FlatParamHandle with an empty parameter list",
         ):
             FlatParamHandle(
                 [],
                 module,
-                torch.device("cuda"),
-                *self._get_default_config(),
-                self.process_group,
-                False,
+                **self._get_default_config(),
             )
 
     @skip_if_lt_x_gpu(1)
@@ -218,10 +224,7 @@ class TestFlattenParams(FSDPTest):
         flat_param_handle = FlatParamHandle(
             params_to_flatten,
             module,
-            torch.device("cuda"),
-            *self._get_default_config(),
-            self.process_group,
-            False,
+            **self._get_default_config(),
         )
         self.assertEqual(ref_numel, flat_param_handle.flat_param.numel())
 
@@ -303,53 +306,30 @@ class TestFlattenParams(FSDPTest):
         optim.step()
         return torch.norm(torch.stack([p.detach().norm() for p in module.parameters()]))
 
-    def test_flat_param_shard_metadata(self):
+    def test_flat_param_shard_metadata_unaligned(self):
         """
-        Tests that ``FlatParameter`` shard metadata are computed as expected.
+        Tests that ``FlatParameter`` shard metadata are computed as expected
+        without any explicit alignment padding.
         """
         module = torch.nn.Sequential(
             torch.nn.Linear(10, 10, bias=False),
-            torch.nn.ReLU(),
+            nn.ReLU(),
             torch.nn.Linear(10, 10, bias=False),
-            torch.nn.ReLU(),
+            nn.ReLU(),
             torch.nn.Linear(10, 10, bias=False),
-            torch.nn.ReLU(),
+            nn.ReLU(),
         )
         params_to_flatten = list(module.parameters())
-        flat_param_handle = FlatParamHandle(
+        handle = FlatParamHandle(
             params_to_flatten,
             module,
-            torch.device("cuda"),
-            *self._get_default_config(),
-            self.process_group,
-            False,
+            **self._get_default_config(),
         )
 
-        def _test(kwargs, expected):
-            """
-            Tests the subroutine ``_get_shard_metadata()`` that computes shard
-            metadata based on start and end indices in the unsharded flattened
-            parameter.
-
-            We manually set the relevant attributes on the flattened parameter
-            to be able to check the effect of ``_get_shard_metadata()`` via
-            ``shard_metadata()`` since normally the attributes are set in
-            ``init_shard_info()`` with the start and end indices fixed based on
-            rank and world size.
-            """
-            flat_param = flat_param_handle.flat_param
-            (
-                flat_param._shard_param_offsets,
-                flat_param._shard_param_indices,
-            ) = flat_param_handle._get_shard_metadata(kwargs["start"], kwargs["end"])
-            self.assertEqual(
-                flat_param_handle.shard_metadata(),
-                expected,
-                msg=f"{flat_param_handle.shard_metadata()}, {expected}",
-            )
-
-        _test(
-            kwargs={"start": 0, "end": 0},
+        self._test_flat_param_shard_metadata(
+            handle,
+            start=0,
+            end=0,
             expected=FlatParamShardMetadata(
                 param_names=["0.weight"],
                 param_shapes=[(10, 10)],
@@ -357,8 +337,10 @@ class TestFlattenParams(FSDPTest):
                 param_offsets=[(0, 0)],
             ),
         )
-        _test(
-            kwargs={"start": 0, "end": 50},
+        self._test_flat_param_shard_metadata(
+            handle,
+            start=0,
+            end=50,
             expected=FlatParamShardMetadata(
                 param_names=["0.weight"],
                 param_shapes=[(10, 10)],
@@ -366,8 +348,10 @@ class TestFlattenParams(FSDPTest):
                 param_offsets=[(0, 50)],
             ),
         )
-        _test(
-            kwargs={"start": 0, "end": 99},
+        self._test_flat_param_shard_metadata(
+            handle,
+            start=0,
+            end=99,
             expected=FlatParamShardMetadata(
                 param_names=["0.weight"],
                 param_shapes=[(10, 10)],
@@ -375,8 +359,10 @@ class TestFlattenParams(FSDPTest):
                 param_offsets=[(0, 99)],
             ),
         )
-        _test(
-            kwargs={"start": 50, "end": 149},
+        self._test_flat_param_shard_metadata(
+            handle,
+            start=50,
+            end=149,
             expected=FlatParamShardMetadata(
                 param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
@@ -384,8 +370,10 @@ class TestFlattenParams(FSDPTest):
                 param_offsets=[(50, 99), (0, 49)],
             ),
         )
-        _test(
-            kwargs={"start": 50, "end": 199},
+        self._test_flat_param_shard_metadata(
+            handle,
+            start=50,
+            end=199,
             expected=FlatParamShardMetadata(
                 param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
@@ -393,8 +381,10 @@ class TestFlattenParams(FSDPTest):
                 param_offsets=[(50, 99), (0, 99)],
             ),
         )
-        _test(
-            kwargs={"start": 99, "end": 199},
+        self._test_flat_param_shard_metadata(
+            handle,
+            start=99,
+            end=199,
             expected=FlatParamShardMetadata(
                 param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
@@ -402,8 +392,10 @@ class TestFlattenParams(FSDPTest):
                 param_offsets=[(99, 99), (0, 99)],
             ),
         )
-        _test(
-            kwargs={"start": 100, "end": 199},
+        self._test_flat_param_shard_metadata(
+            handle,
+            start=100,
+            end=199,
             expected=FlatParamShardMetadata(
                 param_names=["2.weight"],
                 param_shapes=[(10, 10)],
@@ -411,8 +403,10 @@ class TestFlattenParams(FSDPTest):
                 param_offsets=[(0, 99)],
             ),
         )
-        _test(
-            kwargs={"start": 100, "end": 299},
+        self._test_flat_param_shard_metadata(
+            handle,
+            start=100,
+            end=299,
             expected=FlatParamShardMetadata(
                 param_names=["2.weight", "4.weight"],
                 param_shapes=[(10, 10), (10, 10)],
@@ -420,8 +414,10 @@ class TestFlattenParams(FSDPTest):
                 param_offsets=[(0, 99), (0, 99)],
             ),
         )
-        _test(
-            kwargs={"start": 100, "end": 1000},
+        self._test_flat_param_shard_metadata(
+            handle,
+            start=100,
+            end=1000,
             expected=FlatParamShardMetadata(
                 param_names=["2.weight", "4.weight"],
                 param_shapes=[(10, 10), (10, 10)],
@@ -429,14 +425,144 @@ class TestFlattenParams(FSDPTest):
                 param_offsets=[(0, 99), (0, 99)],
             ),
         )
-        _test(
-            kwargs={"start": 299, "end": 299},
+        self._test_flat_param_shard_metadata(
+            handle,
+            start=299,
+            end=299,
             expected=FlatParamShardMetadata(
                 param_names=["4.weight"],
                 param_shapes=[(10, 10)],
                 param_numels=[100],
                 param_offsets=[(99, 99)],
             ),
+        )
+
+    def test_flat_param_shard_metadata_aligned_full_precision(self):
+        """
+        Tests that ``FlatParameter`` shard metadata are computed as expected
+        with alignment padding and parameter full precision.
+        """
+        module = torch.nn.Sequential(
+            torch.nn.Linear(3, 7, bias=False),  # 0.weight
+            torch.nn.Linear(7, 5, bias=False),  # 1.weight
+            torch.nn.Linear(5, 5, bias=False),  # 2.weight
+        )
+        params_to_flatten = list(module.parameters())
+        handle_kwargs = self._get_default_config()
+        handle_kwargs["use_orig_params"] = True
+        handle = FlatParamHandle(params_to_flatten, module, **handle_kwargs)
+        # For 32-bit full precision, FSDP pads up to 3 numel after each
+        # original parameter to achieve 0 mod 4 numel (i.e. 0 mod 16 bytes).
+        # Thus, the unsharded `FlatParameter` layout looks like:
+        #   21 + (3) + 35 + (1) + 25
+        # where (x) means x numel of padding. This gives a total of 85 numel.
+
+        # The `FlatParamShardMetadata` do not include alignment padding but do
+        # account for them
+        self._test_flat_param_shard_metadata(
+            handle,
+            # Emulate rank 0 of 2 ranks
+            start=0,
+            end=42,
+            expected=FlatParamShardMetadata(
+                param_names=["0.weight", "1.weight"],
+                param_shapes=[(7, 3), (5, 7)],
+                param_numels=[21, 35],
+                # 21 + (3) + 19 = 43
+                param_offsets=[(0, 20), (0, 18)],
+            ),
+        )
+        self._test_flat_param_shard_metadata(
+            handle,
+            # Emulate rank 1 of 2 ranks
+            start=43,
+            end=85,
+            expected=FlatParamShardMetadata(
+                param_names=["1.weight", "2.weight"],
+                param_shapes=[(5, 7), (5, 5)],
+                param_numels=[35, 25],
+                # 16 + (1) + 25 = 42
+                param_offsets=[(19, 34), (0, 24)],
+            ),
+        )
+
+    def test_flat_param_shard_metadata_aligned_mixed_precision(self):
+        """
+        Tests that ``FlatParameter`` shard metadata are computed as expected
+        with alignment padding and parameter mixed precision.
+        """
+        module = torch.nn.Sequential(
+            torch.nn.Linear(2, 5, bias=False),  # 0.weight
+            torch.nn.Linear(5, 5, bias=False),  # 1.weight
+            torch.nn.Linear(5, 3, bias=False),  # 2.weight
+        )
+        params_to_flatten = list(module.parameters())
+        handle_kwargs = self._get_default_config()
+        handle_kwargs["use_orig_params"] = True
+        handle_kwargs["mp_param_dtype"] = torch.float16
+        handle = FlatParamHandle(params_to_flatten, module, **handle_kwargs)
+        # For 16-bit mixed precision, FSDP pads up to 7 numel after each
+        # original parameter to achieve 0 mod 8 numel (i.e. 0 mod 16 bytes).
+        # Thus, the unsharded `FlatParameter` layout looks like:
+        #   10 + (6) + 25 + (7) + 15
+        # where (x) means x numel of padding. This gives a total of 63 numel.
+
+        # The `FlatParamShardMetadata` do not include alignment padding but do
+        # account for them
+        self._test_flat_param_shard_metadata(
+            handle,
+            # Emulate rank 0 of 2 ranks
+            start=0,
+            end=31,
+            expected=FlatParamShardMetadata(
+                param_names=["0.weight", "1.weight"],
+                param_shapes=[(5, 2), (5, 5)],
+                param_numels=[10, 25],
+                # 10 + (6) + 16 = 32
+                param_offsets=[(0, 9), (0, 15)],
+            ),
+        )
+        self._test_flat_param_shard_metadata(
+            handle,
+            # Emulate rank 1 of 2 ranks
+            start=32,
+            end=63,
+            expected=FlatParamShardMetadata(
+                param_names=["1.weight", "2.weight"],
+                param_shapes=[(5, 5), (3, 5)],
+                param_numels=[25, 15],
+                # 9 + (7) + 15 = 31
+                param_offsets=[(16, 24), (0, 14)],
+            ),
+        )
+
+    def _test_flat_param_shard_metadata(
+        self,
+        handle: FlatParamHandle,
+        start: int,
+        end: int,
+        expected: FlatParamShardMetadata,
+    ):
+        """
+        Tests the subroutine ``_get_shard_metadata()`` that computes shard
+        metadata based on start and end indices in the unsharded flat
+        parameter, where both indices are inclusive.
+
+        We manually set the relevant attributes on the flat parameter to be
+        able to check the effect of ``_get_shard_metadata()`` via
+        ``shard_metadata()`` since normally the attributes are set in
+        ``_init_shard_metadata()`` with the start and end indices fixed based
+        on rank and world size.
+        """
+        flat_param = handle.flat_param
+        (
+            flat_param._shard_param_offsets,
+            flat_param._shard_param_indices,
+        ) = handle._get_shard_metadata(start, end)
+        self.assertEqual(
+            handle.shard_metadata(),
+            expected,
+            msg=f"{handle.shard_metadata()}, {expected}",
         )
 
 

--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 from torch import distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy
-from torch.distributed.fsdp.flat_param import FLAT_PARAM_PADDING
+from torch.distributed.fsdp.flat_param import _FLAT_PARAM_PADDING
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     CUDAInitMode,
@@ -154,7 +154,7 @@ class TestFSDPIgnoredModules(FSDPTest):
                     for (numel, pi) in zip(
                         flat_param._wp_numels, flat_param._optional_param_infos
                     )
-                    if pi is FLAT_PARAM_PADDING
+                    if pi is _FLAT_PARAM_PADDING
                 )
                 flat_param_numel -= padding_numel
                 self.assertEqual(flat_param_numel, nonignored_numel)
@@ -203,7 +203,7 @@ class TestFSDPIgnoredModules(FSDPTest):
                     for (numel, pi) in zip(
                         flat_param._wp_numels, flat_param._optional_param_infos
                     )
-                    if pi is FLAT_PARAM_PADDING
+                    if pi is _FLAT_PARAM_PADDING
                 )
                 flat_param_numel -= padding_numel
                 self.assertEqual(flat_param_numel, nonignored_numel)

--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -152,7 +152,7 @@ class TestFSDPIgnoredModules(FSDPTest):
                 padding_numel = sum(
                     numel
                     for (numel, pi) in zip(
-                        flat_param._wp_numels, flat_param._optional_param_infos
+                        flat_param._wp_numels, flat_param._wp_param_infos
                     )
                     if pi is _FLAT_PARAM_PADDING
                 )
@@ -201,7 +201,7 @@ class TestFSDPIgnoredModules(FSDPTest):
                 padding_numel = sum(
                     numel
                     for (numel, pi) in zip(
-                        flat_param._wp_numels, flat_param._optional_param_infos
+                        flat_param._wp_numels, flat_param._wp_param_infos
                     )
                     if pi is _FLAT_PARAM_PADDING
                 )

--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -146,7 +146,15 @@ class TestFSDPIgnoredModules(FSDPTest):
         with FSDP.summon_full_params(wrapped_model):
             flat_param = wrapped_model.params[0]
             flat_param_numel = flat_param.numel()
-            self.assertEqual(flat_param_numel, nonignored_numel)
+            if use_orig_params:
+                # Subtract numel from alignment padding
+                padding_numel = sum(
+                    numel
+                    for (numel, pi) in zip(flat_param._numels, flat_param._param_infos)
+                    if pi is None
+                )
+                flat_param_numel -= padding_numel
+                self.assertEqual(flat_param_numel, nonignored_numel)
         # Check that we can run a few iterations
         optim = torch.optim.Adam(wrapped_model.parameters(), lr=1e-3)
         self._train_model(wrapped_model, optim, 3)
@@ -185,6 +193,15 @@ class TestFSDPIgnoredModules(FSDPTest):
         with FSDP.summon_full_params(wrapped_model):
             flat_param = wrapped_model.params[0]
             flat_param_numel = flat_param.numel()
+            if use_orig_params:
+                # Subtract numel from alignment padding
+                padding_numel = sum(
+                    numel
+                    for (numel, pi) in zip(flat_param._numels, flat_param._param_infos)
+                    if pi is None
+                )
+                flat_param_numel -= padding_numel
+                self.assertEqual(flat_param_numel, nonignored_numel)
             self.assertEqual(flat_param_numel, nonignored_numel)
         # Check that we can run a few iterations
         optim = torch.optim.Adam(wrapped_model.parameters(), lr=1e-3)

--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -152,7 +152,7 @@ class TestFSDPIgnoredModules(FSDPTest):
                 padding_numel = sum(
                     numel
                     for (numel, pi) in zip(
-                        flat_param._numels, flat_param._optional_param_infos
+                        flat_param._wp_numels, flat_param._optional_param_infos
                     )
                     if pi is FLAT_PARAM_PADDING
                 )
@@ -201,7 +201,7 @@ class TestFSDPIgnoredModules(FSDPTest):
                 padding_numel = sum(
                     numel
                     for (numel, pi) in zip(
-                        flat_param._numels, flat_param._optional_param_infos
+                        flat_param._wp_numels, flat_param._optional_param_infos
                     )
                     if pi is FLAT_PARAM_PADDING
                 )

--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 from torch import distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy
+from torch.distributed.fsdp.flat_param import FLAT_PARAM_PADDING
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     CUDAInitMode,
@@ -147,11 +148,13 @@ class TestFSDPIgnoredModules(FSDPTest):
             flat_param = wrapped_model.params[0]
             flat_param_numel = flat_param.numel()
             if use_orig_params:
-                # Subtract numel from alignment padding
+                # Subtract the numel contributed from alignment padding
                 padding_numel = sum(
                     numel
-                    for (numel, pi) in zip(flat_param._numels, flat_param._param_infos)
-                    if pi is None
+                    for (numel, pi) in zip(
+                        flat_param._numels, flat_param._optional_param_infos
+                    )
+                    if pi is FLAT_PARAM_PADDING
                 )
                 flat_param_numel -= padding_numel
                 self.assertEqual(flat_param_numel, nonignored_numel)
@@ -194,11 +197,13 @@ class TestFSDPIgnoredModules(FSDPTest):
             flat_param = wrapped_model.params[0]
             flat_param_numel = flat_param.numel()
             if use_orig_params:
-                # Subtract numel from alignment padding
+                # Subtract the numel contributed from alignment padding
                 padding_numel = sum(
                     numel
-                    for (numel, pi) in zip(flat_param._numels, flat_param._param_infos)
-                    if pi is None
+                    for (numel, pi) in zip(
+                        flat_param._numels, flat_param._optional_param_infos
+                    )
+                    if pi is FLAT_PARAM_PADDING
                 )
                 flat_param_numel -= padding_numel
                 self.assertEqual(flat_param_numel, nonignored_numel)

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -454,7 +454,7 @@ class TestFSDPOptimState(FSDPTest):
             fsdp_osd_param_ids = set(fsdp_osd_state.keys())
             self.assertTrue(
                 ref_osd_param_ids == fsdp_osd_param_ids,
-                (ref_osd_param_ids, fsdp_osd_param_ids),
+                f"Rank {self.rank}: {(ref_osd_param_ids, fsdp_osd_param_ids)}",
             )
             # Check state values are the same
             for param_id, param_state in fsdp_osd_state.items():

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -411,9 +411,9 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
                 has_weight = False
                 has_bias = False
                 for param, fqn in zip(flat_param._params, flat_param._fqns):
-                    if "weight" in fqn and param.numel() > 0:
+                    if fqn is not None and "weight" in fqn and param.numel() > 0:
                         has_weight = True
-                    elif "bias" in fqn and param.numel() > 0:
+                    elif fqn is not None and "bias" in fqn and param.numel() > 0:
                         has_bias = True
                 has_both |= has_weight and has_bias
         assert has_both, (
@@ -689,8 +689,10 @@ class TestFSDPUseOrigParamsParamAccess(FSDPTest):
                 torch.manual_seed(42)
                 # 5 * 5 = 25 numel -> pad to 26 -> 13 on each rank
                 self.lin1 = nn.Linear(5, 5, bias=False)
-                # 5 * 7 + 7 = 42 numel -> no pad -> 21 on each rank
-                # 21 of weight on rank 0; 14 of weight and 7 of bias on rank 1
+                # 5 * 7 + (1) + 7 = 43 numel -> pad to 44 -> 22 on each rank,
+                # where the (1) is from intra-`FlatParameter` alignment padding
+                # 22 of weight on rank 0; 13 of weight, 1 alignment padding,
+                # and 7 of bias on rank 1
                 self.lin2 = nn.Linear(5, 7)
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -727,9 +729,9 @@ class TestFSDPUseOrigParamsParamAccess(FSDPTest):
                         p1 = p1.flatten()[13:]
                 elif n1 == "lin2.weight":
                     if self.rank == 0:
-                        p1 = p1.flatten()[:21]
+                        p1 = p1.flatten()[:22]
                     elif self.rank == 1:
-                        p1 = p1.flatten()[21:]
+                        p1 = p1.flatten()[22:]
                 elif n1 == "lin2.bias":
                     if self.rank == 0:
                         p1 = torch.empty(0, device=p1.device)
@@ -1035,7 +1037,7 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
         )
 
     def _test_no_sync_correctness(self, sharding_strategy: ShardingStrategy):
-        model = nn.Linear(3, 3, device="cuda")
+        model = nn.Linear(7, 1, bias=False, device="cuda")
         fsdp_kwargs = {
             "sharding_strategy": sharding_strategy,
         }
@@ -1055,11 +1057,13 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
             _test_model: nn.Module,
         ):
             """
-            This assumes that the model is ``nn.Linear(3, 3, bias=False)``
-            (i.e. with a single weight parameter) to be able to directly
+            This assumes that the model is ``nn.Linear(7, 1, bias=False)``
+            (i.e. with a single 1D weight parameter) to be able to directly
             compare the baseline and test models. On rank 1, the baseline
             includes 1 element of padding.
             """
+            self.assertEqual(len(list(_baseline_model.parameters())), 1)
+            self.assertEqual(len(list(_test_model.parameters())), 1)
             for flat_param, orig_param in zip(
                 _baseline_model.parameters(), _test_model.parameters()
             ):
@@ -1083,8 +1087,8 @@ class TestFSDPUseOrigParamsNoSync(FSDPTest):
                     orig_param.grad,
                 )
 
-        inp = torch.randn((2, 3), device="cuda")
-        grad = torch.rand_like(inp)
+        inp = torch.randn((2, 7), device="cuda")
+        grad = torch.randn((2, 1), device="cuda")
 
         # Compute some reference gradients using one forward/backward
         out_use_flat_params = model_use_flat_params(inp)

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -411,9 +411,9 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
                 has_weight = False
                 has_bias = False
                 for param, fqn in zip(flat_param._params, flat_param._fqns):
-                    if fqn is not None and "weight" in fqn and param.numel() > 0:
+                    if "weight" in fqn and param.numel() > 0:
                         has_weight = True
-                    elif fqn is not None and "bias" in fqn and param.numel() > 0:
+                    elif "bias" in fqn and param.numel() > 0:
                         has_bias = True
                 has_both |= has_weight and has_bias
         assert has_both, (

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -212,9 +212,7 @@ def _get_param_to_fqns(
                 else [param_name]
             )  # prefixed from `module`
             global_fqns = [
-                clean_tensor_name(prefix + name)
-                for name in local_fqns
-                if name is not None
+                clean_tensor_name(prefix + name) for name in local_fqns
             ]  # prefixed from the top level `model` (i.e. including `prefix`)
             is_shared_param = param in param_to_fqns
             if not is_shared_param:

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -212,7 +212,9 @@ def _get_param_to_fqns(
                 else [param_name]
             )  # prefixed from `module`
             global_fqns = [
-                clean_tensor_name(prefix + name) for name in local_fqns
+                clean_tensor_name(prefix + name)
+                for name in local_fqns
+                if name is not None
             ]  # prefixed from the top level `model` (i.e. including `prefix`)
             is_shared_param = param in param_to_fqns
             if not is_shared_param:

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -35,7 +35,7 @@ from torch.distributed.fsdp._runtime_utils import _clear_grads_if_needed, _lazy_
 from torch.distributed.fsdp._shard_utils import _gather_state_dict
 from torch.distributed.fsdp.api import ShardingStrategy
 from torch.distributed.fsdp.flat_param import (
-    FLAT_PARAM_PADDING,
+    _FLAT_PARAM_PADDING,
     FlatParameter,
     FlatParameterPadding,
     FlatParamHandle,
@@ -280,7 +280,7 @@ def _unflatten_communicated_optim_state(
             # Skip any alignment padding -- `views` should never be exhausted
             # before the outer for loop completes
             try:
-                while optim_state is FLAT_PARAM_PADDING:
+                while optim_state is _FLAT_PARAM_PADDING:
                     optim_state = next(views)
             except StopIteration as e:
                 print(
@@ -1565,7 +1565,7 @@ def _get_fqn_to_fsdp_param_info(model: nn.Module) -> Dict[str, FSDPParamInfo]:
         # to preserve correctness since `_shard_orig_params_state()` relies on
         # the indexing
         for idx, local_fqn in enumerate(flat_param._wp_fqns):
-            if local_fqn is FLAT_PARAM_PADDING:
+            if local_fqn is _FLAT_PARAM_PADDING:
                 continue
             fqn = clean_tensor_name(prefix + local_fqn)
             if fqn in fqn_to_param_info:

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -36,8 +36,8 @@ from torch.distributed.fsdp._shard_utils import _gather_state_dict
 from torch.distributed.fsdp.api import ShardingStrategy
 from torch.distributed.fsdp.flat_param import (
     _FLAT_PARAM_PADDING,
+    _FlatParameterPadding,
     FlatParameter,
-    FlatParameterPadding,
     FlatParamHandle,
 )
 
@@ -275,7 +275,7 @@ def _unflatten_communicated_optim_state(
             else:
                 views = flat_param_views[state_name]
             optim_state: Union[
-                torch.Tensor, ShardedTensor, FlatParameterPadding
+                torch.Tensor, ShardedTensor, _FlatParameterPadding
             ] = next(views)
             # Skip any alignment padding -- `views` should never be exhausted
             # before the outer for loop completes

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -248,7 +248,8 @@ def _unflatten_communicated_optim_state(
         unflattened parameter IDs.
     """
     fsdp_state = fsdp_param_info.state
-    flat_param = fsdp_param_info.handle.flat_param
+    handle = fsdp_param_info.handle
+    flat_param = handle.flat_param
     unflat_param_state: List[Dict[str, Any]] = []
     flat_param_views: Dict[str, Iterator] = {}
     num_unflat_params = flat_param._num_params
@@ -264,11 +265,22 @@ def _unflatten_communicated_optim_state(
         for state_name, flat_tensor in sorted_items(tensor_state):
             views_generated = state_name in flat_param_views
             if not views_generated:
-                views = FlatParamHandle._get_unflat_views(flat_param, flat_tensor)
+                views = handle._get_unflat_views(flat_tensor)
                 flat_param_views[state_name] = views
             else:
                 views = flat_param_views[state_name]
-            optim_state: Union[torch.Tensor, ShardedTensor] = next(views)
+            optim_state: Optional[Union[torch.Tensor, ShardedTensor]] = next(views)
+            # Skip any alignment padding -- `views` should never be exhausted
+            # before the outer for loop completes
+            try:
+                while optim_state is None:
+                    optim_state = next(views)
+            except StopIteration as e:
+                print(
+                    f"Rank {dist.get_rank()} exhausted views early while "
+                    "unflattening optimizer state. Please report a bug."
+                )
+                raise e
             if shard_state:
                 assert fsdp_state.process_group is not None
                 optim_state = _ext_chunk_tensor(
@@ -426,13 +438,14 @@ def _flatten_optim_state(
         part will map a key to this returned value.
     """
     fsdp_state = fsdp_param_info.state
-    flat_param = fsdp_param_info.handle.flat_param
+    handle = fsdp_param_info.handle
+    flat_param = handle.flat_param
     num_unflat_params = len(unflat_param_names)
     assert num_unflat_params > 0, (
         "Expects at least one unflattened parameter corresponding to the "
         "flat parameter"
     )
-    unflat_param_shapes = flat_param._shapes
+    unflat_param_shapes = [shape for shape in flat_param._shapes if shape is not None]
     num_unflat_param_shapes = len(unflat_param_shapes)
     assert (
         num_unflat_params == num_unflat_param_shapes
@@ -500,7 +513,7 @@ def _flatten_optim_state(
                 state_values,
                 unflat_param_names,
                 unflat_param_shapes,
-                flat_param,
+                handle,
             )
             if shard_state:
                 # Shard the flattened tensor immediately to minimize max memory
@@ -535,12 +548,12 @@ def _flatten_tensor_optim_state(
     pos_dim_tensors: List[torch.Tensor],
     unflat_param_names: List[str],
     unflat_param_shapes: Sequence[torch.Size],
-    flat_param: FlatParameter,
+    handle: FlatParamHandle,
 ) -> torch.Tensor:
     """
     Flattens the positive-dimension tensor optimizer state given by the values
     ``tensors`` for the state ``state_name`` for a single flat parameter
-    ``flat_param`` corresponding to the unflattened parameter names
+    from ``handle`` corresponding to the unflattened parameter names
     ``unflat_param_names`` and unflatted parameter shapes
     ``unflat_param_shapes``. This flattens each unflattened parameter's tensor
     state into one tensor.
@@ -560,7 +573,7 @@ def _flatten_tensor_optim_state(
             parameter names corresponding to the single flat parameter.
         unflat_param_shapes (List[torch.Size]): Unflattened parameter shapes
             corresponding to the single flat parameter.
-        flat_param (FlatParameter): The flat parameter.
+        handle (FlatParamHandle): The flat parameter's handle.
 
     Returns:
         torch.Tensor: A flat tensor containing the optimizer state
@@ -568,6 +581,7 @@ def _flatten_tensor_optim_state(
         unflattened parameter tensor states in ``pos_dim_tensors`` (using zero
         tensors for any unflattened parameters without the state).
     """
+    flat_param = handle.flat_param
     non_none_tensors = [t for t in pos_dim_tensors if t is not None]
     # Check that all are tensors with the same dtype
     dtypes = {t.dtype for t in non_none_tensors}
@@ -588,11 +602,12 @@ def _flatten_tensor_optim_state(
                 "Tensor optimizer state does not have same shape as its "
                 f"parameter: {tensor.shape} {shape}"
             )
-    # Flatten the tensor states: we do not need to add any padding since the
-    # flat optimizer state tensor sharded via `_get_shard()`, which pads the
-    # shard as needed (just like for the flat parameter)
+    # Flatten the tensor states: we do not need to add any right-hand-side
+    # padding since the flat optimizer state tensor is sharded via
+    # `_get_shard()`, which pads the shard as needed (just like for the flat
+    # parameter)
     cpu_device = torch.device("cpu")
-    tensors = [
+    tensors_to_flatten = [
         torch.flatten(state_value.to(cpu_device))
         if state_value is not None
         else torch.flatten(
@@ -604,7 +619,7 @@ def _flatten_tensor_optim_state(
         )
         for state_value, shape in zip(pos_dim_tensors, unflat_param_shapes)
     ]
-    flat_tensor = torch.cat(tensors)
+    flat_tensor = handle.flatten_tensors(tensors_to_flatten, handle._aligned_numel)
     flat_param_shape = flat_param._unpadded_unsharded_size  # type: ignore[attr-defined]
     assert flat_tensor.shape == flat_param_shape, (
         f"tensor optim state: {flat_tensor.shape} "
@@ -1531,12 +1546,18 @@ def _get_fqn_to_fsdp_param_info(model: nn.Module) -> Dict[str, FSDPParamInfo]:
             return
         _lazy_init(fsdp_state, module)
         handles = _module_handles(fsdp_state, module)
+        assert (
+            len(handles) < 2
+        ), f"Assumes at most 1 FlatParamHandle but {len(handles)} handles"
         if not handles:
             return
         handle = handles[0]
         flat_param = handle.flat_param
         fsdp_param_info = FSDPParamInfo(fsdp_state, handle, {})
         for idx, local_fqn in enumerate(flat_param._fqns):
+            is_padding = local_fqn is None
+            if is_padding:
+                continue
             fqn = clean_tensor_name(prefix + local_fqn)
             if fqn in fqn_to_param_info:
                 assert fqn_to_param_info[fqn].handle.flat_param is flat_param, fqn

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -173,9 +173,9 @@ class FlatParameter(nn.Parameter):
     with them filtered. The former are prefixed with "_optional" and should
     mainly be used within this file. They are needed when iterating over the
     tensors in the ``FlatParameter`` or analogous tensors and the index
-    matters. Developers should take to *not* zip a data structure that includes
-    padding objects (i.e. with "_optional" prefix or ``_numels``) with one that
-    does not include padding objects.
+    matters. Developers should take care to *avoid* zipping a data structure
+    that includes padding objects (i.e. with "_optional" prefix or ``_numels``)
+    with one that does not include padding objects.
 
     Attributes:
         _unpadded_unsharded_size (torch.Size): Unsharded flat parameter's size
@@ -217,8 +217,8 @@ class FlatParameter(nn.Parameter):
             filtered.
         _num_params (int): Number of original parameters flattened into this
             flat parameter; this is the length of ``_param_infos``,
-            ``_shapes``, and ``_fqns``, which are *after* filtering padding
-            objects.
+            ``_shapes``, and ``_fqns``, which have their padding objects
+            filtered.
         _numels (Tuple[int, ...]): Each parameter's numel including entries for
             padding objects.
         _shared_param_infos (Tuple[SharedParamInfo, ...]): Shared parameter
@@ -236,7 +236,7 @@ class FlatParameter(nn.Parameter):
             where the parameters follow the order in which they were originally
             flattened; this indexes appropriately into any data structure that
             follows the flattening order (e.g. ``_param_infos``, ``_numels``,
-            etc.). The indices includes the alignment padding elements.
+            etc.). The indices include the alignment padding elements.
         _shard_numel_padded (int): Numel padded for this rank's sharded flat
             parameter.
 

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -2088,7 +2088,7 @@ class FlatParamHandle:
         for param_info in chain(self.flat_param._param_infos, shared_param_infos):
             is_padding = param_info is None
             if not is_padding:
-                param_name, _, module_name = param_info
+                param_name, _, module_name = param_info  # type: ignore[misc]
                 yield (param_name, module_name)
 
     def shared_param_module_names(self) -> Iterator[Tuple[str, str]]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97667
* #97666
* #97665
* #97664
* #97663
* #97662
* #97661

This PR adds intra-`FlatParameter` 16-byte alignment padding to the `use_orig_params=True` code path to avoid clones in TorchInductor.

**Approach**
The `FlatParameter` maintains several data structures about its original parameters. Notably, the data structures `_param_infos`, `_shapes`, `_numels`, and `_fqns` have the same length and index in the same way.

This PR treats alignment padding _like_ an original parameter in that the padding gets flattened into the `FlatParameter`. Therefore, it must be reflected in the aforementioned data structures. However, given the way in which the data structures are used, we choose to do the following if the `i`th tensor flattened into the `FlatParameter` is padding:
- `_numels[i]` is the numel of padding
- `_param_infos[i] == _shapes[i] == _fqns[i] == None`

This choice is because (1) we must record the padding numel to account for it (e.g. for views) and (2) we prefer to preserve the invariant that the data structures index in the same way over avoiding `None` entries.

To ease the burden of other FSDP developers, we separate the parameter flattening logic:
- `_init_flat_param_and_metadata()`: This should be called only once in the `FlatParamHandle` constructor. The `FlatParameter` metadata is assumed to be static thereafter.
- `flatten_tensors()` / `flatten_tensors_into_flat_param()`: These can be used for optimizer and model state dict and can be called after construction time.

This separation allows `_init_flat_param_and_metadata()` to contain the much heavier metadata logic, while keeping the latter methods to be much lighter. The only constraint is that the alignment padding logic must be kept consistent between the two, but this should be worth the simper interface.

**Testing**
- This PR directly modifies the `use_orig_params=True` code path, so all existing tests passing gives good signal.
    - Some existing unit tests had to be adjusted to account for the alignment padding.
- This PR adds two tests in `test_fsdp_flatten_params.py` to explicitly test the sharding metadata with alignment for both parameter full precision and mixed precision since the latter requires possibly more padding elements due to the decreased per-element size.

