### PR TITLE
[aot] fix disable amp for runtime wrapper

### DIFF
--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1295,7 +1295,8 @@ def aot_dispatch_base(flat_fn, flat_args: List[Tensor], aot_config: AOTConfig, *
         compiled_fw,
         runtime_metadata=fw_metadata,
         trace_joint=False,
-        keep_input_mutations=aot_config.keep_inference_input_mutations
+        keep_input_mutations=aot_config.keep_inference_input_mutations,
+        disable_amp=disable_amp
     )
 
     return compiled_fn
@@ -2096,6 +2097,7 @@ def create_runtime_wrapper(
     runtime_metadata: ViewAndMutationMeta,
     trace_joint: bool,
     keep_input_mutations: bool,
+    disable_amp: bool
 ):
     if not hasattr(compiled_fn, "_boxed_call"):
         compiled_fn = make_boxed_func(compiled_fn)
@@ -2106,13 +2108,13 @@ def create_runtime_wrapper(
                 all_outs = call_func_with_args(
                     compiled_fn,
                     args,
-                    disable_amp=True,
+                    disable_amp=disable_amp,
                 )
         else:
             all_outs = call_func_with_args(
                 compiled_fn,
                 args,
-                disable_amp=True,
+                disable_amp=disable_amp,
             )
 
         num_mutated_inps = runtime_metadata.num_mutated_inputs
@@ -2567,6 +2569,7 @@ def aot_dispatch_autograd(flat_fn, flat_args: List[Any], aot_config: AOTConfig, 
         runtime_metadata=fw_metadata,
         trace_joint=True,
         keep_input_mutations=False,
+        disable_amp=disable_amp
     )
 
     if not config.debug_assert:


### PR DESCRIPTION
For the current runtime wrapper in aot, `disable_amp` is always set to True. In fact, we would like to avoid disabling autocast if possible because accessing TLS is slow. In this PR, `disable_amp` depends on whether there is any autocast enabled instead of always being True. Many operators would get an improvement of performance (inductor v.s. eager) with this fix.

Example of operators' 0.8 speedup in torchbench (inductor v.s. eager):
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/xuanliao/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/xuanliao/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

</head>

<body link="#0563C1" vlink="#954F72">



  | current | new
-- | -- | --
aten.hardsigmoid.default | 0.709372349 | 0.81414306
aten.tanh.default | 0.715227805 | 0.855556349
aten.add.Scalar | 0.682292123 | 0.860371222
aten.sigmoid_backward.default | 0.688039934 | 0.915606579



</body>

</html>


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10