### PR TITLE
[dtensor] remove DeviceMesh typing hack guard type imports

### DIFF
--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -1,5 +1,4 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-import numpy.typing as npt
 import warnings
 from typing import List, Optional, Union
 
@@ -27,6 +26,13 @@ from torch.distributed.distributed_c10d import (
 
 import torch.distributed.distributed_c10d as c10d
 import torch.distributed._functional_collectives as funcol
+
+try:
+    from numpy.typing import ArrayLike
+    NDArrayType = ArrayLike
+except ImportError:
+    NDArrayType = "ArrayLike"
+
 
 _global_device_mesh: Optional["DeviceMesh"] = None
 
@@ -93,7 +99,7 @@ class DeviceMesh(object):
     def __init__(
         self,
         device_type: str,
-        mesh: Union[torch.Tensor, npt.ArrayLike],
+        mesh: Union[torch.Tensor, NDArrayType],
         *,
         _init_process_groups: bool = True,
     ) -> None:

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import warnings
-from typing import List, Optional, Union
+from typing import List, Optional, Union, TYPE_CHECKING
 
 import torch
 from torch.distributed.distributed_c10d import (
@@ -27,11 +27,13 @@ from torch.distributed.distributed_c10d import (
 import torch.distributed.distributed_c10d as c10d
 import torch.distributed._functional_collectives as funcol
 
-try:
-    from numpy.typing import ArrayLike
-    NDArrayType = ArrayLike
-except ImportError:
-    NDArrayType = "ArrayLike"
+# only import numpy when type checking
+if TYPE_CHECKING:
+    try:
+        from numpy.typing import ArrayLike
+        NDArrayType = ArrayLike
+    except ImportError:
+        NDArrayType = "ArrayLike"
 
 
 _global_device_mesh: Optional["DeviceMesh"] = None

--- a/torch/distributed/_tensor/device_mesh.py
+++ b/torch/distributed/_tensor/device_mesh.py
@@ -31,9 +31,8 @@ import torch.distributed._functional_collectives as funcol
 if TYPE_CHECKING:
     try:
         from numpy.typing import ArrayLike
-        NDArrayType = ArrayLike
     except ImportError:
-        NDArrayType = "ArrayLike"
+        warnings.warn("DeviceMesh requires numpy >= 1.21 to be installed for type checking")
 
 
 _global_device_mesh: Optional["DeviceMesh"] = None
@@ -101,7 +100,7 @@ class DeviceMesh(object):
     def __init__(
         self,
         device_type: str,
-        mesh: Union[torch.Tensor, NDArrayType],
+        mesh: Union[torch.Tensor, "ArrayLike"],
         *,
         _init_process_groups: bool = True,
     ) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #97889

This PR relands https://github.com/pytorch/pytorch/pull/94526
and tries to guard the type import for older version numpy