### PR TITLE
Skip test_function_returns_input in the case where it is expected to leak

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -1040,6 +1040,10 @@ class TestAutogradFunction(TestCase):
     @parametrize("save_tensors", ["input", "output", "neither"])
     @parametrize("mark_dirty", [True, False])
     def test_function_returns_input(self, device, inner_requires_grad, save_for, save_tensors, mark_dirty):
+        # This case is expected to leak.
+        if inner_requires_grad and save_for == "vjp" and save_tensors == "output" and mark_dirty:
+            # TODO(soulitzer): we should make this case error somehow
+            return
         class A(torch.autograd.Function):
             @staticmethod
             def forward(x):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97799
* #97212

See `test_function_returns_input_inner_requires_grad_True_save_for_vjp_save_tensors_output_mark_dirty_True_cuda ` in https://ossci-raw-job-status.s3.amazonaws.com/log/12334610983.

This test is expected to leak for this case because we are saving an output as-is which creates a reference cycle.