### PR TITLE
Fix typos under torch/ao directory

### DIFF
--- a/torch/ao/ns/fx/pattern_utils.py
+++ b/torch/ao/ns/fx/pattern_utils.py
@@ -97,7 +97,7 @@ def get_reversed_fusions() -> List[Tuple[NSFusionType, int]]:
             results.append((new_pattern, default_base_op_idx))  # type: ignore[arg-type]
 
 
-    # After this point, results countains values such as
+    # After this point, results contains values such as
     # [..., ((torch.nn.Relu, torch.nn.Conv2d), 0), ...]
 
     # Patterns for matching fp16 emulation are not specified in the quantization

--- a/torch/ao/pruning/_experimental/activation_sparsifier/activation_sparsifier.py
+++ b/torch/ao/pruning/_experimental/activation_sparsifier/activation_sparsifier.py
@@ -302,7 +302,7 @@ class ActivationSparsifier:
 
     def squash_mask(self, attach_sparsify_hook=True, **kwargs):
         """
-        Unregisters aggreagate hook that was applied earlier and registers sparsification hooks if
+        Unregisters aggregate hook that was applied earlier and registers sparsification hooks if
         attach_sparsify_hook = True.
         """
         for name, configs in self.data_groups.items():

--- a/torch/ao/pruning/_experimental/data_scheduler/base_data_scheduler.py
+++ b/torch/ao/pruning/_experimental/data_scheduler/base_data_scheduler.py
@@ -149,7 +149,7 @@ class BaseDataScheduler:
             elif self.data_sparsifier._step_count < 1:  # type: ignore[attr-defined]
                 warnings.warn("Detected call of `scheduler.step()` before `data_sparsifier.step()`. "
                               "You have to make sure you run the data_sparsifier.step() BEFORE any "
-                              "calls to the scheduer.step().", UserWarning)
+                              "calls to the scheduler.step().", UserWarning)
         self._step_count += 1
 
         class _enable_get_sp_call:

--- a/torch/ao/pruning/_experimental/data_sparsifier/data_norm_sparsifier.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/data_norm_sparsifier.py
@@ -128,7 +128,7 @@ class DataNormSparsifier(BaseDataSparsifier):
         else:
             data_norm = (data * data).squeeze()  # square every element for L2
 
-        if len(data_norm.shape) > 2:  # only supports 2 dimensitional data at the moment
+        if len(data_norm.shape) > 2:  # only supports 2 dimensional data at the moment
             raise ValueError("only supports 2-D at the moment")
 
         elif len(data_norm.shape) == 1:  # in case the data is bias (or 1D)

--- a/torch/ao/pruning/_experimental/data_sparsifier/data_norm_sparsifier.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/data_norm_sparsifier.py
@@ -128,7 +128,7 @@ class DataNormSparsifier(BaseDataSparsifier):
         else:
             data_norm = (data * data).squeeze()  # square every element for L2
 
-        if len(data_norm.shape) > 2:  # only supports 2 dimenstional data at the moment
+        if len(data_norm.shape) > 2:  # only supports 2 dimensitional data at the moment
             raise ValueError("only supports 2-D at the moment")
 
         elif len(data_norm.shape) == 1:  # in case the data is bias (or 1D)

--- a/torch/ao/pruning/_experimental/data_sparsifier/lightning/callbacks/_data_sparstity_utils.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/lightning/callbacks/_data_sparstity_utils.py
@@ -6,7 +6,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 def _attach_model_to_data_sparsifier(module, data_sparsifier, config=None):
     """Attaches a data sparsifier to all the layers of the module.
-    Essentialy, loop over all the weight parameters in the module and
+    Essentially, loop over all the weight parameters in the module and
     attach it to the data sparsifier.
     Note::
         The '.' in the layer names are replaced with '_' (refer to _get_valid_name() below)

--- a/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py
+++ b/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py
@@ -285,7 +285,7 @@ class BaseStructuredSparsifier(BaseSparsifier):
                     continue
 
                 first_module = modules.get(node.target)
-                # check if first module exists and has apropriate parameterization, otherwise skip
+                # check if first module exists and has appropriate parameterization, otherwise skip
                 if (
                     first_module is not None
                     and parametrize.is_parametrized(first_module)

--- a/torch/ao/pruning/_experimental/pruner/lstm_saliency_pruner.py
+++ b/torch/ao/pruning/_experimental/pruner/lstm_saliency_pruner.py
@@ -10,13 +10,13 @@ class LSTMSaliencyPruner(BaseStructuredSparsifier):
     - weight_ih_l{k}
     - weight_hh_l{k}
 
-    These tensors pack the weights for the 4 linear layers together for efficency.
+    These tensors pack the weights for the 4 linear layers together for efficiency.
 
     [W_ii | W_if | W_ig | W_io]
 
     Pruning this tensor directly will lead to weights being misassigned when unpacked.
     To ensure that each packed linear layer is pruned the same amount:
-        1. We split the packed weight into the 4 constitutient linear parts
+        1. We split the packed weight into the 4 constituent linear parts
         2. Update the mask for each individual piece using saliency individually
 
     This applies to both weight_ih_l{k} and weight_hh_l{k}.

--- a/torch/ao/pruning/_experimental/pruner/prune_functions.py
+++ b/torch/ao/pruning/_experimental/pruner/prune_functions.py
@@ -1,6 +1,6 @@
 """
 Collection of conversion functions for linear / conv2d structured pruning
