### PR TITLE
[Vulkan] Fix divide-by-zero with padded tensors

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/div.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/div.glsl
@@ -27,9 +27,17 @@ void main() {
     const vec4 v0 = uBlock.isize0.w == 1
                       ? texelFetch(uInput0, input0_pos, 0).xxxx
                       : texelFetch(uInput0, input0_pos, 0);
-    const vec4 v1 = uBlock.isize1.w == 1
-                      ? texelFetch(uInput1, input1_pos, 0).xxxx
-                      : texelFetch(uInput1, input1_pos, 0);
+    vec4 v1 = uBlock.isize1.w == 1
+                ? texelFetch(uInput1, input1_pos, 0).xxxx
+                : texelFetch(uInput1, input1_pos, 0);
+
+    const int c_index = (pos.z % ((uBlock.size.w + 3) / 4)) * 4;
+    if (uBlock.isize1.w != 1 && c_index + 3 >= uBlock.size.w) {
+      ivec4 c_ind = ivec4(c_index) + ivec4(0, 1, 2, 3);
+      vec4 mask = vec4(lessThan(c_ind, ivec4(uBlock.size.w)));
+      v1 = v1 * mask + vec4(1, 1, 1, 1) - mask;
+    }
+
     imageStore(uOutput, pos, v0 / v1);
   }
 }

--- a/aten/src/ATen/native/vulkan/glsl/div_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/div_.glsl
@@ -21,9 +21,17 @@ void main() {
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
     const ivec3 input_pos = pos % uBlock.isize.xyz;
-    const vec4 v = uBlock.isize.w == 1
-                     ? texelFetch(uInput, input_pos, 0).xxxx
-                     : texelFetch(uInput, input_pos, 0);
+    vec4 v = uBlock.isize.w == 1
+                ? texelFetch(uInput, input_pos, 0).xxxx
+                : texelFetch(uInput, input_pos, 0);
+
+    const int c_index = (pos.z % ((uBlock.size.w + 3) / 4)) * 4;
+    if (uBlock.isize.w != 1 && c_index + 3 >= uBlock.size.w) {
+      ivec4 c_ind = ivec4(c_index) + ivec4(0, 1, 2, 3);
+      vec4 mask = vec4(lessThan(c_ind, ivec4(uBlock.size.w)));
+      v = v * mask + vec4(1, 1, 1, 1) - mask;
+    }
+
     imageStore(
         uOutput,
         pos,

--- a/aten/src/ATen/native/vulkan/glsl/quantized_div.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/quantized_div.glsl
@@ -30,9 +30,16 @@ void main() {
     const vec4 v0 = uBlock.isize0.w == 1
                       ? texelFetch(uInput0, input0_pos, 0).xxxx
                       : texelFetch(uInput0, input0_pos, 0);
-    const vec4 v1 = uBlock.isize1.w == 1
-                      ? texelFetch(uInput1, input1_pos, 0).xxxx
-                      : texelFetch(uInput1, input1_pos, 0);
+    vec4 v1 = uBlock.isize1.w == 1
+                ? texelFetch(uInput1, input1_pos, 0).xxxx
+                : texelFetch(uInput1, input1_pos, 0);
+
+    const int c_index = (pos.z % ((uBlock.size.w + 3) / 4)) * 4;
+    if (uBlock.isize1.w != 1 && c_index + 3 >= uBlock.size.w) {
+      ivec4 c_ind = ivec4(c_index) + ivec4(0, 1, 2, 3);
+      vec4 mask = vec4(lessThan(c_ind, ivec4(uBlock.size.w)));
+      v1 = v1 * mask + (vec4(1, 1, 1, 1) - mask) * (uBlock.in_zero_point.y + 1);
+    }
 
     vec4 deq_in_0 = uBlock.in_scale.x * (v0 - uBlock.in_zero_point.x);
     vec4 deq_in_1 = uBlock.in_scale.y * (v1 - uBlock.in_zero_point.y);

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -217,7 +217,7 @@ Tensor arithmetic_tensor(
   const double alpha = alpha_arg ? alpha_arg->to<double>() : 1.0;
   const struct Block final {
     uvec3 extents;
-    uint32_t fill0;
+    uint32_t channelSize;
     uvec3 input1Extents;
     uint32_t channelBatchSize1;
     uvec3 input2Extents;
@@ -225,7 +225,7 @@ Tensor arithmetic_tensor(
     float alpha;
   } block{
       v_output.extents(),
-      0u,
+      get_dim<Dim4D::Channel>(v_output),
       v_self.extents(),
       get_dim<Dim4D::Channel>(self) * get_dim<Dim4D::Batch>(self),
       v_other.extents(),
@@ -291,7 +291,7 @@ Tensor quantized_arithmetic_tensor(
   const int64_t zero_point2 = v_other.get_zero_point();
   const struct Block final {
     uvec3 extents;
-    uint32_t fill0;
+    uint32_t channelSize;
     uvec3 input1Extents;
     uint32_t channelBatchSize1;
     uvec3 input2Extents;
@@ -306,7 +306,7 @@ Tensor quantized_arithmetic_tensor(
     int32_t fill2;
   } block{
       v_output.extents(),
-      0u,
+      get_dim<Dim4D::Channel>(v_output),
       v_self.extents(),
       get_dim<Dim4D::Channel>(self) * get_dim<Dim4D::Batch>(self),
       v_other.extents(),
@@ -379,13 +379,13 @@ Tensor& arithmetic_tensor_(
   const double alpha = alpha_arg ? alpha_arg->to<double>() : 1.0;
   const struct Block final {
     uvec3 extents;
-    uint32_t fill0;
+    uint32_t channelSize;
     uvec3 inputExtents;
     uint32_t channelBatchSizeOther;
     float alpha;
   } block{
       v_self.extents(),
-      0u,
+      get_dim<Dim4D::Channel>(v_self),
       v_other.extents(),
       get_dim<Dim4D::Channel>(other) * get_dim<Dim4D::Batch>(other),
       safe_downcast<float>(alpha),


### PR DESCRIPTION
Summary:
This fixes the divide-by-zero that arises when performing a division in which the denominator has a number of channels that isn't a multiple of 4, and therefore the channel dimension has been padded with 0s.

More details in the comments of this post: https://fb.workplace.com/groups/pytorch.edge.users/permalink/1288546972015593/

Test Plan:
```
buck run --target-platforms ovr_config//platform/macos:arm64-fbsource -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_api_test_binAppleMac\#macosx-arm64
```

```
buck run --target-platforms ovr_config//platform/macos:arm64-fbsource -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64
```

Differential Revision: D44392406

