### PR TITLE
[BE] Enable flake8-bugprone rule B007

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,7 @@ ignore =
     # to line this up with executable bit
     EXE001,
     # these ignores are from flake8-bugbear; please fix!
-    B007,B008,B017,B019,B020,B023,B024,B026,B027,B028,B903,B904,B905,B906,B907
+    B008,B017,B019,B020,B023,B024,B026,B027,B028,B903,B904,B905,B906,B907
     # these ignores are from flake8-comprehensions; please fix!
     C407,C417
     # these ignores are from flake8-logging-format; please fix!

--- a/.github/scripts/test_gitutils.py
+++ b/.github/scripts/test_gitutils.py
@@ -28,7 +28,7 @@ class TestPeekableIterator(TestCase):
 
     def test_peek(self, input_: str = "abcdef") -> None:
         iter_ = PeekableIterator(input_)
-        for idx, c in enumerate(iter_):
+        for idx, _c in enumerate(iter_):
             if idx + 1 < len(input_):
                 self.assertEqual(iter_.peek(), input_[idx + 1])
             else:

--- a/benchmarks/distributed/ddp/benchmark.py
+++ b/benchmarks/distributed/ddp/benchmark.py
@@ -112,7 +112,7 @@ def sweep(benchmark):
     def print_header():
         local_print("\n")
         local_print("%22s" % "")
-        for p in [50, 75, 90, 95]:
+        for _p in [50, 75, 90, 95]:
             local_print("%14s%10s" % ("sec/iter", "ex/sec"))
         local_print("\n")
 

--- a/benchmarks/dynamo/distributed.py
+++ b/benchmarks/dynamo/distributed.py
@@ -33,7 +33,7 @@ def torchviz_model(args, model, inputs, rank):
 
 def profile_model(args, model, inputs, rank):
     with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
-        for i in range(args.repeat):
+        for _i in range(args.repeat):
             with record_function("Forward"):
                 outputs = model(*inputs)
                 loss = reduce_to_scalar_loss(outputs)

--- a/benchmarks/dynamo/training_loss.py
+++ b/benchmarks/dynamo/training_loss.py
@@ -63,7 +63,7 @@ def model_training_evaluation(
     else:
         # Support backends: eager, aot_eager, aot_nvfuser and inductor
         opt_training_iter_fn = torch._dynamo.optimize(backend)(training_iter_fn)
-    for epoch in range(num_epochs):
+    for _epoch in range(num_epochs):
         running_loss = 0.0
         for i, batch in enumerate(train_dataloader, 0):
             batch = {k: v.to(device) for k, v in batch.items()}

--- a/benchmarks/fastrnns/factory.py
+++ b/benchmarks/fastrnns/factory.py
@@ -303,7 +303,7 @@ def layernorm_pytorch_lstm_creator(**kwargs):
         # Layernorm cudnn LSTM in the forward pass
         seq_len = len(input.unbind(0))
         hy, cy = new_hidden
-        for i in range(seq_len):
+        for _i in range(seq_len):
             ln_i_output = ln_i(ln_input1)
             ln_h_output = ln_h(ln_input1)
             cy = ln_c(cy)

--- a/benchmarks/fastrnns/scratch.py
+++ b/benchmarks/fastrnns/scratch.py
@@ -9,7 +9,7 @@ def fn(x, scale, shift):
 @torch.jit.script
 def recurrent(x, scale, shift):
     y = x
-    for i in range(100):
+    for _i in range(100):
         y = fn(y, scale, shift)
     return y
 
@@ -30,7 +30,7 @@ import torch
 @torch.jit.script
 def recurrent_scaleshift(x, scale, shift):
     y = x
-    for i in range(64):
+    for _i in range(64):
         y = scale * y + shift
     return y
 

--- a/benchmarks/framework_overhead_benchmark/SimpleAddModule.py
+++ b/benchmarks/framework_overhead_benchmark/SimpleAddModule.py
@@ -3,7 +3,7 @@ from utils import NUM_LOOP_ITERS
 
 def add_tensors_loop(x, y):
     z = torch.add(x, y)
-    for i in range(NUM_LOOP_ITERS):
+    for _i in range(NUM_LOOP_ITERS):
         z = torch.add(z, x)
     return z
 

--- a/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
+++ b/benchmarks/functional_autograd_benchmark/functional_autograd_benchmark.py
@@ -211,7 +211,7 @@ def run_model(model_getter: GetterType, args: Any, task: str, run_once_fn: Calla
     run_once_fn(model, inp, task, v, maybe_check_consistency=True)
 
     elapsed = []
-    for it in range(args.num_iters):
+    for _it in range(args.num_iters):
         do_sync()
         start = time.time()
         run_once_fn(model, inp, task, v)

--- a/benchmarks/functional_autograd_benchmark/utils.py
+++ b/benchmarks/functional_autograd_benchmark/utils.py
@@ -53,7 +53,7 @@ def extract_weights(mod: nn.Module) -> Tuple[Tuple[Tensor, ...], List[str]]:
     orig_params = tuple(mod.parameters())
     # Remove all the parameters in the model
     names = []
-    for name, p in list(mod.named_parameters()):
+    for name, _p in list(mod.named_parameters()):
         _del_nested_attr(mod, name.split("."))
         names.append(name)
 

--- a/benchmarks/functional_autograd_benchmark/vision_models.py
+++ b/benchmarks/functional_autograd_benchmark/vision_models.py
@@ -94,7 +94,7 @@ def get_detr(device: torch.device) -> GetterReturnType:
 
     inputs = torch.rand(N, 3, 800, 1200, device=device)
     labels = []
-    for idx in range(N):
+    for _idx in range(N):
         targets = {}
         n_targets: int = int(torch.randint(5, 10, size=tuple()).item())
         label = torch.randint(5, 10, size=(n_targets,), device=device)

--- a/benchmarks/instruction_counts/execution/runner.py
+++ b/benchmarks/instruction_counts/execution/runner.py
@@ -166,7 +166,7 @@ class Runner:
 
     def _enqueue_new_jobs(self) -> None:
         work_queue: List[WorkOrder] = []
-        for i, work_order in enumerate(self._work_queue):
+        for _i, work_order in enumerate(self._work_queue):
             self._currently_processed = work_order
             cpu_list = self._core_pool.reserve(work_order.timer_args.num_threads)
 

--- a/benchmarks/nested/nested_bmm_bench.py
+++ b/benchmarks/nested/nested_bmm_bench.py
@@ -12,7 +12,7 @@ def bench(nt_a, nt_b, niter):
     start_event = torch.cuda.Event(enable_timing=True)
     end_event = torch.cuda.Event(enable_timing=True)
     start_event.record()
-    for iter in range(niter):
+    for _iter in range(niter):
         nt_c = nt_a.bmm(nt_b)
     end_event.record()
     torch.cuda.synchronize()

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -273,7 +273,7 @@ def random_sample_configs(**configs):
 
     configs_attrs_list = []
     randomsample = RandomSample(configs)
-    for i in range(configs["total_samples"]):
+    for _i in range(configs["total_samples"]):
         tmp_attr_list = randomsample.get_one_set_of_inputs()
         tmp_attr_list.append({"tags" : '_'.join(configs["tags"])})
         configs_attrs_list.append(tmp_attr_list)

--- a/benchmarks/operator_benchmark/c2/concat_test.py
+++ b/benchmarks/operator_benchmark/c2/concat_test.py
@@ -101,7 +101,7 @@ class ConcatBenchmark(op_bench_c2.Caffe2BenchmarkBase):
         if type(sizes) == list and N == -1:
             gen_sizes = sizes
         else:
-            for i in range(N):
+            for _i in range(N):
                 gen_sizes.append([old_size() if callable(old_size) else old_size for old_size in sizes])
 
         for s in gen_sizes:

--- a/benchmarks/operator_benchmark/pt/cat_test.py
+++ b/benchmarks/operator_benchmark/pt/cat_test.py
@@ -94,7 +94,7 @@ class CatBenchmark(op_bench.TorchBenchmarkBase):
         if type(sizes) == list and N == -1:
             gen_sizes = sizes
         else:
-            for i in range(N):
+            for _i in range(N):
                 gen_sizes.append([old_size() if callable(old_size) else old_size for old_size in sizes])
 
         for s in gen_sizes:

--- a/benchmarks/operator_benchmark/pt/stack_test.py
+++ b/benchmarks/operator_benchmark/pt/stack_test.py
@@ -71,7 +71,7 @@ class StackBenchmark(op_bench.TorchBenchmarkBase):
         if type(sizes) == list and N == -1:
             gen_sizes = sizes
         else:
-            for i in range(N):
+            for _i in range(N):
                 gen_sizes.append([old_size() if callable(old_size) else old_size for old_size in sizes])
 
         for s in gen_sizes:

--- a/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
+++ b/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
@@ -9,7 +9,7 @@ class TestConsumeOp(unittest.TestCase):
         iters = 6
 
         def foo(x):
-            for i in range(iters):
+            for _i in range(iters):
                 result = torch.ops.operator_benchmark._consume(torch.sum(x))
             return result
 
@@ -27,7 +27,7 @@ class TestConsumeOp(unittest.TestCase):
         iters = 6
 
         def foo(x):
-            for i in range(iters):
+            for _i in range(iters):
                 result = torch.ops.operator_benchmark._consume(torch.chunk(x, 2))
             return result
 

--- a/benchmarks/profiler_benchmark/profiler_bench.py
+++ b/benchmarks/profiler_benchmark/profiler_bench.py
@@ -8,17 +8,17 @@ from torch.utils.benchmark import Timer
 PARALLEL_TASKS_NUM = 4
 INTERNAL_ITER = None
 def loop_workload(x):
-    for i in range(INTERNAL_ITER):
+    for _i in range(INTERNAL_ITER):
         x = torch.mm(x, x)
     return x
 
 def parallel_workload(x):
     def parallel_task(x):
-        for i in range(int(INTERNAL_ITER / PARALLEL_TASKS_NUM)):
+        for _i in range(int(INTERNAL_ITER / PARALLEL_TASKS_NUM)):
             x = torch.mm(x, x)
         return x
     futs = []
-    for i in range(PARALLEL_TASKS_NUM):
+    for _i in range(PARALLEL_TASKS_NUM):
         futs.append(torch.jit._fork(parallel_task, x))
     for i in range(PARALLEL_TASKS_NUM):
         torch.jit._wait(futs[i])

--- a/benchmarks/sparse/utils.py
+++ b/benchmarks/sparse/utils.py
@@ -33,7 +33,7 @@ def gen_sparse_coo(shape, nnz):
     dense = np.random.randn(*shape)
     values = []
     indices = [[], []]
-    for n in range(nnz):
+    for _n in range(nnz):
         row = random.randint(0, shape[0] - 1)
         col = random.randint(0, shape[1] - 1)
         indices[0].append(row)

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -289,7 +289,7 @@ class DynamicShape:
     # pre-compute inputs so the creations of random tensors
     # do not add to the compute time
     def load_inputs(self):
-        for i in range(self.SAMPLE_SIZE - 1):
+        for _i in range(self.SAMPLE_SIZE - 1):
             self.instantiate_input()
 
     # returns a randomized shape

--- a/benchmarks/tensorexpr/microbenchmarks.py
+++ b/benchmarks/tensorexpr/microbenchmarks.py
@@ -193,7 +193,7 @@ def run_benchmarks(benchmarks, sizes):
                     for _ in range(10):
                         cg.call([tA, tB, tX])
                     start = time.time()
-                    for it in range(iters):
+                    for _it in range(iters):
                         cg.call([tA, tB, tX])
                     time1 = time.time() - start
 
@@ -203,7 +203,7 @@ def run_benchmarks(benchmarks, sizes):
                     for _ in range(10):
                         tR = fn()
                     start = time.time()
-                    for it in range(iters):
+                    for _it in range(iters):
                         tR = fn()
                     time2 = time.time() - start
 
@@ -225,7 +225,7 @@ def dump_plot(df, sizes):
     keys = []
     vals = []
     indexed = df[df['N'] == df['M']]
-    for index, row in indexed.iterrows():
+    for _index, row in indexed.iterrows():
         keys.append(row['name'])
         vals.append(row['ratio'])
 

--- a/caffe2/experiments/python/SparseTransformer.py
+++ b/caffe2/experiments/python/SparseTransformer.py
@@ -149,7 +149,7 @@ def Prune2Sparse(cur, id2node, name2id, ops, model):
         transFCRelu(cur, id2node, name2id, ops, model)
 
     cur.visited = True
-    for name, n in cur.ops.iteritems():
+    for _name, n in cur.ops.iteritems():
         Prune2Sparse(n, id2node, name2id, ops, model)
 
 

--- a/caffe2/experiments/python/convnet_benchmarks.py
+++ b/caffe2/experiments/python/convnet_benchmarks.py
@@ -609,7 +609,7 @@ def Benchmark(model_gen, arg):
 
     workspace.RunNetOnce(model.param_init_net)
     workspace.CreateNet(model.net)
-    for i in range(arg.warmup_iterations):
+    for _i in range(arg.warmup_iterations):
         workspace.RunNet(model.net.Proto().name)
 
     plan = core.Plan("plan")

--- a/caffe2/python/dataio.py
+++ b/caffe2/python/dataio.py
@@ -546,7 +546,7 @@ class CompositeReader(Reader):
         fields = []
         stop_blobs = []
         all_sub_read_nets = []
-        for name, reader in zip(self._names, self._readers):
+        for _name, reader in zip(self._names, self._readers):
             sub_read_nets, should_stop, record = reader.read_record_ex(
                 local_init_net, local_finish_net)
             stop_blobs.append(should_stop)

--- a/caffe2/python/operator_test/checkpoint_test.py
+++ b/caffe2/python/operator_test/checkpoint_test.py
@@ -27,7 +27,7 @@ class CheckpointTest(test_util.TestCase):
                        db=os.path.join(temp_root, "test_checkpoint_at_%05d"),
                        db_type="leveldb", every=10, absolute_path=True)
         self.assertTrue(workspace.CreateNet(net))
-        for i in range(100):
+        for _i in range(100):
             self.assertTrue(workspace.RunNet("test_checkpoint"))
         for i in range(1, 10):
             # Print statements are only for debugging purposes.

--- a/caffe2/python/operator_test/counter_ops_test.py
+++ b/caffe2/python/operator_test/counter_ops_test.py
@@ -66,7 +66,7 @@ class TestCounterOps(TestCase):
             workspace.RunOperatorOnce(core.CreateOperator(
                 'Save', ['serialized_c'], [], absolute_path=1,
                 db_type='minidb', db=tmp.name))
-            for i in range(10):
+            for _i in range(10):
                 workspace.RunOperatorOnce(core.CreateOperator(
                     'CountDown', ['serialized_c'], ['t8']))
             workspace.RunOperatorOnce(core.CreateOperator(

--- a/caffe2/python/operator_test/load_save_test.py
+++ b/caffe2/python/operator_test/load_save_test.py
@@ -572,7 +572,7 @@ class TestLoadSave(TestLoadSaveBase):
         self.load_and_check_blobs(blobs, [tmp_file])
 
         blob_chunks = self._read_chunk_info(Path(tmp_file))
-        for blob_name, chunks in blob_chunks.items():
+        for _blob_name, chunks in blob_chunks.items():
             self.assertEqual(len(chunks), expected_num_chunks)
 
     def testSaveWithChunkSize(self) -> None:
@@ -688,7 +688,7 @@ class TestLoadSave(TestLoadSaveBase):
         self.load_and_check_blobs(blobs, [tmp_file])
 
         blob_chunks = self._read_chunk_info(Path(tmp_file))
-        for blob_name, chunks in blob_chunks.items():
+        for _blob_name, chunks in blob_chunks.items():
             self.assertEqual(len(chunks), expected_num_chunks)
 
     def testSaveFloatToBfloat16(self) -> None:

--- a/caffe2/python/operator_test/pack_ops_test.py
+++ b/caffe2/python/operator_test/pack_ops_test.py
@@ -117,7 +117,7 @@ class TestTensorPackOps(serial.SerializedTestCase):
                 return data
             output = None
             start = 0
-            for i, length in enumerate(lengths):
+            for _i, length in enumerate(lengths):
                 new_len = max_length if length > max_length else length
                 chunk = data[start: start + new_len]
                 if output is None:

--- a/caffe2/python/operator_test/quantile_test.py
+++ b/caffe2/python/operator_test/quantile_test.py
@@ -47,7 +47,7 @@ class TestQuantile(hu.HypothesisTestCase):
     def test_quantile_1(self):
         inputs = []
         num_tensors = 5
-        for i in range(num_tensors):
+        for _i in range(num_tensors):
             dim = np.random.randint(5, 100)
             inputs.append(np.random.rand(dim))
         self._test_quantile(inputs=inputs, quantile=0.2, abs=1, tol=1e-4)
@@ -55,7 +55,7 @@ class TestQuantile(hu.HypothesisTestCase):
     def test_quantile_2(self):
         inputs = []
         num_tensors = 5
-        for i in range(num_tensors):
+        for _i in range(num_tensors):
             dim = np.random.randint(5, 100)
             inputs.append(np.random.rand(dim))
         self._test_quantile(inputs=inputs, quantile=1e-6, abs=0, tol=1e-3)
@@ -63,7 +63,7 @@ class TestQuantile(hu.HypothesisTestCase):
     def test_quantile_3(self):
         inputs = []
         num_tensors = 5
-        for i in range(num_tensors):
+        for _i in range(num_tensors):
             dim1 = np.random.randint(5, 100)
             dim2 = np.random.randint(5, 100)
             inputs.append(np.random.rand(dim1, dim2))
@@ -72,7 +72,7 @@ class TestQuantile(hu.HypothesisTestCase):
     def test_quantile_4(self):
         inputs = []
         num_tensors = 5
-        for i in range(num_tensors):
+        for _i in range(num_tensors):
             dim1 = np.random.randint(5, 100)
             dim2 = np.random.randint(5, 100)
             inputs.append(np.random.rand(dim1, dim2))

--- a/caffe2/python/operator_test/torch_integration_test.py
+++ b/caffe2/python/operator_test/torch_integration_test.py
@@ -640,9 +640,9 @@ class TorchIntegration(hu.HypothesisTestCase):
         batch_size = len(roi_counts)
         im_dims = np.random.randint(100, 600, batch_size)
         rpn_rois_and_scores = []
-        for i in range(5):
+        for _i in range(5):
             rpn_rois_and_scores.append(torch.tensor(generate_rois(roi_counts, im_dims)))
-        for i in range(5):
+        for _i in range(5):
             rpn_rois_and_scores.append(torch.rand(sum(roi_counts)))
 
         rois = torch.ops._caffe2.CollectRpnProposals(

--- a/caffe2/python/text_file_reader.py
+++ b/caffe2/python/text_file_reader.py
@@ -26,7 +26,7 @@ class TextFileReader(Reader):
             batch_size : Number of rows to read at a time.
         """
         assert isinstance(schema, Struct), 'Schema must be a schema.Struct'
-        for name, child in schema.get_children():
+        for _name, child in schema.get_children():
             assert isinstance(child, Scalar), (
                 'Only scalar fields are supported in TextFileReader.')
         field_types = [

--- a/caffe2/python/trt/test_pt_onnx_trt.py
+++ b/caffe2/python/trt/test_pt_onnx_trt.py
@@ -95,7 +95,7 @@ class Test_PT_ONNX_TRT(unittest.TestCase):
             h_input, d_input, h_output, d_output, stream = allocate_buffers(engine)
             with engine.create_execution_context() as context:
                 err_count = 0
-                for index, f in enumerate(self.image_files):
+                for _index, f in enumerate(self.image_files):
                     test_case = load_normalized_test_case(input_shape, f,\
                         h_input, normalization_hint)
                     cuda.memcpy_htod_async(d_input, h_input, stream)

--- a/caffe2/quantization/server/dnnlowp_test_utils.py
+++ b/caffe2/quantization/server/dnnlowp_test_utils.py
@@ -417,7 +417,7 @@ def run_conv_or_fc(
 
     if init_net:
         test_case.ws.run(init_net)
-    for i in range(1 if engine == "" else 2):
+    for _i in range(1 if engine == "" else 2):
         test_case.ws.run(net)
         Y = test_case.ws.blobs["Y"].fetch()
         if order:
@@ -442,7 +442,7 @@ def run_conv_or_fc(
         if init_net:
             workspace.RunNetOnce(init_net)
         workspace.CreateNet(net)
-        for i in range(2):
+        for _i in range(2):
             workspace.RunNet(net)
             Y = workspace.FetchBlob("Y")
             if order:

--- a/docs/caffe2/process.py
+++ b/docs/caffe2/process.py
@@ -26,7 +26,7 @@ os.system("git checkout caffe2/distributed/.")
 os.system("git checkout caffe2/experiments/.")
 os.system("git checkout caffe2/python/.")
 
-for root, dirs, files in os.walk("."):
+for root, _dirs, files in os.walk("."):
     for file in files:
         if (file.endswith(".py") and not file.endswith("_test.py") and not file.endswith("__.py")):
             filepath = os.path.join(root, file)

--- a/functorch/dim/reference.py
+++ b/functorch/dim/reference.py
@@ -418,7 +418,7 @@ def t__getitem__(self, input):
                 dims_seen.record(idx)
                 view_sizes.append(sz)
             elif isinstance(idx, (tuple, list)) and idx and isinstance(idx[0], Dim):
-                for d in idx:
+                for _d in idx:
                     dims_seen.record(idx)
                 _bind_dims_to_size(sz, idx, f'offset {i}')
                 view_sizes.extend(d.size for d in idx)

--- a/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-ptonly.py
@@ -193,7 +193,7 @@ def test(db, net, device, epoch, log):
     qry_losses = []
     qry_accs = []
 
-    for batch_idx in range(n_test_iter):
+    for _batch_idx in range(n_test_iter):
         x_spt, y_spt, x_qry, y_qry = db.next('test')
         task_num, setsz, c_, h, w = x_spt.size()
 

--- a/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
+++ b/functorch/examples/maml_omniglot/maml-omniglot-transforms.py
@@ -193,7 +193,7 @@ def test(db, net, device, epoch, log):
     qry_losses = []
     qry_accs = []
 
-    for batch_idx in range(n_test_iter):
+    for _batch_idx in range(n_test_iter):
         x_spt, y_spt, x_qry, y_qry = db.next('test')
         task_num, setsz, c_, h, w = x_spt.size()
 

--- a/functorch/examples/maml_omniglot/support/omniglot_loaders.py
+++ b/functorch/examples/maml_omniglot/support/omniglot_loaders.py
@@ -115,7 +115,7 @@ class Omniglot(data.Dataset):
 
 def find_classes(root_dir):
     retour = []
-    for (root, dirs, files) in os.walk(root_dir):
+    for (root, _dirs, files) in os.walk(root_dir):
         for f in files:
             if (f.endswith("png")):
                 r = root.split('/')
@@ -237,10 +237,10 @@ class OmniglotNShot:
         data_cache = []
 
         # print('preload next 50 caches of batchsz of batch.')
-        for sample in range(10):  # num of episodes
+        for _sample in range(10):  # num of episodes
 
             x_spts, y_spts, x_qrys, y_qrys = [], [], [], []
-            for i in range(self.batchsz):  # one batch means one set
+            for _i in range(self.batchsz):  # one batch means one set
 
                 x_spt, y_spt, x_qry, y_qry = [], [], [], []
                 selected_cls = np.random.choice(data_pack.shape[0], self.n_way, False)

--- a/functorch/examples/maml_regression/evjang.py
+++ b/functorch/examples/maml_regression/evjang.py
@@ -99,7 +99,7 @@ t_y = t_A * torch.sin(t_x + t_b)
 opt.zero_grad()
 
 t_params = params
-for k in range(5):
+for _k in range(5):
     t_f = net(t_x, t_params)
     t_loss = F.l1_loss(t_f, t_y)
 

--- a/functorch/examples/maml_regression/evjang_transforms.py
+++ b/functorch/examples/maml_regression/evjang_transforms.py
@@ -106,7 +106,7 @@ t_y = t_A * torch.sin(t_x + t_b)
 opt.zero_grad()
 
 t_params = params
-for k in range(5):
+for _k in range(5):
     t_f = net(t_params, t_x)
     t_loss = F.l1_loss(t_f, t_y)
 

--- a/functorch/examples/maml_regression/evjang_transforms_module.py
+++ b/functorch/examples/maml_regression/evjang_transforms_module.py
@@ -103,7 +103,7 @@ t_y = t_A * torch.sin(t_x + t_b)
 opt.zero_grad()
 
 t_params = params
-for k in range(5):
+for _k in range(5):
     t_f = net(t_params, t_x)
     t_loss = F.l1_loss(t_f, t_y)
 

--- a/test/ao/sparsity/test_sparsifier.py
+++ b/test/ao/sparsity/test_sparsifier.py
@@ -99,7 +99,7 @@ class TestBaseSparsifier(TestCase):
         sparsifier0.prepare(model0, [{'tensor_fqn': 'linear.weight'}])
         mask = model0.linear.parametrizations['weight'][0].mask
         mask.data = torch.arange(mask.shape[0] * mask.shape[1]).reshape(mask.shape)
-        for step in range(step_count):
+        for _step in range(step_count):
             sparsifier0.step()
         state_dict = sparsifier0.state_dict()
 

--- a/test/ao/sparsity/test_sparsity_utils.py
+++ b/test/ao/sparsity/test_sparsity_utils.py
@@ -125,7 +125,7 @@ class TestSparsityUtilFunctions(TestCase):
             list_of_modules = [m for _, m in model.named_modules()] + [model]
             for module in list_of_modules:
                 module_fqn = module_to_fqn(model, module)
-                for tensor_name, tensor in module.named_parameters(recurse=False):
+                for tensor_name, _tensor in module.named_parameters(recurse=False):
                     tensor_fqn = (
                         module_fqn + ("." if module_fqn != "" else "") + tensor_name
                     )

--- a/test/bottleneck_test/test_cuda.py
+++ b/test/bottleneck_test/test_cuda.py
@@ -18,7 +18,7 @@ def main():
     data = torch.randn(10, 50).cuda()
     model = Model().cuda()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.0001)
-    for i in range(10):
+    for _i in range(10):
         optimizer.zero_grad()
         loss = model(data)
         loss.backward()

--- a/test/cpp_api_parity/functional_impl_check.py
+++ b/test/cpp_api_parity/functional_impl_check.py
@@ -225,7 +225,7 @@ def build_cpp_tests(unit_test_class, print_cpp_source=False):
     assert len(unit_test_class.functional_test_params_map) > 0
     cpp_sources = TORCH_NN_COMMON_TEST_HARNESS + SAMPLE_FUNCTIONAL_CPP_SOURCE
     functions = []
-    for test_name, test_params in unit_test_class.functional_test_params_map.items():
+    for _test_name, test_params in unit_test_class.functional_test_params_map.items():
         cpp_sources += generate_test_cpp_sources(test_params=test_params, template=TORCH_NN_FUNCTIONAL_TEST_FORWARD)
         functions.append('{}_test_forward'.format(test_params.functional_variant_name))
     if print_cpp_source:

--- a/test/cpp_api_parity/module_impl_check.py
+++ b/test/cpp_api_parity/module_impl_check.py
@@ -292,7 +292,7 @@ def build_cpp_tests(unit_test_class, print_cpp_source=False):
     assert len(unit_test_class.module_test_params_map) > 0
     cpp_sources = TORCH_NN_COMMON_TEST_HARNESS + SAMPLE_MODULE_CPP_SOURCE
     functions = []
-    for test_name, test_params in unit_test_class.module_test_params_map.items():
+    for _test_name, test_params in unit_test_class.module_test_params_map.items():
         cpp_sources += generate_test_cpp_sources(
             test_params=test_params, template=TORCH_NN_MODULE_TEST_FORWARD_BACKWARD)
         functions.append('{}_test_forward_backward'.format(test_params.module_variant_name))

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -49,7 +49,7 @@ class ChunkAllShardingPlanner(ShardingPlanner):
     def build_plan(self, module: nn.Module) -> ShardingPlan:
         named_params = module.named_parameters()
         plan = {}
-        for name, param in named_params:
+        for name, _param in named_params:
             plan[name] = ChunkShardingSpec(self.dim, placements=self.devices)
 
         return ShardingPlan(plan=plan)

--- a/test/distributed/elastic/timer/file_based_local_timer_test.py
+++ b/test/distributed/elastic/timer/file_based_local_timer_test.py
@@ -110,7 +110,7 @@ if not (IS_WINDOWS or IS_MACOS):
             num_clients = 10
             num_requests_per_client = 10
             processes = []
-            for i in range(num_clients):
+            for _i in range(num_clients):
                 p = mp.Process(target=func, args=(num_requests_per_client, self.file_path))
                 processes.append(p)
                 p.start()
@@ -143,7 +143,7 @@ if not (IS_WINDOWS or IS_MACOS):
         """
         client = timer.FileTimerClient(file_path)
         sem.release()
-        for i in range(0, n):
+        for _i in range(0, n):
             client.acquire("test_scope", 0)
             time.sleep(interval)
 

--- a/test/distributed/fsdp/test_checkpoint_wrapper.py
+++ b/test/distributed/fsdp/test_checkpoint_wrapper.py
@@ -128,7 +128,7 @@ class CheckpointWrapperTest(TestCase):
                     if use_reentrant
                     else CheckpointImpl.NO_REENTRANT,
                 )
-                for i in range(self.n):
+                for _i in range(self.n):
                     l = nn.Sequential(
                         nn.Linear(256, 256), nn.Linear(256, 256), nn.Linear(256, 256)
                     )
@@ -256,7 +256,7 @@ class CheckpointWrapperTest(TestCase):
                     )
 
                 inp = torch.randn(4, 10, requires_grad=True)
-                for i in range(6):
+                for _i in range(6):
                     # Kwarg input
                     loss = model(x=inp).sum()
                     self.assertTrue(loss.requires_grad)

--- a/test/distributed/fsdp/test_fsdp_freezing_weights.py
+++ b/test/distributed/fsdp/test_fsdp_freezing_weights.py
@@ -124,7 +124,7 @@ class TestFreezingWeights(FSDPTest):
         criterion = nn.CrossEntropyLoss()
         optimizer = optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
 
-        for iteration in range(3):
+        for _iteration in range(3):
             out = model(batch)
             fake_loss = criterion(out, target)
             optimizer.zero_grad()

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -211,7 +211,7 @@ class TestFSDPMisc(FSDPTest):
         )
         x = torch.randn(10, 10, device="cuda")
         y = torch.randn(10, 10, device="cuda")
-        for i in range(4):
+        for _i in range(4):
             if use_second_layer:
                 a, b = fsdp(x, y)
             else:

--- a/test/distributed/fsdp/test_fsdp_multiple_wrapping.py
+++ b/test/distributed/fsdp/test_fsdp_multiple_wrapping.py
@@ -44,7 +44,7 @@ class TestMultipleWrapping(FSDPTest):
         model = FSDP(inner_model).cuda()
         optim = SGD(model.parameters(), lr=0.1)
 
-        for i in range(3):
+        for _i in range(3):
             input = torch.rand((1, 5), dtype=torch.float).cuda()
             input.requires_grad = True
             output = model(input)

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -1648,7 +1648,7 @@ class TestFSDPOptimState(FSDPTest):
         )
 
         # Make optim1 has a different state.
