### PR TITLE
Fix NumPy scalar arrays to tensor conversion

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3952,7 +3952,7 @@ class TestAsArray(TestCase):
         zerodim_arr = np.array(1.)
         tensor = torch.asarray(zerodim_arr, dtype=torch.int32)
         self.assertEqual(tensor.dim(), 0)
-        self.assertEqual(tensor.item(), scalar.item())
+        self.assertEqual(tensor.item(), zerodim_arr.item())
         self.assertEqual(tensor.dtype, torch.int32)
 
 

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3948,6 +3948,13 @@ class TestAsArray(TestCase):
         self.assertEqual(tensor.dim(), 0)
         self.assertEqual(tensor.item(), scalar.item())
         self.assertEqual(tensor.dtype, torch.float64)
+        # Regression test for https://github.com/pytorch/pytorch/issues/97021
+        zerodim_arr = np.array(1.)
+        tensor = torch.asarray(zerodim_arr, dtype=torch.int32)
+        self.assertEqual(tensor.dim(), 0)
+        self.assertEqual(tensor.item(), scalar.item())
+        self.assertEqual(tensor.dtype, torch.int32)
+
 
 instantiate_device_type_tests(TestTensorCreation, globals())
 instantiate_device_type_tests(TestRandomTensorCreation, globals())

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -1635,7 +1635,10 @@ Tensor asarray(
       THPObjectPtr ptr;
       auto arr = obj;
 
-      if (is_numpy_scalar) {
+      // According to https://numpy.org/devdocs/reference/c-api/array.html#c.PyArray_CheckScalar
+      // is_numpy_scalar evaluates to true for new scalars and 0-dim arrays.
+      // For 0-dim arrays no casting is needed
+      if (is_numpy_scalar && !is_numpy_array) {
         TORCH_CHECK(
             !force_alias,
             "can't alias NumPy scalars. ",

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -1635,9 +1635,9 @@ Tensor asarray(
       THPObjectPtr ptr;
       auto arr = obj;
 
-      // According to https://numpy.org/devdocs/reference/c-api/array.html#c.PyArray_CheckScalar
-      // is_numpy_scalar evaluates to true for new scalars and 0-dim arrays.
-      // For 0-dim arrays no casting is needed
+      // PyArray_CheckScalar is true for both scalars and 0-dim arrays, per
+      // https://numpy.org/devdocs/reference/c-api/array.html#c.PyArray_CheckScalar
+      // But for 0-dim arrays no `PyArray_FromScalar` call is needed
       if (is_numpy_scalar && !is_numpy_array) {
         TORCH_CHECK(
             !force_alias,


### PR DESCRIPTION
By performing cast from scalar to 0-dim array only if object is not an
array already.

Fixes https://github.com/pytorch/pytorch/issues/97021
