### PR TITLE
[FSDP][8/N] Simplify addr padding internals

### DIFF
--- a/test/distributed/fsdp/test_fsdp_flatten_params.py
+++ b/test/distributed/fsdp/test_fsdp_flatten_params.py
@@ -555,12 +555,10 @@ class TestFlattenParams(FSDPTest):
         on rank and world size.
         """
         flat_param = handle.flat_param
-        (
-            flat_param._shard_param_offsets,
-            flat_param._shard_param_indices,
-        ) = handle._get_shard_metadata(start, end)
+        flat_param._shard_param_infos = handle._get_shard_metadata(start, end)
+        shard_metadata = handle.shard_metadata()
         self.assertEqual(
-            handle.shard_metadata(),
+            shard_metadata,
             expected,
             msg=f"{handle.shard_metadata()}, {expected}",
         )

--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 from torch import distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy
-from torch.distributed.fsdp.flat_param import _FLAT_PARAM_PADDING
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     CUDAInitMode,
@@ -151,10 +150,10 @@ class TestFSDPIgnoredModules(FSDPTest):
                 # Subtract the numel contributed from alignment padding
                 padding_numel = sum(
                     numel
-                    for (numel, pi) in zip(
-                        flat_param._wp_numels, flat_param._wp_param_infos
+                    for (numel, is_padding) in zip(
+                        flat_param._numels_with_padding, flat_param._is_padding_mask
                     )
-                    if pi is _FLAT_PARAM_PADDING
+                    if is_padding
                 )
                 flat_param_numel -= padding_numel
                 self.assertEqual(flat_param_numel, nonignored_numel)
@@ -200,10 +199,10 @@ class TestFSDPIgnoredModules(FSDPTest):
                 # Subtract the numel contributed from alignment padding
                 padding_numel = sum(
                     numel
-                    for (numel, pi) in zip(
-                        flat_param._wp_numels, flat_param._wp_param_infos
+                    for (numel, is_padding) in zip(
+                        flat_param._numels_with_padding, flat_param._is_padding_mask
                     )
-                    if pi is _FLAT_PARAM_PADDING
+                    if is_padding
                 )
                 flat_param_numel -= padding_numel
                 self.assertEqual(flat_param_numel, nonignored_numel)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97796
* #97667
* #97666
* #97665
* #97664
* #97663
* #97662
* #97661

This is a follow-up to the last PR to greatly simplify the approach. This should be much cleaner.

**Details**
Let `N` denote the number of original parameters flattened into a given flat parameter with `M` extra padding tensors.
- `_numels_with_padding`: length `N + M`
- `_is_padding_mask`: length `N + M`
- `_numels`, `_param_infos`, `_shapes`, `_fqns`, `_param_extensions`: length `N`

`_shard_param_indices` and `_shard_param_offsets` were used to determine (1) if a given original parameter is in the local shard and if so, then (2) what is its offset in the _sharded_ flat parameter, and (3) how many numel are in the _sharded_ flat parameter.

This PR reworks how to achieve (1), (2), and (3) to allow for simplifying the previously mentioned data structures. In particular, it saves one extra tuple `_shard_param_infos: Tuple[_ShardParamInfo, ...]` of length `N` where each `_ShardParamInfo` entry gives exactly the needed info. For example, the offset into the sharded flat parameter is now pre-computed, so we do not need to do `offset = 0; offset += numel_in_shard` over a `for` loop each time now.

For optimizer state dict, `FSDPParamInfo.param_indices` now maps to the indexes with respect to the length `N` data structures, not the length `N + M` ones. The only purpose of `param_indices` is to be able to index into `flat_param._shard_param_infos[i]` to get the contained info to flatten the unsharded original parameter optimizer state and extract the part in the local shard.

