### PR TITLE
[wip] add the torch.float8_e4m3fn data type

### DIFF
--- a/aten/src/ATen/AccumulateType.h
+++ b/aten/src/ATen/AccumulateType.h
@@ -3,6 +3,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
+#include <c10/util/float8.h>
 
 // Defines the accumulation type for a scalar type.
 // Example:
@@ -103,6 +104,10 @@ struct AccumulateType<bool, true> {
   using type = bool;
 };
 template <>
+struct AccumulateType<float8_e4m3fn, true> {
+  using type = float;
+};
+template <>
 struct AccumulateType<Half, false> {
   using type = float;
 };
@@ -169,6 +174,10 @@ struct AccumulateType<int64_t, false> {
 template <>
 struct AccumulateType<bool, false> {
   using type = bool;
+};
+template <>
+struct AccumulateType<float8_e4m3fn, false> {
+  using type = float;
 };
 
 template <typename T, bool is_cuda>

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -67,6 +67,9 @@ DLDataType getDLDataType(const Tensor& t) {
     case ScalarType::Bits16:
       TORCH_CHECK(false, "Bit types are not supported by dlpack");
       break;
+    case ScalarType::Float8_E4M3FN:
+      TORCH_CHECK(false, "Float8 types are not supported by dlpack");
+      break;
     case ScalarType::Undefined:
       TORCH_CHECK(false, "Undefined is not a valid ScalarType");
     case ScalarType::NumOptions:

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -520,6 +520,23 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND4(                       \
           SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, SCALARTYPE4, __VA_ARGS__))
 
+#define AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND5(         \
+    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, SCALARTYPE4, SCALARTYPE5, ...) \
+  AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX(__VA_ARGS__)        \
+  AT_DISPATCH_CASE(SCALARTYPE1, __VA_ARGS__)                 \
+  AT_DISPATCH_CASE(SCALARTYPE2, __VA_ARGS__)                 \
+  AT_DISPATCH_CASE(SCALARTYPE3, __VA_ARGS__)                 \
+  AT_DISPATCH_CASE(SCALARTYPE4, __VA_ARGS__)                 \
+  AT_DISPATCH_CASE(SCALARTYPE5, __VA_ARGS__)
+
+#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND5(                          \
+    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, SCALARTYPE4, SCALARTYPE5, TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(                                                    \
+      TYPE,                                                              \
+      NAME,                                                              \
+      AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND5(                       \
+          SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, SCALARTYPE4, SCALARTYPE5, __VA_ARGS__))
+
 #define AT_DISPATCH_INDEX_TYPES(TYPE, NAME, ...)     \
   AT_DISPATCH_SWITCH(                                \
       TYPE,                                          \

--- a/aten/src/ATen/native/Scalar.cpp
+++ b/aten/src/ATen/native/Scalar.cpp
@@ -30,8 +30,8 @@ Scalar item(const Tensor& self) {
 
 Scalar _local_scalar_dense_cpu(const Tensor& self) {
   Scalar r;
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(
-    kComplexHalf, kHalf, kBool, kBFloat16, self.scalar_type(), "_local_scalar_dense_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND5(
+    kComplexHalf, kHalf, kBool, kBFloat16, kFloat8_E4M3FN, self.scalar_type(), "_local_scalar_dense_cpu", [&] {
         scalar_t value = *self.data_ptr<scalar_t>();
         r = Scalar(value);
       });

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -237,9 +237,10 @@ void copy_kernel(TensorIterator& iter, bool /*non_blocking*/) {
     sizeof(BFloat16) == strides_out[0] && (sizeof(float) == strides_in[0] || strides_in[0] == 0)))) {
     float_bfloat16_copy_kernel(iter, requires_neg);
   } else {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(ScalarType::ComplexHalf, ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, dtype, "copy_", [&] {
+    // TODO(before land): also add float8_e5m2
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND5(ScalarType::ComplexHalf, ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, ScalarType::Float8_E4M3FN, dtype, "copy_", [&] {
       using dest_t = scalar_t;
-      AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(ScalarType::ComplexHalf, ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, iter.dtype(1), "copy_", [&] {
+      AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND5(ScalarType::ComplexHalf, ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16, ScalarType::Float8_E4M3FN, iter.dtype(1), "copy_", [&] {
         if (iter.has_contiguous_first_dim()) {
           TORCH_INTERNAL_ASSERT(iter.ninputs() == 1);
           TORCH_INTERNAL_ASSERT(iter.noutputs() == 1);

--- a/aten/src/ATen/native/cuda/jit_utils.h
+++ b/aten/src/ATen/native/cuda/jit_utils.h
@@ -186,6 +186,9 @@ template <> inline std::string typeName<at::Half>(){
 template <> inline std::string typeName<at::BFloat16>(){
     return "at::BFloat16";
 }
+template <> inline std::string typeName<at::float8_e4m3fn>(){
+    return "at::float8_e4m3fn";
+}
 
 #define TYPE_NAME_CASE(ctype, scalartype)                    \
   case ScalarType::scalartype:  return typeName<ctype>();

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -19,6 +19,9 @@ namespace at {
 
  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(DEFINE_CAST)
  AT_FORALL_QINT_TYPES(DEFINE_CAST)
+ // TODO(before land) delete this, keeping around until PR is ready for review
+ // to mark the code spot in case we split float8 out from SCALAR_TYPES
+ // AT_FORALL_FLOAT8_TYPES(DEFINE_CAST)
  #undef DEFINE_CAST
 
  #define DEFINE_ITEM(T, name)      \
@@ -28,6 +31,9 @@ namespace at {
    }
 
  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(DEFINE_ITEM)
+ // TODO(before land) delete this, keeping around until PR is ready for review
+ // to mark the code spot in case we split float8 out from SCALAR_TYPES
+ // AT_FORALL_FLOAT8_TYPES(DEFINE_ITEM)
  #undef DEFINE_ITEM
 
  } //namespace at

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -87,6 +87,9 @@ class C10_API Scalar {
 
   // TODO: Support ComplexHalf accessor
   AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(DEFINE_ACCESSOR)
+  // TODO(before land) delete this, keeping around until PR is ready for review
+  // to mark the code spot in case we split float8 out from SCALAR_TYPES
+  // AT_FORALL_FLOAT8_TYPES(DEFINE_ACCESSOR)
 
 #undef DEFINE_ACCESSOR
 

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -2,6 +2,7 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
+#include <c10/util/float8.h>
 
 #include <type_traits>
 
@@ -73,6 +74,15 @@ struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::BFloat16> {
   C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
       c10::Half>
   apply(c10::BFloat16 src) {
+    return static_cast<c10::complex<c10::Half>>(c10::complex<float>{src});
+  }
+};
+
+template <>
+struct static_cast_with_inter_type<c10::complex<c10::Half>, c10::float8_e4m3fn> {
+  C10_HOST_DEVICE __ubsan_ignore_undefined__ static inline c10::complex<
+      c10::Half>
+  apply(c10::float8_e4m3fn src) {
     return static_cast<c10::complex<c10::Half>>(c10::complex<float>{src});
   }
 };

--- a/c10/util/float8.h
+++ b/c10/util/float8.h
@@ -1,0 +1,166 @@
+#pragma once
+#include <cstdint>
+#include <limits>
+#include <math.h>
+
+#include <c10/macros/Macros.h>
+
+namespace c10 {
+
+namespace detail {
+
+// the kernels below are copy-pasted from fbgemm_gpu:
+// https://github.com/pytorch/FBGEMM/blob/277677039bae25b2570a73013b03bfaa9d2a523e/fbgemm_gpu/include/fbgemm_gpu/quantize_ops_utils.h
+// TODO(future): switch fbgemm_gpu to use these
+
+// reference conversion kernels between float32 and float8
+using fint32 = union fint32 {
+  uint32_t I;
+  float F;
+};
+
+// TODO: add a flag later to control whether underflow
+// flushes to 0 or clips to smallest denorm number.
+inline C10_HOST_DEVICE uint8_t float_to_hfp8(float val_fp, int ebits, int exponent_bias, float max_pos) {
+  int mbits = 7 - ebits;
+  fint32 val_out, bouncer, smallest_normal;
+
+  val_out.F = val_fp;
+  uint32_t sign_bit = val_out.I & 0x80000000;
+  val_out.I = val_out.I & 0x7FFFFFFF;
+  val_out.F = fminf(val_out.F, max_pos);
+
+  smallest_normal.I = (127 - exponent_bias + 1)
+      << 23; // smallest hfp8 normal number in FP32
+  // I don't know if the input "min_pos" is the smallest denormalized number
+  // or the smallest normalized number. The test below needs to be done with
+  // the smallest normal number, which is the numerical value 2^(1-bias)
+
+  // The conversion for denormalized values are slightly different. HFP8 is so
+  // low precision that gradual underflow is probably crucial
+  if (val_out.F >= smallest_normal.F) {
+    // Use round to nearest even. We make use of the standard rounding mechanism
+    // in FP32 rather than rounding the mantissa and handling tie-to-even and
+    // incrementing exponent We want to round of 23-mbits of the FP32 value
+    // val_in This can be done by adding a power of 2 exactly 23-mbits larger
+    // than the exponent of val_in This forces val_in to be moved to the right
+    // and rounding exact at the location corresponding to having mbits of
+    // explicit mantissa left
+    bouncer.I = (val_out.I & 0xFF800000) + ((23 - mbits) << 23);
+    val_out.F = (bouncer.F + val_out.F) - bouncer.F;
+    // adding the bouncer rounds off bits, and subtracting bouncer
+    // leaves the desired value, albeit in FP32 encoding
+    // All we need is to change the exponent encoding to using "bias"
+    val_out.I = uint32_t(val_out.I - ((127 - exponent_bias) << 23))
+        << (8 - ebits);
+    val_out.I =
+        ((val_out.I | sign_bit) >>
+         24); // the 8 lsbs is the desired HFP8 encoding
+
+  } else {
+    // When the value is in the denormal range, IEEE numbers essentially becomes
+    // a fixed point number. The lsb is the smallest non-zero number
+    // 2^(1-bias-mbits) Hence, we define the bouncer so that its lsb is this
+    // smallest non-zero number Adding the input to this bouncer forces rounding
+    // to occur appropriately Also, in this situation, after adding the bouncer,
+    // the 8 least significant bits of the sum is already the HFP8 encoding of
+    // the desired result. Just need to restore the sign bit
+    bouncer.I = (127 + (23 + (1 - exponent_bias - mbits))) << 23;
+    val_out.F = bouncer.F + val_out.F;
+    val_out.I = val_out.I | (sign_bit >> 24);
+    ;
+  }
+
+  uint8_t bfp8_val = val_out.I; // get the 8 lsbs
+  return bfp8_val;
+}
+
+inline C10_HOST_DEVICE float hfp8_to_float(uint8_t hfp8_val, int ebits, int exponent_bias) {
+  fint32 val_out, sign, multiplier;
+
+  sign.I = (hfp8_val & 0x80) << 24;
+  val_out.I = (hfp8_val & 0x7F) << (24 - (8 - ebits));
+  // so that the mantissa bits start at the mantissa bit positions of FP32
+  // encoding
+
+  // Let the hfp8 mantissa bits correspond to the value frac, 0 <= frac < 1
+  // So if the hfp8 value is a normal number, it's value is 2^e x (1+frac)
+  // where e is its (true, unbiased) exponent
+  // If the hfp8 value is denormal, the value is 2^(1-bias) x frac
+
+  // However, the bit pattern in the 8-bit exponent field of val_out.F
+  // is bias+e when hfp8 is normal, and 0 when hfp8 is subnormal.
+  // So, as an FP32 value, when hfp8 is normal, val_out.F represents the value
+  // of 2^(bias+e-127) * (1+frac)
+  // And when hfp8 is subnormal, val_out.F is also subnormal, and represents the
+  // value of 2^(-126) * frac In either case, val_out.F corresponds to
+  // 2^(bias-127) * (value of hfp8 input) Thus, if we multiply val_out.F by
+  // 2^(127-bias), we obtain the hfp8 value as an FP32 number
+
+  multiplier.I = (127 + (127 - exponent_bias))
+      << 23; // multiplier.F is 2^(127-bias)
+  val_out.F *= multiplier.F;
+  val_out.I |= sign.I;
+  return val_out.F;
+}
+
+// constants for float8_e4m3fn
+const float E4M3FN_MAX_POS = 448.f;
+const int E4M3FN_EBITS = 4;
+const int E4M3FN_EXPONENT_BIAS = 7;
+
+} // namespace detail
+
+/**
+ * float8_e4m3fn is the fp8 dtype from https://arxiv.org/abs/2209.05433
+ * with a 4 bit exponent and a 3 bit mantissa. The exponent bias
+ * is assumed to be 7. The `fn` suffix is to signify that only finite and NaN
+ * values are supported.
+ */
+struct alignas(1) float8_e4m3fn {
+  uint8_t val_;
+  float8_e4m3fn() = default;
+
+  struct from_bits_t {};
+  static constexpr C10_HOST_DEVICE from_bits_t from_bits() {
+    return from_bits_t();
+  }
+
+  constexpr C10_HOST_DEVICE float8_e4m3fn(uint8_t bits, from_bits_t) : val_(bits) {};
+  inline C10_HOST_DEVICE float8_e4m3fn(float value) {
+    val_ = detail::float_to_hfp8(
+      value, detail::E4M3FN_EBITS, detail::E4M3FN_EXPONENT_BIAS, detail::E4M3FN_MAX_POS);
+  };
+  inline C10_HOST_DEVICE operator float() const {
+    return detail::hfp8_to_float(
+      val_, detail::E4M3FN_EBITS, detail::E4M3FN_EXPONENT_BIAS);
+  };
+};
+
+// TODO(before land): add float8_e5m2
+
+} // namespace c10
+
+
+namespace std {
+
+template <>
+class numeric_limits<c10::float8_e4m3fn> {
+  public:
+    static constexpr bool is_signed = true;
+    // e4m3_fn does not support infinity
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    // 3 digits in mantissa + leading digit
+    static constexpr int digits = 4;
+    // lowest representable number is -448 (0.1111.110)
+    static constexpr c10::float8_e4m3fn lowest() {
+      return at::float8_e4m3fn(0x7E, at::float8_e4m3fn::from_bits());
+    }
+    // highest representable number is 448 (1.1111.110)
+    static constexpr c10::float8_e4m3fn max() {
+      return at::float8_e4m3fn(0xFE, at::float8_e4m3fn::from_bits());
+    }
+};
+
+} // namespace std

--- a/test/quantization/core/experimental/test_float8.py
+++ b/test/quantization/core/experimental/test_float8.py
@@ -1,0 +1,51 @@
+# Owner(s): ["oncall: quantization"]
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+# TODO(before land): consider moving to test_torch.py, for better consistency
+# with other dtypes
+class TestFloat8(TestCase):
+
+    def test_creation_with_zeros(self):
+        x = torch.zeros(8, dtype=torch.float8_e4m3fn)
+
+    def test_e4m3fn_casts(self):
+        for dtype in (torch.float32, torch.float16):
+            x = torch.randn(16, dtype=torch.float)
+            x_fp8 = x.to(torch.float8_e4m3fn)
+            x_orig_dtype = x_fp8.to(torch.float)
+
+    def test_e4m3fn_numerics(self):
+        # ensure that our format matches https://arxiv.org/pdf/2209.05433.pdf, Table 1
+
+        def _compare(bits_str, expected_fp32, comp_name):
+            bits_int = int(bits_str, 2)
+            tensor_int = torch.tensor([bits_int], dtype=torch.uint8)
+            tensor_fp8 = tensor_int.view(torch.float8_e4m3fn)
+            tensor_fp32 = tensor_fp8.float()
+            ref_tensor_fp32 = torch.tensor([expected_fp32], dtype=torch.float)
+            self.assertTrue(
+                torch.allclose(tensor_fp32, ref_tensor_fp32),
+                f"{comp_name} failed: expected {expected_fp32}, got {tensor_fp32.item()}")
+
+        # TODO(future PR): figure out what to do with infinity, currently it saturates to max_pos
+        # _compare("inf", "01111111", float("inf"))
+        # _compare("neg_inf", "11111111", -1 * float("inf"))
+        _compare("00000000", 0.0, "zero")
+        _compare("10000000", -0.0, "neg_zero")
+        _compare("01111110", 448.0, "max_normal")
+        _compare("11111110", -448.0, "neg_max_normal")
+        _compare("00001000", 2 ** -6, "min_normal")
+        _compare("10001000", -1 * (2 ** -6), "neg_min_normal")
+        _compare("00000111", 0.875 * (2 ** -6), "max_subnorm")
+        _compare("10000111", -0.875 * (2 ** -6), "neg_max_subnorm")
+        _compare("00000001", 2 ** -9, "min_subnorm")
+        _compare("10000001", -1 * (2 ** -9), "neg_min_subnorm")
+
+    # TODO(before land): better verification of casting numerics
+    # TODO(future PR): CUDA support
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -137,6 +137,7 @@ except ImportError:
 
 # Experimental functionality
 from quantization.core.experimental.test_bits import TestBits  # noqa: F401
+from quantization.core.experimental.test_float8 import TestFloat8  # noqa: F401
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -110,6 +110,9 @@ inline PyObject* load_scalar(void* data, at::ScalarType scalarType) {
     case at::kBFloat16:
       return PyFloat_FromDouble(
           at::convert<double, at::BFloat16>(*(at::BFloat16*)data));
+    case at::kFloat8_E4M3FN:
+      return PyFloat_FromDouble(
+          at::convert<double, at::float8_e4m3fn>(*(at::float8_e4m3fn*)data));
     default:
       throw std::runtime_error("invalid type");
   }

--- a/torch/csrc/utils/tensor_dtypes.cpp
+++ b/torch/csrc/utils/tensor_dtypes.cpp
@@ -62,6 +62,8 @@ std::pair<std::string, std::string> getDtypeNames(at::ScalarType scalarType) {
       return std::make_pair("bits8", "");
     case at::ScalarType::Bits16:
       return std::make_pair("bits16", "");
+    case at::ScalarType::Float8_E4M3FN:
+      return std::make_pair("float8_e4m3fn", "");
     default:
       throw std::runtime_error("Unimplemented scalar type");
   }


### PR DESCRIPTION
Summary:

This PR adds initial support for the 8-bit floating point types, matching the spec in https://arxiv.org/pdf/2209.05433.pdf . We are adding this to PyTorch to enable easier experimentation with these dtypes by the research community.

Note: we do not yet have an RFC on a full end to end experience in PyTorch for training and inference with float8, as it is too early to know what a good UEX will look like. Specifically, we need to better understand the performance and accuracy implications of scaling factor calculation to inform the UEX design.

Note: we are aware that there are other specifications of float8, and float8 is not yet in the IEEE spec. We are adding these dtypes to facilitate easier experimentation with the hardware which is currently available, and we are happy to follow-up on other float8 flavors when there is a need.

Note: the scaling factor is outside of the `float8` dtypes, and is expected to be implemented by the user workflow.

Note: the current PR only has `torch.float8_e4m3fn`, to speed up initial review and implementation of any requested changes. Once this passes initial review, I will add `torch.float8_e5m2` in the same manner to this PR. It will be easiest to land the two dtypes together due to some Meta-only changes which will have to be done on the Meta-only version of this PR.

The specific support added here is:

```
// tensor creation with `torch.zeros`
x = torch.zeros(4, dtype=torch.float8_e4m3fn)

// conversion to and from float8 dtypes
// conversion between float32 and float8 uses the kernels copied from fbgemm
// conversion between other dtypes and float8 converts to float32 as an intermediate step
x = torch.randn(4, dtype=torch.float)
x_float8 = x.to(torch.float8_e4m3fn)
x_float32 = x_float8.to(torch.float32)

// printing out the tensor for debugging
// note: the values are converted to float32 before being printed
print(x_float8)

// numerical correctness of the format (see test cases)
```

The following is not in this PR but which we plan to address in the near future:
* ensure all of the functionality above works on CUDA

Test plan:

```
python test/test_quantization.py TestFloat8
```

Fixes #ISSUE_NUMBER


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10