### PR TITLE
[jit][easy] add missing quotes in namedtuple forwardref tests

### DIFF
--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -2103,9 +2103,9 @@ class TestNamedTuple(JitTestCase):
 
     def test_namedtuple_input_forwardref(self):
         class MyNamedTuple(NamedTuple):
-            a : int
-            b : float
-            c : torch.Tensor
+            a : 'int'
+            b : 'float'
+            c : 'torch.Tensor'
 
         make_global(MyNamedTuple)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #97736

Follow-up to #96933. This test was intended to have quotes around the
type annotations for the attributes of the NamedTuple. This PR adds this
missing quotes.