### PR TITLE
remove torch.equal usages in test suite

### DIFF
--- a/docs/source/nested.rst
+++ b/docs/source/nested.rst
@@ -116,7 +116,7 @@ If all dimensions are regular, the NestedTensor is intended to be semantically i
 torch.Size([2, 20, 128])
 >>> torch.stack([a, a]).size()
 torch.Size([2, 20, 128])
->>> torch.equal(torch.stack(nt.unbind()), torch.stack([a, a]))
+>>> (torch.stack(nt.unbind()) == torch.stack([a, a])).all().item()
 True
 
 In the future we might make it easier to detect this condition and convert seamlessly.

--- a/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_binary_cmp.py
@@ -132,7 +132,7 @@ class TestShardedTensorBinaryOps(ShardedTensorTestBase):
 
         spec, alt_spec = self.get_gpu_specs()
         st1, st2 = self.get_random_tensors(spec, spec, 10, 10)
-        self.assertTrue(torch.equal(st1, st2))
+        self.assertEqual(st1, st2, rtol=0, atol=0, exact_device=True)
 
     @with_comms
     @skip_if_lt_x_gpu(4)

--- a/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
@@ -58,9 +58,9 @@ class TestTensorOps(ShardedTensorTestBase):
         )
         st = sharded_tensor.rand(spec, (12, 5))
         ones_st = sharded_tensor.ones(spec, (12, 5))
-        self.assertFalse(torch.equal(ones_st, st))
+        self.assertNotEqual(ones_st, st, rtol=0, atol=0, exact_device=True)
         st.copy_(ones_st)
-        self.assertTrue(torch.equal(st, ones_st))
+        self.assertEqual(st, ones_st, rtol=0, atol=0, exact_device=True)
 
         # no grad inplace_copy should work between two with different requires_grad
         st_with_grad = sharded_tensor.rand(spec, (12, 5), requires_grad=True)

--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -1125,8 +1125,8 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertTrue("sharded_tensor1" in loaded_dict_keys)
         self.assertTrue("submodule.sharded_tensor2" in loaded_dict_keys)
         # Verify after load.
-        self.assertTrue(torch.equal(m.sharded_tensor1, module_load.sharded_tensor1))
-        self.assertTrue(torch.equal(m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2))
+        self.assertEqual(m.sharded_tensor1, module_load.sharded_tensor1, rtol=0, atol=0, exact_device=True)
+        self.assertEqual(m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2, rtol=0, atol=0, exact_device=True)
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -1161,8 +1161,8 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             module_load.load_state_dict(state_dict_deser, strict=False)
 
         # Verify after load.