-        for i in range(5):
+        for _i in range(5):
             batch = torch.rand(5, 8).cuda()
             loss = models[1](batch).sum()
             loss.backward()

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -250,7 +250,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
         model = FSDP(copy.deepcopy(base_model), self.process_group, **fsdp_kwargs)
         model = torch.compile(model)
         optim = torch.optim.Adam(model.parameters(), lr=1e-2)
-        for i in range(10):
+        for _i in range(10):
             losses = []
             inp = ref_model.get_input(torch.device("cuda"))
             for _model, _optim in ((ref_model, ref_optim), (model, optim)):

--- a/test/distributed/pipeline/sync/test_balance.py
+++ b/test/distributed/pipeline/sync/test_balance.py
@@ -83,7 +83,7 @@ def test_balance_by_size_latent():
             self.times = times
 
         def forward(self, x):
-            for i in range(self.times):
+            for _i in range(self.times):
                 x = x + torch.rand_like(x, requires_grad=True)
             return x
 
@@ -120,7 +120,7 @@ def test_balance_by_size_param_scale():
             self.latent_size = latent_size
 
         def forward(self, x):
-            for i in range(self.latent_size):
+            for _i in range(self.latent_size):
                 x = x + torch.rand_like(x, requires_grad=True)
             return x
 

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1880,7 +1880,7 @@ class DistributedDataParallelTest(
         map_location = {"cuda:%d" % 0: "cuda:%d" % self.rank}
         ddp_state_dict = torch.load(checkpoint_path, map_location=map_location)
 
-        for model in [ddp_withload, model_withload]:
+        for _model in [ddp_withload, model_withload]:
             for p in ddp_withload.parameters():
                 with torch.no_grad():
                     p.zero_()

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -554,7 +554,7 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
         for idx in range(num_gpus):
             gpu_idx = local_device_ids[idx]
             output_ts.append([])
-            for rank in range(self.world_size):
+            for _rank in range(self.world_size):
                 output_ts[idx].append(torch.tensor([-1]).cuda(gpu_idx))
 
         expected = [[torch.tensor([rank]) for rank in range(self.world_size)]]
@@ -624,7 +624,7 @@ class ProcessGroupNCCLTest(MultiProcessTestCase):
         for idx in range(num_gpus):
             gpu_idx = local_device_ids[idx]
             output_ts.append([])
-            for rank in range(self.world_size):
+            for _rank in range(self.world_size):
                 output_ts[idx].append(torch.tensor([-1]).cuda(gpu_idx))
 
         with self.assertRaisesRegex(RuntimeError, "invalid root rank"):
@@ -1882,7 +1882,7 @@ class DistributedDataParallelTest(
                                     ),
                                     named_msg,
                                 )
-                                for j, ((param_name, p), p_ddp) in enumerate(
+                                for _j, ((param_name, p), p_ddp) in enumerate(
                                     zip(
                                         m_child.named_parameters(),
                                         m_ddp_child.parameters(),
@@ -2296,7 +2296,7 @@ class DistributedDataParallelTest(
                 process_group=process_group,
             )
 
-            for i in range(3):
+            for _i in range(3):
                 m.zero_grad(set_to_none=try_set_to_none)
                 m(1).sum().backward()
 

--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -725,7 +725,7 @@ class TestDataParallel(TestCase):
                             named_msg = layer_name + ".weight " + iter_msg
                             self.assertTrue(m_child.weight.grad.is_contiguous(memory_format=formats[i]), named_msg)
                             self.assertTrue(m_dp_child.weight.grad.is_contiguous(memory_format=formats[i]), named_msg)
-                            for j, ((param_name, p), p_dp) in enumerate(zip(m_child.named_parameters(),
+                            for _j, ((param_name, p), p_dp) in enumerate(zip(m_child.named_parameters(),
                                                                             m_dp_child.parameters())):
                                 named_msg = layer_name + "." + param_name + " " + iter_msg
                                 self.assertEqual(p.grad, p_dp.grad, rtol=tol, atol=tol)

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2910,7 +2910,7 @@ class TestDistributions(DistributionsTestCase):
         for dim in range(2, 5):
             log_probs = []
             lkj = LKJCholesky(dim, concentration=1., validate_args=True)
-            for i in range(2):
+            for _i in range(2):
                 sample = lkj.sample()
                 sample_tril = tril_matrix_to_vec(sample, diag=-1)
                 log_prob = lkj.log_prob(sample)

--- a/test/dynamo/test_cudagraphs.py
+++ b/test/dynamo/test_cudagraphs.py
@@ -64,7 +64,7 @@ class TestAotCudagraphs(torch._dynamo.test_case.TestCase):
 
         @torch._dynamo.optimize("cudagraphs")
         def fn(x, y):
-            for i in range(N_ITERS):
+            for _i in range(N_ITERS):
                 loss = model(x, y).sum()
                 loss.backward()
 
@@ -81,7 +81,7 @@ class TestAotCudagraphs(torch._dynamo.test_case.TestCase):
 
         @torch._dynamo.optimize("cudagraphs")
         def fn(x, y):
-            for i in range(N_ITERS):
+            for _i in range(N_ITERS):
                 loss = model(x, y).sum()
                 loss.backward()
 
@@ -97,7 +97,7 @@ class TestAotCudagraphs(torch._dynamo.test_case.TestCase):
 
         @torch._dynamo.optimize("cudagraphs")
         def fn(x, y):
-            for i in range(N_ITERS):
+            for _i in range(N_ITERS):
                 loss = model(x, y).sum()
                 loss.backward()
 

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -26,9 +26,9 @@ class ExportTests(torch._dynamo.test_case.TestCase):
             lc_key = state[0]
             lc_val = state[1]
             bar = []
-            for i in range(0, 4):
+            for _i in range(0, 4):
                 bar2 = []
-                for j in range(0, 3):
+                for _j in range(0, 3):
                     bar2.append(
                         lc_key + lc_val + torch.tensor([0.1, 0.25, 0.4, 0.5, 0.1])
                     )
@@ -528,9 +528,9 @@ class ExportTests(torch._dynamo.test_case.TestCase):
             lc_key = state[0]
             lc_val = state[1]
             bar = []
-            for i in range(0, 4):
+            for _i in range(0, 4):
                 bar2 = []
-                for j in range(0, 3):
+                for _j in range(0, 3):
                     bar2.append(
                         lc_key + lc_val + torch.tensor([0.1, 0.25, 0.4, 0.5, 0.1])
                     )

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -528,7 +528,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
                 self.count = 3
 
         def fn(x, cfg):
-            for i in range(cfg.count):
+            for _i in range(cfg.count):
                 x = x + cfg.val
             return x
 
@@ -556,7 +556,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
         def fn(x, cfg):
             if getattr(cfg, "just_add_7", False):
                 return x + 7
-            for i in range(cfg.count):
+            for _i in range(cfg.count):
                 x = x + cfg.val
             return x
 
@@ -657,7 +657,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
     def test_tensor_dict2(self):
         def fn1(inputs):
             total = torch.zeros(1)
-            for k, v in inputs.items():
+            for _k, v in inputs.items():
                 total += v
             return total
 
@@ -864,7 +864,7 @@ class MiscTests(torch._dynamo.test_case.TestCase):
 
     def test_range_with_shape(self):
         def fn(a):
-            for i in range(1, a.shape[0]):
+            for _i in range(1, a.shape[0]):
                 a += 1
             return a
 
@@ -2177,13 +2177,13 @@ class MiscTests(torch._dynamo.test_case.TestCase):
     def test_python_slice(self):
         def f1(input):
             y = 0
-            for i, x in enumerate(input[2:], 1):
+            for _i, x in enumerate(input[2:], 1):
                 y = y + x
             return y
 
         def f2(input):
             y = 0
-            for i, x in enumerate(input.shape[2:], 1):
+            for _i, x in enumerate(input.shape[2:], 1):
                 y = y + x
             return y
 
@@ -2905,10 +2905,10 @@ class MiscTests(torch._dynamo.test_case.TestCase):
                 return logits, loss
 
             def foo(self, memo=None, prefix="", remove_duplicate=False):
-                for mn, m in self.named_modules(
+                for mn, _m in self.named_modules(
                     memo=memo, prefix=prefix, remove_duplicate=remove_duplicate
                 ):
-                    for pn, p in self.named_parameters():
+                    for pn, _p in self.named_parameters():
                         fpn = "%s.%s" % (mn, pn) if mn else pn
                         self.names.append(fpn)
 
@@ -4642,9 +4642,9 @@ class MiscTests(torch._dynamo.test_case.TestCase):
             lc_key = state[0]
             lc_val = state[1]
             bar = []
-            for i in range(0, 4):
+            for _i in range(0, 4):
                 bar2 = []
-                for j in range(0, 3):
+                for _j in range(0, 3):
                     bar2.append(
                         lc_key + lc_val + torch.tensor([0.1, 0.25, 0.4, 0.5, 0.1])
                     )

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -218,7 +218,7 @@ class ConstLoop(torch.nn.Module):
         self.count = 3
 
     def forward(self, x):
-        for i in range(self.count):
+        for _i in range(self.count):
             x = torch.sigmoid(self.linear1(x))
         return x
 
@@ -392,7 +392,7 @@ class CfgModule(torch.nn.Module):
         self.layer = torch.nn.Linear(10, 10)
 
     def forward(self, x):
-        for i in range(self.cfg.count):
+        for _i in range(self.cfg.count):
             x = self.layer(x + self.cfg.val)
         return x
 
@@ -426,7 +426,7 @@ class _DenseBlock(torch.nn.ModuleDict):
 
     def forward(self, init_features):
         features = [init_features]
-        for name, layer in self.items():
+        for _name, layer in self.items():
             new_features = layer(features)
             features.append(new_features)
         return torch.cat(features, 1)
@@ -558,7 +558,7 @@ class EnumValues(torch.nn.ModuleDict):
 
     def forward(self, init_features):
         features = [init_features]
-        for idx, layer in enumerate(self.values()):
+        for _idx, layer in enumerate(self.values()):
             new_features = layer(features)
             features.append(new_features)
         return torch.cat(features, 1)

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -199,7 +199,7 @@ class _ReversibleFunction(torch.autograd.Function):
         # split duplicated tensor
         hidden_states, attn_output = torch.chunk(hidden_states, 2, dim=-1)
 
-        for layer_id, (layer, layer_head_mask) in enumerate(zip(layers, head_mask)):
+        for _layer_id, (layer, _layer_head_mask) in enumerate(zip(layers, head_mask)):
             if output_hidden_states is True:
                 all_hidden_states.append(hidden_states)
 
@@ -1646,7 +1646,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         class Mod(torch.nn.Module):
             def forward(self, listy):
                 x = listy[3:5]
-                for i in range(10):
+                for _i in range(10):
                     z = torch.abs(torch.randn(10)) + 1
                     x[0] = z
                 return x
@@ -1918,7 +1918,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
             def forward(self, inp):
                 res = 0
-                for name, buffer in self.named_buffers():
+                for _name, buffer in self.named_buffers():
                     res += buffer.sum()
 
                 return inp.cos() + res
@@ -1979,7 +1979,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
 
             def forward(self, inp):
                 res = torch.zeros(3, 3)
-                for mod in self.modules():
+                for _mod in self.modules():
                     res += self.fc(inp)
                 return res
 
@@ -2226,7 +2226,7 @@ class ReproTests(torch._dynamo.test_case.TestCase):
         # Repro of huggingface graph break inside loop in `get_parameter_dtype`.
         # Skip only the inner frame that has loop that contains graph break.
         def inner(x):
-            for i in range(3):
+            for _i in range(3):
                 x += 1
                 torch._dynamo.graph_break()
             return x

--- a/test/dynamo/test_subgraphs.py
+++ b/test/dynamo/test_subgraphs.py
@@ -347,7 +347,7 @@ class SubGraphTests(torch._dynamo.test_case.TestCase):
             tmp = [a + 1, b + 2, a + b]
             x = a
             x = unsupported(x, x)
-            for i in range(3):
+            for _i in range(3):
                 x += tmp.pop(-1)
             return x
 
@@ -620,7 +620,7 @@ class SubGraphTests(torch._dynamo.test_case.TestCase):
 
     def test_enumerate_not_break_graph(self):
         def fn(a, b):
-            for i, x in enumerate(a.shape):
+            for _i, x in enumerate(a.shape):
                 b = b + x
             for i, x in enumerate(b.shape, 8):
                 b = b + x * i

--- a/test/functorch/discover_coverage.py
+++ b/test/functorch/discover_coverage.py
@@ -321,7 +321,7 @@ def get_all_tested_ops():
     overridable_outplace_we_care_about = get_public_overridable_outplace_we_care_about()
     op_to_opinfo = get_ops_covered_by_opinfos()
     result = set({})
-    for name, op in get_covered_ops(overridable_outplace_we_care_about).items():
+    for _name, op in get_covered_ops(overridable_outplace_we_care_about).items():
         opinfos = op_to_opinfo[op]
         for opinfo in opinfos:
             result.add(opinfo.name)
@@ -332,7 +332,7 @@ def get_skipped_or_xfailed_ops_for(test_name):
     overridable_outplace_we_care_about = get_public_overridable_outplace_we_care_about()
     op_to_opinfo = get_ops_covered_by_opinfos()
     result = set({})
-    for name, op in get_covered_ops(overridable_outplace_we_care_about).items():
+    for _name, op in get_covered_ops(overridable_outplace_we_care_about).items():
         opinfos = op_to_opinfo[op]
         for opinfo in opinfos:
             for decorator in opinfo.decorators:

--- a/test/functorch/test_dims.py
+++ b/test/functorch/test_dims.py
@@ -200,7 +200,7 @@ class TestMin(TestCase):
             ci, co = dims()
         # python 3.11 adapts bytecode after a number of iterations
         # check that we still match names correctly
-        for i in range(10):
+        for _i in range(10):
             f()
 
     @skipIf(not TEST_CUDA, "no CUDA")

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1128,7 +1128,7 @@ class TestOperators(TestCase):
                 args = tuple(arg_values) + tuple(kwarg_values)
                 fn, args = get_jvp_variant_primals_tangents(op, sample)
                 is_batch_norm_and_training = is_batch_norm_training(op.name, kwarg_values)
-                for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                for _loop_out, _batched_out in get_fallback_and_vmap_exhaustive(
                         fn, args, {}, is_batch_norm_and_training=is_batch_norm_and_training, compute_loop_out=False):
                     pass
         check_vmap_fallback(self, test, op, dry_run=False)
@@ -1233,12 +1233,12 @@ class TestOperators(TestCase):
                 cotangents = get_sample_cotangents(op, sample)
                 fn, args = get_vjp_fn_and_args_with_cotangents(op, sample, cotangents)
                 is_batch_norm_and_training = is_batch_norm_training(op.name, sample.kwargs)
-                for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                for _loop_out, _batched_out in get_fallback_and_vmap_exhaustive(
                         fn, args, {}, is_batch_norm_and_training=is_batch_norm_and_training, compute_loop_out=False):
                     pass
                 for a_op in op.aliases:
                     fn, args = get_vjp_fn_and_args_with_cotangents(a_op, sample, cotangents)
-                    for loop_out, batched_out in get_fallback_and_vmap_exhaustive(
+                    for _loop_out, _batched_out in get_fallback_and_vmap_exhaustive(
                             fn, args, {}, is_batch_norm_and_training=is_batch_norm_and_training, compute_loop_out=False):
                         pass
 
@@ -1657,7 +1657,7 @@ class TestOperators(TestCase):
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
             target_options = self._make_extremal_inputs(shape, device)
-            for input, target, kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
+            for input, target, _kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
                 result = torch.nn.functional.l1_loss(input, target)
                 cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(torch.nn.functional.l1_loss, (cotangents, input, target))
@@ -1669,7 +1669,7 @@ class TestOperators(TestCase):
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
             target_options = self._make_extremal_inputs(shape, device)
-            for input, target, kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
+            for input, target, _kwargs in self._arg_and_kwarg_options((input_options, target_options), kwargs_options):
                 result = torch.nn.functional.mse_loss(input, target)
                 cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(torch.nn.functional.mse_loss, (cotangents, input, target))
@@ -1680,7 +1680,7 @@ class TestOperators(TestCase):
         kwargs_options = ({'dim': 1}, {})
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
-            for input, kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
+            for input, _kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
                 result = torch.nn.functional.softmax(input)
                 cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(torch.nn.functional.softmax, (cotangents, input))
@@ -1692,7 +1692,7 @@ class TestOperators(TestCase):
         kwargs_options = ({'dim': 1}, {})
         for shape in shapes:
             input_options = self._make_extremal_inputs(shape, device)
-            for input, kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
+            for input, _kwargs in self._arg_and_kwarg_options((input_options,), kwargs_options):
                 result = torch.nn.functional.log_softmax(input)
                 cotangents = torch.randn_like(result, device=device)
                 self._compare_jacobians_of_vjp(torch.nn.functional.log_softmax, (cotangents, input))

--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -27,7 +27,7 @@ class TestKernelBenchmark(TestCase):
 
     def get_compiled_module(self):
         compiled_module = None
-        for k, v in PyCodeCache.cache.items():
+        for _k, v in PyCodeCache.cache.items():
             if hasattr(v, "benchmark_compiled_module"):
                 self.assertTrue(
                     compiled_module is None, "Found multiple compiled modules"

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7400,7 +7400,7 @@ if HAS_CUDA and not TEST_WITH_ASAN:
 
             input = torch.randn(10, 10, device="cuda", requires_grad=True)
 
-            for i in range(2):
+            for _i in range(2):
                 output_ref = model_ref(input)
                 output_res = model_opt(input)
                 output_ref.sum().backward()

--- a/test/inductor/test_triton_wrapper.py
+++ b/test/inductor/test_triton_wrapper.py
@@ -12,7 +12,7 @@ from torch.testing._internal.inductor_utils import HAS_CUDA
 class TestTritonWrapper(TestCase):
     def get_compiled_module(self):
         compiled_module = None
-        for k, v in PyCodeCache.cache.items():
+        for _k, v in PyCodeCache.cache.items():
             if hasattr(v, "benchmark_compiled_module"):
                 self.assertTrue(
                     compiled_module is None, "Found multiple compiled modules"

--- a/test/jit/fixtures_srcs/test_upgrader_models_generation.py
+++ b/test/jit/fixtures_srcs/test_upgrader_models_generation.py
@@ -7,7 +7,7 @@ from torch.testing._internal.common_utils import TestCase, run_tests
 
 class TestUpgraderModelGeneration(TestCase):
     def test_all_modules(self):
-        for a_module, expect_operator in ALL_MODULES.items():
+        for a_module, _expect_operator in ALL_MODULES.items():
             module_name = type(a_module).__name__
             self.assertTrue(
                 isinstance(a_module, torch.nn.Module),

--- a/test/jit/test_async.py
+++ b/test/jit/test_async.py
@@ -30,7 +30,7 @@ class TestAsync(JitTestCase):
     def test_async_future_type_python(self):
         def foo(inp):
             futures = torch.jit.annotate(List[torch.jit.Future[torch.Tensor]], [])
-            for i in range(5):
+            for _i in range(5):
                 futures.append(torch.jit.fork(lambda x: x, inp))
             all_outputs = []
             for future in futures:
@@ -423,7 +423,7 @@ class TestAsync(JitTestCase):
         class TestListFutureModule(nn.Module):
             def forward(self, input):
                 input_list = []
-                for i in range(3):
+                for _i in range(3):
                     input_list.append(input)
 
                 fut_list: List[Future[torch.Tensor]] = []

--- a/test/jit/test_autodiff.py
+++ b/test/jit/test_autodiff.py
@@ -64,7 +64,7 @@ class TestAutodiffJit(JitTestCase):
 
         fn_s = torch.jit.script(fn)
 
-        for i in range(4):
+        for _i in range(4):
             x, y = fn_s(a, b, c)
             self.assertFalse(x.requires_grad)
             self.assertTrue(y.requires_grad)
@@ -86,7 +86,7 @@ class TestAutodiffJit(JitTestCase):
         b = torch.rand((10, 10), requires_grad=False)
         c = torch.rand((10, 10), requires_grad=True)
 
-        for i in range(4):
+        for _i in range(4):
             x_s, y_s, z_s = fn_s(a, b, c)
             x, y, z = fn(a, b, c)
 
@@ -111,7 +111,7 @@ class TestAutodiffJit(JitTestCase):
         b = torch.rand((10, 10), requires_grad=False)
         c = torch.rand((10, 10), requires_grad=True)
 
-        for i in range(4):
+        for _i in range(4):
             x_s, y_s, z_s = fn_s(a, b, c)
             x, y, z = fn(a, b, c)
 
@@ -138,7 +138,7 @@ class TestAutodiffJit(JitTestCase):
         b = torch.rand((10, 10), requires_grad=True)
         c = torch.rand((10, 10), requires_grad=True)
 
-        for i in range(4):
+        for _i in range(4):
             x_s, y_s, z_s = fn_s(a, b, c)
             x, y, z = fn(a, b, c)
 

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -152,7 +152,7 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
             input0 = torch.randn((2,), requires_grad=True)
             input1 = torch.randn((2,))
             output_ref = func(input0, input1)
-            for i in range(2):
+            for _i in range(2):
                 output = jit_f(input0, input1)
                 assert(output_ref[0].requires_grad == output[0].requires_grad)
                 assert(output_ref[1][0].requires_grad == output[1][0].requires_grad)
@@ -214,7 +214,7 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
         NUM_PROFILED_RUNS = 1
         with num_profiled_runs(NUM_PROFILED_RUNS):
             WARMUP = 3    # 2 runs to reach backward + 1 to optimize it
-            for x in range(WARMUP):
+            for _x in range(WARMUP):
                 o = t(input, bias)
                 o.sum().backward()
 

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -2279,7 +2279,7 @@ class TestFrozenOptimizations(JitTestCase):
         use_tracing = [True, False]
         bn_running_stats = [True, False]
 
-        for modules, tracing, track_stats in product(module_pairs, use_tracing, bn_running_stats):
+        for modules, tracing, _track_stats in product(module_pairs, use_tracing, bn_running_stats):
             class LinearBN(torch.nn.Module):
                 def __init__(self, in_features, out_features):
                     super().__init__()

--- a/test/jit/test_fuser_common.py
+++ b/test/jit/test_fuser_common.py
@@ -12,7 +12,7 @@ class TestFuserCommon(JitTestCase):
 
             x = torch.randn(5, requires_grad=not rq)
             # cause optimization to be created
-            for i in range(5):
+            for _i in range(5):
                 fn(x)
             # test fallback when optimization is not applicable
             y = fn(torch.randn(5, requires_grad=rq))

--- a/test/jit/test_logging.py
+++ b/test/jit/test_logging.py
@@ -20,7 +20,7 @@ class TestLogging(JitTestCase):
         class ModuleThatLogs(torch.jit.ScriptModule):
             @torch.jit.script_method
             def forward(self, x):
-                for i in range(x.size(0)):
+                for _i in range(x.size(0)):
                     x += 1.0
                     torch.jit._logging.add_stat_value('foo', 1)
 
@@ -35,7 +35,7 @@ class TestLogging(JitTestCase):
         try:
 
             mtl = ModuleThatLogs()
-            for i in range(5):
+            for _i in range(5):
                 mtl(torch.rand(3, 4, 5))
 
             self.assertEqual(logger.get_counter_val('foo'), 15)
@@ -62,7 +62,7 @@ class TestLogging(JitTestCase):
         class ModuleThatTimes(torch.jit.ScriptModule):
             def forward(self, x):
                 tp_start = torch.jit._logging.time_point()
-                for i in range(30):
+                for _i in range(30):
                     x += 1.0
                 tp_end = torch.jit._logging.time_point()
                 torch.jit._logging.add_stat_value('mytimer', tp_end - tp_start)
@@ -82,7 +82,7 @@ class TestLogging(JitTestCase):
             @torch.jit.script_method
             def forward(self, x):
                 tp_start = torch.jit._logging.time_point()
-                for i in range(30):
+                for _i in range(30):
                     x += 1.0
                 tp_end = torch.jit._logging.time_point()
                 torch.jit._logging.add_stat_value('mytimer', tp_end - tp_start)
@@ -99,7 +99,7 @@ class TestLogging(JitTestCase):
 
     def test_counter_aggregation(self):
         def foo(x):
-            for i in range(3):
+            for _i in range(3):
                 torch.jit._logging.add_stat_value('foo', 1)
             return x + 1.0
 

--- a/test/jit/test_misc.py
+++ b/test/jit/test_misc.py
@@ -396,7 +396,7 @@ class TestMisc(JitTestCase):
         ref = fn(x)
 
         script_fn = torch.jit.script(fn)
-        for i in range(4):
+        for _i in range(4):
             res = script_fn(x)
 
         self.assertEqual(ref, res)

--- a/test/jit/test_module_containers.py
+++ b/test/jit/test_module_containers.py
@@ -280,7 +280,7 @@ class TestModuleContainers(JitTestCase):
 
                 # note: unable to index moduledict with a string variable currently
                 i = 0
-                for key in self.moduledict:
+                for _key in self.moduledict:
                     i += 1
                 assert i == len(self.moduledict), "iteration failing for ModuleDict"
 

--- a/test/jit/test_peephole.py
+++ b/test/jit/test_peephole.py
@@ -89,7 +89,7 @@ class TestPeephole(JitTestCase):
         @torch.jit.script
         def foo(x, y, z):
             li = [x, y, z]
-            for i in range(len(x)):
+            for _i in range(len(x)):
                 li.append(x)
             return len([x, y, z])
 
@@ -116,7 +116,7 @@ class TestPeephole(JitTestCase):
         @torch.jit.script
         def foo(x, y, z):
             li = [x, y, z]
-            for i in range(len(x)):
+            for _i in range(len(x)):
                 li.append(x)
             return li[-2]
 

--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -1861,7 +1861,7 @@ class TestTracer(JitTestCase):
         module = torch.jit.trace_module(n, inputs)
 
         check_inputs = []
-        for i in range(2):
+        for _i in range(2):
             check_weight = torch.rand(1, 1, 3, 3)
             check_forward_input = torch.rand(1, 1, 3, 3)
             check_inputs.append({'forward' : check_forward_input, 'weighted_kernel_sum' : check_weight})
@@ -2313,7 +2313,7 @@ class TestMixTracingScripting(JitTestCase):
 
             def forward(self, feature_map: Dict[str, List[Tensor]]) -> Tensor:
                 output = []
-                for i, j in feature_map.items():
+                for _i, j in feature_map.items():
                     output.append(self.linear(j[0]))
 
                 return torch.stack(output)

--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -309,7 +309,7 @@ class TestTypesAndAnnotation(JitTestCase):
                     self.x = x
 
                 def set(self, val: int):
-                    for i in range(3):
+                    for _i in range(3):
                         self.x: int = val
 
         # Type annotation in __init__, should not fail

--- a/test/jit/xnnpack/test_xnnpack_delegate.py
+++ b/test/jit/xnnpack/test_xnnpack_delegate.py
@@ -30,7 +30,7 @@ class TestXNNPackBackend(unittest.TestCase):
             }
         )
 
-        for i in range(0, 20):
+        for _i in range(0, 20):
             sample_input = torch.randn(4, 4, 4)
             actual_output = scripted_module(sample_input)
             expected_output = lowered_module(sample_input)

--- a/test/lazy/test_reuse_ir.py
+++ b/test/lazy/test_reuse_ir.py
@@ -29,10 +29,10 @@ class TestLazyReuseIr(TestCase):
         y_lazy = y.detach().clone().to(device=device)
         z_lazy = z.detach().clone().to(device=device)
 
-        for i in range(10):
+        for _i in range(10):
             z += (x + y)
 
-        for i in range(10):
+        for _i in range(10):
             z_lazy += (x_lazy + y_lazy)
             torch._lazy.mark_step()
 
@@ -107,7 +107,7 @@ class TestLazyReuseIr(TestCase):
         weight = torch.randn(3, device=device)
         bias = torch.randn(3, device=device)
 
-        for i in range(10):
+        for _i in range(10):
             # BatchNorm2d does extra checks on dimensions which SymInts don't support yet
             # so we call `torch.ops.aten.native_batch_norm` to bypass the checks.
             z, _, _ = torch.ops.aten.native_batch_norm(x, weight, bias, None, None, True, 0.1, 1e-5)
@@ -117,7 +117,7 @@ class TestLazyReuseIr(TestCase):
         x_lazy = x.detach().clone().to(device=device)
         weight_lazy = weight.detach().clone().to(device=device)
         bias_lazy = bias.detach().clone().to(device=device)
-        for i in range(10):
+        for _i in range(10):
             z_lazy, _, _ = torch.ops.aten.native_batch_norm(x_lazy, weight_lazy, bias_lazy, None, None, True, 0.1, 1e-5)
             z_legit_lazy, _, _ = torch.ops.aten._native_batch_norm_legit(x_lazy, weight_lazy, bias_lazy, True, 0.1, 1e-5)
             torch._lazy.mark_step()

--- a/test/mobile/model_test/nn_ops.py
+++ b/test/mobile/model_test/nn_ops.py
@@ -380,7 +380,7 @@ class NNVisionModule(torch.nn.Module):
 
     def forward(self):
         input = torch.randn(1, 3, 16, 16)
-        for i, module in enumerate(self.vision_modules):
+        for _i, module in enumerate(self.vision_modules):
             r = module(self.input)
         return len(
             r,

--- a/test/mobile/test_quantize_fx_lite_script_module.py
+++ b/test/mobile/test_quantize_fx_lite_script_module.py
@@ -45,7 +45,7 @@ class TestLiteFuseFx(QuantizationLiteTestCase):
             (default_qconfig, ns.call_module(nn.Embedding)),
         ]
 
-        for qconfig, node in configs:
+        for qconfig, _node in configs:
             qconfig_dict = {"": qconfig}
             m = prepare_fx(
                 model,

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -248,7 +248,7 @@ class TestConvolutionNN(NNTestCase):
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_thnn_conv_strided_padded_dilated(self):
-        for convfn, dims, transposed in (
+        for convfn, dims, _transposed in (
                 (torch.nn.functional.conv2d, 2, False),
                 (torch.nn.functional.conv_transpose2d, 2, True),
                 (torch.nn.functional.conv3d, 3, False),

--- a/test/onnx/test_custom_ops.py
+++ b/test/onnx/test_custom_ops.py
@@ -96,7 +96,7 @@ class TestExportAsContribOps(pytorch_test_common.ExportTestCase):
             def forward(self, x):
                 res = []
                 res2 = []
-                for i in range(x.size(0)):
+                for _i in range(x.size(0)):
                     if len(res) > 0:
                         res2.append(res[0])
                     else:

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5759,7 +5759,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         class NestedLoopsModel(torch.jit.ScriptModule):
             @torch.jit.script_method
             def forward(self, x):
-                for i in range(5):
+                for _i in range(5):
                     a = 0
                     while a < 4:
                         a += 1
@@ -5798,7 +5798,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         class LoopModel(torch.nn.Module):
             def forward(self, x):
                 res = torch.zeros_like(x[0])
-                for i in range(x.size(0)):
+                for _i in range(x.size(0)):
                     res += x[0].transpose(0, 1)
                 return res
 
@@ -6403,7 +6403,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 a = torch.ones(
                     12,
                 )
-                for i in range(10):
+                for _i in range(10):
                     a.add_(
                         torch.ones(
                             12,
@@ -6432,7 +6432,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 b_ref = b  # not used in loop, should not be altered.
                 for i in range(10):
                     if i == 3:
-                        for j in range(5):
+                        for _j in range(5):
                             a += _bias
                             _bias.add_(
                                 torch.ones(
@@ -6477,7 +6477,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 )
                 for i in range(10):
                     if i == 3:
-                        for j in range(5):
+                        for _j in range(5):
                             self._bias += torch.arange(
                                 12,
                             )
@@ -6504,7 +6504,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 )
                 for i in range(10):
                     if i == 3:
-                        for j in range(5):
+                        for _j in range(5):
                             self._bias.copy_(
                                 torch.arange(
                                     12,
@@ -8093,7 +8093,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         class SequanceLoopModel(torch.nn.Module):
             def forward(self, x):
                 outputs = []
-                for i in range(3):
+                for _i in range(3):
                     outputs += [x]
                 return torch.stack(outputs).transpose(0, 1)
 
@@ -9260,9 +9260,9 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 a = (input1, input2)
                 b = a
                 c = (input1, input2, input3)
-                for i in range(5):
+                for _i in range(5):
                     d = a[0]
-                    for j in range(2):
+                    for _j in range(2):
                         e, f = a
                         a = (d, f)
                         f = c[2]
@@ -9286,7 +9286,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         class TupleModule(torch.nn.Module):
             def forward(self, input1: Tensor, input2: Tensor) -> Tuple[Tensor, Tensor]:
                 a = (input1, input2)
-                for x in range(5):
+                for _x in range(5):
                     c, d = a
                     a = (c, d)
                 return a
@@ -9304,7 +9304,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             ) -> Tuple[Tuple[Tensor, Tensor], Tuple[Tensor, Tensor]]:
                 a = input1
                 b = input2
-                for x in range(5):
+                for _x in range(5):
                     c, d = a
                     e, f = b
                     if c.shape[0] == e.shape[0]:
@@ -10906,7 +10906,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 self.conv.weight = torch.arange(10)
                 for i in range(10):
                     if i == 3:
-                        for j in range(10):
+                        for _j in range(10):
                             w = self.conv.weight
                             self.conv.weight = torch.arange(10) + w
 
@@ -10968,7 +10968,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             def set_cell_anchors(self, anchors):
                 self.conv.weight = torch.randn(3, 10)
                 for i in range(self.conv.weight.size(0)):
-                    for j in range(10):
+                    for _j in range(10):
                         self.conv.bias = torch.randn(3, 10, 3)
                         self.conv.weight = anchors * i
                         self.boxes.append(torch.ones(3, 3))
@@ -11939,7 +11939,7 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
                 self.loop_count = loop_count
 
             def forward(self, x):
-                for i in range(self.loop_count):
+                for _i in range(self.loop_count):
                     x.index_add_(self.dim, self.index, self.updates)
                 return x
 

--- a/test/onnx/verify.py
+++ b/test/onnx/verify.py
@@ -530,7 +530,7 @@ def verify(
         run_helper(torch_out, args, remained_onnx_input_idx)
 
         if isinstance(test_args, int):
-            for i in range(test_args):
+            for _i in range(test_args):
                 run(randomize_args(args), remained_onnx_input_idx)
         else:
             for test_arg in test_args:

--- a/test/onnx_caffe2/test_pytorch_onnx_caffe2.py
+++ b/test/onnx_caffe2/test_pytorch_onnx_caffe2.py
@@ -2840,7 +2840,7 @@ class TestCaffe2Backend_opset9(pytorch_test_common.ExportTestCase):
         class NestedLoopsModel(torch.jit.ScriptModule):
             @torch.jit.script_method
             def forward(self, x):
-                for i in range(5):
+                for _i in range(5):
                     a = 0
                     while a < 4:
                         a += 1

--- a/test/onnx_caffe2/test_pytorch_onnx_caffe2_quantized.py
+++ b/test/onnx_caffe2/test_pytorch_onnx_caffe2_quantized.py
@@ -342,7 +342,7 @@ class TestQuantizedOps(pytorch_test_common.ExportTestCase):
                 self.conv1 = nn.Conv2d(3, 3, 1)
                 self.relu1 = nn.ReLU(inplace=False)
                 layers = []
-                for i in range(3):
+                for _i in range(3):
                     layers.append(ConvBNReLUModule())
                 self.features = nn.Sequential(*layers)
                 head = [nn.Linear(300, 10), nn.ReLU(inplace=False)]

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -94,7 +94,7 @@ class TestProfilerCUDA(TestCase):
         t = torch.rand(1, 1).cuda()
         p = psutil.Process()
         last_rss = collections.deque(maxlen=5)
-        for outer_idx in range(10):
+        for _outer_idx in range(10):
             with _profile(use_cuda=True):
                 for _ in range(1024):
                     t = torch.mm(t, t)
@@ -1167,7 +1167,7 @@ class TestProfiler(TestCase):
                 active=2),
             on_trace_ready=trace_handler
         ) as p:
-            for idx in range(8):
+            for _idx in range(8):
                 self.payload(use_cuda=use_cuda)
                 p.step()
 
@@ -1236,7 +1236,7 @@ class TestProfiler(TestCase):
             # See https://github.com/pytorch/pytorch/issues/88446
             optimizer_step()
 
-        for idx in range(niters):
+        for _idx in range(niters):
             run_batch()
 
         with profile(
@@ -1246,7 +1246,7 @@ class TestProfiler(TestCase):
                 warmup=1,
                 active=2),
         ) as p:
-            for idx in range(niters):
+            for _idx in range(niters):
                 run_batch()
                 p.step()
 
@@ -1460,7 +1460,7 @@ class TestProfiler(TestCase):
         )
         inputs = torch.randn(40, 16, 18, 260)
         uint32_max = 2**32 - 1
-        for i in range(5):
+        for _i in range(5):
             with profile() as prof:
                 model(inputs)
             for event in prof.profiler.kineto_results.events():

--- a/test/quantization/core/experimental/apot_fx_graph_mode_ptq.py
+++ b/test/quantization/core/experimental/apot_fx_graph_mode_ptq.py
@@ -31,7 +31,7 @@ from torch.ao.quantization.quantize_fx import prepare_qat_fx
 def calibrate(model, data_loader):
     model.eval()
     with torch.no_grad():
-        for image, target in data_loader:
+        for image, _target in data_loader:
             model(image)
 
 from torch.ao.quantization.experimental.qconfig import (

--- a/test/quantization/core/experimental/quantization_util.py
+++ b/test/quantization/core/experimental/quantization_util.py
@@ -133,7 +133,7 @@ def training_loop(model, criterion, data_loader):
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
     train_loss, correct, total = 0, 0, 0
     model.train()
-    for i in range(10):
+    for _i in range(10):
         for data, target in data_loader:
             optimizer.zero_grad()
             output = model(data)

--- a/test/quantization/core/test_quantized_module.py
+++ b/test/quantization/core/test_quantized_module.py
@@ -201,7 +201,7 @@ class TestStaticQuantizedModule(QuantizationTestCase):
         self.assertEqual(qlinear.scale, loaded_from_package.scale)
         self.assertEqual(qlinear.zero_point, loaded_from_package.zero_point)
 
-        for name, module in loaded_from_package.named_modules():
+        for name, _module in loaded_from_package.named_modules():
             # noop, just make sure attribute "_modules" is restored correctly during torch.package import
             assert(name is not None)  # noqa: E275
 

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -2019,7 +2019,7 @@ class TestQuantizedOps(TestCase):
         X = torch.from_numpy(X)
         new_shape = np.array(X.shape)
         new_shape[dim] = 0
-        for idx in range(num):
+        for _idx in range(num):
             tensors_q.append(torch.quantize_per_tensor(X, scale, zero_point,
                                                        torch_type))
             tensors_ref.append(X)
@@ -5226,7 +5226,7 @@ class TestQuantizedConv(TestCase):
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
                 schedule=my_schedule,
                 on_trace_ready=trace_handler) as prof:
-            for i in range(30):
+            for _i in range(30):
                 conv_op(input, weight, None, stride, padding, dilation, groups)
                 prof.step()
 
@@ -5241,7 +5241,7 @@ class TestQuantizedConv(TestCase):
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
                 schedule=my_schedule,
                 on_trace_ready=trace_handler) as prof:
-            for i in range(30):
+            for _i in range(30):
                 conv_op(input_fp16, weight_fp16, None, stride, padding, dilation, groups)
                 prof.step()
 
@@ -5258,7 +5258,7 @@ class TestQuantizedConv(TestCase):
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
                 schedule=my_schedule,
                 on_trace_ready=trace_handler) as prof:
-            for i in range(30):
+            for _i in range(30):
                 conv_op(input_int8, weight_prepacked, scale, zero_point)
                 prof.step()
 

--- a/test/quantization/core/test_quantized_tensor.py
+++ b/test/quantization/core/test_quantized_tensor.py
@@ -578,7 +578,7 @@ class TestQuantizedTensor(TestCase):
         ]
         axis = 1
         device = torch.device('cuda')
-        for i in range(20):
+        for _i in range(20):
             for dtype, zero_type in dtype_and_zero_types:
                 r = torch.rand(2, 2) * 10
                 r[0, 0] = 2.5
@@ -1103,7 +1103,7 @@ class TestQuantizedTensor(TestCase):
             zero_point = 10
             types = [torch.qint8, torch.quint8, torch.qint32]
             for qtype in types:
-                for i in range(3):
+                for _i in range(3):
                     m = random.randint(10, 20)
                     elems = random.randint(20000, 30000)
                     values = torch.rand(elems, device=device)

--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -1106,7 +1106,7 @@ class TestFusedObsFakeQuantModule(TestCase):
         torch.ao.quantization.enable_observer(mod_ref)
         mod_ref.to(device)
 
-        for i in range(10):
+        for _i in range(10):
             x = torch.randn(5, 5, device=device)
             out = mod(x)
             out_ref = mod_ref(x)
@@ -1242,7 +1242,7 @@ class TestFusedObsFakeQuantModule(TestCase):
 
                 count_fake_quant = 0
                 count_activation_postproc = 0
-                for name, mod in quant_model.named_modules():
+                for name, _mod in quant_model.named_modules():
                     if name.endswith('weight_fake_quant'):
                         count_fake_quant += 1
                     if name.count('activation_post_process') == 1 and 'weight_fake_quant' not in name:

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -310,7 +310,7 @@ class TestFakeQuantizeOps(TestCase):
         maxi = 255
         mini = 0
 
-        for i in range(20):
+        for _i in range(20):
             X1 = torch.randn(5, 5).to(torch.float16)
             Y1 = torch.fake_quantize_per_tensor_affine(X1, scale, zero, mini, maxi)
             Y1r = _fake_quantize_per_tensor_affine_reference(X1, scale, zero, mini, maxi)
@@ -335,7 +335,7 @@ class TestFakeQuantizeOps(TestCase):
         torch_types = (torch.qint8, torch.quint8)
         Xs = (torch.randn(4, 8, device=device), torch.randn(4, 16, device=device)[:, ::2])
         tensor_qparam = (True, False)
-        for float_type, torch_type, X, tensor_qparams in itertools.product(float_types, torch_types, Xs, tensor_qparam):
+        for float_type, torch_type, X, _tensor_qparams in itertools.product(float_types, torch_types, Xs, tensor_qparam):
             # pick the scale + zp so that some values get clipped
             X = X.to(float_type)
             obs = torch.ao.quantization.MinMaxObserver(torch_type)
@@ -732,7 +732,7 @@ class TestFakeQuantizeOps(TestCase):
         mini = 0
         maxi = 255
 
-        for i in range(20):
+        for _i in range(20):
             X1 = torch.randn(4, 5).to(torch.float16)
             Y1 = torch.fake_quantize_per_channel_affine(X1, scale, zero, axis, mini, maxi)
             Y1r = _fake_quantize_per_channel_affine_reference(X1, scale, zero, axis, mini, maxi)
@@ -985,7 +985,7 @@ class TestFakeQuantizeOps(TestCase):
             zero_types = [torch.int]
         devices = [torch.device('cpu'), torch.device('cuda')] if torch.cuda.is_available() else [torch.device('cpu')]
         axis = 1
-        for i in range(20):
+        for _i in range(20):
             for torch_type, float_type, device, zero_type in itertools.product(torch_types, float_types, devices, zero_types):
                 X = torch.randn(3, 3, device=device).to(float_type)
                 scales = (10 * torch.randn(3, device=device)).abs()

--- a/test/quantization/eager/test_bias_correction_eager.py
+++ b/test/quantization/eager/test_bias_correction_eager.py
@@ -39,7 +39,7 @@ class TestBiasCorrectionEager(QuantizationTestCase):
         torch.ao.quantization.convert(artificial_model, inplace=True)
 
         # manually changing bias
-        for name, submodule in artificial_model.named_modules():
+        for _name, submodule in artificial_model.named_modules():
             if type(submodule) in _supported_modules:
                 x = get_param(submodule, 'bias')
                 weight = get_param(submodule, 'weight')

--- a/test/quantization/eager/test_numeric_suite_eager.py
+++ b/test/quantization/eager/test_numeric_suite_eager.py
@@ -104,7 +104,7 @@ class TestNumericSuiteEager(QuantizationTestCase):
                 float_model.state_dict(), q_model.state_dict()
             )
             self.assertEqual(len(weight_dict), 1)
-            for k, v in weight_dict.items():
+            for _k, v in weight_dict.items():
                 self.assertTrue(v["float"].shape == v["quantized"].shape)
 
         model_list = [AnnotatedConvModel(qengine), AnnotatedConvBnReLUModel(qengine)]
@@ -126,7 +126,7 @@ class TestNumericSuiteEager(QuantizationTestCase):
                 float_model.state_dict(), q_model.state_dict()
             )
             self.assertEqual(len(weight_dict), 1)
-            for k, v in weight_dict.items():
+            for _k, v in weight_dict.items():
                 self.assertTrue(v["float"].shape == v["quantized"].shape)
 
         model_list = [AnnotatedSingleLayerLinearModel(qengine)]
@@ -148,9 +148,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
                 float_model.state_dict(), q_model.state_dict()
             )
             self.assertEqual(len(weight_dict), 1)
-            for k, v in weight_dict.items():
+            for _k, v in weight_dict.items():
                 self.assertTrue(len(v["float"]) == len(v["quantized"]))
-                for i, val in enumerate(v["quantized"]):
+                for i, _val in enumerate(v["quantized"]):
                     self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
         model_list = [SingleLayerLinearDynamicModel(qengine)]
@@ -172,9 +172,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
                 float_model.state_dict(), q_model.state_dict()
             )
             self.assertEqual(len(weight_dict), 1)
-            for k, v in weight_dict.items():
+            for _k, v in weight_dict.items():
                 self.assertTrue(len(v["float"]) == len(v["quantized"]))
-                for i, val in enumerate(v["quantized"]):
+                for i, _val in enumerate(v["quantized"]):
                     self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
         model_list = [LSTMwithHiddenDynamicModel(qengine)]
@@ -194,9 +194,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
         def compare_and_validate_results(float_model, q_model, module_swap_list, data):
             ob_dict = compare_model_stub(float_model, q_model, module_swap_list, data)
             self.assertEqual(len(ob_dict), 1)
-            for k, v in ob_dict.items():
+            for _k, v in ob_dict.items():
                 self.assertTrue(len(v["float"]) == len(v["quantized"]))
-                for i, val in enumerate(v["quantized"]):
+                for i, _val in enumerate(v["quantized"]):
                     self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
         model_list = [AnnotatedConvModel(qengine),
@@ -221,9 +221,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
         def compare_and_validate_results(float_model, q_model, module_swap_list, data):
             ob_dict = compare_model_stub(float_model, q_model, module_swap_list, data)
             self.assertEqual(len(ob_dict), 1)
-            for k, v in ob_dict.items():
+            for _k, v in ob_dict.items():
                 self.assertTrue(len(v["float"]) == len(v["quantized"]))
-                for i, val in enumerate(v["quantized"]):
+                for i, _val in enumerate(v["quantized"]):
                     self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
         linear_data = self.calib_data[0][0]
@@ -246,9 +246,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
         def compare_and_validate_results(float_model, q_model, module_swap_list, data):
             ob_dict = compare_model_stub(float_model, q_model, module_swap_list, data)
             self.assertEqual(len(ob_dict), 1)
-            for k, v in ob_dict.items():
+            for _k, v in ob_dict.items():
                 self.assertTrue(len(v["float"]) == len(v["quantized"]))
-                for i, val in enumerate(v["quantized"]):
+                for i, _val in enumerate(v["quantized"]):
                     self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
         linear_data = self.calib_data[0][0]
@@ -301,9 +301,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
         self.assertTrue(isinstance(q_model.myadd_relu, Shadow))
         self.assertTrue(isinstance(q_model.my_scalar_add, Shadow))
         self.assertTrue(isinstance(q_model.my_scalar_mul, Shadow))
-        for k, v in ob_dict.items():
+        for _k, v in ob_dict.items():
             self.assertTrue(len(v["float"]) == len(v["quantized"]))
-            for i, val in enumerate(v["quantized"]):
+            for i, _val in enumerate(v["quantized"]):
                 self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
     @override_qengines
@@ -315,9 +315,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
         def compare_and_validate_results(float_model, q_model, module_swap_list, data):
             ob_dict = compare_model_stub(float_model, q_model, module_swap_list, data)
             self.assertEqual(len(ob_dict), 1)
-            for k, v in ob_dict.items():
+            for _k, v in ob_dict.items():
                 self.assertTrue(len(v["float"]) == len(v["quantized"]))
-                for i, val in enumerate(v["quantized"]):
+                for i, _val in enumerate(v["quantized"]):
                     self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
         linear_data = self.calib_data[0][0]
@@ -344,9 +344,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
                 float_model, q_model, module_swap_list, input, hidden
             )
             self.assertEqual(len(ob_dict), 1)
-            for k, v in ob_dict.items():
+            for _k, v in ob_dict.items():
                 self.assertTrue(len(v["float"]) == len(v["quantized"]))
-                for i, val in enumerate(v["quantized"]):
+                for i, _val in enumerate(v["quantized"]):
                     self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
         lstm_input = torch.rand((1, 1, 2))
@@ -375,7 +375,7 @@ class TestNumericSuiteEager(QuantizationTestCase):
             expected_act_compare_dict_keys = {"conv.stats", "quant.stats"}
 
             self.assertTrue(act_compare_dict.keys() == expected_act_compare_dict_keys)
-            for k, v in act_compare_dict.items():
+            for _k, v in act_compare_dict.items():
                 self.assertTrue(v["float"][0].shape == v["quantized"][0].shape)
 
         model_list = [AnnotatedConvModel(qengine), AnnotatedConvBnReLUModel(qengine)]
@@ -398,9 +398,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
             expected_act_compare_dict_keys = {"fc1.quant.stats", "fc1.module.stats"}
 
             self.assertTrue(act_compare_dict.keys() == expected_act_compare_dict_keys)
-            for k, v in act_compare_dict.items():
+            for _k, v in act_compare_dict.items():
                 self.assertTrue(len(v["float"]) == len(v["quantized"]))
-                for i, val in enumerate(v["quantized"]):
+                for i, _val in enumerate(v["quantized"]):
                     self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
         linear_data = self.calib_data[0][0]
@@ -434,9 +434,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
             "quant.stats",
         }
         self.assertTrue(act_compare_dict.keys() == expected_act_compare_dict_keys)
-        for k, v in act_compare_dict.items():
+        for _k, v in act_compare_dict.items():
             self.assertTrue(len(v["float"]) == len(v["quantized"]))
-            for i, val in enumerate(v["quantized"]):
+            for i, _val in enumerate(v["quantized"]):
                 self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
     @override_qengines
@@ -451,9 +451,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
             expected_act_compare_dict_keys = {"fc1.stats"}
 
             self.assertTrue(act_compare_dict.keys() == expected_act_compare_dict_keys)
-            for k, v in act_compare_dict.items():
+            for _k, v in act_compare_dict.items():
                 self.assertTrue(len(v["float"]) == len(v["quantized"]))
-                for i, val in enumerate(v["quantized"]):
+                for i, _val in enumerate(v["quantized"]):
                     self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
         linear_data = self.calib_data[0][0]
@@ -480,9 +480,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
             expected_act_compare_dict_keys = {"lstm.stats"}
 
             self.assertTrue(act_compare_dict.keys() == expected_act_compare_dict_keys)
-            for k, v in act_compare_dict.items():
+            for _k, v in act_compare_dict.items():
                 self.assertTrue(len(v["float"]) == len(v["quantized"]))
-                for i, val in enumerate(v["quantized"]):
+                for i, _val in enumerate(v["quantized"]):
                     self.assertTrue(len(v["float"][i]) == len(v["quantized"][i]))
                     if i == 0:
                         self.assertTrue(v["float"][i][0].shape == v["quantized"][i][0].shape)

--- a/test/quantization/eager/test_quantize_eager_qat.py
+++ b/test/quantization/eager/test_quantize_eager_qat.py
@@ -854,7 +854,7 @@ class TestQuantizeEagerQATNumerics(QuantizationTestCase):
             ref_op = compose([conv_op, bn_op, relu_op])
 
         input_clone = input.clone().detach().requires_grad_()
-        for i in range(2):
+        for _i in range(2):
             result_ref = ref_op(input)
             result_actual = qat_op(input_clone)
             self.assertEqual(result_ref, result_actual)

--- a/test/quantization/fx/test_model_report_fx.py
+++ b/test/quantization/fx/test_model_report_fx.py
@@ -524,7 +524,7 @@ class TestFxModelReportObserver(QuantizationTestCase):
     def run_model_and_common_checks(self, model, ex_input, num_epochs, batch_size):
         # split up data into batches
         split_up_data = torch.split(ex_input, batch_size)
-        for epoch in range(num_epochs):
+        for _epoch in range(num_epochs):
             # reset all model report obs
             model.apply(
                 lambda module: module.reset_batch_and_epoch_values()
@@ -951,7 +951,7 @@ class TestFxModelReportClass(QuantizationTestCase):
             # see whether observers properly in regular nn.Module
             # there should be 4 observers present in this case
             modules_observer_cnt = 0
-            for fqn, module in prepared_for_callibrate_model.named_modules():
+            for _fqn, module in prepared_for_callibrate_model.named_modules():
                 if isinstance(module, ModelReportObserver):
                     modules_observer_cnt += 1
 
@@ -998,7 +998,7 @@ class TestFxModelReportClass(QuantizationTestCase):
         """
         # get the number of observers stored as modules
         modules_observer_cnt = 0
-        for fqn, module in callibrated_fx_module.named_modules():
+        for _fqn, module in callibrated_fx_module.named_modules():
             if isinstance(module, ModelReportObserver):
                 modules_observer_cnt += 1
 
@@ -1057,7 +1057,7 @@ class TestFxModelReportClass(QuantizationTestCase):
 
             # now callibrate the two models
             num_iterations = 10
-            for i in range(num_iterations):
+            for _i in range(num_iterations):
                 example_input = torch.tensor(torch.randint(100, (1, 3, 3, 3)), dtype=torch.float)
                 prepared_for_callibrate_model_full(example_input)
                 prepared_for_callibrate_model_single(example_input)
@@ -1323,7 +1323,7 @@ class TestFxDetectInputWeightEqualization(QuantizationTestCase):
             fused = self._get_prepped_for_calibration_model(self.TwoBlockComplexNet(), detector_set, fused=True)
 
             # reporter should still give same counts even for fused model
-            for prepared_for_callibrate_model, mod_report in [non_fused, fused]:
+            for prepared_for_callibrate_model, _mod_report in [non_fused, fused]:
 
                 # supported modules to check
                 mods_to_check = {nn.Linear, nn.Conv2d}
@@ -1344,7 +1344,7 @@ class TestFxDetectInputWeightEqualization(QuantizationTestCase):
                 self.assertEqual(number_of_obs_found, correct_number_of_obs_inserted)
 
                 # assert that each of the desired modules have the observers inserted
-                for fqn, module in prepared_for_callibrate_model.named_modules():
+                for _fqn, module in prepared_for_callibrate_model.named_modules():
                     # check if module is a supported module
                     is_in_include_list = sum(list(map(lambda x: isinstance(module, x), mods_to_check))) > 0
 
@@ -1568,7 +1568,7 @@ class TestFxDetectOutliers(QuantizationTestCase):
             self.assertEqual(number_of_obs_found, correct_number_of_obs_inserted)
 
             # assert that each of the desired modules have the observers inserted
-            for fqn, module in prepared_for_callibrate_model.named_modules():
+            for _fqn, module in prepared_for_callibrate_model.named_modules():
                 # check if module is a supported module
                 is_in_include_list = isinstance(module, tuple(mods_to_check))
 

--- a/test/quantization/fx/test_numeric_suite_fx.py
+++ b/test/quantization/fx/test_numeric_suite_fx.py
@@ -637,7 +637,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
         # 4. go through the ops mapped to each QuantizeHandler type, and verify
         # correctness.
         def _op_in_base_sets_of_related_ops(op):
-            for name, ops in base_name_to_sets_of_related_ops.items():
+            for _name, ops in base_name_to_sets_of_related_ops.items():
                 if op in ops:
                     return True
             return False
@@ -1829,7 +1829,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             results, 'fp32', 'int8', compute_cosine_similarity,
             'cosine_similarity_int8_vs_fp32')
 
-        for layer_name, layer_results in results.items():
+        for _layer_name, layer_results in results.items():
             assert 'sqnr_int8_vs_fp32' in \
                 layer_results['weight']['int8'][0].keys()
             assert 'l2_error_int8_vs_fp32' in \
@@ -2249,7 +2249,7 @@ class TestFXNumericSuiteNShadows(FXNumericSuiteQuantizationTestCase):
             msp(*example_input)
 
         def _check_logger_count(model, exp_count_stats, exp_count_comparisons):
-            for name, mod in model.named_modules():
+            for _name, mod in model.named_modules():
                 if isinstance(mod, OutputLogger):
                     self.assertTrue(
                         len(mod.stats) == exp_count_stats,

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1570,7 +1570,7 @@ class TestQuantizeFx(QuantizationTestCase):
                  None),
             ]
             for (ModuleClass, module_constructor_inputs,
-                 inputs, quantized_node, weight_prepack_node) in tests:
+                 inputs, _quantized_node, weight_prepack_node) in tests:
                 for is_reference in [True, False]:
                     node_occurrence = {}
                     if weight_prepack_node:
@@ -4462,13 +4462,13 @@ class TestQuantizeFx(QuantizationTestCase):
             m = prepare(m, {"": qconfig}, example_inputs=example_inputs)
             # check that there is a duplicated observer instance
             actpp_module_count = 0
-            for name, module in m.named_modules(remove_duplicate=False):
+            for _name, module in m.named_modules(remove_duplicate=False):
                 if isinstance(module, actpp_module_class):
                     actpp_module_count += 1
             self.assertEqual(actpp_module_count, 2)
 
             actpp_module_count = 0
-            for name, module in m.named_modules():
+            for _name, module in m.named_modules():
                 if isinstance(module, actpp_module_class):
                     actpp_module_count += 1
             self.assertEqual(actpp_module_count, 1)
@@ -5361,7 +5361,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
 
         options = itertools.product([M1, M2], [True, False])
-        for M, is_qat in options:
+        for _M, _is_qat in options:
             m = M1().eval()
             example_inputs = (torch.randn(1, 3, 3, 3),)
             m = prepare_fx(m, get_default_qconfig_mapping(), example_inputs=example_inputs)
@@ -5522,7 +5522,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 m = M().eval()
                 qconfig_dict = func(backend)
                 m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 1, 1, 1)))
-                for name, mod in m.named_modules():
+                for _name, mod in m.named_modules():
                     if _is_activation_post_process(mod) and mod.dtype == torch.quint8:
                         if backend == "fbgemm":
                             lower_bnd = 0
@@ -8403,7 +8403,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             )
 
         # check it works in None and static qconfig
-        for qconfig in [None, default_qconfig]:
+        for _qconfig in [None, default_qconfig]:
             qconfig_dict = {"": default_qconfig}
             m = M().eval()
             m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
@@ -8955,7 +8955,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
             criterion = nn.CrossEntropyLoss()
             train_one_epoch(prepared, criterion, optimizer, [(input_value, output_value)], torch.device('cpu'), 1)
         else:
-            for i in range(10):
+            for _i in range(10):
                 prepared(input_value)
 
         # print('after observation root:', prepared.root)
@@ -9000,7 +9000,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
                 optimizer = torch.optim.SGD(qeager.parameters(), lr=0.0001)
                 train_one_epoch(qeager, criterion, optimizer, [(input_value, output_value)], torch.device('cpu'), 1)
             else:
-                for i in range(10):
+                for _i in range(10):
                     qeager(input_value)
 
             # print('ref after observation:', qeager)
@@ -9164,7 +9164,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
 
     @override_qengines
     def test_qat_embeddingbag_linear(self):
-        for device in get_supported_device_types():
+        for _device in get_supported_device_types():
             class EmbeddingBagLinear(torch.nn.Module):
                 def __init__(self):
                     super().__init__()
@@ -9205,7 +9205,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
 
     @override_qengines
     def test_qat_embedding_linear(self):
-        for device in get_supported_device_types():
+        for _device in get_supported_device_types():
             class EmbeddingLinear(torch.nn.Module):
                 def __init__(self):
                     super().__init__()

--- a/test/quantization/jit/test_quantize_jit.py
+++ b/test/quantization/jit/test_quantize_jit.py
@@ -329,7 +329,7 @@ class TestQuantizeJitPasses(QuantizationTestCase):
             def __init__(self, dim, num_blocks, enable_bias, enable_affine):
                 super().__init__()
                 layers = []
-                for i in range(num_blocks):
+                for _i in range(num_blocks):
                     layers.append(conv_module[dim](20, 20, 5, 1, bias=enable_bias))
                     bn_obj = bn_module[dim](num_features=20, affine=enable_affine)
                     if enable_affine:

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2206,7 +2206,7 @@ class TestAutograd(TestCase):
         state = set()
         with torch.enable_grad():
             coro = coro_no_grad(state)
-            for i in range(5):
+            for _i in range(5):
                 next(coro)
 
             coro.close()
@@ -2215,7 +2215,7 @@ class TestAutograd(TestCase):
         state = set()
         with torch.no_grad():
             coro = coro_enable_grad(state)
-            for i in range(5):
+            for _i in range(5):
                 next(coro)
 
             coro.close()
@@ -4053,7 +4053,7 @@ Done""")
         rnn = torch.nn.LSTM(10, 20, 2)
         total_time_s = 0
         with profile(record_shapes=True, use_kineto=kineto_available()) as prof:
-            for i in range(20):
+            for _i in range(20):
                 input = torch.randn(5, 3, 10)
                 h = torch.randn(2, 3, 20)
                 c = torch.randn(2, 3, 20)
@@ -4643,7 +4643,7 @@ Done""")
         self.assertTrue(p_a == p_g or p_b == p_g)
 
         # Run backwards multiple times to ensure accumulation works.
-        for i in range(10):
+        for _i in range(10):
             loss.backward(retain_graph=True)
 
         # non-contiguous indices and value, we should trigger a copy.
@@ -4661,7 +4661,7 @@ Done""")
         self.assertFalse(p_b == p_g)
 
         # Run backwards multiple times to ensure accumulation works.
-        for i in range(10):
+        for _i in range(10):
             loss.backward(retain_graph=True)
 
     def test_gradcheck_single_input(self):
@@ -5440,7 +5440,7 @@ for shape in [(1,), ()]:
         )
 
         feat_combined = []
-        for r in range(num_inp):
+        for _r in range(num_inp):
             data_r = torch.empty(1, nz_inp)
             data_r.uniform_()
             data_r.requires_grad = True
@@ -5509,7 +5509,7 @@ for shape in [(1,), ()]:
                 self.use_checkpoint = use_checkpoint
                 self.use_reentrant = use_reentrant
                 self.layers = nn.ModuleList()
-                for i in range(self.n):
+                for _i in range(self.n):
                     layer = nn.Sequential(
                         nn.Linear(256, 256), nn.Linear(256, 256), nn.Linear(256, 256)
                     )
@@ -5691,7 +5691,7 @@ for shape in [(1,), ()]:
 
         feat_combined = []
         feat_combined_no_checkpoint = []
-        for r in range(num_inp):
+        for _r in range(num_inp):
             data_r = torch.empty(1, nz_inp)
             data_r.uniform_()
             data_r.requires_grad = input_requires_grad
@@ -8875,7 +8875,7 @@ class TestAutogradDeviceType(TestCase):
     def test_parameter_resize(self, device):
         asd = torch.nn.Parameter(torch.ones(16, dtype=torch.double, device=device))
 
-        for i in range(2):
+        for _i in range(2):
             with torch.no_grad():
                 asd.set_(asd[1:])
                 asd.grad = None
@@ -9081,7 +9081,7 @@ class TestAutogradDeviceType(TestCase):
 
         # Child gpu graph (much longer than parent graph).
         prev = t2 * t2
-        for i in range(10):
+        for _i in range(10):
             prev = prev * t2
         reentrant_root = prev
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1924,7 +1924,7 @@ except RuntimeError as e:
                                                                   stream if x_first_use_on_ambient else model.stream0))
                     for p in model.parameters():
                         self.assertTrue(p.grad is None)