-Also contains utilities for bias propogation
+Also contains utilities for bias propagation
 """
 from typing import cast, Optional, Callable, Tuple
 
@@ -10,7 +10,7 @@ from torch.nn.utils import parametrize
 from torch.nn.utils.parametrize import ParametrizationList
 from .parametrization import FakeStructuredSparsity, BiasHook
 
-# BIAS PROPOGATION
+# BIAS PROPAGATION
 def _remove_bias_handles(module: nn.Module) -> None:
     if hasattr(module, "_forward_hooks"):
         bias_hooks = []
@@ -86,7 +86,7 @@ def _prune_module_bias(module: nn.Module, mask: Tensor) -> None:
 
 def _propogate_module_bias(module: nn.Module, mask: Tensor) -> Optional[Tensor]:
     r"""
-    In the case that we need to propogate biases, this function will return the biases we need
+    In the case that we need to propagate biases, this function will return the biases we need
     """
     # set current module bias
     if module.bias is not None:
@@ -94,7 +94,7 @@ def _propogate_module_bias(module: nn.Module, mask: Tensor) -> Optional[Tensor]:
     elif getattr(module, "_bias", None) is not None:
         module.bias = nn.Parameter(cast(Tensor, module._bias)[mask])
 
-    # get pruned biases to propogate to subsequent layer
+    # get pruned biases to propagate to subsequent layer
     if getattr(module, "_bias", None) is not None:
         pruned_biases = cast(Tensor, module._bias)[~mask]
     else:

--- a/torch/ao/pruning/scheduler/base_scheduler.py
+++ b/torch/ao/pruning/scheduler/base_scheduler.py
@@ -124,7 +124,7 @@ class BaseScheduler:
             elif self.sparsifier._step_count < 1:  # type: ignore[attr-defined]
                 warnings.warn("Detected call of `scheduler.step()` before `sparsifier.step()`. "
                               "You have to make sure you run the sparsifier.step() BEFORE any "
-                              "calls to the scheduer.step().", UserWarning)
+                              "calls to the scheduler.step().", UserWarning)
         self._step_count += 1
 
         class _enable_get_sl_call:

--- a/torch/ao/pruning/sparsifier/utils.py
+++ b/torch/ao/pruning/sparsifier/utils.py
@@ -115,7 +115,7 @@ def get_arg_info_from_tensor_fqn(model: nn.Module, tensor_fqn: str) -> Dict[str,
 # Parametrizations
 class FakeSparsity(nn.Module):
     r"""Parametrization for the weights. Should be attached to the 'weight' or
-    any other parmeter that requires a mask applied to it.
+    any other parameter that requires a mask applied to it.
 
     Note::
 

--- a/torch/ao/quantization/_equalize.py
+++ b/torch/ao/quantization/_equalize.py
@@ -160,7 +160,7 @@ def converged(curr_modules, prev_modules, threshold=1e-4):
     being less than the given threshold
 
     Takes two dictionaries mapping names to modules, the set of names for each dictionary
