### PR TITLE
Disable dynamo tracing torchrec.distributed

### DIFF
--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -162,12 +162,7 @@ def add(import_name: str):
     assert isinstance(import_name, str)
     try:
         module_spec = importlib.util.find_spec(import_name)
-    except AttributeError as e:
-        # handle fbgemm conflict caused by import torchrec.
-        if "'fbgemm' object has no attribute" in str(e):
-            return
-        raise
-    except ImportError:
+    except Exception:
         return
     if not module_spec:
         return

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -162,7 +162,7 @@ def add(import_name: str):
     assert isinstance(import_name, str)
     try:
         module_spec = importlib.util.find_spec(import_name)
-    except ImportError:
+    except Exception:
         return
     if not module_spec:
         return

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -160,7 +160,10 @@ def add(import_name: str):
     if isinstance(import_name, types.ModuleType):
         return add(import_name.__name__)
     assert isinstance(import_name, str)
-    module_spec = importlib.util.find_spec(import_name)
+    try:
+        module_spec = importlib.util.find_spec(import_name)
+    except ImportError:
+        return
     if not module_spec:
         return
     origin = module_spec.origin
@@ -198,6 +201,7 @@ for _name in (
     "tensorflow",
     "tensorrt",
     "torch2trt",
+    "torchrec.distributed",
     "tqdm",
     "tree",
     "tvm",

--- a/torch/_dynamo/skipfiles.py
+++ b/torch/_dynamo/skipfiles.py
@@ -162,7 +162,12 @@ def add(import_name: str):
     assert isinstance(import_name, str)
     try:
         module_spec = importlib.util.find_spec(import_name)
-    except Exception:
+    except AttributeError as e:
+        # handle fbgemm conflict caused by import torchrec.
+        if "'fbgemm' object has no attribute" in str(e):
+            return
+        raise
+    except ImportError:
         return
     if not module_spec:
         return


### PR DESCRIPTION
This was used to unblock Meta internal use cases, where ```torchrec.distributed``` was used, however, it can't be traced by dynamo properly right now.
We were sending the same fix(#90087) several months ago, but was reverted due to ```fbgemm``` conflicts. This PR catches ```Exception``` rather than ```ImportError``` which can handle the conflicts. 


cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire