### PR TITLE
Stop recursion on trivial replacement

### DIFF
--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -115,7 +115,7 @@ class TestSubgraphRewriter(JitTestCase):
 
         ref_output = comparison_fn(x)
         test_output = traced.forward(x)
-        one_replacement = len(matches) == 1 and len(matches[0].replacements) == 1
+        one_replacement = len(matches) == 1 and len(matches[0].replacements) == 0
         self.assertEqual(ref_output, test_output)
         self.assertTrue(one_replacement)
 

--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -89,6 +89,36 @@ class TestSubgraphRewriter(JitTestCase):
         test_output = traced.forward(x)
         self.assertEqual(ref_output, test_output)
 
+    def test_subgraph_rewriter_with_trivial_replacement(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                val = torch.neg(x)
+                return torch.add(val, val)
+
+        def pattern(x):
+            return torch.add(x, x)
+
+        def replacement(x):
+            return x
+
+        def comparison(x):
+            return torch.neg(x)
+
+        traced = symbolic_trace(M())
+        comparison_fn = symbolic_trace(comparison)
+
+        x = torch.randn(1, 5)
+
+        matches = subgraph_rewriter.replace_pattern_with_filters(traced, pattern, replacement, [])
+
+        traced.graph.lint()
+
+        ref_output = comparison_fn(x)
+        test_output = traced.forward(x)
+        one_replacement = len(matches) == 1 and len(matches[0].replacements) == 1
+        self.assertEqual(ref_output, test_output)
+        self.assertTrue(one_replacement)
+
     def test_subgraph_rewriter_single_pattern_match(self):
         class M(torch.nn.Module):
             def forward(self, x):

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -309,7 +309,10 @@ def _replace_pattern(
             replacement_nodes.append(curr_node)
 
         for ret_node in copied_returning_nodes:
-            get_replacement_nodes(ret_node)
+            if ret_node in match.placeholder_nodes:
+                replacement_nodes.append(ret_node)
+            else:
+                get_replacement_nodes(ret_node)
 
         # Hook the output Node of the replacement subgraph in to the
         # original Graph at the correct location

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -302,6 +302,8 @@ def _replace_pattern(
 
         def get_replacement_nodes(curr_node: Node):
             nonlocal replacement_nodes
+            if curr_node in match.placeholder_nodes:
+                return
             for arg in curr_node.args:
                 if isinstance(arg, Node):
                     if arg not in val_map.values():
@@ -309,10 +311,7 @@ def _replace_pattern(
             replacement_nodes.append(curr_node)
 
         for ret_node in copied_returning_nodes:
-            if ret_node in match.placeholder_nodes:
-                replacement_nodes.append(ret_node)
-            else:
-                get_replacement_nodes(ret_node)
+            get_replacement_nodes(ret_node)
 
         # Hook the output Node of the replacement subgraph in to the
         # original Graph at the correct location


### PR DESCRIPTION
Pattern replacement behaves incorrectly when the replacement pattern maps inputs to outputs (such a pattern can be used to replace redundant code). However, current code in `torch.fx.subgraph_rewriter._replace_pattern` causes the list of replacement nodes to include the entire graph before that node, resulting in an exponential slowdown due to recursive calls traversing the entire graph multiple times.

The proposed fix is to add a check in `_replace_pattern` to prevent the call to `get_replacement_nodes`:
```python
        for ret_node in copied_returning_nodes:
            if ret_node in match.placeholder_nodes:
                replacement_nodes.append(ret_node)
            else:
                get_replacement_nodes(ret_node)
```

Fixes #97817 


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10