-                    for i in range(iters):
+                    for _i in range(iters):
                         loss = model(x, x_first_use_on_ambient).sum()
                         if out_of_place:
                             x_grad = torch.autograd.grad((loss,), (x,))[0]
@@ -2541,7 +2541,7 @@ torch.cuda.synchronize()
 
         orig_params = [p.clone().detach() for p in model.parameters()]
 
-        for i, (input, target) in enumerate(data):
+        for _i, (input, target) in enumerate(data):
             optimizer.zero_grad()
             with torch.autocast('cuda', enabled=True):
                 output = model(input)
@@ -2838,7 +2838,7 @@ torch.cuda.synchronize()
             # Line up threads to increase likelihood of race conditions.
             barrier.wait()
             with torch.cuda.stream(my_stream):
-                for i in range(test_iters):
+                for _i in range(test_iters):
                     # If all threads are sharing the same cublas handle,
                     # the following sequence may occur:
                     # thread 0 calls cublasSetStream()
@@ -2947,7 +2947,7 @@ torch.cuda.synchronize()
             # Line up threads to increase likelihood of race conditions.
             barrier.wait()
             with torch.cuda.stream(my_stream):
-                for i in range(test_iters):
+                for _i in range(test_iters):
                     # If all threads are sharing the same cublas handle,
                     # the following sequence may occur:
                     # thread 0 calls cublasSetStream()
@@ -3494,7 +3494,7 @@ exit(2)
         free_bytes_before, total_bytes = torch.cuda.mem_get_info()
         used_gb_before = (total_bytes - free_bytes_before) / 1e9
 
-        for i in range(100):
+        for _i in range(100):
             torch_graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(torch_graph):
                 torch.mm(a, b)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -192,14 +192,14 @@ class TestDatasetRandomSplit(TestCase):
         dataset = CustomDataset(self, x)
         dataset = random_split(dataset, [5])[0]
         data_loader = DataLoader(dataset)
-        for batch in data_loader:
+        for _batch in data_loader:
             pass
 
         # fractional splitting
         dataset = CustomDataset(self, x)
         dataset = random_split(dataset, [1.0])[0]
         data_loader = DataLoader(dataset)
-        for batch in data_loader:
+        for _batch in data_loader:
             pass
 
     def test_splits_reproducibility(self):
@@ -902,7 +902,7 @@ class TestMultiEpochDataset(IterableDataset):
         worker_info = torch.utils.data.get_worker_info()
         assert worker_info is not None
         worker_id = worker_info.id
