### PR TITLE
[release 2.0.1] [fix] jacrev and jacfwd : support non-tensor args again

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -2140,6 +2140,16 @@ class TestJac(TestCase):
         with self.assertRaisesRegex(RuntimeError, "jacfwd: Expected all outputs"):
             jacfwd(fn)(x)
 
+    @jacrev_and_jacfwd
+    def test_jac_with_non_tensor_args(self, device, jacapi):
+        def f(t, int_x):
+            return t + int_x
+
+        t = torch.randn(3, 3, device=device)
+
+        actual = jacapi(f)(t, 3)
+        expected = torch.autograd.functional.jacobian(partial(f, int_x=3), t)
+        self.assertEqual(actual, expected)
 
 class TestHessian(TestCase):
     def _test_against_reference(self, f, inputs):

--- a/torch/_functorch/eager_transforms.py
+++ b/torch/_functorch/eager_transforms.py
@@ -344,7 +344,7 @@ def _safe_zero_index(x):
 def error_if_complex(func_name, args, is_input):
     flat_args, _ = tree_flatten(args)
     for idx, arg in enumerate(flat_args):
-        if arg.dtype.is_complex:
+        if isinstance(arg, torch.Tensor) and arg.dtype.is_complex:
             input_or_output = ("inputs" if is_input else "outputs")
             err_msg = (f"{func_name}: Expected all {input_or_output} "
                        f"to be real but received complex tensor at flattened input idx: {idx}")


### PR DESCRIPTION
cherry-picked from 2b369eb3c2d9f49c4dfddc31f4e76f7ab8832091