### PR TITLE
[quantized] Fix  return values of _get_name() in quantized ConvTranspose

### DIFF
--- a/torch/ao/nn/quantized/dynamic/modules/conv.py
+++ b/torch/ao/nn/quantized/dynamic/modules/conv.py
@@ -267,7 +267,7 @@ class ConvTranspose1d(nnq.ConvTranspose1d):
             groups, bias, dilation, padding_mode, **factory_kwargs)
 
     def _get_name(self):
-        return 'DynamicQuantizedConvTranpose1d'
+        return 'DynamicQuantizedConvTranspose1d'
 
     def forward(self, input: Tensor, reduce_range: bool = True) -> Tensor:
         # Temporarily using len(shape) instead of ndim due to JIT issue
@@ -328,7 +328,7 @@ class ConvTranspose2d(nnq.ConvTranspose2d):
             groups, bias, dilation, padding_mode, **factory_kwargs)
 
     def _get_name(self):
-        return 'DynamicQuantizedConvTranpose2d'
+        return 'DynamicQuantizedConvTranspose2d'
 
     def forward(self, input: Tensor, reduce_range: bool = True) -> Tensor:
         # Temporarily using len(shape) instead of ndim due to JIT issue
@@ -389,7 +389,7 @@ class ConvTranspose3d(nnq.ConvTranspose3d):
             groups, bias, dilation, padding_mode, **factory_kwargs)
 
     def _get_name(self):
-        return 'DynamicQuantizedConvTranpose3d'
+        return 'DynamicQuantizedConvTranspose3d'
 
     def forward(self, input: Tensor, reduce_range: bool = True) -> Tensor:
         # Temporarily using len(shape) instead of ndim due to JIT issue

--- a/torch/ao/nn/quantized/modules/conv.py
+++ b/torch/ao/nn/quantized/modules/conv.py
@@ -730,7 +730,7 @@ class ConvTranspose1d(_ConvTransposeNd):
             True, output_padding, groups, bias, padding_mode, **factory_kwargs)
 
     def _get_name(self):
-        return 'QuantizedConvTranpose1d'
+        return 'QuantizedConvTranspose1d'
 
     def set_weight_bias(self, w: torch.Tensor, b: Optional[torch.Tensor]) -> None:
         self._packed_params = torch.ops.quantized.conv_transpose1d_prepack(
@@ -821,7 +821,7 @@ class ConvTranspose2d(_ConvTransposeNd):
             True, output_padding, groups, bias, padding_mode, **factory_kwargs)
 
     def _get_name(self):
-        return 'QuantizedConvTranpose2d'
+        return 'QuantizedConvTranspose2d'
 
     def set_weight_bias(self, w: torch.Tensor, b: Optional[torch.Tensor]) -> None:
         self._packed_params = torch.ops.quantized.conv_transpose2d_prepack(
@@ -914,7 +914,7 @@ class ConvTranspose3d(_ConvTransposeNd):
             True, output_padding, groups, bias, padding_mode, **factory_kwargs)
 
     def _get_name(self):
-        return 'QuantizedConvTranpose3d'
+        return 'QuantizedConvTranspose3d'
 
     def set_weight_bias(self, w: torch.Tensor, b: Optional[torch.Tensor]) -> None:
         self._packed_params = torch.ops.quantized.conv_transpose3d_prepack(


### PR DESCRIPTION
This PR fixes incorrect return values of _get_name() in quantized `ConvTranspose?d`.


cc @jerryzh168 @jianyuh @raghuramank100 @jamesr66a @vkuzo @jgong5 @Xia-Weiwen @leslie-fang-intel