### PR TITLE
[kineto] make input shape collection opt-in for on-demand tracing (#746)

### DIFF
--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -23,7 +23,7 @@ class LibKinetoClient : public libkineto::ClientInterface {
   void init() override {}
 
   void prepare(
-      bool report_input_shapes = true,
+      bool report_input_shapes = false,
       bool profile_memory = false,
       bool with_stack = false,
       bool with_flops = false,
@@ -56,7 +56,9 @@ class LibKinetoClient : public libkineto::ClientInterface {
   }
 
  private:
-  bool reportInputShapes_{true};
+  // Temporarily disable shape collection until
+  // we re-roll out the feature for on-demand cases
+  bool reportInputShapes_{false};
   bool profileMemory_{false};
   bool withStack_{false};
   bool withFlops_{false};


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/kineto/pull/746

Make input shape collection opt-in as we are re-rolling out the feature for on-demand tracing. Making this default right away could cause bloated trace size for inferences

Test Plan:
# Repro

## Run
```
buck2 run mode/opt  kineto/libkineto/fb/integration_tests:pytorch_resnet_integration_test
```

## Default Path
```
dyno gputrace
```
https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Fdynocli%2F0%2F1679681884%2F127.0.0.1%2Flibkineto_activities_2125213.json.gz&bucket=gpu_traces

## Opt in
```
echo -e "CLIENT_INTERFACE_ENABLE_OP_INPUTS_COLLECTION=true" > /tmp/sigrid_kineto.conf && dyno gputrace --gpuconf /tmp/sigrid_kineto.conf
```

https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Fdynocli%2F0%2F1679682394%2F127.0.0.1%2Flibkineto_activities_2415763.json.gz&bucket=gpu_traces

Reviewed By: aaronenyeshi

Differential Revision: D44377341

