### PR TITLE
Revisit `torch._six.string_classes` removal (#94709)

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -335,7 +335,7 @@ class MyPythonStore(dist.Store):
         self.store = {}
 
     def set(self, key, value):
-        if not isinstance(key, str):
+        if not isinstance(key, (str, bytes)):
             raise AssertionError("Expected set to be called with string key")
         if type(value) is not bytes:
             raise AssertionError("Expected set to be called with bytes value")

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -47,7 +47,7 @@ def _cast(value, dtype):
     if isinstance(value, torch.Tensor):
         is_eligible = (value.is_floating_point() and value.is_cuda and (value.dtype is not torch.float64))
         return value.to(dtype) if is_eligible else value
-    elif isinstance(value, str):
+    elif isinstance(value, (str, bytes)):
         return value
     elif HAS_NUMPY and isinstance(value, np.ndarray):
         return value

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -90,7 +90,7 @@ def _rendezvous_helper(url: str, rank: int, world_size_opt: Optional[int], **kwa
 
 
 def rendezvous(url: str, rank: int = -1, world_size: int = -1, **kwargs):
-    if not isinstance(url, str):
+    if not isinstance(url, (str, bytes)):
         raise RuntimeError("`url` must be a string. {}: {}".format(type(url), url))
 
     if not isinstance(rank, numbers.Integral):

--- a/torch/onnx/_internal/jit_utils.py
+++ b/torch/onnx/_internal/jit_utils.py
@@ -310,8 +310,7 @@ def _create_node(
 @_beartype.beartype
 def _is_onnx_list(value):
     return (
-        not isinstance(value, (str, bytes))
-        and not isinstance(value, torch.Tensor)
+        not isinstance(value, (str, bytes, torch.Tensor))
         and isinstance(value, Iterable)
     )
 

--- a/torch/onnx/_internal/jit_utils.py
+++ b/torch/onnx/_internal/jit_utils.py
@@ -310,7 +310,7 @@ def _create_node(
 @_beartype.beartype
 def _is_onnx_list(value):
     return (
-        not isinstance(value, str)
+        not isinstance(value, (str, bytes))
         and not isinstance(value, torch.Tensor)
         and isinstance(value, Iterable)
     )

--- a/torch/onnx/_internal/jit_utils.py
+++ b/torch/onnx/_internal/jit_utils.py
@@ -309,9 +309,8 @@ def _create_node(
 
 @_beartype.beartype
 def _is_onnx_list(value):
-    return (
-        not isinstance(value, (str, bytes, torch.Tensor))
-        and isinstance(value, Iterable)
+    return isinstance(value, Iterable) and not isinstance(
+        value, (str, bytes, torch.Tensor)
     )
 
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1080,7 +1080,7 @@ def _get_restore_location(map_location):
         def restore_location(storage, location):
             location = map_location.get(location, location)
             return default_restore_location(storage, location)
-    elif isinstance(map_location, str):
+    elif isinstance(map_location, (str, bytes)):
         def restore_location(storage, location):
             return default_restore_location(storage, map_location)
     elif isinstance(map_location, torch.device):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1978,7 +1978,7 @@ class UnittestPair(Pair):
 
 
 class StringPair(UnittestPair):
-    CLS = str
+    CLS = (str, bytes)
     TYPE_NAME = "string"
 
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -396,8 +396,7 @@ class DataLoader(Generic[T_co]):
                             ('multiprocessing_context option '
                              'should specify a valid start method in {!r}, but got '
                              'multiprocessing_context={!r}').format(valid_start_methods, multiprocessing_context))
-                    # error: Argument 1 to "get_context" has incompatible type "Union[str, bytes]"; expected "str"  [arg-type]
-                    multiprocessing_context = multiprocessing.get_context(multiprocessing_context)  # type: ignore[arg-type]
+                    multiprocessing_context = multiprocessing.get_context(multiprocessing_context)
 
                 if not isinstance(multiprocessing_context, python_multiprocessing.context.BaseContext):
                     raise TypeError(('multiprocessing_context option should be a valid context '


### PR DESCRIPTION
Revisit `torch._six.string_classes` (which is `(str, bytes)`) removal: `isinstance(obj, string_classes) -> isinstance(obj, str)`.

Both `str` and `bytes` are `Sequence` classes.

```python
In [1]: from typing import Sequence

In [2]: issubclass(bytes, Sequence)
Out[2]: True

In [3]: issubclass(str, Sequence)
Out[3]: True
```

Re-add `bytes` to type guards like:

```python
def is_seq(obj):
    return isinstance(obj, Sequence) and not isinstance(obj, (str, bytes))
```

Ref:

- https://github.com/pytorch/pytorch/pull/94709#issuecomment-1487282912
- #97737
- #97789