### PR TITLE
Fixed cuda grads for nearest interpolation with scale factor

### DIFF
--- a/aten/src/ATen/native/cuda/UpSample.cuh
+++ b/aten/src/ATen/native/cuda/UpSample.cuh
@@ -133,21 +133,31 @@ __device__ __forceinline__ static accscalar_t area_pixel_compute_source_index(
 __device__ __forceinline__ static int nearest_neighbor_compute_source_index(
     const float scale,
     int dst_index,
-    int input_size) {
-  // index_f32 = (output_index) * scale
-  // input_index = round(index_f32)
-  // Same as a buggy OpenCV INTER_NEAREST
-  // We keep this method for BC and consider as deprecated.
-  // See nearest_neighbor_exact_compute_source_index as replacement
-  const int src_index =
-      min(static_cast<int>(floorf((dst_index) * scale)), input_size - 1);
-  return src_index;
+    int input_size,
+    int output_size) {
+  if (output_size == input_size) {
+    // no matter scale_factor, simply copy as for CPU
+    return dst_index;
+  } else if (output_size == 2 * input_size) {
+    // no matter scale_factor, shift input index as for CPU
+    return dst_index >> 1;
+  } else {
+    // index_f32 = (output_index) * scale
+    // input_index = round(index_f32)
+    // Same as a buggy OpenCV INTER_NEAREST
+    // We keep this method for BC and consider as deprecated.
+    // See nearest_neighbor_exact_compute_source_index as replacement
+    const int src_index =
+        min(static_cast<int>(floorf((dst_index) * scale)), input_size - 1);
+    return src_index;
+  }
 }
 
 __device__ __forceinline__ static int nearest_neighbor_exact_compute_source_index(
     const float scale,
     int dst_index,
-    int input_size) {
+    int input_size,
+    int output_size) {
   // index_f32 = (output_index + 0.5) * scale - 0.5
   // input_index = round(index_f32)
   // Same as Pillow and Scikit-Image/Scipy ndi.zoom
@@ -159,21 +169,32 @@ __device__ __forceinline__ static int nearest_neighbor_exact_compute_source_inde
 // see NOTE [ Nearest neighbor upsampling kernel implementation ]
 __device__ __forceinline__ static int nearest_neighbor_bw_compute_source_index(
     const float scale,
-    int dst_index,
-    int output_size) {
-  // Equivalent to buggy OpenCV INTER_NEAREST
-  // We keep this method for BC and consider as deprecated.
-  // See nearest_neighbor_exact_bw_compute_source_index as replacement
-  const int src_index =
-      min(static_cast<int>(ceilf(dst_index * scale)), output_size);
-  return src_index;
+    int dst_index,  // grad_input index
+    int output_size,  // grad_output size
+    int input_size  // grad_input size
+) {
+  if (output_size == input_size) {
+    // no matter scale_factor, simply copy as for CPU
+    return dst_index;
+  } else if (output_size == 2 * input_size) {
+    // no matter scale_factor, shift input index as for CPU
+    return dst_index << 1;
+  } else {
+    // Equivalent to buggy OpenCV INTER_NEAREST
+    // We keep this method for BC and consider as deprecated.
+    // See nearest_neighbor_exact_bw_compute_source_index as replacement
+    const int src_index =
+        min(static_cast<int>(ceilf(dst_index * scale)), output_size);
+    return src_index;
+  }
 }
 
 // see NOTE [ Nearest neighbor upsampling kernel implementation ]
 __device__ __forceinline__ static int nearest_neighbor_exact_bw_compute_source_index(
     const float scale,
     int dst_index,
-    int output_size) {
+    int output_size,
+    int input_size) {
   // Equivalent to Pillow and Scikit-Image/Scipy ndi.zoom
   const int src_index =
       min(static_cast<int>(ceilf(dst_index * scale - static_cast<float>(0.5))), output_size);

--- a/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest1d.cu
@@ -25,11 +25,11 @@ namespace {
 
 // Define a typedef to dispatch to nearest_neighbor_compute_source_index or
 // nearest_neighbor_exact_compute_source_index
-typedef int (*nn_compute_source_index_fn_t)(const float, int, int);
+typedef int (*nn_compute_source_index_fn_t)(const float, int, int, int);
 
 // Define a typedef to dispatch to nearest_neighbor_bw_compute_source_index or
 // nearest_neighbor_exact_bw_compute_source_index
-typedef int (*nn_bw_compute_source_index_fn_t)(const float, int, int);
+typedef int (*nn_bw_compute_source_index_fn_t)(const float, int, int, int);
 
 
 // see NOTE [ Nearest neighbor upsampling kernel implementation ]
@@ -50,7 +50,7 @@ __global__ void upsample_nearest1d_out_frame(
   int c = (dst_idx / dst_dim_w) % dim_c;
 
   int dst_x = dst_idx % dst_dim_w;
-  int src_x = nn_compute_source_index_fn(scale_factor, dst_x, src_dim_w);
+  int src_x = nn_compute_source_index_fn(scale_factor, dst_x, src_dim_w, dst_dim_w);
 
   int src_idx = c * src_dim_w + src_x;
   int src_stride = dim_c * src_dim_w;
@@ -85,8 +85,8 @@ __global__ void upsample_nearest1d_backward_out_frame(
   int dst_x = dst_idx % dst_dim_w;
   // note that we do not want to clamp src_x to src_dim_w, since we might
   // intentionally want to skip in case of scale_factor < 1.0
-  int src_x = nn_bw_compute_source_index_fn(scale_factor, dst_x, src_dim_w);
-  int src_x_up = nn_bw_compute_source_index_fn(scale_factor, dst_x+1, src_dim_w);
+  int src_x = nn_bw_compute_source_index_fn(scale_factor, dst_x, src_dim_w, dst_dim_w);
+  int src_x_up = nn_bw_compute_source_index_fn(scale_factor, dst_x+1, src_dim_w, dst_dim_w);
 
   for (int b = 0; b < dim_b; b++) {
     accscalar_t grad = 0;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97770
* #97769

Fixed #97135

This PR is about aligning CPU vs CUDA grad computations for nearest interpolation with scale factor. See https://github.com/pytorch/pytorch/pull/97770#discussion_r1151925947

- Updated the code:
  - fix grads for scale factors around 1 such that output size == input size
  - I also fixing forward cpu/cuda consistency for scales around 2.0 + x where output size == 2 * input size
- Added tests