### PR TITLE
Allow ports to be reused in gloo

### DIFF
--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -220,5 +220,34 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
             for i in range(self.world_size):
                 self.assertEqual(gather_list[i], torch.ones(3, 3) * i)
 
+class TestLargeWorld(MultiThreadedTestCase):
+    @property
+    def world_size(self):
+        return 64
+
+    def setUp(self):
+        super().setUp()
+        self._spawn_threads()
+
+    def test_gloo_init(self):
+        groups = []
+        num_ports_used = 0
+        num_groups = 4
+        # create multiple gloo groups with 64 ranks
+        for i in range(num_groups):
+            group = dist.new_group(backend="gloo")
+            groups.append(group)
+
+        # tear down gloo groups
+        for i in range(num_groups):
+            dist.destroy_process_group(groups[i])
+        groups.clear()
+        self.assertEqual(len(groups), 0)
+
+        # create multiple gloo groups with 64 ranks
+        for i in range(num_groups):
+            group = dist.new_group(backend="gloo")
+            groups.append(group)
+
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Summary:
ProcessGroupGloo and gloo seem to be opening and closing sockets without allowing the port to be reused. We see this issue pop up in larger training jobs "Address already in use" and we assume it to be because all the ephemeral ports are exhausted.

This diff allows ports to be reused, we see a reduced number of ports being in `TIME_WAIT` state.

context: https://fb.workplace.com/groups/319878845696681/permalink/5988899781205532/

another issue: https://fb.workplace.com/groups/319878845696681/permalink/958768178474408/

Test Plan: Add a gloo test to create 4 groups of size 64 using multithreaded PG + gloo. In total 256 ranks.

Differential Revision: D44029927