-        for idx in range(self.length // worker_info.num_workers):
+        for _idx in range(self.length // worker_info.num_workers):
             yield worker_id
 
     def __len__(self):
@@ -1509,7 +1509,7 @@ except RuntimeError as e:
         dataloader = self._get_data_loader(dataset, batch_size=batch_size,
                                            shuffle=False, num_workers=num_workers)
 
-        for ind in range(num_epochs):
+        for _ind in range(num_epochs):
             for batch_idx, sample in enumerate(dataloader):
                 self.assertEqual(sample.tolist(), [batch_idx % num_workers] * batch_size)
 
@@ -2256,7 +2256,7 @@ class IntegrationTestDataLoaderDataPipe(TestCase):
 
                 # Same seeds
                 dl_res = []
-                for epoch in range(2):
+                for _epoch in range(2):
                     torch.manual_seed(123)
                     dl_res.append(list(dl))
                 self.assertEqual(dl_res[0], dl_res[1])
@@ -2447,7 +2447,7 @@ except RuntimeError as e:
             dataloader = self._get_data_loader(dataset, num_workers=2, pin_memory=pin_memory)
             dataset.start = 0
             for i in range(10):
-                for x in dataloader:
+                for _x in dataloader:
                     pass
                 # Changing the start value here doesn't have any effect in the dataset
                 # cached by the workers. since they are not recreated between epochs

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -611,7 +611,7 @@ class TestDataFramesPipes(TestCase):
                       84, ]
 
         actual_i = []
-        for i, j in df_numbers:
+        for i, _j in df_numbers:
             actual_i.append(i)
         self.assertEqual(expected_i, actual_i)
 
@@ -2325,7 +2325,7 @@ class TestTyping(TestCase):
                 self.dp = dp
 
             def __iter__(self) -> Iterator[int]:
-                for a, b in self.dp:
+                for a, _b in self.dp:
                     yield a
 
         # Non-DataPipe input with DataPipe hint

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -235,7 +235,7 @@ class FakeTensorTest(TestCase):
     def test_upsample_bilinear_small_channels(self):
         out = []
         mode = FakeTensorMode()
-        for i, context in enumerate([contextlib.nullcontext, lambda: mode]):
+        for _i, context in enumerate([contextlib.nullcontext, lambda: mode]):
             with context():
                 arg0_1 = torch.empty_strided((3, 427, 640), (1, 1920, 3), dtype=torch.float32, device='cuda')
                 unsqueeze = torch.ops.aten.unsqueeze.default(arg0_1, 0)

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -144,7 +144,7 @@ class TestForeach(TestCase):
     @parametrize("is_fastpath", (True, False))
     def test_binary_op(self, device, dtype, op, is_fastpath):
         scalar_self_arg_test_complete = False
-        for i, sample in enumerate(op.sample_inputs(device, dtype, noncontiguous=not is_fastpath)):
+        for _i, sample in enumerate(op.sample_inputs(device, dtype, noncontiguous=not is_fastpath)):
             (rhs_arg,) = sample.args
             zero_size = sample.kwargs.pop("zero_size")
             kwargs = {} or sample.kwargs

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2057,7 +2057,7 @@ class TestFX(JitTestCase):
 
         g = torch.fx.Graph()
         x = g.placeholder('x')
-        for i in range(depth):
+        for _i in range(depth):
             x = g.call_function(torch.relu, (x,))
         g.output(x)
 
@@ -3387,7 +3387,7 @@ class TestFX(JitTestCase):
 
         def f_sum_dict(x):
             out = 0
-            for k, v in x.items():
+            for _k, v in x.items():
                 out += v
             return out
 
@@ -4113,7 +4113,7 @@ class TestFunctionalTracing(JitTestCase):
                 try:
                     sig = inspect.signature(fn)
                     has_tensor_arg = False
-                    for arg, param in sig.parameters.items():
+                    for _arg, param in sig.parameters.items():
                         if isinstance(param.annotation, type) and issubclass(param.annotation, torch.Tensor):
                             has_tensor_arg = True
                     if not has_tensor_arg:

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -255,7 +255,7 @@ class TestFXExperimental(JitTestCase):
                 self.embedding_layers = torch.nn.ModuleList()
                 el = torch.nn.EmbeddingBag(500000, 4, mode="sum", sparse=True)
                 self.embedding_layers.append(el)
-                for i in range(3):
+                for _i in range(3):
                     el = torch.nn.EmbeddingBag(1000000, 4, mode="sum", sparse=True)
                     self.embedding_layers.append(el)
                 el = torch.nn.EmbeddingBag(500000, 4, mode="sum", sparse=True)
@@ -265,7 +265,7 @@ class TestFXExperimental(JitTestCase):
                 x = self.bottom_layers(a)
                 y = []
                 c = []
-                for i in range(len(self.embedding_layers)):
+                for _i in range(len(self.embedding_layers)):
                     temp = torch.randint(10, (8,))
                     c.append(temp + b)
                 for i in range(len(self.embedding_layers)):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3182,7 +3182,7 @@ class TestScript(JitTestCase):
         with enable_profiling_mode_for_profiling_tests():
 
             def fct_loop(x):
-                for i in range(3):
+                for _i in range(3):
                     x = torch.cat((x, x), 0)
                 return x
 
@@ -3289,7 +3289,7 @@ class TestScript(JitTestCase):
     def test_nested_bailouts(self):
         @torch.jit.script
         def fct_loop(x):
-            for i in range(3):
+            for _i in range(3):
                 x = torch.cat((x, x), 0)
             return x
 
@@ -3951,7 +3951,7 @@ def foo(x):
                 else:
                     return 'v{}'.format(idx - len(exprs))
 
-            for i in range(50):
+            for _i in range(50):
                 n = None
                 while n is None or n > len(exprs) + n_variables:
                     template = random.choice(templates)
@@ -3966,7 +3966,7 @@ def foo(x):
             src_lines.append('  return ({})\n'.format(''.join('v{},'.format(i) for i in range(n_variables))))
             return '\n'.join(src_lines)
 
-        for i in range(100):
+        for _i in range(100):
             g = {'torch': torch}
             code = gen_code()
             builtins.exec(code, g, None)
@@ -4002,7 +4002,7 @@ def foo(x):
                 return e.getattr('name')
 
             return e
-        for k, v in result.items():
+        for _k, v in result.items():
             for i in range(len(v)):
                 if isinstance(v[i], tuple):
                     n, v2 = v[i]
@@ -4642,7 +4642,7 @@ def foo(xyz):
         y = torch.randn(3, 3, requires_grad=True)
 
         def grad_in_loop(x, y):
-            for i in range(100):
+            for _i in range(100):
                 x = y @ x
             return x
 
@@ -5989,7 +5989,7 @@ a")
             # type: (int) -> int
             prev = 1
             v = 1
-            for i in range(0, x):
+            for _i in range(0, x):
                 save = v
                 v = v + prev
                 prev = save
@@ -7823,7 +7823,7 @@ dedent """
             while int(tensor.add_(1)) < 4:
                 if y == 1:
                     continue
-                for i in range(y):
+                for _i in range(y):
                     continue
                     ret += 1
                 ret += 1
@@ -7934,7 +7934,7 @@ dedent """
         def assign_after_break_nested(y):
             # type: (int)
             x = 0
-            for i in range(y):
+            for _i in range(y):
                 if y == 1:
                     x = 5
                     break
@@ -7954,7 +7954,7 @@ dedent """
         def may_break(y):
             # type: (int)
             x = 0
-            for i in range(y):
+            for _i in range(y):
                 if y == 1:
                     x = 5
                 else:
@@ -8026,7 +8026,7 @@ dedent """
         def test_varexit(cond):
             # type: (int)
             m = 0
-            for i in range(3):
+            for _i in range(3):
                 if cond == 2:
                     if cond == 2:
                         m = 2
@@ -8378,7 +8378,7 @@ dedent """
                 # find the last output, then all subsequent uses
                 fc.check(out_name[-1] + " : ")
                 # skip past node body
-                for i in range(contained_blocks(node)):
+                for _i in range(contained_blocks(node)):
                     fc.check("->")
                 if (node.kind() == "prim::If"):
                     fc.check("->").check("->").check("\n")
@@ -8431,7 +8431,7 @@ dedent """
             a = 1
             b = 2
             c = 3
-            for i in range(iter):
+            for _i in range(iter):
                 a = 4
                 b = 5
                 c = 6
@@ -8447,7 +8447,7 @@ dedent """
             a = 1
             b = 2
             c = 3
-            for i in range(iter):
+            for _i in range(iter):
                 c = c + 1
                 b = b + 1
                 a = a + 1
@@ -10936,7 +10936,7 @@ dedent """
 
             # Test symbolic differentiation
             # Run Forward and Backward thrice to trigger autodiff graph
-            for i in range(0, 3):
+            for _i in range(0, 3):
                 y = jit_module(x)
                 y.backward(grad)
             x.grad.zero_()
@@ -11028,7 +11028,7 @@ dedent """
         W.data /= 4
 
         with enable_profiling_mode_for_profiling_tests():
-            for i in range(4):
+            for _i in range(4):
                 self.assertTrue((foo(x, y, W).grad_fn is None) == (jitted_foo(x, y, W).grad_fn is None))
 
 
@@ -11820,7 +11820,7 @@ dedent """
     def test_for_in_tensors(self):
         def test_sizes(x):
             sumz = 0
-            for s in x:
+            for _s in x:
                 sumz += 1
             return sumz
         self.checkScript(test_sizes, (torch.rand(5, 4, 3, 2, 1),))
@@ -11832,7 +11832,7 @@ dedent """
             @torch.jit.script
             def test_sizes(x):
                 sumz = 0
-                for s in x:
+                for _s in x:
                     sumz += 1
                 return sumz
 
@@ -11844,7 +11844,7 @@ dedent """
             def test_sizes(x):
                 # type: (float) -> int
                 sumz = 0
-                for s in x:
+                for _s in x:
                     sumz += 1
                 return sumz
 
@@ -11854,7 +11854,7 @@ dedent """
         def test_sizes(x):
             sumz = 0
             for n in x:
-                for t in n:
+                for _t in n:
                     sumz += 1
             return sumz
 
@@ -13874,7 +13874,7 @@ dedent """
         def test_loop_no_escape(x):
             # type: (int)
             if x >= 0:
-                for i in range(x):
+                for _i in range(x):
                     raise RuntimeError("hi")
             else:
                 return 5
@@ -14087,7 +14087,7 @@ dedent """
 
         def test_will_ret(y):
             # type: (int) -> int
-            for i in range(y):
+            for _i in range(y):
                 return 2
             return 1
 
@@ -14096,8 +14096,8 @@ dedent """
 
         def test_loop_nest_ret(y):
             # type: (int) -> int
-            for i in range(y):
-                for i in range(y - 2):
+            for _i in range(y):
+                for _i in range(y - 2):
                     return 10
                 return 5
             return 0
@@ -15283,7 +15283,7 @@ dedent """
                 if isinstance(item, list):
                     return is_tensor_value(item[0])
                 return False
-            for name, value, the_type in self.get_pickle_values():
+            for name, value, _the_type in self.get_pickle_values():
                 if is_tensor_value(value):
                     continue
                 self.assertEqual(value, getattr(loaded, "_" + name))
@@ -15714,7 +15714,7 @@ dedent """
     def test_for_else(self):
         def fn():
             c = 0
-            for i in range(4):
+            for _i in range(4):
                 c += 10
             else:
                 print("In else block of for...else")

--- a/test/test_jit_autocast.py
+++ b/test/test_jit_autocast.py
@@ -604,7 +604,7 @@ class TestAutocast(JitTestCase):
         t1 = torch.randn(5, 5, device="cuda", dtype=torch.float32).requires_grad_()
 
         # run optimization
-        for i in range(5):
+        for _i in range(5):
             with torch.autocast("cuda", torch.float16):
                 jit_o = jit_t(t0, t1)
             jit_o.sum().backward()

--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -33,7 +33,7 @@ def strip_profiling_nodes(nodes):
 
 def warmup_forward(f, *args):
     profiling_count = 2
-    for i in range(profiling_count):
+    for _i in range(profiling_count):
         results = f(*args)
 
     return results

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -50,7 +50,7 @@ def strip_profiling_nodes(nodes):
     return [n for n in nodes if n.kind() not in profiling_opcodes]
 
 def warmup_forward(f, *args, profiling_count=2):
-    for i in range(profiling_count):
+    for _i in range(profiling_count):
         results = f(*args)
 
     return results
@@ -2088,7 +2088,7 @@ class TestTEFuser(JitTestCase):
         x = torch.arange(-10, 10, dtype=torch.float32, requires_grad=True)
         xs = torch.arange(-10, 10, dtype=torch.float32, requires_grad=True)
         script = torch.jit.script(fn)
-        for i in range(11):
+        for _i in range(11):
             y = fn(x)
             g0 = torch.rand_like(y)
             y.backward(g0)
@@ -2291,7 +2291,7 @@ class TestTEFuser(JitTestCase):
 
                     for i, func in enumerate(funcs):
                         num_args = i + 1
-                        for j, gen in enumerate(gen_tensor):
+                        for _j, gen in enumerate(gen_tensor):
                             inps = (gen(n), gen(n), gen(n))
                             func_s = torch.jit.trace(func, inps, check_trace=False)
                             torch._C._jit_pass_erase_shape_information(func_s.graph)
@@ -2299,7 +2299,7 @@ class TestTEFuser(JitTestCase):
                                 x, y, z = gen(n), gen(n), gen(n)
                                 func_s(x, y, z)
 
-                            for incr in range(3):
+                            for _incr in range(3):
                                 func_s(*[gen(n + 1) for _ in range(3)])
 
                             g = torch.jit.last_executed_optimized_graph()
@@ -2459,7 +2459,7 @@ class TestTEFuser(JitTestCase):
 
             f_traced = torch.jit.trace(f, (x, y))
 
-            for i in range(4):
+            for _i in range(4):
                 # make sure this doesn't error out
                 res = f_traced(x, y)
 
@@ -2478,7 +2478,7 @@ class TestTEFuser(JitTestCase):
         ref = fn(x)
 
         script_fn = torch.jit.script(fn)
-        for i in range(4):
+        for _i in range(4):
             res = script_fn(x)
 
         self.assertEqual(ref, res)

--- a/test/test_jit_llga_fuser.py
+++ b/test/test_jit_llga_fuser.py
@@ -44,7 +44,7 @@ LLGA_FUSION_GROUP = 'prim::oneDNNFusionGroup'
 LLGA_NOT_ENABLED = not torch._C.has_mkldnn or IS_WINDOWS or IS_MACOS
 
 def warmup_forward(f, *args, profiling_count=3):
-    for i in range(profiling_count):
+    for _i in range(profiling_count):
         results = f(*args)
 
     return results
@@ -507,7 +507,7 @@ class TestFusionPattern(JitLlgaTestCase):
                 x = torch.clamp(x, max=2)
                 return x
 
-        for inplace in [False, True]:
+        for _inplace in [False, True]:
             for memory_format in [torch.contiguous_format, torch.channels_last]:
                 x = torch.rand(1, 32, 28, 28).to(memory_format=memory_format)
                 m = M()

--- a/test/test_jiterator.py
+++ b/test/test_jiterator.py
@@ -116,7 +116,7 @@ class TestPythonJiterator(TestCase):
     @parametrize("num_inputs", [1, 5, 8])
     def test_various_num_inputs(self, num_inputs):
         inputs = []
-        for i in range(num_inputs):
+        for _i in range(num_inputs):
             inputs.append(torch.rand(3, device='cuda').mul(10))
 
         input_string = ",".join([f"T i{i}" for i in range(num_inputs)])

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1283,7 +1283,7 @@ class TestLinalg(TestCase):
             ((4, 3), (0, 1.0), TypeError, r"argument 'dim' must be tuple of ints"),
             ((4, 3), (None, ), TypeError, r"argument 'dim' must be tuple of ints"),
         ]
-        for input_size, dim_tuple, error, error_msg in test_cases:
+        for input_size, dim_tuple, error, _error_msg in test_cases:
             input = torch.randn(input_size, device=device)
             # vector_norm should accept a tuple or a list for dim arg
             for dim in [dim_tuple, list(dim_tuple)]:
@@ -5293,7 +5293,7 @@ class TestLinalg(TestCase):
         elapsed_ortho_general = 0
         elapsed_scipy = 0
         elapsed_general_scipy = 0
-        for i in range(repeat):
+        for _i in range(repeat):
             start = time.time()
             torch.lobpcg(A1, X=X1, niter=niter, method='ortho', tol=tol)
             end = time.time()
@@ -6372,7 +6372,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
 
             num_matrices = tensors_batch.size(0)
             tensors_list = []
-            for i in range(num_matrices):
+            for _i in range(num_matrices):
                 tensors_list.append(torch.randn(n[-2], n[-1], dtype=dtype, device=device))
 
             for i in range(num_matrices):

--- a/test/test_mkldnn_fusion.py
+++ b/test/test_mkldnn_fusion.py
@@ -204,7 +204,7 @@ class TestMkldnnFusion(JitTestCase):
                 x = self.unary(x)
                 return x
 
-        for pointwise_name, pointwise_info in self._unary_list().items():
+        for _pointwise_name, pointwise_info in self._unary_list().items():
             options = itertools.product([[2, 3, 10], [2, 10]], [True, False])
             for input_shape, bias in options:
                 with torch.no_grad():
@@ -233,7 +233,7 @@ class TestMkldnnFusion(JitTestCase):
                 return x
 
         input_shapes = {2: (112, 112), 3: (55, 55, 55)}
-        for pointwise_name, pointwise_info in self._unary_list().items():
+        for _pointwise_name, pointwise_info in self._unary_list().items():
             for dim in [2, 3]:
                 channels_last = torch.channels_last if dim == 2 else torch.channels_last_3d
                 options = itertools.product([True, False], [1, 2], [1, 4], [torch.contiguous_format, channels_last])
@@ -347,7 +347,7 @@ class TestMkldnnFusion(JitTestCase):
 
         input_shapes = {2: (28, 28)}
         kernel_size = 3
-        for pointwise_name, pointwise_info in self._unary_list().items():
+        for _pointwise_name, pointwise_info in self._unary_list().items():
             for dim in [2]:
                 channels_last = torch.channels_last if dim == 2 else torch.channels_last_3d
                 options = itertools.product([True, False], [1, 2], [1, 4], [torch.contiguous_format, channels_last], [False, True])

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -799,7 +799,7 @@ class MpsMemoryLeakCheck():
 
         discrepancy_detected = True
         # Query memory multiple items to ensure leak was not transient
-        for n in range(3):
+        for _n in range(3):
             caching_allocator_mem_allocated = torch.mps.current_allocated_memory()
             driver_mem_allocated = torch.mps.driver_allocated_memory()
 
@@ -1234,7 +1234,7 @@ class TestMPS(TestCaseMPS):
         # Test to detect issues in cdist gradient calculation
         # When the distances are 0
         sizex = (1, 27, 32)
-        for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
+        for _p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
             x = torch.randn(sizex, device=device, dtype=torch.float)
             dist_grad = torch.randn((1, 27, 27), device=device, dtype=torch.float)
             y = x.clone()

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -43,7 +43,7 @@ class SubProcess(mp.Process):
 
 
 def _test_cuda_ipc_deadlock_actor(queue, iterations):
-    for i in range(iterations):
+    for _i in range(iterations):
         if not queue.empty():
             queue.get()
         time.sleep(.01)
@@ -51,7 +51,7 @@ def _test_cuda_ipc_deadlock_actor(queue, iterations):
 
 def _test_cuda_ipc_deadlock_learner(queue, iterations):
     net = torch.nn.LSTM(1, 1).cuda()
-    for i in range(iterations):
+    for _i in range(iterations):
         if not queue.full():
             queue.put(copy.deepcopy(net.state_dict()))
         time.sleep(.01)
@@ -85,7 +85,7 @@ def send_and_delete_tensors(queue, event, device, dtype, count, size=5):
 
 def receive_and_send_sum(queue, out_queue, event, device, dtype, count, size=5):
     s = torch.full([size], 0, device=device, dtype=dtype)
-    for i in range(count):
+    for _i in range(count):
         t = queue.get()
         s += t
     out_queue.put(s)
@@ -93,7 +93,7 @@ def receive_and_send_sum(queue, out_queue, event, device, dtype, count, size=5):
 
 
 def receive_and_send(queue, out_queue, event, count):
-    for i in range(count):
+    for _i in range(count):
         t = queue.get()
         out_queue.put(t.clone())
     event.wait()

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -996,7 +996,7 @@ class TestNamedTensor(TestCase):
 
     def test_cummax_cummin(self):
         def test_ops(op):
-            for device in get_all_device_types():
+            for _device in get_all_device_types():
                 names = ('N', 'D')
                 tensor = torch.rand(2, 3, names=names)
                 result = op(tensor, 0)
@@ -1006,14 +1006,14 @@ class TestNamedTensor(TestCase):
         test_ops(torch.cummin)
 
     def test_logcumsumexp(self):
-        for device in get_all_device_types():
+        for _device in get_all_device_types():
             names = ('N', 'D')
             tensor = torch.rand(2, 3, names=names)
             result = torch.logcumsumexp(tensor, 'D')
             self.assertEqual(result.names, names)
 
     def test_bitwise_not(self):
-        for device in get_all_device_types():
+        for _device in get_all_device_types():
             names = ('N', 'D')
             tensor = torch.zeros(2, 3, names=names, dtype=torch.bool)
             result = torch.empty(0, dtype=torch.bool)
@@ -1023,7 +1023,7 @@ class TestNamedTensor(TestCase):
             self.assertEqual(tensor.bitwise_not_().names, names)
 
     def test_logical_not(self):
-        for device in get_all_device_types():
+        for _device in get_all_device_types():
             names = ('N', 'D')
             tensor = torch.zeros(2, 3, names=names, dtype=torch.bool)
             result = torch.empty(0, dtype=torch.bool)
@@ -1033,7 +1033,7 @@ class TestNamedTensor(TestCase):
             self.assertEqual(tensor.logical_not_().names, names)
 
     def test_bernoulli(self):
-        for device in get_all_device_types():
+        for _device in get_all_device_types():
             names = ('N', 'D')
             tensor = torch.rand(2, 3, names=names)
             result = torch.empty(0)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1211,7 +1211,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
         def check():
             self.assertEqual(len(parameter_dict), len(parameters))
-            for i, (k1, (k2, m2)) in enumerate(zip(parameters, parameter_dict.named_parameters())):
+            for _i, (k1, (k2, m2)) in enumerate(zip(parameters, parameter_dict.named_parameters())):
                 self.assertEqual(k1, k2)
                 self.assertIs(parameters[k1], m2)
             for k1, k2 in zip(parameters, parameter_dict):
@@ -3033,7 +3033,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                                                batch_first=batch_first)
 
             # set constant weights of the model
-            for idx, p in enumerate(model.parameters()):
+            for _idx, p in enumerate(model.parameters()):
                 x = p.data
                 sz = x.view(-1).size(0)
                 shape = x.shape
@@ -3182,7 +3182,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                                                activation, batch_first=batch_first)
 
             # set constant weights of the model
-            for idx, p in enumerate(model.parameters()):
+            for _idx, p in enumerate(model.parameters()):
                 x = p.data
                 sz = x.view(-1).size(0)
                 shape = x.shape
@@ -3259,7 +3259,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
             with torch.no_grad():
                 # set constant weights of the model
-                for idx, p in enumerate(layer.parameters()):
+                for _idx, p in enumerate(layer.parameters()):
                     x = p.data
                     sz = x.view(-1).size(0)
                     shape = x.shape
@@ -8588,7 +8588,7 @@ class TestNNDeviceType(NNTestCase):
     @expectedFailureMeta  # RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, -1]
     @onlyNativeDeviceTypes
     def test_Transformer_empty(self, device):
-        for batch_first, src_shape, tgt_shape in [(True, (10, 0, 512), (20, 0, 512))]:
+        for _batch_first, src_shape, tgt_shape in [(True, (10, 0, 512), (20, 0, 512))]:
             transformer_model = nn.Transformer(nhead=16, num_encoder_layers=12).to(device)
             src = torch.rand(*src_shape, requires_grad=True, device=device)
             tgt = torch.rand(*tgt_shape, requires_grad=True, device=device)
@@ -11873,7 +11873,7 @@ class TestNNDeviceType(NNTestCase):
                 model = model.eval()
 
             # set constant weights of the model
-            for idx, p in enumerate(model.parameters()):
+            for _idx, p in enumerate(model.parameters()):
                 x = p.data
                 sz = x.view(-1).size(0)
                 shape = x.shape
@@ -12085,7 +12085,7 @@ class TestNNDeviceType(NNTestCase):
                 model = model.eval()
 
             # set constant weights of the model
-            for idx, p in enumerate(model.parameters()):
+            for _idx, p in enumerate(model.parameters()):
                 x = p.data
                 sz = x.view(-1).size(0)
                 shape = x.shape

--- a/test/test_openmp.py
+++ b/test/test_openmp.py
@@ -36,8 +36,8 @@ class TestOpenMP_ParallelFor(TestCase):
         p = psutil.Process()
         # warm up for 5 runs, then things should be stable for the last 5
         last_rss = collections.deque(maxlen=5)
-        for n in range(10):
-            for i in range(runs):
+        for _n in range(10):
+            for _i in range(runs):
                 self.model(self.x)
             last_rss.append(p.memory_info().rss)
         return last_rss

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1281,7 +1281,7 @@ class TestCommon(TestCase):
                 # one or more tensors requiring grad
                 def _tensor_requires_grad(x):
                     if isinstance(x, dict):
-                        for k, v in x.items():
+                        for _k, v in x.items():
                             if _tensor_requires_grad(v):
                                 return True
                     if isinstance(x, (list, tuple)):
@@ -2143,7 +2143,7 @@ class TestFakeTensor(TestCase):
     def _test_fake_crossref_helper(self, device, dtype, op, context):
         samples = op.sample_inputs(device, dtype, requires_grad=True)
 
-        for iter, sample in enumerate(samples):
+        for _iter, sample in enumerate(samples):
             args = [sample.input] + list(sample.args)
             kwargs = sample.kwargs
 

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1933,7 +1933,7 @@ class TestLRScheduler(TestCase):
 
     def test_old_pattern_warning_resuming(self):
         epochs = 35
-        for i, group in enumerate(self.opt.param_groups):
+        for _i, group in enumerate(self.opt.param_groups):
             group["initial_lr"] = 0.01
 
         with warnings.catch_warnings(record=True) as ws:
@@ -1950,7 +1950,7 @@ class TestLRScheduler(TestCase):
 
     def test_old_pattern_warning_resuming_with_arg(self):
         epochs = 35
-        for i, group in enumerate(self.opt.param_groups):
+        for _i, group in enumerate(self.opt.param_groups):
             group["initial_lr"] = 0.01
 
         with warnings.catch_warnings(record=True) as ws:
@@ -1967,7 +1967,7 @@ class TestLRScheduler(TestCase):
 
     def test_old_pattern_warning_with_overridden_optim_step(self):
         epochs = 35
-        for i, group in enumerate(self.opt.param_groups):
+        for _i, group in enumerate(self.opt.param_groups):
             group["initial_lr"] = 0.01
 
         with warnings.catch_warnings(record=True) as ws:
@@ -2040,7 +2040,7 @@ class TestLRScheduler(TestCase):
         self.opt.step = types.MethodType(new_step, self.opt)
 
         def new_pattern():
-            for e in range(epochs):
+            for _e in range(epochs):
                 self.opt.step()
                 scheduler.step()
 
@@ -4013,7 +4013,7 @@ class TestSWAUtils(TestCase):
         averaged_dnn = AveragedModel(dnn, device=swa_device)
         averaged_params = [torch.zeros_like(param) for param in dnn.parameters()]
         n_updates = 10
