### PR TITLE
[ci][easy] Only print remaining logs if test step ran

### DIFF
--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Test
         id: test
         # Time out the test phase after 3.5 hours
-        timeout-minutes: 1
+        timeout-minutes: 210
         env:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Test
         id: test
         # Time out the test phase after 3.5 hours
-        timeout-minutes: 210
+        timeout-minutes: 1
         env:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -210,7 +210,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: steps.test.conclusion
+        if: always() && steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -210,7 +210,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: always()
+        if: steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: always()
+        if: steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -162,7 +162,6 @@ jobs:
           else
             TEST_COMMAND=.ci/pytorch/test.sh
           fi
-          exit 1
 
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -162,6 +162,7 @@ jobs:
           else
             TEST_COMMAND=.ci/pytorch/test.sh
           fi
+          exit 1
 
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
 
@@ -227,7 +228,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: steps.test.conclusion
+        if: always() && steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: always()
+        if: steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_mac-test-mps.yml
+++ b/.github/workflows/_mac-test-mps.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: steps.test.conclusion
+        if: always() && steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: always()
+        if: steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: steps.test.conclusion
+        if: always() && steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: always()
+        if: steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: steps.test.conclusion
+        if: always() && steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: steps.test.conclusion
+        if: always() && steps.test.conclusion
         run: |
           cat test/**/*.log || true
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Print remaining test logs
         shell: bash
-        if: always()
+        if: steps.test.conclusion
         run: |
           cat test/**/*.log || true
 


### PR DESCRIPTION
it sometimes spits out left over logs from a previous run on the windows ephemeral runner, but this might have been fixed by now.  I get a bit annoyed when the step runs even though it obviously isnt going to be useful since the test step didnt run, 

always() is needed to ensure that it runs on test step failure