### PR TITLE
[Vulkan] Add convert_qconv2d_context op

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Convolution.h
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.h
@@ -2,6 +2,7 @@
 
 #ifdef USE_VULKAN_API
 
+#include <ATen/native/quantized/PackedParams.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/VulkanPackedContext.h>
 
@@ -163,6 +164,11 @@ c10::intrusive_ptr<Conv2dPackedContext> create_qconv2d_context(
     const int64_t groups,
     const c10::optional<Scalar>& output_min = c10::nullopt,
     const c10::optional<Scalar>& output_max = c10::nullopt);
+
+c10::intrusive_ptr<Conv2dPackedContext> convert_qconv2d_context(
+    const c10::intrusive_ptr<ConvPackedParamsBase<2>>& packed_params,
+    const c10::optional<Scalar>& output_min,
+    const c10::optional<Scalar>& output_max);
 
 Tensor run_qconv2d_context(
     const Tensor& input_arg,

--- a/aten/src/ATen/native/vulkan/ops/VulkanPackedContext.h
+++ b/aten/src/ATen/native/vulkan/ops/VulkanPackedContext.h
@@ -20,6 +20,10 @@ class VulkanPackedContext {
     return packed_.get(i);
   }
 
+  inline void set_val(int64_t i, c10::IValue val) const {
+    return packed_.set(i, val);
+  }
+
   virtual const c10::impl::GenericList unpack() const = 0;
 
   virtual ~VulkanPackedContext() = default;


### PR DESCRIPTION
Summary:
This diffs adds a convert_qconv2d_context op, which converts a cpu quantized Conv2dPackedParamsBase object (used by quantized::conv2d) into a vulkan Conv2dPackedContext object.
This op is used in a later diff (D44189363), to do a graph rewrite of quantized conv2d and conv2d_relu ops

Test Plan:
On Mac
```
cd ~/fbsource
buck1 run -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAppleMac\#macosx-arm64
```

On Android
```
cd ~/fbsource
buck1 build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 -c pt.vulkan_full_precision=1 //xplat/caffe2:pt_vulkan_quantized_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_quantized_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_quantized_api_test
adb shell "/data/local/tmp/vulkan_quantized_api_test"
```

Reviewed By: SS-JIA

Differential Revision: D41595032