-        for i in range(n_updates):
+        for _i in range(n_updates):
             for p, p_avg in zip(dnn.parameters(), averaged_params):
                 p.detach().add_(torch.randn_like(p))
                 p_avg += p.detach() / n_updates
@@ -4046,7 +4046,7 @@ class TestSWAUtils(TestCase):
         averaged_dnn = AveragedModel(dnn)
         averaged_params = [torch.zeros_like(param) for param in dnn.parameters()]
         n_updates = 10
-        for i in range(n_updates):
+        for _i in range(n_updates):
             for p, p_avg in zip(dnn.parameters(), averaged_params):
                 p.detach().add_(torch.randn_like(p))
                 p_avg += p.detach() / n_updates
@@ -4064,7 +4064,7 @@ class TestSWAUtils(TestCase):
         averaged_dnn = AveragedModel(dnn)
         averaged_dnn2 = AveragedModel(dnn)
         n_updates = 10
-        for i in range(n_updates):
+        for _i in range(n_updates):
             for p in dnn.parameters():
                 p.detach().add_(torch.randn_like(p))
             averaged_dnn.update_parameters(dnn)

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -379,7 +379,7 @@ class TestPublicBindings(TestCase):
                 for elem in all_api:
                     if not elem.startswith('_'):
                         check_one_element(elem, modname, mod, is_public=True, is_all=False)
-        for _, modname, ispkg in pkgutil.walk_packages(path=torch.__path__, prefix=torch.__name__ + '.'):
+        for _, modname, _ispkg in pkgutil.walk_packages(path=torch.__path__, prefix=torch.__name__ + '.'):
             test_module(modname)
 
         test_module('torch')

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -59,7 +59,7 @@ def _generate_input(shape, dtype, device, with_extremal):
 # TODO: replace with make_tensor
 def _rand_shape(dim, min_size, max_size):
     shape = []
-    for i in range(dim):
+    for _i in range(dim):
         shape.append(random.randint(min_size, max_size))
     return tuple(shape)
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -209,7 +209,7 @@ class SerializationMixin:
             5,
             6
         ]
-        for i in range(0, 100):
+        for _i in range(0, 100):
             data.append(0)
         t = torch.tensor(data, dtype=torch.uint8)
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1375,7 +1375,7 @@ class TestSparse(TestSparseBase):
         def test_shape(num_mats, dim_i, dim_j, dim_k, nnz):
             a_list = []
             b_list = []
-            for mat_idx in range(num_mats):
+            for _mat_idx in range(num_mats):
                 a_mat = self._gen_sparse(2, nnz, [dim_i, dim_j], dtype, device, coalesced)[0]
                 b_mat = torch.randn([dim_j, dim_k], dtype=dtype, device=device)
                 a_list.append(a_mat)
@@ -1435,7 +1435,7 @@ class TestSparse(TestSparseBase):
         def test_shape(num_mats, dim_i, dim_j, dim_k, nnz):
             a_list = []
             b_list = []
-            for mat_idx in range(num_mats):
+            for _mat_idx in range(num_mats):
                 a_list.append(self._gen_sparse(2, nnz, [dim_i, dim_j], dtype, device, coalesced)[0])
                 b_list.append(torch.randn([dim_j, dim_k], dtype=dtype, device=device))
 

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2968,7 +2968,7 @@ class TestSparseCSR(TestCase):
             }[layout]
             if n_dense > 0:
                 # expect all transpose to throw
-                for (name0, dim0), (name1, dim1) in itertools.product(named0, named1):
+                for (_name0, dim0), (_name1, dim1) in itertools.product(named0, named1):
                     msg = r"transpose\(\): hybrid sparse compressed tensors with dense dimensions are not supported"
                     if (dim0 is not None) and (dim1 is not None):
                         with self.assertRaisesRegex(RuntimeError, msg):

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1244,7 +1244,7 @@ class TestFFT(TestCase):
             istft_kwargs = stft_kwargs.copy()
             del istft_kwargs['pad_mode']
             for sizes in data_sizes:
-                for i in range(num_trials):
+                for _i in range(num_trials):
                     original = torch.randn(*sizes, dtype=dtype, device=device)
                     stft = torch.stft(original, return_complex=True, **stft_kwargs)
                     inversed = torch.istft(stft, length=original.size(1), **istft_kwargs)
@@ -1299,7 +1299,7 @@ class TestFFT(TestCase):
                 'onesided': True,
             },
         ]
-        for i, pattern in enumerate(patterns):
+        for _i, pattern in enumerate(patterns):
             _test_istft_is_inverse_of_stft(pattern)
 
     @onlyNativeDeviceTypes
@@ -1315,7 +1315,7 @@ class TestFFT(TestCase):
             del stft_kwargs['size']
             istft_kwargs = stft_kwargs.copy()
             del istft_kwargs['pad_mode']
-            for i in range(num_trials):
+            for _i in range(num_trials):
                 original = torch.randn(*sizes, dtype=dtype, device=device)
                 stft = torch.stft(original, return_complex=True, **stft_kwargs)
                 with self.assertWarnsOnceRegex(UserWarning, "The length of signal is shorter than the length parameter."):
@@ -1366,7 +1366,7 @@ class TestFFT(TestCase):
                 'onesided': True,
             },
         ]
-        for i, pattern in enumerate(patterns):
+        for _i, pattern in enumerate(patterns):
             _test_istft_is_inverse_of_stft_with_padding(pattern)
 
     @onlyNativeDeviceTypes
@@ -1429,7 +1429,7 @@ class TestFFT(TestCase):
         complex_dtype = corresponding_complex_dtype(dtype)
 
         def _test(data_size, kwargs):
-            for i in range(num_trials):
+            for _i in range(num_trials):
                 tensor1 = torch.randn(data_size, device=device, dtype=complex_dtype)
                 tensor2 = torch.randn(data_size, device=device, dtype=complex_dtype)
                 a, b = torch.rand(2, dtype=dtype, device=device)

--- a/test/test_static_runtime.py
+++ b/test/test_static_runtime.py
@@ -160,7 +160,7 @@ def fork_wait_graph_exception(input1, input2):
 
 def loop_graph(a, b, iters: int):
     c = a + b * 2
-    for i in range(iters):
+    for _i in range(iters):
         c = c + b
         c *= 2
         c -= a

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -61,7 +61,7 @@ def _generate_input(shape, dtype, device, with_extremal):
 # TODO: replace with make_tensor
 def _rand_shape(dim, min_size, max_size):
     shape = []
-    for i in range(dim):
+    for _i in range(dim):
         shape.append(random.randint(min_size, max_size))
     return tuple(shape)
 
@@ -828,7 +828,7 @@ class TestTensorCreation(TestCase):
                 num_tensors = random.randint(1, 5)
                 torch_input = []
                 # Create tensors with shape being different along one axis only
-                for param in range(num_tensors):
+                for _param in range(num_tensors):
                     shape[i] = random.randint(1, 5)
                     torch_input.append(_generate_input(tuple(shape), dtype, device, with_extremal=False))
 
@@ -883,7 +883,7 @@ class TestTensorCreation(TestCase):
         ops = ((torch.vstack, np.vstack), (torch.row_stack, np.row_stack))
         for torch_op, np_op in ops:
             self._test_special_stacks(0, 2, torch_op, np_op, device, dtype)
-            for i in range(5):
+            for _i in range(5):
                 # Test dimension change for 1D tensor of size (N) and 2D tensor of size (1, N)
                 n = random.randint(1, 10)
                 input_a = _generate_input((n,), dtype, device, with_extremal=False)
@@ -898,7 +898,7 @@ class TestTensorCreation(TestCase):
     @dtypes(*all_types_and_complex_and(torch.half))
     def test_dstack(self, device, dtype):
         self._test_special_stacks(2, 3, torch.dstack, np.dstack, device, dtype)
-        for i in range(5):
+        for _i in range(5):
             # Test dimension change for 1D tensor of size (N), 2D tensor of size (1, N), and 3D tensor of size (1, N, 1)
             n = random.randint(1, 10)
             input_a = _generate_input((n,), dtype, device, with_extremal=False)
@@ -2690,7 +2690,7 @@ class TestTensorCreation(TestCase):
     @dtypesIfCUDA(torch.float, torch.double, torch.bfloat16, torch.half, torch.long)
     @dtypes(torch.float, torch.double, torch.long)
     def test_kaiser_window(self, device, dtype):
-        for num_test in range(50):
+        for _num_test in range(50):
             self._test_signal_window_functions('kaiser', dtype, device, beta=random.random() * 30)
 
     def test_tensor_factories_empty(self, device):

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1202,7 +1202,7 @@ class TestTensorExprFuser(BaseTestClass):
         @torch.jit.script
         def test(x: torch.Tensor, y: torch.Tensor, z: int) -> torch.Tensor:
             b = y
-            for i in range(0, z):
+            for _i in range(0, z):
                 a = x + y
                 b = b + y
             return b

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2170,7 +2170,7 @@ class TestImports(TestCase):
             ignored_modules.append("torch.testing._internal.common_distributed")
 
         torch_dir = os.path.dirname(torch.__file__)
-        for base, folders, files in os.walk(torch_dir):
+        for base, _folders, files in os.walk(torch_dir):
             prefix = os.path.relpath(base, os.path.dirname(torch_dir)).replace(os.path.sep, ".")
             for f in files:
                 if not f.endswith(".py"):

--- a/test/test_throughput_benchmark.py
+++ b/test/test_throughput_benchmark.py
@@ -44,7 +44,7 @@ class TestThroughputBenchmark(TestCase):
 
         inputs = []
 
-        for i in range(NUM_INPUTS):
+        for _i in range(NUM_INPUTS):
             inputs.append([torch.randn(B, D_in), torch.randn(B, D_in)])
         bench = ThroughputBenchmark(module)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -123,7 +123,7 @@ class TestTorchDeviceType(TestCase):
     # TODO: move all tensor creation to common ops
     def _rand_shape(self, dim, min_size, max_size):
         shape = []
-        for i in range(dim):
+        for _i in range(dim):
             shape.append(random.randint(min_size, max_size))
         return tuple(shape)
 
@@ -156,7 +156,7 @@ class TestTorchDeviceType(TestCase):
 
         element_size = torch._utils._element_size(dtype)
 
-        for i in range(10):
+        for _i in range(10):
             bytes_list = [rand_byte() for _ in range(element_size)]
             scalar = bytes_to_scalar(bytes_list, dtype, device)
             self.assertEqual(scalar.storage().untyped().tolist(), bytes_list)
@@ -1639,7 +1639,7 @@ else:
             else:
                 self.fail(f"'{call_type}' is not a valid call type")
 
