### PR TITLE
[fx] Replace literals with placeholder helper

### DIFF
--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -5,10 +5,11 @@ import sys
 
 import torch
 from torch.fx import symbolic_trace
+from torch.fx.experimental.proxy_tensor import make_fx
 
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
-from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
+from torch.fx.passes.utils.matcher_utils import SubgraphMatcher, replace_literals_with_placeholders
 from torch.testing._internal.jit_utils import JitTestCase
 
 class TestMatcher(JitTestCase):
@@ -72,3 +73,76 @@ class TestMatcher(JitTestCase):
         subgraph_matcher = SubgraphMatcher(pattern_graph)
         match_result = subgraph_matcher.match(original_graph)
         self.assertEqual(len(match_result), 0)
+	
+
+    def check_replace_literals(self, f, inputs, expected_num_placeholders):
+        gm = make_fx(f)(*inputs)
+        graph = replace_literals_with_placeholders(gm.graph)
+
+        num_placeholder = 0
+        for node in graph.nodes:
+            if node.op == "placeholder":
+                num_placeholder += 1
+        self.assertEqual(num_placeholder, expected_num_placeholders)
+
+    def test_replace_literals_regular(self):
+        """
+        Tests replacing literals with placeholders in the case where there are
+        no literals to replace.
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                return x + y
+
+        inputs = (torch.randn(3, 5), torch.randn(3, 5))
+        self.check_replace_literals(M(), inputs, 2)
+
+    def test_replace_literals_args(self):
+        """
+        Tests replacing literals with placeholders in the case where args are
+        literals
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 16, 3)
+
+            def forward(self, x):
+                return self.conv(x)
+
+        inputs = (torch.randn(1, 3, 256, 256),)
+        self.check_replace_literals(M(), inputs, 7)
+
+    def test_replace_literals_kwargs(self):
+        """
+        Tests replacing literals with placeholders in the case where kwargs are
+        literals. This also contains a `getattr` node which should not be
+        modified.
+        """
+
+        def f(x: torch.Tensor, batch1: torch.Tensor, batch2: torch.Tensor) -> torch.Tensor:
+            return torch.addbmm(x, batch1, batch2, alpha=2, beta=3)
+
+        inputs = (torch.randn(3, 5), torch.randn(10, 3, 4), torch.randn(10, 4, 5))
+        self.check_replace_literals(f, inputs, 5)
+
+    def test_replace_literals_linear(self):
+        """
+        Tests replacing literals with placeholders in the case there are
+        `getitem` calls which do not have a schema.
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.split(x, 10)
+
+        inputs = (torch.randn(10),)
+        self.check_replace_literals(M(), inputs, 3)

--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -73,7 +73,7 @@ class TestMatcher(JitTestCase):
         subgraph_matcher = SubgraphMatcher(pattern_graph)
         match_result = subgraph_matcher.match(original_graph)
         self.assertEqual(len(match_result), 0)
-	
+
 
     def check_replace_literals(self, f, inputs, expected_num_placeholders):
         gm = make_fx(f)(*inputs)

--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -76,12 +76,13 @@ class TestMatcher(JitTestCase):
 
     def test_subgraph_matcher_ignore_literals(self):
         def original(x):
-            return torch.nn.Linear(3, 3).eval()(x)
+            return x + 1
+
         original_graph = make_fx(original)(torch.ones(3, 3)).graph
         original_graph.eliminate_dead_code()
 
         def pattern(x):
-            return torch.nn.Linear(4, 5).eval()(x)
+            return x + 2
         pattern_graph = make_fx(pattern)(torch.ones(4, 4)).graph
         pattern_graph.eliminate_dead_code()
 

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Set, Any, Union, Tuple
 import logging
 import os
 
-__all__ = ['SubgraphMatcher', 'InternalMatch', 'replace_literals_with_placeholders']
+__all__ = ['SubgraphMatcher', 'InternalMatch']
 
 # Set`PYTORCH_MATCHER_LOGLEVEL=INFO` to see debug logs
 def _init_logger():
@@ -52,7 +52,8 @@ class SubgraphMatcher:
     def __init__(self, pattern: Graph,
                  match_output: bool = False,
                  match_placeholder: bool = False,
-                 remove_overlapping_matches: bool = True) -> None:
+                 remove_overlapping_matches: bool = True,
+                 ignore_literals: bool = False) -> None:
         """
         Args:
             pattern: the targeted matching pattern, represented in fx.Graph.