-    should be the same, looping over the set of names, for each name take the differnce
+    should be the same, looping over the set of names, for each name take the difference
     between the associated modules in each dictionary
 
     '''

--- a/torch/ao/quantization/backend_config/_common_operator_config_utils.py
+++ b/torch/ao/quantization/backend_config/_common_operator_config_utils.py
@@ -25,7 +25,7 @@ from ..fuser_method_mappings import (
 
 __all__: List[str] = []
 
-# TODO: rename to be more explict, e.g. qat_conv_relu
+# TODO: rename to be more explicit, e.g. qat_conv_relu
 _ConvMetadata = namedtuple(
     "_ConvMetadata",
     ["root", "transpose", "bn", "reference", "transpose_reference",

--- a/torch/ao/quantization/fuse_modules.py
+++ b/torch/ao/quantization/fuse_modules.py
@@ -4,7 +4,7 @@ import copy
 import torch.nn as nn
 
 from torch.ao.quantization.fuser_method_mappings import get_fuser_method
-# for backward compatiblity
+# for backward compatibility
 from torch.ao.quantization.fuser_method_mappings import fuse_conv_bn  # noqa: F401
 from torch.ao.quantization.fuser_method_mappings import fuse_conv_bn_relu  # noqa: F401
 from torch.nn.utils.parametrize import type_before_parametrizations

--- a/torch/ao/quantization/fuser_method_mappings.py
+++ b/torch/ao/quantization/fuser_method_mappings.py
@@ -235,7 +235,7 @@ def _get_valid_patterns(op_pattern):
 def get_fuser_method_new(
         op_pattern: Pattern,
         fuser_method_mapping: Dict[Pattern, Union[nn.Sequential, Callable]]):
-    """ This will be made defult after we deprecate the get_fuser_method
+    """ This will be made default after we deprecate the get_fuser_method
     Would like to implement this first and have a separate PR for deprecation
     """
     op_patterns = _get_valid_patterns(op_pattern)

--- a/torch/ao/quantization/fx/_decomposed.py
+++ b/torch/ao/quantization/fx/_decomposed.py
@@ -80,14 +80,14 @@ def quantize_per_tensor_tensor(
     Same as `quantize_per_tensor` but scale and zero_point are Scalar Tensor instead of
     scalar values
     """
-    assert zero_point.numel() == 1, f"Exepecting zero_point tensor to be one element, but received : {zero_point.numel()}"
-    assert scale.numel() == 1, f"Exepecting scale tensor to be one element, but received : {scale.numel()}"
+    assert zero_point.numel() == 1, f"Expecting zero_point tensor to be one element, but received : {zero_point.numel()}"
+    assert scale.numel() == 1, f"Expecting scale tensor to be one element, but received : {scale.numel()}"
     return quantize_per_tensor(input, scale.item(), zero_point.item(), quant_min, quant_max, dtype)
 
 @impl(quantized_decomposed_lib, "quantize_per_tensor.tensor", "Meta")
 def quantize_per_tensor_tensor_meta(input, scale, zero_point, quant_min, quant_max, dtype):
-    assert zero_point.numel() == 1, f"Exepecting zero_point tensor to be one element, but received : {zero_point.numel()}"
-    assert scale.numel() == 1, f"Exepecting scale tensor to be one element, but received : {scale.numel()}"
+    assert zero_point.numel() == 1, f"Expecting zero_point tensor to be one element, but received : {zero_point.numel()}"
+    assert scale.numel() == 1, f"Expecting scale tensor to be one element, but received : {scale.numel()}"
     assert input.dtype == torch.float32, f"Expecting input to have dtype torch.float32, but got dtype: {input.dtype}"
     _quant_min_max_bounds_check(quant_min, quant_max, dtype)
     return torch.empty_like(input, dtype=dtype)
@@ -161,14 +161,14 @@ def dequantize_per_tensor_tensor(
     Same as `dequantize_per_tensor` but scale and zero_point are Scalar Tensor instead of
     scalar values
     """
-    assert zero_point.numel() == 1, f"Exepecting zero_point tensor to be one element, but received : {zero_point.numel()}"
-    assert scale.numel() == 1, f"Exepecting scale tensor to be one element, but received : {scale.numel()}"
+    assert zero_point.numel() == 1, f"Expecting zero_point tensor to be one element, but received : {zero_point.numel()}"
+    assert scale.numel() == 1, f"Expecting scale tensor to be one element, but received : {scale.numel()}"
     return dequantize_per_tensor(input, scale.item(), zero_point.item(), quant_min, quant_max, dtype)
 
 @impl(quantized_decomposed_lib, "dequantize_per_tensor.tensor", "Meta")
 def dequantize_per_tensor_tensor_meta(input, scale, zero_point, quant_min, quant_max, dtype):
-    assert zero_point.numel() == 1, f"Exepecting zero_point tensor to be one element, but received : {zero_point.numel()}"
-    assert scale.numel() == 1, f"Exepecting scale tensor to be one element, but received : {scale.numel()}"
+    assert zero_point.numel() == 1, f"Expecting zero_point tensor to be one element, but received : {zero_point.numel()}"
+    assert scale.numel() == 1, f"Expecting scale tensor to be one element, but received : {scale.numel()}"
     assert input.dtype == dtype, f"Expecting input to have dtype: {dtype}"
     if dtype in [torch.uint8, torch.int8, torch.int32]:
         return torch.empty_like(input, dtype=torch.float32)

--- a/torch/ao/quantization/fx/_equalize.py
+++ b/torch/ao/quantization/fx/_equalize.py
@@ -280,11 +280,11 @@ def get_op_node_and_weight_eq_obs(
     """ Gets the following weight equalization observer. There should always
     exist a weight equalization observer after an input equalization observer.
 
-    Returns the operation node that follows the input equalizatoin observer node
+    Returns the operation node that follows the input equalization observer node
     and the weight equalization observer
     """
 
-    # Find the op node that comes directly after the input equaliation observer
+    # Find the op node that comes directly after the input equalization observer
     op_node = None
     for user in input_eq_obs_node.users.keys():
         if node_supports_equalization(user, modules):

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -755,7 +755,7 @@ def _lower_weight_only_weighted_ref_module(model: GraphModule):
         # TODO: maybe define a WeightedWeightOnlyQuantizedModule
         q_module = q_class.from_reference(ref_module)  # type: ignore[union-attr]
 
-        # replace reference moduel with dynamically quantized module
+        # replace reference module with dynamically quantized module
         parent_name, module_name = _parent_name(ref_node.target)
         setattr(named_modules[parent_name], module_name, q_module)
 
@@ -981,7 +981,7 @@ def _lower_quantized_binary_op(
         assert bop_node.target in QBIN_OP_MAPPING
         binop_to_qbinop = QBIN_OP_MAPPING if relu_node is None else QBIN_RELU_OP_MAPPING
         qbin_op = binop_to_qbinop[bop_node.target]
-        # prepare the args for quantized bianry op
+        # prepare the args for quantized binary op
         # (x, y)
         qop_node_args = list(bop_node.args)
         # (x, y, scale, zero_point)

--- a/torch/ao/quantization/fx/_model_report/detector.py
+++ b/torch/ao/quantization/fx/_model_report/detector.py
@@ -144,7 +144,7 @@ class DetectorBase(ABC):
 
     @abstractmethod
     def get_qconfig_info(self, model) -> Dict[str, DetectorQConfigInfo]:
-        r""" Returns the DetectorQConfigInfo for each module_fqn relavent
+        r""" Returns the DetectorQConfigInfo for each module_fqn relevant
         Args
             model (nn.Module or subclass): model to find observer insertion points
 
@@ -241,7 +241,7 @@ class PerChannelDetector(DetectorBase):
         return "per_channel_detector"
 
     def get_qconfig_info(self, model) -> Dict[str, DetectorQConfigInfo]:
-        r""" Returns the DetectorQConfigInfo for each module_fqn relavent
+        r""" Returns the DetectorQConfigInfo for each module_fqn relevant
         Args
             model (nn.Module or subclass): model to find observer insertion points
 
@@ -483,7 +483,7 @@ class DynamicStaticDetector(DetectorBase):
 
 
     def get_qconfig_info(self, model) -> Dict[str, DetectorQConfigInfo]:
-        r""" Returns the DetectorQConfigInfo for each module_fqn relavent
+        r""" Returns the DetectorQConfigInfo for each module_fqn relevant
         Args
             model (nn.Module or subclass): model to find observer insertion points
 
@@ -553,7 +553,7 @@ class DynamicStaticDetector(DetectorBase):
         # store modules dynamic vs static information
         module_dynamic_static_info = {}
 
-        # This for loop goes through the modules, and extracts all relavent information into module_dynamic_static_info
+        # This for loop goes through the modules, and extracts all relevant information into module_dynamic_static_info
         #   This information primary includes whether the data distributions around a supported module is stationary or not
         #   Based on this, it is recorded whether dynamic or static quantization is recommended
 
@@ -638,7 +638,7 @@ class DynamicStaticDetector(DetectorBase):
         future_support_str = ". This layer is not yet supported for dynamic quantization"
         # This for loop goes through the information collected in module_dynamic_static_info and:
         #   Populates the string based report with the information from module_dynamic_static_info
-        #   Compiles the complete report by appending relavent formatted strings
+        #   Compiles the complete report by appending relevant formatted strings
 
         for module_fqn in module_dynamic_static_info.keys():
 
@@ -722,12 +722,12 @@ class InputWeightEqualizationDetector(DetectorBase):
         if s_c >= threshold or <= 1 / threshold, recommends input-weight equalization
 
     Args:
-        ratio_threshold (float): The threshold for s_c to determine if input-weight equalization is sugggested
+        ratio_threshold (float): The threshold for s_c to determine if input-weight equalization is suggested
             Should be between 0 and 1 (both non-inclusive)
         ch_axis (int, optional): The channel axis being observed to determine input weight equalization
             Default: 1
 
-    * :attr:`ratio_threshold`: The threshold for s_c to determine if input-weight equalization is sugggested
+    * :attr:`ratio_threshold`: The threshold for s_c to determine if input-weight equalization is suggested
         Should be between 0 and 1
 
     * :attr:`ch_axis`: The channel axis being observed to determine input weight equalization
@@ -777,7 +777,7 @@ class InputWeightEqualizationDetector(DetectorBase):
         if ratio_threshold <= 0 or ratio_threshold >= 1:
             raise ValueError("Make sure threshold is > 0 and < 1")
 
-        # intialize attributes based on args
+        # initialize attributes based on args
         self.ratio_threshold: float = ratio_threshold
         self.ch_axis: int = ch_axis
 
@@ -802,7 +802,7 @@ class InputWeightEqualizationDetector(DetectorBase):
             return is_supported_type and has_obs
 
     def get_qconfig_info(self, model) -> Dict[str, DetectorQConfigInfo]:
-        r""" Returns the DetectorQConfigInfo for each module_fqn relavent
+        r""" Returns the DetectorQConfigInfo for each module_fqn relevant
         Args
             model (nn.Module or subclass): model to find observer insertion points
 
@@ -890,7 +890,7 @@ class InputWeightEqualizationDetector(DetectorBase):
         Args
             model (GraphModule): The prepared and calibrated GraphModule with inserted ModelReportObservers
 
-        Returns a dict mapping relavent module fqns (str) to a dict with keys:
+        Returns a dict mapping relevant module fqns (str) to a dict with keys:
             "input_activation_per_channel_max" : maps to the per_channel max values
             "input_activation_per_channel_min" : maps to the per_channel min values
             "input_activation_global_max" : maps to the global max recorded
@@ -917,7 +917,7 @@ class InputWeightEqualizationDetector(DetectorBase):
 
     def _extract_weight_info(self, model: GraphModule) -> Dict[str, Dict]:
         r"""
-        Takes in a calibrated GraphModule and then finds the relavent observers.
+        Takes in a calibrated GraphModule and then finds the relevant observers.
         It then extracts the weight information for each layer an observer is attached to.
 
         Args
@@ -1007,7 +1007,7 @@ class InputWeightEqualizationDetector(DetectorBase):
             input_info (dict): A dict mapping each observer to input range information
             weight_info (dict): A dict mapping each observer to weight range information
 
-        Returns a dict mapping relavent observer fqns (str) to a 1-D tensor.
+        Returns a dict mapping relevant observer fqns (str) to a 1-D tensor.
             Each value is a different s_c value for a different channel
         """
         # create return dictionary for each observer
@@ -1053,7 +1053,7 @@ class InputWeightEqualizationDetector(DetectorBase):
             weight_info (dict): A dict mapping each module to weight range information
             comp_stats (dict): A dict mapping each module to its corresponding comp stat
 
-        Returns a dictionary mapping each module with relavent ModelReportObservers around them to:
+        Returns a dictionary mapping each module with relevant ModelReportObservers around them to:
             whether input weight equalization is recommended
             their s_c metric compared to the threshold
             the threshold used to make the recommendation
@@ -1067,7 +1067,7 @@ class InputWeightEqualizationDetector(DetectorBase):
         # for each module we add separate set of suggestions
         for module_fqn in input_info:
 
-            # get relavent info for this module
+            # get relevant info for this module
             mod_input_info: Dict = input_info[module_fqn]
             mod_weight_info: Dict = weight_info[module_fqn]
             mod_comp_stat: Dict = comp_stats[module_fqn]
@@ -1280,7 +1280,7 @@ class OutlierDetector(DetectorBase):
         return num_children == 0 and not _is_activation_post_process(module)
 
     def get_qconfig_info(self, model) -> Dict[str, DetectorQConfigInfo]:
-        r""" Returns the DetectorQConfigInfo for each module_fqn relavent
+        r""" Returns the DetectorQConfigInfo for each module_fqn relevant
         Args
             model (nn.Module or subclass): model to find observer insertion points
 
@@ -1390,7 +1390,7 @@ class OutlierDetector(DetectorBase):
         Args:
             model (GraphModule): The prepared and calibrated GraphModule with inserted ModelReportObservers
 
-        Returns a dict mapping relavent module fqns to:
+        Returns a dict mapping relevant module fqns to:
             whether there were outliers found in activation before
             the number of batches used for each channel
             whether fraction of applicable batches used is above fraction_batches_used_threshold
@@ -1454,7 +1454,7 @@ class OutlierDetector(DetectorBase):
         r"""
         Determines whether input weight equalization is appropriate for a given module.
 
-        Takes advantage of the ModelReport Observer which records the relavent percentile information
+        Takes advantage of the ModelReport Observer which records the relevant percentile information
 
         Args:
             model (GraphModule): The prepared and calibrated GraphModule with inserted ModelReportObservers

--- a/torch/ao/quantization/fx/_model_report/model_report.py
+++ b/torch/ao/quantization/fx/_model_report/model_report.py
@@ -20,7 +20,7 @@ class ModelReport:
     The ModelReport class aims to provide users an easy way to diagnose issues that they run into
     with their models. The class works with all traceable GraphModules to help diagnose issues,
     though the requirements on the type of model more-so depends on the specific report the user
-    is trying to generate. With respect to the reports, the ModelReport class is intialized with
+    is trying to generate. With respect to the reports, the ModelReport class is initialized with
     a set of Detector classes, each of which generate reports on quantization configuration
     issues a use might have.
 
@@ -64,7 +64,7 @@ class ModelReport:
     General Flow for Fx workflow:
     1.) Initialize ModelReport object with reports of interest by passing in initialized detector objects and model
     2.) Prepare your model with prepare_fx
-    3.) Call model_report.prepare_detailed_calibration to add relavent observers
+    3.) Call model_report.prepare_detailed_calibration to add relevant observers
     4.) Callibrate your model with data
     5.) Call model_report.generate_report on your model to generate report and optionally remove added observers
     Optional
@@ -136,7 +136,7 @@ class ModelReport:
         self._removed_observers = False
 
         # store the reports that we generated for visualization purposes
-        # intially empty since no reports generated
+        # initially empty since no reports generated
         self._generated_reports: Dict[str, Dict] = {}
 
     def get_desired_reports_names(self) -> Set[str]:
@@ -152,7 +152,7 @@ class ModelReport:
         Takes in a graph model and inserts the following observers:
         - ModelReportObserver
 
-        Each observer is inserted based on the desired_reports into the relavent locations
+        Each observer is inserted based on the desired_reports into the relevant locations
 
         Right now, each report in self._desired_detector_names has independent insertions
             However, if a module already has a Observer of the same type, the insertion will not occur
@@ -250,7 +250,7 @@ class ModelReport:
         Generates all the requested reports.
 
         Note:
-            You should have callibrated the model with relavent data before calling this
+            You should have callibrated the model with relevant data before calling this
 
         The reports generated are specified by the desired_reports specified in desired_reports
 
@@ -261,7 +261,7 @@ class ModelReport:
 
         Returns a mapping of each desired report name to a tuple with:
             The textual summary of that report information
-            A dictionary containing relavent statistics or information for that report
+            A dictionary containing relevant statistics or information for that report
 
         Note:
             Throws exception if we try to generate report on model we already removed observers from

--- a/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
+++ b/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
@@ -58,7 +58,7 @@ class ModelReportVisualizer:
     General Use Flow Expected
     1.) Initialize ModelReport object with reports of interest by passing in initialized detector objects
     2.) Prepare your model with prepare_fx
-    3.) Call model_report.prepare_detailed_calibration on your model to add relavent observers
+    3.) Call model_report.prepare_detailed_calibration on your model to add relevant observers
     4.) Callibrate your model with data
     5.) Call model_report.generate_report on your model to generate report and optionally remove added observers
     6.) Use output of model_report.generate_report to initialize ModelReportVisualizer instance
@@ -132,7 +132,7 @@ class ModelReportVisualizer:
 
     def _get_filtered_data(self, feature_filter: str, module_fqn_filter: str) -> OrderedDict[str, Any]:
         r"""
-        Filters the data and returns it in the same ordered dictionary format so the relavent views can be displayed.
+        Filters the data and returns it in the same ordered dictionary format so the relevant views can be displayed.
 
         Args:
             feature_filter (str): The feature filter, if we want to filter the set of data to only include
@@ -430,11 +430,11 @@ class ModelReportVisualizer:
         # ex. table index, module name, channel index, etc.
         # we want to look at header columns for features, that come after those headers
         if len(tensor_headers) > self.NUM_NON_FEATURE_TENSOR_HEADERS:
-            # if we have at least one tensor level feature to be addded we add tensor table
+            # if we have at least one tensor level feature to be added we add tensor table
             table_str += "Tensor Level Information \n"
             table_str += tabulate(tensor_table, headers=tensor_headers)
         if len(channel_headers) > self.NUM_NON_FEATURE_CHANNEL_HEADERS:
-            # if we have at least one channel level feature to be addded we add tensor table
+            # if we have at least one channel level feature to be added we add tensor table
             table_str += "\n\n Channel Level Information \n"
             table_str += tabulate(channel_table, headers=channel_headers)
 
@@ -454,7 +454,7 @@ class ModelReportVisualizer:
             module_fqn_filter (str): Only includes modules that contains this string
 
         Returns a tuple of three elements
-            The first is a list containing relavent x-axis data
+            The first is a list containing relevant x-axis data
             The second is a list containing the corresponding y-axis data
             If the data is per channel
         """
@@ -504,7 +504,7 @@ class ModelReportVisualizer:
             for table_row_num, row in enumerate(table):
                 # get x_value to append
                 x_val_to_append = table_row_num
-                current_channel = row[self.CHANNEL_NUM_INDEX]  # intially chose current channel
+                current_channel = row[self.CHANNEL_NUM_INDEX]  # initially chose current channel
                 new_module_index: int = table_row_num // num_channels
                 x_val_to_append = new_module_index
 
@@ -534,7 +534,7 @@ class ModelReportVisualizer:
 
         For per channel features, it averages the value across the channels and plots a point
         per module. The reason for this is that for models with hundreds of channels, it can
-        be hard to diffrentiate one channel line from another, and so the point of generating
+        be hard to differentiate one channel line from another, and so the point of generating
         a single average point per module is to give a sense of general trends that encourage
         further deep dives.
 

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -114,7 +114,7 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
         _has_none_qconfig(n, node_name_to_qconfig) for n in
         list(node.args) + list(node.users.keys())])
     if skip_replacement or not _is_conversion_supported(activation_post_process):
-        # didn't find correponding quantize op and info for the activation_post_process
+        # didn't find corresponding quantize op and info for the activation_post_process
         # so we just remove the observer
         with graph.inserting_before(node):
             node.replace_all_uses_with(node.args[0])
@@ -302,7 +302,7 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
     elif dtype == torch.float16:
         raise NotImplementedError("decomposed to float16 op not implemented yet")
 
-    # should not reach since we have checks in the begining to make sure the
+    # should not reach since we have checks in the beginning to make sure the
     # activation_post_process is supported
 
 def _replace_observer_with_quantize_dequantize_node(
@@ -330,7 +330,7 @@ def _replace_observer_with_quantize_dequantize_node(
         _has_none_qconfig(n, node_name_to_qconfig) for n in
         list(node.args) + list(node.users.keys())])
     if skip_replacement or not _is_conversion_supported(activation_post_process):
-        # didn't find correponding quantize op and info for the activation_post_process
+        # didn't find corresponding quantize op and info for the activation_post_process
         # so we just remove the observer
         with graph.inserting_before(node):
             node.replace_all_uses_with(node.args[0])
@@ -425,7 +425,7 @@ def _replace_observer_with_quantize_dequantize_node(
             node.replace_all_uses_with(dequantized_node)
             graph.erase_node(node)
 
-    # should not reach since we have checks in the begining to make sure the
+    # should not reach since we have checks in the beginning to make sure the
     # activation_post_process is supported
 
 # this is a temporary hack for custom module, we may want to implement
@@ -662,7 +662,7 @@ def convert_weighted_module(
     if isinstance(
             original_module,
             qat_module_classes):
-        # Converting qat module to a float module, we need to attch
+        # Converting qat module to a float module, we need to attach
         # weight fake_quant to the module, weight fake_quant is assumed to be run during
         # QAT so we don't need to run it again here
         weight_post_process = original_module.weight_fake_quant
@@ -692,7 +692,7 @@ def convert_weighted_module(
 
     fused_module = None
     float_module = original_module
-    # extract the inidividual float_module and fused module
+    # extract the individual float_module and fused module
     if isinstance(original_module, torch.ao.nn.intrinsic._FusedModule):
         fused_module = float_module
         float_module = fused_module[0]  # type: ignore[index]
@@ -989,7 +989,7 @@ def convert(
             cur_placeholder_node_idx = placeholder_node_seen_cnt
             placeholder_node_seen_cnt += 1
             if cur_placeholder_node_idx in input_quantized_idxs:
-                # Inputs are assumed to be quantized if the user specifid the
+                # Inputs are assumed to be quantized if the user specified the
                 # input_quantized_idxs override.
                 # we need to dequantize the inputs since all operators took
                 # floating point inputs in reference quantized models

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -958,7 +958,7 @@ def propagate_dtypes_for_known_nodes(
                     arg_list = [arg]
 
                 for cur_arg in arg_list:
-                    # hard coded arguments show up but aren't `Node` typed and do not need dtype propgated
+                    # hard coded arguments show up but aren't `Node` typed and do not need dtype propagated
                     if isinstance(cur_arg, torch.fx.node.Node):
                         _maybe_propagate_dtype_for_node(
                             cur_arg, arg_type, node_name_to_match_result_with_qconfig)
@@ -1151,7 +1151,7 @@ def insert_observers_for_model(
     input_quantized_idxs: List[int] = prepare_custom_config.input_quantized_indexes
     output_quantized_idxs: List[int] = prepare_custom_config.output_quantized_indexes
     processed_nodes: Set[Node] = set()
-    # initalize target_dtype_info
+    # initialize target_dtype_info
     for node in model.graph.nodes:
         node.meta["target_dtype_info"] = copy.copy(_DEFAULT_FP32_QCONFIG_FOR_TARGET_DTYPE_INFO)
 

--- a/torch/ao/quantization/fx/qconfig_mapping_utils.py
+++ b/torch/ao/quantization/fx/qconfig_mapping_utils.py
@@ -137,7 +137,7 @@ def _generate_node_name_to_qconfig(
             module_path, module_type = node_name_to_scope[node.name]
             # first use node.target (string) to get the qconfig
             # this is to support configs like
-            # "object_type": [("reshpe", qconfig)]
+            # "object_type": [("reshape", qconfig)]
             qconfig = _maybe_adjust_qconfig_for_module_type_or_name(
                 qconfig_mapping, node.target, module_path, global_qconfig)
             # if there is no special config for the method, we'll fall back to the

--- a/torch/ao/quantization/fx/utils.py
+++ b/torch/ao/quantization/fx/utils.py
@@ -209,7 +209,7 @@ def graph_module_from_producer_nodes(
       A graph module constructed from the producer nodes
     '''
     assert len(producer_nodes) > 0, 'list of producer nodes can not be empty'
