### PR TITLE
[stronghold][bc-linter] add BC linter suppression by `suppress-api-compatibility-check` PR label

### DIFF
--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -1,0 +1,73 @@
+name: BC Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+  workflow_dispatch:
+
+jobs:
+  bc_linter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if user is in the dogfooding group
+        id: check_user
+        run: |
+          allowed_users=("albanD" "ezyang" "izaitsevfb")
+          pr_author="${{ github.event.pull_request.user.login }}"
+          allowed="false"
+          for user in "${allowed_users[@]}"; do
+            if [[ "$pr_author" == "$user" ]]; then
+              allowed="true"
+              break
+            fi
+          done
+          echo "allowed=${allowed}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout PyTorch
+        if: steps.check_user.outputs.allowed == 'true'
+        uses: malfet/checkout@silent-checkout
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: -1
+          submodules: false
+          quiet-checkout: true
+          path: pytorch
+
+      - name: Checkout pytorch/test-infra repository
+        if: steps.check_user.outputs.allowed == 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: pytorch/test-infra
+          path: test-infra
+
+      - name: Check for suppression by label
+        id: check_label
+        if: contains(github.event.pull_request.labels.*.name, 'suppress-api-compatibility-check')
+        run: |
+          echo "API compatibility check is suppressed by label"
+          echo "suppression=--suppressed" >> "${GITHUB_OUTPUT}"
+
+      - name: Build and run BC-linter
+        if: steps.check_user.outputs.allowed == 'true'
+        working-directory: pytorch
+        run: |
+          set -eux
+          ../test-infra/tools/stronghold/bin/build-check-api-compatibility
+
+          # Run the BC-linter script.
+          # The script checks for BC-breaking changes in the PR.
+          # When suppressed by label or #suppress-api-compatibility-check tag in the commit message
+          # the job will not fail and will output notices instead of warnings.
+          ../test-infra/tools/stronghold/bin/check-api-compatibility \
+              --base-commit=${{ github.event.pull_request.base.sha }} \
+              --head-commit=${{ github.event.pull_request.head.sha }} \
+              ${{ steps.check_label.outputs.suppression }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -256,53 +256,6 @@ jobs:
           # All we need to see is that it passes
           python3 torch/utils/collect_env.py
 
-  bc_linter:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Check if user is in the dogfooding group
-        id: check_user
-        run: |
-          allowed_users=("albanD" "ezyang" "izaitsevfb")
-          pr_author="${{ github.event.pull_request.user.login }}"
-          allowed="false"
-          for user in "${allowed_users[@]}"; do
-            if [[ "$pr_author" == "$user" ]]; then
-              allowed="true"
-              break
-            fi
-          done
-          echo "allowed=${allowed}" >> "${GITHUB_OUTPUT}"
-
-      - name: Checkout PyTorch
-        if: steps.check_user.outputs.allowed == 'true'
-        uses: malfet/checkout@silent-checkout
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: -1
-          submodules: false
-          quiet-checkout: true
-          path: pytorch
-
-      - name: Checkout pytorch/test-infra repository
-        if: steps.check_user.outputs.allowed == 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: pytorch/test-infra
-          path: test-infra
-
-      - name: Build and run BC-linter
-        if: steps.check_user.outputs.allowed == 'true'
-        working-directory: pytorch
-        run: |
-          set -eux
-          ../test-infra/tools/stronghold/bin/build-check-api-compatibility
-
-          # Run the BC-linter script
-          ../test-infra/tools/stronghold/bin/check-api-compatibility \
-              --base-commit=${{ github.event.pull_request.base.sha }} \
-              --head-commit=${{ github.event.pull_request.head.sha }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true


### PR DESCRIPTION
Adds the ability to suppress BC-linter by adding `suppress-api-compatibility-check` label to the PR.

See #96977 for the context on the BC-linter.