### PR TITLE
Fix strip_function_call in GuardBuilder

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5246,6 +5246,19 @@ class MiscTests(torch._dynamo.test_case.TestCase):
                 prof.report()
             )
 
+    def test_guards_strip_function_call(self):
+        from torch._dynamo.guards import strip_function_call
+
+        test_case = [
+            ("___odict_getitem(a, 1)", "a"),
+            ("a.layers[slice(2)][0]._xyz", "a"),
+            ("getattr(a.layers[slice(2)][0]._abc, '0')", "a"),
+            ("getattr(getattr(a.x[3], '0'), '3')", "a"),
+        ]
+        # strip_function_call should extract the object from the string.
+        for name, expect_obj in test_case:
+            self.assertEqual(strip_function_call(name), expect_obj)
+
 
 class CustomFunc1(torch.autograd.Function):
     @staticmethod

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -5254,6 +5254,8 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             ("a.layers[slice(2)][0]._xyz", "a"),
             ("getattr(a.layers[slice(2)][0]._abc, '0')", "a"),
             ("getattr(getattr(a.x[3], '0'), '3')", "a"),
+            ("a.layers[slice(None, -1, None)][0]._xyz", "a"),
+            ("a.layers[func('offset', -1, None)][0]._xyz", "a"),
         ]
         # strip_function_call should extract the object from the string.
         for name, expect_obj in test_case:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -76,10 +76,10 @@ def strip_function_call(name):
     valid_name = re.compile("[A-Za-z_].*")
     curr = ""
     for char in name:
-        if char in ' (':
+        if char in " (":
             curr = ""
-        elif char in '),[]':
-            if curr and curr!='None' and valid_name.match(curr):
+        elif char in "),[]":
+            if curr and curr != "None" and valid_name.match(curr):
                 return strip_function_call(curr)
         else:
             curr += char

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -67,9 +67,13 @@ CLOSURE_VARS = collections.OrderedDict(
 def strip_function_call(name):
     """
     "___odict_getitem(a, 1)" => "a"
+    "a.layers[slice(2)][0]._xyz" ==> "a"
+    "getattr(a.layers[slice(2)][0]._abc, '0')" ==> "a"
+    "getattr(getattr(a.x[3], '0'), '3')" ==> "a"
     """
-    m = re.search(r"([a-z0-9_]+)\(([^(),]+)[^()]*\)", name)
-    if m and m.group(1) != "slice":
+    # recursively find valid object name in fuction's first param
+    m = re.search(r"([a-z0-9_]+)\(([A-Za-z_][^),]*)[^()]*", name)
+    if m:
         return strip_function_call(m.group(2))
     return strip_getattr_getitem(name)
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -70,11 +70,20 @@ def strip_function_call(name):
     "a.layers[slice(2)][0]._xyz" ==> "a"
     "getattr(a.layers[slice(2)][0]._abc, '0')" ==> "a"
     "getattr(getattr(a.x[3], '0'), '3')" ==> "a"
+    "a.layers[slice(None, -1, None)][0]._xyz" ==> "a"
     """
-    # recursively find valid object name in fuction's first param
-    m = re.search(r"([a-z0-9_]+)\(([A-Za-z_][^),]*)[^()]*", name)
-    if m:
-        return strip_function_call(m.group(2))
+    # recursively find valid object name in fuction
+    valid_name = re.compile("[A-Za-z_].*")
+    curr = ""
+    for char in name:
+        if char in ' (':
+            curr = ""
+        elif char in '),[]':
+            if curr and curr!='None' and valid_name.match(curr):
+                return strip_function_call(curr)
+        else:
+            curr += char
+
     return strip_getattr_getitem(name)
 
 


### PR DESCRIPTION
repo:
from #92670 this address one of the bug for TorchDynamo

pytest ./generated/test_PeterouZh_CIPS_3D.py -k test_003

Issue:
In GuardBuilder, when parsing argnames with "getattr(a.layers[slice(2)][0]._abc, '0')" it returns "getattr(a", where it suppose to return "a", and thus causing SyntaxError.

This PR fix the regex and add couple test cases.

Fixes #ISSUE_NUMBER


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire