### PR TITLE
NT: Refactor for lazy computation of opt_sizes

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -173,7 +173,7 @@ NestedTensorImpl::NestedTensorImpl(
       nested_sizes_(std::move(nested_sizes)),
       nested_strides_(std::move(nested_strides)),
       storage_offsets_(std::move(storage_offsets)),
-      opt_sizes_(construct_opt_sizes(nested_sizes_)) {
+      opt_sizes_(c10::nullopt) {
   C10_LOG_API_USAGE_ONCE("torch.NestedTensor");
   TORCH_WARN_ONCE(
       "The PyTorch API of nested tensors is in prototype stage and will change "
@@ -230,10 +230,23 @@ NestedTensorImpl::NestedTensorImpl(
       nested_sizes_(std::move(nested_sizes)),
       nested_strides_(std::move(nested_strides)),
       storage_offsets_(std::move(storage_offsets)),
-      opt_sizes_(construct_opt_sizes(nested_sizes_)) {
+      opt_sizes_(c10::nullopt) {
   validate_nested_tensor_metadata(nested_sizes_, nested_strides_, storage_offsets_);
   refresh_dim();
   set_custom_sizes_strides(c10::TensorImpl::SizesStridesPolicy::CustomSizes);
+}
+
+c10::optional<int64_t> NestedTensorImpl::opt_size(int64_t d) const {
+  if (C10_UNLIKELY(!opt_sizes_.has_value())) {
+    // Maintain const-ness for this method even though we're technically mutating.
+    *(const_cast<c10::optional<std::vector<int64_t>>*>(&opt_sizes_)) = c10::make_optional(
+        construct_opt_sizes(nested_sizes_));
+  }
+  d = at::maybe_wrap_dim(d, dim(), false);
+  if ((*opt_sizes_)[d] == -1) {
+    return c10::nullopt;
+  }
+  return (*opt_sizes_)[d];
 }
 
 void NestedTensorImpl::refresh_dim() {

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -57,13 +57,7 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   // Returns nullopt if the ith dimension is irregular. The ith dimension
   // of a NestedTensor is regular if the unbound tensors match in
   // size at the (i-1)th dimension.
-  c10::optional<int64_t> opt_size(int64_t d) const {
-    d = at::maybe_wrap_dim(d, dim(), false);
-    if (opt_sizes_[d] == -1) {
-      return c10::nullopt;
-    }
-    return opt_sizes_[d];
-  }
+  c10::optional<int64_t> opt_size(int64_t d) const;
 
   int64_t size(int64_t d) const {
     c10::optional<int64_t> optional_size = this->opt_size(d);
@@ -167,9 +161,10 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   //    && nesting in ascending order
   const at::Tensor storage_offsets_;
   // NOTE: -1 here means the size is missing
+  // Optional to allow it to be computed lazily from nested
   // TODO: maybe we can remove this metadata since
   //       we can compute it from `nested_sizes_`
-  std::vector<int64_t> opt_sizes_;
+  c10::optional<std::vector<int64_t>> opt_sizes_;
 
   template <typename VariableVersion>
   c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach_core(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #96354
* __->__ #97895
* #97896

This PR changes the `opt_sizes_` metadata to be computed lazily if needed rather than at construction. Since this metadata is data-dependent, we can't calculate it if we have symbolic metadata (i.e. for dynamic shapes). Notes:
* `opt_size()` is the only public accessor of `opt_sizes_`; several kernels use it. During the first call to this, the metadata is computed.
* `size()` / `sym_size()` use `opt_size()`. For the symbolic case, this will have to change.