-        self.assertTrue(torch.equal(m.sharded_tensor1, module_load.sharded_tensor1))
-        self.assertTrue(torch.equal(m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2))
+        self.assertEqual(m.sharded_tensor1, module_load.sharded_tensor1, rtol=0, atol=0, exact_device=True)
+        self.assertEqual(m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2, rtol=0, atol=0, exact_device=True)
 
     @with_comms
     @skip_if_lt_x_gpu(4)

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -74,14 +74,22 @@ def assert_state_dict_equal(
             for local_shard_1, local_shard_2 in zip(
                 value_1.local_shards(), value_2.local_shards()
             ):
-                self.assertTrue(
-                    torch.equal(local_shard_1.tensor, local_shard_2.tensor),
-                    f"Key {key}'s shard does not match",
+                self.assertEqual(
+                    local_shard_1.tensor,
+                    local_shard_2.tensor,
+                    rtol=0,
+                    atol=0,
+                    exact_device=True,
+                    msg=f"Key {key}'s shard does not match"
                 )
         elif isinstance(value_1, torch.Tensor):
-            self.assertTrue(
-                torch.equal(value_1, value_2),
-                f"Key {key}'s tensor does not match",
+            self.assertEqual(
+                value_1,
+                value_2,
+                rtol=0,
+                atol=0,
+                exact_device=True,
+                msg=f"Key {key}'s tensor does not match"
             )
 
     return True

--- a/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint_cpu.py
@@ -73,14 +73,22 @@ def assert_state_dict_equal(
             for local_shard_1, local_shard_2 in zip(
                 value_1.local_shards(), value_2.local_shards()
             ):
-                self.assertTrue(
-                    torch.equal(local_shard_1.tensor, local_shard_2.tensor),
-                    f"Key {key}'s shard does not match",
+                self.assertEqual(
+                    local_shard_1.tensor,
+                    local_shard_2.tensor,
+                    rtol=0,
+                    atol=0,
+                    exact_device=True,
+                    msg=f"Key {key}'s shard does not match",
                 )
         elif isinstance(value_1, torch.Tensor):
-            self.assertTrue(
-                torch.equal(value_1, value_2),
-                f"Key {key}'s tensor does not match",
+            self.assertEqual(
+                value_1,
+                value_2,
+                rtol=0,
+                atol=0,
+                exact_device=True,
+                msg=f"Key {key}'s tensor does not match",
             )
 
     return True

--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -193,12 +193,12 @@ class TestClipGradNorm(FSDPTest):
 
         # Check that the gradients were modified by `clip_grad_norm_()`
         for param, orig_grad in zip(ddp_model.parameters(), orig_ddp_grads):
-            assert not torch.equal(param.grad, orig_grad)
+            self.assertNotEqual(param.grad, orig_grad, rtol=0, atol=0, exact_device=True)
         for param, orig_grad in zip(fsdp_model.parameters(), orig_fsdp_grads):
             if param.grad is None:
-                self.assertEqual(param.grad, orig_grad)  # `None`
+                self.assertIsNone(orig_grad)
             else:
-                assert not torch.equal(param.grad, orig_grad)
+                self.assertNotEqual(param.grad, orig_grad, rtol=0, atol=0, exact_device=True)
 
         # Run an optimizer step to ensure gradients matched after clipping
         ddp_optim.step()

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -173,7 +173,7 @@ class TestFSDPMisc(FSDPTest):
             # above check would be vacuously true.
             self.assertTrue(
                 any(
-                    not torch.equal(p1, p2)
+                    (p1 != p2).all()
                     for p1, p2 in zip(prev_params, m_local.parameters())
                 )
             )

--- a/test/distributed/fsdp/test_fsdp_summon_full_params.py
+++ b/test/distributed/fsdp/test_fsdp_summon_full_params.py
@@ -1,0 +1,750 @@
+# Owner(s): ["oncall: distributed"]
+import contextlib
+import itertools
+import math
+import sys
+from copy import deepcopy
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+from torch import distributed as dist
+from torch.distributed.fsdp import (
+    CPUOffload,
+    FullyShardedDataParallel as FSDP,
+    MixedPrecision,
+    ShardingStrategy,
+)
+from torch.distributed.fsdp.flat_param import FlatParamHandle
+from torch.distributed.fsdp.wrap import enable_wrap, wrap
+from torch.nn.parallel.distributed import DistributedDataParallel as DDP
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import (
+    CUDAInitMode,
+    DeterministicModel,
+    FSDPInitMode,
+    FSDPTest,
+    NestedWrappedModule,
+    TransformerWithSharedParams,
+)
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
+
+if not dist.is_available():
+    print("Distributed not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+
+def _run_test_summon_full_param_writeback(
+    cls, writeback, modify_outer, *fsdp_args, **fsdp_kwargs
+):
+    with enable_wrap(wrapper_cls=FSDP, *fsdp_args, **fsdp_kwargs):
+        lin1 = wrap(nn.Linear(5, 5, bias=False).cuda(cls.rank))
+        lin2 = nn.Linear(5, 3, bias=False).cuda(cls.rank)
+        model = wrap(nn.Sequential(lin1, lin2))
+
+    # set the value
+    outer_param = model._handles[0].flat_param
+    inner_param = model.module[0]._handles[0].flat_param
+    p = outer_param if modify_outer else inner_param
+
+    with torch.no_grad():
+        # This sets the local shard value
+        p[0] = cls.rank + 2
+
+    with model.summon_full_params(model, writeback=writeback):
+        with torch.no_grad():
+            p.copy_(torch.zeros_like(p))
+
+    if writeback or cls.world_size == 1:
+        # When world_size = 1, FSDP does not shard and parameter is not set to
+        # a local shard, so write is always reflected.
+        cls.assertEqual(p.cpu()[0], 0)
+    else:
+        cls.assertEqual(p.cpu()[0], cls.rank + 2)
+
+
+class TestSummonFullParamsNoShard(FSDPTest):
+    @property
+    def world_size(self):
+        return 1  # does not shard
+
+    @skip_if_lt_x_gpu(2)
+    # TODO: CPUOffload summon + writeback does not
+    # work when param is not sharded
+    # (currently when world_size == 1)
+    def test_summon_full_param_writeback(self):
+        subtest_config = {
+            "writeback": [True, False],
+            "modify_outer": [True, False],
+            "mixed_precision": [MixedPrecision(param_dtype=torch.float16), None],
+            "use_orig_params": [True, False],
+        }
+        self.run_subtests(
+            subtest_config,
+            _run_test_summon_full_param_writeback,
+            cls=self,
+            cpu_offload=CPUOffload(offload_params=False),
+        )
+
+
+class TestSummonFullParams(FSDPTest):
+    @property
+    def world_size(self):
+        return 2
+
+    def get_model_param_count(self, m):
+        return sum([p.numel() for p in m.parameters()])
+
+    # padding ensures that all shards have the same size with the least amount of padding
+    def get_expected_sharded_size(self, global_size):
+        return int(math.ceil(global_size / self.world_size))
+
+    @skip_if_lt_x_gpu(2)
+    def test_summon_full_param_writeback(self):
+        subtest_config = {
+            "writeback": [True, False],
+            "modify_outer": [True, False],
+            "mixed_precision": [MixedPrecision(param_dtype=torch.float16), None],
+            "cpu_offload": [
+                CPUOffload(offload_params=False),
+                CPUOffload(offload_params=True),
+            ],
+            "use_orig_params": [True, False],
+        }
+        self.run_subtests(
+            subtest_config,
+            _run_test_summon_full_param_writeback,
+            cls=self,
+        )
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("mixed_precision", [True, False])
+    def test_summon_full_param_shard_value(self, mixed_precision):
+        mixed_precision = (
+            MixedPrecision(param_dtype=torch.float16) if mixed_precision else None
+        )
+        raw_model = nn.Linear(10, 11)
+        raw_model_size = self.get_model_param_count(raw_model)
+        expected_shard_size = self.get_expected_sharded_size(raw_model_size)
+
+        model = FSDP(raw_model.cuda(self.rank), mixed_precision=mixed_precision)
+        self.assertEqual(expected_shard_size, self.get_model_param_count(model))
+
+        # we're assuming a single flattened param
+        self.assertEqual(1, len(list(model.parameters())))
+
+        my_shard = torch.clone(next(model.parameters()))
+
+        with model.summon_full_params(model):
+            self.assertEqual(raw_model_size, self.get_model_param_count(model))
+            parameters = list(model.parameters())
+            all_shards = FlatParamHandle.flatten_params(parameters, requires_grad=False)
+            my_slice = torch.chunk(all_shards, self.world_size)[self.rank]
+
+            # shards are padded but the full_param tensor is not
+            a, b = my_shard[0 : my_slice.numel()], my_slice
+            self.assertEqual(my_shard[0 : my_slice.numel()].cpu(), my_slice.cpu(), rtol=0, atol=0, exact_device=True)
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("recurse", [True, False])
+    @parametrize("summon_outer", [True, False])
+    @parametrize("mixed_precision", [True, False])
+    def test_summon_full_param_recursive(self, recurse, summon_outer, mixed_precision):
+        mixed_precision = (
+            MixedPrecision(param_dtype=torch.float16) if mixed_precision else None
+        )
+        model = FSDP(
+            nn.Sequential(
+                FSDP(nn.Linear(5, 5, bias=False), mixed_precision=mixed_precision),
+                nn.Linear(5, 3, bias=False),
+            ),
+            mixed_precision=mixed_precision,
+        ).cuda(self.rank)
+
+        global_inner_numel = self.get_model_param_count(nn.Linear(5, 5, bias=False))
+        global_outer_numel = self.get_model_param_count(nn.Linear(5, 3, bias=False))
+
+        shard_inner_numel = int(math.ceil(global_inner_numel / self.world_size))
+        shard_outer_numel = int(math.ceil(global_outer_numel / self.world_size))
+
+        outer_param = model._handles[0].flat_param
+        inner_param = model.module[0]._handles[0].flat_param
+        self.assertEqual(shard_outer_numel, outer_param.numel())
+        self.assertEqual(shard_inner_numel, inner_param.numel())
+
+        model_to_summon = model if summon_outer else model[0]
+        # outer is summoned if _summon_full_param is called on the outer FSDP module
+        expected_outer_numel = global_outer_numel if summon_outer else shard_outer_numel
+
+        # inner is summoned if _summon_full_param is called with recursion or on the inner FSDP module
+        expected_inner_numel = (
+            global_inner_numel if recurse or not summon_outer else shard_inner_numel
+        )
+
+        with model_to_summon.summon_full_params(model_to_summon, recurse=recurse):
+            self.assertEqual(expected_outer_numel, outer_param.numel())
+            self.assertEqual(expected_inner_numel, inner_param.numel())
+
+    @skip_if_lt_x_gpu(2)
+    def test_cannot_summon_full_params_from_forward(self):
+        class MyModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = nn.Parameter(torch.zeros(5))
+
+            def forward(self, fsdp_module):
+                with fsdp_module.summon_full_params(fsdp_module):
+                    pass
+
+        model = FSDP(MyModule()).cuda(self.rank)
+        with self.assertRaisesRegex(
+            ValueError, "Current handle state is HandleTrainingState.FORWARD"
+        ):
+            model(model)
+
+    @skip_if_lt_x_gpu(2)
+    def test_cannot_summon_full_params_from_backward(self):
+        model = FSDP(nn.Linear(2, 1)).cuda(self.rank)
+
+        output = model(torch.ones(2).cuda(self.rank))
+
+        def bad_backwards_hook(tensor):
+            with model.summon_full_params(model):
+                pass
+            return None
+
+        self.assertTrue(output.requires_grad)
+        output.register_hook(bad_backwards_hook)
+
+        with self.assertRaisesRegex(
+            ValueError, "Current handle state is HandleTrainingState.BACKWARD_PRE"
+        ):
+            output.backward()
+
+    @skip_if_lt_x_gpu(2)
+    def test_summon_full_params_respects_reshard_after_forward(self):
+        self.run_subtests(
+            {
+                "mixed_precision": [MixedPrecision(param_dtype=torch.float16), None],
+                "use_orig_params": [False, True],
+            },
+            self._test_summon_full_params_respects_reshard_after_forward,
+        )
+
+    def _test_summon_full_params_respects_reshard_after_forward(
+        self, mixed_precision: Optional[MixedPrecision], use_orig_params: bool
+    ):
+        fsdp_kwargs = {
+            "mixed_precision": mixed_precision,
+            "use_orig_params": use_orig_params,
+        }
+        model = FSDP(
+            nn.Sequential(
+                FSDP(nn.Linear(5, 5, bias=False), **fsdp_kwargs),
+                nn.Linear(5, 3, bias=False),
+            ),
+            **fsdp_kwargs,
+        ).cuda(self.rank)
+
+        outer_param = model._handles[0].flat_param
+        inner_param = model.module[0]._handles[0].flat_param
+        outer_full_param_size = outer_param.numel() * self.world_size
+
+        # trigger lazy init
+        model(torch.zeros(5).cuda(self.rank))
+        # the root FSDP module keeps all params around
+        self.assertEqual(
+            outer_full_param_size, outer_param._full_param_padded.storage().size()
+        )
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+        # similarly summon_full_params should have the same behavior
+        with model.summon_full_params(model):
+            pass
+        self.assertEqual(
+            outer_full_param_size, outer_param._full_param_padded.storage().size()
+        )
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+    @skip_if_lt_x_gpu(2)
+    def test_summon_single_param(self):
+        model = FSDP(nn.Linear(1, 1, bias=False)).cuda(self.rank)
+
+        p = model._handles[0].flat_param
+        self.assertEqual(1, p.numel())
+
+        with torch.no_grad():
+            # This sets the local shard value
+            p[0] = self.rank + 2
+
+        with model.summon_full_params(model, writeback=True):
+            self.assertEqual(1, p.numel())
+            with torch.no_grad():
+                p.copy_(torch.zeros_like(p))
+
+        # most ranks hold no data and wrote to padding so only rank zero will observe the above write
+        if self.rank == 0:
+            self.assertEqual(0, p[0])
+        else:
+            self.assertEqual(self.rank + 2, p[0])
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("rank0_only", [True, False])
+    @parametrize("offload_to_cpu", [True, False])
+    def test_summon_full_params_equivalence(self, rank0_only, offload_to_cpu):
+        offload = CPUOffload(offload_params=True)
+        model = FSDP(
+            DeterministicModel(wrap_fsdp=True, cpu_offload=offload), cpu_offload=offload
+        )
+        local_model = DeterministicModel(wrap_fsdp=False)
+
+        params_to_compare = (
+            [p.clone() for p in model.parameters()]
+            if rank0_only and self.rank != 0
+            else list(local_model.parameters())
+        )
+
+        writeback = not rank0_only
+
+        with model.summon_full_params(
+            model,
+            recurse=True,
+            rank0_only=rank0_only,
+            writeback=writeback,
+            offload_to_cpu=offload_to_cpu,
+        ):
+            if writeback:
+                with torch.no_grad():
+                    for p in model.parameters():
+                        p.add_(1)
+                    for p in params_to_compare:
+                        p.add_(1)
+            # Below sleep causes failures without stream synchronization in
+            # summon_full_params fix.
+            torch.cuda._sleep(1000000)
+            # FSDP param deepcopy() of params has issues
+            fsdp_params = [p.clone() for p in model.parameters()]
+
+        self.assertEqual(fsdp_params, params_to_compare)
+
+        # CPU offload is enabled for main API, so we should point back to CPU
+        for param in model.parameters():
+            self.assertEqual(param.device, torch.device("cpu"))
+
+    @skip_if_lt_x_gpu(2)
+    def test_summon_from_non_fsdp(self):
+        class FSDPContainer(nn.Module):
+            def __init__(self, fsdp_1, fsdp_2, fsdp_3):
+                super().__init__()
+                self.fsdp_1 = fsdp_1
+                self.fsdp_2 = fsdp_2
+                self.fsdp_3 = fsdp_3
+
+        model_fsdp = FSDPContainer(
+            FSDP(DeterministicModel(wrap_fsdp=True)),
+            FSDP(DeterministicModel(wrap_fsdp=True)),
+            DeterministicModel(wrap_fsdp=False),
+        )
+        model_no_fsdp = FSDPContainer(
+            DeterministicModel(wrap_fsdp=False),
+            DeterministicModel(wrap_fsdp=False),
+            DeterministicModel(wrap_fsdp=False),
+        )
+
+        params_to_compare = list(model_no_fsdp.parameters())
+        with FSDP.summon_full_params(model_fsdp):
+            fsdp_params = [p.clone() for p in model_fsdp.parameters()]
+
+        self.assertEqual(params_to_compare, fsdp_params)
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("rank0_only", [True, False])
+    @parametrize("offload_to_cpu", [True, False])
+    @parametrize("mixed_precision", [True, False])
+    def test_reshard_outside_forward_backward_iteration(
+        self, rank0_only, offload_to_cpu, mixed_precision
+    ):
+        mixed_precision = (
+            MixedPrecision(param_dtype=torch.float16) if mixed_precision else None
+        )
+        model = FSDP(
+            nn.Sequential(
+                FSDP(nn.Linear(5, 5, bias=False), mixed_precision=mixed_precision),
+                nn.Linear(5, 1, bias=False),
+            ),
+            mixed_precision=mixed_precision,
+        ).cuda(self.rank)
+
+        outer_param = model._handles[0].flat_param
+        inner_param = model.module[0]._handles[0].flat_param
+        outer_full_param_size = outer_param.numel() * self.world_size
+
+        # First lets validate our assumption about resharding
+
+        output = model(torch.zeros(5).cuda(self.rank))
+        # the root FSDP module keeps all params around
+        self.assertEqual(
+            outer_full_param_size, outer_param._full_param_padded.storage().size()
+        )
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+        output.backward()
+        # we reshard everything after backward() finishes
+        self.assertEqual(0, outer_param._full_param_padded.storage().size())
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+        # now lets repeat it with summon done in between
+
+        output = model(torch.zeros(5).cuda(self.rank))
+        self.assertEqual(
+            outer_full_param_size, outer_param._full_param_padded.storage().size()
+        )
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+        with model.summon_full_params(
+            model,
+            rank0_only=rank0_only,
+            writeback=not rank0_only,
+            offload_to_cpu=offload_to_cpu,
+        ):
+            pass
+        self.assertEqual(
+            outer_full_param_size, outer_param._full_param_padded.storage().size()
+        )
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+        output.backward()
+        with model.summon_full_params(
+            model,
+            rank0_only=rank0_only,
+            writeback=not rank0_only,
+            offload_to_cpu=offload_to_cpu,
+        ):
+            pass
+        self.assertEqual(0, outer_param._full_param_padded.storage().size())
+        self.assertEqual(0, inner_param._full_param_padded.storage().size())
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("rank0_only", [True, False])
+    @parametrize("offload_to_cpu", [True, False])
+    @parametrize("mixed_precision", [True, False])
+    def test_params_are_unflattenned(self, rank0_only, offload_to_cpu, mixed_precision):
+        layer_shape = (10, 12)
+        model = nn.Linear(*layer_shape, bias=False).cuda(self.rank)
+        mixed_precision = (
+            MixedPrecision(param_dtype=torch.float16) if mixed_precision else None
+        )
+        fsdp_model = FSDP(deepcopy(model), mixed_precision=mixed_precision).cuda(
+            self.rank
+        )
+
+        def _get_flat_param():
+            return fsdp_model._handles[0].flat_param
+
+        flattened_param = _get_flat_param()
+        self.assertEqual(layer_shape[0] * layer_shape[1] / 2, flattened_param.numel())
+
+        with fsdp_model.summon_full_params(
+            fsdp_model,
+            rank0_only=rank0_only,
+            writeback=not rank0_only,
+            offload_to_cpu=offload_to_cpu,
+        ):
+            if self.rank == 0 or not rank0_only:
+                self.assertEqual(fsdp_model.weight.shape, model.weight.shape)
+                expected_device = (
+                    torch.device("cpu")
+                    if offload_to_cpu
+                    else torch.device("cuda", torch.cuda.current_device())
+                )
+                self.assertTrue(expected_device == fsdp_model.weight.device)
+            else:
+                # Nonzero rank with rank0_only maintains original params.
+                flat_within_ctx = _get_flat_param()
+                self.assertEqual(flat_within_ctx, flattened_param)
+                self.assertEqual(
+                    flat_within_ctx.device, torch.device(torch.cuda.current_device())
+                )
+
+        # CPU offload should restore the param device
+        param = next(fsdp_model.parameters())
+        self.assertTrue(
+            param.device == torch.device("cuda", torch.cuda.current_device())
+        )
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("rank0_only", [True, False])
+    @parametrize("offload_to_cpu", [True, False])
+    @parametrize("mixed_precision", [True, False])
+    def test_params_count_and_value(
+        self,
+        rank0_only: bool,
+        offload_to_cpu: bool,
+        mixed_precision: bool,
+    ):
+        mixed_precision = (
+            MixedPrecision(param_dtype=torch.float16) if mixed_precision else None
+        )
+        model = NestedWrappedModule.init(
+            self.process_group,
+            FSDPInitMode.NO_FSDP,
+            CUDAInitMode.CUDA_BEFORE,
+            deterministic=True,
+        )
+        fsdp_model = NestedWrappedModule.init(
+            self.process_group,
+            FSDPInitMode.RECURSIVE,
+            CUDAInitMode.CUDA_BEFORE,
+            deterministic=True,
+        )
+        dev = (
+            torch.device("cpu")
+            if offload_to_cpu
+            else torch.device("cuda", torch.cuda.current_device())
+        )
+        params_to_compare = (
+            [p.to(dev) for p in model.module.parameters()]
+            if not rank0_only or self.rank == 0
+            else list(p.clone() for p in fsdp_model.parameters())
+        )
+        with FSDP.summon_full_params(
+            fsdp_model, rank0_only=rank0_only, writeback=not rank0_only
+        ):
+            for p1, p2 in itertools.zip_longest(
+                fsdp_model.parameters(), params_to_compare
+            ):
+                self.assertEqual(p1, p2)
+
+        # CPU offload should restore the param device
+        param = next(fsdp_model.parameters())
+        self.assertTrue(
+            param.device == torch.device("cuda", torch.cuda.current_device())
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_raises_rank0_with_writeback(self):
+        """Tests that ``summon_full_params()`` with both ``rank0_only=True``
+        and ``writeback=True`` raises an error."""
+        nested_wrapped_module = NestedWrappedModule.init(
+            self.process_group,
+            FSDPInitMode.RECURSIVE,
+            CUDAInitMode.CUDA_BEFORE,
+        )
+        with self.assertRaisesRegex(ValueError, "is not supported"):
+            with FSDP.summon_full_params(
+                nested_wrapped_module, rank0_only=True, writeback=True
+            ):
+                pass
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("prefix", ["", "test_prefix"])
+    @parametrize("recurse", [False, True])
+    def test_named_parameters_buffers(self, prefix: str, recurse: bool):
+        """Tests that ``named_parameters()`` and ``named_buffers()`` for a
+        top-level FSDP-wrapped model matches their behavior for the equivalent
+        non-wrapped model."""
+        model = NestedWrappedModule.init(
+            self.process_group,
+            FSDPInitMode.NO_FSDP,
+            CUDAInitMode.CUDA_BEFORE,
+            deterministic=True,
+        )
+        model.register_buffer("buffer", torch.ones(1))
+        # `named_parameters()` and `named_buffers` will contain FSDP prefixes
+        # if called on a non-FSDP root module
+        fsdp_model = FSDP(
+            NestedWrappedModule.init(
+                self.process_group,
+                FSDPInitMode.NO_FSDP,
+                CUDAInitMode.CUDA_BEFORE,
+                deterministic=True,
+            ),
+            self.process_group,
+        )
+        fsdp_model.register_buffer("buffer", torch.ones(1))
+        with FSDP.summon_full_params(fsdp_model):
+            for call in ["named_parameters", "named_buffers"]:
+                for (n1, p1), (n2, p2) in itertools.zip_longest(
+                    getattr(fsdp_model, call)(prefix=prefix, recurse=recurse),
+                    getattr(model, call)(prefix=prefix, recurse=recurse),
+                ):
+                    self.assertEqual(n1, n2)
+                    self.assertEqual(p1, p2)
+
+    @skip_if_lt_x_gpu(2)
+    def test_with_grads_core(self):
+        """Tests the core usage of ``summon_full_params(with_grads=True)``."""
+        self.run_subtests(
+            {
+                "writeback": [False, True],
+                "offload_to_cpu": [False, True],
+                "sharding_strategy": [
+                    ShardingStrategy.FULL_SHARD,
+                    ShardingStrategy.SHARD_GRAD_OP,
+                    ShardingStrategy.NO_SHARD,
+                ],
+                "use_orig_params": [True],
+            },
+            self._test_with_grads_core,
+        )
+
+    def _test_with_grads_core(
+        self,
+        writeback: bool,
+        offload_to_cpu: bool,
+        sharding_strategy: ShardingStrategy,
+        use_orig_params: bool,
+    ):
+        def _check_grads(
+            ddp_model: DDP,
+            fsdp_model: FSDP,
+            old_fsdp_grads: Optional[List[torch.Tensor]],
+        ):
+            WRITEBACK_FACTOR = 2
+            with FSDP.summon_full_params(
+                fsdp_model,
+                writeback=writeback,
+                offload_to_cpu=offload_to_cpu,
+                with_grads=True,
+            ):
+                for (n1, p1), (n2, p2) in zip(
+                    ddp_model.module.named_parameters(),
+                    fsdp_model.named_parameters(),
+                ):
+                    # Parameter names are only expected to match because
+                    # `fsdp_model` has top-level FSDP, so its
+                    # `named_parameters()` cleans *all* of the names
+                    self.assertEqual(n1, n2)
+                    assert p1.grad is not None
+                    torch.testing.assert_close(p1.grad, p2.grad)
+                    # Ensure that the tensor is not all zeros, which would
+                    # mean that the multiplication is vacuous
+                    assert torch.count_nonzero(p2.grad) > 0
+                    p2.grad *= WRITEBACK_FACTOR
+            new_fsdp_grads = [
+                param.grad
+                for param in fsdp_model.parameters()
+                if param.grad is not None
+            ]
+            writeback_persists = (
+                writeback or sharding_strategy == ShardingStrategy.NO_SHARD
+            )
+            for old_grad, new_grad in zip(old_fsdp_grads, new_fsdp_grads):
+                if writeback_persists:
+                    torch.testing.assert_close(old_grad * WRITEBACK_FACTOR, new_grad)
+                else:
+                    torch.testing.assert_close(old_grad, new_grad)
+            if writeback_persists:
+                # Modify the DDP gradients for parity
+                for param in ddp_model.parameters():
+                    param.grad *= WRITEBACK_FACTOR
+
+        def _get_error_context(is_supported: bool):
+            return (
+                contextlib.suppress()
+                if is_supported
+                else self.assertRaises(NotImplementedError)
+            )  # some configs not implemented yet
+
+        def _get_fsdp_grads(fsdp_model: FSDP, is_supported: bool):
+            if is_supported:
+                return [
+                    param.grad.clone()
+                    for param in fsdp_model.parameters()
+                    if param.grad is not None
+                ]
+            return None  # unused
+
+        is_supported = use_orig_params and not offload_to_cpu
+        model = TransformerWithSharedParams.init(
+            self.process_group,
+            FSDPInitMode.NO_FSDP,
+            CUDAInitMode.CUDA_BEFORE,
+            deterministic=True,
+        )
+        ddp_model = DDP(model, device_ids=[self.rank])
+        fsdp_model = TransformerWithSharedParams.init(
+            self.process_group,
+            FSDPInitMode.RECURSIVE,
+            CUDAInitMode.CUDA_BEFORE,
+            deterministic=True,
+            fsdp_kwargs={
+                "use_orig_params": use_orig_params,
+                "sharding_strategy": sharding_strategy,
+            },
+        )
+        with FSDP.summon_full_params(fsdp_model):
+            for p1, p2 in zip(ddp_model.module.parameters(), fsdp_model.parameters()):
+                assert torch.all(torch.isclose(p1, p2))
+
+        # Check `summon_full_params()` after backward
+        inp = fsdp_model.get_input(torch.device("cuda"))
+        ddp_out = ddp_model(*inp)
+        fsdp_out = fsdp_model(*inp)
+        ddp_out.sum().backward()
+        fsdp_out.sum().backward()
+        old_fsdp_grads = _get_fsdp_grads(fsdp_model, is_supported)
+        with _get_error_context(is_supported):
+            _check_grads(ddp_model, fsdp_model, old_fsdp_grads)
+
+        # Check `summon_full_params()` between forward and backward
+        inp = fsdp_model.get_input(torch.device("cuda"))
+        ddp_out = ddp_model(*inp)
+        fsdp_out = fsdp_model(*inp)
+        old_fsdp_grads = _get_fsdp_grads(fsdp_model, is_supported)
+        with _get_error_context(is_supported):
+            _check_grads(ddp_model, fsdp_model, old_fsdp_grads)
+
+    @skip_if_lt_x_gpu(2)
+    def test_with_grads_none_grads(self):
+        """
+        Tests that if all ranks' ``FlatParameter`` has ``None`` gradient, then
+        each original parameter sees ``None`` gradient as well.
+        """
+        self.run_subtests(
+            {
+                "sharding_strategy": [
+                    ShardingStrategy.FULL_SHARD,
+                    ShardingStrategy.SHARD_GRAD_OP,
+                    ShardingStrategy.NO_SHARD,
+                ]
+            },
+            self._test_with_grads_none_grads,
+        )
+
+    def _test_with_grads_none_grads(self, sharding_strategy: ShardingStrategy):
+        fsdp_model = TransformerWithSharedParams.init(
+            self.process_group,
+            FSDPInitMode.RECURSIVE,
+            CUDAInitMode.CUDA_BEFORE,
+            deterministic=True,
+            fsdp_kwargs={
+                "use_orig_params": True,
+                "sharding_strategy": sharding_strategy,
+            },
+        )
+        for fsdp_module in FSDP.fsdp_modules(fsdp_model):
+            for handle in fsdp_module._handles:
+                assert handle.flat_param.grad is None
+        with FSDP.summon_full_params(fsdp_model, with_grads=True):
+            for param in fsdp_model.parameters():
+                self.assertTrue(param.grad is None)
+
+
+instantiate_parametrized_tests(TestSummonFullParams)
+instantiate_parametrized_tests(TestSummonFullParamsNoShard)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/pipeline/sync/test_pipe.py
+++ b/test/distributed/pipeline/sync/test_pipe.py
@@ -778,7 +778,7 @@ def test_multiple_inputs(checkpoint, setup_rpc):
     model = Pipe(nn.Sequential(Module1().cuda(0), Module2().cuda(0)), chunks=2, checkpoint=checkpoint)
     t = torch.rand(10)
     res = model(t, t, t).local_value()
-    assert torch.equal(res, (t + t + t) + (t * t * t))
+    torch.testing.assert_close(res, (t + t + t) + (t * t * t), rtol=0, atol=0)
 
 @skip_if_no_cuda
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Need atleast two GPUs")

--- a/test/fx/test_dce_pass.py
+++ b/test/fx/test_dce_pass.py
@@ -60,7 +60,7 @@ class TestDCE(TestCase):
         traced.recompile()
         # Make sure we run and get the same results before/after DCE.
         inputs = [torch.tensor([1.5])] * new_num_phs
-        self.assertTrue(torch.equal(m(*inputs), traced(*inputs)))
+        self.assertEqual(m(*inputs), traced(*inputs), rtol=0, atol=0, exact_device=True)
 
     def test_simple(self):
         """
@@ -167,7 +167,7 @@ class TestDCE(TestCase):
 
         class TestModule(torch.nn.Module):
             def forward(self, a: torch.Tensor) -> torch.Tensor:
-                torch._assert(torch.equal(a, a), "a must equal a")
+                torch._assert((a == a).all(), "a must equal a")
                 return a * 2
 
         # Note: Don't need to specify torch._assert as having side effects

--- a/test/fx/test_fx_const_fold.py
+++ b/test/fx/test_fx_const_fold.py
@@ -79,7 +79,7 @@ class TestConstFold(TestCase):
         in_x, in_y = torch.tensor([[-0.45]]), torch.tensor([0.9])
         base_result = mod(in_x, in_y)
         fold_result = mod_folded(in_x, in_y)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_basic_one_attr_name_collision(self):
         r"""
@@ -125,7 +125,7 @@ class TestConstFold(TestCase):
         in_x, in_y = torch.tensor([[5.0]]), torch.tensor([4.0])
         base_result = mod(in_x, in_y)
         fold_result = mod_folded(in_x, in_y)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_basic_placeholder_reordered(self):
         """
@@ -154,7 +154,7 @@ class TestConstFold(TestCase):
         in_y = torch.tensor([[0.45]])
         base_result = mod(in_x, in_y)
         fold_result = mod_folded(in_x, in_y)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_noop(self):
         r"""
@@ -185,7 +185,7 @@ class TestConstFold(TestCase):
         in_x = torch.tensor([[-0.45]])
         base_result = mod(in_x)
         fold_result = mod_folded(in_x)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_basic_two_attr_three_input(self):
         r"""
@@ -234,7 +234,7 @@ class TestConstFold(TestCase):
         )
         base_result = mod(in_x, in_y, in_z)
         fold_result = mod_folded(in_x, in_y, in_z)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_basic_two_attr(self):
         r"""
@@ -271,7 +271,7 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = mod_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_multi_const_folded_attrs(self):
         r"""
@@ -322,7 +322,7 @@ class TestConstFold(TestCase):
         in_x, in_y = torch.randn(4, 4), torch.randn(4)
         fold_result = mod_folded(in_x, in_y)
         base_result = mod(in_x, in_y)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_submod_hierarchy(self):
         r"""
@@ -356,7 +356,7 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = mod_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_retain_node_meta(self):
         r"""
@@ -409,7 +409,7 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = gm_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_has_inlined_call_module_node(self):
         class ConstFoldTestModule(torch.nn.Module):
@@ -430,7 +430,7 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = gm_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_module_attr(self):
         class ConstFoldTestModule(torch.nn.Module):
@@ -452,7 +452,7 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = gm_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_unused_placeholder(self):
         class ConstFoldTestModule(torch.nn.Module):
@@ -471,7 +471,7 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = gm_folded(in_x, in_x, in_x)
         base_result = mod(in_x, in_x, in_x)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_dict_output(self):
         class ConstFoldTestModule(torch.nn.Module):
@@ -490,7 +490,7 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = gm_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result["result"], base_result["result"]))
+        self.assertEqual(fold_result["result"], base_result["result"], rtol=0, atol=0, exact_device=True)
 
     def test_two_outputs(self):
         class ConstFoldTestModule(torch.nn.Module):
@@ -509,8 +509,8 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = gm_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result[0], base_result[0]))
-        self.assertTrue(torch.equal(fold_result[1], base_result[1]))
+        self.assertEqual(fold_result[0], base_result[0], rtol=0, atol=0, exact_device=True)
+        self.assertEqual(fold_result[1], base_result[1], rtol=0, atol=0, exact_device=True)
 
     def test_three_outputs(self):
         class ConstFoldTestModule(torch.nn.Module):
@@ -529,9 +529,9 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = gm_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result[0], base_result[0]))
-        self.assertTrue(torch.equal(fold_result[1], base_result[1]))
-        self.assertTrue(torch.equal(fold_result[2], base_result[2]))
+        self.assertEqual(fold_result[0], base_result[0], rtol=0, atol=0, exact_device=True)
+        self.assertEqual(fold_result[1], base_result[1], rtol=0, atol=0, exact_device=True)
+        self.assertEqual(fold_result[2], base_result[2], rtol=0, atol=0, exact_device=True)
 
     def test_check_inline_non_const(self):
         r"""
@@ -563,7 +563,7 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = gm_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_check_inline_non_const_mult_return(self):
         r"""
@@ -595,8 +595,8 @@ class TestConstFold(TestCase):
         in_x = torch.randn(2, 3)
         fold_result = gm_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result[0], base_result[0]))
-        self.assertTrue(torch.equal(fold_result[1], base_result[1]))
+        self.assertEqual(fold_result[0], base_result[0], rtol=0, atol=0, exact_device=True)
+        self.assertEqual(fold_result[1], base_result[1], rtol=0, atol=0, exact_device=True)
 
     def test_check_skip_folding_quant_dequant_pattern(self):
         r"""
@@ -642,7 +642,7 @@ class TestConstFold(TestCase):
         # Now run both folded and non-folded to check results equal.
         fold_result = gm_folded(in_x)
         base_result = mod(in_x)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)
 
     def test_fold_module(self):
         r"""
@@ -664,7 +664,7 @@ class TestConstFold(TestCase):
 
         # Now run both folded and non-folded to check results equal.
         inp = torch.randn(4, 4)
-        self.assertTrue(torch.equal(mod_folded(inp), mod(inp)))
+        self.assertEqual(mod_folded(inp), mod(inp), rtol=0, atol=0, exact_device=True)
 
     def test_const_fold_tensor_meta(self):
         self._test_const_fold_tensor_meta(True)
@@ -705,4 +705,4 @@ class TestConstFold(TestCase):
         # Now run both folded and non-folded to check results equal.
         base_result = mod(in_x, in_y)
         fold_result = mod_folded(in_x, in_y)
-        self.assertTrue(torch.equal(fold_result, base_result))
+        self.assertEqual(fold_result, base_result, rtol=0, atol=0, exact_device=True)

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -404,7 +404,7 @@ class TestSaveLoad(JitTestCase):
             m2 = torch.jit.load(path)
 
         x = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        self.assertTrue(torch.equal(m(x), m2(x)))
+        self.assertEqual(m(x), m2(x), rtol=0, atol=0, exact_device=True)
 
     def test_save_nonexit_file(self):
         class Foo(torch.nn.Module):
@@ -997,7 +997,7 @@ class TestSaveLoadFlatbuffer(JitTestCase):
             m2 = torch.jit.load(path)
 
         x = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        self.assertTrue(torch.equal(m(x), m2(x)))
+        self.assertEqual(m(x), m2(x), rtol=0, atol=0, exact_device=True)
 
     def test_save_namedtuple_input_only(self):
         """

--- a/test/nn/test_lazy_modules.py
+++ b/test/nn/test_lazy_modules.py
@@ -118,7 +118,7 @@ class TestLazyModules(TestCase):
         self.assertTrue(module.weight.shape == (10, 5))
         self.assertTrue(module.bias.shape == (10,))
         y = module(input)
-        self.assertTrue(torch.equal(torch.nn.functional.linear(input, module.weight, module.bias), y))
+        self.assertEqual(torch.nn.functional.linear(input, module.weight, module.bias), y, rtol=0, atol=0, exact_device=True)
 
     @suppress_warnings
     def test_lazy_linear_pickle(self):
@@ -170,7 +170,7 @@ class TestLazyModules(TestCase):
         if module.bias is not None:
             self.assertEqual(module.bias.shape, expected_bias_shape)
         y = module(input)
-        self.assertTrue(torch.equal(func(input, module.weight, module.bias), y))
+        self.assertEqual(func(input, module.weight, module.bias), y, rtol=0, atol=0, exact_device=True)
 
     def _check_lazy_conv_pickle(self, cls, lazy_cls, init_args, input_shape,
                                 expected_weight_shape, expected_bias_shape):

--- a/test/quantization/core/experimental/test_fake_quantize.py
+++ b/test/quantization/core/experimental/test_fake_quantize.py
@@ -29,9 +29,9 @@ class TestFakeQuantize(unittest.TestCase):
         qparams_expected = observer.calculate_qparams(signed=False)
 
         self.assertEqual(alpha, qparams_expected[0])
-        self.assertTrue(torch.equal(gamma, qparams_expected[1]))
-        self.assertTrue(torch.equal(quantization_levels, qparams_expected[2]))
-        self.assertTrue(torch.equal(level_indices, qparams_expected[3]))
+        self.assertEqual(gamma, qparams_expected[1], rtol=0, atol=0, exact_device=True)
+        self.assertEqual(quantization_levels, qparams_expected[2], rtol=0, atol=0, exact_device=True)
+        self.assertEqual(level_indices, qparams_expected[3], rtol=0, atol=0, exact_device=True)
 
     r""" Tests fake quantize forward() method
          by comparing result with expected
@@ -58,7 +58,7 @@ class TestFakeQuantize(unittest.TestCase):
         X_to_apot = quantize_APoT(X, alpha, gamma, quantization_levels, level_indices)
         X_expected = dequantize_APoT(X_to_apot)
 
-        self.assertTrue(torch.equal(X_reduced_precision_fp, X_expected))
+        self.assertEqual(X_reduced_precision_fp, X_expected, rtol=0, atol=0, exact_device=True)
 
     r""" Tests fake quantize forward() method
          throws error when qparams are None

--- a/test/quantization/core/experimental/test_linear.py
+++ b/test/quantization/core/experimental/test_linear.py
@@ -31,7 +31,7 @@ class TestNonUniformObserver(unittest.TestCase):
 
         fp_linear_result = fp_linear(activation).data
 
-        self.assertTrue(torch.equal(apot_linear_result, fp_linear_result))
+        self.assertEqual(apot_linear_result, fp_linear_result, rtol=0, atol=0, exact_device=True)
 
     """
         Test linear_APoT_fn by comparing to uniform linear
@@ -59,7 +59,7 @@ class TestNonUniformObserver(unittest.TestCase):
 
         fp_linear_result = fp_linear(activation).data
 
-        self.assertTrue(torch.equal(apot_linear_result, fp_linear_result))
+        self.assertEqual(apot_linear_result, fp_linear_result, rtol=0, atol=0, exact_device=True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/quantization/core/experimental/test_quantized_tensor.py
+++ b/test/quantization/core/experimental/test_quantized_tensor.py
@@ -35,7 +35,7 @@ class TestQuantizedTensor(unittest.TestCase):
         # 0.0215 in tensor2quantize nearest 0.0208 in quantization_levels -> 3 in level_indices
         expected_qtensor_data = torch.tensor([0, 3, 8, 13, 5, 12], dtype=torch.int32)
 
-        self.assertTrue(torch.equal(qtensor_data, expected_qtensor_data))
+        self.assertEqual(qtensor_data, expected_qtensor_data, rtol=0, atol=0, exact_device=True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/quantization/core/experimental/test_quantizer.py
+++ b/test/quantization/core/experimental/test_quantizer.py
@@ -48,7 +48,7 @@ class TestQuantizer(unittest.TestCase):
         qtensor_data = qtensor.data.int()
         uniform_quantized_tensor = uniform_quantized.data.int()
 
-        self.assertTrue(torch.equal(qtensor_data, uniform_quantized_tensor))
+        self.assertEqual(qtensor_data, uniform_quantized_tensor, rtol=0, atol=0, exact_device=True)
 
     r""" Tests quantize_APoT for k != 1.
         Tests quantize_APoT result on random 1-dim tensor and hardcoded values for
@@ -92,7 +92,7 @@ class TestQuantizer(unittest.TestCase):
         # 0.0215 in tensor2quantize nearest 0.0208 in quantization_levels -> 3 in level_indices
         expected_qtensor = torch.tensor([0, 3, 8, 13, 5, 12], dtype=torch.int32)
 
-        self.assertTrue(torch.equal(qtensor_data, expected_qtensor))
+        self.assertEqual(qtensor_data, expected_qtensor, rtol=0, atol=0, exact_device=True)
 
     r""" Tests dequantize_apot result on random 1-dim tensor
         and hardcoded values for b, k.
@@ -137,7 +137,7 @@ class TestQuantizer(unittest.TestCase):
 
         result = final_apot.data.int()
 
-        self.assertTrue(torch.equal(original_input, result))
+        self.assertEqual(original_input, result, rtol=0, atol=0, exact_device=True)
 
     r""" Tests dequantize_apot result on random 1-dim tensor
         and hardcoded values for b, k.
@@ -182,7 +182,7 @@ class TestQuantizer(unittest.TestCase):
 
         result = final_apot.data.int()
 
-        self.assertTrue(torch.equal(original_input, result))
+        self.assertEqual(original_input, result, rtol=0, atol=0, exact_device=True)
 
     r""" Tests for correct dimensions in dequantize_apot result
          on random 3-dim tensor with random dimension sizes

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -2242,7 +2242,7 @@ class TestQuantizedOps(TestCase):
             XQ = torch.quantize_per_tensor(X, scale=0.2, zero_point=0, dtype=torch.quint8)
             YQ = torch.quantize_per_tensor(Y, scale=0.2, zero_point=0, dtype=torch.quint8)
             MQ = XQ.mean((2, 3), keepdim=keep)
-            self.assertTrue(torch.equal(MQ, YQ))
+            self.assertEqual(MQ, YQ, rtol=0, atol=0, exact_device=True)
 
     @override_qengines
     def test_std(self):
@@ -3176,7 +3176,7 @@ class TestDynamicQuantizedOps(TestCase):
         w_packed_fp16 = torch.ops.quantized.linear_prepack_fp16(w, bias)
         w_unpacked_fp16 = torch.ops.quantized.linear_unpack_fp16(w_packed_fp16)
         w_fp16 = w.to(torch.float16).to(torch.float32)
-        self.assertTrue(torch.equal(w_fp16, w_unpacked_fp16[0]))
+        self.assertEqual(w_fp16, w_unpacked_fp16[0], rtol=0, atol=0, exact_device=True)
 
     @skipIfNoFBGEMM
     def test_qlinear_dynamic_fp16(self):

--- a/test/quantization/core/test_quantized_tensor.py
+++ b/test/quantization/core/test_quantized_tensor.py
@@ -1198,7 +1198,7 @@ class TestQuantizedTensor(TestCase):
             self.assertNotEqual(b.int_repr(), c.int_repr())
             # torch.equal is not supported for the cuda backend
             if device == 'cpu':
-                self.assertFalse(torch.equal(b, c))
+                self.assertNotEqual(b, c, rtol=0, atol=0, exact_device=True)
 
             # a case can't view non-contiguos Tensor
             a_int = torch.randint(0, 100, [1, 2, 3, 4], device=device, dtype=dtype)
@@ -1245,7 +1245,7 @@ class TestQuantizedTensor(TestCase):
             self.assertNotEqual(b.int_repr(), c.int_repr())
             # torch.equal is not supported for the cuda backend
             if device == 'cpu':
-                self.assertFalse(torch.equal(b, c))
+                self.assertNotEqual(b, c, rtol=0, atol=0, exact_device=True)
 
             # Throws an error if numel is wrong
             q1_int = torch.randint(0, 100, sizes1, dtype=dtype, device=device)
@@ -1279,7 +1279,7 @@ class TestQuantizedTensor(TestCase):
             self.assertNotEqual(b.int_repr(), c.int_repr())
             # torch.equal is not supported for the cuda backend
             if device == 'cpu':
-                self.assertFalse(torch.equal(b, c))
+                self.assertNotEqual(b, c, rtol=0, atol=0, exact_device=True)
 
             # we can use reshape for non-contiguous Tensor
             a_int = torch.randint(0, 100, [1, 2, 3, 4], dtype=dtype, device=device)

--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -583,12 +583,12 @@ class TestRecordHistogramObserver(QuantizationTestCase):
         x = torch.rand(3, 4)
         obs(x)
         scripted(x)
-        self.assertTrue(torch.equal(obs.get_tensor_value()[0], scripted.get_tensor_value()[0]))
+        self.assertEqual(obs.get_tensor_value()[0], scripted.get_tensor_value()[0], rtol=0, atol=0, exact_device=True)
         buf = io.BytesIO()
         torch.jit.save(scripted, buf)
         buf.seek(0)
         loaded = torch.jit.load(buf)
-        self.assertTrue(torch.equal(obs.get_tensor_value()[0], loaded.get_tensor_value()[0]))
+        self.assertEqual(obs.get_tensor_value()[0], loaded.get_tensor_value()[0], rtol=0, atol=0, exact_device=True)
 
 class TestHistogramObserver(QuantizationTestCase):
     @given(qdtype=st.sampled_from((torch.qint8, torch.quint8)),
@@ -606,12 +606,12 @@ class TestHistogramObserver(QuantizationTestCase):
             x = torch.rand(3, 4)
             obs(x)
             scripted(x)
-            self.assertTrue(torch.equal(obs.histogram, scripted.histogram))
+            self.assertEqual(obs.histogram, scripted.histogram, rtol=0, atol=0, exact_device=True)
             buf = io.BytesIO()
             torch.jit.save(scripted, buf)
             buf.seek(0)
             loaded = torch.jit.load(buf)
-            self.assertTrue(torch.equal(obs.histogram, scripted.histogram))
+            self.assertEqual(obs.histogram, scripted.histogram, rtol=0, atol=0, exact_device=True)
 
     @given(qdtype=st.sampled_from((torch.qint8, torch.quint8)),
            qscheme=st.sampled_from((torch.per_tensor_affine, torch.per_tensor_symmetric)),

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1226,7 +1226,7 @@ class TestQuantizeFx(QuantizationTestCase):
                         module.weight_scale = None
                         model.load_state_dict(state_dict)
                         module = getattr(model, module_name)
-                        self.assertTrue(torch.equal(prev_scale, module.weight_scale))
+                        self.assertEqual(prev_scale, module.weight_scale, rtol=0, atol=0, exact_device=True)
 
 
             checkWeightQParams(qr)
@@ -4912,7 +4912,7 @@ class TestQuantizeFx(QuantizationTestCase):
             m_ref = convert_to_reference_fx(m_copy)
             result = m(*example_inputs)
             result_ref = m_ref(*example_inputs)
-            self.assertTrue(torch.equal(result, result_ref))
+            self.assertEqual(result, result_ref, rtol=0, atol=0, exact_device=True)
 
     def test_ref_conv_module(self):
         """ Make sure the numerics for models with ref conv module
@@ -4950,7 +4950,7 @@ class TestQuantizeFx(QuantizationTestCase):
             m_ref = convert_to_reference_fx(m_copy)
             result = m(data)
             result_ref = m_ref(data)
-            self.assertTrue(torch.equal(result, result_ref))
+            self.assertEqual(result, result_ref, rtol=0, atol=0, exact_device=True)
 
     def test_sub_scalar(self):
         class M(torch.nn.Module):
@@ -5051,7 +5051,7 @@ class TestQuantizeFx(QuantizationTestCase):
             }
             self.checkGraphModuleNodes(m, expected_node_occurrence=expected_node_occurrence)
             # checking result match
-            self.assertTrue(torch.equal(out_ref, out))
+            self.assertEqual(out_ref, out, rtol=0, atol=0, exact_device=True)
 
     def test_convert_qconfig_mapping(self):
         class Linear(torch.nn.Module):

--- a/test/test_autocast.py
+++ b/test/test_autocast.py
@@ -59,7 +59,7 @@ class TestAutocastCPU(TestCase):
             # For example, lstm_cell returns a tuple and equal returns bool.
             def compare(first, second):
                 if isinstance(first, torch.Tensor):
-                    return torch.equal(first, second)
+                    return (first == second).all().item()
                 elif isinstance(first, collections.abc.Iterable):
                     return all(compare(f, s) for f, s in zip(first, second))
                 else:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4311,8 +4311,8 @@ Done""")
         grad = torch.nested.as_nested_tensor([torch.randn(5, 10, requires_grad=True), torch.randn(5, 10, requires_grad=True)])
         out_shape, grad_shape = _calculate_shape(out, grad, False)
 
-        assert torch.equal(out_shape, torch.tensor([[10, 5], [10, 5], [10, 5]]))
-        assert torch.equal(grad_shape, torch.tensor([[5, 10], [5, 10]]))
+        torch.testing.assert_close(out_shape, torch.tensor([[10, 5], [10, 5], [10, 5]]), rtol=0, atol=0)
+        torch.testing.assert_close(grad_shape, torch.tensor([[5, 10], [5, 10]]), rtol=0, atol=0)
 
     def test_nested_anomaly_detect_nan(self):
         size = 10

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3019,7 +3019,7 @@ torch.cuda.synchronize()
             # For example, lstm_cell returns a tuple and equal returns bool.
             def compare(first, second):
                 if isinstance(first, torch.Tensor):
-                    return torch.equal(first, second)
+                    return (first == second).all().item()
                 elif isinstance(first, collections.abc.Iterable):
                     return all(compare(f, s) for f, s in zip(first, second))
                 else:
@@ -4940,13 +4940,13 @@ class TestCudaComm(TestCase):
         for i, x in enumerate(out):
             self.assertTrue(isinstance(x, type(out2[-1])))  # x must be a tensor
             cat = torch.cat((outputs[0][i].to('cpu'), outputs[1][i].to('cpu')))
-            self.assertTrue(torch.equal(x, cat))
+            self.assertEqual(x, cat, rtol=0, atol=0, exact_device=True)
 
         out = scatter_gather.gather(outputs, 0)  # test on GPU
         for i, x in enumerate(out):
             self.assertTrue(isinstance(x, type(out2[-1])))
             cat = torch.cat((outputs[0][i].to(0), outputs[1][i].to(0)))
-            self.assertTrue(torch.equal(x, cat))
+            self.assertEqual(x, cat, rtol=0, atol=0, exact_device=True)
 
         class TestNamedTupleInput_1(NamedTuple):
             a: torch.tensor
@@ -4966,13 +4966,13 @@ class TestCudaComm(TestCase):
         for i, x in enumerate(out):
             self.assertTrue(isinstance(x, type(out2[-1])))
             cat = torch.cat((outputs[0][i].to(0), outputs[1][i].to(0)))
-            self.assertTrue(torch.equal(x, cat))
+            self.assertEqual(x, cat, rtol=0, atol=0, exact_device=True)
 
         out = scatter_gather.gather(outputs, 'cpu')  # test on CPU
         for i, x in enumerate(out):
             self.assertTrue(isinstance(x, type(out2[-1])))
             cat = torch.cat((outputs[0][i].to('cpu'), outputs[1][i].to('cpu')))
-            self.assertTrue(torch.equal(x, cat))
+            self.assertEqual(x, cat, rtol=0, atol=0, exact_device=True)
 
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync")
     def test_memory_snapshot(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -812,7 +812,7 @@ class TestJit(JitTestCase):
     def test_matrix_transpose(self):
         @torch.jit.script
         def check(x):
-            return torch.equal(x.mT, x.transpose(-2, -1))
+            return bool((x.mT == x.transpose(-2, -1)).all())
 
         x = torch.rand(3, 4)
         self.assertTrue(check(x))
@@ -820,7 +820,7 @@ class TestJit(JitTestCase):
     def test_transpose(self):
         @torch.jit.script
         def check(x):
-            return torch.equal(x.T, x.t())
+            return bool((x.T == x.t()).all())
 
         x = torch.rand(3, 4)
         self.assertTrue(check(x))
@@ -828,7 +828,7 @@ class TestJit(JitTestCase):
     def test_matrix_conj_transpose(self):
         @torch.jit.script
         def check(x):
-            return torch.equal(x.mH, x.transpose(-2, -1).conj())
+            return bool((x.mH == x.transpose(-2, -1).conj()).all())
 
         x = torch.rand(3, 4)
         self.assertTrue(check(x))
@@ -839,7 +839,7 @@ class TestJit(JitTestCase):
     def test_conj_transpose(self):
         @torch.jit.script
         def check(x):
-            return torch.equal(x.H, x.t().conj())
+            return bool((x.H == x.t().conj()).all())
 
         x = torch.rand(3, 4)
         self.assertTrue(check(x))
@@ -1204,7 +1204,7 @@ class TestJit(JitTestCase):
             # type: (Tensor, Tensor) -> Tensor
             tmp1 = torch.mul(input1, input2)
             tmp2 = torch.abs(tmp1)
-            if torch.equal(input1, input2):
+            if (input1 == input2).all():
                 tmp2 = torch.acos(tmp2)
             else:
                 tmp2 = torch.atan(tmp2)
@@ -1753,7 +1753,7 @@ graph(%Ra, %Rb):
         t_node = g2.create("prim::TensorTest").t_("a", torch.ones([2, 2]))
         self.assertEqual(t_node.attributeNames(), ["a"])
         g2.appendNode(t_node)
-        self.assertTrue(torch.equal(torch.ones(2, 2), t_node.t("a")))
+        self.assertEqual(torch.ones(2, 2), t_node.t("a"), rtol=0, atol=0, exact_device=True)
         for node in g.nodes():
             self.assertTrue(g2.findNode(node.kind()) is not None)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3161,7 +3161,7 @@ class TestMPS(TestCaseMPS):
     def test_bool_expand(self):
         x = torch.tensor([[1], [0]], dtype=torch.bool, device='mps')
         y = torch.tensor([0, 1], dtype=torch.bool, device='mps')
-        self.assertFalse(torch.equal(x.expand(2, 2), y.expand(2, 2)))
+        self.assertNotEqual(x.expand(2, 2), y.expand(2, 2), rtol=0, atol=0, exact_device=True)
 
     # Empty unary op should return tensor of the same size
     def test_empty_neg(self):
@@ -7252,7 +7252,7 @@ class TestNLLLoss(TestCaseMPS):
         # see https://github.com/pytorch/pytorch/issues/79835#issuecomment-1164984534
         x = torch.ones(4, dtype=torch.int32, device='mps')
         self.assertEqual(x + 1, torch.full((4,), 2, dtype=torch.int32, device='mps'))
-        self.assertTrue(torch.equal(x + 1.5, torch.full((4,), 2.5, device='mps')))
+        self.assertEqual(x + 1.5, torch.full((4,), 2.5, device='mps'), rtol=0, atol=0, exact_device=True)
 
     def test_types_binary_op(self):
         # Float * Bool

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -1082,31 +1082,31 @@ class TestNamedTensor(TestCase):
 
     def test_unflatten(self):
         # test args: tensor, int, namedshape
-        self.assertTrue(torch.equal(
-            torch.ones(4, names=('A',)).unflatten('A', (('A', 2), ('B', 2))),
-            torch.ones(2, 2, names=('A', 'B'))))
-        self.assertTrue(torch.equal(
-            torch.ones(4, names=('A',)).unflatten('A', [('A', 2), ('B', 2)]),
-            torch.ones(2, 2, names=('A', 'B'))))
-        self.assertTrue(torch.equal(
-            torch.ones(4, names=('A',)).unflatten('A', (['A', 2], ['B', 2])),
-            torch.ones(2, 2, names=('A', 'B'))))
-        self.assertTrue(torch.equal(
-            torch.ones(2, 10, names=('A', 'B')).unflatten('B', (['B1', -1],)),
-            torch.ones(2, 10, names=('A', 'B1'))))
-        self.assertTrue(torch.equal(
-            torch.ones(2, 3 * 4 * 5 * 6, names=('A', 'B'))
-                 .unflatten('B', (['B1', 3], ['B2', 4], ['B3', -1], ['B4', 6])),
-            torch.ones(2, 3, 4, 5, 6, names=('A', 'B1', 'B2', 'B3', 'B4'))))
-        self.assertTrue(torch.equal(
-            torch.ones(2, 0, names=('A', 'B'))
-                 .unflatten('B', (['B1', 3], ['B2', -1], ['B3', 4])),
-            torch.ones(2, 3, 0, 4, names=('A', 'B1', 'B2', 'B3'))))
+        self.assertTrue(
+            (torch.ones(4, names=('A',)).unflatten('A', (('A', 2), ('B', 2))) ==
+             torch.ones(2, 2, names=('A', 'B'))).all())
+        self.assertTrue(
+            (torch.ones(4, names=('A',)).unflatten('A', [('A', 2), ('B', 2)]) ==
+             torch.ones(2, 2, names=('A', 'B'))).all())
+        self.assertTrue(
+            (torch.ones(4, names=('A',)).unflatten('A', (['A', 2], ['B', 2])) ==
+             torch.ones(2, 2, names=('A', 'B'))).all())
+        self.assertTrue(
+            (torch.ones(2, 10, names=('A', 'B')).unflatten('B', (['B1', -1],)) ==
+             torch.ones(2, 10, names=('A', 'B1'))).all())
+        self.assertTrue(
+            (torch.ones(2, 3 * 4 * 5 * 6, names=('A', 'B'))
+                  .unflatten('B', (['B1', 3], ['B2', 4], ['B3', -1], ['B4', 6])) ==
+             torch.ones(2, 3, 4, 5, 6, names=('A', 'B1', 'B2', 'B3', 'B4'))).all())
+        self.assertTrue(
+            (torch.ones(2, 0, names=('A', 'B'))
+                  .unflatten('B', (['B1', 3], ['B2', -1], ['B3', 4])) ==
+             torch.ones(2, 3, 0, 4, names=('A', 'B1', 'B2', 'B3'))).all())
 
         # test args: namedtensor, str, namedshape
-        self.assertTrue(torch.equal(
-            torch.ones(2, 4, names=('A', 'B')).unflatten('B', (('B1', 2), ('B2', 2))),
-            torch.ones(2, 2, 2, names=('A', 'B1', 'B2'))))
+        self.assertTrue(
+            (torch.ones(2, 4, names=('A', 'B')).unflatten('B', (('B1', 2), ('B2', 2))) ==
+             torch.ones(2, 2, 2, names=('A', 'B1', 'B2'))).all())
 
         # test invalid args: namedtensor, str, sizes
         with self.assertRaisesRegex(TypeError, r"unflatten\(\): argument 'dim' \(position 1\) must be int, not str"):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1698,7 +1698,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         vector_to_parameters(vec, model.parameters())
 
         sample = next(model.parameters())[0, 0, 0]
-        self.assertTrue(torch.equal(sample.data, vec.data[:5]))
+        self.assertEqual(sample.data, vec.data[:5], rtol=0, atol=0, exact_device=True)
 
     def test_rnn_weight_norm(self):
         def check_weight_norm(l, name, num_params):
@@ -5135,9 +5135,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         # Forward random tensor
         _ = bn(torch.rand(input_size))
         # Ensure none of the buffers has been updated
-        self.assertTrue(torch.equal(num_batches, bn.num_batches_tracked))
-        self.assertTrue(torch.equal(running_mean, bn.running_mean))
-        self.assertTrue(torch.equal(running_var, bn.running_var))
+        self.assertEqual(num_batches, bn.num_batches_tracked, rtol=0, atol=0, exact_device=True)
+        self.assertEqual(running_mean, bn.running_mean, rtol=0, atol=0, exact_device=True)
+        self.assertEqual(running_var, bn.running_var, rtol=0, atol=0, exact_device=True)
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_batchnorm_nhwc_cuda(self):
@@ -5149,7 +5149,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             inp2 = inp1.contiguous(memory_format=torch.channels_last)
             out1 = model(inp1)
             out2 = model(inp2)
-            self.assertTrue(torch.equal(out1, out2))
+            self.assertEqual(out1, out2, rtol=0, atol=0, exact_device=True)
 
     def test_pairwise_distance(self):
         input1 = torch.randn(4, 4, requires_grad=True)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -283,7 +283,7 @@ class SerializationMixin:
         with gzip.open(f2.name, 'rb') as f:
             j = pickle.load(f)
             b = torch.load(f)
-        self.assertTrue(torch.equal(a, b))
+        self.assertEqual(a, b, rtol=0, atol=0, exact_device=True)
         self.assertEqual(i, j)
 
     def _test_serialization_sparse(self, weights_only):
@@ -555,7 +555,7 @@ class SerializationMixin:
         msg = 'filelike serialization with {}'
 
         b = torch.load(data)
-        self.assertTrue(torch.equal(tensor, b), msg.format(desc))
+        self.assertEqual(tensor, b), msg.format(desc, rtol=0, atol=0, exact_device=True)
 
     @unittest.skipIf((3, 8, 0) <= sys.version_info < (3, 8, 2), "See https://bugs.python.org/issue39681")
     def test_serialization_filelike_missing_attrs(self):
@@ -837,7 +837,7 @@ class TestOldSerialization(TestCase, SerializationMixin):
 
     def test_serialization_offset(self):
         a = torch.randn(5, 5)
-        b = torch.randn(1024, 1024, 512, dtype=torch.float32)
+        b = torch.randn(1024, 512, dtype=torch.float32)
         m = torch.nn.Conv2d(1, 1, (1, 3))
         i, j = 41, 43
         with tempfile.NamedTemporaryFile() as f:
@@ -846,15 +846,15 @@ class TestOldSerialization(TestCase, SerializationMixin):
             pickle.dump(j, f)
             torch.save(b, f)
             torch.save(m, f)
-            self.assertTrue(f.tell() > 2 * 1024 * 1024 * 1024)
+            self.assertTrue(f.tell() > 2 * 1024 * 1024)
             f.seek(0)
             i_loaded = pickle.load(f)
             a_loaded = torch.load(f)
             j_loaded = pickle.load(f)
             b_loaded = torch.load(f)
             m_loaded = torch.load(f)
-        self.assertTrue(torch.equal(a, a_loaded))
-        self.assertTrue(torch.equal(b, b_loaded))
+        self.assertEqual(a, a_loaded, rtol=0, atol=0, exact_device=True)
+        self.assertEqual(b, b_loaded, rtol=0, atol=0, exact_device=True)
         self.assertTrue(m.kernel_size == m_loaded.kernel_size)
         self.assertEqual(i, i_loaded)
         self.assertEqual(j, j_loaded)
@@ -862,21 +862,21 @@ class TestOldSerialization(TestCase, SerializationMixin):
     @parametrize('weights_only', (True, False))
     def test_serialization_offset_filelike(self, weights_only):
         a = torch.randn(5, 5)
-        b = torch.randn(1024, 1024, 512, dtype=torch.float32)
+        b = torch.randn(1024, 512, dtype=torch.float32)
         i, j = 41, 43
         with BytesIOContext() as f:
             pickle.dump(i, f)
             torch.save(a, f)
             pickle.dump(j, f)
             torch.save(b, f)
-            self.assertTrue(f.tell() > 2 * 1024 * 1024 * 1024)
+            self.assertTrue(f.tell() > 2 * 1024 * 1024)
             f.seek(0)
             i_loaded = pickle.load(f)
             a_loaded = torch.load(f, weights_only=weights_only)
             j_loaded = pickle.load(f)
             b_loaded = torch.load(f, weights_only=weights_only)
-        self.assertTrue(torch.equal(a, a_loaded))
-        self.assertTrue(torch.equal(b, b_loaded))
+        self.assertEqual(a, a_loaded, rtol=0, atol=0, exact_device=True)
+        self.assertEqual(b, b_loaded, rtol=0, atol=0, exact_device=True)
         self.assertEqual(i, i_loaded)
         self.assertEqual(j, j_loaded)
 

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1476,7 +1476,7 @@ class TestTensorExprFuser(BaseTestClass):
                 scripted = torch.jit.script(test)
                 out = warmup_and_run_forward(scripted, x)
                 self.assertLastGraphAllFused()
-                assert torch.equal(out, test(x))
+                torch.testing.assert_close(out, test(x), rtol=0, atol=0)
 
     def test_simple_add(self):
         val = torch._C._jit_get_te_generate_block_code()

--- a/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
@@ -17,7 +17,7 @@ def _communicate_result(result, pg):
 
     expected_result = torch.ones(1, device=torch.device(torch.cuda.current_device())) * dist.get_world_size(pg)
 
-    return torch.equal(result_tensor, expected_result)
+    return (result_tensor == expected_result).all().item()
 
 def binary_cmp(cmp_fun, types, args, kwargs=None, process_group=None):
     if len(args) != 2:

--- a/torch/distributed/tensor/parallel/multihead_attention_tp.py
+++ b/torch/distributed/tensor/parallel/multihead_attention_tp.py
@@ -151,9 +151,10 @@ class TensorParallelMultiheadAttention(torch.nn.Module):
                 self.value(value), 1, (sk, b * nh, hn)
             )
         else:
-            assert torch.equal(query, key) and torch.equal(
-                query, value
-            ), "inputs are different for self-attention."
+            torch.testing.assert_close(
+                (query, query), (key, value), rtol=0, atol=0, msg="inputs are different for self-attention."
+            )
+
             # =====================
             # Query
             # =====================

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -939,7 +939,7 @@ def expand_as(g: jit_utils.GraphContext, self, other):
         self_t = self_t.to(torch.double)
         dims = []
         for d in range(self_t.dim()):
-            if torch.equal(self_t.mean(d).unsqueeze(d).expand_as(self_t), self_t):
+            if (self_t.mean(d).unsqueeze(d).expand_as(self_t) == self_t).all():
                 dims.append(d)
                 self = g.op(
                     "Constant", value_t=self_t.mean(dims, keepdim=True).to(orig_type)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -115,9 +115,10 @@ class Foo:
 
     def __eq__(self, other):
         def eq(value, other):
-            if isinstance(value, torch.Tensor):
-                return torch.equal(value, other)
-            return value == other
+            result = value == other
+            if isinstance(result, torch.Tensor):
+                result = result.all().item()
+            return result
 
         for attr, value in self.__dict__.items():
             other_value = other.__dict__[attr]
@@ -356,7 +357,7 @@ class ControlFlowToyModel(nn.Module):
 
     def forward(self, x):
         # Second layer is used dependent on input x.
-        use_second_layer = torch.equal(x, torch.ones(20, 10, device=x.device))
+        use_second_layer = (x == torch.ones(20, 10, device=x.device)).all()
         if use_second_layer:
             return self.lin2(F.relu(self.lin1(x)))
         else:
@@ -3567,7 +3568,7 @@ class DistributedTest:
 
             for l1, l2 in zip(output_tensor_lists, expected_tensors):
                 for t1, t2 in zip(l1, l2):
-                    if not torch.equal(t1, t2):
+                    if not (t1 == t2).all():
                         return False
             return True
 
@@ -8112,7 +8113,7 @@ class DistributedTest:
                     # Control-flow that is rank and input dependent for the
                     # model.
                     use_second_layer = (
-                        torch.equal(x, torch.ones(batch, dim, device=x.device))
+                        (x == torch.ones(batch, dim, device=x.device)).all()
                         and self.rank == 1
                     )
 

--- a/torch/testing/_internal/distributed/nn/api/remote_module_test.py
+++ b/torch/testing/_internal/distributed/nn/api/remote_module_test.py
@@ -242,7 +242,7 @@ class RemoteModuleTest(CommonRemoteModuleTest):
         ):
             param_rrefs = remote_module.remote_parameters()
             self.assertEqual(len(param_rrefs), 1)
-            self.assertTrue(torch.equal(param_rrefs[0].to_here(), _PARAM_VAL))
+            self.assertEqual(param_rrefs[0].to_here(), _PARAM_VAL, rtol=0, atol=0, exact_device=True)
 
     @dist_utils.dist_init
     def test_get_module_rref(self):
@@ -257,7 +257,7 @@ class RemoteModuleTest(CommonRemoteModuleTest):
             rref = remote_module.get_module_rref()
             self.assertEqual(rref, remote_module.module_rref)
             for param in rref.to_here().parameters():
-                self.assertTrue(torch.equal(param, _PARAM_VAL))
+                self.assertEqual(param, _PARAM_VAL, rtol=0, atol=0, exact_device=True)
 
     @dist_utils.dist_init
     def test_train_eval(self):

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -71,7 +71,7 @@ def _compare_owner_value(context_id, rref, grad):
         grad = grad.to_dense()
     else:
         assert not grad.is_sparse
-    return torch.equal(x, grad)
+    return (x == grad).all()
 
 
 def create_tensor():

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -237,8 +237,7 @@ def non_cont_test(t_view, t_cont):
         raise Exception('t_view is contiguous!')
     if not t_cont.is_contiguous():
         raise Exception('t_cont is not contiguous!')
-    if not torch.equal(t_view, t_cont):
-        raise Exception('t_view is not equal to t_cont!')
+    torch.testing.assert_close(t_view, t_cont, rtol=0, atol=0, msg='t_view is not equal to t_cont!')
     return t_view
 
 def my_function(a, b, c):
@@ -1068,7 +1067,7 @@ class RpcTestCommon:
             ps_gradient = rref.rpc_sync().get_gradient(rref)
             if ps_gradient.is_sparse:
                 ps_gradient = ps_gradient.to_dense().double()
-            self.assertTrue(torch.equal(gradient, ps_gradient))
+            self.assertEqual(gradient, ps_gradient, rtol=0, atol=0, exact_device=True)
 
     def _my_parameter_server(self, sparse):
         ps_rref = RRef(MyParameterServer(self.world_size - 1))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97767
* #97766
* #97765
* #97764

Redo of #89527. Preparation for the deprecation of `torch.equal`.

I replaced

- `self.assertTrue(torch.equal(...))` with `self.assertEqual(..., rtol=0, atol=0, exact_device=True)`,
- the same for `self.assertFalse(...)` with `self.assertNotEqual(...)`, and
- `assert torch.equal(...)` with `torch.testing.assert_close(..., rtol=0, atol=0)` (note that we don't need to set `check_device=True` here since that is the default).

There were a few instances where the result of `torch.equal` is used directly. In that cases I've replaced with `(... == ...).all().item()` while sometimes also dropping the `.item()` depending on the context.

cc @mruberry @mcarilli @ptrblck @leslie-fang-intel @jgong5