-    # since we traced back from node to getattrr
+    # since we traced back from node to getattr
     producer_nodes.reverse()
     graph = Graph()
     env: Dict[Any, Any] = {}
@@ -520,7 +520,7 @@ def _insert_dequant_stubs_for_custom_module_lstm_output(
     """
     Insert DeQuantStubs after each internal output node of custom module LSTM.
 
-    Custom module LSTM outputs are nested tuples of the sturcture (output, (hidden0, hidden1)),
+    Custom module LSTM outputs are nested tuples of the structure (output, (hidden0, hidden1)),
     Since we cannot dequantize a tuple as a whole, we must first break down the tuple into its
     components through `getitem`. This function transforms the graph as follows:
 

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -1115,7 +1115,7 @@ class HistogramObserver(UniformQuantizationObserverBase):
         Nbins: int,
     ) -> torch.Tensor:
         # First up-sample the histogram with new data by a factor of L
-        # This creates an approximate probability density thats piecwise constant
+        # This creates an approximate probability density thats piecewise constant
         upsampled_histogram = new_hist.repeat_interleave(upsample_rate)
         # Now insert the upsampled histogram into the output
         # histogram, which is initialized with zeros.

--- a/torch/ao/quantization/quantize.py
+++ b/torch/ao/quantization/quantize.py
@@ -209,7 +209,7 @@ def _add_observer_(module, qconfig_propagation_list=None, non_leaf_module_list=N
             if needs_observation(child):
                 child.activation_post_process = get_activation_post_process(child.qconfig, device)
         elif isinstance(child, _FusedModule):
-            # activation_post_process are now added directly to nn.Sequentail/_FusedModule
+            # activation_post_process are now added directly to nn.Sequential/_FusedModule
             if needs_observation(child):
                 insert_activation_post_process(child)
         elif non_leaf_module_list is not None and type_before_parametrizations(child) in non_leaf_module_list:
@@ -323,7 +323,7 @@ def _remove_activation_post_process(module):
        _is_activation_post_process(module.activation_post_process):
         delattr(module, 'activation_post_process')
 
-    # remove activation_post_proceess pre and post hooks
+    # remove activation_post_process pre and post hooks
     def remove_hooks(pre_hook=False):
         hook_map = module._forward_pre_hooks if pre_hook else module._forward_hooks
         observer_hook = _observer_forward_pre_hook if pre_hook else _observer_forward_hook

--- a/torch/ao/quantization/quantize_fx.py
+++ b/torch/ao/quantization/quantize_fx.py
@@ -610,7 +610,7 @@ def convert_to_reference_fx(
 ) -> torch.nn.Module:
     r""" Convert a calibrated or trained model to a reference quantized model,
     see https://github.com/pytorch/rfcs/blob/master/RFC-0019-Extending-PyTorch-Quantization-to-Custom-Backends.md for more details,
-    reference quantzied model is a standard representation of a quantized model provided
+    reference quantized model is a standard representation of a quantized model provided
     by FX Graph Mode Quantization, it can be further lowered to run on the target
     hardware, like accelerators
 
@@ -660,7 +660,7 @@ def _convert_to_reference_decomposed_fx(
     r""" Convert a calibrated or trained model to a reference quantized model, with
     decomposed representation for quantized Tensor
     see https://github.com/pytorch/rfcs/blob/master/RFC-0019-Extending-PyTorch-Quantization-to-Custom-Backends.md for more details,
-    reference quantzied model is a standard representation of a quantized model provided
+    reference quantized model is a standard representation of a quantized model provided
     by FX Graph Mode Quantization, it can be further lowered to run on the target
     hardware, like accelerators
 

--- a/torch/ao/quantization/quantize_jit.py
+++ b/torch/ao/quantization/quantize_jit.py
@@ -254,7 +254,7 @@ def quantize_dynamic_jit(model, qconfig_dict, inplace=False, debug=False):
     ```python
     import torch
     from torch.ao.quantization import per_channel_dynamic_qconfig
-    from torch.ao.quantization import quantize_dynmiac_jit
+    from torch.ao.quantization import quantize_dynamic_jit
 
     ts_model = torch.jit.script(float_model.eval())  # or torch.jit.trace(float_model, input)
     qconfig = get_default_qconfig('fbgemm')

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -603,7 +603,7 @@ def get_fqn_to_example_inputs(
     e.g. {"linear1": (tensor1,), "linear2": (tensor2,), "sub": (tensor3,),
           "sub.linear1": (tensor4,), ...}
 
-    Used to make quantizing submodules easier now that FX Graph Mode Quantization requries
+    Used to make quantizing submodules easier now that FX Graph Mode Quantization requires
     example inputs.
 
     Also works for keyword arguments with default values, we would flatten keyword


### PR DESCRIPTION
This PR fixes typos in comments and messages of `.py` files under `torch/ao` directory