@@ -62,12 +63,15 @@ class SubgraphMatcher:
                 the targeted pattern. If False, placeholder nodes will be used a wildcard.
             remove_overlapping_matches: If True, in the case of overlapping matches, only the first match
                 will be returned.
+            ignore_literals: If True, will not check if literals are equal and
+                will instead treat them as wildcards.
         """
 
         self.pattern = pattern
         self.match_output = match_output
         self.match_placeholder = match_placeholder
         self.remove_overlapping_matches = remove_overlapping_matches
+        self.ignore_literals = ignore_literals
 
         if len(pattern.nodes) == 0:
             raise ValueError("SubgraphMatcher cannot be initialized with an empty pattern")
@@ -217,7 +221,8 @@ class SubgraphMatcher:
                 elif isinstance(a1, (list, tuple)) and isinstance(a2, (list, tuple)):
                     matched = _match_args(a1, a2)
                 else:
-                    matched = self._match_literals(a1, a2, match)
+                    if not self.ignore_literals:
+                        matched = self._match_literals(a1, a2, match)
 
                 if not matched:
                     return False
@@ -350,52 +355,3 @@ class SubgraphMatcher:
         logger.info(f"Matches returned: {matches}")
 
         return matches
-
-
-@compatibility(is_backward_compatible=False)
-def replace_literals_with_placeholders(graph: torch.fx.Graph) -> torch.fx.Graph:
-    """
-    Replaces all the literals that are passed into call_function nodes in the
-    graph as placeholders in the graph. This way during matching these literals
-    will not be compared and will instead be wildcards.
-
-    Note that after this pass the graph module might no longer runnable since
-    we add new arguments/placeholders which can also cause a misalignment
-    between the in_spec and the actual inputs to the graph.
-    """
-    last_placeholder = None  # Place to insert more placeholder nodes
-    for node in graph.nodes:
-        if node.op != "call_function":
-            if node.op == "placeholder":
-                last_placeholder = node
-            continue
-
-        with graph.inserting_after(last_placeholder):
-            if hasattr(node.target, "_schema"):
-                schemas = node.target._schema.arguments
-            else:
-                schemas = None
-
-            args_mapped = []
-            for i, arg in enumerate(node.args):
-                if not isinstance(arg, torch.fx.Node):
-                    # Create a placeholder node
-                    name = schemas[i].name if schemas is not None else "ph"
-                    new_placeholder = graph.placeholder(name)
-                    args_mapped.append(new_placeholder)
-                else:
-                    args_mapped.append(arg)
-
-            kwargs_mapped = {}
-            for kw, arg in node.kwargs.items():
-                if not isinstance(arg, torch.fx.Node):
-                    # Create a placeholder node
-                    new_placeholder = graph.placeholder(kw)
-                    kwargs_mapped[kw] = new_placeholder
-                else:
-                    kwargs_mapped[kw] = arg
-
-        node.args = tuple(args_mapped)
-        node.kwargs = kwargs_mapped
-
-    return graph


### PR DESCRIPTION
Helper function to replace literals that show up in call_function nodes in the graph to become placeholders so that they can be represented as wildcards when matching with the SubgraphMatcher. This pass causes the resulting graph to not be runnable with the original inputs since adding placeholders to the graph will change the number of inputs needed for the graph.

Test: `python test/test_fx.py TestMatcher`

Fixes #ISSUE_NUMBER
