### PR TITLE
[BE] Pass `-faligned-new` if supported by compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -866,11 +866,8 @@ if(NOT MSVC)
     append_cxx_flag_if_supported("-fdiagnostics-color=always" CMAKE_CXX_FLAGS)
   endif()
 
-  if((APPLE AND (NOT ("${CLANG_VERSION_STRING}" VERSION_LESS "9.0")))
-    OR(CMAKE_COMPILER_IS_GNUCXX
-    AND(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 AND NOT APPLE)))
-    string(APPEND CMAKE_CXX_FLAGS " -faligned-new")
-  endif()
+  append_cxx_flag_if_supported("-faligned-new" CMAKE_CXX_FLAGS)
+  
   if(WERROR)
     append_cxx_flag_if_supported("-Werror" CMAKE_CXX_FLAGS)
     if(NOT COMPILER_SUPPORT_WERROR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -867,7 +867,7 @@ if(NOT MSVC)
   endif()
 
   append_cxx_flag_if_supported("-faligned-new" CMAKE_CXX_FLAGS)
-  
+
   if(WERROR)
     append_cxx_flag_if_supported("-Werror" CMAKE_CXX_FLAGS)
     if(NOT COMPILER_SUPPORT_WERROR)


### PR DESCRIPTION
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 507f7a2</samp>

> _`-faligned-new` flag_
> _always on for C++17_
> _simpler winter code_