### PR TITLE
fix compiler version detection on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ if(APPLE)
 
   # Get clang version on macOS
   execute_process( COMMAND ${CMAKE_CXX_COMPILER} --version OUTPUT_VARIABLE clang_full_version_string )
-  string(REGEX REPLACE "Apple LLVM version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION_STRING ${clang_full_version_string})
+  string(REGEX REPLACE "Apple (.*) version ([0-9]+\\.[0-9]+).*" "\\2" CLANG_VERSION_STRING ${clang_full_version_string})
   message( STATUS "CLANG_VERSION_STRING:         " ${CLANG_VERSION_STRING} )
 
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43c1df6</samp>

Fix build error on macOS with Xcode 12 or newer by updating clang version detection in `CMakeLists.txt`.

Fixes https://github.com/pytorch/pytorch/issues/97882
