### PR TITLE
[dynamo] Remove special case for torch.nn methods

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -281,6 +281,17 @@ class UserMethodVariable(UserFunctionVariable):
     def python_type(self):
         return types.MethodType
 
+    def call_function(
+        self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
+    ) -> "VariableTracker":
+        if isinstance(self.obj, variables.NNModuleVariable):
+            module_attr = getattr(self.fn, "__module__", "")
+            if self.is_constant:
+                return self.obj.call_method(
+                    tx, self.fn.__name__, args, kwargs, constant=self.is_constant
+                ).add_options(self)
+        return super().call_function(tx, args, kwargs)
+
     def num_parameters(self):
         return super().num_parameters() - 1
 

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -281,21 +281,6 @@ class UserMethodVariable(UserFunctionVariable):
     def python_type(self):
         return types.MethodType
 
-    def call_function(
-        self, tx, args: "List[VariableTracker]", kwargs: "Dict[str, VariableTracker]"
-    ) -> "VariableTracker":
-        if isinstance(self.obj, variables.NNModuleVariable):
-            module_attr = getattr(self.fn, "__module__", "")
-            if (
-                module_attr is not None
-                and module_attr.startswith("torch.nn.")
-                or self.is_constant
-            ):
-                return self.obj.call_method(
-                    tx, self.fn.__name__, args, kwargs, constant=self.is_constant
-                ).add_options(self)
-        return super().call_function(tx, args, kwargs)
-
     def num_parameters(self):
         return super().num_parameters() - 1
 


### PR DESCRIPTION
This PR removes a special case written for torch.nn methods, which creates inconsistencies between dynamo-traced external `nn.Modules` and internal modules.

The PR is part of the effort on #95021. Trying to get dynamo to stop inlining specific "opaque" user modules/functions on one hand, while allowing users to inline composite (but internal) pytorch modules such as `nn.TransformerEncoderLayer`.

cc @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @Xia-Weiwen @wenzhe-nrv @jiayisunx @desertfire