### PR TITLE
[nccl] Remove lock for nccl collective launch for 2.0+

### DIFF
--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -299,7 +299,10 @@ void check_inputs(
 } // namespace detail
 
 AutoNcclGroup::AutoNcclGroup() {
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR < 2)
+  // nccl < 2.0 cannot be called concurrently with cudaFree
   (c10::cuda::getFreeMutex())->lock();
+#endif
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
   detail::NCCL_CHECK(ncclGroupStart());
 #endif
@@ -309,7 +312,9 @@ AutoNcclGroup::~AutoNcclGroup() noexcept(false) {
 #if defined(NCCL_MAJOR) && (NCCL_MAJOR >= 2)
   detail::NCCL_CHECK(ncclGroupEnd());
 #endif
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR < 2)
   (c10::cuda::getFreeMutex())->unlock();
+#endif
 }
 
 bool is_available(TensorList tensors) {


### PR DESCRIPTION
Summary: It looks nccl 2.0+ no longer needs a lock to avoid being called concurrently with cudaFree.

Test Plan: sandcastle + OSS CI

Differential Revision: D44514446