-        for call_type in ['function', 'method', 'out']:
+        for _call_type in ['function', 'method', 'out']:
             self.check_nondeterministic_alert(
                 lambda: test_func('function'),
                 'kthvalue CUDA',
@@ -2061,7 +2061,7 @@ else:
             if num_observations > 0:
                 fweights = torch.randint(1, 10, (num_observations,), device=device)
                 aweights = make_tensor((num_observations,), dtype=torch.float, device=device, low=1)
-                for correction, fw, aw in product([0, 1, 2], [None, fweights], [None, aweights]):
+                for correction, _fw, _aw in product([0, 1, 2], [None, fweights], [None, aweights]):
                     check(x, correction, fweights, aweights)
 
     @skipIfNoSciPy
@@ -2384,7 +2384,7 @@ else:
         # Test to detect issues in cdist gradient calculation
         # When the distances are 0
         sizex = (1, 27, 32)
-        for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
+        for _p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
             x = torch.randn(sizex, device=device, dtype=torch.float)
             dist_grad = torch.randn((1, 27, 27), device=device, dtype=torch.float)
             y = x.clone()
@@ -4961,7 +4961,7 @@ else:
         prob_dist = torch.rand(10000, 1000, device=device, dtype=dtype)
         n_sample = 1
 
-        for i in range(trials):
+        for _i in range(trials):
             gen.manual_seed(seed)
             samples_1 = torch.multinomial(prob_dist, n_sample, True, generator=gen)
 

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -119,7 +119,7 @@ class TestTransformers(NNTestCase):
         encoder = nn.TransformerEncoder(layer, 2).to(device)
         optimizer = optim.SGD(encoder.parameters(), lr=0.1, momentum=0.9)
         encoder.train()
-        for i in range(iters):
+        for _i in range(iters):
             encoder.train()
             optimizer.zero_grad()
             inputs = torch.cat([torch.randn(1, 2, 2), torch.zeros(1, 2, 2)], dim=1).to(device)
@@ -287,7 +287,7 @@ class TestTransformers(NNTestCase):
 
         with torch.no_grad():
             # set constant weights of the model
-            for idx, p in enumerate(model.parameters()):
+            for _idx, p in enumerate(model.parameters()):
                 x = p.data
                 sz = x.view(-1).size(0)
                 shape = x.shape
@@ -338,7 +338,7 @@ class TestTransformers(NNTestCase):
 
             with torch.no_grad():
                 # set constant weights of the model
-                for idx, p in enumerate(layer.parameters()):
+                for _idx, p in enumerate(layer.parameters()):
                     x = p.data
                     sz = x.view(-1).size(0)
                     shape = x.shape

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -51,7 +51,7 @@ def _generate_input(shape, dtype, device, with_extremal):
 # TODO: replace this with make_tensor() in common_utils.py
 def _rand_shape(dim, min_size, max_size):
     shape = []
-    for i in range(dim):
+    for _i in range(dim):
         shape.append(random.randint(min_size, max_size))
     return tuple(shape)
 
@@ -1429,7 +1429,7 @@ class TestOldViewOps(TestCase):
     def _test_atleast_dim(self, torch_fn, np_fn, device, dtype):
         for ndims in range(0, 5):
             shape = _rand_shape(ndims, min_size=5, max_size=10)
-            for n in range(ndims + 1):
+            for _n in range(ndims + 1):
                 for with_extremal in [False, True]:
                     for contiguous in [False, True]:
                         # Generate Input.

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -1078,7 +1078,7 @@ def emit_body(
             derivative_var_name = derivative.var_names[0]
 
             # Figure out the offset of the edge that uses this variable
-            for edge_off, a in enumerate(args_with_derivatives):
+            for _edge_off, a in enumerate(args_with_derivatives):
                 if a.name == derivative_var_name:
                     break
             else:

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -676,7 +676,7 @@ def create_differentiability_info(
         )
 
     diffinfo_dict = {}
-    for key, defn in defn_dict["dispatch"].items():
+    for key, _defn in defn_dict["dispatch"].items():
         if key != "Default" and key not in _VALID_AUTOGRAD_KEYS:
             raise RuntimeError(
                 f"Invalid dispatch key {key} in derivatives.yaml for {specification},"

--- a/tools/code_analyzer/gen_operators_yaml.py
+++ b/tools/code_analyzer/gen_operators_yaml.py
@@ -340,7 +340,7 @@ def fill_output(output: Dict[str, object], options: object):
 
     # START STATIC BUILD OPS
     static_root_ops_bucket = {}
-    for op_name in static_root_ops:
+    for _op_name in static_root_ops:
         op = SelectiveBuildOperator.from_yaml_dict(
             op_name,
             {

--- a/tools/code_analyzer/gen_oplist.py
+++ b/tools/code_analyzer/gen_oplist.py
@@ -18,7 +18,7 @@ from torchgen.selective_build.selector import (
 
 def extract_all_operators(selective_builder: SelectiveBuilder) -> Set[str]:
     ops = []
-    for op_name, op in selective_builder.operators.items():
+    for op_name, _op in selective_builder.operators.items():
         ops.append(op_name)
     return set(ops)
 
@@ -74,7 +74,7 @@ SupportedMobileModelCheckerRegistry register_model_versions;
         if "debug_info" in model_dict:
             debug_info = json.loads(model_dict["debug_info"][0])
             if debug_info["is_new_style_rule"]:
-                for asset, asset_info in debug_info["asset_info"].items():
+                for _asset, asset_info in debug_info["asset_info"].items():
                     md5_hashes.update(asset_info["md5_hash"])
 
     supported_hashes = ""

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -379,7 +379,7 @@ def fix_extended_args(instructions: List[Instruction]):
             if output and output[-1].opcode == dis.EXTENDED_ARG:
                 output.pop()
 
-    for i, inst in enumerate(instructions):
+    for _i, inst in enumerate(instructions):
         if inst.opcode == dis.EXTENDED_ARG:
             # Leave this instruction alone for now so we never shrink code
             inst.arg = 0

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -274,7 +274,7 @@ class SideEffects:
             if not isinstance(var.mutable_local, AttributeMutationNew):
                 VariableTracker.apply(visit, var)
 
-        for skip_obj, setattrs in self.store_attr_mutations.items():
+        for _skip_obj, setattrs in self.store_attr_mutations.items():
             VariableTracker.apply(visit, setattrs)
 
         self.id_to_variable = collections.OrderedDict(

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -124,7 +124,7 @@ def increment_op_count(cnt):
 def print_time_report():
     total = 0
     total_by_key = {}
-    for frame, timings in frame_phase_timing.items():
+    for _frame, timings in frame_phase_timing.items():
         for key, timing in timings.items():
             total += timing
             if key not in total_by_key:

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -685,7 +685,7 @@ def run_functionalized_fw_and_collect_metadata(
 
         # Inspect the state of the input tensor functional wrapper to detect input mutation info
         # If inp[i] has a metadata-only mutation, then maybe_inputs_with_mutated_metadata[i] contains the updated version
-        for (i, (arg, f_arg)) in enumerate(zip(flat_args, flat_f_args)):
+        for (_i, (arg, f_arg)) in enumerate(zip(flat_args, flat_f_args)):
             if not isinstance(arg, Tensor):
                 new_arg = arg
             else:
@@ -970,7 +970,7 @@ def fn_prepped_for_autograd(
         # This is annoying: our joint function needs to be aware of functionalization
         # (syncing mutated inputs before calling autograd.grad())
         # In theory, we could make the autograd engine do this automatically, although that probably isn't any cleaner.
-        for i, arg in enumerate(args_maybe_cloned):
+        for _i, arg in enumerate(args_maybe_cloned):
             if not isinstance(arg, Tensor):
                 continue
             torch._sync(arg)
@@ -1541,7 +1541,7 @@ def remove_dupe_metadata(
     # Easy invariant: the first argument should never be a dupe (it will be kept)
     assert len(keep_arg_mask) > 0 and keep_arg_mask[0]
     dupe_to_dedup_idx = [0]
-    for i, b in enumerate(keep_arg_mask[1:]):
+    for _i, b in enumerate(keep_arg_mask[1:]):
         if b:
             dupe_to_dedup_idx.append(dupe_to_dedup_idx[-1] + 1)
         else:
@@ -3011,7 +3011,7 @@ def aot_module_simplified(
 
     if hasattr(mod, "graph"):
         # Non dynamo entrypoints can get to here...
-        for i, node in enumerate(mod.graph.nodes):
+        for _i, node in enumerate(mod.graph.nodes):
             if node.op == "placeholder":
                 if hasattr(node, "_dynamo_source"):
                     # ... but not here!

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2702,7 +2702,7 @@ class LoopNestWithSplit:
         loops = self.root
         for loop in loops:
             loop.parallel = par_depth
-        for i in range(1, par_depth):
+        for _i in range(1, par_depth):
             loops = loops[0].inner
             loops[0].collapsed = True
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1585,7 +1585,7 @@ class TritonScheduling:
             current_loop_writes.clear()
             is_current_reductions.clear()
 
-        for index, node in enumerate(nodes):
+        for _index, node in enumerate(nodes):
             if node in done:
                 continue
             done.add(node)

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -736,7 +736,7 @@ class CUDAGraphNode:
         self.expected_dead_indices_after_graph = delta
 
         assert len(self.outputs_weakrefs) == 0
-        for i, o in enumerate(outputs):
+        for _i, o in enumerate(outputs):
             self.output_is_alias_of_static_inputs.append(
                 o is not None
                 and o.untyped_storage().data_ptr() in self.static_input_storage_ptrs

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -256,7 +256,7 @@ class GraphLowering(torch.fx.Interpreter):
                     value.realize()
             return value
 
-        for key, value in self.env.items():
+        for _key, value in self.env.items():
             try:
                 visit(value)
             except Exception:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2619,7 +2619,7 @@ def constant_pad_nd(x, padding, fill_value=0):
 
     def offset_fn(index):
         new_index = list(index[:n])
-        for idx, (low, high) in zip(index[n:], bounds_precomp):
+        for idx, (low, _high) in zip(index[n:], bounds_precomp):
             new_index.append(idx - low)
         assert len(new_index) == len(index)
         return mask(new_index)

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -897,7 +897,7 @@ def get_class_name_lineno(method) -> Tuple[str, int]:
     current_frame = inspect.currentframe()
 
     # one for the get_class_name call, one for _overload_method call
-    for i in range(2):
+    for _i in range(2):
         assert (
             current_frame is not None
         )  # assert current frame is not an Optional[FrameType]

--- a/torch/_lowrank.py
+++ b/torch/_lowrank.py
@@ -68,13 +68,13 @@ def get_approximate_basis(
     A_H = _utils.transjugate(A)
     if M is None:
         Q = torch.linalg.qr(matmul(A, R)).Q
-        for i in range(niter):
+        for _i in range(niter):
             Q = torch.linalg.qr(matmul(A_H, Q)).Q
             Q = torch.linalg.qr(matmul(A, Q)).Q
     else:
         M_H = _utils.transjugate(M)
         Q = torch.linalg.qr(matmul(A, R) - matmul(M, R)).Q
-        for i in range(niter):
+        for _i in range(niter):
             Q = torch.linalg.qr(matmul(A_H, Q) - matmul(M_H, Q)).Q
             Q = torch.linalg.qr(matmul(A, Q) - matmul(M, Q)).Q
 

--- a/torch/ao/nn/quantizable/modules/rnn.py
+++ b/torch/ao/nn/quantizable/modules/rnn.py
@@ -324,7 +324,7 @@ class LSTM(torch.nn.Module):
         layers = [_LSTMLayer(self.input_size, self.hidden_size,
                              self.bias, batch_first=False,
                              bidirectional=self.bidirectional, **factory_kwargs)]
-        for layer in range(1, num_layers):
+        for _layer in range(1, num_layers):
             layers.append(_LSTMLayer(self.hidden_size, self.hidden_size,
                                      self.bias, batch_first=False,
                                      bidirectional=self.bidirectional,

--- a/torch/ao/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/ao/nn/quantized/dynamic/modules/rnn.py
@@ -105,7 +105,7 @@ class RNNBase(torch.nn.Module):
 
         _all_weight_values = []
         for layer in range(num_layers):
-            for direction in range(num_directions):
+            for _direction in range(num_directions):
                 layer_input_size = input_size if layer == 0 else hidden_size * num_directions
 
                 w_ih = torch.randn(gate_size, layer_input_size).to(torch.float)

--- a/torch/ao/ns/_numeric_suite.py
+++ b/torch/ao/ns/_numeric_suite.py
@@ -133,7 +133,7 @@ def _get_logger_dict_helper(
     def get_prefix(prefix):
         return prefix if prefix == "" else prefix + "."
 
-    for name, child in mod.named_children():
+    for _name, child in mod.named_children():
         if isinstance(child, Logger):
             target_dict[get_prefix(prefix) + "stats"] = child.stats
             break

--- a/torch/ao/ns/_numeric_suite_fx.py
+++ b/torch/ao/ns/_numeric_suite_fx.py
@@ -532,7 +532,7 @@ def _extract_logger_info_one_model(
     logger_cls: Callable,
 ) -> None:
     torch._C._log_api_usage_once("quantization_api._numeric_suite_fx._extract_logger_info_one_model")
-    for gm_name, mod in model.named_modules():
+    for _gm_name, mod in model.named_modules():
         # TODO(future PR): better check when scripted
         is_logger = (
             isinstance(mod, logger_cls)  # type: ignore[arg-type]
@@ -966,7 +966,7 @@ def loggers_set_enabled(model: torch.nn.Module, enabled: bool) -> None:
     """
     Sets the `enabled` setting on a `model`'s loggers
     """
-    for name, child in model.named_modules():
+    for _name, child in model.named_modules():
         if isinstance(child, OutputLogger):
             child.enabled = enabled
 
@@ -979,7 +979,7 @@ def loggers_set_save_activations(
     """
     Sets the `save_activations` setting on a `model`'s loggers
     """
-    for name, child in model.named_modules():
+    for _name, child in model.named_modules():
         if isinstance(child, OutputLogger):
             child.save_activations = save_activations
 

--- a/torch/ao/ns/fx/graph_matcher.py
+++ b/torch/ao/ns/fx/graph_matcher.py
@@ -134,7 +134,7 @@ class _NSGraphMatchableSubgraphsIterator:
             for inner_arg in arg:
                 self._recursively_add_node_arg_to_stack(inner_arg)
         elif isinstance(arg, torch.fx.immutable_collections.immutable_dict):
-            for key, value in arg.items():
+            for _key, value in arg.items():
                 self._recursively_add_node_arg_to_stack(value)
 
     def _is_matchable(self, node: Node) -> bool:

--- a/torch/ao/ns/fx/graph_passes.py
+++ b/torch/ao/ns/fx/graph_passes.py
@@ -424,7 +424,7 @@ def _can_insert_copy_of_subgraph_a(
                     return False
             cur_idx += 1
 
-        for kwarg_name, kwarg_val in norm_kwargs.items():
+        for _kwarg_name, kwarg_val in norm_kwargs.items():
             # stitch the inputs from base graph
             if cur_idx == 0:
                 pass
@@ -780,7 +780,7 @@ def create_a_shadows_b(
                         # is added
                         prev_node_c_list = [env_c[arg.name] for arg in prev_node_b]
 
-                        for arg_idx, arg in enumerate(prev_node_b):
+                        for arg_idx, _arg in enumerate(prev_node_b):
                             prev_node_c = prev_node_c_list[arg_idx]
                             env_c[prev_node_c.name] = _insert_logger_after_node(
                                 prev_node_c, gm_b, logger_cls, '_ns_logger_b_inp_',

--- a/torch/ao/ns/fx/mappings.py
+++ b/torch/ao/ns/fx/mappings.py
@@ -455,7 +455,7 @@ def add_op_to_sets_of_related_ops(
     related_op: Optional[NSNodeTargetType],
 ) -> None:
     if related_op is not None:
-        for base_name, set_of_related_ops in base_name_to_sets_of_related_ops.items():
+        for _base_name, set_of_related_ops in base_name_to_sets_of_related_ops.items():
             if related_op in set_of_related_ops:
                 set_of_related_ops.add(op)
                 return

--- a/torch/ao/ns/fx/n_shadows_utils.py
+++ b/torch/ao/ns/fx/n_shadows_utils.py
@@ -704,7 +704,7 @@ def create_add_loggers_graph(
     from torch.ao.ns._numeric_suite_fx import OutputLogger, OutputComparisonLogger
 
     def _get_subgraph_containing_node(node, subgraphs_dedup):
-        for name, subgraph in subgraphs_dedup.items():
+        for _name, subgraph in subgraphs_dedup.items():
             if node in subgraph:
                 return subgraph
         return None
@@ -1289,7 +1289,7 @@ def print_n_shadows_summary(
         return
 
     results = []
-    for subgraph_name, subgraph_data in results_comparison.items():
+    for _subgraph_name, subgraph_data in results_comparison.items():
         mean_all_candidates = [
             candidate['cmp_mean']
             for candidate_name, candidate in subgraph_data['candidates'].items()

--- a/torch/ao/ns/fx/pattern_utils.py
+++ b/torch/ao/ns/fx/pattern_utils.py
@@ -26,7 +26,7 @@ def get_type_a_related_to_b(
     # TODO(future PR): add the rest of modules and ops here
     type_a_related_to_b: Set[Tuple[NSNodeTargetType, NSNodeTargetType]] = set()
 
-    for base_name, s in base_name_to_sets_of_related_ops.items():
+    for _base_name, s in base_name_to_sets_of_related_ops.items():
         s_list = list(s)
         # add every bidirectional pair
         for idx_0 in range(0, len(s_list)):

--- a/torch/ao/ns/fx/utils.py
+++ b/torch/ao/ns/fx/utils.py
@@ -389,8 +389,8 @@ def maybe_add_missing_fqns(results: NSResultsType) -> None:
 
     # Check in the first result to find any model with fqn entries defined.
     model_name_with_fqns = None
-    for layer_name, result_type_to_results in results.items():
-        for result_type, model_name_to_results in result_type_to_results.items():
+    for _layer_name, result_type_to_results in results.items():
+        for _result_type, model_name_to_results in result_type_to_results.items():
             for model_name, model_results in model_name_to_results.items():
                 if len(model_results) > 0:
                     if model_results[0]["fqn"] is not None:
@@ -400,8 +400,8 @@ def maybe_add_missing_fqns(results: NSResultsType) -> None:
         break
 
     if model_name_with_fqns:
-        for layer_name, result_type_to_results in results.items():
-            for result_type, model_name_to_results in result_type_to_results.items():
+        for _layer_name, result_type_to_results in results.items():
+            for _result_type, model_name_to_results in result_type_to_results.items():
                 ref_model_results = model_name_to_results[model_name_with_fqns]
                 for model_name, model_results in model_name_to_results.items():
                     if model_name == model_name_with_fqns:

--- a/torch/ao/pruning/sparsifier/base_sparsifier.py
+++ b/torch/ao/pruning/sparsifier/base_sparsifier.py
@@ -139,7 +139,7 @@ class BaseSparsifier(abc.ABC):
         stack = [model]
         while stack:
             module = stack.pop()
-            for name, child in module.named_children():
+            for _name, child in module.named_children():
                 if type(child) in SUPPORTED_MODULES:
                     module_fqn = module_to_fqn(model, child)
                     assert isinstance(module_fqn, str)  # for mypy

--- a/torch/ao/quantization/_correct_bias.py
+++ b/torch/ao/quantization/_correct_bias.py
@@ -131,6 +131,6 @@ def bias_correction(float_model, quantized_model, img_data, target_modules=_supp
             bias.data = updated_bias
 
             # Resets the data contained in the loggers
-            for name, submodule in quantized_model.named_modules():
+            for _name, submodule in quantized_model.named_modules():
                 if isinstance(submodule, MeanShadowLogger):
                     submodule.clear()

--- a/torch/ao/quantization/experimental/apot_utils.py
+++ b/torch/ao/quantization/experimental/apot_utils.py
@@ -40,7 +40,7 @@ def quant_dequant_util(x, levels, indices):
     min_delta = math.inf
     best_fp = 0.0
 
-    for level, idx in zip(levels_lst, indices_lst):
+    for level, _idx in zip(levels_lst, indices_lst):
         cur_delta = abs(level - x)
         if cur_delta < min_delta:
             min_delta = cur_delta

--- a/torch/ao/quantization/fx/_model_report/model_report.py
+++ b/torch/ao/quantization/fx/_model_report/model_report.py
@@ -395,7 +395,7 @@ class ModelReport:
         features_by_module: OrderedDict[str, Dict] = OrderedDict()
 
         # we loop through modules in graph in order
-        for fqn, module in self._model.named_modules():
+        for fqn, _module in self._model.named_modules():
             # find that fqn in fqns_to_features
             if fqn in module_fqns_to_features:
                 # add it to our ordered dict

--- a/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
+++ b/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
@@ -252,7 +252,7 @@ class ModelReportVisualizer:
 
         if len(channel_features) > 0:
             # now we add all channel data
-            for index, module_fqn in enumerate(filtered_data):
+            for _index, module_fqn in enumerate(filtered_data):
                 # we iterate over all channels
                 for channel in range(num_channels):
                     # we make a new row for the channel
@@ -498,7 +498,7 @@ class ModelReportVisualizer:
             # gather the x_data and multiple y_data
             # calculate the number of channels
             num_channels: int = max(row[self.CHANNEL_NUM_INDEX] for row in table) + 1
-            for channel in range(num_channels):
+            for _channel in range(num_channels):
                 y_data.append([])  # separate data list per channel
 
             for table_row_num, row in enumerate(table):
@@ -644,7 +644,7 @@ class ModelReportVisualizer:
             # set the legend as well
             # combine all the data
             all_data = []
-            for index, channel_info in enumerate(y_data):
+            for _index, channel_info in enumerate(y_data):
                 all_data.extend(channel_info)
 
             val, bins, _ = plt.hist(

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -234,7 +234,7 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
         with graph.inserting_before(node):
             input_node = node.args[0]
             choose_qparams_op_inputs = [node.args[0]]
-            for key, value in qparams.items():
+            for _key, value in qparams.items():
                 # we have quant_min, quant_max and dtype, all should be stored
                 # as literals
                 choose_qparams_op_inputs.append(value)
@@ -401,7 +401,7 @@ def _replace_observer_with_quantize_dequantize_node(
         with graph.inserting_before(node):
             input_node = node.args[0]
             quantize_op_inputs = [input_node]
-            for key, value in qparams.items():
+            for _key, value in qparams.items():
                 quantize_op_inputs.append(value)
 
             quantized_node = graph.create_node(node_type, quantize_op, tuple(quantize_op_inputs), {})
@@ -415,7 +415,7 @@ def _replace_observer_with_quantize_dequantize_node(
         with graph.inserting_before(node):
             input_node = node.args[0]
             quantize_op_inputs = [input_node]
-            for key, value in qparams.items():
+            for value in qparams.values():
                 # TODO: we can add the information of whether a value needs to
                 # be registered as an attribute in qparams dict itself
                 quantize_op_inputs.append(value)

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -1166,7 +1166,7 @@ def insert_observers_for_model(
     # Step 1, set the observer or fake quantize module constructor for each node in the
     # matched_node_pattern
 
-    for node_name, match_res_with_qconfig in node_name_to_match_result_with_qconfig.items():
+    for _node_name, match_res_with_qconfig in node_name_to_match_result_with_qconfig.items():
         last_node, matched_node_pattern, pattern, qhandler, qconfig = match_res_with_qconfig
         assert qhandler is not None
         _set_target_dtype_info_for_matched_node_pattern(
@@ -1214,7 +1214,7 @@ def insert_observers_for_model(
 
     # reset the counters and set of processed_nodes
     processed_nodes = set()
-    for node_name, match_res_with_qconfig in node_name_to_match_result_with_qconfig.items():
+    for _node_name, match_res_with_qconfig in node_name_to_match_result_with_qconfig.items():
         last_node, matched_node_pattern, pattern, qhandler, qconfig = match_res_with_qconfig
         is_supported_by_backend = _is_pattern_dtype_config_and_qconfig_supported_by_backend(
             pattern, matched_node_pattern, qconfig, backend_config)
@@ -1443,8 +1443,8 @@ def _run_prepare_fx_on_standalone_modules(
     their observed versions.
     """
     for (
-        node_name,
-        (root_node, _, pattern, qhandler, qconfig),
+        _node_name,
+        (root_node, _, _pattern, qhandler, qconfig),
     ) in node_name_to_match_result_with_qconfig.items():
         if qhandler is None:
             continue

--- a/torch/ao/quantization/fx/qconfig_mapping_utils.py
+++ b/torch/ao/quantization/fx/qconfig_mapping_utils.py
@@ -217,7 +217,7 @@ def _compare_prepare_convert_qconfig_mappings(
     ]
     dict_names = [_OBJECT_TYPE_DICT_KEY, _MODULE_NAME_DICT_KEY, _MODULE_NAME_REGEX_DICT_KEY]
     for i in range(len(prepare_dicts)):
-        for name, qconfig in prepare_dicts[i].items():
+        for name, _qconfig in prepare_dicts[i].items():
             assert name in convert_dicts[i], "Missing key {} {} in convert QConfigMapping \
                 when it was present in prepare".format(dict_names[i], name)
             assert convert_dicts[i][name] is None \

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -998,7 +998,7 @@ def _test_undefined_forward_mode(func, outputs, inputs):
                 tensor_indices.add(i)
             dual_inputs.append(inp)
 
-        for i, (fw_grad, u) in enumerate(zip(fw_grads, all_u)):
+        for _i, (fw_grad, u) in enumerate(zip(fw_grads, all_u)):
             fw_grad.copy_(u.view_as(fw_grad))
 
         for idx, inp in enumerate(inputs):

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -220,7 +220,7 @@ def _get_numerical_jacobian(fn, inputs, outputs=None, target=None, eps=1e-3,
     if target is None:
         target = inputs
     inp_indices = [i for i, a in enumerate(target) if is_tensor_like(a) and a.requires_grad]
-    for i, (inp, inp_idx) in enumerate(zip(_iter_tensors(target, True), inp_indices)):
+    for _i, (inp, inp_idx) in enumerate(zip(_iter_tensors(target, True), inp_indices)):
         jacobians += [get_numerical_jacobian_wrt_specific_input(fn, inp_idx, inputs, outputs, eps,
                                                                 input=inp, is_forward_ad=is_forward_ad)]
     return jacobians
@@ -415,7 +415,7 @@ def _get_analytical_jacobian_forward_ad(fn, inputs, outputs, *, check_grad_dtype
     with fwAD.dual_level():
         fw_grads = []
         dual_inputs = []
-        for i, inp in enumerate(inputs):
+        for _i, inp in enumerate(inputs):
             if is_tensor_like(inp) and inp.requires_grad:
                 if inp.layout == torch._mkldnn:  # type: ignore[attr-defined]
                     raise ValueError("MKLDNN inputs are not support for forward AD gradcheck.")
@@ -529,7 +529,7 @@ def _get_numerical_jvp_wrt_specific_input(fn, input_idx, inputs, u, eps, is_forw
 def _get_numerical_vJu(fn, inputs, inp_indices, func_out, all_u, all_v, eps, is_forward_ad):
     # Note that all_v can also be None, in that case, this function only computes Ju.
     reduced_jacobians: List[List[torch.Tensor]] = []
-    for i, (inp_idx, u) in enumerate(zip(inp_indices, all_u)):
+    for _i, (inp_idx, u) in enumerate(zip(inp_indices, all_u)):
         all_Ju = _get_numerical_jvp_wrt_specific_input(fn, inp_idx, inputs, u, eps, is_forward_ad)
         # Filter out the Ju for non floating point outputs
         filtered_Ju = []
@@ -1054,7 +1054,7 @@ def _test_undefined_backward_mode(func, outputs, inputs) -> bool:
                 'Please look at "Notes about undefined output gradients" in '
                 '"tools/autograd/derivatives.yaml"')) from e
 
-        for gi, i in zip(grads_input, diff_input_list):
+        for gi, _i in zip(grads_input, diff_input_list):
             if (gi is not None) and (not gi.eq(0).all()):
                 warn_bc_breaking()
                 raise GradcheckError((

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -92,7 +92,7 @@ class EventList(list):
         #
         # Algorithm has O(N * log(N)) complexity where N is number of
         # intervals
-        for thread_id, thread_events in threads:
+        for _thread_id, thread_events in threads:
             thread_events_ = sorted(
                 thread_events,
                 key=lambda event: [event.time_range.start, -event.time_range.end],
@@ -222,7 +222,7 @@ class EventList(list):
                         else f'" node_id:{evt.node_id}, thread_id:{evt.thread} "',
                     )
                 )
-                for k in evt.kernels:
+                for _k in evt.kernels:
                     # 's' and 'f' draw Flow arrows from
                     # the CPU launch to the GPU kernel
                     f.write('{"name": "%s", '

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -675,7 +675,7 @@ def main(args):
 
     launcher = _Launcher()
     launcher.launch(args)
-    for x in sorted(set(os.environ.keys()) - env_before):
+    for _x in sorted(set(os.environ.keys()) - env_before):
         logger.debug("{x}={os.environ[x]}")
 
 if __name__ == "__main__":

--- a/torch/cuda/_memory_viz.py
+++ b/torch/cuda/_memory_viz.py
@@ -480,7 +480,7 @@ def trace_plot(data, device=None, plot_segments=False):
                   *_frames_fmt(frames, full_filename=True)]
         return w.add_element(size, frames)
 
-    for i, e in enumerate(trace):
+    for _i, e in enumerate(trace):
         if e['action'] == alloc:
             elemid = add_element(e['addr'], e['size'], e.get('frames', []))
             addr_to_alloc[e['addr']] = elemid
@@ -557,7 +557,7 @@ def profile_plot(profile, device=None):
                              category)
 
     kv_to_elem = {}
-    for time, action, (tensor_key, version), size in memory_profile.timeline:
+    for _time, action, (tensor_key, version), size in memory_profile.timeline:
         if tensor_key.device != device:
             continue
         if action == Action.CREATE:

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -320,7 +320,7 @@ def make_graphed_callables(callables, sample_args, num_warmup_iters=3, allow_unu
     # Capture backward graphs in reverse order
     per_callable_static_grad_outputs = []
     per_callable_static_grad_inputs = []
-    for static_input_surface, static_outputs, bwd_graph, module_params in \
+    for static_input_surface, static_outputs, bwd_graph, _module_params in \
             zip(reversed(per_callable_static_input_surfaces),
                 reversed(per_callable_static_outputs),
                 reversed(bwd_graphs),

--- a/torch/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/distributed/_shard/sharded_tensor/__init__.py
@@ -409,7 +409,7 @@ def pre_load_state_dict_hook(module, state_dict, prefix, local_metadata, strict,
     Pre-load state dict hook to add ShardedTensor to the module.
     """
     for submodule_name, submodule in module.named_modules():
-        for attr_name, attr in submodule.__dict__.items():
+        for attr_name, _attr in submodule.__dict__.items():
             mod_prefix = prefix + submodule_name
             key = mod_prefix + ('.' if mod_prefix else '') + attr_name
             if key in state_dict:

--- a/torch/distributed/_shard/sharded_tensor/utils.py
+++ b/torch/distributed/_shard/sharded_tensor/utils.py
@@ -109,7 +109,7 @@ def build_metadata_from_local_shards(
     first_shard_is_pinned = local_shards[0].tensor.is_pinned()
 
     # 1). Validate local tensors and associated metadatas
-    for i, local_shard in enumerate(local_shards):
+    for _i, local_shard in enumerate(local_shards):
         local_shard_tensor = local_shard.tensor
         local_shard_meta = local_shard.metadata
         local_shard_metadatas.append(local_shard_meta)

--- a/torch/distributed/_spmd/iter_graph_module.py
+++ b/torch/distributed/_spmd/iter_graph_module.py
@@ -482,7 +482,7 @@ class IterGraph(fx.Graph):
                 self.node_add_user(step_node, optim_node)
 
     def defunctionalize_optim(self) -> None:
-        for i, node in enumerate(reversed(self.nodes)):
+        for _i, node in enumerate(reversed(self.nodes)):
             if node.name.startswith("output"):
                 output_node = node
             elif node.name.startswith(

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -518,7 +518,7 @@ def distribute_module(
     if partition_fn is None:
         # if partition_fn not specified, we by default replicate
         # all module params/buffers
-        for name, submod in module.named_modules():
+        for _name, submod in module.named_modules():
             replicate_module_params_buffers(submod, device_mesh)
     else:
         # apply partition_fun to submodules

--- a/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py
@@ -45,7 +45,7 @@ def _reducer_allreduce_and_upcast_hook(
 
         # Upcast parameters and gradients so optimizer step can run in fp32.
         params, grads = bucket.parameters(), bucket.gradients()
-        for p, g in zip(params, grads):
+        for p, _g in zip(params, grads):
             p.data = p._fp_param
             # free storage for mp param as it will be allocated again in next
             # forward pass.
@@ -61,7 +61,7 @@ def _reducer_allreduce_and_upcast_hook(
         # they may participate in computation. However, they would not be recast
         # by hook above as they don't have a grad hook installed, so cast them
         # back here.
-        for n, p in ddp_weakref().module.named_parameters():
+        for _n, p in ddp_weakref().module.named_parameters():
             if hasattr(p, '_ddp_mp_hook_state'):
                 p._ddp_mp_hook_state[1].remove()
                 delattr(p, '_ddp_mp_hook_state')

--- a/torch/distributed/benchmarks/benchmark_ddp_rpc.py
+++ b/torch/distributed/benchmarks/benchmark_ddp_rpc.py
@@ -82,7 +82,7 @@ def _retrieve_embedding_parameters(emb_rref):
 def _print_header():
     _print_cont("\n")
     _print_cont("%10s" % "")
-    for p in [50, 75, 90, 95]:
+    for _p in [50, 75, 90, 95]:
         _print_cont("%14s%10s" % ("sec/epoch", "epoch/sec"))
     _print_cont("\n")
 
@@ -168,7 +168,7 @@ def _run_trainer(emb_rref_list, rank):
 
     measurements = []
     # Include warm-up cycles during training
-    for epoch in range(100 + WARMUP_CYCLES):
+    for _epoch in range(100 + WARMUP_CYCLES):
         start = time.time()
         batch_size = 0
 

--- a/torch/distributed/checkpoint/planner_helpers.py
+++ b/torch/distributed/checkpoint/planner_helpers.py
@@ -172,7 +172,7 @@ def create_read_items_for_chunk_list(
             dest_offsets = []
             lengths = []
             for (
-                dim,
+                _dim,
                 offset_for_saved_tensor,
                 offset_for_current_tensor,
                 length,

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -778,7 +778,7 @@ class FlatParamHandle:
         sharded_flat_param_numel = unsharded_end_idx - unsharded_start_idx + 1
         # `unsharded_param_start_idx` and `unsharded_param_end_idx` are indices
         # into the unsharded flat parameter (inclusive) of the given parameter
-        for i, (
+        for _i, (
             (unsharded_param_start_idx, unsharded_param_end_idx),
             is_padding,
         ) in enumerate(zip(flat_param_offsets, self.flat_param._is_padding_mask)):
@@ -1764,7 +1764,7 @@ class FlatParamHandle:
                 numel_in_shard = shard_param_info.numel_in_shard
                 param.data = flat_param[offset : offset + numel_in_shard]
         assert self.flat_param._shared_params is not None
-        for i, (
+        for _i, (
             param,
             (param_name, module, _, prim_param_name, prim_module, _),
         ) in enumerate(
@@ -1828,7 +1828,7 @@ class FlatParamHandle:
                 else:
                     param.grad = None
         assert flat_param._shared_params is not None
-        for i, (param, (_, _, _, prim_param_name, prim_module, _)) in enumerate(
+        for _i, (param, (_, _, _, prim_param_name, prim_module, _)) in enumerate(
             zip(flat_param._shared_params, flat_param._shared_param_infos)
         ):
             in_sharded_flat_param = hasattr(prim_module, prim_param_name)

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1684,7 +1684,7 @@ class FlatParamHandle:
                 param.grad.data = view
             else:
                 param.grad = view
-        for i, (
+        for _i, (
             param_name,
             module,
             module_name,

--- a/torch/distributed/pipeline/sync/pipe.py
+++ b/torch/distributed/pipeline/sync/pipe.py
@@ -194,7 +194,7 @@ def _split_module(modules: nn.Sequential) -> Tuple[List[nn.Sequential], List[tor
 
     current_partition = []
     current_device = None
-    for name, module in modules.named_children():
+    for _name, module in modules.named_children():
         if isinstance(module, WithDevice):
             # Process device override and move module to appropriate device.
             device = module.device

--- a/torch/distributed/pipeline/sync/utils.py
+++ b/torch/distributed/pipeline/sync/utils.py
@@ -26,7 +26,7 @@ def partition_model(
     balanced_pipe = []
     for num_layers in balance:
         layers = []
-        for i in range(num_layers):
+        for _i in range(num_layers):
             layers.append(module[pipe_idx])
             pipe_idx += 1
         device = device_idx if devices is None else devices[device_idx]

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -57,11 +57,11 @@ def broadcast_types(t1, t2):
         # We make the types the same length which is the first requirement
         # for consistency
         if s1 > s2:
-            for i in range(s1 - s2):
+            for _i in range(s1 - s2):
                 new_t2.insert(0, 1)
 
         elif s2 > s1:
-            for i in range(s2 - s1):
+            for _i in range(s2 - s1):
                 new_t1.insert(0, 1)
 
         # we replace occurrences of "1" with each tensor with

--- a/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
@@ -251,7 +251,7 @@ def generate_binconstraint_t(constraint, counter):
         disj = [BinConstraintT(constraint.lhs, Dyn, op_eq)]
         for i in range(1, constraint.rhs + 1):
             dims = []
-            for j in range(1, i + 1):
+            for _j in range(1, i + 1):
                 dim_var, counter = gen_dvar(counter)
                 dims.append(dim_var)
             disj.append(BinConstraintT(constraint.lhs, TensorType(dims), op_eq))

--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -235,7 +235,7 @@ if HAS_PYDOT:
                 return result
             elif isinstance(tm, dict):
                 result = ""
-                for k, v in tm.items():
+                for _k, v in tm.items():
                     result += self._tensor_meta_to_label(v)
                 return result
             elif isinstance(tm, tuple):

--- a/torch/fx/passes/graph_manipulation.py
+++ b/torch/fx/passes/graph_manipulation.py
@@ -91,7 +91,7 @@ def get_size_of_node(fx_module: GraphModule, node: Node) -> size_bytes:
         submodule = submodule_dict[node.target]
         parameters = submodule.named_parameters()
         # Parameters are named tuples
-        for name, p in parameters:
+        for _name, p in parameters:
             total_num_of_elems += p.numel()
     # Don't forget the output size
     # node.shape is the shape of this node's output

--- a/torch/fx/passes/reinplace.py
+++ b/torch/fx/passes/reinplace.py
@@ -486,7 +486,7 @@ def reinplace(gm, *sample_args):
 
     # inplace-ify functional ops, subject to the constraints written below.
     all_later_view_inverse_nodes_to_delete = set()
-    for idx, node in enumerate(gm.graph.nodes):
+    for _idx, node in enumerate(gm.graph.nodes):
         if node.op == 'call_function':
 
             # Today, the re-inplace pass on directly acts on:

--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -865,7 +865,7 @@ class _SplitterBase:
     def generate_split_results(self) -> SplitResult:
         split_module = self()
         submodule_names = []
-        for name, mod in split_module.named_children():
+        for name, _mod in split_module.named_children():
             submodule_names.append(name)
         submodule_inputs = generate_inputs_for_submodules(split_module, self.sample_input, submodule_names)
         return SplitResult(split_module, submodule_inputs, self.non_acc_submodule_name)

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -499,7 +499,7 @@ def create_script_module_impl(nn_module, concrete_type, stubs_fn):
     def init_fn(script_module):
         # Initialize the ScriptModule:
         # 1. Copy the attributes/parameters/buffers from the original `nn_module` to the new ScriptModule.
-        for name, (attr_type, is_param) in concrete_type.get_attributes().items():
+        for name, (_attr_type, _is_param) in concrete_type.get_attributes().items():
             orig_value = getattr(nn_module, name)
             orig_value = orig_value.value if isinstance(orig_value, torch.jit.Attribute) else orig_value
             cpp_module.setattr(name, orig_value)

--- a/torch/masked/maskedtensor/core.py
+++ b/torch/masked/maskedtensor/core.py
@@ -83,7 +83,7 @@ def _map_mt_args_kwargs(args, kwargs, map_fn):
     for a in args:
         impl_args.append(_helper(a, map_fn))
     impl_kwargs = {}
-    for k, v in kwargs.items():
+    for k, _v in kwargs.items():
         impl_kwargs[k] = _helper(a, map_fn)
     return impl_args, impl_kwargs
 

--- a/torch/multiprocessing/pool.py
+++ b/torch/multiprocessing/pool.py
@@ -28,7 +28,7 @@ class Pool(multiprocessing.pool.Pool):
         """Bring the number of pool processes up to the specified number,
         for use after reaping workers which have exited.
         """
-        for i in range(self._processes - len(self._pool)):
+        for _i in range(self._processes - len(self._pool)):
             # changed worker -> clean_worker
             args = (self._inqueue, self._outqueue,
                     self._initializer,

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -2078,7 +2078,7 @@ class Module:
             <class 'torch.Tensor'> (20L, 1L, 5L, 5L)
 
         """
-        for name, param in self.named_parameters(recurse=recurse):
+        for _name, param in self.named_parameters(recurse=recurse):
             yield param
 
     def named_parameters(
@@ -2170,7 +2170,7 @@ class Module:
         Yields:
             Module: a child module
         """
-        for name, module in self.named_children():
+        for _name, module in self.named_children():
             yield module
 
     def named_children(self) -> Iterator[Tuple[str, 'Module']]:

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -115,7 +115,7 @@ class SpectralNorm:
 
     @staticmethod
     def apply(module: Module, name: str, n_power_iterations: int, dim: int, eps: float) -> 'SpectralNorm':
-        for k, hook in module._forward_pre_hooks.items():
+        for _k, hook in module._forward_pre_hooks.items():
             if isinstance(hook, SpectralNorm) and hook.name == name:
                 raise RuntimeError("Cannot register two spectral_norm hooks on "
                                    "the same parameter {}".format(name))

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -26,7 +26,7 @@ class WeightNorm:
 
     @staticmethod
     def apply(module, name: str, dim: int) -> 'WeightNorm':
-        for k, hook in module._forward_pre_hooks.items():
+        for _k, hook in module._forward_pre_hooks.items():
             if isinstance(hook, WeightNorm) and hook.name == name:
                 raise RuntimeError("Cannot register two weight_norm hooks on "
                                    "the same parameter {}".format(name))

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -6387,7 +6387,7 @@ def index_add(g: jit_utils.GraphContext, self, dim, index, other, alpha=None):
 
     if other_dim_rank != self_dim_rank:
         delta = self_dim_rank - other_dim_rank
-        for i in range(delta):
+        for _i in range(delta):
             other = symbolic_helper._unsqueeze_helper(
                 g, other, [symbolic_helper._get_tensor_rank(other)]
             )
@@ -6414,10 +6414,10 @@ def index_add(g: jit_utils.GraphContext, self, dim, index, other, alpha=None):
     )
     other = expand_as(g, other, new_shape)
 
-    for i in range(dim):
+    for _i in range(dim):
         index = symbolic_helper._unsqueeze_helper(g, index, [0])
 
-    for i in range(self_dim_rank - dim - 1):
+    for _i in range(self_dim_rank - dim - 1):
         index = symbolic_helper._unsqueeze_helper(
             g, index, [symbolic_helper._get_tensor_rank(index)]
         )

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -666,7 +666,7 @@ class PackageExporter:
             memo: DefaultDict[int, str] = defaultdict(None)
             memo_count = 0
             # pickletools.dis(data_value)
-            for opcode, arg, pos in pickletools.genops(data_value):
+            for opcode, arg, _pos in pickletools.genops(data_value):
                 if pickle_protocol == 4:
                     if (
                         opcode.name == "SHORT_BINUNICODE"
@@ -1001,7 +1001,7 @@ class PackageExporter:
 
     def _validate_dependency_graph(self):
         # 1. Check the graph for any errors inserted during dependency analysis.
-        for module_name, attrs in self.dependency_graph.nodes.items():
+        for _module_name, attrs in self.dependency_graph.nodes.items():
             if "error" in attrs:
                 raise PackagingError(self.dependency_graph, debug=self.debug)
 

--- a/torch/profiler/_memory_profiler.py
+++ b/torch/profiler/_memory_profiler.py
@@ -178,7 +178,7 @@ def _extract_parameters_and_gradients(
 
 
 def extract_parameters(node: _ProfilerEvent) -> Iterator[TensorKey]:
-    for p, p_grad in _extract_parameters_and_gradients(node):
+    for p, _p_grad in _extract_parameters_and_gradients(node):
         if p is not None:
             yield p
 

--- a/torch/quantization/__init__.py
+++ b/torch/quantization/__init__.py
@@ -15,7 +15,7 @@ def default_eval_fn(model, calib_data):
     Default evaluation function takes a torch.utils.data.Dataset or a list of
     input Tensors and run the model on the dataset
     """
-    for data, target in calib_data:
+    for data, _target in calib_data:
         model(data)
 
 __all__ = [

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -906,7 +906,7 @@ def _legacy_load(f, map_location, pickle_module, **pickle_load_args):
             tar.extract('storages', path=tmpdir)
             with open(os.path.join(tmpdir, 'storages'), 'rb', 0) as f:
                 num_storages = pickle_module.load(f, **pickle_load_args)
-                for i in range(num_storages):
+                for _i in range(num_storages):
                     args = pickle_module.load(f, **pickle_load_args)
                     key, location, storage_type = args
                     dtype = storage_type._dtype

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1068,7 +1068,7 @@ class precisionOverride:
 
     def __init__(self, d):
         assert isinstance(d, dict), "precisionOverride not given a dtype : precision dict!"
-        for dtype, prec in d.items():
+        for dtype, _prec in d.items():
             assert isinstance(dtype, torch.dtype), "precisionOverride given unknown dtype {0}".format(dtype)
 
         self.d = d

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -759,7 +759,7 @@ class MultiProcessTestCase(TestCase):
                 self._check_return_codes(elapsed_time)
         finally:
             # Close all pipes
-            for pid, pipe in self.pid_to_pipe.items():
+            for _pid, pipe in self.pid_to_pipe.items():
                 pipe.close()
 
     def _check_no_test_errors(self, elapsed_time) -> None:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -679,7 +679,7 @@ def sample_inputs_jiterator(op, device, dtype, requires_grad, **kwargs):
         lhs = make_arg(shape_lhs)
 
         args = []
-        for i in range(num_inputs - 1):
+        for _i in range(num_inputs - 1):
             args.append(make_arg(shape_rhs))
         broadcasts_input = (shape_lhs != torch.broadcast_shapes(shape_lhs, shape_rhs))
 

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -115,7 +115,7 @@ def test_only_train_fn(model, train_data, loss_fn=_default_loss_fn):
     """
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
     train_loss, correct, total = 0, 0, 0
-    for i in range(10):
+    for _i in range(10):
         model.train()
 
         for data, target in train_data:
@@ -2113,7 +2113,7 @@ class ModelWithSequentialFusion(nn.Module):
         self.conv1 = nn.Conv2d(3, 3, 1)
         self.relu1 = nn.ReLU(inplace=False)
         layers = []
-        for i in range(3):
+        for _i in range(3):
             layers.append(ConvBNReLU())
         self.features = nn.Sequential(*layers)
         head = [nn.Linear(300, 10), nn.ReLU(inplace=False)]

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1608,7 +1608,7 @@ class CudaMemoryLeakCheck():
             discrepancy_detected = True
 
             # Query memory multiple items to ensure leak was not transient
-            for n in range(3):
+            for _n in range(3):
                 caching_allocator_mem_allocated = torch.cuda.memory_allocated(i)
                 bytes_free, bytes_total = torch.cuda.mem_get_info(i)
                 driver_mem_allocated = bytes_total - bytes_free

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4691,7 +4691,7 @@ class DistributedTest:
             # Hook not registered yet, so should be empty
             self.assertEqual(ddp_logging_data.get("comm_hook"), None)
             # After second forward pass, hook should still be empty string
-            for i in range(2):
+            for _i in range(2):
                 inp = torch.ones(1, 1, device=self.rank)
                 loss = ddp_model(inp).sum()
                 loss.backward()
@@ -4792,7 +4792,7 @@ class DistributedTest:
                     )
 
                     # Run optimizer with hook model.
-                    for i in range(6):
+                    for _i in range(6):
                         ddp_model_with_optimizer_hook.zero_grad()
                         out = ddp_model_with_optimizer_hook(inp)
                         loss = out.sum()
@@ -4801,7 +4801,7 @@ class DistributedTest:
                     dist.barrier()
 
                     # Run regular model.
-                    for i in range(6):
+                    for _i in range(6):
                         ddp_model_with_no_hook.zero_grad()
                         out = ddp_model_with_no_hook(inp)
                         loss = out.sum()
@@ -5143,7 +5143,7 @@ class DistributedTest:
                 self.assertEqual(mp_config.param_dtype, p._mp_param.dtype)
                 self.assertEqual(torch.float32, p._fp_param.dtype)
 
-            for i in range(6):
+            for _i in range(6):
                 loss = net(inp).sum()
                 loss.backward()
                 # Verify gradient synchronization and params and grads are fp32.
@@ -6999,7 +6999,7 @@ class DistributedTest:
             profiler_ctx_copy = copy.deepcopy(profiler_ctx)
 
             with profiler_ctx as prof:
-                for i in range(num_iters):
+                for _i in range(num_iters):
                     loss = net(inp).sum()
                     loss.backward()
 
@@ -7027,7 +7027,7 @@ class DistributedTest:
                 device_ids=[self.rank],
                 find_unused_parameters=True,
             )
-            for i in range(3):
+            for _i in range(3):
                 loss = net(inp).sum()
                 loss.backward()
             # Now enable the profiler.
@@ -7103,7 +7103,7 @@ class DistributedTest:
                 model.parameters(), lr=learning_rate * dist.get_world_size()
             )
             with net.join():
-                for i in range(num_iters):
+                for _i in range(num_iters):
                     ddp_optim.zero_grad()
                     out = net(inp)
                     loss = out.sum()
@@ -7273,7 +7273,7 @@ class DistributedTest:
                 n = 0
                 with exception_ctx:
                     with model.join(throw_on_early_termination=True):
-                        for i in range(num_iters):
+                        for _i in range(num_iters):
                             loss = model(model_input).sum()
                             loss.backward()
                             self._model_step(model)
@@ -7695,7 +7695,7 @@ class DistributedTest:
                 local_model = copy.deepcopy(ddp.module).cuda(self.rank)
 
                 inp = torch.ones(1, dtype=torch.float).to(device_id) * (self.rank + 1)
-                for i in range(6):
+                for _i in range(6):
                     ddp(inp).sum().backward()
 
                     local_model(inp).sum().backward()
@@ -7812,7 +7812,7 @@ class DistributedTest:
                     static_graph=static,
                 )
                 inp = torch.randn(20, 10, device=self.rank)
-                for i in range(6):
+                for _i in range(6):
                     loss = ddp_model(inp)
                     # To test https://github.com/pytorch/pytorch/issues/61982
                     loss /= 10
@@ -8649,7 +8649,7 @@ class DistributedTest:
                 static_graph=static_graph,
             )
             random_input = torch.randn(20, 10, device=self.rank)
-            for i in range(10):
+            for _i in range(10):
                 out = ddp_model(random_input)
                 loss = out.sum()
                 loss.backward()
@@ -8985,7 +8985,7 @@ class DistributedTest:
             if ignore_sparse:
                 for module_name, module in model.named_modules():
                     if module == model.sub_module.embedding_net.embedding:
-                        for parameter_name, param in module.named_parameters(
+                        for parameter_name, _param in module.named_parameters(
                             recurse=False
                         ):
                             fqn = f"{module_name}.{parameter_name}"
@@ -9008,7 +9008,7 @@ class DistributedTest:
             fqn_to_param_index = {}
             index = 0
             for module_name, module in model.named_modules():
-                for parameter_name, param in module.named_parameters(recurse=False):
+                for parameter_name, _param in module.named_parameters(recurse=False):
                     fqn = f"{module_name}.{parameter_name}"
                     fqn_to_param_index[fqn] = index
                     if fqn not in sparse_embedding_fqns:
@@ -9144,7 +9144,7 @@ class DistributedTest:
             model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[rank])
             # Test sync occurs in training mode.
             with torch.autograd.profiler.profile() as prof:
-                for i in range(6):
+                for _i in range(6):
                     inp = torch.randn(10, 2, 4, 4).cuda(rank)
                     out = model(inp)
                     loss = out.sum()
@@ -9164,7 +9164,7 @@ class DistributedTest:
             if self.rank == 0:
                 model_inference.eval()
                 with torch.autograd.profiler.profile() as prof:
-                    for i in range(6):
+                    for _i in range(6):
                         inp = torch.randn(10, 2, 4, 4).cuda(rank)
                         out = model_inference(inp)
                         loss = out.sum()
@@ -9271,7 +9271,7 @@ class DistributedTest:
                 "dict": dict,
             }
             for output_type in type_mapping.keys():
-                for i in range(6):
+                for _i in range(6):
                     out = model(inp, output_type=output_type)
                     loss = get_loss(out)
                     loss.backward()
@@ -9320,7 +9320,7 @@ class DistributedTest:
                     find_unused_parameters=find_unused,
                     static_graph=static_graph,
                 )
-                for i in range(6):
+                for _i in range(6):
                     out = ddp(inp)
                     self.assertFalse(out[0].requires_grad)
                     o = (out[0] + out[1]).sum()
@@ -9486,7 +9486,7 @@ class DistributedTest:
                     broadcast_buffers=False,
                 )
                 inp = torch.randn(2, 10, device=rank)
-                for i in range(2):
+                for _i in range(2):
                     loss_hook = model_ddp(inp).sum()
                     # Since buffer reduction is done pre-forward, simulate it for
                     # no hook case here.
@@ -9566,7 +9566,7 @@ class DistributedTest:
                 device_ids=[self.rank],
             )
             inp = torch.randn(2, 10, device=rank)
-            for i in range(2):
+            for _i in range(2):
                 loss_hook = model_ddp(inp).sum()
                 loss_no_hook = model_ddp_no_hook(inp).sum()
                 self._verify_buffers_equal(model_ddp, model_ddp_no_hook)
@@ -9653,7 +9653,7 @@ class DistributedTest:
                 device_ids=[self.rank],
             )
             inp = torch.randn(2, 10, device=rank)
-            for i in range(2):
+            for _i in range(2):
                 if rank == 0:
                     model_ddp.module.buffer = model_ddp.module.buffer + 1
                 loss = model_ddp(inp).sum()

--- a/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_autograd_test.py
@@ -890,7 +890,7 @@ class CommonDistAutogradTest(RpcAgentTestFixture):
             else:
                 loss = loss.sum()
             # Run backward in a loop multiple times.
-            for i in range(1000):
+            for _i in range(1000):
                 dist_autograd.backward(context_id, [loss], retain_graph=True)
 
     # For current context, this rank sends t1 and t2 tensors to dst_rank,
@@ -1279,7 +1279,7 @@ class DistAutogradTest(CommonDistAutogradTest):
         )
 
         context_ids = []
-        for i in range(200):
+        for _i in range(200):
             with dist_autograd.context() as context_id:
                 self.assertEqual(
                     context_id,
@@ -2172,7 +2172,7 @@ class DistAutogradTest(CommonDistAutogradTest):
         if self.rank != 0:
             # All other ranks schedule work on rank 0.
             threads = []
-            for i in range(20):
+            for _i in range(20):
                 t = threading.Thread(target=DistAutogradTest._workload_thread)
                 t.start()
                 threads.append(t)
@@ -2399,7 +2399,7 @@ class DistAutogradTest(CommonDistAutogradTest):
             self.assertTrue(p_a == p_g)
 
             # Run backwards multiple times.
-            for i in range(10):
+            for _i in range(10):
                 dist_autograd.backward(context_id, [loss], retain_graph=True)
 
         # non-contiguous indices and value, we should trigger a copy.
@@ -2418,7 +2418,7 @@ class DistAutogradTest(CommonDistAutogradTest):
             self.assertFalse(p_b == p_g)
 
             # Run backwards multiple times to verify accumulation.
-            for i in range(10):
+            for _i in range(10):
                 dist_autograd.backward(context_id, [loss], retain_graph=True)
 
     @dist_init
@@ -2550,7 +2550,7 @@ class CudaDistAutogradTest(CommonDistAutogradTest):
         t1 = torch.rand(3, 3, requires_grad=True, device="cuda:0")
         t2 = torch.rand(3, 3, requires_grad=True)
         # Run a few iterations.
-        for i in range(3):
+        for _i in range(3):
             t1.grad = None
             t2.grad = None
             # Root is CPU
@@ -2574,7 +2574,7 @@ class CudaDistAutogradTest(CommonDistAutogradTest):
         t1 = torch.rand(3, 3, requires_grad=True, device="cuda:0")
         t2 = torch.rand(3, 3, requires_grad=True)
         # Run a few iterations.
-        for i in range(3):
+        for _i in range(3):
             t1.grad = None
             t2.grad = None
             # Root is CPU

--- a/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py
@@ -108,7 +108,7 @@ class Observer:
             n_steps (int): number of steps in this episode
         """
         state, ep_reward = self.env.reset(), 0
-        for step in range(n_steps):
+        for _step in range(n_steps):
             # send the state to the agent to get an action
             action = _remote_method(Agent.select_action, agent_rref, self.id, state)
 
@@ -220,7 +220,7 @@ class Agent:
 
 
 def run_agent(agent, n_steps):
-    for i_episode in count(1):
+    for _i_episode in count(1):
         agent.run_episode(n_steps=n_steps)
         last_reward = agent.finish_episode()
 

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -264,7 +264,7 @@ def my_complex_tensor_function(list_input, tensor_class_input, dict_input):
     res = list_input[0]
     for t in list_input:
         res += t
-    for k, v in dict_input.items():
+    for _k, v in dict_input.items():
         res += v
     complex_tensors = tensor_class_input.tensors
     return (res, complex_tensors[0], complex_tensors[1], complex_tensors[2])
@@ -1562,7 +1562,7 @@ class RpcTest(RpcAgentTestFixture, RpcTestCommon):
     def test_future_wait_twice(self):
         dst = worker_name((self.rank + 1) % self.world_size)
         futs = []
-        for i in range(20):
+        for _i in range(20):
             futs.append(rpc.rpc_async(dst, raise_func))
 
         with self.assertRaisesRegex(ValueError, "Expected error"):
@@ -2842,7 +2842,7 @@ class RpcTest(RpcAgentTestFixture, RpcTestCommon):
 
         ret_rref = rref_forward_chain(dst_rank, self.world_size, rref, ttl)
 
-        for i in range(ttl):
+        for _i in range(ttl):
             self.assertEqual(len(ret_rref), 1)
             ret_rref = ret_rref[0].to_here()
 

--- a/torch/testing/_internal/hypothesis_utils.py
+++ b/torch/testing/_internal/hypothesis_utils.py
@@ -315,11 +315,11 @@ def tensor_conv(
         spatial_dim = draw(st.sampled_from(spatial_dim))
 
     feature_map_shape = []
-    for i in range(spatial_dim):
+    for _i in range(spatial_dim):
         feature_map_shape.append(draw(st.integers(*feature_map_range)))
 
     kernels = []
-    for i in range(spatial_dim):
+    for _i in range(spatial_dim):
         kernels.append(draw(st.integers(*kernel_range)))
 
     tr = False

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -743,7 +743,7 @@ def attrs_with_prefix(module, prefix):
 def warmup_backward(f, *args):
     profiling_count = 3
     results = []
-    for i in range(profiling_count):
+    for _i in range(profiling_count):
         if len(args) > 0:
             r = torch.autograd.grad(f, *args)
             results.append(r)
@@ -873,7 +873,7 @@ def get_traced_sample_variant_pairs(device, dtype, op):
         return outputs
 
     for sample in samples:
-        for func_type, variant in variants.items():
+        for _func_type, variant in variants.items():
             if variant is None:
                 continue
 

--- a/torch/utils/_freeze.py
+++ b/torch/utils/_freeze.py
@@ -111,7 +111,7 @@ class Freezer:
         # S: skipped (not a package dir)
         # X: skipped (deny-listed)
         # N: skipped (not a python file)
-        for i in range(self.indent):
+        for _i in range(self.indent):
             print("    ", end="")
         print(f"{code} {path}")
 

--- a/torch/utils/benchmark/examples/blas_compare.py
+++ b/torch/utils/benchmark/examples/blas_compare.py
@@ -183,7 +183,7 @@ def main():
         n = len(trials)
         with multiprocessing.dummy.Pool(workers) as pool:
             start_time = time.time()
-            for i, r in enumerate(pool.imap(run_subprocess, trials)):
+            for i, _r in enumerate(pool.imap(run_subprocess, trials)):
                 n_trials_done = i + 1
                 time_per_result = (time.time() - start_time) / n_trials_done
                 eta = int((n - n_trials_done) * time_per_result)

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -323,7 +323,7 @@ class StreamWrapper:
         else:
             # Traverse only simple structures
             if isinstance(v, dict):
-                for kk, vv in v.items():
+                for _kk, vv in v.items():
                     cls.close_streams(vv, depth=depth + 1)
             elif isinstance(v, (list, tuple)):
                 for vv in v:

--- a/torchgen/api/autograd.py
+++ b/torchgen/api/autograd.py
@@ -362,7 +362,7 @@ def gen_foreach_derivativeinfo(
         return None
 
     map_refarg2foreacharg, map_name2arg = {}, {}
-    for i, (arg, ref_arg) in enumerate(
+    for _i, (arg, ref_arg) in enumerate(
         zip(
             foreach_function.func.arguments.flat_non_out,
             function_schema.arguments.flat_non_out,
@@ -373,7 +373,7 @@ def gen_foreach_derivativeinfo(
 
     all_saved_inputs, all_saved_outputs, all_var_names = [], [], []
     modified_derivative_formulas = []
-    for i, derivative in enumerate(ref_diff_info.derivatives):
+    for _i, derivative in enumerate(ref_diff_info.derivatives):
         modified_formula = derivative.formula.replace("grad", "grads[i]").replace(
             "result", "result[i]"
         )

--- a/torchgen/api/unboxing.py
+++ b/torchgen/api/unboxing.py
@@ -114,7 +114,7 @@ def convert_arguments(f: NativeFunction) -> Tuple[List[Binding], List[str]]:
         for i in range(len(args))
     ] + [""]
     binding_list = []
-    for i, arg in enumerate(args):
+    for _i, arg in enumerate(args):
         # expecting only Argument
         if not isinstance(arg.argument, Argument):
             raise Exception(

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -372,7 +372,7 @@ def add_generated_native_functions(
     # First we group of NaitveFunctions by schema kind,
     # then we detect which ones are missing and generate them.
     pre_grouped_native_functions = pre_group_native_functions(rs)
-    for k, d in pre_grouped_native_functions.items():
+    for _k, d in pre_grouped_native_functions.items():
         has_functional = SchemaKind.functional in d
         has_inplace = SchemaKind.inplace in d
         has_mutable = SchemaKind.mutable in d

--- a/torchgen/operator_versions/gen_mobile_upgraders.py
+++ b/torchgen/operator_versions/gen_mobile_upgraders.py
@@ -307,7 +307,7 @@ def get_upgrader_bytecode_function_to_index_map(
     upgrader_bytecode_function_to_index_map = {}
     index = 0
     for upgrader_bytecode in upgrader_dict:
-        for upgrader_name, bytecode in upgrader_bytecode.items():
+        for upgrader_name, _bytecode in upgrader_bytecode.items():
             if upgrader_name in EXCLUE_UPGRADER_SET:
                 continue
             upgrader_bytecode_function_to_index_map[upgrader_name] = index

--- a/torchgen/utils.py
+++ b/torchgen/utils.py
@@ -47,7 +47,7 @@ YamlDumper = Dumper
 class YamlLoader(Loader):
     def construct_mapping(self, node, deep=False):  # type: ignore[no-untyped-def]
         mapping = []
-        for key_node, value_node in node.value:
+        for key_node, _value_node in node.value:
             key = self.construct_object(key_node, deep=deep)  # type: ignore[no-untyped-call]
             assert (
                 key not in mapping


### PR DESCRIPTION
Enable flake8 B007 rule across the codebase with automated fixes from ruff. Requires unused variables in for loops to be proceeded  by an underscore. This makes it easier to identify logical in performance errors.


cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @soumith @voznesenskym @penguinwu @anijain2305 @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @peterbell10 @desertfire