### PR TITLE
Use remote master as the linter merge base

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1,4 +1,4 @@
-merge_base_with = "master"
+merge_base_with = "origin/master"
 
 [[linter]]
 code = 'FLAKE8'


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/96794

Sometimes people never update their local `master` branch. Their workflow instead consists of fetching commits from git and directly creating branches off of the remote `master` branch (e.g. via `git checkout -b <mybranch> origin/master`

For those people, their local `master` is very old and out of date, creating an unreasonably old lint base that tends to catch all sorts of unrelated linter errors.

Anyone with an updated `master` branch will naturally have an updated pointer to the remote `master`, so this change makes lintrunner friendly to both behavior patterns