### PR TITLE
[BE] Update flake8-comprehensions to 3.11.1

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,7 @@ ignore =
     # these ignores are from flake8-bugbear; please fix!
     B007,B008,
     # these ignores are from flake8-comprehensions; please fix!
-    C407
+    C407,C417
     # these ignores are from flake8-logging-format; please fix!
     G001,G002,G003,G004,G100,G101,G200,G201,G202
 per-file-ignores =

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -35,7 +35,7 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     'flake8==3.8.2',
     'flake8-bugbear==20.1.4',
-    'flake8-comprehensions==3.3.0',
+    'flake8-comprehensions==3.11.1',
     'flake8-executable==2.0.4',
     'flake8-logging-format==0.9.0',
     'flake8-pyi==20.5.0',


### PR DESCRIPTION
Updates flake8-comprehensions in lintrunner so we can enforce new checks that have been implemented since the last update (including one implemented by me). I also added C417 to the flake8 ignore codes for now since we do not yet conform to that check.
