### PR TITLE
[inductor] Refactor cpp_wrapper to be an attribute of GraphLowering

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -178,6 +178,7 @@ def compile_fx_inner(
             num_static_inputs=num_fixed,
             graph_id=graph_id,
             aot_mode=aot_mode,
+            cpp_wrapper=config.cpp_wrapper,
         )
         with V.set_graph_handler(graph):
             graph.run(*example_inputs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97709

Summary: to prepare for further AOT Inductor changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7dff885</samp>

This pull request adds support for AOT compilation and C++ wrapper code generation for inductor models. It modifies the `GraphLowering` class in `torch/_inductor/graph.py` and the `compile_fx` function in `torch/_inductor/compile_fx.py` to enable this feature.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @peterbell10