### PR TITLE
Fix strip_function_call in GuardBuilder

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -67,9 +67,13 @@ CLOSURE_VARS = collections.OrderedDict(
 def strip_function_call(name):
     """
     "___odict_getitem(a, 1)" => "a"
+    "a.layers[slice(2)][0]._xyz" ==> "a"
+    "getattr(a.layers[slice(2)][0]._abc, '0')" ==> "a"
+    "getattr(getattr(a.x[3], '0'), '3')" ==> "a"
     """
-    m = re.search(r"([a-z0-9_]+)\(([^(),]+)[^()]*\)", name)
-    if m and m.group(1) != "slice":
+    # find first param of a fuction that's not a number
+    m = re.search(r"([a-z0-9_]+)\((\D[^),]*)[^()]*", name)
+    if m:
         return strip_function_call(m.group(2))
     return strip_getattr_getitem(name)
 

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1386,7 +1386,9 @@ bool FunctionSignature::parse(
         varargs_eligible &&
         ((int_list_overload
               ? is_int_list(args, param.size, &failed_idx)
-              : is_int_or_symint_list(args, param.size, &failed_idx)))) {
+              : is_int_or_symint_list(args, param.size, &failed_idx)) ||
+          // allow tensor when varargs_eligible is true
+          THPVariable_Check(obj))) {
       // take all positional arguments as this parameter
       // e.g. permute(1, 2, 3) -> permute((1, 2, 3))
       dst[i++] = args;

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1387,8 +1387,8 @@ bool FunctionSignature::parse(
         ((int_list_overload
               ? is_int_list(args, param.size, &failed_idx)
               : is_int_or_symint_list(args, param.size, &failed_idx)) ||
-          // allow tensor when varargs_eligible is true
-          THPVariable_Check(obj))) {
+         // allow fake tensor when varargs_eligible is true
+         THPVariable_Check(obj))) {
       // take all positional arguments as this parameter
       // e.g. permute(1, 2, 3) -> permute((1, 2, 3))
       dst[i++] = args;


### PR DESCRIPTION
repo:
from [#92670](https://github.com/pytorch/pytorch/issues/92670) one issue for TorchDynamo

pytest ./generated/test_PeterouZh_CIPS_3D.py -k test_003

Issue:
In GuardBuilder, when parsing argnames with "getattr(a.layers[slice(2)][0]._abc, '0')" it returns "getattr(a", where it suppose to return "a", and thus causing SyntaxError.

This PR fix the regex and add couple test cases.


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire